### PR TITLE
feat: ingest_points_bytes_total records both success and errors

### DIFF
--- a/src/influxdb_ioxd/http.rs
+++ b/src/influxdb_ioxd/http.rs
@@ -462,6 +462,13 @@ where
                 metrics::KeyValue::new("db_name", db_name.to_string()),
             ],
         );
+        server.metrics.ingest_points_bytes_total.add_with_labels(
+            body.len() as u64,
+            &[
+                metrics::KeyValue::new("status", "error"),
+                metrics::KeyValue::new("db_name", db_name.to_string()),
+            ],
+        );
         let num_lines = lines.len();
         debug!(?e, ?db_name, ?num_lines, "error writing lines");
 
@@ -480,7 +487,10 @@ where
     // line protocol bytes successfully written
     server.metrics.ingest_points_bytes_total.add_with_labels(
         body.len() as u64,
-        &[metrics::KeyValue::new("db_name", db_name.to_string())],
+        &[
+            metrics::KeyValue::new("status", "ok"),
+            metrics::KeyValue::new("db_name", db_name.to_string()),
+        ],
     );
 
     obs.ok_with_labels(&metric_kv); // request completed successfully
@@ -949,7 +959,7 @@ mod tests {
         // Bytes of data were written
         metrics_registry
             .has_metric_family("ingest_points_bytes_total")
-            .with_labels(&[("db_name", "MetricsOrg_MetricsBucket")])
+            .with_labels(&[("status", "ok"), ("db_name", "MetricsOrg_MetricsBucket")])
             .counter()
             .eq(98.0)
             .unwrap();


### PR DESCRIPTION
__Rationale__

1. It's useful to know how much data we're throwing on the floor due to errors.
   Common ingestion errors are "no such database" or "max hard size reached".
   In both cases it's useful to be quickly able to gauge how much data would
   be ingested once the limiting factor for ingestion is lifted (e.g. the database is created via
   the management interface).

2. The name of the metric is `ingest_points_bytes_total` and the documentation states: `The number of bytes written`
   It's confusing to only count successes while not mentioning this neither in the metric name,
   nor in the metric description.

3. The sister metric `ingest_points_total` already records both successes and failures.

__Changes__

This PR adds a `status` tag to the `ingest_points_bytes_total`, mirroring what
we already do with `ingest_points_total`, so that  both the overall total and the total successfully
ingested bytes can be counted.
