### PR TITLE
fix: Update git branch ref from master --> main to reflect repository updates

### DIFF
--- a/docker/Dockerfile.ci
+++ b/docker/Dockerfile.ci
@@ -65,7 +65,7 @@ ENV PATH /home/rust/.local/bin:/home/rust/bin:${PATH}
 ADD . /home/rust/project
 RUN sudo chown -R rust:rust /home/rust/project
 RUN sudo chmod u+rwx  /home/rust/project
-RUN cd /home/rust/project && git checkout master && git reset --hard
+RUN cd /home/rust/project && git checkout main && git reset --hard
 
 # Compile the code and bake the results into the image, so actual CI
 # builds are just incremental builds from the last time the image was


### PR DESCRIPTION
The [CI docker image builder](https://app.circleci.com/pipelines/github/influxdata/influxdb_iox/1834/workflows/bf76c1c0-146a-4268-82db-d90242382bb7/jobs/6849) job failed last night due to an outdated reference to `master` (we have since updated this repo to use `main` as the default branch)

```
 ---> 60fe27b4de81
Removing intermediate container 45ad9ca4c8c9
Step 19/21 : RUN cd /home/rust/project && git checkout master && git reset --hard
 ---> Running in eab97803f0e3
error: pathspec 'master' did not match any file(s) known to git
The command '/bin/sh -c cd /home/rust/project && git checkout master && git reset --hard' returned a non-zero code: 1

Exited with code exit status 1
CircleCI received exit code 1
```

This PR updates the Dockerfile to check out the right branch