### PR TITLE
feat: Read Buffer safe for concurrent access

### DIFF
--- a/read_buffer/src/chunk.rs
+++ b/read_buffer/src/chunk.rs
@@ -307,10 +307,10 @@ mod test {
         // Create a Chunk from a Table.
         let columns = vec![(
             "time".to_owned(),
-            ColumnType::create_time(&[1_i64, 2, 3, 4, 5, 6][..]),
+            ColumnType::create_time(&[1_i64, 2, 3, 4, 5, 6]),
         )]
         .into_iter()
-        .collect::<BTreeMap<_, _>>();
+        .collect();
         let rg = RowGroup::new(6, columns);
         let table = Table::new("table_1", rg);
         let mut chunk = Chunk::new(22, table);
@@ -320,10 +320,10 @@ mod test {
         assert_eq!(chunk.tables(), 1);
 
         // Add a row group to the same table in the Chunk.
-        let columns = vec![("time", ColumnType::create_time(&[-2_i64, 2, 8][..]))]
+        let columns = vec![("time", ColumnType::create_time(&[-2_i64, 2, 8]))]
             .into_iter()
             .map(|(k, v)| (k.to_owned(), v))
-            .collect::<BTreeMap<_, _>>();
+            .collect();
         let rg = RowGroup::new(3, columns);
         chunk.upsert_table("table_1", rg);
 
@@ -332,10 +332,10 @@ mod test {
         assert_eq!(chunk.tables(), 1);
 
         // Add a row group to another table in the Chunk.
-        let columns = vec![("time", ColumnType::create_time(&[-3_i64, 2][..]))]
+        let columns = vec![("time", ColumnType::create_time(&[-3_i64, 2]))]
             .into_iter()
             .map(|(k, v)| (k.to_owned(), v))
-            .collect::<BTreeMap<_, _>>();
+            .collect();
         let rg = RowGroup::new(2, columns);
         chunk.upsert_table("table_2", rg);
 
@@ -365,10 +365,10 @@ mod test {
     #[test]
     fn table_names() {
         let columns = vec![
-            ("time", ColumnType::create_time(&[1_i64, 2, 3, 4, 5, 6][..])),
+            ("time", ColumnType::create_time(&[1_i64, 2, 3, 4, 5, 6])),
             (
                 "region",
-                ColumnType::create_tag(&["west", "west", "east", "west", "south", "north"][..]),
+                ColumnType::create_tag(&["west", "west", "east", "west", "south", "north"]),
             ),
         ]
         .into_iter()
@@ -391,10 +391,7 @@ mod test {
         // All table names returned if no predicate and not in skip list
         let table_names = chunk.table_names(
             &Predicate::default(),
-            &["table_2".to_owned()]
-                .iter()
-                .cloned()
-                .collect::<BTreeSet<String>>(),
+            &["table_2".to_owned()].iter().cloned().collect(),
         );
         assert_eq!(
             table_names
@@ -407,10 +404,7 @@ mod test {
         // Table name not returned if it is in skip list
         let table_names = chunk.table_names(
             &Predicate::default(),
-            &["table_1".to_owned()]
-                .iter()
-                .cloned()
-                .collect::<BTreeSet<String>>(),
+            &["table_1".to_owned()].iter().cloned().collect(),
         );
         assert!(table_names.is_empty());
 

--- a/read_buffer/src/chunk.rs
+++ b/read_buffer/src/chunk.rs
@@ -134,8 +134,6 @@ impl Chunk {
         match chunk_data.data.entry(table_name.clone()) {
             Entry::Occupied(mut table_entry) => {
                 let table = table_entry.get_mut();
-                // lock the table (even though we have locked the chunk there
-                // could be in flight queries to the table by design).
                 table.add_row_group(row_group);
             }
             Entry::Vacant(table_entry) => {

--- a/read_buffer/src/chunk.rs
+++ b/read_buffer/src/chunk.rs
@@ -130,7 +130,7 @@ impl Chunk {
         predicate: Predicate,
         group_columns: &Selection<'_>,
         aggregates: &[(ColumnName<'_>, AggregateType)],
-    ) -> Option<table::ReadAggregateResults<'_>> {
+    ) -> Option<table::ReadAggregateResults> {
         // Lookup table by name and dispatch execution.
         self.tables
             .get(table_name)

--- a/read_buffer/src/chunk.rs
+++ b/read_buffer/src/chunk.rs
@@ -105,7 +105,7 @@ impl Chunk {
         table_name: &str,
         predicate: &Predicate,
         select_columns: &Selection<'_>,
-    ) -> Result<table::ReadFilterResults<'_>, Error> {
+    ) -> Result<table::ReadFilterResults, Error> {
         // Lookup table by name and dispatch execution.
         match self.tables.get(table_name) {
             Some(table) => Ok(table.read_filter(select_columns, predicate)),

--- a/read_buffer/src/chunk.rs
+++ b/read_buffer/src/chunk.rs
@@ -43,7 +43,7 @@ pub struct Chunk {
     //
     //    * A read lock is needed for all read operations over chunk data (tables). However, the
     //      read lock is only taken for as long as it takes to determine which table data is needed
-    //      to perform the read, shallow-clone that data (via Rcs), and construct an iterator for
+    //      to perform the read, shallow-clone that data (via Arcs), and construct an iterator for
     //      executing that operation. Once the iterator is returned to the caller, the lock is
     //      freed. Therefore, read execution against the chunk is mostly lock-free.
     //

--- a/read_buffer/src/lib.rs
+++ b/read_buffer/src/lib.rs
@@ -10,7 +10,6 @@ pub(crate) mod table;
 
 use std::{
     collections::{btree_map::Entry, BTreeMap, BTreeSet},
-    convert::TryInto,
     fmt,
 };
 

--- a/read_buffer/src/lib.rs
+++ b/read_buffer/src/lib.rs
@@ -666,7 +666,7 @@ impl<'input, 'chunk> Iterator for ReadAggregateResults<'input, 'chunk> {
                 // table current emits at most one merged result.
                 match row_group_results.len() {
                     0 => self.next(), // no results try next chunk's table
-                    1 => Some(row_group_results.remove(0).try_into().unwrap()),
+                    1 => Some(row_group_results.remove(0)),
                     _ => panic!("currently expect at most one result"),
                 }
             }

--- a/read_buffer/src/lib.rs
+++ b/read_buffer/src/lib.rs
@@ -522,7 +522,7 @@ impl Partition {
 pub struct ReadFilterResults<'input, 'chunk> {
     chunks: Vec<&'chunk Chunk>,
     next_i: usize,
-    curr_table_results: Option<table::ReadFilterResults<'chunk>>,
+    curr_table_results: Option<table::ReadFilterResults>,
 
     table_name: &'input str,
     predicate: Predicate,
@@ -581,11 +581,13 @@ impl<'input, 'chunk> Iterator for ReadFilterResults<'input, 'chunk> {
             // Table potentially has some results.
             Some(table_results) => {
                 // Table has found results in a row group.
+
                 if let Some(row_group_result) = table_results.next() {
                     // it should not be possible for the conversion to record
                     // batch to fail here
-                    let rb = row_group_result.try_into();
-                    return Some(rb.unwrap());
+                    return Some(row_group_result);
+                    // let rb = row_group_result.try_into();
+                    // return Some(rb.unwrap());
                 }
 
                 // no more results for row groups in the table. Try next chunk.

--- a/read_buffer/src/lib.rs
+++ b/read_buffer/src/lib.rs
@@ -214,21 +214,6 @@ impl Database {
             .sum()
     }
 
-    // Internal functions useful for testing.
-
-    // // Get a reference to a single chunk. Panics if it or the partition doesn't
-    // // exist.
-    // fn chunk(&self, partition_key: &str, chunk_id: u32) -> &Chunk {
-    //     &self
-    //         .data
-    //         .read()
-    //         .unwrap()
-    //         .partitions
-    //         .get(partition_key)
-    //         .unwrap()
-    //         .chunk(chunk_id)
-    // }
-
     /// Returns rows for the specified columns in the provided table, for the
     /// specified partition key and chunks within that partition.
     ///
@@ -270,7 +255,8 @@ impl Database {
 
                     // Get all relevant row groups for this chunk's table. This
                     // is cheap because it doesn't execute the read operation,
-                    // but just gets references to the needed to data to do so.
+                    // but just gets pointers to the necessary data for
+                    // execution.
                     let chunk_result = chunk
                         .read_filter(table_name, &predicate, &select_columns)
                         .context(ChunkError)?;
@@ -584,25 +570,6 @@ impl Partition {
         self.data.read().unwrap().chunks.keys().cloned().collect()
     }
 
-    // fn chunks_by_ids(&self, ids: &[u32]) -> Result<Vec<&Chunk>> {
-    //     let chunks = &self.data.read().unwrap().chunks;
-
-    //     let mut filtered_chunks = vec![];
-    //     for chunk_id in ids {
-    //         filtered_chunks.push(
-    //             chunks
-    //                 .get(chunk_id)
-    //                 .ok_or_else(|| Error::ChunkNotFound { id: *chunk_id })?,
-    //         );
-    //     }
-    //     Ok(filtered_chunks)
-    // }
-
-    // Returns the chunk or panics. Useful for internal testing.
-    // fn chunk(&self, id: u32) -> &Chunk {
-    //     self.data.read().unwrap().chunks.get(&id).unwrap()
-    // }
-
     /// Determines the total number of tables under all chunks within the
     /// partition. Useful for tests but not something that is highly performant.
     fn tables(&self) -> usize {
@@ -639,15 +606,13 @@ pub struct ReadFilterResults {
 
 impl fmt::Debug for ReadFilterResults {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        todo!()
-        // f.debug_struct("ReadFilterResults")
-        //     .field("chunks.len", &self.chunks.len())
-        //     .field("next_i", &self.next_i)
-        //     .field("curr_table_results", &"<OPAQUE>")
-        //     .field("table_name", &self.table_name)
-        //     .field("predicate", &self.predicate)
-        //     .field("select_columns", &self.select_columns)
-        //     .finish()
+        f.debug_struct("ReadFilterResults")
+            .field(
+                "all_chunks_table_results.len",
+                &self.all_chunks_table_results.len(),
+            )
+            .field("next_chunk", &self.next_chunk)
+            .finish()
     }
 }
 

--- a/read_buffer/src/row_group.rs
+++ b/read_buffer/src/row_group.rs
@@ -1270,6 +1270,16 @@ impl ColumnType {
             ColumnType::Time(c) => c.size(),
         }
     }
+
+    /// Helper function to construct a `Tag` column from a slice of `&str`
+    pub fn create_tag(values: &[&str]) -> Self {
+        Self::Tag(Column::from(values))
+    }
+
+    /// Helper function to construct a `Time` column from a slice of `i64`
+    pub fn create_time(values: &[i64]) -> Self {
+        Self::Time(Column::from(values))
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/read_buffer/src/table.rs
+++ b/read_buffer/src/table.rs
@@ -110,6 +110,11 @@ impl Table {
         self.table_data.read().unwrap().meta.size
     }
 
+    // Returns the total number of row groups in this table.
+    pub fn row_groups(&self) -> usize {
+        self.table_data.read().unwrap().data.len()
+    }
+
     /// The number of rows in this table.
     pub fn rows(&self) -> u64 {
         self.table_data.read().unwrap().meta.rows


### PR DESCRIPTION
This PR makes the Read Buffer's external API safe for concurrent use 🥳  Big thanks to @carols10cents for the several discussions we had this week on this!

### What?

The PR ensures that it is safe to concurrently call any of the Read Buffer's external APIs.

The design also minimises lock contention in the read path by only holding locks on the read buffer for the initial part of query execution. The most expensive parts of query execution (actually operating on the columnar data and materialising data into record batches) is done in a lock-free manner.

### Why?

Whilst the Read Buffer executes on immutable blocks of data (`Row Groups`), the Read Buffer itself is not immutable because the consumer of the Read Buffer needs to be able to do things like:

 * add new partitions, chunks and tables by adding more immutable row groups;
 * remove partitions/chunk/table data from the read buffer.

Further, I plan to soon add more features to the read buffer that will improve execution performance and these features will require the ability to maintain mutable caches for various intermediate state.

In order to execute queries whilst concurrently adding and removing data the read buffer's APIs need to be safe for concurrent use. Up until this point the focus has been on designing an engine that will satisfy our performance and space needs. 

### How?

It won't be terribly surprising that in-the-main this is achieved by using `RwLock` (a read-write mutex). 

#### Modifications
Anything that involves mutating any state in the read buffer is done whilst holding a write lock. I have been careful to limit the expense of these operations as much as possible. They are restricted to generally updating containers that generally have `O(1)` insert or remove time.

#### Read operations
This is where the design is more interesting... 

* Firstly, one obvious problem with just using a `RwLock` on the read buffer is that if you have expensive operations like... executing queries.  Whilst you can run many of these concurrently (since they only require a read lock) you can—depending on the OS mutex implementation—starve writers from getting hold of a `write` lock. In a system where it would be normal for there to be constant concurrent read operations on the read buffer this seems like it could be a problem.

* Secondly, another problem is that all of your queries against the read buffer need to complete execution before you make any modifications/mutate any data. Consider that Rust, being as safe as it is, does a good job of not letting you shoot yourself in the foot here. Since there may be many queries and they could take a lot of time, this adds further issue.

I managed to come up with a design that I believe will significantly reduces or even eradicates the above two problems with lock contention. It builds upon the iterator design I have recently added to the read buffer.

The general idea is that during query execution the read buffer holds a read lock for as long as it takes to:

 * determine which chunks, tables and row groups are pertinent to answering the query (predicate pushdown);
 * make a _snapshot_ of all immutable row groups and associated meta-data needed to build a result schema and result data.
 * initialise a set of iterators and return those iterators back to the caller.

During these steps no physical operation on the columnar data occurs, and the operation should execute very quickly. Snapshotting is achieved by using Rust smart-pointers (`Arc`) to increment a reference-count on any immutable row-groups needed to answer the query. These smart pointers are then embedded in the returned iterators.

The caller will then drain the returned iterator to begin actual execution and result materialisation. Concurrent to this it is perfectly safe for these row groups to be dropped from the read buffer because Rust will ensure that the necessary memory is not freed until all callers with iterators have dropped/drained them.

### Next Steps

There is a bunch of clean-up I would like to do but this PR is already big. I apologise that there is a lot of code to look at here; it was a bit of a large exploration over the course of this week :-) 

Once I can get this in I plan to do some more realistic testing.





