### PR TITLE
feat: grouped aggregates for low-cardinality columns

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2709,6 +2709,7 @@ dependencies = [
  "criterion",
  "croaring",
  "data_types",
+ "either",
  "itertools 0.9.0",
  "packers",
  "rand",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2692,6 +2692,7 @@ dependencies = [
  "criterion",
  "croaring",
  "data_types",
+ "itertools 0.9.0",
  "packers",
  "rand",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1533,6 +1533,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fc7aa29613bd6a620df431842069224d8bc9011086b1db4c0e0cd47fa03ec9a"
 
 [[package]]
+name = "libm"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7d73b3f436185384286bd8098d17ec07c9a7d2388a6599f824d8502b529702a"
+
+[[package]]
 name = "log"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1876,6 +1882,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
 dependencies = [
  "autocfg",
+ "libm 0.2.1",
 ]
 
 [[package]]
@@ -1972,7 +1979,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3278e0492f961fd4ae70909f56b2723a7e8d01a228427294e19cdfdebda89a17"
 dependencies = [
  "cfg-if 0.1.10",
- "libm",
+ "libm 0.1.4",
 ]
 
 [[package]]
@@ -2344,6 +2351,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_distr"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9e9532ada3929fb8b2e9dbe28d1e06c9b2cc65813f074fcb6bd5fbefeff9d56"
+dependencies = [
+ "num-traits",
+ "rand",
+]
+
+[[package]]
 name = "rand_hc"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2695,6 +2712,7 @@ dependencies = [
  "itertools 0.9.0",
  "packers",
  "rand",
+ "rand_distr",
 ]
 
 [[package]]

--- a/packers/src/packers.rs
+++ b/packers/src/packers.rs
@@ -185,6 +185,12 @@ impl std::convert::From<Vec<Option<u64>>> for Packers {
     }
 }
 
+impl std::convert::From<Vec<Option<String>>> for Packers {
+    fn from(v: Vec<Option<String>>) -> Self {
+        Self::String(Packer::from(v.as_slice()))
+    }
+}
+
 impl std::convert::From<data_types::table_schema::DataType> for Packers {
     fn from(t: data_types::table_schema::DataType) -> Self {
         match t {

--- a/segment_store/Cargo.toml
+++ b/segment_store/Cargo.toml
@@ -12,6 +12,7 @@ arrow_deps = { path = "../arrow_deps" }
 data_types = { path = "../data_types" }
 packers = { path = "../packers" }
 croaring = "0.4.5"
+itertools = "0.9.0"
 
 [dev-dependencies]
 criterion = "0.3"

--- a/segment_store/Cargo.toml
+++ b/segment_store/Cargo.toml
@@ -13,6 +13,7 @@ data_types = { path = "../data_types" }
 packers = { path = "../packers" }
 croaring = "0.4.5"
 itertools = "0.9.0"
+either = "1.6.1"
 
 [dev-dependencies]
 criterion = "0.3.3"

--- a/segment_store/Cargo.toml
+++ b/segment_store/Cargo.toml
@@ -15,8 +15,9 @@ croaring = "0.4.5"
 itertools = "0.9.0"
 
 [dev-dependencies]
-criterion = "0.3"
+criterion = "0.3.3"
 rand = "0.7.3"
+rand_distr = "0.3.0"
 
 [[bench]]
 name = "fixed"
@@ -24,4 +25,8 @@ harness = false
 
 [[bench]]
 name = "dictionary"
+harness = false
+
+[[bench]]
+name = "segment"
 harness = false

--- a/segment_store/benches/segment.rs
+++ b/segment_store/benches/segment.rs
@@ -1,0 +1,375 @@
+use std::collections::BTreeMap;
+
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use rand::distributions::Alphanumeric;
+use rand::prelude::*;
+use rand::Rng;
+use rand_distr::{Distribution, Normal};
+
+use packers::{sorter, Packers};
+
+use segment_store::column::{AggregateType, Column};
+use segment_store::segment::{ColumnType, Segment};
+
+const ONE_MS: i64 = 1_000_000;
+
+const ROWS: [usize; 4] = [250_000, 500_000, 750_000, 1_000_000];
+
+fn read_group(c: &mut Criterion) {
+    let mut rng = rand::thread_rng();
+
+    let cardinalities = vec![
+        (vec!["env"], 2),
+        (vec!["env", "data_centre"], 20),
+        (vec!["data_centre", "cluster"], 200),
+        (vec!["cluster", "node_id"], 2000),
+    ];
+
+    let segment = generate_segment(500_000, &mut rng);
+    benchmark_read_group_pre_computed_groups_no_predicates_vary_cardinality(
+        c,
+        "segment_read_group_pre_computed_groups_no_predicates_cardinality",
+        &segment,
+        cardinalities.as_slice(),
+    );
+
+    benchmark_read_group_pre_computed_groups_no_predicates_vary_group_cols(
+        c,
+        "segment_read_group_pre_computed_groups_no_predicates_group_cols",
+        &segment,
+        vec![
+            (vec!["cluster"], 200),
+            (vec!["data_centre", "cluster"], 200),
+            (vec!["env", "data_centre", "cluster"], 200),
+        ]
+        .as_slice(),
+    );
+
+    benchmark_read_group_pre_computed_groups_no_predicates_vary_rows(
+        c,
+        "segment_read_group_pre_computed_groups_no_predicates_rows",
+        &ROWS,
+        (vec!["data_centre", "cluster"], 200),
+        &mut rng,
+    );
+}
+
+// This benchmark tracks the performance of read_group when it is able to use
+// the per-group bitsets provided by RLE columns. The aim is to understand the
+// expense of working on these bitsets directly in the segment, so the number of
+// rows in the segment is fixed.
+fn benchmark_read_group_pre_computed_groups_no_predicates_vary_cardinality(
+    c: &mut Criterion,
+    benchmark_group_name: &str,
+    segment: &Segment,
+    cardinalities: &[(Vec<&str>, usize)],
+) {
+    let mut group = c.benchmark_group(benchmark_group_name);
+
+    for (group_cols, expected_cardinality) in cardinalities {
+        // benchmark measures the throughput of group creation.
+        group.throughput(Throughput::Elements(*expected_cardinality as u64));
+
+        group.bench_with_input(
+            BenchmarkId::from_parameter(format!("{:?}", expected_cardinality)),
+            &expected_cardinality,
+            |b, expected_cardinality| {
+                b.iter(|| {
+                    let result = segment.read_group(
+                        &[],
+                        group_cols.as_slice(),
+                        &[("duration", AggregateType::Count)],
+                    );
+
+                    // data_centre cardinality is split across env
+                    assert_eq!(result.cardinality(), **expected_cardinality, "{}", &result);
+                });
+            },
+        );
+    }
+    group.finish();
+}
+
+// This benchmark tracks the performance of read_group when it is able to use
+// the per-group bitsets provided by RLE columns. This benchmark seeks to
+// understand the performance of working on these bitsets directly in the segment
+// when the size of these bitsets changes. Therefore the cardinality (groups)
+// is fixed, but the number of rows in the column is varied.
+fn benchmark_read_group_pre_computed_groups_no_predicates_vary_rows(
+    c: &mut Criterion,
+    benchmark_group_name: &str,
+    row_sizes: &[usize],
+    group_columns: (Vec<&str>, usize),
+    rng: &mut ThreadRng,
+) {
+    let mut group = c.benchmark_group(benchmark_group_name);
+
+    for num_rows in row_sizes {
+        let segment = generate_segment(*num_rows, rng);
+
+        // benchmark measures the throughput of group creation.
+        group.throughput(Throughput::Elements(*num_rows as u64));
+
+        group.bench_function(
+            BenchmarkId::from_parameter(format!("{:?}", num_rows)),
+            |b| {
+                b.iter(|| {
+                    let result = segment.read_group(
+                        &[],
+                        group_columns.0.as_slice(),
+                        &[("duration", AggregateType::Count)],
+                    );
+
+                    // data_centre cardinality is split across env
+                    assert_eq!(result.cardinality(), group_columns.1, "{}", &result);
+                });
+            },
+        );
+    }
+    group.finish();
+}
+
+// This benchmark tracks the performance of read_group when it is able to use
+// the per-group bitsets provided by RLE columns. This benchmark seeks to
+// understand the performance of working varying numbers of these bitset
+// combinations. Therefore the cardinality and number of rows are fixed, but the
+// number of columns grouped on increases.
+fn benchmark_read_group_pre_computed_groups_no_predicates_vary_group_cols(
+    c: &mut Criterion,
+    benchmark_group_name: &str,
+    segment: &Segment,
+    group_columns: &[(Vec<&str>, usize)],
+) {
+    let mut group = c.benchmark_group(benchmark_group_name);
+
+    for (group_cols, expected_cardinality) in group_columns {
+        let num_cols = group_cols.len();
+        // benchmark measures the throughput of group creation.
+        group.throughput(Throughput::Elements(num_cols as u64));
+
+        group.bench_with_input(
+            BenchmarkId::from_parameter(format!("{:?}", num_cols)),
+            &group_cols,
+            |b, group_cols| {
+                b.iter(|| {
+                    let result = segment.read_group(
+                        &[],
+                        group_cols.as_slice(),
+                        &[("duration", AggregateType::Count)],
+                    );
+
+                    assert_eq!(result.cardinality(), *expected_cardinality, "{}", &result);
+                });
+            },
+        );
+    }
+    group.finish();
+}
+
+//
+// This generates a segment with a known schema, ~known column cardinalities and
+// variable number of rows.
+//
+// The schema and cardinalities are in-line with a tracing data use-case.
+fn generate_segment(rows: usize, rng: &mut ThreadRng) -> Segment {
+    let mut timestamp = 1351700038292387000_i64;
+    let spans_per_trace = 10;
+
+    let mut column_packers: Vec<Packers> = vec![
+        Packers::from(Vec::<Option<String>>::with_capacity(rows)), // env (card 2)
+        Packers::from(Vec::<Option<String>>::with_capacity(rows)), // data_centre (card 20)
+        Packers::from(Vec::<Option<String>>::with_capacity(rows)), // cluster (card 200)
+        Packers::from(Vec::<Option<String>>::with_capacity(rows)), // user_id (card 200,000)
+        Packers::from(Vec::<Option<String>>::with_capacity(rows)), // request_id (card 2,000,000)
+        Packers::from(Vec::<Option<String>>::with_capacity(rows)), // node_id (card 2,000)
+        Packers::from(Vec::<Option<String>>::with_capacity(rows)), // pod_id (card 20,000)
+        Packers::from(Vec::<Option<String>>::with_capacity(rows)), // trace_id (card "rows / 10")
+        Packers::from(Vec::<Option<String>>::with_capacity(rows)), // span_id (card "rows")
+        Packers::from(Vec::<Option<i64>>::with_capacity(rows)),    // duration
+        Packers::from(Vec::<Option<i64>>::with_capacity(rows)),    // time
+    ];
+
+    let n = rows / spans_per_trace;
+    for _ in 0..n {
+        column_packers =
+            generate_trace_for_segment(spans_per_trace, timestamp, column_packers, rng);
+
+        // next trace is ~10 seconds in the future
+        timestamp += 10_000 * ONE_MS;
+    }
+
+    // sort the packers according to lowest to highest cardinality excluding
+    // columns that are likely to be unique.
+    //
+    // - env, data_centre, cluster, node_id, pod_id, user_id, request_id, time
+    sorter::sort(&mut column_packers, &[0, 1, 2, 5, 6, 3, 4, 10]).unwrap();
+
+    // create columns
+    let columns = vec![
+        (
+            "env".to_string(),
+            ColumnType::Tag(Column::from(column_packers[0].str_packer().values())),
+        ),
+        (
+            "data_centre".to_string(),
+            ColumnType::Tag(Column::from(column_packers[1].str_packer().values())),
+        ),
+        (
+            "cluster".to_string(),
+            ColumnType::Tag(Column::from(column_packers[2].str_packer().values())),
+        ),
+        (
+            "user_id".to_string(),
+            ColumnType::Tag(Column::from(column_packers[3].str_packer().values())),
+        ),
+        (
+            "request_id".to_string(),
+            ColumnType::Tag(Column::from(column_packers[4].str_packer().values())),
+        ),
+        (
+            "node_id".to_string(),
+            ColumnType::Tag(Column::from(column_packers[5].str_packer().values())),
+        ),
+        (
+            "pod_id".to_string(),
+            ColumnType::Tag(Column::from(column_packers[6].str_packer().values())),
+        ),
+        (
+            "trace_id".to_string(),
+            ColumnType::Tag(Column::from(column_packers[7].str_packer().values())),
+        ),
+        (
+            "span_id".to_string(),
+            ColumnType::Tag(Column::from(column_packers[8].str_packer().values())),
+        ),
+        (
+            "duration".to_string(),
+            ColumnType::Field(Column::from(
+                column_packers[9].i64_packer().some_values().as_slice(),
+            )),
+        ),
+        (
+            "time".to_string(),
+            ColumnType::Time(Column::from(
+                column_packers[10].i64_packer().some_values().as_slice(),
+            )),
+        ),
+    ]
+    .into_iter()
+    .collect::<BTreeMap<_, _>>();
+
+    Segment::new(rows as u32, columns)
+}
+
+fn generate_trace_for_segment(
+    spans_per_trace: usize,
+    timestamp: i64,
+    mut column_packers: Vec<Packers>,
+    rng: &mut ThreadRng,
+) -> Vec<Packers> {
+    let env_idx = 0;
+    let data_centre_idx = 1;
+    let cluster_idx = 2;
+    let user_id_idx = 3;
+    let request_id_idx = 4;
+    let node_id_idx = 5;
+    let pod_id_idx = 6;
+    let trace_id_idx = 7;
+    let span_id_idx = 8;
+    let duration_idx = 9;
+    let time_idx = 10;
+
+    let env_value = rng.gen_range(0_u8, 2);
+    let env = format!("env-{:?}", env_value); // cardinality of 2.
+
+    let data_centre_value = rng.gen_range(0_u8, 10);
+    let data_centre = format!("data_centre-{:?}-{:?}", env_value, data_centre_value); // cardinality of 2 * 10  = 20
+
+    let cluster_value = rng.gen_range(0_u8, 10);
+    let cluster = format!(
+        "cluster-{:?}-{:?}-{:?}",
+        env_value,
+        data_centre_value,
+        cluster_value // cardinality of 2 * 10 * 10 = 200
+    );
+
+    // user id is dependent on the cluster
+    let user_id_value = rng.gen_range(0_u32, 1000);
+    let user_id = format!(
+        "uid-{:?}-{:?}-{:?}-{:?}",
+        env_value,
+        data_centre_value,
+        cluster_value,
+        user_id_value // cardinality of 2 * 10 * 10 * 1000 = 200,000
+    );
+
+    let request_id_value = rng.gen_range(0_u32, 10);
+    let request_id = format!(
+        "rid-{:?}-{:?}-{:?}-{:?}-{:?}",
+        env_value,
+        data_centre_value,
+        cluster_value,
+        user_id_value,
+        request_id_value // cardinality of 2 * 10 * 10 * 1000 * 10 = 2,000,000
+    );
+
+    let trace_id = rng.sample_iter(&Alphanumeric).take(8).collect::<String>();
+
+    // the trace should move across hosts, which in this setup would be
+    // nodes and pods.
+    let normal = Normal::new(10.0, 5.0).unwrap();
+    let node_id_prefix = format!("{}-{}-{}", env_value, data_centre_value, cluster_value,);
+    for _ in 0..spans_per_trace {
+        // these values are not the same for each span so need to be generated separately.
+        let node_id = rng.gen_range(0, 10); // cardinality is 2 * 10 * 10 * 10 = 2,000
+        let node_id = format!("node_id-{}-{}", node_id_prefix, node_id);
+
+        column_packers[pod_id_idx].str_packer_mut().push(format!(
+            "pod_id-{}-{}-{}",
+            node_id_prefix,
+            node_id,
+            rng.gen_range(0, 10) // cardinality is 2 * 10 * 10 * 10 * 10 = 20,000
+        ));
+        column_packers[node_id_idx].str_packer_mut().push(node_id);
+
+        // randomly generate a span_id
+        column_packers[span_id_idx]
+            .str_packer_mut()
+            .push(rng.sample_iter(&Alphanumeric).take(8).collect::<String>());
+
+        // randomly generate some duration times in milliseconds.
+        column_packers[duration_idx].i64_packer_mut().push(
+            (normal.sample(rng) * ONE_MS as f64)
+                .max(ONE_MS as f64) // minimum duration is 1ms
+                .round() as i64,
+        );
+    }
+
+    column_packers[env_idx]
+        .str_packer_mut()
+        .fill_with(env, spans_per_trace);
+    column_packers[data_centre_idx]
+        .str_packer_mut()
+        .fill_with(data_centre, spans_per_trace);
+    column_packers[cluster_idx]
+        .str_packer_mut()
+        .fill_with(cluster, spans_per_trace);
+    column_packers[user_id_idx]
+        .str_packer_mut()
+        .fill_with(user_id, spans_per_trace);
+    column_packers[request_id_idx]
+        .str_packer_mut()
+        .fill_with(request_id, spans_per_trace);
+    column_packers[trace_id_idx]
+        .str_packer_mut()
+        .fill_with(trace_id, spans_per_trace);
+
+    column_packers[time_idx]
+        .i64_packer_mut()
+        .fill_with(timestamp, spans_per_trace);
+
+    column_packers
+}
+
+criterion_group!(benches, read_group);
+criterion_main!(benches);

--- a/segment_store/src/column.rs
+++ b/segment_store/src/column.rs
@@ -102,6 +102,17 @@ impl Column {
         }
     }
 
+    pub fn properties(&self) -> &ColumnProperties {
+        match &self {
+            Column::String(meta, _) => &meta.properties,
+            Column::Float(meta, _) => &meta.properties,
+            Column::Integer(meta, _) => &meta.properties,
+            Column::Unsigned(meta, _) => &meta.properties,
+            Column::Bool => todo!(),
+            Column::ByteArray(meta, _) => &meta.properties,
+        }
+    }
+
     pub fn column_min(&self) -> Value<'_> {
         todo!()
     }
@@ -577,6 +588,11 @@ impl Column {
 }
 
 #[derive(Default, Debug, PartialEq)]
+pub struct ColumnProperties {
+    pub has_pre_computed_row_ids: bool,
+}
+
+#[derive(Default, Debug, PartialEq)]
 // The meta-data for a column
 pub struct MetaData<T>
 where
@@ -590,6 +606,8 @@ where
 
     // The minimum and maximum value for this column.
     range: Option<(T, T)>,
+
+    properties: ColumnProperties,
 }
 
 impl<T: PartialOrd + std::fmt::Debug> MetaData<T> {
@@ -848,9 +866,9 @@ impl StringEncoding {
         };
 
         let meta = MetaData {
-            size: 0,
             rows: data.num_rows(),
             range,
+            ..MetaData::default()
         };
 
         // TODO(edd): consider just storing under the `StringEncoding` a
@@ -974,6 +992,9 @@ impl StringEncoding {
                     size: data.size(),
                     rows: data.num_rows(),
                     range,
+                    properties: ColumnProperties {
+                        has_pre_computed_row_ids: true,
+                    },
                 }
             }
             Self::Dictionary(data) => {
@@ -987,9 +1008,9 @@ impl StringEncoding {
                 };
 
                 MetaData {
-                    size: 0,
                     rows: data.num_rows(),
                     range,
+                    ..MetaData::default()
                 }
             }
         }
@@ -1448,6 +1469,7 @@ impl From<&[u64]> for Column {
                     size: data.size(),
                     rows: data.num_rows(),
                     range: Some((min, max)),
+                    ..MetaData::default()
                 };
                 Column::Unsigned(meta, IntegerEncoding::U64U8(data))
             }
@@ -1458,6 +1480,7 @@ impl From<&[u64]> for Column {
                     size: data.size(),
                     rows: data.num_rows(),
                     range: Some((min, max)),
+                    ..MetaData::default()
                 };
                 Column::Unsigned(meta, IntegerEncoding::U64U16(data))
             }
@@ -1468,6 +1491,7 @@ impl From<&[u64]> for Column {
                     size: data.size(),
                     rows: data.num_rows(),
                     range: Some((min, max)),
+                    ..MetaData::default()
                 };
                 Column::Unsigned(meta, IntegerEncoding::U64U32(data))
             }
@@ -1478,6 +1502,7 @@ impl From<&[u64]> for Column {
                     size: data.size(),
                     rows: data.num_rows(),
                     range: Some((min, max)),
+                    ..MetaData::default()
                 };
                 Column::Unsigned(meta, IntegerEncoding::U64U64(data))
             }
@@ -1509,6 +1534,7 @@ impl From<&[u32]> for Column {
                     size: data.size(),
                     rows: data.num_rows(),
                     range: Some((min as u64, max as u64)),
+                    ..MetaData::default()
                 };
                 Column::Unsigned(meta, IntegerEncoding::U64U8(data))
             }
@@ -1519,6 +1545,7 @@ impl From<&[u32]> for Column {
                     size: data.size(),
                     rows: data.num_rows(),
                     range: Some((min as u64, max as u64)),
+                    ..MetaData::default()
                 };
                 Column::Unsigned(meta, IntegerEncoding::U64U16(data))
             }
@@ -1529,6 +1556,7 @@ impl From<&[u32]> for Column {
                     size: data.size(),
                     rows: data.num_rows(),
                     range: Some((min as u64, max as u64)),
+                    ..MetaData::default()
                 };
                 Column::Unsigned(meta, IntegerEncoding::U64U32(data))
             }
@@ -1560,6 +1588,7 @@ impl From<&[u16]> for Column {
                     size: data.size(),
                     rows: data.num_rows(),
                     range: Some((min as u64, max as u64)),
+                    ..MetaData::default()
                 };
                 Column::Unsigned(meta, IntegerEncoding::U64U8(data))
             }
@@ -1570,6 +1599,7 @@ impl From<&[u16]> for Column {
                     size: data.size(),
                     rows: data.num_rows(),
                     range: Some((min as u64, max as u64)),
+                    ..MetaData::default()
                 };
                 Column::Unsigned(meta, IntegerEncoding::U64U16(data))
             }
@@ -1598,6 +1628,7 @@ impl From<&[u8]> for Column {
             size: data.size(),
             rows: data.num_rows(),
             range: Some((min as u64, max as u64)),
+            ..MetaData::default()
         };
         Column::Unsigned(meta, IntegerEncoding::U64U8(data))
     }
@@ -1625,6 +1656,7 @@ impl From<&[i64]> for Column {
                     size: data.size(),
                     rows: data.num_rows(),
                     range: Some((min, max)),
+                    ..MetaData::default()
                 };
                 Column::Integer(meta, IntegerEncoding::I64U8(data))
             }
@@ -1635,6 +1667,7 @@ impl From<&[i64]> for Column {
                     size: data.size(),
                     rows: data.num_rows(),
                     range: Some((min, max)),
+                    ..MetaData::default()
                 };
                 Column::Integer(meta, IntegerEncoding::I64I8(data))
             }
@@ -1645,6 +1678,7 @@ impl From<&[i64]> for Column {
                     size: data.size(),
                     rows: data.num_rows(),
                     range: Some((min, max)),
+                    ..MetaData::default()
                 };
                 Column::Integer(meta, IntegerEncoding::I64U16(data))
             }
@@ -1655,6 +1689,7 @@ impl From<&[i64]> for Column {
                     size: data.size(),
                     rows: data.num_rows(),
                     range: Some((min, max)),
+                    ..MetaData::default()
                 };
                 Column::Integer(meta, IntegerEncoding::I64I16(data))
             }
@@ -1665,6 +1700,7 @@ impl From<&[i64]> for Column {
                     size: data.size(),
                     rows: data.num_rows(),
                     range: Some((min, max)),
+                    ..MetaData::default()
                 };
                 Column::Integer(meta, IntegerEncoding::I64U32(data))
             }
@@ -1675,6 +1711,7 @@ impl From<&[i64]> for Column {
                     size: data.size(),
                     rows: data.num_rows(),
                     range: Some((min, max)),
+                    ..MetaData::default()
                 };
                 Column::Integer(meta, IntegerEncoding::I64I32(data))
             }
@@ -1685,6 +1722,7 @@ impl From<&[i64]> for Column {
                     size: data.size(),
                     rows: data.num_rows(),
                     range: Some((min, max)),
+                    ..MetaData::default()
                 };
                 Column::Integer(meta, IntegerEncoding::I64I64(data))
             }
@@ -1716,6 +1754,7 @@ impl From<&[i32]> for Column {
                     size: data.size(),
                     rows: data.num_rows(),
                     range: Some((min as i64, max as i64)),
+                    ..MetaData::default()
                 };
                 Column::Integer(meta, IntegerEncoding::I64U8(data))
             }
@@ -1726,6 +1765,7 @@ impl From<&[i32]> for Column {
                     size: data.size(),
                     rows: data.num_rows(),
                     range: Some((min as i64, max as i64)),
+                    ..MetaData::default()
                 };
                 Column::Integer(meta, IntegerEncoding::I64I8(data))
             }
@@ -1736,6 +1776,7 @@ impl From<&[i32]> for Column {
                     size: data.size(),
                     rows: data.num_rows(),
                     range: Some((min as i64, max as i64)),
+                    ..MetaData::default()
                 };
                 Column::Integer(meta, IntegerEncoding::I64U16(data))
             }
@@ -1746,6 +1787,7 @@ impl From<&[i32]> for Column {
                     size: data.size(),
                     rows: data.num_rows(),
                     range: Some((min as i64, max as i64)),
+                    ..MetaData::default()
                 };
                 Column::Integer(meta, IntegerEncoding::I64I16(data))
             }
@@ -1756,6 +1798,7 @@ impl From<&[i32]> for Column {
                     size: data.size(),
                     rows: data.num_rows(),
                     range: Some((min as i64, max as i64)),
+                    ..MetaData::default()
                 };
                 Column::Integer(meta, IntegerEncoding::I64I32(data))
             }
@@ -1787,6 +1830,7 @@ impl From<&[i16]> for Column {
                     size: data.size(),
                     rows: data.num_rows(),
                     range: Some((min as i64, max as i64)),
+                    ..MetaData::default()
                 };
                 Column::Integer(meta, IntegerEncoding::I64I8(data))
             }
@@ -1797,6 +1841,7 @@ impl From<&[i16]> for Column {
                     size: data.size(),
                     rows: data.num_rows(),
                     range: Some((min as i64, max as i64)),
+                    ..MetaData::default()
                 };
                 Column::Integer(meta, IntegerEncoding::I64U8(data))
             }
@@ -1807,6 +1852,7 @@ impl From<&[i16]> for Column {
                     size: data.size(),
                     rows: data.num_rows(),
                     range: Some((min as i64, max as i64)),
+                    ..MetaData::default()
                 };
                 Column::Integer(meta, IntegerEncoding::I64I16(data))
             }
@@ -1832,6 +1878,7 @@ impl From<&[i8]> for Column {
             size: data.size(),
             rows: data.num_rows(),
             range: Some((min as i64, max as i64)),
+            ..MetaData::default()
         };
         Column::Integer(meta, IntegerEncoding::I64I8(data))
     }
@@ -1879,6 +1926,7 @@ impl From<arrow::array::Int64Array> for Column {
             size: data.size(),
             rows: data.num_rows(),
             range,
+            ..MetaData::default()
         };
         Column::Integer(meta, IntegerEncoding::I64I64N(data))
     }
@@ -1900,6 +1948,7 @@ impl From<&[f64]> for Column {
             size: data.size(),
             rows: data.num_rows(),
             range: Some((min, max)),
+            ..MetaData::default()
         };
 
         Column::Float(meta, FloatEncoding::Fixed64(data))
@@ -2687,6 +2736,14 @@ mod test {
     }
 
     #[test]
+    fn column_properties() {
+        let data = StringEncoding::RLEDictionary(dictionary::RLE::default());
+        let meta = StringEncoding::meta_from_data(&data);
+        let col = Column::String(meta, data);
+        assert!(col.properties().has_pre_computed_row_ids);
+    }
+
+    #[test]
     fn from_arrow_string_array() {
         let input = vec![None, Some("world"), None, Some("hello")];
         let arr = StringArray::from(input);
@@ -2699,6 +2756,9 @@ mod test {
                     size: 317,
                     rows: 4,
                     range: Some(("hello".to_string(), "world".to_string())),
+                    properties: ColumnProperties {
+                        has_pre_computed_row_ids: true
+                    }
                 }
             );
 
@@ -2724,6 +2784,9 @@ mod test {
                     size: 301,
                     rows: 2,
                     range: Some(("hello".to_string(), "world".to_string())),
+                    properties: ColumnProperties {
+                        has_pre_computed_row_ids: true
+                    }
                 }
             );
 

--- a/segment_store/src/column.rs
+++ b/segment_store/src/column.rs
@@ -1458,6 +1458,13 @@ impl From<&[Option<&str>]> for Column {
     }
 }
 
+impl From<&[Option<String>]> for Column {
+    fn from(arr: &[Option<String>]) -> Self {
+        let other = arr.iter().map(|x| x.as_deref()).collect::<Vec<_>>();
+        Self::from(other.as_slice())
+    }
+}
+
 impl From<&[&str]> for Column {
     fn from(arr: &[&str]) -> Self {
         let data = StringEncoding::from_strs(arr);

--- a/segment_store/src/column.rs
+++ b/segment_store/src/column.rs
@@ -3,15 +3,13 @@ pub mod dictionary;
 pub mod fixed;
 pub mod fixed_null;
 
+use std::collections::BTreeSet;
 use std::convert::TryFrom;
-use std::{
-    borrow::Cow,
-    collections::{BTreeMap, BTreeSet},
-};
 
 use croaring::Bitmap;
 
 use arrow_deps::{arrow, arrow::array::Array};
+use either::Either;
 
 // Edd's totally made up magic constant. This determines whether we would use
 // a run-length encoded dictionary encoding or just a plain dictionary encoding.
@@ -252,7 +250,7 @@ impl Column {
         }
     }
 
-    pub fn grouped_row_ids(&self) -> Cow<'_, BTreeMap<u32, RowIDs>> {
+    pub fn grouped_row_ids(&self) -> Either<Vec<&RowIDs>, Vec<RowIDs>> {
         match &self {
             Column::String(_, data) => data.group_row_ids(),
             _ => unimplemented!("grouping not yet implemented"),
@@ -809,10 +807,10 @@ impl StringEncoding {
     }
 
     /// Calculate all row ids for each distinct value in the column.
-    pub fn group_row_ids(&self) -> Cow<'_, BTreeMap<u32, RowIDs>> {
+    pub fn group_row_ids(&self) -> Either<Vec<&RowIDs>, Vec<RowIDs>> {
         match self {
-            Self::RLEDictionary(enc) => Cow::Borrowed(enc.group_row_ids()),
-            Self::Dictionary(enc) => Cow::Owned(enc.group_row_ids()),
+            Self::RLEDictionary(enc) => Either::Left(enc.group_row_ids()),
+            Self::Dictionary(enc) => Either::Right(enc.group_row_ids()),
         }
     }
 

--- a/segment_store/src/column.rs
+++ b/segment_store/src/column.rs
@@ -2233,30 +2233,30 @@ impl Scalar {
     }
 }
 
-impl<'a> std::ops::AddAssign<&Scalar> for Scalar {
-    fn add_assign(&mut self, _rhs: &Scalar) {
-        if _rhs.is_null() {
+impl std::ops::AddAssign<&Scalar> for Scalar {
+    fn add_assign(&mut self, rhs: &Scalar) {
+        if rhs.is_null() {
             // Adding NULL does nothing.
             return;
         }
 
         match self {
             Scalar::F64(v) => {
-                if let Scalar::F64(other) = _rhs {
+                if let Scalar::F64(other) = rhs {
                     *v += *other;
                 } else {
                     panic!("invalid AddAssign types");
                 };
             }
             Scalar::I64(v) => {
-                if let Scalar::I64(other) = _rhs {
+                if let Scalar::I64(other) = rhs {
                     *v += *other;
                 } else {
                     panic!("invalid AddAssign types");
                 };
             }
             Scalar::U64(v) => {
-                if let Scalar::U64(other) = _rhs {
+                if let Scalar::U64(other) = rhs {
                     *v += *other;
                 } else {
                     panic!("invalid AddAssign types");
@@ -2268,24 +2268,24 @@ impl<'a> std::ops::AddAssign<&Scalar> for Scalar {
 }
 
 impl<'a> std::ops::AddAssign<&Scalar> for &mut Scalar {
-    fn add_assign(&mut self, _rhs: &Scalar) {
+    fn add_assign(&mut self, rhs: &Scalar) {
         match self {
             Scalar::F64(v) => {
-                if let Scalar::F64(other) = _rhs {
+                if let Scalar::F64(other) = rhs {
                     *v += *other;
                 } else {
                     panic!("invalid AddAssign types");
                 };
             }
             Scalar::I64(v) => {
-                if let Scalar::I64(other) = _rhs {
+                if let Scalar::I64(other) = rhs {
                     *v += *other;
                 } else {
                     panic!("invalid AddAssign types");
                 };
             }
             Scalar::U64(v) => {
-                if let Scalar::U64(other) = _rhs {
+                if let Scalar::U64(other) = rhs {
                     *v += *other;
                 } else {
                     panic!("invalid AddAssign types");
@@ -2366,10 +2366,7 @@ pub enum Value<'a> {
 
 impl Value<'_> {
     pub fn is_null(&self) -> bool {
-        if let Self::Null = self {
-            return true;
-        }
-        false
+        matches!(self, Self::Null)
     }
 
     pub fn scalar(&self) -> &Scalar {

--- a/segment_store/src/column.rs
+++ b/segment_store/src/column.rs
@@ -2724,14 +2724,14 @@ impl RowIDs {
 
     pub fn union(&mut self, other: &RowIDs) {
         match (self, other) {
-            (Self::Bitmap(_self), RowIDs::Bitmap(other)) => _self.or_inplace(other),
+            (Self::Bitmap(inner), RowIDs::Bitmap(other)) => inner.or_inplace(other),
             // N.B this seems very inefficient. It should only be used for testing.
-            (Self::Vector(_self), Self::Bitmap(other)) => {
-                let mut bm: Bitmap = _self.iter().cloned().collect();
+            (Self::Vector(inner), Self::Bitmap(other)) => {
+                let mut bm: Bitmap = inner.iter().cloned().collect();
                 bm.or_inplace(other);
 
-                _self.clear();
-                _self.extend(bm.iter());
+                inner.clear();
+                inner.extend(bm.iter());
             }
             (_, _) => unimplemented!("currently unsupported"),
         };

--- a/segment_store/src/column/dictionary.rs
+++ b/segment_store/src/column/dictionary.rs
@@ -122,14 +122,6 @@ impl Encoding {
         }
     }
 
-    // // The set of row ids for each distinct value in the column.
-    // fn group_row_ids(&self) -> Cow<'_, Vec<RowIDs>> {
-    //     match self {
-    //         Encoding::RLE(enc) => Cow::Owned(enc.group_row_ids()),
-    //         Encoding::Plain(enc) => Cow::Borrowed(enc.group_row_ids()),
-    //     }
-    // }
-
     //
     //
     // ---- Methods for getting materialised values.

--- a/segment_store/src/column/dictionary/plain.rs
+++ b/segment_store/src/column/dictionary/plain.rs
@@ -7,7 +7,7 @@ use std::arch::x86::*;
 #[cfg(all(target_arch = "x86_64", target_feature = "avx2"))]
 use std::arch::x86_64::*;
 
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::BTreeSet;
 use std::convert::From;
 use std::mem::size_of;
 
@@ -467,14 +467,12 @@ impl Plain {
     }
 
     // The set of row ids for each distinct value in the column.
-    pub fn group_row_ids(&self) -> BTreeMap<u32, RowIDs> {
-        let mut results = BTreeMap::new();
-        for (i, id) in self.encoded_data.iter().enumerate() {
-            if !results.contains_key(id) {
-                results.insert(*id, RowIDs::bitmap_from_slice(&[i as u32]));
-            }
+    pub fn group_row_ids(&self) -> Vec<RowIDs> {
+        let mut results = vec![];
+        results.resize(self.entries.len(), RowIDs::new_bitmap());
 
-            results.get_mut(id).unwrap().add(i as u32);
+        for (i, id) in self.encoded_data.iter().enumerate() {
+            results[*id as usize].add(i as u32);
         }
 
         results

--- a/segment_store/src/column/dictionary/rle.rs
+++ b/segment_store/src/column/dictionary/rle.rs
@@ -26,7 +26,7 @@ pub struct RLE {
     // The set of rows that belong to each distinct value in the dictionary.
     // This allows essentially constant time grouping of rows on the column by
     // value.
-    index_row_ids: BTreeMap<u32, Bitmap>,
+    index_row_ids: BTreeMap<u32, RowIDs>,
 
     // stores tuples where each pair refers to a dictionary entry and the number
     // of times the entry repeats.
@@ -51,7 +51,7 @@ impl Default for RLE {
             contains_null: false,
             num_rows: 0,
         };
-        _self.index_row_ids.insert(NULL_ID, Bitmap::create());
+        _self.index_row_ids.insert(NULL_ID, RowIDs::new_bitmap());
 
         _self
     }
@@ -69,7 +69,7 @@ impl RLE {
 
             _self.entry_index.insert(entry.clone(), next_id);
             _self.index_entries.push(entry);
-            _self.index_row_ids.insert(next_id, Bitmap::create());
+            _self.index_row_ids.insert(next_id, RowIDs::new_bitmap());
         }
 
         _self
@@ -153,7 +153,7 @@ impl RLE {
                 self.index_row_ids
                     .get_mut(&id)
                     .unwrap()
-                    .add_range(self.num_rows as u64..self.num_rows as u64 + additional as u64);
+                    .add_range(self.num_rows, self.num_rows + additional);
             }
             // no dictionary entry for value.
             None => {
@@ -167,7 +167,7 @@ impl RLE {
                 self.index_entries.push(v.clone());
 
                 self.entry_index.insert(v, next_id);
-                self.index_row_ids.insert(next_id, Bitmap::create());
+                self.index_row_ids.insert(next_id, RowIDs::new_bitmap());
 
                 // start a new run-length
                 self.run_lengths.push((next_id, additional));
@@ -176,7 +176,7 @@ impl RLE {
                 self.index_row_ids
                     .get_mut(&(next_id as u32))
                     .unwrap()
-                    .add_range(self.num_rows as u64..self.num_rows as u64 + additional as u64);
+                    .add_range(self.num_rows, self.num_rows + additional);
             }
         }
         self.num_rows += additional;
@@ -198,7 +198,7 @@ impl RLE {
             self.index_row_ids
                 .get_mut(&NULL_ID)
                 .unwrap()
-                .add_range(self.num_rows as u64..self.num_rows as u64 + additional as u64);
+                .add_range(self.num_rows, self.num_rows + additional);
         } else {
             // very first run-length in column...
             self.run_lengths.push((NULL_ID, additional));
@@ -208,7 +208,7 @@ impl RLE {
             self.index_row_ids
                 .get_mut(&NULL_ID)
                 .unwrap()
-                .add_range(self.num_rows as u64..self.num_rows as u64 + additional as u64);
+                .add_range(self.num_rows, self.num_rows + additional);
         }
 
         self.num_rows += additional;
@@ -259,7 +259,7 @@ impl RLE {
             match op {
                 cmp::Operator::Equal => {
                     let ids = self.index_row_ids.get(encoded_id).unwrap();
-                    dst.add_from_bitmap(ids);
+                    dst.union(ids);
                     return dst;
                 }
                 cmp::Operator::NotEqual => {
@@ -380,7 +380,7 @@ impl RLE {
     }
 
     // The set of row ids for each distinct value in the column.
-    pub fn group_row_ids(&self) -> &BTreeMap<u32, Bitmap> {
+    pub fn group_row_ids(&self) -> &BTreeMap<u32, RowIDs> {
         &self.index_row_ids
     }
 
@@ -423,10 +423,10 @@ impl RLE {
     /// Materialises the decoded value belonging to the provided encoded id.
     ///
     /// Panics if there is no decoded value for the provided id
-    pub fn decode_id(&self, encoded_id: u32) -> Option<String> {
+    pub fn decode_id(&self, encoded_id: u32) -> Option<&str> {
         match encoded_id {
             NULL_ID => None,
-            _ => Some(self.index_entries[encoded_id as usize].clone()),
+            _ => Some(self.index_entries[encoded_id as usize].as_str()),
         }
     }
 
@@ -617,17 +617,14 @@ impl RLE {
     ///
     /// NULL values are represented by None.
     ///
-    pub fn all_values<'a>(
-        &'a mut self,
-        mut dst: Vec<Option<&'a String>>,
-    ) -> Vec<Option<&'a String>> {
+    pub fn all_values<'a>(&'a self, mut dst: Vec<Option<&'a str>>) -> Vec<Option<&'a str>> {
         dst.clear();
         dst.reserve(self.num_rows as usize);
 
         for (id, rl) in &self.run_lengths {
             let v = match *id {
                 NULL_ID => None,
-                id => Some(&self.index_entries[id as usize]),
+                id => Some(self.index_entries[id as usize].as_str()),
             };
 
             dst.extend(iter::repeat(v).take(*rl as usize));

--- a/segment_store/src/column/dictionary/rle.rs
+++ b/segment_store/src/column/dictionary/rle.rs
@@ -380,8 +380,8 @@ impl RLE {
     }
 
     // The set of row ids for each distinct value in the column.
-    pub fn group_row_ids(&self) -> &BTreeMap<u32, RowIDs> {
-        &self.index_row_ids
+    pub fn group_row_ids(&self) -> Vec<&RowIDs> {
+        self.index_row_ids.values().collect()
     }
 
     //

--- a/segment_store/src/lib.rs
+++ b/segment_store/src/lib.rs
@@ -4,7 +4,7 @@
 #![allow(unused_variables)]
 pub mod column;
 pub(crate) mod partition;
-pub(crate) mod segment;
+pub mod segment;
 pub(crate) mod table;
 
 use std::collections::BTreeMap;
@@ -207,6 +207,26 @@ impl Store {
         }
         None
     }
+}
+
+/// Generate a predicate for the time range [from, to).
+pub fn time_range_predicate<'a>(from: i64, to: i64) -> Vec<segment::Predicate<'a>> {
+    vec![
+        (
+            segment::TIME_COLUMN_NAME,
+            (
+                column::cmp::Operator::GTE,
+                column::Value::Scalar(column::Scalar::I64(from)),
+            ),
+        ),
+        (
+            segment::TIME_COLUMN_NAME,
+            (
+                column::cmp::Operator::LT,
+                column::Value::Scalar(column::Scalar::I64(to)),
+            ),
+        ),
+    ]
 }
 
 // A database is scoped to a single tenant. Within a database there exists

--- a/segment_store/src/partition.rs
+++ b/segment_store/src/partition.rs
@@ -51,7 +51,7 @@ impl Partition {
         time_range: (i64, i64),
         predicates: &[(&str, &str)],
         select_columns: Vec<ColumnName<'_>>,
-    ) -> BTreeMap<ColumnName<'_>, Values> {
+    ) -> BTreeMap<ColumnName<'_>, Values<'_>> {
         // Find the measurement name on the partition and dispatch query to the
         // table for that measurement if the partition's time range overlaps the
         // requested time range.
@@ -79,7 +79,7 @@ impl Partition {
         predicates: &[(&str, &str)],
         group_columns: Vec<ColumnName<'_>>,
         aggregates: Vec<(ColumnName<'_>, AggregateType)>,
-    ) -> BTreeMap<GroupKey, Vec<(ColumnName<'_>, AggregateResult<'_>)>> {
+    ) -> BTreeMap<GroupKey<'_>, Vec<(ColumnName<'_>, AggregateResult<'_>)>> {
         // Find the measurement name on the partition and dispatch query to the
         // table for that measurement if the partition's time range overlaps the
         // requested time range.

--- a/segment_store/src/segment.rs
+++ b/segment_store/src/segment.rs
@@ -369,16 +369,10 @@ impl Segment {
             .map(|(col_name, typ)| (self.column_by_name(col_name), typ))
             .collect::<Vec<_>>();
 
-        let encoded_groups_map = group_columns
+        let encoded_groups = group_columns
             .iter()
-            .map(|col| col.grouped_row_ids())
+            .map(|col| col.grouped_row_ids().unwrap_left())
             .collect::<Vec<_>>();
-        let mut encoded_groups: Vec<Vec<&RowIDs>> = vec![];
-        for id_map in &encoded_groups_map {
-            // N.B - this works because grouped_row_ids returns sequential
-            // encoded ids.
-            encoded_groups.push(id_map.values().collect());
-        }
 
         let mut result = ReadGroupResult {
             group_columns: group_column_name,

--- a/segment_store/src/segment.rs
+++ b/segment_store/src/segment.rs
@@ -698,6 +698,11 @@ impl ReadGroupResult<'_> {
     pub fn is_empty(&self) -> bool {
         self.group_keys.is_empty()
     }
+
+    // The number of distinct group keys in the result.
+    pub fn cardinality(&self) -> usize {
+        self.group_keys.len()
+    }
 }
 
 impl<'a> std::fmt::Debug for &ReadGroupResult<'a> {

--- a/segment_store/src/segment.rs
+++ b/segment_store/src/segment.rs
@@ -413,7 +413,7 @@ impl Segment {
         // non-empty sets.
         let group_keys = encoded_groups
             .iter()
-            .map(|ids| ids.keys().cloned())
+            .map(|ids| ids.keys())
             .multi_cartesian_product();
 
         // Let's figure out which of the candidate group keys are actually
@@ -451,7 +451,7 @@ impl Segment {
             // be safe to use `small_vec` here without blowing the stack up.
             let mut material_key = Vec::with_capacity(group_key.len());
             for (col_idx, &encoded_id) in group_key.iter().enumerate() {
-                material_key.push(group_columns[col_idx].decode_id(encoded_id));
+                material_key.push(group_columns[col_idx].decode_id(*encoded_id));
             }
             result.group_keys.push(material_key);
 

--- a/segment_store/src/segment.rs
+++ b/segment_store/src/segment.rs
@@ -435,8 +435,10 @@ impl Segment {
                     .get(&group_key[i])
                     .unwrap()
                     .unwrap_bitmap();
-                aggregate_row_ids = Cow::Owned(aggregate_row_ids.and(other));
-                if aggregate_row_ids.is_empty() {
+
+                if aggregate_row_ids.and_cardinality(other) > 0 {
+                    aggregate_row_ids = Cow::Owned(aggregate_row_ids.and(other));
+                } else {
                     continue 'outer;
                 }
             }

--- a/segment_store/src/segment.rs
+++ b/segment_store/src/segment.rs
@@ -729,8 +729,7 @@ impl<'a> std::fmt::Display for &ReadGroupResult<'a> {
         }
 
         let expected_rows = self.group_keys.len();
-        let mut row = 0;
-        while row < expected_rows {
+        for row in 0..expected_rows {
             if row > 0 {
                 writeln!(f)?;
             }
@@ -747,8 +746,6 @@ impl<'a> std::fmt::Display for &ReadGroupResult<'a> {
                     write!(f, ",")?;
                 }
             }
-
-            row += 1;
         }
 
         writeln!(f)

--- a/segment_store/src/segment.rs
+++ b/segment_store/src/segment.rs
@@ -1008,6 +1008,22 @@ prod,3
 stag,1
 ",
             ),
+            (
+                vec![],
+                vec!["region", "method"],
+                vec![
+                    ("counter", AggregateType::Sum),
+                    ("counter", AggregateType::Min),
+                    ("counter", AggregateType::Max),
+                ],
+                "region,method,counter_sum,counter_min,counter_max
+east,POST,200,200,200
+north,GET,10,10,10
+south,PUT,203,203,203
+west,GET,100,100,100
+west,POST,304,101,203
+",
+            ),
         ];
 
         for (predicate, group_cols, aggs, expected) in cases {

--- a/segment_store/src/segment.rs
+++ b/segment_store/src/segment.rs
@@ -132,6 +132,9 @@ impl Segment {
     }
 
     // Returns a reference to a column from the column name.
+    //
+    // It is the caller's responsibility to ensure the column exists in the
+    // segment. Panics if the column doesn't exist.
     fn column_by_name(&self, name: ColumnName<'_>) -> &Column {
         &self.columns[*self.all_columns_by_name.get(name).unwrap()]
     }


### PR DESCRIPTION
TLDR; this PR adds a method for doing grouped by aggregates on low-cardinality columns that is ~invariant to the number of rows being aggregated across. It could be useful for queries across large numbers of rows where you only want to group on lower cardinality columns.

## Background

This PR adds some initial support for `read_group` aggregates in Segment Store.
Currently it only supports one particular type of grouped aggregates; I will continue to add support for other cases until all general cases are covered.

Expressed in SQL, the kinds of read_group aggregate support (pinching a bit of InfluxDB terminology here...) added in this PR could be expressed in SQL like:

```sql
SELECT SUM(duration), COUNT(foo), MIN(bar) ...
FROM "cpu"
GROUP BY "region", "host", .... 
```

Concretely, for the code-paths in this PR to be hit the following conditions need to be true:

* No predicates on the query that apply to the segment (including time);
* All grouping columns are `RLEDictionary` encoded;

There can be predicates on the query, but they must not filter any data in the segment, so a time-range that overlaps the entire segment is fine, as is a filter that matches all values in a column.
The reason for these restrictions is that the algorithm that does the grouping leverages some pre-computed set data that all rle-encoded columns hold.

Typically grouped aggregates are done in a few steps:

1) Apply all filters and determine what set of rows you're working with on each column;
2) With this intermediate row set calculate each group key across all grouping columns for each `row_id` in the row set.
3) Store these group keys as keys to a hashmap and store the aggregates as the values, which can be built as you go.

An alternative approach is to not build a hashmap but instead to create another table view with the filtered rows that is then sorted on the grouping columns.
You can then stream through the columns you're aggregating in row-order and build the aggregates that way; the hashtable approach is often faster but YMMV.

However, for these scenarios I wanted to see if I could leverage the fact that we already had all the groups pre-computed on each column in compressed bitsets. 

## Implementation

Each rle-encoded columns stores a mapping between each `encoded_id` (the integer that encodes the logical string value in a row) and all of the `row_ids` that contain that value.
These are stored in compressed roaring bitmaps.

For example, suppose you have the following column `region`:

```
["east", "east", "west", "east", "south", "south"]
```

we may encode that as:

```
"east" -> 1
"south" -> 2
"west" -> 3
```

and then we will store the pre-computed rows in compressed bitsets for each _encoded_ value. 
Like this:

```
1: {0, 1, 3}
2: {4, 5}
3: {2}
```

where the sets are themselves compressed.

Now, given another column `az` with a pre-computed grouping like:

```
["az-b", "az-a", "az-e", "az-a", "az-a", "az-b"]

"az-a" -> 1
"az-b" -> 2
"az-e" -> 3

1: {1, 3, 4}
2: {0, 5}
3: {2}
```

we could simply intersect the bitsets for each group combination resulting in the final group keys and row_ids to apply the aggregates to:

```
(1, 1) -> {1, 3}
(1, 2) -> {0}
(2, 2) -> {5}
(3, 3) -> {2}

materialised, the groupings have the following rows.

(east, az-a) -> {1, 3}
(east, az-b) -> {0}
(south, az-b) -> {5}
(west, az-e) -> {2}
```

you can group by as many columns as needed this way as a chain of set intersections.

Cool. All good then?
Well not really because you can't tell what the group keys are unless you check all the candidate's sets against each other, so if you do it naively (which is what I have done here for a starter implementation), you very likely have a non-linear algorithm :-1:.

I think the approach is interesting through and I'm pretty sure you could implement a linear version by "draining" the bitsets as you calculate group keys, but I didn't continue down that road as there is other `read_group` surface area to cover first.

## Commits

Some of the less boring commits in the PR:

* 7bc9738 - This adds the basic algorithm for applying read_group aggregates to columns that support returning pre-computed bit-sets for each distinct value in the column. I think the algorithm is linearithmic (maybe quadratic) because it lazily generates all possible group keys via an cartesian product iterator and then does set operations to determine if each candidate group key is a valid group key. It does short-circuit aggressively though.
* 42f56f4 - Benchmarks used to assess performance. I'll describe these below.
* 7ae27f5 - With benchmarks comes profiling, and with profiling usually comes easy wins. This one checks whether any rows could exist for a group key before allocating a new bitset.
* 3f8208d - This one avoids copying all `encoded_ids` out of the column initially and defers the copy until we know we need to use it to materialise a logical column value.
* 1043495 - This one was fun. Profiling showed that a lot of time was being spent fetching the bitsets for each distinct column value out of their respective `BTreeMaps`. The maps are indexed by integers (the `encoded_id`s for the logical column values). Not only are the maps indexed by integers but they're also guaranteed to be `[0, N)` where `N` is the number of distinct values in the column. So let's use a vector here and simply index into it with the `encoded_id` integer. This was a big performance win.
* f524240 - Solidify the vector idea in the general encoding APIs.

## Results

There are three different benchmarks in the PR, which use a basic data-set that generates column data similar to that found in a tracing use-case.
There are low cardinality columns in the segment, e.g., things like `env`, `data_centre` or `cluster`. 
And there are high cardinality columns like `request_id`, `trace_id` and `span_id`. 
The code described in this PR only applies to grouping on low-cardinality columns that are RLE encoded.

The three benchmarks are as follows:

* One of them varies the cardinality of the results whilst fixing the number of rows in the segment to 500,000. The cardinality of the results just means the number of grouped aggregates produced (the number of group keys). It varies between 2, 20, 200 and 2,000.
* One of them fixes the cardinality (to 200), but varies the number of columns grouped to produce that result set. It varies grouping on 1, 2 or 3 columns.
* One of them fixes cardinality and columns and varies the number of rows in the segment.

The initial results seem interesting (to me anyway). 
Firstly, let's address the current problem which is above-linear behaviour of the current implementation.
Here is a graph showing this behaviour, taken from the first benchmark that varies cardinality for a 500,000 rows segment.

<img width="933" alt="Screenshot 2020-12-04 at 21 18 29" src="https://user-images.githubusercontent.com/501993/101218337-cb522380-367a-11eb-8e10-411b371be2f4.png">

Grouping throughput goes from `~250us` to calculate 200 grouped aggregates (`~800K` groups/second) to `~15ms` to calculate 2,000 grouped aggregates (`~130K).
Ideally we would expect the throughput to be the same as we increased the number of groups.

It's not all bad though.
One interesting aspect to this approach is that it's relatively immune to the actual size of the segments. 
That is, larger segments (number of rows) don't really change the performance of the grouping much.
Here are some benchmarks showing this:

<img width="973" alt="Screenshot 2020-12-04 at 20 14 28" src="https://user-images.githubusercontent.com/501993/101218370-de64f380-367a-11eb-99c5-e852cff795c6.png">

The benchmarks do the equivalent of `SELECT COUNT(duration) FROM cpu GROUP BY "data_centre", "cluster"` but varying the number of rows to process from 250,000 to 1 million.
You can see there is barely any performance change of the query between processing 250K rows (`~245 us`) and processing 1M rows (`~302 us`), which is pretty cool.

Finally, here is a cool [criterion](https://github.com/bheisler/criterion.rs) feature that shows the efforts of some performance tuning I did in the latter commits after doing some profiling:

<img width="966" alt="Screenshot 2020-12-04 at 20 29 03" src="https://user-images.githubusercontent.com/501993/101218504-15d3a000-367b-11eb-8b6d-7647608e8bc8.png">

## Summary

I think for the right kind of queries where you want to get aggregates across low cardinality columns, this implementation could work really well.
One example would be when you have lots of potentially high cardinality data, but you want summary statistics over some of the lower cardinality columns, e.g.,

```sql
// show me the number of traces collected in each region and cluster, as well as the fastest and slowest span.

SELECT COUNT(trace_id), MIN(duration), MAX(duration)
FROM traces
GROUP BY "aws-region", "cluster-type"
```

Even if there are millions of traces in the segment this query will still perform well.

For higher cardinality columns however it will probably be better to stick to traditional hashmap/sorting approaches.

## Next Steps

* I'm going to move onto implementing more general `read_group` support with predicates and higher cardinality columns.
* I think it would be worth figuring out where the overlap is between using this code-path and using a more general hashmap based approach, and then switching between them in IOx at runtime.
* Figure out a better algorithm than testing every group key combination in this PR.