### PR TITLE
refactor: avoid requiring time predicate in Segment

### DIFF
--- a/segment_store/src/column/cmp.rs
+++ b/segment_store/src/column/cmp.rs
@@ -1,5 +1,5 @@
 /// Possible comparison operators
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Copy, Clone)]
 pub enum Operator {
     Equal,
     NotEqual,

--- a/segment_store/src/segment.rs
+++ b/segment_store/src/segment.rs
@@ -232,6 +232,7 @@ impl Segment {
             .iter()
             .filter(|(col, _)| *col == TIME_COLUMN_NAME)
             .count()
+            // Check if we have two predicates on the time column, i.e., a time range.
             == 2
         {
             // Apply optimised filtering to time column


### PR DESCRIPTION
Things would be a bit simpler inside a `Segment` if there wasn't a requirement to have predicates on the `time` column. Enforcing the requirement to range by time can still be achieved, it would just be done at the `table` level rather than the segment level.

For segments that are completely covered by a time-range predicate(s) the `table` can then just remove those predicates before pushing down the rest of the predicates to the relevant segment.