### PR TITLE
fix: Add ca-certificates to iox docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN \
 FROM debian:buster-slim
 
 RUN apt-get update \
-    && apt-get install -y libssl1.1 libgcc1 libc6 --no-install-recommends \
+    && apt-get install -y libssl1.1 libgcc1 libc6 ca-certificates --no-install-recommends \
 	&& rm -rf /var/lib/{apt,dpkg,cache,log}
 
 RUN groupadd -g 1500 rust \

--- a/docker/Dockerfile.iox
+++ b/docker/Dockerfile.iox
@@ -4,7 +4,7 @@
 FROM debian:buster-slim
 
 RUN apt-get update \
-    && apt-get install -y libssl1.1 libgcc1 libc6 \
+    && apt-get install -y libssl1.1 libgcc1 libc6 ca-certificates --no-install-recommends \
 	&& rm -rf /var/lib/{apt,dpkg,cache,log}
 
 RUN groupadd -g 1500 rust \


### PR DESCRIPTION
we cannot talk to S3 otherwise