### PR TITLE
feat: Add Service + CLI command to write line protocol to IOx

### DIFF
--- a/generated_types/build.rs
+++ b/generated_types/build.rs
@@ -28,6 +28,7 @@ fn generate_grpc_types(root: &Path) -> Result<()> {
     let storage_path = root.join("influxdata/platform/storage");
     let idpe_path = root.join("com/github/influxdata/idpe/storage/read");
     let management_path = root.join("influxdata/iox/management/v1");
+    let write_path = root.join("influxdata/iox/write/v1");
     let grpc_path = root.join("grpc/health/v1");
 
     let proto_files = vec![
@@ -40,6 +41,7 @@ fn generate_grpc_types(root: &Path) -> Result<()> {
         management_path.join("base_types.proto"),
         management_path.join("database_rules.proto"),
         management_path.join("service.proto"),
+        write_path.join("service.proto"),
         grpc_path.join("service.proto"),
     ];
 

--- a/generated_types/protos/influxdata/iox/write/v1/service.proto
+++ b/generated_types/protos/influxdata/iox/write/v1/service.proto
@@ -1,0 +1,23 @@
+syntax = "proto3";
+package influxdata.iox.write.v1;
+
+
+service WriteService {
+  // write data into a specific Database
+  rpc Write(WriteDataRequest) returns (WriteDataResponse);
+}
+
+message WriteDataRequest {
+  // name of database into which to write
+  string name = 1;
+
+  // data, in [LineProtcol] format
+  //
+  // [LineProtcol](https://docs.influxdata.com/influxdb/v2.0/reference/syntax/line-protocol/#data-types-and-format)
+  string lp_data = 2;
+}
+
+message WriteDataResponse {
+  // how many lines were parsed and written into the database
+  uint64 lines_written = 1;
+}

--- a/generated_types/protos/influxdata/iox/write/v1/service.proto
+++ b/generated_types/protos/influxdata/iox/write/v1/service.proto
@@ -11,9 +11,9 @@ message WriteRequest {
   // name of database into which to write
   string name = 1;
 
-  // data, in [LineProtcol] format
+  // data, in [LineProtocol] format
   //
-  // [LineProtcol](https://docs.influxdata.com/influxdb/v2.0/reference/syntax/line-protocol/#data-types-and-format)
+  // [LineProtocol](https://docs.influxdata.com/influxdb/v2.0/reference/syntax/line-protocol/#data-types-and-format)
   string lp_data = 2;
 }
 

--- a/generated_types/protos/influxdata/iox/write/v1/service.proto
+++ b/generated_types/protos/influxdata/iox/write/v1/service.proto
@@ -4,10 +4,10 @@ package influxdata.iox.write.v1;
 
 service WriteService {
   // write data into a specific Database
-  rpc Write(WriteDataRequest) returns (WriteDataResponse);
+  rpc Write(WriteRequest) returns (WriteResponse);
 }
 
-message WriteDataRequest {
+message WriteRequest {
   // name of database into which to write
   string name = 1;
 
@@ -17,7 +17,7 @@ message WriteDataRequest {
   string lp_data = 2;
 }
 
-message WriteDataResponse {
+message WriteResponse {
   // how many lines were parsed and written into the database
   uint64 lines_written = 1;
 }

--- a/generated_types/src/lib.rs
+++ b/generated_types/src/lib.rs
@@ -9,6 +9,9 @@
     clippy::clone_on_ref_ptr
 )]
 
+/// This module imports the generated protobuf code into a Rust module
+/// heirarchy that matches the namespace heirarchy of the protobuf
+/// definitions
 mod pb {
     pub mod influxdata {
         pub mod platform {
@@ -31,6 +34,12 @@ mod pb {
             pub mod management {
                 pub mod v1 {
                     include!(concat!(env!("OUT_DIR"), "/influxdata.iox.management.v1.rs"));
+                }
+            }
+
+            pub mod write {
+                pub mod v1 {
+                    include!(concat!(env!("OUT_DIR"), "/influxdata.iox.write.v1.rs"));
                 }
             }
         }

--- a/google_types/src/lib.rs
+++ b/google_types/src/lib.rs
@@ -1,3 +1,6 @@
+//! Protobuf types for errors from the google standards and
+//! conversions to `tonic::Status`
+
 // This crate deliberately does not use the same linting rules as the other
 // crates because of all the generated code it contains that we don't have much
 // control over.
@@ -87,6 +90,9 @@ fn encode_status(code: tonic::Code, message: String, details: Any) -> tonic::Sta
 }
 
 #[derive(Debug, Default, Clone)]
+/// Error returned if a request field has an invalid value. Includes
+/// machinery to add parent field names for context -- thus it will
+/// report `rules.write_timeout` than simply `write_timeout`.
 pub struct FieldViolation {
     pub field: String,
     pub description: String,

--- a/influxdb_iox_client/src/client.rs
+++ b/influxdb_iox_client/src/client.rs
@@ -4,6 +4,9 @@ pub mod health;
 /// Client for the management API
 pub mod management;
 
+/// Client for the write API
+pub mod write;
+
 #[cfg(feature = "flight")]
 /// Client for the flight API
 pub mod flight;

--- a/influxdb_iox_client/src/client/write.rs
+++ b/influxdb_iox_client/src/client/write.rs
@@ -54,11 +54,11 @@ impl Client {
         }
     }
 
-    /// Write the [LineProtcol] formatted data in `lp_data` to
+    /// Write the [LineProtocol] formatted data in `lp_data` to
     /// database `name`. Returns the number of lines which were parsed
     /// and written to the database
     ///
-    /// [LineProtcol](https://docs.influxdata.com/influxdb/v2.0/reference/syntax/line-protocol/#data-types-and-format)
+    /// [LineProtocol](https://docs.influxdata.com/influxdb/v2.0/reference/syntax/line-protocol/#data-types-and-format)
     pub async fn write(
         &mut self,
         name: impl Into<String>,

--- a/influxdb_iox_client/src/client/write.rs
+++ b/influxdb_iox_client/src/client/write.rs
@@ -1,0 +1,77 @@
+use thiserror::Error;
+
+use self::generated_types::{write_service_client::WriteServiceClient, *};
+
+use crate::connection::Connection;
+
+/// Re-export generated_types
+pub mod generated_types {
+    pub use generated_types::influxdata::iox::write::v1::*;
+}
+
+/// Errors returned by Client::write_data
+#[derive(Debug, Error)]
+pub enum WriteDataError {
+    /// Client received an unexpected error from the server
+    #[error("Unexpected server error: {}: {}", .0.code(), .0.message())]
+    ServerError(tonic::Status),
+}
+
+/// An IOx Write API client.
+///
+/// ```no_run
+/// #[tokio::main]
+/// # async fn main() {
+/// use influxdb_iox_client::{
+///     write::Client,
+///     connection::Builder,
+/// };
+///
+/// let mut connection = Builder::default()
+///     .build("http://127.0.0.1:8082")
+///     .await
+///     .unwrap();
+///
+/// let mut client = Client::new(connection);
+///
+/// // write a line of line procol data
+/// client
+///     .write("bananas", "cpu,region=west user=23.2 100")
+///     .await
+///     .expect("failed to create database");
+/// # }
+/// ```
+#[derive(Debug, Clone)]
+pub struct Client {
+    inner: WriteServiceClient<Connection>,
+}
+
+impl Client {
+    /// Creates a new client with the provided connection
+    pub fn new(channel: tonic::transport::Channel) -> Self {
+        Self {
+            inner: WriteServiceClient::new(channel),
+        }
+    }
+
+    /// Write the [LineProtcol] formatted data in `lp_data` to
+    /// database `name`. Returns the number of lines which were parsed
+    /// and written to the database
+    ///
+    /// [LineProtcol](https://docs.influxdata.com/influxdb/v2.0/reference/syntax/line-protocol/#data-types-and-format)
+    pub async fn write(
+        &mut self,
+        name: impl Into<String>,
+        lp_data: impl Into<String>,
+    ) -> Result<usize, WriteDataError> {
+        let name = name.into();
+        let lp_data = lp_data.into();
+        let response = self
+            .inner
+            .write(WriteDataRequest { name, lp_data })
+            .await
+            .map_err(WriteDataError::ServerError)?;
+
+        Ok(response.into_inner().lines_written as usize)
+    }
+}

--- a/influxdb_iox_client/src/client/write.rs
+++ b/influxdb_iox_client/src/client/write.rs
@@ -11,7 +11,7 @@ pub mod generated_types {
 
 /// Errors returned by Client::write_data
 #[derive(Debug, Error)]
-pub enum WriteDataError {
+pub enum WriteError {
     /// Client received an unexpected error from the server
     #[error("Unexpected server error: {}: {}", .0.code(), .0.message())]
     ServerError(tonic::Status),
@@ -63,14 +63,14 @@ impl Client {
         &mut self,
         name: impl Into<String>,
         lp_data: impl Into<String>,
-    ) -> Result<usize, WriteDataError> {
+    ) -> Result<usize, WriteError> {
         let name = name.into();
         let lp_data = lp_data.into();
         let response = self
             .inner
-            .write(WriteDataRequest { name, lp_data })
+            .write(WriteRequest { name, lp_data })
             .await
-            .map_err(WriteDataError::ServerError)?;
+            .map_err(WriteError::ServerError)?;
 
         Ok(response.into_inner().lines_written as usize)
     }

--- a/influxdb_iox_client/src/lib.rs
+++ b/influxdb_iox_client/src/lib.rs
@@ -8,7 +8,7 @@
 )]
 #![allow(clippy::missing_docs_in_private_items)]
 
-pub use client::{health, management};
+pub use client::{health, management, write};
 
 #[cfg(feature = "flight")]
 pub use client::flight;

--- a/src/commands/database.rs
+++ b/src/commands/database.rs
@@ -1,6 +1,12 @@
+//! This module implements the `database` CLI command
+use std::{fs::File, io::Read, path::PathBuf};
+
 use influxdb_iox_client::{
     connection::Builder,
-    management::{generated_types::*, *},
+    management::{
+        self, generated_types::*, CreateDatabaseError, GetDatabaseError, ListDatabaseError,
+    },
+    write::{self, WriteDataError},
 };
 use structopt::StructOpt;
 use thiserror::Error;
@@ -18,6 +24,15 @@ pub enum Error {
 
     #[error("Error connecting to IOx: {0}")]
     ConnectionError(#[from] influxdb_iox_client::connection::Error),
+
+    #[error("Error reading file {:?}: {}", file_name, source)]
+    ReadingFile {
+        file_name: PathBuf,
+        source: std::io::Error,
+    },
+
+    #[error("Error writing: {0}")]
+    WriteError(#[from] WriteDataError),
 }
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
@@ -47,18 +62,30 @@ struct Get {
     name: Option<String>,
 }
 
+/// Write data into the specified database
+#[derive(Debug, StructOpt)]
+struct Write {
+    /// The name of the database
+    name: String,
+
+    /// File with data to load. Currently supported formats are .lp
+    file_name: PathBuf,
+}
+
+/// All possible subcommands for database
 #[derive(Debug, StructOpt)]
 enum Command {
     Create(Create),
     Get(Get),
+    Write(Write),
 }
 
 pub async fn command(url: String, config: Config) -> Result<()> {
     let connection = Builder::default().build(url).await?;
-    let mut client = Client::new(connection);
 
     match config.command {
         Command::Create(command) => {
+            let mut client = management::Client::new(connection);
             client
                 .create_database(DatabaseRules {
                     name: command.name,
@@ -74,6 +101,7 @@ pub async fn command(url: String, config: Config) -> Result<()> {
             println!("Ok");
         }
         Command::Get(get) => {
+            let mut client = management::Client::new(connection);
             if let Some(name) = get.name {
                 let database = client.get_database(name).await?;
                 // TOOD: Do something better than this
@@ -82,6 +110,25 @@ pub async fn command(url: String, config: Config) -> Result<()> {
                 let databases = client.list_databases().await?;
                 println!("{}", databases.join(", "))
             }
+        }
+        Command::Write(write) => {
+            let mut client = write::Client::new(connection);
+
+            let mut file = File::open(&write.file_name).map_err(|e| Error::ReadingFile {
+                file_name: write.file_name.clone(),
+                source: e,
+            })?;
+
+            let mut lp_data = String::new();
+            file.read_to_string(&mut lp_data)
+                .map_err(|e| Error::ReadingFile {
+                    file_name: write.file_name.clone(),
+                    source: e,
+                })?;
+
+            let lines_written = client.write(write.name, lp_data).await?;
+
+            println!("{} Lines OK", lines_written);
         }
     }
 

--- a/src/commands/database.rs
+++ b/src/commands/database.rs
@@ -6,7 +6,7 @@ use influxdb_iox_client::{
     management::{
         self, generated_types::*, CreateDatabaseError, GetDatabaseError, ListDatabaseError,
     },
-    write::{self, WriteDataError},
+    write::{self, WriteError},
 };
 use structopt::StructOpt;
 use thiserror::Error;
@@ -32,7 +32,7 @@ pub enum Error {
     },
 
     #[error("Error writing: {0}")]
-    WriteError(#[from] WriteDataError),
+    WriteError(#[from] WriteError),
 }
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;

--- a/src/influxdb_ioxd/rpc.rs
+++ b/src/influxdb_ioxd/rpc.rs
@@ -8,10 +8,12 @@ use tokio_stream::wrappers::TcpListenerStream;
 use data_types::error::ErrorLogger;
 use server::{ConnectionManager, Server};
 
+pub mod error;
 mod flight;
 mod management;
 mod storage;
 mod testing;
+mod write;
 
 #[derive(Debug, Snafu)]
 pub enum Error {
@@ -50,6 +52,7 @@ where
         .add_service(testing::make_server())
         .add_service(storage::make_server(Arc::clone(&server)))
         .add_service(flight::make_server(Arc::clone(&server)))
+        .add_service(write::make_server(Arc::clone(&server)))
         .add_service(management::make_server(server))
         .serve_with_incoming(stream)
         .await

--- a/src/influxdb_ioxd/rpc/error.rs
+++ b/src/influxdb_ioxd/rpc/error.rs
@@ -1,0 +1,26 @@
+use generated_types::google::{InternalError, NotFound, PreconditionViolation};
+use tracing::error;
+
+use server::Error;
+
+/// map common server errors  to the appropriate tonic Status
+pub fn default_error_handler(error: Error) -> tonic::Status {
+    match error {
+        Error::IdNotSet => PreconditionViolation {
+            category: "Writer ID".to_string(),
+            subject: "influxdata.com/iox".to_string(),
+            description: "Writer ID must be set".to_string(),
+        }
+        .into(),
+        Error::DatabaseNotFound { db_name } => NotFound {
+            resource_type: "database".to_string(),
+            resource_name: db_name,
+            ..Default::default()
+        }
+        .into(),
+        error => {
+            error!(?error, "Unexpected error");
+            InternalError {}.into()
+        }
+    }
+}

--- a/src/influxdb_ioxd/rpc/write.rs
+++ b/src/influxdb_ioxd/rpc/write.rs
@@ -1,0 +1,60 @@
+use std::sync::Arc;
+
+use generated_types::{google::FieldViolation, influxdata::iox::write::v1::*};
+use influxdb_line_protocol::parse_lines;
+use server::{ConnectionManager, Server};
+use std::fmt::Debug;
+use tonic::Response;
+use tracing::debug;
+
+use super::error::default_error_handler;
+
+/// Implementation of the write service
+struct WriteService<M: ConnectionManager> {
+    server: Arc<Server<M>>,
+}
+
+#[tonic::async_trait]
+impl<M> write_service_server::WriteService for WriteService<M>
+where
+    M: ConnectionManager + Send + Sync + Debug + 'static,
+{
+    async fn write(
+        &self,
+        request: tonic::Request<WriteDataRequest>,
+    ) -> Result<tonic::Response<WriteDataResponse>, tonic::Status> {
+        let request = request.into_inner();
+
+        let db_name = request.name;
+        let lp_data = request.lp_data;
+        let lp_chars = lp_data.len();
+
+        let lines = parse_lines(&lp_data)
+            .collect::<Result<Vec<_>, influxdb_line_protocol::Error>>()
+            .map_err(|e| FieldViolation {
+                field: "lp_data".into(),
+                description: format!("Invalid Line Protocol: {}", e),
+            })?;
+
+        let lp_line_count = lines.len();
+        debug!(%db_name, %lp_chars, lp_line_count, "Writing lines into database");
+
+        self.server
+            .write_lines(&db_name, &lines)
+            .await
+            .map_err(|e| default_error_handler(e))?;
+
+        let lines_written = lp_line_count as u64;
+        Ok(Response::new(WriteDataResponse { lines_written }))
+    }
+}
+
+/// Instantiate the write service
+pub fn make_server<M>(
+    server: Arc<Server<M>>,
+) -> write_service_server::WriteServiceServer<impl write_service_server::WriteService>
+where
+    M: ConnectionManager + Send + Sync + Debug + 'static,
+{
+    write_service_server::WriteServiceServer::new(WriteService { server })
+}

--- a/src/influxdb_ioxd/rpc/write.rs
+++ b/src/influxdb_ioxd/rpc/write.rs
@@ -42,7 +42,7 @@ where
         self.server
             .write_lines(&db_name, &lines)
             .await
-            .map_err(|e| default_error_handler(e))?;
+            .map_err(default_error_handler)?;
 
         let lines_written = lp_line_count as u64;
         Ok(Response::new(WriteDataResponse { lines_written }))

--- a/src/influxdb_ioxd/rpc/write.rs
+++ b/src/influxdb_ioxd/rpc/write.rs
@@ -21,8 +21,8 @@ where
 {
     async fn write(
         &self,
-        request: tonic::Request<WriteDataRequest>,
-    ) -> Result<tonic::Response<WriteDataResponse>, tonic::Status> {
+        request: tonic::Request<WriteRequest>,
+    ) -> Result<tonic::Response<WriteResponse>, tonic::Status> {
         let request = request.into_inner();
 
         let db_name = request.name;
@@ -45,7 +45,7 @@ where
             .map_err(default_error_handler)?;
 
         let lines_written = lp_line_count as u64;
-        Ok(Response::new(WriteDataResponse { lines_written }))
+        Ok(Response::new(WriteResponse { lines_written }))
     }
 }
 

--- a/tests/end-to-end.rs
+++ b/tests/end-to-end.rs
@@ -76,7 +76,7 @@ async fn read_and_write_data() {
         .await
         .unwrap();
     let mut storage_client = StorageClient::new(grpc.clone());
-    let mut management_client = influxdb_iox_client::management::Client::new(grpc);
+    let mut management_client = influxdb_iox_client::management::Client::new(grpc.clone());
 
     // These tests share data; TODO: a better way to indicate this
     {
@@ -104,6 +104,8 @@ async fn read_and_write_data() {
     .await;
     management_api::test(&mut management_client).await;
     management_cli::test(GRPC_URL_BASE).await;
+    write_api::test(grpc).await;
+    write_cli::test(GRPC_URL_BASE).await;
     test_http_error_messages(&influxdb2).await.unwrap();
 }
 

--- a/tests/end_to_end_cases/management_api.rs
+++ b/tests/end_to_end_cases/management_api.rs
@@ -1,10 +1,10 @@
 use std::num::NonZeroU32;
 
-use rand::{distributions::Alphanumeric, thread_rng, Rng};
-
 use generated_types::google::protobuf::Empty;
 use generated_types::{google::protobuf::Duration, influxdata::iox::management::v1::*};
 use influxdb_iox_client::management::{Client, CreateDatabaseError};
+
+use super::util::rand_name;
 
 pub async fn test(client: &mut Client) {
     test_set_get_writer_id(client).await;
@@ -148,12 +148,4 @@ async fn test_create_get_database(client: &mut Client) {
         .expect("get database failed");
 
     assert_eq!(response, rules);
-}
-
-fn rand_name() -> String {
-    thread_rng()
-        .sample_iter(&Alphanumeric)
-        .take(10)
-        .map(char::from)
-        .collect()
 }

--- a/tests/end_to_end_cases/mod.rs
+++ b/tests/end_to_end_cases/mod.rs
@@ -3,3 +3,6 @@ pub mod management_api;
 pub mod management_cli;
 pub mod read_api;
 pub mod storage_api;
+pub mod util;
+pub mod write_api;
+pub mod write_cli;

--- a/tests/end_to_end_cases/util.rs
+++ b/tests/end_to_end_cases/util.rs
@@ -1,0 +1,10 @@
+use rand::{distributions::Alphanumeric, thread_rng, Rng};
+
+/// Return a random string suitable for use as a database name
+pub fn rand_name() -> String {
+    thread_rng()
+        .sample_iter(&Alphanumeric)
+        .take(10)
+        .map(char::from)
+        .collect()
+}

--- a/tests/end_to_end_cases/write_api.rs
+++ b/tests/end_to_end_cases/write_api.rs
@@ -1,0 +1,71 @@
+use std::num::NonZeroU32;
+
+use influxdb_iox_client::management::{self, generated_types::DatabaseRules};
+use influxdb_iox_client::write::{self, WriteDataError};
+use test_helpers::assert_contains;
+
+use super::util::rand_name;
+
+/// Tests the basics of the write API
+pub async fn test(channel: tonic::transport::Channel) {
+    let mut management_client = management::Client::new(channel.clone());
+    let mut write_client = write::Client::new(channel);
+
+    test_write(&mut management_client, &mut write_client).await
+}
+
+async fn test_write(management_client: &mut management::Client, write_client: &mut write::Client) {
+    const TEST_ID: u32 = 42;
+
+    let db_name = rand_name();
+
+    management_client
+        .create_database(DatabaseRules {
+            name: db_name.clone(),
+            ..Default::default()
+        })
+        .await
+        .expect("create database failed");
+
+    management_client
+        .update_writer_id(NonZeroU32::new(TEST_ID).unwrap())
+        .await
+        .expect("set ID failed");
+
+    let lp_lines = vec![
+        "cpu,region=west user=23.2 100",
+        "cpu,region=west user=21.0 150",
+        "disk,region=east bytes=99i 200",
+    ];
+
+    let num_lines_written = write_client
+        .write(&db_name, lp_lines.join("\n"))
+        .await
+        .expect("write succeded");
+
+    assert_eq!(num_lines_written, 3);
+
+    // ---- test bad data ----
+    let err = write_client
+        .write(&db_name, "XXX")
+        .await
+        .expect_err("expected write to fail");
+
+    assert_contains!(
+        err.to_string(),
+        r#"Client specified an invalid argument: Violation for field "lp_data": Invalid Line Protocol: A generic parsing error occurred"#
+    );
+    assert!(matches!(dbg!(err), WriteDataError::ServerError(_)));
+
+    // ---- test non existent database ----
+    let err = write_client
+        .write("Non_existent_database", lp_lines.join("\n"))
+        .await
+        .expect_err("expected write to fail");
+
+    assert_contains!(
+        err.to_string(),
+        r#"Unexpected server error: Some requested entity was not found: Resource database/Non_existent_database not found"#
+    );
+    assert!(matches!(dbg!(err), WriteDataError::ServerError(_)));
+}

--- a/tests/end_to_end_cases/write_api.rs
+++ b/tests/end_to_end_cases/write_api.rs
@@ -1,7 +1,7 @@
 use std::num::NonZeroU32;
 
 use influxdb_iox_client::management::{self, generated_types::DatabaseRules};
-use influxdb_iox_client::write::{self, WriteDataError};
+use influxdb_iox_client::write::{self, WriteError};
 use test_helpers::assert_contains;
 
 use super::util::rand_name;
@@ -55,7 +55,7 @@ async fn test_write(management_client: &mut management::Client, write_client: &m
         err.to_string(),
         r#"Client specified an invalid argument: Violation for field "lp_data": Invalid Line Protocol: A generic parsing error occurred"#
     );
-    assert!(matches!(dbg!(err), WriteDataError::ServerError(_)));
+    assert!(matches!(dbg!(err), WriteError::ServerError(_)));
 
     // ---- test non existent database ----
     let err = write_client
@@ -67,5 +67,5 @@ async fn test_write(management_client: &mut management::Client, write_client: &m
         err.to_string(),
         r#"Unexpected server error: Some requested entity was not found: Resource database/Non_existent_database not found"#
     );
-    assert!(matches!(dbg!(err), WriteDataError::ServerError(_)));
+    assert!(matches!(dbg!(err), WriteError::ServerError(_)));
 }

--- a/tests/end_to_end_cases/write_cli.rs
+++ b/tests/end_to_end_cases/write_cli.rs
@@ -1,0 +1,63 @@
+use assert_cmd::Command;
+use predicates::prelude::*;
+use test_helpers::make_temp_file;
+
+use super::util::rand_name;
+
+pub async fn test(addr: impl AsRef<str>) {
+    let db_name = rand_name();
+    let addr = addr.as_ref();
+    create_database(&db_name, addr).await;
+    test_write(&db_name, addr).await;
+}
+
+async fn create_database(db_name: &str, addr: &str) {
+    Command::cargo_bin("influxdb_iox")
+        .unwrap()
+        .arg("database")
+        .arg("create")
+        .arg(db_name)
+        .arg("--host")
+        .arg(addr)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Ok"));
+}
+
+async fn test_write(db_name: &str, addr: &str) {
+    let lp_data = vec![
+        "cpu,region=west user=23.2 100",
+        "cpu,region=west user=21.0 150",
+    ];
+
+    let lp_data_file = make_temp_file(lp_data.join("\n"));
+
+    // read from temp file
+    Command::cargo_bin("influxdb_iox")
+        .unwrap()
+        .arg("database")
+        .arg("write")
+        .arg(db_name)
+        .arg(lp_data_file.as_ref())
+        .arg("--host")
+        .arg(addr)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("2 Lines OK"));
+
+    // try reading a non existent file
+    Command::cargo_bin("influxdb_iox")
+        .unwrap()
+        .arg("database")
+        .arg("write")
+        .arg(db_name)
+        .arg("this_file_does_not_exist")
+        .arg("--host")
+        .arg(addr)
+        .assert()
+        .failure()
+        .stderr(
+            predicate::str::contains(r#"Error reading file "this_file_does_not_exist":"#)
+                .and(predicate::str::contains("No such file or directory")),
+        );
+}


### PR DESCRIPTION
Re https://github.com/influxdata/influxdb_iox/issues/942

# Rationale:
I want to be able to do the basic administration stuff from the IOx client directly (not a mix of curl and the CLI)

# Usage
```
./influxdb_iox database write --data=/path/to/line_protocol.lp
```

Example use:

```
cargo run -- writer set 43
Ok
cargo run -- database create foo
Ok
cargo run -- database write foo tests/fixtures/lineproto/metrics.lp
1000 Lines OK
```

# Changes
* Define and implement a Write gRPC service in IOx
* Define and implement a Write service client in `influxdb_iox_client`
* Implement the write CLI using those pieces
* tests for same

# Implementation Notes

After discussions with @tustvold, I propose adding a new gRPC write endpoint rather than using the existing http `/api/v2/write` endpoint) for the following reason:

1. The CLI currently only has the gRPC endpoint url (the http url is on a different port)
2. The influxdb2 write endpoint is in terms of org and bucket ‚ I need a command in terms of databases; We don't have an http write endpoint in terms of database (yet)

I ~cargo-culted from~ took a friendly look at the management service and tried to follow the same patterns

Note this mirrors the http endpoint pretty closely and does the line protocol parsing on the server side. It would be cool to make `ReplicatedWrite` structures directly on the client, but they have embedded sequence numbers which would we would need to reassign or something.



- [x] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb_iox/blob/main/README.md).
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
