### PR TITLE
chore: logging to debug CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -193,6 +193,9 @@ jobs:
       - run:
           name: Cargo release build with target arch set for CRoaring
           command: ROARING_ARCH=x86-64 cargo build --release
+      - run: |
+          echo sha256sum after build is
+          sha256sum target/release/influxdb_iox
       - setup_remote_docker:
           docker_layer_caching: true
       - run: |

--- a/docker/Dockerfile.iox
+++ b/docker/Dockerfile.iox
@@ -16,6 +16,7 @@ RUN mkdir ~/.influxdb_iox
 RUN ls -la ~/.influxdb_iox
 
 COPY target/release/influxdb_iox /usr/bin/influxdb_iox
+RUN echo "The binary just added has sha256 sum $(sha256sum /usr/bin/influxdb_iox)"
 
 EXPOSE 8080 8082
 


### PR DESCRIPTION
This PR adds some debug output to the CI build process to print out the SHA of the release binary built, and then the SHA of the binary added to the container image built in the "perf" build job, so we have some useful information to look at when debugging the issue we're seeing where two builds are producing an image with the same digest, despite coming from different commits with apparently meaningful code changes.

- [x] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb_iox/blob/main/README.md).
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
