### PR TITLE
perf: Improve `read_group` performance with faster hash function

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2793,6 +2793,7 @@ dependencies = [
  "croaring",
  "data_types",
  "either",
+ "hashbrown",
  "itertools 0.9.0",
  "packers",
  "permutation",

--- a/segment_store/Cargo.toml
+++ b/segment_store/Cargo.toml
@@ -15,6 +15,7 @@ croaring = "0.4.5"
 itertools = "0.9.0"
 either = "1.6.1"
 permutation = "0.2.5"
+hashbrown = "0.9.1"
 
 [dev-dependencies]
 criterion = "0.3.3"

--- a/segment_store/src/column.rs
+++ b/segment_store/src/column.rs
@@ -2558,6 +2558,14 @@ impl EncodedValues {
         panic!("cannot borrow &Vec<u32>");
     }
 
+    /// Takes a `Vec<u32>` out of the enum.
+    pub fn take_u32(&mut self) -> Vec<u32> {
+        std::mem::take(match self {
+            Self::I64(a) => panic!("cannot take Vec<u32> out of I64 variant"),
+            Self::U32(arr) => arr,
+        })
+    }
+
     pub fn len(&self) -> usize {
         match self {
             Self::I64(v) => v.len(),

--- a/segment_store/src/segment.rs
+++ b/segment_store/src/segment.rs
@@ -336,10 +336,14 @@ impl Segment {
         )
     }
 
-    /// Right now, predicates are treated as conjunctive (AND) predicates.
+    /// Returns a set of group keys and aggregated column data associated with
+    /// them. `read_group` currently only supports grouping on columns that have
+    /// integer encoded representations - typically "tag columns".
+    ///
+    /// Right now, predicates are treated conjunctive (AND) predicates.
     /// `read_group` does not guarantee any sort order. Ordering of results
-    /// should be handled high up in the `Table` section of the segment
-    /// store, where multiple segment results may need to be merged.
+    /// should be handled high up in the `Table` section of the segment store,
+    /// where multiple segment results may need to be merged.
     pub fn read_group(
         &self,
         predicates: &[Predicate<'_>],
@@ -425,7 +429,7 @@ impl Segment {
                         encoded_values_buf = col.all_encoded_values(encoded_values_buf);
                     }
                 }
-                encoded_values_buf
+                encoded_values_buf.take_u32()
             })
             .collect();
 
@@ -449,27 +453,26 @@ impl Segment {
             aggregate_columns_data.push(column_values);
         }
 
+        self.read_group_hash_with_vec_key(dst, &groupby_encoded_ids, &aggregate_columns_data)
+    }
+
+    fn read_group_hash_with_vec_key<'a>(
+        &'a self,
+        dst: &mut ReadGroupResult<'a>,
+        groupby_encoded_ids: &[Vec<u32>],
+        aggregate_columns_data: &[Values<'a>],
+    ) {
         // Now begin building the group keys.
-        let mut groups: HashMap<Vec<i64>, Vec<AggregateResult<'_>>> = HashMap::default();
+        let mut groups: HashMap<Vec<u32>, Vec<AggregateResult<'_>>> = HashMap::default();
 
         // key_buf will be used as a temporary buffer for group keys, which are
         // themselves integers.
-        let mut key_buf = vec![0; group_cols_num];
+        let mut key_buf = vec![0; dst.group_columns.len()];
 
         for row in 0..groupby_encoded_ids[0].len() {
             // update the group key buffer with the group key for this row
             for (j, col_ids) in groupby_encoded_ids.iter().enumerate() {
-                match col_ids {
-                    EncodedValues::I64(ids) => {
-                        key_buf[j] = ids[row];
-                    }
-                    EncodedValues::U32(ids) => {
-                        // TODO(edd): hmmmm. This is unfortunate - we only need
-                        // the encoded values to be 64-bit integers if we are grouping
-                        // by time (i64 column).
-                        key_buf[j] = ids[row] as i64;
-                    }
-                }
+                key_buf[j] = col_ids[row];
             }
 
             match groups.raw_entry_mut().from_key(&key_buf) {
@@ -481,7 +484,7 @@ impl Segment {
                 }
                 // group key does not exist, so create it.
                 hash_map::RawEntryMut::Vacant(entry) => {
-                    let mut group_key_aggs = Vec::with_capacity(agg_cols_num);
+                    let mut group_key_aggs = Vec::with_capacity(dst.aggregate_columns.len());
                     for (_, agg_type) in &dst.aggregate_columns {
                         group_key_aggs.push(AggregateResult::from(agg_type));
                     }


### PR DESCRIPTION
This PR improves the performance of `read_group` in the Segment Store by `60-70%` (in terms of numbers of groups/second that we can generate).

<img width="1278" alt="Hashmap-2" src="https://user-images.githubusercontent.com/501993/102523293-3cd49d80-408f-11eb-9670-052b49679eaa.png">

`read_group` runtime is dominated by hashing group keys and checking they exist in the hashmap that builds the aggregates. By default in Rust, the hash function used in `std::collections::HashMap` is cryptographically secure, which means that it's slower than necessary for use-cases where you don't need the security. This is one such case.

Performance can be significantly improved by using an alternative hashing function via the `hashbrown` crate, which is what I have added here.

Benchmarks are included in the 7a40bd5 commit message.

- [x] Get `read_group` working via hashmap. #560
- [x] Replace the hash function used in the hashmap for a much faster one (using `hashbrown`). Also use the `hashbrown` raw entry API. (This PR)
- [ ] When grouping by four or fewer columns in the query we can *pack* the group key (`Vec<u32>`) into a single `u128`. Now you have a single integer key to your hashmap, which is much more performant.
- [ ] When grouping on a single column you don't need a hashmap at all. You can allocate a slab of memory (via a vector) and simply index into it with your group keys (which will be single `u32` values).
- [ ] When you know your group key is "totally ordered", that is, all the columns  you're grouping on are in sorted order, you can just stream out the results and aggregate in one pass.