### PR TITLE
fix: better read_group input validation checking: group and hints fields

### DIFF
--- a/src/server/rpc/expr.rs
+++ b/src/server/rpc/expr.rs
@@ -489,10 +489,12 @@ pub fn make_read_group_aggregate(
 ) -> Result<GroupByAndAggregate> {
     // validate Group setting
     match group {
+        // Group:None is invalid if grouping keys are specified
         RPCGroup::None if !group_keys.is_empty() => InvalidGroupNone {
             num_group_keys: group_keys.len(),
         }
         .fail(),
+        // Group:By is invalid if no grouping keys are specified
         RPCGroup::By if group_keys.is_empty() => InvalidGroupBy {}.fail(),
         _ => Ok(()),
     }?;

--- a/src/server/rpc/expr.rs
+++ b/src/server/rpc/expr.rs
@@ -38,6 +38,17 @@ pub enum Error {
     #[snafu(display("Error creating aggregate: Unknown group type: {}", group_type))]
     UnknownGroup { group_type: i32 },
 
+    #[snafu(display(
+        "Incompatible read_group request: Group::None had {} group keys (expected 0)",
+        num_group_keys
+    ))]
+    InvalidGroupNone { num_group_keys: usize },
+
+    #[snafu(display(
+        "Incompatible read_group request: Group::By had no group keys (expected at least 1)"
+    ))]
+    InvalidGroupBy {},
+
     #[snafu(display("Error creating predicate: Unexpected empty predicate: Node"))]
     EmptyPredicateNode {},
 
@@ -473,9 +484,19 @@ fn build_binary_expr(op: Operator, inputs: Vec<Expr>) -> Result<Expr> {
 
 pub fn make_read_group_aggregate(
     aggregate: Option<RPCAggregate>,
-    _group: RPCGroup,
+    group: RPCGroup,
     group_keys: Vec<String>,
 ) -> Result<GroupByAndAggregate> {
+    // validate Group setting
+    match group {
+        RPCGroup::None if !group_keys.is_empty() => InvalidGroupNone {
+            num_group_keys: group_keys.len(),
+        }
+        .fail(),
+        RPCGroup::By if group_keys.is_empty() => InvalidGroupBy {}.fail(),
+        _ => Ok(()),
+    }?;
+
     let gby_agg = GroupByAndAggregate::Columns {
         agg: convert_aggregate(aggregate)?,
         group_columns: group_keys,
@@ -1129,6 +1150,47 @@ mod tests {
             Ok(_) => "UNEXPECTED SUCCESS".into(),
             Err(e) => format!("{}", e),
         }
+    }
+
+    #[test]
+    fn test_make_read_group_aggregate() {
+        assert_eq!(
+            make_read_group_aggregate(Some(make_aggregate(1)), RPCGroup::None, vec![]).unwrap(),
+            GroupByAndAggregate::Columns {
+                agg: QueryAggregate::Sum,
+                group_columns: vec![]
+            }
+        );
+
+        assert_eq!(
+            make_read_group_aggregate(Some(make_aggregate(1)), RPCGroup::By, vec!["gcol".into()])
+                .unwrap(),
+            GroupByAndAggregate::Columns {
+                agg: QueryAggregate::Sum,
+                group_columns: vec!["gcol".into()]
+            }
+        );
+
+        // error cases
+        assert_eq!(
+            make_read_group_aggregate(None, RPCGroup::None, vec![])
+                .unwrap_err()
+                .to_string(),
+            "Error creating aggregate: Unexpected empty aggregate"
+        );
+
+        assert_eq!(
+            make_read_group_aggregate(Some(make_aggregate(1)), RPCGroup::None, vec!["gcol".into()])
+                .unwrap_err()
+                .to_string(),
+            "Incompatible read_group request: Group::None had 1 group keys (expected 0)"
+        );
+        assert_eq!(
+            make_read_group_aggregate(Some(make_aggregate(1)), RPCGroup::By, vec![])
+                .unwrap_err()
+                .to_string(),
+            "Incompatible read_group request: Group::By had no group keys (expected at least 1)"
+        );
     }
 
     #[test]

--- a/src/server/rpc/service.rs
+++ b/src/server/rpc/service.rs
@@ -1869,7 +1869,7 @@ mod tests {
             partition_id,
         ));
 
-        let group = generated_types::read_group_request::Group::None as i32;
+        let group = generated_types::read_group_request::Group::By as i32;
 
         let request = ReadGroupRequest {
             read_source: source.clone(),
@@ -1915,7 +1915,7 @@ mod tests {
             read_source: source.clone(),
             range: None,
             predicate: None,
-            group_keys: vec![],
+            group_keys: vec![String::from("tag1")],
             group,
             aggregate: Some(RPCAggregate {
                 r#type: AggregateType::Sum as i32,
@@ -1923,7 +1923,6 @@ mod tests {
             hints: 42,
         };
 
-        // Note we don't set the response on the test database, so we expect an error
         let response = fixture.storage_client.read_group(request).await;
         assert!(response.is_err());
         let response_string = format!("{:?}", response);
@@ -1946,7 +1945,7 @@ mod tests {
             read_source: source.clone(),
             range: None,
             predicate: None,
-            group_keys: vec![],
+            group_keys: vec![String::from("tag1")],
             group,
             aggregate: Some(RPCAggregate {
                 r#type: AggregateType::Sum as i32,
@@ -1970,7 +1969,7 @@ mod tests {
             predicate: "Predicate {}".into(),
             gby_agg: GroupByAndAggregate::Columns {
                 agg: QueryAggregate::Sum,
-                group_columns: vec![],
+                group_columns: vec![String::from("tag1")],
             },
         });
         assert_eq!(test_db.get_query_groups_request().await, expected_request);

--- a/src/server/rpc/service.rs
+++ b/src/server/rpc/service.rs
@@ -1875,7 +1875,7 @@ mod tests {
             read_source: source.clone(),
             range: make_timestamp_range(150, 200),
             predicate: make_state_ma_predicate(),
-            group_keys: vec![String::from("tag1")],
+            group_keys: vec!["tag1".into()],
             group,
             aggregate: Some(RPCAggregate {
                 r#type: AggregateType::Sum as i32,
@@ -1887,7 +1887,7 @@ mod tests {
             predicate: "Predicate { exprs: [#state Eq Utf8(\"MA\")] range: TimestampRange { start: 150, end: 200 }}".into(),
             gby_agg: GroupByAndAggregate::Columns {
                 agg: QueryAggregate::Sum,
-                group_columns: vec![String::from("tag1")],
+                group_columns: vec!["tag1".into()],
             }
         };
 
@@ -1915,7 +1915,7 @@ mod tests {
             read_source: source.clone(),
             range: None,
             predicate: None,
-            group_keys: vec![String::from("tag1")],
+            group_keys: vec!["tag1".into()],
             group,
             aggregate: Some(RPCAggregate {
                 r#type: AggregateType::Sum as i32,
@@ -1945,7 +1945,7 @@ mod tests {
             read_source: source.clone(),
             range: None,
             predicate: None,
-            group_keys: vec![String::from("tag1")],
+            group_keys: vec!["tag1".into()],
             group,
             aggregate: Some(RPCAggregate {
                 r#type: AggregateType::Sum as i32,
@@ -1969,7 +1969,7 @@ mod tests {
             predicate: "Predicate {}".into(),
             gby_agg: GroupByAndAggregate::Columns {
                 agg: QueryAggregate::Sum,
-                group_columns: vec![String::from("tag1")],
+                group_columns: vec!["tag1".into()],
             },
         });
         assert_eq!(test_db.get_query_groups_request().await, expected_request);
@@ -2158,7 +2158,7 @@ mod tests {
 
         let request = MeasurementFieldsRequest {
             source: source.clone(),
-            measurement: String::from("TheMeasurement"),
+            measurement: "TheMeasurement".into(),
             range: make_timestamp_range(150, 200),
             predicate: make_state_ma_predicate(),
         };
@@ -2196,7 +2196,7 @@ mod tests {
         // ---
         let request = MeasurementFieldsRequest {
             source: source.clone(),
-            measurement: String::from("TheMeasurement"),
+            measurement: "TheMeasurement".into(),
             range: None,
             predicate: None,
         };


### PR DESCRIPTION

This is a PR towards ensuring the proper implementation of the read_group gRPC call (https://github.com/influxdata/influxdb_iox/issues/448)

It adds validation to the input parameters of `read_group` per the semantics described in [the read_group mini spec](https://docs.google.com/document/d/1UoCov4_NEhJHTxQftn5-YlzfhCiP5hgqDq9ikbRRa3g/)

Here is the rough implementation plan:

- [x] Implement read_group for `None` aggregates (https://github.com/influxdata/influxdb_iox/pull/538)
- [x] Error if any hints are provided, or if there is a discrepancy between `GroupBy` and `GroupNone` type (this PR)
- [ ] Implement read_group for `Sum`, `Count` and `Mean` aggregates
- [ ] Implement user defined aggregates for `min`, `max`, `first` and `last`, selector functions
- [ ] Implement read_group for `Min`, `Max`, `First` and `Last` (using selctor functions)
