### PR TITLE
refactor: Use u32 for Chunk ids consistently

### DIFF
--- a/mutable_buffer/src/chunk.rs
+++ b/mutable_buffer/src/chunk.rs
@@ -55,7 +55,7 @@ pub type Result<T, E = Error> = std::result::Result<T, E>;
 #[derive(Debug)]
 pub struct Chunk {
     /// The id for this chunk
-    pub id: u64,
+    pub id: u32,
 
     /// Time at which the first data was written into this chunk. Note
     /// this is not the same as the timestamps on the data itself
@@ -177,7 +177,7 @@ fn make_range_expr(range: &TimestampRange) -> Expr {
 }
 
 impl Chunk {
-    pub fn new(id: u64) -> Self {
+    pub fn new(id: u32) -> Self {
         Self {
             id,
             dictionary: Dictionary::new(),
@@ -334,7 +334,7 @@ impl Chunk {
     }
 
     /// return the ID of this chunk
-    pub fn id(&self) -> u64 {
+    pub fn id(&self) -> u32 {
         self.id
     }
 
@@ -416,7 +416,7 @@ impl Chunk {
 impl query::PartitionChunk for Chunk {
     type Error = Error;
 
-    fn id(&self) -> u64 {
+    fn id(&self) -> u32 {
         self.id
     }
 

--- a/query/src/lib.rs
+++ b/query/src/lib.rs
@@ -116,7 +116,7 @@ pub trait PartitionChunk: Debug + Send + Sync {
 
     /// returns the Id of this chunk. Ids are unique within a
     /// particular partition.
-    fn id(&self) -> u64;
+    fn id(&self) -> u32;
 
     /// returns the partition metadata stats for every table in the partition
     fn table_stats(&self) -> Result<Vec<TableStats>, Self::Error>;

--- a/query/src/test.rs
+++ b/query/src/test.rs
@@ -439,7 +439,7 @@ pub struct TestChunk {}
 impl PartitionChunk for TestChunk {
     type Error = TestError;
 
-    fn id(&self) -> u64 {
+    fn id(&self) -> u32 {
         unimplemented!()
     }
 

--- a/server/src/db/chunk.rs
+++ b/server/src/db/chunk.rs
@@ -24,7 +24,7 @@ pub enum DBChunk {
 impl PartitionChunk for DBChunk {
     type Error = Error;
 
-    fn id(&self) -> u64 {
+    fn id(&self) -> u32 {
         match self {
             Self::MutableBuffer(chunk) => chunk.id(),
             Self::ReadBuffer => unimplemented!("read buffer not implemented"),


### PR DESCRIPTION
Closes https://github.com/influxdata/influxdb_iox/issues/634

This uses u32 to identify chunks everywhery to harmonize across the IOx systems -- previously `mutable_buffer` used `u64` and `read_buffer` used `u32` which caused some silly friction in https://github.com/influxdata/influxdb_iox/pull/630


- [x] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb_iox/blob/main/README.md).
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
