### PR TITLE
fix: Avoid hours of time running benchmarks

### DIFF
--- a/benches/packers.rs
+++ b/benches/packers.rs
@@ -97,15 +97,15 @@ fn benchmark_get(c: &mut Criterion, benchmark_group_name: &str, batch_sizes: &[u
             u64::try_from(input.len() * mem::size_of::<Option<u64>>()).unwrap(),
         ));
 
+        let mut packer = Packer::with_capacity(input.len());
+        for v in input {
+            packer.push_option(v);
+        }
+
         group.bench_with_input(
             BenchmarkId::from_parameter(batch_size),
-            &input,
-            |b, input| {
-                let mut packer = Packer::with_capacity(input.len());
-                for v in input {
-                    packer.push_option(*v);
-                }
-
+            &packer,
+            |b, packer| {
                 b.iter(|| {
                     // worst case getting last element.
                     packer.get(packer.num_rows() - 1);
@@ -125,15 +125,15 @@ fn benchmark_iter(c: &mut Criterion, benchmark_group_name: &str, batch_sizes: &[
             u64::try_from(input.len() * mem::size_of::<Option<u64>>()).unwrap(),
         ));
 
+        let mut packer = Packer::with_capacity(input.len());
+        for v in input {
+            packer.push_option(v);
+        }
+
         group.bench_with_input(
             BenchmarkId::from_parameter(batch_size),
-            &input,
-            |b, input| {
-                let mut packer = Packer::with_capacity(input.len());
-                for v in input {
-                    packer.push_option(*v);
-                }
-
+            &packer,
+            |b, packer| {
                 let mut sum = 0;
                 b.iter(|| {
                     for v in packer.iter() {


### PR DESCRIPTION
Running `cargo bench` on master currently takes ~12 hours. I left a VM running trying to collect data for the last 30 commits and it ran for almost a week (here is the CPU usage over that time -- when it is at 50% that is when the benchmarks are running) 

<img width="1484" alt="Screen Shot 2021-01-04 at 10 56 39 AM" src="https://user-images.githubusercontent.com/490673/103565398-48e19d00-4e8e-11eb-9e35-1481dc16aecd.png">

I did some profiling and determined that most of the time is being spent in the packers benchmarks re-creating the same input data over and over again.

Now, also if you watch the benchmarks run the behavior makes much more sense -- when the output says "warming up for 3 seconds" it actually finished on a count of three when that was not the case prior to this PR
  

## Prior to this change:
packers: DNF (Did Not Finish -- I killed it after an hour or two)

## After this change
packers: 3m27.166s


## Test script (very sophisticated)
```
set -x
echo "Starting run at " `date`

date
time cargo -v bench --bench encoders
date
time cargo -v bench --bench fixtures
date
time cargo -v bench --bench line_parser
date
time cargo -v bench --bench line_protocol_to_parquet
date
time cargo -v bench --bench mapper
date
time cargo -v bench --bench packers
```




- [x] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb_iox/blob/main/README.md).
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
