### PR TITLE
feat: Add `OBSERVER` mode to SQL repl along with SQL primer / cookbook

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -25,3 +25,4 @@ We hold monthly Tech Talks that explain the project's technical underpinnings. Y
 * [Regenerating Flatbuffers code](regenerating_flatbuffers.md) when updating the version of the `flatbuffers` crate
 * Protobuf tips and tricks: [Protobuf](protobuf.md).
 * Catalog Persistence: [`catalog_persistence.md`](catalog_persistence.md).
+* SQL Repl tips and tricks: [SQL](sql.md).

--- a/docs/sql.md
+++ b/docs/sql.md
@@ -1,0 +1,214 @@
+# InfluxDB SQL Repl Tips and Tricks
+
+InfluxDB IOx contains a built in SQL client you can use to interact with the server using SQL
+
+## Quick Start
+
+```shell
+influxdb_iox --host http://localhost:8082  sql
+
+Connected to IOx Server at http://localhost:8082
+Ready for commands. (Hint: try 'help;')
+>
+
+```
+
+## Remote Mode
+In this mode queries are run on the remote server in the context of a database. To use this mode, specify a database and then run queries as normal
+
+```
+> show databases;
++-----------------------------------+
+| db_name                           |
++-----------------------------------+
+| 084d710ebdd819a5_apps             |
+| 7f4b06e9112d7bc8_system%255Fusage |
+| 7f4b06e9112d7bc8_system%5Fusage   |
+| 844910ece80be8bc_057abada752bc8ce |
+| 844910ece80be8bc_05a7a51565539000 |
++-----------------------------------+
+```
+
+Then run the `USE DATABASE` command
+
+```
+> use database my_db;
+You are now in remote mode, querying database my_db
+my_db>
+```
+
+Now, all queries will be run against the specified database (`my_db`) in this example
+```
+my_db> show tables;
++---------------+--------------------+-------------+------------+
+| table_catalog | table_schema       | table_name  | table_type |
++---------------+--------------------+-------------+------------+
+| public        | iox                | query_count | BASE TABLE |
+| public        | system             | chunks      | BASE TABLE |
+| public        | system             | columns     | BASE TABLE |
+| public        | system             | operations  | BASE TABLE |
+| public        | information_schema | tables      | VIEW       |
+| public        | information_schema | columns     | VIEW       |
++---------------+--------------------+-------------+------------+
+
+Query execution complete in 32.034867ms
+my_db> select count(*) from query_count;
++-----------------+
+| COUNT(UInt8(1)) |
++-----------------+
+| 2               |
++-----------------+
+
+Query execution complete in 46.852934ms
+```
+
+
+## Observer
+In this mode queries are run *locally* against a cached unified view of the remote system tables
+
+```
+my_db> observer;
+Preparing local views of remote system tables
+Loading system tables from 49 databases
+...................................................................................................................................................
+ Completed in 4.048318429s
+You are now in Observer mode.
+
+SQL commands in this mode run against a cached unified view of
+remote system tables in all remote databases.
+
+To see the unified tables available to you, try running
+SHOW TABLES;
+
+To reload the most recent version of the database system tables, run
+OBSERVER;
+
+Example SQL to show the total estimated storage size by database:
+
+SELECT database_name, storage, count(*) as num_chunks,
+  sum(estimated_bytes)/1024/1024 as estimated_mb
+FROM chunks
+GROUP BY database_name, storage
+ORDER BY estimated_mb desc;
+
+OBSERVER>
+
+```
+
+# Query Cookbook
+
+This section contains some common and useful queries against IOx system tables
+
+
+## Explore Schema
+
+
+The `SHOW TABLES` command will show all tables available to you.
+
+```
+my_db> show tables;
++---------------+--------------------+-------------+------------+
+| table_catalog | table_schema       | table_name  | table_type |
++---------------+--------------------+-------------+------------+
+| public        | iox                | query_count | BASE TABLE |
+| public        | system             | chunks      | BASE TABLE |
+| public        | system             | columns     | BASE TABLE |
+| public        | system             | operations  | BASE TABLE |
+| public        | information_schema | tables      | VIEW       |
+| public        | information_schema | columns     | VIEW       |
++---------------+--------------------+-------------+------------+
+
+Query execution complete in 45.06072ms
+```
+tables in the `iox` schema are those that you have loaded (`query_count`) in this example. Tables which allow you to interrogate IOx's internals are in the `system` schema. The `information_schema` schema contains SQL standard views for accessing table and column metadata.
+
+
+The `SHOW COLUMNS FROM <tablename>` command will show the columns in a table
+
+```
+my_db> show columns from query_count;
++---------------+--------------+-------------+-------------+-----------------------------+-------------+
+| table_catalog | table_schema | table_name  | column_name | data_type                   | is_nullable |
++---------------+--------------+-------------+-------------+-----------------------------+-------------+
+| public        | iox          | query_count | avg         | Int64                       | YES         |
+| public        | iox          | query_count | time        | Timestamp(Nanosecond, None) | NO          |
++---------------+--------------+-------------+-------------+-----------------------------+-------------+
+
+Query execution complete in 62.77733ms
+```
+
+A classic trick to explore a table's schema is to select from it with a limit. For example:
+
+```
+my_db> select * from query_count limit 2;
++-----+---------------------+
+| avg | time                |
++-----+---------------------+
+| 461 | 2021-04-28 16:51:00 |
+| 402 | 2021-04-28 17:51:00 |
++-----+---------------------+
+
+Query execution complete in 39.046225ms
+```
+
+
+
+## System Tables
+
+Here are some interesting reports you can run when in `OBSERVER` mode:
+
+### Total storage size taken by each database
+
+```sql
+SELECT
+  database_name, count(*) as num_chunks,
+  sum(estimated_bytes)/1024/1024 as estimated_mb
+FROM chunks
+GROUP BY database_name
+ORDER BY estimated_mb desc
+LIMIT 20;
+```
+
+### Total estimated storage size by database and storage class
+```sql
+SELECT
+  database_name, storage, count(*) as num_chunks,
+  sum(estimated_bytes)/1024/1024 as estimated_mb
+FROM chunks
+GROUP BY database_name, storage
+ORDER BY estimated_mb desc
+LIMIT 20;
+```
+
+### Total estimated storage size by database, table_name and storage class
+
+```sql
+SELECT
+  database_name, table_name, storage, count(*) as num_chunks,
+  sum(estimated_bytes)/1024/1024 as estimated_mb
+FROM chunks
+GROUP BY database_name, table_name, storage
+ORDER BY estimated_mb desc
+LIMIT 20;
+```
+
+
+### Total row count by table
+
+```sql
+SELECT database_name, table_name, max(count) as total_rows
+FROM columns
+GROUP BY database_name, table_name
+ORDER BY total_rows DESC
+LIMIT 20;
+```
+
+### Total row count by partition and table
+
+```sql
+SELECT database_name, partition_key, table_name, max(count) as total_rows
+FROM columns
+GROUP BY database_name, partition_key, table_name
+ORDER BY total_rows DESC
+LIMIT 20;
+```

--- a/src/commands/sql.rs
+++ b/src/commands/sql.rs
@@ -6,6 +6,7 @@ use structopt::StructOpt;
 
 use influxdb_iox_client::connection::{Builder, Connection};
 
+mod observer;
 mod repl;
 mod repl_command;
 

--- a/src/commands/sql/observer.rs
+++ b/src/commands/sql/observer.rs
@@ -1,0 +1,299 @@
+//! This module implements the "Observer" functionality of the SQL repl
+
+use influxdb_iox_client::connection::Connection;
+use snafu::{ResultExt, Snafu};
+
+use std::{collections::HashMap, sync::Arc, time::Instant};
+
+use arrow_deps::{
+    arrow::{
+        array::{Array, ArrayRef, StringArray},
+        datatypes::{Field, Schema},
+        record_batch::RecordBatch,
+    },
+    datafusion::{
+        datasource::MemTable,
+        prelude::{ExecutionConfig, ExecutionContext},
+    },
+};
+
+use observability_deps::tracing::{debug, info};
+
+#[derive(Debug, Snafu)]
+pub enum Error {
+    #[snafu(display("Generic error"))]
+    Generic,
+
+    #[snafu(display("Error loading remote state: {}", source))]
+    LoadingDatabaseNames {
+        source: influxdb_iox_client::management::ListDatabaseError,
+    },
+
+    #[snafu(display("Error running remote query: {}", source))]
+    RunningRemoteQuery {
+        source: influxdb_iox_client::flight::Error,
+    },
+
+    #[snafu(display("Error running observer query: {}", source))]
+    Query {
+        source: arrow_deps::datafusion::error::DataFusionError,
+    },
+}
+
+pub type Result<T, E = Error> = std::result::Result<T, E>;
+
+/// The Observer contains a local DataFusion execution engine that has
+/// pre-loaded with consolidated system table views.
+pub struct Observer {
+    /// DataFusion execution context for executing queries
+    context: ExecutionContext,
+}
+
+impl Observer {
+    /// Attempt to create a new observer instance, loading from the remote server
+    pub async fn try_new(connection: Connection) -> Result<Self> {
+        let mut context =
+            ExecutionContext::with_config(ExecutionConfig::new().with_information_schema(true));
+
+        load_remote_system_tables(&mut context, connection).await?;
+
+        Ok(Self { context })
+    }
+
+    /// Runs the specified sql query locally against the preloaded context
+    pub async fn run_query(&mut self, sql: &str) -> Result<Vec<RecordBatch>> {
+        self.context
+            .sql(sql)
+            .context(Query)?
+            .collect()
+            .await
+            .context(Query)
+    }
+
+    pub fn help(&self) -> String {
+        r#"You are now in Observer mode.
+
+SQL commands in this mode run against a cached unified view of
+remote system tables in all remote databases.
+
+To see the unified tables available to you, try running
+SHOW TABLES;
+
+To reload the most recent version of the database system tables, run
+OBSERVER;
+
+Example SQL to show the total estimated storage size by database:
+
+SELECT database_name, storage, count(*) as num_chunks,
+  sum(estimated_bytes)/1024/1024 as estimated_mb
+FROM chunks
+GROUP BY database_name, storage
+ORDER BY estimated_mb desc;
+
+"#
+        .to_string()
+    }
+}
+
+/// Copies the data from the remote tables across all databases in a
+/// remote server into a local copy that also has an extra
+/// `database_name` column for the database
+async fn load_remote_system_tables(
+    context: &mut ExecutionContext,
+    connection: Connection,
+) -> Result<()> {
+    // all prefixed with "system."
+    let table_names = vec!["chunks", "columns", "operations"];
+
+    let start = Instant::now();
+
+    let mut management_client = influxdb_iox_client::management::Client::new(connection.clone());
+
+    let db_names = management_client
+        .list_databases()
+        .await
+        .context(LoadingDatabaseNames)?;
+
+    println!("Loading system tables from {} databases", db_names.len());
+
+    let tasks = db_names
+        .into_iter()
+        .map(|db_name| {
+            let table_names = table_names.clone();
+            let connection = connection.clone();
+            table_names.into_iter().map(move |table_name| {
+                let table_name = table_name.to_string();
+                let db_name = db_name.to_string();
+                let connection = connection.clone();
+                let sql = format!("select * from system.{}", table_name);
+                tokio::task::spawn(async move {
+                    let mut client = influxdb_iox_client::flight::Client::new(connection);
+                    let mut query_results = client
+                        .perform_query(&db_name, &sql)
+                        .await
+                        .context(RunningRemoteQuery)?;
+
+                    let mut batches = vec![];
+
+                    while let Some(data) = query_results.next().await.context(RunningRemoteQuery)? {
+                        batches.push(data);
+                    }
+
+                    let t: Result<RemoteSystemTable> = Ok(RemoteSystemTable {
+                        db_name,
+                        table_name,
+                        batches,
+                    });
+                    print!("."); // give some indication of progress
+                    use std::io::Write;
+                    std::io::stdout().flush().unwrap();
+                    t
+                })
+            })
+        })
+        .flatten()
+        .collect::<Vec<_>>();
+
+    // now, get the results and combine them
+    let results = futures::future::join_all(tasks).await;
+
+    let mut builder = AggregatedTableBuilder::new();
+    results.into_iter().for_each(|result| {
+        match result {
+            Ok(Ok(table)) => {
+                builder.append(table);
+            }
+            // This is not a fatal error so log it and keep going
+            Ok(Err(e)) => {
+                println!("WARNING: Error running query: {}", e);
+            }
+            // This is not a fatal error so log it and keep going
+            Err(e) => {
+                println!("WARNING: Error running task: {}", e);
+            }
+        }
+    });
+
+    println!();
+    println!(" Completed in {:?}", Instant::now() - start);
+
+    builder.build(context);
+
+    Ok(())
+}
+
+#[derive(Debug)]
+/// Contains the results from a system table query for a specific database
+struct RemoteSystemTable {
+    db_name: String,
+    table_name: String,
+    batches: Vec<RecordBatch>,
+}
+
+#[derive(Debug, Default)]
+/// Aggregates several table responses into a unified view
+struct AggregatedTableBuilder {
+    tables: HashMap<String, VirtualTableBuilder>,
+}
+
+impl AggregatedTableBuilder {
+    fn new() -> Self {
+        Self::default()
+    }
+
+    /// Appends a table response to the aggregated tables being built
+    fn append(&mut self, t: RemoteSystemTable) {
+        let RemoteSystemTable {
+            db_name,
+            table_name,
+            batches,
+        } = t;
+
+        let num_rows: usize = batches.iter().map(|b| b.num_rows()).sum();
+
+        info!(%table_name, %db_name, num_batches=batches.len(), %num_rows, "Aggregating results");
+
+        let table_builder = self
+            .tables
+            .entry(table_name.clone())
+            .or_insert_with(|| VirtualTableBuilder::new(table_name));
+
+        table_builder.append_batches(&db_name, batches);
+    }
+
+    /// register a table provider for this system table
+    fn build(self, ctx: &mut ExecutionContext) {
+        let Self { tables } = self;
+
+        for (table_name, table_builder) in tables {
+            debug!(%table_name, "registering system table");
+            table_builder.build(ctx);
+        }
+    }
+}
+
+/// Creates a "virtual" version of `select * from <table>` which has a
+/// "database_name" column pre-pended to all actual record batches
+#[derive(Debug)]
+struct VirtualTableBuilder {
+    table_name: String,
+    batches: Vec<RecordBatch>,
+}
+
+impl VirtualTableBuilder {
+    pub fn new(table_name: impl Into<String>) -> Self {
+        let table_name = table_name.into();
+        Self {
+            table_name,
+            batches: Vec::new(),
+        }
+    }
+
+    /// Append batches from `select * from <system table>` to the
+    /// results being created
+    fn append_batches(&mut self, db_name: &str, new_batches: Vec<RecordBatch>) {
+        self.batches.extend(new_batches.into_iter().map(|batch| {
+            use std::iter::once;
+
+            let array =
+                StringArray::from_iter_values(std::iter::repeat(db_name).take(batch.num_rows()));
+            let data_type = array.data_type().clone();
+            let array = Arc::new(array) as ArrayRef;
+
+            let new_columns = once(array)
+                .chain(batch.columns().iter().cloned())
+                .collect::<Vec<ArrayRef>>();
+
+            let new_fields = once(Field::new("database_name", data_type, false))
+                .chain(batch.schema().fields().iter().cloned())
+                .collect::<Vec<Field>>();
+            let new_schema = Arc::new(Schema::new(new_fields));
+
+            RecordBatch::try_new(new_schema, new_columns).expect("Creating new record batch")
+        }))
+    }
+
+    /// register a table provider  for this sytem table
+    fn build(self, ctx: &mut ExecutionContext) {
+        let Self {
+            table_name,
+            batches,
+        } = self;
+
+        let schema = if batches.is_empty() {
+            panic!("No batches for ChunksTableBuilder");
+        } else {
+            batches[0].schema()
+        };
+
+        let partitions = batches
+            .into_iter()
+            .map(|batch| vec![batch])
+            .collect::<Vec<_>>();
+
+        let memtable = MemTable::try_new(schema, partitions).expect("creating memtable");
+
+        ctx.register_table(table_name.as_str(), Arc::new(memtable))
+            .ok();
+    }
+}

--- a/tests/end_to_end_cases/sql_cli.rs
+++ b/tests/end_to_end_cases/sql_cli.rs
@@ -127,3 +127,164 @@ async fn test_sql_use_database() {
         .success()
         .stdout(predicate::str::contains(expected_output));
 }
+
+#[tokio::test]
+async fn test_sql_observer() {
+    let fixture = ServerFixture::create_shared().await;
+    let addr = fixture.grpc_base();
+
+    let expected_output = "You are now in Observer mode";
+
+    Command::cargo_bin("influxdb_iox")
+        .unwrap()
+        .arg("sql")
+        .arg("--host")
+        .arg(addr)
+        // write a query against the aggregated chunks
+        .write_stdin("observer;\n\n")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(expected_output));
+}
+
+#[tokio::test]
+async fn test_sql_observer_chunks() {
+    // test chunks aggregated table
+    let fixture = ServerFixture::create_shared().await;
+    let addr = fixture.grpc_base();
+
+    let db_name1 = rand_name();
+    create_two_partition_database(&db_name1, fixture.grpc_channel()).await;
+
+    let db_name2 = rand_name();
+    create_two_partition_database(&db_name2, fixture.grpc_channel()).await;
+
+    let expected_output = r#"
++---------------+------------+
+| partition_key | table_name |
++---------------+------------+
+| cpu           | cpu        |
+| cpu           | cpu        |
+| mem           | mem        |
+| mem           | mem        |
++---------------+------------+
+"#
+    .trim();
+
+    let query = format!(
+        r#"
+select
+  partition_key, table_name
+from
+  chunks
+where
+  database_name IN ('{}', '{}')
+order by
+  partition_key, table_name
+;
+"#,
+        db_name1, db_name2
+    );
+
+    Command::cargo_bin("influxdb_iox")
+        .unwrap()
+        .arg("sql")
+        .arg("--host")
+        .arg(addr)
+        .write_stdin(format!("observer;\n\n{};\n", query))
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(expected_output));
+}
+
+#[tokio::test]
+async fn test_sql_observer_columns() {
+    // test columns aggregated table
+    let fixture = ServerFixture::create_shared().await;
+    let addr = fixture.grpc_base();
+
+    let db_name = rand_name();
+    create_two_partition_database(&db_name, fixture.grpc_channel()).await;
+
+    let expected_output = r#"
++---------------+------------+--------------+
+| partition_key | table_name | column_count |
++---------------+------------+--------------+
+| cpu           | cpu        | 5            |
+| mem           | mem        | 5            |
++---------------+------------+--------------+
+"#
+    .trim();
+
+    let query = format!(
+        r#"observer;
+select
+  partition_key, table_name, count(*) as column_count
+from
+  columns
+where
+  database_name = '{}'
+group by
+  partition_key, table_name
+order by
+  partition_key, table_name, column_count
+;
+"#,
+        db_name
+    );
+
+    Command::cargo_bin("influxdb_iox")
+        .unwrap()
+        .arg("sql")
+        .arg("--host")
+        .arg(addr)
+        .write_stdin(format!("observer;\n\n{};\n", query))
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(expected_output));
+}
+
+#[tokio::test]
+async fn test_sql_observer_operations() {
+    // test columns aggregated table
+    let fixture = ServerFixture::create_shared().await;
+    let addr = fixture.grpc_base();
+
+    let db_name = rand_name();
+    create_two_partition_database(&db_name, fixture.grpc_channel()).await;
+
+    let expected_output = r#"
++---------------+----------+-----------------------------+
+| partition_key | chunk_id | description                 |
++---------------+----------+-----------------------------+
+| cpu           | 0        | Loading chunk to ReadBuffer |
+| cpu           | 0        | Loading chunk to ReadBuffer |
++---------------+----------+-----------------------------+
+"#
+    .trim();
+
+    let query = format!(
+        r#"observer;
+select
+  partition_key, chunk_id, description
+from
+  operations
+where
+  database_name = '{}'
+order by
+  partition_key, chunk_id, description
+;
+"#,
+        db_name
+    );
+
+    Command::cargo_bin("influxdb_iox")
+        .unwrap()
+        .arg("sql")
+        .arg("--host")
+        .arg(addr)
+        .write_stdin(format!("observer;\n\n{};\n", query))
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(expected_output));
+}


### PR DESCRIPTION
# Rationale:
While trying to understand the state of an IOx server, I want to be able to run queries on system tables across databases (so I can have a consolidated view of the system)

# Changes
Follow on to https://github.com/influxdata/influxdb_iox/pull/1332, and based on code from https://github.com/influxdata/influxdb_iox/pull/1117

1. Add the observer mode to SQL repl, with tests
2. Add a quickie "Common queries" document to the admin guide with a cheatsheet of common queries

# Examples of use:

```
OBSERVER> observer;
Preparing local views of remote system tables
Loading system tables from 49 databases
...................................................................................................................................................
 Completed in 3.654190485s
You are now in Observer mode.

SQL commands in this mode run against a cached unified view of
remote system tables in all remote databases.

To see the unified tables available to you, try running
SHOW TABLES;

To reload the most recent version of the database system tables, run
OBSERVER;

Example SQL to show the total estimated storage size by database:

SELECT database_name, storage, count(*) as num_chunks,
  sum(estimated_bytes)/1024/1024 as estimated_mb
FROM chunks
GROUP BY database_name, storage
ORDER BY estimated_mb desc;

OBSERVER> SELECT
  database_name, count(*) as num_chunks,
  sum(estimated_bytes)/1024/1024 as estimated_mb
FROM chunks
GROUP BY database_name
ORDER BY estimated_mb desc
LIMIT 20;

+-----------------------------------+------------+--------------+
| database_name                     | num_chunks | estimated_mb |
+-----------------------------------+------------+--------------+
| 844910ece80be8bc_eaec8df57a81a1e9 | 312        | 979          |
| 844910ece80be8bc_3c0bd4c89186ca89 | 371        | 884          |
| 844910ece80be8bc_64881f0f8fd1653c | 368        | 261          |
| 844910ece80be8bc_frontendservices | 60         | 49           |
| 844910ece80be8bc_05d1e95653672000 | 73         | 49           |
| 844910ece80be8bc_7caaf9613b16e7c2 | 31         | 49           |
| 844910ece80be8bc_b79491dc43e2c47e | 81         | 48           |
| 844910ece80be8bc_istio            | 1151       | 47           |
| 844910ece80be8bc_6f8925e75446c183 | 1881       | 46           |
| 7f4b06e9112d7bc8_system%5Fusage   | 14         | 43           |
| 844910ece80be8bc_apps             | 344        | 42           |
| InfluxData_%5Ftasks               | 6          | 32           |
| 844910ece80be8bc_5d5a6ade9b665dfc | 292        | 25           |
| 844910ece80be8bc_1f8d706e48cf8e70 | 12         | 20           |
| 844910ece80be8bc_81c1fce8c36339dc | 33         | 19           |
| 844910ece80be8bc_4bed41a6ff7f0ee0 | 152        | 16           |
| 844910ece80be8bc_infra            | 446        | 12           |
| 844910ece80be8bc_dfeaf11d9d194efd | 315        | 10           |
| 844910ece80be8bc_84cc8db6499a3d11 | 10         | 10           |
| 844910ece80be8bc_a44813fabdadbc9d | 149        | 5            |
+-----------------------------------+------------+--------------+

Query execution complete in 12.862755ms
```

