### PR TITLE
feat: Update storage protobuf definitions, add stubs for read_window_aggregate

### DIFF
--- a/generated_types/build.rs
+++ b/generated_types/build.rs
@@ -22,12 +22,15 @@ fn main() -> Result<()> {
 
 /// Schema used with IOx specific gRPC requests
 ///
-/// Creates `influxdata.platform.storage.rs`
+/// Creates `influxdata.platform.storage.rs` and `com.github.influxdata.idpe.storage.read.rs`
 fn generate_grpc_types(root: &Path) -> Result<()> {
     let proto_files = vec![
         root.join("influxdb_iox.proto"),
         root.join("predicate.proto"),
+        root.join("storage_common.proto"),
+        root.join("storage_common_idpe.proto"),
         root.join("service.proto"),
+        root.join("source.proto"),
     ];
 
     // Tell cargo to recompile if any of these proto files are changed

--- a/generated_types/service.proto
+++ b/generated_types/service.proto
@@ -1,252 +1,38 @@
-// This file defines the InfluxDB storage gRPC service (how the rest of influxdb /
-// flux / influxql talk to the storage system)
-//
-// Copy/pasted, as closely as verbatim as possible, from
-// https://github.com/influxdata/idpe/blob/master/storage/read/service.proto
-
 syntax = "proto3";
 package influxdata.platform.storage;
 
 import "google/protobuf/empty.proto";
-import "google/protobuf/any.proto";
-import "predicate.proto";
+import "storage_common.proto";
+import "storage_common_idpe.proto";
 
 
 service Storage {
-  // ReadFilter performs a filter operation at storage
-  rpc ReadFilter (ReadFilterRequest) returns (stream ReadResponse);
+    // ReadFilter performs a filter operation at storage
+    rpc ReadFilter (ReadFilterRequest) returns (stream ReadResponse);
 
-  // ReadGroup performs a group operation at storage
-  rpc ReadGroup (ReadGroupRequest) returns (stream ReadResponse);
+    // ReadGroup performs a group operation at storage
+    rpc ReadGroup (ReadGroupRequest) returns (stream ReadResponse);
 
-  // TagKeys performs a read operation for tag keys
-  rpc TagKeys (TagKeysRequest) returns (stream StringValuesResponse);
+    // ReadWindowAggregate performs a window aggregate operation at storage
+    rpc ReadWindowAggregate (ReadWindowAggregateRequest) returns (stream ReadResponse);
 
-  // TagValues performs a read operation for tag values
-  rpc TagValues (TagValuesRequest) returns (stream StringValuesResponse);
+    // TagKeys performs a read operation for tag keys
+    rpc TagKeys (TagKeysRequest) returns (stream StringValuesResponse);
 
-  // Capabilities returns a map of keys and values identifying the capabilities supported by the storage engine
-  rpc Capabilities (google.protobuf.Empty) returns (CapabilitiesResponse);
+    // TagValues performs a read operation for tag values
+    rpc TagValues (TagValuesRequest) returns (stream StringValuesResponse);
 
-  rpc MeasurementNames(MeasurementNamesRequest) returns (stream StringValuesResponse);
+    // ReadSeriesCardinality performs a read operation for series cardinality
+    rpc ReadSeriesCardinality (ReadSeriesCardinalityRequest) returns (stream Int64ValuesResponse);
 
-  rpc MeasurementTagKeys(MeasurementTagKeysRequest) returns (stream StringValuesResponse);
+    // Capabilities returns a map of keys and values identifying the capabilities supported by the storage engine
+    rpc Capabilities (google.protobuf.Empty) returns (CapabilitiesResponse);
 
-  rpc MeasurementTagValues(MeasurementTagValuesRequest) returns (stream StringValuesResponse);
+    rpc MeasurementNames(MeasurementNamesRequest) returns (stream StringValuesResponse);
 
-  rpc MeasurementFields(MeasurementFieldsRequest) returns (stream MeasurementFieldsResponse);
-}
+    rpc MeasurementTagKeys(MeasurementTagKeysRequest) returns (stream StringValuesResponse);
 
-// From https://github.com/influxdata/influxdb/blob/master/storage/reads/datatypes/storage_common.proto
+    rpc MeasurementTagValues(MeasurementTagValuesRequest) returns (stream StringValuesResponse);
 
-message ReadFilterRequest {
-  google.protobuf.Any read_source = 1;
-  TimestampRange range = 2;
-  Predicate predicate = 3;
-}
-
-message ReadGroupRequest {
-  google.protobuf.Any read_source = 1;
-  TimestampRange range = 2;
-  Predicate predicate = 3;
-
-  enum Group {
-    // GroupNone returns all series as a single group.
-    // The single GroupFrame.TagKeys will be the union of all tag keys.
-    GROUP_NONE = 0;
-
-    // GroupBy returns a group for each unique value of the specified GroupKeys.
-    GROUP_BY = 2;
-  }
-
-  // GroupKeys specifies a list of tag keys used to order the data.
-  // It is dependent on the Group property to determine its behavior.
-  repeated string group_keys = 4;
-
-  Group group = 5;
-  Aggregate aggregate = 6;
-}
-
-message Aggregate {
-  enum AggregateType {
-    NONE = 0;
-    SUM = 1;
-    COUNT = 2;
-    MIN = 3;
-    MAX = 4;
-  }
-
-  AggregateType type = 1;
-
-  // additional arguments?
-}
-
-message Tag {
-  bytes key = 1;
-  bytes value = 2;
-}
-
-// Response message for ReadFilter and ReadGroup
-message ReadResponse {
-  enum FrameType {
-    SERIES = 0;
-    POINTS = 1;
-  }
-
-  enum DataType {
-    FLOAT = 0;
-    INTEGER = 1;
-    UNSIGNED = 2;
-    BOOLEAN = 3;
-    STRING = 4;
-  }
-
-  message Frame {
-    oneof data {
-      GroupFrame group = 7;
-      SeriesFrame series = 1;
-      FloatPointsFrame float_points = 2;
-      IntegerPointsFrame integer_points = 3;
-      UnsignedPointsFrame unsigned_points = 4;
-      BooleanPointsFrame boolean_points = 5;
-      StringPointsFrame string_points = 6;
-    }
-  }
-
-  message GroupFrame {
-    // TagKeys
-    repeated bytes tag_keys = 1;
-    // PartitionKeyVals is the values of the partition key for this group, order matching ReadGroupRequest.GroupKeys
-    repeated bytes partition_key_vals = 2;
-  }
-
-  message SeriesFrame {
-    repeated Tag tags = 1;
-    DataType data_type = 2;
-  }
-
-  message FloatPointsFrame {
-    repeated sfixed64 timestamps = 1;
-    repeated double values = 2;
-  }
-
-  message IntegerPointsFrame {
-    repeated sfixed64 timestamps = 1;
-    repeated int64 values = 2;
-  }
-
-  message UnsignedPointsFrame {
-    repeated sfixed64 timestamps = 1;
-    repeated uint64 values = 2;
-  }
-
-  message BooleanPointsFrame {
-    repeated sfixed64 timestamps = 1;
-    repeated bool values = 2;
-  }
-
-  message StringPointsFrame {
-    repeated sfixed64 timestamps = 1;
-    repeated string values = 2;
-  }
-
-  repeated Frame frames = 1;
-}
-
-message CapabilitiesResponse {
-  map<string, string> caps = 1;
-}
-
-// Specifies a continuous range of nanosecond timestamps.
-message TimestampRange {
-  // Start defines the inclusive lower bound.
-  int64 start = 1;
-
-  // End defines the exclusive upper bound.
-  int64 end = 2;
-}
-
-// TagKeysRequest is the request message for Storage.TagKeys.
-message TagKeysRequest {
-  google.protobuf.Any tags_source = 1;
-  TimestampRange range = 2;
-  Predicate predicate = 3;
-}
-
-// TagValuesRequest is the request message for Storage.TagValues.
-message TagValuesRequest {
-  google.protobuf.Any tags_source = 1;
-  TimestampRange range = 2;
-  Predicate predicate = 3;
-  string tag_key = 4;
-}
-
-// Response message for Storage.TagKeys, Storage.TagValues Storage.MeasurementNames,
-// Storage.MeasurementTagKeys and Storage.MeasurementTagValues.
-message StringValuesResponse {
-  repeated bytes values = 1;
-}
-
-// MeasurementNamesRequest is the request message for Storage.MeasurementNames.
-message MeasurementNamesRequest {
-  google.protobuf.Any source = 1;
-  TimestampRange range = 2;
-}
-
-// MeasurementTagKeysRequest is the request message for Storage.MeasurementTagKeys.
-message MeasurementTagKeysRequest {
-  google.protobuf.Any source = 1;
-  string measurement = 2;
-  TimestampRange range = 3;
-  Predicate predicate = 4;
-}
-
-// MeasurementTagValuesRequest is the request message for Storage.MeasurementTagValues.
-message MeasurementTagValuesRequest {
-  google.protobuf.Any source = 1;
-  string measurement = 2;
-  string tag_key = 3;
-  TimestampRange range = 4;
-  Predicate predicate = 5;
-}
-
-// MeasurementFieldsRequest is the request message for Storage.MeasurementFields.
-message MeasurementFieldsRequest {
-  google.protobuf.Any source = 1;
-  string measurement = 2;
-  TimestampRange range = 3;
-  Predicate predicate = 4;
-}
-
-// MeasurementFieldsResponse is the response message for Storage.MeasurementFields.
-message MeasurementFieldsResponse {
-  enum FieldType {
-    FLOAT = 0;
-    INTEGER = 1;
-    UNSIGNED = 2;
-    STRING = 3;
-    BOOLEAN = 4;
-    UNDEFINED = 5;
-  }
-
-  message MessageField {
-    string key = 1;
-    FieldType type = 2;
-    sfixed64 timestamp = 3;
-  }
-
-  repeated MessageField fields = 1;
-}
-
-// From https://github.com/influxdata/idpe/blob/master/storage/read/source.proto
-
-message ReadSource {
-  // OrgID specifies the organization identifier for this request.
-  uint64 org_id = 1;
-
-  // BucketID specifies the bucket in the organization.
-  uint64 bucket_id = 2;
-
-  // PartitionID specifies the partition to be queried.
-  uint64 partition_id = 3;
+    rpc MeasurementFields(MeasurementFieldsRequest) returns (stream MeasurementFieldsResponse);
 }

--- a/generated_types/service.proto
+++ b/generated_types/service.proto
@@ -1,3 +1,9 @@
+// This file defines the InfluxDB storage gRPC service definition (how the rest of influxdb /
+// flux / influxql talk to the storage system)
+//
+// Copy/pasted, as closely as verbatim as possible, from
+// https://github.com/influxdata/idpe/blob/master/storage/storageproto/service.proto
+
 syntax = "proto3";
 package influxdata.platform.storage;
 

--- a/generated_types/source.proto
+++ b/generated_types/source.proto
@@ -1,0 +1,13 @@
+syntax = "proto3";
+package com.github.influxdata.idpe.storage.read;
+
+message ReadSource {
+  // OrgID specifies the organization identifier for this request.
+  uint64 org_id = 1;
+
+  // BucketID specifies the bucket in the organization.
+  uint64 bucket_id = 2;
+
+  // PartitionID specifies the partition to be queried.
+  uint64 partition_id = 3;
+}

--- a/generated_types/src/lib.rs
+++ b/generated_types/src/lib.rs
@@ -7,6 +7,10 @@
 )]
 
 include!(concat!(env!("OUT_DIR"), "/influxdata.platform.storage.rs"));
+include!(concat!(
+    env!("OUT_DIR"),
+    "/com.github.influxdata.idpe.storage.read.rs"
+));
 include!(concat!(env!("OUT_DIR"), "/wal_generated.rs"));
 
 // Can't implement `Default` because `prost::Message` implements `Default`

--- a/generated_types/storage_common.proto
+++ b/generated_types/storage_common.proto
@@ -1,0 +1,258 @@
+// This file defines the InfluxDB storage gRPC message types (how the rest of influxdb /
+// flux / influxql talk to the storage system)
+//
+// Copy/pasted, as closely as verbatim as possible, from
+// https://github.com/influxdata/influxdb/blob/master/storage/reads/datatypes/storage_common.proto
+
+syntax = "proto3";
+package influxdata.platform.storage;
+
+import "google/protobuf/any.proto";
+import "predicate.proto";
+
+
+message ReadFilterRequest {
+  google.protobuf.Any read_source = 1;
+  TimestampRange range = 2;
+  Predicate predicate = 3;
+}
+
+message ReadGroupRequest {
+  google.protobuf.Any read_source = 1;
+  TimestampRange range = 2;
+  Predicate predicate = 3;
+
+  enum Group {
+    // GroupNone returns all series as a single group.
+    // The single GroupFrame.TagKeys will be the union of all tag keys.
+    GROUP_NONE = 0;
+
+    // GroupBy returns a group for each unique value of the specified GroupKeys.
+    GROUP_BY = 2;
+  }
+
+  // GroupKeys specifies a list of tag keys used to order the data.
+  // It is dependent on the Group property to determine its behavior.
+  repeated string group_keys = 4;
+
+  Group group = 5;
+  Aggregate aggregate = 6;
+
+  // TODO(jlapacik): This field is only used in unit tests.
+  // Specifically the two tests in group_resultset_test.go.
+  // This field should be removed and the tests that depend
+  // on it refactored.
+  enum HintFlags {
+    HINT_NONE      = 0x00;
+    HINT_NO_POINTS = 0x01;
+    HINT_NO_SERIES = 0x02;
+    // HintSchemaAllTime performs schema queries without using time ranges
+    HINT_SCHEMA_ALL_TIME = 0x04;
+  }
+  fixed32 hints = 7;
+}
+
+message Aggregate {
+  enum AggregateType {
+    NONE = 0;
+    SUM = 1;
+    COUNT = 2;
+    MIN = 3;
+    MAX = 4;
+    FIRST = 5;
+    LAST = 6;
+    MEAN = 7;
+  }
+
+  AggregateType type = 1;
+
+  // additional arguments?
+}
+
+message Tag {
+  bytes key = 1;
+  bytes value = 2;
+}
+
+// Response message for ReadFilter and ReadGroup
+message ReadResponse {
+  enum FrameType {
+    SERIES = 0;
+    POINTS = 1;
+  }
+
+  enum DataType {
+    FLOAT = 0;
+    INTEGER = 1;
+    UNSIGNED = 2;
+    BOOLEAN = 3;
+    STRING = 4;
+  }
+
+  message Frame {
+    oneof data {
+      GroupFrame group = 7;
+      SeriesFrame series = 1;
+      FloatPointsFrame float_points = 2;
+      IntegerPointsFrame integer_points = 3;
+      UnsignedPointsFrame unsigned_points = 4;
+      BooleanPointsFrame boolean_points = 5;
+      StringPointsFrame string_points = 6;
+    }
+  }
+
+  message GroupFrame {
+    // TagKeys
+    repeated bytes tag_keys = 1;
+    // PartitionKeyVals is the values of the partition key for this group, order matching ReadGroupRequest.GroupKeys
+    repeated bytes partition_key_vals = 2;
+  }
+
+  message SeriesFrame {
+    repeated Tag tags = 1;
+    DataType data_type = 2;
+  }
+
+  message FloatPointsFrame {
+    repeated sfixed64 timestamps = 1;
+    repeated double values = 2;
+  }
+
+  message IntegerPointsFrame {
+    repeated sfixed64 timestamps = 1;
+    repeated int64 values = 2;
+  }
+
+  message UnsignedPointsFrame {
+    repeated sfixed64 timestamps = 1;
+    repeated uint64 values = 2;
+  }
+
+  message BooleanPointsFrame {
+    repeated sfixed64 timestamps = 1;
+    repeated bool values = 2;
+  }
+
+  message StringPointsFrame {
+    repeated sfixed64 timestamps = 1;
+    repeated string values = 2;
+  }
+
+  repeated Frame frames = 1;
+}
+
+message Capability {
+  // Features contains the specific features supported
+  // by this capability.
+  repeated string features = 1;
+}
+
+message CapabilitiesResponse {
+  // Capabilities contains the set of capabilities supported
+  // by the storage engine. It is a map of method names to
+  // the detailed capability information for the method.
+  map<string, Capability> caps = 1;
+}
+
+// Specifies a continuous range of nanosecond timestamps.
+message TimestampRange {
+  // Start defines the inclusive lower bound.
+  int64 start = 1;
+
+  // End defines the exclusive upper bound.
+  int64 end = 2;
+}
+
+// TagKeysRequest is the request message for Storage.TagKeys.
+message TagKeysRequest {
+  google.protobuf.Any tags_source = 1;
+  TimestampRange range = 2;
+  Predicate predicate = 3;
+}
+
+// TagValuesRequest is the request message for Storage.TagValues.
+message TagValuesRequest {
+  google.protobuf.Any tags_source = 1 ;
+  TimestampRange range = 2; // [(gogoproto.nullable) = false];
+  Predicate predicate = 3;
+  string tag_key = 4;
+}
+
+// Response message for Storage.TagKeys, Storage.TagValues Storage.MeasurementNames,
+// Storage.MeasurementTagKeys and Storage.MeasurementTagValues.
+message StringValuesResponse {
+  repeated bytes values = 1;
+}
+
+// MeasurementNamesRequest is the request message for Storage.MeasurementNames.
+message MeasurementNamesRequest {
+  google.protobuf.Any source = 1;
+  TimestampRange range = 2; // [(gogoproto.nullable) = false]
+  Predicate predicate = 3;
+}
+
+// MeasurementTagKeysRequest is the request message for Storage.MeasurementTagKeys.
+message MeasurementTagKeysRequest {
+  google.protobuf.Any source = 1;
+  string measurement = 2;
+  TimestampRange range = 3; // [(gogoproto.nullable) = false]
+  Predicate predicate = 4;
+}
+
+// MeasurementTagValuesRequest is the request message for Storage.MeasurementTagValues.
+message MeasurementTagValuesRequest {
+  google.protobuf.Any source = 1;
+  string measurement = 2;
+  string tag_key = 3;
+  TimestampRange range = 4; // [(gogoproto.nullable) = false];
+  Predicate predicate = 5;
+}
+
+// MeasurementFieldsRequest is the request message for Storage.MeasurementFields.
+message MeasurementFieldsRequest {
+  google.protobuf.Any source = 1;
+  string measurement = 2;
+  TimestampRange range = 3; // [(gogoproto.nullable) = false];
+  Predicate predicate = 4;
+}
+
+// MeasurementFieldsResponse is the response message for Storage.MeasurementFields.
+message MeasurementFieldsResponse {
+  enum FieldType {
+    FLOAT = 0;
+    INTEGER = 1;
+    UNSIGNED = 2;
+    STRING = 3;
+    BOOLEAN = 4;
+    UNDEFINED = 5;
+  }
+
+  message MessageField {
+    string key = 1;
+    FieldType type = 2;
+    sfixed64 timestamp = 3;
+  }
+
+  repeated MessageField fields = 1;// [(gogoproto.nullable) = false];
+}
+
+message ReadWindowAggregateRequest {
+  google.protobuf.Any read_source = 1;
+  TimestampRange range = 2; // [(gogoproto.nullable) = false];
+  Predicate predicate = 3;
+  int64 WindowEvery = 4;
+  int64 Offset = 6;
+  repeated Aggregate aggregate = 5;
+  Window window = 7;
+}
+
+message Window {
+  Duration every = 1;
+  Duration offset = 2;
+}
+
+message Duration {
+  int64 nsecs = 1;
+  int64 months = 2;
+  bool negative = 3;
+}

--- a/generated_types/storage_common_idpe.proto
+++ b/generated_types/storage_common_idpe.proto
@@ -1,0 +1,25 @@
+// This file defines extensions to the InfluxDB storage gRPC common message types
+// that have not yet made it into influxdb.
+
+// It is, effectively, the delta between these two files:
+// https://github.com/influxdata/influxdb/blob/master/storage/reads/datatypes/storage_common.proto
+// https://github.com/influxdata/idpe/blob/master/storage/storageproto/storage_common.proto
+
+
+syntax = "proto3";
+package influxdata.platform.storage;
+
+import "google/protobuf/any.proto";
+import "predicate.proto";
+import "storage_common.proto";
+
+message ReadSeriesCardinalityRequest {
+  google.protobuf.Any read_series_cardinality_source = 1;
+  TimestampRange range = 2; // [(gogoproto.nullable) = false];
+  Predicate predicate = 3;
+}
+
+// Response message for Storage.SeriesCardinality
+message Int64ValuesResponse {
+  repeated int64 values = 1;
+}

--- a/src/server/rpc/storage.rs
+++ b/src/server/rpc/storage.rs
@@ -8,9 +8,10 @@ use generated_types::{
     i_ox_server::{IOx, IOxServer},
     storage_server::{Storage, StorageServer},
     CapabilitiesResponse, CreateBucketRequest, CreateBucketResponse, DeleteBucketRequest,
-    DeleteBucketResponse, GetBucketsResponse, MeasurementFieldsRequest, MeasurementFieldsResponse,
-    MeasurementNamesRequest, MeasurementTagKeysRequest, MeasurementTagValuesRequest, Organization,
-    Predicate, ReadFilterRequest, ReadGroupRequest, ReadResponse, StringValuesResponse,
+    DeleteBucketResponse, GetBucketsResponse, Int64ValuesResponse, MeasurementFieldsRequest,
+    MeasurementFieldsResponse, MeasurementNamesRequest, MeasurementTagKeysRequest,
+    MeasurementTagValuesRequest, Organization, Predicate, ReadFilterRequest, ReadGroupRequest,
+    ReadResponse, ReadSeriesCardinalityRequest, ReadWindowAggregateRequest, StringValuesResponse,
     TagKeysRequest, TagValuesRequest, TestErrorRequest, TestErrorResponse, TimestampRange,
 };
 
@@ -286,6 +287,7 @@ where
             // TODO: handle aggregate values, especially whether None is the same as
             // Some(AggregateType::None) or not
             aggregate: _aggregate,
+            hints: _,
         } = read_group_request;
 
         info!(
@@ -306,6 +308,15 @@ where
         .map_err(|e| e.to_status())?;
 
         Ok(tonic::Response::new(rx))
+    }
+
+    type ReadWindowAggregateStream = mpsc::Receiver<Result<ReadResponse, Status>>;
+
+    async fn read_window_aggregate(
+        &self,
+        _req: tonic::Request<ReadWindowAggregateRequest>,
+    ) -> Result<tonic::Response<Self::ReadGroupStream>, Status> {
+        unimplemented!("read_window_aggregate not yet implemented");
     }
 
     type TagKeysStream = mpsc::Receiver<Result<StringValuesResponse, Status>>;
@@ -409,6 +420,15 @@ where
         Ok(tonic::Response::new(rx))
     }
 
+    type ReadSeriesCardinalityStream = mpsc::Receiver<Result<Int64ValuesResponse, Status>>;
+
+    async fn read_series_cardinality(
+        &self,
+        _req: tonic::Request<ReadSeriesCardinalityRequest>,
+    ) -> Result<tonic::Response<Self::ReadSeriesCardinalityStream>, Status> {
+        unimplemented!("read_series_cardinality not yet implemented");
+    }
+
     async fn capabilities(
         &self,
         _req: tonic::Request<()>,
@@ -439,7 +459,19 @@ where
         let MeasurementNamesRequest {
             source: _source,
             range,
+            predicate,
         } = measurement_names_request;
+
+        if let Some(predicate) = predicate {
+            return NotYetImplemented {
+                operation: format!(
+                    "measurement_names request with a predicate: {:?}",
+                    predicate
+                ),
+            }
+            .fail()
+            .map_err(|e| e.to_status());
+        }
 
         info!(
             "measurement_names for database {}, range: {:?}",
@@ -1036,7 +1068,9 @@ mod tests {
 
     use futures::prelude::*;
 
-    use generated_types::{i_ox_client, read_response::frame, storage_client, ReadSource};
+    use generated_types::{
+        i_ox_client, read_response::frame, storage_client, Capability, ReadSource,
+    };
     use prost::Message;
 
     type IOxClient = i_ox_client::IOxClient<tonic::transport::Channel>;
@@ -1110,6 +1144,7 @@ mod tests {
         let request = MeasurementNamesRequest {
             source: source.clone(),
             range: None,
+            predicate: None,
         };
 
         let actual_measurements = fixture.storage_client.measurement_names(request).await?;
@@ -1124,6 +1159,7 @@ mod tests {
         let request = MeasurementNamesRequest {
             source,
             range: Some(range),
+            predicate: None,
         };
 
         let actual_measurements = fixture.storage_client.measurement_names(request).await?;
@@ -1684,6 +1720,7 @@ mod tests {
             group_keys: vec![String::from("tag1")],
             group,
             aggregate: None,
+            hints: 0,
         };
 
         let expected_request = QueryGroupsRequest {
@@ -1718,6 +1755,7 @@ mod tests {
             group_keys: vec![],
             group,
             aggregate: None,
+            hints: 0,
         };
 
         // Note we don't set the response on the test database, so we expect an error
@@ -1919,10 +1957,19 @@ mod tests {
         }
 
         /// return the capabilities of the server as a hash map
-        async fn capabilities(&mut self) -> Result<HashMap<String, String>, tonic::Status> {
+        async fn capabilities(&mut self) -> Result<HashMap<String, Vec<String>>, tonic::Status> {
             let response = self.inner.capabilities(()).await?.into_inner();
 
             let CapabilitiesResponse { caps } = response;
+
+            // unwrap the Vec of Strings inside each `Capability`
+            let caps = caps
+                .into_iter()
+                .map(|(name, capability)| {
+                    let Capability { features } = capability;
+                    (name, features)
+                })
+                .collect();
 
             Ok(caps)
         }

--- a/src/server/rpc/storage.rs
+++ b/src/server/rpc/storage.rs
@@ -1068,9 +1068,7 @@ mod tests {
 
     use futures::prelude::*;
 
-    use generated_types::{
-        i_ox_client, read_response::frame, storage_client, Capability, ReadSource,
-    };
+    use generated_types::{i_ox_client, read_response::frame, storage_client, ReadSource};
     use prost::Message;
 
     type IOxClient = i_ox_client::IOxClient<tonic::transport::Channel>;
@@ -1965,10 +1963,7 @@ mod tests {
             // unwrap the Vec of Strings inside each `Capability`
             let caps = caps
                 .into_iter()
-                .map(|(name, capability)| {
-                    let Capability { features } = capability;
-                    (name, features)
-                })
+                .map(|(name, capability)| (name, capability.features))
                 .collect();
 
             Ok(caps)

--- a/tests/end-to-end.rs
+++ b/tests/end-to-end.rs
@@ -333,6 +333,7 @@ async fn read_and_write_data() -> Result<()> {
         group_keys: vec![String::from("region")],
         group: Group::By as _,
         aggregate: None,
+        hints: 0,
     });
     let read_group_response = storage_client.read_group(read_group_request).await?;
 
@@ -369,6 +370,7 @@ async fn read_and_write_data() -> Result<()> {
     let measurement_names_request = tonic::Request::new(MeasurementNamesRequest {
         source: read_source.clone(),
         range: range.clone(),
+        predicate: None,
     });
 
     let measurement_names_response = storage_client


### PR DESCRIPTION
Rationale: Ensure IOx is in sync with the influxdb storage gRPC definitions (so it can run Flux and InfluxQL)

Part of a three PR cycle related to https://github.com/influxdata/influxdb_iox/issues/369

- [x] Split proto files to match influxdb (https://github.com/influxdata/influxdb_iox/pull/442)
- [x] Update predicate.proto (https://github.com/influxdata/influxdb_iox/pull/443)
- [x] Update service.proto  (this PR)


This PR copy/pastes the contents, as closely as possible, from 
https://github.com/influxdata/idpe/blob/master/storage/storageproto/source.proto
https://github.com/influxdata/idpe/blob/master/storage/storageproto/service.proto
as well as deltas in https://github.com/influxdata/idpe/blob/master/storage/storageproto/storage_common.proto that haven't yet made it into OSS. 

Changes:
1. Remove  gogoproto specific stuff such as the following:
```
 [(gogoproto.enumvalue_customname) = "FieldTypeFloat"]
```

leaving in annotations for non nullable as comments:
```
 // [(gogoproto.nullable) = false];
```

2. Removed the gogoproto extension of `option = false;`

3. Implemented changes to the Rust code for the newly introduced 

Among other things, this also introduce the `read_window_aggregate` call needed for pushing down grouping into the storage layer (unimplemented at the moment, of course).

New things I learned we need to implement:
* read_window_aggregate
* read_series_cardinality
* measurement_names with a predicate
