### PR TITLE
ci: trigger image promotion for deployment

### DIFF
--- a/.circleci/get-deploy-tags.sh
+++ b/.circleci/get-deploy-tags.sh
@@ -13,7 +13,9 @@
 # And the image is on the host, executing this script with:
 #	./get-deploy-tags "awesome"
 #
-# Will generate the deployment JSON file.
+# Will generate the deployment JSON file and output it to stdout. If
+# IMAGE_PROMOTION_COMMAND is set in the environment, the deployment JSON file is
+# piped to it at the end of execution.
 
 set -euo pipefail
 
@@ -45,4 +47,12 @@ jq --null-input --sort-keys \
 			},
 		},
 		PublishedAt: (now | todateiso8601)
-	}'
+	}' | tee deploy.json
+
+echo ""
+if [[ -z "${IMAGE_PROMOTION_COMMAND}" ]]; then
+	echo "Skipping image promotion (IMAGE_PROMOTION_COMMAND not set)"
+else
+	echo "Triggering image promotion"
+	eval "${IMAGE_PROMOTION_COMMAND}" < deploy.json 
+fi


### PR DESCRIPTION
Once an image is built and ready, exec the binary defined in the env var
IMAGE_PROMOTION_COMMAND to promote it (if set).

Docs to follow elsewhere.