### PR TITLE
feat: Implement logfmt (Heroku) formatted log output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1504,6 +1504,7 @@ dependencies = [
  "influxdb_tsm",
  "ingest",
  "lazy_static",
+ "logfmt",
  "mem_qe",
  "mutable_buffer",
  "object_store",
@@ -1719,6 +1720,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
 dependencies = [
  "cfg-if 1.0.0",
+]
+
+[[package]]
+name = "logfmt"
+version = "0.1.0"
+dependencies = [
+ "lazy_static",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1727,6 +1727,7 @@ name = "logfmt"
 version = "0.1.0"
 dependencies = [
  "lazy_static",
+ "regex",
  "tracing",
  "tracing-subscriber",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ members = [
     "influxdb_tsm",
     "influxdb2_client",
     "ingest",
+    "logfmt",
     "mem_qe",
     "mutable_buffer",
     "object_store",
@@ -41,6 +42,7 @@ influxdb_iox_client = { path = "influxdb_iox_client" }
 influxdb_line_protocol = { path = "influxdb_line_protocol" }
 influxdb_tsm = { path = "influxdb_tsm" }
 ingest = { path = "ingest" }
+logfmt = { path = "logfmt" }
 mem_qe = { path = "mem_qe" }
 mutable_buffer = { path = "mutable_buffer" }
 object_store = { path = "object_store" }

--- a/logfmt/Cargo.toml
+++ b/logfmt/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "logfmt"
+version = "0.1.0"
+authors = ["Andrew Lamb <andrew@nerdnetworks.org>"]
+description="tracing_subscriber layer for writing out logfmt formatted events"
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+tracing = { version = "0.1" }
+tracing-subscriber = "0.2.15"
+
+[dev-dependencies]
+lazy_static = "1.4.0"

--- a/logfmt/Cargo.toml
+++ b/logfmt/Cargo.toml
@@ -13,3 +13,4 @@ tracing-subscriber = "0.2.15"
 
 [dev-dependencies]
 lazy_static = "1.4.0"
+regex = "1.4.3"

--- a/logfmt/src/lib.rs
+++ b/logfmt/src/lib.rs
@@ -66,12 +66,11 @@ where
         let mut p = FieldPrinter::new(writer, event.metadata().level());
         // record fields
         event.record(&mut p);
-        // record source information
-        p.write_source_info(event);
-
         if let Some(span) = ctx.lookup_current() {
             p.write_span_id(span.id())
         }
+        // record source information
+        p.write_source_info(event);
         p.write_timestamp();
     }
 }

--- a/logfmt/src/lib.rs
+++ b/logfmt/src/lib.rs
@@ -232,11 +232,7 @@ fn needs_quotes_and_escaping(value: &str) -> bool {
         return true;
     }
 
-    if value.contains(' ') && !pre_quoted {
-        return true;
-    }
-
-    false
+    value.contains(' ') && !pre_quoted
 }
 
 /// escape any characters in name as needed, otherwise return string as is

--- a/logfmt/src/lib.rs
+++ b/logfmt/src/lib.rs
@@ -1,0 +1,318 @@
+use std::borrow::Cow;
+use std::{io::Write, time::SystemTime};
+use tracing::{
+    field::{Field, Visit},
+    subscriber::Interest,
+    Id, Level, Subscriber,
+};
+use tracing_subscriber::{self, fmt::MakeWriter, layer::Context, registry::LookupSpan, Layer};
+
+/// Implements a `tracing_subscriber::Layer` which generates
+/// [logfmt] formatted log entries, suitable for log ingestion
+///
+/// At time of writing, I could find no good existing crate
+///
+/// https://github.com/mcountryman/logfmt_logger from @mcountryman
+/// looked very small and did not (obviously) work with the tracing subscriber
+///
+/// [logfmt](https://brandur.org/logfmt)
+pub struct LogFmtLayer<W: MakeWriter> {
+    writer: W,
+}
+
+impl<W: MakeWriter> LogFmtLayer<W> {
+    /// Create a new logfmt Layer to pass into tracing_subscriber
+    ///
+    /// Note this layer simply formats and writes to the specified writer. It
+    /// does not do any filtering for levels itself. Filtering can be done
+    /// using a EnvFilter
+    ///
+    /// For example:
+    /// ```
+    ///  use logfmt::LogFmtLayer;
+    ///  use tracing_subscriber::{EnvFilter, prelude::*};
+    ///
+    ///  // setup debug logging level
+    ///  std::env::set_var("RUST_LOG", "debug");
+    ///
+    ///  // setup formatter to write to stderr
+    ///  let formatter =
+    ///    LogFmtLayer::new(std::io::stderr);
+    ///
+    ///  tracing_subscriber::registry()
+    ///    .with(EnvFilter::from_default_env())
+    ///    .with(formatter)
+    ///    .init();
+    /// ```
+    pub fn new(writer: W) -> Self {
+        Self { writer }
+    }
+}
+
+impl<S, W> Layer<S> for LogFmtLayer<W>
+where
+    W: MakeWriter + 'static,
+    S: Subscriber + for<'a> LookupSpan<'a>,
+{
+    fn register_callsite(
+        &self,
+        _metadata: &'static tracing::Metadata<'static>,
+    ) -> tracing::subscriber::Interest {
+        Interest::always()
+    }
+
+    fn on_event(&self, event: &tracing::Event<'_>, ctx: Context<'_, S>) {
+        let writer = self.writer.make_writer();
+        let mut p = FieldPrinter::new(writer, event.metadata().level());
+        // record fields
+        event.record(&mut p);
+        // record source information
+        p.write_source_info(event);
+
+        if let Some(span) = ctx.lookup_current() {
+            p.write_span_id(span.id())
+        }
+        p.write_timestamp();
+    }
+}
+
+/// This thing is responsible for actually printing log information to
+/// a writer
+struct FieldPrinter<W: Write> {
+    writer: W,
+}
+
+impl<W: Write> FieldPrinter<W> {
+    fn new(mut writer: W, level: &Level) -> Self {
+        let level_str = match *level {
+            Level::TRACE => "trace",
+            Level::DEBUG => "debug",
+            Level::INFO => "info",
+            Level::WARN => "warn",
+            Level::ERROR => "error",
+        };
+
+        write!(writer, r#"level={}"#, level_str).ok();
+
+        Self { writer }
+    }
+
+    fn write_source_info(&mut self, event: &tracing::Event<'_>) {
+        let metadata = event.metadata();
+        write!(self.writer, " target=\"{}\"", metadata.target()).ok();
+
+        if let Some(module_path) = metadata.module_path() {
+            if metadata.target() != module_path {
+                write!(self.writer, " module_path=\"{}\"", module_path).ok();
+            }
+        }
+        if let (Some(file), Some(line)) = (metadata.file(), metadata.line()) {
+            write!(self.writer, " location=\"{}:{}\"", file, line).ok();
+        }
+    }
+
+    fn write_span_id(&mut self, id: Id) {
+        write!(self.writer, " span={}", id.into_u64()).ok();
+    }
+
+    fn write_timestamp(&mut self) {
+        let ns_since_epoch = SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .expect("System time should have been after the epoch")
+            .as_nanos();
+
+        write!(self.writer, " time={:?}", ns_since_epoch).ok();
+    }
+}
+
+impl<W: Write> Drop for FieldPrinter<W> {
+    fn drop(&mut self) {
+        // finish the log line
+        writeln!(self.writer).ok();
+    }
+}
+
+impl<W: Write> Visit for FieldPrinter<W> {
+    fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
+        // Note this appears to be invoked via `debug!` and `info! macros
+        let formatted_value = format!("{:?}", value);
+        write!(
+            self.writer,
+            " {}={}",
+            translate_field_name(field.name()),
+            quote_and_escape(&formatted_value)
+        )
+        .ok();
+    }
+
+    fn record_i64(&mut self, field: &Field, value: i64) {
+        write!(
+            self.writer,
+            " {}={}",
+            translate_field_name(field.name()),
+            value
+        )
+        .ok();
+    }
+
+    fn record_u64(&mut self, field: &Field, value: u64) {
+        write!(
+            self.writer,
+            " {}={}",
+            translate_field_name(field.name()),
+            value
+        )
+        .ok();
+    }
+
+    fn record_bool(&mut self, field: &Field, value: bool) {
+        write!(
+            self.writer,
+            " {}={}",
+            translate_field_name(field.name()),
+            value
+        )
+        .ok();
+    }
+
+    fn record_str(&mut self, field: &Field, value: &str) {
+        write!(
+            self.writer,
+            " {}={}",
+            translate_field_name(field.name()),
+            quote_and_escape(value)
+        )
+        .ok();
+    }
+
+    fn record_error(&mut self, field: &Field, value: &(dyn std::error::Error + 'static)) {
+        let field_name = translate_field_name(field.name());
+
+        let debug_formatted = format!("{:?}", value);
+        write!(
+            self.writer,
+            " {}={:?}",
+            field_name,
+            quote_and_escape(&debug_formatted)
+        )
+        .ok();
+
+        let display_formatted = format!("{}", value);
+        write!(
+            self.writer,
+            " {}.display={}",
+            field_name,
+            quote_and_escape(&display_formatted)
+        )
+        .ok();
+    }
+}
+
+/// return true if the string value already starts/ends with quotes and is
+/// already properly escaped (all spaces escaped)
+fn needs_quotes_and_escaping(value: &str) -> bool {
+    // mismatches beginning  / end quotes
+    if value.starts_with('"') != value.ends_with('"') {
+        return true;
+    }
+
+    // ignore begining/ending quotes, if any
+    let pre_quoted = value.len() >= 2 && value.starts_with('"') && value.ends_with('"');
+
+    let value = if pre_quoted {
+        &value[1..value.len() - 1]
+    } else {
+        value
+    };
+
+    // unescaped quotes
+    let c0 = value.chars();
+    let c1 = value.chars().skip(1);
+    if c0.zip(c1).any(|(c0, c1)| c0 != '\\' && c1 == '"') {
+        return true;
+    }
+
+    if value.contains(' ') && !pre_quoted {
+        return true;
+    }
+
+    false
+}
+
+/// escape any characters in name as needed, otherwise return string as is
+fn quote_and_escape(value: &'_ str) -> Cow<'_, str> {
+    if needs_quotes_and_escaping(value) {
+        Cow::Owned(format!("\"{}\"", value.replace("\"", "\\\"")))
+    } else {
+        Cow::Borrowed(value)
+    }
+}
+
+// Translate the field name from tracing into the logfmt style
+fn translate_field_name(name: &str) -> &str {
+    if name == "message" {
+        "msg"
+    } else {
+        name
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn quote_and_escape_len0() {
+        assert_eq!(quote_and_escape(""), "");
+    }
+
+    #[test]
+    fn quote_and_escape_len1() {
+        assert_eq!(quote_and_escape("f"), "f");
+    }
+
+    #[test]
+    fn quote_and_escape_len2() {
+        assert_eq!(quote_and_escape("fo"), "fo");
+    }
+
+    #[test]
+    fn quote_and_escape_len3() {
+        assert_eq!(quote_and_escape("foo"), "foo");
+    }
+
+    #[test]
+    fn quote_and_escape_len3_1quote_start() {
+        assert_eq!(quote_and_escape("\"foo"), "\"\\\"foo\"");
+    }
+
+    #[test]
+    fn quote_and_escape_len3_1quote_end() {
+        assert_eq!(quote_and_escape("foo\""), "\"foo\\\"\"");
+    }
+
+    #[test]
+    fn quote_and_escape_len3_2quote() {
+        assert_eq!(quote_and_escape("\"foo\""), "\"foo\"");
+    }
+
+    #[test]
+    fn quote_and_escape_space() {
+        assert_eq!(quote_and_escape("foo bar"), "\"foo bar\"");
+    }
+
+    #[test]
+    fn quote_and_escape_space_prequoted() {
+        assert_eq!(quote_and_escape("\"foo bar\""), "\"foo bar\"");
+    }
+
+    #[test]
+    fn quote_and_escape_space_prequoted_but_not_escaped() {
+        assert_eq!(quote_and_escape("\"foo \"bar\""), "\"\\\"foo \\\"bar\\\"\"");
+    }
+
+    #[test]
+    fn quote_and_escape_quoted_quotes() {
+        assert_eq!(quote_and_escape("foo:\"bar\""), "\"foo:\\\"bar\\\"\"");
+    }
+}

--- a/logfmt/tests/logging.rs
+++ b/logfmt/tests/logging.rs
@@ -180,10 +180,10 @@ fn event_multi_span() {
     }
 
     let expected = vec![
-        "level=info span_name=\"my_span\" foo=bar span=SPAN0 time=1612209327939714000",
-        "level=info span_name=\"my_second_span\" foo=baz span=SPAN1 time=1612209327939743000",
+        "level=info span_name=\"my_span\" foo=bar span=1 time=1612209327939714000",
+        "level=info span_name=\"my_second_span\" foo=baz span=2 time=1612209327939743000",
         "level=info msg=\"info message in span 2\" shave=yak! target=\"logging\" location=\"logfmt/tests/logging.rs:154\" time=1612209327939774000",
-        "level=info span_name=\"my_second_span\" foo=brmp span=SPAN2 time=1612209327939795000",
+        "level=info span_name=\"my_second_span\" foo=brmp span=3 time=1612209327939795000",
         "level=info msg=\"info message in span 3\" shave=\"mo yak!\" target=\"logging\" location=\"logfmt/tests/logging.rs:160\" time=1612209327939828000",
     ];
 
@@ -243,7 +243,10 @@ fn normalize_location(v: &str) -> String {
 fn normalize_spans(lines: Vec<String>) -> Vec<String> {
     // since there can be multiple unique span values, need to normalize them
     // differently
-    let re = Regex::new(r#"span=(\S+)"#).unwrap();
+    //
+    // Note: we include leading and trailing spaces so that span=2
+    // doesn't also match span=21423
+    let re = Regex::new(r#" span=(\d+) "#).unwrap();
     let span_ids: Vec<String> = lines
         .iter()
         .map(|line| re.find_iter(line))
@@ -257,8 +260,7 @@ fn normalize_spans(lines: Vec<String>) -> Vec<String> {
         .enumerate()
         .fold(lines, |lines, (idx, orig_id)| {
             // replace old span
-            let new_id = format!("span=SPAN{}", idx);
-
+            let new_id = format!(" span=SPAN{} ", idx);
             let re = Regex::new(&orig_id).unwrap();
             lines
                 .into_iter()

--- a/src/commands/config.rs
+++ b/src/commands/config.rs
@@ -48,6 +48,13 @@ pub struct Config {
     #[structopt(long = "--log", env = "RUST_LOG")]
     pub rust_log: Option<String>,
 
+    /// Log message format. Can be one of:
+    ///
+    /// "rust" (default)
+    /// "logfmt" (logfmt/Heroku style - https://brandur.org/logfmt)
+    #[structopt(long = "--log_format", env = "INFLUXDB_IOX_LOG_FORMAT")]
+    pub log_format: Option<LogFormat>,
+
     /// This sets logging up with a pre-configured set of convenient log levels.
     ///
     /// -v  means 'info' log levels
@@ -151,6 +158,48 @@ fn strip_server(args: impl Iterator<Item = String>) -> Vec<String> {
             }
         })
         .collect::<Vec<_>>()
+}
+
+/// How to format output logging messages
+#[derive(Debug, Clone, Copy)]
+pub enum LogFormat {
+    /// Default formatted logging
+    ///
+    /// Example:
+    /// ```
+    /// level=warn msg="NO PERSISTENCE: using memory for object storage" target="influxdb_iox::influxdb_ioxd"
+    /// ```
+    Rust,
+
+    /// Use the (somwhat pretentiously named) Heroku / logfmt formatted output
+    /// format
+    ///
+    /// Example:
+    /// ```
+    /// Jan 31 13:19:39.059  WARN influxdb_iox::influxdb_ioxd: NO PERSISTENCE: using memory for object storage
+    /// ```
+    LogFmt,
+}
+
+impl Default for LogFormat {
+    fn default() -> Self {
+        Self::Rust
+    }
+}
+
+impl std::str::FromStr for LogFormat {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_ascii_lowercase().as_str() {
+            "rust" => Ok(Self::Rust),
+            "logfmt" => Ok(Self::LogFmt),
+            _ => Err(format!(
+                "Invalid log format '{}'. Valid options: rust, logfmt",
+                s
+            )),
+        }
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Closes https://github.com/influxdata/influxdb_iox/issues/516

# Rationale
The heroku logfmt logging format is commonly used (including The InfluxDB cloud service). The Rust standard log format is less commonly used (at the time of this writing). Thus, IOx should make it easy to hook up logs to existing systems.

I *really* want structured logs to appear in our internal InfluxData testing tools clusters as we roll IOx out. logfmt seems like the shortest path to get there.

## Why roll our own?
I could find nothing suitable: https://crates.io/search?q=logfmt

I did not go with the seemingly obvious choice, https://crates.io/crates/logfmt_logger (though thanks @mcountryman for creating that), because
1. Doesn't (obviously) work with `tracing_subscriber`
2. Has been downloaded 65 (not a typo) times total ever
3. Doesn't seem to support fields other than `target` and `message` - https://github.com/mcountryman/logfmt_logger
4. The examples seem to be different than https://brandur.org/logfmt#implementations shows (e.g. the use of "message" instead of "msg" as a field name, for example)

# Changes
1. A `tracing_subscriber` Layer that implements what I percieve as the appropriate `log_fmt` formatting rules
2. Full coverage unit and integration tests that demonstrate the behavior
3. A new command line `--log_format` and environment variable `INFLUXDB_IOX_LOG_FORMAT` that can be used to choose what format is used (defaults to the Rust style)

## Why its own crate?
1. It made the test/recompile cycle faster
2. It makes it easier to open source this / contribute it back to the tracing_subscriber crate in the future if we want

# Examples:

## `influxdb_iox` with logfmt formatted logs:

```
cd /Users/alamb/Software/influxdb_iox && INFLUXDB_IOX_LOGFORMAT="rust" cargo run -- server --log_format=logfmt
   Compiling influxdb_iox v0.1.0 (/Users/alamb/Software/influxdb_iox)
    Finished dev [unoptimized + debuginfo] target(s) in 18.16s
     Running `target/debug/influxdb_iox server --log_format=logfmt`
level=warn msg="NO PERSISTENCE: using memory for object storage" target="influxdb_iox::influxdb_ioxd" location="src/influxdb_ioxd.rs:108" time=1612181728438978000
level=warn msg="server ID not set. ID must be set via the INFLUXDB_IOX_ID config or API before writing or querying data." target="influxdb_iox::influxdb_ioxd" location="src/influxdb_ioxd.rs:127" time=1612181728439095000
level=info msg="gRPC server listening" bind_address=127.0.0.1:8082 target="influxdb_iox::influxdb_ioxd" location="src/influxdb_ioxd.rs:139" time=1612181728439293000
level=info msg="HTTP server listening" bind_address=127.0.0.1:8080 target="influxdb_iox::influxdb_ioxd" location="src/influxdb_ioxd.rs:149" time=1612181728447419000
InfluxDB IOx server ready
```

## `influxdb_iox` default behavior / Rust formatted logs (unchanged)

```
cd /Users/alamb/Software/influxdb_iox && cargo run -- server
    Blocking waiting for file lock on build directory
   Compiling influxdb_iox v0.1.0 (/Users/alamb/Software/influxdb_iox)
    Finished dev [unoptimized + debuginfo] target(s) in 21.20s
     Running `target/debug/influxdb_iox server`
Jan 31 13:19:39.059  WARN influxdb_iox::influxdb_ioxd: NO PERSISTENCE: using memory for object storage
Jan 31 13:19:39.060  WARN influxdb_iox::influxdb_ioxd: server ID not set. ID must be set via the INFLUXDB_IOX_ID config or API before writing or querying data.
Jan 31 13:19:39.060  INFO influxdb_iox::influxdb_ioxd: gRPC server listening bind_address=127.0.0.1:8082
Jan 31 13:19:39.068  INFO influxdb_iox::influxdb_ioxd: HTTP server listening bind_address=127.0.0.1:8080
InfluxDB IOx server ready
```

- [x] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb_iox/blob/main/README.md).
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
