### PR TITLE
refactor: allow `column_names` to be used for tag keys or field keys (or both)

### DIFF
--- a/read_buffer/src/chunk.rs
+++ b/read_buffer/src/chunk.rs
@@ -11,6 +11,7 @@ use crate::row_group::{ColumnName, Predicate};
 use crate::schema::AggregateType;
 use crate::table;
 use crate::table::Table;
+use crate::InfluxColumnNameType;
 
 type TableName = String;
 
@@ -273,6 +274,7 @@ impl Chunk {
         &self,
         table_name: &str,
         predicate: &Predicate,
+        column_types: InfluxColumnNameType,
         dst: BTreeSet<String>,
     ) -> BTreeSet<String> {
         let chunk_data = self.chunk_data.read().unwrap();
@@ -280,7 +282,7 @@ impl Chunk {
         // TODO(edd): same potential contention as `table_names` but I'm ok
         // with this for now.
         match chunk_data.data.get(table_name) {
-            Some(table) => table.column_names(predicate, dst),
+            Some(table) => table.column_names(predicate, column_types, dst),
             None => dst,
         }
     }

--- a/read_buffer/src/table.rs
+++ b/read_buffer/src/table.rs
@@ -13,7 +13,7 @@ use snafu::{ensure, Snafu};
 use crate::row_group::{self, ColumnName, GroupKey, Predicate, RowGroup};
 use crate::schema::{AggregateType, ColumnType, LogicalDataType, ResultSchema};
 use crate::value::{AggregateResult, Scalar, Value};
-
+use crate::InfluxColumnNameType;
 #[derive(Debug, Snafu)]
 pub enum Error {
     #[snafu(display("cannot drop last row group in table; drop table"))]
@@ -435,6 +435,7 @@ impl Table {
     pub fn column_names(
         &self,
         predicate: &Predicate,
+        column_types: InfluxColumnNameType,
         mut dst: BTreeSet<String>,
     ) -> BTreeSet<String> {
         let table_data = self.table_data.read().unwrap();
@@ -459,7 +460,7 @@ impl Table {
         // lock.
         let (_, row_groups) = self.filter_row_groups(predicate);
         for row_group in row_groups {
-            row_group.column_names(predicate, &mut dst);
+            row_group.column_names(predicate, column_types, &mut dst);
         }
 
         dst
@@ -1296,6 +1297,7 @@ west,host-b,100
 
         let rc = ColumnType::Tag(Column::from(&["west", "south", "north"][..]));
         columns.insert("region".to_string(), rc);
+
         let rg = RowGroup::new(3, columns);
         let mut table = Table::new("cpu".to_owned(), rg);
 
@@ -1306,6 +1308,7 @@ west,host-b,100
 
         let rc = ColumnType::Tag(Column::from(vec![Some("north"), None, None].as_slice()));
         columns.insert("region".to_string(), rc);
+
         let rg = RowGroup::new(3, columns);
         table.add_row_group(rg);
 
@@ -1322,7 +1325,7 @@ west,host-b,100
         // NULL,   400
 
         let mut dst: BTreeSet<String> = BTreeSet::new();
-        dst = table.column_names(&Predicate::default(), dst);
+        dst = table.column_names(&Predicate::default(), InfluxColumnNameType::All, dst);
 
         assert_eq!(
             dst.iter().cloned().collect::<Vec<_>>(),
@@ -1330,7 +1333,7 @@ west,host-b,100
         );
 
         // re-run and get the same answer
-        dst = table.column_names(&Predicate::default(), dst);
+        dst = table.column_names(&Predicate::default(), InfluxColumnNameType::All, dst);
         assert_eq!(
             dst.iter().cloned().collect::<Vec<_>>(),
             vec!["region".to_owned(), "time".to_owned()],
@@ -1340,6 +1343,7 @@ west,host-b,100
         // region from previous results.
         dst = table.column_names(
             &Predicate::new(vec![BinaryExpr::from(("time", ">=", 300_i64))]),
+            InfluxColumnNameType::All,
             dst,
         );
         assert_eq!(
@@ -1350,6 +1354,7 @@ west,host-b,100
         // wipe the destination buffer and region won't show up
         dst = table.column_names(
             &Predicate::new(vec![BinaryExpr::from(("time", ">=", 300_i64))]),
+            InfluxColumnNameType::All,
             BTreeSet::new(),
         );
         assert_eq!(

--- a/server/src/db/chunk.rs
+++ b/server/src/db/chunk.rs
@@ -339,7 +339,13 @@ impl PartitionChunk for DBChunk {
                 let chunk_ids = &[chunk_id];
 
                 let names = db
-                    .column_names(partition_key, table_name, chunk_ids, rb_predicate)
+                    .column_names(
+                        partition_key,
+                        table_name,
+                        chunk_ids,
+                        rb_predicate,
+                        read_buffer::InfluxColumnNameType::All,
+                    )
                     .context(ReadBufferChunk { chunk_id })?;
 
                 Ok(names)


### PR DESCRIPTION
This is a little spike of a PR that alters the `column_names` API to allow one to use it for getting just tag keys or field keys (or both).