### PR TITLE
chore: add PublishedAt to get-deploy-tags.sh script

### DIFF
--- a/.circleci/get-deploy-tags.sh
+++ b/.circleci/get-deploy-tags.sh
@@ -41,5 +41,6 @@ jq --null-input --sort-keys \
 		($appKey): {
 		Tag: ($imgPrefix + ":" + $td[0]),
 		Digest: ($imgPrefix + "@" + $td[1]),
-		}
+		},
+		PublishedAt: (now | todateiso8601)
 	}'


### PR DESCRIPTION
Adds PublishedAt to the `get-deploy-tags.sh` script.

- [x] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb_iox/blob/main/README.md).
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
