### PR TITLE
docs: Refer to the example env file and clarify comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,8 +122,13 @@ You can see a list of the current configuration values by running `influxdb_iox
 --help`, as well as the specific subcommand config options such as `influxdb_iox
 server --help`.
 
-Should you desire specifying config via a file, you can do so using a `.env`
-formatted file in the working directory.
+Should you desire specifying config via a file, you can do so using a
+`.env` formatted file in the working directory. You can use the
+provided [example](docs/env.example) as a template if you want:
+
+```bash
+cp docs/env.example .env
+```
 
 
 ### Compiling and Starting the Server

--- a/docs/env.example
+++ b/docs/env.example
@@ -1,7 +1,14 @@
-# This is an example .env file showing all of the environment variables that can
-# be configured within the project. Copy this file to the top level directory with
-# the name `.env`, then remove any `#` at the beginning of the lines of variables
-# you'd like to set and change the values.
+# This is an example .env file showing *SOME* of the environment
+# variables that can be configured within IOx. To use this template,
+# copy this file to the top level directory with the name `.env`, and
+# remove any `#` at the beginning of the lines of variables you'd like
+# to set values for.
+#
+# The full list of available configuration values can be found by in
+# the command line help (e.g. `env: INFLUXDB_IOX_DB_DIR=`):
+#
+# ./influxdb_iox server --help
+#
 #
 # The identifier for the server. Used for writing to object storage and as
 # an identifier that is added to replicated writes, WAL segments and Chunks.


### PR DESCRIPTION
This is a minor documentation clarification follow on from https://github.com/influxdata/influxdb_iox/pull/834 to point users at he example config file and clarify the content of that file

- [x] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb_iox/blob/main/README.md).
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
