### PR TITLE
fix: (re)Implement logging configuration from the command line

### DIFF
--- a/src/commands/config.rs
+++ b/src/commands/config.rs
@@ -1,9 +1,8 @@
 //! Implementation of command line option for manipulating and showing server
 //! config
 
-use std::{io::ErrorKind, net::SocketAddr, path::PathBuf};
+use std::{net::SocketAddr, path::PathBuf};
 
-use dotenv::dotenv;
 use lazy_static::lazy_static;
 use structopt::StructOpt;
 
@@ -31,7 +30,7 @@ lazy_static! {
     set either with the command line flags or with the specified environment \
     variable. If there is a file named '.env' in the current working directory, \
     it is sourced before loading the configuration.
-    
+
 Configuration is loaded from the following sources (highest precedence first):
         - command line arguments
         - user set environment variables
@@ -49,6 +48,22 @@ pub struct Config {
     #[structopt(long = "--log", env = "RUST_LOG")]
     pub rust_log: Option<String>,
 
+    /// This sets logging up with a pre-configured set of convenient log levels.
+    ///
+    /// -v  means 'info' log levels
+    /// -vv means 'verbose' log level (with the exception of some particularly
+    /// low level libraries)
+    ///
+    /// This option is ignored if  --log / RUST_LOG are set
+    #[structopt(
+        short = "-v",
+        long = "--verbose",
+        multiple = true,
+        takes_value = false,
+        parse(from_occurrences)
+    )]
+    pub verbose_count: u64,
+
     /// The identifier for the server.
     ///
     /// Used for writing to object storage and as an identifier that is added to
@@ -60,16 +75,16 @@ pub struct Config {
 
     /// The address on which IOx will serve HTTP API requests.
     #[structopt(
-        long = "--api-bind", 
-        env = "INFLUXDB_IOX_BIND_ADDR", 
+        long = "--api-bind",
+        env = "INFLUXDB_IOX_BIND_ADDR",
         default_value = DEFAULT_API_BIND_ADDR,
     )]
     pub http_bind_address: SocketAddr,
 
     /// The address on which IOx will serve Storage gRPC API requests.
     #[structopt(
-        long = "--grpc-bind", 
-        env = "INFLUXDB_IOX_GRPC_BIND_ADDR", 
+        long = "--grpc-bind",
+        env = "INFLUXDB_IOX_GRPC_BIND_ADDR",
         default_value = DEFAULT_GRPC_BIND_ADDR,
     )]
     pub grpc_bind_address: SocketAddr,
@@ -82,40 +97,43 @@ pub struct Config {
     /// as SERVICE_ACCOUNT must be set.
     #[structopt(long = "--gcp-bucket", env = "INFLUXDB_IOX_GCP_BUCKET")]
     pub gcp_bucket: Option<String>,
+
+    /// If set, Jaeger traces are emitted to this host
+    /// using the OpenTelemetry tracer.
+    ///
+    /// NOTE: The OpenTelemetry agent CAN ONLY be
+    /// configured using environment variables. It CAN NOT be configured
+    /// using the command line at this time. Some useful variables:
+    ///
+    /// * OTEL_SERVICE_NAME: emitter service name (iox by default)
+    /// * OTEL_EXPORTER_JAEGER_AGENT_HOST: hostname/address of the collector
+    /// * OTEL_EXPORTER_JAEGER_AGENT_PORT: listening port of the collector.
+    ///
+    /// The entire list of variables can be found in
+    /// https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/sdk-environment-variables.md#jaeger-exporter
+    #[structopt(
+        long = "--oetl_exporter_jaeger_agent",
+        env = "OTEL_EXPORTER_JAEGER_AGENT_HOST"
+    )]
+    pub jaeger_host: Option<String>,
 }
 
-/// Load the config.
+/// Load the config if `server` was not specified on the command line
+/// (from environment variables and default)
 ///
 /// This pulls in config from the following sources, in order of precedence:
 ///
-///     - command line arguments
 ///     - user set environment variables
 ///     - .env file contents
 ///     - pre-configured default values
 pub fn load_config() -> Config {
-    // Source the .env file before initialising the Config struct - this sets
-    // any envs in the file, which the Config struct then uses.
-    //
-    // Precedence is given to existing env variables.
-    match dotenv() {
-        Ok(_) => {}
-        Err(dotenv::Error::Io(err)) if err.kind() == ErrorKind::NotFound => {
-            // Ignore this - a missing env file is not an error, defaults will
-            // be applied when initialising the Config struct.
-        }
-        Err(e) => {
-            eprintln!("FATAL Error loading config: {}", e);
-            eprintln!("Aborting");
-            std::process::exit(1);
-        }
-    };
-
     // Load the Config struct - this pulls in any envs set by the user or
     // sourced above, and applies any defaults.
     //
     // Strip the "server" portion of the args so the generated Clap instance
     // plays nicely with the subcommand bits in main.
-    let args = std::env::args().skip(1);
+
+    let args = std::env::args().filter(|arg| arg != "server");
 
     Config::from_iter(args)
 }

--- a/src/commands/influxdb_ioxd.rs
+++ b/src/commands/influxdb_ioxd.rs
@@ -16,7 +16,10 @@ use snafu::{ResultExt, Snafu};
 
 use panic_logging::SendPanicsToTracing;
 
-use super::{config::load_config, logging::LoggingLevel};
+use super::{
+    config::{load_config, Config},
+    logging::LoggingLevel,
+};
 
 #[derive(Debug, Snafu)]
 pub enum Error {
@@ -69,11 +72,18 @@ pub enum Error {
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
-/// This is the entry point for the IOx server -- it handles
-/// instantiating all state and getting things ready
-pub async fn main(logging_level: LoggingLevel) -> Result<()> {
-    // try to load the configuration before doing anything else
-    let config = load_config();
+/// This is the entry point for the IOx server. confg represents
+/// command line arguments, if any
+///
+/// The logging_level passed in is the global setting (e.g. if -v or
+/// -vv was passed in before 'server')
+pub async fn main(logging_level: LoggingLevel, config: Option<Config>) -> Result<()> {
+    // load config from environment if no command line
+    let config = config.unwrap_or_else(load_config);
+
+    // Handle the case if -v/-vv is specified both before and after the server
+    // command
+    let logging_level = logging_level.combine(LoggingLevel::new(config.verbose_count));
 
     let _drop_handle = logging_level.setup_logging(&config);
 

--- a/src/commands/influxdb_ioxd.rs
+++ b/src/commands/influxdb_ioxd.rs
@@ -72,7 +72,7 @@ pub enum Error {
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
-/// This is the entry point for the IOx server. confg represents
+/// This is the entry point for the IOx server. `config` represents
 /// command line arguments, if any
 ///
 /// The logging_level passed in is the global setting (e.g. if -v or

--- a/src/commands/logging.rs
+++ b/src/commands/logging.rs
@@ -35,9 +35,7 @@ impl LoggingLevel {
     /// Return a LoggingLevel that represents the most verbose logging
     /// of `self` and `other`
     pub fn combine(self, other: Self) -> Self {
-        let self_val: u64 = self.into();
-        let other_val: u64 = other.into();
-        Self::new(std::cmp::max(self_val, other_val))
+        Self::new(std::cmp::max(self as u64, other as u64))
     }
 
     /// set RUST_LOG to the level represented by self, unless RUST_LOG
@@ -124,15 +122,5 @@ impl LoggingLevel {
             .init();
 
         drop_handle
-    }
-}
-
-impl From<LoggingLevel> for u64 {
-    fn from(level: LoggingLevel) -> Self {
-        match level {
-            LoggingLevel::Default => 0,
-            LoggingLevel::Verbose => 1,
-            LoggingLevel::Debug => 2,
-        }
     }
 }

--- a/src/commands/logging.rs
+++ b/src/commands/logging.rs
@@ -32,6 +32,14 @@ impl LoggingLevel {
         }
     }
 
+    /// Return a LoggingLevel that represents the most verbose logging
+    /// of `self` and `other`
+    pub fn combine(self, other: Self) -> Self {
+        let self_val: u64 = self.into();
+        let other_val: u64 = other.into();
+        Self::new(std::cmp::max(self_val, other_val))
+    }
+
     /// set RUST_LOG to the level represented by self, unless RUST_LOG
     /// is already set
     fn set_rust_log_if_needed(&self, level: Option<String>) {
@@ -52,6 +60,9 @@ impl LoggingLevel {
                         "WARNING: Using RUST_LOG='{}' environment, ignoring -v command line",
                         lvl
                     );
+                } else {
+                    println!("Setting RUST_LOG: {}", lvl);
+                    std::env::set_var("RUST_LOG", lvl);
                 }
             }
             None => {
@@ -114,5 +125,15 @@ impl LoggingLevel {
             .init();
 
         drop_handle
+    }
+}
+
+impl From<LoggingLevel> for u64 {
+    fn from(level: LoggingLevel) -> Self {
+        match level {
+            LoggingLevel::Default => 0,
+            LoggingLevel::Verbose => 1,
+            LoggingLevel::Debug => 2,
+        }
     }
 }

--- a/src/commands/logging.rs
+++ b/src/commands/logging.rs
@@ -61,7 +61,6 @@ impl LoggingLevel {
                         lvl
                     );
                 } else {
-                    println!("Setting RUST_LOG: {}", lvl);
                     std::env::set_var("RUST_LOG", lvl);
                 }
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,13 +1,13 @@
 //! Entrypoint of InfluxDB IOx binary
 #![deny(rust_2018_idioms)]
 #![warn(
-    missing_copy_implementations,
     missing_debug_implementations,
     clippy::explicit_iter_loop,
     clippy::use_self
 )]
 
 use clap::{crate_authors, crate_version, value_t, App, Arg, ArgMatches, SubCommand};
+use dotenv::dotenv;
 use ingest::parquet::writer::CompressionLevel;
 use structopt::StructOpt;
 use tokio::runtime::Runtime;
@@ -25,7 +25,7 @@ mod commands {
     pub mod stats;
 }
 
-use commands::logging::LoggingLevel;
+use commands::{config::Config, logging::LoggingLevel};
 
 enum ReturnCode {
     ConversionFailed = 1,
@@ -59,13 +59,8 @@ Examples:
     # Dumps storage statistics about out.parquet to stdout
     influxdb_iox stats out.parquet
 "#;
-
-    // Source from the .env file (if any) to have the values display in the CLI
-    // help text.
-    //
-    // This is then loaded and validated properly when calling `load_config`
-    // later.
-    let _ = dotenv::dotenv();
+    // load all environment variables from .env before doing anything
+    load_dotenv();
 
     let matches = App::new(help)
         .version(crate_version!())
@@ -197,11 +192,27 @@ async fn dispatch_args(matches: ArgMatches<'_>) {
                 }
             }
         }
-        ("server", Some(_)) | (_, _) => {
+        // Handle the case where the user explicitly specified the server command
+        ("server", Some(sub_matches)) => {
             // Note don't set up basic logging here, different logging rules appy in server
             // mode
             println!("InfluxDB IOx server starting");
-            match commands::influxdb_ioxd::main(logging_level).await {
+            match commands::influxdb_ioxd::main(logging_level, Some(Config::from_clap(sub_matches)))
+                .await
+            {
+                Ok(()) => eprintln!("Shutdown OK"),
+                Err(e) => {
+                    error!("Server shutdown with error: {}", e);
+                    std::process::exit(ReturnCode::ServerExitedAbnormally as _);
+                }
+            }
+        }
+        // handle the case where the user didn't specify a command
+        (_, _) => {
+            // Note don't set up basic logging here, different logging rules appy in server
+            // mode
+            println!("InfluxDB IOx server starting");
+            match commands::influxdb_ioxd::main(logging_level, None).await {
                 Ok(()) => eprintln!("Shutdown OK"),
                 Err(e) => {
                     error!("Server shutdown with error: {}", e);
@@ -256,4 +267,23 @@ fn get_runtime(num_threads: Option<&str>) -> Result<Runtime, std::io::Error> {
             }
         }
     }
+}
+
+/// Source the .env file before initialising the Config struct - this sets
+/// any envs in the file, which the Config struct then uses.
+///
+/// Precedence is given to existing env variables.
+fn load_dotenv() {
+    match dotenv() {
+        Ok(_) => {}
+        Err(dotenv::Error::Io(err)) if err.kind() == std::io::ErrorKind::NotFound => {
+            // Ignore this - a missing env file is not an error, defaults will
+            // be applied when initialising the Config struct.
+        }
+        Err(e) => {
+            eprintln!("FATAL Error loading config from: {}", e);
+            eprintln!("Aborting");
+            std::process::exit(1);
+        }
+    };
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -196,28 +196,23 @@ async fn dispatch_args(matches: ArgMatches<'_>) {
         ("server", Some(sub_matches)) => {
             // Note don't set up basic logging here, different logging rules appy in server
             // mode
-            println!("InfluxDB IOx server starting");
-            match commands::influxdb_ioxd::main(logging_level, Some(Config::from_clap(sub_matches)))
-                .await
-            {
-                Ok(()) => eprintln!("Shutdown OK"),
-                Err(e) => {
-                    error!("Server shutdown with error: {}", e);
-                    std::process::exit(ReturnCode::ServerExitedAbnormally as _);
-                }
+            let res =
+                commands::influxdb_ioxd::main(logging_level, Some(Config::from_clap(sub_matches)))
+                    .await;
+
+            if let Err(e) = res {
+                error!("Server shutdown with error: {}", e);
+                std::process::exit(ReturnCode::ServerExitedAbnormally as _);
             }
         }
         // handle the case where the user didn't specify a command
         (_, _) => {
             // Note don't set up basic logging here, different logging rules appy in server
             // mode
-            println!("InfluxDB IOx server starting");
-            match commands::influxdb_ioxd::main(logging_level, None).await {
-                Ok(()) => eprintln!("Shutdown OK"),
-                Err(e) => {
-                    error!("Server shutdown with error: {}", e);
-                    std::process::exit(ReturnCode::ServerExitedAbnormally as _);
-                }
+            let res = commands::influxdb_ioxd::main(logging_level, None).await;
+            if let Err(e) = res {
+                error!("Server shutdown with error: {}", e);
+                std::process::exit(ReturnCode::ServerExitedAbnormally as _);
             }
         }
     }


### PR DESCRIPTION
I often use the -v and -vv arguments to control the logging level (so I don't have to remember the the right logging levels to set). After https://github.com/influxdata/influxdb_iox/pull/640 was merged in I noticed `-v` didn't work any longer (a classic case of me not having put tests in...), and when I was adding it back in I noticed that specifying `influxdb_iox server --log=<>`  didn't actually set the log level either. 

So this PR fixes both of those items