### PR TITLE
feat: aggregates without group keys

### DIFF
--- a/read_buffer/src/lib.rs
+++ b/read_buffer/src/lib.rs
@@ -1156,7 +1156,7 @@ mod test {
         //
         //   QUERY:
         //
-        //   SELECT SUM("counter"), COUNT("counter")
+        //   SELECT SUM("counter"), COUNT("counter"), MIN("counter"), MAX("counter")
         //   FROM "table_1"
         //   WHERE "time" <= 130
         //
@@ -1171,6 +1171,8 @@ mod test {
                 vec![
                     ("counter", AggregateType::Count),
                     ("counter", AggregateType::Sum),
+                    ("counter", AggregateType::Min),
+                    ("counter", AggregateType::Max),
                 ],
             )
             .unwrap();
@@ -1180,6 +1182,8 @@ mod test {
 
         assert_rb_column_equals(&result, "counter_count", &Values::U64(vec![3]));
         assert_rb_column_equals(&result, "counter_sum", &Values::U64(vec![9000]));
+        assert_rb_column_equals(&result, "counter_min", &Values::U64(vec![1000]));
+        assert_rb_column_equals(&result, "counter_max", &Values::U64(vec![5000]));
 
         //
         // With group keys

--- a/read_buffer/src/lib.rs
+++ b/read_buffer/src/lib.rs
@@ -292,6 +292,15 @@ impl Database {
         group_columns: Selection<'input>,
         aggregates: Vec<(ColumnName<'input>, AggregateType)>,
     ) -> Result<ReadAggregateResults> {
+        for (_, agg) in &aggregates {
+            match agg {
+                AggregateType::First | AggregateType::Last => {
+                    return Err(Error::UnsupportedAggregate { agg: *agg });
+                }
+                _ => {}
+            }
+        }
+
         // get read lock on database
         let partition_data = self.data.read().unwrap();
         let mut chunk_table_results = vec![];
@@ -319,15 +328,6 @@ impl Database {
                 chunk.read_aggregate(table_name, predicate.clone(), &group_columns, &aggregates)
             {
                 chunk_table_results.push(table_results);
-            }
-        }
-
-        for (_, agg) in &aggregates {
-            match agg {
-                AggregateType::First | AggregateType::Last => {
-                    return Err(Error::UnsupportedAggregate { agg: *agg });
-                }
-                _ => {}
             }
         }
 
@@ -1123,7 +1123,7 @@ mod test {
     }
 
     #[test]
-    fn read_aggregate_multiple_row_groups() {
+    fn read_aggregate() {
         let mut db = Database::new();
 
         // Add a bunch of row groups to a single table in a single chunks
@@ -1142,17 +1142,49 @@ mod test {
                 Arc::new(StringArray::from(vec!["west", "west", "east"])),
                 Arc::new(Float64Array::from(vec![10.0, 30000.0, 4500.0])),
                 Arc::new(UInt64Array::from(vec![1000, 3000, 5000])),
-                Arc::new(Int64Array::from(vec![i, 20 * i, 30 * i])),
+                Arc::new(Int64Array::from(vec![i, 20 + i, 30 + i])),
             ];
 
             // Add a record batch to a single partition
             let rb = RecordBatch::try_new(schema.into(), data).unwrap();
-            println!("rb {:?} {:?}", i, &rb);
             // The row group gets added to the same chunk each time.
             db.upsert_partition("hour_1", 1, "table1", rb);
         }
 
-        // Build the following query:
+        //
+        // Simple Aggregates - no group keys.
+        //
+        //   QUERY:
+        //
+        //   SELECT SUM("counter"), COUNT("counter")
+        //   FROM "table_1"
+        //   WHERE "time" <= 130
+        //
+
+        let itr = db
+            .read_aggregate(
+                "hour_1",
+                "table1",
+                &[1],
+                Predicate::new(vec![BinaryExpr::from(("time", "<=", 130_i64))]),
+                Selection::Some(&[]),
+                vec![
+                    ("counter", AggregateType::Count),
+                    ("counter", AggregateType::Sum),
+                ],
+            )
+            .unwrap();
+        let result = itr.collect::<Vec<RecordBatch>>();
+        assert_eq!(result.len(), 1);
+        let result = &result[0];
+
+        assert_rb_column_equals(&result, "counter_count", &Values::U64(vec![3]));
+        assert_rb_column_equals(&result, "counter_sum", &Values::U64(vec![9000]));
+
+        //
+        // With group keys
+        //
+        //   QUERY:
         //
         //   SELECT SUM("temp"), MIN("temp"), SUM("counter"), COUNT("counter")
         //   FROM "table_1"

--- a/read_buffer/src/row_group.rs
+++ b/read_buffer/src/row_group.rs
@@ -917,7 +917,7 @@ impl RowGroup {
                 AggregateType::Max => {
                     aggregate_row.push(AggregateResult::Max(col.max(&row_ids)));
                 }
-                _ => todo!(),
+                _ => unimplemented!("Other aggregates are not yet supported"),
             }
         }
         dst.aggregates.push(AggregateResults(aggregate_row)); // write the row

--- a/read_buffer/src/row_group.rs
+++ b/read_buffer/src/row_group.rs
@@ -874,7 +874,7 @@ impl RowGroup {
     }
 
     // Applies aggregates on multiple columns with an optional predicate.
-    fn aggregate_columns(&self, predicate: &Predicate, dst: &mut ReadAggregateResult<'_>) {
+    fn aggregate_columns<'a>(&'a self, predicate: &Predicate, dst: &mut ReadAggregateResult<'a>) {
         let aggregate_columns = dst
             .schema
             .aggregate_columns
@@ -910,6 +910,12 @@ impl RowGroup {
                 }
                 AggregateType::Sum => {
                     aggregate_row.push(AggregateResult::Sum(col.sum(&row_ids)));
+                }
+                AggregateType::Min => {
+                    aggregate_row.push(AggregateResult::Min(col.min(&row_ids)));
+                }
+                AggregateType::Max => {
+                    aggregate_row.push(AggregateResult::Max(col.max(&row_ids)));
                 }
                 _ => todo!(),
             }

--- a/read_buffer/src/schema.rs
+++ b/read_buffer/src/schema.rs
@@ -68,18 +68,18 @@ impl ResultSchema {
 /// Effectively emits a header line for a CSV-like table.
 impl Display for ResultSchema {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        // do we need to emit the group by and aggregate columns?
-        let has_group_and_agg = !self.group_columns.is_empty();
+        // do we need to emit the group by or aggregate columns?
+        let has_agg_columns = !self.aggregate_columns.is_empty();
 
         for (i, (name, _)) in self.select_columns.iter().enumerate() {
-            if has_group_and_agg || i < self.select_columns.len() - 1 {
+            if has_agg_columns || i < self.select_columns.len() - 1 {
                 write!(f, "{},", name)?;
-            } else if !has_group_and_agg {
+            } else if !has_agg_columns {
                 return write!(f, "{}", name); // last value in header row
             }
         }
 
-        // write out group by columns
+        // write out group by columns, if any
         for (i, (name, _)) in self.group_columns.iter().enumerate() {
             write!(f, "{},", name)?;
         }

--- a/read_buffer/src/table.rs
+++ b/read_buffer/src/table.rs
@@ -1142,12 +1142,12 @@ mod test {
 
         // Build another row group.
         let mut columns = BTreeMap::new();
-        columns.insert("time".to_string(), ColumnType::create_time(&[2, 3, 4]));
+        columns.insert("time".to_string(), ColumnType::create_time(&[2, 3]));
         columns.insert(
             "region".to_string(),
-            ColumnType::create_tag(&["north", "north", "north"]),
+            ColumnType::create_tag(&["north", "north"]),
         );
-        let rg = RowGroup::new(3, columns);
+        let rg = RowGroup::new(2, columns);
         table.add_row_group(rg);
 
         // no predicate aggregate
@@ -1177,7 +1177,7 @@ mod test {
 
         assert_eq!(
             DisplayReadAggregateResults(vec![results.next_merged_result().unwrap()]).to_string(),
-            "time_count,time_sum\n6,609\n",
+            "time_count,time_sum\n5,605\n",
         );
         assert!(matches!(results.next_merged_result(), None));
 

--- a/read_buffer/src/table.rs
+++ b/read_buffer/src/table.rs
@@ -855,6 +855,12 @@ impl Iterator for ReadAggregateResults {
 // Helper type that can pretty print a set of results for `read_aggregate`.
 struct DisplayReadAggregateResults<'a>(Vec<row_group::ReadAggregateResult<'a>>);
 
+// impl DisplayReadAggregateResults<'_> {
+//     fn to_string(&self) -> String {
+//         format!("{}", &self)
+//     }
+// }
+
 impl std::fmt::Display for DisplayReadAggregateResults<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         if self.0.is_empty() {
@@ -1126,7 +1132,70 @@ mod test {
     }
 
     #[test]
-    fn read_group_result() {
+    fn read_aggregate_no_groups() {
+        // Build first row group.
+        let mut columns = BTreeMap::new();
+        columns.insert(
+            "time".to_string(),
+            ColumnType::create_time(&[100, 200, 300]),
+        );
+        columns.insert(
+            "region".to_string(),
+            ColumnType::create_tag(&["west", "west", "east"]),
+        );
+        let rg = RowGroup::new(3, columns);
+        let mut table = Table::new("cpu", rg);
+
+        // Build another row group.
+        let mut columns = BTreeMap::new();
+        columns.insert("time".to_string(), ColumnType::create_time(&[2, 2, 2]));
+        columns.insert(
+            "region".to_string(),
+            ColumnType::create_tag(&["north", "north", "north"]),
+        );
+        let rg = RowGroup::new(3, columns);
+        table.add_row_group(rg);
+
+        // no predicate aggregate
+        let mut results = table.read_aggregate(
+            Predicate::default(),
+            &Selection::Some(&[]),
+            &[("time", AggregateType::Count)],
+        );
+
+        // check the column result schema
+        let exp_schema = ResultSchema {
+            aggregate_columns: vec![(
+                schema::ColumnType::Timestamp("time".to_owned()),
+                AggregateType::Count,
+                LogicalDataType::Integer,
+            )],
+            ..ResultSchema::default()
+        };
+        assert_eq!(results.schema(), &exp_schema);
+
+        assert_eq!(
+            DisplayReadAggregateResults(vec![results.next_merged_result().unwrap()]).to_string(),
+            "time_count\n6\n",
+        );
+        assert!(matches!(results.next_merged_result(), None));
+
+        // apply a predicate
+        let mut results = table.read_aggregate(
+            Predicate::new(vec![BinaryExpr::from(("region", "=", "west"))]),
+            &Selection::Some(&[]),
+            &[("time", AggregateType::Count)],
+        );
+
+        assert_eq!(
+            DisplayReadAggregateResults(vec![results.next_merged_result().unwrap()]).to_string(),
+            "time_count\n2\n",
+        );
+        assert!(matches!(results.next_merged_result(), None));
+    }
+
+    #[test]
+    fn read_aggregate_result_display() {
         let mut result_a = ReadAggregateResult {
             schema: ResultSchema {
                 select_columns: vec![],


### PR DESCRIPTION
This PR adds a feature that I had already built at a lower level, but forgotten to implement in the Read Buffer's table and external API. Now you can use `read_aggregate` to ask for column aggregates without grouping on any other columns. Predicates are supported. So this effectively provides Read Buffer support for things like:

```sql
SELECT COUNT(temp), SUM(foo), MAX(bar) FROM cpu WHERE time > 100;
```

As part of this work I had to teach tables to merge row group results for `read_aggregate` when there were no group keys. My bad for forgetting this previously. 