### PR TITLE
ci: use GitHub for CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -130,21 +130,39 @@ jobs:
 
 workflows:
   version: 2
-  build:
+  
+  # Internal pipeline for perf builds.
+  #
+  # Filter ensures this only runs for git branches ending in `/perf`.
+  perf_build:
     jobs:
-      - fmt
-      - lint
-      - test
-      - build
+      - fmt:
+          filters:
+            branches:
+              only: /.*\/perf$/
+      - lint:
+          filters:
+            branches:
+              only: /.*\/perf$/
+      - test:
+          filters:
+            branches:
+              only: /.*\/perf$/
+      - build:
+          filters:
+            branches:
+              only: /.*\/perf$/
       - perf_image:
+          filters:
+            branches:
+              only: /.*\/perf$/
           requires: # Only do a release build if all tests have passed
             - fmt
             - lint
             - test
             - build
-          filters:
-            branches:
-              only: /.*\/perf$/ # Only do a release build if the branch name ends in `/perf`
+  
+  # Nightly rebuild of the build container
   ci_image:
     triggers:
       - schedule:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,16 +7,13 @@
 #   pushed to `quay.io/influxdb/rust:ci`. This build image is then used to run
 #   the CI tasks for the day.
 #
-# Each CI run:
-#
-#   Runs tests, fmt, & lints and then compiles binaries using the default cargo
-#   target ("dev").
-#
 # CI runs for git branches ending in `/perf`:
 #
 #   Runs tests, fmt, & lints and then compiles binaries using the "release"
 #   cargo target and pushes a container with the binary to
 #   `quay.io/influxdb/fusion` (see perf_image below).
+#
+# CI for all other branches is performed by the GitHub actions (see .github dir)
 
 version: 2.1
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,87 @@
+# CI Overview
+# -----------
+#
+# All pushes and PRs (including from forks) run:
+#
+#   - cargo build with the default cargo profile ("dev")
+#   - cargo test
+#   - cargo fmt
+#   - clippy (with warnings denied)
+#
+# All workflow actions make use of our build container
+# (`quay.io/influxdb/rust:ci`) to satisfy system dependencies, and is updated
+# nightly.
+#
+# Cargo's build artefacts are cached to reduce the build time, see
+# https://github.com/actions/cache for more info.
+
+on: [push, pull_request]
+
+name: ci
+
+jobs:
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    container:
+      image: quay.io/influxdb/rust:ci
+      # Run as the "root" user in the build container to fix workspace & cache
+      # permission errors.
+      options: --user root
+    steps:
+      # Checkout the code
+      - uses: actions/checkout@v2
+
+      # Enable caching of build artefacts
+      - uses: actions/cache@v2
+        with:
+          path: target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+      
+      # Build!
+      - name: Run dev build
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --workspace
+
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    container:
+      image: quay.io/influxdb/rust:ci
+      options: --user root
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/cache@v2
+        with:
+          path: target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+      - name: Run tests
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --workspace
+
+  lints:
+    name: Lints
+    runs-on: ubuntu-latest
+    container:
+      image: quay.io/influxdb/rust:ci
+      options: --user root
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/cache@v2
+        with:
+          path: target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+      - name: Run cargo fmt
+        uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --all -- --check
+      - uses: actions-rs/clippy-check@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          args: --all-targets --workspace -- -D warnings


### PR DESCRIPTION
Splits the internal/community pipelines, with the community pipelines using GitHub Actions.

The main benefits of this are:
* ~~[Fast builds]~~ (~30s `cargo build`, but scheduling runs seems to take longer)
* [GitHub caching] keyed on the `Cargo.lock` file contents (recursive / workspace friendly)
* Changing the dependencies produces a cache for immediate reuse
* Builds for community forks also make use of the same caches
* Separates the internal / container-pushing bits from the public CI runs
* Clippy will [leave comments] on your PRs
* It's free!

Good to know:
* Each repo has 5GB of caching, once a new cache pushes over the limit an old cache is evicted
* The current per-build cache is ~600MB, so we have about 8 cache slots, which means 8 different `Cargo.locks` in parallel
* A cache entry is evicted if unused for 7 days
* The build cache in the build image is unused

If this all works nicely (ha!) then we can stop building IOx in the nightly build container as a method to pre-cache the deps in the main branch - this should reduce the size and therefore time taken by the build image pull step by ~4x (hopefully) which is currently the longest bit.

I've tried to make sure the commands have parity with the existing Circle CI pipeline, but a set of second careful eyes would be great!

[Fast builds]: https://github.com/influxdata/influxdb_iox/runs/1463485294?check_suite_focus=true
[GitHub caching]: https://docs.github.com/en/free-pro-team@latest/actions/guides/caching-dependencies-to-speed-up-workflows
[leave comments]: https://github.com/actions-rs/clippy-check/blob/master/.github/screenshot.png

Closes #495 