### PR TITLE
docs: Add reference to docs directory and a table of contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,3 +205,7 @@ curl -v -G -d 'org=company' -d 'bucket=sensors' --data-urlencode 'sql_query=sele
 We welcome community contributions from anyone!
 
 Read our [Contributing Guide](CONTRIBUTING.md) for instructions on how to make your first contribution.
+
+## Architecture and Technical Documenation
+
+There are a variety of technical documents describing various parts of IOx in the [docs](docs) directory.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,11 @@
+# InfluxDB IOx Documentation
+
+This directory contains internal design documentation of potential
+interest for those who wish to understand how the code works. It is
+not intended to be general user facing documentation
+
+## Table of Contents:
+* Rust style and Idiom guide: [style_guide.md](style_guide.md)
+* Tracing and logging Guide: [tracing.md](tracing.md)
+* Thoughts on parquet encoding and compression for timeseries data: [encoding_thoughts.md](encoding_thoughts.md)
+* Thoughts on using multiple cores: [multi_core_tasks.md](multi_core_tasks.md)


### PR DESCRIPTION
Re #571 

Add a link to the docs directory from the main readme and a small table of contents
