### PR TITLE
fix: Correct and clarify lifetimes around the segment store

### DIFF
--- a/segment_store/src/column.rs
+++ b/segment_store/src/column.rs
@@ -1980,6 +1980,7 @@ impl From<&[f64]> for Column {
 
 /// These variants describe supported aggregates that can applied to columnar
 /// data.
+#[derive(Copy, Clone)]
 pub enum AggregateType {
     Count,
     First,

--- a/segment_store/src/segment.rs
+++ b/segment_store/src/segment.rs
@@ -617,13 +617,13 @@ impl MetaData {
 /// to work with and display.
 pub struct ReadFilterResult<'input, 'segment>(pub Vec<(ColumnName<'input>, Values<'segment>)>);
 
-impl<'input, 'segment> ReadFilterResult<'input, 'segment> {
+impl ReadFilterResult<'_, '_> {
     pub fn is_empty(&self) -> bool {
         self.0.is_empty()
     }
 }
 
-impl<'input, 'segment> std::fmt::Debug for &ReadFilterResult<'input, 'segment> {
+impl std::fmt::Debug for &ReadFilterResult<'_, '_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         // header line.
         for (i, (k, _)) in self.0.iter().enumerate() {
@@ -640,7 +640,7 @@ impl<'input, 'segment> std::fmt::Debug for &ReadFilterResult<'input, 'segment> {
     }
 }
 
-impl<'input, 'segment> std::fmt::Display for &ReadFilterResult<'input, 'segment> {
+impl std::fmt::Display for &ReadFilterResult<'_, '_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         if self.is_empty() {
             return Ok(());

--- a/segment_store/src/segment.rs
+++ b/segment_store/src/segment.rs
@@ -139,8 +139,9 @@ impl Segment {
         &self.columns[*self.all_columns_by_name.get(name).unwrap()]
     }
 
-    // Returns a reference to a column's name and a column from the column name. The returned
-    // column name will have the lifetime of `self`, not the lifetime of the input.
+    // Takes a `ColumnName`, looks up that column in the `Segment`, and returns a reference to
+    // that column's name owned by the `Segment` along with a reference to the column itself.
+    // The returned column name will have the lifetime of `self`, not the lifetime of the input.
     fn column_name_and_column(&self, name: ColumnName<'_>) -> (&str, &Column) {
         let (column_name, column_index) = self.all_columns_by_name.get_key_value(name).unwrap();
         (column_name, &self.columns[*column_index])

--- a/segment_store/src/segment.rs
+++ b/segment_store/src/segment.rs
@@ -170,7 +170,7 @@ impl Segment {
     /// Right now, predicates are conjunctive (AND).
     pub fn read_filter<'input>(
         &self,
-        columns: &'input [ColumnName<'input>],
+        columns: &[ColumnName<'input>],
         predicates: &[Predicate<'_>],
     ) -> ReadFilterResult<'input, '_> {
         let row_ids = self.row_ids_from_predicates(predicates);
@@ -179,7 +179,7 @@ impl Segment {
 
     fn materialise_rows<'input>(
         &self,
-        columns: &'input [ColumnName<'input>],
+        columns: &[ColumnName<'input>],
         row_ids: RowIDsOption,
     ) -> Vec<(ColumnName<'input>, Values<'_>)> {
         let mut results = vec![];
@@ -484,7 +484,7 @@ impl Segment {
         &self,
         predicates: &[Predicate<'_>],
         group_column: ColumnName<'input>,
-        aggregates: &'input [(ColumnName<'input>, AggregateType)],
+        aggregates: &[(ColumnName<'input>, AggregateType)],
     ) -> ReadGroupResult<'input, '_> {
         todo!()
     }
@@ -498,7 +498,7 @@ impl Segment {
         &self,
         predicates: &[Predicate<'_>],
         group_column: ColumnName<'input>,
-        aggregates: &'input [(ColumnName<'input>, AggregateType)],
+        aggregates: &[(ColumnName<'input>, AggregateType)],
     ) -> ReadGroupResult<'input, '_> {
         todo!()
     }

--- a/segment_store/src/segment.rs
+++ b/segment_store/src/segment.rs
@@ -168,20 +168,20 @@ impl Segment {
     /// predicates.
     ///
     /// Right now, predicates are conjunctive (AND).
-    pub fn read_filter<'a>(
-        &'a self,
-        columns: &[ColumnName<'a>],
+    pub fn read_filter<'input>(
+        &self,
+        columns: &'input [ColumnName<'input>],
         predicates: &[Predicate<'_>],
-    ) -> ReadFilterResult<'_> {
+    ) -> ReadFilterResult<'input, '_> {
         let row_ids = self.row_ids_from_predicates(predicates);
         ReadFilterResult(self.materialise_rows(columns, row_ids))
     }
 
-    fn materialise_rows<'a>(
-        &'a self,
-        columns: &[ColumnName<'a>],
+    fn materialise_rows<'input>(
+        &self,
+        columns: &'input [ColumnName<'input>],
         row_ids: RowIDsOption,
-    ) -> Vec<(ColumnName<'_>, Values<'_>)> {
+    ) -> Vec<(ColumnName<'input>, Values<'_>)> {
         let mut results = vec![];
         match row_ids {
             RowIDsOption::None(_) => results, // nothing to materialise
@@ -615,15 +615,15 @@ impl MetaData {
 
 /// Encapsulates results from segments with a structure that makes them easier
 /// to work with and display.
-pub struct ReadFilterResult<'a>(pub Vec<(ColumnName<'a>, Values<'a>)>);
+pub struct ReadFilterResult<'input, 'segment>(pub Vec<(ColumnName<'input>, Values<'segment>)>);
 
-impl<'a> ReadFilterResult<'a> {
+impl<'input, 'segment> ReadFilterResult<'input, 'segment> {
     pub fn is_empty(&self) -> bool {
         self.0.is_empty()
     }
 }
 
-impl<'a> std::fmt::Debug for &ReadFilterResult<'a> {
+impl<'input, 'segment> std::fmt::Debug for &ReadFilterResult<'input, 'segment> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         // header line.
         for (i, (k, _)) in self.0.iter().enumerate() {
@@ -640,7 +640,7 @@ impl<'a> std::fmt::Debug for &ReadFilterResult<'a> {
     }
 }
 
-impl<'a> std::fmt::Display for &ReadFilterResult<'a> {
+impl<'input, 'segment> std::fmt::Display for &ReadFilterResult<'input, 'segment> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         if self.is_empty() {
             return Ok(());

--- a/segment_store/src/table.rs
+++ b/segment_store/src/table.rs
@@ -512,7 +512,7 @@ impl MetaData {
 /// to work with and display.
 pub struct ReadFilterResults<'input, 'segment> {
     pub names: Vec<ColumnName<'input>>,
-    pub values: Vec<ReadFilterResult<'input, 'segment>>,
+    pub values: Vec<ReadFilterResult<'segment>>,
 }
 
 impl<'input, 'segment> ReadFilterResults<'input, 'segment> {

--- a/segment_store/src/table.rs
+++ b/segment_store/src/table.rs
@@ -132,11 +132,11 @@ impl Table {
     /// but can be ranged by time, which should be represented as nanoseconds
     /// since the epoch. Results are included if they satisfy the predicate and
     /// fall with the [min, max) time range domain.
-    pub fn select<'a>(
-        &'a self,
-        columns: &[ColumnName<'a>],
+    pub fn select<'input>(
+        &self,
+        columns: &'input [ColumnName<'input>],
         predicates: &[Predicate<'_>],
-    ) -> ReadFilterResults<'a> {
+    ) -> ReadFilterResults<'input, '_> {
         // identify segments where time range and predicates match could match
         // using segment meta data, and then execute against those segments and
         // merge results.
@@ -510,18 +510,18 @@ impl MetaData {
 
 /// Encapsulates results from tables with a structure that makes them easier
 /// to work with and display.
-pub struct ReadFilterResults<'a> {
-    pub names: Vec<ColumnName<'a>>,
-    pub values: Vec<ReadFilterResult<'a>>,
+pub struct ReadFilterResults<'input, 'segment> {
+    pub names: Vec<ColumnName<'input>>,
+    pub values: Vec<ReadFilterResult<'input, 'segment>>,
 }
 
-impl<'a> ReadFilterResults<'a> {
+impl<'input, 'segment> ReadFilterResults<'input, 'segment> {
     pub fn is_empty(&self) -> bool {
         self.values.is_empty()
     }
 }
 
-impl<'a> Display for ReadFilterResults<'a> {
+impl<'input, 'segment> Display for ReadFilterResults<'input, 'segment> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         // header line.
         for (i, k) in self.names.iter().enumerate() {

--- a/segment_store/src/table.rs
+++ b/segment_store/src/table.rs
@@ -554,7 +554,7 @@ pub struct ReadGroupResults<'input, 'segment> {
     aggregate_columns: &'input [(ColumnName<'input>, AggregateType)],
 
     // segment-wise result sets containing grouped values and aggregates
-    values: Vec<ReadGroupResult<'input, 'segment>>,
+    values: Vec<ReadGroupResult<'segment>>,
 }
 
 impl std::fmt::Display for ReadGroupResults<'_, '_> {

--- a/segment_store/src/table.rs
+++ b/segment_store/src/table.rs
@@ -134,7 +134,7 @@ impl Table {
     /// fall with the [min, max) time range domain.
     pub fn select<'input>(
         &self,
-        columns: &'input [ColumnName<'input>],
+        columns: &[ColumnName<'input>],
         predicates: &[Predicate<'_>],
     ) -> ReadFilterResults<'input, '_> {
         // identify segments where time range and predicates match could match

--- a/segment_store/src/table.rs
+++ b/segment_store/src/table.rs
@@ -173,12 +173,12 @@ impl Table {
     /// Required aggregates are specified via a tuple comprising a column name
     /// and the type of aggregation required. Multiple aggregations can be
     /// applied to the same column.
-    pub fn aggregate<'a>(
-        &'a self,
-        predicates: &[Predicate<'a>],
-        group_columns: &'a [ColumnName<'a>],
-        aggregates: &'a [(ColumnName<'a>, AggregateType)],
-    ) -> ReadGroupResults<'a> {
+    pub fn aggregate<'input>(
+        &self,
+        predicates: &[Predicate<'_>],
+        group_columns: &'input [ColumnName<'input>],
+        aggregates: &'input [(ColumnName<'input>, AggregateType)],
+    ) -> ReadGroupResults<'input, '_> {
         if !self.has_all_columns(&group_columns) {
             return ReadGroupResults::default(); //TODO(edd): return an error here "group key column x not found"
         }
@@ -546,18 +546,18 @@ impl<'input, 'segment> Display for ReadFilterResults<'input, 'segment> {
 }
 
 #[derive(Default)]
-pub struct ReadGroupResults<'a> {
+pub struct ReadGroupResults<'input, 'segment> {
     // column-wise collection of columns being grouped by
-    groupby_columns: &'a [ColumnName<'a>],
+    groupby_columns: &'input [ColumnName<'input>],
 
     // column-wise collection of columns being aggregated on
-    aggregate_columns: &'a [(ColumnName<'a>, AggregateType)],
+    aggregate_columns: &'input [(ColumnName<'input>, AggregateType)],
 
     // segment-wise result sets containing grouped values and aggregates
-    values: Vec<ReadGroupResult<'a>>,
+    values: Vec<ReadGroupResult<'input, 'segment>>,
 }
 
-impl<'a> std::fmt::Display for ReadGroupResults<'a> {
+impl std::fmt::Display for ReadGroupResults<'_, '_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         // header line - display group columns first
         for (i, name) in self.groupby_columns.iter().enumerate() {


### PR DESCRIPTION
These commits detangle and simplify the way data is borrowed around the segment store and query results. There's some more we could do here, but I did talk to @e-dard about this and we agreed this helps :)