### PR TITLE
feat: Use single db-wide executor for running queries

### DIFF
--- a/arrow_deps/src/test_util.rs
+++ b/arrow_deps/src/test_util.rs
@@ -29,6 +29,46 @@ macro_rules! assert_table_eq {
     };
 }
 
+/// Compares formatted output of a record batch with an expected
+/// vector of strings in a way that order does not matter.
+/// This is a macro so errors appear on the correct line
+///
+/// Designed so that failure output can be directly copy/pasted
+/// into the test code as expected results.
+///
+/// Expects to be called about like this:
+///
+/// `assert_batch_sorted_eq!(expected_lines: &[&str], batches: &[RecordBatch])`
+#[macro_export]
+macro_rules! assert_batches_sorted_eq {
+    ($EXPECTED_LINES: expr, $CHUNKS: expr) => {
+        let mut expected_lines: Vec<String> = $EXPECTED_LINES.iter().map(|&s| s.into()).collect();
+
+        // sort except for header + footer
+        let num_lines = expected_lines.len();
+        if num_lines > 3 {
+            expected_lines.as_mut_slice()[2..num_lines - 1].sort_unstable()
+        }
+
+        let formatted = arrow_deps::arrow::util::pretty::pretty_format_batches($CHUNKS).unwrap();
+        // fix for windows: \r\n -->
+
+        let mut actual_lines: Vec<&str> = formatted.trim().lines().collect();
+
+        // sort except for header + footer
+        let num_lines = actual_lines.len();
+        if num_lines > 3 {
+            actual_lines.as_mut_slice()[2..num_lines - 1].sort_unstable()
+        }
+
+        assert_eq!(
+            expected_lines, actual_lines,
+            "\n\nexpected:\n\n{:#?}\nactual:\n\n{:#?}\n\n",
+            expected_lines, actual_lines
+        );
+    };
+}
+
 // sort a record batch by all columns (to provide a stable output order for test
 // comparison)
 pub fn sort_record_batch(batch: RecordBatch) -> RecordBatch {

--- a/query/src/exec.rs
+++ b/query/src/exec.rs
@@ -35,7 +35,7 @@ use crate::plan::{
     stringset::StringSetPlan,
 };
 
-use self::task::DedicatedExecutor;
+use self::task::{DedicatedExecutor, Error as ExecutorError};
 
 #[derive(Debug, Snafu)]
 pub enum Error {
@@ -87,7 +87,7 @@ pub enum Error {
     },
 
     #[snafu(display("Joining execution task: {}", source))]
-    JoinError { source: tokio::task::JoinError },
+    JoinError { source: ExecutorError },
 }
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
@@ -159,7 +159,7 @@ impl Executor {
                 let (plan_tx, plan_rx) = mpsc::channel(1);
                 rx_channels.push(plan_rx);
 
-                tokio::task::spawn(async move {
+                self.exec.spawn(async move {
                     let SeriesSetPlan {
                         table_name,
                         plan,
@@ -172,7 +172,6 @@ impl Executor {
 
                     let physical_plan = ctx
                         .prepare_plan(&plan)
-                        .await
                         .context(DataFusionPhysicalPlanning)?;
 
                     let it = ctx
@@ -224,10 +223,9 @@ impl Executor {
             .into_iter()
             .map(|plan| {
                 let ctx = self.new_context();
-                tokio::task::spawn(async move {
+                self.exec.spawn(async move {
                     let physical_plan = ctx
                         .prepare_plan(&plan)
-                        .await
                         .context(DataFusionPhysicalPlanning)?;
 
                     // TODO: avoid this buffering
@@ -280,11 +278,10 @@ impl Executor {
             .into_iter()
             .map(|plan| {
                 let ctx = self.new_context();
-                // TODO run these on some executor other than the main tokio pool
-                tokio::task::spawn(async move {
+
+                self.exec.spawn(async move {
                     let physical_plan = ctx
                         .prepare_plan(&plan)
-                        .await
                         .context(DataFusionPhysicalPlanning)?;
 
                     // TODO: avoid this buffering

--- a/query/src/exec/task.rs
+++ b/query/src/exec/task.rs
@@ -12,6 +12,9 @@ use observability_deps::tracing::warn;
 /// The type of thing that the dedicated executor runs
 type Task = Pin<Box<dyn Future<Output = ()> + Send>>;
 
+/// The type of error that is returned from tasks in this module
+pub type Error = tokio::sync::oneshot::error::RecvError;
+
 /// Runs futures (and any `tasks` that are `tokio::task::spawned` by
 /// them) on a separate tokio Executor
 #[derive(Clone)]

--- a/query/src/frontend/sql.rs
+++ b/query/src/frontend/sql.rs
@@ -84,7 +84,7 @@ impl SQLQueryPlanner {
     /// Plan a SQL query against the data in `database`, and return a
     /// DataFusion physical execution plan. The plan can then be
     /// executed using `executor` in a streaming fashion.
-    pub async fn query<D: CatalogProvider + 'static>(
+    pub fn query<D: CatalogProvider + 'static>(
         &self,
         database: Arc<D>,
         query: &str,
@@ -92,6 +92,6 @@ impl SQLQueryPlanner {
     ) -> Result<Arc<dyn ExecutionPlan>> {
         let mut ctx = executor.new_context();
         ctx.inner_mut().register_catalog(DEFAULT_CATALOG, database);
-        ctx.prepare_sql(query).await.context(Preparing)
+        ctx.prepare_sql(query).context(Preparing)
     }
 }

--- a/server/benches/tag_values.rs
+++ b/server/benches/tag_values.rs
@@ -56,7 +56,6 @@ pub fn benchmark_tag_values(c: &mut Criterion) {
 // predicate.
 fn execute_benchmark_group(c: &mut Criterion, scenarios: &[DBScenario]) {
     let planner = InfluxRPCPlanner::new();
-    let executor = Executor::new(1); // single thread to execute queries
 
     let predicates = vec![
         (PredicateBuilder::default().build(), "no_pred"),
@@ -85,10 +84,11 @@ fn execute_benchmark_group(c: &mut Criterion, scenarios: &[DBScenario]) {
                     BenchmarkId::from_parameter(format!("{}/{}", tag_key, pred_name)),
                     tag_key,
                     |b, &tag_key| {
+                        let executor = db.executor();
                         b.to_async(Runtime::new().unwrap()).iter(|| {
                             run_tag_values_query(
                                 &planner,
-                                &executor,
+                                executor.as_ref(),
                                 db,
                                 tag_key,
                                 predicate.clone(),

--- a/server/src/db.rs
+++ b/server/src/db.rs
@@ -33,7 +33,7 @@ use data_types::{
 use internal_types::selection::Selection;
 use object_store::ObjectStore;
 use parquet_file::{chunk::Chunk, storage::Storage};
-use query::{Database, DEFAULT_SCHEMA};
+use query::{exec::Executor, Database, DEFAULT_SCHEMA};
 use read_buffer::Chunk as ReadBufferChunk;
 use tracker::{MemRegistry, TaskTracker, TrackedFutureExt};
 
@@ -223,7 +223,11 @@ pub struct Db {
 
     pub server_id: NonZeroU32, // this is also the Query Server ID
 
+    /// Interface to use for peristence
     pub store: Arc<ObjectStore>,
+
+    /// Executor for running queries
+    exec: Arc<Executor>,
 
     /// The catalog holds chunks of data under partitions for the database.
     /// The underlying chunks may be backed by different execution engines
@@ -271,6 +275,7 @@ impl Db {
         rules: DatabaseRules,
         server_id: NonZeroU32,
         object_store: Arc<ObjectStore>,
+        exec: Arc<Executor>,
         wal_buffer: Option<Buffer>,
         jobs: Arc<JobRegistry>,
     ) -> Self {
@@ -284,6 +289,7 @@ impl Db {
             rules,
             server_id,
             store,
+            exec,
             catalog,
             wal_buffer,
             jobs,
@@ -292,6 +298,11 @@ impl Db {
             sequence: AtomicU64::new(STARTING_SEQUENCE),
             worker_iterations: AtomicUsize::new(0),
         }
+    }
+
+    /// Return a handle to the executor used to run queries
+    pub fn executor(&self) -> Arc<Executor> {
+        Arc::clone(&self.exec)
     }
 
     /// Rolls over the active chunk in the database's specified
@@ -850,9 +861,8 @@ mod tests {
     use crate::query_tests::utils::{make_database, make_db};
     use ::test_helpers::assert_contains;
     use arrow_deps::{
-        arrow::record_batch::RecordBatch,
-        assert_table_eq,
-        datafusion::{execution::context, physical_plan::collect},
+        arrow::record_batch::RecordBatch, assert_batches_sorted_eq, assert_table_eq,
+        datafusion::execution::context,
     };
     use chrono::Utc;
     use data_types::{
@@ -863,7 +873,7 @@ mod tests {
     use object_store::{
         disk::File, path::ObjectStorePath, path::Path, ObjectStore, ObjectStoreApi,
     };
-    use query::{exec::Executor, frontend::sql::SQLQueryPlanner, PartitionChunk};
+    use query::{frontend::sql::SQLQueryPlanner, PartitionChunk};
 
     use super::*;
     use futures::stream;
@@ -926,7 +936,7 @@ mod tests {
             "+-----+------+",
         ];
         let batches = run_query(Arc::clone(&db), "select * from cpu").await;
-        assert_table_eq!(expected, &batches);
+        assert_batches_sorted_eq!(expected, &batches);
 
         // add new data
         write_lp(db.as_ref(), "cpu bar=2 20");
@@ -939,14 +949,14 @@ mod tests {
             "+-----+------+",
         ];
         let batches = run_query(Arc::clone(&db), "select * from cpu").await;
-        assert_table_eq!(&expected, &batches);
+        assert_batches_sorted_eq!(&expected, &batches);
 
         // And expect that we still get the same thing when data is rolled over again
         let chunk = db.rollover_partition("1970-01-01T00").await.unwrap();
         assert_eq!(chunk.id(), 1);
 
         let batches = run_query(db, "select * from cpu").await;
-        assert_table_eq!(&expected, &batches);
+        assert_batches_sorted_eq!(&expected, &batches);
     }
 
     #[tokio::test]
@@ -1703,11 +1713,11 @@ mod tests {
     // run a sql query against the database, returning the results as record batches
     async fn run_query(db: Arc<Db>, query: &str) -> Vec<RecordBatch> {
         let planner = SQLQueryPlanner::default();
-        let executor = Executor::new(1);
+        let executor = db.executor();
 
         let physical_plan = planner.query(db, query, &executor).await.unwrap();
 
-        collect(physical_plan).await.unwrap()
+        executor.collect(physical_plan).await.unwrap()
     }
 
     fn mutable_chunk_ids(db: &Db, partition_key: &str) -> Vec<u32> {

--- a/server/src/db.rs
+++ b/server/src/db.rs
@@ -1715,7 +1715,7 @@ mod tests {
         let planner = SQLQueryPlanner::default();
         let executor = db.executor();
 
-        let physical_plan = planner.query(db, query, &executor).await.unwrap();
+        let physical_plan = planner.query(db, query, &executor).unwrap();
 
         executor.collect(physical_plan).await.unwrap()
     }

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -232,7 +232,7 @@ pub struct Server<M: ConnectionManager> {
     config: Arc<Config>,
     connection_manager: Arc<M>,
     pub store: Arc<ObjectStore>,
-    executor: Arc<Executor>,
+    exec: Arc<Executor>,
     jobs: Arc<JobRegistry>,
 }
 
@@ -263,7 +263,7 @@ impl<M: ConnectionManager> Server<M> {
             config: Arc::new(Config::new(Arc::clone(&jobs))),
             store: object_store,
             connection_manager: Arc::new(connection_manager),
-            executor: Arc::new(Executor::new(num_worker_threads)),
+            exec: Arc::new(Executor::new(num_worker_threads)),
             jobs,
         }
     }
@@ -282,12 +282,7 @@ impl<M: ConnectionManager> Server<M> {
     }
 
     /// Tells the server the set of rules for a database.
-    pub async fn create_database(
-        &self,
-        rules: DatabaseRules,
-        server_id: NonZeroU32,
-        object_store: Arc<ObjectStore>,
-    ) -> Result<()> {
+    pub async fn create_database(&self, rules: DatabaseRules, server_id: NonZeroU32) -> Result<()> {
         // Return an error if this server hasn't yet been setup with an id
         self.require_id()?;
         let db_reservation = self.config.create_db(rules)?;
@@ -295,7 +290,7 @@ impl<M: ConnectionManager> Server<M> {
         self.persist_database_rules(db_reservation.rules().clone())
             .await?;
 
-        db_reservation.commit(server_id, object_store);
+        db_reservation.commit(server_id, Arc::clone(&self.store), Arc::clone(&self.exec));
 
         Ok(())
     }
@@ -350,6 +345,7 @@ impl<M: ConnectionManager> Server<M> {
             .map(|mut path| {
                 let store = Arc::clone(&self.store);
                 let config = Arc::clone(&self.config);
+                let exec = Arc::clone(&self.exec);
 
                 path.set_file_name(DB_RULES_FILE_NAME);
 
@@ -375,7 +371,7 @@ impl<M: ConnectionManager> Server<M> {
                         }
                         Ok(rules) => match config.create_db(rules) {
                             Err(e) => error!("error adding database to config: {}", e),
-                            Ok(handle) => handle.commit(server_id, store),
+                            Ok(handle) => handle.commit(server_id, store, exec),
                         },
                     }
                 })
@@ -614,12 +610,8 @@ where
         let db = match self.db(&db_name) {
             Some(db) => db,
             None => {
-                self.create_database(
-                    DatabaseRules::new(db_name.clone()),
-                    self.require_id()?,
-                    Arc::clone(&self.store),
-                )
-                .await?;
+                self.create_database(DatabaseRules::new(db_name.clone()), self.require_id()?)
+                    .await?;
                 self.db(&db_name).expect("db not inserted")
             }
         };
@@ -627,8 +619,9 @@ where
         Ok(db)
     }
 
+    /// Return a handle to the query executor
     fn executor(&self) -> Arc<Executor> {
-        Arc::clone(&self.executor)
+        Arc::clone(&self.exec)
     }
 }
 
@@ -781,11 +774,7 @@ mod tests {
 
         // Create a database
         server
-            .create_database(
-                rules.clone(),
-                server.require_id().unwrap(),
-                Arc::clone(&server.store),
-            )
+            .create_database(rules.clone(), server.require_id().unwrap())
             .await
             .expect("failed to create database");
 
@@ -813,7 +802,6 @@ mod tests {
             .create_database(
                 DatabaseRules::new(db2.clone()),
                 server.require_id().unwrap(),
-                Arc::clone(&server.store),
             )
             .await
             .expect("failed to create 2nd db");
@@ -845,7 +833,6 @@ mod tests {
             .create_database(
                 DatabaseRules::new(name.clone()),
                 server.require_id().unwrap(),
-                Arc::clone(&server.store),
             )
             .await
             .expect("failed to create database");
@@ -855,7 +842,6 @@ mod tests {
             .create_database(
                 DatabaseRules::new(name.clone()),
                 server.require_id().unwrap(),
-                Arc::clone(&server.store),
             )
             .await
             .unwrap_err();
@@ -876,11 +862,7 @@ mod tests {
         for name in &names {
             let name = DatabaseName::new(name.to_string()).unwrap();
             server
-                .create_database(
-                    DatabaseRules::new(name),
-                    server.require_id().unwrap(),
-                    Arc::clone(&server.store),
-                )
+                .create_database(DatabaseRules::new(name), server.require_id().unwrap())
                 .await
                 .expect("failed to create database");
         }
@@ -897,11 +879,7 @@ mod tests {
 
         let name = DatabaseName::new("foo".to_string()).unwrap();
         server
-            .create_database(
-                DatabaseRules::new(name),
-                server.require_id().unwrap(),
-                Arc::clone(&server.store),
-            )
+            .create_database(DatabaseRules::new(name), server.require_id().unwrap())
             .await
             .unwrap();
 
@@ -994,7 +972,6 @@ mod tests {
             .create_database(
                 DatabaseRules::new(db_name.clone()),
                 server.require_id().unwrap(),
-                Arc::clone(&server.store),
             )
             .await
             .unwrap();

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -726,7 +726,7 @@ mod tests {
     use tokio::task::JoinHandle;
     use tokio_util::sync::CancellationToken;
 
-    use arrow_deps::{assert_table_eq, datafusion::physical_plan::collect};
+    use arrow_deps::assert_table_eq;
     use data_types::database_rules::{PartitionTemplate, TemplatePart, NO_SHARD_CONFIG};
     use influxdb_line_protocol::parse_lines;
     use object_store::{memory::InMemory, path::ObjectStorePath};
@@ -894,10 +894,9 @@ mod tests {
         let executor = server.executor();
         let physical_plan = planner
             .query(db, "select * from cpu", executor.as_ref())
-            .await
             .unwrap();
 
-        let batches = collect(physical_plan).await.unwrap();
+        let batches = executor.collect(physical_plan).await.unwrap();
         let expected = vec![
             "+-----+------+",
             "| bar | time |",
@@ -916,11 +915,7 @@ mod tests {
 
         let name = DatabaseName::new("foo".to_string()).unwrap();
         server
-            .create_database(
-                DatabaseRules::new(name),
-                server.require_id().unwrap(),
-                Arc::clone(&server.store),
-            )
+            .create_database(DatabaseRules::new(name), server.require_id().unwrap())
             .await
             .unwrap();
 
@@ -942,10 +937,9 @@ mod tests {
         let executor = server.executor();
         let physical_plan = planner
             .query(db, "select * from cpu", executor.as_ref())
-            .await
             .unwrap();
 
-        let batches = collect(physical_plan).await.unwrap();
+        let batches = executor.collect(physical_plan).await.unwrap();
         let expected = vec![
             "+-----+------+",
             "| bar | time |",

--- a/server/src/query_tests/influxrpc/field_columns.rs
+++ b/server/src/query_tests/influxrpc/field_columns.rs
@@ -4,10 +4,7 @@ use arrow_deps::{
     datafusion::logical_plan::{col, lit},
 };
 use query::{
-    exec::{
-        fieldlist::{Field, FieldList},
-        Executor,
-    },
+    exec::fieldlist::{Field, FieldList},
     frontend::influxrpc::InfluxRPCPlanner,
     predicate::PredicateBuilder,
 };
@@ -31,7 +28,7 @@ macro_rules! run_field_columns_test_case {
             println!("Running scenario '{}'", scenario_name);
             println!("Predicate: '{:#?}'", predicate);
             let planner = InfluxRPCPlanner::new();
-            let executor = Executor::new(1);
+            let executor = db.executor();
 
             let plan = planner
                 .field_columns(&db, predicate.clone())
@@ -132,7 +129,6 @@ async fn test_field_name_plan() {
         println!("Running scenario '{}'", scenario_name);
         println!("Predicate: '{:#?}'", predicate);
         let planner = InfluxRPCPlanner::new();
-        let executor = Executor::new(1);
 
         let plan = planner
             .field_columns(&db, predicate.clone())
@@ -144,7 +140,8 @@ async fn test_field_name_plan() {
 
         // run the created plan directly, ensuring the output is as
         // expected (specifically that the column ordering is correct)
-        let results = executor
+        let results = db
+            .executor()
             .run_logical_plan(plan)
             .await
             .expect("ok running plan");

--- a/server/src/query_tests/influxrpc/read_filter.rs
+++ b/server/src/query_tests/influxrpc/read_filter.rs
@@ -4,7 +4,6 @@ use crate::query_tests::scenarios::*;
 use arrow_deps::datafusion::logical_plan::{col, lit};
 use async_trait::async_trait;
 use query::{
-    exec::Executor,
     frontend::influxrpc::InfluxRPCPlanner,
     predicate::{Predicate, PredicateBuilder, EMPTY_PREDICATE},
 };
@@ -47,13 +46,12 @@ macro_rules! run_read_filter_test_case {
             println!("Running scenario '{}'", scenario_name);
             println!("Predicate: '{:#?}'", predicate);
             let planner = InfluxRPCPlanner::new();
-            let executor = Executor::new(1);
 
             let plan = planner
                 .read_filter(&db, predicate.clone())
                 .expect("built plan successfully");
 
-            let string_results = run_series_set_plan(executor, plan).await;
+            let string_results = run_series_set_plan(db.executor(), plan).await;
 
             assert_eq!(
                 expected_results, string_results,

--- a/server/src/query_tests/influxrpc/read_group.rs
+++ b/server/src/query_tests/influxrpc/read_group.rs
@@ -4,7 +4,6 @@ use crate::query_tests::scenarios::*;
 use arrow_deps::{arrow::util::pretty::pretty_format_batches, datafusion::prelude::*};
 use async_trait::async_trait;
 use query::{
-    exec::Executor,
     frontend::influxrpc::InfluxRPCPlanner,
     group_by::Aggregate,
     predicate::{Predicate, PredicateBuilder},
@@ -26,7 +25,6 @@ macro_rules! run_read_group_test_case {
             println!("Running scenario '{}'", scenario_name);
             println!("Predicate: '{:#?}'", predicate);
             let planner = InfluxRPCPlanner::new();
-            let executor = Executor::new(1);
 
             let plans = planner
                 .read_group(&db, predicate.clone(), agg, &group_columns)
@@ -45,7 +43,8 @@ macro_rules! run_read_group_test_case {
 
             let mut string_results = vec![];
             for plan in plans.into_iter() {
-                let batches = executor
+                let batches = db
+                    .executor()
                     .run_logical_plan(plan.plan)
                     .await
                     .expect("ok running plan");

--- a/server/src/query_tests/influxrpc/read_window_aggregate.rs
+++ b/server/src/query_tests/influxrpc/read_window_aggregate.rs
@@ -7,7 +7,6 @@ use crate::{
 use arrow_deps::{arrow::util::pretty::pretty_format_batches, datafusion::prelude::*};
 use async_trait::async_trait;
 use query::{
-    exec::Executor,
     frontend::influxrpc::InfluxRPCPlanner,
     group_by::{Aggregate, WindowDuration},
     predicate::{Predicate, PredicateBuilder},
@@ -30,7 +29,6 @@ macro_rules! run_read_window_aggregate_test_case {
             println!("Running scenario '{}'", scenario_name);
             println!("Predicate: '{:#?}'", predicate);
             let planner = InfluxRPCPlanner::new();
-            let executor = Executor::new(1);
 
             let plans = planner
                 .read_window_aggregate(&db, predicate.clone(), agg, every.clone(), offset.clone())
@@ -40,7 +38,8 @@ macro_rules! run_read_window_aggregate_test_case {
 
             let mut string_results = vec![];
             for plan in plans.into_iter() {
-                let batches = executor
+                let batches = db
+                    .executor()
                     .run_logical_plan(plan.plan)
                     .await
                     .expect("ok running plan");

--- a/server/src/query_tests/influxrpc/table_names.rs
+++ b/server/src/query_tests/influxrpc/table_names.rs
@@ -1,9 +1,6 @@
 //! Tests for the Influx gRPC queries
 use query::{
-    exec::{
-        stringset::{IntoStringSet, StringSetRef},
-        Executor,
-    },
+    exec::stringset::{IntoStringSet, StringSetRef},
     frontend::influxrpc::InfluxRPCPlanner,
     predicate::{Predicate, PredicateBuilder, EMPTY_PREDICATE},
 };
@@ -23,12 +20,12 @@ macro_rules! run_table_names_test_case {
             println!("Running scenario '{}'", scenario_name);
             println!("Predicate: '{:#?}'", predicate);
             let planner = InfluxRPCPlanner::new();
-            let executor = Executor::new(1);
 
             let plan = planner
                 .table_names(&db, predicate.clone())
                 .expect("built plan successfully");
-            let names = executor
+            let names = db
+                .executor()
                 .to_string_set(plan)
                 .await
                 .expect("converted plan to strings successfully");

--- a/server/src/query_tests/influxrpc/tag_keys.rs
+++ b/server/src/query_tests/influxrpc/tag_keys.rs
@@ -1,9 +1,6 @@
 use arrow_deps::datafusion::logical_plan::{col, lit};
 use query::{
-    exec::{
-        stringset::{IntoStringSet, StringSetRef},
-        Executor,
-    },
+    exec::stringset::{IntoStringSet, StringSetRef},
     frontend::influxrpc::InfluxRPCPlanner,
     predicate::PredicateBuilder,
 };
@@ -27,12 +24,12 @@ macro_rules! run_tag_keys_test_case {
             println!("Running scenario '{}'", scenario_name);
             println!("Predicate: '{:#?}'", predicate);
             let planner = InfluxRPCPlanner::new();
-            let executor = Executor::new(1);
 
             let plan = planner
                 .tag_keys(&db, predicate.clone())
                 .expect("built plan successfully");
-            let names = executor
+            let names = db
+                .executor()
                 .to_string_set(plan)
                 .await
                 .expect("converted plan to strings successfully");

--- a/server/src/query_tests/influxrpc/tag_values.rs
+++ b/server/src/query_tests/influxrpc/tag_values.rs
@@ -1,9 +1,6 @@
 use arrow_deps::datafusion::logical_plan::{col, lit};
 use query::{
-    exec::{
-        stringset::{IntoStringSet, StringSetRef},
-        Executor,
-    },
+    exec::stringset::{IntoStringSet, StringSetRef},
     frontend::influxrpc::InfluxRPCPlanner,
     predicate::PredicateBuilder,
 };
@@ -25,12 +22,12 @@ macro_rules! run_tag_values_test_case {
             println!("Running scenario '{}'", scenario_name);
             println!("Predicate: '{:#?}'", predicate);
             let planner = InfluxRPCPlanner::new();
-            let executor = Executor::new(1);
 
             let plan = planner
                 .tag_values(&db, &tag_name, predicate.clone())
                 .expect("built plan successfully");
-            let names = executor
+            let names = db
+                .executor()
                 .to_string_set(plan)
                 .await
                 .expect("converted plan to strings successfully");

--- a/server/src/query_tests/influxrpc/util.rs
+++ b/server/src/query_tests/influxrpc/util.rs
@@ -51,7 +51,7 @@ pub fn dump_series_set(s: SeriesSet) -> Vec<String> {
 }
 
 /// Run a series set plan to completion and produce a Vec<String> representation
-pub async fn run_series_set_plan(executor: Executor, plans: SeriesSetPlans) -> Vec<String> {
+pub async fn run_series_set_plan(executor: Arc<Executor>, plans: SeriesSetPlans) -> Vec<String> {
     // Use a channel sufficiently large to buffer the series
     let (tx, mut rx) = mpsc::channel(100);
     executor

--- a/server/src/query_tests/sql.rs
+++ b/server/src/query_tests/sql.rs
@@ -6,9 +6,7 @@
 #![allow(unused_imports, dead_code, unused_macros)]
 
 use super::scenarios::*;
-use arrow_deps::{
-    arrow::record_batch::RecordBatch, assert_table_eq, datafusion::physical_plan::collect,
-};
+use arrow_deps::{arrow::record_batch::RecordBatch, assert_batches_sorted_eq};
 use query::frontend::sql::SQLQueryPlanner;
 use std::sync::Arc;
 
@@ -31,12 +29,12 @@ macro_rules! run_sql_test_case {
 
             let physical_plan = planner
                 .query(db, &sql, executor.as_ref())
-                .await
                 .expect("built plan successfully");
 
-            let results: Vec<RecordBatch> = collect(physical_plan).await.expect("Running plan");
+            let results: Vec<RecordBatch> =
+                executor.collect(physical_plan).await.expect("Running plan");
 
-            assert_table_eq!($EXPECTED_LINES, &results);
+            assert_batches_sorted_eq!($EXPECTED_LINES, &results);
         }
     };
 }

--- a/server/src/query_tests/sql.rs
+++ b/server/src/query_tests/sql.rs
@@ -9,7 +9,7 @@ use super::scenarios::*;
 use arrow_deps::{
     arrow::record_batch::RecordBatch, assert_table_eq, datafusion::physical_plan::collect,
 };
-use query::{exec::Executor, frontend::sql::SQLQueryPlanner};
+use query::frontend::sql::SQLQueryPlanner;
 use std::sync::Arc;
 
 /// runs table_names(predicate) and compares it to the expected
@@ -27,10 +27,10 @@ macro_rules! run_sql_test_case {
             println!("Running scenario '{}'", scenario_name);
             println!("SQL: '{:#?}'", sql);
             let planner = SQLQueryPlanner::default();
-            let executor = Executor::new(1);
+            let executor = db.executor();
 
             let physical_plan = planner
-                .query(db, &sql, &executor)
+                .query(db, &sql, executor.as_ref())
                 .await
                 .expect("built plan successfully");
 

--- a/server/src/query_tests/utils.rs
+++ b/server/src/query_tests/utils.rs
@@ -4,7 +4,7 @@ use data_types::{
     DatabaseName,
 };
 use object_store::{memory::InMemory, ObjectStore};
-use query::Database;
+use query::{exec::Executor, Database};
 
 use crate::{db::Db, JobRegistry};
 use std::{num::NonZeroU32, sync::Arc};
@@ -13,21 +13,25 @@ use std::{num::NonZeroU32, sync::Arc};
 pub fn make_db() -> Db {
     let server_id: NonZeroU32 = NonZeroU32::new(1).unwrap();
     let object_store = Arc::new(ObjectStore::new_in_memory(InMemory::new()));
+    let exec = Arc::new(Executor::new(1));
 
     Db::new(
         DatabaseRules::new(DatabaseName::new("placeholder").unwrap()),
         server_id,
         object_store,
+        exec,
         None, // wal buffer
         Arc::new(JobRegistry::new()),
     )
 }
 
 pub fn make_database(server_id: NonZeroU32, object_store: Arc<ObjectStore>, db_name: &str) -> Db {
+    let exec = Arc::new(Executor::new(1));
     Db::new(
         DatabaseRules::new(DatabaseName::new(db_name.to_string()).unwrap()),
         server_id,
         object_store,
+        exec,
         None, // wal buffer
         Arc::new(JobRegistry::new()),
     )

--- a/server/src/snapshot.rs
+++ b/server/src/snapshot.rs
@@ -279,7 +279,7 @@ mod tests {
     use futures::TryStreamExt;
     use mutable_buffer::chunk::Chunk as ChunkWB;
     use object_store::memory::InMemory;
-    use query::Database;
+    use query::{exec::Executor, Database};
     use tracker::MemRegistry;
 
     #[tokio::test]
@@ -391,11 +391,13 @@ mem,host=A,region=west used=45 1
     pub fn make_db() -> Db {
         let object_store = Arc::new(ObjectStore::new_in_memory(InMemory::new()));
         let server_id = std::num::NonZeroU32::new(1).unwrap();
+        let exec = Arc::new(Executor::new(1));
 
         Db::new(
             DatabaseRules::new(DatabaseName::new("placeholder").unwrap()),
             server_id,
             object_store,
+            exec,
             None, // wal buffer
             Arc::new(JobRegistry::new()),
         )

--- a/src/influxdb_ioxd/http.rs
+++ b/src/influxdb_ioxd/http.rs
@@ -733,7 +733,6 @@ mod tests {
     use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 
     use arrow_deps::{arrow::record_batch::RecordBatch, assert_table_eq};
-    use query::exec::Executor;
     use reqwest::{Client, Response};
 
     use data_types::{database_rules::DatabaseRules, DatabaseName};
@@ -768,7 +767,6 @@ mod tests {
             .create_database(
                 DatabaseRules::new(DatabaseName::new("MyOrg_MyBucket").unwrap()),
                 app_server.require_id().unwrap(),
-                Arc::clone(&app_server.store),
             )
             .await
             .unwrap();
@@ -817,7 +815,6 @@ mod tests {
             .create_database(
                 DatabaseRules::new(DatabaseName::new("MetricsOrg_MetricsBucket").unwrap()),
                 app_server.require_id().unwrap(),
-                Arc::clone(&app_server.store),
             )
             .await
             .unwrap();
@@ -876,7 +873,6 @@ mod tests {
             .create_database(
                 DatabaseRules::new(DatabaseName::new("MyOrg_MyBucket").unwrap()),
                 app_server.require_id().unwrap(),
-                Arc::clone(&app_server.store),
             )
             .await
             .unwrap();
@@ -1010,7 +1006,6 @@ mod tests {
             .create_database(
                 DatabaseRules::new(DatabaseName::new("MyOrg_MyBucket").unwrap()),
                 app_server.require_id().unwrap(),
-                Arc::clone(&app_server.store),
             )
             .await
             .unwrap();
@@ -1059,7 +1054,6 @@ mod tests {
             .create_database(
                 DatabaseRules::new(DatabaseName::new("MyOrg_MyBucket").unwrap()),
                 app_server.require_id().unwrap(),
-                Arc::clone(&app_server.store),
             )
             .await
             .unwrap();
@@ -1166,8 +1160,8 @@ mod tests {
     /// Run the specified SQL query and return formatted results as a string
     async fn run_query(db: Arc<Db>, query: &str) -> Vec<RecordBatch> {
         let planner = SQLQueryPlanner::default();
-        let executor = Executor::new(1);
-        let physical_plan = planner.query(db, query, &executor).await.unwrap();
+        let executor = db.executor();
+        let physical_plan = planner.query(db, query, executor.as_ref()).await.unwrap();
 
         collect(physical_plan).await.unwrap()
     }

--- a/src/influxdb_ioxd/rpc/flight.rs
+++ b/src/influxdb_ioxd/rpc/flight.rs
@@ -157,12 +157,12 @@ where
         let planner = SQLQueryPlanner::default();
         let executor = self.server.executor();
 
-        let physical_plan = planner
-            .query(db, &read_info.sql_query, &executor)
-            .await
-            .context(PlanningSQLQuery {
-                query: &read_info.sql_query,
-            })?;
+        let physical_plan =
+            planner
+                .query(db, &read_info.sql_query, &executor)
+                .context(PlanningSQLQuery {
+                    query: &read_info.sql_query,
+                })?;
 
         // execute the query
         let results = executor

--- a/src/influxdb_ioxd/rpc/management.rs
+++ b/src/influxdb_ioxd/rpc/management.rs
@@ -126,13 +126,8 @@ where
             Some(id) => id,
             None => return Err(NotFound::default().into()),
         };
-        let object_store = Arc::clone(&self.server.store);
 
-        match self
-            .server
-            .create_database(rules, server_id, object_store)
-            .await
-        {
+        match self.server.create_database(rules, server_id).await {
             Ok(_) => Ok(Response::new(CreateDatabaseResponse {})),
             Err(Error::DatabaseAlreadyExists { db_name }) => {
                 return Err(AlreadyExists {


### PR DESCRIPTION
Follow on to https://github.com/influxdata/influxdb_iox/pull/1191, and related to https://github.com/influxdata/conductor/issues/244 where running CPU heavy queries can cause IOx to stop responding to health check queries.

# Rationale:
Ensure that all queries are executed on the dedicated worker pool rather than the main tokio pool

# Changes:
1. Plumb a single `Arc<Executor>` through the Server and down into each Db
2. Ensure that all invocations of planning / plans happen via the `Executor`'s thread pool and not the (implicit) tokio one

# Done:
- [x] Audit code for all explicit instantiations of `Executor` and remove as many as possible
- [x] Audit code for uses of datafusion::physical_plan::collect
- [x] Audit code for use of `tokio::task::spawn`
- [x] Remove some extraneous `async` functions and corresponding `await`

# Not yet done
I plan this for the (next) PR:
- [ ] move planning into the Executor thread pool

