### PR TITLE
feat: add SHOW TABLES and `select * from information_schema.columns`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -111,7 +111,7 @@ checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 [[package]]
 name = "arrow"
 version = "4.0.0-SNAPSHOT"
-source = "git+https://github.com/apache/arrow.git?rev=9aa0f85a2750b7faaf8ad069e05a89b4f8a1754f#9aa0f85a2750b7faaf8ad069e05a89b4f8a1754f"
+source = "git+https://github.com/apache/arrow.git?rev=090f11cf9583a72a967956d383e5d452db17bd96#090f11cf9583a72a967956d383e5d452db17bd96"
 dependencies = [
  "cfg_aliases",
  "chrono",
@@ -134,7 +134,7 @@ dependencies = [
 [[package]]
 name = "arrow-flight"
 version = "4.0.0-SNAPSHOT"
-source = "git+https://github.com/apache/arrow.git?rev=9aa0f85a2750b7faaf8ad069e05a89b4f8a1754f#9aa0f85a2750b7faaf8ad069e05a89b4f8a1754f"
+source = "git+https://github.com/apache/arrow.git?rev=090f11cf9583a72a967956d383e5d452db17bd96#090f11cf9583a72a967956d383e5d452db17bd96"
 dependencies = [
  "arrow",
  "bytes",
@@ -777,7 +777,7 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "4.0.0-SNAPSHOT"
-source = "git+https://github.com/apache/arrow.git?rev=9aa0f85a2750b7faaf8ad069e05a89b4f8a1754f#9aa0f85a2750b7faaf8ad069e05a89b4f8a1754f"
+source = "git+https://github.com/apache/arrow.git?rev=090f11cf9583a72a967956d383e5d452db17bd96#090f11cf9583a72a967956d383e5d452db17bd96"
 dependencies = [
  "ahash 0.7.2",
  "arrow",
@@ -792,6 +792,7 @@ dependencies = [
  "parquet",
  "paste",
  "pin-project-lite",
+ "smallvec",
  "sqlparser",
  "tokio",
  "tokio-stream",
@@ -2253,7 +2254,7 @@ dependencies = [
 [[package]]
 name = "parquet"
 version = "4.0.0-SNAPSHOT"
-source = "git+https://github.com/apache/arrow.git?rev=9aa0f85a2750b7faaf8ad069e05a89b4f8a1754f#9aa0f85a2750b7faaf8ad069e05a89b4f8a1754f"
+source = "git+https://github.com/apache/arrow.git?rev=090f11cf9583a72a967956d383e5d452db17bd96#090f11cf9583a72a967956d383e5d452db17bd96"
 dependencies = [
  "arrow",
  "base64 0.12.3",

--- a/arrow_deps/Cargo.toml
+++ b/arrow_deps/Cargo.toml
@@ -8,14 +8,14 @@ description = "Apache Arrow / Parquet / DataFusion dependencies for InfluxDB IOx
 [dependencies] # In alphabetical order
 # We are using development version of arrow/parquet/datafusion and the dependencies are at the same rev
 
-# The version can be found here: https://github.com/apache/arrow/commit/9aa0f85a2750b7faaf8ad069e05a89b4f8a1754f
+# The version can be found here: https://github.com/apache/arrow/commit/090f11cf9583a72a967956d383e5d452db17bd96
 #
-arrow = { git = "https://github.com/apache/arrow.git", rev = "9aa0f85a2750b7faaf8ad069e05a89b4f8a1754f" , features = ["simd"] }
-arrow-flight = { git = "https://github.com/apache/arrow.git", rev = "9aa0f85a2750b7faaf8ad069e05a89b4f8a1754f" }
+arrow = { git = "https://github.com/apache/arrow.git", rev = "090f11cf9583a72a967956d383e5d452db17bd96" , features = ["simd"] }
+arrow-flight = { git = "https://github.com/apache/arrow.git", rev = "090f11cf9583a72a967956d383e5d452db17bd96" }
 
 # Turn off optional datafusion features (function packages)
-datafusion = { git = "https://github.com/apache/arrow.git", rev = "9aa0f85a2750b7faaf8ad069e05a89b4f8a1754f", default-features = false }
+datafusion = { git = "https://github.com/apache/arrow.git", rev = "090f11cf9583a72a967956d383e5d452db17bd96", default-features = false }
 
 # Turn off the "arrow" feature; it currently has a bug that causes the crate to rebuild every time
 # and we're not currently using it anyway
-parquet = { git = "https://github.com/apache/arrow.git", rev = "9aa0f85a2750b7faaf8ad069e05a89b4f8a1754f", default-features = false, features = ["snap", "brotli", "flate2", "lz4", "zstd"] }
+parquet = { git = "https://github.com/apache/arrow.git", rev = "090f11cf9583a72a967956d383e5d452db17bd96", default-features = false, features = ["snap", "brotli", "flate2", "lz4", "zstd"] }

--- a/server/src/query_tests/sql.rs
+++ b/server/src/query_tests/sql.rs
@@ -191,11 +191,41 @@ async fn sql_select_from_information_schema_tables() {
         "| public        | iox                | h2o        | BASE TABLE |",
         "| public        | iox                | o2         | BASE TABLE |",
         "| public        | information_schema | tables     | VIEW       |",
+        "| public        | information_schema | columns    | VIEW       |",
         "+---------------+--------------------+------------+------------+",
     ];
     run_sql_test_case!(
         TwoMeasurementsManyFields {},
         "SELECT * from information_schema.tables",
+        &expected
+    );
+    run_sql_test_case!(TwoMeasurementsManyFields {}, "SHOW TABLES", &expected);
+}
+
+#[tokio::test]
+async fn sql_select_from_information_schema_columns() {
+    // validate we have access to information schema for listing columns
+    // names
+    let expected = vec![
+    "+---------------+--------------+------------+-------------+------------------+----------------+-------------+-----------+--------------------------+------------------------+-------------------+-------------------------+---------------+--------------------+---------------+",
+    "| table_catalog | table_schema | table_name | column_name | ordinal_position | column_default | is_nullable | data_type | character_maximum_length | character_octet_length | numeric_precision | numeric_precision_radix | numeric_scale | datetime_precision | interval_type |",
+    "+---------------+--------------+------------+-------------+------------------+----------------+-------------+-----------+--------------------------+------------------------+-------------------+-------------------------+---------------+--------------------+---------------+",
+    "| public        | iox          | h2o        | city        | 0                |                | YES         | Utf8      |                          | 2147483647             |                   |                         |               |                    |               |",
+    "| public        | iox          | h2o        | moisture    | 1                |                | YES         | Float64   |                          |                        | 24                | 2                       |               |                    |               |",
+    "| public        | iox          | h2o        | other_temp  | 2                |                | YES         | Float64   |                          |                        | 24                | 2                       |               |                    |               |",
+    "| public        | iox          | h2o        | state       | 3                |                | YES         | Utf8      |                          | 2147483647             |                   |                         |               |                    |               |",
+    "| public        | iox          | h2o        | temp        | 4                |                | YES         | Float64   |                          |                        | 24                | 2                       |               |                    |               |",
+    "| public        | iox          | h2o        | time        | 5                |                | NO          | Int64     |                          |                        |                   |                         |               |                    |               |",
+    "| public        | iox          | o2         | city        | 0                |                | YES         | Utf8      |                          | 2147483647             |                   |                         |               |                    |               |",
+    "| public        | iox          | o2         | reading     | 1                |                | YES         | Float64   |                          |                        | 24                | 2                       |               |                    |               |",
+    "| public        | iox          | o2         | state       | 2                |                | YES         | Utf8      |                          | 2147483647             |                   |                         |               |                    |               |",
+    "| public        | iox          | o2         | temp        | 3                |                | YES         | Float64   |                          |                        | 24                | 2                       |               |                    |               |",
+    "| public        | iox          | o2         | time        | 4                |                | NO          | Int64     |                          |                        |                   |                         |               |                    |               |",
+    "+---------------+--------------+------------+-------------+------------------+----------------+-------------+-----------+--------------------------+------------------------+-------------------+-------------------------+---------------+--------------------+---------------+",
+    ];
+    run_sql_test_case!(
+        TwoMeasurementsManyFields {},
+        "SELECT * from information_schema.columns",
         &expected
     );
 }


### PR DESCRIPTION
Update Arrow/DataFusion dependencies to get access to the `SHOW TABLES` and `information_schema.columns` table

Note `SHOW COLUMNS` is coming, but the upstream Arrow PR https://github.com/apache/arrow/pull/9866 is not yet merged


# Examples:
```
./target/debug/influxdb_iox database query 26f7e5a4b7be365b_917b97a92e883afc "SHOW TABLES"
+---------------+--------------------+------------+------------+
| table_catalog | table_schema       | table_name | table_type |
+---------------+--------------------+------------+------------+
| public        | iox                | cpu        | BASE TABLE |
| public        | iox                | disk       | BASE TABLE |
| public        | iox                | diskio     | BASE TABLE |
| public        | iox                | mem        | BASE TABLE |
| public        | iox                | net        | BASE TABLE |
| public        | iox                | processes  | BASE TABLE |
| public        | iox                | swap       | BASE TABLE |
| public        | iox                | system     | BASE TABLE |
| public        | information_schema | tables     | VIEW       |
| public        | information_schema | columns    | VIEW       |
+---------------+--------------------+------------+------------+
```
and access to columns:

```
./target/debug/influxdb_iox database query 26f7e5a4b7be365b_917b97a92e883afc "select table_name, column_name, data_type, is_nullable from information_schema.columns";
+------------+-------------------+-----------+-------------+
| table_name | column_name       | data_type | is_nullable |
+------------+-------------------+-----------+-------------+
| cpu        | cpu               | Utf8      | YES         |
| cpu        | host              | Utf8      | YES         |
| cpu        | time              | Int64     | NO          |
| cpu        | usage_guest       | Float64   | YES         |
| cpu        | usage_guest_nice  | Float64   | YES         |
| cpu        | usage_idle        | Float64   | YES         |
| cpu        | usage_iowait      | Float64   | YES         |
| cpu        | usage_irq         | Float64   | YES         |
| cpu        | usage_nice        | Float64   | YES         |
| cpu        | usage_softirq     | Float64   | YES         |
| cpu        | usage_steal       | Float64   | YES         |
| cpu        | usage_system      | Float64   | YES         |
| cpu        | usage_user        | Float64   | YES         |
| disk       | device            | Utf8      | YES         |
| disk       | free              | Int64     | YES         |
| disk       | fstype            | Utf8      | YES         |
| disk       | host              | Utf8      | YES         |
| disk       | inodes_free       | Int64     | YES         |
| disk       | inodes_total      | Int64     | YES         |
| disk       | inodes_used       | Int64     | YES         |
| disk       | mode              | Utf8      | YES         |
| disk       | path              | Utf8      | YES         |
```




- [x] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb_iox/blob/main/README.md).
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
