### PR TITLE
fix: Get file-based object store working with regards to object store paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2214,6 +2214,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tokio-util",
+ "walkdir",
 ]
 
 [[package]]

--- a/object_store/Cargo.toml
+++ b/object_store/Cargo.toml
@@ -23,6 +23,7 @@ tokio = { version = "0.2", features = ["full"] }
 
 # Filesystem integration
 tokio-util = "0.3.1"
+walkdir = "2"
 
 # Microsoft Azure Blob storage integration
 azure_sdk_core = "0.43.7"

--- a/object_store/src/path.rs
+++ b/object_store/src/path.rs
@@ -784,6 +784,46 @@ mod tests {
     }
 
     #[test]
+    fn path_buf_to_dirs_and_file_name_conversion() {
+        // Last section ending in `.json` is a file name
+        let path_buf = PathRepresentation::RawPathBuf("/one/two/blah.json".into());
+        let path_buf_parts: DirsAndFileName = path_buf.into();
+        assert_eq!(path_buf_parts.directories.len(), 3);
+        assert_eq!(path_buf_parts.file_name.unwrap().0, "blah.json");
+
+        // Last section ending in `.segment` is a file name
+        let path_buf = PathRepresentation::RawPathBuf("/one/two/blah.segment".into());
+        let path_buf_parts: DirsAndFileName = path_buf.into();
+        assert_eq!(path_buf_parts.directories.len(), 3);
+        assert_eq!(path_buf_parts.file_name.unwrap().0, "blah.segment");
+
+        // Last section ending in `.parquet` is a file name
+        let path_buf = PathRepresentation::RawPathBuf("/one/two/blah.parquet".into());
+        let path_buf_parts: DirsAndFileName = path_buf.into();
+        assert_eq!(path_buf_parts.directories.len(), 3);
+        assert_eq!(path_buf_parts.file_name.unwrap().0, "blah.parquet");
+
+        // Last section ending in `.txt` is NOT a file name; we don't recognize that
+        // extension
+        let path_buf = PathRepresentation::RawPathBuf("/one/two/blah.txt".into());
+        let path_buf_parts: DirsAndFileName = path_buf.into();
+        assert_eq!(path_buf_parts.directories.len(), 4);
+        assert!(path_buf_parts.file_name.is_none());
+
+        // Last section containing a `.` isn't a file name
+        let path_buf = PathRepresentation::RawPathBuf("/one/two/blah.blah".into());
+        let path_buf_parts: DirsAndFileName = path_buf.into();
+        assert_eq!(path_buf_parts.directories.len(), 4);
+        assert!(path_buf_parts.file_name.is_none());
+
+        // Last section starting with a `.` isn't a file name (macos temp dirs do this)
+        let path_buf = PathRepresentation::RawPathBuf("/one/two/.blah".into());
+        let path_buf_parts: DirsAndFileName = path_buf.into();
+        assert_eq!(path_buf_parts.directories.len(), 4);
+        assert!(path_buf_parts.file_name.is_none());
+    }
+
+    #[test]
     fn parts_after_prefix_behavior() {
         let mut existing_path = DirsAndFileName::default();
         existing_path.push_all_dirs(&["apple", "bear", "cow", "dog"]);

--- a/object_store/src/path.rs
+++ b/object_store/src/path.rs
@@ -425,7 +425,7 @@ impl FileConverter {
                     .map(|p| &p.0)
                     .collect();
                 if let Some(file_name) = &dirs_and_file_name.file_name {
-                    path.set_file_name(&file_name.0);
+                    path.push(&file_name.0);
                 }
                 path
             }

--- a/object_store/src/path.rs
+++ b/object_store/src/path.rs
@@ -330,7 +330,14 @@ impl From<PathRepresentation> for DirsAndFileName {
                     .collect();
 
                 let maybe_file_name = match parts.pop() {
-                    Some(file) if file.0.contains('.') => Some(file),
+                    Some(file)
+                        if !file.0.starts_with('.')
+                            && (file.0.ends_with(".json")
+                                || file.0.ends_with(".parquet")
+                                || file.0.ends_with(".segment")) =>
+                    {
+                        Some(file)
+                    }
                     Some(dir) => {
                         parts.push(dir);
                         None


### PR DESCRIPTION
This gets the tests working for the `File` object store.

I'm still not completely happy with the structure of these types overall, but I have Jake helping me with that. So this doesn't take care of some of the `todo!`s from [the last PR](https://github.com/influxdata/influxdb_iox/pull/629), but it does make the existing structure function properly at least.