### PR TITLE
feat: Implement schema merging

### DIFF
--- a/data_types/src/schema.rs
+++ b/data_types/src/schema.rs
@@ -865,6 +865,37 @@ mod test {
     }
 
     #[test]
+    fn test_merge_compatible_schema_only_measurement() {
+        let schema1 = SchemaBuilder::new()
+            .tag("the_tag")
+            .measurement("the_measurement")
+            .build()
+            .unwrap();
+
+        // schema has same fields but not measurement name
+        let schema2 = SchemaBuilder::new()
+            .tag("the_tag")
+            .build()
+            .unwrap();
+
+        // ensure the merge is not optimized away
+        let merged_schema = schema1.try_merge(schema2).unwrap();
+
+        let expected_schema = SchemaBuilder::new()
+            .tag("the_tag")
+            .measurement("the_measurement")
+            .build()
+            .unwrap();
+
+        assert_eq!(
+            expected_schema, merged_schema,
+            "\nExpected:\n{:#?}\nActual:\n{:#?}",
+            expected_schema, merged_schema
+        );
+    }
+
+
+    #[test]
     fn test_merge_measurement_names() {
         let schema1 = SchemaBuilder::new().tag("the_tag").build().unwrap();
 

--- a/data_types/src/schema.rs
+++ b/data_types/src/schema.rs
@@ -842,6 +842,29 @@ mod test {
     }
 
     #[test]
+    fn test_merge_compatible_schema_no_names() {
+        let schema1 = SchemaBuilder::new().tag("the_tag").build().unwrap();
+
+        // has some of the same and some new, different fields
+        let schema2 = SchemaBuilder::new().tag("the_other_tag").build().unwrap();
+
+        // ensure the merge is not optimized away
+        let merged_schema = schema1.try_merge(schema2).unwrap();
+
+        let expected_schema = SchemaBuilder::new()
+            .tag("the_tag")
+            .tag("the_other_tag")
+            .build()
+            .unwrap();
+
+        assert_eq!(
+            expected_schema, merged_schema,
+            "\nExpected:\n{:#?}\nActual:\n{:#?}",
+            expected_schema, merged_schema
+        );
+    }
+
+    #[test]
     fn test_merge_measurement_names() {
         let schema1 = SchemaBuilder::new().tag("the_tag").build().unwrap();
 

--- a/data_types/src/schema.rs
+++ b/data_types/src/schema.rs
@@ -873,10 +873,7 @@ mod test {
             .unwrap();
 
         // schema has same fields but not measurement name
-        let schema2 = SchemaBuilder::new()
-            .tag("the_tag")
-            .build()
-            .unwrap();
+        let schema2 = SchemaBuilder::new().tag("the_tag").build().unwrap();
 
         // ensure the merge is not optimized away
         let merged_schema = schema1.try_merge(schema2).unwrap();
@@ -893,7 +890,6 @@ mod test {
             expected_schema, merged_schema
         );
     }
-
 
     #[test]
     fn test_merge_measurement_names() {

--- a/data_types/src/schema.rs
+++ b/data_types/src/schema.rs
@@ -1,9 +1,10 @@
 //! This module contains the schema definiton for IOx
-use snafu::Snafu;
+use snafu::{ResultExt, Snafu};
 use std::{
     collections::{BTreeSet, HashMap, HashSet},
     convert::{TryFrom, TryInto},
     fmt,
+    sync::Arc,
 };
 
 use arrow_deps::arrow::datatypes::{
@@ -18,9 +19,6 @@ pub mod builder;
 /// Database schema creation / validation errors.
 #[derive(Debug, Snafu)]
 pub enum Error {
-    #[snafu(display("Error building schema: {}", source,))]
-    BuilderError { source: self::builder::Error },
-
     #[snafu(display("Error validating schema: '{}' is both a field and a tag", column_name,))]
     BothFieldAndTag { column_name: String },
 
@@ -46,6 +44,62 @@ pub enum Error {
         column_name: String,
         existing_type: InfluxColumnType,
     },
+
+    #[snafu(display(
+        "Schema Merge Error: Incompatible measurement names. Existing measurement name '{}', new measurement name '{}'",
+        existing_measurement, new_measurement
+    ))]
+    TryMergeDifferentMeasurementNames {
+        existing_measurement: String,
+        new_measurement: String,
+    },
+
+    #[snafu(display(
+        "Schema Merge Error: Incompatible column type for '{}'. Existing type {:?}, new type {:?}",
+        field_name,
+        influx_column_type,
+        existing_influx_column_type
+    ))]
+    TryMergeBadColumnType {
+        field_name: String,
+        existing_influx_column_type: Option<InfluxColumnType>,
+        influx_column_type: Option<InfluxColumnType>,
+    },
+
+    #[snafu(display(
+        "Schema Merge Error: Incompatible data type for '{}'. Existing type {:?}, new type {:?}",
+        field_name,
+        existing_data_type,
+        new_data_type
+    ))]
+    TryMergeBadArrowType {
+        field_name: String,
+        existing_data_type: ArrowDataType,
+        new_data_type: ArrowDataType,
+    },
+
+    #[snafu(display(
+        "Schema Merge Error: Incompatible nullability for '{}'. Existing field {}, new field {}",
+        field_name, nullable_to_str(*existing_nullability), nullable_to_str(*new_nullability)
+    ))]
+    TryMergeBadNullability {
+        field_name: String,
+        existing_nullability: bool,
+        new_nullability: bool,
+    },
+
+    #[snafu(display("Schema Merge: Error merging underlying schema: {}", source))]
+    MergingSchemas {
+        source: arrow_deps::arrow::error::ArrowError,
+    },
+}
+
+fn nullable_to_str(nullability: bool) -> &'static str {
+    if nullability {
+        "can be null"
+    } else {
+        "can not be null"
+    }
 }
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
@@ -63,7 +117,7 @@ pub type Result<T, E = Error> = std::result::Result<T, E>;
 /// Specifically, each column in the Arrow schema has a corresponding
 /// InfluxDB data model type of Tag, Field or Timestamp which is stored in
 /// the metadata field of the ArrowSchemaRef
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Schema {
     /// All the actual data lives on the metadata structure in
     /// `ArrowSchemaRef` and this structure knows how to access that
@@ -209,6 +263,11 @@ impl Schema {
         (influxdb_column_type, field)
     }
 
+    /// Find the index of the column with the given name, if any.
+    pub fn find_index_of(&self, name: &str) -> Option<usize> {
+        self.inner.index_of(name).ok()
+    }
+
     /// Provides the InfluxDB data model measurement name for this schema, if
     /// any
     pub fn measurement(&self) -> Option<&String> {
@@ -230,6 +289,109 @@ impl Schema {
         SchemaIter {
             schema: self,
             idx: 0,
+        }
+    }
+
+    /// Merges any new columns from new_schema, consuming self. If the
+    /// column already exists, self is unchanged.  if the column
+    /// definition conflicts with a prior definition, an error is
+    /// returned.
+    pub fn try_merge(self, other: Self) -> Result<Self> {
+        // Optimize for the common case of the same schema
+        let mut need_merge = false;
+
+        // Do our own pre-checks of the new fields to make nicer error messages
+        if let (Some(existing_measurement), Some(new_measurement)) =
+            (self.measurement(), other.measurement())
+        {
+            if existing_measurement != new_measurement {
+                return TryMergeDifferentMeasurementNames {
+                    existing_measurement,
+                    new_measurement,
+                }
+                .fail();
+            }
+        }
+
+        // if one side has a measurement and the other doesn't need to merge
+        if self.measurement() != other.measurement() {
+            need_merge = true;
+        }
+
+        other
+            .iter()
+            .filter_map(|(influx_column_type, field)| {
+                if let Some(idx) = self.find_index_of(field.name()) {
+                    let (existing_influx_column_type, existing_field) = self.field(idx);
+                    Some((
+                        existing_influx_column_type,
+                        existing_field,
+                        influx_column_type,
+                        field,
+                    ))
+                } else {
+                    // new field
+                    need_merge = true;
+                    None
+                }
+            })
+            .try_for_each(
+                |(existing_influx_column_type, existing_field, influx_column_type, field)| {
+                    let field_name = field.name();
+
+                    // for now, insist the types are exactly the same
+                    // (e.g. None and Some(..) don't match). We could
+                    // consider relaxing this constrait
+                    if existing_influx_column_type != influx_column_type {
+                        TryMergeBadColumnType {
+                            field_name,
+                            existing_influx_column_type,
+                            influx_column_type,
+                        }
+                        .fail()
+                    } else if field.data_type() != existing_field.data_type() {
+                        TryMergeBadArrowType {
+                            field_name,
+                            existing_data_type: existing_field.data_type().clone(),
+                            new_data_type: field.data_type().clone(),
+                        }
+                        .fail()
+                    } else if field.is_nullable() != existing_field.is_nullable() {
+                        TryMergeBadNullability {
+                            field_name,
+                            existing_nullability: existing_field.is_nullable(),
+                            new_nullability: field.is_nullable(),
+                        }
+                        .fail()
+                    } else {
+                        Ok(())
+                    }
+                },
+            )?;
+
+        let new_self = if need_merge {
+            // Delegate the rest of the actual work to arrow schema
+            let new_schema = ArrowSchema::try_merge(&[
+                self.unwrap_to_inner_owned(),
+                other.unwrap_to_inner_owned(),
+            ])
+            .context(MergingSchemas)?;
+            Self {
+                inner: Arc::new(new_schema),
+            }
+        } else {
+            self
+        };
+
+        Ok(new_self)
+    }
+
+    fn unwrap_to_inner_owned(self) -> ArrowSchema {
+        // try and avoid a clone if possible, but it might be required if the Arc is
+        // shared
+        match Arc::try_unwrap(self.inner) {
+            Ok(schema) => schema,
+            Err(schema_arc) => schema_arc.as_ref().clone(),
         }
     }
 }
@@ -642,5 +804,140 @@ mod test {
             assert_eq!(iter_field, field);
         }
         assert_eq!(schema.iter().count(), 3);
+    }
+
+    #[test]
+    fn test_merge_compatible_schema() {
+        let schema1 = SchemaBuilder::new()
+            .tag("the_tag")
+            .influx_field("int_field", Integer)
+            .build()
+            .unwrap();
+
+        // has some of the same and some new, different fields
+        let schema2 = SchemaBuilder::new()
+            .measurement("my_measurement")
+            .tag("the_other_tag")
+            .influx_field("int_field", Integer)
+            .influx_field("another_field", Integer)
+            .build()
+            .unwrap();
+
+        let merged_schema = schema1.try_merge(schema2).unwrap();
+
+        let expected_schema = SchemaBuilder::new()
+            .measurement("my_measurement")
+            .tag("the_tag")
+            .influx_field("int_field", Integer)
+            .tag("the_other_tag")
+            .influx_field("another_field", Integer)
+            .build()
+            .unwrap();
+
+        assert_eq!(
+            expected_schema, merged_schema,
+            "\nExpected:\n{:#?}\nActual:\n{:#?}",
+            expected_schema, merged_schema
+        );
+    }
+
+    #[test]
+    fn test_merge_measurement_names() {
+        let schema1 = SchemaBuilder::new().tag("the_tag").build().unwrap();
+
+        // has some of the same and some different fields
+        let schema2 = SchemaBuilder::new()
+            .measurement("my_measurement")
+            .build()
+            .unwrap();
+
+        let merged_schema = schema1.try_merge(schema2).unwrap();
+
+        let expected_schema = SchemaBuilder::new()
+            .measurement("my_measurement")
+            .tag("the_tag")
+            .build()
+            .unwrap();
+
+        assert_eq!(
+            expected_schema, merged_schema,
+            "\nExpected:\n{:#?}\nActual:\n{:#?}",
+            expected_schema, merged_schema
+        );
+    }
+
+    #[test]
+    fn test_merge_incompatible_schema_measurement_names() {
+        let schema1 = SchemaBuilder::new()
+            .tag("the_tag")
+            .measurement("measurement1")
+            .build()
+            .unwrap();
+
+        // different measurement name, same otherwise
+        let schema2 = SchemaBuilder::new()
+            .tag("the_tag")
+            .measurement("measurement2")
+            .build()
+            .unwrap();
+
+        let merged_schema_error = schema1.try_merge(schema2).unwrap_err();
+
+        assert_eq!(
+            merged_schema_error.to_string(),
+            "Schema Merge Error: Incompatible measurement names. Existing measurement name 'measurement1', new measurement name 'measurement2'"
+        );
+    }
+
+    #[test]
+    fn test_merge_incompatible_data_types() {
+        // same field name with different type
+        let schema1 = SchemaBuilder::new()
+            .field("the_field", ArrowDataType::Int16)
+            .build()
+            .unwrap();
+
+        // same field name with different type
+        let schema2 = SchemaBuilder::new()
+            .field("the_field", ArrowDataType::Int8)
+            .build()
+            .unwrap();
+
+        let merged_schema_error = schema1.try_merge(schema2).unwrap_err();
+
+        assert_eq!(merged_schema_error.to_string(), "Schema Merge Error: Incompatible data type for 'the_field'. Existing type Int16, new type Int8");
+    }
+
+    #[test]
+    fn test_merge_incompatible_column_types() {
+        let schema1 = SchemaBuilder::new().tag("the_tag").build().unwrap();
+
+        // same field name with different type
+        let schema2 = SchemaBuilder::new()
+            .influx_field("the_tag", Integer)
+            .build()
+            .unwrap();
+
+        let merged_schema_error = schema1.try_merge(schema2).unwrap_err();
+
+        assert_eq!(merged_schema_error.to_string(), "Schema Merge Error: Incompatible column type for 'the_tag'. Existing type Some(Field(Integer)), new type Some(Tag)");
+    }
+
+    #[test]
+    fn test_merge_incompatible_schema_nullability() {
+        let schema1 = SchemaBuilder::new()
+            .non_null_field("int_field", ArrowDataType::Int64)
+            .build()
+            .unwrap();
+
+        // same field name with different nullability
+        let schema2 = SchemaBuilder::new()
+            .field("int_field", ArrowDataType::Int64)
+            .build()
+            .unwrap();
+
+        let merged_schema_error = schema1.try_merge(schema2).unwrap_err();
+
+        assert_eq!(merged_schema_error.to_string(), "Schema Merge Error: Incompatible nullability for 'int_field'. Existing field can not be null, new field can be null");
     }
 }

--- a/data_types/src/schema.rs
+++ b/data_types/src/schema.rs
@@ -293,7 +293,7 @@ impl Schema {
     }
 
     /// Merges any new columns from new_schema, consuming self. If the
-    /// column already exists, self is unchanged.  if the column
+    /// column already exists, self is unchanged. If the column
     /// definition conflicts with a prior definition, an error is
     /// returned.
     pub fn try_merge(self, other: Self) -> Result<Self> {

--- a/data_types/src/schema/builder.rs
+++ b/data_types/src/schema/builder.rs
@@ -305,12 +305,17 @@ impl InfluxSchemaBuilder {
 
 /// Schema Merger
 ///
-/// The usecase for this is when different chunks have different
-/// schemas. This struct can be used to build a combined schema.  It
-/// merges Schemas together applying the following rules:
+/// The usecase for merging schemas is when different chunks have
+/// different schemas. This struct can be used to build a combined
+/// schema by mergeing Schemas together according to the following
+/// rules:
 ///
 /// 1. New columns may be added in subsequent schema, but the types of
-/// the columns (including any metadata) must be the same
+///    the columns (including any metadata) must be the same
+///
+/// 2. The measurement names must be consistent: one or both can be
+///    `None`, but if they are `Some(name`), then `name` must be the
+///    same
 #[derive(Debug, Default)]
 pub struct SchemaMerger {
     inner: Option<Schema>,

--- a/data_types/src/schema/builder.rs
+++ b/data_types/src/schema/builder.rs
@@ -26,9 +26,13 @@ pub enum Error {
     },
 
     #[snafu(display("Error validating schema: {}", source))]
-    ValidatingSchema {
-        source: Box<dyn std::error::Error + 'static + Send + Sync>,
-    },
+    ValidatingSchema { source: super::Error },
+
+    #[snafu(display("Error while merging schemas: {}", source))]
+    MergingSchemas { source: super::Error },
+
+    #[snafu(display("No schemas found when building merged schema",))]
+    NoSchemas {},
 }
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
@@ -167,7 +171,6 @@ impl SchemaBuilder {
         } = self;
 
         Schema::new_from_parts(measurement, fields, tag_cols, field_cols, time_col)
-            .map_err(|e| Box::new(e) as _)
             .context(ValidatingSchema)
     }
 
@@ -297,6 +300,47 @@ impl InfluxSchemaBuilder {
 
         // and now timestamp
         builder.timestamp().build()
+    }
+}
+
+/// Schema Merger
+///
+/// The usecase for this is when different chunks have different
+/// schemas. This struct can be used to build a combined schema.  It
+/// merges Schemas together applying the following rules:
+///
+/// 1. New columns may be added in subsequent schema, but the types of
+/// the columns (including any metadata) must be the same
+#[derive(Debug, Default)]
+pub struct SchemaMerger {
+    inner: Option<Schema>,
+}
+
+impl SchemaMerger {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Appends the schema to the merged schema being built,
+    /// validating that no columns are added.
+    ///
+    /// O(n^2) in the number of fields (columns)
+    pub fn merge(mut self, new_schema: Schema) -> Result<Self> {
+        self.inner = match self.inner.take() {
+            None => Some(new_schema),
+            Some(existing_schema) => {
+                let merged_schema = existing_schema
+                    .try_merge(new_schema)
+                    .context(MergingSchemas)?;
+                Some(merged_schema)
+            }
+        };
+        Ok(self)
+    }
+
+    /// Returns the schema that was built, consuming the builder
+    pub fn build(self) -> Result<Schema> {
+        self.inner.map(Ok).unwrap_or_else(|| NoSchemas {}.fail())
     }
 }
 
@@ -517,5 +561,41 @@ mod test {
         assert_column_eq!(s, 1, Timestamp, "time");
 
         assert_eq!(s.len(), 2);
+    }
+
+    #[test]
+    fn test_merge_schema_empty() {
+        let merged_schema_error = SchemaMerger::new().build().unwrap_err();
+
+        assert_eq!(
+            merged_schema_error.to_string(),
+            "No schemas found when building merged schema"
+        );
+    }
+
+    #[test]
+    fn test_merge_same_schema() {
+        let schema1 = SchemaBuilder::new()
+            .tag("the_tag")
+            .influx_field("int_field", Integer)
+            .build()
+            .unwrap();
+
+        let schema2 = SchemaBuilder::new()
+            .tag("the_tag")
+            .influx_field("int_field", Integer)
+            .build()
+            .unwrap();
+
+        let merged_schema = SchemaMerger::new()
+            .merge(schema1.clone())
+            .unwrap()
+            .merge(schema2.clone())
+            .unwrap()
+            .build()
+            .unwrap();
+
+        assert_eq!(merged_schema, schema1);
+        assert_eq!(merged_schema, schema2);
     }
 }

--- a/data_types/src/schema/builder.rs
+++ b/data_types/src/schema/builder.rs
@@ -314,8 +314,7 @@ impl InfluxSchemaBuilder {
 ///    the columns (including any metadata) must be the same
 ///
 /// 2. The measurement names must be consistent: one or both can be
-///    `None`, but if they are `Some(name`), then `name` must be the
-///    same
+///    `None`, or they can both be  are `Some(name`)
 #[derive(Debug, Default)]
 pub struct SchemaMerger {
     inner: Option<Schema>,


### PR DESCRIPTION
## Rationale
The ability to merge potentially different schemas across chunks is a precursor to being able to query across those chunks.

## Changes
This PR adds a builder (and tests) for merging schemas by  implementing the logic for "compatibile" schemas  -- namely that columns can be added but there can not be any datatype conflicts.

Related to https://github.com/influxdata/influxdb_iox/pull/700

- [x] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb_iox/blob/main/README.md).
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
