### PR TITLE
fix: increase timing tolerance for tracker timing test (#1051)

### DIFF
--- a/server/src/tracker.rs
+++ b/server/src/tracker.rs
@@ -551,11 +551,12 @@ mod tests {
 
         let assert_fuzzy = |actual: usize, expected: std::time::Duration| {
             // Number of milliseconds of toleration
-            let epsilon = Duration::from_millis(10).as_nanos() as usize;
+            let epsilon = Duration::from_millis(25).as_nanos() as usize;
             let expected = expected.as_nanos() as usize;
 
+            // std::thread::sleep is guaranteed to take at least as long as requested
             assert!(
-                actual > expected.saturating_sub(epsilon),
+                actual > expected,
                 "Expected {} got {}",
                 expected,
                 actual

--- a/server/src/tracker.rs
+++ b/server/src/tracker.rs
@@ -555,12 +555,7 @@ mod tests {
             let expected = expected.as_nanos() as usize;
 
             // std::thread::sleep is guaranteed to take at least as long as requested
-            assert!(
-                actual > expected,
-                "Expected {} got {}",
-                expected,
-                actual
-            );
+            assert!(actual > expected, "Expected {} got {}", expected, actual);
             assert!(
                 actual < expected.saturating_add(epsilon),
                 "Expected {} got {}",


### PR DESCRIPTION
fixes #1051 

It would appear some systems may not wake from sleep in a timely manner - I suspect this is probably correlated with system load.

This bumps the threshold, and removes the epsilon lower bound as `std::thread::sleep` is guaranteed to sleep for at least as long as requested