### PR TITLE
feat: tests for cases when data are in both RUB and OS

### DIFF
--- a/object_store/src/disk.rs
+++ b/object_store/src/disk.rs
@@ -252,7 +252,8 @@ impl File {
         }
     }
 
-    fn path(&self, location: &FilePath) -> PathBuf {
+    /// Return full path of the given location
+    pub fn path(&self, location: &FilePath) -> PathBuf {
         let mut path = self.root.clone();
         path.push_path(location);
         path.to_raw()

--- a/parquet_file/src/chunk.rs
+++ b/parquet_file/src/chunk.rs
@@ -1,11 +1,11 @@
 use snafu::{OptionExt, ResultExt, Snafu};
-use std::collections::BTreeSet;
+use std::{collections::BTreeSet, sync::Arc};
 
 use crate::table::Table;
 use arrow_deps::datafusion::physical_plan::SendableRecordBatchStream;
 use data_types::{partition_metadata::TableSummary, timestamp::TimestampRange};
 use internal_types::{schema::Schema, selection::Selection};
-use object_store::path::Path;
+use object_store::{ObjectStore, path::Path};
 use query::predicate::Predicate;
 use tracker::{MemRegistry, MemTracker};
 
@@ -94,11 +94,12 @@ impl Chunk {
         &mut self,
         table_summary: TableSummary,
         file_location: Path,
+        store: Arc<ObjectStore>,
         schema: Schema,
         range: Option<TimestampRange>,
     ) {
         self.tables
-            .push(Table::new(table_summary, file_location, schema, range));
+            .push(Table::new(table_summary, file_location, store, schema, range));
     }
 
     /// Return true if this chunk includes the given table

--- a/parquet_file/src/chunk.rs
+++ b/parquet_file/src/chunk.rs
@@ -5,7 +5,7 @@ use crate::table::Table;
 use arrow_deps::datafusion::physical_plan::SendableRecordBatchStream;
 use data_types::{partition_metadata::TableSummary, timestamp::TimestampRange};
 use internal_types::{schema::Schema, selection::Selection};
-use object_store::{ObjectStore, path::Path};
+use object_store::{path::Path, ObjectStore};
 use query::predicate::Predicate;
 use tracker::{MemRegistry, MemTracker};
 
@@ -98,8 +98,13 @@ impl Chunk {
         schema: Schema,
         range: Option<TimestampRange>,
     ) {
-        self.tables
-            .push(Table::new(table_summary, file_location, store, schema, range));
+        self.tables.push(Table::new(
+            table_summary,
+            file_location,
+            store,
+            schema,
+            range,
+        ));
     }
 
     /// Return true if this chunk includes the given table

--- a/parquet_file/src/storage.rs
+++ b/parquet_file/src/storage.rs
@@ -5,7 +5,12 @@ use arrow_deps::{
         datatypes::{Schema, SchemaRef},
         error::Result as ArrowResult,
         record_batch::RecordBatch,
-    }, datafusion::{physical_plan::{RecordBatchStream, SendableRecordBatchStream, common::SizedRecordBatchStream, parquet::RowGroupPredicateBuilder}}, parquet::{
+    },
+    datafusion::physical_plan::{
+        common::SizedRecordBatchStream, parquet::RowGroupPredicateBuilder, RecordBatchStream,
+        SendableRecordBatchStream,
+    },
+    parquet::{
         self,
         arrow::{arrow_reader::ParquetFileArrowReader, ArrowReader, ArrowWriter},
         file::{reader::FileReader, serialized_reader::SerializedFileReader, writer::TryClone},

--- a/parquet_file/src/storage.rs
+++ b/parquet_file/src/storage.rs
@@ -308,7 +308,7 @@ impl Storage {
             &mut batches,
             limit,
         ) {
-            println!("Parquet reader terminated due to error: {:?}", e);
+            return Err(e);
         }
 
         // TODO: removed when #1082 done

--- a/parquet_file/src/storage.rs
+++ b/parquet_file/src/storage.rs
@@ -1,6 +1,7 @@
 /// This module responsible to write given data to specify object store and
 /// read them back
-use arrow_deps::{arrow::{
+use arrow_deps::{
+    arrow::{
         datatypes::{Schema, SchemaRef},
         error::Result as ArrowResult,
         record_batch::RecordBatch,
@@ -10,16 +11,17 @@ use arrow_deps::{arrow::{
         file::{reader::FileReader, serialized_reader::SerializedFileReader, writer::TryClone},
     },
 };
-use bytes::Bytes;
-use data_types::server_id::ServerId;
-use futures::{Stream, StreamExt};
 use internal_types::selection::Selection;
 use object_store::{
     path::{ObjectStorePath, Path},
-    ObjectStore, ObjectStoreApi,
+    ObjectStore, ObjectStoreApi, ObjectStoreIntegration,
 };
-use parking_lot::Mutex;
 use query::predicate::Predicate;
+
+use bytes::Bytes;
+use data_types::server_id::ServerId;
+use futures::{Stream, StreamExt};
+use parking_lot::Mutex;
 use snafu::{OptionExt, ResultExt, Snafu};
 use std::{
     fs::File,
@@ -245,9 +247,8 @@ impl Storage {
         selection: Selection<'_>,
         schema: SchemaRef,
         path: Path,
-        store: Arc<ObjectStore>
+        store: Arc<ObjectStore>,
     ) -> Result<SendableRecordBatchStream> {
-
         // The below code is based on
         // datafusion::physical_plan::parquet::ParquetExec::execute
         // Will be improved as we go
@@ -270,9 +271,8 @@ impl Storage {
         // Limit of total rows to read
         let limit: Option<usize> = None; // Todo: this should be a parameter of the function
 
-        // Todo: Convert this tokio into using thread pool Andrew has implemented
-        // recently
-        // TODO: Until this read_filter is an async, we cannot mate this mutlthread yet
+        // TODO: These commented-out code lines will either be used or deleted when #1082 done
+        // TODO: Until this read_filter is an async, we cannot make this multi-threaded yet
         //       because it returns wrong results if other thread rerun before full results are returned
         // task::spawn_blocking(move || {
         //     if let Err(e) = Self::read_file(
@@ -303,20 +303,19 @@ impl Storage {
             &mut batches,
             limit,
         ) {
-            println!("Parquet reader thread terminated due to error: {:?}", e);
+            println!("Parquet reader terminated due to error: {:?}", e);
         }
 
-        println!("Record batches from read_file: {:#?}", batches);
+        // TODO: removed when #1082 done
+        // println!("Record batches from read_file: {:#?}", batches);
 
-        //let batches = vec![Arc::new(batch)];
-        Ok(Box::pin(SizedRecordBatchStream::new(
-            schema,
-            batches,
-        )))
-
-
+        Ok(Box::pin(SizedRecordBatchStream::new(schema, batches)))
     }
 
+    // TODO notes: implemented this for #1082 but i turns out might not be able to use
+    // because needs to finish #1342 before #1082 is fully tested. Thi function will
+    // be either used or removed when #1082 is done
+    //
     // fn send_result(
     //     response_tx: &Sender<ArrowResult<RecordBatch>>,
     //     result: ArrowResult<RecordBatch>,
@@ -330,6 +329,7 @@ impl Storage {
     //     Ok(())
     // }
 
+    // TODO: see the notes for send_result above
     // fn read_file(
     //     path: Path,
     //     store: Arc<ObjectStore>,
@@ -343,7 +343,7 @@ impl Storage {
     //     // TODO: support non local file object store
     //     let (file_root, file_path) = match (&store.0, path) {
     //         (ObjectStoreIntegration::File(file), Path::File(location)) => (file, location),
-    //         (_, _) => { 
+    //         (_, _) => {
     //             panic!("Non local file object store not supported")
     //         }
     //     };
@@ -351,10 +351,10 @@ impl Storage {
     //     let full_path = format!("{:?}", file_root.path(&file_path));
     //     let full_path = full_path.trim_matches('"');
     //     println!("Full path filename: {}", full_path);
-     
+
     //     let mut total_rows = 0;
-    
-    //     let file = File::open(&full_path).context(OpenFile)?; 
+
+    //     let file = File::open(&full_path).context(OpenFile)?;
     //     let mut file_reader = SerializedFileReader::new(file).context(SerializedFileReaderError)?;
     //     if let Some(predicate_builder) = predicate_builder {
     //         let row_group_predicate =
@@ -397,39 +397,39 @@ impl Storage {
     //     Ok(())
     // }
 
-
+    /// Read the given path of the parquet file and return record batches satisfied
+    /// the given predicate_builder
     fn read_file(
         path: Path,
         store: Arc<ObjectStore>,
         projection: &[usize],
         predicate_builder: Option<&RowGroupPredicateBuilder>,
         batch_size: usize,
-        batches : &mut Vec<Arc<RecordBatch>>,
+        batches: &mut Vec<Arc<RecordBatch>>,
         limit: Option<usize>,
     ) -> Result<()> {
-
-        // TODO: support non local file object store
+        // TODO: support non local file object store. Ticket #1342
         let (file_root, file_path) = match (&store.0, path) {
             (ObjectStoreIntegration::File(file), Path::File(location)) => (file, location),
-            (_, _) => { 
+            (_, _) => {
                 panic!("Non local file object store not supported")
             }
         };
         // Get full string path
         let full_path = format!("{:?}", file_root.path(&file_path));
         let full_path = full_path.trim_matches('"');
-        println!("Full path filename: {}", full_path);
-    
+        //println!("Full path filename: {}", full_path);  // TOTO: to be removed after both #1082 and #1342 done
+
         let mut total_rows = 0;
 
-        let file = File::open(&full_path).context(OpenFile)?; 
+        let file = File::open(&full_path).context(OpenFile)?;
         let mut file_reader = SerializedFileReader::new(file).context(SerializedFileReaderError)?;
         if let Some(predicate_builder) = predicate_builder {
             let row_group_predicate =
                 predicate_builder.build_row_group_predicate(file_reader.metadata().row_groups());
             file_reader.filter_row_groups(&row_group_predicate); //filter out
-                                                                // row group based
-                                                                // on the predicate
+                                                                 // row group based
+                                                                 // on the predicate
         }
         let mut arrow_reader = ParquetFileArrowReader::new(Arc::new(file_reader));
         let mut batch_reader = arrow_reader
@@ -438,7 +438,8 @@ impl Storage {
         loop {
             match batch_reader.next() {
                 Some(Ok(batch)) => {
-                    //println!("ParquetExec got new batch from {}", filename);
+                    //println!("ParquetExec got new batch from {}", filename);  TODO: remove when #1082  done
+                    //println!("Batch value: {:#?}", batch);
                     total_rows += batch.num_rows();
                     batches.push(Arc::new(batch));
                     if limit.map(|l| total_rows >= l).unwrap_or(false) {
@@ -449,19 +450,11 @@ impl Storage {
                     break;
                 }
                 Some(Err(e)) => {
-                    let err_msg =
-                        //format!("Error reading batch from {}: {}", filename, e.to_string());
-                        format!("Error reading batch: {}", e.to_string());
-                    // terminate thread with error
                     return Err(e).context(ReadingFile);
                 }
             }
         }
 
-        println!("Record batches right after reading from file: {:#?}", batches);
-
-        // finished reading files (dropping response_tx will close
-        // channel)
         Ok(())
     }
 }

--- a/parquet_file/src/storage.rs
+++ b/parquet_file/src/storage.rs
@@ -1,19 +1,10 @@
 /// This module responsible to write given data to specify object store and
 /// read them back
-use arrow_deps::{
-    arrow::{
+use arrow_deps::{arrow::{
         datatypes::{Schema, SchemaRef},
-        error::ArrowError,
         error::Result as ArrowResult,
         record_batch::RecordBatch,
-    },
-    datafusion::{
-        error::DataFusionError,
-        physical_plan::{
-            parquet::RowGroupPredicateBuilder, RecordBatchStream, SendableRecordBatchStream,
-        },
-    },
-    parquet::{
+    }, datafusion::{physical_plan::{RecordBatchStream, SendableRecordBatchStream, common::SizedRecordBatchStream, parquet::RowGroupPredicateBuilder}}, parquet::{
         self,
         arrow::{arrow_reader::ParquetFileArrowReader, ArrowReader, ArrowWriter},
         file::{reader::FileReader, serialized_reader::SerializedFileReader, writer::TryClone},
@@ -35,10 +26,6 @@ use std::{
     io::{Cursor, Seek, SeekFrom, Write},
     sync::Arc,
     task::{Context, Poll},
-};
-use tokio::{
-    sync::mpsc::{channel, Receiver, Sender},
-    task,
 };
 use tokio_stream::wrappers::ReceiverStream;
 
@@ -257,27 +244,18 @@ impl Storage {
         predicate: &Predicate,
         selection: Selection<'_>,
         schema: SchemaRef,
-        path: &Path,
+        path: Path,
+        store: Arc<ObjectStore>
     ) -> Result<SendableRecordBatchStream> {
-        // TODO: support non local file object store
-        if !path.local_file() {
-            panic!("Non local file object store not supported")
-        }
 
         // The below code is based on
         // datafusion::physical_plan::parquet::ParquetExec::execute
         // Will be improved as we go
 
-        let (response_tx, response_rx): (
-            Sender<ArrowResult<RecordBatch>>,
-            Receiver<ArrowResult<RecordBatch>>,
-        ) = channel(2);
-
-        // Full path of the parquet file
-        // Might need different function if this display function does not show the full
-        // path
-        let filename = path.display();
-        // println!("Parquet filename: {}", filename); // TODO: remove after tests
+        // let (response_tx, response_rx): (
+        //     Sender<ArrowResult<RecordBatch>>,
+        //     Receiver<ArrowResult<RecordBatch>>,
+        // ) = channel(2);
 
         // Indices of columns in the schema needed to read
         let projection: Vec<usize> = Self::column_indices(selection, Arc::clone(&schema));
@@ -294,55 +272,164 @@ impl Storage {
 
         // Todo: Convert this tokio into using thread pool Andrew has implemented
         // recently
-        task::spawn_blocking(move || {
-            if let Err(e) = Self::read_file(
-                filename,
-                projection.as_slice(),
-                predicate_builder.as_ref(),
-                batch_size,
-                response_tx,
-                limit,
-            ) {
-                println!("Parquet reader thread terminated due to error: {:?}", e);
-            }
-        });
+        // TODO: Until this read_filter is an async, we cannot mate this mutlthread yet
+        //       because it returns wrong results if other thread rerun before full results are returned
+        // task::spawn_blocking(move || {
+        //     if let Err(e) = Self::read_file(
+        //         path,
+        //         Arc::clone(&store),
+        //         projection.as_slice(),
+        //         predicate_builder.as_ref(),
+        //         batch_size,
+        //         response_tx,
+        //         limit,
+        //     ) {
+        //         println!("Parquet reader thread terminated due to error: {:?}", e);
+        //     }
+        // });
 
-        Ok(Box::pin(ParquetStream {
+        // Ok(Box::pin(ParquetStream {
+        //     schema,
+        //     inner: ReceiverStream::new(response_rx),
+        // }))
+
+        let mut batches: Vec<Arc<RecordBatch>> = vec![];
+        if let Err(e) = Self::read_file(
+            path,
+            Arc::clone(&store),
+            projection.as_slice(),
+            predicate_builder.as_ref(),
+            batch_size,
+            &mut batches,
+            limit,
+        ) {
+            println!("Parquet reader thread terminated due to error: {:?}", e);
+        }
+
+        println!("Record batches from read_file: {:#?}", batches);
+
+        //let batches = vec![Arc::new(batch)];
+        Ok(Box::pin(SizedRecordBatchStream::new(
             schema,
-            inner: ReceiverStream::new(response_rx),
-        }))
+            batches,
+        )))
+
+
     }
 
-    fn send_result(
-        response_tx: &Sender<ArrowResult<RecordBatch>>,
-        result: ArrowResult<RecordBatch>,
-    ) -> Result<()> {
-        // Note this function is running on its own blocking tokio thread so blocking
-        // here is ok.
-        response_tx
-            .blocking_send(result)
-            .map_err(|e| DataFusionError::Execution(e.to_string()))
-            .context(SendResult)?;
-        Ok(())
-    }
+    // fn send_result(
+    //     response_tx: &Sender<ArrowResult<RecordBatch>>,
+    //     result: ArrowResult<RecordBatch>,
+    // ) -> Result<()> {
+    //     // Note this function is running on its own blocking tokio thread so blocking
+    //     // here is ok.
+    //     response_tx
+    //         .blocking_send(result)
+    //         .map_err(|e| DataFusionError::Execution(e.to_string()))
+    //         .context(SendResult)?;
+    //     Ok(())
+    // }
+
+    // fn read_file(
+    //     path: Path,
+    //     store: Arc<ObjectStore>,
+    //     projection: &[usize],
+    //     predicate_builder: Option<&RowGroupPredicateBuilder>,
+    //     batch_size: usize,
+    //     response_tx: Sender<ArrowResult<RecordBatch>>,
+    //     limit: Option<usize>,
+    // ) -> Result<()> {
+
+    //     // TODO: support non local file object store
+    //     let (file_root, file_path) = match (&store.0, path) {
+    //         (ObjectStoreIntegration::File(file), Path::File(location)) => (file, location),
+    //         (_, _) => { 
+    //             panic!("Non local file object store not supported")
+    //         }
+    //     };
+    //     // Get full string path
+    //     let full_path = format!("{:?}", file_root.path(&file_path));
+    //     let full_path = full_path.trim_matches('"');
+    //     println!("Full path filename: {}", full_path);
+     
+    //     let mut total_rows = 0;
+    
+    //     let file = File::open(&full_path).context(OpenFile)?; 
+    //     let mut file_reader = SerializedFileReader::new(file).context(SerializedFileReaderError)?;
+    //     if let Some(predicate_builder) = predicate_builder {
+    //         let row_group_predicate =
+    //             predicate_builder.build_row_group_predicate(file_reader.metadata().row_groups());
+    //         file_reader.filter_row_groups(&row_group_predicate); //filter out
+    //                                                              // row group based
+    //                                                              // on the predicate
+    //     }
+    //     let mut arrow_reader = ParquetFileArrowReader::new(Arc::new(file_reader));
+    //     let mut batch_reader = arrow_reader
+    //         .get_record_reader_by_columns(projection.to_owned(), batch_size)
+    //         .context(ParquetArrowReaderError)?;
+    //     loop {
+    //         match batch_reader.next() {
+    //             Some(Ok(batch)) => {
+    //                 //println!("ParquetExec got new batch from {}", filename);
+    //                 total_rows += batch.num_rows();
+    //                 Self::send_result(&response_tx, Ok(batch))?;
+    //                 if limit.map(|l| total_rows >= l).unwrap_or(false) {
+    //                     break;
+    //                 }
+    //             }
+    //             None => {
+    //                 break;
+    //             }
+    //             Some(Err(e)) => {
+    //                 let err_msg =
+    //                     //format!("Error reading batch from {}: {}", filename, e.to_string());
+    //                     format!("Error reading batch: {}", e.to_string());
+    //                 // send error to operator
+    //                 Self::send_result(&response_tx, Err(ArrowError::ParquetError(err_msg)))?;
+    //                 // terminate thread with error
+    //                 return Err(e).context(ReadingFile);
+    //             }
+    //         }
+    //     }
+
+    //     // finished reading files (dropping response_tx will close
+    //     // channel)
+    //     Ok(())
+    // }
+
+
     fn read_file(
-        filename: String,
+        path: Path,
+        store: Arc<ObjectStore>,
         projection: &[usize],
         predicate_builder: Option<&RowGroupPredicateBuilder>,
         batch_size: usize,
-        response_tx: Sender<ArrowResult<RecordBatch>>,
+        batches : &mut Vec<Arc<RecordBatch>>,
         limit: Option<usize>,
     ) -> Result<()> {
+
+        // TODO: support non local file object store
+        let (file_root, file_path) = match (&store.0, path) {
+            (ObjectStoreIntegration::File(file), Path::File(location)) => (file, location),
+            (_, _) => { 
+                panic!("Non local file object store not supported")
+            }
+        };
+        // Get full string path
+        let full_path = format!("{:?}", file_root.path(&file_path));
+        let full_path = full_path.trim_matches('"');
+        println!("Full path filename: {}", full_path);
+    
         let mut total_rows = 0;
 
-        let file = File::open(&filename).context(OpenFile)?;
+        let file = File::open(&full_path).context(OpenFile)?; 
         let mut file_reader = SerializedFileReader::new(file).context(SerializedFileReaderError)?;
         if let Some(predicate_builder) = predicate_builder {
             let row_group_predicate =
                 predicate_builder.build_row_group_predicate(file_reader.metadata().row_groups());
             file_reader.filter_row_groups(&row_group_predicate); //filter out
-                                                                 // row group based
-                                                                 // on the predicate
+                                                                // row group based
+                                                                // on the predicate
         }
         let mut arrow_reader = ParquetFileArrowReader::new(Arc::new(file_reader));
         let mut batch_reader = arrow_reader
@@ -353,7 +440,7 @@ impl Storage {
                 Some(Ok(batch)) => {
                     //println!("ParquetExec got new batch from {}", filename);
                     total_rows += batch.num_rows();
-                    Self::send_result(&response_tx, Ok(batch))?;
+                    batches.push(Arc::new(batch));
                     if limit.map(|l| total_rows >= l).unwrap_or(false) {
                         break;
                     }
@@ -363,14 +450,15 @@ impl Storage {
                 }
                 Some(Err(e)) => {
                     let err_msg =
-                        format!("Error reading batch from {}: {}", filename, e.to_string());
-                    // send error to operator
-                    Self::send_result(&response_tx, Err(ArrowError::ParquetError(err_msg)))?;
+                        //format!("Error reading batch from {}: {}", filename, e.to_string());
+                        format!("Error reading batch: {}", e.to_string());
                     // terminate thread with error
                     return Err(e).context(ReadingFile);
                 }
             }
         }
+
+        println!("Record batches right after reading from file: {:#?}", batches);
 
         // finished reading files (dropping response_tx will close
         // channel)

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -35,6 +35,7 @@ serde = "1.0"
 serde_json = "1.0"
 snafu = "0.6"
 snap = "1.0.0"
+tempfile = "3.1.0"
 tokio = { version = "1.0", features = ["macros", "time"] }
 tokio-util = { version = "0.6.3" }
 tracker = { path = "../tracker" }
@@ -43,7 +44,6 @@ uuid = { version = "0.8", features = ["serde", "v4"] }
 [dev-dependencies] # In alphabetical order
 criterion = { version = "0.3.4", features = ["async_tokio"] }
 flate2 = "1.0.20"
-tempfile = "3.1.0"
 test_helpers = { path = "../test_helpers" }
 
 [features]

--- a/server/src/db.rs
+++ b/server/src/db.rs
@@ -684,7 +684,7 @@ impl Db {
                 .try_into()
                 .context(SchemaConversion)?;
             let table_time_range = time_range.map(|(start, end)| TimestampRange::new(start, end));
-            parquet_chunk.add_table(stats, path, schema, table_time_range);
+            parquet_chunk.add_table(stats, path, Arc::clone(&self.store), schema, table_time_range);
         }
 
         // Relock the chunk again (nothing else should have been able
@@ -703,7 +703,7 @@ impl Db {
         self.metrics.update_chunk_state(chunk.state());
         debug!(%partition_key, %table_name, %chunk_id, "chunk marked MOVED. Persisting to object store complete");
 
-        Ok(DbChunk::snapshot(&chunk))
+        Ok(DbChunk::parquet_file_snapshot(&chunk))
     }
 
     /// Spawns a task to perform
@@ -1819,6 +1819,10 @@ mod tests {
             .await
             .unwrap();
 
+        db.write_chunk_to_object_store("1970-01-01T00", "cpu", 0)
+            .await
+            .unwrap();
+
         print!("Partitions2: {:?}", db.partition_keys().unwrap());
 
         db.rollover_partition("1970-01-05T15", "cpu").await.unwrap();
@@ -1836,8 +1840,8 @@ mod tests {
                 to_arc("1970-01-01T00"),
                 to_arc("cpu"),
                 0,
-                ChunkStorage::ReadBuffer,
-                1213,
+                ChunkStorage::ReadBufferAndObjectStore,
+                1213 + 675, // size of RB and OB chunks
             ),
             ChunkSummary::new_without_timestamps(
                 to_arc("1970-01-01T00"),
@@ -1870,6 +1874,7 @@ mod tests {
 
         assert_eq!(db.memory_registries.mutable_buffer.bytes(), 100 + 129 + 131);
         assert_eq!(db.memory_registries.read_buffer.bytes(), 1213);
+        assert_eq!(db.memory_registries.parquet.bytes(), 89);  // TODO: This 89 must be replaced with 675. Ticket #1311
     }
 
     #[tokio::test]
@@ -1889,6 +1894,11 @@ mod tests {
 
         // load a chunk to the read buffer
         db.load_chunk_to_read_buffer("1970-01-01T00", "cpu", chunk_id)
+            .await
+            .unwrap();
+
+        // write the read buffer chunk to object store
+        db.write_chunk_to_object_store("1970-01-01T00", "cpu", chunk_id)
             .await
             .unwrap();
 

--- a/server/src/db/catalog/chunk.rs
+++ b/server/src/db/catalog/chunk.rs
@@ -41,6 +41,8 @@ pub enum ChunkState {
 
     // Chunk has been completely written into object store
     WrittenToObjectStore(Arc<ReadBufferChunk>, Arc<ParquetChunk>),
+
+    // Todo : There must be another state for chunk that only in object store
 }
 
 impl ChunkState {
@@ -215,8 +217,8 @@ impl Chunk {
             ChunkState::WritingToObjectStore(chunk) => {
                 (chunk.size(), ChunkStorage::ReadBufferAndObjectStore)
             }
-            ChunkState::WrittenToObjectStore(chunk, _) => {
-                (chunk.size(), ChunkStorage::ReadBufferAndObjectStore)
+            ChunkState::WrittenToObjectStore(chunk, parquet_chunk) => {
+                (chunk.size() + parquet_chunk.size(), ChunkStorage::ReadBufferAndObjectStore)
             }
         };
 

--- a/server/src/db/catalog/chunk.rs
+++ b/server/src/db/catalog/chunk.rs
@@ -41,8 +41,8 @@ pub enum ChunkState {
 
     // Chunk has been completely written into object store
     WrittenToObjectStore(Arc<ReadBufferChunk>, Arc<ParquetChunk>),
-
     // Todo : There must be another state for chunk that only in object store
+    // ticket #1314
 }
 
 impl ChunkState {
@@ -217,9 +217,10 @@ impl Chunk {
             ChunkState::WritingToObjectStore(chunk) => {
                 (chunk.size(), ChunkStorage::ReadBufferAndObjectStore)
             }
-            ChunkState::WrittenToObjectStore(chunk, parquet_chunk) => {
-                (chunk.size() + parquet_chunk.size(), ChunkStorage::ReadBufferAndObjectStore)
-            }
+            ChunkState::WrittenToObjectStore(chunk, parquet_chunk) => (
+                chunk.size() + parquet_chunk.size(),
+                ChunkStorage::ReadBufferAndObjectStore,
+            ),
         };
 
         ChunkSummary {

--- a/server/src/db/chunk.rs
+++ b/server/src/db/chunk.rs
@@ -111,10 +111,10 @@ impl DbChunk {
                 chunk: Arc::clone(chunk),
                 partition_key,
                 // Since data exists in both read buffer and object store, we should
-                // return chunk of read buffer
+                // snapshot the chunk of read buffer
             },
-            // Todo: When we have a state for parquet_file chunk only,
-            // ChunkState::InObjectStoreOnly(chunk) => {  
+            // Todo: Turn this on When we have this state
+            // ChunkState::ObjectStoreOnly(chunk) => {
             //     let chunk = Arc::clone(chunk);
             //     Self::ParquetFile { chunk }
             // }
@@ -122,6 +122,11 @@ impl DbChunk {
         Arc::new(db_chunk)
     }
 
+    /// Return the snapshot of the chunk with type ParquetFile
+    /// This function should be only invoked when you know your chunk
+    /// is ParquetFile type whose state is  WrittenToObjectStore. The
+    /// reason we have this function is because the above snapshot
+    /// function always returns the read buffer one for the same state
     pub fn parquet_file_snapshot(chunk: &super::catalog::chunk::Chunk) -> Arc<Self> {
         use super::catalog::chunk::ChunkState;
 
@@ -129,9 +134,9 @@ impl DbChunk {
             ChunkState::WrittenToObjectStore(_, chunk) => {
                 let chunk = Arc::clone(chunk);
                 Self::ParquetFile { chunk }
-            },
+            }
             _ => {
-                panic!("This is not state of a parquet_fil chunk");
+                panic!("Internal error: This chunk's state is not WrittenToObjectStore");
             }
         };
         Arc::new(db_chunk)

--- a/server/src/query_tests/influxrpc/field_columns.rs
+++ b/server/src/query_tests/influxrpc/field_columns.rs
@@ -115,7 +115,7 @@ async fn test_field_columns_with_ts_pred() {
 }
 
 #[tokio::test]
-async fn test_field_name_plan() {
+async fn test_field_name_plan() {  // TODO: Test fails
     test_helpers::maybe_start_logging();
     // Tests that the ordering that comes out is reasonable
     let scenarios = OneMeasurementManyFields {}.make().await;

--- a/server/src/query_tests/influxrpc/field_columns.rs
+++ b/server/src/query_tests/influxrpc/field_columns.rs
@@ -115,7 +115,7 @@ async fn test_field_columns_with_ts_pred() {
 }
 
 #[tokio::test]
-async fn test_field_name_plan() {  // TODO: Test fails
+async fn test_field_name_plan() {
     test_helpers::maybe_start_logging();
     // Tests that the ordering that comes out is reasonable
     let scenarios = OneMeasurementManyFields {}.make().await;

--- a/server/src/query_tests/influxrpc/read_window_aggregate.rs
+++ b/server/src/query_tests/influxrpc/read_window_aggregate.rs
@@ -184,6 +184,7 @@ impl DbSetup for MeasurementForWindowAggregateMonths {
         let db = make_db().db;
         let data = lp_lines.join("\n");
         write_lp(&db, &data);
+        // roll over and load chunks into both RUB and OS
         rollover_and_load(&db, "2020-03-01T00", "h2o").await;
         rollover_and_load(&db, "2020-03-02T00", "h2o").await;
         rollover_and_load(&db, "2020-04-01T00", "h2o").await;
@@ -193,7 +194,7 @@ impl DbSetup for MeasurementForWindowAggregateMonths {
             db,
         };
 
-        // TODO: Add 2 more scenarios: one for RUB and one for RUB+OS
+        // TODO: Add a scenario for OS only in #1342
 
         vec![scenario1, scenario2, scenario3]
     }

--- a/server/src/query_tests/influxrpc/read_window_aggregate.rs
+++ b/server/src/query_tests/influxrpc/read_window_aggregate.rs
@@ -193,6 +193,8 @@ impl DbSetup for MeasurementForWindowAggregateMonths {
             db,
         };
 
+        // TODO: Add 2 more scenarios: one for RUB and one for RUB+OS
+
         vec![scenario1, scenario2, scenario3]
     }
 }

--- a/server/src/query_tests/scenarios.rs
+++ b/server/src/query_tests/scenarios.rs
@@ -68,7 +68,7 @@ impl DbSetup for NoData {
                 .id(),
             0
         );
-        assert_eq!(count_mutable_buffer_chunks(&db), 2); // 2 chunks open and closed
+        assert_eq!(count_mutable_buffer_chunks(&db), 1); // 
         assert_eq!(count_read_buffer_chunks(&db), 0); // nothing yet
         assert_eq!(count_object_store_chunks(&db), 0); // nothing yet
 
@@ -76,14 +76,14 @@ impl DbSetup for NoData {
         db.load_chunk_to_read_buffer(partition_key, table_name, 0)
             .await
             .unwrap();
-        assert_eq!(count_mutable_buffer_chunks(&db), 1); // open chunk only
+        assert_eq!(count_mutable_buffer_chunks(&db), 0); // open chunk only
         assert_eq!(count_read_buffer_chunks(&db), 1); // close chunk only
         assert_eq!(count_object_store_chunks(&db), 0); // nothing yet
 
         // drop chunk 0
         db.drop_chunk(partition_key, table_name, 0).unwrap();
 
-        assert_eq!(count_mutable_buffer_chunks(&db), 1); // open chunk only
+        assert_eq!(count_mutable_buffer_chunks(&db), 0); // open chunk only
         assert_eq!(count_read_buffer_chunks(&db), 0); // nothing after dropping chunk 0
         assert_eq!(count_object_store_chunks(&db), 0); // still nothing
 
@@ -106,7 +106,7 @@ impl DbSetup for NoData {
                 .id(),
             0
         );
-        assert_eq!(count_mutable_buffer_chunks(&db), 2); // 2 chunks open and closed
+        assert_eq!(count_mutable_buffer_chunks(&db), 1); // 1 open chunk
         assert_eq!(count_read_buffer_chunks(&db), 0); // nothing yet
         assert_eq!(count_object_store_chunks(&db), 0); // nothing yet
 
@@ -114,7 +114,7 @@ impl DbSetup for NoData {
         db.load_chunk_to_read_buffer(partition_key, table_name, 0)
             .await
             .unwrap();
-        assert_eq!(count_mutable_buffer_chunks(&db), 1); // open chunk only
+        assert_eq!(count_mutable_buffer_chunks(&db), 0); // open chunk only
         assert_eq!(count_read_buffer_chunks(&db), 1); // close chunk only
         assert_eq!(count_object_store_chunks(&db), 0); // nothing yet
 
@@ -123,7 +123,7 @@ impl DbSetup for NoData {
             .await
             .unwrap();
         // it should be the same chunk!
-        assert_eq!(count_mutable_buffer_chunks(&db), 1); // open chunk only
+        assert_eq!(count_mutable_buffer_chunks(&db), 0); // open chunk only
         assert_eq!(count_read_buffer_chunks(&db), 1); // closed chunk only
         assert_eq!(count_object_store_chunks(&db), 1); // close chunk only
 
@@ -522,7 +522,7 @@ pub async fn make_two_chunk_scenarios(
             .await
             .unwrap();
     }
-    write_lp(&db, data2);
+    let table_names = write_lp(&db, data2);
     for table_name in &table_names {
         db.rollover_partition(partition_key, &table_name)
             .await

--- a/server/src/query_tests/scenarios.rs
+++ b/server/src/query_tests/scenarios.rs
@@ -68,7 +68,7 @@ impl DbSetup for NoData {
                 .id(),
             0
         );
-        assert_eq!(count_mutable_buffer_chunks(&db), 1); // 
+        assert_eq!(count_mutable_buffer_chunks(&db), 1); //
         assert_eq!(count_read_buffer_chunks(&db), 0); // nothing yet
         assert_eq!(count_object_store_chunks(&db), 0); // nothing yet
 

--- a/server/src/query_tests/scenarios.rs
+++ b/server/src/query_tests/scenarios.rs
@@ -7,7 +7,9 @@ use async_trait::async_trait;
 
 use crate::{db::test_helpers::write_lp, Db};
 
-use super::utils::{count_mutable_buffer_chunks, count_read_buffer_chunks, count_object_store_chunks, make_db};
+use super::utils::{
+    count_mutable_buffer_chunks, count_object_store_chunks, count_read_buffer_chunks, make_db,
+};
 
 /// Holds a database and a description of how its data was configured
 #[derive(Debug)]
@@ -46,7 +48,7 @@ impl DbSetup for NoData {
         let db = make_db().db;
         assert_eq!(count_mutable_buffer_chunks(&db), 0);
         assert_eq!(count_read_buffer_chunks(&db), 0);
-        assert_eq!(count_object_store_chunks(&db), 0); 
+        assert_eq!(count_object_store_chunks(&db), 0);
         let scenario2 = DbScenario {
             scenario_name: "New, Empty Database after partitions are listed".into(),
             db,
@@ -81,7 +83,7 @@ impl DbSetup for NoData {
         // drop chunk 0
         db.drop_chunk(partition_key, table_name, 0).unwrap();
 
-        assert_eq!(count_mutable_buffer_chunks(&db), 1);  // open chunk only
+        assert_eq!(count_mutable_buffer_chunks(&db), 1); // open chunk only
         assert_eq!(count_read_buffer_chunks(&db), 0); // nothing after dropping chunk 0
         assert_eq!(count_object_store_chunks(&db), 0); // still nothing
 
@@ -99,6 +101,7 @@ impl DbSetup for NoData {
         assert_eq!(
             db.rollover_partition(partition_key, table_name)
                 .await
+                .unwrap()
                 .unwrap()
                 .id(),
             0
@@ -120,7 +123,7 @@ impl DbSetup for NoData {
             .await
             .unwrap();
         // it should be the same chunk!
-        assert_eq!(count_mutable_buffer_chunks(&db), 1);  // open chunk only
+        assert_eq!(count_mutable_buffer_chunks(&db), 1); // open chunk only
         assert_eq!(count_read_buffer_chunks(&db), 1); // closed chunk only
         assert_eq!(count_object_store_chunks(&db), 1); // close chunk only
 
@@ -129,7 +132,7 @@ impl DbSetup for NoData {
 
         assert_eq!(count_mutable_buffer_chunks(&db), 0);
         assert_eq!(count_read_buffer_chunks(&db), 0);
-        assert_eq!(count_object_store_chunks(&db), 0); 
+        assert_eq!(count_object_store_chunks(&db), 0);
 
         let scenario4 = DbScenario {
             scenario_name: "Empty Database after drop chunk".into(),
@@ -429,6 +432,7 @@ pub(crate) async fn make_one_chunk_scenarios(partition_key: &str, data: &str) ->
     };
 
     // TODO: Add scenario 5 where data is in object store only
+    // go with #1342
 
     vec![scenario1, scenario2, scenario3, scenario4]
 }
@@ -548,12 +552,15 @@ pub async fn make_two_chunk_scenarios(
     vec![scenario1, scenario2, scenario3, scenario4, scenario5]
 }
 
-/// Rollover the mutable buffer and load chunk 0 to the read bufer
+/// Rollover the mutable buffer and load chunk 0 to the read buffer and object store
 pub async fn rollover_and_load(db: &Db, partition_key: &str, table_name: &str) {
     db.rollover_partition(partition_key, table_name)
         .await
         .unwrap();
     db.load_chunk_to_read_buffer(partition_key, table_name, 0)
+        .await
+        .unwrap();
+    db.write_chunk_to_object_store(partition_key, table_name, 0)
         .await
         .unwrap();
 }

--- a/server/src/query_tests/scenarios.rs
+++ b/server/src/query_tests/scenarios.rs
@@ -5,9 +5,9 @@ use query::PartitionChunk;
 
 use async_trait::async_trait;
 
-use crate::db::{test_helpers::write_lp, Db};
+use crate::{db::test_helpers::write_lp, Db};
 
-use super::utils::{count_mutable_buffer_chunks, count_read_buffer_chunks, make_db};
+use super::utils::{count_mutable_buffer_chunks, count_read_buffer_chunks, count_object_store_chunks, make_db};
 
 /// Holds a database and a description of how its data was configured
 #[derive(Debug)]
@@ -31,24 +31,29 @@ impl DbSetup for NoData {
     async fn make(&self) -> Vec<DbScenario> {
         let partition_key = "1970-01-01T00";
         let table_name = "cpu";
+
+        // Scenario 1: No data in the DB yet
+        //
         let db = make_db().db;
         let scenario1 = DbScenario {
             scenario_name: "New, Empty Database".into(),
             db,
         };
 
-        // listing partitions (which may create an entry in a map)
+        // Scenario 2: listing partitions (which may create an entry in a map)
         // in an empty database
+        //
         let db = make_db().db;
         assert_eq!(count_mutable_buffer_chunks(&db), 0);
         assert_eq!(count_read_buffer_chunks(&db), 0);
+        assert_eq!(count_object_store_chunks(&db), 0); 
         let scenario2 = DbScenario {
             scenario_name: "New, Empty Database after partitions are listed".into(),
             db,
         };
 
-        // a scenario where the database has had data loaded and then deleted
-
+        // Scenario 3: the database has had data loaded into RB and then deleted
+        //
         let db = make_db().db;
         let data = "cpu,region=west user=23.2 100";
         write_lp(&db, data);
@@ -61,28 +66,77 @@ impl DbSetup for NoData {
                 .id(),
             0
         );
+        assert_eq!(count_mutable_buffer_chunks(&db), 2); // 2 chunks open and closed
+        assert_eq!(count_read_buffer_chunks(&db), 0); // nothing yet
+        assert_eq!(count_object_store_chunks(&db), 0); // nothing yet
 
-        assert_eq!(count_mutable_buffer_chunks(&db), 1);
-        assert_eq!(count_read_buffer_chunks(&db), 0); // only open chunk
-
+        // Now load the closed chunk into the RB
         db.load_chunk_to_read_buffer(partition_key, table_name, 0)
             .await
             .unwrap();
+        assert_eq!(count_mutable_buffer_chunks(&db), 1); // open chunk only
+        assert_eq!(count_read_buffer_chunks(&db), 1); // close chunk only
+        assert_eq!(count_object_store_chunks(&db), 0); // nothing yet
 
-        assert_eq!(count_mutable_buffer_chunks(&db), 0);
-        assert_eq!(count_read_buffer_chunks(&db), 1); // only open chunk
-
+        // drop chunk 0
         db.drop_chunk(partition_key, table_name, 0).unwrap();
 
-        assert_eq!(count_mutable_buffer_chunks(&db), 0);
-        assert_eq!(count_read_buffer_chunks(&db), 0);
+        assert_eq!(count_mutable_buffer_chunks(&db), 1);  // open chunk only
+        assert_eq!(count_read_buffer_chunks(&db), 0); // nothing after dropping chunk 0
+        assert_eq!(count_object_store_chunks(&db), 0); // still nothing
 
         let scenario3 = DbScenario {
             scenario_name: "Empty Database after drop chunk".into(),
             db,
         };
 
-        vec![scenario1, scenario2, scenario3]
+        // Scenario 4: the database has had data loaded into RB & Object Store and then deleted
+        //
+        let db = make_db().db;
+        let data = "cpu,region=west user=23.2 100";
+        write_lp(&db, data);
+        // move data out of open chunk
+        assert_eq!(
+            db.rollover_partition(partition_key, table_name)
+                .await
+                .unwrap()
+                .id(),
+            0
+        );
+        assert_eq!(count_mutable_buffer_chunks(&db), 2); // 2 chunks open and closed
+        assert_eq!(count_read_buffer_chunks(&db), 0); // nothing yet
+        assert_eq!(count_object_store_chunks(&db), 0); // nothing yet
+
+        // Now load the closed chunk into the RB
+        db.load_chunk_to_read_buffer(partition_key, table_name, 0)
+            .await
+            .unwrap();
+        assert_eq!(count_mutable_buffer_chunks(&db), 1); // open chunk only
+        assert_eq!(count_read_buffer_chunks(&db), 1); // close chunk only
+        assert_eq!(count_object_store_chunks(&db), 0); // nothing yet
+
+        // Now write the data in RB to object store but keep it in RB
+        db.write_chunk_to_object_store(partition_key, "cpu", 0)
+            .await
+            .unwrap();
+        // it should be the same chunk!
+        assert_eq!(count_mutable_buffer_chunks(&db), 1);  // open chunk only
+        assert_eq!(count_read_buffer_chunks(&db), 1); // closed chunk only
+        assert_eq!(count_object_store_chunks(&db), 1); // close chunk only
+
+        // drop chunk 0
+        db.drop_chunk(partition_key, table_name, 0).unwrap();
+
+        assert_eq!(count_mutable_buffer_chunks(&db), 0);
+        assert_eq!(count_read_buffer_chunks(&db), 0);
+        assert_eq!(count_object_store_chunks(&db), 0); 
+
+        let scenario4 = DbScenario {
+            scenario_name: "Empty Database after drop chunk".into(),
+            db,
+        };
+
+        vec![scenario1, scenario2, scenario3, scenario4]
     }
 }
 
@@ -356,7 +410,27 @@ pub(crate) async fn make_one_chunk_scenarios(partition_key: &str, data: &str) ->
         db,
     };
 
-    vec![scenario1, scenario2, scenario3]
+    let db = make_db().db;
+    let table_names = write_lp(&db, data);
+    for table_name in &table_names {
+        db.rollover_partition(partition_key, &table_name)
+            .await
+            .unwrap();
+        db.load_chunk_to_read_buffer(partition_key, &table_name, 0)
+            .await
+            .unwrap();
+        db.write_chunk_to_object_store(partition_key, &table_name, 0)
+            .await
+            .unwrap();
+    }
+    let scenario4 = DbScenario {
+        scenario_name: "Data in both read buffer and object store".into(),
+        db,
+    };
+
+    // TODO: Add scenario 5 where data is in object store only
+
+    vec![scenario1, scenario2, scenario3, scenario4]
 }
 
 /// This function loads two chunks of lp data into 4 different scenarios
@@ -436,7 +510,42 @@ pub async fn make_two_chunk_scenarios(
         db,
     };
 
-    vec![scenario1, scenario2, scenario3, scenario4]
+    // in 2 read buffer chunks that also loaded into object store
+    let db = make_db().db;
+    let table_names = write_lp(&db, data1);
+    for table_name in &table_names {
+        db.rollover_partition(partition_key, &table_name)
+            .await
+            .unwrap();
+    }
+    write_lp(&db, data2);
+    for table_name in &table_names {
+        db.rollover_partition(partition_key, &table_name)
+            .await
+            .unwrap();
+
+        db.load_chunk_to_read_buffer(partition_key, &table_name, 0)
+            .await
+            .unwrap();
+
+        db.load_chunk_to_read_buffer(partition_key, &table_name, 1)
+            .await
+            .unwrap();
+
+        db.write_chunk_to_object_store(partition_key, &table_name, 0)
+            .await
+            .unwrap();
+
+        db.write_chunk_to_object_store(partition_key, &table_name, 1)
+            .await
+            .unwrap();
+    }
+    let scenario5 = DbScenario {
+        scenario_name: "Data in two read buffer chunks and two parquet file chunks".into(),
+        db,
+    };
+
+    vec![scenario1, scenario2, scenario3, scenario4, scenario5]
 }
 
 /// Rollover the mutable buffer and load chunk 0 to the read bufer

--- a/server/src/query_tests/scenarios.rs
+++ b/server/src/query_tests/scenarios.rs
@@ -88,7 +88,7 @@ impl DbSetup for NoData {
         assert_eq!(count_object_store_chunks(&db), 0); // still nothing
 
         let scenario3 = DbScenario {
-            scenario_name: "Empty Database after drop chunk".into(),
+            scenario_name: "Empty Database after drop chunk that is in read buffer".into(),
             db,
         };
 
@@ -135,7 +135,9 @@ impl DbSetup for NoData {
         assert_eq!(count_object_store_chunks(&db), 0);
 
         let scenario4 = DbScenario {
-            scenario_name: "Empty Database after drop chunk".into(),
+            scenario_name:
+                "Empty Database after drop chunk that is in both read buffer and object store"
+                    .into(),
             db,
         };
 

--- a/server/src/query_tests/utils.rs
+++ b/server/src/query_tests/utils.rs
@@ -8,7 +8,7 @@ use object_store::{disk::File, ObjectStore};
 use query::{exec::Executor, Database};
 
 use crate::{db::Db, JobRegistry};
-use std::{convert::TryFrom, num::NonZeroU32, sync::Arc};
+use std::{convert::TryFrom, sync::Arc};
 use tempfile::TempDir;
 
 // A wrapper around a Db and a metrics registry allowing for isolated testing
@@ -23,8 +23,9 @@ pub struct TestDb {
 pub fn make_db() -> TestDb {
     let server_id = ServerId::try_from(1).unwrap();
     // TODO: When we support parquet file in memory, we will either turn this test back to memory
-    // or have both tests local disk and memory
+    // or have both tests: local disk and memory
     //let object_store = Arc::new(ObjectStore::new_in_memory(InMemory::new()));
+    //
     // Create an object store with a specified location in a local disk
     let root = TempDir::new().unwrap();
     let object_store = Arc::new(ObjectStore::new_file(File::new(root.path())));
@@ -79,19 +80,19 @@ pub fn count_mutable_buffer_chunks(db: &Db) -> usize {
 /// Returns the number of read buffer chunks in the specified database
 pub fn count_read_buffer_chunks(db: &Db) -> usize {
     chunk_summary_iter(db)
-        .filter(|s| 
-            s.storage == ChunkStorage::ReadBuffer ||
-            s.storage == ChunkStorage::ReadBufferAndObjectStore
-        )
+        .filter(|s| {
+            s.storage == ChunkStorage::ReadBuffer
+                || s.storage == ChunkStorage::ReadBufferAndObjectStore
+        })
         .count()
 }
 
 /// Returns the number of object store chunks in the specified database
 pub fn count_object_store_chunks(db: &Db) -> usize {
     chunk_summary_iter(db)
-        .filter(|s| 
-            s.storage == ChunkStorage::ReadBufferAndObjectStore ||
-            s.storage == ChunkStorage::ObjectStoreOnly
-        )
+        .filter(|s| {
+            s.storage == ChunkStorage::ReadBufferAndObjectStore
+                || s.storage == ChunkStorage::ObjectStoreOnly
+        })
         .count()
 }

--- a/server/src/query_tests/utils.rs
+++ b/server/src/query_tests/utils.rs
@@ -4,11 +4,12 @@ use data_types::{
     server_id::ServerId,
     DatabaseName,
 };
-use object_store::{memory::InMemory, ObjectStore};
+use object_store::{disk::File, ObjectStore};
 use query::{exec::Executor, Database};
 
 use crate::{db::Db, JobRegistry};
-use std::{convert::TryFrom, sync::Arc};
+use std::{convert::TryFrom, num::NonZeroU32, sync::Arc};
+use tempfile::TempDir;
 
 // A wrapper around a Db and a metrics registry allowing for isolated testing
 // of a Db and its metrics.
@@ -21,7 +22,12 @@ pub struct TestDb {
 /// Used for testing: create a Database with a local store
 pub fn make_db() -> TestDb {
     let server_id = ServerId::try_from(1).unwrap();
-    let object_store = Arc::new(ObjectStore::new_in_memory(InMemory::new()));
+    // TODO: When we support parquet file in memory, we will either turn this test back to memory
+    // or have both tests local disk and memory
+    //let object_store = Arc::new(ObjectStore::new_in_memory(InMemory::new()));
+    // Create an object store with a specified location in a local disk
+    let root = TempDir::new().unwrap();
+    let object_store = Arc::new(ObjectStore::new_file(File::new(root.path())));
     let exec = Arc::new(Executor::new(1));
     let metrics_registry = Arc::new(metrics::MetricRegistry::new());
 
@@ -73,6 +79,19 @@ pub fn count_mutable_buffer_chunks(db: &Db) -> usize {
 /// Returns the number of read buffer chunks in the specified database
 pub fn count_read_buffer_chunks(db: &Db) -> usize {
     chunk_summary_iter(db)
-        .filter(|s| s.storage == ChunkStorage::ReadBuffer)
+        .filter(|s| 
+            s.storage == ChunkStorage::ReadBuffer ||
+            s.storage == ChunkStorage::ReadBufferAndObjectStore
+        )
+        .count()
+}
+
+/// Returns the number of object store chunks in the specified database
+pub fn count_object_store_chunks(db: &Db) -> usize {
+    chunk_summary_iter(db)
+        .filter(|s| 
+            s.storage == ChunkStorage::ReadBufferAndObjectStore ||
+            s.storage == ChunkStorage::ObjectStoreOnly
+        )
         .count()
 }


### PR DESCRIPTION
Closes #1333 

These are tests and related bug fixes for cases when data is in both RUB and OS. This PR will serve both #1333 and a part of #1082.

# Changes:
  . Added more scenarios in which data is in both RUB and OS that are automatically included in almost all tests under server/query_tests
  . Fixed a bug that always snapshot a RUB chunk if they are both in RUB and OS
  . Fixed a few other related bugs that return correct results if we read data in OS. Note that since we always read from RUB in this PR,  we do not expose read data from parquet files which will be done next.


- [x] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb_iox/blob/main/README.md).
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
