### PR TITLE
feat: Implement initial Catalog (Request for Comments)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -424,6 +424,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "catalog"
+version = "0.1.0"
+dependencies = [
+ "snafu",
+]
+
+[[package]]
 name = "cc"
 version = "1.0.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3132,6 +3139,7 @@ dependencies = [
  "arrow_deps",
  "async-trait",
  "bytes",
+ "catalog",
  "chrono",
  "crc32fast",
  "data_types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 [workspace] # In alphabetical order
 members = [
     "arrow_deps",
+    "catalog",
     "data_types",
     "generated_types",
     "google_types",

--- a/catalog/Cargo.toml
+++ b/catalog/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "catalog"
+version = "0.1.0"
+authors = ["Andrew Lamb <andrew@nerdnetworks.org>"]
+edition = "2018"
+description = "InfluxDB IOx Metadata catalog implementation"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+snafu = "0.6"

--- a/catalog/src/chunk.rs
+++ b/catalog/src/chunk.rs
@@ -1,0 +1,70 @@
+use std::sync::Arc;
+
+/// The state
+#[derive(Debug, PartialEq, Clone, Copy)]
+pub enum ChunkState {
+    /// Chunk can accept new writes
+    Open,
+
+    /// Chunk can still accept new writes, but will likely be closed soon
+    Closing,
+
+    /// Chunk is closed for new writes and has become read only
+    Closed,
+
+    /// Chunk is closed for new writes, and is actively moving to the read
+    /// buffer
+    Moving,
+
+    /// Chunk has been completely loaded in the read buffer
+    Moved,
+    // TODO do we need an "error" state??
+}
+
+/// The catalog representation of a Chunk in IOx. Note that a chunk
+/// may exist in several physical locations at any given time (e.g. in
+/// mutable buffer and in read buffer)
+#[derive(Debug, PartialEq)]
+pub struct Chunk {
+    /// What partition does the chunk belong to?
+    partition_key: Arc<String>,
+
+    /// The ID of the chunk
+    id: u32,
+
+    /// The state of this chunk
+    state: ChunkState,
+    /* TODO: Additional fields
+     *Object store path, etc. */
+}
+
+impl Chunk {
+    /// Create a new chunk in the Open state
+    pub(crate) fn new(partition_key: impl Into<String>, id: u32) -> Self {
+        let partition_key = Arc::new(partition_key.into());
+
+        Self {
+            partition_key,
+            id,
+            state: ChunkState::Open,
+        }
+    }
+
+    pub fn id(&self) -> u32 {
+        self.id
+    }
+
+    pub fn key(&self) -> &str {
+        self.partition_key.as_ref()
+    }
+
+    pub fn state(&self) -> ChunkState {
+        self.state
+    }
+
+    pub fn set_state(&mut self, state: ChunkState) {
+        // TODO add state transition validation here?
+
+        self.state = state;
+    }
+}

--- a/catalog/src/lib.rs
+++ b/catalog/src/lib.rs
@@ -1,0 +1,178 @@
+//! This module contains the implementation of the InfluxDB IOx Metadata catalog
+#![deny(rust_2018_idioms)]
+#![warn(
+    missing_debug_implementations,
+    clippy::explicit_iter_loop,
+    clippy::use_self,
+    clippy::clone_on_ref_ptr
+)]
+use std::collections::{btree_map::Entry, BTreeMap};
+
+//use snafu::{OptionExt, ResultExt, Snafu};
+use snafu::Snafu;
+
+#[derive(Debug, Snafu)]
+pub enum Error {
+    #[snafu(display("unknown chunk {}:{}", partition_key, chunk_id))]
+    NoSuchChunk {
+        partition_key: String,
+        chunk_id: u32,
+    },
+    #[snafu(display(
+        "internal error: can not create pre-existing partition: {}",
+        partition_key
+    ))]
+    InternalPartitionAlreadyExists { partition_key: String },
+}
+pub type Result<T, E = Error> = std::result::Result<T, E>;
+
+pub mod chunk;
+pub mod partition;
+
+use chunk::Chunk;
+use partition::Partition;
+
+/// InfluxDB IOx Metadata Catalog
+///
+/// The Catalog stores information such as which chunks exist, what
+/// state they are in, and what objects on object store are used, etc.
+///
+/// The catalog is also responsible for (eventually) persisting this
+/// information as well as ensuring that references between different
+/// objects remain valid (e.g. that the `partition_key` field of all
+/// Chunk's refer to valid partitions).
+#[derive(Debug, Default)]
+pub struct Catalog {
+    /// The set of chunks in this database. The key is the partition
+    /// key, the values are the chunks for that partition
+    chunks: BTreeMap<String, Vec<Chunk>>,
+
+    /// key is id, value is Partition data
+    partitions: BTreeMap<String, Partition>,
+}
+
+impl Catalog {
+    pub fn new() -> Self {
+        Self {
+            ..Default::default()
+        }
+    }
+
+    /// return an immutable chunk reference given the specified partition and
+    /// chunk id
+    pub fn chunk(&self, partition_key: impl AsRef<str>, chunk_id: u32) -> Option<&Chunk> {
+        // todo: build some sort of index so we don't have to look at all chunks
+        let partition_key = partition_key.as_ref();
+        self.chunks
+            .get(partition_key)
+            .map(|chunks| chunks.iter().find(|c| c.id() == chunk_id))
+            .unwrap_or(None)
+    }
+
+    /// return an mutable chunk reference given the specified partition and
+    /// chunk id
+    pub fn chunk_mut(
+        &mut self,
+        partition_key: impl AsRef<str>,
+        chunk_id: u32,
+    ) -> Option<&mut Chunk> {
+        // todo: build some sort of index so we don't have to look at all chunks
+        let partition_key = partition_key.as_ref();
+        self.chunks
+            .get_mut(partition_key)
+            .map(|chunks| chunks.iter_mut().find(|c| c.id() == chunk_id))
+            .unwrap_or(None)
+    }
+
+    /// Creates a new chunk with the catalog
+    ///
+    /// This function also validates 'referential integrity' - aka that the
+    /// partition
+    // referred to by this chunk exists in the catalog
+    pub fn create_chunk(&mut self, partition_key: &str, id: u32) -> Result<()> {
+        let chunks = self.chunks.get_mut(partition_key);
+
+        // TODO return a proper error here if there is no partititon
+        let chunks = chunks.expect("No such partition");
+
+        // Ensure this chunk doesn't already exist
+        if chunks.iter().find(|c| c.id() == id).is_some() {
+            panic!("chunk already exists");
+        }
+
+        chunks.push(Chunk::new(partition_key, id));
+        Ok(())
+    }
+
+    /// Removes the specified chunk from the catalog, returning the existing
+    /// chunk, if any
+    pub fn drop_chunk(&mut self, partition_key: &str, id: u32) -> Option<Chunk> {
+        let chunks = self.chunks.get_mut(partition_key);
+
+        // TODO return a proper error here if there is no partititon
+        let chunks = chunks.expect("No such partition");
+
+        let idx = chunks
+            .iter()
+            .enumerate()
+            .filter(|(_, c)| c.id() == id)
+            .map(|(i, _)| i)
+            .next();
+        if let Some(idx) = idx {
+            Some(chunks.remove(idx))
+        } else {
+            None
+        }
+    }
+
+    /// List all chunks in this database
+    pub fn chunks(&self) -> impl Iterator<Item = &Chunk> {
+        self.chunks.values().map(|chunks| chunks.iter()).flatten()
+    }
+
+    /// List all chunks in a particular partition
+    pub fn partition_chunks(&self, key: &str) -> impl Iterator<Item = &Chunk> {
+        self.chunks
+            .get(key)
+            .into_iter()
+            .map(|chunks| chunks.iter())
+            .flatten()
+    }
+
+    // List all partitions in this dataase
+    pub fn partitions(&self) -> impl Iterator<Item = &Partition> {
+        self.partitions.values()
+    }
+
+    // Get a specific partition by name
+    pub fn partition(&self, key: impl AsRef<str>) -> Option<&Partition> {
+        let key = key.as_ref();
+        self.partitions.get(key)
+    }
+
+    // Create a new partition in the catalog, returning an error if it already
+    // exists
+    pub fn create_partition(&mut self, key: impl Into<String>) -> Result<()> {
+        let key = key.into();
+
+        let entry = self.partitions.entry(key);
+        if matches!(entry, Entry::Occupied(_)) {
+            return InternalPartitionAlreadyExists {
+                partition_key: entry.key(),
+            }
+            .fail();
+        }
+
+        let chunks = self.chunks.insert(entry.key().to_string(), Vec::new());
+        //TODO proper error handling (shouldn't had a previous chunks entry)
+        assert!(chunks.is_none());
+
+        let partition = Partition::new(entry.key());
+        entry.or_insert(partition);
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {}

--- a/catalog/src/lib.rs
+++ b/catalog/src/lib.rs
@@ -96,7 +96,7 @@ impl Catalog {
         let chunks = chunks.expect("No such partition");
 
         // Ensure this chunk doesn't already exist
-        if chunks.iter().find(|c| c.id() == id).is_some() {
+        if chunks.iter().any(|c| c.id() == id) {
             panic!("chunk already exists");
         }
 

--- a/catalog/src/partition.rs
+++ b/catalog/src/partition.rs
@@ -1,0 +1,23 @@
+//! The catalog representation of a Partition
+
+use std::sync::Arc;
+
+#[derive(Debug, Default)]
+pub struct Partition {
+    /// The partition key
+    key: Arc<String>,
+}
+
+impl Partition {
+    /// Create a new partition catalog object.
+    pub(crate) fn new(key: impl Into<String>) -> Self {
+        let key = key.into();
+
+        let key = Arc::new(key);
+        Self { key }
+    }
+
+    pub fn key(&self) -> &Arc<String> {
+        &self.key
+    }
+}

--- a/influxdb_iox_client/src/client/management.rs
+++ b/influxdb_iox_client/src/client/management.rs
@@ -156,9 +156,9 @@ pub enum ListPartitionChunksError {
 /// Errors returned by Client::new_partition_chunk
 #[derive(Debug, Error)]
 pub enum NewPartitionChunkError {
-    /// Database not found
-    #[error("Database not found")]
-    DatabaseNotFound,
+    /// Database or partition not found
+    #[error("{}", .0)]
+    NotFound(String),
 
     /// Client received an unexpected error from the server
     #[error("Unexpected server error: {}: {}", .0.code(), .0.message())]
@@ -437,7 +437,9 @@ impl Client {
             })
             .await
             .map_err(|status| match status.code() {
-                tonic::Code::NotFound => NewPartitionChunkError::DatabaseNotFound,
+                tonic::Code::NotFound => {
+                    NewPartitionChunkError::NotFound(status.message().to_string())
+                },
                 _ => NewPartitionChunkError::ServerError(status),
             })?;
 

--- a/influxdb_iox_client/src/client/management.rs
+++ b/influxdb_iox_client/src/client/management.rs
@@ -439,7 +439,7 @@ impl Client {
             .map_err(|status| match status.code() {
                 tonic::Code::NotFound => {
                     NewPartitionChunkError::NotFound(status.message().to_string())
-                },
+                }
                 _ => NewPartitionChunkError::ServerError(status),
             })?;
 

--- a/mutable_buffer/src/database.rs
+++ b/mutable_buffer/src/database.rs
@@ -104,10 +104,10 @@ impl MutableBufferDb {
 
     /// Rolls over the active chunk in this partititon.  Returns the
     /// previously open (now closed) Chunk
-    pub fn rollover_partition(&self, partition_key: &str) -> Result<Arc<Chunk>> {
+    pub fn rollover_partition(&self, partition_key: &str) -> Arc<Chunk> {
         let partition = self.get_partition(partition_key);
         let mut partition = partition.write().expect("mutex poisoned");
-        Ok(partition.rollover_chunk())
+        partition.rollover_chunk()
     }
 
     /// return the specified chunk from the partition

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2018"
 arrow_deps = { path = "../arrow_deps" }
 async-trait = "0.1"
 bytes = "1.0"
+catalog = { path = "../catalog" }
 chrono = "0.4"
 crc32fast = "1.2.0"
 data_types = { path = "../data_types" }

--- a/server/src/db.rs
+++ b/server/src/db.rs
@@ -1,27 +1,25 @@
 //! This module contains the main IOx Database object which has the
 //! instances of the mutable buffer, read buffer, and object store
 
-use std::{
-    collections::BTreeMap,
-    sync::{
-        atomic::{AtomicU64, Ordering},
-        Arc,
-    },
+use std::sync::{
+    atomic::{AtomicU64, Ordering},
+    Arc,
 };
 
 use async_trait::async_trait;
+use catalog::{chunk::ChunkState, Catalog};
 use data_types::{chunk::ChunkSummary, database_rules::DatabaseRules};
 use internal_types::{data::ReplicatedWrite, selection::Selection};
 use mutable_buffer::MutableBufferDb;
-use parking_lot::Mutex;
-use query::{Database, PartitionChunk};
+use parking_lot::{Mutex, RwLock};
+use query::Database;
 use read_buffer::Database as ReadBufferDb;
 use serde::{Deserialize, Serialize};
 use snafu::{OptionExt, ResultExt, Snafu};
 
 use crate::buffer::Buffer;
 
-use tracing::info;
+use tracing::{debug, info};
 
 mod chunk;
 pub(crate) use chunk::DBChunk;
@@ -35,11 +33,41 @@ pub enum Error {
         source: mutable_buffer::chunk::Error,
     },
 
+    #[snafu(display("Cannot drop unknown chunk {} {} ", partition_key, chunk_id))]
+    UnknownChunkToDrop {
+        partition_key: String,
+        chunk_id: u32,
+    },
+
+    #[snafu(display("Internal error: can not rollover unknown partition chunk {} {}", partition_key, chunk_id ))]
+    InternalRolloverUnknownChunk {
+        partition_key: String,
+        chunk_id: u32,
+    },
+
+    #[snafu(display("Cannot rollover non existent partition:  {} ", partition_key ))]
+    UnknownPartition {
+        partition_key: String,
+    },
+
     #[snafu(display("Unknown Mutable Buffer Chunk {}", chunk_id))]
     UnknownMutableBufferChunk { chunk_id: u32 },
 
     #[snafu(display("Cannot write to this database: no mutable buffer configured"))]
     DatatbaseNotWriteable {},
+
+    #[snafu(display("Internal error: cannot create partition in catalog: {}", source))]
+    CreatingPartition {
+        partition_key: String,
+        source: catalog::Error,
+    },
+
+    #[snafu(display("Internal error: cannot create chunk in catalog: {}", source))]
+    CreatingChunk {
+        partition_key: String,
+        chunk_id: u32,
+        source: catalog::Error,
+    },
 
     #[snafu(display("Cannot read to this database: no mutable buffer configured"))]
     DatabaseNotReadable {},
@@ -56,11 +84,6 @@ pub enum Error {
 
     #[snafu(display("Error dropping data from mutable buffer: {}", source))]
     MutableBufferDrop {
-        source: mutable_buffer::database::Error,
-    },
-
-    #[snafu(display("Error rolling partition: {}", source))]
-    RollingPartition {
         source: mutable_buffer::database::Error,
     },
 
@@ -84,20 +107,33 @@ const STARTING_SEQUENCE: u64 = 1;
 #[derive(Debug, Serialize, Deserialize)]
 /// This is the main IOx Database object. It is the root object of any
 /// specific InfluxDB IOx instance
+///
+/// Catalog Usage: The high level invariant / design is that the state
+/// of the catalog and the state of the `Db` must remain in sync. If
+/// they are ever out of sync, the IOx system should be shutdown and
+/// forced through a "recovery" to correctly recconcile the state.
+///
+/// Ensuring the catalog and Db remain in sync is accomplished by
+/// manipulating the catalog state alongside the state in the `Db`
+/// itself. The catalog state can be observed (but not mutated) by things
+/// outside of the Db
 pub struct Db {
     #[serde(flatten)]
     pub rules: DatabaseRules,
 
     #[serde(skip)]
+    catalog: RwLock<Catalog>,
+
+    #[serde(skip)]
     /// The (optional) mutable buffer stores incoming writes. If a
     /// database does not have a mutable buffer it can not accept
     /// writes (it is a read replica)
-    pub mutable_buffer: Option<MutableBufferDb>,
+    mutable_buffer: Option<MutableBufferDb>,
 
     #[serde(skip)]
     /// The read buffer holds chunk data in an in-memory optimized
     /// format.
-    pub read_buffer: Arc<ReadBufferDb>,
+    read_buffer: Arc<ReadBufferDb>,
 
     #[serde(skip)]
     /// The wal buffer holds replicated writes in an append in-memory
@@ -117,8 +153,10 @@ impl Db {
     ) -> Self {
         let wal_buffer = wal_buffer.map(Mutex::new);
         let read_buffer = Arc::new(read_buffer);
+        let catalog = RwLock::new(Catalog::new());
         Self {
             rules,
+            catalog,
             mutable_buffer,
             read_buffer,
             wal_buffer,
@@ -129,28 +167,50 @@ impl Db {
     /// Rolls over the active chunk in the database's specified
     /// partition. Returns the previously open (now closed) Chunk
     pub async fn rollover_partition(&self, partition_key: &str) -> Result<Arc<DBChunk>> {
-        if let Some(local_store) = self.mutable_buffer.as_ref() {
-            local_store
-                .rollover_partition(partition_key)
-                .context(RollingPartition)
-                .map(|c| DBChunk::new_mb(c, partition_key, false))
-        } else {
-            DatatbaseNotWriteable {}.fail()
-        }
+        let mutable_buffer = self
+            .mutable_buffer
+            .as_ref()
+            .context(DatatbaseNotWriteable)?;
+
+        // hold catalog lock to prevent any concurrent modifications
+        let mut catalog = self.catalog.write();
+
+        // After this point, the catalog transaction has to succeed or
+        // we need to crash / force a recovery as the in-memory state
+        // may be inconsistent with the catalog state
+
+        // validate that the partition is known
+        catalog.partition(partition_key)
+            .context(UnknownPartition { partition_key })?;
+
+        let chunk_id = mutable_buffer.open_chunk_id(partition_key);
+
+        let catalog_chunk = catalog
+            .chunk_mut(partition_key, chunk_id)
+            .context(InternalRolloverUnknownChunk { partition_key, chunk_id})?;
+
+        assert_eq!(
+            catalog_chunk.state(),
+            ChunkState::Open,
+            "catalog mismatch??"
+        );
+
+        // This operation must be infallable (otherwise the catalog/state are out of
+        // sync)
+        let new_mb_chunk = mutable_buffer.rollover_partition(partition_key);
+
+        catalog_chunk.set_state(ChunkState::Closing);
+
+        // make a new chunk to track the newly created chunk in this partition
+        catalog
+            .create_chunk(partition_key, mutable_buffer.open_chunk_id(partition_key))
+            .unwrap();
+
+        // And we are all good here
+        return Ok(DBChunk::new_mb(new_mb_chunk, partition_key, false));
     }
 
-    /// Return true if the specified chunk is still open for new writes
-    pub fn is_open_chunk(&self, partition_key: &str, chunk_id: u32) -> bool {
-        if let Some(mutable_buffer) = self.mutable_buffer.as_ref() {
-            let open_chunk_id = mutable_buffer.open_chunk_id(partition_key);
-            open_chunk_id == chunk_id
-        } else {
-            false
-        }
-    }
-
-    // Return a list of all chunks in the mutable_buffer (that can
-    // potentially be migrated into the read buffer or object store)
+    // Get handles to all chunks in the mutable_buffer
     pub fn mutable_buffer_chunks(&self, partition_key: &str) -> Vec<Arc<DBChunk>> {
         let chunks = if let Some(mutable_buffer) = self.mutable_buffer.as_ref() {
             let open_chunk_id = mutable_buffer.open_chunk_id(partition_key);
@@ -169,7 +229,7 @@ impl Db {
         chunks
     }
 
-    // Return the specified chunk in the mutable buffer
+    // Return a handle to the specified chunk in the mutable buffer
     pub fn mutable_buffer_chunk(
         &self,
         partition_key: &str,
@@ -182,7 +242,10 @@ impl Db {
             .context(UnknownMutableBufferChunk { chunk_id })
     }
 
-    /// List chunks that are currently in the read buffer
+    /// Get handles to all chunks currently loaded the read buffer
+    ///
+    /// NOTE the results may contain partially loaded chunks. The catalog
+    /// should always be used to determine where to find each chunk
     pub fn read_buffer_chunks(&self, partition_key: &str) -> Vec<Arc<DBChunk>> {
         self.read_buffer
             .chunk_ids(partition_key)
@@ -191,73 +254,104 @@ impl Db {
             .collect()
     }
 
-    /// Drops the specified chunk from the mutable buffer, returning
-    /// the dropped chunk.
-    pub async fn drop_mutable_buffer_chunk(
-        &self,
-        partition_key: &str,
-        chunk_id: u32,
-    ) -> Result<Arc<DBChunk>> {
-        self.mutable_buffer
+    /// Drops the specified chunk from the catalog and all storage systems
+    pub fn drop_chunk(&self, partition_key: &str, chunk_id: u32) -> Result<()> {
+        debug!(%partition_key, %chunk_id, "dropping chunk");
+
+        let mutable_buffer = self
+            .mutable_buffer
             .as_ref()
-            .context(DatatbaseNotWriteable)?
+            .context(DatatbaseNotWriteable)?;
+
+        // TODO: avoid dropping chunks that are actively being moved??
+        // or is cleaning up after the movement ok?
+
+        // Remove chunk from the catalog
+        let mut catalog = self.catalog.write();
+        let chunk = catalog
             .drop_chunk(partition_key, chunk_id)
-            .map(|c| DBChunk::new_mb(c, partition_key, false))
-            .context(MutableBufferDrop)
+            .context(UnknownChunkToDrop {
+                partition_key,
+                chunk_id,
+            })?;
+
+        // clear it also from the read buffer / mutable buffer, if any
+        let (drop_mb, drop_rb) = match chunk.state() {
+            ChunkState::Open => (true, false),
+            ChunkState::Closing => (true, false),
+            ChunkState::Closed => (true, false),
+            ChunkState::Moving => (true, true), // data may be partially in read buffer
+            ChunkState::Moved => (false, true),
+        };
+
+        debug!(%partition_key, %chunk_id, chunk_state=?chunk.state(), drop_mb, drop_rb, "clearing chunk memory");
+
+        if drop_mb {
+            mutable_buffer
+                .drop_chunk(partition_key, chunk_id)
+                .context(MutableBufferDrop)?;
+        }
+
+        if drop_rb {
+            self.read_buffer
+                .drop_chunk(partition_key, chunk_id)
+                .context(ReadBufferDrop)?;
+        }
+
+        Ok(())
     }
 
-    /// Drops the specified chunk from the read buffer, returning
-    /// the dropped chunk.
-    pub async fn drop_read_buffer_chunk(
-        &self,
-        partition_key: &str,
-        chunk_id: u32,
-    ) -> Result<Arc<DBChunk>> {
-        self.read_buffer
-            .drop_chunk(partition_key, chunk_id)
-            .context(ReadBufferDrop)?;
-
-        Ok(DBChunk::new_rb(
-            Arc::clone(&self.read_buffer),
-            partition_key,
-            chunk_id,
-        ))
-    }
-
-    /// Loads a chunk into the ReadBuffer.
+    /// Copies a chunk in the Closing state into the ReadBuffer from
+    /// the mutable buffer and marks the chunk with `Moved` state
     ///
-    /// If the chunk is present in the mutable_buffer then it is
-    /// loaded from there. Otherwise, the chunk must be fetched from the
-    /// object store (Not yet implemented)
-    ///
-    /// Also uncontemplated as of yet is ensuring the read buffer does
-    /// not exceed a memory limit)
+    /// This code does not do any checking of the read buffer against
+    /// memory limits, etc
     ///
     /// This (async) function returns when this process is complete,
     /// but the process may take a long time
     ///
-    /// Returns a reference to the newly loaded chunk in the read buffer
+    /// Returns a handle to the newly loaded chunk in the read buffer
     pub async fn load_chunk_to_read_buffer(
         &self,
         partition_key: &str,
         chunk_id: u32,
     ) -> Result<Arc<DBChunk>> {
-        let mb_chunk = self.mutable_buffer_chunk(partition_key, chunk_id)?;
+        let mutable_buffer = self
+            .mutable_buffer
+            .as_ref()
+            .context(DatatbaseNotWriteable)?;
 
-        // Can't load an open chunk to the read buffer
-        if self.is_open_chunk(partition_key, chunk_id) {
-            return ChunkNotClosed {
-                partition_key,
-                chunk_id,
-            }
-            .fail();
+        if chunk_id == mutable_buffer.open_chunk_id(partition_key) {
+            debug!(%partition_key, %chunk_id, "rolling over partition to load into read buffer");
+            self.rollover_partition(partition_key).await?;
         }
+
+        // state must be "closing"
+        {
+            let mut catalog = self.catalog.write();
+            //todo real error
+            let catalog_chunk = catalog
+                .chunk_mut(partition_key, chunk_id)
+                .expect("chunk exists");
+            if catalog_chunk.state() != ChunkState::Closing {
+                // todo real error
+                panic!("Can only load chunks that are closing");
+            }
+
+            // update the catalog to say we are processing this chunk and
+            // then drop the lock while we do the work
+            catalog_chunk.set_state(ChunkState::Moving);
+            // drop the catalog lock and do the real work
+        }
+        let mb_chunk = self.mutable_buffer_chunk(partition_key, chunk_id)?;
+        debug!(%partition_key, %chunk_id, "chunk marked MOVING, loading tables into read buffer");
 
         let mut batches = Vec::new();
         for stats in mb_chunk.table_stats().unwrap() {
+            debug!(%partition_key, %chunk_id, table=%stats.name, "loading table to read buffer");
             mb_chunk
                 .table_to_arrow(&mut batches, &stats.name, Selection::All)
-                .unwrap();
+                .unwrap(); // TODO real error handling!
             for batch in batches.drain(..) {
                 // As implemented now, taking this write lock will wait
                 // until all reads to the read buffer to complete and
@@ -266,6 +360,31 @@ impl Db {
                     .upsert_partition(partition_key, mb_chunk.id(), &stats.name, batch)
             }
         }
+
+        // Relock the catalog again (nothing else should have
+        // been able to modify the chunk state while we were moving it.
+        //
+        // TODO: Handle the case we do in the case when someone dropped
+        // the chunk / partition while we were moving it. We probably
+        // need to purge it from the read buffer now after the fact
+        let mut catalog = self.catalog.write();
+        // TODO real error
+        let catalog_chunk = catalog
+            .chunk_mut(partition_key, chunk_id)
+            .expect("chunk exists");
+        if catalog_chunk.state() != ChunkState::Moving {
+            // todo real error
+            panic!("Chunk catalog mismatch");
+        }
+
+        // Drop chunk data from the mutable buffer
+        mutable_buffer
+            .drop_chunk(partition_key, chunk_id)
+            .expect("dropping mutable buffer chunk after movement");
+
+        // update the catalog to say we are done processing
+        catalog_chunk.set_state(ChunkState::Moved);
+        debug!(%partition_key, %chunk_id, "chunk marked MOVED. loading complete");
 
         Ok(DBChunk::new_rb(
             Arc::clone(&self.read_buffer),
@@ -281,6 +400,7 @@ impl Db {
 
     /// Drops partitions from the mutable buffer if it is over size
     pub fn check_size_and_drop_partitions(&self) -> Result<()> {
+        // TODO: update the catalog as well??
         if let (Some(db), Some(config)) = (&self.mutable_buffer, &self.rules.mutable_buffer_config)
         {
             let mut size = db.size();
@@ -306,7 +426,8 @@ impl Db {
         Ok(())
     }
 
-    /// Return Summary information for chunks in the specified partition
+    /// Return Summary information for all chunks in the specified
+    /// partition across all storage systems
     pub fn partition_chunk_summaries(
         &self,
         partition_key: &str,
@@ -315,6 +436,43 @@ impl Db {
             .into_iter()
             .chain(self.read_buffer_chunks(&partition_key).into_iter())
             .map(|c| c.summary())
+    }
+
+    /// Returns true if this database can accept writes
+    pub fn writeable(&self) -> bool {
+        self.mutable_buffer.is_some()
+    }
+
+    /// Ensures that all partition_keys referenced in the `write` have been
+    /// created in the catalog, doing so if necessary
+    fn create_partitions_if_needed(&self, write: &ReplicatedWrite) -> Result<()> {
+        let batch = if let Some(batch) = write.write_buffer_batch() {
+            batch
+        } else {
+            return Ok(());
+        };
+
+        let entries = if let Some(entries) = batch.entries() {
+            entries
+        } else {
+            return Ok(());
+        };
+
+        // Create any partitions in the catalog that might be created by these writes
+        let mut catalog = self.catalog.write();
+        for key in entries.into_iter().filter_map(|k| k.partition_key()) {
+            if catalog.partition(key).is_none() {
+                catalog
+                    .create_partition(key)
+                    .context(CreatingPartition { partition_key: key })?;
+                let chunk_id = 0;
+                catalog.create_chunk(key, chunk_id).context(CreatingChunk {
+                    partition_key: key,
+                    chunk_id,
+                })?;
+            }
+        }
+        Ok(())
     }
 }
 
@@ -332,27 +490,33 @@ impl Database for Db {
 
     /// Return a covering set of chunks for a particular partition
     fn chunks(&self, partition_key: &str) -> Vec<Arc<Self::Chunk>> {
-        // return a coverting set of chunks. TODO include read buffer
-        // chunks and take them preferentially from the read buffer.
-        // returns a coverting set of chunks -- aka take chunks from read buffer
-        // preferentially
-        let mutable_chunk_iter = self.mutable_buffer_chunks(partition_key).into_iter();
+        let catalog = self.catalog.read();
 
-        let read_buffer_chunk_iter = self.read_buffer_chunks(partition_key).into_iter();
-
-        let chunks: BTreeMap<_, _> = mutable_chunk_iter
-            .chain(read_buffer_chunk_iter)
-            .map(|chunk| (chunk.id(), chunk))
-            .collect();
-
-        // inserting into the map will have removed any dupes
-        chunks.into_iter().map(|(_id, chunk)| chunk).collect()
+        catalog
+            .partition_chunks(partition_key)
+            .map(|c| {
+                match c.state() {
+                    ChunkState::Open
+                    | ChunkState::Closing
+                    | ChunkState::Closed
+                    | ChunkState::Moving => {
+                        let mb_chunk = self
+                            .mutable_buffer_chunk(c.key(), c.id())
+                            .expect("catalog mismatch");
+                        // TODO remove the bool flat here
+                        DBChunk::new_mb(mb_chunk, partition_key, c.state() == ChunkState::Open)
+                    }
+                    ChunkState::Moved => {
+                        DBChunk::new_rb(Arc::clone(&self.read_buffer), partition_key, c.id())
+                    }
+                }
+            })
+            .collect()
     }
 
-    // Note that most of the functions below will eventually be removed from
-    // this trait. For now, pass them directly on to the local store
-
     async fn store_replicated_write(&self, write: &ReplicatedWrite) -> Result<(), Self::Error> {
+        self.create_partitions_if_needed(write)?;
+
         self.mutable_buffer
             .as_ref()
             .context(DatatbaseNotWriteable)?
@@ -362,11 +526,11 @@ impl Database for Db {
     }
 
     fn partition_keys(&self) -> Result<Vec<String>, Self::Error> {
-        self.mutable_buffer
-            .as_ref()
-            .context(DatabaseNotReadable)?
-            .partition_keys()
-            .context(MutableBufferRead)
+        let catalog = self.catalog.read();
+
+        let partition_keys = catalog.partitions().map(|p| p.key().to_string()).collect();
+
+        Ok(partition_keys)
     }
 
     fn chunk_summaries(&self) -> Result<Vec<ChunkSummary>> {
@@ -476,28 +640,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn no_load_open_chunk() {
-        // Test that data can not be loaded into the ReadBuffer while
-        // still open (no way to ensure that new data gets into the
-        // read buffer)
-        let db = make_db();
-        let mut writer = TestLPWriter::default();
-        writer.write_lp_string(&db, "cpu bar=1 10").await.unwrap();
-
-        let partition_key = "1970-01-01T00";
-        let err = db
-            .load_chunk_to_read_buffer(partition_key, 0)
-            .await
-            .unwrap_err();
-
-        // it should be the same chunk!
-        assert_contains!(
-            err.to_string(),
-            "Only closed chunks can be moved to read buffer. Chunk 1970-01-01T00 0 was open"
-        );
-    }
-
-    #[tokio::test]
     async fn read_from_read_buffer() {
         // Test that data can be loaded into the ReadBuffer
         let db = make_db();
@@ -517,7 +659,7 @@ mod tests {
 
         // we should have chunks in both the mutable buffer and read buffer
         // (Note the currently open chunk is not listed)
-        assert_eq!(mutable_chunk_ids(&db, partition_key), vec![0, 1]);
+        assert_eq!(mutable_chunk_ids(&db, partition_key), vec![1]);
         assert_eq!(read_buffer_chunk_ids(&db, partition_key), vec![0]);
 
         // data should be readable
@@ -532,21 +674,8 @@ mod tests {
         let batches = run_query(&db, "select * from cpu").await;
         assert_table_eq!(&expected, &batches);
 
-        // now, drop the mutable buffer chunk and results should still be the same
-        db.drop_mutable_buffer_chunk(partition_key, mb_chunk.id())
-            .await
-            .unwrap();
-
-        assert_eq!(mutable_chunk_ids(&db, partition_key), vec![1]);
-        assert_eq!(read_buffer_chunk_ids(&db, partition_key), vec![0]);
-
-        let batches = run_query(&db, "select * from cpu").await;
-        assert_table_eq!(&expected, &batches);
-
         // drop, the chunk from the read buffer
-        db.drop_read_buffer_chunk(partition_key, mb_chunk.id())
-            .await
-            .unwrap();
+        db.drop_chunk(partition_key, mb_chunk.id()).unwrap();
         assert_eq!(
             read_buffer_chunk_ids(&db, partition_key),
             vec![] as Vec<u32>
@@ -588,7 +717,7 @@ mod tests {
 
         writer.write_lp_string(&db, "cpu bar=1 40").await.unwrap();
 
-        assert_eq!(mutable_chunk_ids(&db, partition_key), vec![0, 1, 2]);
+        assert_eq!(mutable_chunk_ids(&db, partition_key), vec![0, 2]);
         assert_eq!(read_buffer_chunk_ids(&db, partition_key), vec![1]);
     }
 
@@ -695,7 +824,6 @@ mod tests {
         let mut writer = TestLPWriter::default();
 
         // get three chunks: one open, one closed in mb and one close in rb
-
         writer.write_lp_string(&db, "cpu bar=1 1").await.unwrap();
         db.rollover_partition("1970-01-01T00").await.unwrap();
 
@@ -704,15 +832,22 @@ mod tests {
             .await
             .unwrap();
 
-        // a fourth chunk in a different partition
         writer
-            .write_lp_string(&db, "cpu bar=1,baz2,frob=3 400000000000000")
+            .write_lp_string(&db, "cpu bar=1,baz=2,frob=3 400000000000000")
             .await
             .unwrap();
 
         print!("Partitions: {:?}", db.partition_keys().unwrap());
 
         db.load_chunk_to_read_buffer("1970-01-01T00", 0)
+            .await
+            .unwrap();
+
+        print!("Partitions2: {:?}", db.partition_keys().unwrap());
+
+        db.rollover_partition("1970-01-05T15").await.unwrap();
+        writer
+            .write_lp_string(&db, "cpu bar=1,baz=3,blargh=3 400000000000000")
             .await
             .unwrap();
 
@@ -724,12 +859,6 @@ mod tests {
         chunk_summaries.sort_unstable();
 
         let expected = vec![
-            ChunkSummary {
-                partition_key: to_arc("1970-01-01T00"),
-                id: 0,
-                storage: ChunkStorage::ClosedMutableBuffer,
-                estimated_bytes: 70,
-            },
             ChunkSummary {
                 partition_key: to_arc("1970-01-01T00"),
                 id: 0,
@@ -745,8 +874,14 @@ mod tests {
             ChunkSummary {
                 partition_key: to_arc("1970-01-05T15"),
                 id: 0,
+                storage: ChunkStorage::ClosedMutableBuffer,
+                estimated_bytes: 133,
+            },
+            ChunkSummary {
+                partition_key: to_arc("1970-01-05T15"),
+                id: 1,
                 storage: ChunkStorage::OpenMutableBuffer,
-                estimated_bytes: 107,
+                estimated_bytes: 135,
             },
         ];
 

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -88,7 +88,7 @@ use internal_types::data::{lines_to_replicated_write, ReplicatedWrite};
 
 use influxdb_line_protocol::ParsedLine;
 use object_store::{path::ObjectStorePath, ObjectStore, ObjectStoreApi};
-use query::{exec::Executor, DatabaseStore};
+use query::{exec::Executor, Database, DatabaseStore};
 
 use crate::{
     config::{
@@ -325,8 +325,8 @@ impl<M: ConnectionManager> Server<M> {
         db: &Db,
         write: ReplicatedWrite,
     ) -> Result<()> {
-        if let Some(buf) = &db.mutable_buffer {
-            buf.store_replicated_write(&write)
+        if db.writeable() {
+            db.store_replicated_write(&write)
                 .await
                 .map_err(|e| Box::new(e) as DatabaseError)
                 .context(UnknownDatabaseError {})?;
@@ -429,27 +429,8 @@ impl<M: ConnectionManager> Server<M> {
         });
 
         let task = async move {
-            // Close the chunk if it isn't already closed
-            if db.is_open_chunk(&partition_key, chunk_id) {
-                debug!(%db_name, %partition_key, %chunk_id, "Rolling over partition to close chunk");
-                let result = db.rollover_partition(&partition_key).await;
-
-                if let Err(e) = result {
-                    info!(?e, %db_name, %partition_key, %chunk_id, "background task error during chunk closing");
-                    return Err(e);
-                }
-            }
-
             debug!(%db_name, %partition_key, %chunk_id, "background task loading chunk to read buffer");
             let result = db.load_chunk_to_read_buffer(&partition_key, chunk_id).await;
-            if let Err(e) = result {
-                info!(?e, %db_name, %partition_key, %chunk_id, "background task error loading read buffer chunk");
-                return Err(e);
-            }
-
-            // now, drop the chunk
-            debug!(%db_name, %partition_key, %chunk_id, "background task dropping mutable buffer chunk");
-            let result = db.drop_mutable_buffer_chunk(&partition_key, chunk_id).await;
             if let Err(e) = result {
                 info!(?e, %db_name, %partition_key, %chunk_id, "background task error loading read buffer chunk");
                 return Err(e);

--- a/server/src/query_tests/scenarios.rs
+++ b/server/src/query_tests/scenarios.rs
@@ -50,14 +50,21 @@ impl DBSetup for NoData {
         writer.write_lp_string(&db, data).await.unwrap();
         // move data out of open chunk
         assert_eq!(db.rollover_partition(partition_key).await.unwrap().id(), 0);
-        // drop it
-        db.drop_mutable_buffer_chunk(partition_key, 0)
+
+        assert_eq!(db.mutable_buffer_chunks(partition_key).len(), 2);
+        assert_eq!(db.read_buffer_chunks(partition_key).len(), 0); // only open chunk
+
+        db.load_chunk_to_read_buffer(partition_key, 0)
             .await
             .unwrap();
 
         assert_eq!(db.mutable_buffer_chunks(partition_key).len(), 1);
+        assert_eq!(db.read_buffer_chunks(partition_key).len(), 1); // only open chunk
 
-        assert_eq!(db.read_buffer_chunks(partition_key).len(), 0); // only open chunk
+        db.drop_chunk(partition_key, 0).unwrap();
+
+        assert_eq!(db.mutable_buffer_chunks(partition_key).len(), 1);
+        assert_eq!(db.read_buffer_chunks(partition_key).len(), 0);
 
         let scenario3 = DBScenario {
             scenario_name: "Empty Database after drop chunk".into(),
@@ -228,26 +235,11 @@ pub(crate) async fn make_one_chunk_scenarios(partition_key: &str, data: &str) ->
         .await
         .unwrap();
     let scenario3 = DBScenario {
-        scenario_name: "Data in both read buffer and mutable buffer".into(),
+        scenario_name: "Data in read buffer".into(),
         db,
     };
 
-    let db = make_db();
-    let mut writer = TestLPWriter::default();
-    writer.write_lp_string(&db, data).await.unwrap();
-    db.rollover_partition(partition_key).await.unwrap();
-    db.load_chunk_to_read_buffer(partition_key, 0)
-        .await
-        .unwrap();
-    db.drop_mutable_buffer_chunk(partition_key, 0)
-        .await
-        .unwrap();
-    let scenario4 = DBScenario {
-        scenario_name: "Data in only read buffer and not mutable buffer".into(),
-        db,
-    };
-
-    vec![scenario1, scenario2, scenario3, scenario4]
+    vec![scenario1, scenario2, scenario3]
 }
 
 /// This function loads two chunks of lp data into 4 different scenarios
@@ -289,9 +281,6 @@ pub async fn make_two_chunk_scenarios(
     db.load_chunk_to_read_buffer(partition_key, 0)
         .await
         .unwrap();
-    db.drop_mutable_buffer_chunk(partition_key, 0)
-        .await
-        .unwrap();
     writer.write_lp_string(&db, data2).await.unwrap();
     let scenario3 = DBScenario {
         scenario_name: "Data in open chunk of mutable buffer, and one chunk of read buffer".into(),
@@ -309,14 +298,8 @@ pub async fn make_two_chunk_scenarios(
     db.load_chunk_to_read_buffer(partition_key, 0)
         .await
         .unwrap();
-    db.drop_mutable_buffer_chunk(partition_key, 0)
-        .await
-        .unwrap();
 
     db.load_chunk_to_read_buffer(partition_key, 1)
-        .await
-        .unwrap();
-    db.drop_mutable_buffer_chunk(partition_key, 1)
         .await
         .unwrap();
     let scenario4 = DBScenario {

--- a/src/influxdb_ioxd/rpc/error.rs
+++ b/src/influxdb_ioxd/rpc/error.rs
@@ -46,7 +46,7 @@ pub fn default_db_error_handler(error: server::db::Error) -> tonic::Status {
             description: "Cannot write to database: no mutable buffer configured".to_string(),
         }
         .into(),
-        Error::UnknownPartition {partition_key} => NotFound {
+        Error::UnknownPartition { partition_key } => NotFound {
             resource_type: "partition".to_string(),
             resource_name: partition_key,
             ..Default::default()

--- a/src/influxdb_ioxd/rpc/error.rs
+++ b/src/influxdb_ioxd/rpc/error.rs
@@ -46,6 +46,12 @@ pub fn default_db_error_handler(error: server::db::Error) -> tonic::Status {
             description: "Cannot write to database: no mutable buffer configured".to_string(),
         }
         .into(),
+        Error::UnknownPartition {partition_key} => NotFound {
+            resource_type: "partition".to_string(),
+            resource_name: partition_key,
+            ..Default::default()
+        }
+        .into(),
         error => {
             error!(?error, "Unexpected error");
             InternalError {}.into()

--- a/tests/end_to_end_cases/management_api.rs
+++ b/tests/end_to_end_cases/management_api.rs
@@ -279,20 +279,6 @@ async fn test_chunk_get_errors() {
     );
 
     create_unreadable_database(&db_name, fixture.grpc_channel()).await;
-
-    let err = management_client
-        .list_chunks(&db_name)
-        .await
-        .expect_err("db can't be read");
-
-    assert_contains!(
-        err.to_string(),
-        "Precondition violation influxdata.com/iox - database"
-    );
-    assert_contains!(
-        err.to_string(),
-        "Cannot read from database: no mutable buffer configured"
-    );
 }
 
 #[tokio::test]
@@ -508,28 +494,13 @@ async fn test_new_partition_chunk() {
         chunks
     );
 
-    // Rollover a (currently non existent) partition which is OK
-    management_client
+    // Rollover a (currently non existent) partition which is not OK
+    let err = management_client
         .new_partition_chunk(&db_name, "non_existent_partition")
         .await
-        .expect("new partition chunk");
+        .expect_err("new partition chunk");
 
-    assert_eq!(chunks.len(), 2, "Chunks: {:#?}", chunks);
-    assert_eq!(
-        chunks.iter().filter(|c| c.partition_key == "cpu").count(),
-        2,
-        "Chunks: {:#?}",
-        chunks
-    );
-    assert_eq!(
-        chunks
-            .iter()
-            .filter(|c| c.partition_key == "non_existent_partition")
-            .count(),
-        0,
-        "Chunks: {:#?}",
-        chunks
-    );
+    assert_eq!("Resource partition/non_existent_partition not found", err.to_string());
 }
 
 #[tokio::test]
@@ -542,7 +513,7 @@ async fn test_new_partition_chunk_error() {
         .await
         .expect_err("expected error");
 
-    assert_contains!(err.to_string(), "Database not found");
+    assert_contains!(err.to_string(), "Resource database/this database does not exist not found");
 }
 
 #[tokio::test]

--- a/tests/end_to_end_cases/management_api.rs
+++ b/tests/end_to_end_cases/management_api.rs
@@ -500,7 +500,10 @@ async fn test_new_partition_chunk() {
         .await
         .expect_err("new partition chunk");
 
-    assert_eq!("Resource partition/non_existent_partition not found", err.to_string());
+    assert_eq!(
+        "Resource partition/non_existent_partition not found",
+        err.to_string()
+    );
 }
 
 #[tokio::test]
@@ -513,7 +516,10 @@ async fn test_new_partition_chunk_error() {
         .await
         .expect_err("expected error");
 
-    assert_contains!(err.to_string(), "Resource database/this database does not exist not found");
+    assert_contains!(
+        err.to_string(),
+        "Resource database/this database does not exist not found"
+    );
 }
 
 #[tokio::test]

--- a/tests/end_to_end_cases/management_cli.rs
+++ b/tests/end_to_end_cases/management_cli.rs
@@ -497,7 +497,9 @@ async fn test_new_partition_chunk_error() {
         .arg(addr)
         .assert()
         .failure()
-        .stderr(predicate::str::contains("Resource database/non_existent_database not found"));
+        .stderr(predicate::str::contains(
+            "Resource database/non_existent_database not found",
+        ));
 }
 
 #[tokio::test]

--- a/tests/end_to_end_cases/management_cli.rs
+++ b/tests/end_to_end_cases/management_cli.rs
@@ -497,7 +497,7 @@ async fn test_new_partition_chunk_error() {
         .arg(addr)
         .assert()
         .failure()
-        .stderr(predicate::str::contains("Database not found"));
+        .stderr(predicate::str::contains("Resource database/non_existent_database not found"));
 }
 
 #[tokio::test]


### PR DESCRIPTION
# Overview
This PR has a proposed approach for a metadata catalog https://github.com/influxdata/influxdb_iox/issues/1016 and a demonstration of its use. Tests pass. The PR is based partially on code from @NGA-TRAN in https://github.com/influxdata/influxdb_iox/pull/944

I believe it also fixes https://github.com/influxdata/influxdb_iox/issues/1006 and https://github.com/influxdata/influxdb_iox/issues/1008 (concurrent read/modification of the read buffer)

The high level design is that the `Catalog` is used as the single source of truth about what chunks there are and what their "state" is. The Catalog is kept in sync with the state of the `Db` struct. 

This PR  also illustrates the dance required to create new objects in the catalog and keep it in sync with the state of the read buffer and mutable buffer (more comments inline). With this state tracking in place, coding the "move chunks automatically" should be relatively straightforward.

If people think this approach is reasonable, I will polish up this PR for merge ( write some tests for the catalog itself, add proper error handling, etc) 

# Rationale:
Introduce a single place that is responsible for tracking the state of chunks in the system
See background on https://github.com/influxdata/influxdb_iox/issues/1016 for additional rationle.

# Changes:
1. Add `Catalog`, `Partition` and `Chunk` catalog `struct`s
2. Change `Db` struct to use the `Catalog` as source of Chunk states
3. Remove direct manipulation of fields on db  (as now it will be important catalog doesn't get out of sync)

# Rough implementation plan:
1. PR with catalog structs + tests
2. PR to update `Db` to use catalog structs
3. PR to  chunk id assignment to the catalog from the mutable_buffer (this PR relies on implicit assumptions of ordering which may not be valid

# Future work
1. A better system for handling dependencies / ensuring referential integrity (e.g. that chunks always belong to a valid partition, etc). Right now that is managed internally in the Catalog but I am not 100% thrilled with this
2. Proper "transactions" for changes to multiple objects or any sort of fine grained concurrently control -- concurrency is controlled now by means of One Giant Lock (TM)
2. Persistence: There are still some unknown questions about how and what we will persist in the catalog (especially for state that is not reflected in the object store, such as Chunks which move between mutable_buffer and read buffer
3. Other types of catalog objects -- It may make sense to pull the `DatabaseRules` struct (and its serialization / deserialization) into the Catalog crate eventually

- [x] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb_iox/blob/main/README.md).
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
