### PR TITLE
refactor: use then method on bool

### DIFF
--- a/mutable_buffer/src/chunk/snapshot.rs
+++ b/mutable_buffer/src/chunk/snapshot.rs
@@ -127,10 +127,9 @@ impl ChunkSnapshot {
         self.records
             .iter()
             .flat_map(move |(table_name, table_snapshot)| {
-                match table_snapshot.matches_predicate(&timestamp_range) {
-                    true => Some(table_name),
-                    false => None,
-                }
+                table_snapshot
+                    .matches_predicate(&timestamp_range)
+                    .then(|| table_name)
             })
     }
 

--- a/read_buffer/src/chunk.rs
+++ b/read_buffer/src/chunk.rs
@@ -491,10 +491,9 @@ impl Chunk {
                     return None;
                 }
 
-                match table.satisfies_predicate(predicate) {
-                    true => Some(name.to_owned()),
-                    false => None,
-                }
+                table
+                    .satisfies_predicate(predicate)
+                    .then(|| name.to_owned())
             })
             .collect::<BTreeSet<_>>()
     }


### PR DESCRIPTION
Rust 1.50 made stable [`bool::then`](https://blog.rust-lang.org/2021/02/11/Rust-1.50.0.html#library-changes), which lets you transform `true` into `Some(x)` and `false` into `None`. There were a coupleof places in IOx where this  could be used so I've updated them.
