### PR TITLE
perf: use vector to build aggregates for single-column grouping

### DIFF
--- a/segment_store/benches/segment.rs
+++ b/segment_store/benches/segment.rs
@@ -36,6 +36,7 @@ fn read_group_predicate_all_time(c: &mut Criterion, segment: &Segment, rng: &mut
         &time_pred,
         // grouping columns and expected cardinality
         vec![
+            (vec!["env"], 20),
             (vec!["env", "data_centre"], 20),
             (vec!["data_centre", "cluster"], 200),
             (vec!["cluster", "node_id"], 2000),
@@ -53,6 +54,7 @@ fn read_group_predicate_all_time(c: &mut Criterion, segment: &Segment, rng: &mut
         &time_pred,
         // number of cols to group on and expected cardinality
         vec![
+            (vec!["pod_id"], 20000),
             (vec!["node_id", "pod_id"], 20000),
             (vec!["cluster", "node_id", "pod_id"], 20000),
             (vec!["data_centre", "cluster", "node_id", "pod_id"], 20000),

--- a/segment_store/src/segment.rs
+++ b/segment_store/src/segment.rs
@@ -385,37 +385,24 @@ impl Segment {
             return result;
         }
 
-        // If there is a single group column then we can use an optimised
-        // approach for building group keys
-        if group_columns.len() == 1 {
-            self.read_group_single_group_column(predicates, &mut result);
-            return result;
-        }
-
-        // Perform the group by using a hashmap
-        self.read_group_hash(predicates, &mut result);
-        result
-    }
-
-    // read_group_hash executes a read-group-aggregate operation on the segment
-    // using a hashmap to build up a collection of group keys and aggregates.
-    //
-    // read_group_hash accepts a set of conjunctive predicates.
-    fn read_group_hash<'a>(&'a self, predicates: &[Predicate<'_>], dst: &mut ReadGroupResult<'a>) {
+        // There are predicates. The next stage is apply them and determine the
+        // intermediate set of row ids.
         let row_ids = self.row_ids_from_predicates(predicates);
         let filter_row_ids = match row_ids {
-            RowIDsOption::None(_) => return, // no matching rows
+            RowIDsOption::None(_) => {
+                return result;
+            } // no matching rows
             RowIDsOption::Some(row_ids) => Some(row_ids.to_vec()),
             RowIDsOption::All(row_ids) => None,
         };
 
-        let group_cols_num = dst.group_columns.len();
-        let agg_cols_num = dst.aggregate_columns.len();
+        let group_cols_num = result.group_columns.len();
+        let agg_cols_num = result.aggregate_columns.len();
 
         // materialise all *encoded* values for each column we are grouping on.
         // These will not be the logical (typically string) values, but will be
         // vectors of integers representing the physical values.
-        let groupby_encoded_ids: Vec<_> = dst
+        let groupby_encoded_ids: Vec<_> = result
             .group_columns
             .iter()
             .map(|name| {
@@ -423,13 +410,15 @@ impl Segment {
                 let mut encoded_values_buf =
                     EncodedValues::with_capacity_u32(col.num_rows() as usize);
 
-                // do we want some rows for the column or all of them?
+                // Do we want some rows for the column (predicate filtered some rows)
+                // or all of them (predicates filtered no rows).
                 match &filter_row_ids {
                     Some(row_ids) => {
                         encoded_values_buf = col.encoded_values(row_ids, encoded_values_buf);
                     }
                     None => {
-                        // None implies "no partial set of row ids" meaning get all of them.
+                        // None here means "no partial set of row ids" meaning get
+                        // all of them.
                         encoded_values_buf = col.all_encoded_values(encoded_values_buf);
                     }
                 }
@@ -437,9 +426,9 @@ impl Segment {
             })
             .collect();
 
-        // Materialise decoded values in aggregate columns.
+        // Materialise values in aggregate columns.
         let mut aggregate_columns_data = Vec::with_capacity(agg_cols_num);
-        for (name, agg_type) in &dst.aggregate_columns {
+        for (name, agg_type) in &result.aggregate_columns {
             let col = self.column_by_name(name);
 
             // TODO(edd): this materialises a column per aggregate. If there are
@@ -457,6 +446,28 @@ impl Segment {
             aggregate_columns_data.push(column_values);
         }
 
+        // If there is a single group column then we can use an optimised
+        // approach for building group keys
+        if group_columns.len() == 1 {
+            self.read_group_single_group_column(predicates, &mut result);
+            return result;
+        }
+
+        // Perform the group by using a hashmap
+        self.read_group_with_hashing(&mut result, &groupby_encoded_ids, aggregate_columns_data);
+        result
+    }
+
+    // read_group_hash executes a read-group-aggregate operation on the segment
+    // using a hashmap to build up a collection of group keys and aggregates.
+    //
+    // read_group_hash accepts a set of conjunctive predicates.
+    fn read_group_with_hashing<'a>(
+        &'a self,
+        dst: &mut ReadGroupResult<'a>,
+        groupby_encoded_ids: &[Vec<u32>],
+        aggregate_columns_data: Vec<Values<'a>>,
+    ) {
         // An optimised approach to building the hashmap of group keys using a
         // single 128-bit integer as the group key. If grouping is on more than
         // four columns then a fallback to using an vector as a key will happen.
@@ -465,7 +476,7 @@ impl Segment {
             return;
         }
 
-        self.read_group_hash_with_vec_key(dst, &groupby_encoded_ids, &aggregate_columns_data)
+        self.read_group_hash_with_vec_key(dst, &groupby_encoded_ids, &aggregate_columns_data);
     }
 
     // This function is used with `read_group_hash` when the number of columns

--- a/segment_store/src/segment.rs
+++ b/segment_store/src/segment.rs
@@ -782,10 +782,11 @@ impl Segment {
                     }
                 }
                 None => {
-                    let mut group_key_aggs = Vec::with_capacity(dst.aggregate_columns.len());
-                    for (_, agg_type) in &dst.aggregate_columns {
-                        group_key_aggs.push(AggregateResult::from(agg_type));
-                    }
+                    let mut group_key_aggs = dst
+                        .aggregate_columns
+                        .iter()
+                        .map(|(_, agg_type)| AggregateResult::from(agg_type))
+                        .collect::<Vec<_>>();
 
                     for (i, values) in aggregate_columns_data.iter().enumerate() {
                         group_key_aggs[i].update(values.value(row));


### PR DESCRIPTION
This PR adds functionality to `read_group` that improves performance when grouping on a single column, such as:

```
SELECT MIN(a), SUM(b) FROM cpu
GROUP BY "host"
```

In  this case, rather than using a `Hashmap` to map group keys to aggregates we can just allocate a single vector and use the encoded group key for the column (`u32`) to _index into the vector_. This provides constant-time access to the appropriate aggregate to update as we move through the rows in the columns we're aggregating using the value in the grouping column as an index.

Encoded values for group columns are always sequential, monotonically increasing integers so the maximum length that the allocated vector needs to be is the cardinality of the column we are grouping on. Therefore, the space requirements for this approach should be less than if we used a `Hashmap` (because the values will need the same memory, but we don't need to store keys).

Benchmarks for this PR show that when grouping on a single column with 20,000 groups over 500,000 rows, `read_group` execution time went from **14.077** down to **6.05ms**. A reduction of **~57%**.

- [x] Get `read_group` working via hashmap. #560
- [x] Replace the hash function used in the hashmap for a much faster one (using `hashbrown`). Also use the `hashbrown` raw entry API. #572
- [x] When grouping by four or fewer columns in the query we can *pack* the group key (`Vec<u32>`) into a single `u128`. Now you have a single integer key to your hashmap, which is much more performant. #573
- [x] When grouping on a single column you don't need a hashmap at all. You can allocate a slab of memory (via a vector) and simply index into it with your group keys (which will be single `u32` values). (This PR)
- [ ] When you know your group key is "totally ordered", that is, all the columns  you're grouping on are in sorted order, you can just stream out the results and aggregate in one pass.