### PR TITLE
refactor: Remove impl of `query::PartititionChunk` in mutable_buffer

### DIFF
--- a/server/src/db.rs
+++ b/server/src/db.rs
@@ -23,7 +23,7 @@ use crate::buffer::Buffer;
 use tracing::info;
 
 mod chunk;
-use chunk::DBChunk;
+pub(crate) use chunk::DBChunk;
 pub mod pred;
 mod streams;
 

--- a/server/src/snapshot.rs
+++ b/server/src/snapshot.rs
@@ -363,7 +363,7 @@ impl TryClone for MemWriter {
 
 #[cfg(test)]
 mod tests {
-    use crate::db::Db;
+    use crate::db::{DBChunk, Db};
     use read_buffer::Database as ReadBufferDb;
 
     use super::*;
@@ -442,7 +442,7 @@ mem,host=A,region=west used=45 1
         ];
 
         let store = Arc::new(ObjectStore::new_in_memory(InMemory::new()));
-        let chunk = Arc::new(ChunkWB::new(11));
+        let chunk = DBChunk::new_mb(Arc::new(ChunkWB::new(11)));
         let mut metadata_path = store.new_path();
         metadata_path.push_dir("meta");
 


### PR DESCRIPTION
Part of #815; Working  to ensure there is no query logic in the `mutable_buffer`

Order of PRs (dependent):
- [x] feat: Add read_group / read_window_aggregate into higher level planner: https://github.com/influxdata/influxdb_iox/pull/905
- [x] refactor: remove query plan logic in mutable_buffer: https://github.com/influxdata/influxdb_iox/pull/912
- [x] refactor: Remove impl of `query::Database` in mutable_buffer: https://github.com/influxdata/influxdb_iox/pull/914
- [x] refactor: Move chunk predicate creation from query::Predicate into server crate: https://github.com/influxdata/influxdb_iox/pull/922
- [x] refactor: Remove impl of `query::PartititionChunk` in mutable_buffer: This PR
- [ ] refactor: Move TimestampRange into DataTypes
- [ ] refactor: Remove query dependency in mutable buffer and delete all the old code.
- [ ] refactor: Remove GroupByAndAggregate and call the right planner function directly


Adminstrivia

- [x] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb_iox/blob/main/README.md).
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).

