### PR TITLE
refactor: rename closing to closed

### DIFF
--- a/data_types/src/chunk.rs
+++ b/data_types/src/chunk.rs
@@ -72,7 +72,7 @@ pub struct ChunkSummary {
     /// itself
     pub time_of_last_write: Option<DateTime<Utc>>,
 
-    /// Time at which this chunk was marked as closing. Note this is
+    /// Time at which this chunk was marked as closed. Note this is
     /// not the same as the timestamps on the data itself
     pub time_closed: Option<DateTime<Utc>>,
 }
@@ -196,7 +196,7 @@ impl TryFrom<management::Chunk> for ChunkSummary {
             .map(TryInto::try_into)
             .transpose()
             .map_err(|_| FieldViolation {
-                field: "time_closing".to_string(),
+                field: "time_closed".to_string(),
                 description: "Timestamp must be positive".to_string(),
             })?;
 

--- a/data_types/src/chunk.rs
+++ b/data_types/src/chunk.rs
@@ -74,7 +74,7 @@ pub struct ChunkSummary {
 
     /// Time at which this chunk was marked as closing. Note this is
     /// not the same as the timestamps on the data itself
-    pub time_closing: Option<DateTime<Utc>>,
+    pub time_closed: Option<DateTime<Utc>>,
 }
 
 impl ChunkSummary {
@@ -96,7 +96,7 @@ impl ChunkSummary {
             row_count,
             time_of_first_write: None,
             time_of_last_write: None,
-            time_closing: None,
+            time_closed: None,
         }
     }
 }
@@ -113,7 +113,7 @@ impl From<ChunkSummary> for management::Chunk {
             row_count,
             time_of_first_write,
             time_of_last_write,
-            time_closing,
+            time_closed,
         } = summary;
 
         let storage: management::ChunkStorage = storage.into();
@@ -137,7 +137,7 @@ impl From<ChunkSummary> for management::Chunk {
 
         let time_of_first_write = time_of_first_write.map(|t| t.into());
         let time_of_last_write = time_of_last_write.map(|t| t.into());
-        let time_closing = time_closing.map(|t| t.into());
+        let time_closed = time_closed.map(|t| t.into());
 
         Self {
             partition_key,
@@ -148,7 +148,7 @@ impl From<ChunkSummary> for management::Chunk {
             row_count,
             time_of_first_write,
             time_of_last_write,
-            time_closing,
+            time_closed,
         }
     }
 }
@@ -191,8 +191,8 @@ impl TryFrom<management::Chunk> for ChunkSummary {
                 description: "Timestamp must be positive".to_string(),
             })?;
 
-        let time_closing = proto
-            .time_closing
+        let time_closed = proto
+            .time_closed
             .map(TryInto::try_into)
             .transpose()
             .map_err(|_| FieldViolation {
@@ -223,7 +223,7 @@ impl TryFrom<management::Chunk> for ChunkSummary {
             row_count,
             time_of_first_write,
             time_of_last_write,
-            time_closing,
+            time_closed,
         })
     }
 }
@@ -260,7 +260,7 @@ mod test {
             storage: management::ChunkStorage::ObjectStoreOnly.into(),
             time_of_first_write: None,
             time_of_last_write: None,
-            time_closing: None,
+            time_closed: None,
         };
 
         let summary = ChunkSummary::try_from(proto).expect("conversion successful");
@@ -273,7 +273,7 @@ mod test {
             storage: ChunkStorage::ObjectStoreOnly,
             time_of_first_write: None,
             time_of_last_write: None,
-            time_closing: None,
+            time_closed: None,
         };
 
         assert_eq!(
@@ -294,7 +294,7 @@ mod test {
             storage: ChunkStorage::ObjectStoreOnly,
             time_of_first_write: None,
             time_of_last_write: None,
-            time_closing: None,
+            time_closed: None,
         };
 
         let proto = management::Chunk::try_from(summary).expect("conversion successful");
@@ -308,7 +308,7 @@ mod test {
             storage: management::ChunkStorage::ObjectStoreOnly.into(),
             time_of_first_write: None,
             time_of_last_write: None,
-            time_closing: None,
+            time_closed: None,
         };
 
         assert_eq!(

--- a/data_types/src/database_rules.rs
+++ b/data_types/src/database_rules.rs
@@ -178,7 +178,7 @@ pub struct LifecycleRules {
     /// this many seconds will be frozen and compacted (moved to the read
     /// buffer) if the chunk is older than mutable_min_lifetime_seconds
     ///
-    /// Represents the chunk transition open -> moving and closing -> moving
+    /// Represents the chunk transition open -> moving and closed -> moving
     pub mutable_linger_seconds: Option<NonZeroU32>,
 
     /// A chunk of data within a partition is guaranteed to remain mutable

--- a/generated_types/protos/influxdata/iox/management/v1/chunk.proto
+++ b/generated_types/protos/influxdata/iox/management/v1/chunk.proto
@@ -54,8 +54,8 @@ message Chunk {
   // itself
   google.protobuf.Timestamp time_of_last_write = 6;
 
-  /// Time at which this chunk was marked as closing. Note this is not
+  /// Time at which this chunk was marked as closed. Note this is not
   /// the same as the timestamps on the data itself
-  google.protobuf.Timestamp time_closing = 7;
+  google.protobuf.Timestamp time_closed = 7;
 
 }

--- a/generated_types/protos/influxdata/iox/management/v1/database_rules.proto
+++ b/generated_types/protos/influxdata/iox/management/v1/database_rules.proto
@@ -120,7 +120,7 @@ message LifecycleRules {
   // many seconds will be frozen and compacted (moved to the read buffer)
   // if the chunk is older than mutable_min_lifetime_seconds
   //
-  // Represents the chunk transition open -> moving and closing -> moving
+  // Represents the chunk transition open -> moving and closed -> moving
   uint32 mutable_linger_seconds = 1;
 
   // A chunk of data within a partition is guaranteed to remain mutable

--- a/server/src/db.rs
+++ b/server/src/db.rs
@@ -326,7 +326,7 @@ struct DbMetrics {
     catalog_chunks: metrics::Counter,
 
     // Tracks a distribution of sizes in bytes of chunks as they're moved into
-    // various immutable stages in IOx: closing/moving in the MUB, in the RB,
+    // various immutable stages in IOx: closed/moving in the MUB, in the RB,
     // and in Parquet.
     catalog_immutable_chunk_bytes: metrics::Histogram,
 }
@@ -499,7 +499,7 @@ impl Db {
             })
     }
 
-    /// Copies a chunk in the Closing state into the ReadBuffer from
+    /// Copies a chunk in the Closed state into the ReadBuffer from
     /// the mutable buffer and marks the chunk with `Moved` state
     ///
     /// This code does not do any checking of the read buffer against
@@ -783,7 +783,7 @@ impl Db {
                 return Err(e);
             }
 
-            debug!(%name, %partition_key, %table_name, %chunk_id, "background task completed closing chunk");
+            debug!(%name, %partition_key, %table_name, %chunk_id, "background task completed loading chunk to read buffer");
 
             Ok(())
         };
@@ -963,7 +963,7 @@ impl Db {
                                     chunk_id,
                                 })?;
 
-                            check_chunk_closing(chunk, mutable_size_threshold, &self.metrics);
+                            check_chunk_closed(chunk, mutable_size_threshold, &self.metrics);
                         }
                         None => {
                             let new_chunk = partition
@@ -976,7 +976,7 @@ impl Db {
                                 .context(OpenEntry { partition_key })?;
                             self.metrics.update_chunk_state(new_chunk.read().state()); // track new chunk
 
-                            check_chunk_closing(
+                            check_chunk_closed(
                                 new_chunk.write(),
                                 mutable_size_threshold,
                                 &self.metrics,
@@ -992,9 +992,7 @@ impl Db {
 }
 
 /// Check if the given chunk should be closed based on the the MutableBuffer size threshold.
-///
-/// If the chunk should be closed, it will be set to "closing",
-fn check_chunk_closing(
+fn check_chunk_closed(
     mut chunk: RwLockWriteGuard<'_, RawRwLock, CatalogChunk>,
     mutable_size_threshold: Option<NonZeroUsize>,
     metrics: &DbMetrics,
@@ -1191,13 +1189,13 @@ mod tests {
 
         db.rollover_partition("1970-01-01T00", "cpu").await.unwrap();
 
-        // A chunk is now closing
+        // A chunk is now closed
         test_db
             .metric_registry
             .has_metric_family("catalog_chunks_total")
             .with_labels(&[
                 ("db_name", "placeholder"),
-                ("state", "closing"),
+                ("state", "closed"),
                 ("svr_id", "1"),
             ])
             .counter()
@@ -1214,7 +1212,7 @@ mod tests {
             .has_metric_family("catalog_chunks_total")
             .with_labels(&[
                 ("db_name", "placeholder"),
-                ("state", "closing"),
+                ("state", "closed"),
                 ("svr_id", "1"),
             ])
             .counter()

--- a/server/src/db/catalog/chunk.rs
+++ b/server/src/db/catalog/chunk.rs
@@ -98,7 +98,7 @@ pub struct Chunk {
     /// itself
     time_of_last_write: Option<DateTime<Utc>>,
 
-    /// Time at which this chunk was maked as closing. Note this is
+    /// Time at which this chunk was maked as closed. Note this is
     /// not the same as the timestamps on the data itself
     time_closed: Option<DateTime<Utc>>,
 }
@@ -301,14 +301,14 @@ impl Chunk {
     }
 
     /// Returns a mutable reference to the mutable buffer storage for
-    /// chunks in the Open or Closing state
+    /// chunks in the Open or Closed state
     ///
-    /// Must be in open or closing state
+    /// Must be in open or closed state
     pub fn mutable_buffer(&mut self) -> Result<&mut MBChunk> {
         match &mut self.state {
             ChunkState::Open(chunk) => Ok(chunk),
             ChunkState::Closed(chunk) => Ok(chunk),
-            state => unexpected_state!(self, "mutable buffer reference", "Open or Closing", state),
+            state => unexpected_state!(self, "mutable buffer reference", "Open or Closed", state),
         }
     }
 
@@ -326,7 +326,7 @@ impl Chunk {
             }
             state => {
                 self.state = state;
-                unexpected_state!(self, "setting closing", "Open or Closing", &self.state)
+                unexpected_state!(self, "setting closed", "Open or Closed", &self.state)
             }
         }
     }
@@ -345,7 +345,7 @@ impl Chunk {
             }
             state => {
                 self.state = state;
-                unexpected_state!(self, "setting moving", "Open or Closing", &self.state)
+                unexpected_state!(self, "setting moving", "Open or Closed", &self.state)
             }
         }
     }

--- a/server/src/db/catalog/chunk.rs
+++ b/server/src/db/catalog/chunk.rs
@@ -26,8 +26,8 @@ pub enum ChunkState {
     /// Chunk can accept new writes
     Open(MBChunk),
 
-    /// Chunk can still accept new writes, but will likely be closed soon
-    Closing(MBChunk),
+    /// Chunk is closed for new writes
+    Closed(MBChunk),
 
     /// Chunk is closed for new writes, and is actively moving to the read
     /// buffer
@@ -50,7 +50,7 @@ impl ChunkState {
         match self {
             Self::Invalid => "Invalid",
             Self::Open(_) => "Open",
-            Self::Closing(_) => "Closing",
+            Self::Closed(_) => "Closed",
             Self::Moving(_) => "Moving",
             Self::Moved(_) => "Moved",
             Self::WritingToObjectStore(_) => "Writing to Object Store",
@@ -63,7 +63,7 @@ impl ChunkState {
         match self {
             Self::Invalid => "invalid",
             Self::Open(_) => "open",
-            Self::Closing(_) => "closing",
+            Self::Closed(_) => "closed",
             Self::Moving(_) => "moving",
             Self::Moved(_) => "moved",
             Self::WritingToObjectStore(_) => "writing_os",
@@ -100,7 +100,7 @@ pub struct Chunk {
 
     /// Time at which this chunk was maked as closing. Note this is
     /// not the same as the timestamps on the data itself
-    time_closing: Option<DateTime<Utc>>,
+    time_closed: Option<DateTime<Utc>>,
 }
 
 macro_rules! unexpected_state {
@@ -152,7 +152,7 @@ impl Chunk {
             state,
             time_of_first_write: None,
             time_of_last_write: None,
-            time_closing: None,
+            time_closed: None,
         };
         chunk.record_write();
         Ok(chunk)
@@ -193,8 +193,8 @@ impl Chunk {
         self.time_of_last_write
     }
 
-    pub fn time_closing(&self) -> Option<DateTime<Utc>> {
-        self.time_closing
+    pub fn time_closed(&self) -> Option<DateTime<Utc>> {
+        self.time_closed
     }
 
     /// Update the write timestamps for this chunk
@@ -213,7 +213,7 @@ impl Chunk {
             ChunkState::Open(chunk) => {
                 (chunk.size(), chunk.rows(), ChunkStorage::OpenMutableBuffer)
             }
-            ChunkState::Closing(chunk) => (
+            ChunkState::Closed(chunk) => (
                 chunk.size(),
                 chunk.rows(),
                 ChunkStorage::ClosedMutableBuffer,
@@ -249,7 +249,7 @@ impl Chunk {
             row_count,
             time_of_first_write: self.time_of_first_write,
             time_of_last_write: self.time_of_last_write,
-            time_closing: self.time_closing,
+            time_closed: self.time_closed,
         }
     }
 
@@ -257,7 +257,7 @@ impl Chunk {
     pub fn table_summary(&self) -> TableSummary {
         match &self.state {
             ChunkState::Invalid => panic!("invalid chunk state"),
-            ChunkState::Open(chunk) | ChunkState::Closing(chunk) => {
+            ChunkState::Open(chunk) | ChunkState::Closed(chunk) => {
                 let mut summaries = chunk.table_summaries();
                 assert_eq!(summaries.len(), 1);
                 summaries.remove(0)
@@ -290,7 +290,7 @@ impl Chunk {
     pub fn size(&self) -> usize {
         match &self.state {
             ChunkState::Invalid => 0,
-            ChunkState::Open(chunk) | ChunkState::Closing(chunk) => chunk.size(),
+            ChunkState::Open(chunk) | ChunkState::Closed(chunk) => chunk.size(),
             ChunkState::Moving(chunk) => chunk.size(),
             ChunkState::Moved(chunk) => chunk.size() as usize,
             ChunkState::WritingToObjectStore(chunk) => chunk.size() as usize,
@@ -307,21 +307,21 @@ impl Chunk {
     pub fn mutable_buffer(&mut self) -> Result<&mut MBChunk> {
         match &mut self.state {
             ChunkState::Open(chunk) => Ok(chunk),
-            ChunkState::Closing(chunk) => Ok(chunk),
+            ChunkState::Closed(chunk) => Ok(chunk),
             state => unexpected_state!(self, "mutable buffer reference", "Open or Closing", state),
         }
     }
 
-    /// Set the chunk to the Closing state
-    pub fn set_closing(&mut self) -> Result<()> {
+    /// Set the chunk to the Closed state
+    pub fn set_closed(&mut self) -> Result<()> {
         let mut s = ChunkState::Invalid;
         std::mem::swap(&mut s, &mut self.state);
 
         match s {
-            ChunkState::Open(s) | ChunkState::Closing(s) => {
-                assert!(self.time_closing.is_none());
-                self.time_closing = Some(Utc::now());
-                self.state = ChunkState::Closing(s);
+            ChunkState::Open(s) | ChunkState::Closed(s) => {
+                assert!(self.time_closed.is_none());
+                self.time_closed = Some(Utc::now());
+                self.state = ChunkState::Closed(s);
                 Ok(())
             }
             state => {
@@ -338,7 +338,7 @@ impl Chunk {
         std::mem::swap(&mut s, &mut self.state);
 
         match s {
-            ChunkState::Open(chunk) | ChunkState::Closing(chunk) => {
+            ChunkState::Open(chunk) | ChunkState::Closed(chunk) => {
                 let chunk = Arc::new(chunk);
                 self.state = ChunkState::Moving(Arc::clone(&chunk));
                 Ok(chunk)

--- a/server/src/db/chunk.rs
+++ b/server/src/db/chunk.rs
@@ -93,7 +93,7 @@ impl DbChunk {
             ChunkState::Invalid => {
                 panic!("Invalid internal state");
             }
-            ChunkState::Open(chunk) | ChunkState::Closing(chunk) => Self::MutableBuffer {
+            ChunkState::Open(chunk) | ChunkState::Closed(chunk) => Self::MutableBuffer {
                 chunk: chunk.snapshot(),
             },
             ChunkState::Moving(chunk) => Self::MutableBuffer {

--- a/server/src/db/lifecycle.rs
+++ b/server/src/db/lifecycle.rs
@@ -842,7 +842,7 @@ mod tests {
     }
 
     #[test]
-    fn test_moves_closing() {
+    fn test_moves_closed() {
         let rules = LifecycleRules {
             mutable_linger_seconds: Some(NonZeroU32::new(10).unwrap()),
             mutable_minimum_age_seconds: Some(NonZeroU32::new(60).unwrap()),
@@ -858,7 +858,7 @@ mod tests {
 
         mover.chunks[0].write().set_closed().unwrap();
 
-        // As soon as closing can move
+        // As soon as closed can move
         mover.check_for_work(from_secs(80));
         assert_eq!(mover.events, vec![MoverEvents::Move(0)]);
     }

--- a/server/src/db/lifecycle.rs
+++ b/server/src/db/lifecycle.rs
@@ -134,7 +134,7 @@ trait ChunkMover {
             match chunk_guard.state() {
                 ChunkState::Open(_) if move_tracker.is_none() && would_move => {
                     let mut chunk_guard = RwLockUpgradableReadGuard::upgrade(chunk_guard);
-                    chunk_guard.set_closing().expect("cannot close open chunk");
+                    chunk_guard.set_closed().expect("cannot close open chunk");
 
                     let partition_key = chunk_guard.key().to_string();
                     let table_name = chunk_guard.table_name().to_string();
@@ -145,7 +145,7 @@ trait ChunkMover {
                     move_tracker =
                         Some(self.move_to_read_buffer(partition_key, table_name, chunk_id));
                 }
-                ChunkState::Closing(_) if move_tracker.is_none() => {
+                ChunkState::Closed(_) if move_tracker.is_none() => {
                     let partition_key = chunk_guard.key().to_string();
                     let table_name = chunk_guard.table_name().to_string();
                     let chunk_id = chunk_guard.id();
@@ -380,7 +380,7 @@ mod tests {
 
     /// Transitions a new ("open") chunk into the "moving" state.
     fn transition_to_moving(mut chunk: Chunk) -> Chunk {
-        chunk.set_closing().unwrap();
+        chunk.set_closed().unwrap();
         chunk.set_moving().unwrap();
         chunk
     }
@@ -856,7 +856,7 @@ mod tests {
         mover.check_for_work(from_secs(80));
         assert_eq!(mover.events, vec![]);
 
-        mover.chunks[0].write().set_closing().unwrap();
+        mover.chunks[0].write().set_closed().unwrap();
 
         // As soon as closing can move
         mover.check_for_work(from_secs(80));

--- a/server/src/db/system_tables.rs
+++ b/server/src/db/system_tables.rs
@@ -120,7 +120,7 @@ fn from_chunk_summaries(chunks: Vec<ChunkSummary>) -> Result<RecordBatch> {
         ("row_count", Arc::new(row_counts), false),
         ("time_of_first_write", Arc::new(time_of_first_write), true),
         ("time_of_last_write", Arc::new(time_of_last_write), true),
-        ("time_closing", Arc::new(time_closed), true),
+        ("time_closed", Arc::new(time_closed), true),
     ])
 }
 
@@ -235,12 +235,12 @@ mod tests {
         ];
 
         let expected = vec![
-            "+----+---------------+------------+-------------------+-----------------+-----------+---------------------+---------------------+--------------+",
-            "| id | partition_key | table_name | storage           | estimated_bytes | row_count | time_of_first_write | time_of_last_write  | time_closing |",
-            "+----+---------------+------------+-------------------+-----------------+-----------+---------------------+---------------------+--------------+",
-            "| 0  | p1            | table1     | OpenMutableBuffer | 23754           | 11        | 1970-01-01 00:00:10 |                     |              |",
-            "| 0  | p1            | table1     | OpenMutableBuffer | 23454           | 22        |                     | 1970-01-01 00:01:20 |              |",
-            "+----+---------------+------------+-------------------+-----------------+-----------+---------------------+---------------------+--------------+",
+            "+----+---------------+------------+-------------------+-----------------+-----------+---------------------+---------------------+-------------+",
+            "| id | partition_key | table_name | storage           | estimated_bytes | row_count | time_of_first_write | time_of_last_write  | time_closed |",
+            "+----+---------------+------------+-------------------+-----------------+-----------+---------------------+---------------------+-------------+",
+            "| 0  | p1            | table1     | OpenMutableBuffer | 23754           | 11        | 1970-01-01 00:00:10 |                     |             |",
+            "| 0  | p1            | table1     | OpenMutableBuffer | 23454           | 22        |                     | 1970-01-01 00:01:20 |             |",
+            "+----+---------------+------------+-------------------+-----------------+-----------+---------------------+---------------------+-------------+",
         ];
 
         let batch = from_chunk_summaries(chunks).unwrap();

--- a/server/src/db/system_tables.rs
+++ b/server/src/db/system_tables.rs
@@ -108,8 +108,8 @@ fn from_chunk_summaries(chunks: Vec<ChunkSummary>) -> Result<RecordBatch> {
     let time_of_last_write = TimestampNanosecondArray::from_iter(
         chunks.iter().map(|c| c.time_of_last_write).map(time_to_ts),
     );
-    let time_closing =
-        TimestampNanosecondArray::from_iter(chunks.iter().map(|c| c.time_closing).map(time_to_ts));
+    let time_closed =
+        TimestampNanosecondArray::from_iter(chunks.iter().map(|c| c.time_closed).map(time_to_ts));
 
     RecordBatch::try_from_iter_with_nullable(vec![
         ("id", Arc::new(id) as ArrayRef, false),
@@ -120,7 +120,7 @@ fn from_chunk_summaries(chunks: Vec<ChunkSummary>) -> Result<RecordBatch> {
         ("row_count", Arc::new(row_counts), false),
         ("time_of_first_write", Arc::new(time_of_first_write), true),
         ("time_of_last_write", Arc::new(time_of_last_write), true),
-        ("time_closing", Arc::new(time_closing), true),
+        ("time_closing", Arc::new(time_closed), true),
     ])
 }
 
@@ -216,7 +216,7 @@ mod tests {
                     Utc,
                 )),
                 time_of_last_write: None,
-                time_closing: None,
+                time_closed: None,
             },
             ChunkSummary {
                 partition_key: Arc::new("p1".to_string()),
@@ -230,7 +230,7 @@ mod tests {
                     NaiveDateTime::from_timestamp(80, 0),
                     Utc,
                 )),
-                time_closing: None,
+                time_closed: None,
             },
         ];
 

--- a/src/commands/database.rs
+++ b/src/commands/database.rs
@@ -74,7 +74,7 @@ struct Create {
     /// this many seconds will be frozen and compacted (moved to the read
     /// buffer) if the chunk is older than mutable_min_lifetime_seconds
     ///
-    /// Represents the chunk transition open -> moving and closing -> moving
+    /// Represents the chunk transition open -> moving and closed -> moving
     #[structopt(long, default_value = "300")] // 5 minutes
     mutable_linger_seconds: u32,
 

--- a/tests/end_to_end_cases/management_api.rs
+++ b/tests/end_to_end_cases/management_api.rs
@@ -263,7 +263,7 @@ async fn test_chunk_get() {
     assert!(
         chunks[0].time_of_first_write.is_some()
             && chunks[0].time_of_last_write.is_some()
-            && chunks[0].time_closing.is_none(), // chunk is not yet closed
+            && chunks[0].time_closed.is_none(), // chunk is not yet closed
         "actual:{:#?}",
         chunks[0]
     );
@@ -280,7 +280,7 @@ async fn test_chunk_get() {
             row_count: 2,
             time_of_first_write: None,
             time_of_last_write: None,
-            time_closing: None,
+            time_closed: None,
         },
         Chunk {
             partition_key: "disk".into(),
@@ -291,7 +291,7 @@ async fn test_chunk_get() {
             row_count: 1,
             time_of_first_write: None,
             time_of_last_write: None,
-            time_closing: None,
+            time_closed: None,
         },
     ];
     assert_eq!(
@@ -459,7 +459,7 @@ async fn test_list_partition_chunks() {
         row_count: 2,
         time_of_first_write: None,
         time_of_last_write: None,
-        time_closing: None,
+        time_closed: None,
     }];
 
     assert_eq!(
@@ -743,7 +743,7 @@ fn normalize_chunks(chunks: Vec<Chunk>) -> Vec<Chunk> {
                 row_count,
                 time_of_first_write: None,
                 time_of_last_write: None,
-                time_closing: None,
+                time_closed: None,
             }
         })
         .collect::<Vec<_>>()


### PR DESCRIPTION
IOx does not actually have a closing state that receives writes to its keyspace. Instead it has a state called Closing that behaves like what Closed would be, and is sometimes printed as Closed e.g. in the system tables.

This is needlessly confusing. This PR therefore renames the closing state to closed, and when we add support for "closing" semantics we can add a new state for it