### PR TITLE
feat: change default log level to INFO

### DIFF
--- a/src/commands/logging.rs
+++ b/src/commands/logging.rs
@@ -49,7 +49,7 @@ impl LoggingLevel {
         const DEFAULT_VERBOSE_LOG_LEVEL: &str = "info";
 
         // Default log level is warn level for all components
-        const DEFAULT_LOG_LEVEL: &str = "warn";
+        const DEFAULT_LOG_LEVEL: &str = "info";
 
         match level {
             Some(lvl) => {


### PR DESCRIPTION
Rationale (from @pauldix 👍 )

> I would think info should be the default log level. Things like what configuration options it’s using on startup, individual requests, etc would be info and I’d expect those to show up in the default logging level.

Changes: Change the default IOx logging level to INFO


- [x] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb_iox/blob/main/README.md).
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
