### PR TITLE
feat: Change table_names to return either Some(set) or None, rather than a plan

### DIFF
--- a/data_types/src/lib.rs
+++ b/data_types/src/lib.rs
@@ -11,6 +11,14 @@
 
 pub use schema::TIME_COLUMN_NAME;
 
+/// The name of the column containing table names returned by a call to
+/// `table_names`.
+pub const TABLE_NAMES_COLUMN_NAME: &str = "table";
+
+/// The name of the column containing column names returned by a call to
+/// `column_names`.
+pub const COLUMN_NAMES_COLUMN_NAME: &str = "column";
+
 pub mod data;
 pub mod database_rules;
 pub mod error;

--- a/data_types/src/schema.rs
+++ b/data_types/src/schema.rs
@@ -12,6 +12,7 @@ use arrow_deps::arrow::datatypes::{
     SchemaRef as ArrowSchemaRef,
 };
 
+/// The name of the timestamp column in the InfluxDB datamodel
 pub const TIME_COLUMN_NAME: &str = "time";
 
 pub mod builder;

--- a/mutable_buffer/src/chunk.rs
+++ b/mutable_buffer/src/chunk.rs
@@ -4,7 +4,7 @@ use arrow_deps::{
     arrow::record_batch::RecordBatch,
     datafusion::{
         error::{DataFusionError, Result as DatafusionResult},
-        logical_plan::{Expr, ExpressionVisitor, LogicalPlan, Operator, Recursion},
+        logical_plan::{Expr, ExpressionVisitor, Operator, Recursion},
         optimizer::utils::expr_to_column_names,
         physical_plan::SendableRecordBatchStream,
         prelude::*,
@@ -20,6 +20,7 @@ use data_types::{
 };
 
 use query::{
+    exec::stringset::StringSet,
     predicate::{Predicate, TimestampRange},
     util::AndExprBuilder,
 };
@@ -510,7 +511,11 @@ impl query::PartitionChunk for Chunk {
         self.table_stats()
     }
 
-    async fn table_names(&self, _predicate: &Predicate) -> Result<LogicalPlan, Self::Error> {
+    async fn table_names(
+        &self,
+        _predicate: &Predicate,
+        _known_tables: &StringSet,
+    ) -> Result<Option<StringSet>, Self::Error> {
         unimplemented!("This function is slated for removal")
     }
 

--- a/mutable_buffer/src/database.rs
+++ b/mutable_buffer/src/database.rs
@@ -1,12 +1,12 @@
 use generated_types::wal;
-use query::group_by::Aggregate;
 use query::group_by::GroupByAndAggregate;
 use query::group_by::WindowDuration;
 use query::{
-    exec::{stringset::StringSet, FieldListPlan, SeriesSetPlan, SeriesSetPlans, StringSetPlan},
+    exec::{stringset::StringSet, FieldListPlan, SeriesSetPlan, SeriesSetPlans},
     predicate::Predicate,
     Database,
 };
+use query::{group_by::Aggregate, plan::stringset::StringSetPlan};
 
 use crate::column::Column;
 use crate::table::Table;

--- a/query/src/frontend/influxrpc.rs
+++ b/query/src/frontend/influxrpc.rs
@@ -48,7 +48,7 @@ pub type Result<T, E = Error> = std::result::Result<T, E>;
 /// specific queries, but also provides more generic access to the
 /// same underlying data via other frontends (e.g. SQL).
 ///
-/// The InfluxDB data model can can be thought of as a relational
+/// The InfluxDB data model can be thought of as a relational
 /// database table where each column has both a type as well as one of
 /// the following categories:
 ///

--- a/query/src/frontend/influxrpc.rs
+++ b/query/src/frontend/influxrpc.rs
@@ -1,3 +1,44 @@
+use std::sync::Arc;
+
+use snafu::{ResultExt, Snafu};
+
+use crate::{
+    plan::stringset::{Error as StringSetError, StringSetPlan, StringSetPlanBuilder},
+    predicate::Predicate,
+    Database, PartitionChunk,
+};
+
+#[derive(Debug, Snafu)]
+pub enum Error {
+    #[snafu(display("gRPC planner got error making table_name plan for chunk: {}", source))]
+    TableNamePlan {
+        source: Box<dyn std::error::Error + Send + Sync>,
+    },
+
+    #[snafu(display("gRPC planner got error listing partition keys: {}", source))]
+    ListingPartitions {
+        source: Box<dyn std::error::Error + Send + Sync>,
+    },
+
+    #[snafu(display("Unsupported predicate in gRPC table_names: {:?}", predicate))]
+    UnsupportedPredicate { predicate: Predicate },
+
+    #[snafu(display(
+        "gRPC planner got error checking if chunk {} could pass predicate: {}",
+        chunk_id,
+        source
+    ))]
+    CheckingChunkPredicate {
+        chunk_id: u32,
+        source: Box<dyn std::error::Error + Send + Sync>,
+    },
+
+    #[snafu(display("gRPC planner got error creating string set: {}", source))]
+    CreatingStringSet { source: StringSetError },
+}
+
+pub type Result<T, E = Error> = std::result::Result<T, E>;
+
 /// Plans queries that originate from the InfluxDB Storage gRPC
 /// interface, which are in terms of the InfluxDB Data model (e.g.
 /// `ParsedLine`). The query methods on this trait such as
@@ -18,35 +59,6 @@
 /// While the underlying storage is the same for columns in different
 /// categories with the same data type, columns of different
 /// categories are treated differently in the different query types.
-use snafu::{ResultExt, Snafu};
-
-use crate::{exec::StringSetPlan, predicate::Predicate, Database, PartitionChunk};
-
-#[derive(Debug, Snafu)]
-pub enum Error {
-    #[snafu(display("gRPC planner got error making table_name plan for chunk: {}", source))]
-    TableNamePlan {
-        source: Box<dyn std::error::Error + Send + Sync>,
-    },
-
-    #[snafu(display("gRPC planner got error listing partition keys: {}", source))]
-    ListingPartitions {
-        source: Box<dyn std::error::Error + Send + Sync>,
-    },
-
-    #[snafu(display(
-        "gRPC planner got error checking if chunk {} could pass predicate: {}",
-        chunk_id,
-        source
-    ))]
-    CheckingChunkPredicate {
-        chunk_id: u32,
-        source: Box<dyn std::error::Error + Send + Sync>,
-    },
-}
-
-pub type Result<T, E = Error> = std::result::Result<T, E>;
-
 #[derive(Default, Debug)]
 pub struct InfluxRPCPlanner {}
 
@@ -64,7 +76,46 @@ impl InfluxRPCPlanner {
         database: &D,
         predicate: Predicate,
     ) -> Result<StringSetPlan> {
-        let mut plans = Vec::new();
+        let mut builder = StringSetPlanBuilder::new();
+
+        for chunk in self.filtered_chunks(database, &predicate).await? {
+            let new_table_names = chunk
+                .table_names(&predicate, builder.known_strings())
+                .await
+                .map_err(|e| Box::new(e) as _)
+                .context(TableNamePlan)?;
+
+            builder = match new_table_names {
+                Some(new_table_names) => builder.append(new_table_names.into()),
+                None => {
+                    // TODO: General purpose plans for
+                    // table_names. For now, if we couldn't figure out
+                    // the table names from only metadata, generate an
+                    // error
+                    return UnsupportedPredicate { predicate }.fail();
+                }
+            }
+        }
+
+        let plan = builder.build().context(CreatingStringSet)?;
+
+        Ok(plan)
+    }
+
+    /// Returns a list of chunks across all partitions which may
+    /// contain data that pass the predicate
+    async fn filtered_chunks<D>(
+        &self,
+        database: &D,
+        predicate: &Predicate,
+    ) -> Result<Vec<Arc<<D as Database>::Chunk>>>
+    where
+        D: Database,
+    {
+        let mut db_chunks = Vec::new();
+
+        // TODO write the following in a functional style (need to get
+        // rid of `await` on `Database::chunks`)
 
         let partition_keys = database
             .partition_keys()
@@ -74,27 +125,20 @@ impl InfluxRPCPlanner {
 
         for key in partition_keys {
             // TODO prune partitions somehow
-            let chunks = database.chunks(&key).await;
-            for chunk in chunks {
+            let partition_chunks = database.chunks(&key).await;
+            for chunk in partition_chunks {
                 let could_pass_predicate = chunk
-                    .could_pass_predicate(&predicate)
+                    .could_pass_predicate(predicate)
                     .map_err(|e| Box::new(e) as _)
                     .context(CheckingChunkPredicate {
                         chunk_id: chunk.id(),
                     })?;
 
                 if could_pass_predicate {
-                    let plan = chunk
-                        .table_names(&predicate)
-                        .await
-                        .map_err(|e| Box::new(e) as _)
-                        .context(TableNamePlan)?;
-
-                    plans.push(plan);
+                    db_chunks.push(chunk)
                 }
             }
         }
-
-        Ok(plans.into())
+        Ok(db_chunks)
     }
 }

--- a/query/src/lib.rs
+++ b/query/src/lib.rs
@@ -127,13 +127,13 @@ pub trait PartitionChunk: Debug + Send + Sync {
     /// Returns all table names from this chunk that have at least one
     /// row that matches the `predicate` and are not already in `known_tables`.
     ///
-    /// If the predicate can not be evaluated (e.g it has predicates
-    /// that can not be directly evaluated in the chunk), Noneis
+    /// If the predicate cannot be evaluated (e.g it has predicates
+    /// that cannot be directly evaluated in the chunk), `None` is
     /// returned.
     ///
-    /// known_tables is a list of table names already known to be in
+    /// `known_tables` is a list of table names already known to be in
     /// other chunks from the same partition. It may be empty or
-    /// contain table_names not in this chunk.
+    /// contain `table_names` not in this chunk.
     async fn table_names(
         &self,
         predicate: &Predicate,

--- a/query/src/lib.rs
+++ b/query/src/lib.rs
@@ -5,12 +5,13 @@
     clippy::use_self
 )]
 
-use arrow_deps::datafusion::{logical_plan::LogicalPlan, physical_plan::SendableRecordBatchStream};
+use arrow_deps::datafusion::physical_plan::SendableRecordBatchStream;
 use async_trait::async_trait;
 use data_types::{
     data::ReplicatedWrite, partition_metadata::TableSummary, schema::Schema, selection::Selection,
 };
-use exec::{Executor, FieldListPlan, SeriesSetPlans, StringSetPlan};
+use exec::{stringset::StringSet, Executor, FieldListPlan, SeriesSetPlans};
+use plan::stringset::StringSetPlan;
 
 use std::{fmt::Debug, sync::Arc};
 
@@ -18,6 +19,7 @@ pub mod exec;
 pub mod frontend;
 pub mod func;
 pub mod group_by;
+pub mod plan;
 pub mod predicate;
 pub mod provider;
 pub mod util;
@@ -122,16 +124,21 @@ pub trait PartitionChunk: Debug + Send + Sync {
     /// Returns true if this chunk contains data for the specified table
     async fn has_table(&self, table_name: &str) -> bool;
 
-    /// Returns a datafusion plan that produces
-    /// a single string column representing the names
-    /// of the tables that have at least one row that matches the
-    /// `predicate`
+    /// Returns all table names from this chunk that have at least one
+    /// row that matches the `predicate` and are not already in `known_tables`.
     ///
-    /// Note that the table names produced may be duplicated (e.g. if
-    /// the same table exists in multiple distinct chunks) and it is
-    /// the responsibility of the caller to deduplicate them if
-    /// desired.
-    async fn table_names(&self, predicate: &Predicate) -> Result<LogicalPlan, Self::Error>;
+    /// If the predicate can not be evaluated (e.g it has predicates
+    /// that can not be directly evaluated in the chunk), Noneis
+    /// returned.
+    ///
+    /// known_tables is a list of table names already known to be in
+    /// other chunks from the same partition. It may be empty or
+    /// contain table_names not in this chunk.
+    async fn table_names(
+        &self,
+        predicate: &Predicate,
+        known_tables: &StringSet,
+    ) -> Result<Option<StringSet>, Self::Error>;
 
     /// Returns the Schema for a table in this chunk, with the
     /// specified column selection

--- a/query/src/plan.rs
+++ b/query/src/plan.rs
@@ -1,0 +1,1 @@
+pub mod stringset;

--- a/query/src/plan/stringset.rs
+++ b/query/src/plan/stringset.rs
@@ -1,0 +1,257 @@
+use std::sync::Arc;
+
+use arrow_deps::{datafusion::logical_plan::LogicalPlan, util::str_iter_to_batch};
+use data_types::TABLE_NAMES_COLUMN_NAME;
+
+use crate::{
+    exec::stringset::{StringSet, StringSetRef},
+    util::make_scan_plan,
+};
+
+use snafu::{ResultExt, Snafu};
+
+#[derive(Debug, Snafu)]
+pub enum Error {
+    #[snafu(display("Internal error converting to arrow: {}", source))]
+    InternalConvertingToArrow {
+        source: arrow_deps::arrow::error::ArrowError,
+    },
+
+    #[snafu(display("Internal creating a plan for stringset: {}", source))]
+    InternalPlanningStringSet {
+        source: arrow_deps::datafusion::error::DataFusionError,
+    },
+}
+
+pub type Result<T, E = Error> = std::result::Result<T, E>;
+
+/// A plan which produces a logical set of Strings (e.g. tag
+/// values). This includes variants with pre-calculated results as
+/// well a variant that runs a full on DataFusion plan.
+#[derive(Debug)]
+pub enum StringSetPlan {
+    /// The plan errored and we are delaying reporting the results
+    KnownError(Box<dyn std::error::Error + Send + Sync + 'static>),
+
+    /// The results are known from metadta only without having to run
+    /// an actual datafusion plan
+    KnownOk(StringSetRef),
+
+    /// A DataFusion plan(s) to execute. Each plan must produce
+    /// RecordBatches with exactly one String column, though the
+    /// the values produced by the plan may be repeated
+    ///
+    /// TODO: it would be cool to have a single datafusion LogicalPlan
+    /// that merged all the results together. However, no such Union
+    /// node exists at the time of writing, so we do the unioning in IOx
+    Plan(Vec<LogicalPlan>),
+}
+
+impl From<StringSetRef> for StringSetPlan {
+    /// Create a StringSetPlan from a StringSetRef
+    fn from(set: StringSetRef) -> Self {
+        Self::KnownOk(set)
+    }
+}
+
+impl From<StringSet> for StringSetPlan {
+    /// Create a StringSetPlan from a StringSet result, wrapping the error type
+    /// appropriately
+    fn from(set: StringSet) -> Self {
+        Self::KnownOk(StringSetRef::new(set))
+    }
+}
+
+impl<E> From<Result<StringSetRef, E>> for StringSetPlan
+where
+    E: std::error::Error + Send + Sync + 'static,
+{
+    /// Create a StringSetPlan from a Result<StringSetRef> result, wrapping the
+    /// error type appropriately
+    fn from(result: Result<StringSetRef, E>) -> Self {
+        match result {
+            Ok(set) => Self::KnownOk(set),
+            Err(e) => Self::KnownError(Box::new(e)),
+        }
+    }
+}
+
+impl From<Vec<LogicalPlan>> for StringSetPlan {
+    /// Create a DataFusion LogicalPlan node, each if which must
+    /// produce a single output Utf8 column. The output of each plan
+    /// will be included into the final set.
+    fn from(plans: Vec<LogicalPlan>) -> Self {
+        Self::Plan(plans)
+    }
+}
+
+/// Builder for StringSet plans for appending multiple plans together
+///
+/// If the values are known beforehand, the builder merges the
+/// strings, otherwise it falls back to generic plans
+#[derive(Debug, Default)]
+pub struct StringSetPlanBuilder {
+    /// If there was any error
+    error: Option<Box<dyn std::error::Error + Send + Sync + 'static>>,
+
+    /// Known strings
+    strings: StringSet,
+    /// General plans
+    plans: Vec<LogicalPlan>,
+}
+
+impl StringSetPlanBuilder {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Returns a reference to any strings alreay known to be in this
+    /// set
+    pub fn known_strings(&self) -> &StringSet {
+        &self.strings
+    }
+
+    /// Append the strings from the passed plan into ourselves if possible, or
+    /// passes on the plan
+    pub fn append(mut self, other: StringSetPlan) -> Self {
+        match other {
+            StringSetPlan::KnownError(err) => self.error = Some(err),
+            StringSetPlan::KnownOk(ssref) => match Arc::try_unwrap(ssref) {
+                Ok(mut ss) => {
+                    self.strings.append(&mut ss);
+                }
+                Err(ssref) => {
+                    for s in ssref.iter() {
+                        self.strings.insert(s.clone());
+                    }
+                }
+            },
+            StringSetPlan::Plan(mut other_plans) => self.plans.append(&mut other_plans),
+        }
+
+        self
+    }
+
+    /// Create a StringSetPlan that produces the deduplicated (union)
+    /// of all plans `append`ed to this builder.
+    pub fn build(self) -> Result<StringSetPlan> {
+        let Self {
+            error,
+            strings,
+            mut plans,
+        } = self;
+
+        if let Some(err) = error {
+            // is an error, so nothing else matters
+            Ok(StringSetPlan::KnownError(err))
+        } else if plans.is_empty() {
+            // only a known set of strings
+            Ok(StringSetPlan::KnownOk(Arc::new(strings)))
+        } else {
+            // Had at least one general plan, so need to use general purpose plan for
+
+            if !strings.is_empty() {
+                let batch =
+                    str_iter_to_batch(TABLE_NAMES_COLUMN_NAME, strings.into_iter().map(Some))
+                        .context(InternalConvertingToArrow)?;
+
+                let plan = make_scan_plan(batch).context(InternalPlanningStringSet)?;
+
+                plans.push(plan)
+            }
+
+            Ok(StringSetPlan::Plan(plans))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::exec::Executor;
+
+    use super::*;
+
+    #[test]
+    fn test_builder_empty() {
+        let plan = StringSetPlanBuilder::new().build().unwrap();
+        let empty_ss = StringSet::new().into();
+        if let StringSetPlan::KnownOk(ss) = plan {
+            assert_eq!(ss, empty_ss)
+        } else {
+            panic!("unexpected type: {:?}", plan)
+        }
+    }
+
+    #[test]
+    fn test_builder_strings_only() {
+        let plan = StringSetPlanBuilder::new()
+            .append(to_string_set(&["foo", "bar"]).into())
+            .append(to_string_set(&["bar", "baz"]).into())
+            .build()
+            .unwrap();
+
+        let expected_ss = to_string_set(&["foo", "bar", "baz"]).into();
+
+        if let StringSetPlan::KnownOk(ss) = plan {
+            assert_eq!(ss, expected_ss)
+        } else {
+            panic!("unexpected type: {:?}", plan)
+        }
+    }
+
+    #[derive(Debug)]
+    struct TestError {}
+
+    impl std::fmt::Display for TestError {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "this is an error")
+        }
+    }
+
+    impl std::error::Error for TestError {}
+
+    #[test]
+    fn test_builder_error() {
+        let err = Box::new(TestError {});
+        let error = StringSetPlan::KnownError(err);
+
+        // when an error is generated, ensure it gets returned
+        let plan = StringSetPlanBuilder::new()
+            .append(to_string_set(&["foo", "bar"]).into())
+            .append(error)
+            .append(to_string_set(&["bar", "baz"]).into())
+            .build()
+            .unwrap();
+
+        if let StringSetPlan::KnownError(err) = plan {
+            assert_eq!(err.to_string(), "this is an error")
+        } else {
+            panic!("unexpected type: {:?}", plan)
+        }
+    }
+
+    #[tokio::test]
+    async fn test_builder_plan() {
+        let batch = str_iter_to_batch("column_name", vec![Some("from_a_plan")]).unwrap();
+        let df_plan = make_scan_plan(batch).unwrap();
+
+        // when a df plan is appended the whole plan should be different
+        let plan = StringSetPlanBuilder::new()
+            .append(to_string_set(&["foo", "bar"]).into())
+            .append(vec![df_plan].into())
+            .append(to_string_set(&["baz"]).into())
+            .build()
+            .unwrap();
+
+        let expected_ss = to_string_set(&["foo", "bar", "baz", "from_a_plan"]).into();
+
+        assert!(matches!(plan, StringSetPlan::Plan(_)));
+        let executor = Executor::new();
+        let ss = executor.to_string_set(plan).await.unwrap();
+        assert_eq!(ss, expected_ss);
+    }
+
+    fn to_string_set(v: &[&str]) -> StringSet {
+        v.iter().map(|s| s.to_string()).collect::<StringSet>()
+    }
+}

--- a/query/src/plan/stringset.rs
+++ b/query/src/plan/stringset.rs
@@ -17,7 +17,7 @@ pub enum Error {
         source: arrow_deps::arrow::error::ArrowError,
     },
 
-    #[snafu(display("Internal creating a plan for stringset: {}", source))]
+    #[snafu(display("Internal error creating a plan for stringset: {}", source))]
     InternalPlanningStringSet {
         source: arrow_deps::datafusion::error::DataFusionError,
     },
@@ -33,13 +33,13 @@ pub enum StringSetPlan {
     /// The plan errored and we are delaying reporting the results
     KnownError(Box<dyn std::error::Error + Send + Sync + 'static>),
 
-    /// The results are known from metadta only without having to run
+    /// The results are known from metadata only without having to run
     /// an actual datafusion plan
     KnownOk(StringSetRef),
 
     /// A DataFusion plan(s) to execute. Each plan must produce
     /// RecordBatches with exactly one String column, though the
-    /// the values produced by the plan may be repeated
+    /// values produced by the plan may be repeated
     ///
     /// TODO: it would be cool to have a single datafusion LogicalPlan
     /// that merged all the results together. However, no such Union
@@ -66,7 +66,7 @@ impl<E> From<Result<StringSetRef, E>> for StringSetPlan
 where
     E: std::error::Error + Send + Sync + 'static,
 {
-    /// Create a StringSetPlan from a Result<StringSetRef> result, wrapping the
+    /// Create a `StringSetPlan` from a `Result<StringSetRef>`, wrapping the
     /// error type appropriately
     fn from(result: Result<StringSetRef, E>) -> Self {
         match result {
@@ -77,7 +77,7 @@ where
 }
 
 impl From<Vec<LogicalPlan>> for StringSetPlan {
-    /// Create a DataFusion LogicalPlan node, each if which must
+    /// Create a DataFusion LogicalPlan node, each of which must
     /// produce a single output Utf8 column. The output of each plan
     /// will be included into the final set.
     fn from(plans: Vec<LogicalPlan>) -> Self {
@@ -105,7 +105,7 @@ impl StringSetPlanBuilder {
         Self::default()
     }
 
-    /// Returns a reference to any strings alreay known to be in this
+    /// Returns a reference to any strings already known to be in this
     /// set
     pub fn known_strings(&self) -> &StringSet {
         &self.strings

--- a/query/src/plan/stringset.rs
+++ b/query/src/plan/stringset.rs
@@ -148,8 +148,8 @@ impl StringSetPlanBuilder {
             // only a known set of strings
             Ok(StringSetPlan::KnownOk(Arc::new(strings)))
         } else {
-            // Had at least one general plan, so need to use general purpose plan for
-
+            // Had at least one general plan, so need to use general
+            // purpose plan for the known strings
             if !strings.is_empty() {
                 let batch =
                     str_iter_to_batch(TABLE_NAMES_COLUMN_NAME, strings.into_iter().map(Some))

--- a/query/src/test.rs
+++ b/query/src/test.rs
@@ -7,7 +7,7 @@ use crate::{exec::Executor, group_by::GroupByAndAggregate, plan::stringset::Stri
 use crate::{
     exec::{
         stringset::{StringSet, StringSetRef},
-        FieldListPlan, SeriesSetPlans, StringSetPlan,
+        FieldListPlan, SeriesSetPlans,
     },
     Database, DatabaseStore, PartitionChunk, Predicate,
 };

--- a/query/src/test.rs
+++ b/query/src/test.rs
@@ -1,12 +1,9 @@
 //! This module provides a reference implementaton of `query::DatabaseSource`
 //! and `query::Database` for use in testing.
 
-use arrow_deps::{
-    datafusion::{logical_plan::LogicalPlan, physical_plan::SendableRecordBatchStream},
-    util::str_iter_to_batch,
-};
+use arrow_deps::datafusion::physical_plan::SendableRecordBatchStream;
 
-use crate::{exec::Executor, group_by::GroupByAndAggregate, util::make_scan_plan};
+use crate::{exec::Executor, group_by::GroupByAndAggregate, plan::stringset::StringSetPlan};
 use crate::{
     exec::{
         stringset::{StringSet, StringSetRef},
@@ -542,16 +539,19 @@ impl PartitionChunk for TestChunk {
         unimplemented!()
     }
 
-    async fn table_names(&self, predicate: &Predicate) -> Result<LogicalPlan, Self::Error> {
+    async fn table_names(
+        &self,
+        predicate: &Predicate,
+        _known_tables: &StringSet,
+    ) -> Result<Option<StringSet>, Self::Error> {
         // save the predicate
         self.table_names_predicate
             .lock()
             .expect("mutex poisoned")
             .replace(predicate.clone());
 
-        let names = self.table_names.iter().map(Some);
-        let batch = str_iter_to_batch("tables", names).unwrap();
-        Ok(make_scan_plan(batch).unwrap())
+        let names = self.table_names.iter().cloned().collect::<BTreeSet<_>>();
+        Ok(Some(names))
     }
 
     async fn table_schema(

--- a/read_buffer/benches/database.rs
+++ b/read_buffer/benches/database.rs
@@ -96,7 +96,7 @@ fn benchmark_table_names(
                 let tables = database
                     .table_names("hour_1", chunk_ids, predicate)
                     .unwrap();
-                assert_eq!(tables.num_rows(), expected_rows);
+                assert_eq!(tables.len(), expected_rows);
             },
             BatchSize::SmallInput,
         );

--- a/server/src/db.rs
+++ b/server/src/db.rs
@@ -12,7 +12,7 @@ use std::{
 use async_trait::async_trait;
 use data_types::{data::ReplicatedWrite, database_rules::DatabaseRules, selection::Selection};
 use mutable_buffer::MutableBufferDb;
-use query::{Database, PartitionChunk};
+use query::{plan::stringset::StringSetPlan, Database, PartitionChunk};
 use read_buffer::Database as ReadBufferDb;
 use serde::{Deserialize, Serialize};
 use snafu::{OptionExt, ResultExt, Snafu};
@@ -280,7 +280,7 @@ impl Database for Db {
     async fn tag_column_names(
         &self,
         predicate: query::predicate::Predicate,
-    ) -> Result<query::exec::StringSetPlan, Self::Error> {
+    ) -> Result<query::plan::stringset::StringSetPlan, Self::Error> {
         self.mutable_buffer
             .as_ref()
             .context(DatabaseNotReadable)?
@@ -305,7 +305,7 @@ impl Database for Db {
         &self,
         column_name: &str,
         predicate: query::predicate::Predicate,
-    ) -> Result<query::exec::StringSetPlan, Self::Error> {
+    ) -> Result<StringSetPlan, Self::Error> {
         self.mutable_buffer
             .as_ref()
             .context(DatabaseNotReadable)?


### PR DESCRIPTION
# Rationale:
This is part of the implementation for making the `tag_names` gRPC call work across data in the mutable buffer and the read buffer

As background, all the metadata-ish queries have two modes:
1. The result can be found entirely from metadata (e.g. has only a time predicate)
2. The result requires running an actual DataFusion plan (because it has predicates -- think `A OR B` -- that can't be evaluated from metadata only)

To implement the second mode, I need to hoist the "can this be answered using only metadata/not" one level higher so I actually have access to the set of table names during plan time (not just a RecordBatch)

# Changes:
1. Change the Mutable Buffer and Read Buffer's interface so that they produce `Option<StringSet>` if they can't figure out the `table_names` solely based on metadata and move the "create a plan" logic into the query planner.
2. Extract StringSet into its own module


- [x] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb_iox/blob/main/README.md).
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
