### PR TITLE
feat: Return newline delimited database names in database list

### DIFF
--- a/src/commands/database.rs
+++ b/src/commands/database.rs
@@ -196,7 +196,7 @@ pub async fn command(url: String, config: Config) -> Result<()> {
         Command::List(_) => {
             let mut client = management::Client::new(connection);
             let databases = client.list_databases().await?;
-            println!("{}", databases.join(", "))
+            println!("{}", databases.join("\n"))
         }
         Command::Get(get) => {
             let mut client = management::Client::new(connection);


### PR DESCRIPTION
Rationale: it's easier to work with a newline separated list of names, rather than a comma separated one.
You can `head`, or `tail` or `| while read i; do ...`, or just copy paste it and manipulate it around more easily.
