### PR TITLE
fix: set defaults for `persist` and `drop_non_persisted` to `true`

### DIFF
--- a/data_types/src/database_rules.rs
+++ b/data_types/src/database_rules.rs
@@ -207,6 +207,7 @@ pub struct LifecycleRules {
     pub sort_order: SortOrder,
 
     /// Allow dropping data that has not been persisted to object storage
+    /// once the database size has exceeded the configured limits
     pub drop_non_persisted: bool,
 
     /// Persists chunks to object storage.

--- a/generated_types/protos/influxdata/iox/management/v1/database_rules.proto
+++ b/generated_types/protos/influxdata/iox/management/v1/database_rules.proto
@@ -149,6 +149,7 @@ message LifecycleRules {
   SortOrder sort_order = 6;
 
   // Allow dropping data that has not been persisted to object storage
+  // once the database size has exceeded the configured limits
   bool drop_non_persisted = 7;
 
   // Persists chunks to object storage.

--- a/src/commands/database.rs
+++ b/src/commands/database.rs
@@ -102,11 +102,12 @@ struct Create {
     buffer_size_hard: usize,
 
     /// Allow dropping data that has not been persisted to object storage
-    #[structopt(long)]
+    /// once the database size has exceeded the configured limits
+    #[structopt(long = "drop-persisted-only", parse(from_flag = std::ops::Not::not))]
     drop_non_persisted: bool,
 
     /// Persists chunks to object storage.
-    #[structopt(long)]
+    #[structopt(long = "skip-persist", parse(from_flag = std::ops::Not::not))]
     persist: bool,
 
     /// Do not allow writing new data to this database


### PR DESCRIPTION
This should prevent writer deaths for default configs.

Closes #1225.
