### PR TITLE
refactor: log new row groups added to read buffer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2803,12 +2803,14 @@ dependencies = [
  "hashbrown 0.9.1",
  "internal_types",
  "itertools 0.9.0",
+ "observability_deps",
  "packers",
  "parking_lot",
  "permutation",
  "rand 0.8.3",
  "rand_distr",
  "snafu",
+ "test_helpers",
  "tracker",
 ]
 

--- a/read_buffer/Cargo.toml
+++ b/read_buffer/Cargo.toml
@@ -18,6 +18,7 @@ either = "1.6.1"
 hashbrown = "0.9.1"
 internal_types = { path = "../internal_types" }
 itertools = "0.9.0"
+"observability_deps" = { path = "../observability_deps" }
 packers = { path = "../packers" }
 parking_lot = "0.11"
 permutation = "0.2.5"
@@ -28,6 +29,7 @@ tracker = { path = "../tracker" }
 criterion = "0.3.3"
 rand = "0.8.3"
 rand_distr = "0.4.0"
+test_helpers = { path = "../test_helpers" }
 
 [[bench]]
 name = "database"

--- a/read_buffer/src/column.rs
+++ b/read_buffer/src/column.rs
@@ -1098,6 +1098,19 @@ impl From<arrow::array::BooleanArray> for Column {
     }
 }
 
+impl std::fmt::Display for Column {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::String(_, enc) => enc.fmt(f),
+            Self::Float(_, enc) => enc.fmt(f),
+            Self::Integer(_, enc) => enc.fmt(f),
+            Self::Unsigned(_, enc) => enc.fmt(f),
+            Self::Bool(_, enc) => enc.fmt(f),
+            Self::ByteArray(_, enc) => enc.fmt(f),
+        }
+    }
+}
+
 #[derive(Debug, PartialEq)]
 enum PredicateMatch {
     None,

--- a/read_buffer/src/column/boolean.rs
+++ b/read_buffer/src/column/boolean.rs
@@ -110,6 +110,14 @@ impl BooleanEncoding {
     }
 }
 
+impl std::fmt::Display for BooleanEncoding {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::BooleanNull(enc) => enc.fmt(f),
+        }
+    }
+}
+
 /// Converts an Arrow `BooleanArray` into a `BooleanEncoding`.
 impl From<arrow::array::BooleanArray> for BooleanEncoding {
     fn from(arr: arrow::array::BooleanArray) -> Self {

--- a/read_buffer/src/column/encoding/dictionary/rle.rs
+++ b/read_buffer/src/column/encoding/dictionary/rle.rs
@@ -924,7 +924,7 @@ impl std::fmt::Display for RLE {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "[RLE Dictionary] size: {:?} rows: {:?} cardinality: {}, runs: {} ",
+            "[RLE] size: {:?} rows: {:?} cardinality: {}, runs: {} ",
             self.size(),
             self.num_rows,
             self.cardinality(),

--- a/read_buffer/src/column/encoding/fixed.rs
+++ b/read_buffer/src/column/encoding/fixed.rs
@@ -49,7 +49,7 @@ where
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "[Plain<T>] rows: {:?}, size: {}",
+            "[Array] rows: {:?}, size: {}",
             self.num_rows(),
             self.size()
         )

--- a/read_buffer/src/column/encoding/fixed_null.rs
+++ b/read_buffer/src/column/encoding/fixed_null.rs
@@ -43,7 +43,7 @@ where
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "[Arrow<T>] rows: {:?}, nulls: {:?}, size: {}",
+            "[Array] rows: {:?}, nulls: {:?}, size: {}",
             self.arr.len(),
             self.arr.null_count(),
             self.size()

--- a/read_buffer/src/column/float.rs
+++ b/read_buffer/src/column/float.rs
@@ -151,6 +151,15 @@ impl FloatEncoding {
     }
 }
 
+impl std::fmt::Display for FloatEncoding {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Fixed64(enc) => enc.fmt(f),
+            Self::FixedNull64(enc) => enc.fmt(f),
+        }
+    }
+}
+
 /// Converts a slice of `f64` values into a `FloatEncoding`.
 impl From<&[f64]> for FloatEncoding {
     fn from(arr: &[f64]) -> Self {

--- a/read_buffer/src/column/integer.rs
+++ b/read_buffer/src/column/integer.rs
@@ -384,6 +384,26 @@ impl IntegerEncoding {
     }
 }
 
+impl std::fmt::Display for IntegerEncoding {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::I64I64(enc) => write!(f, "phys i64: {}", enc),
+            Self::I64I32(enc) => write!(f, "phys i32: {}", enc),
+            Self::I64U32(enc) => write!(f, "phys u32: {}", enc),
+            Self::I64I16(enc) => write!(f, "phys i16: {}", enc),
+            Self::I64U16(enc) => write!(f, "phys u16: {}", enc),
+            Self::I64I8(enc) => write!(f, "phys i8: {}", enc),
+            Self::I64U8(enc) => write!(f, "phys u8: {}", enc),
+            Self::U64U64(enc) => write!(f, "phys u64: {}", enc),
+            Self::U64U32(enc) => write!(f, "phys u32: {}", enc),
+            Self::U64U16(enc) => write!(f, "phys u16: {}", enc),
+            Self::U64U8(enc) => write!(f, "phys u8: {}", enc),
+            Self::I64I64N(enc) => write!(f, "phys i64: {}", enc),
+            Self::U64U64N(enc) => write!(f, "phys u64: {}", enc),
+        }
+    }
+}
+
 /// Converts a slice of i64 values into an IntegerEncoding.
 ///
 /// The most compact physical type needed to store the columnar values is

--- a/read_buffer/src/row_group.rs
+++ b/read_buffer/src/row_group.rs
@@ -3,6 +3,7 @@ use std::{
     cmp::Ordering,
     collections::{BTreeMap, BTreeSet},
     convert::{TryFrom, TryInto},
+    fmt::Display,
     sync::Arc,
 };
 
@@ -1634,15 +1635,15 @@ impl TryFrom<ReadFilterResult<'_>> for RecordBatch {
 impl std::fmt::Debug for &ReadFilterResult<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         // Display the header
-        std::fmt::Display::fmt(self.schema(), f)?;
+        Display::fmt(self.schema(), f)?;
         writeln!(f)?;
 
         // Display the rest of the values.
-        std::fmt::Display::fmt(&self, f)
+        Display::fmt(&self, f)
     }
 }
 
-impl std::fmt::Display for &ReadFilterResult<'_> {
+impl Display for &ReadFilterResult<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         if self.is_empty() {
             return Ok(());
@@ -2148,16 +2149,16 @@ impl PartialEq for ReadAggregateResult<'_> {
 impl std::fmt::Debug for &ReadAggregateResult<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         // Display the schema
-        std::fmt::Display::fmt(&self.schema(), f)?;
+        Display::fmt(&self.schema(), f)?;
 
         // Display the rest of the values.
-        std::fmt::Display::fmt(&self, f)
+        Display::fmt(&self, f)
     }
 }
 
 /// The Display implementation emits all of the column data for the results, but
 /// omits the schema.
-impl std::fmt::Display for &ReadAggregateResult<'_> {
+impl Display for &ReadAggregateResult<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         if self.is_empty() {
             return Ok(());

--- a/read_buffer/src/row_group.rs
+++ b/read_buffer/src/row_group.rs
@@ -1073,6 +1073,25 @@ impl RowGroup {
     }
 }
 
+impl std::fmt::Display for &RowGroup {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.metadata().fmt(f)?;
+
+        for (name, idx) in &self.all_columns_by_name {
+            writeln!(
+                f,
+                "'{}' (pos {}): size: {} {}",
+                name,
+                idx,
+                self.size(),
+                self.columns[*idx]
+            )?;
+        }
+
+        Ok(())
+    }
+}
+
 /// Initialise a `RowGroup` from an Arrow RecordBatch.
 ///
 /// Presently this requires the RecordBatch to contain meta-data that specifies
@@ -1414,6 +1433,15 @@ impl ColumnMeta {
     }
 }
 
+impl Display for &ColumnMeta {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        writeln!(
+            f,
+            "sem_type: {}, log_type: {}, range: ({}, {})",
+            self.typ, self.logical_data_type, &self.range.0, &self.range.1
+        )
+    }
+}
 // column metadata is equivalent for two columns if their logical type and
 // semantic type are equivalent.
 impl PartialEq for ColumnMeta {
@@ -1445,6 +1473,21 @@ pub struct MetaData {
     // This can be used to skip the table entirely if the time range for a query
     // falls outside of this range.
     pub time_range: (i64, i64),
+}
+
+impl std::fmt::Display for &MetaData {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        writeln!(
+            f,
+            "[META] rows: {:?}, columns: {:?}",
+            self.rows, self.columns
+        )?;
+
+        for (name, meta) in &self.columns {
+            writeln!(f, "'{}': {}", name, meta)?;
+        }
+        Ok(())
+    }
 }
 
 impl MetaData {

--- a/read_buffer/src/schema.rs
+++ b/read_buffer/src/schema.rs
@@ -153,6 +153,19 @@ pub enum LogicalDataType {
     Boolean,  //
 }
 
+impl Display for LogicalDataType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Integer => write!(f, "INT"),
+            Self::Unsigned => write!(f, "UINT"),
+            Self::Float => write!(f, "FLOAT"),
+            Self::String => write!(f, "UTF8"),
+            Self::Binary => write!(f, "BIN"),
+            Self::Boolean => write!(f, "BOOL"),
+        }
+    }
+}
+
 impl From<&LogicalDataType> for arrow::datatypes::DataType {
     fn from(logical_type: &LogicalDataType) -> Self {
         match logical_type {

--- a/read_buffer/src/value.rs
+++ b/read_buffer/src/value.rs
@@ -1093,13 +1093,13 @@ impl std::ops::Add for Scalar {
     }
 }
 
-impl std::fmt::Display for Scalar {
+impl std::fmt::Display for &Scalar {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::Null => write!(f, "NULL"),
-            Self::I64(v) => write!(f, "{}", v),
-            Self::U64(v) => write!(f, "{}", v),
-            Self::F64(v) => write!(f, "{}", v),
+            Scalar::Null => write!(f, "NULL"),
+            Scalar::I64(v) => write!(f, "{}", v),
+            Scalar::U64(v) => write!(f, "{}", v),
+            Scalar::F64(v) => write!(f, "{}", v),
         }
     }
 }
@@ -1130,6 +1130,18 @@ impl OwnedValue {
             Self::String(s) => s.len() + self_size,
             Self::ByteArray(arr) => arr.len() + self_size,
             _ => self_size,
+        }
+    }
+}
+
+impl std::fmt::Display for &OwnedValue {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            OwnedValue::Null => write!(f, "NULL"),
+            OwnedValue::String(s) => s.fmt(f),
+            OwnedValue::ByteArray(s) => write!(f, "{}", String::from_utf8_lossy(s)),
+            OwnedValue::Boolean(b) => b.fmt(f),
+            OwnedValue::Scalar(s) => s.fmt(f),
         }
     }
 }


### PR DESCRIPTION
Closes https://github.com/influxdata/conductor/issues/253

This PR adds some logging to the Read Buffer to give me an idea of what the current situation is within our internal monitoring cluster.

I am emitting a fair bit of noise at `info` at the moment, which I will quieten down in due course and turn into alternative telemetry.