### PR TITLE
chore(server): add logs for dropped WAL segments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -434,7 +434,6 @@ dependencies = [
  "serde_json",
  "snafu",
  "storage",
- "test_helpers",
  "tokio",
  "tracing",
  "write_buffer",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -434,7 +434,9 @@ dependencies = [
  "serde_json",
  "snafu",
  "storage",
+ "test_helpers",
  "tokio",
+ "tracing",
  "write_buffer",
 ]
 

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -17,8 +17,12 @@ influxdb_line_protocol = { path = "../influxdb_line_protocol" }
 storage = { path = "../storage" }
 write_buffer = { path = "../write_buffer" }
 object_store = { path = "../object_store" }
+tracing = "0.1"
 tokio = { version = "0.2", features = ["full"] }
 arrow_deps = { path = "../arrow_deps" }
 futures = "0.3.7"
 bytes = "0.5"
 chrono = "0.4"
+
+[dev-dependencies]
+test_helpers = { path = "../test_helpers" }

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -23,6 +23,3 @@ arrow_deps = { path = "../arrow_deps" }
 futures = "0.3.7"
 bytes = "0.5"
 chrono = "0.4"
-
-[dev-dependencies]
-test_helpers = { path = "../test_helpers" }

--- a/server/src/buffer.rs
+++ b/server/src/buffer.rs
@@ -81,14 +81,14 @@ impl Buffer {
             };
 
             if oldest_is_persisted {
-                let _ = self.remove_oldest_segment();
+                self.remove_oldest_segment();
                 continue;
             }
 
             match self.rollover_behavior {
                 WalBufferRollover::DropIncoming => {
                     warn!(
-                        "dropping incoming write for current segment (segment id: {:?})",
+                        "WAL is full, dropping incoming write for current segment (segment id: {:?})",
                         self.open_segment.id,
                     );
                     return Ok(None);
@@ -96,7 +96,7 @@ impl Buffer {
                 WalBufferRollover::DropOldSegment => {
                     let oldest_segment_id = self.remove_oldest_segment();
                     warn!(
-                        "dropping oldest segment (segment id: {:?})",
+                        "WAL is full, dropping oldest segment (segment id: {:?})",
                         oldest_segment_id
                     );
                 }

--- a/server/src/buffer.rs
+++ b/server/src/buffer.rs
@@ -11,6 +11,8 @@ use chrono::{DateTime, Utc};
 use snafu::Snafu;
 use tokio::sync::Mutex;
 
+use tracing::warn;
+
 #[derive(Debug, Snafu)]
 pub enum Error {
     #[snafu(display("Max size limit hit {}", size))]
@@ -79,13 +81,25 @@ impl Buffer {
             };
 
             if oldest_is_persisted {
-                self.remove_oldest_segment();
+                let _ = self.remove_oldest_segment();
                 continue;
             }
 
             match self.rollover_behavior {
-                WalBufferRollover::DropIncoming => return Ok(None),
-                WalBufferRollover::DropOldSegment => self.remove_oldest_segment(),
+                WalBufferRollover::DropIncoming => {
+                    warn!(
+                        "dropping incoming write for current segment (segment id: {:?})",
+                        self.open_segment.id,
+                    );
+                    return Ok(None);
+                }
+                WalBufferRollover::DropOldSegment => {
+                    let oldest_segment_id = self.remove_oldest_segment();
+                    warn!(
+                        "dropping oldest segment (segment id: {:?})",
+                        oldest_segment_id
+                    );
+                }
                 WalBufferRollover::ReturnError => {
                     return UnableToDropSegment {
                         size: self.current_size,
@@ -185,10 +199,12 @@ impl Buffer {
         writes
     }
 
+    // Removes the oldest segment present in the buffer, returning its id
     #[allow(dead_code)]
-    fn remove_oldest_segment(&mut self) {
+    fn remove_oldest_segment(&mut self) -> u64 {
         let removed_segment = self.closed_segments.remove(0);
         self.current_size -= removed_segment.size;
+        removed_segment.id
     }
 }
 


### PR DESCRIPTION
Resolves #466

Added logging for dropped writes and old segments in rollover scenarios

Some notes on the PR:

1) I wasn't entirely sure what the most useful context would be for the logs. I figured the segment `id` might be relevant at least. Let me know what else you'd like to see.

2) I added a dev-dep on the `test_helpers` crate in order to use the `enable_logging` function to test my change. I cut the usage since I didn't want to spam logs during test runs, but I left the dep in since it's included in most other crates in the repo.

3) I almost like feel [this function][1] should return the whole segment-- collections like `Vec` and `HashMap` usually do this on removal. However, I was only *actually* using the ID so I couldn't justify it.

[1]: https://github.com/influxdata/influxdb_iox/pull/478/files#diff-075802bccad88ba0a9fdcfa58440282d9ff555ee9478cc985cedaae23aa6d57fR204