### PR TITLE
chore: remove unused dependency from influxdb_line_protocol

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1568,7 +1568,6 @@ dependencies = [
 name = "influxdb_line_protocol"
 version = "0.1.0"
 dependencies = [
- "influxdb2_client",
  "nom",
  "observability_deps",
  "smallvec",

--- a/influxdb_line_protocol/Cargo.toml
+++ b/influxdb_line_protocol/Cargo.toml
@@ -5,7 +5,6 @@ authors = ["Paul Dix <paul@pauldix.net>"]
 edition = "2018"
 
 [dependencies] # In alphabetical order
-influxdb2_client = { path = "../influxdb2_client" }
 nom = "5.1.1"
 smallvec = "1.2.0"
 snafu = "0.6.2"


### PR DESCRIPTION
This isn't used as far as I can tell, if anything the dependency should be the other way around...