### PR TITLE
feat: encoding of standard gRPC error details payloads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1310,6 +1310,7 @@ dependencies = [
  "prost",
  "prost-build",
  "prost-types",
+ "tonic",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1311,6 +1311,7 @@ dependencies = [
  "prost-build",
  "prost-types",
  "tonic",
+ "tracing",
 ]
 
 [[package]]

--- a/google_types/Cargo.toml
+++ b/google_types/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2018"
 prost = "0.7"
 prost-types = "0.7"
 tonic = "0.4"
+tracing = { version = "0.1" }
 
 [build-dependencies] # In alphabetical order
 prost-build = "0.7"

--- a/google_types/Cargo.toml
+++ b/google_types/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2018"
 [dependencies] # In alphabetical order
 prost = "0.7"
 prost-types = "0.7"
+tonic = "0.4"
 
 [build-dependencies] # In alphabetical order
 prost-build = "0.7"

--- a/google_types/src/lib.rs
+++ b/google_types/src/lib.rs
@@ -12,7 +12,29 @@
 mod pb {
     pub mod google {
         pub mod protobuf {
+            use std::convert::{TryFrom, TryInto};
+
             include!(concat!(env!("OUT_DIR"), "/google.protobuf.rs"));
+
+            impl TryFrom<Duration> for std::time::Duration {
+                type Error = std::num::TryFromIntError;
+
+                fn try_from(value: Duration) -> Result<Self, Self::Error> {
+                    Ok(std::time::Duration::new(
+                        value.seconds.try_into()?,
+                        value.nanos.try_into()?,
+                    ))
+                }
+            }
+
+            impl From<std::time::Duration> for Duration {
+                fn from(value: std::time::Duration) -> Self {
+                    Self {
+                        seconds: value.as_secs() as _,
+                        nanos: value.subsec_nanos() as _,
+                    }
+                }
+            }
         }
 
         pub mod rpc {
@@ -22,3 +44,243 @@ mod pb {
 }
 
 pub use pb::google::*;
+
+use pb::google::protobuf::Any;
+use prost::{
+    bytes::{Bytes, BytesMut},
+    Message,
+};
+use std::convert::{TryFrom, TryInto};
+use std::fmt::Display;
+use std::iter::FromIterator;
+
+fn encode_status(code: tonic::Code, message: String, details: Option<Any>) -> tonic::Status {
+    if let Some(details) = details {
+        let mut buffer = BytesMut::new();
+        let status = pb::google::rpc::Status {
+            code: code as i32,
+            message: message.clone(),
+            details: vec![details],
+        };
+
+        if status.encode(&mut buffer).is_ok() {
+            return tonic::Status::with_details(code, message, buffer.freeze());
+        }
+    }
+    tonic::Status::new(code, message)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct FieldViolation {
+    pub field: String,
+    pub description: String,
+}
+
+impl FieldViolation {
+    pub fn required(field: impl Into<String>) -> Self {
+        Self {
+            field: field.into(),
+            description: "Field is required".to_string(),
+        }
+    }
+
+    /// Re-scopes this error as the child of another field
+    pub fn scope(self, field: impl Into<String>) -> Self {
+        let field = if self.field.is_empty() {
+            field.into()
+        } else {
+            [field.into(), self.field].join(".")
+        };
+
+        Self {
+            field,
+            description: self.description,
+        }
+    }
+}
+
+fn encode_bad_request(violation: Vec<FieldViolation>) -> Result<Any, prost::EncodeError> {
+    let mut buffer = BytesMut::new();
+
+    pb::google::rpc::BadRequest {
+        field_violations: violation
+            .into_iter()
+            .map(|f| pb::google::rpc::bad_request::FieldViolation {
+                field: f.field,
+                description: f.description,
+            })
+            .collect(),
+    }
+    .encode(&mut buffer)?;
+
+    Ok(Any {
+        type_url: "type.googleapis.com/google.rpc.BadRequest".to_string(),
+        value: buffer.freeze(),
+    })
+}
+
+impl From<FieldViolation> for tonic::Status {
+    fn from(f: FieldViolation) -> Self {
+        let message = format!("Violation for field \"{}\": {}", f.field, f.description);
+        encode_status(
+            tonic::Code::InvalidArgument,
+            message,
+            encode_bad_request(vec![f]).ok(),
+        )
+    }
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct InternalError {}
+
+impl From<InternalError> for tonic::Status {
+    fn from(_: InternalError) -> Self {
+        tonic::Status::new(tonic::Code::Internal, "Internal Error")
+    }
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct AlreadyExists {
+    pub resource_type: String,
+    pub resource_name: String,
+    pub owner: String,
+    pub description: String,
+}
+
+fn encode_resource_info(
+    resource_type: String,
+    resource_name: String,
+    owner: String,
+    description: String,
+) -> Result<Any, prost::EncodeError> {
+    let mut buffer = BytesMut::new();
+
+    pb::google::rpc::ResourceInfo {
+        resource_type,
+        resource_name,
+        owner,
+        description,
+    }
+    .encode(&mut buffer)?;
+
+    Ok(Any {
+        type_url: "type.googleapis.com/google.rpc.ResourceInfo".to_string(),
+        value: buffer.freeze(),
+    })
+}
+
+impl From<AlreadyExists> for tonic::Status {
+    fn from(exists: AlreadyExists) -> Self {
+        let message = format!(
+            "Resource {}/{} already exists",
+            exists.resource_type, exists.resource_name
+        );
+        encode_status(
+            tonic::Code::AlreadyExists,
+            message,
+            encode_resource_info(
+                exists.resource_type,
+                exists.resource_name,
+                exists.owner,
+                exists.description,
+            )
+            .ok(),
+        )
+    }
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct NotFound {
+    pub resource_type: String,
+    pub resource_name: String,
+    pub owner: String,
+    pub description: String,
+}
+
+impl From<NotFound> for tonic::Status {
+    fn from(not_found: NotFound) -> Self {
+        let message = format!(
+            "Resource {}/{} not found",
+            not_found.resource_type, not_found.resource_name
+        );
+        encode_status(
+            tonic::Code::NotFound,
+            message,
+            encode_resource_info(
+                not_found.resource_type,
+                not_found.resource_name,
+                not_found.owner,
+                not_found.description,
+            )
+            .ok(),
+        )
+    }
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct PreconditionViolation {
+    pub category: String,
+    pub subject: String,
+    pub description: String,
+}
+
+fn encode_precondition_failure(
+    violations: Vec<PreconditionViolation>,
+) -> Result<Any, prost::EncodeError> {
+    use pb::google::rpc::precondition_failure::Violation;
+
+    let mut buffer = BytesMut::new();
+
+    pb::google::rpc::PreconditionFailure {
+        violations: violations
+            .into_iter()
+            .map(|x| Violation {
+                r#type: x.category,
+                subject: x.subject,
+                description: x.description,
+            })
+            .collect(),
+    }
+    .encode(&mut buffer)?;
+
+    Ok(Any {
+        type_url: "type.googleapis.com/google.rpc.PreconditionFailure".to_string(),
+        value: buffer.freeze(),
+    })
+}
+
+impl From<PreconditionViolation> for tonic::Status {
+    fn from(violation: PreconditionViolation) -> Self {
+        let message = format!(
+            "Precondition violation {} - {}: {}",
+            violation.subject, violation.category, violation.description
+        );
+        encode_status(
+            tonic::Code::FailedPrecondition,
+            message,
+            encode_precondition_failure(vec![violation]).ok(),
+        )
+    }
+}
+
+/// An extension trait that adds the ability to convert an error
+/// that can be converted to a String to a FieldViolation
+pub trait FieldViolationExt {
+    type Output;
+
+    fn field(self, field: &'static str) -> Result<Self::Output, FieldViolation>;
+}
+
+impl<T, E> FieldViolationExt for Result<T, E>
+where
+    E: ToString,
+{
+    type Output = T;
+
+    fn field(self, field: &'static str) -> Result<T, FieldViolation> {
+        self.map_err(|e| FieldViolation {
+            field: field.to_string(),
+            description: e.to_string(),
+        })
+    }
+}


### PR DESCRIPTION
gRPC responses contain a response code and a string message, and originally this was the only way they could return errors. To fix this gRPC has since added the ability to return an opaque error details byte array, but, as gRPC is codec agnostic, it doesn't constrain what this payload is.

However, the convention is for it to contain a serialized `google.rpc.Status` protobuf message, which duplicates the status code and message, and includes a repeated field of `google.protobuf.Any`. Again these can be anything, but the [convention](https://cloud.google.com/apis/design/errors#error_payloads) is for one of them to be the standard error payload for the status code. These are just conventions, but many clients either assume them, or make APIs following the convention easier to interface with. As we don't have a strong reason to deviate from these conventions, it makes sense to use them.

Unfortunately aside from exposing a details byte array which it base64 encodes into the relevant header, tonic does not provide support for error details. This PR adds this functionality by allowing conversion from a concrete error type, to a tonic::Status - which is the error type used by tonic gRPC services. The reverse conversion is not yet needed by the influxdb_iox_client, but if/when it is, it would make sense to provide it.