### PR TITLE
refactor: lift chunk and table summaries out of DBChunk

### DIFF
--- a/query/src/lib.rs
+++ b/query/src/lib.rs
@@ -8,7 +8,7 @@
 
 use arrow_deps::datafusion::physical_plan::SendableRecordBatchStream;
 use async_trait::async_trait;
-use data_types::{chunk::ChunkSummary, partition_metadata::TableSummary};
+use data_types::chunk::ChunkSummary;
 use exec::{stringset::StringSet, Executor};
 use internal_types::{data::ReplicatedWrite, schema::Schema, selection::Selection};
 
@@ -61,9 +61,6 @@ pub trait PartitionChunk: Debug + Send + Sync {
     /// returns the Id of this chunk. Ids are unique within a
     /// particular partition.
     fn id(&self) -> u32;
-
-    /// returns summary information for every table in the chunk
-    fn table_summaries(&self) -> Vec<TableSummary>;
 
     /// Returns true if this chunk *might* have data that passes the
     /// predicate. If false is returned, this chunk can be

--- a/query/src/test.rs
+++ b/query/src/test.rs
@@ -345,10 +345,6 @@ impl PartitionChunk for TestChunk {
         self.id
     }
 
-    fn table_summaries(&self) -> Vec<data_types::partition_metadata::TableSummary> {
-        unimplemented!("Table summaries are not implemented for test chunk")
-    }
-
     fn read_filter(
         &self,
         table_name: &str,

--- a/server/src/snapshot.rs
+++ b/server/src/snapshot.rs
@@ -232,13 +232,12 @@ pub fn snapshot_chunk<T>(
     store: Arc<ObjectStore>,
     partition_key: &str,
     chunk: Arc<T>,
+    table_stats: Vec<TableSummary>,
     notify: Option<oneshot::Sender<()>>,
 ) -> Result<Arc<Snapshot<T>>>
 where
     T: Send + Sync + 'static + PartitionChunk,
 {
-    let table_stats = chunk.table_summaries();
-
     let snapshot = Snapshot::new(
         partition_key.to_string(),
         metadata_path,
@@ -304,6 +303,7 @@ mem,host=A,region=west used=45 1
         data_path.push_dir("data");
 
         let chunk = Arc::clone(&db.chunks("1970-01-01T00")[0]);
+        let table_summaries = db.table_summaries("1970-01-01T00", chunk.id());
 
         let snapshot = snapshot_chunk(
             metadata_path.clone(),
@@ -311,6 +311,7 @@ mem,host=A,region=west used=45 1
             Arc::clone(&store),
             "testaroo",
             chunk,
+            table_summaries,
             Some(tx),
         )
         .unwrap();


### PR DESCRIPTION
This lifts the table and chunk summarisation out of DBChunk (and by extension PartitionChunk) and into the catalog.

In the short term this removes the need to snapshot column statistics from the mutable buffer, and avoids some potential confusion as to whether methods like size() are the size of the snapshot or the snapshotted chunk.

Longer term, I think we will want to be lifting table statistics into the catalog anyway for immutable data in the read buffer, object storage, etc... so I think this change also makes sense in light of that