### PR TITLE
fix: Remove authorization header in middleware

### DIFF
--- a/src/influxdb_ioxd/http.rs
+++ b/src/influxdb_ioxd/http.rs
@@ -306,8 +306,10 @@ where
     // Create a router and specify the the handlers.
     Router::builder()
         .data(server)
-        .middleware(Middleware::pre(|req| async move {
-            debug!(request = ?req, "Processing request");
+        .middleware(Middleware::pre(|mut req| async move {
+            // we don't need the authorization header and we don't want to accidentally log it.
+            req.headers_mut().remove("authorization");
+            debug!(request = ?req,"Processing request");
             Ok(req)
         }))
         .middleware(Middleware::post(|res| async move {


### PR DESCRIPTION
__Rationale__

Debug logs in the middle ware (and potentially elsewhere) can cause authorization headers
(containing authentication tokens) to be accidentally leaked in the logs.

It's easy to just remove those headers early in our HTTP middleware.
