### PR TITLE
refactor: rename assert_table_eq to assert_batches_eq

### DIFF
--- a/arrow_deps/src/test_util.rs
+++ b/arrow_deps/src/test_util.rs
@@ -10,9 +10,9 @@ use crate::arrow::compute::kernels::sort::{lexsort, SortColumn, SortOptions};
 /// into the test code as expected results.
 ///
 /// Expects to be called about like this:
-/// assert_table_eq(expected_lines: &[&str], chunks: &[RecordBatch])
+/// assert_batches_eq(expected_lines: &[&str], chunks: &[RecordBatch])
 #[macro_export]
-macro_rules! assert_table_eq {
+macro_rules! assert_batches_eq {
     ($EXPECTED_LINES: expr, $CHUNKS: expr) => {
         let expected_lines: Vec<String> =
             $EXPECTED_LINES.into_iter().map(|s| s.to_string()).collect();

--- a/internal_types/src/arrow/sort.rs
+++ b/internal_types/src/arrow/sort.rs
@@ -102,7 +102,7 @@ pub fn sort_record_batch(batch: RecordBatch) -> Result<RecordBatch> {
 mod tests {
     use arrow_deps::arrow::array::{Int32Array, TimestampNanosecondArray};
     use arrow_deps::arrow::datatypes::DataType;
-    use arrow_deps::assert_table_eq;
+    use arrow_deps::assert_batches_eq;
 
     use crate::schema::builder::SchemaBuilder;
 
@@ -154,7 +154,7 @@ mod tests {
         let sorted = sort_record_batch(batch).unwrap();
 
         // Expects to be sorted first by tag2, then tag1, then time
-        assert_table_eq!(
+        assert_batches_eq!(
             &[
                 "+----------+-------+-------------------------------+------+",
                 "| tag1     | tag2  | time                          | data |",

--- a/mutable_buffer/src/chunk.rs
+++ b/mutable_buffer/src/chunk.rs
@@ -266,7 +266,7 @@ pub mod test_helpers {
 mod tests {
     use super::test_helpers::write_lp_to_chunk;
     use super::*;
-    use arrow_deps::assert_table_eq;
+    use arrow_deps::assert_batches_eq;
 
     #[test]
     fn writes_table_batches() {
@@ -282,7 +282,7 @@ mod tests {
 
         write_lp_to_chunk(&lp, &mut chunk).unwrap();
 
-        assert_table_eq!(
+        assert_batches_eq!(
             vec![
                 "+------+-------------------------------+-----+",
                 "| host | time                          | val |",
@@ -294,7 +294,7 @@ mod tests {
             &chunk_to_batches(&chunk, "cpu")
         );
 
-        assert_table_eq!(
+        assert_batches_eq!(
             vec![
                 "+------+-------------------------------+-------+",
                 "| host | time                          | val   |",
@@ -329,7 +329,7 @@ mod tests {
 
         write_lp_to_chunk(&lp, &mut chunk).unwrap();
 
-        assert_table_eq!(
+        assert_batches_eq!(
             vec![
                 "+------+-------------------------------+-----+",
                 "| host | time                          | val |",
@@ -342,7 +342,7 @@ mod tests {
             &chunk_to_batches(&chunk, "cpu")
         );
 
-        assert_table_eq!(
+        assert_batches_eq!(
             vec![
                 "+-------------------------------+------+",
                 "| time                          | val  |",
@@ -353,7 +353,7 @@ mod tests {
             &chunk_to_batches(&chunk, "disk")
         );
 
-        assert_table_eq!(
+        assert_batches_eq!(
             vec![
                 "+------+------+-------------------------------+-------+",
                 "| host | sval | time                          | val   |",

--- a/query/src/provider/adapter.rs
+++ b/query/src/provider/adapter.rs
@@ -233,7 +233,7 @@ mod tests {
             datatypes::{Field, Schema},
             record_batch::RecordBatch,
         },
-        assert_table_eq,
+        assert_batches_eq,
         datafusion::physical_plan::common::{collect, SizedRecordBatchStream},
     };
     use test_helpers::assert_contains;
@@ -259,7 +259,7 @@ mod tests {
             "| 3 | 6 | baz |",
             "+---+---+-----+",
         ];
-        assert_table_eq!(&expected, &output);
+        assert_batches_eq!(&expected, &output);
     }
 
     #[tokio::test]
@@ -288,7 +288,7 @@ mod tests {
             "| 6 | baz | 3 |",
             "+---+-----+---+",
         ];
-        assert_table_eq!(&expected, &output);
+        assert_batches_eq!(&expected, &output);
     }
 
     #[tokio::test]
@@ -318,7 +318,7 @@ mod tests {
             "| baz |   | 6 |   | 3 |",
             "+-----+---+---+---+---+",
         ];
-        assert_table_eq!(&expected, &output);
+        assert_batches_eq!(&expected, &output);
     }
 
     #[tokio::test]

--- a/server/src/db.rs
+++ b/server/src/db.rs
@@ -1101,7 +1101,7 @@ mod tests {
     use crate::query_tests::utils::{make_database, make_db};
     use ::test_helpers::assert_contains;
     use arrow_deps::{
-        arrow::record_batch::RecordBatch, assert_batches_sorted_eq, assert_table_eq,
+        arrow::record_batch::RecordBatch, assert_batches_eq, assert_batches_sorted_eq,
         datafusion::execution::context,
     };
     use chrono::Utc;
@@ -1156,7 +1156,7 @@ mod tests {
             "| 1   | 1970-01-01 00:00:00.000000010 |",
             "+-----+-------------------------------+",
         ];
-        assert_table_eq!(expected, &batches);
+        assert_batches_eq!(expected, &batches);
     }
 
     #[tokio::test]
@@ -1322,7 +1322,7 @@ mod tests {
             "+------+--------+-------------------------------+------+",
         ];
         let batches = run_query(Arc::clone(&db), "select * from cpu").await;
-        assert_table_eq!(expected, &batches);
+        assert_batches_eq!(expected, &batches);
     }
 
     #[tokio::test]
@@ -1360,7 +1360,7 @@ mod tests {
             "+-----+-------------------------------+",
         ];
         let batches = run_query(Arc::clone(&db), "select * from cpu").await;
-        assert_table_eq!(&expected, &batches);
+        assert_batches_eq!(&expected, &batches);
 
         // drop, the chunk from the read buffer
         db.drop_chunk(partition_key, "cpu", mb_chunk.id()).unwrap();
@@ -1373,7 +1373,7 @@ mod tests {
         // purge tables after data bas been dropped println!("running
         // query after all data dropped!"); let expected = vec![] as
         // Vec<&str>; let batches = run_query(&db, "select * from
-        // cpu").await; assert_table_eq!(expected, &batches);
+        // cpu").await; assert_batches_eq!(expected, &batches);
     }
 
     async fn collect_read_filter(chunk: &DbChunk, table_name: &str) -> Vec<RecordBatch> {
@@ -1443,7 +1443,7 @@ mod tests {
 
         // Test that data on load into the read buffer is sorted
 
-        assert_table_eq!(
+        assert_batches_eq!(
             &[
                 "+-----+----------+------+-------------------------------+",
                 "| bar | tag1     | tag2 | time                          |",
@@ -1459,7 +1459,7 @@ mod tests {
             &mb
         );
 
-        assert_table_eq!(
+        assert_batches_eq!(
             &[
                 "+-----+----------+------+-------------------------------+",
                 "| bar | tag1     | tag2 | time                          |",
@@ -1590,7 +1590,7 @@ mod tests {
             "| 2   | 1970-01-01 00:00:00.000000020 |",
             "+-----+-------------------------------+",
         ];
-        assert_table_eq!(expected, &content);
+        assert_batches_eq!(expected, &content);
     }
 
     #[tokio::test]

--- a/server/src/db/system_tables.rs
+++ b/server/src/db/system_tables.rs
@@ -196,7 +196,7 @@ fn from_task_trackers(db_name: &str, jobs: Vec<TaskTracker<Job>>) -> Result<Reco
 #[cfg(test)]
 mod tests {
     use super::*;
-    use arrow_deps::assert_table_eq;
+    use arrow_deps::assert_batches_eq;
     use chrono::NaiveDateTime;
     use data_types::chunk::ChunkStorage;
     use data_types::partition_metadata::{ColumnSummary, StatValues, Statistics, TableSummary};
@@ -244,7 +244,7 @@ mod tests {
         ];
 
         let batch = from_chunk_summaries(chunks).unwrap();
-        assert_table_eq!(&expected, &[batch]);
+        assert_batches_eq!(&expected, &[batch]);
     }
 
     #[test]
@@ -289,6 +289,6 @@ mod tests {
         ];
 
         let batch = from_partition_summaries(partitions).unwrap();
-        assert_table_eq!(&expected, &[batch]);
+        assert_batches_eq!(&expected, &[batch]);
     }
 }

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -946,7 +946,7 @@ mod tests {
     use tokio::task::JoinHandle;
     use tokio_util::sync::CancellationToken;
 
-    use arrow_deps::assert_table_eq;
+    use arrow_deps::assert_batches_eq;
     use data_types::database_rules::{
         HashRing, PartitionTemplate, ShardConfig, TemplatePart, NO_SHARD_CONFIG,
     };
@@ -1141,7 +1141,7 @@ mod tests {
             "| 1   | 1970-01-01 00:00:00.000000010 |",
             "+-----+-------------------------------+",
         ];
-        assert_table_eq!(expected, &batches);
+        assert_batches_eq!(expected, &batches);
     }
 
     #[tokio::test]
@@ -1185,7 +1185,7 @@ mod tests {
             "| 1   | 1970-01-01 00:00:00.000000010 |",
             "+-----+-------------------------------+",
         ];
-        assert_table_eq!(expected, &batches);
+        assert_batches_eq!(expected, &batches);
 
         metric_registry
             .has_metric_family("ingest_entries_bytes_total")

--- a/server/src/query_tests/influxrpc/field_columns.rs
+++ b/server/src/query_tests/influxrpc/field_columns.rs
@@ -1,6 +1,6 @@
 use arrow_deps::{
     arrow::datatypes::DataType,
-    assert_table_eq,
+    assert_batches_eq,
     datafusion::logical_plan::{col, lit},
 };
 use query::{
@@ -156,6 +156,6 @@ async fn test_field_name_plan() {
             "+--------+--------+--------+--------+-------------------------------+",
         ];
 
-        assert_table_eq!(expected, &results);
+        assert_batches_eq!(expected, &results);
     }
 }

--- a/src/influxdb_ioxd/http.rs
+++ b/src/influxdb_ioxd/http.rs
@@ -853,7 +853,7 @@ mod tests {
         num::NonZeroU32,
     };
 
-    use arrow_deps::{arrow::record_batch::RecordBatch, assert_table_eq};
+    use arrow_deps::{arrow::record_batch::RecordBatch, assert_batches_eq};
     use reqwest::{Client, Response};
 
     use data_types::{database_rules::DatabaseRules, server_id::ServerId, DatabaseName};
@@ -932,7 +932,7 @@ mod tests {
             "| 50.4           | santa_monica | CA    | 65.2            | 2021-04-01 14:10:24 |",
             "+----------------+--------------+-------+-----------------+---------------------+",
         ];
-        assert_table_eq!(expected, &batches);
+        assert_batches_eq!(expected, &batches);
     }
 
     #[tokio::test]
@@ -1200,7 +1200,7 @@ mod tests {
             "| 50.4           | santa_monica | CA    | 65.2            | 2021-04-01 14:10:24 |",
             "+----------------+--------------+-------+-----------------+---------------------+",
         ];
-        assert_table_eq!(expected, &batches);
+        assert_batches_eq!(expected, &batches);
     }
 
     #[tokio::test]

--- a/tests/end_to_end_cases/flight_api.rs
+++ b/tests/end_to_end_cases/flight_api.rs
@@ -1,6 +1,6 @@
 use super::scenario::{collect_query, create_readable_database, rand_name, Scenario};
 use crate::common::server_fixture::ServerFixture;
-use arrow_deps::assert_table_eq;
+use arrow_deps::assert_batches_eq;
 
 #[tokio::test]
 pub async fn test() {
@@ -24,7 +24,7 @@ pub async fn test() {
 
     let batches = collect_query(query_results).await;
 
-    assert_table_eq!(expected_read_data, &batches);
+    assert_batches_eq!(expected_read_data, &batches);
 }
 
 #[tokio::test]

--- a/tests/end_to_end_cases/system_tables.rs
+++ b/tests/end_to_end_cases/system_tables.rs
@@ -1,5 +1,5 @@
 use crate::common::server_fixture::ServerFixture;
-use arrow_deps::assert_table_eq;
+use arrow_deps::assert_batches_eq;
 
 use super::scenario::{collect_query, create_readable_database, rand_name};
 
@@ -55,7 +55,7 @@ async fn test_operations() {
         "+----------+----------+-----------------------------+",
     ];
 
-    assert_table_eq!(expected_read_data, &batches);
+    assert_batches_eq!(expected_read_data, &batches);
 
     // Should not see jobs from db1 when querying db2
     let query_results = client.perform_query(&db_name2, sql_query).await.unwrap();
@@ -63,5 +63,5 @@ async fn test_operations() {
     let batches = collect_query(query_results).await;
     let expected_read_data = vec!["++", "||", "++", "++"];
 
-    assert_table_eq!(expected_read_data, &batches);
+    assert_batches_eq!(expected_read_data, &batches);
 }


### PR DESCRIPTION
# Rationale
Keep these macro names consistent with DataFusion as well as consistent with `assert_batches_sorted_eq`

# Background
I wrote `assert_table_eq` originally for IOx, and then contributed a version to DataFusion called `assert_batches_eq` and `assert_batches_eq` which left a potpourii of names I would like to be consistent.

# Changes
Ran `find . -name '*.rs' -or -name '*.toml' | grep -v target | xargs sed -i '' -e 's|assert_table_eq|assert_batches_eq|g'` and checked in the result
