### PR TITLE
feat: preserve parquet metadata + proper path in catalog

### DIFF
--- a/generated_types/protos/influxdata/iox/catalog/v1/catalog.proto
+++ b/generated_types/protos/influxdata/iox/catalog/v1/catalog.proto
@@ -22,6 +22,15 @@ message Upgrade {
 message AddParquet {
     // Path of the file within the object store.
     Path path = 1;
+
+    // [Apache Parquet] metadata encoded using [Apache Thrift].
+    //
+    // The metadata is encoded using the [Thrift Compact Protocol].
+    //
+    // [Apache Parquet]: https://parquet.apache.org/
+    // [Apache Thrift]: https://thrift.apache.org/
+    // [Thrift Compact Protocol]: https://github.com/apache/thrift/blob/master/doc/specs/thrift-compact-protocol.md
+    bytes metadata = 2;
 }
 
 // Removes a [Parquet] file from the catalog.

--- a/generated_types/protos/influxdata/iox/catalog/v1/catalog.proto
+++ b/generated_types/protos/influxdata/iox/catalog/v1/catalog.proto
@@ -37,7 +37,9 @@ message Transaction {
     // Transaction format version.
     uint32 version = 1;
 
+    // Action as part of the transaction, wraps an enum.
     message Action {
+        // Inner enum.
         oneof action {
             Upgrade upgrade = 1;
 
@@ -46,6 +48,7 @@ message Transaction {
         }
     }
 
+    // Ordered list of actions that are part of this transaction.
     repeated Action actions = 2;
 
     // Revision counter, must by "previous revision" + 1 or 0 for the first transaction.

--- a/generated_types/protos/influxdata/iox/catalog/v1/catalog.proto
+++ b/generated_types/protos/influxdata/iox/catalog/v1/catalog.proto
@@ -1,6 +1,15 @@
 syntax = "proto3";
 package influxdata.iox.catalog.v1;
 
+// Path for object store interaction.
+message Path {
+    // Directory hierarchy.
+    repeated string directories = 1;
+
+    // File name.
+    string file_name = 2;
+}
+
 // Upgrades the catalog to a new version.
 message Upgrade {
     // Format string describing the next catalog version.
@@ -12,7 +21,7 @@ message Upgrade {
 // [Parquet]: https://parquet.apache.org/
 message AddParquet {
     // Path of the file within the object store.
-    string path = 1;
+    Path path = 1;
 }
 
 // Removes a [Parquet] file from the catalog.
@@ -20,7 +29,7 @@ message AddParquet {
 // [Parquet]: https://parquet.apache.org/
 message RemoveParquet {
     // Path of the file within the object store.
-    string path = 1;
+    Path path = 1;
 }
 
 // Single, self-contained transaction.

--- a/object_store/src/path.rs
+++ b/object_store/src/path.rs
@@ -13,7 +13,8 @@ use file::FilePath;
 pub mod parsed;
 use parsed::DirsAndFileName;
 
-mod parts;
+/// Parts for parsed paths.
+pub mod parts;
 use parts::PathPart;
 
 /// The delimiter to separate object namespaces, creating a directory structure.

--- a/object_store/src/path/parsed.rs
+++ b/object_store/src/path/parsed.rs
@@ -3,7 +3,7 @@ use super::{ObjectStorePath, PathPart, DELIMITER};
 use itertools::Itertools;
 
 /// A path stored as a collection of 0 or more directories and 0 or 1 file name
-#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Default)]
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Default, Hash)]
 pub struct DirsAndFileName {
     /// Directory hierarchy.
     pub directories: Vec<PathPart>,

--- a/object_store/src/path/parsed.rs
+++ b/object_store/src/path/parsed.rs
@@ -132,6 +132,46 @@ impl DirsAndFileName {
     }
 }
 
+/// Short-cut macro to create [`DirsAndFileName`] instances.
+///
+/// # Example
+/// ```
+/// use object_store::parsed_path;
+///
+/// // empty path
+/// parsed_path!();
+///
+/// // filename only
+/// parsed_path!("test.txt");
+///
+/// // directories only
+/// parsed_path!(["path", "to"]);
+///
+/// // filename + directories
+/// parsed_path!(["path", "to"], "test.txt");
+/// ```
+#[macro_export]
+macro_rules! parsed_path {
+    ([$($dir:expr),*], $file:expr) => {
+        $crate::path::parsed::DirsAndFileName {
+            directories: vec![$($crate::path::parts::PathPart::from($dir)),*],
+            file_name: Some($crate::path::parts::PathPart::from($file)),
+        }
+    };
+    ([$($dir:expr),*]) => {
+        $crate::path::parsed::DirsAndFileName {
+            directories: vec![$($crate::path::parts::PathPart::from($dir)),*],
+            file_name: None,
+        }
+    };
+    ($file:expr) => {
+        parsed_path!([], $file)
+    };
+    () => {
+        parsed_path!([])
+    };
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -294,5 +334,50 @@ mod tests {
             haystack,
             needle
         );
+    }
+
+    #[test]
+    fn test_macro() {
+        let actual = parsed_path!(["foo", "bar"], "baz");
+        let expected = DirsAndFileName {
+            directories: vec![PathPart::from("foo"), PathPart::from("bar")],
+            file_name: Some(PathPart::from("baz")),
+        };
+        assert_eq!(actual, expected);
+
+        let actual = parsed_path!([], "foo");
+        let expected = DirsAndFileName {
+            directories: vec![],
+            file_name: Some(PathPart::from("foo")),
+        };
+        assert_eq!(actual, expected);
+
+        let actual = parsed_path!("foo");
+        let expected = DirsAndFileName {
+            directories: vec![],
+            file_name: Some(PathPart::from("foo")),
+        };
+        assert_eq!(actual, expected);
+
+        let actual = parsed_path!(["foo", "bar"]);
+        let expected = DirsAndFileName {
+            directories: vec![PathPart::from("foo"), PathPart::from("bar")],
+            file_name: None,
+        };
+        assert_eq!(actual, expected);
+
+        let actual = parsed_path!([]);
+        let expected = DirsAndFileName {
+            directories: vec![],
+            file_name: None,
+        };
+        assert_eq!(actual, expected);
+
+        let actual = parsed_path!();
+        let expected = DirsAndFileName {
+            directories: vec![],
+            file_name: None,
+        };
+        assert_eq!(actual, expected);
     }
 }

--- a/object_store/src/path/parts.rs
+++ b/object_store/src/path/parts.rs
@@ -16,7 +16,7 @@ const EMPTY: &str = "%";
 ///
 /// A PathPart instance is guaranteed to be non-empty and to contain no `/`
 /// characters as it can only be constructed by going through the `from` impl.
-#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Default)]
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Default, Hash)]
 pub struct PathPart(pub(super) String);
 
 /// Characters we want to encode.

--- a/object_store/src/path/parts.rs
+++ b/object_store/src/path/parts.rs
@@ -78,6 +78,7 @@ impl std::fmt::Display for PathPart {
 }
 
 impl PathPart {
+    /// Encode as string.
     pub fn encoded(&self) -> &str {
         &self.0
     }

--- a/parquet_file/src/catalog.rs
+++ b/parquet_file/src/catalog.rs
@@ -2,13 +2,14 @@
 use std::{
     collections::{
         hash_map::Entry::{Occupied, Vacant},
-        HashMap, HashSet,
+        HashMap,
     },
     fmt::{Debug, Display},
     str::FromStr,
     sync::Arc,
 };
 
+use crate::metadata::{parquet_metadata_to_thrift, thrift_to_parquet_metadata};
 use bytes::Bytes;
 use data_types::server_id::ServerId;
 use futures::TryStreamExt;
@@ -18,6 +19,7 @@ use object_store::{
     ObjectStore, ObjectStoreApi,
 };
 use observability_deps::tracing::{info, warn};
+use parquet::file::metadata::ParquetMetaData;
 use prost::{DecodeError, EncodeError, Message};
 use snafu::{OptionExt, ResultExt, Snafu};
 use uuid::Uuid;
@@ -116,8 +118,14 @@ pub enum Error {
     #[snafu(display("Parquet already exists in catalog: {:?}", path))]
     ParquetFileAlreadyExists { path: DirsAndFileName },
 
-    #[snafu(display("Parquet already does not exists in catalog: {:?}", path))]
-    ParquetFileDoesNotExists { path: DirsAndFileName },
+    #[snafu(display("Parquet does not exist in catalog: {:?}", path))]
+    ParquetFileDoesNotExist { path: DirsAndFileName },
+
+    #[snafu(display("Cannot encode parquet metadata: {}", source))]
+    MetadataEncodingFailed { source: crate::metadata::Error },
+
+    #[snafu(display("Cannot decode parquet metadata: {}", source))]
+    MetadataDecodingFailed { source: crate::metadata::Error },
 }
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
@@ -380,22 +388,21 @@ fn parse_uuid_required(s: &str) -> Result<Uuid> {
     parse_uuid(s)?.context(UuidRequired {})
 }
 
-/// Parse [`DirsAndFilename`] from protobuf.
+/// Parse [`DirsAndFilename`](object_store::path::parsed::DirsAndFileName) from protobuf.
 fn parse_dirs_and_filename(proto: &Option<proto::Path>) -> Result<DirsAndFileName> {
-    match proto {
-        Some(proto) => Ok(DirsAndFileName {
-            directories: proto
-                .directories
-                .iter()
-                .map(|s| PathPart::from(&s[..]))
-                .collect(),
-            file_name: Some(PathPart::from(&proto.file_name[..])),
-        }),
-        None => Err(Error::PathRequired {}),
-    }
+    let proto = proto.as_ref().context(PathRequired)?;
+
+    Ok(DirsAndFileName {
+        directories: proto
+            .directories
+            .iter()
+            .map(|s| PathPart::from(&s[..]))
+            .collect(),
+        file_name: Some(PathPart::from(&proto.file_name[..])),
+    })
 }
 
-/// Store [`DirsAndFilename`] as protobuf.
+/// Store [`DirsAndFilename`](object_store::path::parsed::DirsAndFileName) as protobuf.
 fn unparse_dirs_and_filename(path: &DirsAndFileName) -> proto::Path {
     proto::Path {
         directories: path
@@ -406,7 +413,8 @@ fn unparse_dirs_and_filename(path: &DirsAndFileName) -> proto::Path {
         file_name: path
             .file_name
             .as_ref()
-            .map_or_else(|| "".to_string(), |part| part.encoded().to_string()),
+            .map(|part| part.encoded().to_string())
+            .unwrap_or_default(),
     }
 }
 
@@ -426,14 +434,14 @@ impl Display for TransactionKey {
 /// In-memory catalog state, for testing.
 #[derive(Clone, Debug)]
 pub struct CatalogState {
-    pub parquet_files: HashSet<DirsAndFileName>,
+    pub parquet_files: HashMap<DirsAndFileName, ParquetMetaData>,
 }
 
 impl CatalogState {
     /// Create new empty state w/o any tracked files.
     fn new_empty() -> Self {
         Self {
-            parquet_files: HashSet::new(),
+            parquet_files: HashMap::new(),
         }
     }
 }
@@ -483,14 +491,28 @@ impl OpenTransaction {
             }
             proto::transaction::action::Action::AddParquet(a) => {
                 let path = parse_dirs_and_filename(&a.path)?;
-                if !state.parquet_files.insert(path.clone()) {
-                    ParquetFileAlreadyExists { path }.fail()?;
+                match state.parquet_files.entry(path) {
+                    Occupied(o) => {
+                        return Err(Error::ParquetFileAlreadyExists {
+                            path: o.key().clone(),
+                        });
+                    }
+                    Vacant(v) => {
+                        let metadata = thrift_to_parquet_metadata(&a.metadata)
+                            .context(MetadataDecodingFailed)?;
+                        v.insert(metadata);
+                    }
                 }
             }
             proto::transaction::action::Action::RemoveParquet(a) => {
                 let path = parse_dirs_and_filename(&a.path)?;
-                if !state.parquet_files.remove(&path) {
-                    ParquetFileDoesNotExists { path }.fail()?;
+                match state.parquet_files.entry(path) {
+                    Occupied(o) => {
+                        o.remove();
+                    }
+                    Vacant(v) => {
+                        return Err(Error::ParquetFileDoesNotExist { path: v.into_key() });
+                    }
                 }
             }
         };
@@ -634,13 +656,19 @@ impl<'c> TransactionHandle<'c> {
     /// Add a new parquet file to the catalog.
     ///
     /// If a file with the same path already exists an error will be returned.
-    pub fn add_parquet(&mut self, path: &DirsAndFileName) -> Result<()> {
+    pub fn add_parquet(
+        &mut self,
+        path: &DirsAndFileName,
+        metadata: &ParquetMetaData,
+    ) -> Result<()> {
         self.transaction
             .as_mut()
             .expect("transaction handle w/o transaction?!")
             .handle_action_and_record(proto::transaction::action::Action::AddParquet(
                 proto::AddParquet {
                     path: Some(unparse_dirs_and_filename(path)),
+                    metadata: parquet_metadata_to_thrift(metadata)
+                        .context(MetadataEncodingFailed)?,
                 },
             ))
     }
@@ -681,7 +709,14 @@ impl<'c> Drop for TransactionHandle<'c> {
 mod tests {
     use std::num::NonZeroU32;
 
-    use object_store::{memory::InMemory, parsed_path};
+    use crate::{
+        metadata::{
+            read_parquet_metadata_from_file, read_schema_from_parquet_metadata,
+            read_statistics_from_parquet_metadata,
+        },
+        utils::{load_parquet_from_store, make_chunk, make_object_store},
+    };
+    use object_store::parsed_path;
 
     use super::*;
 
@@ -1074,25 +1109,40 @@ mod tests {
     }
 
     /// Get sorted list of catalog files from state
-    fn get_catalog_parquet_files(state: &CatalogState) -> Vec<String> {
-        let mut files: Vec<String> = state
+    fn get_catalog_parquet_files(state: &CatalogState) -> Vec<(String, ParquetMetaData)> {
+        let mut files: Vec<(String, ParquetMetaData)> = state
             .parquet_files
             .iter()
-            .map(DirsAndFileName::display)
+            .map(|(path, md)| (path.display(), md.clone()))
             .collect();
-        files.sort();
+        files.sort_by_key(|(path, _)| path.clone());
         files
     }
 
     /// Assert that set of parquet files tracked by a catalog are identical to the given sorted list.
-    fn assert_catalog_parquet_files(catalog: &PreservedCatalog, expected: &[String]) {
-        let actual: Vec<String> = get_catalog_parquet_files(catalog.state());
-        assert_eq!(&actual, expected);
-    }
+    fn assert_catalog_parquet_files(
+        catalog: &PreservedCatalog,
+        expected: &[(String, ParquetMetaData)],
+    ) {
+        let actual = get_catalog_parquet_files(catalog.state());
+        for ((actual_path, actual_md), (expected_path, expected_md)) in
+            actual.iter().zip(expected.iter())
+        {
+            assert_eq!(actual_path, expected_path);
 
-    /// Creates new in-memory object store for testing.
-    fn make_object_store() -> Arc<ObjectStore> {
-        Arc::new(ObjectStore::new_in_memory(InMemory::new()))
+            let actual_schema = read_schema_from_parquet_metadata(actual_md).unwrap();
+            let expected_schema = read_schema_from_parquet_metadata(expected_md).unwrap();
+            assert_eq!(actual_schema, expected_schema);
+
+            // NOTE: the actual table name is not important here as long as it is the same for both calls, since it is
+            // only used to generate out statistics struct (not to read / dispatch anything).
+            let actual_stats =
+                read_statistics_from_parquet_metadata(actual_md, &actual_schema, "foo").unwrap();
+            let expected_stats =
+                read_statistics_from_parquet_metadata(expected_md, &expected_schema, "foo")
+                    .unwrap();
+            assert_eq!(actual_stats, expected_stats);
+        }
     }
 
     /// Creates new test server ID
@@ -1157,6 +1207,10 @@ mod tests {
         let mut catalog =
             PreservedCatalog::new_empty(Arc::clone(&object_store), server_id, db_name.to_string());
 
+        // get some test metadata
+        let metadata1 = make_metadata(object_store, "foo").await;
+        let metadata2 = make_metadata(object_store, "bar").await;
+
         // track all the intermediate results
         let mut trace = TestTrace::new();
 
@@ -1168,9 +1222,13 @@ mod tests {
         {
             let mut t = catalog.open_transaction();
 
-            t.add_parquet(&parsed_path!("test1")).unwrap();
-            t.add_parquet(&parsed_path!("test2")).unwrap();
-            t.add_parquet(&parsed_path!("test3")).unwrap();
+            t.add_parquet(&parsed_path!("test1"), &metadata1).unwrap();
+            t.add_parquet(&parsed_path!(["sub1"], "test1"), &metadata2)
+                .unwrap();
+            t.add_parquet(&parsed_path!(["sub1"], "test2"), &metadata2)
+                .unwrap();
+            t.add_parquet(&parsed_path!(["sub2"], "test1"), &metadata1)
+                .unwrap();
 
             t.commit().await.unwrap();
         }
@@ -1178,9 +1236,10 @@ mod tests {
         assert_catalog_parquet_files(
             &catalog,
             &[
-                "test1".to_string(),
-                "test2".to_string(),
-                "test3".to_string(),
+                ("sub1/test1".to_string(), metadata2.clone()),
+                ("sub1/test2".to_string(), metadata2.clone()),
+                ("sub2/test1".to_string(), metadata1.clone()),
+                ("test1".to_string(), metadata1.clone()),
             ],
         );
         trace.record(&catalog);
@@ -1190,11 +1249,11 @@ mod tests {
             let mut t = catalog.open_transaction();
 
             // "real" modifications
-            t.add_parquet(&parsed_path!("test4")).unwrap();
+            t.add_parquet(&parsed_path!("test4"), &metadata1).unwrap();
             t.remove_parquet(&parsed_path!("test1")).unwrap();
 
             // wrong modifications
-            t.add_parquet(&parsed_path!("test2"))
+            t.add_parquet(&parsed_path!(["sub1"], "test2"), &metadata2)
                 .expect_err("add file twice should error");
             t.remove_parquet(&parsed_path!("does_not_exist"))
                 .expect_err("removing unknown file should error");
@@ -1207,9 +1266,10 @@ mod tests {
         assert_catalog_parquet_files(
             &catalog,
             &[
-                "test2".to_string(),
-                "test3".to_string(),
-                "test4".to_string(),
+                ("sub1/test1".to_string(), metadata2.clone()),
+                ("sub1/test2".to_string(), metadata2.clone()),
+                ("sub2/test1".to_string(), metadata1.clone()),
+                ("test4".to_string(), metadata1.clone()),
             ],
         );
         trace.record(&catalog);
@@ -1218,8 +1278,8 @@ mod tests {
         {
             let mut t = catalog.open_transaction();
 
-            t.add_parquet(&parsed_path!("test5")).unwrap();
-            t.remove_parquet(&parsed_path!("test2")).unwrap();
+            t.add_parquet(&parsed_path!("test5"), &metadata1).unwrap();
+            t.remove_parquet(&parsed_path!(["sub1"], "test2")).unwrap();
 
             // NO commit here!
         }
@@ -1227,9 +1287,10 @@ mod tests {
         assert_catalog_parquet_files(
             &catalog,
             &[
-                "test2".to_string(),
-                "test3".to_string(),
-                "test4".to_string(),
+                ("sub1/test1".to_string(), metadata2.clone()),
+                ("sub1/test2".to_string(), metadata2.clone()),
+                ("sub2/test1".to_string(), metadata1.clone()),
+                ("test4".to_string(), metadata1.clone()),
             ],
         );
         trace.record(&catalog);
@@ -1259,5 +1320,15 @@ mod tests {
             &catalog,
             &get_catalog_parquet_files(trace.states.last().unwrap()),
         );
+    }
+
+    /// Create test metadata. See [`make_chunk`] for details.
+    async fn make_metadata(
+        object_store: &Arc<ObjectStore>,
+        column_prefix: &str,
+    ) -> ParquetMetaData {
+        let chunk = make_chunk(Arc::clone(object_store), column_prefix).await;
+        let (_, parquet_data) = load_parquet_from_store(&chunk, Arc::clone(object_store)).await;
+        read_parquet_metadata_from_file(parquet_data).unwrap()
     }
 }


### PR DESCRIPTION
Closes #1380.

**NOTE: I did NOT yet preserve any hashes within the catalog. Will do that as part of #1434 since I need a bit of prep within the `object_store` crate to figure out if cloud-provided MD5es "just work".**