### PR TITLE
chore: Cleaning things in prep for rust 2021

### DIFF
--- a/influxdb_iox_client/src/client.rs
+++ b/influxdb_iox_client/src/client.rs
@@ -120,7 +120,7 @@ impl Client {
         #[derive(serde::Serialize)]
         struct WriterIdBody {
             id: u32,
-        };
+        }
 
         let r = self
             .http

--- a/influxdb_tsm/src/key.rs
+++ b/influxdb_tsm/src/key.rs
@@ -178,7 +178,7 @@ fn parse_tsm_field_key_value(rem_key: impl Iterator<Item = u8>) -> Result<String
         Key2,   // saw #!
         Key3,   // saw #!~
         Done,
-    };
+    }
 
     let mut field_name = String::with_capacity(100);
     let mut state = State::Data;
@@ -231,7 +231,7 @@ fn parse_tsm_field_key_value(rem_key: impl Iterator<Item = u8>) -> Result<String
                 }
             }
         }
-    };
+    }
 
     // loop over input byte by byte and once we are at the end of the field key,
     // consume the rest of the key stream (ignoring all remaining characters)
@@ -316,7 +316,7 @@ fn parse_tsm_tag_key(rem_key: impl Iterator<Item = u8>) -> Result<KeyType, DataE
         Measurement,
         Field,
         Escape,
-    };
+    }
 
     let mut state = State::Data;
     let mut key = String::with_capacity(250);
@@ -402,7 +402,7 @@ fn parse_tsm_tag_value(
         Start,
         Data,
         Escape,
-    };
+    }
 
     let mut state = State::Start;
     let mut tag_value = String::with_capacity(100);
@@ -668,8 +668,9 @@ mod tests {
         // expect that a representation of the actual TSM key is in the error message
         assert!(
             err_str.contains(
-                "Error while parsing tsm tag key '1234567887654321, =m,tag1=val1,tag2=val2':"
+                "Error while parsing tsm tag key '1234567887654321,\x00=m,tag1=val1,tag2=val2':"
             ),
+            "{}",
             err_str
         );
     }
@@ -684,6 +685,7 @@ mod tests {
             .to_string();
         assert!(
             err_str.contains("No field key (expected to find in tag field \\xff)"),
+            "{}",
             err_str
         );
     }

--- a/influxdb_tsm/src/reader.rs
+++ b/influxdb_tsm/src/reader.rs
@@ -732,10 +732,8 @@ mod tests {
 
                     assert!(
                         e.parse_key().is_ok(),
-                        format!(
-                            "failed to parse key name for {:}",
-                            String::from_utf8_lossy(entry.key.as_slice())
-                        )
+                        "failed to parse key name for {:}",
+                        String::from_utf8_lossy(entry.key.as_slice())
                     );
                 }
                 Err(e) => panic!("{:?} {:?}", e, got_blocks),

--- a/mutable_buffer/src/database.rs
+++ b/mutable_buffer/src/database.rs
@@ -1035,7 +1035,7 @@ mod tests {
             description: &'a str,
             predicate: Predicate,
             expected_tag_keys: Result<Vec<&'a str>>,
-        };
+        }
 
         let test_cases = vec![
             TestCase {
@@ -1194,7 +1194,7 @@ mod tests {
             column_name: &'a str,
             predicate: Predicate,
             expected_column_values: Result<Vec<&'a str>>,
-        };
+        }
 
         let test_cases = vec![
             TestCase {

--- a/read_buffer/src/column.rs
+++ b/read_buffer/src/column.rs
@@ -147,11 +147,9 @@ impl Column {
     pub fn value(&self, row_id: u32) -> Value<'_> {
         assert!(
             row_id < self.num_rows(),
-            format!(
-                "cannot read row {:?} from column with {:?} rows",
-                row_id,
-                self.num_rows()
-            )
+            "cannot read row {:?} from column with {:?} rows",
+            row_id,
+            self.num_rows()
         );
 
         match &self {
@@ -168,11 +166,9 @@ impl Column {
     pub fn values(&self, row_ids: &[u32]) -> Values<'_> {
         assert!(
             row_ids.len() as u32 <= self.num_rows(),
-            format!(
-                "too many row ids {:?} provided for column with {:?} rows",
-                row_ids.len(),
-                self.num_rows()
-            )
+            "too many row ids {:?} provided for column with {:?} rows",
+            row_ids.len(),
+            self.num_rows()
         );
 
         match &self {
@@ -210,11 +206,9 @@ impl Column {
     pub fn distinct_values(&self, row_ids: &[u32]) -> ValueSet<'_> {
         assert!(
             row_ids.len() as u32 <= self.num_rows(),
-            format!(
-                "too many row ids {:?} provided for column with {:?} rows",
-                row_ids.len(),
-                self.num_rows()
-            )
+            "too many row ids {:?} provided for column with {:?} rows",
+            row_ids.len(),
+            self.num_rows()
         );
 
         match &self {
@@ -232,11 +226,9 @@ impl Column {
     pub fn encoded_values(&self, row_ids: &[u32], dst: EncodedValues) -> EncodedValues {
         assert!(
             row_ids.len() as u32 <= self.num_rows(),
-            format!(
-                "too many row ids {:?} provided for column with {:?} rows",
-                row_ids.len(),
-                self.num_rows()
-            )
+            "too many row ids {:?} provided for column with {:?} rows",
+            row_ids.len(),
+            self.num_rows()
         );
 
         match &self {

--- a/src/commands/input.rs
+++ b/src/commands/input.rs
@@ -273,7 +273,7 @@ impl InputPath {
         struct PathAndType {
             path: PathBuf,
             file_type: fs::FileType,
-        };
+        }
 
         let mut paths = VecDeque::new();
         let root_path = root_path.into();

--- a/src/influxdb_ioxd/http.rs
+++ b/src/influxdb_ioxd/http.rs
@@ -608,7 +608,7 @@ async fn set_writer<M: ConnectionManager + Send + Sync + Debug + 'static>(
     #[derive(Serialize, Deserialize)]
     struct WriterIdBody {
         id: u32,
-    };
+    }
     let req: WriterIdBody = serde_json::from_slice(body.as_ref()).context(InvalidRequestBody)?;
 
     // Set the writer ID


### PR DESCRIPTION
I tried to build with nightly-2021-02-12 and noticed a few things causing warnings.

I'd propose switching to `nightly-2021-02-12` in a separate PR, but these fixes still apply with the current version recorded in rust-toolchain. Although the current toolchain will not report warnings of new occurrences of these constructs, it's still a good idea to cleanup the code base, since often one takes pieces of existing code as inspiration for new code (if not straight copy&paste).

Also removed a literal NUL byte in a string literal and replaced with `\x00`; some editors drop NUL bytes when saving files.

- [x] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb_iox/blob/main/README.md).
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
