### PR TITLE
test: Don't run any integration tests unless TEST_INTEGRATION is set

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -12,12 +12,9 @@ setup to do.
 By default, `cargo test -p object_store` does not run any tests that actually contact
 any cloud services: tests that do contact the services will silently pass.
 
-To ensure you've configured object storage integration testing correctly, you can run
-`TEST_INTEGRATION=1 cargo test -p object_store`, which will run the tests that contact the cloud
-services and fail them if the required environment variables aren't set.
-
-If you don't specify the `TEST_INTEGRATION` environment variable but you do configure some or all
-of the object stores, the relevant tests will run.
+To run integration tests, use `TEST_INTEGRATION=1 cargo test -p object_store`, which will run the
+tests that contact the cloud services and fail them if the required environment variables aren't
+set.
 
 ### Configuration differences when running the tests
 
@@ -33,15 +30,12 @@ of `influxdb_iox run --help` for instructions.
 ## InfluxDB 2 Client
 
 The `influxdb2_client` crate may be used by people using InfluxDB 2.0 OSS, and should be compatible
-with both that and IOx. If you have `docker` in your path, the integration tests for the
-`influxdb2_client` crate will run integration tests against `influxd` running in a Docker
-container. If you do not have `docker`, by default, those tests will not be run and will silently
-pass.
+with both that and IOx. If you want to run the integration tests for the client against InfluxDB
+2.0 OSS, you will need to set `TEST_INTEGRATION=1`.
+
+If you have `docker` in your path, the integration tests for the `influxdb2_client` crate will run
+integration tests against `influxd` running in a Docker container.
 
 If you do not want to use Docker locally, but you do have `influxd` for InfluxDB
 2.0 locally, you can use that instead by running the tests with the environment variable
 `INFLUXDB_IOX_INTEGRATION_LOCAL=1`.
-
-To ensure you're running the `influxdb2_client` integration tests, you can run `TEST_INTEGRATION=1
-cargo test -p influxdb2_client`, which will fail the tests if `docker` (or `influxd`, if
-`INFLUXDB_IOX_INTEGRATION_LOCAL=1` is set) is not available.

--- a/influxdb2_client/tests/common/server_fixture.rs
+++ b/influxdb2_client/tests/common/server_fixture.rs
@@ -11,13 +11,12 @@ use std::{
 use tokio::sync::Mutex;
 
 #[macro_export]
-/// If InfluxDB 2.0 OSS is available (either locally via `influxd` directly if
-/// the `INFLUXDB_IOX_INTEGRATION_LOCAL` environment variable is set, or via
-/// `docker` otherwise), set up the server as requested and return it to the caller.
+/// If `TEST_INTEGRATION` is set and InfluxDB 2.0 OSS is available (either locally
+/// via `influxd` directly if  the `INFLUXDB_IOX_INTEGRATION_LOCAL` environment
+// variable is set, or via `docker` otherwise), set up the server as requested and
+/// return it to the caller.
 ///
-/// If InfluxDB is not available, skip the calling test by returning
-/// early. Additionally if `TEST_INTEGRATION` is set, turn this early return
-/// into a panic to force a hard fail for skipped integration tests.
+/// If `TEST_INTEGRATION` is not set, skip the calling test by returning early.
 macro_rules! maybe_skip_integration {
     ($server_fixture:expr) => {{
         let local = std::env::var("INFLUXDB_IOX_INTEGRATION_LOCAL").is_ok();
@@ -32,7 +31,7 @@ macro_rules! maybe_skip_integration {
                 .success(),
             std::env::var("TEST_INTEGRATION").is_ok(),
         ) {
-            (true, _) => $server_fixture,
+            (true, true) => $server_fixture,
             (false, true) => {
                 panic!(
                     "TEST_INTEGRATION is set which requires running integration tests, but \
@@ -41,7 +40,11 @@ macro_rules! maybe_skip_integration {
                 )
             }
             _ => {
-                eprintln!("skipping integration test - install `{}` to run", command);
+                eprintln!(
+                    "skipping integration test - set the TEST_INTEGRATION environment variable \
+                     and install `{}` to run",
+                    command
+                );
                 return Ok(());
             }
         }

--- a/object_store/src/aws.rs
+++ b/object_store/src/aws.rs
@@ -445,8 +445,7 @@ mod tests {
         bucket: String,
     }
 
-    // Helper macro to skip tests if the AWS environment variables are not set.
-    // Skips become hard errors if TEST_INTEGRATION is set.
+    // Helper macro to skip tests if TEST_INTEGRATION and the AWS environment variables are not set.
     macro_rules! maybe_skip_integration {
         () => {{
             dotenv::dotenv().ok();
@@ -474,11 +473,14 @@ mod tests {
                             but variable(s) {} need to be set",
                     unset_var_names
                 );
-            } else if force.is_err() && !unset_var_names.is_empty() {
+            } else if force.is_err() {
                 eprintln!(
-                    "skipping AWS integration test - set \
-                               {} to run",
-                    unset_var_names
+                    "skipping AWS integration test - set {}TEST_INTEGRATION to run",
+                    if unset_var_names.is_empty() {
+                        String::new()
+                    } else {
+                        format!("{} and ", unset_var_names)
+                    }
                 );
                 return;
             } else {

--- a/object_store/src/azure.rs
+++ b/object_store/src/azure.rs
@@ -287,8 +287,8 @@ mod tests {
         bucket: String,
     }
 
-    // Helper macro to skip tests if the Azure environment variables are not set.
-    // Skips become hard errors if TEST_INTEGRATION is set.
+    // Helper macro to skip tests if TEST_INTEGRATION and the Azure environment
+    // variables are not set.
     macro_rules! maybe_skip_integration {
         () => {{
             dotenv::dotenv().ok();
@@ -315,11 +315,14 @@ mod tests {
                         but variable(s) {} need to be set",
                     unset_var_names
                 )
-            } else if force.is_err() && !unset_var_names.is_empty() {
+            } else if force.is_err() {
                 eprintln!(
-                    "skipping Azure integration test - set \
-                           {} to run",
-                    unset_var_names
+                    "skipping Azure integration test - set {}TEST_INTEGRATION to run",
+                    if unset_var_names.is_empty() {
+                        String::new()
+                    } else {
+                        format!("{} and ", unset_var_names)
+                    }
                 );
                 return;
             } else {

--- a/object_store/src/gcp.rs
+++ b/object_store/src/gcp.rs
@@ -287,8 +287,7 @@ mod test {
         service_account: String,
     }
 
-    // Helper macro to skip tests if the GCP environment variables are not set.
-    // Skips become hard errors if TEST_INTEGRATION is set.
+    // Helper macro to skip tests if TEST_INTEGRATION and the GCP environment variables are not set.
     macro_rules! maybe_skip_integration {
         () => {{
             dotenv::dotenv().ok();
@@ -311,11 +310,14 @@ mod test {
                             but variable(s) {} need to be set",
                     unset_var_names
                 )
-            } else if force.is_err() && !unset_var_names.is_empty() {
+            } else if force.is_err() {
                 eprintln!(
-                    "skipping Google Cloud integration test - set \
-                               {} to run",
-                    unset_var_names
+                    "skipping Google Cloud integration test - set {}TEST_INTEGRATION to run",
+                    if unset_var_names.is_empty() {
+                        String::new()
+                    } else {
+                        format!("{} and ", unset_var_names)
+                    }
                 );
                 return;
             } else {


### PR DESCRIPTION
By popular vote, this changes the default test running behavior to not even try to run the `influxdb2_client` or `object_store` integration tests unless the `TEST_INTEGRATION` environment variable is set.