### PR TITLE
refactor: Remove async from PartitionChunk

### DIFF
--- a/query/src/frontend/influxrpc.rs
+++ b/query/src/frontend/influxrpc.rs
@@ -204,7 +204,6 @@ impl InfluxRPCPlanner {
         for chunk in self.filtered_chunks(database, &predicate).await? {
             let new_table_names = chunk
                 .table_names(&predicate, builder.known_strings())
-                .await
                 .map_err(|e| Box::new(e) as _)
                 .context(TableNamePlan)?;
 
@@ -272,7 +271,6 @@ impl InfluxRPCPlanner {
                 // filter the columns further from the predicate
                 let maybe_names = chunk
                     .column_names(&table_name, &predicate, selection)
-                    .await
                     .map_err(|e| Box::new(e) as _)
                     .context(FindingColumnNames)?;
 
@@ -395,7 +393,6 @@ impl InfluxRPCPlanner {
                 // try and get the list of values directly from metadata
                 let maybe_values = chunk
                     .column_values(&table_name, tag_name, &predicate)
-                    .await
                     .map_err(|e| Box::new(e) as _)
                     .context(FindingColumnValues)?;
 
@@ -669,7 +666,6 @@ impl InfluxRPCPlanner {
         // try and get the table names that have rows that match the predicate
         let table_names = chunk
             .table_names(&predicate, &no_tables)
-            .await
             .map_err(|e| Box::new(e) as _)
             .context(TableNamePlan)?;
 
@@ -690,7 +686,6 @@ impl InfluxRPCPlanner {
                 };
                 chunk
                     .table_names(&table_name_predicate, &no_tables)
-                    .await
                     .map_err(|e| Box::new(e) as _)
                     .context(InternalTableNamePlanForDefault)?
                     // unwrap the Option

--- a/query/src/lib.rs
+++ b/query/src/lib.rs
@@ -56,7 +56,6 @@ pub trait Database: Debug + Send + Sync {
 }
 
 /// Collection of data that shares the same partition key
-#[async_trait]
 pub trait PartitionChunk: Debug + Send + Sync {
     type Error: std::error::Error + Send + Sync + 'static;
 
@@ -90,7 +89,7 @@ pub trait PartitionChunk: Debug + Send + Sync {
     /// `known_tables` is a list of table names already known to be in
     /// other chunks from the same partition. It may be empty or
     /// contain `table_names` not in this chunk.
-    async fn table_names(
+    fn table_names(
         &self,
         predicate: &Predicate,
         known_tables: &StringSet,
@@ -100,7 +99,7 @@ pub trait PartitionChunk: Debug + Send + Sync {
     /// table that have at least one row that matches `predicate`, if
     /// the predicate can be evaluated entirely on the metadata of
     /// this Chunk. Returns `None` otherwise
-    async fn column_names(
+    fn column_names(
         &self,
         table_name: &str,
         predicate: &Predicate,
@@ -112,7 +111,7 @@ pub trait PartitionChunk: Debug + Send + Sync {
     /// on the metadata of this Chunk. Returns `None` otherwise
     ///
     /// The requested columns must all have String type.
-    async fn column_values(
+    fn column_values(
         &self,
         table_name: &str,
         column_name: &str,
@@ -141,7 +140,7 @@ pub trait PartitionChunk: Debug + Send + Sync {
     /// several chunks within a partition, so there needs to be an
     /// implementation of `TableProvider` that stitches together the
     /// streams from several different `PartitionChunks`.
-    async fn read_filter(
+    fn read_filter(
         &self,
         table_name: &str,
         predicate: &Predicate,

--- a/query/src/provider/physical.rs
+++ b/query/src/provider/physical.rs
@@ -104,7 +104,6 @@ impl<C: PartitionChunk + 'static> ExecutionPlan for IOxReadFilterNode<C> {
 
         let stream = chunk
             .read_filter(&self.table_name, &self.predicate, selection)
-            .await
             .map_err(|e| {
                 DataFusionError::Execution(format!(
                     "Error creating scan for table {} chunk {}: {}",

--- a/query/src/test.rs
+++ b/query/src/test.rs
@@ -339,7 +339,6 @@ impl TestChunk {
     }
 }
 
-#[async_trait]
 impl PartitionChunk for TestChunk {
     type Error = TestError;
 
@@ -353,7 +352,7 @@ impl PartitionChunk for TestChunk {
         unimplemented!()
     }
 
-    async fn read_filter(
+    fn read_filter(
         &self,
         table_name: &str,
         predicate: &Predicate,
@@ -369,7 +368,7 @@ impl PartitionChunk for TestChunk {
         Ok(Box::pin(stream))
     }
 
-    async fn table_names(
+    fn table_names(
         &self,
         predicate: &Predicate,
         _known_tables: &StringSet,
@@ -407,7 +406,7 @@ impl PartitionChunk for TestChunk {
             })
     }
 
-    async fn column_values(
+    fn column_values(
         &self,
         _table_name: &str,
         _column_name: &str,
@@ -421,7 +420,7 @@ impl PartitionChunk for TestChunk {
         self.table_schemas.contains_key(table_name)
     }
 
-    async fn column_names(
+    fn column_names(
         &self,
         table_name: &str,
         predicate: &Predicate,

--- a/server/src/db/chunk.rs
+++ b/server/src/db/chunk.rs
@@ -14,8 +14,6 @@ use super::{
     streams::{MutableBufferChunkStream, ReadFilterResultsStream},
 };
 
-use async_trait::async_trait;
-
 #[derive(Debug, Snafu)]
 pub enum Error {
     #[snafu(display("Mutable Buffer Chunk Error: {}", source))]
@@ -144,7 +142,6 @@ impl DBChunk {
     }
 }
 
-#[async_trait]
 impl PartitionChunk for DBChunk {
     type Error = Error;
 
@@ -166,7 +163,7 @@ impl PartitionChunk for DBChunk {
         }
     }
 
-    async fn table_names(
+    fn table_names(
         &self,
         predicate: &Predicate,
         _known_tables: &StringSet,
@@ -306,7 +303,7 @@ impl PartitionChunk for DBChunk {
         }
     }
 
-    async fn read_filter(
+    fn read_filter(
         &self,
         table_name: &str,
         predicate: &Predicate,
@@ -390,7 +387,7 @@ impl PartitionChunk for DBChunk {
         }
     }
 
-    async fn column_names(
+    fn column_names(
         &self,
         table_name: &str,
         predicate: &Predicate,
@@ -438,7 +435,7 @@ impl PartitionChunk for DBChunk {
         }
     }
 
-    async fn column_values(
+    fn column_values(
         &self,
         table_name: &str,
         column_name: &str,

--- a/server/src/snapshot.rs
+++ b/server/src/snapshot.rs
@@ -165,7 +165,6 @@ where
             let stream = self
                 .chunk
                 .read_filter(table_name, &EMPTY_PREDICATE, Selection::All)
-                .await
                 .map_err(|e| Box::new(e) as _)
                 .context(PartitionError)?;
 


### PR DESCRIPTION
These functions needed to be `async` when the underlying implementations used the async versions of `Mutex` and `RwLock`. Now that we are using the `sync` versions of those locking primitives, there is no need for `PartitionChunk` to be async either

- [x] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb_iox/blob/main/README.md).
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
