### PR TITLE
fix: Don't be as clever in the flatbuffer checking

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -166,7 +166,7 @@ jobs:
       - checkout
       - run:
           name: Check Flatbuffers
-          command: ./generated_types/check-flatbuffers.sh << pipeline.git.base_revision >> <<pipeline.git.revision>>
+          command: ./generated_types/check-flatbuffers.sh
 
   # Compile a cargo "release" profile binary for branches that end in `/perf`
   #

--- a/docker/Dockerfile.ci
+++ b/docker/Dockerfile.ci
@@ -23,11 +23,16 @@ RUN apt-get update \
   && apt-get install -y \
     git locales sudo openssh-client ca-certificates tar gzip parallel \
     unzip zip bzip2 gnupg curl make pkg-config libssl-dev \
-    jq clang lld \
+    jq clang lld g++ \
     --no-install-recommends \
   && apt-get clean autoclean \
 	&& apt-get autoremove --yes \
 	&& rm -rf /var/lib/{apt,dpkg,cache,log}
+
+# Install bazel using the binary installer to enable building of flatc in the flatbuffers check
+RUN curl -Lo bazel-4.0.0-installer-linux-x86_64.sh https://github.com/bazelbuild/bazel/releases/download/4.0.0/bazel-4.0.0-installer-linux-x86_64.sh
+RUN chmod +x bazel-4.0.0-installer-linux-x86_64.sh
+RUN ./bazel-4.0.0-installer-linux-x86_64.sh --user
 
 # Set timezone to UTC by default
 RUN ln -sf /usr/share/zoneinfo/Etc/UTC /etc/localtime

--- a/generated_types/check-flatbuffers.sh
+++ b/generated_types/check-flatbuffers.sh
@@ -1,44 +1,33 @@
 #!/bin/bash -eu
 
-BEFORE_SHA=$1
-AFTER_SHA=$2
-
 # Change to the generated_types crate directory, where this script is located
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 pushd $DIR
 
-echo "Checking for changes to fbs files between ${BEFORE_SHA} and ${AFTER_SHA}..."
+echo "Regenerating flatbuffers code..."
 
-FBS_CHANGES=$(git rev-list "${BEFORE_SHA}".."${AFTER_SHA}" "**/*.fbs" | wc -l)
+# Will move this to docker if it works
+sudo apt install g++
+curl -Lo bazel-4.0.0-installer-linux-x86_64.sh https://github.com/bazelbuild/bazel/releases/download/4.0.0/bazel-4.0.0-installer-linux-x86_64.sh
+ls -lrta
+chmod +x bazel-4.0.0-installer-linux-x86_64.sh
+./bazel-4.0.0-installer-linux-x86_64.sh --user
 
-if [[ $FBS_CHANGES -gt 0 ]]; then
-  echo "Changes to fbs files detected, regenerating flatbuffers code..."
+./regenerate-flatbuffers.sh
 
-  # Will move this to docker if it works
-  sudo apt install g++
-  curl -Lo bazel-4.0.0-installer-linux-x86_64.sh https://github.com/bazelbuild/bazel/releases/download/4.0.0/bazel-4.0.0-installer-linux-x86_64.sh
-  ls -lrta
-  chmod +x bazel-4.0.0-installer-linux-x86_64.sh
-  ./bazel-4.0.0-installer-linux-x86_64.sh --user
+echo "Checking for uncommitted changes..."
 
-  ./regenerate-flatbuffers.sh
-
-  echo "Checking for uncommitted changes..."
-
-  if ! git diff-index --quiet HEAD --; then
-    echo "git diff-index HEAD found:"
-    git diff-index HEAD --
-    echo "git diff found:"
-    git diff HEAD
-    echo "************************************************************"
-    echo "* Found uncommitted changes to generated flatbuffers code! *"
-    echo "* Please run \`generated_types/regenerate-flatbuffers.sh\`   *"
-    echo "* to regenerate the flatbuffers code and check it in!      *"
-    echo "************************************************************"
-    exit 1
-  else
-    echo "No uncommitted changes; this is fine."
-  fi
+if ! git diff-index --quiet HEAD --; then
+  echo "git diff-index HEAD found:"
+  git diff-index HEAD --
+  echo "git diff found:"
+  git diff HEAD
+  echo "************************************************************"
+  echo "* Found uncommitted changes to generated flatbuffers code! *"
+  echo "* Please run \`generated_types/regenerate-flatbuffers.sh\`   *"
+  echo "* to regenerate the flatbuffers code and check it in!      *"
+  echo "************************************************************"
+  exit 1
 else
-  echo "No changes to fbs files detected."
+  echo "No uncommitted changes; this is fine."
 fi

--- a/generated_types/check-flatbuffers.sh
+++ b/generated_types/check-flatbuffers.sh
@@ -17,9 +17,7 @@ chmod +x bazel-4.0.0-installer-linux-x86_64.sh
 
 echo "Checking for uncommitted changes..."
 
-if ! git diff-index --quiet HEAD --; then
-  echo "git diff-index HEAD found:"
-  git diff-index HEAD --
+if ! git diff --quiet HEAD --; then
   echo "git diff found:"
   git diff HEAD
   echo "************************************************************"

--- a/generated_types/check-flatbuffers.sh
+++ b/generated_types/check-flatbuffers.sh
@@ -26,6 +26,10 @@ if [[ $FBS_CHANGES -gt 0 ]]; then
   echo "Checking for uncommitted changes..."
 
   if ! git diff-index --quiet HEAD --; then
+    echo "git diff-index HEAD found:"
+    git diff-index HEAD --
+    echo "git diff found:"
+    git diff HEAD
     echo "************************************************************"
     echo "* Found uncommitted changes to generated flatbuffers code! *"
     echo "* Please run \`generated_types/regenerate-flatbuffers.sh\`   *"


### PR DESCRIPTION
Ok, there were a number of problems that surfaced when the flatbuffers checking got merged into main that I'm fixing now:

- If the script found changes that weren't checked in, it wouldn't show you what the changes were. Now, if there are changes, the script will run `git diff` without `--quiet` to show what it thinks changed.
- I was trying to only run the checks if the current PR changed the flatbuffers schemas. However, there isn't actually a way to do that-- Circle CI gives you the commit that was last run for that branch and the current commit for that branch. So if you push a commit that changes the flatbuffers but doesn't check in the changes, that'll fail, but if you push another commit to the same branch that *doesn't* change the flatbuffers schema, the checks won't run and that job will pass. And what's happening on master now is that a PR failed and then the next PR that was merged didn't make changes-- so it looks more like a flaky test than an actual failure. I think a better mode is to keep failing until someone fixes it, so I removed the check for if the schemas have changed and it'll just run every time now.
- For the purposes of testing, the script installs bazel every time it's run (and now it's getting run more often), so I added installing bazel to the Docker build which should get updated tonight and then we can stop doing that on every build tomorrow.
- The REAL problem that caused the failure on master is that `git diff-index` isn't only looking at the contents of the files, it also looks at the timestamps, which do change even if the contents don't change 😅 So don't do that, just use `git diff`.

I *think* this should fix everything 🤞🏻 