### PR TITLE
feat: add WAL metadata endpoint (#724)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1503,6 +1503,7 @@ dependencies = [
  "assert_cmd",
  "byteorder",
  "bytes",
+ "chrono",
  "clap",
  "criterion",
  "csv",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,7 @@ wal = { path = "wal" }
 # Crates.io dependencies, in alphabetical order
 byteorder = "1.3.4"
 bytes = "1.0"
+chrono = "0.4"
 clap = "2.33.1"
 csv = "1.1"
 dirs = "3.0.1"

--- a/data_types/Cargo.toml
+++ b/data_types/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 [dependencies] # In alphabetical order
 arrow_deps = { path = "../arrow_deps" }
-chrono = "0.4"
+chrono = { version = "0.4", features = ["serde"] }
 crc32fast = "1.2.0"
 flatbuffers = "0.6"
 generated_types = { path = "../generated_types" }

--- a/data_types/src/http.rs
+++ b/data_types/src/http.rs
@@ -1,0 +1,20 @@
+//! This module contains structs for the HTTP API
+use crate::wal::SegmentSummary;
+use serde::{Deserialize, Serialize};
+
+/// Query string for WAL metadata endpoint
+#[derive(Debug, Clone, Serialize, Deserialize, Default, Eq, PartialEq)]
+pub struct WalMetadataQuery {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub limit: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub offset: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub newer_than: Option<chrono::DateTime<chrono::Utc>>,
+}
+
+/// Response for WAL metadata endpoint
+#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
+pub struct WalMetadataResponse {
+    pub segments: Vec<SegmentSummary>,
+}

--- a/data_types/src/lib.rs
+++ b/data_types/src/lib.rs
@@ -14,10 +14,12 @@ pub use schema::TIME_COLUMN_NAME;
 pub mod data;
 pub mod database_rules;
 pub mod error;
+pub mod http;
 pub mod names;
 pub mod partition_metadata;
 pub mod schema;
 pub mod selection;
+pub mod wal;
 
 mod database_name;
 pub use database_name::*;

--- a/data_types/src/wal.rs
+++ b/data_types/src/wal.rs
@@ -1,0 +1,28 @@
+use crate::database_rules::WriterId;
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+
+/// The summary information for a writer that has data in a segment
+#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
+pub struct WriterSummary {
+    pub start_sequence: u64,
+    pub end_sequence: u64,
+    pub missing_sequence: bool,
+}
+
+/// The persistence metadata associated with a given segment
+#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
+pub struct SegmentPersistence {
+    pub location: String,
+    pub time: DateTime<Utc>,
+}
+
+/// The summary information for a segment
+#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
+pub struct SegmentSummary {
+    pub size: u64,
+    pub created_at: DateTime<Utc>,
+    pub persisted: Option<SegmentPersistence>,
+    pub writers: BTreeMap<WriterId, WriterSummary>,
+}


### PR DESCRIPTION
Partially closes #724

Will update `influxdb_iox_client` as separate PR as this one was getting fairly large. I've moved a couple of data structures from within the WAL module to data_types in order to facilitate this.