### PR TITLE
feat: report support for read_group in gRPC

### DIFF
--- a/src/server/rpc/service.rs
+++ b/src/server/rpc/service.rs
@@ -332,8 +332,6 @@ where
             InternalHintsFieldNotSupported { hints }.fail()?
         }
 
-        warn!("read_group implementation not yet complete: https://github.com/influxdata/influxdb_iox/issues/448");
-
         let aggregate_string = format!(
             "aggregate: {:?}, group: {:?}, group_keys: {:?}",
             aggregate, group, group_keys
@@ -569,15 +567,18 @@ where
         //
 
         // For now, hard code our list of support
-        let caps = [(
-            "WindowAggregate",
-            vec![
-                "Count", "Sum", // "First"
-                // "Last",
-                "Min", "Max", "Mean",
-                // "Offset"
-            ],
-        )];
+        let caps = [
+            (
+                "WindowAggregate",
+                vec![
+                    "Count", "Sum", // "First"
+                    // "Last",
+                    "Min", "Max", "Mean",
+                    // "Offset"
+                ],
+            ),
+            ("Group", vec!["First", "Last", "Min", "Max"]),
+        ];
 
         // Turn it into the HashMap -> Capabiltity
         let caps = caps
@@ -1240,6 +1241,8 @@ mod tests {
             "WindowAggregate".into(),
             to_str_vec(&["Count", "Sum", "Min", "Max", "Mean"]),
         );
+
+        expected_capabilities.insert("Group".into(), to_str_vec(&["First", "Last", "Min", "Max"]));
 
         assert_eq!(
             expected_capabilities,

--- a/tests/end-to-end.rs
+++ b/tests/end-to-end.rs
@@ -203,7 +203,7 @@ async fn read_and_write_data() -> Result<()> {
     let capabilities_response = capabilities_response.into_inner();
     assert_eq!(
         capabilities_response.caps.len(),
-        1,
+        2,
         "Response: {:?}",
         capabilities_response
     );


### PR DESCRIPTION
This is the final PR for `read_group` support, advertising that IOx support read_group queries. Closes https://github.com/influxdata/influxdb_iox/issues/448

- [x] Implement read_group for `None` aggregates (https://github.com/influxdata/influxdb_iox/pull/538)
- [x] Error if any hints are provided, or if there is a discrepancy between `GroupBy` and `GroupNone` type (https://github.com/influxdata/influxdb_iox/pull/539)
- [x] Implement read_group for `Sum`, `Count` and `Mean` aggregates (https://github.com/influxdata/influxdb_iox/pull/557)
- [x] Implement user defined aggregates for `min`, `max`, `first` and `last`, selector functions (https://github.com/influxdata/influxdb_iox/pull/565)
- [x] Implement read_group for `Min`, `Max`, `First` and `Last` using selector functions  (https://github.com/influxdata/influxdb_iox/pull/583)
- [x] Update capabilities response that says IOx can support read_group  (this PR)
