### PR TITLE
refactor: use read_buffer column range for time range

### DIFF
--- a/read_buffer/src/chunk.rs
+++ b/read_buffer/src/chunk.rs
@@ -316,19 +316,6 @@ impl Chunk {
         Ok(table.read_filter(&select_columns, &predicate))
     }
 
-    /// Returns timestamp range for specified table
-    pub fn read_time_range(&self, table_name: &str) -> Result<Option<(i64, i64)>> {
-        // read lock on chunk.
-        let chunk_data = self.chunk_data.read().unwrap();
-
-        let table = chunk_data
-            .data
-            .get(table_name)
-            .context(TableNotFound { table_name })?;
-
-        Ok(table.time_range())
-    }
-
     /// Returns an iterable collection of data in group columns and aggregate
     /// columns, optionally filtered by the provided predicate. Results are
     /// merged across all row groups within the returned table.
@@ -387,6 +374,29 @@ impl Chunk {
             .values()
             .map(|table| table.table_summary())
             .collect()
+    }
+
+    /// A helper method for determining the time-range associated with the
+    /// specified table.
+    ///
+    /// A table's schema need not contain a column representing the time,
+    /// however any table that represents data using the InfluxDB model does
+    /// contain a column that represents the timestamp associated with each
+    /// row.
+    ///
+    /// `table_time_range` will return the min and max values for that column
+    /// if the table is using the InfluxDB data-model, otherwise it will return
+    /// `None`. An error will be returned if the table does not exist.
+    pub fn table_time_range(&self, table_name: &str) -> Result<Option<(i64, i64)>> {
+        // read lock on chunk.
+        let chunk_data = self.chunk_data.read().unwrap();
+
+        let table = chunk_data
+            .data
+            .get(table_name)
+            .context(TableNotFound { table_name })?;
+
+        Ok(table.time_range())
     }
 
     /// Returns a schema object for a `read_filter` operation using the provided

--- a/server/src/db.rs
+++ b/server/src/db.rs
@@ -514,7 +514,7 @@ impl Db {
                 .context(ReadBufferChunkSchemaError { chunk_id })?
                 .into();
             let time_range = rb_chunk
-                .read_time_range(stats.name.as_str())
+                .table_time_range(stats.name.as_str())
                 .context(ReadBufferChunkTimestampError { chunk_id })?;
             let stream: SendableRecordBatchStream = Box::pin(
                 streams::ReadFilterResultsStream::new(read_results, Arc::clone(&arrow_schema)),


### PR DESCRIPTION
Follows on from #1201

This PR refactors the `read_time_range` method recently added in #1201 to use the semantic type of the columns in the table schema to determine which is the timestamp column, and then return the range for that column.

I changed it to do this as the `time_range` `i64` methods/fields in the Read Buffer are vestiges of a time when I was thinking about timestamps as being particularly special. They're not, and I'm going to remove those references.