### PR TITLE
feat: Management API + CLI command to close a  chunk and move to read buffer

### DIFF
--- a/generated_types/protos/influxdata/iox/management/v1/jobs.proto
+++ b/generated_types/protos/influxdata/iox/management/v1/jobs.proto
@@ -2,22 +2,46 @@ syntax = "proto3";
 package influxdata.iox.management.v1;
 
 message OperationMetadata {
+  // How many nanoseconds of CPU time have been spent on this job so far?
   uint64 cpu_nanos = 1;
+
+  // How many nanoseconds has it been since the job was submitted
   uint64 wall_nanos = 2;
+
+  // How many total tasks does this job have currently
   uint64 task_count = 3;
+
+  // How many tasks for this job are still pending
   uint64 pending_count = 4;
 
+  // What kind of job is it?
   oneof job {
     Dummy dummy = 5;
     PersistSegment persist_segment = 6;
+    CloseChunk close_chunk = 7;
   }
 }
 
+// A job that simply sleeps for a specified time and then returns success
+message Dummy {
+  // How long the job should sleep for before
+  repeated uint64 nanos = 1;
+}
+
+// A job that persists a WAL segment to object store
 message PersistSegment {
   uint32 writer_id = 1;
   uint64 segment_id = 2;
 }
 
-message Dummy {
-  repeated uint64 nanos = 1;
+// A job that simply sleeps for a specified time and then returns success
+message CloseChunk {
+  // name of the database
+  string db_name = 1;
+
+  // partition key
+  string partition_key = 2;
+
+  // chunk_id
+  uint32 chunk_id = 3;
 }

--- a/generated_types/protos/influxdata/iox/management/v1/jobs.proto
+++ b/generated_types/protos/influxdata/iox/management/v1/jobs.proto
@@ -24,7 +24,7 @@ message OperationMetadata {
 
 // A job that simply sleeps for a specified time and then returns success
 message Dummy {
-  // How long the job should sleep for before
+  // How long the job should sleep for before returning
   repeated uint64 nanos = 1;
 }
 
@@ -34,7 +34,7 @@ message PersistSegment {
   uint64 segment_id = 2;
 }
 
-// A job that simply sleeps for a specified time and then returns success
+// Move a chunk from mutable buffer to read buffer
 message CloseChunk {
   // name of the database
   string db_name = 1;

--- a/generated_types/protos/influxdata/iox/management/v1/service.proto
+++ b/generated_types/protos/influxdata/iox/management/v1/service.proto
@@ -50,6 +50,9 @@ service ManagementService {
   // Create a new chunk in the mutable buffer
   rpc NewPartitionChunk(NewPartitionChunkRequest) returns (NewPartitionChunkResponse);
 
+  // Close a chunk and move it to the read buffer
+  rpc ClosePartitionChunk(ClosePartitionChunkRequest) returns (ClosePartitionChunkResponse);
+
 }
 
 message GetWriterIdRequest {}
@@ -183,4 +186,21 @@ message NewPartitionChunkRequest {
 }
 
 message NewPartitionChunkResponse {
+}
+
+// Request that a chunk be closed and moved to the read buffer
+message ClosePartitionChunkRequest {
+  // the name of the database
+  string db_name = 1;
+
+  // the partition key
+  string partition_key = 2;
+
+  // the chunk id
+  uint32 chunk_id = 3;
+}
+
+message ClosePartitionChunkResponse {
+  // The operation that tracks the work for migrating the chunk
+  google.longrunning.Operation operation = 1;
 }

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -403,7 +403,7 @@ impl<M: ConnectionManager> Server<M> {
         tracker
     }
 
-    /// Closes a chunk and starts movubg its data to the read buffer, as a
+    /// Closes a chunk and starts moving its data to the read buffer, as a
     /// background job, dropping when complete.
     pub fn close_chunk(
         &self,

--- a/src/influxdb_ioxd/rpc/error.rs
+++ b/src/influxdb_ioxd/rpc/error.rs
@@ -1,4 +1,4 @@
-use generated_types::google::{InternalError, NotFound, PreconditionViolation};
+use generated_types::google::{FieldViolation, InternalError, NotFound, PreconditionViolation};
 use tracing::error;
 
 /// map common `server::Error` errors  to the appropriate tonic Status
@@ -16,6 +16,11 @@ pub fn default_server_error_handler(error: server::Error) -> tonic::Status {
             resource_type: "database".to_string(),
             resource_name: db_name,
             ..Default::default()
+        }
+        .into(),
+        Error::InvalidDatabaseName { source } => FieldViolation {
+            field: "db_name".into(),
+            description: source.to_string(),
         }
         .into(),
         error => {

--- a/src/influxdb_ioxd/rpc/management.rs
+++ b/src/influxdb_ioxd/rpc/management.rs
@@ -292,7 +292,7 @@ where
         } = request.into_inner();
 
         // Validate that the database name is legit
-        DatabaseName::new(&db_name).field("db_name")?;
+        let db_name = DatabaseName::new(db_name).field("db_name")?;
 
         let tracker = self
             .server

--- a/src/influxdb_ioxd/rpc/management.rs
+++ b/src/influxdb_ioxd/rpc/management.rs
@@ -132,8 +132,8 @@ where
         request: Request<CreateDummyJobRequest>,
     ) -> Result<Response<CreateDummyJobResponse>, Status> {
         let request = request.into_inner();
-        let slot = self.server.spawn_dummy_job(request.nanos);
-        let operation = Some(super::operations::encode_tracker(slot)?);
+        let tracker = self.server.spawn_dummy_job(request.nanos);
+        let operation = Some(super::operations::encode_tracker(tracker)?);
         Ok(Response::new(CreateDummyJobResponse { operation }))
     }
 
@@ -279,6 +279,29 @@ where
             .map_err(default_db_error_handler)?;
 
         Ok(Response::new(NewPartitionChunkResponse {}))
+    }
+
+    async fn close_partition_chunk(
+        &self,
+        request: Request<ClosePartitionChunkRequest>,
+    ) -> Result<Response<ClosePartitionChunkResponse>, Status> {
+        let ClosePartitionChunkRequest {
+            db_name,
+            partition_key,
+            chunk_id,
+        } = request.into_inner();
+
+        // Validate that the database name is legit
+        DatabaseName::new(&db_name).field("db_name")?;
+
+        let tracker = self
+            .server
+            .close_chunk(db_name, partition_key, chunk_id)
+            .map_err(default_server_error_handler)?;
+
+        let operation = Some(super::operations::encode_tracker(tracker)?);
+
+        Ok(Response::new(ClosePartitionChunkResponse { operation }))
     }
 }
 

--- a/tests/end_to_end_cases/management_api.rs
+++ b/tests/end_to_end_cases/management_api.rs
@@ -1,27 +1,20 @@
 use std::num::NonZeroU32;
 
 use generated_types::{
-    google::protobuf::{Any, Duration, Empty},
+    google::protobuf::{Duration, Empty},
     influxdata::iox::management::v1::*,
-    protobuf_type_url_eq,
 };
 use influxdb_iox_client::management::CreateDatabaseError;
 use test_helpers::assert_contains;
 
-use crate::common::server_fixture::ServerFixture;
-
-use super::scenario::{
-    create_readable_database, create_two_partition_database, create_unreadable_database, rand_name,
+use super::{
+    operations_api::get_operation_metadata,
+    scenario::{
+        create_readable_database, create_two_partition_database, create_unreadable_database,
+        rand_name,
+    },
 };
-
-// TODO remove after #1001 and use something directly in the influxdb_iox_client
-// crate
-fn get_operation_metadata(metadata: Option<Any>) -> OperationMetadata {
-    assert!(metadata.is_some());
-    let metadata = metadata.unwrap();
-    assert!(protobuf_type_url_eq(&metadata.type_url, OPERATION_METADATA));
-    prost::Message::decode(metadata.value).expect("failed to decode metadata")
-}
+use crate::common::server_fixture::ServerFixture;
 
 #[tokio::test]
 async fn test_list_update_remotes() {

--- a/tests/end_to_end_cases/management_api.rs
+++ b/tests/end_to_end_cases/management_api.rs
@@ -1,7 +1,10 @@
 use std::num::NonZeroU32;
 
-use generated_types::google::protobuf::Empty;
-use generated_types::{google::protobuf::Duration, influxdata::iox::management::v1::*};
+use generated_types::{
+    google::protobuf::{Any, Duration, Empty},
+    influxdata::iox::management::v1::*,
+    protobuf_type_url_eq,
+};
 use influxdb_iox_client::management::CreateDatabaseError;
 use test_helpers::assert_contains;
 
@@ -10,6 +13,15 @@ use crate::common::server_fixture::ServerFixture;
 use super::scenario::{
     create_readable_database, create_two_partition_database, create_unreadable_database, rand_name,
 };
+
+// TODO remove after #1001 and use something directly in the influxdb_iox_client
+// crate
+fn get_operation_metadata(metadata: Option<Any>) -> OperationMetadata {
+    assert!(metadata.is_some());
+    let metadata = metadata.unwrap();
+    assert!(protobuf_type_url_eq(&metadata.type_url, OPERATION_METADATA));
+    prost::Message::decode(metadata.value).expect("failed to decode metadata")
+}
 
 #[tokio::test]
 async fn test_list_update_remotes() {
@@ -534,6 +546,89 @@ async fn test_new_partition_chunk_error() {
 
     let err = management_client
         .new_partition_chunk("this database does not exist", "nor_does_this_partition")
+        .await
+        .expect_err("expected error");
+
+    assert_contains!(err.to_string(), "Database not found");
+}
+
+#[tokio::test]
+async fn test_close_partition_chunk() {
+    use influxdb_iox_client::management::generated_types::operation_metadata::Job;
+    use influxdb_iox_client::management::generated_types::ChunkStorage;
+
+    let fixture = ServerFixture::create_shared().await;
+    let mut management_client = fixture.management_client();
+    let mut write_client = fixture.write_client();
+    let mut operations_client = fixture.operations_client();
+
+    let db_name = rand_name();
+    create_readable_database(&db_name, fixture.grpc_channel()).await;
+
+    let partition_key = "cpu";
+    let lp_lines = vec!["cpu,region=west user=23.2 100"];
+
+    write_client
+        .write(&db_name, lp_lines.join("\n"))
+        .await
+        .expect("write succeded");
+
+    let chunks = management_client
+        .list_chunks(&db_name)
+        .await
+        .expect("listing chunks");
+
+    assert_eq!(chunks.len(), 1, "Chunks: {:#?}", chunks);
+    assert_eq!(chunks[0].id, 0);
+    assert_eq!(chunks[0].storage, ChunkStorage::OpenMutableBuffer as i32);
+
+    // Move the chunk to read buffer
+    let operation = management_client
+        .close_partition_chunk(&db_name, partition_key, 0)
+        .await
+        .expect("new partition chunk");
+
+    println!("Operation response is {:?}", operation);
+    let operation_id = operation.name.parse().expect("not an integer");
+
+    let meta = get_operation_metadata(operation.metadata);
+
+    // ensure we got a legit job description back
+    if let Some(Job::CloseChunk(close_chunk)) = meta.job {
+        assert_eq!(close_chunk.db_name, db_name);
+        assert_eq!(close_chunk.partition_key, partition_key);
+        assert_eq!(close_chunk.chunk_id, 0);
+    } else {
+        panic!("unexpected job returned")
+    };
+
+    // wait for the job to be done
+    operations_client
+        .wait_operation(operation_id, Some(std::time::Duration::from_secs(1)))
+        .await
+        .expect("failed to wait operation");
+
+    // And now the chunk  should be good
+    let mut chunks = management_client
+        .list_chunks(&db_name)
+        .await
+        .expect("listing chunks");
+    chunks.sort_by(|c1, c2| c1.id.cmp(&c2.id));
+
+    assert_eq!(chunks.len(), 2, "Chunks: {:#?}", chunks);
+    assert_eq!(chunks[0].id, 0);
+    assert_eq!(chunks[0].storage, ChunkStorage::ReadBuffer as i32);
+    assert_eq!(chunks[1].id, 1);
+    assert_eq!(chunks[1].storage, ChunkStorage::OpenMutableBuffer as i32);
+}
+
+#[tokio::test]
+async fn test_close_partition_chunk_error() {
+    let fixture = ServerFixture::create_shared().await;
+    let mut management_client = fixture.management_client();
+
+    let err = management_client
+        .close_partition_chunk("this database does not exist", "nor_does_this_partition", 0)
         .await
         .expect_err("expected error");
 

--- a/tests/end_to_end_cases/operations_api.rs
+++ b/tests/end_to_end_cases/operations_api.rs
@@ -3,6 +3,8 @@ use generated_types::google::protobuf::Any;
 use influxdb_iox_client::{management::generated_types::*, operations, protobuf_type_url_eq};
 use std::time::Duration;
 
+// TODO remove after #1001 and use something directly in the influxdb_iox_client
+// crate
 fn get_operation_metadata(metadata: Option<Any>) -> OperationMetadata {
     assert!(metadata.is_some());
     let metadata = metadata.unwrap();

--- a/tests/end_to_end_cases/operations_api.rs
+++ b/tests/end_to_end_cases/operations_api.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 
 // TODO remove after #1001 and use something directly in the influxdb_iox_client
 // crate
-fn get_operation_metadata(metadata: Option<Any>) -> OperationMetadata {
+pub fn get_operation_metadata(metadata: Option<Any>) -> OperationMetadata {
     assert!(metadata.is_some());
     let metadata = metadata.unwrap();
     assert!(protobuf_type_url_eq(&metadata.type_url, OPERATION_METADATA));


### PR DESCRIPTION
Part of https://github.com/influxdata/influxdb_iox/issues/979

Note us built on  https://github.com/influxdata/influxdb_iox/pull/995 and https://github.com/influxdata/influxdb_iox/pull/1000 so those need to be merged first.

# Rationale:
Need a way to manually control the chunks on an IOx cluster

# Changes:
* Adds management API and CLI for closing a chunk in the mutable buffer and moving to read buffer
* CLI looks like `./influxdb_iox database partition close-chunk <db_name> <partition_key> <chunk_id>`


# Example

List chunks
```
./influxdb_iox database partition list-chunks 26f7e5a4b7be365b_917b97a92e883afc  "2021-03-16 20:00:00"
[
  {
    "partition_key": "2021-03-16 20:00:00",
    "id": 1,
    "storage": "OpenMutableBuffer",
    "estimated_bytes": 132086
  },
  {
    "partition_key": "2021-03-16 20:00:00",
    "id": 0,
    "storage": "ReadBuffer",
    "estimated_bytes": 708801
  }
]
```

Close current chunk (get handle to background task)
```
./influxdb_iox database partition close-chunk 26f7e5a4b7be365b_917b97a92e883afc  "2021-03-16 20:00:00" 1
{
  "id": 3,
  "task_count": 1,
  "pending_count": 1,
  "wall_time": {
    "secs": 0,
    "nanos": 0
  },
  "cpu_time": {
    "secs": 0,
    "nanos": 0
  },
  "job": {
    "CloseChunk": {
      "db_name": "26f7e5a4b7be365b_917b97a92e883afc",
      "partition_key": "2021-03-16 20:00:00",
      "chunk_id": 1
    }
  }
}
```

List chunks again see new chunk
```
./influxdb_iox database partition list-chunks 26f7e5a4b7be365b_917b97a92e883afc  "2021-03-16 20:00:00"
[
  {
    "partition_key": "2021-03-16 20:00:00",
    "id": 2,
    "storage": "OpenMutableBuffer",
    "estimated_bytes": 0
  },
  {
    "partition_key": "2021-03-16 20:00:00",
    "id": 0,
    "storage": "ReadBuffer",
    "estimated_bytes": 708801
  },
  {
    "partition_key": "2021-03-16 20:00:00",
    "id": 1,
    "storage": "ReadBuffer",
    "estimated_bytes": 119133
  }
]
```


- [x] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb_iox/blob/main/README.md).
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
