### PR TITLE
 feat: Add ability to get `PartitionSummary` statistics from a Db

### DIFF
--- a/mutable_buffer/src/table.rs
+++ b/mutable_buffer/src/table.rs
@@ -542,36 +542,31 @@ impl Table {
         }
     }
 
-    pub fn stats(&self, chunk: &Chunk) -> Result<Vec<ColumnSummary>> {
-        let mut summaries = Vec::with_capacity(self.columns.len());
-
-        for (column_id, c) in &self.columns {
-            let column_name =
-                chunk
+    pub fn stats(&self, chunk: &Chunk) -> Vec<ColumnSummary> {
+        self.columns
+            .iter()
+            .map(|(column_id, c)| {
+                let column_name = chunk
                     .dictionary
                     .lookup_id(*column_id)
-                    .context(ColumnIdNotFoundInDictionary {
-                        column_id: *column_id,
-                        chunk: chunk.id,
-                    })?;
+                    .expect("column name in dictionary");
 
-            let stats = match c {
-                Column::F64(_, stats) => Statistics::F64(stats.clone()),
-                Column::I64(_, stats) => Statistics::I64(stats.clone()),
-                Column::U64(_, stats) => Statistics::U64(stats.clone()),
-                Column::Bool(_, stats) => Statistics::Bool(stats.clone()),
-                Column::String(_, stats) | Column::Tag(_, stats) => {
-                    Statistics::String(stats.clone())
+                let stats = match c {
+                    Column::F64(_, stats) => Statistics::F64(stats.clone()),
+                    Column::I64(_, stats) => Statistics::I64(stats.clone()),
+                    Column::U64(_, stats) => Statistics::U64(stats.clone()),
+                    Column::Bool(_, stats) => Statistics::Bool(stats.clone()),
+                    Column::String(_, stats) | Column::Tag(_, stats) => {
+                        Statistics::String(stats.clone())
+                    }
+                };
+
+                ColumnSummary {
+                    name: column_name.to_string(),
+                    stats,
                 }
-            };
-
-            summaries.push(ColumnSummary {
-                name: column_name.to_string(),
-                stats,
-            });
-        }
-
-        Ok(summaries)
+            })
+            .collect()
     }
 }
 

--- a/query/src/lib.rs
+++ b/query/src/lib.rs
@@ -62,8 +62,8 @@ pub trait PartitionChunk: Debug + Send + Sync {
     /// particular partition.
     fn id(&self) -> u32;
 
-    /// returns the partition metadata stats for every table in the chunk
-    fn table_stats(&self) -> Result<Vec<TableSummary>, Self::Error>;
+    /// returns summary information for every table in the chunk
+    fn table_summaries(&self) -> Vec<TableSummary>;
 
     /// Returns true if this chunk *might* have data that passes the
     /// predicate. If false is returned, this chunk can be

--- a/query/src/test.rs
+++ b/query/src/test.rs
@@ -345,10 +345,8 @@ impl PartitionChunk for TestChunk {
         self.id
     }
 
-    fn table_stats(
-        &self,
-    ) -> Result<Vec<data_types::partition_metadata::TableSummary>, Self::Error> {
-        unimplemented!()
+    fn table_summaries(&self) -> Vec<data_types::partition_metadata::TableSummary> {
+        unimplemented!("Table summaries are not implemented for test chunk")
     }
 
     fn read_filter(

--- a/server/src/db/catalog/chunk.rs
+++ b/server/src/db/catalog/chunk.rs
@@ -2,8 +2,9 @@ use std::collections::BTreeSet;
 use std::sync::Arc;
 
 use chrono::{DateTime, Utc};
-use data_types::chunk::ChunkSummary;
+use data_types::{chunk::ChunkSummary, partition_metadata::TableSummary};
 use mutable_buffer::chunk::Chunk as MBChunk;
+use query::PartitionChunk;
 use read_buffer::Database as ReadBufferDb;
 
 use crate::db::DBChunk;
@@ -143,6 +144,11 @@ impl Chunk {
             time_closing: self.time_closing,
             ..DBChunk::snapshot(self).summary()
         }
+    }
+
+    /// Return TableSummary metadata for each table in this chunk
+    pub fn table_summaries(&self) -> impl Iterator<Item = TableSummary> {
+        DBChunk::snapshot(self).table_summaries().into_iter()
     }
 
     /// Returns true if this chunk contains a table with the provided name

--- a/server/src/db/chunk.rs
+++ b/server/src/db/chunk.rs
@@ -180,12 +180,12 @@ impl PartitionChunk for DBChunk {
         }
     }
 
-    fn table_stats(
-        &self,
-    ) -> Result<Vec<data_types::partition_metadata::TableSummary>, Self::Error> {
+    fn table_summaries(&self) -> Vec<data_types::partition_metadata::TableSummary> {
         match self {
-            Self::MutableBuffer { chunk, .. } => chunk.table_stats().context(MutableBufferChunk),
-            Self::ReadBuffer { .. } => unimplemented!("read buffer not implemented"),
+            Self::MutableBuffer { chunk, .. } => chunk.table_summaries(),
+            Self::ReadBuffer { .. } => {
+                unimplemented!("table_summaries not implemented for read buffer")
+            }
             Self::ParquetFile => unimplemented!("parquet file not implemented"),
         }
     }

--- a/server/src/snapshot.rs
+++ b/server/src/snapshot.rs
@@ -284,10 +284,7 @@ pub fn snapshot_chunk<T>(
 where
     T: Send + Sync + 'static + PartitionChunk,
 {
-    let table_stats = chunk
-        .table_stats()
-        .map_err(|e| Box::new(e) as _)
-        .context(PartitionError)?;
+    let table_stats = chunk.table_summaries();
 
     let snapshot = Snapshot::new(
         partition_key.to_string(),


### PR DESCRIPTION
# Rationale
We want to expose catalog column level details via the management API (and system tables) - https://github.com/influxdata/influxdb_iox/issues/1085

# Changes:
This PR
1. Adds a way to get a `PartitionSummary` for partitions in a `Db`
2. Makes some methods unfallable (as they only way for them to fail is if the mutable buffer got into a state where the dictionary was corrupted, from which there is no reasonable recovery)


# Planned PRs:
- [x] Add API to get `ColumnSummary` from `Db` for all chunks (this PR)
- [ ] Add TableSummary generation for read buffer
- [ ] Add a protobuf definition to convert back/forth between `ColumnSummary` and management and CLI interfaces