### PR TITLE
chore: Group all tracing-related crates under one crate for easier upgrade management

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -771,7 +771,7 @@ dependencies = [
  "snafu",
  "test_helpers",
  "tonic",
- "tracing",
+ "tracing_deps",
 ]
 
 [[package]]
@@ -1149,7 +1149,7 @@ dependencies = [
  "serde_json",
  "tonic",
  "tonic-build",
- "tracing",
+ "tracing_deps",
 ]
 
 [[package]]
@@ -1435,7 +1435,6 @@ dependencies = [
  "data_types",
  "dirs 3.0.1",
  "dotenv",
- "env_logger",
  "flate2",
  "futures",
  "generated_types",
@@ -1453,8 +1452,6 @@ dependencies = [
  "mutable_buffer",
  "object_store",
  "once_cell",
- "opentelemetry",
- "opentelemetry-jaeger",
  "packers",
  "panic_logging",
  "parking_lot",
@@ -1480,10 +1477,7 @@ dependencies = [
  "tokio-util",
  "tonic",
  "tonic-health",
- "tracing",
- "tracing-futures",
- "tracing-opentelemetry",
- "tracing-subscriber",
+ "tracing_deps",
  "wal",
 ]
 
@@ -1514,7 +1508,7 @@ dependencies = [
  "smallvec",
  "snafu",
  "test_helpers",
- "tracing",
+ "tracing_deps",
 ]
 
 [[package]]
@@ -1528,7 +1522,7 @@ dependencies = [
  "snafu",
  "snap",
  "test_helpers",
- "tracing",
+ "tracing_deps",
 ]
 
 [[package]]
@@ -1544,7 +1538,7 @@ dependencies = [
  "parking_lot",
  "snafu",
  "test_helpers",
- "tracing",
+ "tracing_deps",
 ]
 
 [[package]]
@@ -1576,7 +1570,7 @@ dependencies = [
  "influxdb_line_protocol",
  "ouroboros",
  "snafu",
- "tracing",
+ "tracing_deps",
 ]
 
 [[package]]
@@ -1719,8 +1713,7 @@ dependencies = [
  "once_cell",
  "parking_lot",
  "regex",
- "tracing",
- "tracing-subscriber",
+ "tracing_deps",
 ]
 
 [[package]]
@@ -1773,11 +1766,10 @@ dependencies = [
  "criterion",
  "croaring",
  "crossbeam",
- "env_logger",
  "human_format",
  "packers",
  "snafu",
- "tracing",
+ "tracing_deps",
 ]
 
 [[package]]
@@ -1873,7 +1865,7 @@ dependencies = [
  "string-interner",
  "test_helpers",
  "tokio",
- "tracing",
+ "tracing_deps",
 ]
 
 [[package]]
@@ -2216,14 +2208,14 @@ dependencies = [
  "rand 0.8.3",
  "snafu",
  "test_helpers",
- "tracing",
+ "tracing_deps",
 ]
 
 [[package]]
 name = "panic_logging"
 version = "0.1.0"
 dependencies = [
- "tracing",
+ "tracing_deps",
 ]
 
 [[package]]
@@ -2585,7 +2577,7 @@ dependencies = [
  "test_helpers",
  "tokio",
  "tokio-stream",
- "tracing",
+ "tracing_deps",
 ]
 
 [[package]]
@@ -3213,7 +3205,7 @@ dependencies = [
  "test_helpers",
  "tokio",
  "tokio-util",
- "tracing",
+ "tracing_deps",
  "uuid",
 ]
 
@@ -3521,8 +3513,7 @@ dependencies = [
  "dotenv",
  "parking_lot",
  "tempfile",
- "tracing",
- "tracing-subscriber",
+ "tracing_deps",
 ]
 
 [[package]]
@@ -3924,6 +3915,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing_deps"
+version = "0.1.0"
+dependencies = [
+ "env_logger",
+ "opentelemetry",
+ "opentelemetry-jaeger",
+ "tracing",
+ "tracing-futures",
+ "tracing-opentelemetry",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "treeline"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4049,7 +4053,7 @@ dependencies = [
  "snap",
  "test_helpers",
  "tokio",
- "tracing",
+ "tracing_deps",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ members = [
     "read_buffer",
     "server",
     "test_helpers",
+    "tracing_deps",
     "wal",
 ]
 
@@ -56,6 +57,7 @@ panic_logging = { path = "panic_logging" }
 query = { path = "query" }
 read_buffer = { path = "read_buffer" }
 server = { path = "server" }
+tracing_deps = { path = "tracing_deps" }
 wal = { path = "wal" }
 
 # Crates.io dependencies, in alphabetical order
@@ -66,13 +68,10 @@ clap = "2.33.1"
 csv = "1.1"
 dirs = "3.0.1"
 dotenv = "0.15.0"
-env_logger = "0.8.3"
 flate2 = "1.0"
 futures = "0.3.1"
 http = "0.2.0"
 hyper = "0.14"
-opentelemetry = { version = "0.12", default-features = false, features = ["trace", "tokio-support"] }
-opentelemetry-jaeger = { version = "0.11", features = ["tokio"] }
 # used by arrow/datafusion anyway
 prettytable-rs = "0.8"
 prost = "0.7"
@@ -89,10 +88,6 @@ tokio-stream = { version = "0.1.2", features = ["net"] }
 tokio-util = { version = "0.6.3" }
 tonic = "0.4.0"
 tonic-health = "0.3.0"
-tracing = { version = "0.1", features = ["release_max_level_debug"] }
-tracing-futures = "0.2.4"
-tracing-opentelemetry = "0.11.0"
-tracing-subscriber = { version = "0.2.15", features = ["parking_lot"] }
 
 [dev-dependencies]
 # Workspace dependencies, in alphabetical order

--- a/data_types/Cargo.toml
+++ b/data_types/Cargo.toml
@@ -17,7 +17,7 @@ serde = { version = "1.0", features = ["rc"] }
 serde_regex = "1.1"
 snafu = "0.6"
 tonic = { version = "0.4.0" }
-tracing = "0.1"
+tracing_deps = { path = "../tracing_deps" }
 
 [dev-dependencies] # In alphabetical order
 test_helpers = { path = "../test_helpers" }

--- a/data_types/src/error.rs
+++ b/data_types/src/error.rs
@@ -1,7 +1,7 @@
 //! Common error utilities
 use std::fmt::Debug;
 
-use tracing::error;
+use tracing_deps::tracing::error;
 
 /// Add ability for Results to log error messages via `error!` logs.
 /// This is useful when using async tasks that may not have a natural

--- a/generated_types/Cargo.toml
+++ b/generated_types/Cargo.toml
@@ -13,7 +13,7 @@ futures = "0.3.1"
 prost = "0.7"
 prost-types = "0.7"
 tonic = "0.4"
-tracing = "0.1"
+tracing_deps = { path = "../tracing_deps" }
 google_types = { path = "../google_types" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.44"

--- a/generated_types/src/google.rs
+++ b/generated_types/src/google.rs
@@ -19,7 +19,7 @@ use prost::{
 use std::convert::{TryFrom, TryInto};
 use std::iter::FromIterator;
 use tonic::Status;
-use tracing::error;
+use tracing_deps::tracing::error;
 
 // A newtype struct to provide conversion into tonic::Status
 struct EncodeError(prost::EncodeError);

--- a/influxdb_line_protocol/Cargo.toml
+++ b/influxdb_line_protocol/Cargo.toml
@@ -9,7 +9,7 @@ influxdb2_client = { path = "../influxdb2_client" }
 nom = "5.1.1"
 smallvec = "1.2.0"
 snafu = "0.6.2"
-tracing = "0.1"
+tracing_deps = { path = "../tracing_deps" }
 
 [dev-dependencies] # In alphabetical order
 test_helpers = { path = "../test_helpers" }

--- a/influxdb_line_protocol/src/lib.rs
+++ b/influxdb_line_protocol/src/lib.rs
@@ -35,7 +35,7 @@ use std::{
     fmt,
     ops::Deref,
 };
-use tracing::debug;
+use tracing_deps::tracing::debug;
 
 #[derive(Debug, Snafu)]
 pub enum Error {

--- a/influxdb_tsm/Cargo.toml
+++ b/influxdb_tsm/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 integer-encoding = "1.0.7"
 snafu = "0.6.2"
 snap = "1.0.0"
-tracing = "0.1"
+tracing_deps = { path = "../tracing_deps" }
 
 [dev-dependencies] # In alphabetical order
 flate2 = "1.0"

--- a/influxdb_tsm/src/mapper.rs
+++ b/influxdb_tsm/src/mapper.rs
@@ -3,7 +3,7 @@
 use crate::reader::{BlockData, BlockDecoder, TSMIndexReader, ValuePair};
 use crate::{Block, BlockType, TSMError};
 
-use tracing::warn;
+use tracing_deps::tracing::warn;
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt::{Display, Formatter};

--- a/ingest/Cargo.toml
+++ b/ingest/Cargo.toml
@@ -11,7 +11,7 @@ influxdb_tsm = { path = "../influxdb_tsm" }
 internal_types = { path = "../internal_types" }
 packers = { path = "../packers" }
 snafu = "0.6.2"
-tracing = "0.1"
+tracing_deps = { path = "../tracing_deps" }
 
 [dev-dependencies] # In alphabetical order
 flate2 = "1.0"

--- a/ingest/src/lib.rs
+++ b/ingest/src/lib.rs
@@ -28,7 +28,7 @@ use std::{
     collections::{BTreeMap, BTreeSet},
     io::{Read, Seek},
 };
-use tracing::debug;
+use tracing_deps::tracing::debug;
 
 pub mod parquet;
 

--- a/ingest/src/parquet/stats.rs
+++ b/ingest/src/parquet/stats.rs
@@ -9,7 +9,7 @@ use packers::{
 };
 use snafu::ResultExt;
 use std::{collections::BTreeMap, convert::TryInto};
-use tracing::debug;
+use tracing_deps::tracing::debug;
 
 use super::{
     error::{ParquetLibraryError, Result},

--- a/ingest/src/parquet/writer.rs
+++ b/ingest/src/parquet/writer.rs
@@ -21,7 +21,7 @@ use std::{
     str::FromStr,
     sync::Arc,
 };
-use tracing::{debug, log::warn};
+use tracing_deps::tracing::{debug, log::warn};
 
 use super::metadata::parquet_schema_as_string;
 use packers::{Error as TableError, IOxTableWriter, Packers};

--- a/internal_types/Cargo.toml
+++ b/internal_types/Cargo.toml
@@ -18,7 +18,7 @@ generated_types = { path = "../generated_types" }
 influxdb_line_protocol = { path = "../influxdb_line_protocol" }
 ouroboros = "0.8.3"
 snafu = "0.6"
-tracing = "0.1"
+tracing_deps = { path = "../tracing_deps" }
 
 [dev-dependencies] # In alphabetical order
 criterion = "0.3"

--- a/internal_types/src/schema/builder.rs
+++ b/internal_types/src/schema/builder.rs
@@ -3,7 +3,7 @@ use std::{
     collections::{HashMap, HashSet},
     convert::TryInto,
 };
-use tracing::warn;
+use tracing_deps::tracing::warn;
 
 use arrow_deps::arrow::datatypes::{DataType as ArrowDataType, Field as ArrowField};
 

--- a/logfmt/Cargo.toml
+++ b/logfmt/Cargo.toml
@@ -6,8 +6,7 @@ description="tracing_subscriber layer for writing out logfmt formatted events"
 edition = "2018"
 
 [dependencies] # In alphabetical order
-tracing = { version = "0.1" }
-tracing-subscriber = "0.2.15"
+tracing_deps = { path = "../tracing_deps" }
 
 [dev-dependencies] # In alphabetical order
 once_cell = { version = "1.4.0", features = ["parking_lot"] }

--- a/logfmt/src/lib.rs
+++ b/logfmt/src/lib.rs
@@ -1,11 +1,14 @@
 use std::borrow::Cow;
 use std::{io::Write, time::SystemTime};
-use tracing::{
+use tracing_deps::tracing::{
+    self,
     field::{Field, Visit},
     subscriber::Interest,
     Id, Level, Subscriber,
 };
-use tracing_subscriber::{self, fmt::MakeWriter, layer::Context, registry::LookupSpan, Layer};
+use tracing_deps::tracing_subscriber::{
+    fmt::MakeWriter, layer::Context, registry::LookupSpan, Layer,
+};
 
 /// Implements a `tracing_subscriber::Layer` which generates
 /// [logfmt] formatted log entries, suitable for log ingestion
@@ -30,7 +33,7 @@ impl<W: MakeWriter> LogFmtLayer<W> {
     /// For example:
     /// ```
     ///  use logfmt::LogFmtLayer;
-    ///  use tracing_subscriber::{EnvFilter, prelude::*};
+    ///  use tracing_deps::tracing_subscriber::{EnvFilter, prelude::*, self};
     ///
     ///  // setup debug logging level
     ///  std::env::set_var("RUST_LOG", "debug");

--- a/logfmt/tests/logging.rs
+++ b/logfmt/tests/logging.rs
@@ -11,8 +11,8 @@ use std::{
     fmt,
     io::{self, Cursor},
 };
-use tracing::{debug, error, info, span, trace, warn, Level};
-use tracing_subscriber::{fmt::MakeWriter, prelude::*};
+use tracing_deps::tracing::{debug, error, info, span, trace, warn, Level};
+use tracing_deps::tracing_subscriber::{self, fmt::MakeWriter, prelude::*};
 
 /// Compares the captured messages with the expected messages,
 /// normalizing for time and location

--- a/mem_qe/Cargo.toml
+++ b/mem_qe/Cargo.toml
@@ -9,11 +9,10 @@ arrow_deps = { path = "../arrow_deps" }
 chrono = "0.4"
 croaring = "0.4.5"
 crossbeam = "0.8"
-env_logger = "0.8.3"
 human_format = "1.0.3"
 packers = { path = "../packers" }
 snafu = "0.6.8"
-tracing = "0.1"
+tracing_deps = { path = "../tracing_deps" }
 
 [dev-dependencies] # In alphabetical order
 criterion = "0.3"

--- a/mem_qe/src/bin/main.rs
+++ b/mem_qe/src/bin/main.rs
@@ -9,7 +9,7 @@ use std::{
 
 use datatypes::TimeUnit;
 use snafu::Snafu;
-use tracing::debug;
+use tracing_deps::tracing::debug;
 
 use arrow_deps::arrow::record_batch::{RecordBatch, RecordBatchReader};
 use arrow_deps::arrow::{array, array::Array, datatypes, ipc};
@@ -27,7 +27,7 @@ fn format_size(sz: usize) -> String {
 }
 
 fn main() {
-    env_logger::init();
+    tracing_deps::env_logger::init();
     let args: Vec<String> = env::args().collect();
 
     let path = &args[1];

--- a/mem_qe/src/column.rs
+++ b/mem_qe/src/column.rs
@@ -5,7 +5,7 @@ use arrow_deps::arrow;
 
 use super::encoding;
 
-use tracing::debug;
+use tracing_deps::tracing::debug;
 
 #[derive(Debug)]
 pub enum Set<'a> {

--- a/mem_qe/src/segment.rs
+++ b/mem_qe/src/segment.rs
@@ -1,6 +1,6 @@
 use std::collections::{BTreeMap, BTreeSet};
 
-use tracing::{debug, error, info};
+use tracing_deps::tracing::{debug, error, info};
 
 use super::column;
 use super::column::{AggregateType, Column};

--- a/mem_qe/src/sorter.rs
+++ b/mem_qe/src/sorter.rs
@@ -19,7 +19,7 @@ use std::ops::Range;
 
 use snafu::ensure;
 use snafu::Snafu;
-use tracing::debug;
+use tracing_deps::tracing::debug;
 
 use super::column;
 

--- a/mutable_buffer/Cargo.toml
+++ b/mutable_buffer/Cargo.toml
@@ -26,7 +26,7 @@ influxdb_line_protocol = { path = "../influxdb_line_protocol" }
 snafu = "0.6.2"
 string-interner = "0.12.2"
 tokio = { version = "1.0", features = ["macros"] }
-tracing = "0.1"
+tracing_deps = { path = "../tracing_deps" }
 
 [dev-dependencies] # In alphabetical order
 test_helpers = { path = "../test_helpers" }

--- a/packers/Cargo.toml
+++ b/packers/Cargo.toml
@@ -10,7 +10,7 @@ human_format = "1.0.3"
 influxdb_tsm = { path = "../influxdb_tsm" }
 internal_types = { path = "../internal_types" }
 snafu = "0.6.2"
-tracing = "0.1"
+tracing_deps = { path = "../tracing_deps" }
 
 [dev-dependencies] # In alphabetical order
 rand = "0.8.3"

--- a/panic_logging/Cargo.toml
+++ b/panic_logging/Cargo.toml
@@ -5,4 +5,4 @@ authors = ["Paul Dix <paul@pauldix.net>"]
 edition = "2018"
 
 [dependencies] # In alphabetical order
-tracing = { version = "0.1", features = ["release_max_level_debug"] }
+tracing_deps = { path = "../tracing_deps" }

--- a/panic_logging/src/lib.rs
+++ b/panic_logging/src/lib.rs
@@ -12,7 +12,7 @@
 use std::{fmt, panic, sync::Arc};
 
 use panic::PanicInfo;
-use tracing::{error, warn};
+use tracing_deps::tracing::{error, warn};
 
 type PanicFunctionPtr = Arc<Box<dyn Fn(&PanicInfo<'_>) + Sync + Send + 'static>>;
 

--- a/query/Cargo.toml
+++ b/query/Cargo.toml
@@ -27,7 +27,7 @@ snafu = "0.6.2"
 sqlparser = "0.8.0"
 tokio = { version = "1.0", features = ["macros"] }
 tokio-stream = "0.1.2"
-tracing = "0.1"
+tracing_deps = { path = "../tracing_deps" }
 
 [dev-dependencies] # In alphabetical order
 test_helpers = { path = "../test_helpers" }

--- a/query/src/exec/context.rs
+++ b/query/src/exec/context.rs
@@ -20,7 +20,7 @@ use arrow_deps::{
 
 use crate::exec::schema_pivot::{SchemaPivotExec, SchemaPivotNode};
 
-use tracing::debug;
+use tracing_deps::tracing::debug;
 
 // Reuse DataFusion error and Result types for this module
 pub use arrow_deps::datafusion::error::{DataFusionError as Error, Result};

--- a/query/src/frontend/influxrpc.rs
+++ b/query/src/frontend/influxrpc.rs
@@ -19,7 +19,7 @@ use internal_types::{
     selection::Selection,
 };
 use snafu::{ensure, OptionExt, ResultExt, Snafu};
-use tracing::debug;
+use tracing_deps::tracing::debug;
 
 use crate::{
     exec::{field::FieldColumns, make_schema_pivot, stringset::StringSet},

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -32,7 +32,7 @@ snafu = "0.6"
 snap = "1.0.0"
 tokio = { version = "1.0", features = ["macros", "time"] }
 tokio-util = { version = "0.6.3" }
-tracing = "0.1"
+tracing_deps = { path = "../tracing_deps" }
 uuid = { version = "0.8", features = ["serde", "v4"] }
 
 [dev-dependencies] # In alphabetical order

--- a/server/src/buffer.rs
+++ b/server/src/buffer.rs
@@ -23,7 +23,7 @@ use data_types::database_rules::WalBufferConfig;
 use data_types::wal::{SegmentPersistence, SegmentSummary, WriterSummary};
 use parking_lot::Mutex;
 use snafu::{ensure, OptionExt, ResultExt, Snafu};
-use tracing::{error, info, warn};
+use tracing_deps::tracing::{error, info, warn};
 
 #[derive(Debug, Snafu)]
 pub enum Error {

--- a/server/src/config.rs
+++ b/server/src/config.rs
@@ -14,7 +14,7 @@ use read_buffer::Database as ReadBufferDb;
 use crate::{db::Db, Error, JobRegistry, Result};
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
-use tracing::{error, info, warn, Instrument};
+use tracing_deps::tracing::{self, error, info, warn, Instrument};
 
 pub(crate) const DB_RULES_FILE_NAME: &str = "rules.pb";
 

--- a/server/src/db.rs
+++ b/server/src/db.rs
@@ -10,7 +10,7 @@ use std::sync::{
 use async_trait::async_trait;
 use parking_lot::{Mutex, RwLock};
 use snafu::{OptionExt, ResultExt, Snafu};
-use tracing::{debug, info};
+use tracing_deps::tracing::{debug, info};
 
 use arrow_deps::{
     datafusion::catalog::{catalog::CatalogProvider, schema::SchemaProvider},

--- a/server/src/db/chunk.rs
+++ b/server/src/db/chunk.rs
@@ -6,7 +6,7 @@ use parquet_file::chunk::Chunk as ParquetChunk;
 use query::{exec::stringset::StringSet, predicate::Predicate, PartitionChunk};
 use read_buffer::Database as ReadBufferDb;
 use snafu::{ResultExt, Snafu};
-use tracing::debug;
+use tracing_deps::tracing::debug;
 
 use std::sync::Arc;
 

--- a/server/src/db/lifecycle.rs
+++ b/server/src/db/lifecycle.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 use chrono::{DateTime, Utc};
 use parking_lot::{RwLock, RwLockUpgradableReadGuard};
-use tracing::{error, info};
+use tracing_deps::tracing::{error, info};
 
 use data_types::{database_rules::LifecycleRules, error::ErrorLogger, job::Job};
 

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -77,7 +77,7 @@ use bytes::BytesMut;
 use futures::stream::TryStreamExt;
 use parking_lot::Mutex;
 use snafu::{OptionExt, ResultExt, Snafu};
-use tracing::{error, info, warn};
+use tracing_deps::tracing::{error, info, warn};
 
 use data_types::{
     database_rules::{DatabaseRules, WriterId},

--- a/server/src/snapshot.rs
+++ b/server/src/snapshot.rs
@@ -18,7 +18,7 @@ use futures::StreamExt;
 use parking_lot::Mutex;
 use snafu::{ResultExt, Snafu};
 use tokio::sync::oneshot;
-use tracing::{error, info};
+use tracing_deps::tracing::{error, info};
 use uuid::Uuid;
 
 #[derive(Debug, Snafu)]

--- a/server/src/tracker.rs
+++ b/server/src/tracker.rs
@@ -85,7 +85,7 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use tokio_util::sync::CancellationToken;
-use tracing::warn;
+use tracing_deps::tracing::warn;
 
 pub use future::{TrackedFuture, TrackedFutureExt};
 pub use history::TrackerRegistryWithHistory;

--- a/server/src/tracker/history.rs
+++ b/server/src/tracker/history.rs
@@ -2,7 +2,7 @@ use super::{Tracker, TrackerId, TrackerRegistration, TrackerRegistry};
 use hashbrown::hash_map::Entry;
 use hashbrown::HashMap;
 use std::hash::Hash;
-use tracing::info;
+use tracing_deps::tracing::info;
 
 /// A wrapper around a TrackerRegistry that automatically retains a history
 #[derive(Debug)]

--- a/server/src/tracker/registry.rs
+++ b/server/src/tracker/registry.rs
@@ -2,7 +2,7 @@ use super::{Tracker, TrackerRegistration};
 use hashbrown::HashMap;
 use std::str::FromStr;
 use std::sync::Arc;
-use tracing::debug;
+use tracing_deps::tracing::debug;
 
 /// Every future registered with a `TrackerRegistry` is assigned a unique
 /// `TrackerId`

--- a/src/commands/convert.rs
+++ b/src/commands/convert.rs
@@ -13,7 +13,7 @@ use std::{
     io::{BufReader, Read},
     path::{Path, PathBuf},
 };
-use tracing::{debug, info, warn};
+use tracing_deps::tracing::{debug, info, warn};
 
 use crate::commands::input::{FileType, InputReader};
 

--- a/src/commands/logging.rs
+++ b/src/commands/logging.rs
@@ -1,6 +1,9 @@
 //! Logging initization and setup
 
-use tracing_subscriber::{prelude::*, EnvFilter};
+use tracing_deps::{
+    env_logger, opentelemetry_jaeger, tracing_opentelemetry,
+    tracing_subscriber::{self, prelude::*, EnvFilter},
+};
 
 use super::run::{Config, LogFormat};
 

--- a/src/commands/meta.rs
+++ b/src/commands/meta.rs
@@ -5,7 +5,7 @@ use std::{
     collections::{BTreeMap, BTreeSet},
     convert::TryInto,
 };
-use tracing::{debug, info};
+use tracing_deps::tracing::{debug, info};
 
 use crate::commands::input::{FileType, InputReader};
 

--- a/src/commands/stats.rs
+++ b/src/commands/stats.rs
@@ -2,7 +2,7 @@
 
 use snafu::{ResultExt, Snafu};
 use structopt::StructOpt;
-use tracing::info;
+use tracing_deps::tracing::info;
 
 use ingest::parquet::{error::IOxParquetError, stats as parquet_stats};
 use packers::{

--- a/src/influxdb_ioxd.rs
+++ b/src/influxdb_ioxd.rs
@@ -11,7 +11,7 @@ use panic_logging::SendPanicsToTracing;
 use server::{ConnectionManagerImpl as ConnectionManager, Server as AppServer};
 use snafu::{ResultExt, Snafu};
 use std::{convert::TryFrom, fs, net::SocketAddr, path::PathBuf, sync::Arc};
-use tracing::{error, info, warn, Instrument};
+use tracing_deps::tracing::{self, error, info, warn, Instrument};
 
 mod http;
 mod rpc;

--- a/src/influxdb_ioxd/http.rs
+++ b/src/influxdb_ioxd/http.rs
@@ -31,7 +31,7 @@ use hyper::{Body, Method, Request, Response, StatusCode};
 use routerify::{prelude::*, Middleware, RequestInfo, Router, RouterError, RouterService};
 use serde::Deserialize;
 use snafu::{OptionExt, ResultExt, Snafu};
-use tracing::{debug, error, info};
+use tracing_deps::tracing::{self, debug, error, info};
 
 use data_types::http::WalMetadataResponse;
 use hyper::server::conn::AddrIncoming;
@@ -411,7 +411,7 @@ async fn parse_body(req: hyper::Request<Body>) -> Result<Bytes, ApplicationError
     }
 }
 
-#[tracing::instrument(level = "debug")]
+#[tracing_deps::instrument(level = "debug")]
 async fn write<M>(req: Request<Body>) -> Result<Response<Body>, ApplicationError>
 where
     M: ConnectionManager + Send + Sync + Debug + 'static,

--- a/src/influxdb_ioxd/rpc/error.rs
+++ b/src/influxdb_ioxd/rpc/error.rs
@@ -1,5 +1,5 @@
 use generated_types::google::{FieldViolation, InternalError, NotFound, PreconditionViolation};
-use tracing::error;
+use tracing_deps::tracing::error;
 
 /// map common `server::Error` errors  to the appropriate tonic Status
 pub fn default_server_error_handler(error: server::Error) -> tonic::Status {

--- a/src/influxdb_ioxd/rpc/flight.rs
+++ b/src/influxdb_ioxd/rpc/flight.rs
@@ -4,7 +4,7 @@ use futures::Stream;
 use serde::Deserialize;
 use snafu::{OptionExt, ResultExt, Snafu};
 use tonic::{Request, Response, Streaming};
-use tracing::error;
+use tracing_deps::tracing::error;
 
 use arrow_deps::{
     arrow,

--- a/src/influxdb_ioxd/rpc/operations.rs
+++ b/src/influxdb_ioxd/rpc/operations.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use bytes::BytesMut;
 use prost::Message;
 use tonic::Response;
-use tracing::debug;
+use tracing_deps::tracing::debug;
 
 use data_types::job::Job;
 use generated_types::google::FieldViolationExt;

--- a/src/influxdb_ioxd/rpc/storage/expr.rs
+++ b/src/influxdb_ioxd/rpc/storage/expr.rs
@@ -22,7 +22,7 @@ use super::{TAG_KEY_FIELD, TAG_KEY_MEASUREMENT};
 use query::group_by::{Aggregate as QueryAggregate, WindowDuration};
 use query::predicate::PredicateBuilder;
 use snafu::{ResultExt, Snafu};
-use tracing::warn;
+use tracing_deps::tracing::warn;
 
 #[derive(Debug, Snafu)]
 pub enum Error {

--- a/src/influxdb_ioxd/rpc/storage/service.rs
+++ b/src/influxdb_ioxd/rpc/storage/service.rs
@@ -32,7 +32,7 @@ use std::{collections::HashMap, sync::Arc};
 use tokio::sync::mpsc;
 use tokio_stream::wrappers::ReceiverStream;
 use tonic::Status;
-use tracing::{error, info};
+use tracing_deps::tracing::{error, info};
 
 #[derive(Debug, Snafu)]
 pub enum Error {

--- a/src/influxdb_ioxd/rpc/testing.rs
+++ b/src/influxdb_ioxd/rpc/testing.rs
@@ -1,6 +1,6 @@
 use generated_types::i_ox_testing_server::{IOxTesting, IOxTestingServer};
 use generated_types::{TestErrorRequest, TestErrorResponse};
-use tracing::warn;
+use tracing_deps::tracing::warn;
 
 /// Concrete implementation of the gRPC IOx testing service API
 struct IOxTestingService {}

--- a/src/influxdb_ioxd/rpc/write.rs
+++ b/src/influxdb_ioxd/rpc/write.rs
@@ -5,7 +5,7 @@ use influxdb_line_protocol::parse_lines;
 use server::{ConnectionManager, Server};
 use std::fmt::Debug;
 use tonic::Response;
-use tracing::debug;
+use tracing_deps::tracing::debug;
 
 use super::error::default_server_error_handler;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,7 @@ use std::str::FromStr;
 use dotenv::dotenv;
 use structopt::StructOpt;
 use tokio::runtime::Runtime;
-use tracing::{debug, warn};
+use tracing_deps::tracing::{debug, warn};
 
 use commands::logging::LoggingLevel;
 use ingest::parquet::writer::CompressionLevel;

--- a/test_helpers/Cargo.toml
+++ b/test_helpers/Cargo.toml
@@ -8,5 +8,4 @@ edition = "2018"
 dotenv = "0.15.0"
 parking_lot = "0.11.1"
 tempfile = "3.1.0"
-tracing = "0.1"
-tracing-subscriber = "0.2.15"
+tracing_deps = { path = "../tracing_deps" }

--- a/test_helpers/src/lib.rs
+++ b/test_helpers/src/lib.rs
@@ -99,7 +99,7 @@ pub fn start_logging() {
         // Configure the logger to write to stderr and install it
         let output_stream = std::io::stderr;
 
-        use tracing_subscriber::{prelude::*, EnvFilter};
+        use tracing_deps::tracing_subscriber::{self, prelude::*, EnvFilter};
 
         tracing_subscriber::registry()
             .with(EnvFilter::from_default_env())

--- a/test_helpers/src/tracing.rs
+++ b/test_helpers/src/tracing.rs
@@ -2,7 +2,8 @@
 use std::{fmt, sync::Arc};
 
 use parking_lot::Mutex;
-use tracing::{
+use tracing_deps::tracing::{
+    self,
     field::Field,
     span::{Attributes, Id, Record},
     subscriber::{DefaultGuard, Subscriber},

--- a/tracing_deps/Cargo.toml
+++ b/tracing_deps/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "tracing_deps"
+version = "0.1.0"
+authors = ["Paul Dix <paul@pauldix.net>"]
+edition = "2018"
+description = "Tracing ecosystem dependencies for InfluxDB IOx, to ensure consistent versions and unified updates"
+
+[dependencies] # In alphabetical order
+env_logger = "0.8.3"
+opentelemetry = { version = "0.12", default-features = false, features = ["trace", "tokio-support"] }
+opentelemetry-jaeger = { version = "0.11", features = ["tokio"] }
+tracing = { version = "0.1", features = ["release_max_level_debug"] }
+tracing-futures = "0.2.4"
+tracing-opentelemetry = "0.11.0"
+tracing-subscriber = { version = "0.2.15", features = ["parking_lot"] }

--- a/tracing_deps/src/lib.rs
+++ b/tracing_deps/src/lib.rs
@@ -1,0 +1,12 @@
+//! This crate exists to coordinate versions of `tracing` and related
+//! crates so that we can manage their updates in a single crate.
+
+// Export these crates publicly so we can have a single reference
+pub use env_logger;
+pub use opentelemetry;
+pub use opentelemetry_jaeger;
+pub use tracing;
+pub use tracing::instrument;
+pub use tracing_futures;
+pub use tracing_opentelemetry;
+pub use tracing_subscriber;

--- a/wal/Cargo.toml
+++ b/wal/Cargo.toml
@@ -16,7 +16,7 @@ serde_json = "1.0.44"
 snafu = "0.6.6"
 snap = "1.0.0"
 tokio = { version = "1.0", features=["macros", "fs"] }
-tracing = "0.1"
+tracing_deps = { path = "../tracing_deps" }
 
 [dev-dependencies] # In alphabetical order
 test_helpers = { path = "../test_helpers" }

--- a/wal/src/writer.rs
+++ b/wal/src/writer.rs
@@ -10,7 +10,7 @@ use futures::{channel::mpsc, SinkExt, StreamExt};
 use snafu::{ResultExt, Snafu};
 
 use serde::{Deserialize, Serialize};
-use tracing::{error, info};
+use tracing_deps::tracing::{error, info};
 
 use std::path::PathBuf;
 


### PR DESCRIPTION
This should help with #1096, @jacobmarble -- at least when you upgrade the versions of tracing and opentelemetry related crates, you'll only have to mess with the versions in one Cargo.toml instead of tracking down versions all over. Hopefully. 🤞🏻 