### PR TITLE
feat: implement read_group aggregates with a hashmap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2130,6 +2130,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
+name = "permutation"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9978962f8a4b158e97447a6d09d2d75e206d2994eff056c894019f362b27142"
+
+[[package]]
 name = "petgraph"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2789,6 +2795,7 @@ dependencies = [
  "either",
  "itertools 0.9.0",
  "packers",
+ "permutation",
  "rand",
  "rand_distr",
 ]

--- a/segment_store/Cargo.toml
+++ b/segment_store/Cargo.toml
@@ -14,6 +14,7 @@ packers = { path = "../packers" }
 croaring = "0.4.5"
 itertools = "0.9.0"
 either = "1.6.1"
+permutation = "0.2.5"
 
 [dev-dependencies]
 criterion = "0.3.3"

--- a/segment_store/benches/segment.rs
+++ b/segment_store/benches/segment.rs
@@ -21,9 +21,10 @@ fn read_group(c: &mut Criterion) {
     read_group_pre_computed_groups(c, &segment, &mut rng);
 }
 
-// These benchmarks track the performance of read_group using the general approach
-// of building up a mapping of group keys. To avoid hitting the optimised no
-// predicate implementation we apply a time predicate that covers the segment.
+// These benchmarks track the performance of read_group using the general
+// approach of building up a mapping of group keys. To avoid hitting the
+// optimised no predicate implementation we apply a time predicate that covers
+// the segment.
 fn read_group_predicate_all_time(c: &mut Criterion, segment: &Segment, rng: &mut ThreadRng) {
     // This benchmark fixes the number of rows in the segment (500K), and varies
     // the cardinality of the group keys.

--- a/segment_store/src/segment.rs
+++ b/segment_store/src/segment.rs
@@ -357,7 +357,23 @@ impl Segment {
             return self.read_group_all_rows_all_rle(group_columns, aggregates);
         }
 
-        ReadGroupResult::default()
+        // If there is a single group column then we can use an optimised
+        // approach for building group keys
+        if group_columns.len() == 1 {
+            return self.read_group_single_group_column(predicates, group_columns[0], aggregates);
+        }
+
+        // Perform the group by using a hashmap
+        self.read_group_hash(predicates, group_columns, aggregates)
+    }
+
+    fn read_group_hash(
+        &self,
+        predicates: &[Predicate<'_>],
+        group_columns: &[ColumnName<'_>],
+        aggregates: &[(ColumnName<'_>, AggregateType)],
+    ) -> ReadGroupResult<'_> {
+        todo!()
     }
 
     // Optimised read group method when there are no predicates and all the group

--- a/segment_store/src/segment.rs
+++ b/segment_store/src/segment.rs
@@ -1,4 +1,7 @@
-use std::{borrow::Cow, collections::BTreeMap};
+use std::{
+    borrow::Cow,
+    collections::{BTreeMap, HashMap},
+};
 
 use itertools::Itertools;
 
@@ -445,7 +448,7 @@ impl Segment {
         }
 
         // Now begin building the group keys.
-        let mut groups = BTreeMap::new();
+        let mut groups = HashMap::new();
 
         // key_buf will be used as a temporary buffer for group keys, which are
         // themselves integers.

--- a/segment_store/src/segment.rs
+++ b/segment_store/src/segment.rs
@@ -911,29 +911,31 @@ impl std::fmt::Display for &ReadGroupResult<'_> {
     }
 }
 
+/// helper function useful for tests and benchmarks. Creates a time-range predicate
+/// in the domain `[from, to)`.
+pub fn build_predicates_with_time(
+    from: i64,
+    to: i64,
+    others: Vec<Predicate<'_>>,
+) -> Vec<Predicate<'_>> {
+    let mut arr = vec![
+        (
+            TIME_COLUMN_NAME,
+            (Operator::GTE, Value::Scalar(Scalar::I64(from))),
+        ),
+        (
+            TIME_COLUMN_NAME,
+            (Operator::LT, Value::Scalar(Scalar::I64(to))),
+        ),
+    ];
+
+    arr.extend(others);
+    arr
+}
+
 #[cfg(test)]
 mod test {
     use super::*;
-
-    fn build_predicates_with_time(
-        from: i64,
-        to: i64,
-        others: Vec<Predicate<'_>>,
-    ) -> Vec<Predicate<'_>> {
-        let mut arr = vec![
-            (
-                TIME_COLUMN_NAME,
-                (Operator::GTE, Value::Scalar(Scalar::I64(from))),
-            ),
-            (
-                TIME_COLUMN_NAME,
-                (Operator::LT, Value::Scalar(Scalar::I64(to))),
-            ),
-        ];
-
-        arr.extend(others);
-        arr
-    }
 
     #[test]
     fn row_ids_from_predicates() {

--- a/segment_store/src/segment.rs
+++ b/segment_store/src/segment.rs
@@ -1242,6 +1242,21 @@ south,NULL,PUT
 west,prod,GET
 ",
             ),
+            // This case is identical to above but has an explicit
+            // `region > "north"` predicate.
+            (
+                build_predicates_with_time(
+                    -1,
+                    10,
+                    vec![("region", (Operator::GT, Value::String("north")))],
+                ),
+                vec!["region", "env"],
+                vec![("method", AggregateType::Min)], // Yep, you can aggregate any column.
+                "region,env,method_min
+south,NULL,PUT
+west,prod,GET
+",
+            ),
         ];
 
         for (predicate, group_cols, aggs, expected) in cases {

--- a/segment_store/src/table.rs
+++ b/segment_store/src/table.rs
@@ -180,32 +180,31 @@ impl Table {
         aggregates: &'input [(ColumnName<'input>, AggregateType)],
     ) -> ReadGroupResults<'input, '_> {
         if !self.has_all_columns(&group_columns) {
-            return ReadGroupResults::default(); //TODO(edd): return an error
-                                                // here "group key column x not
-                                                // found"
+            todo!() //TODO(edd): return an error here "group key column x not
+                    //found"
         }
 
         if !self.has_all_columns(&aggregates.iter().map(|(name, _)| *name).collect::<Vec<_>>()) {
-            return ReadGroupResults::default(); //TODO(edd): return an error
-                                                // here "aggregate column x not
-                                                // found"
+            todo!() //TODO(edd): return an error here "aggregate column x not
+                    // found"
         }
 
         if !self.has_all_columns(&predicates.iter().map(|(name, _)| *name).collect::<Vec<_>>()) {
-            return ReadGroupResults::default(); //TODO(edd): return an error
-                                                // here "predicate column x not
-                                                // found"
+            todo!() //TODO(edd): return an error here "predicate column x not
+                    // found"
         }
 
         // identify segments where time range and predicates match could match
         // using segment meta data, and then execute against those segments and
         // merge results.
+        let mut results = ReadGroupResults::default();
         let segments = self.filter_segments(predicates);
         if segments.is_empty() {
-            return ReadGroupResults::default();
+            results.groupby_columns = group_columns;
+            results.aggregate_columns = aggregates;
+            return results;
         }
 
-        let mut results = ReadGroupResults::default();
         results.values.reserve(segments.len());
         for segment in segments {
             let segment_result = segment.read_group(predicates, &group_columns, &aggregates);


### PR DESCRIPTION
This PR provides an initial implementation of `read_group` aggregation in the segment store. Grouping by any column other than a dictionary encoded string column, e.g., a "tag column" is not covered in this PR.

Further, there are three subsequent PRs that will each add optimisations to this operation for specific types of query. 

The implementation in this PR is pretty simple. First we apply predicates to the appropriate columns in the segment and materialise an intermediate set of row ids held in a compressed bitset. 

We take that set of row IDs and then materialise the _encoded_ values for columns we are grouping on, i.e., we materialise vectors of `u32` integers for each grouping column. We do the same for the columns we will be aggregating on.

Next we iterate over each row for all columns and we build the group key for the row, which is a `Vec<u32>` of the encoded ids for each column. We check if this group key already exists in a hashmap. If it does not exist we create some initial aggregates for the columns we are aggregating on and set them in the map. If the key does exist we then _update_ the aggregates in the map using the values we find on the same row in the aggregate columns.

Finally in this PR I swap out a `BTreeMap` for a `HashMap` after demonstrating that it is significantly more performant (**20-50%**), which is not surprising for larger maps. Naturally, using a `HashMap` means that the order of the groups is undefined. This is fine for a segment because ordering of results will be handled higher up in a `Table` (where we may need to merged segment results). However, to make the testing story somewhat pleasant I implemented `Ord` on the `GroupKey` type so that we can sort collections of group keys and verify the `read_group` is working properly.

This is certainly not the end of the performance story for `read_group`. I have the following work in PRs to follow:

- [x] Get `read_group` working via hashmap.
- [ ] Replace the hash function used in the hashmap for a much faster one (using `hashbrown`). Also use the `hashbrown` raw entry API.
- [ ] When grouping by four or fewer columns in the query we can *pack* the group key (`Vec<u32>`) into a single `u128`. Now you have a single integer key to your hashmap, which is much more performant.
- [ ] When grouping on a single column you don't need a hashmap at all. You can allocate a slab of memory (via a vector) and simply index into it with your group keys (which will be single `u32` values).
- [ ] When you know your group key is "totally ordered", that is, all the columns  you're grouping on are in sorted order, you can just stream out the results and aggregate in one pass.

There are benchmarks available in the final 7c0ed96 commit, but the current performance of `read_group` in this PR is able to generate several hundred thousand groups per second. 

There are three types of benchmarks:

 - those that vary the cardinality of a segment whilst fixing the number of rows and columns being grouped on
 - those that fix cardinality and number of rows and vary the number of columns being grouped.
 - those that fix cardinality and columns and vary the number of rows.
