### PR TITLE
fix: Compiler errors missed in aws object store tests

### DIFF
--- a/object_store/src/lib.rs
+++ b/object_store/src/lib.rs
@@ -1121,7 +1121,7 @@ mod tests {
                 .await
                 .unwrap_err();
             if let Some(Error(InternalError::UnableToListDataFromS3 { source, bucket })) =
-                e.downcast_ref::<crate::Error>()
+                err.downcast_ref::<crate::Error>()
             {
                 assert!(matches!(
                     source,
@@ -1129,7 +1129,7 @@ mod tests {
                         rusoto_s3::ListObjectsV2Error::NoSuchBucket(_),
                     )
                 ));
-                assert_eq!(bucket, &bucket_name);
+                assert_eq!(bucket, bucket_name);
             } else {
                 panic!("unexpected error type")
             }


### PR DESCRIPTION
So this doesn't fix the underlying problem of not compiling all targets that is detailed in #537, but it does solve the compilation errors in the AWS tests that weren't caught because we're not compiling them in CI... I was hitting them locally because I did have the env vars set.