### PR TITLE
fix: set nullability correctly for system tables

### DIFF
--- a/server/src/db/system_tables.rs
+++ b/server/src/db/system_tables.rs
@@ -111,16 +111,16 @@ fn from_chunk_summaries(chunks: Vec<ChunkSummary>) -> Result<RecordBatch> {
     let time_closing =
         TimestampNanosecondArray::from_iter(chunks.iter().map(|c| c.time_closing).map(time_to_ts));
 
-    RecordBatch::try_from_iter(vec![
-        ("id", Arc::new(id) as ArrayRef),
-        ("partition_key", Arc::new(partition_key)),
-        ("table_name", Arc::new(table_name)),
-        ("storage", Arc::new(storage)),
-        ("estimated_bytes", Arc::new(estimated_bytes)),
-        ("row_count", Arc::new(row_counts)),
-        ("time_of_first_write", Arc::new(time_of_first_write)),
-        ("time_of_last_write", Arc::new(time_of_last_write)),
-        ("time_closing", Arc::new(time_closing)),
+    RecordBatch::try_from_iter_with_nullable(vec![
+        ("id", Arc::new(id) as ArrayRef, false),
+        ("partition_key", Arc::new(partition_key), false),
+        ("table_name", Arc::new(table_name), false),
+        ("storage", Arc::new(storage), false),
+        ("estimated_bytes", Arc::new(estimated_bytes), false),
+        ("row_count", Arc::new(row_counts), false),
+        ("time_of_first_write", Arc::new(time_of_first_write), true),
+        ("time_of_last_write", Arc::new(time_of_last_write), true),
+        ("time_closing", Arc::new(time_closing), true),
     ])
 }
 
@@ -182,14 +182,14 @@ fn from_task_trackers(db_name: &str, jobs: Vec<TaskTracker<Job>>) -> Result<Reco
     let descriptions =
         StringArray::from_iter(jobs.iter().map(|job| Some(job.metadata().description())));
 
-    RecordBatch::try_from_iter(vec![
-        ("id", Arc::new(ids) as ArrayRef),
-        ("status", Arc::new(statuses)),
-        ("cpu_time_used", Arc::new(cpu_time_used)),
-        ("wall_time_used", Arc::new(wall_time_used)),
-        ("partition_key", Arc::new(partition_keys)),
-        ("chunk_id", Arc::new(chunk_ids)),
-        ("description", Arc::new(descriptions)),
+    RecordBatch::try_from_iter_with_nullable(vec![
+        ("id", Arc::new(ids) as ArrayRef, false),
+        ("status", Arc::new(statuses), true),
+        ("cpu_time_used", Arc::new(cpu_time_used), true),
+        ("wall_time_used", Arc::new(wall_time_used), true),
+        ("partition_key", Arc::new(partition_keys), true),
+        ("chunk_id", Arc::new(chunk_ids), true),
+        ("description", Arc::new(descriptions), true),
     ])
 }
 


### PR DESCRIPTION
# Problem
Fixes bug introduced in https://github.com/influxdata/influxdb_iox/pull/1374 and https://github.com/influxdata/influxdb_iox/pull/1373

I used an API that set column nullability based on the actual contents of the record batch for creating system tables. However some of these RecordBatches don't have nulls in their columns, resulting in schemas that can differ in their nullability.

# Fix
Ensure that all system tables have the same schema nullability, regardless of the data

A better fix would be to merge the schemas more diligently in observer (so it doesn't error about a mismatch in schema) but for now ensuring the system tables all have the same schema )

# Example Error
I now get the following error trying to created aggregated system table views: 

```
alamb@ip-10-0-0-124:~/Software/influxdb_iox$ ./target/debug/influxdb_iox sql --host http://localhost:1234
Connected to IOx Server at http://localhost:1234
Ready for commands. (Hint: try 'help;')
> observer;
Preparing local views of remote system tables
Loading system tables from 49 databases
...................................................................................................................................................
 Completed in 1.64034412s
thread 'main' panicked at 'creating memtable: Plan("Mismatch between schema and batches")', src/commands/sql/observer.rs:294:62
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```


- [x] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb_iox/blob/main/README.md).
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
