### PR TITLE
ci: Remove cargo build stage

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -3,8 +3,7 @@
 #
 # All pushes and PRs (including from forks) run:
 #
-#   - cargo build with the default cargo profile ("dev")
-#   - cargo test
+#   - cargo test with the default cargo profile ("dev") (also builds all)
 #   - cargo fmt
 #   - clippy (with warnings denied)
 #
@@ -20,31 +19,6 @@ on: [pull_request]
 name: ci
 
 jobs:
-
-  build:
-    name: Build
-    runs-on: ubuntu-latest
-    container:
-      image: quay.io/influxdb/rust:ci
-      # Run as the "root" user in the build container to fix workspace & cache
-      # permission errors.
-      options: --user root
-    steps:
-      # Checkout the code
-      - uses: actions/checkout@v2
-
-      # Enable caching of build artefacts
-      - uses: actions/cache@v2
-        with:
-          path: target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-
-      # Build!
-      - name: Run dev build
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --workspace
 
   test:
     name: Test


### PR DESCRIPTION
It's my understanding that `cargo test --workspace` builds all things `cargo build --workspace` would have built (and more).

Thus keeping a GH worker busy for 9m to duplicate work done in the `cargo test` job is waste of resources and potentially also slowing down parallel builds because of increased build queue pressure.

- [x] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb_iox/blob/main/README.md).
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
