### PR TITLE
feat: Add edit_db_rules script

### DIFF
--- a/scripts/edit_db_rules
+++ b/scripts/edit_db_rules
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+#set -eu -o pipefail
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+usage() {
+  echo "$0 <host> <db_name>"
+  exit 1
+}
+
+grpcurl() {
+  "${SCRIPT_DIR}"/grpcurl "$@"
+}
+
+
+main() {
+  local host
+  host="${1:-}"
+  shift
+
+  if [ -z "${host}" ]; then
+    usage
+  fi
+
+  local db_name
+  db_name="${1:-}"
+  shift
+
+  if [ -z "${db_name}" ]; then
+    usage
+  fi
+
+  local tmp
+
+  cleanup() {
+    rm -rf "${tmp}"
+  }
+  trap cleanup EXIT
+
+  tmp="$(mktemp)"
+
+  local req
+  read -r -d '' req <<EOF
+    {"name": "${db_name}"}
+EOF
+
+  grpcurl -plaintext -d "${req}" "${host}" \
+    influxdata.iox.management.v1.ManagementService.GetDatabase \
+    > "${tmp}"
+
+  "${EDITOR:-vim}" "${tmp}"
+
+  grpcurl -plaintext -d @ "${host}" \
+    influxdata.iox.management.v1.ManagementService.UpdateDatabase \
+    < "${tmp}"
+
+}
+main "$@"

--- a/scripts/edit_db_rules
+++ b/scripts/edit_db_rules
@@ -2,6 +2,9 @@
 
 #set -eu -o pipefail
 
+# This is a simple shell script that uses the grpc API to edit the database rules on a remote
+# IOx server. It fetches the rules, spawns your default text editor, waits until your editor quits,
+# and then calls the update API with the results of your local edit.
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 usage() {


### PR DESCRIPTION
There are a few yaks to be shaven before we have a good CLI for editing database rules.

This is a simple shell script that uses the grpc API to edit the database rules on a remote
IOx server. It fetches the rules, spawns your default text editor, waits until your editor quits,
and then calls the update API with the results of your local edit.

(if you use emacs, there is a thing called emacsclient which knows how to block until you closed
the buffer in your main persistent emacs)
