### PR TITLE
feat: Add gauge metric

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1825,6 +1825,7 @@ dependencies = [
 name = "metrics"
 version = "0.1.0"
 dependencies = [
+ "dashmap",
  "observability_deps",
  "snafu",
 ]

--- a/metrics/Cargo.toml
+++ b/metrics/Cargo.toml
@@ -4,18 +4,19 @@ version = "0.1.0"
 authors = ["Edd Robinson <me@edd.io>"]
 edition = "2018"
 
-# This crate contains the application-specific abstraction of the metrics 
-# implementation for IOx. Any crate that wants to expose telemetry should use 
-# this crate. 
+# This crate contains the application-specific abstraction of the metrics
+# implementation for IOx. Any crate that wants to expose telemetry should use
+# this crate.
 #
-# The crate exposes a special type of metrics registry which allows users to 
-# isolate their metrics from the rest of the system so they can be tested 
+# The crate exposes a special type of metrics registry which allows users to
+# isolate their metrics from the rest of the system so they can be tested
 # in isolation.
 
 
 [dependencies] # In alphabetical order
 observability_deps = { path = "../observability_deps" }
 snafu = "0.6"
+dashmap = { version = "4.0.1" }
 
 [dev-dependencies] # In alphabetical order
 


### PR DESCRIPTION
This PR implements a Gauge metric + all the testing helpers that will allow us to test the code that uses gauges.

It's correct to think of this gauge implementation as a hack.
It's possible to spend more time and figure out how to do this "the right" way,
but I really think we need gauges right now.

On the upside, I think that the API is going to be stable even once we figure out the "right way" to plumb this into opentelemetry.