### PR TITLE
fix: don't increment chunk state on drop

### DIFF
--- a/server/src/db.rs
+++ b/server/src/db.rs
@@ -491,8 +491,6 @@ impl Db {
                     chunk_state,
                 }
             );
-
-            self.metrics.update_chunk_state(chunk.state());
         };
 
         debug!(%partition_key, %table_name, %chunk_id, %chunk_state, "dropping chunk");


### PR DESCRIPTION
Dropping a chunk doesn't represent a state transition and so calling update_chunk_state when dropping a chunk will double-count that chunk, this is incorrect.

I'm personally of the opinion these metrics should be pushed into the catalog which can ensure they're incremented on any state transition and only then, but that's a topic for another PR