### PR TITLE
refactor: Remove async locking from test database

### DIFF
--- a/query/src/test.rs
+++ b/query/src/test.rs
@@ -8,10 +8,9 @@ use arrow_deps::{
 
 use crate::{exec::Executor, group_by::GroupByAndAggregate, util::make_scan_plan};
 use crate::{
-    exec::FieldListPlan,
     exec::{
         stringset::{StringSet, StringSetRef},
-        SeriesSetPlans, StringSetPlan,
+        FieldListPlan, SeriesSetPlans, StringSetPlan,
     },
     Database, DatabaseStore, PartitionChunk, Predicate,
 };
@@ -26,11 +25,11 @@ use influxdb_line_protocol::{parse_lines, ParsedLine};
 
 use async_trait::async_trait;
 use snafu::{OptionExt, ResultExt, Snafu};
-use std::{collections::BTreeMap, collections::BTreeSet, sync::Arc};
-
-use std::fmt::Write;
-
-use tokio::sync::Mutex;
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    fmt::Write,
+    sync::{Arc, Mutex},
+};
 
 #[derive(Debug, Default)]
 pub struct TestDatabase {
@@ -138,13 +137,13 @@ impl TestDatabase {
     }
 
     /// Get all lines written to this database
-    pub async fn get_lines(&self) -> Vec<String> {
-        self.saved_lines.lock().await.clone()
+    pub fn get_lines(&self) -> Vec<String> {
+        self.saved_lines.lock().expect("mutex poisoned").clone()
     }
 
     /// Get all replicated writs to this database
-    pub async fn get_writes(&self) -> Vec<ReplicatedWrite> {
-        self.replicated_writes.lock().await.clone()
+    pub fn get_writes(&self) -> Vec<ReplicatedWrite> {
+        self.replicated_writes.lock().expect("mutex poisoned").clone()
     }
 
     /// Parse line protocol and add it as new lines to this
@@ -158,15 +157,15 @@ impl TestDatabase {
         writer.write_lines(self, &parsed_lines).await.unwrap();
 
         // Writes parsed lines into this database
-        let mut saved_lines = self.saved_lines.lock().await;
+        let mut saved_lines = self.saved_lines.lock().expect("mutex poisoned");
         for line in parsed_lines {
             saved_lines.push(line.to_string())
         }
     }
 
     /// Add a test chunk to the database
-    pub async fn add_chunk(&self, partition_key: &str, chunk: Arc<TestChunk>) {
-        let mut partitions = self.partitions.lock().await;
+    pub fn add_chunk(&self, partition_key: &str, chunk: Arc<TestChunk>) {
+        let mut partitions = self.partitions.lock().expect("mutex poisoned");
         let chunks = partitions
             .entry(partition_key.to_string())
             .or_insert_with(BTreeMap::new);
@@ -174,70 +173,70 @@ impl TestDatabase {
     }
 
     /// Get the specified chunk
-    pub async fn get_chunk(&self, partition_key: &str, id: u32) -> Option<Arc<TestChunk>> {
+    pub fn get_chunk(&self, partition_key: &str, id: u32) -> Option<Arc<TestChunk>> {
         self.partitions
             .lock()
-            .await
+            .expect("mutex poisoned")
             .get(partition_key)
             .and_then(|p| p.get(&id).cloned())
     }
 
     /// Set the list of column names that will be returned on a call to
     /// column_names
-    pub async fn set_column_names(&self, column_names: Vec<String>) {
+    pub fn set_column_names(&self, column_names: Vec<String>) {
         let column_names = column_names.into_iter().collect::<StringSet>();
         let column_names = Arc::new(column_names);
 
-        *(self.column_names.clone().lock().await) = Some(column_names)
+        *(self.column_names.clone().lock().expect("mutex poisoned")) = Some(column_names)
     }
 
     /// Get the parameters from the last column name request
-    pub async fn get_column_names_request(&self) -> Option<ColumnNamesRequest> {
-        self.column_names_request.clone().lock().await.take()
+    pub fn get_column_names_request(&self) -> Option<ColumnNamesRequest> {
+        self.column_names_request.clone().lock().expect("mutex poisoned").take()
     }
 
     /// Set the list of column values that will be returned on a call to
     /// column_values
-    pub async fn set_column_values(&self, column_values: Vec<String>) {
+    pub fn set_column_values(&self, column_values: Vec<String>) {
         let column_values = column_values.into_iter().collect::<StringSet>();
         let column_values = Arc::new(column_values);
 
-        *(self.column_values.clone().lock().await) = Some(column_values)
+        *(self.column_values.clone().lock().expect("mutex poisoned")) = Some(column_values)
     }
 
     /// Get the parameters from the last column name request
-    pub async fn get_column_values_request(&self) -> Option<ColumnValuesRequest> {
-        self.column_values_request.clone().lock().await.take()
+    pub fn get_column_values_request(&self) -> Option<ColumnValuesRequest> {
+        self.column_values_request.clone().lock().expect("mutex poisoned").take()
     }
 
     /// Set the series that will be returned on a call to query_series
-    pub async fn set_query_series_values(&self, plan: SeriesSetPlans) {
-        *(self.query_series_values.clone().lock().await) = Some(plan);
+    pub fn set_query_series_values(&self, plan: SeriesSetPlans) {
+        *(self.query_series_values.clone().lock().expect("mutex poisoned")) = Some(plan);
     }
 
     /// Get the parameters from the last column name request
-    pub async fn get_query_series_request(&self) -> Option<QuerySeriesRequest> {
-        self.query_series_request.clone().lock().await.take()
+    pub fn get_query_series_request(&self) -> Option<QuerySeriesRequest> {
+        self.query_series_request.clone().lock().expect("mutex poisoned").take()
     }
 
     /// Set the series that will be returned on a call to query_groups
-    pub async fn set_query_groups_values(&self, plan: SeriesSetPlans) {
-        *(self.query_groups_values.clone().lock().await) = Some(plan);
+    pub fn set_query_groups_values(&self, plan: SeriesSetPlans) {
+        *(self.query_groups_values.clone().lock().expect("mutex poisoned")) = Some(plan);
     }
 
     /// Get the parameters from the last column name request
-    pub async fn get_query_groups_request(&self) -> Option<QueryGroupsRequest> {
-        self.query_groups_request.clone().lock().await.take()
+    pub fn get_query_groups_request(&self) -> Option<QueryGroupsRequest> {
+        self.query_groups_request.clone().lock().expect("mutex poisoned").take()
     }
 
     /// Set the FieldSet plan that will be returned
-    pub async fn set_field_colum_names_values(&self, plan: FieldListPlan) {
-        *(self.field_columns_value.clone().lock().await) = Some(plan);
+    pub fn set_field_colum_names_values(&self, plan: FieldListPlan) {
+        *(self.field_columns_value.clone().lock().expect("mutex poisoned")) = Some(plan);
     }
 
     /// Get the parameters from the last column name request
-    pub async fn get_field_columns_request(&self) -> Option<FieldColumnsRequest> {
-        self.field_columns_request.clone().lock().await.take()
+    pub fn get_field_columns_request(&self) -> Option<FieldColumnsRequest> {
+        self.field_columns_request.clone().lock().expect("mutex poisoned").take()
     }
 }
 
@@ -291,7 +290,7 @@ impl Database for TestDatabase {
 
     /// Adds the replicated write to this database
     async fn store_replicated_write(&self, write: &ReplicatedWrite) -> Result<(), Self::Error> {
-        self.replicated_writes.lock().await.push(write.clone());
+        self.replicated_writes.lock().expect("mutex poisoned").push(write.clone());
         Ok(())
     }
 
@@ -302,14 +301,14 @@ impl Database for TestDatabase {
 
         let new_column_names_request = Some(ColumnNamesRequest { predicate });
 
-        *self.column_names_request.clone().lock().await = new_column_names_request;
+        *self.column_names_request.clone().lock().expect("mutex poisoned") = new_column_names_request;
 
         // pull out the saved columns
         let column_names = self
             .column_names
             .clone()
             .lock()
-            .await
+            .expect("mutex poisoned")
             .take()
             // Turn None into an error
             .context(General {
@@ -325,13 +324,13 @@ impl Database for TestDatabase {
 
         let field_columns_request = Some(FieldColumnsRequest { predicate });
 
-        *self.field_columns_request.clone().lock().await = field_columns_request;
+        *self.field_columns_request.clone().lock().expect("mutex poisoned") = field_columns_request;
 
         // pull out the saved columns
         self.field_columns_value
             .clone()
             .lock()
-            .await
+            .expect("mutex poisoned")
             .take()
             // Turn None into an error
             .context(General {
@@ -353,14 +352,14 @@ impl Database for TestDatabase {
             predicate,
         });
 
-        *self.column_values_request.clone().lock().await = new_column_values_request;
+        *self.column_values_request.clone().lock().expect("mutex poisoned") = new_column_values_request;
 
         // pull out the saved columns
         let column_values = self
             .column_values
             .clone()
             .lock()
-            .await
+            .expect("mutex poisoned")
             .take()
             // Turn None into an error
             .context(General {
@@ -375,12 +374,12 @@ impl Database for TestDatabase {
 
         let new_queries_series_request = Some(QuerySeriesRequest { predicate });
 
-        *self.query_series_request.clone().lock().await = new_queries_series_request;
+        *self.query_series_request.clone().lock().expect("mutex poisoned") = new_queries_series_request;
 
         self.query_series_values
             .clone()
             .lock()
-            .await
+            .expect("mutex poisoned")
             .take()
             // Turn None into an error
             .context(General {
@@ -397,12 +396,12 @@ impl Database for TestDatabase {
 
         let new_queries_groups_request = Some(QueryGroupsRequest { predicate, gby_agg });
 
-        *self.query_groups_request.clone().lock().await = new_queries_groups_request;
+        *self.query_groups_request.clone().lock().expect("mutex poisoned") = new_queries_groups_request;
 
         self.query_groups_values
             .clone()
             .lock()
-            .await
+            .expect("mutex poisoned")
             .take()
             // Turn None into an error
             .context(General {
@@ -412,13 +411,13 @@ impl Database for TestDatabase {
 
     /// Return the partition keys for data in this DB
     async fn partition_keys(&self) -> Result<Vec<String>, Self::Error> {
-        let partitions = self.partitions.lock().await;
+        let partitions = self.partitions.lock().expect("mutex poisoned");
         let keys = partitions.keys().cloned().collect();
         Ok(keys)
     }
 
     async fn chunks(&self, partition_key: &str) -> Vec<Arc<Self::Chunk>> {
-        let partitions = self.partitions.lock().await;
+        let partitions = self.partitions.lock().expect("mutex poisoned");
         if let Some(chunks) = partitions.get(partition_key) {
             chunks.values().cloned().collect()
         } else {
@@ -545,14 +544,14 @@ impl DatabaseStore for TestDatabaseStore {
 
     /// List the database names.
     async fn db_names_sorted(&self) -> Vec<String> {
-        let databases = self.databases.lock().await;
+        let databases = self.databases.lock().expect("mutex poisoned");
 
         databases.keys().cloned().collect()
     }
 
     /// Retrieve the database specified name
     async fn db(&self, name: &str) -> Option<Arc<Self::Database>> {
-        let databases = self.databases.lock().await;
+        let databases = self.databases.lock().expect("mutex poisoned");
 
         databases.get(name).cloned()
     }
@@ -560,7 +559,7 @@ impl DatabaseStore for TestDatabaseStore {
     /// Retrieve the database specified by name, creating it if it
     /// doesn't exist.
     async fn db_or_create(&self, name: &str) -> Result<Arc<Self::Database>, Self::Error> {
-        let mut databases = self.databases.lock().await;
+        let mut databases = self.databases.lock().expect("mutex poisoned");
 
         if let Some(db) = databases.get(name) {
             Ok(db.clone())

--- a/query/src/test.rs
+++ b/query/src/test.rs
@@ -143,7 +143,10 @@ impl TestDatabase {
 
     /// Get all replicated writs to this database
     pub fn get_writes(&self) -> Vec<ReplicatedWrite> {
-        self.replicated_writes.lock().expect("mutex poisoned").clone()
+        self.replicated_writes
+            .lock()
+            .expect("mutex poisoned")
+            .clone()
     }
 
     /// Parse line protocol and add it as new lines to this
@@ -192,7 +195,11 @@ impl TestDatabase {
 
     /// Get the parameters from the last column name request
     pub fn get_column_names_request(&self) -> Option<ColumnNamesRequest> {
-        self.column_names_request.clone().lock().expect("mutex poisoned").take()
+        self.column_names_request
+            .clone()
+            .lock()
+            .expect("mutex poisoned")
+            .take()
     }
 
     /// Set the list of column values that will be returned on a call to
@@ -206,37 +213,65 @@ impl TestDatabase {
 
     /// Get the parameters from the last column name request
     pub fn get_column_values_request(&self) -> Option<ColumnValuesRequest> {
-        self.column_values_request.clone().lock().expect("mutex poisoned").take()
+        self.column_values_request
+            .clone()
+            .lock()
+            .expect("mutex poisoned")
+            .take()
     }
 
     /// Set the series that will be returned on a call to query_series
     pub fn set_query_series_values(&self, plan: SeriesSetPlans) {
-        *(self.query_series_values.clone().lock().expect("mutex poisoned")) = Some(plan);
+        *(self
+            .query_series_values
+            .clone()
+            .lock()
+            .expect("mutex poisoned")) = Some(plan);
     }
 
     /// Get the parameters from the last column name request
     pub fn get_query_series_request(&self) -> Option<QuerySeriesRequest> {
-        self.query_series_request.clone().lock().expect("mutex poisoned").take()
+        self.query_series_request
+            .clone()
+            .lock()
+            .expect("mutex poisoned")
+            .take()
     }
 
     /// Set the series that will be returned on a call to query_groups
     pub fn set_query_groups_values(&self, plan: SeriesSetPlans) {
-        *(self.query_groups_values.clone().lock().expect("mutex poisoned")) = Some(plan);
+        *(self
+            .query_groups_values
+            .clone()
+            .lock()
+            .expect("mutex poisoned")) = Some(plan);
     }
 
     /// Get the parameters from the last column name request
     pub fn get_query_groups_request(&self) -> Option<QueryGroupsRequest> {
-        self.query_groups_request.clone().lock().expect("mutex poisoned").take()
+        self.query_groups_request
+            .clone()
+            .lock()
+            .expect("mutex poisoned")
+            .take()
     }
 
     /// Set the FieldSet plan that will be returned
     pub fn set_field_colum_names_values(&self, plan: FieldListPlan) {
-        *(self.field_columns_value.clone().lock().expect("mutex poisoned")) = Some(plan);
+        *(self
+            .field_columns_value
+            .clone()
+            .lock()
+            .expect("mutex poisoned")) = Some(plan);
     }
 
     /// Get the parameters from the last column name request
     pub fn get_field_columns_request(&self) -> Option<FieldColumnsRequest> {
-        self.field_columns_request.clone().lock().expect("mutex poisoned").take()
+        self.field_columns_request
+            .clone()
+            .lock()
+            .expect("mutex poisoned")
+            .take()
     }
 }
 
@@ -290,7 +325,10 @@ impl Database for TestDatabase {
 
     /// Adds the replicated write to this database
     async fn store_replicated_write(&self, write: &ReplicatedWrite) -> Result<(), Self::Error> {
-        self.replicated_writes.lock().expect("mutex poisoned").push(write.clone());
+        self.replicated_writes
+            .lock()
+            .expect("mutex poisoned")
+            .push(write.clone());
         Ok(())
     }
 
@@ -301,7 +339,11 @@ impl Database for TestDatabase {
 
         let new_column_names_request = Some(ColumnNamesRequest { predicate });
 
-        *self.column_names_request.clone().lock().expect("mutex poisoned") = new_column_names_request;
+        *self
+            .column_names_request
+            .clone()
+            .lock()
+            .expect("mutex poisoned") = new_column_names_request;
 
         // pull out the saved columns
         let column_names = self
@@ -324,7 +366,11 @@ impl Database for TestDatabase {
 
         let field_columns_request = Some(FieldColumnsRequest { predicate });
 
-        *self.field_columns_request.clone().lock().expect("mutex poisoned") = field_columns_request;
+        *self
+            .field_columns_request
+            .clone()
+            .lock()
+            .expect("mutex poisoned") = field_columns_request;
 
         // pull out the saved columns
         self.field_columns_value
@@ -352,7 +398,11 @@ impl Database for TestDatabase {
             predicate,
         });
 
-        *self.column_values_request.clone().lock().expect("mutex poisoned") = new_column_values_request;
+        *self
+            .column_values_request
+            .clone()
+            .lock()
+            .expect("mutex poisoned") = new_column_values_request;
 
         // pull out the saved columns
         let column_values = self
@@ -374,7 +424,11 @@ impl Database for TestDatabase {
 
         let new_queries_series_request = Some(QuerySeriesRequest { predicate });
 
-        *self.query_series_request.clone().lock().expect("mutex poisoned") = new_queries_series_request;
+        *self
+            .query_series_request
+            .clone()
+            .lock()
+            .expect("mutex poisoned") = new_queries_series_request;
 
         self.query_series_values
             .clone()
@@ -396,7 +450,11 @@ impl Database for TestDatabase {
 
         let new_queries_groups_request = Some(QueryGroupsRequest { predicate, gby_agg });
 
-        *self.query_groups_request.clone().lock().expect("mutex poisoned") = new_queries_groups_request;
+        *self
+            .query_groups_request
+            .clone()
+            .lock()
+            .expect("mutex poisoned") = new_queries_groups_request;
 
         self.query_groups_values
             .clone()

--- a/src/influxdb_ioxd/rpc/service.rs
+++ b/src/influxdb_ioxd/rpc/service.rs
@@ -1183,8 +1183,7 @@ mod tests {
             .db_or_create(&db_info.db_name)
             .await
             .unwrap()
-            .add_chunk("my_partition_key", Arc::new(chunk))
-            .await;
+            .add_chunk("my_partition_key", Arc::new(chunk));
 
         let source = Some(StorageClientWrapper::read_source(
             db_info.org_id,
@@ -1234,7 +1233,6 @@ mod tests {
             .await
             .expect("getting db")
             .get_chunk("my_partition_key", 0)
-            .await
             .and_then(|chunk| chunk.table_names_predicate());
 
         let expected_predicate = Some(
@@ -1284,7 +1282,7 @@ mod tests {
             predicate: "Predicate { exprs: [#state Eq Utf8(\"MA\")] range: TimestampRange { start: 150, end: 200 }}".into()
         };
 
-        test_db.set_column_names(to_string_vec(&tag_keys)).await;
+        test_db.set_column_names(to_string_vec(&tag_keys));
 
         let actual_tag_keys = fixture.storage_client.tag_keys(request).await?;
         let mut expected_tag_keys = vec!["_f(0xff)", "_m(0x00)"];
@@ -1295,7 +1293,7 @@ mod tests {
             "unexpected tag keys while getting column names"
         );
         assert_eq!(
-            test_db.get_column_names_request().await,
+            test_db.get_column_names_request(),
             Some(expected_request),
             "unexpected request while getting column names"
         );
@@ -1325,7 +1323,7 @@ mod tests {
         let expected_request = Some(ColumnNamesRequest {
             predicate: "Predicate {}".into(),
         });
-        assert_eq!(test_db.get_column_names_request().await, expected_request);
+        assert_eq!(test_db.get_column_names_request(), expected_request);
 
         Ok(())
     }
@@ -1376,7 +1374,7 @@ mod tests {
             predicate: "Predicate { table_names: m4 exprs: [#state Eq Utf8(\"MA\")] range: TimestampRange { start: 150, end: 200 }}".into()
         };
 
-        test_db.set_column_names(to_string_vec(&tag_keys)).await;
+        test_db.set_column_names(to_string_vec(&tag_keys));
 
         let actual_tag_keys = fixture.storage_client.measurement_tag_keys(request).await?;
 
@@ -1389,7 +1387,7 @@ mod tests {
         );
 
         assert_eq!(
-            test_db.get_column_names_request().await,
+            test_db.get_column_names_request(),
             Some(expected_request),
             "unexpected request while getting column names"
         );
@@ -1420,7 +1418,7 @@ mod tests {
         let expected_request = Some(ColumnNamesRequest {
             predicate: "Predicate { table_names: m5}".into(),
         });
-        assert_eq!(test_db.get_column_names_request().await, expected_request);
+        assert_eq!(test_db.get_column_names_request(), expected_request);
 
         Ok(())
     }
@@ -1461,7 +1459,7 @@ mod tests {
             column_name: "the_tag_key".into(),
         };
 
-        test_db.set_column_values(to_string_vec(&tag_values)).await;
+        test_db.set_column_values(to_string_vec(&tag_values));
 
         let actual_tag_values = fixture.storage_client.tag_values(request).await.unwrap();
         assert_eq!(
@@ -1469,7 +1467,7 @@ mod tests {
             "unexpected tag values while getting tag values"
         );
         assert_eq!(
-            test_db.get_column_values_request().await,
+            test_db.get_column_values_request(),
             Some(expected_request),
             "unexpected request while getting tag values"
         );
@@ -1491,8 +1489,7 @@ mod tests {
             .db_or_create(&db_info.db_name)
             .await
             .unwrap()
-            .add_chunk("my_partition_key", Arc::new(chunk))
-            .await;
+            .add_chunk("my_partition_key", Arc::new(chunk));
 
         let tag_values = vec!["h2o"];
         let actual_tag_values = fixture.storage_client.tag_values(request).await.unwrap();
@@ -1520,7 +1517,7 @@ mod tests {
             }],
         };
         let fieldlist_plan = FieldListPlan::Known(Ok(fieldlist));
-        test_db.set_field_colum_names_values(fieldlist_plan).await;
+        test_db.set_field_colum_names_values(fieldlist_plan);
 
         let expected_tag_values = vec!["Field1"];
         let actual_tag_values = fixture.storage_client.tag_values(request).await.unwrap();
@@ -1556,7 +1553,7 @@ mod tests {
             predicate: "Predicate {}".into(),
             column_name: "the_tag_key".into(),
         });
-        assert_eq!(test_db.get_column_values_request().await, expected_request);
+        assert_eq!(test_db.get_column_values_request(), expected_request);
 
         // ---
         // test error with non utf8 value
@@ -1617,7 +1614,7 @@ mod tests {
             column_name: "the_tag_key".into(),
         };
 
-        test_db.set_column_values(to_string_vec(&tag_values)).await;
+        test_db.set_column_values(to_string_vec(&tag_values));
 
         let actual_tag_values = fixture
             .storage_client
@@ -1631,7 +1628,7 @@ mod tests {
         );
 
         assert_eq!(
-            test_db.get_column_values_request().await,
+            test_db.get_column_values_request(),
             Some(expected_request),
             "unexpected request while getting tag values",
         );
@@ -1664,7 +1661,7 @@ mod tests {
             predicate: "Predicate { table_names: m5}".into(),
             column_name: "the_tag_key".into(),
         });
-        assert_eq!(test_db.get_column_values_request().await, expected_request);
+        assert_eq!(test_db.get_column_values_request(), expected_request);
     }
 
     #[tokio::test]
@@ -1763,7 +1760,7 @@ mod tests {
         };
 
         let dummy_series_set_plan = SeriesSetPlans::from(vec![]);
-        test_db.set_query_series_values(dummy_series_set_plan).await;
+        test_db.set_query_series_values(dummy_series_set_plan);
 
         let actual_frames = fixture.storage_client.read_filter(request).await?;
 
@@ -1775,7 +1772,7 @@ mod tests {
             "unexpected frames returned by query_series",
         );
         assert_eq!(
-            test_db.get_query_series_request().await,
+            test_db.get_query_series_request(),
             Some(expected_request),
             "unexpected request to query_series",
         );
@@ -1804,7 +1801,7 @@ mod tests {
         let expected_request = Some(QuerySeriesRequest {
             predicate: "Predicate {}".into(),
         });
-        assert_eq!(test_db.get_query_series_request().await, expected_request);
+        assert_eq!(test_db.get_query_series_request(), expected_request);
 
         Ok(())
     }
@@ -1853,7 +1850,7 @@ mod tests {
 
         // TODO setup any expected results
         let dummy_groups_set_plan = SeriesSetPlans::from(vec![]);
-        test_db.set_query_groups_values(dummy_groups_set_plan).await;
+        test_db.set_query_groups_values(dummy_groups_set_plan);
 
         let actual_frames = fixture.storage_client.read_group(request).await?;
         let expected_frames: Vec<String> = vec!["0 group frames".into()];
@@ -1863,7 +1860,7 @@ mod tests {
             "unexpected frames returned by query_groups"
         );
         assert_eq!(
-            test_db.get_query_groups_request().await,
+            test_db.get_query_groups_request(),
             Some(expected_request),
             "unexpected request to query_groups"
         );
@@ -1896,7 +1893,7 @@ mod tests {
 
         // Errored out in gRPC and never got to database layer
         let expected_request: Option<QueryGroupsRequest> = None;
-        assert_eq!(test_db.get_query_groups_request().await, expected_request);
+        assert_eq!(test_db.get_query_groups_request(), expected_request);
 
         // ---
         // test error returned in database processing
@@ -1932,7 +1929,7 @@ mod tests {
                 group_columns: vec!["tag1".into()],
             },
         });
-        assert_eq!(test_db.get_query_groups_request().await, expected_request);
+        assert_eq!(test_db.get_query_groups_request(), expected_request);
 
         Ok(())
     }
@@ -1989,7 +1986,7 @@ mod tests {
 
         // setup expected results
         let dummy_groups_set_plan = SeriesSetPlans::from(vec![]);
-        test_db.set_query_groups_values(dummy_groups_set_plan).await;
+        test_db.set_query_groups_values(dummy_groups_set_plan);
 
         let actual_frames = fixture
             .storage_client
@@ -2002,7 +1999,7 @@ mod tests {
             "unexpected frames returned by query_groups"
         );
         assert_eq!(
-            test_db.get_query_groups_request().await,
+            test_db.get_query_groups_request(),
             Some(expected_request_window_every),
             "unexpected request to query_groups"
         );
@@ -2051,7 +2048,7 @@ mod tests {
 
         // setup expected results
         let dummy_groups_set_plan = SeriesSetPlans::from(vec![]);
-        test_db.set_query_groups_values(dummy_groups_set_plan).await;
+        test_db.set_query_groups_values(dummy_groups_set_plan);
 
         let actual_frames = fixture
             .storage_client
@@ -2064,7 +2061,7 @@ mod tests {
             "unexpected frames returned by query_groups"
         );
         assert_eq!(
-            test_db.get_query_groups_request().await,
+            test_db.get_query_groups_request(),
             Some(expected_request_window.clone()),
             "unexpected request to query_groups"
         );
@@ -2089,7 +2086,7 @@ mod tests {
         );
 
         assert_eq!(
-            test_db.get_query_groups_request().await,
+            test_db.get_query_groups_request(),
             Some(expected_request_window)
         );
 
@@ -2136,7 +2133,7 @@ mod tests {
         };
 
         let fieldlist_plan = FieldListPlan::Known(Ok(fieldlist));
-        test_db.set_field_colum_names_values(fieldlist_plan).await;
+        test_db.set_field_colum_names_values(fieldlist_plan);
 
         let actual_fields = fixture.storage_client.measurement_fields(request).await?;
         let expected_fields: Vec<String> = vec!["key: Field1, type: 3, timestamp: 1000".into()];
@@ -2146,7 +2143,7 @@ mod tests {
             "unexpected frames returned by measuremnt_fields"
         );
         assert_eq!(
-            test_db.get_field_columns_request().await,
+            test_db.get_field_columns_request(),
             Some(expected_request),
             "unexpected request to measurement-fields"
         );
@@ -2176,7 +2173,7 @@ mod tests {
         let expected_request = Some(FieldColumnsRequest {
             predicate: "Predicate { table_names: TheMeasurement}".into(),
         });
-        assert_eq!(test_db.get_field_columns_request().await, expected_request);
+        assert_eq!(test_db.get_field_columns_request(), expected_request);
 
         Ok(())
     }


### PR DESCRIPTION
# Rationale:

Per @carols10cents  suggestion in https://github.com/influxdata/influxdb_iox/pull/749#pullrequestreview-583690120

Same as in #749: Follow best practice and reduce the amount of async in the code

# Changes
Switch to `std::sync::Mutex` instead of `tokio::sync::Mutex` and reduce async functions

- [x] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb_iox/blob/main/README.md).
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
