### PR TITLE
fix: unambigious bucket/org to DB mappings

### DIFF
--- a/data_types/src/database_name.rs
+++ b/data_types/src/database_name.rs
@@ -1,10 +1,10 @@
 use snafu::Snafu;
-use std::{borrow::Cow, ops::Range};
+use std::{borrow::Cow, ops::RangeInclusive};
 
 /// Length constraints for a database name.
 ///
-/// A `Range` is half open covering [1, 64)
-const LENGTH_CONSTRAINT: Range<usize> = 1..64;
+/// A `Range` is half open covering [1, 64]
+const LENGTH_CONSTRAINT: RangeInclusive<usize> = 1..=64;
 
 /// Database name validation errors.
 #[derive(Debug, Snafu)]
@@ -12,8 +12,8 @@ pub enum DatabaseNameError {
     #[snafu(display(
         "Database name {} length must be between {} and {} characters",
         name,
-        LENGTH_CONSTRAINT.start,
-        LENGTH_CONSTRAINT.end
+        LENGTH_CONSTRAINT.start(),
+        LENGTH_CONSTRAINT.end()
     ))]
     LengthConstraint { name: String },
 

--- a/data_types/src/database_name.rs
+++ b/data_types/src/database_name.rs
@@ -3,7 +3,7 @@ use std::{borrow::Cow, ops::RangeInclusive};
 
 /// Length constraints for a database name.
 ///
-/// A `Range` is half open covering [1, 64]
+/// A `RangeInclusive` is a closed interval, covering [1, 64]
 const LENGTH_CONSTRAINT: RangeInclusive<usize> = 1..=64;
 
 /// Database name validation errors.

--- a/data_types/src/database_name.rs
+++ b/data_types/src/database_name.rs
@@ -1,0 +1,147 @@
+use snafu::Snafu;
+use std::{borrow::Cow, ops::Range};
+
+/// Length constraints for a database name.
+///
+/// A `Range` is half open covering [1, 64)
+const LENGTH_CONSTRAINT: Range<usize> = 1..64;
+
+/// Database name validation errors.
+#[derive(Debug, Snafu)]
+pub enum DatabaseNameError {
+    #[snafu(display(
+        "Database name {} length must be between {} and {} characters",
+        name,
+        LENGTH_CONSTRAINT.start,
+        LENGTH_CONSTRAINT.end
+    ))]
+    LengthConstraint { name: String },
+
+    #[snafu(display(
+        "Database name {} contains invalid characters (allowed: alphanumeric, _ and -)",
+        name
+    ))]
+    BadChars { name: String },
+}
+
+/// A correctly formed database name.
+///
+/// Using this wrapper type allows the consuming code to enforce the invariant
+/// that only valid names are provided.
+///
+/// This type derefs to a `str` and therefore can be used in place of anything
+/// that is expecting a `str`:
+///
+/// ```rust
+/// # use data_types::DatabaseName;
+/// fn print_database(s: &str) {
+///     println!("database name: {}", s);
+/// }
+///
+/// let db = DatabaseName::new("data").unwrap();
+/// print_database(&db);
+/// ```
+///
+/// But this is not reciprocal - functions that wish to accept only
+/// pre-validated names can use `DatabaseName` as a parameter.
+#[derive(
+    Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, serde::Serialize, serde::Deserialize,
+)]
+pub struct DatabaseName<'a>(Cow<'a, str>);
+
+impl<'a> DatabaseName<'a> {
+    pub fn new<T: Into<Cow<'a, str>>>(name: T) -> Result<Self, DatabaseNameError> {
+        let name: Cow<'a, str> = name.into();
+
+        if !LENGTH_CONSTRAINT.contains(&name.len()) {
+            return Err(DatabaseNameError::LengthConstraint {
+                name: name.to_string(),
+            });
+        }
+
+        // Validate the name contains only valid characters.
+        //
+        // NOTE: If changing these characters, please update the error message
+        // above.
+        if !name
+            .chars()
+            .all(|c| c.is_alphanumeric() || c == '_' || c == '-')
+        {
+            return Err(DatabaseNameError::BadChars {
+                name: name.to_string(),
+            });
+        }
+
+        Ok(Self(name))
+    }
+}
+
+impl<'a> std::convert::TryFrom<&'a str> for DatabaseName<'a> {
+    type Error = DatabaseNameError;
+
+    fn try_from(v: &'a str) -> Result<Self, Self::Error> {
+        Self::new(v)
+    }
+}
+
+impl<'a> std::convert::TryFrom<String> for DatabaseName<'a> {
+    type Error = DatabaseNameError;
+
+    fn try_from(v: String) -> Result<Self, Self::Error> {
+        Self::new(v)
+    }
+}
+
+impl<'a> std::ops::Deref for DatabaseName<'a> {
+    type Target = str;
+
+    fn deref(&self) -> &Self::Target {
+        self.0.as_ref()
+    }
+}
+
+impl<'a> std::fmt::Display for DatabaseName<'a> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::convert::TryFrom;
+
+    #[test]
+    fn test_deref() {
+        let db = DatabaseName::new("my_example_name").unwrap();
+        assert_eq!(&*db, "my_example_name");
+    }
+
+    #[test]
+    fn test_too_short() {
+        let name = "".to_string();
+        let got = DatabaseName::try_from(name).unwrap_err();
+
+        assert!(matches!(
+            got,
+            DatabaseNameError::LengthConstraint { name: _n }
+        ));
+    }
+
+    #[test]
+    fn test_too_long() {
+        let name = "my_example_name_that_is_quite_a_bit_longer_than_allowed_even_though_database_names_can_be_quite_long_bananas".to_string();
+        let got = DatabaseName::try_from(name).unwrap_err();
+
+        assert!(matches!(
+            got,
+            DatabaseNameError::LengthConstraint { name: _n }
+        ));
+    }
+
+    #[test]
+    fn test_bad_chars() {
+        let got = DatabaseName::new("example!").unwrap_err();
+        assert!(matches!(got, DatabaseNameError::BadChars { name: _n }));
+    }
+}

--- a/data_types/src/lib.rs
+++ b/data_types/src/lib.rs
@@ -16,3 +16,6 @@ pub mod database_rules;
 pub mod error;
 pub mod partition_metadata;
 pub mod table_schema;
+
+mod database_name;
+pub use database_name::*;

--- a/query/src/lib.rs
+++ b/query/src/lib.rs
@@ -129,14 +129,6 @@ pub trait DatabaseStore: Debug + Send + Sync {
     async fn db_or_create(&self, name: &str) -> Result<Arc<Self::Database>, Self::Error>;
 }
 
-/// Compatibility: return the database name to use for the specified
-/// org and bucket name.
-///
-/// TODO move to somewhere else / change the traits to take the database name directly
-pub fn org_and_bucket_to_database(org: impl Into<String>, bucket: &str) -> String {
-    org.into() + "_" + bucket
-}
-
 // Note: I would like to compile this module only in the 'test' cfg,
 // but when I do so then other modules can not find them. For example:
 //

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -199,7 +199,7 @@ impl<M: ConnectionManager> Server<M> {
             .databases
             .get(&db_name)
             .context(DatabaseNotFound {
-                db_name: db_name.to_string(),
+                db_name: &*db_name,
             })?;
 
         let sequence = db.next_sequence();
@@ -219,11 +219,11 @@ impl<M: ConnectionManager> Server<M> {
             .databases
             .get(&db_name)
             .context(DatabaseNotFound {
-                db_name: db_name.to_string(),
+                db_name: &*db_name,
             })?;
 
         let buff = db.local_store.as_ref().context(NoLocalBuffer {
-            db: db_name.to_string(),
+            db: &*db_name,
         })?;
         buff.query(query)
             .await

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -231,9 +231,9 @@ impl<M: ConnectionManager> Server<M> {
             .context(UnknownDatabaseError {})
     }
 
-    pub async fn handle_replicated_write<'a>(
+    pub async fn handle_replicated_write(
         &self,
-        db_name: &DatabaseName<'a>,
+        db_name: &DatabaseName<'_>,
         db: &Db,
         write: ReplicatedWrite,
     ) -> Result<()> {
@@ -266,10 +266,10 @@ impl<M: ConnectionManager> Server<M> {
     // replicates to a single host in the group based on hashing rules. If that host is unavailable
     // an error will be returned. The request may still succeed if enough of the other host groups
     // have returned a success.
-    async fn replicate_to_host_group<'a>(
+    async fn replicate_to_host_group(
         &self,
         host_group_id: &str,
-        db_name: &DatabaseName<'a>,
+        db_name: &DatabaseName<'_>,
         write: &ReplicatedWrite,
     ) -> Result<()> {
         let group = self

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -418,7 +418,7 @@ mod tests {
                 ..Default::default()
             };
             let got = server.create_database(name, rules).await.unwrap_err();
-            if !matches!(got, Error::InvalidDatabaseName { source: _s }) {
+            if !matches!(got, Error::InvalidDatabaseName { .. }) {
                 panic!("expected invalid name error");
             }
         }

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -198,9 +198,7 @@ impl<M: ConnectionManager> Server<M> {
             .config
             .databases
             .get(&db_name)
-            .context(DatabaseNotFound {
-                db_name: &*db_name,
-            })?;
+            .context(DatabaseNotFound { db_name: &*db_name })?;
 
         let sequence = db.next_sequence();
         let write = lines_to_replicated_write(id, sequence, lines, &db.rules);
@@ -218,13 +216,12 @@ impl<M: ConnectionManager> Server<M> {
             .config
             .databases
             .get(&db_name)
-            .context(DatabaseNotFound {
-                db_name: &*db_name,
-            })?;
+            .context(DatabaseNotFound { db_name: &*db_name })?;
 
-        let buff = db.local_store.as_ref().context(NoLocalBuffer {
-            db: &*db_name,
-        })?;
+        let buff = db
+            .local_store
+            .as_ref()
+            .context(NoLocalBuffer { db: &*db_name })?;
         buff.query(query)
             .await
             .map_err(|e| Box::new(e) as DatabaseError)

--- a/src/server.rs
+++ b/src/server.rs
@@ -33,8 +33,8 @@ pub(crate) fn org_and_bucket_to_database<'a, O: AsRef<str>, B: AsRef<str>>(
         || bucket.as_ref().chars().any(|c| c == SEPARATOR)
     {
         return InvalidBucketOrgName {
-            bucket_name: bucket.as_ref().to_string(),
-            org: org.as_ref().to_string(),
+            bucket_name: bucket.as_ref(),
+            org: org.as_ref(),
         }
         .fail();
     }
@@ -52,7 +52,7 @@ mod tests {
     fn test_org_bucket_map_db_ok() {
         let got = org_and_bucket_to_database("org", "bucket").expect("failed on valid DB mapping");
 
-        assert_eq!(got.to_string(), "org_bucket");
+        assert_eq!(&*got, "org_bucket");
     }
 
     #[test]

--- a/src/server.rs
+++ b/src/server.rs
@@ -43,3 +43,30 @@ pub(crate) fn org_and_bucket_to_database<'a, O: AsRef<str>, B: AsRef<str>>(
 
     DatabaseName::new(db_name).context(InvalidDatabaseName)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_org_bucket_map_db_ok() {
+        let got = org_and_bucket_to_database("org", "bucket").expect("failed on valid DB mapping");
+
+        assert_eq!(got.to_string(), "org_bucket");
+    }
+
+    #[test]
+    fn test_org_bucket_map_db_contains_underscore() {
+        let err = org_and_bucket_to_database("my_org", "bucket").unwrap_err();
+        assert!(matches!(err, OrgBucketMappingError::InvalidBucketOrgName {..}));
+
+        let err = org_and_bucket_to_database("org", "my_bucket").unwrap_err();
+        assert!(matches!(err, OrgBucketMappingError::InvalidBucketOrgName {..}));
+    }
+
+    #[test]
+    fn test_bad_database_name() {
+        let err = org_and_bucket_to_database("org!", "bucket?").unwrap_err();
+        assert!(matches!(err, OrgBucketMappingError::InvalidDatabaseName {..}));
+    }
+}

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,2 +1,45 @@
 pub mod http_routes;
 pub mod rpc;
+
+use data_types::{DatabaseName, DatabaseNameError};
+use snafu::{ResultExt, Snafu};
+
+#[derive(Debug, Snafu)]
+pub enum OrgBucketMappingError {
+    #[snafu(display(
+        "Internal error accessing org {}, bucket {}: the '_' character is reserved",
+        org,
+        bucket_name,
+    ))]
+    InvalidBucketOrgName { org: String, bucket_name: String },
+
+    #[snafu(display("Invalid database name: {}", source))]
+    InvalidDatabaseName { source: DatabaseNameError },
+}
+
+/// Map an InfluxDB 2.X org & bucket into an IOx DatabaseName.
+///
+/// This function ensures the mapping is unambiguous by requiring both `org` and
+/// `bucket` to not contain the `_` character in addition to the [`DatabaseName`]
+/// validation.
+pub(crate) fn org_and_bucket_to_database<'a, O: AsRef<str>, B: AsRef<str>>(
+    org: O,
+    bucket: B,
+) -> Result<DatabaseName<'a>, OrgBucketMappingError> {
+    const SEPARATOR: char = '_';
+
+    // Ensure neither the org, nor the bucket contain the separator character.
+    if org.as_ref().chars().any(|c| c == SEPARATOR)
+        || bucket.as_ref().chars().any(|c| c == SEPARATOR)
+    {
+        return InvalidBucketOrgName {
+            bucket_name: bucket.as_ref().to_string(),
+            org: org.as_ref().to_string(),
+        }
+        .fail();
+    }
+
+    let db_name = format!("{}{}{}", org.as_ref(), SEPARATOR, bucket.as_ref());
+
+    DatabaseName::new(db_name).context(InvalidDatabaseName)
+}

--- a/src/server/rpc/service.rs
+++ b/src/server/rpc/service.rs
@@ -812,9 +812,7 @@ where
     let plan = db_store
         .db(&db_name)
         .await
-        .context(DatabaseNotFound {
-            db_name: &*db_name,
-        })?
+        .context(DatabaseNotFound { db_name: &*db_name })?
         .table_names(predicate)
         .await
         .map_err(|e| Error::ListingTables {
@@ -862,9 +860,10 @@ where
         })?
         .build();
 
-    let db = db_store.db(&db_name).await.context(DatabaseNotFound {
-        db_name: &*db_name,
-    })?;
+    let db = db_store
+        .db(&db_name)
+        .await
+        .context(DatabaseNotFound { db_name: &*db_name })?;
 
     let tag_key_plan = db
         .tag_column_names(predicate)
@@ -916,9 +915,10 @@ where
         })?
         .build();
 
-    let db = db_store.db(&db_name).await.context(DatabaseNotFound {
-        db_name: &*db_name,
-    })?;
+    let db = db_store
+        .db(&db_name)
+        .await
+        .context(DatabaseNotFound { db_name: &*db_name })?;
 
     let tag_value_plan =
         db.column_values(&tag_name, predicate)
@@ -974,9 +974,10 @@ where
         })?
         .build();
 
-    let db = db_store.db(&db_name).await.context(DatabaseNotFound {
-        db_name: &*db_name,
-    })?;
+    let db = db_store
+        .db(&db_name)
+        .await
+        .context(DatabaseNotFound { db_name: &*db_name })?;
 
     let series_plan =
         db.query_series(predicate)
@@ -1056,9 +1057,10 @@ where
         })?
         .build();
 
-    let db = db_store.db(&db_name).await.context(DatabaseNotFound {
-        db_name: &*db_name,
-    })?;
+    let db = db_store
+        .db(&db_name)
+        .await
+        .context(DatabaseNotFound { db_name: &*db_name })?;
 
     let grouped_series_set_plan =
         db.query_groups(predicate, gby_agg)
@@ -1116,9 +1118,10 @@ where
         })?
         .build();
 
-    let db = db_store.db(&db_name).await.context(DatabaseNotFound {
-        db_name: &*db_name,
-    })?;
+    let db = db_store
+        .db(&db_name)
+        .await
+        .context(DatabaseNotFound { db_name: &*db_name })?;
 
     let fieldlist_plan =
         db.field_column_names(predicate)

--- a/src/server/rpc/service.rs
+++ b/src/server/rpc/service.rs
@@ -786,7 +786,7 @@ impl SetRange for PredicateBuilder {
     }
 }
 
-fn get_database_name<'a>(input: &impl GrpcInputs) -> Result<DatabaseName<'a>, Status> {
+fn get_database_name(input: &impl GrpcInputs) -> Result<DatabaseName<'static>, Status> {
     org_and_bucket_to_database(input.org_id()?.to_string(), &input.bucket_name()?)
         .map_err(|e| Status::internal(e.to_string()))
 }

--- a/src/server/rpc/service.rs
+++ b/src/server/rpc/service.rs
@@ -813,7 +813,7 @@ where
         .db(&db_name)
         .await
         .context(DatabaseNotFound {
-            db_name: db_name.to_string(),
+            db_name: &*db_name,
         })?
         .table_names(predicate)
         .await
@@ -863,7 +863,7 @@ where
         .build();
 
     let db = db_store.db(&db_name).await.context(DatabaseNotFound {
-        db_name: db_name.to_string(),
+        db_name: &*db_name,
     })?;
 
     let tag_key_plan = db
@@ -917,7 +917,7 @@ where
         .build();
 
     let db = db_store.db(&db_name).await.context(DatabaseNotFound {
-        db_name: db_name.to_string(),
+        db_name: &*db_name,
     })?;
 
     let tag_value_plan =
@@ -975,7 +975,7 @@ where
         .build();
 
     let db = db_store.db(&db_name).await.context(DatabaseNotFound {
-        db_name: db_name.to_string(),
+        db_name: &*db_name,
     })?;
 
     let series_plan =
@@ -1057,7 +1057,7 @@ where
         .build();
 
     let db = db_store.db(&db_name).await.context(DatabaseNotFound {
-        db_name: db_name.to_string(),
+        db_name: &*db_name,
     })?;
 
     let grouped_series_set_plan =
@@ -1117,7 +1117,7 @@ where
         .build();
 
     let db = db_store.db(&db_name).await.context(DatabaseNotFound {
-        db_name: db_name.to_string(),
+        db_name: &*db_name,
     })?;
 
     let fieldlist_plan =


### PR DESCRIPTION
Previously the $ORG and $BUCKET was joined as:

	$ORG + "_" + $BUCKET

Which is fine unless either $ORG or $BUCKET includes a "_", such as:

	$ORG = "org_a"
	$BUCKET = "bucket"

	and

	$ORG = "org"
	$BUCKET = "a_bucket"

This change continues to join $ORG and $BUCKET with an underscore, but
disallows underscores in either $ORG or $BUCKET. It appears these values
are non-zero u64s in the gRPC protocol converted to their base-10 string
representations for the DB name, so this seems safe to enforce.

In addition, this change introduces a `DatabaseName` type to avoid
passing bare strings around, and allow consuming code to ensure only
valid database names are provided at compile type. This type works with
both owned & borrowed content so doesn't force a string copy where we
can avoid it, and derefs to `str` to make it easier to use with existing
code.

I've been minimally invasive in pushing the `DatabaseName` through the
existing code and figured I'd see what the sentement is first.
Candidates for conversion from `str` to `DatabaseName` that seem to make
sense to me include:

- `DatabaseStore` trait
- `RemoteServer` trait
- Others? Basically anywhere other than the "edge" API inputs

Fixes #436 (thanks @zeebo)