### PR TITLE
fix: Do not leave child processes around after the end-to-end tes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1507,6 +1507,7 @@ dependencies = [
  "opentelemetry-jaeger",
  "packers",
  "panic_logging",
+ "parking_lot",
  "predicates",
  "prost",
  "query",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,6 +94,7 @@ influxdb2_client = { path = "influxdb2_client" }
 influxdb_iox_client = { path = "influxdb_iox_client", features = ["flight"] }
 test_helpers = { path = "test_helpers" }
 once_cell = { version = "1.4.0", features = ["parking_lot"] }
+parking_lot = "0.11.1"
 
 # Crates.io dependencies, in alphabetical order
 assert_cmd = "1.0.0"


### PR DESCRIPTION
Closes https://github.com/influxdata/influxdb_iox/issues/951, built on https://github.com/influxdata/influxdb_iox/pull/949

# Rationale
In https://github.com/influxdata/influxdb_iox/pull/945 I introduced a (global static) fixture that ran the `influxdb_iox` binary as a process. In the process I introduced a bug where that child process is never terminated: https://github.com/influxdata/influxdb_iox/issues/951

# Changes
The fix is to hold a "weak" reference to the shared fixtured rather than a "strong" one. This means that once a test has started using the shared fixture, and other test that is started at the same time will share it. However, when the last test is done, the descructor will be torn down.

# Testing:

Prior to this PR a child process is left:
```
alamb@ip-10-0-0-124 influxdb_iox2 % cargo test --test end-to-end 
cargo test --test end-to-end 
   Compiling influxdb_iox v0.1.0 (/Users/alamb/Software/influxdb_iox2)
ps -ef | grep iox
ps -ef | grep iox
    Finished test [unoptimized + debuginfo] target(s) in 26.70s
     Running target/debug/deps/end_to_end-6e00d2357c56a816

running 6 tests
test test_http_error_messages ... ok
test end_to_end_cases::write_api::test_write ... ok
test end_to_end_cases::management_api::test ... ok
test end_to_end_cases::write_cli::test ... ok
test end_to_end_cases::management_cli::test ... ok
test read_and_write_data ... ok

test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

alamb@ip-10-0-0-124 influxdb_iox2 % ps -ef | grep iox
  501 27999     1   0  6:00AM ttys003    0:00.15 /Users/alamb/Software/influxdb_iox2/target/debug/influxdb_iox
  501 28010 49435   0  6:00AM ttys003    0:00.00 grep iox
```

With the code in this PR, running the same commands does not show any errant processes:
```
alamb@ip-10-0-0-124 influxdb_iox2 % cargo test --test end-to-end 
cargo test --test end-to-end 
    Finished test [unoptimized + debuginfo] target(s) in 0.44s
     Running target/debug/deps/end_to_end-9ce990e743cafa59

running 6 tests
test test_http_error_messages ... ok
test end_to_end_cases::write_api::test_write ... ok
test end_to_end_cases::management_api::test ... ok
test end_to_end_cases::write_cli::test ... ok
test read_and_write_data ... ok
test end_to_end_cases::management_cli::test ... ok

test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

alamb@ip-10-0-0-124 influxdb_iox2 % ps -ef | grep iox
ps -ef | grep iox
  501 38177 49435   0  6:41AM ttys003    0:00.00 grep iox
alamb@ip-10-0-0-124 influxdb_iox2 % 
```

