### PR TITLE
chore: update circle job

### DIFF
--- a/docker/Dockerfile.ci
+++ b/docker/Dockerfile.ci
@@ -48,7 +48,7 @@ RUN locale-gen C.UTF-8 || true
 ENV LANG=C.UTF-8
 
 RUN rustup toolchain install nightly-2021-03-24
-RUN rustup component add rustfmt clippy --toolchain nightly-2021-03-24
+RUN rustup component add rustfmt clippy --toolchain stable
 
 RUN groupadd -g 1500 rust \
   && useradd -u 1500 -g rust -s /bin/bash -m rust \


### PR DESCRIPTION
This updates our CI builder to use `stable` Rust. This will allow me to regenerate the CI build to close out #1261 