### PR TITLE
refactor: replicated write to represent new IOx organizational structure

### DIFF
--- a/generated_types/protos/wal.fbs
+++ b/generated_types/protos/wal.fbs
@@ -1,5 +1,68 @@
 namespace wal;
 
+// Every modification to a database is represented as an entry. These can be forwarded
+// on to other IOx servers or can be wrapped with a sequence number for ordering in
+// a WAL or subscribers.
+//
+// Take the example of sharding, where an IOx server is configured to split an
+// incoming write into shards and send them onto others. The batch of line protocol
+// written in a request will be split up so that each shard with data will have a
+// single Entry that will be sent to it. Writes to multiple partitions can be
+// represented with each having multiple lines. If the server that is doing the
+// sharding is not generating partition keys, the key in partition write won't be
+// present. It can be generated downstream. Although it's better to have the sharding
+// layer generate the partition keys while it's at the job of parsing and validating
+// the line protocol. This will save the downstream stateful layers from doing
+// extra work.
+table Entry {
+  writes: [PartitionWrite];
+  deletes: [Delete];
+}
+
+// A delete from a single table with a predicate.
+table Delete {
+  table_name: string;
+  predicate: string;
+}
+
+// A write to a  partition. If the IOx server creating this PartitionWrite has
+// no rules for generating partition keys, the key will be null, representing
+// the empty string.
+table PartitionWrite {
+  key: string;
+  table_batches: [TableWriteBatch];
+}
+
+// A collection of rows to write to a single table.
+table TableWriteBatch {
+  name: string;
+  rows: [Row];
+}
+
+// A single row
+table Row {
+  values: [Value];
+}
+
+// A value for a specific column
+table Value {
+  column: string;
+  value: ColumnValue;
+}
+
+union ColumnValue {
+  TagValue,
+  I64Value,
+  U64Value,
+  F64Value,
+  BoolValue,
+  StringValue
+}
+
+table TagValue {
+  value: string;
+}
+
 table I64Value {
   value: int64;
 }
@@ -20,78 +83,24 @@ table StringValue {
   value: string;
 }
 
-table Delete {
-  predicate: string;
-  start_time: int64;
-  stop_time: int64;
-}
+// The following definitions are for the WAL and for downstream subscribers to
+// the WAL.
 
-// Segment is a collection of ReplicatedWrites. It is the payload of a WAL
+// Segment is a collection of RawEntries. It is the payload of a WAL
 // segment file.
 table Segment {
   // the segment number
   id: uint64;
   // the writer id of the server that persisted this segment
   writer_id: uint32;
-  writes: [ReplicatedWriteData];
+  // the raw entry data along with their sequence numbers
+  entries: [SequencedEntry];
 }
 
-// ReplciatedWriteData is the raw bytes of an individual replicated write in a
-// segment.
-table ReplicatedWriteData {
-  // payload is the raw bytes of the replicated write
-  payload: [ubyte];
-}
-
-// ReplicatedWrite is what gets sent between InfluxDB IOx servers and potentially
-// persisted up to object storage from the servers that receive it. The combination
-// of the writer, timestamp and checksum in this table can be used to deduplicate
-// replicated writes from other hosts.
-table ReplicatedWrite {
-  // writer is a unique identifier for the router that received this write
-  writer: uint32;
-  // sequence is number this write comes in. This resets on restart of the writer
-  sequence: uint64;
-  // checksum is a crc32 checksum of the payload
-  checksum: uint32;
-  // payload is the raw bytes of a WriteBufferBatch
-  payload: [ubyte];
-}
-
-table WriteBufferBatch {
-  entries: [WriteBufferEntry];
-}
-
-table WriteBufferEntry {
-  partition_key: string;
-  table_batches: [TableWriteBatch];
-}
-
-enum ColumnType : byte { I64, U64, F64, Tag, String, Bool }
-
-table TableWriteBatch {
-  name: string;
-  rows: [Row];
-}
-
-table Row {
-  values: [Value];
-}
-
-table TagValue {
-  value: string;
-}
-
-union ColumnValue {
-  TagValue,
-  I64Value,
-  U64Value,
-  F64Value,
-  BoolValue,
-  StringValue
-}
-
-table Value {
-  column: string;
-  value: ColumnValue;
+// SequencedEntry are what get inserted into a WAL Buffer. These are
+// what go out to subscribers of the WAL. The sequence numbers can
+// be used to order the entries from a WAL server.
+table SequencedEntry {
+  sequence_number: uint64;
+  entry_data: [ubyte];
 }

--- a/generated_types/protos/wal.fbs
+++ b/generated_types/protos/wal.fbs
@@ -1,18 +1,5 @@
 namespace wal;
 
-table Entry {
-  entry_type: EntryType;
-}
-
-table EntryType {
-  write: Write;
-  delete: Delete;
-}
-
-table Write {
-  points: [Point];
-}
-
 table I64Value {
   value: int64;
 }
@@ -31,20 +18,6 @@ table BoolValue {
 
 table StringValue {
   value: string;
-}
-
-union PointValue {
-  I64Value,
-  U64Value,
-  F64Value,
-  BoolValue,
-  StringValue
-}
-
-table Point {
-  key: string;
-  time: int64;
-  value: PointValue;
 }
 
 table Delete {
@@ -70,15 +43,6 @@ table ReplicatedWriteData {
   payload: [ubyte];
 }
 
-// WriterSummary contains the inormation for a writer that has writes in a Segment
-table WriterSummary {
-  writer_id: uint64;
-  start_sequence: uint64;
-  end_sequence: uint64;
-  // if true, there are sequence numbers between start and end that were missing
-  missing_sequences: bool;
-}
-
 // ReplicatedWrite is what gets sent between InfluxDB IOx servers and potentially
 // persisted up to object storage from the servers that receive it. The combination
 // of the writer, timestamp and checksum in this table can be used to deduplicate
@@ -101,7 +65,6 @@ table WriteBufferBatch {
 table WriteBufferEntry {
   partition_key: string;
   table_batches: [TableWriteBatch];
-  delete: WriteBufferDelete;
 }
 
 enum ColumnType : byte { I64, U64, F64, Tag, String, Bool }
@@ -131,9 +94,4 @@ union ColumnValue {
 table Value {
   column: string;
   value: ColumnValue;
-}
-
-table WriteBufferDelete {
-  table_name: string;
-  predicate: string;
 }

--- a/generated_types/protos/wal.fbs
+++ b/generated_types/protos/wal.fbs
@@ -14,12 +14,23 @@ namespace wal;
 // layer generate the partition keys while it's at the job of parsing and validating
 // the line protocol. This will save the downstream stateful layers from doing
 // extra work.
+//
+// Even though this entry type has multiple fields (writes, deletes, others), they
+// are mutually exclusive. That is an Entry will only ever have one of those fields.
+// So you won't have an entry that has writes and deletes.
 table Entry {
+  // A collection of partition writes. A given partition will have at most one
+  // write in this collection.
   writes: [PartitionWrite];
+  // A collection of deletes. Each delete targets a single table, with each table
+  // having no more than one delete. Deletes can span partitions because they
+  // only have a predicate and do not target any specific partition.
   deletes: [Delete];
 }
 
-// A delete from a single table with a predicate.
+// A delete from a single table with a predicate. Deletes can span partitions since
+// they're concerned with data that has already been written. Partitioning is a way
+// to split up writes as they land.
 table Delete {
   table_name: string;
   predicate: string;

--- a/generated_types/protos/wal.fbs
+++ b/generated_types/protos/wal.fbs
@@ -102,5 +102,6 @@ table Segment {
 // be used to order the entries from a WAL server.
 table SequencedEntry {
   sequence_number: uint64;
+  writer_id: uint32;
   entry_data: [ubyte];
 }


### PR DESCRIPTION
Here's my proposal for how to refactor replicated write. It takes into account the splitting of data into shards and then putting that data into the WAL. It also removes old cruft that was no longer in use.

I wanted to get this up for comment before I push on it. The refactor is going to be pretty lengthy and touch many parts of the code base. It'll likely be best to just [view the file](https://github.com/influxdata/influxdb_iox/blob/59801ca4dbcd8a90eaf3a8cdfcf4169a4073f1ac/generated_types/protos/wal.fbs).