### PR TITLE
feat: gRPC measurement_names support for read buffer

### DIFF
--- a/server/src/db.rs
+++ b/server/src/db.rs
@@ -737,20 +737,56 @@ mod test_influxrpc {
     #[async_trait]
     impl DBSetup for TwoMeasurements {
         async fn make(&self) -> Vec<DBScenario> {
-            let db = make_db();
+            let partition_key = "1970-01-01T00";
             let data = "cpu,region=west user=23.2 100\n\
                         cpu,region=west user=21.0 150\n\
                         disk,region=east bytes=99i 200";
 
+            let db = make_db();
             let mut writer = TestLPWriter::default();
-
             writer.write_lp_string(&db, data).await.unwrap();
-            vec![
-                DBScenario {
-                    scenario_name: "Data in open chunk of mutable buffer".into(),
-                    db,
-                }, // todo add a scenario where the database has had data loaded and then deleted
-            ]
+            let scenario1 = DBScenario {
+                scenario_name: "Data in open chunk of mutable buffer".into(),
+                db,
+            };
+
+            let db = make_db();
+            let mut writer = TestLPWriter::default();
+            writer.write_lp_string(&db, data).await.unwrap();
+            db.rollover_partition(partition_key).await.unwrap();
+            let scenario2 = DBScenario {
+                scenario_name: "Data in closed chunk of mutable buffer".into(),
+                db,
+            };
+
+            let db = make_db();
+            let mut writer = TestLPWriter::default();
+            writer.write_lp_string(&db, data).await.unwrap();
+            db.rollover_partition(partition_key).await.unwrap();
+            db.load_chunk_to_read_buffer(partition_key, 0)
+                .await
+                .unwrap();
+            let scenario3 = DBScenario {
+                scenario_name: "Data in both read buffer and mutable buffer".into(),
+                db,
+            };
+
+            let db = make_db();
+            let mut writer = TestLPWriter::default();
+            writer.write_lp_string(&db, data).await.unwrap();
+            db.rollover_partition(partition_key).await.unwrap();
+            db.load_chunk_to_read_buffer(partition_key, 0)
+                .await
+                .unwrap();
+            db.drop_mutable_buffer_chunk(partition_key, 0)
+                .await
+                .unwrap();
+            let scenario4 = DBScenario {
+                scenario_name: "Data in only buffer and not mutable buffer".into(),
+                db,
+            };
+
+            vec![scenario1, scenario2, scenario3, scenario4]
         }
     }
 


### PR DESCRIPTION
This PR adds proper support for `meausrement_names` for gRPC queries to data in the read buffer.  It is the first time gRPC requests will include data in the read buffer 🎉 

~The only slightly sketchy bit is skipping the predicate scenarios with the read buffer (as predicate's are not yet supported there). I'll add some notes inline~
(update: sketchy bit removed as https://github.com/influxdata/influxdb_iox/pull/698 merged)

- [x] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb_iox/blob/main/README.md).
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
