### PR TITLE
feat: Add iterators over different types of columns in Schema

### DIFF
--- a/data_types/src/schema.rs
+++ b/data_types/src/schema.rs
@@ -707,9 +707,9 @@ where
 
     fn next(&mut self) -> Option<Self::Item> {
         while let Some(idx) = self.next_idx() {
-            let (influx_colum_type, field) = self.schema.field(idx);
-            if self.filter.passes(influx_colum_type, field) {
-                return Some((influx_colum_type, field));
+            let (influx_column_type, field) = self.schema.field(idx);
+            if self.filter.passes(influx_column_type, field) {
+                return Some((influx_column_type, field));
             }
         }
         None


### PR DESCRIPTION
This is related to #811 where I am moving `read_filter` into the gRPC planner, and is easily separable. I need to be able to iterate over tags / fields / timestamps easily so I can create selections in the plan in some straightforward way. 

This may also come in handy for some of the work that @NGA-TRAN  is doing on https://github.com/influxdata/influxdb_iox/pull/875

- [x] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb_iox/blob/main/README.md).
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
