### PR TITLE
feat: use StringDictionary to encoding tag columns - DEMO / POC

### DIFF
--- a/mutable_buffer/src/database.rs
+++ b/mutable_buffer/src/database.rs
@@ -1088,6 +1088,7 @@ mod tests {
 
     use arrow_deps::arrow::{
         array::{Array, StringArray},
+        compute::cast,
         datatypes::DataType,
         record_batch::RecordBatch,
         util::pretty::pretty_format_batches,
@@ -1210,7 +1211,11 @@ mod tests {
             columns
         );
 
-        let region_col = columns[0]
+        // cast that bad boy to a string column (it is a string dictionary)
+        let cast_region =
+            cast(&columns[0], &DataType::Utf8).expect("Casting region column to Utf8");
+
+        let region_col = cast_region
             .as_any()
             .downcast_ref::<StringArray>()
             .expect("Get region column as a string");
@@ -1221,7 +1226,10 @@ mod tests {
         assert!(region_col.is_null(1), "is_null(1): {:?}", region_col);
         assert!(region_col.is_null(2), "is_null(1): {:?}", region_col);
 
-        let host_col = columns[1]
+        // cast that bad boy to a string column (it is a string dictionary)
+        let cast_host = cast(&columns[1], &DataType::Utf8).expect("Casting host column to Utf8");
+
+        let host_col = cast_host
             .as_any()
             .downcast_ref::<StringArray>()
             .expect("Get host column as a string");

--- a/mutable_buffer/src/dictionary.rs
+++ b/mutable_buffer/src/dictionary.rs
@@ -32,6 +32,16 @@ impl Dictionary {
         Self(StringInterner::new())
     }
 
+    /// Returns the number of items in this dictionary
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    /// Returns true if the underlying dictionary is empty
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
     /// Returns the id corresponding to value, adding an entry for the
     /// id if it is not yet present in the dictionary.
     pub fn lookup_value_or_insert(&mut self, value: &str) -> u32 {

--- a/mutable_buffer/src/table.rs
+++ b/mutable_buffer/src/table.rs
@@ -22,8 +22,13 @@ use snafu::{OptionExt, ResultExt, Snafu};
 use arrow_deps::{
     arrow,
     arrow::{
-        array::{ArrayRef, BooleanBuilder, Float64Builder, Int64Builder, StringBuilder},
-        datatypes::{DataType as ArrowDataType, Field as ArrowField, Schema as ArrowSchema},
+        array::{
+            ArrayRef, BooleanBuilder, Float64Builder, Int64Builder, PrimitiveBuilder,
+            StringBuilder, StringDictionaryBuilder,
+        },
+        datatypes::{
+            DataType as ArrowDataType, Field as ArrowField, Int32Type, Schema as ArrowSchema,
+        },
         record_batch::RecordBatch,
     },
     datafusion::{
@@ -32,6 +37,9 @@ use arrow_deps::{
         prelude::*,
     },
 };
+/// swag that each tag is ~ 10 bytes long for dictionary allocation
+/// purposes
+const ESTIMATED_TAG_SIZE: usize = 10;
 
 #[derive(Debug, Snafu)]
 pub enum Error {
@@ -880,23 +888,35 @@ impl Table {
                     Arc::new(builder.finish())
                 }
                 Column::Tag(vals, _) => {
-                    fields.push(ArrowField::new(column_name, ArrowDataType::Utf8, true));
-                    let mut builder = StringBuilder::with_capacity(vals.len(), vals.len() * 10);
+                    // build using a StringDictionary (32 bit indexes = keys)
+                    let field_type = ArrowDataType::Dictionary(
+                        Box::new(ArrowDataType::Int32),
+                        Box::new(ArrowDataType::Utf8),
+                    );
+                    fields.push(ArrowField::new(column_name, field_type, true));
+                    let dictionary = &chunk.dictionary;
+
+                    let keys_builder = PrimitiveBuilder::<Int32Type>::new(vals.len());
+                    // swag that each tag is ~ 10 bytes long
+                    let values_builder = StringBuilder::with_capacity(
+                        dictionary.len(),
+                        dictionary.len() * ESTIMATED_TAG_SIZE,
+                    );
+                    let mut builder = StringDictionaryBuilder::new(keys_builder, values_builder);
 
                     for v in vals {
                         match v {
-                            None => builder.append_null(),
+                            None => builder.append_null().context(ArrowError {})?,
                             Some(value_id) => {
-                                let tag_value = chunk.dictionary.lookup_id(*value_id).context(
+                                let tag_value = dictionary.lookup_id(*value_id).context(
                                     TagValueIdNotFoundInDictionary {
                                         value: *value_id,
                                         chunk: &chunk.key,
                                     },
                                 )?;
-                                builder.append_value(tag_value)
+                                builder.append(tag_value).context(ArrowError {})?;
                             }
                         }
-                        .context(ArrowError {})?;
                     }
 
                     Arc::new(builder.finish())


### PR DESCRIPTION
This PR changes the write buffer to use a `StringDictionary` type for encoding tag columns in the write buffer, and would close https://github.com/influxdata/delorean/issues/334

It currently uses a hacked up arrow version from https://github.com/alamb/arrow/tree/alamb/datafusion-string-dictionary


If run against master arrow, it results in the following errors:
```

---- database::tests::list_column_names_predicate stdout ----
thread 'database::tests::list_column_names_predicate' panicked at 'Execution of predicate plan: DataFusionPhysicalPlanning { source: General("\'Dictionary(Int32, Utf8) = Utf8\' can\'t be evaluated because there isn\'t a common type to coerce the types to") }', delorean_write_buffer/src/database.rs:1129:31

---- database::tests::recover_partial_entries stdout ----
thread 'database::tests::recover_partial_entries' panicked at 'called `Result::unwrap()` on an `Err` value: InvalidArgumentError("Unsupported Dictionary(Int32, Utf8) type for repl.")', delorean_write_buffer/src/database.rs:610:19

---- database::tests::write_data_and_recover stdout ----
thread 'database::tests::write_data_and_recover' panicked at 'called `Result::unwrap()` on an `Err` value: InvalidArgumentError("Unsupported Dictionary(Int32, Utf8) type for repl.")', delorean_write_buffer/src/database.rs:610:19
```

I  am working to get the proper support in arrow upstream under the aegis of https://issues.apache.org/jira/browse/ARROW-10159

