### PR TITLE
fix: Allow arbitrary characters in database names

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -869,6 +869,7 @@ dependencies = [
  "flatbuffers 0.6.1",
  "generated_types",
  "influxdb_line_protocol",
+ "percent-encoding",
  "serde",
  "snafu",
  "tracing",

--- a/data_types/Cargo.toml
+++ b/data_types/Cargo.toml
@@ -16,6 +16,7 @@ chrono = "0.4"
 flatbuffers = "0.6"
 crc32fast = "1.2.0"
 tracing = "0.1"
+percent-encoding = "2.1.0"
 
 [dev-dependencies]
 criterion = "0.3"

--- a/data_types/src/database_name.rs
+++ b/data_types/src/database_name.rs
@@ -16,12 +16,6 @@ pub enum DatabaseNameError {
         LENGTH_CONSTRAINT.end()
     ))]
     LengthConstraint { name: String },
-
-    #[snafu(display(
-        "Database name {} contains invalid characters (allowed: alphanumeric, _,  -, and %)",
-        name
-    ))]
-    BadChars { name: String },
 }
 
 /// A correctly formed database name.
@@ -57,17 +51,6 @@ impl<'a> DatabaseName<'a> {
             return Err(DatabaseNameError::LengthConstraint {
                 name: name.to_string(),
             });
-        }
-
-        // Validate the name contains only valid characters.
-        //
-        // NOTE: If changing these characters, please update the error message
-        // above.
-        if !name
-            .chars()
-            .all(|c| c.is_alphanumeric() || c == '_' || c == '-' || c == '%')
-        {
-            return BadChars { name }.fail();
         }
 
         Ok(Self(name))
@@ -122,7 +105,7 @@ mod tests {
     #[test]
     fn test_deref() {
         let db = DatabaseName::new("my_example_name").unwrap();
-        assert_eq!(&*db, "my_example_name");
+        assert_eq!(db.as_str(), "my_example_name");
     }
 
     #[test]
@@ -148,8 +131,8 @@ mod tests {
     }
 
     #[test]
-    fn test_bad_chars() {
-        let got = DatabaseName::new("example!").unwrap_err();
-        assert!(matches!(got, DatabaseNameError::BadChars { name: _n }));
+    fn test_previously_bad_chars() {
+        let db = DatabaseName::new("example!").unwrap();
+        assert_eq!(db.as_str(), "example!");
     }
 }

--- a/data_types/src/database_name.rs
+++ b/data_types/src/database_name.rs
@@ -18,7 +18,7 @@ pub enum DatabaseNameError {
     LengthConstraint { name: String },
 
     #[snafu(display(
-        "Database name {} contains invalid characters (allowed: alphanumeric, _ and -)",
+        "Database name {} contains invalid characters (allowed: alphanumeric, _,  -, and %)",
         name
     ))]
     BadChars { name: String },
@@ -65,14 +65,16 @@ impl<'a> DatabaseName<'a> {
         // above.
         if !name
             .chars()
-            .all(|c| c.is_alphanumeric() || c == '_' || c == '-')
+            .all(|c| c.is_alphanumeric() || c == '_' || c == '-' || c == '%')
         {
-            return Err(DatabaseNameError::BadChars {
-                name: name.to_string(),
-            });
+            return BadChars { name }.fail();
         }
 
         Ok(Self(name))
+    }
+
+    pub fn as_str(&self) -> &str {
+        self.0.as_ref()
     }
 }
 
@@ -102,7 +104,7 @@ impl<'a> std::ops::Deref for DatabaseName<'a> {
     type Target = str;
 
     fn deref(&self) -> &Self::Target {
-        self.0.as_ref()
+        self.as_str()
     }
 }
 

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -615,7 +615,7 @@ mod tests {
         let server = Server::new(manager, store);
         server.set_id(1);
 
-        let reject: [&str; 5] = [
+        let accept = vec![
             "bananas!",
             r#""bananas\"are\"great"#,
             "bananas:good",
@@ -623,15 +623,15 @@ mod tests {
             "bananas\n",
         ];
 
-        for &name in &reject {
+        for name in accept {
             let rules = DatabaseRules {
                 store_locally: true,
                 ..Default::default()
             };
-            let got = server.create_database(name, rules).await.unwrap_err();
-            if !matches!(got, Error::InvalidDatabaseName { .. }) {
-                panic!("expected invalid name error");
-            }
+            server.create_database(name, rules).await.unwrap();
+            // make sure the database has been created
+            let db_name = DatabaseName::new(name).unwrap();
+            assert!(server.db(&db_name).await.is_some());
         }
 
         Ok(())


### PR DESCRIPTION
Fixes #677 and allows arbitrary characters in database names

Builds off https://github.com/influxdata/influxdb_iox/pull/678

This PR basically removes all character restrictions from `DatabaseNames` on the theory that we will percent encode such names before they appear in paths in object store (which makes sense to me).



- [x] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb_iox/blob/main/README.md).
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
