### PR TITLE
feat: move closing chunks as soon as possible

### DIFF
--- a/data_types/src/database_rules.rs
+++ b/data_types/src/database_rules.rs
@@ -181,14 +181,12 @@ pub struct LifecycleRules {
     pub mutable_linger_seconds: Option<NonZeroU32>,
 
     /// A chunk of data within a partition is guaranteed to remain mutable
-    /// for at least this number of seconds
+    /// for at least this number of seconds unless it exceeds the mutable_size_threshold
     pub mutable_minimum_age_seconds: Option<NonZeroU32>,
 
     /// Once a chunk of data within a partition reaches this number of bytes
-    /// writes outside its keyspace will be directed to a new chunk
-    ///
-    /// This chunk will be then compacted once it becomes cold for writes
-    /// based on the mutable_linger_seconds and mutable_minimum_age_seconds
+    /// writes outside its keyspace will be directed to a new chunk and this
+    /// chunk will be compacted to the read buffer as soon as possible
     pub mutable_size_threshold: Option<NonZeroUsize>,
 
     /// Once the total amount of buffered data in memory reaches this size start

--- a/generated_types/protos/influxdata/iox/management/v1/database_rules.proto
+++ b/generated_types/protos/influxdata/iox/management/v1/database_rules.proto
@@ -124,14 +124,12 @@ message LifecycleRules {
   uint32 mutable_linger_seconds = 1;
 
   // A chunk of data within a partition is guaranteed to remain mutable
-  // for at least this number of seconds
+  // for at least this number of seconds unless it exceeds the mutable_size_threshold
   uint32 mutable_minimum_age_seconds = 2;
 
   // Once a chunk of data within a partition reaches this number of bytes
-  // writes outside its keyspace will be directed to a new chunk
-  //
-  // This chunk will be then compacted once it becomes cold for writes
-  // based on the mutable_linger_seconds and mutable_minimum_age_seconds
+  // writes outside its keyspace will be directed to a new chunk and this
+  // chunk will be compacted to the read buffer as soon as possible
   uint64 mutable_size_threshold = 3;
 
   // Once the total amount of buffered data in memory reaches this size start

--- a/server/src/db/lifecycle.rs
+++ b/server/src/db/lifecycle.rs
@@ -102,11 +102,11 @@ trait ChunkMover {
 
             buffer_size += Self::chunk_size(&*chunk_guard);
 
-            let would_move = !move_active && can_move(&rules, &*chunk_guard, now);
+            let would_move = can_move(&rules, &*chunk_guard, now);
             let would_write = !write_active && rules.persist;
 
             match chunk_guard.state() {
-                ChunkState::Open(_) if would_move => {
+                ChunkState::Open(_) if !move_active && would_move => {
                     let mut chunk_guard = RwLockUpgradableReadGuard::upgrade(chunk_guard);
                     chunk_guard.set_closing().expect("cannot close open chunk");
 
@@ -119,7 +119,7 @@ trait ChunkMover {
                     move_active = true;
                     self.move_to_read_buffer(partition_key, table_name, chunk_id);
                 }
-                ChunkState::Closing(_) if would_move => {
+                ChunkState::Closing(_) if !move_active => {
                     let partition_key = chunk_guard.key().to_string();
                     let table_name = chunk_guard.table_name().to_string();
                     let chunk_id = chunk_guard.id();
@@ -729,5 +729,27 @@ mod tests {
         mover.check_for_work(from_secs(0));
 
         assert_eq!(mover.events, vec![MoverEvents::Write(1)]);
+    }
+
+    #[test]
+    fn test_moves_closing() {
+        let rules = LifecycleRules {
+            mutable_linger_seconds: Some(NonZeroU32::new(10).unwrap()),
+            mutable_minimum_age_seconds: Some(NonZeroU32::new(60).unwrap()),
+            ..Default::default()
+        };
+        let chunks = vec![new_chunk(0, Some(40), Some(40))];
+
+        let mut mover = DummyMover::new(rules, chunks);
+
+        // Initially can't move
+        mover.check_for_work(from_secs(80));
+        assert_eq!(mover.events, vec![]);
+
+        mover.chunks[0].write().set_closing().unwrap();
+
+        // As soon as closing can move
+        mover.check_for_work(from_secs(80));
+        assert_eq!(mover.events, vec![MoverEvents::Move(0)]);
     }
 }


### PR DESCRIPTION
Having chunks linger in a closing state seems to be a repeated source of confusion, and currently serves no purpose as the requisite logic is not hooked up in the write path anyway.

This PR changes the mutable_linger_seconds and mutable_minimum_age_seconds to only impact whether a chunk in the open state is considered a move candidate, any closing chunks will immediately be considered candidates, with the order determined by the sort order.

This effectively redefines the closing state to be the window of time between when a chunk exceeds the mutable size threshold and when it starts to be moved to the read buffer based on available resource (currently the heuristic for this is very basic, it just moves them one at a time)