### PR TITLE
fix: Use datafusion optimizer in IOx query plans

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,7 +78,7 @@ checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 [[package]]
 name = "arrow"
 version = "3.0.0-SNAPSHOT"
-source = "git+https://github.com/apache/arrow.git?rev=e7ce8cfda3a612cd54fa47d06e26ca07b83a7cd6#e7ce8cfda3a612cd54fa47d06e26ca07b83a7cd6"
+source = "git+https://github.com/apache/arrow.git?rev=8e4d9ebef30857bab7a35003af0c663e776909aa#8e4d9ebef30857bab7a35003af0c663e776909aa"
 dependencies = [
  "chrono",
  "csv",
@@ -707,7 +707,7 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "3.0.0-SNAPSHOT"
-source = "git+https://github.com/apache/arrow.git?rev=e7ce8cfda3a612cd54fa47d06e26ca07b83a7cd6#e7ce8cfda3a612cd54fa47d06e26ca07b83a7cd6"
+source = "git+https://github.com/apache/arrow.git?rev=8e4d9ebef30857bab7a35003af0c663e776909aa#8e4d9ebef30857bab7a35003af0c663e776909aa"
 dependencies = [
  "arrow",
  "async-trait",
@@ -1983,7 +1983,7 @@ dependencies = [
 [[package]]
 name = "parquet"
 version = "3.0.0-SNAPSHOT"
-source = "git+https://github.com/apache/arrow.git?rev=e7ce8cfda3a612cd54fa47d06e26ca07b83a7cd6#e7ce8cfda3a612cd54fa47d06e26ca07b83a7cd6"
+source = "git+https://github.com/apache/arrow.git?rev=8e4d9ebef30857bab7a35003af0c663e776909aa#8e4d9ebef30857bab7a35003af0c663e776909aa"
 dependencies = [
  "arrow",
  "base64 0.11.0",

--- a/arrow_deps/Cargo.toml
+++ b/arrow_deps/Cargo.toml
@@ -11,10 +11,10 @@ description = "Apache Arrow / Parquet / DataFusion dependencies for InfluxDB IOx
 [dependencies]
 # We are using development version of arrow/parquet/datafusion and the dependencies are at the same rev
 
-# The version can be found here: https://github.com/apache/arrow/commit/e7ce8cfda3a612cd54fa47d06e26ca07b83a7cd6
+# The version can be found here: https://github.com/apache/arrow/commit/8e4d9ebef30857bab7a35003af0c663e776909aa
 #
-arrow = { git = "https://github.com/apache/arrow.git", rev = "e7ce8cfda3a612cd54fa47d06e26ca07b83a7cd6" , features = ["simd"] }
-datafusion = { git = "https://github.com/apache/arrow.git", rev = "e7ce8cfda3a612cd54fa47d06e26ca07b83a7cd6" }
+arrow = { git = "https://github.com/apache/arrow.git", rev = "8e4d9ebef30857bab7a35003af0c663e776909aa" , features = ["simd"] }
+datafusion = { git = "https://github.com/apache/arrow.git", rev = "8e4d9ebef30857bab7a35003af0c663e776909aa" }
 # Turn off the "arrow" feature; it currently has a bug that causes the crate to rebuild every time
 # and we're not currently using it anyway
-parquet = { git = "https://github.com/apache/arrow.git", rev = "e7ce8cfda3a612cd54fa47d06e26ca07b83a7cd6", default-features = false, features = ["snap", "brotli", "flate2", "lz4", "zstd"] }
+parquet = { git = "https://github.com/apache/arrow.git", rev = "8e4d9ebef30857bab7a35003af0c663e776909aa", default-features = false, features = ["snap", "brotli", "flate2", "lz4", "zstd"] }

--- a/storage/src/util.rs
+++ b/storage/src/util.rs
@@ -1,8 +1,5 @@
 //! This module contains DataFusion utility functions and helpers
-use arrow_deps::datafusion::{
-    logical_plan::Expr, logical_plan::LogicalPlan, logical_plan::Operator, optimizer::utils::inputs,
-};
-use std::io::Write;
+use arrow_deps::datafusion::{logical_plan::Expr, logical_plan::Operator};
 
 /// Encode the traversal of an expression tree. When passed to
 /// `visit_expression`, `ExpressionVisitor::visit` is invoked
@@ -125,24 +122,6 @@ pub fn dump_expr(expr: &Expr) -> String {
     visit_expression(expr, &mut visitor);
     let ExprToString { indent: _, output } = visitor;
     output
-}
-
-/// dumps the plan, and schema information to a string
-pub fn dump_plan(p: &LogicalPlan) -> String {
-    let mut buf = Vec::new();
-    dump_plan_impl("", p, &mut buf);
-    String::from_utf8_lossy(&buf).to_string()
-}
-
-fn dump_plan_impl(prefix: &str, p: &LogicalPlan, buf: &mut impl Write) {
-    writeln!(buf, "output schema: {:?}", p.schema()).unwrap();
-    writeln!(buf, "{:?}", p).unwrap();
-
-    let new_prefix = format!("{}    ", prefix);
-    for i in inputs(p) {
-        writeln!(buf).unwrap();
-        dump_plan_impl(&new_prefix, i, buf);
-    }
 }
 
 /// Creates a single expression representing the conjunction (aka

--- a/write_buffer/src/table.rs
+++ b/write_buffer/src/table.rs
@@ -1,8 +1,5 @@
 use generated_types::wal as wb;
-use storage::{
-    exec::{make_schema_pivot, GroupedSeriesSetPlan, SeriesSetPlan},
-    util::dump_plan,
-};
+use storage::exec::{make_schema_pivot, GroupedSeriesSetPlan, SeriesSetPlan};
 use tracing::debug;
 
 use std::{collections::BTreeSet, collections::HashMap, sync::Arc};
@@ -374,7 +371,7 @@ impl Table {
         debug!(
             "Created column_name plan for table '{}':\n{}",
             partition.dictionary.lookup_id(self.id).unwrap(),
-            dump_plan(&plan)
+            plan.display_indent_schema()
         );
 
         Ok(plan)


### PR DESCRIPTION
There was a bug in Apache Arrow DataFusion (https://issues.apache.org/jira/browse/ARROW-10547, fixed in https://github.com/apache/arrow/pull/8633) that prevented us from enabling its query Optimizer passes in IOx. The issue has been resolved upstream so we can now enable the optimizer in IOx.

This PR:
1. Upgrades to use a new version of arrow https://github.com/apache/arrow/commit/8e4d9ebef30857bab7a35003af0c663e776909aa
2. Enables the query optimizer passes
3. Note this also removes vestigial `dump_plan` code in IOx in favor of `display_indent_schema` and `display_graphviz` from DataFusion.
4. Fixes #422

