### PR TITLE
chore: validate database names

### DIFF
--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -406,11 +406,12 @@ mod tests {
         let mut server = Server::new(manager, store);
         server.set_id(1);
 
-        let reject: [&str; 4] = [
+        let reject: [&str; 5] = [
             "bananas!",
             r#""bananas\"are\"great"#,
             "bananas:good",
             "bananas/cavendish",
+            "bananas\n",
         ];
 
         for &name in &reject {


### PR DESCRIPTION
Ensure database names contain only `{alphanumeric, -, _}` characters.

Fixes #278.