### PR TITLE
feat: Log error message returned to gRPC in IOx logs

### DIFF
--- a/src/server/rpc/storage.rs
+++ b/src/server/rpc/storage.rs
@@ -41,7 +41,7 @@ use snafu::{OptionExt, ResultExt, Snafu};
 
 use tokio::sync::mpsc;
 use tonic::Status;
-use tracing::{info, warn};
+use tracing::{error, info, warn};
 
 use super::data::{
     fieldlist_to_measurement_fields_response, grouped_series_set_item_to_read_response,
@@ -172,6 +172,7 @@ pub type Result<T, E = Error> = std::result::Result<T, E>;
 impl From<Error> for tonic::Status {
     /// Converts a result from the business logic into the appropriate tonic status
     fn from(err: Error) -> Self {
+        error!("Error handling gRPC request: {}", err);
         err.to_status()
     }
 }


### PR DESCRIPTION
I found this while tracking down #490 -- namely when a gRPC request results in an error, the error is reported properly to the UI

```
 query error: rpc error: code = InvalidArgument desc = Error converting read_aggregate_window aggregate definition 'aggregate: [Aggregate { r#type: Sum }], window_every: 0, offset: 0, window: Some(Window { every: Some(Duration { nsecs: 10000000000, months: 0, negative: false }), offset: Some(Duration { nsecs: 0, months: 0, negative: false }) })': Error parsing window bounds duration 'window.offset': duration used as an interval cannot be zero
```

However, the  IOx logs don't' include the error message which is a bit of an oversight 🤣 . Though they do include a reference to the request being sent:

```
[2020-11-25T20:25:04Z INFO  influxdb_iox::server::rpc::storage] read_window_aggregate for database 26f7e5a4b7be365b_917b97a92e883afc, range: Some(TimestampRange { start: 1606335604437610000, end: 1606335904437610000 }), window_every: 0, offset: 0, aggregate: [Aggregate { r#type: Sum }], window: Some(Window { every: Some(Duration { nsecs: 10000000000, months: 0, negative: false }), offset: Some(Duration { nsecs: 0, months: 0, negative: false }) })
```

After this change the error is also logged:

```
[2020-11-25T20:45:33Z ERROR influxdb_iox::server::rpc::storage] Error handling gRPC request: Error converting read_aggregate_window aggregate definition 'aggregate: [Aggregate { r#type: Sum }], window_every: 0, offset: 0, window: Some(Window { every: Some(Duration { nsecs: 10000000000, months: 0, negative: false }), offset: Some(Duration { nsecs: 0, months: 0, negative: false }) })':  Error parsing window bounds duration 'window.offset': duration used as an interval cannot be zero 
```

Sometimes it is the little things in life
