### PR TITLE
fix: Flight Query API Internal error "There were no results from ticket"

### DIFF
--- a/src/influxdb_ioxd/rpc/flight.rs
+++ b/src/influxdb_ioxd/rpc/flight.rs
@@ -170,9 +170,6 @@ where
             .context(Query {
                 database_name: &read_info.database_name,
             })?;
-        if results.is_empty() {
-            return Err(tonic::Status::internal("There were no results from ticket"));
-        }
 
         let options = arrow::ipc::writer::IpcWriteOptions::default();
         let schema = physical_plan.schema();


### PR DESCRIPTION
Closes #1226

# Rationale
It is perfectly legitimate for a query to return 0 rows, so there is no reason to make an error in this case
(I was seeing this error when scraping remote system tables in https://github.com/influxdata/influxdb_iox/pull/1117 for databases that had no data yet)

# Changes
Remove error, add test
