### PR TITLE
feat: Add database rules configuration for mutable buffer

### DIFF
--- a/data_types/src/database_rules.rs
+++ b/data_types/src/database_rules.rs
@@ -142,7 +142,7 @@ pub struct MutableBufferConfig {
     /// Drop partitions to free up space in this order. Can be by the oldest
     /// created at time, the longest since the last write, or the min or max of
     /// some column.
-    pub partition_drop_order: PartitionDropRules,
+    pub partition_drop_order: PartitionSortRules,
     /// Attempt to persist partitions after they haven't received a write for
     /// this number of seconds. If not set, partitions won't be
     /// automatically persisted.
@@ -164,7 +164,7 @@ impl Default for MutableBufferConfig {
             buffer_size: DEFAULT_MUTABLE_BUFFER_SIZE,
             // keep taking writes and drop partitions on the floor
             reject_if_not_persisted: false,
-            partition_drop_order: PartitionDropRules {
+            partition_drop_order: PartitionSortRules {
                 order: Order::Desc,
                 sort: PartitionSort::CreatedAtTime,
             },
@@ -175,22 +175,22 @@ impl Default for MutableBufferConfig {
     }
 }
 
-/// This struct specifies the rules for the order in which to drop partitions
-/// from the mutable buffer after it exceeds its max size. The last partition in
-/// the list will be dropped, until enough space has been freed up to be below
-/// the max size.
+/// This struct specifies the rules for the order to sort partitions
+/// from the mutable buffer. This is used to determine which order to drop them
+/// in. The last partition in the list will be dropped, until enough space has
+/// been freed up to be below the max size.
 ///
 /// For example, to drop the partition that has been open longest:
 /// ```
-/// use data_types::database_rules::{PartitionDropRules, Order, PartitionSort};
+/// use data_types::database_rules::{PartitionSortRules, Order, PartitionSort};
 ///
-/// let rules = PartitionDropRules{
+/// let rules = PartitionSortRules{
 ///     order: Order::Desc,
 ///     sort: PartitionSort::CreatedAtTime,
 /// };
 /// ```
 #[derive(Debug, Serialize, Deserialize, Eq, PartialEq, Clone)]
-pub struct PartitionDropRules {
+pub struct PartitionSortRules {
     /// Sort partitions by this order. Last will be dropped.
     pub order: Order,
     /// Sort by either a column value, or when the partition was opened, or when

--- a/data_types/src/database_rules.rs
+++ b/data_types/src/database_rules.rs
@@ -100,6 +100,13 @@ pub struct DatabaseRules {
     /// configuration.
     #[serde(default)]
     pub wal_buffer_config: Option<WalBufferConfig>,
+
+    /// When set this will collect writes into a queryable in-memory database
+    /// called the Mutable Buffer. It is optimized to receive writes so they
+    /// can be batched together later to the Read Buffer or to Parquet files
+    /// in object storage.
+    #[serde(default = "MutableBufferConfig::default_option")]
+    pub mutable_buffer_config: Option<MutableBufferConfig>,
 }
 
 impl DatabaseRules {
@@ -110,6 +117,128 @@ impl DatabaseRules {
     ) -> Result<String> {
         self.partition_template.partition_key(line, default_time)
     }
+}
+
+/// MutableBufferConfig defines the configuration for the in-memory database
+/// that is hot for writes as they arrive. Operators can define rules for
+/// evicting data once the mutable buffer passes a set memory threshold.
+#[derive(Debug, Serialize, Deserialize, Eq, PartialEq, Clone)]
+pub struct MutableBufferConfig {
+    /// The size the mutable buffer should be limited to. Once the buffer gets
+    /// to this size it will drop partitions in the given order. If unable
+    /// to drop partitions (because of later rules in this config) it will
+    /// reject writes until it is able to drop partitions.
+    pub buffer_size: u64,
+    /// If set, the mutable buffer will not drop partitions that have chunks
+    /// that have not yet been persisted. Thus it will reject writes if it
+    /// is over size and is unable to drop partitions. The default is to
+    /// drop partitions in the sort order, regardless of whether they have
+    /// unpersisted chunks or not. The WAL Buffer can be used to ensure
+    /// persistence, but this may cause longer recovery times.
+    pub reject_if_not_persisted: bool,
+    /// Drop partitions to free up space in this order. Can be by the oldest
+    /// created at time, the longest since the last write, or the min or max of
+    /// some column.
+    pub partition_drop_order: PartitionDropRules,
+    /// Attempt to persist partitions after they haven't received a write for
+    /// this number of seconds. If not set, partitions won't be
+    /// automatically persisted.
+    pub persist_after_cold_seconds: Option<u32>,
+}
+
+const DEFAULT_MUTABLE_BUFFER_SIZE: u64 = 2_147_483_648; // 2 GB
+const DEFAULT_PERSIST_AFTER_COLD_SECONDS: u32 = 900; // 15 minutes
+
+impl MutableBufferConfig {
+    fn default_option() -> Option<Self> {
+        Some(Self::default())
+    }
+}
+
+impl Default for MutableBufferConfig {
+    fn default() -> Self {
+        Self {
+            buffer_size: DEFAULT_MUTABLE_BUFFER_SIZE,
+            // keep taking writes and drop partitions on the floor
+            reject_if_not_persisted: false,
+            partition_drop_order: PartitionDropRules {
+                order: Order::Desc,
+                sort: PartitionSort::CreatedAtTime,
+            },
+            // rollover the chunk and persist the it after the partiton has been cold for
+            // 15 minutes
+            persist_after_cold_seconds: Some(DEFAULT_PERSIST_AFTER_COLD_SECONDS),
+        }
+    }
+}
+
+/// This struct specifies the rules for the order in which to drop partitions
+/// from the mutable buffer after it exceeds its max size. The last partition in
+/// the list will be dropped, until enough space has been freed up to be below
+/// the max size.
+///
+/// For example, to drop the partition that has been open longest:
+/// ```
+/// use data_types::database_rules::{PartitionDropRules, Order, PartitionSort};
+///
+/// let rules = PartitionDropRules{
+///     order: Order::Desc,
+///     sort: PartitionSort::CreatedAtTime,
+/// };
+/// ```
+#[derive(Debug, Serialize, Deserialize, Eq, PartialEq, Clone)]
+pub struct PartitionDropRules {
+    /// Sort partitions by this order. Last will be dropped.
+    pub order: Order,
+    /// Sort by either a column value, or when the partition was opened, or when
+    /// it last received a write.
+    pub sort: PartitionSort,
+}
+
+/// What to sort the partition by.
+#[derive(Debug, Serialize, Deserialize, Eq, PartialEq, Clone)]
+pub enum PartitionSort {
+    /// The last time the partition received a write.
+    LastWriteTime,
+    /// When the partition was opened in the mutable buffer.
+    CreatedAtTime,
+    /// A column name, its expected type, and whether to use the min or max
+    /// value. The ColumnType is necessary because the column can appear in
+    /// any number of tables and be of a different type. This specifies that
+    /// when sorting partitions, only columns with the given name and type
+    /// should be used for the purposes of determining the partition order. If a
+    /// partition doesn't have the given column in any way, the partition will
+    /// appear at the beginning of the list with a null value where all
+    /// partitions having null for that value will then be
+    /// sorted by created_at_time desc. So if none of the partitions in the
+    /// mutable buffer had this column with this type, then the partition
+    /// that was created first would appear last in the list and thus be the
+    /// first up to be dropped.
+    Column(String, ColumnType, ColumnValue),
+}
+
+/// The sort order.
+#[derive(Debug, Serialize, Deserialize, Eq, PartialEq, Clone)]
+pub enum Order {
+    Asc,
+    Desc,
+}
+
+/// Use columns of this type.
+#[derive(Debug, Serialize, Deserialize, Eq, PartialEq, Clone)]
+pub enum ColumnType {
+    I64,
+    U64,
+    F64,
+    String,
+    Bool,
+}
+
+/// Use either the min or max summary statistic.
+#[derive(Debug, Serialize, Deserialize, Eq, PartialEq, Clone)]
+pub enum ColumnValue {
+    Min,
+    Max,
 }
 
 /// WalBufferConfig defines the configuration for buffering data from the WAL in

--- a/data_types/src/database_rules.rs
+++ b/data_types/src/database_rules.rs
@@ -27,11 +27,6 @@ pub struct DatabaseRules {
     /// db
     #[serde(default)]
     pub partition_template: PartitionTemplate,
-    /// If `store_locally` is set to `true`, this server will store writes and
-    /// replicated writes in a local write buffer database. This is step #4
-    /// from the diagram.
-    #[serde(default)]
-    pub store_locally: bool,
     /// The set of host groups that data should be replicated to. Which host a
     /// write goes to within a host group is determined by consistent hashing of
     /// the partition key. We'd use this to create a host group per
@@ -116,6 +111,13 @@ impl DatabaseRules {
         default_time: &DateTime<Utc>,
     ) -> Result<String> {
         self.partition_template.partition_key(line, default_time)
+    }
+
+    pub fn new() -> Self {
+        Self {
+            mutable_buffer_config: MutableBufferConfig::default_option(),
+            ..Default::default()
+        }
     }
 }
 

--- a/data_types/src/database_rules.rs
+++ b/data_types/src/database_rules.rs
@@ -96,7 +96,8 @@ pub struct DatabaseRules {
     #[serde(default)]
     pub wal_buffer_config: Option<WalBufferConfig>,
 
-    /// When set this will collect writes into a queryable in-memory database
+    /// Unless explicitly disabled by setting this to None (or null in JSON),
+    /// writes will go into a queryable in-memory database
     /// called the Mutable Buffer. It is optimized to receive writes so they
     /// can be batched together later to the Read Buffer or to Parquet files
     /// in object storage.
@@ -167,7 +168,7 @@ impl Default for MutableBufferConfig {
                 order: Order::Desc,
                 sort: PartitionSort::CreatedAtTime,
             },
-            // rollover the chunk and persist the it after the partiton has been cold for
+            // rollover the chunk and persist it after the partition has been cold for
             // 15 minutes
             persist_after_cold_seconds: Some(DEFAULT_PERSIST_AFTER_COLD_SECONDS),
         }

--- a/influxdb_iox_client/src/client.rs
+++ b/influxdb_iox_client/src/client.rs
@@ -25,7 +25,7 @@ use data_types::{http::ListDatabasesResponse, DatabaseName};
 ///
 /// // Create a new database!
 /// client
-///     .create_database("bananas", &DatabaseRules::default())
+///     .create_database("bananas", &DatabaseRules::new())
 ///     .await
 ///     .expect("failed to create database");
 /// # }
@@ -227,7 +227,7 @@ mod tests {
             .await
             .expect("set ID failed");
 
-        c.create_database(rand_name(), &DatabaseRules::default())
+        c.create_database(rand_name(), &DatabaseRules::new())
             .await
             .expect("create database failed");
     }
@@ -243,12 +243,12 @@ mod tests {
 
         let db_name = rand_name();
 
-        c.create_database(db_name.clone(), &DatabaseRules::default())
+        c.create_database(db_name.clone(), &DatabaseRules::new())
             .await
             .expect("create database failed");
 
         let err = c
-            .create_database(db_name, &DatabaseRules::default())
+            .create_database(db_name, &DatabaseRules::new())
             .await
             .expect_err("create database failed");
 
@@ -265,7 +265,7 @@ mod tests {
             .expect("set ID failed");
 
         let err = c
-            .create_database("my_example\ndb", &DatabaseRules::default())
+            .create_database("my_example\ndb", &DatabaseRules::new())
             .await
             .expect_err("expected request to fail");
 

--- a/server/src/buffer.rs
+++ b/server/src/buffer.rs
@@ -939,7 +939,7 @@ mod tests {
         lp: &str,
     ) -> Arc<ReplicatedWrite> {
         let lines: Vec<_> = parse_lines(lp).map(|l| l.unwrap()).collect();
-        let rules = DatabaseRules::default();
+        let rules = DatabaseRules::new();
         Arc::new(lines_to_replicated_write(
             writer_id,
             sequence_number,

--- a/server/src/config.rs
+++ b/server/src/config.rs
@@ -36,7 +36,7 @@ impl Config {
             });
         }
 
-        let mutable_buffer = if rules.store_locally {
+        let mutable_buffer = if rules.mutable_buffer_config.is_some() {
             Some(MutableBufferDb::new(name.to_string()))
         } else {
             None
@@ -147,7 +147,7 @@ mod test {
     fn create_db() {
         let name = DatabaseName::new("foo").unwrap();
         let config = Config::default();
-        let rules = DatabaseRules::default();
+        let rules = DatabaseRules::new();
 
         {
             let _db_reservation = config.create_db(name.clone(), rules.clone()).unwrap();

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -459,12 +459,7 @@ where
         let db = match self.db(&db_name).await {
             Some(db) => db,
             None => {
-                let rules = DatabaseRules {
-                    store_locally: true,
-                    ..Default::default()
-                };
-
-                self.create_database(name, rules).await?;
+                self.create_database(name, DatabaseRules::new()).await?;
                 self.db(&db_name).await.expect("db not inserted")
             }
         };
@@ -581,7 +576,7 @@ mod tests {
         let store = Arc::new(ObjectStore::new_in_memory(InMemory::new()));
         let mut server = Server::new(manager, store);
 
-        let rules = DatabaseRules::default();
+        let rules = DatabaseRules::new();
         let resp = server.create_database("foo", rules).await.unwrap_err();
         assert!(matches!(resp, Error::IdNotSet));
 
@@ -642,7 +637,7 @@ mod tests {
 
         let db2 = "db_awesome";
         server
-            .create_database(db2, DatabaseRules::default())
+            .create_database(db2, DatabaseRules::new())
             .await
             .expect("failed to create 2nd db");
 
@@ -670,13 +665,13 @@ mod tests {
 
         // Create a database
         server
-            .create_database(name, DatabaseRules::default())
+            .create_database(name, DatabaseRules::new())
             .await
             .expect("failed to create database");
 
         // Then try and create another with the same name
         let got = server
-            .create_database(name, DatabaseRules::default())
+            .create_database(name, DatabaseRules::new())
             .await
             .unwrap_err();
 
@@ -698,7 +693,7 @@ mod tests {
 
         for name in &names {
             server
-                .create_database(*name, DatabaseRules::default())
+                .create_database(*name, DatabaseRules::new())
                 .await
                 .expect("failed to create database");
         }
@@ -723,11 +718,10 @@ mod tests {
         ];
 
         for name in reject {
-            let rules = DatabaseRules {
-                store_locally: true,
-                ..Default::default()
-            };
-            let got = server.create_database(name, rules).await.unwrap_err();
+            let got = server
+                .create_database(name, DatabaseRules::new())
+                .await
+                .unwrap_err();
             if !matches!(got, Error::InvalidDatabaseName { .. }) {
                 panic!("expected invalid name error");
             }
@@ -742,11 +736,7 @@ mod tests {
         let store = Arc::new(ObjectStore::new_in_memory(InMemory::new()));
         let server = Server::new(manager, store);
         server.set_id(1);
-        let rules = DatabaseRules {
-            store_locally: true,
-            ..Default::default()
-        };
-        server.create_database("foo", rules).await?;
+        server.create_database("foo", DatabaseRules::new()).await?;
 
         let line = "cpu bar=1 10";
         let lines: Vec<_> = parse_lines(line).map(|l| l.unwrap()).collect();

--- a/server/src/query_tests/utils.rs
+++ b/server/src/query_tests/utils.rs
@@ -7,7 +7,7 @@ use crate::db::Db;
 pub fn make_db() -> Db {
     let name = "test_db";
     Db::new(
-        DatabaseRules::default(),
+        DatabaseRules::new(),
         Some(MutableBufferDb::new(name)),
         read_buffer::Database::new(),
         None, // wal buffer

--- a/server/src/snapshot.rs
+++ b/server/src/snapshot.rs
@@ -477,7 +477,7 @@ mem,host=A,region=west used=45 1
     pub fn make_db() -> Db {
         let name = "test_db";
         Db::new(
-            DatabaseRules::default(),
+            DatabaseRules::new(),
             Some(MutableBufferDb::new(name)),
             ReadBufferDb::new(),
             None, // wal buffer

--- a/src/influxdb_ioxd/http.rs
+++ b/src/influxdb_ioxd/http.rs
@@ -787,12 +787,8 @@ mod tests {
             Arc::new(ObjectStore::new_in_memory(InMemory::new())),
         ));
         test_storage.set_id(1);
-        let rules = DatabaseRules {
-            store_locally: true,
-            ..Default::default()
-        };
         test_storage
-            .create_database("MyOrg_MyBucket", rules)
+            .create_database("MyOrg_MyBucket", DatabaseRules::new())
             .await
             .unwrap();
         let server_url = test_server(test_storage.clone());
@@ -849,12 +845,8 @@ mod tests {
             Arc::new(ObjectStore::new_in_memory(InMemory::new())),
         ));
         test_storage.set_id(1);
-        let rules = DatabaseRules {
-            store_locally: true,
-            ..Default::default()
-        };
         test_storage
-            .create_database("MyOrg_MyBucket", rules)
+            .create_database("MyOrg_MyBucket", DatabaseRules::new())
             .await
             .unwrap();
         let server_url = test_server(test_storage.clone());
@@ -937,7 +929,6 @@ mod tests {
         for database_name in &database_names {
             let rules = DatabaseRules {
                 name: database_name.clone(),
-                store_locally: true,
                 ..Default::default()
             };
             server.create_database(database_name, rules).await.unwrap();
@@ -965,7 +956,7 @@ mod tests {
         server.set_id(1);
         let server_url = test_server(server.clone());
 
-        let data = r#"{"store_locally": true}"#;
+        let data = r#"{}"#;
 
         let database_name = DatabaseName::new("foo_bar").unwrap();
 
@@ -983,7 +974,7 @@ mod tests {
 
         server.db(&database_name).await.unwrap();
         let db_rules = server.db_rules(&database_name).await.unwrap();
-        assert_eq!(db_rules.store_locally, true);
+        assert!(db_rules.mutable_buffer_config.is_some());
     }
 
     #[tokio::test]
@@ -998,7 +989,6 @@ mod tests {
         let database_name = "foo_bar";
         let rules = DatabaseRules {
             name: database_name.to_owned(),
-            store_locally: true,
             ..Default::default()
         };
         let data = serde_json::to_string(&rules).unwrap();
@@ -1029,7 +1019,6 @@ mod tests {
         let database_name = "foo_bar";
         let rules = DatabaseRules {
             name: database_name.to_owned(),
-            store_locally: true,
             wal_buffer_config: Some(WalBufferConfig {
                 buffer_size: 500,
                 segment_size: 10,

--- a/tests/end-to-end.rs
+++ b/tests/end-to-end.rs
@@ -160,10 +160,7 @@ impl Scenario {
 }
 
 async fn create_database(client: &reqwest::Client, database_name: &str) {
-    let rules = DatabaseRules {
-        store_locally: true,
-        ..Default::default()
-    };
+    let rules = DatabaseRules::new();
     let data = serde_json::to_vec(&rules).unwrap();
 
     client


### PR DESCRIPTION
Here's what I'm thinking for the configuration options for the mutable buffer management. If this looks good, I'll follow up with a commit to remove the `store_locally` flag in `DatabaseRules`. After that I can move to actually implement these rules in the server.