### PR TITLE
feat: use CatalogProvider and SchemaProvider

### DIFF
--- a/query/src/exec.rs
+++ b/query/src/exec.rs
@@ -144,7 +144,7 @@ impl Executor {
             .into_iter()
             .map(|plan| {
                 // TODO run these on some executor other than the main tokio pool (maybe?)
-                let ctx = self.new_context(true);
+                let ctx = self.new_context();
                 let (plan_tx, plan_rx) = mpsc::channel(1);
                 rx_channels.push(plan_rx);
 
@@ -215,7 +215,7 @@ impl Executor {
                 let counters = Arc::clone(&self.counters);
 
                 tokio::task::spawn(async move {
-                    let ctx = IOxExecutionContext::new(counters, true);
+                    let ctx = IOxExecutionContext::new(counters);
                     let physical_plan = ctx
                         .prepare_plan(&plan)
                         .await
@@ -251,8 +251,8 @@ impl Executor {
     }
 
     /// Create a new execution context, suitable for executing a new query
-    pub fn new_context(&self, default_catalog: bool) -> IOxExecutionContext {
-        IOxExecutionContext::new(Arc::clone(&self.counters), default_catalog)
+    pub fn new_context(&self) -> IOxExecutionContext {
+        IOxExecutionContext::new(Arc::clone(&self.counters))
     }
 
     /// plans and runs the plans in parallel and collects the results
@@ -261,7 +261,7 @@ impl Executor {
         let value_futures = plans
             .into_iter()
             .map(|plan| {
-                let ctx = self.new_context(true);
+                let ctx = self.new_context();
                 // TODO run these on some executor other than the main tokio pool
                 tokio::task::spawn(async move {
                     let physical_plan = ctx

--- a/query/src/exec/context.rs
+++ b/query/src/exec/context.rs
@@ -28,9 +28,9 @@ pub use arrow_deps::datafusion::error::{DataFusionError as Error, Result};
 use super::counters::ExecutionCounters;
 
 // The default catalog name - this impacts what SQL queries use if not specified
-pub const DEFAULT_CATALOG: &'static str = "public";
+pub const DEFAULT_CATALOG: &str = "public";
 // The default schema name - this impacts what SQL queries use if not specified
-pub const DEFAULT_SCHEMA: &'static str = "iox";
+pub const DEFAULT_SCHEMA: &str = "iox";
 
 /// This structure implements the DataFusion notion of "query planner"
 /// and is needed to create plans with the IOx extension nodes.
@@ -99,13 +99,16 @@ impl fmt::Debug for IOxExecutionContext {
 
 impl IOxExecutionContext {
     /// Create an ExecutionContext suitable for executing DataFusion plans
-    pub fn new(counters: Arc<ExecutionCounters>, default_catalog: bool) -> Self {
+    ///
+    /// The config is created with a default catalog and schema, but this
+    /// can be overridden at a later date
+    pub fn new(counters: Arc<ExecutionCounters>) -> Self {
         const BATCH_SIZE: usize = 1000;
 
         // TBD: Should we be reusing an execution context across all executions?
         let config = ExecutionConfig::new()
             .with_batch_size(BATCH_SIZE)
-            .create_default_catalog_and_schema(default_catalog)
+            .create_default_catalog_and_schema(true)
             .with_default_catalog_and_schema(DEFAULT_CATALOG, DEFAULT_SCHEMA)
             .with_query_planner(Arc::new(IOxQueryPlanner {}));
 

--- a/query/src/exec/context.rs
+++ b/query/src/exec/context.rs
@@ -27,6 +27,11 @@ pub use arrow_deps::datafusion::error::{DataFusionError as Error, Result};
 
 use super::counters::ExecutionCounters;
 
+// The default catalog name - this impacts what SQL queries use if not specified
+pub const DEFAULT_CATALOG: &'static str = "public";
+// The default schema name - this impacts what SQL queries use if not specified
+pub const DEFAULT_SCHEMA: &'static str = "iox";
+
 /// This structure implements the DataFusion notion of "query planner"
 /// and is needed to create plans with the IOx extension nodes.
 struct IOxQueryPlanner {}
@@ -94,12 +99,14 @@ impl fmt::Debug for IOxExecutionContext {
 
 impl IOxExecutionContext {
     /// Create an ExecutionContext suitable for executing DataFusion plans
-    pub fn new(counters: Arc<ExecutionCounters>) -> Self {
+    pub fn new(counters: Arc<ExecutionCounters>, default_catalog: bool) -> Self {
         const BATCH_SIZE: usize = 1000;
 
         // TBD: Should we be reusing an execution context across all executions?
         let config = ExecutionConfig::new()
             .with_batch_size(BATCH_SIZE)
+            .create_default_catalog_and_schema(default_catalog)
+            .with_default_catalog_and_schema(DEFAULT_CATALOG, DEFAULT_SCHEMA)
             .with_query_planner(Arc::new(IOxQueryPlanner {}));
 
         let inner = ExecutionContext::with_config(config);

--- a/query/src/frontend/sql.rs
+++ b/query/src/frontend/sql.rs
@@ -2,9 +2,10 @@ use std::sync::Arc;
 
 use snafu::{ResultExt, Snafu};
 
-use crate::{exec::Executor, provider::ProviderBuilder, Database, PartitionChunk};
-use arrow_deps::datafusion::{error::DataFusionError, physical_plan::ExecutionPlan};
-use internal_types::selection::Selection;
+use crate::exec::{context::DEFAULT_CATALOG, Executor};
+use arrow_deps::datafusion::{
+    catalog::catalog::CatalogProvider, error::DataFusionError, physical_plan::ExecutionPlan,
+};
 
 #[derive(Debug, Snafu)]
 pub enum Error {
@@ -15,12 +16,6 @@ pub enum Error {
     InvalidSqlQuery {
         query: String,
         source: sqlparser::parser::ParserError,
-    },
-
-    #[snafu(display("Unsupported SQL statement in query {}: {}", query, statement))]
-    UnsupportedStatement {
-        query: String,
-        statement: Box<Statement>,
     },
 
     #[snafu(display("Internal Error creating memtable for table {}: {}", table, source))]
@@ -89,96 +84,14 @@ impl SQLQueryPlanner {
     /// Plan a SQL query against the data in `database`, and return a
     /// DataFusion physical execution plan. The plan can then be
     /// executed using `executor` in a streaming fashion.
-    pub async fn query<D: Database + 'static>(
+    pub async fn query<D: CatalogProvider + 'static>(
         &self,
-        database: &D,
+        database: Arc<D>,
         query: &str,
         executor: &Executor,
     ) -> Result<Arc<dyn ExecutionPlan>> {
-        let mut ctx = executor.new_context();
-
-        // figure out the table names that appear in the sql
-        let table_names = table_names(query)?;
-
-        let partition_keys = database
-            .partition_keys()
-            .map_err(|e| Box::new(e) as _)
-            .context(GettingDatabasePartition)?;
-
-        // Register a table provider for each table so DataFusion
-        // knows what the schema of that table is and how to obtain
-        // its data when needed.
-        for table_name in &table_names {
-            let mut builder = ProviderBuilder::new(table_name);
-
-            for partition_key in &partition_keys {
-                for chunk in database.chunks(partition_key) {
-                    if chunk.has_table(table_name) {
-                        let chunk_id = chunk.id();
-                        let chunk_table_schema = chunk
-                            .table_schema(table_name, Selection::All)
-                            .await
-                            .map_err(|e| Box::new(e) as _)
-                            .context(GettingTableSchema {
-                                table_name,
-                                chunk_id,
-                            })?;
-
-                        builder = builder.add_chunk(chunk, chunk_table_schema).context(
-                            AddingChunkToProvider {
-                                table_name,
-                                chunk_id,
-                            },
-                        )?
-                    }
-                }
-            }
-            let provider = builder
-                .build()
-                .context(CreatingTableProvider { table_name })?;
-
-            ctx.inner_mut()
-                .register_table(table_name.as_str(), Arc::new(provider))
-                .context(RegisteringTableProvider { table_name })?;
-        }
-
+        let mut ctx = executor.new_context(false);
+        ctx.inner_mut().register_catalog(DEFAULT_CATALOG, database);
         ctx.prepare_sql(query).await.context(Preparing)
     }
-}
-
-use sqlparser::{
-    ast::{SetExpr, Statement, TableFactor},
-    dialect::GenericDialect,
-    parser::Parser,
-};
-
-/// return a list of table names that appear in the query
-/// TODO find some way to avoid using sql parser direcly here
-fn table_names(query: &str) -> Result<Vec<String>> {
-    let mut tables = vec![];
-
-    let dialect = GenericDialect {};
-    let ast = Parser::parse_sql(&dialect, query).context(InvalidSqlQuery { query })?;
-
-    for statement in ast {
-        match statement {
-            Statement::Query(q) => {
-                if let SetExpr::Select(q) = q.body {
-                    for item in q.from {
-                        if let TableFactor::Table { name, .. } = item.relation {
-                            tables.push(name.to_string());
-                        }
-                    }
-                }
-            }
-            _ => {
-                return UnsupportedStatement {
-                    query: query.to_string(),
-                    statement,
-                }
-                .fail()
-            }
-        }
-    }
-    Ok(tables)
 }

--- a/query/src/frontend/sql.rs
+++ b/query/src/frontend/sql.rs
@@ -90,7 +90,7 @@ impl SQLQueryPlanner {
         query: &str,
         executor: &Executor,
     ) -> Result<Arc<dyn ExecutionPlan>> {
-        let mut ctx = executor.new_context(false);
+        let mut ctx = executor.new_context();
         ctx.inner_mut().register_catalog(DEFAULT_CATALOG, database);
         ctx.prepare_sql(query).await.context(Preparing)
     }

--- a/query/src/lib.rs
+++ b/query/src/lib.rs
@@ -23,6 +23,8 @@ pub mod predicate;
 pub mod provider;
 pub mod util;
 
+pub use exec::context::{DEFAULT_CATALOG, DEFAULT_SCHEMA};
+
 use self::predicate::Predicate;
 
 /// A `Database` is the main trait implemented by the IOx subsystems

--- a/server/src/db/catalog/partition.rs
+++ b/server/src/db/catalog/partition.rs
@@ -85,6 +85,10 @@ impl Partition {
         })
     }
 
+    pub fn chunk_ids(&self) -> impl Iterator<Item = u32> + '_ {
+        self.chunks.keys().cloned()
+    }
+
     /// Return a iterator over chunks in this partition
     pub fn chunks(&self) -> impl Iterator<Item = &Arc<RwLock<Chunk>>> {
         self.chunks.values()

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -684,6 +684,7 @@ mod tests {
     use crate::buffer::Segment;
 
     use super::*;
+    use crate::db::DbCatalog;
 
     type TestError = Box<dyn std::error::Error + Send + Sync + 'static>;
     type Result<T = (), E = TestError> = std::result::Result<T, E>;
@@ -860,7 +861,11 @@ mod tests {
         let planner = SQLQueryPlanner::default();
         let executor = server.executor();
         let physical_plan = planner
-            .query(db.as_ref(), "select * from cpu", executor.as_ref())
+            .query(
+                Arc::new(DbCatalog::new(db)),
+                "select * from cpu",
+                executor.as_ref(),
+            )
             .await
             .unwrap();
 

--- a/server/src/query_tests/sql.rs
+++ b/server/src/query_tests/sql.rs
@@ -4,10 +4,12 @@
 //! important SQL does not regress)
 
 use super::scenarios::*;
+use crate::db::DbCatalog;
 use arrow_deps::{
     arrow::record_batch::RecordBatch, assert_table_eq, datafusion::physical_plan::collect,
 };
 use query::{exec::Executor, frontend::sql::SQLQueryPlanner};
+use std::sync::Arc;
 
 /// runs table_names(predicate) and compares it to the expected
 /// output
@@ -19,13 +21,15 @@ macro_rules! run_sql_test_case {
             let DBScenario {
                 scenario_name, db, ..
             } = scenario;
+            let db = Arc::new(db);
+
             println!("Running scenario '{}'", scenario_name);
             println!("SQL: '{:#?}'", sql);
-            let planner = SQLQueryPlanner::new();
+            let planner = SQLQueryPlanner::default();
             let executor = Executor::new();
 
             let physical_plan = planner
-                .query(&db, &sql, &executor)
+                .query(Arc::new(DbCatalog::new(db)), &sql, &executor)
                 .await
                 .expect("built plan successfully");
 

--- a/src/influxdb_ioxd/http.rs
+++ b/src/influxdb_ioxd/http.rs
@@ -777,7 +777,7 @@ mod tests {
             .db(&DatabaseName::new("MyOrg_MyBucket").unwrap())
             .expect("Database exists");
 
-        let batches = run_query(test_db.as_ref(), "select * from h2o_temperature").await;
+        let batches = run_query(test_db, "select * from h2o_temperature").await;
         let expected = vec![
             "+----------------+--------------+-------+-----------------+------------+",
             "| bottom_degrees | location     | state | surface_degrees | time       |",
@@ -967,7 +967,7 @@ mod tests {
             .db(&DatabaseName::new("MyOrg_MyBucket").unwrap())
             .expect("Database exists");
 
-        let batches = run_query(test_db.as_ref(), "select * from h2o_temperature").await;
+        let batches = run_query(test_db, "select * from h2o_temperature").await;
 
         let expected = vec![
             "+----------------+--------------+-------+-----------------+------------+",
@@ -1195,7 +1195,10 @@ mod tests {
     async fn run_query(db: Arc<Db>, query: &str) -> Vec<RecordBatch> {
         let planner = SQLQueryPlanner::default();
         let executor = Executor::new();
-        let physical_plan = planner.query(db, query, &executor).await.unwrap();
+        let physical_plan = planner
+            .query(Arc::new(DbCatalog::new(db)), query, &executor)
+            .await
+            .unwrap();
 
         collect(physical_plan).await.unwrap()
     }

--- a/src/influxdb_ioxd/http.rs
+++ b/src/influxdb_ioxd/http.rs
@@ -35,6 +35,7 @@ use tracing::{debug, error, info};
 
 use data_types::http::WalMetadataResponse;
 use hyper::server::conn::AddrIncoming;
+use server::db::DbCatalog;
 use std::{
     fmt::Debug,
     str::{self, FromStr},
@@ -505,7 +506,7 @@ async fn query<M: ConnectionManager + Send + Sync + Debug + 'static>(
     let executor = server.executor();
 
     let physical_plan = planner
-        .query(db.as_ref(), &q, executor.as_ref())
+        .query(Arc::new(DbCatalog::new(db)), &q, executor.as_ref())
         .await
         .context(PlanningSQLQuery { query: &q })?;
 
@@ -1191,7 +1192,7 @@ mod tests {
     }
 
     /// Run the specified SQL query and return formatted results as a string
-    async fn run_query(db: &Db, query: &str) -> Vec<RecordBatch> {
+    async fn run_query(db: Arc<Db>, query: &str) -> Vec<RecordBatch> {
         let planner = SQLQueryPlanner::default();
         let executor = Executor::new();
         let physical_plan = planner.query(db, query, &executor).await.unwrap();

--- a/src/influxdb_ioxd/rpc/flight.rs
+++ b/src/influxdb_ioxd/rpc/flight.rs
@@ -16,7 +16,11 @@ use arrow_deps::{
     },
     datafusion::physical_plan::collect,
 };
+use data_types::DatabaseName;
 use query::{frontend::sql::SQLQueryPlanner, DatabaseStore};
+use server::db::DbCatalog;
+use server::{ConnectionManager, Server};
+use std::fmt::Debug;
 
 #[derive(Debug, Snafu)]
 pub enum Error {
@@ -87,18 +91,21 @@ struct ReadInfo {
 
 /// Concrete implementation of the gRPC Arrow Flight Service API
 #[derive(Debug)]
-struct FlightService<T: DatabaseStore> {
-    pub db_store: Arc<T>,
+struct FlightService<M: ConnectionManager> {
+    server: Arc<Server<M>>,
 }
 
-pub fn make_server<T: DatabaseStore + 'static>(db_store: Arc<T>) -> FlightServer<impl Flight> {
-    FlightServer::new(FlightService { db_store })
+pub fn make_server<M>(server: Arc<Server<M>>) -> FlightServer<impl Flight>
+where
+    M: ConnectionManager + Send + Sync + Debug + 'static,
+{
+    FlightServer::new(FlightService { server })
 }
 
 #[tonic::async_trait]
-impl<T> Flight for FlightService<T>
+impl<M: ConnectionManager> Flight for FlightService<M>
 where
-    T: DatabaseStore + 'static,
+    M: ConnectionManager + Send + Sync + Debug + 'static,
 {
     type HandshakeStream = TonicStream<HandshakeResponse>;
     type ListFlightsStream = TonicStream<FlightInfo>;
@@ -129,18 +136,22 @@ where
         let read_info: ReadInfo =
             serde_json::from_str(&json_str).context(InvalidQuery { query: &json_str })?;
 
-        let db = self
-            .db_store
-            .db(&read_info.database_name)
-            .context(DatabaseNotFound {
-                database_name: &read_info.database_name,
-            })?;
+        // TODO: Fixme
+        let database = DatabaseName::new(&read_info.database_name).unwrap();
+
+        let db = self.server.db(&database).context(DatabaseNotFound {
+            database_name: &read_info.database_name,
+        })?;
 
         let planner = SQLQueryPlanner::default();
-        let executor = self.db_store.executor();
+        let executor = self.server.executor();
 
         let physical_plan = planner
-            .query(&*db, &read_info.sql_query, &executor)
+            .query(
+                Arc::new(DbCatalog::new(db)),
+                &read_info.sql_query,
+                &executor,
+            )
             .await
             .context(PlanningSQLQuery {
                 query: &read_info.sql_query,

--- a/tests/end_to_end_cases/read_cli.rs
+++ b/tests/end_to_end_cases/read_cli.rs
@@ -148,7 +148,7 @@ async fn test_read_error(db_name: &str, addr: &str) {
         .assert()
         .failure()
         .stderr(predicate::str::contains(
-            "no chunks found in builder for table",
+            "Table or CTE with name \\'unknown_table\\' not found",
         ));
 
     Command::cargo_bin("influxdb_iox")


### PR DESCRIPTION
This is a really hacky implementation of getting CatalogProvider and SchemaProvider plumbed into IOx.

Being able to do this properly is largely dependent on the work in #1042 and #1057 as it needs an infallible, non-async way to access chunks and their associated metadata

This will also allow #1013 to put the system tables in their own schema.

Finally it will likely fix #1054  