### PR TITLE
fix(ci): Pass debuginfo=1 to have line numbers in tracebacks

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -20,8 +20,9 @@ on: [pull_request]
 name: ci
 
 env:
-  # Disable debug symbol generation to speed up CI build
-  RUSTFLAGS: "-C debuginfo=0"
+  # Disable full debug symbol generation to speed up CI build
+  # "1" means line tables only, which is useful for panic tracebacks.
+  RUSTFLAGS: "-C debuginfo=1"
 
 jobs:
 


### PR DESCRIPTION
I assumes that debuginfo=0 would still preserve traceback line numbers but I tried it out and it doesn't.
debuginfo=1 is almost as fast as debuginfo=1 (on my mac at least)