### PR TITLE
refactor: split lifecycle tracking from chunk state (#1361) (#1099)

### DIFF
--- a/server/src/db/catalog.rs
+++ b/server/src/db/catalog.rs
@@ -50,7 +50,7 @@ pub enum Error {
     },
 
     #[snafu(display(
-        "Internal unexpected chunk state for {}:{}:{}  during {}. Expected {}, got {}",
+        "Internal Error: unexpected chunk state for {}:{}:{}  during {}. Expected {}, got {}",
         partition_key,
         table_name,
         chunk_id,
@@ -68,7 +68,7 @@ pub enum Error {
     },
 
     #[snafu(display(
-        "A lifecycle action '{}' is already in progress for  {}:{}:{}",
+        "Internal Error: A lifecycle action '{}' is already in progress for  {}:{}:{}",
         lifecycle_action,
         partition_key,
         table_name,
@@ -82,7 +82,7 @@ pub enum Error {
     },
 
     #[snafu(display(
-        "Unexpected chunk state for {}:{}:{}. Expected {}, got {}",
+        "Internal Error: Unexpected chunk state for {}:{}:{}. Expected {}, got {}",
         partition_key,
         table_name,
         chunk_id,

--- a/server/src/db/catalog.rs
+++ b/server/src/db/catalog.rs
@@ -68,6 +68,36 @@ pub enum Error {
     },
 
     #[snafu(display(
+        "A lifecycle action '{}' is already in progress for  {}:{}:{}",
+        lifecycle_action,
+        partition_key,
+        table_name,
+        chunk_id,
+    ))]
+    LifecycleActionAlreadyInProgress {
+        partition_key: String,
+        table_name: String,
+        chunk_id: u32,
+        lifecycle_action: String,
+    },
+
+    #[snafu(display(
+        "Unexpected chunk state for {}:{}:{}. Expected {}, got {}",
+        partition_key,
+        table_name,
+        chunk_id,
+        expected,
+        actual
+    ))]
+    UnexpectedLifecycleAction {
+        partition_key: String,
+        table_name: String,
+        chunk_id: u32,
+        expected: String,
+        actual: String,
+    },
+
+    #[snafu(display(
         "Can not add an empty chunk to the catalog {}:{}",
         partition_key,
         chunk_id

--- a/server/src/db/catalog/chunk.rs
+++ b/server/src/db/catalog/chunk.rs
@@ -9,9 +9,32 @@ use mutable_buffer::chunk::Chunk as MBChunk;
 use parquet_file::chunk::Chunk as ParquetChunk;
 use read_buffer::Chunk as ReadBufferChunk;
 
-use super::{ChunkIsEmpty, InternalChunkState, Result};
+use super::{ChunkIsEmpty, Error, InternalChunkState, Result};
 use metrics::{Counter, Histogram, KeyValue};
 use snafu::ensure;
+
+/// Any lifecycle action currently in progress for this chunk
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub enum ChunkLifecycleAction {
+    /// Chunk is in the process of being moved to the read buffer
+    Moving,
+
+    /// Chunk is in the process of being written to object storage
+    Persisting,
+
+    /// Chunk is in the process of being compacted
+    Compacting,
+}
+
+impl ChunkLifecycleAction {
+    pub fn name(&self) -> &'static str {
+        match self {
+            Self::Moving => "Moving to the Read Buffer",
+            Self::Persisting => "Persisting to Object Storage",
+            Self::Compacting => "Compacting",
+        }
+    }
+}
 
 /// The state a Chunk is in and what its underlying backing storage is
 #[derive(Debug)]
@@ -25,17 +48,10 @@ pub enum ChunkState {
     Open(MBChunk),
 
     /// Chunk is closed for new writes
-    Closed(MBChunk),
-
-    /// Chunk is closed for new writes, and is actively moving to the read
-    /// buffer
-    Moving(Arc<MBChunk>),
+    Closed(Arc<MBChunk>),
 
     /// Chunk has been completely loaded in the read buffer
     Moved(Arc<ReadBufferChunk>),
-
-    // Chunk is actively writing to object store
-    WritingToObjectStore(Arc<ReadBufferChunk>),
 
     // Chunk has been completely written into object store
     WrittenToObjectStore(Arc<ReadBufferChunk>, Arc<ParquetChunk>),
@@ -50,9 +66,7 @@ impl ChunkState {
             Self::Invalid => "Invalid",
             Self::Open(_) => "Open",
             Self::Closed(_) => "Closed",
-            Self::Moving(_) => "Moving",
             Self::Moved(_) => "Moved",
-            Self::WritingToObjectStore(_) => "Writing to Object Store",
             Self::WrittenToObjectStore(_, _) => "Written to Object Store",
             Self::ObjectStoreOnly(_) => "Object Store Only",
         }
@@ -75,6 +89,9 @@ pub struct Chunk {
 
     /// The state of this chunk
     state: ChunkState,
+
+    /// The active lifecycle task if any
+    lifecycle_action: Option<ChunkLifecycleAction>,
 
     /// The metrics for this chunk
     metrics: ChunkMetrics,
@@ -159,6 +176,7 @@ impl Chunk {
             table_name,
             id: chunk_id,
             state,
+            lifecycle_action: None,
             metrics,
             time_of_first_write: None,
             time_of_last_write: None,
@@ -226,6 +244,10 @@ impl Chunk {
         &self.state
     }
 
+    pub fn lifecycle_action(&self) -> Option<&ChunkLifecycleAction> {
+        self.lifecycle_action.as_ref()
+    }
+
     pub fn time_of_first_write(&self) -> Option<DateTime<Utc>> {
         self.time_of_first_write
     }
@@ -259,20 +281,10 @@ impl Chunk {
                 chunk.rows(),
                 ChunkStorage::ClosedMutableBuffer,
             ),
-            ChunkState::Moving(chunk) => (
-                chunk.size(),
-                chunk.rows(),
-                ChunkStorage::ClosedMutableBuffer,
-            ),
             ChunkState::Moved(chunk) => (
                 chunk.size(),
                 chunk.rows() as usize,
                 ChunkStorage::ReadBuffer,
-            ),
-            ChunkState::WritingToObjectStore(chunk) => (
-                chunk.size(),
-                chunk.rows() as usize,
-                ChunkStorage::ReadBufferAndObjectStore,
             ),
             ChunkState::WrittenToObjectStore(chunk, parquet_chunk) => (
                 chunk.size() + parquet_chunk.size(),
@@ -314,9 +326,7 @@ impl Chunk {
             ChunkState::Invalid => panic!("invalid chunk state"),
             ChunkState::Open(chunk) => chunk.column_sizes().map(to_summary).collect(),
             ChunkState::Closed(chunk) => chunk.column_sizes().map(to_summary).collect(),
-            ChunkState::Moving(chunk) => chunk.column_sizes().map(to_summary).collect(),
             ChunkState::Moved(chunk) => chunk.column_sizes(&self.table_name),
-            ChunkState::WritingToObjectStore(chunk) => chunk.column_sizes(&self.table_name),
             ChunkState::WrittenToObjectStore(chunk, _parquet_chunk) => {
                 chunk.column_sizes(&self.table_name)
             }
@@ -330,14 +340,9 @@ impl Chunk {
     pub fn table_summary(&self) -> TableSummary {
         match &self.state {
             ChunkState::Invalid => panic!("invalid chunk state"),
-            ChunkState::Open(chunk) | ChunkState::Closed(chunk) => chunk.table_summary(),
-            ChunkState::Moving(chunk) => chunk.table_summary(),
+            ChunkState::Open(chunk) => chunk.table_summary(),
+            ChunkState::Closed(chunk) => chunk.table_summary(),
             ChunkState::Moved(chunk) => {
-                let mut summaries = chunk.table_summaries();
-                assert_eq!(summaries.len(), 1);
-                summaries.remove(0)
-            }
-            ChunkState::WritingToObjectStore(chunk) => {
                 let mut summaries = chunk.table_summaries();
                 assert_eq!(summaries.len(), 1);
                 summaries.remove(0)
@@ -360,10 +365,9 @@ impl Chunk {
     pub fn size(&self) -> usize {
         match &self.state {
             ChunkState::Invalid => 0,
-            ChunkState::Open(chunk) | ChunkState::Closed(chunk) => chunk.size(),
-            ChunkState::Moving(chunk) => chunk.size(),
+            ChunkState::Open(chunk) => chunk.size(),
+            ChunkState::Closed(chunk) => chunk.size(),
             ChunkState::Moved(chunk) => chunk.size() as usize,
-            ChunkState::WritingToObjectStore(chunk) => chunk.size() as usize,
             ChunkState::WrittenToObjectStore(chunk, parquet_chunk) => {
                 parquet_chunk.size() + chunk.size() as usize
             }
@@ -372,19 +376,18 @@ impl Chunk {
     }
 
     /// Returns a mutable reference to the mutable buffer storage for
-    /// chunks in the Open or Closed state
+    /// chunks in the Open state
     ///
     /// Must be in open or closed state
     pub fn mutable_buffer(&mut self) -> Result<&mut MBChunk> {
         match &mut self.state {
             ChunkState::Open(chunk) => Ok(chunk),
-            ChunkState::Closed(chunk) => Ok(chunk),
             state => unexpected_state!(self, "mutable buffer reference", "Open or Closed", state),
         }
     }
 
     /// Set the chunk to the Closed state
-    pub fn set_closed(&mut self) -> Result<()> {
+    pub fn set_closed(&mut self) -> Result<Arc<MBChunk>> {
         let mut s = ChunkState::Invalid;
         std::mem::swap(&mut s, &mut self.state);
 
@@ -392,11 +395,17 @@ impl Chunk {
             ChunkState::Open(s) => {
                 assert!(self.time_closed.is_none());
                 self.time_closed = Some(Utc::now());
-                self.state = ChunkState::Closed(s);
+                let s = Arc::new(s);
+                self.state = ChunkState::Closed(Arc::clone(&s));
                 self.metrics
                     .state
                     .inc_with_labels(&[KeyValue::new("state", "closed")]);
-                Ok(())
+
+                self.metrics
+                    .immutable_chunk_size
+                    .observe_with_labels(s.size() as f64, &[KeyValue::new("state", "closed")]);
+
+                Ok(s)
             }
             state => {
                 self.state = state;
@@ -407,6 +416,8 @@ impl Chunk {
 
     /// Set the chunk to the Moving state, returning a handle to the underlying
     /// storage
+    ///
+    /// If called on an open chunk will first close the chunk
     pub fn set_moving(&mut self) -> Result<Arc<MBChunk>> {
         // This ensures the closing logic is consistent but doesn't break code that
         // assumes a chunk can be moved from open
@@ -414,26 +425,19 @@ impl Chunk {
             self.set_closed()?;
         }
 
-        let mut s = ChunkState::Invalid;
-        std::mem::swap(&mut s, &mut self.state);
-
-        match s {
+        match &self.state {
             ChunkState::Closed(chunk) => {
-                let chunk = Arc::new(chunk);
-                self.state = ChunkState::Moving(Arc::clone(&chunk));
+                let chunk = Arc::clone(chunk);
+                self.set_lifecycle_action(ChunkLifecycleAction::Moving)?;
+
                 self.metrics
                     .state
                     .inc_with_labels(&[KeyValue::new("state", "moving")]);
 
-                self.metrics
-                    .immutable_chunk_size
-                    .observe_with_labels(chunk.size() as f64, &[KeyValue::new("state", "moving")]);
-
                 Ok(chunk)
             }
             state => {
-                self.state = state;
-                unexpected_state!(self, "setting moving", "Open or Closed", &self.state)
+                unexpected_state!(self, "setting moving", "Open or Closed", state)
             }
         }
     }
@@ -442,11 +446,9 @@ impl Chunk {
     /// storage handle to db, and discarding the underlying mutable buffer
     /// storage.
     pub fn set_moved(&mut self, chunk: Arc<ReadBufferChunk>) -> Result<()> {
-        let mut s = ChunkState::Invalid;
-        std::mem::swap(&mut s, &mut self.state);
-
-        match s {
-            ChunkState::Moving(_) => {
+        match &self.state {
+            ChunkState::Closed(_) => {
+                self.finish_lifecycle_action(ChunkLifecycleAction::Moving)?;
                 self.metrics
                     .state
                     .inc_with_labels(&[KeyValue::new("state", "moved")]);
@@ -459,28 +461,24 @@ impl Chunk {
                 Ok(())
             }
             state => {
-                self.state = state;
-                unexpected_state!(self, "setting moved", "Moving", &self.state)
+                unexpected_state!(self, "setting moved", "Moving", state)
             }
         }
     }
 
     /// Set the chunk to the MovingToObjectStore state
     pub fn set_writing_to_object_store(&mut self) -> Result<Arc<ReadBufferChunk>> {
-        let mut s = ChunkState::Invalid;
-        std::mem::swap(&mut s, &mut self.state);
-
-        match s {
+        match &self.state {
             ChunkState::Moved(db) => {
+                let db = Arc::clone(db);
+                self.set_lifecycle_action(ChunkLifecycleAction::Persisting)?;
                 self.metrics
                     .state
                     .inc_with_labels(&[KeyValue::new("state", "writing_os")]);
-                self.state = ChunkState::WritingToObjectStore(Arc::clone(&db));
                 Ok(db)
             }
             state => {
-                self.state = state;
-                unexpected_state!(self, "setting object store", "Moved", &self.state)
+                unexpected_state!(self, "setting object store", "Moved", state)
             }
         }
     }
@@ -488,11 +486,11 @@ impl Chunk {
     /// Set the chunk to the MovedToObjectStore state, returning a handle to the
     /// underlying storage
     pub fn set_written_to_object_store(&mut self, chunk: Arc<ParquetChunk>) -> Result<()> {
-        let mut s = ChunkState::Invalid;
-        std::mem::swap(&mut s, &mut self.state);
+        match &self.state {
+            ChunkState::Moved(db) => {
+                let db = Arc::clone(&db);
+                self.finish_lifecycle_action(ChunkLifecycleAction::Persisting)?;
 
-        match s {
-            ChunkState::WritingToObjectStore(db) => {
                 self.metrics
                     .state
                     .inc_with_labels(&[KeyValue::new("state", "rub_and_os")]);
@@ -506,13 +504,7 @@ impl Chunk {
                 Ok(())
             }
             state => {
-                self.state = state;
-                unexpected_state!(
-                    self,
-                    "setting object store",
-                    "MovingToObjectStore",
-                    &self.state
-                )
+                unexpected_state!(self, "setting object store", "MovingToObjectStore", state)
             }
         }
     }
@@ -540,5 +532,37 @@ impl Chunk {
                 unexpected_state!(self, "setting unload", "WrittenToObjectStore", &self.state)
             }
         }
+    }
+
+    /// Set the chunk's in progress lifecycle action or return an error if already in-progress
+    fn set_lifecycle_action(&mut self, lifecycle_action: ChunkLifecycleAction) -> Result<()> {
+        if let Some(lifecycle_action) = &self.lifecycle_action {
+            return Err(Error::LifecycleActionAlreadyInProgress {
+                partition_key: self.partition_key.to_string(),
+                table_name: self.table_name.to_string(),
+                chunk_id: self.id,
+                lifecycle_action: lifecycle_action.name().to_string(),
+            });
+        }
+        self.lifecycle_action = Some(lifecycle_action);
+        Ok(())
+    }
+
+    /// Clear the chunk's lifecycle action or return an error if it doesn't match that provided
+    fn finish_lifecycle_action(&mut self, lifecycle_action: ChunkLifecycleAction) -> Result<()> {
+        match &self.lifecycle_action {
+            Some(actual) if actual == &lifecycle_action => {}
+            actual => {
+                return Err(Error::UnexpectedLifecycleAction {
+                    partition_key: self.partition_key.to_string(),
+                    table_name: self.table_name.to_string(),
+                    chunk_id: self.id,
+                    expected: lifecycle_action.name().to_string(),
+                    actual: actual.map(|x| x.name()).unwrap_or("None").to_string(),
+                })
+            }
+        }
+        self.lifecycle_action = None;
+        Ok(())
     }
 }

--- a/server/src/db/catalog/chunk.rs
+++ b/server/src/db/catalog/chunk.rs
@@ -210,6 +210,7 @@ impl Chunk {
             table_name,
             id: chunk_id,
             state,
+            lifecycle_action: None,
             metrics,
             time_of_first_write: None,
             time_of_last_write: None,

--- a/server/src/db/catalog/chunk.rs
+++ b/server/src/db/catalog/chunk.rs
@@ -435,6 +435,10 @@ impl Chunk {
                     .state
                     .inc_with_labels(&[KeyValue::new("state", "moving")]);
 
+                self.metrics
+                    .immutable_chunk_size
+                    .observe_with_labels(chunk.size() as f64, &[KeyValue::new("state", "moving")]);
+
                 Ok(chunk)
             }
             state => {

--- a/server/src/db/chunk.rs
+++ b/server/src/db/chunk.rs
@@ -96,17 +96,13 @@ impl DbChunk {
             ChunkState::Invalid => {
                 panic!("Invalid internal state");
             }
-            ChunkState::Open(chunk) | ChunkState::Closed(chunk) => State::MutableBuffer {
+            ChunkState::Open(chunk) => State::MutableBuffer {
                 chunk: chunk.snapshot(),
             },
-            ChunkState::Moving(chunk) => State::MutableBuffer {
+            ChunkState::Closed(chunk) => State::MutableBuffer {
                 chunk: chunk.snapshot(),
             },
             ChunkState::Moved(chunk) => State::ReadBuffer {
-                chunk: Arc::clone(chunk),
-                partition_key,
-            },
-            ChunkState::WritingToObjectStore(chunk) => State::ReadBuffer {
                 chunk: Arc::clone(chunk),
                 partition_key,
             },

--- a/server/src/db/lifecycle.rs
+++ b/server/src/db/lifecycle.rs
@@ -133,6 +133,10 @@ trait ChunkMover {
             let would_move = can_move(&rules, &*chunk_guard, now);
             let would_write = write_tracker.is_none() && rules.persist;
 
+            if chunk_guard.lifecycle_action().is_some() {
+                continue;
+            }
+
             match chunk_guard.state() {
                 ChunkState::Open(_) => {
                     open_partitions.insert(chunk_guard.key().to_string());
@@ -191,6 +195,11 @@ trait ChunkMover {
                 match chunks.next() {
                     Some(chunk) => {
                         let chunk_guard = chunk.read();
+                        if chunk_guard.lifecycle_action().is_some() {
+                            // Cannot drop chunk with in-progress lifecycle action
+                            continue;
+                        }
+
                         if (rules.drop_non_persisted
                             && matches!(chunk_guard.state(), ChunkState::Moved(_)))
                             || matches!(chunk_guard.state(), ChunkState::WrittenToObjectStore(_, _))
@@ -762,7 +771,7 @@ mod tests {
             new_chunk(1, Some(0), Some(0)),
             // "moved" chunk => can be dropped because `drop_non_persistent=true`
             transition_to_moved(new_chunk(2, Some(0), Some(0)), &rb),
-            // "writing" chunk => cannot be drop while write is in-progess
+            // "writing" chunk => cannot be drop while write is in-progress
             transition_to_writing_to_object_store(new_chunk(3, Some(0), Some(0)), &rb),
             // "written" chunk => can be dropped
             transition_to_written_to_object_store(new_chunk(4, Some(0), Some(0)), &rb),


### PR DESCRIPTION
This splits the states that exist to track in-progress tasks into a separate field on the chunk and adds one for compaction. This is to allow compaction to be tracked independently from the primary catalog states as seems to be the consensus on #1361. It is still necessary for the state to be tracked on the catalog chunk as the lifecycle manager is not the only thing that can trigger these actions, they can also be triggered by an API call.
