### PR TITLE
feat: allow gauges to be increased or decreased

### DIFF
--- a/metrics/src/lib.rs
+++ b/metrics/src/lib.rs
@@ -24,7 +24,7 @@ use observability_deps::{
 };
 use std::sync::Arc;
 
-pub use crate::metrics::{Counter, Histogram, KeyValue, RedMetric};
+pub use crate::metrics::{Counter, Gauge, Histogram, KeyValue, RedMetric};
 pub use crate::tests::*;
 
 /// A registry responsible for initialising IOx metrics and exposing their
@@ -702,5 +702,26 @@ mod test {
             ]
             .join("\n")
         );
+
+        metric.add_with_labels(100, &[KeyValue::new("me", "new")]);
+        reg.has_metric_family("http_mem_bytes")
+            .with_labels(&[("tier", "a"), ("me", "new")])
+            .gauge()
+            .eq(100.0)
+            .unwrap();
+
+        metric.add_with_labels(11, &[KeyValue::new("me", "new")]);
+        reg.has_metric_family("http_mem_bytes")
+            .with_labels(&[("tier", "a"), ("me", "new")])
+            .gauge()
+            .eq(111.0)
+            .unwrap();
+
+        metric.sub(11);
+        reg.has_metric_family("http_mem_bytes")
+            .with_labels(&[("tier", "a")])
+            .gauge()
+            .eq(29.0)
+            .unwrap();
     }
 }

--- a/metrics/src/lib.rs
+++ b/metrics/src/lib.rs
@@ -315,7 +315,7 @@ impl Domain {
         let values_captured = Arc::clone(&values);
         let gauge = self
             .meter
-            .u64_value_observer(
+            .f64_value_observer(
                 match unit {
                     Some(unit) => {
                         format!("{}.{}", self.build_metric_prefix(name, None), unit)
@@ -325,7 +325,7 @@ impl Domain {
                 move |arg| {
                     for i in values_captured.iter() {
                         // currently rust type inference cannot deduct the type of i.value()
-                        let i: RefMulti<'_, _, (u64, Vec<KeyValue>), _> = i;
+                        let i: RefMulti<'_, _, (f64, Vec<KeyValue>), _> = i;
                         let &(value, ref labels) = i.value();
                         arg.observe(value, labels);
                     }
@@ -663,13 +663,13 @@ mod test {
             vec![KeyValue::new("tier", "a")],
         );
 
-        metric.set(40);
-        metric.set_with_labels(41, &[KeyValue::new("tier", "b")]);
+        metric.set(40.0);
+        metric.set_with_labels(41.0, &[KeyValue::new("tier", "b")]);
         metric.set_with_labels(
-            42,
+            42.0,
             &[KeyValue::new("tier", "c"), KeyValue::new("tier", "b")],
         );
-        metric.set_with_labels(43, &[KeyValue::new("beer", "c")]);
+        metric.set_with_labels(43.0, &[KeyValue::new("beer", "c")]);
 
         reg.has_metric_family("http_mem_bytes")
             .with_labels(&[("tier", "a")])
@@ -703,21 +703,21 @@ mod test {
             .join("\n")
         );
 
-        metric.add_with_labels(100, &[KeyValue::new("me", "new")]);
+        metric.add_with_labels(100.0, &[KeyValue::new("me", "new")]);
         reg.has_metric_family("http_mem_bytes")
             .with_labels(&[("tier", "a"), ("me", "new")])
             .gauge()
             .eq(100.0)
             .unwrap();
 
-        metric.add_with_labels(11, &[KeyValue::new("me", "new")]);
+        metric.add_with_labels(11.0, &[KeyValue::new("me", "new")]);
         reg.has_metric_family("http_mem_bytes")
             .with_labels(&[("tier", "a"), ("me", "new")])
             .gauge()
             .eq(111.0)
             .unwrap();
 
-        metric.sub(11);
+        metric.sub(11.0);
         reg.has_metric_family("http_mem_bytes")
             .with_labels(&[("tier", "a")])
             .gauge()

--- a/metrics/src/metrics.rs
+++ b/metrics/src/metrics.rs
@@ -284,16 +284,16 @@ impl Counter {
 /// (e.g. current memory usage)
 #[derive(Debug)]
 pub struct Gauge {
-    gauge: OTGauge<u64>,
+    gauge: OTGauge<f64>,
     default_labels: Vec<KeyValue>,
-    values: Arc<DashMap<String, (u64, Vec<KeyValue>)>>,
+    values: Arc<DashMap<String, (f64, Vec<KeyValue>)>>,
 }
 
 impl Gauge {
     pub(crate) fn new(
-        gauge: OTGauge<u64>,
+        gauge: OTGauge<f64>,
         default_labels: Vec<KeyValue>,
-        values: Arc<DashMap<String, (u64, Vec<KeyValue>)>>,
+        values: Arc<DashMap<String, (f64, Vec<KeyValue>)>>,
     ) -> Self {
         Self {
             gauge,
@@ -303,13 +303,13 @@ impl Gauge {
     }
 
     // Set the gauge's `value`
-    pub fn set(&self, value: u64) {
+    pub fn set(&self, value: f64) {
         self.set_with_labels(value, &[]);
     }
 
     /// Set the gauge's `value` and associate the observation with the
     /// provided labels.
-    pub fn set_with_labels(&self, value: u64, labels: &[KeyValue]) {
+    pub fn set_with_labels(&self, value: f64, labels: &[KeyValue]) {
         // Note: provided labels need to go last so that they overwrite
         // any default labels.
 
@@ -324,13 +324,13 @@ impl Gauge {
     }
 
     // Increase the gauge's value by `value`.
-    pub fn add(&self, value: u64) {
+    pub fn add(&self, value: f64) {
         self.add_with_labels(value, &[]);
     }
 
     /// Increase the gauge's value by `value` and associate the observation with the
     /// provided labels.
-    pub fn add_with_labels(&self, value: u64, labels: &[KeyValue]) {
+    pub fn add_with_labels(&self, value: f64, labels: &[KeyValue]) {
         // Note: provided labels need to go last so that they overwrite
         // any default labels.
 
@@ -355,34 +355,14 @@ impl Gauge {
     }
 
     // Decrease the gauge's value by `value`.
-    pub fn sub(&self, value: u64) {
+    pub fn sub(&self, value: f64) {
         self.sub_with_labels(value, &[]);
     }
 
     /// Decrease the gauge's value by `value` and associate the observation with the
     /// provided labels.
-    pub fn sub_with_labels(&self, value: u64, labels: &[KeyValue]) {
-        // Note: provided labels need to go last so that they overwrite
-        // any default labels.
-
-        let mut labels_new = self.default_labels.clone();
-        labels_new.extend(labels.iter().cloned());
-
-        // this may seem inefficient but it's nothing compared to this and more that happens in the
-        // internals of opentelemetry. There's lots of room for improvement everywhere.
-        let label_set = labels::LabelSet::from_labels(labels_new.iter().cloned());
-        let encoded_labels = label_set.encoded(Some(&labels::DefaultLabelEncoder));
-
-        // update value
-        match self.values.entry(encoded_labels) {
-            dashmap::mapref::entry::Entry::Occupied(mut entry) => {
-                let (current_value, _) = entry.get_mut();
-                *current_value -= value;
-            }
-            dashmap::mapref::entry::Entry::Vacant(entry) => {
-                entry.insert((value, labels_new));
-            }
-        }
+    pub fn sub_with_labels(&self, value: f64, labels: &[KeyValue]) {
+        self.add_with_labels(-value, labels);
     }
 }
 


### PR DESCRIPTION
Contributes to #1391 

This PR adds `add` and `sub` methods on a gauge, allowing gauges to be increased or decreased. I also changed the type of gauges from `u64` to `f64` to support this.