### PR TITLE
chore: mark generated code with .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+generated_types/src/** linguist-generated


### PR DESCRIPTION
This change causes GitHub to treat generated code a bit differently:
- exclude from language stats
- suppress changes in diffs


- [x] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb_iox/blob/main/README.md).
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
