### PR TITLE
chore: use newly added Arrow's Expr::is_not_null function

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -101,7 +101,7 @@ checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 [[package]]
 name = "arrow"
 version = "4.0.0-SNAPSHOT"
-source = "git+https://github.com/apache/arrow.git?rev=5ae63f8ec0c14d5e871aa79d90e5d163b369e704#5ae63f8ec0c14d5e871aa79d90e5d163b369e704"
+source = "git+https://github.com/apache/arrow.git?rev=a3a619382f90e9472b5b7b93159e77289e8c8031#a3a619382f90e9472b5b7b93159e77289e8c8031"
 dependencies = [
  "cfg_aliases",
  "chrono",
@@ -124,7 +124,7 @@ dependencies = [
 [[package]]
 name = "arrow-flight"
 version = "4.0.0-SNAPSHOT"
-source = "git+https://github.com/apache/arrow.git?rev=5ae63f8ec0c14d5e871aa79d90e5d163b369e704#5ae63f8ec0c14d5e871aa79d90e5d163b369e704"
+source = "git+https://github.com/apache/arrow.git?rev=a3a619382f90e9472b5b7b93159e77289e8c8031#a3a619382f90e9472b5b7b93159e77289e8c8031"
 dependencies = [
  "arrow",
  "bytes",
@@ -643,22 +643,8 @@ dependencies = [
  "crossbeam-channel 0.4.4",
  "crossbeam-deque 0.7.3",
  "crossbeam-epoch 0.8.2",
- "crossbeam-queue 0.2.3",
+ "crossbeam-queue",
  "crossbeam-utils 0.7.2",
-]
-
-[[package]]
-name = "crossbeam"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd01a6eb3daaafa260f6fc94c3a6c36390abc2080e38e3e34ced87393fb77d80"
-dependencies = [
- "cfg-if 1.0.0",
- "crossbeam-channel 0.5.0",
- "crossbeam-deque 0.8.0",
- "crossbeam-epoch 0.9.3",
- "crossbeam-queue 0.3.1",
- "crossbeam-utils 0.8.3",
 ]
 
 [[package]]
@@ -740,16 +726,6 @@ dependencies = [
  "cfg-if 0.1.10",
  "crossbeam-utils 0.7.2",
  "maybe-uninit",
-]
-
-[[package]]
-name = "crossbeam-queue"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f6cb3c7f5b8e51bc3ebb73a2327ad4abdbd119dc13223f14f961d2f38486756"
-dependencies = [
- "cfg-if 1.0.0",
- "crossbeam-utils 0.8.3",
 ]
 
 [[package]]
@@ -836,14 +812,13 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "4.0.0-SNAPSHOT"
-source = "git+https://github.com/apache/arrow.git?rev=5ae63f8ec0c14d5e871aa79d90e5d163b369e704#5ae63f8ec0c14d5e871aa79d90e5d163b369e704"
+source = "git+https://github.com/apache/arrow.git?rev=a3a619382f90e9472b5b7b93159e77289e8c8031#a3a619382f90e9472b5b7b93159e77289e8c8031"
 dependencies = [
  "ahash 0.7.1",
  "arrow",
  "async-trait",
  "chrono",
  "clap",
- "crossbeam 0.8.0",
  "futures",
  "hashbrown",
  "log",
@@ -857,6 +832,7 @@ dependencies = [
  "sha2",
  "sqlparser 0.8.0",
  "tokio",
+ "tokio-stream",
  "unicode-segmentation",
 ]
 
@@ -1853,7 +1829,7 @@ dependencies = [
  "chrono",
  "criterion",
  "croaring",
- "crossbeam 0.7.3",
+ "crossbeam",
  "env_logger 0.7.1",
  "human_format",
  "packers",
@@ -2335,7 +2311,7 @@ dependencies = [
 [[package]]
 name = "parquet"
 version = "4.0.0-SNAPSHOT"
-source = "git+https://github.com/apache/arrow.git?rev=5ae63f8ec0c14d5e871aa79d90e5d163b369e704#5ae63f8ec0c14d5e871aa79d90e5d163b369e704"
+source = "git+https://github.com/apache/arrow.git?rev=a3a619382f90e9472b5b7b93159e77289e8c8031#a3a619382f90e9472b5b7b93159e77289e8c8031"
 dependencies = [
  "arrow",
  "base64 0.12.3",

--- a/arrow_deps/Cargo.toml
+++ b/arrow_deps/Cargo.toml
@@ -8,11 +8,11 @@ description = "Apache Arrow / Parquet / DataFusion dependencies for InfluxDB IOx
 [dependencies] # In alphabetical order
 # We are using development version of arrow/parquet/datafusion and the dependencies are at the same rev
 
-# The version can be found here: https://github.com/apache/arrow/commit/5ae63f8ec0c14d5e871aa79d90e5d163b369e704
+# The version can be found here: https://github.com/apache/arrow/commit/a3a619382f90e9472b5b7b93159e77289e8c8031
 #
-arrow = { git = "https://github.com/apache/arrow.git", rev = "5ae63f8ec0c14d5e871aa79d90e5d163b369e704" , features = ["simd"] }
-arrow-flight = { git = "https://github.com/apache/arrow.git", rev = "5ae63f8ec0c14d5e871aa79d90e5d163b369e704" }
-datafusion = { git = "https://github.com/apache/arrow.git", rev = "5ae63f8ec0c14d5e871aa79d90e5d163b369e704" }
+arrow = { git = "https://github.com/apache/arrow.git", rev = "a3a619382f90e9472b5b7b93159e77289e8c8031" , features = ["simd"] }
+arrow-flight = { git = "https://github.com/apache/arrow.git", rev = "a3a619382f90e9472b5b7b93159e77289e8c8031" }
+datafusion = { git = "https://github.com/apache/arrow.git", rev = "a3a619382f90e9472b5b7b93159e77289e8c8031" }
 # Turn off the "arrow" feature; it currently has a bug that causes the crate to rebuild every time
 # and we're not currently using it anyway
-parquet = { git = "https://github.com/apache/arrow.git", rev = "5ae63f8ec0c14d5e871aa79d90e5d163b369e704", default-features = false, features = ["snap", "brotli", "flate2", "lz4", "zstd"] }
+parquet = { git = "https://github.com/apache/arrow.git", rev = "a3a619382f90e9472b5b7b93159e77289e8c8031", default-features = false, features = ["snap", "brotli", "flate2", "lz4", "zstd"] }

--- a/query/src/frontend/influxrpc.rs
+++ b/query/src/frontend/influxrpc.rs
@@ -414,10 +414,7 @@ impl InfluxRPCPlanner {
                 schema: _,
             }) = scan_and_filter
             {
-                // TODO use Expr::is_null() here when this
-                // https://issues.apache.org/jira/browse/ARROW-11742
-                // is completed.
-                let tag_name_is_not_null = Expr::IsNotNull(Box::new(col(tag_name)));
+                let tag_name_is_not_null = Expr::Column(tag_name.to_string()).is_not_null();
 
                 // TODO: optimize this to use "DISINCT" or do
                 // something more intelligent that simply fetching all


### PR DESCRIPTION
Closes #

This is the work of [#913](https://github.com/influxdata/influxdb_iox/issues/913)  to use Arrow's Expr::is_not_null newly added in [ARROW-11742](https://issues.apache.org/jira/browse/ARROW-11742)


- [x] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb_iox/blob/main/README.md).
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
