### PR TITLE
refactor: expose ReadBuffer public API at Chunk level

### DIFF
--- a/read_buffer/benches/row_group.rs
+++ b/read_buffer/benches/row_group.rs
@@ -1,5 +1,3 @@
-use std::collections::BTreeMap;
-
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
 use rand::distributions::Alphanumeric;
 use rand::prelude::*;
@@ -333,9 +331,7 @@ fn generate_row_group(rows: usize, rng: &mut ThreadRng) -> RowGroup {
                 column_packers[10].i64_packer().some_values().as_slice(),
             )),
         ),
-    ]
-    .into_iter()
-    .collect::<BTreeMap<_, _>>();
+    ];
 
     RowGroup::new(rows as u32, columns)
 }

--- a/read_buffer/src/chunk.rs
+++ b/read_buffer/src/chunk.rs
@@ -160,7 +160,7 @@ impl Chunk {
     ///
     /// TODO(edd): to be deprecated.
     pub(crate) fn upsert_table_with_row_group(
-        &mut self,
+        &self,
         table_name: impl Into<String>,
         row_group: RowGroup,
     ) {
@@ -190,7 +190,7 @@ impl Chunk {
     /// the update. If the `Table` already exists then a new `RowGroup` will be
     /// added to the `Table`. Otherwise a new `Table` with a single `RowGroup`
     /// will be created.
-    pub fn upsert_table(&mut self, table_name: impl Into<String>, table_data: RecordBatch) {
+    pub fn upsert_table(&self, table_name: impl Into<String>, table_data: RecordBatch) {
         // This call is expensive. Complete it before locking.
         let row_group = RowGroup::from(table_data);
         let table_name = table_name.into();
@@ -600,7 +600,7 @@ mod test {
 
     #[test]
     fn add_remove_tables() {
-        let mut chunk = Chunk::new(22);
+        let chunk = Chunk::new(22);
 
         // Add a new table to the chunk.
         chunk.upsert_table("a_table", gen_recordbatch());
@@ -660,7 +660,7 @@ mod test {
 
     #[test]
     fn read_filter_table_schema() {
-        let mut chunk = Chunk::new(22);
+        let chunk = Chunk::new(22);
 
         // Add a new table to the chunk.
         chunk.upsert_table("a_table", gen_recordbatch());
@@ -704,7 +704,7 @@ mod test {
 
     #[test]
     fn has_table() {
-        let mut chunk = Chunk::new(22);
+        let chunk = Chunk::new(22);
 
         // Add a new table to the chunk.
         chunk.upsert_table("a_table", gen_recordbatch());
@@ -714,7 +714,7 @@ mod test {
 
     #[test]
     fn read_filter() {
-        let mut chunk = Chunk::new(22);
+        let chunk = Chunk::new(22);
 
         // Add a bunch of row groups to a single table in a single chunk
         for &i in &[100, 200, 300] {
@@ -804,7 +804,7 @@ mod test {
 
     #[test]
     fn could_pass_predicate() {
-        let mut chunk = Chunk::new(22);
+        let chunk = Chunk::new(22);
 
         // Add a new table to the chunk.
         chunk.upsert_table("a_table", gen_recordbatch());
@@ -830,7 +830,7 @@ mod test {
         ];
         let rg = RowGroup::new(6, columns);
         let table = Table::new("table_1", rg);
-        let mut chunk = Chunk::new_with_table(22, table);
+        let chunk = Chunk::new_with_table(22, table);
 
         // All table names returned when no predicate.
         let table_names = chunk.table_names(&Predicate::default(), &BTreeSet::new());
@@ -929,7 +929,7 @@ mod test {
 
     #[test]
     fn column_names() {
-        let mut chunk = Chunk::new(22);
+        let chunk = Chunk::new(22);
 
         let schema = SchemaBuilder::new()
             .non_null_tag("region")

--- a/read_buffer/src/chunk.rs
+++ b/read_buffer/src/chunk.rs
@@ -59,6 +59,7 @@ pub struct Chunk {
 }
 
 // Tie data and meta-data together so that they can be wrapped in RWLock.
+#[derive(Default)]
 struct TableData {
     rows: u64, // Total number of rows across all tables
 
@@ -71,7 +72,16 @@ struct TableData {
 }
 
 impl Chunk {
-    pub fn new(id: u32, table: Table) -> Self {
+    /// Initialises a new `Chunk`.
+    pub fn new(id: u32) -> Self {
+        Self {
+            id,
+            chunk_data: RwLock::new(TableData::default()),
+        }
+    }
+
+    /// Initialises a new `Chunk` seeded with the provided `Table`.
+    pub(crate) fn new_with_table(id: u32, table: Table) -> Self {
         Self {
             id,
             chunk_data: RwLock::new(TableData {
@@ -348,7 +358,7 @@ mod test {
         .collect();
         let rg = RowGroup::new(6, columns);
         let table = Table::new("table_1", rg);
-        let mut chunk = Chunk::new(22, table);
+        let mut chunk = Chunk::new_with_table(22, table);
 
         assert_eq!(chunk.rows(), 6);
         assert_eq!(chunk.row_groups(), 1);
@@ -418,7 +428,7 @@ mod test {
         .collect::<BTreeMap<_, _>>();
         let rg = RowGroup::new(6, columns);
         let table = Table::new("table_1", rg);
-        let mut chunk = Chunk::new(22, table);
+        let mut chunk = Chunk::new_with_table(22, table);
 
         // All table names returned when no predicate.
         let table_names = chunk.table_names(&Predicate::default(), &BTreeSet::new());

--- a/read_buffer/src/chunk.rs
+++ b/read_buffer/src/chunk.rs
@@ -112,17 +112,17 @@ impl Chunk {
     }
 
     /// The total number of rows in all row groups in all tables in this chunk.
-    pub fn rows(&self) -> u64 {
+    pub(crate) fn rows(&self) -> u64 {
         self.chunk_data.read().unwrap().rows
     }
 
     /// The total number of row groups in all tables in this chunk.
-    pub fn row_groups(&self) -> usize {
+    pub(crate) fn row_groups(&self) -> usize {
         self.chunk_data.read().unwrap().row_groups
     }
 
     /// The total number of tables in this chunk.
-    pub fn tables(&self) -> usize {
+    pub(crate) fn tables(&self) -> usize {
         self.chunk_data.read().unwrap().data.len()
     }
 
@@ -136,7 +136,7 @@ impl Chunk {
     }
 
     /// Returns true if there are no tables under this chunk.
-    pub fn is_empty(&self) -> bool {
+    pub(crate) fn is_empty(&self) -> bool {
         self.chunk_data.read().unwrap().data.len() == 0
     }
 
@@ -168,7 +168,7 @@ impl Chunk {
     /// the specified table have finished.
     ///
     /// Dropping a table that does not exist is effectively an no-op.
-    pub fn drop_table(&mut self, name: &str) {
+    pub(crate) fn drop_table(&mut self, name: &str) {
         let mut chunk_data = self.chunk_data.write().unwrap();
 
         // Remove table and update chunk meta-data if table exists.
@@ -221,7 +221,7 @@ impl Chunk {
     ///
     /// Note: `read_aggregate` currently only supports grouping on "tag"
     /// columns.
-    pub fn read_aggregate(
+    pub(crate) fn read_aggregate(
         &self,
         table_name: &str,
         predicate: Predicate,

--- a/read_buffer/src/chunk.rs
+++ b/read_buffer/src/chunk.rs
@@ -670,6 +670,16 @@ mod test {
     }
 
     #[test]
+    fn has_table() {
+        let mut chunk = Chunk::new(22);
+
+        // Add a new table to the chunk.
+        chunk.upsert_table("a_table", gen_recordbatch());
+        assert!(chunk.has_table("a_table"));
+        assert!(!chunk.has_table("b_table"));
+    }
+
+    #[test]
     fn table_names() {
         let columns = vec![
             (

--- a/read_buffer/src/lib.rs
+++ b/read_buffer/src/lib.rs
@@ -524,7 +524,9 @@ impl Database {
             // the dst buffer is pushed into each chunk's `column_names`
             // implementation ensuring that we short-circuit any tables where
             // we have already determined column names.
-            chunk.column_names(table_name, &predicate, only_columns, dst)
+            chunk
+                .column_names(table_name, predicate.clone(), only_columns, dst)
+                .unwrap()
         });
 
         Ok(Some(names))

--- a/read_buffer/src/lib.rs
+++ b/read_buffer/src/lib.rs
@@ -1,7 +1,7 @@
 #![deny(rust_2018_idioms)]
 #![warn(clippy::clone_on_ref_ptr, clippy::use_self)]
 #![allow(dead_code, clippy::too_many_arguments)]
-pub(crate) mod chunk;
+pub mod chunk;
 pub(crate) mod column;
 pub(crate) mod row_group;
 mod schema;
@@ -308,7 +308,7 @@ impl Database {
                     // but just gets pointers to the necessary data for
                     // execution.
                     let chunk_result = chunk
-                        .read_filter(table_name, predicate.clone(), select_columns.clone())
+                        .read_filter(table_name, predicate.clone(), select_columns)
                         .context(ChunkError)?;
                     chunk_table_results.push(chunk_result);
                 }

--- a/read_buffer/src/lib.rs
+++ b/read_buffer/src/lib.rs
@@ -646,7 +646,7 @@ impl Partition {
         match chunk_data.chunks.entry(chunk_id) {
             Entry::Occupied(mut chunk_entry) => {
                 let chunk = chunk_entry.get_mut();
-                chunk.upsert_table(table_name, row_group);
+                chunk.upsert_table_with_row_group(table_name, row_group);
             }
             Entry::Vacant(chunk_entry) => {
                 chunk_entry.insert(Chunk::new_with_table(

--- a/read_buffer/src/lib.rs
+++ b/read_buffer/src/lib.rs
@@ -276,6 +276,8 @@ impl Database {
     ///
     /// `read_filter` is lazy - it does not execute against the next chunk until
     /// the results for the previous one have been emitted.
+    ///
+    /// Note(edd): to be deprecated
     pub fn read_filter<'a>(
         &self,
         partition_key: &str,
@@ -306,7 +308,7 @@ impl Database {
                     // but just gets pointers to the necessary data for
                     // execution.
                     let chunk_result = chunk
-                        .read_filter(table_name, &predicate, &select_columns)
+                        .read_filter(table_name, predicate.clone(), select_columns.clone())
                         .context(ChunkError)?;
                     chunk_table_results.push(chunk_result);
                 }

--- a/read_buffer/src/lib.rs
+++ b/read_buffer/src/lib.rs
@@ -700,6 +700,8 @@ impl Partition {
     /// returns TableSummaries for all the tables in all row groups in
     /// this partition.  Note that there can be more than one
     /// TableSummary for each table
+    ///
+    /// TODO(edd): to deprecate
     pub fn table_summaries(&self, chunk_ids: &[u32]) -> Vec<TableSummary> {
         let chunk_data = self.data.read().unwrap();
         chunk_ids

--- a/read_buffer/src/lib.rs
+++ b/read_buffer/src/lib.rs
@@ -116,7 +116,7 @@ impl Database {
             Entry::Vacant(e) => {
                 e.insert(Partition::new(
                     partition_key,
-                    Chunk::new(chunk_id, Table::new(table_name.to_owned(), row_group)),
+                    Chunk::new_with_table(chunk_id, Table::new(table_name.to_owned(), row_group)),
                 ));
             }
         };
@@ -649,7 +649,10 @@ impl Partition {
                 chunk.upsert_table(table_name, row_group);
             }
             Entry::Vacant(chunk_entry) => {
-                chunk_entry.insert(Chunk::new(chunk_id, Table::new(table_name, row_group)));
+                chunk_entry.insert(Chunk::new_with_table(
+                    chunk_id,
+                    Table::new(table_name, row_group),
+                ));
             }
         };
     }

--- a/read_buffer/src/table.rs
+++ b/read_buffer/src/table.rs
@@ -707,6 +707,10 @@ impl ReadFilterResults {
         self.row_groups.is_empty()
     }
 
+    pub fn len(&self) -> usize {
+        self.row_groups.len()
+    }
+
     /// Returns the schema associated with table result and therefore all of the
     /// results for all of row groups in the table results.
     pub fn schema(&self) -> &ResultSchema {

--- a/read_buffer/src/table.rs
+++ b/read_buffer/src/table.rs
@@ -573,7 +573,6 @@ impl MetaData {
     /// As `schema_for_column_names` but for all columns in the table. Schema
     /// information is returned in the same order as columns in the table.
     pub fn schema_for_all_columns(&self) -> Vec<(ColumnType, LogicalDataType)> {
-        println!("{:?}", self.column_names);
         let mut column_schema = vec![];
         for column_name in &self.column_names {
             let schema = self.columns.get(column_name).unwrap();

--- a/server/src/db.rs
+++ b/server/src/db.rs
@@ -1204,7 +1204,7 @@ mod tests {
                 to_arc("1970-01-01T00"),
                 0,
                 ChunkStorage::ReadBuffer,
-                1221,
+                1269,
             ),
             ChunkSummary::new_without_timestamps(
                 to_arc("1970-01-01T00"),


### PR DESCRIPTION
This PR refactors the Read Buffer so that a public API is exposed at the `Chunk` level. It does not break any existing behaviour (I kept the existing top-level DB/Partition for now).

The plan is to update the Catalog and Chunk representation in a follow on PR to use this new `Chunk` API and then I will start to cull code from the Read Buffer that's not longer needed.

I have exposed the following API:

- Chunk size: `size()`
- Chunk id: `id() -> u64`
- Table Names `table_names` and also `all_table_names`
- The schema for a `read_filter` execution `read_filter_table_schema` in 42c10e0 
- Whether there is a table in the chunk `has_table` in 6b7a5cf
- `read_filter` in 84ad3ac
- Whether a specified table could possible have rows for a predicate: `could_pass_predicate` in 82a5b78
- `column_names` in 27bbd2f
- `column_values` in 25e762a
- A summary of all the tables in the `Chunk`: 454a1c4

Note: there is now a method to get the output schema of a `read_filter` call before having to execute the `read_filter` operation. I believe this may make some code easier to plumb higher up in the query engine. This will only be useful as long as a chunk is always immutable though (as in it may not really work out once you can start applying deletes to chunks).

Finally, I have started refactoring the `Catalog` / `Chunk` in the Query Engine to see if this is playing nicely and it seems to be going OK but I wanted to get this PR up first.

