### PR TITLE
feat: change background worker to use backoff instead of poll (#1339)

### DIFF
--- a/data_types/src/database_rules.rs
+++ b/data_types/src/database_rules.rs
@@ -216,9 +216,9 @@ pub struct LifecycleRules {
     /// Do not allow writing new data to this database
     pub immutable: bool,
 
-    /// The background worker will evaluate whether there is work to do
-    /// at every `period` milliseconds.
-    pub background_worker_period_millis: Option<NonZeroU64>,
+    /// If the background worker doesn't find anything to do it
+    /// will sleep for this many milliseconds before looking again
+    pub worker_backoff_millis: Option<NonZeroU64>,
 }
 
 impl From<LifecycleRules> for management::LifecycleRules {
@@ -248,9 +248,7 @@ impl From<LifecycleRules> for management::LifecycleRules {
             drop_non_persisted: config.drop_non_persisted,
             persist: config.persist,
             immutable: config.immutable,
-            background_worker_period_millis: config
-                .background_worker_period_millis
-                .map_or(0, NonZeroU64::get),
+            worker_backoff_millis: config.worker_backoff_millis.map_or(0, NonZeroU64::get),
         }
     }
 }
@@ -269,7 +267,7 @@ impl TryFrom<management::LifecycleRules> for LifecycleRules {
             drop_non_persisted: proto.drop_non_persisted,
             persist: proto.persist,
             immutable: proto.immutable,
-            background_worker_period_millis: NonZeroU64::new(proto.background_worker_period_millis),
+            worker_backoff_millis: NonZeroU64::new(proto.worker_backoff_millis),
         })
     }
 }
@@ -1381,7 +1379,7 @@ mod tests {
             drop_non_persisted: true,
             persist: true,
             immutable: true,
-            background_worker_period_millis: 1000,
+            worker_backoff_millis: 1000,
         };
 
         let config: LifecycleRules = protobuf.clone().try_into().unwrap();
@@ -1421,25 +1419,19 @@ mod tests {
         assert_eq!(back.buffer_size_hard, protobuf.buffer_size_hard);
         assert_eq!(back.drop_non_persisted, protobuf.drop_non_persisted);
         assert_eq!(back.immutable, protobuf.immutable);
-        assert_eq!(
-            back.background_worker_period_millis,
-            protobuf.background_worker_period_millis
-        );
+        assert_eq!(back.worker_backoff_millis, protobuf.worker_backoff_millis);
     }
 
     #[test]
-    fn default_background_worker_period_millis() {
+    fn default_background_worker_backoff_millis() {
         let protobuf = management::LifecycleRules {
-            background_worker_period_millis: 0,
+            worker_backoff_millis: 0,
             ..Default::default()
         };
 
         let config: LifecycleRules = protobuf.clone().try_into().unwrap();
         let back: management::LifecycleRules = config.into();
-        assert_eq!(
-            back.background_worker_period_millis,
-            protobuf.background_worker_period_millis
-        );
+        assert_eq!(back.worker_backoff_millis, protobuf.worker_backoff_millis);
     }
 
     #[test]

--- a/generated_types/protos/influxdata/iox/management/v1/database_rules.proto
+++ b/generated_types/protos/influxdata/iox/management/v1/database_rules.proto
@@ -161,7 +161,7 @@ message LifecycleRules {
   //
   // If 0, the default backoff is used
   // See server::db::lifecycle::DEFAULT_LIFECYCLE_BACKOFF
-  uint64 worker_backoff_millis = 11;
+  uint64 worker_backoff_millis = 10;
 }
 
 message DatabaseRules {

--- a/generated_types/protos/influxdata/iox/management/v1/database_rules.proto
+++ b/generated_types/protos/influxdata/iox/management/v1/database_rules.proto
@@ -156,12 +156,12 @@ message LifecycleRules {
   // Do not allow writing new data to this database
   bool immutable = 8;
 
-  /// The background worker will evaluate whether there is work to do
-  /// at every `period` milliseconds.
-  ///
-  /// If 0, the default period is used
-  // (See data_types::database_rules::LifecycleRules::DEFAULT_BACKGROUND_WORKER_PERIOD_MILLIS)
-  uint64 background_worker_period_millis = 10;
+  // If the background worker doesn't find any work to do it will
+  // sleep for this many milliseconds before looking again
+  //
+  // If 0, the default backoff is used
+  // See server::db::lifecycle::DEFAULT_LIFECYCLE_BACKOFF
+  uint64 worker_backoff_millis = 10;
 }
 
 message DatabaseRules {

--- a/generated_types/protos/influxdata/iox/management/v1/database_rules.proto
+++ b/generated_types/protos/influxdata/iox/management/v1/database_rules.proto
@@ -161,7 +161,7 @@ message LifecycleRules {
   //
   // If 0, the default backoff is used
   // See server::db::lifecycle::DEFAULT_LIFECYCLE_BACKOFF
-  uint64 worker_backoff_millis = 10;
+  uint64 worker_backoff_millis = 11;
 }
 
 message DatabaseRules {

--- a/server/src/db.rs
+++ b/server/src/db.rs
@@ -15,7 +15,6 @@ use catalog::{
     Catalog,
 };
 pub(crate) use chunk::DbChunk;
-use core::num::NonZeroU64;
 use data_types::{
     chunk::ChunkSummary,
     database_rules::DatabaseRules,
@@ -197,7 +196,6 @@ pub enum Error {
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
 const STARTING_SEQUENCE: u64 = 1;
-const DEFAULT_BACKGROUND_WORKER_PERIOD_MILLIS: u64 = 1000;
 
 /// This is the main IOx Database object. It is the root object of any
 /// specific InfluxDB IOx instance
@@ -832,39 +830,12 @@ impl Db {
     ) {
         info!("started background worker");
 
-        fn make_interval(millis: Option<NonZeroU64>) -> tokio::time::Interval {
-            tokio::time::interval(tokio::time::Duration::from_millis(
-                millis.map_or(DEFAULT_BACKGROUND_WORKER_PERIOD_MILLIS, NonZeroU64::get),
-            ))
-        }
-
-        let mut period_millis = {
-            self.rules
-                .read()
-                .lifecycle_rules
-                .background_worker_period_millis
-        };
-
-        let mut interval = make_interval(period_millis);
         let mut lifecycle_manager = LifecycleManager::new(Arc::clone(&self));
 
         while !shutdown.is_cancelled() {
             self.worker_iterations.fetch_add(1, Ordering::Relaxed);
-
-            lifecycle_manager.check_for_work();
-
-            let possibly_updated_period_millis = {
-                self.rules
-                    .read()
-                    .lifecycle_rules
-                    .background_worker_period_millis
-            };
-            if period_millis != possibly_updated_period_millis {
-                period_millis = possibly_updated_period_millis;
-                interval = make_interval(period_millis);
-            }
             tokio::select! {
-                _ = interval.tick() => {},
+                _ = lifecycle_manager.check_for_work() => {},
                 _ = shutdown.cancelled() => break
             }
         }

--- a/server/src/db/lifecycle.rs
+++ b/server/src/db/lifecycle.rs
@@ -45,9 +45,7 @@ impl LifecycleManager {
     /// Should be called periodically and should spawn any long-running
     /// work onto the tokio threadpool and return
     ///
-    /// If any background work was started by this iteration it returns
-    /// a future that resolves when any of it completes. Otherwise
-    /// it returns a future that resolves when this method should be called next
+    /// Returns a future that resolves when this method should be called next
     pub fn check_for_work(&mut self) -> BoxFuture<'static, ()> {
         ChunkMover::check_for_work(self, Utc::now())
     }
@@ -91,7 +89,7 @@ trait ChunkMover {
 
     /// The core policy logic
     ///
-    /// It returns a future that resolves when this method should be called next
+    /// Returns a future that resolves when this method should be called next
     fn check_for_work(&mut self, now: DateTime<Utc>) -> BoxFuture<'static, ()> {
         let rules = self.rules();
         let chunks = self.chunks(&rules.sort_order);

--- a/src/commands/database.rs
+++ b/src/commands/database.rs
@@ -180,7 +180,7 @@ pub async fn command(url: String, config: Config) -> Result<()> {
                     drop_non_persisted: command.drop_non_persisted,
                     persist: command.persist,
                     immutable: command.immutable,
-                    background_worker_period_millis: Default::default(),
+                    worker_backoff_millis: Default::default(),
                 }),
 
                 // Default to hourly partitions

--- a/tracker/src/task.rs
+++ b/tracker/src/task.rs
@@ -189,6 +189,21 @@ impl<T> Clone for TaskTracker<T> {
 }
 
 impl<T> TaskTracker<T> {
+    /// Creates a new task tracker from the provided registration
+    pub fn new(id: TaskId, registration: &TaskRegistration, metadata: T) -> Self {
+        Self {
+            id,
+            metadata: Arc::new(metadata),
+            state: Arc::clone(&registration.state),
+        }
+    }
+
+    /// Returns a complete task tracker
+    pub fn complete(metadata: T) -> Self {
+        let registration = TaskRegistration::new();
+        Self::new(TaskId(0), &registration, metadata)
+    }
+
     /// Returns the ID of the Tracker - these are unique per TrackerRegistry
     pub fn id(&self) -> TaskId {
         self.id
@@ -288,8 +303,8 @@ impl Clone for TaskRegistration {
     }
 }
 
-impl TaskRegistration {
-    fn new() -> Self {
+impl Default for TaskRegistration {
+    fn default() -> Self {
         let state = Arc::new(TrackerState {
             start_instant: Instant::now(),
             cpu_nanos: AtomicUsize::new(0),
@@ -302,6 +317,12 @@ impl TaskRegistration {
         });
 
         Self { state }
+    }
+}
+
+impl TaskRegistration {
+    pub fn new() -> Self {
+        Self::default()
     }
 }
 

--- a/tracker/src/task/registry.rs
+++ b/tracker/src/task/registry.rs
@@ -1,7 +1,6 @@
 use super::{TaskRegistration, TaskTracker};
 use hashbrown::HashMap;
 use std::str::FromStr;
-use std::sync::Arc;
 
 /// Every future registered with a `TaskRegistry` is assigned a unique
 /// `TaskId`
@@ -52,12 +51,7 @@ impl<T> TaskRegistry<T> {
         self.next_id += 1;
 
         let registration = TaskRegistration::new();
-
-        let tracker = TaskTracker {
-            id,
-            metadata: Arc::new(metadata),
-            state: Arc::clone(&registration.state),
-        };
+        let tracker = TaskTracker::new(id, &registration, metadata);
 
         self.tasks.insert(id, tracker.clone());
 


### PR DESCRIPTION
This reformulates the lifecycle manager to instead backoff when there is nothing to do, and to immediately start looking for work when work it spawned completes. Previously it would just look at a regular poll frequency.

Formulating in terms of a backoff instead of a poll frequency should make it much less likely to need tweaking for high-throughput databases, but I've translated the configuration knob instead of removing it just in case I'm wrong about this.