### PR TITLE
refactor: Move chunk predicate creation from query::Predicate into server crate

### DIFF
--- a/mutable_buffer/src/lib.rs
+++ b/mutable_buffer/src/lib.rs
@@ -62,6 +62,7 @@ mod column;
 pub mod database;
 mod dictionary;
 mod partition;
+pub mod pred;
 mod table;
 
 // Allow restore chunks to be used outside of this crate (for

--- a/mutable_buffer/src/pred.rs
+++ b/mutable_buffer/src/pred.rs
@@ -1,0 +1,297 @@
+use std::collections::{BTreeSet, HashSet};
+
+use crate::dictionary::{Dictionary, Error as DictionaryError};
+
+use arrow_deps::datafusion::{
+    error::{DataFusionError, Result as DatafusionResult},
+    logical_plan::{Expr, ExpressionVisitor, Operator, Recursion},
+    optimizer::utils::expr_to_column_names,
+};
+use data_types::TIME_COLUMN_NAME;
+use query::{
+    predicate::TimestampRange,
+    util::{make_range_expr, AndExprBuilder},
+};
+//use snafu::{OptionExt, ResultExt, Snafu};
+use snafu::{ensure, ResultExt, Snafu};
+
+#[derive(Debug, Snafu)]
+pub enum Error {
+    #[snafu(display("Error writing table '{}': {}", table_name, source))]
+    TableWrite {
+        table_name: String,
+        source: crate::table::Error,
+    },
+
+    #[snafu(display("Time Column was not not found in dictionary: {}", source))]
+    TimeColumnNotFound { source: DictionaryError },
+
+    #[snafu(display("Unsupported predicate. Mutable buffer does not support: {}", source))]
+    UnsupportedPredicate { source: DataFusionError },
+
+    #[snafu(display(
+        "Internal error visiting expressions in ChunkPredicateBuilder: {}",
+        source
+    ))]
+    InternalVisitingExpressions { source: DataFusionError },
+
+    #[snafu(display("table_names has already been specified in ChunkPredicateBuilder"))]
+    TableNamesAlreadySet {},
+
+    #[snafu(display("field_names has already been specified in ChunkPredicateBuilder"))]
+    FieldNamesAlreadySet {},
+
+    #[snafu(display("range has already been specified in ChunkPredicateBuilder"))]
+    RangeAlreadySet {},
+
+    #[snafu(display("exprs has already been specified in ChunkPredicateBuilder"))]
+    ExprsAlreadySet {},
+
+    #[snafu(display("required_columns has already been specified in ChunkPredicateBuilder"))]
+    RequiredColumnsAlreadySet {},
+}
+
+pub type Result<T, E = Error> = std::result::Result<T, E>;
+
+/// Describes the result of translating a set of strings into
+/// chunk specific ids
+#[derive(Debug, PartialEq, Eq)]
+pub enum ChunkIdSet {
+    /// At least one of the strings was not present in the chunks'
+    /// dictionary.
+    ///
+    /// This is important when testing for the presence of all ids in
+    /// a set, as we know they can not all be present
+    AtLeastOneMissing,
+
+    /// All strings existed in this chunk's dictionary
+    Present(BTreeSet<u32>),
+}
+
+/// a 'Compiled' set of predicates / filters that can be evaluated on
+/// this chunk (where strings have been translated to chunk
+/// specific u32 ids)
+#[derive(Debug, Default)]
+pub struct ChunkPredicate {
+    /// If present, restrict the request to just those tables whose
+    /// names are in table_names. If present but empty, means there
+    /// was a predicate but no tables named that way exist in the
+    /// chunk (so no table can pass)
+    pub table_name_predicate: Option<BTreeSet<u32>>,
+
+    /// Optional column restriction. If present, further
+    /// restrict any field columns returned to only those named, and
+    /// skip tables entirely when querying metadata that do not have
+    /// *any* of the fields
+    pub field_name_predicate: Option<BTreeSet<u32>>,
+
+    /// General DataFusion expressions (arbitrary predicates) applied
+    /// as a filter using logical conjuction (aka are 'AND'ed
+    /// together). Only rows that evaluate to TRUE for all these
+    /// expressions should be returned.
+    ///
+    /// TODO these exprs should eventually be removed (when they are
+    /// all handled one layer up in the query layer)
+    pub chunk_exprs: Vec<Expr>,
+
+    /// If Some, then the table must contain all columns specified
+    /// to pass the predicate
+    pub required_columns: Option<ChunkIdSet>,
+
+    /// The id of the "time" column in this chunk
+    pub time_column_id: u32,
+
+    /// Timestamp range: only rows within this range should be considered
+    pub range: Option<TimestampRange>,
+}
+
+impl ChunkPredicate {
+    /// Creates and adds a datafuson predicate representing the
+    /// combination of predicate and timestamp.
+    pub fn filter_expr(&self) -> Option<Expr> {
+        // build up a list of expressions
+        let mut builder =
+            AndExprBuilder::default().append_opt(self.make_timestamp_predicate_expr());
+
+        for expr in &self.chunk_exprs {
+            builder = builder.append_expr(expr.clone());
+        }
+
+        builder.build()
+    }
+
+    /// For plans which select a subset of fields, returns true if
+    /// the field should be included in the results
+    pub fn should_include_field(&self, field_id: u32) -> bool {
+        match &self.field_name_predicate {
+            None => true,
+            Some(field_restriction) => field_restriction.contains(&field_id),
+        }
+    }
+
+    /// Return true if this column is the time column
+    pub fn is_time_column(&self, id: u32) -> bool {
+        self.time_column_id == id
+    }
+
+    /// Creates a DataFusion predicate for appliying a timestamp range:
+    ///
+    /// range.start <= time and time < range.end`
+    fn make_timestamp_predicate_expr(&self) -> Option<Expr> {
+        self.range
+            .map(|range| make_range_expr(range.start, range.end))
+    }
+}
+
+/// Builds ChunkPredicates
+#[derive(Debug)]
+pub struct ChunkPredicateBuilder<'a> {
+    inner: ChunkPredicate,
+    dictionary: &'a Dictionary,
+}
+
+impl<'a> ChunkPredicateBuilder<'a> {
+    pub fn new(dictionary: &'a Dictionary) -> Result<Self> {
+        let time_column_id = dictionary
+            .lookup_value(TIME_COLUMN_NAME)
+            .context(TimeColumnNotFound)?;
+
+        let inner = ChunkPredicate {
+            time_column_id,
+            ..Default::default()
+        };
+
+        Ok(Self { inner, dictionary })
+    }
+
+    /// Set table_name_predicate so only tables in `names` are returned
+    pub fn table_names(mut self, names: Option<&BTreeSet<String>>) -> Result<Self> {
+        ensure!(
+            self.inner.table_name_predicate.is_none(),
+            TableNamesAlreadySet
+        );
+        self.inner.table_name_predicate = self.compile_string_list(names);
+        Ok(self)
+    }
+
+    /// Set field_name_predicate so only tables in `names` are returned
+    pub fn field_names(mut self, names: Option<&BTreeSet<String>>) -> Result<Self> {
+        ensure!(
+            self.inner.field_name_predicate.is_none(),
+            FieldNamesAlreadySet
+        );
+        self.inner.field_name_predicate = self.compile_string_list(names);
+        Ok(self)
+    }
+
+    pub fn range(mut self, range: Option<TimestampRange>) -> Result<Self> {
+        ensure!(self.inner.range.is_none(), RangeAlreadySet);
+        self.inner.range = range;
+        Ok(self)
+    }
+
+    /// Set the general purpose predicates
+    pub fn exprs(mut self, chunk_exprs: Vec<Expr>) -> Result<Self> {
+        // In order to evaluate expressions in the table, all columns
+        // referenced in the expression must appear (I think, not sure
+        // about NOT, etc so panic if we see one of those);
+        let mut visitor = SupportVisitor {};
+        let mut predicate_columns: HashSet<String> = HashSet::new();
+        for expr in &chunk_exprs {
+            visitor = expr.accept(visitor).context(UnsupportedPredicate)?;
+            expr_to_column_names(&expr, &mut predicate_columns)
+                .context(InternalVisitingExpressions)?;
+        }
+
+        ensure!(self.inner.chunk_exprs.is_empty(), ExprsAlreadySet);
+        self.inner.chunk_exprs = chunk_exprs;
+
+        // if there are any column references in the expression, ensure they appear in
+        // any table
+        if !predicate_columns.is_empty() {
+            ensure!(
+                self.inner.required_columns.is_none(),
+                RequiredColumnsAlreadySet
+            );
+            self.inner.required_columns = Some(self.make_chunk_ids(predicate_columns.iter()));
+        }
+        Ok(self)
+    }
+
+    /// Return the created chunk predicate, consuming self
+    pub fn build(self) -> ChunkPredicate {
+        self.inner
+    }
+
+    /// Converts a Set of strings into a set of ids in terms of this
+    /// Chunk's dictionary.
+    ///
+    /// If there are no matching Strings in the chunks dictionary,
+    /// those strings are ignored and a (potentially empty) set is
+    /// returned.
+    fn compile_string_list(&self, names: Option<&BTreeSet<String>>) -> Option<BTreeSet<u32>> {
+        names.map(|names| {
+            names
+                .iter()
+                .filter_map(|name| self.dictionary.id(name))
+                .collect::<BTreeSet<_>>()
+        })
+    }
+
+    /// Translate a bunch of strings into a set of ids from the dictionarythis
+    /// chunk
+    pub fn make_chunk_ids<'b, I>(&self, predicate_columns: I) -> ChunkIdSet
+    where
+        I: Iterator<Item = &'b String>,
+    {
+        let mut symbols = BTreeSet::new();
+        for column_name in predicate_columns {
+            if let Some(column_id) = self.dictionary.id(column_name) {
+                symbols.insert(column_id);
+            } else {
+                return ChunkIdSet::AtLeastOneMissing;
+            }
+        }
+
+        ChunkIdSet::Present(symbols)
+    }
+}
+
+/// Used to figure out if we know how to deal with this kind of
+/// predicate in the write buffer
+struct SupportVisitor {}
+
+impl ExpressionVisitor for SupportVisitor {
+    fn pre_visit(self, expr: &Expr) -> DatafusionResult<Recursion<Self>> {
+        match expr {
+            Expr::Literal(..) => Ok(Recursion::Continue(self)),
+            Expr::Column(..) => Ok(Recursion::Continue(self)),
+            Expr::BinaryExpr { op, .. } => {
+                match op {
+                    Operator::Eq
+                    | Operator::Lt
+                    | Operator::LtEq
+                    | Operator::Gt
+                    | Operator::GtEq
+                    | Operator::Plus
+                    | Operator::Minus
+                    | Operator::Multiply
+                    | Operator::Divide
+                    | Operator::And
+                    | Operator::Or => Ok(Recursion::Continue(self)),
+                    // Unsupported (need to think about ramifications)
+                    Operator::NotEq | Operator::Modulus | Operator::Like | Operator::NotLike => {
+                        Err(DataFusionError::NotImplemented(format!(
+                            "Operator {:?} not yet supported in IOx MutableBuffer",
+                            op
+                        )))
+                    }
+                }
+            }
+            _ => Err(DataFusionError::NotImplemented(format!(
+                "Unsupported expression in mutable_buffer database: {:?}",
+                expr
+            ))),
+        }
+    }
+}

--- a/mutable_buffer/src/table.rs
+++ b/mutable_buffer/src/table.rs
@@ -6,11 +6,11 @@ use std::{
 };
 
 use crate::{
-    chunk::ChunkIdSet,
-    chunk::{Chunk, ChunkPredicate},
+    chunk::Chunk,
     column,
     column::Column,
     dictionary::{Dictionary, Error as DictionaryError},
+    pred::{ChunkIdSet, ChunkPredicate},
 };
 use data_types::{
     partition_metadata::{ColumnSummary, Statistics},

--- a/server/src/db/chunk.rs
+++ b/server/src/db/chunk.rs
@@ -8,7 +8,10 @@ use tracing::debug;
 
 use std::sync::Arc;
 
-use super::{pred::{to_mutable_buffer_predicate, to_read_buffer_predicate}, streams::{MutableBufferChunkStream, ReadFilterResultsStream}};
+use super::{
+    pred::{to_mutable_buffer_predicate, to_read_buffer_predicate},
+    streams::{MutableBufferChunkStream, ReadFilterResultsStream},
+};
 
 use async_trait::async_trait;
 

--- a/server/src/db/chunk.rs
+++ b/server/src/db/chunk.rs
@@ -8,10 +8,7 @@ use tracing::debug;
 
 use std::sync::Arc;
 
-use super::{
-    pred::to_read_buffer_predicate,
-    streams::{MutableBufferChunkStream, ReadFilterResultsStream},
-};
+use super::{pred::{to_mutable_buffer_predicate, to_read_buffer_predicate}, streams::{MutableBufferChunkStream, ReadFilterResultsStream}};
 
 use async_trait::async_trait;
 
@@ -120,7 +117,7 @@ impl PartitionChunk for DBChunk {
                 if chunk.is_empty() {
                     Some(StringSet::new())
                 } else {
-                    let chunk_predicate = match chunk.compile_predicate(predicate) {
+                    let chunk_predicate = match to_mutable_buffer_predicate(chunk, predicate) {
                         Ok(chunk_predicate) => chunk_predicate,
                         Err(e) => {
                             debug!(?predicate, %e, "mutable buffer predicate not supported for table_names, falling back");
@@ -342,7 +339,7 @@ impl PartitionChunk for DBChunk {
     ) -> Result<Option<StringSet>, Self::Error> {
         match self {
             Self::MutableBuffer { chunk } => {
-                let chunk_predicate = match chunk.compile_predicate(predicate) {
+                let chunk_predicate = match to_mutable_buffer_predicate(chunk, predicate) {
                     Ok(chunk_predicate) => chunk_predicate,
                     Err(e) => {
                         debug!(?predicate, %e, "mutable buffer predicate not supported for column_names, falling back");
@@ -392,7 +389,7 @@ impl PartitionChunk for DBChunk {
             Self::MutableBuffer { chunk } => {
                 use mutable_buffer::chunk::Error::UnsupportedColumnTypeForListingValues;
 
-                let chunk_predicate = match chunk.compile_predicate(predicate) {
+                let chunk_predicate = match to_mutable_buffer_predicate(chunk, predicate) {
                     Ok(chunk_predicate) => chunk_predicate,
                     Err(e) => {
                         debug!(?predicate, %e, "mutable buffer predicate not supported for column_values, falling back");

--- a/server/src/db/pred.rs
+++ b/server/src/db/pred.rs
@@ -58,7 +58,6 @@ pub fn to_mutable_buffer_predicate(
     chunk: impl AsRef<Chunk>,
     predicate: &Predicate,
 ) -> Result<ChunkPredicate> {
-    // TODO proper errors here
     let predicate = chunk
         .as_ref()
         .predicate_builder()?

--- a/server/src/db/pred.rs
+++ b/server/src/db/pred.rs
@@ -3,7 +3,7 @@
 
 use std::convert::TryFrom;
 
-use mutable_buffer::chunk::{Chunk, ChunkPredicate};
+use mutable_buffer::{chunk::Chunk, pred::ChunkPredicate};
 use query::predicate::Predicate;
 use snafu::Snafu;
 
@@ -11,6 +11,15 @@ use snafu::Snafu;
 pub enum Error {
     #[snafu(display("Error translating predicate: {}", msg))]
     ReadBufferPredicate { msg: String, pred: Predicate },
+
+    #[snafu(display("Error building predicate for mutable buffer: {}", source))]
+    MutableBufferPredicate { source: mutable_buffer::pred::Error },
+}
+
+impl From<mutable_buffer::pred::Error> for Error {
+    fn from(source: mutable_buffer::pred::Error) -> Self {
+        Self::MutableBufferPredicate { source }
+    }
 }
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
@@ -45,10 +54,23 @@ pub fn to_read_buffer_predicate(predicate: &Predicate) -> Result<read_buffer::Pr
 
 /// Converts a [`query::Predicate`] into [`ChunkPredicate`],
 /// suitable for evaluating on the MutableBuffer.
-pub fn to_mutable_buffer_predicate(chunk: impl AsRef<Chunk>, predicate: &Predicate) -> Result<ChunkPredicate> {
-    todo!()
-}
+pub fn to_mutable_buffer_predicate(
+    chunk: impl AsRef<Chunk>,
+    predicate: &Predicate,
+) -> Result<ChunkPredicate> {
+    // TODO proper errors here
+    let predicate = chunk
+        .as_ref()
+        .predicate_builder()?
+        .table_names(predicate.table_names.as_ref())?
+        .field_names(predicate.field_columns.as_ref())?
+        .range(predicate.range)?
+        // it would be nice to avoid cloning all the exprs here.
+        .exprs(predicate.exprs.clone())?
+        .build();
 
+    Ok(predicate)
+}
 
 #[cfg(test)]
 pub mod test {
@@ -175,6 +197,7 @@ pub mod test {
                 Error::ReadBufferPredicate { msg, pred: _ } => {
                     assert_eq!(msg, exp.to_owned());
                 }
+                _ => panic!("Unexpected error type"),
             }
         }
     }

--- a/server/src/db/pred.rs
+++ b/server/src/db/pred.rs
@@ -3,6 +3,7 @@
 
 use std::convert::TryFrom;
 
+use mutable_buffer::chunk::{Chunk, ChunkPredicate};
 use query::predicate::Predicate;
 use snafu::Snafu;
 
@@ -14,6 +15,8 @@ pub enum Error {
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
+/// Converts a [`query::Predicate`] into [`read_buffer::Predicate`],
+/// suitable for evaluating on the ReadBuffer.
 pub fn to_read_buffer_predicate(predicate: &Predicate) -> Result<read_buffer::Predicate> {
     // Try to convert non-time column expressions into binary expressions
     // that are compatible with the read buffer.
@@ -39,6 +42,13 @@ pub fn to_read_buffer_predicate(predicate: &Predicate) -> Result<read_buffer::Pr
         }),
     }
 }
+
+/// Converts a [`query::Predicate`] into [`ChunkPredicate`],
+/// suitable for evaluating on the MutableBuffer.
+pub fn to_mutable_buffer_predicate(chunk: impl AsRef<Chunk>, predicate: &Predicate) -> Result<ChunkPredicate> {
+    todo!()
+}
+
 
 #[cfg(test)]
 pub mod test {


### PR DESCRIPTION
Part of #815; Working  to ensure there is no query logic in the `mutable_buffer`

Order of PRs (dependent):
- [x] feat: Add read_group / read_window_aggregate into higher level planner: https://github.com/influxdata/influxdb_iox/pull/905
- [x] refactor: remove query plan logic in mutable_buffer: https://github.com/influxdata/influxdb_iox/pull/912
- [x] refactor: Remove impl of `query::Database` in mutable_buffer: https://github.com/influxdata/influxdb_iox/pull/914
- [x] refactor: Move chunk predicate creation from query::Predicate into server crate: This PR
- [ ] refactor: Remove impl of `query::PartititionChunk` in mutable_buffer
- [ ] refactor: Move TimestampRange into DataTypes
- [ ] refactor: Remove query dependency in mutable buffer and delete all the old code.
- [ ] refactor: Remove GroupByAndAggregate and call the right planner function directly

Adminstrivia

- [x] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb_iox/blob/main/README.md).
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
