### PR TITLE
refactor: clean up public Read Buffer API

### DIFF
--- a/read_buffer/benches/dictionary.rs
+++ b/read_buffer/benches/dictionary.rs
@@ -3,7 +3,7 @@ use rand::distributions::Alphanumeric;
 use rand::prelude::*;
 use rand::Rng;
 
-use read_buffer::{column::cmp::Operator, column::dictionary, column::RowIDs};
+use read_buffer::benchmarks::{dictionary, Operator, RowIDs};
 
 const ROWS: [usize; 3] = [100_000, 1_000_000, 10_000_000];
 const LOCATIONS: [Location; 3] = [Location::Start, Location::Middle, Location::End];

--- a/read_buffer/benches/fixed.rs
+++ b/read_buffer/benches/fixed.rs
@@ -4,8 +4,8 @@ use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Through
 use rand::prelude::*;
 
 use arrow_deps::arrow::datatypes::*;
-use read_buffer::column::fixed::Fixed;
-use read_buffer::column::fixed_null::FixedNull;
+use read_buffer::benchmarks::Fixed;
+use read_buffer::benchmarks::FixedNull;
 
 const ROWS: [usize; 5] = [10, 100, 1_000, 10_000, 60_000];
 const CHUNKS: [Chunks; 4] = [

--- a/read_buffer/benches/plain.rs
+++ b/read_buffer/benches/plain.rs
@@ -4,8 +4,8 @@ use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Through
 use rand::prelude::*;
 
 use arrow_deps::arrow::datatypes::*;
-use read_buffer::column::fixed::Fixed;
-use read_buffer::column::fixed_null::FixedNull;
+use read_buffer::benchmarks::Fixed;
+use read_buffer::benchmarks::FixedNull;
 
 const ROWS: [usize; 5] = [10, 100, 1_000, 10_000, 60_000];
 const CHUNKS: [Chunks; 4] = [

--- a/read_buffer/benches/row_group.rs
+++ b/read_buffer/benches/row_group.rs
@@ -7,9 +7,8 @@ use rand::Rng;
 use rand_distr::{Distribution, Normal};
 
 use packers::{sorter, Packers};
-
-use read_buffer::column::{AggregateType, Column};
-use read_buffer::row_group::{ColumnType, Predicate, RowGroup};
+use read_buffer::benchmarks::{Column, ColumnType, RowGroup};
+use read_buffer::{AggregateType, Predicate};
 
 const ONE_MS: i64 = 1_000_000;
 

--- a/read_buffer/src/chunk.rs
+++ b/read_buffer/src/chunk.rs
@@ -131,10 +131,6 @@ impl Chunk {
     /// Returns the distinct set of table names that contain data that satisfies
     /// the time range and predicates.
     pub fn table_names(&self, predicate: &Predicate) -> BTreeSet<&String> {
-        if !predicate.is_empty() {
-            unimplemented!("Predicate support on `table_names` is not yet implemented");
-        }
-
         self.tables.keys().collect::<BTreeSet<&String>>()
     }
 

--- a/read_buffer/src/lib.rs
+++ b/read_buffer/src/lib.rs
@@ -3,8 +3,8 @@
 #![allow(clippy::too_many_arguments)]
 #![allow(unused_variables)]
 pub(crate) mod chunk;
-pub mod column;
-pub mod row_group;
+pub(crate) mod column;
+pub(crate) mod row_group;
 pub(crate) mod table;
 
 use std::{
@@ -20,10 +20,13 @@ use arrow_deps::arrow::{
 };
 use snafu::{ResultExt, Snafu};
 
+// Identifiers that are exported as part of the public API.
+pub use column::{FIELD_COLUMN_TYPE, TAG_COLUMN_TYPE, TIME_COLUMN_TYPE};
+pub use row_group::{BinaryExpr, Predicate};
+pub use table::ColumnSelection;
+
 use chunk::Chunk;
 use column::AggregateType;
-pub use column::{FIELD_COLUMN_TYPE, TAG_COLUMN_TYPE, TIME_COLUMN_TYPE};
-pub use row_group::Predicate;
 use row_group::{ColumnName, RowGroup};
 use table::Table;
 
@@ -189,7 +192,7 @@ impl Database {
         table_name: &'a str,
         chunk_ids: &[u32],
         predicate: Predicate,
-        select_columns: table::ColumnSelection<'a>,
+        select_columns: ColumnSelection<'a>,
     ) -> Result<ReadFilterResults<'a, '_>> {
         match self.partitions.get(partition_key) {
             Some(partition) => {

--- a/read_buffer/src/lib.rs
+++ b/read_buffer/src/lib.rs
@@ -834,7 +834,7 @@ mod test {
 
         db.upsert_partition("hour_1", 2, "20 Size", gen_recordbatch());
         let data = db
-            .table_names("hour_1", &[22], Predicate::default())
+            .table_names("hour_1", &[2, 22], Predicate::default())
             .unwrap();
         assert_rb_column_equals(
             &data,

--- a/read_buffer/src/lib.rs
+++ b/read_buffer/src/lib.rs
@@ -1017,3 +1017,17 @@ mod test {
         assert!(itr.next().is_none());
     }
 }
+
+/// THIS MODULE SHOULD ONLY BE IMPORTED FOR BENCHMARKS.
+///
+/// This module lets us expose internal parts of the crate so that we can use
+/// libraries like criterion for benchmarking.
+///
+/// It should not be imported into any non-testing or benchmarking crates.
+pub mod benchmarks {
+    pub use crate::column::{
+        cmp::Operator, dictionary, fixed::Fixed, fixed_null::FixedNull, Column, RowIDs,
+    };
+
+    pub use crate::row_group::{ColumnType, RowGroup};
+}

--- a/read_buffer/src/lib.rs
+++ b/read_buffer/src/lib.rs
@@ -296,7 +296,7 @@ impl Database {
     //
 
     /// Returns the distinct set of table names that contain data that satisfies
-    /// the time range and predicates.
+    /// the provided predicate.
     ///
     /// TODO(edd): Implement predicate support.
     pub fn table_names(
@@ -339,14 +339,14 @@ impl Database {
         }
     }
 
-    /// Returns the distinct set of tag keys (column names) matching the
-    /// provided optional predicates and time range.
-    pub fn tag_keys(
+    /// Returns the distinct set of column names (tag keys) that satisfy the
+    /// provided predicate.
+    pub fn column_names(
         &self,
-        table_name: &str,
-        time_range: (i64, i64),
+        partition_key: &str,
+        chunk_ids: &[u32],
         predicate: Predicate,
-    ) -> Option<RecordBatch> {
+    ) -> Result<RecordBatch> {
         // Find all matching chunks using:
         //   - time range
         //   - measurement name.
@@ -355,7 +355,9 @@ impl Database {
         // a chunk allows the caller to provide already found tag keys
         // (column names). This allows the execution to skip entire chunks,
         // tables or segments if there are no new columns to be found there...
-        todo!();
+        Err(Error::UnsupportedOperation {
+            msg: "`column_names` call not yet hooked up".to_owned(),
+        })
     }
 
     /// Returns the distinct set of tag values (column values) for each provided

--- a/read_buffer/src/lib.rs
+++ b/read_buffer/src/lib.rs
@@ -253,7 +253,7 @@ impl Database {
         predicate: Predicate,
         group_columns: ColumnSelection<'_>,
         aggregates: Vec<(ColumnName<'_>, AggregateType)>,
-    ) -> Result<ReadAggregateWindowResults> {
+    ) -> Result<ReadAggregateResults> {
         Err(Error::UnsupportedOperation {
             msg: "`read_aggregate` not yet implemented".to_owned(),
         })
@@ -276,7 +276,7 @@ impl Database {
     ///
     /// `window` should be a positive value indicating a duration in
     /// nanoseconds.
-    pub fn read_aggregate_window(
+    pub fn read_window_aggregate(
         &self,
         partition_key: &str,
         table_name: &str,
@@ -285,7 +285,7 @@ impl Database {
         group_columns: ColumnSelection<'_>,
         aggregates: Vec<(ColumnName<'_>, AggregateType)>,
         window: u64,
-    ) -> Result<ReadAggregateWindowResults> {
+    ) -> Result<ReadWindowAggregateResults> {
         Err(Error::UnsupportedOperation {
             msg: "`read_aggregate_window` not yet implemented".to_owned(),
         })
@@ -297,7 +297,7 @@ impl Database {
     ///
     /// SELECT DISTINCT(column_name) WHERE XYZ
     ///
-    /// In the future the `ReadBuffer` should just proobably just add this
+    /// In the future the `ReadBuffer` should just probably just add this
     /// special execution to read_filter queries with `DISTINCT` expressions
     /// on the selector columns.
     ///
@@ -564,13 +564,13 @@ impl Iterator for ReadAggregateResults {
     }
 }
 
-/// An iterable set of results for calls to `read_aggregate_window`.
+/// An iterable set of results for calls to `read_window_aggregate`.
 ///
 /// There may be some internal buffering and merging of results before a record
 /// batch is emitted from the iterator.
-pub struct ReadAggregateWindowResults {}
+pub struct ReadWindowAggregateResults {}
 
-impl Iterator for ReadAggregateWindowResults {
+impl Iterator for ReadWindowAggregateResults {
     type Item = RecordBatch;
 
     fn next(&mut self) -> Option<Self::Item> {

--- a/read_buffer/src/table.rs
+++ b/read_buffer/src/table.rs
@@ -552,8 +552,10 @@ impl MetaData {
     }
 }
 
-/// A collection of columns, with a variant that implies all columns for the
-/// table should be included.
+/// A collection of columns to include in query results.
+///
+/// The `All` variant denotes that the caller wishes to include all table
+/// columns in the results.
 pub enum ColumnSelection<'a> {
     All,
     Some(&'a [&'a str]),

--- a/server/src/db.rs
+++ b/server/src/db.rs
@@ -279,7 +279,7 @@ pub fn to_read_buffer_predicate(predicate: &Predicate) -> Result<read_buffer::Pr
     match predicate
         .exprs
         .iter()
-        .map(read_buffer::row_group::BinaryExpr::try_from)
+        .map(read_buffer::BinaryExpr::try_from)
         .collect::<Result<Vec<_>, _>>()
     {
         Ok(exprs) => {
@@ -306,7 +306,7 @@ pub mod test {
     use arrow_deps::datafusion::scalar::ScalarValue;
 
     use query::predicate::PredicateBuilder;
-    use read_buffer::row_group::BinaryExpr as RBBinaryExpr;
+    use read_buffer::BinaryExpr as RBBinaryExpr;
     use read_buffer::Predicate as RBPredicate;
 
     #[test]


### PR DESCRIPTION
This PR is a refactoring of the Read Buffer API to provide an externally consumable API, which hopefully won't have to change much.

Currently I have got hooked up:

 - `read_filter`, with predicate support;
 -  `table_names`, without predicate support (this is a drop-in for `SHOW MEASUREMENTS`);

And this PR adds/refactors public stubs for:

 - `read_aggregate` - just a stub at the moment;
 - `read_window_aggregate` - just a stub at the moment;
 - `column_names` -  just a stub at the moment (this is a drop-in for `SHOW TAG KEYS`);
 - `tag_values` - just a stub at the moment (this will support `SHOW TAG VALUES`).

The only extra thing I planned to do here was to not return concrete types but return `Result<impl Iterator<Item = RecordBatch>>` but there are some lifetime things to straighten out first.

Finally, I realise that with this PR I am shutting the door on a lot of the internals I had been exercising with criterion benchmarks. I came up with a solution, though this isn't documented anywhere as a good idea.... 

The idea basically is that I will export a public module `benchmarks` from `read_buffer` that re-exports any implementation details that can be benchmarked by criterion. This is described in commit c6ff633.