### PR TITLE
feat: make CLI to listing database consistent with other commands

### DIFF
--- a/src/commands/database.rs
+++ b/src/commands/database.rs
@@ -63,11 +63,15 @@ struct Create {
     mutable_buffer: Option<u64>,
 }
 
-/// Get list of databases, or return configuration of specific database
+/// Get list of databases
+#[derive(Debug, StructOpt)]
+struct List {}
+
+/// Return configuration of specific database
 #[derive(Debug, StructOpt)]
 struct Get {
-    /// If specified returns configuration of database
-    name: Option<String>,
+    /// The name of the database
+    name: String,
 }
 
 /// Write data into the specified database
@@ -98,6 +102,7 @@ struct Query {
 #[derive(Debug, StructOpt)]
 enum Command {
     Create(Create),
+    List(List),
     Get(Get),
     Write(Write),
     Query(Query),
@@ -123,16 +128,16 @@ pub async fn command(url: String, config: Config) -> Result<()> {
                 .await?;
             println!("Ok");
         }
+        Command::List(_) => {
+            let mut client = management::Client::new(connection);
+            let databases = client.list_databases().await?;
+            println!("{}", databases.join(", "))
+        }
         Command::Get(get) => {
             let mut client = management::Client::new(connection);
-            if let Some(name) = get.name {
-                let database = client.get_database(name).await?;
-                // TOOD: Do something better than this
-                println!("{:#?}", database);
-            } else {
-                let databases = client.list_databases().await?;
-                println!("{}", databases.join(", "))
-            }
+            let database = client.get_database(get.name).await?;
+            // TOOD: Do something better than this
+            println!("{:#?}", database);
         }
         Command::Write(write) => {
             let mut client = write::Client::new(connection);

--- a/tests/end_to_end_cases/management_cli.rs
+++ b/tests/end_to_end_cases/management_cli.rs
@@ -64,7 +64,7 @@ async fn test_create_database(addr: &str) {
     Command::cargo_bin("influxdb_iox")
         .unwrap()
         .arg("database")
-        .arg("get")
+        .arg("list")
         .arg("--host")
         .arg(addr)
         .assert()


### PR DESCRIPTION
# Current behavior:

To list databases
```
influxdb_iox database get
```
(aka no args)

To list remotes:
```
influxdb_iox remote list
```

To list chunks
```
influxdb_iox database chunk list
```

# Proposed behavior:
List databases via
```
influxdb_iox db list
```

Making it consistent with the other commands


- [x] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb_iox/blob/main/README.md).
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
