### PR TITLE
refactor: remove additional uses of RecordBatch::try_new

### DIFF
--- a/arrow_deps/src/util.rs
+++ b/arrow_deps/src/util.rs
@@ -5,7 +5,6 @@ use std::sync::Arc;
 
 use arrow::{
     array::{ArrayRef, StringArray},
-    datatypes::{DataType, Field, Schema},
     error::ArrowError,
     record_batch::RecordBatch,
 };
@@ -22,15 +21,9 @@ where
     I: IntoIterator<Item = Option<Ptr>>,
     Ptr: AsRef<str>,
 {
-    let schema = Arc::new(Schema::new(vec![Field::new(
-        field_name,
-        DataType::Utf8,
-        false,
-    )]));
     let array = StringArray::from_iter(iter);
-    let columns: Vec<ArrayRef> = vec![Arc::new(array)];
 
-    RecordBatch::try_new(schema, columns)
+    RecordBatch::try_from_iter(vec![(field_name, Arc::new(array) as ArrayRef)])
 }
 
 /// Traits to help creating DataFusion expressions from strings

--- a/query/src/provider/adapter.rs
+++ b/query/src/provider/adapter.rs
@@ -229,7 +229,7 @@ mod tests {
     use super::*;
     use arrow_deps::{
         arrow::{
-            array::{Array, Int32Array, StringArray},
+            array::{ArrayRef, Int32Array, StringArray},
             datatypes::{Field, Schema},
             record_batch::RecordBatch,
         },
@@ -362,12 +362,7 @@ mod tests {
         let col_b = Arc::new(Int32Array::from(vec![4, 5, 6]));
         let col_c = Arc::new(StringArray::from(vec!["foo", "bar", "baz"]));
 
-        let schema = Schema::new(vec![
-            Field::new("a", col_a.data_type().clone(), false),
-            Field::new("b", col_b.data_type().clone(), false),
-            Field::new("c", col_c.data_type().clone(), false),
-        ]);
-
-        RecordBatch::try_new(Arc::new(schema), vec![col_a, col_b, col_c]).unwrap()
+        RecordBatch::try_from_iter(vec![("a", col_a as ArrayRef), ("b", col_b), ("c", col_c)])
+            .unwrap()
     }
 }

--- a/read_buffer/benches/database.rs
+++ b/read_buffer/benches/database.rs
@@ -115,7 +115,7 @@ fn generate_row_group(rows: usize) -> RecordBatch {
         )),
     ];
 
-    RecordBatch::try_new(schema.into(), data).unwrap()
+x    RecordBatch::try_new(schema.into(), data).unwrap()
 }
 
 criterion_group!(benches, table_names);

--- a/read_buffer/benches/database.rs
+++ b/read_buffer/benches/database.rs
@@ -115,7 +115,7 @@ fn generate_row_group(rows: usize) -> RecordBatch {
         )),
     ];
 
-x    RecordBatch::try_new(schema.into(), data).unwrap()
+    RecordBatch::try_new(schema.into(), data).unwrap()
 }
 
 criterion_group!(benches, table_names);

--- a/tests/end_to_end_cases/scenario.rs
+++ b/tests/end_to_end_cases/scenario.rs
@@ -206,21 +206,13 @@ impl Scenario {
         );
         let value_array = Float64Array::from(vec![0.64, 27.99, 3.89, 1234567.891011, 0.000003]);
 
-        let schema = Schema::new(vec![
-            Field::new("host", host_array.data_type().clone(), true),
-            Field::new("region", region_array.data_type().clone(), true),
-            Field::new("time", time_array.data_type().clone(), true),
-            Field::new("value", value_array.data_type().clone(), true),
-        ]);
-
-        let columns: Vec<ArrayRef> = vec![
-            Arc::new(host_array),
-            Arc::new(region_array),
-            Arc::new(time_array),
-            Arc::new(value_array),
-        ];
-
-        let batch = RecordBatch::try_new(Arc::new(schema), columns).unwrap();
+        let batch = RecordBatch::try_from_iter_with_nullable(vec![
+            ("host", Arc::new(host_array) as ArrayRef, true),
+            ("region", Arc::new(region_array), true),
+            ("time", Arc::new(time_array), true),
+            ("value", Arc::new(value_array), true),
+        ])
+        .unwrap();
 
         arrow_deps::arrow::util::pretty::pretty_format_batches(&[batch])
             .unwrap()

--- a/tests/end_to_end_cases/scenario.rs
+++ b/tests/end_to_end_cases/scenario.rs
@@ -17,8 +17,7 @@ use data_types::{names::org_and_bucket_to_database, DatabaseName};
 use generated_types::{influxdata::iox::management::v1::DatabaseRules, ReadSource, TimestampRange};
 
 use arrow_deps::arrow::{
-    array::{Array, ArrayRef, Float64Array, StringArray, TimestampNanosecondArray},
-    datatypes::{Field, Schema},
+    array::{ArrayRef, Float64Array, StringArray, TimestampNanosecondArray},
     record_batch::RecordBatch,
 };
 


### PR DESCRIPTION
Similar to https://github.com/influxdata/influxdb_iox/pull/1374

This has been bugging me for a long time (the redundancy in creating `RecordBatch`es -- hopefully this PR will make it is people in IOx follow the nicer pattern. 
