### PR TITLE
feat: Add debug to update_chunk_state metrics

### DIFF
--- a/server/src/db.rs
+++ b/server/src/db.rs
@@ -350,6 +350,12 @@ impl DbMetrics {
         prev_state_size: Option<(&'static str, usize)>,
         next_state_size: Option<(&'static str, usize)>,
     ) {
+        debug!(
+            ?prev_state_size,
+            ?next_state_size,
+            "updating chunk state metrics"
+        );
+
         // Reduce bytes tracked metric for previous state
         if let Some((state, size)) = prev_state_size {
             let labels = vec![metrics::KeyValue::new("state", state)];


### PR DESCRIPTION
We can then run this with `LOG_FILTER=info,server::db=debug` and troubleshoot why the 
`catalog_chunk_size_bytes` is not touched in our staging env.