### PR TITLE
feat: initial size-based chunk migration to read buffer

### DIFF
--- a/data_types/src/database_rules.rs
+++ b/data_types/src/database_rules.rs
@@ -1,5 +1,3 @@
-use std::time::Duration;
-
 use influxdb_line_protocol::ParsedLine;
 
 use chrono::{DateTime, TimeZone, Utc};

--- a/server/src/query_tests/scenarios.rs
+++ b/server/src/query_tests/scenarios.rs
@@ -51,9 +51,7 @@ impl DBSetup for NoData {
         // move data out of open chunk
         assert_eq!(db.rollover_partition(partition_key).await.unwrap().id(), 0);
         // drop it
-        db.drop_mutable_buffer_chunk(partition_key, 0)
-            .await
-            .unwrap();
+        db.drop_mutable_buffer_chunk(partition_key, 0).unwrap();
 
         assert_eq!(db.mutable_buffer_chunks(partition_key).len(), 1);
 
@@ -230,9 +228,7 @@ async fn make_one_chunk_scenarios(partition_key: &str, data: &str) -> Vec<DBScen
     db.load_chunk_to_read_buffer(partition_key, 0)
         .await
         .unwrap();
-    db.drop_mutable_buffer_chunk(partition_key, 0)
-        .await
-        .unwrap();
+    db.drop_mutable_buffer_chunk(partition_key, 0).unwrap();
     let scenario4 = DBScenario {
         scenario_name: "Data in only read buffer and not mutable buffer".into(),
         db,
@@ -310,9 +306,7 @@ async fn make_two_chunk_scenarios(
     db.load_chunk_to_read_buffer(partition_key, 0)
         .await
         .unwrap();
-    db.drop_mutable_buffer_chunk(partition_key, 0)
-        .await
-        .unwrap();
+    db.drop_mutable_buffer_chunk(partition_key, 0).unwrap();
     writer.write_lp_string(&db, data2).await.unwrap();
     let scenario3 = DBScenario {
         scenario_name: "Data in open chunk of mutable buffer, and one chunk of read buffer".into(),
@@ -330,16 +324,12 @@ async fn make_two_chunk_scenarios(
     db.load_chunk_to_read_buffer(partition_key, 0)
         .await
         .unwrap();
-    db.drop_mutable_buffer_chunk(partition_key, 0)
-        .await
-        .unwrap();
+    db.drop_mutable_buffer_chunk(partition_key, 0).unwrap();
 
     db.load_chunk_to_read_buffer(partition_key, 1)
         .await
         .unwrap();
-    db.drop_mutable_buffer_chunk(partition_key, 1)
-        .await
-        .unwrap();
+    db.drop_mutable_buffer_chunk(partition_key, 1).unwrap();
     let scenario4 = DBScenario {
         scenario_name: "Data in two read buffer chunks".into(),
         db,


### PR DESCRIPTION
This is a PR that is intended to incite a ~riot~ bit of discussion about how we want to handle these sorts of CPU-bound background events. Since there is nothing in IOx currently that runs on an interval in the background and periodically does CPU-bound work I had to basically propose something (thought I took counsel from @shepmaster and @tustvold).

The general idea here is that we know that we have certain jobs, work, activities etc that need to periodically run. We want to check for any work often, and when it occurs it will be CPU-bound. Generally it's organising and/or shuffling bits around :-)

I propose that we try and avoid any `async` in these code-paths and instead bubble this work up as high as possible, such that we can move it onto a thread pool etc for "bounded execution". I have **not** added this notion of a thread pool in this PR, but I have bubbled the work up as high as I can. 

Then, I have added a simple `async` function at the top of the server that kicks a loop off, which checks for any work to do and does the work in the same thread (this is where we would normally move the work off to another dedicated thread pool so we are not holding the loop up).

Other things in this PR:

 - I thought of a simple size-based migration strategy: move a closed chunk if it's X MB in size. Probably a simpler one is to just move all closed chunks??
 -  I can't see where chunks get closed? Maybe @pauldix  can help with that. It might make the initial migration policy simpler.
 - There no tests yet! I want to get agreement on the general pattern then I can write some tests.
 - I don't think that the current implementation of the DB understands the concept of "a chunk is in the read buffer but it's not ready for querying yet". I think that needs to be added.
