### PR TITLE
feat: Add management API and CLI to list chunks

### DIFF
--- a/data_types/src/chunk.rs
+++ b/data_types/src/chunk.rs
@@ -72,10 +72,10 @@ impl From<ChunkSummary> for management::Chunk {
 impl From<ChunkStorage> for management::ChunkStorage {
     fn from(storage: ChunkStorage) -> Self {
         match storage {
-            ChunkStorage::OpenMutableBuffer => management::ChunkStorage::OpenMutableBuffer,
-            ChunkStorage::ClosedMutableBuffer => management::ChunkStorage::ClosedMutableBuffer,
-            ChunkStorage::ReadBuffer => management::ChunkStorage::ReadBuffer,
-            ChunkStorage::ObjectStore => management::ChunkStorage::ObjectStore,
+            ChunkStorage::OpenMutableBuffer => Self::OpenMutableBuffer,
+            ChunkStorage::ClosedMutableBuffer => Self::ClosedMutableBuffer,
+            ChunkStorage::ReadBuffer => Self::ReadBuffer,
+            ChunkStorage::ObjectStore => Self::ObjectStore,
         }
     }
 }
@@ -112,10 +112,10 @@ impl TryFrom<management::ChunkStorage> for ChunkStorage {
 
     fn try_from(proto: management::ChunkStorage) -> Result<Self, Self::Error> {
         match proto {
-            management::ChunkStorage::OpenMutableBuffer => Ok(ChunkStorage::OpenMutableBuffer),
-            management::ChunkStorage::ClosedMutableBuffer => Ok(ChunkStorage::ClosedMutableBuffer),
-            management::ChunkStorage::ReadBuffer => Ok(ChunkStorage::ReadBuffer),
-            management::ChunkStorage::ObjectStore => Ok(ChunkStorage::ObjectStore),
+            management::ChunkStorage::OpenMutableBuffer => Ok(Self::OpenMutableBuffer),
+            management::ChunkStorage::ClosedMutableBuffer => Ok(Self::ClosedMutableBuffer),
+            management::ChunkStorage::ReadBuffer => Ok(Self::ReadBuffer),
+            management::ChunkStorage::ObjectStore => Ok(Self::ObjectStore),
             management::ChunkStorage::Unspecified => Err(FieldViolation::required("")),
         }
     }

--- a/data_types/src/chunk.rs
+++ b/data_types/src/chunk.rs
@@ -19,7 +19,7 @@ pub type Result<T, E = Error> = std::result::Result<T, E>;
 /// Which storage system is a chunk located in?
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Serialize, Deserialize)]
 pub enum ChunkStorage {
-    /// The chunk is still open for writes new writes, in the Mutable Buffer
+    /// The chunk is still open for new writes, in the Mutable Buffer
     OpenMutableBuffer,
 
     /// The chunk is no longer open for writes, in the Mutable Buffer
@@ -33,7 +33,7 @@ pub enum ChunkStorage {
 }
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Serialize, Deserialize)]
-/// Represents metadata about a chunkin a database.
+/// Represents metadata about a chunk in a database.
 /// A chunk can contain one or more tables.
 pub struct ChunkSummary {
     /// The partitition key of this chunk
@@ -91,7 +91,7 @@ impl From<ChunkStorage> for i32 {
     }
 }
 
-/// Conversion code to management API chunk structure
+/// Conversion code from management API chunk structure
 impl TryFrom<management::Chunk> for ChunkSummary {
     type Error = Error;
 

--- a/data_types/src/chunk.rs
+++ b/data_types/src/chunk.rs
@@ -1,0 +1,153 @@
+//! Module contains a representation of chunk metadata
+use snafu::Snafu;
+use std::{
+    convert::{TryFrom, TryInto},
+    sync::Arc,
+};
+
+use generated_types::influxdata::iox::management::v1 as management;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Snafu)]
+pub enum Error {
+    #[snafu(display("Unknown value for ChunkStorage: {}", v))]
+    UnknownChunkStorage { v: i32 },
+}
+
+pub type Result<T, E = Error> = std::result::Result<T, E>;
+
+/// Which storage system is a chunk located in?
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Serialize, Deserialize)]
+pub enum ChunkStorage {
+    /// The chunk is still open for writes new writes, in the Mutable Buffer
+    OpenMutableBuffer,
+
+    /// The chunk is no longer open for writes, in the Mutable Buffer
+    ClosedMutableBuffer,
+
+    /// The chunk is in the Read Buffer (where it can not be mutated)
+    ReadBuffer,
+
+    /// The chunk is stored in Object Storage (where it can not be mutated)
+    ObjectStore,
+}
+
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Serialize, Deserialize)]
+/// Represents metadata about a chunkin a database.
+/// A chunk can contain one or more tables.
+pub struct ChunkSummary {
+    /// The partitition key of this chunk
+    pub partition_key: Arc<String>,
+
+    /// The id of this chunk
+    pub id: u32,
+
+    /// How is this chunk stored?
+    pub storage: ChunkStorage,
+
+    /// The total estimated size of this chunk, in bytes
+    pub estimated_bytes: usize,
+}
+
+/// Conversion code to management API chunk structure
+impl From<ChunkSummary> for management::Chunk {
+    fn from(summary: ChunkSummary) -> Self {
+        let ChunkSummary {
+            partition_key,
+            id,
+            storage,
+            estimated_bytes,
+        } = summary;
+
+        let storage = storage.into();
+        let estimated_bytes = estimated_bytes as u64;
+
+        let partition_key = match Arc::try_unwrap(partition_key) {
+            // no one else has a reference so take the string
+            Ok(partition_key) => partition_key,
+            // some other refernece exists to this string, so clone it
+            Err(partition_key) => partition_key.as_ref().clone(),
+        };
+
+        Self {
+            partition_key,
+            id,
+            storage,
+            estimated_bytes,
+        }
+    }
+}
+
+impl From<ChunkStorage> for i32 {
+    fn from(storage: ChunkStorage) -> Self {
+        match storage {
+            ChunkStorage::OpenMutableBuffer => management::ChunkStorage::OpenMutableBuffer as Self,
+            ChunkStorage::ClosedMutableBuffer => {
+                management::ChunkStorage::ClosedMutableBuffer as Self
+            }
+            ChunkStorage::ReadBuffer => management::ChunkStorage::ReadBuffer as Self,
+            ChunkStorage::ObjectStore => management::ChunkStorage::ObjectStore as Self,
+        }
+    }
+}
+
+/// Conversion code to management API chunk structure
+impl TryFrom<management::Chunk> for ChunkSummary {
+    type Error = Error;
+
+    fn try_from(chunk: management::Chunk) -> Result<Self, Self::Error> {
+        let management::Chunk {
+            partition_key,
+            id,
+            storage,
+            estimated_bytes,
+        } = chunk;
+
+        let storage = storage.try_into()?;
+        let estimated_bytes = estimated_bytes as usize;
+        let partition_key = Arc::new(partition_key);
+
+        Ok(Self {
+            partition_key,
+            id,
+            storage,
+            estimated_bytes,
+        })
+    }
+}
+
+impl TryFrom<i32> for ChunkStorage {
+    type Error = Error;
+
+    fn try_from(v: i32) -> Result<Self, Self::Error> {
+        // There must be a better way to do this...
+        if v == management::ChunkStorage::OpenMutableBuffer as i32 {
+            Ok(Self::OpenMutableBuffer)
+        } else if v == management::ChunkStorage::ClosedMutableBuffer as i32 {
+            Ok(Self::ClosedMutableBuffer)
+        } else if v == management::ChunkStorage::ReadBuffer as i32 {
+            Ok(Self::ReadBuffer)
+        } else if v == management::ChunkStorage::ObjectStore as i32 {
+            Ok(Self::ObjectStore)
+        } else {
+            UnknownChunkStorage { v }.fail()
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn valid_chunk_storage() {
+        let storage = ChunkStorage::try_from(3).expect("conversion successful");
+        assert_eq!(storage, ChunkStorage::ReadBuffer);
+    }
+
+    #[test]
+    fn invalid_chunk_storage() {
+        let err = ChunkStorage::try_from(33).expect_err("Unknown value for ChunkStorage: 33");
+        assert_eq!(err.to_string(), "Unknown value for ChunkStorage: 33");
+    }
+}

--- a/data_types/src/lib.rs
+++ b/data_types/src/lib.rs
@@ -20,6 +20,7 @@ pub const TABLE_NAMES_COLUMN_NAME: &str = "table";
 /// `column_names`.
 pub const COLUMN_NAMES_COLUMN_NAME: &str = "column";
 
+pub mod chunk;
 pub mod data;
 pub mod database_rules;
 pub mod error;

--- a/generated_types/build.rs
+++ b/generated_types/build.rs
@@ -39,6 +39,7 @@ fn generate_grpc_types(root: &Path) -> Result<()> {
         idpe_path.join("source.proto"),
         management_path.join("base_types.proto"),
         management_path.join("database_rules.proto"),
+        management_path.join("chunk.proto"),
         management_path.join("service.proto"),
         write_path.join("service.proto"),
         root.join("grpc/health/v1/service.proto"),

--- a/generated_types/protos/influxdata/iox/management/v1/chunk.proto
+++ b/generated_types/protos/influxdata/iox/management/v1/chunk.proto
@@ -1,0 +1,36 @@
+syntax = "proto3";
+package influxdata.iox.management.v1;
+
+
+ // Which storage system is a chunk located in?
+enum ChunkStorage {
+  // Not currently returned
+  CHUNK_STORAGE_UNSPECIFIED = 0;
+
+  // The chunk is still open for writes new writes, in the Mutable Buffer
+  CHUNK_STORAGE_OPEN_MUTABLE_BUFFER = 1;
+
+  // The chunk is no longer open for writes, in the Mutable Buffer
+  CHUNK_STORAGE_CLOSED_MUTABLE_BUFFER = 2;
+
+  // The chunk is in the Read Buffer (where it can not be mutated)
+  CHUNK_STORAGE_READ_BUFFER = 3;
+
+  // The chunk is stored in Object Storage (where it can not be mutated)
+  CHUNK_STORAGE_OBJECT_STORE = 4;
+}
+
+// `Chunk` represents part of a partition of data in a database.
+// A chunk can contain one or more tables.
+message Chunk {
+  // The partitition key of this chunk
+  string partition_key = 1;
+
+  // The id of this chunk
+  uint32 id = 2;
+
+  ChunkStorage storage = 3;
+
+  // The total estimated size of this chunk, in bytes
+  uint64 estimated_bytes = 4;
+}

--- a/generated_types/protos/influxdata/iox/management/v1/chunk.proto
+++ b/generated_types/protos/influxdata/iox/management/v1/chunk.proto
@@ -29,6 +29,7 @@ message Chunk {
   // The id of this chunk
   uint32 id = 2;
 
+  // Which storage system the chunk is located in
   ChunkStorage storage = 3;
 
   // The total estimated size of this chunk, in bytes

--- a/generated_types/protos/influxdata/iox/management/v1/chunk.proto
+++ b/generated_types/protos/influxdata/iox/management/v1/chunk.proto
@@ -7,7 +7,7 @@ enum ChunkStorage {
   // Not currently returned
   CHUNK_STORAGE_UNSPECIFIED = 0;
 
-  // The chunk is still open for writes new writes, in the Mutable Buffer
+  // The chunk is still open for new writes, in the Mutable Buffer
   CHUNK_STORAGE_OPEN_MUTABLE_BUFFER = 1;
 
   // The chunk is no longer open for writes, in the Mutable Buffer

--- a/generated_types/protos/influxdata/iox/management/v1/service.proto
+++ b/generated_types/protos/influxdata/iox/management/v1/service.proto
@@ -3,6 +3,7 @@ package influxdata.iox.management.v1;
 
 import "google/protobuf/empty.proto";
 import "influxdata/iox/management/v1/database_rules.proto";
+import "influxdata/iox/management/v1/chunk.proto";
 
 service ManagementService {
   rpc GetWriterId(GetWriterIdRequest) returns (GetWriterIdResponse);
@@ -14,6 +15,9 @@ service ManagementService {
   rpc GetDatabase(GetDatabaseRequest) returns (GetDatabaseResponse);
 
   rpc CreateDatabase(CreateDatabaseRequest) returns (CreateDatabaseResponse);
+
+  // List chunks available on this database
+  rpc ListChunks(ListChunksRequest) returns (ListChunksResponse);
 
   // List remote IOx servers we know about.
   rpc ListRemotes(ListRemotesRequest) returns (ListRemotesResponse);
@@ -56,6 +60,16 @@ message CreateDatabaseRequest {
 }
 
 message CreateDatabaseResponse {}
+
+message ListChunksRequest {
+  // the name of the database
+  string db_name = 1;
+}
+
+message ListChunksResponse {
+  repeated Chunk chunks = 1;
+}
+
 
 message ListRemotesRequest {}
 

--- a/generated_types/protos/influxdata/iox/write/v1/service.proto
+++ b/generated_types/protos/influxdata/iox/write/v1/service.proto
@@ -9,7 +9,7 @@ service WriteService {
 
 message WriteRequest {
   // name of database into which to write
-  string name = 1;
+  string db_name = 1;
 
   // data, in [LineProtocol] format
   //

--- a/influxdb_iox_client/src/client/write.rs
+++ b/influxdb_iox_client/src/client/write.rs
@@ -61,14 +61,14 @@ impl Client {
     /// [LineProtocol](https://docs.influxdata.com/influxdb/v2.0/reference/syntax/line-protocol/#data-types-and-format)
     pub async fn write(
         &mut self,
-        name: impl Into<String>,
+        db_name: impl Into<String>,
         lp_data: impl Into<String>,
     ) -> Result<usize, WriteError> {
-        let name = name.into();
+        let db_name = db_name.into();
         let lp_data = lp_data.into();
         let response = self
             .inner
-            .write(WriteRequest { name, lp_data })
+            .write(WriteRequest { db_name, lp_data })
             .await
             .map_err(WriteError::ServerError)?;
 

--- a/mutable_buffer/src/database.rs
+++ b/mutable_buffer/src/database.rs
@@ -79,6 +79,14 @@ impl MutableBufferDb {
         }
     }
 
+    /// returns the id of the current open chunk in the specified partition
+    pub fn open_chunk_id(&self, partition_key: &str) -> u32 {
+        let partition = self.get_partition(partition_key);
+        let partition = partition.read().expect("mutex poisoned");
+
+        partition.open_chunk_id()
+    }
+
     /// Directs the writes from batch into the appropriate partitions
     fn write_entries_to_partitions(&self, batch: &wal::WriteBufferBatch<'_>) -> Result<()> {
         if let Some(entries) = batch.entries() {

--- a/mutable_buffer/src/partition.rs
+++ b/mutable_buffer/src/partition.rs
@@ -107,6 +107,11 @@ impl Partition {
         }
     }
 
+    /// returns the id of the current open chunk in this partition
+    pub(crate) fn open_chunk_id(&self) -> u32 {
+        self.open_chunk.id()
+    }
+
     /// write data to the open chunk
     pub fn write_entry(&mut self, entry: &wb::WriteBufferEntry<'_>) -> Result<()> {
         assert_eq!(

--- a/query/src/lib.rs
+++ b/query/src/lib.rs
@@ -9,7 +9,8 @@
 use arrow_deps::datafusion::physical_plan::SendableRecordBatchStream;
 use async_trait::async_trait;
 use data_types::{
-    data::ReplicatedWrite, partition_metadata::TableSummary, schema::Schema, selection::Selection,
+    chunk::ChunkSummary, data::ReplicatedWrite, partition_metadata::TableSummary, schema::Schema,
+    selection::Selection,
 };
 use exec::{stringset::StringSet, Executor};
 
@@ -49,6 +50,9 @@ pub trait Database: Debug + Send + Sync {
     /// covering set means that together the chunks make up a single
     /// complete copy of the data being queried.
     fn chunks(&self, partition_key: &str) -> Vec<Arc<Self::Chunk>>;
+
+    /// Return a summary of all chunks in this database, in all partitions
+    fn chunk_summaries(&self) -> Result<Vec<ChunkSummary>, Self::Error>;
 }
 
 /// Collection of data that shares the same partition key
@@ -60,7 +64,7 @@ pub trait PartitionChunk: Debug + Send + Sync {
     /// particular partition.
     fn id(&self) -> u32;
 
-    /// returns the partition metadata stats for every table in the partition
+    /// returns the partition metadata stats for every table in the chunk
     fn table_stats(&self) -> Result<Vec<TableSummary>, Self::Error>;
 
     /// Returns true if this chunk *might* have data that passes the

--- a/query/src/test.rs
+++ b/query/src/test.rs
@@ -154,6 +154,10 @@ impl Database for TestDatabase {
             vec![]
         }
     }
+
+    fn chunk_summaries(&self) -> Result<Vec<data_types::chunk::ChunkSummary>, Self::Error> {
+        unimplemented!("summaries not implemented TestDatabase")
+    }
 }
 
 #[derive(Debug, Default)]

--- a/read_buffer/src/lib.rs
+++ b/read_buffer/src/lib.rs
@@ -177,6 +177,25 @@ impl Database {
             .unwrap_or_default()
     }
 
+    /// Returns the total estimated size in bytes for the chunks in the
+    /// specified partition. Returns None if there is no such partition
+    pub fn chunks_size<'a>(
+        &self,
+        partition_key: &str,
+        chunk_ids: impl IntoIterator<Item = &'a u32>,
+    ) -> Option<u64> {
+        let partition_data = self.data.read().unwrap();
+
+        let partition = partition_data.partitions.get(partition_key);
+
+        partition.map(|partition| {
+            chunk_ids
+                .into_iter()
+                .map(|chunk_id| partition.chunk_size(*chunk_id))
+                .sum::<u64>()
+        })
+    }
+
     /// Returns the total estimated size in bytes of the database.
     pub fn size(&self) -> u64 {
         let base_size = std::mem::size_of::<Self>();
@@ -661,6 +680,16 @@ impl Partition {
                 .values()
                 .map(|chunk| std::mem::size_of::<u32>() as u64 + chunk.size())
                 .sum::<u64>()
+    }
+
+    /// The total estimated size in bytes of the specified chunk id
+    pub fn chunk_size(&self, chunk_id: u32) -> u64 {
+        let chunk_data = self.data.read().unwrap();
+        chunk_data
+            .chunks
+            .get(&chunk_id)
+            .map(|chunk| chunk.size())
+            .unwrap_or(0) // treat known chunks as zero size
     }
 }
 

--- a/read_buffer/src/lib.rs
+++ b/read_buffer/src/lib.rs
@@ -689,7 +689,7 @@ impl Partition {
             .chunks
             .get(&chunk_id)
             .map(|chunk| chunk.size())
-            .unwrap_or(0) // treat known chunks as zero size
+            .unwrap_or(0) // treat unknown chunks as zero size
     }
 }
 

--- a/server/src/snapshot.rs
+++ b/server/src/snapshot.rs
@@ -442,7 +442,7 @@ mem,host=A,region=west used=45 1
         ];
 
         let store = Arc::new(ObjectStore::new_in_memory(InMemory::new()));
-        let chunk = DBChunk::new_mb(Arc::new(ChunkWB::new(11)));
+        let chunk = DBChunk::new_mb(Arc::new(ChunkWB::new(11)), "key", false);
         let mut metadata_path = store.new_path();
         metadata_path.push_dir("meta");
 

--- a/src/commands/chunk.rs
+++ b/src/commands/chunk.rs
@@ -1,5 +1,6 @@
 //! This module implements the `chunk` CLI command
 use data_types::chunk::ChunkSummary;
+use generated_types::google::FieldViolation;
 use influxdb_iox_client::{
     connection::Builder,
     management::{self, ListChunksError},
@@ -13,8 +14,8 @@ pub enum Error {
     #[error("Error listing chunks: {0}")]
     ListChunkError(#[from] ListChunksError),
 
-    #[error("Error interpreting server response: {0}")]
-    ConvertingResponse(#[from] data_types::chunk::Error),
+    #[error("Error interpreting server response: {:?}", .0)]
+    ConvertingResponse(FieldViolation),
 
     #[error("Error rendering response as JSON: {0}")]
     WritingJson(#[from] serde_json::Error),

--- a/src/commands/chunk.rs
+++ b/src/commands/chunk.rs
@@ -1,0 +1,72 @@
+//! This module implements the `chunk` CLI command
+use data_types::chunk::ChunkSummary;
+use influxdb_iox_client::{
+    connection::Builder,
+    management::{self, ListChunksError},
+};
+use std::convert::TryFrom;
+use structopt::StructOpt;
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error("Error listing chunks: {0}")]
+    ListChunkError(#[from] ListChunksError),
+
+    #[error("Error interpreting server response: {0}")]
+    ConvertingResponse(#[from] data_types::chunk::Error),
+
+    #[error("Error rendering response as JSON: {0}")]
+    WritingJson(#[from] serde_json::Error),
+
+    #[error("Error connecting to IOx: {0}")]
+    ConnectionError(#[from] influxdb_iox_client::connection::Error),
+}
+
+pub type Result<T, E = Error> = std::result::Result<T, E>;
+
+/// Manage IOx databases
+#[derive(Debug, StructOpt)]
+pub struct Config {
+    #[structopt(subcommand)]
+    command: Command,
+}
+
+/// Get list of chunks for the specified database in JSON format
+#[derive(Debug, StructOpt)]
+struct Get {
+    /// The name of the database
+    db_name: String,
+}
+
+/// All possible subcommands for chunk
+#[derive(Debug, StructOpt)]
+enum Command {
+    Get(Get),
+}
+
+pub async fn command(url: String, config: Config) -> Result<()> {
+    let connection = Builder::default().build(url).await?;
+
+    match config.command {
+        Command::Get(get) => {
+            let Get { db_name } = get;
+
+            let mut client = management::Client::new(connection);
+
+            let chunks = client
+                .list_chunks(db_name)
+                .await
+                .map_err(Error::ListChunkError)?;
+
+            let chunks = chunks
+                .into_iter()
+                .map(|c| ChunkSummary::try_from(c).map_err(Error::ConvertingResponse))
+                .collect::<Result<Vec<_>>>()?;
+
+            serde_json::to_writer_pretty(std::io::stdout(), &chunks).map_err(Error::WritingJson)?;
+        }
+    }
+
+    Ok(())
+}

--- a/src/commands/database.rs
+++ b/src/commands/database.rs
@@ -13,6 +13,8 @@ use influxdb_iox_client::{
 use structopt::StructOpt;
 use thiserror::Error;
 
+mod chunk;
+
 #[derive(Debug, Error)]
 pub enum Error {
     #[error("Error creating database: {0}")]
@@ -41,6 +43,9 @@ pub enum Error {
 
     #[error("Error querying: {0}")]
     Query(#[from] influxdb_iox_client::flight::Error),
+
+    #[error("Error in chunk subcommand: {0}")]
+    Chunk(#[from] chunk::Error),
 }
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
@@ -101,10 +106,11 @@ enum Command {
     Get(Get),
     Write(Write),
     Query(Query),
+    Chunk(chunk::Config),
 }
 
 pub async fn command(url: String, config: Config) -> Result<()> {
-    let connection = Builder::default().build(url).await?;
+    let connection = Builder::default().build(url.clone()).await?;
 
     match config.command {
         Command::Create(command) => {
@@ -175,6 +181,9 @@ pub async fn command(url: String, config: Config) -> Result<()> {
             let formatted_result = format.format(&batches)?;
 
             println!("{}", formatted_result);
+        }
+        Command::Chunk(config) => {
+            chunk::command(url, config).await?;
         }
     }
 

--- a/src/commands/database.rs
+++ b/src/commands/database.rs
@@ -173,6 +173,7 @@ pub async fn command(url: String, config: Config) -> Result<()> {
             }
 
             let formatted_result = format.format(&batches)?;
+
             println!("{}", formatted_result);
         }
     }

--- a/src/commands/database/chunk.rs
+++ b/src/commands/database/chunk.rs
@@ -33,9 +33,9 @@ pub struct Config {
     command: Command,
 }
 
-/// Get list of chunks for the specified database in JSON format
+/// List the chunks for the specified database in JSON format
 #[derive(Debug, StructOpt)]
-struct Get {
+struct List {
     /// The name of the database
     db_name: String,
 }
@@ -43,15 +43,15 @@ struct Get {
 /// All possible subcommands for chunk
 #[derive(Debug, StructOpt)]
 enum Command {
-    Get(Get),
+    List(List),
 }
 
 pub async fn command(url: String, config: Config) -> Result<()> {
     let connection = Builder::default().build(url).await?;
 
     match config.command {
-        Command::Get(get) => {
-            let Get { db_name } = get;
+        Command::List(get) => {
+            let List { db_name } = get;
 
             let mut client = management::Client::new(connection);
 

--- a/src/influxdb_ioxd/rpc/write.rs
+++ b/src/influxdb_ioxd/rpc/write.rs
@@ -7,7 +7,7 @@ use std::fmt::Debug;
 use tonic::Response;
 use tracing::debug;
 
-use super::error::default_error_handler;
+use super::error::default_server_error_handler;
 
 /// Implementation of the write service
 struct WriteService<M: ConnectionManager> {
@@ -25,7 +25,7 @@ where
     ) -> Result<tonic::Response<WriteResponse>, tonic::Status> {
         let request = request.into_inner();
 
-        let db_name = request.name;
+        let db_name = request.db_name;
         let lp_data = request.lp_data;
         let lp_chars = lp_data.len();
 
@@ -42,7 +42,7 @@ where
         self.server
             .write_lines(&db_name, &lines)
             .await
-            .map_err(default_error_handler)?;
+            .map_err(default_server_error_handler)?;
 
         let lines_written = lp_line_count as u64;
         Ok(Response::new(WriteResponse { lines_written }))

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,6 +18,7 @@ use commands::logging::LoggingLevel;
 use ingest::parquet::writer::CompressionLevel;
 
 mod commands {
+    pub mod chunk;
     pub mod convert;
     pub mod database;
     mod input;
@@ -109,6 +110,7 @@ enum Command {
         /// The input filename to read from
         input: String,
     },
+    Chunk(commands::chunk::Config),
     Database(commands::database::Config),
     Stats(commands::stats::Config),
     // Clippy recommended boxing this variant because it's much larger than the others
@@ -167,6 +169,13 @@ fn main() -> Result<(), std::io::Error> {
                         eprintln!("Stats dump failed: {}", e);
                         std::process::exit(ReturnCode::Failure as _)
                     }
+                }
+            }
+            Command::Chunk(config) => {
+                logging_level.setup_basic_logging();
+                if let Err(e) = commands::chunk::command(host, config).await {
+                    eprintln!("{}", e);
+                    std::process::exit(ReturnCode::Failure as _)
                 }
             }
             Command::Database(config) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,7 +18,6 @@ use commands::logging::LoggingLevel;
 use ingest::parquet::writer::CompressionLevel;
 
 mod commands {
-    pub mod chunk;
     pub mod convert;
     pub mod database;
     mod input;
@@ -110,7 +109,6 @@ enum Command {
         /// The input filename to read from
         input: String,
     },
-    Chunk(commands::chunk::Config),
     Database(commands::database::Config),
     Stats(commands::stats::Config),
     // Clippy recommended boxing this variant because it's much larger than the others
@@ -169,13 +167,6 @@ fn main() -> Result<(), std::io::Error> {
                         eprintln!("Stats dump failed: {}", e);
                         std::process::exit(ReturnCode::Failure as _)
                     }
-                }
-            }
-            Command::Chunk(config) => {
-                logging_level.setup_basic_logging();
-                if let Err(e) = commands::chunk::command(host, config).await {
-                    eprintln!("{}", e);
-                    std::process::exit(ReturnCode::Failure as _)
                 }
             }
             Command::Database(config) => {

--- a/tests/end_to_end_cases/management_cli.rs
+++ b/tests/end_to_end_cases/management_cli.rs
@@ -121,8 +121,9 @@ async fn test_get_chunks() {
 
     Command::cargo_bin("influxdb_iox")
         .unwrap()
+        .arg("database")
         .arg("chunk")
-        .arg("get")
+        .arg("list")
         .arg(&db_name)
         .arg("--host")
         .arg(addr)
@@ -142,8 +143,9 @@ async fn test_list_chunks_error() {
     // list the chunks
     Command::cargo_bin("influxdb_iox")
         .unwrap()
+        .arg("database")
         .arg("chunk")
-        .arg("get")
+        .arg("list")
         .arg(&db_name)
         .arg("--host")
         .arg(addr)

--- a/tests/end_to_end_cases/management_cli.rs
+++ b/tests/end_to_end_cases/management_cli.rs
@@ -6,7 +6,6 @@ use crate::common::server_fixture::ServerFixture;
 
 use super::util::{create_readable_database, rand_name};
 
-
 #[tokio::test]
 async fn test_writer_id() {
     let server_fixture = ServerFixture::create_shared().await;
@@ -156,9 +155,8 @@ async fn test_list_chunks_error() {
         );
 }
 
-
 #[tokio::test]
-async fn test_remotes(addr: &str) {
+async fn test_remotes() {
     let server_fixture = ServerFixture::create_single_use().await;
     let addr = server_fixture.grpc_base();
     Command::cargo_bin("influxdb_iox")

--- a/tests/end_to_end_cases/management_cli.rs
+++ b/tests/end_to_end_cases/management_cli.rs
@@ -1,19 +1,16 @@
 use assert_cmd::Command;
 use predicates::prelude::*;
+use test_helpers::make_temp_file;
 
 use crate::common::server_fixture::ServerFixture;
 
+use super::util::{create_readable_database, rand_name};
+
+
 #[tokio::test]
-pub async fn test() {
-    let server_fixture = ServerFixture::create_single_use().await;
+async fn test_writer_id() {
+    let server_fixture = ServerFixture::create_shared().await;
     let addr = server_fixture.grpc_base();
-
-    test_writer_id(addr).await;
-    test_create_database(addr).await;
-    test_remotes(addr).await;
-}
-
-async fn test_writer_id(addr: &str) {
     Command::cargo_bin("influxdb_iox")
         .unwrap()
         .arg("writer")
@@ -36,8 +33,12 @@ async fn test_writer_id(addr: &str) {
         .stdout(predicate::str::contains("32"));
 }
 
-async fn test_create_database(addr: &str) {
-    let db = "management-cli-test";
+#[tokio::test]
+async fn test_create_database() {
+    let server_fixture = ServerFixture::create_shared().await;
+    let addr = server_fixture.grpc_base();
+    let db_name = rand_name();
+    let db = &db_name;
 
     Command::cargo_bin("influxdb_iox")
         .unwrap()
@@ -83,7 +84,83 @@ async fn test_create_database(addr: &str) {
         .stdout(predicate::str::contains(format!("name: \"{}\"", db)));
 }
 
+#[tokio::test]
+async fn test_get_chunks() {
+    let server_fixture = ServerFixture::create_shared().await;
+    let addr = server_fixture.grpc_base();
+    let db_name = rand_name();
+
+    create_readable_database(&db_name, server_fixture.grpc_channel()).await;
+
+    let lp_data = vec![
+        "cpu,region=west user=23.2 100",
+        "cpu,region=west user=21.0 150",
+    ];
+
+    let lp_data_file = make_temp_file(lp_data.join("\n"));
+
+    Command::cargo_bin("influxdb_iox")
+        .unwrap()
+        .arg("database")
+        .arg("write")
+        .arg(&db_name)
+        .arg(lp_data_file.as_ref())
+        .arg("--host")
+        .arg(addr)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("2 Lines OK"));
+
+    let expected = r#"[
+  {
+    "partition_key": "cpu",
+    "id": 0,
+    "storage": "OpenMutableBuffer",
+    "estimated_bytes": 145
+  }
+]"#;
+
+    Command::cargo_bin("influxdb_iox")
+        .unwrap()
+        .arg("chunk")
+        .arg("get")
+        .arg(&db_name)
+        .arg("--host")
+        .arg(addr)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(expected));
+}
+
+#[tokio::test]
+async fn test_list_chunks_error() {
+    let server_fixture = ServerFixture::create_shared().await;
+    let addr = server_fixture.grpc_base();
+    let db_name = rand_name();
+
+    // note don't make the database, expect error
+
+    // list the chunks
+    Command::cargo_bin("influxdb_iox")
+        .unwrap()
+        .arg("chunk")
+        .arg("get")
+        .arg(&db_name)
+        .arg("--host")
+        .arg(addr)
+        .assert()
+        .failure()
+        .stderr(
+            predicate::str::contains("Some requested entity was not found: Resource database")
+                .and(predicate::str::contains(&db_name)),
+        );
+}
+
+
+#[tokio::test]
 async fn test_remotes(addr: &str) {
+    let server_fixture = ServerFixture::create_single_use().await;
+    let addr = server_fixture.grpc_base();
     Command::cargo_bin("influxdb_iox")
         .unwrap()
         .arg("server")

--- a/tests/end_to_end_cases/util.rs
+++ b/tests/end_to_end_cases/util.rs
@@ -1,5 +1,8 @@
 use rand::{distributions::Alphanumeric, thread_rng, Rng};
 
+use generated_types::google::protobuf::Empty;
+use generated_types::influxdata::iox::management::v1::*;
+
 /// Return a random string suitable for use as a database name
 pub fn rand_name() -> String {
     thread_rng()
@@ -7,4 +10,52 @@ pub fn rand_name() -> String {
         .take(10)
         .map(char::from)
         .collect()
+}
+
+/// given a channel to talk with the managment api, create a new
+/// database with the specified name configured with a 10MB mutable
+/// buffer, partitioned on table
+pub async fn create_readable_database(
+    db_name: impl Into<String>,
+    channel: tonic::transport::Channel,
+) {
+    let mut management_client = influxdb_iox_client::management::Client::new(channel);
+
+    let rules = DatabaseRules {
+        name: db_name.into(),
+        partition_template: Some(PartitionTemplate {
+            parts: vec![partition_template::Part {
+                part: Some(partition_template::part::Part::Table(Empty {})),
+            }],
+        }),
+        mutable_buffer_config: Some(MutableBufferConfig {
+            buffer_size: 10 * 1024 * 1024,
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+
+    management_client
+        .create_database(rules.clone())
+        .await
+        .expect("create database failed");
+}
+
+/// given a channel to talk with the managment api, create a new
+/// database with no mutable buffer configured, no partitioning rules
+pub async fn create_unreadable_database(
+    db_name: impl Into<String>,
+    channel: tonic::transport::Channel,
+) {
+    let mut management_client = influxdb_iox_client::management::Client::new(channel);
+
+    let rules = DatabaseRules {
+        name: db_name.into(),
+        ..Default::default()
+    };
+
+    management_client
+        .create_database(rules.clone())
+        .await
+        .expect("create database failed");
 }

--- a/tests/end_to_end_cases/write_api.rs
+++ b/tests/end_to_end_cases/write_api.rs
@@ -1,26 +1,17 @@
-use influxdb_iox_client::management::{self, generated_types::DatabaseRules};
 use influxdb_iox_client::write::{self, WriteError};
 use test_helpers::assert_contains;
 
-use super::util::rand_name;
-
 use crate::common::server_fixture::ServerFixture;
+
+use super::util::{create_readable_database, rand_name};
 
 #[tokio::test]
 async fn test_write() {
     let fixture = ServerFixture::create_shared().await;
-    let mut management_client = management::Client::new(fixture.grpc_channel());
     let mut write_client = write::Client::new(fixture.grpc_channel());
 
     let db_name = rand_name();
-
-    management_client
-        .create_database(DatabaseRules {
-            name: db_name.clone(),
-            ..Default::default()
-        })
-        .await
-        .expect("create database failed");
+    create_readable_database(&db_name, fixture.grpc_channel()).await;
 
     let lp_lines = vec![
         "cpu,region=west user=23.2 100",


### PR DESCRIPTION
Re https://github.com/influxdata/influxdb_iox/issues/942

# Rationale:
As I add commands to move partitions around, I also need to be able to observe the changes they are making

# Changes:
* Add gRPC definition and implementation for listing chunks
* Add list_chunks to management api
* implement `ChunkSummary` and `Db::chunk_summaries` in Server
* tests for same


# Example Usage (updated)
Given a database loaded thusly:
```
./target/debug/influxdb_iox database write my_db tests/fixtures/lineproto/metrics.lp
1000 Lines OK
```

List the chunks (note the partition key is "" due to https://github.com/influxdata/influxdb_iox/issues/966):
```
./target/debug/influxdb_iox database chunk list my_db
[
  {
    "partition_key": "",
    "id": 0,
    "storage": "OpenMutableBuffer",
    "estimated_bytes": 564520
  }
```

# Notes
* This API does not include the tables in each chunk -- I felt like adding a second layer of nesting was going to make the results too large to be useful. Instead, we can to add a separate API to list all tables in each chunk

Next up  I plan to add the partition command to list and manipulate partitions


- [ ] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb_iox/blob/main/README.md).
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
