### PR TITLE
feat: Allow to put streams of unknown length to objectstore

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1208,6 +1208,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-test"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b30f48f6b9cd26d8739965d6e3345c511718884fb223795b80dc71d24a9ea9a"
+dependencies = [
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+ "once_cell",
+ "pin-project 1.0.5",
+ "pin-utils",
+]
+
+[[package]]
 name = "futures-util"
 version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2135,6 +2152,7 @@ dependencies = [
  "cloud-storage",
  "dotenv",
  "futures",
+ "futures-test",
  "itertools 0.9.0",
  "percent-encoding",
  "reqwest",

--- a/object_store/Cargo.toml
+++ b/object_store/Cargo.toml
@@ -24,11 +24,13 @@ rusoto_s3 = "0.46.0"
 snafu = { version = "0.6.10", features = ["futures"] }
 tokio = { version = "1.0", features = ["macros", "fs"] }
 # Filesystem integration
-tokio-util = "0.6.2"
+tokio-util = { version = "0.6.3", features = [ "io" ] }
 reqwest = "0.11"
 # Filesystem integration
 walkdir = "2"
+tempfile = "3.1.0"
 
 [dev-dependencies] # In alphabetical order
 dotenv = "0.15.0"
 tempfile = "3.1.0"
+futures-test = "0.3.12"

--- a/object_store/src/buffer.rs
+++ b/object_store/src/buffer.rs
@@ -1,0 +1,130 @@
+//! This module contains a `Stream` wrapper that fully consumes (slurps) a
+//! `Stream` so it can compute its size, while saving it to a backing store for
+//! later replay.
+use bytes::Bytes;
+use futures::{pin_mut, Stream, StreamExt};
+use std::io::{Cursor, Result, SeekFrom};
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use tokio::fs::File;
+use tokio::io::{copy, AsyncRead, AsyncSeek, AsyncSeekExt, AsyncWrite};
+use tokio_util::io::{ReaderStream, StreamReader};
+
+/// Returns a BufferedStream backend by a temporary file.
+///
+/// The temporary file will be deleted when the result stream
+/// is dropped.
+pub async fn slurp_stream_tempfile<S>(bytes: S) -> Result<BufferedStream<File>>
+where
+    S: Stream<Item = Result<Bytes>> + Send + Sync,
+{
+    let tmp = File::from_std(tempfile::tempfile()?);
+    BufferedStream::new(tmp, bytes).await
+}
+
+/// Returns a BufferedStream backend by a in-memory buffer.
+#[allow(dead_code)]
+pub async fn slurp_stream_memory<S>(bytes: S) -> Result<BufferedStream<Cursor<Vec<u8>>>>
+where
+    S: Stream<Item = Result<Bytes>> + Send + Sync,
+{
+    BufferedStream::new(Cursor::new(Vec::new()), bytes).await
+}
+
+// A stream fully buffered by a backing store..
+pub struct BufferedStream<R>
+where
+    R: AsyncRead + AsyncWrite + AsyncSeek + Unpin,
+{
+    size: usize,
+    inner: ReaderStream<R>,
+}
+
+impl<R> BufferedStream<R>
+where
+    R: AsyncRead + AsyncWrite + AsyncSeek + Unpin,
+{
+    /// Consumes the bytes stream fully and writes its content into file.
+    /// It returns a Stream implementation that reads the same content from the
+    /// buffered file.
+    ///
+    /// The granularity of stream "chunks" will not be preserved.
+    pub async fn new<S>(mut backing_store: R, bytes: S) -> Result<Self>
+    where
+        S: Stream<Item = Result<Bytes>> + Send + Sync,
+    {
+        pin_mut!(bytes);
+        let mut read = StreamReader::new(bytes);
+        let size = copy(&mut read, &mut backing_store).await? as usize;
+        backing_store.seek(SeekFrom::Start(0)).await?;
+
+        Ok(Self {
+            size,
+            inner: ReaderStream::new(backing_store),
+        })
+    }
+
+    pub fn size(&self) -> usize {
+        self.size
+    }
+}
+
+impl<R> Stream for BufferedStream<R>
+where
+    R: AsyncRead + AsyncWrite + AsyncSeek + Unpin,
+{
+    type Item = Result<Bytes>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        self.inner.poll_next_unpin(cx)
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (self.size, Some(self.size()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures::stream::{self, TryStreamExt};
+    use futures_test::stream::StreamTestExt;
+
+    fn test_data() -> impl Stream<Item = Result<Bytes>> + Send + Sync {
+        stream::iter(vec!["foo", "bar", "baz"])
+            .map(|i| Ok(Bytes::from(i)))
+            .interleave_pending()
+    }
+
+    async fn check_stream<R>(buf_stream: BufferedStream<R>) -> Result<()>
+    where
+        R: AsyncRead + AsyncWrite + AsyncSeek + Unpin,
+    {
+        assert_eq!(buf_stream.size(), 9);
+        assert_eq!(buf_stream.size_hint(), (9, Some(9)));
+
+        let content = buf_stream
+            .map_ok(|b| bytes::BytesMut::from(&b[..]))
+            .try_concat()
+            .await?;
+
+        assert_eq!(content, "foobarbaz");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_buffered_stream() -> Result<()> {
+        let backing_store = std::io::Cursor::new(Vec::new()); // in-memory buffer
+        check_stream(BufferedStream::new(backing_store, test_data()).await?).await
+    }
+
+    #[tokio::test]
+    async fn test_slurp_stream_tempfile() -> Result<()> {
+        check_stream(slurp_stream_tempfile(test_data()).await?).await
+    }
+
+    #[tokio::test]
+    async fn test_slurp_stream_memory() -> Result<()> {
+        check_stream(slurp_stream_memory(test_data()).await?).await
+    }
+}

--- a/object_store/src/lib.rs
+++ b/object_store/src/lib.rs
@@ -18,6 +18,7 @@
 
 pub mod aws;
 pub mod azure;
+mod buffer;
 pub mod disk;
 pub mod gcp;
 pub mod memory;
@@ -54,7 +55,7 @@ pub trait ObjectStoreApi: Send + Sync + 'static {
         &self,
         location: &Self::Path,
         bytes: S,
-        length: usize,
+        length: Option<usize>,
     ) -> Result<(), Self::Error>
     where
         S: Stream<Item = io::Result<Bytes>> + Send + Sync + 'static;
@@ -130,7 +131,7 @@ impl ObjectStoreApi for ObjectStore {
         }
     }
 
-    async fn put<S>(&self, location: &Self::Path, bytes: S, length: usize) -> Result<()>
+    async fn put<S>(&self, location: &Self::Path, bytes: S, length: Option<usize>) -> Result<()>
     where
         S: Stream<Item = io::Result<Bytes>> + Send + Sync + 'static,
     {
@@ -485,7 +486,7 @@ mod tests {
             .put(
                 &location,
                 futures::stream::once(async move { stream_data }),
-                data.len(),
+                Some(data.len()),
             )
             .await?;
 
@@ -551,7 +552,7 @@ mod tests {
                 .put(
                     f,
                     futures::stream::once(async move { stream_data }),
-                    data.len(),
+                    Some(data.len()),
                 )
                 .await
                 .unwrap();

--- a/server/src/buffer.rs
+++ b/server/src/buffer.rs
@@ -399,7 +399,7 @@ impl Segment {
                     .put(
                         &location,
                         futures::stream::once(async move { stream_data }),
-                        len,
+                        Some(len),
                     )
                     .await
                 {

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -216,7 +216,7 @@ impl<M: ConnectionManager> Server<M> {
             .put(
                 &location,
                 futures::stream::once(async move { stream_data }),
-                len,
+                Some(len),
             )
             .await
             .context(StoreError)?;

--- a/server/src/snapshot.rs
+++ b/server/src/snapshot.rs
@@ -194,7 +194,7 @@ where
             .put(
                 &partition_meta_path,
                 futures::stream::once(async move { stream_data }),
-                len,
+                Some(len),
             )
             .await
             .context(WritingToObjectStore)?;
@@ -247,7 +247,7 @@ where
             .put(
                 &file_name,
                 futures::stream::once(async move { stream_data }),
-                len,
+                Some(len),
             )
             .await
             .context(WritingToObjectStore)


### PR DESCRIPTION
# Overview

Addresses the API aspect of #818

This PR contains a utility module that helps computing the length of a stream while buffering it
for later replay (in-memory or spilling it in a temporary file). This is intended to be used as a stop-gap measure until
we implement proper streaming support in the various ObjectStore implementations. Hopefully we will be able to get rid of this buffering stage since all the support object stores support "streaming" uploads (of one kind or another).

# Details

We'll add streaming functionality to the relevant ObjectStore implementations in subsequent PRs.

Most current ObjectStore implementations already slurp the input stream into memory before proceeding,
or otherwise don't need the length parameter for anything other than ensuring it matches the actual
stream length (and erroring if it doesn't).

The S3 object_store didn't, and instead passed the length directly to the s3 client library (rusoto).
Rusoto-s3 doesn't provide a high level abstraction for streaming, but it does provide the building blocks
(multi part put operations). In a future PR we'll add a layer that will turn a Stream<Bytes> into a sequence
of multi-part put operations.

In the meantime though, we need to know the size of the stream. Instead of slurping the whole stream into memory, we spill the stream into a temporary file and then lazily read it back as the underlying object store implementation consumes the buffered stream.


- [x] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb_iox/blob/main/README.md).
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
