### PR TITLE
chore: Benchmark ReplicatedWrite

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -67,9 +67,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.36"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68803225a7b13e47191bab76f2687382b60d259e8cf37f6e1893658b84bb9479"
+checksum = "ee67c11feeac938fae061b232e38e0b6d94f97a9df10e6271319325ac4c56a86"
 
 [[package]]
 name = "arrayref"
@@ -715,6 +715,7 @@ version = "0.1.0"
 dependencies = [
  "chrono",
  "crc32fast",
+ "criterion",
  "flatbuffers 0.6.1",
  "generated_types",
  "influxdb_line_protocol",
@@ -843,9 +844,9 @@ checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
 
 [[package]]
 name = "dtoa"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "134951f4028bdadb9b84baf4232681efbf277da25144b9b0ad65df75946c422b"
+checksum = "88d7ed2934d741c6b37e33e3832298e8850b53fd2d2bea03873375596c7cea4e"
 
 [[package]]
 name = "either"
@@ -1475,9 +1476,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc6f3ad7b9d11a0c00842ff8de1b60ee58661048eb8049ed33c73594f359d7e6"
+checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
 
 [[package]]
 name = "jobserver"
@@ -1820,9 +1821,9 @@ dependencies = [
 
 [[package]]
 name = "native-tls"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fcc7939b5edc4e4f86b1b4a04bb1498afaaf871b1a6691838ed06fcb48d3a3f"
+checksum = "b8d96b2e1c8da3957d58100b09f102c6d9cfdfced01b7ec5a8974044bb09dbd4"
 dependencies = [
  "lazy_static",
  "libc",
@@ -2109,7 +2110,7 @@ version = "3.0.0-SNAPSHOT"
 source = "git+https://github.com/apache/arrow.git?rev=c46fd102678fd22b9781642437ad8821f907d9db#c46fd102678fd22b9781642437ad8821f907d9db"
 dependencies = [
  "arrow",
- "base64 0.12.3",
+ "base64 0.13.0",
  "brotli",
  "byteorder",
  "chrono",
@@ -2260,9 +2261,9 @@ checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
 
 [[package]]
 name = "predicates"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96bfead12e90dccead362d62bb2c90a5f6fc4584963645bc7f71a735e0b0735a"
+checksum = "73dd9b7b200044694dfede9edf907c1ca19630908443e9447e624993700c6932"
 dependencies = [
  "difference",
  "float-cmp",
@@ -2273,15 +2274,15 @@ dependencies = [
 
 [[package]]
 name = "predicates-core"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06075c3a3e92559ff8929e7a280684489ea27fe44805174c3ebd9328dcb37178"
+checksum = "fb3dbeaaf793584e29c58c7e3a82bbb3c7c06b63cea68d13b0e3cddc124104dc"
 
 [[package]]
 name = "predicates-tree"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e63c4859013b38a76eca2414c64911fba30def9e3202ac461a2d22831220124"
+checksum = "aee95d988ee893cb35c06b148c80ed2cd52c8eea927f50ba7a0be1a786aeab73"
 dependencies = [
  "predicates-core",
  "treeline",
@@ -2891,9 +2892,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.60"
+version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1500e84d27fe482ed1dc791a56eddc2f230046a040fa908c08bda1d9fb615779"
+checksum = "4fceb2595057b6891a4ee808f70054bd2d12f0e97f1cbb78689b59f676df325a"
 dependencies = [
  "indexmap",
  "itoa",
@@ -3071,9 +3072,9 @@ dependencies = [
 
 [[package]]
 name = "standback"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf906c8b8fc3f6ecd1046e01da1d8ddec83e48c8b08b84dcc02b585a6bedf5a8"
+checksum = "c66a8cff4fa24853fdf6b51f75c6d7f8206d7c75cab4e467bcd7f25c2b1febe0"
 dependencies = [
  "version_check",
 ]
@@ -3158,9 +3159,9 @@ checksum = "2d67a5a62ba6e01cb2192ff309324cb4875d0c451d55fe2319433abe7a05a8ee"
 
 [[package]]
 name = "syn"
-version = "1.0.55"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a571a711dddd09019ccc628e1b17fe87c59b09d513c06c026877aa708334f37a"
+checksum = "a9802ddde94170d186eeee5005b798d9c159fa970403f1be19976d0cfb939b72"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/data_types/Cargo.toml
+++ b/data_types/Cargo.toml
@@ -15,3 +15,10 @@ chrono = "0.4"
 flatbuffers = "0.6"
 crc32fast = "1.2.0"
 tracing = "0.1"
+
+[dev-dependencies]
+criterion = "0.3"
+
+[[bench]]
+name = "benchmark"
+harness = false

--- a/data_types/benches/benchmark.rs
+++ b/data_types/benches/benchmark.rs
@@ -1,0 +1,392 @@
+use criterion::measurement::WallTime;
+use criterion::{criterion_group, criterion_main, Bencher, BenchmarkId, Criterion, Throughput};
+use data_types::data::{lines_to_replicated_write as lines_to_rw, ReplicatedWrite};
+use data_types::database_rules::{DatabaseRules, PartitionTemplate, TemplatePart};
+use generated_types::wal as wb;
+use influxdb_line_protocol::{parse_lines, ParsedLine};
+use std::collections::BTreeMap;
+use std::fmt;
+use std::time::Duration;
+
+const NEXT_ENTRY_NS: i64 = 1_000_000_000;
+const STARTING_TIMESTAMP_NS: i64 = 0;
+
+#[derive(Debug)]
+struct Config {
+    // total number of rows written in, regardless of the number of partitions
+    line_count: i64,
+    // this will be the number of write buffer entries per replicated write
+    partition_count: usize,
+    // the number of tables (measurements) in each replicated write
+    table_count: usize,
+    // the number of unique tag values for the tag in each replicated write
+    tag_cardinality: usize,
+}
+
+impl Config {
+    fn lines_per_partition(&self) -> i64 {
+        self.line_count / self.partition_count as i64
+    }
+}
+
+impl fmt::Display for Config {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "lines: {} ({} per partition) | partitions: {} | tables per: {} | unique tag values per: {}",
+            self.line_count,
+            self.line_count / self.partition_count as i64,
+            self.partition_count,
+            self.table_count,
+            self.tag_cardinality
+        )
+    }
+}
+
+fn lines_to_replicated_write(c: &mut Criterion) {
+    run_group("lines_to_replicated_write", c, |lines, rules, config, b| {
+        b.iter(|| {
+            let write = lines_to_rw(0, 0, &lines, &rules);
+            assert_eq!(write.entry_count(), config.partition_count);
+        });
+    });
+}
+
+fn replicated_write_into_bytes(c: &mut Criterion) {
+    run_group(
+        "replicated_write_into_bytes",
+        c,
+        |lines, rules, config, b| {
+            let write = lines_to_rw(0, 0, &lines, &rules);
+            assert_eq!(write.entry_count(), config.partition_count);
+
+            b.iter(|| {
+                let _ = write.bytes().len();
+            });
+        },
+    );
+}
+
+// simulates the speed of marshalling the bytes into something like the mutable
+// buffer or read buffer, which won't use the replicated write structure anyway
+fn bytes_into_struct(c: &mut Criterion) {
+    run_group("bytes_into_struct", c, |lines, rules, config, b| {
+        let write = lines_to_rw(0, 0, &lines, &rules);
+        assert_eq!(write.entry_count(), config.partition_count);
+        let data = write.bytes();
+
+        b.iter(|| {
+            let mut db = Db::default();
+            db.deserialize_write(data);
+            assert_eq!(db.partition_count(), config.partition_count);
+            assert_eq!(db.row_count() as i64, config.line_count);
+            assert_eq!(db.measurement_count(), config.table_count);
+            assert_eq!(db.tag_cardinality(), config.tag_cardinality);
+        });
+    });
+}
+
+fn run_group(
+    group_name: &str,
+    c: &mut Criterion,
+    bench: impl Fn(&[ParsedLine], &DatabaseRules, &Config, &mut Bencher<WallTime>),
+) {
+    let mut group = c.benchmark_group(group_name);
+    group.measurement_time(Duration::from_secs(10));
+    let rules = rules_with_time_partition();
+
+    for partition_count in [1, 10, 100, 1000].iter() {
+        let config = Config {
+            line_count: 1_000,
+            partition_count: *partition_count,
+            table_count: 1,
+            tag_cardinality: 1,
+        };
+        let id = BenchmarkId::new("partition count", config.partition_count);
+        group.throughput(Throughput::Elements(config.line_count as u64));
+
+        let lp = create_lp(&config);
+        let lines: Vec<_> = parse_lines(&lp).map(|l| l.unwrap()).collect();
+
+        group.bench_with_input(id, &config, |b, config| {
+            bench(&lines, &rules, &config, b);
+        });
+    }
+
+    for table_count in [1, 10, 100, 1000].iter() {
+        let config = Config {
+            line_count: 1_000,
+            partition_count: 1,
+            table_count: *table_count,
+            tag_cardinality: 1,
+        };
+        let id = BenchmarkId::new("table count", config.table_count);
+        group.throughput(Throughput::Elements(config.line_count as u64));
+
+        let lp = create_lp(&config);
+        let lines: Vec<_> = parse_lines(&lp).map(|l| l.unwrap()).collect();
+
+        group.bench_with_input(id, &config, |b, config| {
+            bench(&lines, &rules, &config, b);
+        });
+    }
+
+    for tag_cardinality in [1, 10, 100, 1000].iter() {
+        let config = Config {
+            line_count: 1_000,
+            partition_count: 1,
+            table_count: 1,
+            tag_cardinality: *tag_cardinality,
+        };
+        let id = BenchmarkId::new("tag cardinality", config.tag_cardinality);
+        group.throughput(Throughput::Elements(config.line_count as u64));
+
+        let lp = create_lp(&config);
+        let lines: Vec<_> = parse_lines(&lp).map(|l| l.unwrap()).collect();
+
+        group.bench_with_input(id, &config, |b, config| {
+            bench(&lines, &rules, &config, b);
+        });
+    }
+
+    group.finish();
+}
+
+#[derive(Default)]
+struct Db {
+    partitions: BTreeMap<String, Partition>,
+}
+
+impl Db {
+    fn deserialize_write(&mut self, data: &[u8]) {
+        let write = ReplicatedWrite::from(data);
+
+        if let Some(batch) = write.write_buffer_batch() {
+            if let Some(entries) = batch.entries() {
+                for entry in entries {
+                    let key = entry.partition_key().unwrap();
+
+                    if self.partitions.get(key).is_none() {
+                        self.partitions
+                            .insert(key.to_string(), Partition::default());
+                    }
+                    let partition = self.partitions.get_mut(key).unwrap();
+
+                    if let Some(tables) = entry.table_batches() {
+                        for table_fb in tables {
+                            let table_name = table_fb.name().unwrap();
+
+                            if partition.tables.get(table_name).is_none() {
+                                let table = Table {
+                                    name: table_name.to_string(),
+                                    ..Default::default()
+                                };
+                                partition.tables.insert(table_name.to_string(), table);
+                            }
+                            let table = partition.tables.get_mut(table_name).unwrap();
+
+                            if let Some(rows) = table_fb.rows() {
+                                for row_fb in rows {
+                                    if let Some(values) = row_fb.values() {
+                                        let mut row = Row {
+                                            values: Vec::with_capacity(values.len()),
+                                        };
+
+                                        for value in values {
+                                            let column_name = value.column().unwrap();
+
+                                            if partition.dict.get(column_name).is_none() {
+                                                partition.dict.insert(
+                                                    column_name.to_string(),
+                                                    partition.dict.len(),
+                                                );
+                                            }
+                                            let column_index =
+                                                *partition.dict.get(column_name).unwrap();
+
+                                            let val = match value.value_type() {
+                                                wb::ColumnValue::TagValue => {
+                                                    let tag = value
+                                                        .value_as_tag_value()
+                                                        .unwrap()
+                                                        .value()
+                                                        .unwrap();
+
+                                                    if partition.dict.get(tag).is_none() {
+                                                        partition.dict.insert(
+                                                            tag.to_string(),
+                                                            partition.dict.len(),
+                                                        );
+                                                    }
+                                                    let tag_index =
+                                                        *partition.dict.get(tag).unwrap();
+
+                                                    Value::Tag(tag_index)
+                                                }
+                                                wb::ColumnValue::F64Value => {
+                                                    let val =
+                                                        value.value_as_f64value().unwrap().value();
+
+                                                    Value::F64(val)
+                                                }
+                                                wb::ColumnValue::I64Value => {
+                                                    let val =
+                                                        value.value_as_i64value().unwrap().value();
+
+                                                    Value::I64(val)
+                                                }
+                                                _ => panic!("not supported!"),
+                                            };
+
+                                            let column_value = ColumnValue {
+                                                column_name_index: column_index,
+                                                value: val,
+                                            };
+
+                                            row.values.push(column_value);
+                                        }
+
+                                        table.rows.push(row);
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    fn partition_count(&self) -> usize {
+        self.partitions.len()
+    }
+
+    fn row_count(&self) -> usize {
+        let mut count = 0;
+
+        for p in self.partitions.values() {
+            for t in p.tables.values() {
+                count += t.rows.len();
+            }
+        }
+
+        count
+    }
+
+    fn tag_cardinality(&self) -> usize {
+        let mut tags = BTreeMap::new();
+
+        for p in self.partitions.values() {
+            for t in p.tables.values() {
+                for r in &t.rows {
+                    for v in &r.values {
+                        if let Value::Tag(idx) = &v.value {
+                            tags.insert(*idx, ());
+                        }
+                    }
+                }
+            }
+        }
+
+        tags.len()
+    }
+
+    fn measurement_count(&self) -> usize {
+        let mut measurements = BTreeMap::new();
+
+        for p in self.partitions.values() {
+            for t in p.tables.values() {
+                measurements.insert(t.name.to_string(), ());
+            }
+        }
+
+        measurements.len()
+    }
+}
+
+#[derive(Default)]
+struct Partition {
+    dict: BTreeMap<String, usize>,
+    tables: BTreeMap<String, Table>,
+}
+
+#[derive(Default)]
+struct Table {
+    name: String,
+    rows: Vec<Row>,
+}
+
+struct Row {
+    values: Vec<ColumnValue>,
+}
+
+#[derive(Debug)]
+struct ColumnValue {
+    column_name_index: usize,
+    value: Value,
+}
+
+#[derive(Debug)]
+enum Value {
+    I64(i64),
+    F64(f64),
+    Tag(usize),
+}
+
+fn create_lp(config: &Config) -> String {
+    use std::fmt::Write;
+
+    let mut s = String::new();
+
+    let lines_per_partition = config.lines_per_partition();
+    assert!(
+        lines_per_partition >= config.table_count as i64,
+        format!(
+            "can't fit {} unique tables (measurements) into partition with {} rows",
+            config.table_count, lines_per_partition
+        )
+    );
+    assert!(
+        lines_per_partition >= config.tag_cardinality as i64,
+        format!(
+            "can't fit {} unique tags into partition with {} rows",
+            config.tag_cardinality, lines_per_partition
+        )
+    );
+
+    for line in 0..config.line_count {
+        let partition_number = line / lines_per_partition % config.partition_count as i64;
+        let timestamp = STARTING_TIMESTAMP_NS + (partition_number * NEXT_ENTRY_NS);
+        let mn = line % config.table_count as i64;
+        let tn = line % config.tag_cardinality as i64;
+        writeln!(
+            s,
+            "processes-{mn},host=my.awesome.computer.example.com-{tn} blocked=0i,zombies=0i,stopped=0i,running=42i,sleeping=999i,total=1041i,unknown=0i,idle=0i {timestamp}",
+            mn = mn,
+            tn = tn,
+            timestamp = timestamp,
+        ).unwrap();
+    }
+
+    s
+}
+
+fn rules_with_time_partition() -> DatabaseRules {
+    let partition_template = PartitionTemplate {
+        parts: vec![TemplatePart::TimeFormat("%Y-%m-%d %H:%M:%S".to_string())],
+    };
+
+    DatabaseRules {
+        partition_template,
+        ..Default::default()
+    }
+}
+
+criterion_group!(
+    benches,
+    lines_to_replicated_write,
+    replicated_write_into_bytes,
+    bytes_into_struct,
+);
+
+criterion_main!(benches);

--- a/data_types/src/data.rs
+++ b/data_types/src/data.rs
@@ -58,6 +58,30 @@ impl ReplicatedWrite {
         let fb = self.to_fb();
         (fb.writer(), fb.sequence())
     }
+
+    /// Returns the serialized bytes for the write. (used for benchmarking)
+    pub fn bytes(&self) -> &Vec<u8> {
+        &self.data
+    }
+
+    /// Returns the number of write buffer entries in this replicated write
+    pub fn entry_count(&self) -> usize {
+        if let Some(batch) = self.write_buffer_batch() {
+            if let Some(entries) = batch.entries() {
+                return entries.len();
+            }
+        }
+
+        0
+    }
+}
+
+impl From<&[u8]> for ReplicatedWrite {
+    fn from(data: &[u8]) -> Self {
+        Self {
+            data: Vec::from(data),
+        }
+    }
 }
 
 impl fmt::Display for ReplicatedWrite {

--- a/data_types/src/database_rules.rs
+++ b/data_types/src/database_rules.rs
@@ -147,7 +147,7 @@ pub enum WalBufferRollover {
 /// what partition key is generated.
 #[derive(Debug, Serialize, Deserialize, Default, Eq, PartialEq)]
 pub struct PartitionTemplate {
-    parts: Vec<TemplatePart>,
+    pub parts: Vec<TemplatePart>,
 }
 
 impl PartitionTemplate {


### PR DESCRIPTION
This adds benchmarks to the data_types crate for ReplicatedWrite. This was part of a broader effort to see if switching to JSON for the WAL Buffer format made any sense (#606). The conclusion is that we'll continue to use Flatbuffers, but these benches might be worth keeping around.