### PR TITLE
feat: pushdown table and partition key predicates to catalog (#736)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3288,6 +3288,7 @@ dependencies = [
  "influxdb_iox_client",
  "influxdb_line_protocol",
  "internal_types",
+ "itertools 0.9.0",
  "metrics",
  "mutable_buffer",
  "num_cpus",

--- a/query/src/frontend/influxrpc.rs
+++ b/query/src/frontend/influxrpc.rs
@@ -201,7 +201,7 @@ impl InfluxRpcPlanner {
     {
         let mut builder = StringSetPlanBuilder::new();
 
-        for chunk in self.filtered_chunks(database, &predicate) {
+        for chunk in database.chunks(&predicate) {
             let new_table_names = chunk
                 .table_names(&predicate, builder.known_strings())
                 .map_err(|e| Box::new(e) as _)
@@ -246,7 +246,7 @@ impl InfluxRpcPlanner {
         let mut need_full_plans = BTreeMap::new();
 
         let mut known_columns = BTreeSet::new();
-        for chunk in self.filtered_chunks(database, &predicate) {
+        for chunk in database.chunks(&predicate) {
             // try and get the table names that have rows that match the predicate
             let table_names = self.chunk_table_names(chunk.as_ref(), &predicate)?;
 
@@ -351,7 +351,7 @@ impl InfluxRpcPlanner {
         let mut need_full_plans = BTreeMap::new();
 
         let mut known_values = BTreeSet::new();
-        for chunk in self.filtered_chunks(database, &predicate) {
+        for chunk in database.chunks(&predicate) {
             let table_names = self.chunk_table_names(chunk.as_ref(), &predicate)?;
 
             for table_name in table_names {
@@ -484,7 +484,7 @@ impl InfluxRpcPlanner {
         // values and stops the plan executing once it has them
 
         // map table -> Vec<Arc<Chunk>>
-        let chunks = self.filtered_chunks(database, &predicate);
+        let chunks = database.chunks(&predicate);
         let table_chunks = self.group_chunks_by_table(&predicate, chunks)?;
 
         let mut field_list_plan = FieldListPlan::new();
@@ -523,7 +523,7 @@ impl InfluxRpcPlanner {
 
         // group tables by chunk, pruning if possible
         // key is table name, values are chunks
-        let chunks = self.filtered_chunks(database, &predicate);
+        let chunks = database.chunks(&predicate);
         let table_chunks = self.group_chunks_by_table(&predicate, chunks)?;
 
         // now, build up plans for each table
@@ -558,7 +558,7 @@ impl InfluxRpcPlanner {
         debug!(predicate=?predicate, agg=?agg, "planning read_group");
 
         // group tables by chunk, pruning if possible
-        let chunks = self.filtered_chunks(database, &predicate);
+        let chunks = database.chunks(&predicate);
         let table_chunks = self.group_chunks_by_table(&predicate, chunks)?;
         let num_prefix_tag_group_columns = group_columns.len();
 
@@ -598,7 +598,7 @@ impl InfluxRpcPlanner {
         debug!(predicate=?predicate, "planning read_window_aggregate");
 
         // group tables by chunk, pruning if possible
-        let chunks = self.filtered_chunks(database, &predicate);
+        let chunks = database.chunks(&predicate);
         let table_chunks = self.group_chunks_by_table(&predicate, chunks)?;
 
         // now, build up plans for each table
@@ -1167,19 +1167,6 @@ impl InfluxRpcPlanner {
             plan_builder,
             schema,
         }))
-    }
-
-    /// Returns a list of chunks across all partitions which may
-    /// contain data that pass the predicate
-    fn filtered_chunks<D>(
-        &self,
-        database: &D,
-        predicate: &Predicate,
-    ) -> Vec<Arc<<D as Database>::Chunk>>
-    where
-        D: Database,
-    {
-        database.chunks(predicate)
     }
 }
 

--- a/query/src/frontend/influxrpc.rs
+++ b/query/src/frontend/influxrpc.rs
@@ -1179,39 +1179,7 @@ impl InfluxRpcPlanner {
     where
         D: Database,
     {
-        let mut db_chunks = Vec::new();
-
-        // TODO write the following in a functional style (need to get
-        // rid of `await` on `Database::chunks`)
-
-        let partition_keys = database
-            .partition_keys()
-            .map_err(|e| Box::new(e) as _)
-            .context(ListingPartitions)?;
-
-        debug!(partition_keys=?partition_keys, "Considering partition keys");
-
-        for key in partition_keys {
-            // TODO prune partitions somehow
-            let partition_chunks = database.chunks(&key);
-            for chunk in partition_chunks {
-                let could_pass_predicate = chunk
-                    .could_pass_predicate(predicate)
-                    .map_err(|e| Box::new(e) as _)
-                    .context(CheckingChunkPredicate {
-                        chunk_id: chunk.id(),
-                    })?;
-
-                debug!(
-                    chunk_id = chunk.id(),
-                    could_pass_predicate, "Considering chunk"
-                );
-                if could_pass_predicate {
-                    db_chunks.push(chunk)
-                }
-            }
-        }
-        Ok(db_chunks)
+        Ok(database.chunks(predicate))
     }
 }
 

--- a/query/src/frontend/influxrpc.rs
+++ b/query/src/frontend/influxrpc.rs
@@ -201,7 +201,7 @@ impl InfluxRpcPlanner {
     {
         let mut builder = StringSetPlanBuilder::new();
 
-        for chunk in self.filtered_chunks(database, &predicate)? {
+        for chunk in self.filtered_chunks(database, &predicate) {
             let new_table_names = chunk
                 .table_names(&predicate, builder.known_strings())
                 .map_err(|e| Box::new(e) as _)
@@ -246,7 +246,7 @@ impl InfluxRpcPlanner {
         let mut need_full_plans = BTreeMap::new();
 
         let mut known_columns = BTreeSet::new();
-        for chunk in self.filtered_chunks(database, &predicate)? {
+        for chunk in self.filtered_chunks(database, &predicate) {
             // try and get the table names that have rows that match the predicate
             let table_names = self.chunk_table_names(chunk.as_ref(), &predicate)?;
 
@@ -351,7 +351,7 @@ impl InfluxRpcPlanner {
         let mut need_full_plans = BTreeMap::new();
 
         let mut known_values = BTreeSet::new();
-        for chunk in self.filtered_chunks(database, &predicate)? {
+        for chunk in self.filtered_chunks(database, &predicate) {
             let table_names = self.chunk_table_names(chunk.as_ref(), &predicate)?;
 
             for table_name in table_names {
@@ -484,7 +484,7 @@ impl InfluxRpcPlanner {
         // values and stops the plan executing once it has them
 
         // map table -> Vec<Arc<Chunk>>
-        let chunks = self.filtered_chunks(database, &predicate)?;
+        let chunks = self.filtered_chunks(database, &predicate);
         let table_chunks = self.group_chunks_by_table(&predicate, chunks)?;
 
         let mut field_list_plan = FieldListPlan::new();
@@ -523,7 +523,7 @@ impl InfluxRpcPlanner {
 
         // group tables by chunk, pruning if possible
         // key is table name, values are chunks
-        let chunks = self.filtered_chunks(database, &predicate)?;
+        let chunks = self.filtered_chunks(database, &predicate);
         let table_chunks = self.group_chunks_by_table(&predicate, chunks)?;
 
         // now, build up plans for each table
@@ -558,7 +558,7 @@ impl InfluxRpcPlanner {
         debug!(predicate=?predicate, agg=?agg, "planning read_group");
 
         // group tables by chunk, pruning if possible
-        let chunks = self.filtered_chunks(database, &predicate)?;
+        let chunks = self.filtered_chunks(database, &predicate);
         let table_chunks = self.group_chunks_by_table(&predicate, chunks)?;
         let num_prefix_tag_group_columns = group_columns.len();
 
@@ -598,7 +598,7 @@ impl InfluxRpcPlanner {
         debug!(predicate=?predicate, "planning read_window_aggregate");
 
         // group tables by chunk, pruning if possible
-        let chunks = self.filtered_chunks(database, &predicate)?;
+        let chunks = self.filtered_chunks(database, &predicate);
         let table_chunks = self.group_chunks_by_table(&predicate, chunks)?;
 
         // now, build up plans for each table
@@ -1175,11 +1175,11 @@ impl InfluxRpcPlanner {
         &self,
         database: &D,
         predicate: &Predicate,
-    ) -> Result<Vec<Arc<<D as Database>::Chunk>>>
+    ) -> Vec<Arc<<D as Database>::Chunk>>
     where
         D: Database,
     {
-        Ok(database.chunks(predicate))
+        database.chunks(predicate)
     }
 }
 

--- a/query/src/lib.rs
+++ b/query/src/lib.rs
@@ -42,10 +42,9 @@ pub trait Database: Debug + Send + Sync {
     /// Return the partition keys for data in this DB
     fn partition_keys(&self) -> Result<Vec<String>, Self::Error>;
 
-    /// Returns a covering set of chunks in the specified partition. A
-    /// covering set means that together the chunks make up a single
-    /// complete copy of the data being queried.
-    fn chunks(&self, partition_key: &str) -> Vec<Arc<Self::Chunk>>;
+    /// Returns a set of chunks within the partition that match
+    /// the provided predicate
+    fn chunks(&self, predicate: &Predicate) -> Vec<Arc<Self::Chunk>>;
 
     /// Return a summary of all chunks in this database, in all partitions
     fn chunk_summaries(&self) -> Result<Vec<ChunkSummary>, Self::Error>;
@@ -58,16 +57,6 @@ pub trait PartitionChunk: Debug + Send + Sync {
     /// returns the Id of this chunk. Ids are unique within a
     /// particular partition.
     fn id(&self) -> u32;
-
-    /// Returns true if this chunk *might* have data that passes the
-    /// predicate. If false is returned, this chunk can be
-    /// skipped entirely. If true is returned, there still may not be
-    /// rows that match.
-    ///
-    /// This is used during query planning to skip including entire chunks
-    fn could_pass_predicate(&self, _predicate: &Predicate) -> Result<bool, Self::Error> {
-        Ok(true)
-    }
 
     /// Returns true if this chunk contains data for the specified table
     fn has_table(&self, table_name: &str) -> bool;

--- a/query/src/lib.rs
+++ b/query/src/lib.rs
@@ -42,8 +42,9 @@ pub trait Database: Debug + Send + Sync {
     /// Return the partition keys for data in this DB
     fn partition_keys(&self) -> Result<Vec<String>, Self::Error>;
 
-    /// Returns a set of chunks within the partition that match
-    /// the provided predicate
+    /// Returns a set of chunks within the partition with data that may match
+    /// the provided predicate. If possible, chunks which have no rows that can
+    /// possibly match the predicate are omitted.
     fn chunks(&self, predicate: &Predicate) -> Vec<Arc<Self::Chunk>>;
 
     /// Return a summary of all chunks in this database, in all partitions

--- a/query/src/test.rs
+++ b/query/src/test.rs
@@ -103,13 +103,13 @@ impl Database for TestDatabase {
         Ok(keys)
     }
 
-    fn chunks(&self, partition_key: &str) -> Vec<Arc<Self::Chunk>> {
+    fn chunks(&self, _predicate: &Predicate) -> Vec<Arc<Self::Chunk>> {
         let partitions = self.partitions.lock();
-        if let Some(chunks) = partitions.get(partition_key) {
-            chunks.values().cloned().collect()
-        } else {
-            vec![]
-        }
+        partitions
+            .values()
+            .flat_map(|x| x.values())
+            .cloned()
+            .collect()
     }
 
     fn chunk_summaries(&self) -> Result<Vec<data_types::chunk::ChunkSummary>, Self::Error> {

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -16,6 +16,7 @@ data_types = { path = "../data_types" }
 flatbuffers = "0.8"
 futures = "0.3"
 futures-util = { version = "0.3.1" }
+itertools = "0.9.0"
 generated_types = { path = "../generated_types" }
 influxdb_iox_client = { path = "../influxdb_iox_client" }
 influxdb_line_protocol = { path = "../influxdb_line_protocol" }

--- a/server/src/db/catalog/partition.rs
+++ b/server/src/db/catalog/partition.rs
@@ -187,15 +187,10 @@ impl Partition {
         &'a self,
         predicate: &'a Predicate,
     ) -> impl Iterator<Item = &Arc<RwLock<Chunk>>> + 'a {
-        match &predicate.table_names {
-            Some(tables) => {
-                itertools::Either::Left(self.tables.iter().filter_map(
-                    move |(table_name, table)| tables.contains(table_name).then(|| table),
-                ))
-            }
-            None => itertools::Either::Right(self.tables.values()),
-        }
-        .flat_map(|table| table.chunks.values())
+        self.tables
+            .iter()
+            .filter(move |(table_name, _)| predicate.should_include_table(table_name))
+            .flat_map(|(_, table)| table.chunks.values())
     }
 
     /// Return a PartitionSummary for this partition

--- a/server/src/db/chunk.rs
+++ b/server/src/db/chunk.rs
@@ -290,30 +290,6 @@ impl PartitionChunk for DbChunk {
         }
     }
 
-    fn could_pass_predicate(&self, _predicate: &Predicate) -> Result<bool> {
-        match self {
-            Self::MutableBuffer { .. } => {
-                // For now, we might get an error if we try and
-                // compile a chunk predicate (e.g. for tables that
-                // don't exist in the chunk) which could signal the
-                // chunk can't pass the predicate.
-
-                // However, we can also get an error if there is some
-                // unsupported operation and we need a way to
-                // distinguish the two cases.
-                Ok(true)
-            }
-            Self::ReadBuffer { .. } => {
-                // TODO: ask Edd how he wants this wired up in the read buffer
-                Ok(true)
-            }
-            Self::ParquetFile { .. } => {
-                // TODO proper filtering for parquet files
-                Ok(true)
-            }
-        }
-    }
-
     fn column_names(
         &self,
         table_name: &str,

--- a/server/src/snapshot.rs
+++ b/server/src/snapshot.rs
@@ -280,7 +280,7 @@ mod tests {
     use futures::TryStreamExt;
     use mutable_buffer::chunk::Chunk as ChunkWB;
     use object_store::memory::InMemory;
-    use query::{exec::Executor, Database};
+    use query::{exec::Executor, predicate::Predicate, Database};
     use tracker::MemRegistry;
 
     #[tokio::test]
@@ -302,7 +302,7 @@ cpu,host=B,region=east user=10.0,system=74.1 1
         let mut data_path = store.new_path();
         data_path.push_dir("data");
 
-        let chunk = Arc::clone(&db.chunks("1970-01-01T00")[0]);
+        let chunk = Arc::clone(&db.chunks(&Predicate::default())[0]);
         let table_summary = db
             .table_summary("1970-01-01T00", "cpu", chunk.id())
             .unwrap();


### PR DESCRIPTION
Relates to #736 and https://github.com/influxdata/influxdb_iox/issues/735 #734

This plumbs predicate pushdown into the catalog, and provides implementations for pruning based on partition key and table name.  Pruning based on chunk data is left for a future PR. The major benefit of pushing predicates through to the catalog is it allows pruning to occur before snapshotting any chunks.

It should be noted that the way the SQL frontend is currently wired up means that no predicates are passed down, this is tracked by #734

