### PR TITLE
fix: dotenv is both a build and a dev dependency

### DIFF
--- a/object_store/Cargo.toml
+++ b/object_store/Cargo.toml
@@ -23,6 +23,7 @@ tokio-util = "0.3.1"
 
 [dev-dependencies]
 tempfile = "3.1.0"
+dotenv = "0.15.0"
 
 [build-dependencies]
 dotenv = "0.15.0"


### PR DESCRIPTION
I'm not sure why this just started happening just now for me, but I was getting an error from `objectstore/src/lib.rs` that it couldn't find `dotenv` (which is used in tests). `dotenv` is also used in `objectstore`'s `build.rs`, so it needs to be listed under both `dev` and `build` dependencies.