### PR TITLE
feat: Implement TableProvider for Trait for `Db`

### DIFF
--- a/mutable_buffer/src/chunk.rs
+++ b/mutable_buffer/src/chunk.rs
@@ -6,6 +6,7 @@ use arrow_deps::{
         error::{DataFusionError, Result as DatafusionResult},
         logical_plan::{Expr, ExpressionVisitor, LogicalPlan, Operator, Recursion},
         optimizer::utils::expr_to_column_names,
+        physical_plan::SendableRecordBatchStream,
         prelude::*,
     },
 };
@@ -500,17 +501,17 @@ impl query::PartitionChunk for Chunk {
         self.table_stats()
     }
 
-    fn table_to_arrow(
-        &self,
-        dst: &mut Vec<RecordBatch>,
-        table_name: &str,
-        selection: Selection<'_>,
-    ) -> Result<(), Self::Error> {
-        self.table_to_arrow(dst, table_name, selection)
+    async fn table_names(&self, _predicate: &Predicate) -> Result<LogicalPlan, Self::Error> {
+        unimplemented!("This function is slated for removal")
     }
 
-    async fn table_names(&self, _predicate: &Predicate) -> Result<LogicalPlan, Self::Error> {
-        unimplemented!("please use table_names function directly")
+    async fn read_filter(
+        &self,
+        _table_name: &str,
+        _predicate: &Predicate,
+        _selection: Selection<'_>,
+    ) -> Result<SendableRecordBatchStream, Self::Error> {
+        unimplemented!("This function is slated for removal")
     }
 
     async fn table_schema(

--- a/query/src/provider.rs
+++ b/query/src/provider.rs
@@ -108,8 +108,7 @@ impl<C: PartitionChunk> ProviderBuilder<C> {
             table_name: table_name.as_ref(),
         })?;
 
-        // if the table was reported to exist, it should not be empty (eventually we
-        // should get the schema and table data separtely)
+        // if the table was reported to exist, it should not be empty
         if chunks.is_empty() {
             return InternalNoRowsInTable {
                 table_name: table_name.as_ref(),
@@ -128,7 +127,7 @@ impl<C: PartitionChunk> ProviderBuilder<C> {
 /// Implementation of a DataFusion TableProvider in terms of PartitionChunks
 ///
 /// This allows DataFusion to see data from Chunks as a single table, as well as
-/// push predicates down to chunks
+/// push predicates and selections down to chunks
 #[derive(Debug)]
 pub struct ChunkTableProvider<C: PartitionChunk> {
     table_name: Arc<String>,

--- a/query/src/provider.rs
+++ b/query/src/provider.rs
@@ -1,0 +1,185 @@
+//! Implementation of a DataFusion TableProvider in terms of PartitionChunks
+
+use std::sync::Arc;
+
+use arrow_deps::{
+    arrow::datatypes::SchemaRef,
+    datafusion::{
+        datasource::{
+            datasource::{Statistics, TableProviderFilterPushDown},
+            TableProvider,
+        },
+        error::{DataFusionError, Result as DataFusionResult},
+        logical_plan::Expr,
+        physical_plan::ExecutionPlan,
+    },
+};
+
+use crate::{predicate::Predicate, PartitionChunk};
+
+use snafu::{OptionExt, Snafu};
+
+mod physical;
+use self::physical::IOxReadFilterNode;
+
+#[derive(Debug, Snafu)]
+pub enum Error {
+    #[snafu(display(
+        "Chunk schema not compatible for table '{}'. They must be identical. Existing: {:?}, New: {:?}",
+        table_name,
+        existing_schema,
+        chunk_schema
+    ))]
+    ChunkSchemaNotCompatible {
+        table_name: String,
+        existing_schema: SchemaRef,
+        chunk_schema: SchemaRef,
+    },
+
+    #[snafu(display(
+        "Internal error: no chunks found in builder for table {:?}",
+        table_name,
+    ))]
+    NoChunks { table_name: String },
+
+    #[snafu(display("No rows found in table {}", table_name))]
+    InternalNoRowsInTable { table_name: String },
+}
+pub type Result<T, E = Error> = std::result::Result<T, E>;
+
+/// Builds a ChunkTableProvider from a series of `PartitionChunks`
+/// and ensures the schema across the chunks is compatible and
+/// consistent.
+#[derive(Debug)]
+pub struct ProviderBuilder<C: PartitionChunk + 'static> {
+    table_name: Arc<String>,
+    schema: Option<SchemaRef>,
+    chunks: Vec<Arc<C>>,
+}
+
+impl<C: PartitionChunk> ProviderBuilder<C> {
+    pub fn new(table_name: impl Into<String>) -> Self {
+        Self {
+            table_name: Arc::new(table_name.into()),
+            schema: None,
+            chunks: Vec::new(),
+        }
+    }
+
+    /// Add a new chunk to this provider
+    pub fn add_chunk(mut self, chunk: Arc<C>, chunk_table_schema: SchemaRef) -> Result<Self> {
+        self.schema = Some(if let Some(existing_schema) = self.schema.take() {
+            self.check_schema(existing_schema, chunk_table_schema)?
+        } else {
+            chunk_table_schema
+        });
+        self.chunks.push(chunk);
+        Ok(self)
+    }
+
+    /// returns Ok(combined_schema) if the schema of chunk is compatible with
+    /// `existing_schema`, Err() with why otherwise
+    fn check_schema(
+        &self,
+        existing_schema: SchemaRef,
+        chunk_schema: SchemaRef,
+    ) -> Result<SchemaRef> {
+        // For now, use strict equality. Eventually should union the schema
+        if existing_schema != chunk_schema {
+            ChunkSchemaNotCompatible {
+                table_name: self.table_name.as_ref(),
+                existing_schema,
+                chunk_schema,
+            }
+            .fail()
+        } else {
+            Ok(chunk_schema)
+        }
+    }
+
+    pub fn build(self) -> Result<ChunkTableProvider<C>> {
+        let Self {
+            table_name,
+            schema,
+            chunks,
+        } = self;
+
+        let schema = schema.context(NoChunks {
+            table_name: table_name.as_ref(),
+        })?;
+
+        // if the table was reported to exist, it should not be empty (eventually we
+        // should get the schema and table data separtely)
+        if chunks.is_empty() {
+            return InternalNoRowsInTable {
+                table_name: table_name.as_ref(),
+            }
+            .fail();
+        }
+
+        Ok(ChunkTableProvider {
+            table_name,
+            schema,
+            chunks,
+        })
+    }
+}
+
+/// Implementation of a DataFusion TableProvider in terms of PartitionChunks
+///
+/// This allows DataFusion to see data from Chunks as a single table, as well as
+/// push predicates down to chunks
+#[derive(Debug)]
+pub struct ChunkTableProvider<C: PartitionChunk> {
+    table_name: Arc<String>,
+    schema: SchemaRef,
+    chunks: Vec<Arc<C>>,
+}
+
+impl<C: PartitionChunk + 'static> TableProvider for ChunkTableProvider<C> {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    fn schema(&self) -> SchemaRef {
+        self.schema.clone()
+    }
+
+    fn scan(
+        &self,
+        projection: &Option<Vec<usize>>,
+        _batch_size: usize,
+        _filters: &[Expr],
+    ) -> std::result::Result<Arc<dyn ExecutionPlan>, DataFusionError> {
+        // TODO Here is where predicate pushdown will happen.  To make
+        // predicate push down happen, the provider need need to
+        // create a Predicate from the Expr .
+        //
+        // Note that `filters` don't actually need to be evaluated in
+        // the scan for the plans to be correct, they are an extra
+        // optimization for providers which can offer them
+        let predicate = Predicate::default();
+
+        let plan = IOxReadFilterNode::new(
+            self.table_name.clone(),
+            self.schema.clone(),
+            self.chunks.clone(),
+            predicate,
+            projection.clone(),
+        );
+
+        Ok(Arc::new(plan))
+    }
+
+    fn statistics(&self) -> Statistics {
+        // TODO translate IOx stats to DataFusion statistics
+        Statistics::default()
+    }
+
+    fn supports_filter_pushdown(
+        &self,
+        _filter: &Expr,
+    ) -> DataFusionResult<TableProviderFilterPushDown> {
+        Ok(TableProviderFilterPushDown::Unsupported)
+    }
+}

--- a/query/src/provider/physical.rs
+++ b/query/src/provider/physical.rs
@@ -1,0 +1,115 @@
+//! Implementation of a DataFusion PhysicalPlan node across partition chunks
+
+use std::sync::Arc;
+
+use arrow_deps::{
+    arrow::datatypes::SchemaRef,
+    datafusion::{
+        error::DataFusionError,
+        physical_plan::{ExecutionPlan, Partitioning, SendableRecordBatchStream},
+    },
+};
+use data_types::selection::Selection;
+
+use crate::{predicate::Predicate, PartitionChunk};
+
+use async_trait::async_trait;
+
+/// Implements the DataFusion physical plan interface
+#[derive(Debug)]
+pub struct IOxReadFilterNode<C: PartitionChunk + 'static> {
+    table_name: Arc<String>,
+    schema: SchemaRef,
+    chunks: Vec<Arc<C>>,
+    predicate: Predicate,
+    projection: Option<Vec<usize>>,
+}
+
+impl<C: PartitionChunk + 'static> IOxReadFilterNode<C> {
+    pub fn new(
+        table_name: Arc<String>,
+        schema: SchemaRef,
+        chunks: Vec<Arc<C>>,
+        predicate: Predicate,
+        projection: Option<Vec<usize>>,
+    ) -> Self {
+        Self {
+            table_name,
+            schema,
+            chunks,
+            predicate,
+            projection,
+        }
+    }
+}
+
+#[async_trait]
+impl<C: PartitionChunk + 'static> ExecutionPlan for IOxReadFilterNode<C> {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    fn schema(&self) -> SchemaRef {
+        self.schema.clone()
+    }
+
+    fn output_partitioning(&self) -> Partitioning {
+        Partitioning::UnknownPartitioning(self.chunks.len())
+    }
+
+    fn children(&self) -> Vec<Arc<dyn ExecutionPlan>> {
+        // no inputs
+        vec![]
+    }
+
+    fn with_new_children(
+        &self,
+        children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> arrow_deps::datafusion::error::Result<Arc<dyn ExecutionPlan>> {
+        assert!(children.is_empty(), "no children expected in iox plan");
+
+        // For some reason when I used an automatically derived `Clone` implementation
+        // the compiler didn't recognize the trait implementation
+        let new_self = Self {
+            table_name: self.table_name.clone(),
+            schema: self.schema.clone(),
+            chunks: self.chunks.clone(),
+            predicate: self.predicate.clone(),
+            projection: self.projection.clone(),
+        };
+
+        Ok(Arc::new(new_self))
+    }
+
+    async fn execute(
+        &self,
+        partition: usize,
+    ) -> arrow_deps::datafusion::error::Result<SendableRecordBatchStream> {
+        let fields = self.schema.fields();
+        let selection_cols = self.projection.as_ref().map(|projection| {
+            projection
+                .iter()
+                .map(|&index| fields[index].name() as &str)
+                .collect::<Vec<_>>()
+        });
+
+        let selection = if let Some(selection_cols) = selection_cols.as_ref() {
+            Selection::Some(&selection_cols)
+        } else {
+            Selection::All
+        };
+
+        let chunk = &self.chunks[partition];
+        chunk
+            .read_filter(&self.table_name, &self.predicate, selection)
+            .await
+            .map_err(|e| {
+                DataFusionError::Execution(format!(
+                    "Error creating scan for table {} chunk {}: {}",
+                    self.table_name,
+                    chunk.id(),
+                    e
+                ))
+            })
+    }
+}

--- a/query/src/test.rs
+++ b/query/src/test.rs
@@ -2,7 +2,7 @@
 //! and `query::Database` for use in testing.
 
 use arrow_deps::{
-    arrow::record_batch::RecordBatch, datafusion::logical_plan::LogicalPlan,
+    datafusion::{logical_plan::LogicalPlan, physical_plan::SendableRecordBatchStream},
     util::str_iter_to_batch,
 };
 
@@ -474,12 +474,12 @@ impl PartitionChunk for TestChunk {
         unimplemented!()
     }
 
-    fn table_to_arrow(
+    async fn read_filter(
         &self,
-        _dst: &mut Vec<RecordBatch>,
         _table_name: &str,
+        _predicate: &Predicate,
         _selection: Selection<'_>,
-    ) -> Result<(), Self::Error> {
+    ) -> Result<SendableRecordBatchStream, Self::Error> {
         unimplemented!()
     }
 

--- a/server/src/db.rs
+++ b/server/src/db.rs
@@ -22,6 +22,7 @@ use crate::buffer::Buffer;
 mod chunk;
 use chunk::DBChunk;
 pub mod pred;
+mod streams;
 
 #[derive(Debug, Snafu)]
 pub enum Error {

--- a/server/src/db/streams.rs
+++ b/server/src/db/streams.rs
@@ -1,0 +1,169 @@
+//! Adapter streams for different Chunk types that implement the interface
+//! needed by DataFusion
+use arrow_deps::{
+    arrow::{
+        datatypes::SchemaRef,
+        error::{ArrowError, Result as ArrowResult},
+        record_batch::RecordBatch,
+    },
+    datafusion::physical_plan::RecordBatchStream,
+};
+use data_types::selection::Selection;
+use mutable_buffer::chunk::Chunk as MBChunk;
+use read_buffer::ReadFilterResults;
+
+use std::{
+    sync::Arc,
+    task::{Context, Poll},
+};
+
+use snafu::{ResultExt, Snafu};
+
+#[derive(Debug, Snafu)]
+pub enum Error {
+    #[snafu(display(
+        "Error getting data for table '{}' chunk {}: {}",
+        table_name,
+        chunk_id,
+        source
+    ))]
+    GettingTableData {
+        table_name: String,
+        chunk_id: u32,
+        source: mutable_buffer::chunk::Error,
+    },
+}
+
+/// Adapter which will produce record batches from a mutable buffer
+/// chunk on demand
+pub(crate) struct MutableBufferChunkStream {
+    /// Schema
+    schema: SchemaRef,
+    chunk: Arc<MBChunk>,
+    table_name: Arc<String>,
+    selection: OwnedSelection,
+
+    /// Vector of record batches to send in reverse order (send data[len-1]
+    /// next) Is None until the first call to poll_next
+    data: Option<Vec<RecordBatch>>,
+}
+
+impl MutableBufferChunkStream {
+    pub fn new(
+        chunk: Arc<MBChunk>,
+        schema: SchemaRef,
+        table_name: impl Into<String>,
+        selection: Selection<'_>,
+    ) -> Self {
+        Self {
+            chunk,
+            schema,
+            table_name: Arc::new(table_name.into()),
+            selection: selection.into(),
+            data: None,
+        }
+    }
+
+    // gets the next batch, as needed
+    fn next_batch(&mut self) -> ArrowResult<Option<RecordBatch>> {
+        if self.data.is_none() {
+            let selected_cols = match &self.selection {
+                OwnedSelection::Some(cols) => cols.iter().map(|s| s as &str).collect(),
+                OwnedSelection::All => vec![],
+            };
+            let selection = match &self.selection {
+                OwnedSelection::Some(_) => Selection::Some(&selected_cols),
+                OwnedSelection::All => Selection::All,
+            };
+
+            let mut data = Vec::new();
+            self.chunk
+                .table_to_arrow(&mut data, self.table_name.as_ref(), selection)
+                .context(GettingTableData {
+                    table_name: self.table_name.as_ref(),
+                    chunk_id: self.chunk.id(),
+                })
+                .map_err(|e| ArrowError::ExternalError(Box::new(e)))?;
+
+            // reverse the array so we can pop off the back
+            data.reverse();
+            self.data = Some(data);
+        }
+
+        // self.data was set to Some above
+        Ok(self.data.as_mut().unwrap().pop())
+    }
+}
+
+impl RecordBatchStream for MutableBufferChunkStream {
+    fn schema(&self) -> SchemaRef {
+        self.schema.clone()
+    }
+}
+
+impl futures::Stream for MutableBufferChunkStream {
+    type Item = ArrowResult<RecordBatch>;
+
+    fn poll_next(
+        mut self: std::pin::Pin<&mut Self>,
+        _: &mut Context<'_>,
+    ) -> Poll<Option<Self::Item>> {
+        Poll::Ready(self.next_batch().transpose())
+    }
+
+    // TODO is there a useful size_hint to pass?
+}
+
+/// Adapter which will take a ReadFilterResults and make it an async stream
+pub struct ReadFilterResultsStream {
+    read_results: ReadFilterResults,
+    schema: SchemaRef,
+}
+
+impl ReadFilterResultsStream {
+    pub fn new(read_results: ReadFilterResults, schema: SchemaRef) -> Self {
+        Self {
+            read_results,
+            schema,
+        }
+    }
+}
+
+impl RecordBatchStream for ReadFilterResultsStream {
+    fn schema(&self) -> SchemaRef {
+        self.schema.clone()
+    }
+}
+
+impl futures::Stream for ReadFilterResultsStream {
+    type Item = ArrowResult<RecordBatch>;
+
+    fn poll_next(
+        mut self: std::pin::Pin<&mut Self>,
+        _: &mut Context<'_>,
+    ) -> Poll<Option<Self::Item>> {
+        Poll::Ready(Ok(self.read_results.next()).transpose())
+    }
+
+    // TODO is there a useful size_hint to pass?
+}
+
+// Something which owns the column names for the selection
+enum OwnedSelection {
+    Some(Vec<String>),
+    All,
+}
+
+impl OwnedSelection {}
+
+impl From<Selection<'_>> for OwnedSelection {
+    fn from(s: Selection<'_>) -> Self {
+        match s {
+            Selection::All => Self::All,
+            Selection::Some(col_refs) => {
+                let cols = col_refs.iter().map(|s| s.to_string()).collect();
+                Self::Some(cols)
+            }
+        }
+    }
+}

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -722,12 +722,10 @@ mod tests {
         let db_name = DatabaseName::new("foo").unwrap();
         let db = server.db(&db_name).await.unwrap();
 
-        let buff = db.mutable_buffer.as_ref().unwrap();
-
         let planner = SQLQueryPlanner::default();
         let executor = server.executor();
         let physical_plan = planner
-            .query(buff, "select * from cpu", executor.as_ref())
+            .query(db.as_ref(), "select * from cpu", executor.as_ref())
             .await
             .unwrap();
 


### PR DESCRIPTION
Closes #701

## Rationale: 

TLDR is that this is needed to supporting streaming execution, selection and predicate pushdown into the Mutable Buffer, Read Buffer and Parquet chunks. 

### New Features
This PR adds the following features itself
* Streams reads out of the ReadBuffer and MutableBuffer during (SQL) queries
* Projection pushdown (only materialize columns needed by query rather than all of them) during (SQL) queries
* Streams data during the creation of parquet snapshots

Streaming in this case means "process one record batch at time" rather than "get them all at once". This is beneficial so that data isn't buffered overly long as well as limiting wasted work if the plan shuts down early (eg. `.. LIMIT 10`) if results aren't sent

While I specifically say "SQL" above, the mechanism will work for all DataFusion based plans (which will be everything except some metadata queries that are special cased)

### Not (yet) Implemented

This PR allows for, but does not yet implement, the following features (I am going to track them in their own tasks)

2. Implement Predicate pushdown in `TableProvider`
3. Implement chunk pruning across chunks of the read buffer, mutable buffer and parquet files
4. Implement partition pruning optimization to rule out data in a partition based on predicates and partition key
1. Implement statistics for `TableProvider` (let DataFusion planner know about cardinalities, etc).

## Changes in this PR

1. Replaces the "give me all your data" `table_to_arrow` call in the `PartitionCunk` with `read_filter` which takes a predicate and selection and does a proper read (with a filter!!!)
2. Implements the `TableProvider` trait and adapters that allow for streaming results.

After this change, you can no longer run SQL queries against the mutable buffer directly (you have to do so via the `Db` object), which is a step towards getting query logic out of the mutable buffer. 🎉 

## A note on testing
As this PR is mostly wiring up a bunch of the DataFusion APIs -- there is almost no new logic (and thus now new tests, as the features are covered via the end to end query tests in db.rs).

- [x] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb_iox/blob/main/README.md).
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
