### PR TITLE
refactor: Port end-to-end tests that modify global state to their own fixture

### DIFF
--- a/tests/common/server_fixture.rs
+++ b/tests/common/server_fixture.rs
@@ -3,10 +3,7 @@ use std::{
     str,
     sync::atomic::{AtomicUsize, Ordering::SeqCst},
 };
-use std::{
-    num::NonZeroU32,
-    process::{Child, Command},
-};
+use std::{num::NonZeroU32, process::Child};
 
 use crate::common::no_orphan_cargo::cargo_bin;
 use futures::prelude::*;

--- a/tests/end_to_end_cases/management_api.rs
+++ b/tests/end_to_end_cases/management_api.rs
@@ -4,15 +4,21 @@ use generated_types::google::protobuf::Empty;
 use generated_types::{google::protobuf::Duration, influxdata::iox::management::v1::*};
 use influxdb_iox_client::management::{Client, CreateDatabaseError};
 
+use crate::common::server_fixture::ServerFixture;
+
 use super::util::rand_name;
 
-pub async fn test(client: &mut Client) {
-    test_list_update_remotes(client).await;
-    test_set_get_writer_id(client).await;
-    test_create_database_duplicate_name(client).await;
-    test_create_database_invalid_name(client).await;
-    test_list_databases(client).await;
-    test_create_get_database(client).await;
+#[tokio::test]
+pub async fn test() {
+    let server_fixture = ServerFixture::create_single_use().await;
+    let mut client = Client::new(server_fixture.grpc_channel());
+
+    test_list_update_remotes(&mut client).await;
+    test_set_get_writer_id(&mut client).await;
+    test_create_database_duplicate_name(&mut client).await;
+    test_create_database_invalid_name(&mut client).await;
+    test_list_databases(&mut client).await;
+    test_create_get_database(&mut client).await;
 }
 
 async fn test_list_update_remotes(client: &mut Client) {

--- a/tests/end_to_end_cases/management_cli.rs
+++ b/tests/end_to_end_cases/management_cli.rs
@@ -3,7 +3,9 @@ use predicates::prelude::*;
 
 use crate::common::server_fixture::ServerFixture;
 
-pub async fn test(server_fixture: &ServerFixture) {
+#[tokio::test]
+pub async fn test() {
+    let server_fixture = ServerFixture::create_single_use().await;
     let addr = server_fixture.grpc_base();
 
     test_writer_id(addr).await;

--- a/tests/end_to_end_cases/management_cli.rs
+++ b/tests/end_to_end_cases/management_cli.rs
@@ -4,7 +4,7 @@ use predicates::prelude::*;
 use crate::common::server_fixture::ServerFixture;
 
 pub async fn test(server_fixture: &ServerFixture) {
-    let addr = server_fixture.grpc_url_base();
+    let addr = server_fixture.grpc_base();
 
     test_writer_id(addr).await;
     test_create_database(addr).await;

--- a/tests/end_to_end_cases/read_cli.rs
+++ b/tests/end_to_end_cases/read_cli.rs
@@ -6,9 +6,12 @@ use crate::common::server_fixture::ServerFixture;
 
 use super::util::rand_name;
 
-pub async fn test(server_fixture: &ServerFixture) {
+#[tokio::test]
+pub async fn test() {
+    let server_fixture = ServerFixture::create_single_use().await;
     let db_name = rand_name();
-    let addr = server_fixture.grpc_url_base();
+    let addr = server_fixture.grpc_base();
+
     create_database(&db_name, addr).await;
     test_read_default(&db_name, addr).await;
     test_read_format_pretty(&db_name, addr).await;

--- a/tests/end_to_end_cases/write_api.rs
+++ b/tests/end_to_end_cases/write_api.rs
@@ -1,5 +1,3 @@
-use std::num::NonZeroU32;
-
 use influxdb_iox_client::management::{self, generated_types::DatabaseRules};
 use influxdb_iox_client::write::{self, WriteError};
 use test_helpers::assert_contains;
@@ -10,12 +8,9 @@ use crate::common::server_fixture::ServerFixture;
 
 #[tokio::test]
 async fn test_write() {
-    // TODO sort out changing the test ID
     let fixture = ServerFixture::create_shared().await;
     let mut management_client = management::Client::new(fixture.grpc_channel());
     let mut write_client = write::Client::new(fixture.grpc_channel());
-
-    const TEST_ID: u32 = 42;
 
     let db_name = rand_name();
 
@@ -26,11 +21,6 @@ async fn test_write() {
         })
         .await
         .expect("create database failed");
-
-    management_client
-        .update_writer_id(NonZeroU32::new(TEST_ID).unwrap())
-        .await
-        .expect("set ID failed");
 
     let lp_lines = vec![
         "cpu,region=west user=23.2 100",

--- a/tests/end_to_end_cases/write_cli.rs
+++ b/tests/end_to_end_cases/write_cli.rs
@@ -8,7 +8,7 @@ use super::util::rand_name;
 
 pub async fn test(server_fixture: &ServerFixture) {
     let db_name = rand_name();
-    let addr = server_fixture.grpc_url_base();
+    let addr = server_fixture.grpc_base();
     create_database(&db_name, addr).await;
     test_write(&db_name, addr).await;
 }

--- a/tests/end_to_end_cases/write_cli.rs
+++ b/tests/end_to_end_cases/write_cli.rs
@@ -6,7 +6,9 @@ use crate::common::server_fixture::ServerFixture;
 
 use super::util::rand_name;
 
-pub async fn test(server_fixture: &ServerFixture) {
+#[tokio::test]
+async fn test() {
+    let server_fixture = ServerFixture::create_shared().await;
     let db_name = rand_name();
     let addr = server_fixture.grpc_base();
     create_database(&db_name, addr).await;


### PR DESCRIPTION
Re: https://github.com/influxdata/influxdb_iox/issues/890

# Rationale:

Some of these tests were changing writer id (which is shared across tests) and thus shouldn't be run in parallel.

# Changes

Add a way to start up independent servers (on their own ports) and make such non-shared servers for tests that manipulate the writer id

# Work plan
- [x] Introduce fixture: https://github.com/influxdata/influxdb_iox/pull/945
- [x] Use only fixture: https://github.com/influxdata/influxdb_iox/pull/948
- [x] Port tests that modify global state to their own fixture: this PR
- [ ] Port all remaining tests to run in parallel with shared fixture

# Example output

The end-to-end.rs test is starting to look legit:
```
cargo test --test end-to-end
...
test test_http_error_messages ... ok
test end_to_end_cases::write_api::test_write ... ok
test end_to_end_cases::management_api::test ... ok
test end_to_end_cases::write_cli::test ... ok
test end_to_end_cases::management_cli::test ... ok
test read_and_write_data ... ok
```


