### PR TITLE
feat: implement field_columns plan

### DIFF
--- a/query/src/frontend/influxrpc.rs
+++ b/query/src/frontend/influxrpc.rs
@@ -5,7 +5,7 @@ use std::{
 
 use arrow_deps::datafusion::{
     error::{DataFusionError, Result as DatafusionResult},
-    logical_plan::{Expr, ExpressionVisitor, LogicalPlanBuilder, Operator, Recursion},
+    logical_plan::{Expr, ExpressionVisitor, LogicalPlan, LogicalPlanBuilder, Operator, Recursion},
     prelude::col,
 };
 use data_types::{
@@ -17,7 +17,10 @@ use tracing::debug;
 
 use crate::{
     exec::{make_schema_pivot, stringset::StringSet},
-    plan::stringset::{Error as StringSetError, StringSetPlan, StringSetPlanBuilder},
+    plan::{
+        fieldlist::FieldListPlan,
+        stringset::{Error as StringSetError, StringSetPlan, StringSetPlanBuilder},
+    },
     predicate::{Predicate, PredicateBuilder},
     provider::ProviderBuilder,
     util::schema_has_all_expr_columns,
@@ -188,40 +191,10 @@ impl InfluxRPCPlanner {
         // entirely using the metadata
         let mut need_full_plans = BTreeMap::new();
 
-        let no_tables = StringSet::new();
         let mut known_columns = BTreeSet::new();
         for chunk in self.filtered_chunks(database, &predicate).await? {
             // try and get the table names that have rows that match the predicate
-            let table_names = chunk
-                .table_names(&predicate, &no_tables)
-                .await
-                .map_err(|e| Box::new(e) as _)
-                .context(TableNamePlan)?;
-
-            debug!(table_names=?table_names, chunk_id = chunk.id(), "chunk tables");
-
-            let table_names = match table_names {
-                Some(table_names) => {
-                    debug!("found table names with original predicate");
-                    table_names
-                }
-                None => {
-                    // couldn't find table names with predicate, get all chunk tables,
-                    // fall back to filtering ourself
-                    let table_name_predicate = if let Some(table_names) = &predicate.table_names {
-                        PredicateBuilder::new().tables(table_names).build()
-                    } else {
-                        Predicate::default()
-                    };
-                    chunk
-                        .table_names(&table_name_predicate, &no_tables)
-                        .await
-                        .map_err(|e| Box::new(e) as _)
-                        .context(InternalTableNamePlanForDefault)?
-                        // unwrap the Option
-                        .context(InternalTableNameCannotGetPlanForDefault)?
-                }
-            };
+            let table_names = self.chunk_table_names(chunk.as_ref(), &predicate).await?;
 
             for table_name in table_names {
                 debug!(
@@ -296,6 +269,97 @@ impl InfluxRPCPlanner {
             .context(CreatingStringSet)
     }
 
+    /// Returns a plan that produces a list of columns and their
+    /// datatypes (as defined in the data written via `write_lines`),
+    /// and which have more than zero rows which pass the conditions
+    /// specified by `predicate`.
+    pub async fn field_columns<D>(
+        &self,
+        database: &D,
+        predicate: Predicate,
+    ) -> Result<FieldListPlan>
+    where
+        D: Database + 'static,
+    {
+        debug!(predicate=?predicate, "planning field_columns");
+
+        // Algorithm is to run a "select field_cols from table where
+        // <predicate> type plan for each table in the chunks"
+        //
+        // The executor then figures out which columns have non-null
+        // values and stops the plan executing once it has them
+
+        // map table -> Vec<Arc<Chunk>>
+        let mut table_chunks = BTreeMap::new();
+        let chunks = self.filtered_chunks(database, &predicate).await?;
+        for chunk in chunks {
+            let table_names = self.chunk_table_names(chunk.as_ref(), &predicate).await?;
+            for table_name in table_names {
+                table_chunks
+                    .entry(table_name)
+                    .or_insert_with(Vec::new)
+                    .push(Arc::clone(&chunk));
+            }
+        }
+
+        let mut field_list_plan = FieldListPlan::new();
+        for (table_name, chunks) in table_chunks {
+            if let Some(plan) = self
+                .field_columns_plan(&table_name, &predicate, chunks)
+                .await?
+            {
+                field_list_plan = field_list_plan.append(plan);
+            }
+        }
+
+        Ok(field_list_plan)
+    }
+
+    /// Find all the table names in the specified chunk that pass the predicate
+    async fn chunk_table_names<C>(
+        &self,
+        chunk: &C,
+        predicate: &Predicate,
+    ) -> Result<BTreeSet<String>>
+    where
+        C: PartitionChunk + 'static,
+    {
+        let no_tables = StringSet::new();
+
+        // try and get the table names that have rows that match the predicate
+        let table_names = chunk
+            .table_names(&predicate, &no_tables)
+            .await
+            .map_err(|e| Box::new(e) as _)
+            .context(TableNamePlan)?;
+
+        debug!(table_names=?table_names, chunk_id = chunk.id(), "chunk tables");
+
+        let table_names = match table_names {
+            Some(table_names) => {
+                debug!("found table names with original predicate");
+                table_names
+            }
+            None => {
+                // couldn't find table names with predicate, get all chunk tables,
+                // fall back to filtering ourself
+                let table_name_predicate = if let Some(table_names) = &predicate.table_names {
+                    PredicateBuilder::new().tables(table_names).build()
+                } else {
+                    Predicate::default()
+                };
+                chunk
+                    .table_names(&table_name_predicate, &no_tables)
+                    .await
+                    .map_err(|e| Box::new(e) as _)
+                    .context(InternalTableNamePlanForDefault)?
+                    // unwrap the Option
+                    .context(InternalTableNameCannotGetPlanForDefault)?
+            }
+        };
+        Ok(table_names)
+    }
+
     /// removes any columns from Names that are not "Tag"s in the Influx Data
     /// Model
     fn restrict_to_tags(&self, schema: &Schema, names: BTreeSet<String>) -> BTreeSet<String> {
@@ -325,6 +389,119 @@ impl InfluxRPCPlanner {
     where
         C: PartitionChunk + 'static,
     {
+        let scan_and_filter = self.scan_and_filter(table_name, predicate, chunks).await?;
+
+        let TableScanAndFilter {
+            plan_builder,
+            schema,
+        } = match scan_and_filter {
+            None => return Ok(None),
+            Some(t) => t,
+        };
+
+        // now, select only the tag columns
+        let select_exprs = schema
+            .iter()
+            .filter_map(|(influx_column_type, field)| {
+                if matches!(influx_column_type, Some(InfluxColumnType::Tag)) {
+                    Some(col(field.name()))
+                } else {
+                    None
+                }
+            })
+            .collect::<Vec<_>>();
+
+        let plan = plan_builder
+            .project(&select_exprs)
+            .context(BuildingPlan)?
+            .build()
+            .context(BuildingPlan)?;
+
+        // And finally pivot the plan
+        let plan = make_schema_pivot(plan);
+        debug!(table_name=table_name, plan=%plan.display_indent_schema(),
+               "created column_name plan for table");
+
+        Ok(Some(plan.into()))
+    }
+
+    /// Creates a DataFusion LogicalPlan that returns the timestamp
+    /// and all field columns for a specified table:
+    ///
+    /// The output looks like (field0, field1, ..., time)
+    ///
+    /// The data is not sorted in any particular order
+    ///
+    /// returns `None` if the table contains no rows that would pass
+    /// the predicate.
+    ///
+    /// The created plan looks like:
+    ///
+    ///    Projection (select the field columns needed)
+    ///        Filter(predicate) [optional]
+    ///          InMemoryScan
+    async fn field_columns_plan<C>(
+        &self,
+        table_name: &str,
+        predicate: &Predicate,
+        chunks: Vec<Arc<C>>,
+    ) -> Result<Option<LogicalPlan>>
+    where
+        C: PartitionChunk + 'static,
+    {
+        let scan_and_filter = self.scan_and_filter(table_name, predicate, chunks).await?;
+        let TableScanAndFilter {
+            plan_builder,
+            schema,
+        } = match scan_and_filter {
+            None => return Ok(None),
+            Some(t) => t,
+        };
+
+        // Selection of only fields and time
+        let select_exprs = schema
+            .iter()
+            .filter_map(|(influx_column_type, field)| match influx_column_type {
+                Some(InfluxColumnType::Field(_)) => Some(col(field.name())),
+                Some(InfluxColumnType::Timestamp) => Some(col(field.name())),
+                Some(_) => None,
+                None => None,
+            })
+            .collect::<Vec<_>>();
+
+        let plan = plan_builder
+            .project(&select_exprs)
+            .context(BuildingPlan)?
+            .build()
+            .context(BuildingPlan)?;
+
+        Ok(Some(plan))
+    }
+
+    /// Create a plan that scans the specified table, and applies any
+    /// filtering specified on the predicate, if any.
+    ///
+    /// If the table can produce no rows based on predicate
+    /// evaluation, returns Ok(None)
+    ///
+    /// The created plan looks like:
+    ///
+    ///        Filter(predicate) [optional]
+    ///          InMemoryScan
+    async fn scan_and_filter<C>(
+        &self,
+        table_name: &str,
+        predicate: &Predicate,
+        chunks: Vec<Arc<C>>,
+    ) -> Result<Option<TableScanAndFilter>>
+    where
+        C: PartitionChunk + 'static,
+    {
+        // Scan all columns to begin with (datafusion projection
+        // pushdown optimization will prune out uneeded columns later)
+        let projection = None;
+        let selection = Selection::All;
+
         // Prepare the scan of the table
         let mut builder = ProviderBuilder::new(table_name);
         for chunk in chunks {
@@ -339,7 +516,7 @@ impl InfluxRPCPlanner {
             );
 
             let chunk_table_schema = chunk
-                .table_schema(table_name, Selection::All)
+                .table_schema(table_name, selection.clone())
                 .await
                 .map_err(|e| Box::new(e) as _)
                 .context(GettingTableSchema {
@@ -355,10 +532,6 @@ impl InfluxRPCPlanner {
         let provider = builder.build().context(CreatingProvider { table_name })?;
         let schema = provider.iox_schema();
 
-        // Scan all columns to begin with (datafusion projection
-        // pushdown optimization will prune out uneeded columns later)
-        let projection = None;
-
         let mut plan_builder = LogicalPlanBuilder::scan(table_name, Arc::new(provider), projection)
             .context(BuildingPlan)?;
 
@@ -369,40 +542,25 @@ impl InfluxRPCPlanner {
             // to evaluate the predicate (if not, it means no rows can
             // match and thus we should skip this plan)
             if !schema_has_all_expr_columns(&schema, &filter_expr) {
-                debug!(table_name=table_name, schema=?schema, filter_expr=?filter_expr, "Skipping table as schema doesn't have all filter_expr columns");
+                debug!(table_name=table_name,
+                       schema=?schema,
+                       filter_expr=?filter_expr,
+                       "Skipping table as schema doesn't have all filter_expr columns");
                 return Ok(None);
             }
             // Assuming that if a table doesn't have all the columns
             // in an expression it can't be true isn't correct for
             // certain predicates (e.g. IS NOT NULL), so error out
-            // here until we have proper support for that
+            // here until we have proper support for that case
             check_predicate_support(&filter_expr)?;
 
             plan_builder = plan_builder.filter(filter_expr).context(BuildingPlan)?;
         }
 
-        // now, select only the tag columns
-        let select_exprs = schema
-            .iter()
-            .filter_map(|(influx_column_type, field)| {
-                if matches!(influx_column_type, Some(InfluxColumnType::Tag)) {
-                    Some(col(field.name()))
-                } else {
-                    None
-                }
-            })
-            .collect::<Vec<_>>();
-
-        let plan_builder = plan_builder.project(&select_exprs).context(BuildingPlan)?;
-
-        let plan = plan_builder.build().context(BuildingPlan)?;
-
-        // And finally pivot the plan
-        let plan = make_schema_pivot(plan);
-        debug!(table_name=table_name, plan=%plan.display_indent_schema(),
-               "created column_name plan for table");
-
-        Ok(Some(plan.into()))
+        Ok(Some(TableScanAndFilter {
+            plan_builder,
+            schema,
+        }))
     }
 
     /// Returns a list of chunks across all partitions which may
@@ -504,4 +662,11 @@ impl ExpressionVisitor for SupportVisitor {
             ))),
         }
     }
+}
+
+struct TableScanAndFilter {
+    /// Represents plan that scans a table and applies optional filtering
+    plan_builder: LogicalPlanBuilder,
+    /// The IOx schema of the result
+    schema: Schema,
 }

--- a/query/src/frontend/influxrpc.rs
+++ b/query/src/frontend/influxrpc.rs
@@ -377,9 +377,11 @@ impl InfluxRPCPlanner {
     ///
     /// The created plan looks like:
     ///
+    /// ```text
     ///  Extension(PivotSchema)
     ///    Filter(predicate)
     ///      TableScan (of chunks)
+    /// ```
     async fn tag_column_names_plan<C>(
         &self,
         table_name: &str,
@@ -437,9 +439,11 @@ impl InfluxRPCPlanner {
     ///
     /// The created plan looks like:
     ///
-    ///    Projection (select the field columns needed)
-    ///        Filter(predicate) [optional]
-    ///          InMemoryScan
+    /// ```text
+    ///  Projection (select the field columns needed)
+    ///      Filter(predicate) [optional]
+    ///        InMemoryScan
+    /// ```
     async fn field_columns_plan<C>(
         &self,
         table_name: &str,
@@ -486,8 +490,10 @@ impl InfluxRPCPlanner {
     ///
     /// The created plan looks like:
     ///
-    ///        Filter(predicate) [optional]
-    ///          InMemoryScan
+    /// ```text
+    ///   Filter(predicate) [optional]
+    ///     InMemoryScan
+    /// ```
     async fn scan_and_filter<C>(
         &self,
         table_name: &str,

--- a/query/src/lib.rs
+++ b/query/src/lib.rs
@@ -11,7 +11,7 @@ use async_trait::async_trait;
 use data_types::{
     data::ReplicatedWrite, partition_metadata::TableSummary, schema::Schema, selection::Selection,
 };
-use exec::{stringset::StringSet, Executor, FieldListPlan, SeriesSetPlans};
+use exec::{stringset::StringSet, Executor, SeriesSetPlans};
 use plan::stringset::StringSetPlan;
 
 use std::{fmt::Debug, sync::Arc};
@@ -54,12 +54,6 @@ pub trait Database: Debug + Send + Sync {
     // ----------
     // The functions below are slated for removal (migration into a gRPC query
     // frontend) ---------
-
-    /// Returns a plan that produces a list of column names in this
-    /// database which store fields (as defined in the data written
-    /// via `write_lines`), and which have at least one row which
-    /// matches the conditions listed on `predicate`.
-    async fn field_column_names(&self, predicate: Predicate) -> Result<FieldListPlan, Self::Error>;
 
     /// Returns a plan which finds the distinct values in the
     /// `column_name` column of this database which pass the

--- a/query/src/plan.rs
+++ b/query/src/plan.rs
@@ -1,1 +1,2 @@
+pub mod fieldlist;
 pub mod stringset;

--- a/query/src/plan/fieldlist.rs
+++ b/query/src/plan/fieldlist.rs
@@ -1,0 +1,20 @@
+use arrow_deps::datafusion::logical_plan::LogicalPlan;
+
+/// A plan which produces a logical set of Fields (e.g. InfluxDB
+/// Fields with name, and data type, and last_timestamp).
+#[derive(Debug, Default)]
+pub struct FieldListPlan {
+    pub plans: Vec<LogicalPlan>,
+}
+
+impl FieldListPlan {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Append a new plan to this list of plans
+    pub fn append(mut self, plan: LogicalPlan) -> Self {
+        self.plans.push(plan);
+        self
+    }
+}

--- a/server/src/db.rs
+++ b/server/src/db.rs
@@ -277,18 +277,6 @@ impl Database for Db {
             .context(MutableBufferWrite)
     }
 
-    async fn field_column_names(
-        &self,
-        predicate: query::predicate::Predicate,
-    ) -> Result<query::exec::FieldListPlan, Self::Error> {
-        self.mutable_buffer
-            .as_ref()
-            .context(DatabaseNotReadable)?
-            .field_column_names(predicate)
-            .await
-            .context(MutableBufferRead)
-    }
-
     async fn column_values(
         &self,
         column_name: &str,

--- a/server/src/query_tests/influxrpc.rs
+++ b/server/src/query_tests/influxrpc.rs
@@ -1,2 +1,3 @@
+pub mod field_columns;
 pub mod table_names;
 pub mod tag_column_names;

--- a/server/src/query_tests/influxrpc/field_columns.rs
+++ b/server/src/query_tests/influxrpc/field_columns.rs
@@ -1,0 +1,166 @@
+use arrow_deps::{
+    arrow::datatypes::DataType,
+    assert_table_eq,
+    datafusion::logical_plan::{col, lit},
+};
+use query::{
+    exec::{
+        fieldlist::{Field, FieldList},
+        Executor,
+    },
+    frontend::influxrpc::InfluxRPCPlanner,
+    predicate::PredicateBuilder,
+};
+
+use crate::query_tests::scenarios::*;
+
+/// Creates and loads several database scenarios using the db_setup
+/// function.
+///
+/// runs field_column_names(predicate) and compares it to the expected
+/// output
+macro_rules! run_field_columns_test_case {
+    ($DB_SETUP:expr, $PREDICATE:expr, $EXPECTED_FIELDS:expr) => {
+        test_helpers::maybe_start_logging();
+        let predicate = $PREDICATE;
+        let expected_fields = $EXPECTED_FIELDS;
+        for scenario in $DB_SETUP.make().await {
+            let DBScenario {
+                scenario_name, db, ..
+            } = scenario;
+            println!("Running scenario '{}'", scenario_name);
+            println!("Predicate: '{:#?}'", predicate);
+            let planner = InfluxRPCPlanner::new();
+            let executor = Executor::new();
+
+            let plan = planner
+                .field_columns(&db, predicate.clone())
+                .await
+                .expect("built plan successfully");
+            let fields = executor
+                .to_field_list(plan)
+                .await
+                .expect("converted plan to strings successfully");
+
+            assert_eq!(
+                fields, expected_fields,
+                "Error in  scenario '{}'\n\nexpected:\n{:#?}\nactual:\n{:#?}",
+                scenario_name, expected_fields, fields
+            );
+        }
+    };
+}
+
+#[tokio::test]
+async fn test_field_columns_empty_database() {
+    let predicate = PredicateBuilder::default().build();
+    let expected_fields = FieldList::default();
+    run_field_columns_test_case!(NoData {}, predicate, expected_fields);
+}
+
+#[tokio::test]
+async fn test_field_columns_no_predicate() {
+    let predicate = PredicateBuilder::default()
+        .table("NoSuchTable")
+        .add_expr(col("state").eq(lit("MA"))) // state=MA
+        .build();
+    let expected_fields = FieldList::default();
+    run_field_columns_test_case!(TwoMeasurementsManyFields {}, predicate, expected_fields);
+}
+
+#[tokio::test]
+async fn test_field_columns_with_pred() {
+    // get only fields from h20 (but both chunks)
+    let predicate = PredicateBuilder::default()
+        .table("h2o")
+        .add_expr(col("state").eq(lit("MA"))) // state=MA
+        .build();
+
+    let expected_fields = FieldList {
+        fields: vec![
+            Field {
+                name: "moisture".into(),
+                data_type: DataType::Float64,
+                last_timestamp: 100000,
+            },
+            Field {
+                name: "other_temp".into(),
+                data_type: DataType::Float64,
+                last_timestamp: 250,
+            },
+            Field {
+                name: "temp".into(),
+                data_type: DataType::Float64,
+                last_timestamp: 100000,
+            },
+        ],
+    };
+
+    run_field_columns_test_case!(TwoMeasurementsManyFields {}, predicate, expected_fields);
+}
+
+#[tokio::test]
+async fn test_field_columns_with_ts_pred() {
+    let predicate = PredicateBuilder::default()
+        .table("h2o")
+        .timestamp_range(200, 300)
+        .add_expr(col("state").eq(lit("MA"))) // state=MA
+        .build();
+
+    let expected_fields = FieldList {
+        fields: vec![Field {
+            name: "other_temp".into(),
+            data_type: DataType::Float64,
+            last_timestamp: 250,
+        }],
+    };
+
+    run_field_columns_test_case!(TwoMeasurementsManyFields {}, predicate, expected_fields);
+}
+
+#[tokio::test]
+async fn test_field_name_plan() {
+    test_helpers::maybe_start_logging();
+    // Tests that the ordering that comes out is reasonable
+    let scenarios = OneMeasurementManyFields {}.make().await;
+
+    for scenario in scenarios {
+        let predicate = PredicateBuilder::default().timestamp_range(0, 200).build();
+
+        let DBScenario {
+            scenario_name, db, ..
+        } = scenario;
+        println!("Running scenario '{}'", scenario_name);
+        println!("Predicate: '{:#?}'", predicate);
+        let planner = InfluxRPCPlanner::new();
+        let executor = Executor::new();
+
+        let plan = planner
+            .field_columns(&db, predicate.clone())
+            .await
+            .expect("built plan successfully");
+
+        let mut plans = plan.plans;
+        let plan = plans.pop().unwrap();
+        assert!(plans.is_empty()); // only one plan
+
+        // run the created plan directly, ensuring the output is as
+        // expected (specifically that the column ordering is correct)
+        let results = executor
+            .run_logical_plan(plan)
+            .await
+            .expect("ok running plan");
+
+        let expected = vec![
+            "+--------+--------+--------+--------+------+",
+            "| field1 | field2 | field3 | field4 | time |",
+            "+--------+--------+--------+--------+------+",
+            "| 70.6   |        | 2      |        | 100  |",
+            "| 70.4   | ss     |        |        | 100  |",
+            "| 70.5   | ss     |        |        | 100  |",
+            "+--------+--------+--------+--------+------+",
+        ];
+
+        assert_table_eq!(expected, &results);
+    }
+}

--- a/server/src/query_tests/influxrpc/table_names.rs
+++ b/server/src/query_tests/influxrpc/table_names.rs
@@ -17,7 +17,9 @@ macro_rules! run_table_names_test_case {
         test_helpers::maybe_start_logging();
         let predicate = $PREDICATE;
         for scenario in $DB_SETUP.make().await {
-            let DBScenario { scenario_name, db } = scenario;
+            let DBScenario {
+                scenario_name, db, ..
+            } = scenario;
             println!("Running scenario '{}'", scenario_name);
             println!("Predicate: '{:#?}'", predicate);
             let planner = InfluxRPCPlanner::new();

--- a/server/src/query_tests/influxrpc/tag_column_names.rs
+++ b/server/src/query_tests/influxrpc/tag_column_names.rs
@@ -13,7 +13,7 @@ use crate::query_tests::scenarios::*;
 /// Creates and loads several database scenarios using the db_setup
 /// function.
 ///
-/// runs table_tag_column_names(predicate) and compares it to the expected
+/// runs table_column_names(predicate) and compares it to the expected
 /// output
 macro_rules! run_tag_column_names_test_case {
     ($DB_SETUP:expr, $PREDICATE:expr, $EXPECTED_NAMES:expr) => {
@@ -21,7 +21,9 @@ macro_rules! run_tag_column_names_test_case {
         let predicate = $PREDICATE;
         let expected_names = $EXPECTED_NAMES;
         for scenario in $DB_SETUP.make().await {
-            let DBScenario { scenario_name, db } = scenario;
+            let DBScenario {
+                scenario_name, db, ..
+            } = scenario;
             println!("Running scenario '{}'", scenario_name);
             println!("Predicate: '{:#?}'", predicate);
             let planner = InfluxRPCPlanner::new();

--- a/server/src/query_tests/sql.rs
+++ b/server/src/query_tests/sql.rs
@@ -16,7 +16,9 @@ macro_rules! run_sql_test_case {
         test_helpers::maybe_start_logging();
         let sql = $SQL.to_string();
         for scenario in $DB_SETUP.make().await {
-            let DBScenario { scenario_name, db } = scenario;
+            let DBScenario {
+                scenario_name, db, ..
+            } = scenario;
             println!("Running scenario '{}'", scenario_name);
             println!("SQL: '{:#?}'", sql);
             let planner = SQLQueryPlanner::new();

--- a/server/src/query_tests/table_schema.rs
+++ b/server/src/query_tests/table_schema.rs
@@ -19,7 +19,9 @@ macro_rules! run_table_schema_test_case {
         let expected_schema = $EXPECTED_SCHEMA;
 
         for scenario in $DB_SETUP.make().await {
-            let DBScenario { scenario_name, db } = scenario;
+            let DBScenario {
+                scenario_name, db, ..
+            } = scenario;
             println!("Running scenario '{}'", scenario_name);
             println!(
                 "Getting schema for table '{}', selection {:?}",


### PR DESCRIPTION
Closes https://github.com/influxdata/influxdb_iox/issues/810 (includes rationale)

# Changes
This PR ports the `field_columns` planning logic to the `InfluxRPC` frontend, along with tests, so that it now works across mutable buffer and read buffer.

# Things I am pleased with:
* it was straightforward to port the code and tests
* The actual new logic is very small and the gRPC planner has almost all the right logic already
* requires no changes to the read buffer (or mutable buffer, other than removing code)

# Things I am not pleased with:

The performance of the implementation of `field_columns` is likely from ideal. The only difference between the tag_names and field_columns is that field_columns returns type information as well as a name and a timestamp.

However, the  logic in the mutable buffer (and hence now in the gRPC planner) basically runs  `SELECT <field columns> from TABLE where PREDICATE` for each table specified. The executor scans the output of those plans and finds which columns are null. It would be cool to have special handling for this kind of predicate in the `MutableBuffer` and `ReadBuffer`


- [x] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb_iox/blob/main/README.md).
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
