### PR TITLE
refactor: Move end-to-end test server fixture into its own module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1502,6 +1502,7 @@ dependencies = [
  "mem_qe",
  "mutable_buffer",
  "object_store",
+ "once_cell",
  "opentelemetry",
  "opentelemetry-jaeger",
  "packers",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,6 +93,7 @@ tracing-subscriber = { version = "0.2.15", features = ["parking_lot"] }
 influxdb2_client = { path = "influxdb2_client" }
 influxdb_iox_client = { path = "influxdb_iox_client", features = ["flight"] }
 test_helpers = { path = "test_helpers" }
+once_cell = { version = "1.4.0", features = ["parking_lot"] }
 
 # Crates.io dependencies, in alphabetical order
 assert_cmd = "1.0.0"

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,0 +1,1 @@
+pub mod server_fixture;

--- a/tests/common/server_fixture.rs
+++ b/tests/common/server_fixture.rs
@@ -1,0 +1,257 @@
+use std::{fs::File, str};
+use std::{
+    num::NonZeroU32,
+    process::{Child, Command},
+};
+
+use assert_cmd::prelude::*;
+use futures::prelude::*;
+use std::time::Duration;
+use tempfile::TempDir;
+
+type Error = Box<dyn std::error::Error + Send + Sync + 'static>;
+type Result<T, E = Error> = std::result::Result<T, E>;
+
+// These port numbers are chosen to not collide with a development ioxd server
+// running locally.
+// TODO(786): allocate random free ports instead of hardcoding.
+// TODO(785): we cannot use localhost here.
+macro_rules! http_bind_addr {
+    () => {
+        "127.0.0.1:8090"
+    };
+}
+macro_rules! grpc_bind_addr {
+    () => {
+        "127.0.0.1:8092"
+    };
+}
+
+const HTTP_BIND_ADDR: &str = http_bind_addr!();
+const GRPC_BIND_ADDR: &str = grpc_bind_addr!();
+
+const HTTP_BASE: &str = concat!("http://", http_bind_addr!());
+const IOX_API_V1_BASE: &str = concat!("http://", http_bind_addr!(), "/iox/api/v1");
+pub const GRPC_URL_BASE: &str = concat!("http://", grpc_bind_addr!(), "/");
+
+pub const TOKEN: &str = "InfluxDB IOx doesn't have authentication yet";
+
+use std::sync::Arc;
+
+use once_cell::sync::OnceCell;
+use tokio::sync::Mutex;
+
+/// Represents a server that has been started and is available for
+/// testing.
+pub struct ServerFixture {
+    server: Arc<TestServer>,
+}
+
+impl ServerFixture {
+    /// Create a new server fixture and wait for it to be ready. This
+    /// is called "create" rather than new because it is async and waits
+    ///
+    /// This is currently implemented as a singleton so all tests *must*
+    /// use a new database and not interfere with the existing database.
+    pub async fn create_shared() -> Self {
+        static SERVER: OnceCell<Arc<TestServer>> = OnceCell::new();
+
+        let server = Arc::clone(SERVER.get_or_init(|| {
+            let server = TestServer::new().expect("Could start test server");
+            Arc::new(server)
+        }));
+
+        // ensure the server is ready
+        server.wait_until_ready().await;
+        ServerFixture { server }
+    }
+
+    /// Return a channel connected to the gRPC API. Panics if the
+    /// server is not yet up
+    pub async fn grpc_channel(&self) -> tonic::transport::Channel {
+        self.server
+            .grpc_channel()
+            .await
+            .expect("The server should be up")
+    }
+
+    /// Return the http base URL for the HTTP API
+    pub fn http_base(&self) -> &str {
+        self.server.http_base()
+    }
+
+    /// Return the base URL for the IOx V1 API
+    pub fn iox_api_v1_base(&self) -> &str {
+        self.server.iox_api_v1_base()
+    }
+}
+
+struct TestServer {
+    /// Is the server ready to accept connections?
+    ready: Mutex<bool>,
+
+    server_process: Child,
+
+    // The temporary directory **must** be last so that it is
+    // dropped after the database closes.
+    #[allow(dead_code)]
+    dir: TempDir,
+}
+
+impl TestServer {
+    fn new() -> Result<Self> {
+        let ready = Mutex::new(false);
+
+        let dir = test_helpers::tmp_dir().unwrap();
+        // Make a log file in the temporary dir (don't auto delete it to help debugging
+        // efforts)
+        let mut log_path = std::env::temp_dir();
+        log_path.push("server_fixture.log");
+
+        println!("****************");
+        println!("Server Logging to {:?}", log_path);
+        println!("****************");
+        let log_file = File::create(log_path).expect("Opening log file");
+
+        let stdout_log_file = log_file
+            .try_clone()
+            .expect("cloning file handle for stdout");
+        let stderr_log_file = log_file;
+
+        let server_process = Command::cargo_bin("influxdb_iox")
+            .unwrap()
+            // Can enable for debbugging
+            //.arg("-vv")
+            .env("INFLUXDB_IOX_ID", "1")
+            .env("INFLUXDB_IOX_BIND_ADDR", HTTP_BIND_ADDR)
+            .env("INFLUXDB_IOX_GRPC_BIND_ADDR", GRPC_BIND_ADDR)
+            // redirect output to log file
+            .stdout(stdout_log_file)
+            .stderr(stderr_log_file)
+            .spawn()
+            .unwrap();
+
+        Ok(Self {
+            ready,
+            dir,
+            server_process,
+        })
+    }
+
+    #[allow(dead_code)]
+    fn restart(&mut self) -> Result<()> {
+        self.server_process.kill().unwrap();
+        self.server_process.wait().unwrap();
+        self.server_process = Command::cargo_bin("influxdb_iox")
+            .unwrap()
+            // Can enable for debbugging
+            //.arg("-vv")
+            .env("INFLUXDB_IOX_DB_DIR", self.dir.path())
+            .env("INFLUXDB_IOX_ID", "1")
+            .spawn()
+            .unwrap();
+        Ok(())
+    }
+
+    async fn wait_until_ready(&self) {
+        let mut ready = self.ready.lock().await;
+        if *ready {
+            return;
+        }
+
+        // Poll the RPC and HTTP servers separately as they listen on
+        // different ports but both need to be up for the test to run
+        let try_grpc_connect = async {
+            let mut interval = tokio::time::interval(Duration::from_millis(500));
+
+            loop {
+                match self.grpc_channel().await {
+                    Ok(channel) => {
+                        println!("Successfully connected to server");
+
+                        let mut health = influxdb_iox_client::health::Client::new(channel);
+
+                        match health.check_storage().await {
+                            Ok(_) => {
+                                println!("Storage service is running");
+                                return;
+                            }
+                            Err(e) => {
+                                println!("Error checking storage service status: {}", e);
+                            }
+                        }
+                    }
+                    Err(e) => {
+                        println!("Waiting for gRPC API to be up: {}", e);
+                    }
+                }
+                interval.tick().await;
+            }
+        };
+
+        let try_http_connect = async {
+            let client = reqwest::Client::new();
+            let url = format!("{}/health", HTTP_BASE);
+            let mut interval = tokio::time::interval(Duration::from_millis(500));
+            loop {
+                match client.get(&url).send().await {
+                    Ok(resp) => {
+                        println!("Successfully got a response from HTTP: {:?}", resp);
+                        return;
+                    }
+                    Err(e) => {
+                        println!("Waiting for HTTP server to be up: {}", e);
+                    }
+                }
+                interval.tick().await;
+            }
+        };
+
+        let pair = future::join(try_http_connect, try_grpc_connect);
+
+        let capped_check = tokio::time::timeout(Duration::from_secs(3), pair);
+
+        match capped_check.await {
+            Ok(_) => println!("Server is up correctly"),
+            Err(e) => println!("WARNING: server was not ready: {}", e),
+        }
+
+        // Set the writer id, if requested (TODO if requested)
+        let channel = self.grpc_channel().await.expect("gRPC should be running");
+        let mut management_client = influxdb_iox_client::management::Client::new(channel);
+
+        let id = NonZeroU32::new(42).expect("42 is non zero, among its other properties");
+
+        management_client
+            .update_writer_id(id)
+            .await
+            .expect("set ID failed");
+
+        *ready = true;
+    }
+
+    /// Create a connection channel for the gRPR endpoing
+    async fn grpc_channel(
+        &self,
+    ) -> influxdb_iox_client::connection::Result<tonic::transport::Channel> {
+        influxdb_iox_client::connection::Builder::default()
+            .build(GRPC_URL_BASE)
+            .await
+    }
+
+    fn http_base(&self) -> &str {
+        HTTP_BASE
+    }
+
+    fn iox_api_v1_base(&self) -> &str {
+        IOX_API_V1_BASE
+    }
+}
+
+impl Drop for TestServer {
+    fn drop(&mut self) {
+        self.server_process
+            .kill()
+            .expect("Should have been able to kill the test server");
+    }
+}

--- a/tests/common/server_fixture.rs
+++ b/tests/common/server_fixture.rs
@@ -226,7 +226,7 @@ impl TestServer {
 
         match capped_check.await {
             Ok(_) => {
-                println!("Server is up correctly");
+                println!("Successfully started {}", self);
                 *ready = ServerState::Ready;
             }
             Err(e) => {

--- a/tests/end-to-end.rs
+++ b/tests/end-to-end.rs
@@ -18,15 +18,12 @@
 // - Stopping the server after all relevant tests are run
 
 use std::convert::TryInto;
-use std::process::{Child, Command};
 use std::str;
-use std::time::{Duration, SystemTime};
+use std::time::SystemTime;
 use std::u32;
 
-use assert_cmd::prelude::*;
 use futures::prelude::*;
 use prost::Message;
-use tempfile::TempDir;
 
 use data_types::{names::org_and_bucket_to_database, DatabaseName};
 use end_to_end_cases::*;
@@ -35,42 +32,19 @@ use generated_types::{
     TimestampRange,
 };
 
-// These port numbers are chosen to not collide with a development ioxd server
-// running locally.
-// TODO(786): allocate random free ports instead of hardcoding.
-// TODO(785): we cannot use localhost here.
-macro_rules! http_bind_addr {
-    () => {
-        "127.0.0.1:8090"
-    };
-}
-macro_rules! grpc_bind_addr {
-    () => {
-        "127.0.0.1:8092"
-    };
-}
-
-const HTTP_BIND_ADDR: &str = http_bind_addr!();
-const GRPC_BIND_ADDR: &str = grpc_bind_addr!();
-
-const HTTP_BASE: &str = concat!("http://", http_bind_addr!());
-const IOX_API_V1_BASE: &str = concat!("http://", http_bind_addr!(), "/iox/api/v1");
-const GRPC_URL_BASE: &str = concat!("http://", grpc_bind_addr!(), "/");
-
-const TOKEN: &str = "InfluxDB IOx doesn't have authentication yet";
-
 type Error = Box<dyn std::error::Error + Send + Sync + 'static>;
 type Result<T, E = Error> = std::result::Result<T, E>;
 
+pub mod common;
 mod end_to_end_cases;
+
+use common::server_fixture::*;
 
 #[tokio::test]
 async fn read_and_write_data() {
-    let server = TestServer::new().unwrap();
-    server.wait_until_ready().await;
+    let fixture = ServerFixture::create_shared().await;
 
-    let http_client = reqwest::Client::new();
-    let influxdb2 = influxdb2_client::Client::new(HTTP_BASE, TOKEN);
+    let influxdb2 = influxdb2_client::Client::new(fixture.http_base(), TOKEN);
     let grpc = influxdb_iox_client::connection::Builder::default()
         .build(GRPC_URL_BASE)
         .await
@@ -89,7 +63,7 @@ async fn read_and_write_data() {
         let expected_read_data = load_data(&influxdb2, &scenario).await;
         let sql_query = "select * from cpu_load_short";
 
-        read_api::test(&http_client, &scenario, sql_query, &expected_read_data).await;
+        read_api::test(&fixture, &scenario, sql_query, &expected_read_data).await;
         storage_api::test(&mut storage_client, &scenario).await;
         flight_api::test(&scenario, sql_query, &expected_read_data).await;
     }
@@ -104,7 +78,7 @@ async fn read_and_write_data() {
     .await;
     management_api::test(&mut management_client).await;
     management_cli::test(GRPC_URL_BASE).await;
-    write_api::test(grpc).await;
+    //write_api::test(grpc).await;
     write_cli::test(GRPC_URL_BASE).await;
     test_http_error_messages(&influxdb2).await.unwrap();
 }
@@ -344,119 +318,4 @@ fn substitute_nanos(ns_since_epoch: i64, lines: &[&str]) -> Vec<String> {
             line
         })
         .collect()
-}
-
-struct TestServer {
-    server_process: Child,
-
-    // The temporary directory **must** be last so that it is
-    // dropped after the database closes.
-    #[allow(dead_code)]
-    dir: TempDir,
-}
-
-impl TestServer {
-    fn new() -> Result<Self> {
-        let dir = test_helpers::tmp_dir().unwrap();
-
-        let server_process = Command::cargo_bin("influxdb_iox")
-            .unwrap()
-            // Can enable for debbugging
-            //.arg("-vv")
-            .env("INFLUXDB_IOX_ID", "1")
-            .env("INFLUXDB_IOX_BIND_ADDR", HTTP_BIND_ADDR)
-            .env("INFLUXDB_IOX_GRPC_BIND_ADDR", GRPC_BIND_ADDR)
-            .spawn()
-            .unwrap();
-
-        Ok(Self {
-            dir,
-            server_process,
-        })
-    }
-
-    #[allow(dead_code)]
-    fn restart(&mut self) -> Result<()> {
-        self.server_process.kill().unwrap();
-        self.server_process.wait().unwrap();
-        self.server_process = Command::cargo_bin("influxdb_iox")
-            .unwrap()
-            // Can enable for debbugging
-            //.arg("-vv")
-            .env("INFLUXDB_IOX_DB_DIR", self.dir.path())
-            .env("INFLUXDB_IOX_ID", "1")
-            .spawn()
-            .unwrap();
-        Ok(())
-    }
-
-    async fn wait_until_ready(&self) {
-        // Poll the RPC and HTTP servers separately as they listen on
-        // different ports but both need to be up for the test to run
-        let try_grpc_connect = async {
-            let mut interval = tokio::time::interval(Duration::from_millis(500));
-
-            loop {
-                match influxdb_iox_client::connection::Builder::default()
-                    .build(GRPC_URL_BASE)
-                    .await
-                {
-                    Ok(connection) => {
-                        println!("Successfully connected to server");
-
-                        let mut health = influxdb_iox_client::health::Client::new(connection);
-
-                        match health.check_storage().await {
-                            Ok(_) => {
-                                println!("Storage service is running");
-                                return;
-                            }
-                            Err(e) => {
-                                println!("Error checking storage service status: {}", e);
-                            }
-                        }
-                    }
-                    Err(e) => {
-                        println!("Waiting for gRPC API to be up: {}", e);
-                    }
-                }
-                interval.tick().await;
-            }
-        };
-
-        let try_http_connect = async {
-            let client = reqwest::Client::new();
-            let url = format!("{}/health", HTTP_BASE);
-            let mut interval = tokio::time::interval(Duration::from_millis(500));
-            loop {
-                match client.get(&url).send().await {
-                    Ok(resp) => {
-                        println!("Successfully got a response from HTTP: {:?}", resp);
-                        return;
-                    }
-                    Err(e) => {
-                        println!("Waiting for HTTP server to be up: {}", e);
-                    }
-                }
-                interval.tick().await;
-            }
-        };
-
-        let pair = future::join(try_http_connect, try_grpc_connect);
-
-        let capped_check = tokio::time::timeout(Duration::from_secs(3), pair);
-
-        match capped_check.await {
-            Ok(_) => println!("Server is up correctly"),
-            Err(e) => println!("WARNING: server was not ready: {}", e),
-        }
-    }
-}
-
-impl Drop for TestServer {
-    fn drop(&mut self) {
-        self.server_process
-            .kill()
-            .expect("Should have been able to kill the test server");
-    }
 }

--- a/tests/end-to-end.rs
+++ b/tests/end-to-end.rs
@@ -78,7 +78,6 @@ async fn read_and_write_data() {
     .await;
     management_api::test(&mut management_client).await;
     management_cli::test(GRPC_URL_BASE).await;
-    //write_api::test(grpc).await;
     write_cli::test(GRPC_URL_BASE).await;
     test_http_error_messages(&influxdb2).await.unwrap();
 }

--- a/tests/end_to_end_cases/write_api.rs
+++ b/tests/end_to_end_cases/write_api.rs
@@ -6,15 +6,15 @@ use test_helpers::assert_contains;
 
 use super::util::rand_name;
 
-/// Tests the basics of the write API
-pub async fn test(channel: tonic::transport::Channel) {
-    let mut management_client = management::Client::new(channel.clone());
-    let mut write_client = write::Client::new(channel);
+use crate::common::server_fixture::ServerFixture;
 
-    test_write(&mut management_client, &mut write_client).await
-}
+#[tokio::test]
+async fn test_write() {
+    // TODO sort out changing the test ID
+    let fixture = ServerFixture::create_shared().await;
+    let mut management_client = management::Client::new(fixture.grpc_channel().await);
+    let mut write_client = write::Client::new(fixture.grpc_channel().await);
 
-async fn test_write(management_client: &mut management::Client, write_client: &mut write::Client) {
     const TEST_ID: u32 = 42;
 
     let db_name = rand_name();


### PR DESCRIPTION
Re: https://github.com/influxdata/influxdb_iox/issues/890

# Rationale:

This is the first in what I hope to be a series of refactors to better manage the end to end tests. Specifically I want to be able to control and report on the tests individually as a normal rust test (each be a `#[tokio::test]`) as well as run them in parallel

If we like the pattern established in this PR, I will port the rest of the tests so they run as their own individual tests and make the harness more sophisticated (e.g. so setting writer_id doesn't trample on each other) but I didn't want to do so until I had some agreement this was what was an improvement.

# Changes:

1. Pulls the creation / setup of the server under test into a global lazily initialized fixture so that multiple tests can use it but only one server is started
2. Moves the write_api test into its own test as a demonstration of the technique working
3. Route logging to a log file into a temp file (filename printed to stdout)

Regarding logging: it would be nice to just print all the child's output to stdout but I couldn't figure that out with some quick googling and figured this would be ok for now.

# Example use:
Basic output (showing `test_write` running as its own test)
```
cargo test --test end-to-end

running 2 tests
test end_to_end_cases::write_api::test_write ... ok
test read_and_write_data ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

With more verbosity:

```
cargo test --test end-to-end -- write_api --nocapture

running 1 test
****************
Server Logging to "/var/folders/s3/h5hgj43j0bv83shtmz_t_w400000gn/T/server_fixture.log"
****************
Waiting for HTTP server to be up: error sending request for url (http://127.0.0.1:8090/health): error trying to connect: tcp connect error: Connection refused (os error 61)
Waiting for gRPC API to be up: Connection error: transport error: error trying to connect: tcp connect error: Connection refused (os error 61)
Waiting for HTTP server to be up: error sending request for url (http://127.0.0.1:8090/health): error trying to connect: tcp connect error: Connection refused (os error 61)
Waiting for gRPC API to be up: Connection error: transport error: error trying to connect: tcp connect error: Connection refused (os error 61)
Successfully connected to server
Successfully got a response from HTTP: Response { url: Url { scheme: "http", username: "", password: None, host: Some(Ipv4(127.0.0.1)), port: Some(8090), path: "/health", query: None, fragment: None }, status: 200, headers: {"x-powered-by": "Routerify v2.0.0-beta-2", "content-length": "2", "date": "Tue, 09 Mar 2021 13:12:18 GMT"} }
Storage service is running
Server is up correctly
[tests/end_to_end_cases/write_api.rs:58] err = ServerError(
    Status {
        code: InvalidArgument,
        message: "Violation for field \"lp_data\": Invalid Line Protocol: A generic parsing error occurred: TakeWhile1",
        details: b"\x08\x03\x12bViolation for field \"lp_data\": Invalid Line Protocol: A generic parsing error occurred: TakeWhile1\x1a}\n)type.googleapis.com/google.rpc.BadRequest\x12P\nN\n\x07lp_data\x12CInvalid Line Protocol: A generic parsing error occurred: TakeWhile1",
        metadata: MetadataMap {
            headers: {
                "content-type": "application/grpc",
                "date": "Tue, 09 Mar 2021 13:12:18 GMT",
            },
        },
    },
)
[tests/end_to_end_cases/write_api.rs:70] err = ServerError(
    Status {
        code: NotFound,
        message: "Resource database/Non_existent_database not found",
        details: b"\x08\x05\x121Resource database/Non_existent_database not found\x1aP\n+type.googleapis.com/google.rpc.ResourceInfo\x12!\n\x08database\x12\x15Non_existent_database",
        metadata: MetadataMap {
            headers: {
                "content-type": "application/grpc",
                "date": "Tue, 09 Mar 2021 13:12:18 GMT",
            },
        },
    },
)
test end_to_end_cases::write_api::test_write ... ok
```

```
alamb@ip-10-0-0-124 influxdb_iox2 % cat /var/folders/s3/h5hgj43j0bv83shtmz_t_w400000gn/T/server_fixture.log
cat /var/folders/s3/h5hgj43j0bv83shtmz_t_w400000gn/T/server_fixture.log
Mar 09 08:12:17.638  WARN influxdb_iox::influxdb_ioxd: NO PERSISTENCE: using Memory for object storage
Mar 09 08:12:17.639  INFO influxdb_iox::influxdb_ioxd: gRPC server listening bind_address=127.0.0.1:8092
Mar 09 08:12:17.650  INFO influxdb_iox::influxdb_ioxd: HTTP server listening bind_address=127.0.0.1:8090
Mar 09 08:12:17.650  INFO influxdb_iox::influxdb_ioxd: InfluxDB IOx server ready git_hash="8927b175f2ebe7a9e66c82551b951408ca411afc"
Mar 09 08:12:18.122  INFO influxdb_iox::influxdb_ioxd::http: Processing request request=Request { method: GET, uri: /health, version: HTTP/1.1, headers: {"accept": "*/*", "host": "127.0.0.1:8090"}, body: Body(Empty) }
Mar 09 08:12:18.122  INFO influxdb_iox::influxdb_ioxd::http: Successfully processed request response=Response { status: 200, version: HTTP/1.1, headers: {"x-powered-by": "Routerify v2.0.0-beta-2"}, body: Body(Full(b"OK")) }
```

# Notes:

I would basically plan the following next steps:
1.  Use a different server process (different ports) for testing setting writer id so that doesn't interfere with other tests
2. Port over the rest of the tests to use the fixture.


- [x] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb_iox/blob/main/README.md).
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
