### PR TITLE
feat: Write out a sample `.env` file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -323,7 +323,7 @@ dependencies = [
  "bitflags",
  "cexpr",
  "clang-sys",
- "clap",
+ "clap 2.33.3",
  "env_logger 0.8.3",
  "lazy_static",
  "lazycell",
@@ -493,10 +493,42 @@ dependencies = [
  "ansi_term 0.11.0",
  "atty",
  "bitflags",
- "strsim",
- "textwrap",
+ "strsim 0.8.0",
+ "textwrap 0.11.0",
  "unicode-width",
  "vec_map",
+]
+
+[[package]]
+name = "clap"
+version = "3.0.0-beta.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bd1061998a501ee7d4b6d449020df3266ca3124b941ec56cf2005c3779ca142"
+dependencies = [
+ "atty",
+ "bitflags",
+ "clap_derive",
+ "indexmap",
+ "lazy_static",
+ "os_str_bytes",
+ "strsim 0.10.0",
+ "termcolor",
+ "textwrap 0.12.1",
+ "unicode-width",
+ "vec_map",
+]
+
+[[package]]
+name = "clap_derive"
+version = "3.0.0-beta.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "370f715b81112975b1b69db93e0b56ea4cd4e5002ac43b2da8474106a54096a1"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -583,7 +615,7 @@ checksum = "ab327ed7354547cc2ef43cbe20ef68b988e70b4b593cbd66a2a61733123a3d23"
 dependencies = [
  "atty",
  "cast",
- "clap",
+ "clap 2.33.3",
  "criterion-plot",
  "csv",
  "itertools 0.10.0",
@@ -818,7 +850,7 @@ dependencies = [
  "arrow",
  "async-trait",
  "chrono",
- "clap",
+ "clap 2.33.3",
  "futures",
  "hashbrown",
  "log",
@@ -1480,7 +1512,7 @@ dependencies = [
  "byteorder",
  "bytes",
  "chrono",
- "clap",
+ "clap 3.0.0-beta.2",
  "criterion",
  "csv",
  "data_types",
@@ -1518,7 +1550,6 @@ dependencies = [
  "serde_urlencoded 0.7.0",
  "server",
  "snafu",
- "structopt",
  "tempfile",
  "test_helpers",
  "thiserror",
@@ -2215,6 +2246,12 @@ checksum = "766f840da25490628d8e63e529cd21c014f6600c6b8517add12a6fa6167a6218"
 dependencies = [
  "num-traits",
 ]
+
+[[package]]
+name = "os_str_bytes"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afb2e1c3ee07430c2cf76151675e583e0f19985fa6efae47d6848a3e2c824f85"
 
 [[package]]
 name = "packed_simd_2"
@@ -3426,28 +3463,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
-name = "structopt"
-version = "0.3.21"
+name = "strsim"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5277acd7ee46e63e5168a80734c9f6ee81b1367a7d8772a2d765df2a3705d28c"
-dependencies = [
- "clap",
- "lazy_static",
- "structopt-derive",
-]
-
-[[package]]
-name = "structopt-derive"
-version = "0.4.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ba9cdfda491b814720b6b06e0cac513d922fc407582032e8706e9f137976f90"
-dependencies = [
- "heck",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn",
-]
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "subtle"
@@ -3528,6 +3547,15 @@ name = "textwrap"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+dependencies = [
+ "unicode-width",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "203008d98caf094106cfaba70acfed15e18ed3ddb7d94e49baec153a2b462789"
 dependencies = [
  "unicode-width",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -502,8 +502,7 @@ dependencies = [
 [[package]]
 name = "clap"
 version = "3.0.0-beta.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bd1061998a501ee7d4b6d449020df3266ca3124b941ec56cf2005c3779ca142"
+source = "git+https://github.com/clap-rs/clap?rev=09009761ec5f6be4d406f70042d85fca543eeca8#09009761ec5f6be4d406f70042d85fca543eeca8"
 dependencies = [
  "atty",
  "bitflags",
@@ -513,16 +512,14 @@ dependencies = [
  "os_str_bytes",
  "strsim 0.10.0",
  "termcolor",
- "textwrap 0.12.1",
- "unicode-width",
+ "textwrap 0.13.4",
  "vec_map",
 ]
 
 [[package]]
 name = "clap_derive"
 version = "3.0.0-beta.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "370f715b81112975b1b69db93e0b56ea4cd4e5002ac43b2da8474106a54096a1"
+source = "git+https://github.com/clap-rs/clap?rev=09009761ec5f6be4d406f70042d85fca543eeca8#09009761ec5f6be4d406f70042d85fca543eeca8"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -2249,9 +2246,9 @@ dependencies = [
 
 [[package]]
 name = "os_str_bytes"
-version = "2.4.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afb2e1c3ee07430c2cf76151675e583e0f19985fa6efae47d6848a3e2c824f85"
+checksum = "e293568965aea261bdf010db17df7030e3c9a275c415d51d6112f7cf9b7af012"
 
 [[package]]
 name = "packed_simd_2"
@@ -3553,9 +3550,9 @@ dependencies = [
 
 [[package]]
 name = "textwrap"
-version = "0.12.1"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "203008d98caf094106cfaba70acfed15e18ed3ddb7d94e49baec153a2b462789"
+checksum = "cd05616119e612a8041ef58f2b578906cc2531a6069047ae092cfb86a325d835"
 dependencies = [
  "unicode-width",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ wal = { path = "wal" }
 byteorder = "1.3.4"
 bytes = "1.0"
 chrono = "0.4"
-clap = "2.33.1"
+clap = { version = "3.0.0-beta.2" }
 csv = "1.1"
 dirs = "3.0.1"
 dotenv = "0.15.0"
@@ -77,7 +77,6 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.44"
 serde_urlencoded = "0.7.0"
 snafu = "0.6.9"
-structopt = "0.3.21"
 thiserror = "1.0.23"
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread", "parking_lot"] }
 tokio-stream = { version = "0.1.2", features = ["net"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ wal = { path = "wal" }
 byteorder = "1.3.4"
 bytes = "1.0"
 chrono = "0.4"
-clap = { version = "3.0.0-beta.2" }
+clap = { git = "https://github.com/clap-rs/clap", rev = "09009761ec5f6be4d406f70042d85fca543eeca8" }
 csv = "1.1"
 dirs = "3.0.1"
 dotenv = "0.15.0"

--- a/src/commands/database.rs
+++ b/src/commands/database.rs
@@ -1,8 +1,8 @@
+use clap::Clap;
 use influxdb_iox_client::{
     connection::Builder,
     management::{generated_types::*, *},
 };
-use structopt::StructOpt;
 use thiserror::Error;
 
 #[derive(Debug, Error)]
@@ -23,31 +23,31 @@ pub enum Error {
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
 /// Manage IOx databases
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Clap)]
 pub struct Config {
-    #[structopt(subcommand)]
+    #[clap(subcommand)]
     command: Command,
 }
 
 /// Create a new database
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Clap)]
 struct Create {
     /// The name of the database
     name: String,
 
     /// Create a mutable buffer of the specified size in bytes
-    #[structopt(short, long)]
+    #[clap(short, long)]
     mutable_buffer: Option<u64>,
 }
 
 /// Get list of databases, or return configuration of specific database
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Clap)]
 struct Get {
     /// If specified returns configuration of database
     name: Option<String>,
 }
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Clap)]
 enum Command {
     Create(Create),
     Get(Get),

--- a/src/commands/server.rs
+++ b/src/commands/server.rs
@@ -1,9 +1,8 @@
 //! Implementation of command line option for manipulating and showing server
 //! config
 
-use clap::arg_enum;
+use clap::{ArgEnum, Clap};
 use std::{net::SocketAddr, net::ToSocketAddrs, path::PathBuf};
-use structopt::StructOpt;
 
 /// The default bind address for the HTTP API.
 pub const DEFAULT_API_BIND_ADDR: &str = "127.0.0.1:8080";
@@ -15,8 +14,8 @@ pub const DEFAULT_GRPC_BIND_ADDR: &str = "127.0.0.1:8082";
 /// specified.
 pub const FALLBACK_AWS_REGION: &str = "us-east-1";
 
-#[derive(Debug, StructOpt)]
-#[structopt(
+#[derive(Debug, Clap)]
+#[clap(
     name = "server",
     about = "Runs in server mode (default)",
     long_about = "Run the IOx server.\n\nThe configuration options below can be \
@@ -38,14 +37,14 @@ pub struct Config {
     /// `debug,hyper::proto::h1=info` specifies debug logging for all modules
     /// except for the `hyper::proto::h1' module which will only display info
     /// level logging.
-    #[structopt(long = "--log", env = "RUST_LOG")]
+    #[clap(long = "--log", env = "RUST_LOG")]
     pub rust_log: Option<String>,
 
     /// Log message format. Can be one of:
     ///
     /// "rust" (default)
     /// "logfmt" (logfmt/Heroku style - https://brandur.org/logfmt)
-    #[structopt(long = "--log_format", env = "INFLUXDB_IOX_LOG_FORMAT")]
+    #[clap(long = "--log_format", env = "INFLUXDB_IOX_LOG_FORMAT")]
     pub log_format: Option<LogFormat>,
 
     /// This sets logging up with a pre-configured set of convenient log levels.
@@ -55,8 +54,8 @@ pub struct Config {
     /// low level libraries)
     ///
     /// This option is ignored if  --log / RUST_LOG are set
-    #[structopt(
-        short = "-v",
+    #[clap(
+        short = 'v',
         long = "--verbose",
         multiple = true,
         takes_value = false,
@@ -70,11 +69,11 @@ pub struct Config {
     /// replicated writes, WAL segments and Chunks. Must be unique in a group of
     /// connected or semi-connected IOx servers. Must be a number that can be
     /// represented by a 32-bit unsigned integer.
-    #[structopt(long = "--writer-id", env = "INFLUXDB_IOX_ID")]
+    #[clap(long = "--writer-id", env = "INFLUXDB_IOX_ID")]
     pub writer_id: Option<u32>,
 
     /// The address on which IOx will serve HTTP API requests.
-    #[structopt(
+    #[clap(
         long = "--api-bind",
         env = "INFLUXDB_IOX_BIND_ADDR",
         default_value = DEFAULT_API_BIND_ADDR,
@@ -83,7 +82,7 @@ pub struct Config {
     pub http_bind_address: SocketAddr,
 
     /// The address on which IOx will serve Storage gRPC API requests.
-    #[structopt(
+    #[clap(
         long = "--grpc-bind",
         env = "INFLUXDB_IOX_GRPC_BIND_ADDR",
         default_value = DEFAULT_GRPC_BIND_ADDR,
@@ -92,15 +91,16 @@ pub struct Config {
     pub grpc_bind_address: SocketAddr,
 
     /// The location InfluxDB IOx will use to store files locally.
-    #[structopt(long = "--data-dir", env = "INFLUXDB_IOX_DB_DIR")]
+    #[clap(long = "--data-dir", env = "INFLUXDB_IOX_DB_DIR")]
     pub database_directory: Option<PathBuf>,
 
-    #[structopt(
+    #[clap(
         long = "--object-store",
         env = "INFLUXDB_IOX_OBJECT_STORE",
-        possible_values = &ObjectStore::variants(),
+        possible_values = ObjectStore::VARIANTS,
         case_insensitive = true,
-        long_help = r#"Which object storage to use. If not specified, defaults to memory.
+        parse(try_from_str = ObjectStore::from_str_insensitive),
+        long_about = r#"Which object storage to use. If not specified, defaults to memory.
 
 Possible values (case insensitive):
 
@@ -129,7 +129,7 @@ Possible values (case insensitive):
     /// container you've created in the associated storage account, under
     /// Blob Service > Containers. Must also set `--azure-storage-account` and
     /// `--azure-storage-access-key`.
-    #[structopt(long = "--bucket", env = "INFLUXDB_IOX_BUCKET")]
+    #[clap(long = "--bucket", env = "INFLUXDB_IOX_BUCKET")]
     pub bucket: Option<String>,
 
     /// When using Amazon S3 as the object store, set this to an access key that
@@ -141,7 +141,7 @@ Possible values (case insensitive):
     ///
     /// Prefer the environment variable over the command line flag in shared
     /// environments.
-    #[structopt(long = "--aws-access-key-id", env = "AWS_ACCESS_KEY_ID")]
+    #[clap(long = "--aws-access-key-id", env = "AWS_ACCESS_KEY_ID")]
     pub aws_access_key_id: Option<String>,
 
     /// When using Amazon S3 as the object store, set this to the secret access
@@ -152,7 +152,7 @@ Possible values (case insensitive):
     ///
     /// Prefer the environment variable over the command line flag in shared
     /// environments.
-    #[structopt(long = "--aws-secret-access-key", env = "AWS_SECRET_ACCESS_KEY")]
+    #[clap(long = "--aws-secret-access-key", env = "AWS_SECRET_ACCESS_KEY")]
     pub aws_secret_access_key: Option<String>,
 
     /// When using Amazon S3 as the object store, set this to the region
@@ -161,7 +161,7 @@ Possible values (case insensitive):
     ///
     /// Must also set `--object-store=s3`, `--bucket`, `--aws-access-key-id`,
     /// and `--aws-secret-access-key`.
-    #[structopt(
+    #[clap(
         long = "--aws-default-region",
         env = "AWS_DEFAULT_REGION",
         default_value = FALLBACK_AWS_REGION,
@@ -172,7 +172,7 @@ Possible values (case insensitive):
     /// path to the JSON file that contains the Google credentials.
     ///
     /// Must also set `--object-store=google` and `--bucket`.
-    #[structopt(long = "--google-service-account", env = "GOOGLE_SERVICE_ACCOUNT")]
+    #[clap(long = "--google-service-account", env = "GOOGLE_SERVICE_ACCOUNT")]
     pub google_service_account: Option<String>,
 
     /// When using Microsoft Azure as the object store, set this to the
@@ -180,7 +180,7 @@ Possible values (case insensitive):
     ///
     /// Must also set `--object-store=azure`, `--bucket`, and
     /// `--azure-storage-access-key`.
-    #[structopt(long = "--azure-storage-account", env = "AZURE_STORAGE_ACCOUNT")]
+    #[clap(long = "--azure-storage-account", env = "AZURE_STORAGE_ACCOUNT")]
     pub azure_storage_account: Option<String>,
 
     /// When using Microsoft Azure as the object store, set this to one of the
@@ -191,7 +191,7 @@ Possible values (case insensitive):
     ///
     /// Prefer the environment variable over the command line flag in shared
     /// environments.
-    #[structopt(long = "--azure-storage-access-key", env = "AZURE_STORAGE_ACCESS_KEY")]
+    #[clap(long = "--azure-storage-access-key", env = "AZURE_STORAGE_ACCESS_KEY")]
     pub azure_storage_access_key: Option<String>,
 
     /// If set, Jaeger traces are emitted to this host
@@ -207,7 +207,7 @@ Possible values (case insensitive):
     ///
     /// The entire list of variables can be found in
     /// https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/sdk-environment-variables.md#jaeger-exporter
-    #[structopt(
+    #[clap(
         long = "--oetl_exporter_jaeger_agent",
         env = "OTEL_EXPORTER_JAEGER_AGENT_HOST"
     )]
@@ -228,7 +228,7 @@ pub fn load_config() -> Box<Config> {
     //
 
     //let args = std::env::args().filter(|arg| arg != "server");
-    Box::new(Config::from_iter(strip_server(std::env::args()).iter()))
+    Box::new(Config::parse_from(strip_server(std::env::args()).iter()))
 }
 
 fn parse_socket_addr(s: &str) -> std::io::Result<SocketAddr> {
@@ -259,14 +259,18 @@ fn strip_server(args: impl Iterator<Item = String>) -> Vec<String> {
         .collect::<Vec<_>>()
 }
 
-arg_enum! {
-    #[derive(Debug, Copy, Clone, PartialEq)]
-    pub enum ObjectStore {
-        Memory,
-        File,
-        S3,
-        Google,
-        Azure,
+#[derive(Debug, Copy, Clone, PartialEq, ArgEnum)]
+pub enum ObjectStore {
+    Memory,
+    File,
+    S3,
+    Google,
+    Azure,
+}
+
+impl ObjectStore {
+    fn from_str_insensitive(s: &str) -> Result<Self, String> {
+        Self::from_str(s, true)
     }
 }
 
@@ -372,7 +376,7 @@ mod tests {
 
     #[test]
     fn test_socketaddr() -> Result<(), clap::Error> {
-        let c = Config::from_iter_safe(strip_server(
+        let c = Config::try_parse_from(strip_server(
             to_vec(&["cmd", "server", "--api-bind", "127.0.0.1:1234"]).into_iter(),
         ))?;
         assert_eq!(
@@ -380,7 +384,7 @@ mod tests {
             SocketAddr::from(([127, 0, 0, 1], 1234))
         );
 
-        let c = Config::from_iter_safe(strip_server(
+        let c = Config::try_parse_from(strip_server(
             to_vec(&["cmd", "server", "--api-bind", "localhost:1234"]).into_iter(),
         ))?;
         // depending on where the test runs, localhost will either resolve to a ipv4 or
@@ -396,7 +400,7 @@ mod tests {
         };
 
         assert_eq!(
-            Config::from_iter_safe(strip_server(
+            Config::try_parse_from(strip_server(
                 to_vec(&["cmd", "server", "--api-bind", "!@INv_a1d(ad0/resp_!"]).into_iter(),
             ))
             .map_err(|e| e.kind)

--- a/src/commands/stats.rs
+++ b/src/commands/stats.rs
@@ -1,7 +1,7 @@
 //! This module contains code to report compression statistics for storage files
 
+use clap::Clap;
 use snafu::{ResultExt, Snafu};
-use structopt::StructOpt;
 use tracing::info;
 
 use ingest::parquet::{error::IOxParquetError, stats as parquet_stats};
@@ -29,17 +29,17 @@ pub type Result<T, E = Error> = std::result::Result<T, E>;
 /// Print out storage statistics information to stdout.
 ///
 /// If a directory is specified, checks all files recursively
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Clap)]
 pub struct Config {
     /// The input filename or directory to read from
     input: String,
 
     /// Include detailed information per column
-    #[structopt(long)]
+    #[clap(long)]
     per_column: bool,
 
     /// Include detailed information per file
-    #[structopt(long)]
+    #[clap(long)]
     per_file: bool,
 }
 

--- a/src/commands/writer.rs
+++ b/src/commands/writer.rs
@@ -1,6 +1,6 @@
+use clap::Clap;
 use influxdb_iox_client::{connection::Builder, management::*};
 use std::num::NonZeroU32;
-use structopt::StructOpt;
 use thiserror::Error;
 
 #[derive(Debug, Error)]
@@ -18,20 +18,20 @@ pub enum Error {
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
 /// Manage IOx writer ID
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Clap)]
 pub struct Config {
-    #[structopt(subcommand)]
+    #[clap(subcommand)]
     command: Command,
 }
 
 /// Set writer ID
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Clap)]
 struct Set {
     /// The writer ID to set
     id: NonZeroU32,
 }
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Clap)]
 enum Command {
     Set(Set),
 

--- a/src/influxdb_ioxd.rs
+++ b/src/influxdb_ioxd.rs
@@ -50,7 +50,7 @@ pub enum Error {
     ServingRPC { source: self::rpc::Error },
 
     #[snafu(display(
-        "Specified {} for the object store, required configuration missing for {}",
+        "Specified {:?} for the object store, required configuration missing for {}",
         object_store,
         missing
     ))]
@@ -97,7 +97,7 @@ pub async fn main(logging_level: LoggingLevel, config: Option<Box<Config>>) -> R
             warn!("NO PERSISTENCE: using Memory for object storage");
         }
         Some(store) => {
-            info!("Using {} for object storage", store);
+            info!("Using {:?} for object storage", store);
         }
     }
 
@@ -280,13 +280,13 @@ impl TryFrom<&Config> for ObjectStore {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use clap::Clap;
     use object_store::ObjectStoreIntegration;
-    use structopt::StructOpt;
     use tempfile::TempDir;
 
     #[test]
     fn default_object_store_is_memory() {
-        let config = Config::from_iter_safe(&["server"]).unwrap();
+        let config = Config::try_parse_from(&["server"]).unwrap();
 
         let object_store = ObjectStore::try_from(&config).unwrap();
 
@@ -298,7 +298,7 @@ mod tests {
 
     #[test]
     fn explicitly_set_object_store_to_memory() {
-        let config = Config::from_iter_safe(&["server", "--object-store", "memory"]).unwrap();
+        let config = Config::try_parse_from(&["server", "--object-store", "memory"]).unwrap();
 
         let object_store = ObjectStore::try_from(&config).unwrap();
 
@@ -310,7 +310,7 @@ mod tests {
 
     #[test]
     fn valid_s3_config() {
-        let config = Config::from_iter_safe(&[
+        let config = Config::try_parse_from(&[
             "server",
             "--object-store",
             "s3",
@@ -333,7 +333,7 @@ mod tests {
 
     #[test]
     fn s3_config_missing_params() {
-        let config = Config::from_iter_safe(&["server", "--object-store", "s3"]).unwrap();
+        let config = Config::try_parse_from(&["server", "--object-store", "s3"]).unwrap();
 
         let err = ObjectStore::try_from(&config).unwrap_err().to_string();
 
@@ -346,7 +346,7 @@ mod tests {
 
     #[test]
     fn valid_google_config() {
-        let config = Config::from_iter_safe(&[
+        let config = Config::try_parse_from(&[
             "server",
             "--object-store",
             "google",
@@ -367,7 +367,7 @@ mod tests {
 
     #[test]
     fn google_config_missing_params() {
-        let config = Config::from_iter_safe(&["server", "--object-store", "google"]).unwrap();
+        let config = Config::try_parse_from(&["server", "--object-store", "google"]).unwrap();
 
         let err = ObjectStore::try_from(&config).unwrap_err().to_string();
 
@@ -380,7 +380,7 @@ mod tests {
 
     #[test]
     fn valid_azure_config() {
-        let config = Config::from_iter_safe(&[
+        let config = Config::try_parse_from(&[
             "server",
             "--object-store",
             "azure",
@@ -403,7 +403,7 @@ mod tests {
 
     #[test]
     fn azure_config_missing_params() {
-        let config = Config::from_iter_safe(&["server", "--object-store", "azure"]).unwrap();
+        let config = Config::try_parse_from(&["server", "--object-store", "azure"]).unwrap();
 
         let err = ObjectStore::try_from(&config).unwrap_err().to_string();
 
@@ -418,7 +418,7 @@ mod tests {
     fn valid_file_config() {
         let root = TempDir::new().unwrap();
 
-        let config = Config::from_iter_safe(&[
+        let config = Config::try_parse_from(&[
             "server",
             "--object-store",
             "file",
@@ -437,7 +437,7 @@ mod tests {
 
     #[test]
     fn file_config_missing_params() {
-        let config = Config::from_iter_safe(&["server", "--object-store", "file"]).unwrap();
+        let config = Config::try_parse_from(&["server", "--object-store", "file"]).unwrap();
 
         let err = ObjectStore::try_from(&config).unwrap_err().to_string();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,8 +9,8 @@
 
 use std::str::FromStr;
 
+use clap::Clap;
 use dotenv::dotenv;
-use structopt::StructOpt;
 use tokio::runtime::Runtime;
 use tracing::{debug, error, warn};
 
@@ -34,8 +34,8 @@ enum ReturnCode {
     Failure = 1,
 }
 
-#[derive(Debug, StructOpt)]
-#[structopt(
+#[derive(Debug, Clap)]
+#[clap(
     name = "influxdb_iox",
     about = "InfluxDB IOx server and command line tools",
     long_about = r#"InfluxDB IOx server and command line tools
@@ -64,11 +64,11 @@ Examples:
 "#
 )]
 struct Config {
-    #[structopt(short, long, parse(from_occurrences))]
+    #[clap(short, long, parse(from_occurrences))]
     verbose: u64,
 
     /// gRPC address of IOx server to connect to
-    #[structopt(
+    #[clap(
         short,
         long,
         global = true,
@@ -77,16 +77,16 @@ struct Config {
     )]
     host: String, /* TODO: This must be on the root due to https://github.com/clap-rs/clap/pull/2253 */
 
-    #[structopt(long)]
+    #[clap(long)]
     /// Set the maximum number of threads to use. Defaults to the number of
     /// cores on the system
     num_threads: Option<usize>,
 
-    #[structopt(subcommand)]
+    #[clap(subcommand)]
     command: Option<Command>,
 }
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Clap)]
 enum Command {
     /// Convert one storage format to another
     Convert {
@@ -97,7 +97,7 @@ enum Command {
         /// How much to compress the output data. 'max' compresses the most;
         /// 'compatibility' compresses in a manner more likely to be readable by
         /// other tools.
-        #[structopt(
+        #[clap(
         short, long, default_value = "compatibility",
         possible_values = & ["max", "compatibility"])]
         compression_level: String,
@@ -119,7 +119,7 @@ fn main() -> Result<(), std::io::Error> {
     // load all environment variables from .env before doing anything
     load_dotenv();
 
-    let config = Config::from_args();
+    let config = Config::parse();
 
     // Logging level is determined via:
     // 1. If RUST_LOG environment variable is set, use that value

--- a/tests/commands.rs
+++ b/tests/commands.rs
@@ -59,7 +59,7 @@ fn convert_bad_compression_level() {
         .assert();
 
     assert.failure().code(2).stderr(predicate::str::contains(
-        "error: 'maxxx' isn't a valid value for '--compression-level <compression-level>",
+        r#"error: "maxxx" isn't a valid value for '--compression-level <compression-level>"#,
     ));
 }
 

--- a/tests/commands.rs
+++ b/tests/commands.rs
@@ -58,7 +58,7 @@ fn convert_bad_compression_level() {
         .arg("/tmp")
         .assert();
 
-    assert.failure().code(1).stderr(predicate::str::contains(
+    assert.failure().code(2).stderr(predicate::str::contains(
         "error: 'maxxx' isn't a valid value for '--compression-level <compression-level>",
     ));
 }


### PR DESCRIPTION
Closes #881

<details>
<summary>Example output</summary>

```
# IOX_ADDR=http://127.0.0.1:8082

# This controls the IOx server logging level, as described in https://crates.io/crates/env_logger.
# 
# Levels for different modules can be specified as well. For example `debug,hyper::proto::h1=info` specifies debug logging for all modules except for the `hyper::proto::h1' module which will only display info level logging.
# RUST_LOG=

# Log message format. Can be one of:
# 
# "rust" (default) "logfmt" (logfmt/Heroku style - https://brandur.org/logfmt)
# INFLUXDB_IOX_LOG_FORMAT=

# The identifier for the server.
# 
# Used for writing to object storage and as an identifier that is added to replicated writes, WAL segments and Chunks. Must be unique in a group of connected or semi-connected IOx servers. Must be a number that can be represented by a 32-bit unsigned integer.
# INFLUXDB_IOX_ID=

# INFLUXDB_IOX_BIND_ADDR=127.0.0.1:8080

# INFLUXDB_IOX_GRPC_BIND_ADDR=127.0.0.1:8082

# INFLUXDB_IOX_DB_DIR=

# Which object storage to use. If not specified, defaults to memory.
# 
# Possible values (case insensitive):
# 
# * memory (default): Effectively no object persistence.
# * file: Stores objects in the local filesystem. Must also set `--data-dir`.
# * s3: Amazon S3. Must also set `--bucket`, `--aws-access-key-id`, `--aws-secret-access-key`, and
#    possibly `--aws-default-region`.
# * google: Google Cloud Storage. Must also set `--bucket` and `--google-service-account`.
# * azure: Microsoft Azure blob storage. Must also set `--bucket`, `--azure-storage-account`,
#    and `--azure-storage-access-key`.
#         
# Possible values: memory, file, s3, google, azure
# INFLUXDB_IOX_OBJECT_STORE=

# Name of the bucket to use for the object store. Must also set `--object-store` to a cloud object storage to have any effect.
# 
# If using Google Cloud Storage for the object store, this item as well as `--google-service-account` must be set.
# 
# If using S3 for the object store, must set this item as well as `--aws-access-key-id` and `--aws-secret-access-key`. Can also set `--aws-default-region` if not using the fallback region.
# 
# If using Azure for the object store, set this item to the name of a container you've created in the associated storage account, under Blob Service > Containers. Must also set `--azure-storage-account` and `--azure-storage-access-key`.
# INFLUXDB_IOX_BUCKET=

# When using Amazon S3 as the object store, set this to an access key that has permission to read from and write to the specified S3 bucket.
# 
# Must also set `--object-store=s3`, `--bucket`, and `--aws-secret-access-key`. Can also set `--aws-default-region` if not using the fallback region.
# 
# Prefer the environment variable over the command line flag in shared environments.
# AWS_ACCESS_KEY_ID=

# When using Amazon S3 as the object store, set this to the secret access key that goes with the specified access key ID.
# 
# Must also set `--object-store=s3`, `--bucket`, `--aws-access-key-id`. Can also set `--aws-default-region` if not using the fallback region.
# 
# Prefer the environment variable over the command line flag in shared environments.
# AWS_SECRET_ACCESS_KEY=

# When using Amazon S3 as the object store, set this to the region that goes with the specified bucket if different from the fallback value.
# 
# Must also set `--object-store=s3`, `--bucket`, `--aws-access-key-id`, and `--aws-secret-access-key`.
# AWS_DEFAULT_REGION=us-east-1

# When using Google Cloud Storage as the object store, set this to the path to the JSON file that contains the Google credentials.
# 
# Must also set `--object-store=google` and `--bucket`.
# GOOGLE_SERVICE_ACCOUNT=

# When using Microsoft Azure as the object store, set this to the name you see when going to All Services > Storage accounts > [name].
# 
# Must also set `--object-store=azure`, `--bucket`, and `--azure-storage-access-key`.
# AZURE_STORAGE_ACCOUNT=

# When using Microsoft Azure as the object store, set this to one of the Key values in the Storage account's Settings > Access keys.
# 
# Must also set `--object-store=azure`, `--bucket`, and `--azure-storage-account`.
# 
# Prefer the environment variable over the command line flag in shared environments.
# AZURE_STORAGE_ACCESS_KEY=

# If set, Jaeger traces are emitted to this host using the OpenTelemetry tracer.
# 
# NOTE: The OpenTelemetry agent CAN ONLY be configured using environment variables. It CAN NOT be configured using the command line at this time. Some useful variables:
# 
# * OTEL_SERVICE_NAME: emitter service name (iox by default) * OTEL_EXPORTER_JAEGER_AGENT_HOST: hostname/address of the collector * OTEL_EXPORTER_JAEGER_AGENT_PORT: listening port of the collector.
# 
# The entire list of variables can be found in https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/sdk-environment-variables.md#jaeger-exporter
# OTEL_EXPORTER_JAEGER_AGENT_HOST=
```

</details>