### PR TITLE
fix: don't clone arrays to make TimestampNanosecondArrays

### DIFF
--- a/mutable_buffer/src/table.rs
+++ b/mutable_buffer/src/table.rs
@@ -383,9 +383,7 @@ impl Table {
                 }
                 Column::I64(vals, _) => {
                     if col.column_name == TIME_COLUMN_NAME {
-                        // TODO: there is no reason that this needs an owned copy of the Vec...
-                        // should file a ticket with arrow to add something to avoid the clone
-                        let array = TimestampNanosecondArray::from_opt_vec(vals.clone(), None);
+                        let array = TimestampNanosecondArray::from_iter(vals.iter());
                         Arc::new(array)
                     } else {
                         let array = Int64Array::from_iter(vals.iter());

--- a/query/src/func/window.rs
+++ b/query/src/func/window.rs
@@ -1,9 +1,9 @@
 mod internal;
 
 pub use internal::{Duration, Window};
-use internal_types::schema::{TIME_DATA_TIMEZONE, TIME_DATA_TYPE};
+use internal_types::schema::TIME_DATA_TYPE;
 
-use std::sync::Arc;
+use std::{iter::FromIterator, sync::Arc};
 
 use arrow_deps::{
     arrow::array::{ArrayRef, TimestampNanosecondArray},
@@ -56,17 +56,14 @@ fn window_bounds(
 
     // calculate the output times, one at a time, one element at a time
 
-    let values = time
-        .iter()
-        .map(|ts| {
-            ts.map(|ts| {
-                let bounds = window.get_earliest_bounds(ts);
-                bounds.stop
-            })
+    let values = time.iter().map(|ts| {
+        ts.map(|ts| {
+            let bounds = window.get_earliest_bounds(ts);
+            bounds.stop
         })
-        .collect::<Vec<_>>();
+    });
 
-    let array = TimestampNanosecondArray::from_opt_vec(values, TIME_DATA_TIMEZONE());
+    let array = TimestampNanosecondArray::from_iter(values);
     Ok(Arc::new(array) as ArrayRef)
 }
 


### PR DESCRIPTION
This is cleanup of some code that got introduced in https://github.com/influxdata/influxdb_iox/pull/1230

# Rationale:
There is no reason to create copies of `Vec`s to make `TimestamNanosecondArrays`

# Change
Stop making copies of `Vec`s to make `TimestamNanosecondArrays`

