### PR TITLE
feat: Interface for writing and querying mutable buffer, read buffer and parquet

### DIFF
--- a/mutable_buffer/src/database.rs
+++ b/mutable_buffer/src/database.rs
@@ -1943,7 +1943,7 @@ mod tests {
 
     /// write lines into this database
     async fn write_lines(database: &MutableBufferDb, lines: &[ParsedLine<'_>]) {
-        let mut planner = query::test::TestLPWritePlanner::default();
-        planner.write_lines(database, lines).await.unwrap()
+        let mut writer = query::test::TestLPWriter::default();
+        writer.write_lines(database, lines).await.unwrap()
     }
 }

--- a/mutable_buffer/src/database.rs
+++ b/mutable_buffer/src/database.rs
@@ -194,7 +194,6 @@ impl MutableBufferDb {
 
 #[async_trait]
 impl Database for MutableBufferDb {
-    type Chunk = crate::chunk::Chunk;
     type Error = Error;
 
     async fn store_replicated_write(&self, write: &ReplicatedWrite) -> Result<(), Self::Error> {
@@ -298,7 +297,6 @@ impl Database for MutableBufferDb {
 
 #[async_trait]
 impl SQLDatabase for MutableBufferDb {
-    type Chunk = Chunk;
     type Error = Error;
 
     async fn query(&self, query: &str) -> Result<Vec<RecordBatch>, Self::Error> {

--- a/mutable_buffer/src/database.rs
+++ b/mutable_buffer/src/database.rs
@@ -1,11 +1,10 @@
-use generated_types::wal as wb;
-use influxdb_line_protocol::ParsedLine;
+use generated_types::wal;
 use query::group_by::GroupByAndAggregate;
 use query::group_by::WindowDuration;
 use query::{
     exec::{stringset::StringSet, FieldListPlan, SeriesSetPlan, SeriesSetPlans, StringSetPlan},
     predicate::Predicate,
-    SQLDatabase, TSDatabase,
+    Database, SQLDatabase,
 };
 use query::{group_by::Aggregate, predicate::PredicateBuilder};
 
@@ -26,12 +25,11 @@ use arrow_deps::{
         logical_plan::LogicalPlan, physical_plan::collect, prelude::ExecutionConfig,
     },
 };
-use data_types::data::{split_lines_into_write_entry_partitions, ReplicatedWrite};
+use data_types::data::ReplicatedWrite;
 
 use crate::dictionary::Error as DictionaryError;
 
 use async_trait::async_trait;
-use chrono::{offset::TimeZone, Utc};
 use snafu::{ResultExt, Snafu};
 use sqlparser::{
     ast::{SetExpr, Statement, TableFactor},
@@ -160,7 +158,7 @@ impl MutableBufferDb {
     }
 
     /// Directs the writes from batch into the appropriate partitions
-    async fn write_entries_to_partitions(&self, batch: &wb::WriteBufferBatch<'_>) -> Result<()> {
+    async fn write_entries_to_partitions(&self, batch: &wal::WriteBufferBatch<'_>) -> Result<()> {
         if let Some(entries) = batch.entries() {
             for entry in entries {
                 let key = entry
@@ -195,21 +193,9 @@ impl MutableBufferDb {
 }
 
 #[async_trait]
-impl TSDatabase for MutableBufferDb {
+impl Database for MutableBufferDb {
     type Chunk = crate::chunk::Chunk;
     type Error = Error;
-
-    // TODO: writes lines creates a column named "time" for the timestamp data. If
-    //       we keep this we need to validate that no tag or field has the same
-    // name.
-    async fn write_lines(&self, lines: &[ParsedLine<'_>]) -> Result<(), Self::Error> {
-        let data = split_lines_into_write_entry_partitions(compute_partition_key, lines);
-        let batch = flatbuffers::get_root::<wb::WriteBufferBatch<'_>>(&data);
-
-        self.write_entries_to_partitions(&batch).await?;
-
-        Ok(())
-    }
 
     async fn store_replicated_write(&self, write: &ReplicatedWrite) -> Result<(), Self::Error> {
         match write.write_buffer_batch() {
@@ -1053,17 +1039,6 @@ impl Visitor for WindowGroupsVisitor {
     }
 }
 
-// compute_partition_key returns the partititon key for the given
-// line. The key will be the prefix of a chunk name (multiple chunks
-// can exist for each key).  It uses the user defined chunking rules
-// to construct this key
-pub fn compute_partition_key(line: &ParsedLine<'_>) -> String {
-    // TODO - wire this up to use chunking rules, for now just chunk by day
-    let ts = line.timestamp.unwrap();
-    let dt = Utc.timestamp_nanos(ts);
-    dt.format("%Y-%m-%dT%H").to_string()
-}
-
 struct ArrowTable {
     name: String,
     schema: Arc<ArrowSchema>,
@@ -1081,7 +1056,7 @@ mod tests {
             Executor,
         },
         predicate::PredicateBuilder,
-        TSDatabase,
+        Database,
     };
 
     use arrow_deps::{
@@ -1092,7 +1067,7 @@ mod tests {
         assert_table_eq,
         datafusion::prelude::*,
     };
-    use influxdb_line_protocol::parse_lines;
+    use influxdb_line_protocol::{parse_lines, ParsedLine};
     use test_helpers::str_pair_vec_to_vec;
     use tokio::sync::mpsc;
 
@@ -1129,7 +1104,7 @@ mod tests {
             parse_lines("cpu,region=west user=23.2 10\ndisk,region=east bytes=99i 11")
                 .map(|l| l.unwrap())
                 .collect();
-        db.write_lines(&lines).await?;
+        write_lines(&db, &lines).await;
 
         // Now, we should see the two tables
         assert_eq!(
@@ -1151,7 +1126,7 @@ mod tests {
             parse_lines("cpu,region=west user=23.2 100\ncpu,region=west user=21.0 150\ndisk,region=east bytes=99i 200")
                 .map(|l| l.unwrap())
                 .collect();
-        db.write_lines(&lines).await?;
+        write_lines(&db, &lines).await;
 
         // Cover all times
         let predicate = PredicateBuilder::default().timestamp_range(0, 201).build();
@@ -1189,7 +1164,7 @@ mod tests {
         )
         .map(|l| l.unwrap())
         .collect();
-        db.write_lines(&lines).await?;
+        write_lines(&db, &lines).await;
 
         let chunks = db.table_to_arrow("cpu", &["region", "core"]).await?;
         let columns = chunks[0].columns();
@@ -1233,7 +1208,7 @@ mod tests {
         let lines: Vec<_> = parse_lines("cpu,region=west,host=A user=23.2,other=1i 10")
             .map(|l| l.unwrap())
             .collect();
-        db.write_lines(&lines).await?;
+        write_lines(&db, &lines).await;
 
         let results = db.query("select * from cpu").await?;
 
@@ -1251,21 +1226,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn db_partition_key() -> Result {
-        let partition_keys: Vec<_> = parse_lines(
-            "\
-cpu user=23.2 1600107710000000000
-disk bytes=23432323i 1600136510000000000",
-        )
-        .map(|line| compute_partition_key(&line.unwrap()))
-        .collect();
-
-        assert_eq!(partition_keys, vec!["2020-09-14T18", "2020-09-15T02"]);
-
-        Ok(())
-    }
-
-    #[tokio::test]
     async fn list_column_names() -> Result {
         let db = MutableBufferDb::new("column_namedb");
 
@@ -1278,7 +1238,7 @@ disk bytes=23432323i 1600136510000000000",
                        o2,state=NY,city=NYC,borough=Brooklyn temp=61.0 600\n";
 
         let lines: Vec<_> = parse_lines(lp_data).map(|l| l.unwrap()).collect();
-        db.write_lines(&lines).await?;
+        write_lines(&db, &lines).await;
 
         #[derive(Debug)]
         struct TestCase<'a> {
@@ -1403,7 +1363,7 @@ disk bytes=23432323i 1600136510000000000",
                        o2,state=NY,city=NYC,borough=Brooklyn temp=60.8 400\n";
 
         let lines: Vec<_> = parse_lines(lp_data).map(|l| l.unwrap()).collect();
-        db.write_lines(&lines).await?;
+        write_lines(&db, &lines).await;
 
         // Predicate: state=MA
         let expr = col("state").eq(lit("MA"));
@@ -1436,7 +1396,7 @@ disk bytes=23432323i 1600136510000000000",
                        o2,state=NY temp=60.8 400\n";
 
         let lines: Vec<_> = parse_lines(lp_data).map(|l| l.unwrap()).collect();
-        db.write_lines(&lines).await?;
+        write_lines(&db, &lines).await;
 
         #[derive(Debug)]
         struct TestCase<'a> {
@@ -1600,7 +1560,7 @@ disk bytes=23432323i 1600136510000000000",
         let lp_data = lp_lines.join("\n");
 
         let lines: Vec<_> = parse_lines(&lp_data).map(|l| l.unwrap()).collect();
-        db.write_lines(&lines).await?;
+        write_lines(&db, &lines).await;
 
         let predicate = Predicate::default();
 
@@ -1672,7 +1632,7 @@ disk bytes=23432323i 1600136510000000000",
         let lp_data = lp_lines.join("\n");
 
         let lines: Vec<_> = parse_lines(&lp_data).map(|l| l.unwrap()).collect();
-        db.write_lines(&lines).await?;
+        write_lines(&db, &lines).await;
 
         // filter out one row in h20
         let predicate = PredicateBuilder::default()
@@ -1717,7 +1677,7 @@ disk bytes=23432323i 1600136510000000000",
         let lp_data = lp_lines.join("\n");
 
         let lines: Vec<_> = parse_lines(&lp_data).map(|l| l.unwrap()).collect();
-        db.write_lines(&lines).await?;
+        write_lines(&db, &lines).await;
 
         let predicate = PredicateBuilder::default()
             .add_expr(col("tag_not_in_h20").eq(lit("foo")))
@@ -1776,7 +1736,7 @@ disk bytes=23432323i 1600136510000000000",
         let lp_data = lp_lines.join("\n");
 
         let lines: Vec<_> = parse_lines(&lp_data).map(|l| l.unwrap()).collect();
-        db.write_lines(&lines).await.unwrap();
+        write_lines(&db, &lines).await;
 
         let predicate = PredicateBuilder::default()
             .add_expr(col("state").not_eq(lit("MA")))
@@ -1801,9 +1761,9 @@ disk bytes=23432323i 1600136510000000000",
         .join("\n");
 
         let lines: Vec<_> = parse_lines(&lp_data).map(|l| l.unwrap()).collect();
-        db.write_lines(&lines).await?;
+        write_lines(&db, &lines).await;
 
-        // write a new lp_line that is in a new day and thus a new chunk
+        // write a new lp_line that is in a new day and thus a new partititon
         let nanoseconds_per_day: i64 = 1_000_000_000 * 60 * 60 * 24;
 
         let lp_data = vec![format!(
@@ -1812,7 +1772,7 @@ disk bytes=23432323i 1600136510000000000",
         )]
         .join("\n");
         let lines: Vec<_> = parse_lines(&lp_data).map(|l| l.unwrap()).collect();
-        db.write_lines(&lines).await?;
+        write_lines(&db, &lines).await;
 
         // ensure there are 2 chunks
         assert_eq!(db.len().await, 2);
@@ -1896,7 +1856,7 @@ disk bytes=23432323i 1600136510000000000",
         .join("\n");
 
         let lines: Vec<_> = parse_lines(&lp_data).map(|l| l.unwrap()).collect();
-        db.write_lines(&lines).await?;
+        write_lines(&db, &lines).await;
 
         // setup to run the execution plan (
         let executor = Executor::default();
@@ -1979,5 +1939,11 @@ disk bytes=23432323i 1600136510000000000",
         println!("The results are: {:#?}", results);
 
         results
+    }
+
+    /// write lines into this database
+    async fn write_lines(database: &MutableBufferDb, lines: &[ParsedLine<'_>]) {
+        let mut planner = query::test::TestLPWritePlanner::default();
+        planner.write_lines(database, lines).await.unwrap()
     }
 }

--- a/mutable_buffer/src/lib.rs
+++ b/mutable_buffer/src/lib.rs
@@ -58,7 +58,7 @@
 
 pub mod chunk;
 mod column;
-mod database;
+pub mod database;
 mod dictionary;
 mod partition;
 mod store;

--- a/query/src/lib.rs
+++ b/query/src/lib.rs
@@ -33,8 +33,6 @@ use self::predicate::{Predicate, TimestampRange};
 /// trait and into the various query planners.
 #[async_trait]
 pub trait Database: Debug + Send + Sync {
-    /// the type of partition that is stored by this database
-    type Chunk: Send + Sync + 'static + PartitionChunk;
     type Error: std::error::Error + Send + Sync + 'static;
 
     /// Stores the replicated write in the write buffer and, if enabled, the
@@ -93,8 +91,6 @@ pub trait Database: Debug + Send + Sync {
 
 #[async_trait]
 pub trait SQLDatabase: Debug + Send + Sync {
-    /// the type of partition that is stored by this database
-    type Chunk: Send + Sync + 'static + PartitionChunk;
     type Error: std::error::Error + Send + Sync + 'static;
 
     /// Execute the specified query and return arrow record batches with the

--- a/query/src/lib.rs
+++ b/query/src/lib.rs
@@ -9,7 +9,6 @@ use arrow_deps::arrow::record_batch::RecordBatch;
 use async_trait::async_trait;
 use data_types::{data::ReplicatedWrite, partition_metadata::Table as TableStats};
 use exec::{FieldListPlan, SeriesSetPlans, StringSetPlan};
-use influxdb_line_protocol::ParsedLine;
 
 use std::{fmt::Debug, sync::Arc};
 
@@ -17,40 +16,26 @@ pub mod exec;
 pub mod func;
 pub mod group_by;
 pub mod id;
+pub mod planner;
 pub mod predicate;
 pub mod util;
 
 use self::group_by::GroupByAndAggregate;
 use self::predicate::{Predicate, TimestampRange};
 
-/// A `TSDatabase` describes something that Timeseries data using the
-/// InfluxDB Line Protocol data model (`ParsedLine` structures) and
-/// provides an interface to query that data. The query methods on
-/// this trait such as `tag_columns are specific to this data model.
+/// A `Database` is the main trait implemented by the IOx subsystems
+/// that store actual data.
 ///
-/// The IOx storage engine implements this trait to provide Timeseries
-/// specific queries, but also provides more generic access to the same
-/// underlying data via other interfaces (e.g. SQL).
+/// Databases store data organized by partitions and each partition stores
+/// data in Chunks.
 ///
-/// The InfluxDB Timeseries data model can can be thought of as a
-/// relational database table where each column has both a type as
-/// well as one of the following categories:
-///
-/// * Tag (always String type)
-/// * Field (Float64, Int64, UInt64, String, or Bool)
-/// * Time (Int64)
-///
-/// While the underlying storage is the same for columns in different
-/// categories with the same data type, columns of different
-/// categories are treated differently in the different query types.
+/// TODO: Move all Query and Line Protocol specific things out of this
+/// trait and into the various query planners.
 #[async_trait]
-pub trait TSDatabase: Debug + Send + Sync {
+pub trait Database: Debug + Send + Sync {
     /// the type of partition that is stored by this database
     type Chunk: Send + Sync + 'static + PartitionChunk;
     type Error: std::error::Error + Send + Sync + 'static;
-
-    /// writes parsed lines into this database
-    async fn write_lines(&self, lines: &[ParsedLine<'_>]) -> Result<(), Self::Error>;
 
     /// Stores the replicated write in the write buffer and, if enabled, the
     /// write ahead log.
@@ -161,7 +146,7 @@ pub trait PartitionChunk: Debug + Send + Sync {
 /// Storage for `Databases` which can be retrieved by name
 pub trait DatabaseStore: Debug + Send + Sync {
     /// The type of database that is stored by this DatabaseStore
-    type Database: TSDatabase + SQLDatabase;
+    type Database: Database + SQLDatabase;
 
     /// The type of error this DataBase store generates
     type Error: std::error::Error + Send + Sync + 'static;

--- a/query/src/planner.rs
+++ b/query/src/planner.rs
@@ -1,0 +1,36 @@
+//! The main query planners of InfluxDB IOx
+
+/// Plans queries agains the InfluxDB Line Protocol data model (`ParsedLine`
+/// structures) and provides an interface to query that data. The query methods
+/// on this trait such as `tag_columns are specific to this data model.
+///
+/// The IOx storage engine implements this trait to provide Timeseries
+/// specific queries, but also provides more generic access to the
+/// same underlying data via other interfaces (e.g. SQL).
+///
+/// The InfluxDB Timeseries data model can can be thought of as a
+/// relational database table where each column has both a type as
+/// well as one of the following categories:
+///
+/// * Tag (always String type)
+/// * Field (Float64, Int64, UInt64, String, or Bool)
+/// * Time (Int64)
+///
+/// While the underlying storage is the same for columns in different
+/// categories with the same data type, columns of different
+/// categories are treated differently in the different query types.
+#[derive(Debug)]
+pub struct TSQueryPlanner {
+    // Example methods:
+//
+// async fn table_names(&self, database: impl Database, predicate: Predicate) ->
+// Result<StringSetPlan>; async fn tag_column_names(&self, database: impl Database, predicate:
+// Predicate) -> Result<StringSetPlan>; ...
+}
+
+/// Plans queries as SQL against databases
+#[derive(Debug)]
+pub struct SQLQueryPlanner {
+    // Example methods:
+//async fn query(&self, database: &impl Database, query: &str) -> Result<Vec<RecordBatch>>;
+}

--- a/query/src/planner.rs
+++ b/query/src/planner.rs
@@ -2,7 +2,7 @@
 
 /// Plans queries agains the InfluxDB Line Protocol data model (`ParsedLine`
 /// structures) and provides an interface to query that data. The query methods
-/// on this trait such as `tag_columns are specific to this data model.
+/// on this trait such as `tag_columns` are specific to this data model.
 ///
 /// The IOx storage engine implements this trait to provide Timeseries
 /// specific queries, but also provides more generic access to the

--- a/query/src/planner.rs
+++ b/query/src/planner.rs
@@ -1,8 +1,10 @@
 //! The main query planners of InfluxDB IOx
 
-/// Plans queries agains the InfluxDB Line Protocol data model (`ParsedLine`
-/// structures) and provides an interface to query that data. The query methods
-/// on this trait such as `tag_columns` are specific to this data model.
+/// Plans queries that originate from the InfluxDB Storage gRPC
+/// interface, which are in terms of the InfluxDB Line Protocol data
+/// model (the `ParsedLine` structures) and provides an interface to query
+/// that data. The query methods on this trait such as `tag_columns`
+/// are specific to this data model.
 ///
 /// The IOx storage engine implements this trait to provide Timeseries
 /// specific queries, but also provides more generic access to the
@@ -20,7 +22,7 @@
 /// categories with the same data type, columns of different
 /// categories are treated differently in the different query types.
 #[derive(Debug)]
-pub struct TSQueryPlanner {
+pub struct InfluxRPCPlanner {
     // Example methods:
 //
 // async fn table_names(&self, database: impl Database, predicate: Predicate) ->

--- a/query/src/test.rs
+++ b/query/src/test.rs
@@ -144,8 +144,8 @@ impl TestDatabase {
             .collect::<Result<Vec<_>, _>>()
             .unwrap_or_else(|_| panic!("parsing line protocol: {}", lp_data));
 
-        let mut planner = TestLPWritePlanner::default();
-        planner.write_lines(self, &parsed_lines).await.unwrap();
+        let mut writer = TestLPWriter::default();
+        writer.write_lines(self, &parsed_lines).await.unwrap();
 
         // Writes parsed lines into this database
         let mut saved_lines = self.saved_lines.lock().await;
@@ -528,15 +528,15 @@ impl DatabaseStore for TestDatabaseStore {
     }
 }
 
-/// Planner to write data into test databases (handles creating sequence numbers
-/// and writer ids
+/// Helper for writing line protocol data directly into test databases
+/// (handles creating sequence numbers and writer ids
 #[derive(Debug, Default)]
-pub struct TestLPWritePlanner {
+pub struct TestLPWriter {
     writer_id: u32,
     sequence_number: u64,
 }
 
-impl TestLPWritePlanner {
+impl TestLPWriter {
     // writes data in LineProtocol format into a database
     pub async fn write_lines<D: Database>(
         &mut self,

--- a/query/src/test.rs
+++ b/query/src/test.rs
@@ -268,7 +268,6 @@ fn predicate_to_test_string(predicate: &Predicate) -> String {
 
 #[async_trait]
 impl Database for TestDatabase {
-    type Chunk = TestChunk;
     type Error = TestError;
 
     /// Adds the replicated write to this database
@@ -413,7 +412,6 @@ impl Database for TestDatabase {
 
 #[async_trait]
 impl SQLDatabase for TestDatabase {
-    type Chunk = TestChunk;
     type Error = TestError;
 
     /// Execute the specified query and return arrow record batches with the

--- a/query/src/test.rs
+++ b/query/src/test.rs
@@ -10,10 +10,13 @@ use crate::{
         stringset::{StringSet, StringSetRef},
         SeriesSetPlans, StringSetPlan,
     },
-    DatabaseStore, PartitionChunk, Predicate, SQLDatabase, TSDatabase, TimestampRange,
+    Database, DatabaseStore, PartitionChunk, Predicate, SQLDatabase, TimestampRange,
 };
 
-use data_types::data::ReplicatedWrite;
+use data_types::{
+    data::{lines_to_replicated_write, ReplicatedWrite},
+    database_rules::{DatabaseRules, PartitionTemplate, TemplatePart},
+};
 use influxdb_line_protocol::{parse_lines, ParsedLine};
 
 use async_trait::async_trait;
@@ -110,7 +113,14 @@ pub enum TestError {
 
     #[snafu(display("Test database execution:  {:?}", source))]
     Execution { source: crate::exec::Error },
+
+    #[snafu(display("Test error writing to database: {}", source))]
+    DatabaseWrite {
+        source: Box<dyn std::error::Error + Send + Sync + 'static>,
+    },
 }
+
+pub type Result<T, E = TestError> = std::result::Result<T, E>;
 
 impl TestDatabase {
     pub fn new() -> Self {
@@ -134,9 +144,14 @@ impl TestDatabase {
             .collect::<Result<Vec<_>, _>>()
             .unwrap_or_else(|_| panic!("parsing line protocol: {}", lp_data));
 
-        self.write_lines(&parsed_lines)
-            .await
-            .expect("writing lines");
+        let mut planner = TestLPWritePlanner::default();
+        planner.write_lines(self, &parsed_lines).await.unwrap();
+
+        // Writes parsed lines into this database
+        let mut saved_lines = self.saved_lines.lock().await;
+        for line in parsed_lines {
+            saved_lines.push(line.to_string())
+        }
     }
 
     /// Set the list of column names that will be returned on a call to
@@ -252,18 +267,9 @@ fn predicate_to_test_string(predicate: &Predicate) -> String {
 }
 
 #[async_trait]
-impl TSDatabase for TestDatabase {
+impl Database for TestDatabase {
     type Chunk = TestChunk;
     type Error = TestError;
-
-    /// Writes parsed lines into this database
-    async fn write_lines(&self, lines: &[ParsedLine<'_>]) -> Result<(), Self::Error> {
-        let mut saved_lines = self.saved_lines.lock().await;
-        for line in lines {
-            saved_lines.push(line.to_string())
-        }
-        Ok(())
-    }
 
     /// Adds the replicated write to this database
     async fn store_replicated_write(&self, write: &ReplicatedWrite) -> Result<(), Self::Error> {
@@ -519,5 +525,41 @@ impl DatabaseStore for TestDatabaseStore {
             databases.insert(name.to_string(), new_db.clone());
             Ok(new_db)
         }
+    }
+}
+
+/// Planner to write data into test databases (handles creating sequence numbers
+/// and writer ids
+#[derive(Debug, Default)]
+pub struct TestLPWritePlanner {
+    writer_id: u32,
+    sequence_number: u64,
+}
+
+impl TestLPWritePlanner {
+    // writes data in LineProtocol format into a database
+    pub async fn write_lines<D: Database>(
+        &mut self,
+        database: &D,
+        lines: &[ParsedLine<'_>],
+    ) -> Result<()> {
+        // partitions data in hourly segments
+        let partition_template = PartitionTemplate {
+            parts: vec![TemplatePart::TimeFormat("%Y-%m-%dT%H".to_string())],
+        };
+
+        let rules = DatabaseRules {
+            partition_template,
+            ..Default::default()
+        };
+
+        let write = lines_to_replicated_write(self.writer_id, self.sequence_number, &lines, &rules);
+        self.sequence_number += 1;
+        database
+            .store_replicated_write(&write)
+            .await
+            .map_err(|e| TestError::DatabaseWrite {
+                source: Box::new(e),
+            })
     }
 }

--- a/server/src/db.rs
+++ b/server/src/db.rs
@@ -22,10 +22,10 @@ pub enum Error {
         source: mutable_buffer::chunk::Error,
     },
 
-    #[snafu(display("Can not write to this database: no mutable buffer configured"))]
+    #[snafu(display("Cannot write to this database: no mutable buffer configured"))]
     DatatbaseNotWriteable {},
 
-    #[snafu(display("Can not read to this database: no mutable buffer configured"))]
+    #[snafu(display("Cannot read to this database: no mutable buffer configured"))]
     DatabaseNotReadable {},
 
     #[snafu(display("Error rolling partition: {}", source))]

--- a/server/src/db.rs
+++ b/server/src/db.rs
@@ -154,7 +154,6 @@ impl PartitionChunk for DBChunk {
 
 #[async_trait]
 impl Database for Db {
-    type Chunk = DBChunk;
     type Error = Error;
 
     // Note that most of these traits will eventually be removed from
@@ -246,8 +245,6 @@ impl Database for Db {
 
 #[async_trait]
 impl SQLDatabase for Db {
-    type Chunk = DBChunk;
-
     type Error = Error;
 
     async fn query(

--- a/server/src/db.rs
+++ b/server/src/db.rs
@@ -1,0 +1,298 @@
+//! This module contains the main IOx database object that points to all the
+//! data
+
+use std::sync::{
+    atomic::{AtomicU64, Ordering},
+    Arc,
+};
+
+use async_trait::async_trait;
+use data_types::{data::ReplicatedWrite, database_rules::DatabaseRules};
+use mutable_buffer::MutableBufferDb;
+use query::{Database, PartitionChunk, SQLDatabase};
+use serde::{Deserialize, Serialize};
+use snafu::{OptionExt, ResultExt, Snafu};
+
+use crate::buffer::Buffer;
+
+#[derive(Debug, Snafu)]
+pub enum Error {
+    #[snafu(display("Mutable Buffer Chunk Error: {}", source))]
+    MutableBufferChunk {
+        source: mutable_buffer::chunk::Error,
+    },
+
+    #[snafu(display("Can not write to this database: no mutable buffer configured"))]
+    DatatbaseNotWriteable {},
+
+    #[snafu(display("Can not read to this database: no mutable buffer configured"))]
+    DatabaseNotReadable {},
+
+    #[snafu(display("Error rolling partition: {}", source))]
+    RollingPartition {
+        source: mutable_buffer::database::Error,
+    },
+
+    #[snafu(display("Error querying mutable buffer: {}", source))]
+    MutableBufferRead {
+        source: mutable_buffer::database::Error,
+    },
+
+    #[snafu(display("Error writing to mutable buffer: {}", source))]
+    MutableBufferWrite {
+        source: mutable_buffer::database::Error,
+    },
+}
+pub type Result<T, E = Error> = std::result::Result<T, E>;
+
+#[derive(Debug, Serialize, Deserialize)]
+/// This is the main IOx Database object. It is the root object of any
+/// specific InfluxDB IOx instance
+pub struct Db {
+    #[serde(flatten)]
+    pub rules: DatabaseRules,
+    #[serde(skip)]
+    pub local_store: Option<Arc<MutableBufferDb>>,
+    #[serde(skip)]
+    wal_buffer: Option<Buffer>,
+    #[serde(skip)]
+    sequence: AtomicU64,
+}
+impl Db {
+    pub fn new(
+        rules: DatabaseRules,
+        local_store: Option<Arc<MutableBufferDb>>,
+        wal_buffer: Option<Buffer>,
+        sequence: AtomicU64,
+    ) -> Self {
+        Self {
+            rules,
+            local_store,
+            wal_buffer,
+            sequence,
+        }
+    }
+
+    /// Rolls over the active chunk in the database's specified partition
+    pub async fn rollover_partition(&self, partition_key: &str) -> Result<Arc<DBChunk>> {
+        if let Some(local_store) = self.local_store.as_ref() {
+            local_store
+                .rollover_partition(partition_key)
+                .await
+                .context(RollingPartition)
+                .map(|c| Arc::new(DBChunk::MutableBuffer(c)))
+        } else {
+            DatatbaseNotWriteable {}.fail()
+        }
+    }
+}
+
+impl PartialEq for Db {
+    fn eq(&self, other: &Self) -> bool {
+        self.rules == other.rules
+    }
+}
+impl Eq for Db {}
+
+impl Db {
+    pub fn next_sequence(&self) -> u64 {
+        self.sequence.fetch_add(1, Ordering::SeqCst)
+    }
+}
+
+/// A IOx DatabaseChunk can come from one of three places:
+/// MutableBuffer, ReadBuffer, or a ParquetFile
+#[derive(Debug)]
+pub enum DBChunk {
+    MutableBuffer(Arc<mutable_buffer::chunk::Chunk>),
+    ReadBuffer,  // TODO add appropriate type here
+    ParquetFile, // TODO add appropriate type here
+}
+
+impl PartitionChunk for DBChunk {
+    type Error = Error;
+
+    fn key(&self) -> &str {
+        match self {
+            Self::MutableBuffer(chunk) => chunk.key(),
+            Self::ReadBuffer => unimplemented!("read buffer not implemented"),
+            Self::ParquetFile => unimplemented!("parquet file not implemented"),
+        }
+    }
+
+    fn id(&self) -> u64 {
+        match self {
+            Self::MutableBuffer(chunk) => chunk.id(),
+            Self::ReadBuffer => unimplemented!("read buffer not implemented"),
+            Self::ParquetFile => unimplemented!("parquet file not implemented"),
+        }
+    }
+
+    fn table_stats(&self) -> Result<Vec<data_types::partition_metadata::Table>, Self::Error> {
+        match self {
+            Self::MutableBuffer(chunk) => chunk.table_stats().context(MutableBufferChunk),
+            Self::ReadBuffer => unimplemented!("read buffer not implemented"),
+            Self::ParquetFile => unimplemented!("parquet file not implemented"),
+        }
+    }
+
+    fn table_to_arrow(
+        &self,
+        dst: &mut Vec<arrow_deps::arrow::record_batch::RecordBatch>,
+        table_name: &str,
+        columns: &[&str],
+    ) -> Result<(), Self::Error> {
+        match self {
+            Self::MutableBuffer(chunk) => chunk
+                .table_to_arrow(dst, table_name, columns)
+                .context(MutableBufferChunk),
+            Self::ReadBuffer => unimplemented!("read buffer not implemented"),
+            Self::ParquetFile => unimplemented!("parquet file not implemented"),
+        }
+    }
+}
+
+#[async_trait]
+impl Database for Db {
+    type Chunk = DBChunk;
+    type Error = Error;
+
+    // Note that most of these traits will eventually be removed from
+    // this trait. For now, pass them directly on to the local store
+
+    async fn store_replicated_write(&self, write: &ReplicatedWrite) -> Result<(), Self::Error> {
+        self.local_store
+            .as_ref()
+            .context(DatatbaseNotWriteable)?
+            .store_replicated_write(write)
+            .await
+            .context(MutableBufferWrite)
+    }
+
+    async fn table_names(
+        &self,
+        predicate: query::predicate::Predicate,
+    ) -> Result<query::exec::StringSetPlan, Self::Error> {
+        self.local_store
+            .as_ref()
+            .context(DatabaseNotReadable)?
+            .table_names(predicate)
+            .await
+            .context(MutableBufferRead)
+    }
+
+    async fn tag_column_names(
+        &self,
+        predicate: query::predicate::Predicate,
+    ) -> Result<query::exec::StringSetPlan, Self::Error> {
+        self.local_store
+            .as_ref()
+            .context(DatabaseNotReadable)?
+            .tag_column_names(predicate)
+            .await
+            .context(MutableBufferRead)
+    }
+
+    async fn field_column_names(
+        &self,
+        predicate: query::predicate::Predicate,
+    ) -> Result<query::exec::FieldListPlan, Self::Error> {
+        self.local_store
+            .as_ref()
+            .context(DatabaseNotReadable)?
+            .field_column_names(predicate)
+            .await
+            .context(MutableBufferRead)
+    }
+
+    async fn column_values(
+        &self,
+        column_name: &str,
+        predicate: query::predicate::Predicate,
+    ) -> Result<query::exec::StringSetPlan, Self::Error> {
+        self.local_store
+            .as_ref()
+            .context(DatabaseNotReadable)?
+            .column_values(column_name, predicate)
+            .await
+            .context(MutableBufferRead)
+    }
+
+    async fn query_series(
+        &self,
+        predicate: query::predicate::Predicate,
+    ) -> Result<query::exec::SeriesSetPlans, Self::Error> {
+        self.local_store
+            .as_ref()
+            .context(DatabaseNotReadable)?
+            .query_series(predicate)
+            .await
+            .context(MutableBufferRead)
+    }
+
+    async fn query_groups(
+        &self,
+        predicate: query::predicate::Predicate,
+        gby_agg: query::group_by::GroupByAndAggregate,
+    ) -> Result<query::exec::SeriesSetPlans, Self::Error> {
+        self.local_store
+            .as_ref()
+            .context(DatabaseNotReadable)?
+            .query_groups(predicate, gby_agg)
+            .await
+            .context(MutableBufferRead)
+    }
+}
+
+#[async_trait]
+impl SQLDatabase for Db {
+    type Chunk = DBChunk;
+
+    type Error = Error;
+
+    async fn query(
+        &self,
+        query: &str,
+    ) -> Result<Vec<arrow_deps::arrow::record_batch::RecordBatch>, Self::Error> {
+        self.local_store
+            .as_ref()
+            .context(DatabaseNotReadable)?
+            .query(query)
+            .await
+            .context(MutableBufferRead)
+    }
+
+    async fn table_to_arrow(
+        &self,
+        table_name: &str,
+        columns: &[&str],
+    ) -> Result<Vec<arrow_deps::arrow::record_batch::RecordBatch>, Self::Error> {
+        self.local_store
+            .as_ref()
+            .context(DatabaseNotReadable)?
+            .table_to_arrow(table_name, columns)
+            .await
+            .context(MutableBufferRead)
+    }
+
+    async fn partition_keys(&self) -> Result<Vec<String>, Self::Error> {
+        self.local_store
+            .as_ref()
+            .context(DatabaseNotReadable)?
+            .partition_keys()
+            .await
+            .context(MutableBufferRead)
+    }
+
+    async fn table_names_for_partition(
+        &self,
+        partition_key: &str,
+    ) -> Result<Vec<String>, Self::Error> {
+        self.local_store
+            .as_ref()
+            .context(DatabaseNotReadable)?
+            .table_names_for_partition(partition_key)
+            .await
+            .context(MutableBufferRead)
+    }
+}

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -67,5 +67,6 @@
 )]
 
 pub mod buffer;
+pub mod db;
 pub mod server;
 pub mod snapshot;

--- a/src/server/rpc/service.rs
+++ b/src/server/rpc/service.rs
@@ -34,7 +34,7 @@ use query::{
         Executor as QueryExecutor,
     },
     predicate::PredicateBuilder,
-    DatabaseStore, TSDatabase,
+    Database, DatabaseStore,
 };
 
 use snafu::{OptionExt, ResultExt, Snafu};


### PR DESCRIPTION
Related to #532 

## Summary
This PR lays out a proposed evolution of the existing code structure for holding and managing data across the mutable buffer, read buffer, and parquet files. It shows one (very small) example pattern for the write path and I try to sketch out how it would work for the read path.

See also [Background slides / query engine design proposal](https://docs.google.com/presentation/d/1Q9WhgX2Ylxhz33o-AglJVML2n6pMLxkQYa2tDUeuCt8)

## Rationale for the change:
The current code, as written, has the query APIs as part of the storage -- and thus the query code is all in the mutable_buffer now. As we  expand IOx so it can store data in multiple places (chunks) we need to handle querying across multiple chunks as well as different types of chunks.

Chunks can be in one of three places:
* mutable_buffer -- and the chunks can be open or closed
* read_buffer (closed chunks)
* parquet files

The high level design in this PR is that the three sources of chunks (mutable_buffer, read_buffer, and parquet store) implement common traits, and then the  `Db` struct in the `server` trait combines those three sources in the actual server and also implements the traits. 

My plan for querying is to create new planners with the common logic extracted from the mutable buffer. The planners will take a `Database` instance as input. I envision at least two planners:  a `TSQueryPlanner` struct for gRPC / storage API calls, and an `SQLQueryPlanner` for planning SQL queries

## Project Plan
While this is gathering feedback, I plan to forge ahead and try to port one of the query traits out of the Database so we can see what the new pattern might look like 


From a project perspective, plan to implement an initial gRPC call (measurement_names, for example) in this new style, leaving everything else hooked up the way it is, and then migrate over the other query planning calls out of TSDatabase and into TSQueryPlanner.

- [x] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb_iox/blob/main/README.md).
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
