### PR TITLE
feat: Implement Update API for Database (rules)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1467,6 +1467,7 @@ dependencies = [
  "influxdb_tsm",
  "ingest",
  "internal_types",
+ "itertools 0.9.0",
  "logfmt",
  "mem_qe",
  "mutable_buffer",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,6 +76,7 @@ http = "0.2.0"
 hyper = "0.14"
 once_cell = { version = "1.4.0", features = ["parking_lot"] }
 parking_lot = "0.11.1"
+itertools = "0.9.0"
 # used by arrow/datafusion anyway
 prettytable-rs = "0.8"
 prost = "0.7"

--- a/buf.yaml
+++ b/buf.yaml
@@ -4,6 +4,7 @@ build:
     - generated_types/protos/
 
 lint:
+  allow_comment_ignores: true
   ignore:
     - google
     - grpc

--- a/data_types/src/field_validation.rs
+++ b/data_types/src/field_validation.rs
@@ -26,7 +26,7 @@ where
 
 /// An extension trait that adds the methods `optional` and `required` to any
 /// Option containing a type implementing `TryInto<U, Error = FieldViolation>`
-pub(crate) trait FromFieldOpt<T> {
+pub trait FromFieldOpt<T> {
     /// Try to convert inner type, if any, using TryInto calling
     /// `FieldViolation::scope` on any error encountered
     ///

--- a/data_types/src/lib.rs
+++ b/data_types/src/lib.rs
@@ -23,4 +23,4 @@ pub mod timestamp;
 pub mod wal;
 
 mod database_name;
-pub(crate) mod field_validation;
+pub mod field_validation;

--- a/generated_types/protos/influxdata/iox/management/v1/service.proto
+++ b/generated_types/protos/influxdata/iox/management/v1/service.proto
@@ -1,7 +1,9 @@
 syntax = "proto3";
 package influxdata.iox.management.v1;
 
+
 import "google/longrunning/operations.proto";
+import "google/protobuf/field_mask.proto";
 import "influxdata/iox/management/v1/database_rules.proto";
 import "influxdata/iox/management/v1/chunk.proto";
 import "influxdata/iox/management/v1/partition.proto";
@@ -16,6 +18,11 @@ service ManagementService {
   rpc GetDatabase(GetDatabaseRequest) returns (GetDatabaseResponse);
 
   rpc CreateDatabase(CreateDatabaseRequest) returns (CreateDatabaseResponse);
+
+  // Update a database.
+  //
+  // Roughly follows the https://google.aip.dev/134 pattern, except we wrap the response
+  rpc UpdateDatabase(UpdateDatabaseRequest) returns (UpdateDatabaseResponse);
 
   // List chunks available on this database
   rpc ListChunks(ListChunksRequest) returns (ListChunksResponse);
@@ -52,7 +59,6 @@ service ManagementService {
 
   // Close a chunk and move it to the read buffer
   rpc ClosePartitionChunk(ClosePartitionChunkRequest) returns (ClosePartitionChunkResponse);
-
 }
 
 message GetWriterIdRequest {}
@@ -86,6 +92,16 @@ message CreateDatabaseRequest {
 }
 
 message CreateDatabaseResponse {}
+
+// Update a database.
+message UpdateDatabaseRequest {
+  // The rule's `name` field is used to identify the database rules to be updated.
+  DatabaseRules rules = 1;
+}
+
+message UpdateDatabaseResponse {
+  DatabaseRules rules = 1;
+}
 
 message ListChunksRequest {
   // the name of the database

--- a/influxdb_iox_client/src/client/management.rs
+++ b/influxdb_iox_client/src/client/management.rs
@@ -53,6 +53,26 @@ pub enum CreateDatabaseError {
     ServerError(tonic::Status),
 }
 
+/// Errors returned by Client::update_database
+#[derive(Debug, Error)]
+pub enum UpdateDatabaseError {
+    /// Writer ID is not set
+    #[error("Writer ID not set")]
+    NoWriterId,
+
+    /// Database not found
+    #[error("Database not found")]
+    DatabaseNotFound,
+
+    /// Server returned an invalid argument error
+    #[error("Unexpected server error: {}: {}", .0.code(), .0.message())]
+    InvalidArgument(tonic::Status),
+
+    /// Client received an unexpected error from the server
+    #[error("Unexpected server error: {}: {}", .0.code(), .0.message())]
+    ServerError(tonic::Status),
+}
+
 /// Errors returned by Client::list_databases
 #[derive(Debug, Error)]
 pub enum ListDatabaseError {
@@ -269,6 +289,25 @@ impl Client {
             })?;
 
         Ok(())
+    }
+
+    /// Updates the configuration for a database.
+    pub async fn update_database(
+        &mut self,
+        rules: DatabaseRules,
+    ) -> Result<DatabaseRules, UpdateDatabaseError> {
+        let response = self
+            .inner
+            .update_database(UpdateDatabaseRequest { rules: Some(rules) })
+            .await
+            .map_err(|status| match status.code() {
+                tonic::Code::NotFound => UpdateDatabaseError::DatabaseNotFound,
+                tonic::Code::FailedPrecondition => UpdateDatabaseError::NoWriterId,
+                tonic::Code::InvalidArgument => UpdateDatabaseError::InvalidArgument(status),
+                _ => UpdateDatabaseError::ServerError(status),
+            })?;
+
+        Ok(response.into_inner().rules.unwrap())
     }
 
     /// List databases.


### PR DESCRIPTION
Part of #919

https://google.aip.dev/134 describes a pattern for gRPC CRUD.  We don't implement field_masks, which are optional.

This PR implements the Update API for database rules resources.

We deviate a little bit from https://google.aip.dev/134 in that we didn't reach consensus on whether to adopt the resource style of https://google.aip.dev/134 w.r.t return message of the CRUD methods, so we'll keep following the good old non-aip protobuf rules (every method should have their own request and response types).

In another PR I'll implement e-tags, so we can safely perform read-update-write cycles using this API.

---

This PR used to have a field_mask implementation which was pulled out and will be proposed again in another PR in the future, once it has better ergonomic and we gain more experience on how an update API is going to be used by us, so we can make a better case for it.