### PR TITLE
feat: Add TableSummary calculation to ReadBuffer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2711,6 +2711,7 @@ dependencies = [
  "arrow_deps",
  "criterion",
  "croaring",
+ "data_types",
  "either",
  "hashbrown 0.9.1",
  "internal_types",

--- a/data_types/src/partition_metadata.rs
+++ b/data_types/src/partition_metadata.rs
@@ -102,7 +102,7 @@ pub struct ColumnSummary {
 
 impl ColumnSummary {
     /// Returns the total number of rows in this column
-    pub fn count(&self) -> u32 {
+    pub fn count(&self) -> u64 {
         self.stats.count()
     }
 
@@ -174,7 +174,7 @@ pub struct Column {
 
 impl Column {
     /// Returns the total number of rows in this column
-    pub fn count(&self) -> u32 {
+    pub fn count(&self) -> u64 {
         self.stats.count()
     }
 }
@@ -191,7 +191,7 @@ pub enum Statistics {
 
 impl Statistics {
     /// Returns the total number of rows in this column
-    pub fn count(&self) -> u32 {
+    pub fn count(&self) -> u64 {
         match self {
             Self::I64(s) => s.count,
             Self::U64(s) => s.count,
@@ -208,7 +208,7 @@ pub struct StatValues<T: PartialEq + PartialOrd + Debug + Display + Clone> {
     pub min: T,
     pub max: T,
     /// number of non-nil values in this column
-    pub count: u32,
+    pub count: u64,
 }
 
 impl<T> StatValues<T>

--- a/read_buffer/Cargo.toml
+++ b/read_buffer/Cargo.toml
@@ -13,6 +13,7 @@ edition = "2018"
 [dependencies] # In alphabetical order
 arrow_deps = { path = "../arrow_deps" }
 croaring = "0.4.5"
+data_types = { path = "../data_types" }
 either = "1.6.1"
 hashbrown = "0.9.1"
 internal_types = { path = "../internal_types" }

--- a/read_buffer/src/chunk.rs
+++ b/read_buffer/src/chunk.rs
@@ -3,6 +3,7 @@ use std::{
     sync::RwLock,
 };
 
+use data_types::partition_metadata::TableSummary;
 use internal_types::selection::Selection;
 use snafu::{OptionExt, ResultExt, Snafu};
 
@@ -165,6 +166,19 @@ impl Chunk {
             chunk_data.rows -= table.rows();
             chunk_data.row_groups -= table.row_groups();
         }
+    }
+
+    /// Return table summaries or all tables in this chunk. Note that
+    /// there can be more than one TableSummary for each table.
+    pub fn table_summaries(&self) -> Vec<TableSummary> {
+        // read lock on chunk.
+        let chunk_data = self.chunk_data.read().unwrap();
+
+        chunk_data
+            .data
+            .values()
+            .map(|table| table.table_summary())
+            .collect()
     }
 
     /// Returns an iterator of lazily executed `read_filter` operations on the

--- a/server/src/db.rs
+++ b/server/src/db.rs
@@ -1080,12 +1080,14 @@ mod tests {
         let mut writer = TestLPWriter::default();
 
         writer.write_lp_string(&db, "cpu bar=1 1").unwrap();
-        let _chunk_id = db.rollover_partition("1970-01-01T00").await.unwrap().id();
+        let chunk_id = db.rollover_partition("1970-01-01T00").await.unwrap().id();
         writer.write_lp_string(&db, "cpu bar=2,baz=3.0 2").unwrap();
         writer.write_lp_string(&db, "mem foo=1 1").unwrap();
 
-        // TODO: load a chunk to the read buffer (needs read buffer to be hooked up)
-        //db.load_chunk_to_read_buffer("1970-01-01T00", chunk_id).unwrap()
+        // load a chunk to the read buffer
+        db.load_chunk_to_read_buffer("1970-01-01T00", chunk_id)
+            .await
+            .unwrap();
 
         // write into a separate partitiion
         writer

--- a/server/src/db/chunk.rs
+++ b/server/src/db/chunk.rs
@@ -183,9 +183,11 @@ impl PartitionChunk for DBChunk {
     fn table_summaries(&self) -> Vec<data_types::partition_metadata::TableSummary> {
         match self {
             Self::MutableBuffer { chunk, .. } => chunk.table_summaries(),
-            Self::ReadBuffer { .. } => {
-                unimplemented!("table_summaries not implemented for read buffer")
-            }
+            Self::ReadBuffer {
+                chunk_id,
+                partition_key,
+                db,
+            } => db.table_summaries(partition_key, &[*chunk_id]),
             Self::ParquetFile => unimplemented!("parquet file not implemented"),
         }
     }


### PR DESCRIPTION
Builds on https://github.com/influxdata/influxdb_iox/pull/1090

# Rationale
We want to expose catalog column level details via the management API (and system tables) - https://github.com/influxdata/influxdb_iox/issues/1085

# Changes:
1. Adds calculation of `TableSummary` from ReadBufferDb
2. Hooks up to Partition chunk

# Discussion point

This PR proposes adding a dependence from the `read_buffer` crate on the`data_types` crate
(which has many other transitive dependencies). An alternative design
is to make `MetaData` public and move the conversion code to
`TableSummary` into the `server` crate. I don't have a strong
preference, and will be happy to make a change to this PR if others do.


# Planned PRs:
- [x] Add API to get `ColumnSummary` from `Db` for all chunks https://github.com/influxdata/influxdb_iox/pull/1090
- [x] Add TableSummary generation for read buffer (this PR)
- [ ] Add a protobuf definition to convert back/forth between `ColumnSummary` and management and CLI interfaces
