### PR TITLE
chore: Upgrade arrow dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,12 +86,12 @@ checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 [[package]]
 name = "arrow"
 version = "3.0.0-SNAPSHOT"
-source = "git+https://github.com/apache/arrow.git?rev=9724afd732481115c675fe68973d741c5530d23d#9724afd732481115c675fe68973d741c5530d23d"
+source = "git+https://github.com/apache/arrow.git?rev=c46fd102678fd22b9781642437ad8821f907d9db#c46fd102678fd22b9781642437ad8821f907d9db"
 dependencies = [
  "cfg_aliases",
  "chrono",
  "csv",
- "flatbuffers",
+ "flatbuffers 0.8.0",
  "hex",
  "indexmap",
  "lazy_static",
@@ -715,7 +715,7 @@ version = "0.1.0"
 dependencies = [
  "chrono",
  "crc32fast",
- "flatbuffers",
+ "flatbuffers 0.6.1",
  "generated_types",
  "influxdb_line_protocol",
  "serde",
@@ -726,7 +726,7 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "3.0.0-SNAPSHOT"
-source = "git+https://github.com/apache/arrow.git?rev=9724afd732481115c675fe68973d741c5530d23d#9724afd732481115c675fe68973d741c5530d23d"
+source = "git+https://github.com/apache/arrow.git?rev=c46fd102678fd22b9781642437ad8821f907d9db#c46fd102678fd22b9781642437ad8821f907d9db"
 dependencies = [
  "ahash 0.6.2",
  "arrow",
@@ -736,6 +736,7 @@ dependencies = [
  "crossbeam 0.8.0",
  "futures",
  "hashbrown",
+ "log",
  "num_cpus",
  "parquet",
  "paste",
@@ -914,6 +915,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "flatbuffers"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4d0e80bffea40f65eb6eefd74f2bef75d3c4f5dfdf973b91449706d43369cd9"
+dependencies = [
+ "bitflags",
+ "smallvec",
+ "thiserror",
+]
+
+[[package]]
 name = "flate2"
 version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1080,7 +1092,7 @@ dependencies = [
 name = "generated_types"
 version = "0.1.0"
 dependencies = [
- "flatbuffers",
+ "flatbuffers 0.6.1",
  "futures",
  "prost",
  "prost-types",
@@ -1794,7 +1806,7 @@ dependencies = [
  "chrono",
  "criterion",
  "data_types",
- "flatbuffers",
+ "flatbuffers 0.6.1",
  "generated_types",
  "influxdb_line_protocol",
  "query",
@@ -2094,10 +2106,10 @@ dependencies = [
 [[package]]
 name = "parquet"
 version = "3.0.0-SNAPSHOT"
-source = "git+https://github.com/apache/arrow.git?rev=9724afd732481115c675fe68973d741c5530d23d#9724afd732481115c675fe68973d741c5530d23d"
+source = "git+https://github.com/apache/arrow.git?rev=c46fd102678fd22b9781642437ad8821f907d9db#c46fd102678fd22b9781642437ad8821f907d9db"
 dependencies = [
  "arrow",
- "base64 0.13.0",
+ "base64 0.12.3",
  "brotli",
  "byteorder",
  "chrono",
@@ -3206,6 +3218,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 dependencies = [
  "unicode-width",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76cc616c6abf8c8928e2fdcc0dbfab37175edd8fb49a4641066ad1364fdab146"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9be73a2caec27583d0046ef3796c3794f868a5bc813db689eed00c7631275cd1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/arrow_deps/Cargo.toml
+++ b/arrow_deps/Cargo.toml
@@ -11,10 +11,10 @@ description = "Apache Arrow / Parquet / DataFusion dependencies for InfluxDB IOx
 [dependencies]
 # We are using development version of arrow/parquet/datafusion and the dependencies are at the same rev
 
-# The version can be found here: https://github.com/apache/arrow/commit/9724afd732481115c675fe68973d741c5530d23d
+# The version can be found here: https://github.com/apache/arrow/commit/c46fd102678fd22b9781642437ad8821f907d9db
 #
-arrow = { git = "https://github.com/apache/arrow.git", rev = "9724afd732481115c675fe68973d741c5530d23d" , features = ["simd"] }
-datafusion = { git = "https://github.com/apache/arrow.git", rev = "9724afd732481115c675fe68973d741c5530d23d" }
+arrow = { git = "https://github.com/apache/arrow.git", rev = "c46fd102678fd22b9781642437ad8821f907d9db" , features = ["simd"] }
+datafusion = { git = "https://github.com/apache/arrow.git", rev = "c46fd102678fd22b9781642437ad8821f907d9db" }
 # Turn off the "arrow" feature; it currently has a bug that causes the crate to rebuild every time
 # and we're not currently using it anyway
-parquet = { git = "https://github.com/apache/arrow.git", rev = "9724afd732481115c675fe68973d741c5530d23d", default-features = false, features = ["snap", "brotli", "flate2", "lz4", "zstd"] }
+parquet = { git = "https://github.com/apache/arrow.git", rev = "c46fd102678fd22b9781642437ad8821f907d9db", default-features = false, features = ["snap", "brotli", "flate2", "lz4", "zstd"] }

--- a/mem_qe/src/bin/main.rs
+++ b/mem_qe/src/bin/main.rs
@@ -157,7 +157,7 @@ fn convert_record_batch(rb: RecordBatch, segment: &mut Segment) -> Result<(), Er
                     .as_any()
                     .downcast_ref::<array::Float64Array>()
                     .unwrap();
-                let column = Column::from(arr.value_slice(0, rb.num_rows()));
+                let column = Column::from(arr.values());
                 segment.add_column(rb.schema().field(i).name(), ColumnType::Field(column));
 
                 // TODO(edd): figure out how to get ownership here without
@@ -172,7 +172,7 @@ fn convert_record_batch(rb: RecordBatch, segment: &mut Segment) -> Result<(), Er
                     panic!("null integers not expected in testing");
                 }
                 let arr = column.as_any().downcast_ref::<array::Int64Array>().unwrap();
-                let column = Column::from(arr.value_slice(0, rb.num_rows()));
+                let column = Column::from(arr.values());
                 segment.add_column(rb.schema().field(i).name(), ColumnType::Time(column));
 
                 // TODO(edd): figure out how to get ownership here without
@@ -190,7 +190,7 @@ fn convert_record_batch(rb: RecordBatch, segment: &mut Segment) -> Result<(), Er
                     .as_any()
                     .downcast_ref::<array::TimestampMicrosecondArray>()
                     .unwrap();
-                let column = Column::from(arr.value_slice(0, rb.num_rows()));
+                let column = Column::from(arr.values());
                 segment.add_column(rb.schema().field(i).name(), ColumnType::Time(column));
 
                 // TODO(edd): figure out how to get ownership here without

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -550,7 +550,7 @@ mod tests {
                 writer.write(&r).unwrap();
             }
         }
-        assert_eq!(&sw.to_string(), "bar,time\n1,10\n");
+        assert_eq!(&sw.to_string(), "bar,time\n1.0,10\n");
 
         Ok(())
     }


### PR DESCRIPTION
Arrow is fast moving. I want to keep up to date as much as possible and thus avoid massive merge conflicts down the line

- [x] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb_iox/blob/main/README.md).
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
