### PR TITLE
fix: Move rand to a dev-dependency of packers

### DIFF
--- a/packers/Cargo.toml
+++ b/packers/Cargo.toml
@@ -9,9 +9,9 @@ arrow_deps = { path = "../arrow_deps" }
 data_types = { path = "../data_types" }
 human_format = "1.0.3"
 influxdb_tsm = { path = "../influxdb_tsm" }
-rand = "0.7.3"
 snafu = "0.6.2"
 tracing = "0.1"
 
 [dev-dependencies] # In alphabetical order
+rand = "0.7.3"
 test_helpers = { path = "../test_helpers" }


### PR DESCRIPTION
I'm currently trying to [update the version of `rand` in the data generator crate](https://github.com/influxdata/iox_data_generator/issues/2), and I'm trying to make sure that there's the fewest number of different `rand` and `rand-*` sub crates in the dependency tree as possible.

`data_generator` depends on `packers`, which pulls in `rand` as a dependency even though as far as I can tell, `packers` only uses `rand` in tests.

So this PR moves `rand` to a dev dependency of `packers`.