### PR TITLE
fix: Fix copy&pasted check_response descriptions

### DIFF
--- a/src/influxdb_ioxd/http_routes.rs
+++ b/src/influxdb_ioxd/http_routes.rs
@@ -879,7 +879,7 @@ mod tests {
             .send()
             .await;
 
-        check_response("write", response, StatusCode::NO_CONTENT, "").await;
+        check_response("gzip_write", response, StatusCode::NO_CONTENT, "").await;
 
         // Check that the data got into the right bucket
         let test_db = test_storage
@@ -982,7 +982,7 @@ mod tests {
             .send()
             .await;
 
-        check_response("create_database", response, StatusCode::OK, &data).await;
+        check_response("get_database", response, StatusCode::OK, &data).await;
     }
 
     /// checks a http response against expected results


### PR DESCRIPTION
Copy pasta is best pasta

