### PR TITLE
ci: Remove nightly-2021-02-12

### DIFF
--- a/docker/Dockerfile.ci
+++ b/docker/Dockerfile.ci
@@ -53,9 +53,7 @@ RUN locale-gen C.UTF-8 || true
 ENV LANG=C.UTF-8
 
 RUN rustup toolchain install nightly-2020-11-19
-RUN rustup toolchain install nightly-2021-02-12
 RUN rustup component add rustfmt clippy --toolchain nightly-2020-11-19
-RUN rustup component add rustfmt clippy --toolchain nightly-2021-02-12
 
 RUN groupadd -g 1500 rust \
   && useradd -u 1500 -g rust -s /bin/bash -m rust \


### PR DESCRIPTION
This reverts commit c1856d2946f99d09b5d4133ef3ca27d1603196e6.

https://github.com/influxdata/influxdb_iox/pull/799#issuecomment-779371477:
> Lets drop the changes from #800 then - the build image has to be pulled for each CI run so we try to keep it small


We decided to aim for stable (see #809)