### PR TITLE
feat: implement format parameter on sql query endpoint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,6 +78,7 @@ serde_json = "1.0.44"
 serde_urlencoded = "0.7.0"
 snafu = "0.6.9"
 structopt = "0.3.21"
+tempfile = "3.1.0"
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread", "parking_lot"] }
 tokio-stream = { version = "0.1.2", features = ["net"] }
 tonic = "0.4.0"
@@ -100,7 +101,6 @@ hex = "0.4.2"
 predicates = "1.0.4"
 rand = "0.7.2"
 reqwest = "0.11"
-tempfile = "3.1.0"
 
 [[bin]]
 name = "cpu_feature_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,7 +78,6 @@ serde_json = "1.0.44"
 serde_urlencoded = "0.7.0"
 snafu = "0.6.9"
 structopt = "0.3.21"
-tempfile = "3.1.0"
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread", "parking_lot"] }
 tokio-stream = { version = "0.1.2", features = ["net"] }
 tonic = "0.4.0"
@@ -101,6 +100,7 @@ hex = "0.4.2"
 predicates = "1.0.4"
 rand = "0.7.2"
 reqwest = "0.11"
+tempfile = "3.1.0"
 
 [[bin]]
 name = "cpu_feature_check"

--- a/src/influxdb_ioxd/http.rs
+++ b/src/influxdb_ioxd/http.rs
@@ -1,5 +1,6 @@
-//! This module contains a partial implementation of the /v2 HTTP api
-//! routes for InfluxDB IOx.
+//! This module contains the HTTP api for InfluxDB IOx, including a
+//! partial implementation of the /v2 HTTP api routes from InfluxDB
+//! for compatibility.
 //!
 //! Note that these routes are designed to be just helpers for now,
 //! and "close enough" to the real /v2 api to be able to test InfluxDB IOx
@@ -10,7 +11,7 @@
 //! database names and may remove this quasi /v2 API.
 
 // Influx crates
-use arrow_deps::{arrow, datafusion::physical_plan::collect};
+use arrow_deps::datafusion::physical_plan::collect;
 use data_types::{
     database_rules::DatabaseRules,
     http::{ListDatabasesResponse, WalMetadataQuery},
@@ -34,6 +35,9 @@ use tracing::{debug, error, info};
 
 use data_types::http::WalMetadataResponse;
 use std::{fmt::Debug, str, sync::Arc};
+
+mod format;
+use format::QueryOutputFormat;
 
 #[derive(Debug, Snafu)]
 pub enum ApplicationError {
@@ -86,7 +90,9 @@ pub enum ApplicationError {
     #[snafu(display("Expected query string in request, but none was provided"))]
     ExpectedQueryString {},
 
-    #[snafu(display("Invalid query string '{}': {}", query_string, source))]
+    /// Error for when we could not parse the http query uri (e.g.
+    /// `?foo=bar&bar=baz)`
+    #[snafu(display("Invalid query string in HTTP URI '{}': {}", query_string, source))]
     InvalidQueryString {
         query_string: String,
         source: serde_urlencoded::de::Error,
@@ -151,6 +157,18 @@ pub enum ApplicationError {
 
     #[snafu(display("Database {} does not have a WAL", name))]
     WALNotFound { name: String },
+
+    #[snafu(display(
+        "Error formatting results of SQL query '{}' using '{:?}': {}",
+        q,
+        format,
+        source
+    ))]
+    FormattingResult {
+        q: String,
+        format: QueryOutputFormat,
+        source: format::Error,
+    },
 }
 
 impl ApplicationError {
@@ -181,6 +199,7 @@ impl ApplicationError {
             Self::DatabaseNameError { .. } => self.bad_request(),
             Self::DatabaseNotFound { .. } => self.not_found(),
             Self::WALNotFound { .. } => self.not_found(),
+            Self::FormattingResult { .. } => self.internal_error(),
         }
     }
 
@@ -259,7 +278,6 @@ where
         })) // this endpoint is for API backward compatibility with InfluxDB 2.x
         .post("/api/v2/write", write::<M>)
         .get("/ping", ping)
-        .get("/api/v2/read", read::<M>)
         .get("/iox/api/v1/databases", list_databases::<M>)
         .put("/iox/api/v1/databases/:name", create_database::<M>)
         .get("/iox/api/v1/databases/:name", get_database::<M>)
@@ -407,80 +425,35 @@ where
         .unwrap())
 }
 
-#[derive(Deserialize, Debug)]
-/// Body of the request to the /read endpoint
-struct ReadInfo {
-    org: String,
-    bucket: String,
-    // TODO This is currently a "SQL" request -- should be updated to conform
-    // to the V2 API for reading (using timestamps, etc).
-    sql_query: String,
-}
-
-// TODO: figure out how to stream read results out rather than rendering the
-// whole thing in mem
-#[tracing::instrument(level = "debug")]
-async fn read<M: ConnectionManager + Send + Sync + Debug + 'static>(
-    req: Request<Body>,
-) -> Result<Response<Body>, ApplicationError> {
-    let server = Arc::clone(&req.data::<Arc<AppServer<M>>>().expect("server state"));
-    let query = req.uri().query().context(ExpectedQueryString {})?;
-
-    let read_info: ReadInfo = serde_urlencoded::from_str(query).context(InvalidQueryString {
-        query_string: query,
-    })?;
-
-    let planner = SQLQueryPlanner::default();
-    let executor = server.executor();
-
-    let db_name = org_and_bucket_to_database(&read_info.org, &read_info.bucket)
-        .context(BucketMappingError)?;
-
-    let db = server.db(&db_name).await.context(BucketNotFound {
-        org: read_info.org.clone(),
-        bucket: read_info.bucket.clone(),
-    })?;
-
-    let physical_plan = planner
-        .query(db.as_ref(), &read_info.sql_query, executor.as_ref())
-        .await
-        .context(PlanningSQLQuery { query })?;
-
-    let batches = collect(physical_plan)
-        .await
-        .map_err(|e| Box::new(e) as _)
-        .context(Query { db_name })?;
-
-    let results = arrow::util::pretty::pretty_format_batches(&batches).unwrap();
-
-    Ok(Response::new(Body::from(results.into_bytes())))
-}
-
-#[derive(Deserialize, Debug)]
-/// Body of the request to the .../query endpoint
-struct QueryInfo {
+#[derive(Deserialize, Debug, PartialEq)]
+/// Parsed URI Parameters of the request to the .../query endpoint
+struct QueryParams {
     q: String,
+    #[serde(default)]
+    format: QueryOutputFormat,
 }
 
-// TODO: figure out how to stream read results out rather than rendering the
-// whole thing in mem
 #[tracing::instrument(level = "debug")]
 async fn query<M: ConnectionManager + Send + Sync + Debug + 'static>(
     req: Request<Body>,
 ) -> Result<Response<Body>, ApplicationError> {
     let server = Arc::clone(&req.data::<Arc<AppServer<M>>>().expect("server state"));
 
-    let query = req.uri().query().context(ExpectedQueryString {})?;
+    let uri_query = req.uri().query().context(ExpectedQueryString {})?;
 
-    let query_info: QueryInfo = serde_urlencoded::from_str(query).context(InvalidQueryString {
-        query_string: query,
-    })?;
+    let QueryParams { q, format } =
+        serde_urlencoded::from_str(uri_query).context(InvalidQueryString {
+            query_string: uri_query,
+        })?;
 
     let db_name_str = req
         .param("name")
-        .expect("db name must have been set")
+        .expect("db name must have been set by routerify")
         .clone();
+
     let db_name = DatabaseName::new(&db_name_str).context(DatabaseNameError)?;
+    debug!(uri = ?req.uri(), %q, ?format, %db_name, "running SQL query");
+
     let db = server
         .db(&db_name)
         .await
@@ -490,16 +463,20 @@ async fn query<M: ConnectionManager + Send + Sync + Debug + 'static>(
     let executor = server.executor();
 
     let physical_plan = planner
-        .query(db.as_ref(), &query_info.q, executor.as_ref())
+        .query(db.as_ref(), &q, executor.as_ref())
         .await
-        .context(PlanningSQLQuery { query })?;
+        .context(PlanningSQLQuery { query: &q })?;
 
+    // TODO: stream read results out rather than rendering the
+    // whole thing in mem
     let batches = collect(physical_plan)
         .await
         .map_err(|e| Box::new(e) as _)
         .context(Query { db_name })?;
 
-    let results = arrow::util::pretty::pretty_format_batches(&batches).unwrap();
+    let results = format
+        .format(&batches)
+        .context(FormattingResult { q, format })?;
 
     Ok(Response::new(Body::from(results.into_bytes())))
 }
@@ -882,9 +859,11 @@ mod tests {
         Ok(())
     }
 
-    #[tokio::test]
-    async fn test_query() -> Result<()> {
-        let test_storage = Arc::new(AppServer::new(
+    /// Sets up a test database with some data for testing the query endpoint
+    /// returns a client for communicting with the server, and the server
+    /// endpoint
+    async fn setup_test_data() -> (Client, String) {
+        let test_storage: Arc<AppServer<ConnectionManagerImpl>> = Arc::new(AppServer::new(
             ConnectionManagerImpl {},
             Arc::new(ObjectStore::new_in_memory(InMemory::new())),
         ));
@@ -912,6 +891,12 @@ mod tests {
             .await;
 
         check_response("write", response, StatusCode::NO_CONTENT, "").await;
+        (client, server_url)
+    }
+
+    #[tokio::test]
+    async fn test_query_pretty() -> Result<()> {
+        let (client, server_url) = setup_test_data().await;
 
         // send query data
         let response = client
@@ -927,6 +912,75 @@ mod tests {
                    +----------------+--------------+-------+-----------------+------------+\n\
                    | 50.4           | santa_monica | CA    | 65.2            | 1568756160 |\n\
                    +----------------+--------------+-------+-----------------+------------+\n";
+        check_response("query", response, StatusCode::OK, res).await;
+
+        // same response is expected if we explicitly request 'format=pretty'
+        let response = client
+            .get(&format!(
+                "{}/iox/api/v1/databases/MyOrg_MyBucket/query?q={}&format=pretty",
+                server_url, "select%20*%20from%20h2o_temperature"
+            ))
+            .send()
+            .await;
+        check_response("query", response, StatusCode::OK, res).await;
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_query_csv() -> Result<()> {
+        let (client, server_url) = setup_test_data().await;
+
+        // send query data
+        let response = client
+            .get(&format!(
+                "{}/iox/api/v1/databases/MyOrg_MyBucket/query?q={}&format=csv",
+                server_url, "select%20*%20from%20h2o_temperature"
+            ))
+            .send()
+            .await;
+
+        let res = "bottom_degrees,location,state,surface_degrees,time\n\
+                   50.4,santa_monica,CA,65.2,1568756160\n";
+        check_response("query", response, StatusCode::OK, res).await;
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_query_json() -> Result<()> {
+        let (client, server_url) = setup_test_data().await;
+
+        // send a second line of data to demontrate how that works
+        let lp_data = "h2o_temperature,location=Boston,state=MA surface_degrees=50.2 1568756160";
+
+        // send write data
+        let bucket_name = "MyBucket";
+        let org_name = "MyOrg";
+        let response = client
+            .post(&format!(
+                "{}/api/v2/write?bucket={}&org={}",
+                server_url, bucket_name, org_name
+            ))
+            .body(lp_data)
+            .send()
+            .await;
+
+        check_response("write", response, StatusCode::NO_CONTENT, "").await;
+
+        // send query data
+        let response = client
+            .get(&format!(
+                "{}/iox/api/v1/databases/MyOrg_MyBucket/query?q={}&format=json",
+                server_url, "select%20*%20from%20h2o_temperature"
+            ))
+            .send()
+            .await;
+
+        // Note two json records: one record on each line
+        let res = r#"{"bottom_degrees":50.4,"location":"santa_monica","state":"CA","surface_degrees":65.2,"time":1568756160}
+{"location":"Boston","state":"MA","surface_degrees":50.2,"time":1568756160}
+"#;
         check_response("query", response, StatusCode::OK, res).await;
 
         Ok(())
@@ -1289,5 +1343,60 @@ mod tests {
         let physical_plan = planner.query(db, query, &executor).await.unwrap();
 
         collect(physical_plan).await.unwrap()
+    }
+
+    #[test]
+    fn query_params_format_default() {
+        // default to pretty format when not otherwise specified
+        assert_eq!(
+            serde_urlencoded::from_str("q=foo"),
+            Ok(QueryParams {
+                q: "foo".to_string(),
+                format: QueryOutputFormat::Pretty
+            })
+        );
+    }
+
+    #[test]
+    fn query_params_format_pretty() {
+        assert_eq!(
+            serde_urlencoded::from_str("q=foo&format=pretty"),
+            Ok(QueryParams {
+                q: "foo".to_string(),
+                format: QueryOutputFormat::Pretty
+            })
+        );
+    }
+
+    #[test]
+    fn query_params_format_csv() {
+        assert_eq!(
+            serde_urlencoded::from_str("q=foo&format=csv"),
+            Ok(QueryParams {
+                q: "foo".to_string(),
+                format: QueryOutputFormat::CSV
+            })
+        );
+    }
+
+    #[test]
+    fn query_params_format_json() {
+        assert_eq!(
+            serde_urlencoded::from_str("q=foo&format=json"),
+            Ok(QueryParams {
+                q: "foo".to_string(),
+                format: QueryOutputFormat::JSON
+            })
+        );
+    }
+
+    #[test]
+    fn query_params_bad_format() {
+        assert_eq!(
+            serde_urlencoded::from_str::<QueryParams>("q=foo&format=jsob")
+                .unwrap_err()
+                .to_string(),
+            "unknown variant `jsob`, expected one of `pretty`, `csv`, `json`"
+        );
     }
 }

--- a/src/influxdb_ioxd/http.rs
+++ b/src/influxdb_ioxd/http.rs
@@ -996,9 +996,7 @@ mod tests {
         assert_eq!(get_content_type(&response), "application/json");
 
         // Note two json records: one record on each line
-        let res = r#"{"bottom_degrees":50.4,"location":"santa_monica","state":"CA","surface_degrees":65.2,"time":1568756160}
-{"location":"Boston","state":"MA","surface_degrees":50.2,"time":1568756160}
-"#;
+        let res = r#"[{"bottom_degrees":50.4,"location":"santa_monica","state":"CA","surface_degrees":65.2,"time":1568756160},{"location":"Boston","state":"MA","surface_degrees":50.2,"time":1568756160}]"#;
         check_response("query", response, StatusCode::OK, res).await;
 
         Ok(())

--- a/src/influxdb_ioxd/http/format.rs
+++ b/src/influxdb_ioxd/http/format.rs
@@ -1,0 +1,140 @@
+//! Output formatting utilities for query endpoint
+
+use serde::Deserialize;
+use snafu::{ResultExt, Snafu};
+use std::io::{BufWriter, Read, Seek};
+
+use arrow_deps::arrow::{self, csv::WriterBuilder, error::ArrowError, record_batch::RecordBatch};
+
+#[derive(Debug, Snafu)]
+pub enum Error {
+    #[snafu(display("Arrow pretty printing error {}", source))]
+    PrettyArrow { source: ArrowError },
+
+    #[snafu(display("Arrow csv printing error {}", source))]
+    CsvArrow { source: ArrowError },
+
+    #[snafu(display("Arrow json printing error {}", source))]
+    JsonArrow { source: ArrowError },
+
+    #[snafu(display("Error creating temp file: {}", source))]
+    TempFileCreation { source: std::io::Error },
+
+    #[snafu(display("Temp file error while {}: {}", note, source))]
+    TempFile {
+        note: String,
+        source: std::io::Error,
+    },
+}
+type Result<T, E = Error> = std::result::Result<T, E>;
+
+#[derive(Deserialize, Debug, Copy, Clone, PartialEq)]
+/// Requested output format for the query endpoint
+pub enum QueryOutputFormat {
+    /// Arrow pretty printer format (default)
+    #[serde(rename = "pretty")]
+    Pretty,
+    /// Comma separated values
+    #[serde(rename = "csv")]
+    CSV,
+    /// Arrow JSON format
+    #[serde(rename = "json")]
+    JSON,
+}
+
+impl Default for QueryOutputFormat {
+    fn default() -> Self {
+        Self::Pretty
+    }
+}
+
+impl QueryOutputFormat {
+    /// Format the [`RecordBatch`]es into a String in one of the following
+    /// formats:
+    ///
+    /// Pretty:
+    /// ```text
+    /// +----------------+--------------+-------+-----------------+------------+
+    /// | bottom_degrees | location     | state | surface_degrees | time       |
+    /// +----------------+--------------+-------+-----------------+------------+
+    /// | 50.4           | santa_monica | CA    | 65.2            | 1568756160 |
+    /// +----------------+--------------+-------+-----------------+------------+
+    /// ```
+    ///
+    /// CSV:
+    /// ```text
+    /// bottom_degrees,location,state,surface_degrees,time
+    /// 50.4,santa_monica,CA,65.2,1568756160
+    /// ```
+    ///
+    /// JSON:
+    ///
+    /// Example:
+    /// ```text
+    /// {"bottom_degrees":50.4,"location":"santa_monica","state":"CA","surface_degrees":65.2,"time":1568756160}
+    /// {"location":"Boston","state":"MA","surface_degrees":50.2,"time":1568756160}
+    /// ```
+    pub fn format(&self, batches: &[RecordBatch]) -> Result<String> {
+        match self {
+            Self::Pretty => batches_to_pretty(&batches),
+            Self::CSV => batches_to_csv(&batches),
+            Self::JSON => batches_to_json(&batches),
+        }
+    }
+}
+
+fn batches_to_pretty(batches: &[RecordBatch]) -> Result<String> {
+    arrow::util::pretty::pretty_format_batches(batches).context(PrettyArrow)
+}
+
+fn batches_to_csv(batches: &[RecordBatch]) -> Result<String> {
+    let mut tmp = tempfile::tempfile().context(TempFileCreation)?;
+
+    let tmp_writer = BufWriter::new(tmp.try_clone().context(TempFile {
+        note: "cloning filehandle",
+    })?);
+
+    let mut writer = WriterBuilder::new().has_headers(true).build(tmp_writer);
+
+    for batch in batches {
+        writer.write(batch).context(CsvArrow)?;
+    }
+    // drop the write to ensure we have flushed all data
+    std::mem::drop(writer);
+
+    tmp.seek(std::io::SeekFrom::Start(0)).context(TempFile {
+        note: "seeking to start",
+    })?;
+
+    let mut csv = String::new();
+    tmp.read_to_string(&mut csv).context(TempFile {
+        note: "reading as string",
+    })?;
+
+    Ok(csv)
+}
+
+fn batches_to_json(batches: &[RecordBatch]) -> Result<String> {
+    let mut tmp = tempfile::tempfile().context(TempFileCreation)?;
+
+    let tmp_writer = BufWriter::new(tmp.try_clone().context(TempFile {
+        note: "cloning filehandle",
+    })?);
+
+    let mut writer = arrow::json::Writer::new(tmp_writer);
+    writer.write_batches(batches).context(JsonArrow)?;
+
+    // drop the write to ensure we have flushed all data
+    std::mem::drop(writer);
+
+    tmp.seek(std::io::SeekFrom::Start(0)).context(TempFile {
+        note: "seeking to start",
+    })?;
+
+    let mut json = String::new();
+    tmp.read_to_string(&mut json).context(TempFile {
+        note: "reading as string",
+    })?;
+
+    Ok(json)
+}

--- a/src/influxdb_ioxd/http/format.rs
+++ b/src/influxdb_ioxd/http/format.rs
@@ -142,10 +142,8 @@ fn batches_to_json(batches: &[RecordBatch]) -> Result<String> {
 ///
 /// This is based on the arrow JSON writer (json::writer::Writer)
 ///
-/// TODO contribute this back to arrow) alongside  (or maybe have it be an
-/// option)
-
-pub struct JsonArrayWriter<W>
+/// TODO contribute this back to arrow: https://issues.apache.org/jira/browse/ARROW-11773
+struct JsonArrayWriter<W>
 where
     W: Write,
 {
@@ -167,7 +165,8 @@ where
     }
 
     /// Consume self and return the inner writer
-    pub fn to_inner(self) -> W {
+    #[cfg(test)]
+    pub fn into_inner(self) -> W {
         self.writer
     }
 
@@ -212,7 +211,7 @@ mod tests {
     fn json_writer_empty() {
         let mut writer = JsonArrayWriter::new(vec![] as Vec<u8>);
         writer.finish().unwrap();
-        assert_eq!(String::from_utf8(writer.to_inner()).unwrap(), "");
+        assert_eq!(String::from_utf8(writer.into_inner()).unwrap(), "");
     }
 
     #[test]
@@ -222,7 +221,7 @@ mod tests {
         writer.write_row(&v).unwrap();
         writer.finish().unwrap();
         assert_eq!(
-            String::from_utf8(writer.to_inner()).unwrap(),
+            String::from_utf8(writer.into_inner()).unwrap(),
             r#"[{"an":"object"}]"#
         );
     }
@@ -236,7 +235,7 @@ mod tests {
         writer.write_row(&v).unwrap();
         writer.finish().unwrap();
         assert_eq!(
-            String::from_utf8(writer.to_inner()).unwrap(),
+            String::from_utf8(writer.into_inner()).unwrap(),
             r#"[{"an":"object"},{"another":"object"}]"#
         );
     }

--- a/src/influxdb_ioxd/http/format.rs
+++ b/src/influxdb_ioxd/http/format.rs
@@ -49,6 +49,17 @@ impl Default for QueryOutputFormat {
 }
 
 impl QueryOutputFormat {
+    /// Return the content type of the relevant format
+    pub fn content_type(&self) -> &'static str {
+        match self {
+            Self::Pretty => "text/plain",
+            Self::CSV => "text/csv",
+            Self::JSON => "application/json",
+        }
+    }
+}
+
+impl QueryOutputFormat {
     /// Format the [`RecordBatch`]es into a String in one of the following
     /// formats:
     ///

--- a/tests/end-to-end.rs
+++ b/tests/end-to-end.rs
@@ -48,7 +48,7 @@ const HTTP_BIND_ADDR: &str = http_bind_addr!();
 const GRPC_BIND_ADDR: &str = grpc_bind_addr!();
 
 const HTTP_BASE: &str = concat!("http://", http_bind_addr!());
-const API_BASE: &str = concat!("http://", http_bind_addr!(), "/api/v2");
+const IOX_API_V1_BASE: &str = concat!("http://", http_bind_addr!(), "/iox/api/v1");
 const GRPC_URL_BASE: &str = concat!("http://", grpc_bind_addr!(), "/");
 
 const TOKEN: &str = "InfluxDB IOx doesn't have authentication yet";

--- a/tests/end_to_end_cases/read_api.rs
+++ b/tests/end_to_end_cases/read_api.rs
@@ -1,4 +1,4 @@
-use crate::{Scenario, API_BASE};
+use crate::{Scenario, IOX_API_V1_BASE};
 
 pub async fn test(
     client: &reqwest::Client,
@@ -6,7 +6,7 @@ pub async fn test(
     sql_query: &str,
     expected_read_data: &[String],
 ) {
-    let text = read_data_as_sql(&client, "/read", scenario, sql_query).await;
+    let text = read_data_as_sql(&client, scenario, sql_query).await;
 
     assert_eq!(
         text, expected_read_data,
@@ -17,18 +17,15 @@ pub async fn test(
 
 async fn read_data_as_sql(
     client: &reqwest::Client,
-    path: &str,
     scenario: &Scenario,
     sql_query: &str,
 ) -> Vec<String> {
-    let url = format!("{}{}", API_BASE, path);
+    let db_name = format!("{}_{}", scenario.org_id_str(), scenario.bucket_id_str());
+    let path = format!("/databases/{}/query", db_name);
+    let url = format!("{}{}", IOX_API_V1_BASE, path);
     let lines = client
         .get(&url)
-        .query(&[
-            ("bucket", scenario.bucket_id_str()),
-            ("org", scenario.org_id_str()),
-            ("sql_query", sql_query),
-        ])
+        .query(&[("q", sql_query)])
         .send()
         .await
         .unwrap()


### PR DESCRIPTION
Resolves #726, builds on https://github.com/influxdata/influxdb_iox/pull/866 from @mkmik 

# Changes:
1. Adds the ability to get the results of a query in CSV and JSON as well as pretty print (defaults to pretty)
2. Remove old (org/bucket based) query api

# Follow on work:
1. Contemplate supporting jsonl -- tracked by https://github.com/influxdata/influxdb_iox/issues/872
2. Support query streaming -- https://github.com/influxdata/influxdb_iox/issues/873
3. Contribute Arrow JSON writer upstream: https://issues.apache.org/jira/browse/ARROW-11773


- [x] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb_iox/blob/main/README.md).
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
