### PR TITLE
fix: update the branch referece in nightly ci image to main

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,6 +109,6 @@ workflows:
           filters:
             branches:
               only:
-                - master
+                - main
     jobs:
       - ci_image


### PR DESCRIPTION
I got an email from circle ci this morning that the nightly ci image didn't build. I think it needs a branch name update

![Screen Shot 2020-11-11 at 6 23 37 AM](https://user-images.githubusercontent.com/490673/98805967-70643e00-23e6-11eb-97eb-f2ae78f14529.png)
