### PR TITLE
feat: add support for writing chunks to ReadBuffer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2736,6 +2736,7 @@ dependencies = [
  "permutation",
  "rand",
  "rand_distr",
+ "snafu",
 ]
 
 [[package]]

--- a/read_buffer/Cargo.toml
+++ b/read_buffer/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2018"
 
 
 [dependencies]
+snafu = "0.6"
 arrow_deps = { path = "../arrow_deps" }
 data_types = { path = "../data_types" }
 packers = { path = "../packers" }

--- a/read_buffer/src/chunk.rs
+++ b/read_buffer/src/chunk.rs
@@ -31,6 +31,31 @@ impl Chunk {
         p
     }
 
+    /// The total size in bytes of all row groups in all tables in this chunk.
+    pub fn size(&self) -> u64 {
+        self.meta.size
+    }
+
+    /// The total number of rows in all row groups in all tables in this chunk.
+    pub fn rows(&self) -> u64 {
+        self.meta.rows
+    }
+
+    /// The total number of row groups in all tables in this chunk.
+    pub fn row_groups(&self) -> usize {
+        self.meta.row_groups
+    }
+
+    /// The total number of tables in this chunk.
+    pub fn tables(&self) -> usize {
+        self.tables.len()
+    }
+
+    /// Returns true if there are no tables under this chunk.
+    pub fn is_empty(&self) -> bool {
+        self.tables() == 0
+    }
+
     /// Add a table to the chunk, updating all Chunk meta data.
     pub fn update_table(&mut self, table_name: String, row_group: RowGroup) {
         // update meta data
@@ -142,6 +167,8 @@ struct MetaData {
     size: u64, // size in bytes of the chunk
     rows: u64, // Total number of rows across all tables
 
+    row_groups: usize, // Total number of row groups across all tables in the chunk.
+
     // The total time range of *all* data (across all tables) within this
     // chunk.
     //
@@ -156,6 +183,7 @@ impl MetaData {
             size: table.size(),
             rows: table.rows(),
             time_range: table.time_range(),
+            row_groups: 1,
         }
     }
 
@@ -164,6 +192,7 @@ impl MetaData {
     pub fn update(&mut self, table_data: &RowGroup) {
         self.size += table_data.size();
         self.rows += table_data.rows() as u64;
+        self.row_groups += 1;
 
         match &mut self.time_range {
             Some((this_min, this_max)) => {

--- a/read_buffer/src/chunk.rs
+++ b/read_buffer/src/chunk.rs
@@ -116,12 +116,12 @@ impl Chunk {
 
     /// Returns the distinct set of table names that contain data that satisfies
     /// the time range and predicates.
-    pub fn table_names(&self, predicates: &[Predicate<'_>]) -> BTreeSet<String> {
-        //
-        // TODO(edd): do we want to add the ability to apply a predicate to the
-        // table names? For example, a regex where you only want table names
-        // beginning with /cpu.+/ or something?
-        todo!()
+    pub fn table_names(&self, predicates: &[Predicate<'_>]) -> BTreeSet<&String> {
+        if !predicates.is_empty() {
+            unimplemented!("Predicate support on `table_names` is not yet implemented");
+        }
+
+        self.tables.keys().collect::<BTreeSet<&String>>()
     }
 
     /// Returns the distinct set of tag keys (column names) matching the

--- a/read_buffer/src/column.rs
+++ b/read_buffer/src/column.rs
@@ -21,7 +21,7 @@ use either::Either;
 // compression is worth the memory and compute costs to work on it.
 pub const TEMP_CARDINALITY_DICTIONARY_ENCODING_LIMIT: usize = 100_000;
 
-/// Stringified names for different column types.
+/// Stringified names for different column
 pub const TAG_COLUMN_TYPE: &str = "tag";
 pub const FIELD_COLUMN_TYPE: &str = "field";
 pub const TIME_COLUMN_TYPE: &str = "timestamp";
@@ -814,14 +814,7 @@ impl StringEncoding {
         }
     }
 
-    fn from_arrow_string_array(arr: arrow::array::StringArray) -> Self {
-        //
-        // TODO(edd): potentially switch on things like cardinality in the input
-        // and encode in different ways. Right now we only encode with RLE.
-        //
-
-        // RLE creation.
-
+    fn from_arrow_string_array(arr: &arrow::array::StringArray) -> Self {
         // build a sorted dictionary.
         let mut dictionary = BTreeSet::new();
 
@@ -1058,8 +1051,9 @@ pub enum IntegerEncoding {
 
     // TODO - add all the other possible integer combinations.
 
-    // Nullable encodings - TODO
+    // Nullable encodings - TODO, add variants for smaller physical types.
     I64I64N(fixed_null::FixedNull<arrow::datatypes::Int64Type>),
+    U64U64N(fixed_null::FixedNull<arrow::datatypes::UInt64Type>),
 }
 
 impl IntegerEncoding {
@@ -1096,6 +1090,10 @@ impl IntegerEncoding {
                 Some(v) => Value::Scalar(Scalar::I64(v)),
                 None => Value::Null,
             },
+            Self::U64U64N(c) => match c.value(row_id) {
+                Some(v) => Value::Scalar(Scalar::U64(v)),
+                None => Value::Null,
+            },
         }
     }
 
@@ -1121,6 +1119,7 @@ impl IntegerEncoding {
             Self::U64U8(c) => Values::U64(c.values::<u64>(row_ids, vec![])),
 
             Self::I64I64N(c) => Values::I64N(c.values(row_ids, vec![])),
+            Self::U64U64N(c) => Values::U64N(c.values(row_ids, vec![])),
         }
     }
 
@@ -1146,6 +1145,7 @@ impl IntegerEncoding {
             Self::U64U8(c) => Values::U64(c.all_values::<u64>(vec![])),
 
             Self::I64I64N(c) => Values::I64N(c.all_values(vec![])),
+            Self::U64U64N(c) => Values::U64N(c.all_values(vec![])),
         }
     }
 
@@ -1212,6 +1212,7 @@ impl IntegerEncoding {
             Self::U64U8(c) => c.row_ids_filter(value.as_u8(), op, dst),
 
             Self::I64I64N(c) => c.row_ids_filter(value.as_i64(), op, dst),
+            Self::U64U64N(c) => c.row_ids_filter(value.as_u64(), op, dst),
         }
     }
 
@@ -1263,6 +1264,7 @@ impl IntegerEncoding {
             }
 
             Self::I64I64N(c) => todo!(),
+            Self::U64U64N(c) => todo!(),
         }
     }
 
@@ -1281,6 +1283,10 @@ impl IntegerEncoding {
             IntegerEncoding::U64U8(c) => Value::Scalar(Scalar::U64(c.min(row_ids))),
             IntegerEncoding::I64I64N(c) => match c.min(row_ids) {
                 Some(v) => Value::Scalar(Scalar::I64(v)),
+                None => Value::Null,
+            },
+            IntegerEncoding::U64U64N(c) => match c.min(row_ids) {
+                Some(v) => Value::Scalar(Scalar::U64(v)),
                 None => Value::Null,
             },
         }
@@ -1303,6 +1309,10 @@ impl IntegerEncoding {
                 Some(v) => Value::Scalar(Scalar::I64(v)),
                 None => Value::Null,
             },
+            IntegerEncoding::U64U64N(c) => match c.max(row_ids) {
+                Some(v) => Value::Scalar(Scalar::U64(v)),
+                None => Value::Null,
+            },
         }
     }
 
@@ -1323,6 +1333,10 @@ impl IntegerEncoding {
                 Some(v) => Scalar::I64(v),
                 None => Scalar::Null,
             },
+            IntegerEncoding::U64U64N(c) => match c.sum(row_ids) {
+                Some(v) => Scalar::U64(v),
+                None => Scalar::Null,
+            },
         }
     }
 
@@ -1340,12 +1354,14 @@ impl IntegerEncoding {
             IntegerEncoding::U64U16(c) => c.count(row_ids),
             IntegerEncoding::U64U8(c) => c.count(row_ids),
             IntegerEncoding::I64I64N(c) => c.count(row_ids),
+            IntegerEncoding::U64U64N(c) => c.count(row_ids),
         }
     }
 }
 
 pub enum FloatEncoding {
-    Fixed64(fixed::Fixed<f64>), // TODO(edd): encodings for nullable columns
+    Fixed64(fixed::Fixed<f64>),
+    FixedNull64(fixed_null::FixedNull<arrow::datatypes::Float64Type>),
 }
 
 impl FloatEncoding {
@@ -1360,6 +1376,10 @@ impl FloatEncoding {
     pub fn value(&self, row_id: u32) -> Value<'_> {
         match &self {
             Self::Fixed64(c) => Value::Scalar(Scalar::F64(c.value(row_id))),
+            Self::FixedNull64(c) => match c.value(row_id) {
+                Some(v) => Value::Scalar(Scalar::F64(v)),
+                None => Value::Null,
+            },
         }
     }
 
@@ -1369,6 +1389,7 @@ impl FloatEncoding {
     pub fn values(&self, row_ids: &[u32]) -> Values<'_> {
         match &self {
             Self::Fixed64(c) => Values::F64(c.values::<f64>(row_ids, vec![])),
+            Self::FixedNull64(c) => Values::F64N(c.values(row_ids, vec![])),
         }
     }
 
@@ -1378,6 +1399,7 @@ impl FloatEncoding {
     pub fn all_values(&self) -> Values<'_> {
         match &self {
             Self::Fixed64(c) => Values::F64(c.all_values::<f64>(vec![])),
+            Self::FixedNull64(c) => Values::F64N(c.all_values(vec![])),
         }
     }
 
@@ -1388,7 +1410,8 @@ impl FloatEncoding {
     /// `row_ids_filter` will panic if this invariant is broken.
     pub fn row_ids_filter(&self, op: &cmp::Operator, value: &Scalar, dst: RowIDs) -> RowIDs {
         match &self {
-            FloatEncoding::Fixed64(c) => c.row_ids_filter(value.as_f64(), op, dst),
+            Self::Fixed64(c) => c.row_ids_filter(value.as_f64(), op, dst),
+            Self::FixedNull64(c) => c.row_ids_filter(value.as_f64(), op, dst),
         }
     }
 
@@ -1407,30 +1430,44 @@ impl FloatEncoding {
             FloatEncoding::Fixed64(c) => {
                 c.row_ids_filter_range((low.1.as_f64(), &low.0), (high.1.as_f64(), &high.0), dst)
             }
+            FloatEncoding::FixedNull64(c) => todo!(),
         }
     }
 
     pub fn min(&self, row_ids: &[u32]) -> Value<'_> {
         match &self {
             FloatEncoding::Fixed64(c) => Value::Scalar(Scalar::F64(c.min(row_ids))),
+            FloatEncoding::FixedNull64(c) => match c.min(row_ids) {
+                Some(v) => Value::Scalar(Scalar::F64(v)),
+                None => Value::Null,
+            },
         }
     }
 
     pub fn max(&self, row_ids: &[u32]) -> Value<'_> {
         match &self {
             FloatEncoding::Fixed64(c) => Value::Scalar(Scalar::F64(c.max(row_ids))),
+            FloatEncoding::FixedNull64(c) => match c.max(row_ids) {
+                Some(v) => Value::Scalar(Scalar::F64(v)),
+                None => Value::Null,
+            },
         }
     }
 
     pub fn sum(&self, row_ids: &[u32]) -> Scalar {
         match &self {
             FloatEncoding::Fixed64(c) => Scalar::F64(c.sum(row_ids)),
+            FloatEncoding::FixedNull64(c) => match c.sum(row_ids) {
+                Some(v) => Scalar::F64(v),
+                None => Scalar::Null,
+            },
         }
     }
 
     pub fn count(&self, row_ids: &[u32]) -> u32 {
         match &self {
             FloatEncoding::Fixed64(c) => c.count(row_ids),
+            FloatEncoding::FixedNull64(c) => c.count(row_ids),
         }
     }
 }
@@ -1444,6 +1481,13 @@ impl FloatEncoding {
 // ideally it's a "write once read many" scenario.
 impl From<arrow::array::StringArray> for Column {
     fn from(arr: arrow::array::StringArray) -> Self {
+        let data = StringEncoding::from_arrow_string_array(&arr);
+        Column::String(StringEncoding::meta_from_data(&data), data)
+    }
+}
+
+impl From<&arrow::array::StringArray> for Column {
+    fn from(arr: &arrow::array::StringArray) -> Self {
         let data = StringEncoding::from_arrow_string_array(arr);
         Column::String(StringEncoding::meta_from_data(&data), data)
     }
@@ -1530,6 +1574,71 @@ impl From<&[u64]> for Column {
                 Column::Unsigned(meta, IntegerEncoding::U64U64(data))
             }
         }
+    }
+}
+
+impl From<arrow::array::UInt64Array> for Column {
+    fn from(arr: arrow::array::UInt64Array) -> Self {
+        if arr.null_count() == 0 {
+            return Self::from(arr.values());
+        }
+
+        // determine min and max values.
+        let mut min: Option<u64> = None;
+        let mut max: Option<u64> = None;
+
+        for i in 0..arr.len() {
+            if arr.is_null(i) {
+                continue;
+            }
+
+            let v = arr.value(i);
+            match min {
+                Some(m) => {
+                    if v < m {
+                        min = Some(v);
+                    }
+                }
+                None => min = Some(v),
+            };
+
+            match max {
+                Some(m) => {
+                    if v > m {
+                        max = Some(v)
+                    }
+                }
+                None => max = Some(v),
+            };
+        }
+
+        let range = match (min, max) {
+            (None, None) => None,
+            (Some(min), Some(max)) => Some((min, max)),
+            _ => unreachable!("min/max must both be Some or None"),
+        };
+
+        let data = fixed_null::FixedNull::<arrow::datatypes::UInt64Type>::from(arr);
+        let meta = MetaData {
+            size: data.size(),
+            rows: data.num_rows(),
+            range,
+            ..MetaData::default()
+        };
+
+        // TODO(edd): currently fixed null only supports 64-bit logical/physical
+        // types. Need to add support for storing as smaller physical types.
+        Column::Unsigned(meta, IntegerEncoding::U64U64N(data))
+    }
+}
+
+impl From<&arrow::array::UInt64Array> for Column {
+    fn from(arr: &arrow::array::UInt64Array) -> Self {
+        if arr.null_count() == 0 {
+            return Self::from(arr.values());
+        }
+
+        todo!("figure out how to run off of a borrowed arrow array");
     }
 }
 
@@ -1753,6 +1862,71 @@ impl From<&[i64]> for Column {
     }
 }
 
+impl From<arrow::array::Int64Array> for Column {
+    fn from(arr: arrow::array::Int64Array) -> Self {
+        if arr.null_count() == 0 {
+            return Self::from(arr.values());
+        }
+
+        // determine min and max values.
+        let mut min: Option<i64> = None;
+        let mut max: Option<i64> = None;
+
+        for i in 0..arr.len() {
+            if arr.is_null(i) {
+                continue;
+            }
+
+            let v = arr.value(i);
+            match min {
+                Some(m) => {
+                    if v < m {
+                        min = Some(v);
+                    }
+                }
+                None => min = Some(v),
+            };
+
+            match max {
+                Some(m) => {
+                    if v > m {
+                        max = Some(v)
+                    }
+                }
+                None => max = Some(v),
+            };
+        }
+
+        let range = match (min, max) {
+            (None, None) => None,
+            (Some(min), Some(max)) => Some((min, max)),
+            _ => unreachable!("min/max must both be Some or None"),
+        };
+
+        let data = fixed_null::FixedNull::<arrow::datatypes::Int64Type>::from(arr);
+        let meta = MetaData {
+            size: data.size(),
+            rows: data.num_rows(),
+            range,
+            ..MetaData::default()
+        };
+
+        // TODO(edd): currently fixed null only supports 64-bit logical/physical
+        // types. Need to add support for storing as smaller physical types.
+        Column::Integer(meta, IntegerEncoding::I64I64N(data))
+    }
+}
+
+impl From<&arrow::array::Int64Array> for Column {
+    fn from(arr: &arrow::array::Int64Array) -> Self {
+        if arr.null_count() == 0 {
+            return Self::from(arr.values());
+        }
+
+        todo!("figure out how to run off of a borrowed arrow array");
+    }
+}
+
 /// Converts a slice of i32 values into the most compact fixed-width physical
 /// encoding. Whilst `i32` isn't a supported logical type it is still possible
 /// to store these values as logically `i64` values with `i32`, `i16`, `u16`,
@@ -1907,11 +2081,38 @@ impl From<&[i8]> for Column {
     }
 }
 
-impl From<arrow::array::Int64Array> for Column {
-    fn from(arr: arrow::array::Int64Array) -> Self {
+/// Converts a slice of `f64` values into a fixed-width column encoding.
+impl From<&[f64]> for Column {
+    fn from(arr: &[f64]) -> Self {
         // determine min and max values.
-        let mut min: Option<i64> = None;
-        let mut max: Option<i64> = None;
+        let mut min = arr[0];
+        let mut max = arr[0];
+        for &v in arr.iter().skip(1) {
+            min = min.min(v);
+            max = max.max(v);
+        }
+
+        let data = fixed::Fixed::<f64>::from(arr);
+        let meta = MetaData {
+            size: data.size(),
+            rows: data.num_rows(),
+            range: Some((min, max)),
+            ..MetaData::default()
+        };
+
+        Column::Float(meta, FloatEncoding::Fixed64(data))
+    }
+}
+
+impl From<arrow::array::Float64Array> for Column {
+    fn from(arr: arrow::array::Float64Array) -> Self {
+        if arr.null_count() == 0 {
+            return Self::from(arr.values());
+        }
+
+        // determine min and max values.
+        let mut min: Option<f64> = None;
+        let mut max: Option<f64> = None;
 
         for i in 0..arr.len() {
             if arr.is_null(i) {
@@ -1944,37 +2145,27 @@ impl From<arrow::array::Int64Array> for Column {
             _ => unreachable!("min/max must both be Some or None"),
         };
 
-        let data = fixed_null::FixedNull::<arrow::datatypes::Int64Type>::from(arr);
+        let data = fixed_null::FixedNull::<arrow::datatypes::Float64Type>::from(arr);
         let meta = MetaData {
             size: data.size(),
             rows: data.num_rows(),
             range,
             ..MetaData::default()
         };
-        Column::Integer(meta, IntegerEncoding::I64I64N(data))
+
+        // TODO(edd): currently fixed null only supports 64-bit logical/physical
+        // types. Need to add support for storing as smaller physical types.
+        Column::Float(meta, FloatEncoding::FixedNull64(data))
     }
 }
 
-/// Converts a slice of `f64` values into a fixed-width column encoding.
-impl From<&[f64]> for Column {
-    fn from(arr: &[f64]) -> Self {
-        // determine min and max values.
-        let mut min = arr[0];
-        let mut max = arr[0];
-        for &v in arr.iter().skip(1) {
-            min = min.min(v);
-            max = max.max(v);
+impl From<&arrow::array::Float64Array> for Column {
+    fn from(arr: &arrow::array::Float64Array) -> Self {
+        if arr.null_count() == 0 {
+            return Self::from(arr.values());
         }
 
-        let data = fixed::Fixed::<f64>::from(arr);
-        let meta = MetaData {
-            size: data.size(),
-            rows: data.num_rows(),
-            range: Some((min, max)),
-            ..MetaData::default()
-        };
-
-        Column::Float(meta, FloatEncoding::Fixed64(data))
+        todo!("figure out how to run off of a borrowed arrow array");
     }
 }
 

--- a/read_buffer/src/column.rs
+++ b/read_buffer/src/column.rs
@@ -20,6 +20,12 @@ use either::Either;
 // it's how many run-lengths would be produced in an RLE column and whether that
 // compression is worth the memory and compute costs to work on it.
 pub const TEMP_CARDINALITY_DICTIONARY_ENCODING_LIMIT: usize = 100_000;
+
+/// Stringified names for different column types.
+pub const TAG_COLUMN_TYPE: &str = "tag";
+pub const FIELD_COLUMN_TYPE: &str = "field";
+pub const TIME_COLUMN_TYPE: &str = "timestamp";
+
 /// The possible logical types that column values can have. All values in a
 /// column have the same physical type.
 pub enum Column {

--- a/read_buffer/src/column/fixed_null.rs
+++ b/read_buffer/src/column/fixed_null.rs
@@ -568,6 +568,9 @@ macro_rules! fixed_from_arrow_impls {
 // Need to look at possibility of initialising smaller datatypes...
 fixed_from_arrow_impls! {
     (arrow::array::Int64Array, arrow_deps::arrow::datatypes::Int64Type),
+    (arrow::array::UInt64Array, arrow_deps::arrow::datatypes::UInt64Type),
+    (arrow::array::Float64Array, arrow_deps::arrow::datatypes::Float64Type),
+
     // TODO(edd): add more datatypes
 }
 

--- a/read_buffer/src/lib.rs
+++ b/read_buffer/src/lib.rs
@@ -13,6 +13,7 @@ use arrow_deps::arrow::record_batch::RecordBatch;
 
 use chunk::Chunk;
 use column::AggregateType;
+pub use column::{FIELD_COLUMN_TYPE, TAG_COLUMN_TYPE, TIME_COLUMN_TYPE};
 use row_group::{ColumnName, Predicate};
 
 /// Generate a predicate for the time range [from, to).
@@ -41,8 +42,8 @@ pub fn time_range_predicate<'a>(from: i64, to: i64) -> Vec<row_group::Predicate<
 #[derive(Default)]
 pub struct Database {
     // The collection of chunks in the database. Each chunk is uniquely
-    // identified by a chunk key.
-    chunks: BTreeMap<String, Chunk>,
+    // identified by a chunk id.
+    chunks: BTreeMap<u32, Chunk>,
 
     // The current total size of the database.
     size: u64,
@@ -64,11 +65,11 @@ impl Database {
         Self::default()
     }
 
-    pub fn add_chunk(&mut self, chunk: Chunk) {
+    pub fn add_chunk(&mut self, chunk_id: u32, chunk_data: BTreeMap<String, RecordBatch>) {
         todo!()
     }
 
-    pub fn remove_chunk(&mut self, chunk: Chunk) {
+    pub fn remove_chunk(&mut self, chunk_id: u32) {
         todo!()
     }
 

--- a/read_buffer/src/table.rs
+++ b/read_buffer/src/table.rs
@@ -643,7 +643,7 @@ mod test {
         let fc = ColumnType::Field(Column::from(&[1000_u64, 1002, 1200][..]));
         columns.insert("count".to_string(), fc);
         let segment = RowGroup::new(3, columns);
-        table.add_segment(segment);
+        table.add_row_group(segment);
 
         // Get all the results
         let results = table.select(

--- a/read_buffer/src/table.rs
+++ b/read_buffer/src/table.rs
@@ -76,12 +76,12 @@ impl Table {
 
     /// The total size of the table in bytes.
     pub fn size(&self) -> u64 {
-        todo!()
+        self.meta.size
     }
 
     /// The number of rows in this table.
     pub fn rows(&self) -> u64 {
-        todo!()
+        self.meta.rows
     }
 
     /// The time range of all row groups within this table.

--- a/read_buffer/src/table.rs
+++ b/read_buffer/src/table.rs
@@ -32,7 +32,6 @@ pub struct Table {
     // Metadata about the table's segments
     meta: MetaData,
 
-    // schema // TODO(edd): schema type
     segments: Vec<RowGroup>,
 }
 


### PR DESCRIPTION
This PR adds a mechanism for writing individual row groups to the `ReadBuffer`. Using this API a caller can add entire chunks from, e.g., the `MutableBuffer` in a way that breaks down the potentially large amount of materialisation that would happen if all tables had to be materialised to record batches.

It also implements the `table_names` method end-to-end, meaning `table_names` is now exposed outside of the `ReadBuffer`.

The general idea is that the `ReadBuffer` store will accept new chunks, and these chunks should be submitted by providing:

 - a `u32` chunk id;
 - A table name;
 - Table data for the table.

Table data should be represented by an Arrow `RecordBatch`. The API allows a caller (the `MutableBuffer` for example) to add individual `RowGroups` to tables and chunks. A `RowGroup` in the `ReadBuffer` is simply a horizontal partition of a table with its own set of meta data about its columns.

This API allows the caller to faux-stream through large tables splitting them into record batches with identical schemas, which will then be compressed in turn and stored as separate `RowGroups` on the `Table`.

The `ReadBuffer` can do pruning and predicate pushdown at the `Chunk`, `Table`, `RowGroup` and `Column` levels.

The record batch is converted into a table quite high up in the read buffer, and then all of the structures below (table, row group etc) have their appropriate meta data updated as new tables are added.

Currently the RecordBatch needs to have the correct metadata associated with it for it to be accepted by the `ReadBuffer`. The logic to decorate record batches with the correct meta data needs to be encapsulated in a crate, maybe the `arrow_deps` or similar?