### PR TITLE
fix: support upper case for scientific notation

### DIFF
--- a/influxdb_line_protocol/src/lib.rs
+++ b/influxdb_line_protocol/src/lib.rs
@@ -677,9 +677,7 @@ fn field_uinteger_value(i: &str) -> IResult<&str, u64> {
 fn field_float_value(i: &str) -> IResult<&str, f64> {
     let value = alt((
         field_float_value_with_exponential_and_decimal,
-        field_float_value_with_upper_case_exponential_and_decimal,
         field_float_value_with_exponential_no_decimal,
-        field_float_value_with_upper_case_exponential_no_decimal,
         field_float_value_with_decimal,
         field_float_value_no_decimal,
     ));
@@ -699,27 +697,13 @@ fn field_float_value_with_exponential_and_decimal(i: &str) -> IResult<&str, &str
         exponential_value,
     ))(i)
 }
-fn field_float_value_with_upper_case_exponential_and_decimal(i: &str) -> IResult<&str, &str> {
-    recognize(separated_pair(
-        integral_value_signed,
-        tag("."),
-        upper_case_exponential_value,
-    ))(i)
-}
+
 fn field_float_value_with_exponential_no_decimal(i: &str) -> IResult<&str, &str> {
     exponential_value(i)
 }
 
 fn exponential_value(i: &str) -> IResult<&str, &str> {
-    recognize(separated_pair(digit1, tag("e+"), digit1))(i)
-}
-
-fn field_float_value_with_upper_case_exponential_no_decimal(i: &str) -> IResult<&str, &str> {
-    upper_case_exponential_value(i)
-}
-
-fn upper_case_exponential_value(i: &str) -> IResult<&str, &str> {
-    recognize(separated_pair(digit1, tag("E+"), digit1))(i)
+    recognize(separated_pair(digit1, alt((tag("e+"), tag("E+"))), digit1))(i)
 }
 
 fn field_float_value_no_decimal(i: &str) -> IResult<&str, &str> {

--- a/influxdb_line_protocol/src/lib.rs
+++ b/influxdb_line_protocol/src/lib.rs
@@ -30,6 +30,7 @@ use snafu::{ResultExt, Snafu};
 use std::cmp::Ordering;
 use std::{
     borrow::Cow,
+    char,
     collections::{btree_map::Entry, BTreeMap},
     fmt,
     ops::Deref,
@@ -705,7 +706,7 @@ fn field_float_value_with_exponential_no_decimal(i: &str) -> IResult<&str, &str>
 fn exponential_value(i: &str) -> IResult<&str, &str> {
     recognize(separated_pair(
         digit1,
-        alt((tag("e+"), tag("E+"), tag("e-"), tag("E-"))),
+        tuple((alt((tag("e"), tag("E"))), alt((tag("-"), tag("+"))))),
         digit1,
     ))(i)
 }


### PR DESCRIPTION
Closes #1040

Add support upper case "E" for scientific notation

Describe your proposed changes here.

- [x] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb_iox/blob/main/README.md).
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
