### PR TITLE
feat: Add S3 plumbing to iodx config

### DIFF
--- a/docs/env.example
+++ b/docs/env.example
@@ -28,7 +28,7 @@
 # AWS_ACCESS_KEY_ID=access_key_value
 # AWS_SECRET_ACCESS_KEY=secret_access_key_value
 # AWS_DEFAULT_REGION=us-east-2
-# AWS_S3_BUCKET_NAME=bucket-name
+# INFLUXDB_IOX_S3_BUCKET=bucket-name
 #
 # If using Google Cloud Storage as an object store:
 # GCS_BUCKET_NAME=bucket_name

--- a/object_store/src/aws.rs
+++ b/object_store/src/aws.rs
@@ -419,26 +419,26 @@ mod tests {
             dotenv::dotenv().ok();
 
             let region = env::var("AWS_DEFAULT_REGION");
-            let bucket_name = env::var("AWS_S3_BUCKET_NAME");
+            let bucket_name = env::var("INFLUXDB_IOX_S3_BUCKET");
             let force = std::env::var("TEST_INTEGRATION");
 
             match (region.is_ok(), bucket_name.is_ok(), force.is_ok()) {
                 (false, false, true) => {
                     panic!(
                         "TEST_INTEGRATION is set, \
-                            but AWS_DEFAULT_REGION and AWS_S3_BUCKET_NAME are not"
+                            but AWS_DEFAULT_REGION and INFLUXDB_IOX_S3_BUCKET are not"
                     )
                 }
                 (false, true, true) => {
                     panic!("TEST_INTEGRATION is set, but AWS_DEFAULT_REGION is not")
                 }
                 (true, false, true) => {
-                    panic!("TEST_INTEGRATION is set, but AWS_S3_BUCKET_NAME is not")
+                    panic!("TEST_INTEGRATION is set, but INFLUXDB_IOX_S3_BUCKET is not")
                 }
                 (false, false, false) => {
                     eprintln!(
                         "skipping integration test - set \
-                               AWS_DEFAULT_REGION and AWS_S3_BUCKET_NAME to run"
+                               AWS_DEFAULT_REGION and INFLUXDB_IOX_S3_BUCKET to run"
                     );
                     return Ok(());
                 }
@@ -447,7 +447,7 @@ mod tests {
                     return Ok(());
                 }
                 (true, false, false) => {
-                    eprintln!("skipping integration test - set AWS_S3_BUCKET_NAME to run");
+                    eprintln!("skipping integration test - set INFLUXDB_IOX_S3_BUCKET to run");
                     return Ok(());
                 }
                 _ => {}
@@ -466,8 +466,8 @@ mod tests {
             "The environment variable AWS_DEFAULT_REGION must be set \
                  to a value like `us-east-2`"
         })?;
-        let bucket_name = env::var("AWS_S3_BUCKET_NAME")
-            .map_err(|_| "The environment variable AWS_S3_BUCKET_NAME must be set")?;
+        let bucket_name = env::var("INFLUXDB_IOX_S3_BUCKET")
+            .map_err(|_| "The environment variable INFLUXDB_IOX_S3_BUCKET must be set")?;
 
         Ok((region.parse()?, bucket_name))
     }

--- a/src/commands/config.rs
+++ b/src/commands/config.rs
@@ -96,6 +96,12 @@ pub struct Config {
     #[structopt(long = "--gcp-bucket", env = "INFLUXDB_IOX_GCP_BUCKET")]
     pub gcp_bucket: Option<String>,
 
+    /// If using S3 for the object store, this item, as well
+    /// as AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY and AWS_DEFAULT_REGION must
+    /// be set.
+    #[structopt(long = "--s3-bucket", env = "INFLUXDB_IOX_S3_BUCKET")]
+    pub s3_bucket: Option<String>,
+
     /// If set, Jaeger traces are emitted to this host
     /// using the OpenTelemetry tracer.
     ///


### PR DESCRIPTION
Rename bucket env var to `INFLUXDB_IOX_S3_BUCKET` for consistency with other storage location related env vars.
(`AWS_S3_BUCKET_NAME` was not a standard env var anyway).

Now S3 can be used to persist snapshots.

Tracking issue #808