### PR TITLE
refactor: Remove async from Database trait

### DIFF
--- a/mutable_buffer/src/database.rs
+++ b/mutable_buffer/src/database.rs
@@ -183,7 +183,7 @@ impl MutableBufferDb {
         partitions
     }
 
-    pub async fn store_replicated_write(&self, write: &ReplicatedWrite) -> Result<()> {
+    pub fn store_replicated_write(&self, write: &ReplicatedWrite) -> Result<()> {
         match write.write_buffer_batch() {
             Some(b) => self.write_entries_to_partitions(&b)?,
             None => {
@@ -385,10 +385,7 @@ mod tests {
         let replicated_write =
             lines_to_replicated_write(writer_id, sequence_number, &lines, &partitioner);
 
-        database
-            .store_replicated_write(&replicated_write)
-            .await
-            .unwrap()
+        database.store_replicated_write(&replicated_write).unwrap()
     }
 
     // Outputs a set partition key for testing. Used for parsing line protocol into

--- a/query/src/lib.rs
+++ b/query/src/lib.rs
@@ -35,13 +35,12 @@ use self::predicate::Predicate;
 ///
 /// TODO: Move all Query and Line Protocol specific things out of this
 /// trait and into the various query planners.
-#[async_trait]
 pub trait Database: Debug + Send + Sync {
     type Error: std::error::Error + Send + Sync + 'static;
     type Chunk: PartitionChunk;
 
     /// Stores the replicated write into the database.
-    async fn store_replicated_write(&self, write: &ReplicatedWrite) -> Result<(), Self::Error>;
+    fn store_replicated_write(&self, write: &ReplicatedWrite) -> Result<(), Self::Error>;
 
     /// Return the partition keys for data in this DB
     fn partition_keys(&self) -> Result<Vec<String>, Self::Error>;

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -365,7 +365,6 @@ impl<M: ConnectionManager> Server<M> {
     ) -> Result<()> {
         if db.writeable() {
             db.store_replicated_write(&write)
-                .await
                 .map_err(|e| Box::new(e) as DatabaseError)
                 .context(UnknownDatabaseError {})?;
         }

--- a/server/src/query_tests/influxrpc/read_window_aggregate.rs
+++ b/server/src/query_tests/influxrpc/read_window_aggregate.rs
@@ -164,7 +164,7 @@ impl DBSetup for MeasurementForWindowAggregateMonths {
         let db = make_db();
         let mut writer = TestLPWriter::default();
         let data = lp_lines.join("\n");
-        writer.write_lp_string(&db, &data).await.unwrap();
+        writer.write_lp_string(&db, &data).unwrap();
         let scenario1 = DBScenario {
             scenario_name: "Data in 4 partitions, open chunks of mutable buffer".into(),
             db,
@@ -173,7 +173,7 @@ impl DBSetup for MeasurementForWindowAggregateMonths {
         let db = make_db();
         let mut writer = TestLPWriter::default();
         let data = lp_lines.join("\n");
-        writer.write_lp_string(&db, &data).await.unwrap();
+        writer.write_lp_string(&db, &data).unwrap();
         db.rollover_partition("2020-03-01T00").await.unwrap();
         db.rollover_partition("2020-03-02T00").await.unwrap();
         let scenario2 = DBScenario {
@@ -186,7 +186,7 @@ impl DBSetup for MeasurementForWindowAggregateMonths {
         let db = make_db();
         let mut writer = TestLPWriter::default();
         let data = lp_lines.join("\n");
-        writer.write_lp_string(&db, &data).await.unwrap();
+        writer.write_lp_string(&db, &data).unwrap();
         rollover_and_load(&db, "2020-03-01T00").await;
         rollover_and_load(&db, "2020-03-02T00").await;
         rollover_and_load(&db, "2020-04-01T00").await;

--- a/server/src/query_tests/scenarios.rs
+++ b/server/src/query_tests/scenarios.rs
@@ -47,7 +47,7 @@ impl DBSetup for NoData {
         let db = make_db();
         let data = "cpu,region=west user=23.2 100";
         let mut writer = TestLPWriter::default();
-        writer.write_lp_string(&db, data).await.unwrap();
+        writer.write_lp_string(&db, data).unwrap();
         // move data out of open chunk
         assert_eq!(db.rollover_partition(partition_key).await.unwrap().id(), 0);
 
@@ -208,7 +208,7 @@ impl DBSetup for EndToEndTest {
 
         let db = make_db();
         let mut writer = TestLPWriter::default();
-        let res = writer.write_lp_string(&db, &lp_data).await;
+        let res = writer.write_lp_string(&db, &lp_data);
         assert!(res.is_ok(), "Error: {}", res.unwrap_err());
 
         let scenario1 = DBScenario {
@@ -228,7 +228,7 @@ impl DBSetup for EndToEndTest {
 pub(crate) async fn make_one_chunk_scenarios(partition_key: &str, data: &str) -> Vec<DBScenario> {
     let db = make_db();
     let mut writer = TestLPWriter::default();
-    writer.write_lp_string(&db, data).await.unwrap();
+    writer.write_lp_string(&db, data).unwrap();
     let scenario1 = DBScenario {
         scenario_name: "Data in open chunk of mutable buffer".into(),
         db,
@@ -236,7 +236,7 @@ pub(crate) async fn make_one_chunk_scenarios(partition_key: &str, data: &str) ->
 
     let db = make_db();
     let mut writer = TestLPWriter::default();
-    writer.write_lp_string(&db, data).await.unwrap();
+    writer.write_lp_string(&db, data).unwrap();
     db.rollover_partition(partition_key).await.unwrap();
     let scenario2 = DBScenario {
         scenario_name: "Data in closed chunk of mutable buffer".into(),
@@ -245,7 +245,7 @@ pub(crate) async fn make_one_chunk_scenarios(partition_key: &str, data: &str) ->
 
     let db = make_db();
     let mut writer = TestLPWriter::default();
-    writer.write_lp_string(&db, data).await.unwrap();
+    writer.write_lp_string(&db, data).unwrap();
     db.rollover_partition(partition_key).await.unwrap();
     db.load_chunk_to_read_buffer(partition_key, 0)
         .await
@@ -271,8 +271,8 @@ pub async fn make_two_chunk_scenarios(
 ) -> Vec<DBScenario> {
     let db = make_db();
     let mut writer = TestLPWriter::default();
-    writer.write_lp_string(&db, data1).await.unwrap();
-    writer.write_lp_string(&db, data2).await.unwrap();
+    writer.write_lp_string(&db, data1).unwrap();
+    writer.write_lp_string(&db, data2).unwrap();
     let scenario1 = DBScenario {
         scenario_name: "Data in single open chunk of mutable buffer".into(),
         db,
@@ -281,9 +281,9 @@ pub async fn make_two_chunk_scenarios(
     // spread across 2 mutable buffer chunks
     let db = make_db();
     let mut writer = TestLPWriter::default();
-    writer.write_lp_string(&db, data1).await.unwrap();
+    writer.write_lp_string(&db, data1).unwrap();
     db.rollover_partition(partition_key).await.unwrap();
-    writer.write_lp_string(&db, data2).await.unwrap();
+    writer.write_lp_string(&db, data2).unwrap();
     let scenario2 = DBScenario {
         scenario_name: "Data in one open chunk and one closed chunk of mutable buffer".into(),
         db,
@@ -292,12 +292,12 @@ pub async fn make_two_chunk_scenarios(
     // spread across 1 mutable buffer, 1 read buffer chunks
     let db = make_db();
     let mut writer = TestLPWriter::default();
-    writer.write_lp_string(&db, data1).await.unwrap();
+    writer.write_lp_string(&db, data1).unwrap();
     db.rollover_partition(partition_key).await.unwrap();
     db.load_chunk_to_read_buffer(partition_key, 0)
         .await
         .unwrap();
-    writer.write_lp_string(&db, data2).await.unwrap();
+    writer.write_lp_string(&db, data2).unwrap();
     let scenario3 = DBScenario {
         scenario_name: "Data in open chunk of mutable buffer, and one chunk of read buffer".into(),
         db,
@@ -306,9 +306,9 @@ pub async fn make_two_chunk_scenarios(
     // in 2 read buffer chunks
     let db = make_db();
     let mut writer = TestLPWriter::default();
-    writer.write_lp_string(&db, data1).await.unwrap();
+    writer.write_lp_string(&db, data1).unwrap();
     db.rollover_partition(partition_key).await.unwrap();
-    writer.write_lp_string(&db, data2).await.unwrap();
+    writer.write_lp_string(&db, data2).unwrap();
     db.rollover_partition(partition_key).await.unwrap();
 
     db.load_chunk_to_read_buffer(partition_key, 0)

--- a/server/src/snapshot.rs
+++ b/server/src/snapshot.rs
@@ -385,7 +385,7 @@ mem,host=A,region=west used=45 1
 
         let db = make_db();
         let mut writer = TestLPWriter::default();
-        writer.write_lp_string(&db, &lp).await.unwrap();
+        writer.write_lp_string(&db, &lp).unwrap();
 
         let store = Arc::new(ObjectStore::new_in_memory(InMemory::new()));
         let (tx, rx) = tokio::sync::oneshot::channel();


### PR DESCRIPTION
Similar to https://github.com/influxdata/influxdb_iox/pull/1062


These functions needed to be `async` when the underlying implementations used the async versions of `Mutex` and `RwLock`. Now that we are using the `sync` versions of those locking primitives, there is no need for `Database` to be async either

- [x] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb_iox/blob/main/README.md).
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
