### PR TITLE
test: Add test for generic predicate in `measurement_names` (DRAFT)

### DIFF
--- a/server/src/db.rs
+++ b/server/src/db.rs
@@ -670,6 +670,18 @@ mod test_influxrpc {
         run_table_names_test_case!(TwoMeasurements {}, tsp(250, 300), vec![]);
     }
 
+    #[tokio::test]
+    async fn list_table_names_data_pred_bytes() {
+        use arrow_deps::datafusion::logical_plan::*;
+
+        // bytes > 50
+        let predicate = PredicateBuilder::default()
+            .add_expr(col("bytes").gt(lit(50)))
+            .build();
+
+        run_table_names_test_case!(TwoMeasurements {}, predicate, vec!["disk"]);
+    }
+
     // No predicate at all
     fn empty_predicate() -> Predicate {
         Predicate::default()


### PR DESCRIPTION
This PR adds a test to show a general expression predicate working against `measurement_names`

It doesn't yet work (as general predicates don't work) but it will (hopefully after the TableProvider I am working on).

- [x] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb_iox/blob/main/README.md).
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
