### PR TITLE
feat: Include GIT_HASH in startup log message

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,14 @@
+// Include the GIT_HASH, if any, in `GIT_HASH` environment variable at build
+// time
+//
+// https://stackoverflow.com/questions/43753491/include-git-commit-hash-as-string-into-rust-program
+use std::process::Command;
+fn main() {
+    let output = Command::new("git").args(&["rev-parse", "HEAD"]).output();
+
+    if let Ok(output) = output {
+        if let Ok(git_hash) = String::from_utf8(output.stdout) {
+            println!("cargo:rustc-env=GIT_HASH={}", git_hash);
+        }
+    }
+}

--- a/src/influxdb_ioxd.rs
+++ b/src/influxdb_ioxd.rs
@@ -145,7 +145,8 @@ pub async fn main(logging_level: LoggingLevel, config: Option<Config>) -> Result
         .serve(router_service);
     info!(bind_address=?bind_addr, "HTTP server listening");
 
-    info!("InfluxDB IOx server ready");
+    let git_hash = option_env!("GIT_HASH").unwrap_or("UNKNOWN");
+    info!(git_hash, "InfluxDB IOx server ready");
 
     // Wait for both the servers to complete
     let (grpc_server, server) = futures::future::join(grpc_server, http_server).await;


### PR DESCRIPTION
Built on https://github.com/influxdata/influxdb_iox/pull/828

I wonder of @carols10cents  or @shepmaster  could comment on how reasonable an approach this is?

# Rationale:
I would rather like to know what version of the code is running on the IOx server in tools. So while I was waiting for a new image to be deployed I figured I would propose adding this information to the log message

# Changes:
* include the git SHA from which the server was built.

# Example Output:

```
cd /Users/alamb/Software/influxdb_iox && cargo  run -- server
    Finished dev [unoptimized + debuginfo] target(s) in 0.40s
     Running `target/debug/influxdb_iox server`
Feb 17 15:03:33.815  WARN influxdb_iox::influxdb_ioxd: NO PERSISTENCE: using memory for object storage
Feb 17 15:03:33.817  INFO influxdb_iox::influxdb_ioxd: gRPC server listening bind_address=127.0.0.1:8082
Feb 17 15:03:33.827  INFO influxdb_iox::influxdb_ioxd: HTTP server listening bind_address=127.0.0.1:8080
Feb 17 15:03:33.827  INFO influxdb_iox::influxdb_ioxd: InfluxDB IOx server ready git_hash="feb724f91869c604806f5a074924e2392687fa69"
Feb 17 15:03:42.893  INFO influxdb_iox::influxdb_ioxd::http: Processing request request=Request { method: POST,
...
```

- [x] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb_iox/blob/main/README.md).
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
