### PR TITLE
fix: Fix gRPC panic` when multiple field selections are provided

### DIFF
--- a/query/src/predicate.rs
+++ b/query/src/predicate.rs
@@ -36,20 +36,20 @@ impl TimestampRange {
 }
 
 /// Represents a parsed predicate for evaluation by the
-/// InfluxDB IOx storage system.
+/// TSDatabase InfluxDB IOx query engine.
 ///
-/// Note that the input data model (e.g. ParsedLine's) distinguishes
-/// between some types of columns (tags and fields), and likewise
-/// this structure has some types of restrictions that only apply to
-/// certain types of columns.
+/// Note that the data model of TSDatabase (e.g. ParsedLine's)
+/// distinguishes between some types of columns (tags and fields), and
+/// likewise the semantics of this structure has some types of
+/// restrictions that only apply to certain types of columns.
 #[derive(Clone, Debug, Default)]
 pub struct Predicate {
-    /// Optional filter. If present, restrict the results to only
-    /// those tables whose names are in `table_names`
+    /// Optional table restriction. If present, restricts the results
+    /// to only tables whose names are in `table_names`
     pub table_names: Option<BTreeSet<String>>,
 
-    // Optional field column selection. If present, further restrict any
-    // field columns returned to only those named
+    // Optional field restriction. If present, restrict the results to only
+    // tables which have *at least one* of the fields in field_columns.
     pub field_columns: Option<BTreeSet<String>>,
 
     /// Optional arbitrary predicates, represented as list of
@@ -86,12 +86,24 @@ impl From<Predicate> for PredicateBuilder {
 impl PredicateBuilder {
     /// Sets the timestamp range
     pub fn timestamp_range(mut self, start: i64, end: i64) -> Self {
+        // without more thought, redefining the timestamp range would
+        // lose the old range. Asser that that cannot happen.
+        assert!(
+            self.inner.range.is_none(),
+            "Unexpected re-definition of timestamp range"
+        );
         self.inner.range = Some(TimestampRange { start, end });
         self
     }
 
     /// sets the optional timestamp range, if any
     pub fn timestamp_range_option(mut self, range: Option<TimestampRange>) -> Self {
+        // without more thought, redefining the timestamp range would
+        // lose the old range. Asser that that cannot happen.
+        assert!(
+            range.is_none() || self.inner.range.is_none(),
+            "Unexpected re-definition of timestamp range"
+        );
         self.inner.range = range;
         self
     }
@@ -134,10 +146,9 @@ impl PredicateBuilder {
     pub fn field_columns(mut self, columns: Vec<String>) -> Self {
         // We need to distinguish predicates like `column_name In
         // (foo, bar)` and `column_name = foo and column_name = bar` in order to handle this
-        assert!(
-            self.inner.field_columns.is_none(),
-            "Multiple table predicate specification not yet supported"
-        );
+        if !self.inner.field_columns.is_none() {
+            unimplemented!("Complex/Multi field predicates are not yet supported");
+        }
 
         let column_names = columns.into_iter().collect::<BTreeSet<_>>();
         self.inner.field_columns = Some(column_names);

--- a/query/src/predicate.rs
+++ b/query/src/predicate.rs
@@ -146,7 +146,7 @@ impl PredicateBuilder {
     pub fn field_columns(mut self, columns: Vec<String>) -> Self {
         // We need to distinguish predicates like `column_name In
         // (foo, bar)` and `column_name = foo and column_name = bar` in order to handle this
-        if !self.inner.field_columns.is_none() {
+        if self.inner.field_columns.is_some() {
             unimplemented!("Complex/Multi field predicates are not yet supported");
         }
 

--- a/query/src/predicate.rs
+++ b/query/src/predicate.rs
@@ -48,7 +48,7 @@ pub struct Predicate {
     /// to only tables whose names are in `table_names`
     pub table_names: Option<BTreeSet<String>>,
 
-    // Optional field restriction. If present, restrict the results to only
+    // Optional field restriction. If present, restricts the results to only
     // tables which have *at least one* of the fields in field_columns.
     pub field_columns: Option<BTreeSet<String>>,
 
@@ -86,7 +86,7 @@ impl From<Predicate> for PredicateBuilder {
 impl PredicateBuilder {
     /// Sets the timestamp range
     pub fn timestamp_range(mut self, start: i64, end: i64) -> Self {
-        // without more thought, redefining the timestamp range would
+        // Without more thought, redefining the timestamp range would
         // lose the old range. Asser that that cannot happen.
         assert!(
             self.inner.range.is_none(),
@@ -98,7 +98,7 @@ impl PredicateBuilder {
 
     /// sets the optional timestamp range, if any
     pub fn timestamp_range_option(mut self, range: Option<TimestampRange>) -> Self {
-        // without more thought, redefining the timestamp range would
+        // Without more thought, redefining the timestamp range would
         // lose the old range. Asser that that cannot happen.
         assert!(
             range.is_none() || self.inner.range.is_none(),

--- a/src/server/rpc/service.rs
+++ b/src/server/rpc/service.rs
@@ -885,7 +885,7 @@ where
 
     // Map the resulting collection of Strings into a Vec<Vec<u8>>for return
     let values = tag_keys_to_byte_vecs(tag_keys);
-    // Debugging help: comment this out to see what is coming back
+    // Debugging help: uncomment this out to see what is coming back
     // info!("Returning tag keys");
     // values.iter().for_each(|k| info!("  {}", String::from_utf8_lossy(k)));
 

--- a/write_buffer/src/column.rs
+++ b/write_buffer/src/column.rs
@@ -232,6 +232,11 @@ impl Column {
         }
     }
 
+    /// Return true of this column's type is a Tag
+    pub fn is_tag(&self) -> bool {
+        matches!(self, Self::Tag(..))
+    }
+
     /// Returns true if there exists at least one row idx where this
     /// self[i] is within the range [min_value, max_value). Inclusive
     /// of `start`, exclusive of `end` and where col[i] is non null

--- a/write_buffer/src/database.rs
+++ b/write_buffer/src/database.rs
@@ -406,7 +406,7 @@ impl TSDatabase for Db {
             let partition_predicate = partition.compile_predicate(&predicate)?;
             // this doesn't seem to make any sense
             assert!(
-                partition_predicate.field_restriction.is_none(),
+                partition_predicate.field_name_predicate.is_none(),
                 "Column selection for table names not supported"
             );
 


### PR DESCRIPTION
Closes  https://github.com/influxdata/influxdb_iox/issues/518 (by removing the `assert!`, 😆 ).

When I first wrote this code, my mind wasn't prepared to comprehend what a metadata query (e.g. `tag_keys` or `tag_values`) with a field list meant, so I left an `assert!` rather than trying to figure it out then.

Now that I am older, wiser, and have had a chance to study the existing Go code more, I believe the field restrictions will work as intended here, and have clarified the comments in the code with my new found understanding

I also added a test and fixed a bug (that field restrictions were also being applied to tag columns) that it discovered. 