### PR TITLE
feat: add chunk size histogram

### DIFF
--- a/metrics/src/lib.rs
+++ b/metrics/src/lib.rs
@@ -22,7 +22,7 @@ use observability_deps::{
     tracing::*,
 };
 
-pub use crate::metrics::{Counter, KeyValue, RedMetric};
+pub use crate::metrics::{Counter, Histogram, KeyValue, RedMetric};
 pub use crate::tests::*;
 
 /// A registry responsible for initialising IOx metrics and exposing their

--- a/server/src/query_tests/utils.rs
+++ b/server/src/query_tests/utils.rs
@@ -40,18 +40,21 @@ pub fn make_db() -> TestDb {
 }
 
 /// Used for testing: create a Database with a local store and a specified name
-pub fn make_database(server_id: ServerId, object_store: Arc<ObjectStore>, db_name: &str) -> Db {
+pub fn make_database(server_id: ServerId, object_store: Arc<ObjectStore>, db_name: &str) -> TestDb {
     let exec = Arc::new(Executor::new(1));
     let metrics_registry = Arc::new(metrics::MetricRegistry::new());
-    Db::new(
-        DatabaseRules::new(DatabaseName::new(db_name.to_string()).unwrap()),
-        server_id,
-        object_store,
-        exec,
-        None, // write buffer
-        Arc::new(JobRegistry::new()),
-        metrics_registry,
-    )
+    TestDb {
+        metric_registry: metrics::TestMetricRegistry::new(Arc::clone(&metrics_registry)),
+        db: Db::new(
+            DatabaseRules::new(DatabaseName::new(db_name.to_string()).unwrap()),
+            server_id,
+            object_store,
+            exec,
+            None, // write buffer
+            Arc::new(JobRegistry::new()),
+            metrics_registry,
+        ),
+    }
 }
 
 fn chunk_summary_iter(db: &Db) -> impl Iterator<Item = ChunkSummary> + '_ {


### PR DESCRIPTION
Contributes to #1370

This PR adds a new histogram metric to track the size of newly created chunks (that is, chunks that have moved to a new _stage_). It purposely only focusses on immutable chunks:

 - MUB chunks just as they begin their movement into RB chunks;
 - RB chunks;
 - Parquet chunks.

These metrics would probably be nicely completemented by gauges that track the current size of all chunks in each stage. 