### PR TITLE
refactor: introduce clone_on_ref_ptr clippy lint

### DIFF
--- a/arrow_deps/src/lib.rs
+++ b/arrow_deps/src/lib.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::clone_on_ref_ptr)]
+
 //! This crate exists to add a dependency on (likely as yet
 //! unpublished) versions of arrow / parquet / datafusion so we can
 //! manage the version used by InfluxDB IOx in a single crate.

--- a/data_types/src/lib.rs
+++ b/data_types/src/lib.rs
@@ -6,7 +6,8 @@
 #![warn(
     missing_debug_implementations,
     clippy::explicit_iter_loop,
-    clippy::use_self
+    clippy::use_self,
+    clippy::clone_on_ref_ptr
 )]
 
 pub use schema::TIME_COLUMN_NAME;

--- a/data_types/src/schema.rs
+++ b/data_types/src/schema.rs
@@ -194,7 +194,7 @@ impl Schema {
 
     /// Return a valid Arrow `SchemaRef` representing this `Schema`
     pub fn as_arrow(&self) -> ArrowSchemaRef {
-        self.inner.clone()
+        Arc::clone(&self.inner)
     }
 
     /// Create and validate a new Schema, creating metadata to
@@ -637,7 +637,7 @@ mod test {
         ]));
 
         // Given a schema created from arrow record batch with no metadata
-        let schema: Schema = arrow_schema.clone().try_into().unwrap();
+        let schema: Schema = Arc::clone(&arrow_schema).try_into().unwrap();
         assert_eq!(schema.len(), 2);
 
         // It still works, but has no lp column types

--- a/generated_types/src/lib.rs
+++ b/generated_types/src/lib.rs
@@ -5,7 +5,8 @@
     unused_imports,
     clippy::redundant_static_lifetimes,
     clippy::redundant_closure,
-    clippy::redundant_field_names
+    clippy::redundant_field_names,
+    clippy::clone_on_ref_ptr
 )]
 
 include!(concat!(env!("OUT_DIR"), "/influxdata.platform.storage.rs"));

--- a/google_types/src/lib.rs
+++ b/google_types/src/lib.rs
@@ -5,7 +5,8 @@
     unused_imports,
     clippy::redundant_static_lifetimes,
     clippy::redundant_closure,
-    clippy::redundant_field_names
+    clippy::redundant_field_names,
+    clippy::clone_on_ref_ptr
 )]
 
 mod pb {

--- a/influxdb2_client/src/lib.rs
+++ b/influxdb2_client/src/lib.rs
@@ -4,7 +4,8 @@
     missing_debug_implementations,
     missing_docs,
     clippy::explicit_iter_loop,
-    clippy::use_self
+    clippy::use_self,
+    clippy::clone_on_ref_ptr
 )]
 
 //! # influxdb2_client

--- a/influxdb_iox_client/src/client/flight.rs
+++ b/influxdb_iox_client/src/client/flight.rs
@@ -152,7 +152,7 @@ impl PerformQuery {
 
         Ok(Some(flight_data_to_arrow_batch(
             &data,
-            schema.clone(),
+            Arc::clone(&schema),
             &dictionaries_by_field,
         )?))
     }

--- a/influxdb_iox_client/src/lib.rs
+++ b/influxdb_iox_client/src/lib.rs
@@ -1,6 +1,11 @@
 //! An InfluxDB IOx API client.
 #![deny(rust_2018_idioms, missing_debug_implementations, unreachable_pub)]
-#![warn(missing_docs, clippy::todo, clippy::dbg_macro)]
+#![warn(
+    missing_docs,
+    clippy::todo,
+    clippy::dbg_macro,
+    clippy::clone_on_ref_ptr
+)]
 #![allow(clippy::missing_docs_in_private_items)]
 
 mod builder;

--- a/influxdb_line_protocol/src/lib.rs
+++ b/influxdb_line_protocol/src/lib.rs
@@ -12,7 +12,8 @@
     missing_copy_implementations,
     missing_debug_implementations,
     clippy::explicit_iter_loop,
-    clippy::use_self
+    clippy::use_self,
+    clippy::clone_on_ref_ptr
 )]
 
 use fmt::Display;

--- a/influxdb_tsm/src/lib.rs
+++ b/influxdb_tsm/src/lib.rs
@@ -3,7 +3,8 @@
     missing_copy_implementations,
     missing_debug_implementations,
     clippy::explicit_iter_loop,
-    clippy::use_self
+    clippy::use_self,
+    clippy::clone_on_ref_ptr
 )]
 
 pub mod encoders;

--- a/ingest/src/lib.rs
+++ b/ingest/src/lib.rs
@@ -7,7 +7,8 @@
     missing_copy_implementations,
     missing_debug_implementations,
     clippy::explicit_iter_loop,
-    clippy::use_self
+    clippy::use_self,
+    clippy::clone_on_ref_ptr
 )]
 
 use data_types::{
@@ -1211,7 +1212,7 @@ mod tests {
                 format!("Created writer for measurement {}", measurement_name),
             );
             Ok(Box::new(NoOpWriter::new(
-                self.log.clone(),
+                Arc::clone(&self.log),
                 measurement_name.to_string(),
             )))
         }
@@ -1443,7 +1444,7 @@ mod tests {
     #[test]
     fn measurement_writer_buffering() -> Result<(), Error> {
         let log = Arc::new(Mutex::new(WriterLog::new()));
-        let table_writer = Box::new(NoOpWriter::new(log.clone(), String::from("cpu")));
+        let table_writer = Box::new(NoOpWriter::new(Arc::clone(&log), String::from("cpu")));
 
         let schema = InfluxSchemaBuilder::new()
             .saw_measurement("cpu")
@@ -1682,7 +1683,7 @@ mod tests {
 
         let settings = ConversionSettings::default();
         let mut converter =
-            LineProtocolConverter::new(settings, NoOpWriterSource::new(log.clone()));
+            LineProtocolConverter::new(settings, NoOpWriterSource::new(Arc::clone(&log)));
         converter
             .convert(parsed_lines)
             .expect("conversion ok")
@@ -1718,7 +1719,7 @@ mod tests {
         };
 
         let mut converter =
-            LineProtocolConverter::new(settings, NoOpWriterSource::new(log.clone()));
+            LineProtocolConverter::new(settings, NoOpWriterSource::new(Arc::clone(&log)));
 
         converter
             .convert(parsed_lines)
@@ -2072,7 +2073,7 @@ mod tests {
         decoder.read_to_end(&mut buf).unwrap();
 
         let log = Arc::new(Mutex::new(WriterLog::new()));
-        let mut converter = TSMFileConverter::new(NoOpWriterSource::new(log.clone()));
+        let mut converter = TSMFileConverter::new(NoOpWriterSource::new(Arc::clone(&log)));
         let index_steam = BufReader::new(Cursor::new(&buf));
         let block_stream = BufReader::new(Cursor::new(&buf));
         converter
@@ -2125,7 +2126,7 @@ mod tests {
         block_streams.push(BufReader::new(Cursor::new(&buf_b)));
 
         let log = Arc::new(Mutex::new(WriterLog::new()));
-        let mut converter = TSMFileConverter::new(NoOpWriterSource::new(log.clone()));
+        let mut converter = TSMFileConverter::new(NoOpWriterSource::new(Arc::clone(&log)));
 
         converter.convert(index_streams, block_streams).unwrap();
 

--- a/ingest/src/parquet/writer.rs
+++ b/ingest/src/parquet/writer.rs
@@ -148,10 +148,12 @@ where
         let writer_props = create_writer_props(&schema, compression_level);
         let parquet_schema = convert_to_parquet_schema(&schema)?;
 
-        let file_writer = SerializedFileWriter::new(writer, parquet_schema.clone(), writer_props)
-            .context(ParquetLibraryError {
-            message: String::from("Error trying to create a SerializedFileWriter"),
-        })?;
+        let file_writer =
+            SerializedFileWriter::new(writer, Arc::clone(&parquet_schema), writer_props).context(
+                ParquetLibraryError {
+                    message: String::from("Error trying to create a SerializedFileWriter"),
+                },
+            )?;
 
         let parquet_writer = Self {
             parquet_schema,

--- a/mutable_buffer/src/database.rs
+++ b/mutable_buffer/src/database.rs
@@ -415,10 +415,10 @@ impl MutableBufferDb {
         let mut partitions = self.partitions.write().expect("mutex poisoned");
 
         if let Some(partition) = partitions.get(partition_key) {
-            partition.clone()
+            Arc::clone(&partition)
         } else {
             let partition = Arc::new(RwLock::new(Partition::new(partition_key)));
-            partitions.insert(partition_key.to_string(), partition.clone());
+            partitions.insert(partition_key.to_string(), Arc::clone(&partition));
             partition
         }
     }

--- a/mutable_buffer/src/lib.rs
+++ b/mutable_buffer/src/lib.rs
@@ -53,7 +53,8 @@
     missing_copy_implementations,
     missing_debug_implementations,
     clippy::explicit_iter_loop,
-    clippy::use_self
+    clippy::use_self,
+    clippy::clone_on_ref_ptr
 )]
 
 pub mod chunk;

--- a/mutable_buffer/src/partition.rs
+++ b/mutable_buffer/src/partition.rs
@@ -119,7 +119,7 @@ impl Partition {
         let mut chunks: Vec<_> = self
             .closed_chunks
             .iter()
-            .map(|(_, chunk)| chunk.clone())
+            .map(|(_, chunk)| Arc::clone(&chunk))
             .collect::<Vec<_>>();
 
         chunks.push(self.open_chunk_snapshot());
@@ -131,7 +131,7 @@ impl Partition {
     /// subsequent writes.
     pub fn get_chunk(&self, chunk_id: u32) -> Result<Arc<Chunk>> {
         if let Some(chunk) = self.closed_chunks.get(&chunk_id) {
-            Ok(chunk.clone())
+            Ok(Arc::clone(&chunk))
         } else if chunk_id == self.open_chunk.id {
             Ok(self.open_chunk_snapshot())
         } else {
@@ -168,7 +168,7 @@ impl Partition {
         chunk.mark_closed();
         let chunk = Arc::new(chunk);
         if !chunk.is_empty() {
-            let existing_value = self.closed_chunks.insert(chunk.id(), chunk.clone());
+            let existing_value = self.closed_chunks.insert(chunk.id(), Arc::clone(&chunk));
             assert!(existing_value.is_none());
         }
         chunk

--- a/mutable_buffer/src/table.rs
+++ b/mutable_buffer/src/table.rs
@@ -1179,7 +1179,7 @@ fn reorder_prefix(
 
     let mut new_tag_columns = prefix_map
         .iter()
-        .map(|&i| tag_columns[i].clone())
+        .map(|&i| Arc::clone(&tag_columns[i]))
         .collect::<Vec<_>>();
 
     new_tag_columns.extend(tag_columns.into_iter().enumerate().filter_map(|(i, c)| {
@@ -1294,7 +1294,7 @@ impl AggExprs {
                     )?);
 
                     field_list.push((
-                        field_name.clone(), // value name
+                        Arc::clone(field_name), // value name
                         time_column_name,
                     ));
                 }

--- a/object_store/src/azure.rs
+++ b/object_store/src/azure.rs
@@ -100,7 +100,7 @@ impl ObjectStoreApi for MicrosoftAzure {
     }
 
     async fn get(&self, location: &Self::Path) -> Result<BoxStream<'static, Result<Bytes>>> {
-        let container_client = self.container_client.clone();
+        let container_client = Arc::clone(&self.container_client);
         let location = location.to_raw();
         Ok(async move {
             container_client
@@ -200,7 +200,7 @@ impl MicrosoftAzure {
         let http_client: Arc<Box<dyn HttpClient>> = Arc::new(Box::new(reqwest::Client::new()));
 
         let storage_account_client =
-            StorageAccountClient::new_access_key(http_client.clone(), &account, &master_key);
+            StorageAccountClient::new_access_key(Arc::clone(&http_client), &account, &master_key);
 
         let storage_client = storage_account_client.as_storage_client();
 

--- a/object_store/src/lib.rs
+++ b/object_store/src/lib.rs
@@ -4,7 +4,8 @@
     missing_debug_implementations,
     missing_docs,
     clippy::explicit_iter_loop,
-    clippy::use_self
+    clippy::use_self,
+    clippy::clone_on_ref_ptr
 )]
 
 //! # object_store

--- a/packers/src/lib.rs
+++ b/packers/src/lib.rs
@@ -3,7 +3,8 @@
     missing_copy_implementations,
     missing_debug_implementations,
     clippy::explicit_iter_loop,
-    clippy::use_self
+    clippy::use_self,
+    clippy::clone_on_ref_ptr
 )]
 
 pub mod packers;

--- a/panic_logging/src/lib.rs
+++ b/panic_logging/src/lib.rs
@@ -5,7 +5,8 @@
 #![warn(
     missing_debug_implementations,
     clippy::explicit_iter_loop,
-    clippy::use_self
+    clippy::use_self,
+    clippy::clone_on_ref_ptr
 )]
 
 use std::{fmt, panic, sync::Arc};
@@ -32,7 +33,7 @@ pub struct SendPanicsToTracing {
 impl SendPanicsToTracing {
     pub fn new() -> Self {
         let current_panic_hook: PanicFunctionPtr = Arc::new(panic::take_hook());
-        let old_panic_hook = Some(current_panic_hook.clone());
+        let old_panic_hook = Some(Arc::clone(&current_panic_hook));
         panic::set_hook(Box::new(move |info| {
             tracing_panic_hook(&current_panic_hook, info)
         }));

--- a/query/src/exec/context.rs
+++ b/query/src/exec/context.rs
@@ -63,7 +63,7 @@ impl ExtensionPlanner for IOxExtensionPlanner {
             .map(|schema_pivot| {
                 assert_eq!(inputs.len(), 1, "Inconsistent number of inputs");
                 let execution_plan = Arc::new(SchemaPivotExec::new(
-                    inputs[0].clone(),
+                    Arc::clone(&inputs[0]),
                     schema_pivot.schema().as_ref().clone().into(),
                 ));
                 Ok(execution_plan as _)

--- a/query/src/exec/schema_pivot.rs
+++ b/query/src/exec/schema_pivot.rs
@@ -164,7 +164,7 @@ impl ExecutionPlan for SchemaPivotExec {
     }
 
     fn schema(&self) -> SchemaRef {
-        self.schema.clone()
+        Arc::clone(&self.schema)
     }
 
     fn output_partitioning(&self) -> Partitioning {
@@ -176,7 +176,7 @@ impl ExecutionPlan for SchemaPivotExec {
     }
 
     fn children(&self) -> Vec<Arc<dyn ExecutionPlan>> {
-        vec![self.input.clone()]
+        vec![Arc::clone(&self.input)]
     }
 
     fn with_new_children(
@@ -185,8 +185,8 @@ impl ExecutionPlan for SchemaPivotExec {
     ) -> Result<Arc<dyn ExecutionPlan>> {
         match children.len() {
             1 => Ok(Arc::new(Self {
-                input: children[0].clone(),
-                schema: self.schema.clone(),
+                input: Arc::clone(&children[0]),
+                schema: Arc::clone(&self.schema),
             })),
             _ => Err(DataFusionError::Internal(
                 "SchemaPivotExec wrong number of children".to_string(),
@@ -512,7 +512,7 @@ mod tests {
                 .map(|test_batch| {
                     let a_vec = test_batch.a.iter().copied().collect::<Vec<_>>();
                     RecordBatch::try_new(
-                        schema.clone(),
+                        Arc::clone(&schema),
                         vec![
                             Arc::new(Int64Array::from(a_vec)),
                             to_string_array(test_batch.b),

--- a/query/src/exec/seriesset.rs
+++ b/query/src/exec/seriesset.rs
@@ -234,7 +234,7 @@ impl SeriesSetConverter {
                 .iter()
                 .map(|end_row| {
                     let series_set = SeriesSet {
-                        table_name: table_name.clone(),
+                        table_name: Arc::clone(&table_name),
                         tags: Self::get_tag_keys(
                             &batch,
                             start_row as usize,
@@ -336,7 +336,7 @@ impl SeriesSetConverter {
                     .expect("Tag column was a String")
                     .value(row)
                     .into();
-                (column_name.clone(), Arc::new(tag_value))
+                (Arc::clone(&column_name), Arc::new(tag_value))
             })
             .collect()
     }
@@ -917,7 +917,7 @@ mod tests {
     }
 
     fn parse_to_iterator(schema: SchemaRef, data: &str) -> SendableRecordBatchStream {
-        let batch = parse_to_record_batch(schema.clone(), data);
+        let batch = parse_to_record_batch(Arc::clone(&schema), data);
         Box::pin(SizedRecordBatchStream::new(schema, vec![Arc::new(batch)]))
     }
 }

--- a/query/src/exec/stringset.rs
+++ b/query/src/exec/stringset.rs
@@ -66,7 +66,7 @@ impl IntoStringSet for Vec<RecordBatch> {
             ensure!(
                 fields.len() == 1,
                 InternalSchemaWasNotString {
-                    schema: schema.clone(),
+                    schema: Arc::clone(&schema),
                 }
             );
 
@@ -75,7 +75,7 @@ impl IntoStringSet for Vec<RecordBatch> {
             ensure!(
                 field.data_type() == &DataType::Utf8,
                 InternalSchemaWasNotString {
-                    schema: schema.clone(),
+                    schema: Arc::clone(&schema),
                 }
             );
 

--- a/query/src/lib.rs
+++ b/query/src/lib.rs
@@ -2,7 +2,8 @@
 #![warn(
     missing_debug_implementations,
     clippy::explicit_iter_loop,
-    clippy::use_self
+    clippy::use_self,
+    clippy::clone_on_ref_ptr
 )]
 
 use arrow_deps::datafusion::physical_plan::SendableRecordBatchStream;

--- a/query/src/provider.rs
+++ b/query/src/provider.rs
@@ -80,7 +80,7 @@ where
     fn clone(&self) -> Self {
         Self {
             chunk_table_schema: self.chunk_table_schema.clone(),
-            chunk: self.chunk.clone(),
+            chunk: Arc::clone(&self.chunk),
         }
     }
 }
@@ -207,7 +207,7 @@ impl<C: PartitionChunk + 'static> TableProvider for ChunkTableProvider<C> {
         let scan_schema = project_schema(self.arrow_schema(), projection);
 
         let plan = IOxReadFilterNode::new(
-            self.table_name.clone(),
+            Arc::clone(&self.table_name),
             scan_schema,
             self.chunk_and_infos.clone(),
             predicate,

--- a/query/src/provider/physical.rs
+++ b/query/src/provider/physical.rs
@@ -51,7 +51,7 @@ impl<C: PartitionChunk + 'static> ExecutionPlan for IOxReadFilterNode<C> {
     }
 
     fn schema(&self) -> SchemaRef {
-        self.schema.clone()
+        Arc::clone(&self.schema)
     }
 
     fn output_partitioning(&self) -> Partitioning {
@@ -72,8 +72,8 @@ impl<C: PartitionChunk + 'static> ExecutionPlan for IOxReadFilterNode<C> {
         // For some reason when I used an automatically derived `Clone` implementation
         // the compiler didn't recognize the trait implementation
         let new_self = Self {
-            table_name: self.table_name.clone(),
-            schema: self.schema.clone(),
+            table_name: Arc::clone(&self.table_name),
+            schema: Arc::clone(&self.schema),
             chunk_and_infos: self.chunk_and_infos.clone(),
             predicate: self.predicate.clone(),
         };
@@ -114,7 +114,7 @@ impl<C: PartitionChunk + 'static> ExecutionPlan for IOxReadFilterNode<C> {
                 ))
             })?;
 
-        let adapter = SchemaAdapterStream::try_new(stream, self.schema.clone())
+        let adapter = SchemaAdapterStream::try_new(stream, Arc::clone(&self.schema))
             .map_err(|e| DataFusionError::Internal(e.to_string()))?;
 
         Ok(Box::pin(adapter))

--- a/query/src/test.rs
+++ b/query/src/test.rs
@@ -187,13 +187,14 @@ impl TestDatabase {
         let column_names = column_names.into_iter().collect::<StringSet>();
         let column_names = Arc::new(column_names);
 
-        *(self.column_names.clone().lock().expect("mutex poisoned")) = Some(column_names)
+        *(Arc::clone(&self.column_names)
+            .lock()
+            .expect("mutex poisoned")) = Some(column_names)
     }
 
     /// Get the parameters from the last column name request
     pub fn get_column_names_request(&self) -> Option<ColumnNamesRequest> {
-        self.column_names_request
-            .clone()
+        Arc::clone(&self.column_names_request)
             .lock()
             .expect("mutex poisoned")
             .take()
@@ -205,13 +206,14 @@ impl TestDatabase {
         let column_values = column_values.into_iter().collect::<StringSet>();
         let column_values = Arc::new(column_values);
 
-        *(self.column_values.clone().lock().expect("mutex poisoned")) = Some(column_values)
+        *(Arc::clone(&self.column_values)
+            .lock()
+            .expect("mutex poisoned")) = Some(column_values)
     }
 
     /// Get the parameters from the last column name request
     pub fn get_column_values_request(&self) -> Option<ColumnValuesRequest> {
-        self.column_values_request
-            .clone()
+        Arc::clone(&self.column_values_request)
             .lock()
             .expect("mutex poisoned")
             .take()
@@ -219,17 +221,14 @@ impl TestDatabase {
 
     /// Set the series that will be returned on a call to query_series
     pub fn set_query_series_values(&self, plan: SeriesSetPlans) {
-        *(self
-            .query_series_values
-            .clone()
+        *(Arc::clone(&self.query_series_values)
             .lock()
             .expect("mutex poisoned")) = Some(plan);
     }
 
     /// Get the parameters from the last column name request
     pub fn get_query_series_request(&self) -> Option<QuerySeriesRequest> {
-        self.query_series_request
-            .clone()
+        Arc::clone(&self.query_series_request)
             .lock()
             .expect("mutex poisoned")
             .take()
@@ -237,17 +236,14 @@ impl TestDatabase {
 
     /// Set the series that will be returned on a call to query_groups
     pub fn set_query_groups_values(&self, plan: SeriesSetPlans) {
-        *(self
-            .query_groups_values
-            .clone()
+        *(Arc::clone(&self.query_groups_values)
             .lock()
             .expect("mutex poisoned")) = Some(plan);
     }
 
     /// Get the parameters from the last column name request
     pub fn get_query_groups_request(&self) -> Option<QueryGroupsRequest> {
-        self.query_groups_request
-            .clone()
+        Arc::clone(&self.query_groups_request)
             .lock()
             .expect("mutex poisoned")
             .take()
@@ -255,17 +251,14 @@ impl TestDatabase {
 
     /// Set the FieldSet plan that will be returned
     pub fn set_field_colum_names_values(&self, plan: FieldListPlan) {
-        *(self
-            .field_columns_value
-            .clone()
+        *(Arc::clone(&self.field_columns_value)
             .lock()
             .expect("mutex poisoned")) = Some(plan);
     }
 
     /// Get the parameters from the last column name request
     pub fn get_field_columns_request(&self) -> Option<FieldColumnsRequest> {
-        self.field_columns_request
-            .clone()
+        Arc::clone(&self.field_columns_request)
             .lock()
             .expect("mutex poisoned")
             .take()
@@ -336,16 +329,12 @@ impl Database for TestDatabase {
 
         let new_column_names_request = Some(ColumnNamesRequest { predicate });
 
-        *self
-            .column_names_request
-            .clone()
+        *Arc::clone(&self.column_names_request)
             .lock()
             .expect("mutex poisoned") = new_column_names_request;
 
         // pull out the saved columns
-        let column_names = self
-            .column_names
-            .clone()
+        let column_names = Arc::clone(&self.column_names)
             .lock()
             .expect("mutex poisoned")
             .take()
@@ -363,15 +352,12 @@ impl Database for TestDatabase {
 
         let field_columns_request = Some(FieldColumnsRequest { predicate });
 
-        *self
-            .field_columns_request
-            .clone()
+        *Arc::clone(&self.field_columns_request)
             .lock()
             .expect("mutex poisoned") = field_columns_request;
 
         // pull out the saved columns
-        self.field_columns_value
-            .clone()
+        Arc::clone(&self.field_columns_value)
             .lock()
             .expect("mutex poisoned")
             .take()
@@ -395,16 +381,12 @@ impl Database for TestDatabase {
             predicate,
         });
 
-        *self
-            .column_values_request
-            .clone()
+        *Arc::clone(&self.column_values_request)
             .lock()
             .expect("mutex poisoned") = new_column_values_request;
 
         // pull out the saved columns
-        let column_values = self
-            .column_values
-            .clone()
+        let column_values = Arc::clone(&self.column_values)
             .lock()
             .expect("mutex poisoned")
             .take()
@@ -421,14 +403,11 @@ impl Database for TestDatabase {
 
         let new_queries_series_request = Some(QuerySeriesRequest { predicate });
 
-        *self
-            .query_series_request
-            .clone()
+        *Arc::clone(&self.query_series_request)
             .lock()
             .expect("mutex poisoned") = new_queries_series_request;
 
-        self.query_series_values
-            .clone()
+        Arc::clone(&self.query_series_values)
             .lock()
             .expect("mutex poisoned")
             .take()
@@ -447,14 +426,11 @@ impl Database for TestDatabase {
 
         let new_queries_groups_request = Some(QueryGroupsRequest { predicate, gby_agg });
 
-        *self
-            .query_groups_request
-            .clone()
+        *Arc::clone(&self.query_groups_request)
             .lock()
             .expect("mutex poisoned") = new_queries_groups_request;
 
-        self.query_groups_values
-            .clone()
+        Arc::clone(&self.query_groups_values)
             .lock()
             .expect("mutex poisoned")
             .take()
@@ -622,16 +598,16 @@ impl DatabaseStore for TestDatabaseStore {
         let mut databases = self.databases.lock().expect("mutex poisoned");
 
         if let Some(db) = databases.get(name) {
-            Ok(db.clone())
+            Ok(Arc::clone(&db))
         } else {
             let new_db = Arc::new(TestDatabase::new());
-            databases.insert(name.to_string(), new_db.clone());
+            databases.insert(name.to_string(), Arc::clone(&new_db));
             Ok(new_db)
         }
     }
 
     fn executor(&self) -> Arc<Executor> {
-        self.executor.clone()
+        Arc::clone(&self.executor)
     }
 }
 

--- a/read_buffer/src/lib.rs
+++ b/read_buffer/src/lib.rs
@@ -2,6 +2,7 @@
 #![allow(dead_code)]
 #![allow(clippy::too_many_arguments)]
 #![allow(unused_variables)]
+#![warn(clippy::clone_on_ref_ptr)]
 pub(crate) mod chunk;
 pub(crate) mod column;
 pub(crate) mod row_group;

--- a/src/influxdb_ioxd.rs
+++ b/src/influxdb_ioxd.rs
@@ -135,13 +135,13 @@ pub async fn main(logging_level: LoggingLevel, config: Option<Config>) -> Result
         .await
         .context(StartListeningGrpc { grpc_bind_addr })?;
 
-    let grpc_server = self::rpc::make_server(socket, app_server.clone());
+    let grpc_server = self::rpc::make_server(socket, Arc::clone(&app_server));
 
     info!(bind_address=?grpc_bind_addr, "gRPC server listening");
 
     // Construct and start up HTTP server
 
-    let router_service = http::router_service(app_server.clone());
+    let router_service = http::router_service(Arc::clone(&app_server));
 
     let bind_addr = config.http_bind_address;
     let http_server = Server::try_bind(&bind_addr)

--- a/src/influxdb_ioxd/flight.rs
+++ b/src/influxdb_ioxd/flight.rs
@@ -13,7 +13,7 @@ use futures::Stream;
 use query::{frontend::sql::SQLQueryPlanner, DatabaseStore};
 use serde::Deserialize;
 use snafu::{OptionExt, ResultExt, Snafu};
-use std::pin::Pin;
+use std::{pin::Pin, sync::Arc};
 use tonic::{Request, Response, Streaming};
 use tracing::error;
 
@@ -137,7 +137,7 @@ where
             })?;
 
         // execute the query
-        let results = collect(physical_plan.clone())
+        let results = collect(Arc::clone(&physical_plan))
             .await
             .map_err(|e| Box::new(e) as _)
             .context(Query {

--- a/src/influxdb_ioxd/rpc.rs
+++ b/src/influxdb_ioxd/rpc.rs
@@ -42,8 +42,10 @@ where
     let stream = TcpListenerStream::new(socket);
 
     tonic::transport::Server::builder()
-        .add_service(IOxTestingServer::new(GrpcService::new(storage.clone())))
-        .add_service(StorageServer::new(GrpcService::new(storage.clone())))
+        .add_service(IOxTestingServer::new(GrpcService::new(Arc::clone(
+            &storage,
+        ))))
+        .add_service(StorageServer::new(GrpcService::new(Arc::clone(&storage))))
         .add_service(FlightServiceServer::new(GrpcService::new(storage)))
         .serve_with_incoming(stream)
         .await

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,8 @@
 #![warn(
     missing_debug_implementations,
     clippy::explicit_iter_loop,
-    clippy::use_self
+    clippy::use_self,
+    clippy::clone_on_ref_ptr
 )]
 
 use clap::{crate_authors, crate_version, value_t, App, Arg, ArgMatches, SubCommand};

--- a/test_helpers/src/lib.rs
+++ b/test_helpers/src/lib.rs
@@ -3,7 +3,8 @@
     missing_copy_implementations,
     missing_debug_implementations,
     clippy::explicit_iter_loop,
-    clippy::use_self
+    clippy::use_self,
+    clippy::clone_on_ref_ptr
 )]
 
 use std::{

--- a/test_helpers/src/tracing.rs
+++ b/test_helpers/src/tracing.rs
@@ -30,7 +30,9 @@ impl TracingCapture {
         let logs = Arc::new(Mutex::new(Vec::new()));
 
         // Register a subscriber to actually capture the log messages
-        let my_subscriber = TracingCaptureSubscriber { logs: logs.clone() };
+        let my_subscriber = TracingCaptureSubscriber {
+            logs: Arc::clone(&logs),
+        };
 
         // install the subscriber (is uninstalled when the guard is dropped)
         let guard = tracing::subscriber::set_default(my_subscriber);

--- a/wal/src/lib.rs
+++ b/wal/src/lib.rs
@@ -3,7 +3,8 @@
     missing_copy_implementations,
     missing_debug_implementations,
     clippy::explicit_iter_loop,
-    clippy::use_self
+    clippy::use_self,
+    clippy::clone_on_ref_ptr
 )]
 
 //! # wal


### PR DESCRIPTION
This PR proposes that we introduce the `clone_on_ref_ptr` clippy lint as a warning on all crates.

Personally I do not like using `.clone()` on an `Arc` or `Rc` because it puts the burden on the reader to understand that the type of object being cloned is a smart pointer.

I was recently made aware that there is a `clippy` lint that enforces this, and I would like to add that to IOx.

Here is what the Rust docs say about this topic too:

https://doc.rust-lang.org/std/rc/index.html#cloning-references

> The `Rc::clone(&from)` syntax is the most idiomatic because it conveys more explicitly the meaning of the code. In the example above, this syntax makes it easier to see that this code is creating a new reference rather than copying the whole content of foo.

And here is the clippy lint:

https://rust-lang.github.io/rust-clippy/master/#clone_on_ref_ptr

> Calling ‘.clone()’ on an Rc, Arc, or Weak can obscure the fact that only the pointer is being cloned, not the underlying data.
