### PR TITLE
refactor: Remove partition key from the Chunk trait

### DIFF
--- a/mutable_buffer/src/database.rs
+++ b/mutable_buffer/src/database.rs
@@ -41,7 +41,7 @@ pub enum Error {
     #[snafu(display("Table name {} not found in dictionary of chunk {}", table, chunk))]
     TableNameNotFoundInDictionary {
         table: String,
-        chunk: String,
+        chunk: u64,
         source: DictionaryError,
     },
 
@@ -52,21 +52,21 @@ pub enum Error {
     ))]
     ColumnNameNotFoundInDictionary {
         column_name: String,
-        chunk: String,
+        chunk: u64,
         source: DictionaryError,
     },
 
     #[snafu(display("Column ID {} not found in dictionary of chunk {}", column_id, chunk))]
     ColumnIdNotFoundInDictionary {
         column_id: u32,
-        chunk: String,
+        chunk: u64,
         source: DictionaryError,
     },
 
     #[snafu(display("Value ID {} not found in dictionary of chunk {}", value_id, chunk))]
     ColumnValueIdNotFoundInDictionary {
         value_id: u32,
-        chunk: String,
+        chunk: u64,
         source: DictionaryError,
     },
 
@@ -607,7 +607,7 @@ impl Visitor for NameVisitor {
                     .lookup_id(column_id)
                     .context(ColumnIdNotFoundInDictionary {
                         column_id,
-                        chunk: &chunk.key,
+                        chunk: chunk.id,
                     })?;
 
             if !self.column_names.contains(column_name) {
@@ -743,7 +743,7 @@ impl<'a> Visitor for ValueVisitor<'a> {
         self.column_id = Some(chunk.dictionary.lookup_value(self.column_name).context(
             ColumnNameNotFoundInDictionary {
                 column_name: self.column_name,
-                chunk: &chunk.key,
+                chunk: chunk.id,
             },
         )?);
 
@@ -808,7 +808,7 @@ impl<'a> Visitor for ValueVisitor<'a> {
             let value = chunk.dictionary.lookup_id(value_id).context(
                 ColumnValueIdNotFoundInDictionary {
                     value_id,
-                    chunk: &chunk.key,
+                    chunk: chunk.id,
                 },
             )?;
 

--- a/mutable_buffer/src/partition.rs
+++ b/mutable_buffer/src/partition.rs
@@ -73,7 +73,7 @@ impl Partition {
         let mut id_generator = 0;
 
         let key: String = key.into();
-        let open_chunk = Chunk::new(&key, id_generator);
+        let open_chunk = Chunk::new(id_generator);
         id_generator += 1;
 
         Self {
@@ -132,7 +132,7 @@ impl Partition {
     pub fn rollover_chunk(&mut self) -> Arc<Chunk> {
         let chunk_id = self.id_generator;
         self.id_generator += 1;
-        let mut chunk = Chunk::new(self.key(), chunk_id);
+        let mut chunk = Chunk::new(chunk_id);
         std::mem::swap(&mut chunk, &mut self.open_chunk);
         chunk.mark_closed();
         let chunk = Arc::new(chunk);

--- a/mutable_buffer/src/table.rs
+++ b/mutable_buffer/src/table.rs
@@ -38,7 +38,7 @@ pub enum Error {
     #[snafu(display("Tag value ID {} not found in dictionary of chunk {}", value, chunk))]
     TagValueIdNotFoundInDictionary {
         value: u32,
-        chunk: String,
+        chunk: u64,
         source: DictionaryError,
     },
 
@@ -73,7 +73,7 @@ pub enum Error {
     ))]
     ColumnNameNotFoundInDictionary {
         column_name: String,
-        chunk: String,
+        chunk: u64,
         source: DictionaryError,
     },
 
@@ -84,7 +84,7 @@ pub enum Error {
     ))]
     ColumnIdNotFoundInDictionary {
         column_id: u32,
-        chunk: String,
+        chunk: u64,
         source: DictionaryError,
     },
 
@@ -805,7 +805,7 @@ impl Table {
                 .lookup_value(column_name)
                 .context(ColumnNameNotFoundInDictionary {
                     column_name,
-                    chunk: &chunk.key,
+                    chunk: chunk.id,
                 })?;
 
         self.column_id_to_index
@@ -842,7 +842,7 @@ impl Table {
                 let column_name = chunk.dictionary.lookup_id(column_id).context(
                     ColumnIdNotFoundInDictionary {
                         column_id,
-                        chunk: &chunk.key,
+                        chunk: chunk.id,
                     },
                 )?;
                 Ok((column_name, column_index))
@@ -892,7 +892,7 @@ impl Table {
                                 let tag_value = chunk.dictionary.lookup_id(*value_id).context(
                                     TagValueIdNotFoundInDictionary {
                                         value: *value_id,
-                                        chunk: &chunk.key,
+                                        chunk: chunk.id,
                                     },
                                 )?;
                                 builder.append_value(tag_value)
@@ -1275,7 +1275,7 @@ mod tests {
 
     #[test]
     fn test_has_columns() {
-        let mut chunk = Chunk::new("dummy_chunk_key", 42);
+        let mut chunk = Chunk::new(42);
         let dictionary = &mut chunk.dictionary;
         let mut table = Table::new(dictionary.lookup_value_or_insert("table_name"));
 
@@ -1317,7 +1317,7 @@ mod tests {
 
     #[test]
     fn test_matches_table_name_predicate() {
-        let mut chunk = Chunk::new("dummy_chunk_key", 42);
+        let mut chunk = Chunk::new(42);
         let dictionary = &mut chunk.dictionary;
         let mut table = Table::new(dictionary.lookup_value_or_insert("h2o"));
 
@@ -1347,7 +1347,7 @@ mod tests {
 
     #[test]
     fn test_matches_column_name_predicate() {
-        let mut chunk = Chunk::new("dummy_chunk_key", 42);
+        let mut chunk = Chunk::new(42);
         let dictionary = &mut chunk.dictionary;
         let mut table = Table::new(dictionary.lookup_value_or_insert("h2o"));
 
@@ -1393,7 +1393,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_series_set_plan() {
-        let mut chunk = Chunk::new("dummy_chunk_key", 42);
+        let mut chunk = Chunk::new(42);
         let dictionary = &mut chunk.dictionary;
         let mut table = Table::new(dictionary.lookup_value_or_insert("table_name"));
 
@@ -1440,7 +1440,7 @@ mod tests {
         // test that the columns and rows come out in the right order (tags then
         // timestamp)
 
-        let mut chunk = Chunk::new("dummy_chunk_key", 42);
+        let mut chunk = Chunk::new(42);
         let dictionary = &mut chunk.dictionary;
         let mut table = Table::new(dictionary.lookup_value_or_insert("table_name"));
 
@@ -1489,7 +1489,7 @@ mod tests {
     async fn test_series_set_plan_filter() {
         // test that filters are applied reasonably
 
-        let mut chunk = Chunk::new("dummy_chunk_key", 42);
+        let mut chunk = Chunk::new(42);
         let dictionary = &mut chunk.dictionary;
         let mut table = Table::new(dictionary.lookup_value_or_insert("table_name"));
 
@@ -1878,7 +1878,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_grouped_window_series_set_plan_nanoseconds() {
-        let mut chunk = Chunk::new("dummy_chunk_key", 42);
+        let mut chunk = Chunk::new(42);
         let dictionary = &mut chunk.dictionary;
         let mut table = Table::new(dictionary.lookup_value_or_insert("table_name"));
 
@@ -1942,7 +1942,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_grouped_window_series_set_plan_months() {
-        let mut chunk = Chunk::new("dummy_chunk_key", 42);
+        let mut chunk = Chunk::new(42);
         let dictionary = &mut chunk.dictionary;
         let mut table = Table::new(dictionary.lookup_value_or_insert("table_name"));
 
@@ -1987,7 +1987,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_field_name_plan() {
-        let mut chunk = Chunk::new("dummy_chunk_key", 42);
+        let mut chunk = Chunk::new(42);
         let dictionary = &mut chunk.dictionary;
         let mut table = Table::new(dictionary.lookup_value_or_insert("table_name"));
 
@@ -2164,7 +2164,7 @@ mod tests {
     impl TableFixture {
         /// Create an Table with the specified lines loaded
         fn new(lp_lines: Vec<&str>) -> Self {
-            let mut chunk = Chunk::new("dummy_chunk_key", 42);
+            let mut chunk = Chunk::new(42);
             let dictionary = &mut chunk.dictionary;
             let mut table = Table::new(dictionary.lookup_value_or_insert("table_name"));
 

--- a/query/src/lib.rs
+++ b/query/src/lib.rs
@@ -114,9 +114,6 @@ pub trait Database: Debug + Send + Sync {
 pub trait PartitionChunk: Debug + Send + Sync {
     type Error: std::error::Error + Send + Sync + 'static;
 
-    /// returns the partition key of this chunk
-    fn key(&self) -> &str;
-
     /// returns the Id of this chunk. Ids are unique within a
     /// particular partition.
     fn id(&self) -> u64;

--- a/query/src/test.rs
+++ b/query/src/test.rs
@@ -439,10 +439,6 @@ pub struct TestChunk {}
 impl PartitionChunk for TestChunk {
     type Error = TestError;
 
-    fn key(&self) -> &str {
-        unimplemented!()
-    }
-
     fn id(&self) -> u64 {
         unimplemented!()
     }

--- a/server/src/db.rs
+++ b/server/src/db.rs
@@ -126,14 +126,6 @@ pub enum DBChunk {
 impl PartitionChunk for DBChunk {
     type Error = Error;
 
-    fn key(&self) -> &str {
-        match self {
-            Self::MutableBuffer(chunk) => chunk.key(),
-            Self::ReadBuffer => unimplemented!("read buffer not implemented"),
-            Self::ParquetFile => unimplemented!("parquet file not implemented"),
-        }
-    }
-
     fn id(&self) -> u64 {
         match self {
             Self::MutableBuffer(chunk) => chunk.id(),

--- a/src/server/http_routes.rs
+++ b/src/server/http_routes.rs
@@ -592,7 +592,7 @@ async fn list_partitions<M: ConnectionManager + Send + Sync + Debug + 'static>(
 struct SnapshotInfo {
     org: String,
     bucket: String,
-    chunk: String,
+    partition: String,
 }
 
 #[tracing::instrument(level = "debug")]
@@ -640,14 +640,16 @@ async fn snapshot_partition<M: ConnectionManager + Send + Sync + Debug + 'static
     metadata_path.push(&db_name.to_string());
     let mut data_path = metadata_path.clone();
     metadata_path.push("meta");
-    data_path.push_all(&["data", &snapshot.chunk]);
+    data_path.push_all(&["data", &snapshot.partition]);
 
-    let partition = db.rollover_partition(&snapshot.chunk).await.unwrap();
+    let partition_key = &snapshot.partition;
+    let chunk = db.rollover_partition(partition_key).await.unwrap();
     let snapshot = server::snapshot::snapshot_chunk(
         metadata_path,
         data_path,
         server.store.clone(),
-        partition,
+        partition_key,
+        chunk,
         None,
     )
     .unwrap();


### PR DESCRIPTION
Closes #

Chunks are part of partitions but they shoudn't have to have the back pointer too. The `key` is left over from prior to the introduction of Chunks. I think this is causing confusion (e.g. https://github.com/influxdata/influxdb_iox/pull/621#discussion_r553619255) so I propose removing them. 


- [x] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb_iox/blob/main/README.md).
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
