### PR TITLE
feat: use Timestamp(TimeUnit::Nanosecond, None) for timestamps (DRAFT)

### DIFF
--- a/internal_types/src/schema.rs
+++ b/internal_types/src/schema.rs
@@ -7,10 +7,7 @@ use std::{
     sync::Arc,
 };
 
-use arrow_deps::arrow::datatypes::{
-    DataType as ArrowDataType, Field as ArrowField, Schema as ArrowSchema,
-    SchemaRef as ArrowSchemaRef,
-};
+use arrow_deps::arrow::datatypes::{DataType as ArrowDataType, Field as ArrowField, Schema as ArrowSchema, SchemaRef as ArrowSchemaRef, TimeUnit};
 
 /// The name of the timestamp column in the InfluxDB datamodel
 pub const TIME_COLUMN_NAME: &str = "time";
@@ -596,7 +593,7 @@ impl From<&InfluxColumnType> for ArrowDataType {
         match t {
             InfluxColumnType::Tag => Self::Utf8,
             InfluxColumnType::Field(influxdb_field_type) => (*influxdb_field_type).into(),
-            InfluxColumnType::Timestamp => Self::Int64,
+            InfluxColumnType::Timestamp => Self::Time64(TimeUnit::Nanosecond),
         }
     }
 }
@@ -702,7 +699,7 @@ mod test {
             ArrowField::new("float_col", ArrowDataType::Float64, false),
             ArrowField::new("str_col", ArrowDataType::Utf8, false),
             ArrowField::new("bool_col", ArrowDataType::Boolean, false),
-            ArrowField::new("time_col", ArrowDataType::Int64, false),
+            ArrowField::new("time_col", ArrowDataType::Time64(TimeUnit::Nanosecond), false),
         ];
 
         let metadata: HashMap<_, _> = vec![

--- a/internal_types/src/schema.rs
+++ b/internal_types/src/schema.rs
@@ -593,7 +593,10 @@ impl From<&InfluxColumnType> for ArrowDataType {
         match t {
             InfluxColumnType::Tag => Self::Utf8,
             InfluxColumnType::Field(influxdb_field_type) => (*influxdb_field_type).into(),
-            InfluxColumnType::Timestamp => Self::Time64(TimeUnit::Nanosecond),
+            InfluxColumnType::Timestamp => {
+                let timezone = None;
+                Self::Timestamp(TimeUnit::Nanosecond, timezone)
+            },
         }
     }
 }
@@ -699,7 +702,7 @@ mod test {
             ArrowField::new("float_col", ArrowDataType::Float64, false),
             ArrowField::new("str_col", ArrowDataType::Utf8, false),
             ArrowField::new("bool_col", ArrowDataType::Boolean, false),
-            ArrowField::new("time_col", ArrowDataType::Time64(TimeUnit::Nanosecond), false),
+            ArrowField::new("time_col", ArrowDataType::Timestamp(TimeUnit::Nanosecond, None), false),
         ];
 
         let metadata: HashMap<_, _> = vec![

--- a/mutable_buffer/src/table.rs
+++ b/mutable_buffer/src/table.rs
@@ -21,14 +21,7 @@ use internal_types::{
 
 use snafu::{OptionExt, ResultExt, Snafu};
 
-use arrow_deps::{
-    arrow,
-    arrow::{
-        array::{ArrayRef, BooleanArray, Float64Array, Int64Array, StringArray, UInt64Array},
-        datatypes::DataType as ArrowDataType,
-        record_batch::RecordBatch,
-    },
-};
+use arrow_deps::{arrow, arrow::{array::{ArrayRef, BooleanArray, Float64Array, Int64Array, StringArray, Time64NanosecondArray, UInt64Array}, datatypes::DataType as ArrowDataType, record_batch::RecordBatch}};
 
 #[derive(Debug, Snafu)]
 pub enum Error {
@@ -365,8 +358,14 @@ impl Table {
                     Arc::new(array) as ArrayRef
                 }
                 Column::I64(vals, _) => {
-                    let array = Int64Array::from_iter(vals.iter());
-                    Arc::new(array) as ArrayRef
+                    if col.column_name == TIME_COLUMN_NAME {
+                        let array = Time64NanosecondArray::from_iter(vals.iter());
+                        Arc::new(array) as ArrayRef
+                    }
+                    else {
+                        let array = Int64Array::from_iter(vals.iter());
+                        Arc::new(array) as ArrayRef
+                    }
                 }
                 Column::U64(vals, _) => {
                     let array = UInt64Array::from_iter(vals.iter());

--- a/mutable_buffer/src/table.rs
+++ b/mutable_buffer/src/table.rs
@@ -21,7 +21,7 @@ use internal_types::{
 
 use snafu::{OptionExt, ResultExt, Snafu};
 
-use arrow_deps::{arrow, arrow::{array::{ArrayRef, BooleanArray, Float64Array, Int64Array, StringArray, Time64NanosecondArray, UInt64Array}, datatypes::DataType as ArrowDataType, record_batch::RecordBatch}};
+use arrow_deps::{arrow, arrow::{array::{ArrayRef, BooleanArray, Float64Array, Int64Array, StringArray, TimestampNanosecondArray, UInt64Array}, datatypes::DataType as ArrowDataType, record_batch::RecordBatch}};
 
 #[derive(Debug, Snafu)]
 pub enum Error {
@@ -359,7 +359,7 @@ impl Table {
                 }
                 Column::I64(vals, _) => {
                     if col.column_name == TIME_COLUMN_NAME {
-                        let array = Time64NanosecondArray::from_iter(vals.iter());
+                        let array = TimestampNanosecondArray::from_iter(vals.iter());
                         Arc::new(array) as ArrayRef
                     }
                     else {


### PR DESCRIPTION
This is part of #1084.

# Rationale
We need to tell DataFusion that the `time` column is a nanosecond precision timestamp rather than an `i64` so that that type information is displayed to the user (and so that it gets into parquet files, etc)

Here is an illustration of the problem in IOx: `time` comes back as a number and if you want it to be displayed as a timestamp (or to use time specific functions like `date_trunc`) you need to cast it:

```
/target/debug/influxdb_iox database query 26f7e5a4b7be365b_917b97a92e883afc "select time, cast (time as timestamp) from cpu limit 10";

+---------------------+-------------------------------------------+
| time                | CAST(time AS Timestamp(Nanosecond, None)) |
+---------------------+-------------------------------------------+
| 1617130130000000000 | 2021-03-30 18:48:50                       |
| 1617130130000000000 | 2021-03-30 18:48:50                       |
| 1617130130000000000 | 2021-03-30 18:48:50                       |
| 1617130130000000000 | 2021-03-30 18:48:50                       |
| 1617130130000000000 | 2021-03-30 18:48:50                       |
| 1617130130000000000 | 2021-03-30 18:48:50                       |
| 1617130130000000000 | 2021-03-30 18:48:50                       |
| 1617130130000000000 | 2021-03-30 18:48:50                       |
| 1617130130000000000 | 2021-03-30 18:48:50                       |
| 1617130130000000000 | 2021-03-30 18:48:50                       |
+---------------------+-------------------------------------------+
```

I expect `time` to be returned as a timestamp without casting

# Arrow Types

The arrow `DataType` for timestamps is `Timestamp(TimeUnit::Nanosecond, None)` and the `Array` type is `Time64NanosecondArray`. This type of array still uses `i64` as its underlying data representation. They are both `PrimitiveArray`s [source link](https://github.com/apache/arrow/blob/8e43f23dcc6a9e630516228f110c48b64d13cec6/rust/arrow/src/array/mod.rs#L139):

(edit: previously this said `Time64(TimeUnit::Nanosecond)`)
```
pub type Int64Array = PrimitiveArray<Int64Type>;
pub type TimestampNanosecondArray = PrimitiveArray<TimestampNanosecondType>;
```

Where `TimestampNanosecondType` is [source link](https://github.com/apache/arrow/blob/8e43f23dcc6a9e630516228f110c48b64d13cec6/rust/arrow/src/datatypes/types.rs) stored using `i64`

# Changes
The changes needed are:
- [x]  Change `Schema` to return `Time64(TimeUnit::Nanosecond)` rather than `Int64` for timestamps
- [x] Update MutableBuffer to produce `TimestampNanosecondArray` rather than `Int64Array` for timestamps
- [ ] Update ReadBuffer to accept timestamp data from `TimestampNanosecondArray`
- [ ] Update ReadBuffer to prodice timestamp data as `TimestampNanosecondArray`
- [ ] Update all tests 



