### PR TITLE
feat(tracing): integrate Jaeger tracing sink

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,6 +56,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ansi_term"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
+dependencies = [
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -384,7 +393,7 @@ version = "2.33.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002"
 dependencies = [
- "ansi_term",
+ "ansi_term 0.11.0",
  "atty",
  "bitflags",
  "strsim",
@@ -1081,6 +1090,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "generator"
+version = "0.6.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cdc09201b2e8ca1b19290cf7e65de2246b8e91fb6874279722189c4de7b94dc"
+dependencies = [
+ "cc",
+ "libc",
+ "log",
+ "rustc_version",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1333,6 +1355,8 @@ dependencies = [
  "ingest",
  "mem_qe",
  "object_store",
+ "opentelemetry",
+ "opentelemetry-jaeger",
  "packers",
  "predicates",
  "prost",
@@ -1352,6 +1376,8 @@ dependencies = [
  "tonic",
  "tracing",
  "tracing-futures",
+ "tracing-opentelemetry",
+ "tracing-subscriber",
  "wal",
  "write_buffer",
 ]
@@ -1548,6 +1574,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "loom"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0e8460f2f2121162705187214720353c517b97bdfb3494c0b1e33d83ebe4bed"
+dependencies = [
+ "cfg-if 0.1.10",
+ "generator",
+ "scoped-tls",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "lz4"
 version = "1.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1565,6 +1604,15 @@ checksum = "dca79aa95d8b3226213ad454d328369853be3a1382d89532a854f4d69640acae"
 dependencies = [
  "cc",
  "libc",
+]
+
+[[package]]
+name = "matchers"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f099785f7595cc4b4553a174ce30dd7589ef93391ff414dbb67f62392b9e0ce1"
+dependencies = [
+ "regex-automata",
 ]
 
 [[package]]
@@ -1961,6 +2009,34 @@ dependencies = [
  "libc",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "opentelemetry"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e260f0ef133e1043b95143f83cfc8f6be023cf4b46a526da0212039b45392679"
+dependencies = [
+ "async-trait",
+ "futures",
+ "lazy_static",
+ "percent-encoding",
+ "pin-project 0.4.27",
+ "rand",
+ "regex",
+ "tokio",
+]
+
+[[package]]
+name = "opentelemetry-jaeger"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1434625fc67118fa79088f260051cf9149ca0d8737aefb7e4b5c6a861c765ca"
+dependencies = [
+ "async-trait",
+ "opentelemetry",
+ "thrift",
+ "tokio",
 ]
 
 [[package]]
@@ -2439,6 +2515,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae1ded71d66a4a97f5e961fd0cb25a5f366a42a41570d16a763a69c092c26ae4"
 dependencies = [
  "byteorder",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -2836,6 +2913,16 @@ dependencies = [
  "digest",
  "fake-simd",
  "opaque-debug",
+]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4921be914e16899a80adefb821f8ddb7974e3f1250223575a44ed994882127"
+dependencies = [
+ "lazy_static",
+ "loom",
 ]
 
 [[package]]
@@ -3508,6 +3595,62 @@ checksum = "ab7bb6f14721aa00656086e9335d363c5c8747bae02ebe32ea2c7dece5689b4c"
 dependencies = [
  "pin-project 0.4.27",
  "tracing",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e0f8c7178e13481ff6765bd169b33e8d554c5d2bbede5e32c356194be02b9b9"
+dependencies = [
+ "lazy_static",
+ "log",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-opentelemetry"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08457d22f95dc05ff929afcdc3d57f3a2437f9377765bb6e20ffeb67d72b1719"
+dependencies = [
+ "opentelemetry",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "tracing-serde"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb65ea441fbb84f9f6748fd496cf7f63ec9af5bca94dd86456978d055e8eb28b"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1fa8f0c8f4c594e4fc9debc1990deab13238077271ba84dd853d54902ee3401"
+dependencies = [
+ "ansi_term 0.12.1",
+ "chrono",
+ "lazy_static",
+ "matchers",
+ "regex",
+ "serde",
+ "serde_json",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1342,7 +1342,6 @@ dependencies = [
  "data_types",
  "dirs 3.0.1",
  "dotenv",
- "env_logger",
  "flate2",
  "futures",
  "generated_types",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1413,7 +1413,6 @@ version = "0.1.0"
 dependencies = [
  "arrow_deps",
  "data_types",
- "env_logger",
  "flate2",
  "influxdb_line_protocol",
  "influxdb_tsm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,7 @@ byteorder = "1.3.4"
 tonic = "0.3.1"
 prost = "0.6.1"
 prost-types = "0.6.1"
-tracing = "0.1"
+tracing = { version = "0.1", features = ["release_max_level_debug"] }
 tracing-futures="0.2.4"
 
 # OpenTelemetry sinks for tracing

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,6 @@ tokio = { version = "0.2", features = ["full"] }
 clap = "2.33.1"
 dotenv = "0.15.0"
 dirs = "3.0.1"
-env_logger = "0.7.1"
 futures = "0.3.1"
 
 serde_json = "1.0.44"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,6 +69,12 @@ prost-types = "0.6.1"
 tracing = "0.1"
 tracing-futures="0.2.4"
 
+# OpenTelemetry sinks for tracing
+tracing-subscriber = "0.2.15"
+tracing-opentelemetry = "0.9.0"
+opentelemetry = { version = "0.10", default-features = false, features = ["trace", "tokio"] }
+opentelemetry-jaeger = { version = "0.9", features = ["tokio"] }
+
 http = "0.2.0"
 snafu = "0.6.9"
 flate2 = "1.0"

--- a/docs/env.example
+++ b/docs/env.example
@@ -18,3 +18,8 @@
 # If using Google Cloud Storage as an object store:
 # GCS_BUCKET_NAME=bucket_name
 # SERVICE_ACCOUNT=/path/to/auth/info.json
+#
+# To enable Jaeger tracing:
+# OTEL_SERVICE_NAME="iox" # defaults to iox
+# OTEL_EXPORTER_JAEGER_AGENT_HOST="jaeger.influxdata.net"
+# OTEL_EXPORTER_JAEGER_AGENT_PORT="6831"

--- a/docs/tracing.md
+++ b/docs/tracing.md
@@ -1,0 +1,153 @@
+# Tracing in IOx
+
+IOx makes use of Rust's tracing ecosystem to output both application logs and
+tracing events to Jaeger for distributed request correlation.
+
+## The Components
+
+The `tracing` framework aims to provide individual, pluggable crates that are
+composed together to build a feature set custom to the application's needs.
+
+### The `tracing` framework
+
+Rust has the excellent [`tracing` crate] to facilitate collection of application
+events with associated contextual information. 
+
+The most user visible components provided are the `debug!()`, `info!()`, etc
+function-like macros, and the `#[tracing::instrument]` attribute macro.
+
+The `info!()` macro and friends emit an "event" - a point in time event tagged
+with relevant data.
+
+If you add the `instrument` macro to a function, the tracing framework records
+the function entry as a "span" that covers the duration of the call, and records
+the timestamp when it returns. Any events or sub-spans emitted further down the
+call stack inside this function's span are recorded as children of this span to
+track causality.
+
+The `tracing` crate focuses on providing a good API for emitting events & spans.
+Consumers of the tracing data are called `Subscribers` and they are implemented
+in other crates - there are subscribers that consume events and emit logs, some
+that use the function entry spans for timing/metric data, and more every day!
+
+### OpenTelemetry
+
+[OpenTelemetry] is a relatively new standard to encourage interoperability within
+the telemetry/tracing ecosystem. The `tracing-opentelemetry` crate subscribes to
+the data produced by the `tracing` crate.
+
+It's essentially an adaptor, consuming from `tracing` and converting them to
+OpenTelemetry compatible events.
+
+There are many [configuration options] supported at runtime.
+
+### Jaeger (`opentelemetry_jaeger`)
+
+[Jaeger] is a widely used telemetry collector with its own wire protocol,
+separate from OpenTelemetry. While they're working on adding support for the
+OpenTelemetry standard, it is not yet fully integrated (though I believe there
+are builds available.)
+
+The [`opentelemetry_jaeger` crate] sits at the end of the chain - the `tracing`
+events are converted to `tracing-opentelemetry` events, which dispatches them to
+this crate to be emitted to a listening Jaeger service.
+
+## Using it
+
+### Running IOx
+
+First off, when running IOx you need to choose how much information you want.
+You do this by setting the `RUST_LOG="debug"` environment variable (or `info`,
+`error`, etc) or passing `-v` or `-vv` on the command line. The `RUST_LOG`
+environment variable provides [granular control] over what log verbosity is
+configured for individual internal components (tip: try `RUST_LOG="iox=debug"`!)
+
+You can also choose to collect traces in Jaeger - this helps visualise
+request-scoped events and provides timing information, and is generally a pretty
+helpful tool when debugging. To enable Jaeger tracing output, set the following
+environment variables:
+
+```shell
+OTEL_SERVICE_NAME="iox" # Defaults to iox if not specified
+
+# No default, must be set
+OTEL_EXPORTER_JAEGER_AGENT_HOST="jaeger.influxdata.net"
+OTEL_EXPORTER_JAEGER_AGENT_PORT="6831"
+```
+
+### Working on IOx
+
+When you're writing code, you should liberally use `debug` level tracing, as
+well as `info` and above for information that is important to the user. This
+helps greatly when tracking down any problems or to simply understand where
+requests wind up in the codebase - this is particularly important when requests
+span multiple servers!
+
+Instrument your important functions at `info` - these provide a logical request
+call stack rather than a _function_ call stack, so you can construct meaningful
+traces without lots of noise.
+
+Emit logs as you normally would, but [include contextual information] in them as
+**fields** rather than interpolated strings:
+
+```rust
+#[tracing::instrument]
+fn say_hello(name: &str) {
+	// This is good - fields come first!
+    info!(name, "hello there");
+
+	// This is alright, but less structured / useful
+    info!("hello there {}", name);
+}
+```
+
+Instrumented functions wind up as distinct spans in the Jaeger trace, and all
+the events emitted within them are output to stdout as log lines (with the
+contextual information) as well as in the Jaeger span.
+
+Instrumented functions also record the call arguments automatically (though you
+can [control it]) with args printed using `Display` at `level=info` and above,
+or `Debug` being used for `level=debug`. For example:
+
+If your function returns a `Result<T, E>` and `E: Display` then you can record
+the error too:
+
+```rust
+#[tracing::instrument(err)]
+fn my_function(arg: usize) -> Result<(), std::io::Error> {
+    Ok(())
+}
+```
+
+You can also instrument a function only at the "debug" level (`info` is the
+default):
+
+```rust
+#[tracing::instrument(level = "debug")]
+fn say_hello() {}
+```
+
+## Good to Know
+
+* If you have an outer func that is instrumented with `level=debug`, and an
+  inner that is instrumented for `level=info`, the inner shows up when
+  `level=info` even if the outer does not (children are independent of their
+  parents).
+
+* You can control the log level of the Jaeger events with the OpenTelemetry
+  config envs, but ultimately the `RUST_LOG` env sets the log level filter - you
+  cannot configure telemetry to emit at a log level lower than `RUST_LOG`.
+
+* Be careful passing around sensitive arguments - instrumented functions will
+  record them! It's best to wrap them in some wrapper type that implements
+  neither `Display` nor `Debug` - then they can never be printed anywhere,
+  including in tracing!
+
+[configuration options]: https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/sdk-environment-variables.md#opentelemetry-environment-variable-specification
+[control it]: https://docs.rs/tracing/0.1.22/tracing/attr.instrument.html
+[granular control]: https://docs.rs/tracing-subscriber/0.2.15/tracing_subscriber/filter/struct.EnvFilter.html
+[`tracing` crate]: https://docs.rs/tracing/0.1.22/tracing/
+[OpenTelemetry]: https://opentelemetry.io/
+[Jaeger]: https://www.jaegertracing.io/
+[`opentelemetry_jaeger` crate]: https://docs.rs/opentelemetry/0.10.0/opentelemetry/
+[include contextual information]: https://docs.rs/tracing/0.1.22/tracing/#recording-fields

--- a/docs/tracing.md
+++ b/docs/tracing.md
@@ -87,6 +87,16 @@ Instrument your important functions at `info` - these provide a logical request
 call stack rather than a _function_ call stack, so you can construct meaningful
 traces without lots of noise.
 
+The `trace!()` level is useful to instrument areas of code for development or
+testing that should not wind up in the release binary - as such, the `trace`
+level is compiled at when building a "release" binary. As a guideline:
+
+* `trace!()` for debug builds and verbose messaging, used liberally as required.
+  Compiled out in release builds.
+* `debug!()` for events that would help tracking down bugs, but are not useful
+  to the user
+* `info!()` & above for info useful to the user
+
 Emit logs as you normally would, but [include contextual information] in them as
 **fields** rather than interpolated strings:
 

--- a/ingest/Cargo.toml
+++ b/ingest/Cargo.toml
@@ -8,7 +8,6 @@ edition = "2018"
 
 [dependencies]
 snafu = "0.6.2"
-env_logger = "0.7.1"
 tracing = "0.1"
 
 influxdb_line_protocol = { path = "../influxdb_line_protocol" }

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,6 +24,7 @@ mod commands {
 }
 
 use panic::SendPanicsToTracing;
+use tracing_subscriber::{prelude::*, EnvFilter};
 
 enum ReturnCode {
     ConversionFailed = 1,
@@ -129,7 +130,15 @@ Examples:
         ))
         .get_matches();
 
-    setup_logging(matches.occurrences_of("verbose"));
+    let mut tokio_runtime = get_runtime(matches.value_of("num-threads"))?;
+    tokio_runtime.block_on(dispatch_args(matches));
+
+    info!("InfluxDB IOx server shutting down");
+    Ok(())
+}
+
+async fn dispatch_args(matches: ArgMatches<'_>) {
+    let _drop_handle = setup_logging(matches.occurrences_of("verbose"));
 
     // Install custom panic handler and forget about it.
     //
@@ -140,14 +149,6 @@ Examples:
     let f = SendPanicsToTracing::new();
     std::mem::forget(f);
 
-    let mut tokio_runtime = get_runtime(matches.value_of("num-threads"))?;
-    tokio_runtime.block_on(dispatch_args(matches));
-
-    info!("InfluxDB IOx server shutting down");
-    Ok(())
-}
-
-async fn dispatch_args(matches: ArgMatches<'_>) {
     match matches.subcommand() {
         ("convert", Some(sub_matches)) => {
             let input_path = sub_matches.value_of("INPUT").unwrap();
@@ -216,7 +217,7 @@ const DEFAULT_LOG_LEVEL: &str = "warn";
 /// 2. if `-vv` (multiple instances of verbose), use DEFAULT_DEBUG_LOG_LEVEL
 /// 2. if `-v` (single instances of verbose), use DEFAULT_VERBOSE_LOG_LEVEL
 /// 3. Otherwise use DEFAULT_LOG_LEVEL
-fn setup_logging(num_verbose: u64) {
+fn setup_logging(num_verbose: u64) -> Option<opentelemetry_jaeger::Uninstall> {
     let rust_log_env = std::env::var("RUST_LOG");
 
     match rust_log_env {
@@ -235,7 +236,52 @@ fn setup_logging(num_verbose: u64) {
         },
     }
 
-    env_logger::init();
+    // Configure the OpenTelemetry tracer, if requested.
+    //
+    // To enable the tracing functionality, set OTEL_EXPORTER_JAEGER_AGENT_HOST
+    // env to some suitable value (see below).
+    //
+    // The Jaeger layer emits traces under the service name of "iox" if not
+    // overwrote by the user by setting the env below. All configuration is
+    // sourced from the environment:
+    //
+    // - OTEL_SERVICE_NAME: emitter service name (iox by default)
+    // - OTEL_EXPORTER_JAEGER_AGENT_HOST: hostname/address of the collector
+    // - OTEL_EXPORTER_JAEGER_AGENT_PORT: listening port of the collector
+    //
+    let (opentelemetry, drop_handle) = match std::env::var("OTEL_EXPORTER_JAEGER_AGENT_HOST") {
+        Ok(_) => {
+            // Initialise the jaeger event emitter
+            let (tracer, drop_handle) = opentelemetry_jaeger::new_pipeline()
+                .with_service_name("iox")
+                .from_env()
+                .install()
+                .unwrap();
+
+            // Initialise the opentelemetry tracing layer, giving it the jaeger emitter
+            let opentelemetry = tracing_opentelemetry::layer().with_tracer(tracer);
+
+            (Some(opentelemetry), Some(drop_handle))
+        }
+        Err(_) => (None, None),
+    };
+
+    // Configure the logger to write to stderr
+    let logger = tracing_subscriber::fmt::layer().with_writer(std::io::stderr);
+
+    // Register the chain of event subscribers:
+    //
+    //      - Jaeger tracing emitter
+    //      - Env filter (using RUST_LOG as the filter env)
+    //      - A stdout logger
+    //
+    tracing_subscriber::registry()
+        .with(opentelemetry)
+        .with(EnvFilter::from_default_env())
+        .with(logger)
+        .init();
+
+    drop_handle
 }
 
 /// Creates the tokio runtime for executing IOx
@@ -243,12 +289,17 @@ fn setup_logging(num_verbose: u64) {
 /// if nthreads is none, uses the default scheduler
 /// otherwise, creates a scheduler with the number of threads
 fn get_runtime(num_threads: Option<&str>) -> Result<Runtime, std::io::Error> {
+    // NOTE: no log macros will work here!
+    //
+    // That means use eprintln!() instead of error!() and so on. The log emitter
+    // requires a running tokio runtime and is initialised after this function.
+
     use tokio::runtime::Builder;
     let kind = std::io::ErrorKind::Other;
     match num_threads {
         None => Runtime::new(),
         Some(num_threads) => {
-            info!(
+            println!(
                 "Setting number of threads to '{}' per command line request",
                 num_threads
             );

--- a/src/main.rs
+++ b/src/main.rs
@@ -249,21 +249,20 @@ fn setup_logging(num_verbose: u64) -> Option<opentelemetry_jaeger::Uninstall> {
     // - OTEL_EXPORTER_JAEGER_AGENT_HOST: hostname/address of the collector
     // - OTEL_EXPORTER_JAEGER_AGENT_PORT: listening port of the collector
     //
-    let (opentelemetry, drop_handle) = match std::env::var("OTEL_EXPORTER_JAEGER_AGENT_HOST") {
-        Ok(_) => {
-            // Initialise the jaeger event emitter
-            let (tracer, drop_handle) = opentelemetry_jaeger::new_pipeline()
-                .with_service_name("iox")
-                .from_env()
-                .install()
-                .unwrap();
+    let (opentelemetry, drop_handle) = if std::env::var("OTEL_EXPORTER_JAEGER_AGENT_HOST").is_ok() {
+        // Initialise the jaeger event emitter
+        let (tracer, drop_handle) = opentelemetry_jaeger::new_pipeline()
+            .with_service_name("iox")
+            .from_env()
+            .install()
+            .unwrap();
 
-            // Initialise the opentelemetry tracing layer, giving it the jaeger emitter
-            let opentelemetry = tracing_opentelemetry::layer().with_tracer(tracer);
+        // Initialise the opentelemetry tracing layer, giving it the jaeger emitter
+        let opentelemetry = tracing_opentelemetry::layer().with_tracer(tracer);
 
-            (Some(opentelemetry), Some(drop_handle))
-        }
-        Err(_) => (None, None),
+        (Some(opentelemetry), Some(drop_handle))
+    } else {
+        (None, None)
     };
 
     // Configure the logger to write to stderr

--- a/src/main.rs
+++ b/src/main.rs
@@ -255,7 +255,7 @@ fn setup_logging(num_verbose: u64) -> Option<opentelemetry_jaeger::Uninstall> {
             .with_service_name("iox")
             .from_env()
             .install()
-            .unwrap();
+            .expect("failed to initialise the Jaeger tracing sink");
 
         // Initialise the opentelemetry tracing layer, giving it the jaeger emitter
         let opentelemetry = tracing_opentelemetry::layer().with_tracer(tracer);


### PR DESCRIPTION
Adds tracing support to IOx, pushing the spans to a Jaeger collector that is optionally enabled at runtime.

I've wrote a doc ([rendered here]) that covers a lot of what I would have put in this description - I'm interested to know if there's any other topics that should be included. I've tried to keep it relatively brief, but link to more resources for further detail - there's a lot to read about if you're inclined!

[rendered here]: https://github.com/influxdata/influxdb_iox/blob/dom/opentelemetry/docs/tracing.md

----

commit 4091823c4d6b4ba4076e1d1e80006ce0b2288441 (HEAD -> dom/opentelemetry, origin/dom/opentelemetry)
Author: Dom <dom@itsallbroken.com>
Date:   Thu Dec 10 11:05:36 2020 +0000

    docs(tracing): add IOx tracing usage doc

    Describes the components involved in, and usage of the tracing system in IOx.

commit a7077543d24daf997095707865fc6547360cb40f
Author: Dom <dom@itsallbroken.com>
Date:   Wed Dec 9 23:01:40 2020 +0000

    feat(tracing): add Jaeger tracing sink

    Adds telemetry / tracing with support for a Jaeger backend, and changes the
    logger from env_logger to a tracing subscriber to collect the log entries.

    Events are batched and then emitted asynchronosuly via UDP to the Jaeger
    collector using the tokio runtime. There's a bunch of settings (env
    vars) related to batch sizes and flush frequency etc - they're all using
    their default values at the moment (if it ain't broke...) See the docs
    for more info:

        https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/sdk-environment-variables.md#opentelemetry-environment-variable-specification

    This is only part 1 of telemetry - it does NOT propagate traces across RPC
    boundaries as we're still defining how all this should work. I've created #541
    to track this.

    Closes #202 and closes #203.
