### PR TITLE
chore: add debug symbols to benchmarks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,9 @@ members = [
 [profile.release]
 debug = true
 
+[profile.bench]
+debug = true
+
 [dependencies]
 data_types = { path = "data_types" }
 arrow_deps = { path = "arrow_deps" }


### PR DESCRIPTION
This makes it easier to do visualise profiles when running benchmarks.