### PR TITLE
chore: Benchmark WAL formats

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -715,6 +715,7 @@ version = "0.1.0"
 dependencies = [
  "chrono",
  "crc32fast",
+ "criterion",
  "flatbuffers",
  "generated_types",
  "influxdb_line_protocol",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -720,6 +720,7 @@ dependencies = [
  "generated_types",
  "influxdb_line_protocol",
  "serde",
+ "serde_json",
  "snafu",
  "tracing",
 ]

--- a/data_types/Cargo.toml
+++ b/data_types/Cargo.toml
@@ -15,3 +15,10 @@ chrono = "0.4"
 flatbuffers = "0.6"
 crc32fast = "1.2.0"
 tracing = "0.1"
+
+[dev-dependencies]
+criterion = "0.3"
+
+[[bench]]
+name = "benchmark"
+harness = false

--- a/data_types/Cargo.toml
+++ b/data_types/Cargo.toml
@@ -18,6 +18,7 @@ tracing = "0.1"
 
 [dev-dependencies]
 criterion = "0.3"
+serde_json = "1.0"
 
 [[bench]]
 name = "benchmark"

--- a/data_types/benches/benchmark.rs
+++ b/data_types/benches/benchmark.rs
@@ -1,0 +1,392 @@
+use criterion::measurement::WallTime;
+use criterion::{criterion_group, criterion_main, Bencher, BenchmarkId, Criterion, Throughput};
+use data_types::data::{lines_to_replicated_write as lines_to_rw, ReplicatedWrite};
+use data_types::database_rules::{DatabaseRules, PartitionTemplate, TemplatePart};
+use generated_types::wal as wb;
+use influxdb_line_protocol::{parse_lines, ParsedLine};
+use std::collections::BTreeMap;
+use std::fmt;
+use std::time::Duration;
+
+const NEXT_ENTRY_NS: i64 = 1_000_000_000;
+const STARTING_TIMESTAMP_NS: i64 = 0;
+
+#[derive(Debug)]
+struct Config {
+    // total number of rows written in, regardless of the number of partitions
+    line_count: i64,
+    // this will be the number of write buffer entries per replicated write
+    partition_count: usize,
+    // the number of tables (measurements) in each replicated write
+    table_count: usize,
+    // the number of unique tag values for the tag in each replicated write
+    tag_cardinality: usize,
+}
+
+impl Config {
+    fn lines_per_partition(&self) -> i64 {
+        self.line_count / self.partition_count as i64
+    }
+}
+
+impl fmt::Display for Config {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "lines: {} ({} per partition) | partitions: {} | tables per: {} | unique tag values per: {}",
+            self.line_count,
+            self.line_count / self.partition_count as i64,
+            self.partition_count,
+            self.table_count,
+            self.tag_cardinality
+        )
+    }
+}
+
+fn lines_to_replicated_write(c: &mut Criterion) {
+    run_group("lines_to_replicated_write", c, |lines, rules, config, b| {
+        b.iter(|| {
+            let write = lines_to_rw(0, 0, &lines, &rules);
+            assert_eq!(write.entry_count(), config.partition_count);
+        });
+    });
+}
+
+fn replicated_write_into_bytes(c: &mut Criterion) {
+    run_group(
+        "replicated_write_into_bytes",
+        c,
+        |lines, rules, config, b| {
+            let write = lines_to_rw(0, 0, &lines, &rules);
+            assert_eq!(write.entry_count(), config.partition_count);
+
+            b.iter(|| {
+                let _ = write.bytes().len();
+            });
+        },
+    );
+}
+
+// simulates the speed of marshalling the bytes into something like the mutable
+// buffer or read buffer, which won't use the replicated write structure anyway
+fn bytes_into_struct(c: &mut Criterion) {
+    run_group("bytes_into_struct", c, |lines, rules, config, b| {
+        let write = lines_to_rw(0, 0, &lines, &rules);
+        assert_eq!(write.entry_count(), config.partition_count);
+        let data = write.bytes();
+
+        b.iter(|| {
+            let mut db = Db::default();
+            db.deserialize_write(data);
+            assert_eq!(db.partition_count(), config.partition_count);
+            assert_eq!(db.row_count() as i64, config.line_count);
+            assert_eq!(db.measurement_count(), config.table_count);
+            assert_eq!(db.tag_cardinality(), config.tag_cardinality);
+        });
+    });
+}
+
+fn run_group(
+    group_name: &str,
+    c: &mut Criterion,
+    bench: impl Fn(&[ParsedLine], &DatabaseRules, &Config, &mut Bencher<WallTime>),
+) {
+    let mut group = c.benchmark_group(group_name);
+    group.measurement_time(Duration::from_secs(10));
+    let rules = rules_with_time_partition();
+
+    for partition_count in [1, 10, 100, 1000].iter() {
+        let config = Config {
+            line_count: 1_000,
+            partition_count: *partition_count,
+            table_count: 1,
+            tag_cardinality: 1,
+        };
+        let id = BenchmarkId::new("partition count", config.partition_count);
+        group.throughput(Throughput::Elements(config.line_count as u64));
+
+        let lp = create_lp(&config);
+        let lines: Vec<_> = parse_lines(&lp).map(|l| l.unwrap()).collect();
+
+        group.bench_with_input(id, &config, |b, config| {
+            bench(&lines, &rules, &config, b);
+        });
+    }
+
+    for table_count in [1, 10, 100, 1000].iter() {
+        let config = Config {
+            line_count: 1_000,
+            partition_count: 1,
+            table_count: *table_count,
+            tag_cardinality: 1,
+        };
+        let id = BenchmarkId::new("table count", config.table_count);
+        group.throughput(Throughput::Elements(config.line_count as u64));
+
+        let lp = create_lp(&config);
+        let lines: Vec<_> = parse_lines(&lp).map(|l| l.unwrap()).collect();
+
+        group.bench_with_input(id, &config, |b, config| {
+            bench(&lines, &rules, &config, b);
+        });
+    }
+
+    for tag_cardinality in [1, 10, 100, 1000].iter() {
+        let config = Config {
+            line_count: 1_000,
+            partition_count: 1,
+            table_count: 1,
+            tag_cardinality: *tag_cardinality,
+        };
+        let id = BenchmarkId::new("tag cardinality", config.tag_cardinality);
+        group.throughput(Throughput::Elements(config.line_count as u64));
+
+        let lp = create_lp(&config);
+        let lines: Vec<_> = parse_lines(&lp).map(|l| l.unwrap()).collect();
+
+        group.bench_with_input(id, &config, |b, config| {
+            bench(&lines, &rules, &config, b);
+        });
+    }
+
+    group.finish();
+}
+
+#[derive(Default)]
+struct Db {
+    partitions: BTreeMap<String, Partition>,
+}
+
+impl Db {
+    fn deserialize_write(&mut self, data: &[u8]) {
+        let write = ReplicatedWrite::from(data);
+
+        if let Some(batch) = write.write_buffer_batch() {
+            if let Some(entries) = batch.entries() {
+                for entry in entries {
+                    let key = entry.partition_key().unwrap();
+
+                    if self.partitions.get(key).is_none() {
+                        self.partitions
+                            .insert(key.to_string(), Partition::default());
+                    }
+                    let partition = self.partitions.get_mut(key).unwrap();
+
+                    if let Some(tables) = entry.table_batches() {
+                        for table_fb in tables {
+                            let table_name = table_fb.name().unwrap();
+
+                            if partition.tables.get(table_name).is_none() {
+                                let table = Table {
+                                    name: table_name.to_string(),
+                                    ..Default::default()
+                                };
+                                partition.tables.insert(table_name.to_string(), table);
+                            }
+                            let table = partition.tables.get_mut(table_name).unwrap();
+
+                            if let Some(rows) = table_fb.rows() {
+                                for row_fb in rows {
+                                    if let Some(values) = row_fb.values() {
+                                        let mut row = Row {
+                                            values: Vec::with_capacity(values.len()),
+                                        };
+
+                                        for value in values {
+                                            let column_name = value.column().unwrap();
+
+                                            if partition.dict.get(column_name).is_none() {
+                                                partition.dict.insert(
+                                                    column_name.to_string(),
+                                                    partition.dict.len(),
+                                                );
+                                            }
+                                            let column_index =
+                                                *partition.dict.get(column_name).unwrap();
+
+                                            let val = match value.value_type() {
+                                                wb::ColumnValue::TagValue => {
+                                                    let tag = value
+                                                        .value_as_tag_value()
+                                                        .unwrap()
+                                                        .value()
+                                                        .unwrap();
+
+                                                    if partition.dict.get(tag).is_none() {
+                                                        partition.dict.insert(
+                                                            tag.to_string(),
+                                                            partition.dict.len(),
+                                                        );
+                                                    }
+                                                    let tag_index =
+                                                        *partition.dict.get(tag).unwrap();
+
+                                                    Value::Tag(tag_index)
+                                                }
+                                                wb::ColumnValue::F64Value => {
+                                                    let val =
+                                                        value.value_as_f64value().unwrap().value();
+
+                                                    Value::F64(val)
+                                                }
+                                                wb::ColumnValue::I64Value => {
+                                                    let val =
+                                                        value.value_as_i64value().unwrap().value();
+
+                                                    Value::I64(val)
+                                                }
+                                                _ => panic!("not supported!"),
+                                            };
+
+                                            let column_value = ColumnValue {
+                                                column_name_index: column_index,
+                                                value: val,
+                                            };
+
+                                            row.values.push(column_value);
+                                        }
+
+                                        table.rows.push(row);
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    fn partition_count(&self) -> usize {
+        self.partitions.len()
+    }
+
+    fn row_count(&self) -> usize {
+        let mut count = 0;
+
+        for p in self.partitions.values() {
+            for t in p.tables.values() {
+                count += t.rows.len();
+            }
+        }
+
+        count
+    }
+
+    fn tag_cardinality(&self) -> usize {
+        let mut tags = BTreeMap::new();
+
+        for p in self.partitions.values() {
+            for t in p.tables.values() {
+                for r in &t.rows {
+                    for v in &r.values {
+                        if let Value::Tag(idx) = &v.value {
+                            tags.insert(*idx, ());
+                        }
+                    }
+                }
+            }
+        }
+
+        tags.len()
+    }
+
+    fn measurement_count(&self) -> usize {
+        let mut measurements = BTreeMap::new();
+
+        for p in self.partitions.values() {
+            for t in p.tables.values() {
+                measurements.insert(t.name.to_string(), ());
+            }
+        }
+
+        measurements.len()
+    }
+}
+
+#[derive(Default)]
+struct Partition {
+    dict: BTreeMap<String, usize>,
+    tables: BTreeMap<String, Table>,
+}
+
+#[derive(Default)]
+struct Table {
+    name: String,
+    rows: Vec<Row>,
+}
+
+struct Row {
+    values: Vec<ColumnValue>,
+}
+
+#[derive(Debug)]
+struct ColumnValue {
+    column_name_index: usize,
+    value: Value,
+}
+
+#[derive(Debug)]
+enum Value {
+    I64(i64),
+    F64(f64),
+    Tag(usize),
+}
+
+fn create_lp(config: &Config) -> String {
+    use std::fmt::Write;
+
+    let mut s = String::new();
+
+    let lines_per_partition = config.lines_per_partition();
+    assert!(
+        lines_per_partition >= config.table_count as i64,
+        format!(
+            "can't fit {} unique tables (measurements) into partition with {} rows",
+            config.table_count, lines_per_partition
+        )
+    );
+    assert!(
+        lines_per_partition >= config.tag_cardinality as i64,
+        format!(
+            "can't fit {} unique tags into partition with {} rows",
+            config.tag_cardinality, lines_per_partition
+        )
+    );
+
+    for line in 0..config.line_count {
+        let partition_number = line / lines_per_partition % config.partition_count as i64;
+        let timestamp = STARTING_TIMESTAMP_NS + (partition_number * NEXT_ENTRY_NS);
+        let mn = line % config.table_count as i64;
+        let tn = line % config.tag_cardinality as i64;
+        writeln!(
+            s,
+            "processes-{mn},host=my.awesome.computer.example.com-{tn} blocked=0i,zombies=0i,stopped=0i,running=42i,sleeping=999i,total=1041i,unknown=0i,idle=0i {timestamp}",
+            mn = mn,
+            tn = tn,
+            timestamp = timestamp,
+        ).unwrap();
+    }
+
+    s
+}
+
+fn rules_with_time_partition() -> DatabaseRules {
+    let partition_template = PartitionTemplate {
+        parts: vec![TemplatePart::TimeFormat("%Y-%m-%d %H:%M:%S".to_string())],
+    };
+
+    DatabaseRules {
+        partition_template,
+        ..Default::default()
+    }
+}
+
+criterion_group!(
+    benches,
+    lines_to_replicated_write,
+    replicated_write_into_bytes,
+    bytes_into_struct,
+);
+
+criterion_main!(benches);

--- a/data_types/src/data.rs
+++ b/data_types/src/data.rs
@@ -58,6 +58,30 @@ impl ReplicatedWrite {
         let fb = self.to_fb();
         (fb.writer(), fb.sequence())
     }
+
+    /// Returns the serialized bytes for the write. (used for benchmarking)
+    pub fn bytes(&self) -> &Vec<u8> {
+        &self.data
+    }
+
+    /// Returns the number of write buffer entries in this replicated write
+    pub fn entry_count(&self) -> usize {
+        if let Some(batch) = self.write_buffer_batch() {
+            if let Some(entries) = batch.entries() {
+                return entries.len();
+            }
+        }
+
+        0
+    }
+}
+
+impl From<&[u8]> for ReplicatedWrite {
+    fn from(data: &[u8]) -> Self {
+        Self {
+            data: Vec::from(data),
+        }
+    }
 }
 
 impl fmt::Display for ReplicatedWrite {

--- a/data_types/src/data.rs
+++ b/data_types/src/data.rs
@@ -9,7 +9,7 @@ use influxdb_line_protocol::{FieldValue, ParsedLine};
 use std::{collections::BTreeMap, fmt};
 
 use chrono::Utc;
-use crc32fast::Hasher;
+// use crc32fast::Hasher;
 use flatbuffers::FlatBufferBuilder;
 
 pub fn type_description(value: wb::ColumnValue) -> &'static str {
@@ -172,9 +172,10 @@ pub fn lines_to_replicated_write(
         lines,
     );
 
-    let mut hasher = Hasher::new();
-    hasher.update(&entry_bytes);
-    let checksum = hasher.finalize();
+    // let mut hasher = Hasher::new();
+    // hasher.update(&entry_bytes);
+    // let checksum = hasher.finalize();
+    let checksum = 0u32;
 
     let mut fbb = flatbuffers::FlatBufferBuilder::new_with_capacity(1024);
     let payload = fbb.create_vector_direct(&entry_bytes);

--- a/data_types/src/database_rules.rs
+++ b/data_types/src/database_rules.rs
@@ -147,7 +147,7 @@ pub enum WalBufferRollover {
 /// what partition key is generated.
 #[derive(Debug, Serialize, Deserialize, Default, Eq, PartialEq)]
 pub struct PartitionTemplate {
-    parts: Vec<TemplatePart>,
+    pub parts: Vec<TemplatePart>,
 }
 
 impl PartitionTemplate {


### PR DESCRIPTION
This PR started as a result of my desire to move the WAL Buffer over to using JSON as the format. My reasoning was as follows:
* The Flatbuffers generated code is painful to work with in Rust.
* The WAL Segment files in Object Storage are part of the public facing IOx API, thus having an easier to work with format would be something that users would appreciate.
* This [writeup indicates that JSON is faster than Flatbuffers in their tests](https://blog.logrocket.com/rust-serialization-whats-ready-for-production-today/), so maybe it's not really worth it?
* Whatever the replication format is, it's going to get converted into different Rust structs to make it useful for querying or writing when it gets converted to Parquet for storage in object store. My thought was that this would dominate any deserialization time.

Mainly, I was wondering if Flatbuffers was a premature optimization that we didn't really need. Maybe we could simplify the code base and the WAL Segment format all in one go?

My conclusion after running through this exercise is that we should keep the Flatbuffers format and, if needed, build more helper functions around it. We might also want to build C wrappers that can be used in other languages to make it easier to work with natively.

## Detailed Description
This PR is split into two commits. The first commit (7586fc3968d4231b28416f8bb1e9dbc44368ad9e) adds some benchmarking for the existing Flatbuffers structure. We'll likely want to keep this around once people have a chance to review this PR and comment on it. If so, I can cherry-pick it into another PR to get it into shape for merging into main. The second commit (ba48064a7513a1cd69e6be93d78fd29b4bd4a7bf) adds some methods in the benchmark that mirror the existing ReplicatedWrite structure, but with JSON so that we can compare its performance. In this commit I commented out the checksum computation that the Flatbuffers implementation does so the comparison is fair.

I wanted to separate the benchmarks into discrete things that we'll do in a production system. Sometimes we'd have these end-to-end, but many times a server will only be doing one of these steps. The benchmarks test:
* `lines_to_replicated_write` - taking already parsed line protocol and creating a ReplicatedWrite struct with it.
* `replicated_write_into_bytes` - convert a ReplicatedWrite into bytes so that it can be sent over the network or into a segment file.
* `bytes_into_struct` - deserialize a replicated write and load it into a toy DB struct. The idea here is that a ReplicatedWrite will always have to be converted over to either the MutableBuffer, ReadBuffer, or RecordBatch. None of the underlying crates will use the ReplicatedWrite as is. I implemented something basic that uses a dictionary per partition to avoid a bunch of String allocations taking up the lion's share of the time.

The easiest way to see the results is to pull down this branch and do from the project root:

```
cd data_types
cargo bench
open target/criterion/report/index.html 
```

## Results Summary
JSON is slightly faster in the lines to replicated write benchmark at 4.9% to 8.4% faster. This is about 250 microseconds in a bench that takes 2.75 to 2.97 milliseconds. The impact is slightly more pronounced in scenarios with a single partition and either many tables or tags (which would likely be most commmon). But it's not much.

In the bytes to struct benchmark, JSON time is taken up largely by deserializing the bytes, giving Flatbuffers over a 3x advantage.

The results of replicated write to bytes are predictable in that Flatbuffers takes no time (< 1ns) while JSON serialization takes around 820 microseconds for the same thing. While 820 microseconds seems small, it will likely add up with larger segment files (i.e. not microbenchmarks) and particularly for replication or subscriptions that take the replicated writes as is (i.e. they contain no filter).

## Closing Thoughts
There are a few other advantages that Flatbuffers has over JSON. I think a declarative schema is a win. We should take advantage of this and version them so we can evolve over time without breaking users. Also, we plan to support blob types in IOx, which will be trivial in Flatbuffers, while in JSON we'd end up doing something ugly like base64 encoding. Generally, data types in Flatbuffers are more specific. We won't have a problem representing `u64` or the range of `float` values for instance.

One thing this doesn't reflect is that subscriptions will likely filter out portions of a ReplicatedWrite. This means that it will need to be processed so that a new one can be built and then serialized. So we'll be creating new data as we go. This would likely remove a bit of the performance advantage of Flatbuffers over JSON, but I think it'll still be much faster than we'd otherwise get with JSON.

I didn't get very far into this effort before I started reaching the conclusion that Flatbuffers would be the better choice. It seems obvious in retrospect, but I thought that other factors would likely drown out any performance differences between JSON and Flatbuffers (or make the difference small enough that ease of use would win out). But I decided to forge ahead anyway so that we'd have this documented and to convince myself.

Unless I'm missing something?