### PR TITLE
test: add a SQL test case for selection (of columns)

### DIFF
--- a/server/src/query_tests/sql.rs
+++ b/server/src/query_tests/sql.rs
@@ -81,6 +81,23 @@ async fn sql_select_from_cpu_pred() {
 }
 
 #[tokio::test]
+async fn sql_select_from_cpu_with_projection_and_pred() {
+    // expect that to get a subset of the columns and in the order specified
+    let expected = vec![
+        "+------+--------+",
+        "| user | region |",
+        "+------+--------+",
+        "| 21   | west   |",
+        "+------+--------+",
+    ];
+    run_sql_test_case!(
+        TwoMeasurements {},
+        "SELECT user, region from cpu where time > 125",
+        &expected
+    );
+}
+
+#[tokio::test]
 async fn sql_select_from_cpu_group() {
     let expected = vec![
         "+-----------------+",

--- a/server/src/query_tests/sql.rs
+++ b/server/src/query_tests/sql.rs
@@ -47,6 +47,24 @@ async fn sql_select_from_cpu() {
 }
 
 #[tokio::test]
+async fn sql_select_from_cpu_with_projection() {
+    // expect that to get a subset of the columns and in the order specified
+    let expected = vec![
+        "+------+--------+",
+        "| user | region |",
+        "+------+--------+",
+        "| 23.2 | west   |",
+        "| 21   | west   |",
+        "+------+--------+",
+    ];
+    run_sql_test_case!(
+        TwoMeasurements {},
+        "SELECT user, region from cpu",
+        &expected
+    );
+}
+
+#[tokio::test]
 async fn sql_select_from_cpu_pred() {
     let expected = vec![
         "+--------+------+------+",


### PR DESCRIPTION
I am tracking down a bug in the gRPC planner and I thought there might be a bug in the selection code, so I added a test. Turns out this is not the actual problem but since I had written the test anyways I figured this is a good one to add to the suite

- [x] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb_iox/blob/main/README.md).
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
