### PR TITLE
build: include jq in CI image

### DIFF
--- a/docker/Dockerfile.ci
+++ b/docker/Dockerfile.ci
@@ -16,6 +16,7 @@ RUN apt-get update \
   && mkdir -p /usr/share/man/man1 \
   && apt-get install -y \
     git make clang cmake llvm \
+    jq \
     --no-install-recommends \
   && git clone -b v1.12.0 -- https://github.com/google/flatbuffers.git /usr/local/src/flatbuffers \
   && cmake -S /usr/local/src/flatbuffers -B /usr/local/src/flatbuffers \


### PR DESCRIPTION
Adds jq to the builder image used for CI runs.

This lets us use some existing scripts provided by the deployments team for
consistency.