### PR TITLE
fix: Validate that ClockValue is never 0

### DIFF
--- a/internal_types/benches/benchmark.rs
+++ b/internal_types/benches/benchmark.rs
@@ -29,7 +29,7 @@ fn sequenced_entry(c: &mut Criterion) {
         554
     );
 
-    let clock_value = ClockValue::new(23);
+    let clock_value = ClockValue::try_from(23).unwrap();
     let server_id = ServerId::try_from(2).unwrap();
 
     group.bench_function("new_from_entry_bytes", |b| {

--- a/mutable_buffer/benches/snapshot.rs
+++ b/mutable_buffer/benches/snapshot.rs
@@ -25,7 +25,7 @@ fn chunk(count: usize) -> Chunk {
             for write in entry.partition_writes().iter().flatten() {
                 chunk
                     .write_table_batches(
-                        ClockValue::new(0),
+                        ClockValue::try_from(5).unwrap(),
                         ServerId::try_from(1).unwrap(),
                         write.table_batches().as_slice(),
                     )

--- a/mutable_buffer/benches/write.rs
+++ b/mutable_buffer/benches/write.rs
@@ -16,7 +16,7 @@ fn write_chunk(count: usize, entries: &[Entry]) {
             for write in entry.partition_writes().iter().flatten() {
                 chunk
                     .write_table_batches(
-                        ClockValue::new(0),
+                        ClockValue::try_from(5).unwrap(),
                         ServerId::try_from(1).unwrap(),
                         write.table_batches().as_slice(),
                     )

--- a/mutable_buffer/src/chunk.rs
+++ b/mutable_buffer/src/chunk.rs
@@ -247,7 +247,7 @@ pub mod test_helpers {
 
         for w in entry.partition_writes().unwrap() {
             chunk.write_table_batches(
-                ClockValue::new(0),
+                ClockValue::try_from(5).unwrap(),
                 ServerId::try_from(1).unwrap(),
                 &w.table_batches(),
             )?;

--- a/mutable_buffer/src/table.rs
+++ b/mutable_buffer/src/table.rs
@@ -424,13 +424,14 @@ mod tests {
         let mut dictionary = Dictionary::new();
         let mut table = Table::new(dictionary.lookup_value_or_insert("foo"));
         let server_id = ServerId::try_from(1).unwrap();
+        let clock_value = ClockValue::try_from(5).unwrap();
 
         let lp = "foo,t1=asdf iv=1i,uv=1u,fv=1.0,bv=true,sv=\"hi\" 1";
         let entry = lp_to_entry(&lp);
         table
             .write_columns(
                 &mut dictionary,
-                ClockValue::new(0),
+                clock_value,
                 server_id,
                 entry
                     .partition_writes()
@@ -449,7 +450,7 @@ mod tests {
         let response = table
             .write_columns(
                 &mut dictionary,
-                ClockValue::new(0),
+                clock_value,
                 server_id,
                 entry
                     .partition_writes()
@@ -483,7 +484,7 @@ mod tests {
         let response = table
             .write_columns(
                 &mut dictionary,
-                ClockValue::new(0),
+                clock_value,
                 server_id,
                 entry
                     .partition_writes()
@@ -517,7 +518,7 @@ mod tests {
         let response = table
             .write_columns(
                 &mut dictionary,
-                ClockValue::new(0),
+                clock_value,
                 server_id,
                 entry
                     .partition_writes()
@@ -551,7 +552,7 @@ mod tests {
         let response = table
             .write_columns(
                 &mut dictionary,
-                ClockValue::new(0),
+                clock_value,
                 server_id,
                 entry
                     .partition_writes()
@@ -585,7 +586,7 @@ mod tests {
         let response = table
             .write_columns(
                 &mut dictionary,
-                ClockValue::new(0),
+                clock_value,
                 server_id,
                 entry
                     .partition_writes()
@@ -619,7 +620,7 @@ mod tests {
         let response = table
             .write_columns(
                 &mut dictionary,
-                ClockValue::new(0),
+                clock_value,
                 server_id,
                 entry
                     .partition_writes()
@@ -664,7 +665,7 @@ mod tests {
             table
                 .write_columns(
                     dictionary,
-                    ClockValue::new(0),
+                    ClockValue::try_from(5).unwrap(),
                     ServerId::try_from(1).unwrap(),
                     batch.columns(),
                 )

--- a/server/src/db/catalog.rs
+++ b/server/src/db/catalog.rs
@@ -269,12 +269,11 @@ impl SchemaProvider for Catalog {
 
 #[cfg(test)]
 mod tests {
-    use std::num::NonZeroU32;
-
     use super::*;
     use data_types::server_id::ServerId;
     use internal_types::entry::{test_helpers::lp_to_entry, ClockValue};
     use query::predicate::PredicateBuilder;
+    use std::convert::TryFrom;
     use tracker::MemRegistry;
 
     fn create_open_chunk(partition: &Arc<RwLock<Partition>>, table: &str, registry: &MemRegistry) {
@@ -285,8 +284,8 @@ mod tests {
         partition
             .create_open_chunk(
                 batch,
-                ClockValue::new(0),
-                ServerId::new(NonZeroU32::new(1).unwrap()),
+                ClockValue::try_from(5).unwrap(),
+                ServerId::try_from(1).unwrap(),
                 registry,
             )
             .unwrap();

--- a/server/src/db/lifecycle.rs
+++ b/server/src/db/lifecycle.rs
@@ -275,7 +275,10 @@ mod tests {
     use super::*;
     use data_types::server_id::ServerId;
     use internal_types::entry::{test_helpers::lp_to_entry, ClockValue};
-    use std::num::{NonZeroU32, NonZeroUsize};
+    use std::{
+        convert::TryFrom,
+        num::{NonZeroU32, NonZeroUsize},
+    };
     use tracker::MemRegistry;
 
     fn from_secs(secs: i64) -> DateTime<Utc> {
@@ -294,8 +297,8 @@ mod tests {
             batch,
             "",
             id,
-            ClockValue::new(0),
-            ServerId::new(NonZeroU32::new(1).unwrap()),
+            ClockValue::try_from(5).unwrap(),
+            ServerId::try_from(1).unwrap(),
             &MemRegistry::new(),
         )
         .unwrap();


### PR DESCRIPTION
Which is effectively the same thing as always the same in the flatbuffers, as the flatbuffers generated code will return a value of 0 if the clock value isn't present.