### PR TITLE
feat: Run background server thread in background and cleanup when server is done

### DIFF
--- a/src/influxdb_ioxd.rs
+++ b/src/influxdb_ioxd.rs
@@ -141,11 +141,11 @@ pub async fn main(logging_level: LoggingLevel, config: Config) -> Result<()> {
     let git_hash = option_env!("GIT_HASH").unwrap_or("UNKNOWN");
     info!(git_hash, "InfluxDB IOx server ready");
 
-    // Get IOx background worker task
-    let app = app_server.background_worker();
+    // start the background task
+    AppServer::start_background_task(&app_server);
 
     // TODO: Fix shutdown handling (#827)
-    let (grpc_server, server, _) = futures::future::join3(grpc_server, http_server, app).await;
+    let (grpc_server, server) = futures::future::join(grpc_server, http_server).await;
 
     grpc_server.context(ServingRPC)?;
     server.context(ServingHttp)?;


### PR DESCRIPTION
Re #827

# Rationale:
If Server.background_worker() is not running, any calls to `TaskTracker<T>::join` will hang forever. I found this while writing tests for `move_chunk`.

# Changes
Add a method that spawns the `background_worker` process for a server, existing the task when the server is torn down

The  property I want is “once the DB is dropped the background thread also is dropped without any explicit additional action” . I suspect there are multiple ways to achieve this goal

# Notes / Future Work
I think @tustvold  has some concerns about the (lack of) graceful shutdown story for the server in general (#827)(terminating hyper, etc)...  At the moment it may be highly non-trivial to reason about the order things shutdown.


- [x] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb_iox/blob/main/README.md).
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
