### PR TITLE
chore: Update predicate protobuf definitions

### DIFF
--- a/generated_types/predicate.proto
+++ b/generated_types/predicate.proto
@@ -9,51 +9,53 @@ package influxdata.platform.storage;
 
 
 message Node {
-    enum Type {
-        LOGICAL_EXPRESSION = 0;
-        COMPARISON_EXPRESSION = 1;
-        PAREN_EXPRESSION = 2;
-        TAG_REF = 3;
-        LITERAL = 4;
-        FIELD_REF = 5;
-    }
+  enum Type {
+    LOGICAL_EXPRESSION = 0;
+    COMPARISON_EXPRESSION = 1;
+    PAREN_EXPRESSION = 2;
+    TAG_REF = 3;
+    LITERAL = 4;
+    FIELD_REF = 5;
+  }
 
-    enum Comparison {
-        EQUAL = 0;
-        NOT_EQUAL = 1;
-        STARTS_WITH = 2;
-        REGEX = 3;
-        NOT_REGEX = 4;
-        LT = 5;
-        LTE = 6;
-        GT = 7;
-        GTE = 8;
-    }
+  enum Comparison {
+    EQUAL = 0;
+    NOT_EQUAL = 1;
+    STARTS_WITH = 2;
+    REGEX = 3;
+    NOT_REGEX = 4;
+    LT = 5;
+    LTE = 6;
+    GT = 7;
+    GTE = 8;
+  }
 
-    // Logical operators apply to boolean values and combine to produce a single boolean result.
-    enum Logical {
-        AND = 0;
-        OR = 1;
-    }
+  // Logical operators apply to boolean values and combine to produce a single boolean result.
+  enum Logical {
+    AND = 0;
+    OR = 1;
+  }
 
-    repeated Node children = 2;
 
-    oneof value {
-        string string_value = 3;
-        bool bool_value = 4;
-        int64 int_value = 5;
-        uint64 uint_value = 6;
-        double float_value = 7;
-        string regex_value = 8;
-        //string tag_ref_value = 9;
-        // AAL changed from string --> bytes to handle \xff and \x00 literals
-        bytes tag_ref_value = 9;
-        string field_ref_value = 10;
-        Logical logical = 11;
-        Comparison comparison = 12;
-    }
+  Type node_type = 1;
+  repeated Node children = 2;
+
+  oneof value {
+    string string_value = 3;
+    bool bool_value = 4;
+    int64 int_value = 5;
+    uint64 uint_value = 6;
+    double float_value = 7;
+    string regex_value = 8;
+    //    string tag_ref_value = 9;
+    // AAL changed from string --> bytes to handle \xff literals in Rust which are not valid UTF-8
+    bytes tag_ref_value = 9;
+    string field_ref_value = 10;
+    Logical logical = 11;
+    Comparison comparison = 12;
+  }
 }
 
 message Predicate {
-    Node root = 1;
+  Node root = 1;
 }

--- a/src/server/rpc/storage.rs
+++ b/src/server/rpc/storage.rs
@@ -1836,15 +1836,18 @@ mod tests {
     ///
     /// state="MA"
     fn make_state_ma_predicate() -> Option<Predicate> {
-        use node::{Comparison, Value};
+        use node::{Comparison, Type, Value};
         let root = Node {
+            node_type: Type::ComparisonExpression as i32,
             value: Some(Value::Comparison(Comparison::Equal as i32)),
             children: vec![
                 Node {
+                    node_type: Type::TagRef as i32,
                     value: Some(Value::TagRefValue("state".to_string().into_bytes())),
                     children: vec![],
                 },
                 Node {
+                    node_type: Type::Literal as i32,
                     value: Some(Value::StringValue("MA".to_string())),
                     children: vec![],
                 },

--- a/tests/end-to-end.rs
+++ b/tests/end-to-end.rs
@@ -18,7 +18,7 @@
 use assert_cmd::prelude::*;
 use futures::prelude::*;
 use generated_types::{
-    node::{Comparison, Value},
+    node::{Comparison, Type as NodeType, Value},
     read_group_request::Group,
     read_response::{frame::Data, *},
     storage_client::StorageClient,
@@ -237,12 +237,15 @@ async fn read_and_write_data() -> Result<()> {
 
     let predicate = Predicate {
         root: Some(Node {
+            node_type: NodeType::ComparisonExpression as i32,
             children: vec![
                 Node {
+                    node_type: NodeType::TagRef as i32,
                     children: vec![],
                     value: Some(Value::TagRefValue("host".into())),
                 },
                 Node {
+                    node_type: NodeType::Literal as i32,
                     children: vec![],
                     value: Some(Value::StringValue("server01".into())),
                 },


### PR DESCRIPTION
Rationale: Ensure IOx is in sync with the influxdb storage gRPC definitions

Part of a three PR cycle:

- [x] Split proto files to match influxdb (https://github.com/influxdata/influxdb_iox/pull/442)
- [x] Update predicate.proto (this PR)
- [ ] Update service.proto 


This PR copy/pastes the contents, as closely as possible, from https://github.com/influxdata/influxdb/blob/master/storage/reads/datatypes/predicate.proto

Changes:
1. Remove  gogoproto specific stuff such as the following:
```
[(gogoproto.enumvalue_customname) = "ComparisonGreater"]
```

2. Change `tag_ref_value` from string --> bytes (as influx can send `0xff` for a field reference which is not a valid UTF-8 String and causes an error in Rust)

3. Removed the gogoproto extension of `option = false;`


