### PR TITLE
feat: add a id() method to `management::Operations` 

### DIFF
--- a/generated_types/src/google.rs
+++ b/generated_types/src/google.rs
@@ -10,18 +10,16 @@ pub mod rpc {
 pub mod longrunning {
     include!(concat!(env!("OUT_DIR"), "/google.longrunning.rs"));
 
-
     impl Operation {
         /// Return the IOx operation `id`. This `id` can
         /// be passed to the various APIs in the
-        /// operations client [`wait_operation`];
+        /// operations client such as [`wait_operation`];
         pub fn id(&self) -> usize {
             self.name
                 .parse()
                 .expect("Internal error: id returned from server was not an integer")
         }
     }
-
 }
 
 use self::protobuf::Any;

--- a/generated_types/src/google.rs
+++ b/generated_types/src/google.rs
@@ -9,6 +9,19 @@ pub mod rpc {
 
 pub mod longrunning {
     include!(concat!(env!("OUT_DIR"), "/google.longrunning.rs"));
+
+
+    impl Operation {
+        /// Return the IOx operation `id`. This `id` can
+        /// be passed to the various APIs in the
+        /// operations client [`wait_operation`];
+        pub fn id(&self) -> usize {
+            self.name
+                .parse()
+                .expect("Internal error: id returned from server was not an integer")
+        }
+    }
+
 }
 
 use self::protobuf::Any;

--- a/generated_types/src/google.rs
+++ b/generated_types/src/google.rs
@@ -13,7 +13,7 @@ pub mod longrunning {
     impl Operation {
         /// Return the IOx operation `id`. This `id` can
         /// be passed to the various APIs in the
-        /// operations client such as [`wait_operation`];
+        /// operations client such as `influxdb_iox_client::operations::Client::wait_operation`;
         pub fn id(&self) -> usize {
             self.name
                 .parse()

--- a/tests/end_to_end_cases/management_api.rs
+++ b/tests/end_to_end_cases/management_api.rs
@@ -622,7 +622,7 @@ async fn test_close_partition_chunk() {
         .expect("new partition chunk");
 
     println!("Operation response is {:?}", operation);
-    let operation_id = operation.name.parse().expect("not an integer");
+    let operation_id = operation.id();
 
     let meta = operations::ClientOperation::try_new(operation)
         .unwrap()

--- a/tests/end_to_end_cases/sql_cli.rs
+++ b/tests/end_to_end_cases/sql_cli.rs
@@ -267,12 +267,11 @@ async fn test_sql_observer_operations() {
         .expect("new partition chunk");
 
     println!("Operation response is {:?}", operation);
-    let operation_id = operation.name.parse().expect("not an integer");
 
     // wait for the job to be done
     fixture
         .operations_client()
-        .wait_operation(operation_id, Some(std::time::Duration::from_secs(1)))
+        .wait_operation(operation.id(), Some(std::time::Duration::from_secs(1)))
         .await
         .expect("failed to wait operation");
 

--- a/tests/end_to_end_cases/system_tables.rs
+++ b/tests/end_to_end_cases/system_tables.rs
@@ -32,7 +32,7 @@ async fn test_operations() {
         .await
         .expect("new partition chunk");
 
-    let operation_id = operation.name.parse().expect("not an integer");
+    let operation_id = operation.id();
     operations_client
         .wait_operation(operation_id, Some(std::time::Duration::from_secs(1)))
         .await


### PR DESCRIPTION
# Rationale
It is awkward to use the operation client and wait for it to be done. Initially, the challenge is that the `id` passed to `wait_operation` is an integer, but to get it the user needs to parse a String from the response.

It is also annoying to have to instantiate a new client type to wait on an operation created by `management::Client` but perhaps I'll fix that some other time.

Here is an example of having to interpret `name` as an `id`:
```
    let mut management_client = fixture.management_client();

    let operation = management_client
        .close_partition_chunk(&db_name, partition_key, table_name, 0)
        .await
        .expect("new partition chunk");

    let operation_id = operation.name.parse().expect("not an integer");

    // wait for the job to be done
    fixture.operations_client()
        .wait_operation(operation_id, Some(std::time::Duration::from_secs(1)))
        .await
        .expect("failed to wait operation");
```

# Changes
1. Add a `id()` method to Operation to get the requested `operation_id` (rather than requiring the user to parse a `name` into a string)
