### PR TITLE
feat: Improve git-log-pr

### DIFF
--- a/scripts/git-log-prs
+++ b/scripts/git-log-prs
@@ -13,6 +13,8 @@
 
 set -eu -o pipefail
 
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
 usage() {
   echo "$0 [ --titles ] <rev_range>"
   exit 1
@@ -31,18 +33,47 @@ ensure_command_gh() {
   }
 }
 
+get_title() {
+  local sha="$1"
+  local pr="$2"
+
+  if [ "$(git show "${sha}" --pretty=format:%b | wc -l | awk '{print $1}')" == 1 ]; then
+    git show "${sha}" --pretty=format:%b
+  else
+    ensure_command_gh
+    gh pr view "${pr}" --json title --jq '.title'
+  fi
+}
+
 main() {
   local positionals=()
+  local commits=""
   local titles=""
+  local git_dir="${SCRIPT_DIR}/.."
 
   while [[ $# -gt 0 ]]; do
     local key="$1"
 
     case "${key}" in
+        # print titles
         --titles)
         titles=true
         shift
         ;;
+
+        # print commit shas
+        --commits)
+        commits=true
+        shift
+        ;;
+
+        # git directory; defaults to the repo where this script lives
+        -C)
+        git_dir="$2"
+        shift
+        shift
+        ;;
+
         *)
         positionals+=("$1")
         shift
@@ -55,21 +86,32 @@ main() {
   fi
 
   local rev_range="${positionals[0]}"
+  cd "${git_dir}"
 
   git log \
       --committer='GitHub <noreply@github.com>' \
-      --pretty=format:'%s' \
+      --pretty=format:'%h: %s' \
       "${rev_range}" \
-    | sed 's/Merge pull request #\([0-9]*\).*/\1/' \
-    | sed 's/.*(#\([0-9]*\))$/\1/' \
-    | grep -E '^[0-9]*$' \
-    | while read -r pr; do
-    local title=""
-    if [ -n "${titles}" ]; then
-      ensure_command_gh
-      title=$(gh pr view "${pr}" --json title --jq '.title')
-    fi
-    echo "${pr} ${title}"
+    | sed 's/\([^:]*\): Merge pull request #\([0-9]*\).*/\1: \2/' \
+    | sed 's/\([^:]*\): .*(#\([0-9]*\))$/\1: \2/' \
+    | grep -E '^[a-f0-9]*: [0-9]*$' \
+    | while read -r line; do
+      read -r -a line_arr <<< "${line}"
+
+      local sha="${line_arr[0]%:}"
+      local pr=${line_arr[1]}
+
+      local title=""
+      if [ -n "${titles}" ]; then
+        title=$(get_title "${sha}" "${pr}")
+      fi
+
+      local commit=""
+      if [ -n "${commits}" ]; then
+        commit="${sha} "
+      fi
+
+      echo "${commit}${pr} ${title}"
   done
 }
 


### PR DESCRIPTION
1. by default use the repo where the `git-log-pr` script is located in, allowing it to be called
   from other scripts in other repos (e.g. k8s-idpe) without too much cerimony
2. allow the git repo to be overriden with the `-C` flag (like the `git` command itself)
3. add a `--commits` flag which prints also commit shas in addition to PR numbers
4. GH merge commits contain the PR title as the body; if present use that instead of using the `gh` cli (which is slow and requires this tool to be installed).
