### PR TITLE
feat: Implement list_with_delimiter for Azure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -237,7 +237,7 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 [[package]]
 name = "azure_core"
 version = "0.1.0"
-source = "git+https://github.com/Azure/azure-sdk-for-rust.git?rev=5ecad7216e1f04c5ff41e7de4667f006664c8cca#5ecad7216e1f04c5ff41e7de4667f006664c8cca"
+source = "git+https://github.com/Azure/azure-sdk-for-rust.git?rev=14ff9326bb1ba07f98733a548988eccd4532b945#14ff9326bb1ba07f98733a548988eccd4532b945"
 dependencies = [
  "RustyXML",
  "async-trait",
@@ -266,7 +266,7 @@ dependencies = [
 [[package]]
 name = "azure_storage"
 version = "0.1.0"
-source = "git+https://github.com/Azure/azure-sdk-for-rust.git?rev=5ecad7216e1f04c5ff41e7de4667f006664c8cca#5ecad7216e1f04c5ff41e7de4667f006664c8cca"
+source = "git+https://github.com/Azure/azure-sdk-for-rust.git?rev=14ff9326bb1ba07f98733a548988eccd4532b945#14ff9326bb1ba07f98733a548988eccd4532b945"
 dependencies = [
  "RustyXML",
  "azure_core",
@@ -289,6 +289,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "smallvec",
+ "thiserror",
  "time 0.2.25",
  "url",
  "uuid",

--- a/docs/env.example
+++ b/docs/env.example
@@ -1,0 +1,44 @@
+# This is an example .env file showing all of the environment variables that can
+# be configured within the project. Copy this file to the top level directory with
+# the name `.env`, then remove any `#` at the beginning of the lines of variables
+# you'd like to set and change the values.
+#
+# The identifier for the server. Used for writing to object storage and as
+# an identifier that is added to replicated writes, WAL segments and Chunks.
+# Must be unique in a group of connected or semi-connected IOx servers.
+# Must be a number that can be represented by a 32-bit unsigned integer.
+# INFLUXDB_IOX_ID=1
+#
+# Where to store files on disk:
+# INFLUXDB_IOX_DB_DIR=$HOME/.influxdb_iox
+# TEST_INFLUXDB_IOX_DB_DIR=$HOME/.influxdb_iox
+#
+# Addresses for the server processes:
+# INFLUXDB_IOX_BIND_ADDR=127.0.0.1:8080
+# INFLUXDB_IOX_GRPC_BIND_ADDR=127.0.0.1:8082
+#
+# If using Amazon S3 as an object store:
+# AWS_ACCESS_KEY_ID=access_key_value
+# AWS_SECRET_ACCESS_KEY=secret_access_key_value
+# AWS_DEFAULT_REGION=us-east-2
+# AWS_S3_BUCKET_NAME=bucket-name
+#
+# If using Google Cloud Storage as an object store:
+# GCS_BUCKET_NAME=bucket_name
+# Set one of SERVICE_ACCOUNT or GOOGLE_APPLICATION_CREDENTIALS, either to a path of a filename
+# containing Google credential JSON or to the JSON directly.
+# SERVICE_ACCOUNT=/path/to/auth/info.json
+# GOOGLE_APPLICATION_CREDENTIALS={"project_id": ...}
+#
+# If using Microsoft Azure as an object store:
+# The name you see when going to All Services > Storage accounts > [name]
+# AZURE_STORAGE_ACCOUNT=
+# The name of a container you've created in the storage account, under Blob Service > Containers
+# AZURE_STORAGE_CONTAINER=
+# In the Storage account's Settings > Access keys, one of the Key values
+# AZURE_STORAGE_MASTER_KEY=
+#
+# To enable Jaeger tracing:
+# OTEL_SERVICE_NAME="iox" # defaults to iox
+# OTEL_EXPORTER_JAEGER_AGENT_HOST="jaeger.influxdata.net"
+# OTEL_EXPORTER_JAEGER_AGENT_PORT="6831"

--- a/object_store/Cargo.toml
+++ b/object_store/Cargo.toml
@@ -7,9 +7,9 @@ edition = "2018"
 [dependencies] # In alphabetical order
 async-trait = "0.1.42"
 # Microsoft Azure Blob storage integration
-# In order to support tokio 1.0 needed to pull in unreleased azure sdk
-azure_core = { git = "https://github.com/Azure/azure-sdk-for-rust.git", rev = "5ecad7216e1f04c5ff41e7de4667f006664c8cca" }
-azure_storage = { git = "https://github.com/Azure/azure-sdk-for-rust.git", rev = "5ecad7216e1f04c5ff41e7de4667f006664c8cca", default-features = false, features = ["table", "blob"] }
+# In order to support tokio 1.0 and delimiters, needed to pull in unreleased azure sdk
+azure_core = { git = "https://github.com/Azure/azure-sdk-for-rust.git", rev = "14ff9326bb1ba07f98733a548988eccd4532b945" }
+azure_storage = { git = "https://github.com/Azure/azure-sdk-for-rust.git", rev = "14ff9326bb1ba07f98733a548988eccd4532b945", default-features = false, features = ["table", "blob", "queue"] }
 bytes = "1.0"
 chrono = "0.4"
 # Google Cloud Storage integration

--- a/object_store/src/azure.rs
+++ b/object_store/src/azure.rs
@@ -255,7 +255,7 @@ mod tests {
                 (false, false, true) => {
                     panic!(
                         "TEST_INTEGRATION is set, \
-                            but AZURE_STROAGE_ACCOUNT and AZURE_STORAGE_CONTAINER are not"
+                            but AZURE_STORAGE_ACCOUNT and AZURE_STORAGE_CONTAINER are not"
                     )
                 }
                 (false, true, true) => {
@@ -267,7 +267,7 @@ mod tests {
                 (false, false, false) => {
                     eprintln!(
                         "skipping integration test - set \
-                               AZURE_STROAGE_ACCOUNT and AZURE_STORAGE_CONTAINER to run"
+                               AZURE_STORAGE_ACCOUNT and AZURE_STORAGE_CONTAINER to run"
                     );
                     return Ok(());
                 }


### PR DESCRIPTION
Fixes https://github.com/influxdata/influxdb_iox/issues/765.

This did require a few patches to upstream, and they've been incorporated, but the Azure crates are not being published yet so pointing to GitHub is the best we can do for the foreseeable future. In other words, this is ready for review and merging IMO.

@alamb I noticed you removed the `docs/env.sample` file in https://github.com/influxdata/influxdb_iox/pull/608, and that @domodwyer went back to `.env` over `.influxdb_iox/config` in https://github.com/influxdata/influxdb_iox/pull/640... 

The `.env` file still works (and is still relevant for tests that aren't running the `influxdb_iox` command). I think the sample file with documentation is still valuable if only for developer setup? I also tried running `influxdb_iox server --help`: it's really hard to read what environment variables exist, and the Amazon ones are missing, which is understandable because the code doesn't actually support S3 yet but the tests do, so... 🤷‍♀️ ?

I just wanted to have someplace to try to document the Azure environment variables because I had some Fun Times trying to figure out what the values were supposed to be and wanted to save the next person some trouble 😅 