### PR TITLE
fix: avoid spamming the logs with errors that are not errors

### DIFF
--- a/server/src/db/lifecycle.rs
+++ b/server/src/db/lifecycle.rs
@@ -2,7 +2,7 @@ use std::convert::TryInto;
 use std::sync::Arc;
 
 use chrono::{DateTime, Utc};
-use observability_deps::tracing::{debug, info};
+use observability_deps::tracing::{info, warn};
 use parking_lot::{RwLock, RwLockUpgradableReadGuard};
 
 use data_types::{database_rules::LifecycleRules, error::ErrorLogger, job::Job};
@@ -18,13 +18,17 @@ use data_types::database_rules::SortOrder;
 /// Handles the lifecycle of chunks within a Db
 pub struct LifecycleManager {
     db: Arc<Db>,
+    db_name: String,
     move_task: Option<Tracker<Job>>,
 }
 
 impl LifecycleManager {
     pub fn new(db: Arc<Db>) -> Self {
+        let db_name = db.rules.read().name.clone().into();
+
         Self {
             db,
+            db_name,
             move_task: None,
         }
     }
@@ -47,6 +51,9 @@ trait ChunkMover {
     fn chunk_size(chunk: &Chunk) -> usize {
         chunk.size()
     }
+
+    /// Return the name of the database
+    fn db_name(&self) -> &str;
 
     /// Returns the lifecycle policy
     fn rules(&self) -> LifecycleRules;
@@ -136,7 +143,7 @@ trait ChunkMover {
                         }
                     }
                     None => {
-                        debug!("failed to find chunk to evict");
+                        warn!(db_name=self.db_name(), "soft limited exceeded, but no chunks found that can be evicted. Check lifecycle rules");
                         break;
                     }
                 }
@@ -175,6 +182,10 @@ impl ChunkMover for LifecycleManager {
             .db
             .drop_chunk(&partition_key, chunk_id)
             .log_if_error("dropping chunk to free up memory");
+    }
+
+    fn db_name(&self) -> &str {
+        &self.db_name
     }
 }
 
@@ -297,6 +308,10 @@ mod tests {
 
         fn drop_chunk(&mut self, _: String, chunk_id: u32) {
             self.events.push(MoverEvents::Drop(chunk_id))
+        }
+
+        fn db_name(&self) -> &str {
+            "my_awesome_db"
         }
     }
 

--- a/server/src/db/lifecycle.rs
+++ b/server/src/db/lifecycle.rs
@@ -136,7 +136,7 @@ trait ChunkMover {
                         }
                     }
                     None => {
-                        error!("failed to find chunk to evict");
+                        debug!("failed to find chunk to evict");
                         break;
                     }
                 }

--- a/server/src/db/lifecycle.rs
+++ b/server/src/db/lifecycle.rs
@@ -143,7 +143,8 @@ trait ChunkMover {
                         }
                     }
                     None => {
-                        warn!(db_name=self.db_name(), "soft limited exceeded, but no chunks found that can be evicted. Check lifecycle rules");
+                        warn!(db_name=self.db_name(), soft_limit, buffer_size,
+                              "soft limited exceeded, but no chunks found that can be evicted. Check lifecycle rules");
                         break;
                     }
                 }

--- a/server/src/db/lifecycle.rs
+++ b/server/src/db/lifecycle.rs
@@ -2,7 +2,7 @@ use std::convert::TryInto;
 use std::sync::Arc;
 
 use chrono::{DateTime, Utc};
-use observability_deps::tracing::{error, info};
+use observability_deps::tracing::{debug, info};
 use parking_lot::{RwLock, RwLockUpgradableReadGuard};
 
 use data_types::{database_rules::LifecycleRules, error::ErrorLogger, job::Job};


### PR DESCRIPTION
If you look at the logs from tools [https://logs.aws.influxdata.io/search?q=kubernetes_container_name%3Aiox+AND+log_processed_level%3Aerror&rangetype=relative&relative=7200](link)

![Screen Shot 2021-04-06 at 12 21 22 PM](https://user-images.githubusercontent.com/490673/113745738-8f37d980-96d3-11eb-814f-ed96007a7f7f.png)

There are many log messages about not being able to evict a chunk, but I don't think that is an error
