### PR TITLE
chore: fix usize 32-bit overflow

### DIFF
--- a/influxdb_tsm/src/encoders/simple8b.rs
+++ b/influxdb_tsm/src/encoders/simple8b.rs
@@ -59,7 +59,7 @@ pub fn encode(src: &[u64], dst: &mut Vec<u8>) -> Result<(), Box<dyn Error>> {
             }
 
             let max_val = 1u64 << (bit_n & 0x3f) as u64;
-            let mut val = ((idx + 2) << S8B_BIT_SIZE) as u64;
+            let mut val = ((idx as u64) + 2) << S8B_BIT_SIZE;
             for (k, in_v) in src[i..].iter().enumerate() {
                 if k < int_n {
                     if *in_v >= max_val {


### PR DESCRIPTION
This fixes an overflow error when `usize` is 32 bits. Not sure if this will actually run on a 32-bit Raspberry Pi.

```
pi@pi2:~/projects/influxdb_iox $ cargo build -j 1
   Compiling croaring-sys v0.4.6
   Compiling influxdb_tsm v0.1.0 (/home/pi/projects/influxdb_iox/influxdb_tsm)
error: this arithmetic operation will overflow
  --> influxdb_tsm/src/encoders/simple8b.rs:62:27
   |
62 |             let mut val = ((idx + 2) << S8B_BIT_SIZE) as u64;
   |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^ attempt to shift left by `60_usize`, which would overflow
   |
   = note: `#[deny(arithmetic_overflow)]` on by default
error: aborting due to previous error
error: could not compile `influxdb_tsm`
To learn more, run the command again with --verbose.
warning: build failed, waiting for other jobs to finish...
error: build failed
```

- [x] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb_iox/blob/main/README.md).
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
