### PR TITLE
chore: use flate2 everywhere

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7,12 +7,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee2a4ec343196209d6594e19543ae87a39f96d5534d7174822a3ad825dd6ed7e"
 
 [[package]]
-name = "adler32"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aae1277d39aeec15cb388266ecc24b11c80469deae6067e17a1a7aa9e5c1f234"
-
-[[package]]
 name = "ahash"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1360,7 +1354,6 @@ dependencies = [
  "influxdb_line_protocol",
  "influxdb_tsm",
  "ingest",
- "libflate",
  "mem_qe",
  "object_store",
  "packers",
@@ -1401,9 +1394,9 @@ dependencies = [
 name = "influxdb_tsm"
 version = "0.1.0"
 dependencies = [
+ "flate2",
  "hex",
  "integer-encoding",
- "libflate",
  "rand",
  "snafu",
  "snap",
@@ -1418,9 +1411,9 @@ dependencies = [
  "arrow_deps",
  "data_types",
  "env_logger",
+ "flate2",
  "influxdb_line_protocol",
  "influxdb_tsm",
- "libflate",
  "packers",
  "snafu",
  "test_helpers",
@@ -1544,24 +1537,6 @@ name = "libc"
 version = "0.2.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d58d1b70b004888f764dfbf6a26a3b0342a1632d33968e4a179d8011c760614"
-
-[[package]]
-name = "libflate"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389de7875e06476365974da3e7ff85d55f1972188ccd9f6020dd7c8156e17914"
-dependencies = [
- "adler32",
- "crc32fast",
- "libflate_lz77",
- "rle-decode-fast",
-]
-
-[[package]]
-name = "libflate_lz77"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3286f09f7d4926fc486334f28d8d2e6ebe4f7f9994494b6dab27ddfad2c9b11b"
 
 [[package]]
 name = "libloading"
@@ -2528,12 +2503,6 @@ dependencies = [
  "web-sys",
  "winapi 0.3.9",
 ]
-
-[[package]]
-name = "rle-decode-fast"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cabe4fa914dec5870285fa7f71f602645da47c486e68486d2b4ceb4a343e90ac"
 
 [[package]]
 name = "rusoto_core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,7 +75,7 @@ criterion = "0.3"
 test_helpers = { path = "test_helpers" }
 hex = "0.4.2"
 influxdb2_client = { path = "influxdb2_client" }
-libflate = "1.0.0"
+flate2 = "1.0"
 rand = "0.7.2"
 reqwest = "0.10.1"
 predicates = "1.0.4"

--- a/influxdb_tsm/Cargo.toml
+++ b/influxdb_tsm/Cargo.toml
@@ -14,6 +14,6 @@ snafu = "0.6.2"
 
 [dev-dependencies]
 hex = "0.4.2"
-libflate = "1.0.0"
+flate2 = "1.0"
 rand = "0.7.2"
 test_helpers = { path = "../test_helpers" }

--- a/influxdb_tsm/src/mapper.rs
+++ b/influxdb_tsm/src/mapper.rs
@@ -641,7 +641,7 @@ mod tests {
     use super::*;
     use crate::reader::*;
 
-    use libflate::gzip;
+    use flate2::read::GzDecoder;
 
     use std::fs::File;
     use std::io::BufReader;
@@ -653,7 +653,7 @@ mod tests {
     #[test]
     fn map_tsm_index() {
         let file = File::open("../tests/fixtures/000000000000005-000000002.tsm.gz");
-        let mut decoder = gzip::Decoder::new(file.unwrap()).unwrap();
+        let mut decoder = GzDecoder::new(file.unwrap());
         let mut buf = Vec::new();
         decoder.read_to_end(&mut buf).unwrap();
 
@@ -669,7 +669,7 @@ mod tests {
     #[test]
     fn map_field_columns_file() {
         let file = File::open("../tests/fixtures/000000000000005-000000002.tsm.gz");
-        let mut decoder = gzip::Decoder::new(file.unwrap()).unwrap();
+        let mut decoder = GzDecoder::new(file.unwrap());
         let mut buf = Vec::new();
         decoder.read_to_end(&mut buf).unwrap();
 
@@ -712,7 +712,7 @@ mod tests {
     #[test]
     fn measurement_table_columns() {
         let file = File::open("../tests/fixtures/000000000000005-000000002.tsm.gz");
-        let mut decoder = gzip::Decoder::new(file.unwrap()).unwrap();
+        let mut decoder = GzDecoder::new(file.unwrap());
         let mut buf = Vec::new();
         decoder.read_to_end(&mut buf).unwrap();
 

--- a/influxdb_tsm/src/reader.rs
+++ b/influxdb_tsm/src/reader.rs
@@ -14,13 +14,13 @@ use std::u64;
 ///
 /// ```
 /// # use influxdb_tsm::reader::*;
-/// # use libflate::gzip;
+/// # use flate2::read::GzDecoder;
 /// # use std::fs::File;
 /// # use std::io::BufReader;
 /// # use std::io::Cursor;
 /// # use std::io::Read;
 /// # let file = File::open("../tests/fixtures/000000000000005-000000002.tsm.gz");
-/// # let mut decoder = gzip::Decoder::new(file.unwrap()).unwrap();
+/// # let mut decoder = GzDecoder::new(file.unwrap());
 /// # let mut buf = Vec::new();
 /// # decoder.read_to_end(&mut buf).unwrap();
 /// # let data_len = buf.len();
@@ -675,7 +675,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use libflate::gzip;
+    use flate2::read::GzDecoder;
     use std::fs::File;
     use std::i64;
     use std::io::BufReader;
@@ -685,7 +685,7 @@ mod tests {
     #[test]
     fn read_tsm_index() {
         let file = File::open("../tests/fixtures/000000000000005-000000002.tsm.gz");
-        let mut decoder = gzip::Decoder::new(file.unwrap()).unwrap();
+        let mut decoder = GzDecoder::new(file.unwrap());
         let mut buf = Vec::new();
         decoder.read_to_end(&mut buf).unwrap();
 
@@ -698,7 +698,7 @@ mod tests {
     #[test]
     fn read_tsm_block() {
         let file = File::open("../tests/fixtures/000000000000005-000000002.tsm.gz");
-        let mut decoder = gzip::Decoder::new(file.unwrap()).unwrap();
+        let mut decoder = GzDecoder::new(file.unwrap());
         let mut buf = Vec::new();
         decoder.read_to_end(&mut buf).unwrap();
 
@@ -752,7 +752,7 @@ mod tests {
     #[test]
     fn decode_tsm_blocks() {
         let file = File::open("../tests/fixtures/000000000000005-000000002.tsm.gz");
-        let mut decoder = gzip::Decoder::new(file.unwrap()).unwrap();
+        let mut decoder = GzDecoder::new(file.unwrap());
         let mut buf = Vec::new();
         decoder.read_to_end(&mut buf).unwrap();
         let r = Cursor::new(buf);
@@ -803,7 +803,7 @@ mod tests {
     // ensures no errors are returned from the reader.
     fn walk_index_and_check_for_errors(tsm_gz_path: &str) {
         let file = File::open(tsm_gz_path);
-        let mut decoder = gzip::Decoder::new(file.unwrap()).unwrap();
+        let mut decoder = GzDecoder::new(file.unwrap());
         let mut buf = Vec::new();
         decoder.read_to_end(&mut buf).unwrap();
         let data_len = buf.len();

--- a/ingest/Cargo.toml
+++ b/ingest/Cargo.toml
@@ -19,4 +19,4 @@ arrow_deps = { path = "../arrow_deps" }
 
 [dev-dependencies]
 test_helpers ={ path = "../test_helpers" }
-libflate = "1.0.0"
+flate2 = "1.0"

--- a/ingest/src/lib.rs
+++ b/ingest/src/lib.rs
@@ -1097,7 +1097,7 @@ mod tests {
     use packers::{Error as TableError, IOxTableWriter, IOxTableWriterSource, Packers};
     use test_helpers::approximately_equal;
 
-    use libflate::gzip;
+    use flate2::read::GzDecoder;
     use std::fs::File;
     use std::io::BufReader;
     use std::io::Cursor;
@@ -2063,7 +2063,7 @@ mod tests {
     #[test]
     fn conversion_tsm_file_single() -> Result<(), Error> {
         let file = File::open("../tests/fixtures/merge-tsm/merge_a.tsm.gz");
-        let mut decoder = gzip::Decoder::new(file.unwrap()).unwrap();
+        let mut decoder = GzDecoder::new(file.unwrap());
         let mut buf = Vec::new();
         decoder.read_to_end(&mut buf).unwrap();
 
@@ -2107,14 +2107,14 @@ mod tests {
         let mut block_streams = Vec::new();
 
         let file_a = File::open("../tests/fixtures/merge-tsm/merge_a.tsm.gz");
-        let mut decoder_a = gzip::Decoder::new(file_a.unwrap()).unwrap();
+        let mut decoder_a = GzDecoder::new(file_a.unwrap());
         let mut buf_a = Vec::new();
         decoder_a.read_to_end(&mut buf_a).unwrap();
         index_streams.push((BufReader::new(Cursor::new(&buf_a)), 39475));
         block_streams.push(BufReader::new(Cursor::new(&buf_a)));
 
         let file_b = File::open("../tests/fixtures/merge-tsm/merge_b.tsm.gz");
-        let mut decoder_b = gzip::Decoder::new(file_b.unwrap()).unwrap();
+        let mut decoder_b = GzDecoder::new(file_b.unwrap());
         let mut buf_b = Vec::new();
         decoder_b.read_to_end(&mut buf_b).unwrap();
         index_streams.push((BufReader::new(Cursor::new(&buf_b)), 45501));

--- a/src/server/http_routes.rs
+++ b/src/server/http_routes.rs
@@ -405,15 +405,11 @@ mod tests {
     }
 
     fn gzip_str(s: &str) -> Vec<u8> {
-        use libflate::gzip::Encoder;
+        use flate2::{write::GzEncoder, Compression};
         use std::io::Write;
-
-        let mut encoder = Encoder::new(Vec::new()).expect("creating gzip encoder");
+        let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
         write!(encoder, "{}", s).expect("writing into encoder");
-        encoder
-            .finish()
-            .into_result()
-            .expect("successfully encoding gzip data")
+        encoder.finish().expect("successfully encoding gzip data")
     }
 
     #[tokio::test]

--- a/tests/commands.rs
+++ b/tests/commands.rs
@@ -5,7 +5,6 @@ use std::path::Path;
 
 use assert_cmd::assert::Assert;
 use assert_cmd::Command;
-use libflate::gzip;
 use predicates::prelude::*;
 
 /// Validates that p is a valid parquet file
@@ -261,7 +260,7 @@ fn uncompress_gz(input_path: &str, output_extension: &str) -> test_helpers::temp
         .into_temp_path();
 
     let mut output_file = File::create(&output_path).expect("error opening output");
-    let mut decoder = gzip::Decoder::new(gz_file).expect("error creating gzip decoder");
+    let mut decoder = flate2::read::GzDecoder::new(gz_file);
     std::io::copy(&mut decoder, &mut output_file).expect("error copying stream");
     output_path
 }


### PR DESCRIPTION
Follows #505 - switches all other usage of `libflate` to `flate2`.