### PR TITLE
feat: Add support for listing tables via information_schema.tables

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -111,7 +111,7 @@ checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 [[package]]
 name = "arrow"
 version = "4.0.0-SNAPSHOT"
-source = "git+https://github.com/apache/arrow.git?rev=2c5e26423550d82ab2bd3f7a8f7f1d7eac89cf36#2c5e26423550d82ab2bd3f7a8f7f1d7eac89cf36"
+source = "git+https://github.com/apache/arrow.git?rev=9aa0f85a2750b7faaf8ad069e05a89b4f8a1754f#9aa0f85a2750b7faaf8ad069e05a89b4f8a1754f"
 dependencies = [
  "cfg_aliases",
  "chrono",
@@ -134,7 +134,7 @@ dependencies = [
 [[package]]
 name = "arrow-flight"
 version = "4.0.0-SNAPSHOT"
-source = "git+https://github.com/apache/arrow.git?rev=2c5e26423550d82ab2bd3f7a8f7f1d7eac89cf36#2c5e26423550d82ab2bd3f7a8f7f1d7eac89cf36"
+source = "git+https://github.com/apache/arrow.git?rev=9aa0f85a2750b7faaf8ad069e05a89b4f8a1754f#9aa0f85a2750b7faaf8ad069e05a89b4f8a1754f"
 dependencies = [
  "arrow",
  "bytes",
@@ -544,9 +544,9 @@ dependencies = [
 
 [[package]]
 name = "const_fn"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28b9d6de7f49e22cf97ad17fc4036ece69300032f45f78f30b4a4482cdc3f4a6"
+checksum = "076a6803b0dacd6a88cfe64deba628b01533ff5ef265687e6938280c1afd0a28"
 
 [[package]]
 name = "constant_time_eq"
@@ -774,7 +774,7 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "4.0.0-SNAPSHOT"
-source = "git+https://github.com/apache/arrow.git?rev=2c5e26423550d82ab2bd3f7a8f7f1d7eac89cf36#2c5e26423550d82ab2bd3f7a8f7f1d7eac89cf36"
+source = "git+https://github.com/apache/arrow.git?rev=9aa0f85a2750b7faaf8ad069e05a89b4f8a1754f#9aa0f85a2750b7faaf8ad069e05a89b4f8a1754f"
 dependencies = [
  "ahash 0.7.2",
  "arrow",
@@ -881,9 +881,9 @@ checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
 
 [[package]]
 name = "dtoa"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88d7ed2934d741c6b37e33e3832298e8850b53fd2d2bea03873375596c7cea4e"
+checksum = "56899898ce76aaf4a0f24d914c97ea6ed976d42fec6ad33fcbb0a1103e07b2b0"
 
 [[package]]
 name = "either"
@@ -1608,9 +1608,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.49"
+version = "0.3.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc15e39392125075f60c95ba416f5381ff6c3a948ff02ab12464715adf56c821"
+checksum = "2d99f9e3e84b8f67f846ef5b4cbbc3b1c29f6c759fcbce6f01aa0e73d932a24c"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1656,9 +1656,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.91"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8916b1f6ca17130ec6568feccee27c156ad12037880833a3b842a823236502e7"
+checksum = "56d855069fafbb9b344c0f962150cd2c1187975cb1c22c1522c240d8c4986714"
 
 [[package]]
 name = "libloading"
@@ -1776,9 +1776,9 @@ checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
 
 [[package]]
 name = "memoffset"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc14fc54a812b4472b4113facc3e44d099fbc0ea2ce0551fa5c703f8edfbfd38"
+checksum = "f83fb6581e8ed1f85fd45c116db8405483899489e38406156c25eb743554361d"
 dependencies = [
  "autocfg",
 ]
@@ -2243,7 +2243,7 @@ dependencies = [
 [[package]]
 name = "parquet"
 version = "4.0.0-SNAPSHOT"
-source = "git+https://github.com/apache/arrow.git?rev=2c5e26423550d82ab2bd3f7a8f7f1d7eac89cf36#2c5e26423550d82ab2bd3f7a8f7f1d7eac89cf36"
+source = "git+https://github.com/apache/arrow.git?rev=9aa0f85a2750b7faaf8ad069e05a89b4f8a1754f#9aa0f85a2750b7faaf8ad069e05a89b4f8a1754f"
 dependencies = [
  "arrow",
  "base64 0.12.3",
@@ -2315,11 +2315,11 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "0.4.27"
+version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ffbc8e94b38ea3d2d8ba92aea2983b503cd75d0888d75b86bb37970b5698e15"
+checksum = "918192b5c59119d51e0cd221f4d49dde9112824ba717369e903c97d076083d0f"
 dependencies = [
- "pin-project-internal 0.4.27",
+ "pin-project-internal 0.4.28",
 ]
 
 [[package]]
@@ -2333,9 +2333,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-internal"
-version = "0.4.27"
+version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65ad2ae56b6abe3a1ee25f15ee605bacadb9a764edaba9c2bf4103800d4a1895"
+checksum = "3be26700300be6d9d23264c73211d8190e755b6b5ca7a1b28230025511b52a5e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2518,7 +2518,7 @@ dependencies = [
  "prost",
  "prost-types",
  "tempfile",
- "which 4.0.2",
+ "which 4.1.0",
 ]
 
 [[package]]
@@ -3035,9 +3035,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d493c5f39e02dfb062cd8f33301f90f9b13b650e8c1b1d0fd75c19dd64bff69d"
+checksum = "3670b1d2fdf6084d192bc71ead7aabe6c06aa2ea3fbd9cc3ac111fa5c2b1bd84"
 dependencies = [
  "bitflags",
  "core-foundation",
@@ -3048,9 +3048,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dee48cdde5ed250b0d3252818f646e174ab414036edb884dde62d80a3ac6082d"
+checksum = "3676258fd3cfe2c9a0ec99ce3038798d847ce3e4bb17746373eb9f0f1ac16339"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -3269,7 +3269,7 @@ checksum = "eab12d3c261b2308b0d80c26fffb58d17eba81a4be97890101f416b478c79ca7"
 dependencies = [
  "doc-comment",
  "futures-core",
- "pin-project 0.4.27",
+ "pin-project 0.4.28",
  "snafu-derive",
 ]
 
@@ -3434,9 +3434,9 @@ checksum = "1e81da0851ada1f3e9d4312c704aa4f8806f0f9d69faaf8df2f3464b4a9437c2"
 
 [[package]]
 name = "syn"
-version = "1.0.65"
+version = "1.0.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3a1d708c221c5a612956ef9f75b37e454e88d1f7b899fbd3a18d4252012d663"
+checksum = "6498a9efc342871f91cc2d0d694c674368b4ceb40f62b65a7a08c3792935e702"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4062,9 +4062,9 @@ checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.72"
+version = "0.2.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fe8f61dba8e5d645a4d8132dc7a0a66861ed5e1045d2c0ed940fab33bac0fbe"
+checksum = "83240549659d187488f91f33c0f8547cbfef0b2088bc470c116d1d260ef623d9"
 dependencies = [
  "cfg-if 1.0.0",
  "serde",
@@ -4074,9 +4074,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.72"
+version = "0.2.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "046ceba58ff062da072c7cb4ba5b22a37f00a302483f7e2a6cdc18fedbdc1fd3"
+checksum = "ae70622411ca953215ca6d06d3ebeb1e915f0f6613e3b495122878d7ebec7dae"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -4089,9 +4089,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.22"
+version = "0.4.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73157efb9af26fb564bb59a009afd1c7c334a44db171d280690d0c3faaec3468"
+checksum = "81b8b767af23de6ac18bf2168b690bed2902743ddf0fb39252e36f9e2bfc63ea"
 dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
@@ -4101,9 +4101,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.72"
+version = "0.2.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ef9aa01d36cda046f797c57959ff5f3c615c9cc63997a8d545831ec7976819b"
+checksum = "3e734d91443f177bfdb41969de821e15c516931c3c3db3d318fa1b68975d0f6f"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4111,9 +4111,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.72"
+version = "0.2.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96eb45c1b2ee33545a813a92dbb53856418bf7eb54ab34f7f7ff1448a5b3735d"
+checksum = "d53739ff08c8a68b0fdbcd54c372b8ab800b1449ab3c9d706503bc7dd1621b2c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4124,15 +4124,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.72"
+version = "0.2.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7148f4696fb4960a346eaa60bbfb42a1ac4ebba21f750f75fc1375b098d5ffa"
+checksum = "d9a543ae66aa233d14bb765ed9af4a33e81b8b58d1584cf1b47ff8cd0b9e4489"
 
 [[package]]
 name = "web-sys"
-version = "0.3.49"
+version = "0.3.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59fe19d70f5dacc03f6e46777213facae5ac3801575d56ca6cbd4c93dcd12310"
+checksum = "a905d57e488fec8861446d3393670fb50d27a262344013181c2cdf9fff5481be"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4168,12 +4168,12 @@ dependencies = [
 
 [[package]]
 name = "which"
-version = "4.0.2"
+version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87c14ef7e1b8b8ecfc75d5eca37949410046e66f15d185c01d70824f1f8111ef"
+checksum = "b55551e42cbdf2ce2bedd2203d0cc08dba002c27510f86dab6d0ce304cba3dfe"
 dependencies = [
+ "either",
  "libc",
- "thiserror",
 ]
 
 [[package]]

--- a/arrow_deps/Cargo.toml
+++ b/arrow_deps/Cargo.toml
@@ -8,14 +8,14 @@ description = "Apache Arrow / Parquet / DataFusion dependencies for InfluxDB IOx
 [dependencies] # In alphabetical order
 # We are using development version of arrow/parquet/datafusion and the dependencies are at the same rev
 
-# The version can be found here: https://github.com/apache/arrow/commit/2c5e26423550d82ab2bd3f7a8f7f1d7eac89cf36
+# The version can be found here: https://github.com/apache/arrow/commit/9aa0f85a2750b7faaf8ad069e05a89b4f8a1754f
 #
-arrow = { git = "https://github.com/apache/arrow.git", rev = "2c5e26423550d82ab2bd3f7a8f7f1d7eac89cf36" , features = ["simd"] }
-arrow-flight = { git = "https://github.com/apache/arrow.git", rev = "2c5e26423550d82ab2bd3f7a8f7f1d7eac89cf36" }
+arrow = { git = "https://github.com/apache/arrow.git", rev = "9aa0f85a2750b7faaf8ad069e05a89b4f8a1754f" , features = ["simd"] }
+arrow-flight = { git = "https://github.com/apache/arrow.git", rev = "9aa0f85a2750b7faaf8ad069e05a89b4f8a1754f" }
 
 # Turn off optional datafusion features (function packages)
-datafusion = { git = "https://github.com/apache/arrow.git", rev = "2c5e26423550d82ab2bd3f7a8f7f1d7eac89cf36", default-features = false }
+datafusion = { git = "https://github.com/apache/arrow.git", rev = "9aa0f85a2750b7faaf8ad069e05a89b4f8a1754f", default-features = false }
 
 # Turn off the "arrow" feature; it currently has a bug that causes the crate to rebuild every time
 # and we're not currently using it anyway
-parquet = { git = "https://github.com/apache/arrow.git", rev = "2c5e26423550d82ab2bd3f7a8f7f1d7eac89cf36", default-features = false, features = ["snap", "brotli", "flate2", "lz4", "zstd"] }
+parquet = { git = "https://github.com/apache/arrow.git", rev = "9aa0f85a2750b7faaf8ad069e05a89b4f8a1754f", default-features = false, features = ["snap", "brotli", "flate2", "lz4", "zstd"] }

--- a/query/src/exec/context.rs
+++ b/query/src/exec/context.rs
@@ -109,6 +109,7 @@ impl IOxExecutionContext {
         let config = ExecutionConfig::new()
             .with_batch_size(BATCH_SIZE)
             .create_default_catalog_and_schema(true)
+            .with_information_schema(true)
             .with_default_catalog_and_schema(DEFAULT_CATALOG, DEFAULT_SCHEMA)
             .with_query_planner(Arc::new(IOxQueryPlanner {}));
 

--- a/server/src/query_tests/sql.rs
+++ b/server/src/query_tests/sql.rs
@@ -181,6 +181,50 @@ async fn sql_select_from_school() {
 }
 
 #[tokio::test]
+async fn sql_select_from_information_schema_tables() {
+    // validate we have access to information schema for listing table
+    // names
+    let expected = vec![
+        "+---------------+--------------------+------------+------------+",
+        "| table_catalog | table_schema       | table_name | table_type |",
+        "+---------------+--------------------+------------+------------+",
+        "| public        | iox                | h2o        | BASE TABLE |",
+        "| public        | iox                | o2         | BASE TABLE |",
+        "| public        | information_schema | tables     | VIEW       |",
+        "+---------------+--------------------+------------+------------+",
+    ];
+    run_sql_test_case!(
+        TwoMeasurementsManyFields {},
+        "SELECT * from information_schema.tables",
+        &expected
+    );
+}
+
+#[tokio::test]
+async fn sql_union_all() {
+    // validate name resolution works for UNION ALL queries
+    let expected = vec![
+        "+--------+",
+        "| name   |",
+        "+--------+",
+        "| MA     |",
+        "| MA     |",
+        "| CA     |",
+        "| MA     |",
+        "| Boston |",
+        "| Boston |",
+        "| Boston |",
+        "| Boston |",
+        "+--------+",
+    ];
+    run_sql_test_case!(
+        TwoMeasurementsManyFields {},
+        "select state as name from h2o UNION ALL select city as name from h2o",
+        &expected
+    );
+}
+
+#[tokio::test]
 async fn sql_select_with_schema_merge_subset() {
     let expected = vec![
         "+------+--------+--------+",


### PR DESCRIPTION
# Rationale:
So we can see what tables are in each database (tada!)

Implements part of https://github.com/influxdata/influxdb_iox/issues/1013 (system tables) and adds  a test for https://github.com/influxdata/influxdb_iox/issues/1054

# Changes
1. Update datafusion deps (to get https://github.com/apache/arrow/pull/9818) and run `cargo update`
2. Add tests demonstrating the use of `information_schema`

# Notes
I plan to add "SHOW TABLES" support as well, but I am not sure yet if that should be baked into DataFusion or special cased in IOx. I will propose adding in DataFusion and see how far I get

# Example of use
```
alamb@ip-10-0-0-124 influxdb_iox % ./target/debug/influxdb_iox database query 26f7e5a4b7be365b_917b97a92e883afc 'select * from information_schema.tables'

+---------------+--------------------+------------+------------+
| table_catalog | table_schema       | table_name | table_type |
+---------------+--------------------+------------+------------+
| public        | iox                | cpu        | BASE TABLE |
| public        | iox                | disk       | BASE TABLE |
| public        | iox                | diskio     | BASE TABLE |
| public        | iox                | mem        | BASE TABLE |
| public        | iox                | net        | BASE TABLE |
| public        | iox                | processes  | BASE TABLE |
| public        | iox                | swap       | BASE TABLE |
| public        | iox                | system     | BASE TABLE |
| public        | information_schema | tables     | VIEW       |
+---------------+--------------------+------------+------------+
```

- [x] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb_iox/blob/main/README.md).
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
