### PR TITLE
feat: add row_count to chunks system table

### DIFF
--- a/data_types/src/chunk.rs
+++ b/data_types/src/chunk.rs
@@ -60,6 +60,9 @@ pub struct ChunkSummary {
     /// The total estimated size of this chunk, in bytes
     pub estimated_bytes: usize,
 
+    /// The total number of rows in this chunk
+    pub row_count: usize,
+
     /// Time at which the first data was written into this chunk. Note
     /// this is not the same as the timestamps on the data itself
     pub time_of_first_write: Option<DateTime<Utc>>,
@@ -82,6 +85,7 @@ impl ChunkSummary {
         id: u32,
         storage: ChunkStorage,
         estimated_bytes: usize,
+        row_count: usize,
     ) -> Self {
         Self {
             partition_key,
@@ -89,6 +93,7 @@ impl ChunkSummary {
             id,
             storage,
             estimated_bytes,
+            row_count,
             time_of_first_write: None,
             time_of_last_write: None,
             time_closing: None,
@@ -105,6 +110,7 @@ impl From<ChunkSummary> for management::Chunk {
             id,
             storage,
             estimated_bytes,
+            row_count,
             time_of_first_write,
             time_of_last_write,
             time_closing,
@@ -114,6 +120,7 @@ impl From<ChunkSummary> for management::Chunk {
         let storage = storage.into(); // convert to i32
 
         let estimated_bytes = estimated_bytes as u64;
+        let row_count = row_count as u64;
 
         let partition_key = match Arc::try_unwrap(partition_key) {
             // no one else has a reference so take the string
@@ -138,6 +145,7 @@ impl From<ChunkSummary> for management::Chunk {
             id,
             storage,
             estimated_bytes,
+            row_count,
             time_of_first_write,
             time_of_last_write,
             time_closing,
@@ -197,10 +205,12 @@ impl TryFrom<management::Chunk> for ChunkSummary {
             table_name,
             id,
             estimated_bytes,
+            row_count,
             ..
         } = proto;
 
         let estimated_bytes = estimated_bytes as usize;
+        let row_count = row_count as usize;
         let partition_key = Arc::new(partition_key);
         let table_name = Arc::new(table_name);
 
@@ -210,6 +220,7 @@ impl TryFrom<management::Chunk> for ChunkSummary {
             id,
             storage,
             estimated_bytes,
+            row_count,
             time_of_first_write,
             time_of_last_write,
             time_closing,
@@ -245,6 +256,7 @@ mod test {
             table_name: "bar".to_string(),
             id: 42,
             estimated_bytes: 1234,
+            row_count: 321,
             storage: management::ChunkStorage::ObjectStoreOnly.into(),
             time_of_first_write: None,
             time_of_last_write: None,
@@ -257,6 +269,7 @@ mod test {
             table_name: Arc::new("bar".to_string()),
             id: 42,
             estimated_bytes: 1234,
+            row_count: 321,
             storage: ChunkStorage::ObjectStoreOnly,
             time_of_first_write: None,
             time_of_last_write: None,
@@ -277,6 +290,7 @@ mod test {
             table_name: Arc::new("bar".to_string()),
             id: 42,
             estimated_bytes: 1234,
+            row_count: 321,
             storage: ChunkStorage::ObjectStoreOnly,
             time_of_first_write: None,
             time_of_last_write: None,
@@ -290,6 +304,7 @@ mod test {
             table_name: "bar".to_string(),
             id: 42,
             estimated_bytes: 1234,
+            row_count: 321,
             storage: management::ChunkStorage::ObjectStoreOnly.into(),
             time_of_first_write: None,
             time_of_last_write: None,

--- a/generated_types/protos/influxdata/iox/management/v1/chunk.proto
+++ b/generated_types/protos/influxdata/iox/management/v1/chunk.proto
@@ -42,6 +42,9 @@ message Chunk {
   // The total estimated size of this chunk, in bytes
   uint64 estimated_bytes = 4;
 
+  // The number of rows in this chunk
+  uint64 row_count = 9;
+
   // Time at which the first data was written into this chunk. Note
   // this is not the same as the timestamps on the data itself
   google.protobuf.Timestamp time_of_first_write = 5;

--- a/mutable_buffer/src/chunk.rs
+++ b/mutable_buffer/src/chunk.rs
@@ -225,8 +225,13 @@ impl Chunk {
     /// Return the approximate memory size of the chunk, in bytes including the
     /// dictionary, tables, and their rows.
     pub fn size(&self) -> usize {
-        let data_size = self.tables.values().fold(0, |acc, val| acc + val.size());
+        let data_size: usize = self.tables.values().map(|t| t.size()).sum();
         data_size + self.dictionary.size()
+    }
+
+    /// Return the number of rows in this chunk
+    pub fn rows(&self) -> usize {
+        self.tables.values().map(|t| t.row_count()).sum()
     }
 
     /// Return true if this chunk has the specified table name

--- a/read_buffer/src/chunk.rs
+++ b/read_buffer/src/chunk.rs
@@ -75,15 +75,16 @@ pub struct Chunk {
     pub(crate) chunk_data: RwLock<TableData>,
 }
 
-// Tie data and meta-data together so that they can be wrapped in RWLock.
+/// Tie data and meta-data together so that they can be wrapped in RWLock.
 pub(crate) struct TableData {
-    rows: u64, // Total number of rows across all tables
+    /// Total number of rows across all tables
+    rows: u64,
 
-    // Total number of row groups across all tables in the chunk.
+    /// Total number of row groups across all tables in the chunk.
     row_groups: usize,
 
-    // The set of tables within this chunk. Each table is identified by a
-    // measurement name.
+    /// The set of tables within this chunk. Each table is identified by a
+    /// measurement name.
     data: BTreeMap<TableName, Table>,
 
     /// keep track of memory used by table data in chunk
@@ -170,7 +171,7 @@ impl Chunk {
     }
 
     /// The total number of rows in all row groups in all tables in this chunk.
-    pub(crate) fn rows(&self) -> u64 {
+    pub fn rows(&self) -> u64 {
         self.chunk_data.read().rows
     }
 

--- a/server/src/db.rs
+++ b/server/src/db.rs
@@ -1664,6 +1664,7 @@ mod tests {
                     id,
                     storage,
                     estimated_bytes,
+                    row_count,
                     ..
                 } = summary;
                 ChunkSummary::new_without_timestamps(
@@ -1672,6 +1673,7 @@ mod tests {
                     id,
                     storage,
                     estimated_bytes,
+                    row_count,
                 )
             })
             .collect::<Vec<_>>();
@@ -1705,6 +1707,7 @@ mod tests {
             0,
             ChunkStorage::OpenMutableBuffer,
             106,
+            1,
         )];
 
         let size: usize = db
@@ -1810,6 +1813,7 @@ mod tests {
                 0,
                 ChunkStorage::ReadBuffer,
                 1213,
+                1,
             ),
             ChunkSummary::new_without_timestamps(
                 to_arc("1970-01-01T00"),
@@ -1817,6 +1821,7 @@ mod tests {
                 1,
                 ChunkStorage::OpenMutableBuffer,
                 100,
+                1,
             ),
             ChunkSummary::new_without_timestamps(
                 to_arc("1970-01-05T15"),
@@ -1824,6 +1829,7 @@ mod tests {
                 0,
                 ChunkStorage::ClosedMutableBuffer,
                 129,
+                1,
             ),
             ChunkSummary::new_without_timestamps(
                 to_arc("1970-01-05T15"),
@@ -1831,6 +1837,7 @@ mod tests {
                 1,
                 ChunkStorage::OpenMutableBuffer,
                 131,
+                1,
             ),
         ];
 

--- a/server/src/query_tests/sql.rs
+++ b/server/src/query_tests/sql.rs
@@ -265,16 +265,16 @@ async fn sql_select_from_system_chunks() {
     //  test timestamps, etc)
 
     let expected = vec![
-        "+----+---------------+------------+-------------------+-----------------+",
-        "| id | partition_key | table_name | storage           | estimated_bytes |",
-        "+----+---------------+------------+-------------------+-----------------+",
-        "| 0  | 1970-01-01T00 | h2o        | OpenMutableBuffer | 257             |",
-        "| 0  | 1970-01-01T00 | o2         | OpenMutableBuffer | 221             |",
-        "+----+---------------+------------+-------------------+-----------------+",
+        "+----+---------------+------------+-------------------+-----------------+-----------+",
+        "| id | partition_key | table_name | storage           | estimated_bytes | row_count |",
+        "+----+---------------+------------+-------------------+-----------------+-----------+",
+        "| 0  | 1970-01-01T00 | h2o        | OpenMutableBuffer | 257             | 3         |",
+        "| 0  | 1970-01-01T00 | o2         | OpenMutableBuffer | 221             | 2         |",
+        "+----+---------------+------------+-------------------+-----------------+-----------+",
     ];
     run_sql_test_case!(
         TwoMeasurementsManyFieldsOneChunk {},
-        "SELECT id, partition_key, table_name, storage, estimated_bytes from system.chunks",
+        "SELECT id, partition_key, table_name, storage, estimated_bytes, row_count from system.chunks",
         &expected
     );
 }

--- a/tests/end_to_end_cases/management_api.rs
+++ b/tests/end_to_end_cases/management_api.rs
@@ -277,6 +277,7 @@ async fn test_chunk_get() {
             id: 0,
             storage: ChunkStorage::OpenMutableBuffer as i32,
             estimated_bytes: 132,
+            row_count: 2,
             time_of_first_write: None,
             time_of_last_write: None,
             time_closing: None,
@@ -287,6 +288,7 @@ async fn test_chunk_get() {
             id: 0,
             storage: ChunkStorage::OpenMutableBuffer as i32,
             estimated_bytes: 114,
+            row_count: 1,
             time_of_first_write: None,
             time_of_last_write: None,
             time_closing: None,
@@ -454,6 +456,7 @@ async fn test_list_partition_chunks() {
         id: 0,
         storage: ChunkStorage::OpenMutableBuffer as i32,
         estimated_bytes: 132,
+        row_count: 2,
         time_of_first_write: None,
         time_of_last_write: None,
         time_closing: None,
@@ -728,6 +731,7 @@ fn normalize_chunks(chunks: Vec<Chunk>) -> Vec<Chunk> {
                 id,
                 storage,
                 estimated_bytes,
+                row_count,
                 ..
             } = summary;
             Chunk {
@@ -736,6 +740,7 @@ fn normalize_chunks(chunks: Vec<Chunk>) -> Vec<Chunk> {
                 id,
                 storage,
                 estimated_bytes,
+                row_count,
                 time_of_first_write: None,
                 time_of_last_write: None,
                 time_closing: None,


### PR DESCRIPTION
# Rationale
I want to compute the storage consumption of data in IOx (bytes per row). While the row count exists in `system.columns` the DataFusion JOIN functionality is not good enough yet for me to calculate storage statistics directly (I can’t join in the table to get row counts).

Here is the join error for the morbidly curious:
```
select *
FROM
chunks JOIN columns using (database_name, partition)
limit 10;

Error running observer query: Error running observer query: Error during planning: Schema contains duplicate unqualified field name 'partition_key'
```