### PR TITLE
feat: Add management API and CLI for listing partitions

### DIFF
--- a/generated_types/build.rs
+++ b/generated_types/build.rs
@@ -40,6 +40,7 @@ fn generate_grpc_types(root: &Path) -> Result<()> {
         management_path.join("base_types.proto"),
         management_path.join("database_rules.proto"),
         management_path.join("chunk.proto"),
+        management_path.join("partition.proto"),
         management_path.join("service.proto"),
         management_path.join("jobs.proto"),
         write_path.join("service.proto"),

--- a/generated_types/protos/influxdata/iox/management/v1/partition.proto
+++ b/generated_types/protos/influxdata/iox/management/v1/partition.proto
@@ -1,0 +1,12 @@
+syntax = "proto3";
+package influxdata.iox.management.v1;
+
+
+// `Partition` is comprised of data in one or more chunks
+//
+// TODO: add additional information to this structure (e.g. partition
+// names, stats, etc)
+message Partition {
+  // The partitition key of this partition
+  string key = 1;
+}

--- a/generated_types/protos/influxdata/iox/management/v1/service.proto
+++ b/generated_types/protos/influxdata/iox/management/v1/service.proto
@@ -4,6 +4,7 @@ package influxdata.iox.management.v1;
 import "google/longrunning/operations.proto";
 import "influxdata/iox/management/v1/database_rules.proto";
 import "influxdata/iox/management/v1/chunk.proto";
+import "influxdata/iox/management/v1/partition.proto";
 
 service ManagementService {
   rpc GetWriterId(GetWriterIdRequest) returns (GetWriterIdResponse);
@@ -36,6 +37,13 @@ service ManagementService {
       metadata_type: "OperationMetadata"
     };
   }
+
+  // List partitions in a database
+  rpc ListPartitions(ListPartitionsRequest) returns (ListPartitionsResponse);
+
+  // Get detail information about a partition
+  rpc GetPartition(GetPartitionRequest) returns (GetPartitionResponse);
+
 }
 
 message GetWriterIdRequest {}
@@ -119,3 +127,29 @@ message DeleteRemoteRequest{
 }
 
 message DeleteRemoteResponse {}
+
+// Request to list all partitions from a named database
+message ListPartitionsRequest {
+  // the name of the database
+  string db_name = 1;
+}
+
+message ListPartitionsResponse {
+  // All partition keys in a database
+  repeated string partition_keys = 1;
+}
+
+
+// Request to get details of a specific partition from a named database
+message GetPartitionRequest {
+  // the name of the database
+  string db_name = 1;
+
+  // the partition key
+  string partition_key = 2;
+}
+
+message GetPartitionResponse {
+  // Detailed information about a partition
+  Partition partition = 1;
+}

--- a/generated_types/protos/influxdata/iox/management/v1/service.proto
+++ b/generated_types/protos/influxdata/iox/management/v1/service.proto
@@ -135,8 +135,8 @@ message ListPartitionsRequest {
 }
 
 message ListPartitionsResponse {
-  // All partition keys in a database
-  repeated string partition_keys = 1;
+  // All partitions in a database
+  repeated Partition partitions = 1;
 }
 
 

--- a/influxdb_iox_client/src/client/management.rs
+++ b/influxdb_iox_client/src/client/management.rs
@@ -303,11 +303,11 @@ impl Client {
         Ok(())
     }
 
-    /// List partition keys of a database
+    /// List all partitions of the database
     pub async fn list_partitions(
         &mut self,
         db_name: impl Into<String>,
-    ) -> Result<Vec<String>, ListPartitionsError> {
+    ) -> Result<Vec<Partition>, ListPartitionsError> {
         let db_name = db_name.into();
         let response = self
             .inner
@@ -318,12 +318,12 @@ impl Client {
                 _ => ListPartitionsError::ServerError(status),
             })?;
 
-        let ListPartitionsResponse { partition_keys } = response.into_inner();
+        let ListPartitionsResponse { partitions } = response.into_inner();
 
-        Ok(partition_keys)
+        Ok(partitions)
     }
 
-    /// Get details about a partition
+    /// Get details about a specific partition
     pub async fn get_partition(
         &mut self,
         db_name: impl Into<String>,

--- a/src/commands/database.rs
+++ b/src/commands/database.rs
@@ -14,6 +14,7 @@ use structopt::StructOpt;
 use thiserror::Error;
 
 mod chunk;
+mod partition;
 
 #[derive(Debug, Error)]
 pub enum Error {
@@ -46,6 +47,9 @@ pub enum Error {
 
     #[error("Error in chunk subcommand: {0}")]
     Chunk(#[from] chunk::Error),
+
+    #[error("Error in partition subcommand: {0}")]
+    Partition(#[from] partition::Error),
 }
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
@@ -112,6 +116,7 @@ enum Command {
     Write(Write),
     Query(Query),
     Chunk(chunk::Config),
+    Partition(partition::Config),
 }
 
 pub async fn command(url: String, config: Config) -> Result<()> {
@@ -189,6 +194,9 @@ pub async fn command(url: String, config: Config) -> Result<()> {
         }
         Command::Chunk(config) => {
             chunk::command(url, config).await?;
+        }
+        Command::Partition(config) => {
+            partition::command(url, config).await?;
         }
     }
 

--- a/src/commands/database/chunk.rs
+++ b/src/commands/database/chunk.rs
@@ -26,7 +26,7 @@ pub enum Error {
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
-/// Manage IOx databases
+/// Manage IOx chunks
 #[derive(Debug, StructOpt)]
 pub struct Config {
     #[structopt(subcommand)]
@@ -55,17 +55,14 @@ pub async fn command(url: String, config: Config) -> Result<()> {
 
             let mut client = management::Client::new(connection);
 
-            let chunks = client
-                .list_chunks(db_name)
-                .await
-                .map_err(Error::ListChunkError)?;
+            let chunks = client.list_chunks(db_name).await?;
 
             let chunks = chunks
                 .into_iter()
                 .map(ChunkSummary::try_from)
                 .collect::<Result<Vec<_>, FieldViolation>>()?;
 
-            serde_json::to_writer_pretty(std::io::stdout(), &chunks).map_err(Error::WritingJson)?;
+            serde_json::to_writer_pretty(std::io::stdout(), &chunks)?;
         }
     }
 

--- a/src/commands/database/partition.rs
+++ b/src/commands/database/partition.rs
@@ -65,7 +65,9 @@ pub async fn command(url: String, config: Config) -> Result<()> {
     match config.command {
         Command::List(list) => {
             let List { db_name } = list;
-            let partition_keys = client.list_partitions(db_name).await?;
+            let partitions = client.list_partitions(db_name).await?;
+            let partition_keys = partitions.into_iter().map(|p| p.key).collect::<Vec<_>>();
+
             serde_json::to_writer_pretty(std::io::stdout(), &partition_keys)?;
         }
         Command::Get(get) => {

--- a/src/commands/database/partition.rs
+++ b/src/commands/database/partition.rs
@@ -1,0 +1,95 @@
+//! This module implements the `partition` CLI command
+use influxdb_iox_client::{
+    connection::Builder,
+    management::{self, GetPartitionError, ListPartitionsError},
+};
+use structopt::StructOpt;
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error("Error listing partitions: {0}")]
+    ListPartitionsError(#[from] ListPartitionsError),
+
+    #[error("Error getting partition: {0}")]
+    GetPartitionsError(#[from] GetPartitionError),
+
+    #[error("Error rendering response as JSON: {0}")]
+    WritingJson(#[from] serde_json::Error),
+
+    // #[error("Error rendering response as JSON: {0}")]
+    // WritingJson(#[from] serde_json::Error),
+    #[error("Error connecting to IOx: {0}")]
+    ConnectionError(#[from] influxdb_iox_client::connection::Error),
+}
+
+pub type Result<T, E = Error> = std::result::Result<T, E>;
+
+/// Manage IOx partitions
+#[derive(Debug, StructOpt)]
+pub struct Config {
+    #[structopt(subcommand)]
+    command: Command,
+}
+
+/// List all known partition keys for a database
+#[derive(Debug, StructOpt)]
+struct List {
+    /// The name of the database
+    db_name: String,
+}
+
+/// Get details of a specific partition in JSON format (TODO)
+#[derive(Debug, StructOpt)]
+struct Get {
+    /// The name of the database
+    db_name: String,
+
+    /// The partition key
+    partition_key: String,
+}
+
+/// All possible subcommands for partition
+#[derive(Debug, StructOpt)]
+enum Command {
+    // List partitions
+    List(List),
+    // Get details about a particular partition
+    Get(Get),
+}
+
+pub async fn command(url: String, config: Config) -> Result<()> {
+    let connection = Builder::default().build(url).await?;
+    let mut client = management::Client::new(connection);
+
+    match config.command {
+        Command::List(list) => {
+            let List { db_name } = list;
+            let partition_keys = client.list_partitions(db_name).await?;
+            serde_json::to_writer_pretty(std::io::stdout(), &partition_keys)?;
+        }
+        Command::Get(get) => {
+            let Get {
+                db_name,
+                partition_key,
+            } = get;
+
+            let management::generated_types::Partition { key } =
+                client.get_partition(db_name, partition_key).await?;
+
+            // TODO: get more details from the partition, andprint it
+            // out better (i.e. move to using Partition summary that
+            // is already in data_types)
+            #[derive(serde::Serialize)]
+            struct PartitionDetail {
+                key: String,
+            }
+
+            let partition_detail = PartitionDetail { key };
+
+            serde_json::to_writer_pretty(std::io::stdout(), &partition_detail)?;
+        }
+    }
+
+    Ok(())
+}

--- a/src/influxdb_ioxd/rpc/management.rs
+++ b/src/influxdb_ioxd/rpc/management.rs
@@ -183,6 +183,52 @@ where
 
         Ok(Response::new(DeleteRemoteResponse {}))
     }
+
+    async fn list_partitions(
+        &self,
+        request: Request<ListPartitionsRequest>,
+    ) -> Result<Response<ListPartitionsResponse>, Status> {
+        let ListPartitionsRequest { db_name } = request.into_inner();
+        let db_name = DatabaseName::new(db_name).field("db_name")?;
+
+        let db = self.server.db(&db_name).ok_or_else(|| NotFound {
+            resource_type: "database".to_string(),
+            resource_name: db_name.to_string(),
+            ..Default::default()
+        })?;
+
+        let partition_keys = db.partition_keys().map_err(default_db_error_handler)?;
+
+        Ok(Response::new(ListPartitionsResponse { partition_keys }))
+    }
+
+    async fn get_partition(
+        &self,
+        request: Request<GetPartitionRequest>,
+    ) -> Result<Response<GetPartitionResponse>, Status> {
+        let GetPartitionRequest {
+            db_name,
+            partition_key,
+        } = request.into_inner();
+        let db_name = DatabaseName::new(db_name).field("db_name")?;
+
+        let db = self.server.db(&db_name).ok_or_else(|| NotFound {
+            resource_type: "database".to_string(),
+            resource_name: db_name.to_string(),
+            ..Default::default()
+        })?;
+
+        // TODO: get more actual partition details
+        let partition_keys = db.partition_keys().map_err(default_db_error_handler)?;
+
+        let partition = if partition_keys.contains(&partition_key) {
+            Some(Partition { key: partition_key })
+        } else {
+            None
+        };
+
+        Ok(Response::new(GetPartitionResponse { partition }))
+    }
 }
 
 pub fn make_server<M>(

--- a/src/influxdb_ioxd/rpc/management.rs
+++ b/src/influxdb_ioxd/rpc/management.rs
@@ -198,8 +198,12 @@ where
         })?;
 
         let partition_keys = db.partition_keys().map_err(default_db_error_handler)?;
+        let partitions = partition_keys
+            .into_iter()
+            .map(|key| Partition { key })
+            .collect::<Vec<_>>();
 
-        Ok(Response::new(ListPartitionsResponse { partition_keys }))
+        Ok(Response::new(ListPartitionsResponse { partitions }))
     }
 
     async fn get_partition(

--- a/tests/end_to_end_cases/management_api.rs
+++ b/tests/end_to_end_cases/management_api.rs
@@ -304,9 +304,16 @@ async fn test_partition_list() {
         .expect("listing partition");
 
     // ensure the output order is consistent
-    partitions.sort();
+    partitions.sort_by(|p1, p2| p1.key.cmp(&p2.key));
 
-    let expected = vec!["cpu".to_string(), "mem".to_string()];
+    let expected = vec![
+        Partition {
+            key: "cpu".to_string(),
+        },
+        Partition {
+            key: "mem".to_string(),
+        },
+    ];
 
     assert_eq!(
         expected, partitions,


### PR DESCRIPTION
Re https://github.com/influxdata/influxdb_iox/issues/942 and https://github.com/influxdata/influxdb_iox/issues/979

# Rationale:
I need a place to hang the CLI commands to move chunks in a partition (https://github.com/influxdata/influxdb_iox/issues/979)

# Changes:
* Add RPC definition + implementations for listing partitions
* Add new cli command `influxdb_iox database partition list db_name` to get a list of partition keys

# Follow on work
There is a bunch of information about a partition that should probably be included in the output of `database partition get` but I don't need it for my demo.

Thus, I figured I would get what I did need (`list`) up alongside the basic plumbing for `get` and we can fill in the details later

# Examples
List all partition keys;
```
./influxdb_iox database partition list my_db
[
  "2020-06-11 16:00:00",
  "2021-03-12 14:00:00"
]
```

Get detail of a particular partiton key (nothing interesting yet):
```
./influxdb_iox database partition get my_db "2021-03-12 14:00:00"
{
  "key": "2021-03-12 14:00:00"
}
```
