### PR TITLE
feat: add Boolean column support

### DIFF
--- a/read_buffer/src/column.rs
+++ b/read_buffer/src/column.rs
@@ -1,3 +1,4 @@
+pub mod bool;
 pub mod cmp;
 pub mod dictionary;
 pub mod fixed;

--- a/read_buffer/src/column.rs
+++ b/read_buffer/src/column.rs
@@ -37,20 +37,16 @@ pub enum Column {
 
     // A column of signed integers, which may be encoded with a different
     // physical type to the logical type.
-    //
-    // TODO - meta stored at highest precision, but returning correct logical
-    // type probably needs some thought.
     Integer(MetaData<i64>, IntegerEncoding),
 
     // A column of unsigned integers, which may be encoded with a different
     // physical type to the logical type.
-    //
-    // TODO - meta stored at highest precision, but returning correct logical
-    // type probably needs some thought.
-    Unsigned(MetaData<u64>, IntegerEncoding), // TODO - 64-bit unsigned integers
+    Unsigned(MetaData<u64>, IntegerEncoding),
+
+    // A column of boolean values.
+    Bool(MetaData<bool>, BooleanEncoding),
 
     // These are TODO
-    Bool,                                         // TODO - booleans
     ByteArray(MetaData<Vec<u8>>, StringEncoding), // TODO - arbitrary bytes
 }
 
@@ -64,7 +60,7 @@ impl Column {
             Column::Float(meta, _) => meta.rows,
             Column::Integer(meta, _) => meta.rows,
             Column::Unsigned(meta, _) => meta.rows,
-            Column::Bool => todo!(),
+            Column::Bool(meta, _) => meta.rows,
             Column::ByteArray(meta, _) => meta.rows,
         }
     }
@@ -76,7 +72,7 @@ impl Column {
             Column::Float(_, _) => LogicalDataType::Float,
             Column::Integer(_, _) => LogicalDataType::Integer,
             Column::Unsigned(_, _) => LogicalDataType::Unsigned,
-            Column::Bool => LogicalDataType::Boolean,
+            Column::Bool(_, _) => LogicalDataType::Boolean,
             Column::ByteArray(_, _) => LogicalDataType::Binary,
         }
     }
@@ -116,7 +112,10 @@ impl Column {
                 )),
                 None => None,
             },
-            Column::Bool => todo!(),
+            Column::Bool(meta, _) => match meta.range {
+                Some(range) => Some((OwnedValue::Boolean(range.0), OwnedValue::Boolean(range.1))),
+                None => None,
+            },
             Column::ByteArray(_, _) => todo!(),
         }
     }
@@ -127,7 +126,7 @@ impl Column {
             Column::Float(meta, _) => &meta.properties,
             Column::Integer(meta, _) => &meta.properties,
             Column::Unsigned(meta, _) => &meta.properties,
-            Column::Bool => todo!(),
+            Column::Bool(meta, _) => &meta.properties,
             Column::ByteArray(meta, _) => &meta.properties,
         }
     }
@@ -160,7 +159,7 @@ impl Column {
             Column::Float(_, data) => data.value(row_id),
             Column::Integer(_, data) => data.value(row_id),
             Column::Unsigned(_, data) => data.value(row_id),
-            Column::Bool => todo!(),
+            Column::Bool(_, data) => data.value(row_id),
             Column::ByteArray(_, _) => todo!(),
         }
     }
@@ -181,7 +180,7 @@ impl Column {
             Column::Float(_, data) => data.values(row_ids),
             Column::Integer(_, data) => data.values(row_ids),
             Column::Unsigned(_, data) => data.values(row_ids),
-            Column::Bool => todo!(),
+            Column::Bool(_, data) => data.values(row_ids),
             Column::ByteArray(_, _) => todo!(),
         }
     }
@@ -193,7 +192,7 @@ impl Column {
             Column::Float(_, data) => data.all_values(),
             Column::Integer(_, data) => data.all_values(),
             Column::Unsigned(_, data) => data.all_values(),
-            Column::Bool => todo!(),
+            Column::Bool(_, data) => data.all_values(),
             Column::ByteArray(_, _) => todo!(),
         }
     }
@@ -300,7 +299,7 @@ impl Column {
             Column::Float(_, data) => data.row_ids_filter(op, value.scalar(), dst),
             Column::Integer(_, data) => data.row_ids_filter(op, value.scalar(), dst),
             Column::Unsigned(_, data) => data.row_ids_filter(op, value.scalar(), dst),
-            Column::Bool => todo!(),
+            Column::Bool(_, data) => data.row_ids_filter(op, value.bool(), dst),
             Column::ByteArray(_, data) => todo!(),
         };
 
@@ -359,7 +358,7 @@ impl Column {
             Column::Unsigned(_, data) => {
                 data.row_ids_filter_range((&low.0, low.1.scalar()), (&high.0, high.1.scalar()), dst)
             }
-            Column::Bool => todo!(),
+            Column::Bool(_, data) => unimplemented!("filter_range not supported on boolean column"),
             Column::ByteArray(_, data) => todo!(),
         };
 
@@ -412,7 +411,9 @@ impl Column {
         PredicateMatch::SomeMaybe
     }
 
-    // Helper method to determine if the column possibly contains this value
+    // Helper method to determine if the column possibly contains this value.
+    //
+    // TODO(edd): currently this only handles non-null values.
     fn might_contain_value(&self, value: &Value<'_>) -> bool {
         match &self {
             Column::String(meta, _) => {
@@ -442,13 +443,19 @@ impl Column {
                 .scalar()
                 .try_as_u64()
                 .map_or_else(|| false, |v| meta.might_contain_value(v)),
-            Column::Bool => todo!(),
+            Column::Bool(meta, _) => match value {
+                Value::Null => false,
+                Value::Boolean(b) => meta.might_contain_value(*b),
+                v => panic!("cannot compare boolean to {:?}", v),
+            },
             Column::ByteArray(meta, _) => todo!(),
         }
     }
 
     // Helper method to determine if the predicate matches all the values in
     // the column.
+    //
+    // TODO(edd): this doesn't handle matching on NULL yet.
     fn predicate_matches_all_values(&self, op: &cmp::Operator, value: &Value<'_>) -> bool {
         match &self {
             Column::String(meta, data) => {
@@ -499,7 +506,17 @@ impl Column {
                     .try_as_u64()
                     .map_or_else(|| false, |v| meta.might_match_all_values(op, v))
             }
-            Column::Bool => todo!(),
+            Column::Bool(meta, data) => {
+                if data.contains_null() {
+                    return false;
+                }
+
+                match value {
+                    Value::Null => false,
+                    Value::Boolean(b) => meta.might_match_all_values(op, *b),
+                    v => panic!("cannot compare on boolean column using {:?}", v),
+                }
+            }
             Column::ByteArray(meta, _) => todo!(),
         }
     }
@@ -523,7 +540,7 @@ impl Column {
             Column::Float(meta, data) => meta.match_no_values(op, value.scalar().as_f64()),
             Column::Integer(meta, data) => meta.match_no_values(op, value.scalar().as_i64()),
             Column::Unsigned(meta, data) => meta.match_no_values(op, value.scalar().as_u64()),
-            Column::Bool => todo!(),
+            Column::Bool(meta, data) => meta.match_no_values(op, value.bool()),
             Column::ByteArray(meta, _) => todo!(),
         }
     }
@@ -541,7 +558,7 @@ impl Column {
             Column::Float(_, data) => data.min(row_ids),
             Column::Integer(_, data) => data.min(row_ids),
             Column::Unsigned(_, data) => data.min(row_ids),
-            Column::Bool => todo!(),
+            Column::Bool(_, data) => data.min(row_ids),
             Column::ByteArray(_, _) => todo!(),
         }
     }
@@ -555,7 +572,7 @@ impl Column {
             Column::Float(_, data) => data.max(row_ids),
             Column::Integer(_, data) => data.max(row_ids),
             Column::Unsigned(_, data) => data.max(row_ids),
-            Column::Bool => todo!(),
+            Column::Bool(_, data) => data.max(row_ids),
             Column::ByteArray(_, _) => todo!(),
         }
     }
@@ -585,7 +602,7 @@ impl Column {
             Column::Float(_, data) => data.count(row_ids),
             Column::Integer(_, data) => data.count(row_ids),
             Column::Unsigned(_, data) => data.count(row_ids),
-            Column::Bool => todo!(),
+            Column::Bool(_, data) => data.count(row_ids),
             Column::ByteArray(_, _) => todo!(),
         }
     }
@@ -1379,9 +1396,10 @@ pub enum FloatEncoding {
 impl FloatEncoding {
     /// Determines if the column contains a NULL value.
     pub fn contains_null(&self) -> bool {
-        // TODO(edd): when adding the nullable columns then ask the nullable
-        // encoding if it has any null values.
-        false
+        match self {
+            Self::Fixed64(_) => false,
+            Self::FixedNull64(enc) => enc.contains_null(),
+        }
     }
 
     /// Returns the logical value found at the provided row id.
@@ -1480,6 +1498,83 @@ impl FloatEncoding {
         match &self {
             FloatEncoding::Fixed64(c) => c.count(row_ids),
             FloatEncoding::FixedNull64(c) => c.count(row_ids),
+        }
+    }
+}
+
+/// Encodings for boolean values.
+pub enum BooleanEncoding {
+    BooleanNull(bool::Bool),
+}
+
+impl BooleanEncoding {
+    /// Determines if the column contains a NULL value.
+    pub fn contains_null(&self) -> bool {
+        match self {
+            BooleanEncoding::BooleanNull(enc) => enc.contains_null(),
+        }
+    }
+
+    /// Returns the logical value found at the provided row id.
+    pub fn value(&self, row_id: u32) -> Value<'_> {
+        match &self {
+            Self::BooleanNull(c) => match c.value(row_id) {
+                Some(v) => Value::Boolean(v),
+                None => Value::Null,
+            },
+        }
+    }
+
+    /// Returns the logical values found at the provided row ids.
+    ///
+    /// TODO(edd): perf - pooling of destination vectors.
+    pub fn values(&self, row_ids: &[u32]) -> Values<'_> {
+        match &self {
+            Self::BooleanNull(c) => Values::Bool(c.values(row_ids, vec![])),
+        }
+    }
+
+    /// Returns all logical values in the column.
+    ///
+    /// TODO(edd): perf - pooling of destination vectors.
+    pub fn all_values(&self) -> Values<'_> {
+        match &self {
+            Self::BooleanNull(c) => Values::Bool(c.all_values(vec![])),
+        }
+    }
+
+    /// Returns the row ids that satisfy the provided predicate.
+    ///
+    /// Note: it is the caller's responsibility to ensure that the provided
+    /// `Scalar` value will fit within the physical type of the encoded column.
+    /// `row_ids_filter` will panic if this invariant is broken.
+    pub fn row_ids_filter(&self, op: &cmp::Operator, value: bool, dst: RowIDs) -> RowIDs {
+        match &self {
+            Self::BooleanNull(c) => c.row_ids_filter(value, op, dst),
+        }
+    }
+
+    pub fn min(&self, row_ids: &[u32]) -> Value<'_> {
+        match &self {
+            Self::BooleanNull(c) => match c.min(row_ids) {
+                Some(v) => Value::Boolean(v),
+                None => Value::Null,
+            },
+        }
+    }
+
+    pub fn max(&self, row_ids: &[u32]) -> Value<'_> {
+        match &self {
+            Self::BooleanNull(c) => match c.max(row_ids) {
+                Some(v) => Value::Boolean(v),
+                None => Value::Null,
+            },
+        }
+    }
+
+    pub fn count(&self, row_ids: &[u32]) -> u32 {
+        match &self {
+            Self::BooleanNull(c) => c.count(row_ids),
         }
     }
 }
@@ -2403,6 +2498,13 @@ impl Value<'_> {
             return s;
         }
         panic!("cannot unwrap Value to String");
+    }
+
+    pub fn bool(&self) -> bool {
+        if let Self::Boolean(b) = self {
+            return *b;
+        }
+        panic!("cannot unwrap Value to Scalar");
     }
 }
 

--- a/read_buffer/src/column/bool.rs
+++ b/read_buffer/src/column/bool.rs
@@ -1,0 +1,440 @@
+//! An encoding nullable bool, by an Arrow array.
+use std::cmp::Ordering;
+use std::fmt::Debug;
+
+use arrow_deps::arrow::array::{Array, BooleanArray};
+
+use crate::column::{cmp, RowIDs};
+
+#[derive(Debug)]
+pub struct Bool {
+    arr: BooleanArray,
+}
+
+impl std::fmt::Display for Bool {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "[Bool] rows: {:?}, nulls: {:?}, size: {}",
+            self.arr.len(),
+            self.arr.null_count(),
+            self.size()
+        )
+    }
+}
+impl Bool {
+    pub fn num_rows(&self) -> u32 {
+        self.arr.len() as u32
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.arr.is_empty()
+    }
+
+    pub fn contains_null(&self) -> bool {
+        self.arr.null_count() > 0
+    }
+
+    /// Returns the total size in bytes of the encoded data. Note, this method
+    /// is really an "accurate" estimation. It doesn't include for example the
+    /// size of the `Plain` struct receiver.
+    pub fn size(&self) -> u64 {
+        unimplemented!("not yet implemented")
+    }
+
+    //
+    //
+    // ---- Methods for getting row ids from values.
+    //
+    //
+
+    /// Returns the first logical row that contains a value `v`.
+    pub fn first_row_id_eq_value(&self, v: bool) -> Option<usize> {
+        for i in 0..self.arr.len() {
+            if self.arr.is_null(i) {
+                continue;
+            } else if self.arr.value(i) == v {
+                return Some(i);
+            }
+        }
+        None
+    }
+
+    //
+    //
+    // ---- Methods for getting decoded values.
+    //
+    //
+
+    /// Return the logical value at the provided row ID. A NULL value
+    /// is represented by None.
+    pub fn value(&self, row_id: u32) -> Option<bool> {
+        if self.arr.is_null(row_id as usize) {
+            return None;
+        }
+        Some(self.arr.value(row_id as usize))
+    }
+
+    /// Returns the logical values for the provided row IDs.
+    ///
+    /// NULL values are represented by None.
+    pub fn values(&self, row_ids: &[u32], mut dst: Vec<Option<bool>>) -> Vec<Option<bool>> {
+        dst.clear();
+        dst.reserve(row_ids.len());
+
+        for &row_id in row_ids {
+            if self.arr.is_null(row_id as usize) {
+                dst.push(None)
+            } else {
+                dst.push(Some(self.arr.value(row_id as usize)))
+            }
+        }
+        assert_eq!(dst.len(), row_ids.len());
+        dst
+    }
+
+    /// Returns the logical values for all the rows in the column.
+    ///
+    /// NULL values are represented by None.
+    pub fn all_values(&self, mut dst: Vec<Option<bool>>) -> Vec<Option<bool>> {
+        dst.clear();
+        dst.reserve(self.arr.len());
+
+        for i in 0..self.num_rows() as usize {
+            if self.arr.is_null(i) {
+                dst.push(None)
+            } else {
+                dst.push(Some(self.arr.value(i)))
+            }
+        }
+        assert_eq!(dst.len(), self.num_rows() as usize);
+        dst
+    }
+
+    //
+    //
+    // ---- Methods for aggregation.
+    //
+    //
+
+    /// Returns the count of the non-null values for the provided
+    /// row IDs.
+    pub fn count(&self, row_ids: &[u32]) -> u32 {
+        if self.arr.null_count() == 0 {
+            return row_ids.len() as u32;
+        }
+
+        let mut count = 0;
+        for &i in row_ids {
+            if self.arr.is_null(i as usize) {
+                continue;
+            }
+            count += 1;
+        }
+        count
+    }
+
+    /// Returns the first logical (decoded) value from the provided
+    /// row IDs.
+    pub fn first(&self, row_ids: &[u32]) -> Option<bool> {
+        self.value(row_ids[0])
+    }
+
+    /// Returns the last logical (decoded) value from the provided
+    /// row IDs.
+    pub fn last(&self, row_ids: &[u32]) -> Option<bool> {
+        self.value(row_ids[row_ids.len() - 1])
+    }
+
+    /// Returns the minimum logical (decoded) non-null value from the provided
+    /// row IDs.
+    pub fn min(&self, row_ids: &[u32]) -> Option<bool> {
+        let mut min: Option<bool> = self.value(row_ids[0]);
+        for &v in row_ids.iter().skip(1) {
+            if self.arr.is_null(v as usize) {
+                continue;
+            }
+
+            if self.value(v) < min {
+                min = self.value(v);
+            }
+        }
+        min
+    }
+
+    /// Returns the maximum logical (decoded) non-null value from the provided
+    /// row IDs.
+    pub fn max(&self, row_ids: &[u32]) -> Option<bool> {
+        let mut max: Option<bool> = self.value(row_ids[0]);
+        for &v in row_ids.iter().skip(1) {
+            if self.arr.is_null(v as usize) {
+                continue;
+            }
+
+            if self.value(v) > max {
+                max = self.value(v);
+            }
+        }
+        max
+    }
+
+    //
+    //
+    // ---- Methods for filtering via operators.
+    //
+    //
+
+    /// Returns the set of row ids that satisfy a binary operator on a logical
+    /// value.
+    ///
+    /// Essentially, this supports `value {=, !=, >, >=, <, <=} x`.
+    ///
+    /// The equivalent of `IS NULL` is not currently supported via this method.
+    pub fn row_ids_filter(&self, value: bool, op: &cmp::Operator, dst: RowIDs) -> RowIDs {
+        match op {
+            cmp::Operator::GT => self.row_ids_cmp_order(value, Self::ord_from_op(&op), dst),
+            cmp::Operator::GTE => self.row_ids_cmp_order(value, Self::ord_from_op(&op), dst),
+            cmp::Operator::LT => self.row_ids_cmp_order(value, Self::ord_from_op(&op), dst),
+            cmp::Operator::LTE => self.row_ids_cmp_order(value, Self::ord_from_op(&op), dst),
+            _ => self.row_ids_equal(value, op, dst),
+        }
+    }
+
+    // Helper function to convert comparison operators to cmp orderings.
+    fn ord_from_op(op: &cmp::Operator) -> (Ordering, Ordering) {
+        match op {
+            cmp::Operator::GT => (Ordering::Greater, Ordering::Greater),
+            cmp::Operator::GTE => (Ordering::Greater, Ordering::Equal),
+            cmp::Operator::LT => (Ordering::Less, Ordering::Less),
+            cmp::Operator::LTE => (Ordering::Less, Ordering::Equal),
+            _ => panic!("cannot convert operator to ordering"),
+        }
+    }
+
+    // Handles finding all rows that match the provided operator on `value`.
+    // For performance reasons ranges of matching values are collected up and
+    // added in bulk to the bitmap.
+    fn row_ids_equal(&self, value: bool, op: &cmp::Operator, mut dst: RowIDs) -> RowIDs {
+        dst.clear();
+
+        let desired;
+        if let cmp::Operator::Equal = op {
+            desired = true; // == operator
+        } else {
+            desired = false; // != operator
+        }
+
+        let mut found = false;
+        let mut count = 0;
+        for i in 0..self.num_rows() as usize {
+            let mut cmp_result: bool;
+            let cmp_result = self.arr.value(i) == value;
+
+            if (self.arr.is_null(i) || cmp_result != desired) && found {
+                let (min, max) = (i as u32 - count, i as u32);
+                dst.add_range(min, max);
+                found = false;
+                count = 0;
+                continue;
+            } else if self.arr.is_null(i) || cmp_result != desired {
+                continue;
+            }
+
+            if !found {
+                found = true;
+            }
+            count += 1;
+        }
+
+        // add any remaining range.
+        if found {
+            let (min, max) = (self.num_rows() - count, self.num_rows());
+            dst.add_range(min, max);
+        }
+        dst
+    }
+
+    // Handles finding all rows that match the provided operator on `value`.
+    // For performance reasons ranges of matching values are collected up and
+    // added in bulk to the bitmap.
+    //
+    // `op` is a tuple of comparisons where at least one of them must be
+    // satisfied to satisfy the overall operator.
+    fn row_ids_cmp_order(
+        &self,
+        value: bool,
+        op: (std::cmp::Ordering, std::cmp::Ordering),
+        mut dst: RowIDs,
+    ) -> RowIDs {
+        dst.clear();
+
+        let mut found = false;
+        let mut count = 0;
+        for i in 0..self.num_rows() as usize {
+            let cmp_result = self.arr.value(i).partial_cmp(&value);
+
+            if (self.arr.is_null(i) || (cmp_result != Some(op.0) && cmp_result != Some(op.1)))
+                && found
+            {
+                let (min, max) = (i as u32 - count, i as u32);
+                dst.add_range(min, max);
+                found = false;
+                count = 0;
+                continue;
+            } else if self.arr.is_null(i) || (cmp_result != Some(op.0) && cmp_result != Some(op.1))
+            {
+                continue;
+            }
+
+            if !found {
+                found = true;
+            }
+            count += 1;
+        }
+
+        // add any remaining range.
+        if found {
+            let (min, max) = (self.num_rows() - count, self.num_rows());
+            dst.add_range(min, max);
+        }
+        dst
+    }
+}
+
+impl From<&[bool]> for Bool {
+    fn from(v: &[bool]) -> Self {
+        Self {
+            arr: BooleanArray::from(v.to_vec()),
+        }
+    }
+}
+
+impl From<&[Option<bool>]> for Bool {
+    fn from(v: &[Option<bool>]) -> Self {
+        Self {
+            arr: BooleanArray::from(v.to_vec()),
+        }
+    }
+}
+
+impl From<BooleanArray> for Bool {
+    fn from(arr: BooleanArray) -> Self {
+        Self { arr }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::cmp::Operator;
+    use super::*;
+
+    fn some_vec<T: Copy>(v: Vec<T>) -> Vec<Option<T>> {
+        v.iter().map(|x| Some(*x)).collect()
+    }
+
+    #[test]
+    fn first_row_id_eq_value() {
+        let v = Bool::from(vec![true, true].as_slice());
+
+        assert_eq!(v.first_row_id_eq_value(true), Some(0));
+        assert_eq!(v.first_row_id_eq_value(false), None);
+    }
+
+    #[test]
+    fn value() {
+        let v = Bool::from(vec![Some(false), Some(true), Some(false), None].as_slice());
+        assert_eq!(v.value(1), Some(true));
+        assert_eq!(v.value(3), None);
+    }
+
+    #[test]
+    fn count() {
+        let v = Bool::from(&[Some(true), None, Some(true)][..]);
+        assert_eq!(v.count(&[0, 1, 2]), 2);
+        assert_eq!(v.count(&[0, 2]), 2);
+        assert_eq!(v.count(&[0, 1]), 1);
+        assert_eq!(v.count(&[1]), 0);
+    }
+
+    #[test]
+    fn first() {
+        let v = Bool::from(&[false, true, true][..]);
+        assert_eq!(v.first(&[0, 1, 2]), Some(false));
+        assert_eq!(v.first(&[1, 2]), Some(true));
+    }
+
+    #[test]
+    fn last() {
+        let v = Bool::from(&[false, true, false][..]);
+        assert_eq!(v.last(&[0, 1, 2]), Some(false));
+        assert_eq!(v.last(&[1, 2]), Some(false));
+        assert_eq!(v.last(&[0, 2]), Some(false));
+    }
+
+    #[test]
+    fn min() {
+        let v = Bool::from(&[Some(true), Some(true), Some(false), None][..]);
+        assert_eq!(v.min(&[0, 1, 2, 3]), Some(false));
+        assert_eq!(v.min(&[1, 2]), Some(false));
+        assert_eq!(v.min(&[0, 1]), Some(true));
+        assert_eq!(v.min(&[0, 3]), Some(true));
+        assert_eq!(v.min(&[3]), None);
+    }
+
+    #[test]
+    fn max() {
+        let v = Bool::from(&[Some(true), Some(true), Some(false), None][..]);
+        assert_eq!(v.max(&[0, 1, 2, 3]), Some(true));
+        assert_eq!(v.max(&[1, 2]), Some(true));
+        assert_eq!(v.max(&[0, 1]), Some(true));
+        assert_eq!(v.max(&[0, 3]), Some(true));
+        assert_eq!(v.max(&[3]), None);
+    }
+
+    #[test]
+    fn row_ids_filter() {
+        let v = Bool::from(&[Some(true), Some(false), None, None, Some(true)][..]);
+
+        // EQ
+        let row_ids = v.row_ids_filter(true, &Operator::Equal, RowIDs::new_vector());
+        assert_eq!(row_ids.to_vec(), vec![0, 4]);
+
+        let row_ids = v.row_ids_filter(false, &Operator::Equal, RowIDs::new_vector());
+        assert_eq!(row_ids.to_vec(), vec![1]);
+
+        // NEQ
+        let row_ids = v.row_ids_filter(true, &Operator::NotEqual, RowIDs::new_vector());
+        assert_eq!(row_ids.to_vec(), vec![1]);
+
+        let row_ids = v.row_ids_filter(false, &Operator::NotEqual, RowIDs::new_vector());
+        assert_eq!(row_ids.to_vec(), vec![0, 4]);
+
+        // GT
+        let row_ids = v.row_ids_filter(true, &Operator::GT, RowIDs::new_vector());
+        assert_eq!(row_ids.to_vec(), Vec::<u32>::new());
+
+        let row_ids = v.row_ids_filter(false, &Operator::GT, RowIDs::new_vector());
+        assert_eq!(row_ids.to_vec(), vec![0, 4]);
+
+        // GTE
+        let row_ids = v.row_ids_filter(true, &Operator::GTE, RowIDs::new_vector());
+        assert_eq!(row_ids.to_vec(), vec![0, 4]);
+
+        let row_ids = v.row_ids_filter(false, &Operator::GTE, RowIDs::new_vector());
+        assert_eq!(row_ids.to_vec(), vec![0, 1, 4]);
+
+        // LT
+        let row_ids = v.row_ids_filter(true, &Operator::LT, RowIDs::new_vector());
+        assert_eq!(row_ids.to_vec(), vec![1]);
+
+        let row_ids = v.row_ids_filter(false, &Operator::LT, RowIDs::new_vector());
+        assert_eq!(row_ids.to_vec(), Vec::<u32>::new());
+
+        // LTE
+        let row_ids = v.row_ids_filter(true, &Operator::LTE, RowIDs::new_vector());
+        assert_eq!(row_ids.to_vec(), vec![0, 1, 4]);
+
+        let row_ids = v.row_ids_filter(false, &Operator::LTE, RowIDs::new_vector());
+        assert_eq!(row_ids.to_vec(), vec![1]);
+    }
+}

--- a/read_buffer/src/column/bool.rs
+++ b/read_buffer/src/column/bool.rs
@@ -39,7 +39,7 @@ impl Bool {
     /// is really an "accurate" estimation. It doesn't include for example the
     /// size of the `Plain` struct receiver.
     pub fn size(&self) -> u64 {
-        unimplemented!("not yet implemented")
+        0
     }
 
     //

--- a/read_buffer/src/column/bool.rs
+++ b/read_buffer/src/column/bool.rs
@@ -217,12 +217,11 @@ impl Bool {
     fn row_ids_equal(&self, value: bool, op: &cmp::Operator, mut dst: RowIDs) -> RowIDs {
         dst.clear();
 
-        let desired;
-        if let cmp::Operator::Equal = op {
-            desired = true; // == operator
+        let desired =  if let cmp::Operator::Equal = op {
+            true // == operator
         } else {
-            desired = false; // != operator
-        }
+            false // != operator
+        };
 
         let mut found = false;
         let mut count = 0;

--- a/read_buffer/src/lib.rs
+++ b/read_buffer/src/lib.rs
@@ -716,7 +716,7 @@ mod test {
         array::{
             ArrayRef, BinaryArray, BooleanArray, Float64Array, Int64Array, StringArray, UInt64Array,
         },
-        datatypes::DataType::{Float64, Int64, UInt64},
+        datatypes::DataType::{Boolean, Float64, Int64, UInt64},
     };
 
     use column::Values;
@@ -727,6 +727,7 @@ mod test {
         let schema = SchemaBuilder::new()
             .non_null_tag("region")
             .non_null_field("counter", Float64)
+            .non_null_field("active", Boolean)
             .timestamp()
             .field("sketchy_sensor", Float64)
             .build()
@@ -736,6 +737,7 @@ mod test {
         let data: Vec<ArrayRef> = vec![
             Arc::new(StringArray::from(vec!["west", "west", "east"])),
             Arc::new(Float64Array::from(vec![1.2, 3.3, 45.3])),
+            Arc::new(BooleanArray::from(vec![true, false, true])),
             Arc::new(Int64Array::from(vec![11111111, 222222, 3333])),
             Arc::new(Float64Array::from(vec![Some(11.0), None, Some(12.0)])),
         ];
@@ -1001,6 +1003,7 @@ mod test {
                 .non_null_tag("region")
                 .non_null_field("counter", Float64)
                 .field("sketchy_sensor", Int64)
+                .non_null_field("active", Boolean)
                 .timestamp()
                 .build()
                 .unwrap();
@@ -1010,6 +1013,7 @@ mod test {
                 Arc::new(StringArray::from(vec!["west", "west", "east"])),
                 Arc::new(Float64Array::from(vec![1.2, 300.3, 4500.3])),
                 Arc::new(Int64Array::from(vec![None, Some(33), Some(44)])),
+                Arc::new(BooleanArray::from(vec![true, false, false])),
                 Arc::new(Int64Array::from(vec![i, 2 * i, 3 * i])),
             ];
 
@@ -1038,6 +1042,7 @@ mod test {
         let exp_region_values = Values::String(vec![Some("west")]);
         let exp_counter_values = Values::F64(vec![1.2]);
         let exp_sketchy_sensor_values = Values::I64N(vec![None]);
+        let exp_active_values = Values::Bool(vec![Some(true)]);
 
         let first_row_group = itr.next().unwrap();
         println!("{:?}", first_row_group);
@@ -1049,6 +1054,7 @@ mod test {
             "sketchy_sensor",
             &exp_sketchy_sensor_values,
         );
+        assert_rb_column_equals(&first_row_group, "active", &exp_active_values);
         assert_rb_column_equals(&first_row_group, "time", &Values::I64(vec![100])); // first row from first record batch
 
         let second_row_group = itr.next().unwrap();
@@ -1061,6 +1067,7 @@ mod test {
             "sketchy_sensor",
             &exp_sketchy_sensor_values,
         );
+        assert_rb_column_equals(&first_row_group, "active", &exp_active_values);
         assert_rb_column_equals(&second_row_group, "time", &Values::I64(vec![200])); // first row from second record batch
 
         // No more data
@@ -1149,6 +1156,7 @@ mod test {
                 .non_null_field("temp", Float64)
                 .non_null_field("counter", UInt64)
                 .field("sketchy_sensor", UInt64)
+                .non_null_field("active", Boolean)
                 .timestamp()
                 .build()
                 .unwrap();
@@ -1159,6 +1167,7 @@ mod test {
                 Arc::new(Float64Array::from(vec![10.0, 30000.0, 4500.0])),
                 Arc::new(UInt64Array::from(vec![1000, 3000, 5000])),
                 Arc::new(UInt64Array::from(vec![Some(44), None, Some(55)])),
+                Arc::new(BooleanArray::from(vec![true, true, false])),
                 Arc::new(Int64Array::from(vec![i, 20 + i, 30 + i])),
             ];
 
@@ -1194,6 +1203,9 @@ mod test {
                     ("sketchy_sensor", AggregateType::Sum),
                     ("sketchy_sensor", AggregateType::Min),
                     ("sketchy_sensor", AggregateType::Max),
+                    ("active", AggregateType::Count),
+                    ("active", AggregateType::Min),
+                    ("active", AggregateType::Max),
                 ],
             )
             .unwrap();
@@ -1209,6 +1221,9 @@ mod test {
         assert_rb_column_equals(&result, "sketchy_sensor_sum", &Values::U64(vec![99])); // sum of non-null values
         assert_rb_column_equals(&result, "sketchy_sensor_min", &Values::U64(vec![44])); // min of non-null values
         assert_rb_column_equals(&result, "sketchy_sensor_max", &Values::U64(vec![55])); // max of non-null values
+        assert_rb_column_equals(&result, "active_count", &Values::U64(vec![3]));
+        assert_rb_column_equals(&result, "active_min", &Values::Bool(vec![Some(false)]));
+        assert_rb_column_equals(&result, "active_max", &Values::Bool(vec![Some(true)]));
 
         //
         // With group keys


### PR DESCRIPTION
This PR adds support for nullable boolean column values in the Read Buffer.

The following aggregations are currently supported on them: `{Count, Sum, Min, Max}`, along with the following predicate operators: `{=, !=, <, <=, >, >=}`.

The encoding is backed by an arrow `BooleanArray`.


