### PR TITLE
chore: update tonic to 0.4.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3844,9 +3844,9 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91491e5f15431f2189ec8c1f9dcbadac949450399c22c912ceae9570eb472f61"
+checksum = "556dc31b450f45d18279cfc3d2519280273f460d5387e6b7b24503e65d206f8b"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -3873,9 +3873,9 @@ dependencies = [
 
 [[package]]
 name = "tonic-build"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2e09854abff4c0716059219e155ab0539aecbfc26a40214897b062653adb6ba"
+checksum = "c695de27302f4697191dda1c7178131a8cb805463dda02864acb80fe1322fdcf"
 dependencies = [
  "proc-macro2",
  "prost-build",


### PR DESCRIPTION
https://github.com/hyperium/tonic/pull/591 introduced a change to tonic codegen was then released in 0.4.2.

Arrow-flight is checking in the generated code from tonic, which has been updated to use 0.4.2. The result is that trying to compile arrow-flight with an older version of tonic e.g. 0.4.1 results in errors about `futures_core` not existing.

I personally feel that a breaking API change probably shouldn't have been a patch version bump in tonic, which cargo views as semver compatible, but the quick fix is to update the lockfile to use the new versions