### PR TITLE
refactor: quieten down logs

### DIFF
--- a/read_buffer/src/chunk.rs
+++ b/read_buffer/src/chunk.rs
@@ -248,9 +248,11 @@ impl Chunk {
         let row_group = RowGroup::from(table_data);
         let table_name = table_name.into();
 
+        let rows = self.rows();
         let rg_size = row_group.size();
         let compression = format!("{:.2}%", (rg_size as f64 / rb_size as f64) * 100.0);
-        info!(rb_size, rg_size, %compression, %row_group, "row group added");
+        let chunk_id = self.id();
+        info!(%rows, rb_size, rg_size, %compression, ?table_name, %chunk_id, "row group added");
 
         let mut chunk_data = self.chunk_data.write();
 

--- a/server/src/db.rs
+++ b/server/src/db.rs
@@ -420,7 +420,7 @@ impl Db {
             })?
         };
 
-        debug!(%partition_key, %chunk_id, "chunk marked MOVING, loading tables into read buffer");
+        info!(%partition_key, %chunk_id, "chunk marked MOVING, loading tables into read buffer");
 
         let mut batches = Vec::new();
         let table_stats = mb_chunk.table_summaries();


### PR DESCRIPTION
Now I have some good data on what's currently happening with chunk migration into the Read Buffer we can quieten down the logs. 

I have decided to continue to emit details at the `info` level on a single line for when we move a row group into the Read Buffer so as to provide some high level observability in the logs around this.