### PR TITLE
feat: add fanout task tracking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3195,6 +3195,7 @@ dependencies = [
  "flatbuffers 0.6.1",
  "futures",
  "generated_types",
+ "hashbrown",
  "influxdb_line_protocol",
  "mutable_buffer",
  "object_store",
@@ -3208,6 +3209,7 @@ dependencies = [
  "snap",
  "test_helpers",
  "tokio",
+ "tokio-util",
  "tracing",
  "uuid",
 ]

--- a/data_types/src/job.rs
+++ b/data_types/src/job.rs
@@ -1,0 +1,24 @@
+use generated_types::influxdata::iox::management::v1 as management;
+
+/// Metadata associated with a set of background tasks
+/// Used in combination with TrackerRegistry
+#[derive(Debug, Clone)]
+pub enum Job {
+    PersistSegment { writer_id: u32, segment_id: u64 },
+    Dummy { nanos: Vec<u64> },
+}
+
+impl From<Job> for management::operation_metadata::Job {
+    fn from(job: Job) -> Self {
+        match job {
+            Job::PersistSegment {
+                writer_id,
+                segment_id,
+            } => Self::PersistSegment(management::PersistSegment {
+                writer_id,
+                segment_id,
+            }),
+            Job::Dummy { nanos } => Self::Dummy(management::Dummy { nanos }),
+        }
+    }
+}

--- a/data_types/src/lib.rs
+++ b/data_types/src/lib.rs
@@ -10,6 +10,7 @@
     clippy::clone_on_ref_ptr
 )]
 
+pub use database_name::*;
 pub use schema::TIME_COLUMN_NAME;
 
 /// The name of the column containing table names returned by a call to
@@ -24,6 +25,7 @@ pub mod data;
 pub mod database_rules;
 pub mod error;
 pub mod http;
+pub mod job;
 pub mod names;
 pub mod partition_metadata;
 pub mod schema;
@@ -32,6 +34,4 @@ pub mod timestamp;
 pub mod wal;
 
 mod database_name;
-pub use database_name::*;
-
 pub(crate) mod field_validation;

--- a/generated_types/build.rs
+++ b/generated_types/build.rs
@@ -40,6 +40,7 @@ fn generate_grpc_types(root: &Path) -> Result<()> {
         management_path.join("base_types.proto"),
         management_path.join("database_rules.proto"),
         management_path.join("service.proto"),
+        management_path.join("jobs.proto"),
         write_path.join("service.proto"),
         root.join("grpc/health/v1/service.proto"),
         root.join("google/longrunning/operations.proto"),

--- a/generated_types/protos/influxdata/iox/management/v1/jobs.proto
+++ b/generated_types/protos/influxdata/iox/management/v1/jobs.proto
@@ -1,0 +1,23 @@
+syntax = "proto3";
+package influxdata.iox.management.v1;
+
+message OperationMetadata {
+  uint64 cpu_nanos = 1;
+  uint64 wall_nanos = 2;
+  uint64 task_count = 3;
+  uint64 pending_count = 4;
+
+  oneof job {
+    Dummy dummy = 5;
+    PersistSegment persist_segment = 6;
+  }
+}
+
+message PersistSegment {
+  uint32 writer_id = 1;
+  uint64 segment_id = 2;
+}
+
+message Dummy {
+  repeated uint64 nanos = 1;
+}

--- a/generated_types/protos/influxdata/iox/management/v1/service.proto
+++ b/generated_types/protos/influxdata/iox/management/v1/service.proto
@@ -1,7 +1,7 @@
 syntax = "proto3";
 package influxdata.iox.management.v1;
 
-import "google/protobuf/empty.proto";
+import "google/longrunning/operations.proto";
 import "influxdata/iox/management/v1/database_rules.proto";
 
 service ManagementService {
@@ -23,6 +23,15 @@ service ManagementService {
 
   // Delete a reference to remote IOx server.
   rpc DeleteRemote(DeleteRemoteRequest) returns (DeleteRemoteResponse);
+
+  // Creates a dummy job that for each value of the nanos field
+  // spawns a task that sleeps for that number of nanoseconds before returning
+  rpc CreateDummyJob(CreateDummyJobRequest) returns (CreateDummyJobResponse) {
+    option (google.longrunning.operation_info) = {
+      response_type: "google.protobuf.Empty"
+      metadata_type: "OperationMetadata"
+    };
+  }
 }
 
 message GetWriterIdRequest {}
@@ -56,6 +65,14 @@ message CreateDatabaseRequest {
 }
 
 message CreateDatabaseResponse {}
+
+message CreateDummyJobRequest {
+  repeated uint64 nanos = 1;
+}
+
+message CreateDummyJobResponse {
+  google.longrunning.Operation operation = 1;
+}
 
 message ListRemotesRequest {}
 

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -14,6 +14,7 @@ data_types = { path = "../data_types" }
 flatbuffers = "0.6"
 futures = "0.3.7"
 generated_types = { path = "../generated_types" }
+hashbrown = "0.9.1"
 influxdb_line_protocol = { path = "../influxdb_line_protocol" }
 mutable_buffer = { path = "../mutable_buffer" }
 object_store = { path = "../object_store" }
@@ -26,6 +27,7 @@ serde_json = "1.0"
 snafu = "0.6"
 snap = "1.0.0"
 tokio = { version = "1.0", features = ["macros", "time"] }
+tokio-util = { version = "0.6.3" }
 tracing = "0.1"
 uuid = { version = "0.8", features = ["serde", "v4"] }
 

--- a/server/src/tracker.rs
+++ b/server/src/tracker.rs
@@ -1,241 +1,592 @@
-use std::collections::HashMap;
-use std::future::Future;
-use std::pin::Pin;
+//! This module contains a future tracking system supporting fanout,
+//! cancellation and asynchronous signalling of completion
+//!
+//! A Tracker is created by calling TrackerRegistry::register. TrackedFutures
+//! can then be associated with this Tracker and monitored and/or cancelled.
+//!
+//! This is used within IOx to track futures spawned as multiple tokio tasks.
+//!
+//! For example, when migrating a chunk from the mutable buffer to the read
+//! buffer:
+//!
+//! - There is a single over-arching Job being performed
+//! - A single tracker is allocated from a TrackerRegistry in Server and
+//!   associated with the Job metadata
+//! - This tracker is registered with every future that is spawned as a tokio
+//!   task
+//!
+//! This same system may in future form part of a query tracking story
+//!
+//! # Correctness
+//!
+//! The key correctness property of the Tracker system is Tracker::is_complete
+//! only returns true when all futures associated with the tracker have
+//! completed and no more can be spawned. Additionally at such a point
+//! all metrics - cpu_nanos, wall_nanos, created_futures should be visible
+//! to the calling thread
+//!
+//! Note: there is no guarantee that pending_registrations or pending_futures
+//! ever reaches 0, a program could call mem::forget on a TrackerRegistration,
+//! leak the TrackerRegistration, spawn a future that never finishes, etc...
+//! Such a program would never consider the Tracker complete and therefore this
+//! doesn't violate the correctness property
+//!
+//! ## Proof
+//!
+//! 1. pending_registrations starts at 1, and is incremented on
+//! TrackerRegistration::clone. A TrackerRegistration cannot be created from an
+//! existing TrackerState, only another TrackerRegistration
+//!
+//! 2. pending_registrations is decremented with release semantics on
+//! TrackerRegistration::drop
+//!
+//! 3. pending_futures is only incremented with a TrackerRegistration in scope
+//!
+//! 4. 2. + 3. -> A thread that increments pending_futures, decrements
+//! pending_registrations with release semantics afterwards. By definition of
+//! release semantics these writes to pending_futures cannot be reordered to
+//! come after the atomic decrement of pending_registrations
+//!
+//! 5. 1. + 2. + drop cannot be called multiple times on the same object -> once
+//! pending_registrations is decremented to 0 it can never be incremented again
+//!
+//! 6. 4. + 5. -> the decrement to 0 of pending_registrations must commit after
+//! the last increment of pending_futures
+//!
+//! 7. pending_registrations is loaded with acquire semantics
+//!
+//! 8. By definition of acquire semantics, any thread that reads
+//! pending_registrations is guaranteed to see any increments to pending_futures
+//! performed before the most recent decrement of pending_registrations
+//!
+//! 9. 6. + 8. -> A thread that observes a pending_registrations of 0 cannot
+//! subsequently observe pending_futures to increase
+//!
+//! 10. Tracker::is_complete returns if it observes pending_registrations to be
+//! 0 and then pending_futures to be 0
+//!
+//! 11. 9 + 10 -> A thread can only observe Tracker::is_complete() == true
+//! after all futures have been dropped and no more can be created
+//!
+//! 12. pending_futures is decremented with Release semantics on
+//! TrackedFuture::drop after any associated metrics have been incremented
+//!
+//! 13. pending_futures is loaded with acquire semantics
+//!
+//! 14. 12. + 13. -> A thread that observes a pending_futures of 0 is guaranteed
+//! to see any metrics from any dropped TrackedFuture
+//!
+//! Note: this proof ignores the complexity of moving Trackers, TrackedFutures,
+//! etc... between threads as any such functionality must perform the necessary
+//! synchronisation to be well-formed.
+
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
-use std::task::{Context, Poll};
+use std::time::Instant;
 
-use futures::prelude::*;
-use parking_lot::Mutex;
-use pin_project::{pin_project, pinned_drop};
+use tokio_util::sync::CancellationToken;
+use tracing::warn;
 
-/// Every future registered with a `TrackerRegistry` is assigned a unique
-/// `TrackerId`
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-pub struct TrackerId(usize);
+pub use future::{TrackedFuture, TrackedFutureExt};
+pub use registry::{TrackerId, TrackerRegistry};
 
+mod future;
+mod registry;
+
+/// The state shared between all sibling tasks
 #[derive(Debug)]
-struct Tracker<T> {
-    data: T,
-    abort: future::AbortHandle,
+struct TrackerState {
+    start_instant: Instant,
+    cancel_token: CancellationToken,
+    cpu_nanos: AtomicUsize,
+    wall_nanos: AtomicUsize,
+
+    created_futures: AtomicUsize,
+    pending_futures: AtomicUsize,
+    pending_registrations: AtomicUsize,
+
+    watch: tokio::sync::watch::Receiver<bool>,
 }
 
+/// A Tracker can be used to monitor/cancel/wait for a set of associated futures
 #[derive(Debug)]
-struct TrackerContextInner<T> {
-    id: AtomicUsize,
-    trackers: Mutex<HashMap<TrackerId, Tracker<T>>>,
+pub struct Tracker<T> {
+    id: TrackerId,
+    state: Arc<TrackerState>,
+    metadata: Arc<T>,
 }
 
-/// Allows tracking the lifecycle of futures registered by
-/// `TrackedFutureExt::track` with an accompanying metadata payload of type T
-///
-/// Additionally can trigger graceful termination of registered futures
-#[derive(Debug)]
-pub struct TrackerRegistry<T> {
-    inner: Arc<TrackerContextInner<T>>,
-}
-
-// Manual Clone to workaround https://github.com/rust-lang/rust/issues/26925
-impl<T> Clone for TrackerRegistry<T> {
+impl<T> Clone for Tracker<T> {
     fn clone(&self) -> Self {
         Self {
-            inner: Arc::clone(&self.inner),
+            id: self.id,
+            state: Arc::clone(&self.state),
+            metadata: Arc::clone(&self.metadata),
         }
     }
 }
 
-impl<T> Default for TrackerRegistry<T> {
-    fn default() -> Self {
-        Self {
-            inner: Arc::new(TrackerContextInner {
-                id: AtomicUsize::new(0),
-                trackers: Mutex::new(Default::default()),
-            }),
-        }
-    }
-}
-
-impl<T> TrackerRegistry<T> {
-    pub fn new() -> Self {
-        Default::default()
+impl<T> Tracker<T> {
+    /// Returns the ID of the Tracker - these are unique per TrackerRegistry
+    pub fn id(&self) -> TrackerId {
+        self.id
     }
 
-    /// Trigger graceful termination of a registered future
-    ///
-    /// Returns false if no future found with the provided ID
+    /// Returns a reference to the metadata stored within this Tracker
+    pub fn metadata(&self) -> &T {
+        &self.metadata
+    }
+
+    /// Trigger graceful termination of any futures tracked by
+    /// this tracker
     ///
     /// Note: If the future is currently executing, termination
     /// will only occur when the future yields (returns from poll)
-    #[allow(dead_code)]
-    pub fn terminate(&self, id: TrackerId) -> bool {
-        if let Some(meta) = self.inner.trackers.lock().get_mut(&id) {
-            meta.abort.abort();
-            true
-        } else {
-            false
+    /// and is then scheduled to run again
+    pub fn cancel(&self) {
+        self.state.cancel_token.cancel();
+    }
+
+    /// Returns the number of outstanding futures
+    pub fn pending_futures(&self) -> usize {
+        self.state.pending_futures.load(Ordering::Relaxed)
+    }
+
+    /// Returns the number of TrackedFutures created with this Tracker
+    pub fn created_futures(&self) -> usize {
+        self.state.created_futures.load(Ordering::Relaxed)
+    }
+
+    /// Returns the number of nanoseconds futures tracked by this
+    /// tracker have spent executing
+    pub fn cpu_nanos(&self) -> usize {
+        self.state.cpu_nanos.load(Ordering::Relaxed)
+    }
+
+    /// Returns the number of nanoseconds since the Tracker was registered
+    /// to the time the last TrackedFuture was dropped
+    ///
+    /// Returns 0 if there are still pending tasks
+    pub fn wall_nanos(&self) -> usize {
+        if !self.is_complete() {
+            return 0;
+        }
+        self.state.wall_nanos.load(Ordering::Relaxed)
+    }
+
+    /// Returns true if all futures associated with this tracker have
+    /// been dropped and no more can be created
+    pub fn is_complete(&self) -> bool {
+        // The atomic decrement in TrackerRegistration::drop has release semantics
+        // acquire here ensures that if a thread observes the tracker to have
+        // no pending_registrations it cannot subsequently observe pending_futures
+        // to increase. If it could, observing pending_futures==0 would be insufficient
+        // to conclude there are no outstanding futures
+        let pending_registrations = self.state.pending_registrations.load(Ordering::Acquire);
+
+        // The atomic decrement in TrackedFuture::drop has release semantics
+        // acquire therefore ensures that if a thread observes the completion of
+        // a TrackedFuture, it is guaranteed to see its updates (e.g. wall_nanos)
+        let pending_futures = self.state.pending_futures.load(Ordering::Acquire);
+
+        pending_registrations == 0 && pending_futures == 0
+    }
+
+    /// Returns if this tracker has been cancelled
+    pub fn is_cancelled(&self) -> bool {
+        self.state.cancel_token.is_cancelled()
+    }
+
+    /// Blocks until all futures associated with the tracker have been
+    /// dropped and no more can be created
+    pub async fn join(&self) {
+        let mut watch = self.state.watch.clone();
+
+        // Wait until watch is set to true or the tx side is dropped
+        while !*watch.borrow() {
+            if watch.changed().await.is_err() {
+                // tx side has been dropped
+                warn!("tracker watch dropped without signalling");
+                break;
+            }
         }
     }
-
-    fn untrack(&self, id: &TrackerId) {
-        self.inner.trackers.lock().remove(id);
-    }
-
-    fn track(&self, metadata: T) -> (TrackerId, future::AbortRegistration) {
-        let id = TrackerId(self.inner.id.fetch_add(1, Ordering::Relaxed));
-        let (abort_handle, abort_registration) = future::AbortHandle::new_pair();
-
-        self.inner.trackers.lock().insert(
-            id,
-            Tracker {
-                abort: abort_handle,
-                data: metadata,
-            },
-        );
-
-        (id, abort_registration)
-    }
 }
 
-impl<T: Clone> TrackerRegistry<T> {
-    /// Returns a list of tracked futures, with their accompanying IDs and
-    /// metadata
-    #[allow(dead_code)]
-    pub fn tracked(&self) -> Vec<(TrackerId, T)> {
-        // TODO: Improve this - (#711)
-        self.inner
-            .trackers
-            .lock()
-            .iter()
-            .map(|(id, value)| (*id, value.data.clone()))
-            .collect()
-    }
+/// A TrackerRegistration is returned by TrackerRegistry::register and can be
+/// used to register new TrackedFutures
+///
+/// A tracker will not be considered completed until all TrackerRegistrations
+/// referencing it have been dropped. This is to prevent a race where further
+/// TrackedFutures are registered with a Tracker that has already signalled
+/// completion
+#[derive(Debug)]
+pub struct TrackerRegistration {
+    state: Arc<TrackerState>,
 }
 
-/// An extension trait that provides `self.track(reg, {})` allowing
-/// registering this future with a `TrackerRegistry`
-pub trait TrackedFutureExt: Future {
-    fn track<T>(self, reg: &TrackerRegistry<T>, metadata: T) -> TrackedFuture<Self, T>
-    where
-        Self: Sized,
-    {
-        let (id, registration) = reg.track(metadata);
+impl Clone for TrackerRegistration {
+    fn clone(&self) -> Self {
+        self.state
+            .pending_registrations
+            .fetch_add(1, Ordering::Relaxed);
 
-        TrackedFuture {
-            inner: future::Abortable::new(self, registration),
-            reg: reg.clone(),
-            id,
+        Self {
+            state: Arc::clone(&self.state),
         }
     }
 }
 
-impl<T: ?Sized> TrackedFutureExt for T where T: Future {}
+impl TrackerRegistration {
+    fn new(watch: tokio::sync::watch::Receiver<bool>) -> Self {
+        let state = Arc::new(TrackerState {
+            start_instant: Instant::now(),
+            cpu_nanos: AtomicUsize::new(0),
+            wall_nanos: AtomicUsize::new(0),
+            cancel_token: CancellationToken::new(),
+            created_futures: AtomicUsize::new(0),
+            pending_futures: AtomicUsize::new(0),
+            pending_registrations: AtomicUsize::new(1),
+            watch,
+        });
 
-/// The `Future` returned by `TrackedFutureExt::track()`
-/// Unregisters the future from the registered `TrackerRegistry` on drop
-/// and provides the early termination functionality used by
-/// `TrackerRegistry::terminate`
-#[pin_project(PinnedDrop)]
-pub struct TrackedFuture<F: Future, T> {
-    #[pin]
-    inner: future::Abortable<F>,
-
-    reg: TrackerRegistry<T>,
-    id: TrackerId,
-}
-
-impl<F: Future, T> Future for TrackedFuture<F, T> {
-    type Output = Result<F::Output, future::Aborted>;
-
-    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        self.project().inner.poll(cx)
+        Self { state }
     }
 }
 
-#[pinned_drop]
-impl<F: Future, T> PinnedDrop for TrackedFuture<F, T> {
-    fn drop(self: Pin<&mut Self>) {
-        // Note: This could cause a double-panic in an extreme situation where
-        // the internal `TrackerRegistry` lock is poisoned and drop was
-        // called as part of unwinding the stack to handle another panic
-        let this = self.project();
-        this.reg.untrack(this.id)
+impl Drop for TrackerRegistration {
+    fn drop(&mut self) {
+        let previous = self
+            .state
+            .pending_registrations
+            .fetch_sub(1, Ordering::Release);
+        assert_ne!(previous, 0);
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use std::time::Duration;
+
     use super::*;
     use tokio::sync::oneshot;
 
     #[tokio::test]
     async fn test_lifecycle() {
         let (sender, receive) = oneshot::channel();
-        let reg = TrackerRegistry::new();
+        let registry = TrackerRegistry::new();
+        let (_, registration) = registry.register(());
 
-        let task = tokio::spawn(receive.track(&reg, ()));
+        let task = tokio::spawn(receive.track(registration));
 
-        assert_eq!(reg.tracked().len(), 1);
+        assert_eq!(registry.running().len(), 1);
 
         sender.send(()).unwrap();
         task.await.unwrap().unwrap().unwrap();
 
-        assert_eq!(reg.tracked().len(), 0);
+        assert_eq!(registry.running().len(), 0);
     }
 
     #[tokio::test]
     async fn test_interleaved() {
         let (sender1, receive1) = oneshot::channel();
         let (sender2, receive2) = oneshot::channel();
-        let reg = TrackerRegistry::new();
+        let registry = TrackerRegistry::new();
+        let (_, registration1) = registry.register(1);
+        let (_, registration2) = registry.register(2);
 
-        let task1 = tokio::spawn(receive1.track(&reg, 1));
-        let task2 = tokio::spawn(receive2.track(&reg, 2));
+        let task1 = tokio::spawn(receive1.track(registration1));
+        let task2 = tokio::spawn(receive2.track(registration2));
 
-        let mut tracked: Vec<_> = reg.tracked().iter().map(|x| x.1).collect();
-        tracked.sort_unstable();
-        assert_eq!(tracked, vec![1, 2]);
+        let tracked = sorted(registry.running());
+        assert_eq!(get_metadata(&tracked), vec![1, 2]);
 
         sender2.send(()).unwrap();
         task2.await.unwrap().unwrap().unwrap();
 
-        let tracked: Vec<_> = reg.tracked().iter().map(|x| x.1).collect();
-        assert_eq!(tracked, vec![1]);
+        let tracked: Vec<_> = sorted(registry.running());
+        assert_eq!(get_metadata(&tracked), vec![1]);
 
         sender1.send(42).unwrap();
         let ret = task1.await.unwrap().unwrap().unwrap();
 
         assert_eq!(ret, 42);
-        assert_eq!(reg.tracked().len(), 0);
+        assert_eq!(registry.running().len(), 0);
     }
 
     #[tokio::test]
     async fn test_drop() {
-        let reg = TrackerRegistry::new();
+        let registry = TrackerRegistry::new();
+        let (_, registration) = registry.register(());
 
         {
-            let f = futures::future::pending::<()>().track(&reg, ());
+            let f = futures::future::pending::<()>().track(registration);
 
-            assert_eq!(reg.tracked().len(), 1);
+            assert_eq!(registry.running().len(), 1);
 
             std::mem::drop(f);
         }
 
-        assert_eq!(reg.tracked().len(), 0);
+        assert_eq!(registry.running().len(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_drop_multiple() {
+        let registry = TrackerRegistry::new();
+        let (_, registration) = registry.register(());
+
+        {
+            let f = futures::future::pending::<()>().track(registration.clone());
+            {
+                let f = futures::future::pending::<()>().track(registration);
+                assert_eq!(registry.running().len(), 1);
+                std::mem::drop(f);
+            }
+            assert_eq!(registry.running().len(), 1);
+            std::mem::drop(f);
+        }
+
+        assert_eq!(registry.running().len(), 0);
     }
 
     #[tokio::test]
     async fn test_terminate() {
-        let reg = TrackerRegistry::new();
+        let registry = TrackerRegistry::new();
+        let (_, registration) = registry.register(());
 
-        let task = tokio::spawn(futures::future::pending::<()>().track(&reg, ()));
+        let task = tokio::spawn(futures::future::pending::<()>().track(registration));
 
-        let tracked = reg.tracked();
+        let tracked = registry.running();
         assert_eq!(tracked.len(), 1);
 
-        reg.terminate(tracked[0].0);
+        tracked[0].cancel();
         let result = task.await.unwrap();
 
         assert!(result.is_err());
-        assert_eq!(reg.tracked().len(), 0);
+        assert_eq!(registry.running().len(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_terminate_early() {
+        let registry = TrackerRegistry::new();
+        let (tracker, registration) = registry.register(());
+        tracker.cancel();
+
+        let task1 = tokio::spawn(futures::future::pending::<()>().track(registration));
+        let result1 = task1.await.unwrap();
+
+        assert!(result1.is_err());
+        assert_eq!(registry.running().len(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_terminate_multiple() {
+        let registry = TrackerRegistry::new();
+        let (_, registration) = registry.register(());
+
+        let task1 = tokio::spawn(futures::future::pending::<()>().track(registration.clone()));
+        let task2 = tokio::spawn(futures::future::pending::<()>().track(registration));
+
+        let tracked = registry.running();
+        assert_eq!(tracked.len(), 1);
+
+        tracked[0].cancel();
+
+        let result1 = task1.await.unwrap();
+        let result2 = task2.await.unwrap();
+
+        assert!(result1.is_err());
+        assert!(result2.is_err());
+        assert_eq!(registry.running().len(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_reclaim() {
+        let registry = TrackerRegistry::new();
+
+        let (_, registration1) = registry.register(1);
+        let (_, registration2) = registry.register(2);
+        let (_, registration3) = registry.register(3);
+
+        let task1 = tokio::spawn(futures::future::pending::<()>().track(registration1.clone()));
+        let task2 = tokio::spawn(futures::future::pending::<()>().track(registration1));
+        let task3 = tokio::spawn(futures::future::ready(()).track(registration2.clone()));
+        let task4 = tokio::spawn(futures::future::pending::<()>().track(registration2));
+        let task5 = tokio::spawn(futures::future::pending::<()>().track(registration3));
+
+        let running = sorted(registry.running());
+        let tracked = sorted(registry.tracked());
+
+        assert_eq!(running.len(), 3);
+        assert_eq!(get_metadata(&running), vec![1, 2, 3]);
+        assert_eq!(tracked.len(), 3);
+        assert_eq!(get_metadata(&tracked), vec![1, 2, 3]);
+
+        // Trigger termination of task1 and task2
+        running[0].cancel();
+
+        let result1 = task1.await.unwrap();
+        let result2 = task2.await.unwrap();
+
+        assert!(result1.is_err());
+        assert!(result2.is_err());
+
+        let running = sorted(registry.running());
+        let tracked = sorted(registry.tracked());
+
+        assert_eq!(running.len(), 2);
+        assert_eq!(get_metadata(&running), vec![2, 3]);
+        assert_eq!(tracked.len(), 3);
+        assert_eq!(get_metadata(&tracked), vec![1, 2, 3]);
+
+        // Expect reclaim to find now finished registration1
+        let reclaimed = sorted(registry.reclaim());
+        assert_eq!(reclaimed.len(), 1);
+        assert_eq!(get_metadata(&reclaimed), vec![1]);
+
+        // Now expect tracked to match running
+        let running = sorted(registry.running());
+        let tracked = sorted(registry.tracked());
+
+        assert_eq!(running.len(), 2);
+        assert_eq!(get_metadata(&running), vec![2, 3]);
+        assert_eq!(tracked.len(), 2);
+        assert_eq!(get_metadata(&tracked), vec![2, 3]);
+
+        // Wait for task3 to finish
+        let result3 = task3.await.unwrap();
+        assert!(result3.is_ok());
+
+        assert_eq!(tracked[0].pending_futures(), 1);
+        assert_eq!(tracked[0].created_futures(), 2);
+        assert!(!tracked[0].is_complete());
+
+        // Trigger termination of task5
+        running[1].cancel();
+
+        let result5 = task5.await.unwrap();
+        assert!(result5.is_err());
+
+        let running = sorted(registry.running());
+        let tracked = sorted(registry.tracked());
+
+        assert_eq!(running.len(), 1);
+        assert_eq!(get_metadata(&running), vec![2]);
+        assert_eq!(tracked.len(), 2);
+        assert_eq!(get_metadata(&tracked), vec![2, 3]);
+
+        // Trigger termination of task4
+        running[0].cancel();
+
+        let result4 = task4.await.unwrap();
+        assert!(result4.is_err());
+
+        assert_eq!(running[0].pending_futures(), 0);
+        assert_eq!(running[0].created_futures(), 2);
+        assert!(running[0].is_complete());
+
+        let reclaimed = sorted(registry.reclaim());
+
+        assert_eq!(reclaimed.len(), 2);
+        assert_eq!(get_metadata(&reclaimed), vec![2, 3]);
+        assert_eq!(registry.tracked().len(), 0);
+    }
+
+    // Use n+1 threads where n is the number of "blocking" tasks
+    // to prevent stalling the tokio executor
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn test_timing() {
+        let registry = TrackerRegistry::new();
+        let (tracker1, registration1) = registry.register(1);
+        let (tracker2, registration2) = registry.register(2);
+        let (tracker3, registration3) = registry.register(3);
+
+        let task1 =
+            tokio::spawn(tokio::time::sleep(Duration::from_millis(100)).track(registration1));
+        let task2 = tokio::spawn(
+            async move { std::thread::sleep(Duration::from_millis(100)) }.track(registration2),
+        );
+
+        let task3 = tokio::spawn(
+            async move { std::thread::sleep(Duration::from_millis(100)) }
+                .track(registration3.clone()),
+        );
+
+        let task4 = tokio::spawn(
+            async move { std::thread::sleep(Duration::from_millis(100)) }.track(registration3),
+        );
+
+        task1.await.unwrap().unwrap();
+        task2.await.unwrap().unwrap();
+        task3.await.unwrap().unwrap();
+        task4.await.unwrap().unwrap();
+
+        assert_eq!(tracker1.pending_futures(), 0);
+        assert_eq!(tracker2.pending_futures(), 0);
+        assert_eq!(tracker3.pending_futures(), 0);
+
+        assert!(tracker1.is_complete());
+        assert!(tracker2.is_complete());
+        assert!(tracker3.is_complete());
+
+        assert_eq!(tracker2.created_futures(), 1);
+        assert_eq!(tracker2.created_futures(), 1);
+        assert_eq!(tracker3.created_futures(), 2);
+
+        let assert_fuzzy = |actual: usize, expected: std::time::Duration| {
+            // Number of milliseconds of toleration
+            let epsilon = Duration::from_millis(10).as_nanos() as usize;
+            let expected = expected.as_nanos() as usize;
+
+            assert!(
+                actual > expected.saturating_sub(epsilon),
+                "Expected {} got {}",
+                expected,
+                actual
+            );
+            assert!(
+                actual < expected.saturating_add(epsilon),
+                "Expected {} got {}",
+                expected,
+                actual
+            );
+        };
+
+        assert_fuzzy(tracker1.cpu_nanos(), Duration::from_millis(0));
+        assert_fuzzy(tracker1.wall_nanos(), Duration::from_millis(100));
+        assert_fuzzy(tracker2.cpu_nanos(), Duration::from_millis(100));
+        assert_fuzzy(tracker2.wall_nanos(), Duration::from_millis(100));
+        assert_fuzzy(tracker3.cpu_nanos(), Duration::from_millis(200));
+        assert_fuzzy(tracker3.wall_nanos(), Duration::from_millis(100));
+    }
+
+    #[tokio::test]
+    async fn test_register_race() {
+        let registry = TrackerRegistry::new();
+        let (_, registration) = registry.register(());
+
+        let task1 = tokio::spawn(futures::future::ready(()).track(registration.clone()));
+        task1.await.unwrap().unwrap();
+
+        // Should only consider tasks complete once cannot register more Futures
+        let reclaimed = registry.reclaim();
+        assert_eq!(reclaimed.len(), 0);
+
+        let task2 = tokio::spawn(futures::future::ready(()).track(registration));
+        task2.await.unwrap().unwrap();
+
+        let reclaimed = registry.reclaim();
+        assert_eq!(reclaimed.len(), 1);
+    }
+
+    fn sorted(mut input: Vec<Tracker<i32>>) -> Vec<Tracker<i32>> {
+        input.sort_unstable_by_key(|x| *x.metadata());
+        input
+    }
+
+    fn get_metadata(input: &[Tracker<i32>]) -> Vec<i32> {
+        let mut ret: Vec<_> = input.iter().map(|x| *x.metadata()).collect();
+        ret.sort_unstable();
+        ret
     }
 }

--- a/server/src/tracker/future.rs
+++ b/server/src/tracker/future.rs
@@ -1,0 +1,87 @@
+use std::pin::Pin;
+use std::sync::atomic::Ordering;
+use std::task::{Context, Poll};
+use std::time::Instant;
+
+use futures::{future::BoxFuture, prelude::*};
+use pin_project::{pin_project, pinned_drop};
+
+use super::{TrackerRegistration, TrackerState};
+use std::sync::Arc;
+
+/// An extension trait that provides `self.track(registration)` allowing
+/// associating this future with a `TrackerRegistration`
+pub trait TrackedFutureExt: Future {
+    fn track(self, registration: TrackerRegistration) -> TrackedFuture<Self>
+    where
+        Self: Sized,
+    {
+        let tracker = Arc::clone(&registration.state);
+        let token = tracker.cancel_token.clone();
+
+        tracker.created_futures.fetch_add(1, Ordering::Relaxed);
+        tracker.pending_futures.fetch_add(1, Ordering::Relaxed);
+
+        // This must occur after the increment of pending_futures
+        std::mem::drop(registration);
+
+        // The future returned by CancellationToken::cancelled borrows the token
+        // In order to ensure we get a future with a static lifetime
+        // we box them up together and let async work its magic
+        let abort = Box::pin(async move { token.cancelled().await });
+
+        TrackedFuture {
+            inner: self,
+            abort,
+            tracker,
+        }
+    }
+}
+
+impl<T: ?Sized> TrackedFutureExt for T where T: Future {}
+
+/// The `Future` returned by `TrackedFutureExt::track()`
+/// Unregisters the future from the registered `TrackerRegistry` on drop
+/// and provides the early termination functionality used by
+/// `TrackerRegistry::terminate`
+#[pin_project(PinnedDrop)]
+#[allow(missing_debug_implementations)]
+pub struct TrackedFuture<F: Future> {
+    #[pin]
+    inner: F,
+    #[pin]
+    abort: BoxFuture<'static, ()>,
+    tracker: Arc<TrackerState>,
+}
+
+impl<F: Future> Future for TrackedFuture<F> {
+    type Output = Result<F::Output, future::Aborted>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        if self.as_mut().project().abort.poll(cx).is_ready() {
+            return Poll::Ready(Err(future::Aborted {}));
+        }
+
+        let start = Instant::now();
+        let poll = self.as_mut().project().inner.poll(cx);
+        let delta = start.elapsed().as_nanos() as usize;
+
+        self.tracker.cpu_nanos.fetch_add(delta, Ordering::Relaxed);
+
+        poll.map(Ok)
+    }
+}
+
+#[pinned_drop]
+impl<F: Future> PinnedDrop for TrackedFuture<F> {
+    fn drop(self: Pin<&mut Self>) {
+        let state = &self.project().tracker;
+
+        let wall_nanos = state.start_instant.elapsed().as_nanos() as usize;
+
+        state.wall_nanos.fetch_max(wall_nanos, Ordering::Relaxed);
+
+        let previous = state.pending_futures.fetch_sub(1, Ordering::Release);
+        assert_ne!(previous, 0);
+    }
+}

--- a/server/src/tracker/registry.rs
+++ b/server/src/tracker/registry.rs
@@ -1,0 +1,126 @@
+use super::{Tracker, TrackerRegistration};
+use hashbrown::HashMap;
+use parking_lot::Mutex;
+use std::str::FromStr;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+use tracing::debug;
+
+/// Every future registered with a `TrackerRegistry` is assigned a unique
+/// `TrackerId`
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+pub struct TrackerId(usize);
+
+impl FromStr for TrackerId {
+    type Err = std::num::ParseIntError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(Self(FromStr::from_str(s)?))
+    }
+}
+
+impl ToString for TrackerId {
+    fn to_string(&self) -> String {
+        self.0.to_string()
+    }
+}
+
+/// Internal data stored by TrackerRegistry
+#[derive(Debug)]
+struct TrackerSlot<T> {
+    tracker: Tracker<T>,
+    watch: tokio::sync::watch::Sender<bool>,
+}
+
+/// Allows tracking the lifecycle of futures registered by
+/// `TrackedFutureExt::track` with an accompanying metadata payload of type T
+///
+/// Additionally can trigger graceful cancellation of registered futures
+#[derive(Debug)]
+pub struct TrackerRegistry<T> {
+    next_id: AtomicUsize,
+    trackers: Mutex<HashMap<TrackerId, TrackerSlot<T>>>,
+}
+
+impl<T> Default for TrackerRegistry<T> {
+    fn default() -> Self {
+        Self {
+            next_id: AtomicUsize::new(0),
+            trackers: Default::default(),
+        }
+    }
+}
+
+impl<T> TrackerRegistry<T> {
+    pub fn new() -> Self {
+        Default::default()
+    }
+
+    /// Register a new tracker in the registry
+    pub fn register(&self, metadata: T) -> (Tracker<T>, TrackerRegistration) {
+        let id = TrackerId(self.next_id.fetch_add(1, Ordering::Relaxed));
+        let (sender, receiver) = tokio::sync::watch::channel(false);
+        let registration = TrackerRegistration::new(receiver);
+
+        let tracker = Tracker {
+            id,
+            metadata: Arc::new(metadata),
+            state: Arc::clone(&registration.state),
+        };
+
+        self.trackers.lock().insert(
+            id,
+            TrackerSlot {
+                tracker: tracker.clone(),
+                watch: sender,
+            },
+        );
+
+        (tracker, registration)
+    }
+
+    /// Removes completed tasks from the registry and returns a list of those
+    /// removed
+    pub fn reclaim(&self) -> Vec<Tracker<T>> {
+        self.trackers
+            .lock()
+            .drain_filter(|_, v| v.tracker.is_complete())
+            .map(|(_, v)| {
+                if let Err(error) = v.watch.send(true) {
+                    // As we hold a reference to the Tracker here, this should be impossible
+                    debug!(?error, "failed to publish tracker completion")
+                }
+                v.tracker
+            })
+            .collect()
+    }
+}
+
+impl<T: Clone> TrackerRegistry<T> {
+    pub fn get(&self, id: TrackerId) -> Option<Tracker<T>> {
+        self.trackers.lock().get(&id).map(|x| x.tracker.clone())
+    }
+
+    /// Returns a list of trackers, including those that are no longer running
+    pub fn tracked(&self) -> Vec<Tracker<T>> {
+        self.trackers
+            .lock()
+            .iter()
+            .map(|(_, v)| v.tracker.clone())
+            .collect()
+    }
+
+    /// Returns a list of active trackers
+    pub fn running(&self) -> Vec<Tracker<T>> {
+        self.trackers
+            .lock()
+            .iter()
+            .filter_map(|(_, v)| {
+                if !v.tracker.is_complete() {
+                    return Some(v.tracker.clone());
+                }
+                None
+            })
+            .collect()
+    }
+}

--- a/src/influxdb_ioxd/rpc.rs
+++ b/src/influxdb_ioxd/rpc.rs
@@ -11,6 +11,7 @@ use server::{ConnectionManager, Server};
 pub mod error;
 mod flight;
 mod management;
+mod operations;
 mod storage;
 mod testing;
 mod write;
@@ -53,7 +54,8 @@ where
         .add_service(storage::make_server(Arc::clone(&server)))
         .add_service(flight::make_server(Arc::clone(&server)))
         .add_service(write::make_server(Arc::clone(&server)))
-        .add_service(management::make_server(server))
+        .add_service(management::make_server(Arc::clone(&server)))
+        .add_service(operations::make_server(server))
         .serve_with_incoming(stream)
         .await
         .context(ServerError {})

--- a/src/influxdb_ioxd/rpc/management.rs
+++ b/src/influxdb_ioxd/rpc/management.rs
@@ -96,6 +96,16 @@ where
         }
     }
 
+    async fn create_dummy_job(
+        &self,
+        request: Request<CreateDummyJobRequest>,
+    ) -> Result<Response<CreateDummyJobResponse>, Status> {
+        let request = request.into_inner();
+        let slot = self.server.spawn_dummy_job(request.nanos);
+        let operation = Some(super::operations::encode_tracker(slot)?);
+        Ok(Response::new(CreateDummyJobResponse { operation }))
+    }
+
     async fn list_remotes(
         &self,
         _: Request<ListRemotesRequest>,

--- a/src/influxdb_ioxd/rpc/operations.rs
+++ b/src/influxdb_ioxd/rpc/operations.rs
@@ -1,0 +1,182 @@
+use std::fmt::Debug;
+use std::sync::Arc;
+
+use bytes::BytesMut;
+use prost::Message;
+use tonic::Response;
+use tracing::debug;
+
+use data_types::job::Job;
+use generated_types::google::FieldViolationExt;
+use generated_types::{
+    google::{
+        longrunning::*,
+        protobuf::{Any, Empty},
+        rpc::Status,
+        FieldViolation, InternalError, NotFound,
+    },
+    influxdata::iox::management::v1 as management,
+};
+use server::{
+    tracker::{Tracker, TrackerId},
+    ConnectionManager, Server,
+};
+use std::convert::TryInto;
+
+/// Implementation of the write service
+struct OperationsService<M: ConnectionManager> {
+    server: Arc<Server<M>>,
+}
+
+pub fn encode_tracker(tracker: Tracker<Job>) -> Result<Operation, tonic::Status> {
+    let id = tracker.id();
+    let is_complete = tracker.is_complete();
+    let is_cancelled = tracker.is_cancelled();
+
+    let mut buffer = BytesMut::new();
+    management::OperationMetadata {
+        cpu_nanos: tracker.cpu_nanos() as _,
+        wall_nanos: tracker.wall_nanos() as _,
+        task_count: tracker.created_futures() as _,
+        pending_count: tracker.pending_futures() as _,
+        job: Some(tracker.metadata().clone().into()),
+    }
+    .encode(&mut buffer)
+    .map_err(|error| {
+        debug!(?error, "Unexpected error");
+        InternalError {}
+    })?;
+
+    let metadata = Any {
+        type_url: "type.googleapis.com/influxdata.iox.management.v1.OperationMetadata".to_string(),
+        value: buffer.freeze(),
+    };
+
+    let result = match (is_complete, is_cancelled) {
+        (true, true) => Some(operation::Result::Error(Status {
+            code: tonic::Code::Cancelled as _,
+            message: "Job cancelled".to_string(),
+            details: vec![],
+        })),
+
+        (true, false) => Some(operation::Result::Response(Any {
+            type_url: "type.googleapis.com/google.protobuf.Empty".to_string(),
+            value: Default::default(), // TODO: Verify this is correct
+        })),
+
+        _ => None,
+    };
+
+    Ok(Operation {
+        name: id.to_string(),
+        metadata: Some(metadata),
+        done: is_complete,
+        result,
+    })
+}
+
+fn get_tracker<M>(server: &Server<M>, tracker: String) -> Result<Tracker<Job>, tonic::Status>
+where
+    M: ConnectionManager,
+{
+    let tracker_id = tracker.parse::<TrackerId>().map_err(|e| FieldViolation {
+        field: "name".to_string(),
+        description: e.to_string(),
+    })?;
+
+    let tracker = server.get_job(tracker_id).ok_or(NotFound {
+        resource_type: "job".to_string(),
+        resource_name: tracker,
+        ..Default::default()
+    })?;
+
+    Ok(tracker)
+}
+
+#[tonic::async_trait]
+impl<M> operations_server::Operations for OperationsService<M>
+where
+    M: ConnectionManager + Send + Sync + Debug + 'static,
+{
+    async fn list_operations(
+        &self,
+        _request: tonic::Request<ListOperationsRequest>,
+    ) -> Result<tonic::Response<ListOperationsResponse>, tonic::Status> {
+        // TODO: Support pagination
+        let operations: Result<Vec<_>, _> = self
+            .server
+            .tracked_jobs()
+            .into_iter()
+            .map(encode_tracker)
+            .collect();
+
+        Ok(Response::new(ListOperationsResponse {
+            operations: operations?,
+            next_page_token: Default::default(),
+        }))
+    }
+
+    async fn get_operation(
+        &self,
+        request: tonic::Request<GetOperationRequest>,
+    ) -> Result<tonic::Response<Operation>, tonic::Status> {
+        let request = request.into_inner();
+        let tracker = get_tracker(self.server.as_ref(), request.name)?;
+
+        Ok(Response::new(encode_tracker(tracker)?))
+    }
+
+    async fn delete_operation(
+        &self,
+        _: tonic::Request<DeleteOperationRequest>,
+    ) -> Result<tonic::Response<Empty>, tonic::Status> {
+        Err(tonic::Status::unimplemented(
+            "IOx does not support operation deletion",
+        ))
+    }
+
+    async fn cancel_operation(
+        &self,
+        request: tonic::Request<CancelOperationRequest>,
+    ) -> Result<tonic::Response<Empty>, tonic::Status> {
+        let request = request.into_inner();
+
+        let tracker = get_tracker(self.server.as_ref(), request.name)?;
+        tracker.cancel();
+
+        Ok(Response::new(Empty {}))
+    }
+
+    async fn wait_operation(
+        &self,
+        request: tonic::Request<WaitOperationRequest>,
+    ) -> Result<tonic::Response<Operation>, tonic::Status> {
+        // This should take into account the context deadline timeout
+        // Unfortunately these are currently stripped by tonic
+        // - https://github.com/hyperium/tonic/issues/75
+
+        let request = request.into_inner();
+
+        let tracker = get_tracker(self.server.as_ref(), request.name)?;
+        if let Some(timeout) = request.timeout {
+            let timeout = timeout.try_into().field("timeout")?;
+
+            // Timeout is not an error so suppress it
+            let _ = tokio::time::timeout(timeout, tracker.join()).await;
+        } else {
+            tracker.join().await;
+        }
+
+        Ok(Response::new(encode_tracker(tracker)?))
+    }
+}
+
+/// Instantiate the write service
+pub fn make_server<M>(
+    server: Arc<Server<M>>,
+) -> operations_server::OperationsServer<impl operations_server::Operations>
+where
+    M: ConnectionManager + Send + Sync + Debug + 'static,
+{
+    operations_server::OperationsServer::new(OperationsService { server })
+}


### PR DESCRIPTION
Needs more tests, currently the gRPC API has no tests :grimacing:, and I will probably split into smaller PRs for detailed review, but wanted to create a draft for feedback on the high-level design.

Examples:

```
./scripts/grpcurl -plaintext -d '{"nanos": [10000000000, 100, 10000]}' 127.0.0.1:8082 influxdata.iox.management.v1.ManagementService.CreateDummyJob
{
  "name": "2",
  "metadata": {
    "@type": "type.googleapis.com/influxdata.iox.management.v1.OperationMetadata",
    "dummy": {
      "nanos": [
        "10000000000",
        "100",
        "10000"
      ]
    },
    "pendingCount": "3",
    "taskCount": "3"
  }
}
```

```
./scripts/grpcurl -plaintext -d '{"name": "2"}' 127.0.0.1:8082 google.longrunning.Operations.GetOperation
{
  "name": "2",
  "metadata": {
    "@type": "type.googleapis.com/influxdata.iox.management.v1.OperationMetadata",
    "cpuNanos": "22142",
    "dummy": {
      "nanos": [
        "100000000000",
        "100",
        "10000"
      ]
    },
    "pendingCount": "1",
    "taskCount": "3"
  }
}
```
```
./scripts/grpcurl -plaintext -d '{"name": "2"}' 127.0.0.1:8082 google.longrunning.Operations.WaitOperation
{
  "name": "2",
  "metadata": {
    "@type": "type.googleapis.com/influxdata.iox.management.v1.OperationMetadata",
    "cpuNanos": "22142",
    "dummy": {
      "nanos": [
        "100000000000",
        "100",
        "10000"
      ]
    },
    "taskCount": "3",
    "wallNanos": "98662066953"
  },
  "done": true,
  "error": {
    "code": 1,
    "message": "Job cancelled"
  }
}
```
In parallel with the above
```
./scripts/grpcurl -plaintext -d '{"name": "2"}' 127.0.0.1:8082 google.longrunning.Operations.CancelOperation
```
