### PR TITLE
feat: consistent global error handling and logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2869,7 +2869,7 @@ dependencies = [
 [[package]]
 name = "routerify"
 version = "2.0.0-beta-2"
-source = "git+https://github.com/influxdata/routerify?rev=bfe198e#bfe198e006d85b1b648ac96101d676b620d6f569"
+source = "git+https://github.com/influxdata/routerify?rev=274e250#274e250e556b968ad02259282c0433e445db4200"
 dependencies = [
  "http",
  "hyper",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ bytes = "1.0"
 hyper = "0.14"
 
 # Forked to upgrade hyper and tokio
-routerify = { git = "https://github.com/influxdata/routerify", rev = "bfe198e" }
+routerify = { git = "https://github.com/influxdata/routerify", rev = "274e250" }
 
 tokio = { version = "1.0", features=["macros", "rt-multi-thread"] }
 tokio-stream = {version = "0.1.2", features=["net"]}


### PR DESCRIPTION
Uses routerify [changes](https://github.com/influxdata/routerify/pull/1) to allow stripping out the per-handler wrapper shims, thereby providing more consistent error handling and logging