### PR TITLE
refactor: Put tests in same file that defines the Structure under test

### DIFF
--- a/query/src/lib.rs
+++ b/query/src/lib.rs
@@ -161,32 +161,3 @@ pub trait DatabaseStore: Debug + Send + Sync {
 //
 //#[cfg(test)]
 pub mod test;
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_timestamp_range_contains() {
-        let range = TimestampRange::new(100, 200);
-        assert!(!range.contains(99));
-        assert!(range.contains(100));
-        assert!(range.contains(101));
-        assert!(range.contains(199));
-        assert!(!range.contains(200));
-        assert!(!range.contains(201));
-    }
-
-    #[test]
-    fn test_timestamp_range_contains_opt() {
-        let range = TimestampRange::new(100, 200);
-        assert!(!range.contains_opt(Some(99)));
-        assert!(range.contains_opt(Some(100)));
-        assert!(range.contains_opt(Some(101)));
-        assert!(range.contains_opt(Some(199)));
-        assert!(!range.contains_opt(Some(200)));
-        assert!(!range.contains_opt(Some(201)));
-
-        assert!(!range.contains_opt(None));
-    }
-}

--- a/query/src/predicate.rs
+++ b/query/src/predicate.rs
@@ -175,3 +175,32 @@ impl PredicateBuilder {
         self.inner
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_timestamp_range_contains() {
+        let range = TimestampRange::new(100, 200);
+        assert!(!range.contains(99));
+        assert!(range.contains(100));
+        assert!(range.contains(101));
+        assert!(range.contains(199));
+        assert!(!range.contains(200));
+        assert!(!range.contains(201));
+    }
+
+    #[test]
+    fn test_timestamp_range_contains_opt() {
+        let range = TimestampRange::new(100, 200);
+        assert!(!range.contains_opt(Some(99)));
+        assert!(range.contains_opt(Some(100)));
+        assert!(range.contains_opt(Some(101)));
+        assert!(range.contains_opt(Some(199)));
+        assert!(!range.contains_opt(Some(200)));
+        assert!(!range.contains_opt(Some(201)));
+
+        assert!(!range.contains_opt(None));
+    }
+}


### PR DESCRIPTION
The struct for `TimestampRange` was moved into a module but its tests did not go along for the ride. Put the tests in the same file as their definition

- [x] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb_iox/blob/main/README.md).
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
