### PR TITLE
chore: Add debuginfo=0 to CI builds

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -19,6 +19,10 @@ on: [pull_request]
 
 name: ci
 
+env:
+  # Disable debug symbol generation to speed up CI build
+  RUSTFLAGS: "-C debuginfo=0"
+
 jobs:
 
   build:


### PR DESCRIPTION
Possibly this will make CI jobs faster

(the theory is that no one will be using the interactive debugger on builds created on CI so don't spend CPU cycles creating them)