### PR TITLE
feat: List background operations as system.operations table

### DIFF
--- a/data_types/src/job.rs
+++ b/data_types/src/job.rs
@@ -113,6 +113,48 @@ impl From<management::operation_metadata::Job> for Job {
     }
 }
 
+impl Job {
+    /// Returns the database name assocated with this job, if any
+    pub fn db_name(&self) -> Option<&str> {
+        match self {
+            Self::Dummy { .. } => None,
+            Self::PersistSegment { .. } => None,
+            Self::CloseChunk { db_name, .. } => Some(db_name),
+            Self::WriteChunk { db_name, .. } => Some(db_name),
+        }
+    }
+
+    /// Returns the partition name assocated with this job, if any
+    pub fn partition_key(&self) -> Option<&str> {
+        match self {
+            Self::Dummy { .. } => None,
+            Self::PersistSegment { .. } => None,
+            Self::CloseChunk { partition_key, .. } => Some(partition_key),
+            Self::WriteChunk { partition_key, .. } => Some(partition_key),
+        }
+    }
+
+    /// Returns the chunk_id assocated with this job, if any
+    pub fn chunk_id(&self) -> Option<u32> {
+        match self {
+            Self::Dummy { .. } => None,
+            Self::PersistSegment { .. } => None,
+            Self::CloseChunk { chunk_id, .. } => Some(*chunk_id),
+            Self::WriteChunk { chunk_id, .. } => Some(*chunk_id),
+        }
+    }
+
+    /// Returns a human readable description assocated with this job, if any
+    pub fn description(&self) -> &str {
+        match self {
+            Self::Dummy { .. } => "Dummy Job, for testing",
+            Self::PersistSegment { .. } => "Persisting segment to Object Store",
+            Self::CloseChunk { .. } => "Loading chunk to ReadBuffer",
+            Self::WriteChunk { .. } => "Writing chunk to Object Storage",
+        }
+    }
+}
+
 /// The status of a running operation
 #[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
 pub enum OperationStatus {

--- a/server/src/db.rs
+++ b/server/src/db.rs
@@ -352,7 +352,8 @@ impl Db {
         let store = Arc::clone(&object_store);
         let write_buffer = write_buffer.map(Mutex::new);
         let catalog = Arc::new(Catalog::new());
-        let system_tables = Arc::new(SystemSchemaProvider::new(Arc::clone(&catalog)));
+        let system_tables = SystemSchemaProvider::new(Arc::clone(&catalog), Arc::clone(&jobs));
+        let system_tables = Arc::new(system_tables);
 
         let domain = metrics.register_domain("catalog");
         let db_metrics = DbMetrics {
@@ -366,7 +367,6 @@ impl Db {
                 metrics::KeyValue::new("svr_id", format!("{:?}", server_id)),
             ],
         };
-
         Self {
             rules,
             server_id,

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -202,6 +202,12 @@ impl JobRegistry {
     pub fn register(&self, job: Job) -> (TaskTracker<Job>, TaskRegistration) {
         self.inner.lock().register(job)
     }
+
+    /// Returns a list of recent Jobs, including some that are no
+    /// longer running
+    pub fn tracked(&self) -> Vec<TaskTracker<Job>> {
+        self.inner.lock().tracked()
+    }
 }
 
 const STORE_ERROR_PAUSE_SECONDS: u64 = 100;

--- a/server/src/query_tests/scenarios.rs
+++ b/server/src/query_tests/scenarios.rs
@@ -1,7 +1,5 @@
 //! This module contains testing scenarios for Db
 
-use std::time::Duration;
-
 #[allow(unused_imports, dead_code, unused_macros)]
 use query::PartitionChunk;
 
@@ -241,7 +239,7 @@ impl DbSetup for TwoMeasurementsManyFieldsLifecycle {
             "h2o".to_string(),
             0,
         );
-        assert_eq!(job.wait_for_complete(Duration::from_secs(3)).await, true);
+        job.join().await;
 
         write_lp(
             &db,
@@ -253,7 +251,7 @@ impl DbSetup for TwoMeasurementsManyFieldsLifecycle {
             "h2o".to_string(),
             0,
         );
-        assert_eq!(job.wait_for_complete(Duration::from_secs(3)).await, true);
+        job.join().await;
 
         let db =
             std::sync::Arc::try_unwrap(db).expect("All background handles to db should be done");

--- a/server/src/query_tests/sql.rs
+++ b/server/src/query_tests/sql.rs
@@ -188,12 +188,13 @@ async fn sql_select_from_information_schema_tables() {
         "+---------------+--------------------+------------+------------+",
         "| table_catalog | table_schema       | table_name | table_type |",
         "+---------------+--------------------+------------+------------+",
+        "| public        | information_schema | columns    | VIEW       |",
+        "| public        | information_schema | tables     | VIEW       |",
         "| public        | iox                | h2o        | BASE TABLE |",
         "| public        | iox                | o2         | BASE TABLE |",
         "| public        | system             | chunks     | BASE TABLE |",
         "| public        | system             | columns    | BASE TABLE |",
-        "| public        | information_schema | tables     | VIEW       |",
-        "| public        | information_schema | columns    | VIEW       |",
+        "| public        | system             | operations | BASE TABLE |",
         "+---------------+--------------------+------------+------------+",
     ];
     run_sql_test_case!(
@@ -209,37 +210,25 @@ async fn sql_select_from_information_schema_columns() {
     // validate we have access to information schema for listing columns
     // names
     let expected = vec![
-    "+---------------+--------------+------------+---------------------+------------------+----------------+-------------+-----------------------------+--------------------------+------------------------+-------------------+-------------------------+---------------+--------------------+---------------+",
-    "| table_catalog | table_schema | table_name | column_name         | ordinal_position | column_default | is_nullable | data_type                   | character_maximum_length | character_octet_length | numeric_precision | numeric_precision_radix | numeric_scale | datetime_precision | interval_type |",
-    "+---------------+--------------+------------+---------------------+------------------+----------------+-------------+-----------------------------+--------------------------+------------------------+-------------------+-------------------------+---------------+--------------------+---------------+",
-    "| public        | iox          | h2o        | city                | 0                |                | YES         | Utf8                        |                          | 2147483647             |                   |                         |               |                    |               |",
-    "| public        | iox          | h2o        | moisture            | 1                |                | YES         | Float64                     |                          |                        | 24                | 2                       |               |                    |               |",
-    "| public        | iox          | h2o        | other_temp          | 2                |                | YES         | Float64                     |                          |                        | 24                | 2                       |               |                    |               |",
-    "| public        | iox          | h2o        | state               | 3                |                | YES         | Utf8                        |                          | 2147483647             |                   |                         |               |                    |               |",
-    "| public        | iox          | h2o        | temp                | 4                |                | YES         | Float64                     |                          |                        | 24                | 2                       |               |                    |               |",
-    "| public        | iox          | h2o        | time                | 5                |                | NO          | Timestamp(Nanosecond, None) |                          |                        |                   |                         |               |                    |               |",
-    "| public        | iox          | o2         | city                | 0                |                | YES         | Utf8                        |                          | 2147483647             |                   |                         |               |                    |               |",
-    "| public        | iox          | o2         | reading             | 1                |                | YES         | Float64                     |                          |                        | 24                | 2                       |               |                    |               |",
-    "| public        | iox          | o2         | state               | 2                |                | YES         | Utf8                        |                          | 2147483647             |                   |                         |               |                    |               |",
-    "| public        | iox          | o2         | temp                | 3                |                | YES         | Float64                     |                          |                        | 24                | 2                       |               |                    |               |",
-    "| public        | iox          | o2         | time                | 4                |                | NO          | Timestamp(Nanosecond, None) |                          |                        |                   |                         |               |                    |               |",
-    "| public        | system       | chunks     | estimated_bytes     | 4                |                | YES         | UInt64                      |                          |                        |                   |                         |               |                    |               |",
-    "| public        | system       | chunks     | id                  | 0                |                | NO          | UInt32                      |                          |                        | 32                | 2                       |               |                    |               |",
-    "| public        | system       | chunks     | partition_key       | 1                |                | NO          | Utf8                        |                          | 2147483647             |                   |                         |               |                    |               |",
-    "| public        | system       | chunks     | storage             | 3                |                | NO          | Utf8                        |                          | 2147483647             |                   |                         |               |                    |               |",
-    "| public        | system       | chunks     | table_name          | 2                |                | NO          | Utf8                        |                          | 2147483647             |                   |                         |               |                    |               |",
-    "| public        | system       | chunks     | time_closing        | 7                |                | YES         | Timestamp(Nanosecond, None) |                          |                        |                   |                         |               |                    |               |",
-    "| public        | system       | chunks     | time_of_first_write | 5                |                | YES         | Timestamp(Nanosecond, None) |                          |                        |                   |                         |               |                    |               |",
-    "| public        | system       | chunks     | time_of_last_write  | 6                |                | YES         | Timestamp(Nanosecond, None) |                          |                        |                   |                         |               |                    |               |",
-    "| public        | system       | columns    | column_name         | 2                |                | YES         | Utf8                        |                          | 2147483647             |                   |                         |               |                    |               |",
-    "| public        | system       | columns    | count               | 3                |                | YES         | UInt64                      |                          |                        |                   |                         |               |                    |               |",
-    "| public        | system       | columns    | partition_key       | 0                |                | NO          | Utf8                        |                          | 2147483647             |                   |                         |               |                    |               |",
-    "| public        | system       | columns    | table_name          | 1                |                | YES         | Utf8                        |                          | 2147483647             |                   |                         |               |                    |               |",
-    "+---------------+--------------+------------+---------------------+------------------+----------------+-------------+-----------------------------+--------------------------+------------------------+-------------------+-------------------------+---------------+--------------------+---------------+",
+        "+---------------+--------------+------------+-------------+------------------+----------------+-------------+-----------------------------+--------------------------+------------------------+-------------------+-------------------------+---------------+--------------------+---------------+",
+        "| table_catalog | table_schema | table_name | column_name | ordinal_position | column_default | is_nullable | data_type                   | character_maximum_length | character_octet_length | numeric_precision | numeric_precision_radix | numeric_scale | datetime_precision | interval_type |",
+        "+---------------+--------------+------------+-------------+------------------+----------------+-------------+-----------------------------+--------------------------+------------------------+-------------------+-------------------------+---------------+--------------------+---------------+",
+        "| public        | iox          | h2o        | city        | 0                |                | YES         | Utf8                        |                          | 2147483647             |                   |                         |               |                    |               |",
+        "| public        | iox          | h2o        | moisture    | 1                |                | YES         | Float64                     |                          |                        | 24                | 2                       |               |                    |               |",
+        "| public        | iox          | h2o        | other_temp  | 2                |                | YES         | Float64                     |                          |                        | 24                | 2                       |               |                    |               |",
+        "| public        | iox          | h2o        | state       | 3                |                | YES         | Utf8                        |                          | 2147483647             |                   |                         |               |                    |               |",
+        "| public        | iox          | h2o        | temp        | 4                |                | YES         | Float64                     |                          |                        | 24                | 2                       |               |                    |               |",
+        "| public        | iox          | h2o        | time        | 5                |                | NO          | Timestamp(Nanosecond, None) |                          |                        |                   |                         |               |                    |               |",
+        "| public        | iox          | o2         | city        | 0                |                | YES         | Utf8                        |                          | 2147483647             |                   |                         |               |                    |               |",
+        "| public        | iox          | o2         | reading     | 1                |                | YES         | Float64                     |                          |                        | 24                | 2                       |               |                    |               |",
+        "| public        | iox          | o2         | state       | 2                |                | YES         | Utf8                        |                          | 2147483647             |                   |                         |               |                    |               |",
+        "| public        | iox          | o2         | temp        | 3                |                | YES         | Float64                     |                          |                        | 24                | 2                       |               |                    |               |",
+        "| public        | iox          | o2         | time        | 4                |                | NO          | Timestamp(Nanosecond, None) |                          |                        |                   |                         |               |                    |               |",
+        "+---------------+--------------+------------+-------------+------------------+----------------+-------------+-----------------------------+--------------------------+------------------------+-------------------+-------------------------+---------------+--------------------+---------------+",
     ];
     run_sql_test_case!(
         TwoMeasurementsManyFields {},
-        "SELECT * from information_schema.columns",
+        "SELECT * from information_schema.columns where table_name = 'h2o' OR table_name = 'o2'",
         &expected
     );
 }
@@ -268,7 +257,7 @@ async fn sql_show_columns() {
 }
 
 #[tokio::test]
-async fn sql_select_from_system_tables() {
+async fn sql_select_from_system_chunks() {
     // system tables reflect the state of chunks, so don't run them
     // with different chunk configurations.
 
@@ -288,6 +277,15 @@ async fn sql_select_from_system_tables() {
         "SELECT id, partition_key, table_name, storage, estimated_bytes from system.chunks",
         &expected
     );
+}
+
+#[tokio::test]
+async fn sql_select_from_system_columns() {
+    // system tables reflect the state of chunks, so don't run them
+    // with different chunk configurations.
+
+    //  ensures the tables / plumbing are hooked up (so no need to
+    //  test timestamps, etc)
 
     let expected = vec![
         "+---------------+------------+-------------+-------+",
@@ -308,6 +306,27 @@ async fn sql_select_from_system_tables() {
     run_sql_test_case!(
         TwoMeasurementsManyFieldsOneChunk {},
         "SELECT * from system.columns",
+        &expected
+    );
+}
+
+#[tokio::test]
+async fn sql_select_from_system_operations() {
+    test_helpers::maybe_start_logging();
+    let expected = vec![
+        "+----+-----------+-------------+---------------+----------+---------------------------------+",
+        "| id | took_time | db_name     | partition_key | chunk_id | description                     |",
+        "+----+-----------+-------------+---------------+----------+---------------------------------+",
+        "| 0  | true      | placeholder | 1970-01-01T00 | 0        | Loading chunk to ReadBuffer     |",
+        "| 1  | true      | placeholder | 1970-01-01T00 | 0        | Writing chunk to Object Storage |",
+        "+----+-----------+-------------+---------------+----------+---------------------------------+",
+    ];
+
+    // Check that the cpu time used reported is greater than zero as it isn't
+    // repeatable
+    run_sql_test_case!(
+        TwoMeasurementsManyFieldsLifecycle {},
+        "SELECT id, CAST(cpu_time_used AS BIGINT) > 0 as took_time, db_name, partition_key, chunk_id, description from system.operations",
         &expected
     );
 }

--- a/server/src/query_tests/sql.rs
+++ b/server/src/query_tests/sql.rs
@@ -314,19 +314,19 @@ async fn sql_select_from_system_columns() {
 async fn sql_select_from_system_operations() {
     test_helpers::maybe_start_logging();
     let expected = vec![
-        "+----+-----------+-------------+---------------+----------+---------------------------------+",
-        "| id | took_time | db_name     | partition_key | chunk_id | description                     |",
-        "+----+-----------+-------------+---------------+----------+---------------------------------+",
-        "| 0  | true      | placeholder | 1970-01-01T00 | 0        | Loading chunk to ReadBuffer     |",
-        "| 1  | true      | placeholder | 1970-01-01T00 | 0        | Writing chunk to Object Storage |",
-        "+----+-----------+-------------+---------------+----------+---------------------------------+",
+        "+----+----------+-----------+-------------+---------------+----------+---------------------------------+",
+        "| id | status   | took_time | db_name     | partition_key | chunk_id | description                     |",
+        "+----+----------+-----------+-------------+---------------+----------+---------------------------------+",
+        "| 0  | Complete | true      | placeholder | 1970-01-01T00 | 0        | Loading chunk to ReadBuffer     |",
+        "| 1  | Complete | true      | placeholder | 1970-01-01T00 | 0        | Writing chunk to Object Storage |",
+        "+----+----------+-----------+-------------+---------------+----------+---------------------------------+",
     ];
 
     // Check that the cpu time used reported is greater than zero as it isn't
     // repeatable
     run_sql_test_case!(
         TwoMeasurementsManyFieldsLifecycle {},
-        "SELECT id, CAST(cpu_time_used AS BIGINT) > 0 as took_time, db_name, partition_key, chunk_id, description from system.operations",
+        "SELECT id, status, CAST(cpu_time_used AS BIGINT) > 0 as took_time, db_name, partition_key, chunk_id, description from system.operations",
         &expected
     );
 }

--- a/tracker/src/task.rs
+++ b/tracker/src/task.rs
@@ -148,6 +148,27 @@ pub enum TaskStatus {
     },
 }
 
+impl TaskStatus {
+    /// return a human readable name for this status
+    pub fn name(&self) -> &'static str {
+        match self {
+            Self::Creating => "Creating",
+            Self::Running { .. } => "Running",
+            Self::Complete { .. } => "Complete",
+        }
+    }
+
+    /// If the job has competed, returns the total amount of CPU time
+    /// spent executing futures
+    pub fn cpu_nanos(&self) -> Option<usize> {
+        match self {
+            Self::Creating => None,
+            Self::Running { cpu_nanos, .. } => Some(*cpu_nanos),
+            Self::Complete { cpu_nanos, .. } => Some(*cpu_nanos),
+        }
+    }
+}
+
 /// A Tracker can be used to monitor/cancel/wait for a set of associated futures
 #[derive(Debug)]
 pub struct TaskTracker<T> {

--- a/tracker/src/task.rs
+++ b/tracker/src/task.rs
@@ -80,9 +80,12 @@
 //! etc... between threads as any such functionality must perform the necessary
 //! synchronisation to be well-formed.
 
-use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::Instant;
+use std::{
+    sync::atomic::{AtomicUsize, Ordering},
+    time::Duration,
+};
 
 use tokio_util::sync::CancellationToken;
 
@@ -222,6 +225,31 @@ impl<T> TaskTracker<T> {
     /// Returns if this tracker has been cancelled
     pub fn is_cancelled(&self) -> bool {
         self.state.cancel_token.is_cancelled()
+    }
+
+    /// Waits for up to N seconds for the task to complete Returns
+    /// true if the task is complete after this timeout false
+    /// otherwise, false if not
+    pub async fn wait_for_complete(&self, timeout: Duration) -> bool {
+        let state = Arc::clone(&self.state);
+        let wait_loop = async move {
+            let mut interval = tokio::time::interval(Duration::from_millis(500));
+            loop {
+                let pending_registrations = state.pending_registrations.load(Ordering::Acquire);
+                let pending_futures = state.pending_futures.load(Ordering::Acquire);
+
+                if pending_registrations == 0 && pending_futures == 0 {
+                    return;
+                } else {
+                    interval.tick().await;
+                }
+            }
+        };
+
+        match tokio::time::timeout(timeout, wait_loop).await {
+            Ok(()) => true,
+            Err(_) => false,
+        }
     }
 
     /// Blocks until all futures associated with the tracker have been


### PR DESCRIPTION
Closes https://github.com/influxdata/influxdb_iox/issues/1214

# Rationale
As someone administering an IOx cluster
I want to be able to slice and dice the list of operations that an IOx server is doing using SQL
So that I can easily narrow in on what the server is doing

# Example output:

```
alamb@ip-10-0-0-124 influxdb_iox % ./target/debug/influxdb_iox database query my_db "select * from system.operations"
+----+----------+--------------------+---------+---------------------+----------+-----------------------------+
| id | status   | cpu_time_used      | db_name | partition_key       | chunk_id | description                 |
+----+----------+--------------------+---------+---------------------+----------+-----------------------------+
| 0  | Complete | 00:00:00.023225348 | my_db   | 2020-06-11 16:00:00 | 0        | Loading chunk to ReadBuffer |
+----+----------+--------------------+---------+---------------------+----------+-----------------------------+

```

How to test:
```
./target/debug/influxdb_iox database create my_db
./target/debug/influxdb_iox database write my_db tests/fixtures/lineproto/metrics.lp
./target/debug/influxdb_iox database write my_db tests/fixtures/lineproto/metrics.lp
./target/debug/influxdb_iox database partition close-chunk my_db "2020-06-11 16:00:00" 0
./target/debug/influxdb_iox database query my_db "select * from system.operations"
```

# Planned follow on work
- [ ] Clean up creation of other system tables to avoid the use of builders
- [ ] https://github.com/influxdata/influxdb_iox/issues/1244 for adding job start/stop time (at some future time)

