### PR TITLE
feat: Make background task period configurable

### DIFF
--- a/generated_types/protos/influxdata/iox/management/v1/database_rules.proto
+++ b/generated_types/protos/influxdata/iox/management/v1/database_rules.proto
@@ -155,6 +155,13 @@ message LifecycleRules {
 
   // Do not allow writing new data to this database
   bool immutable = 8;
+
+  /// The background worker will evaluate whether there is work to do
+  /// at every `period` milliseconds.
+  ///
+  /// If 0, the default period is used
+  // (See data_types::database_rules::LifecycleRules::DEFAULT_BACKGROUND_WORKER_PERIOD_MILLIS)
+  uint64 background_worker_period_millis = 10;
 }
 
 message DatabaseRules {

--- a/src/commands/database.rs
+++ b/src/commands/database.rs
@@ -180,6 +180,7 @@ pub async fn command(url: String, config: Config) -> Result<()> {
                     drop_non_persisted: command.drop_non_persisted,
                     persist: command.persist,
                     immutable: command.immutable,
+                    background_worker_period_millis: Default::default(),
                 }),
 
                 // Default to hourly partitions


### PR DESCRIPTION
__Rationale__

We want to be able to explore the effects of the background worker loop period before prioritizing work on more clever loop adaptive control.