### PR TITLE
fix: do not use `println!` on server startup

### DIFF
--- a/src/influxdb_ioxd.rs
+++ b/src/influxdb_ioxd.rs
@@ -145,7 +145,7 @@ pub async fn main(logging_level: LoggingLevel, config: Option<Config>) -> Result
         .serve(router_service);
     info!(bind_address=?bind_addr, "HTTP server listening");
 
-    println!("InfluxDB IOx server ready");
+    info!("InfluxDB IOx server ready");
 
     // Wait for both the servers to complete
     let (grpc_server, server) = futures::future::join(grpc_server, http_server).await;


### PR DESCRIPTION
Rationale:
We should only write to stdout/stderr if requested like a good 12 factor app https://12factor.net/ . 

Also I would like to be able to find log messages easily showing when the server has started

This `println!` is left over from an earlier age

- [x] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb_iox/blob/main/README.md).
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
