### PR TITLE
feat: Implement gRPC and storage interface for read_group_aggregate

### DIFF
--- a/src/server/rpc/expr.rs
+++ b/src/server/rpc/expr.rs
@@ -604,7 +604,7 @@ pub fn convert_group_type(group: i32) -> Result<RPCGroup> {
     } else if group == RPCGroup::By as i32 {
         Ok(RPCGroup::By)
     } else {
-        return UnknownGroup { group_type: group }.fail();
+        UnknownGroup { group_type: group }.fail();
     }
 }
 

--- a/src/server/rpc/expr.rs
+++ b/src/server/rpc/expr.rs
@@ -49,11 +49,14 @@ pub enum Error {
     #[snafu(display("Error parsing window bounds: No window specified"))]
     EmptyWindow {},
 
-    #[snafu(display("Error parsing window bounds duration '{}': {}", location, description))]
-    InvalidDuration {
-        location: String,
-        description: String,
-    },
+    #[snafu(display("Error parsing window bounds duration 'window.every': {}", description))]
+    InvalidWindowEveryDuration { description: String },
+
+    #[snafu(display(
+        "Error parsing window bounds duration 'window.offset': {}",
+        description
+    ))]
+    InvalidWindowOffsetDuration { description: String },
 
     #[snafu(display("Internal error: found measurement tag reference in unexpected location"))]
     InternalInvalidMeasurementReference {},
@@ -527,12 +530,10 @@ pub fn make_read_window_aggregate(
         let window = window.ok_or(Error::EmptyWindow {})?;
 
         (
-            convert_duration(window.every).map_err(|e| Error::InvalidDuration {
-                location: "window.every".into(),
+            convert_duration(window.every).map_err(|e| Error::InvalidWindowEveryDuration {
                 description: e.into(),
             })?,
-            convert_duration(window.offset).map_err(|e| Error::InvalidDuration {
-                location: "window.offset".into(),
+            convert_duration(window.offset).map_err(|e| Error::InvalidWindowOffsetDuration {
                 description: e.into(),
             })?,
         )

--- a/src/server/rpc/expr.rs
+++ b/src/server/rpc/expr.rs
@@ -1,6 +1,9 @@
-//! This module has logic to translate gRPC `Predicate` nodes into the
-//! native storage system predicate form,  `storage::Predicates`
-
+//! This module has logic to translate gRPC sructures into the native
+//! storage system form by extending the builders for those structures with new traits
+//!
+//! RPCPredicate --> storage::Predicates
+//!
+//! Aggregates / windows --> storage::GroupByAndAggregate
 use std::convert::TryFrom;
 
 use arrow_deps::datafusion::{
@@ -8,19 +11,49 @@ use arrow_deps::datafusion::{
     scalar::ScalarValue,
 };
 use generated_types::{
-    node::Comparison as RPCComparison, node::Logical as RPCLogical, node::Value as RPCValue,
-    Node as RPCNode, Predicate as RPCPredicate,
+    aggregate::AggregateType as RPCAggregateType, node::Comparison as RPCComparison,
+    node::Logical as RPCLogical, node::Value as RPCValue, read_group_request::Group as RPCGroup,
+    Aggregate as RPCAggregate, Duration as RPCDuration, Node as RPCNode, Predicate as RPCPredicate,
+    Window as RPCWindow,
 };
 use snafu::{ResultExt, Snafu};
+use storage::groupby::WindowDuration;
+use storage::groupby::{Aggregate as StorageAggregate, GroupByAndAggregate};
 use storage::predicate::PredicateBuilder;
+use tracing::warn;
 
 #[derive(Debug, Snafu)]
 pub enum Error {
+    #[snafu(display("Error creating aggregate: Unexpected empty aggregate"))]
+    EmptyAggregate {},
+
+    #[snafu(display("Error creating aggregate: Unsupported none aggregate"))]
+    NoneAggregate {},
+
+    #[snafu(display("Error creating aggregate: Exactly one aggregate is supported, but {} were supplied: {:?}",
+                    aggregates.len(), aggregates))]
+    AggregateNotSingleton { aggregates: Vec<RPCAggregate> },
+
+    #[snafu(display("Error creating aggregate: Unknown aggregate type {}", aggregate_type))]
+    UnknownAggregate { aggregate_type: i32 },
+
+    #[snafu(display("Error creating aggregate: Unknown group type: {}", group_type))]
+    UnknownGroup { group_type: i32 },
+
     #[snafu(display("Error creating predicate: Unexpected empty predicate: Node"))]
     EmptyPredicateNode {},
 
-    #[snafu(display("Error creating predicate: Unexpected empty predicate: Value"))]
+    #[snafu(display("Error creating predicate: Unexpected empty predicate value"))]
     EmptyPredicateValue {},
+
+    #[snafu(display("Error parsing window bounds: No window specified"))]
+    EmptyWindow {},
+
+    #[snafu(display("Error parsing window bounds duration '{}': {}", location, description))]
+    InvalidDuration {
+        location: String,
+        description: String,
+    },
 
     #[snafu(display("Internal error: found measurement tag reference in unexpected location"))]
     InternalInvalidMeasurementReference {},
@@ -445,6 +478,136 @@ fn build_binary_expr(op: Operator, inputs: Vec<Expr>) -> Result<Expr> {
     }
 }
 
+pub fn make_read_group_aggregate(
+    aggregate: Option<RPCAggregate>,
+    _group: RPCGroup,
+    group_keys: Vec<String>,
+) -> Result<GroupByAndAggregate> {
+    let gby_agg = GroupByAndAggregate::Columns {
+        agg: convert_aggregate(aggregate)?,
+        group_columns: group_keys,
+    };
+    Ok(gby_agg)
+}
+
+/// Builds GroupByAndAggregate::Windows s
+pub fn make_read_window_aggregate(
+    aggregates: Vec<RPCAggregate>,
+    window_every: i64,
+    offset: i64,
+    window: Option<RPCWindow>,
+) -> Result<GroupByAndAggregate> {
+    // only support single aggregate for now
+    if aggregates.len() != 1 {
+        return AggregateNotSingleton { aggregates }.fail();
+    }
+    let agg = convert_aggregate(Some(aggregates.into_iter().next().unwrap()))?;
+
+    // Translation from these parameters to window bound
+    // is defined in the Go code:
+    // https://github.com/influxdata/idpe/pull/8636/files#diff-94c0a8d7e427e2d7abe49f01dced50ad776b65ec8f2c8fb2a2c8b90e2e377ed5R82
+    //
+    // Quoting:
+    //
+    // Window and the WindowEvery/Offset should be mutually
+    // exclusive. If you set either the WindowEvery or Offset with
+    // nanosecond values, then the Window will be ignored
+
+    let (every, offset) = if window_every > 0 || offset > 0 {
+        // warn if window is being ignored
+        if window.is_some() {
+            warn!("window_every {} or offset {} was non zero, so ignoring window specification '{:?}' on read_window_aggregate",
+                  window_every, offset, window);
+        }
+        (
+            WindowDuration::from_nanoseconds(window_every),
+            WindowDuration::from_nanoseconds(offset),
+        )
+    } else {
+        let window = window.ok_or(Error::EmptyWindow {})?;
+
+        (
+            convert_duration(window.every).map_err(|e| Error::InvalidDuration {
+                location: "window.every".into(),
+                description: e.into(),
+            })?,
+            convert_duration(window.offset).map_err(|e| Error::InvalidDuration {
+                location: "window.offset".into(),
+                description: e.into(),
+            })?,
+        )
+    };
+
+    Ok(GroupByAndAggregate::Window { agg, every, offset })
+}
+
+fn convert_duration(duration: Option<RPCDuration>) -> Result<WindowDuration, &'static str> {
+    let duration = duration.ok_or("No duration specified in RPC")?;
+
+    match (duration.nsecs != 0, duration.months != 0) {
+        (true, false) => Ok(WindowDuration::from_nanoseconds(duration.nsecs)),
+        (false, true) => Ok(WindowDuration::from_months(
+            duration.months,
+            duration.negative,
+        )),
+        // Same error as Go code: https://github.com/influxdata/flux/blob/master/execute/window.go#L36
+        (true, true) => Err("duration used as an interval cannot mix month and nanosecond units"),
+        (false, false) => Err("duration used as an interval cannot be zero"),
+    }
+}
+
+fn convert_aggregate(aggregate: Option<RPCAggregate>) -> Result<StorageAggregate> {
+    let aggregate = match aggregate {
+        None => return EmptyAggregate {}.fail(),
+        Some(aggregate) => aggregate,
+    };
+
+    let storage_aggregate = match convert_aggregate_type(aggregate.r#type)? {
+        RPCAggregateType::None => return NoneAggregate {}.fail(),
+        RPCAggregateType::Sum => StorageAggregate::Sum,
+        RPCAggregateType::Count => StorageAggregate::Count,
+        RPCAggregateType::Min => StorageAggregate::Min,
+        RPCAggregateType::Max => StorageAggregate::Max,
+        RPCAggregateType::First => StorageAggregate::First,
+        RPCAggregateType::Last => StorageAggregate::Last,
+        RPCAggregateType::Mean => StorageAggregate::Mean,
+    };
+
+    Ok(storage_aggregate)
+}
+
+fn convert_aggregate_type(aggregate_type: i32) -> Result<RPCAggregateType> {
+    if aggregate_type == RPCAggregateType::None as i32 {
+        Ok(RPCAggregateType::None)
+    } else if aggregate_type == RPCAggregateType::Sum as i32 {
+        Ok(RPCAggregateType::Sum)
+    } else if aggregate_type == RPCAggregateType::Count as i32 {
+        Ok(RPCAggregateType::Count)
+    } else if aggregate_type == RPCAggregateType::Min as i32 {
+        Ok(RPCAggregateType::Min)
+    } else if aggregate_type == RPCAggregateType::Max as i32 {
+        Ok(RPCAggregateType::Max)
+    } else if aggregate_type == RPCAggregateType::First as i32 {
+        Ok(RPCAggregateType::First)
+    } else if aggregate_type == RPCAggregateType::Last as i32 {
+        Ok(RPCAggregateType::Last)
+    } else if aggregate_type == RPCAggregateType::Mean as i32 {
+        Ok(RPCAggregateType::Mean)
+    } else {
+        UnknownAggregate { aggregate_type }.fail()
+    }
+}
+
+pub fn convert_group_type(group: i32) -> Result<RPCGroup> {
+    if group == RPCGroup::None as i32 {
+        Ok(RPCGroup::None)
+    } else if group == RPCGroup::By as i32 {
+        Ok(RPCGroup::By)
+    } else {
+        return UnknownGroup { group_type: group }.fail();
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use generated_types::node::Type as RPCNodeType;
@@ -827,6 +990,205 @@ mod tests {
         match res {
             Ok(_) => "UNEXPECTED SUCCESS".into(),
             Err(e) => format!("{}", e),
+        }
+    }
+
+    #[test]
+    fn test_make_read_window_aggregate() {
+        let pos_5_ns = WindowDuration::from_nanoseconds(5);
+        let pos_10_ns = WindowDuration::from_nanoseconds(10);
+        let pos_3_months = WindowDuration::from_months(3, false);
+        let neg_1_months = WindowDuration::from_months(1, true);
+
+        let agg = make_read_window_aggregate(vec![], 5, 10, None);
+        let expected =
+            "Error creating aggregate: Exactly one aggregate is supported, but 0 were supplied: []";
+        assert_eq!(error_result_to_string(agg), expected);
+
+        let agg =
+            make_read_window_aggregate(vec![make_aggregate(1), make_aggregate(2)], 5, 10, None);
+        let expected = "Error creating aggregate: Exactly one aggregate is supported, but 2 were supplied: [Aggregate { r#type: Sum }, Aggregate { r#type: Count }]";
+        assert_eq!(error_result_to_string(agg), expected);
+
+        // now window specified
+        let agg = make_read_window_aggregate(vec![make_aggregate(1)], 0, 0, None);
+        let expected = "Error parsing window bounds: No window specified";
+        assert_eq!(error_result_to_string(agg), expected);
+
+        // correct window + window_every
+        let agg = make_read_window_aggregate(vec![make_aggregate(1)], 5, 10, None).unwrap();
+        let expected = make_storage_window(StorageAggregate::Sum, &pos_5_ns, &pos_10_ns);
+        assert_eq!(agg, expected);
+
+        // correct every + offset
+        let agg = make_read_window_aggregate(
+            vec![make_aggregate(1)],
+            0,
+            0,
+            Some(make_rpc_window(5, 0, false, 10, 0, false)),
+        )
+        .unwrap();
+        let expected = make_storage_window(StorageAggregate::Sum, &pos_5_ns, &pos_10_ns);
+        assert_eq!(agg, expected);
+
+        // correct every + offset in months
+        let agg = make_read_window_aggregate(
+            vec![make_aggregate(1)],
+            0,
+            0,
+            Some(make_rpc_window(0, 3, false, 0, 1, true)),
+        )
+        .unwrap();
+        let expected = make_storage_window(StorageAggregate::Sum, &pos_3_months, &neg_1_months);
+        assert_eq!(agg, expected);
+
+        // correct every + offset in months
+        let agg = make_read_window_aggregate(
+            vec![make_aggregate(1)],
+            0,
+            0,
+            Some(make_rpc_window(0, 1, true, 0, 3, false)),
+        )
+        .unwrap();
+        let expected = make_storage_window(StorageAggregate::Sum, &neg_1_months, &pos_3_months);
+        assert_eq!(agg, expected);
+
+        // both window + window_every and every + offset -- every + offset overrides
+        // (100 and 200 should be ignored)
+        let agg = make_read_window_aggregate(
+            vec![make_aggregate(1)],
+            5,
+            10,
+            Some(make_rpc_window(100, 0, false, 200, 0, false)),
+        )
+        .unwrap();
+        let expected = make_storage_window(StorageAggregate::Sum, &pos_5_ns, &pos_10_ns);
+        assert_eq!(agg, expected);
+
+        // invalid durations
+        let agg = make_read_window_aggregate(
+            vec![make_aggregate(1)],
+            0,
+            0,
+            Some(make_rpc_window(5, 1, false, 10, 0, false)),
+        );
+        let expected = "Error parsing window bounds duration \'window.every\': duration used as an interval cannot mix month and nanosecond units";
+        assert_eq!(error_result_to_string(agg), expected);
+
+        // invalid durations
+        let agg = make_read_window_aggregate(
+            vec![make_aggregate(1)],
+            0,
+            0,
+            Some(make_rpc_window(5, 0, false, 10, 1, false)),
+        );
+        let expected = "Error parsing window bounds duration \'window.offset\': duration used as an interval cannot mix month and nanosecond units";
+        assert_eq!(error_result_to_string(agg), expected);
+
+        // invalid durations
+        let agg = make_read_window_aggregate(
+            vec![make_aggregate(1)],
+            0,
+            0,
+            Some(make_rpc_window(5, 0, false, 0, 0, false)),
+        );
+        let expected = "Error parsing window bounds duration \'window.offset\': duration used as an interval cannot be zero";
+        assert_eq!(error_result_to_string(agg), expected);
+    }
+
+    #[test]
+    fn test_convert_group_type() {
+        assert_eq!(convert_group_type(0).unwrap(), RPCGroup::None);
+        assert_eq!(convert_group_type(2).unwrap(), RPCGroup::By);
+        assert_eq!(
+            error_result_to_string(convert_group_type(1)),
+            "Error creating aggregate: Unknown group type: 1"
+        );
+    }
+
+    #[test]
+    fn test_convert_aggregate() {
+        assert_eq!(
+            error_result_to_string(convert_aggregate(None)),
+            "Error creating aggregate: Unexpected empty aggregate"
+        );
+        assert_eq!(
+            error_result_to_string(convert_aggregate(make_aggregate_opt(0))),
+            "Error creating aggregate: Unsupported none aggregate"
+        );
+        assert_eq!(
+            convert_aggregate(make_aggregate_opt(1)).unwrap(),
+            StorageAggregate::Sum
+        );
+        assert_eq!(
+            convert_aggregate(make_aggregate_opt(2)).unwrap(),
+            StorageAggregate::Count
+        );
+        assert_eq!(
+            convert_aggregate(make_aggregate_opt(3)).unwrap(),
+            StorageAggregate::Min
+        );
+        assert_eq!(
+            convert_aggregate(make_aggregate_opt(4)).unwrap(),
+            StorageAggregate::Max
+        );
+        assert_eq!(
+            convert_aggregate(make_aggregate_opt(5)).unwrap(),
+            StorageAggregate::First
+        );
+        assert_eq!(
+            convert_aggregate(make_aggregate_opt(6)).unwrap(),
+            StorageAggregate::Last
+        );
+        assert_eq!(
+            convert_aggregate(make_aggregate_opt(7)).unwrap(),
+            StorageAggregate::Mean
+        );
+        assert_eq!(
+            error_result_to_string(convert_aggregate(make_aggregate_opt(100))),
+            "Error creating aggregate: Unknown aggregate type 100"
+        );
+    }
+
+    fn make_aggregate(t: i32) -> RPCAggregate {
+        RPCAggregate { r#type: t }
+    }
+
+    fn make_aggregate_opt(t: i32) -> Option<RPCAggregate> {
+        Some(make_aggregate(t))
+    }
+
+    fn make_rpc_window(
+        every_nsecs: i64,
+        every_months: i64,
+        every_negative: bool,
+        offset_nsecs: i64,
+        offset_months: i64,
+        offset_negative: bool,
+    ) -> RPCWindow {
+        RPCWindow {
+            every: Some(RPCDuration {
+                nsecs: every_nsecs,
+                months: every_months,
+                negative: every_negative,
+            }),
+            offset: Some(RPCDuration {
+                nsecs: offset_nsecs,
+                months: offset_months,
+                negative: offset_negative,
+            }),
+        }
+    }
+
+    fn make_storage_window(
+        agg: StorageAggregate,
+        every: &WindowDuration,
+        offset: &WindowDuration,
+    ) -> GroupByAndAggregate {
+        GroupByAndAggregate::Window {
+            agg,
+            every: every.clone(),
+            offset: offset.clone(),
         }
     }
 }

--- a/src/server/rpc/expr.rs
+++ b/src/server/rpc/expr.rs
@@ -1,4 +1,4 @@
-//! This module has logic to translate gRPC sructures into the native
+//! This module has logic to translate gRPC structures into the native
 //! storage system form by extending the builders for those structures with new traits
 //!
 //! RPCPredicate --> storage::Predicates
@@ -490,7 +490,7 @@ pub fn make_read_group_aggregate(
     Ok(gby_agg)
 }
 
-/// Builds GroupByAndAggregate::Windows s
+/// Builds GroupByAndAggregate::Windows
 pub fn make_read_window_aggregate(
     aggregates: Vec<RPCAggregate>,
     window_every: i64,

--- a/src/server/rpc/expr.rs
+++ b/src/server/rpc/expr.rs
@@ -563,37 +563,24 @@ fn convert_aggregate(aggregate: Option<RPCAggregate>) -> Result<StorageAggregate
         Some(aggregate) => aggregate,
     };
 
-    let storage_aggregate = match convert_aggregate_type(aggregate.r#type)? {
-        RPCAggregateType::None => return NoneAggregate {}.fail(),
-        RPCAggregateType::Sum => StorageAggregate::Sum,
-        RPCAggregateType::Count => StorageAggregate::Count,
-        RPCAggregateType::Min => StorageAggregate::Min,
-        RPCAggregateType::Max => StorageAggregate::Max,
-        RPCAggregateType::First => StorageAggregate::First,
-        RPCAggregateType::Last => StorageAggregate::Last,
-        RPCAggregateType::Mean => StorageAggregate::Mean,
-    };
+    let aggregate_type = aggregate.r#type;
 
-    Ok(storage_aggregate)
-}
-
-fn convert_aggregate_type(aggregate_type: i32) -> Result<RPCAggregateType> {
     if aggregate_type == RPCAggregateType::None as i32 {
-        Ok(RPCAggregateType::None)
+        NoneAggregate {}.fail()
     } else if aggregate_type == RPCAggregateType::Sum as i32 {
-        Ok(RPCAggregateType::Sum)
+        Ok(StorageAggregate::Sum)
     } else if aggregate_type == RPCAggregateType::Count as i32 {
-        Ok(RPCAggregateType::Count)
+        Ok(StorageAggregate::Count)
     } else if aggregate_type == RPCAggregateType::Min as i32 {
-        Ok(RPCAggregateType::Min)
+        Ok(StorageAggregate::Min)
     } else if aggregate_type == RPCAggregateType::Max as i32 {
-        Ok(RPCAggregateType::Max)
+        Ok(StorageAggregate::Max)
     } else if aggregate_type == RPCAggregateType::First as i32 {
-        Ok(RPCAggregateType::First)
+        Ok(StorageAggregate::First)
     } else if aggregate_type == RPCAggregateType::Last as i32 {
-        Ok(RPCAggregateType::Last)
+        Ok(StorageAggregate::Last)
     } else if aggregate_type == RPCAggregateType::Mean as i32 {
-        Ok(RPCAggregateType::Mean)
+        Ok(StorageAggregate::Mean)
     } else {
         UnknownAggregate { aggregate_type }.fail()
     }

--- a/src/server/rpc/expr.rs
+++ b/src/server/rpc/expr.rs
@@ -604,7 +604,7 @@ pub fn convert_group_type(group: i32) -> Result<RPCGroup> {
     } else if group == RPCGroup::By as i32 {
         Ok(RPCGroup::By)
     } else {
-        UnknownGroup { group_type: group }.fail();
+        UnknownGroup { group_type: group }.fail()
     }
 }
 

--- a/src/server/rpc/input.rs
+++ b/src/server/rpc/input.rs
@@ -2,8 +2,8 @@ use tonic::Status;
 
 use generated_types::{
     MeasurementFieldsRequest, MeasurementNamesRequest, MeasurementTagKeysRequest,
-    MeasurementTagValuesRequest, ReadFilterRequest, ReadGroupRequest, ReadSource, TagKeysRequest,
-    TagValuesRequest,
+    MeasurementTagValuesRequest, ReadFilterRequest, ReadGroupRequest, ReadSource,
+    ReadWindowAggregateRequest, TagKeysRequest, TagValuesRequest,
 };
 use storage::id::Id;
 
@@ -92,5 +92,11 @@ impl GrpcInputs for MeasurementTagValuesRequest {
 impl GrpcInputs for MeasurementFieldsRequest {
     fn read_source_field(&self) -> Option<&prost_types::Any> {
         self.source.as_ref()
+    }
+}
+
+impl GrpcInputs for ReadWindowAggregateRequest {
+    fn read_source_field(&self) -> Option<&prost_types::Any> {
+        self.read_source.as_ref()
     }
 }

--- a/src/server/rpc/storage.rs
+++ b/src/server/rpc/storage.rs
@@ -1853,7 +1853,7 @@ mod tests {
 
         let expected_request = QueryGroupsRequest {
             predicate: "Predicate { exprs: [#state Eq Utf8(\"MA\")] range: TimestampRange { start: 150, end: 200 }}".into(),
-            gby_agg : GroupByAndAggregate::Columns {
+            gby_agg: GroupByAndAggregate::Columns {
                 agg: StorageAggregate::Sum,
                 group_columns: vec![String::from("tag1")],
             }
@@ -1956,7 +1956,7 @@ mod tests {
 
         let expected_request_window_every = QueryGroupsRequest {
             predicate: "Predicate { exprs: [#state Eq Utf8(\"MA\")] range: TimestampRange { start: 150, end: 200 }}".into(),
-            gby_agg : GroupByAndAggregate::Window {
+            gby_agg: GroupByAndAggregate::Window {
                 agg: StorageAggregate::Sum,
                 every: StorageWindowDuration::Fixed {
                     nanoseconds: 1122,

--- a/src/server/rpc/storage.rs
+++ b/src/server/rpc/storage.rs
@@ -543,10 +543,7 @@ where
         let caps = caps
             .iter()
             .map(|(cap_name, features)| {
-                let features = features
-                    .iter()
-                    .map(|f| f.to_string())
-                    .collect::<Vec<_>>();
+                let features = features.iter().map(|f| f.to_string()).collect::<Vec<_>>();
                 (cap_name.to_string(), Capability { features })
             })
             .collect::<HashMap<String, Capability>>();

--- a/src/server/rpc/storage.rs
+++ b/src/server/rpc/storage.rs
@@ -544,7 +544,7 @@ where
             .iter()
             .map(|(cap_name, features)| {
                 let features = features
-                    .into_iter()
+                    .iter()
                     .map(|f| f.to_string())
                     .collect::<Vec<_>>();
                 (cap_name.to_string(), Capability { features })

--- a/src/server/rpc/storage.rs
+++ b/src/server/rpc/storage.rs
@@ -7,12 +7,13 @@ use std::{collections::HashMap, net::SocketAddr, sync::Arc};
 use generated_types::{
     i_ox_server::{IOx, IOxServer},
     storage_server::{Storage, StorageServer},
-    CapabilitiesResponse, CreateBucketRequest, CreateBucketResponse, DeleteBucketRequest,
-    DeleteBucketResponse, GetBucketsResponse, Int64ValuesResponse, MeasurementFieldsRequest,
-    MeasurementFieldsResponse, MeasurementNamesRequest, MeasurementTagKeysRequest,
-    MeasurementTagValuesRequest, Organization, Predicate, ReadFilterRequest, ReadGroupRequest,
-    ReadResponse, ReadSeriesCardinalityRequest, ReadWindowAggregateRequest, StringValuesResponse,
-    TagKeysRequest, TagValuesRequest, TestErrorRequest, TestErrorResponse, TimestampRange,
+    CapabilitiesResponse, Capability, CreateBucketRequest, CreateBucketResponse,
+    DeleteBucketRequest, DeleteBucketResponse, GetBucketsResponse, Int64ValuesResponse,
+    MeasurementFieldsRequest, MeasurementFieldsResponse, MeasurementNamesRequest,
+    MeasurementTagKeysRequest, MeasurementTagValuesRequest, Organization, Predicate,
+    ReadFilterRequest, ReadGroupRequest, ReadResponse, ReadSeriesCardinalityRequest,
+    ReadWindowAggregateRequest, StringValuesResponse, TagKeysRequest, TagValuesRequest,
+    TestErrorRequest, TestErrorResponse, TimestampRange,
 };
 
 use data_types::error::ErrorLogger;
@@ -21,8 +22,9 @@ use data_types::error::ErrorLogger;
 // For some reason rust thinks these imports are unused, but then
 // complains of unresolved imports if they are not imported.
 use generated_types::{node, Node};
+use storage::groupby::GroupByAndAggregate;
 
-use crate::server::rpc::expr::{AddRPCNode, SpecialTagKeys};
+use crate::server::rpc::expr::{self, AddRPCNode, SpecialTagKeys};
 use crate::server::rpc::input::GrpcInputs;
 
 use storage::{
@@ -108,9 +110,35 @@ pub enum Error {
         source: Box<dyn std::error::Error + Send + Sync>,
     },
 
-    #[snafu(display("Converting Predicate:  {}", source))]
+    #[snafu(display("Error converting Predicate '{}: {}", rpc_predicate_string, source))]
     ConvertingPredicate {
         rpc_predicate_string: String,
+        source: crate::server::rpc::expr::Error,
+    },
+
+    #[snafu(display("Error converting group type '{}':  {}", aggregate_string, source))]
+    ConvertingReadGroupType {
+        aggregate_string: String,
+        source: crate::server::rpc::expr::Error,
+    },
+
+    #[snafu(display(
+        "Error converting read_group aggregate '{}':  {}",
+        aggregate_string,
+        source
+    ))]
+    ConvertingReadGroupAggregate {
+        aggregate_string: String,
+        source: crate::server::rpc::expr::Error,
+    },
+
+    #[snafu(display(
+        "Error converting read_aggregate_window aggregate definition '{}':  {}",
+        aggregate_string,
+        source
+    ))]
+    ConvertingWindowAggregate {
+        aggregate_string: String,
         source: crate::server::rpc::expr::Error,
     },
 
@@ -141,6 +169,13 @@ pub enum Error {
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
+impl From<Error> for tonic::Status {
+    /// Converts a result from the business logic into the appropriate tonic status
+    fn from(err: Error) -> Self {
+        err.to_status()
+    }
+}
+
 impl Error {
     /// Converts a result from the business logic into the appropriate tonic status
     fn to_status(&self) -> tonic::Status {
@@ -162,6 +197,9 @@ impl Error {
             Self::GroupingSeries { .. } => Status::invalid_argument(self.to_string()),
             Self::ListingTagValues { .. } => Status::invalid_argument(self.to_string()),
             Self::ConvertingPredicate { .. } => Status::invalid_argument(self.to_string()),
+            Self::ConvertingReadGroupAggregate { .. } => Status::invalid_argument(self.to_string()),
+            Self::ConvertingReadGroupType { .. } => Status::invalid_argument(self.to_string()),
+            Self::ConvertingWindowAggregate { .. } => Status::invalid_argument(self.to_string()),
             Self::ComputingSeriesSet { .. } => Status::invalid_argument(self.to_string()),
             Self::ComputingGroupedSeriesSet { .. } => Status::invalid_argument(self.to_string()),
             Self::ConvertingSeriesSet { .. } => Status::invalid_argument(self.to_string()),
@@ -282,27 +320,38 @@ where
             range,
             predicate,
             group_keys,
-            // TODO: handle Group::None
-            group: _group,
-            // TODO: handle aggregate values, especially whether None is the same as
-            // Some(AggregateType::None) or not
-            aggregate: _aggregate,
+            group,
+            aggregate,
             hints: _,
         } = read_group_request;
 
         info!(
-            "read_group for database {}, range: {:?}, group_keys: {:?}",
-            db_name, range, group_keys
+            "read_group for database {}, range: {:?}, group_keys: {:?}, group: {:?}, aggregate: {:?}",
+            db_name, range, group_keys, group, aggregate
         );
 
-        read_group_impl(
+        warn!("read_group implementation not yet complete: https://github.com/influxdata/influxdb_iox/issues/448");
+
+        let aggregate_string = format!(
+            "aggregate: {:?}, group: {:?}, group_keys: {:?}",
+            aggregate, group, group_keys
+        );
+
+        let group = expr::convert_group_type(group).context(ConvertingReadGroupType {
+            aggregate_string: &aggregate_string,
+        })?;
+
+        let gby_agg = expr::make_read_group_aggregate(aggregate, group, group_keys)
+            .context(ConvertingReadGroupAggregate { aggregate_string })?;
+
+        query_group_impl(
             tx.clone(),
             self.db_store.clone(),
             self.executor.clone(),
             db_name,
             range,
             predicate,
-            group_keys,
+            gby_agg,
         )
         .await
         .map_err(|e| e.to_status())?;
@@ -314,9 +363,50 @@ where
 
     async fn read_window_aggregate(
         &self,
-        _req: tonic::Request<ReadWindowAggregateRequest>,
+        req: tonic::Request<ReadWindowAggregateRequest>,
     ) -> Result<tonic::Response<Self::ReadGroupStream>, Status> {
-        unimplemented!("read_window_aggregate not yet implemented");
+        let (tx, rx) = mpsc::channel(4);
+
+        let read_window_aggregate_request = req.into_inner();
+
+        let db_name = get_database_name(&read_window_aggregate_request)?;
+
+        let ReadWindowAggregateRequest {
+            read_source: _read_source,
+            range,
+            predicate,
+            window_every,
+            offset,
+            aggregate,
+            window,
+        } = read_window_aggregate_request;
+
+        info!(
+            "read_window_aggregate for database {}, range: {:?}, window_every: {:?}, offset: {:?}, aggregate: {:?}, window: {:?}",
+            db_name, range, window_every, offset, aggregate, window
+        );
+
+        let aggregate_string = format!(
+            "aggregate: {:?}, window_every: {:?}, offset: {:?}, window: {:?}",
+            aggregate, window_every, offset, window
+        );
+
+        let gby_agg = expr::make_read_window_aggregate(aggregate, window_every, offset, window)
+            .context(ConvertingWindowAggregate { aggregate_string })?;
+
+        query_group_impl(
+            tx.clone(),
+            self.db_store.clone(),
+            self.executor.clone(),
+            db_name,
+            range,
+            predicate,
+            gby_agg,
+        )
+        .await
+        .map_err(|e| e.to_status())?;
+
+        Ok(tonic::Response::new(rx))
     }
 
     type TagKeysStream = mpsc::Receiver<Result<StringValuesResponse, Status>>;
@@ -437,10 +527,31 @@ where
         // idpe/storage/read/capabilities.go (aka window aggregate /
         // pushdown)
         //
-        // For now, do not claim to support any capabilities
-        let caps = CapabilitiesResponse {
-            caps: HashMap::new(),
-        };
+
+        // For now, hard code our list of support
+        let caps = [(
+            "WindowAggregate",
+            vec![
+                "Count", "Sum", // "First"
+                // "Last",
+                "Min", "Max", "Mean",
+                // "Offset"
+            ],
+        )];
+
+        // Turn it into the HashMap -> Capabiltity
+        let caps = caps
+            .iter()
+            .map(|(cap_name, features)| {
+                let features = features
+                    .into_iter()
+                    .map(|f| f.to_string())
+                    .collect::<Vec<_>>();
+                (cap_name.to_string(), Capability { features })
+            })
+            .collect::<HashMap<String, Capability>>();
+
+        let caps = CapabilitiesResponse { caps };
         Ok(tonic::Response::new(caps))
     }
 
@@ -883,14 +994,14 @@ async fn convert_series_set(
 }
 
 /// Launch async tasks that send the result of executing read_group to `tx`
-async fn read_group_impl<T>(
+async fn query_group_impl<T>(
     tx: mpsc::Sender<Result<ReadResponse, Status>>,
     db_store: Arc<T>,
     executor: Arc<StorageExecutor>,
     db_name: String,
     range: Option<TimestampRange>,
     rpc_predicate: Option<Predicate>,
-    group_keys: Vec<String>,
+    gby_agg: GroupByAndAggregate,
 ) -> Result<()>
 where
     T: DatabaseStore,
@@ -910,12 +1021,13 @@ where
         .await
         .context(DatabaseNotFound { db_name: &db_name })?;
 
-    let grouped_series_set_plan = db.query_groups(predicate, group_keys).await.map_err(|e| {
-        Error::PlanningFilteringSeries {
-            db_name: db_name.clone(),
-            source: Box::new(e),
-        }
-    })?;
+    let grouped_series_set_plan =
+        db.query_groups(predicate, gby_agg)
+            .await
+            .map_err(|e| Error::PlanningFilteringSeries {
+                db_name: db_name.clone(),
+                source: Box::new(e),
+            })?;
 
     // Spawn task to convert between series sets and the gRPC results
     // and to run the actual plans (so we can return a result to the
@@ -1056,6 +1168,7 @@ mod tests {
         exec::FieldListPlan,
         exec::GroupedSeriesSetPlans,
         exec::SeriesSetPlans,
+        groupby::{Aggregate as StorageAggregate, WindowDuration as StorageWindowDuration},
         id::Id,
         test::ColumnNamesRequest,
         test::FieldColumnsRequest,
@@ -1068,7 +1181,11 @@ mod tests {
 
     use futures::prelude::*;
 
-    use generated_types::{i_ox_client, read_response::frame, storage_client, ReadSource};
+    use generated_types::{
+        aggregate::AggregateType, i_ox_client, read_response::frame, storage_client,
+        Aggregate as RPCAggregate, Duration as RPCDuration, ReadSource, Window as RPCWindow,
+    };
+
     use prost::Message;
 
     type IOxClient = i_ox_client::IOxClient<tonic::transport::Channel>;
@@ -1102,6 +1219,10 @@ mod tests {
         Ok(())
     }
 
+    fn to_str_vec(s: &[&str]) -> Vec<String> {
+        s.iter().map(|s| s.to_string()).collect()
+    }
+
     #[tokio::test]
     async fn test_storage_rpc_capabilities() -> Result<(), tonic::Status> {
         // Note we use a unique port. TODO: let the OS pick the port
@@ -1110,7 +1231,16 @@ mod tests {
             .expect("Connecting to test server");
 
         // Test response from storage server
-        assert_eq!(HashMap::new(), fixture.storage_client.capabilities().await?);
+        let mut expected_capabilities: HashMap<String, Vec<String>> = HashMap::new();
+        expected_capabilities.insert(
+            "WindowAggregate".into(),
+            to_str_vec(&["Count", "Sum", "Min", "Max", "Mean"]),
+        );
+
+        assert_eq!(
+            expected_capabilities,
+            fixture.storage_client.capabilities().await?
+        );
 
         Ok(())
     }
@@ -1603,7 +1733,8 @@ mod tests {
         }
 
         // Ensure there are still threads to answer actual client queries
-        assert_eq!(HashMap::new(), fixture.storage_client.capabilities().await?);
+        let caps = fixture.storage_client.capabilities().await?;
+        assert!(!caps.is_empty(), "Caps: {:?}", caps);
 
         Ok(())
     }
@@ -1717,13 +1848,18 @@ mod tests {
             predicate: make_state_ma_predicate(),
             group_keys: vec![String::from("tag1")],
             group,
-            aggregate: None,
+            aggregate: Some(RPCAggregate {
+                r#type: AggregateType::Sum as i32,
+            }),
             hints: 0,
         };
 
         let expected_request = QueryGroupsRequest {
             predicate: "Predicate { exprs: [#state Eq Utf8(\"MA\")] range: TimestampRange { start: 150, end: 200 }}".into(),
-            group_columns: vec![String::from("tag1")],
+            gby_agg : GroupByAndAggregate::Columns {
+                agg: StorageAggregate::Sum,
+                group_columns: vec![String::from("tag1")],
+            }
         };
 
         // TODO setup any expected results
@@ -1752,7 +1888,9 @@ mod tests {
             predicate: None,
             group_keys: vec![],
             group,
-            aggregate: None,
+            aggregate: Some(RPCAggregate {
+                r#type: AggregateType::Sum as i32,
+            }),
             hints: 0,
         };
 
@@ -1770,7 +1908,10 @@ mod tests {
 
         let expected_request = Some(QueryGroupsRequest {
             predicate: "Predicate {}".into(),
-            group_columns: vec![],
+            gby_agg: GroupByAndAggregate::Columns {
+                agg: StorageAggregate::Sum,
+                group_columns: vec![],
+            },
         });
         assert_eq!(test_db.get_query_groups_request().await, expected_request);
 
@@ -1778,9 +1919,170 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_measurement_fields() -> Result<(), tonic::Status> {
+    async fn test_read_window_aggegate() -> Result<(), tonic::Status> {
         // Note we use a unique port. TODO: let the OS pick the port
         let mut fixture = Fixture::new(11903)
+            .await
+            .expect("Connecting to test server");
+
+        let db_info = OrgAndBucket::new(123, 456);
+        let partition_id = 1;
+
+        let test_db = fixture
+            .test_storage
+            .db_or_create(&db_info.db_name)
+            .await
+            .expect("creating test database");
+
+        let source = Some(StorageClientWrapper::read_source(
+            db_info.org_id,
+            db_info.bucket_id,
+            partition_id,
+        ));
+
+        // -----
+        // Test with window_every/offset setup
+        // -----
+
+        let request_window_every = ReadWindowAggregateRequest {
+            read_source: source.clone(),
+            range: make_timestamp_range(150, 200),
+            predicate: make_state_ma_predicate(),
+            window_every: 1122,
+            offset: 15,
+            aggregate: vec![RPCAggregate {
+                r#type: AggregateType::Sum as i32,
+            }],
+            // old skool window definition
+            window: None,
+        };
+
+        let expected_request_window_every = QueryGroupsRequest {
+            predicate: "Predicate { exprs: [#state Eq Utf8(\"MA\")] range: TimestampRange { start: 150, end: 200 }}".into(),
+            gby_agg : GroupByAndAggregate::Window {
+                agg: StorageAggregate::Sum,
+                every: StorageWindowDuration::Fixed {
+                    nanoseconds: 1122,
+                },
+                offset: StorageWindowDuration::Fixed {
+                    nanoseconds: 15,
+                }
+            }
+        };
+
+        // setup expected results
+        let dummy_groups_set_plan = GroupedSeriesSetPlans::from(vec![]);
+        test_db.set_query_groups_values(dummy_groups_set_plan).await;
+
+        let actual_frames = fixture
+            .storage_client
+            .read_window_aggregate(request_window_every)
+            .await?;
+        let expected_frames: Vec<String> = vec!["0 aggregate_frames".into()];
+
+        assert_eq!(
+            actual_frames, expected_frames,
+            "unexpected frames returned by query_groups"
+        );
+        assert_eq!(
+            test_db.get_query_groups_request().await,
+            Some(expected_request_window_every),
+            "unexpected request to query_groups"
+        );
+
+        // -----
+        // Test with window.every and window.offset durations specified
+        // -----
+
+        let request_window = ReadWindowAggregateRequest {
+            read_source: source.clone(),
+            range: make_timestamp_range(150, 200),
+            predicate: make_state_ma_predicate(),
+            window_every: 0,
+            offset: 0,
+            aggregate: vec![RPCAggregate {
+                r#type: AggregateType::Sum as i32,
+            }],
+            // old skool window definition
+            window: Some(RPCWindow {
+                every: Some(RPCDuration {
+                    nsecs: 1122,
+                    months: 0,
+                    negative: false,
+                }),
+                offset: Some(RPCDuration {
+                    nsecs: 0,
+                    months: 4,
+                    negative: true,
+                }),
+            }),
+        };
+
+        let expected_request_window = QueryGroupsRequest {
+            predicate: "Predicate { exprs: [#state Eq Utf8(\"MA\")] range: TimestampRange { start: 150, end: 200 }}".into(),
+            gby_agg : GroupByAndAggregate::Window {
+                agg: StorageAggregate::Sum,
+                every: StorageWindowDuration::Fixed {
+                    nanoseconds: 1122,
+                },
+                offset: StorageWindowDuration::Variable {
+                    months: 4,
+                    negative: true,
+                }
+            }
+        };
+
+        // setup expected results
+        let dummy_groups_set_plan = GroupedSeriesSetPlans::from(vec![]);
+        test_db.set_query_groups_values(dummy_groups_set_plan).await;
+
+        let actual_frames = fixture
+            .storage_client
+            .read_window_aggregate(request_window.clone())
+            .await?;
+        let expected_frames: Vec<String> = vec!["0 aggregate_frames".into()];
+
+        assert_eq!(
+            actual_frames, expected_frames,
+            "unexpected frames returned by query_groups"
+        );
+        assert_eq!(
+            test_db.get_query_groups_request().await,
+            Some(expected_request_window.clone()),
+            "unexpected request to query_groups"
+        );
+
+        // ---
+        // test error
+        // ---
+
+        // Note we don't set the response on the test database, so we expect an error
+        let response = fixture
+            .storage_client
+            .read_window_aggregate(request_window)
+            .await;
+        assert!(response.is_err());
+        let response_string = format!("{:?}", response);
+        let expected_error = "No saved query_groups in TestDatabase";
+        assert!(
+            response_string.contains(expected_error),
+            "'{}' did not contain expected content '{}'",
+            response_string,
+            expected_error
+        );
+
+        assert_eq!(
+            test_db.get_query_groups_request().await,
+            Some(expected_request_window)
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_measurement_fields() -> Result<(), tonic::Status> {
+        // Note we use a unique port. TODO: let the OS pick the port
+        let mut fixture = Fixture::new(11904)
             .await
             .expect("Connecting to test server");
 
@@ -1984,6 +2286,31 @@ mod tests {
                 .await?;
 
             Ok(self.to_string_vec(responses))
+        }
+
+        /// Make a request to Storage::read_window_aggregate and do the
+        /// required async dance to flatten the resulting stream to Strings
+        async fn read_window_aggregate(
+            &mut self,
+            request: ReadWindowAggregateRequest,
+        ) -> Result<Vec<String>, tonic::Status> {
+            let responses: Vec<_> = self
+                .inner
+                .read_window_aggregate(request)
+                .await?
+                .into_inner()
+                .try_collect()
+                .await?;
+
+            let data_frames: Vec<frame::Data> = responses
+                .into_iter()
+                .flat_map(|r| r.frames)
+                .flat_map(|f| f.data)
+                .collect();
+
+            let s = format!("{} aggregate_frames", data_frames.len());
+
+            Ok(vec![s])
         }
 
         /// Make a request to Storage::tag_keys and do the

--- a/storage/src/exec/seriesset.rs
+++ b/storage/src/exec/seriesset.rs
@@ -3,7 +3,7 @@
 //!
 //! Specifically, this thing can produce represents a set of "tables",
 //! and each table is sorted on a set of "tag" columns, meaning the
-//! groups / series will be contiguous.
+//! data for groups / series will be contiguous.
 //!
 //! For example, the output columns of such a plan would be:
 //! (tag col0) (tag col1) ... (tag colN) (field val1) (field val2) ... (field valN) .. (timestamps)
@@ -11,11 +11,12 @@
 //! Note that the data will come out ordered by the tag keys (ORDER BY
 //! (tag col0) (tag col1) ... (tag colN))
 //!
-//! NOTE: We think the influx storage engine returns series sorted by
-//! the tag values, but the order of the columns is also sorted. So
-//! for example, if you have `region`, `host`, and `service` as tags,
-//! the columns would be ordered `host`, `region`, and `service` as
-//! well.
+//! NOTE: The InfluxDB classic storage engine not only returns
+//! series sorted by the tag values, but the order of the tag columns
+//! (and thus the actual sort order) is also lexographically
+//! sorted. So for example, if you have `region`, `host`, and
+//! `service` as tags, the columns would be ordered `host`, `region`,
+//! and `service` as well.
 
 use std::sync::Arc;
 
@@ -86,7 +87,10 @@ pub struct SeriesSet {
     /// timestamp column index
     pub timestamp_index: usize,
 
-    /// the column index each data field
+    /// the column index of each "field" of the time series. For
+    /// example, if there are two field indexes then this series set
+    /// would result in two distinct series being sent back, one for
+    /// each field.
     pub field_indices: Arc<Vec<usize>>,
 
     // The row in the record batch where the data starts (inclusive)

--- a/storage/src/groupby.rs
+++ b/storage/src/groupby.rs
@@ -1,0 +1,70 @@
+//! This module contains definitionsf or Timeseries specific Grouping
+//! and Aggregate functions in IOx, designed to be compatible with
+//! InfluxDB
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum Aggregate {
+    Sum,
+    Count,
+    Min,
+    Max,
+    First,
+    Last,
+    Mean,
+}
+
+/// Defines the different ways series can be grouped and aggregated
+#[derive(Debug, Clone, PartialEq)]
+pub enum GroupByAndAggregate {
+    /// group by a set of (Tag) columns, applying agg to each field
+    Columns {
+        agg: Aggregate,
+        group_columns: Vec<String>,
+    },
+
+    /// Group by a "window" in time, applying agg to each field
+    ///
+    /// The window is defined in terms three values:
+    ///
+    /// time: timestamp
+    /// every: Duration
+    /// offset: Duration
+    ///
+    /// The bounds are then calculated at a high leve by
+    /// bounds = truncate((time_column_reference + offset), every)
+    ///
+    /// Where the truncate function is different depending on the
+    /// specifics of the Duration
+    ///
+    /// This structure is different than the input (typically from gRPC)
+    /// and the underyling calculation (in window.rs), so that we can do
+    /// the input validation checking when creating this structure (rather
+    /// than in window.rs). The alternate would be to pass the structure
+    /// more directly from gRPC to window.rs, which would require less
+    /// translation but more error checking in window.rs.
+    Window {
+        agg: Aggregate,
+        every: WindowDuration,
+        offset: WindowDuration,
+    },
+}
+
+/// Represents some duration in time
+#[derive(Debug, Clone, PartialEq)]
+pub enum WindowDuration {
+    /// Variable sized window,
+    Variable { months: i64, negative: bool },
+
+    /// fixed size, in nanoseconds
+    Fixed { nanoseconds: i64 },
+}
+
+impl WindowDuration {
+    pub fn from_nanoseconds(nanoseconds: i64) -> Self {
+        Self::Fixed { nanoseconds }
+    }
+
+    pub fn from_months(months: i64, negative: bool) -> Self {
+        Self::Variable { months, negative }
+    }
+}

--- a/storage/src/groupby.rs
+++ b/storage/src/groupby.rs
@@ -1,6 +1,6 @@
-//! This module contains definitionsf or Timeseries specific Grouping
+//! This module contains definitions for Timeseries specific Grouping
 //! and Aggregate functions in IOx, designed to be compatible with
-//! InfluxDB
+//! InfluxDB classic
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum Aggregate {
@@ -30,11 +30,11 @@ pub enum GroupByAndAggregate {
     /// every: Duration
     /// offset: Duration
     ///
-    /// The bounds are then calculated at a high leve by
+    /// The bounds are then calculated at a high level by
     /// bounds = truncate((time_column_reference + offset), every)
     ///
     /// Where the truncate function is different depending on the
-    /// specifics of the Duration
+    /// specific Duration
     ///
     /// This structure is different than the input (typically from gRPC)
     /// and the underyling calculation (in window.rs), so that we can do

--- a/storage/src/predicate.rs
+++ b/storage/src/predicate.rs
@@ -1,3 +1,7 @@
+//! This module contains a Timeseries specific Predicate structure for
+//! IOXxthat can select and filter Fields and Tags, designed to be
+//! compatible with InfluxDB
+
 use std::collections::BTreeSet;
 
 use arrow_deps::datafusion::logical_plan::Expr;

--- a/storage/src/test.rs
+++ b/storage/src/test.rs
@@ -3,6 +3,7 @@
 
 use arrow_deps::arrow::record_batch::RecordBatch;
 
+use crate::groupby::GroupByAndAggregate;
 use crate::{
     exec::FieldListPlan,
     exec::{
@@ -91,7 +92,8 @@ pub struct QuerySeriesRequest {
 pub struct QueryGroupsRequest {
     /// Stringified '{:?}' version of the predicate
     pub predicate: String,
-    pub group_columns: Vec<String>,
+    /// The requested aggregate
+    pub gby_agg: GroupByAndAggregate,
 }
 
 /// Records the parameters passed to a `field_columns` request
@@ -380,14 +382,11 @@ impl Database for TestDatabase {
     async fn query_groups(
         &self,
         predicate: Predicate,
-        group_columns: Vec<String>,
+        gby_agg: GroupByAndAggregate,
     ) -> Result<GroupedSeriesSetPlans, Self::Error> {
         let predicate = predicate_to_test_string(&predicate);
 
-        let new_queries_groups_request = Some(QueryGroupsRequest {
-            predicate,
-            group_columns,
-        });
+        let new_queries_groups_request = Some(QueryGroupsRequest { predicate, gby_agg });
 
         *self.query_groups_request.clone().lock().await = new_queries_groups_request;
 


### PR DESCRIPTION

Rationale: We need to implement the `read_window_aggregate` gRPC service (#449) to provide Flux (and maybe InfluxQL)  compatible group push down with the other storage engines (OSS and Cloud).

See the the design [spec](https://docs.google.com/document/d/1yY2CcicBK32rUkS8VQtHztGCJJhnU-pO_NAwThKa6Jc/edit#) for supporting `read_window_aggregate`

This PR implements:
* Storage interface: `storage/src/groupby.rs`
* gRPC --> storage interface translation (including input validation)
* storage --> gRPC data translation
* Capability and capability response claiming support for window aggregates (which isn't quite true yet, but will be)

After this PR, the only thing left to do is actually hooking this up into the write buffer for plan execution.

Here is how this PR fits into past and planned PRs:

- [x] Update the protobuf definitions: (https://github.com/influxdata/influxdb_iox/pull/444)
- [x] Implement window_bounds from the Go code. (https://github.com/influxdata/influxdb_iox/pull/460)
- [x] Implement gRPC trappings and translation (this PR)
- [ ] Implement read_window_aggregate plan in write_buffer_database, and add end-to-end test
