### PR TITLE
perf: enable row ID bitset optimisation for equality predicates

### DIFF
--- a/segment_store/Cargo.toml
+++ b/segment_store/Cargo.toml
@@ -20,3 +20,7 @@ rand = "0.7.3"
 [[bench]]
 name = "fixed"
 harness = false
+
+[[bench]]
+name = "dictionary"
+harness = false

--- a/segment_store/benches/dictionary.rs
+++ b/segment_store/benches/dictionary.rs
@@ -1,0 +1,129 @@
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use rand::distributions::Alphanumeric;
+use rand::prelude::*;
+use rand::Rng;
+
+use segment_store::{column::cmp::Operator, column::dictionary::RLE, column::RowIDs};
+
+const ROWS: [usize; 3] = [100_000, 1_000_000, 10_000_000];
+const LOCATIONS: [Location; 3] = [Location::Start, Location::Middle, Location::End];
+const ROWS_MATCHING_VALUE: [usize; 3] = [10, 100, 1000];
+
+#[derive(Debug)]
+enum Location {
+    Start,
+    Middle,
+    End,
+}
+
+enum EncType {
+    RLE,
+}
+
+fn select(c: &mut Criterion) {
+    let mut rng = rand::thread_rng();
+    benchmark_select(
+        c,
+        "encoding_rle_select",
+        EncType::RLE,
+        &ROWS,
+        &LOCATIONS,
+        &ROWS_MATCHING_VALUE,
+        &mut rng,
+    );
+}
+
+fn benchmark_select(
+    c: &mut Criterion,
+    benchmark_group_name: &str,
+    enc_type: EncType,
+    row_size: &[usize],
+    locations: &[Location],
+    rows_selected: &[usize],
+    rng: &mut ThreadRng,
+) {
+    let mut group = c.benchmark_group(benchmark_group_name);
+    for &num_rows in row_size {
+        for location in locations {
+            for &rows_select in rows_selected.iter().rev() {
+                let col_data = generate_column(num_rows, rows_select, rng);
+                let cardinality = num_rows / rows_select;
+
+                let mut col_dict = std::collections::BTreeSet::new();
+                for v in &col_data {
+                    col_dict.insert(v.clone());
+                }
+
+                let value = match location {
+                    Location::Start => {
+                        // find a value in the column close to the beginning.
+                        &col_data[rng.gen_range(0, col_data.len() / 20)] // something in first 5%
+                    }
+                    Location::Middle => {
+                        // find a value in the column somewhere in the middle
+                        let fifth = col_data.len() / 5;
+                        &col_data[rng.gen_range(2 * fifth, 3 * fifth)] // something in middle fifth
+                    }
+                    Location::End => {
+                        &col_data
+                            [rng.gen_range(col_data.len() - (col_data.len() / 9), col_data.len())]
+                    } // something in the last ~10%
+                };
+
+                group.throughput(Throughput::Elements(num_rows as u64));
+                match enc_type {
+                    EncType::RLE => {
+                        let mut encoding = RLE::with_dictionary(col_dict);
+                        // Could be faster but it's just the bench setup...
+                        for v in &col_data {
+                            encoding.push(v.to_owned());
+                        }
+
+                        let input = (RowIDs::new_bitmap(), value);
+
+                        group.bench_with_input(
+                            BenchmarkId::from_parameter(format!(
+                                "rows_{:?}/loc_{:?}/card_{:?}",
+                                num_rows, location, cardinality
+                            )),
+                            &input,
+                            |b, _| {
+                                b.iter(|| {
+                                    // do work
+                                    let row_ids = encoding.row_ids_filter(
+                                        value.as_str(),
+                                        &Operator::Equal,
+                                        RowIDs::new_bitmap(),
+                                    );
+
+                                    let as_vec = row_ids.to_vec();
+                                    let values = encoding.values(as_vec.as_slice(), vec![]);
+                                    assert_eq!(values.len(), rows_select);
+                                });
+                            },
+                        );
+                    }
+                }
+            }
+        }
+    }
+    group.finish();
+}
+
+fn generate_column(rows: usize, rows_per_value: usize, rng: &mut ThreadRng) -> Vec<String> {
+    let mut col = Vec::with_capacity(rows);
+    let distinct_values = rows / rows_per_value;
+    for _ in 0..distinct_values {
+        let value = format!(
+            "value-{}",
+            rng.sample_iter(&Alphanumeric).take(8).collect::<String>()
+        );
+        col.extend(std::iter::repeat(value).take(rows_per_value));
+    }
+
+    assert_eq!(col.len(), rows);
+    col
+}
+
+criterion_group!(benches, select,);
+criterion_main!(benches);

--- a/segment_store/src/column.rs
+++ b/segment_store/src/column.rs
@@ -2479,6 +2479,14 @@ impl RowIDs {
         }
     }
 
+    // Adds all the values from the provided bitmap into self.
+    pub fn add_from_bitmap(&mut self, other: &croaring::Bitmap) {
+        match self {
+            RowIDs::Bitmap(_self) => _self.or_inplace(other),
+            RowIDs::Vector(_self) => _self.extend_from_slice(other.to_vec().as_slice()),
+        }
+    }
+
     pub fn intersect(&mut self, other: &RowIDs) {
         match (self, other) {
             (RowIDs::Bitmap(_self), RowIDs::Bitmap(ref other)) => _self.and_inplace(other),


### PR DESCRIPTION
This PR enables an optimisation for producing `RowID` sets on a column when providing an equality predicate. In this specific but common case I already have the logical row ids for each distinct logical value on the RLE columns. They're maintained as compressed bitmaps on the column. These bitsets will also be utilised during grouping.

I added a benchmark that exercises applying an equality predicate to an RLE column and then materialises the resulting values at the matching logical rows.

<details>
<summary>Benchmark Results</summary>

```code
 Running target/release/deps/dictionary-96a531812a599449
encoding_rle_select/rows_100000/loc_Start/card_100                                                                             
                        time:   [3.9631 us 3.9838 us 4.0056 us]
                        thrpt:  [24.965 Gelem/s 25.102 Gelem/s 25.232 Gelem/s]
                 change:
                        time:   [-1.3727% -0.6455% +0.1181%] (p = 0.07 > 0.05)
                        thrpt:  [-0.1180% +0.6497% +1.3918%]
                        No change in performance detected.
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) high mild
  1 (1.00%) high severe
encoding_rle_select/rows_100000/loc_Start/card_1000                                                                             
                        time:   [995.03 ns 1.0009 us 1.0071 us]
                        thrpt:  [99.298 Gelem/s 99.913 Gelem/s 100.50 Gelem/s]
                 change:
                        time:   [-47.823% -47.464% -47.054%] (p = 0.00 < 0.05)
                        thrpt:  [+88.873% +90.346% +91.654%]
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild
encoding_rle_select/rows_100000/loc_Start/card_10000                                                                             
                        time:   [901.19 ns 906.72 ns 912.58 ns]
                        thrpt:  [109.58 Gelem/s 110.29 Gelem/s 110.96 Gelem/s]
                 change:
                        time:   [-89.335% -89.220% -89.111%] (p = 0.00 < 0.05)
                        thrpt:  [+818.33% +827.65% +837.63%]
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild
encoding_rle_select/rows_100000/loc_Middle/card_100                                                                             
                        time:   [3.8551 us 3.8765 us 3.8993 us]
                        thrpt:  [25.645 Gelem/s 25.797 Gelem/s 25.939 Gelem/s]
                 change:
                        time:   [+2.3167% +3.7743% +5.2145%] (p = 0.00 < 0.05)
                        thrpt:  [-4.9560% -3.6370% -2.2642%]
                        Performance has regressed.
Found 3 outliers among 100 measurements (3.00%)
  1 (1.00%) high mild
  2 (2.00%) high severe
encoding_rle_select/rows_100000/loc_Middle/card_1000                                                                             
                        time:   [1.1479 us 1.1523 us 1.1569 us]
                        thrpt:  [86.440 Gelem/s 86.782 Gelem/s 87.118 Gelem/s]
                 change:
                        time:   [-44.837% -43.793% -42.697%] (p = 0.00 < 0.05)
                        thrpt:  [+74.511% +77.913% +81.279%]
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  2 (2.00%) high mild
  5 (5.00%) high severe
encoding_rle_select/rows_100000/loc_Middle/card_10000                                                                             
                        time:   [3.0576 us 3.1118 us 3.1618 us]
                        thrpt:  [31.628 Gelem/s 32.136 Gelem/s 32.706 Gelem/s]
                 change:
                        time:   [-72.716% -72.220% -71.713%] (p = 0.00 < 0.05)
                        thrpt:  [+253.52% +259.97% +266.52%]
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high severe
encoding_rle_select/rows_100000/loc_End/card_100                                                                             
                        time:   [3.9210 us 3.9633 us 4.0124 us]
                        thrpt:  [24.923 Gelem/s 25.231 Gelem/s 25.503 Gelem/s]
                 change:
                        time:   [+7.5264% +9.3375% +11.026%] (p = 0.00 < 0.05)
                        thrpt:  [-9.9308% -8.5401% -6.9996%]
                        Performance has regressed.
Found 6 outliers among 100 measurements (6.00%)
  5 (5.00%) high mild
  1 (1.00%) high severe
encoding_rle_select/rows_100000/loc_End/card_1000                                                                             
                        time:   [1.3775 us 1.3991 us 1.4246 us]
                        thrpt:  [70.195 Gelem/s 71.473 Gelem/s 72.596 Gelem/s]
                 change:
                        time:   [-33.394% -32.188% -30.902%] (p = 0.00 < 0.05)
                        thrpt:  [+44.723% +47.466% +50.137%]
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild
encoding_rle_select/rows_100000/loc_End/card_10000                                                                             
                        time:   [4.8368 us 4.8739 us 4.9112 us]
                        thrpt:  [20.361 Gelem/s 20.518 Gelem/s 20.675 Gelem/s]
                 change:
                        time:   [-62.715% -62.256% -61.774%] (p = 0.00 < 0.05)
                        thrpt:  [+161.61% +164.94% +168.21%]
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  5 (5.00%) high mild
  3 (3.00%) high severe
encoding_rle_select/rows_1000000/loc_Start/card_1000                                                                             
                        time:   [3.7813 us 3.8018 us 3.8245 us]
                        thrpt:  [261.47 Gelem/s 263.03 Gelem/s 264.46 Gelem/s]
                 change:
                        time:   [-11.124% -10.303% -9.4350%] (p = 0.00 < 0.05)
                        thrpt:  [+10.418% +11.486% +12.517%]
                        Performance has improved.
Found 10 outliers among 100 measurements (10.00%)
  1 (1.00%) low mild
  6 (6.00%) high mild
  3 (3.00%) high severe
encoding_rle_select/rows_1000000/loc_Start/card_10000                                                                             
                        time:   [1.1693 us 1.1772 us 1.1865 us]
                        thrpt:  [842.82 Gelem/s 849.50 Gelem/s 855.20 Gelem/s]
                 change:
                        time:   [-85.739% -85.569% -85.388%] (p = 0.00 < 0.05)
                        thrpt:  [+584.35% +592.93% +601.19%]
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  5 (5.00%) high mild
  3 (3.00%) high severe
encoding_rle_select/rows_1000000/loc_Start/card_100000                                                                             
                        time:   [1.4961 us 1.5234 us 1.5529 us]
                        thrpt:  [643.94 Gelem/s 656.41 Gelem/s 668.42 Gelem/s]
                 change:
                        time:   [-98.097% -98.062% -98.030%] (p = 0.00 < 0.05)
                        thrpt:  [+4975.0% +5060.5% +5154.7%]
                        Performance has improved.
Found 12 outliers among 100 measurements (12.00%)
  5 (5.00%) high mild
  7 (7.00%) high severe
encoding_rle_select/rows_1000000/loc_Middle/card_1000                                                                             
                        time:   [4.5471 us 4.6047 us 4.6588 us]
                        thrpt:  [214.65 Gelem/s 217.17 Gelem/s 219.92 Gelem/s]
                 change:
                        time:   [-2.3556% -0.6227% +0.9496%] (p = 0.48 > 0.05)
                        thrpt:  [-0.9407% +0.6266% +2.4124%]
                        No change in performance detected.
Found 6 outliers among 100 measurements (6.00%)
  5 (5.00%) high mild
  1 (1.00%) high severe
encoding_rle_select/rows_1000000/loc_Middle/card_10000                                                                             
                        time:   [3.3845 us 3.4290 us 3.4711 us]
                        thrpt:  [288.09 Gelem/s 291.63 Gelem/s 295.46 Gelem/s]
                 change:
                        time:   [-67.188% -66.696% -66.159%] (p = 0.00 < 0.05)
                        thrpt:  [+195.50% +200.27% +204.77%]
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high severe
encoding_rle_select/rows_1000000/loc_Middle/card_100000                                                                             
                        time:   [20.352 us 20.729 us 21.126 us]
                        thrpt:  [47.335 Gelem/s 48.241 Gelem/s 49.135 Gelem/s]
                 change:
                        time:   [-78.287% -77.844% -77.410%] (p = 0.00 < 0.05)
                        thrpt:  [+342.67% +351.34% +360.56%]
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) high mild
  1 (1.00%) high severe
encoding_rle_select/rows_1000000/loc_End/card_1000                                                                             
                        time:   [4.4035 us 4.4557 us 4.5160 us]
                        thrpt:  [221.44 Gelem/s 224.43 Gelem/s 227.09 Gelem/s]
                 change:
                        time:   [-2.6133% -1.2484% +0.1620%] (p = 0.08 > 0.05)
                        thrpt:  [-0.1617% +1.2642% +2.6834%]
                        No change in performance detected.
encoding_rle_select/rows_1000000/loc_End/card_10000                                                                             
                        time:   [5.1673 us 5.2752 us 5.3854 us]
                        thrpt:  [185.69 Gelem/s 189.57 Gelem/s 193.52 Gelem/s]
                 change:
                        time:   [-60.707% -59.991% -59.293%] (p = 0.00 < 0.05)
                        thrpt:  [+145.66% +149.95% +154.50%]
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild
encoding_rle_select/rows_1000000/loc_End/card_100000                                                                             
                        time:   [41.248 us 41.621 us 42.020 us]
                        thrpt:  [23.798 Gelem/s 24.027 Gelem/s 24.244 Gelem/s]
                 change:
                        time:   [-65.235% -64.609% -63.983%] (p = 0.00 < 0.05)
                        thrpt:  [+177.64% +182.56% +187.64%]
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  4 (4.00%) high mild
  4 (4.00%) high severe
encoding_rle_select/rows_10000000/loc_Start/card_10000                                                                             
                        time:   [3.9045 us 3.9334 us 3.9655 us]
                        thrpt:  [2521.7 Gelem/s 2542.3 Gelem/s 2561.1 Gelem/s]
                 change:
                        time:   [-64.773% -64.277% -63.786%] (p = 0.00 < 0.05)
                        thrpt:  [+176.14% +179.93% +183.88%]
                        Performance has improved.
Found 12 outliers among 100 measurements (12.00%)
  7 (7.00%) high mild
  5 (5.00%) high severe
encoding_rle_select/rows_10000000/loc_Start/card_100000                                                                             
                        time:   [1.2071 us 1.2201 us 1.2354 us]
                        thrpt:  [8094.7 Gelem/s 8196.1 Gelem/s 8284.0 Gelem/s]
                 change:
                        time:   [-98.465% -98.447% -98.427%] (p = 0.00 < 0.05)
                        thrpt:  [+6258.5% +6337.8% +6415.2%]
                        Performance has improved.
Found 12 outliers among 100 measurements (12.00%)
  7 (7.00%) high mild
  5 (5.00%) high severe
encoding_rle_select/rows_10000000/loc_Start/card_1000000                                                                             
                        time:   [4.6760 us 4.7649 us 4.8503 us]
                        thrpt:  [2061.7 Gelem/s 2098.7 Gelem/s 2138.6 Gelem/s]
                 change:
                        time:   [-99.405% -99.393% -99.380%] (p = 0.00 < 0.05)
                        thrpt:  [+16041% +16373% +16714%]
                        Performance has improved.
encoding_rle_select/rows_10000000/loc_Middle/card_10000                                                                             
                        time:   [6.1913 us 6.3098 us 6.4190 us]
                        thrpt:  [1557.9 Gelem/s 1584.8 Gelem/s 1615.2 Gelem/s]
                 change:
                        time:   [-54.373% -53.475% -52.654%] (p = 0.00 < 0.05)
                        thrpt:  [+111.21% +114.94% +119.17%]
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild
encoding_rle_select/rows_10000000/loc_Middle/card_100000                                                                             
                        time:   [25.301 us 25.499 us 25.700 us]
                        thrpt:  [389.11 Gelem/s 392.17 Gelem/s 395.24 Gelem/s]
                 change:
                        time:   [-75.092% -74.805% -74.536%] (p = 0.00 < 0.05)
                        thrpt:  [+292.70% +296.91% +301.48%]
                        Performance has improved.
Found 17 outliers among 100 measurements (17.00%)
  1 (1.00%) low severe
  8 (8.00%) low mild
  7 (7.00%) high mild
  1 (1.00%) high severe
encoding_rle_select/rows_10000000/loc_Middle/card_1000000                                                                            
                        time:   [197.28 us 199.47 us 201.73 us]
                        thrpt:  [49.570 Gelem/s 50.133 Gelem/s 50.688 Gelem/s]
                 change:
                        time:   [-80.927% -80.582% -80.283%] (p = 0.00 < 0.05)
                        thrpt:  [+407.17% +415.00% +424.31%]
                        Performance has improved.
encoding_rle_select/rows_10000000/loc_End/card_10000                                                                             
                        time:   [8.7384 us 8.8313 us 8.9300 us]
                        thrpt:  [1119.8 Gelem/s 1132.3 Gelem/s 1144.4 Gelem/s]
                 change:
                        time:   [-44.985% -44.201% -43.407%] (p = 0.00 < 0.05)
                        thrpt:  [+76.701% +79.216% +81.767%]
                        Performance has improved.
encoding_rle_select/rows_10000000/loc_End/card_100000                                                                             
                        time:   [44.040 us 44.711 us 45.460 us]
                        thrpt:  [219.97 Gelem/s 223.66 Gelem/s 227.06 Gelem/s]
                 change:
                        time:   [-62.362% -61.468% -60.596%] (p = 0.00 < 0.05)
                        thrpt:  [+153.78% +159.52% +165.69%]
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  4 (4.00%) high mild
encoding_rle_select/rows_10000000/loc_End/card_1000000                                                                            
                        time:   [460.78 us 468.73 us 476.68 us]
                        thrpt:  [20.979 Gelem/s 21.334 Gelem/s 21.702 Gelem/s]
                 change:
                        time:   [-64.917% -64.068% -63.224%] (p = 0.00 < 0.05)
                        thrpt:  [+171.91% +178.31% +185.04%]
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild
```

</details>


In general this improves the performance of finding rows matchin an equality predicate dramatically because the row ids can be fetched in constant time by looking up a bitset (`~500ns` on my laptop). 

The majority of the remaining time is spent on materialising the rows; I have some improvements in the pipeline for that.


