### PR TITLE
refactor: use DatabaseName in DatabaseRules

### DIFF
--- a/query/src/test.rs
+++ b/query/src/test.rs
@@ -18,7 +18,7 @@ use crate::{
     Database, DatabaseStore, PartitionChunk, Predicate,
 };
 
-use data_types::database_rules::{DatabaseRules, PartitionTemplate, TemplatePart};
+use data_types::database_rules::{PartitionTemplate, TemplatePart};
 use influxdb_line_protocol::{parse_lines, ParsedLine};
 use internal_types::{
     data::{lines_to_replicated_write, ReplicatedWrite},
@@ -530,12 +530,12 @@ impl TestLPWriter {
             parts: vec![TemplatePart::TimeFormat("%Y-%m-%dT%H".to_string())],
         };
 
-        let rules = DatabaseRules {
-            partition_template,
-            ..Default::default()
-        };
-
-        let write = lines_to_replicated_write(self.writer_id, self.sequence_number, &lines, &rules);
+        let write = lines_to_replicated_write(
+            self.writer_id,
+            self.sequence_number,
+            &lines,
+            &partition_template,
+        );
         self.sequence_number += 1;
         database
             .store_replicated_write(&write)

--- a/server/src/buffer.rs
+++ b/server/src/buffer.rs
@@ -581,7 +581,7 @@ fn database_object_store_path(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use data_types::database_rules::DatabaseRules;
+    use data_types::database_rules::PartitionTemplate;
     use influxdb_line_protocol::parse_lines;
     use internal_types::data::lines_to_replicated_write;
     use object_store::memory::InMemory;
@@ -959,12 +959,12 @@ mod tests {
         lp: &str,
     ) -> Arc<ReplicatedWrite> {
         let lines: Vec<_> = parse_lines(lp).map(|l| l.unwrap()).collect();
-        let rules = DatabaseRules::new();
+        let partitioner = PartitionTemplate::default();
         Arc::new(lines_to_replicated_write(
             writer_id,
             sequence_number,
             &lines,
-            &rules,
+            &partitioner,
         ))
     }
 }

--- a/server/src/db.rs
+++ b/server/src/db.rs
@@ -536,7 +536,7 @@ impl Db {
     ) -> Tracker<Job> {
         let name = self.rules.read().name.clone();
         let (tracker, registration) = self.jobs.register(Job::CloseChunk {
-            db_name: name.clone(),
+            db_name: name.to_string(),
             partition_key: partition_key.clone(),
             chunk_id,
         });
@@ -730,7 +730,7 @@ mod tests {
     use chrono::Utc;
     use data_types::{
         chunk::ChunkStorage,
-        database_rules::{LifecycleRules, Order, Sort, SortOrder},
+        database_rules::{Order, Sort, SortOrder},
         partition_metadata::{ColumnSummary, StatValues, Statistics, TableSummary},
     };
     use query::{
@@ -747,15 +747,7 @@ mod tests {
     async fn write_no_mutable_buffer() {
         // Validate that writes are rejected if there is no mutable buffer
         let db = make_db();
-        let rules = DatabaseRules {
-            lifecycle_rules: LifecycleRules {
-                immutable: true,
-                ..Default::default()
-            },
-            ..DatabaseRules::new()
-        };
-        let rules = RwLock::new(rules);
-        let db = Db { rules, ..db };
+        db.rules.write().lifecycle_rules.immutable = true;
 
         let mut writer = TestLPWriter::default();
         let res = writer.write_lp_string(&db, "cpu bar=1 10");

--- a/server/src/query_tests/utils.rs
+++ b/server/src/query_tests/utils.rs
@@ -1,6 +1,7 @@
 use data_types::{
     chunk::{ChunkStorage, ChunkSummary},
     database_rules::DatabaseRules,
+    DatabaseName,
 };
 use query::Database;
 
@@ -10,7 +11,7 @@ use std::sync::Arc;
 /// Used for testing: create a Database with a local store
 pub fn make_db() -> Db {
     Db::new(
-        DatabaseRules::new(),
+        DatabaseRules::new(DatabaseName::new("placeholder").unwrap()),
         read_buffer::Database::new(),
         None, // wal buffer
         Arc::new(JobRegistry::new()),

--- a/server/src/snapshot.rs
+++ b/server/src/snapshot.rs
@@ -276,6 +276,7 @@ mod tests {
 
     use super::*;
     use data_types::database_rules::DatabaseRules;
+    use data_types::DatabaseName;
     use futures::TryStreamExt;
     use mutable_buffer::chunk::Chunk as ChunkWB;
     use object_store::memory::InMemory;
@@ -389,7 +390,7 @@ mem,host=A,region=west used=45 1
     /// Create a Database with a local store
     pub fn make_db() -> Db {
         Db::new(
-            DatabaseRules::new(),
+            DatabaseRules::new(DatabaseName::new("placeholder").unwrap()),
             ReadBufferDb::new(),
             None, // wal buffer
             Arc::new(JobRegistry::new()),

--- a/src/influxdb_ioxd/http.rs
+++ b/src/influxdb_ioxd/http.rs
@@ -755,7 +755,9 @@ mod tests {
         ));
         test_storage.set_id(1);
         test_storage
-            .create_database("MyOrg_MyBucket", DatabaseRules::new())
+            .create_database(DatabaseRules::new(
+                DatabaseName::new("MyOrg_MyBucket").unwrap(),
+            ))
             .await
             .unwrap();
         let server_url = test_server(Arc::clone(&test_storage));
@@ -806,7 +808,9 @@ mod tests {
         ));
         test_storage.set_id(1);
         test_storage
-            .create_database("MyOrg_MyBucket", DatabaseRules::new())
+            .create_database(DatabaseRules::new(
+                DatabaseName::new("MyOrg_MyBucket").unwrap(),
+            ))
             .await
             .unwrap();
         let server_url = test_server(Arc::clone(&test_storage));
@@ -945,7 +949,9 @@ mod tests {
         ));
         test_storage.set_id(1);
         test_storage
-            .create_database("MyOrg_MyBucket", DatabaseRules::new())
+            .create_database(DatabaseRules::new(
+                DatabaseName::new("MyOrg_MyBucket").unwrap(),
+            ))
             .await
             .unwrap();
         let server_url = test_server(Arc::clone(&test_storage));
@@ -995,7 +1001,9 @@ mod tests {
         ));
         test_storage.set_id(1);
         test_storage
-            .create_database("MyOrg_MyBucket", DatabaseRules::new())
+            .create_database(DatabaseRules::new(
+                DatabaseName::new("MyOrg_MyBucket").unwrap(),
+            ))
             .await
             .unwrap();
         let server_url = test_server(Arc::clone(&test_storage));
@@ -1032,7 +1040,8 @@ mod tests {
 
         let database_name = "foo_bar";
         let rules = DatabaseRules {
-            name: database_name.to_owned(),
+            name: DatabaseName::new(database_name).unwrap(),
+            partition_template: Default::default(),
             wal_buffer_config: Some(WalBufferConfig {
                 buffer_size: 500,
                 segment_size: 10,
@@ -1040,10 +1049,11 @@ mod tests {
                 store_segments: true,
                 close_segment_after: None,
             }),
-            ..Default::default()
+            lifecycle_rules: Default::default(),
+            shard_config: None,
         };
 
-        server.create_database(database_name, rules).await.unwrap();
+        server.create_database(rules).await.unwrap();
 
         let base_url = format!(
             "{}/iox/api/v1/databases/{}/wal/meta",

--- a/src/influxdb_ioxd/rpc/management.rs
+++ b/src/influxdb_ioxd/rpc/management.rs
@@ -79,10 +79,7 @@ where
             .and_then(TryInto::try_into)
             .map_err(|e| e.scope("rules"))?;
 
-        let name =
-            DatabaseName::new(rules.name.clone()).expect("protobuf mapping didn't validate name");
-
-        match self.server.create_database(name, rules).await {
+        match self.server.create_database(rules).await {
             Ok(_) => Ok(Response::new(CreateDatabaseResponse {})),
             Err(Error::DatabaseAlreadyExists { db_name }) => {
                 return Err(AlreadyExists {


### PR DESCRIPTION
This turned into a bit of a yak shave as various tests were relying on being able to construct invalid DatabaseRules structures, but I think this is probably a good thing to fix