### PR TITLE
fix: Fix influxdb_iox_client integration tests

### DIFF
--- a/influxdb_iox_client/src/errors/client_error.rs
+++ b/influxdb_iox_client/src/errors/client_error.rs
@@ -1,0 +1,9 @@
+use thiserror::Error;
+
+/// Error responses when creating a new IOx database.
+#[derive(Debug, Error)]
+pub enum ClientError {
+    /// The database name contains an invalid character.
+    #[error("the database name contains an invalid character")]
+    InvalidDatabaseName,
+}

--- a/influxdb_iox_client/src/errors/create_database.rs
+++ b/influxdb_iox_client/src/errors/create_database.rs
@@ -1,6 +1,6 @@
 use thiserror::Error;
 
-use super::{ApiErrorCode, HttpError, ServerErrorResponse};
+use super::{ApiErrorCode, ClientError, HttpError, ServerErrorResponse};
 
 /// Error responses when creating a new IOx database.
 #[derive(Debug, Error)]
@@ -13,7 +13,7 @@ pub enum CreateDatabaseError {
     #[error("a database with the requested name already exists")]
     AlreadyExists,
 
-    /// An unknown server error occured.
+    /// An unknown server error occurred.
     ///
     /// The error string contains the error string returned by the server.
     #[error(transparent)]
@@ -22,6 +22,10 @@ pub enum CreateDatabaseError {
     /// A non-application HTTP request/response error occurred.
     #[error(transparent)]
     HttpError(#[from] HttpError),
+
+    /// An error occurred in the client.
+    #[error(transparent)]
+    ClientError(#[from] ClientError),
 }
 
 /// Convert a [`ServerErrorResponse`] into a [`CreateDatabaseError`].

--- a/influxdb_iox_client/src/errors/mod.rs
+++ b/influxdb_iox_client/src/errors/mod.rs
@@ -23,6 +23,9 @@ use thiserror::Error;
 mod http_error;
 pub use http_error::*;
 
+mod client_error;
+pub use client_error::*;
+
 mod server_error_response;
 pub use server_error_response::*;
 


### PR DESCRIPTION
The writer ID changes appear to have broken these tests, and as they aren't currently run in CI, this has gone unnoticed.

Additionally, IOx no longer considers `bananas!` an invalid database name, only disallowing names with control characters. As url::parse silently strips such characters, it was necessary to add database name validation within the client to preserve the spirit of the test.