### PR TITLE
fix: allow empty `offset` widows for read_window_aggregate offset

### DIFF
--- a/query/src/group_by.rs
+++ b/query/src/group_by.rs
@@ -91,6 +91,10 @@ impl Aggregate {
 }
 
 impl WindowDuration {
+    pub fn empty() -> Self {
+        Self::Fixed { nanoseconds: 0 }
+    }
+
     pub fn from_nanoseconds(nanoseconds: i64) -> Self {
         Self::Fixed { nanoseconds }
     }


### PR DESCRIPTION
fix: allow empty `offset` widows for read_window_aggregate offset

This is fix 1 of 2 needed to get read_window_aggregate working correctly (#490)

- [x] Allow empty `offset` windows (this PR)
- [ ] Don't send back GroupFrames in responses

My input error checking was overly aggressive. It turns out that offset windows can be zero.

# Details

With this input query:

```
from(bucket: "devbucket")
  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)
  |> filter(fn: (r) => r["_measurement"] == "cpu")
  |> aggregateWindow(every: v.windowPeriod, fn: sum, createEmpty: false)
  |> yield(name: "sum")
```

This gRPC request is sent to storage (note the offset duration is zero):

```
read_window_aggregate
   database 26f7e5a4b7be365b_917b97a92e883afc,
   range: Some(TimestampRange { start: 1606335604437610000, end: 1606335904437610000 }),
   window_every: 0,
   offset: 0,
   aggregate: [Aggregate { r#type: Sum }],
   window: Some(Window {
     every: Some(Duration { nsecs: 10000000000, months: 0, negative: false }),
     offset: Some(Duration { nsecs: 0, months: 0, negative: false })
   })

On the main branch the following error is produced

```
 query error: rpc error: code = InvalidArgument desc = Error converting read_aggregate_window aggregate definition 'aggregate: [Aggregate { r#type: Sum }], window_every: 0, offset: 0, window: Some(Window { every: Some(Duration { nsecs: 10000000000, months: 0, negative: false }), offset: Some(Duration { nsecs: 0, months: 0, negative: false }) })': Error parsing window bounds duration 'window.offset': duration used as an interval cannot be zero
```

After this PR, it passes
