### PR TITLE
docs: Add query README file and explain some rationale

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -10,3 +10,4 @@ not intended to be general user facing documentation
 * How InfluxDB IOx manages the lifecycle of time series data: [data_management.md](data_management.md)
 * Thoughts on parquet encoding and compression for timeseries data: [encoding_thoughts.md](encoding_thoughts.md)
 * Thoughts on using multiple cores: [multi_core_tasks.md](multi_core_tasks.md)
+* [Query Engine Docs](../query/README.md)

--- a/query/README.md
+++ b/query/README.md
@@ -1,0 +1,92 @@
+# IOx Query Layer
+
+The IOx query layer is responsible for translating query requests from
+different query languages and planning and executing them against
+Chunks stored across various IOx storage systems.
+
+
+Query Frontends
+* SQL
+* Storage gRPC
+* Flux (possibly in the future)
+* InfluxQL (possibly in the future)
+* Others (possibly in the future)
+
+Sources of Chunk data
+* ReadBuffer
+* MutableBuffer
+* Parquet Files
+* Others (possibly in the fugure, like Remote Chunk?)
+
+The goal is to use the shared query / plan representation in order to
+avoid N*M combinations of languge and Chunk source.
+
+Thus query planning is implemented in terms of traits, and those
+traits are implemented by different chunk impementations.
+
+Amont othe rthings, this means that this crate should not depend
+directly on the ReadBuffer or the MutableBuffer.
+
+
+```text
+┌───────────────┐  ┌────────────────┐    ┌──────────────┐      ┌──────────────┐
+│Mutable Buffer │  │  Read Buffer   │    │Parquet Files │  ... │Future Source │
+│               │  │                │    │              │      │              │
+└───────────────┘  └────────────────┘    └──────────────┘      └──────────────┘
+        ▲                   ▲                    ▲                     ▲
+        └───────────────────┴─────────┬──────────┴─────────────────────┘
+                                      │
+                                      │
+                     ┌─────────────────────────────────┐
+                     │          Shared Common          │
+                     │   Predicate, Plans, Execution   │
+                     └─────────────────────────────────┘
+                                      ▲
+                                      │
+                                      │
+               ┌──────────────────────┼─────────────────────────┐
+               │                      │                         │
+               │                      │                         │
+               │                      │                         │
+     ┌───────────────────┐  ┌──────────────────┐      ┌──────────────────┐
+     │   SQL Frontend    │  │   gRPC Storage   │ ...  │ Future Frontend  │
+     │                   │  │     Frontend     │      │ (e.g. InfluxQL)  │
+     └───────────────────┘  └──────────────────┘      └──────────────────┘
+```
+
+We are trying to avoid ending up with something like this:
+
+
+```
+                          ┌─────────────────────────────────────────────────┐
+                          │                                                 │
+                          ▼                                                 │
+                   ┌────────────┐                                           │
+                   │Read Buffer │                  ┌────────────────────────┤
+        ┌──────────┼────────────┼─────┬────────────┼────────────────────────┤
+        │          └────────────┘     │            ▼                        │
+        ▼                 ▲           │    ┌──────────────┐                 │
+┌───────────────┐         │           │    │Parquet Files │                 │
+│Mutable Buffer │         │           ├───▶│              │...              │
+│               │◀────────┼───────────┤    └──────────────┘   ┌─────────────┼┐
+└───────────────┘         │           │            ▲          │Future Source││
+        ▲                 │           ├────────────┼─────────▶│             ││◀─┐
+        │                 │           │            │          └─────────────┼┘  │
+        │                 │           │            │                        │   │
+        │                 │           │            │                        │   │
+        │      ┌──────────┘           │            │                        │   │
+        │      │                      │            │                        │   │
+        │      ├──────────────────────┼────────────┘                        │   │
+        └──────┤                      │                                     │   │
+               │                      │                                     │   │
+               │                      │                                     │   │
+               │                      │                                     │   │
+               │                      │                                     │   │
+               │                      │                                     │   │
+               │                      │                                     │   │
+               │                      │                                     │   │
+     ┌───────────────────┐  ┌──────────────────┐      ┌──────────────────┐  │   │
+     │   SQL Frontend    │  │   gRPC Storage   │ ...  │ Future Frontend  │  │   │
+     │                   │  │     Frontend     │      │ (e.g. InfluxQL)  │──┴───┘
+     └───────────────────┘  └──────────────────┘      └──────────────────┘
+```

--- a/query/README.md
+++ b/query/README.md
@@ -16,15 +16,15 @@ Sources of Chunk data
 * ReadBuffer
 * MutableBuffer
 * Parquet Files
-* Others (possibly in the fugure, like Remote Chunk?)
+* Others (possibly in the future, like Remote Chunk?)
 
 The goal is to use the shared query / plan representation in order to
-avoid N*M combinations of languge and Chunk source.
+avoid N*M combinations of language and Chunk source.
 
 Thus query planning is implemented in terms of traits, and those
-traits are implemented by different chunk impementations.
+traits are implemented by different chunk implementations.
 
-Amont othe rthings, this means that this crate should not depend
+Among other things, this means that this crate should not depend
 directly on the ReadBuffer or the MutableBuffer.
 
 


### PR DESCRIPTION
This adds a README.md file in the query crate trying to capture the rationale and sweet sweet ASCII art. I figured that since @pauldix  said this matches what he currently has in mind  https://github.com/influxdata/influxdb_iox/pull/630#discussion_r555757382 I would get it into the repo.

- [x] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb_iox/blob/main/README.md).
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
