### PR TITLE
feat: Management API + CLI command to list chunks in a partition

### DIFF
--- a/generated_types/protos/influxdata/iox/management/v1/service.proto
+++ b/generated_types/protos/influxdata/iox/management/v1/service.proto
@@ -44,6 +44,9 @@ service ManagementService {
   // Get detail information about a partition
   rpc GetPartition(GetPartitionRequest) returns (GetPartitionResponse);
 
+  // List chunks in a partition
+  rpc ListPartitionChunks(ListPartitionChunksRequest) returns (ListPartitionChunksResponse);
+
   // Create a new chunk in the mutable buffer
   rpc NewPartitionChunk(NewPartitionChunkRequest) returns (NewPartitionChunkResponse);
 
@@ -142,8 +145,8 @@ message ListPartitionsResponse {
   repeated Partition partitions = 1;
 }
 
-// Request to get details of a specific partition from a named database
-message GetPartitionRequest {
+// Request to list all chunks in a specific partitions from a named database
+message ListPartitionChunksRequest {
   // the name of the database
   string db_name = 1;
 
@@ -154,6 +157,20 @@ message GetPartitionRequest {
 message GetPartitionResponse {
   // Detailed information about a partition
   Partition partition = 1;
+}
+
+message ListPartitionChunksResponse {
+  // All chunks in a partition
+  repeated Chunk chunks = 1;
+}
+
+// Request to get details of a specific partition from a named database
+message GetPartitionRequest {
+  // the name of the database
+  string db_name = 1;
+
+  // the partition key
+  string partition_key = 2;
 }
 
 // Request that a new chunk for writing is created in the mutable buffer

--- a/server/src/db.rs
+++ b/server/src/db.rs
@@ -269,6 +269,20 @@ impl Db {
 
         Ok(())
     }
+
+    /// Return Summary information for chunks in the specified partition
+    pub fn partition_chunk_summaries(
+        &self,
+        partition_key: &str,
+    ) -> Result<impl Iterator<Item = ChunkSummary>> {
+        let summaries = self
+            .mutable_buffer_chunks(&partition_key)
+            .into_iter()
+            .chain(self.read_buffer_chunks(&partition_key).into_iter())
+            .map(|c| c.summary());
+
+        Ok(summaries)
+    }
 }
 
 impl PartialEq for Db {
@@ -326,12 +340,8 @@ impl Database for Db {
         let summaries = self
             .partition_keys()?
             .into_iter()
-            .map(|partition_key| {
-                self.mutable_buffer_chunks(&partition_key)
-                    .into_iter()
-                    .chain(self.read_buffer_chunks(&partition_key).into_iter())
-                    .map(|c| c.summary())
-            })
+            .map(|partition_key| self.partition_chunk_summaries(&partition_key))
+            .flatten()
             .flatten()
             .collect();
         Ok(summaries)
@@ -581,6 +591,48 @@ mod tests {
             sort: PartitionSort::LastWriteTime,
         };
         db.rules.mutable_buffer_config = Some(mbconf);
+    }
+
+    #[tokio::test]
+    async fn partition_chunk_summaries() {
+        // Test that chunk id listing is hooked up
+        let db = make_db();
+        let mut writer = TestLPWriter::default();
+
+        writer.write_lp_string(&db, "cpu bar=1 1").await.unwrap();
+        db.rollover_partition("1970-01-01T00").await.unwrap();
+
+        // write into a separate partitiion
+        writer
+            .write_lp_string(&db, "cpu bar=1,baz2,frob=3 400000000000000")
+            .await
+            .unwrap();
+
+        print!("Partitions: {:?}", db.partition_keys().unwrap());
+
+        fn to_arc(s: &str) -> Arc<String> {
+            Arc::new(s.to_string())
+        }
+
+        let mut chunk_summaries = db
+            .partition_chunk_summaries("1970-01-05T15")
+            .expect("expected summary to return")
+            .collect::<Vec<_>>();
+
+        chunk_summaries.sort_unstable();
+
+        let expected = vec![ChunkSummary {
+            partition_key: to_arc("1970-01-05T15"),
+            id: 0,
+            storage: ChunkStorage::OpenMutableBuffer,
+            estimated_bytes: 107,
+        }];
+
+        assert_eq!(
+            expected, chunk_summaries,
+            "expected:\n{:#?}\n\nactual:{:#?}\n\n",
+            expected, chunk_summaries
+        );
     }
 
     #[tokio::test]

--- a/server/src/db.rs
+++ b/server/src/db.rs
@@ -274,14 +274,11 @@ impl Db {
     pub fn partition_chunk_summaries(
         &self,
         partition_key: &str,
-    ) -> Result<impl Iterator<Item = ChunkSummary>> {
-        let summaries = self
-            .mutable_buffer_chunks(&partition_key)
+    ) -> impl Iterator<Item = ChunkSummary> {
+        self.mutable_buffer_chunks(&partition_key)
             .into_iter()
             .chain(self.read_buffer_chunks(&partition_key).into_iter())
-            .map(|c| c.summary());
-
-        Ok(summaries)
+            .map(|c| c.summary())
     }
 }
 
@@ -341,7 +338,6 @@ impl Database for Db {
             .partition_keys()?
             .into_iter()
             .map(|partition_key| self.partition_chunk_summaries(&partition_key))
-            .flatten()
             .flatten()
             .collect();
         Ok(summaries)
@@ -616,7 +612,6 @@ mod tests {
 
         let mut chunk_summaries = db
             .partition_chunk_summaries("1970-01-05T15")
-            .expect("expected summary to return")
             .collect::<Vec<_>>();
 
         chunk_summaries.sort_unstable();

--- a/src/influxdb_ioxd/rpc/management.rs
+++ b/src/influxdb_ioxd/rpc/management.rs
@@ -250,13 +250,8 @@ where
             ..Default::default()
         })?;
 
-        let chunk_summaries = match db.partition_chunk_summaries(&partition_key) {
-            Ok(chunk_summaries) => chunk_summaries,
-            Err(e) => return Err(default_db_error_handler(e)),
-        };
-
-        let chunks: Vec<Chunk> = chunk_summaries
-            .into_iter()
+        let chunks: Vec<Chunk> = db
+            .partition_chunk_summaries(&partition_key)
             .map(|summary| summary.into())
             .collect();
 

--- a/src/influxdb_ioxd/rpc/management.rs
+++ b/src/influxdb_ioxd/rpc/management.rs
@@ -234,6 +234,35 @@ where
         Ok(Response::new(GetPartitionResponse { partition }))
     }
 
+    async fn list_partition_chunks(
+        &self,
+        request: Request<ListPartitionChunksRequest>,
+    ) -> Result<Response<ListPartitionChunksResponse>, Status> {
+        let ListPartitionChunksRequest {
+            db_name,
+            partition_key,
+        } = request.into_inner();
+        let db_name = DatabaseName::new(db_name).field("db_name")?;
+
+        let db = self.server.db(&db_name).ok_or_else(|| NotFound {
+            resource_type: "database".to_string(),
+            resource_name: db_name.to_string(),
+            ..Default::default()
+        })?;
+
+        let chunk_summaries = match db.partition_chunk_summaries(&partition_key) {
+            Ok(chunk_summaries) => chunk_summaries,
+            Err(e) => return Err(default_db_error_handler(e)),
+        };
+
+        let chunks: Vec<Chunk> = chunk_summaries
+            .into_iter()
+            .map(|summary| summary.into())
+            .collect();
+
+        Ok(Response::new(ListPartitionChunksResponse { chunks }))
+    }
+
     async fn new_partition_chunk(
         &self,
         request: Request<NewPartitionChunkRequest>,


### PR DESCRIPTION
Part of https://github.com/influxdata/influxdb_iox/issues/979

# Rationale:
The commands to manipulate a chunk are in the context of a partition. The current CLI / management API to see chunks is database wide (across all partitions). Until there is a more general purpose way to restrict what comes back, add a ad hoc command to list just the chunks in a partition.

# Changes:
* Adds management API and CLI for listing chunks in a partition
* CLI looks like `./influxdb_iox database partition list-chunks <db_name> <partition_key>`


# Example

```
./influxdb_iox database partition list-chunks 26f7e5a4b7be365b_917b97a92e883afc '2021-03-15 12:00:00'`
[
  {
    "partition_key": "2021-03-15 12:00:00",
    "id": 0,
    "storage": "OpenMutableBuffer",
    "estimated_bytes": 0
  }
]
```


- [x] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb_iox/blob/main/README.md).
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
