### PR TITLE
feat: Add support for ready API to influxdb_client

### DIFF
--- a/influxdb2_client/examples/ready.rs
+++ b/influxdb2_client/examples/ready.rs
@@ -1,0 +1,11 @@
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let influx_url = "some-url";
+    let token = "some-token";
+
+    let client = influxdb2_client::Client::new(influx_url, token);
+
+    println!("{:?}", client.ready().await?);
+
+    Ok(())
+}

--- a/influxdb2_client/src/lib.rs
+++ b/influxdb2_client/src/lib.rs
@@ -302,3 +302,5 @@ cpu,host=server01,region=us-west usage=0.87
         Ok(())
     }
 }
+
+mod ready;

--- a/influxdb2_client/src/ready.rs
+++ b/influxdb2_client/src/ready.rs
@@ -1,0 +1,51 @@
+use reqwest::{Method, StatusCode};
+use snafu::ResultExt;
+
+use super::{Client, Http, RequestError, ReqwestProcessing};
+
+impl Client {
+    /// Get the readiness of an instance at startup
+    pub async fn ready(&self) -> Result<bool, RequestError> {
+        let ready_url = format!("{}/ready", self.url);
+        let response = self
+            .request(Method::GET, &ready_url)
+            .send()
+            .await
+            .context(ReqwestProcessing)?;
+
+        match response.status() {
+            StatusCode::OK => Ok(true),
+            _ => {
+                let status = response.status();
+                let text = response.text().await.context(ReqwestProcessing)?;
+                Http { status, text }.fail()?
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mockito::mock;
+
+    type Error = Box<dyn std::error::Error>;
+    type Result<T = (), E = Error> = std::result::Result<T, E>;
+
+    #[tokio::test]
+    async fn ready() -> Result {
+        let token = "some-token";
+
+        let mock_server = mock("GET", "/ready")
+            .match_header("Authorization", format!("Token {}", token).as_str())
+            .create();
+
+        let client = Client::new(&mockito::server_url(), token);
+
+        let _result = client.ready().await;
+
+        mock_server.assert();
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
Get the readiness of an instance at startup

Signed-off-by: Aakash Hemadri <aakashhemadri123@gmail.com>

Messed up #988
Could require possible edits if #998 is accepted. (placement of ready.rs and import in lib.rs)

- [x] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb_iox/blob/main/README.md).
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
