### PR TITLE
feat: add approximate memory size tracking to mutable buffer

### DIFF
--- a/mutable_buffer/src/chunk.rs
+++ b/mutable_buffer/src/chunk.rs
@@ -484,6 +484,13 @@ impl Chunk {
             .schema(self, selection)
             .context(NamedTableError { table_name })
     }
+
+    /// Return the approximate memory size of the chunk, in bytes including the
+    /// dictionary, tables, and their rows.
+    pub fn size(&self) -> usize {
+        let data_size = self.tables.values().fold(0, |acc, val| acc + val.size());
+        data_size + self.dictionary.size
+    }
 }
 
 #[async_trait]

--- a/mutable_buffer/src/database.rs
+++ b/mutable_buffer/src/database.rs
@@ -184,6 +184,19 @@ impl MutableBufferDb {
             .drop_chunk(chunk_id)
             .context(DroppingChunk { partition_key })
     }
+
+    /// The approximate size in memory of all data in the mutable buffer, in
+    /// bytes
+    pub async fn size(&self) -> usize {
+        let partitions: Vec<_> = { self.partitions.read().await.values().cloned().collect() };
+
+        let mut size = 0;
+        for p in partitions {
+            size += p.read().await.size();
+        }
+
+        size
+    }
 }
 
 #[async_trait]
@@ -1678,6 +1691,24 @@ mod tests {
         );
 
         Ok(())
+    }
+
+    #[tokio::test]
+    async fn db_size() {
+        let db = MutableBufferDb::new("column_namedb");
+
+        let lp_data = vec![
+            "h2o,state=MA,city=Boston temp=70.4 50",
+            "h2o,state=MA,city=Boston other_temp=70.4 250",
+            "h2o,state=CA,city=Boston other_temp=72.4 350",
+            "o2,state=MA,city=Boston temp=53.4,reading=51 50",
+        ]
+        .join("\n");
+
+        let lines: Vec<_> = parse_lines(&lp_data).map(|l| l.unwrap()).collect();
+        write_lines(&db, &lines).await;
+
+        assert_eq!(429, db.size().await);
     }
 
     /// Run the plan and gather the results in a order that can be compared

--- a/mutable_buffer/src/partition.rs
+++ b/mutable_buffer/src/partition.rs
@@ -201,6 +201,14 @@ impl Partition {
     pub fn iter(&self) -> ChunkIter<'_> {
         ChunkIter::new(self)
     }
+
+    /// Return the estimated size in bytes of the partition
+    pub fn size(&self) -> usize {
+        self.closed_chunks
+            .values()
+            .fold(0, |acc, val| acc + val.size())
+            + self.open_chunk.size()
+    }
 }
 
 /// information on chunks for this partition
@@ -781,6 +789,38 @@ mod tests {
         assert_table_eq!(expected1, &dump_chunk_table(&chunk0_snapshot1, "h2o"));
         assert_table_eq!(expected2, &dump_chunk_table(&chunk0_snapshot2, "h2o"));
         assert_table_eq!(expected2, &dump_chunk_table(&chunk0_rollover, "h2o"));
+    }
+
+    #[tokio::test]
+    async fn partition_size() {
+        let mut partition = Partition::new("a_key");
+
+        load_data(&mut partition, &["h2o,state=MA,city=Boston temp=71.4 100"]).await;
+        assert_eq!(136, partition.size());
+
+        // should increase by less because we're not adding to the dictionary
+        load_data(&mut partition, &["h2o,state=MA,city=Boston temp=71.4 100"]).await;
+        assert_eq!(184, partition.size());
+
+        // make sure it increases by the lesser amount
+        load_data(&mut partition, &["h2o,state=MA,city=Boston temp=71.4 100"]).await;
+        assert_eq!(232, partition.size());
+
+        // make sure a new table makes it increase by more
+        load_data(
+            &mut partition,
+            &["another,state=MA,city=Boston temp=71.4 100"],
+        )
+        .await;
+        assert_eq!(323, partition.size());
+
+        // now roll the chunk and make sure writing into a new chunk will
+        // increase by the same initial amount
+        let chunk = partition.rollover_chunk();
+        assert_eq!(323, chunk.size());
+
+        load_data(&mut partition, &["h2o,state=MA,city=Boston temp=71.4 100"]).await;
+        assert_eq!(459, partition.size());
     }
 
     fn row_count(table_name: &str, chunk: &Chunk) -> u32 {


### PR DESCRIPTION
This updates the mutable buffer, partitions, chunks, dictionary, tables, and individual columns to be able to return their approximate memory size used. This doesn't aim to be exact. There are spots where I'm not counting table or column pointers or the partition key. My expectation is that the data size will dominate and a few pointers here and there won't matter.

This PR is the first bit of work that will enable a user to set how much memory they want the mutable buffer to take on a database. Follow on PRs to get there will be:
1. Adding  column names to summary statistics
2. Enabling partitions to roll up summary statistics
3. Adding to database rules to let users specify partition eviction rules
4. Add per database periodic checking to enforce sizes rules and evict partitions