### PR TITLE
feat: add partition concept to ReadBuffer

### DIFF
--- a/read_buffer/src/chunk.rs
+++ b/read_buffer/src/chunk.rs
@@ -31,6 +31,11 @@ impl Chunk {
         p
     }
 
+    /// The chunk's ID.
+    pub fn id(&self) -> u32 {
+        self.id
+    }
+
     /// The total size in bytes of all row groups in all tables in this chunk.
     pub fn size(&self) -> u64 {
         self.meta.size
@@ -57,7 +62,7 @@ impl Chunk {
     }
 
     /// Add a row_group to a table in the chunk, updating all Chunk meta data.
-    pub fn update_table(&mut self, table_name: String, row_group: RowGroup) {
+    pub fn upsert_table(&mut self, table_name: String, row_group: RowGroup) {
         // update meta data
         self.meta.update(&row_group);
 

--- a/read_buffer/src/lib.rs
+++ b/read_buffer/src/lib.rs
@@ -369,7 +369,7 @@ pub struct Partition {
     // The partition's key
     key: String,
 
-    // The collection of chunks in the database. Each chunk is uniquely
+    // The collection of chunks in the partition. Each chunk is uniquely
     // identified by a chunk id.
     chunks: BTreeMap<u32, Chunk>,
 


### PR DESCRIPTION
This adds back the concept of a `partition` to the `ReadBuffer` so that we can ensure that chunk ids do not clash within a database (chunk ids are not guaranteed to be unique across partitions).

This could have been a map of a map but since I knew we will want to do bulk operations on a partition, e.g., drop all the chunks in it, I dug out some previous code and refactored it back into the `ReadBuffer`.

I took the opportunity to rename the `update_*` methods to `upsert_x` since, as @domodwyer pointed out, they both modify and create.