### PR TITLE
feat: add instrumentation via RED metrics in gRPC API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2721,6 +2721,7 @@ dependencies = [
  "influxdb_line_protocol",
  "internal_types",
  "libc",
+ "metrics",
  "observability_deps",
  "parking_lot",
  "snafu",

--- a/metrics/src/tests.rs
+++ b/metrics/src/tests.rs
@@ -58,8 +58,8 @@ impl TestMetricRegistry {
         Self { registry }
     }
 
-    pub fn registry(&self) -> &MetricRegistry {
-        &self.registry
+    pub fn registry(&self) -> Arc<MetricRegistry> {
+        Arc::clone(&self.registry)
     }
 
     /// Returns an assertion builder for the specified metric name or an error

--- a/query/Cargo.toml
+++ b/query/Cargo.toml
@@ -22,6 +22,7 @@ data_types = { path = "../data_types" }
 futures = "0.3"
 influxdb_line_protocol = { path = "../influxdb_line_protocol" }
 internal_types = { path = "../internal_types" }
+metrics = { path = "../metrics" }
 parking_lot = "0.11.1"
 snafu = "0.6.2"
 sqlparser = "0.8.0"

--- a/query/src/test.rs
+++ b/query/src/test.rs
@@ -409,6 +409,7 @@ impl PartitionChunk for TestChunk {
 pub struct TestDatabaseStore {
     databases: Mutex<BTreeMap<String, Arc<TestDatabase>>>,
     executor: Arc<Executor>,
+    pub metrics_registry: metrics::TestMetricRegistry,
 }
 
 impl TestDatabaseStore {
@@ -422,6 +423,7 @@ impl Default for TestDatabaseStore {
         Self {
             databases: Mutex::new(BTreeMap::new()),
             executor: Arc::new(Executor::new(1)),
+            metrics_registry: metrics::TestMetricRegistry::default(),
         }
     }
 }

--- a/src/influxdb_ioxd/rpc.rs
+++ b/src/influxdb_ioxd/rpc.rs
@@ -46,7 +46,10 @@ where
     tonic::transport::Server::builder()
         .add_service(health_service)
         .add_service(testing::make_server())
-        .add_service(storage::make_server(Arc::clone(&server)))
+        .add_service(storage::make_server(
+            Arc::clone(&server),
+            Arc::clone(&server.registry),
+        ))
         .add_service(flight::make_server(Arc::clone(&server)))
         .add_service(write::make_server(Arc::clone(&server)))
         .add_service(management::make_server(Arc::clone(&server)))

--- a/src/influxdb_ioxd/rpc/storage.rs
+++ b/src/influxdb_ioxd/rpc/storage.rs
@@ -1,4 +1,4 @@
-//! This module contains gRPC service implementatations
+//! This module contains gRPC service implementations
 
 /// `[0x00]` is the magic value that that the storage gRPC layer uses to
 /// encode a tag_key that means "measurement name"
@@ -15,6 +15,7 @@ pub mod input;
 pub mod service;
 
 use generated_types::storage_server::{Storage, StorageServer};
+use metrics::{MetricRegistry, RedMetric};
 use query::DatabaseStore;
 use std::sync::Arc;
 
@@ -22,15 +23,34 @@ use std::sync::Arc;
 #[derive(Debug)]
 struct StorageService<T: DatabaseStore> {
     pub db_store: Arc<T>,
-    pub metrics_registry: Arc<metrics::MetricRegistry>,
+    pub metrics: Metrics,
 }
 
 pub fn make_server<T: DatabaseStore + 'static>(
     db_store: Arc<T>,
-    metrics_registry: Arc<metrics::MetricRegistry>,
+    metrics_registry: Arc<MetricRegistry>,
 ) -> StorageServer<impl Storage> {
     StorageServer::new(StorageService {
         db_store,
-        metrics_registry,
+        metrics: Metrics::new(metrics_registry),
     })
+}
+
+// These are the metrics associated with the gRPC server.
+#[derive(Debug)]
+pub struct Metrics {
+    /// The metric tracking the outcome of requests to the gRPC service
+    pub requests: RedMetric,
+
+    // Holding the registry allows it to be replaced for a test implementation
+    pub(crate) metrics_registry: Arc<MetricRegistry>,
+}
+
+impl Metrics {
+    fn new(registry: Arc<MetricRegistry>) -> Self {
+        Self {
+            requests: registry.register_domain("gRPC").register_red_metric(None),
+            metrics_registry: registry,
+        }
+    }
 }

--- a/src/influxdb_ioxd/rpc/storage.rs
+++ b/src/influxdb_ioxd/rpc/storage.rs
@@ -22,8 +22,15 @@ use std::sync::Arc;
 #[derive(Debug)]
 struct StorageService<T: DatabaseStore> {
     pub db_store: Arc<T>,
+    pub metrics_registry: Arc<metrics::MetricRegistry>,
 }
 
-pub fn make_server<T: DatabaseStore + 'static>(db_store: Arc<T>) -> StorageServer<impl Storage> {
-    StorageServer::new(StorageService { db_store })
+pub fn make_server<T: DatabaseStore + 'static>(
+    db_store: Arc<T>,
+    metrics_registry: Arc<metrics::MetricRegistry>,
+) -> StorageServer<impl Storage> {
+    StorageServer::new(StorageService {
+        db_store,
+        metrics_registry,
+    })
 }

--- a/src/influxdb_ioxd/rpc/storage/service.rs
+++ b/src/influxdb_ioxd/rpc/storage/service.rs
@@ -2583,9 +2583,10 @@ mod tests {
 
             let router = tonic::transport::Server::builder()
                 .add_service(crate::influxdb_ioxd::rpc::testing::make_server())
-                .add_service(crate::influxdb_ioxd::rpc::storage::make_server(Arc::clone(
-                    &test_storage,
-                )));
+                .add_service(crate::influxdb_ioxd::rpc::storage::make_server(
+                    Arc::clone(&test_storage),
+                    test_storage.metrics_registry.registry(),
+                ));
 
             let server = async move {
                 let stream = TcpListenerStream::new(socket);


### PR DESCRIPTION
Contributes to #1370

This PR instruments the gRPC server with `RED` (requests, errors, duration) style metrics so we can observe the performance of the API.

It segments metrics by:

 - operation: e.g., `read_filter`, `read_group`, `tag_values`.
 - database: the database the request was for.
 - status: the outcome of the request. Ok, client error (e.g., bad arguments), error (internal error).

We capture both requests and their outcome and also distributions of the latency of each request.

