### PR TITLE
chore: Clean up Cargo.tomls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,11 +5,12 @@ authors = ["Paul Dix <paul@pauldix.net>"]
 edition = "2018"
 default-run = "influxdb_iox"
 
-[workspace]
+[workspace] # In alphabetical order
 members = [
     "arrow_deps",
     "data_types",
     "generated_types",
+    "influxdb_iox_client",
     "influxdb_line_protocol",
     "influxdb_tsm",
     "influxdb2_client",
@@ -25,7 +26,6 @@ members = [
     "server",
     "test_helpers",
     "wal",
-    "influxdb_iox_client",
 ]
 
 [profile.release]
@@ -35,6 +35,7 @@ debug = true
 debug = true
 
 [dependencies]
+# Workspace dependencies, in alphabetical order
 arrow_deps = { path = "arrow_deps" }
 data_types = { path = "data_types" }
 generated_types = { path = "generated_types" }
@@ -53,62 +54,53 @@ read_buffer = { path = "read_buffer" }
 server = { path = "server" }
 wal = { path = "wal" }
 
-bytes = "1.0"
-hyper = "0.14"
-
-# Forked to upgrade hyper and tokio
-routerify = { git = "https://github.com/influxdata/routerify", rev = "274e250" }
-
-tokio = { version = "1.0", features=["macros", "rt-multi-thread"] }
-tokio-stream = {version = "0.1.2", features=["net"]}
-
-
-clap = "2.33.1"
-futures = "0.3.1"
-
-serde_json = "1.0.44"
-serde_urlencoded = "0.7.0"
-serde = { version = "1.0", features = ["derive"] }
-csv = "1.1"
+# Crates.io dependencies, in alphabetical order
 byteorder = "1.3.4"
-
-tonic = "0.4.0"
-prost = "0.7"
-prost-types = "0.7"
+bytes = "1.0"
+clap = "2.33.1"
+csv = "1.1"
+dirs = "3.0.1"
+dotenv = "0.15.0"
 env_logger = "0.7.1"
-tracing = { version = "0.1", features = ["release_max_level_debug"] }
-tracing-futures="0.2.4"
-
-# OpenTelemetry sinks for tracing
-tracing-subscriber = "0.2.15"
-tracing-opentelemetry = "0.11.0"
+flate2 = "1.0"
+futures = "0.3.1"
+http = "0.2.0"
+hyper = "0.14"
+lazy_static = "1.4.0"
 opentelemetry = { version = "0.12", default-features = false, features = ["trace", "tokio-support"] }
 opentelemetry-jaeger = { version = "0.11", features = ["tokio"] }
-
-http = "0.2.0"
+prost = "0.7"
+prost-types = "0.7"
+# Forked to upgrade hyper and tokio
+routerify = { git = "https://github.com/influxdata/routerify", rev = "274e250" }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0.44"
+serde_urlencoded = "0.7.0"
 snafu = "0.6.9"
-flate2 = "1.0"
 structopt = "0.3.21"
-dotenv = "0.15.0"
-dirs = "3.0.1"
-lazy_static = "1.4.0"
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
+tokio-stream = { version = "0.1.2", features = ["net"] }
+tonic = "0.4.0"
+tracing = { version = "0.1", features = ["release_max_level_debug"] }
+tracing-futures = "0.2.4"
+tracing-opentelemetry = "0.11.0"
+tracing-subscriber = "0.2.15"
 
-[dev-dependencies]
+[dev-dependencies] # In alphabetical order
 assert_cmd = "1.0.0"
 criterion = "0.3"
-test_helpers = { path = "test_helpers" }
+flate2 = "1.0"
 hex = "0.4.2"
 influxdb2_client = { path = "influxdb2_client" }
-flate2 = "1.0"
+predicates = "1.0.4"
 rand = "0.7.2"
 reqwest = "0.11"
-predicates = "1.0.4"
 tempfile = "3.1.0"
+test_helpers = { path = "test_helpers" }
 
 [[bin]]
 name = "cpu_feature_check"
 path = "src/cpu_feature_check/main.rs"
-
 
 [[bench]]
 name = "encoders"

--- a/arrow_deps/Cargo.toml
+++ b/arrow_deps/Cargo.toml
@@ -5,10 +5,7 @@ authors = ["Andrew Lamb <andrew@nerdnetworks.org>"]
 edition = "2018"
 description = "Apache Arrow / Parquet / DataFusion dependencies for InfluxDB IOx, to ensure consistent versions and unified updates"
 
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
-[dependencies]
+[dependencies] # In alphabetical order
 # We are using development version of arrow/parquet/datafusion and the dependencies are at the same rev
 
 # The version can be found here: https://github.com/apache/arrow/commit/fc7540328ca686fa29247928abc158b3f33d0701

--- a/data_types/Cargo.toml
+++ b/data_types/Cargo.toml
@@ -4,21 +4,19 @@ version = "0.1.0"
 authors = ["pauldix <paul@pauldix.net>"]
 edition = "2018"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
-[dependencies]
+[dependencies] # In alphabetical order
 arrow_deps = { path = "../arrow_deps" }
-snafu = "0.6"
-serde = "1.0"
+chrono = "0.4"
+crc32fast = "1.2.0"
+flatbuffers = "0.6"
 generated_types = { path = "../generated_types" }
 influxdb_line_protocol = { path = "../influxdb_line_protocol" }
-chrono = "0.4"
-flatbuffers = "0.6"
-crc32fast = "1.2.0"
-tracing = "0.1"
 percent-encoding = "2.1.0"
+serde = "1.0"
+snafu = "0.6"
+tracing = "0.1"
 
-[dev-dependencies]
+[dev-dependencies] # In alphabetical order
 criterion = "0.3"
 test_helpers = { path = "../test_helpers" }
 

--- a/generated_types/Cargo.toml
+++ b/generated_types/Cargo.toml
@@ -4,14 +4,12 @@ version = "0.1.0"
 authors = ["Paul Dix <paul@pauldix.net>"]
 edition = "2018"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
-[dependencies]
+[dependencies] # In alphabetical order
 flatbuffers = "0.6.1"
 futures = "0.3.1"
 prost = "0.7"
 prost-types = "0.7"
 tonic = "0.4"
 
-[build-dependencies]
+[build-dependencies] # In alphabetical order
 tonic-build = "0.4"

--- a/influxdb2_client/Cargo.toml
+++ b/influxdb2_client/Cargo.toml
@@ -4,14 +4,14 @@ version = "0.1.0"
 authors = ["Paul Dix <paul@pauldix.net>"]
 edition = "2018"
 
-[dependencies]
-bytes = { version = "1.0", default-features=false }
+[dependencies] # In alphabetical order
+bytes = { version = "1.0", default-features = false }
 futures = { version = "0.3.5", default-features = false }
 reqwest = { version = "0.11", default-features = false, features = ["stream"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.44"
 snafu = "0.6.6"
 
-[dev-dependencies]
+[dev-dependencies] # In alphabetical order
 mockito = "0.26.0"
-tokio = { version = "1.0", features=["macros"] }
+tokio = { version = "1.0", features = ["macros"] }

--- a/influxdb_iox_client/Cargo.toml
+++ b/influxdb_iox_client/Cargo.toml
@@ -4,15 +4,13 @@ version = "0.1.0"
 authors = ["Dom Dwyer <dom@itsallbroken.com>"]
 edition = "2018"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
-[dependencies]
+[dependencies] # In alphabetical order
 data_types = { path = "../data_types" }
 reqwest = { version = "0.11.0", features = ["gzip", "json"] }
 serde = "1.0.118"
 thiserror = "1.0.23"
-tokio = { version = "1.0", features=["macros"] }
+tokio = { version = "1.0", features = ["macros"] }
 
-[dev-dependencies]
+[dev-dependencies] # In alphabetical order
 rand = "0.8.1"
 serde_json = "1.0"

--- a/influxdb_line_protocol/Cargo.toml
+++ b/influxdb_line_protocol/Cargo.toml
@@ -4,12 +4,12 @@ version = "0.1.0"
 authors = ["Paul Dix <paul@pauldix.net>"]
 edition = "2018"
 
-[dependencies]
-tracing = "0.1"
+[dependencies] # In alphabetical order
+influxdb2_client = { path = "../influxdb2_client" }
 nom = "5.1.1"
 smallvec = "1.2.0"
 snafu = "0.6.2"
-influxdb2_client = { path = "../influxdb2_client" }
+tracing = "0.1"
 
-[dev-dependencies]
+[dev-dependencies] # In alphabetical order
 test_helpers = { path = "../test_helpers" }

--- a/influxdb_tsm/Cargo.toml
+++ b/influxdb_tsm/Cargo.toml
@@ -4,16 +4,14 @@ version = "0.1.0"
 authors = ["Edd Robinson <me@edd.io>"]
 edition = "2018"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
-[dependencies]
+[dependencies] # In alphabetical order
 integer-encoding = "1.0.7"
+snafu = "0.6.2"
 snap = "1.0.0"
 tracing = "0.1"
-snafu = "0.6.2"
 
-[dev-dependencies]
-hex = "0.4.2"
+[dev-dependencies] # In alphabetical order
 flate2 = "1.0"
+hex = "0.4.2"
 rand = "0.7.2"
 test_helpers = { path = "../test_helpers" }

--- a/ingest/Cargo.toml
+++ b/ingest/Cargo.toml
@@ -4,18 +4,15 @@ version = "0.1.0"
 authors = ["Andrew Lamb <andrew@nerdnetworks.org>"]
 edition = "2018"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
-[dependencies]
+[dependencies] # In alphabetical order
+arrow_deps = { path = "../arrow_deps" }
+data_types = { path = "../data_types" }
+influxdb_line_protocol = { path = "../influxdb_line_protocol" }
+influxdb_tsm = { path = "../influxdb_tsm" }
+packers = { path = "../packers" }
 snafu = "0.6.2"
 tracing = "0.1"
 
-influxdb_line_protocol = { path = "../influxdb_line_protocol" }
-packers = { path = "../packers" }
-data_types = { path = "../data_types" }
-influxdb_tsm = { path = "../influxdb_tsm" }
-arrow_deps = { path = "../arrow_deps" }
-
-[dev-dependencies]
-test_helpers ={ path = "../test_helpers" }
+[dev-dependencies] # In alphabetical order
 flate2 = "1.0"
+test_helpers = { path = "../test_helpers" }

--- a/logfmt/Cargo.toml
+++ b/logfmt/Cargo.toml
@@ -5,12 +5,10 @@ authors = ["Andrew Lamb <andrew@nerdnetworks.org>"]
 description="tracing_subscriber layer for writing out logfmt formatted events"
 edition = "2018"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
-[dependencies]
+[dependencies] # In alphabetical order
 tracing = { version = "0.1" }
 tracing-subscriber = "0.2.15"
 
-[dev-dependencies]
+[dev-dependencies] # In alphabetical order
 lazy_static = "1.4.0"
 regex = "1.4.3"

--- a/mem_qe/Cargo.toml
+++ b/mem_qe/Cargo.toml
@@ -4,21 +4,16 @@ version = "0.1.0"
 authors = ["Edd Robinson <me@edd.io>"]
 edition = "2018"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
-
-[dependencies]
+[dependencies] # In alphabetical order
 arrow_deps = { path = "../arrow_deps" }
-packers = { path = "../packers" }
-snafu = "0.6.8"
+chrono = "0.4"
 croaring = "0.4.5"
 crossbeam = "0.7.3"
-chrono = "0.4"
-tracing = "0.1"
 env_logger = "0.7.1"
 human_format = "1.0.3"
+packers = { path = "../packers" }
+snafu = "0.6.8"
+tracing = "0.1"
 
-
-
-[dev-dependencies]
+[dev-dependencies] # In alphabetical order
 criterion = "0.3"

--- a/mutable_buffer/Cargo.toml
+++ b/mutable_buffer/Cargo.toml
@@ -4,7 +4,6 @@ version = "0.1.0"
 authors = ["Andrew Lamb <andrew@nerdnetworks.org>"]
 edition = "2018"
 
-
 # Note the long term goal is that this crate is standalone and not
 # dependent on the IOx Query Engine (even though this is not the case
 # now).
@@ -14,22 +13,20 @@ edition = "2018"
 # 1. Keep the API clean (and concerns separated) and allow for potential future reuse outside of IOx
 # 2. Keep change/compile/link time down during development when working on just this crate
 
-[dependencies]
-
+[dependencies] # In alphabetical order
 arrow_deps = { path = "../arrow_deps" }
+async-trait = "0.1"
+chrono = "0.4"
 data_types = { path = "../data_types" }
+flatbuffers = "0.6.1"
 generated_types = { path = "../generated_types" }
 influxdb_line_protocol = { path = "../influxdb_line_protocol" }
 query = { path = "../query" }
-
-async-trait = "0.1"
-chrono = "0.4"
-flatbuffers = "0.6.1"
 snafu = "0.6.2"
 string-interner = "0.12.2"
 tokio = { version = "1.0", features = ["macros"] }
 tracing = "0.1"
 
-[dev-dependencies]
+[dev-dependencies] # In alphabetical order
 test_helpers = { path = "../test_helpers" }
 criterion = "0.3"

--- a/mutable_buffer/Cargo.toml
+++ b/mutable_buffer/Cargo.toml
@@ -21,7 +21,6 @@ data_types = { path = "../data_types" }
 generated_types = { path = "../generated_types" }
 influxdb_line_protocol = { path = "../influxdb_line_protocol" }
 query = { path = "../query" }
-test_helpers = { path = "../test_helpers" }
 
 async-trait = "0.1"
 chrono = "0.4"

--- a/object_store/Cargo.toml
+++ b/object_store/Cargo.toml
@@ -35,6 +35,3 @@ azure_storage = {git = "https://github.com/Azure/azure-sdk-for-rust.git", rev = 
 [dev-dependencies]
 tempfile = "3.1.0"
 dotenv = "0.15.0"
-
-[build-dependencies]
-dotenv = "0.15.0"

--- a/object_store/Cargo.toml
+++ b/object_store/Cargo.toml
@@ -4,34 +4,31 @@ version = "0.1.0"
 authors = ["Paul Dix <paul@pauldix.net>"]
 edition = "2018"
 
-[dependencies]
+[dependencies] # In alphabetical order
 async-trait = "0.1.42"
+# Microsoft Azure Blob storage integration
+# In order to support tokio 1.0 needed to pull in unreleased azure sdk
+azure_core = { git = "https://github.com/Azure/azure-sdk-for-rust.git", rev = "5ecad7216e1f04c5ff41e7de4667f006664c8cca" }
+azure_storage = { git = "https://github.com/Azure/azure-sdk-for-rust.git", rev = "5ecad7216e1f04c5ff41e7de4667f006664c8cca", default-features = false, features = ["table", "blob"] }
 bytes = "1.0"
 chrono = "0.4"
+# Google Cloud Storage integration
+cloud-storage = { version = "0.7.0" }
 futures = "0.3.5"
 itertools = "0.9.0"
 percent-encoding = "2.1"
-snafu = { version = "0.6.10", features = ["futures"] }
-tokio = { version = "1.0", features=["macros"] }
-reqwest = "0.11"
-
-# Amazon S3 integration
+# rusoto crates are for Amazon S3 integration
 rusoto_core = "0.46.0"
 rusoto_credential = "0.46.0"
 rusoto_s3 = "0.46.0"
-
-# Google Cloud Storage integration
-cloud-storage = { version = "0.7.0" }
-
+snafu = { version = "0.6.10", features = ["futures"] }
+tokio = { version = "1.0", features = ["macros"] }
 # Filesystem integration
 tokio-util = "0.6.2"
+reqwest = "0.11"
+# Filesystem integration
 walkdir = "2"
 
-# Microsoft Azure Blob storage integration
-# In order to support tokio 1.0 needed to pull in unreleased azure sdk
-azure_core = {git = "https://github.com/Azure/azure-sdk-for-rust.git", rev = "5ecad7216e1f04c5ff41e7de4667f006664c8cca"}
-azure_storage = {git = "https://github.com/Azure/azure-sdk-for-rust.git", rev = "5ecad7216e1f04c5ff41e7de4667f006664c8cca", default-features = false, features=["table", "blob"]}
-
-[dev-dependencies]
-tempfile = "3.1.0"
+[dev-dependencies] # In alphabetical order
 dotenv = "0.15.0"
+tempfile = "3.1.0"

--- a/packers/Cargo.toml
+++ b/packers/Cargo.toml
@@ -4,16 +4,14 @@ version = "0.1.0"
 authors = ["Andrew Lamb <andrew@nerdnetworks.org>"]
 edition = "2018"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-[dependencies]
-snafu = "0.6.2"
-tracing = "0.1"
-rand = "0.7.3"
-human_format = "1.0.3"
-
+[dependencies] # In alphabetical order
 arrow_deps = { path = "../arrow_deps" }
 data_types = { path = "../data_types" }
+human_format = "1.0.3"
 influxdb_tsm = { path = "../influxdb_tsm" }
+rand = "0.7.3"
+snafu = "0.6.2"
+tracing = "0.1"
 
-[dev-dependencies]
-test_helpers ={ path = "../test_helpers" }
+[dev-dependencies] # In alphabetical order
+test_helpers = { path = "../test_helpers" }

--- a/panic_logging/Cargo.toml
+++ b/panic_logging/Cargo.toml
@@ -4,5 +4,5 @@ version = "0.1.0"
 authors = ["Paul Dix <paul@pauldix.net>"]
 edition = "2018"
 
-[dependencies]
+[dependencies] # In alphabetical order
 tracing = { version = "0.1", features = ["release_max_level_debug"] }

--- a/query/Cargo.toml
+++ b/query/Cargo.toml
@@ -31,4 +31,6 @@ arrow_deps = { path = "../arrow_deps" }
 sqlparser = "0.6.1"
 influxdb_line_protocol = { path = "../influxdb_line_protocol" }
 data_types = { path = "../data_types" }
+
+[dev-dependencies]
 test_helpers = { path = "../test_helpers" }

--- a/query/Cargo.toml
+++ b/query/Cargo.toml
@@ -5,10 +5,7 @@ authors = ["Andrew Lamb <andrew@nerdnetworks.org>"]
 edition = "2018"
 description = "IOx Query Interface and Executor"
 
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
-# This create is designed to be independent of the rest of the IOx
+# This crate is designed to be independent of the rest of the IOx
 # server and specific storage systems such as Mutable Buffer and Read Buffer.
 #
 # The rationale for this is to:
@@ -16,21 +13,18 @@ description = "IOx Query Interface and Executor"
 # 1. Keep change/compile/link time down during development when working on just this crate
 # 2. Allow for query logic testing without bringing in all the storage systems.
 
-
-
-[dependencies]
-snafu = "0.6.2"
+[dependencies] # In alphabetical order
+arrow_deps = { path = "../arrow_deps" }
 async-trait = "0.1"
-tokio = { version = "1.0", features=["macros"] }
+chrono = "0.4"
+croaring = "0.4.5"
+data_types = { path = "../data_types" }
+influxdb_line_protocol = { path = "../influxdb_line_protocol" }
+snafu = "0.6.2"
+sqlparser = "0.6.1"
+tokio = { version = "1.0", features = ["macros"] }
 tokio-stream = "0.1.2"
 tracing = "0.1"
-croaring = "0.4.5"
-chrono = "0.4"
 
-arrow_deps = { path = "../arrow_deps" }
-sqlparser = "0.6.1"
-influxdb_line_protocol = { path = "../influxdb_line_protocol" }
-data_types = { path = "../data_types" }
-
-[dev-dependencies]
+[dev-dependencies] # In alphabetical order
 test_helpers = { path = "../test_helpers" }

--- a/read_buffer/Cargo.toml
+++ b/read_buffer/Cargo.toml
@@ -4,29 +4,24 @@ version = "0.1.0"
 authors = ["Edd Robinson <me@edd.io>"]
 edition = "2018"
 
-
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 # Note this crate is designed to be standalone, and should not depend
 # on the IOx Query Engine. The rationale is:
 #
 # 1. Keep the API clean (and concerns separated) and allow for potential future reuse outside of IOx
 # 2. Keep change/compile/link time down during development when working on just this crate
 
-
-[dependencies]
-snafu = "0.6"
+[dependencies] # In alphabetical order
 arrow_deps = { path = "../arrow_deps" }
-data_types = { path = "../data_types" }
-packers = { path = "../packers" }
 croaring = "0.4.5"
-itertools = "0.9.0"
+data_types = { path = "../data_types" }
 either = "1.6.1"
-permutation = "0.2.5"
 hashbrown = "0.9.1"
+itertools = "0.9.0"
+packers = { path = "../packers" }
+permutation = "0.2.5"
+snafu = "0.6"
 
-[dev-dependencies]
+[dev-dependencies] # In alphabetical order
 criterion = "0.3.3"
 rand = "0.7.3"
 rand_distr = "0.3.0"

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -4,30 +4,28 @@ version = "0.1.0"
 authors = ["pauldix <paul@pauldix.net>"]
 edition = "2018"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
-[dependencies]
-snafu = "0.6"
-serde = "1.0"
-serde_json = "1.0"
-async-trait = "0.1"
-data_types = { path = "../data_types" }
-generated_types = { path = "../generated_types" }
-influxdb_line_protocol = { path = "../influxdb_line_protocol" }
-query = { path = "../query" }
-mutable_buffer = { path = "../mutable_buffer" }
-read_buffer = { path = "../read_buffer" }
-object_store = { path = "../object_store" }
-tracing = "0.1"
-tokio = { version = "1.0", features=["macros", "time"] }
+[dependencies] # In alphabetical order
 arrow_deps = { path = "../arrow_deps" }
-futures = "0.3.7"
+async-trait = "0.1"
 bytes = "1.0"
 chrono = "0.4"
-uuid = { version = "0.8", features = ["serde", "v4"]}
-flatbuffers = "0.6"
 crc32fast = "1.2.0"
+data_types = { path = "../data_types" }
+flatbuffers = "0.6"
+futures = "0.3.7"
+generated_types = { path = "../generated_types" }
+influxdb_line_protocol = { path = "../influxdb_line_protocol" }
+mutable_buffer = { path = "../mutable_buffer" }
+object_store = { path = "../object_store" }
+query = { path = "../query" }
+read_buffer = { path = "../read_buffer" }
+serde = "1.0"
+serde_json = "1.0"
+snafu = "0.6"
 snap = "1.0.0"
+tokio = { version = "1.0", features = ["macros", "time"] }
+tracing = "0.1"
+uuid = { version = "0.8", features = ["serde", "v4"] }
 
-[dev-dependencies]
+[dev-dependencies] # In alphabetical order
 test_helpers = { path = "../test_helpers" }

--- a/test_helpers/Cargo.toml
+++ b/test_helpers/Cargo.toml
@@ -4,10 +4,8 @@ version = "0.1.0"
 authors = ["Paul Dix <paul@pauldix.net>"]
 edition = "2018"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
-[dependencies]
+[dependencies] # In alphabetical order
 dotenv = "0.15.0"
-tempfile = "3.1.0"
 env_logger = "0.7.1"
+tempfile = "3.1.0"
 tracing = "0.1"

--- a/wal/Cargo.toml
+++ b/wal/Cargo.toml
@@ -4,20 +4,19 @@ version = "0.1.0"
 authors = ["Paul Dix <paul@pauldix.net>"]
 edition = "2018"
 
-[dependencies]
+[dependencies] # In alphabetical order
 byteorder = "1.3.4"
 crc32fast = "1.2.0"
-snafu = "0.6.6"
-snap = "1.0.0"
-regex = "1.3.7"
+futures = "0.3.4"
 itertools = "0.9.0"
 once_cell = "1.4.0"
-futures = "0.3.4"
+regex = "1.3.7"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.44"
-tracing = "0.1"
+snafu = "0.6.6"
+snap = "1.0.0"
 tokio = { version = "1.0", features=["macros", "fs"] }
+tracing = "0.1"
 
-
-[dev-dependencies]
+[dev-dependencies] # In alphabetical order
 test_helpers = { path = "../test_helpers" }


### PR DESCRIPTION
Mostly alphabetization... Much like using rustfmt, I don't want to have to spend too much time thinking about where a new dependency should go in a Cargo.toml. So now everything is nice and tidy and alphabetized!

I also found some instances where test_helper was a regular dependency rather than a dev dependency, and the object_store crate no longer has a build script so the build dep can go away.

I'm happy to manage merge conflicts.