### PR TITLE
fix: Do not send GroupFrames in response to read_window_aggregate

### DIFF
--- a/query/src/exec.rs
+++ b/query/src/exec.rs
@@ -186,6 +186,9 @@ pub struct GroupedSeriesSetPlan {
     /// How many of the series_set_plan::tag_columns should be used to
     /// compute the group
     pub num_prefix_tag_group_columns: usize,
+
+    /// HACK: Do not send Group items
+    pub skip_group_items: bool,
 }
 
 /// A container for plans which each produces a logical stream of
@@ -361,6 +364,7 @@ impl Executor {
                     let GroupedSeriesSetPlan {
                         series_set_plan,
                         num_prefix_tag_group_columns,
+                        skip_group_items,
                     } = plan;
 
                     let SeriesSetPlan {
@@ -390,6 +394,7 @@ impl Executor {
                             table_name,
                             tag_columns,
                             num_prefix_tag_group_columns,
+                            skip_group_items,
                             field_columns,
                             it,
                         )

--- a/query/src/exec/seriesset.rs
+++ b/query/src/exec/seriesset.rs
@@ -898,6 +898,7 @@ mod tests {
                     table_name,
                     tag_columns,
                     num_prefix_tag_group_columns,
+                    false, // skip_group_items
                     field_columns,
                     it,
                 )

--- a/query/src/exec/seriesset.rs
+++ b/query/src/exec/seriesset.rs
@@ -372,6 +372,8 @@ impl GroupedSeriesSetConverter {
     ///
     /// num_prefix_tag_group_columns: The size of the prefix of tag_columns that defines each group
     ///
+    /// skip_group_items: HACK: Do not send Group items
+    ///
     /// field_columns: The names of the columns which are "fields"
     ///
     /// it: record batch iterator that produces data in the desired order
@@ -380,6 +382,7 @@ impl GroupedSeriesSetConverter {
         table_name: Arc<String>,
         tag_columns: Arc<Vec<Arc<String>>>,
         num_prefix_tag_group_columns: usize,
+        skip_group_items: bool,
         field_columns: Arc<Vec<Arc<String>>>,
         it: SendableRecordBatchStream,
     ) -> Result<()> {
@@ -389,6 +392,7 @@ impl GroupedSeriesSetConverter {
                 table_name,
                 tag_columns,
                 num_prefix_tag_group_columns,
+                skip_group_items,
                 field_columns,
                 it,
             )
@@ -410,6 +414,7 @@ impl GroupedSeriesSetConverter {
         table_name: Arc<String>,
         tag_columns: Arc<Vec<Arc<String>>>,
         num_prefix_tag_group_columns: usize,
+        skip_group_items: bool,
         field_columns: Arc<Vec<Arc<String>>>,
         it: SendableRecordBatchStream,
     ) -> Result<()> {
@@ -437,7 +442,7 @@ impl GroupedSeriesSetConverter {
                     }
                 };
 
-                if need_group_start {
+                if need_group_start && !skip_group_items {
                     let group_tags = series_set.tags[0..num_prefix_tag_group_columns].to_vec();
 
                     let group_desc = GroupDescription {

--- a/tests/end-to-end.rs
+++ b/tests/end-to-end.rs
@@ -534,10 +534,8 @@ async fn test_read_window_aggregate(
         .collect();
 
     let expected_frames = vec![
-        "GroupFrame, tag_keys: city,state, partition_key_vals: Boston,MA",
         "SeriesFrame, tags: _field=temp,_measurement=h2o,city=Boston,state=MA, type: 0",
         "FloatPointsFrame, timestamps: [400, 600], values: \"143,147\"",
-        "GroupFrame, tag_keys: city,state, partition_key_vals: Cambridge,MA",
         "SeriesFrame, tags: _field=temp,_measurement=h2o,city=Cambridge,state=MA, type: 0",
         "FloatPointsFrame, timestamps: [400, 600], values: \"163,167\"",
     ];

--- a/write_buffer/src/table.rs
+++ b/write_buffer/src/table.rs
@@ -550,10 +550,12 @@ impl Table {
         let series_set_plan =
             self.series_set_plan_impl(partition_predicate, Some(&group_columns), partition)?;
         let num_prefix_tag_group_columns = group_columns.len();
+        let skip_group_items = false;
 
         Ok(GroupedSeriesSetPlan {
             series_set_plan,
             num_prefix_tag_group_columns,
+            skip_group_items,
         })
     }
 
@@ -654,6 +656,7 @@ impl Table {
 
         Ok(GroupedSeriesSetPlan {
             num_prefix_tag_group_columns: tag_columns.len(),
+            skip_group_items: true,
             series_set_plan: SeriesSetPlan {
                 table_name: self.table_name(partition),
                 plan,


### PR DESCRIPTION
This is fix 2 of 2 needed to get read_window_aggregate working correctly

Closes #490

- [x] Allow empty `offset` windows (https://github.com/influxdata/influxdb_iox/pull/493
- [x] Don't send back GroupFrames in responses (this PR)

# Background:

Despite even writing a mini spec, I still ended up creating a plan that sent back `GroupFrame` responses for read_window_aggregate, which is not correct

This PR adds a hack / special case to not do this.

I am also working a PR with a much more significant refactoring to unify / remove the duplication between the Group / non Grouped query execution path and remove this special case but figured I would get this one up so that I had it ready and so I can demonstrate the the functionality working.
