### PR TITLE
refactor: update schema conflicts to display column name

### DIFF
--- a/mutable_buffer/src/table.rs
+++ b/mutable_buffer/src/table.rs
@@ -587,9 +587,12 @@ mod tests {
                     expected_column_type,
                     actual_column_type,
                     column,
-                } if expected_column_type == "tag" && actual_column_type == "String" && column == "t1"),
-                "didn't match returned error: {:?}",
-                response
+                } if expected_column_type == "tag"
+                     && actual_column_type == "String"
+                     && column == "t1"
+            ),
+            "didn't match returned error: {:?}",
+            response
         );
 
         let lp = "foo iv=1u 1";
@@ -612,7 +615,16 @@ mod tests {
             .err()
             .unwrap();
         assert!(
-            matches!(&response, Error::ColumnTypeMismatch {expected_column_type, actual_column_type, column} if expected_column_type == "i64" && actual_column_type == "u64" && column == "iv"),
+            matches!(
+                &response,
+                Error::ColumnTypeMismatch {
+                    expected_column_type,
+                    actual_column_type,
+                    column
+                } if expected_column_type == "i64"
+                    && actual_column_type == "u64"
+                    && column == "iv"
+            ),
             "didn't match returned error: {:?}",
             response
         );
@@ -637,7 +649,16 @@ mod tests {
             .err()
             .unwrap();
         assert!(
-            matches!(&response, Error::ColumnTypeMismatch {expected_column_type, actual_column_type, column} if expected_column_type == "f64" && actual_column_type == "i64" && column == "fv"),
+            matches!(
+                &response,
+                Error::ColumnTypeMismatch {
+                    expected_column_type,
+                    actual_column_type,
+                    column
+                } if expected_column_type == "f64"
+                    && actual_column_type == "i64"
+                    && column == "fv"
+            ),
             "didn't match returned error: {:?}",
             response
         );
@@ -662,7 +683,16 @@ mod tests {
             .err()
             .unwrap();
         assert!(
-            matches!(&response, Error::ColumnTypeMismatch {expected_column_type, actual_column_type, column} if expected_column_type == "bool" && actual_column_type == "f64" && column == "bv"),
+            matches!(
+                &response,
+                Error::ColumnTypeMismatch {
+                    expected_column_type,
+                    actual_column_type,
+                    column
+                } if expected_column_type == "bool"
+                    && actual_column_type == "f64"
+                    && column == "bv"
+            ),
             "didn't match returned error: {:?}",
             response
         );
@@ -687,7 +717,16 @@ mod tests {
             .err()
             .unwrap();
         assert!(
-            matches!(&response, Error::ColumnTypeMismatch {expected_column_type, actual_column_type, column} if expected_column_type == "String" && actual_column_type == "bool" && column == "sv"),
+            matches!(
+                &response,
+                Error::ColumnTypeMismatch {
+                    expected_column_type,
+                    actual_column_type,
+                    column
+                } if expected_column_type == "String"
+                    && actual_column_type == "bool"
+                    && column == "sv"
+            ),
             "didn't match returned error: {:?}",
             response
         );

--- a/mutable_buffer/src/table.rs
+++ b/mutable_buffer/src/table.rs
@@ -38,18 +38,6 @@ pub enum Error {
     },
 
     #[snafu(display(
-        "Internal error: Expected column {} to be type {} but was {}",
-        column_id,
-        expected_column_type,
-        actual_column_type
-    ))]
-    InternalColumnTypeMismatch {
-        column_id: DID,
-        expected_column_type: String,
-        actual_column_type: String,
-    },
-
-    #[snafu(display(
         "Expected column {} to be type {} but was {}",
         column,
         expected_column_type,


### PR DESCRIPTION
Otherwise we see a horrible message such as the following in the log


```
level=error msg="Error while handling request" error="WritingPoints { org: \"844910ece80be8bc\", bucket_name: \"05d2e1304a88c000\", source: UnknownDatabaseError { source: WriteEntry { partition_key: \"2021-04-13 17:00:00\", chunk_id: 0, source: TableWrite { table_name: \"query_log\", source: InternalColumnTypeMismatch { column_id: 7, expected_column_type: \"i64\", actual_column_type: \"f64\" } } } } }" error_message="Internal error writing points into org 844910ece80be8bc, bucket 05d2e1304a88c000:  database error: Can not write entry 2021-04-13 17:00:00 0: Error writing table \'query_log\': Internal error: Expected column 7 to be type i64 but was f64" 
```