### PR TITLE
docs: Update README.md to refer to the command and CLI help

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ influxdb_iox database query company_sensors "SELECT * FROM cpu LIMIT 10"
 
 To ease deloyment, IOx is packaged as a combined binary which has
 commands to start the IOx server as well as a CLI interface for
-interacting and configuring such servers.
+interacting with and configuring such servers.
 
 The CLI itself is documented via extensive built in help which you can
 access by runing `influxdb_iox --help`

--- a/README.md
+++ b/README.md
@@ -222,6 +222,15 @@ To query data stored in the `company_sensors` database:
 influxdb_iox database query company_sensors "SELECT * FROM cpu LIMIT 10"
 ```
 
+### Using the CLI
+
+To ease deloyment, IOx is packaged as a combined binary which has
+commands to start the IOx server as well as a CLI interface for
+interacting and configuring such servers.
+
+The CLI itself is documented via extensive built in help which you can
+access by runing `influxdb_iox --help`
+
 
 ### InfluxDB 2.0 compatibility
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -63,6 +63,14 @@ Examples:
 
     # Dumps storage statistics about out.parquet to stdout
     influxdb_iox stats out.parquet
+
+Command are generally structured in the form:
+    <type of object> <action> <arguments>
+
+For exampl, a command such as the following shows all actions
+    available for database chunks, including get and list.
+
+    influxdb_iox database chunk --help
 "#
 )]
 struct Config {

--- a/src/main.rs
+++ b/src/main.rs
@@ -67,7 +67,7 @@ Examples:
 Command are generally structured in the form:
     <type of object> <action> <arguments>
 
-For exampl, a command such as the following shows all actions
+For example, a command such as the following shows all actions
     available for database chunks, including get and list.
 
     influxdb_iox database chunk --help


### PR DESCRIPTION
Adds a pointer in the README.md to the command line tool, and documents the common pattern of command structure we hope to follow (re https://github.com/influxdata/influxdb_iox/issues/979)

- [x] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb_iox/blob/main/README.md).
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
