### PR TITLE
refactor: put exporters behind feature flag (#1351)

### DIFF
--- a/logfmt/Cargo.toml
+++ b/logfmt/Cargo.toml
@@ -6,7 +6,7 @@ description="tracing_subscriber layer for writing out logfmt formatted events"
 edition = "2018"
 
 [dependencies] # In alphabetical order
-observability_deps = { path = "../observability_deps" }
+observability_deps = { path = "../observability_deps", features = ["exporters"] }
 
 [dev-dependencies] # In alphabetical order
 once_cell = { version = "1.4.0", features = ["parking_lot"] }

--- a/metrics/Cargo.toml
+++ b/metrics/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2018"
 
 
 [dependencies] # In alphabetical order
-observability_deps = { path = "../observability_deps" }
+observability_deps = { path = "../observability_deps", features = ["exporters"] }
 snafu = "0.6"
 dashmap = { version = "4.0.1" }
 

--- a/observability_deps/Cargo.toml
+++ b/observability_deps/Cargo.toml
@@ -6,12 +6,16 @@ edition = "2018"
 description = "Observability ecosystem dependencies for InfluxDB IOx, to ensure consistent versions and unified updates"
 
 [dependencies] # In alphabetical order
-env_logger = "0.8"
+env_logger = { version = "0.8", optional = true }
 opentelemetry = { version = "0.13", default-features = false, features = ["trace", "metrics", "rt-tokio"] }
-opentelemetry-jaeger = { version = "0.12", features = ["tokio"] }
-opentelemetry-otlp = "0.6"
-opentelemetry-prometheus = "0.6"
-prometheus = "0.12"
+opentelemetry-jaeger = { version = "0.12", features = ["tokio"], optional = true }
+opentelemetry-otlp = { version = "0.6", optional = true }
+opentelemetry-prometheus = { version = "0.6", optional = true }
+prometheus = { version = "0.12", optional = true }
 tracing = { version = "0.1", features = ["max_level_trace", "release_max_level_debug"] }
-tracing-opentelemetry = { version = "0.12", default-features = false }
-tracing-subscriber = { version = "0.2", default-features = false, features = ["env-filter", "smallvec", "chrono", "parking_lot", "registry", "fmt", "ansi", "json"] }
+tracing-opentelemetry = { version = "0.12", default-features = false, optional = true }
+tracing-subscriber = { version = "0.2", default-features = false, features = ["env-filter", "smallvec", "chrono", "parking_lot", "registry", "fmt", "ansi", "json"], optional = true }
+
+[features]
+# Whether to include the exporters
+exporters = ["env_logger", "opentelemetry-jaeger", "opentelemetry-otlp", "opentelemetry-prometheus", "prometheus", "tracing-opentelemetry", "tracing-subscriber"]

--- a/observability_deps/src/lib.rs
+++ b/observability_deps/src/lib.rs
@@ -3,13 +3,20 @@
 //! single crate.
 
 // Export these crates publicly so we can have a single reference
-pub use env_logger;
-pub use opentelemetry;
-pub use opentelemetry_jaeger;
-pub use opentelemetry_otlp;
-pub use opentelemetry_prometheus;
-pub use prometheus;
 pub use tracing;
-pub use tracing::instrument;
-pub use tracing_opentelemetry;
-pub use tracing_subscriber;
+pub use opentelemetry;
+
+#[cfg(feature = "exporters")]
+mod exporters {
+    pub use tracing::instrument;
+    pub use tracing_opentelemetry;
+    pub use tracing_subscriber;
+    pub use env_logger;
+    pub use opentelemetry_jaeger;
+    pub use opentelemetry_otlp;
+    pub use opentelemetry_prometheus;
+    pub use prometheus;
+}
+
+#[cfg(feature = "exporters")]
+pub use exporters::*;


### PR DESCRIPTION
This avoids bringing in the full dependency chain into all of the crates within IOx.

Currently generated_types has an issue that brings in the a lot of the kitchen sink anyway, which I intend to fix, but for crates like the tracker crate this reduces the number of dependencies from 170 to 71.