### PR TITLE
feat: Read Buffer read_aggregate support 

### DIFF
--- a/read_buffer/src/chunk.rs
+++ b/read_buffer/src/chunk.rs
@@ -131,7 +131,7 @@ impl Chunk {
         // Lookup table by name and dispatch execution.
         self.tables
             .get(table_name)
-            .and_then(|table| Some(table.read_aggregate(predicate, group_columns, aggregates)))
+            .map(|table| table.read_aggregate(predicate, group_columns, aggregates))
     }
 
     //

--- a/read_buffer/src/column.rs
+++ b/read_buffer/src/column.rs
@@ -2712,14 +2712,6 @@ impl Value<'_> {
         panic!("cannot unwrap Value to Scalar");
     }
 
-    pub fn try_as_scalar(&self) -> Option<&Scalar> {
-        match &self {
-            Value::Null => None,
-            Value::Scalar(s) => Some(s),
-            _ => panic!("cannot unwrap Value to Scalar"),
-        }
-    }
-
     pub fn string(&self) -> &str {
         if let Self::String(s) = self {
             return s;

--- a/read_buffer/src/column.rs
+++ b/read_buffer/src/column.rs
@@ -2320,6 +2320,156 @@ impl<'a> AggregateResult<'a> {
             (a, b) => unimplemented!("merging {:?} into {:?} not yet implemented", b, a),
         }
     }
+
+    pub fn try_as_str(&self) -> Option<&str> {
+        match &self {
+            AggregateResult::Min(v) => match v {
+                Value::Null => None,
+                Value::String(s) => Some(s),
+                v => panic!("cannot convert {:?} to &str", v),
+            },
+            AggregateResult::Max(v) => match v {
+                Value::Null => None,
+                Value::String(s) => Some(s),
+                v => panic!("cannot convert {:?} to &str", v),
+            },
+            AggregateResult::First(_) => panic!("cannot convert first tuple to &str"),
+            AggregateResult::Last(_) => panic!("cannot convert last tuple to &str"),
+            AggregateResult::Sum(v) => panic!("cannot convert {:?} to &str", v),
+            AggregateResult::Count(_) => panic!("cannot convert count to &str"),
+        }
+    }
+
+    pub fn try_as_bytes(&self) -> Option<&[u8]> {
+        match &self {
+            AggregateResult::Min(v) => match v {
+                Value::Null => None,
+                Value::ByteArray(s) => Some(s),
+                v => panic!("cannot convert {:?} to &[u8]", v),
+            },
+            AggregateResult::Max(v) => match v {
+                Value::Null => None,
+                Value::ByteArray(s) => Some(s),
+                v => panic!("cannot convert {:?} to &[u8]", v),
+            },
+            AggregateResult::First(_) => panic!("cannot convert first tuple to &[u8]"),
+            AggregateResult::Last(_) => panic!("cannot convert last tuple to &[u8]"),
+            AggregateResult::Sum(v) => panic!("cannot convert {:?} to &[u8]", v),
+            AggregateResult::Count(_) => panic!("cannot convert count to &[u8]"),
+        }
+    }
+
+    pub fn try_as_bool(&self) -> Option<bool> {
+        match &self {
+            AggregateResult::Min(v) => match v {
+                Value::Null => None,
+                Value::Boolean(s) => Some(*s),
+                v => panic!("cannot convert {:?} to bool", v),
+            },
+            AggregateResult::Max(v) => match v {
+                Value::Null => None,
+                Value::Boolean(s) => Some(*s),
+                v => panic!("cannot convert {:?} to bool", v),
+            },
+            AggregateResult::First(_) => panic!("cannot convert first tuple to bool"),
+            AggregateResult::Last(_) => panic!("cannot convert last tuple to bool"),
+            AggregateResult::Sum(v) => panic!("cannot convert {:?} to bool", v),
+            AggregateResult::Count(_) => panic!("cannot convert count to bool"),
+        }
+    }
+
+    pub fn try_as_i64_scalar(&self) -> Option<i64> {
+        match &self {
+            AggregateResult::Sum(v) => match v {
+                Scalar::Null => None,
+                Scalar::I64(v) => Some(*v),
+                v => panic!("cannot convert {:?} to i64", v),
+            },
+            AggregateResult::Min(v) => match v {
+                Value::Null => None,
+                Value::Scalar(s) => match s {
+                    Scalar::Null => None,
+                    Scalar::I64(v) => Some(*v),
+                    v => panic!("cannot convert {:?} to u64", v),
+                },
+                v => panic!("cannot convert {:?} to i64", v),
+            },
+            AggregateResult::Max(v) => match v {
+                Value::Null => None,
+                Value::Scalar(s) => match s {
+                    Scalar::Null => None,
+                    Scalar::I64(v) => Some(*v),
+                    v => panic!("cannot convert {:?} to u64", v),
+                },
+                v => panic!("cannot convert {:?} to i64", v),
+            },
+            AggregateResult::First(_) => panic!("cannot convert first tuple to scalar"),
+            AggregateResult::Last(_) => panic!("cannot convert last tuple to scalar"),
+            AggregateResult::Count(_) => panic!("cannot represent count as i64"),
+        }
+    }
+
+    pub fn try_as_u64_scalar(&self) -> Option<u64> {
+        match &self {
+            AggregateResult::Sum(v) => match v {
+                Scalar::Null => None,
+                Scalar::U64(v) => Some(*v),
+                v => panic!("cannot convert {:?} to u64", v),
+            },
+            AggregateResult::Count(c) => Some(*c),
+            AggregateResult::Min(v) => match v {
+                Value::Null => None,
+                Value::Scalar(s) => match s {
+                    Scalar::Null => None,
+                    Scalar::U64(v) => Some(*v),
+                    v => panic!("cannot convert {:?} to u64", v),
+                },
+                v => panic!("cannot convert {:?} to u64", v),
+            },
+            AggregateResult::Max(v) => match v {
+                Value::Null => None,
+                Value::Scalar(s) => match s {
+                    Scalar::Null => None,
+                    Scalar::U64(v) => Some(*v),
+                    v => panic!("cannot convert {:?} to u64", v),
+                },
+                v => panic!("cannot convert {:?} to u64", v),
+            },
+            AggregateResult::First(_) => panic!("cannot convert first tuple to scalar"),
+            AggregateResult::Last(_) => panic!("cannot convert last tuple to scalar"),
+        }
+    }
+
+    pub fn try_as_f64_scalar(&self) -> Option<f64> {
+        match &self {
+            AggregateResult::Sum(v) => match v {
+                Scalar::Null => None,
+                Scalar::F64(v) => Some(*v),
+                v => panic!("cannot convert {:?} to f64", v),
+            },
+            AggregateResult::Min(v) => match v {
+                Value::Null => None,
+                Value::Scalar(s) => match s {
+                    Scalar::Null => None,
+                    Scalar::F64(v) => Some(*v),
+                    v => panic!("cannot convert {:?} to f64", v),
+                },
+                v => panic!("cannot convert {:?} to f64", v),
+            },
+            AggregateResult::Max(v) => match v {
+                Value::Null => None,
+                Value::Scalar(s) => match s {
+                    Scalar::Null => None,
+                    Scalar::F64(v) => Some(*v),
+                    v => panic!("cannot convert {:?} to f64", v),
+                },
+                v => panic!("cannot convert {:?} to f64", v),
+            },
+            AggregateResult::First(_) => panic!("cannot convert first tuple to scalar"),
+            AggregateResult::Last(_) => panic!("cannot convert last tuple to scalar"),
+            AggregateResult::Count(_) => panic!("cannot represent count as f64"),
+        }
+    }
 }
 
 impl From<&AggregateType> for AggregateResult<'_> {
@@ -2380,7 +2530,7 @@ macro_rules! typed_scalar_converters {
                     Self::I64(v) => $type::try_from(*v).ok(),
                     Self::U64(v) => $type::try_from(*v).ok(),
                     Self::F64(v) => panic!("cannot convert Self::F64"),
-                    Self::Null => panic!("cannot convert Scalar::Null"),
+                    Self::Null => None,
                 }
             }
         )*
@@ -2560,6 +2710,14 @@ impl Value<'_> {
             return s;
         }
         panic!("cannot unwrap Value to Scalar");
+    }
+
+    pub fn try_as_scalar(&self) -> Option<&Scalar> {
+        match &self {
+            Value::Null => None,
+            Value::Scalar(s) => Some(s),
+            _ => panic!("cannot unwrap Value to Scalar"),
+        }
     }
 
     pub fn string(&self) -> &str {

--- a/read_buffer/src/lib.rs
+++ b/read_buffer/src/lib.rs
@@ -53,6 +53,9 @@ pub enum Error {
 
     #[snafu(display("unsupported operation: {}", msg))]
     UnsupportedOperation { msg: String },
+
+    #[snafu(display("unsupported aggregate: {}", agg))]
+    UnsupportedAggregate { agg: AggregateType },
 }
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
@@ -283,6 +286,15 @@ impl Database {
                             .get(chunk_id)
                             .ok_or_else(|| Error::ChunkNotFound { id: *chunk_id })?,
                     )
+                }
+
+                for (_, agg) in &aggregates {
+                    match agg {
+                        AggregateType::First | AggregateType::Last => {
+                            return Err(Error::UnsupportedAggregate { agg: *agg });
+                        }
+                        _ => {}
+                    }
                 }
 
                 Ok(ReadAggregateResults::new(

--- a/read_buffer/src/lib.rs
+++ b/read_buffer/src/lib.rs
@@ -305,9 +305,7 @@ impl Database {
                     aggregates,
                 ))
             }
-            None => PartitionNotFound {
-                key: partition_key,
-            }.fail(),
+            None => PartitionNotFound { key: partition_key }.fail(),
         }
     }
 
@@ -1138,6 +1136,7 @@ mod test {
                 vec![
                     ("temp", AggregateType::Sum),
                     ("temp", AggregateType::Min),
+                    ("temp", AggregateType::Max),
                     ("counter", AggregateType::Sum),
                     ("counter", AggregateType::Count),
                 ],
@@ -1155,6 +1154,7 @@ mod test {
 
         assert_rb_column_equals(&result, "temp_sum", &Values::F64(vec![13500.0, 90030.0]));
         assert_rb_column_equals(&result, "temp_min", &Values::F64(vec![4500.0, 10.0]));
+        assert_rb_column_equals(&result, "temp_max", &Values::F64(vec![4500.0, 30000.0]));
         assert_rb_column_equals(&result, "counter_sum", &Values::U64(vec![15000, 12000]));
         assert_rb_column_equals(&result, "counter_count", &Values::U64(vec![3, 6]));
     }

--- a/read_buffer/src/lib.rs
+++ b/read_buffer/src/lib.rs
@@ -257,18 +257,46 @@ impl Database {
     ///
     /// This method might be deprecated in the future, replaced by a call to
     /// `read_aggregate_window` with a `window` of `0`.
-    pub fn read_aggregate(
+    pub fn read_aggregate<'input>(
         &self,
         partition_key: &str,
-        table_name: &str,
+        table_name: &'input str,
         chunk_ids: &[u32],
         predicate: Predicate,
-        group_columns: ColumnSelection<'_>,
-        aggregates: Vec<(ColumnName<'_>, AggregateType)>,
-    ) -> Result<ReadAggregateResults> {
-        Err(Error::UnsupportedOperation {
-            msg: "`read_aggregate` not yet implemented".to_owned(),
-        })
+        group_columns: ColumnSelection<'input>,
+        aggregates: Vec<(ColumnName<'input>, AggregateType)>,
+    ) -> Result<ReadAggregateResults<'input, '_>> {
+        match self.partitions.get(partition_key) {
+            Some(partition) => {
+                let mut chunks = vec![];
+                for chunk_id in chunk_ids {
+                    let chunk = partition
+                        .chunks
+                        .get(chunk_id)
+                        .context(ChunkNotFound { id: *chunk_id })?;
+
+                    ensure!(chunk.has_table(table_name), TableNotFound { table_name });
+
+                    chunks.push(
+                        partition
+                            .chunks
+                            .get(chunk_id)
+                            .ok_or_else(|| Error::ChunkNotFound { id: *chunk_id })?,
+                    )
+                }
+
+                Ok(ReadAggregateResults::new(
+                    chunks,
+                    table_name,
+                    predicate,
+                    group_columns,
+                    aggregates,
+                ))
+            }
+            None => Err(Error::PartitionNotFound {
+                key: partition_key.to_owned(),
+            }),
+        }
     }
 
     /// Returns windowed aggregates for each group specified by the values of
@@ -585,15 +613,68 @@ impl<'input, 'chunk> Iterator for ReadFilterResults<'input, 'chunk> {
 
 /// An iterable set of results for calls to `read_aggregate`.
 ///
-/// There may be some internal buffering and merging of results before a record
-/// batch can be emitted from the iterator.
-pub struct ReadAggregateResults {}
+/// The iterator lazily executes against each chunk on a call to `next`.
+/// Currently all row group results inside the chunk's table are merged before
+/// this iterator returns a record batch. Therefore the caller can expect at
+/// most one record batch to be yielded for each chunk.
+pub struct ReadAggregateResults<'input, 'chunk> {
+    chunks: Vec<&'chunk Chunk>,
+    next_i: usize,
 
-impl Iterator for ReadAggregateResults {
+    table_name: &'input str,
+    predicate: Predicate,
+    group_columns: table::ColumnSelection<'input>,
+    aggregates: Vec<(ColumnName<'input>, AggregateType)>,
+}
+
+impl<'input, 'chunk> ReadAggregateResults<'input, 'chunk> {
+    fn new(
+        chunks: Vec<&'chunk Chunk>,
+        table_name: &'input str,
+        predicate: Predicate,
+        group_columns: table::ColumnSelection<'input>,
+        aggregates: Vec<(ColumnName<'input>, AggregateType)>,
+    ) -> Self {
+        Self {
+            chunks,
+            next_i: 0,
+            table_name,
+            predicate,
+            group_columns,
+            aggregates,
+        }
+    }
+}
+
+impl<'input, 'chunk> Iterator for ReadAggregateResults<'input, 'chunk> {
     type Item = RecordBatch;
 
     fn next(&mut self) -> Option<Self::Item> {
-        None
+        if self.next_i == self.chunks.len() {
+            return None;
+        }
+
+        let curr_i = self.next_i;
+        self.next_i += 1;
+
+        // execute against next chunk
+        match &mut self.chunks[curr_i].read_aggregate(
+            self.table_name,
+            self.predicate.clone(),
+            &self.group_columns,
+            &self.aggregates,
+        ) {
+            Some(results_itr) => {
+                let mut row_group_results = results_itr.collect::<Vec<_>>();
+                // table current emits at most one merged result.
+                match row_group_results.len() {
+                    0 => self.next(), // no results try next chunk's table
+                    1 => Some(row_group_results.remove(0).try_into().unwrap()),
+                    _ => panic!("currently expect at most one result"),
+                }
+            }
+            None => self.next(), // try next chunk
+        }
     }
 }
 
@@ -634,7 +715,7 @@ mod test {
         array::{
             ArrayRef, BinaryArray, BooleanArray, Float64Array, Int64Array, StringArray, UInt64Array,
         },
-        datatypes::DataType::Float64,
+        datatypes::DataType::{Float64, UInt64},
     };
 
     use column::Values;
@@ -996,6 +1077,74 @@ mod test {
 
         // No matching data for chunk 3, so iteration ends.
         assert!(itr.next().is_none());
+    }
+
+    #[test]
+    fn read_aggregate_multiple_row_groups() {
+        let mut db = Database::new();
+
+        // Add a bunch of row groups to a single table in a single chunks
+        for &i in &[100, 200, 300] {
+            let schema = SchemaBuilder::new()
+                .non_null_tag("env")
+                .non_null_tag("region")
+                .non_null_field("temp", Float64)
+                .non_null_field("counter", UInt64)
+                .timestamp()
+                .build()
+                .unwrap();
+
+            let data: Vec<ArrayRef> = vec![
+                Arc::new(StringArray::from(vec!["prod", "dev", "prod"])),
+                Arc::new(StringArray::from(vec!["west", "west", "east"])),
+                Arc::new(Float64Array::from(vec![10.0, 30000.0, 4500.0])),
+                Arc::new(UInt64Array::from(vec![1000, 3000, 5000])),
+                Arc::new(Int64Array::from(vec![i, 20 * i, 30 * i])),
+            ];
+
+            // Add a record batch to a single partition
+            let rb = RecordBatch::try_new(schema.into(), data).unwrap();
+            println!("rb {:?} {:?}", i, &rb);
+            // The row group gets added to the same chunk each time.
+            db.upsert_partition("hour_1", 1, "table1", rb);
+        }
+
+        // Build the following query:
+        //
+        //   SELECT SUM("temp"), MIN("temp"), SUM("counter"), COUNT("counter")
+        //   FROM "table_1"
+        //   GROUP BY "region"
+        //
+
+        let itr = db
+            .read_aggregate(
+                "hour_1",
+                "table1",
+                &[1],
+                Predicate::default(),
+                table::ColumnSelection::Some(&["region"]),
+                vec![
+                    ("temp", AggregateType::Sum),
+                    ("temp", AggregateType::Min),
+                    ("counter", AggregateType::Sum),
+                    ("counter", AggregateType::Count),
+                ],
+            )
+            .unwrap();
+        let result = itr.collect::<Vec<RecordBatch>>();
+        assert_eq!(result.len(), 1);
+        let result = &result[0];
+
+        assert_rb_column_equals(
+            &result,
+            "region",
+            &Values::String(vec![Some("east"), Some("west")]),
+        );
+
+        assert_rb_column_equals(&result, "temp_sum", &Values::F64(vec![13500.0, 90030.0]));
+        assert_rb_column_equals(&result, "temp_min", &Values::F64(vec![4500.0, 10.0]));
+        assert_rb_column_equals(&result, "counter_sum", &Values::U64(vec![15000, 12000]));
+        assert_rb_column_equals(&result, "counter_count", &Values::U64(vec![3, 6]));
     }
 }
 

--- a/read_buffer/src/lib.rs
+++ b/read_buffer/src/lib.rs
@@ -305,9 +305,9 @@ impl Database {
                     aggregates,
                 ))
             }
-            None => Err(Error::PartitionNotFound {
-                key: partition_key.to_owned(),
-            }),
+            None => PartitionNotFound {
+                key: partition_key,
+            }.fail(),
         }
     }
 

--- a/read_buffer/src/row_group.rs
+++ b/read_buffer/src/row_group.rs
@@ -1206,6 +1206,7 @@ impl<'row_group> AggregateResults<'row_group> {
     }
 
     fn merge(&mut self, other: &AggregateResults<'row_group>) {
+        assert_eq!(self.0.len(), other.len());
         for (i, agg) in self.0.iter_mut().enumerate() {
             agg.merge(&other.0[i]);
         }

--- a/read_buffer/src/schema.rs
+++ b/read_buffer/src/schema.rs
@@ -9,7 +9,7 @@ use data_types::schema::InfluxFieldType;
 /// This schema is useful for helping with displaying information in tests and
 /// decorating Arrow record batches when results are converted before leaving
 /// the read buffer.
-#[derive(Default, PartialEq, Debug)]
+#[derive(Default, PartialEq, Debug, Clone)]
 pub struct ResultSchema {
     pub select_columns: Vec<(ColumnType, LogicalDataType)>,
     pub group_columns: Vec<(ColumnType, LogicalDataType)>,

--- a/read_buffer/src/schema.rs
+++ b/read_buffer/src/schema.rs
@@ -1,6 +1,5 @@
 use std::{convert::TryFrom, fmt::Display};
 
-use arrow::array;
 use arrow_deps::arrow;
 use data_types::schema::InfluxFieldType;
 
@@ -151,21 +150,6 @@ pub enum LogicalDataType {
     String,   // UTF-8 valid string
     Binary,   // Arbitrary collection of bytes
     Boolean,  //
-}
-
-impl LogicalDataType {
-    /// Returns an Arrow array builder for the `LogicalDataType` with
-    /// `capacity`.
-    pub fn arrow_builder(&self, capacity: usize) -> Box<dyn array::ArrayBuilder> {
-        match &self {
-            LogicalDataType::Integer => Box::new(array::Int64Builder::new(capacity)),
-            LogicalDataType::Unsigned => Box::new(array::UInt64Builder::new(capacity)),
-            LogicalDataType::Float => Box::new(array::Float64Builder::new(capacity)),
-            LogicalDataType::String => Box::new(array::StringBuilder::new(capacity)),
-            LogicalDataType::Binary => Box::new(array::BinaryBuilder::new(capacity)),
-            LogicalDataType::Boolean => Box::new(array::BooleanBuilder::new(capacity)),
-        }
-    }
 }
 
 impl From<&LogicalDataType> for arrow::datatypes::DataType {


### PR DESCRIPTION
This PR adds some initial support for `read_aggregate`, including predicate support.

Currently supported aggregates:

 - SUM
 - COUNT
 - MIN
 - MAX

First/Last are not hooked up in the read buffer yet.

Further, you can only currently group on tag columns. This means you can't do time-based windowing; that will arrive with `read_windowed_aggregate`.

The Read Buffer will merge multiple results from row groups within the same table automatically, but they're collected lazily, which is cool. Each chunk is also processed lazily.

**Note**: I want to get this in so there is simply some working `read_aggregate` support to keep things moving but I'm not happy with the design and I plan to change how aggregates are built up and materialised to be more "SOA" than "AOS".