### PR TITLE
feat: configure databases created with CLI with reasonable defaults

### DIFF
--- a/data_types/src/database_rules.rs
+++ b/data_types/src/database_rules.rs
@@ -629,10 +629,19 @@ impl TryFrom<management::PartitionTemplate> for PartitionTemplate {
 /// part of a partition key.
 #[derive(Debug, Serialize, Deserialize, Eq, PartialEq, Clone)]
 pub enum TemplatePart {
+    /// The name of a table (blank to
     Table,
+    /// The value in a named column
     Column(String),
+    /// Applies a  `strftime` format to the "time" column.
+    ///
+    /// For example, a time format of "%Y-%m-%d %H:%M:%S" will produce
+    /// partition key parts such as "2021-03-14 12:25:21" and
+    /// "2021-04-14 12:24:21"
     TimeFormat(String),
+    /// Applies a regex to the value in a string column
     RegexCapture(RegexCapture),
+    /// Applies a strftime pattern to some column other than "time"
     StrftimeColumn(StrftimeColumn),
 }
 
@@ -644,8 +653,15 @@ pub struct RegexCapture {
     regex: String,
 }
 
-/// `StrftimeColumn` can be used to create a time based partition key off some
+/// [`StrftimeColumn`] is be used to create a time based partition key off some
 /// column other than the builtin `time` column.
+///
+/// The value of the named column is formatted using a `strftime`
+/// style string.
+///
+/// For example, a time format of "%Y-%m-%d %H:%M:%S" will produce
+/// partition key parts such as "2021-03-14 12:25:21" and
+/// "2021-04-14 12:24:21"
 #[derive(Debug, Serialize, Deserialize, Eq, PartialEq, Clone)]
 pub struct StrftimeColumn {
     column: String,

--- a/data_types/src/database_rules.rs
+++ b/data_types/src/database_rules.rs
@@ -629,7 +629,7 @@ impl TryFrom<management::PartitionTemplate> for PartitionTemplate {
 /// part of a partition key.
 #[derive(Debug, Serialize, Deserialize, Eq, PartialEq, Clone)]
 pub enum TemplatePart {
-    /// The name of a table (blank to
+    /// The name of a table
     Table,
     /// The value in a named column
     Column(String),

--- a/data_types/src/database_rules.rs
+++ b/data_types/src/database_rules.rs
@@ -641,7 +641,7 @@ pub enum TemplatePart {
     TimeFormat(String),
     /// Applies a regex to the value in a string column
     RegexCapture(RegexCapture),
-    /// Applies a strftime pattern to some column other than "time"
+    /// Applies a `strftime` pattern to some column other than "time"
     StrftimeColumn(StrftimeColumn),
 }
 
@@ -653,7 +653,7 @@ pub struct RegexCapture {
     regex: String,
 }
 
-/// [`StrftimeColumn`] is be used to create a time based partition key off some
+/// [`StrftimeColumn`] is used to create a time based partition key off some
 /// column other than the builtin `time` column.
 ///
 /// The value of the named column is formatted using a `strftime`

--- a/src/commands/database.rs
+++ b/src/commands/database.rs
@@ -68,8 +68,8 @@ struct Create {
     name: String,
 
     /// Create a mutable buffer of the specified size in bytes
-    #[structopt(short, long)]
-    mutable_buffer: Option<u64>,
+    #[structopt(short, long, default_value = "104857600")] // 104857600 = 100*1024*1024
+    mutable_buffer: u64,
 }
 
 /// Get list of databases
@@ -125,18 +125,32 @@ pub async fn command(url: String, config: Config) -> Result<()> {
     match config.command {
         Command::Create(command) => {
             let mut client = management::Client::new(connection);
-            client
-                .create_database(DatabaseRules {
-                    name: command.name,
-                    mutable_buffer_config: command.mutable_buffer.map(|buffer_size| {
-                        MutableBufferConfig {
-                            buffer_size,
-                            ..Default::default()
-                        }
-                    }),
+
+            let buffer_size = command.mutable_buffer;
+
+            let rules = DatabaseRules {
+                name: command.name,
+
+                mutable_buffer_config: Some(MutableBufferConfig {
+                    buffer_size,
                     ..Default::default()
-                })
-                .await?;
+                }),
+
+                // Default to hourly partitions
+                partition_template: Some(PartitionTemplate {
+                    parts: vec![partition_template::Part {
+                        part: Some(partition_template::part::Part::Time(
+                            "%Y-%m-%d %H:00:00".into(),
+                        )),
+                    }],
+                }),
+
+                // Note no wal buffer config
+                ..Default::default()
+            };
+
+            client.create_database(rules).await?;
+
             println!("Ok");
         }
         Command::List(_) => {

--- a/tests/end_to_end_cases/management_cli.rs
+++ b/tests/end_to_end_cases/management_cli.rs
@@ -61,6 +61,7 @@ async fn test_create_database() {
         .success()
         .stdout(predicate::str::contains("Ok"));
 
+    // Listing the database includes the name
     Command::cargo_bin("influxdb_iox")
         .unwrap()
         .arg("database")
@@ -80,7 +81,13 @@ async fn test_create_database() {
         .arg(addr)
         .assert()
         .success()
-        .stdout(predicate::str::contains(format!("name: \"{}\"", db)));
+        .stdout(
+            predicate::str::contains(format!("name: \"{}\"", db)).and(
+                // validate the defaults have been set reasonably
+                predicate::str::contains("%Y-%m-%d %H:00:00")
+                    .and(predicate::str::contains("buffer_size: 104857600")),
+            ),
+        );
 }
 
 #[tokio::test]

--- a/tests/end_to_end_cases/management_cli.rs
+++ b/tests/end_to_end_cases/management_cli.rs
@@ -61,7 +61,7 @@ async fn test_create_database() {
         .success()
         .stdout(predicate::str::contains("Ok"));
 
-    // Listing the database includes the name
+    // Listing the databases includes the newly created database
     Command::cargo_bin("influxdb_iox")
         .unwrap()
         .arg("database")
@@ -71,6 +71,46 @@ async fn test_create_database() {
         .assert()
         .success()
         .stdout(predicate::str::contains(db));
+
+    // Retrieving the database includes the name and a mutable buffer configuration
+    Command::cargo_bin("influxdb_iox")
+        .unwrap()
+        .arg("database")
+        .arg("get")
+        .arg(db)
+        .arg("--host")
+        .arg(addr)
+        .assert()
+        .success()
+        .stdout(
+            predicate::str::contains(db)
+                .and(predicate::str::contains(format!("name: \"{}\"", db)))
+                // validate the defaults have been set reasonably
+                .and(predicate::str::contains("%Y-%m-%d %H:00:00"))
+                .and(predicate::str::contains("buffer_size: 104857600"))
+                .and(predicate::str::contains("MutableBufferConfig")),
+        );
+}
+
+#[tokio::test]
+async fn test_create_database_size() {
+    let server_fixture = ServerFixture::create_shared().await;
+    let addr = server_fixture.grpc_base();
+    let db_name = rand_name();
+    let db = &db_name;
+
+    Command::cargo_bin("influxdb_iox")
+        .unwrap()
+        .arg("database")
+        .arg("create")
+        .arg(db)
+        .arg("-m")
+        .arg("1000")
+        .arg("--host")
+        .arg(addr)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Ok"));
 
     Command::cargo_bin("influxdb_iox")
         .unwrap()
@@ -82,12 +122,42 @@ async fn test_create_database() {
         .assert()
         .success()
         .stdout(
-            predicate::str::contains(format!("name: \"{}\"", db)).and(
-                // validate the defaults have been set reasonably
-                predicate::str::contains("%Y-%m-%d %H:00:00")
-                    .and(predicate::str::contains("buffer_size: 104857600")),
-            ),
+            predicate::str::contains("buffer_size: 1000")
+                .and(predicate::str::contains("MutableBufferConfig")),
         );
+}
+
+#[tokio::test]
+async fn test_create_database_zero_size() {
+    let server_fixture = ServerFixture::create_shared().await;
+    let addr = server_fixture.grpc_base();
+    let db_name = rand_name();
+    let db = &db_name;
+
+    Command::cargo_bin("influxdb_iox")
+        .unwrap()
+        .arg("database")
+        .arg("create")
+        .arg(db)
+        .arg("-m")
+        .arg("0")
+        .arg("--host")
+        .arg(addr)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Ok"));
+
+    Command::cargo_bin("influxdb_iox")
+        .unwrap()
+        .arg("database")
+        .arg("get")
+        .arg(db)
+        .arg("--host")
+        .arg(addr)
+        .assert()
+        .success()
+        // Should not have a mutable buffer
+        .stdout(predicate::str::contains("MutableBufferConfig").not());
 }
 
 #[tokio::test]


### PR DESCRIPTION
Closes https://github.com/influxdata/influxdb_iox/issues/966.  

# Rationale:
Currently  running the `influxdb_iox database create foo` command creates a database that is not very usable:
1. It has no mutable buffer so it can't accept writes
2. It has no partitioning rules (so all data goes into a single partition)

# Changes
Changes the default database configuration to:

1. Have a 100MB mutable buffer (configurable via command line)
2. Have a default hourly partitioning rule

# Example:

```
./target/debug/influxdb_iox database create my_db
Ok

./target/debug/influxdb_iox database write my_db tests/fixtures/lineproto/metrics.lp
1000 Lines OK

./target/debug/influxdb_iox database chunk list my_db 
[
  {
    "partition_key": "2020-06-11 16:00:00",
    "id": 0,
    "storage": "OpenMutableBuffer",
    "estimated_bytes": 189868
  }

```

Note the partitioning value ("2020-06-11 16:00:00")



# Notes
I didn't add any command line way to set a more complex partitioning
rule, as I believe the vision from @pauldix is that anyone who wants
more sophistication will use the management API instead.

- [x] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb_iox/blob/main/README.md).
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
