### PR TITLE
perf(gzip): switch to flate2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1350,6 +1350,7 @@ dependencies = [
  "dirs 3.0.1",
  "dotenv",
  "env_logger",
+ "flate2",
  "futures",
  "generated_types",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,7 @@ tracing-futures="0.2.4"
 
 http = "0.2.0"
 snafu = "0.6.9"
-libflate = "1.0.0"
+flate2 = "1.0"
 
 [dev-dependencies]
 assert_cmd = "1.0.0"

--- a/src/server/http_routes.rs
+++ b/src/server/http_routes.rs
@@ -188,6 +188,10 @@ async fn parse_body(req: hyper::Request<Body>) -> Result<Bytes, ApplicationError
     if ungzip {
         use std::io::Read;
         let decoder = flate2::read::GzDecoder::new(&body[..]);
+
+        // Read at most MAX_SIZE bytes to prevent a decompression bomb based
+        // DoS.
+        let mut decoder = decoder.take(MAX_SIZE as u64);
         let mut decoded_data = Vec::new();
         decoder
             .read_to_end(&mut decoded_data)


### PR DESCRIPTION
A quick set of benchmarks confirms decompression in `flate2` is indeed faster
than `libflate` by ~2x or more:

```
enwiki-latest-all-titles-in-ns0.gz/flate2/enwiki-latest-all-titles-in-ns0.gz
                        time:   [1.0241 s 1.0276 s 1.0313 s]
                        thrpt:  [308.88 MiB/s 309.98 MiB/s 311.06 MiB/s]

enwiki-latest-all-titles-in-ns0.gz/libflate/enwiki-latest-all-titles-in-ns0.gz
                        time:   [1.9891 s 1.9928 s 1.9968 s]
                        thrpt:  [159.53 MiB/s 159.85 MiB/s 160.15 MiB/s]

000000000068612-000000044.tsm.gz/flate2/000000000068612-000000044.tsm.gz
                        time:   [4.6415 s 4.6483 s 4.6556 s]
                        thrpt:  [439.93 MiB/s 440.62 MiB/s 441.27 MiB/s]

000000000068612-000000044.tsm.gz/libflate/000000000068612-000000044.tsm.gz
                        time:   [12.165 s 12.232 s 12.306 s]
                        thrpt:  [166.43 MiB/s 167.45 MiB/s 168.36 MiB/s]
```

Where:
* `enwiki-latest-all-titles-in-ns0` is a generic dataset (wikipedia article titles)
* `000000000068612-000000044.tsm.gz` is a compressed TSM from @alamb

I ran the TSM convert tool as far as the deflate step for each. With the
original code using `libflate`, the deflate step ran in ~7m11s (431s):

```
curiosity:influxdb_iox % cargo run --release -- -vv convert  ~/Documents/rust/flate-bench/000000000068612-000000044.tsm.gz /dev/null
	Finished release [optimized + debuginfo] target(s) in 0.71s
     Running `target/release/influxdb_iox -vv convert /Users/dom/Documents/rust/flate-bench/000000000068612-000000044.tsm.gz /dev/null`
[2020-11-30T13:49:48Z INFO  influxdb_iox::commands::convert] convert starting
[2020-11-30T13:49:48Z DEBUG influxdb_iox::commands::convert] Reading from input path /Users/dom/Documents/rust/flate-bench/000000000068612-000000044.tsm.gz
[2020-11-30T13:56:59Z INFO  influxdb_iox::commands::convert] Preparing to convert 2147630631 bytes from /Users/dom/Documents/rust/flate-bench/000000000068612-000000044.tsm.gz
```

After switching to `flate2` it takes ~7s:

```
curiosity:influxdb_iox % cargo run --release -- -vv convert  ~/Documents/rust/flate-bench/000000000068612-000000044.tsm.gz /dev/null
    Finished release [optimized + debuginfo] target(s) in 0.74s
     Running `target/release/influxdb_iox -vv convert /Users/dom/Documents/rust/flate-bench/000000000068612-000000044.tsm.gz /dev/null`
[2020-11-30T13:36:58Z INFO  influxdb_iox::commands::convert] convert starting
[2020-11-30T13:36:58Z DEBUG influxdb_iox::commands::convert] Reading from input path /Users/dom/Documents/rust/flate-bench/000000000068612-000000044.tsm.gz
[2020-11-30T13:37:05Z INFO  influxdb_iox::commands::convert] Preparing to convert 2147630631 bytes from /Users/dom/Documents/rust/flate-bench/000000000068612-000000044.tsm.gz
```

However that's not the full story - the `libflate` performance was so bad
(beyond what was reflected in the deflate benchmarks above) I suspected it was
not buffering IO. Adding a [`BufReader`] cut the deflate step down to a way more
reasonable 18s:

```
curiosity:influxdb_iox % cargo run --release -- -vv convert  ~/Documents/rust/flate-bench/000000000068612-000000044.tsm.gz /dev/null
   Compiling influxdb_iox v0.1.0 (/Users/dom/Documents/rust/influxdb_iox)
    Finished release [optimized + debuginfo] target(s) in 2m 14s
     Running `target/release/influxdb_iox -vv convert /Users/dom/Documents/rust/flate-bench/000000000068612-000000044.tsm.gz /dev/null`
[2020-11-30T14:31:41Z INFO  influxdb_iox::commands::convert] convert starting
[2020-11-30T14:31:41Z DEBUG influxdb_iox::commands::convert] Reading from input path /Users/dom/Documents/rust/flate-bench/000000000068612-000000044.tsm.gz
[2020-11-30T14:31:59Z INFO  influxdb_iox::commands::convert] Preparing to convert 2147630631 bytes from /Users/dom/Documents/rust/flate-bench/000000000068612-000000044.tsm.gz
```

There was no change when running `flate2` with a `BufReader`.

Therefore this PR changes to the `flate2` crate as it still ~twice as fast -
worth keeping in mind that it seems to be doing internal buffering when using
it.

[`BufReader`]: https://doc.rust-lang.org/std/io/struct.BufReader.html

Closes #246 