### PR TITLE
feat: Add shard_id to Entry

### DIFF
--- a/data_types/src/database_rules.rs
+++ b/data_types/src/database_rules.rs
@@ -742,7 +742,7 @@ impl TryFrom<management::partition_template::Part> for TemplatePart {
 }
 
 /// ShardId maps to a nodegroup that holds the the shard.
-pub type ShardId = u16;
+pub type ShardId = u32;
 
 /// Assigns a given line to a specific shard id.
 pub trait Sharder {

--- a/generated_types/protos/influxdata/iox/write/v1/entry.fbs
+++ b/generated_types/protos/influxdata/iox/write/v1/entry.fbs
@@ -37,6 +37,7 @@ table DeleteOperations {
 
 table Entry {
   operation: Operation;
+  shard_id: uint32;
 }
 
 // A write to a  partition. If the IOx server creating this PartitionWrite has

--- a/generated_types/regenerate-flatbuffers.sh
+++ b/generated_types/regenerate-flatbuffers.sh
@@ -3,7 +3,7 @@
 # The commit where the Rust `flatbuffers` crate version was changed to the version in `Cargo.lock`
 # Update this, rerun this script, and check in the changes in the generated code when the
 # `flatbuffers` crate version is updated.
-FB_COMMIT="261cf3b20473abdf95fc34da0827e4986f065c39"
+FB_COMMIT="86401e078d0746d2381735415f8c2dfe849f3f52"
 
 # Change to the generated_types crate directory, where this script is located
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"

--- a/generated_types/src/entry_generated.rs
+++ b/generated_types/src/entry_generated.rs
@@ -623,6 +623,7 @@ pub mod influxdata {
                         args: &'args EntryArgs,
                     ) -> flatbuffers::WIPOffset<Entry<'bldr>> {
                         let mut builder = EntryBuilder::new(_fbb);
+                        builder.add_shard_id(args.shard_id);
                         if let Some(x) = args.operation {
                             builder.add_operation(x);
                         }
@@ -632,6 +633,7 @@ pub mod influxdata {
 
                     pub const VT_OPERATION_TYPE: flatbuffers::VOffsetT = 4;
                     pub const VT_OPERATION: flatbuffers::VOffsetT = 6;
+                    pub const VT_SHARD_ID: flatbuffers::VOffsetT = 8;
 
                     #[inline]
                     pub fn operation_type(&self) -> Operation {
@@ -646,6 +648,10 @@ pub mod influxdata {
                                 Entry::VT_OPERATION,
                                 None,
                             )
+                    }
+                    #[inline]
+                    pub fn shard_id(&self) -> u32 {
+                        self._tab.get::<u32>(Entry::VT_SHARD_ID, Some(0)).unwrap()
                     }
                     #[inline]
                     #[allow(non_snake_case)]
@@ -683,6 +689,7 @@ pub mod influxdata {
           _ => Ok(()),
         }
      })?
+     .visit_field::<u32>(&"shard_id", Self::VT_SHARD_ID, false)?
      .finish();
                         Ok(())
                     }
@@ -690,6 +697,7 @@ pub mod influxdata {
                 pub struct EntryArgs {
                     pub operation_type: Operation,
                     pub operation: Option<flatbuffers::WIPOffset<flatbuffers::UnionWIPOffset>>,
+                    pub shard_id: u32,
                 }
                 impl<'a> Default for EntryArgs {
                     #[inline]
@@ -697,6 +705,7 @@ pub mod influxdata {
                         EntryArgs {
                             operation_type: Operation::NONE,
                             operation: None,
+                            shard_id: 0,
                         }
                     }
                 }
@@ -722,6 +731,10 @@ pub mod influxdata {
                             Entry::VT_OPERATION,
                             operation,
                         );
+                    }
+                    #[inline]
+                    pub fn add_shard_id(&mut self, shard_id: u32) {
+                        self.fbb_.push_slot::<u32>(Entry::VT_SHARD_ID, shard_id, 0);
                     }
                     #[inline]
                     pub fn new(
@@ -764,6 +777,7 @@ pub mod influxdata {
                                 ds.field("operation", &x)
                             }
                         };
+                        ds.field("shard_id", &self.shard_id());
                         ds.finish()
                     }
                 }

--- a/internal_types/benches/benchmark.rs
+++ b/internal_types/benches/benchmark.rs
@@ -1,6 +1,6 @@
 use chrono::{DateTime, Utc};
 use criterion::{criterion_group, criterion_main, Criterion};
-use data_types::database_rules::{Error as DataError, Partitioner, Sharder};
+use data_types::database_rules::{Error as DataError, Partitioner, ShardId, Sharder};
 use influxdb_line_protocol::ParsedLine;
 use internal_types::entry::{lines_to_sharded_entries, SequencedEntry};
 
@@ -43,7 +43,7 @@ criterion_group!(benches, sequenced_entry);
 
 criterion_main!(benches);
 
-fn sharder(count: u16) -> TestSharder {
+fn sharder(count: ShardId) -> TestSharder {
     TestSharder {
         count,
         n: std::cell::RefCell::new(0),
@@ -52,12 +52,12 @@ fn sharder(count: u16) -> TestSharder {
 
 // For each line passed to shard returns a shard id from [0, count) in order
 struct TestSharder {
-    count: u16,
-    n: std::cell::RefCell<u16>,
+    count: ShardId,
+    n: std::cell::RefCell<ShardId>,
 }
 
 impl Sharder for TestSharder {
-    fn shard(&self, _line: &ParsedLine<'_>) -> Result<u16, DataError> {
+    fn shard(&self, _line: &ParsedLine<'_>) -> Result<ShardId, DataError> {
         let n = *self.n.borrow();
         self.n.replace(n + 1);
         Ok(n % self.count)

--- a/internal_types/src/entry.rs
+++ b/internal_types/src/entry.rs
@@ -115,6 +115,7 @@ fn build_sharded_entry(
         &entry_fb::EntryArgs {
             operation_type: entry_fb::Operation::write,
             operation: Some(write_operations.as_union_value()),
+            shard_id,
         },
     );
 
@@ -1726,7 +1727,7 @@ mod tests {
         assert_eq!(&values, &[None, Some(23.2), None]);
     }
 
-    fn sharder(count: u16) -> TestSharder {
+    fn sharder(count: ShardId) -> TestSharder {
         TestSharder {
             count,
             n: std::cell::RefCell::new(0),
@@ -1735,12 +1736,12 @@ mod tests {
 
     // For each line passed to shard returns a shard id from [0, count) in order
     struct TestSharder {
-        count: u16,
-        n: std::cell::RefCell<u16>,
+        count: ShardId,
+        n: std::cell::RefCell<ShardId>,
     }
 
     impl Sharder for TestSharder {
-        fn shard(&self, _line: &ParsedLine<'_>) -> Result<u16, DataError> {
+        fn shard(&self, _line: &ParsedLine<'_>) -> Result<ShardId, DataError> {
             let n = *self.n.borrow();
             self.n.replace(n + 1);
             Ok(n % self.count)


### PR DESCRIPTION
Part of #1156

Also upped shardid to u32 to align it with the node id space; not really needed now but changing schemas with flatbuffers is a PITA; these 2 extra bytes per entry are not going to bankrupt us
