### PR TITLE
feat: Add subcommands to server

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,5 +37,4 @@ EXPOSE 8080 8082
 
 ENTRYPOINT ["/usr/bin/influxdb_iox"]
 
-CMD ["server"]
-
+CMD ["server", "run"]

--- a/docker/Dockerfile.iox
+++ b/docker/Dockerfile.iox
@@ -21,4 +21,4 @@ EXPOSE 8080 8082
 
 ENTRYPOINT ["influxdb_iox"]
 
-CMD ["server"]
+CMD ["server", "run"]

--- a/src/commands/logging.rs
+++ b/src/commands/logging.rs
@@ -2,7 +2,7 @@
 
 use tracing_subscriber::{prelude::*, EnvFilter};
 
-use super::server::{Config, LogFormat};
+use super::server::{LogFormat, RunConfig};
 
 /// Handles setting up logging levels
 #[derive(Debug)]
@@ -81,7 +81,7 @@ impl LoggingLevel {
 
     /// Configures logging and tracing, based on the configuration
     /// values, for the IOx server (the whole enchalada)
-    pub fn setup_logging(&self, config: &Config) -> Option<opentelemetry_jaeger::Uninstall> {
+    pub fn setup_logging(&self, config: &RunConfig) -> Option<opentelemetry_jaeger::Uninstall> {
         // Copy anything from the config to the rust log environment
         self.set_rust_log_if_needed(config.rust_log.clone());
 

--- a/tests/common/server_fixture.rs
+++ b/tests/common/server_fixture.rs
@@ -226,6 +226,7 @@ impl TestServer {
         let server_process = Command::cargo_bin("influxdb_iox")
             .unwrap()
             .arg("server")
+            .arg("run")
             // Can enable for debugging
             //.arg("-vv")
             .env("INFLUXDB_IOX_BIND_ADDR", &addrs.http_bind_addr)
@@ -251,6 +252,7 @@ impl TestServer {
         self.server_process = Command::cargo_bin("influxdb_iox")
             .unwrap()
             .arg("server")
+            .arg("run")
             // Can enable for debugging
             //.arg("-vv")
             .env("INFLUXDB_IOX_DB_DIR", self.dir.path())


### PR DESCRIPTION
Part of #917; the goal there is to add a bunch of commands like:

```console
$ influxdb_iox server remote set 23 http://10.1.1.23:8080
```

To that end, I turned the `server` into a "subcommand group" layer, and added a `run` command that actually runs the server:

```console
$ influxdb_iox server run
```

The rest of the PR contains some simplifications and cleanups.