### PR TITLE
refactor: update size method to return usize

### DIFF
--- a/read_buffer/src/chunk.rs
+++ b/read_buffer/src/chunk.rs
@@ -115,16 +115,16 @@ impl Chunk {
 
     /// The total estimated size in bytes of this `Chunk` and all contained
     /// data.
-    pub fn size(&self) -> u64 {
+    pub fn size(&self) -> usize {
         let base_size = std::mem::size_of::<Self>();
 
         let table_data = self.chunk_data.read().unwrap();
-        base_size as u64
+        base_size
             + table_data
                 .data
                 .iter()
-                .map(|(k, table)| k.len() as u64 + table.size())
-                .sum::<u64>()
+                .map(|(k, table)| k.len() + table.size() as usize)
+                .sum::<usize>()
     }
 
     /// The total number of rows in all row groups in all tables in this chunk.

--- a/read_buffer/src/column.rs
+++ b/read_buffer/src/column.rs
@@ -50,44 +50,40 @@ impl Column {
     //
 
     /// The estimated size in bytes of the column.
-    pub fn size(&self) -> u64 {
+    pub fn size(&self) -> usize {
         // Since `MetaData` is generic each value in the range can have a
         // different size, so just do the calculations here where we know each
         // `T`.
         match &self {
             Self::String(meta, data) => {
                 let mut meta_size =
-                    (size_of::<Option<(String, String)>>() + size_of::<ColumnProperties>()) as u64;
+                    size_of::<Option<(String, String)>>() + size_of::<ColumnProperties>();
                 if let Some((min, max)) = &meta.range {
-                    meta_size += (min.len() + max.len()) as u64;
+                    meta_size += min.len() + max.len();
                 };
                 meta_size + data.size()
             }
             Self::Float(_, data) => {
-                let meta_size =
-                    (size_of::<Option<(f64, f64)>>() + size_of::<ColumnProperties>()) as u64;
+                let meta_size = size_of::<Option<(f64, f64)>>() + size_of::<ColumnProperties>();
                 meta_size + data.size()
             }
             Self::Integer(_, data) => {
-                let meta_size =
-                    (size_of::<Option<(i64, i64)>>() + size_of::<ColumnProperties>()) as u64;
+                let meta_size = size_of::<Option<(i64, i64)>>() + size_of::<ColumnProperties>();
                 meta_size + data.size()
             }
             Self::Unsigned(_, data) => {
-                let meta_size =
-                    (size_of::<Option<(u64, u64)>>() + size_of::<ColumnProperties>()) as u64;
+                let meta_size = size_of::<Option<(u64, u64)>>() + size_of::<ColumnProperties>();
                 meta_size + data.size()
             }
             Self::Bool(_, data) => {
-                let meta_size =
-                    (size_of::<Option<(bool, bool)>>() + size_of::<ColumnProperties>()) as u64;
+                let meta_size = size_of::<Option<(bool, bool)>>() + size_of::<ColumnProperties>();
                 meta_size + data.size()
             }
             Self::ByteArray(meta, data) => {
-                let mut meta_size = (size_of::<Option<(Vec<u8>, Vec<u8>)>>()
-                    + size_of::<ColumnProperties>()) as u64;
+                let mut meta_size =
+                    size_of::<Option<(Vec<u8>, Vec<u8>)>>() + size_of::<ColumnProperties>();
                 if let Some((min, max)) = &meta.range {
-                    meta_size += (min.len() + max.len()) as u64;
+                    meta_size += min.len() + max.len();
                 };
 
                 meta_size + data.size()

--- a/read_buffer/src/column/boolean.rs
+++ b/read_buffer/src/column/boolean.rs
@@ -11,7 +11,7 @@ pub enum BooleanEncoding {
 
 impl BooleanEncoding {
     /// The total size in bytes of the store columnar data.
-    pub fn size(&self) -> u64 {
+    pub fn size(&self) -> usize {
         match self {
             Self::BooleanNull(enc) => enc.size(),
         }

--- a/read_buffer/src/column/encoding/bool.rs
+++ b/read_buffer/src/column/encoding/bool.rs
@@ -38,8 +38,8 @@ impl Bool {
 
     /// Returns an estimation of the total size in bytes used by this column
     /// encoding.
-    pub fn size(&self) -> u64 {
-        (std::mem::size_of::<BooleanArray>() + self.arr.get_array_memory_size()) as u64
+    pub fn size(&self) -> usize {
+        std::mem::size_of::<BooleanArray>() + self.arr.get_array_memory_size()
     }
 
     //

--- a/read_buffer/src/column/encoding/dictionary.rs
+++ b/read_buffer/src/column/encoding/dictionary.rs
@@ -27,7 +27,7 @@ impl Encoding {
         }
     }
 
-    pub fn size(&self) -> u64 {
+    pub fn size(&self) -> usize {
         match &self {
             Self::RLE(enc) => enc.size(),
             Self::Plain(enc) => enc.size(),

--- a/read_buffer/src/column/encoding/dictionary/plain.rs
+++ b/read_buffer/src/column/encoding/dictionary/plain.rs
@@ -60,7 +60,7 @@ impl Plain {
     }
 
     /// A reasonable estimation of the on-heap size this encoding takes up.
-    pub fn size(&self) -> u64 {
+    pub fn size(&self) -> usize {
         // the total size of all decoded values in the column.
         let decoded_keys_size = self
             .entries
@@ -75,7 +75,7 @@ impl Plain {
         let encoded_ids_size = size_of::<Vec<u32>>() + (size_of::<u32>() * self.encoded_data.len());
 
         // + 1 for contains_null field
-        (entries_size + encoded_ids_size + 1) as u64
+        entries_size + encoded_ids_size + 1
     }
 
     /// The number of distinct logical values in this column encoding.

--- a/read_buffer/src/column/encoding/dictionary/rle.rs
+++ b/read_buffer/src/column/encoding/dictionary/rle.rs
@@ -76,7 +76,7 @@ impl RLE {
     }
 
     /// A reasonable estimation of the on-heap size this encoding takes up.
-    pub fn size(&self) -> u64 {
+    pub fn size(&self) -> usize {
         // the total size of all decoded values in the column.
         let decoded_keys_size = self.entry_index.keys().map(|k| k.len()).sum::<usize>();
 
@@ -103,7 +103,7 @@ impl RLE {
         let run_lengths_size = size_of::<Vec<(u32, u32)>>() + // container size
             (size_of::<(u32, u32)>() * self.run_lengths.len()); // each run-length size
 
-        (entry_index_size + index_entry_size + index_row_ids_size + run_lengths_size + 1 + 4) as u64
+        entry_index_size + index_entry_size + index_row_ids_size + run_lengths_size + 1 + 4
     }
 
     /// The number of distinct logical values in this column encoding.

--- a/read_buffer/src/column/encoding/fixed.rs
+++ b/read_buffer/src/column/encoding/fixed.rs
@@ -71,8 +71,8 @@ where
     /// Returns the total size in bytes of the encoded data. Note, this method
     /// is really an "accurate" estimation. It doesn't include for example the
     /// size of the `Fixed` struct receiver.
-    pub fn size(&self) -> u64 {
-        (size_of::<Vec<T>>() + (size_of::<T>() * self.values.len())) as u64
+    pub fn size(&self) -> usize {
+        size_of::<Vec<T>>() + (size_of::<T>() * self.values.len())
     }
 
     //

--- a/read_buffer/src/column/encoding/fixed_null.rs
+++ b/read_buffer/src/column/encoding/fixed_null.rs
@@ -68,8 +68,8 @@ where
 
     /// Returns an estimation of the total size in bytes used by this column
     /// encoding.
-    pub fn size(&self) -> u64 {
-        (std::mem::size_of::<PrimitiveArray<T>>() + self.arr.get_array_memory_size()) as u64
+    pub fn size(&self) -> usize {
+        std::mem::size_of::<PrimitiveArray<T>>() + self.arr.get_array_memory_size()
     }
 
     //

--- a/read_buffer/src/column/float.rs
+++ b/read_buffer/src/column/float.rs
@@ -11,7 +11,7 @@ pub enum FloatEncoding {
 
 impl FloatEncoding {
     /// The total size in bytes of the store columnar data.
-    pub fn size(&self) -> u64 {
+    pub fn size(&self) -> usize {
         match self {
             Self::Fixed64(enc) => enc.size(),
             Self::FixedNull64(enc) => enc.size(),

--- a/read_buffer/src/column/integer.rs
+++ b/read_buffer/src/column/integer.rs
@@ -25,7 +25,7 @@ pub enum IntegerEncoding {
 
 impl IntegerEncoding {
     /// The total size in bytes of the store columnar data.
-    pub fn size(&self) -> u64 {
+    pub fn size(&self) -> usize {
         match self {
             Self::I64I64(enc) => enc.size(),
             Self::I64I32(enc) => enc.size(),

--- a/read_buffer/src/column/string.rs
+++ b/read_buffer/src/column/string.rs
@@ -27,7 +27,7 @@ pub enum StringEncoding {
 /// different encodings.
 impl StringEncoding {
     /// The total size in bytes of the store columnar data.
-    pub fn size(&self) -> u64 {
+    pub fn size(&self) -> usize {
         match self {
             Self::RLEDictionary(enc) => enc.size(),
             Self::Dictionary(enc) => enc.size(),

--- a/read_buffer/src/lib.rs
+++ b/read_buffer/src/lib.rs
@@ -211,16 +211,16 @@ impl Database {
     }
 
     /// Returns the total estimated size in bytes of the database.
-    pub fn size(&self) -> u64 {
+    pub fn size(&self) -> usize {
         let base_size = std::mem::size_of::<Self>();
 
         let partition_data = self.data.read().unwrap();
-        base_size as u64
+        base_size
             + partition_data
                 .partitions
                 .iter()
-                .map(|(name, partition)| name.len() as u64 + partition.size())
-                .sum::<u64>()
+                .map(|(name, partition)| name.len() + partition.size() as usize)
+                .sum::<usize>()
     }
 
     pub fn rows(&self) -> u64 {
@@ -723,16 +723,18 @@ impl Partition {
 
     /// The total estimated size in bytes of the `Partition` and all contained
     /// data.
-    pub fn size(&self) -> u64 {
+    ///
+    /// TODO(edd): to be deprecated
+    pub fn size(&self) -> usize {
         let base_size = std::mem::size_of::<Self>() + self.key.len();
 
         let chunk_data = self.data.read().unwrap();
-        base_size as u64
+        (base_size as u64
             + chunk_data
                 .chunks
                 .values()
-                .map(|chunk| std::mem::size_of::<u32>() as u64 + chunk.size())
-                .sum::<u64>()
+                .map(|chunk| std::mem::size_of::<u32>() as u64 + chunk.size() as u64)
+                .sum::<u64>()) as usize
     }
 
     /// The total estimated size in bytes of the specified chunk id
@@ -741,7 +743,7 @@ impl Partition {
         chunk_data
             .chunks
             .get(&chunk_id)
-            .map(|chunk| chunk.size())
+            .map(|chunk| chunk.size() as u64)
             .unwrap_or(0) // treat unknown chunks as zero size
     }
 }

--- a/read_buffer/src/row_group.rs
+++ b/read_buffer/src/row_group.rs
@@ -137,14 +137,14 @@ impl RowGroup {
     }
 
     /// The total estimated size in bytes of the row group
-    pub fn size(&self) -> u64 {
+    pub fn size(&self) -> usize {
         let base_size = std::mem::size_of::<Self>()
             + self
                 .all_columns_by_name
                 .keys()
                 .map(|key| key.len() + std::mem::size_of::<usize>())
                 .sum::<usize>();
-        base_size as u64 + self.meta.size()
+        base_size + self.meta.size()
     }
 
     /// The number of rows in the `RowGroup` (all columns have the same number
@@ -1377,7 +1377,7 @@ pub enum ColumnType {
 
 impl ColumnType {
     // The total size in bytes of the column
-    pub fn size(&self) -> u64 {
+    pub fn size(&self) -> usize {
         match &self {
             Self::Tag(c) => c.size(),
             Self::Field(c) => c.size(),
@@ -1420,7 +1420,7 @@ impl PartialEq for ColumnMeta {
 #[derive(Default, Debug)]
 pub struct MetaData {
     // The total size in bytes of all column data in the `RowGroup`.
-    pub columns_size: u64,
+    pub columns_size: usize,
 
     // The total number of rows in the `RowGroup`.
     pub rows: u32,
@@ -1445,7 +1445,7 @@ pub struct MetaData {
 impl MetaData {
     /// Returns the estimated size in bytes of the meta data and all column data
     /// associated with a `RowGroup`.
-    pub fn size(&self) -> u64 {
+    pub fn size(&self) -> usize {
         let base_size = std::mem::size_of::<Self>();
 
         (base_size
@@ -1454,7 +1454,7 @@ impl MetaData {
                 .columns
                 .iter()
                 .map(|(k, v)| k.len() + v.size())
-                .sum::<usize>()) as u64
+                .sum::<usize>())
             + self.columns_size
     }
 
@@ -1499,7 +1499,7 @@ impl MetaData {
     pub fn add_column(
         &mut self,
         name: &str,
-        column_size: u64,
+        column_size: usize,
         col_type: schema::ColumnType,
         logical_data_type: LogicalDataType,
         range: (OwnedValue, OwnedValue),

--- a/read_buffer/src/table.rs
+++ b/read_buffer/src/table.rs
@@ -130,10 +130,10 @@ impl Table {
     }
 
     /// The total size of the table in bytes.
-    pub fn size(&self) -> u64 {
+    pub fn size(&self) -> usize {
         let base_size = std::mem::size_of::<Self>() + self.name.len();
         // meta.size accounts for all the row group data.
-        base_size as u64 + self.table_data.read().unwrap().meta.size()
+        base_size + self.table_data.read().unwrap().meta.size()
     }
 
     // Returns the total number of row groups in this table.
@@ -463,7 +463,7 @@ impl Table {
 #[derive(Clone)]
 pub struct MetaData {
     // The total size of the table in bytes.
-    size: u64,
+    size: usize,
 
     // The total number of rows in the table.
     rows: u64,
@@ -497,7 +497,7 @@ impl MetaData {
 
     /// Returns the estimated size in bytes of the `MetaData` struct and all of
     /// the row group data associated with a `Table`.
-    pub fn size(&self) -> u64 {
+    pub fn size(&self) -> usize {
         let base_size = std::mem::size_of::<Self>();
         let columns_meta_size = self
             .columns
@@ -506,7 +506,7 @@ impl MetaData {
             .sum::<usize>();
 
         let column_names_size = self.column_names.iter().map(|c| c.len()).sum::<usize>();
-        (base_size + columns_meta_size + column_names_size) as u64 + self.size
+        (base_size + columns_meta_size + column_names_size) + self.size
     }
 
     /// Create a new `MetaData` by consuming `this` and incorporating `other`.


### PR DESCRIPTION
@tustvold suggested it would be more consistent with the std library if the `size` method returned a `usize` rather than a `u64`. This PR makes those changes.

The changes to the `Database` and `Partition` are just hacked in with casting because those APIs are going away soon.