### PR TITLE
feat: Enable/Disable logging in tests via RUST_LOG environment variable

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,6 +99,25 @@ The `cargo` build tool runs tests as well. Run:
 cargo test --workspace
 ```
 
+### Enabling logging in tests
+
+To enable logging to stderr during a run of `cargo test` set the Rust
+`RUST_LOG` environment varable. For example, to see all INFO
+messages:
+
+```shell
+RUST_LOG=info cargo test --workspace
+```
+
+This uses [`env_logger`](https://crates.io/crates/env_logger)
+internally, so you can use all the features of that crate. For
+example, to disable the (somewhat noisy) h2 logs, you can use a
+value of `RUST_LOG` such as:
+
+```shell
+RUST_LOG=debug,hyper::proto::h1=info,h2=info cargo test --workspace
+```
+
 ## Running `rustfmt` and `clippy`
 
 CI will check the code formatting with [`rustfmt`] and Rust best practices with [`clippy`].

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,17 +102,17 @@ cargo test --workspace
 ### Enabling logging in tests
 
 To enable logging to stderr during a run of `cargo test` set the Rust
-`RUST_LOG` environment varable. For example, to see all INFO
-messages:
+`RUST_LOG` environment varable. For example, to see all INFO messages:
 
 ```shell
 RUST_LOG=info cargo test --workspace
 ```
 
-This uses [`env_logger`](https://crates.io/crates/env_logger)
-internally, so you can use all the features of that crate. For
-example, to disable the (somewhat noisy) h2 logs, you can use a
-value of `RUST_LOG` such as:
+Since this feature uses
+[`env_logger`](https://crates.io/crates/env_logger) internally, you
+can use all the features of that crate. For example, to disable the
+(somewhat noisy) logs in sime h2 modules, you can use a value of
+`RUST_LOG` such as:
 
 ```shell
 RUST_LOG=debug,hyper::proto::h1=info,h2=info cargo test --workspace

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -109,9 +109,9 @@ RUST_LOG=info cargo test --workspace
 ```
 
 Since this feature uses
-[`env_logger`](https://crates.io/crates/env_logger) internally, you
+[`EnvFilter`](https://docs.rs/tracing-subscriber/0.2.15/tracing_subscriber/filter/struct.EnvFilter.html) internally, you
 can use all the features of that crate. For example, to disable the
-(somewhat noisy) logs in sime h2 modules, you can use a value of
+(somewhat noisy) logs in some h2 modules, you can use a value of
 `RUST_LOG` such as:
 
 ```shell

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3536,9 +3536,9 @@ name = "test_helpers"
 version = "0.1.0"
 dependencies = [
  "dotenv",
- "env_logger 0.7.1",
  "tempfile",
  "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/server/src/query_tests/sql.rs
+++ b/server/src/query_tests/sql.rs
@@ -13,7 +13,7 @@ use query::{exec::Executor, frontend::sql::SQLQueryPlanner};
 /// output
 macro_rules! run_sql_test_case {
     ($DB_SETUP:expr, $SQL:expr, $EXPECTED_LINES:expr) => {
-        //test_helpers::enable_logging();
+        test_helpers::maybe_start_logging();
         let sql = $SQL.to_string();
         for scenario in $DB_SETUP.make().await {
             let DBScenario { scenario_name, db } = scenario;

--- a/server/src/query_tests/table_schema.rs
+++ b/server/src/query_tests/table_schema.rs
@@ -13,6 +13,7 @@ use super::scenarios::*;
 /// output
 macro_rules! run_table_schema_test_case {
     ($DB_SETUP:expr, $SELECTION:expr, $TABLE_NAME:expr, $EXPECTED_SCHEMA:expr) => {
+        test_helpers::maybe_start_logging();
         let selection = $SELECTION;
         let table_name = $TABLE_NAME;
         let expected_schema = $EXPECTED_SCHEMA;

--- a/test_helpers/Cargo.toml
+++ b/test_helpers/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2018"
 
 [dependencies] # In alphabetical order
 dotenv = "0.15.0"
-env_logger = "0.7.1"
 tempfile = "3.1.0"
 tracing = "0.1"
-
+tracing-subscriber = "0.2.15"

--- a/test_helpers/src/lib.rs
+++ b/test_helpers/src/lib.rs
@@ -95,7 +95,15 @@ pub fn start_logging() {
         if std::env::var("RUST_LOG").is_err() {
             std::env::set_var("RUST_LOG", "debug");
         }
-        env_logger::init();
+        // Configure the logger to write to stderr and install it
+        let output_stream = std::io::stderr;
+
+        use tracing_subscriber::{prelude::*, EnvFilter};
+
+        tracing_subscriber::registry()
+            .with(EnvFilter::from_default_env())
+            .with(tracing_subscriber::fmt::layer().with_writer(output_stream))
+            .init();
     })
 }
 

--- a/test_helpers/src/lib.rs
+++ b/test_helpers/src/lib.rs
@@ -85,15 +85,27 @@ pub fn tag_key_bytes_to_strings(bytes: Vec<u8>) -> String {
 
 static LOG_SETUP: Once = Once::new();
 
-/// Enables debug logging. This function can be called more than once
-pub fn enable_logging() {
+/// Enables debug logging regardless of the value of RUST_LOG
+/// environment variable. If RUST_LOG isn't specifies, defaults to
+/// "debug"
+pub fn start_logging() {
     // ensure the global has been initialized
     LOG_SETUP.call_once(|| {
-        // TODO honor any existing RUST_LOG level (and maybe not start
-        // logging unless it is set??)
-        std::env::set_var("RUST_LOG", "debug");
+        // honor any existing RUST_LOG level
+        if std::env::var("RUST_LOG").is_err() {
+            std::env::set_var("RUST_LOG", "debug");
+        }
         env_logger::init();
     })
+}
+
+/// Enables debug logging if the RUST_LOG environment variable is
+/// set. Does nothing if RUST_LOG is not set. If enable_logging has
+/// been set previously, does nothing
+pub fn maybe_start_logging() {
+    if std::env::var("RUST_LOG").is_ok() {
+        start_logging()
+    }
 }
 
 #[macro_export]


### PR DESCRIPTION
TLDR; This PR allows runtime enabling/disable of logging in tests

# Rationale

I am trying to be more productive.

My debugging flow in the query engine often looks like
1. run tests
2. find those that fail
3. add `test_util::enable_logging()`
4. rerun to get logging

I am trying to avoid the recompile/rerun steps 3 and 4

# Changes:

Add a function to enable logging if `RUST_LOG` is set in the environment, and does nothing if `RUST_LOG` is not set

So now, you can enable logs in the tests without a recompile via:

```
RUST_LOG=debug cargo test -p query
```

# Examples:

## Tests as Normal
```
cargo test -p server -- sql
```

Which runs the tests like you would hope, nice and quiet like

```
cd /Users/alamb/Software/influxdb_iox2 && cargo test -p server -- sql
    Blocking waiting for file lock on build directory
   Compiling server v0.1.0 (/Users/alamb/Software/influxdb_iox2/server)
    Finished test [unoptimized + debuginfo] target(s) in 23.50s
     Running target/debug/deps/server-c6c98a959c339054

running 6 tests
test query_tests::sql::sql_select_from_disk ... ok
test query_tests::sql::sql_select_from_cpu_with_projection ... ok
test query_tests::sql::sql_select_from_cpu ... ok
test query_tests::sql::sql_select_from_cpu_pred ... ok
test query_tests::sql::sql_select_from_cpu_with_projection_and_pred ... ok
test query_tests::sql::sql_select_from_cpu_group ... ok

test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 46 filtered out

   Doc-tests server

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out


Compilation finished at Fri Feb 12 06:56:32
```
## Log Connoisseur Mode
If you want a heaping helping of logs, you can do:

```
RUST_LOG=debug cargo test -p server -- sql
```

Which produces
```
cd /Users/alamb/Software/influxdb_iox2 && RUST_LOG=debug cargo test -p server -- sql
    Finished test [unoptimized + debuginfo] target(s) in 0.36s
     Running target/debug/deps/server-c6c98a959c339054

running 6 tests
[2021-02-12T11:57:23Z DEBUG sqlparser::parser] Parsing sql 'SELECT user, region from cpu'...
[2021-02-12T11:57:23Z DEBUG sqlparser::parser] Parsing sql 'SELECT count(*) from cpu group by region'...
[2021-02-12T11:57:23Z DEBUG sqlparser::parser] parsing expr
[2021-02-12T11:57:23Z DEBUG sqlparser::parser] Parsing sql 'SELECT user, region from cpu where time > 125'...
[2021-02-12T11:57:23Z DEBUG sqlparser::parser] Parsing sql 'SELECT * from disk'...
[2021-02-12T11:57:23Z DEBUG sqlparser::parser] parsing expr
... (SNIP) ...
    ----
[2021-02-12T11:57:27Z DEBUG datafusion::physical_plan::coalesce_batches] Combined 1 batches containing 1 rows
test query_tests::sql::sql_select_from_cpu_with_projection_and_pred ... ok

test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 46 filtered out

   Doc-tests server

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out


Compilation finished at Fri Feb 12 06:57:27
```


- [x] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb_iox/blob/main/README.md).
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
