### PR TITLE
feat: implement column_values in Read Buffer

### DIFF
--- a/read_buffer/src/chunk.rs
+++ b/read_buffer/src/chunk.rs
@@ -293,6 +293,7 @@ impl Chunk {
     /// where each returned value sits in a row matching the provided
     /// predicate. All values are deduplicated across row groups in the table.
     ///
+    /// All specified columns must be of `String` type
     /// If the predicate is empty then all distinct values are returned for the
     /// table.
     pub fn column_values<'a>(

--- a/read_buffer/src/column.rs
+++ b/read_buffer/src/column.rs
@@ -244,19 +244,19 @@ impl Column {
         match &self {
             Column::String(_, data) => data.distinct_values(row_ids),
             Column::Float(_, _) => {
-                unimplemented!("distinct values is not implemented for Float column")
+                unimplemented!("distinct values is unimplemented for Float column")
             }
             Column::Integer(_, _) => {
-                unimplemented!("distinct values is not implemented for Integer column")
+                unimplemented!("distinct values is unimplemented for Integer column")
             }
             Column::Unsigned(_, _) => {
-                unimplemented!("distinct values is not implemented for Unsigned column")
+                unimplemented!("distinct values is unimplemented for Unsigned column")
             }
             Column::Bool(_, _) => {
-                unimplemented!("distinct values is not implemented for Bool column")
+                unimplemented!("distinct values is unimplemented for Bool column")
             }
             Column::ByteArray(_, _) => {
-                unimplemented!("distinct values is not implemented for ByteArray column")
+                unimplemented!("distinct values is unimplemented for ByteArray column")
             }
         }
     }

--- a/read_buffer/src/column.rs
+++ b/read_buffer/src/column.rs
@@ -683,10 +683,21 @@ impl Column {
         }
     }
 
-    /// Determines if the column contains other values than those provided in
-    /// `values`.
-    pub fn has_other_values(&self, values: &BTreeSet<String>) -> bool {
-        todo!()
+    /// Determines if the column contains any string values that are not present
+    /// in the provided `values` argument.
+    pub fn has_other_non_null_string_values(&self, values: &BTreeSet<String>) -> bool {
+        match self {
+            Column::String(_, data) => data.has_other_non_null_values(values),
+            Column::Float(_, _) => unimplemented!("operation not supported on `Float` column"),
+            Column::Integer(_, _) => unimplemented!("operation not supported on `Integer` column"),
+            Column::Unsigned(_, _) => {
+                unimplemented!("operation not supported on `Unsigned` column")
+            }
+            Column::Bool(_, _) => unimplemented!("operation not supported on `Bool` column"),
+            Column::ByteArray(_, _) => {
+                unimplemented!("operation not supported on `ByteArray` column")
+            }
+        }
     }
 }
 

--- a/read_buffer/src/column/encoding/dictionary.rs
+++ b/read_buffer/src/column/encoding/dictionary.rs
@@ -1031,19 +1031,31 @@ mod test {
 
     #[test]
     fn distinct_values() {
-        let mut enc = Encoding::RLE(RLE::default());
-        enc.push_additional(Some("east".to_string()), 100);
+        let encodings = vec![
+            Encoding::RLE(RLE::default()),
+            Encoding::Plain(Plain::default()),
+        ];
 
-        let values = enc.distinct_values((0..100).collect::<Vec<_>>().as_slice(), BTreeSet::new());
+        for enc in encodings {
+            _distinct_values(enc);
+        }
+    }
+
+    fn _distinct_values(mut enc: Encoding) {
+        let name = enc.debug_name();
+
+        enc.push_additional(Some("east".to_string()), 3);
+
+        let values = enc.distinct_values((0..3).collect::<Vec<_>>().as_slice(), BTreeSet::new());
         assert_eq!(
             values,
             vec![Some(&"east".to_string())]
                 .into_iter()
-                .collect::<BTreeSet<_>>()
+                .collect::<BTreeSet<_>>(),
+            "{}",
+            name,
         );
 
-        enc = Encoding::RLE(RLE::default());
-        enc.push_additional(Some("east".to_string()), 3); // 0, 1, 2
         enc.push_additional(Some("north".to_string()), 1); // 3
         enc.push_additional(Some("east".to_string()), 5); // 4, 5, 6, 7, 8
         enc.push_additional(Some("south".to_string()), 2); // 9, 10
@@ -1059,7 +1071,9 @@ mod test {
                 Some(&"south".to_string()),
             ]
             .into_iter()
-            .collect::<BTreeSet<_>>()
+            .collect::<BTreeSet<_>>(),
+            "{}",
+            name,
         );
 
         let values = enc.distinct_values((0..4).collect::<Vec<_>>().as_slice(), BTreeSet::new());
@@ -1067,7 +1081,9 @@ mod test {
             values,
             vec![Some(&"east".to_string()), Some(&"north".to_string()),]
                 .into_iter()
-                .collect::<BTreeSet<_>>()
+                .collect::<BTreeSet<_>>(),
+            "{}",
+            name,
         );
 
         let values = enc.distinct_values(&[3, 10], BTreeSet::new());
@@ -1075,11 +1091,10 @@ mod test {
             values,
             vec![Some(&"north".to_string()), Some(&"south".to_string()),]
                 .into_iter()
-                .collect::<BTreeSet<_>>()
+                .collect::<BTreeSet<_>>(),
+            "{}",
+            name,
         );
-
-        let values = enc.distinct_values(&[100], BTreeSet::new());
-        assert!(values.is_empty());
     }
 
     #[test]

--- a/read_buffer/src/column/encoding/dictionary.rs
+++ b/read_buffer/src/column/encoding/dictionary.rs
@@ -237,9 +237,9 @@ impl Encoding {
     /// increasing set.
     fn distinct_values<'a>(
         &'a self,
-        row_ids: &[u32],
-        dst: BTreeSet<Option<&'a String>>,
-    ) -> BTreeSet<Option<&'a String>> {
+        row_ids: impl Iterator<Item = u32>,
+        dst: BTreeSet<Option<&'a str>>,
+    ) -> BTreeSet<Option<&'a str>> {
         match self {
             Encoding::RLE(enc) => enc.distinct_values(row_ids, dst),
             Encoding::Plain(enc) => enc.distinct_values(row_ids, dst),
@@ -1046,12 +1046,10 @@ mod test {
 
         enc.push_additional(Some("east".to_string()), 3);
 
-        let values = enc.distinct_values((0..3).collect::<Vec<_>>().as_slice(), BTreeSet::new());
+        let values = enc.distinct_values((0..3).collect::<Vec<_>>().into_iter(), BTreeSet::new());
         assert_eq!(
             values,
-            vec![Some(&"east".to_string())]
-                .into_iter()
-                .collect::<BTreeSet<_>>(),
+            vec![Some("east")].into_iter().collect::<BTreeSet<_>>(),
             "{}",
             name,
         );
@@ -1061,35 +1059,30 @@ mod test {
         enc.push_additional(Some("south".to_string()), 2); // 9, 10
         enc.push_none(); // 11
 
-        let values = enc.distinct_values((0..12).collect::<Vec<_>>().as_slice(), BTreeSet::new());
+        let values = enc.distinct_values((0..12).collect::<Vec<_>>().into_iter(), BTreeSet::new());
         assert_eq!(
             values,
-            vec![
-                None,
-                Some(&"east".to_string()),
-                Some(&"north".to_string()),
-                Some(&"south".to_string()),
-            ]
-            .into_iter()
-            .collect::<BTreeSet<_>>(),
-            "{}",
-            name,
-        );
-
-        let values = enc.distinct_values((0..4).collect::<Vec<_>>().as_slice(), BTreeSet::new());
-        assert_eq!(
-            values,
-            vec![Some(&"east".to_string()), Some(&"north".to_string()),]
+            vec![None, Some("east"), Some("north"), Some("south"),]
                 .into_iter()
                 .collect::<BTreeSet<_>>(),
             "{}",
             name,
         );
 
-        let values = enc.distinct_values(&[3, 10], BTreeSet::new());
+        let values = enc.distinct_values((0..4).collect::<Vec<_>>().into_iter(), BTreeSet::new());
         assert_eq!(
             values,
-            vec![Some(&"north".to_string()), Some(&"south".to_string()),]
+            vec![Some("east"), Some("north"),]
+                .into_iter()
+                .collect::<BTreeSet<_>>(),
+            "{}",
+            name,
+        );
+
+        let values = enc.distinct_values(vec![3, 10].into_iter(), BTreeSet::new());
+        assert_eq!(
+            values,
+            vec![Some("north"), Some("south"),]
                 .into_iter()
                 .collect::<BTreeSet<_>>(),
             "{}",

--- a/read_buffer/src/column/encoding/dictionary/plain.rs
+++ b/read_buffer/src/column/encoding/dictionary/plain.rs
@@ -618,19 +618,19 @@ impl Plain {
     /// increasing set.
     pub fn distinct_values<'a>(
         &'a self,
-        row_ids: &[u32],
-        mut dst: BTreeSet<Option<&'a String>>,
-    ) -> BTreeSet<Option<&'a String>> {
+        row_ids: impl Iterator<Item = u32>,
+        mut dst: BTreeSet<Option<&'a str>>,
+    ) -> BTreeSet<Option<&'a str>> {
         // TODO(edd): Perf... We can improve on this if we know the column is
         // totally ordered.
         dst.clear();
 
-        for &row_id in row_ids {
+        for row_id in row_ids {
             let encoded_id = self.encoded_data[row_id as usize];
-            let value = &self.entries[encoded_id as usize].as_ref();
 
-            if !dst.contains(value) {
-                dst.insert(*value);
+            let value = self.entries[encoded_id as usize].as_deref();
+            if !dst.contains(&value) {
+                dst.insert(value);
             }
 
             if dst.len() as u32 == self.cardinality() {

--- a/read_buffer/src/column/encoding/dictionary/plain.rs
+++ b/read_buffer/src/column/encoding/dictionary/plain.rs
@@ -625,7 +625,21 @@ impl Plain {
         // totally ordered.
         dst.clear();
 
-        todo!()
+        for &row_id in row_ids {
+            let encoded_id = self.encoded_data[row_id as usize];
+            let value = &self.entries[encoded_id as usize].as_ref();
+
+            if !dst.contains(value) {
+                dst.insert(*value);
+            }
+
+            if dst.len() as u32 == self.cardinality() {
+                // no more distinct values to find.
+                return dst;
+            }
+        }
+
+        dst
     }
 
     //

--- a/read_buffer/src/column/encoding/dictionary/rle.rs
+++ b/read_buffer/src/column/encoding/dictionary/rle.rs
@@ -689,10 +689,6 @@ impl RLE {
 
         let mut i = 1;
         'by_row: for row_id in row_ids {
-            if row_id >= &self.num_rows {
-                return dst; // rows beyond the column size
-            }
-
             while curr_logical_row_id + curr_entry_rl <= *row_id {
                 // this encoded entry does not cover the row we need.
                 // move on to next entry

--- a/read_buffer/src/column/encoding/dictionary/rle.rs
+++ b/read_buffer/src/column/encoding/dictionary/rle.rs
@@ -664,9 +664,9 @@ impl RLE {
     /// increasing set.
     pub fn distinct_values<'a>(
         &'a self,
-        row_ids: &[u32],
-        mut dst: BTreeSet<Option<&'a String>>,
-    ) -> BTreeSet<Option<&'a String>> {
+        row_ids: impl Iterator<Item = u32>,
+        mut dst: BTreeSet<Option<&'a str>>,
+    ) -> BTreeSet<Option<&'a str>> {
         // TODO(edd): Perf... We can improve on this if we know the column is
         // totally ordered.
         dst.clear();
@@ -689,7 +689,7 @@ impl RLE {
 
         let mut i = 1;
         'by_row: for row_id in row_ids {
-            while curr_logical_row_id + curr_entry_rl <= *row_id {
+            while curr_logical_row_id + curr_entry_rl <= row_id {
                 // this encoded entry does not cover the row we need.
                 // move on to next entry
                 curr_logical_row_id += curr_entry_rl;

--- a/read_buffer/src/column/encoding/dictionary/rle.rs
+++ b/read_buffer/src/column/encoding/dictionary/rle.rs
@@ -784,37 +784,19 @@ impl RLE {
     /// differ from the provided set of values.
     ///
     /// Informally, this method provides an efficient way of answering "is it
-    /// worth spending time reading this column for values or do I already have
-    /// all the values in a set".
+    /// worth spending time reading this column for distinct values that are not
+    /// present in the provided set?".
     ///
     /// More formally, this method returns the relative complement of this
-    /// column's values in the provided set of values.
-    ///
-    /// This method would be useful when the same column is being read across
-    /// many segments, and one wants to determine to the total distinct set of
-    /// values. By exposing the current result set to each column (as an
-    /// argument to `contains_other_values`) columns can be short-circuited when
-    /// they only contain values that have already been discovered.
-    pub fn contains_other_values(&self, values: &BTreeSet<Option<&String>>) -> bool {
-        let mut encoded_values = self.index_entries.len();
-        if !self.contains_null {
-            encoded_values -= 1; // this column doesn't encode NULL
-        }
-
-        if encoded_values > values.len() {
+    /// column's dictionary in the provided set of values.
+    pub fn has_other_non_null_values(&self, values: &BTreeSet<String>) -> bool {
+        if self.cardinality() as usize > values.len() {
             return true;
         }
 
-        for key in self.entry_index.keys() {
-            if !values.contains(&Some(key)) {
-                return true;
-            }
-        }
-
-        if self.contains_null && !values.contains(&None) {
-            return true;
-        }
-        false
+        // If any of the distinct values in this column are not present in
+        // `values` then return `true`.
+        self.entry_index.keys().any(|entry| !values.contains(entry))
     }
 
     /// Determines if the column contains at least one non-null value.

--- a/read_buffer/src/column/string.rs
+++ b/read_buffer/src/column/string.rs
@@ -3,8 +3,8 @@ use std::collections::BTreeSet;
 use arrow_deps::arrow::{self, array::Array};
 use either::Either;
 
+use super::cmp;
 use super::encoding::dictionary::{Encoding, Plain, RLE};
-use super::{cmp, ValueSet};
 use crate::column::{RowIDs, Value, Values};
 
 // Edd's totally made up magic constant. This determines whether we would use
@@ -142,10 +142,10 @@ impl StringEncoding {
     /// Returns the distinct set of values found at the provided row ids.
     ///
     /// TODO(edd): perf - pooling of destination sets.
-    pub fn distinct_values(&self, row_ids: &[u32]) -> ValueSet<'_> {
+    pub fn distinct_values(&self, row_ids: impl Iterator<Item = u32>) -> BTreeSet<Option<&'_ str>> {
         match &self {
-            Self::RLEDictionary(c) => ValueSet::String(c.distinct_values(row_ids, BTreeSet::new())),
-            Self::Dictionary(c) => ValueSet::String(c.distinct_values(row_ids, BTreeSet::new())),
+            Self::RLEDictionary(c) => c.distinct_values(row_ids, BTreeSet::new()),
+            Self::Dictionary(c) => c.distinct_values(row_ids, BTreeSet::new()),
         }
     }
 

--- a/read_buffer/src/column/string.rs
+++ b/read_buffer/src/column/string.rs
@@ -91,6 +91,15 @@ impl StringEncoding {
         }
     }
 
+    /// Determines if the column contains any values other than those provided.
+    /// Short-circuits execution as soon as it finds a value not in `values`.
+    pub fn has_other_non_null_values(&self, values: &BTreeSet<String>) -> bool {
+        match &self {
+            Self::RLEDictionary(c) => c.has_other_non_null_values(values),
+            Self::Dictionary(c) => c.has_other_non_null_values(values),
+        }
+    }
+
     /// Returns the logical value found at the provided row id.
     pub fn value(&self, row_id: u32) -> Value<'_> {
         match &self {

--- a/read_buffer/src/row_group.rs
+++ b/read_buffer/src/row_group.rs
@@ -3005,7 +3005,7 @@ west,host-d,11,9
         );
     }
 
-    fn to_map<'a>(arr: Vec<(&str, &[&'a str])>) -> BTreeMap<String, BTreeSet<String>> {
+    fn to_map(arr: Vec<(&str, &[&str])>) -> BTreeMap<String, BTreeSet<String>> {
         arr.iter()
             .map(|(k, values)| {
                 (


### PR DESCRIPTION
Closes #868.

This PR implements `column_values` in the Read Buffer.

`column_values` returns the distinct set of non-null values for a pushed-down set of columns. Currently, these columns must have the semantic type of InfluxDB tags. The reasoning for this is: (1) this operation is only currently going to be used to support execution of a `SHOW TAG KEYS` type call via the gRPC API (used by InfluxQL and Flux); and (2) the operation only supports returning `String` values at the moment.

`column_values` will return an error is `Selection::All` is used as the column push-down. It will also return an error if one of the provided columns does not conform to the semantic type laid out above.

`column_values` is smart about how it executes the operation. It passes a buffer of previously calculated results around as it interrogates required chunks, tables and row_groups. Before interrogating a row group's columns, `column_names` will first check the previously calculated column values for each column against that column encoding's dictionary. If the column does not contain any different values to those previously discovered then execution will short-circuit.

This buffer of previous results is also passed between chunks meaning the process of merging is done as the operation executes. The buffer is then returned as the final result set.

I have `column_names` ear-marked in my head as a potential place for performance improvements due to the possibly large materialisation cost for high cardinality columns, but for now I am happy to 🚢 
