### PR TITLE
feat: Print message to stdout when the server is ready

### DIFF
--- a/src/commands/write_buffer_server.rs
+++ b/src/commands/write_buffer_server.rs
@@ -84,6 +84,8 @@ pub async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let server = Server::bind(&bind_addr).serve(make_svc);
     info!("Listening on http://{}", bind_addr);
 
+    println!("InfluxDB IOx server ready");
+
     // Wait for both the servers to complete
     let (grpc_server, server) = futures::future::join(grpc_server, server).await;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -183,7 +183,7 @@ async fn dispatch_args(matches: ArgMatches<'_>) {
             }
         }
         ("server", Some(_)) | (_, _) => {
-            println!("Starting InfluxDB IOx server");
+            println!("InfluxDB IOx server starting");
             match commands::write_buffer_server::main().await {
                 Ok(()) => eprintln!("Shutdown OK"),
                 Err(e) => {


### PR DESCRIPTION
@rbetts  noted that the current message when the IOx server starts is somewhat misleading as it implies startup is still in process and it is not obvious that the server is ready.

```
$ cargo run
Starting InfluxDB IOx server
```

This PR proposes making the output look as follows (there can actually be a significant delay between the two messages if there is a lot of data in the WAL)

```
$ cargo run
InfluxDB IOx server starting
InfluxDB IOx server ready
```
