### PR TITLE
feat: Actually route SequencedEntry to the Write Buffer, if present

### DIFF
--- a/internal_types/src/entry.rs
+++ b/internal_types/src/entry.rs
@@ -1202,7 +1202,7 @@ enum InnerClockValueError {
     ValueMayNotBeZero,
 }
 
-pub trait SequencedEntry {
+pub trait SequencedEntry: Send + Sync + std::fmt::Debug {
     fn partition_writes(&self) -> Option<Vec<PartitionWrite<'_>>>;
 
     fn fb(&self) -> &entry_fb::SequencedEntry<'_>;
@@ -1392,7 +1392,7 @@ impl Segment {
         segment_id: u64,
         server_id: ServerId,
         clock_value: Option<ClockValue>,
-        entries: &[Arc<OwnedSequencedEntry>],
+        entries: &[Arc<dyn SequencedEntry>],
     ) -> Self {
         let mut fbb = FlatBufferBuilder::new_with_capacity(1024);
 

--- a/server/src/buffer.rs
+++ b/server/src/buffer.rs
@@ -1,9 +1,7 @@
 //! This module contains code for managing the Write Buffer
 
 use data_types::{database_rules::WriteBufferRollover, server_id::ServerId, DatabaseName};
-use internal_types::entry::{
-    ClockValue, OwnedSequencedEntry, Segment as EntrySegment, SequencedEntry,
-};
+use internal_types::entry::{ClockValue, Segment as EntrySegment, SequencedEntry};
 use object_store::{path::ObjectStorePath, ObjectStore, ObjectStoreApi};
 
 use std::{convert::TryInto, mem, sync::Arc};
@@ -128,7 +126,7 @@ impl Buffer {
     /// has been closed out. If the max size of the buffer would be exceeded
     /// by accepting the write, the oldest (first) of the closed segments
     /// will be dropped, if it is persisted. Otherwise, an error is returned.
-    pub fn append(&mut self, write: Arc<OwnedSequencedEntry>) -> Result<Option<Arc<Segment>>> {
+    pub fn append(&mut self, write: Arc<dyn SequencedEntry>) -> Result<Option<Arc<Segment>>> {
         let write_size = write.size();
 
         while self.current_size + write_size > self.max_size {
@@ -193,7 +191,7 @@ impl Buffer {
     }
 
     /// Returns any writes after the passed in `ClockValue`
-    pub fn writes_since(&self, since: ClockValue) -> Vec<Arc<OwnedSequencedEntry>> {
+    pub fn writes_since(&self, since: ClockValue) -> Vec<Arc<dyn SequencedEntry>> {
         let mut writes = Vec::new();
 
         // start with the newest writes and go back. Hopefully they're asking for
@@ -203,7 +201,7 @@ impl Buffer {
                 writes.reverse();
                 return writes;
             }
-            writes.push(Arc::clone(&w));
+            writes.push(Arc::clone(w));
         }
 
         for s in self.closed_segments.iter().rev() {
@@ -212,7 +210,7 @@ impl Buffer {
                     writes.reverse();
                     return writes;
                 }
-                writes.push(Arc::clone(&w));
+                writes.push(Arc::clone(w));
             }
         }
 
@@ -234,7 +232,7 @@ impl Buffer {
 pub struct Segment {
     pub(crate) id: u64,
     size: usize,
-    pub writes: Vec<Arc<OwnedSequencedEntry>>,
+    pub writes: Vec<Arc<dyn SequencedEntry>>,
     // Time this segment was initialized
     created_at: DateTime<Utc>,
     // Persistence metadata if segment is persisted
@@ -257,7 +255,7 @@ impl Segment {
     }
 
     // appends the write to the segment
-    fn append(&mut self, write: Arc<OwnedSequencedEntry>) {
+    fn append(&mut self, write: Arc<dyn SequencedEntry>) {
         self.size += write.size();
         self.writes.push(write);
     }
@@ -617,7 +615,7 @@ mod tests {
     }
 
     fn equal_to_server_id_and_clock_value(
-        sequenced_entry: &OwnedSequencedEntry,
+        sequenced_entry: Arc<dyn SequencedEntry>,
         expected_server_id: ServerId,
         expected_clock_value: u64,
     ) {
@@ -666,9 +664,9 @@ mod tests {
 
         let writes = buf.writes_since(ClockValue::try_from(1).unwrap());
         assert_eq!(3, writes.len());
-        equal_to_server_id_and_clock_value(&writes[0], server_id1, 2);
-        equal_to_server_id_and_clock_value(&writes[1], server_id1, 3);
-        equal_to_server_id_and_clock_value(&writes[2], server_id2, 2);
+        equal_to_server_id_and_clock_value(Arc::clone(&writes[0]), server_id1, 2);
+        equal_to_server_id_and_clock_value(Arc::clone(&writes[1]), server_id1, 3);
+        equal_to_server_id_and_clock_value(Arc::clone(&writes[2]), server_id2, 2);
     }
 
     #[test]
@@ -745,7 +743,7 @@ mod tests {
         server_id: ServerId,
         clock_value: u64,
         line_protocol: &str,
-    ) -> Arc<OwnedSequencedEntry> {
+    ) -> Arc<dyn SequencedEntry> {
         Arc::new(lp_2_se(line_protocol, server_id.get_u32(), clock_value))
     }
 }

--- a/server/src/buffer.rs
+++ b/server/src/buffer.rs
@@ -414,7 +414,7 @@ mod tests {
     use super::*;
     use internal_types::entry::{test_helpers::lp_to_sequenced_entry as lp_2_se, SequencedEntry};
     use object_store::memory::InMemory;
-    use std::convert::TryFrom;
+    use std::{convert::TryFrom, ops::Deref};
 
     #[test]
     fn append_increments_current_size_and_uses_existing_segment() {
@@ -615,7 +615,7 @@ mod tests {
     }
 
     fn equal_to_server_id_and_clock_value(
-        sequenced_entry: Arc<dyn SequencedEntry>,
+        sequenced_entry: &dyn SequencedEntry,
         expected_server_id: ServerId,
         expected_clock_value: u64,
     ) {
@@ -664,9 +664,9 @@ mod tests {
 
         let writes = buf.writes_since(ClockValue::try_from(1).unwrap());
         assert_eq!(3, writes.len());
-        equal_to_server_id_and_clock_value(Arc::clone(&writes[0]), server_id1, 2);
-        equal_to_server_id_and_clock_value(Arc::clone(&writes[1]), server_id1, 3);
-        equal_to_server_id_and_clock_value(Arc::clone(&writes[2]), server_id2, 2);
+        equal_to_server_id_and_clock_value(writes[0].deref(), server_id1, 2);
+        equal_to_server_id_and_clock_value(writes[1].deref(), server_id1, 3);
+        equal_to_server_id_and_clock_value(writes[2].deref(), server_id2, 2);
     }
 
     #[test]

--- a/server/src/db.rs
+++ b/server/src/db.rs
@@ -1283,6 +1283,10 @@ pub mod test_helpers {
 
 #[cfg(test)]
 mod tests {
+    use super::{
+        test_helpers::{try_write_lp, write_lp},
+        *,
+    };
     use crate::query_tests::utils::{make_database, make_db};
     use ::test_helpers::assert_contains;
     use arrow_deps::{
@@ -1295,20 +1299,13 @@ mod tests {
         database_rules::{Order, Sort, SortOrder},
         partition_metadata::{ColumnSummary, StatValues, Statistics, TableSummary},
     };
+    use futures::{stream, StreamExt, TryStreamExt};
+    use internal_types::entry::test_helpers::lp_to_entry;
     use object_store::{
         disk::File, path::ObjectStorePath, path::Path, ObjectStore, ObjectStoreApi,
     };
     use query::{frontend::sql::SqlQueryPlanner, PartitionChunk};
-
-    use super::*;
-    use futures::stream;
-    use futures::{StreamExt, TryStreamExt};
-    use std::{convert::TryFrom, iter::Iterator};
-
-    use super::test_helpers::{try_write_lp, write_lp};
-    use internal_types::entry::test_helpers::lp_to_entry;
-    use std::num::NonZeroUsize;
-    use std::str;
+    use std::{convert::TryFrom, iter::Iterator, num::NonZeroUsize, str};
     use tempfile::TempDir;
 
     type Error = Box<dyn std::error::Error + Send + Sync + 'static>;

--- a/server/src/db.rs
+++ b/server/src/db.rs
@@ -1301,9 +1301,7 @@ mod tests {
     };
     use futures::{stream, StreamExt, TryStreamExt};
     use internal_types::entry::test_helpers::lp_to_entry;
-    use object_store::{
-        disk::File, path::ObjectStorePath, path::Path, ObjectStore, ObjectStoreApi,
-    };
+    use object_store::{disk::File, path::Path, ObjectStore, ObjectStoreApi};
     use query::{frontend::sql::SqlQueryPlanner, PartitionChunk};
     use std::{convert::TryFrom, iter::Iterator, num::NonZeroUsize, str};
     use tempfile::TempDir;
@@ -1824,17 +1822,21 @@ mod tests {
         assert_eq!(path_list, paths.clone());
 
         // Get full string path
-        let root_path = format!("{:?}", root.path());
-        let root_path = root_path.trim_matches('"'); // end quote to fix syntax highlighting: "
-        let path = format!("{}/{}", root_path, paths[0].display());
-        println!("path: {}", path);
+        let path0 = match &paths[0] {
+            Path::File(file_path) => file_path.to_raw(),
+            other => panic!("expected `Path::File`, got: {:?}", other),
+        };
+
+        let mut path = root.path().to_path_buf();
+        path.push(&path0);
+        println!("path: {}", path.display());
 
         // Create External table of this parquet file to get its content in a human
         // readable form
         // Note: We do not care about escaping quotes here because it is just a test
         let sql = format!(
             "CREATE EXTERNAL TABLE parquet_table STORED AS PARQUET LOCATION '{}'",
-            path
+            path.display()
         );
 
         let mut ctx = context::ExecutionContext::new();
@@ -1963,17 +1965,21 @@ mod tests {
         assert_eq!(path_list, paths.clone());
 
         // Get full string path
-        let root_path = format!("{:?}", root.path());
-        let root_path = root_path.trim_matches('"'); // end quote to fix syntax highlighting: "
-        let path = format!("{}/{}", root_path, paths[0].display());
-        println!("path: {}", path);
+        let path0 = match &paths[0] {
+            Path::File(file_path) => file_path.to_raw(),
+            other => panic!("expected `Path::File`, got: {:?}", other),
+        };
+
+        let mut path = root.path().to_path_buf();
+        path.push(&path0);
+        println!("path: {}", path.display());
 
         // Create External table of this parquet file to get its content in a human
         // readable form
         // Note: We do not care about escaping quotes here because it is just a test
         let sql = format!(
             "CREATE EXTERNAL TABLE parquet_table STORED AS PARQUET LOCATION '{}'",
-            path
+            path.display()
         );
 
         let mut ctx = context::ExecutionContext::new();

--- a/server/src/db.rs
+++ b/server/src/db.rs
@@ -1098,6 +1098,10 @@ impl Db {
     ///   will replicate the `SequencedEntry` based on the configured rules.
     /// - If the mutable buffer is configured, the `SequencedEntry` is then written into the
     ///   mutable buffer.
+    ///
+    /// Note that if the write buffer is configured but there is an error storing the
+    /// `SequencedEntry` in the write buffer, the `SequencedEntry` will *not* reach the mutable
+    /// buffer.
     pub fn store_sequenced_entry(&self, sequenced_entry: Arc<dyn SequencedEntry>) -> Result<()> {
         // Send to the write buffer, if configured
         if let Some(wb) = &self.write_buffer {

--- a/server/src/db.rs
+++ b/server/src/db.rs
@@ -1287,7 +1287,7 @@ mod tests {
         test_helpers::{try_write_lp, write_lp},
         *,
     };
-    use crate::query_tests::utils::{make_database, make_db};
+    use crate::query_tests::utils::{make_db, TestDb};
     use ::test_helpers::assert_contains;
     use arrow_deps::{
         arrow::record_batch::RecordBatch, assert_batches_eq, assert_batches_sorted_eq,
@@ -1758,7 +1758,12 @@ mod tests {
         // Create a DB given a server id, an object store and a db name
         let server_id = ServerId::try_from(10).unwrap();
         let db_name = "parquet_test_db";
-        let test_db = make_database(server_id, Arc::clone(&object_store), db_name);
+        let test_db = TestDb::builder()
+            .server_id(server_id)
+            .object_store(Arc::clone(&object_store))
+            .db_name(db_name)
+            .build();
+
         let db = Arc::new(test_db.db);
 
         // Write some line protocols in Mutable buffer of the DB
@@ -1820,7 +1825,7 @@ mod tests {
 
         // Get full string path
         let root_path = format!("{:?}", root.path());
-        let root_path = root_path.trim_matches('"');
+        let root_path = root_path.trim_matches('"'); // end quote to fix syntax highlighting: "
         let path = format!("{}/{}", root_path, paths[0].display());
         println!("path: {}", path);
 
@@ -1864,7 +1869,12 @@ mod tests {
         // Create a DB given a server id, an object store and a db name
         let server_id = ServerId::try_from(10).unwrap();
         let db_name = "unload_read_buffer_test_db";
-        let test_db = make_database(server_id, Arc::clone(&object_store), db_name);
+        let test_db = TestDb::builder()
+            .server_id(server_id)
+            .object_store(Arc::clone(&object_store))
+            .db_name(db_name)
+            .build();
+
         let db = Arc::new(test_db.db);
 
         // Write some line protocols in Mutable buffer of the DB
@@ -1954,7 +1964,7 @@ mod tests {
 
         // Get full string path
         let root_path = format!("{:?}", root.path());
-        let root_path = root_path.trim_matches('"');
+        let root_path = root_path.trim_matches('"'); // end quote to fix syntax highlighting: "
         let path = format!("{}/{}", root_path, paths[0].display());
         println!("path: {}", path);
 

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -666,7 +666,7 @@ impl<M: ConnectionManager> Server<M> {
         db: &Db,
         sequenced_entry: OwnedSequencedEntry,
     ) -> Result<()> {
-        db.store_sequenced_entry(sequenced_entry)
+        db.store_sequenced_entry(Arc::new(sequenced_entry))
             .map_err(|e| Error::UnknownDatabaseError {
                 source: Box::new(e),
             })?;

--- a/server/src/query_tests/utils.rs
+++ b/server/src/query_tests/utils.rs
@@ -8,7 +8,7 @@ use object_store::{disk::File, ObjectStore};
 use query::{exec::Executor, Database};
 
 use crate::{db::Db, JobRegistry};
-use std::{convert::TryFrom, sync::Arc};
+use std::{borrow::Cow, convert::TryFrom, sync::Arc};
 use tempfile::TempDir;
 
 // A wrapper around a Db and a metrics registry allowing for isolated testing
@@ -19,49 +19,79 @@ pub struct TestDb {
     pub metric_registry: metrics::TestMetricRegistry,
 }
 
-/// Used for testing: create a Database with a local store
-pub fn make_db() -> TestDb {
-    let server_id = ServerId::try_from(1).unwrap();
-    // TODO: When we support parquet file in memory, we will either turn this test back to memory
-    // or have both tests: local disk and memory
-    //let object_store = Arc::new(ObjectStore::new_in_memory(InMemory::new()));
-    //
-    // Create an object store with a specified location in a local disk
-    let root = TempDir::new().unwrap();
-    let object_store = Arc::new(ObjectStore::new_file(File::new(root.path())));
-    let exec = Arc::new(Executor::new(1));
-    let metrics_registry = Arc::new(metrics::MetricRegistry::new());
-
-    TestDb {
-        metric_registry: metrics::TestMetricRegistry::new(Arc::clone(&metrics_registry)),
-        db: Db::new(
-            DatabaseRules::new(DatabaseName::new("placeholder").unwrap()),
-            server_id,
-            object_store,
-            exec,
-            None, // write buffer
-            Arc::new(JobRegistry::new()),
-            metrics_registry,
-        ),
+impl TestDb {
+    pub fn builder() -> TestDbBuilder {
+        TestDbBuilder::new()
     }
 }
 
-/// Used for testing: create a Database with a local store and a specified name
-pub fn make_database(server_id: ServerId, object_store: Arc<ObjectStore>, db_name: &str) -> TestDb {
-    let exec = Arc::new(Executor::new(1));
-    let metrics_registry = Arc::new(metrics::MetricRegistry::new());
-    TestDb {
-        metric_registry: metrics::TestMetricRegistry::new(Arc::clone(&metrics_registry)),
-        db: Db::new(
-            DatabaseRules::new(DatabaseName::new(db_name.to_string()).unwrap()),
-            server_id,
-            object_store,
-            exec,
-            None, // write buffer
-            Arc::new(JobRegistry::new()),
-            metrics_registry,
-        ),
+#[derive(Debug, Default)]
+pub struct TestDbBuilder {
+    server_id: Option<ServerId>,
+    object_store: Option<Arc<ObjectStore>>,
+    db_name: Option<DatabaseName<'static>>,
+}
+
+impl TestDbBuilder {
+    pub fn new() -> Self {
+        Self::default()
     }
+
+    pub fn build(self) -> TestDb {
+        let server_id = self
+            .server_id
+            .unwrap_or_else(|| ServerId::try_from(1).unwrap());
+        let db_name = self
+            .db_name
+            .unwrap_or_else(|| DatabaseName::new("placeholder").unwrap());
+
+        // TODO: When we support parquet file in memory, we will either turn this test back to
+        // memory or have both tests: local disk and memory
+        //let object_store = Arc::new(ObjectStore::new_in_memory(InMemory::new()));
+        //
+        // Unless otherwise specified, create an object store with a specified location in a local
+        // disk
+        let object_store = self.object_store.unwrap_or_else(|| {
+            let root = TempDir::new().unwrap();
+            Arc::new(ObjectStore::new_file(File::new(root.path())))
+        });
+
+        let exec = Arc::new(Executor::new(1));
+        let metrics_registry = Arc::new(metrics::MetricRegistry::new());
+
+        TestDb {
+            metric_registry: metrics::TestMetricRegistry::new(Arc::clone(&metrics_registry)),
+            db: Db::new(
+                DatabaseRules::new(db_name),
+                server_id,
+                object_store,
+                exec,
+                None, // write buffer
+                Arc::new(JobRegistry::new()),
+                metrics_registry,
+            ),
+        }
+    }
+
+    pub fn server_id(mut self, server_id: ServerId) -> Self {
+        self.server_id = Some(server_id);
+        self
+    }
+
+    pub fn object_store(mut self, object_store: Arc<ObjectStore>) -> Self {
+        self.object_store = Some(object_store);
+        self
+    }
+
+    pub fn db_name<T: Into<Cow<'static, str>>>(mut self, db_name: T) -> Self {
+        self.db_name = Some(DatabaseName::new(db_name).unwrap());
+        self
+    }
+}
+
+/// Used for testing: create a Database with a local store
+pub fn make_db() -> TestDb {
+    TestDb::builder().build()
 }
 
 fn chunk_summary_iter(db: &Db) -> impl Iterator<Item = ChunkSummary> + '_ {

--- a/server/src/snapshot.rs
+++ b/server/src/snapshot.rs
@@ -269,15 +269,13 @@ where
 mod tests {
     use super::*;
     use crate::{
-        db::{test_helpers::write_lp, Db, DbChunk},
-        JobRegistry,
+        db::{test_helpers::write_lp, DbChunk},
+        query_tests::utils::TestDb,
     };
-    use data_types::{database_rules::DatabaseRules, server_id::ServerId, DatabaseName};
     use futures::TryStreamExt;
     use mutable_buffer::chunk::Chunk as ChunkWB;
     use object_store::memory::InMemory;
-    use query::{exec::Executor, predicate::Predicate, Database};
-    use std::convert::TryFrom;
+    use query::{predicate::Predicate, Database};
     use tracker::MemRegistry;
 
     #[tokio::test]
@@ -288,7 +286,10 @@ cpu,host=A,region=west user=3.2,system=50.1 10
 cpu,host=B,region=east user=10.0,system=74.1 1
         "#;
 
-        let db = make_db();
+        let db = TestDb::builder()
+            .object_store(Arc::new(ObjectStore::new_in_memory(InMemory::new())))
+            .build()
+            .db;
         write_lp(&db, &lp);
 
         let store = Arc::new(ObjectStore::new_in_memory(InMemory::new()));
@@ -384,23 +385,5 @@ cpu,host=B,region=east user=10.0,system=74.1 1
         snapshot.mark_table_finished(0);
         snapshot.mark_table_finished(2);
         assert!(snapshot.finished());
-    }
-
-    /// Create a Database with a local store
-    pub fn make_db() -> Db {
-        let metrics_registry = Arc::new(metrics::MetricRegistry::new());
-        let object_store = Arc::new(ObjectStore::new_in_memory(InMemory::new()));
-        let server_id = ServerId::try_from(1).unwrap();
-        let exec = Arc::new(Executor::new(1));
-
-        Db::new(
-            DatabaseRules::new(DatabaseName::new("placeholder").unwrap()),
-            server_id,
-            object_store,
-            exec,
-            None, // write buffer
-            Arc::new(JobRegistry::new()),
-            Arc::clone(&metrics_registry),
-        )
     }
 }

--- a/server/src/snapshot.rs
+++ b/server/src/snapshot.rs
@@ -267,20 +267,17 @@ where
 
 #[cfg(test)]
 mod tests {
-    use std::convert::TryFrom;
-
+    use super::*;
     use crate::{
-        db::{Db, DbChunk},
+        db::{test_helpers::write_lp, Db, DbChunk},
         JobRegistry,
     };
-
-    use super::*;
-    use crate::db::test_helpers::write_lp;
     use data_types::{database_rules::DatabaseRules, server_id::ServerId, DatabaseName};
     use futures::TryStreamExt;
     use mutable_buffer::chunk::Chunk as ChunkWB;
     use object_store::memory::InMemory;
     use query::{exec::Executor, predicate::Predicate, Database};
+    use std::convert::TryFrom;
     use tracker::MemRegistry;
 
     #[tokio::test]


### PR DESCRIPTION
Connects to #1157.

This doesn't finish 1157, as the logical clock isn't implemented yet. If you'd rather the logical clock be implemented before merging this, I'm fine with waiting and I'll work on the logical clock next in any case!

The write buffer will still only be used if configured in the database rules.