### PR TITLE
fix: influxdb2_client example project

### DIFF
--- a/influxdb2_client/Cargo.toml
+++ b/influxdb2_client/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 [dependencies] # In alphabetical order
 bytes = { version = "1.0", default-features = false }
 futures = { version = "0.3.5", default-features = false }
-reqwest = { version = "0.11", default-features = false, features = ["stream"] }
+reqwest = { version = "0.11", features = ["stream"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.44"
 snafu = "0.6.6"

--- a/influxdb2_client/Cargo.toml
+++ b/influxdb2_client/Cargo.toml
@@ -14,4 +14,4 @@ snafu = "0.6.6"
 
 [dev-dependencies] # In alphabetical order
 mockito = "0.26.0"
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }


### PR DESCRIPTION
Fixes build issues with the `influxdb2_client` example project.
- Enable `rt-multi-thread` in `tokio`
- Enable default features for `reqwest` which allows sending data to https endpoints.

- [x] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb_iox/blob/main/README.md).
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
