### PR TITLE
ci: remove IOx pre-building in rust build container

### DIFF
--- a/docker/Dockerfile.ci
+++ b/docker/Dockerfile.ci
@@ -61,18 +61,4 @@ RUN groupadd -g 1500 rust \
 USER rust
 ENV PATH /home/rust/.local/bin:/home/rust/bin:${PATH}
 
-# Copy the source into the image
-ADD . /home/rust/project
-RUN sudo chown -R rust:rust /home/rust/project
-RUN sudo chmod u+rwx  /home/rust/project
-RUN cd /home/rust/project && git checkout main && git reset --hard
-
-# Compile the code and bake the results into the image, so actual CI
-# builds are just incremental builds from the last time the image was
-# made.
-
-RUN cd /home/rust/project && cargo build --all && \
-    cargo clippy && \
-    cargo test --no-run
-
 CMD ["/bin/bash"]


### PR DESCRIPTION
Stops adding the IOx source code and performing a cargo build/test/clippy each
night. Previously this build would compile the IOx source & dependencies,
populating the incremental build cache and allowing builds that used the same
dependencies to complete quicker. This build caching was moved to
per-dependency-set caching in #496, and this pre-build is no longer used.

This should reduce the build image size substantially, making the whole CI
process a bit faster.

---

I was going to disable the nightly building of the build container to stop pushing identical images to quay, but we need to produce a new image whenever the CI Dockerfile is changed so left it for now - I'm open to ideas how to automate this!