### PR TITLE
refactor: derive Clone for API client

### DIFF
--- a/influxdb_iox_client/src/client.rs
+++ b/influxdb_iox_client/src/client.rs
@@ -40,7 +40,7 @@ pub use flight::PerformQuery;
 ///     .expect("failed to create database");
 /// # }
 /// ```
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Client {
     pub(crate) http: reqwest::Client,
 


### PR DESCRIPTION
In what has to be the least controversial change of the week, this PR derives `Clone` for the API client.