### PR TITLE
feat: implement read_group in the write_buffer

### DIFF
--- a/query/src/exec/field.rs
+++ b/query/src/exec/field.rs
@@ -1,0 +1,182 @@
+use std::sync::Arc;
+
+use arrow_deps::arrow::{self, datatypes::SchemaRef};
+use data_types::TIME_COLUMN_NAME;
+use snafu::{ResultExt, Snafu};
+
+#[derive(Debug, Snafu)]
+pub enum Error {
+    #[snafu(display("Error finding field column: {:?} in schema '{}'", column_name, source))]
+    ColumnNotFoundForField {
+        column_name: String,
+        source: arrow::error::ArrowError,
+    },
+}
+
+pub type Result<T, E = Error> = std::result::Result<T, E>;
+
+/// Names for a field: a value field and the associated timestamp columns
+#[derive(Debug, PartialEq)]
+pub enum FieldColumns {
+    /// All field columns share a timestamp column, named TIME_COLUMN_NAME
+    SharedTimestamp(Vec<Arc<String>>),
+
+    /// Each field has a potentially different timestamp column
+    // (value_name, timestamp_name)
+    DifferentTimestamp(Vec<(Arc<String>, Arc<String>)>),
+}
+
+impl From<Vec<Arc<String>>> for FieldColumns {
+    fn from(v: Vec<Arc<String>>) -> Self {
+        Self::SharedTimestamp(v)
+    }
+}
+
+impl From<Vec<(Arc<String>, Arc<String>)>> for FieldColumns {
+    fn from(v: Vec<(Arc<String>, Arc<String>)>) -> Self {
+        Self::DifferentTimestamp(v)
+    }
+}
+
+impl From<Vec<&str>> for FieldColumns {
+    fn from(v: Vec<&str>) -> Self {
+        let v = v.into_iter().map(|v| Arc::new(v.to_string())).collect();
+
+        Self::SharedTimestamp(v)
+    }
+}
+
+impl From<&[&str]> for FieldColumns {
+    fn from(v: &[&str]) -> Self {
+        let v = v.iter().map(|v| Arc::new(v.to_string())).collect();
+
+        Self::SharedTimestamp(v)
+    }
+}
+
+/// Column indexes for a field: a value and corresponding timestamp
+#[derive(Debug, PartialEq, Clone)]
+pub struct FieldIndex {
+    pub value_index: usize,
+    pub timestamp_index: usize,
+}
+
+#[derive(Debug, PartialEq, Clone)]
+pub struct FieldIndexes {
+    inner: Arc<Vec<FieldIndex>>,
+}
+
+impl FieldIndexes {
+    /// Create FieldIndexes where each field has the same timestamp
+    /// and different value index
+    pub fn from_timestamp_and_value_indexes(
+        timestamp_index: usize,
+        value_indexes: &[usize],
+    ) -> Self {
+        value_indexes
+            .iter()
+            .map(|&value_index| FieldIndex {
+                value_index,
+                timestamp_index,
+            })
+            .collect::<Vec<_>>()
+            .into()
+    }
+
+    /// Convert a slice of pairs (value_index, time_index) into
+    /// FieldIndexes
+    pub fn from_slice(v: &[(usize, usize)]) -> Self {
+        let inner = v
+            .iter()
+            .map(|&(value_index, timestamp_index)| FieldIndex {
+                value_index,
+                timestamp_index,
+            })
+            .collect();
+
+        Self {
+            inner: Arc::new(inner),
+        }
+    }
+
+    pub fn as_slice(&self) -> &[FieldIndex] {
+        &self.inner.as_ref()
+    }
+}
+
+impl Into<FieldIndexes> for Vec<FieldIndex> {
+    fn into(self) -> FieldIndexes {
+        FieldIndexes {
+            inner: Arc::new(self),
+        }
+    }
+}
+
+impl FieldIndexes {
+    // look up which column index correponds to each column name
+    pub fn names_to_indexes(
+        schema: &SchemaRef,
+        column_names: &[Arc<String>],
+    ) -> Result<Vec<usize>> {
+        column_names
+            .iter()
+            .map(|column_name| {
+                schema
+                    .index_of(&*column_name)
+                    .context(ColumnNotFoundForField {
+                        column_name: column_name.as_ref(),
+                    })
+            })
+            .collect()
+    }
+
+    /// Translate the field columns into pairs of (field_index, timestamp_index)
+    pub fn from_field_columns(schema: &SchemaRef, field_columns: &FieldColumns) -> Result<Self> {
+        let indexes = match field_columns {
+            FieldColumns::SharedTimestamp(field_names) => {
+                let timestamp_index =
+                    schema
+                        .index_of(TIME_COLUMN_NAME)
+                        .context(ColumnNotFoundForField {
+                            column_name: TIME_COLUMN_NAME,
+                        })?;
+
+                Self::names_to_indexes(schema, &field_names)?
+                    .into_iter()
+                    .map(|field_index| FieldIndex {
+                        value_index: field_index,
+                        timestamp_index,
+                    })
+                    .collect::<Vec<_>>()
+                    .into()
+            }
+            FieldColumns::DifferentTimestamp(fields_and_timestamp_names) => {
+                fields_and_timestamp_names
+                    .iter()
+                    .map(|(field_name, timestamp_name)| {
+                        let field_index =
+                            schema
+                                .index_of(&*field_name)
+                                .context(ColumnNotFoundForField {
+                                    column_name: field_name.as_ref(),
+                                })?;
+
+                        let timestamp_index =
+                            schema
+                                .index_of(timestamp_name)
+                                .context(ColumnNotFoundForField {
+                                    column_name: TIME_COLUMN_NAME,
+                                })?;
+
+                        Ok(FieldIndex {
+                            value_index: field_index,
+                            timestamp_index,
+                        })
+                    })
+                    .collect::<Result<Vec<_>>>()?
+                    .into()
+            }
+        };
+        Ok(indexes)
+    }
+}

--- a/query/src/exec/seriesset.rs
+++ b/query/src/exec/seriesset.rs
@@ -21,19 +21,18 @@
 
 use std::sync::Arc;
 
-use arrow::{
-    array::StringArray, datatypes::DataType, datatypes::SchemaRef, record_batch::RecordBatch,
-};
+use arrow::{array::StringArray, datatypes::DataType, record_batch::RecordBatch};
 use arrow_deps::{
     arrow::{self},
     datafusion::physical_plan::SendableRecordBatchStream,
 };
-use data_types::TIME_COLUMN_NAME;
 use snafu::{ResultExt, Snafu};
 use tokio::stream::StreamExt;
 use tokio::sync::mpsc::{self, error::SendError};
 
 use croaring::bitmap::Bitmap;
+
+use super::field::{FieldColumns, FieldIndexes};
 
 #[derive(Debug, Snafu)]
 pub enum Error {
@@ -48,11 +47,8 @@ pub enum Error {
     ))]
     ReadingRecordBatch { source: arrow::error::ArrowError },
 
-    #[snafu(display("Error finding column: {:?} in schema '{}'", column_name, source))]
-    ColumnNotFoundForSeriesSet {
-        column_name: String,
-        source: arrow::error::ArrowError,
-    },
+    #[snafu(display("Intrnal field error while converting series set: {}", source))]
+    InternalField { source: super::field::Error },
 
     #[snafu(display("Sending series set results during conversion: {:?}", source))]
     SendingDuringConversion {
@@ -85,14 +81,11 @@ pub struct SeriesSet {
     /// key = value pairs that define this series
     pub tags: Vec<(Arc<String>, Arc<String>)>,
 
-    /// timestamp column index
-    pub timestamp_index: usize,
-
     /// the column index of each "field" of the time series. For
     /// example, if there are two field indexes then this series set
     /// would result in two distinct series being sent back, one for
     /// each field.
-    pub field_indices: Arc<Vec<usize>>,
+    pub field_indexes: FieldIndexes,
 
     // The row in the record batch where the data starts (inclusive)
     pub start_row: usize,
@@ -114,7 +107,6 @@ pub struct SeriesSet {
 pub struct GroupDescription {
     /// key = value  pairs that define the group
     pub tags: Vec<(Arc<String>, Arc<String>)>,
-    // TODO: maybe also include the resulting aggregate value (per group) here
 }
 
 #[derive(Debug)]
@@ -155,7 +147,7 @@ impl SeriesSetConverter {
         &mut self,
         table_name: Arc<String>,
         tag_columns: Arc<Vec<Arc<String>>>,
-        field_columns: Arc<Vec<Arc<String>>>,
+        field_columns: FieldColumns,
         num_prefix_tag_group_columns: Option<usize>,
         it: SendableRecordBatchStream,
     ) -> Result<()> {
@@ -185,7 +177,7 @@ impl SeriesSetConverter {
         &mut self,
         table_name: Arc<String>,
         tag_columns: Arc<Vec<Arc<String>>>,
-        field_columns: Arc<Vec<Arc<String>>>,
+        field_columns: FieldColumns,
         num_prefix_tag_group_columns: Option<usize>,
         mut it: SendableRecordBatchStream,
     ) -> Result<()> {
@@ -202,20 +194,15 @@ impl SeriesSetConverter {
 
             let schema = batch.schema();
             // TODO: check that the tag columns are sorted by tag name...
-
-            let timestamp_index =
-                schema
-                    .index_of(TIME_COLUMN_NAME)
-                    .context(ColumnNotFoundForSeriesSet {
-                        column_name: TIME_COLUMN_NAME,
-                    })?;
-            let tag_indicies = Self::names_to_indices(&schema, &tag_columns)?;
-            let field_indicies = Arc::new(Self::names_to_indices(&schema, &field_columns)?);
+            let tag_indexes =
+                FieldIndexes::names_to_indexes(&schema, &tag_columns).context(InternalField)?;
+            let field_indexes =
+                FieldIndexes::from_field_columns(&schema, &field_columns).context(InternalField)?;
 
             // Algorithm: compute, via bitsets, the rows at which each
             // tag column changes and thereby where the tagset
             // changes. Emit a new SeriesSet at each such transition
-            let mut tag_transitions = tag_indicies
+            let mut tag_transitions = tag_indexes
                 .iter()
                 .map(|&col| Self::compute_transitions(&batch, col))
                 .collect::<Result<Vec<_>>>()?;
@@ -253,10 +240,9 @@ impl SeriesSetConverter {
                             &batch,
                             start_row as usize,
                             &tag_columns,
-                            &tag_indicies,
+                            &tag_indexes,
                         ),
-                        timestamp_index,
-                        field_indices: field_indicies.clone(),
+                        field_indexes: field_indexes.clone(),
                         start_row: start_row as usize,
                         num_rows: (end_row - start_row) as usize,
                         batch: batch.clone(),
@@ -288,21 +274,7 @@ impl SeriesSetConverter {
         Ok(())
     }
 
-    // look up which column index correponds to each column name
-    fn names_to_indices(schema: &SchemaRef, column_names: &[Arc<String>]) -> Result<Vec<usize>> {
-        column_names
-            .iter()
-            .map(|column_name| {
-                schema
-                    .index_of(&*column_name)
-                    .context(ColumnNotFoundForSeriesSet {
-                        column_name: column_name.as_ref(),
-                    })
-            })
-            .collect()
-    }
-
-    /// returns a bitset with all row indicies where the value of the
+    /// returns a bitset with all row indexes where the value of the
     /// batch[col_idx] changes.  Does not include row 0, always includes
     /// the last row, `batch.num_rows() - 1`
     fn compute_transitions(batch: &RecordBatch, col_idx: usize) -> Result<Bitmap> {
@@ -345,18 +317,18 @@ impl SeriesSetConverter {
 
     /// Creates (column_name, column_value) pairs for each column
     /// named in `tag_column_name` at the corresponding index
-    /// `tag_indicies`
+    /// `tag_indexes`
     fn get_tag_keys(
         batch: &RecordBatch,
         row: usize,
         tag_column_names: &[Arc<String>],
-        tag_indicies: &[usize],
+        tag_indexes: &[usize],
     ) -> Vec<(Arc<String>, Arc<String>)> {
-        assert_eq!(tag_column_names.len(), tag_indicies.len());
+        assert_eq!(tag_column_names.len(), tag_indexes.len());
 
         tag_column_names
             .iter()
-            .zip(tag_indicies)
+            .zip(tag_indexes)
             .map(|(column_name, column_index)| {
                 let tag_value: String = batch
                     .column(*column_index)
@@ -471,8 +443,10 @@ mod tests {
 
         assert_eq!(*series_set.table_name, "foo");
         assert!(series_set.tags.is_empty());
-        assert_eq!(series_set.timestamp_index, 4);
-        assert_eq!(series_set.field_indices, Arc::new(vec![2]));
+        assert_eq!(
+            series_set.field_indexes,
+            FieldIndexes::from_timestamp_and_value_indexes(4, &[2])
+        );
         assert_eq!(series_set.start_row, 0);
         assert_eq!(series_set.num_rows, 2);
 
@@ -524,8 +498,10 @@ mod tests {
 
         assert_eq!(*series_set.table_name, "foo");
         assert!(series_set.tags.is_empty());
-        assert_eq!(series_set.timestamp_index, 4);
-        assert_eq!(series_set.field_indices, Arc::new(vec![2]));
+        assert_eq!(
+            series_set.field_indexes,
+            FieldIndexes::from_timestamp_and_value_indexes(4, &[2])
+        );
         assert_eq!(series_set.start_row, 0);
         assert_eq!(series_set.num_rows, 2);
 
@@ -577,8 +553,10 @@ mod tests {
 
         assert_eq!(*series_set.table_name, "bar");
         assert_eq!(series_set.tags, str_pair_vec_to_vec(&[("tag_a", "one")]));
-        assert_eq!(series_set.timestamp_index, 4);
-        assert_eq!(series_set.field_indices, Arc::new(vec![2]));
+        assert_eq!(
+            series_set.field_indexes,
+            FieldIndexes::from_timestamp_and_value_indexes(4, &[2])
+        );
         assert_eq!(series_set.start_row, 0);
         assert_eq!(series_set.num_rows, 2);
 
@@ -614,8 +592,10 @@ mod tests {
 
         assert_eq!(*series_set1.table_name, "foo");
         assert_eq!(series_set1.tags, str_pair_vec_to_vec(&[("tag_a", "one")]));
-        assert_eq!(series_set1.timestamp_index, 4);
-        assert_eq!(series_set1.field_indices, Arc::new(vec![3]));
+        assert_eq!(
+            series_set1.field_indexes,
+            FieldIndexes::from_timestamp_and_value_indexes(4, &[3])
+        );
         assert_eq!(series_set1.start_row, 0);
         assert_eq!(series_set1.num_rows, 3);
 
@@ -623,8 +603,10 @@ mod tests {
 
         assert_eq!(*series_set2.table_name, "foo");
         assert_eq!(series_set2.tags, str_pair_vec_to_vec(&[("tag_a", "two")]));
-        assert_eq!(series_set2.timestamp_index, 4);
-        assert_eq!(series_set2.field_indices, Arc::new(vec![3]));
+        assert_eq!(
+            series_set2.field_indexes,
+            FieldIndexes::from_timestamp_and_value_indexes(4, &[3])
+        );
         assert_eq!(series_set2.start_row, 3);
         assert_eq!(series_set2.num_rows, 2);
 
@@ -844,7 +826,7 @@ mod tests {
 
         let table_name = Arc::new(table_name.into());
         let tag_columns = str_vec_to_arc_vec(tag_columns);
-        let field_columns = str_vec_to_arc_vec(field_columns);
+        let field_columns = FieldColumns::from(field_columns);
 
         tokio::task::spawn(async move {
             converter
@@ -881,7 +863,7 @@ mod tests {
 
         let table_name = Arc::new(table_name.into());
         let tag_columns = str_vec_to_arc_vec(tag_columns);
-        let field_columns = str_vec_to_arc_vec(field_columns);
+        let field_columns = FieldColumns::from(field_columns);
 
         tokio::task::spawn(async move {
             converter

--- a/query/src/exec/seriesset.rs
+++ b/query/src/exec/seriesset.rs
@@ -47,7 +47,7 @@ pub enum Error {
     ))]
     ReadingRecordBatch { source: arrow::error::ArrowError },
 
-    #[snafu(display("Intrnal field error while converting series set: {}", source))]
+    #[snafu(display("Internal field error while converting series set: {}", source))]
     InternalField { source: super::field::Error },
 
     #[snafu(display("Sending series set results during conversion: {:?}", source))]

--- a/write_buffer/src/column.rs
+++ b/write_buffer/src/column.rs
@@ -4,6 +4,8 @@ use snafu::Snafu;
 use crate::dictionary::Dictionary;
 use data_types::{data::type_description, partition_metadata::Statistics};
 
+use arrow_deps::arrow::datatypes::DataType as ArrowDataType;
+
 #[derive(Debug, Snafu)]
 pub enum Error {
     #[snafu(display("Don't know how to insert a column of type {}", inserted_value_type))]
@@ -122,6 +124,17 @@ impl Column {
             Self::String(_, _) => "String",
             Self::Bool(_, _) => "bool",
             Self::Tag(_, _) => "tag",
+        }
+    }
+
+    /// Return the arrow DataType for this column
+    pub fn data_type(&self) -> ArrowDataType {
+        match self {
+            Self::F64(..) => ArrowDataType::Float64,
+            Self::I64(..) => ArrowDataType::Int64,
+            Self::String(..) => ArrowDataType::Utf8,
+            Self::Bool(..) => ArrowDataType::Boolean,
+            Self::Tag(..) => ArrowDataType::Utf8,
         }
     }
 

--- a/write_buffer/src/database.rs
+++ b/write_buffer/src/database.rs
@@ -519,11 +519,7 @@ impl TSDatabase for Db {
         let mut filter = PartitionTableFilter::new(predicate);
 
         match gby_agg {
-            GroupByAndAggregate::Columns {
-                // TODO use aggregate:  https://github.com/influxdata/influxdb_iox/issues/448
-                agg,
-                group_columns,
-            } => {
+            GroupByAndAggregate::Columns { agg, group_columns } => {
                 // Add any specified groups as predicate columns (so we
                 // can skip tables without those tags)
                 let mut filter = filter.add_required_columns(&group_columns);
@@ -1236,7 +1232,8 @@ struct ArrowTable {
 mod tests {
     use super::*;
     use arrow_deps::datafusion::prelude::*;
-    use query::exec::seriesset::SeriesSetItem;
+    use query::exec::{field::FieldIndexes, seriesset::SeriesSetItem};
+
     use query::{
         exec::fieldlist::{Field, FieldList},
         exec::{
@@ -1998,8 +1995,10 @@ disk bytes=23432323i 1600136510000000000",
             series_set0.tags,
             str_pair_vec_to_vec(&[("city", "Boston"), ("state", "MA")])
         );
-        assert_eq!(series_set0.timestamp_index, 3);
-        assert_eq!(series_set0.field_indices, Arc::new(vec![2]));
+        assert_eq!(
+            series_set0.field_indexes,
+            FieldIndexes::from_timestamp_and_value_indexes(3, &[2])
+        );
         assert_eq!(series_set0.start_row, 0);
         assert_eq!(series_set0.num_rows, 2);
 
@@ -2009,8 +2008,10 @@ disk bytes=23432323i 1600136510000000000",
             series_set1.tags,
             str_pair_vec_to_vec(&[("city", "LA"), ("state", "CA")])
         );
-        assert_eq!(series_set1.timestamp_index, 3);
-        assert_eq!(series_set1.field_indices, Arc::new(vec![2]));
+        assert_eq!(
+            series_set1.field_indexes,
+            FieldIndexes::from_timestamp_and_value_indexes(3, &[2])
+        );
         assert_eq!(series_set1.start_row, 2);
         assert_eq!(series_set1.num_rows, 2);
 
@@ -2020,8 +2021,10 @@ disk bytes=23432323i 1600136510000000000",
             series_set2.tags,
             str_pair_vec_to_vec(&[("city", "Boston"), ("state", "MA")])
         );
-        assert_eq!(series_set2.timestamp_index, 4);
-        assert_eq!(series_set2.field_indices, Arc::new(vec![2, 3]));
+        assert_eq!(
+            series_set2.field_indexes,
+            FieldIndexes::from_timestamp_and_value_indexes(4, &[2, 3])
+        );
         assert_eq!(series_set2.start_row, 0);
         assert_eq!(series_set2.num_rows, 2);
 
@@ -2069,8 +2072,10 @@ disk bytes=23432323i 1600136510000000000",
             series_set0.tags,
             str_pair_vec_to_vec(&[("city", "LA"), ("state", "CA")])
         );
-        assert_eq!(series_set0.timestamp_index, 3);
-        assert_eq!(series_set0.field_indices, Arc::new(vec![2]));
+        assert_eq!(
+            series_set0.field_indexes,
+            FieldIndexes::from_timestamp_and_value_indexes(3, &[2])
+        );
         assert_eq!(series_set0.start_row, 0);
         assert_eq!(series_set0.num_rows, 1); // only has one row!
 

--- a/write_buffer/src/table.rs
+++ b/write_buffer/src/table.rs
@@ -3,6 +3,8 @@ use query::{
     exec::{make_schema_pivot, SeriesSetPlan},
     func::window::make_window_bound_expr,
     group_by::{Aggregate, WindowDuration},
+    func::selectors::{selector_first, SelectorOutput},
+    func::selectors::{selector_last, selector_max, selector_min},
 };
 use tracing::debug;
 
@@ -84,6 +86,12 @@ pub enum Error {
         expected_column_type: String,
         actual_column_type: String,
     },
+
+    #[snafu(display("Internal error: unexpected aggregate request for None aggregate",))]
+    InternalUnexpectedNoneAggregate {},
+
+    #[snafu(display("Internal error: aggregate {:?} is not a selector", agg))]
+    InternalAggregateNotSelector { agg: Aggregate },
 
     #[snafu(display(
         "Column name '{}' not found in dictionary of partition {}",
@@ -475,7 +483,7 @@ impl Table {
         // and finally create the plan
         let plan = plan_builder.build().context(BuildingPlan)?;
 
-        Ok(SeriesSetPlan::new(
+        Ok(SeriesSetPlan::new_from_shared_timestamp(
             self.table_name(partition),
             plan,
             tag_columns,
@@ -533,14 +541,10 @@ impl Table {
     ) -> Result<SeriesSetPlan> {
         let num_prefix_tag_group_columns = group_columns.len();
 
-        let plan = match agg {
-            Aggregate::None => {
-                self.series_set_plan_impl(partition_predicate, Some(&group_columns), partition)?
-            }
-            Aggregate::Sum | Aggregate::Count | Aggregate::Mean => {
-                self.aggregate_series_set_plan(partition_predicate, agg, group_columns, partition)?
-            }
-            _ => todo!("Aggregate {:?} not implemented", agg),
+        let plan = if let Aggregate::None = agg {
+            self.series_set_plan_impl(partition_predicate, Some(&group_columns), partition)?
+        } else {
+            self.aggregate_series_set_plan(partition_predicate, agg, group_columns, partition)?
         };
 
         Ok(plan.grouped(num_prefix_tag_group_columns))
@@ -551,21 +555,38 @@ impl Table {
     /// group by all tags (so group within series) and the
     /// group_columns define the order of the result
     ///
-    /// Equivalent to this SQL query:
+    /// Equivalent to this SQL query for 'aggregates': sum, count, mean
     /// SELECT
     ///   tag1...tagN
-    ///   agg_function(_val) as _value
+    ///   agg_function(_val1) as _value1
+    ///   ...
+    ///   agg_function(_valN) as _valueN
     ///   agg_function(time) as time
     /// GROUP BY
     ///   group_key1, group_key2, remaining tags,
     /// ORDER BY
-    ///   group_key1, group_key2, remaining tags, time,
+    ///   group_key1, group_key2, remaining tags
+    ///
+    /// Equivalent to this SQL query for 'selector' functions: first, last, min,
+    /// max as they can have different values of the timestamp colum
+    ///
+    /// SELECT
+    ///   tag1...tagN
+    ///   agg_function(_val1) as _value1
+    ///   agg_function(time) as time1
+    ///   ..
+    ///   agg_function(_valN) as _valueN
+    ///   agg_function(time) as timeN
+    /// GROUP BY
+    ///   group_key1, group_key2, remaining tags,
+    /// ORDER BY
+    ///   group_key1, group_key2, remaining tags
     ///
     /// The created plan looks like:
     ///
-    ///  OrderBy(gby: tag columns, window_function; agg: aggregate(field)
-    ///      GroupBy(gby: tag columns, window_function; agg: aggregate(field)
-    ///        Filter(predicate)
+    ///  OrderBy(gby cols; agg)
+    ///     GroupBy(gby cols, aggs, time cols)
+    ///       Filter(predicate)
     ///          InMemoryScan
     pub fn aggregate_series_set_plan(
         &self,
@@ -590,20 +611,18 @@ impl Table {
             .map(|tag_name| col(tag_name.as_ref()))
             .collect::<Vec<_>>();
 
-        // aggregate each field *and* the timestamp field
-        let mut agg_exprs = field_columns
-            .iter()
-            .map(|field_name| make_agg_expr(agg, field_name.as_ref()))
-            .collect::<Result<Vec<_>>>()?;
-        // also aggregate the time column itself
-        agg_exprs.push(make_agg_expr(agg, TIME_COLUMN_NAME)?);
+        let AggExprs {
+            agg_exprs,
+            field_columns,
+        } = AggExprs::new(agg, field_columns, |col_name| {
+            let index = self.column_index(partition, col_name)?;
+            Ok(self.columns[index].data_type())
+        })?;
 
-        // sort by the group by expressions as well as (aggregated) time value
-        let mut sort_exprs = group_exprs
+        let sort_exprs = group_exprs
             .iter()
             .map(|expr| expr.into_sort_expr())
             .collect::<Vec<_>>();
-        sort_exprs.push(TIME_COLUMN_NAME.into_sort_expr());
 
         let plan_builder = plan_builder
             .aggregate(group_exprs, agg_exprs)
@@ -695,7 +714,7 @@ impl Table {
         // and finally create the plan
         let plan = plan_builder.build().context(BuildingPlan)?;
 
-        Ok(SeriesSetPlan::new(
+        Ok(SeriesSetPlan::new_from_shared_timestamp(
             self.table_name(partition),
             plan,
             tag_columns,
@@ -831,6 +850,24 @@ impl Table {
         }
     }
 
+    fn column_index(&self, partition: &Partition, column_name: &str) -> Result<usize> {
+        let column_id = partition.dictionary.lookup_value(column_name).context(
+            ColumnNameNotFoundInDictionary {
+                column_name,
+                partition: &partition.key,
+            },
+        )?;
+
+        self.column_id_to_index
+            .get(&column_id)
+            .copied()
+            .context(InternalNoColumnInIndex {
+                column_name,
+                column_id,
+            })
+    }
+
+    /// Returns (name, index) pairs for all named columns
     fn column_names_with_index<'a>(
         &self,
         partition: &Partition,
@@ -839,21 +876,7 @@ impl Table {
         columns
             .iter()
             .map(|&column_name| {
-                let column_id = partition.dictionary.lookup_value(column_name).context(
-                    ColumnNameNotFoundInDictionary {
-                        column_name,
-                        partition: &partition.key,
-                    },
-                )?;
-
-                let column_index =
-                    *self
-                        .column_id_to_index
-                        .get(&column_id)
-                        .context(InternalNoColumnInIndex {
-                            column_name,
-                            column_id,
-                        })?;
+                let column_index = self.column_index(partition, column_name)?;
 
                 Ok((column_name, column_index))
             })
@@ -1176,6 +1199,89 @@ impl IntoExpr for Expr {
     }
 }
 
+struct AggExprs {
+    agg_exprs: Vec<Expr>,
+    field_columns: FieldColumns,
+}
+
+/// Creates aggregate and sort expressions for an aggregate plan,
+/// according to the rules explained on
+/// `aggregate_series_set_plan`
+impl AggExprs {
+    /// Create the appropriate aggregate expressions, based on the type of
+    fn new<F>(agg: Aggregate, field_columns: Vec<Arc<String>>, field_type_lookup: F) -> Result<Self>
+    where
+        F: Fn(&str) -> Result<ArrowDataType>,
+    {
+        match agg {
+            Aggregate::Sum | Aggregate::Count | Aggregate::Mean => {
+                //  agg_function(_val1) as _value1
+                //  ...
+                //  agg_function(_valN) as _valueN
+                //  agg_function(time) as time
+
+                let mut agg_exprs = field_columns
+                    .iter()
+                    .map(|field_name| make_agg_expr(agg, field_name.as_ref()))
+                    .collect::<Result<Vec<_>>>()?;
+
+                agg_exprs.push(make_agg_expr(agg, TIME_COLUMN_NAME)?);
+
+                let field_columns = field_columns.into();
+                Ok(Self {
+                    agg_exprs,
+                    field_columns,
+                })
+            }
+            Aggregate::First | Aggregate::Last | Aggregate::Min | Aggregate::Max => {
+                //   agg_function(_val1) as _value1
+                //   agg_function(time) as time1
+                //   ..
+                //   agg_function(_valN) as _valueN
+                //   agg_function(time) as timeN
+
+                // might be nice to use a more functional style here
+                let mut agg_exprs = Vec::with_capacity(field_columns.len() * 2);
+                let mut field_list = Vec::with_capacity(field_columns.len());
+
+                for field_name in &field_columns {
+                    let field_type = field_type_lookup(field_name.as_ref())?;
+
+                    agg_exprs.push(make_selector_expr(
+                        agg,
+                        SelectorOutput::Value,
+                        field_name.as_ref(),
+                        &field_type,
+                        field_name.as_ref(),
+                    )?);
+
+                    let time_column_name = Arc::new(format!("{}_{}", TIME_COLUMN_NAME, field_name));
+
+                    agg_exprs.push(make_selector_expr(
+                        agg,
+                        SelectorOutput::Time,
+                        field_name.as_ref(),
+                        &field_type,
+                        time_column_name.as_ref(),
+                    )?);
+
+                    field_list.push((
+                        field_name.clone(), // value name
+                        time_column_name,
+                    ));
+                }
+
+                let field_columns = field_list.into();
+                Ok(Self {
+                    agg_exprs,
+                    field_columns,
+                })
+            }
+            Aggregate::None => InternalUnexpectedNoneAggregate.fail(),
+        }
+    }
+}
+
 /// Creates a DataFusion expression suitable for calculating an aggregate:
 ///
 /// equivalent to `CAST agg(field) as field`
@@ -1183,6 +1289,29 @@ fn make_agg_expr(agg: Aggregate, field_name: &str) -> Result<Expr> {
     agg.to_datafusion_expr(col(field_name))
         .context(CreatingAggregates)
         .map(|agg| agg.alias(field_name))
+}
+
+/// Creates a DataFusion expression suitable for calculating the time
+/// part of a selector:
+///
+/// equivalent to `CAST selector_time(field) as column_name`
+fn make_selector_expr(
+    agg: Aggregate,
+    output: SelectorOutput,
+    field_name: &str,
+    data_type: &ArrowDataType,
+    column_name: &str,
+) -> Result<Expr> {
+    let uda = match agg {
+        Aggregate::First => selector_first(data_type, output),
+        Aggregate::Last => selector_last(data_type, output),
+        Aggregate::Min => selector_min(data_type, output),
+        Aggregate::Max => selector_max(data_type, output),
+        _ => return InternalAggregateNotSelector { agg }.fail(),
+    };
+    Ok(uda
+        .call(vec![col(field_name), col(TIME_COLUMN_NAME)])
+        .alias(column_name))
 }
 
 #[cfg(test)]
@@ -1343,10 +1472,7 @@ mod tests {
             series_set_plan.tag_columns,
             *str_vec_to_arc_vec(&["city", "state"])
         );
-        assert_eq!(
-            series_set_plan.field_columns,
-            *str_vec_to_arc_vec(&["temp"])
-        );
+        assert_eq!(series_set_plan.field_columns, vec!["temp"].into());
 
         // run the created plan, ensuring the output is as expected
         let results = run_plan(series_set_plan.plan).await;
@@ -1394,10 +1520,7 @@ mod tests {
             series_set_plan.tag_columns,
             *str_vec_to_arc_vec(&["city", "state", "zz_tag"])
         );
-        assert_eq!(
-            series_set_plan.field_columns,
-            *str_vec_to_arc_vec(&["other", "temp"])
-        );
+        assert_eq!(series_set_plan.field_columns, vec!["other", "temp"].into(),);
 
         // run the created plan, ensuring the output is as expected
         let results = run_plan(series_set_plan.plan).await;
@@ -1450,10 +1573,7 @@ mod tests {
             series_set_plan.tag_columns,
             *str_vec_to_arc_vec(&["city", "state"])
         );
-        assert_eq!(
-            series_set_plan.field_columns,
-            *str_vec_to_arc_vec(&["temp"])
-        );
+        assert_eq!(series_set_plan.field_columns, vec!["temp"].into(),);
 
         // run the created plan, ensuring the output is as expected
         let results = run_plan(series_set_plan.plan).await;
@@ -1632,6 +1752,134 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_grouped_series_set_plan_first() {
+        let lp_lines = vec![
+            "h2o,state=MA,city=Cambridge f=8.0,i=8i,b=true,s=\"d\" 1000",
+            "h2o,state=MA,city=Cambridge f=7.0,i=7i,b=true,s=\"c\" 2000",
+            "h2o,state=MA,city=Cambridge f=6.0,i=6i,b=false,s=\"b\" 3000",
+            "h2o,state=MA,city=Cambridge f=5.0,i=5i,b=false,s=\"a\" 4000",
+        ];
+
+        let mut fixture = TableFixture::new(lp_lines);
+
+        let predicate = PredicateBuilder::default()
+            // fiter out first row (ts 1000)
+            .timestamp_range(1001, 4000)
+            .build();
+
+        // run the created plan, ensuring the output is as expected
+        let results = fixture
+            .grouped_series_set(predicate, Aggregate::First, &["state"])
+            .await;
+
+        let expected = vec![
+            "+-------+-----------+------+--------+---+--------+---+--------+---+--------+",
+            "| state | city      | b    | time_b | f | time_f | i | time_i | s | time_s |",
+            "+-------+-----------+------+--------+---+--------+---+--------+---+--------+",
+            "| MA    | Cambridge | true | 2000   | 7 | 2000   | 7 | 2000   | c | 2000   |",
+            "+-------+-----------+------+--------+---+--------+---+--------+---+--------+",
+        ];
+
+        assert_eq!(expected, results, "expected output");
+    }
+
+    #[tokio::test]
+    async fn test_grouped_series_set_plan_last() {
+        let lp_lines = vec![
+            "h2o,state=MA,city=Cambridge f=8.0,i=8i,b=true,s=\"d\" 1000",
+            "h2o,state=MA,city=Cambridge f=7.0,i=7i,b=true,s=\"c\" 2000",
+            "h2o,state=MA,city=Cambridge f=6.0,i=6i,b=false,s=\"b\" 3000",
+            "h2o,state=MA,city=Cambridge f=5.0,i=5i,b=false,s=\"a\" 4000",
+        ];
+
+        let mut fixture = TableFixture::new(lp_lines);
+
+        let predicate = PredicateBuilder::default()
+            // fiter out last row (ts 4000)
+            .timestamp_range(100, 3999)
+            .build();
+
+        // run the created plan, ensuring the output is as expected
+        let results = fixture
+            .grouped_series_set(predicate, Aggregate::Last, &["state"])
+            .await;
+
+        let expected = vec![
+            "+-------+-----------+-------+--------+---+--------+---+--------+---+--------+",
+            "| state | city      | b     | time_b | f | time_f | i | time_i | s | time_s |",
+            "+-------+-----------+-------+--------+---+--------+---+--------+---+--------+",
+            "| MA    | Cambridge | false | 3000   | 6 | 3000   | 6 | 3000   | b | 3000   |",
+            "+-------+-----------+-------+--------+---+--------+---+--------+---+--------+",
+        ];
+
+        assert_eq!(expected, results, "expected output");
+    }
+
+    #[tokio::test]
+    async fn test_grouped_series_set_plan_min() {
+        let lp_lines = vec![
+            "h2o,state=MA,city=Cambridge f=8.0,i=8i,b=true,s=\"d\" 1000",
+            "h2o,state=MA,city=Cambridge f=7.0,i=7i,b=true,s=\"c\" 2000",
+            "h2o,state=MA,city=Cambridge f=6.0,i=6i,b=false,s=\"b\" 3000",
+            "h2o,state=MA,city=Cambridge f=5.0,i=5i,b=false,s=\"a\" 4000",
+        ];
+
+        let mut fixture = TableFixture::new(lp_lines);
+
+        let predicate = PredicateBuilder::default()
+            // fiter out last row (ts 4000)
+            .timestamp_range(100, 3999)
+            .build();
+
+        // run the created plan, ensuring the output is as expected
+        let results = fixture
+            .grouped_series_set(predicate, Aggregate::Min, &["state"])
+            .await;
+
+        let expected = vec![
+            "+-------+-----------+-------+--------+---+--------+---+--------+---+--------+",
+            "| state | city      | b     | time_b | f | time_f | i | time_i | s | time_s |",
+            "+-------+-----------+-------+--------+---+--------+---+--------+---+--------+",
+            "| MA    | Cambridge | false | 3000   | 6 | 3000   | 6 | 3000   | b | 3000   |",
+            "+-------+-----------+-------+--------+---+--------+---+--------+---+--------+",
+        ];
+
+        assert_eq!(expected, results, "expected output");
+    }
+
+    #[tokio::test]
+    async fn test_grouped_series_set_plan_max() {
+        let lp_lines = vec![
+            "h2o,state=MA,city=Cambridge f=8.0,i=8i,b=true,s=\"d\" 1000",
+            "h2o,state=MA,city=Cambridge f=7.0,i=7i,b=true,s=\"c\" 2000",
+            "h2o,state=MA,city=Cambridge f=6.0,i=6i,b=false,s=\"b\" 3000",
+            "h2o,state=MA,city=Cambridge f=5.0,i=5i,b=false,s=\"a\" 4000",
+        ];
+
+        let mut fixture = TableFixture::new(lp_lines);
+
+        let predicate = PredicateBuilder::default()
+            // fiter out first row (ts 1000)
+            .timestamp_range(1001, 4000)
+            .build();
+
+        // run the created plan, ensuring the output is as expected
+        let results = fixture
+            .grouped_series_set(predicate, Aggregate::Max, &["state"])
+            .await;
+
+        let expected = vec![
+            "+-------+-----------+------+--------+---+--------+---+--------+---+--------+",
+            "| state | city      | b    | time_b | f | time_f | i | time_i | s | time_s |",
+            "+-------+-----------+------+--------+---+--------+---+--------+---+--------+",
+            "| MA    | Cambridge | true | 2000   | 7 | 2000   | 7 | 2000   | c | 2000   |",
+            "+-------+-----------+------+--------+---+--------+---+--------+---+--------+",
+        ];
+
+        assert_eq!(expected, results, "expected output");
+    }
+
+    #[tokio::test]
     async fn test_grouped_series_set_plan_group_by_keys() {
         let lp_lines = vec![
             "h2o,state=MA,city=Cambridge temp=80 50",
@@ -1725,7 +1973,7 @@ mod tests {
             .expect("creating the grouped_series set plan");
 
         assert_eq!(plan.tag_columns, *str_vec_to_arc_vec(&["city", "state"]));
-        assert_eq!(plan.field_columns, *str_vec_to_arc_vec(&["temp"]));
+        assert_eq!(plan.field_columns, vec!["temp"].into());
 
         // run the created plan, ensuring the output is as expected
         let results = run_plan(plan.plan).await;
@@ -1774,7 +2022,7 @@ mod tests {
             .expect("creating the grouped_series set plan");
 
         assert_eq!(plan.tag_columns, *str_vec_to_arc_vec(&["city", "state"]));
-        assert_eq!(plan.field_columns, *str_vec_to_arc_vec(&["temp"]));
+        assert_eq!(plan.field_columns, vec!["temp"].into());
 
         // run the created plan, ensuring the output is as expected
         let results = run_plan(plan.plan).await;

--- a/write_buffer/src/table.rs
+++ b/write_buffer/src/table.rs
@@ -1763,7 +1763,7 @@ mod tests {
 
         let predicate = PredicateBuilder::default()
             // fiter out first row (ts 1000)
-            .timestamp_range(1001, 4000)
+            .timestamp_range(1001, 4001)
             .build();
 
         // run the created plan, ensuring the output is as expected
@@ -1817,10 +1817,10 @@ mod tests {
     #[tokio::test]
     async fn test_grouped_series_set_plan_min() {
         let lp_lines = vec![
-            "h2o,state=MA,city=Cambridge f=8.0,i=8i,b=true,s=\"d\" 1000",
-            "h2o,state=MA,city=Cambridge f=7.0,i=7i,b=true,s=\"c\" 2000",
-            "h2o,state=MA,city=Cambridge f=6.0,i=6i,b=false,s=\"b\" 3000",
-            "h2o,state=MA,city=Cambridge f=5.0,i=5i,b=false,s=\"a\" 4000",
+            "h2o,state=MA,city=Cambridge f=8.0,i=8i,b=false,s=\"c\" 1000",
+            "h2o,state=MA,city=Cambridge f=7.0,i=7i,b=false,s=\"a\" 2000",
+            "h2o,state=MA,city=Cambridge f=6.0,i=6i,b=true,s=\"z\" 3000",
+            "h2o,state=MA,city=Cambridge f=5.0,i=5i,b=true,s=\"c\" 4000",
         ];
 
         let mut fixture = TableFixture::new(lp_lines);
@@ -1839,7 +1839,7 @@ mod tests {
             "+-------+-----------+-------+--------+---+--------+---+--------+---+--------+",
             "| state | city      | b     | time_b | f | time_f | i | time_i | s | time_s |",
             "+-------+-----------+-------+--------+---+--------+---+--------+---+--------+",
-            "| MA    | Cambridge | false | 3000   | 6 | 3000   | 6 | 3000   | b | 3000   |",
+            "| MA    | Cambridge | false | 1000   | 6 | 3000   | 6 | 3000   | a | 2000   |",
             "+-------+-----------+-------+--------+---+--------+---+--------+---+--------+",
         ];
 
@@ -1849,17 +1849,17 @@ mod tests {
     #[tokio::test]
     async fn test_grouped_series_set_plan_max() {
         let lp_lines = vec![
-            "h2o,state=MA,city=Cambridge f=8.0,i=8i,b=true,s=\"d\" 1000",
-            "h2o,state=MA,city=Cambridge f=7.0,i=7i,b=true,s=\"c\" 2000",
-            "h2o,state=MA,city=Cambridge f=6.0,i=6i,b=false,s=\"b\" 3000",
-            "h2o,state=MA,city=Cambridge f=5.0,i=5i,b=false,s=\"a\" 4000",
+            "h2o,state=MA,city=Cambridge f=8.0,i=8i,b=true,s=\"c\" 1000",
+            "h2o,state=MA,city=Cambridge f=7.0,i=7i,b=false,s=\"d\" 2000",
+            "h2o,state=MA,city=Cambridge f=6.0,i=6i,b=true,s=\"a\" 3000",
+            "h2o,state=MA,city=Cambridge f=5.0,i=5i,b=true,s=\"z\" 4000",
         ];
 
         let mut fixture = TableFixture::new(lp_lines);
 
         let predicate = PredicateBuilder::default()
             // fiter out first row (ts 1000)
-            .timestamp_range(1001, 4000)
+            .timestamp_range(1001, 4001)
             .build();
 
         // run the created plan, ensuring the output is as expected
@@ -1871,7 +1871,7 @@ mod tests {
             "+-------+-----------+------+--------+---+--------+---+--------+---+--------+",
             "| state | city      | b    | time_b | f | time_f | i | time_i | s | time_s |",
             "+-------+-----------+------+--------+---+--------+---+--------+---+--------+",
-            "| MA    | Cambridge | true | 2000   | 7 | 2000   | 7 | 2000   | c | 2000   |",
+            "| MA    | Cambridge | true | 3000   | 7 | 2000   | 7 | 2000   | z | 4000   |",
             "+-------+-----------+------+--------+---+--------+---+--------+---+--------+",
         ];
 

--- a/write_buffer/src/table.rs
+++ b/write_buffer/src/table.rs
@@ -1,10 +1,9 @@
 use generated_types::wal as wb;
 use query::{
-    exec::{make_schema_pivot, SeriesSetPlan},
     func::window::make_window_bound_expr,
     group_by::{Aggregate, WindowDuration},
-    func::selectors::{selector_first, SelectorOutput},
-    func::selectors::{selector_last, selector_max, selector_min},
+    exec::{field::FieldColumns, make_schema_pivot, SeriesSetPlan},
+    func::selectors::{selector_first, selector_last, selector_max, selector_min, SelectorOutput},
 };
 use tracing::debug;
 

--- a/write_buffer/src/table.rs
+++ b/write_buffer/src/table.rs
@@ -1,9 +1,9 @@
 use generated_types::wal as wb;
 use query::{
-    func::window::make_window_bound_expr,
-    group_by::{Aggregate, WindowDuration},
     exec::{field::FieldColumns, make_schema_pivot, SeriesSetPlan},
     func::selectors::{selector_first, selector_last, selector_max, selector_min, SelectorOutput},
+    func::window::make_window_bound_expr,
+    group_by::{Aggregate, WindowDuration},
 };
 use tracing::debug;
 

--- a/write_buffer/src/table.rs
+++ b/write_buffer/src/table.rs
@@ -567,7 +567,7 @@ impl Table {
     ///   group_key1, group_key2, remaining tags
     ///
     /// Equivalent to this SQL query for 'selector' functions: first, last, min,
-    /// max as they can have different values of the timestamp colum
+    /// max as they can have different values of the timestamp column
     ///
     /// SELECT
     ///   tag1...tagN


### PR DESCRIPTION
This PR completes the implementation of `read_group` gRPC (https://github.com/influxdata/influxdb_iox/issues/448)

This PR implements the approach described in https://github.com/influxdata/influxdb_iox/issues/448#issuecomment-744601824. The actual change to the plans is fairly small (use different aggregate functions) but there is a bunch of plumbing required as the previous assumption that all aggregated field values share the same timestamp is no longer the case. 

I'll leave more comments inline

- [x] Implement read_group for `None` aggregates (https://github.com/influxdata/influxdb_iox/pull/538)
- [x] Error if any hints are provided, or if there is a discrepancy between `GroupBy` and `GroupNone` type (https://github.com/influxdata/influxdb_iox/pull/539)
- [x] Implement read_group for `Sum`, `Count` and `Mean` aggregates (https://github.com/influxdata/influxdb_iox/pull/557)
- [x] Implement user defined aggregates for `min`, `max`, `first` and `last`, selector functions (https://github.com/influxdata/influxdb_iox/pull/565)
- [x] Implement read_group for `Min`, `Max`, `First` and `Last` using selector functions  (this PR)
- [ ] Update capabilities response that says IOx can support read_group 
