### PR TITLE
feat: add predicate support to `table_names` in the Read Buffer

### DIFF
--- a/read_buffer/Cargo.toml
+++ b/read_buffer/Cargo.toml
@@ -32,6 +32,10 @@ rand = "0.7.3"
 rand_distr = "0.3.0"
 
 [[bench]]
+name = "database"
+harness = false
+
+[[bench]]
 name = "fixed"
 harness = false
 

--- a/read_buffer/benches/database.rs
+++ b/read_buffer/benches/database.rs
@@ -1,0 +1,148 @@
+use std::sync::Arc;
+
+use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
+
+use arrow_deps::arrow::{
+    array::{ArrayRef, Int64Array, StringArray},
+    record_batch::RecordBatch,
+};
+use data_types::schema::builder::SchemaBuilder;
+use read_buffer::{BinaryExpr, Database, Predicate};
+
+const BASE_TIME: i64 = 1351700038292387000_i64;
+const ONE_MS: i64 = 1_000_000;
+
+fn table_names(c: &mut Criterion) {
+    let rb = generate_row_group(500_000);
+    let mut db = Database::new();
+    db.upsert_partition("hour_1", 0, "table_a", rb.clone());
+
+    // no predicate - return all the tables
+    benchmark_table_names(
+        c,
+        "database_table_names_all_tables",
+        &db,
+        &[0],
+        Predicate::default(),
+        1,
+    );
+
+    // predicate - meta data proves not present
+    benchmark_table_names(
+        c,
+        "database_table_names_meta_pred_no_match",
+        &db,
+        &[0],
+        Predicate::new(vec![BinaryExpr::from(("env", "=", "zoo"))]),
+        0,
+    );
+
+    // predicate - single predicate match
+    benchmark_table_names(
+        c,
+        "database_table_names_single_pred_match",
+        &db,
+        &[0],
+        Predicate::new(vec![BinaryExpr::from(("env", "=", "prod"))]),
+        1,
+    );
+
+    // predicate - multi predicate match
+    benchmark_table_names(
+        c,
+        "database_table_names_multi_pred_match",
+        &db,
+        &[0],
+        Predicate::new(vec![
+            BinaryExpr::from(("env", "=", "prod")),
+            BinaryExpr::from(("time", ">=", BASE_TIME)),
+            BinaryExpr::from(("time", "<", BASE_TIME + (ONE_MS * 10000))),
+        ]),
+        1,
+    );
+
+    // Add the table into ten more chunks. Show that performance is not impacted.
+    for chunk_id in 1..=10 {
+        db.upsert_partition("hour_1", chunk_id, "table_a", rb.clone());
+    }
+
+    // predicate - multi predicate match on all chunks
+    benchmark_table_names(
+        c,
+        "database_table_names_multi_pred_match_multi_tables",
+        &db,
+        &(0..=10).into_iter().collect::<Vec<_>>(),
+        Predicate::new(vec![
+            BinaryExpr::from(("env", "=", "prod")),
+            BinaryExpr::from(("time", ">=", BASE_TIME)),
+            BinaryExpr::from(("time", "<", BASE_TIME + (ONE_MS * 10000))),
+        ]),
+        1,
+    );
+}
+
+fn benchmark_table_names(
+    c: &mut Criterion,
+    bench_name: &str,
+    database: &Database,
+    chunk_ids: &[u32],
+    predicate: Predicate,
+    expected_rows: usize,
+) {
+    c.bench_function(bench_name, |b| {
+        b.iter_batched(
+            || predicate.clone(), // don't want to time predicate cloning
+            |predicate: Predicate| {
+                let tables = database
+                    .table_names("hour_1", chunk_ids, predicate)
+                    .unwrap();
+                assert_eq!(tables.num_rows(), expected_rows);
+            },
+            BatchSize::SmallInput,
+        );
+    });
+}
+
+// generate a row group with three columns of varying cardinality.
+fn generate_row_group(rows: usize) -> RecordBatch {
+    let schema = SchemaBuilder::new()
+        .non_null_tag("env")
+        .non_null_tag("container_id")
+        .timestamp()
+        .build()
+        .unwrap();
+
+    let container_ids = (0..rows)
+        .into_iter()
+        .map(|i| format!("my_container_{:?}", i))
+        .collect::<Vec<_>>();
+
+    let data: Vec<ArrayRef> = vec![
+        // sorted 2 cardinality column
+        Arc::new(StringArray::from(
+            (0..rows)
+                .into_iter()
+                .map(|i| if i < rows / 2 { "prod" } else { "dev" })
+                .collect::<Vec<_>>(),
+        )),
+        // completely unique cardinality column
+        Arc::new(StringArray::from(
+            container_ids
+                .iter()
+                .map(|id| id.as_str())
+                .collect::<Vec<_>>(),
+        )),
+        // ms increasing time column;
+        Arc::new(Int64Array::from(
+            (0..rows)
+                .into_iter()
+                .map(|i| BASE_TIME + (i as i64 * ONE_MS))
+                .collect::<Vec<_>>(),
+        )),
+    ];
+
+    RecordBatch::try_new(schema.into(), data).unwrap()
+}
+
+criterion_group!(benches, table_names);
+criterion_main!(benches);

--- a/read_buffer/src/lib.rs
+++ b/read_buffer/src/lib.rs
@@ -378,12 +378,6 @@ impl Database {
         chunk_ids: &[u32],
         predicate: Predicate,
     ) -> Result<RecordBatch> {
-        if !predicate.is_empty() {
-            return Err(Error::UnsupportedOperation {
-                msg: "predicate support on `table_names` not implemented".to_owned(),
-            });
-        }
-
         let partition = self
             .partitions
             .get(partition_key)
@@ -395,7 +389,10 @@ impl Database {
         let names = chunks
             .iter()
             .fold(BTreeSet::new(), |mut names, chunk| {
-                names.append(&mut chunk.table_names(&predicate, &BTreeSet::new()));
+                // notice that `names` is pushed into the chunk `table_name`
+                // implementation. This ensure we don't process more tables than
+                // we need to.
+                names.append(&mut chunk.table_names(&predicate, &names));
                 names
             })
             // have a BTreeSet here, convert to an iterator of Some(&str)
@@ -907,24 +904,25 @@ mod test {
     #[test]
     fn table_names() {
         let mut db = Database::new();
+        let res_col = TABLE_NAMES_COLUMN_NAME;
 
         db.upsert_partition("hour_1", 22, "Coolverine", gen_recordbatch());
         let data = db
             .table_names("hour_1", &[22], Predicate::default())
             .unwrap();
-        assert_rb_column_equals(&data, "table", &Values::String(vec![Some("Coolverine")]));
+        assert_rb_column_equals(&data, res_col, &Values::String(vec![Some("Coolverine")]));
 
         db.upsert_partition("hour_1", 22, "Coolverine", gen_recordbatch());
         let data = db
             .table_names("hour_1", &[22], Predicate::default())
             .unwrap();
-        assert_rb_column_equals(&data, "table", &Values::String(vec![Some("Coolverine")]));
+        assert_rb_column_equals(&data, res_col, &Values::String(vec![Some("Coolverine")]));
 
         db.upsert_partition("hour_1", 2, "Coolverine", gen_recordbatch());
         let data = db
             .table_names("hour_1", &[22], Predicate::default())
             .unwrap();
-        assert_rb_column_equals(&data, "table", &Values::String(vec![Some("Coolverine")]));
+        assert_rb_column_equals(&data, res_col, &Values::String(vec![Some("Coolverine")]));
 
         db.upsert_partition("hour_1", 2, "20 Size", gen_recordbatch());
         let data = db
@@ -932,7 +930,20 @@ mod test {
             .unwrap();
         assert_rb_column_equals(
             &data,
-            "table",
+            res_col,
+            &Values::String(vec![Some("20 Size"), Some("Coolverine")]),
+        );
+
+        let data = db
+            .table_names(
+                "hour_1",
+                &[2, 22],
+                Predicate::new(vec![BinaryExpr::from(("region", ">", "north"))]),
+            )
+            .unwrap();
+        assert_rb_column_equals(
+            &data,
+            res_col,
             &Values::String(vec![Some("20 Size"), Some("Coolverine")]),
         );
     }

--- a/read_buffer/src/lib.rs
+++ b/read_buffer/src/lib.rs
@@ -395,7 +395,7 @@ impl Database {
         let names = chunks
             .iter()
             .fold(BTreeSet::new(), |mut names, chunk| {
-                names.append(&mut chunk.table_names(&predicate));
+                names.append(&mut chunk.table_names(&predicate, &BTreeSet::new()));
                 names
             })
             // have a BTreeSet here, convert to an iterator of Some(&str)


### PR DESCRIPTION
This PR adds support for pushing predicates down into the `table_names` implementation in the Read Buffer.

In terms of InfluxDB-type meta queries, this will provide the ability to answer queries like `SHOW MEASUREMENTS WHERE "region" = 'foo' AND time > 100 AND time <= 2000`. Currently, as with other Read Buffer operations only conjunctive binary expressions are supported.

The Read Buffer will answer this operation pretty quickly. Within this implementation it know how to:

 - skip row groups that cannot possible satisfy all expressions on a predicate (column pruning);
 - skip tables that cannot possible satisfy all expressions on a table (row group pruning);
 - skip tables that have already been returned from other chunks;
 - return early if a row group contains rows satisfying the predicate.

Assuming that it is not possible to rule out a table from pruning/meta-data checking the execution engine will then attempt to identify one or more rows in a row group in a table that satisfy the predicate.

Currently the implementation works by processing each expression in turn (each expression targets a single column) and generating a bitset of all matching ordinal positions within the column. No logical values are materialised. Bitsets from each expression are then combined to produce a final row set. If this set is non-empty then the row group contains at least one row satisfying the predicate. The operation short-circuits and the table name is added to the result set.

Of course, this could be faster... For large row groups this is doing more work than it possibly needs to because it's effectively finding all rows that pass the predicate rather than one. It could be quicker to work row-wise rather than column-wise, but of course if the row that passes the predicate is down the bottom of the table you're going to have a bad time dot com processing row wise.

So for now I have stuck to the existing execution engine approach I built out for the normal read path.

I have also added an optimisation that will help when running this query across many chunks. Namely that if all of those chunks are provided the Read Buffer will skip processing tables that have already been identified as part of the results in previous chunks. This will significantly improve the execution time of `table_name`, so callers should batch up chunks and pass them all in when possible.

Finally, I have added some benchmarks to get a feel for the performance of `table_names` in the Read Buffer. The full results are in the commit log but broadly speaking on my laptop, for a table with a single row group with **500,000** rows in it:

 - table matches because predicate is empty: **~2.3 us**
 - table can't match predicate based on pruning: **~1.9 us**
 - table matches a single predicate on "tag" column: **5.5 us**
 - table matches tag predicate and time range predicate: **480 us**
 - table matches tag/time predicate across ten chunks:: **478 us** 

The third result is able to leverage the compressed columnar encoding to produce a bitset of matching rows in constant time. 

The fourth result has to process all 500,000 rows in the timestamp column, so a result `<500 us` means it is processing about a billion rows per second. 

The fifth result shows that the Read Buffer short circuits the table in the other nine chunks when it finds the table matches in the first one. Of course, it will process those chunks for other tables if necessary.

