### PR TITLE
chore: add DS_Store into .gitignore to avoid unecessary noises

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .idea/
 .env
 *.tsm
+**/.DS_Store


### PR DESCRIPTION
Closes #

This PR adds DS_Store into .gitignore to avoid unnecessary noises on Mac

- [x] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb_iox/blob/main/README.md).
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
