### PR TITLE
refactor: remove explicit time_range field from read buffer

### DIFF
--- a/read_buffer/src/row_group.rs
+++ b/read_buffer/src/row_group.rs
@@ -106,15 +106,6 @@ impl RowGroup {
                 ColumnType::Time(c) => {
                     assert_eq!(c.num_rows(), rows);
 
-                    meta.time_range = match c.column_range() {
-                        None => panic!("time column must have non-null value"),
-                        Some((
-                            OwnedValue::Scalar(Scalar::I64(min)),
-                            OwnedValue::Scalar(Scalar::I64(max)),
-                        )) => (min, max),
-                        Some((_, _)) => unreachable!("unexpected types for time range"),
-                    };
-
                     meta.add_column(
                         &name,
                         c.size(),
@@ -183,11 +174,6 @@ impl RowGroup {
     // Returns a reference to the timestamp column.
     fn time_column(&self) -> &Column {
         &self.columns[self.time_column]
-    }
-
-    /// The time range of the `RowGroup` (of the time column).
-    pub fn time_range(&self) -> (i64, i64) {
-        self.meta.time_range
     }
 
     /// Efficiently determines if the row group _might_ satisfy all of the
@@ -1475,12 +1461,6 @@ pub struct MetaData {
     pub columns: BTreeMap<String, ColumnMeta>,
 
     pub column_names: Vec<String>,
-
-    // The total time range of this `RowGroup`.
-    //
-    // This can be used to skip the table entirely if the time range for a query
-    // falls outside of this range.
-    pub time_range: (i64, i64),
 }
 
 impl std::fmt::Display for &MetaData {

--- a/server/src/db.rs
+++ b/server/src/db.rs
@@ -1704,7 +1704,7 @@ mod tests {
                 to_arc("cpu"),
                 0,
                 ChunkStorage::ReadBuffer,
-                1269,
+                1213,
             ),
             ChunkSummary::new_without_timestamps(
                 to_arc("1970-01-01T00"),
@@ -1736,7 +1736,7 @@ mod tests {
         );
 
         assert_eq!(db.memory_registries.mutable_buffer.bytes(), 121 + 157 + 159);
-        assert_eq!(db.memory_registries.read_buffer.bytes(), 1269);
+        assert_eq!(db.memory_registries.read_buffer.bytes(), 1213);
     }
 
     #[tokio::test]


### PR DESCRIPTION
The Read Buffer treats time as just another column, and the `time_range` fields I had on the meta data of tables and row groups is just  cruft from a previous design iteration.

As mentioned in https://github.com/influxdata/influxdb_iox/pull/1212 we can just use column ranges for the time column.
This PR removes the explicit `time_range` field.