### PR TITLE
refactor: remove mutable buffer predicate logic

### DIFF
--- a/mutable_buffer/src/chunk.rs
+++ b/mutable_buffer/src/chunk.rs
@@ -5,20 +5,17 @@ use std::sync::Arc;
 
 use snafu::{OptionExt, ResultExt, Snafu};
 
-use arrow_deps::{arrow::record_batch::RecordBatch, datafusion::logical_plan::Expr};
+use arrow_deps::arrow::record_batch::RecordBatch;
 use data_types::{database_rules::WriterId, partition_metadata::TableSummary};
 use internal_types::{
     entry::{ClockValue, TableBatch},
-    schema::Schema,
     selection::Selection,
 };
 use tracker::{MemRegistry, MemTracker};
 
 use crate::chunk::snapshot::ChunkSnapshot;
 use crate::{
-    column::Column,
     dictionary::{Dictionary, Error as DictionaryError},
-    pred::{ChunkPredicate, ChunkPredicateBuilder},
     table::Table,
 };
 
@@ -38,53 +35,8 @@ pub enum Error {
         source: crate::table::Error,
     },
 
-    #[snafu(display("Error checking predicate in table {}: {}", table_id, source))]
-    PredicateCheck {
-        table_id: u32,
-        source: crate::table::Error,
-    },
-
-    #[snafu(display("Error checking predicate in table '{}': {}", table_name, source))]
-    NamedTablePredicateCheck {
-        table_name: String,
-        source: crate::table::Error,
-    },
-
-    #[snafu(display(
-        "Unsupported predicate when mutable buffer table names. Found a general expression: {:?}",
-        exprs
-    ))]
-    PredicateNotYetSupported { exprs: Vec<Expr> },
-
-    #[snafu(display("Table ID {} not found in dictionary of chunk {}", table_id, chunk))]
-    TableIdNotFoundInDictionary {
-        table_id: u32,
-        chunk: u64,
-        source: DictionaryError,
-    },
-
-    #[snafu(display(
-        "Internal error: table {} not found in dictionary of chunk {}",
-        table_name,
-        chunk_id
-    ))]
-    InternalTableNotFoundInDictionary { table_name: String, chunk_id: u32 },
-
     #[snafu(display("Table {} not found in chunk {}", table, chunk))]
     TableNotFoundInChunk { table: u32, chunk: u64 },
-
-    #[snafu(display("Table '{}' not found in chunk {}", table_name, chunk_id))]
-    NamedTableNotFoundInChunk { table_name: String, chunk_id: u64 },
-
-    #[snafu(display("Attempt to write table batch without a name"))]
-    TableWriteWithoutName,
-
-    #[snafu(display("Value ID {} not found in dictionary of chunk {}", value_id, chunk_id))]
-    InternalColumnValueIdNotFoundInDictionary {
-        value_id: u32,
-        chunk_id: u64,
-        source: DictionaryError,
-    },
 
     #[snafu(display("Column ID {} not found in dictionary of chunk {}", column_id, chunk))]
     ColumnIdNotFoundInDictionary {
@@ -103,12 +55,6 @@ pub enum Error {
         chunk_id: u64,
         source: DictionaryError,
     },
-
-    #[snafu(display(
-        "Column '{}' is not a string tag column and thus can not list values",
-        column_name
-    ))]
-    UnsupportedColumnTypeForListingValues { column_name: String },
 }
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
@@ -185,214 +131,6 @@ impl Chunk {
         Arc::new(ChunkSnapshot::new(self))
     }
 
-    /// Return all the names of the tables names in this chunk that match
-    /// chunk predicate
-    pub fn table_names(&self, chunk_predicate: &ChunkPredicate) -> Result<Vec<&str>> {
-        // we don't support arbitrary expressions in chunk predicate yet
-        if !chunk_predicate.chunk_exprs.is_empty() {
-            return PredicateNotYetSupported {
-                exprs: chunk_predicate.chunk_exprs.clone(),
-            }
-            .fail();
-        }
-
-        self.tables
-            .iter()
-            .filter_map(|(&table_id, table)| {
-                // could match is good enough for this metadata query
-                match table.could_match_predicate(chunk_predicate) {
-                    Ok(true) => Some(self.dictionary.lookup_id(table_id).context(
-                        TableIdNotFoundInDictionary {
-                            table_id,
-                            chunk: self.id,
-                        },
-                    )),
-                    Ok(false) => None,
-                    Err(e) => Some(Err(e).context(PredicateCheck { table_id })),
-                }
-            })
-            .collect()
-    }
-
-    /// If the column names that match the predicate can be found
-    /// from the predicate entirely using metadata, return those
-    /// strings.
-    ///
-    /// If the predicate cannot be evaluated entirely with
-    /// metadata, return `Ok(None)`.
-    pub fn column_names(
-        &self,
-        table_name: &str,
-        chunk_predicate: &ChunkPredicate,
-        selection: Selection<'_>,
-    ) -> Result<Option<BTreeSet<String>>> {
-        // No support for general purpose expressions
-        if !chunk_predicate.chunk_exprs.is_empty() {
-            return Ok(None);
-        }
-
-        let table_name_id = self.table_name_id(table_name)?;
-
-        let mut chunk_column_ids = BTreeSet::new();
-
-        // Is this table in the chunk?
-        if let Some(table) = self.tables.get(&table_name_id) {
-            for (&column_id, column) in &table.columns {
-                let column_matches_predicate = table
-                    .column_matches_predicate(&column, chunk_predicate)
-                    .context(NamedTableError { table_name })?;
-
-                if column_matches_predicate {
-                    chunk_column_ids.insert(column_id);
-                }
-            }
-        }
-
-        // Only return subset of these selection_cols if not all_cols
-        let mut all_cols = true;
-        let selection_cols = match selection {
-            Selection::All => &[""],
-            Selection::Some(cols) => {
-                all_cols = false;
-                cols
-            }
-        };
-
-        let mut column_names = BTreeSet::new();
-        for &column_id in &chunk_column_ids {
-            let column_name =
-                self.dictionary
-                    .lookup_id(column_id)
-                    .context(ColumnIdNotFoundInDictionary {
-                        column_id,
-                        chunk: self.id,
-                    })?;
-
-            if !column_names.contains(column_name)
-                && (all_cols || selection_cols.contains(&column_name))
-            {
-                // only use columns in selection_cols
-                column_names.insert(column_name.to_string());
-            }
-        }
-
-        Ok(Some(column_names))
-    }
-
-    /// Return the id of the table in the chunk's dictionary
-    fn table_name_id(&self, table_name: &str) -> Result<u32> {
-        self.dictionary
-            .id(table_name)
-            .context(InternalTableNotFoundInDictionary {
-                table_name,
-                chunk_id: self.id(),
-            })
-    }
-
-    /// Returns the strings of the specified Tag column that satisfy
-    /// the predicate, if they can be determined entirely using metadata.
-    ///
-    /// If the predicate cannot be evaluated entirely with metadata,
-    /// return `Ok(None)`.
-    pub fn tag_column_values(
-        &self,
-        table_name: &str,
-        column_name: &str,
-        chunk_predicate: &ChunkPredicate,
-    ) -> Result<Option<BTreeSet<String>>> {
-        // No support for general purpose expressions
-        if !chunk_predicate.chunk_exprs.is_empty() {
-            return Ok(None);
-        }
-        let chunk_id = self.id();
-
-        let table_name_id = self.table_name_id(table_name)?;
-
-        // Is this table even in the chunk?
-        let table = self
-            .tables
-            .get(&table_name_id)
-            .context(NamedTableNotFoundInChunk {
-                table_name,
-                chunk_id,
-            })?;
-
-        // See if we can rule out the table entire on metadata
-        let could_match = table
-            .could_match_predicate(chunk_predicate)
-            .context(NamedTablePredicateCheck { table_name })?;
-
-        if !could_match {
-            // No columns could match, return empty set
-            return Ok(Default::default());
-        }
-
-        let column_id =
-            self.dictionary
-                .lookup_value(column_name)
-                .context(ColumnNameNotFoundInDictionary {
-                    column_name,
-                    chunk_id,
-                })?;
-
-        let column = table
-            .column(column_id)
-            .context(NamedTableError { table_name })?;
-
-        if let Column::Tag(column, _) = column {
-            // if we have a timestamp predicate, find all values
-            // where the timestamp is within range. Otherwise take
-            // all values.
-
-            // Collect matching ids into BTreeSet to deduplicate on
-            // ids *before* looking up Strings
-            let column_value_ids: BTreeSet<u32> = match chunk_predicate.range {
-                None => {
-                    // take all non-null values
-                    column.iter().filter_map(|&s| s).collect()
-                }
-                Some(range) => {
-                    // filter out all values that don't match the timestmap
-                    let time_column = table
-                        .column_i64(chunk_predicate.time_column_id)
-                        .context(NamedTableError { table_name })?;
-
-                    column
-                        .iter()
-                        .zip(time_column.iter())
-                        .filter_map(|(&column_value_id, &timestamp_value)| {
-                            if range.contains_opt(timestamp_value) {
-                                column_value_id
-                            } else {
-                                None
-                            }
-                        })
-                        .collect()
-                }
-            };
-
-            // convert all the (deduplicated) ids to Strings
-            let column_values = column_value_ids
-                .into_iter()
-                .map(|value_id| {
-                    let value = self.dictionary.lookup_id(value_id).context(
-                        InternalColumnValueIdNotFoundInDictionary { value_id, chunk_id },
-                    )?;
-                    Ok(value.to_string())
-                })
-                .collect::<Result<BTreeSet<String>>>()?;
-
-            Ok(Some(column_values))
-        } else {
-            UnsupportedColumnTypeForListingValues { column_name }.fail()
-        }
-    }
-
-    /// Return a builder suitable to create predicates for this Chunk
-    pub fn predicate_builder(&self) -> Result<ChunkPredicateBuilder<'_>, crate::pred::Error> {
-        ChunkPredicateBuilder::new(&self.dictionary)
-    }
-
     /// returns true if there is no data in this chunk
     pub fn is_empty(&self) -> bool {
         self.tables.is_empty()
@@ -451,21 +189,6 @@ impl Chunk {
             Err(_) => None,
         };
         Ok(table)
-    }
-
-    /// Return Schema for the specified table / columns
-    pub fn table_schema(&self, table_name: &str, selection: Selection<'_>) -> Result<Schema> {
-        let table = self
-            .table(table_name)?
-            // Option --> Result
-            .context(NamedTableNotFoundInChunk {
-                table_name,
-                chunk_id: self.id(),
-            })?;
-
-        table
-            .schema(self, selection)
-            .context(NamedTableError { table_name })
     }
 
     /// Return the approximate memory size of the chunk, in bytes including the

--- a/mutable_buffer/src/lib.rs
+++ b/mutable_buffer/src/lib.rs
@@ -60,5 +60,4 @@
 pub mod chunk;
 mod column;
 mod dictionary;
-pub mod pred;
 mod table;

--- a/server/src/db/streams.rs
+++ b/server/src/db/streams.rs
@@ -1,115 +1,15 @@
 //! Adapter streams for different Chunk types that implement the interface
 //! needed by DataFusion
 use arrow_deps::{
-    arrow::{
-        datatypes::SchemaRef,
-        error::{ArrowError, Result as ArrowResult},
-        record_batch::RecordBatch,
-    },
+    arrow::{datatypes::SchemaRef, error::Result as ArrowResult, record_batch::RecordBatch},
     datafusion::physical_plan::RecordBatchStream,
 };
-use internal_types::selection::Selection;
-use mutable_buffer::chunk::Chunk as MBChunk;
 use read_buffer::ReadFilterResults;
 
 use std::{
     sync::Arc,
     task::{Context, Poll},
 };
-
-use snafu::{ResultExt, Snafu};
-
-#[derive(Debug, Snafu)]
-pub enum Error {
-    #[snafu(display(
-        "Error getting data for table '{}' chunk {}: {}",
-        table_name,
-        chunk_id,
-        source
-    ))]
-    GettingTableData {
-        table_name: String,
-        chunk_id: u32,
-        source: mutable_buffer::chunk::Error,
-    },
-}
-
-/// Adapter which will produce record batches from a mutable buffer
-/// chunk on demand
-pub(crate) struct MutableBufferChunkStream {
-    /// Requested output schema (includes selection)
-    schema: SchemaRef,
-    chunk: Arc<MBChunk>,
-    table_name: Arc<String>,
-
-    /// Vector of record batches to send in reverse order (send data[len-1]
-    /// next) Is None until the first call to poll_next
-    data: Option<Vec<RecordBatch>>,
-}
-
-impl MutableBufferChunkStream {
-    #[allow(dead_code)]
-    pub fn new(chunk: Arc<MBChunk>, schema: SchemaRef, table_name: impl Into<String>) -> Self {
-        Self {
-            chunk,
-            schema,
-            table_name: Arc::new(table_name.into()),
-            data: None,
-        }
-    }
-
-    // gets the next batch, as needed
-    fn next_batch(&mut self) -> ArrowResult<Option<RecordBatch>> {
-        if self.data.is_none() {
-            // Want all the columns in the schema. Note we don't
-            // use `Selection::All` here because the mutable buffer chunk would interpret it
-            // as "all columns in the table in that chunk" rather than
-            // all columns this query needs
-            let selected_cols = self
-                .schema
-                .fields()
-                .iter()
-                .map(|f| f.name() as &str)
-                .collect::<Vec<_>>();
-            let selection = Selection::Some(&selected_cols);
-
-            let mut data = Vec::new();
-            self.chunk
-                .table_to_arrow(&mut data, self.table_name.as_ref(), selection)
-                .context(GettingTableData {
-                    table_name: self.table_name.as_ref(),
-                    chunk_id: self.chunk.id(),
-                })
-                .map_err(|e| ArrowError::ExternalError(Box::new(e)))?;
-
-            // reverse the array so we can pop off the back
-            data.reverse();
-            self.data = Some(data);
-        }
-
-        // self.data was set to Some above
-        Ok(self.data.as_mut().unwrap().pop())
-    }
-}
-
-impl RecordBatchStream for MutableBufferChunkStream {
-    fn schema(&self) -> SchemaRef {
-        Arc::clone(&self.schema)
-    }
-}
-
-impl futures::Stream for MutableBufferChunkStream {
-    type Item = ArrowResult<RecordBatch>;
-
-    fn poll_next(
-        mut self: std::pin::Pin<&mut Self>,
-        _: &mut Context<'_>,
-    ) -> Poll<Option<Self::Item>> {
-        Poll::Ready(self.next_batch().transpose())
-    }
-
-    // TODO is there a useful size_hint to pass?
-}
 
 /// Adapter which will take a ReadFilterResults and make it an async stream
 pub struct ReadFilterResultsStream {


### PR DESCRIPTION
#1179 removed the query handling logic to instead point at ChunkSnapshots instead of MBChunks, effectively orphaning all this code. 

We may in future push more predicates into the ChunkSnapshot, but the current formulation of MUB predicates is tightly coupled with the MUB data representation. As the ChunkSnapshots are formulated instead in terms of arrow record batches, I'm not sure there is much reason to keep this code around. It will, of course, be preserved in the git history should we wish to refer to it in future