### PR TITLE
refactor: Remove async from `PartitionChunk::table_schema`

### DIFF
--- a/query/src/frontend/influxrpc.rs
+++ b/query/src/frontend/influxrpc.rs
@@ -261,7 +261,6 @@ impl InfluxRPCPlanner {
                 // get only tag columns from metadata
                 let schema = chunk
                     .table_schema(&table_name, Selection::All)
-                    .await
                     .expect("to be able to get table schema");
                 let column_names: Vec<&str> = schema
                     .tags_iter()
@@ -367,7 +366,6 @@ impl InfluxRPCPlanner {
                 // use schema to validate column type
                 let schema = chunk
                     .table_schema(&table_name, Selection::All)
-                    .await
                     .expect("to be able to get table schema");
 
                 // Skip this table if the tag_name is not a column in this table
@@ -1150,7 +1148,6 @@ impl InfluxRPCPlanner {
 
             let chunk_table_schema = chunk
                 .table_schema(table_name, selection)
-                .await
                 .map_err(|e| Box::new(e) as _)
                 .context(GettingTableSchema {
                     table_name,

--- a/query/src/frontend/sql.rs
+++ b/query/src/frontend/sql.rs
@@ -117,7 +117,6 @@ impl SQLQueryPlanner {
                         let chunk_id = chunk.id();
                         let chunk_table_schema = chunk
                             .table_schema(table_name, Selection::All)
-                            .await
                             .map_err(|e| Box::new(e) as _)
                             .context(GettingTableSchema {
                                 table_name,

--- a/query/src/lib.rs
+++ b/query/src/lib.rs
@@ -120,7 +120,7 @@ pub trait PartitionChunk: Debug + Send + Sync {
     /// Returns the Schema for a table in this chunk, with the
     /// specified column selection. An error is returned if the
     /// selection refers to columns that do not exist.
-    async fn table_schema(
+    fn table_schema(
         &self,
         table_name: &str,
         selection: Selection<'_>,

--- a/query/src/test.rs
+++ b/query/src/test.rs
@@ -390,7 +390,7 @@ impl PartitionChunk for TestChunk {
         Ok(Some(names))
     }
 
-    async fn table_schema(
+    fn table_schema(
         &self,
         table_name: &str,
         selection: Selection<'_>,

--- a/server/src/db/chunk.rs
+++ b/server/src/db/chunk.rs
@@ -242,7 +242,7 @@ impl PartitionChunk for DBChunk {
         Ok(names)
     }
 
-    async fn table_schema(
+    fn table_schema(
         &self,
         table_name: &str,
         selection: Selection<'_>,
@@ -323,7 +323,7 @@ impl PartitionChunk for DBChunk {
                     }
                     .fail();
                 }
-                let schema: Schema = self.table_schema(table_name, selection).await?;
+                let schema: Schema = self.table_schema(table_name, selection)?;
 
                 Ok(Box::pin(MutableBufferChunkStream::new(
                     Arc::clone(&chunk),

--- a/server/src/query_tests/table_schema.rs
+++ b/server/src/query_tests/table_schema.rs
@@ -35,10 +35,8 @@ macro_rules! run_table_schema_test_case {
                 for chunk in db.chunks(&partition_key) {
                     if chunk.has_table(table_name) {
                         chunks_with_table += 1;
-                        let actual_schema = chunk
-                            .table_schema(table_name, selection.clone())
-                            .await
-                            .unwrap();
+                        let actual_schema =
+                            chunk.table_schema(table_name, selection.clone()).unwrap();
 
                         assert_eq!(
                             expected_schema,


### PR DESCRIPTION

Here is an attempt to help https://github.com/influxdata/influxdb_iox/pull/1058

Rationale: `async` is no longer needed now we are using sync mutexes

Changes: remove some `async` and `await` calls.

- [x] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb_iox/blob/main/README.md).
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
