### PR TITLE
refactor: consolidate GroupedSeriesSet and SeriesSet

### DIFF
--- a/query/src/lib.rs
+++ b/query/src/lib.rs
@@ -8,7 +8,7 @@
 use arrow_deps::arrow::record_batch::RecordBatch;
 use async_trait::async_trait;
 use data_types::data::ReplicatedWrite;
-use exec::{FieldListPlan, GroupedSeriesSetPlans, SeriesSetPlans, StringSetPlan};
+use exec::{FieldListPlan, SeriesSetPlans, StringSetPlan};
 use influxdb_line_protocol::ParsedLine;
 
 use std::{fmt::Debug, sync::Arc};
@@ -103,7 +103,7 @@ pub trait Database: Debug + Send + Sync {
         &self,
         predicate: Predicate,
         gby_agg: GroupByAndAggregate,
-    ) -> Result<GroupedSeriesSetPlans, Self::Error>;
+    ) -> Result<SeriesSetPlans, Self::Error>;
 
     /// Fetch the specified table names and columns as Arrow
     /// RecordBatches. Columns are returned in the order specified.

--- a/query/src/test.rs
+++ b/query/src/test.rs
@@ -8,7 +8,7 @@ use crate::{
     exec::FieldListPlan,
     exec::{
         stringset::{StringSet, StringSetRef},
-        GroupedSeriesSetPlans, SeriesSetPlans, StringSetPlan,
+        SeriesSetPlans, StringSetPlan,
     },
     Database, DatabaseStore, Predicate, TimestampRange,
 };
@@ -51,7 +51,7 @@ pub struct TestDatabase {
     query_series_request: Arc<Mutex<Option<QuerySeriesRequest>>>,
 
     /// Responses to return on the next request to `query_groups`
-    query_groups_values: Arc<Mutex<Option<GroupedSeriesSetPlans>>>,
+    query_groups_values: Arc<Mutex<Option<SeriesSetPlans>>>,
 
     /// The last request for `query_series`
     query_groups_request: Arc<Mutex<Option<QueryGroupsRequest>>>,
@@ -176,7 +176,7 @@ impl TestDatabase {
     }
 
     /// Set the series that will be returned on a call to query_groups
-    pub async fn set_query_groups_values(&self, plan: GroupedSeriesSetPlans) {
+    pub async fn set_query_groups_values(&self, plan: SeriesSetPlans) {
         *(self.query_groups_values.clone().lock().await) = Some(plan);
     }
 
@@ -383,7 +383,7 @@ impl Database for TestDatabase {
         &self,
         predicate: Predicate,
         gby_agg: GroupByAndAggregate,
-    ) -> Result<GroupedSeriesSetPlans, Self::Error> {
+    ) -> Result<SeriesSetPlans, Self::Error> {
         let predicate = predicate_to_test_string(&predicate);
 
         let new_queries_groups_request = Some(QueryGroupsRequest { predicate, gby_agg });


### PR DESCRIPTION
This PR removes a bunch of the code  duplication (mostly plumbing, ~200 lines) that allowed for a distinction between "grouped series sets" and "series sets" -- as mentioned in https://github.com/influxdata/influxdb_iox/pull/497. Instead this PR generalizes SeriesSet in general. 

As backstory, `SeriesSets` represent results from running a query, along with timeseries specific metadata (aka what columns are the tags and fields) needed to convert those results into the format needed for gRPC. `GroupedSeriesSets` was a wrapper over a wrapper wrapper that also includes information about "groups" -- which I am sure is not correct anyways (I will fix it https://github.com/influxdata/influxdb_iox/issues/448)

The only difference between series and grouped series sets is a single field and ~ 20 lines of logic during conversion which I will point out below
