### PR TITLE
chore: update arrow versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,7 +113,7 @@ checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 [[package]]
 name = "arrow"
 version = "4.0.0-SNAPSHOT"
-source = "git+https://github.com/apache/arrow.git?rev=d4c5c3c02e52e76579d95a84ae33491b9c1284c9#d4c5c3c02e52e76579d95a84ae33491b9c1284c9"
+source = "git+https://github.com/apache/arrow-rs?rev=c3fe3bab9905739fdda75301dab07a18c91731bd#c3fe3bab9905739fdda75301dab07a18c91731bd"
 dependencies = [
  "cfg_aliases",
  "chrono",
@@ -135,7 +135,7 @@ dependencies = [
 [[package]]
 name = "arrow-flight"
 version = "4.0.0-SNAPSHOT"
-source = "git+https://github.com/apache/arrow.git?rev=d4c5c3c02e52e76579d95a84ae33491b9c1284c9#d4c5c3c02e52e76579d95a84ae33491b9c1284c9"
+source = "git+https://github.com/apache/arrow-rs?rev=c3fe3bab9905739fdda75301dab07a18c91731bd#c3fe3bab9905739fdda75301dab07a18c91731bd"
 dependencies = [
  "arrow",
  "bytes",
@@ -784,7 +784,7 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "4.0.0-SNAPSHOT"
-source = "git+https://github.com/apache/arrow.git?rev=d4c5c3c02e52e76579d95a84ae33491b9c1284c9#d4c5c3c02e52e76579d95a84ae33491b9c1284c9"
+source = "git+https://github.com/apache/arrow-datafusion.git?rev=ddaea81f9f46e918b5ab4e6257f1963b2a8a0f15#ddaea81f9f46e918b5ab4e6257f1963b2a8a0f15"
 dependencies = [
  "ahash 0.7.2",
  "arrow",
@@ -2307,7 +2307,7 @@ dependencies = [
 [[package]]
 name = "parquet"
 version = "4.0.0-SNAPSHOT"
-source = "git+https://github.com/apache/arrow.git?rev=d4c5c3c02e52e76579d95a84ae33491b9c1284c9#d4c5c3c02e52e76579d95a84ae33491b9c1284c9"
+source = "git+https://github.com/apache/arrow-rs?rev=c3fe3bab9905739fdda75301dab07a18c91731bd#c3fe3bab9905739fdda75301dab07a18c91731bd"
 dependencies = [
  "arrow",
  "base64 0.12.3",

--- a/arrow_deps/Cargo.toml
+++ b/arrow_deps/Cargo.toml
@@ -5,17 +5,14 @@ authors = ["Andrew Lamb <andrew@nerdnetworks.org>"]
 edition = "2018"
 description = "Apache Arrow / Parquet / DataFusion dependencies for InfluxDB IOx, to ensure consistent versions and unified updates"
 
-[dependencies] # In alphabetical order
-# We are using development version of arrow/parquet/datafusion and the dependencies are at the same rev
+[dependencies]
 
-# The version can be found here: https://github.com/apache/arrow/commit/d4c5c3c02e52e76579d95a84ae33491b9c1284c9
-#
-arrow = { git = "https://github.com/apache/arrow.git", rev = "d4c5c3c02e52e76579d95a84ae33491b9c1284c9" , default-features = false }
-arrow-flight = { git = "https://github.com/apache/arrow.git", rev = "d4c5c3c02e52e76579d95a84ae33491b9c1284c9" }
+arrow = { git = "https://github.com/apache/arrow-rs", rev = "c3fe3bab9905739fdda75301dab07a18c91731bd" , default-features = false, features = ["prettyprint"]}
+arrow-flight = { git = "https://github.com/apache/arrow-rs", rev = "c3fe3bab9905739fdda75301dab07a18c91731bd" }
 
 # Turn off optional datafusion features (function packages)
-datafusion = { git = "https://github.com/apache/arrow.git", rev = "d4c5c3c02e52e76579d95a84ae33491b9c1284c9", default-features = false }
+datafusion = { git = "https://github.com/apache/arrow-datafusion.git", rev = "ddaea81f9f46e918b5ab4e6257f1963b2a8a0f15", default-features = false }
 
 # Turn off the "arrow" feature; it currently has a bug that causes the crate to rebuild every time
 # and we're not currently using it anyway
-parquet = { git = "https://github.com/apache/arrow.git", rev = "d4c5c3c02e52e76579d95a84ae33491b9c1284c9", default-features = false, features = ["snap", "brotli", "flate2", "lz4", "zstd"] }
+parquet = { git = "https://github.com/apache/arrow-rs", rev = "c3fe3bab9905739fdda75301dab07a18c91731bd", default-features = false, features = ["snap", "brotli", "flate2", "lz4", "zstd"] }


### PR DESCRIPTION
This moves to using arrow and Datafusion sourced from their new git repositories.

Unfortunately the split between the repositories whilst retaining git version pins requires replicating the exact version pins from DataFusion here, which isn't ideal. I've created https://github.com/apache/arrow-datafusion/issues/80 to maybe kickstart a discussion on doing this differently. We're fortunate Datafusion is the only library in our dependency tree that depends on arrow and isn't versioned in the same git repository as arrow itself - otherwise we'd be in a bit of a pickle.