### PR TITLE
chore: Update arrow dependencies, remove custom min/max implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,8 +86,9 @@ checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 [[package]]
 name = "arrow"
 version = "3.0.0-SNAPSHOT"
-source = "git+https://github.com/apache/arrow.git?rev=edff65dfe73d3380a211b678f3760a60a66e5544#edff65dfe73d3380a211b678f3760a60a66e5544"
+source = "git+https://github.com/apache/arrow.git?rev=9724afd732481115c675fe68973d741c5530d23d#9724afd732481115c675fe68973d741c5530d23d"
 dependencies = [
+ "cfg_aliases",
  "chrono",
  "csv",
  "flatbuffers",
@@ -362,6 +363,12 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
 
 [[package]]
 name = "chrono"
@@ -729,7 +736,7 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "3.0.0-SNAPSHOT"
-source = "git+https://github.com/apache/arrow.git?rev=edff65dfe73d3380a211b678f3760a60a66e5544#edff65dfe73d3380a211b678f3760a60a66e5544"
+source = "git+https://github.com/apache/arrow.git?rev=9724afd732481115c675fe68973d741c5530d23d#9724afd732481115c675fe68973d741c5530d23d"
 dependencies = [
  "ahash 0.6.2",
  "arrow",
@@ -2075,10 +2082,10 @@ dependencies = [
 [[package]]
 name = "parquet"
 version = "3.0.0-SNAPSHOT"
-source = "git+https://github.com/apache/arrow.git?rev=edff65dfe73d3380a211b678f3760a60a66e5544#edff65dfe73d3380a211b678f3760a60a66e5544"
+source = "git+https://github.com/apache/arrow.git?rev=9724afd732481115c675fe68973d741c5530d23d#9724afd732481115c675fe68973d741c5530d23d"
 dependencies = [
  "arrow",
- "base64 0.13.0",
+ "base64 0.12.3",
  "brotli",
  "byteorder",
  "chrono",

--- a/arrow_deps/Cargo.toml
+++ b/arrow_deps/Cargo.toml
@@ -11,10 +11,10 @@ description = "Apache Arrow / Parquet / DataFusion dependencies for InfluxDB IOx
 [dependencies]
 # We are using development version of arrow/parquet/datafusion and the dependencies are at the same rev
 
-# The version can be found here: https://github.com/apache/arrow/commit/edff65dfe73d3380a211b678f3760a60a66e5544
+# The version can be found here: https://github.com/apache/arrow/commit/9724afd732481115c675fe68973d741c5530d23d
 #
-arrow = { git = "https://github.com/apache/arrow.git", rev = "edff65dfe73d3380a211b678f3760a60a66e5544" , features = ["simd"] }
-datafusion = { git = "https://github.com/apache/arrow.git", rev = "edff65dfe73d3380a211b678f3760a60a66e5544" }
+arrow = { git = "https://github.com/apache/arrow.git", rev = "9724afd732481115c675fe68973d741c5530d23d" , features = ["simd"] }
+datafusion = { git = "https://github.com/apache/arrow.git", rev = "9724afd732481115c675fe68973d741c5530d23d" }
 # Turn off the "arrow" feature; it currently has a bug that causes the crate to rebuild every time
 # and we're not currently using it anyway
-parquet = { git = "https://github.com/apache/arrow.git", rev = "edff65dfe73d3380a211b678f3760a60a66e5544", default-features = false, features = ["snap", "brotli", "flate2", "lz4", "zstd"] }
+parquet = { git = "https://github.com/apache/arrow.git", rev = "9724afd732481115c675fe68973d741c5530d23d", default-features = false, features = ["snap", "brotli", "flate2", "lz4", "zstd"] }

--- a/query/src/exec/planning.rs
+++ b/query/src/exec/planning.rs
@@ -13,6 +13,7 @@ use arrow_deps::{
         execution::context::{ExecutionContextState, QueryPlanner},
         logical_plan::{Expr, LogicalPlan, UserDefinedLogicalNode},
         physical_plan::{
+            collect,
             functions::ScalarFunctionImplementation,
             merge::MergeExec,
             planner::{DefaultPhysicalPlanner, ExtensionPlanner},
@@ -126,7 +127,7 @@ impl IOxExecutionContext {
 
         debug!("Running plan, physical:\n{:?}", physical_plan);
 
-        self.inner.collect(physical_plan).await
+        collect(physical_plan).await
     }
 
     /// Executes the physical plan and produces a RecordBatchStream to stream

--- a/write_buffer/src/database.rs
+++ b/write_buffer/src/database.rs
@@ -28,10 +28,9 @@ use std::{
 use arrow_deps::{
     arrow,
     arrow::{datatypes::Schema as ArrowSchema, record_batch::RecordBatch},
-    datafusion::logical_plan::LogicalPlan,
-    datafusion::prelude::ExecutionConfig,
     datafusion::{
         datasource::MemTable, error::DataFusionError, execution::context::ExecutionContext,
+        logical_plan::LogicalPlan, physical_plan::collect, prelude::ExecutionConfig,
     },
 };
 use data_types::data::{split_lines_into_write_entry_partitions, ReplicatedWrite};
@@ -596,7 +595,7 @@ impl SQLDatabase for Db {
             .create_physical_plan(&plan)
             .context(QueryError { query })?;
 
-        ctx.collect(plan).await.context(QueryError { query })
+        collect(plan).await.context(QueryError { query })
     }
 
     /// Fetch the specified table names and columns as Arrow


### PR DESCRIPTION
Updates to latest arrow upstream

Closes https://github.com/influxdata/influxdb_iox/issues/568 by removing custom min/max implementation for boolean (which I have ported upstream).
