### PR TITLE
feat: Create table_schema api call and implementation

### DIFF
--- a/data_types/src/selection.rs
+++ b/data_types/src/selection.rs
@@ -1,4 +1,4 @@
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 /// A collection of columns to include in query results.
 ///
 /// The `All` variant denotes that the caller wishes to include all table

--- a/query/src/lib.rs
+++ b/query/src/lib.rs
@@ -8,7 +8,8 @@
 use arrow_deps::{arrow::record_batch::RecordBatch, datafusion::logical_plan::LogicalPlan};
 use async_trait::async_trait;
 use data_types::{
-    data::ReplicatedWrite, partition_metadata::Table as TableStats, selection::Selection,
+    data::ReplicatedWrite, partition_metadata::Table as TableStats, schema::Schema,
+    selection::Selection,
 };
 use exec::{Executor, FieldListPlan, SeriesSetPlans, StringSetPlan};
 
@@ -118,6 +119,9 @@ pub trait PartitionChunk: Debug + Send + Sync {
         true
     }
 
+    /// Returns true if this chunk contains data for the specified table
+    async fn has_table(&self, table_name: &str) -> bool;
+
     /// Returns a datafusion plan that produces
     /// a single string column representing the names
     /// of the tables that have at least one row that matches the
@@ -128,6 +132,14 @@ pub trait PartitionChunk: Debug + Send + Sync {
     /// the responsibility of the caller to deduplicate them if
     /// desired.
     async fn table_names(&self, predicate: &Predicate) -> Result<LogicalPlan, Self::Error>;
+
+    /// Returns the Schema for a table in this chunk, with the
+    /// specified column selection
+    async fn table_schema(
+        &self,
+        table_name: &str,
+        selection: Selection<'_>,
+    ) -> Result<Schema, Self::Error>;
 
     /// converts the table to an Arrow RecordBatch and writes to dst
     /// TODO turn this into a streaming interface

--- a/query/src/test.rs
+++ b/query/src/test.rs
@@ -19,6 +19,7 @@ use crate::{
 use data_types::{
     data::{lines_to_replicated_write, ReplicatedWrite},
     database_rules::{DatabaseRules, PartitionTemplate, TemplatePart},
+    schema::Schema,
     selection::Selection,
 };
 use influxdb_line_protocol::{parse_lines, ParsedLine};
@@ -492,6 +493,18 @@ impl PartitionChunk for TestChunk {
         let names = self.table_names.iter().map(Some);
         let batch = str_iter_to_batch("tables", names).unwrap();
         Ok(make_scan_plan(batch).unwrap())
+    }
+
+    async fn table_schema(
+        &self,
+        _table_name: &str,
+        _selection: Selection<'_>,
+    ) -> Result<Schema, Self::Error> {
+        unimplemented!()
+    }
+
+    async fn has_table(&self, _table_name: &str) -> bool {
+        unimplemented!()
     }
 }
 


### PR DESCRIPTION
## Rationale
In order to plan queries, DataFusion (and really any query engine) needs to know what the schemas of the input tables are

## Changes
1. adds functions to the `PartitionChunk` trait for if a table is present and what its schema is for a particular chunk / set of chunks
2. Implements this function for mutable buffer and read buffer
3. Tests that the same schema is reported for the same data laid out in several different ways


This is part of my planned sequence of PRs:
- [x] Better column selection in mutable buffer (https://github.com/influxdata/influxdb_iox/pull/700)
- [x] Support table_schema / ColumnSelection in PartitionChunk (this PR)
- [ ] Add scan_data to PartitionChunk
- [ ] Add TableProvider API (implemented in terms of scan_data and table_schema), port SQL to use



Describe your proposed changes here.

- [ ] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb_iox/blob/main/README.md).
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
