### PR TITLE
refactor: move SeriesSetPlans into its own module

### DIFF
--- a/mutable_buffer/src/database.rs
+++ b/mutable_buffer/src/database.rs
@@ -3,14 +3,13 @@ use data_types::{
     database_rules::{PartitionSort, PartitionSortRules},
 };
 use generated_types::wal;
-use query::group_by::Aggregate;
 use query::group_by::GroupByAndAggregate;
 use query::group_by::WindowDuration;
 use query::{
-    exec::{SeriesSetPlan, SeriesSetPlans},
-    predicate::Predicate,
-    Database,
+    group_by::Aggregate,
+    plan::seriesset::{SeriesSetPlan, SeriesSetPlans},
 };
+use query::{predicate::Predicate, Database};
 
 use crate::column::Column;
 use crate::table::Table;

--- a/mutable_buffer/src/table.rs
+++ b/mutable_buffer/src/table.rs
@@ -1,9 +1,10 @@
 use generated_types::wal as wb;
 use query::{
-    exec::{field::FieldColumns, SeriesSetPlan},
+    exec::field::FieldColumns,
     func::selectors::{selector_first, selector_last, selector_max, selector_min, SelectorOutput},
     func::window::make_window_bound_expr,
     group_by::{Aggregate, WindowDuration},
+    plan::seriesset::SeriesSetPlan,
 };
 
 use std::{

--- a/query/src/exec.rs
+++ b/query/src/exec.rs
@@ -18,7 +18,6 @@ use arrow_deps::{
 use counters::ExecutionCounters;
 
 use context::IOxExecutionContext;
-use field::FieldColumns;
 use schema_pivot::SchemaPivotNode;
 
 use fieldlist::{FieldList, IntoFieldList};
@@ -28,7 +27,11 @@ use tokio::sync::mpsc::{self, error::SendError};
 
 use snafu::{ResultExt, Snafu};
 
-use crate::plan::{fieldlist::FieldListPlan, stringset::StringSetPlan};
+use crate::plan::{
+    fieldlist::FieldListPlan,
+    seriesset::{SeriesSetPlan, SeriesSetPlans},
+    stringset::StringSetPlan,
+};
 
 #[derive(Debug, Snafu)]
 pub enum Error {
@@ -84,91 +87,6 @@ pub enum Error {
 }
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
-
-/// A plan that can be run to produce a logical stream of time series,
-/// as represented as sequence of SeriesSets from a single DataFusion
-/// plan, optionally grouped in some way.
-#[derive(Debug)]
-pub struct SeriesSetPlan {
-    /// The table name this came from
-    pub table_name: Arc<String>,
-
-    /// Datafusion plan to execute. The plan must produce
-    /// RecordBatches that have:
-    ///
-    /// * fields for each name in `tag_columns` and `field_columns`
-    /// * a timestamp column called 'time'
-    /// * each column in tag_columns must be a String (Utf8)
-    pub plan: LogicalPlan,
-
-    /// The names of the columns that define tags.
-    ///
-    /// Note these are `Arc` strings because they are duplicated for
-    /// *each* resulting `SeriesSet` that is produced when this type
-    /// of plan is executed.
-    pub tag_columns: Vec<Arc<String>>,
-
-    /// The names of the columns which are "fields"
-    ///
-    /// Note these are `Arc` strings because they are duplicated for
-    /// *each* resulting `SeriesSet` that is produced when this type
-    /// of plan is executed.
-    pub field_columns: FieldColumns,
-
-    /// If present, how many of the series_set_plan::tag_columns
-    /// should be used to compute the group
-    pub num_prefix_tag_group_columns: Option<usize>,
-}
-
-impl SeriesSetPlan {
-    /// Create a SeriesSetPlan that will not produce any Group items
-    pub fn new_from_shared_timestamp(
-        table_name: Arc<String>,
-        plan: LogicalPlan,
-        tag_columns: Vec<Arc<String>>,
-        field_columns: Vec<Arc<String>>,
-    ) -> Self {
-        Self::new(table_name, plan, tag_columns, field_columns.into())
-    }
-
-    /// Create a SeriesSetPlan that will not produce any Group items
-    pub fn new(
-        table_name: Arc<String>,
-        plan: LogicalPlan,
-        tag_columns: Vec<Arc<String>>,
-        field_columns: FieldColumns,
-    ) -> Self {
-        let num_prefix_tag_group_columns = None;
-
-        Self {
-            table_name,
-            plan,
-            tag_columns,
-            field_columns,
-            num_prefix_tag_group_columns,
-        }
-    }
-
-    /// Create a SeriesSetPlan that will produce Group items, according to
-    /// num_prefix_tag_group_columns.
-    pub fn grouped(mut self, num_prefix_tag_group_columns: usize) -> Self {
-        self.num_prefix_tag_group_columns = Some(num_prefix_tag_group_columns);
-        self
-    }
-}
-
-/// A container for plans which each produce a logical stream of
-/// timeseries (from across many potential tables).
-#[derive(Debug, Default)]
-pub struct SeriesSetPlans {
-    pub plans: Vec<SeriesSetPlan>,
-}
-
-impl From<Vec<SeriesSetPlan>> for SeriesSetPlans {
-    fn from(plans: Vec<SeriesSetPlan>) -> Self {
-        Self { plans }
-    }
-}
 
 /// Handles executing plans, and marshalling the results into rust
 /// native structures.

--- a/query/src/lib.rs
+++ b/query/src/lib.rs
@@ -11,7 +11,8 @@ use async_trait::async_trait;
 use data_types::{
     data::ReplicatedWrite, partition_metadata::TableSummary, schema::Schema, selection::Selection,
 };
-use exec::{stringset::StringSet, Executor, SeriesSetPlans};
+use exec::{stringset::StringSet, Executor};
+use plan::seriesset::SeriesSetPlans;
 
 use std::{fmt::Debug, sync::Arc};
 

--- a/query/src/plan.rs
+++ b/query/src/plan.rs
@@ -1,2 +1,3 @@
 pub mod fieldlist;
+pub mod seriesset;
 pub mod stringset;

--- a/query/src/plan/seriesset.rs
+++ b/query/src/plan/seriesset.rs
@@ -1,0 +1,86 @@
+use std::sync::Arc;
+
+use arrow_deps::datafusion::logical_plan::LogicalPlan;
+
+use crate::exec::field::FieldColumns;
+
+/// A plan that can be run to produce a logical stream of time series,
+/// as represented as sequence of SeriesSets from a single DataFusion
+/// plan, optionally grouped in some way.
+#[derive(Debug)]
+pub struct SeriesSetPlan {
+    /// The table name this came from
+    pub table_name: Arc<String>,
+
+    /// Datafusion plan to execute. The plan must produce
+    /// RecordBatches that have:
+    ///
+    /// * fields for each name in `tag_columns` and `field_columns`
+    /// * a timestamp column called 'time'
+    /// * each column in tag_columns must be a String (Utf8)
+    pub plan: LogicalPlan,
+
+    /// The names of the columns that define tags.
+    ///
+    /// Note these are `Arc` strings because they are duplicated for
+    /// *each* resulting `SeriesSet` that is produced when this type
+    /// of plan is executed.
+    pub tag_columns: Vec<Arc<String>>,
+
+    /// The names of the columns which are "fields"
+    pub field_columns: FieldColumns,
+
+    /// If present, how many of the series_set_plan::tag_columns
+    /// should be used to compute the group
+    pub num_prefix_tag_group_columns: Option<usize>,
+}
+
+impl SeriesSetPlan {
+    /// Create a SeriesSetPlan that will not produce any Group items
+    pub fn new_from_shared_timestamp(
+        table_name: Arc<String>,
+        plan: LogicalPlan,
+        tag_columns: Vec<Arc<String>>,
+        field_columns: Vec<Arc<String>>,
+    ) -> Self {
+        Self::new(table_name, plan, tag_columns, field_columns.into())
+    }
+
+    /// Create a SeriesSetPlan that will not produce any Group items
+    pub fn new(
+        table_name: Arc<String>,
+        plan: LogicalPlan,
+        tag_columns: Vec<Arc<String>>,
+        field_columns: FieldColumns,
+    ) -> Self {
+        let num_prefix_tag_group_columns = None;
+
+        Self {
+            table_name,
+            plan,
+            tag_columns,
+            field_columns,
+            num_prefix_tag_group_columns,
+        }
+    }
+
+    /// Create a SeriesSetPlan that will produce Group items, according to
+    /// num_prefix_tag_group_columns.
+    pub fn grouped(mut self, num_prefix_tag_group_columns: usize) -> Self {
+        self.num_prefix_tag_group_columns = Some(num_prefix_tag_group_columns);
+        self
+    }
+}
+
+/// A container for plans which each produce a logical stream of
+/// timeseries (from across many potential tables).
+#[derive(Debug, Default)]
+pub struct SeriesSetPlans {
+    pub plans: Vec<SeriesSetPlan>,
+}
+
+impl From<Vec<SeriesSetPlan>> for SeriesSetPlans {
+    fn from(plans: Vec<SeriesSetPlan>) -> Self {
+        Self { plans }
+    }
+}

--- a/query/src/test.rs
+++ b/query/src/test.rs
@@ -12,14 +12,11 @@ use arrow_deps::{
     datafusion::physical_plan::{common::SizedRecordBatchStream, SendableRecordBatchStream},
 };
 
-use crate::{exec::Executor, group_by::GroupByAndAggregate};
 use crate::{
-    exec::{
-        stringset::{StringSet, StringSetRef},
-        SeriesSetPlans,
-    },
+    exec::stringset::{StringSet, StringSetRef},
     Database, DatabaseStore, PartitionChunk, Predicate,
 };
+use crate::{exec::Executor, group_by::GroupByAndAggregate, plan::seriesset::SeriesSetPlans};
 
 use data_types::{
     data::{lines_to_replicated_write, ReplicatedWrite},

--- a/server/src/db.rs
+++ b/server/src/db.rs
@@ -309,7 +309,7 @@ impl Database for Db {
     async fn query_series(
         &self,
         predicate: query::predicate::Predicate,
-    ) -> Result<query::exec::SeriesSetPlans, Self::Error> {
+    ) -> Result<query::plan::seriesset::SeriesSetPlans, Self::Error> {
         self.mutable_buffer
             .as_ref()
             .context(DatabaseNotReadable)?
@@ -322,7 +322,7 @@ impl Database for Db {
         &self,
         predicate: query::predicate::Predicate,
         gby_agg: query::group_by::GroupByAndAggregate,
-    ) -> Result<query::exec::SeriesSetPlans, Self::Error> {
+    ) -> Result<query::plan::seriesset::SeriesSetPlans, Self::Error> {
         self.mutable_buffer
             .as_ref()
             .context(DatabaseNotReadable)?

--- a/src/influxdb_ioxd/rpc/storage/service.rs
+++ b/src/influxdb_ioxd/rpc/storage/service.rs
@@ -1109,8 +1109,8 @@ mod tests {
     use arrow_deps::datafusion::logical_plan::{col, lit, Expr};
     use panic_logging::SendPanicsToTracing;
     use query::{
-        exec::SeriesSetPlans,
         group_by::{Aggregate as QueryAggregate, WindowDuration as QueryWindowDuration},
+        plan::seriesset::SeriesSetPlans,
         test::QueryGroupsRequest,
         test::TestDatabaseStore,
         test::{QuerySeriesRequest, TestChunk},


### PR DESCRIPTION
This is related to #811 where I am moving `read_filter` into the gRPC planner but was easily separable.

- [x] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb_iox/blob/main/README.md).
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
