### PR TITLE
refactor: Manage storage directly in the Catalog

### DIFF
--- a/mutable_buffer/src/chunk.rs
+++ b/mutable_buffer/src/chunk.rs
@@ -193,6 +193,16 @@ impl Chunk {
         self.time_closed = Some(Utc::now())
     }
 
+    // Add all tables names in this chunk to `names` if they are not already present
+    pub fn all_table_names(&self, names: &mut BTreeSet<String>) {
+        for &table_id in self.tables.keys() {
+            let table_name = self.dictionary.lookup_id(table_id).unwrap();
+            if !names.contains(table_name) {
+                names.insert(table_name.to_string());
+            }
+        }
+    }
+
     /// Return all the names of the tables names in this chunk that match
     /// chunk predicate
     pub fn table_names(&self, chunk_predicate: &ChunkPredicate) -> Result<Vec<&str>> {

--- a/query/src/lib.rs
+++ b/query/src/lib.rs
@@ -94,6 +94,14 @@ pub trait PartitionChunk: Debug + Send + Sync {
         known_tables: &StringSet,
     ) -> Result<Option<StringSet>, Self::Error>;
 
+    /// Adds all table names from this chunk without any predicate to
+    /// `known_tables)
+    ///
+    /// `known_tables` is a list of table names already known to be in
+    /// other chunks from the same partition. It may be empty or
+    /// contain `table_names` not in this chunk.
+    fn all_table_names(&self, known_tables: &mut StringSet);
+
     /// Returns a set of Strings with column names from the specified
     /// table that have at least one row that matches `predicate`, if
     /// the predicate can be evaluated entirely on the metadata of

--- a/query/src/test.rs
+++ b/query/src/test.rs
@@ -388,6 +388,10 @@ impl PartitionChunk for TestChunk {
         Ok(Some(names))
     }
 
+    fn all_table_names(&self, known_tables: &mut StringSet) {
+        known_tables.extend(self.table_schemas.keys().cloned())
+    }
+
     fn table_schema(
         &self,
         table_name: &str,

--- a/server/src/config.rs
+++ b/server/src/config.rs
@@ -7,7 +7,6 @@ use data_types::{
     database_rules::{DatabaseRules, WriterId},
     DatabaseName,
 };
-use mutable_buffer::MutableBufferDb;
 use object_store::path::ObjectStorePath;
 use read_buffer::Database as ReadBufferDb;
 
@@ -55,18 +54,11 @@ impl Config {
             });
         }
 
-        let mutable_buffer = if !rules.lifecycle_rules.immutable {
-            Some(MutableBufferDb::new(name.to_string()))
-        } else {
-            None
-        };
-
         let read_buffer = ReadBufferDb::new();
 
         let wal_buffer = rules.wal_buffer_config.as_ref().map(Into::into);
         let db = Arc::new(Db::new(
             rules,
-            mutable_buffer,
             read_buffer,
             wal_buffer,
             Arc::clone(&self.jobs),

--- a/server/src/db.rs
+++ b/server/src/db.rs
@@ -20,7 +20,7 @@ use arrow_deps::datafusion::{
 use catalog::{chunk::ChunkState, Catalog};
 use data_types::{chunk::ChunkSummary, database_rules::DatabaseRules, error::ErrorLogger};
 use internal_types::{data::ReplicatedWrite, selection::Selection};
-use mutable_buffer::{pred::ChunkPredicate, MutableBufferDb};
+use mutable_buffer::{chunk::Chunk, pred::ChunkPredicate};
 use query::{
     provider::{self, ProviderBuilder},
     Database, PartitionChunk, DEFAULT_SCHEMA,
@@ -50,25 +50,25 @@ pub enum Error {
         source: catalog::Error,
     },
 
-    #[snafu(display(
-        "Can not rollover partition chunk {} {}: {}",
-        partition_key,
-        chunk_id,
-        source
-    ))]
-    RollingOverChunk {
+    #[snafu(display("Can not rollover partition {}: {}", partition_key, source))]
+    RollingOverPartition {
         partition_key: String,
-        chunk_id: u32,
         source: catalog::Error,
     },
+
+    #[snafu(display(
+        "Internal error: no open chunk while rolling over partition {}",
+        partition_key,
+    ))]
+    InternalNoOpenChunk { partition_key: String },
 
     #[snafu(display("Internal error: unexpected state rolling over partition chunk {} {}: expected {:?}, but was {:?}",
                     partition_key, chunk_id, expected_state, actual_state))]
     InternalRollingOverUnexpectedState {
         partition_key: String,
         chunk_id: u32,
-        expected_state: ChunkState,
-        actual_state: ChunkState,
+        expected_state: String,
+        actual_state: String,
     },
 
     #[snafu(display(
@@ -80,19 +80,7 @@ pub enum Error {
     DropMovingChunk {
         partition_key: String,
         chunk_id: u32,
-        chunk_state: ChunkState,
-    },
-
-    #[snafu(display(
-        "Can load chunk {} {} to read buffer. Chunk was in state {:?}, needs to be Closing",
-        partition_key,
-        chunk_id,
-        chunk_state
-    ))]
-    LoadNonClosingChunk {
-        partition_key: String,
-        chunk_id: u32,
-        chunk_state: ChunkState,
+        chunk_state: String,
     },
 
     #[snafu(display(
@@ -122,7 +110,6 @@ pub enum Error {
     #[snafu(display("Internal error: cannot create chunk in catalog: {}", source))]
     CreatingChunk {
         partition_key: String,
-        chunk_id: u32,
         source: catalog::Error,
     },
 
@@ -170,11 +157,6 @@ pub struct Db {
     /// The metadata catalog
     catalog: Catalog,
 
-    /// The (optional) mutable buffer stores incoming writes. If a
-    /// database does not have a mutable buffer it can not accept
-    /// writes (it is a read replica)
-    mutable_buffer: Option<MutableBufferDb>,
-
     /// The read buffer holds chunk data in an in-memory optimized
     /// format.
     read_buffer: Arc<ReadBufferDb>,
@@ -195,7 +177,6 @@ pub struct Db {
 impl Db {
     pub fn new(
         rules: DatabaseRules,
-        mutable_buffer: Option<MutableBufferDb>,
         read_buffer: ReadBufferDb,
         wal_buffer: Option<Buffer>,
         jobs: Arc<JobRegistry>,
@@ -206,7 +187,6 @@ impl Db {
         Self {
             rules,
             catalog,
-            mutable_buffer,
             read_buffer,
             wal_buffer,
             jobs,
@@ -218,112 +198,42 @@ impl Db {
     /// Rolls over the active chunk in the database's specified
     /// partition. Returns the previously open (now closed) Chunk
     pub async fn rollover_partition(&self, partition_key: &str) -> Result<Arc<DBChunk>> {
-        let mutable_buffer = self
-            .mutable_buffer
-            .as_ref()
-            .context(DatatbaseNotWriteable)?;
-
         // After this point, the catalog transaction has to succeed or
         // we need to crash / force a recovery as the in-memory state
         // may be inconsistent with the catalog state
 
-        let chunk_id = mutable_buffer.open_chunk_id(partition_key);
-
         let partition = self
             .catalog
             .valid_partition(partition_key)
-            .context(RollingOverChunk {
-                partition_key,
-                chunk_id,
-            })?;
+            .context(RollingOverPartition { partition_key })?;
 
         let mut partition = partition.write();
-
-        let chunk = partition.chunk(chunk_id).context(RollingOverChunk {
-            partition_key,
-            chunk_id,
-        })?;
+        let chunk = partition
+            .open_chunk()
+            .context(InternalNoOpenChunk { partition_key })?;
 
         let mut chunk = chunk.write();
-
-        if chunk.state() != ChunkState::Open {
-            return InternalRollingOverUnexpectedState {
-                partition_key,
-                chunk_id,
-                expected_state: ChunkState::Open,
-                actual_state: chunk.state(),
-            }
-            .fail();
-        }
-
-        // after here, the operation must be infallable (otherwise
-        // the catalog/state are out of sync)
-        let new_mb_chunk = mutable_buffer.rollover_partition(partition_key);
-        chunk.set_state(ChunkState::Closing);
+        chunk
+            .set_closing()
+            .context(RollingOverPartition { partition_key })?;
 
         // make a new chunk to track the newly created chunk in this partition
-        partition
-            .create_chunk(mutable_buffer.open_chunk_id(partition_key))
-            .expect("Creating new chunk after partition rollover");
+        let new_chunk = partition
+            .create_chunk()
+            .context(RollingOverPartition { partition_key })?;
 
-        return Ok(DBChunk::new_mb(new_mb_chunk, partition_key, false));
-    }
+        let mut new_chunk = new_chunk.write();
+        let chunk_id = new_chunk.id();
+        new_chunk
+            .set_open(Chunk::new(chunk_id))
+            .context(RollingOverPartition { partition_key })?;
 
-    /// Get handles to all chunks in the mutable_buffer
-    ///
-    /// TODO: make this function non pub and use partition_summary
-    /// information in the query_tests
-    fn mutable_buffer_chunks(&self, partition_key: &str) -> Vec<Arc<DBChunk>> {
-        let chunks = if let Some(mutable_buffer) = self.mutable_buffer.as_ref() {
-            let open_chunk_id = mutable_buffer.open_chunk_id(partition_key);
-
-            mutable_buffer
-                .chunks(partition_key)
-                .into_iter()
-                .map(|c| {
-                    let open = c.id() == open_chunk_id;
-                    DBChunk::new_mb(c, partition_key, open)
-                })
-                .collect()
-        } else {
-            vec![]
-        };
-        chunks
-    }
-
-    /// Return a handle to the specified chunk in the mutable buffer
-    fn mutable_buffer_chunk(
-        &self,
-        partition_key: &str,
-        chunk_id: u32,
-    ) -> Result<Arc<mutable_buffer::chunk::Chunk>> {
-        self.mutable_buffer
-            .as_ref()
-            .context(DatatbaseNotWriteable)?
-            .get_chunk(partition_key, chunk_id)
-            .context(UnknownMutableBufferChunk { chunk_id })
-    }
-
-    /// Get handles to all chunks currently loaded the read buffer
-    ///
-    /// NOTE the results may contain partially loaded chunks. The catalog
-    /// should always be used to determine where to find each chunk
-    fn read_buffer_chunks(&self, partition_key: &str) -> Vec<Arc<DBChunk>> {
-        self.read_buffer
-            .chunk_ids(partition_key)
-            .into_iter()
-            .map(|chunk_id| DBChunk::new_rb(Arc::clone(&self.read_buffer), partition_key, chunk_id))
-            .collect()
+        return Ok(DBChunk::snapshot(&chunk));
     }
 
     /// Drops the specified chunk from the catalog and all storage systems
     pub fn drop_chunk(&self, partition_key: &str, chunk_id: u32) -> Result<()> {
         debug!(%partition_key, %chunk_id, "dropping chunk");
-
-        let mutable_buffer = self
-            .mutable_buffer
-            .as_ref()
-            .context(DatatbaseNotWriteable)?;
 
         let partition = self
             .catalog
@@ -333,56 +243,50 @@ impl Db {
                 chunk_id,
             })?;
 
-        // lock the partition so that no one else can be messing with
-        // it while we drop the chunk
+        // lock the partition so that no one else can be messing /
+        // with it while we drop the chunk
         let mut partition = partition.write();
 
-        let chunk_state = {
+        // We can remove the need to drop the read buffer chunk once
+        // we inline its ownership into Catalog::Chunk
+        let mut drop_rb = false;
+        let chunk_state;
+
+        {
             let chunk = partition.chunk(chunk_id).context(DroppingChunk {
                 partition_key,
                 chunk_id,
             })?;
             let chunk = chunk.read();
+            chunk_state = chunk.state().name();
 
-            let chunk_state = chunk.state();
             // prevent chunks that are actively being moved. TODO it
             // would be nicer to allow this to happen have the chunk
             // migration logic cleanup afterwards so that users
             // weren't prevented from dropping chunks due to
             // background tasks
-            if chunk_state == ChunkState::Moving {
-                return DropMovingChunk {
-                    partition_key,
-                    chunk_id,
-                    chunk_state,
+            match chunk.state() {
+                ChunkState::Moving(_) => {
+                    return DropMovingChunk {
+                        partition_key,
+                        chunk_id,
+                        chunk_state,
+                    }
+                    .fail()
                 }
-                .fail();
+                ChunkState::Moved(_) => {
+                    drop_rb = true;
+                }
+                _ => {}
             }
-            chunk_state
         };
+
+        debug!(%partition_key, %chunk_id, %chunk_state, drop_rb, "dropping chunk");
 
         partition.drop_chunk(chunk_id).context(DroppingChunk {
             partition_key,
             chunk_id,
         })?;
-
-        // clear it also from the read buffer / mutable buffer, if needed
-        let (drop_mb, drop_rb) = match chunk_state {
-            ChunkState::Open => (true, false),
-            ChunkState::Closing => (true, false),
-            ChunkState::Closed => (true, false),
-            ChunkState::Moving => (true, true), /* not possible as `ChunkState::Moving` checked */
-            // above
-            ChunkState::Moved => (false, true),
-        };
-
-        debug!(%partition_key, %chunk_id, ?chunk_state, drop_mb, drop_rb, "clearing chunk memory");
-
-        if drop_mb {
-            mutable_buffer
-                .drop_chunk(partition_key, chunk_id)
-                .expect("Dropping mutable buffer chunk");
-        }
 
         if drop_rb {
             self.read_buffer
@@ -408,16 +312,6 @@ impl Db {
         partition_key: &str,
         chunk_id: u32,
     ) -> Result<Arc<DBChunk>> {
-        let mutable_buffer = self
-            .mutable_buffer
-            .as_ref()
-            .context(DatatbaseNotWriteable)?;
-
-        if chunk_id == mutable_buffer.open_chunk_id(partition_key) {
-            debug!(%partition_key, %chunk_id, "rolling over partition to load into read buffer");
-            self.rollover_partition(partition_key).await?;
-        }
-
         let chunk = {
             let partition = self
                 .catalog
@@ -436,23 +330,15 @@ impl Db {
 
         // update the catalog to say we are processing this chunk and
         // then drop the lock while we do the work
-        {
+        let mb_chunk = {
             let mut chunk = chunk.write();
-            let chunk_state = chunk.state();
 
-            if chunk_state != ChunkState::Closing {
-                return LoadNonClosingChunk {
-                    partition_key,
-                    chunk_id,
-                    chunk_state,
-                }
-                .fail();
-            }
+            chunk.set_moving().context(LoadingChunk {
+                partition_key,
+                chunk_id,
+            })?
+        };
 
-            chunk.set_state(ChunkState::Moving);
-        }
-
-        let mb_chunk = self.mutable_buffer_chunk(partition_key, chunk_id)?;
         debug!(%partition_key, %chunk_id, "chunk marked MOVING, loading tables into read buffer");
 
         let mut batches = Vec::new();
@@ -481,25 +367,17 @@ impl Db {
         // Relock the chunk again (nothing else should have been able
         // to modify the chunk state while we were moving it
         let mut chunk = chunk.write();
-
-        if chunk.state() != ChunkState::Moving {
-            panic!("Chunk state change while it was moving");
-        }
-
-        // Drop chunk data from the mutable buffer
-        mutable_buffer
-            .drop_chunk(partition_key, chunk_id)
-            .expect("dropping mutable buffer chunk after movement");
-
         // update the catalog to say we are done processing
-        chunk.set_state(ChunkState::Moved);
+        chunk
+            .set_moved(Arc::clone(&self.read_buffer))
+            .context(LoadingChunk {
+                partition_key,
+                chunk_id,
+            })?;
+
         debug!(%partition_key, %chunk_id, "chunk marked MOVED. loading complete");
 
-        Ok(DBChunk::new_rb(
-            Arc::clone(&self.read_buffer),
-            partition_key,
-            mb_chunk.id,
-        ))
+        Ok(DBChunk::snapshot(&chunk))
     }
 
     /// Returns the next write sequence number
@@ -513,10 +391,7 @@ impl Db {
         &self,
         partition_key: &str,
     ) -> impl Iterator<Item = ChunkSummary> {
-        self.mutable_buffer_chunks(&partition_key)
-            .into_iter()
-            .chain(self.read_buffer_chunks(&partition_key).into_iter())
-            .map(|c| c.summary())
+        self.chunks(partition_key).into_iter().map(|c| c.summary())
     }
 
     /// Returns the number of iterations of the background worker loop
@@ -544,40 +419,7 @@ impl Db {
 
     /// Returns true if this database can accept writes
     pub fn writeable(&self) -> bool {
-        self.mutable_buffer.is_some()
-    }
-
-    /// Ensures that all partition_keys referenced in the `write` have been
-    /// created in the catalog, doing so if necessary
-    fn create_partitions_if_needed(&self, write: &ReplicatedWrite) -> Result<()> {
-        let batch = if let Some(batch) = write.write_buffer_batch() {
-            batch
-        } else {
-            return Ok(());
-        };
-
-        let entries = if let Some(entries) = batch.entries() {
-            entries
-        } else {
-            return Ok(());
-        };
-
-        // Create any partitions in the catalog that might be created by these writes
-        for key in entries.into_iter().filter_map(|k| k.partition_key()) {
-            if self.catalog.partition(key).is_none() {
-                let partition = self
-                    .catalog
-                    .create_partition(key)
-                    .context(CreatingPartition { partition_key: key })?;
-                let chunk_id = 0;
-                let mut partition = partition.write();
-                partition.create_chunk(chunk_id).context(CreatingChunk {
-                    partition_key: key,
-                    chunk_id,
-                })?;
-            }
-        }
-        Ok(())
+        !self.rules.lifecycle_rules.immutable
     }
 }
 
@@ -609,33 +451,65 @@ impl Database for Db {
             .chunks()
             .map(|chunk| {
                 let chunk = chunk.read();
-                match chunk.state() {
-                    ChunkState::Open
-                    | ChunkState::Closing
-                    | ChunkState::Closed
-                    | ChunkState::Moving => {
-                        let mb_chunk = self
-                            .mutable_buffer_chunk(chunk.key(), chunk.id())
-                            .expect("catalog mismatch");
-                        // TODO remove the bool flag here
-                        DBChunk::new_mb(mb_chunk, partition_key, chunk.state() == ChunkState::Open)
-                    }
-                    ChunkState::Moved => {
-                        DBChunk::new_rb(Arc::clone(&self.read_buffer), partition_key, chunk.id())
-                    }
-                }
+                DBChunk::snapshot(&chunk)
             })
             .collect()
     }
 
     fn store_replicated_write(&self, write: &ReplicatedWrite) -> Result<(), Self::Error> {
-        self.create_partitions_if_needed(write)?;
+        if !self.writeable() {
+            return DatatbaseNotWriteable {}.fail();
+        }
 
-        self.mutable_buffer
-            .as_ref()
-            .context(DatatbaseNotWriteable)?
-            .store_replicated_write(write)
-            .context(MutableBufferWrite)
+        let batch = if let Some(batch) = write.write_buffer_batch() {
+            batch
+        } else {
+            return Ok(());
+        };
+
+        let entries = if let Some(entries) = batch.entries() {
+            entries
+        } else {
+            return Ok(());
+        };
+
+        for entry in entries.into_iter() {
+            if let Some(partition_key) = entry.partition_key() {
+                let chunk = match self.catalog.partition(partition_key) {
+                    // no partition key
+                    None => {
+                        // Create a new partition with an empty chunk
+                        let partition = self
+                            .catalog
+                            .create_partition(partition_key)
+                            .context(CreatingPartition { partition_key })?;
+
+                        let mut partition = partition.write();
+                        let chunk = partition
+                            .create_chunk()
+                            .context(CreatingChunk { partition_key })?;
+                        {
+                            let mut chunk = chunk.write();
+                            let chunk_id = chunk.id();
+                            chunk
+                                .set_open(Chunk::new(chunk_id))
+                                .context(CreatingChunk { partition_key })?;
+                        }
+                        chunk
+                    }
+                    Some(partition) => {
+                        let partition = partition.read();
+                        partition
+                            .open_chunk()
+                            .context(InternalNoOpenChunk { partition_key })?
+                    }
+                };
+                let mut chunk = chunk.write();
+                // TODO update the last read/write time of this partition
+                chunk.mutable_buffer().unwrap().write_entry(&entry).unwrap()
+            }
+        }
+        Ok(())
     }
 
     fn partition_keys(&self) -> Result<Vec<String>, Self::Error> {
@@ -756,7 +630,7 @@ mod tests {
     use arrow_deps::{
         arrow::record_batch::RecordBatch, assert_table_eq, datafusion::physical_plan::collect,
     };
-    use data_types::chunk::ChunkStorage;
+    use data_types::{chunk::ChunkStorage, database_rules::LifecycleRules};
     use query::{
         exec::Executor, frontend::sql::SQLQueryPlanner, test::TestLPWriter, PartitionChunk,
     };
@@ -769,12 +643,16 @@ mod tests {
     #[tokio::test]
     async fn write_no_mutable_buffer() {
         // Validate that writes are rejected if there is no mutable buffer
-        let mutable_buffer = None;
         let db = make_db();
-        let db = Db {
-            mutable_buffer,
-            ..db
+        let rules = DatabaseRules {
+            lifecycle_rules: LifecycleRules {
+                immutable: true,
+                ..Default::default()
+            },
+            ..DatabaseRules::new()
         };
+        let db = Db { rules, ..db };
+        assert!(!db.writeable());
 
         let mut writer = TestLPWriter::default();
         let res = writer.write_lp_string(&db, "cpu bar=1 10");
@@ -1050,9 +928,13 @@ mod tests {
 
     fn mutable_chunk_ids(db: &Db, partition_key: &str) -> Vec<u32> {
         let mut chunk_ids: Vec<u32> = db
-            .mutable_buffer_chunks(partition_key)
-            .iter()
-            .map(|chunk| chunk.id())
+            .partition_chunk_summaries(partition_key)
+            .filter_map(|chunk| match chunk.storage {
+                ChunkStorage::OpenMutableBuffer | ChunkStorage::ClosedMutableBuffer => {
+                    Some(chunk.id)
+                }
+                _ => None,
+            })
             .collect();
         chunk_ids.sort_unstable();
         chunk_ids
@@ -1060,9 +942,11 @@ mod tests {
 
     fn read_buffer_chunk_ids(db: &Db, partition_key: &str) -> Vec<u32> {
         let mut chunk_ids: Vec<u32> = db
-            .read_buffer_chunks(partition_key)
-            .iter()
-            .map(|chunk| chunk.id())
+            .partition_chunk_summaries(partition_key)
+            .filter_map(|chunk| match chunk.storage {
+                ChunkStorage::ReadBuffer => Some(chunk.id),
+                _ => None,
+            })
             .collect();
         chunk_ids.sort_unstable();
         chunk_ids

--- a/server/src/db/catalog/chunk.rs
+++ b/server/src/db/catalog/chunk.rs
@@ -1,29 +1,49 @@
+use mutable_buffer::chunk::Chunk as MBChunk;
+use read_buffer::Database as ReadBufferDb;
 use std::sync::Arc;
 
-/// The state
-#[derive(Debug, PartialEq, Clone, Copy)]
+use super::{InternalChunkState, Result};
+
+/// The state a Chunk is in and what its underlying backing storage is
+#[derive(Debug)]
 pub enum ChunkState {
+    /// Chunk has no backing state, and it ca
+    None,
+
     /// Chunk can accept new writes
-    Open,
+    Open(MBChunk),
 
     /// Chunk can still accept new writes, but will likely be closed soon
-    Closing,
+    Closing(MBChunk),
 
     /// Chunk is closed for new writes and has become read only
-    Closed,
+    Closed(Arc<MBChunk>),
 
     /// Chunk is closed for new writes, and is actively moving to the read
     /// buffer
-    Moving,
+    Moving(Arc<MBChunk>),
 
     /// Chunk has been completely loaded in the read buffer
-    Moved,
+    Moved(Arc<ReadBufferDb>), // todo use read buffer chunk here
+}
+
+impl ChunkState {
+    pub fn name(&self) -> &'static str {
+        match self {
+            Self::None => "None",
+            Self::Open(_) => "Open",
+            Self::Closing(_) => "Closing",
+            Self::Closed(_) => "Closed",
+            Self::Moving(_) => "Moving",
+            Self::Moved(_) => "Moved",
+        }
+    }
 }
 
 /// The catalog representation of a Chunk in IOx. Note that a chunk
 /// may exist in several physical locations at any given time (e.g. in
 /// mutable buffer and in read buffer)
-#[derive(Debug, PartialEq)]
+#[derive(Debug)]
 pub struct Chunk {
     /// What partition does the chunk belong to?
     partition_key: Arc<String>,
@@ -37,15 +57,30 @@ pub struct Chunk {
      * such as object_store_path, etc */
 }
 
+macro_rules! unexpected_state {
+    ($SELF: expr, $OP: expr, $EXPECTED: expr, $STATE: expr) => {
+        InternalChunkState {
+            partition_key: $SELF.partition_key.as_str(),
+            chunk_id: $SELF.id,
+            operation: $OP,
+            expected: $EXPECTED,
+            actual: $STATE.name(),
+        }
+        .fail()
+    };
+}
+
 impl Chunk {
     /// Create a new chunk in the Open state
     pub(crate) fn new(partition_key: impl Into<String>, id: u32) -> Self {
         let partition_key = Arc::new(partition_key.into());
 
+        let state = ChunkState::None;
+
         Self {
             partition_key,
             id,
-            state: ChunkState::Open,
+            state,
         }
     }
 
@@ -57,13 +92,93 @@ impl Chunk {
         self.partition_key.as_ref()
     }
 
-    pub fn state(&self) -> ChunkState {
-        self.state
+    pub fn state(&self) -> &ChunkState {
+        &self.state
     }
 
-    pub fn set_state(&mut self, state: ChunkState) {
-        // TODO add state transition validation here?
+    /// Returns a mutable reference to the mutable buffer storage for
+    /// chunks in the Open or Closing state
+    ///
+    /// Must be in open or closing state
+    pub fn mutable_buffer(&mut self) -> Result<&mut MBChunk> {
+        match &mut self.state {
+            ChunkState::Open(chunk) => Ok(chunk),
+            ChunkState::Closing(chunk) => Ok(chunk),
+            state => unexpected_state!(self, "mutable buffer reference", "Open or Closing", state),
+        }
+    }
 
-        self.state = state;
+    /// Set the chunk to Open, suitable for writing new data
+    pub fn set_open(&mut self, chunk: MBChunk) -> Result<()> {
+        if matches!(self.state, ChunkState::None) {
+            self.state = ChunkState::Open(chunk);
+            Ok(())
+        } else {
+            unexpected_state!(self, "setting open", "None", &self.state)
+        }
+    }
+
+    /// Set the chunk to the Closing state
+    pub fn set_closing(&mut self) -> Result<()> {
+        let mut s = ChunkState::None;
+        std::mem::swap(&mut s, &mut self.state);
+
+        match s {
+            ChunkState::Open(s) | ChunkState::Closing(s) => {
+                self.state = ChunkState::Closing(s);
+                Ok(())
+            }
+            state => {
+                self.state = state;
+                unexpected_state!(self, "setting closing", "Open or Closing", &self.state)
+            }
+        }
+    }
+
+    /// Set the chunk to the Moving state, returning a handle to the underlying
+    /// storage
+    pub fn set_moving(&mut self) -> Result<Arc<MBChunk>> {
+        let mut s = ChunkState::None;
+        std::mem::swap(&mut s, &mut self.state);
+
+        match s {
+            ChunkState::Open(chunk) | ChunkState::Closing(chunk) => {
+                let chunk = Arc::new(chunk);
+                self.state = ChunkState::Moving(Arc::clone(&chunk));
+                Ok(chunk)
+            }
+            ChunkState::Closed(chunk) => {
+                self.state = ChunkState::Moving(Arc::clone(&chunk));
+                Ok(chunk)
+            }
+            state => {
+                self.state = state;
+                unexpected_state!(
+                    self,
+                    "setting moving",
+                    "Open, Closing or Closed",
+                    &self.state
+                )
+            }
+        }
+    }
+
+    /// Set the chunk in the Moved state, setting the underlying
+    /// storage handle to db, and discarding the underlying mutable buffer
+    /// storage.
+    pub fn set_moved(&mut self, db: Arc<ReadBufferDb>) -> Result<()> {
+        let mut s = ChunkState::None;
+        std::mem::swap(&mut s, &mut self.state);
+
+        match s {
+            ChunkState::Moving(_) => {
+                self.state = ChunkState::Moved(db);
+                Ok(())
+            }
+            state => {
+                self.state = state;
+                unexpected_state!(self, "setting moved", "Moving", &self.state)
+            }
+        }
     }
 }

--- a/server/src/db/chunk.rs
+++ b/server/src/db/chunk.rs
@@ -72,32 +72,56 @@ pub enum DBChunk {
 }
 
 impl DBChunk {
-    /// Create a new mutable buffer chunk
-    pub fn new_mb(
-        chunk: Arc<mutable_buffer::chunk::Chunk>,
-        partition_key: impl Into<String>,
-        open: bool,
-    ) -> Arc<Self> {
-        let partition_key = Arc::new(partition_key.into());
-        Arc::new(Self::MutableBuffer {
-            chunk,
-            partition_key,
-            open,
-        })
-    }
+    /// Create a DBChunk snapshot of the catalog chunk
+    pub fn snapshot(chunk: &super::catalog::chunk::Chunk) -> Arc<Self> {
+        let partition_key = Arc::new(chunk.key().to_string());
+        let chunk_id = chunk.id();
 
-    /// create a new read buffer chunk
-    pub fn new_rb(
-        db: Arc<ReadBufferDb>,
-        partition_key: impl Into<String>,
-        chunk_id: u32,
-    ) -> Arc<Self> {
-        let partition_key = Arc::new(partition_key.into());
-        Arc::new(Self::ReadBuffer {
-            db,
-            chunk_id,
-            partition_key,
-        })
+        let db_chunk = match chunk.state() {
+            super::catalog::chunk::ChunkState::None => {
+                panic!("Invalid internal state");
+            }
+            super::catalog::chunk::ChunkState::Open(chunk) => {
+                // TODO the performance if cloning the chunk is terrible
+                // Proper performance is tracked in
+                // https://github.com/influxdata/influxdb_iox/issues/635
+                let chunk = Arc::new(chunk.clone());
+                Self::MutableBuffer {
+                    chunk,
+                    partition_key,
+                    open: true,
+                }
+            }
+            super::catalog::chunk::ChunkState::Closing(chunk) => {
+                // TODO the performance if cloning the chunk is terrible
+                // Proper performance is tracked in
+                // https://github.com/influxdata/influxdb_iox/issues/635
+                let chunk = Arc::new(chunk.clone());
+                Self::MutableBuffer {
+                    chunk,
+                    partition_key,
+                    open: false,
+                }
+            }
+            super::catalog::chunk::ChunkState::Closed(chunk)
+            | super::catalog::chunk::ChunkState::Moving(chunk) => {
+                let chunk = Arc::clone(chunk);
+                Self::MutableBuffer {
+                    chunk,
+                    partition_key,
+                    open: false,
+                }
+            }
+            super::catalog::chunk::ChunkState::Moved(db) => {
+                let db = Arc::clone(db);
+                Self::ReadBuffer {
+                    db,
+                    partition_key,
+                    chunk_id,
+                }
+            }
+        };
+        Arc::new(db_chunk)
     }
 
     pub fn summary(&self) -> ChunkSummary {

--- a/server/src/db/chunk.rs
+++ b/server/src/db/chunk.rs
@@ -187,6 +187,20 @@ impl PartitionChunk for DBChunk {
         }
     }
 
+    fn all_table_names(&self, known_tables: &mut StringSet) {
+        match self {
+            Self::MutableBuffer { chunk, .. } => chunk.all_table_names(known_tables),
+            Self::ReadBuffer {
+                db,
+                partition_key,
+                chunk_id,
+            } => db.all_table_names(partition_key, &[*chunk_id], known_tables),
+            Self::ParquetFile => {
+                unimplemented!("parquet files")
+            }
+        }
+    }
+
     fn table_names(
         &self,
         predicate: &Predicate,

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -930,7 +930,7 @@ mod tests {
             .map(|s| format!("{:?} {}", s.storage, s.id))
             .collect::<Vec<_>>();
 
-        let expected = vec!["ReadBuffer 0", "OpenMutableBuffer 1"];
+        let expected = vec!["ReadBuffer 0"];
 
         assert_eq!(
             expected, actual,

--- a/server/src/query_tests/utils.rs
+++ b/server/src/query_tests/utils.rs
@@ -2,7 +2,6 @@ use data_types::{
     chunk::{ChunkStorage, ChunkSummary},
     database_rules::DatabaseRules,
 };
-use mutable_buffer::MutableBufferDb;
 use query::Database;
 
 use crate::{db::Db, JobRegistry};
@@ -10,10 +9,8 @@ use std::sync::Arc;
 
 /// Used for testing: create a Database with a local store
 pub fn make_db() -> Db {
-    let name = "test_db";
     Db::new(
         DatabaseRules::new(),
-        Some(MutableBufferDb::new(name)),
         read_buffer::Database::new(),
         None, // wal buffer
         Arc::new(JobRegistry::new()),

--- a/src/influxdb_ioxd/rpc/error.rs
+++ b/src/influxdb_ioxd/rpc/error.rs
@@ -72,7 +72,7 @@ pub fn default_db_error_handler(error: server::db::Error) -> tonic::Status {
             description: "Cannot write to database: no mutable buffer configured".to_string(),
         }
         .into(),
-        Error::RollingOverChunk { source, .. } => default_catalog_error_handler(source),
+        Error::RollingOverPartition { source, .. } => default_catalog_error_handler(source),
         error => {
             error!(?error, "Unexpected error");
             InternalError {}.into()

--- a/tests/end_to_end_cases/management_api.rs
+++ b/tests/end_to_end_cases/management_api.rs
@@ -583,11 +583,9 @@ async fn test_close_partition_chunk() {
         .expect("listing chunks");
     chunks.sort_by(|c1, c2| c1.id.cmp(&c2.id));
 
-    assert_eq!(chunks.len(), 2, "Chunks: {:#?}", chunks);
+    assert_eq!(chunks.len(), 1, "Chunks: {:#?}", chunks);
     assert_eq!(chunks[0].id, 0);
     assert_eq!(chunks[0].storage, ChunkStorage::ReadBuffer as i32);
-    assert_eq!(chunks[1].id, 1);
-    assert_eq!(chunks[1].storage, ChunkStorage::OpenMutableBuffer as i32);
 }
 
 #[tokio::test]


### PR DESCRIPTION
 This PR is the core change proposed for https://github.com/influxdata/influxdb_iox/issues/1042 -- it collapses the `MutableBufferDb` into the `Db` itself, by storing the mutable buffer Chunks in the Catalog

# Rationale:
This PR ensures that the Chunks and the state in the catalog remain in sync (by storing them together)

# Changes

Store the actual chunk implementation (mutable buffer chunk) in the the `catalog::Chunk` state. This leverages Rust's type system.

Note there is some logic still in the mutable buffer that isn't connected to anything yet, but that I would port over if we like this PR, such as 'last write time' for chunks and partitions.


# Behavior change
One small change in behavior is that chunks in the mutable buffer are now created only when data is actually written to them. Previously, they were eagerly created on partition rollover as well


- [x] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb_iox/blob/main/README.md).
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
