### PR TITLE
refactor: make chunks per-table

### DIFF
--- a/data_types/src/job.rs
+++ b/data_types/src/job.rs
@@ -25,6 +25,7 @@ pub enum Job {
     CloseChunk {
         db_name: String,
         partition_key: String,
+        table_name: String,
         chunk_id: u32,
     },
 
@@ -32,6 +33,7 @@ pub enum Job {
     WriteChunk {
         db_name: String,
         partition_key: String,
+        table_name: String,
         chunk_id: u32,
     },
 }
@@ -50,19 +52,23 @@ impl From<Job> for management::operation_metadata::Job {
             Job::CloseChunk {
                 db_name,
                 partition_key,
+                table_name,
                 chunk_id,
             } => Self::CloseChunk(management::CloseChunk {
                 db_name,
                 partition_key,
+                table_name,
                 chunk_id,
             }),
             Job::WriteChunk {
                 db_name,
                 partition_key,
+                table_name,
                 chunk_id,
             } => Self::WriteChunk(management::WriteChunk {
                 db_name,
                 partition_key,
+                table_name,
                 chunk_id,
             }),
         }
@@ -84,19 +90,23 @@ impl From<management::operation_metadata::Job> for Job {
             Job::CloseChunk(management::CloseChunk {
                 db_name,
                 partition_key,
+                table_name,
                 chunk_id,
             }) => Self::CloseChunk {
                 db_name,
                 partition_key,
+                table_name,
                 chunk_id,
             },
             Job::WriteChunk(management::WriteChunk {
                 db_name,
                 partition_key,
+                table_name,
                 chunk_id,
             }) => Self::WriteChunk {
                 db_name,
                 partition_key,
+                table_name,
                 chunk_id,
             },
         }

--- a/generated_types/protos/influxdata/iox/management/v1/chunk.proto
+++ b/generated_types/protos/influxdata/iox/management/v1/chunk.proto
@@ -30,6 +30,9 @@ message Chunk {
   // The partitition key of this chunk
   string partition_key = 1;
 
+  // The table of this chunk
+  string table_name = 8;
+
   // The id of this chunk
   uint32 id = 2;
 

--- a/generated_types/protos/influxdata/iox/management/v1/jobs.proto
+++ b/generated_types/protos/influxdata/iox/management/v1/jobs.proto
@@ -43,6 +43,9 @@ message CloseChunk {
   // partition key
   string partition_key = 2;
 
+  // table name
+  string table_name = 4;
+
   // chunk_id
   uint32 chunk_id = 3;
 }
@@ -54,6 +57,9 @@ message WriteChunk {
 
   // partition key
   string partition_key = 2;
+
+  // table name
+  string table_name = 4;
 
   // chunk_id
   uint32 chunk_id = 3;

--- a/generated_types/protos/influxdata/iox/management/v1/service.proto
+++ b/generated_types/protos/influxdata/iox/management/v1/service.proto
@@ -199,6 +199,9 @@ message NewPartitionChunkRequest {
 
   // the partition key
   string partition_key = 2;
+
+  // the table name
+  string table_name = 3;
 }
 
 message NewPartitionChunkResponse {
@@ -211,6 +214,9 @@ message ClosePartitionChunkRequest {
 
   // the partition key
   string partition_key = 2;
+
+  // the table name
+  string table_name = 4;
 
   // the chunk id
   uint32 chunk_id = 3;

--- a/influxdb_iox_client/src/client/management.rs
+++ b/influxdb_iox_client/src/client/management.rs
@@ -465,13 +465,16 @@ impl Client {
         &mut self,
         db_name: impl Into<String>,
         partition_key: impl Into<String>,
+        table_name: impl Into<String>,
     ) -> Result<(), NewPartitionChunkError> {
         let db_name = db_name.into();
         let partition_key = partition_key.into();
+        let table_name = table_name.into();
 
         self.inner
             .new_partition_chunk(NewPartitionChunkRequest {
                 db_name,
+                table_name,
                 partition_key,
             })
             .await
@@ -512,16 +515,19 @@ impl Client {
         &mut self,
         db_name: impl Into<String>,
         partition_key: impl Into<String>,
+        table_name: impl Into<String>,
         chunk_id: u32,
     ) -> Result<Operation, ClosePartitionChunkError> {
         let db_name = db_name.into();
         let partition_key = partition_key.into();
+        let table_name = table_name.into();
 
         let response = self
             .inner
             .close_partition_chunk(ClosePartitionChunkRequest {
                 db_name,
                 partition_key,
+                table_name,
                 chunk_id,
             })
             .await

--- a/server/src/query_tests/influxrpc/read_window_aggregate.rs
+++ b/server/src/query_tests/influxrpc/read_window_aggregate.rs
@@ -172,8 +172,8 @@ impl DbSetup for MeasurementForWindowAggregateMonths {
         let db = make_db();
         let data = lp_lines.join("\n");
         write_lp(&db, &data);
-        db.rollover_partition("2020-03-01T00").await.unwrap();
-        db.rollover_partition("2020-03-02T00").await.unwrap();
+        db.rollover_partition("2020-03-01T00", "h2o").await.unwrap();
+        db.rollover_partition("2020-03-02T00", "h2o").await.unwrap();
         let scenario2 = DbScenario {
             scenario_name:
                 "Data in 4 partitions, two open chunk and two closed chunks of mutable buffer"
@@ -184,10 +184,10 @@ impl DbSetup for MeasurementForWindowAggregateMonths {
         let db = make_db();
         let data = lp_lines.join("\n");
         write_lp(&db, &data);
-        rollover_and_load(&db, "2020-03-01T00").await;
-        rollover_and_load(&db, "2020-03-02T00").await;
-        rollover_and_load(&db, "2020-04-01T00").await;
-        rollover_and_load(&db, "2020-04-02T00").await;
+        rollover_and_load(&db, "2020-03-01T00", "h2o").await;
+        rollover_and_load(&db, "2020-03-02T00", "h2o").await;
+        rollover_and_load(&db, "2020-04-01T00", "h2o").await;
+        rollover_and_load(&db, "2020-04-02T00", "h2o").await;
         let scenario3 = DbScenario {
             scenario_name: "Data in 4 partitions, 4 closed chunks in mutable buffer".into(),
             db,

--- a/server/src/query_tests/sql.rs
+++ b/server/src/query_tests/sql.rs
@@ -223,13 +223,14 @@ async fn sql_select_from_information_schema_columns() {
     "| public        | iox          | o2         | state               | 2                |                | YES         | Utf8                        |                          | 2147483647             |                   |                         |               |                    |               |",
     "| public        | iox          | o2         | temp                | 3                |                | YES         | Float64                     |                          |                        | 24                | 2                       |               |                    |               |",
     "| public        | iox          | o2         | time                | 4                |                | NO          | Timestamp(Nanosecond, None) |                          |                        |                   |                         |               |                    |               |",
-    "| public        | system       | chunks     | estimated_bytes     | 3                |                | YES         | UInt64                      |                          |                        |                   |                         |               |                    |               |",
+    "| public        | system       | chunks     | estimated_bytes     | 4                |                | YES         | UInt64                      |                          |                        |                   |                         |               |                    |               |",
     "| public        | system       | chunks     | id                  | 0                |                | NO          | UInt32                      |                          |                        | 32                | 2                       |               |                    |               |",
     "| public        | system       | chunks     | partition_key       | 1                |                | NO          | Utf8                        |                          | 2147483647             |                   |                         |               |                    |               |",
-    "| public        | system       | chunks     | storage             | 2                |                | NO          | Utf8                        |                          | 2147483647             |                   |                         |               |                    |               |",
-    "| public        | system       | chunks     | time_closing        | 6                |                | YES         | Timestamp(Nanosecond, None) |                          |                        |                   |                         |               |                    |               |",
-    "| public        | system       | chunks     | time_of_first_write | 4                |                | YES         | Timestamp(Nanosecond, None) |                          |                        |                   |                         |               |                    |               |",
-    "| public        | system       | chunks     | time_of_last_write  | 5                |                | YES         | Timestamp(Nanosecond, None) |                          |                        |                   |                         |               |                    |               |",
+    "| public        | system       | chunks     | storage             | 3                |                | NO          | Utf8                        |                          | 2147483647             |                   |                         |               |                    |               |",
+    "| public        | system       | chunks     | table_name          | 2                |                | NO          | Utf8                        |                          | 2147483647             |                   |                         |               |                    |               |",
+    "| public        | system       | chunks     | time_closing        | 7                |                | YES         | Timestamp(Nanosecond, None) |                          |                        |                   |                         |               |                    |               |",
+    "| public        | system       | chunks     | time_of_first_write | 5                |                | YES         | Timestamp(Nanosecond, None) |                          |                        |                   |                         |               |                    |               |",
+    "| public        | system       | chunks     | time_of_last_write  | 6                |                | YES         | Timestamp(Nanosecond, None) |                          |                        |                   |                         |               |                    |               |",
     "| public        | system       | columns    | column_name         | 2                |                | YES         | Utf8                        |                          | 2147483647             |                   |                         |               |                    |               |",
     "| public        | system       | columns    | count               | 3                |                | YES         | UInt64                      |                          |                        |                   |                         |               |                    |               |",
     "| public        | system       | columns    | partition_key       | 0                |                | NO          | Utf8                        |                          | 2147483647             |                   |                         |               |                    |               |",
@@ -275,15 +276,16 @@ async fn sql_select_from_system_tables() {
     //  test timestamps, etc)
 
     let expected = vec![
-        "+----+---------------+-------------------+-----------------+",
-        "| id | partition_key | storage           | estimated_bytes |",
-        "+----+---------------+-------------------+-----------------+",
-        "| 0  | 1970-01-01T00 | OpenMutableBuffer | 501             |",
-        "+----+---------------+-------------------+-----------------+",
+        "+----+---------------+------------+-------------------+-----------------+",
+        "| id | partition_key | table_name | storage           | estimated_bytes |",
+        "+----+---------------+------------+-------------------+-----------------+",
+        "| 0  | 1970-01-01T00 | h2o        | OpenMutableBuffer | 324             |",
+        "| 0  | 1970-01-01T00 | o2         | OpenMutableBuffer | 264             |",
+        "+----+---------------+------------+-------------------+-----------------+",
     ];
     run_sql_test_case!(
         TwoMeasurementsManyFieldsOneChunk {},
-        "SELECT id, partition_key, storage, estimated_bytes from system.chunks",
+        "SELECT id, partition_key, table_name, storage, estimated_bytes from system.chunks",
         &expected
     );
 

--- a/src/commands/database/partition.rs
+++ b/src/commands/database/partition.rs
@@ -85,6 +85,9 @@ struct NewChunk {
 
     /// The partition key
     partition_key: String,
+
+    /// The table name
+    table_name: String,
 }
 
 /// Closes a chunk in the mutable buffer for writing and starts its migration to
@@ -96,6 +99,9 @@ struct CloseChunk {
 
     /// The partition key
     partition_key: String,
+
+    /// The table name
+    table_name: String,
 
     /// The chunk id
     chunk_id: u32,
@@ -168,21 +174,25 @@ pub async fn command(url: String, config: Config) -> Result<()> {
             let NewChunk {
                 db_name,
                 partition_key,
+                table_name,
             } = new_chunk;
 
             // Ignore response for now
-            client.new_partition_chunk(db_name, partition_key).await?;
+            client
+                .new_partition_chunk(db_name, partition_key, table_name)
+                .await?;
             println!("Ok");
         }
         Command::CloseChunk(close_chunk) => {
             let CloseChunk {
                 db_name,
                 partition_key,
+                table_name,
                 chunk_id,
             } = close_chunk;
 
             let operation: Operation = client
-                .close_partition_chunk(db_name, partition_key, chunk_id)
+                .close_partition_chunk(db_name, partition_key, table_name, chunk_id)
                 .await?
                 .try_into()?;
 

--- a/src/influxdb_ioxd/rpc/error.rs
+++ b/src/influxdb_ioxd/rpc/error.rs
@@ -59,12 +59,22 @@ pub fn default_catalog_error_handler(error: server::db::catalog::Error) -> tonic
             ..Default::default()
         }
         .into(),
+        Error::UnknownTable {
+            partition_key,
+            table_name,
+        } => NotFound {
+            resource_type: "table".to_string(),
+            resource_name: format!("{}:{}", partition_key, table_name),
+            ..Default::default()
+        }
+        .into(),
         Error::UnknownChunk {
             partition_key,
+            table_name,
             chunk_id,
         } => NotFound {
             resource_type: "chunk".to_string(),
-            resource_name: format!("{}:{}", partition_key, chunk_id),
+            resource_name: format!("{}:{}:{}", partition_key, table_name, chunk_id),
             ..Default::default()
         }
         .into(),

--- a/src/influxdb_ioxd/rpc/management.rs
+++ b/src/influxdb_ioxd/rpc/management.rs
@@ -329,6 +329,7 @@ where
         let NewPartitionChunkRequest {
             db_name,
             partition_key,
+            table_name,
         } = request.into_inner();
         let db_name = DatabaseName::new(db_name).field("db_name")?;
 
@@ -338,7 +339,7 @@ where
             ..Default::default()
         })?;
 
-        db.rollover_partition(&partition_key)
+        db.rollover_partition(&partition_key, &table_name)
             .await
             .map_err(default_db_error_handler)?;
 
@@ -352,6 +353,7 @@ where
         let ClosePartitionChunkRequest {
             db_name,
             partition_key,
+            table_name,
             chunk_id,
         } = request.into_inner();
 
@@ -360,7 +362,7 @@ where
 
         let tracker = self
             .server
-            .close_chunk(db_name, partition_key, chunk_id)
+            .close_chunk(db_name, partition_key, table_name, chunk_id)
             .map_err(default_server_error_handler)?;
 
         let operation = Some(super::operations::encode_tracker(tracker)?);

--- a/tests/end_to_end_cases/management_cli.rs
+++ b/tests/end_to_end_cases/management_cli.rs
@@ -406,6 +406,7 @@ async fn test_list_partition_chunks() {
 
     let expected = r#"
     "partition_key": "cpu",
+    "table_name": "cpu",
     "id": 0,
     "storage": "OpenMutableBuffer",
 "#;
@@ -472,6 +473,7 @@ async fn test_new_partition_chunk() {
         .arg("new-chunk")
         .arg(&db_name)
         .arg("cpu")
+        .arg("cpu")
         .arg("--host")
         .arg(addr)
         .assert()
@@ -504,6 +506,7 @@ async fn test_new_partition_chunk_error() {
         .arg("new-chunk")
         .arg("non_existent_database")
         .arg("non_existent_partition")
+        .arg("non_existent_table")
         .arg("--host")
         .arg(addr)
         .assert()
@@ -532,6 +535,7 @@ async fn test_close_partition_chunk() {
             .arg("close-chunk")
             .arg(&db_name)
             .arg("cpu")
+            .arg("cpu")
             .arg("0")
             .arg("--host")
             .arg(addr)
@@ -545,6 +549,7 @@ async fn test_close_partition_chunk() {
     let expected_job = Job::CloseChunk {
         db_name,
         partition_key: "cpu".into(),
+        table_name: "cpu".into(),
         chunk_id: 0,
     };
 
@@ -568,6 +573,7 @@ async fn test_close_partition_chunk_error() {
         .arg("close-chunk")
         .arg("non_existent_database")
         .arg("non_existent_partition")
+        .arg("non_existent_table")
         .arg("0")
         .arg("--host")
         .arg(addr)


### PR DESCRIPTION
This changes the hierarchy from

```
database -> partition -> chunk -> table
```

to

```
database -> partition -> table -> chunk
```

Only the high-level APIs are changed for now. The chunk states (like
MutableBuffer and ReadBuffer) still multiplex tables, although they will
always only get a single table assigned (or no table if no data was
presented yet).

Closes #1256.
