### PR TITLE
ci: Add nightly-2021-02-12 to quay.io/influxdb/rust:ci

### DIFF
--- a/docker/Dockerfile.ci
+++ b/docker/Dockerfile.ci
@@ -52,7 +52,9 @@ RUN locale-gen C.UTF-8 || true
 ENV LANG=C.UTF-8
 
 RUN rustup toolchain install nightly-2020-11-19
+RUN rustup toolchain install nightly-2021-02-12
 RUN rustup component add rustfmt clippy --toolchain nightly-2020-11-19
+RUN rustup component add rustfmt clippy --toolchain nightly-2021-02-12
 
 RUN groupadd -g 1500 rust \
   && useradd -u 1500 -g rust -s /bin/bash -m rust \


### PR DESCRIPTION
#799 is blocked on quay.io/influxdb/rust:ci having nightly-2021-02-12

that image is build on circleci, so we first need to land this, wait until it gets pushed and try #799 again