### PR TITLE
fix: Log errors if they happen on separate tokio tasks

### DIFF
--- a/data_types/src/error.rs
+++ b/data_types/src/error.rs
@@ -1,0 +1,30 @@
+//! Common error utilities
+use std::fmt::Debug;
+
+use tracing::error;
+
+/// Add ability for Results to log error messages via `error!` logs.
+/// This is useful when using async tasks that may not have a natural
+/// return error
+pub trait ErrorLogger {
+    /// Log the contents of self with a string of context. The context
+    /// should appear in a message such as
+    ///
+    /// "Error <context>: <formatted error message>
+    fn log_if_error(self, context: &str) -> Self;
+
+    /// Provided method to log an error via the `error!` macro
+    fn log_error<E: Debug>(context: &str, e: E) {
+        error!("Error {}: {:?}", context, e);
+    }
+}
+
+/// Implement logging for all results
+impl<T, E: Debug> ErrorLogger for Result<T, E> {
+    fn log_if_error(self, context: &str) -> Self {
+        if let Err(e) = &self {
+            Self::log_error(context, e);
+        }
+        self
+    }
+}

--- a/data_types/src/lib.rs
+++ b/data_types/src/lib.rs
@@ -14,5 +14,6 @@ pub const TIME_COLUMN_NAME: &str = "time";
 
 pub mod data;
 pub mod database_rules;
+pub mod error;
 pub mod partition_metadata;
 pub mod table_schema;


### PR DESCRIPTION
Rationale:

I was trying to trace down a test failure that happens on https://github.com/influxdata/delorean/pull/328, but there was no mention of an error in the logs. After looking into it, it turns out that the error was being swallowed by spawned task  -- nothing checked return results and thus the error was not logged

This PR adds logging to operations in the tasks so the errors can be debugged more easily.
