### PR TITLE
feat: lifecycle rules (RFC)

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ influxdb_iox writer set 42
 To write data, you need to create a database. You can do so via the API or using the CLI. For example, to create a database called `company_sensors` with a 100MB mutable buffer, use this command:
 
 ```shell
-influxdb_iox database create company_sensors -m 100
+influxdb_iox database create company_sensors
 ```
 
 Data can be stored in InfluxDB IOx by sending it in [line protocol]

--- a/data_types/Cargo.toml
+++ b/data_types/Cargo.toml
@@ -13,7 +13,7 @@ influxdb_line_protocol = { path = "../influxdb_line_protocol" }
 percent-encoding = "2.1.0"
 prost = "0.7"
 regex = "1.4"
-serde = "1.0"
+serde = { version = "1.0", features = ["rc"] }
 serde_regex = "1.1"
 snafu = "0.6"
 tonic = { version = "0.4.0" }

--- a/data_types/src/chunk.rs
+++ b/data_types/src/chunk.rs
@@ -25,7 +25,7 @@ pub enum ChunkStorage {
 /// Represents metadata about a chunk in a database.
 /// A chunk can contain one or more tables.
 pub struct ChunkSummary {
-    /// The partitition key of this chunk
+    /// The partition key of this chunk
     pub partition_key: Arc<String>,
 
     /// The id of this chunk

--- a/generated_types/protos/influxdata/iox/management/v1/database_rules.proto
+++ b/generated_types/protos/influxdata/iox/management/v1/database_rules.proto
@@ -84,61 +84,75 @@ message WalBufferConfig {
   google.protobuf.Duration close_segment_after = 5;
 }
 
-message MutableBufferConfig {
-  message PartitionDropOrder {
+message LifecycleRules {
+  message SortOrder {
     message ColumnSort {
       string column_name = 1;
       ColumnType column_type = 2;
       Aggregate column_value = 3;
     }
 
-    // Sort partitions by this order. Last will be dropped first.
+    // Sort by this order
     Order order = 1;
 
     // Configure sort key
     oneof sort {
-      // The last time the partition received a write.
+      // The last time the item received a write.
       google.protobuf.Empty last_write_time = 2;
 
-      // When the partition was opened in the mutable buffer.
+      // When the item was created.
       google.protobuf.Empty created_at_time = 3;
 
       // A column name, its expected type, and whether to use the min or max
       // value. The ColumnType is necessary because the column can appear in
       // any number of tables and be of a different type. This specifies that
-      // when sorting partitions, only columns with the given name and type
-      // should be used for the purposes of determining the partition order. If a
-      // partition doesn't have the given column in any way, the partition will
-      // appear at the beginning of the list with a null value where all
-      // partitions having null for that value will then be
-      // sorted by created_at_time desc. So if none of the partitions in the
-      // mutable buffer had this column with this type, then the partition
-      // that was created first would appear last in the list and thus be the
-      // first up to be dropped.
+      // when sorting j, only columns with the given name and type
+      // should be used for the purposes of determining the order.
+      //
+      // All items are first sorted by created_at_time asc and then stably
+      // sorted based on the selected aggregate. If an item doesn't have the
+      // given column in any way, it will appear at the beginning of the list.
       ColumnSort column = 4;
     }
   }
-  // The size the mutable buffer should be limited to. Once the buffer gets
-  // to this size it will drop partitions in the given order. If unable
-  // to drop partitions (because of later rules in this config) it will
-  // reject writes until it is able to drop partitions.
-  uint64 buffer_size = 1;
 
-  // If set, the mutable buffer will not drop partitions that have chunks
-  // that have not yet been persisted. Thus it will reject writes if it
-  // is over size and is unable to drop partitions. The default is to
-  // drop partitions in the sort order, regardless of whether they have
-  // unpersisted chunks or not. The WAL Buffer can be used to ensure
-  // persistence, but this may cause longer recovery times.
-  bool reject_if_not_persisted = 2;
+  // A chunk of data within a partition that has been cold for writes for this
+  // many seconds will be frozen and compacted (moved to the read buffer)
+  // if the chunk is older than mutable_min_lifetime_seconds
+  //
+  // Represents the chunk transition open -> moving and closing -> moving
+  uint32 mutable_linger_seconds = 1;
 
-  // Configure order to drop partitions in
-  PartitionDropOrder partition_drop_order = 3;
+  // A chunk of data within a partition is guaranteed to remain mutable
+  // for at least this number of seconds
+  uint32 mutable_minimum_age_seconds = 2;
 
-  // Attempt to persist partitions after they haven't received a write for
-  // this number of seconds. If not set, partitions won't be
-  // automatically persisted.
-  uint32 persist_after_cold_seconds = 4;
+  // Once a chunk of data within a partition reaches this number of bytes
+  // writes outside its keyspace will be directed to a new chunk
+  //
+  // This chunk will be then compacted once it becomes cold for writes
+  // based on the mutable_linger_seconds and mutable_minimum_age_seconds
+  uint64 mutable_size_threshold = 3;
+
+  // Once the total amount of buffered data in memory reaches this size start
+  // dropping data from memory based on the drop_order
+  uint64 buffer_size_soft = 4;
+
+  // Once the amount of data in memory reaches this size start
+  // rejecting writes
+  uint64 buffer_size_hard = 5;
+
+  // Configure order to transition data
+  //
+  // In the case of multiple candidates, data will be
+  // compacted, persisted and dropped in this order
+  SortOrder sort_order = 6;
+
+  // Allow dropping data that has not been persisted to object storage
+  bool drop_non_persisted = 7;
+
+  // Do not allow writing new data to this database
+  bool immutable = 8;
 }
 
 message DatabaseRules {
@@ -148,11 +162,11 @@ message DatabaseRules {
   // Template that generates a partition key for each row inserted into the database
   PartitionTemplate partition_template = 2;
 
+  // Configures how data flows through the system
+  LifecycleRules lifecycle_rules = 3;
+
   // WAL configuration for this database
   WalBufferConfig wal_buffer_config = 6;
-
-  // Mutable buffer configuration for this database
-  MutableBufferConfig mutable_buffer_config = 7;
 
   // Shard  config
   ShardConfig shard_config = 8;

--- a/server/src/config.rs
+++ b/server/src/config.rs
@@ -55,7 +55,7 @@ impl Config {
             });
         }
 
-        let mutable_buffer = if rules.mutable_buffer_config.is_some() {
+        let mutable_buffer = if !rules.lifecycle_rules.immutable {
             Some(MutableBufferDb::new(name.to_string()))
         } else {
             None

--- a/server/src/db.rs
+++ b/server/src/db.rs
@@ -507,34 +507,6 @@ impl Db {
         self.sequence.fetch_add(1, Ordering::SeqCst)
     }
 
-    /// Drops partitions from the mutable buffer if it is over size
-    pub fn check_size_and_drop_partitions(&self) -> Result<()> {
-        // TODO: update the catalog as well??
-        if let (Some(db), Some(config)) = (&self.mutable_buffer, &self.rules.mutable_buffer_config)
-        {
-            let mut size = db.size();
-            if size > config.buffer_size {
-                let mut partitions = db.partitions_sorted_by(&config.partition_drop_order);
-                while let Some(p) = partitions.pop() {
-                    let p = p.read().expect("mutex poisoned");
-                    let partition_size = p.size();
-                    size -= partition_size;
-                    let key = p.key();
-                    db.drop_partition(key);
-                    info!(
-                        partition_key = key,
-                        partition_size, "dropped partition from mutable buffer",
-                    );
-                    if size < config.buffer_size {
-                        return Ok(());
-                    }
-                }
-            }
-        }
-
-        Ok(())
-    }
-
     /// Return Summary information for all chunks in the specified
     /// partition across all storage systems
     pub fn partition_chunk_summaries(
@@ -784,10 +756,7 @@ mod tests {
     use arrow_deps::{
         arrow::record_batch::RecordBatch, assert_table_eq, datafusion::physical_plan::collect,
     };
-    use data_types::{
-        chunk::ChunkStorage,
-        database_rules::{MutableBufferConfig, Order, PartitionSort, PartitionSortRules},
-    };
+    use data_types::chunk::ChunkStorage;
     use query::{
         exec::Executor, frontend::sql::SQLQueryPlanner, test::TestLPWriter, PartitionChunk,
     };
@@ -954,55 +923,6 @@ mod tests {
 
         assert_eq!(mutable_chunk_ids(&db, partition_key), vec![0, 2]);
         assert_eq!(read_buffer_chunk_ids(&db, partition_key), vec![1]);
-    }
-
-    #[tokio::test]
-    async fn check_size_and_drop_partitions() {
-        let mut mbconf = MutableBufferConfig {
-            buffer_size: 300,
-            ..Default::default()
-        };
-
-        let rules = DatabaseRules {
-            mutable_buffer_config: Some(mbconf.clone()),
-            ..Default::default()
-        };
-
-        let mut db = Db::new(
-            rules,
-            Some(MutableBufferDb::new("foo")),
-            read_buffer::Database::new(),
-            None, // wal buffer
-            Arc::new(JobRegistry::new()),
-        );
-
-        let mut writer = TestLPWriter::default();
-
-        writer.write_lp_to_partition(&db, "cpu,adsf=jkl,foo=bar val=1 1", "p1");
-        writer.write_lp_to_partition(&db, "cpu,foo=bar val=1 1", "p2");
-        writer.write_lp_to_partition(&db, "cpu,foo=bar val=1 1", "p3");
-
-        assert!(db.mutable_buffer.as_ref().unwrap().size() > 300);
-        db.check_size_and_drop_partitions().unwrap();
-        assert!(db.mutable_buffer.as_ref().unwrap().size() < 300);
-
-        let mut partitions = db
-            .mutable_buffer
-            .as_ref()
-            .unwrap()
-            .partition_keys()
-            .unwrap();
-        partitions.sort();
-        assert_eq!(&partitions[0], "p2");
-        assert_eq!(&partitions[1], "p3");
-
-        writer.write_lp_to_partition(&db, "cpu,foo=bar val=1 1", "p4");
-        mbconf.buffer_size = db.mutable_buffer.as_ref().unwrap().size();
-        mbconf.partition_drop_order = PartitionSortRules {
-            order: Order::Desc,
-            sort: PartitionSort::LastWriteTime,
-        };
-        db.rules.mutable_buffer_config = Some(mbconf);
     }
 
     #[tokio::test]

--- a/tests/end_to_end_cases/management_api.rs
+++ b/tests/end_to_end_cases/management_api.rs
@@ -185,16 +185,13 @@ async fn test_create_get_database() {
                 nanos: 2,
             }),
         }),
-        mutable_buffer_config: Some(MutableBufferConfig {
-            buffer_size: 553,
-            reject_if_not_persisted: true,
-            partition_drop_order: Some(mutable_buffer_config::PartitionDropOrder {
+        lifecycle_rules: Some(LifecycleRules {
+            buffer_size_hard: 553,
+            sort_order: Some(lifecycle_rules::SortOrder {
                 order: Order::Asc as _,
-                sort: Some(
-                    mutable_buffer_config::partition_drop_order::Sort::CreatedAtTime(Empty {}),
-                ),
+                sort: Some(lifecycle_rules::sort_order::Sort::CreatedAtTime(Empty {})),
             }),
-            persist_after_cold_seconds: 34,
+            ..Default::default()
         }),
         shard_config: None,
     };

--- a/tests/end_to_end_cases/management_cli.rs
+++ b/tests/end_to_end_cases/management_cli.rs
@@ -88,8 +88,8 @@ async fn test_create_database() {
                 .and(predicate::str::contains(format!("name: \"{}\"", db)))
                 // validate the defaults have been set reasonably
                 .and(predicate::str::contains("%Y-%m-%d %H:00:00"))
-                .and(predicate::str::contains("buffer_size: 104857600"))
-                .and(predicate::str::contains("MutableBufferConfig")),
+                .and(predicate::str::contains("buffer_size_hard: 104857600"))
+                .and(predicate::str::contains("LifecycleRules")),
         );
 }
 
@@ -105,7 +105,7 @@ async fn test_create_database_size() {
         .arg("database")
         .arg("create")
         .arg(db)
-        .arg("-m")
+        .arg("--buffer-size-hard")
         .arg("1000")
         .arg("--host")
         .arg(addr)
@@ -123,13 +123,13 @@ async fn test_create_database_size() {
         .assert()
         .success()
         .stdout(
-            predicate::str::contains("buffer_size: 1000")
-                .and(predicate::str::contains("MutableBufferConfig")),
+            predicate::str::contains("buffer_size_hard: 1000")
+                .and(predicate::str::contains("LifecycleRules")),
         );
 }
 
 #[tokio::test]
-async fn test_create_database_zero_size() {
+async fn test_create_database_immutable() {
     let server_fixture = ServerFixture::create_shared().await;
     let addr = server_fixture.grpc_base();
     let db_name = rand_name();
@@ -140,8 +140,7 @@ async fn test_create_database_zero_size() {
         .arg("database")
         .arg("create")
         .arg(db)
-        .arg("-m")
-        .arg("0")
+        .arg("--immutable")
         .arg("--host")
         .arg(addr)
         .assert()
@@ -158,7 +157,7 @@ async fn test_create_database_zero_size() {
         .assert()
         .success()
         // Should not have a mutable buffer
-        .stdout(predicate::str::contains("MutableBufferConfig").not());
+        .stdout(predicate::str::contains("immutable: true"));
 }
 
 #[tokio::test]

--- a/tests/end_to_end_cases/read_cli.rs
+++ b/tests/end_to_end_cases/read_cli.rs
@@ -26,8 +26,6 @@ async fn create_database(db_name: &str, addr: &str) {
         .arg("database")
         .arg("create")
         .arg(db_name)
-        .arg("-m")
-        .arg("100") // give it a mutable buffer
         .arg("--host")
         .arg(addr)
         .assert()

--- a/tests/end_to_end_cases/scenario.rs
+++ b/tests/end_to_end_cases/scenario.rs
@@ -96,12 +96,12 @@ impl Scenario {
         })
     }
 
-    /// Create's the database on the server for this scenario
+    /// Creates the database on the server for this scenario
     pub async fn create_database(&self, client: &mut influxdb_iox_client::management::Client) {
         client
             .create_database(DatabaseRules {
                 name: self.database_name().to_string(),
-                mutable_buffer_config: Some(Default::default()),
+                lifecycle_rules: Some(Default::default()),
                 ..Default::default()
             })
             .await
@@ -255,7 +255,7 @@ pub fn rand_id() -> String {
         .collect()
 }
 
-/// given a channel to talk with the managment api, create a new
+/// given a channel to talk with the management api, create a new
 /// database with the specified name configured with a 10MB mutable
 /// buffer, partitioned on table
 pub async fn create_readable_database(
@@ -271,8 +271,8 @@ pub async fn create_readable_database(
                 part: Some(partition_template::part::Part::Table(Empty {})),
             }],
         }),
-        mutable_buffer_config: Some(MutableBufferConfig {
-            buffer_size: 10 * 1024 * 1024,
+        lifecycle_rules: Some(LifecycleRules {
+            buffer_size_hard: 10 * 1024 * 1024,
             ..Default::default()
         }),
         ..Default::default()


### PR DESCRIPTION
A draft PR to get feedback - this will not compile.

This is my, potentially incorrect, interpretation of the feedback on #1041.

Specifically, as well articulated by @alamb, it seeks to provide a way to configure automatic:

* Movement of a chunk from mutable buffer -> read buffer
* Persisting of a chunk to parquet
* Dropping of chunks

As such it does the following:

* It renames MutableBufferConfig to LifecycleRules
* Renames PartitionDropOrder to SortOrder
* Adds additional new settings for configuring automated chunk movement
* Renames partition_drop_order to sort_order and generalises it to cover all chunk motion <sup>1</sup> <sup>2</sup> 

<sup>1</sup> _this implicitly encodes an assumption that people would prefer to drop data later in the lifecycle than earlier and only matters if configured to drop non persisted data_

<sup>2</sup>_It also is the other way round to the previous drop order where it would drop the last item in the order (i.e. reverse of the order specified), I can change if people feel strongly but it seemed counter-intuitive to me_

Now this does specify the motion in terms of chunks and not partitions. In most normal operation the two interpretations will be completely interchangeable. However, it was unclear to me if the last_write_time or created_at_time referred to the partitions or the chunks within the partitions, if it is the latter when backfilling the system will likely end up dropping hot data - which seems unfortunate? The formulation in terms of chunks should not materially impact the normal behaviour of the system, but I think is more precise in terms of what actually would be implemented?

Longer term it occurs to me that we are going to probably need some formulation of hot for reads, e.g. LRU or something, but that's likely not a problem until we have the ability to load historical data from object storage.
