### PR TITLE
fix: If possible drop MUB chunks when under pressure

### DIFF
--- a/server/src/db/lifecycle.rs
+++ b/server/src/db/lifecycle.rs
@@ -153,7 +153,10 @@ trait ChunkMover {
                     Some(chunk) => {
                         let chunk_guard = chunk.read();
                         if (rules.drop_non_persisted
-                            && matches!(chunk_guard.state(), ChunkState::Moved(_)))
+                            && matches!(
+                                chunk_guard.state(),
+                                ChunkState::Moved(_) | ChunkState::Closing(_)
+                            ))
                             || matches!(chunk_guard.state(), ChunkState::WrittenToObjectStore(_, _))
                         {
                             let partition_key = chunk_guard.key().to_string();


### PR DESCRIPTION
__Rationale__

The `ChunkMover` moves chunks out of the MUB into the ReadBuffer according to various policies.

On of those policies is: 

>  // Allow dropping data that has not been persisted to object storage
>  // once the database size has exceeded the configured limits
> drop_not_persisted: bool

The idea is that when the sum of all MUB chunks is bigger than:

>  // Once the total amount of buffered data in memory reaches this size start
>  // dropping data from memory based on the drop_order
 > buffer_size_soft: usize

we need to start dropping the "oldest" chunks (according to some configurable sort order) until we the size gets below the soft limit.

However, the current code refuses to drop chunks that have not yet been moved to the ReadBuffer.

The consequence of that choice is that, for some big tables, where we cannot digest data as fast as we can ingest (for whatever reason, to be solved in other PRs), we fill our memory until we reach the hard limit and then we start refusing new data.

__Proposal__

Since the ReadBuffer will drop the chunk anyway, let's not waste time in queue while we wait our turn to be compressed and then dropped on the floor later.

The idea is that, scenarios that have `drop_not_persisted = true`, will likely prefer having the most recent data anyway rather than some arbitrary "not fresh, not old" subset of the data that just happens to sit in the queue before being shredded by the ReadBuffer.