### PR TITLE
fix: Crash early when writer id is passed on cmdline and cannot loaddb from objectstore

### DIFF
--- a/src/influxdb_ioxd.rs
+++ b/src/influxdb_ioxd.rs
@@ -69,6 +69,9 @@ pub enum Error {
     // don't return `Result`.
     #[snafu(display("Amazon S3 configuration was invalid: {}", source))]
     InvalidS3Config { source: object_store::aws::Error },
+
+    #[snafu(display("cannot load database config: {}", source))]
+    LoadDatabaseConfig { source: server::Error },
 }
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
@@ -146,12 +149,10 @@ pub async fn main(logging_level: LoggingLevel, config: Config) -> Result<()> {
     // call
     if let Some(id) = config.writer_id {
         app_server.set_id(id).expect("writer id already set");
-        if let Err(e) = app_server.load_database_configs().await {
-            error!(
-                "unable to load database configurations from object storage: {}",
-                e
-            )
-        }
+        app_server
+            .load_database_configs()
+            .await
+            .context(LoadDatabaseConfig)?;
     } else {
         warn!("server ID not set. ID must be set via the INFLUXDB_IOX_ID config or API before writing or querying data.");
     }


### PR DESCRIPTION
Closes #1206

__Rationale__

The IOx server can be started with an writer id flag/env variable, or the writer id
can be set with an RPC call from conductor.

If the writer ID is passed from a flag, it immediately loads the database configuration
at startup time.

If the pod networking system is not yet ready during early startup (e.g. when the main
container wins the race against the istio envoy sidecar), network requests to S3 (and to the
local cloud metadata server anycast address used to retrieve the IAM auth token) will fail.

In these cases, generally the simplest thing to do is to crash early; k8s will restart the
container and eventually envoy will be ready.

If the crash is caused by a config error, the crashlooping effect will effectively
inform the deployment controller that the rollout has failed and it will rollback to the previous version of the deployment (and things like argocd will rollback the whole rollout).

__Caveat__

This PR doesn't change nor address the scenario where the IOx server starts without writer ID
and conductor sets it later.
