### PR TITLE
feat: Make server no longer the default command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,3 +36,6 @@ COPY --from=build /root/influxdb_iox /usr/bin/influxdb_iox
 EXPOSE 8080 8082
 
 ENTRYPOINT ["/usr/bin/influxdb_iox"]
+
+CMD ["server"]
+

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ which will create a binary in `target/debug` that you can run with:
 You can compile and run with one command by using:
 
 ```shell
-cargo run
+cargo run -- server
 ```
 
 When compiling for performance testing, build in release mode by using:
@@ -175,13 +175,13 @@ cargo build --release
 which will create the corresponding binary in `target/release`:
 
 ```shell
-./target/release/influxdb_iox
+./target/release/influxdb_iox server
 ```
 
 Similarly, you can do this in one step with:
 
 ```shell
-cargo run --release
+cargo run --release -- server
 ```
 
 The server will, by default, start an HTTP API server on port `8080` and a gRPC server on port

--- a/docker/Dockerfile.iox
+++ b/docker/Dockerfile.iox
@@ -20,3 +20,5 @@ COPY target/release/influxdb_iox /usr/bin/influxdb_iox
 EXPOSE 8080 8082
 
 ENTRYPOINT ["influxdb_iox"]
+
+CMD ["server"]

--- a/src/commands/server.rs
+++ b/src/commands/server.rs
@@ -18,7 +18,7 @@ pub const FALLBACK_AWS_REGION: &str = "us-east-1";
 #[derive(Debug, StructOpt)]
 #[structopt(
     name = "server",
-    about = "Runs in server mode (default)",
+    about = "Runs in server mode",
     long_about = "Run the IOx server.\n\nThe configuration options below can be \
     set either with the command line flags or with the specified environment \
     variable. If there is a file named '.env' in the current working directory, \

--- a/src/main.rs
+++ b/src/main.rs
@@ -87,6 +87,7 @@ struct Config {
 }
 
 #[derive(Debug, StructOpt)]
+#[structopt(setting = structopt::clap::AppSettings::SubcommandRequiredElseHelp)]
 enum Command {
     /// Convert one storage format to another
     Convert {
@@ -194,13 +195,9 @@ fn main() -> Result<(), std::io::Error> {
                 }
             }
             None => {
-                // Note don't set up basic logging here, different logging rules apply in server
-                // mode
-                let res = influxdb_ioxd::main(logging_level, None).await;
-                if let Err(e) = res {
-                    error!("Server shutdown with error: {}", e);
-                    std::process::exit(ReturnCode::Failure as _);
-                }
+                unreachable!(
+                    "SubcommandRequiredElseHelp will print help if there is no subcommand"
+                );
             }
         }
     });

--- a/tests/common/server_fixture.rs
+++ b/tests/common/server_fixture.rs
@@ -225,6 +225,7 @@ impl TestServer {
 
         let server_process = Command::cargo_bin("influxdb_iox")
             .unwrap()
+            .arg("server")
             // Can enable for debugging
             //.arg("-vv")
             .env("INFLUXDB_IOX_BIND_ADDR", &addrs.http_bind_addr)
@@ -249,6 +250,7 @@ impl TestServer {
         self.server_process.wait().unwrap();
         self.server_process = Command::cargo_bin("influxdb_iox")
             .unwrap()
+            .arg("server")
             // Can enable for debugging
             //.arg("-vv")
             .env("INFLUXDB_IOX_DB_DIR", self.dir.path())


### PR DESCRIPTION
The iox binary is both a client and a server. The user can use iox binary for all sorts of configuration tasks.
By making the iox binary itself clearly show it's such a multipurpose tool, the user can figure that out without having
to remember to read the docs (and without accidentally starting another server)
