### PR TITLE
fix: Remove test for non-existing DNS record

### DIFF
--- a/src/commands/config.rs
+++ b/src/commands/config.rs
@@ -301,15 +301,6 @@ mod tests {
             clap::ErrorKind::ValueValidation
         );
 
-        assert_eq!(
-            Config::from_iter_safe(strip_server(
-                to_vec(&["cmd", "server", "--api-bind", "badhost.badtld:1234"]).into_iter(),
-            ))
-            .map_err(|e| e.kind)
-            .expect_err("must fail"),
-            clap::ErrorKind::ValueValidation
-        );
-
         Ok(())
     }
 }


### PR DESCRIPTION
Some recursive DNS servers by design return an IP record for every single request they get, even if there is no real DNS record for that name. My mobile ISP (TIM italy) is one of them; I didn't notice because I override the DHCP settings on my laptop to force 8.8.8.8.

I don't know how to write a portable test that ensures we fail with validation error in case of a DNS name that doesn't return any records. Hence I think we should drop this test that causes more problems that what it solves.