### PR TITLE
feat: Run query plans on the database wide executor as well

### DIFF
--- a/query/src/exec.rs
+++ b/query/src/exec.rs
@@ -303,9 +303,8 @@ impl Executor {
     }
 
     /// Runs the specified Future (and any tasks it spawns) on the
-    /// worker pool for this executor, returning the result of the computation
-    ///
-    /// This means among other things that
+    /// worker pool for this executor, returning the result of the
+    /// computation.
     pub async fn run<T>(&self, task: T) -> Result<T::Output>
     where
         T: Future + Send + 'static,

--- a/query/src/exec.rs
+++ b/query/src/exec.rs
@@ -87,8 +87,8 @@ pub enum Error {
         source: Box<SendError<Result<SeriesSetItem, SeriesSetError>>>,
     },
 
-    #[snafu(display("Error running execution task: {}", source))]
-    JoinError { source: ExecutorError },
+    #[snafu(display("Error joining execution task: {}", source))]
+    TaskJoinError { source: ExecutorError },
 }
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
@@ -210,7 +210,7 @@ impl Executor {
         // now, wait for all the values to resolve so we can report
         // any errors
         for join_handle in handles {
-            join_handle.await.context(JoinError)??;
+            join_handle.await.context(TaskJoinError)??;
         }
         Ok(())
     }
@@ -245,7 +245,7 @@ impl Executor {
         // collect them all up and combine them
         let mut results = Vec::new();
         for join_handle in handles {
-            let fieldlist = join_handle.await.context(JoinError)???;
+            let fieldlist = join_handle.await.context(TaskJoinError)???;
 
             results.push(fieldlist);
         }
@@ -296,7 +296,7 @@ impl Executor {
         // now, wait for all the values to resolve and collect them together
         let mut results = Vec::new();
         for join_handle in value_futures {
-            let mut plan_result = join_handle.await.context(JoinError)??;
+            let mut plan_result = join_handle.await.context(TaskJoinError)??;
             results.append(&mut plan_result);
         }
         Ok(results)
@@ -316,7 +316,7 @@ impl Executor {
             .spawn(task)
             // wait on the *current* tokio executor
             .await
-            .context(JoinError)
+            .context(TaskJoinError)
     }
 }
 /// Create a SchemaPivot node which  an arbitrary input like

--- a/query/src/exec/seriesset.rs
+++ b/query/src/exec/seriesset.rs
@@ -59,9 +59,6 @@ pub enum Error {
     SendingDuringGroupedConversion {
         source: Box<SendError<Result<SeriesSetItem>>>,
     },
-
-    #[snafu(display("Joining conversion execution task: {}", source))]
-    JoinError { source: tokio::task::JoinError },
 }
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;

--- a/query/src/frontend/influxrpc.rs
+++ b/query/src/frontend/influxrpc.rs
@@ -513,7 +513,6 @@ impl InfluxRPCPlanner {
     /// The data is sorted on (tag_col1, tag_col2, ...) so that all
     /// rows for a particular series (groups where all tags are the
     /// same) occur together in the plan
-
     pub fn read_filter<D>(&self, database: &D, predicate: Predicate) -> Result<SeriesSetPlans>
     where
         D: Database + 'static,
@@ -917,7 +916,7 @@ impl InfluxRPCPlanner {
     ///     GroupBy(gby cols, aggs, time cols)
     ///       Filter(predicate)
     ///          Scan
-    pub fn read_group_plan<C>(
+    fn read_group_plan<C>(
         &self,
         table_name: impl Into<String>,
         predicate: &Predicate,
@@ -1007,7 +1006,7 @@ impl InfluxRPCPlanner {
     ///      GroupBy(gby: tag columns, window_function; agg: aggregate(field)
     ///        Filter(predicate)
     ///          Scan
-    pub fn read_window_aggregate_plan<C>(
+    fn read_window_aggregate_plan<C>(
         &self,
         table_name: impl Into<String>,
         predicate: &Predicate,

--- a/src/influxdb_ioxd.rs
+++ b/src/influxdb_ioxd.rs
@@ -18,6 +18,7 @@ use snafu::{ResultExt, Snafu};
 use std::{convert::TryFrom, fs, net::SocketAddr, path::PathBuf, sync::Arc};
 
 mod http;
+mod planner;
 mod rpc;
 
 #[derive(Debug, Snafu)]

--- a/src/influxdb_ioxd/planner.rs
+++ b/src/influxdb_ioxd/planner.rs
@@ -1,0 +1,232 @@
+//! Query planner wrapper for use in IOx services
+use std::sync::Arc;
+
+use arrow_deps::datafusion::{catalog::catalog::CatalogProvider, physical_plan::ExecutionPlan};
+use query::{
+    exec::Executor,
+    frontend::{influxrpc::InfluxRPCPlanner, sql::SQLQueryPlanner},
+    group_by::{Aggregate, WindowDuration},
+    plan::{fieldlist::FieldListPlan, seriesset::SeriesSetPlans, stringset::StringSetPlan},
+    predicate::Predicate,
+    Database,
+};
+use snafu::{ResultExt, Snafu};
+
+#[derive(Debug, Snafu)]
+pub enum Error {
+    #[snafu(display("Error planning sql query {}", source))]
+    Sql {
+        query: String,
+        source: query::frontend::sql::Error,
+    },
+
+    #[snafu(display("Error planning InfluxRPC query {}", source))]
+    InfluxRPC {
+        source: query::frontend::influxrpc::Error,
+    },
+
+    #[snafu(display("Internal executor error while planning query: {}", source))]
+    InternalExecutionWhilePlanning { source: query::exec::Error },
+}
+
+pub type Result<T, E = Error> = std::result::Result<T, E>;
+
+/// Query planner that plans queries on a separate threadpool.
+///
+/// Query planning was, at time of writing, a single threaded
+/// affair. In order to avoid tying up the tokio executor that is
+/// handling API requests, we plan queries using a separate thread
+/// pool.
+///
+/// The structures in this module run the core planning logic using
+/// a separate thread pool
+pub struct Planner {
+    /// Executors (whose threadpool to use)
+    exec: Arc<Executor>,
+}
+
+impl Planner {
+    /// Create a new planner that will plan queries using the threadpool of
+    /// `exec`
+    pub fn new(exec: Arc<Executor>) -> Self {
+        Self { exec }
+    }
+
+    /// Plan a SQL query against the data in `database`, and return a
+    /// DataFusion physical execution plan.
+    pub async fn sql<D: CatalogProvider + 'static>(
+        &self,
+        database: Arc<D>,
+        query: impl Into<String>,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        let planner = SQLQueryPlanner::new();
+        let q_executor = Arc::clone(&self.exec);
+        let query = query.into();
+
+        self.exec
+            .run(async move {
+                planner
+                    .query(database, &query, q_executor.as_ref())
+                    .context(Sql { query })
+            })
+            .await
+            .context(InternalExecutionWhilePlanning)?
+    }
+
+    /// Creates a plan as described on
+    /// [`InfluxRPCPlanner::table_names`], on a separate threadpool
+    pub async fn table_names<D>(
+        &self,
+        database: Arc<D>,
+        predicate: Predicate,
+    ) -> Result<StringSetPlan>
+    where
+        D: Database + 'static,
+    {
+        let planner = InfluxRPCPlanner::new();
+
+        self.exec
+            .run(async move {
+                planner
+                    .table_names(database.as_ref(), predicate)
+                    .context(InfluxRPC)
+            })
+            .await
+            .context(InternalExecutionWhilePlanning)?
+    }
+
+    /// Creates a plan as described on
+    /// [`InfluxRPCPlanner::tag_keys`], on a separate threadpool
+    pub async fn tag_keys<D>(&self, database: Arc<D>, predicate: Predicate) -> Result<StringSetPlan>
+    where
+        D: Database + 'static,
+    {
+        let planner = InfluxRPCPlanner::new();
+
+        self.exec
+            .run(async move {
+                planner
+                    .tag_keys(database.as_ref(), predicate)
+                    .context(InfluxRPC)
+            })
+            .await
+            .context(InternalExecutionWhilePlanning)?
+    }
+
+    /// Creates a plan as described on
+    /// [`InfluxRPCPlanner::tag_values`], on a separate threadpool
+    pub async fn tag_values<D>(
+        &self,
+        database: Arc<D>,
+        tag_name: impl Into<String>,
+        predicate: Predicate,
+    ) -> Result<StringSetPlan>
+    where
+        D: Database + 'static,
+    {
+        let tag_name = tag_name.into();
+        let planner = InfluxRPCPlanner::new();
+
+        self.exec
+            .run(async move {
+                planner
+                    .tag_values(database.as_ref(), &tag_name, predicate)
+                    .context(InfluxRPC)
+            })
+            .await
+            .context(InternalExecutionWhilePlanning)?
+    }
+
+    /// Creates a plan as described on
+    /// [`InfluxRPCPlanner::field_columns`], on a separate threadpool
+    pub async fn field_columns<D>(
+        &self,
+        database: Arc<D>,
+        predicate: Predicate,
+    ) -> Result<FieldListPlan>
+    where
+        D: Database + 'static,
+    {
+        let planner = InfluxRPCPlanner::new();
+
+        self.exec
+            .run(async move {
+                planner
+                    .field_columns(database.as_ref(), predicate)
+                    .context(InfluxRPC)
+            })
+            .await
+            .context(InternalExecutionWhilePlanning)?
+    }
+
+    /// Creates a plan as described on
+    /// [`InfluxRPCPlanner::read_filter`], on a separate threadpool
+    pub async fn read_filter<D>(
+        &self,
+        database: Arc<D>,
+        predicate: Predicate,
+    ) -> Result<SeriesSetPlans>
+    where
+        D: Database + 'static,
+    {
+        let planner = InfluxRPCPlanner::new();
+
+        self.exec
+            .run(async move {
+                planner
+                    .read_filter(database.as_ref(), predicate)
+                    .context(InfluxRPC)
+            })
+            .await
+            .context(InternalExecutionWhilePlanning)?
+    }
+
+    /// Creates a plan as described on
+    /// [`InfluxRPCPlanner::read_group`], on a separate threadpool
+    pub async fn read_group<D>(
+        &self,
+        database: Arc<D>,
+        predicate: Predicate,
+        agg: Aggregate,
+        group_columns: Vec<String>,
+    ) -> Result<SeriesSetPlans>
+    where
+        D: Database + 'static,
+    {
+        let planner = InfluxRPCPlanner::new();
+
+        self.exec
+            .run(async move {
+                planner
+                    .read_group(database.as_ref(), predicate, agg, &group_columns)
+                    .context(InfluxRPC)
+            })
+            .await
+            .context(InternalExecutionWhilePlanning)?
+    }
+
+    /// Creates a plan as described on
+    /// [`InfluxRPCPlanner::read_window_aggregate`], on a separate threadpool
+    pub async fn read_window_aggregate<D>(
+        &self,
+        database: Arc<D>,
+        predicate: Predicate,
+        agg: Aggregate,
+        every: WindowDuration,
+        offset: WindowDuration,
+    ) -> Result<SeriesSetPlans>
+    where
+        D: Database + 'static,
+    {
+        let planner = InfluxRPCPlanner::new();
+
+        self.exec
+            .run(async move {
+                planner
+                    .read_window_aggregate(database.as_ref(), predicate, agg, every, offset)
+                    .context(InfluxRPC)
+            })
+            .await
+            .context(InternalExecutionWhilePlanning)?
+    }
+}

--- a/src/influxdb_ioxd/planner.rs
+++ b/src/influxdb_ioxd/planner.rs
@@ -37,9 +37,6 @@ pub type Result<T, E = Error> = std::result::Result<T, E>;
 /// affair. In order to avoid tying up the tokio executor that is
 /// handling API requests, we plan queries using a separate thread
 /// pool.
-///
-/// The structures in this module run the core planning logic using
-/// a separate thread pool
 pub struct Planner {
     /// Executors (whose threadpool to use)
     exec: Arc<Executor>,


### PR DESCRIPTION
Follow on to https://github.com/influxdata/influxdb_iox/pull/1198 and closes https://github.com/influxdata/conductor/issues/244 where running CPU heavy queries can cause IOx to stop responding to health check queries.

# Rationale:
Some queries can take a long time to plan (e.g. some of the "metadata" queries that touch actual data"), and we would liek these queries not to prevent other API requests from being serviced.

# Changes:

- [x] Add new `Planner` structure in `influxdb_ioxd` which handles creating plans on the query execution thread pool
- [x] Update influxdb_ioxd handlers to use `Planner` rather than `SQLQueryPlanner` or `InfluxRPCPlanner` directly
- [x] Audit use of InfluxRPCPlanner and SQLPlanner in the `influxdb_ioxd` code

# Discussion

While the `Planner` structure is somewhat repetitive, wrapping the underlying `query::frontend` planners, this design has the benefit of keeping all the async / threading out of the core planning logic and isolated to the `influxdb_ioxd` module, where it is needed.

This structure should also make switching to a dedicated thread pool just for planning, if we ever want to, relatively straightforward

# Questions / Future work

I don't really have a good testing story for this PR other than "on production". I thought of tracking how many tasks got run on the dedicated executor and writing some tests to makes sure queries are planned there but I thought that would likely be brittle (the numbers of tasks would change based on changes to the underlying planners, etc) and not add sufficient testing to be worth the effort.

It seems what we really need is a system level stress test showing api responses aren't held up by query planning or execution. This is probably something we need a higher level test harness / system but I don't think we are at the point of the project to invest yet. So I am "testing on my machine" and calling it good!

As mentioned above, we also considered planning queries using a threadpool dedicated only to queries. This would ensure that some queries (e.g. metadata queries like SHOW TAG KEYS) that are often run without a DataFusion plan and are used to drive the UI could respond without waiting for slower queries to finish. Given the way tokio / DataFusion work, if we plan using the same pool as we execute on, the plans will back up behind any currently executing queries, which doesn't sound good)

In an ideal world, we would have some sort of IOx scheduler that would have a list of queries to run and only start them based on our own application logic. This would have to include some sort of periodic yield to the scheduler as well. Some day (TM)
