### PR TITLE
feat: Implement write buffer to Parquet snapshotting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -325,9 +325,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.65"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95752358c8f7552394baf48cd82695b345628ad3f170d607de3ca03b8dacca15"
+checksum = "4c0496836a84f8d0495758516b8621a622beb77c0fed418570e50764093ced48"
 dependencies = [
  "jobserver",
 ]
@@ -410,28 +410,6 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
-]
-
-[[package]]
-name = "cluster"
-version = "0.1.0"
-dependencies = [
- "arrow_deps",
- "async-trait",
- "bytes",
- "chrono",
- "data_types",
- "futures",
- "generated_types",
- "influxdb_line_protocol",
- "object_store",
- "query",
- "serde",
- "serde_json",
- "snafu",
- "tokio",
- "tracing",
- "write_buffer",
 ]
 
 [[package]]
@@ -573,9 +551,9 @@ dependencies = [
  "cfg-if 1.0.0",
  "crossbeam-channel 0.5.0",
  "crossbeam-deque 0.8.0",
- "crossbeam-epoch 0.9.0",
- "crossbeam-queue 0.3.0",
- "crossbeam-utils 0.8.0",
+ "crossbeam-epoch 0.9.1",
+ "crossbeam-queue 0.3.1",
+ "crossbeam-utils 0.8.1",
 ]
 
 [[package]]
@@ -595,7 +573,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dca26ee1f8d361640700bde38b2c37d8c22b3ce2d360e1fc1c74ea4b0aa7d775"
 dependencies = [
  "cfg-if 1.0.0",
- "crossbeam-utils 0.8.0",
+ "crossbeam-utils 0.8.1",
 ]
 
 [[package]]
@@ -616,8 +594,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94af6efb46fef72616855b036a624cf27ba656ffc9be1b9a3c931cfc7749a9a9"
 dependencies = [
  "cfg-if 1.0.0",
- "crossbeam-epoch 0.9.0",
- "crossbeam-utils 0.8.0",
+ "crossbeam-epoch 0.9.1",
+ "crossbeam-utils 0.8.1",
 ]
 
 [[package]]
@@ -631,21 +609,21 @@ dependencies = [
  "crossbeam-utils 0.7.2",
  "lazy_static",
  "maybe-uninit",
- "memoffset",
+ "memoffset 0.5.6",
  "scopeguard",
 ]
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0f606a85340376eef0d6d8fec399e6d4a544d648386c6645eb6d0653b27d9f"
+checksum = "a1aaa739f95311c2c7887a76863f500026092fb1dce0161dab577e559ef3569d"
 dependencies = [
  "cfg-if 1.0.0",
  "const_fn",
- "crossbeam-utils 0.8.0",
+ "crossbeam-utils 0.8.1",
  "lazy_static",
- "memoffset",
+ "memoffset 0.6.1",
  "scopeguard",
 ]
 
@@ -662,12 +640,12 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-queue"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b2a58563f049aa3bae172bc4120f093b5901161c629f280a1f40ba55317d774"
+checksum = "0f6cb3c7f5b8e51bc3ebb73a2327ad4abdbd119dc13223f14f961d2f38486756"
 dependencies = [
  "cfg-if 1.0.0",
- "crossbeam-utils 0.8.0",
+ "crossbeam-utils 0.8.1",
 ]
 
 [[package]]
@@ -683,13 +661,12 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec91540d98355f690a86367e566ecad2e9e579f230230eb7c21398372be73ea5"
+checksum = "02d96d1e189ef58269ebe5b97953da3274d83a93af647c2ddd6f9dab28cedb8d"
 dependencies = [
  "autocfg",
  "cfg-if 1.0.0",
- "const_fn",
  "lazy_static",
 ]
 
@@ -705,9 +682,9 @@ dependencies = [
 
 [[package]]
 name = "csv"
-version = "1.1.4"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc4666154fd004af3fd6f1da2e81a96fd5a81927fe8ddb6ecc79e2aa6e138b54"
+checksum = "f9d58633299b24b515ac72a3f869f8b91306a3cec616a602843a383acd6f9e97"
 dependencies = [
  "bstr",
  "csv-core",
@@ -1367,6 +1344,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded 0.7.0",
+ "server",
  "snafu",
  "tempfile",
  "test_helpers",
@@ -1476,9 +1454,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.45"
+version = "0.3.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca059e81d9486668f12d455a4ea6daa600bd408134cd17e3d3fb5a32d1f016f8"
+checksum = "cf3d7383929f7c9c7c2d0fa596f325832df98c3704f2c60553080f7127a58175"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1633,6 +1611,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "memoffset"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "157b4208e3059a8f9e78d559edc658e13df41410cb3ae03979c83130067fdd87"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1660,9 +1647,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.6.22"
+version = "0.6.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fce347092656428bc8eaf6201042cb551b8d67855af7374542a92a0fbfcac430"
+checksum = "4afd66f5b91bf2a3bc13fad0e21caedac168ca4c707504e75585648ae80e4cc4"
 dependencies = [
  "cfg-if 0.1.10",
  "fuchsia-zircon",
@@ -1671,7 +1658,7 @@ dependencies = [
  "kernel32-sys",
  "libc",
  "log",
- "miow 0.2.1",
+ "miow 0.2.2",
  "net2",
  "slab",
  "winapi 0.2.8",
@@ -1702,9 +1689,9 @@ dependencies = [
 
 [[package]]
 name = "miow"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919"
+checksum = "ebd808424166322d4a38da87083bfddd3ac4c131334ed55856112eb06d46944d"
 dependencies = [
  "kernel32-sys",
  "net2",
@@ -1766,9 +1753,9 @@ dependencies = [
 
 [[package]]
 name = "net2"
-version = "0.2.35"
+version = "0.2.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ebc3ec692ed7c9a255596c67808dee269f64655d8baf7b4f0638e51ba1d6853"
+checksum = "d7cf75f38f16cb05ea017784dc6dbfd354f76c223dba37701734c4f5a9337d02"
 dependencies = [
  "cfg-if 0.1.10",
  "libc",
@@ -2394,7 +2381,7 @@ checksum = "9ab346ac5921dc62ffa9f89b7a773907511cdfa5490c572ae9be1be33e8afa4a"
 dependencies = [
  "crossbeam-channel 0.5.0",
  "crossbeam-deque 0.8.0",
- "crossbeam-utils 0.8.0",
+ "crossbeam-utils 0.8.1",
  "lazy_static",
  "num_cpus",
 ]
@@ -2491,9 +2478,9 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.16.17"
+version = "0.16.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5911690c9b773bab7e657471afc207f3827b249a657241327e3544d79bcabdd"
+checksum = "024a1e66fea74c66c66624ee5622a7ff0e4b73a13b4f5c326ddb50c708944226"
 dependencies = [
  "cc",
  "libc",
@@ -2600,7 +2587,7 @@ dependencies = [
  "base64 0.13.0",
  "blake2b_simd",
  "constant_time_eq",
- "crossbeam-utils 0.8.0",
+ "crossbeam-utils 0.8.1",
 ]
 
 [[package]]
@@ -2756,9 +2743,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.59"
+version = "1.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcac07dbffa1c65e7f816ab9eba78eb142c6d44410f4eeba1e26e4f5dfa56b95"
+checksum = "1500e84d27fe482ed1dc791a56eddc2f230046a040fa908c08bda1d9fb615779"
 dependencies = [
  "indexmap",
  "itoa",
@@ -2788,6 +2775,29 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "server"
+version = "0.1.0"
+dependencies = [
+ "arrow_deps",
+ "async-trait",
+ "bytes",
+ "chrono",
+ "data_types",
+ "futures",
+ "generated_types",
+ "influxdb_line_protocol",
+ "object_store",
+ "query",
+ "serde",
+ "serde_json",
+ "snafu",
+ "tokio",
+ "tracing",
+ "uuid",
+ "write_buffer",
 ]
 
 [[package]]
@@ -2848,9 +2858,9 @@ checksum = "7acad6f34eb9e8a259d3283d1e8c1d34d7415943d4895f65cc73813c7396fc85"
 
 [[package]]
 name = "snafu"
-version = "0.6.9"
+version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c4e6046e4691afe918fd1b603fd6e515bcda5388a1092a9edbada307d159f09"
+checksum = "eab12d3c261b2308b0d80c26fffb58d17eba81a4be97890101f416b478c79ca7"
 dependencies = [
  "doc-comment",
  "futures-core",
@@ -2860,9 +2870,9 @@ dependencies = [
 
 [[package]]
 name = "snafu-derive"
-version = "0.6.9"
+version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7073448732a89f2f3e6581989106067f403d378faeafb4a50812eb814170d3e5"
+checksum = "1508efa03c362e23817f96cde18abed596a25219a8b2c66e8db33c03543d315b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2991,9 +3001,9 @@ checksum = "2d67a5a62ba6e01cb2192ff309324cb4875d0c451d55fe2319433abe7a05a8ee"
 
 [[package]]
 name = "syn"
-version = "1.0.51"
+version = "1.0.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b4f34193997d92804d359ed09953e25d5138df6bcc055a71bf68ee89fdf9223"
+checksum = "8833e20724c24de12bbaba5ad230ea61c3eafb05b881c7c9d3cfe8638b187e68"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3568,6 +3578,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "936e4b492acfd135421d8dca4b1aa80a7bfc26e702ef3af710e0752684df5372"
 
 [[package]]
+name = "uuid"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fde2f6a4bea1d6e007c4ad38c6839fa71cbb63b6dbf5b595aa38dc9b1093c11"
+dependencies = [
+ "rand",
+ "serde",
+]
+
+[[package]]
 name = "vcpkg"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3648,11 +3668,11 @@ checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.68"
+version = "0.2.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ac64ead5ea5f05873d7c12b545865ca2b8d28adfc50a49b84770a3a97265d42"
+checksum = "3cd364751395ca0f68cafb17666eee36b63077fb5ecd972bbcd74c90c4bf736e"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "serde",
  "serde_json",
  "wasm-bindgen-macro",
@@ -3660,9 +3680,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.68"
+version = "0.2.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f22b422e2a757c35a73774860af8e112bff612ce6cb604224e8e47641a9e4f68"
+checksum = "1114f89ab1f4106e5b55e688b828c0ab0ea593a1ea7c094b141b14cbaaec2d62"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -3675,11 +3695,11 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.18"
+version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7866cab0aa01de1edf8b5d7936938a7e397ee50ce24119aef3e1eaa3b6171da"
+checksum = "1fe9756085a84584ee9457a002b7cdfe0bfff169f45d2591d8be1345a6780e35"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "js-sys",
  "wasm-bindgen",
  "web-sys",
@@ -3687,9 +3707,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.68"
+version = "0.2.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b13312a745c08c469f0b292dd2fcd6411dba5f7160f593da6ef69b64e407038"
+checksum = "7a6ac8995ead1f084a8dea1e65f194d0973800c7f571f6edd70adf06ecf77084"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3697,9 +3717,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.68"
+version = "0.2.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f249f06ef7ee334cc3b8ff031bfc11ec99d00f34d86da7498396dc1e3b1498fe"
+checksum = "b5a48c72f299d80557c7c62e37e7225369ecc0c963964059509fbafe917c7549"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3710,15 +3730,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.68"
+version = "0.2.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d649a3145108d7d3fbcde896a468d1bd636791823c9921135218ad89be08307"
+checksum = "7e7811dd7f9398f14cc76efd356f98f03aa30419dea46aa810d71e819fc97158"
 
 [[package]]
 name = "wasm-bindgen-test"
-version = "0.3.18"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34d1cdc8b98a557f24733d50a1199c4b0635e465eecba9c45b214544da197f64"
+checksum = "0355fa0c1f9b792a09b6dcb6a8be24d51e71e6d74972f9eb4a44c4c004d24a25"
 dependencies = [
  "console_error_panic_hook",
  "js-sys",
@@ -3730,9 +3750,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-test-macro"
-version = "0.3.18"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8fb9c67be7439ee8ab1b7db502a49c05e51e2835b66796c705134d9b8e1a585"
+checksum = "27e07b46b98024c2ba2f9e83a10c2ef0515f057f2da299c1762a2017de80438b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3740,9 +3760,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.45"
+version = "0.3.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bf6ef87ad7ae8008e15a355ce696bed26012b7caa21605188cfd8214ab51e2d"
+checksum = "222b1ef9334f92a21d3fb53dc3fd80f30836959a90f9274a626d7e06315ba3c3"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ object_store = { path = "object_store" }
 query = { path = "query" }
 influxdb_tsm = { path = "influxdb_tsm" }
 wal = { path = "wal" }
+server = { path = "server" }
 
 bytes = "0.5.4"
 hyper = "0.13"

--- a/data_types/src/partition_metadata.rs
+++ b/data_types/src/partition_metadata.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 
 /// Describes the schema, summary statistics for each column in each table and the location of
 /// the partition in storage.
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, PartialEq)]
 pub struct Partition {
     /// The identifier for the partition, the partition key computed from PartitionRules
     pub key: String,
@@ -16,14 +16,14 @@ pub struct Partition {
 }
 
 /// Metadata and statistics information for a table.
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, PartialEq)]
 pub struct Table {
     pub name: String,
     pub columns: Vec<Column>,
 }
 
 /// Statistics and type information for a column.
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, PartialEq)]
 pub enum Column {
     I64(Statistics<i64>),
     U64(Statistics<u64>),
@@ -33,7 +33,7 @@ pub enum Column {
 }
 
 /// Summary statistics for a column.
-#[derive(Debug, Deserialize, Serialize, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
 pub struct Statistics<T: PartialEq + PartialOrd + Debug + Display + Clone> {
     pub min: T,
     pub max: T,

--- a/object_store/Cargo.toml
+++ b/object_store/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 [dependencies]
 bytes = "0.5.4"
 futures = "0.3.5"
-snafu = { version = "0.6.6", features = ["futures"] }
+snafu = { version = "0.6.10", features = ["futures"] }
 
 # Amazon S3 integration
 rusoto_core = "0.44.0"

--- a/object_store/src/lib.rs
+++ b/object_store/src/lib.rs
@@ -491,15 +491,25 @@ impl File {
         );
 
         let path = self.path(location);
-        if let Some(parent) = path.parent() {
-            fs::create_dir_all(&parent)
-                .await
-                .context(UnableToCreateDir { path: parent })?;
-        }
 
-        let mut file = fs::File::create(&path)
-            .await
-            .context(UnableToCreateFile { path })?;
+        let mut file = match fs::File::create(&path).await {
+            Ok(f) => f,
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => match path.parent() {
+                Some(parent) => {
+                    fs::create_dir_all(&parent)
+                        .await
+                        .context(UnableToCreateDir { path: parent })?;
+
+                    match fs::File::create(&path).await {
+                        Ok(f) => f,
+                        Err(err) => return UnableToCreateFile { path, err }.fail(),
+                    }
+                }
+                None => return UnableToCreateFile { path, err }.fail(),
+            },
+            Err(err) => return UnableToCreateFile { path, err }.fail(),
+        };
+
         tokio::io::copy(&mut &content[..], &mut file)
             .await
             .context(UnableToCopyDataToFile)?;
@@ -653,9 +663,9 @@ enum InternalError {
     },
     NoDataInMemory,
 
-    #[snafu(display("Unable to create file {}: {}", path.display(), source))]
+    #[snafu(display("Unable to create file {}: {}", path.display(), err))]
     UnableToCreateFile {
-        source: io::Error,
+        err: io::Error,
         path: PathBuf,
     },
     #[snafu(display("Unable to create dir {}: {}", path.display(), source))]
@@ -899,6 +909,34 @@ mod tests {
                     actual: 11,
                 },
             );
+
+            Ok(())
+        }
+
+        #[tokio::test]
+        async fn creates_dir_if_not_present() -> Result<()> {
+            let root = TempDir::new()?;
+            let storage = ObjectStore::new_file(File::new(root.path()));
+
+            let data = Bytes::from("arbitrary data");
+            let location = "nested/file/test_file";
+
+            let stream_data = std::io::Result::Ok(data.clone());
+            storage
+                .put(
+                    location,
+                    futures::stream::once(async move { stream_data }),
+                    data.len(),
+                )
+                .await?;
+
+            let read_data = storage
+                .get(location)
+                .await?
+                .map_ok(|b| bytes::BytesMut::from(&b[..]))
+                .try_concat()
+                .await?;
+            assert_eq!(&*read_data, data);
 
             Ok(())
         }

--- a/object_store/src/lib.rs
+++ b/object_store/src/lib.rs
@@ -491,6 +491,12 @@ impl File {
         );
 
         let path = self.path(location);
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(&parent)
+                .await
+                .context(UnableToCreateDir { path: parent })?;
+        }
+
         let mut file = fs::File::create(&path)
             .await
             .context(UnableToCreateFile { path })?;
@@ -649,6 +655,11 @@ enum InternalError {
 
     #[snafu(display("Unable to create file {}: {}", path.display(), source))]
     UnableToCreateFile {
+        source: io::Error,
+        path: PathBuf,
+    },
+    #[snafu(display("Unable to create dir {}: {}", path.display(), source))]
+    UnableToCreateDir {
         source: io::Error,
         path: PathBuf,
     },

--- a/query/src/lib.rs
+++ b/query/src/lib.rs
@@ -122,13 +122,6 @@ pub trait SQLDatabase: Debug + Send + Sync {
         columns: &[&str],
     ) -> Result<Vec<RecordBatch>, Self::Error>;
 
-    /// Return the partition metadata with the arrow data
-    async fn partition_table_to_arrow_with_meta(
-        &self,
-        table_name: &str,
-        partition_key: &str,
-    ) -> Result<(RecordBatch, data_types::partition_metadata::Table), Self::Error>;
-
     /// Return the partition keys for data in this DB
     async fn partition_keys(&self) -> Result<Vec<String>, Self::Error>;
 

--- a/query/src/lib.rs
+++ b/query/src/lib.rs
@@ -46,7 +46,7 @@ use self::predicate::{Predicate, TimestampRange};
 #[async_trait]
 pub trait TSDatabase: Debug + Send + Sync {
     /// the type of partition that is stored by this database
-    type Partition: Send + Sync + 'static + Partition;
+    type Partition: Send + Sync + 'static + PartitionChunk;
     type Error: std::error::Error + Send + Sync + 'static;
 
     /// writes parsed lines into this database
@@ -108,7 +108,7 @@ pub trait TSDatabase: Debug + Send + Sync {
 #[async_trait]
 pub trait SQLDatabase: Debug + Send + Sync {
     /// the type of partition that is stored by this database
-    type Partition: Send + Sync + 'static + Partition;
+    type Partition: Send + Sync + 'static + PartitionChunk;
     type Error: std::error::Error + Send + Sync + 'static;
 
     /// Execute the specified query and return arrow record batches with the result
@@ -146,7 +146,7 @@ pub trait SQLDatabase: Debug + Send + Sync {
 }
 
 /// Collection of data that shares the same partition key
-pub trait Partition: Debug + Send + Sync {
+pub trait PartitionChunk: Debug + Send + Sync {
     type Error: std::error::Error + Send + Sync + 'static;
 
     /// returns the partition key

--- a/query/src/lib.rs
+++ b/query/src/lib.rs
@@ -7,7 +7,7 @@
 
 use arrow_deps::arrow::record_batch::RecordBatch;
 use async_trait::async_trait;
-use data_types::data::ReplicatedWrite;
+use data_types::{data::ReplicatedWrite, partition_metadata::Table as TableStats};
 use exec::{FieldListPlan, SeriesSetPlans, StringSetPlan};
 use influxdb_line_protocol::ParsedLine;
 
@@ -45,6 +45,8 @@ use self::predicate::{Predicate, TimestampRange};
 /// categories are treated differently in the different query types.
 #[async_trait]
 pub trait TSDatabase: Debug + Send + Sync {
+    /// the type of partition that is stored by this database
+    type Partition: Send + Sync + 'static + Partition;
     type Error: std::error::Error + Send + Sync + 'static;
 
     /// writes parsed lines into this database
@@ -105,10 +107,60 @@ pub trait TSDatabase: Debug + Send + Sync {
 
 #[async_trait]
 pub trait SQLDatabase: Debug + Send + Sync {
+    /// the type of partition that is stored by this database
+    type Partition: Send + Sync + 'static + Partition;
     type Error: std::error::Error + Send + Sync + 'static;
 
     /// Execute the specified query and return arrow record batches with the result
     async fn query(&self, query: &str) -> Result<Vec<RecordBatch>, Self::Error>;
+
+    /// Fetch the specified table names and columns as Arrow
+    /// RecordBatches. Columns are returned in the order specified.
+    async fn table_to_arrow(
+        &self,
+        table_name: &str,
+        columns: &[&str],
+    ) -> Result<Vec<RecordBatch>, Self::Error>;
+
+    /// Return the partition metadata with the arrow data
+    async fn partition_table_to_arrow_with_meta(
+        &self,
+        table_name: &str,
+        partition_key: &str,
+    ) -> Result<(RecordBatch, data_types::partition_metadata::Table), Self::Error>;
+
+    /// Return the partition keys for data in this DB
+    async fn partition_keys(&self) -> Result<Vec<String>, Self::Error>;
+
+    /// Return the table names that are in a given partition key
+    async fn table_names_for_partition(
+        &self,
+        partition_key: &str,
+    ) -> Result<Vec<String>, Self::Error>;
+
+    /// Removes the partition from the database and returns it
+    async fn remove_partition(
+        &self,
+        partition_key: &str,
+    ) -> Result<Arc<Self::Partition>, Self::Error>;
+}
+
+/// Collection of data that shares the same partition key
+pub trait Partition: Debug + Send + Sync {
+    type Error: std::error::Error + Send + Sync + 'static;
+
+    /// returns the partition key
+    fn key(&self) -> &str;
+
+    /// returns the partition metadata stats for every table in the partition
+    fn table_stats(&self) -> Result<Vec<TableStats>, Self::Error>;
+
+    /// converts the table to an Arrow RecordBatch
+    fn table_to_arrow(
+        &self,
+        table_name: &str,
+        columns: &[&str],
+    ) -> Result<RecordBatch, Self::Error>;
 }
 
 #[async_trait]

--- a/query/src/test.rs
+++ b/query/src/test.rs
@@ -408,15 +408,6 @@ impl SQLDatabase for TestDatabase {
         unimplemented!("query Not yet implemented");
     }
 
-    /// Return the partition metadata with the arrow data
-    async fn partition_table_to_arrow_with_meta(
-        &self,
-        _table_name: &str,
-        _partition_key: &str,
-    ) -> Result<(RecordBatch, data_types::partition_metadata::Table), Self::Error> {
-        unimplemented!("partition_table_to_arrow_with_meta not yet implemented for test database");
-    }
-
     /// Return the partition keys for data in this DB
     async fn partition_keys(&self) -> Result<Vec<String>, Self::Error> {
         unimplemented!("partition_keys not yet implemented for test database");
@@ -427,7 +418,7 @@ impl SQLDatabase for TestDatabase {
         &self,
         _partition_key: &str,
     ) -> Result<Vec<String>, Self::Error> {
-        unimplemented!("table_names_for_partitino not yet implemented for test database");
+        unimplemented!("table_names_for_partition not yet implemented for test database");
     }
 
     async fn remove_partition(

--- a/query/src/test.rs
+++ b/query/src/test.rs
@@ -10,7 +10,7 @@ use crate::{
         stringset::{StringSet, StringSetRef},
         SeriesSetPlans, StringSetPlan,
     },
-    DatabaseStore, Predicate, SQLDatabase, TSDatabase, TimestampRange,
+    DatabaseStore, Partition, Predicate, SQLDatabase, TSDatabase, TimestampRange,
 };
 
 use data_types::data::ReplicatedWrite;
@@ -246,6 +246,7 @@ fn predicate_to_test_string(predicate: &Predicate) -> String {
 
 #[async_trait]
 impl TSDatabase for TestDatabase {
+    type Partition = TestPartition;
     type Error = TestError;
 
     /// Writes parsed lines into this database
@@ -399,11 +400,74 @@ impl TSDatabase for TestDatabase {
 
 #[async_trait]
 impl SQLDatabase for TestDatabase {
+    type Partition = TestPartition;
     type Error = TestError;
 
     /// Execute the specified query and return arrow record batches with the result
     async fn query(&self, _query: &str) -> Result<Vec<RecordBatch>, Self::Error> {
         unimplemented!("query Not yet implemented");
+    }
+
+    /// Return the partition metadata with the arrow data
+    async fn partition_table_to_arrow_with_meta(
+        &self,
+        _table_name: &str,
+        _partition_key: &str,
+    ) -> Result<(RecordBatch, data_types::partition_metadata::Table), Self::Error> {
+        unimplemented!("partition_table_to_arrow_with_meta not yet implemented for test database");
+    }
+
+    /// Return the partition keys for data in this DB
+    async fn partition_keys(&self) -> Result<Vec<String>, Self::Error> {
+        unimplemented!("partition_keys not yet implemented for test database");
+    }
+
+    /// Return the table names that are in a given partition key
+    async fn table_names_for_partition(
+        &self,
+        _partition_key: &str,
+    ) -> Result<Vec<String>, Self::Error> {
+        unimplemented!("table_names_for_partitino not yet implemented for test database");
+    }
+
+    async fn remove_partition(
+        &self,
+        _partition_key: &str,
+    ) -> Result<Arc<Self::Partition>, Self::Error> {
+        unimplemented!()
+    }
+
+    /// Fetch the specified table names and columns as Arrow
+    /// RecordBatches. Columns are returned in the order specified.
+    async fn table_to_arrow(
+        &self,
+        _table_name: &str,
+        _columns: &[&str],
+    ) -> Result<Vec<RecordBatch>, Self::Error> {
+        unimplemented!()
+    }
+}
+
+#[derive(Debug)]
+pub struct TestPartition {}
+
+impl Partition for TestPartition {
+    type Error = TestError;
+
+    fn key(&self) -> &str {
+        unimplemented!()
+    }
+
+    fn table_stats(&self) -> Result<Vec<data_types::partition_metadata::Table>, Self::Error> {
+        unimplemented!()
+    }
+
+    fn table_to_arrow(
+        &self,
+        _table_name: &str,
+        _columns: &[&str],
+    ) -> Result<RecordBatch, Self::Error> {
+        unimplemented!()
     }
 }
 

--- a/query/src/test.rs
+++ b/query/src/test.rs
@@ -10,7 +10,7 @@ use crate::{
         stringset::{StringSet, StringSetRef},
         SeriesSetPlans, StringSetPlan,
     },
-    DatabaseStore, Partition, Predicate, SQLDatabase, TSDatabase, TimestampRange,
+    DatabaseStore, PartitionChunk, Predicate, SQLDatabase, TSDatabase, TimestampRange,
 };
 
 use data_types::data::ReplicatedWrite;
@@ -451,7 +451,7 @@ impl SQLDatabase for TestDatabase {
 #[derive(Debug)]
 pub struct TestPartition {}
 
-impl Partition for TestPartition {
+impl PartitionChunk for TestPartition {
     type Error = TestError;
 
     fn key(&self) -> &str {

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "cluster"
+name = "server"
 version = "0.1.0"
 authors = ["pauldix <paul@pauldix.net>"]
 edition = "2018"
@@ -23,3 +23,4 @@ arrow_deps = { path = "../arrow_deps" }
 futures = "0.3.7"
 bytes = "0.5"
 chrono = "0.4"
+uuid = { version = "0.8", features = ["serde", "v4"]}

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -64,3 +64,4 @@
 
 pub mod buffer;
 pub mod server;
+pub mod snapshot;

--- a/server/src/snapshot.rs
+++ b/server/src/snapshot.rs
@@ -1,0 +1,307 @@
+use arrow_deps::{
+    arrow::record_batch::RecordBatch,
+    parquet::{arrow::ArrowWriter, file::writer::TryClone},
+};
+/// This module contains code for snapshotting a database partition to Parquet files in object
+/// storage.
+use data_types::partition_metadata::{Partition as PartitionMeta, Table};
+use object_store::ObjectStore;
+use query::Partition;
+
+use std::io::{Cursor, Seek, SeekFrom, Write};
+use std::sync::{Arc, Mutex};
+
+use bytes::Bytes;
+use snafu::{OptionExt, ResultExt, Snafu};
+use tokio::sync::oneshot;
+use uuid::Uuid;
+
+#[derive(Debug, Snafu)]
+pub enum Error {
+    #[snafu(display("Partition error creating snapshot: {}", source))]
+    PartitionError {
+        source: write_buffer::partition::Error,
+    },
+
+    #[snafu(display("Table not found running: {}", table))]
+    TableNotFound { table: usize },
+
+    #[snafu(display("Error generating json response: {}", source))]
+    JsonGenerationError { source: serde_json::Error },
+}
+
+pub type Result<T, E = Error> = std::result::Result<T, E>;
+
+#[derive(Debug)]
+pub struct Snapshot {
+    pub id: Uuid,
+    pub partition_meta: PartitionMeta,
+    status: Mutex<Status>,
+}
+
+impl Snapshot {
+    fn new(partition_key: String, tables: Vec<Table>) -> Self {
+        let remaining_tables: Vec<_> = (0..tables.len()).collect();
+        let status = Status {
+            remaining_tables,
+            ..Default::default()
+        };
+
+        Self {
+            id: Uuid::new_v4(),
+            partition_meta: PartitionMeta {
+                key: partition_key,
+                tables,
+            },
+            status: Mutex::new(status),
+        }
+    }
+
+    fn next_table(&self) -> Option<(usize, &str)> {
+        let mut status = self.status.lock().expect("mutex poisoned");
+        match status.next_table_position() {
+            Some(pos) => Some((pos, &self.partition_meta.tables[pos].name)),
+            None => None,
+        }
+    }
+
+    fn mark_table_finished(&self, table_position: usize) -> Result<()> {
+        let mut status = self.status.lock().expect("mutex poisoned");
+        status.mark_table_finished(table_position)
+    }
+
+    fn mark_meta_written(&self) {
+        let mut status = self.status.lock().expect("mutex poisoned");
+        status.meta_written = true;
+    }
+
+    pub fn finished(&self) -> bool {
+        self.status.lock().expect("mutex poisoned").finished()
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct Status {
+    remaining_tables: Vec<usize>,
+    running_tables: Vec<usize>,
+    finished_tables: Vec<usize>,
+    meta_written: bool,
+    stop_on_next_update: bool,
+    errors: Vec<Error>,
+}
+
+impl Status {
+    fn next_table_position(&mut self) -> Option<usize> {
+        self.remaining_tables.pop().map(|pos| {
+            self.running_tables.push(pos);
+            pos
+        })
+    }
+
+    fn mark_table_finished(&mut self, position: usize) -> Result<()> {
+        let pos = self
+            .running_tables
+            .iter()
+            .position(|t| *t == position)
+            .context(TableNotFound { table: position })?;
+
+        let _ = self.running_tables.remove(pos);
+        self.finished_tables.push(position);
+
+        Ok(())
+    }
+
+    fn finished(&self) -> bool {
+        self.remaining_tables.is_empty() && self.running_tables.is_empty() && self.meta_written
+    }
+}
+
+pub fn snapshot_partition<T: Send + Sync + 'static + Partition>(
+    metadata_path: impl Into<String>,
+    data_path: impl Into<String>,
+    store: Arc<ObjectStore>,
+    partition: Arc<T>,
+    notify: Option<oneshot::Sender<()>>,
+) -> Result<Arc<Snapshot>> {
+    let metadata_path = metadata_path.into();
+    let data_path = data_path.into();
+
+    let table_stats = partition.table_stats().unwrap();
+
+    let snapshot = Snapshot::new(partition.key().to_string(), table_stats);
+    let snapshot = Arc::new(snapshot);
+
+    let return_snapshot = snapshot.clone();
+
+    tokio::spawn(async move {
+        while let Some((pos, table_name)) = snapshot.next_table() {
+            let batch = partition.table_to_arrow(table_name, &[]).unwrap();
+
+            let file_name = format!("{}/{}.parquet", &data_path, table_name);
+
+            write_batch(batch, snapshot.clone(), &file_name, store.clone())
+                .await
+                .unwrap();
+
+            snapshot.mark_table_finished(pos).unwrap();
+        }
+
+        let partition_meta_path = format!("{}/{}.json", &metadata_path, &partition.key());
+        let json_data = serde_json::to_vec(&snapshot.partition_meta)
+            .context(JsonGenerationError)
+            .unwrap();
+        let data = Bytes::from(json_data);
+        let len = data.len();
+        let stream_data = std::io::Result::Ok(data);
+        store
+            .put(
+                &partition_meta_path,
+                futures::stream::once(async move { stream_data }),
+                len,
+            )
+            .await
+            .unwrap();
+
+        snapshot.mark_meta_written();
+
+        if let Some(notify) = notify {
+            // TODO: log this error only to the log
+            let _ = notify.send(());
+        }
+    });
+
+    Ok(return_snapshot)
+}
+
+async fn write_batch(
+    batch: RecordBatch,
+    _snapshot: Arc<Snapshot>,
+    file_name: &str,
+    store: Arc<ObjectStore>,
+) -> Result<()> {
+    let mem_writer = MemWriter::default();
+    {
+        let mut writer = ArrowWriter::try_new(mem_writer.clone(), batch.schema(), None).unwrap();
+        writer.write(&batch).unwrap();
+        writer.close().unwrap();
+    } // drop the reference to the MemWriter that the SerializedFileWriter has
+
+    let data = mem_writer
+        .into_inner()
+        .expect("Nothing else should have a reference here");
+
+    let len = data.len();
+    let data = Bytes::from(data);
+    let stream_data = std::io::Result::Ok(data);
+
+    store
+        .put(
+            &file_name,
+            futures::stream::once(async move { stream_data }),
+            len,
+        )
+        .await
+        .unwrap();
+
+    Ok(())
+}
+
+#[derive(Debug, Default, Clone)]
+struct MemWriter {
+    mem: Arc<Mutex<Cursor<Vec<u8>>>>,
+}
+
+impl MemWriter {
+    /// Returns the inner buffer as long as there are no other references to the Arc.
+    pub fn into_inner(self) -> Option<Vec<u8>> {
+        Arc::try_unwrap(self.mem)
+            .ok()
+            .and_then(|mutex| mutex.into_inner().ok())
+            .map(|cursor| cursor.into_inner())
+    }
+}
+
+impl Write for MemWriter {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        let mut inner = self.mem.lock().unwrap();
+        inner.write(buf)
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        let mut inner = self.mem.lock().unwrap();
+        inner.flush()
+    }
+}
+
+impl Seek for MemWriter {
+    fn seek(&mut self, pos: SeekFrom) -> std::io::Result<u64> {
+        let mut inner = self.mem.lock().unwrap();
+        inner.seek(pos)
+    }
+}
+
+impl TryClone for MemWriter {
+    fn try_clone(&self) -> std::io::Result<Self> {
+        Ok(Self {
+            mem: self.mem.clone(),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use data_types::data::lines_to_replicated_write;
+    use data_types::database_rules::DatabaseRules;
+    use futures::TryStreamExt;
+    use influxdb_line_protocol::parse_lines;
+    use object_store::InMemory;
+    use write_buffer::partition::Partition as PartitionWB;
+
+    #[tokio::test]
+    async fn snapshot() {
+        let lp = r#"
+cpu,host=A,region=west user=23.2,system=55.1 1
+cpu,host=A,region=west user=3.2,system=50.1 10
+cpu,host=B,region=east user=10.0,system=74.1 1
+mem,host=A,region=west used=45 1
+        "#;
+
+        let lines: Vec<_> = parse_lines(lp).map(|l| l.unwrap()).collect();
+        let write = lines_to_replicated_write(1, 1, &lines, &DatabaseRules::default());
+        let mut partition = PartitionWB::new("testaroo");
+
+        for e in write.write_buffer_batch().unwrap().entries().unwrap() {
+            partition.write_entry(&e).unwrap();
+        }
+
+        let store = Arc::new(ObjectStore::new_in_memory(InMemory::new()));
+        let partition = Arc::new(partition);
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        let metadata_path = "/meta";
+        let data_path = "/data";
+
+        let snapshot = snapshot_partition(
+            metadata_path,
+            data_path,
+            store.clone(),
+            partition.clone(),
+            Some(tx),
+        )
+        .unwrap();
+
+        rx.await.unwrap();
+
+        let summary = store
+            .get("/meta/testaroo.json")
+            .await
+            .unwrap()
+            .map_ok(|b| bytes::BytesMut::from(&b[..]))
+            .try_concat()
+            .await
+            .unwrap();
+
+        let meta: PartitionMeta = serde_json::from_slice(&*summary).unwrap();
+        assert_eq!(meta, snapshot.partition_meta);
+    }
+}

--- a/server/src/snapshot.rs
+++ b/server/src/snapshot.rs
@@ -6,7 +6,7 @@ use arrow_deps::{
 /// storage.
 use data_types::partition_metadata::{Partition as PartitionMeta, Table};
 use object_store::ObjectStore;
-use query::Partition;
+use query::PartitionChunk;
 
 use std::io::{Cursor, Seek, SeekFrom, Write};
 use std::sync::{Arc, Mutex};
@@ -116,7 +116,7 @@ pub struct Status {
     errors: Vec<Error>,
 }
 
-pub fn snapshot_partition<T: Send + Sync + 'static + Partition>(
+pub fn snapshot_partition<T: Send + Sync + 'static + PartitionChunk>(
     metadata_path: impl Into<String>,
     data_path: impl Into<String>,
     store: Arc<ObjectStore>,

--- a/src/commands/server.rs
+++ b/src/commands/server.rs
@@ -10,6 +10,7 @@ use crate::server::rpc::service;
 
 use hyper::service::{make_service_fn, service_fn};
 use hyper::Server;
+use object_store::{self, GoogleCloudStorage, ObjectStore};
 use query::exec::Executor as QueryExecutor;
 use write_buffer::{Db, WriteBufferDatabases};
 
@@ -74,6 +75,16 @@ pub async fn main() -> Result<()> {
     debug!("InfluxDB IOx Server using database directory: {:?}", db_dir);
 
     let storage = Arc::new(WriteBufferDatabases::new(&db_dir));
+
+    let object_store = if let Ok(bucket) = std::env::var("INFLUXDB_IOX_GCP_BUCKET") {
+        info!("Using GCP bucket {} for storage", &bucket);
+        ObjectStore::new_google_cloud_storage(GoogleCloudStorage::new(bucket))
+    } else {
+        info!("Using local dir {} for storage", &db_dir);
+        ObjectStore::new_file(object_store::File::new(&db_dir))
+    };
+    let object_storage = Arc::new(object_store);
+
     let dirs = storage
         .wal_dirs()
         .map_err(|e| Box::new(e) as Box<dyn std::error::Error + Send + Sync>)
@@ -87,6 +98,11 @@ pub async fn main() -> Result<()> {
             .context(RestoringWriteBuffer { dir })?;
         storage.add_db(db).await;
     }
+
+    let app_server = Arc::new(http_routes::AppServer {
+        write_buffer: storage.clone(),
+        object_store: object_storage.clone(),
+    });
 
     // Fire up the query executor
     let executor = Arc::new(QueryExecutor::default());
@@ -124,10 +140,10 @@ pub async fn main() -> Result<()> {
     };
 
     let make_svc = make_service_fn(move |_conn| {
-        let storage = storage.clone();
+        let app_server = app_server.clone();
         async move {
             Ok::<_, http::Error>(service_fn(move |req| {
-                let state = storage.clone();
+                let state = app_server.clone();
                 http_routes::service(req, state)
             }))
         }

--- a/src/server/http_routes.rs
+++ b/src/server/http_routes.rs
@@ -120,7 +120,7 @@ pub enum ApplicationError {
     #[snafu(display("No handler for {:?} {}", method, path))]
     RouteNotFound { method: Method, path: String },
 
-    #[snafu(display("Internal error from database {}:  {}", database, source))]
+    #[snafu(display("Internal error from database {}: {}", database, source))]
     DatabaseError {
         database: String,
         source: Box<dyn std::error::Error + Send + Sync>,

--- a/src/server/http_routes.rs
+++ b/src/server/http_routes.rs
@@ -396,6 +396,7 @@ async fn snapshot_partition<T: DatabaseStore>(
     let db_name =
         org_and_bucket_to_database(&snapshot.org, &snapshot.bucket).context(BucketMappingError)?;
 
+    // TODO: refactor the rest of this out of the http route and into the server crate.
     let db = server
         .write_buffer
         .db(&db_name)
@@ -406,7 +407,7 @@ async fn snapshot_partition<T: DatabaseStore>(
         })?;
 
     let metadata_path = format!("{}/meta", &db_name);
-    let data_path = format!("{}/data", &db_name);
+    let data_path = format!("{}/data/{}", &db_name, &snapshot.partition);
     let partition = db.remove_partition(&snapshot.partition).await.unwrap();
     let snapshot = server::snapshot::snapshot_partition(
         metadata_path,

--- a/src/server/http_routes.rs
+++ b/src/server/http_routes.rs
@@ -119,6 +119,18 @@ pub enum ApplicationError {
 
     #[snafu(display("No handler for {:?} {}", method, path))]
     RouteNotFound { method: Method, path: String },
+
+    #[snafu(display("Internal error creating gzip decoder: {:?}", source))]
+    CreatingGzipDecoder { source: std::io::Error },
+
+    #[snafu(display("Internal error from database {}:  {}", database, source))]
+    DatabaseError {
+        database: String,
+        source: Box<dyn std::error::Error + Send + Sync>,
+    },
+
+    #[snafu(display("Error generating json response: {}", source))]
+    JsonGenerationError { source: serde_json::Error },
 }
 
 impl ApplicationError {
@@ -141,6 +153,9 @@ impl ApplicationError {
             Self::ParsingLineProtocol { .. } => StatusCode::BAD_REQUEST,
             Self::ReadingBodyAsGzip { .. } => StatusCode::BAD_REQUEST,
             Self::RouteNotFound { .. } => StatusCode::NOT_FOUND,
+            Self::CreatingGzipDecoder { .. } => StatusCode::INTERNAL_SERVER_ERROR,
+            Self::DatabaseError { .. } => StatusCode::INTERNAL_SERVER_ERROR,
+            Self::JsonGenerationError { .. } => StatusCode::INTERNAL_SERVER_ERROR,
         }
     }
 }
@@ -209,7 +224,7 @@ async fn parse_body(req: hyper::Request<Body>) -> Result<Bytes, ApplicationError
 #[tracing::instrument(level = "debug")]
 async fn write<T: DatabaseStore>(
     req: hyper::Request<Body>,
-    storage: Arc<T>,
+    server: Arc<AppServer<T>>,
 ) -> Result<Option<Body>, ApplicationError> {
     let query = req.uri().query().context(ExpectedQueryString)?;
 
@@ -220,12 +235,13 @@ async fn write<T: DatabaseStore>(
     let db_name = org_and_bucket_to_database(&write_info.org, &write_info.bucket)
         .context(BucketMappingError)?;
 
-    let db = storage
+    let db = server
+        .write_buffer
         .db_or_create(&db_name)
         .await
         .map_err(|e| Box::new(e) as _)
         .context(BucketByName {
-            org: write_info.org.clone(),
+            org: &write_info.org.clone(),
             bucket_name: write_info.bucket.clone(),
         })?;
 
@@ -270,7 +286,7 @@ struct ReadInfo {
 #[tracing::instrument(level = "debug")]
 async fn read<T: DatabaseStore>(
     req: hyper::Request<Body>,
-    storage: Arc<T>,
+    server: Arc<AppServer<T>>,
 ) -> Result<Option<Body>, ApplicationError> {
     let query = req.uri().query().context(ExpectedQueryString {})?;
 
@@ -281,10 +297,14 @@ async fn read<T: DatabaseStore>(
     let db_name = org_and_bucket_to_database(&read_info.org, &read_info.bucket)
         .context(BucketMappingError)?;
 
-    let db = storage.db(&db_name).await.context(BucketNotFound {
-        org: read_info.org.clone(),
-        bucket: read_info.bucket.clone(),
-    })?;
+    let db = server
+        .write_buffer
+        .db(&db_name)
+        .await
+        .context(BucketNotFound {
+            org: read_info.org.clone(),
+            bucket: read_info.bucket.clone(),
+        })?;
 
     let results = db
         .query(&read_info.sql_query)
@@ -308,18 +328,118 @@ fn no_op(name: &str) -> Result<Option<Body>, ApplicationError> {
     Ok(None)
 }
 
+#[derive(Debug)]
+pub struct AppServer<T> {
+    pub write_buffer: Arc<T>,
+    pub object_store: Arc<object_store::ObjectStore>,
+}
+
+#[derive(Deserialize, Debug)]
+/// Arguments in the query string of the request to /partitions
+struct DatabaseInfo {
+    org: String,
+    bucket: String,
+}
+
+#[tracing::instrument(level = "debug")]
+async fn list_partitions<T: DatabaseStore>(
+    req: hyper::Request<Body>,
+    app_server: Arc<AppServer<T>>,
+) -> Result<Option<Body>, ApplicationError> {
+    let query = req.uri().query().context(ExpectedQueryString {})?;
+
+    let info: DatabaseInfo = serde_urlencoded::from_str(query).context(InvalidQueryString {
+        query_string: query,
+    })?;
+
+    let db_name =
+        org_and_bucket_to_database(&info.org, &info.bucket).context(BucketMappingError)?;
+
+    let db = app_server
+        .write_buffer
+        .db(&db_name)
+        .await
+        .context(BucketNotFound {
+            org: &info.org,
+            bucket: &info.bucket,
+        })?;
+
+    let partition_keys = db
+        .partition_keys()
+        .await
+        .map_err(|e| Box::new(e) as _)
+        .context(BucketByName {
+            org: &info.org,
+            bucket_name: &info.bucket,
+        })?;
+
+    let result = serde_json::to_string(&partition_keys).context(JsonGenerationError)?;
+
+    Ok(Some(result.into_bytes().into()))
+}
+
+#[derive(Deserialize, Debug)]
+/// Arguments in the query string of the request to /snapshot
+struct SnapshotInfo {
+    org: String,
+    bucket: String,
+    partition: String,
+}
+
+#[tracing::instrument(level = "debug")]
+async fn snapshot_partition<T: DatabaseStore>(
+    req: hyper::Request<Body>,
+    server: Arc<AppServer<T>>,
+) -> Result<Option<Body>, ApplicationError> {
+    let query = req.uri().query().context(ExpectedQueryString {})?;
+
+    let snapshot: SnapshotInfo = serde_urlencoded::from_str(query).context(InvalidQueryString {
+        query_string: query,
+    })?;
+
+    let db_name =
+        org_and_bucket_to_database(&snapshot.org, &snapshot.bucket).context(BucketMappingError)?;
+
+    let db = server
+        .write_buffer
+        .db(&db_name)
+        .await
+        .context(BucketNotFound {
+            org: &snapshot.org,
+            bucket: &snapshot.bucket,
+        })?;
+
+    let metadata_path = format!("{}/meta", &db_name);
+    let data_path = format!("{}/data", &db_name);
+    let partition = db.remove_partition(&snapshot.partition).await.unwrap();
+    let snapshot = server::snapshot::snapshot_partition(
+        metadata_path,
+        data_path,
+        server.object_store.clone(),
+        partition,
+        None,
+    )
+    .unwrap();
+
+    let ret = format!("{}", snapshot.id);
+    Ok(Some(ret.into_bytes().into()))
+}
+
 pub async fn service<T: DatabaseStore>(
     req: hyper::Request<Body>,
-    storage: Arc<T>,
+    server: Arc<AppServer<T>>,
 ) -> http::Result<hyper::Response<Body>> {
     let method = req.method().clone();
     let uri = req.uri().clone();
 
     let response = match (req.method(), req.uri().path()) {
-        (&Method::POST, "/api/v2/write") => write(req, storage).await,
+        (&Method::POST, "/api/v2/write") => write(req, server).await,
         (&Method::POST, "/api/v2/buckets") => no_op("create bucket"),
         (&Method::GET, "/ping") => ping(req).await,
-        (&Method::GET, "/api/v2/read") => read(req, storage).await,
+        (&Method::GET, "/api/v2/read") => read(req, server).await,
+        // TODO: implement routing to change this API
+        (&Method::GET, "/api/v1/partitions") => list_partitions(req, server).await,
+        (&Method::POST, "/api/v1/snapshot") => snapshot_partition(req, server).await,
         _ => Err(ApplicationError::RouteNotFound {
             method: method.clone(),
             path: uri.to_string(),
@@ -358,6 +478,7 @@ mod tests {
     use hyper::service::{make_service_fn, service_fn};
     use hyper::Server;
 
+    use object_store::{InMemory, ObjectStore};
     use query::{test::TestDatabaseStore, DatabaseStore};
 
     type Error = Box<dyn std::error::Error + Send + Sync + 'static>;
@@ -365,7 +486,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_ping() -> Result<()> {
-        let test_storage = Arc::new(TestDatabaseStore::new());
+        let test_storage = Arc::new(AppServer {
+            write_buffer: Arc::new(TestDatabaseStore::new()),
+            object_store: Arc::new(ObjectStore::new_in_memory(InMemory::new())),
+        });
         let server_url = test_server(test_storage.clone());
 
         let client = Client::new();
@@ -378,7 +502,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_write() -> Result<()> {
-        let test_storage = Arc::new(TestDatabaseStore::new());
+        let test_storage = Arc::new(AppServer {
+            write_buffer: Arc::new(TestDatabaseStore::new()),
+            object_store: Arc::new(ObjectStore::new_in_memory(InMemory::new())),
+        });
         let server_url = test_server(test_storage.clone());
 
         let client = Client::new();
@@ -401,6 +528,7 @@ mod tests {
 
         // Check that the data got into the right bucket
         let test_db = test_storage
+            .write_buffer
             .db("MyOrg_MyBucket")
             .await
             .expect("Database exists");
@@ -420,7 +548,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_gzip_write() -> Result<()> {
-        let test_storage = Arc::new(TestDatabaseStore::new());
+        let test_storage = Arc::new(AppServer {
+            write_buffer: Arc::new(TestDatabaseStore::new()),
+            object_store: Arc::new(ObjectStore::new_in_memory(InMemory::new())),
+        });
         let server_url = test_server(test_storage.clone());
 
         let client = Client::new();
@@ -443,6 +574,7 @@ mod tests {
 
         // Check that the data got into the right bucket
         let test_db = test_storage
+            .write_buffer
             .db("MyOrg_MyBucket")
             .await
             .expect("Database exists");
@@ -479,13 +611,13 @@ mod tests {
 
     /// creates an instance of the http service backed by a in-memory
     /// testable database.  Returns the url of the server
-    fn test_server(storage: Arc<TestDatabaseStore>) -> String {
+    fn test_server(server: Arc<AppServer<TestDatabaseStore>>) -> String {
         let make_svc = make_service_fn(move |_conn| {
-            let storage = storage.clone();
+            let server = server.clone();
             async move {
                 Ok::<_, http::Error>(service_fn(move |req| {
-                    let state = storage.clone();
-                    super::service(req, state)
+                    let server = server.clone();
+                    super::service(req, server)
                 }))
             }
         });

--- a/src/server/http_routes.rs
+++ b/src/server/http_routes.rs
@@ -120,9 +120,6 @@ pub enum ApplicationError {
     #[snafu(display("No handler for {:?} {}", method, path))]
     RouteNotFound { method: Method, path: String },
 
-    #[snafu(display("Internal error creating gzip decoder: {:?}", source))]
-    CreatingGzipDecoder { source: std::io::Error },
-
     #[snafu(display("Internal error from database {}:  {}", database, source))]
     DatabaseError {
         database: String,
@@ -153,7 +150,6 @@ impl ApplicationError {
             Self::ParsingLineProtocol { .. } => StatusCode::BAD_REQUEST,
             Self::ReadingBodyAsGzip { .. } => StatusCode::BAD_REQUEST,
             Self::RouteNotFound { .. } => StatusCode::NOT_FOUND,
-            Self::CreatingGzipDecoder { .. } => StatusCode::INTERNAL_SERVER_ERROR,
             Self::DatabaseError { .. } => StatusCode::INTERNAL_SERVER_ERROR,
             Self::JsonGenerationError { .. } => StatusCode::INTERNAL_SERVER_ERROR,
         }

--- a/write_buffer/src/database.rs
+++ b/write_buffer/src/database.rs
@@ -605,27 +605,6 @@ impl SQLDatabase for Db {
         self.table_to_arrow(table_name, columns).await
     }
 
-    async fn partition_table_to_arrow_with_meta(
-        &self,
-        table_name: &str,
-        partition_key: &str,
-    ) -> Result<(RecordBatch, data_types::partition_metadata::Table), Self::Error> {
-        let partitions = self.partitions.read().await;
-        let partition = partitions
-            .iter()
-            .find(|p| p.key == partition_key)
-            .context(PartitionNotFound { partition_key })?;
-
-        let result = partition
-            .partition_table_to_arrow_with_meta(table_name)
-            .context(PartitionTableToArrowError {
-                partition_key,
-                table_name,
-            })?;
-
-        Ok(result)
-    }
-
     /// Return the partition keys for data in this DB
     async fn partition_keys(&self) -> Result<Vec<String>, Self::Error> {
         let partitions = self.partitions.read().await;

--- a/write_buffer/src/database.rs
+++ b/write_buffer/src/database.rs
@@ -202,6 +202,21 @@ pub enum Error {
 
     #[snafu(display("replicated write from writer {} missing payload", writer))]
     MissingPayload { writer: u32 },
+
+    #[snafu(display("partition {} not found", partition_key))]
+    PartitionNotFound { partition_key: String },
+
+    #[snafu(display(
+        "error converting partition table to arrow on partition {} with table {}: {}",
+        partition_key,
+        table_name,
+        source
+    ))]
+    PartitionTableToArrowError {
+        partition_key: String,
+        table_name: String,
+        source: crate::partition::Error,
+    },
 }
 
 impl From<crate::table::Error> for Error {
@@ -350,10 +365,21 @@ impl Db {
 
         Ok(batches)
     }
+
+    pub async fn remove_partition(&self, partition_key: &str) -> Result<Partition> {
+        let mut partitions = self.partitions.write().await;
+        let pos = partitions
+            .iter()
+            .position(|p| p.key == partition_key)
+            .context(PartitionNotFound { partition_key })?;
+
+        Ok(partitions.remove(pos))
+    }
 }
 
 #[async_trait]
 impl TSDatabase for Db {
+    type Partition = crate::partition::Partition;
     type Error = Error;
 
     // TODO: writes lines creates a column named "time" for the timestamp data. If
@@ -513,6 +539,7 @@ impl TSDatabase for Db {
 
 #[async_trait]
 impl SQLDatabase for Db {
+    type Partition = Partition;
     type Error = Error;
 
     async fn query(&self, query: &str) -> Result<Vec<RecordBatch>, Self::Error> {
@@ -566,6 +593,84 @@ impl SQLDatabase for Db {
             .context(QueryError { query })?;
 
         ctx.collect(plan).await.context(QueryError { query })
+    }
+
+    /// Fetch the specified table names and columns as Arrow
+    /// RecordBatches. Columns are returned in the order specified.
+    async fn table_to_arrow(
+        &self,
+        table_name: &str,
+        columns: &[&str],
+    ) -> Result<Vec<RecordBatch>, Self::Error> {
+        self.table_to_arrow(table_name, columns).await
+    }
+
+    async fn partition_table_to_arrow_with_meta(
+        &self,
+        table_name: &str,
+        partition_key: &str,
+    ) -> Result<(RecordBatch, data_types::partition_metadata::Table), Self::Error> {
+        let partitions = self.partitions.read().await;
+        let partition = partitions
+            .iter()
+            .find(|p| p.key == partition_key)
+            .context(PartitionNotFound { partition_key })?;
+
+        let result = partition
+            .partition_table_to_arrow_with_meta(table_name)
+            .context(PartitionTableToArrowError {
+                partition_key,
+                table_name,
+            })?;
+
+        Ok(result)
+    }
+
+    /// Return the partition keys for data in this DB
+    async fn partition_keys(&self) -> Result<Vec<String>, Self::Error> {
+        let partitions = self.partitions.read().await;
+        let keys = partitions.iter().map(|p| p.key.clone()).collect();
+
+        Ok(keys)
+    }
+
+    /// Return the table names that are in a given partition key
+    async fn table_names_for_partition(
+        &self,
+        partition_key: &str,
+    ) -> Result<Vec<String>, Self::Error> {
+        let partitions = self.partitions.read().await;
+        let partition = partitions
+            .iter()
+            .find(|p| p.key == partition_key)
+            .context(PartitionNotFound { partition_key })?;
+
+        let mut tables = Vec::with_capacity(partition.tables.len());
+
+        for id in partition.tables.keys() {
+            let name =
+                partition
+                    .dictionary
+                    .lookup_id(*id)
+                    .context(TableIdNotFoundInDictionary {
+                        table: *id,
+                        partition: &partition.key,
+                    })?;
+
+            tables.push(name.to_string());
+        }
+
+        Ok(tables)
+    }
+
+    async fn remove_partition(&self, partition_key: &str) -> Result<Arc<Partition>> {
+        let mut partitions = self.partitions.write().await;
+        let pos = partitions
+            .iter()
+            .position(|p| p.key == partition_key)
+            .context(PartitionNotFound { partition_key })?;
+
+        Ok(Arc::new(partitions.remove(pos)))
     }
 }
 

--- a/write_buffer/src/lib.rs
+++ b/write_buffer/src/lib.rs
@@ -11,7 +11,7 @@
 mod column;
 mod database;
 mod dictionary;
-mod partition;
+pub mod partition;
 mod store;
 mod table;
 

--- a/write_buffer/src/partition.rs
+++ b/write_buffer/src/partition.rs
@@ -371,27 +371,6 @@ impl Partition {
         Ok(stats)
     }
 
-    /// Convert the table specified into arrow record batch and return partition metadata with
-    /// summary statistics.
-    pub fn partition_table_to_arrow_with_meta(
-        &self,
-        table_name: &str,
-    ) -> Result<(RecordBatch, TableStats)> {
-        let table = self.table(table_name)?;
-
-        let batch = table
-            .to_arrow(&self, &[])
-            .context(NamedTableError { table_name })?;
-
-        let columns = table.stats();
-        let table_stats = TableStats {
-            name: table_name.to_string(),
-            columns,
-        };
-
-        Ok((batch, table_stats))
-    }
-
     fn table(&self, table_name: &str) -> Result<&Table> {
         let table_id =
             self.dictionary

--- a/write_buffer/src/partition.rs
+++ b/write_buffer/src/partition.rs
@@ -430,7 +430,7 @@ impl Partition {
     }
 }
 
-impl query::Partition for Partition {
+impl query::PartitionChunk for Partition {
     type Error = Error;
 
     fn key(&self) -> &str {

--- a/write_buffer/src/table.rs
+++ b/write_buffer/src/table.rs
@@ -13,7 +13,7 @@ use crate::{
     partition::PartitionIdSet,
     partition::{Partition, PartitionPredicate},
 };
-use data_types::TIME_COLUMN_NAME;
+use data_types::{partition_metadata::Column as ColumnStats, TIME_COLUMN_NAME};
 use snafu::{OptionExt, ResultExt, Snafu};
 
 use arrow_deps::{
@@ -1030,6 +1030,20 @@ impl Table {
                     })
             }
         }
+    }
+
+    pub fn stats(&self) -> Vec<ColumnStats> {
+        self.columns
+            .iter()
+            .map(|c| match c {
+                Column::F64(_, stats) => ColumnStats::F64(stats.clone()),
+                Column::I64(_, stats) => ColumnStats::I64(stats.clone()),
+                Column::Bool(_, stats) => ColumnStats::Bool(stats.clone()),
+                Column::String(_, stats) | Column::Tag(_, stats) => {
+                    ColumnStats::String(stats.clone())
+                }
+            })
+            .collect()
     }
 }
 


### PR DESCRIPTION
This introduces snapshot to the server packages to manage snapshotting. It also introduces a new trait for representing a PartitionChunk. There is a very crude API wired up in http_routes for testing purposes. Follow on work will bring the server package into http_routes and rework the snapshot API.

Currently, this removes the partition being snapshotted from the write buffer database and snapshots it in the background. Obviously we'll want to instead keep an Arc of that partition in the write buffer DB so the data is queryable while its getting snapshotted. I think this work might coincide well with some re-organization to bring in the concept of `Chunks` vs. `Partitions`.

The snapshotting currently happens serially (one table after the other) but I've structured the status in a way that we could update it to parallelize the work depending on what the user passes in. I'd like the level of parallelism to be controllable by the operator on a per request basis, mainly so they can limit the number of tables that get converted into arrow and over to Parquet (which all happens in memory before getting sent along to the object store).

One approach I played with was to have some generic Task that the server cold work with and then create specific ones like Snapshot, etc. However, that seemed too complex and it just wasn't an abstraction that was needed. Representing a Snapshot specifically with what it needs seemed to be much cleaner.