### PR TITLE
refactor: Remove impl of `query::Database` in mutable_buffer

### DIFF
--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -94,7 +94,7 @@ use data_types::{
 };
 use influxdb_line_protocol::ParsedLine;
 use object_store::{path::ObjectStorePath, ObjectStore, ObjectStoreApi};
-use query::{exec::Executor, Database, DatabaseStore};
+use query::{exec::Executor, DatabaseStore};
 
 use async_trait::async_trait;
 use bytes::Bytes;


### PR DESCRIPTION
Part of #815; Working  to ensure there is no query logic in the `mutable_buffer`


Order of PRs (dependent):
- [x] feat: Add read_group / read_window_aggregate into higher level planner: https://github.com/influxdata/influxdb_iox/pull/905
- [x] refactor: remove query plan logic in mutable_buffer: https://github.com/influxdata/influxdb_iox/pull/912
- [x] refactor: Remove impl of `query::Database` in mutable_buffer: this PR
- [ ] refactor: Move chunk predicate creation from query::Predicate into server crate
- [ ] refactor: Remove query dependency in mutable buffer and delete all the old code.
- [ ] refactor: Remove GroupByAndAggregate and call the right planner function directly

Adminstrivia

- [x] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb_iox/blob/main/README.md).
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
