### PR TITLE
refactor: remove Db::writeable

### DIFF
--- a/server/src/db.rs
+++ b/server/src/db.rs
@@ -436,11 +436,6 @@ impl Db {
 
         info!("finished background worker");
     }
-
-    /// Returns true if this database can accept writes
-    pub fn writeable(&self) -> bool {
-        !self.rules.read().lifecycle_rules.immutable
-    }
 }
 
 #[async_trait]
@@ -584,7 +579,6 @@ mod tests {
         };
         let rules = RwLock::new(rules);
         let db = Db { rules, ..db };
-        assert!(!db.writeable());
 
         let mut writer = TestLPWriter::default();
         let res = writer.write_lp_string(&db, "cpu bar=1 10");


### PR DESCRIPTION
This started as an exercise to avoid acquiring a mutex on DatabaseRules twice in rapid succession, and then morphed into removing a very confusingly named member function. However, it does highlight that Db has two member functions with very similar names that do similar but subtly different things:

* `Database::store_replicated_write` - stores data to the mutable buffer
* `Db::handle_replicated_write` - stores data into the WAL and potentially the mutable buffer via calling store_replicated_write

I've preserved the existing behavior but I wonder if there isn't something a little bit off here?