### PR TITLE
feat: Switch to jemalloc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1037,6 +1037,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs_extra"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2022715d62ab30faffd124d40b76f4134a550a87792276512b18d63272333394"
+
+[[package]]
 name = "futures"
 version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1486,6 +1492,7 @@ dependencies = [
  "tempfile",
  "test_helpers",
  "thiserror",
+ "tikv-jemallocator",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -3648,6 +3655,27 @@ dependencies = [
  "log",
  "ordered-float 1.1.1",
  "threadpool",
+]
+
+[[package]]
+name = "tikv-jemalloc-sys"
+version = "0.4.1+5.2.1-patched"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a26331b05179d4cb505c8d6814a7e18d298972f0a551b0e3cefccff927f86d3"
+dependencies = [
+ "cc",
+ "fs_extra",
+ "libc",
+]
+
+[[package]]
+name = "tikv-jemallocator"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c14a5a604eb8715bc5785018a37d00739b180bcf609916ddf4393d33d49ccdf"
+dependencies = [
+ "libc",
+ "tikv-jemalloc-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,6 +87,7 @@ serde_urlencoded = "0.7.0"
 snafu = "0.6.9"
 structopt = "0.3.21"
 thiserror = "1.0.23"
+tikv-jemallocator = "0.4.0"
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread", "parking_lot", "signal"] }
 tokio-stream = { version = "0.1.2", features = ["net"] }
 tokio-util = { version = "0.6.3" }

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,6 +17,8 @@ use tokio::runtime::Runtime;
 use commands::logging::LoggingLevel;
 use ingest::parquet::writer::CompressionLevel;
 
+use tikv_jemallocator::Jemalloc;
+
 mod commands {
     pub mod convert;
     pub mod database;
@@ -33,6 +35,9 @@ mod commands {
 }
 
 pub mod influxdb_ioxd;
+
+#[global_allocator]
+static GLOBAL: Jemalloc = Jemalloc;
 
 enum ReturnCode {
     Failure = 1,


### PR DESCRIPTION
jemalloc is a good allocator, which IIUC was the default in rust, but since it's not available on all the supported rust targets it is no longer default. Rust not supports choosing an allocator and thus users can choose whether to use jemalloc.

See https://internals.rust-lang.org/t/jemalloc-was-just-removed-from-the-standard-library/8759