### PR TITLE
fix: Allow more flexible database names

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -892,6 +892,7 @@ dependencies = [
  "percent-encoding",
  "serde",
  "snafu",
+ "test_helpers",
  "tracing",
 ]
 

--- a/data_types/Cargo.toml
+++ b/data_types/Cargo.toml
@@ -20,6 +20,7 @@ percent-encoding = "2.1.0"
 
 [dev-dependencies]
 criterion = "0.3"
+test_helpers = { path = "../test_helpers" }
 
 [[bench]]
 name = "benchmark"

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -615,15 +615,13 @@ mod tests {
         let server = Server::new(manager, store);
         server.set_id(1);
 
-        let reject: [&str; 5] = [
-            "bananas!",
-            r#""bananas\"are\"great"#,
-            "bananas:good",
-            "bananas/cavendish",
-            "bananas\n",
+        let reject = vec![
+            "bananas\t",
+            "bananas\"are\u{0099}\"great",
+            "bananas\nfoster",
         ];
 
-        for &name in &reject {
+        for name in reject {
             let rules = DatabaseRules {
                 store_locally: true,
                 ..Default::default()


### PR DESCRIPTION
Fixes #677 and allows any valid UTF-8 string that doesn't have "control" characters to be used as a database name

This PR disallows all ascii characters between 0x00 (null) and 0x1F (unit separator) as well as some more esoteric control codes in [UnicodeData.txt](https://www.unicode.org/Public/UCD/latest/ucd/UnicodeData.txt). This means that characters like \t 'tab' and \n 'newline' are not allowed but space ' ', underscore '_', and minus '-' are.

<img width="1512" alt="Screen Shot 2021-01-21 at 10 34 14 AM" src="https://user-images.githubusercontent.com/490673/105379759-2912de80-5bdb-11eb-9339-4f3a14b0a7ce.png">

- [ ] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb_iox/blob/main/README.md).
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
