### PR TITLE
feat: add sequenced entry builder

### DIFF
--- a/generated_types/protos/influxdata/iox/write/v1/entry.fbs
+++ b/generated_types/protos/influxdata/iox/write/v1/entry.fbs
@@ -156,4 +156,5 @@ table SequencedEntry {
   clock_value: uint64;
   writer_id: uint32;
   entry: Entry;
+  entry_bytes: [ubyte];
 }

--- a/generated_types/protos/influxdata/iox/write/v1/entry.fbs
+++ b/generated_types/protos/influxdata/iox/write/v1/entry.fbs
@@ -155,6 +155,9 @@ table Segment {
 table SequencedEntry {
   clock_value: uint64;
   writer_id: uint32;
-  entry: Entry;
+  // The raw bytes for an Entry flatbuffers. Because we can't build the SequencedEntry
+  // Flatbuffers from the bytes of an Entry, we do this to avoid reconstructing the
+  // whole thing. See for the examples and a little context on it:
+  // https://github.com/influxdata/influxdb_iox/pull/1149
   entry_bytes: [ubyte];
 }

--- a/generated_types/src/entry_generated.rs
+++ b/generated_types/src/entry_generated.rs
@@ -2501,17 +2501,13 @@ pub mod influxdata {
                         if let Some(x) = args.entry_bytes {
                             builder.add_entry_bytes(x);
                         }
-                        if let Some(x) = args.entry {
-                            builder.add_entry(x);
-                        }
                         builder.add_writer_id(args.writer_id);
                         builder.finish()
                     }
 
                     pub const VT_CLOCK_VALUE: flatbuffers::VOffsetT = 4;
                     pub const VT_WRITER_ID: flatbuffers::VOffsetT = 6;
-                    pub const VT_ENTRY: flatbuffers::VOffsetT = 8;
-                    pub const VT_ENTRY_BYTES: flatbuffers::VOffsetT = 10;
+                    pub const VT_ENTRY_BYTES: flatbuffers::VOffsetT = 8;
 
                     #[inline]
                     pub fn clock_value(&self) -> u64 {
@@ -2524,13 +2520,6 @@ pub mod influxdata {
                         self._tab
                             .get::<u32>(SequencedEntry::VT_WRITER_ID, Some(0))
                             .unwrap()
-                    }
-                    #[inline]
-                    pub fn entry(&self) -> Option<Entry<'a>> {
-                        self._tab.get::<flatbuffers::ForwardsUOffset<Entry>>(
-                            SequencedEntry::VT_ENTRY,
-                            None,
-                        )
                     }
                     #[inline]
                     pub fn entry_bytes(&self) -> Option<&'a [u8]> {
@@ -2553,7 +2542,6 @@ pub mod influxdata {
                         v.visit_table(pos)?
      .visit_field::<u64>(&"clock_value", Self::VT_CLOCK_VALUE, false)?
      .visit_field::<u32>(&"writer_id", Self::VT_WRITER_ID, false)?
-     .visit_field::<flatbuffers::ForwardsUOffset<Entry>>(&"entry", Self::VT_ENTRY, false)?
      .visit_field::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'_, u8>>>(&"entry_bytes", Self::VT_ENTRY_BYTES, false)?
      .finish();
                         Ok(())
@@ -2562,7 +2550,6 @@ pub mod influxdata {
                 pub struct SequencedEntryArgs<'a> {
                     pub clock_value: u64,
                     pub writer_id: u32,
-                    pub entry: Option<flatbuffers::WIPOffset<Entry<'a>>>,
                     pub entry_bytes: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, u8>>>,
                 }
                 impl<'a> Default for SequencedEntryArgs<'a> {
@@ -2571,7 +2558,6 @@ pub mod influxdata {
                         SequencedEntryArgs {
                             clock_value: 0,
                             writer_id: 0,
-                            entry: None,
                             entry_bytes: None,
                         }
                     }
@@ -2590,13 +2576,6 @@ pub mod influxdata {
                     pub fn add_writer_id(&mut self, writer_id: u32) {
                         self.fbb_
                             .push_slot::<u32>(SequencedEntry::VT_WRITER_ID, writer_id, 0);
-                    }
-                    #[inline]
-                    pub fn add_entry(&mut self, entry: flatbuffers::WIPOffset<Entry<'b>>) {
-                        self.fbb_.push_slot_always::<flatbuffers::WIPOffset<Entry>>(
-                            SequencedEntry::VT_ENTRY,
-                            entry,
-                        );
                     }
                     #[inline]
                     pub fn add_entry_bytes(
@@ -2630,7 +2609,6 @@ pub mod influxdata {
                         let mut ds = f.debug_struct("SequencedEntry");
                         ds.field("clock_value", &self.clock_value());
                         ds.field("writer_id", &self.writer_id());
-                        ds.field("entry", &self.entry());
                         ds.field("entry_bytes", &self.entry_bytes());
                         ds.finish()
                     }

--- a/generated_types/src/entry_generated.rs
+++ b/generated_types/src/entry_generated.rs
@@ -2498,6 +2498,9 @@ pub mod influxdata {
                     ) -> flatbuffers::WIPOffset<SequencedEntry<'bldr>> {
                         let mut builder = SequencedEntryBuilder::new(_fbb);
                         builder.add_clock_value(args.clock_value);
+                        if let Some(x) = args.entry_bytes {
+                            builder.add_entry_bytes(x);
+                        }
                         if let Some(x) = args.entry {
                             builder.add_entry(x);
                         }
@@ -2508,6 +2511,7 @@ pub mod influxdata {
                     pub const VT_CLOCK_VALUE: flatbuffers::VOffsetT = 4;
                     pub const VT_WRITER_ID: flatbuffers::VOffsetT = 6;
                     pub const VT_ENTRY: flatbuffers::VOffsetT = 8;
+                    pub const VT_ENTRY_BYTES: flatbuffers::VOffsetT = 10;
 
                     #[inline]
                     pub fn clock_value(&self) -> u64 {
@@ -2528,6 +2532,15 @@ pub mod influxdata {
                             None,
                         )
                     }
+                    #[inline]
+                    pub fn entry_bytes(&self) -> Option<&'a [u8]> {
+                        self._tab
+                            .get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'a, u8>>>(
+                                SequencedEntry::VT_ENTRY_BYTES,
+                                None,
+                            )
+                            .map(|v| v.safe_slice())
+                    }
                 }
 
                 impl flatbuffers::Verifiable for SequencedEntry<'_> {
@@ -2538,14 +2551,11 @@ pub mod influxdata {
                     ) -> Result<(), flatbuffers::InvalidFlatbuffer> {
                         use self::flatbuffers::Verifiable;
                         v.visit_table(pos)?
-                            .visit_field::<u64>(&"clock_value", Self::VT_CLOCK_VALUE, false)?
-                            .visit_field::<u32>(&"writer_id", Self::VT_WRITER_ID, false)?
-                            .visit_field::<flatbuffers::ForwardsUOffset<Entry>>(
-                                &"entry",
-                                Self::VT_ENTRY,
-                                false,
-                            )?
-                            .finish();
+     .visit_field::<u64>(&"clock_value", Self::VT_CLOCK_VALUE, false)?
+     .visit_field::<u32>(&"writer_id", Self::VT_WRITER_ID, false)?
+     .visit_field::<flatbuffers::ForwardsUOffset<Entry>>(&"entry", Self::VT_ENTRY, false)?
+     .visit_field::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'_, u8>>>(&"entry_bytes", Self::VT_ENTRY_BYTES, false)?
+     .finish();
                         Ok(())
                     }
                 }
@@ -2553,6 +2563,7 @@ pub mod influxdata {
                     pub clock_value: u64,
                     pub writer_id: u32,
                     pub entry: Option<flatbuffers::WIPOffset<Entry<'a>>>,
+                    pub entry_bytes: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, u8>>>,
                 }
                 impl<'a> Default for SequencedEntryArgs<'a> {
                     #[inline]
@@ -2561,6 +2572,7 @@ pub mod influxdata {
                             clock_value: 0,
                             writer_id: 0,
                             entry: None,
+                            entry_bytes: None,
                         }
                     }
                 }
@@ -2587,6 +2599,16 @@ pub mod influxdata {
                         );
                     }
                     #[inline]
+                    pub fn add_entry_bytes(
+                        &mut self,
+                        entry_bytes: flatbuffers::WIPOffset<flatbuffers::Vector<'b, u8>>,
+                    ) {
+                        self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(
+                            SequencedEntry::VT_ENTRY_BYTES,
+                            entry_bytes,
+                        );
+                    }
+                    #[inline]
                     pub fn new(
                         _fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>,
                     ) -> SequencedEntryBuilder<'a, 'b> {
@@ -2609,6 +2631,7 @@ pub mod influxdata {
                         ds.field("clock_value", &self.clock_value());
                         ds.field("writer_id", &self.writer_id());
                         ds.field("entry", &self.entry());
+                        ds.field("entry_bytes", &self.entry_bytes());
                         ds.finish()
                     }
                 }

--- a/internal_types/benches/benchmark.rs
+++ b/internal_types/benches/benchmark.rs
@@ -1,391 +1,90 @@
-use criterion::measurement::WallTime;
-use criterion::{criterion_group, criterion_main, Bencher, BenchmarkId, Criterion, Throughput};
-use data_types::database_rules::{PartitionTemplate, TemplatePart};
-use generated_types::wal as wb;
-use influxdb_line_protocol::{parse_lines, ParsedLine};
-use internal_types::data::{lines_to_replicated_write as lines_to_rw, ReplicatedWrite};
-use std::{
-    collections::{BTreeMap, BTreeSet},
-    convert::TryFrom,
-    fmt,
-    time::Duration,
-};
+use chrono::{DateTime, Utc};
+use criterion::{criterion_group, criterion_main, Criterion};
+use data_types::database_rules::{Error as DataError, Partitioner, Sharder};
+use influxdb_line_protocol::ParsedLine;
+use internal_types::entry::{lines_to_sharded_entries, SequencedEntry};
 
-const NEXT_ENTRY_NS: i64 = 1_000_000_000;
-const STARTING_TIMESTAMP_NS: i64 = 0;
+static LINES: &str = include_str!("../../tests/fixtures/lineproto/prometheus.lp");
 
-#[derive(Debug)]
-struct Config {
-    // total number of rows written in, regardless of the number of partitions
-    line_count: usize,
-    // this will be the number of write buffer entries per replicated write
-    partition_count: usize,
-    // the number of tables (measurements) in each replicated write
-    table_count: usize,
-    // the number of unique tag values for the tag in each replicated write
-    tag_cardinality: usize,
-}
+fn sequenced_entry(c: &mut Criterion) {
+    let mut group = c.benchmark_group("sequenced_entry_generator");
 
-impl Config {
-    fn lines_per_partition(&self) -> usize {
-        self.line_count / self.partition_count
-    }
-}
-
-impl fmt::Display for Config {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(
-            f,
-            "lines: {} ({} per partition) | partitions: {} | tables per: {} | unique tag values per: {}",
-            self.line_count,
-            self.lines_per_partition(),
-            self.partition_count,
-            self.table_count,
-            self.tag_cardinality
-        )
-    }
-}
-
-fn lines_to_replicated_write(c: &mut Criterion) {
-    run_group("lines_to_replicated_write", c, |lines, rules, config, b| {
-        b.iter(|| {
-            let write = lines_to_rw(0, 0, &lines, rules);
-            assert_eq!(write.entry_count(), config.partition_count);
-        });
-    });
-}
-
-fn replicated_write_into_bytes(c: &mut Criterion) {
-    run_group(
-        "replicated_write_into_bytes",
-        c,
-        |lines, rules, config, b| {
-            let write = lines_to_rw(0, 0, &lines, rules);
-            assert_eq!(write.entry_count(), config.partition_count);
-
-            b.iter(|| {
-                let _ = write.data().len();
-            });
-        },
+    let lines = influxdb_line_protocol::parse_lines(LINES)
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap();
+    let sharded_entries = lines_to_sharded_entries(&lines, &sharder(1), &partitioner(1)).unwrap();
+    let entry = &sharded_entries.first().unwrap().entry;
+    assert_eq!(
+        entry
+            .partition_writes()
+            .unwrap()
+            .first()
+            .unwrap()
+            .table_batches()
+            .first()
+            .unwrap()
+            .row_count(),
+        554
     );
-}
 
-// simulates the speed of marshalling the bytes into something like the mutable
-// buffer or read buffer, which won't use the replicated write structure anyway
-fn bytes_into_struct(c: &mut Criterion) {
-    run_group("bytes_into_struct", c, |lines, rules, config, b| {
-        let write = lines_to_rw(0, 0, &lines, rules);
-        assert_eq!(write.entry_count(), config.partition_count);
-        let data = write.data();
-
+    group.bench_function("new_from_entry", |b| {
         b.iter(|| {
-            let mut db = Db::default();
-            db.deserialize_write(data);
-            assert_eq!(db.partition_count(), config.partition_count);
-            assert_eq!(db.row_count(), config.line_count);
-            assert_eq!(db.measurement_count(), config.table_count);
-            assert_eq!(db.tag_cardinality(), config.tag_cardinality);
-        });
+            let sequenced_entry = SequencedEntry::new_from_entry(23, 2, entry).unwrap();
+            assert_eq!(sequenced_entry.clock_value(), 23);
+            assert_eq!(sequenced_entry.writer_id(), 2);
+        })
     });
-}
-
-fn run_group(
-    group_name: &str,
-    c: &mut Criterion,
-    bench: impl Fn(&[ParsedLine], &PartitionTemplate, &Config, &mut Bencher<WallTime>),
-) {
-    let mut group = c.benchmark_group(group_name);
-    group.sample_size(50);
-    group.measurement_time(Duration::from_secs(10));
-    let template = partition_time();
-
-    for partition_count in [1, 100].iter() {
-        let config = Config {
-            line_count: 1_000,
-            partition_count: *partition_count,
-            table_count: 1,
-            tag_cardinality: 1,
-        };
-        let id = BenchmarkId::new("partition count", config.partition_count);
-        group.throughput(Throughput::Elements(config.line_count as u64));
-
-        let lp = create_lp(&config);
-        let lines: Vec<_> = parse_lines(&lp).map(|l| l.unwrap()).collect();
-
-        group.bench_with_input(id, &config, |b, config| {
-            bench(&lines, &template, &config, b);
-        });
-    }
-
-    for table_count in [1, 100].iter() {
-        let config = Config {
-            line_count: 1_000,
-            partition_count: 1,
-            table_count: *table_count,
-            tag_cardinality: 1,
-        };
-        let id = BenchmarkId::new("table count", config.table_count);
-        group.throughput(Throughput::Elements(config.line_count as u64));
-
-        let lp = create_lp(&config);
-        let lines: Vec<_> = parse_lines(&lp).map(|l| l.unwrap()).collect();
-
-        group.bench_with_input(id, &config, |b, config| {
-            bench(&lines, &template, &config, b);
-        });
-    }
-
-    for tag_cardinality in [1, 100].iter() {
-        let config = Config {
-            line_count: 1_000,
-            partition_count: 1,
-            table_count: 1,
-            tag_cardinality: *tag_cardinality,
-        };
-        let id = BenchmarkId::new("tag cardinality", config.tag_cardinality);
-        group.throughput(Throughput::Elements(config.line_count as u64));
-
-        let lp = create_lp(&config);
-        let lines: Vec<_> = parse_lines(&lp).map(|l| l.unwrap()).collect();
-
-        group.bench_with_input(id, &config, |b, config| {
-            bench(&lines, &template, &config, b);
-        });
-    }
 
     group.finish();
 }
 
-#[derive(Default)]
-struct Db {
-    partitions: BTreeMap<String, Partition>,
-}
-
-impl Db {
-    fn deserialize_write(&mut self, data: &[u8]) {
-        let write = ReplicatedWrite::try_from(data.to_vec()).unwrap();
-
-        if let Some(batch) = write.write_buffer_batch() {
-            if let Some(entries) = batch.entries() {
-                for entry in entries {
-                    let key = entry.partition_key().unwrap();
-
-                    if self.partitions.get(key).is_none() {
-                        self.partitions
-                            .insert(key.to_string(), Partition::default());
-                    }
-                    let partition = self.partitions.get_mut(key).unwrap();
-
-                    if let Some(tables) = entry.table_batches() {
-                        for table_fb in tables {
-                            let table_name = table_fb.name().unwrap();
-
-                            if partition.tables.get(table_name).is_none() {
-                                let table = Table {
-                                    name: table_name.to_string(),
-                                    ..Default::default()
-                                };
-                                partition.tables.insert(table_name.to_string(), table);
-                            }
-                            let table = partition.tables.get_mut(table_name).unwrap();
-
-                            if let Some(rows) = table_fb.rows() {
-                                for row_fb in rows {
-                                    if let Some(values) = row_fb.values() {
-                                        let mut row = Row {
-                                            values: Vec::with_capacity(values.len()),
-                                        };
-
-                                        for value in values {
-                                            let column_name = value.column().unwrap();
-
-                                            if partition.dict.get(column_name).is_none() {
-                                                partition.dict.insert(
-                                                    column_name.to_string(),
-                                                    partition.dict.len(),
-                                                );
-                                            }
-                                            let column_index =
-                                                *partition.dict.get(column_name).unwrap();
-
-                                            let val = match value.value_type() {
-                                                wb::ColumnValue::TagValue => {
-                                                    let tag = value
-                                                        .value_as_tag_value()
-                                                        .unwrap()
-                                                        .value()
-                                                        .unwrap();
-
-                                                    if partition.dict.get(tag).is_none() {
-                                                        partition.dict.insert(
-                                                            tag.to_string(),
-                                                            partition.dict.len(),
-                                                        );
-                                                    }
-                                                    let tag_index =
-                                                        *partition.dict.get(tag).unwrap();
-
-                                                    Value::Tag(tag_index)
-                                                }
-                                                wb::ColumnValue::F64Value => {
-                                                    let val =
-                                                        value.value_as_f64value().unwrap().value();
-
-                                                    Value::F64(val)
-                                                }
-                                                wb::ColumnValue::I64Value => {
-                                                    let val =
-                                                        value.value_as_i64value().unwrap().value();
-
-                                                    Value::I64(val)
-                                                }
-                                                _ => panic!("not supported!"),
-                                            };
-
-                                            let column_value = ColumnValue {
-                                                column_name_index: column_index,
-                                                value: val,
-                                            };
-
-                                            row.values.push(column_value);
-                                        }
-
-                                        table.rows.push(row);
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    fn partition_count(&self) -> usize {
-        self.partitions.len()
-    }
-
-    fn row_count(&self) -> usize {
-        let mut count = 0;
-
-        for p in self.partitions.values() {
-            for t in p.tables.values() {
-                count += t.rows.len();
-            }
-        }
-
-        count
-    }
-
-    fn tag_cardinality(&self) -> usize {
-        let mut tags = BTreeMap::new();
-
-        for p in self.partitions.values() {
-            for t in p.tables.values() {
-                for r in &t.rows {
-                    for v in &r.values {
-                        if let Value::Tag(idx) = &v.value {
-                            tags.insert(*idx, ());
-                        }
-                    }
-                }
-            }
-        }
-
-        tags.len()
-    }
-
-    fn measurement_count(&self) -> usize {
-        let mut measurements = BTreeSet::new();
-
-        for p in self.partitions.values() {
-            for t in p.tables.values() {
-                measurements.insert(t.name.to_string());
-            }
-        }
-
-        measurements.len()
-    }
-}
-
-#[derive(Default)]
-struct Partition {
-    dict: BTreeMap<String, usize>,
-    tables: BTreeMap<String, Table>,
-}
-
-#[derive(Default)]
-struct Table {
-    name: String,
-    rows: Vec<Row>,
-}
-
-struct Row {
-    values: Vec<ColumnValue>,
-}
-
-#[derive(Debug)]
-struct ColumnValue {
-    column_name_index: usize,
-    value: Value,
-}
-
-#[derive(Debug)]
-enum Value {
-    I64(i64),
-    F64(f64),
-    Tag(usize),
-}
-
-fn create_lp(config: &Config) -> String {
-    use std::fmt::Write;
-
-    let mut s = String::new();
-
-    let lines_per_partition = config.lines_per_partition();
-    assert!(
-        lines_per_partition >= config.table_count,
-        format!(
-            "can't fit {} unique tables (measurements) into partition with {} rows",
-            config.table_count, lines_per_partition
-        )
-    );
-    assert!(
-        lines_per_partition >= config.tag_cardinality,
-        format!(
-            "can't fit {} unique tags into partition with {} rows",
-            config.tag_cardinality, lines_per_partition
-        )
-    );
-
-    for line in 0..config.line_count {
-        let partition_number = line / lines_per_partition % config.partition_count;
-        let timestamp = STARTING_TIMESTAMP_NS + (partition_number as i64 * NEXT_ENTRY_NS);
-        let mn = line % config.table_count;
-        let tn = line % config.tag_cardinality;
-        writeln!(
-            s,
-            "processes-{mn},host=my.awesome.computer.example.com-{tn} blocked=0i,zombies=0i,stopped=0i,running=42i,sleeping=999i,total=1041i,unknown=0i,idle=0i {timestamp}",
-            mn = mn,
-            tn = tn,
-            timestamp = timestamp,
-        ).unwrap();
-    }
-
-    s
-}
-
-fn partition_time() -> PartitionTemplate {
-    PartitionTemplate {
-        parts: vec![TemplatePart::TimeFormat("%Y-%m-%d %H:%M:%S".to_string())],
-    }
-}
-
-criterion_group!(
-    benches,
-    lines_to_replicated_write,
-    replicated_write_into_bytes,
-    bytes_into_struct,
-);
+criterion_group!(benches, sequenced_entry);
 
 criterion_main!(benches);
+
+fn sharder(count: u16) -> TestSharder {
+    TestSharder {
+        count,
+        n: std::cell::RefCell::new(0),
+    }
+}
+
+// For each line passed to shard returns a shard id from [0, count) in order
+struct TestSharder {
+    count: u16,
+    n: std::cell::RefCell<u16>,
+}
+
+impl Sharder for TestSharder {
+    fn shard(&self, _line: &ParsedLine<'_>) -> Result<u16, DataError> {
+        let n = *self.n.borrow();
+        self.n.replace(n + 1);
+        Ok(n % self.count)
+    }
+}
+
+fn partitioner(count: u8) -> TestPartitioner {
+    TestPartitioner {
+        count,
+        n: std::cell::RefCell::new(0),
+    }
+}
+
+// For each line passed to partition_key returns a key with a number from [0,
+// count)
+struct TestPartitioner {
+    count: u8,
+    n: std::cell::RefCell<u8>,
+}
+
+impl Partitioner for TestPartitioner {
+    fn partition_key(
+        &self,
+        _line: &ParsedLine<'_>,
+        _default_time: &DateTime<Utc>,
+    ) -> data_types::database_rules::Result<String> {
+        let n = *self.n.borrow();
+        self.n.replace(n + 1);
+        Ok(format!("key_{}", n % self.count))
+    }
+}

--- a/internal_types/benches/benchmark.rs
+++ b/internal_types/benches/benchmark.rs
@@ -2,7 +2,7 @@ use chrono::{DateTime, Utc};
 use criterion::{criterion_group, criterion_main, Criterion};
 use data_types::database_rules::{Error as DataError, Partitioner, Sharder};
 use influxdb_line_protocol::ParsedLine;
-use internal_types::entry::{lines_to_sharded_entries, SequencedEntry, SequencedEntryRaw};
+use internal_types::entry::{lines_to_sharded_entries, SequencedEntry};
 
 static LINES: &str = include_str!("../../tests/fixtures/lineproto/prometheus.lp");
 
@@ -28,17 +28,9 @@ fn sequenced_entry(c: &mut Criterion) {
         554
     );
 
-    group.bench_function("new_from_entry", |b| {
-        b.iter(|| {
-            let sequenced_entry = SequencedEntry::new_from_entry(23, 2, entry).unwrap();
-            assert_eq!(sequenced_entry.clock_value(), 23);
-            assert_eq!(sequenced_entry.writer_id(), 2);
-        })
-    });
-
     group.bench_function("new_from_entry_bytes", |b| {
         b.iter(|| {
-            let sequenced_entry = SequencedEntryRaw::new_from_entry_bytes(23, 2, data).unwrap();
+            let sequenced_entry = SequencedEntry::new_from_entry_bytes(23, 2, data).unwrap();
             assert_eq!(sequenced_entry.clock_value(), 23);
             assert_eq!(sequenced_entry.writer_id(), 2);
         })

--- a/internal_types/src/entry.rs
+++ b/internal_types/src/entry.rs
@@ -11,7 +11,7 @@ use std::{collections::BTreeMap, convert::TryFrom};
 use chrono::{DateTime, Utc};
 use flatbuffers::{FlatBufferBuilder, Follow, ForwardsUOffset, Vector, VectorIter, WIPOffset};
 use ouroboros::self_referencing;
-use snafu::{ResultExt, Snafu};
+use snafu::{OptionExt, ResultExt, Snafu};
 use std::fmt::Formatter;
 
 #[derive(Debug, Snafu)]
@@ -35,6 +35,9 @@ pub enum Error {
         line_number: usize,
         source: ColumnError,
     },
+
+    #[snafu(display("invalid flatbuffers: field {} is required", field))]
+    FlatbufferFieldMissing { field: String },
 }
 
 #[derive(Debug, Snafu)]
@@ -1079,6 +1082,253 @@ enum ColumnRaw<'a> {
     Bool(Vec<bool>),
 }
 
+#[self_referencing]
+#[derive(Debug)]
+pub struct SequencedEntry {
+    data: Vec<u8>,
+    #[borrows(data)]
+    #[covariant]
+    fb: entry_fb::SequencedEntry<'this>,
+}
+
+impl SequencedEntry {
+    pub fn new_from_entry(clock_value: u64, writer_id: u32, entry: &Entry) -> Result<Self> {
+        let mut fbb = FlatBufferBuilder::new_with_capacity(1024);
+
+        let entry = match entry.fb().operation_type() {
+            entry_fb::Operation::write => {
+                let partition_writes =
+                    entry.partition_writes().context(FlatbufferFieldMissing {
+                        field: "partition writes",
+                    })?;
+
+                let partition_writes = partition_writes.iter().map(|w|{
+                        let table_batches = w.table_batches().iter().map(|t| {
+                            let columns = t.columns().iter().map(|c| {
+                                let null_mask = c.fb.null_mask().map(|n| {
+                                    fbb.create_vector_direct(n)
+                                });
+
+                                let name = fbb.create_string(c.fb.name().context(FlatbufferFieldMissing{field: "column name"})?);
+
+                                let values = match c.fb.values_type() {
+                                    entry_fb::ColumnValues::StringValues => {
+                                        let values = c
+                                            .fb
+                                            .values_as_string_values()
+                                            .expect("invalid flatbuffers")
+                                            .values()
+                                            .expect("flatbuffers StringValues must have string values set")
+                                            .iter()
+                                            .map(|v| fbb.create_string(v))
+                                            .collect::<Vec<_>>();
+                                        let values = fbb.create_vector(&values);
+
+                                        let values = entry_fb::StringValues::create(
+                                            &mut fbb,
+                                            &entry_fb::StringValuesArgs{
+                                                values: Some(values),
+                                            },
+                                        );
+
+                                        values.as_union_value()
+                                    },
+                                    entry_fb::ColumnValues::I64Values => {
+                                        let values = c
+                                            .fb
+                                            .values_as_i64values()
+                                            .expect("invalid flatbuffers")
+                                            .values()
+                                            .expect("flatbuffers I64Values must have i64 values set")
+                                            .iter()
+                                            .collect::<Vec<_>>();
+                                        let values = fbb.create_vector(&values);
+
+                                        let values = entry_fb::I64Values::create(
+                                            &mut fbb,
+                                            &entry_fb::I64ValuesArgs{
+                                                values: Some(values),
+                                            }
+                                        );
+
+                                        values.as_union_value()
+                                    },
+                                    entry_fb::ColumnValues::F64Values => {
+                                        let values = c
+                                            .fb
+                                            .values_as_f64values()
+                                            .expect("invalid flatbuffers")
+                                            .values()
+                                            .expect("flatbuffers F64Values must have f64 values set")
+                                            .iter()
+                                            .collect::<Vec<_>>();
+                                        let values = fbb.create_vector(&values);
+
+                                        let values = entry_fb::F64Values::create(
+                                            &mut fbb,
+                                            &entry_fb::F64ValuesArgs{
+                                                values: Some(values),
+                                            }
+                                        );
+
+                                        values.as_union_value()
+                                    },
+                                    entry_fb::ColumnValues::U64Values => {
+                                        let values = c
+                                            .fb
+                                            .values_as_u64values()
+                                            .expect("invalid flatbuffers")
+                                            .values()
+                                            .expect("flatbuffers U64Values must have u64 values set")
+                                            .iter()
+                                            .collect::<Vec<_>>();
+                                        let values = fbb.create_vector(&values);
+
+                                        let values = entry_fb::U64Values::create(
+                                            &mut fbb,
+                                            &entry_fb::U64ValuesArgs{
+                                                values: Some(values),
+                                            }
+                                        );
+
+                                        values.as_union_value()
+                                    },
+                                    entry_fb::ColumnValues::BoolValues => {
+                                        let values = c
+                                            .fb
+                                            .values_as_bool_values()
+                                            .expect("invalid flatbuffers")
+                                            .values()
+                                            .expect("flatbuffers BoolValues must have bool values set")
+                                            .iter()
+                                            .copied()
+                                            .collect::<Vec<_>>();
+                                        let values = fbb.create_vector(&values);
+
+                                        let values = entry_fb::BoolValues::create(
+                                            &mut fbb,
+                                            &entry_fb::BoolValuesArgs{
+                                                values: Some(values),
+                                            }
+                                        );
+
+                                        values.as_union_value()
+                                    }
+                                    _ => panic!("unsupported column"),
+                                };
+
+                                Ok(entry_fb::Column::create(
+                                    &mut fbb,
+                                    &entry_fb::ColumnArgs{
+                                        name: Some(name),
+                                        logical_column_type: c.fb.logical_column_type(),
+                                        values_type: c.fb.values_type(),
+                                        values: Some(values),
+                                        null_mask,
+                                    }
+                                ))
+                            }).collect::<Result<Vec<_>>>()?;
+                            let columns = fbb.create_vector(&columns);
+
+                            let table_name = fbb.create_string(t.name().context(FlatbufferFieldMissing{field: "table name"})?);
+
+                            Ok(entry_fb::TableWriteBatch::create(
+                                &mut fbb,
+                                &entry_fb::TableWriteBatchArgs{
+                                    name: Some(table_name),
+                                    columns: Some(columns),
+                                },
+                            ))
+                        }).collect::<Result<Vec<_>>>()?;
+                        let table_batches = fbb.create_vector(&table_batches);
+
+                        let key = fbb.create_string(w.key().context(FlatbufferFieldMissing{field: "partition key"})?);
+
+                        Ok(entry_fb::PartitionWrite::create(
+                            &mut fbb,
+                            &entry_fb::PartitionWriteArgs{
+                                key: Some(key),
+                                table_batches: Some(table_batches),
+                            }
+                        ))
+                    } ).collect::<Result<Vec<_>>>()?;
+                let partition_writes = fbb.create_vector(&partition_writes);
+
+                let write_operations = entry_fb::WriteOperations::create(
+                    &mut fbb,
+                    &entry_fb::WriteOperationsArgs {
+                        partition_writes: Some(partition_writes),
+                    },
+                );
+
+                entry_fb::Entry::create(
+                    &mut fbb,
+                    &entry_fb::EntryArgs {
+                        operation_type: entry_fb::Operation::write,
+                        operation: Some(write_operations.as_union_value()),
+                    },
+                )
+            }
+            _ => panic!("unsupported"),
+        };
+
+        let sequenced_entry = entry_fb::SequencedEntry::create(
+            &mut fbb,
+            &entry_fb::SequencedEntryArgs {
+                clock_value,
+                writer_id,
+                entry: Some(entry),
+            },
+        );
+
+        fbb.finish(sequenced_entry, None);
+
+        let (mut data, idx) = fbb.collapse();
+        let sequenced_entry = Self::try_from(data.split_off(idx))
+            .expect("Flatbuffer data just constructed should be valid");
+
+        Ok(sequenced_entry)
+    }
+
+    /// Returns the Flatbuffers struct for the SequencedEntry
+    pub fn fb(&self) -> &entry_fb::SequencedEntry<'_> {
+        self.borrow_fb()
+    }
+
+    pub fn partition_writes(&self) -> Option<Vec<PartitionWrite<'_>>> {
+        match self.fb().entry().as_ref() {
+            Some(e) => match e.operation_as_write().as_ref() {
+                Some(w) => w
+                    .partition_writes()
+                    .as_ref()
+                    .map(|w| w.iter().map(|fb| PartitionWrite { fb }).collect::<Vec<_>>()),
+                None => None,
+            },
+            None => None,
+        }
+    }
+
+    pub fn clock_value(&self) -> u64 {
+        self.fb().clock_value()
+    }
+
+    pub fn writer_id(&self) -> u32 {
+        self.fb().writer_id()
+    }
+}
+
+impl TryFrom<Vec<u8>> for SequencedEntry {
+    type Error = flatbuffers::InvalidFlatbuffer;
+
+    fn try_from(data: Vec<u8>) -> Result<Self, Self::Error> {
+        SequencedEntryTryBuilder {
+            data,
+            fb_builder: |data| flatbuffers::root::<entry_fb::SequencedEntry<'_>>(data),
+        }
+        .try_build()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1541,6 +1791,88 @@ mod tests {
         let sharded_entries = lines_to_sharded_entries(&lines, &sharder(1), &partitioner(1));
 
         assert!(sharded_entries.is_err());
+    }
+
+    #[test]
+    fn sequenced_entry() {
+        let lp = vec![
+            "a,host=a val=23i 983",
+            "a,host=a,region=west val2=23.2 2343",
+            "a val=21i,bool=true,string=\"hello\" 222",
+        ]
+        .join("\n");
+        let lines: Vec<_> = parse_lines(&lp).map(|l| l.unwrap()).collect();
+
+        let sharded_entries =
+            lines_to_sharded_entries(&lines, &sharder(1), &partitioner(1)).unwrap();
+
+        let sequenced_entry =
+            SequencedEntry::new_from_entry(23, 2, &sharded_entries.first().unwrap().entry).unwrap();
+        assert_eq!(sequenced_entry.clock_value(), 23);
+        assert_eq!(sequenced_entry.writer_id(), 2);
+
+        let partition_writes = sequenced_entry.partition_writes().unwrap();
+        let table_batches = partition_writes.first().unwrap().table_batches();
+        let batch = table_batches.first().unwrap();
+
+        let columns = batch.columns();
+
+        assert_eq!(batch.row_count(), 3);
+        assert_eq!(columns.len(), 7);
+
+        let col = columns.get(0).unwrap();
+        assert_eq!(col.name().unwrap(), "bool");
+        assert_eq!(col.logical_type(), entry_fb::LogicalColumnType::Field);
+        let values = col.values().bool_values().unwrap();
+        assert_eq!(&values, &[None, None, Some(true)]);
+
+        let col = columns.get(1).unwrap();
+        assert_eq!(col.name().unwrap(), "host");
+        assert_eq!(col.logical_type(), entry_fb::LogicalColumnType::Tag);
+        let values = match col.values() {
+            TypedValuesIterator::String(v) => v,
+            _ => panic!("wrong type"),
+        };
+        let values = values.collect::<Vec<_>>();
+        assert_eq!(&values, &[Some("a"), Some("a"), None]);
+
+        let col = columns.get(2).unwrap();
+        assert_eq!(col.name().unwrap(), "region");
+        assert_eq!(col.logical_type(), entry_fb::LogicalColumnType::Tag);
+        let values = match col.values() {
+            TypedValuesIterator::String(v) => v,
+            _ => panic!("wrong type"),
+        };
+        let values = values.collect::<Vec<_>>();
+        assert_eq!(&values, &[None, Some("west"), None]);
+
+        let col = columns.get(3).unwrap();
+        assert_eq!(col.name().unwrap(), "string");
+        assert_eq!(col.logical_type(), entry_fb::LogicalColumnType::Field);
+        let values = match col.values() {
+            TypedValuesIterator::String(v) => v,
+            _ => panic!("wrong type"),
+        };
+        let values = values.collect::<Vec<_>>();
+        assert_eq!(&values, &[None, None, Some("hello")]);
+
+        let col = columns.get(4).unwrap();
+        assert_eq!(col.name().unwrap(), TIME_COLUMN_NAME);
+        assert_eq!(col.logical_type(), entry_fb::LogicalColumnType::Time);
+        let values = col.values().i64_values().unwrap();
+        assert_eq!(&values, &[Some(983), Some(2343), Some(222)]);
+
+        let col = columns.get(5).unwrap();
+        assert_eq!(col.name().unwrap(), "val");
+        assert_eq!(col.logical_type(), entry_fb::LogicalColumnType::Field);
+        let values = col.values().i64_values().unwrap();
+        assert_eq!(&values, &[Some(23), None, Some(21)]);
+
+        let col = columns.get(6).unwrap();
+        assert_eq!(col.name().unwrap(), "val2");
+        assert_eq!(col.logical_type(), entry_fb::LogicalColumnType::Field);
+        let values = col.values().f64_values().unwrap();
+        assert_eq!(&values, &[None, Some(23.2), None]);
     }
 
     fn sharder(count: u16) -> TestSharder {


### PR DESCRIPTION
This PR adds a builder and wrapper type for SequencedEntry. I've broken it out into 4 commits to do a little testing along the way and it might be useful to look at this in that order.

First, I implemented the builder as the flatbuffer was constructed: 0c4baa49d04c48b68b829f683c09d3a1022e0f54

That looked ugly to me and I was worried about rebuilding the flatbuffer being wasteful so I decided I'd try it out with the Entry in SequencedEntry just being a raw byte array of the previously built Entry flatbuffer. So I created a benchmark to see how long a SequencedEntry would take to construct: a5be1470eedcedb30bd3c01ed2ff0ffc5ed678b4

And then I added a new SequencedEntryRaw type and updated the flatbuffer so I could have the raw entry bytes: 0ecb379c4e0483573e1d234f5a937d8abae10fa9.

And finally I added a benchmark for the SequencedEntryRaw: 2f2905356c16271195bb0139e0225eb15b6f66a1.

Here's the output of running the benchmark:
```
sequenced_entry_generator/new_from_entry                                                                            
                        time:   [247.97 us 250.69 us 253.63 us]
                        change: [-1.7851% -0.0255% +1.6474%] (p = 0.98 > 0.05)
                        No change in performance detected.
Found 11 outliers among 100 measurements (11.00%)
  7 (7.00%) high mild
  4 (4.00%) high severe
sequenced_entry_generator/new_from_entry_bytes                                                                            
                        time:   [105.01 us 106.15 us 107.50 us]
                        change: [-1.1096% +0.6083% +2.2616%] (p = 0.49 > 0.05)
                        No change in performance detected.
Found 11 outliers among 100 measurements (11.00%)
  1 (1.00%) low mild
  5 (5.00%) high mild
  5 (5.00%) high severe
```

The raw builder is definitely faster, but I'm not sure how much that difference matters. In our infrastructure, only the first Write Buffer server to receive the replicated Entry will have to build this SequencedEntry. The other Write Buffer servers will just receive the SequencedEntry flatbuffer bytes.

Thoughts or preference on what to go with? I'll clean up this PR based on that and any additional feedback.