### PR TITLE
fix: return error from binding HTTP server address instead of panicking

### DIFF
--- a/src/commands/write_buffer_server.rs
+++ b/src/commands/write_buffer_server.rs
@@ -81,7 +81,7 @@ pub async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         }
     });
 
-    let server = Server::bind(&bind_addr).serve(make_svc);
+    let server = Server::try_bind(&bind_addr)?.serve(make_svc);
     info!("Listening on http://{}", bind_addr);
 
     println!("InfluxDB IOx server ready");


### PR DESCRIPTION
Make sure an error is returned to the user, instead of panicking, if binding the HTTP server address fails.