### PR TITLE
refactor: initial split of observability_deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1508,6 +1508,8 @@ dependencies = [
  "object_store",
  "observability_deps",
  "once_cell",
+ "opentelemetry-jaeger",
+ "opentelemetry-otlp",
  "packers",
  "panic_logging",
  "parking_lot",
@@ -1538,6 +1540,7 @@ dependencies = [
  "tonic",
  "tonic-health",
  "tonic-reflection",
+ "tracing-opentelemetry",
  "tracker",
  "write_buffer",
 ]
@@ -1824,6 +1827,7 @@ dependencies = [
  "criterion",
  "croaring",
  "crossbeam",
+ "env_logger",
  "human_format",
  "observability_deps",
  "packers",
@@ -1852,6 +1856,8 @@ version = "0.1.0"
 dependencies = [
  "dashmap",
  "observability_deps",
+ "opentelemetry-prometheus",
+ "prometheus",
  "snafu",
 ]
 
@@ -2179,14 +2185,8 @@ dependencies = [
 name = "observability_deps"
 version = "0.1.0"
 dependencies = [
- "env_logger",
  "opentelemetry",
- "opentelemetry-jaeger",
- "opentelemetry-otlp",
- "opentelemetry-prometheus",
- "prometheus",
  "tracing",
- "tracing-opentelemetry",
  "tracing-subscriber",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,6 +84,8 @@ futures = "0.3"
 http = "0.2.0"
 hyper = "0.14"
 once_cell = { version = "1.4.0", features = ["parking_lot"] }
+opentelemetry-jaeger = { version = "0.12", features = ["tokio"] }
+opentelemetry-otlp = "0.6"
 parking_lot = "0.11.1"
 itertools = "0.9.0"
 # used by arrow/datafusion anyway
@@ -106,6 +108,7 @@ tokio-util = { version = "0.6.3" }
 tonic = "0.4.0"
 tonic-health = "0.3.0"
 tonic-reflection = "0.1.0"
+tracing-opentelemetry = { version = "0.12", default-features = false }
 
 [dev-dependencies]
 # Workspace dependencies, in alphabetical order

--- a/mem_qe/Cargo.toml
+++ b/mem_qe/Cargo.toml
@@ -9,6 +9,7 @@ arrow = { path = "../arrow" }
 chrono = "0.4"
 croaring = "0.4.5"
 crossbeam = "0.8"
+env_logger = "0.8"
 human_format = "1.0.3"
 packers = { path = "../packers" }
 snafu = "0.6.8"

--- a/mem_qe/src/bin/main.rs
+++ b/mem_qe/src/bin/main.rs
@@ -27,7 +27,7 @@ fn format_size(sz: usize) -> String {
 }
 
 fn main() {
-    observability_deps::env_logger::init();
+    env_logger::init();
     let args: Vec<String> = env::args().collect();
 
     let path = &args[1];

--- a/metrics/Cargo.toml
+++ b/metrics/Cargo.toml
@@ -15,6 +15,8 @@ edition = "2018"
 
 [dependencies] # In alphabetical order
 observability_deps = { path = "../observability_deps" }
+prometheus = "0.12"
+opentelemetry-prometheus = "0.6"
 snafu = "0.6"
 dashmap = { version = "4.0.1" }
 

--- a/metrics/src/lib.rs
+++ b/metrics/src/lib.rs
@@ -18,10 +18,11 @@ use observability_deps::{
             metrics::{controllers, selectors::simple::Selector},
         },
     },
-    opentelemetry_prometheus::PrometheusExporter,
-    prometheus::{Encoder, Registry, TextEncoder},
     tracing::*,
 };
+use opentelemetry_prometheus::PrometheusExporter;
+use prometheus::{Encoder, Registry, TextEncoder};
+
 use std::sync::Arc;
 
 pub use crate::metrics::{Counter, Gauge, Histogram, KeyValue, RedMetric};

--- a/metrics/src/tests.rs
+++ b/metrics/src/tests.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use snafu::{ensure, OptionExt, Snafu};
 
-use observability_deps::prometheus::proto::{
+use prometheus::proto::{
     Counter as PromCounter, Gauge as PromGauge, Histogram as PromHistogram, MetricFamily,
 };
 

--- a/observability_deps/Cargo.toml
+++ b/observability_deps/Cargo.toml
@@ -6,12 +6,6 @@ edition = "2018"
 description = "Observability ecosystem dependencies for InfluxDB IOx, to ensure consistent versions and unified updates"
 
 [dependencies] # In alphabetical order
-env_logger = "0.8"
 opentelemetry = { version = "0.13", default-features = false, features = ["trace", "metrics", "rt-tokio"] }
-opentelemetry-jaeger = { version = "0.12", features = ["tokio"] }
-opentelemetry-otlp = "0.6"
-opentelemetry-prometheus = "0.6"
-prometheus = "0.12"
 tracing = { version = "0.1", features = ["max_level_trace", "release_max_level_debug"] }
-tracing-opentelemetry = { version = "0.12", default-features = false }
 tracing-subscriber = { version = "0.2", default-features = false, features = ["env-filter", "smallvec", "chrono", "parking_lot", "registry", "fmt", "ansi", "json"] }

--- a/observability_deps/src/lib.rs
+++ b/observability_deps/src/lib.rs
@@ -3,13 +3,7 @@
 //! single crate.
 
 // Export these crates publicly so we can have a single reference
-pub use env_logger;
 pub use opentelemetry;
-pub use opentelemetry_jaeger;
-pub use opentelemetry_otlp;
-pub use opentelemetry_prometheus;
-pub use prometheus;
 pub use tracing;
 pub use tracing::instrument;
-pub use tracing_opentelemetry;
 pub use tracing_subscriber;

--- a/src/commands/tracing.rs
+++ b/src/commands/tracing.rs
@@ -6,7 +6,7 @@ use observability_deps::{
     opentelemetry::sdk::trace,
     opentelemetry::sdk::Resource,
     opentelemetry::KeyValue,
-    opentelemetry_jaeger, opentelemetry_otlp, tracing, tracing_opentelemetry,
+    tracing,
     tracing_subscriber::{self, fmt, layer::SubscriberExt, EnvFilter},
 };
 


### PR DESCRIPTION
An initial pass at reducing the number of dependencies brought in by the observability_deps crate.