### PR TITLE
fix(line-protocol): add unsigned integer field type

### DIFF
--- a/data_types/src/data.rs
+++ b/data_types/src/data.rs
@@ -317,6 +317,7 @@ fn add_line<'a>(
     for (column, value) in &line.field_set {
         let val = match value {
             FieldValue::I64(v) => add_i64_value(fbb, column.as_str(), *v),
+            FieldValue::U64(v) => add_u64_value(fbb, column.as_str(), *v),
             FieldValue::F64(v) => add_f64_value(fbb, column.as_str(), *v),
             FieldValue::Boolean(v) => add_bool_value(fbb, column.as_str(), *v),
             FieldValue::String(v) => add_string_value(fbb, column.as_str(), v.as_str()),
@@ -391,6 +392,16 @@ fn add_i64_value<'a>(
     let iv = wb::I64Value::create(fbb, &wb::I64ValueArgs { value });
 
     add_value(fbb, column, wb::ColumnValue::I64Value, iv.as_union_value())
+}
+
+fn add_u64_value<'a>(
+    fbb: &mut FlatBufferBuilder<'a>,
+    column: &str,
+    value: u64,
+) -> flatbuffers::WIPOffset<wb::Value<'a>> {
+    let iv = wb::U64Value::create(fbb, &wb::U64ValueArgs { value });
+
+    add_value(fbb, column, wb::ColumnValue::U64Value, iv.as_union_value())
 }
 
 fn add_bool_value<'a>(

--- a/influxdb_line_protocol/src/lib.rs
+++ b/influxdb_line_protocol/src/lib.rs
@@ -1462,7 +1462,7 @@ mod test {
         let parsed = parse(input);
 
         assert!(
-            matches!(parsed, Err(super::Error::UIntegerValueInvalid { .. })),
+            matches!(parsed, Err(super::Error::CannotParseEntireLine { .. })),
             "Wrong error: {:?}",
             parsed,
         );

--- a/ingest/src/lib.rs
+++ b/ingest/src/lib.rs
@@ -310,6 +310,7 @@ impl<'a> MeasurementSampler<'a> {
                 let field_type = match field_value {
                     FieldValue::F64(_) => InfluxFieldType::Float,
                     FieldValue::I64(_) => InfluxFieldType::Integer,
+                    FieldValue::U64(_) => InfluxFieldType::UInteger,
                     FieldValue::String(_) => InfluxFieldType::String,
                     FieldValue::Boolean(_) => InfluxFieldType::Boolean,
                 };
@@ -473,6 +474,9 @@ fn pack_lines<'a>(schema: &Schema, lines: &[ParsedLine<'a>]) -> Vec<Packers> {
                     }
                     FieldValue::I64(i) => {
                         packer.i64_packer_mut().push(i);
+                    }
+                    FieldValue::U64(i) => {
+                        packer.u64_packer_mut().push(i);
                     }
                     FieldValue::String(ref s) => {
                         packer.bytes_packer_mut().push(ByteArray::from(s.as_str()));

--- a/mutable_buffer/src/table.rs
+++ b/mutable_buffer/src/table.rs
@@ -762,10 +762,10 @@ mod tests {
             .tag("city")
             .field("float_field", ArrowDataType::Float64)
             .field("int_field", ArrowDataType::Int64)
-            .field("uint_field", ArrowDataType::UInt64)
             .tag("state")
             .field("string_field", ArrowDataType::Utf8)
             .timestamp()
+            .field("uint_field", ArrowDataType::UInt64)
             .build()
             .unwrap();
 

--- a/mutable_buffer/src/table.rs
+++ b/mutable_buffer/src/table.rs
@@ -748,7 +748,7 @@ mod tests {
         let mut table = Table::new(dictionary.lookup_value_or_insert("table_name"));
 
         let lp_lines = vec![
-            "h2o,state=MA,city=Boston float_field=70.4,int_field=8i,bool_field=t,string_field=\"foo\" 100",
+            "h2o,state=MA,city=Boston float_field=70.4,int_field=8i,uint_field=42u,bool_field=t,string_field=\"foo\" 100",
         ];
 
         write_lines_to_table(&mut table, dictionary, lp_lines);
@@ -760,6 +760,7 @@ mod tests {
             .tag("city")
             .field("float_field", ArrowDataType::Float64)
             .field("int_field", ArrowDataType::Int64)
+            .field("uint_field", ArrowDataType::UInt64)
             .tag("state")
             .field("string_field", ArrowDataType::Utf8)
             .timestamp()

--- a/mutable_buffer/src/table.rs
+++ b/mutable_buffer/src/table.rs
@@ -23,7 +23,9 @@ use snafu::{OptionExt, ResultExt, Snafu};
 use arrow_deps::{
     arrow,
     arrow::{
-        array::{ArrayRef, BooleanBuilder, Float64Builder, Int64Builder, UInt64Builder, StringBuilder},
+        array::{
+            ArrayRef, BooleanBuilder, Float64Builder, Int64Builder, StringBuilder, UInt64Builder,
+        },
         datatypes::DataType as ArrowDataType,
         record_batch::RecordBatch,
     },

--- a/packers/src/packers.rs
+++ b/packers/src/packers.rs
@@ -20,6 +20,7 @@ use std::default::Default;
 pub enum Packers {
     Float(Packer<f64>),
     Integer(Packer<i64>),
+    UInteger(Packer<u64>),
     Bytes(Packer<ByteArray>),
     String(Packer<String>),
     Boolean(Packer<bool>),
@@ -52,6 +53,7 @@ impl<'a> Packers {
         match self {
             Self::Float(p) => PackerChunker::Float(p.values.chunks(chunk_size)),
             Self::Integer(p) => PackerChunker::Integer(p.values.chunks(chunk_size)),
+            Self::UInteger(p) => PackerChunker::UInteger(p.values.chunks(chunk_size)),
             Self::Bytes(p) => PackerChunker::Bytes(p.values.chunks(chunk_size)),
             Self::String(p) => PackerChunker::String(p.values.chunks(chunk_size)),
             Self::Boolean(p) => PackerChunker::Boolean(p.values.chunks(chunk_size)),
@@ -69,6 +71,7 @@ impl<'a> Packers {
         match self {
             Self::Float(p) => p.reserve_exact(additional),
             Self::Integer(p) => p.reserve_exact(additional),
+            Self::UInteger(p) => p.reserve_exact(additional),
             Self::Bytes(p) => p.reserve_exact(additional),
             Self::String(p) => p.reserve_exact(additional),
             Self::Boolean(p) => p.reserve_exact(additional),
@@ -79,6 +82,7 @@ impl<'a> Packers {
         match self {
             Self::Float(p) => p.push_option(None),
             Self::Integer(p) => p.push_option(None),
+            Self::UInteger(p) => p.push_option(None),
             Self::Bytes(p) => p.push_option(None),
             Self::String(p) => p.push_option(None),
             Self::Boolean(p) => p.push_option(None),
@@ -90,6 +94,7 @@ impl<'a> Packers {
         match self {
             Self::Float(p) => p.swap(a, b),
             Self::Integer(p) => p.swap(a, b),
+            Self::UInteger(p) => p.swap(a, b),
             Self::Bytes(p) => p.swap(a, b),
             Self::String(p) => p.swap(a, b),
             Self::Boolean(p) => p.swap(a, b),
@@ -101,6 +106,7 @@ impl<'a> Packers {
         match self {
             Self::Float(p) => p.num_rows(),
             Self::Integer(p) => p.num_rows(),
+            Self::UInteger(p) => p.num_rows(),
             Self::Bytes(p) => p.num_rows(),
             Self::String(p) => p.num_rows(),
             Self::Boolean(p) => p.num_rows(),
@@ -114,6 +120,7 @@ impl<'a> Packers {
         match self {
             Self::Float(p) => p.is_null(row),
             Self::Integer(p) => p.is_null(row),
+            Self::UInteger(p) => p.is_null(row),
             Self::Bytes(p) => p.is_null(row),
             Self::String(p) => p.is_null(row),
             Self::Boolean(p) => p.is_null(row),
@@ -124,6 +131,7 @@ impl<'a> Packers {
     typed_packer_accessors! {
         (f64_packer, f64_packer_mut, f64, Float),
         (i64_packer, i64_packer_mut, i64, Integer),
+        (u64_packer, u64_packer_mut, u64, UInteger),
         (bytes_packer, bytes_packer_mut, ByteArray, Bytes),
         (str_packer, str_packer_mut, String, String),
         (bool_packer, bool_packer_mut, bool, Boolean),
@@ -245,6 +253,7 @@ impl std::convert::From<Vec<Option<Vec<u8>>>> for Packers {
 pub enum PackerChunker<'a> {
     Float(Chunks<'a, Option<f64>>),
     Integer(Chunks<'a, Option<i64>>),
+    UInteger(Chunks<'a, Option<u64>>),
     Bytes(Chunks<'a, Option<ByteArray>>),
     String(Chunks<'a, Option<String>>),
     Boolean(Chunks<'a, Option<bool>>),
@@ -523,6 +532,7 @@ mod test {
         let mut packers: Vec<Packers> = Vec::new();
         packers.push(Packers::Float(Packer::new()));
         packers.push(Packers::Integer(Packer::new()));
+        packers.push(Packers::UInteger(Packer::new()));
         packers.push(Packers::Boolean(Packer::new()));
 
         packers.get_mut(0).unwrap().f64_packer_mut().push(22.033);


### PR DESCRIPTION
Fixes #904

The line protocol parser was lacking the unsigned integer type, which
suffixes values with `u`. This adds unsigned integer support to the line
protocol parser, and fills a few corresponding gaps in the mutable
buffer.

Describe your proposed changes here.

- [x] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb_iox/blob/main/README.md).
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
