### PR TITLE
test: Adds tests for read_group for None aggregates

### DIFF
--- a/src/server/rpc/expr.rs
+++ b/src/server/rpc/expr.rs
@@ -28,9 +28,6 @@ pub enum Error {
     #[snafu(display("Error creating aggregate: Unexpected empty aggregate"))]
     EmptyAggregate {},
 
-    #[snafu(display("Error creating aggregate: Unsupported none aggregate"))]
-    NoneAggregate {},
-
     #[snafu(display("Error creating aggregate: Exactly one aggregate is supported, but {} were supplied: {:?}",
                     aggregates.len(), aggregates))]
     AggregateNotSingleton { aggregates: Vec<RPCAggregate> },
@@ -578,7 +575,7 @@ fn convert_aggregate(aggregate: Option<RPCAggregate>) -> Result<QueryAggregate> 
     let aggregate_type = aggregate.r#type;
 
     if aggregate_type == RPCAggregateType::None as i32 {
-        NoneAggregate {}.fail()
+        Ok(QueryAggregate::None)
     } else if aggregate_type == RPCAggregateType::Sum as i32 {
         Ok(QueryAggregate::Sum)
     } else if aggregate_type == RPCAggregateType::Count as i32 {
@@ -1266,8 +1263,8 @@ mod tests {
             "Error creating aggregate: Unexpected empty aggregate"
         );
         assert_eq!(
-            error_result_to_string(convert_aggregate(make_aggregate_opt(0))),
-            "Error creating aggregate: Unsupported none aggregate"
+            convert_aggregate(make_aggregate_opt(0)).unwrap(),
+            QueryAggregate::None
         );
         assert_eq!(
             convert_aggregate(make_aggregate_opt(1)).unwrap(),


### PR DESCRIPTION
This is the first PR towards ensuring the proper implementation of the read_group gRPC call (https://github.com/influxdata/influxdb_iox/issues/448)

It adds tests to ensure `read_group` implements the semantics described in [the read_group mini spec](https://docs.google.com/document/d/1UoCov4_NEhJHTxQftn5-YlzfhCiP5hgqDq9ikbRRa3g/) for queries that use the `None` aggregate and adds some additional commentary

Here is the rough implementation plan:

- [x] Implement read_group for `None` aggregates (this PR)
- [ ] Implement read_group for `Sum`, `Count` and `Mean` aggregates
- [ ] Error if any hints are provided, or if there is a discrepancy between `GroupBy` and `GroupNone` type
- [ ] Implement user defined aggregates for `min`, `max`, `first` and `last`, selector functions
- [ ] Implement read_group for `Min`, `Max`, `First` and `Last` (using selctor functions)
