### PR TITLE
refactor: Remove mutable_buffer crate dependency on query

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1913,7 +1913,6 @@ dependencies = [
  "flatbuffers 0.6.1",
  "generated_types",
  "influxdb_line_protocol",
- "query",
  "snafu",
  "string-interner",
  "test_helpers",

--- a/arrow_deps/src/util.rs
+++ b/arrow_deps/src/util.rs
@@ -9,7 +9,7 @@ use arrow::{
     error::ArrowError,
     record_batch::RecordBatch,
 };
-use datafusion::logical_plan::{col, Expr};
+use datafusion::logical_plan::{binary_expr, col, lit, Expr, Operator};
 
 /// Returns a single column record batch of type Utf8 from the
 /// contents of something that can be turned into an iterator over
@@ -60,5 +60,75 @@ impl IntoExpr for str {
 impl IntoExpr for Expr {
     fn into_expr(&self) -> Expr {
         self.clone()
+    }
+}
+
+/// Creates expression like:
+/// start <= time && time < end
+pub fn make_range_expr(start: i64, end: i64, time: impl AsRef<str>) -> Expr {
+    let ts_low = lit(start).lt_eq(col(time.as_ref()));
+    let ts_high = col(time.as_ref()).lt(lit(end));
+
+    ts_low.and(ts_high)
+}
+
+/// Creates a single expression representing the conjunction (aka
+/// AND'ing) together of a set of expressions
+#[derive(Debug, Default)]
+pub struct AndExprBuilder {
+    cur_expr: Option<Expr>,
+}
+
+impl AndExprBuilder {
+    /// append `new_expr` to the expression chain being built
+    pub fn append_opt_ref(self, new_expr: Option<&Expr>) -> Self {
+        match new_expr {
+            None => self,
+            Some(new_expr) => self.append_expr(new_expr.clone()),
+        }
+    }
+
+    /// append `new_expr` to the expression chain being built
+    pub fn append_opt(self, new_expr: Option<Expr>) -> Self {
+        match new_expr {
+            None => self,
+            Some(new_expr) => self.append_expr(new_expr),
+        }
+    }
+
+    /// Append `new_expr` to the expression chain being built
+    pub fn append_expr(self, new_expr: Expr) -> Self {
+        let Self { cur_expr } = self;
+
+        let cur_expr = if let Some(cur_expr) = cur_expr {
+            binary_expr(cur_expr, Operator::And, new_expr)
+        } else {
+            new_expr
+        };
+
+        let cur_expr = Some(cur_expr);
+
+        Self { cur_expr }
+    }
+
+    /// Creates the new filter expression, consuming Self
+    pub fn build(self) -> Option<Expr> {
+        self.cur_expr
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_make_range_expr() {
+        // Test that the generated predicate is correct
+
+        let ts_predicate_expr = make_range_expr(101, 202, "time");
+        let expected_string = "Int64(101) LtEq #time And #time Lt Int64(202)";
+        let actual_string = format!("{:?}", ts_predicate_expr);
+
+        assert_eq!(actual_string, expected_string);
     }
 }

--- a/data_types/src/lib.rs
+++ b/data_types/src/lib.rs
@@ -28,6 +28,7 @@ pub mod names;
 pub mod partition_metadata;
 pub mod schema;
 pub mod selection;
+pub mod timestamp;
 pub mod wal;
 
 mod database_name;

--- a/data_types/src/timestamp.rs
+++ b/data_types/src/timestamp.rs
@@ -1,0 +1,58 @@
+/// Specifies a continuous range of nanosecond timestamps. Timestamp
+/// predicates are so common and critical to performance of timeseries
+/// databases in general, and IOx in particular, that they are handled
+/// specially
+#[derive(Clone, PartialEq, Copy, Debug)]
+pub struct TimestampRange {
+    /// Start defines the inclusive lower bound.
+    pub start: i64,
+    /// End defines the exclusive upper bound.
+    pub end: i64,
+}
+
+impl TimestampRange {
+    pub fn new(start: i64, end: i64) -> Self {
+        Self { start, end }
+    }
+
+    #[inline]
+    /// Returns true if this range contains the value v
+    pub fn contains(&self, v: i64) -> bool {
+        self.start <= v && v < self.end
+    }
+
+    #[inline]
+    /// Returns true if this range contains the value v
+    pub fn contains_opt(&self, v: Option<i64>) -> bool {
+        Some(true) == v.map(|ts| self.contains(ts))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_timestamp_range_contains() {
+        let range = TimestampRange::new(100, 200);
+        assert!(!range.contains(99));
+        assert!(range.contains(100));
+        assert!(range.contains(101));
+        assert!(range.contains(199));
+        assert!(!range.contains(200));
+        assert!(!range.contains(201));
+    }
+
+    #[test]
+    fn test_timestamp_range_contains_opt() {
+        let range = TimestampRange::new(100, 200);
+        assert!(!range.contains_opt(Some(99)));
+        assert!(range.contains_opt(Some(100)));
+        assert!(range.contains_opt(Some(101)));
+        assert!(range.contains_opt(Some(199)));
+        assert!(!range.contains_opt(Some(200)));
+        assert!(!range.contains_opt(Some(201)));
+
+        assert!(!range.contains_opt(None));
+    }
+}

--- a/mutable_buffer/Cargo.toml
+++ b/mutable_buffer/Cargo.toml
@@ -21,7 +21,6 @@ data_types = { path = "../data_types" }
 flatbuffers = "0.6.1"
 generated_types = { path = "../generated_types" }
 influxdb_line_protocol = { path = "../influxdb_line_protocol" }
-query = { path = "../query" }
 snafu = "0.6.2"
 string-interner = "0.12.2"
 tokio = { version = "1.0", features = ["macros"] }

--- a/mutable_buffer/src/pred.rs
+++ b/mutable_buffer/src/pred.rs
@@ -2,16 +2,16 @@ use std::collections::{BTreeSet, HashSet};
 
 use crate::dictionary::{Dictionary, Error as DictionaryError};
 
-use arrow_deps::datafusion::{
-    error::{DataFusionError, Result as DatafusionResult},
-    logical_plan::{Expr, ExpressionVisitor, Operator, Recursion},
-    optimizer::utils::expr_to_column_names,
-};
-use data_types::TIME_COLUMN_NAME;
-use query::{
-    predicate::TimestampRange,
+use arrow_deps::{
+    datafusion::{
+        error::{DataFusionError, Result as DatafusionResult},
+        logical_plan::{Expr, ExpressionVisitor, Operator, Recursion},
+        optimizer::utils::expr_to_column_names,
+    },
     util::{make_range_expr, AndExprBuilder},
 };
+use data_types::{timestamp::TimestampRange, TIME_COLUMN_NAME};
+
 //use snafu::{OptionExt, ResultExt, Snafu};
 use snafu::{ensure, ResultExt, Snafu};
 
@@ -139,7 +139,7 @@ impl ChunkPredicate {
     /// range.start <= time and time < range.end`
     fn make_timestamp_predicate_expr(&self) -> Option<Expr> {
         self.range
-            .map(|range| make_range_expr(range.start, range.end))
+            .map(|range| make_range_expr(range.start, range.end, TIME_COLUMN_NAME))
     }
 }
 

--- a/mutable_buffer/src/table.rs
+++ b/mutable_buffer/src/table.rs
@@ -117,9 +117,6 @@ pub enum Error {
         all_tag_column_names: String,
     },
 
-    #[snafu(display("Error creating aggregate expression:  {}", source))]
-    CreatingAggregates { source: query::group_by::Error },
-
     #[snafu(display("Duplicate group column '{}'", column_name))]
     DuplicateGroupColumn { column_name: String },
 

--- a/query/src/frontend/influxrpc.rs
+++ b/query/src/frontend/influxrpc.rs
@@ -28,7 +28,7 @@ use crate::{
         selectors::{selector_first, selector_last, selector_max, selector_min, SelectorOutput},
         window::make_window_bound_expr,
     },
-    group_by::{Aggregate, GroupByAndAggregate, WindowDuration},
+    group_by::{Aggregate, WindowDuration},
     plan::{
         fieldlist::FieldListPlan,
         seriesset::{SeriesSetPlan, SeriesSetPlans},
@@ -555,29 +555,6 @@ impl InfluxRPCPlanner {
         }
 
         Ok(ss_plans.into())
-    }
-
-    /// Query groups (dispatch to read_group or read_window_aggregate).
-    /// TODO remove this dispatch and just call the right thing directly
-    pub async fn query_group<D>(
-        &self,
-        database: &D,
-        predicate: Predicate,
-        gby_agg: GroupByAndAggregate,
-    ) -> Result<SeriesSetPlans>
-    where
-        D: Database + 'static,
-    {
-        match gby_agg {
-            GroupByAndAggregate::Columns { agg, group_columns } => {
-                self.read_group(database, predicate, agg, &group_columns)
-                    .await
-            }
-            GroupByAndAggregate::Window { agg, every, offset } => {
-                self.read_window_aggregate(database, predicate, agg, every, offset)
-                    .await
-            }
-        }
     }
 
     /// Creates a GroupedSeriesSet plan that produces an output table

--- a/query/src/group_by.rs
+++ b/query/src/group_by.rs
@@ -65,45 +65,6 @@ pub enum Aggregate {
     None,
 }
 
-/// Defines the different ways series can be grouped and aggregated
-#[derive(Debug, Clone, PartialEq)]
-pub enum GroupByAndAggregate {
-    /// group by a set of (Tag) columns, applying an agg to each field
-    ///
-    /// The resulting data is ordered so that series with the same
-    /// values in `group_columns` appear contiguously.
-    Columns {
-        agg: Aggregate,
-        group_columns: Vec<String>,
-    },
-
-    /// Group by a "window" in time, applying agg to each field
-    ///
-    /// The window is defined in terms three values:
-    ///
-    /// time: timestamp
-    /// every: Duration
-    /// offset: Duration
-    ///
-    /// The bounds are then calculated at a high level by
-    /// bounds = truncate((time_column_reference + offset), every)
-    ///
-    /// Where the truncate function is different depending on the
-    /// specific Duration
-    ///
-    /// This structure is different than the input (typically from gRPC)
-    /// and the underyling calculation (in window.rs), so that we can do
-    /// the input validation checking when creating this structure (rather
-    /// than in window.rs). The alternate would be to pass the structure
-    /// more directly from gRPC to window.rs, which would require less
-    /// translation but more error checking in window.rs.
-    Window {
-        agg: Aggregate,
-        every: WindowDuration,
-        offset: WindowDuration,
-    },
-}
-
 /// Represents some duration in time
 #[derive(Debug, Clone, PartialEq)]
 pub enum WindowDuration {

--- a/query/src/predicate.rs
+++ b/query/src/predicate.rs
@@ -5,39 +5,11 @@
 
 use std::collections::BTreeSet;
 
-use arrow_deps::datafusion::logical_plan::Expr;
-
-use crate::util::{make_range_expr, AndExprBuilder};
-
-/// Specifies a continuous range of nanosecond timestamps. Timestamp
-/// predicates are so common and critical to performance of timeseries
-/// databases in general, and IOx in particular, that they are handled
-/// specially
-#[derive(Clone, PartialEq, Copy, Debug)]
-pub struct TimestampRange {
-    /// Start defines the inclusive lower bound.
-    pub start: i64,
-    /// End defines the exclusive upper bound.
-    pub end: i64,
-}
-
-impl TimestampRange {
-    pub fn new(start: i64, end: i64) -> Self {
-        Self { start, end }
-    }
-
-    #[inline]
-    /// Returns true if this range contains the value v
-    pub fn contains(&self, v: i64) -> bool {
-        self.start <= v && v < self.end
-    }
-
-    #[inline]
-    /// Returns true if this range contains the value v
-    pub fn contains_opt(&self, v: Option<i64>) -> bool {
-        Some(true) == v.map(|ts| self.contains(ts))
-    }
-}
+use arrow_deps::{
+    datafusion::logical_plan::Expr,
+    util::{make_range_expr, AndExprBuilder},
+};
+use data_types::{timestamp::TimestampRange, TIME_COLUMN_NAME};
 
 /// This `Predicate` represents the empty predicate (aka that
 /// evaluates to true for all rows).
@@ -124,7 +96,7 @@ impl Predicate {
     /// `range.start <= time and time < range.end`
     fn make_timestamp_predicate_expr(&self) -> Option<Expr> {
         self.range
-            .map(|range| make_range_expr(range.start, range.end))
+            .map(|range| make_range_expr(range.start, range.end, TIME_COLUMN_NAME))
     }
 
     /// Returns true if ths predicate evaluates to true for all rows
@@ -252,30 +224,6 @@ impl PredicateBuilder {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn test_timestamp_range_contains() {
-        let range = TimestampRange::new(100, 200);
-        assert!(!range.contains(99));
-        assert!(range.contains(100));
-        assert!(range.contains(101));
-        assert!(range.contains(199));
-        assert!(!range.contains(200));
-        assert!(!range.contains(201));
-    }
-
-    #[test]
-    fn test_timestamp_range_contains_opt() {
-        let range = TimestampRange::new(100, 200);
-        assert!(!range.contains_opt(Some(99)));
-        assert!(range.contains_opt(Some(100)));
-        assert!(range.contains_opt(Some(101)));
-        assert!(range.contains_opt(Some(199)));
-        assert!(!range.contains_opt(Some(200)));
-        assert!(!range.contains_opt(Some(201)));
-
-        assert!(!range.contains_opt(None));
-    }
 
     #[test]
     fn test_default_predicate_is_empty() {


### PR DESCRIPTION
🎉 

This involves moving `TimestampRange` into data_types, and some basic Expr stuff into data_types.

Closes #815 and completes removing query logic from the `mutable_buffer`

Order of PRs (dependent):
- [x] feat: Add read_group / read_window_aggregate into higher level planner: https://github.com/influxdata/influxdb_iox/pull/905
- [x] refactor: remove query plan logic in mutable_buffer: https://github.com/influxdata/influxdb_iox/pull/912
- [x] refactor: Remove impl of `query::Database` in mutable_buffer: https://github.com/influxdata/influxdb_iox/pull/914
- [x] refactor: Move chunk predicate creation from query::Predicate into server crate: https://github.com/influxdata/influxdb_iox/pull/922
- [x] refactor: Remove impl of `query::PartititionChunk` in mutable_buffer: https://github.com/influxdata/influxdb_iox/pull/923
- [x] refactor: remove query dependency in mutable buffer code: This PR

Adminstrivia

- [x] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb_iox/blob/main/README.md).
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
