### PR TITLE
chore: refactor how columns are kept in the table in the mutable buffer

### DIFF
--- a/mutable_buffer/src/database.rs
+++ b/mutable_buffer/src/database.rs
@@ -457,13 +457,8 @@ impl MutableBufferDb {
                         if filter.should_visit_table(table)? {
                             visitor.pre_visit_table(table, chunk, filter)?;
 
-                            for (column_id, column_index) in &table.column_id_to_index {
-                                visitor.visit_column(
-                                    table,
-                                    *column_id,
-                                    &table.columns[*column_index],
-                                    filter,
-                                )?
+                            for (column_id, column) in &table.columns {
+                                visitor.visit_column(table, *column_id, column, filter)?
                             }
 
                             visitor.post_visit_table(table, chunk)?;


### PR DESCRIPTION
This one is a bit of a yak shave in advance of adding column names to the summary statistics. I needed the column and its name (or identifier) to be together, rather than the id to index map that existed before. I think the table_id and column_id stuff should be refactored out over time since they add a ton of complexity to the code and don't add much value. Having those as Strings would be much easier and probably be a drop in the bucket for memory usage. Basically, I don't think they need to be interned. But that would be an even more massive refactor touching so many things in the MutableBuffer, I leave it as a later exercise.

Hopefully this makes the code simpler and cleaner in the interim and it gives me the column_id with the column so that I can easily look up the name when generating the summary statistics for a chunk.