### PR TITLE
feat: add create and get database to API

### DIFF
--- a/data_types/src/database_rules.rs
+++ b/data_types/src/database_rules.rs
@@ -21,10 +21,12 @@ pub type Result<T, E = Error> = std::result::Result<T, E>;
 pub struct DatabaseRules {
     /// Template that generates a partition key for each row inserted into the
     /// db
+    #[serde(default)]
     pub partition_template: PartitionTemplate,
     /// If `store_locally` is set to `true`, this server will store writes and
     /// replicated writes in a local write buffer database. This is step #4
     /// from the diagram.
+    #[serde(default)]
     pub store_locally: bool,
     /// The set of host groups that data should be replicated to. Which host a
     /// write goes to within a host group is determined by consistent hashing of
@@ -36,16 +38,19 @@ pub struct DatabaseRules {
     /// before returning success. Its purpose is to ensure write durability,
     /// rather than write availability for query (this is covered by
     /// subscriptions).
+    #[serde(default)]
     pub replication: Vec<HostGroupId>,
     /// The minimum number of host groups to replicate a write to before success
     /// is returned. This can be overridden on a per request basis.
     /// Replication will continue to write to the other host groups in the
     /// background.
+    #[serde(default)]
     pub replication_count: u8,
     /// How long the replication queue can get before either rejecting writes or
     /// dropping missed writes. The queue is kept in memory on a
     /// per-database basis. A queue size of zero means it will only try to
     /// replicate synchronously and drop any failures.
+    #[serde(default)]
     pub replication_queue_max_size: usize,
     /// `subscriptions` are used for query servers to get data via either push
     /// or pull as it arrives. They are separate from replication as they
@@ -53,12 +58,14 @@ pub struct DatabaseRules {
     /// that want to subscribe to some subset of data being written in. This
     /// could either be specific partitions, ranges of partitions, tables, or
     /// rows matching some predicate. This is step #3 from the diagram.
+    #[serde(default)]
     pub subscriptions: Vec<Subscription>,
 
     /// If set to `true`, this server should answer queries from one or more of
     /// of its local write buffer and any read-only partitions that it knows
     /// about. In this case, results will be merged with any others from the
     /// remote goups or read only partitions.
+    #[serde(default)]
     pub query_local: bool,
     /// Set `primary_query_group` to a host group if remote servers should be
     /// issued queries for this database. All hosts in the group should be
@@ -71,7 +78,9 @@ pub struct DatabaseRules {
     /// partition. We'd set the primary group to be the 4 hosts in the same
     /// AZ as this one, and the secondary groups as the hosts in the other 2
     /// AZs.
+    #[serde(default)]
     pub primary_query_group: Option<HostGroupId>,
+    #[serde(default)]
     pub secondary_query_groups: Vec<HostGroupId>,
 
     /// Use `read_only_partitions` when a server should answer queries for
@@ -80,10 +89,12 @@ pub struct DatabaseRules {
     /// collection of partitions and then telling it to also pull
     /// data from the replication servers (writes that haven't been snapshotted
     /// into a partition).
+    #[serde(default)]
     pub read_only_partitions: Vec<PartitionId>,
 
     /// When set this will buffer WAL writes in memory based on the
     /// configuration.
+    #[serde(default)]
     pub wal_buffer_config: Option<WalBufferConfig>,
 }
 

--- a/data_types/src/database_rules.rs
+++ b/data_types/src/database_rules.rs
@@ -17,7 +17,7 @@ pub type Result<T, E = Error> = std::result::Result<T, E>;
 
 /// DatabaseRules contains the rules for replicating data, sending data to
 /// subscribers, and querying data for a single database.
-#[derive(Debug, Serialize, Deserialize, Default, Eq, PartialEq)]
+#[derive(Debug, Serialize, Deserialize, Default, Eq, PartialEq, Clone)]
 pub struct DatabaseRules {
     /// Template that generates a partition key for each row inserted into the
     /// db
@@ -100,7 +100,7 @@ impl DatabaseRules {
 /// WalBufferConfig defines the configuration for buffering data from the WAL in
 /// memory. This buffer is used for asynchronous replication and to collect
 /// segments before sending them to object storage.
-#[derive(Debug, Serialize, Deserialize, Eq, PartialEq)]
+#[derive(Debug, Serialize, Deserialize, Eq, PartialEq, Clone)]
 pub struct WalBufferConfig {
     /// The size the WAL buffer should be limited to. Once the buffer gets to
     /// this size it will drop old segments to remain below this size, but
@@ -145,7 +145,7 @@ pub enum WalBufferRollover {
 ///
 /// The key is constructed in order of the template parts; thus ordering changes
 /// what partition key is generated.
-#[derive(Debug, Serialize, Deserialize, Default, Eq, PartialEq)]
+#[derive(Debug, Serialize, Deserialize, Default, Eq, PartialEq, Clone)]
 pub struct PartitionTemplate {
     pub parts: Vec<TemplatePart>,
 }
@@ -182,7 +182,7 @@ impl PartitionTemplate {
 
 /// `TemplatePart` specifies what part of a row should be used to compute this
 /// part of a partition key.
-#[derive(Debug, Serialize, Deserialize, Eq, PartialEq)]
+#[derive(Debug, Serialize, Deserialize, Eq, PartialEq, Clone)]
 pub enum TemplatePart {
     Table,
     Column(String),
@@ -193,7 +193,7 @@ pub enum TemplatePart {
 
 /// `RegexCapture` is for pulling parts of a string column into the partition
 /// key.
-#[derive(Debug, Serialize, Deserialize, Eq, PartialEq)]
+#[derive(Debug, Serialize, Deserialize, Eq, PartialEq, Clone)]
 pub struct RegexCapture {
     column: String,
     regex: String,
@@ -201,7 +201,7 @@ pub struct RegexCapture {
 
 /// `StrftimeColumn` can be used to create a time based partition key off some
 /// column other than the builtin `time` column.
-#[derive(Debug, Serialize, Deserialize, Eq, PartialEq)]
+#[derive(Debug, Serialize, Deserialize, Eq, PartialEq, Clone)]
 pub struct StrftimeColumn {
     column: String,
     format: String,
@@ -223,7 +223,7 @@ pub type WriterId = u32;
 ///
 /// For pull based subscriptions, the requester will send a matcher, which the
 /// receiver will execute against its in-memory WAL.
-#[derive(Debug, Serialize, Deserialize, Eq, PartialEq)]
+#[derive(Debug, Serialize, Deserialize, Eq, PartialEq, Clone)]
 pub struct Subscription {
     pub name: String,
     pub host_group_id: HostGroupId,
@@ -232,7 +232,7 @@ pub struct Subscription {
 
 /// `Matcher` specifies the rule against the table name and/or a predicate
 /// against the row to determine if it matches the write rule.
-#[derive(Debug, Serialize, Deserialize, Eq, PartialEq)]
+#[derive(Debug, Serialize, Deserialize, Eq, PartialEq, Clone)]
 pub struct Matcher {
     #[serde(flatten)]
     pub tables: MatchTables,
@@ -243,7 +243,7 @@ pub struct Matcher {
 
 /// `MatchTables` looks at the table name of a row to determine if it should
 /// match the rule.
-#[derive(Debug, Serialize, Deserialize, Eq, PartialEq)]
+#[derive(Debug, Serialize, Deserialize, Eq, PartialEq, Clone)]
 #[serde(rename_all = "camelCase")]
 pub enum MatchTables {
     #[serde(rename = "*")]
@@ -254,7 +254,7 @@ pub enum MatchTables {
 
 pub type HostGroupId = String;
 
-#[derive(Debug, Serialize, Deserialize, Eq, PartialEq)]
+#[derive(Debug, Serialize, Deserialize, Eq, PartialEq, Clone)]
 pub struct HostGroup {
     pub id: HostGroupId,
     /// `hosts` is a vector of connection strings for remote hosts.

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -321,6 +321,11 @@ impl<M: ConnectionManager> Server<M> {
         let config = self.config.read().await;
         config.databases.get(&name).cloned()
     }
+
+    pub async fn db_rules(&self, name: &DatabaseName<'_>) -> Option<DatabaseRules> {
+        let config = self.config.read().await;
+        config.databases.get(&name).map(|d| d.rules.clone())
+    }
 }
 
 #[async_trait]

--- a/src/server/http_routes.rs
+++ b/src/server/http_routes.rs
@@ -13,7 +13,10 @@ use super::{org_and_bucket_to_database, OrgBucketMappingError};
 
 // Influx crates
 use arrow_deps::arrow;
-use data_types::database_rules::DatabaseRules;
+use data_types::{
+    DatabaseName,
+    database_rules::DatabaseRules
+};
 use influxdb_line_protocol::parse_lines;
 use object_store::path::ObjectStorePath;
 use query::SQLDatabase;
@@ -91,11 +94,8 @@ pub enum ApplicationError {
         source: Box<dyn std::error::Error + Send + Sync>,
     },
 
-    #[snafu(display("Invalid request body '{}': {}", request_body, source))]
-    InvalidRequestBody {
-        request_body: String,
-        source: serde_json::error::Error,
-    },
+    #[snafu(display("Invalid request body: {}", source))]
+    InvalidRequestBody { source: serde_json::error::Error },
 
     #[snafu(display("Invalid content encoding: {}", content_encoding))]
     InvalidContentEncoding { content_encoding: String },
@@ -131,6 +131,17 @@ pub enum ApplicationError {
 
     #[snafu(display("Error generating json response: {}", source))]
     JsonGenerationError { source: serde_json::Error },
+
+    #[snafu(display("Error creating database: {}", source))]
+    ErrorCreatingDatabase { source: server::server::Error },
+
+    #[snafu(display("Invalid database name: {}", source))]
+    DatabaseNameError {
+        source: data_types::DatabaseNameError,
+    },
+
+    #[snafu(display("Database {} not found", name))]
+    DatabaseNotFound { name: String },
 }
 
 impl ApplicationError {
@@ -155,6 +166,9 @@ impl ApplicationError {
             Self::RouteNotFound { .. } => self.not_found(),
             Self::DatabaseError { .. } => self.internal_error(),
             Self::JsonGenerationError { .. } => self.internal_error(),
+            Self::ErrorCreatingDatabase { .. } => self.bad_request(),
+            Self::DatabaseNameError { .. } => self.bad_request(),
+            Self::DatabaseNotFound { .. } => self.not_found(),
         })
     }
 
@@ -205,6 +219,8 @@ where
         .post("/api/v2/write", write_handler::<M>)
         .get("/ping", ping)
         .get("/api/v2/read", read_handler::<M>)
+        .put("/iox/api/v1/databases/:name", create_database_handler::<M>)
+        .get("/iox/api/v1/databases/:name", get_database_handler::<M>)
         .get("/api/v1/partitions", list_partitions_handler::<M>)
         .post("/api/v1/snapshot", snapshot_partition_handler::<M>)
         // Specify the error handler to handle any errors caused by
@@ -337,23 +353,6 @@ where
         write_info.bucket
     );
 
-    // TODO: remove this once the API is in to create a database
-    if server.db(&db_name).await.is_none() {
-        let rules = DatabaseRules {
-            store_locally: true,
-            ..Default::default()
-        };
-
-        server
-            .create_database(db_name.to_string(), rules)
-            .await
-            .map_err(|e| Box::new(e) as _)
-            .context(WritingPoints {
-                org: write_info.org.clone(),
-                bucket_name: write_info.bucket.clone(),
-            })?;
-    }
-
     server
         .write_lines(&db_name, &lines)
         .await
@@ -426,6 +425,91 @@ async fn read<M: ConnectionManager + Send + Sync + Debug + 'static>(
     let results = arrow::util::pretty::pretty_format_batches(&results).unwrap();
 
     Ok(Response::new(Body::from(results.into_bytes())))
+}
+
+#[tracing::instrument(level = "debug")]
+async fn create_database_handler<M>(req: Request<Body>) -> Result<Response<Body>, ApplicationError>
+where
+    M: ConnectionManager + Send + Sync + Debug + 'static,
+{
+    match create_database::<M>(req).await {
+        Err(e) => {
+            error!(error = ?e, error_message = ?e.to_string(), "Error while handling request");
+
+            e.response()
+        }
+        res => res,
+    }
+}
+
+#[tracing::instrument(level = "debug")]
+async fn create_database<M: ConnectionManager + Send + Sync + Debug + 'static>(
+    req: Request<Body>,
+) -> Result<Response<Body>, ApplicationError> {
+    let server = req
+        .data::<Arc<AppServer<M>>>()
+        .expect("server state")
+        .clone();
+
+    // with routerify, we shouldn't have gotten here without this being set
+    let db_name = req
+        .param("name")
+        .expect("db name must have been set")
+        .clone();
+    let body = parse_body(req).await?;
+
+    let rules: DatabaseRules = serde_json::from_slice(body.as_ref()).context(InvalidRequestBody)?;
+    server
+        .create_database(db_name, rules)
+        .await
+        .context(ErrorCreatingDatabase)?;
+
+    Ok(Response::new(Body::empty()))
+}
+
+#[tracing::instrument(level = "debug")]
+async fn get_database_handler<M>(req: Request<Body>) -> Result<Response<Body>, ApplicationError>
+where
+    M: ConnectionManager + Send + Sync + Debug + 'static,
+{
+    match get_database::<M>(req).await {
+        Err(e) => {
+            error!(error = ?e, error_message = ?e.to_string(), "Error while handling request");
+
+            e.response()
+        }
+        res => res,
+    }
+}
+
+#[tracing::instrument(level = "debug")]
+async fn get_database<M: ConnectionManager + Send + Sync + Debug + 'static>(
+    req: Request<Body>,
+) -> Result<Response<Body>, ApplicationError> {
+    let server = req
+        .data::<Arc<AppServer<M>>>()
+        .expect("server state")
+        .clone();
+
+    // with routerify, we shouldn't have gotten here without this being set
+    let db_name_str = req
+        .param("name")
+        .expect("db name must have been set")
+        .clone();
+    let db_name = DatabaseName::new(&db_name_str).context(DatabaseNameError)?;
+    let db = server
+        .db_rules(&db_name)
+        .await
+        .context(DatabaseNotFound { name: &db_name_str })?;
+
+    let data = serde_json::to_string(&db).context(JsonGenerationError)?;
+    let response = Response::builder()
+        .header("Content-Type", "application/json")
+        .status(StatusCode::OK)
+        .body(Body::from(data))
+        .expect("builder should be successful");
+
+    Ok(response)
 }
 
 // Route to test that the server is alive
@@ -731,6 +815,69 @@ mod tests {
         assert_eq!(results, expected);
 
         Ok(())
+    }
+
+    #[tokio::test]
+    async fn create_database() {
+        let server = Arc::new(AppServer::new(
+            ConnectionManagerImpl {},
+            Arc::new(ObjectStore::new_in_memory(InMemory::new())),
+        ));
+        server.set_id(1).await;
+        let server_url = test_server(server.clone());
+
+        let rules = DatabaseRules {
+            store_locally: true,
+            ..Default::default()
+        };
+        let data = serde_json::to_vec(&rules).unwrap();
+
+        let database_name = DatabaseName::new("foo_bar").unwrap();
+
+        let client = Client::new();
+        let response = client
+            .put(&format!(
+                "{}/iox/api/v1/databases/{}",
+                server_url, database_name
+            ))
+            .body(data)
+            .send()
+            .await;
+
+        check_response("create_database", response, StatusCode::OK, "").await;
+
+        let db = server.db(&database_name).await.unwrap();
+        assert_eq!(db.name, database_name.to_string());
+    }
+
+    #[tokio::test]
+    async fn get_database() {
+        let server = Arc::new(AppServer::new(
+            ConnectionManagerImpl {},
+            Arc::new(ObjectStore::new_in_memory(InMemory::new())),
+        ));
+        server.set_id(1).await;
+        let server_url = test_server(server.clone());
+
+        let rules = DatabaseRules {
+            store_locally: true,
+            ..Default::default()
+        };
+        let data = serde_json::to_string(&rules).unwrap();
+
+        let database_name = "foo_bar";
+        server.create_database(database_name, rules).await.unwrap();
+
+        let client = Client::new();
+        let response = client
+            .get(&format!(
+                "{}/iox/api/v1/databases/{}",
+                server_url, database_name
+            ))
+            .send()
+            .await;
+
+        check_response("create_database", response, StatusCode::OK, &data).await;
     }
 
     /// checks a http response against expected results

--- a/src/server/http_routes.rs
+++ b/src/server/http_routes.rs
@@ -13,10 +13,7 @@ use super::{org_and_bucket_to_database, OrgBucketMappingError};
 
 // Influx crates
 use arrow_deps::arrow;
-use data_types::{
-    DatabaseName,
-    database_rules::DatabaseRules
-};
+use data_types::{database_rules::DatabaseRules, DatabaseName};
 use influxdb_line_protocol::parse_lines;
 use object_store::path::ObjectStorePath;
 use query::SQLDatabase;
@@ -844,8 +841,7 @@ mod tests {
 
         check_response("create_database", response, StatusCode::OK, "").await;
 
-        let db = server.db(&database_name).await.unwrap();
-        assert_eq!(db.name, database_name.to_string());
+        server.db(&database_name).await.unwrap();
         let db_rules = server.db_rules(&database_name).await.unwrap();
         assert_eq!(db_rules.store_locally, true);
     }

--- a/tests/end-to-end.rs
+++ b/tests/end-to-end.rs
@@ -18,6 +18,7 @@
 // - Stopping the server after all relevant tests are run
 
 use assert_cmd::prelude::*;
+use data_types::database_rules::DatabaseRules;
 use futures::prelude::*;
 use generated_types::{
     aggregate::AggregateType,
@@ -98,6 +99,24 @@ async fn read_and_write_data() -> Result<()> {
 
     let client = reqwest::Client::new();
     let client2 = influxdb2_client::Client::new(HTTP_BASE, TOKEN);
+
+    let rules = DatabaseRules {
+        store_locally: true,
+        ..Default::default()
+    };
+    let data = serde_json::to_vec(&rules).unwrap();
+
+    let database_name = format!("{}_{}", org_id_str, bucket_id_str);
+
+    client
+        .put(&format!(
+            "{}/iox/api/v1/databases/{}",
+            HTTP_BASE, &database_name
+        ))
+        .body(data)
+        .send()
+        .await
+        .unwrap();
 
     let start_time = SystemTime::now();
     let ns_since_epoch: i64 = start_time


### PR DESCRIPTION
This PR is start of the IOx specific API. It puts everything under /iox/api/v1 as this is the beginning of the IOx API. Creating a database is done with a PUT and a GET request can retrieve the DatabaseRules details.

After having implemented this, I think there may be a broader discussion to be had about how to make the creation/configuration of a database easier or more straightforward. The `DatabaseRules` struct has a ton of stuff in it. So while a user could create a JSON payload to set all those rules in one go, doing so would likely be a little painful. I'll have to give it some thought, but open to ideas.