### PR TITLE
refactor: rework all end-to-end.rs tests to use the server fixture rather than const connection strings

### DIFF
--- a/tests/end_to_end_cases/flight_api.rs
+++ b/tests/end_to_end_cases/flight_api.rs
@@ -1,11 +1,14 @@
-use crate::{Scenario, GRPC_URL_BASE};
+use crate::{common::server_fixture::ServerFixture, Scenario};
 use arrow_deps::assert_table_eq;
-use influxdb_iox_client::{connection::Builder, flight::Client};
+use influxdb_iox_client::flight::Client;
 
-pub async fn test(scenario: &Scenario, sql_query: &str, expected_read_data: &[String]) {
-    let connection = Builder::default().build(GRPC_URL_BASE).await.unwrap();
-
-    let mut client = Client::new(connection);
+pub async fn test(
+    server_fixture: &ServerFixture,
+    scenario: &Scenario,
+    sql_query: &str,
+    expected_read_data: &[String],
+) {
+    let mut client = Client::new(server_fixture.grpc_channel());
 
     let mut query_results = client
         .perform_query(scenario.database_name(), sql_query)

--- a/tests/end_to_end_cases/management_cli.rs
+++ b/tests/end_to_end_cases/management_cli.rs
@@ -1,9 +1,13 @@
 use assert_cmd::Command;
 use predicates::prelude::*;
 
-pub async fn test(addr: impl AsRef<str>) {
-    test_writer_id(addr.as_ref()).await;
-    test_create_database(addr.as_ref()).await;
+use crate::common::server_fixture::ServerFixture;
+
+pub async fn test(server_fixture: &ServerFixture) {
+    let addr = server_fixture.grpc_url_base();
+
+    test_writer_id(addr).await;
+    test_create_database(addr).await;
 }
 
 async fn test_writer_id(addr: &str) {

--- a/tests/end_to_end_cases/write_api.rs
+++ b/tests/end_to_end_cases/write_api.rs
@@ -12,8 +12,8 @@ use crate::common::server_fixture::ServerFixture;
 async fn test_write() {
     // TODO sort out changing the test ID
     let fixture = ServerFixture::create_shared().await;
-    let mut management_client = management::Client::new(fixture.grpc_channel().await);
-    let mut write_client = write::Client::new(fixture.grpc_channel().await);
+    let mut management_client = management::Client::new(fixture.grpc_channel());
+    let mut write_client = write::Client::new(fixture.grpc_channel());
 
     const TEST_ID: u32 = 42;
 

--- a/tests/end_to_end_cases/write_cli.rs
+++ b/tests/end_to_end_cases/write_cli.rs
@@ -2,11 +2,13 @@ use assert_cmd::Command;
 use predicates::prelude::*;
 use test_helpers::make_temp_file;
 
+use crate::common::server_fixture::ServerFixture;
+
 use super::util::rand_name;
 
-pub async fn test(addr: impl AsRef<str>) {
+pub async fn test(server_fixture: &ServerFixture) {
     let db_name = rand_name();
-    let addr = addr.as_ref();
+    let addr = server_fixture.grpc_url_base();
     create_database(&db_name, addr).await;
     test_write(&db_name, addr).await;
 }


### PR DESCRIPTION
Re: https://github.com/influxdata/influxdb_iox/issues/890, built on https://github.com/influxdata/influxdb_iox/pull/945

# Rationale:

I plan to be able to run some of these tests against different servers on different ports, so I want them to rely on the ServerFixture not a constant.

# Changes

This moves tests that change database wide stuff (like writer id) to use their own server process so they don't potentially clobber other tests that are running in parallel

# Work plan
- [x] Introduce fixture: https://github.com/influxdata/influxdb_iox/pull/945
- [x] Use only fixture: This PR
- [ ] Port tests that modify global state to their own fixture
- [ ] Port all remaining tests to run in parallel with shared fixture

Other:

- [x] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb_iox/blob/main/README.md).
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
