### PR TITLE
feat: make read_group and read_window_aggregate work across chunks

### DIFF
--- a/query/src/frontend/influxrpc.rs
+++ b/query/src/frontend/influxrpc.rs
@@ -1343,8 +1343,7 @@ fn reorder_prefix<'a>(
     // Note that this is an O(N^2) algorithm. We are assuming the
     // number of tag columns is reasonably small
 
-    // map from prefix_column[idx] -> index in tag_columns
-    let prefix_map = prefix_columns
+    let mut new_tag_columns = prefix_columns
         .iter()
         .map(|pc| {
             let found_location = tag_columns
@@ -1352,7 +1351,7 @@ fn reorder_prefix<'a>(
                 .enumerate()
                 .find(|(_, c)| pc.as_ref() == c as &str);
 
-            if let Some((index, _)) = found_location {
+            if let Some((index, &tag_column)) = found_location {
                 if tag_used_set[index] {
                     DuplicateGroupColumn {
                         column_name: pc.as_ref(),
@@ -1360,7 +1359,7 @@ fn reorder_prefix<'a>(
                     .fail()
                 } else {
                     tag_used_set[index] = true;
-                    Ok(index)
+                    Ok(tag_column)
                 }
             } else {
                 GroupColumnNotFound {
@@ -1371,11 +1370,6 @@ fn reorder_prefix<'a>(
             }
         })
         .collect::<Result<Vec<_>>>()?;
-
-    let mut new_tag_columns = prefix_map
-        .iter()
-        .map(|&i| tag_columns[i])
-        .collect::<Vec<_>>();
 
     new_tag_columns.extend(tag_columns.into_iter().enumerate().filter_map(|(i, c)| {
         // already used in prefix

--- a/query/src/frontend/influxrpc.rs
+++ b/query/src/frontend/influxrpc.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use arrow_deps::{
-    arrow::datatypes::DataType,
+    arrow::datatypes::{DataType, Field},
     datafusion::{
         error::{DataFusionError, Result as DatafusionResult},
         logical_plan::{
@@ -17,12 +17,18 @@ use arrow_deps::{
 use data_types::{
     schema::{InfluxColumnType, Schema},
     selection::Selection,
+    TIME_COLUMN_NAME,
 };
 use snafu::{ensure, OptionExt, ResultExt, Snafu};
 use tracing::debug;
 
 use crate::{
-    exec::{make_schema_pivot, stringset::StringSet},
+    exec::{field::FieldColumns, make_schema_pivot, stringset::StringSet},
+    func::{
+        selectors::{selector_first, selector_last, selector_max, selector_min, SelectorOutput},
+        window::make_window_bound_expr,
+    },
+    group_by::{Aggregate, GroupByAndAggregate, WindowDuration},
     plan::{
         fieldlist::FieldListPlan,
         seriesset::{SeriesSetPlan, SeriesSetPlans},
@@ -132,6 +138,28 @@ pub enum Error {
         tag_name: String,
         data_type: DataType,
     },
+
+    #[snafu(display("Duplicate group column '{}'", column_name))]
+    DuplicateGroupColumn { column_name: String },
+
+    #[snafu(display(
+        "Group column '{}' not found in tag columns: {}",
+        column_name,
+        all_tag_column_names
+    ))]
+    GroupColumnNotFound {
+        column_name: String,
+        all_tag_column_names: String,
+    },
+
+    #[snafu(display("Error creating aggregate expression:  {}", source))]
+    CreatingAggregates { source: crate::group_by::Error },
+
+    #[snafu(display("Internal error: unexpected aggregate request for None aggregate",))]
+    InternalUnexpectedNoneAggregate {},
+
+    #[snafu(display("Internal error: aggregate {:?} is not a selector", agg))]
+    InternalAggregateNotSelector { agg: Aggregate },
 }
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
@@ -469,17 +497,8 @@ impl InfluxRPCPlanner {
         // values and stops the plan executing once it has them
 
         // map table -> Vec<Arc<Chunk>>
-        let mut table_chunks = BTreeMap::new();
         let chunks = self.filtered_chunks(database, &predicate).await?;
-        for chunk in chunks {
-            let table_names = self.chunk_table_names(chunk.as_ref(), &predicate).await?;
-            for table_name in table_names {
-                table_chunks
-                    .entry(table_name)
-                    .or_insert_with(Vec::new)
-                    .push(Arc::clone(&chunk));
-            }
-        }
+        let table_chunks = self.group_chunks_by_table(&predicate, chunks).await?;
 
         let mut field_list_plan = FieldListPlan::new();
         for (table_name, chunks) in table_chunks {
@@ -521,23 +540,16 @@ impl InfluxRPCPlanner {
 
         // group tables by chunk, pruning if possible
         // key is table name, values are chunks
-        let mut table_chunks = BTreeMap::new();
-
-        for chunk in self.filtered_chunks(database, &predicate).await? {
-            let table_names = self.chunk_table_names(chunk.as_ref(), &predicate).await?;
-            for table_name in table_names.into_iter() {
-                table_chunks
-                    .entry(table_name)
-                    .or_insert_with(Vec::new)
-                    .push(Arc::clone(&chunk));
-            }
-        }
+        let chunks = self.filtered_chunks(database, &predicate).await?;
+        let table_chunks = self.group_chunks_by_table(&predicate, chunks).await?;
 
         // now, build up plans for each table
         let mut ss_plans = Vec::with_capacity(table_chunks.len());
         for (table_name, chunks) in table_chunks {
+            let prefix_columns: Option<&[&str]> = None;
+
             let ss_plan = self
-                .read_filter_plan(table_name, &predicate, chunks)
+                .read_filter_plan(table_name, prefix_columns, &predicate, chunks)
                 .await?;
             // If we have to do real work, add it to the list of plans
             if let Some(ss_plan) = ss_plan {
@@ -546,6 +558,130 @@ impl InfluxRPCPlanner {
         }
 
         Ok(ss_plans.into())
+    }
+
+    /// Query groups (dispatch to read_group or read_window_aggregate).
+    /// TODO remove this dispatch and just call the right thing directly
+    pub async fn query_group<D>(
+        &self,
+        database: &D,
+        predicate: Predicate,
+        gby_agg: GroupByAndAggregate,
+    ) -> Result<SeriesSetPlans>
+    where
+        D: Database + 'static,
+    {
+        match gby_agg {
+            GroupByAndAggregate::Columns { agg, group_columns } => {
+                self.read_group(database, predicate, agg, &group_columns)
+                    .await
+            }
+            GroupByAndAggregate::Window { agg, every, offset } => {
+                self.read_window_aggregate(database, predicate, agg, every, offset)
+                    .await
+            }
+        }
+    }
+
+    /// Creates a GroupedSeriesSet plan that produces an output table
+    /// with rows grouped by an aggregate function. Note that we still
+    /// group by all tags (so group within series) and the
+    /// group_columns define the order of the result
+    pub async fn read_group<D>(
+        &self,
+        database: &D,
+        predicate: Predicate,
+        agg: Aggregate,
+        group_columns: &[impl AsRef<str>],
+    ) -> Result<SeriesSetPlans>
+    where
+        D: Database + 'static,
+    {
+        debug!(predicate=?predicate, agg=?agg, "planning read_group");
+
+        // group tables by chunk, pruning if possible
+        let chunks = self.filtered_chunks(database, &predicate).await?;
+        let table_chunks = self.group_chunks_by_table(&predicate, chunks).await?;
+        let num_prefix_tag_group_columns = group_columns.len();
+
+        // now, build up plans for each table
+        let mut ss_plans = Vec::with_capacity(table_chunks.len());
+        for (table_name, chunks) in table_chunks {
+            let ss_plan = match agg {
+                Aggregate::None => {
+                    self.read_filter_plan(table_name, Some(group_columns), &predicate, chunks)
+                        .await?
+                }
+                _ => {
+                    self.read_group_plan(table_name, &predicate, agg, group_columns, chunks)
+                        .await?
+                }
+            };
+
+            // If we have to do real work, add it to the list of plans
+            if let Some(ss_plan) = ss_plan {
+                let grouped_plan = ss_plan.grouped(num_prefix_tag_group_columns);
+                ss_plans.push(grouped_plan);
+            }
+        }
+
+        Ok(ss_plans.into())
+    }
+
+    /// Creates a GroupedSeriesSet plan that produces an output table with rows
+    /// that are grouped by window defintions
+    pub async fn read_window_aggregate<D>(
+        &self,
+        database: &D,
+        predicate: Predicate,
+        agg: Aggregate,
+        every: WindowDuration,
+        offset: WindowDuration,
+    ) -> Result<SeriesSetPlans>
+    where
+        D: Database + 'static,
+    {
+        debug!(predicate=?predicate, "planning read_window_aggregate");
+
+        // group tables by chunk, pruning if possible
+        let chunks = self.filtered_chunks(database, &predicate).await?;
+        let table_chunks = self.group_chunks_by_table(&predicate, chunks).await?;
+
+        // now, build up plans for each table
+        let mut ss_plans = Vec::with_capacity(table_chunks.len());
+        for (table_name, chunks) in table_chunks {
+            let ss_plan = self
+                .read_window_aggregate_plan(table_name, &predicate, agg, &every, &offset, chunks)
+                .await?;
+            // If we have to do real work, add it to the list of plans
+            if let Some(ss_plan) = ss_plan {
+                ss_plans.push(ss_plan);
+            }
+        }
+
+        Ok(ss_plans.into())
+    }
+
+    /// Creates a map of table_name --> Chunks that have that table
+    async fn group_chunks_by_table<C>(
+        &self,
+        predicate: &Predicate,
+        chunks: Vec<Arc<C>>,
+    ) -> Result<BTreeMap<String, Vec<Arc<C>>>>
+    where
+        C: PartitionChunk + 'static,
+    {
+        let mut table_chunks = BTreeMap::new();
+        for chunk in chunks {
+            let table_names = self.chunk_table_names(chunk.as_ref(), &predicate).await?;
+            for table_name in table_names {
+                table_chunks
+                    .entry(table_name)
+                    .or_insert_with(Vec::new)
+                    .push(Arc::clone(&chunk));
+            }
+        }
+        Ok(table_chunks)
     }
 
     /// Find all the table names in the specified chunk that pass the predicate
@@ -707,6 +843,8 @@ impl InfluxRPCPlanner {
     /// returning None if the predicate rules out matching any rows in
     /// the table
     ///
+    /// prefix_columns, if any, are the prefix of the ordering.
+    //
     /// The created plan looks like:
     ///
     ///    Projection (select the columns needed)
@@ -716,6 +854,7 @@ impl InfluxRPCPlanner {
     async fn read_filter_plan<C>(
         &self,
         table_name: impl Into<String>,
+        prefix_columns: Option<&[impl AsRef<str>]>,
         predicate: &Predicate,
         chunks: Vec<Arc<C>>,
     ) -> Result<Option<SeriesSetPlan>>
@@ -733,10 +872,22 @@ impl InfluxRPCPlanner {
             Some(t) => t,
         };
 
-        let tags_and_timestamp: Vec<Expr> = schema
+        let tags_and_timestamp: Vec<_> = schema
             .tags_iter()
             .chain(schema.time_iter())
-            .map(|field| field.name().into_sort_expr())
+            .map(|f| f.name() as &str)
+            .collect();
+
+        // Reorder, if requested
+        let tags_and_timestamp: Vec<_> = match prefix_columns {
+            Some(prefix_columns) => reorder_prefix(prefix_columns, tags_and_timestamp)?,
+            None => tags_and_timestamp,
+        };
+
+        // Convert to SortExprs to pass to the plan builder
+        let tags_and_timestamp: Vec<_> = tags_and_timestamp
+            .into_iter()
+            .map(|n| n.into_sort_expr())
             .collect();
 
         // Order by
@@ -747,7 +898,7 @@ impl InfluxRPCPlanner {
         // Select away anything that isn't in the influx data model
         let tags_fields_and_timestamps: Vec<Expr> = schema
             .tags_iter()
-            .chain(schema.fields_iter())
+            .chain(filtered_fields_iter(&schema, predicate))
             .chain(schema.time_iter())
             .map(|field| field.name().into_expr())
             .collect();
@@ -763,13 +914,215 @@ impl InfluxRPCPlanner {
             .map(|field| Arc::new(field.name().to_string()))
             .collect();
 
-        let field_columns = schema
-            .fields_iter()
+        let field_columns = filtered_fields_iter(&schema, predicate)
             .map(|field| Arc::new(field.name().to_string()))
             .collect();
 
         // TODO: remove the use of tag_columns and field_column names
         // and instead use the schema directly)
+        let ss_plan = SeriesSetPlan::new_from_shared_timestamp(
+            Arc::new(table_name),
+            plan,
+            tag_columns,
+            field_columns,
+        );
+
+        Ok(Some(ss_plan))
+    }
+
+    /// Creates a GroupedSeriesSet plan that produces an output table
+    /// with rows grouped by an aggregate function. Note that we still
+    /// group by all tags (so group within series) and the
+    /// group_columns define the order of the result
+    ///
+    /// Equivalent to this SQL query for 'aggregates': sum, count, mean
+    /// SELECT
+    ///   tag1...tagN
+    ///   agg_function(_val1) as _value1
+    ///   ...
+    ///   agg_function(_valN) as _valueN
+    ///   agg_function(time) as time
+    /// GROUP BY
+    ///   group_key1, group_key2, remaining tags,
+    /// ORDER BY
+    ///   group_key1, group_key2, remaining tags
+    ///
+    /// Equivalent to this SQL query for 'selector' functions: first, last, min,
+    /// max as they can have different values of the timestamp column
+    ///
+    /// SELECT
+    ///   tag1...tagN
+    ///   agg_function(_val1) as _value1
+    ///   agg_function(time) as time1
+    ///   ..
+    ///   agg_function(_valN) as _valueN
+    ///   agg_function(time) as timeN
+    /// GROUP BY
+    ///   group_key1, group_key2, remaining tags,
+    /// ORDER BY
+    ///   group_key1, group_key2, remaining tags
+    ///
+    /// The created plan looks like:
+    ///
+    ///  OrderBy(gby cols; agg)
+    ///     GroupBy(gby cols, aggs, time cols)
+    ///       Filter(predicate)
+    ///          Scan
+    pub async fn read_group_plan<C>(
+        &self,
+        table_name: impl Into<String>,
+        predicate: &Predicate,
+        agg: Aggregate,
+        group_columns: &[impl AsRef<str>],
+        chunks: Vec<Arc<C>>,
+    ) -> Result<Option<SeriesSetPlan>>
+    where
+        C: PartitionChunk + 'static,
+    {
+        let table_name = table_name.into();
+        let scan_and_filter = self.scan_and_filter(&table_name, predicate, chunks).await?;
+
+        let TableScanAndFilter {
+            plan_builder,
+            schema,
+        } = match scan_and_filter {
+            None => return Ok(None),
+            Some(t) => t,
+        };
+
+        // order the tag columns so that the group keys come first (we
+        // will group and
+        // order in the same order)
+        let tag_columns: Vec<_> = schema.tags_iter().map(|f| f.name() as &str).collect();
+
+        let tag_columns: Vec<_> = reorder_prefix(group_columns, tag_columns)?
+            .into_iter()
+            .map(|name| Arc::new(name.to_string()))
+            .collect();
+
+        // Group by all tag columns
+        let group_exprs = tag_columns
+            .iter()
+            .map(|tag_name| tag_name.into_expr())
+            .collect::<Vec<_>>();
+
+        let AggExprs {
+            agg_exprs,
+            field_columns,
+        } = AggExprs::try_new(agg, &schema, predicate)?;
+
+        let sort_exprs = group_exprs
+            .iter()
+            .map(|expr| expr.into_sort_expr())
+            .collect::<Vec<_>>();
+
+        let plan_builder = plan_builder
+            .aggregate(&group_exprs, &agg_exprs)
+            .context(BuildingPlan)?
+            .sort(&sort_exprs)
+            .context(BuildingPlan)?;
+
+        // and finally create the plan
+        let plan = plan_builder.build().context(BuildingPlan)?;
+
+        let ss_plan = SeriesSetPlan::new(Arc::new(table_name), plan, tag_columns, field_columns);
+
+        Ok(Some(ss_plan))
+    }
+
+    /// Creates a GroupedSeriesSet plan that produces an output table with rows
+    /// that are grouped by window defintions
+    ///
+    /// The order of the tag_columns
+    ///
+    /// The data is sorted on tag_col1, tag_col2, ...) so that all
+    /// rows for a particular series (groups where all tags are the
+    /// same) occur together in the plan
+    ///
+    /// Equivalent to this SQL query
+    ///
+    /// SELECT tag1, ... tagN,
+    ///   window_bound(time, every, offset) as time,
+    ///   agg_function1(field), as field_name
+    /// FROM measurement
+    /// GROUP BY
+    ///   tag1, ... tagN,
+    ///   window_bound(time, every, offset) as time,
+    /// ORDER BY
+    ///   tag1, ... tagN,
+    ///   window_bound(time, every, offset) as time
+    ///
+    /// The created plan looks like:
+    ///
+    ///  OrderBy(gby: tag columns, window_function; agg: aggregate(field)
+    ///      GroupBy(gby: tag columns, window_function; agg: aggregate(field)
+    ///        Filter(predicate)
+    ///          InMemoryScan
+    pub async fn read_window_aggregate_plan<C>(
+        &self,
+        table_name: impl Into<String>,
+        predicate: &Predicate,
+        agg: Aggregate,
+        every: &WindowDuration,
+        offset: &WindowDuration,
+        chunks: Vec<Arc<C>>,
+    ) -> Result<Option<SeriesSetPlan>>
+    where
+        C: PartitionChunk + 'static,
+    {
+        let table_name = table_name.into();
+        let scan_and_filter = self.scan_and_filter(&table_name, predicate, chunks).await?;
+
+        let TableScanAndFilter {
+            plan_builder,
+            schema,
+        } = match scan_and_filter {
+            None => return Ok(None),
+            Some(t) => t,
+        };
+
+        // Group by all tag columns and the window bounds
+        let window_bound = make_window_bound_expr(TIME_COLUMN_NAME.into_expr(), &every, &offset)
+            .alias(TIME_COLUMN_NAME);
+
+        let group_exprs = schema
+            .tags_iter()
+            .map(|field| field.name().into_expr())
+            .chain(std::iter::once(window_bound))
+            .collect::<Vec<_>>();
+
+        // aggregate each field
+        let agg_exprs = filtered_fields_iter(&schema, predicate)
+            .map(|field| make_agg_expr(agg, field.name()))
+            .collect::<Result<Vec<_>>>()?;
+
+        // sort by the group by expressions as well
+        let sort_exprs = group_exprs
+            .iter()
+            .map(|expr| expr.into_sort_expr())
+            .collect::<Vec<_>>();
+
+        let plan_builder = plan_builder
+            .aggregate(&group_exprs, &agg_exprs)
+            .context(BuildingPlan)?
+            .sort(&sort_exprs)
+            .context(BuildingPlan)?;
+
+        // and finally create the plan
+        let plan = plan_builder.build().context(BuildingPlan)?;
+
+        let tag_columns = schema
+            .tags_iter()
+            .map(|field| Arc::new(field.name().to_string()))
+            .collect();
+
+        let field_columns = filtered_fields_iter(&schema, predicate)
+            .map(|field| Arc::new(field.name().to_string()))
+            .collect();
+
+        // TODO: remove the use of tag_columns and field_column names
+        // and instead use the schema directly)
+
         let ss_plan = SeriesSetPlan::new_from_shared_timestamp(
             Arc::new(table_name),
             plan,
@@ -972,4 +1325,272 @@ struct TableScanAndFilter {
     plan_builder: LogicalPlanBuilder,
     /// The IOx schema of the result
     schema: Schema,
+}
+
+/// Reorders tag_columns so that its prefix matches exactly
+/// prefix_columns. Returns an error if there are duplicates, or other
+/// untoward inputs
+fn reorder_prefix<'a>(
+    prefix_columns: &[impl AsRef<str>],
+    tag_columns: Vec<&'a str>,
+) -> Result<Vec<&'a str>> {
+    // tag_used_set[i[ is true if we have used the value in tag_columns[i]
+    let mut tag_used_set = vec![false; tag_columns.len()];
+
+    // Note that this is an O(N^2) algorithm. We are assuming the
+    // number of tag columns is reasonably small
+
+    // map from prefix_column[idx] -> index in tag_columns
+    let prefix_map = prefix_columns
+        .iter()
+        .map(|pc| {
+            let found_location = tag_columns
+                .iter()
+                .enumerate()
+                .find(|(_, c)| pc.as_ref() == c as &str);
+
+            if let Some((index, _)) = found_location {
+                if tag_used_set[index] {
+                    DuplicateGroupColumn {
+                        column_name: pc.as_ref(),
+                    }
+                    .fail()
+                } else {
+                    tag_used_set[index] = true;
+                    Ok(index)
+                }
+            } else {
+                GroupColumnNotFound {
+                    column_name: pc.as_ref(),
+                    all_tag_column_names: tag_columns.join(", "),
+                }
+                .fail()
+            }
+        })
+        .collect::<Result<Vec<_>>>()?;
+
+    let mut new_tag_columns = prefix_map
+        .iter()
+        .map(|&i| tag_columns[i])
+        .collect::<Vec<_>>();
+
+    new_tag_columns.extend(tag_columns.into_iter().enumerate().filter_map(|(i, c)| {
+        // already used in prefix
+        if tag_used_set[i] {
+            None
+        } else {
+            Some(c)
+        }
+    }));
+
+    Ok(new_tag_columns)
+}
+
+/// Helper for creating aggregates
+pub(crate) struct AggExprs {
+    agg_exprs: Vec<Expr>,
+    field_columns: FieldColumns,
+}
+
+/// Returns an iterator of fields from schema that pass the predicate
+fn filtered_fields_iter<'a>(
+    schema: &'a Schema,
+    predicate: &'a Predicate,
+) -> impl Iterator<Item = &'a Field> {
+    schema
+        .fields_iter()
+        .filter(move |f| predicate.should_include_field(f.name()))
+}
+
+/// Creates aggregate expressions and tracks field output according to
+/// the rules explained on `read_group_plan`
+impl AggExprs {
+    /// Create the appropriate aggregate expressions, based on the type of the
+    /// field
+    pub fn try_new(agg: Aggregate, schema: &Schema, predicate: &Predicate) -> Result<Self> {
+        match agg {
+            Aggregate::Sum | Aggregate::Count | Aggregate::Mean => {
+                //  agg_function(_val1) as _value1
+                //  ...
+                //  agg_function(_valN) as _valueN
+                //  agg_function(time) as time
+
+                let agg_exprs = filtered_fields_iter(schema, predicate)
+                    .chain(schema.time_iter())
+                    .map(|field| make_agg_expr(agg, field.name()))
+                    .collect::<Result<Vec<_>>>()?;
+
+                let field_columns = filtered_fields_iter(schema, predicate)
+                    .map(|field| Arc::new(field.name().to_string()))
+                    .collect::<Vec<_>>()
+                    .into();
+
+                Ok(Self {
+                    agg_exprs,
+                    field_columns,
+                })
+            }
+            Aggregate::First | Aggregate::Last | Aggregate::Min | Aggregate::Max => {
+                //   agg_function(_val1) as _value1
+                //   agg_function(time) as time1
+                //   ..
+                //   agg_function(_valN) as _valueN
+                //   agg_function(time) as timeN
+
+                // might be nice to use a more functional style here
+                let mut agg_exprs = Vec::new();
+                let mut field_list = Vec::new();
+
+                for field in filtered_fields_iter(schema, predicate) {
+                    agg_exprs.push(make_selector_expr(
+                        agg,
+                        SelectorOutput::Value,
+                        field.name(),
+                        field.data_type(),
+                        field.name(),
+                    )?);
+
+                    let time_column_name = format!("{}_{}", TIME_COLUMN_NAME, field.name());
+
+                    agg_exprs.push(make_selector_expr(
+                        agg,
+                        SelectorOutput::Time,
+                        field.name(),
+                        field.data_type(),
+                        &time_column_name,
+                    )?);
+
+                    field_list.push((
+                        Arc::new(field.name().to_string()), // value name
+                        Arc::new(time_column_name),
+                    ));
+                }
+
+                let field_columns = field_list.into();
+                Ok(Self {
+                    agg_exprs,
+                    field_columns,
+                })
+            }
+            Aggregate::None => InternalUnexpectedNoneAggregate.fail(),
+        }
+    }
+}
+
+/// Creates a DataFusion expression suitable for calculating an aggregate:
+///
+/// equivalent to `CAST agg(field) as field`
+fn make_agg_expr(agg: Aggregate, field_name: &str) -> Result<Expr> {
+    agg.to_datafusion_expr(col(field_name))
+        .context(CreatingAggregates)
+        .map(|agg| agg.alias(field_name))
+}
+
+/// Creates a DataFusion expression suitable for calculating the time
+/// part of a selector:
+///
+/// equivalent to `CAST selector_time(field) as column_name`
+fn make_selector_expr(
+    agg: Aggregate,
+    output: SelectorOutput,
+    field_name: &str,
+    data_type: &DataType,
+    column_name: &str,
+) -> Result<Expr> {
+    let uda = match agg {
+        Aggregate::First => selector_first(data_type, output),
+        Aggregate::Last => selector_last(data_type, output),
+        Aggregate::Min => selector_min(data_type, output),
+        Aggregate::Max => selector_max(data_type, output),
+        _ => return InternalAggregateNotSelector { agg }.fail(),
+    };
+    Ok(uda
+        .call(vec![col(field_name), col(TIME_COLUMN_NAME)])
+        .alias(column_name))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_reorder_prefix() {
+        assert_eq!(reorder_prefix_ok(&[], &[]), &[] as &[&str]);
+
+        assert_eq!(reorder_prefix_ok(&[], &["one"]), &["one"]);
+        assert_eq!(reorder_prefix_ok(&["one"], &["one"]), &["one"]);
+
+        assert_eq!(reorder_prefix_ok(&[], &["one", "two"]), &["one", "two"]);
+        assert_eq!(
+            reorder_prefix_ok(&["one"], &["one", "two"]),
+            &["one", "two"]
+        );
+        assert_eq!(
+            reorder_prefix_ok(&["two"], &["one", "two"]),
+            &["two", "one"]
+        );
+        assert_eq!(
+            reorder_prefix_ok(&["two", "one"], &["one", "two"]),
+            &["two", "one"]
+        );
+
+        assert_eq!(
+            reorder_prefix_ok(&[], &["one", "two", "three"]),
+            &["one", "two", "three"]
+        );
+        assert_eq!(
+            reorder_prefix_ok(&["one"], &["one", "two", "three"]),
+            &["one", "two", "three"]
+        );
+        assert_eq!(
+            reorder_prefix_ok(&["two"], &["one", "two", "three"]),
+            &["two", "one", "three"]
+        );
+        assert_eq!(
+            reorder_prefix_ok(&["three", "one"], &["one", "two", "three"]),
+            &["three", "one", "two"]
+        );
+
+        // errors
+        assert_eq!(
+            reorder_prefix_err(&["one"], &[]),
+            "Group column \'one\' not found in tag columns: "
+        );
+        assert_eq!(
+            reorder_prefix_err(&["one"], &["two", "three"]),
+            "Group column \'one\' not found in tag columns: two, three"
+        );
+        assert_eq!(
+            reorder_prefix_err(&["two", "one", "two"], &["one", "two"]),
+            "Duplicate group column \'two\'"
+        );
+    }
+
+    fn reorder_prefix_ok(prefix: &[&str], table_columns: &[&str]) -> Vec<String> {
+        let table_columns = table_columns.to_vec();
+
+        let res = reorder_prefix(prefix, table_columns);
+        let message = format!("Expected OK, got {:?}", res);
+        let res = res.expect(&message);
+
+        res.into_iter().map(|s| s.to_string()).collect()
+    }
+
+    // returns the error string or panics if `reorder_prefix` doesn't return an
+    // error
+    fn reorder_prefix_err(prefix: &[&str], table_columns: &[&str]) -> String {
+        let table_columns = table_columns.to_vec();
+
+        let res = reorder_prefix(&prefix, table_columns);
+
+        match res {
+            Ok(r) => {
+                panic!(
+                    "Expected error result from reorder_prefix_err, but was OK: '{:?}'",
+                    r
+                );
+            }
+            Err(e) => format!("{}", e),
+        }
+    }
 }

--- a/query/src/frontend/influxrpc.rs
+++ b/query/src/frontend/influxrpc.rs
@@ -947,6 +947,9 @@ impl InfluxRPCPlanner {
     /// ORDER BY
     ///   group_key1, group_key2, remaining tags
     ///
+    /// Note the columns are the same but in a different order 
+    /// for GROUP BY / ORDER BY
+    ///
     /// Equivalent to this SQL query for 'selector' functions: first, last, min,
     /// max as they can have different values of the timestamp column
     ///
@@ -1334,7 +1337,7 @@ fn reorder_prefix<'a>(
     prefix_columns: &[impl AsRef<str>],
     tag_columns: Vec<&'a str>,
 ) -> Result<Vec<&'a str>> {
-    // tag_used_set[i[ is true if we have used the value in tag_columns[i]
+    // tag_used_set[i] is true if we have used the value in tag_columns[i]
     let mut tag_used_set = vec![false; tag_columns.len()];
 
     // Note that this is an O(N^2) algorithm. We are assuming the

--- a/query/src/frontend/influxrpc.rs
+++ b/query/src/frontend/influxrpc.rs
@@ -947,7 +947,7 @@ impl InfluxRPCPlanner {
     /// ORDER BY
     ///   group_key1, group_key2, remaining tags
     ///
-    /// Note the columns are the same but in a different order 
+    /// Note the columns are the same but in a different order
     /// for GROUP BY / ORDER BY
     ///
     /// Equivalent to this SQL query for 'selector' functions: first, last, min,

--- a/query/src/lib.rs
+++ b/query/src/lib.rs
@@ -12,7 +12,6 @@ use data_types::{
     data::ReplicatedWrite, partition_metadata::TableSummary, schema::Schema, selection::Selection,
 };
 use exec::{stringset::StringSet, Executor};
-use plan::seriesset::SeriesSetPlans;
 
 use std::{fmt::Debug, sync::Arc};
 
@@ -25,7 +24,7 @@ pub mod predicate;
 pub mod provider;
 pub mod util;
 
-use self::{group_by::GroupByAndAggregate, predicate::Predicate};
+use self::predicate::Predicate;
 
 /// A `Database` is the main trait implemented by the IOx subsystems
 /// that store actual data.
@@ -50,24 +49,6 @@ pub trait Database: Debug + Send + Sync {
     /// covering set means that together the chunks make up a single
     /// complete copy of the data being queried.
     fn chunks(&self, partition_key: &str) -> Vec<Arc<Self::Chunk>>;
-
-    // ----------
-    // The functions below are slated for removal (migration into a gRPC query
-    // frontend) ---------
-
-    /// Returns a plan that finds rows which pass the conditions
-    /// specified by `predicate` and have been logically grouped and
-    /// aggregate according to `gby_agg`.
-    ///
-    /// Each time series is defined by the unique values in a set of
-    /// tag columns, and each field in the set of field columns. Each
-    /// group is is defined by unique combinations of the columns
-    /// in `group_columns` or an optional time window.
-    async fn query_groups(
-        &self,
-        predicate: Predicate,
-        gby_agg: GroupByAndAggregate,
-    ) -> Result<SeriesSetPlans, Self::Error>;
 }
 
 /// Collection of data that shares the same partition key

--- a/query/src/plan/seriesset.rs
+++ b/query/src/plan/seriesset.rs
@@ -83,6 +83,12 @@ pub struct SeriesSetPlans {
     pub plans: Vec<SeriesSetPlan>,
 }
 
+impl SeriesSetPlans {
+    pub fn into_inner(self) -> Vec<SeriesSetPlan> {
+        self.plans
+    }
+}
+
 impl From<Vec<SeriesSetPlan>> for SeriesSetPlans {
     fn from(plans: Vec<SeriesSetPlan>) -> Self {
         Self { plans }

--- a/server/src/db.rs
+++ b/server/src/db.rs
@@ -306,19 +306,6 @@ impl Database for Db {
             .context(MutableBufferWrite)
     }
 
-    async fn query_groups(
-        &self,
-        predicate: query::predicate::Predicate,
-        gby_agg: query::group_by::GroupByAndAggregate,
-    ) -> Result<query::plan::seriesset::SeriesSetPlans, Self::Error> {
-        self.mutable_buffer
-            .as_ref()
-            .context(DatabaseNotReadable)?
-            .query_groups(predicate, gby_agg)
-            .await
-            .context(MutableBufferRead)
-    }
-
     fn partition_keys(&self) -> Result<Vec<String>, Self::Error> {
         self.mutable_buffer
             .as_ref()

--- a/server/src/query_tests/influxrpc.rs
+++ b/server/src/query_tests/influxrpc.rs
@@ -1,5 +1,8 @@
 pub mod field_columns;
 pub mod read_filter;
+pub mod read_group;
+pub mod read_window_aggregate;
 pub mod table_names;
 pub mod tag_keys;
 pub mod tag_values;
+pub mod util;

--- a/server/src/query_tests/influxrpc/read_group.rs
+++ b/server/src/query_tests/influxrpc/read_group.rs
@@ -1,0 +1,546 @@
+//! Tests for the Influx gRPC queries
+use crate::query_tests::scenarios::*;
+
+use arrow_deps::{arrow::util::pretty::pretty_format_batches, datafusion::prelude::*};
+use async_trait::async_trait;
+use query::{
+    exec::Executor,
+    frontend::influxrpc::InfluxRPCPlanner,
+    group_by::Aggregate,
+    predicate::{Predicate, PredicateBuilder},
+};
+
+/// runs read_group(predicate) and compares it to the expected
+/// output
+macro_rules! run_read_group_test_case {
+    ($DB_SETUP:expr, $PREDICATE:expr, $AGG:expr, $GROUP_COLUMNS:expr, $EXPECTED_RESULTS:expr) => {
+        test_helpers::maybe_start_logging();
+        let predicate = $PREDICATE;
+        let agg = $AGG;
+        let group_columns = $GROUP_COLUMNS;
+        let expected_results = $EXPECTED_RESULTS;
+        for scenario in $DB_SETUP.make().await {
+            let DBScenario {
+                scenario_name, db, ..
+            } = scenario;
+            println!("Running scenario '{}'", scenario_name);
+            println!("Predicate: '{:#?}'", predicate);
+            let planner = InfluxRPCPlanner::new();
+            let executor = Executor::new();
+
+            let plans = planner
+                .read_group(&db, predicate.clone(), agg, &group_columns)
+                .await
+                .expect("built plan successfully");
+
+            let plans = plans.into_inner();
+
+            for (i, plan) in plans.iter().enumerate() {
+                assert_eq!(
+                    plan.num_prefix_tag_group_columns,
+                    Some(group_columns.len()),
+                    "Mismatch in plan index {}",
+                    i
+                );
+            }
+
+            let mut string_results = vec![];
+            for plan in plans.into_iter() {
+                let batches = executor
+                    .run_logical_plan(plan.plan)
+                    .await
+                    .expect("ok running plan");
+
+                string_results.extend(
+                    pretty_format_batches(&batches)
+                        .expect("formatting results")
+                        .trim()
+                        .split('\n')
+                        .map(|s| s.to_string()),
+                );
+            }
+
+            assert_eq!(
+                expected_results, string_results,
+                "Error in  scenario '{}'\n\nexpected:\n{:#?}\nactual:\n{:#?}",
+                scenario_name, expected_results, string_results
+            );
+        }
+    };
+}
+
+#[tokio::test]
+async fn test_read_group_no_data_no_pred() {
+    let predicate = Predicate::default();
+    let agg = Aggregate::Mean;
+    let group_columns = vec![] as Vec<String>;
+    let expected_results = vec![] as Vec<&str>;
+
+    run_read_group_test_case!(NoData {}, predicate, agg, group_columns, expected_results);
+}
+
+struct OneMeasurementForAggs {}
+#[async_trait]
+impl DBSetup for OneMeasurementForAggs {
+    async fn make(&self) -> Vec<DBScenario> {
+        let partition_key = "1970-01-01T00";
+
+        let lp_lines1 = vec![
+            "h2o,state=MA,city=Boston temp=70.4 100",
+            "h2o,state=MA,city=Boston temp=72.4 250",
+        ];
+        let lp_lines2 = vec![
+            "h2o,state=CA,city=LA temp=90.0 200",
+            "h2o,state=CA,city=LA temp=90.0 350",
+        ];
+
+        make_two_chunk_scenarios(partition_key, &lp_lines1.join("\n"), &lp_lines2.join("\n")).await
+    }
+}
+
+#[tokio::test]
+async fn test_read_group_data_pred() {
+    let predicate = PredicateBuilder::default()
+        .add_expr(col("city").eq(lit("LA")))
+        .timestamp_range(190, 210)
+        .build();
+    let agg = Aggregate::Sum;
+    let group_columns = vec!["state"];
+    let expected_results = vec![
+        "+-------+------+------+------+",
+        "| state | city | temp | time |",
+        "+-------+------+------+------+",
+        "| CA    | LA   | 90   | 200  |",
+        "+-------+------+------+------+",
+    ];
+
+    run_read_group_test_case!(
+        OneMeasurementForAggs {},
+        predicate,
+        agg,
+        group_columns,
+        expected_results
+    );
+}
+
+#[tokio::test]
+async fn test_read_group_data_field_restriction() {
+    // restrict to only the temp column
+    let predicate = PredicateBuilder::default()
+        .field_columns(vec!["temp"])
+        .build();
+    let agg = Aggregate::Sum;
+    let group_columns = vec!["state"];
+    let expected_results = vec![
+        "+-------+--------+-------+------+",
+        "| state | city   | temp  | time |",
+        "+-------+--------+-------+------+",
+        "| CA    | LA     | 180   | 550  |",
+        "| MA    | Boston | 142.8 | 350  |",
+        "+-------+--------+-------+------+",
+    ];
+
+    run_read_group_test_case!(
+        OneMeasurementForAggs {},
+        predicate,
+        agg,
+        group_columns,
+        expected_results
+    );
+}
+
+struct AnotherMeasurementForAggs {}
+#[async_trait]
+impl DBSetup for AnotherMeasurementForAggs {
+    async fn make(&self) -> Vec<DBScenario> {
+        let partition_key = "1970-01-01T00";
+
+        let lp_lines1 = vec![
+            "h2o,state=MA,city=Cambridge temp=80 50",
+            "h2o,state=MA,city=Cambridge temp=81 100",
+            "h2o,state=MA,city=Cambridge temp=82 200",
+            "h2o,state=MA,city=Boston temp=70 300",
+        ];
+        let lp_lines2 = vec![
+            "h2o,state=MA,city=Boston temp=71 400",
+            "h2o,state=CA,city=LA temp=90,humidity=10 500",
+            "h2o,state=CA,city=LA temp=91,humidity=11 600",
+        ];
+
+        make_two_chunk_scenarios(partition_key, &lp_lines1.join("\n"), &lp_lines2.join("\n")).await
+    }
+}
+
+#[tokio::test]
+async fn test_grouped_series_set_plan_sum() {
+    let predicate = PredicateBuilder::default()
+        // city=Boston OR city=Cambridge (filters out LA rows)
+        .add_expr(
+            col("city")
+                .eq(lit("Boston"))
+                .or(col("city").eq(lit("Cambridge"))),
+        )
+        // fiter out first Cambridge row
+        .timestamp_range(100, 1000)
+        .build();
+
+    let agg = Aggregate::Sum;
+    let group_columns = vec!["state"];
+
+    // The null field (after predicates) are not sent as series
+    // Note order of city key (boston --> cambridge)
+    let expected_results = vec![
+        "+-------+-----------+----------+------+------+",
+        "| state | city      | humidity | temp | time |",
+        "+-------+-----------+----------+------+------+",
+        "| MA    | Boston    |          | 141  | 700  |",
+        "| MA    | Cambridge |          | 163  | 300  |",
+        "+-------+-----------+----------+------+------+",
+    ];
+
+    run_read_group_test_case!(
+        AnotherMeasurementForAggs {},
+        predicate,
+        agg,
+        group_columns,
+        expected_results
+    );
+}
+
+#[tokio::test]
+async fn test_grouped_series_set_plan_count() {
+    let predicate = PredicateBuilder::default()
+        // city=Boston OR city=Cambridge (filters out LA rows)
+        .add_expr(
+            col("city")
+                .eq(lit("Boston"))
+                .or(col("city").eq(lit("Cambridge"))),
+        )
+        // fiter out first Cambridge row
+        .timestamp_range(100, 1000)
+        .build();
+
+    let agg = Aggregate::Count;
+    let group_columns = vec!["state"];
+
+    let expected_results = vec![
+        "+-------+-----------+----------+------+------+",
+        "| state | city      | humidity | temp | time |",
+        "+-------+-----------+----------+------+------+",
+        "| MA    | Boston    | 0        | 2    | 2    |",
+        "| MA    | Cambridge | 0        | 2    | 2    |",
+        "+-------+-----------+----------+------+------+",
+    ];
+
+    run_read_group_test_case!(
+        AnotherMeasurementForAggs {},
+        predicate,
+        agg,
+        group_columns,
+        expected_results
+    );
+}
+
+#[tokio::test]
+async fn test_grouped_series_set_plan_mean() {
+    let predicate = PredicateBuilder::default()
+        // city=Boston OR city=Cambridge (filters out LA rows)
+        .add_expr(
+            col("city")
+                .eq(lit("Boston"))
+                .or(col("city").eq(lit("Cambridge"))),
+        )
+        // fiter out first Cambridge row
+        .timestamp_range(100, 1000)
+        .build();
+
+    let agg = Aggregate::Mean;
+    let group_columns = vec!["state"];
+
+    let expected_results = vec![
+        "+-------+-----------+----------+------+------+",
+        "| state | city      | humidity | temp | time |",
+        "+-------+-----------+----------+------+------+",
+        "| MA    | Boston    |          | 70.5 | 350  |",
+        "| MA    | Cambridge |          | 81.5 | 150  |",
+        "+-------+-----------+----------+------+------+",
+    ];
+
+    run_read_group_test_case!(
+        AnotherMeasurementForAggs {},
+        predicate,
+        agg,
+        group_columns,
+        expected_results
+    );
+}
+
+struct MeasurementForSelectors {}
+#[async_trait]
+impl DBSetup for MeasurementForSelectors {
+    async fn make(&self) -> Vec<DBScenario> {
+        let partition_key = "1970-01-01T00";
+
+        let lp_lines1 = vec!["h2o,state=MA,city=Cambridge f=8.0,i=8i,b=true,s=\"d\" 1000"];
+        let lp_lines2 = vec![
+            "h2o,state=MA,city=Cambridge f=7.0,i=7i,b=true,s=\"c\" 2000",
+            "h2o,state=MA,city=Cambridge f=6.0,i=6i,b=false,s=\"b\" 3000",
+            "h2o,state=MA,city=Cambridge f=5.0,i=5i,b=false,s=\"a\" 4000",
+        ];
+
+        make_two_chunk_scenarios(partition_key, &lp_lines1.join("\n"), &lp_lines2.join("\n")).await
+    }
+}
+
+#[tokio::test]
+async fn test_grouped_series_set_plan_first() {
+    let predicate = PredicateBuilder::default()
+        // fiter out first row (ts 1000)
+        .timestamp_range(1001, 4001)
+        .build();
+
+    let agg = Aggregate::First;
+    let group_columns = vec!["state"];
+
+    let expected_results = vec![
+        "+-------+-----------+------+--------+---+--------+---+--------+---+--------+",
+        "| state | city      | b    | time_b | f | time_f | i | time_i | s | time_s |",
+        "+-------+-----------+------+--------+---+--------+---+--------+---+--------+",
+        "| MA    | Cambridge | true | 2000   | 7 | 2000   | 7 | 2000   | c | 2000   |",
+        "+-------+-----------+------+--------+---+--------+---+--------+---+--------+",
+    ];
+
+    run_read_group_test_case!(
+        MeasurementForSelectors {},
+        predicate,
+        agg,
+        group_columns,
+        expected_results
+    );
+}
+
+#[tokio::test]
+async fn test_grouped_series_set_plan_last() {
+    let predicate = PredicateBuilder::default()
+        // fiter out last row (ts 4000)
+        .timestamp_range(100, 3999)
+        .build();
+
+    let agg = Aggregate::Last;
+    let group_columns = vec!["state"];
+
+    let expected_results = vec![
+        "+-------+-----------+-------+--------+---+--------+---+--------+---+--------+",
+        "| state | city      | b     | time_b | f | time_f | i | time_i | s | time_s |",
+        "+-------+-----------+-------+--------+---+--------+---+--------+---+--------+",
+        "| MA    | Cambridge | false | 3000   | 6 | 3000   | 6 | 3000   | b | 3000   |",
+        "+-------+-----------+-------+--------+---+--------+---+--------+---+--------+",
+    ];
+
+    run_read_group_test_case!(
+        MeasurementForSelectors {},
+        predicate,
+        agg,
+        group_columns,
+        expected_results
+    );
+}
+
+struct MeasurementForMin {}
+#[async_trait]
+impl DBSetup for MeasurementForMin {
+    async fn make(&self) -> Vec<DBScenario> {
+        let partition_key = "1970-01-01T00";
+
+        let lp_lines1 = vec![
+            "h2o,state=MA,city=Cambridge f=8.0,i=8i,b=false,s=\"c\" 1000",
+            "h2o,state=MA,city=Cambridge f=7.0,i=7i,b=false,s=\"a\" 2000",
+        ];
+        let lp_lines2 = vec![
+            "h2o,state=MA,city=Cambridge f=6.0,i=6i,b=true,s=\"z\" 3000",
+            "h2o,state=MA,city=Cambridge f=5.0,i=5i,b=true,s=\"c\" 4000",
+        ];
+
+        make_two_chunk_scenarios(partition_key, &lp_lines1.join("\n"), &lp_lines2.join("\n")).await
+    }
+}
+
+#[tokio::test]
+async fn test_grouped_series_set_plan_min() {
+    let predicate = PredicateBuilder::default()
+        // fiter out last row (ts 4000)
+        .timestamp_range(100, 3999)
+        .build();
+
+    let agg = Aggregate::Min;
+    let group_columns = vec!["state"];
+
+    let expected_results = vec![
+        "+-------+-----------+-------+--------+---+--------+---+--------+---+--------+",
+        "| state | city      | b     | time_b | f | time_f | i | time_i | s | time_s |",
+        "+-------+-----------+-------+--------+---+--------+---+--------+---+--------+",
+        "| MA    | Cambridge | false | 1000   | 6 | 3000   | 6 | 3000   | a | 2000   |",
+        "+-------+-----------+-------+--------+---+--------+---+--------+---+--------+",
+    ];
+
+    run_read_group_test_case!(
+        MeasurementForMin {},
+        predicate,
+        agg,
+        group_columns,
+        expected_results
+    );
+}
+
+struct MeasurementForMax {}
+#[async_trait]
+impl DBSetup for MeasurementForMax {
+    async fn make(&self) -> Vec<DBScenario> {
+        let partition_key = "1970-01-01T00";
+
+        let lp_lines1 = vec![
+            "h2o,state=MA,city=Cambridge f=8.0,i=8i,b=true,s=\"c\" 1000",
+            "h2o,state=MA,city=Cambridge f=7.0,i=7i,b=false,s=\"d\" 2000",
+            "h2o,state=MA,city=Cambridge f=6.0,i=6i,b=true,s=\"a\" 3000",
+        ];
+        let lp_lines2 = vec!["h2o,state=MA,city=Cambridge f=5.0,i=5i,b=true,s=\"z\" 4000"];
+
+        make_two_chunk_scenarios(partition_key, &lp_lines1.join("\n"), &lp_lines2.join("\n")).await
+    }
+}
+
+#[tokio::test]
+async fn test_grouped_series_set_plan_max() {
+    let predicate = PredicateBuilder::default()
+        // fiter out first row (ts 1000)
+        .timestamp_range(1001, 4001)
+        .build();
+
+    let agg = Aggregate::Max;
+    let group_columns = vec!["state"];
+
+    let expected_results = vec![
+        "+-------+-----------+------+--------+---+--------+---+--------+---+--------+",
+        "| state | city      | b    | time_b | f | time_f | i | time_i | s | time_s |",
+        "+-------+-----------+------+--------+---+--------+---+--------+---+--------+",
+        "| MA    | Cambridge | true | 3000   | 7 | 2000   | 7 | 2000   | z | 4000   |",
+        "+-------+-----------+------+--------+---+--------+---+--------+---+--------+",
+    ];
+
+    run_read_group_test_case!(
+        MeasurementForMax {},
+        predicate,
+        agg,
+        group_columns,
+        expected_results
+    );
+}
+
+struct MeasurementForGroupKeys {}
+#[async_trait]
+impl DBSetup for MeasurementForGroupKeys {
+    async fn make(&self) -> Vec<DBScenario> {
+        let partition_key = "1970-01-01T00";
+
+        let lp_lines1 = vec![
+            "h2o,state=MA,city=Cambridge temp=80 50",
+            "h2o,state=MA,city=Cambridge temp=81 100",
+            "h2o,state=MA,city=Cambridge temp=82 200",
+        ];
+        let lp_lines2 = vec![
+            "h2o,state=MA,city=Boston temp=70 300",
+            "h2o,state=MA,city=Boston temp=71 400",
+            "h2o,state=CA,city=LA temp=90,humidity=10 500",
+            "h2o,state=CA,city=LA temp=91,humidity=11 600",
+        ];
+
+        make_two_chunk_scenarios(partition_key, &lp_lines1.join("\n"), &lp_lines2.join("\n")).await
+    }
+}
+
+#[tokio::test]
+async fn test_grouped_series_set_plan_group_by_state_city() {
+    // no predicate
+    let predicate = PredicateBuilder::default().build();
+
+    let agg = Aggregate::Sum;
+    let group_columns = vec!["state", "city"];
+
+    let expected_results = vec![
+        "+-------+-----------+----------+------+------+",
+        "| state | city      | humidity | temp | time |",
+        "+-------+-----------+----------+------+------+",
+        "| CA    | LA        | 21       | 181  | 1100 |",
+        "| MA    | Boston    |          | 141  | 700  |",
+        "| MA    | Cambridge |          | 243  | 350  |",
+        "+-------+-----------+----------+------+------+",
+    ];
+
+    run_read_group_test_case!(
+        MeasurementForGroupKeys {},
+        predicate,
+        agg,
+        group_columns,
+        expected_results
+    );
+}
+
+#[tokio::test]
+async fn test_grouped_series_set_plan_group_by_city_state() {
+    // no predicate
+    let predicate = PredicateBuilder::default().build();
+
+    let agg = Aggregate::Sum;
+    let group_columns = vec!["city", "state"];
+
+    // Test with alternate group key order (note the order of columns is different)
+    let expected_results = vec![
+        "+-----------+-------+----------+------+------+",
+        "| city      | state | humidity | temp | time |",
+        "+-----------+-------+----------+------+------+",
+        "| Boston    | MA    |          | 141  | 700  |",
+        "| Cambridge | MA    |          | 243  | 350  |",
+        "| LA        | CA    | 21       | 181  | 1100 |",
+        "+-----------+-------+----------+------+------+",
+    ];
+
+    run_read_group_test_case!(
+        MeasurementForGroupKeys {},
+        predicate,
+        agg,
+        group_columns,
+        expected_results
+    );
+}
+
+#[tokio::test]
+async fn test_grouped_series_set_plan_group_aggregate_none() {
+    // no predicate
+    let predicate = PredicateBuilder::default().build();
+
+    let agg = Aggregate::None;
+    let group_columns = vec!["city", "state"];
+
+    // Expect order of the columns to begin with city/state
+    let expected_results = vec![
+        "+-----------+-------+----------+------+------+",
+        "| city      | state | humidity | temp | time |",
+        "+-----------+-------+----------+------+------+",
+        "| Boston    | MA    |          | 70   | 300  |",
+        "| Boston    | MA    |          | 71   | 400  |",
+        "| Cambridge | MA    |          | 80   | 50   |",
+        "| Cambridge | MA    |          | 81   | 100  |",
+        "| Cambridge | MA    |          | 82   | 200  |",
+        "| LA        | CA    | 10       | 90   | 500  |",
+        "| LA        | CA    | 11       | 91   | 600  |",
+        "+-----------+-------+----------+------+------+",
+    ];
+
+    run_read_group_test_case!(
+        MeasurementForGroupKeys {},
+        predicate,
+        agg,
+        group_columns,
+        expected_results
+    );
+}

--- a/server/src/query_tests/influxrpc/read_window_aggregate.rs
+++ b/server/src/query_tests/influxrpc/read_window_aggregate.rs
@@ -1,0 +1,229 @@
+//! Tests for the Influx gRPC queries
+use crate::query_tests::{scenarios::*, utils::make_db};
+
+use arrow_deps::{arrow::util::pretty::pretty_format_batches, datafusion::prelude::*};
+use async_trait::async_trait;
+use query::{
+    exec::Executor,
+    frontend::influxrpc::InfluxRPCPlanner,
+    group_by::{Aggregate, WindowDuration},
+    predicate::{Predicate, PredicateBuilder},
+    test::TestLPWriter,
+};
+
+/// runs read_window_aggregate(predicate) and compares it to the expected
+/// output
+macro_rules! run_read_window_aggregate_test_case {
+    ($DB_SETUP:expr, $PREDICATE:expr, $AGG:expr, $EVERY:expr, $OFFSET:expr, $EXPECTED_RESULTS:expr) => {
+        test_helpers::maybe_start_logging();
+        let predicate = $PREDICATE;
+        let agg = $AGG;
+        let every = $EVERY;
+        let offset = $OFFSET;
+        let expected_results = $EXPECTED_RESULTS;
+        for scenario in $DB_SETUP.make().await {
+            let DBScenario {
+                scenario_name, db, ..
+            } = scenario;
+            println!("Running scenario '{}'", scenario_name);
+            println!("Predicate: '{:#?}'", predicate);
+            let planner = InfluxRPCPlanner::new();
+            let executor = Executor::new();
+
+            let plans = planner
+                .read_window_aggregate(&db, predicate.clone(), agg, every.clone(), offset.clone())
+                .await
+                .expect("built plan successfully");
+
+            let plans = plans.into_inner();
+
+            let mut string_results = vec![];
+            for plan in plans.into_iter() {
+                let batches = executor
+                    .run_logical_plan(plan.plan)
+                    .await
+                    .expect("ok running plan");
+
+                string_results.extend(
+                    pretty_format_batches(&batches)
+                        .expect("formatting results")
+                        .trim()
+                        .split('\n')
+                        .map(|s| s.to_string()),
+                );
+            }
+
+            assert_eq!(
+                expected_results, string_results,
+                "Error in  scenario '{}'\n\nexpected:\n{:#?}\nactual:\n{:#?}",
+                scenario_name, expected_results, string_results
+            );
+        }
+    };
+}
+
+#[tokio::test]
+async fn test_read_window_aggregate_no_data_no_pred() {
+    let predicate = Predicate::default();
+    let agg = Aggregate::Mean;
+    let every = WindowDuration::from_nanoseconds(200);
+    let offset = WindowDuration::from_nanoseconds(0);
+    let expected_results = vec![] as Vec<&str>;
+
+    run_read_window_aggregate_test_case!(
+        NoData {},
+        predicate,
+        agg,
+        every,
+        offset,
+        expected_results
+    );
+}
+
+struct MeasurementForWindowAggregate {}
+#[async_trait]
+impl DBSetup for MeasurementForWindowAggregate {
+    async fn make(&self) -> Vec<DBScenario> {
+        let partition_key = "1970-01-01T00";
+
+        let lp_lines1 = vec![
+            "h2o,state=MA,city=Boston temp=70.0 100",
+            "h2o,state=MA,city=Boston temp=71.0 200",
+            "h2o,state=MA,city=Boston temp=72.0 300",
+            "h2o,state=MA,city=Boston temp=73.0 400",
+            "h2o,state=MA,city=Boston temp=74.0 500",
+            "h2o,state=MA,city=Cambridge temp=80.0 100",
+            "h2o,state=MA,city=Cambridge temp=81.0 200",
+        ];
+        let lp_lines2 = vec![
+            "h2o,state=MA,city=Cambridge temp=82.0 300",
+            "h2o,state=MA,city=Cambridge temp=83.0 400",
+            "h2o,state=MA,city=Cambridge temp=84.0 500",
+            "h2o,state=CA,city=LA temp=90.0 100",
+            "h2o,state=CA,city=LA temp=91.0 200",
+            "h2o,state=CA,city=LA temp=92.0 300",
+            "h2o,state=CA,city=LA temp=93.0 400",
+            "h2o,state=CA,city=LA temp=94.0 500",
+        ];
+
+        make_two_chunk_scenarios(partition_key, &lp_lines1.join("\n"), &lp_lines2.join("\n")).await
+    }
+}
+
+#[tokio::test]
+async fn test_read_window_aggregate_nanoseconds() {
+    let predicate = PredicateBuilder::default()
+        // city=Boston or city=LA
+        .add_expr(col("city").eq(lit("Boston")).or(col("city").eq(lit("LA"))))
+        .timestamp_range(100, 450)
+        .build();
+
+    let agg = Aggregate::Mean;
+    let every = WindowDuration::from_nanoseconds(200);
+    let offset = WindowDuration::from_nanoseconds(0);
+
+    // note the name of the field is "temp" even though it is the average
+    let expected_results = vec![
+        "+--------+-------+------+------+",
+        "| city   | state | time | temp |",
+        "+--------+-------+------+------+",
+        "| Boston | MA    | 200  | 70   |",
+        "| Boston | MA    | 400  | 71.5 |",
+        "| Boston | MA    | 600  | 73   |",
+        "| LA     | CA    | 200  | 90   |",
+        "| LA     | CA    | 400  | 91.5 |",
+        "| LA     | CA    | 600  | 93   |",
+        "+--------+-------+------+------+",
+    ];
+
+    run_read_window_aggregate_test_case!(
+        MeasurementForWindowAggregate {},
+        predicate,
+        agg,
+        every,
+        offset,
+        expected_results
+    );
+}
+
+struct MeasurementForWindowAggregateMonths {}
+#[async_trait]
+impl DBSetup for MeasurementForWindowAggregateMonths {
+    async fn make(&self) -> Vec<DBScenario> {
+        // Note the lines are written into 4 different partititions (as we are
+        // partitioned by day, effectively)
+        let lp_lines = vec![
+            "h2o,state=MA,city=Boston temp=70.0 1583020800000000000", // 2020-03-01T00:00:00Z
+            "h2o,state=MA,city=Boston temp=71.0 1583107920000000000", // 2020-03-02T00:12:00Z
+            "h2o,state=MA,city=Boston temp=72.0 1585699200000000000", // 2020-04-01T00:00:00Z
+            "h2o,state=MA,city=Boston temp=73.0 1585785600000000000", // 2020-04-02T00:00:00Z
+        ];
+        // partition keys are: ["2020-03-02T00", "2020-03-01T00", "2020-04-01T00",
+        // "2020-04-02T00"]
+
+        let db = make_db();
+        let mut writer = TestLPWriter::default();
+        let data = lp_lines.join("\n");
+        writer.write_lp_string(&db, &data).await.unwrap();
+        let scenario1 = DBScenario {
+            scenario_name: "Data in 4 partitions, open chunks of mutable buffer".into(),
+            db,
+        };
+
+        let db = make_db();
+        let mut writer = TestLPWriter::default();
+        let data = lp_lines.join("\n");
+        writer.write_lp_string(&db, &data).await.unwrap();
+        db.rollover_partition("2020-03-01T00").await.unwrap();
+        db.rollover_partition("2020-03-02T00").await.unwrap();
+        let scenario2 = DBScenario {
+            scenario_name:
+                "Data in 4 partitions, two open chunk and two closed chunks of mutable buffer"
+                    .into(),
+            db,
+        };
+
+        let db = make_db();
+        let mut writer = TestLPWriter::default();
+        let data = lp_lines.join("\n");
+        writer.write_lp_string(&db, &data).await.unwrap();
+        rollover_and_load(&db, "2020-03-01T00").await;
+        rollover_and_load(&db, "2020-03-02T00").await;
+        rollover_and_load(&db, "2020-04-01T00").await;
+        rollover_and_load(&db, "2020-04-02T00").await;
+        let scenario3 = DBScenario {
+            scenario_name: "Data in 4 partitions, 4 closed chunks in mutable buffer".into(),
+            db,
+        };
+
+        vec![scenario1, scenario2, scenario3]
+    }
+}
+
+#[tokio::test]
+async fn test_read_window_aggregate_months() {
+    let predicate = PredicateBuilder::default().build();
+
+    let agg = Aggregate::Mean;
+    let every = WindowDuration::from_months(1, false);
+    let offset = WindowDuration::from_months(0, false);
+
+    // note the name of the field is "temp" even though it is the average
+    let expected_results = vec![
+        "+--------+-------+---------------------+------+",
+        "| city   | state | time                | temp |",
+        "+--------+-------+---------------------+------+",
+        "| Boston | MA    | 1585699200000000000 | 70.5 |",
+        "| Boston | MA    | 1588291200000000000 | 72.5 |",
+        "+--------+-------+---------------------+------+",
+    ];
+
+    run_read_window_aggregate_test_case!(
+        MeasurementForWindowAggregateMonths {},
+        predicate,
+        agg,
+        every,
+        offset,
+        expected_results
+    );
+}

--- a/server/src/query_tests/influxrpc/util.rs
+++ b/server/src/query_tests/influxrpc/util.rs
@@ -1,0 +1,90 @@
+use std::sync::Arc;
+
+use arrow_deps::arrow::util::pretty::pretty_format_batches;
+use query::{
+    exec::{
+        field::FieldIndexes,
+        seriesset::{SeriesSet, SeriesSetItem},
+        Executor,
+    },
+    plan::seriesset::SeriesSetPlans,
+};
+
+use tokio::sync::mpsc;
+
+/// Format the field indexes into strings
+pub fn dump_field_indexes(f: FieldIndexes) -> Vec<String> {
+    f.as_slice()
+        .iter()
+        .map(|field_index| {
+            format!(
+                "  (value_index: {}, timestamp_index: {})",
+                field_index.value_index, field_index.timestamp_index
+            )
+        })
+        .collect()
+}
+
+/// Format a the vec of Arc strings paris into strings
+pub fn dump_arc_vec(v: Vec<(Arc<String>, Arc<String>)>) -> Vec<String> {
+    v.into_iter()
+        .map(|(k, v)| format!("  ({}, {})", k, v))
+        .collect()
+}
+
+/// Format a series set into a format that is easy to compare in tests
+pub fn dump_series_set(s: SeriesSet) -> Vec<String> {
+    let mut f = vec![];
+    f.push("SeriesSet".into());
+    f.push(format!("table_name: {}", s.table_name));
+    f.push("tags".to_string());
+    f.extend(dump_arc_vec(s.tags).into_iter());
+    f.push("field_indexes:".to_string());
+    f.extend(dump_field_indexes(s.field_indexes).into_iter());
+    f.push(format!("start_row: {}", s.start_row));
+    f.push(format!("num_rows: {}", s.num_rows));
+    f.push("Batches:".into());
+    let formatted_batch = pretty_format_batches(&[s.batch]).unwrap();
+    f.extend(formatted_batch.trim().split('\n').map(|s| s.to_string()));
+
+    f
+}
+
+/// Run a series set plan to completion and produce a Vec<String> representation
+pub async fn run_series_set_plan(executor: Executor, plans: SeriesSetPlans) -> Vec<String> {
+    // Use a channel sufficiently large to buffer the series
+    let (tx, mut rx) = mpsc::channel(100);
+    executor
+        .to_series_set(plans, tx)
+        .await
+        .expect("Running series set plan");
+
+    // gather up the sets and compare them
+    let mut results = vec![];
+    while let Some(r) = rx.recv().await {
+        let item = r.expect("unexpected error in execution");
+        let item = if let SeriesSetItem::Data(series_set) = item {
+            series_set
+        } else {
+            panic!(
+                "Unexpected result from converting. Expected SeriesSetItem::Data, got: {:?}",
+                item
+            )
+        };
+
+        results.push(item);
+    }
+
+    // sort the results so that we can reliably compare
+    results.sort_by(|r1, r2| {
+        r1.table_name
+            .cmp(&r2.table_name)
+            .then(r1.tags.cmp(&r2.tags))
+    });
+
+    results
+        .into_iter()
+        .map(|s| dump_series_set(s).into_iter())
+        .flatten()
+        .collect::<Vec<_>>()
+}

--- a/server/src/query_tests/scenarios.rs
+++ b/server/src/query_tests/scenarios.rs
@@ -237,7 +237,7 @@ pub(crate) async fn make_one_chunk_scenarios(partition_key: &str, data: &str) ->
 /// Data in one open mutable buffer chunk, one closed mutable chunk
 /// Data in one open mutable buffer chunk, one read buffer chunk
 /// Data in one two read buffer chunks,
-async fn make_two_chunk_scenarios(
+pub async fn make_two_chunk_scenarios(
     partition_key: &str,
     data1: &str,
     data2: &str,
@@ -306,4 +306,12 @@ async fn make_two_chunk_scenarios(
     };
 
     vec![scenario1, scenario2, scenario3, scenario4]
+}
+
+/// Rollover the mutable buffer and load chunk 0 to the read bufer
+pub async fn rollover_and_load(db: &Db, partition_key: &str) {
+    db.rollover_partition(partition_key).await.unwrap();
+    db.load_chunk_to_read_buffer(partition_key, 0)
+        .await
+        .unwrap();
 }


### PR DESCRIPTION
Closes https://github.com/influxdata/influxdb_iox/issues/812

Note: I have taken a slightly different approach with this PR than in previous porting exercises -- I have simply brought the code from the mutable buffer over without removing the old version yet. I plan to remove the old implementations with several follow on PRs and thus spare you, dear reviewer, an even larger PR


# Rationale:
Users want to query data via flux / influxql when it lives in any type of IOx chunk. Flux / InfuxQL use the gRPC storage API.

# Changes
This PR ports the `read_group` and `read_window_aggregate`(which is very similar plan) into the `InfluxRPCPlanner` from the `MutableBuffer` so that it works across all types of Chunks.

# Follow on work:

## Remove old version in the MutableBuffer:

This removal of the vesigal query code from the mutable buffer is tracked in https://github.com/influxdata/influxdb_iox/issues/815. The work is roughly:

1. Move chunk predicate creation from `query::Predicate` into `server` crate and out of `mutable_buffer` crate
2. Move anything else needed out
3. Remove query dependency in mutable buffer and delete all the old code.
3. Remove  GroupByAndAggregate and call the right thing directly -- the combining read_group and read_window_aggregate to a single request just to dispatch again in InfluxRPC is silly, but I kept the structure in this PR to minimize the size of an already large PR.

## Better query testing harness
* https://github.com/influxdata/influxdb_iox/issues/843: for a data driven testing harness  (this is tantalizing close now that @tustvold has the management API almost ready to go)


- [x] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb_iox/blob/main/README.md).
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
