### PR TITLE
fix: emit correct number of rows in log line

### DIFF
--- a/read_buffer/src/chunk.rs
+++ b/read_buffer/src/chunk.rs
@@ -245,14 +245,16 @@ impl Chunk {
             .sum::<usize>();
 
         // This call is expensive. Complete it before locking.
+        let now = std::time::Instant::now();
         let row_group = RowGroup::from(table_data);
+        let compressing_took = now.elapsed();
         let table_name = table_name.into();
 
         let rows = row_group.rows();
         let rg_size = row_group.size();
         let compression = format!("{:.2}%", (1.0 - (rg_size as f64 / rb_size as f64)) * 100.0);
         let chunk_id = self.id();
-        info!(%rows, rb_size, rg_size, %compression, ?table_name, %chunk_id, "row group added");
+        info!(%rows, rb_size, rg_size, %compression, ?table_name, %chunk_id, ?compressing_took, "row group added");
 
         let mut chunk_data = self.chunk_data.write();
 

--- a/read_buffer/src/chunk.rs
+++ b/read_buffer/src/chunk.rs
@@ -248,7 +248,7 @@ impl Chunk {
         let row_group = RowGroup::from(table_data);
         let table_name = table_name.into();
 
-        let rows = self.rows();
+        let rows = row_group.rows();
         let rg_size = row_group.size();
         let compression = format!("{:.2}%", (rg_size as f64 / rb_size as f64) * 100.0);
         let chunk_id = self.id();

--- a/read_buffer/src/chunk.rs
+++ b/read_buffer/src/chunk.rs
@@ -250,7 +250,7 @@ impl Chunk {
 
         let rows = row_group.rows();
         let rg_size = row_group.size();
-        let compression = format!("{:.2}%", (rg_size as f64 / rb_size as f64) * 100.0);
+        let compression = format!("{:.2}%", (1.0 - (rg_size as f64 / rb_size as f64)) * 100.0);
         let chunk_id = self.id();
         info!(%rows, rb_size, rg_size, %compression, ?table_name, %chunk_id, "row group added");
 


### PR DESCRIPTION
This PR fixes the log key/value for the number of rows emitted by a log line from read buffer chunk creation.

It also changes the compression ratio so it's using the "space saving" compression definition, which would be:

 - before in MUB: 50MB;
 - after in RB: 34MB;
 - compression = `(1 - 34 / 50) * 100.0 = 32%`

The row group has been compressed by 32% and is now 68% of the size it was before. If row groups grow when compressed in the Read Buffer the compression will be negative.

Finally, the PR adds some timing information to the row group creation, which can be useful to know.