### PR TITLE
feat: RFC API for moving data out of immutable buffer and into read buffer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2958,6 +2958,7 @@ dependencies = [
  "serde",
  "serde_json",
  "snafu",
+ "test_helpers",
  "tokio",
  "tracing",
  "uuid",

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -25,3 +25,6 @@ futures = "0.3.7"
 bytes = "0.5"
 chrono = "0.4"
 uuid = { version = "0.8", features = ["serde", "v4"]}
+
+[dev-dependencies]
+test_helpers = { path = "../test_helpers" }

--- a/server/src/db.rs
+++ b/server/src/db.rs
@@ -1,5 +1,6 @@
 //! This module contains the main IOx Database object which has the
 //! instances of the immutable buffer, read buffer, and object store
+#![allow(unused_variables)]
 
 use std::sync::{
     atomic::{AtomicU64, Ordering},
@@ -9,20 +10,18 @@ use std::sync::{
 use async_trait::async_trait;
 use data_types::{data::ReplicatedWrite, database_rules::DatabaseRules};
 use mutable_buffer::MutableBufferDb;
-use query::{Database, PartitionChunk};
+use query::Database;
 use read_buffer::Database as ReadBufferDb;
 use serde::{Deserialize, Serialize};
 use snafu::{OptionExt, ResultExt, Snafu};
 
 use crate::buffer::Buffer;
 
+mod chunk;
+use chunk::DBChunk;
+
 #[derive(Debug, Snafu)]
 pub enum Error {
-    #[snafu(display("Mutable Buffer Chunk Error: {}", source))]
-    MutableBufferChunk {
-        source: mutable_buffer::chunk::Error,
-    },
-
     #[snafu(display("Cannot write to this database: no mutable buffer configured"))]
     DatatbaseNotWriteable {},
 
@@ -68,6 +67,7 @@ pub struct Db {
     wal_buffer: Option<Buffer>,
 
     #[serde(skip)]
+    /// Next write sequence number
     sequence: AtomicU64,
 }
 impl Db {
@@ -87,7 +87,9 @@ impl Db {
         }
     }
 
-    /// Rolls over the active chunk in the database's specified partition
+    /// Rolls over the currently active, open chunk in the database's
+    /// specified partition to the closed state. Returns the chunk
+    /// which was closed.
     pub async fn rollover_partition(&self, partition_key: &str) -> Result<Arc<DBChunk>> {
         if let Some(local_store) = self.mutable_buffer.as_ref() {
             local_store
@@ -99,6 +101,46 @@ impl Db {
             DatatbaseNotWriteable {}.fail()
         }
     }
+
+    /// Return the next write sequence number
+    pub fn next_sequence(&self) -> u64 {
+        self.sequence.fetch_add(1, Ordering::SeqCst)
+    }
+
+    // List Chunks available in a partition. Note this list may have
+    // multiple chunks with the same chunk_id if the same data is in
+    // multiple places (e.g. immutable_buffer and normal buffer);
+
+    // List closed chunks in the mutable_buffer (that can potentially
+    // be migrated into the read buffer or object store)
+    pub async fn mutable_buffer_chunks(partition_key: &str) -> Vec<Arc<DBChunk>> {
+        todo!();
+    }
+
+    // List chunks which are currently present in the read buffer
+    pub async fn list_mutable_chunks(partition_key: &str) -> Vec<Arc<DBChunk>> {
+        todo!();
+    }
+
+    /// migrates a chunk to the read buffer.
+    ///
+    /// If the chunk is present in the mutable_buffer then it is
+    /// loaded from there. Otherwise, the chunk is fetched from the
+    /// object store.
+    ///
+    /// TODO: what happens if there is no more memory available in the read
+    /// buffer?
+    ///
+    /// This (async) function returns when this process is complete,
+    /// but the process may take a long time
+    pub async fn load_chunk_to_read_buffer(
+        partition_key: &str,
+        chunk_id: u64,
+    ) -> Vec<Arc<DBChunk>> {
+        todo!();
+    }
+
+    // TODO things like "migrate a chunk
 }
 
 impl PartialEq for Db {
@@ -107,64 +149,6 @@ impl PartialEq for Db {
     }
 }
 impl Eq for Db {}
-
-impl Db {
-    pub fn next_sequence(&self) -> u64 {
-        self.sequence.fetch_add(1, Ordering::SeqCst)
-    }
-}
-
-/// A IOx DatabaseChunk can come from one of three places:
-/// MutableBuffer, ReadBuffer, or a ParquetFile
-#[derive(Debug)]
-pub enum DBChunk {
-    MutableBuffer(Arc<mutable_buffer::chunk::Chunk>),
-    ReadBuffer,  // TODO add appropriate type here
-    ParquetFile, // TODO add appropriate type here
-}
-
-impl PartitionChunk for DBChunk {
-    type Error = Error;
-
-    fn key(&self) -> &str {
-        match self {
-            Self::MutableBuffer(chunk) => chunk.key(),
-            Self::ReadBuffer => unimplemented!("read buffer not implemented"),
-            Self::ParquetFile => unimplemented!("parquet file not implemented"),
-        }
-    }
-
-    fn id(&self) -> u64 {
-        match self {
-            Self::MutableBuffer(chunk) => chunk.id(),
-            Self::ReadBuffer => unimplemented!("read buffer not implemented"),
-            Self::ParquetFile => unimplemented!("parquet file not implemented"),
-        }
-    }
-
-    fn table_stats(&self) -> Result<Vec<data_types::partition_metadata::Table>, Self::Error> {
-        match self {
-            Self::MutableBuffer(chunk) => chunk.table_stats().context(MutableBufferChunk),
-            Self::ReadBuffer => unimplemented!("read buffer not implemented"),
-            Self::ParquetFile => unimplemented!("parquet file not implemented"),
-        }
-    }
-
-    fn table_to_arrow(
-        &self,
-        dst: &mut Vec<arrow_deps::arrow::record_batch::RecordBatch>,
-        table_name: &str,
-        columns: &[&str],
-    ) -> Result<(), Self::Error> {
-        match self {
-            Self::MutableBuffer(chunk) => chunk
-                .table_to_arrow(dst, table_name, columns)
-                .context(MutableBufferChunk),
-            Self::ReadBuffer => unimplemented!("read buffer not implemented"),
-            Self::ParquetFile => unimplemented!("parquet file not implemented"),
-        }
-    }
-}
 
 #[async_trait]
 impl Database for Db {
@@ -288,5 +272,120 @@ impl Database for Db {
             .table_names_for_partition(partition_key)
             .await
             .context(MutableBufferRead)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use arrow_deps::{
+        arrow::record_batch::RecordBatch, assert_table_eq, datafusion::physical_plan::collect,
+    };
+    use query::{
+        exec::Executor, frontend::sql::SQLQueryPlanner, test::TestLPWriter, PartitionChunk,
+    };
+    use test_helpers::assert_contains;
+
+    use super::*;
+
+    /// Create a Database with a local store
+    fn make_db() -> Db {
+        let name = "test_db";
+        Db {
+            rules: DatabaseRules::default(),
+            mutable_buffer: Some(Arc::new(MutableBufferDb::new(name))),
+            read_buffer: Arc::new(ReadBufferDb::new()),
+            wal_buffer: None,
+            sequence: AtomicU64::new(0),
+        }
+    }
+
+    #[tokio::test]
+    async fn write_no_mutable_buffer() {
+        // Validate that writes are rejected if there is no mutable buffer
+        let mutable_buffer = None;
+        let db = make_db();
+        let db = Db {
+            mutable_buffer,
+            ..db
+        };
+
+        let mut writer = TestLPWriter::default();
+        let res = writer.write_lp_string(&db, "cpu bar=1 10").await;
+        assert_contains!(
+            res.unwrap_err().to_string(),
+            "Cannot write to this database: no mutable buffer configured"
+        );
+    }
+
+    #[tokio::test]
+    async fn read_write() {
+        let db = make_db();
+        let mut writer = TestLPWriter::default();
+        writer.write_lp_string(&db, "cpu bar=1 10").await.unwrap();
+
+        let batches = run_query(&db, "select * from cpu").await;
+
+        let expected = vec![
+            "+-----+------+",
+            "| bar | time |",
+            "+-----+------+",
+            "| 1   | 10   |",
+            "+-----+------+",
+        ];
+        assert_table_eq!(expected, &batches);
+    }
+
+    #[tokio::test]
+    async fn write_with_rollover() {
+        let db = make_db();
+        let mut writer = TestLPWriter::default();
+        writer.write_lp_string(&db, "cpu bar=1 10").await.unwrap();
+        assert_eq!(vec!["1970-01-01T00"], db.partition_keys().await.unwrap());
+
+        let chunk = db.rollover_partition("1970-01-01T00").await.unwrap();
+        assert_eq!(chunk.id(), 0);
+
+        let expected = vec![
+            "+-----+------+",
+            "| bar | time |",
+            "+-----+------+",
+            "| 1   | 10   |",
+            "+-----+------+",
+        ];
+        let batches = run_query(&db, "select * from cpu").await;
+        assert_table_eq!(expected, &batches);
+
+        // add new data
+        writer.write_lp_string(&db, "cpu bar=2 20").await.unwrap();
+        let expected = vec![
+            "+-----+------+",
+            "| bar | time |",
+            "+-----+------+",
+            "| 1   | 10   |",
+            "| 2   | 20   |",
+            "+-----+------+",
+        ];
+        let batches = run_query(&db, "select * from cpu").await;
+        assert_table_eq!(expected, &batches);
+
+        // And expect that we still get the same thing when data is rolled over again
+        let chunk = db.rollover_partition("1970-01-01T00").await.unwrap();
+        assert_eq!(chunk.id(), 1);
+
+        let batches = run_query(&db, "select * from cpu").await;
+        assert_table_eq!(expected, &batches);
+    }
+
+    // run a sql query against the database, returning the results as record batches
+    async fn run_query(db: &Db, query: &str) -> Vec<RecordBatch> {
+        let planner = SQLQueryPlanner::default();
+        let executor = Executor::new();
+
+        let physical_plan = planner
+            .query(db, "select * from cpu", &executor)
+            .await
+            .unwrap();
+
+        collect(physical_plan).await.unwrap()
     }
 }

--- a/server/src/db/chunk.rs
+++ b/server/src/db/chunk.rs
@@ -1,0 +1,65 @@
+use query::PartitionChunk;
+use snafu::{ResultExt, Snafu};
+
+use std::sync::Arc;
+
+#[derive(Debug, Snafu)]
+pub enum Error {
+    #[snafu(display("Mutable Buffer Chunk Error: {}", source))]
+    MutableBufferChunk {
+        source: mutable_buffer::chunk::Error,
+    },
+}
+pub type Result<T, E = Error> = std::result::Result<T, E>;
+
+/// A IOx DatabaseChunk can come from one of three places:
+/// MutableBuffer, ReadBuffer, or a ParquetFile
+#[derive(Debug)]
+pub enum DBChunk {
+    MutableBuffer(Arc<mutable_buffer::chunk::Chunk>),
+    ReadBuffer,  // TODO add appropriate type here
+    ParquetFile, // TODO add appropriate type here
+}
+
+impl PartitionChunk for DBChunk {
+    type Error = Error;
+
+    fn key(&self) -> &str {
+        match self {
+            Self::MutableBuffer(chunk) => chunk.key(),
+            Self::ReadBuffer => unimplemented!("read buffer not implemented"),
+            Self::ParquetFile => unimplemented!("parquet file not implemented"),
+        }
+    }
+
+    fn id(&self) -> u64 {
+        match self {
+            Self::MutableBuffer(chunk) => chunk.id(),
+            Self::ReadBuffer => unimplemented!("read buffer not implemented"),
+            Self::ParquetFile => unimplemented!("parquet file not implemented"),
+        }
+    }
+
+    fn table_stats(&self) -> Result<Vec<data_types::partition_metadata::Table>, Self::Error> {
+        match self {
+            Self::MutableBuffer(chunk) => chunk.table_stats().context(MutableBufferChunk),
+            Self::ReadBuffer => unimplemented!("read buffer not implemented"),
+            Self::ParquetFile => unimplemented!("parquet file not implemented"),
+        }
+    }
+
+    fn table_to_arrow(
+        &self,
+        dst: &mut Vec<arrow_deps::arrow::record_batch::RecordBatch>,
+        table_name: &str,
+        columns: &[&str],
+    ) -> Result<(), Self::Error> {
+        match self {
+            Self::MutableBuffer(chunk) => chunk
+                .table_to_arrow(dst, table_name, columns)
+                .context(MutableBufferChunk),
+            Self::ReadBuffer => unimplemented!("read buffer not implemented"),
+            Self::ParquetFile => unimplemented!("parquet file not implemented"),
+        }
+    }
+}


### PR DESCRIPTION
This PR sketches out how I imagine the API for chunk migration between immutable buffer, read buffer, and parquet files looking.

I envision some other system above this (perhaps in server or conductor) actually calling these functions. However, this isn't quite what @pauldix  implemented (e.g. he has the snapshot code in its own module: https://github.com/influxdata/influxdb_iox/blob/main/server/src/snapshot.rs#L249).

I also started adding tests showing how these apis work

They aren't completely hooked up but I wanted to sketch out one proposal of how they might work before I got too far

- [x] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb_iox/blob/main/README.md).
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
