### PR TITLE
feat: Add tests for writing RB chunks to Object Store

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3274,6 +3274,7 @@ dependencies = [
  "serde_json",
  "snafu",
  "snap",
+ "tempfile",
  "test_helpers",
  "tokio",
  "tokio-util",

--- a/data_types/src/chunk.rs
+++ b/data_types/src/chunk.rs
@@ -21,8 +21,11 @@ pub enum ChunkStorage {
     /// The chunk is in the Read Buffer (where it can not be mutated)
     ReadBuffer,
 
+    /// The chunk is both in ReadBuffer and Object Store
+    ReadBufferAndObjectStore,
+
     /// The chunk is stored in Object Storage (where it can not be mutated)
-    ObjectStore,
+    ObjectStoreOnly,
 }
 
 impl ChunkStorage {
@@ -32,7 +35,8 @@ impl ChunkStorage {
             Self::OpenMutableBuffer => "OpenMutableBuffer",
             Self::ClosedMutableBuffer => "ClosedMutableBuffer",
             Self::ReadBuffer => "ReadBuffer",
-            Self::ObjectStore => "ObjectStore",
+            Self::ReadBufferAndObjectStore => "ReadBufferAndObjectStore",
+            Self::ObjectStoreOnly => "ObjectStoreOnly",
         }
     }
 }
@@ -134,7 +138,8 @@ impl From<ChunkStorage> for management::ChunkStorage {
             ChunkStorage::OpenMutableBuffer => Self::OpenMutableBuffer,
             ChunkStorage::ClosedMutableBuffer => Self::ClosedMutableBuffer,
             ChunkStorage::ReadBuffer => Self::ReadBuffer,
-            ChunkStorage::ObjectStore => Self::ObjectStore,
+            ChunkStorage::ReadBufferAndObjectStore => Self::ReadBufferAndObjectStore,
+            ChunkStorage::ObjectStoreOnly => Self::ObjectStoreOnly,
         }
     }
 }
@@ -204,7 +209,10 @@ impl TryFrom<management::ChunkStorage> for ChunkStorage {
             management::ChunkStorage::OpenMutableBuffer => Ok(Self::OpenMutableBuffer),
             management::ChunkStorage::ClosedMutableBuffer => Ok(Self::ClosedMutableBuffer),
             management::ChunkStorage::ReadBuffer => Ok(Self::ReadBuffer),
-            management::ChunkStorage::ObjectStore => Ok(Self::ObjectStore),
+            management::ChunkStorage::ReadBufferAndObjectStore => {
+                Ok(Self::ReadBufferAndObjectStore)
+            }
+            management::ChunkStorage::ObjectStoreOnly => Ok(Self::ObjectStoreOnly),
             management::ChunkStorage::Unspecified => Err(FieldViolation::required("")),
         }
     }
@@ -220,7 +228,7 @@ mod test {
             partition_key: "foo".to_string(),
             id: 42,
             estimated_bytes: 1234,
-            storage: management::ChunkStorage::ObjectStore.into(),
+            storage: management::ChunkStorage::ObjectStoreOnly.into(),
             time_of_first_write: None,
             time_of_last_write: None,
             time_closing: None,
@@ -231,7 +239,7 @@ mod test {
             partition_key: Arc::new("foo".to_string()),
             id: 42,
             estimated_bytes: 1234,
-            storage: ChunkStorage::ObjectStore,
+            storage: ChunkStorage::ObjectStoreOnly,
             time_of_first_write: None,
             time_of_last_write: None,
             time_closing: None,
@@ -250,7 +258,7 @@ mod test {
             partition_key: Arc::new("foo".to_string()),
             id: 42,
             estimated_bytes: 1234,
-            storage: ChunkStorage::ObjectStore,
+            storage: ChunkStorage::ObjectStoreOnly,
             time_of_first_write: None,
             time_of_last_write: None,
             time_closing: None,
@@ -262,7 +270,7 @@ mod test {
             partition_key: "foo".to_string(),
             id: 42,
             estimated_bytes: 1234,
-            storage: management::ChunkStorage::ObjectStore.into(),
+            storage: management::ChunkStorage::ObjectStoreOnly.into(),
             time_of_first_write: None,
             time_of_last_write: None,
             time_closing: None,

--- a/generated_types/protos/influxdata/iox/management/v1/chunk.proto
+++ b/generated_types/protos/influxdata/iox/management/v1/chunk.proto
@@ -17,8 +17,11 @@ enum ChunkStorage {
   // The chunk is in the Read Buffer (where it can not be mutated)
   CHUNK_STORAGE_READ_BUFFER = 3;
 
+  // The chunk is in the Read Buffer and Object Store
+  CHUNK_STORAGE_READ_BUFFER_AND_OBJECT_STORE = 4;
+
   // The chunk is stored in Object Storage (where it can not be mutated)
-  CHUNK_STORAGE_OBJECT_STORE = 4;
+  CHUNK_STORAGE_OBJECT_STORE_ONLY = 5;
 }
 
 // `Chunk` represents part of a partition of data in a database.

--- a/parquet_file/src/chunk.rs
+++ b/parquet_file/src/chunk.rs
@@ -10,13 +10,13 @@ use std::mem;
 #[derive(Debug)]
 pub struct Chunk {
     /// Partition this chunk belongs to
-    pub partition_key: String,
+    partition_key: String,
 
     /// The id for this chunk
-    pub id: u32,
+    id: u32,
 
     /// Tables of this chunk
-    pub tables: Vec<Table>,
+    tables: Vec<Table>,
 
     /// Track memory used by this chunk
     memory_tracker: MemTracker,
@@ -32,6 +32,26 @@ impl Chunk {
         };
         chunk.memory_tracker.set_bytes(chunk.size());
         chunk
+    }
+
+    /// Return the chunk id
+    pub fn id(&self) -> u32 {
+        self.id
+    }
+
+    /// Return the chunk's partition key
+    pub fn partition_key(&self) -> &str {
+        self.partition_key.as_ref()
+    }
+
+    /// Return all paths of this chunks
+    pub fn all_paths(&self) -> Vec<Path> {
+        self.tables.iter().map(|t| t.path()).collect()
+    }
+
+    /// Returns a vec of the summary statistics of the tables in this chunk
+    pub fn table_summaries(&self) -> Vec<TableSummary> {
+        self.tables.iter().map(|t| t.table_summary()).collect()
     }
 
     /// Add a chunk's table and its summary

--- a/parquet_file/src/table.rs
+++ b/parquet_file/src/table.rs
@@ -7,12 +7,12 @@ use std::mem;
 #[derive(Debug, Clone)]
 pub struct Table {
     /// Meta data of the table
-    pub table_summary: TableSummary,
+    table_summary: TableSummary,
 
     /// Path in the object store. Format:
     ///  <writer id>/<database>/data/<partition key>/<chunk
     /// id>/<tablename>.parquet
-    pub object_store_path: Path,
+    object_store_path: Path,
 }
 
 impl Table {
@@ -21,6 +21,10 @@ impl Table {
             table_summary: meta,
             object_store_path: path,
         }
+    }
+
+    pub fn table_summary(&self) -> TableSummary {
+        self.table_summary.clone()
     }
 
     pub fn has_table(&self, table_name: &str) -> bool {
@@ -37,5 +41,10 @@ impl Table {
     /// Return name of this table
     pub fn name(&self) -> String {
         self.table_summary.name.clone()
+    }
+
+    /// Return the object store path of this table
+    pub fn path(&self) -> Path {
+        self.object_store_path.clone()
     }
 }

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -29,7 +29,6 @@ serde = "1.0"
 serde_json = "1.0"
 snafu = "0.6"
 snap = "1.0.0"
-tempfile = "3.1.0"
 tokio = { version = "1.0", features = ["macros", "time"] }
 tokio-util = { version = "0.6.3" }
 tracker = { path = "../tracker" }
@@ -37,3 +36,4 @@ uuid = { version = "0.8", features = ["serde", "v4"] }
 
 [dev-dependencies] # In alphabetical order
 test_helpers = { path = "../test_helpers" }
+tempfile = "3.1.0"

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -29,6 +29,7 @@ serde = "1.0"
 serde_json = "1.0"
 snafu = "0.6"
 snap = "1.0.0"
+tempfile = "3.1.0"
 tokio = { version = "1.0", features = ["macros", "time"] }
 tokio-util = { version = "0.6.3" }
 tracker = { path = "../tracker" }

--- a/server/src/query_tests/utils.rs
+++ b/server/src/query_tests/utils.rs
@@ -23,6 +23,16 @@ pub fn make_db() -> Db {
     )
 }
 
+pub fn make_database(server_id: NonZeroU32, object_store: Arc<ObjectStore>, db_name: &str) -> Db {
+    Db::new(
+        DatabaseRules::new(DatabaseName::new(db_name.to_string()).unwrap()),
+        server_id,
+        object_store,
+        None, // wal buffer
+        Arc::new(JobRegistry::new()),
+    )
+}
+
 fn chunk_summary_iter(db: &Db) -> impl Iterator<Item = ChunkSummary> + '_ {
     db.partition_keys()
         .unwrap()


### PR DESCRIPTION
Closes #

This is kind of e2e test for the function [load_chunk_to_object_store](https://github.com/influxdata/influxdb_iox/blob/d84f05b2f5eca6a3f95fb7a21f7fe48046231d88/server/src/db.rs#L424) implemented for #1081 to write data to Object Store (OS). In order to test this, a new DB I created then data is loaded in MB, then moved to RB, then loaded to OS.

- [x] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb_iox/blob/main/README.md).
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
