### PR TITLE
chore: Add the serde feature to bytes dep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1137,6 +1137,7 @@ dependencies = [
 name = "generated_types"
 version = "0.1.0"
 dependencies = [
+ "bytes",
  "flatbuffers",
  "futures",
  "google_types",
@@ -1198,6 +1199,7 @@ checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 name = "google_types"
 version = "0.1.0"
 dependencies = [
+ "bytes",
  "chrono",
  "prost",
  "prost-build",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ wal = { path = "wal" }
 
 # Crates.io dependencies, in alphabetical order
 byteorder = "1.3.4"
-bytes = { version = "1.0", features = ["serde"] }
+bytes = "1.0"
 chrono = "0.4"
 clap = "2.33.1"
 csv = "1.1"

--- a/generated_types/Cargo.toml
+++ b/generated_types/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Paul Dix <paul@pauldix.net>"]
 edition = "2018"
 
 [dependencies] # In alphabetical order
+bytes = { version = "1.0", features = ["serde"] }
 # See docs/regenerating_flatbuffers.md about updating generated code when updating the
 # version of the flatbuffers crate
 flatbuffers = "0.8"

--- a/google_types/Cargo.toml
+++ b/google_types/Cargo.toml
@@ -6,6 +6,7 @@ description = "Standard Protobuf definitions - extracted into separate crate to 
 edition = "2018"
 
 [dependencies] # In alphabetical order
+bytes = { version = "1.0", features = ["serde"] }
 chrono = "0.4"
 prost = "0.7"
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
After #1069 building some crates directly fails:

```console
$ cd internal_types
$ cargo build
....
#[prost(bytes="bytes", tag="1")]
744 | |     pub value: ::prost::bytes::Bytes,
    | |____________________________________^ the trait `Deserialize<'_>` is not implemented for `prost::bytes::Bytes`
```

The `build.rs` file of the `generated_types` and `google_types` configures prost code generation so that it adds `#[derive(serde)]` to to all types; some types contain `Bytes` fields, which requires the `bytes` crate to have the `serde` feature flag turned on. Thus, it makes sense to declare the `bytes/serde` feature flag dependency in the crates that trigger that dependency proper.

In #1069 that feature flag was enabled in the top-level `Cargo.toml` file, which made CI happy because the CI build process builds all the workspace crates from the top-level. Some developers (like yours truly) didn't notice the problem because they were compiling individual crates with `cargo build --package internal_types`, but some others hit the snag because their workflow included building the crate from within the directory. This PR fixes the experience for the latter. Unfortunately we don't test this property on the CI so it's possible we re-introduce a similar regression unless we improve our CI scripts in another PR.