### PR TITLE
feat: Add persistence of database rules

### DIFF
--- a/data_types/src/database_rules.rs
+++ b/data_types/src/database_rules.rs
@@ -256,7 +256,6 @@ pub struct Subscription {
 /// against the row to determine if it matches the write rule.
 #[derive(Debug, Serialize, Deserialize, Eq, PartialEq, Clone)]
 pub struct Matcher {
-    #[serde(flatten)]
     pub tables: MatchTables,
     // TODO: make this work with query::Predicate
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/server/src/config.rs
+++ b/server/src/config.rs
@@ -136,7 +136,7 @@ impl<'a> Drop for CreateDatabaseHandle<'a> {
 #[cfg(test)]
 mod test {
     use super::*;
-    use object_store::path::CloudConverter;
+    use object_store::path::cloud::CloudConverter;
 
     #[test]
     fn create_db() {

--- a/server/src/config.rs
+++ b/server/src/config.rs
@@ -1,0 +1,154 @@
+/// This module contains code for managing the configuration of the server.
+use crate::{db::Db, Error, Result};
+use data_types::{
+    database_rules::{DatabaseRules, HostGroup, HostGroupId},
+    DatabaseName,
+};
+use mutable_buffer::MutableBufferDb;
+use object_store::path::ObjectStorePath;
+use read_buffer::Database as ReadBufferDb;
+
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    sync::{Arc, RwLock},
+};
+
+const DB_RULES_FILE_NAME: &str = "rules.json";
+
+#[derive(Default, Debug)]
+pub(crate) struct Config {
+    state: RwLock<ConfigState>,
+}
+
+impl Config {
+    pub(crate) fn create_db(
+        &self,
+        name: DatabaseName<'static>,
+        rules: DatabaseRules,
+    ) -> Result<CreateDatabaseHandle<'_>> {
+        let mut state = self.state.write().expect("mutex poisoned");
+        if state.reservations.contains(&name) || state.databases.contains_key(&name) {
+            return Err(Error::DatabaseAlreadyExists {
+                db_name: name.to_string(),
+            });
+        }
+
+        let mutable_buffer = if rules.store_locally {
+            Some(Arc::new(MutableBufferDb::new(name.to_string())))
+        } else {
+            None
+        };
+
+        let read_buffer = Arc::new(ReadBufferDb::new());
+
+        let wal_buffer = rules.wal_buffer_config.as_ref().map(Into::into);
+        let db = Arc::new(Db::new(rules, mutable_buffer, read_buffer, wal_buffer));
+
+        state.reservations.insert(name.clone());
+        Ok(CreateDatabaseHandle {
+            db,
+            config: &self,
+            name,
+        })
+    }
+
+    pub(crate) fn db(&self, name: &DatabaseName<'_>) -> Option<Arc<Db>> {
+        let state = self.state.read().expect("mutex poisoned");
+        state.databases.get(name).cloned()
+    }
+
+    pub(crate) fn create_host_group(&self, host_group: HostGroup) {
+        let mut state = self.state.write().expect("mutex poisoned");
+        state
+            .host_groups
+            .insert(host_group.id.clone(), Arc::new(host_group));
+    }
+
+    pub(crate) fn host_group(&self, host_group_id: &str) -> Option<Arc<HostGroup>> {
+        let state = self.state.read().expect("mutex poinsoned");
+        state.host_groups.get(host_group_id).cloned()
+    }
+
+    fn commit(&self, name: &DatabaseName<'static>, db: Arc<Db>) {
+        let mut state = self.state.write().expect("mutex poisoned");
+        let name = state
+            .reservations
+            .take(name)
+            .expect("reservation doesn't exist");
+        assert!(state.databases.insert(name, db).is_none())
+    }
+
+    fn rollback(&self, name: &DatabaseName<'static>) {
+        let mut state = self.state.write().expect("mutex poisoned");
+        state.reservations.remove(name);
+    }
+}
+
+pub fn object_store_path_for_database_config(
+    root: &ObjectStorePath,
+    name: &DatabaseName<'_>,
+) -> ObjectStorePath {
+    let mut path = root.clone();
+    path.push_dir(name.to_string());
+    path.set_file_name(DB_RULES_FILE_NAME);
+    path
+}
+
+#[derive(Default, Debug)]
+struct ConfigState {
+    reservations: BTreeSet<DatabaseName<'static>>,
+    databases: BTreeMap<DatabaseName<'static>, Arc<Db>>,
+    host_groups: BTreeMap<HostGroupId, Arc<HostGroup>>,
+}
+
+#[derive(Debug)]
+pub(crate) struct CreateDatabaseHandle<'a> {
+    pub db: Arc<Db>,
+    pub name: DatabaseName<'static>,
+    config: &'a Config,
+}
+
+impl<'a> CreateDatabaseHandle<'a> {
+    pub(crate) fn commit(self) {
+        self.config.commit(&self.name, self.db.clone())
+    }
+}
+
+impl<'a> Drop for CreateDatabaseHandle<'a> {
+    fn drop(&mut self) {
+        self.config.rollback(&self.name);
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use object_store::path::CloudConverter;
+
+    #[test]
+    fn create_db() {
+        let name = DatabaseName::new("foo").unwrap();
+        let config = Config::default();
+        let rules = DatabaseRules::default();
+
+        {
+            let _db_reservation = config.create_db(name.clone(), rules.clone()).unwrap();
+            let err = config.create_db(name.clone(), rules.clone()).unwrap_err();
+            assert!(matches!(err, Error::DatabaseAlreadyExists{ .. }));
+        }
+
+        let db_reservation = config.create_db(name.clone(), rules).unwrap();
+        db_reservation.commit();
+        assert!(config.db(&name).is_some());
+    }
+
+    #[test]
+    fn object_store_path_for_database_config() {
+        let path = ObjectStorePath::from_cloud_unchecked("1");
+        let name = DatabaseName::new("foo").unwrap();
+        let rules_path = super::object_store_path_for_database_config(&path, &name);
+        let rules_path = CloudConverter::convert(&rules_path);
+
+        assert_eq!(rules_path, "1/foo/rules.json");
+    }
+}

--- a/server/src/db.rs
+++ b/server/src/db.rs
@@ -53,6 +53,8 @@ pub enum Error {
 }
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
+const STARTING_SEQUENCE: u64 = 1;
+
 #[derive(Debug, Serialize, Deserialize)]
 /// This is the main IOx Database object. It is the root object of any
 /// specific InfluxDB IOx instance
@@ -86,7 +88,6 @@ impl Db {
         mutable_buffer: Option<Arc<MutableBufferDb>>,
         read_buffer: Arc<ReadBufferDb>,
         wal_buffer: Option<Buffer>,
-        sequence: AtomicU64,
     ) -> Self {
         let wal_buffer = wal_buffer.map(Mutex::new);
         Self {
@@ -94,7 +95,7 @@ impl Db {
             mutable_buffer,
             read_buffer,
             wal_buffer,
-            sequence,
+            sequence: AtomicU64::new(STARTING_SEQUENCE),
         }
     }
 


### PR DESCRIPTION
This pulls the server configuration into its own module. It updates the config so that databases can be created and saved without holding a write lock across an async call. Follow on work will add reading of these rules from object store on server initialization.