### PR TITLE
feat: Make read_filter work for mutable buffer and read buffer

### DIFF
--- a/arrow_deps/src/util.rs
+++ b/arrow_deps/src/util.rs
@@ -9,6 +9,7 @@ use arrow::{
     error::ArrowError,
     record_batch::RecordBatch,
 };
+use datafusion::logical_plan::{col, Expr};
 
 /// Returns a single column record batch of type Utf8 from the
 /// contents of something that can be turned into an iterator over
@@ -27,4 +28,37 @@ where
     let columns: Vec<ArrayRef> = vec![Arc::new(array)];
 
     RecordBatch::try_new(schema, columns)
+}
+
+/// Traits to help creating DataFuson expressions from strings
+pub trait IntoExpr {
+    /// Creates a DataFuson expr
+    fn into_expr(&self) -> Expr;
+
+    /// creates a DataFusion SortExpr
+    fn into_sort_expr(&self) -> Expr {
+        Expr::Sort {
+            expr: Box::new(self.into_expr()),
+            asc: true, // Sort ASCENDING
+            nulls_first: true,
+        }
+    }
+}
+
+impl IntoExpr for Arc<String> {
+    fn into_expr(&self) -> Expr {
+        col(self.as_ref())
+    }
+}
+
+impl IntoExpr for str {
+    fn into_expr(&self) -> Expr {
+        col(self)
+    }
+}
+
+impl IntoExpr for Expr {
+    fn into_expr(&self) -> Expr {
+        self.clone()
+    }
 }

--- a/arrow_deps/src/util.rs
+++ b/arrow_deps/src/util.rs
@@ -30,7 +30,7 @@ where
     RecordBatch::try_new(schema, columns)
 }
 
-/// Traits to help creating DataFuson expressions from strings
+/// Traits to help creating DataFusion expressions from strings
 pub trait IntoExpr {
     /// Creates a DataFusion expr
     fn into_expr(&self) -> Expr;

--- a/query/src/frontend/influxrpc.rs
+++ b/query/src/frontend/influxrpc.rs
@@ -12,6 +12,7 @@ use arrow_deps::{
         },
         prelude::col,
     },
+    util::IntoExpr,
 };
 use data_types::{
     schema::{InfluxColumnType, Schema},
@@ -24,6 +25,7 @@ use crate::{
     exec::{make_schema_pivot, stringset::StringSet},
     plan::{
         fieldlist::FieldListPlan,
+        seriesset::{SeriesSetPlan, SeriesSetPlans},
         stringset::{Error as StringSetError, StringSetPlan, StringSetPlanBuilder},
     },
     predicate::{Predicate, PredicateBuilder},
@@ -488,6 +490,60 @@ impl InfluxRPCPlanner {
         Ok(field_list_plan)
     }
 
+    /// Returns a plan that finds all rows rows which pass the
+    /// conditions specified by `predicate` in the form of logical
+    /// time series.
+    ///
+    /// A time series is defined by the unique values in a set of
+    /// "tag_columns" for each field in the "field_columns", ordered by
+    /// the time column.
+    ///
+    /// The output looks like:
+    /// ```text
+    /// (tag_col1, tag_col2, ... field1, field2, ... timestamp)
+    /// ```
+    ///
+    /// The  tag_columns are ordered by name.
+    ///
+    /// The data is sorted on tag_col1, tag_col2, ...) so that all
+    /// rows for a particular series (groups where all tags are the
+    /// same) occur together in the plan
+
+    pub async fn read_filter<D>(&self, database: &D, predicate: Predicate) -> Result<SeriesSetPlans>
+    where
+        D: Database + 'static,
+    {
+        debug!(predicate=?predicate, "planning read_filter");
+
+        // group tables by chunk, pruning if possible
+        // key is table name, values are chunks
+        let mut table_chunks = BTreeMap::new();
+
+        for chunk in self.filtered_chunks(database, &predicate).await? {
+            let table_names = self.chunk_table_names(chunk.as_ref(), &predicate).await?;
+            for table_name in table_names.into_iter() {
+                table_chunks
+                    .entry(table_name)
+                    .or_insert_with(Vec::new)
+                    .push(Arc::clone(&chunk));
+            }
+        }
+
+        // now, build up plans for each table
+        let mut ss_plans = vec![];
+        for (table_name, chunks) in table_chunks {
+            let ss_plan = self
+                .read_filter_plan(table_name, &predicate, chunks)
+                .await?;
+            // If we have to do real work, add it to the list of plans
+            if let Some(ss_plan) = ss_plan {
+                ss_plans.push(ss_plan);
+            }
+        }
+
+        Ok(ss_plans.into())
+    }
+
     /// Find all the table names in the specified chunk that pass the predicate
     async fn chunk_table_names<C>(
         &self,
@@ -653,6 +709,83 @@ impl InfluxRPCPlanner {
             .context(BuildingPlan)?;
 
         Ok(Some(plan))
+    }
+
+    /// Creates a plan for computing series sets for a given table,
+    /// returning None if the predicate rules out matching any rows in
+    /// the table
+    ///
+    /// The created plan looks like:
+    ///
+    ///    Projection (select the columns needed)
+    ///      Order by (tag_columns, timestamp_column)
+    ///        Filter(predicate)
+    ///          InMemoryScan
+    async fn read_filter_plan<C>(
+        &self,
+        table_name: impl Into<String>,
+        predicate: &Predicate,
+        chunks: Vec<Arc<C>>,
+    ) -> Result<Option<SeriesSetPlan>>
+    where
+        C: PartitionChunk + 'static,
+    {
+        let table_name = table_name.into();
+        let scan_and_filter = self.scan_and_filter(&table_name, predicate, chunks).await?;
+
+        let TableScanAndFilter {
+            plan_builder,
+            schema,
+        } = match scan_and_filter {
+            None => return Ok(None),
+            Some(t) => t,
+        };
+
+        let tags_and_timestamp: Vec<Expr> = schema
+            .tags_iter()
+            .chain(schema.time_iter())
+            .map(|field| field.name().into_sort_expr())
+            .collect();
+
+        // Order by
+        let plan_builder = plan_builder
+            .sort(&tags_and_timestamp)
+            .context(BuildingPlan)?;
+
+        // Select away anything that isn't in the influx data model
+        let tags_fields_and_timestamps: Vec<Expr> = schema
+            .tags_iter()
+            .chain(schema.fields_iter())
+            .chain(schema.time_iter())
+            .map(|field| field.name().into_expr())
+            .collect();
+
+        let plan_builder = plan_builder
+            .project(&tags_fields_and_timestamps)
+            .context(BuildingPlan)?;
+
+        let plan = plan_builder.build().context(BuildingPlan)?;
+
+        let tag_columns = schema
+            .tags_iter()
+            .map(|field| Arc::new(field.name().to_string()))
+            .collect();
+
+        let field_columns = schema
+            .fields_iter()
+            .map(|field| Arc::new(field.name().to_string()))
+            .collect();
+
+        // TODO: remove the use of tag_columns and field_column names
+        // and instead use the schema directly)
+        let ss_plan = SeriesSetPlan::new_from_shared_timestamp(
+            Arc::new(table_name),
+            plan,
+            tag_columns,
+            field_columns,
+        );
+
+        Ok(Some(ss_plan))
     }
 
     /// Create a plan that scans the specified table, and applies any

--- a/query/src/lib.rs
+++ b/query/src/lib.rs
@@ -55,15 +55,6 @@ pub trait Database: Debug + Send + Sync {
     // The functions below are slated for removal (migration into a gRPC query
     // frontend) ---------
 
-    /// Returns a plan that finds all rows rows which pass the
-    /// conditions specified by `predicate` in the form of logical
-    /// time series.
-    ///
-    /// A time series is defined by the unique values in a set of
-    /// "tag_columns" for each field in the "field_columns", orderd by
-    /// the time column.
-    async fn query_series(&self, predicate: Predicate) -> Result<SeriesSetPlans, Self::Error>;
-
     /// Returns a plan that finds rows which pass the conditions
     /// specified by `predicate` and have been logically grouped and
     /// aggregate according to `gby_agg`.
@@ -152,7 +143,10 @@ pub trait PartitionChunk: Debug + Send + Sync {
     ) -> Result<Schema, Self::Error>;
 
     /// Provides access to raw `PartitionChunk` data as an
-    /// asynchronous stream of `RecordBatch`es.
+    /// asynchronous stream of `RecordBatch`es filtered by a *required*
+    /// predicate. Note that not all chunks can evaluate all types of
+    /// predicates and this function will return an error
+    /// if requested to evaluate with a predicate that is not supported
     ///
     /// This is the analog of the `TableProvider` in DataFusion
     ///

--- a/query/src/plan/seriesset.rs
+++ b/query/src/plan/seriesset.rs
@@ -7,6 +7,10 @@ use crate::exec::field::FieldColumns;
 /// A plan that can be run to produce a logical stream of time series,
 /// as represented as sequence of SeriesSets from a single DataFusion
 /// plan, optionally grouped in some way.
+///
+/// TODO: remove the tag/field designations below and attach a
+/// `Schema` to the plan (which has the tag and field column
+/// information natively)
 #[derive(Debug)]
 pub struct SeriesSetPlan {
     /// The table name this came from

--- a/server/src/db.rs
+++ b/server/src/db.rs
@@ -306,18 +306,6 @@ impl Database for Db {
             .context(MutableBufferWrite)
     }
 
-    async fn query_series(
-        &self,
-        predicate: query::predicate::Predicate,
-    ) -> Result<query::plan::seriesset::SeriesSetPlans, Self::Error> {
-        self.mutable_buffer
-            .as_ref()
-            .context(DatabaseNotReadable)?
-            .query_series(predicate)
-            .await
-            .context(MutableBufferRead)
-    }
-
     async fn query_groups(
         &self,
         predicate: query::predicate::Predicate,

--- a/server/src/db/chunk.rs
+++ b/server/src/db/chunk.rs
@@ -4,6 +4,7 @@ use mutable_buffer::chunk::Chunk as MBChunk;
 use query::{exec::stringset::StringSet, predicate::Predicate, PartitionChunk};
 use read_buffer::Database as ReadBufferDb;
 use snafu::{ResultExt, Snafu};
+use tracing::debug;
 
 use std::sync::Arc;
 
@@ -30,8 +31,14 @@ pub enum Error {
     #[snafu(display("Internal error restricting schema: {}", source))]
     InternalSelectingSchema { source: data_types::schema::Error },
 
-    #[snafu(display("Internal Predicate Conversion Error: {}", source))]
-    InternalPredicateConversion { source: super::pred::Error },
+    #[snafu(display("Predicate conversion error: {}", source))]
+    PredicateConversion { source: super::pred::Error },
+
+    #[snafu(display(
+        "Internal error: mutable buffer does not support predicate pushdown, but got: {:?}",
+        predicate
+    ))]
+    InternalPredicateNotSupported { predicate: Predicate },
 
     #[snafu(display("internal error creating plan: {}", source))]
     InternalPlanCreation {
@@ -113,9 +120,13 @@ impl PartitionChunk for DBChunk {
                 if chunk.is_empty() {
                     Some(StringSet::new())
                 } else {
-                    let chunk_predicate = chunk
-                        .compile_predicate(predicate)
-                        .context(MutableBufferChunk)?;
+                    let chunk_predicate = match chunk.compile_predicate(predicate) {
+                        Ok(chunk_predicate) => chunk_predicate,
+                        Err(e) => {
+                            debug!(?predicate, %e, "mutable buffer predicate not supported for table_names, falling back");
+                            return Ok(None);
+                        }
+                    };
 
                     // we don't support arbitrary expressions in chunk predicate yet
                     if !chunk_predicate.chunk_exprs.is_empty() {
@@ -139,11 +150,15 @@ impl PartitionChunk for DBChunk {
             } => {
                 let chunk_id = *chunk_id;
 
-                // TODO: figure out if this predicate was "not
-                // supported" or "actual error". If not supported,
-                // should return Ok(None)
-                let rb_predicate =
-                    to_read_buffer_predicate(&predicate).context(InternalPredicateConversion)?;
+                // If not supported, ReadBuffer can't answer with
+                // metadata only
+                let rb_predicate = match to_read_buffer_predicate(&predicate) {
+                    Ok(rb_predicate) => rb_predicate,
+                    Err(e) => {
+                        debug!(?predicate, %e, "read buffer predicate not supported for table_names, falling back");
+                        return Ok(None);
+                    }
+                };
 
                 let names = db
                     .table_names(partition_key, &[chunk_id], rb_predicate)
@@ -243,9 +258,15 @@ impl PartitionChunk for DBChunk {
     ) -> Result<SendableRecordBatchStream, Self::Error> {
         match self {
             Self::MutableBuffer { chunk } => {
-                // Note Mutable buffer doesn't support predicate
+                // Note MutableBuffer doesn't support predicate
                 // pushdown (other than pruning out the entire chunk
                 // via `might_pass_predicate)
+                if predicate != &Predicate::default() {
+                    return InternalPredicateNotSupported {
+                        predicate: predicate.clone(),
+                    }
+                    .fail();
+                }
                 let schema: Schema = self.table_schema(table_name, selection).await?;
 
                 Ok(Box::pin(MutableBufferChunkStream::new(
@@ -260,8 +281,9 @@ impl PartitionChunk for DBChunk {
                 chunk_id,
             } => {
                 let chunk_id = *chunk_id;
+                // Error converting to a rb_predicate needs to fail
                 let rb_predicate =
-                    to_read_buffer_predicate(&predicate).context(InternalPredicateConversion)?;
+                    to_read_buffer_predicate(&predicate).context(PredicateConversion)?;
 
                 let chunk_ids = &[chunk_id];
 
@@ -319,9 +341,13 @@ impl PartitionChunk for DBChunk {
     ) -> Result<Option<StringSet>, Self::Error> {
         match self {
             Self::MutableBuffer { chunk } => {
-                let chunk_predicate = chunk
-                    .compile_predicate(predicate)
-                    .context(MutableBufferChunk)?;
+                let chunk_predicate = match chunk.compile_predicate(predicate) {
+                    Ok(chunk_predicate) => chunk_predicate,
+                    Err(e) => {
+                        debug!(?predicate, %e, "mutable buffer predicate not supported for column_names, falling back");
+                        return Ok(None);
+                    }
+                };
 
                 chunk
                     .column_names(table_name, &chunk_predicate)
@@ -333,8 +359,13 @@ impl PartitionChunk for DBChunk {
                 chunk_id,
             } => {
                 let chunk_id = *chunk_id;
-                let rb_predicate =
-                    to_read_buffer_predicate(&predicate).context(InternalPredicateConversion)?;
+                let rb_predicate = match to_read_buffer_predicate(&predicate) {
+                    Ok(rb_predicate) => rb_predicate,
+                    Err(e) => {
+                        debug!(?predicate, %e, "read buffer predicate not supported for column_names, falling back");
+                        return Ok(None);
+                    }
+                };
 
                 let chunk_ids = &[chunk_id];
 
@@ -366,9 +397,13 @@ impl PartitionChunk for DBChunk {
             Self::MutableBuffer { chunk } => {
                 use mutable_buffer::chunk::Error::UnsupportedColumnTypeForListingValues;
 
-                let chunk_predicate = chunk
-                    .compile_predicate(predicate)
-                    .context(MutableBufferChunk)?;
+                let chunk_predicate = match chunk.compile_predicate(predicate) {
+                    Ok(chunk_predicate) => chunk_predicate,
+                    Err(e) => {
+                        debug!(?predicate, %e, "mutable buffer predicate not supported for column_values, falling back");
+                        return Ok(None);
+                    }
+                };
 
                 let values = chunk.tag_column_values(table_name, column_name, &chunk_predicate);
 

--- a/server/src/query_tests/influxrpc.rs
+++ b/server/src/query_tests/influxrpc.rs
@@ -1,4 +1,5 @@
 pub mod field_columns;
+pub mod read_filter;
 pub mod table_names;
 pub mod tag_keys;
 pub mod tag_values;

--- a/server/src/query_tests/influxrpc/read_filter.rs
+++ b/server/src/query_tests/influxrpc/read_filter.rs
@@ -1,0 +1,507 @@
+//! Tests for the Influx gRPC queries
+use std::sync::Arc;
+
+use crate::query_tests::scenarios::*;
+use arrow_deps::{
+    arrow::util::pretty::pretty_format_batches,
+    datafusion::logical_plan::{col, lit},
+};
+use async_trait::async_trait;
+use query::{
+    exec::{
+        field::FieldIndexes,
+        seriesset::{SeriesSet, SeriesSetItem},
+        Executor,
+    },
+    frontend::influxrpc::InfluxRPCPlanner,
+    predicate::{Predicate, PredicateBuilder},
+};
+use tokio::sync::mpsc;
+
+pub struct TwoMeasurementsMultiSeries {}
+#[async_trait]
+impl DBSetup for TwoMeasurementsMultiSeries {
+    async fn make(&self) -> Vec<DBScenario> {
+        let partition_key = "1970-01-01T00";
+
+        let mut data = vec![
+            "h2o,state=MA,city=Boston temp=70.4 100", // to row 2
+            "h2o,state=MA,city=Boston temp=72.4 250", // to row 1
+            "h2o,state=CA,city=LA temp=90.0 200",     // to row 0
+            "h2o,state=CA,city=LA temp=90.0 350",     // to row 3
+            "o2,state=MA,city=Boston temp=50.4,reading=50 100", // to row 5
+            "o2,state=MA,city=Boston temp=53.4,reading=51 250", // to row 4
+        ];
+
+        // Swap around  data is not inserted in series order
+        data.swap(0, 2);
+        data.swap(4, 5);
+
+        make_one_chunk_scenarios(partition_key, &data.join("\n")).await
+    }
+}
+
+/// runs read_filter(predicate) and compares it to the expected
+/// output
+macro_rules! run_read_filter_test_case {
+    ($DB_SETUP:expr, $PREDICATE:expr, $EXPECTED_RESULTS:expr) => {
+        test_helpers::maybe_start_logging();
+        let predicate = $PREDICATE;
+        let expected_results = $EXPECTED_RESULTS;
+        for scenario in $DB_SETUP.make().await {
+            let DBScenario {
+                scenario_name, db, ..
+            } = scenario;
+            println!("Running scenario '{}'", scenario_name);
+            println!("Predicate: '{:#?}'", predicate);
+            let planner = InfluxRPCPlanner::new();
+            let executor = Executor::new();
+
+            let plans = planner
+                .read_filter(&db, predicate.clone())
+                .await
+                .expect("built plan successfully");
+
+            // Use a channel sufficiently large to buffer the series
+            let (tx, mut rx) = mpsc::channel(100);
+            executor
+                .to_series_set(plans, tx)
+                .await
+                .expect("Running series set plan");
+
+            // gather up the sets and compare them
+            let mut results = vec![];
+            while let Some(r) = rx.recv().await {
+                let item = r.expect("unexpected error in execution");
+                let item = if let SeriesSetItem::Data(series_set) = item {
+                    series_set
+                }
+                else {
+                    panic!("Unexpected result from converting. Expected SeriesSetItem::Data, got: {:?}", item)
+                };
+
+                results.push(item);
+            }
+
+            // sort the results so that we can reliably compare
+            results.sort_by(|r1, r2| {
+                r1
+                    .table_name
+                    .cmp(&r2.table_name)
+                    .then(r1.tags.cmp(&r2.tags))
+            });
+
+            let string_results = results
+                .into_iter()
+                .map(|s| dump_series_set(s).into_iter())
+                .flatten()
+                .collect::<Vec<_>>();
+
+            assert_eq!(
+                expected_results,
+                string_results,
+                "Error in  scenario '{}'\n\nexpected:\n{:#?}\nactual:\n{:#?}",
+                scenario_name,
+                expected_results,
+                string_results
+            );
+        }
+    };
+}
+
+/// Format the field indexes into strings
+fn dump_field_indexes(f: FieldIndexes) -> Vec<String> {
+    f.as_slice()
+        .iter()
+        .map(|field_index| {
+            format!(
+                "  (value_index: {}, timestamp_index: {})",
+                field_index.value_index, field_index.timestamp_index
+            )
+        })
+        .collect()
+}
+
+/// Format a the vec of Arc strings paris into strings
+fn dump_arc_vec(v: Vec<(Arc<String>, Arc<String>)>) -> Vec<String> {
+    v.into_iter()
+        .map(|(k, v)| format!("  ({}, {})", k, v))
+        .collect()
+}
+
+/// Format a series set into a format that is easy to compare in tests
+fn dump_series_set(s: SeriesSet) -> Vec<String> {
+    let mut f = vec![];
+    f.push("SeriesSet".into());
+    f.push(format!("table_name: {}", s.table_name));
+    f.push("tags".to_string());
+    f.extend(dump_arc_vec(s.tags).into_iter());
+    f.push("field_indexes:".to_string());
+    f.extend(dump_field_indexes(s.field_indexes).into_iter());
+    f.push(format!("start_row: {}", s.start_row));
+    f.push(format!("num_rows: {}", s.num_rows));
+    f.push("Batches:".into());
+    let formatted_batch = pretty_format_batches(&[s.batch]).unwrap();
+    f.extend(formatted_batch.trim().split('\n').map(|s| s.to_string()));
+
+    f
+}
+
+#[tokio::test]
+async fn test_read_filter_no_data_no_pred() {
+    let predicate = Predicate::default();
+    let expected_results = vec![] as Vec<&str>;
+
+    run_read_filter_test_case!(NoData {}, predicate, expected_results);
+}
+
+#[tokio::test]
+async fn test_read_filter_data_no_pred() {
+    let predicate = Predicate::default();
+    let expected_results = vec![
+        "SeriesSet",
+        "table_name: h2o",
+        "tags",
+        "  (city, Boston)",
+        "  (state, MA)",
+        "field_indexes:",
+        "  (value_index: 2, timestamp_index: 3)",
+        "start_row: 0",
+        "num_rows: 2",
+        "Batches:",
+        "+--------+-------+------+------+",
+        "| city   | state | temp | time |",
+        "+--------+-------+------+------+",
+        "| Boston | MA    | 70.4 | 100  |",
+        "| Boston | MA    | 72.4 | 250  |",
+        "| LA     | CA    | 90   | 200  |",
+        "| LA     | CA    | 90   | 350  |",
+        "+--------+-------+------+------+",
+        "SeriesSet",
+        "table_name: h2o",
+        "tags",
+        "  (city, LA)",
+        "  (state, CA)",
+        "field_indexes:",
+        "  (value_index: 2, timestamp_index: 3)",
+        "start_row: 2",
+        "num_rows: 2",
+        "Batches:",
+        "+--------+-------+------+------+",
+        "| city   | state | temp | time |",
+        "+--------+-------+------+------+",
+        "| Boston | MA    | 70.4 | 100  |",
+        "| Boston | MA    | 72.4 | 250  |",
+        "| LA     | CA    | 90   | 200  |",
+        "| LA     | CA    | 90   | 350  |",
+        "+--------+-------+------+------+",
+        "SeriesSet",
+        "table_name: o2",
+        "tags",
+        "  (city, Boston)",
+        "  (state, MA)",
+        "field_indexes:",
+        "  (value_index: 2, timestamp_index: 4)",
+        "  (value_index: 3, timestamp_index: 4)",
+        "start_row: 0",
+        "num_rows: 2",
+        "Batches:",
+        "+--------+-------+---------+------+------+",
+        "| city   | state | reading | temp | time |",
+        "+--------+-------+---------+------+------+",
+        "| Boston | MA    | 50      | 50.4 | 100  |",
+        "| Boston | MA    | 51      | 53.4 | 250  |",
+        "+--------+-------+---------+------+------+",
+    ];
+
+    run_read_filter_test_case!(TwoMeasurementsMultiSeries {}, predicate, expected_results);
+}
+
+#[tokio::test]
+async fn test_read_filter_data_filter() {
+    // filter out one row in h20
+    let predicate = PredicateBuilder::default()
+        .timestamp_range(200, 300)
+        .add_expr(col("state").eq(lit("CA"))) // state=CA
+        .build();
+
+    let expected_results = vec![
+        "SeriesSet",
+        "table_name: h2o",
+        "tags",
+        "  (city, LA)",
+        "  (state, CA)",
+        "field_indexes:",
+        "  (value_index: 2, timestamp_index: 3)",
+        "start_row: 0",
+        "num_rows: 1",
+        "Batches:",
+        "+------+-------+------+------+",
+        "| city | state | temp | time |",
+        "+------+-------+------+------+",
+        "| LA   | CA    | 90   | 200  |",
+        "+------+-------+------+------+",
+    ];
+
+    run_read_filter_test_case!(TwoMeasurementsMultiSeries {}, predicate, expected_results);
+}
+
+//     let plans = db
+//         .query_series(predicate)
+//         .await
+//         .expect("Created query_series plan successfully");
+
+//     let results = run_and_gather_results(plans).await;
+
+//     assert_eq!(results.len(), 1);
+
+//     let series_set0 = results[0].as_ref().expect("Correctly converted");
+//     assert_eq!(*series_set0.table_name, "h2o");
+//     assert_eq!(
+//         series_set0.tags,
+//         str_pair_vec_to_vec(&[("city", "LA"), ("state", "CA")])
+//     );
+//     assert_eq!(
+//         series_set0.field_indexes,
+//         FieldIndexes::from_timestamp_and_value_indexes(3, &[2])
+//     );
+//     assert_eq!(series_set0.start_row, 0);
+//     assert_eq!(series_set0.num_rows, 1); // only has one row!
+
+//     Ok(())
+// }
+
+#[tokio::test]
+async fn test_read_filter_data_pred_refers_to_non_existent_column() {
+    let predicate = PredicateBuilder::default()
+        .add_expr(col("tag_not_in_h20").eq(lit("foo")))
+        .build();
+
+    let expected_results = vec![] as Vec<&str>;
+
+    run_read_filter_test_case!(TwoMeasurements {}, predicate, expected_results);
+}
+
+#[tokio::test]
+async fn test_read_filter_data_pred_no_columns() {
+    // predicate with no columns,
+    let predicate = PredicateBuilder::default()
+        .add_expr(lit("foo").eq(lit("foo")))
+        .build();
+
+    let expected_results = vec![
+        "SeriesSet",
+        "table_name: cpu",
+        "tags",
+        "  (region, west)",
+        "field_indexes:",
+        "  (value_index: 1, timestamp_index: 2)",
+        "start_row: 0",
+        "num_rows: 2",
+        "Batches:",
+        "+--------+------+------+",
+        "| region | user | time |",
+        "+--------+------+------+",
+        "| west   | 23.2 | 100  |",
+        "| west   | 21   | 150  |",
+        "+--------+------+------+",
+        "SeriesSet",
+        "table_name: disk",
+        "tags",
+        "  (region, east)",
+        "field_indexes:",
+        "  (value_index: 1, timestamp_index: 2)",
+        "start_row: 0",
+        "num_rows: 1",
+        "Batches:",
+        "+--------+-------+------+",
+        "| region | bytes | time |",
+        "+--------+-------+------+",
+        "| east   | 99    | 200  |",
+        "+--------+-------+------+",
+    ];
+
+    run_read_filter_test_case!(TwoMeasurements {}, predicate, expected_results);
+}
+
+#[tokio::test]
+async fn test_read_filter_data_pred_refers_to_good_and_non_existent_columns() {
+    // predicate with both a column that does and does not appear
+    let predicate = PredicateBuilder::default()
+        .add_expr(col("state").eq(lit("MA")))
+        .add_expr(col("tag_not_in_h20").eq(lit("foo")))
+        .build();
+
+    let expected_results = vec![] as Vec<&str>;
+
+    run_read_filter_test_case!(TwoMeasurements {}, predicate, expected_results);
+}
+
+#[tokio::test]
+async fn test_read_filter_data_pred_unsupported_in_scan() {
+    test_helpers::maybe_start_logging();
+
+    // These predicates can't be pushed down into chunks, but they can
+    // be evaluated by the general purpose DataFusion plan
+    // (STATE = 'CA') OR (READING > 0)
+    let predicate = PredicateBuilder::default()
+        .add_expr(col("state").eq(lit("CA")).or(col("reading").gt(lit(0))))
+        .build();
+
+    // Note these results are incorrect (they do not include data from h2o where
+    // state = CA)
+    let expected_results = vec![
+        "SeriesSet",
+        "table_name: o2",
+        "tags",
+        "  (city, Boston)",
+        "  (state, MA)",
+        "field_indexes:",
+        "  (value_index: 2, timestamp_index: 4)",
+        "  (value_index: 3, timestamp_index: 4)",
+        "start_row: 0",
+        "num_rows: 2",
+        "Batches:",
+        "+--------+-------+---------+------+------+",
+        "| city   | state | reading | temp | time |",
+        "+--------+-------+---------+------+------+",
+        "| Boston | MA    | 50      | 50.4 | 100  |",
+        "| Boston | MA    | 51      | 53.4 | 250  |",
+        "+--------+-------+---------+------+------+",
+    ];
+
+    run_read_filter_test_case!(TwoMeasurementsMultiSeries {}, predicate, expected_results);
+}
+
+pub struct MeasurementsSortableTags {}
+#[async_trait]
+impl DBSetup for MeasurementsSortableTags {
+    async fn make(&self) -> Vec<DBScenario> {
+        let partition_key = "1970-01-01T00";
+
+        let data = vec![
+            "h2o,zz_tag=A,state=MA,city=Kingston temp=70.1 800",
+            "h2o,state=MA,city=Kingston,zz_tag=B temp=70.2 100",
+            "h2o,state=CA,city=Boston temp=70.3 250",
+            "h2o,state=MA,city=Boston,zz_tag=A temp=70.4 1000",
+            "h2o,state=MA,city=Boston temp=70.5,other=5.0 250",
+        ];
+
+        make_one_chunk_scenarios(partition_key, &data.join("\n")).await
+    }
+}
+
+#[tokio::test]
+async fn test_read_filter_data_plan_order() {
+    test_helpers::maybe_start_logging();
+    let predicate = Predicate::default();
+    let expected_results = vec![
+        "SeriesSet",
+        "table_name: h2o",
+        "tags",
+        "  (city, Boston)",
+        "  (state, CA)",
+        "  (zz_tag, )",
+        "field_indexes:",
+        "  (value_index: 3, timestamp_index: 5)",
+        "  (value_index: 4, timestamp_index: 5)",
+        "start_row: 0",
+        "num_rows: 1",
+        "Batches:",
+        "+----------+-------+--------+-------+------+------+",
+        "| city     | state | zz_tag | other | temp | time |",
+        "+----------+-------+--------+-------+------+------+",
+        "| Boston   | CA    |        |       | 70.3 | 250  |",
+        "| Boston   | MA    |        | 5     | 70.5 | 250  |",
+        "| Boston   | MA    | A      |       | 70.4 | 1000 |",
+        "| Kingston | MA    | A      |       | 70.1 | 800  |",
+        "| Kingston | MA    | B      |       | 70.2 | 100  |",
+        "+----------+-------+--------+-------+------+------+",
+        "SeriesSet",
+        "table_name: h2o",
+        "tags",
+        "  (city, Boston)",
+        "  (state, MA)",
+        "  (zz_tag, )",
+        "field_indexes:",
+        "  (value_index: 3, timestamp_index: 5)",
+        "  (value_index: 4, timestamp_index: 5)",
+        "start_row: 1",
+        "num_rows: 1",
+        "Batches:",
+        "+----------+-------+--------+-------+------+------+",
+        "| city     | state | zz_tag | other | temp | time |",
+        "+----------+-------+--------+-------+------+------+",
+        "| Boston   | CA    |        |       | 70.3 | 250  |",
+        "| Boston   | MA    |        | 5     | 70.5 | 250  |",
+        "| Boston   | MA    | A      |       | 70.4 | 1000 |",
+        "| Kingston | MA    | A      |       | 70.1 | 800  |",
+        "| Kingston | MA    | B      |       | 70.2 | 100  |",
+        "+----------+-------+--------+-------+------+------+",
+        "SeriesSet",
+        "table_name: h2o",
+        "tags",
+        "  (city, Boston)",
+        "  (state, MA)",
+        "  (zz_tag, A)",
+        "field_indexes:",
+        "  (value_index: 3, timestamp_index: 5)",
+        "  (value_index: 4, timestamp_index: 5)",
+        "start_row: 2",
+        "num_rows: 1",
+        "Batches:",
+        "+----------+-------+--------+-------+------+------+",
+        "| city     | state | zz_tag | other | temp | time |",
+        "+----------+-------+--------+-------+------+------+",
+        "| Boston   | CA    |        |       | 70.3 | 250  |",
+        "| Boston   | MA    |        | 5     | 70.5 | 250  |",
+        "| Boston   | MA    | A      |       | 70.4 | 1000 |",
+        "| Kingston | MA    | A      |       | 70.1 | 800  |",
+        "| Kingston | MA    | B      |       | 70.2 | 100  |",
+        "+----------+-------+--------+-------+------+------+",
+        "SeriesSet",
+        "table_name: h2o",
+        "tags",
+        "  (city, Kingston)",
+        "  (state, MA)",
+        "  (zz_tag, A)",
+        "field_indexes:",
+        "  (value_index: 3, timestamp_index: 5)",
+        "  (value_index: 4, timestamp_index: 5)",
+        "start_row: 3",
+        "num_rows: 1",
+        "Batches:",
+        "+----------+-------+--------+-------+------+------+",
+        "| city     | state | zz_tag | other | temp | time |",
+        "+----------+-------+--------+-------+------+------+",
+        "| Boston   | CA    |        |       | 70.3 | 250  |",
+        "| Boston   | MA    |        | 5     | 70.5 | 250  |",
+        "| Boston   | MA    | A      |       | 70.4 | 1000 |",
+        "| Kingston | MA    | A      |       | 70.1 | 800  |",
+        "| Kingston | MA    | B      |       | 70.2 | 100  |",
+        "+----------+-------+--------+-------+------+------+",
+        "SeriesSet",
+        "table_name: h2o",
+        "tags",
+        "  (city, Kingston)",
+        "  (state, MA)",
+        "  (zz_tag, B)",
+        "field_indexes:",
+        "  (value_index: 3, timestamp_index: 5)",
+        "  (value_index: 4, timestamp_index: 5)",
+        "start_row: 4",
+        "num_rows: 1",
+        "Batches:",
+        "+----------+-------+--------+-------+------+------+",
+        "| city     | state | zz_tag | other | temp | time |",
+        "+----------+-------+--------+-------+------+------+",
+        "| Boston   | CA    |        |       | 70.3 | 250  |",
+        "| Boston   | MA    |        | 5     | 70.5 | 250  |",
+        "| Boston   | MA    | A      |       | 70.4 | 1000 |",
+        "| Kingston | MA    | A      |       | 70.1 | 800  |",
+        "| Kingston | MA    | B      |       | 70.2 | 100  |",
+        "+----------+-------+--------+-------+------+------+",
+    ];
+
+    run_read_filter_test_case!(MeasurementsSortableTags {}, predicate, expected_results);
+}

--- a/server/src/query_tests/influxrpc/read_filter.rs
+++ b/server/src/query_tests/influxrpc/read_filter.rs
@@ -246,30 +246,6 @@ async fn test_read_filter_data_filter() {
     run_read_filter_test_case!(TwoMeasurementsMultiSeries {}, predicate, expected_results);
 }
 
-//     let plans = db
-//         .query_series(predicate)
-//         .await
-//         .expect("Created query_series plan successfully");
-
-//     let results = run_and_gather_results(plans).await;
-
-//     assert_eq!(results.len(), 1);
-
-//     let series_set0 = results[0].as_ref().expect("Correctly converted");
-//     assert_eq!(*series_set0.table_name, "h2o");
-//     assert_eq!(
-//         series_set0.tags,
-//         str_pair_vec_to_vec(&[("city", "LA"), ("state", "CA")])
-//     );
-//     assert_eq!(
-//         series_set0.field_indexes,
-//         FieldIndexes::from_timestamp_and_value_indexes(3, &[2])
-//     );
-//     assert_eq!(series_set0.start_row, 0);
-//     assert_eq!(series_set0.num_rows, 1); // only has one row!
-
-//     Ok(())
-// }
 
 #[tokio::test]
 async fn test_read_filter_data_pred_refers_to_non_existent_column() {

--- a/server/src/query_tests/influxrpc/read_filter.rs
+++ b/server/src/query_tests/influxrpc/read_filter.rs
@@ -246,7 +246,6 @@ async fn test_read_filter_data_filter() {
     run_read_filter_test_case!(TwoMeasurementsMultiSeries {}, predicate, expected_results);
 }
 
-
 #[tokio::test]
 async fn test_read_filter_data_pred_refers_to_non_existent_column() {
     let predicate = PredicateBuilder::default()

--- a/server/src/query_tests/scenarios.rs
+++ b/server/src/query_tests/scenarios.rs
@@ -183,7 +183,7 @@ impl DBSetup for EndToEndTest {
 /// Data in single closed mutable buffer chunk, one closed mutable chunk
 /// Data in both read buffer and mutable buffer chunk
 /// Data in one only read buffer chunk
-async fn make_one_chunk_scenarios(partition_key: &str, data: &str) -> Vec<DBScenario> {
+pub(crate) async fn make_one_chunk_scenarios(partition_key: &str, data: &str) -> Vec<DBScenario> {
     let db = make_db();
     let mut writer = TestLPWriter::default();
     writer.write_lp_string(&db, data).await.unwrap();


### PR DESCRIPTION
Build https://github.com/influxdata/influxdb_iox/pull/879

# Rationale:
Users want to query data via flux / influxql when it lives in any type of IOx chunk. Flux / InfuxQL use the gRPC storage API.

# Changes
This PR ports the `read_filter` query into the `InfluxRPCPlanner` from the `MutableBuffer` so that it works across all types of Chunks.

# Follow on work:
* https://github.com/influxdata/influxdb_iox/issues/883 for possibly incorrect results with 'OR' predicate

Note I really want to write some tests with more complicated predicates in general, but I I plan to make something like https://github.com/influxdata/influxdb_iox/issues/843 before spending time adding more complex scenarios

- [x] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb_iox/blob/main/README.md).
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
