### PR TITLE
refactor: Make `Db::mutable_buffer_chunks` and `Db::read_buffer_chunks` private

### DIFF
--- a/server/src/db.rs
+++ b/server/src/db.rs
@@ -256,7 +256,7 @@ impl Db {
     ///
     /// TODO: make this function non pub and use partition_summary
     /// information in the query_tests
-    pub fn mutable_buffer_chunks(&self, partition_key: &str) -> Vec<Arc<DBChunk>> {
+    fn mutable_buffer_chunks(&self, partition_key: &str) -> Vec<Arc<DBChunk>> {
         let chunks = if let Some(mutable_buffer) = self.mutable_buffer.as_ref() {
             let open_chunk_id = mutable_buffer.open_chunk_id(partition_key);
 
@@ -291,10 +291,7 @@ impl Db {
     ///
     /// NOTE the results may contain partially loaded chunks. The catalog
     /// should always be used to determine where to find each chunk
-    ///
-    /// TODO: make this function non pub and use partition_summary
-    /// information in the query_tests
-    pub fn read_buffer_chunks(&self, partition_key: &str) -> Vec<Arc<DBChunk>> {
+    fn read_buffer_chunks(&self, partition_key: &str) -> Vec<Arc<DBChunk>> {
         self.read_buffer
             .chunk_ids(partition_key)
             .into_iter()

--- a/server/src/query_tests/utils.rs
+++ b/server/src/query_tests/utils.rs
@@ -1,5 +1,9 @@
-use data_types::database_rules::DatabaseRules;
+use data_types::{
+    chunk::{ChunkStorage, ChunkSummary},
+    database_rules::DatabaseRules,
+};
 use mutable_buffer::MutableBufferDb;
+use query::Database;
 
 use crate::{db::Db, JobRegistry};
 use std::sync::Arc;
@@ -14,4 +18,28 @@ pub fn make_db() -> Db {
         None, // wal buffer
         Arc::new(JobRegistry::new()),
     )
+}
+
+fn chunk_summary_iter(db: &Db) -> impl Iterator<Item = ChunkSummary> + '_ {
+    db.partition_keys()
+        .unwrap()
+        .into_iter()
+        .flat_map(move |partition_key| db.partition_chunk_summaries(&partition_key))
+}
+
+/// Returns the number of mutable buffer chunks in the specified database
+pub fn count_mutable_buffer_chunks(db: &Db) -> usize {
+    chunk_summary_iter(db)
+        .filter(|s| {
+            s.storage == ChunkStorage::OpenMutableBuffer
+                || s.storage == ChunkStorage::ClosedMutableBuffer
+        })
+        .count()
+}
+
+/// Returns the number of read buffer chunks in the specified database
+pub fn count_read_buffer_chunks(db: &Db) -> usize {
+    chunk_summary_iter(db)
+        .filter(|s| s.storage == ChunkStorage::ReadBuffer)
+        .count()
 }


### PR DESCRIPTION
Builds on https://github.com/influxdata/influxdb_iox/pull/1043

# Rationale:
Reduce direct dependencies on how `Db` is structured in the rest of the code base (so we can more plausibly consolidate partitions)


# Change
Make `Db::mutable_buffer_chunks` and `Db::read_buffer_chunks` private


- [x] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb_iox/blob/main/README.md).
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
