### PR TITLE
refactor: Remove unneeded StringSetPlan::KnownError variant

### DIFF
--- a/query/src/exec.rs
+++ b/query/src/exec.rs
@@ -194,7 +194,6 @@ impl Executor {
     pub async fn to_string_set(&self, plan: StringSetPlan) -> Result<StringSetRef> {
         match plan {
             StringSetPlan::KnownOk(ss) => Ok(ss),
-            StringSetPlan::KnownError(source) => Err(Error::Execution { source }),
             StringSetPlan::Plan(plans) => self
                 .run_logical_plans(plans)
                 .await?
@@ -415,32 +414,11 @@ mod tests {
     #[tokio::test]
     async fn executor_known_string_set_plan_ok() -> Result<()> {
         let expected_strings = to_set(&["Foo", "Bar"]);
-        let result: Result<_> = Ok(expected_strings.clone());
-        let plan = result.into();
+        let plan = StringSetPlan::KnownOk(expected_strings.clone());
 
         let executor = Executor::default();
         let result_strings = executor.to_string_set(plan).await?;
         assert_eq!(result_strings, expected_strings);
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn executor_known_string_set_plan_err() -> Result<()> {
-        let result = InternalResultsExtraction {
-            message: "this is a test",
-        }
-        .fail();
-
-        let plan = result.into();
-
-        let executor = Executor::default();
-        let actual_result = executor.to_string_set(plan).await;
-        assert!(actual_result.is_err());
-        assert!(
-            format!("{:?}", actual_result).contains("this is a test"),
-            "Actual result: '{:?}'",
-            actual_result
-        );
         Ok(())
     }
 

--- a/query/src/exec.rs
+++ b/query/src/exec.rs
@@ -193,7 +193,7 @@ impl Executor {
     /// Executes this plan and returns the resulting set of strings
     pub async fn to_string_set(&self, plan: StringSetPlan) -> Result<StringSetRef> {
         match plan {
-            StringSetPlan::KnownOk(ss) => Ok(ss),
+            StringSetPlan::Known(ss) => Ok(ss),
             StringSetPlan::Plan(plans) => self
                 .run_logical_plans(plans)
                 .await?
@@ -414,7 +414,7 @@ mod tests {
     #[tokio::test]
     async fn executor_known_string_set_plan_ok() -> Result<()> {
         let expected_strings = to_set(&["Foo", "Bar"]);
-        let plan = StringSetPlan::KnownOk(expected_strings.clone());
+        let plan = StringSetPlan::Known(expected_strings.clone());
 
         let executor = Executor::default();
         let result_strings = executor.to_string_set(plan).await?;

--- a/query/src/plan/stringset.rs
+++ b/query/src/plan/stringset.rs
@@ -32,7 +32,7 @@ pub type Result<T, E = Error> = std::result::Result<T, E>;
 pub enum StringSetPlan {
     /// The results are known from metadata only without having to run
     /// an actual datafusion plan
-    KnownOk(StringSetRef),
+    Known(StringSetRef),
 
     /// A DataFusion plan(s) to execute. Each plan must produce
     /// RecordBatches with exactly one String column, though the
@@ -47,7 +47,7 @@ pub enum StringSetPlan {
 impl From<StringSetRef> for StringSetPlan {
     /// Create a StringSetPlan from a StringSetRef
     fn from(set: StringSetRef) -> Self {
-        Self::KnownOk(set)
+        Self::Known(set)
     }
 }
 
@@ -55,7 +55,7 @@ impl From<StringSet> for StringSetPlan {
     /// Create a StringSetPlan from a StringSet result, wrapping the error type
     /// appropriately
     fn from(set: StringSet) -> Self {
-        Self::KnownOk(StringSetRef::new(set))
+        Self::Known(StringSetRef::new(set))
     }
 }
 
@@ -95,7 +95,7 @@ impl StringSetPlanBuilder {
     /// passes on the plan
     pub fn append(mut self, other: StringSetPlan) -> Self {
         match other {
-            StringSetPlan::KnownOk(ssref) => match Arc::try_unwrap(ssref) {
+            StringSetPlan::Known(ssref) => match Arc::try_unwrap(ssref) {
                 Ok(mut ss) => {
                     self.strings.append(&mut ss);
                 }
@@ -120,7 +120,7 @@ impl StringSetPlanBuilder {
 
         if plans.is_empty() {
             // only a known set of strings
-            Ok(StringSetPlan::KnownOk(Arc::new(strings)))
+            Ok(StringSetPlan::Known(Arc::new(strings)))
         } else {
             // Had at least one general plan, so need to use general
             // purpose plan for the known strings
@@ -149,7 +149,7 @@ mod tests {
     fn test_builder_empty() {
         let plan = StringSetPlanBuilder::new().build().unwrap();
         let empty_ss = StringSet::new().into();
-        if let StringSetPlan::KnownOk(ss) = plan {
+        if let StringSetPlan::Known(ss) = plan {
             assert_eq!(ss, empty_ss)
         } else {
             panic!("unexpected type: {:?}", plan)
@@ -166,7 +166,7 @@ mod tests {
 
         let expected_ss = to_string_set(&["foo", "bar", "baz"]).into();
 
-        if let StringSetPlan::KnownOk(ss) = plan {
+        if let StringSetPlan::Known(ss) = plan {
             assert_eq!(ss, expected_ss)
         } else {
             panic!("unexpected type: {:?}", plan)

--- a/query/src/test.rs
+++ b/query/src/test.rs
@@ -354,7 +354,7 @@ impl Database for TestDatabase {
                 message: "No saved column_names in TestDatabase",
             })?;
 
-        Ok(StringSetPlan::KnownOk(column_names))
+        Ok(StringSetPlan::Known(column_names))
     }
 
     async fn field_column_names(&self, predicate: Predicate) -> Result<FieldListPlan, Self::Error> {
@@ -413,7 +413,7 @@ impl Database for TestDatabase {
                 message: "No saved column_values in TestDatabase",
             })?;
 
-        Ok(StringSetPlan::KnownOk(column_values))
+        Ok(StringSetPlan::Known(column_values))
     }
 
     async fn query_series(&self, predicate: Predicate) -> Result<SeriesSetPlans, Self::Error> {

--- a/query/src/test.rs
+++ b/query/src/test.rs
@@ -352,9 +352,9 @@ impl Database for TestDatabase {
             // Turn None into an error
             .context(General {
                 message: "No saved column_names in TestDatabase",
-            });
+            })?;
 
-        Ok(column_names.into())
+        Ok(StringSetPlan::KnownOk(column_names))
     }
 
     async fn field_column_names(&self, predicate: Predicate) -> Result<FieldListPlan, Self::Error> {
@@ -411,9 +411,9 @@ impl Database for TestDatabase {
             // Turn None into an error
             .context(General {
                 message: "No saved column_values in TestDatabase",
-            });
+            })?;
 
-        Ok(column_values.into())
+        Ok(StringSetPlan::KnownOk(column_values))
     }
 
     async fn query_series(&self, predicate: Predicate) -> Result<SeriesSetPlans, Self::Error> {


### PR DESCRIPTION
As pointed out by @e-dard in https://github.com/influxdata/influxdb_iox/pull/759/files#r572917700,  comment, `KnownOK` and `KnownError` are  confusing and it turns out uneeded. 

Remove the `KnownError` variant and rename `KnownOk` --> `Known`

- [x] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb_iox/blob/main/README.md).
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
