### PR TITLE
fix: add Images toplevel object to JSON in get-deploy-tags.sh

### DIFF
--- a/.circleci/get-deploy-tags.sh
+++ b/.circleci/get-deploy-tags.sh
@@ -38,9 +38,11 @@ jq --null-input --sort-keys \
 	--arg imgPrefix "${DOCKER_IMAGE}" \
 	--arg appKey "$APP_NAME" \
 	'$tagDigest | split(" ") as $td | {
-		($appKey): {
-		Tag: ($imgPrefix + ":" + $td[0]),
-		Digest: ($imgPrefix + "@" + $td[1]),
+		Images: {
+			($appKey): {
+				Tag: ($imgPrefix + ":" + $td[0]),
+				Digest: ($imgPrefix + "@" + $td[1]),
+			},
 		},
 		PublishedAt: (now | todateiso8601)
 	}'


### PR DESCRIPTION
Fixes the structure of JSON file generated in `get-deploy-tags.sh`

- [x] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb_iox/blob/main/README.md).
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
