### PR TITLE
feat: add basic memory tracking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1877,6 +1877,7 @@ dependencies = [
  "string-interner",
  "test_helpers",
  "tokio",
+ "tracker",
 ]
 
 [[package]]
@@ -2321,6 +2322,7 @@ dependencies = [
  "object_store",
  "parking_lot",
  "snafu",
+ "tracker",
 ]
 
 [[package]]

--- a/mutable_buffer/Cargo.toml
+++ b/mutable_buffer/Cargo.toml
@@ -21,12 +21,13 @@ data_types = { path = "../data_types" }
 # version of the flatbuffers crate
 flatbuffers = "0.8"
 generated_types = { path = "../generated_types" }
-internal_types = { path = "../internal_types" }
 influxdb_line_protocol = { path = "../influxdb_line_protocol" }
+internal_types = { path = "../internal_types" }
+observability_deps = { path = "../observability_deps" }
 snafu = "0.6.2"
 string-interner = "0.12.2"
 tokio = { version = "1.0", features = ["macros"] }
-observability_deps = { path = "../observability_deps" }
+tracker = { path = "../tracker" }
 
 [dev-dependencies] # In alphabetical order
 test_helpers = { path = "../test_helpers" }

--- a/mutable_buffer/src/table.rs
+++ b/mutable_buffer/src/table.rs
@@ -596,10 +596,12 @@ mod tests {
     use internal_types::data::split_lines_into_write_entry_partitions;
 
     use super::*;
+    use tracker::MemRegistry;
 
     #[test]
     fn test_has_columns() {
-        let mut chunk = Chunk::new(42);
+        let registry = Arc::new(MemRegistry::new());
+        let mut chunk = Chunk::new(42, registry.as_ref());
         let dictionary = &mut chunk.dictionary;
         let mut table = Table::new(dictionary.lookup_value_or_insert("table_name"));
 
@@ -641,7 +643,8 @@ mod tests {
 
     #[test]
     fn table_size() {
-        let mut chunk = Chunk::new(42);
+        let registry = Arc::new(MemRegistry::new());
+        let mut chunk = Chunk::new(42, registry.as_ref());
         let dictionary = &mut chunk.dictionary;
         let mut table = Table::new(dictionary.lookup_value_or_insert("table_name"));
 
@@ -664,7 +667,8 @@ mod tests {
 
     #[test]
     fn test_matches_table_name_predicate() {
-        let mut chunk = Chunk::new(42);
+        let registry = Arc::new(MemRegistry::new());
+        let mut chunk = Chunk::new(42, registry.as_ref());
         let dictionary = &mut chunk.dictionary;
         let mut table = Table::new(dictionary.lookup_value_or_insert("h2o"));
 
@@ -694,7 +698,8 @@ mod tests {
 
     #[test]
     fn test_matches_column_name_predicate() {
-        let mut chunk = Chunk::new(42);
+        let registry = Arc::new(MemRegistry::new());
+        let mut chunk = Chunk::new(42, registry.as_ref());
         let dictionary = &mut chunk.dictionary;
         let mut table = Table::new(dictionary.lookup_value_or_insert("h2o"));
 
@@ -740,7 +745,8 @@ mod tests {
 
     #[test]
     fn test_to_arrow_schema_all() {
-        let mut chunk = Chunk::new(42);
+        let registry = Arc::new(MemRegistry::new());
+        let mut chunk = Chunk::new(42, registry.as_ref());
         let dictionary = &mut chunk.dictionary;
         let mut table = Table::new(dictionary.lookup_value_or_insert("table_name"));
 
@@ -773,7 +779,8 @@ mod tests {
 
     #[test]
     fn test_to_arrow_schema_subset() {
-        let mut chunk = Chunk::new(42);
+        let registry = Arc::new(MemRegistry::new());
+        let mut chunk = Chunk::new(42, registry.as_ref());
         let dictionary = &mut chunk.dictionary;
         let mut table = Table::new(dictionary.lookup_value_or_insert("table_name"));
 

--- a/parquet_file/Cargo.toml
+++ b/parquet_file/Cargo.toml
@@ -12,3 +12,4 @@ futures = "0.3.7"
 object_store = {path = "../object_store"}
 parking_lot = "0.11.1"
 snafu = "0.6"
+tracker = { path = "../tracker" }

--- a/server/src/buffer.rs
+++ b/server/src/buffer.rs
@@ -23,7 +23,7 @@ use data_types::wal::{SegmentPersistence, SegmentSummary, WriterSummary};
 use observability_deps::tracing::{error, info, warn};
 use parking_lot::Mutex;
 use snafu::{ensure, OptionExt, ResultExt, Snafu};
-use tracker::task::{TrackedFutureExt, TrackerRegistration};
+use tracker::{TaskRegistration, TrackedFutureExt};
 
 #[derive(Debug, Snafu)]
 pub enum Error {
@@ -378,7 +378,7 @@ impl Segment {
     /// the given object store location.
     pub fn persist_bytes_in_background(
         &self,
-        tracker: TrackerRegistration,
+        tracker: TaskRegistration,
         writer_id: u32,
         db_name: &DatabaseName<'_>,
         store: Arc<ObjectStore>,

--- a/server/src/db/catalog.rs
+++ b/server/src/db/catalog.rs
@@ -231,6 +231,7 @@ impl SchemaProvider for Catalog {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tracker::MemRegistry;
 
     #[test]
     fn partition_get() {
@@ -269,12 +270,13 @@ mod tests {
 
     #[test]
     fn chunk_create() {
+        let registry = MemRegistry::new();
         let catalog = Catalog::new();
         let p1 = catalog.get_or_create_partition("p1");
 
         let mut p1 = p1.write();
-        p1.create_open_chunk();
-        p1.create_open_chunk();
+        p1.create_open_chunk(&registry);
+        p1.create_open_chunk(&registry);
 
         let c1_0 = p1.chunk(0).unwrap();
         assert_eq!(c1_0.read().key(), "p1");
@@ -290,20 +292,21 @@ mod tests {
 
     #[test]
     fn chunk_list() {
+        let registry = MemRegistry::new();
         let catalog = Catalog::new();
 
         let p1 = catalog.get_or_create_partition("p1");
         {
             let mut p1 = p1.write();
 
-            p1.create_open_chunk();
-            p1.create_open_chunk();
+            p1.create_open_chunk(&registry);
+            p1.create_open_chunk(&registry);
         }
 
         let p2 = catalog.get_or_create_partition("p2");
         {
             let mut p2 = p2.write();
-            p2.create_open_chunk();
+            p2.create_open_chunk(&registry);
         }
 
         assert_eq!(
@@ -355,19 +358,20 @@ mod tests {
 
     #[test]
     fn chunk_drop() {
+        let registry = MemRegistry::new();
         let catalog = Catalog::new();
 
         let p1 = catalog.get_or_create_partition("p1");
         {
             let mut p1 = p1.write();
-            p1.create_open_chunk();
-            p1.create_open_chunk();
+            p1.create_open_chunk(&registry);
+            p1.create_open_chunk(&registry);
         }
 
         let p2 = catalog.get_or_create_partition("p2");
         {
             let mut p2 = p2.write();
-            p2.create_open_chunk();
+            p2.create_open_chunk(&registry);
         }
 
         assert_eq!(chunk_strings(&catalog).len(), 3);
@@ -399,14 +403,15 @@ mod tests {
 
     #[test]
     fn chunk_recreate_dropped() {
+        let registry = MemRegistry::new();
         let catalog = Catalog::new();
 
         let p1 = catalog.get_or_create_partition("p1");
 
         {
             let mut p1 = p1.write();
-            p1.create_open_chunk();
-            p1.create_open_chunk();
+            p1.create_open_chunk(&registry);
+            p1.create_open_chunk(&registry);
         }
         assert_eq!(chunk_strings(&catalog).len(), 2);
 
@@ -419,7 +424,7 @@ mod tests {
         // should be ok to recreate (thought maybe not a great idea)
         {
             let mut p1 = p1.write();
-            p1.create_open_chunk();
+            p1.create_open_chunk(&registry);
         }
         assert_eq!(chunk_strings(&catalog).len(), 2);
     }

--- a/server/src/db/catalog/chunk.rs
+++ b/server/src/db/catalog/chunk.rs
@@ -11,6 +11,7 @@ use read_buffer::Database as ReadBufferDb;
 use crate::db::DBChunk;
 
 use super::{InternalChunkState, Result};
+use tracker::MemRegistry;
 
 /// The state a Chunk is in and what its underlying backing storage is
 #[derive(Debug)]
@@ -109,8 +110,12 @@ impl Chunk {
     }
 
     /// Creates a new open chunk
-    pub(crate) fn new_open(partition_key: impl Into<String>, id: u32) -> Self {
-        let state = ChunkState::Open(mutable_buffer::chunk::Chunk::new(id));
+    pub(crate) fn new_open(
+        partition_key: impl Into<String>,
+        id: u32,
+        memory_registry: &MemRegistry,
+    ) -> Self {
+        let state = ChunkState::Open(mutable_buffer::chunk::Chunk::new(id, memory_registry));
         Self::new(partition_key, id, state)
     }
 

--- a/server/src/db/catalog/partition.rs
+++ b/server/src/db/catalog/partition.rs
@@ -11,6 +11,7 @@ use data_types::chunk::ChunkSummary;
 use data_types::partition_metadata::PartitionSummary;
 use parking_lot::RwLock;
 use snafu::OptionExt;
+use tracker::MemRegistry;
 
 /// IOx Catalog Partition
 ///
@@ -76,11 +77,15 @@ impl Partition {
     }
 
     /// Create a new Chunk in the open state
-    pub fn create_open_chunk(&mut self) -> Arc<RwLock<Chunk>> {
+    pub fn create_open_chunk(&mut self, memory_registry: &MemRegistry) -> Arc<RwLock<Chunk>> {
         let chunk_id = self.next_chunk_id;
         self.next_chunk_id += 1;
 
-        let chunk = Arc::new(RwLock::new(Chunk::new_open(&self.key, chunk_id)));
+        let chunk = Arc::new(RwLock::new(Chunk::new_open(
+            &self.key,
+            chunk_id,
+            memory_registry,
+        )));
 
         if self.chunks.insert(chunk_id, Arc::clone(&chunk)).is_some() {
             // A fundamental invariant has been violated - abort

--- a/server/src/db/lifecycle.rs
+++ b/server/src/db/lifecycle.rs
@@ -7,7 +7,7 @@ use parking_lot::{RwLock, RwLockUpgradableReadGuard};
 
 use data_types::{database_rules::LifecycleRules, error::ErrorLogger, job::Job};
 
-use tracker::task::Tracker;
+use tracker::TaskTracker;
 
 use super::{
     catalog::chunk::{Chunk, ChunkState},
@@ -19,7 +19,7 @@ use data_types::database_rules::SortOrder;
 pub struct LifecycleManager {
     db: Arc<Db>,
     db_name: String,
-    move_task: Option<Tracker<Job>>,
+    move_task: Option<TaskTracker<Job>>,
 }
 
 impl LifecycleManager {
@@ -232,6 +232,7 @@ fn can_move(rules: &LifecycleRules, chunk: &Chunk, now: DateTime<Utc>) -> bool {
 mod tests {
     use super::*;
     use std::num::{NonZeroU32, NonZeroUsize};
+    use tracker::MemRegistry;
 
     fn from_secs(secs: i64) -> DateTime<Utc> {
         DateTime::from_utc(chrono::NaiveDateTime::from_timestamp(secs, 0), Utc)
@@ -242,7 +243,7 @@ mod tests {
         time_of_first_write: Option<i64>,
         time_of_last_write: Option<i64>,
     ) -> Chunk {
-        let mut chunk = Chunk::new_open("", id);
+        let mut chunk = Chunk::new_open("", id, &MemRegistry::new());
         chunk.set_timestamps(
             time_of_first_write.map(from_secs),
             time_of_last_write.map(from_secs),

--- a/server/src/snapshot.rs
+++ b/server/src/snapshot.rs
@@ -281,6 +281,7 @@ mod tests {
     use mutable_buffer::chunk::Chunk as ChunkWB;
     use object_store::memory::InMemory;
     use query::{test::TestLPWriter, Database};
+    use tracker::MemRegistry;
 
     #[tokio::test]
     async fn snapshot() {
@@ -350,9 +351,10 @@ mem,host=A,region=west used=45 1
             },
         ];
 
+        let registry = MemRegistry::new();
         let store = Arc::new(ObjectStore::new_in_memory(InMemory::new()));
         let chunk = Arc::new(DBChunk::MutableBuffer {
-            chunk: Arc::new(ChunkWB::new(11)),
+            chunk: Arc::new(ChunkWB::new(11, &registry)),
             partition_key: Arc::new("key".to_string()),
             open: false,
         });

--- a/tracker/src/lib.rs
+++ b/tracker/src/lib.rs
@@ -6,4 +6,8 @@
     clippy::clone_on_ref_ptr
 )]
 
-pub mod task;
+mod mem;
+mod task;
+
+pub use mem::*;
+pub use task::*;

--- a/tracker/src/mem.rs
+++ b/tracker/src/mem.rs
@@ -1,0 +1,117 @@
+//! This module contains a basic memory tracking system
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+
+/// A simple memory registry that tracks the total memory consumption
+/// across a set of MemTrackers
+#[derive(Debug, Default)]
+pub struct MemRegistry {
+    inner: Arc<MemTrackerShared>,
+}
+
+#[derive(Debug, Default)]
+struct MemTrackerShared {
+    /// The total bytes across all registered trackers
+    bytes: AtomicUsize,
+}
+
+impl MemRegistry {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn bytes(&self) -> usize {
+        self.inner.bytes.load(Ordering::Relaxed)
+    }
+
+    pub fn register(&self) -> MemTracker {
+        MemTracker {
+            shared: Arc::clone(&self.inner),
+            bytes: 0,
+        }
+    }
+}
+
+/// A MemTracker is created with a reference to a MemRegistry
+/// The memory "allocation" associated with a specific MemTracker
+/// can be increased or decreased and this will update the totals
+/// on the MemRegistry
+///
+/// On Drop the "allocated" bytes associated with the MemTracker
+/// will be decremented from the MemRegistry's total
+///
+/// Note: this purposefully does not implement Clone as the semantics
+/// of such a construct are unclear
+///
+/// Note: this purposefully does not implement Default to avoid
+/// accidentally creating untracked objects
+#[derive(Debug)]
+pub struct MemTracker {
+    shared: Arc<MemTrackerShared>,
+    bytes: usize,
+}
+
+impl MemTracker {
+    /// Creates a new empty tracker registered to
+    /// the same registry as this tracker
+    pub fn clone_empty(&self) -> Self {
+        Self {
+            shared: Arc::clone(&self.shared),
+            bytes: 0,
+        }
+    }
+
+    /// Set the number of bytes associated with this tracked instance
+    pub fn set_bytes(&mut self, new: usize) {
+        if new > self.bytes {
+            self.shared
+                .bytes
+                .fetch_add(new - self.bytes, Ordering::Relaxed);
+        } else {
+            self.shared
+                .bytes
+                .fetch_sub(self.bytes - new, Ordering::Relaxed);
+        }
+        self.bytes = new;
+    }
+}
+
+impl Drop for MemTracker {
+    fn drop(&mut self) {
+        self.shared.bytes.fetch_sub(self.bytes, Ordering::Relaxed);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_tracker() {
+        let registry = MemRegistry::new();
+        let mut t1 = registry.register();
+        let mut t2 = registry.register();
+
+        t1.set_bytes(200);
+
+        assert_eq!(registry.bytes(), 200);
+
+        t1.set_bytes(100);
+
+        assert_eq!(registry.bytes(), 100);
+
+        t2.set_bytes(300);
+
+        assert_eq!(registry.bytes(), 400);
+
+        t2.set_bytes(400);
+        assert_eq!(registry.bytes(), 500);
+
+        std::mem::drop(t2);
+        assert_eq!(registry.bytes(), 100);
+
+        std::mem::drop(t1);
+        assert_eq!(registry.bytes(), 0);
+    }
+}

--- a/tracker/src/task/future.rs
+++ b/tracker/src/task/future.rs
@@ -6,13 +6,13 @@ use std::time::Instant;
 use futures::{future::BoxFuture, prelude::*};
 use pin_project::{pin_project, pinned_drop};
 
-use super::{TrackerRegistration, TrackerState};
+use super::{TaskRegistration, TrackerState};
 use std::sync::Arc;
 
 /// An extension trait that provides `self.track(registration)` allowing
 /// associating this future with a `TrackerRegistration`
 pub trait TrackedFutureExt: Future {
-    fn track(self, registration: TrackerRegistration) -> TrackedFuture<Self>
+    fn track(self, registration: TaskRegistration) -> TrackedFuture<Self>
     where
         Self: Sized,
     {


### PR DESCRIPTION
Builds on top of #1124 and adds an extremely basic memory tracker.

Creating as a draft to get feedback on the general approach before improving the end-to-end test coverage.

The basic idea is to allow instrumenting objects with memory tracking handles that can easily be updated from said object, and will record the memory as "freed" on drop. Initially this is useful for providing memory instrumentation within the catalog, but I'd imagine this pattern could be useful for tracking memory usage for queries, and/or data structures within the read buffer, etc... 

The advantage of this approach over a global count coordinated in Db or similar, is it is guaranteed to live as long as the objects themselves live, which due to the use of Arcs may after they've been removed from the owning data structure.

I still need to give some thought to how to properly support DBChunk snapshotting, ideally the memory would only be "freed" once it is dropped also - but that's probably an extension for another day.

Tracked by #1100 