### PR TITLE
fix: Improve error messages in main server loop

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -187,7 +187,7 @@ async fn dispatch_args(matches: ArgMatches<'_>) {
             match commands::write_buffer_server::main().await {
                 Ok(()) => eprintln!("Shutdown OK"),
                 Err(e) => {
-                    error!("Server shutdown with error: {:?}", e);
+                    error!("Server shutdown with error: {}", e);
                     std::process::exit(ReturnCode::ServerExitedAbnormally as _);
                 }
             }


### PR DESCRIPTION
Inspired by https://github.com/influxdata/influxdb_iox/pull/453#issuecomment-728152365, this PR improves the error reporting for the main server loop by bringing it up to the [error standards](https://github.com/influxdata/influxdb_iox/blob/main/docs/style_guide.md#errors)


Old message (before this PR):
```
InfluxDB IOx server starting
[2020-11-16T15:50:25Z ERROR influxdb_iox] Server shutdown with error: hyper::Error(Listen, Os { code: 48, kind: AddrInUse, message: "Address already in use" })
```

New message (with this PR -- note the inclusion of the host/port (`127.0.0.1:8080`):
```
InfluxDB IOx server starting
[2020-11-16T16:38:02Z ERROR influxdb_iox] Server shutdown with error: Unable to bind to listen for HTTP requests on 127.0.0.1:8080: error creating server listener: Address already in use (os error 48)
```

While I am annoyed at the amount of typing this required, I am happy with the result of the errors (and that path information has been included in database failures too)

