### PR TITLE
feat: read filter API for lazily streaming out of Read Buffer

### DIFF
--- a/read_buffer/src/chunk.rs
+++ b/read_buffer/src/chunk.rs
@@ -1,7 +1,7 @@
 use std::collections::{btree_map::Entry, BTreeMap, BTreeSet};
 
 use crate::row_group::{ColumnName, Predicate};
-use crate::table::{ReadFilterResults, ReadGroupResults, Table};
+use crate::table::{ColumnSelection, ReadFilterResults, ReadGroupResults, Table};
 use crate::{column::AggregateType, row_group::RowGroup};
 
 type TableName = String;
@@ -93,7 +93,7 @@ impl Chunk {
         &self,
         table_name: &str,
         predicates: &'a [Predicate<'a>],
-        select_columns: &'a [ColumnName<'a>],
+        select_columns: &ColumnSelection<'_>,
     ) -> Option<ReadFilterResults<'a, '_>> {
         match self.tables.get(table_name) {
             Some(table) => Some(table.read_filter(select_columns, predicates)),

--- a/read_buffer/src/chunk.rs
+++ b/read_buffer/src/chunk.rs
@@ -77,19 +77,28 @@ impl Chunk {
         };
     }
 
-    /// Returns data for the specified column selections on the specified table
-    /// name.
+    /// Returns an iterator of lazily executed `read_filter` operations on the
+    /// provided table for the specified column selections.
     ///
-    /// Results may be filtered by conjunctive predicates. Time predicates
-    /// should use as nanoseconds since the epoch.
-    pub fn select(
+    /// Results may be filtered by conjunctive predicates.
+    ///
+    /// `None` indicates that the table was not found on the chunk, whilst a
+    /// `ReadFilterResults` value that immediately yields `None` indicates that
+    /// there were no matching results.
+    ///
+    /// TODO(edd): Alternatively we could assert the caller must have done
+    /// appropriate pruning and that the table should always exist, meaning we
+    /// can blow up here and not need to return an option.
+    pub fn read_filter<'a>(
         &self,
         table_name: &str,
-        predicates: &[Predicate<'_>],
-        select_columns: &[ColumnName<'_>],
-    ) -> ReadFilterResults<'_, '_> {
-        // Lookup table by name and dispatch execution.
-        todo!();
+        predicates: &'a [Predicate<'a>],
+        select_columns: &'a [ColumnName<'a>],
+    ) -> Option<ReadFilterResults<'a, '_>> {
+        match self.tables.get(table_name) {
+            Some(table) => Some(table.read_filter(select_columns, predicates)),
+            None => None,
+        }
     }
 
     /// Returns aggregates segmented by grouping keys for the specified

--- a/read_buffer/src/column.rs
+++ b/read_buffer/src/column.rs
@@ -2727,10 +2727,12 @@ impl<'a> Values<'a> {
             },
         }
     }
+}
 
-    // Moves ownership of self into an Arrow array.
-    pub fn take_arrow_array(self) -> array::ArrayRef {
-        match self {
+/// Moves ownership of Values into an arrow `ArrayRef`.
+impl From<Values<'_>> for array::ArrayRef {
+    fn from(values: Values<'_>) -> Self {
+        match values {
             Values::String(values) => Arc::new(arrow::array::StringArray::from(values)),
             Values::I64(values) => Arc::new(arrow::array::Int64Array::from(values)),
             Values::U64(values) => Arc::new(arrow::array::UInt64Array::from(values)),

--- a/read_buffer/src/column.rs
+++ b/read_buffer/src/column.rs
@@ -69,6 +69,18 @@ impl Column {
         }
     }
 
+    /// Returns the logical data-type associated with the column.
+    pub fn logical_datatype(&self) -> LogicalDataType {
+        match self {
+            Column::String(_, _) => LogicalDataType::String,
+            Column::Float(_, _) => LogicalDataType::Float,
+            Column::Integer(_, _) => LogicalDataType::Integer,
+            Column::Unsigned(_, _) => LogicalDataType::Unsigned,
+            Column::Bool => LogicalDataType::Boolean,
+            Column::ByteArray(_, _) => LogicalDataType::Binary,
+        }
+    }
+
     pub fn size(&self) -> u64 {
         0
     }
@@ -598,6 +610,17 @@ impl Column {
 #[derive(Default, Debug, PartialEq)]
 pub struct ColumnProperties {
     pub has_pre_computed_row_ids: bool,
+}
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+/// The logical data-type for a column.
+pub enum LogicalDataType {
+    Integer,  // Signed integer
+    Unsigned, // Unsigned integer
+    Float,    //
+    String,   // UTF-8 valid string
+    Binary,   // Arbitrary collection of bytes
+    Boolean,  //
 }
 
 #[derive(Default, Debug, PartialEq)]

--- a/read_buffer/src/lib.rs
+++ b/read_buffer/src/lib.rs
@@ -188,7 +188,7 @@ impl Database {
         table_name: &'a str,
         chunk_ids: &[u32],
         predicates: &'a [Predicate<'a>],
-        select_columns: &'a [ColumnName<'a>],
+        select_columns: table::ColumnSelection<'a>,
     ) -> Result<ReadFilterResults<'a, '_>> {
         match self.partitions.get(partition_key) {
             Some(partition) => {
@@ -488,7 +488,7 @@ pub struct ReadFilterResults<'input, 'chunk> {
 
     table_name: &'input str,
     predicates: &'input [Predicate<'input>],
-    select_columns: &'input [ColumnName<'input>],
+    select_columns: table::ColumnSelection<'input>,
 }
 
 impl<'input, 'chunk> ReadFilterResults<'input, 'chunk> {
@@ -496,7 +496,7 @@ impl<'input, 'chunk> ReadFilterResults<'input, 'chunk> {
         chunks: Vec<&'chunk Chunk>,
         table_name: &'input str,
         predicates: &'input [Predicate<'input>],
-        select_columns: &'input [ColumnName<'input>],
+        select_columns: table::ColumnSelection<'input>,
     ) -> Self {
         Self {
             chunks,
@@ -876,11 +876,11 @@ mod test {
 
         let mut itr = db
             .read_filter(
-                "Coolverine",
                 "hour_1",
+                "Coolverine",
                 &[22],
                 &predicates,
-                &["env", "region", "counter", "time"],
+                table::ColumnSelection::All,
             )
             .unwrap();
 
@@ -968,11 +968,11 @@ mod test {
 
         let mut itr = db
             .read_filter(
-                "Coolverine",
                 "hour_1",
+                "Coolverine",
                 &[100, 200, 300],
                 &predicates,
-                &["env", "region", "counter", "time"],
+                table::ColumnSelection::Some(&["env", "region", "counter", "time"]),
             )
             .unwrap();
 

--- a/read_buffer/src/row_group.rs
+++ b/read_buffer/src/row_group.rs
@@ -1112,7 +1112,7 @@ impl ReadFilterResult<'_> {
         let columns = self
             .data
             .into_iter()
-            .map(|values| values.take_arrow_array())
+            .map(arrow::array::ArrayRef::from)
             .collect::<Vec<_>>();
 
         // try_new only returns an error if the schema is invalid or the number

--- a/read_buffer/src/row_group.rs
+++ b/read_buffer/src/row_group.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, collections::BTreeMap};
+use std::{borrow::Cow, collections::BTreeMap, sync::Arc};
 
 use hashbrown::{hash_map, HashMap};
 use itertools::Itertools;
@@ -171,32 +171,45 @@ impl RowGroup {
     /// predicates.
     ///
     /// Right now, predicates are conjunctive (AND).
+    ///
+    /// TODO(edd): this should probably return an Option and the caller can
+    /// filter None results.
     pub fn read_filter(
         &self,
         columns: &[ColumnName<'_>],
         predicates: &[Predicate<'_>],
     ) -> ReadFilterResult<'_> {
         let row_ids = self.row_ids_from_predicates(predicates);
-        ReadFilterResult(self.materialise_rows(columns, row_ids))
+
+        // ensure meta/data have same lifetime by using column names from row
+        // group rather than from input.
+        let (col_names, col_data) = self.materialise_rows(columns, row_ids);
+        let schema = self.meta.schema_for_column_names(&col_names);
+        ReadFilterResult {
+            schema,
+            data: col_data,
+        }
     }
 
     fn materialise_rows(
         &self,
         names: &[ColumnName<'_>],
         row_ids: RowIDsOption,
-    ) -> Vec<(ColumnName<'_>, Values<'_>)> {
-        let mut results = vec![];
+    ) -> (Vec<&str>, Vec<Values<'_>>) {
+        let mut col_names = Vec::with_capacity(names.len());
+        let mut col_data = Vec::with_capacity(names.len());
         match row_ids {
-            RowIDsOption::None(_) => results, // nothing to materialise
+            RowIDsOption::None(_) => (col_names, col_data), // nothing to materialise
             RowIDsOption::Some(row_ids) => {
                 // TODO(edd): causes an allocation. Implement a way to pass a
                 // pooled buffer to the croaring Bitmap API.
                 let row_ids = row_ids.to_vec();
                 for &name in names {
                     let (col_name, col) = self.column_name_and_column(name);
-                    results.push((col_name, col.values(row_ids.as_slice())));
+                    col_names.push(col_name);
+                    col_data.push(col.values(row_ids.as_slice()));
                 }
-                results
+                (col_names, col_data)
             }
 
             RowIDsOption::All(_) => {
@@ -207,9 +220,10 @@ impl RowGroup {
 
                 for &name in names {
                     let (col_name, col) = self.column_name_and_column(name);
-                    results.push((col_name, col.values(row_ids.as_slice())));
+                    col_names.push(col_name);
+                    col_data.push(col.values(row_ids.as_slice()));
                 }
-                results
+                (col_names, col_data)
             }
         }
     }
@@ -1054,25 +1068,67 @@ impl MetaData {
             Operator::LTE => column_min <= value,
         }
     }
+
+    // Extract schema information for a set of columns.
+    fn schema_for_column_names<'a>(
+        &self,
+        names: &[ColumnName<'a>],
+    ) -> Vec<(&'a str, LogicalDataType)> {
+        names
+            .iter()
+            .map(|&name| (name, *self.column_types.get(name).unwrap()))
+            .collect::<Vec<_>>()
+    }
 }
 
 /// Encapsulates results from `RowGroup`s with a structure that makes them
 /// easier to work with and display.
-pub struct ReadFilterResult<'row_group>(pub Vec<(ColumnName<'row_group>, Values<'row_group>)>);
+pub struct ReadFilterResult<'row_group> {
+    schema: Vec<(ColumnName<'row_group>, LogicalDataType)>,
+    data: Vec<Values<'row_group>>,
+}
 
 impl ReadFilterResult<'_> {
     pub fn is_empty(&self) -> bool {
-        self.0.is_empty()
+        self.data.is_empty()
+    }
+
+    pub fn schema(&self) -> &Vec<(ColumnName<'_>, LogicalDataType)> {
+        &self.schema
+    }
+
+    /// Produces a `RecordBatch` from the results, giving up ownership to the
+    /// returned record batch.
+    pub fn record_batch(self) -> arrow::record_batch::RecordBatch {
+        let schema = arrow::datatypes::Schema::new(
+            self.schema()
+                .iter()
+                .map(|(col_name, col_typ)| {
+                    arrow::datatypes::Field::new(col_name, col_typ.to_arrow_datatype(), true)
+                })
+                .collect::<Vec<_>>(),
+        );
+
+        let columns = self
+            .data
+            .into_iter()
+            .map(|values| values.take_arrow_array())
+            .collect::<Vec<_>>();
+
+        // try_new only returns an error if the schema is invalid or the number
+        // of rows on columns differ. We have full control over both so there
+        // should never be an error to return...
+        arrow::record_batch::RecordBatch::try_new(Arc::new(schema), columns).unwrap()
     }
 }
 
 impl std::fmt::Debug for &ReadFilterResult<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         // header line.
-        for (i, (k, _)) in self.0.iter().enumerate() {
+        for (i, (k, _)) in self.schema.iter().enumerate() {
             write!(f, "{}", k)?;
 
-            if i < self.0.len() - 1 {
+            if i < self.schema.len() - 1 {
                 write!(f, ",")?;
             }
         }
@@ -1089,26 +1145,24 @@ impl std::fmt::Display for &ReadFilterResult<'_> {
             return Ok(());
         }
 
-        let expected_rows = self.0[0].1.len();
+        let expected_rows = self.data[0].len();
         let mut rows = 0;
 
         let mut iter_map = self
-            .0
+            .data
             .iter()
-            .map(|(k, v)| (*k, ValuesIterator::new(v)))
-            .collect::<BTreeMap<&str, ValuesIterator<'_>>>();
+            .map(|v| ValuesIterator::new(v))
+            .collect::<Vec<_>>();
 
         while rows < expected_rows {
             if rows > 0 {
                 writeln!(f)?;
             }
 
-            for (i, (k, _)) in self.0.iter().enumerate() {
-                if let Some(itr) = iter_map.get_mut(k) {
-                    write!(f, "{}", itr.next().unwrap())?;
-                    if i < self.0.len() - 1 {
-                        write!(f, ",")?;
-                    }
+            for (i, (k, _)) in self.schema.iter().enumerate() {
+                write!(f, "{}", iter_map[i].next().unwrap())?;
+                if i < self.schema.len() - 1 {
+                    write!(f, ",")?;
                 }
             }
 


### PR DESCRIPTION
This PR adds an API that enables a caller to lazily stream results out of the `ReadBuffer` in the form of record batches.

The external API (that other crates may use) looks like:

```rust
    pub fn read_filter<'a>(
        &self,
        table_name: &str,
        partition_key: &str,
        chunk_ids: &[u32],
        select_columns: ColumnSelection<'a>,
        predicates: &'a [Predicate<'a>],
    ) -> Result<ReadFilterResults<'a, '_>> {
```

`chunk_ids` should specify all of the chunks that the caller wishes to query across. The caller could provide single chunk ids and call `read_filter` multiple times, or it can provide many chunk ids and call it once. 

`ColumnSelection` is an enum that lets you ask for "all columns" or specify some columns. 

`predicates are a set of conjunctive predicates. The `ReadBuffer` currently supports `=, !=, <, <=, >, >=`.

`read_filter` returns an iterator. This iterator will emit record batches on calls to `next`. Structuring the code in this way means that the `ReadBuffer` can control how many or how big these record batches should be.

Finally, execution for `read_filter` is now lazy - each row group is not executed against until the caller calls `next` on the returned iterator.
