### PR TITLE
chore: CI check that generated flatbuffers code has been updated if needed

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,6 +20,7 @@
 #   - cargo fmt
 #   - clippy (with warnings denied)
 #   - lint protobufs
+#   - check if generated flatbuffers code is up to date
 
 version: 2.1
 
@@ -156,6 +157,17 @@ jobs:
           name: buf lint
           command: buf lint
 
+  # Check that the generated flatbuffers code is up-to-date with the changes in this PR.
+  check-flatbuffers:
+    docker:
+      - image: quay.io/influxdb/rust:ci
+    resource_class: xlarge # use of a smaller executor tends crashes on link
+    steps:
+      - checkout
+      - run:
+          name: Check Flatbuffers
+          command: ./generated_types/check-flatbuffers.sh << pipeline.git.base_revision >> <<pipeline.git.revision>>
+
   # Compile a cargo "release" profile binary for branches that end in `/perf`
   #
   # Uses the latest ci_image (influxdb/rust below) to build a release binary and
@@ -234,6 +246,7 @@ workflows:
       - test
       - test_influxdb2_client
       - build
+      - check-flatbuffers
 
   # Internal pipeline for perf builds.
   #

--- a/generated_types/check-flatbuffers.sh
+++ b/generated_types/check-flatbuffers.sh
@@ -1,0 +1,44 @@
+#!/bin/bash -eu
+
+BEFORE_SHA=$1
+AFTER_SHA=$2
+
+# Change to the generated_types crate directory, where this script is located
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+pushd $DIR
+
+echo "Checking for changes to fbs files between ${BEFORE_SHA} and ${AFTER_SHA}..."
+
+WAL_FBS="$DIR/protos/wal.fbs"
+ENTRY_FBS="$DIR/protos/influxdata/iox/write/v1/entry.fbs"
+
+WAL_CHANGES=$(git rev-list "${BEFORE_SHA}".."${AFTER_SHA}" "${WAL_FBS}" | wc -l)
+ENTRY_CHANGES=$(git rev-list "${BEFORE_SHA}".."${AFTER_SHA}" "${ENTRY_FBS}" | wc -l)
+
+if [[ $WAL_CHANGES -gt 0 || $ENTRY_CHANGES -gt 0 ]]; then
+  echo "Changes to fbs files detected, regenerating flatbuffers code..."
+
+  # Will move this to docker if it works
+  sudo apt install g++
+  curl -Lo bazel-4.0.0-installer-linux-x86_64.sh https://github.com/bazelbuild/bazel/releases/download/4.0.0/bazel-4.0.0-installer-linux-x86_64.sh
+  ls -lrta
+  chmod +x bazel-4.0.0-installer-linux-x86_64.sh
+  ./bazel-4.0.0-installer-linux-x86_64.sh --user
+
+  ./regenerate-flatbuffers.sh
+
+  echo "Checking for uncommitted changes..."
+
+  if ! git diff-index --quiet HEAD --; then
+    echo "************************************************************"
+    echo "* Found uncommitted changes to generated flatbuffers code! *"
+    echo "* Please run \`generated_types/regenerate-flatbuffers.sh\`   *"
+    echo "* to regenerate the flatbuffers code and check it in!      *"
+    echo "************************************************************"
+    exit 1
+  else
+    echo "No uncommitted changes; this is fine."
+  fi
+else
+  echo "No changes to fbs files detected."
+fi

--- a/generated_types/check-flatbuffers.sh
+++ b/generated_types/check-flatbuffers.sh
@@ -9,13 +9,9 @@ pushd $DIR
 
 echo "Checking for changes to fbs files between ${BEFORE_SHA} and ${AFTER_SHA}..."
 
-WAL_FBS="$DIR/protos/wal.fbs"
-ENTRY_FBS="$DIR/protos/influxdata/iox/write/v1/entry.fbs"
+FBS_CHANGES=$(git rev-list "${BEFORE_SHA}".."${AFTER_SHA}" "**/*.fbs" | wc -l)
 
-WAL_CHANGES=$(git rev-list "${BEFORE_SHA}".."${AFTER_SHA}" "${WAL_FBS}" | wc -l)
-ENTRY_CHANGES=$(git rev-list "${BEFORE_SHA}".."${AFTER_SHA}" "${ENTRY_FBS}" | wc -l)
-
-if [[ $WAL_CHANGES -gt 0 || $ENTRY_CHANGES -gt 0 ]]; then
+if [[ $FBS_CHANGES -gt 0 ]]; then
   echo "Changes to fbs files detected, regenerating flatbuffers code..."
 
   # Will move this to docker if it works

--- a/generated_types/regenerate-flatbuffers.sh
+++ b/generated_types/regenerate-flatbuffers.sh
@@ -38,15 +38,11 @@ echo "run: bazel build :flatc ..."
 bazel build :flatc
 popd
 
-WAL_FBS="$DIR/protos/wal.fbs"
-WAL_RS_DIR="$DIR/src"
-
-$FLATC --rust -o $WAL_RS_DIR $WAL_FBS
-
-ENTRY_FBS="$DIR/protos/influxdata/iox/write/v1/entry.fbs"
-ENTRY_RS_DIR="$DIR/src"
-
-$FLATC --rust -o $ENTRY_RS_DIR $ENTRY_FBS
+RUST_DIR="$DIR/src"
+while read -r FBS_FILE; do
+    echo "Compiling ${FBS_file}"
+    $FLATC --rust -o $RUST_DIR $FBS_FILE
+done < <(git ls-files $DIR/*.fbs)
 
 cargo fmt
 popd


### PR DESCRIPTION
Fixes #1019.

[Here's an example of the job failing when I intentionally changed the fbs without updating the generated code](https://app.circleci.com/pipelines/github/influxdata/influxdb_iox/4425/workflows/c19aa192-f7f8-4411-9d39-828b86a2ca3a/jobs/9287).