### PR TITLE
feat: add support for getting column names from Read Buffer

### DIFF
--- a/read_buffer/src/chunk.rs
+++ b/read_buffer/src/chunk.rs
@@ -217,7 +217,7 @@ impl Chunk {
     /// Returns the distinct set of table names that contain data satisfying the
     /// provided predicate.
     ///
-    /// `exclude_table_names` can be used to provide a set of table names to
+    /// `skip_table_names` can be used to provide a set of table names to
     /// skip, typically because they're already included in results from other
     /// chunks.
     pub fn table_names(
@@ -257,18 +257,27 @@ impl Chunk {
             .collect::<BTreeSet<_>>()
     }
 
-    /// Returns the distinct set of tag keys (column names) matching the
-    /// provided optional predicates and time range.
-    pub fn tag_keys(
+    /// Returns the distinct set of column names that contain data matching the
+    /// provided optional predicate.
+    ///
+    /// `dst` is a buffer that will be populated with results. `column_names` is
+    /// smart enough to short-circuit processing on row groups when it
+    /// determines that all the columns in the row group are already contained
+    /// in the results buffer.
+    pub fn column_names(
         &self,
-        table_name: String,
-        predicate: Predicate,
-        found_keys: &BTreeSet<ColumnName<'_>>,
-    ) -> BTreeSet<ColumnName<'_>> {
-        // Lookup table by name and dispatch execution if the table's time range
-        // overlaps the requested time range *and* there exists columns in the
-        // table's schema that are *not* already found.
-        todo!();
+        table_name: &str,
+        predicate: &Predicate,
+        dst: BTreeSet<String>,
+    ) -> BTreeSet<String> {
+        let chunk_data = self.chunk_data.read().unwrap();
+
+        // TODO(edd): same potential contention as `table_names` but I'm ok
+        // with this for now.
+        match chunk_data.data.get(table_name) {
+            Some(table) => table.column_names(predicate, dst),
+            None => dst,
+        }
     }
 
     /// Returns the distinct set of tag values (column values) for each provided

--- a/read_buffer/src/chunk.rs
+++ b/read_buffer/src/chunk.rs
@@ -258,7 +258,7 @@ impl Chunk {
     }
 
     /// Returns the distinct set of column names that contain data matching the
-    /// provided optional predicate.
+    /// provided predicate, which may be empty.
     ///
     /// `dst` is a buffer that will be populated with results. `column_names` is
     /// smart enough to short-circuit processing on row groups when it

--- a/read_buffer/src/column.rs
+++ b/read_buffer/src/column.rs
@@ -455,7 +455,7 @@ impl Column {
     // Helper method to determine if the predicate matches all the values in
     // the column.
     //
-    // TODO(edd): this doesn't handle matching on NULL yet.
+    // TODO(edd): this doesn't handle operators that compare to a NULL value yet.
     fn predicate_matches_all_values(&self, op: &cmp::Operator, value: &Value<'_>) -> bool {
         match &self {
             Column::String(meta, data) => {
@@ -614,7 +614,14 @@ impl Column {
     /// Determines if the column has a non-null value at any of the provided
     /// rows.
     pub fn has_non_null_value(&self, row_ids: &[u32]) -> bool {
-        todo!()
+        match &self {
+            Column::String(_, data) => data.has_non_null_value(row_ids),
+            Column::Float(_, data) => data.has_non_null_value(row_ids),
+            Column::Integer(_, data) => data.has_non_null_value(row_ids),
+            Column::Unsigned(_, data) => data.has_non_null_value(row_ids),
+            Column::Bool(_, data) => data.has_non_null_value(row_ids),
+            Column::ByteArray(_, _) => todo!(),
+        }
     }
 
     /// Determines if the column contains other values than those provided in
@@ -723,9 +730,18 @@ pub enum StringEncoding {
 impl StringEncoding {
     /// Determines if the column contains a NULL value.
     pub fn contains_null(&self) -> bool {
+        match self {
+            StringEncoding::RLEDictionary(enc) => enc.contains_null(),
+            StringEncoding::Dictionary(enc) => enc.contains_null(),
+        }
+    }
+
+    /// Determines if the column contains a non-null value at one of the
+    /// provided rows.
+    pub fn has_non_null_value(&self, row_ids: &[u32]) -> bool {
         match &self {
-            Self::RLEDictionary(c) => c.contains_null(),
-            Self::Dictionary(c) => c.contains_null(),
+            Self::RLEDictionary(c) => c.has_non_null_value(row_ids),
+            Self::Dictionary(c) => c.has_non_null_value(row_ids),
         }
     }
 
@@ -1088,10 +1104,21 @@ pub enum IntegerEncoding {
 impl IntegerEncoding {
     /// Determines if the column contains a NULL value.
     pub fn contains_null(&self) -> bool {
-        if let Self::I64I64N(c) = &self {
-            return c.contains_null();
+        match self {
+            IntegerEncoding::I64I64N(enc) => enc.contains_null(),
+            IntegerEncoding::U64U64N(enc) => enc.contains_null(),
+            _ => false,
         }
-        false
+    }
+
+    /// Determines if the column contains a non-null value at one of the
+    /// provided rows.
+    pub fn has_non_null_value(&self, row_ids: &[u32]) -> bool {
+        match self {
+            IntegerEncoding::I64I64N(enc) => enc.has_non_null_value(row_ids),
+            IntegerEncoding::U64U64N(enc) => enc.has_non_null_value(row_ids),
+            _ => false,
+        }
     }
 
     /// Returns the logical value found at the provided row id.
@@ -1397,8 +1424,17 @@ impl FloatEncoding {
     /// Determines if the column contains a NULL value.
     pub fn contains_null(&self) -> bool {
         match self {
+            FloatEncoding::Fixed64(_) => false,
+            FloatEncoding::FixedNull64(enc) => enc.contains_null(),
+        }
+    }
+
+    /// Determines if the column contains a non-null value at one of the
+    /// provided rows.
+    pub fn has_non_null_value(&self, row_ids: &[u32]) -> bool {
+        match self {
             Self::Fixed64(_) => false,
-            Self::FixedNull64(enc) => enc.contains_null(),
+            Self::FixedNull64(enc) => enc.has_non_null_value(row_ids),
         }
     }
 
@@ -1512,6 +1548,14 @@ impl BooleanEncoding {
     pub fn contains_null(&self) -> bool {
         match self {
             BooleanEncoding::BooleanNull(enc) => enc.contains_null(),
+        }
+    }
+
+    /// Determines if the column contains a non-null value at one of the
+    /// provided rows.
+    pub fn has_non_null_value(&self, row_ids: &[u32]) -> bool {
+        match self {
+            Self::BooleanNull(enc) => enc.has_non_null_value(row_ids),
         }
     }
 

--- a/read_buffer/src/column.rs
+++ b/read_buffer/src/column.rs
@@ -2593,6 +2593,8 @@ impl PartialEq<Value<'_>> for OwnedValue {
         match (&self, other) {
             (OwnedValue::String(a), Value::String(b)) => a == b,
             (OwnedValue::Scalar(a), Value::Scalar(b)) => a == b,
+            (OwnedValue::Boolean(a), Value::Boolean(b)) => a == b,
+            (OwnedValue::ByteArray(a), Value::ByteArray(b)) => a == b,
             _ => false,
         }
     }
@@ -2603,6 +2605,8 @@ impl PartialOrd<Value<'_>> for OwnedValue {
         match (&self, other) {
             (OwnedValue::String(a), Value::String(b)) => Some(a.as_str().cmp(b)),
             (OwnedValue::Scalar(a), Value::Scalar(b)) => a.partial_cmp(b),
+            (OwnedValue::Boolean(a), Value::Boolean(b)) => a.partial_cmp(b),
+            (OwnedValue::ByteArray(a), Value::ByteArray(b)) => a.as_slice().partial_cmp(*b),
             _ => None,
         }
     }

--- a/read_buffer/src/column/bool.rs
+++ b/read_buffer/src/column/bool.rs
@@ -298,6 +298,21 @@ impl Bool {
         }
         dst
     }
+
+    /// Determines if the column contains a non-null value.
+    pub fn has_any_non_null_value(&self) -> bool {
+        self.arr.null_count() < self.num_rows() as usize
+    }
+
+    /// Returns true if the column contains any non-null values at the rows
+    /// provided.
+    pub fn has_non_null_value(&self, row_ids: &[u32]) -> bool {
+        if !self.contains_null() {
+            return true;
+        }
+
+        row_ids.iter().any(|id| !self.arr.is_null(*id as usize))
+    }
 }
 
 impl From<&[bool]> for Bool {
@@ -435,5 +450,34 @@ mod test {
 
         let row_ids = v.row_ids_filter(false, &Operator::LTE, RowIDs::new_vector());
         assert_eq!(row_ids.to_vec(), vec![1]);
+    }
+
+    #[test]
+    fn has_any_non_null_value() {
+        let v = Bool::from(vec![None, None].as_slice());
+        assert!(!v.has_any_non_null_value());
+
+        let v = Bool::from(vec![Some(true), Some(false)].as_slice());
+        assert!(v.has_any_non_null_value());
+
+        let v = Bool::from(vec![Some(true), None, Some(false)].as_slice());
+        assert!(v.has_any_non_null_value());
+    }
+
+    #[test]
+    fn has_non_null_value() {
+        let v = Bool::from(vec![None, None].as_slice());
+        assert!(!v.has_non_null_value(&[0, 1]));
+        assert!(!v.has_non_null_value(&[0]));
+
+        let v = Bool::from(vec![Some(true), Some(false)].as_slice());
+        assert!(v.has_non_null_value(&[0, 1]));
+        assert!(v.has_non_null_value(&[1]));
+
+        let v = Bool::from(vec![Some(true), None, Some(false)].as_slice());
+        assert!(v.has_non_null_value(&[0, 1, 2]));
+        assert!(v.has_non_null_value(&[0]));
+        assert!(v.has_non_null_value(&[1, 2]));
+        assert!(!v.has_non_null_value(&[1]));
     }
 }

--- a/read_buffer/src/column/bool.rs
+++ b/read_buffer/src/column/bool.rs
@@ -307,11 +307,7 @@ impl Bool {
     /// Returns true if the column contains any non-null values at the rows
     /// provided.
     pub fn has_non_null_value(&self, row_ids: &[u32]) -> bool {
-        if !self.contains_null() {
-            return true;
-        }
-
-        row_ids.iter().any(|id| !self.arr.is_null(*id as usize))
+        !self.contains_null() || row_ids.iter().any(|id| !self.arr.is_null(*id as usize))
     }
 }
 

--- a/read_buffer/src/column/dictionary/plain.rs
+++ b/read_buffer/src/column/dictionary/plain.rs
@@ -664,13 +664,29 @@ impl Plain {
         todo!()
     }
 
+    /// Determines if the column contains at least one non-null value.
+    pub fn has_any_non_null_value(&self) -> bool {
+        if !self.contains_null() {
+            return true;
+        }
+
+        // If there are more than one dictionary entries then there is a non-null
+        // value in the column.
+        self.entries.len() > 1
+    }
+
     /// Determines if the column contains at least one non-null value at
     /// any of the provided row ids.
-    ///
-    /// It is the caller's responsibility to ensure row ids are a monotonically
-    /// increasing set.
     pub fn has_non_null_value(&self, row_ids: &[u32]) -> bool {
-        todo!()
+        if !self.contains_null() {
+            return true;
+        }
+
+        // If there are encoded values at any of the row IDs then there is at
+        // least one non-null value in the column.
+        row_ids
+            .iter()
+            .any(|id| self.encoded_data[*id as usize] != NULL_ID)
     }
 
     // Returns true if there exists an encoded non-null value at any of the row
@@ -815,5 +831,31 @@ mod test {
         let mut enc = Plain::default();
         enc.push("b".to_string());
         enc.push("a".to_string());
+    }
+
+    #[test]
+    fn has_non_null_value() {
+        let mut enc = Plain::default();
+        enc.push_none();
+        enc.push_none();
+
+        assert!(!enc.has_non_null_value(&[0, 1]));
+
+        enc.push("b".to_string());
+        assert!(enc.has_non_null_value(&[0, 1, 2]));
+        assert!(enc.has_non_null_value(&[2]));
+        assert!(!enc.has_non_null_value(&[0, 1]));
+    }
+
+    #[test]
+    fn has_any_non_null_value() {
+        let mut enc = Plain::default();
+        enc.push_none();
+        enc.push_none();
+
+        assert!(!enc.has_any_non_null_value());
+
+        enc.push("b".to_string());
+        assert!(enc.has_any_non_null_value());
     }
 }

--- a/read_buffer/src/column/dictionary/plain.rs
+++ b/read_buffer/src/column/dictionary/plain.rs
@@ -670,7 +670,7 @@ impl Plain {
             return true;
         }
 
-        // If there are more than one dictionary entries then there is a non-null
+        // If there is more than one dictionary entry then there is a non-null
         // value in the column.
         self.entries.len() > 1
     }

--- a/read_buffer/src/column/dictionary/rle.rs
+++ b/read_buffer/src/column/dictionary/rle.rs
@@ -801,7 +801,7 @@ impl RLE {
             return true;
         }
 
-        // If there are any non-null rows then there will entries in the
+        // If there are any non-null rows then there are entries in the
         // dictionary.
         !self.entry_index.is_empty()
     }

--- a/read_buffer/src/column/dictionary/rle.rs
+++ b/read_buffer/src/column/dictionary/rle.rs
@@ -795,6 +795,17 @@ impl RLE {
         false
     }
 
+    /// Determines if the column contains at least one non-null value.
+    pub fn has_any_non_null_value(&self) -> bool {
+        if !self.contains_null() {
+            return true;
+        }
+
+        // If there are any non-null rows then there will entries in the
+        // dictionary.
+        !self.entry_index.is_empty()
+    }
+
     /// Determines if the column contains at least one non-null value at
     /// any of the provided row ids.
     ///

--- a/read_buffer/src/lib.rs
+++ b/read_buffer/src/lib.rs
@@ -488,7 +488,7 @@ impl Database {
             })?;
 
         let chunk_data = partition.data.read().unwrap();
-        let mut filtered_chunks = vec![];
+        let mut filtered_chunks = Vec::with_capacity(chunk_ids.len());
         for id in chunk_ids {
             filtered_chunks.push(
                 chunk_data

--- a/read_buffer/src/lib.rs
+++ b/read_buffer/src/lib.rs
@@ -34,6 +34,10 @@ use table::Table;
 /// `table_names`.
 pub const TABLE_NAMES_COLUMN_NAME: &str = "table";
 
+/// The name of the column containing column names returned by a call to
+/// `column_names`.
+pub const COLUMN_NAMES_COLUMN_NAME: &str = "column";
+
 #[derive(Debug, Snafu)]
 pub enum Error {
     #[snafu(display("arrow conversion error: {}", source))]
@@ -470,20 +474,42 @@ impl Database {
     pub fn column_names(
         &self,
         partition_key: &str,
+        table_name: &str,
         chunk_ids: &[u32],
         predicate: Predicate,
     ) -> Result<RecordBatch> {
-        // Find all matching chunks using:
-        //   - time range
-        //   - measurement name.
-        //
-        // Execute query against matching chunks. The `tag_keys` method for
-        // a chunk allows the caller to provide already found tag keys
-        // (column names). This allows the execution to skip entire chunks,
-        // tables or segments if there are no new columns to be found there...
-        Err(Error::UnsupportedOperation {
-            msg: "`column_names` call not yet hooked up".to_owned(),
-        })
+        let partition_data = self.data.read().unwrap();
+
+        let partition = partition_data
+            .partitions
+            .get(partition_key)
+            .ok_or_else(|| Error::PartitionNotFound {
+                key: partition_key.to_owned(),
+            })?;
+
+        let chunk_data = partition.data.read().unwrap();
+        let mut filtered_chunks = vec![];
+        for id in chunk_ids {
+            filtered_chunks.push(
+                chunk_data
+                    .chunks
+                    .get(id)
+                    .ok_or_else(|| Error::ChunkNotFound { id: *id })?,
+            );
+        }
+
+        let names = filtered_chunks
+            .iter()
+            .fold(BTreeSet::new(), |dst, chunk| {
+                // the dst buffer is pushed into each chunk's `column_names`
+                // implementation ensuring that we short-circuit any tables where
+                // we have already determined column names.
+                chunk.column_names(table_name, &predicate, dst)
+            }) // have a BTreeSet here, convert to an iterator of Some(&str)
+            .into_iter()
+            .map(Some);
+
+        str_iter_to_batch(COLUMN_NAMES_COLUMN_NAME, names).context(ArrowError)
     }
 }
 
@@ -1039,6 +1065,126 @@ mod test {
             &data,
             res_col,
             &Values::String(vec![Some("20 Size"), Some("Coolverine")]),
+        );
+    }
+
+    #[test]
+    fn column_names() {
+        let mut db = Database::new();
+        let res_col = COLUMN_NAMES_COLUMN_NAME;
+
+        let schema = SchemaBuilder::new()
+            .non_null_tag("region")
+            .non_null_field("counter", Float64)
+            .timestamp()
+            .field("sketchy_sensor", Float64)
+            .build()
+            .unwrap()
+            .into();
+
+        let data: Vec<ArrayRef> = vec![
+            Arc::new(StringArray::from(vec!["west", "west", "east"])),
+            Arc::new(Float64Array::from(vec![1.2, 3.3, 45.3])),
+            Arc::new(Int64Array::from(vec![11111111, 222222, 3333])),
+            Arc::new(Float64Array::from(vec![Some(11.0), None, Some(12.0)])),
+        ];
+
+        // Add the above table to a chunk and partition
+        let rb = RecordBatch::try_new(schema, data).unwrap();
+        db.upsert_partition("hour_1", 22, "Utopia", rb);
+
+        // Add a different but compatible table to a different chunk in the same
+        // partition.
+        let schema = SchemaBuilder::new()
+            .field("active", Boolean)
+            .timestamp()
+            .build()
+            .unwrap()
+            .into();
+
+        let data: Vec<ArrayRef> = vec![
+            Arc::new(BooleanArray::from(vec![Some(true), None, None])),
+            Arc::new(Int64Array::from(vec![10, 20, 30])),
+        ];
+        let rb = RecordBatch::try_new(schema, data).unwrap();
+        db.upsert_partition("hour_1", 40, "Utopia", rb);
+
+        // Just query against the first chunk.
+        let result = db
+            .column_names("hour_1", "Utopia", &[22], Predicate::default())
+            .unwrap();
+
+        assert_rb_column_equals(
+            &result,
+            res_col,
+            &Values::String(
+                vec!["counter", "region", "sketchy_sensor", "time"]
+                    .into_iter()
+                    .map(Some)
+                    .collect(),
+            ),
+        );
+
+        // Now the second - different columns.
+        let result = db
+            .column_names("hour_1", "Utopia", &[40], Predicate::default())
+            .unwrap();
+
+        assert_rb_column_equals(
+            &result,
+            res_col,
+            &Values::String(vec!["active", "time"].into_iter().map(Some).collect()),
+        );
+
+        // And now the union across all chunks.
+        let result = db
+            .column_names("hour_1", "Utopia", &[22, 40], Predicate::default())
+            .unwrap();
+
+        assert_rb_column_equals(
+            &result,
+            res_col,
+            &Values::String(
+                vec!["active", "counter", "region", "sketchy_sensor", "time"]
+                    .into_iter()
+                    .map(Some)
+                    .collect(),
+            ),
+        );
+
+        // Testing predicates
+        let result = db
+            .column_names(
+                "hour_1",
+                "Utopia",
+                &[22, 40],
+                Predicate::new(vec![BinaryExpr::from(("time", "=", 30_i64))]),
+            )
+            .unwrap();
+
+        // only time will be returned - "active" in the second chunk is NULL for
+        // matching rows
+        assert_rb_column_equals(
+            &result,
+            res_col,
+            &Values::String(vec!["time"].into_iter().map(Some).collect()),
+        );
+
+        let result = db
+            .column_names(
+                "hour_1",
+                "Utopia",
+                &[22, 40],
+                Predicate::new(vec![BinaryExpr::from(("active", "=", true))]),
+            )
+            .unwrap();
+
+        // there exists at least one row in the second chunk with a matching
+        // non-null value across the active and time columns.
+        assert_rb_column_equals(
+            &result,
+            res_col,
+            &Values::String(vec!["active", "time"].into_iter().map(Some).collect()),
         );
     }
 

--- a/read_buffer/src/row_group.rs
+++ b/read_buffer/src/row_group.rs
@@ -923,10 +923,10 @@ impl RowGroup {
         dst.aggregates.push(AggregateResults(aggregate_row)); // write the row
     }
 
-    /// Given the optional predicate, determines a set of rows contained in this
-    /// row group that satisfy it. Any column that contains a non-null value at
-    /// any of these row positions is then included in the results, which are
-    /// added to `dst`.
+    /// Given the predicate (which may be empty), determine a set of rows
+    /// contained in this row group that satisfy it. Any column that contains a
+    /// non-null value at any of these row positions is then included in the
+    /// results, which are added to `dst`.
     ///
     /// As an optimisation, the contents of `dst` are checked before execution
     /// and any columns already existing in the set are not interrogated.

--- a/read_buffer/src/row_group.rs
+++ b/read_buffer/src/row_group.rs
@@ -195,7 +195,7 @@ impl RowGroup {
     /// Determines if the row group contains one or more rows that satisfy all
     /// of the provided binary expressions, when conjunctively applied.
     ///
-    /// `row_satisfies_predicate` currently constructs a set of row ids for all
+    /// `satisfies_predicate` currently constructs a set of row ids for all
     /// rows that satisfy the predicate, but does not materialise any
     /// values. There are some optimisation opportunities here, but I don't
     /// think they're at all worth it at the moment.
@@ -204,7 +204,7 @@ impl RowGroup {
     ///  * for predicates with single expression just find a matching value in
     ///    the column;
     ///  * in some cases perhaps work row by row rather than column by column.
-    pub fn row_satisfies_predicate(&self, predicate: &Predicate) -> bool {
+    pub fn satisfies_predicate(&self, predicate: &Predicate) -> bool {
         if !self.could_satisfy_conjunctive_binary_expressions(predicate.iter()) {
             return false;
         }
@@ -2396,46 +2396,46 @@ west,POST,304,101,203
         let row_group = RowGroup::new(6, columns);
 
         let mut predicate = Predicate::default();
-        assert_eq!(row_group.row_satisfies_predicate(&predicate), true);
+        assert_eq!(row_group.satisfies_predicate(&predicate), true);
 
         predicate = Predicate::new(vec![BinaryExpr::from(("region", "=", "east"))]);
-        assert_eq!(row_group.row_satisfies_predicate(&predicate), true);
+        assert_eq!(row_group.satisfies_predicate(&predicate), true);
 
         // all expressions satisfied in data
         predicate = Predicate::new(vec![
             BinaryExpr::from(("region", "=", "east")),
             BinaryExpr::from(("method", "!=", "POST")),
         ]);
-        assert_eq!(row_group.row_satisfies_predicate(&predicate), true);
+        assert_eq!(row_group.satisfies_predicate(&predicate), true);
 
         // all expressions satisfied in data by all rows
         predicate = Predicate::new(vec![BinaryExpr::from(("method", "=", "GET"))]);
-        assert_eq!(row_group.row_satisfies_predicate(&predicate), true);
+        assert_eq!(row_group.satisfies_predicate(&predicate), true);
 
         // one expression satisfied in data but other ruled out via column pruning.
         predicate = Predicate::new(vec![
             BinaryExpr::from(("region", "=", "east")),
             BinaryExpr::from(("method", ">", "GET")),
         ]);
-        assert_eq!(row_group.row_satisfies_predicate(&predicate), false);
+        assert_eq!(row_group.satisfies_predicate(&predicate), false);
 
         // all expressions rules out via column pruning.
         predicate = Predicate::new(vec![
             BinaryExpr::from(("region", ">", "west")),
             BinaryExpr::from(("method", ">", "GET")),
         ]);
-        assert_eq!(row_group.row_satisfies_predicate(&predicate), false);
+        assert_eq!(row_group.satisfies_predicate(&predicate), false);
 
         // column does not exist
         predicate = Predicate::new(vec![BinaryExpr::from(("track", "=", "Jeanette"))]);
-        assert_eq!(row_group.row_satisfies_predicate(&predicate), false);
+        assert_eq!(row_group.satisfies_predicate(&predicate), false);
 
         // one column satisfies expression but other column does not exist
         predicate = Predicate::new(vec![
             BinaryExpr::from(("region", "=", "south")),
             BinaryExpr::from(("track", "=", "Jeanette")),
         ]);
-        assert_eq!(row_group.row_satisfies_predicate(&predicate), false);
+        assert_eq!(row_group.satisfies_predicate(&predicate), false);
     }
 
     #[test]

--- a/read_buffer/src/row_group.rs
+++ b/read_buffer/src/row_group.rs
@@ -1,7 +1,7 @@
 use std::{
     borrow::Cow,
     cmp::Ordering,
-    collections::BTreeMap,
+    collections::{BTreeMap, BTreeSet},
     convert::{TryFrom, TryInto},
     sync::Arc,
 };
@@ -195,16 +195,16 @@ impl RowGroup {
     /// Determines if the row group contains one or more rows that satisfy all
     /// of the provided binary expressions, when conjunctively applied.
     ///
-    /// `satisfies_predicate` currently constructs a set of row ids for all rows
-    /// that satisfy the predicate, but does not materialise any values. There
-    /// are some optimisation opportunities here, but I don't think they're at
-    /// all worth it at the moment.
+    /// `row_satisfies_predicate` currently constructs a set of row ids for all
+    /// rows that satisfy the predicate, but does not materialise any
+    /// values. There are some optimisation opportunities here, but I don't
+    /// think they're at all worth it at the moment.
     ///
     /// They could be:
     ///  * for predicates with single expression just find a matching value in
     ///    the column;
     ///  * in some cases perhaps work row by row rather than column by column.
-    pub fn satisfies_predicate(&self, predicate: &Predicate) -> bool {
+    pub fn row_satisfies_predicate(&self, predicate: &Predicate) -> bool {
         if !self.could_satisfy_conjunctive_binary_expressions(predicate.iter()) {
             return false;
         }
@@ -921,6 +921,51 @@ impl RowGroup {
             }
         }
         dst.aggregates.push(AggregateResults(aggregate_row)); // write the row
+    }
+
+    /// Given the optional predicate, determines a set of rows contained in this
+    /// row group that satisfy it. Any column that contains a non-null value at
+    /// any of these row positions is then included in the results, which are
+    /// added to `dst`.
+    ///
+    /// As an optimisation, the contents of `dst` are checked before execution
+    /// and any columns already existing in the set are not interrogated.
+    ///
+    /// If you are familiar with InfluxDB, this is essentially an implementation
+    /// of `SHOW TAG KEYS`.
+    pub fn column_names(&self, predicate: &Predicate, dst: &mut BTreeSet<String>) {
+        // Determine the set of columns in this row group that are not already
+        // present in `dst`, i.e., they haven't been identified in other row
+        // groups already.
+        let candidate_columns = self
+            .all_columns_by_name
+            .iter()
+            .filter_map(|(name, &id)| match dst.contains(name) {
+                // N.B there is bool::then() but it's currently unstable.
+                true => None,
+                false => Some((name, &self.columns[id])),
+            })
+            .collect::<Vec<_>>();
+
+        match self.row_ids_from_predicate(predicate) {
+            RowIDsOption::None(_) => {} // nothing matches predicate
+            RowIDsOption::Some(row_ids) => {
+                let row_ids = row_ids.to_vec();
+
+                for (name, column) in candidate_columns {
+                    if column.has_non_null_value(&row_ids) {
+                        dst.insert(name.to_owned());
+                    }
+                }
+            }
+            RowIDsOption::All(_) => {
+                for (name, column) in candidate_columns {
+                    if column.has_any_non_null_value() {
+                        dst.insert(name.to_owned());
+                    }
+                }
+            }
+        }
     }
 }
 
@@ -2351,46 +2396,46 @@ west,POST,304,101,203
         let row_group = RowGroup::new(6, columns);
 
         let mut predicate = Predicate::default();
-        assert_eq!(row_group.satisfies_predicate(&predicate), true);
+        assert_eq!(row_group.row_satisfies_predicate(&predicate), true);
 
         predicate = Predicate::new(vec![BinaryExpr::from(("region", "=", "east"))]);
-        assert_eq!(row_group.satisfies_predicate(&predicate), true);
+        assert_eq!(row_group.row_satisfies_predicate(&predicate), true);
 
         // all expressions satisfied in data
         predicate = Predicate::new(vec![
             BinaryExpr::from(("region", "=", "east")),
             BinaryExpr::from(("method", "!=", "POST")),
         ]);
-        assert_eq!(row_group.satisfies_predicate(&predicate), true);
+        assert_eq!(row_group.row_satisfies_predicate(&predicate), true);
 
         // all expressions satisfied in data by all rows
         predicate = Predicate::new(vec![BinaryExpr::from(("method", "=", "GET"))]);
-        assert_eq!(row_group.satisfies_predicate(&predicate), true);
+        assert_eq!(row_group.row_satisfies_predicate(&predicate), true);
 
         // one expression satisfied in data but other ruled out via column pruning.
         predicate = Predicate::new(vec![
             BinaryExpr::from(("region", "=", "east")),
             BinaryExpr::from(("method", ">", "GET")),
         ]);
-        assert_eq!(row_group.satisfies_predicate(&predicate), false);
+        assert_eq!(row_group.row_satisfies_predicate(&predicate), false);
 
         // all expressions rules out via column pruning.
         predicate = Predicate::new(vec![
             BinaryExpr::from(("region", ">", "west")),
             BinaryExpr::from(("method", ">", "GET")),
         ]);
-        assert_eq!(row_group.satisfies_predicate(&predicate), false);
+        assert_eq!(row_group.row_satisfies_predicate(&predicate), false);
 
         // column does not exist
         predicate = Predicate::new(vec![BinaryExpr::from(("track", "=", "Jeanette"))]);
-        assert_eq!(row_group.satisfies_predicate(&predicate), false);
+        assert_eq!(row_group.row_satisfies_predicate(&predicate), false);
 
         // one column satisfies expression but other column does not exist
         predicate = Predicate::new(vec![
             BinaryExpr::from(("region", "=", "south")),
             BinaryExpr::from(("track", "=", "Jeanette")),
         ]);
-        assert_eq!(row_group.satisfies_predicate(&predicate), false);
+        assert_eq!(row_group.row_satisfies_predicate(&predicate), false);
     }
 
     #[test]
@@ -2721,5 +2766,76 @@ west,host-d,11,9
         assert_eq!(col1, col2);
         assert_ne!(col1, col3);
         assert_ne!(col2, col3);
+    }
+
+    #[test]
+    fn column_names() {
+        let mut columns = BTreeMap::new();
+        let rc = ColumnType::Tag(Column::from(&[Some("west"), Some("west"), None, None][..]));
+        columns.insert("region".to_string(), rc);
+        let track = ColumnType::Tag(Column::from(
+            &[Some("Thinking"), Some("of"), Some("a"), Some("place")][..],
+        ));
+        columns.insert("track".to_string(), track);
+        let tc = ColumnType::Time(Column::from(&[100_i64, 200, 500, 600][..]));
+        columns.insert("time".to_string(), tc);
+        let row_group = RowGroup::new(4, columns);
+
+        // No predicate - just find a value in each column that matches.
+        let mut dst = BTreeSet::new();
+        row_group.column_names(&Predicate::default(), &mut dst);
+        assert_eq!(
+            dst,
+            vec!["region", "time", "track"]
+                .into_iter()
+                .map(|s| s.to_owned())
+                .collect()
+        );
+
+        // A predicate, but no rows match. No columns should be returned.
+        let mut dst = BTreeSet::new();
+        row_group.column_names(
+            &Predicate::new(vec![BinaryExpr::from(("region", "=", "east"))]),
+            &mut dst,
+        );
+        assert!(dst.is_empty());
+
+        // A predicate, that matches some rows. Columns with non-null values at
+        // those rows should be returned.
+        let mut dst = BTreeSet::new();
+        let names = row_group.column_names(
+            &Predicate::new(vec![BinaryExpr::from(("track", "=", "place"))]),
+            &mut dst,
+        );
+        // query matches one row.
+        //
+        // region, track, time
+        // NULL  , place, 600
+        //
+        assert_eq!(
+            dst,
+            vec!["track", "time"]
+                .into_iter()
+                .map(|s| s.to_owned())
+                .collect()
+        );
+
+        // Reusing the same buffer keeps existing results even if they're not
+        // part of the result-set from the row group.
+        let mut columns = BTreeMap::new();
+        let rc = ColumnType::Tag(Column::from(&[Some("prod")][..]));
+        columns.insert("env".to_string(), rc);
+        let tc = ColumnType::Time(Column::from(&[100_i64][..]));
+        columns.insert("time".to_string(), tc);
+        let row_group = RowGroup::new(1, columns);
+
+        row_group.column_names(&Predicate::default(), &mut dst);
+        assert_eq!(
+            dst,
+            vec!["env", "time", "track"]
+                .into_iter()
+                .map(|s| s.to_owned())
+                .collect()
+        );
     }
 }

--- a/read_buffer/src/table.rs
+++ b/read_buffer/src/table.rs
@@ -541,7 +541,7 @@ impl Table {
         // processed but this operation is now lock-free.
         row_groups
             .iter()
-            .any(|row_group| row_group.row_satisfies_predicate(predicate))
+            .any(|row_group| row_group.satisfies_predicate(predicate))
     }
 }
 

--- a/read_buffer/src/table.rs
+++ b/read_buffer/src/table.rs
@@ -520,7 +520,7 @@ impl Table {
         // processed but this operation is now lock-free.
         row_groups
             .iter()
-            .any(|row_group| row_group.satisfies_predicate(predicate))
+            .any(|row_group| row_group.row_satisfies_predicate(predicate))
     }
 }
 


### PR DESCRIPTION
This PR implements the physical operation `column_names` on the Read Buffer. This operation can be used to retrieve a set of columns names for a single table across one or more Chunks of data. `column_names` accepts an optional predicate, which if set will ensure only column names are returned where at least one value in the column is on a row that matches the predicate.

This functionality will provide the execution  for IOx's equivalent of InfluxDB's `SHOW TAG KEYS WHERE ...` schema exploration query and Flux's `schema.tagKeys()`.

Here is an example using a pseudo query language:

```
Table: cpu

region  | env  | counter  | time
--------------------------------
west    | prod |    22    |  100
east    | prod |  NULL    |  200
west    | dev  |  NULL    |  300


SHOW COLUMN_NAMES FROM "cpu";

names
-------
counter
env
region
time

SHOW COLUMN_NAMES FROM "cpu" WHERE env = 'dev';

names
------- 
             <-- counter has no non-null values for matching rows
env
region
time
``` 

The usual current rules apply to the predicate provided the read buffer - conjunctive binary expressions only at the moment supporting `=, !=, >, <, <=, >=` on any column.

#### Implementation Notes

I have implemented `column_names` in a similar way to `table_names`, which I think will be performant enough for a while.

The implementation has the following features:

 - it works across chunks if multiple chunks are provided;
 - it maintains a set of matching column names, which are pushed down to each table and row group;
 - if a row group does not contain any columns that are not present in the matched result set it skips it;
 - if a column in a row group already exists in the result set it skips it.

These features means that in the general case across large swathes of data, `column_names` will be very efficient in the general case. 