### PR TITLE
chore: Connect server crate to http routes and server command

### DIFF
--- a/docs/env.example
+++ b/docs/env.example
@@ -1,6 +1,11 @@
 # This is an example .env file showing all of the environment variables that can
 # be configured within the project.
 #
+# The identifier for the server. Used for writing to object storage and as
+# an identifier that is added to replicated writes, WAL segments and Chunks.
+# Must be unique in a group of connected or semi-connected IOx servers.
+# INFLUXDB_IOX_ID=1
+#
 # Where to store files on disk:
 # INFLUXDB_IOX_DB_DIR=$HOME/.influxdb_iox
 # TEST_INFLUXDB_IOX_DB_DIR=$HOME/.influxdb_iox

--- a/docs/env.example
+++ b/docs/env.example
@@ -4,6 +4,7 @@
 # The identifier for the server. Used for writing to object storage and as
 # an identifier that is added to replicated writes, WAL segments and Chunks.
 # Must be unique in a group of connected or semi-connected IOx servers.
+# Must be a number that can be represented by a 32-bit unsigned integer.
 # INFLUXDB_IOX_ID=1
 #
 # Where to store files on disk:

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -17,7 +17,7 @@ use data_types::{
 };
 use influxdb_line_protocol::ParsedLine;
 use object_store::ObjectStore;
-use query::{SQLDatabase, TSDatabase};
+use query::{DatabaseStore, SQLDatabase, TSDatabase};
 use write_buffer::Db as WriteBufferDb;
 
 use async_trait::async_trait;
@@ -25,6 +25,7 @@ use bytes::Bytes;
 use futures::stream::TryStreamExt;
 use serde::{Deserialize, Serialize};
 use snafu::{OptionExt, ResultExt, Snafu};
+use tokio::sync::RwLock;
 
 type DatabaseError = Box<dyn std::error::Error + Send + Sync + 'static>;
 
@@ -68,9 +69,9 @@ pub type Result<T, E = Error> = std::result::Result<T, E>;
 /// of these structs, which keeps track of all replication and query rules.
 #[derive(Debug)]
 pub struct Server<M: ConnectionManager> {
-    config: Config,
+    config: RwLock<Config>,
     connection_manager: M,
-    store: ObjectStore,
+    pub store: Arc<ObjectStore>,
 }
 
 #[derive(Debug, Default, Serialize, Deserialize, Eq, PartialEq)]
@@ -82,9 +83,9 @@ struct Config {
 }
 
 impl<M: ConnectionManager> Server<M> {
-    pub fn new(connection_manager: M, store: ObjectStore) -> Self {
+    pub fn new(connection_manager: M, store: Arc<ObjectStore>) -> Self {
         Self {
-            config: Config::default(),
+            config: RwLock::new(Config::default()),
             store,
             connection_manager,
         }
@@ -92,28 +93,30 @@ impl<M: ConnectionManager> Server<M> {
 
     /// sets the id of the server, which is used for replication and the base
     /// path in object storage
-    pub fn set_id(&mut self, id: u32) {
-        self.config.id = Some(id);
+    pub async fn set_id(&self, id: u32) {
+        let mut config = self.config.write().await;
+        config.id = Some(id);
     }
 
-    fn require_id(&self) -> Result<u32> {
-        self.config.id.context(IdNotSet)
+    async fn require_id(&self) -> Result<u32> {
+        let config = self.config.read().await;
+        config.id.context(IdNotSet)
     }
 
     /// Tells the server the set of rules for a database. Currently, this is not
     /// persisted and is for in-memory processing rules only.
     pub async fn create_database(
-        &mut self,
+        &self,
         db_name: impl Into<String>,
         rules: DatabaseRules,
     ) -> Result<()> {
         // Return an error if this server hasn't yet been setup with an id
-        self.require_id()?;
+        self.require_id().await?;
 
         let db_name = DatabaseName::new(db_name.into()).context(InvalidDatabaseName)?;
 
         let buffer = if rules.store_locally {
-            Some(WriteBufferDb::new(db_name.to_string()))
+            Some(Arc::new(WriteBufferDb::new(db_name.to_string())))
         } else {
             None
         };
@@ -126,7 +129,8 @@ impl<M: ConnectionManager> Server<M> {
             sequence,
         };
 
-        self.config.databases.insert(db_name, db);
+        let mut config = self.config.write().await;
+        config.databases.insert(db_name, db);
 
         Ok(())
     }
@@ -136,9 +140,10 @@ impl<M: ConnectionManager> Server<M> {
     /// manager can use to return a remote server to work with.
     pub async fn create_host_group(&mut self, id: HostGroupId, hosts: Vec<String>) -> Result<()> {
         // Return an error if this server hasn't yet been setup with an id
-        self.require_id()?;
+        self.require_id().await?;
 
-        self.config
+        let mut config = self.config.write().await;
+        config
             .host_groups
             .insert(id.clone(), HostGroup { id, hosts });
 
@@ -149,9 +154,12 @@ impl<M: ConnectionManager> Server<M> {
     /// JSON file in the configured store under a directory /<writer
     /// ID/config.json
     pub async fn store_configuration(&self) -> Result<()> {
-        let id = self.require_id()?;
+        let id = self.require_id().await?;
 
-        let data = Bytes::from(serde_json::to_vec(&self.config).context(ErrorSerializing)?);
+        let data = {
+            let config = self.config.read().await;
+            Bytes::from(serde_json::to_vec(&*config).context(ErrorSerializing)?)
+        };
         let len = data.len();
         let location = config_location(id);
 
@@ -183,8 +191,10 @@ impl<M: ConnectionManager> Server<M> {
             .await
             .context(StoreError)?;
 
-        let config: Config = serde_json::from_slice(&read_data).context(ErrorDeserializing)?;
-        self.config = config;
+        let loaded_config: Config =
+            serde_json::from_slice(&read_data).context(ErrorDeserializing)?;
+        let mut config = self.config.write().await;
+        *config = loaded_config;
 
         Ok(())
     }
@@ -194,11 +204,14 @@ impl<M: ConnectionManager> Server<M> {
     /// on the configuration of the `db`. This is step #1 from the crate
     /// level documentation.
     pub async fn write_lines(&self, db_name: &str, lines: &[ParsedLine<'_>]) -> Result<()> {
-        let id = self.require_id()?;
+        let id = self.require_id().await?;
 
         let db_name = DatabaseName::new(db_name).context(InvalidDatabaseName)?;
-        let db = self
-            .config
+        // TODO: update server structure to not have to hold this lock to write to the
+        // DB.       i.e. wrap DB in an arc or rethink how db is structured as
+        // well
+        let config = self.config.read().await;
+        let db = config
             .databases
             .get(&db_name)
             .context(DatabaseNotFound { db_name: &*db_name })?;
@@ -215,8 +228,8 @@ impl<M: ConnectionManager> Server<M> {
     pub async fn query_local(&self, db_name: &str, query: &str) -> Result<Vec<RecordBatch>> {
         let db_name = DatabaseName::new(db_name).context(InvalidDatabaseName)?;
 
-        let db = self
-            .config
+        let config = self.config.read().await;
+        let db = config
             .databases
             .get(&db_name)
             .context(DatabaseNotFound { db_name: &*db_name })?;
@@ -272,8 +285,8 @@ impl<M: ConnectionManager> Server<M> {
         db_name: &DatabaseName<'_>,
         write: &ReplicatedWrite,
     ) -> Result<()> {
-        let group = self
-            .config
+        let config = self.config.read().await;
+        let group = config
             .host_groups
             .get(host_group_id)
             .context(HostGroupNotFound { id: host_group_id })?;
@@ -299,6 +312,53 @@ impl<M: ConnectionManager> Server<M> {
             .context(ErrorReplicating {})?;
 
         Ok(())
+    }
+
+    pub async fn db(&self, name: &DatabaseName<'_>) -> Option<Arc<WriteBufferDb>> {
+        let config = self.config.read().await;
+        config
+            .databases
+            .get(&name)
+            .and_then(|d| d.local_store.clone())
+    }
+}
+
+// TODO: refactor other parts of codebase to not use this DatabaseStore trait.
+// They shouldn't        be accessing the DB directly.
+#[async_trait]
+impl DatabaseStore for Server<ConnectionManagerImpl> {
+    type Database = WriteBufferDb;
+    type Error = Error;
+
+    async fn db(&self, name: &str) -> Option<Arc<Self::Database>> {
+        if let Ok(name) = DatabaseName::new(name) {
+            return self.db(&name).await;
+        }
+
+        None
+    }
+
+    // TODO: refactor usages of this to use the Server rather than this trait and to
+    //       explicitly create a database.
+    async fn db_or_create(&self, name: &str) -> Result<Arc<Self::Database>, Self::Error> {
+        let db_name = DatabaseName::new(name.to_string()).context(InvalidDatabaseName)?;
+        let mut config = self.config.write().await;
+        let db = config.databases.entry(db_name).or_insert_with(|| {
+            let sequence = AtomicU64::new(STARTING_SEQUENCE);
+            let rules = DatabaseRules::default();
+            Db {
+                rules,
+                local_store: Some(Arc::new(WriteBufferDb::new(name))),
+                wal_buffer: None,
+                sequence,
+            }
+        });
+
+        Ok(db
+            .local_store
+            .as_ref()
+            .expect("this should be refactored out")
+            .clone())
     }
 }
 
@@ -334,7 +394,7 @@ pub struct Db {
     #[serde(flatten)]
     pub rules: DatabaseRules,
     #[serde(skip)]
-    pub local_store: Option<WriteBufferDb>,
+    pub local_store: Option<Arc<WriteBufferDb>>,
     #[serde(skip)]
     wal_buffer: Option<Buffer>,
     #[serde(skip)]
@@ -353,6 +413,39 @@ const STARTING_SEQUENCE: u64 = 1;
 impl Db {
     fn next_sequence(&self) -> u64 {
         self.sequence.fetch_add(1, Ordering::SeqCst)
+    }
+}
+
+/// The connection manager maps a host identifier to a remote server.
+#[derive(Debug)]
+pub struct ConnectionManagerImpl {}
+
+#[async_trait]
+impl ConnectionManager for ConnectionManagerImpl {
+    type Error = Error;
+    type RemoteServer = RemoteServerImpl;
+
+    async fn remote_server(&self, _connect: &str) -> Result<Arc<Self::RemoteServer>, Self::Error> {
+        unimplemented!()
+    }
+}
+
+/// An implementation for communicating with other IOx servers. This should
+/// be moved into and implemented in an influxdb_iox_client create at a later
+/// date.
+#[derive(Debug)]
+pub struct RemoteServerImpl {}
+
+#[async_trait]
+impl RemoteServer for RemoteServerImpl {
+    type Error = Error;
+
+    async fn replicate(
+        &self,
+        _db: &str,
+        _replicated_write: &ReplicatedWrite,
+    ) -> Result<(), Self::Error> {
+        unimplemented!()
     }
 }
 
@@ -379,7 +472,7 @@ mod tests {
     #[tokio::test]
     async fn server_api_calls_return_error_with_no_id_set() -> Result {
         let manager = TestConnectionManager::new();
-        let store = ObjectStore::new_in_memory(InMemory::new());
+        let store = Arc::new(ObjectStore::new_in_memory(InMemory::new()));
         let mut server = Server::new(manager, store);
 
         let rules = DatabaseRules::default();
@@ -402,9 +495,9 @@ mod tests {
     #[tokio::test]
     async fn database_name_validation() -> Result {
         let manager = TestConnectionManager::new();
-        let store = ObjectStore::new_in_memory(InMemory::new());
-        let mut server = Server::new(manager, store);
-        server.set_id(1);
+        let store = Arc::new(ObjectStore::new_in_memory(InMemory::new()));
+        let server = Server::new(manager, store);
+        server.set_id(1).await;
 
         let reject: [&str; 5] = [
             "bananas!",
@@ -431,9 +524,9 @@ mod tests {
     #[tokio::test]
     async fn writes_local() -> Result {
         let manager = TestConnectionManager::new();
-        let store = ObjectStore::new_in_memory(InMemory::new());
-        let mut server = Server::new(manager, store);
-        server.set_id(1);
+        let store = Arc::new(ObjectStore::new_in_memory(InMemory::new()));
+        let server = Server::new(manager, store);
+        server.set_id(1).await;
         let rules = DatabaseRules {
             store_locally: true,
             ..Default::default()
@@ -470,10 +563,10 @@ mod tests {
             .remotes
             .insert(remote_id.to_string(), remote.clone());
 
-        let store = ObjectStore::new_in_memory(InMemory::new());
+        let store = Arc::new(ObjectStore::new_in_memory(InMemory::new()));
 
         let mut server = Server::new(manager, store);
-        server.set_id(1);
+        server.set_id(1).await;
         let host_group_id = "az1".to_string();
         let rules = DatabaseRules {
             replication: vec![host_group_id.clone()],
@@ -529,10 +622,10 @@ partition_key:
             .remotes
             .insert(remote_id.to_string(), remote.clone());
 
-        let store = ObjectStore::new_in_memory(InMemory::new());
+        let store = Arc::new(ObjectStore::new_in_memory(InMemory::new()));
 
         let mut server = Server::new(manager, store);
-        server.set_id(1);
+        server.set_id(1).await;
         let host_group_id = "az1".to_string();
         let rules = DatabaseRules {
             subscriptions: vec![Subscription {
@@ -588,10 +681,10 @@ partition_key:
     #[tokio::test]
     async fn store_and_load_configuration() -> Result {
         let manager = TestConnectionManager::new();
-        let store = ObjectStore::new_in_memory(InMemory::new());
+        let store = Arc::new(ObjectStore::new_in_memory(InMemory::new()));
 
         let mut server = Server::new(manager, store);
-        server.set_id(1);
+        server.set_id(1).await;
         let host_group_id = "az1".to_string();
         let remote_id = "serverA";
         let rules = DatabaseRules {
@@ -625,16 +718,23 @@ partition_key:
         assert_eq!(read_data, config);
 
         let manager = TestConnectionManager::new();
-        let store = match server.store.0 {
+        let store = match &server.store.0 {
             ObjectStoreIntegration::InMemory(in_mem) => in_mem.clone().await,
             _ => panic!("wrong type"),
         };
-        let store = ObjectStore::new_in_memory(store);
+        let store = Arc::new(ObjectStore::new_in_memory(store));
 
         let mut recovered_server = Server::new(manager, store);
-        assert_ne!(server.config, recovered_server.config);
+        let server_config = server.config.read().await;
+
+        {
+            let recovered_config = recovered_server.config.read().await;
+            assert_ne!(*server_config, *recovered_config);
+        }
+
         recovered_server.load_configuration(1).await.unwrap();
-        assert_eq!(server.config, recovered_server.config);
+        let recovered_config = recovered_server.config.read().await;
+        assert_eq!(*server_config, *recovered_config);
 
         Ok(())
     }

--- a/src/commands/server.rs
+++ b/src/commands/server.rs
@@ -1,4 +1,4 @@
-use tracing::{debug, info};
+use tracing::info;
 
 use std::fs;
 use std::net::SocketAddr;
@@ -7,12 +7,12 @@ use std::{env::VarError, path::PathBuf};
 
 use crate::server::http_routes;
 use crate::server::rpc::service;
+use server::server::{ConnectionManagerImpl as ConnectionManager, Server as AppServer};
 
 use hyper::service::{make_service_fn, service_fn};
 use hyper::Server;
 use object_store::{self, GoogleCloudStorage, ObjectStore};
 use query::exec::Executor as QueryExecutor;
-use write_buffer::{Db, WriteBufferDatabases};
 
 use snafu::{ResultExt, Snafu};
 
@@ -72,10 +72,6 @@ pub async fn main() -> Result<()> {
 
     fs::create_dir_all(&db_dir).context(CreatingDatabaseDirectory { path: &db_dir })?;
 
-    debug!("InfluxDB IOx Server using database directory: {:?}", db_dir);
-
-    let storage = Arc::new(WriteBufferDatabases::new(&db_dir));
-
     let object_store = if let Ok(bucket) = std::env::var("INFLUXDB_IOX_GCP_BUCKET") {
         info!("Using GCP bucket {} for storage", &bucket);
         ObjectStore::new_google_cloud_storage(GoogleCloudStorage::new(bucket))
@@ -85,24 +81,20 @@ pub async fn main() -> Result<()> {
     };
     let object_storage = Arc::new(object_store);
 
-    let dirs = storage
-        .wal_dirs()
-        .map_err(|e| Box::new(e) as Box<dyn std::error::Error + Send + Sync>)
-        .context(InitializingWriteBuffer { db_dir })?;
+    let connection_manager = ConnectionManager {};
+    let app_server = Arc::new(AppServer::new(connection_manager, object_storage));
 
-    // TODO: make recovery of multiple databases multi-threaded
-    for dir in dirs {
-        let db = Db::restore_from_wal(&dir)
-            .await
-            .map_err(|e| Box::new(e) as Box<dyn std::error::Error + Send + Sync>)
-            .context(RestoringWriteBuffer { dir })?;
-        storage.add_db(db).await;
+    // if this ID isn't set the server won't be usable until this is set via an API
+    // call
+    if let Ok(id) = std::env::var("INFLUXDB_IOX_ID") {
+        let id = id
+            .parse::<u32>()
+            .expect("INFLUXDB_IOX_ID must be a u32 integer");
+        info!("setting server ID to {}", id);
+        app_server.set_id(id).await;
+    } else {
+        info!("server ID not set. This must be set via API before writing or querying data.");
     }
-
-    let app_server = Arc::new(http_routes::AppServer {
-        write_buffer: storage.clone(),
-        object_store: object_storage.clone(),
-    });
 
     // Fire up the query executor
     let executor = Arc::new(QueryExecutor::default());
@@ -123,7 +115,7 @@ pub async fn main() -> Result<()> {
         .await
         .expect("failed to bind server");
 
-    let grpc_server = service::make_server(socket, storage.clone(), executor);
+    let grpc_server = service::make_server(socket, app_server.clone(), executor);
 
     info!("gRPC server listening on http://{}", grpc_bind_addr);
 

--- a/src/commands/server.rs
+++ b/src/commands/server.rs
@@ -1,4 +1,4 @@
-use tracing::info;
+use tracing::{info, warn};
 
 use std::fs;
 use std::net::SocketAddr;
@@ -93,7 +93,7 @@ pub async fn main() -> Result<()> {
         info!("setting server ID to {}", id);
         app_server.set_id(id).await;
     } else {
-        info!("server ID not set. This must be set via API before writing or querying data.");
+        warn!("server ID not set. This must be set via API before writing or querying data.");
     }
 
     // Fire up the query executor


### PR DESCRIPTION
This updates the http_routes and main server to use the Server crate. This is the first step in a larger effort to start hooking up the initial IOx API and get things running end to end with in-memory database, WAL buffer, and object storage.

For the time being, this disables the previous disk based WAL. Or rather, it uses the WriteBufferDb without it. That means that this IOx server has no persistence until later. Because of this, the restart in the end-to-end was removed.

Later PRs will add the WAL buffer and restart logic that loads from object store. We can opt to bring the local disk based WAL back later, but it will likely require some refactoring to work with how the WAL Buffer will operate.

The next PR will bring in the Routerify routes and move the snapshot logic over to Server. After that the create database API, which should then pave the way for removing the DatabaseStore trait and refactoring gRPC to use Server directly.