### PR TITLE
feat: Consolidate all bucket config into one option/env var

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -5,9 +5,11 @@ interest for those who wish to understand how the code works. It is
 not intended to be general user facing documentation
 
 ## Table of Contents:
+
 * Rust style and Idiom guide: [style_guide.md](style_guide.md)
 * Tracing and logging Guide: [tracing.md](tracing.md)
 * How InfluxDB IOx manages the lifecycle of time series data: [data_management.md](data_management.md)
 * Thoughts on parquet encoding and compression for timeseries data: [encoding_thoughts.md](encoding_thoughts.md)
 * Thoughts on using multiple cores: [multi_core_tasks.md](multi_core_tasks.md)
 * [Query Engine Docs](../query/README.md)
+* [Testing documentation](testing.md) for developers of IOx

--- a/docs/env.example
+++ b/docs/env.example
@@ -28,10 +28,10 @@
 # AWS_ACCESS_KEY_ID=access_key_value
 # AWS_SECRET_ACCESS_KEY=secret_access_key_value
 # AWS_DEFAULT_REGION=us-east-2
-# INFLUXDB_IOX_S3_BUCKET=bucket-name
+# INFLUXDB_IOX_BUCKET=bucket-name
 #
 # If using Google Cloud Storage as an object store:
-# INFLUXDB_IOX_GCP_BUCKET=bucket_name
+# INFLUXDB_IOX_BUCKET=bucket_name
 # Set one of SERVICE_ACCOUNT or GOOGLE_APPLICATION_CREDENTIALS, either to a path of a filename
 # containing Google credential JSON or to the JSON directly.
 # SERVICE_ACCOUNT=/path/to/auth/info.json
@@ -41,7 +41,7 @@
 # The name you see when going to All Services > Storage accounts > [name]
 # AZURE_STORAGE_ACCOUNT=
 # The name of a container you've created in the storage account, under Blob Service > Containers
-# AZURE_STORAGE_CONTAINER=
+# INFLUXDB_IOX_BUCKET=
 # In the Storage account's Settings > Access keys, one of the Key values
 # AZURE_STORAGE_MASTER_KEY=
 #

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -9,11 +9,11 @@ This document covers details that are only relevant if you are developing IOx an
 If you are testing integration with some or all of the object storage options, you'll have more
 setup to do.
 
-By default, `cargo test --workspace` does not run any tests that actually contact any cloud
-services: tests that do contact the services will silently pass.
+By default, `cargo test -p object_store` does not run any tests that actually contact
+any cloud services: tests that do contact the services will silently pass.
 
 To ensure you've configured object storage integration testing correctly, you can run
-`TEST_INTEGRATION=1 cargo test --workspace`, which will run the tests that contact the cloud
+`TEST_INTEGRATION=1 cargo test -p object_store`, which will run the tests that contact the cloud
 services and fail them if the required environment variables aren't set.
 
 If you don't specify the `TEST_INTEGRATION` environment variable but you do configure some or all
@@ -25,3 +25,26 @@ When running `influxdb_iox server`, you can pick one object store to use. When r
 you can run them against all the possible object stores. There's still only one
 `INFLUXDB_IOX_BUCKET` variable, though, so that will set the bucket name for all configured object
 stores. Use the same bucket name when setting up the different services.
+
+Other than possibly configuring multiple object stores, configuring the tests to use the object
+store services is the same as configuring the server to use an object store service. See the output
+of `influxdb_iox server --help` for instructions.
+
+## InfluxDB IOx Client
+
+The `influxdb_iox_client` crate might be used by people who are using a managed IOx server. In
+other words, they might only use the `influxdb_iox_client` crate and not the rest of the crates in
+this workspace. The tests in `influxdb_iox_client` see an IOx server in the same way as IOx servers
+see the object store services: sometimes you'll want to run the tests against an actual server, and
+sometimes you won't.
+
+Like in the `object_store` crate, the `influxdb_iox_client` crate's tests use the
+`TEST_INTEGRATION` environment variable to enforce running tests that use an actual IOx server.
+Running `cargo test -p influxdb_iox_client` will silently pass tests that contact a server.
+
+Start an IOx server in one terminal and run `TEST_INTEGRATION=1
+TEST_IOX_ENDPOINT=http://127.0.0.1:8080 cargo test -p influxdb_iox_client` in another (where
+`http://127.0.0.1:8080` is the address to the IOx HTTP server) to run the client tests against the
+server. If you set `TEST_INTEGRATION` but not `TEST_IOX_ENDPOINT`, the integration tests will fail
+because of the missed configuration. If you set `TEST_IOX_ENDPOINT` but not `TEST_INTEGRATION`, the
+integration tests will be run.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,27 @@
+# Testing
+
+This document covers details that are only relevant if you are developing IOx and running the tests.
+
+## Object storage
+
+### To run the tests or not run the tests
+
+If you are testing integration with some or all of the object storage options, you'll have more
+setup to do.
+
+By default, `cargo test --workspace` does not run any tests that actually contact any cloud
+services: tests that do contact the services will silently pass.
+
+To ensure you've configured object storage integration testing correctly, you can run
+`TEST_INTEGRATION=1 cargo test --workspace`, which will run the tests that contact the cloud
+services and fail them if the required environment variables aren't set.
+
+If you don't specify the `TEST_INTEGRATION` environment variable but you do configure some or all
+of the object stores, the relevant tests will run.
+
+### Configuration differences when running the tests
+
+When running `influxdb_iox server`, you can pick one object store to use. When running the tests,
+you can run them against all the possible object stores. There's still only one
+`INFLUXDB_IOX_BUCKET` variable, though, so that will set the bucket name for all configured object
+stores. Use the same bucket name when setting up the different services.

--- a/object_store/src/aws.rs
+++ b/object_store/src/aws.rs
@@ -419,26 +419,26 @@ mod tests {
             dotenv::dotenv().ok();
 
             let region = env::var("AWS_DEFAULT_REGION");
-            let bucket_name = env::var("INFLUXDB_IOX_S3_BUCKET");
+            let bucket_name = env::var("INFLUXDB_IOX_BUCKET");
             let force = std::env::var("TEST_INTEGRATION");
 
             match (region.is_ok(), bucket_name.is_ok(), force.is_ok()) {
                 (false, false, true) => {
                     panic!(
                         "TEST_INTEGRATION is set, \
-                            but AWS_DEFAULT_REGION and INFLUXDB_IOX_S3_BUCKET are not"
+                            but AWS_DEFAULT_REGION and INFLUXDB_IOX_BUCKET are not"
                     )
                 }
                 (false, true, true) => {
                     panic!("TEST_INTEGRATION is set, but AWS_DEFAULT_REGION is not")
                 }
                 (true, false, true) => {
-                    panic!("TEST_INTEGRATION is set, but INFLUXDB_IOX_S3_BUCKET is not")
+                    panic!("TEST_INTEGRATION is set, but INFLUXDB_IOX_BUCKET is not")
                 }
                 (false, false, false) => {
                     eprintln!(
                         "skipping integration test - set \
-                               AWS_DEFAULT_REGION and INFLUXDB_IOX_S3_BUCKET to run"
+                               AWS_DEFAULT_REGION and INFLUXDB_IOX_BUCKET to run"
                     );
                     return Ok(());
                 }
@@ -447,7 +447,7 @@ mod tests {
                     return Ok(());
                 }
                 (true, false, false) => {
-                    eprintln!("skipping integration test - set INFLUXDB_IOX_S3_BUCKET to run");
+                    eprintln!("skipping integration test - set INFLUXDB_IOX_BUCKET to run");
                     return Ok(());
                 }
                 _ => {}
@@ -466,8 +466,8 @@ mod tests {
             "The environment variable AWS_DEFAULT_REGION must be set \
                  to a value like `us-east-2`"
         })?;
-        let bucket_name = env::var("INFLUXDB_IOX_S3_BUCKET")
-            .map_err(|_| "The environment variable INFLUXDB_IOX_S3_BUCKET must be set")?;
+        let bucket_name = env::var("INFLUXDB_IOX_BUCKET")
+            .map_err(|_| "The environment variable INFLUXDB_IOX_BUCKET must be set")?;
 
         Ok((region.parse()?, bucket_name))
     }

--- a/object_store/src/azure.rs
+++ b/object_store/src/azure.rs
@@ -299,7 +299,7 @@ mod tests {
 
             let required_vars = [
                 "AZURE_STORAGE_ACCOUNT",
-                "AZURE_STORAGE_CONTAINER",
+                "INFLUXDB_IOX_BUCKET",
                 "AZURE_STORAGE_MASTER_KEY",
             ];
             let unset_vars: Vec<_> = required_vars
@@ -334,8 +334,8 @@ mod tests {
     async fn azure_blob_test() -> Result<()> {
         maybe_skip_integration!();
 
-        let container_name = env::var("AZURE_STORAGE_CONTAINER")
-            .map_err(|_| "The environment variable AZURE_STORAGE_CONTAINER must be set")?;
+        let container_name = env::var("INFLUXDB_IOX_BUCKET")
+            .map_err(|_| "The environment variable INFLUXDB_IOX_BUCKET must be set")?;
         let integration = MicrosoftAzure::new_from_env(container_name);
 
         put_get_delete_list(&integration).await?;

--- a/object_store/src/gcp.rs
+++ b/object_store/src/gcp.rs
@@ -267,15 +267,15 @@ mod test {
         () => {
             dotenv::dotenv().ok();
 
-            let bucket_name = env::var("GCS_BUCKET_NAME");
+            let bucket_name = env::var("INFLUXDB_IOX_BUCKET");
             let force = std::env::var("TEST_INTEGRATION");
 
             match (bucket_name.is_ok(), force.is_ok()) {
                 (false, true) => {
-                    panic!("TEST_INTEGRATION is set, but GCS_BUCKET_NAME is not")
+                    panic!("TEST_INTEGRATION is set, but INFLUXDB_IOX_BUCKET is not")
                 }
                 (false, false) => {
-                    eprintln!("skipping integration test - set GCS_BUCKET_NAME to run");
+                    eprintln!("skipping integration test - set INFLUXDB_IOX_BUCKET to run");
                     return Ok(());
                 }
                 _ => {}
@@ -284,8 +284,8 @@ mod test {
     }
 
     fn bucket_name() -> Result<String> {
-        Ok(env::var("GCS_BUCKET_NAME")
-            .map_err(|_| "The environment variable GCS_BUCKET_NAME must be set")?)
+        Ok(env::var("INFLUXDB_IOX_BUCKET")
+            .map_err(|_| "The environment variable INFLUXDB_IOX_BUCKET must be set")?)
     }
 
     #[tokio::test]

--- a/src/commands/config.rs
+++ b/src/commands/config.rs
@@ -1,8 +1,8 @@
 //! Implementation of command line option for manipulating and showing server
 //! config
 
+use clap::arg_enum;
 use std::{net::SocketAddr, net::ToSocketAddrs, path::PathBuf};
-
 use structopt::StructOpt;
 
 /// The default bind address for the HTTP API.
@@ -91,16 +91,37 @@ pub struct Config {
     #[structopt(long = "--data-dir", env = "INFLUXDB_IOX_DB_DIR")]
     pub database_directory: Option<PathBuf>,
 
+    #[structopt(
+        long = "--object-store",
+        env = "INFLUXDB_IOX_OBJECT_STORE",
+        possible_values = &ObjectStore::variants(),
+        case_insensitive = true,
+        long_help = r#"Which object storage to use. If not specified, defaults to memory.
+
+Possible values (case insensitive):
+
+* memory (default): Effectively no object persistence.
+* file: Stores objects in the local filesystem. Must also set `--database_directory`.
+* s3: Amazon S3. Must also set `--bucket`, AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, and
+   AWS_DEFAULT_REGION.
+* google: Google Cloud Storage. Must also set `--bucket` and SERVICE_ACCOUNT.
+* azure: Microsoft Azure blob storage. Must also set `--bucket`, AZURE_STORAGE_ACCOUNT,
+   and AZURE_STORAGE_MASTER_KEY.
+        "#,
+    )]
+    pub object_store: Option<ObjectStore>,
+
+    /// Name of the bucket to use for the object store. Must also set
+    /// `--object_store` to a cloud object storage to have any effect.
+    ///
     /// If using Google Cloud Storage for the object store, this item, as well
     /// as SERVICE_ACCOUNT must be set.
-    #[structopt(long = "--gcp-bucket", env = "INFLUXDB_IOX_GCP_BUCKET")]
-    pub gcp_bucket: Option<String>,
-
+    ///
     /// If using S3 for the object store, this item, as well
     /// as AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY and AWS_DEFAULT_REGION must
     /// be set.
-    #[structopt(long = "--s3-bucket", env = "INFLUXDB_IOX_S3_BUCKET")]
-    pub s3_bucket: Option<String>,
+    #[structopt(long = "--bucket", env = "INFLUXDB_IOX_BUCKET")]
+    pub bucket: Option<String>,
 
     /// If set, Jaeger traces are emitted to this host
     /// using the OpenTelemetry tracer.
@@ -165,6 +186,17 @@ fn strip_server(args: impl Iterator<Item = String>) -> Vec<String> {
             }
         })
         .collect::<Vec<_>>()
+}
+
+arg_enum! {
+    #[derive(Debug, Copy, Clone, PartialEq)]
+    pub enum ObjectStore {
+        Memory,
+        File,
+        S3,
+        Google,
+        Azure,
+    }
 }
 
 /// How to format output logging messages

--- a/src/commands/config.rs
+++ b/src/commands/config.rs
@@ -101,7 +101,7 @@ pub struct Config {
 Possible values (case insensitive):
 
 * memory (default): Effectively no object persistence.
-* file: Stores objects in the local filesystem. Must also set `--database_directory`.
+* file: Stores objects in the local filesystem. Must also set `--data-dir`.
 * s3: Amazon S3. Must also set `--bucket`, AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, and
    AWS_DEFAULT_REGION.
 * google: Google Cloud Storage. Must also set `--bucket` and SERVICE_ACCOUNT.


### PR DESCRIPTION
Fixes #869.

I chose to unify the object store bucket variables first because it should save a bit of work when bringing all of the object store configuration into the config system (https://github.com/influxdata/influxdb_iox/issues/610).

I also added a document in docs/testing.md for info that's only relevant for running tests. For example, the `TEST_INTEGRATION` environment variable is not at all relevant for people using `influxdb_iox server`, so documenting that in `influxdb_iox server --help` doesn't seem appropriate. If the docs dir isn't a good spot I'm happy to move what I've put there to wherever people would rather have it :)