### PR TITLE
feat: Implement WriteBuffer gRPC

### DIFF
--- a/generated_types/protos/influxdata/iox/write/v1/service.proto
+++ b/generated_types/protos/influxdata/iox/write/v1/service.proto
@@ -4,7 +4,12 @@ package influxdata.iox.write.v1;
 
 service WriteService {
   // write data into a specific Database
-  rpc Write(WriteRequest) returns (WriteResponse);
+  rpc Write(WriteRequest) returns (WriteResponse) {
+    option deprecated = true;
+  };
+
+  // write an entry into a Database
+  rpc WriteEntry(WriteEntryRequest) returns (WriteEntryResponse);
 }
 
 message WriteRequest {
@@ -20,4 +25,18 @@ message WriteRequest {
 message WriteResponse {
   // how many lines were parsed and written into the database
   uint64 lines_written = 1;
+}
+
+
+message WriteEntryRequest {
+  // name of database into which to write
+  string db_name = 1;
+
+  // entry, in serialized flatbuffers [Entry] format
+  //
+  // [Entry](https://github.com/influxdata/influxdb_iox/blob/main/generated_types/protos/influxdata/iox/write/v1/entry.fbs)
+  bytes entry = 2;
+}
+
+message WriteEntryResponse {
 }

--- a/server/src/db.rs
+++ b/server/src/db.rs
@@ -642,6 +642,10 @@ impl Db {
         )
         .context(SequencedEntryError)?;
 
+        if self.rules.read().wal_buffer_config.is_some() {
+            todo!("route to the Write Buffer. TODO: carols10cents #1157")
+        }
+
         self.store_sequenced_entry(sequenced_entry)
     }
 

--- a/src/influxdb_ioxd/rpc/error.rs
+++ b/src/influxdb_ioxd/rpc/error.rs
@@ -23,6 +23,11 @@ pub fn default_server_error_handler(error: server::Error) -> tonic::Status {
             description: source.to_string(),
         }
         .into(),
+        Error::DecodingEntry { source } => FieldViolation {
+            field: "entry".into(),
+            description: source.to_string(),
+        }
+        .into(),
         error => {
             error!(?error, "Unexpected error");
             InternalError {}.into()

--- a/src/influxdb_ioxd/rpc/write.rs
+++ b/src/influxdb_ioxd/rpc/write.rs
@@ -47,6 +47,23 @@ where
         let lines_written = lp_line_count as u64;
         Ok(Response::new(WriteResponse { lines_written }))
     }
+
+    async fn write_entry(
+        &self,
+        request: tonic::Request<WriteEntryRequest>,
+    ) -> Result<tonic::Response<WriteEntryResponse>, tonic::Status> {
+        let request = request.into_inner();
+        if request.entry.is_empty() {
+            return Err(FieldViolation::required("entry").into());
+        }
+
+        self.server
+            .write_entry(&request.db_name, request.entry)
+            .await
+            .map_err(default_server_error_handler)?;
+
+        Ok(Response::new(WriteEntryResponse {}))
+    }
 }
 
 /// Instantiate the write service


### PR DESCRIPTION
Part of #916 

This PR adds a WriteBuffer gRPC API endpoint and an implementation that sends the entry to the Server.

The Server currently only implements the "local" short-circuit, which sends entries to the mutable buffer if the "write buffer" (aka WAL) is not configured for this node+database.

This PR is a prerequisite integration point for further work in the query later and in the write buffer layer.