### PR TITLE
build: move serde_json to dev deps for API client

### DIFF
--- a/influxdb_iox_client/Cargo.toml
+++ b/influxdb_iox_client/Cargo.toml
@@ -10,9 +10,9 @@ edition = "2018"
 data_types = { path = "../data_types" }
 reqwest = { version = "0.10.10", features = ["gzip", "json"] } # Latest release using tokio 0.2
 serde = "1.0.118"
-serde_json = "1.0.61"
 thiserror = "1.0.23"
 tokio = { version = "0.2", features = ["net", "tcp", "macros"] }
 
 [dev-dependencies]
 rand = "0.8.1"
+serde_json = "1.0"


### PR DESCRIPTION
The serde_json package is only actually used in tests, so doesn't need to be
part of the API client dependencies.

This also relaxes the version pin as it was conflicting with dependencies in
other projects.