### PR TITLE
chore: Changes to the CI docker image to enable flatbuffer regeneration and InfluxDB 2.0 integration tests

### DIFF
--- a/docker/Dockerfile.ci
+++ b/docker/Dockerfile.ci
@@ -35,6 +35,12 @@ RUN curl -Lo bazel-4.0.0-installer-linux-x86_64.sh https://github.com/bazelbuild
   && ./bazel-4.0.0-installer-linux-x86_64.sh \
   && rm bazel-4.0.0-installer-linux-x86_64.sh
 
+# Install InfluxDB 2.0 OSS to enable integration tests of the influxdb2_client crate
+RUN curl -o influxdb2.tar.gz https://dl.influxdata.com/influxdb/releases/influxdb2-2.0.4-linux-amd64.tar.gz \
+  && tar xvzf influxdb2.tar.gz \
+  && sudo cp influxdb2-2.0.4-linux-amd64/influxd /usr/local/bin/ \
+  && rm -rf influxdb2-2.0.4-linux-amd64
+
 # Set timezone to UTC by default
 RUN ln -sf /usr/share/zoneinfo/Etc/UTC /etc/localtime
 # Use unicode

--- a/docker/Dockerfile.ci
+++ b/docker/Dockerfile.ci
@@ -30,9 +30,10 @@ RUN apt-get update \
 	&& rm -rf /var/lib/{apt,dpkg,cache,log}
 
 # Install bazel using the binary installer to enable building of flatc in the flatbuffers check
-RUN curl -Lo bazel-4.0.0-installer-linux-x86_64.sh https://github.com/bazelbuild/bazel/releases/download/4.0.0/bazel-4.0.0-installer-linux-x86_64.sh
-RUN chmod +x bazel-4.0.0-installer-linux-x86_64.sh
-RUN ./bazel-4.0.0-installer-linux-x86_64.sh --user
+RUN curl -Lo bazel-4.0.0-installer-linux-x86_64.sh https://github.com/bazelbuild/bazel/releases/download/4.0.0/bazel-4.0.0-installer-linux-x86_64.sh \
+  && chmod +x bazel-4.0.0-installer-linux-x86_64.sh \
+  && ./bazel-4.0.0-installer-linux-x86_64.sh \
+  && rm bazel-4.0.0-installer-linux-x86_64.sh
 
 # Set timezone to UTC by default
 RUN ln -sf /usr/share/zoneinfo/Etc/UTC /etc/localtime


### PR DESCRIPTION
I *think* I have everything I'll need installed correctly. Tomorrow I'll be pushing code that uses these changes and adds scripts to regenerate the flatbuffers and run the InfluxDB 2.0 OSS integration tests in docker containers by default, but these changes will need to be merged first so submitting them separately.

I hackily ran the `ci_image` job to make sure it'll pass - [it did](https://app.circleci.com/pipelines/github/influxdata/influxdb_iox/4762/workflows/0dd451c4-6a2b-4acc-84c1-6e9de1eeebf3/jobs/11627), and the image is tagged ci-test in quay if you want to take a look at it. 

Figured pushing a different tag to quay would be a way I can use these changes in CI before this is merged and the `ci_image` job is run for real.