### PR TITLE
feat: smaller IOx build images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,7 +86,7 @@ jobs:
   # out for parallel CI runs!
   #
   # To change the contents of the build container, modify docker/Dockerfile.ci
-  # To change the final release container, modify docker/Dockerfile.perf
+  # To change the final release container, modify docker/Dockerfile.iox
   perf_image:
     docker:
       - image: quay.io/influxdb/rust:ci
@@ -105,7 +105,7 @@ jobs:
           echo "$QUAY_PASS" | docker login quay.io --username $QUAY_USER --password-stdin
       - run: |
           BRANCH=$(git rev-parse --abbrev-ref HEAD | tr '/' '.')
-          docker build -t quay.io/influxdb/fusion:$BRANCH -f docker/Dockerfile.perf .
+          docker build -t quay.io/influxdb/fusion:$BRANCH -f docker/Dockerfile.iox .
           docker push quay.io/influxdb/fusion:$BRANCH
           echo "export BRANCH=${BRANCH}" >> $BASH_ENV
       - run:

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+# Ignore everything
+**
+# Except
+!target/release/influxdb_iox

--- a/docker/Dockerfile.iox
+++ b/docker/Dockerfile.iox
@@ -1,7 +1,11 @@
 ###
-# Dockerfile for the image used in CI performance tests
+# Dockerfile used for deploying IOx
 ##
-FROM rust:slim-buster
+FROM debian:buster-slim
+
+RUN apt-get update \
+    && apt-get install -y libssl1.1 libgcc1 libc6 \
+	&& rm -rf /var/lib/{apt,dpkg,cache,log}
 
 RUN groupadd -g 1500 rust \
   && useradd -u 1500 -g rust -s /bin/bash -m rust
@@ -15,4 +19,4 @@ COPY target/release/influxdb_iox /usr/bin/influxdb_iox
 
 EXPOSE 8080 8082
 
-CMD ["influxdb_iox"]
+ENTRYPOINT ["influxdb_iox"]


### PR DESCRIPTION
Makes the IOx deploy image smaller by not bringing in 600MB of Rust build dependencies. Also sets entrypoint intead of command, which allows using the container as if it were the binary `e.g. podman run iox:VERSION --help`.

Creating as draft as I can't easily test this locally as my local GCC is newer than is bundled in debian buster. This will also serve the dual purpose of building an image I can deploy to get the new `/health` endpoint.