### PR TITLE
refactor: Add rwlock around db rules

### DIFF
--- a/server/src/db.rs
+++ b/server/src/db.rs
@@ -8,7 +8,7 @@ use std::sync::{
 };
 
 use async_trait::async_trait;
-use parking_lot::Mutex;
+use parking_lot::{Mutex, RwLock};
 use snafu::{OptionExt, ResultExt, Snafu};
 use tracing::{debug, info};
 
@@ -154,7 +154,7 @@ const STARTING_SEQUENCE: u64 = 1;
 /// itself. The catalog state can be observed (but not mutated) by things
 /// outside of the Db
 pub struct Db {
-    pub rules: DatabaseRules,
+    pub rules: RwLock<DatabaseRules>,
 
     /// The metadata catalog
     catalog: Arc<Catalog>,
@@ -183,6 +183,7 @@ impl Db {
         wal_buffer: Option<Buffer>,
         jobs: Arc<JobRegistry>,
     ) -> Self {
+        let rules = RwLock::new(rules);
         let wal_buffer = wal_buffer.map(Mutex::new);
         let read_buffer = Arc::new(read_buffer);
         let catalog = Arc::new(Catalog::new());
@@ -438,16 +439,9 @@ impl Db {
 
     /// Returns true if this database can accept writes
     pub fn writeable(&self) -> bool {
-        !self.rules.lifecycle_rules.immutable
+        !self.rules.read().lifecycle_rules.immutable
     }
 }
-
-impl PartialEq for Db {
-    fn eq(&self, other: &Self) -> bool {
-        self.rules == other.rules
-    }
-}
-impl Eq for Db {}
 
 #[async_trait]
 impl Database for Db {
@@ -476,9 +470,12 @@ impl Database for Db {
     }
 
     fn store_replicated_write(&self, write: &ReplicatedWrite) -> Result<(), Self::Error> {
-        if !self.writeable() {
+        let rules = self.rules.read();
+        let mutable_size_threshold = rules.lifecycle_rules.mutable_size_threshold;
+        if rules.lifecycle_rules.immutable {
             return DatabaseNotWriteable {}.fail();
         }
+        std::mem::drop(rules);
 
         let entries = match write.write_buffer_batch().and_then(|batch| batch.entries()) {
             Some(entries) => entries,
@@ -510,7 +507,7 @@ impl Database for Db {
 
                 let size = mb_chunk.size();
 
-                if let Some(threshold) = self.rules.lifecycle_rules.mutable_size_threshold {
+                if let Some(threshold) = mutable_size_threshold {
                     if size > threshold.get() {
                         chunk.set_closing().expect("cannot close open chunk")
                     }
@@ -585,6 +582,7 @@ mod tests {
             },
             ..DatabaseRules::new()
         };
+        let rules = RwLock::new(rules);
         let db = Db { rules, ..db };
         assert!(!db.writeable());
 
@@ -804,8 +802,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_chunk_closing() {
-        let mut db = make_db();
-        db.rules.lifecycle_rules.mutable_size_threshold = Some(NonZeroUsize::new(2).unwrap());
+        let db = make_db();
+        db.rules.write().lifecycle_rules.mutable_size_threshold =
+            Some(NonZeroUsize::new(2).unwrap());
 
         let mut writer = TestLPWriter::default();
         writer.write_lp_string(&db, "cpu bar=1 10").unwrap();

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -225,8 +225,7 @@ impl<M: ConnectionManager> Server<M> {
         }
     }
 
-    /// Tells the server the set of rules for a database. Currently, this is not
-    /// persisted and is for in-memory processing rules only.
+    /// Tells the server the set of rules for a database.
     pub async fn create_database(
         &self,
         db_name: impl Into<String>,
@@ -241,17 +240,25 @@ impl<M: ConnectionManager> Server<M> {
 
         let db_reservation = self.config.create_db(db_name, rules)?;
 
+        let rules = db_reservation.db.rules.read().clone();
+        self.persist_database_rules(&db_reservation.name, rules)
+            .await?;
+
+        db_reservation.commit();
+
+        Ok(())
+    }
+
+    pub async fn persist_database_rules<'a>(
+        &self,
+        db_name: &DatabaseName<'static>,
+        rules: DatabaseRules,
+    ) -> Result<()> {
         let mut data = BytesMut::new();
-        db_reservation
-            .db
-            .rules
-            .clone()
-            .encode(&mut data)
-            .context(ErrorSerializing)?;
+        rules.encode(&mut data).context(ErrorSerializing)?;
 
         let len = data.len();
-        let location =
-            object_store_path_for_database_config(&self.root_path()?, &db_reservation.name);
+        let location = object_store_path_for_database_config(&self.root_path()?, db_name);
 
         let stream_data = std::io::Result::Ok(data.freeze());
         self.store
@@ -262,9 +269,6 @@ impl<M: ConnectionManager> Server<M> {
             )
             .await
             .context(StoreError)?;
-
-        db_reservation.commit();
-
         Ok(())
     }
 
@@ -350,7 +354,7 @@ impl<M: ConnectionManager> Server<M> {
             .context(DatabaseNotFound { db_name: &*db_name })?;
 
         let sequence = db.next_sequence();
-        let write = lines_to_replicated_write(id, sequence, lines, &db.rules);
+        let write = lines_to_replicated_write(id, sequence, lines, &*db.rules.read());
 
         self.handle_replicated_write(&db_name, &db, write).await?;
 
@@ -411,7 +415,7 @@ impl<M: ConnectionManager> Server<M> {
     }
 
     pub fn db_rules(&self, name: &DatabaseName<'_>) -> Option<DatabaseRules> {
-        self.config.db(name).map(|d| d.rules.clone())
+        self.config.db(name).map(|d| d.rules.read().clone())
     }
 
     pub fn remotes_sorted(&self) -> Vec<(WriterId, String)> {


### PR DESCRIPTION
This takes the non-controversial parts of #1066 that are highly likely to cause conflicts with other concurrent PRs

We need to be able to mutate the database rules. This PR only a RwLock around the database rules in the `Db` struct.

A secondary aspect of this PR is that `persist_database_rules` is split out of `create_database`, in preparation for an `update_db_rules` method that can use the same code to keep database rules config file persisted on objectstore.
The actual `update_db_rules` is being worked on in a separate PR (split out from #1066)
