### PR TITLE
feat: full implementation of parquet's read_filter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2337,7 +2337,10 @@ dependencies = [
  "internal_types",
  "object_store",
  "parking_lot",
+ "query",
  "snafu",
+ "tokio",
+ "tokio-stream",
  "tracker",
 ]
 

--- a/mutable_buffer/src/table.rs
+++ b/mutable_buffer/src/table.rs
@@ -383,9 +383,7 @@ impl Table {
                 }
                 Column::I64(vals, _) => {
                     if col.column_name == TIME_COLUMN_NAME {
-                        // TODO: there is no reason that this needs an owned copy of the Vec...
-                        // should file a ticket with arrow to add something to avoid the clone
-                        let array = TimestampNanosecondArray::from_opt_vec(vals.clone(), None);
+                        let array = TimestampNanosecondArray::from_iter(vals.iter());
                         Arc::new(array)
                     } else {
                         let array = Int64Array::from_iter(vals.iter());

--- a/object_store/src/path.rs
+++ b/object_store/src/path.rs
@@ -60,6 +60,13 @@ pub enum Path {
     MicrosoftAzure(CloudPath),
 }
 
+impl Path {
+    /// Temp function until we support non-local files
+    pub fn local_file(&self) -> bool {
+        matches!(self, Self::File(_))
+    }
+}
+
 impl ObjectStorePath for Path {
     fn set_file_name(&mut self, part: impl Into<String>) {
         match self {

--- a/object_store/src/path.rs
+++ b/object_store/src/path.rs
@@ -62,6 +62,7 @@ pub enum Path {
 
 impl Path {
     /// Temp function until we support non-local files
+    /// Return true if this file i located on the local filesystem
     pub fn local_file(&self) -> bool {
         matches!(self, Self::File(_))
     }

--- a/parquet_file/Cargo.toml
+++ b/parquet_file/Cargo.toml
@@ -12,5 +12,8 @@ futures = "0.3.7"
 internal_types = {path = "../internal_types"}
 object_store = {path = "../object_store"}
 parking_lot = "0.11.1"
+query = { path = "../query" }
 snafu = "0.6"
+tokio = { version = "1.0", features = ["macros", "rt", "rt-multi-thread", "sync"] }
+tokio-stream = "0.1"
 tracker = { path = "../tracker" }

--- a/parquet_file/src/storage.rs
+++ b/parquet_file/src/storage.rs
@@ -1,24 +1,45 @@
 /// This module responsible to write given data to specify object store and
 /// read them back
 use arrow_deps::{
-    arrow::datatypes::SchemaRef,
-    datafusion::physical_plan::SendableRecordBatchStream,
-    parquet::{self, arrow::ArrowWriter, file::writer::TryClone},
+    arrow::{
+        datatypes::{Schema, SchemaRef},
+        error::ArrowError,
+        error::Result as ArrowResult,
+        record_batch::RecordBatch,
+    },
+    datafusion::{
+        error::DataFusionError,
+        physical_plan::{
+            parquet::RowGroupPredicateBuilder, RecordBatchStream, SendableRecordBatchStream,
+        },
+    },
+    parquet::{
+        self,
+        arrow::{arrow_reader::ParquetFileArrowReader, ArrowReader, ArrowWriter},
+        file::{reader::FileReader, serialized_reader::SerializedFileReader, writer::TryClone},
+    },
 };
+use internal_types::selection::Selection;
 use object_store::{
     path::{ObjectStorePath, Path},
     ObjectStore, ObjectStoreApi,
 };
+use query::predicate::Predicate;
 
 use bytes::Bytes;
-use futures::StreamExt;
+use futures::{Stream, StreamExt};
 use parking_lot::Mutex;
 use snafu::{OptionExt, ResultExt, Snafu};
 use std::{
+    fs::File,
     io::{Cursor, Seek, SeekFrom, Write},
     num::NonZeroU32,
     sync::Arc,
+    task::{Context, Poll},
 };
+use tokio::sync::mpsc::{channel, Receiver, Sender};
+use tokio::task;
+use tokio_stream::wrappers::ReceiverStream;
 
 #[derive(Debug, Snafu)]
 pub enum Error {
@@ -47,8 +68,57 @@ pub enum Error {
 
     #[snafu(display("Error converting to vec[u8]: Nothing else should have a reference here"))]
     WritingToMemWriter {},
+
+    #[snafu(display("Non local file not supported"))]
+    NonLocalFile {},
+
+    #[snafu(display("Error open file: {}", source))]
+    OpenFile { source: std::io::Error },
+
+    #[snafu(display("Error at serialized file reader: {}", source))]
+    SerializedFileReaderError {
+        source: arrow_deps::parquet::errors::ParquetError,
+    },
+
+    #[snafu(display("Error at parquet arrow reader: {}", source))]
+    ParquetArrowReaderError {
+        source: arrow_deps::parquet::errors::ParquetError,
+    },
+
+    #[snafu(display("Error reading data from parquet file: {}", source))]
+    ReadingFile {
+        source: arrow_deps::arrow::error::ArrowError,
+    },
+
+    #[snafu(display("Error sending results: {}", source))]
+    SendResult {
+        source: arrow_deps::datafusion::error::DataFusionError,
+    },
 }
 pub type Result<T, E = Error> = std::result::Result<T, E>;
+
+#[derive(Debug)]
+pub struct ParquetStream {
+    schema: SchemaRef,
+    inner: ReceiverStream<ArrowResult<RecordBatch>>,
+}
+
+impl Stream for ParquetStream {
+    type Item = ArrowResult<RecordBatch>;
+
+    fn poll_next(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Self::Item>> {
+        self.inner.poll_next_unpin(cx)
+    }
+}
+
+impl RecordBatchStream for ParquetStream {
+    fn schema(&self) -> SchemaRef {
+        Arc::clone(&self.schema)
+    }
+}
 
 #[derive(Debug, Clone)]
 pub struct Storage {
@@ -90,6 +160,8 @@ impl Storage {
         path
     }
 
+    /// Write the given stream of data of a specified table of
+    // a specified partitioned chunk to a parquet file of this storage
     pub async fn write_to_object_store(
         &self,
         partition_key: String,
@@ -106,6 +178,8 @@ impl Storage {
 
         Ok(path.clone())
     }
+
+    /// Convert the given stream of RecordBatches to bytes
 
     pub async fn parquet_stream_to_bytes(
         mut stream: SendableRecordBatchStream,
@@ -125,6 +199,7 @@ impl Storage {
         mem_writer.into_inner().context(WritingToMemWriter)
     }
 
+    /// Put the given vector of bytes to the specified location
     pub async fn to_object_store(
         &self,
         data: Vec<u8>,
@@ -142,6 +217,165 @@ impl Storage {
             )
             .await
             .context(WritingToObjectStore)
+    }
+
+    /// Make a datafusion predicate builder for the given predicate and schema
+    pub fn predicate_builder(
+        predicate: &Predicate,
+        schema: Schema,
+    ) -> Option<RowGroupPredicateBuilder> {
+        if predicate.exprs.is_empty() {
+            None
+        } else {
+            // TODO: not sure why we store a list of exprs. It should be an expressions of
+            // one or many AND/OR. Make it one Expr for now to be consistent
+            // with DataFusion's predicate builder.
+            // Reference:
+            // datafusion::physical_plan::parquet::RowGroupPredicateBuilder::try_new
+            let predicate = predicate.exprs[0].clone();
+            Some(RowGroupPredicateBuilder::try_new(&predicate, schema).ok()?)
+        }
+    }
+
+    /// Return indices of the schema's fields of the selection columns
+    pub fn column_indices(selection: Selection<'_>, schema: SchemaRef) -> Vec<usize> {
+        let fields = schema.fields().iter();
+
+        match selection {
+            Selection::Some(cols) => fields
+                .enumerate()
+                .filter_map(|(p, x)| {
+                    if cols.contains(&x.name().as_str()) {
+                        Some(p)
+                    } else {
+                        None
+                    }
+                })
+                .collect(),
+            Selection::All => fields.enumerate().map(|(p, _)| p).collect(),
+        }
+    }
+
+    pub fn read_filter(
+        predicate: &Predicate,
+        selection: Selection<'_>,
+        schema: SchemaRef,
+        path: &Path,
+    ) -> Result<SendableRecordBatchStream> {
+        // TODO: support non local file object store
+        if !path.local_file() {
+            panic!("Non local file object store not supported")
+        }
+
+        // The below code is based on
+        // datafusion::physical_plan::parquet::ParquetExec::execute
+        // Will be improved as we go
+
+        let (response_tx, response_rx): (
+            Sender<ArrowResult<RecordBatch>>,
+            Receiver<ArrowResult<RecordBatch>>,
+        ) = channel(2);
+
+        // Full path of the parquet file
+        // Might need different function if this display function does not show the full
+        // path
+        let filename = path.display();
+        println!("Parquet filename: {}", filename);
+
+        // Indices of columns in the schema needed to read
+        let projection: Vec<usize> = Self::column_indices(selection, Arc::clone(&schema));
+
+        // Filter needed predicates
+        let builder_schema = Schema::new(schema.fields().clone());
+        let predicate_builder = Self::predicate_builder(predicate, builder_schema);
+
+        // Size of each batch
+        let batch_size = 1024; // Todo: make a constant or policy for this
+
+        // Limit of total rows to read
+        let limit: Option<usize> = None; // Todo: this should be a parameter of the function
+
+        // Todo: Convert this tokio into using thread pool Andrew has implemented
+        // recently
+        task::spawn_blocking(move || {
+            if let Err(e) = Self::read_file(
+                filename,
+                projection.as_slice(),
+                &predicate_builder,
+                batch_size,
+                response_tx,
+                limit,
+            ) {
+                println!("Parquet reader thread terminated due to error: {:?}", e);
+            }
+        });
+
+        Ok(Box::pin(ParquetStream {
+            schema,
+            inner: ReceiverStream::new(response_rx),
+        }))
+    }
+
+    fn send_result(
+        response_tx: &Sender<ArrowResult<RecordBatch>>,
+        result: ArrowResult<RecordBatch>,
+    ) -> Result<()> {
+        // Note this function is running on its own blockng tokio thread so blocking
+        // here is ok.
+        response_tx
+            .blocking_send(result)
+            .map_err(|e| DataFusionError::Execution(e.to_string()))
+            .context(SendResult)?;
+        Ok(())
+    }
+    fn read_file(
+        filename: String,
+        projection: &[usize],
+        predicate_builder: &Option<RowGroupPredicateBuilder>,
+        batch_size: usize,
+        response_tx: Sender<ArrowResult<RecordBatch>>,
+        limit: Option<usize>,
+    ) -> Result<()> {
+        let mut total_rows = 0;
+
+        let file = File::open(&filename).context(OpenFile)?;
+        let mut file_reader = SerializedFileReader::new(file).context(SerializedFileReaderError)?;
+        if let Some(predicate_builder) = predicate_builder {
+            let row_group_predicate =
+                predicate_builder.build_row_group_predicate(file_reader.metadata().row_groups());
+            file_reader.filter_row_groups(&row_group_predicate);
+        }
+        let mut arrow_reader = ParquetFileArrowReader::new(Arc::new(file_reader));
+        let mut batch_reader = arrow_reader
+            .get_record_reader_by_columns(projection.to_owned(), batch_size)
+            .context(ParquetArrowReaderError)?;
+        loop {
+            match batch_reader.next() {
+                Some(Ok(batch)) => {
+                    //println!("ParquetExec got new batch from {}", filename);
+                    total_rows += batch.num_rows();
+                    Self::send_result(&response_tx, Ok(batch))?;
+                    if limit.map(|l| total_rows >= l).unwrap_or(false) {
+                        break;
+                    }
+                }
+                None => {
+                    break;
+                }
+                Some(Err(e)) => {
+                    let err_msg =
+                        format!("Error reading batch from {}: {}", filename, e.to_string());
+                    // send error to operator
+                    Self::send_result(&response_tx, Err(ArrowError::ParquetError(err_msg)))?;
+                    // terminate thread with error
+                    return Err(e).context(ReadingFile);
+                }
+            }
+        }
+
+        // finished reading files (dropping response_tx will close
+        // channel)
+        Ok(())
     }
 }
 

--- a/parquet_file/src/storage.rs
+++ b/parquet_file/src/storage.rs
@@ -301,7 +301,7 @@ impl Storage {
             if let Err(e) = Self::read_file(
                 filename,
                 projection.as_slice(),
-                &predicate_builder,
+                predicate_builder.as_ref(),
                 batch_size,
                 response_tx,
                 limit,
@@ -331,7 +331,7 @@ impl Storage {
     fn read_file(
         filename: String,
         projection: &[usize],
-        predicate_builder: &Option<RowGroupPredicateBuilder>,
+        predicate_builder: Option<&RowGroupPredicateBuilder>,
         batch_size: usize,
         response_tx: Sender<ArrowResult<RecordBatch>>,
         limit: Option<usize>,

--- a/query/src/func/window.rs
+++ b/query/src/func/window.rs
@@ -1,9 +1,9 @@
 mod internal;
 
 pub use internal::{Duration, Window};
-use internal_types::schema::{TIME_DATA_TIMEZONE, TIME_DATA_TYPE};
+use internal_types::schema::TIME_DATA_TYPE;
 
-use std::sync::Arc;
+use std::{iter::FromIterator, sync::Arc};
 
 use arrow_deps::{
     arrow::array::{ArrayRef, TimestampNanosecondArray},
@@ -56,17 +56,14 @@ fn window_bounds(
 
     // calculate the output times, one at a time, one element at a time
 
-    let values = time
-        .iter()
-        .map(|ts| {
-            ts.map(|ts| {
-                let bounds = window.get_earliest_bounds(ts);
-                bounds.stop
-            })
+    let values = time.iter().map(|ts| {
+        ts.map(|ts| {
+            let bounds = window.get_earliest_bounds(ts);
+            bounds.stop
         })
-        .collect::<Vec<_>>();
+    });
 
-    let array = TimestampNanosecondArray::from_opt_vec(values, TIME_DATA_TIMEZONE());
+    let array = TimestampNanosecondArray::from_iter(values);
     Ok(Arc::new(array) as ArrayRef)
 }
 

--- a/server/src/db/chunk.rs
+++ b/server/src/db/chunk.rs
@@ -282,9 +282,11 @@ impl PartitionChunk for DBChunk {
                     schema.into(),
                 )))
             }
-            Self::ParquetFile { .. } => {
-                unimplemented!("parquet file not implemented for scan_data")
-            }
+            Self::ParquetFile { chunk, .. } => chunk
+                .read_filter(table_name, predicate, selection)
+                .context(ParquetFileChunkError {
+                    chunk_id: chunk.id(),
+                }),
         }
     }
 


### PR DESCRIPTION
Closes #

The third PR for #1082 which implements the most tricky function read_filter for parquet.
@alamb: I follow what have been done in DataFusion but need some changes to work for us. At this stage, I am seeking for feedback whether this is an acceptable approach for us. 

- [x] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb_iox/blob/main/README.md).
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
