### PR TITLE
feat: add line protocol ingest metrics

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,6 +74,7 @@ flate2 = "1.0"
 futures = "0.3.1"
 http = "0.2.0"
 hyper = "0.14"
+once_cell = { version = "1.4.0", features = ["parking_lot"] }
 parking_lot = "0.11.1"
 # used by arrow/datafusion anyway
 prettytable-rs = "0.8"
@@ -97,7 +98,6 @@ tonic-health = "0.3.0"
 influxdb2_client = { path = "influxdb2_client" }
 influxdb_iox_client = { path = "influxdb_iox_client", features = ["flight"] }
 test_helpers = { path = "test_helpers" }
-once_cell = { version = "1.4.0", features = ["parking_lot"] }
 parking_lot = "0.11.1"
 
 # Crates.io dependencies, in alphabetical order

--- a/src/commands/metrics.rs
+++ b/src/commands/metrics.rs
@@ -1,10 +1,68 @@
 use super::run::Config;
 use observability_deps::{
-    opentelemetry, opentelemetry_prometheus,
+    opentelemetry::{self, metrics::Counter},
+    opentelemetry_prometheus,
     prometheus::{Encoder, TextEncoder},
     tracing::log::warn,
 };
+use once_cell::sync::Lazy;
 use parking_lot::{const_rwlock, RwLock};
+
+///! IOx metrics interface
+
+/// Contains the counters for system wide metrics.
+///
+/// These are gouped into a single crate-wide reference to keep all
+/// metrics definitions close together, so it is be clear what the
+/// realm of possibilities for IOx metrics is.
+///
+/// We think this structure will also make it easier to document and
+/// refactor metrics easier.
+pub struct SystemMetrics {
+    /// How many line protocol lines were parsed but rejected
+    pub lp_lines_errors: Counter<u64>,
+    /// How many line protocol lines were parsed and successfully loaded
+    pub lp_lines_success: Counter<u64>,
+    /// How many bytes of protocol line were parsed and successfully loaded
+    pub lp_bytes_success: Counter<u64>,
+}
+
+/// crate wide metrics
+///
+/// To use:
+///
+/// ```
+/// use metrics::IOXD_METRICS;
+///
+/// // Record that 64 lines of line protocol were processed
+/// let metric_kv = [
+///   KeyValue::new("db_name", "my awesome db name"),
+/// ];
+///
+/// IOXD_METRICS.lp_lines_success.add(lines.len() as u64, &metric_kv);
+/// ```
+pub static IOXD_METRICS: Lazy<SystemMetrics> = Lazy::new(SystemMetrics::new);
+
+impl SystemMetrics {
+    fn new() -> Self {
+        Self {
+            lp_lines_errors: meter()
+                .u64_counter("ingest.lp.lines.errors")
+                .with_description("line protocol formatted lines which were rejected")
+                .init(),
+
+            lp_lines_success: meter()
+                .u64_counter("ingest.lp.lines.success")
+                .with_description("line protocol formatted lines which were successfully loaded")
+                .init(),
+
+            lp_bytes_success: meter()
+                .u64_counter("ingest.lp.bytes.success")
+                .with_description("line protocol formatted bytes which were successfully loaded")
+                .init(),
+        }
+    }
+}
 
 // TODO(jacobmarble): better way to write-once-read-many without a lock
 // TODO(jacobmarble): generic OTel exporter, rather than just prometheus
@@ -34,7 +92,8 @@ pub fn init_metrics_internal(exporter: opentelemetry_prometheus::PrometheusExpor
     *guard = Some(exporter);
 }
 
-/// Returns the global IOx [`Meter`] for reporting metrics
+/// Returns a global [`Meter`] for reporting metrics. See
+/// [`IOXD_METRICS`] for specific crate wide counters.
 ///
 /// # Example
 ///
@@ -53,7 +112,7 @@ pub fn init_metrics_internal(exporter: opentelemetry_prometheus::PrometheusExpor
 /// counter.add(100, &[KeyValue::new("key", "value")]);
 /// recorder.record(100, &[KeyValue::new("key", "value")]);
 /// ```
-pub fn meter() -> opentelemetry::metrics::Meter {
+fn meter() -> opentelemetry::metrics::Meter {
     opentelemetry::global::meter("iox")
 }
 

--- a/src/influxdb_ioxd/http.rs
+++ b/src/influxdb_ioxd/http.rs
@@ -842,6 +842,17 @@ mod tests {
             .await
             .expect("sent data");
 
+        // Generate an error
+        client
+            .post(&format!(
+                "{}/api/v2/write?bucket=NotMyBucket&org=NotMyOrg",
+                server_url,
+            ))
+            .body(lp_data)
+            .send()
+            .await
+            .unwrap();
+
         let metrics_string = String::from_utf8(metrics::metrics_as_text()).unwrap();
         assert_contains!(
             &metrics_string,
@@ -849,7 +860,7 @@ mod tests {
         );
         assert_contains!(
             &metrics_string,
-            r#"ingest_lp_lines_errors{bucket="NotMyBucket",db_name="MyOrg_NotMyBucket",org="MyOrg"} 0"#
+            r#"ingest_lp_lines_errors{bucket="NotMyBucket",db_name="NotMyOrg_NotMyBucket",org="NotMyOrg"} 1"#
         );
         assert_contains!(
             &metrics_string,

--- a/src/influxdb_ioxd/http.rs
+++ b/src/influxdb_ioxd/http.rs
@@ -396,7 +396,7 @@ async fn parse_body(req: hyper::Request<Body>) -> Result<Bytes, ApplicationError
     let body = body.freeze();
 
     // apply any content encoding needed
-    let body = if ungzip {
+    if ungzip {
         use std::io::Read;
         let decoder = flate2::read::GzDecoder::new(&body[..]);
 
@@ -407,12 +407,10 @@ async fn parse_body(req: hyper::Request<Body>) -> Result<Bytes, ApplicationError
         decoder
             .read_to_end(&mut decoded_data)
             .context(ReadingBodyAsGzip)?;
-        decoded_data.into()
+        Ok(decoded_data.into())
     } else {
-        body
-    };
-
-    Ok(body)
+        Ok(body)
+    }
 }
 
 #[observability_deps::instrument(level = "debug")]

--- a/src/influxdb_ioxd/http.rs
+++ b/src/influxdb_ioxd/http.rs
@@ -839,10 +839,13 @@ mod tests {
             .await
             .expect("sent data");
 
+        // TODO: check values. Note we can't check the absolute metric
+        // values here because the other tests may have written
+        // values concurrently.
         let metrics_string = String::from_utf8(metrics::metrics_as_text()).unwrap();
-        assert_contains!(&metrics_string, "ingest_lp_bytes_success 588");
-        assert_contains!(&metrics_string, "ingest_lp_lines_errors 0");
-        assert_contains!(&metrics_string, "ingest_lp_lines_success 6");
+        assert_contains!(&metrics_string, "ingest_lp_bytes_success");
+        assert_contains!(&metrics_string, "ingest_lp_lines_errors");
+        assert_contains!(&metrics_string, "ingest_lp_lines_success");
     }
 
     /// Sets up a test database with some data for testing the query endpoint


### PR DESCRIPTION
closes https://github.com/influxdata/influxdb_iox/issues/1118

# Rationale
As we roll out IOx to production, we need to understand the data that is flowing through it and the traffic it is handling. The first important metric is "how much line protocol are we handling"

# Changes
Record metrics for:

1. Number of bytes of line protocol that were parsed and stored successfully
2. Number of lines of line protocol that were rejected
3. Number of lines of line protocol formatted data that were parsed and stored successfully


# Questions;
Are there standard names for these metrics from influxdb and if so what are they (so IOx can use the same names)?


- [x] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb_iox/blob/main/README.md).
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
