### PR TITLE
chore: upgrade Rust CI to nightly-2021-03-24

### DIFF
--- a/docker/Dockerfile.ci
+++ b/docker/Dockerfile.ci
@@ -47,8 +47,8 @@ RUN ln -sf /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN locale-gen C.UTF-8 || true
 ENV LANG=C.UTF-8
 
-RUN rustup toolchain install nightly-2020-11-19
-RUN rustup component add rustfmt clippy --toolchain nightly-2020-11-19
+RUN rustup toolchain install nightly-2021-03-24
+RUN rustup component add rustfmt clippy --toolchain nightly-2021-03-24
 
 RUN groupadd -g 1500 rust \
   && useradd -u 1500 -g rust -s /bin/bash -m rust \


### PR DESCRIPTION
To be merged and triggered before #1249 