### PR TITLE
fix: remove spaces in bench name to ease automatic scraping

### DIFF
--- a/benches/mapper.rs
+++ b/benches/mapper.rs
@@ -79,7 +79,7 @@ fn map_field_columns(c: &mut Criterion) {
     block_map.insert(2, block2);
     let decoder = reader::MockBlockDecoder::new(block_map);
 
-    group.bench_function("map field columns", move |b| {
+    group.bench_function("map_field_columns", move |b| {
         b.iter_batched(
             || (decoder.clone(), measurement_table.clone()),
             |(mut data, mut measurement_table)| {


### PR DESCRIPTION
As the bench name ends up in file names, avoid spaces to make scraping scripts easier to write. 

The Right Thing (TM) would be to update the script (https://github.com/influxdata/influxdb_iox/pull/605) to handle spaces. But for now I just want the 'expedient' thing to get everything wired up.

- [x] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb_iox/blob/main/README.md).
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
