### PR TITLE
feat: add String support to Packers

### DIFF
--- a/packers/src/packers.rs
+++ b/packers/src/packers.rs
@@ -20,6 +20,7 @@ pub enum Packers {
     Float(Packer<f64>),
     Integer(Packer<i64>),
     String(Packer<ByteArray>),
+    UtfString(Packer<String>),
     Boolean(Packer<bool>),
 }
 
@@ -51,6 +52,7 @@ impl<'a> Packers {
             Self::Float(p) => PackerChunker::Float(p.values.chunks(chunk_size)),
             Self::Integer(p) => PackerChunker::Integer(p.values.chunks(chunk_size)),
             Self::String(p) => PackerChunker::String(p.values.chunks(chunk_size)),
+            Self::UtfString(p) => PackerChunker::UtfString(p.values.chunks(chunk_size)),
             Self::Boolean(p) => PackerChunker::Boolean(p.values.chunks(chunk_size)),
         }
     }
@@ -67,6 +69,7 @@ impl<'a> Packers {
             Self::Float(p) => p.reserve_exact(additional),
             Self::Integer(p) => p.reserve_exact(additional),
             Self::String(p) => p.reserve_exact(additional),
+            Self::UtfString(p) => p.reserve_exact(additional),
             Self::Boolean(p) => p.reserve_exact(additional),
         }
     }
@@ -76,6 +79,7 @@ impl<'a> Packers {
             Self::Float(p) => p.push_option(None),
             Self::Integer(p) => p.push_option(None),
             Self::String(p) => p.push_option(None),
+            Self::UtfString(p) => p.push_option(None),
             Self::Boolean(p) => p.push_option(None),
         }
     }
@@ -86,6 +90,7 @@ impl<'a> Packers {
             Self::Float(p) => p.swap(a, b),
             Self::Integer(p) => p.swap(a, b),
             Self::String(p) => p.swap(a, b),
+            Self::UtfString(p) => p.swap(a, b),
             Self::Boolean(p) => p.swap(a, b),
         }
     }
@@ -96,6 +101,7 @@ impl<'a> Packers {
             Self::Float(p) => p.num_rows(),
             Self::Integer(p) => p.num_rows(),
             Self::String(p) => p.num_rows(),
+            Self::UtfString(p) => p.num_rows(),
             Self::Boolean(p) => p.num_rows(),
         }
     }
@@ -108,6 +114,7 @@ impl<'a> Packers {
             Self::Float(p) => p.is_null(row),
             Self::Integer(p) => p.is_null(row),
             Self::String(p) => p.is_null(row),
+            Self::UtfString(p) => p.is_null(row),
             Self::Boolean(p) => p.is_null(row),
         }
     }
@@ -117,6 +124,7 @@ impl<'a> Packers {
         (f64_packer, f64_packer_mut, f64, Float),
         (i64_packer, i64_packer_mut, i64, Integer),
         (str_packer, str_packer_mut, ByteArray, String),
+        (utf_packer, utf_packer_mut, String, UtfString),
         (bool_packer, bool_packer_mut, bool, Boolean),
     }
 }
@@ -221,6 +229,7 @@ pub enum PackerChunker<'a> {
     Float(Chunks<'a, Option<f64>>),
     Integer(Chunks<'a, Option<i64>>),
     String(Chunks<'a, Option<ByteArray>>),
+    UtfString(Chunks<'a, Option<String>>),
     Boolean(Chunks<'a, Option<bool>>),
 }
 


### PR DESCRIPTION
This adds support for `String` packers backed by a `std::string::String`. This is useful when generating test data as it's cheaper to deal with `Strings` than the Parquet `ByteArray` in several situations.