### PR TITLE
fix: Report a failure to parse an AWS datetime

### DIFF
--- a/object_store/src/aws.rs
+++ b/object_store/src/aws.rs
@@ -84,6 +84,16 @@ pub enum Error {
         source: rusoto_core::RusotoError<rusoto_s3::ListObjectsV2Error>,
         bucket: String,
     },
+
+    #[snafu(display(
+        "Unable to parse last modified date. Bucket: {}, Error: {}",
+        bucket,
+        source
+    ))]
+    UnableToParseLastModified {
+        source: chrono::ParseError,
+        bucket: String,
+    },
 }
 
 /// Configuration for connecting to [Amazon S3](https://aws.amazon.com/s3/).
@@ -306,34 +316,29 @@ impl AmazonS3 {
 
         let contents = resp.contents.unwrap_or_default();
 
-        let objects: Vec<_> = contents
+        let objects = contents
             .into_iter()
             .map(|object| {
                 let location =
                     CloudPath::raw(object.key.expect("object doesn't exist without a key"));
                 let last_modified = match object.last_modified {
-                    Some(lm) => {
-                        DateTime::parse_from_rfc3339(&lm)
-                            .unwrap()
-                            .with_timezone(&Utc)
-                        // match dt {
-                        //     Err(err) => return
-                        // Err(Error::UnableToParseLastModifiedTime{value: lm,
-                        // err})     Ok(dt) =>
-                        // dt.with_timezone(&Utc), }
-                    }
+                    Some(lm) => DateTime::parse_from_rfc3339(&lm)
+                        .context(UnableToParseLastModified {
+                            bucket: &self.bucket_name,
+                        })?
+                        .with_timezone(&Utc),
                     None => Utc::now(),
                 };
                 let size = usize::try_from(object.size.unwrap_or(0))
                     .expect("unsupported size on this platform");
 
-                ObjectMeta {
+                Ok(ObjectMeta {
                     location,
                     last_modified,
                     size,
-                }
+                })
             })
-            .collect();
+            .collect::<Result<Vec<_>>>()?;
 
         let common_prefixes = resp
             .common_prefixes


### PR DESCRIPTION
Removes an `unwrap` we saw while doing other things. Also use `.context` in a few missing places.