### PR TITLE
refactor: make certain Database method sync

### DIFF
--- a/mutable_buffer/src/database.rs
+++ b/mutable_buffer/src/database.rs
@@ -266,7 +266,7 @@ impl Database for MutableBufferDb {
     }
 
     /// Return the partition keys for data in this DB
-    async fn partition_keys(&self) -> Result<Vec<String>, Self::Error> {
+    fn partition_keys(&self) -> Result<Vec<String>, Self::Error> {
         let partitions = self.partitions.read().expect("mutex poisoned");
         let keys = partitions.keys().cloned().collect();
         Ok(keys)
@@ -274,7 +274,7 @@ impl Database for MutableBufferDb {
 
     /// Return the list of chunks, in order of id, for the specified
     /// partition_key
-    async fn chunks(&self, partition_key: &str) -> Vec<Arc<Chunk>> {
+    fn chunks(&self, partition_key: &str) -> Vec<Arc<Chunk>> {
         let partition = self.get_partition(partition_key);
         let partition = partition.read().expect("mutex poisoned");
         partition.chunks()

--- a/query/src/frontend/influxrpc.rs
+++ b/query/src/frontend/influxrpc.rs
@@ -586,7 +586,6 @@ impl InfluxRPCPlanner {
 
         let partition_keys = database
             .partition_keys()
-            .await
             .map_err(|e| Box::new(e) as _)
             .context(ListingPartitions)?;
 
@@ -594,7 +593,7 @@ impl InfluxRPCPlanner {
 
         for key in partition_keys {
             // TODO prune partitions somehow
-            let partition_chunks = database.chunks(&key).await;
+            let partition_chunks = database.chunks(&key);
             for chunk in partition_chunks {
                 let could_pass_predicate = chunk
                     .could_pass_predicate(predicate)

--- a/query/src/frontend/sql.rs
+++ b/query/src/frontend/sql.rs
@@ -92,7 +92,6 @@ impl SQLQueryPlanner {
 
         let partition_keys = database
             .partition_keys()
-            .await
             .map_err(|e| Box::new(e) as _)
             .context(GettingDatabasePartition)?;
 
@@ -103,7 +102,7 @@ impl SQLQueryPlanner {
             let mut builder = ProviderBuilder::new(table_name);
 
             for partition_key in &partition_keys {
-                for chunk in database.chunks(partition_key).await {
+                for chunk in database.chunks(partition_key) {
                     if chunk.has_table(table_name) {
                         let chunk_id = chunk.id();
                         let chunk_table_schema = chunk

--- a/query/src/lib.rs
+++ b/query/src/lib.rs
@@ -44,12 +44,12 @@ pub trait Database: Debug + Send + Sync {
     async fn store_replicated_write(&self, write: &ReplicatedWrite) -> Result<(), Self::Error>;
 
     /// Return the partition keys for data in this DB
-    async fn partition_keys(&self) -> Result<Vec<String>, Self::Error>;
+    fn partition_keys(&self) -> Result<Vec<String>, Self::Error>;
 
     /// Returns a covering set of chunks in the specified partition. A
     /// covering set means that together the chunks make up a single
     /// complete copy of the data being queried.
-    async fn chunks(&self, partition_key: &str) -> Vec<Arc<Self::Chunk>>;
+    fn chunks(&self, partition_key: &str) -> Vec<Arc<Self::Chunk>>;
 
     // ----------
     // The functions below are slated for removal (migration into a gRPC query

--- a/query/src/test.rs
+++ b/query/src/test.rs
@@ -362,13 +362,13 @@ impl Database for TestDatabase {
     }
 
     /// Return the partition keys for data in this DB
-    async fn partition_keys(&self) -> Result<Vec<String>, Self::Error> {
+    fn partition_keys(&self) -> Result<Vec<String>, Self::Error> {
         let partitions = self.partitions.lock().expect("mutex poisoned");
         let keys = partitions.keys().cloned().collect();
         Ok(keys)
     }
 
-    async fn chunks(&self, partition_key: &str) -> Vec<Arc<Self::Chunk>> {
+    fn chunks(&self, partition_key: &str) -> Vec<Arc<Self::Chunk>> {
         let partitions = self.partitions.lock().expect("mutex poisoned");
         if let Some(chunks) = partitions.get(partition_key) {
             chunks.values().cloned().collect()

--- a/server/src/db.rs
+++ b/server/src/db.rs
@@ -126,11 +126,10 @@ impl Db {
 
     // Return a list of all chunks in the mutable_buffer (that can
     // potentially be migrated into the read buffer or object store)
-    pub async fn mutable_buffer_chunks(&self, partition_key: &str) -> Vec<Arc<DBChunk>> {
+    pub fn mutable_buffer_chunks(&self, partition_key: &str) -> Vec<Arc<DBChunk>> {
         let chunks = if let Some(mutable_buffer) = self.mutable_buffer.as_ref() {
             mutable_buffer
                 .chunks(partition_key)
-                .await
                 .into_iter()
                 .map(DBChunk::new_mb)
                 .collect()
@@ -141,7 +140,7 @@ impl Db {
     }
 
     /// List chunks that are currently in the read buffer
-    pub async fn read_buffer_chunks(&self, partition_key: &str) -> Vec<Arc<DBChunk>> {
+    pub fn read_buffer_chunks(&self, partition_key: &str) -> Vec<Arc<DBChunk>> {
         self.read_buffer
             .chunk_ids(partition_key)
             .into_iter()
@@ -247,14 +246,14 @@ impl Database for Db {
     type Chunk = DBChunk;
 
     /// Return a covering set of chunks for a particular partition
-    async fn chunks(&self, partition_key: &str) -> Vec<Arc<Self::Chunk>> {
+    fn chunks(&self, partition_key: &str) -> Vec<Arc<Self::Chunk>> {
         // return a coverting set of chunks. TODO include read buffer
         // chunks and take them preferentially from the read buffer.
         // returns a coverting set of chunks -- aka take chunks from read buffer
         // preferentially
-        let mutable_chunk_iter = self.mutable_buffer_chunks(partition_key).await.into_iter();
+        let mutable_chunk_iter = self.mutable_buffer_chunks(partition_key).into_iter();
 
-        let read_buffer_chunk_iter = self.read_buffer_chunks(partition_key).await.into_iter();
+        let read_buffer_chunk_iter = self.read_buffer_chunks(partition_key).into_iter();
 
         let chunks: BTreeMap<_, _> = mutable_chunk_iter
             .chain(read_buffer_chunk_iter)
@@ -315,12 +314,11 @@ impl Database for Db {
             .context(MutableBufferRead)
     }
 
-    async fn partition_keys(&self) -> Result<Vec<String>, Self::Error> {
+    fn partition_keys(&self) -> Result<Vec<String>, Self::Error> {
         self.mutable_buffer
             .as_ref()
             .context(DatabaseNotReadable)?
             .partition_keys()
-            .await
             .context(MutableBufferRead)
     }
 }
@@ -380,7 +378,7 @@ mod tests {
         let db = make_db();
         let mut writer = TestLPWriter::default();
         writer.write_lp_string(&db, "cpu bar=1 10").await.unwrap();
-        assert_eq!(vec!["1970-01-01T00"], db.partition_keys().await.unwrap());
+        assert_eq!(vec!["1970-01-01T00"], db.partition_keys().unwrap());
 
         let mb_chunk = db.rollover_partition("1970-01-01T00").await.unwrap();
         assert_eq!(mb_chunk.id(), 0);
@@ -436,8 +434,8 @@ mod tests {
 
         // we should have chunks in both the mutable buffer and read buffer
         // (Note the currently open chunk is not listed)
-        assert_eq!(mutable_chunk_ids(&db, partition_key).await, vec![0, 1]);
-        assert_eq!(read_buffer_chunk_ids(&db, partition_key).await, vec![0]);
+        assert_eq!(mutable_chunk_ids(&db, partition_key), vec![0, 1]);
+        assert_eq!(read_buffer_chunk_ids(&db, partition_key), vec![0]);
 
         // data should be readable
         let expected = vec![
@@ -456,8 +454,8 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(mutable_chunk_ids(&db, partition_key).await, vec![1]);
-        assert_eq!(read_buffer_chunk_ids(&db, partition_key).await, vec![0]);
+        assert_eq!(mutable_chunk_ids(&db, partition_key), vec![1]);
+        assert_eq!(read_buffer_chunk_ids(&db, partition_key), vec![0]);
 
         let batches = run_query(&db, "select * from cpu").await;
         assert_table_eq!(&expected, &batches);
@@ -467,7 +465,7 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(
-            read_buffer_chunk_ids(&db, partition_key).await,
+            read_buffer_chunk_ids(&db, partition_key),
             vec![] as Vec<u32>
         );
 
@@ -487,9 +485,9 @@ mod tests {
         writer.write_lp_string(&db, "cpu bar=1 10").await.unwrap();
         writer.write_lp_string(&db, "cpu bar=1 20").await.unwrap();
 
-        assert_eq!(mutable_chunk_ids(&db, partition_key).await, vec![0]);
+        assert_eq!(mutable_chunk_ids(&db, partition_key), vec![0]);
         assert_eq!(
-            read_buffer_chunk_ids(&db, partition_key).await,
+            read_buffer_chunk_ids(&db, partition_key),
             vec![] as Vec<u32>
         );
 
@@ -507,8 +505,8 @@ mod tests {
 
         writer.write_lp_string(&db, "cpu bar=1 40").await.unwrap();
 
-        assert_eq!(mutable_chunk_ids(&db, partition_key).await, vec![0, 1, 2]);
-        assert_eq!(read_buffer_chunk_ids(&db, partition_key).await, vec![1]);
+        assert_eq!(mutable_chunk_ids(&db, partition_key), vec![0, 1, 2]);
+        assert_eq!(read_buffer_chunk_ids(&db, partition_key), vec![1]);
     }
 
     // run a sql query against the database, returning the results as record batches
@@ -521,10 +519,9 @@ mod tests {
         collect(physical_plan).await.unwrap()
     }
 
-    async fn mutable_chunk_ids(db: &Db, partition_key: &str) -> Vec<u32> {
+    fn mutable_chunk_ids(db: &Db, partition_key: &str) -> Vec<u32> {
         let mut chunk_ids: Vec<u32> = db
             .mutable_buffer_chunks(partition_key)
-            .await
             .iter()
             .map(|chunk| chunk.id())
             .collect();
@@ -532,10 +529,9 @@ mod tests {
         chunk_ids
     }
 
-    async fn read_buffer_chunk_ids(db: &Db, partition_key: &str) -> Vec<u32> {
+    fn read_buffer_chunk_ids(db: &Db, partition_key: &str) -> Vec<u32> {
         let mut chunk_ids: Vec<u32> = db
             .read_buffer_chunks(partition_key)
-            .await
             .iter()
             .map(|chunk| chunk.id())
             .collect();

--- a/server/src/query_tests/scenarios.rs
+++ b/server/src/query_tests/scenarios.rs
@@ -36,8 +36,8 @@ impl DBSetup for NoData {
         // listing partitions (which may create an entry in a map)
         // in an empty database
         let db = make_db();
-        assert_eq!(db.mutable_buffer_chunks(partition_key).await.len(), 1); // only open chunk
-        assert_eq!(db.read_buffer_chunks(partition_key).await.len(), 0);
+        assert_eq!(db.mutable_buffer_chunks(partition_key).len(), 1); // only open chunk
+        assert_eq!(db.read_buffer_chunks(partition_key).len(), 0);
         let scenario2 = DBScenario {
             scenario_name: "New, Empty Database after partitions are listed".into(),
             db,
@@ -55,9 +55,9 @@ impl DBSetup for NoData {
             .await
             .unwrap();
 
-        assert_eq!(db.mutable_buffer_chunks(partition_key).await.len(), 1);
+        assert_eq!(db.mutable_buffer_chunks(partition_key).len(), 1);
 
-        assert_eq!(db.read_buffer_chunks(partition_key).await.len(), 0); // only open chunk
+        assert_eq!(db.read_buffer_chunks(partition_key).len(), 0); // only open chunk
 
         let scenario3 = DBScenario {
             scenario_name: "Empty Database after drop chunk".into(),

--- a/server/src/query_tests/table_schema.rs
+++ b/server/src/query_tests/table_schema.rs
@@ -31,8 +31,8 @@ macro_rules! run_table_schema_test_case {
             // Make sure at least one table has data
             let mut chunks_with_table = 0;
 
-            for partition_key in db.partition_keys().await.unwrap() {
-                for chunk in db.chunks(&partition_key).await {
+            for partition_key in db.partition_keys().unwrap() {
+                for chunk in db.chunks(&partition_key) {
                     if chunk.has_table(table_name) {
                         chunks_with_table += 1;
                         let actual_schema = chunk

--- a/server/src/snapshot.rs
+++ b/server/src/snapshot.rs
@@ -393,7 +393,7 @@ mem,host=A,region=west used=45 1
         let mut data_path = store.new_path();
         data_path.push_dir("data");
 
-        let chunk = Arc::clone(&db.chunks("1970-01-01T00").await[0]);
+        let chunk = Arc::clone(&db.chunks("1970-01-01T00")[0]);
 
         let snapshot = snapshot_chunk(
             metadata_path.clone(),

--- a/src/influxdb_ioxd/http.rs
+++ b/src/influxdb_ioxd/http.rs
@@ -668,14 +668,13 @@ async fn list_partitions<M: ConnectionManager + Send + Sync + Debug + 'static>(
         bucket: &info.bucket,
     })?;
 
-    let partition_keys = db
-        .partition_keys()
-        .await
-        .map_err(|e| Box::new(e) as _)
-        .context(BucketByName {
-            org: &info.org,
-            bucket_name: &info.bucket,
-        })?;
+    let partition_keys =
+        db.partition_keys()
+            .map_err(|e| Box::new(e) as _)
+            .context(BucketByName {
+                org: &info.org,
+                bucket_name: &info.bucket,
+            })?;
 
     let result = serde_json::to_string(&partition_keys).context(JsonGenerationError)?;
 


### PR DESCRIPTION
A couple of methods on the `Database` trait (there could be others I guess?) don't have any `await` points in their implementations (there are two implementations: one for the mutable buffer and one for the `server::Db`).

To simplify the code it seemed reasonable to make these methods on the trait not async. This means that other methods that build on them may themselves not need to be async in some cases.

I ran into this because I was working on a feature to migrate chunks from the mutable buffer to the read buffer that will be entirely cpu-bound and therefore doesn't need to have await points in it, yet it needs to use the two methods `partition_keys` and `chunks` I've changed in this PR.

Since I'm not sure if there could every be an implementation that _does_ need to have these functions as `async` I'm not sure if this PR is going to add any long-term value, but certainly in the short-term it makes things clearer (to me anyway) and it doesn't seem to hard to make these things `async` in the future so that actually be warranted. 