### PR TITLE
chore: Run flatbuffers regeneration and InfluxDB 2.0 integration tests in docker by default

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -115,7 +115,7 @@ jobs:
       - cache_restore
       - run:
           name: Cargo test
-          command: TEST_INTEGRATION=1 cargo test -p influxdb2_client
+          command: TEST_INTEGRATION=1 LOCAL=1 cargo test -p influxdb2_client
       - cache_save
 
   # Build a dev binary.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -168,7 +168,7 @@ jobs:
       - rust_components # Regenerating flatbuffers uses rustfmt
       - run:
           name: Check Flatbuffers
-          command: ./generated_types/check-flatbuffers.sh
+          command: LOCAL=1 ./generated_types/check-flatbuffers.sh
 
   # Compile a cargo "release" profile binary for branches that end in `/perf`
   #

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,12 +111,6 @@ jobs:
         RUSTFLAGS: "-C debuginfo=1"
     steps:
       - checkout
-      - run:
-          name: Install InfluxDB 2.0 OSS
-          command: |
-              curl -o influxdb2.tar.gz https://dl.influxdata.com/influxdb/releases/influxdb2-2.0.4-linux-amd64.tar.gz
-              tar xvzf influxdb2.tar.gz
-              sudo cp influxdb2-2.0.4-linux-amd64/{influx,influxd} /usr/local/bin/
       - rust_components
       - cache_restore
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -115,7 +115,7 @@ jobs:
       - cache_restore
       - run:
           name: Cargo test
-          command: TEST_INTEGRATION=1 LOCAL=1 cargo test -p influxdb2_client
+          command: TEST_INTEGRATION=1 INFLUXDB_IOX_INTEGRATION_LOCAL=1 cargo test -p influxdb2_client
       - cache_save
 
   # Build a dev binary.
@@ -162,7 +162,7 @@ jobs:
       - rust_components # Regenerating flatbuffers uses rustfmt
       - run:
           name: Check Flatbuffers
-          command: LOCAL=1 ./generated_types/check-flatbuffers.sh
+          command: INFLUXDB_IOX_INTEGRATION_LOCAL=1 ./generated_types/check-flatbuffers.sh
 
   # Compile a cargo "release" profile binary for branches that end in `/perf`
   #

--- a/docs/regenerating_flatbuffers.md
+++ b/docs/regenerating_flatbuffers.md
@@ -27,5 +27,5 @@ new major or minor version:
 
 By default, the `generated_types/regenerate-flatbuffers.sh` script will run a Docker container that
 uses the same image we use in CI that will have all the necessary dependencies. If you don't want
-to use Docker, run this script with `LOCAL=1`, which will require you to have `bazel` available.
-You can likely install `bazel` with your favourite package manager.
+to use Docker, run this script with `INFLUXDB_IOX_INTEGRATION_LOCAL=1`, which will require you to
+have `bazel` available. You can likely install `bazel` with your favourite package manager.

--- a/docs/regenerating_flatbuffers.md
+++ b/docs/regenerating_flatbuffers.md
@@ -1,10 +1,31 @@
 # Regenerating Flatbuffers code
 
-When updating the version of the [flatbuffers](https://crates.io/crates/flatbuffers) Rust crate used as a dependency in the IOx workspace, the generated Rust code in `generated_types/src/wal_generated.rs` also needs to be updated in sync.
+If you have changed some `*.fbs` files:
 
-To update the generated code, edit `generated_types/regenerate-flatbuffers.sh` and set the `FB_COMMIT` variable at the top of the file to the commit SHA of the same commit in the [flatbuffers repository](https://github.com/google/flatbuffers) where the `flatbuffers` Rust crate version was updated. This ensures we'll be [using the same version of `flatc` that the crate was tested with](https://github.com/google/flatbuffers/issues/6199#issuecomment-714562121).
+- Run `./generated_types/regenerate-flatbuffers.sh` to regenerate the corresponding Rust code.
+- Run `cargo test` to make sure everything works as you would expect.
+- Check in the changes to the generated code along with your changes to the `*.fbs` files.
+- You should not need to edit the `generated_types/regenerate-flatbuffers.sh` script.
 
-Then run the `generated_types/regenerate-flatbuffers.sh` script and check in any changes. Check the whole project builds.
+If you are updating the version of the `flatbuffers` crate in `Cargo.lock`, either because a new
+patch release has come out that is compatible with the version range in `Cargo.toml` and you have
+run `cargo update`, or because you've updated the version constraint in `Cargo.toml` to change to a
+new major or minor version:
 
-`generated_types/regenerate-flatbuffers.sh` will build `flatc` from source if it cannot be found.
-In order to do that your system will require `bazel`; you can likely install this with your favourite package manager.
+- The `flatbuffers` crate gets developed in sync with the `flatc` compiler in the same repo,
+  so when updating the `flatbuffers` crate we also need to update the `flatc` compiler we're
+  using.
+- Go to https://github.com/google/flatbuffers/blame/master/rust/flatbuffers/Cargo.toml and find
+  the commit SHA where the `version` metadata was updated to the version of the `flatbuffers`
+  crate we now want to have in our `Cargo.lock`.
+- In the `generated_types/regenerate-flatbuffers.sh` script, put that commit SHA in the `FB_COMMIT`
+  variable.
+- Run `./generated_types/regenerate-flatbuffers.sh` to regenerate the corresponding Rust code.
+- Run `cargo test` to make sure everything works as you would expect.
+- Check in the changes to the generated code along with your changes to the `Cargo.lock` file,
+  `Cargo.toml` file if relevant, and the `generated_types/regenerate-flatbuffers.sh` script.
+
+By default, the `generated_types/regenerate-flatbuffers.sh` script will run a Docker container that
+uses the same image we use in CI that will have all the necessary dependencies. If you don't want
+to use Docker, run this script with `LOCAL=1`, which will require you to have `bazel` available.
+You can likely install `bazel` with your favourite package manager.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -33,9 +33,14 @@ of `influxdb_iox run --help` for instructions.
 ## InfluxDB 2 Client
 
 The `influxdb2_client` crate may be used by people using InfluxDB 2.0 OSS, and should be compatible
-with both that and IOx. If you have `influxd` in your path, the integration tests for the
-`influxdb2_client` crate will run integration tests against `influxd`. If you do not have
-`influxd`, those tests will not be run and will silently pass.
+with both that and IOx. If you have `docker` in your path, the integration tests for the
+`influxdb2_client` crate will run integration tests against `influxd` running in a Docker
+container. If you do not have `docker`, by default, those tests will not be run and will silently
+pass.
+
+If you do not have and do not want to have Docker locally, but you do have `influxd` for InfluxDB
+2.0 locally, you can use that instead by running the tests with the environment variable `LOCAL=1`.
 
 To ensure you're running the `influxdb2_client` integration tests, you can run `TEST_INTEGRATION=1
-cargo test -p influxdb2_client`, which will fail the tests if `influxd` is not available.
+cargo test -p influxdb2_client`, which will fail the tests if `docker` (or `influxd`, if `LOCAL=1`
+is set) is not available.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -39,8 +39,9 @@ container. If you do not have `docker`, by default, those tests will not be run 
 pass.
 
 If you do not want to use Docker locally, but you do have `influxd` for InfluxDB
-2.0 locally, you can use that instead by running the tests with the environment variable `LOCAL=1`.
+2.0 locally, you can use that instead by running the tests with the environment variable
+`INFLUXDB_IOX_INTEGRATION_LOCAL=1`.
 
 To ensure you're running the `influxdb2_client` integration tests, you can run `TEST_INTEGRATION=1
-cargo test -p influxdb2_client`, which will fail the tests if `docker` (or `influxd`, if `LOCAL=1`
-is set) is not available.
+cargo test -p influxdb2_client`, which will fail the tests if `docker` (or `influxd`, if
+`INFLUXDB_IOX_INTEGRATION_LOCAL=1` is set) is not available.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -38,7 +38,7 @@ with both that and IOx. If you have `docker` in your path, the integration tests
 container. If you do not have `docker`, by default, those tests will not be run and will silently
 pass.
 
-If you do not have and do not want to have Docker locally, but you do have `influxd` for InfluxDB
+If you do not want to use Docker locally, but you do have `influxd` for InfluxDB
 2.0 locally, you can use that instead by running the tests with the environment variable `LOCAL=1`.
 
 To ensure you're running the `influxdb2_client` integration tests, you can run `TEST_INTEGRATION=1

--- a/generated_types/check-flatbuffers.sh
+++ b/generated_types/check-flatbuffers.sh
@@ -6,13 +6,6 @@ pushd $DIR
 
 echo "Regenerating flatbuffers code..."
 
-# Will move this to docker if it works
-sudo apt install g++
-curl -Lo bazel-4.0.0-installer-linux-x86_64.sh https://github.com/bazelbuild/bazel/releases/download/4.0.0/bazel-4.0.0-installer-linux-x86_64.sh
-ls -lrta
-chmod +x bazel-4.0.0-installer-linux-x86_64.sh
-./bazel-4.0.0-installer-linux-x86_64.sh --user
-
 ./regenerate-flatbuffers.sh
 
 echo "Checking for uncommitted changes..."

--- a/generated_types/regenerate-flatbuffers.sh
+++ b/generated_types/regenerate-flatbuffers.sh
@@ -26,8 +26,8 @@ FB_COMMIT="86401e078d0746d2381735415f8c2dfe849f3f52"
 
 # By default, this script will run a Docker container that uses the same image we use in CI that
 # will have all the necessary dependencies. If you don't want to run Docker, run this script with
-# LOCAL=1.
-if [ -z "${LOCAL}" ]; then
+# INFLUXDB_IOX_INTEGRATION_LOCAL=1.
+if [ -z "${INFLUXDB_IOX_INTEGRATION_LOCAL}" ]; then
   echo "Running in Docker..."
 
   CI_IMAGE=quay.io/influxdb/rust:ci
@@ -48,7 +48,7 @@ if [ -z "${LOCAL}" ]; then
     --volume "${DIR}/..:${DOCKER_IOX_DIR}" \
     ${CI_IMAGE}
 
-  docker exec -e LOCAL=1 flatc .${DOCKER_IOX_DIR}/generated_types/regenerate-flatbuffers.sh
+  docker exec -e INFLUXDB_IOX_INTEGRATION_LOCAL=1 flatc .${DOCKER_IOX_DIR}/generated_types/regenerate-flatbuffers.sh
 
   docker rm --force flatc || true
 else

--- a/generated_types/regenerate-flatbuffers.sh
+++ b/generated_types/regenerate-flatbuffers.sh
@@ -58,7 +58,7 @@ popd
 
 RUST_DIR="$DIR/src"
 while read -r FBS_FILE; do
-    echo "Compiling ${FBS_file}"
+    echo "Compiling ${FBS_FILE}"
     $FLATC --rust -o $RUST_DIR $FBS_FILE
 done < <(git ls-files $DIR/*.fbs)
 

--- a/generated_types/regenerate-flatbuffers.sh
+++ b/generated_types/regenerate-flatbuffers.sh
@@ -24,45 +24,78 @@ FB_COMMIT="86401e078d0746d2381735415f8c2dfe849f3f52"
 # - Check in the changes to the generated code along with your changes to the `Cargo.lock` file and
 #   this script.
 
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-pushd $DIR
+# By default, this script will run a Docker container that uses the same image we use in CI that
+# will have all the necessary dependencies. If you don't want to run Docker, run this script with
+# LOCAL=1.
+if [ -z ${LOCAL} ]; then
+  echo "Running in Docker..."
 
-echo "Building flatc from source ..."
+  CI_IMAGE=quay.io/influxdb/rust:ci
 
-FB_URL="https://github.com/google/flatbuffers"
-FB_DIR=".flatbuffers"
-FLATC="$FB_DIR/bazel-bin/flatc"
+  DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+  pushd $DIR
 
-if [ -z $(which bazel) ]; then
-    echo "bazel is required to build flatc"
-    exit 1
-fi
+  DOCKER_IOX_DIR=/home/rust/influxdb_iox
 
-echo "Bazel version: $(bazel version | head -1 | awk -F':' '{print $2}')"
+  docker kill flatc || true
+  docker rm flatc || true
 
-if [ ! -e $FB_DIR ]; then
-    echo "git clone $FB_URL ..."
-    git clone -b master --no-tag $FB_URL $FB_DIR
+  docker pull ${CI_IMAGE} || true
+
+  docker run \
+    -it \
+    --detach \
+    --name=flatc \
+    --volume ${DIR}/..:${DOCKER_IOX_DIR} \
+    ${CI_IMAGE}
+
+  docker exec -e LOCAL=1 flatc .${DOCKER_IOX_DIR}/generated_types/regenerate-flatbuffers.sh
+
+  docker kill flatc || true
+  docker rm flatc || true
 else
-    echo "git pull $FB_URL ..."
-    git -C $FB_DIR pull --ff-only
+  echo "Running locally..."
+
+  DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+  pushd $DIR
+
+  echo "Building flatc from source ..."
+
+  FB_URL="https://github.com/google/flatbuffers"
+  FB_DIR=".flatbuffers"
+  FLATC="$FB_DIR/bazel-bin/flatc"
+
+  if [ -z $(which bazel) ]; then
+      echo "bazel is required to build flatc"
+      exit 1
+  fi
+
+  echo "Bazel version: $(bazel version | head -1 | awk -F':' '{print $2}')"
+
+  if [ ! -e $FB_DIR ]; then
+      echo "git clone $FB_URL ..."
+      git clone -b master --no-tag $FB_URL $FB_DIR
+  else
+      echo "git pull $FB_URL ..."
+      git -C $FB_DIR pull --ff-only
+  fi
+
+  echo "hard reset to $FB_COMMIT"
+  git -C $FB_DIR reset --hard $FB_COMMIT
+
+  pushd $FB_DIR
+  echo "run: bazel build :flatc ..."
+  bazel build :flatc
+  popd
+
+  RUST_DIR="$DIR/src"
+  while read -r FBS_FILE; do
+      echo "Compiling ${FBS_FILE}"
+      $FLATC --rust -o $RUST_DIR $FBS_FILE
+  done < <(git ls-files $DIR/*.fbs)
+
+  cargo fmt
+  popd
+
+  echo "DONE! Please run 'cargo test' and check in any changes."
 fi
-
-echo "hard reset to $FB_COMMIT"
-git -C $FB_DIR reset --hard $FB_COMMIT
-
-pushd $FB_DIR
-echo "run: bazel build :flatc ..."
-bazel build :flatc
-popd
-
-RUST_DIR="$DIR/src"
-while read -r FBS_FILE; do
-    echo "Compiling ${FBS_FILE}"
-    $FLATC --rust -o $RUST_DIR $FBS_FILE
-done < <(git ls-files $DIR/*.fbs)
-
-cargo fmt
-popd
-
-echo "DONE! Please run 'cargo test' and check in any changes."

--- a/generated_types/regenerate-flatbuffers.sh
+++ b/generated_types/regenerate-flatbuffers.sh
@@ -37,8 +37,7 @@ if [ -z ${LOCAL} ]; then
 
   DOCKER_IOX_DIR=/home/rust/influxdb_iox
 
-  docker kill flatc || true
-  docker rm flatc || true
+  docker rm --force flatc || true
 
   docker pull ${CI_IMAGE} || true
 
@@ -51,8 +50,7 @@ if [ -z ${LOCAL} ]; then
 
   docker exec -e LOCAL=1 flatc .${DOCKER_IOX_DIR}/generated_types/regenerate-flatbuffers.sh
 
-  docker kill flatc || true
-  docker rm flatc || true
+  docker rm --force flatc || true
 else
   echo "Running locally..."
 

--- a/generated_types/regenerate-flatbuffers.sh
+++ b/generated_types/regenerate-flatbuffers.sh
@@ -27,13 +27,13 @@ FB_COMMIT="86401e078d0746d2381735415f8c2dfe849f3f52"
 # By default, this script will run a Docker container that uses the same image we use in CI that
 # will have all the necessary dependencies. If you don't want to run Docker, run this script with
 # LOCAL=1.
-if [ -z ${LOCAL} ]; then
+if [ -z "${LOCAL}" ]; then
   echo "Running in Docker..."
 
   CI_IMAGE=quay.io/influxdb/rust:ci
 
   DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-  pushd $DIR
+  pushd "$DIR"
 
   DOCKER_IOX_DIR=/home/rust/influxdb_iox
 
@@ -45,7 +45,7 @@ if [ -z ${LOCAL} ]; then
     -it \
     --detach \
     --name=flatc \
-    --volume ${DIR}/..:${DOCKER_IOX_DIR} \
+    --volume "${DIR}/..:${DOCKER_IOX_DIR}" \
     ${CI_IMAGE}
 
   docker exec -e LOCAL=1 flatc .${DOCKER_IOX_DIR}/generated_types/regenerate-flatbuffers.sh
@@ -55,7 +55,7 @@ else
   echo "Running locally..."
 
   DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-  pushd $DIR
+  pushd "$DIR"
 
   echo "Building flatc from source ..."
 
@@ -63,7 +63,7 @@ else
   FB_DIR=".flatbuffers"
   FLATC="$FB_DIR/bazel-bin/flatc"
 
-  if [ -z $(which bazel) ]; then
+  if [ -z "$(which bazel)" ]; then
       echo "bazel is required to build flatc"
       exit 1
   fi
@@ -89,8 +89,8 @@ else
   RUST_DIR="$DIR/src"
   while read -r FBS_FILE; do
       echo "Compiling ${FBS_FILE}"
-      $FLATC --rust -o $RUST_DIR $FBS_FILE
-  done < <(git ls-files $DIR/*.fbs)
+      $FLATC --rust -o "$RUST_DIR" "$FBS_FILE"
+  done < <(git ls-files "$DIR"/*.fbs)
 
   cargo fmt
   popd

--- a/influxdb2_client/tests/common/server_fixture.rs
+++ b/influxdb2_client/tests/common/server_fixture.rs
@@ -10,8 +10,6 @@ use std::{
 };
 use tokio::sync::Mutex;
 
-type Result<T = (), E = Box<dyn std::error::Error>> = std::result::Result<T, E>;
-
 #[macro_export]
 /// If InfluxDB 2.0 OSS is available (either locally via `influxd` directly if
 /// the `INFLUXDB_IOX_INTEGRATION_LOCAL` environment variable is set, or via
@@ -77,7 +75,7 @@ impl ServerFixture {
             Some(server) => server,
             None => {
                 // if not, create one
-                let mut server = TestServer::new().expect("Starting of test server");
+                let mut server = TestServer::new();
                 // ensure the server is ready
                 server.wait_until_ready(InitialConfig::Onboarded).await;
 
@@ -99,7 +97,7 @@ impl ServerFixture {
     /// waits. The database is left unconfigured and is not shared
     /// with any other tests.
     pub async fn create_single_use() -> Self {
-        let mut server = TestServer::new().expect("Could start test server");
+        let mut server = TestServer::new();
 
         // ensure the server is ready
         server.wait_until_ready(InitialConfig::None).await;
@@ -166,7 +164,7 @@ struct TestServer {
 }
 
 impl TestServer {
-    fn new() -> Result<Self> {
+    fn new() -> Self {
         let ready = Mutex::new(ServerState::Started);
         let http_port = NEXT_PORT.fetch_add(1, SeqCst);
         let http_base = format!("http://127.0.0.1:{}", http_port);
@@ -239,13 +237,13 @@ impl TestServer {
             (cmd, Some(container_name))
         };
 
-        Ok(Self {
+        Self {
             ready,
             server_process,
             docker_name,
             http_base,
             admin_token: None,
-        })
+        }
     }
 
     async fn wait_until_ready(&mut self, initial_config: InitialConfig) {

--- a/influxdb2_client/tests/common/server_fixture.rs
+++ b/influxdb2_client/tests/common/server_fixture.rs
@@ -14,15 +14,15 @@ type Result<T = (), E = Box<dyn std::error::Error>> = std::result::Result<T, E>;
 
 #[macro_export]
 /// If InfluxDB 2.0 OSS is available (either locally via `influxd` directly if
-/// the `LOCAL` environment variable is set, or via `docker` otherwise), set
-/// up the server as requested and return it to the caller.
+/// the `INFLUXDB_IOX_INTEGRATION_LOCAL` environment variable is set, or via
+/// `docker` otherwise), set up the server as requested and return it to the caller.
 ///
 /// If InfluxDB is not available, skip the calling test by returning
 /// early. Additionally if `TEST_INTEGRATION` is set, turn this early return
 /// into a panic to force a hard fail for skipped integration tests.
 macro_rules! maybe_skip_integration {
     ($server_fixture:expr) => {{
-        let local = std::env::var("LOCAL").is_ok();
+        let local = std::env::var("INFLUXDB_IOX_INTEGRATION_LOCAL").is_ok();
         let command = if local { "influxd" } else { "docker" };
 
         match (
@@ -192,7 +192,7 @@ impl TestServer {
             .expect("cloning file handle for stdout");
         let stderr_log_file = log_file;
 
-        let local = std::env::var("LOCAL").is_ok();
+        let local = std::env::var("INFLUXDB_IOX_INTEGRATION_LOCAL").is_ok();
 
         let (server_process, docker_name) = if local {
             let cmd = Command::new("influxd")

--- a/influxdb2_client/tests/common/server_fixture.rs
+++ b/influxdb2_client/tests/common/server_fixture.rs
@@ -209,7 +209,7 @@ impl TestServer {
                 .expect("starting of local server process");
             (cmd, None)
         } else {
-            let ci_image = "quay.io/influxdb/rust:bf4ea222";
+            let ci_image = "quay.io/influxdb/rust:ci";
             let container_name = format!("influxdb2_{}", http_port);
 
             Command::new("docker")


### PR DESCRIPTION
Fixes #1176.
Fixes #1166.

If you want to opt out of using Docker for either regenerating the flatbuffers or running the InfluxDB 2.0 integration tests, you can set the environment variable `LOCAL=1`.