### PR TITLE
refactor: split exporters from observability_deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1488,7 +1488,7 @@ dependencies = [
  "metrics",
  "mutable_buffer",
  "object_store",
- "observability_deps",
+ "observability_exporters",
  "once_cell",
  "packers",
  "panic_logging",
@@ -1745,7 +1745,7 @@ dependencies = [
 name = "logfmt"
 version = "0.1.0"
 dependencies = [
- "observability_deps",
+ "observability_exporters",
  "once_cell",
  "parking_lot",
  "regex",
@@ -2154,13 +2154,20 @@ dependencies = [
 name = "observability_deps"
 version = "0.1.0"
 dependencies = [
- "env_logger",
  "opentelemetry",
- "opentelemetry-jaeger",
- "opentelemetry-otlp",
  "opentelemetry-prometheus",
  "prometheus",
  "tracing",
+]
+
+[[package]]
+name = "observability_exporters"
+version = "0.1.0"
+dependencies = [
+ "env_logger",
+ "observability_deps",
+ "opentelemetry-jaeger",
+ "opentelemetry-otlp",
  "tracing-opentelemetry",
  "tracing-subscriber",
 ]
@@ -4134,9 +4141,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.2.17"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "705096c6f83bf68ea5d357a6aa01829ddbdac531b357b45abeca842938085baa"
+checksum = "aa5553bf0883ba7c9cbe493b085c29926bd41b66afc31ff72cf17ff4fb60dcd5"
 dependencies = [
  "ansi_term 0.12.1",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ members = [
     "mutable_buffer",
     "object_store",
     "observability_deps",
+    "observability_exporters",
     "packers",
     "panic_logging",
     "query",
@@ -54,7 +55,7 @@ mem_qe = { path = "mem_qe" }
 metrics = { path = "metrics" }
 mutable_buffer = { path = "mutable_buffer" }
 object_store = { path = "object_store" }
-observability_deps = { path = "observability_deps" }
+observability_exporters = { path = "observability_exporters" }
 packers = { path = "packers" }
 panic_logging = { path = "panic_logging" }
 query = { path = "query" }

--- a/logfmt/Cargo.toml
+++ b/logfmt/Cargo.toml
@@ -6,7 +6,7 @@ description="tracing_subscriber layer for writing out logfmt formatted events"
 edition = "2018"
 
 [dependencies] # In alphabetical order
-observability_deps = { path = "../observability_deps" }
+observability_exporters = { path = "../observability_exporters" }
 
 [dev-dependencies] # In alphabetical order
 once_cell = { version = "1.4.0", features = ["parking_lot"] }

--- a/logfmt/src/lib.rs
+++ b/logfmt/src/lib.rs
@@ -1,6 +1,6 @@
 #![deny(broken_intra_doc_links, rust_2018_idioms)]
 
-use observability_deps::{
+use observability_exporters::{
     tracing::{
         self,
         field::{Field, Visit},

--- a/observability_deps/Cargo.toml
+++ b/observability_deps/Cargo.toml
@@ -3,15 +3,11 @@ name = "observability_deps"
 version = "0.1.0"
 authors = ["Paul Dix <paul@pauldix.net>"]
 edition = "2018"
-description = "Observability ecosystem dependencies for InfluxDB IOx, to ensure consistent versions and unified updates"
+description = "Observability dependencies for instrumenting client code"
 
 [dependencies] # In alphabetical order
-env_logger = "0.8"
 opentelemetry = { version = "0.13", default-features = false, features = ["trace", "metrics", "rt-tokio"] }
-opentelemetry-jaeger = { version = "0.12", features = ["tokio"] }
-opentelemetry-otlp = "0.6"
 opentelemetry-prometheus = "0.6"
-prometheus = "0.12"
+prometheus = { version = "0.12", default-features = false }
 tracing = { version = "0.1", features = ["max_level_trace", "release_max_level_debug"] }
-tracing-opentelemetry = { version = "0.12", default-features = false }
-tracing-subscriber = { version = "0.2", default-features = false, features = ["env-filter", "smallvec", "chrono", "parking_lot", "registry", "fmt", "ansi", "json"] }
+

--- a/observability_deps/src/lib.rs
+++ b/observability_deps/src/lib.rs
@@ -1,15 +1,12 @@
-//! This crate exists to coordinate versions of `opentelemetry`, `tracing`,
-//! `prometheus` and related crates so that we can manage their updates in a
-//! single crate.
+//! This crate exists to coordinate versions of `opentelemetry`, `tracing` and `prometheus`
+//! so that we can manage their updates in a single crate.
 
 // Export these crates publicly so we can have a single reference
-pub use env_logger;
 pub use opentelemetry;
-pub use opentelemetry_jaeger;
-pub use opentelemetry_otlp;
-pub use opentelemetry_prometheus;
-pub use prometheus;
+
 pub use tracing;
 pub use tracing::instrument;
-pub use tracing_opentelemetry;
-pub use tracing_subscriber;
+
+// These are somewhat unfortunate but are used for testing
+pub use opentelemetry_prometheus;
+pub use prometheus;

--- a/observability_exporters/Cargo.toml
+++ b/observability_exporters/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "observability_exporters"
+version = "0.1.0"
+authors = ["Paul Dix <paul@pauldix.net>"]
+edition = "2018"
+description = "Observability ecosystem dependencies for InfluxDB IOx, to ensure consistent versions and unified updates"
+
+[dependencies] # In alphabetical order
+env_logger = "0.8"
+observability_deps = { path = "../observability_deps" }
+opentelemetry-jaeger = { version = "0.12", features = ["tokio"] }
+opentelemetry-otlp = "0.6"
+tracing-opentelemetry = { version = "0.12", default-features = false }
+tracing-subscriber = { version = "0.2", default-features = false, features = ["env-filter", "smallvec", "chrono", "parking_lot", "registry", "fmt", "ansi", "json"] }

--- a/observability_exporters/src/lib.rs
+++ b/observability_exporters/src/lib.rs
@@ -1,0 +1,10 @@
+//! This crate exists to coordinate versions of `opentelemetry`, `prometheus` and `tracing`
+//! exporters so that we can manage their updates in a single crate.
+
+// Export these crates publicly so we can have a single reference
+pub use env_logger;
+pub use observability_deps::*;
+pub use opentelemetry_jaeger;
+pub use opentelemetry_otlp;
+pub use tracing_opentelemetry;
+pub use tracing_subscriber;

--- a/src/commands/convert.rs
+++ b/src/commands/convert.rs
@@ -4,7 +4,7 @@ use ingest::{
     ConversionSettings, Error as IngestError, LineProtocolConverter, TsmFileConverter,
 };
 use internal_types::schema::Schema;
-use observability_deps::tracing::{debug, info, warn};
+use observability_exporters::tracing::{debug, info, warn};
 use packers::{Error as TableError, IOxTableWriter, IOxTableWriterSource};
 use snafu::{OptionExt, ResultExt, Snafu};
 use std::{

--- a/src/commands/meta.rs
+++ b/src/commands/meta.rs
@@ -1,6 +1,6 @@
 use influxdb_tsm::{reader::IndexEntry, reader::TsmIndexReader, InfluxId, TsmError};
 use ingest::parquet::metadata::print_parquet_metadata;
-use observability_deps::tracing::{debug, info};
+use observability_exporters::tracing::{debug, info};
 use snafu::{ResultExt, Snafu};
 use std::{
     collections::{BTreeMap, BTreeSet},

--- a/src/commands/sql.rs
+++ b/src/commands/sql.rs
@@ -1,6 +1,6 @@
 //! Entrypoint for interactive SQL repl loop
 
-use observability_deps::tracing::debug;
+use observability_exporters::tracing::debug;
 use snafu::{ResultExt, Snafu};
 use structopt::StructOpt;
 

--- a/src/commands/sql/observer.rs
+++ b/src/commands/sql/observer.rs
@@ -17,7 +17,7 @@ use arrow_deps::{
     },
 };
 
-use observability_deps::tracing::{debug, info};
+use observability_exporters::tracing::{debug, info};
 
 #[derive(Debug, Snafu)]
 pub enum Error {

--- a/src/commands/sql/repl.rs
+++ b/src/commands/sql/repl.rs
@@ -4,7 +4,7 @@ use arrow_deps::arrow::{
     array::{ArrayRef, StringArray},
     record_batch::RecordBatch,
 };
-use observability_deps::tracing::{debug, info};
+use observability_exporters::tracing::{debug, info};
 use rustyline::{error::ReadlineError, Editor};
 use snafu::{ResultExt, Snafu};
 

--- a/src/commands/sql/repl_command.rs
+++ b/src/commands/sql/repl_command.rs
@@ -1,6 +1,6 @@
 use std::convert::TryInto;
 
-use observability_deps::tracing::{debug, warn};
+use observability_exporters::tracing::{debug, warn};
 
 /// Represents the parsed command from the user (which may be over many lines)
 #[derive(Debug, PartialEq)]

--- a/src/commands/stats.rs
+++ b/src/commands/stats.rs
@@ -1,6 +1,6 @@
 //! This module contains code to report compression statistics for storage files
 
-use observability_deps::tracing::info;
+use observability_exporters::tracing::info;
 use snafu::{ResultExt, Snafu};
 use structopt::StructOpt;
 

--- a/src/commands/tracing.rs
+++ b/src/commands/tracing.rs
@@ -1,7 +1,7 @@
 //! Log and trace initialization and setup
 
-use observability_deps::tracing::dispatcher::SetGlobalDefaultError;
-use observability_deps::{
+use observability_exporters::tracing::dispatcher::SetGlobalDefaultError;
+use observability_exporters::{
     opentelemetry,
     opentelemetry::sdk::trace,
     opentelemetry::sdk::Resource,

--- a/src/influxdb_ioxd.rs
+++ b/src/influxdb_ioxd.rs
@@ -4,7 +4,7 @@ use hyper::server::conn::AddrIncoming;
 use object_store::{
     self, aws::AmazonS3, azure::MicrosoftAzure, gcp::GoogleCloudStorage, ObjectStore,
 };
-use observability_deps::tracing::{self, error, info, warn, Instrument};
+use observability_exporters::tracing::{self, error, info, warn, Instrument};
 use panic_logging::SendPanicsToTracing;
 use server::{
     ConnectionManagerImpl as ConnectionManager, Server as AppServer,

--- a/src/influxdb_ioxd/http.rs
+++ b/src/influxdb_ioxd/http.rs
@@ -27,7 +27,7 @@ use bytes::{Bytes, BytesMut};
 use futures::{self, StreamExt};
 use http::header::{CONTENT_ENCODING, CONTENT_TYPE};
 use hyper::{Body, Method, Request, Response, StatusCode};
-use observability_deps::{
+use observability_exporters::{
     opentelemetry::KeyValue,
     tracing::{self, debug, error},
 };
@@ -431,7 +431,7 @@ async fn parse_body(req: hyper::Request<Body>) -> Result<Bytes, ApplicationError
     }
 }
 
-#[observability_deps::instrument(level = "debug")]
+#[observability_exporters::instrument(level = "debug")]
 async fn write<M>(req: Request<Body>) -> Result<Response<Body>, ApplicationError>
 where
     M: ConnectionManager + Send + Sync + Debug + 'static,

--- a/src/influxdb_ioxd/rpc/error.rs
+++ b/src/influxdb_ioxd/rpc/error.rs
@@ -1,7 +1,7 @@
 use generated_types::google::{
     FieldViolation, InternalError, NotFound, PreconditionViolation, QuotaFailure,
 };
-use observability_deps::tracing::error;
+use observability_exporters::tracing::error;
 
 /// map common `server::Error` errors  to the appropriate tonic Status
 pub fn default_server_error_handler(error: server::Error) -> tonic::Status {

--- a/src/influxdb_ioxd/rpc/flight.rs
+++ b/src/influxdb_ioxd/rpc/flight.rs
@@ -2,7 +2,7 @@
 use std::{pin::Pin, sync::Arc};
 
 use futures::Stream;
-use observability_deps::tracing::error;
+use observability_exporters::tracing::error;
 use serde::Deserialize;
 use snafu::{OptionExt, ResultExt, Snafu};
 use tonic::{Request, Response, Streaming};

--- a/src/influxdb_ioxd/rpc/management.rs
+++ b/src/influxdb_ioxd/rpc/management.rs
@@ -10,7 +10,7 @@ use generated_types::google::{
     AlreadyExists, FieldViolation, FieldViolationExt, InternalError, NotFound,
 };
 use generated_types::influxdata::iox::management::v1::*;
-use observability_deps::tracing::info;
+use observability_exporters::tracing::info;
 use query::{Database, DatabaseStore};
 use server::{ConnectionManager, Error, Server};
 use tonic::{Request, Response, Status};

--- a/src/influxdb_ioxd/rpc/operations.rs
+++ b/src/influxdb_ioxd/rpc/operations.rs
@@ -2,7 +2,7 @@ use std::fmt::Debug;
 use std::sync::Arc;
 
 use bytes::BytesMut;
-use observability_deps::tracing::debug;
+use observability_exporters::tracing::debug;
 use prost::Message;
 use tonic::Response;
 

--- a/src/influxdb_ioxd/rpc/storage/expr.rs
+++ b/src/influxdb_ioxd/rpc/storage/expr.rs
@@ -19,7 +19,7 @@ use generated_types::{
 };
 
 use super::{TAG_KEY_FIELD, TAG_KEY_MEASUREMENT};
-use observability_deps::tracing::warn;
+use observability_exporters::tracing::warn;
 use query::group_by::{Aggregate as QueryAggregate, WindowDuration};
 use query::predicate::PredicateBuilder;
 use snafu::{ResultExt, Snafu};

--- a/src/influxdb_ioxd/rpc/storage/service.rs
+++ b/src/influxdb_ioxd/rpc/storage/service.rs
@@ -24,7 +24,7 @@ use generated_types::{
     TimestampRange,
 };
 use metrics::KeyValue;
-use observability_deps::tracing::{error, info};
+use observability_exporters::tracing::{error, info};
 use query::{
     exec::fieldlist::FieldList, exec::seriesset::Error as SeriesSetError,
     predicate::PredicateBuilder, DatabaseStore,

--- a/src/influxdb_ioxd/rpc/testing.rs
+++ b/src/influxdb_ioxd/rpc/testing.rs
@@ -1,6 +1,6 @@
 use generated_types::i_ox_testing_server::{IOxTesting, IOxTestingServer};
 use generated_types::{TestErrorRequest, TestErrorResponse};
-use observability_deps::tracing::warn;
+use observability_exporters::tracing::warn;
 
 /// Concrete implementation of the gRPC IOx testing service API
 struct IOxTestingService {}

--- a/src/influxdb_ioxd/rpc/write.rs
+++ b/src/influxdb_ioxd/rpc/write.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use generated_types::{google::FieldViolation, influxdata::iox::write::v1::*};
 use influxdb_line_protocol::parse_lines;
-use observability_deps::tracing::debug;
+use observability_exporters::tracing::debug;
 use server::{ConnectionManager, Server};
 use std::fmt::Debug;
 use tonic::Response;

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,10 +15,10 @@ use tokio::runtime::Runtime;
 
 use commands::tracing::{init_logs_and_tracing, init_simple_logs};
 use ingest::parquet::writer::CompressionLevel;
-use observability_deps::tracing::{debug, warn};
+use observability_exporters::tracing::{debug, warn};
 
 use crate::commands::tracing::TracingGuard;
-use observability_deps::tracing::dispatcher::SetGlobalDefaultError;
+use observability_exporters::tracing::dispatcher::SetGlobalDefaultError;
 use tikv_jemallocator::Jemalloc;
 
 mod commands {


### PR DESCRIPTION
This splits the observability_deps crate to reduce the number of packages that intermediate crates are dependent on. For an extreme example, this reduces the tracker crate from 170 to 84, effectively halving the time it takes to build.

The impact is currently somewhat limited because of the combined impact of arrow_deps and generated_types, which suffer from the same kitchen sink problem, but I hope to address those next.

I initially used a feature flag for this in #1417 but decided this was a bad idea because:

* It requires recompiling crates unnecessarily when switching from building the workspace to individual crates
* It is fragile because the CI only checks that a workspace compilation, with feature flags deduced for the entire workspace, works
* This solution allows workspace builds to benefit from greater parallelism
