### PR TITLE
fix: Report bucket/location when relevant with object store errors

### DIFF
--- a/docs/env.example
+++ b/docs/env.example
@@ -13,7 +13,7 @@
 # AWS_ACCESS_KEY_ID=access_key_value
 # AWS_SECRET_ACCESS_KEY=secret_access_key_value
 # AWS_DEFAULT_REGION=us-east-2
-# AWS_S3_BUCKET_NAME=bucket_name
+# AWS_S3_BUCKET_NAME=bucket-name
 #
 # If using Google Cloud Storage as an object store:
 # GCS_BUCKET_NAME=bucket_name

--- a/object_store/src/lib.rs
+++ b/object_store/src/lib.rs
@@ -153,14 +153,14 @@ impl GoogleCloudStorage {
             }
         );
 
-        let location_string = location.to_string();
+        let location_copy = location.to_string();
         let bucket_name = self.bucket_name.clone();
 
         let _ = tokio::task::spawn_blocking(move || {
             cloud_storage::Object::create(
                 &bucket_name,
                 &temporary_non_streaming,
-                &location_string,
+                &location_copy,
                 "application/octet-stream",
             )
         })
@@ -177,11 +177,11 @@ impl GoogleCloudStorage {
         &self,
         location: &str,
     ) -> InternalResult<impl Stream<Item = InternalResult<Bytes>>> {
-        let location_string = location.to_string();
+        let location_copy = location.to_string();
         let bucket_name = self.bucket_name.clone();
 
         let bytes = tokio::task::spawn_blocking(move || {
-            cloud_storage::Object::download(&bucket_name, &location_string)
+            cloud_storage::Object::download(&bucket_name, &location_copy)
         })
         .await
         .context(UnableToGetDataFromGcs {
@@ -198,11 +198,11 @@ impl GoogleCloudStorage {
 
     /// Delete the object at the specified location.
     async fn delete(&self, location: &str) -> InternalResult<()> {
-        let location_string = location.to_string();
+        let location_copy = location.to_string();
         let bucket_name = self.bucket_name.clone();
 
         tokio::task::spawn_blocking(move || {
-            cloud_storage::Object::delete(&bucket_name, &location_string)
+            cloud_storage::Object::delete(&bucket_name, &location_copy)
         })
         .await
         .context(UnableToDeleteDataFromGcs {

--- a/object_store/src/lib.rs
+++ b/object_store/src/lib.rs
@@ -640,22 +640,22 @@ impl Error {
         match self.0 {
             UnableToPutDataToS3 {
                 source: RusotoError::Credentials(_),
-                bucket: _,
-                location: _,
+                bucket: String(_),
+                location: String(_),
             } => true,
             UnableToGetDataFromS3 {
                 source: RusotoError::Credentials(_),
-                bucket: _,
-                location: _,
+                bucket: String(_),
+                location: String(_),
             } => true,
             UnableToDeleteDataFromS3 {
                 source: RusotoError::Credentials(_),
-                bucket: _,
-                location: _,
+                bucket: String(_),
+                location: String(_),
             } => true,
             UnableToListDataFromS3 {
                 source: RusotoError::Credentials(_),
-                bucket: _,
+                bucket: String(_),
             } => true,
             _ => false,
         }

--- a/object_store/src/lib.rs
+++ b/object_store/src/lib.rs
@@ -640,22 +640,22 @@ impl Error {
         match self.0 {
             UnableToPutDataToS3 {
                 source: RusotoError::Credentials(_),
-                bucket: String(_),
-                location: String(_),
+                bucket: _,
+                location: _,
             } => true,
             UnableToGetDataFromS3 {
                 source: RusotoError::Credentials(_),
-                bucket: String(_),
-                location: String(_),
+                bucket: _,
+                location: _,
             } => true,
             UnableToDeleteDataFromS3 {
                 source: RusotoError::Credentials(_),
-                bucket: String(_),
-                location: String(_),
+                bucket: _,
+                location: _,
             } => true,
             UnableToListDataFromS3 {
                 source: RusotoError::Credentials(_),
-                bucket: String(_),
+                bucket: _,
             } => true,
             _ => false,
         }

--- a/object_store/src/lib.rs
+++ b/object_store/src/lib.rs
@@ -166,7 +166,7 @@ impl GoogleCloudStorage {
         })
         .await
         .context(UnableToPutDataToGcs {
-            bucket: self.bucket_name.clone(),
+            bucket: &self.bucket_name,
             location,
         })?;
 
@@ -185,11 +185,11 @@ impl GoogleCloudStorage {
         })
         .await
         .context(UnableToGetDataFromGcs {
-            bucket: self.bucket_name.clone(),
+            bucket: &self.bucket_name,
             location,
         })?
         .context(UnableToGetDataFromGcs2 {
-            bucket: self.bucket_name.clone(),
+            bucket: &self.bucket_name,
             location,
         })?;
 
@@ -206,11 +206,11 @@ impl GoogleCloudStorage {
         })
         .await
         .context(UnableToDeleteDataFromGcs {
-            bucket: self.bucket_name.clone(),
+            bucket: &self.bucket_name,
             location,
         })?
         .context(UnableToDeleteDataFromGcs2 {
-            bucket: self.bucket_name.clone(),
+            bucket: &self.bucket_name,
             location,
         })?;
 
@@ -231,10 +231,10 @@ impl GoogleCloudStorage {
         })
         .await
         .context(UnableToListDataFromGcs {
-            bucket: self.bucket_name.clone(),
+            bucket: &self.bucket_name,
         })?
         .context(UnableToListDataFromGcs2 {
-            bucket: self.bucket_name.clone(),
+            bucket: &self.bucket_name,
         })?;
 
         Ok(futures::stream::once(async move {
@@ -297,7 +297,7 @@ impl AmazonS3 {
             .put_object(put_request)
             .await
             .context(UnableToPutDataToS3 {
-                bucket: self.bucket_name.to_owned(),
+                bucket: &self.bucket_name,
                 location: location.to_string(),
             })?;
         Ok(())

--- a/object_store/src/lib.rs
+++ b/object_store/src/lib.rs
@@ -792,7 +792,7 @@ mod tests {
     type Result<T, E = Error> = std::result::Result<T, E>;
 
     #[cfg(any(test_aws, test_gcs))]
-    const NON_EXISTANT_NAME: &str = "nonexistantname";
+    const NON_EXISTENT_NAME: &str = "nonexistentname";
 
     macro_rules! assert_error {
         ($res:expr, $error_pat:pat$(,)?) => {
@@ -862,7 +862,7 @@ mod tests {
     }
 
     #[cfg(any(test_aws, test_gcs))]
-    async fn get_nonexistant_object(
+    async fn get_nonexistent_object(
         storage: &ObjectStore,
         location: Option<&str>,
     ) -> Result<Bytes> {
@@ -910,15 +910,13 @@ mod tests {
         }
 
         #[tokio::test]
-        async fn gcs_test_get_nonexistant_location() -> Result<()> {
+        async fn gcs_test_get_nonexistent_location() -> Result<()> {
             let bucket_name = bucket_name()?;
-            let location_name = NON_EXISTANT_NAME;
+            let location_name = NON_EXISTENT_NAME;
             let integration =
                 ObjectStore::new_google_cloud_storage(GoogleCloudStorage::new(&bucket_name));
 
-            let result = get_nonexistant_object(&integration, Some(location_name))
-                .await
-                .unwrap();
+            let result = get_nonexistent_object(&integration, Some(location_name)).await?;
 
             assert_eq!(
                 result,
@@ -929,15 +927,13 @@ mod tests {
         }
 
         #[tokio::test]
-        async fn gcs_test_get_nonexistant_bucket() -> Result<()> {
-            let bucket_name = NON_EXISTANT_NAME;
-            let location_name = NON_EXISTANT_NAME;
+        async fn gcs_test_get_nonexistent_bucket() -> Result<()> {
+            let bucket_name = NON_EXISTENT_NAME;
+            let location_name = NON_EXISTENT_NAME;
             let integration =
                 ObjectStore::new_google_cloud_storage(GoogleCloudStorage::new(bucket_name));
 
-            let result = get_nonexistant_object(&integration, Some(location_name))
-                .await
-                .unwrap();
+            let result = get_nonexistent_object(&integration, Some(location_name)).await?;
 
             assert_eq!(result, Bytes::from("Not Found"));
 
@@ -945,9 +941,9 @@ mod tests {
         }
 
         #[tokio::test]
-        async fn gcs_test_delete_nonexistant_location() -> Result<()> {
+        async fn gcs_test_delete_nonexistent_location() -> Result<()> {
             let bucket_name = bucket_name()?;
-            let location_name = NON_EXISTANT_NAME;
+            let location_name = NON_EXISTENT_NAME;
             let integration =
                 ObjectStore::new_google_cloud_storage(GoogleCloudStorage::new(&bucket_name));
 
@@ -970,9 +966,9 @@ mod tests {
         }
 
         #[tokio::test]
-        async fn gcs_test_delete_nonexistant_bucket() -> Result<()> {
-            let bucket_name = NON_EXISTANT_NAME;
-            let location_name = NON_EXISTANT_NAME;
+        async fn gcs_test_delete_nonexistent_bucket() -> Result<()> {
+            let bucket_name = NON_EXISTENT_NAME;
+            let location_name = NON_EXISTENT_NAME;
             let integration =
                 ObjectStore::new_google_cloud_storage(GoogleCloudStorage::new(bucket_name));
 
@@ -995,9 +991,9 @@ mod tests {
         }
 
         #[tokio::test]
-        async fn gcs_test_put_nonexistant_bucket() -> Result<()> {
-            let bucket_name = NON_EXISTANT_NAME;
-            let location_name = NON_EXISTANT_NAME;
+        async fn gcs_test_put_nonexistent_bucket() -> Result<()> {
+            let bucket_name = NON_EXISTENT_NAME;
+            let location_name = NON_EXISTENT_NAME;
             let integration =
                 ObjectStore::new_google_cloud_storage(GoogleCloudStorage::new(bucket_name));
             let data = Bytes::from("arbitrary data");
@@ -1057,14 +1053,14 @@ mod tests {
         }
 
         #[tokio::test]
-        async fn s3_test_get_nonexistant_region() -> Result<()> {
+        async fn s3_test_get_nonexistent_region() -> Result<()> {
             // Assumes environment variables do not provide credentials to AWS US West 1
             let (_, bucket_name) = region_and_bucket_name()?;
             let region = rusoto_core::Region::UsWest1;
             let integration = ObjectStore::new_amazon_s3(AmazonS3::new(region, &bucket_name));
-            let location_name = NON_EXISTANT_NAME;
+            let location_name = NON_EXISTENT_NAME;
 
-            let err = get_nonexistant_object(&integration, Some(location_name))
+            let err = get_nonexistent_object(&integration, Some(location_name))
                 .await
                 .unwrap_err();
             if let Some(Error(InternalError::UnableToListDataFromS3 { source, bucket })) =
@@ -1080,12 +1076,12 @@ mod tests {
         }
 
         #[tokio::test]
-        async fn s3_test_get_nonexistant_location() -> Result<()> {
+        async fn s3_test_get_nonexistent_location() -> Result<()> {
             let (region, bucket_name) = region_and_bucket_name()?;
             let integration = ObjectStore::new_amazon_s3(AmazonS3::new(region, &bucket_name));
-            let location_name = NON_EXISTANT_NAME;
+            let location_name = NON_EXISTENT_NAME;
 
-            let err = get_nonexistant_object(&integration, Some(location_name))
+            let err = get_nonexistent_object(&integration, Some(location_name))
                 .await
                 .unwrap_err();
             if let Some(Error(InternalError::UnableToGetDataFromS3 {
@@ -1108,13 +1104,13 @@ mod tests {
         }
 
         #[tokio::test]
-        async fn s3_test_get_nonexistant_bucket() -> Result<()> {
+        async fn s3_test_get_nonexistent_bucket() -> Result<()> {
             let (region, _) = region_and_bucket_name()?;
-            let bucket_name = NON_EXISTANT_NAME;
+            let bucket_name = NON_EXISTENT_NAME;
             let integration = ObjectStore::new_amazon_s3(AmazonS3::new(region, bucket_name));
-            let location_name = NON_EXISTANT_NAME;
+            let location_name = NON_EXISTENT_NAME;
 
-            let err = get_nonexistant_object(&integration, Some(location_name))
+            let err = get_nonexistent_object(&integration, Some(location_name))
                 .await
                 .unwrap_err();
             if let Some(Error(InternalError::UnableToListDataFromS3 { source, bucket })) =
@@ -1135,12 +1131,12 @@ mod tests {
         }
 
         #[tokio::test]
-        async fn s3_test_put_nonexistant_region() -> Result<()> {
+        async fn s3_test_put_nonexistent_region() -> Result<()> {
             // Assumes environment variables do not provide credentials to AWS US West 1
             let (_, bucket_name) = region_and_bucket_name()?;
             let region = rusoto_core::Region::UsWest1;
             let integration = ObjectStore::new_amazon_s3(AmazonS3::new(region, &bucket_name));
-            let location_name = NON_EXISTANT_NAME;
+            let location_name = NON_EXISTENT_NAME;
             let data = Bytes::from("arbitrary data");
             let stream_data = std::io::Result::Ok(data.clone());
 
@@ -1170,11 +1166,11 @@ mod tests {
         }
 
         #[tokio::test]
-        async fn s3_test_put_nonexistant_bucket() -> Result<()> {
+        async fn s3_test_put_nonexistent_bucket() -> Result<()> {
             let (region, _) = region_and_bucket_name()?;
-            let bucket_name = NON_EXISTANT_NAME;
+            let bucket_name = NON_EXISTENT_NAME;
             let integration = ObjectStore::new_amazon_s3(AmazonS3::new(region, bucket_name));
-            let location_name = NON_EXISTANT_NAME;
+            let location_name = NON_EXISTENT_NAME;
             let data = Bytes::from("arbitrary data");
             let stream_data = std::io::Result::Ok(data.clone());
 
@@ -1204,10 +1200,10 @@ mod tests {
         }
 
         #[tokio::test]
-        async fn s3_test_delete_nonexistant_location() -> Result<()> {
+        async fn s3_test_delete_nonexistent_location() -> Result<()> {
             let (region, bucket_name) = region_and_bucket_name()?;
             let integration = ObjectStore::new_amazon_s3(AmazonS3::new(region, &bucket_name));
-            let location_name = NON_EXISTANT_NAME;
+            let location_name = NON_EXISTENT_NAME;
 
             let result = integration.delete(location_name).await;
 
@@ -1217,12 +1213,12 @@ mod tests {
         }
 
         #[tokio::test]
-        async fn s3_test_delete_nonexistant_region() -> Result<()> {
+        async fn s3_test_delete_nonexistent_region() -> Result<()> {
             // Assumes environment variables do not provide credentials to AWS US West 1
             let (_, bucket_name) = region_and_bucket_name()?;
             let region = rusoto_core::Region::UsWest1;
             let integration = ObjectStore::new_amazon_s3(AmazonS3::new(region, &bucket_name));
-            let location_name = NON_EXISTANT_NAME;
+            let location_name = NON_EXISTENT_NAME;
 
             let err = integration.delete(location_name).await.unwrap_err();
             if let Error(InternalError::UnableToDeleteDataFromS3 {
@@ -1242,11 +1238,11 @@ mod tests {
         }
 
         #[tokio::test]
-        async fn s3_test_delete_nonexistant_bucket() -> Result<()> {
+        async fn s3_test_delete_nonexistent_bucket() -> Result<()> {
             let (region, _) = region_and_bucket_name()?;
-            let bucket_name = NON_EXISTANT_NAME;
+            let bucket_name = NON_EXISTENT_NAME;
             let integration = ObjectStore::new_amazon_s3(AmazonS3::new(region, bucket_name));
-            let location_name = NON_EXISTANT_NAME;
+            let location_name = NON_EXISTENT_NAME;
 
             let err = integration.delete(location_name).await.unwrap_err();
             if let Error(InternalError::UnableToDeleteDataFromS3 {


### PR DESCRIPTION
Closes #140 

This PR adds the members `bucket` and `location` both of `String` type to various `object_store` applicable S3 and GCS error enum variants. Also, adds some unit tests for S3 and GCS to attempt to receive errors that we assert saved the `bucket` and `location` members saved. The unit tests only cover a subset of the error enum variants added.

Questions and Remarks:
1. Should `bucket` and `location` represent `String` objects or `&str`?   
1. I plan to add the snafu display to the modified enum variants, but would like guidance on what the format should be to indicate the `source`, `bucket`, and `location` values.
1. Any guidance on more full code coverage to trigger a `tokio::task::JoinError`.
1. I believe the `put_get_delete_list` test helper function is susceptible to race conditions. Given the rust unit tests are run asynchronously by default, I believe this will frequently throw false negatives if there are other tests that modify the same bucket. I can write up a new issue or modify within this PR if desired. 
1. For local testing of S3, I used [localstack](https://github.com/localstack/localstack) and a [custom rusoto region](https://www.rusoto.org/regions.html). An option to ease this would be the addition of a new environment variable to represent local development and the local AWS mock server endpoint or the local AWS mock server endpoint environment variable and a conditional compilation flag for that endpoint environment variable . I can create the issue if this makes sense.
1. Is there a Google Cloud Storage mock server? I searched online and was not very successful so I tested using real Google Cloud Storage credentials.
1. See inline comment about modification to the `docs/env.example` `AWS_S3_BUCKET_NAME` default environment variable name.
1. Let me know if there's better ways to factor out or reduce some of the error checking in the test cases.
1. I do not fully understand the implications of removing `#[snafu(context(false))]`. I've read https://docs.rs/snafu/0.6.6/snafu/guide/attributes/index.html#controlling-context, but don't believe I understand this well enough. I needed to remove it to allow new `String` members to be added to the enum variant. I received this error if the `[snafu(context(false))]` remained: `Context selectors without context must not have context fields`

- [x] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb_iox/blob/main/README.md).
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
