### PR TITLE
feat: Add selection interface to mutable buffer and query interface

### DIFF
--- a/mutable_buffer/src/database.rs
+++ b/mutable_buffer/src/database.rs
@@ -919,6 +919,8 @@ impl Visitor for WindowGroupsVisitor {
 
 #[cfg(test)]
 mod tests {
+    use crate::chunk::ChunkSelection;
+
     use super::*;
     use query::{
         exec::fieldlist::{Field, FieldList},
@@ -973,8 +975,9 @@ mod tests {
 
         let chunk = db.get_chunk(partition_key, 0).await.unwrap();
         let mut batches = Vec::new();
+        let selection = ChunkSelection::Some(&["region", "core"]);
         chunk
-            .table_to_arrow(&mut batches, "cpu", &["region", "core"])
+            .table_to_arrow(&mut batches, "cpu", selection)
             .unwrap();
         let columns = batches[0].columns();
 

--- a/mutable_buffer/src/partition.rs
+++ b/mutable_buffer/src/partition.rs
@@ -252,6 +252,8 @@ impl<'a> Iterator for ChunkIter<'a> {
 
 #[cfg(test)]
 mod tests {
+    use crate::chunk::ChunkSelection;
+
     use super::*;
     use chrono::Utc;
     use data_types::data::split_lines_into_write_entry_partitions;
@@ -815,10 +817,10 @@ mod tests {
 
     fn dump_table(partition: &Partition, table_name: &str) -> Vec<RecordBatch> {
         let mut dst = vec![];
-        let requested_columns = []; // empty ==> request all columns
         for chunk in partition.chunks() {
+            let selection = ChunkSelection::All;
             chunk
-                .table_to_arrow(&mut dst, table_name, &requested_columns)
+                .table_to_arrow(&mut dst, table_name, selection)
                 .unwrap();
         }
 
@@ -827,10 +829,10 @@ mod tests {
     }
 
     fn dump_chunk_table(chunk: &Chunk, table_name: &str) -> Vec<RecordBatch> {
-        let requested_columns = []; // empty ==> request all columns
         let mut dst = vec![];
+        let selection = ChunkSelection::All;
         chunk
-            .table_to_arrow(&mut dst, table_name, &requested_columns)
+            .table_to_arrow(&mut dst, table_name, selection)
             .unwrap();
         dst.into_iter().map(sort_record_batch).collect()
     }

--- a/mutable_buffer/src/table.rs
+++ b/mutable_buffer/src/table.rs
@@ -11,7 +11,7 @@ use std::{collections::BTreeSet, collections::HashMap, sync::Arc};
 
 use crate::{
     chunk::ChunkIdSet,
-    chunk::{Chunk, ChunkPredicate},
+    chunk::{Chunk, ChunkPredicate, ChunkSelection},
     column,
     column::Column,
     dictionary::{Dictionary, Error as DictionaryError},
@@ -282,10 +282,11 @@ impl Table {
         let time_column_id = chunk_predicate.time_column_id;
 
         // figure out the tag columns
-        let requested_columns_with_index = self
-            .column_id_to_index
-            .iter()
-            .filter_map(|(&column_id, &column_index)| {
+        let selection = TableColSelection::with_capacity(self.column_id_to_index.len());
+
+        let selection = self.column_id_to_index.iter().fold(
+            selection,
+            |selection, (&column_id, &column_index)| {
                 // keep tag columns and the timestamp column, if needed to evaluate a timestamp
                 // predicate
                 let need_column = if let Column::Tag(_, _) = self.columns[column_index] {
@@ -297,15 +298,15 @@ impl Table {
                 if need_column {
                     // the id came out of our map, so it should always be valid
                     let column_name = chunk.dictionary.lookup_id(column_id).unwrap();
-                    Some((column_name, column_index))
+                    selection.add_column(column_name, column_index)
                 } else {
-                    None
+                    selection
                 }
-            })
-            .collect::<Vec<_>>();
+            },
+        );
 
         // TODO avoid materializing here
-        let data = self.to_arrow_impl(chunk, &requested_columns_with_index)?;
+        let data = self.to_arrow_impl(chunk, &selection)?;
 
         let schema = data.schema();
 
@@ -321,11 +322,12 @@ impl Table {
             plan_builder
         } else {
             // Create expressions for all columns except time
-            let select_exprs = requested_columns_with_index
+            let select_exprs = selection
+                .cols
                 .iter()
-                .filter_map(|&(column_name, _)| {
-                    if column_name != TIME_COLUMN_NAME {
-                        Some(col(column_name))
+                .filter_map(|col_selection| {
+                    if col_selection.column_name != TIME_COLUMN_NAME {
+                        Some(col(col_selection.column_name))
                     } else {
                         None
                     }
@@ -460,7 +462,8 @@ impl Table {
     ) -> Result<LogicalPlanBuilder> {
         // TODO avoid materializing all the columns here (ideally
         // DataFusion can prune some of them out)
-        let data = self.all_to_arrow(chunk)?;
+        let selection = self.all_columns_selection(chunk)?;
+        let data = self.to_arrow_impl(chunk, &selection)?;
 
         let schema = data.schema();
 
@@ -791,20 +794,7 @@ impl Table {
         field_columns
     }
 
-    /// Converts this table to an arrow record batch.
-    ///
-    /// If requested_columns is empty (`[]`), retrieve all columns in
-    /// the table
-    pub fn to_arrow(&self, chunk: &Chunk, requested_columns: &[&str]) -> Result<RecordBatch> {
-        if requested_columns.is_empty() {
-            self.all_to_arrow(chunk)
-        } else {
-            let columns_with_index = self.column_names_with_index(chunk, requested_columns)?;
-
-            self.to_arrow_impl(chunk, &columns_with_index)
-        }
-    }
-
+    /// Return the index of the column named `column_name`
     fn column_index(&self, chunk: &Chunk, column_name: &str) -> Result<usize> {
         let column_id =
             chunk
@@ -824,55 +814,75 @@ impl Table {
             })
     }
 
-    /// Returns (name, index) pairs for all named columns
-    fn column_names_with_index<'a>(
-        &self,
-        chunk: &Chunk,
-        columns: &[&'a str],
-    ) -> Result<Vec<(&'a str, usize)>> {
-        columns
-            .iter()
-            .map(|&column_name| {
-                let column_index = self.column_index(chunk, column_name)?;
+    /// Returns the column selection for all the columns in this table, orderd
+    /// by table name
+    fn all_columns_selection<'a>(&self, chunk: &'a Chunk) -> Result<TableColSelection<'a>> {
+        let selection = TableColSelection::with_capacity(self.column_id_to_index.len());
 
-                Ok((column_name, column_index))
-            })
-            .collect()
-    }
-
-    /// Convert all columns to an arrow record batch
-    pub fn all_to_arrow(&self, chunk: &Chunk) -> Result<RecordBatch> {
-        let mut requested_columns_with_index = self
-            .column_id_to_index
-            .iter()
-            .map(|(&column_id, &column_index)| {
+        let selection = self.column_id_to_index.iter().try_fold(
+            selection,
+            |selection, (&column_id, &column_index)| {
                 let column_name = chunk.dictionary.lookup_id(column_id).context(
                     ColumnIdNotFoundInDictionary {
                         column_id,
                         chunk: chunk.id,
                     },
                 )?;
-                Ok((column_name, column_index))
+                Ok(selection.add_column(column_name, column_index))
+            },
+        )?;
+
+        // sort so the columns always come out in a predictable name
+        Ok(selection.sort_by_name())
+    }
+
+    /// Returns a column selection for just the specified columns
+    fn specific_columns_selection<'a>(
+        &self,
+        chunk: &'a Chunk,
+        columns: &'a [&'a str],
+    ) -> Result<TableColSelection<'a>> {
+        let selection = TableColSelection::with_capacity(columns.len());
+        columns
+            .iter()
+            .try_fold(selection, |selection, &column_name| {
+                let column_index = self.column_index(chunk, column_name)?;
+
+                Ok(selection.add_column(column_name, column_index))
             })
-            .collect::<Result<Vec<_>>>()?;
+    }
 
-        requested_columns_with_index.sort_by(|(a, _), (b, _)| a.cmp(b));
-
-        self.to_arrow_impl(chunk, &requested_columns_with_index)
+    /// Converts this table to an arrow record batch.
+    ///
+    /// If requested_columns is empty (`[]`), retrieve all columns in
+    /// the table
+    ///
+    /// TODO: make this take a ColumnSelection structure rather than &[&str]
+    /// directly.
+    pub fn to_arrow(&self, chunk: &Chunk, selection: ChunkSelection<'_>) -> Result<RecordBatch> {
+        // translate chunk selection into name/indexes:
+        let selection = match selection {
+            ChunkSelection::All => self.all_columns_selection(chunk),
+            ChunkSelection::Some(cols) => self.specific_columns_selection(chunk, cols),
+        }?;
+        self.to_arrow_impl(chunk, &selection)
     }
 
     /// Converts this table to an arrow record batch,
     ///
     /// requested columns with index are tuples of column_name, column_index
-    pub fn to_arrow_impl(
+    fn to_arrow_impl(
         &self,
         chunk: &Chunk,
-        requested_columns_with_index: &[(&str, usize)],
+        selection: &TableColSelection<'_>,
     ) -> Result<RecordBatch> {
         let mut schema_builder = SchemaBuilder::new();
-        let mut columns: Vec<ArrayRef> = Vec::with_capacity(requested_columns_with_index.len());
+        let mut columns: Vec<ArrayRef> = Vec::with_capacity(selection.cols.len());
 
-        for &(column_name, column_index) in requested_columns_with_index.iter() {
+        for col in &selection.cols {
+            let column_name = col.column_name;
+            let column_index = col.column_index;
+
             let arrow_col: ArrayRef = match &self.columns[column_index] {
                 Column::String(vals, _) => {
                     schema_builder = schema_builder.field(column_name, ArrowDataType::Utf8);
@@ -1268,6 +1278,40 @@ fn make_selector_expr(
     Ok(uda
         .call(vec![col(field_name), col(TIME_COLUMN_NAME)])
         .alias(column_name))
+}
+
+struct ColSelection<'a> {
+    column_name: &'a str,
+    column_index: usize,
+}
+
+/// Represets a set of column_name, column_index pairs
+/// for a specific selection
+struct TableColSelection<'a> {
+    cols: Vec<ColSelection<'a>>,
+}
+
+impl<'a> TableColSelection<'a> {
+    fn with_capacity(sz: usize) -> Self {
+        Self {
+            cols: Vec::with_capacity(sz),
+        }
+    }
+
+    /// Add a column to this selection
+    fn add_column(mut self, name: &'a str, index: usize) -> Self {
+        self.cols.push(ColSelection {
+            column_name: name,
+            column_index: index,
+        });
+        self
+    }
+
+    /// Sorts the columns by name
+    fn sort_by_name(mut self) -> Self {
+        self.cols.sort_by(|a, b| a.column_name.cmp(b.column_name));
+        self
+    }
 }
 
 #[cfg(test)]

--- a/mutable_buffer/src/table.rs
+++ b/mutable_buffer/src/table.rs
@@ -853,12 +853,6 @@ impl Table {
     }
 
     /// Converts this table to an arrow record batch.
-    ///
-    /// If requested_columns is empty (`[]`), retrieve all columns in
-    /// the table
-    ///
-    /// TODO: make this take a ColumnSelection structure rather than &[&str]
-    /// directly.
     pub fn to_arrow(&self, chunk: &Chunk, selection: ChunkSelection<'_>) -> Result<RecordBatch> {
         // translate chunk selection into name/indexes:
         let selection = match selection {

--- a/query/src/frontend/sql.rs
+++ b/query/src/frontend/sql.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use snafu::{ResultExt, Snafu};
 
-use crate::{exec::Executor, Database, PartitionChunk};
+use crate::{exec::Executor, selection::Selection, Database, PartitionChunk};
 use arrow_deps::datafusion::{
     datasource::MemTable, error::DataFusionError, physical_plan::ExecutionPlan,
 };
@@ -71,7 +71,7 @@ impl SQLQueryPlanner {
             for partition_key in &partition_keys {
                 for chunk in database.chunks(partition_key).await {
                     chunk
-                        .table_to_arrow(&mut data, &table, &[])
+                        .table_to_arrow(&mut data, &table, Selection::All)
                         .map_err(|e| Box::new(e) as _)
                         .context(InternalTableConversion { table })?
                 }

--- a/query/src/lib.rs
+++ b/query/src/lib.rs
@@ -17,10 +17,10 @@ pub mod frontend;
 pub mod func;
 pub mod group_by;
 pub mod predicate;
+pub mod selection;
 pub mod util;
 
-use self::group_by::GroupByAndAggregate;
-use self::predicate::Predicate;
+use self::{group_by::GroupByAndAggregate, predicate::Predicate, selection::Selection};
 
 /// A `Database` is the main trait implemented by the IOx subsystems
 /// that store actual data.
@@ -134,7 +134,7 @@ pub trait PartitionChunk: Debug + Send + Sync {
         &self,
         dst: &mut Vec<RecordBatch>,
         table_name: &str,
-        columns: &[&str],
+        selection: Selection<'_>,
     ) -> Result<(), Self::Error>;
 }
 

--- a/query/src/selection.rs
+++ b/query/src/selection.rs
@@ -1,0 +1,9 @@
+#[derive(Debug)]
+/// This represents the request to select set of columns from a table
+pub enum Selection<'a> {
+    /// Return all columns (e.g. SELECT *)
+    All,
+
+    /// Return only the named columns
+    Some(&'a [&'a str]),
+}

--- a/query/src/test.rs
+++ b/query/src/test.rs
@@ -6,7 +6,9 @@ use arrow_deps::{
     util::str_iter_to_batch,
 };
 
-use crate::{exec::Executor, group_by::GroupByAndAggregate, util::make_scan_plan};
+use crate::{
+    exec::Executor, group_by::GroupByAndAggregate, selection::Selection, util::make_scan_plan,
+};
 use crate::{
     exec::FieldListPlan,
     exec::{
@@ -476,7 +478,7 @@ impl PartitionChunk for TestChunk {
         &self,
         _dst: &mut Vec<RecordBatch>,
         _table_name: &str,
-        _columns: &[&str],
+        _selection: Selection<'_>,
     ) -> Result<(), Self::Error> {
         unimplemented!()
     }

--- a/server/src/db.rs
+++ b/server/src/db.rs
@@ -11,7 +11,7 @@ use std::{
 
 use async_trait::async_trait;
 use data_types::{data::ReplicatedWrite, database_rules::DatabaseRules};
-use mutable_buffer::MutableBufferDb;
+use mutable_buffer::{chunk::ChunkSelection, MutableBufferDb};
 use query::{Database, PartitionChunk};
 use read_buffer::Database as ReadBufferDb;
 use serde::{Deserialize, Serialize};
@@ -22,6 +22,7 @@ use crate::buffer::Buffer;
 mod chunk;
 use chunk::DBChunk;
 pub mod pred;
+pub mod selection;
 
 #[derive(Debug, Snafu)]
 pub enum Error {
@@ -218,7 +219,7 @@ impl Db {
         let mut batches = Vec::new();
         for stats in mb_chunk.table_stats().unwrap() {
             mb_chunk
-                .table_to_arrow(&mut batches, &stats.name, &[])
+                .table_to_arrow(&mut batches, &stats.name, ChunkSelection::All)
                 .unwrap();
             for batch in batches.drain(..) {
                 // As implemented now, taking this write lock will wait

--- a/server/src/db/chunk.rs
+++ b/server/src/db/chunk.rs
@@ -4,15 +4,20 @@ use arrow_deps::{
 };
 use query::{
     predicate::{Predicate, PredicateBuilder},
+    selection::Selection,
     util::make_scan_plan,
     PartitionChunk,
 };
-use read_buffer::{ColumnSelection, Database as ReadBufferDb};
+use read_buffer::Database as ReadBufferDb;
 use snafu::{ResultExt, Snafu};
 
 use std::sync::{Arc, RwLock};
 
-use super::pred::to_read_buffer_predicate;
+use super::{
+    pred::to_read_buffer_predicate,
+    selection::{make_read_buffer_selection, to_mutable_buffer_selection},
+};
+
 use async_trait::async_trait;
 
 #[derive(Debug, Snafu)]
@@ -103,12 +108,13 @@ impl PartitionChunk for DBChunk {
         &self,
         dst: &mut Vec<RecordBatch>,
         table_name: &str,
-        columns: &[&str],
+        selection: Selection<'_>,
     ) -> Result<(), Self::Error> {
         match self {
             Self::MutableBuffer { chunk } => {
+                let mb_selection = to_mutable_buffer_selection(selection);
                 chunk
-                    .table_to_arrow(dst, table_name, columns)
+                    .table_to_arrow(dst, table_name, mb_selection)
                     .context(MutableBufferChunk)?;
             }
             Self::ReadBuffer {
@@ -117,17 +123,11 @@ impl PartitionChunk for DBChunk {
                 chunk_id,
             } => {
                 let chunk_id = *chunk_id;
-                // Translate the predicates to ReadBuffer style
+                // Translate the predicate and selection to ReadBuffer style
                 let predicate = PredicateBuilder::default().build();
                 let rb_predicate =
                     to_read_buffer_predicate(&predicate).context(InternalPredicateConversion)?;
-
-                // translate column selection
-                let column_selection = if columns.is_empty() {
-                    ColumnSelection::All
-                } else {
-                    ColumnSelection::Some(columns)
-                };
+                let rb_selection = make_read_buffer_selection(selection);
 
                 // run the query
                 let db = db.read().unwrap();
@@ -137,7 +137,7 @@ impl PartitionChunk for DBChunk {
                         table_name,
                         &[chunk_id],
                         rb_predicate,
-                        column_selection,
+                        rb_selection,
                     )
                     .context(ReadBufferChunk { chunk_id })?;
 

--- a/server/src/db/chunk.rs
+++ b/server/src/db/chunk.rs
@@ -15,7 +15,7 @@ use std::sync::{Arc, RwLock};
 
 use super::{
     pred::to_read_buffer_predicate,
-    selection::{to_read_buffer_selection, to_mutable_buffer_selection},
+    selection::{to_mutable_buffer_selection, to_read_buffer_selection},
 };
 
 use async_trait::async_trait;

--- a/server/src/db/chunk.rs
+++ b/server/src/db/chunk.rs
@@ -15,7 +15,7 @@ use std::sync::{Arc, RwLock};
 
 use super::{
     pred::to_read_buffer_predicate,
-    selection::{make_read_buffer_selection, to_mutable_buffer_selection},
+    selection::{to_read_buffer_selection, to_mutable_buffer_selection},
 };
 
 use async_trait::async_trait;
@@ -127,7 +127,7 @@ impl PartitionChunk for DBChunk {
                 let predicate = PredicateBuilder::default().build();
                 let rb_predicate =
                     to_read_buffer_predicate(&predicate).context(InternalPredicateConversion)?;
-                let rb_selection = make_read_buffer_selection(selection);
+                let rb_selection = to_read_buffer_selection(selection);
 
                 // run the query
                 let db = db.read().unwrap();

--- a/server/src/db/selection.rs
+++ b/server/src/db/selection.rs
@@ -10,7 +10,7 @@ pub fn to_mutable_buffer_selection(selection: Selection<'_>) -> ChunkSelection<'
 }
 
 /// Convert a query::Selection into one specific for read buffer
-pub fn make_read_buffer_selection(selection: Selection<'_>) -> ColumnSelection<'_> {
+pub fn to_read_buffer_selection(selection: Selection<'_>) -> ColumnSelection<'_> {
     match selection {
         Selection::All => ColumnSelection::All,
         Selection::Some(cols) => ColumnSelection::Some(cols),

--- a/server/src/db/selection.rs
+++ b/server/src/db/selection.rs
@@ -1,0 +1,18 @@
+use mutable_buffer::chunk::ChunkSelection;
+use query::selection::Selection;
+use read_buffer::ColumnSelection;
+/// Convert a query::Selection into one specific for mutable buffer
+pub fn to_mutable_buffer_selection(selection: Selection<'_>) -> ChunkSelection<'_> {
+    match selection {
+        Selection::All => ChunkSelection::All,
+        Selection::Some(cols) => ChunkSelection::Some(cols),
+    }
+}
+
+/// Convert a query::Selection into one specific for read buffer
+pub fn make_read_buffer_selection(selection: Selection<'_>) -> ColumnSelection<'_> {
+    match selection {
+        Selection::All => ColumnSelection::All,
+        Selection::Some(cols) => ColumnSelection::Some(cols),
+    }
+}

--- a/server/src/snapshot.rs
+++ b/server/src/snapshot.rs
@@ -6,7 +6,7 @@ use arrow_deps::{
 };
 use data_types::partition_metadata::{Partition as PartitionMeta, Table};
 use object_store::{path::ObjectStorePath, ObjectStore};
-use query::PartitionChunk;
+use query::{selection::Selection, PartitionChunk};
 
 use std::io::{Cursor, Seek, SeekFrom, Write};
 use std::sync::{Arc, Mutex};
@@ -150,7 +150,7 @@ where
         while let Some((pos, table_name)) = self.next_table() {
             let mut batches = Vec::new();
             self.partition
-                .table_to_arrow(&mut batches, table_name, &[])
+                .table_to_arrow(&mut batches, table_name, Selection::All)
                 .map_err(|e| Box::new(e) as _)
                 .context(PartitionError)?;
 


### PR DESCRIPTION
Rationale: This is part of implementing the DataFusion `TableProvider` api for cross chunk queries in IOx (#701). I am trying to avoid a massive single PR.

Part of what is needed is a uniform way to describe which columns are selected in a query. This PR follows the model of the ReadBuffer to introduce a reasonable selection API (aka what columns) for the mutable buffer and the query interface.

Among other benefits, this should clear up mistakes related to confusing `[]` as "all columns" --  I have been confused about this and I think @pauldix  has as well. I will comment inline.

This is part of my planned sequence of PRs:
- [x] Better column selection in mutable buffer (this PR)
- [ ] Support table_schema / ColumnSelection in PartitionChunk
- [ ] Add scan_data to PartitionChunk
- [ ] Add TableProvider API (implemented in terms of scan_data and table_schema), port SQL to use it

Basic PR checklist:
- [x] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb_iox/blob/main/README.md).
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
