### PR TITLE
fix: disable minimum age by default

### DIFF
--- a/src/commands/database.rs
+++ b/src/commands/database.rs
@@ -80,7 +80,7 @@ struct Create {
 
     /// A chunk of data within a partition is guaranteed to remain mutable
     /// for at least this number of seconds
-    #[structopt(long, default_value = "1800")] // 30 minutes
+    #[structopt(long, default_value = "0")] // 0 minutes
     mutable_minimum_age_seconds: u32,
 
     /// Once a chunk of data within a partition reaches this number of bytes


### PR DESCRIPTION
As writes are currently not ever directed to a closing chunk, there currently isn't a reason to delay moving a chunk once the linger time has passed. This will occur when the partition is no longer hot for writes, or when the chunk has been moved to closing due to exceeding the mutable_size_threshold.