### PR TITLE
feat: add pre-commit hook

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euf
+set -o pipefail
+
+echo "Running githook"
+
+# Format all files and only stage those that were previously staged
+files=$(comm -12 <(git diff --cached --name-only --line-prefix="$(git rev-parse --show-toplevel)/" | sort) <(cargo fmt -- -l | sort))
+for f in $files; do
+  echo "Formatted $f"
+  git add "$f"
+done

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -186,3 +186,13 @@ cargo clippy --all-targets --workspace -- -D warnings
 
 [`rustfmt`]: https://github.com/rust-lang/rustfmt
 [`clippy`]: https://github.com/rust-lang/rust-clippy
+
+## Pre-Commit Hook
+
+A pre-commit hook is provided that will automatically format your code prior to submission. 
+
+It can be installed by running the below from the root directory of the repository
+
+```shell
+ln -s ../../.githooks/pre-commit .git/hooks/pre-commit
+```


### PR DESCRIPTION
Adds a basic pre-commit githook that runs cargo fmt and re-stages formatted files that were previously staged
