### PR TITLE
feat: Expose the storage usage for each column in system.chunk_columns

### DIFF
--- a/data_types/src/chunk.rs
+++ b/data_types/src/chunk.rs
@@ -76,7 +76,7 @@ pub struct ChunkSummary {
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct ChunkColumnSummary {
     /// Column name
-    pub name: Arc<String>,
+    pub name: Arc<str>,
 
     /// Estimated size, in bytes, consumed by this column.
     pub estimated_bytes: usize,
@@ -156,8 +156,8 @@ mod test {
     fn coalesce_summary() {
         let mut detailed_summary = DetailedChunkSummary {
             inner: ChunkSummary {
-                partition_key: Arc::new("foo".to_string()),
-                table_name: Arc::new("bar".to_string()),
+                partition_key: Arc::from("foo"),
+                table_name: Arc::from("bar"),
                 id: 42,
                 estimated_bytes: 1234,
                 row_count: 321,
@@ -168,23 +168,23 @@ mod test {
             },
             columns: vec![
                 ChunkColumnSummary {
-                    name: Arc::new("c3".to_string()),
+                    name: Arc::from("c3"),
                     estimated_bytes: 1000,
                 },
                 ChunkColumnSummary {
-                    name: Arc::new("c1".to_string()),
+                    name: Arc::from("c1"),
                     estimated_bytes: 11,
                 },
                 ChunkColumnSummary {
-                    name: Arc::new("c2".to_string()),
+                    name: Arc::from("c2"),
                     estimated_bytes: 100,
                 },
                 ChunkColumnSummary {
-                    name: Arc::new("c2".to_string()),
+                    name: Arc::from("c2"),
                     estimated_bytes: 200,
                 },
                 ChunkColumnSummary {
-                    name: Arc::new("c1".to_string()),
+                    name: Arc::from("c1"),
                     estimated_bytes: 200,
                 },
             ],
@@ -194,15 +194,15 @@ mod test {
             inner: detailed_summary.inner.clone(),
             columns: vec![
                 ChunkColumnSummary {
-                    name: Arc::new("c1".to_string()),
+                    name: Arc::from("c1"),
                     estimated_bytes: 211,
                 },
                 ChunkColumnSummary {
-                    name: Arc::new("c2".to_string()),
+                    name: Arc::from("c2"),
                     estimated_bytes: 300,
                 },
                 ChunkColumnSummary {
-                    name: Arc::new("c3".to_string()),
+                    name: Arc::from("c3"),
                     estimated_bytes: 1000,
                 },
             ],

--- a/data_types/src/chunk.rs
+++ b/data_types/src/chunk.rs
@@ -36,9 +36,9 @@ impl ChunkStorage {
     }
 }
 
+/// Represents metadata about the physical storage of a chunk in a
+/// database.
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Serialize, Deserialize)]
-/// Represents metadata about a chunk in a database.
-/// A chunk can contain one or more tables.
 pub struct ChunkSummary {
     /// The partition key of this chunk
     pub partition_key: Arc<str>,
@@ -72,6 +72,58 @@ pub struct ChunkSummary {
     pub time_closed: Option<DateTime<Utc>>,
 }
 
+/// Represents metadata about the physical storage of a column in a chunk
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct ChunkColumnSummary {
+    /// Column name
+    pub name: Arc<String>,
+
+    /// Estimated size, in bytes, consumed by this column.
+    pub estimated_bytes: usize,
+}
+
+/// Contains additional per-column details about physical storage of a chunk
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct DetailedChunkSummary {
+    /// Overall chunk statistic
+    pub inner: ChunkSummary,
+
+    /// Per column breakdown
+    pub columns: Vec<ChunkColumnSummary>,
+}
+
+impl DetailedChunkSummary {
+    /// aggregates any duplicate entries in `columns`
+    pub fn coalesce(&mut self) {
+        self.columns.sort_by(|c1, c2| c1.name.cmp(&c2.name));
+        let has_dupes = self
+            .columns
+            .iter()
+            .zip(self.columns.iter().skip(1))
+            .any(|(c1, c2)| c1.name == c2.name);
+
+        if has_dupes {
+            let mut t = Vec::new();
+            std::mem::swap(&mut self.columns, &mut t);
+            let mut deduplicated = t
+                .into_iter()
+                .fold(std::collections::BTreeMap::new(), |mut map, c| {
+                    let entry = map.entry(c.name).or_insert(0);
+                    *entry += c.estimated_bytes;
+                    map
+                })
+                // now we have a hash map with the aggregated values
+                .into_iter()
+                .map(|(name, estimated_bytes)| ChunkColumnSummary {
+                    name,
+                    estimated_bytes,
+                })
+                .collect::<Vec<_>>();
+            std::mem::swap(&mut self.columns, &mut deduplicated);
+        }
+    }
+}
+
 impl ChunkSummary {
     /// Construct a ChunkSummary that has None for all timestamps
     pub fn new_without_timestamps(
@@ -93,5 +145,72 @@ impl ChunkSummary {
             time_of_last_write: None,
             time_closed: None,
         }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn coalesce_summary() {
+        let mut detailed_summary = DetailedChunkSummary {
+            inner: ChunkSummary {
+                partition_key: Arc::new("foo".to_string()),
+                table_name: Arc::new("bar".to_string()),
+                id: 42,
+                estimated_bytes: 1234,
+                row_count: 321,
+                storage: ChunkStorage::ObjectStoreOnly,
+                time_of_first_write: None,
+                time_of_last_write: None,
+                time_closed: None,
+            },
+            columns: vec![
+                ChunkColumnSummary {
+                    name: Arc::new("c3".to_string()),
+                    estimated_bytes: 1000,
+                },
+                ChunkColumnSummary {
+                    name: Arc::new("c1".to_string()),
+                    estimated_bytes: 11,
+                },
+                ChunkColumnSummary {
+                    name: Arc::new("c2".to_string()),
+                    estimated_bytes: 100,
+                },
+                ChunkColumnSummary {
+                    name: Arc::new("c2".to_string()),
+                    estimated_bytes: 200,
+                },
+                ChunkColumnSummary {
+                    name: Arc::new("c1".to_string()),
+                    estimated_bytes: 200,
+                },
+            ],
+        };
+
+        let expected = DetailedChunkSummary {
+            inner: detailed_summary.inner.clone(),
+            columns: vec![
+                ChunkColumnSummary {
+                    name: Arc::new("c1".to_string()),
+                    estimated_bytes: 211,
+                },
+                ChunkColumnSummary {
+                    name: Arc::new("c2".to_string()),
+                    estimated_bytes: 300,
+                },
+                ChunkColumnSummary {
+                    name: Arc::new("c3".to_string()),
+                    estimated_bytes: 1000,
+                },
+            ],
+        };
+
+        assert_ne!(&detailed_summary, &expected);
+
+        detailed_summary.coalesce();
+        assert_eq!(&detailed_summary, &expected);
     }
 }

--- a/mutable_buffer/src/column.rs
+++ b/mutable_buffer/src/column.rs
@@ -66,22 +66,22 @@ impl Column {
             InfluxColumnType::Field(InfluxFieldType::Boolean) => {
                 let mut data = BitSet::new();
                 data.append_unset(row_count);
-                ColumnData::Bool(data, StatValues::new())
+                ColumnData::Bool(data, StatValues::default())
             }
             InfluxColumnType::Field(InfluxFieldType::UInteger) => {
-                ColumnData::U64(vec![0; row_count], StatValues::new())
+                ColumnData::U64(vec![0; row_count], StatValues::default())
             }
             InfluxColumnType::Field(InfluxFieldType::Float) => {
-                ColumnData::F64(vec![0.0; row_count], StatValues::new())
+                ColumnData::F64(vec![0.0; row_count], StatValues::default())
             }
             InfluxColumnType::Field(InfluxFieldType::Integer) | InfluxColumnType::Timestamp => {
-                ColumnData::I64(vec![0; row_count], StatValues::new())
+                ColumnData::I64(vec![0; row_count], StatValues::default())
             }
             InfluxColumnType::Field(InfluxFieldType::String) => {
-                ColumnData::String(vec![String::new(); row_count], StatValues::new())
+                ColumnData::String(vec![String::new(); row_count], StatValues::default())
             }
             InfluxColumnType::Tag => {
-                ColumnData::Tag(vec![DID::invalid(); row_count], StatValues::new())
+                ColumnData::Tag(vec![DID::invalid(); row_count], StatValues::default())
             }
         };
 

--- a/mutable_buffer/src/table.rs
+++ b/mutable_buffer/src/table.rs
@@ -117,7 +117,12 @@ impl Table {
     /// that the space taken for the tag string values is represented in the
     /// dictionary size in the chunk that holds the table.
     pub fn size(&self) -> usize {
-        self.columns.values().fold(0, |acc, v| acc + v.size())
+        self.columns.values().map(|v| v.size()).sum()
+    }
+
+    /// Returns an iterator over (column_name, estimated_size) for each column
+    pub fn column_sizes(&self) -> impl Iterator<Item = (&DID, usize)> + '_ {
+        self.columns.iter().map(|(did, c)| (did, c.size()))
     }
 
     /// Returns a reference to the specified column

--- a/read_buffer/src/chunk.rs
+++ b/read_buffer/src/chunk.rs
@@ -170,11 +170,10 @@ impl Chunk {
         Self::base_size() + table_data.size()
     }
 
-    /// Return the estimated size, for each column in the specific table
-    /// if no such table exists in this chunk, an empty Vec is returned
+    /// Return the estimated size for each column in the specific table.
+    /// Note there may be multiple entries for each column.
     ///
-    /// The estimated size for each column in this table. Note there
-    /// may be multiple entries for each column.
+    /// If no such table exists in this chunk, an empty Vec is returned.
     pub fn column_sizes(&self, table_name: &str) -> Vec<ChunkColumnSummary> {
         let chunk_data = self.chunk_data.read();
         chunk_data

--- a/read_buffer/src/chunk.rs
+++ b/read_buffer/src/chunk.rs
@@ -7,7 +7,7 @@ use parking_lot::RwLock;
 use snafu::{OptionExt, ResultExt, Snafu};
 
 use arrow::record_batch::RecordBatch;
-use data_types::partition_metadata::TableSummary;
+use data_types::{chunk::ChunkColumnSummary, partition_metadata::TableSummary};
 use internal_types::{schema::builder::Error as SchemaError, schema::Schema, selection::Selection};
 use observability_deps::tracing::info;
 use tracker::{MemRegistry, MemTracker};
@@ -168,6 +168,20 @@ impl Chunk {
     pub fn size(&self) -> usize {
         let table_data = self.chunk_data.read();
         Self::base_size() + table_data.size()
+    }
+
+    /// Return the estimated size, for each column in the specific table
+    /// if no such table exists in this chunk, an empty Vec is returned
+    ///
+    /// The estimated size for each column in this table. Note there
+    /// may be multiple entries for each column.
+    pub fn column_sizes(&self, table_name: &str) -> Vec<ChunkColumnSummary> {
+        let chunk_data = self.chunk_data.read();
+        chunk_data
+            .data
+            .get(table_name)
+            .map(|table| table.column_sizes())
+            .unwrap_or_default()
     }
 
     /// The total number of rows in all row groups in all tables in this chunk.

--- a/read_buffer/src/row_group.rs
+++ b/read_buffer/src/row_group.rs
@@ -138,6 +138,15 @@ impl RowGroup {
         base_size + self.meta.size()
     }
 
+    /// Returns an iterator of (column_name, estimated_size) for all
+    /// columns in this row_group
+    pub fn column_sizes(&self) -> impl Iterator<Item = (&str, usize)> + '_ {
+        self.all_columns_by_name.iter().map(move |(name, idx)| {
+            let column = &self.columns[*idx];
+            (name.as_str(), column.size())
+        })
+    }
+
     /// The number of rows in the `RowGroup` (all columns have the same number
     /// of rows).
     pub fn rows(&self) -> u32 {

--- a/read_buffer/src/table.rs
+++ b/read_buffer/src/table.rs
@@ -150,7 +150,7 @@ impl Table {
             .iter()
             .flat_map(|rg| rg.column_sizes())
             .map(|(name, estimated_bytes)| ChunkColumnSummary {
-                name: Arc::new(name.to_string()),
+                name: name.into(),
                 estimated_bytes,
             })
             .collect()

--- a/read_buffer/src/table.rs
+++ b/read_buffer/src/table.rs
@@ -141,14 +141,21 @@ impl Table {
         base_size + self.table_data.read().meta.size()
     }
 
-    /// The estimated size for each column in this table. Note there
-    /// may be multiple entries for each column.
+    /// The estimated size for each column in this table.
     pub fn column_sizes(&self) -> Vec<ChunkColumnSummary> {
         self.table_data
             .read()
             .data
             .iter()
             .flat_map(|rg| rg.column_sizes())
+            // combine statistics for columns across row groups
+            .fold(BTreeMap::new(), |mut map, (name, estimated_bytes)| {
+                let entry = map.entry(name).or_insert(0);
+                *entry += estimated_bytes;
+                map
+            })
+            // Now turn into Vec<ChunkColumnSummary>
+            .into_iter()
             .map(|(name, estimated_bytes)| ChunkColumnSummary {
                 name: name.into(),
                 estimated_bytes,
@@ -1039,6 +1046,35 @@ mod test {
         table
             .drop_row_group(0)
             .expect_err("drop_row_group should have returned an error");
+    }
+
+    #[test]
+    fn column_sizes() {
+        let tc = ColumnType::Time(Column::from(&[10_i64, 20, 30][..]));
+        let fc = ColumnType::Field(Column::from(&[1000_u64, 1002, 1200][..]));
+        let columns = vec![("time".to_string(), tc), ("count".to_string(), fc)];
+        let row_group = RowGroup::new(3, columns);
+        let mut table = Table::new("cpu".to_owned(), row_group);
+
+        // add another row group
+        let tc = ColumnType::Time(Column::from(&[1_i64, 2, 3, 4, 5, 6][..]));
+        let fc = ColumnType::Field(Column::from(&[100_u64, 101, 200, 203, 203, 10][..]));
+        let columns = vec![("time".to_string(), tc), ("count".to_string(), fc)];
+        let rg = RowGroup::new(6, columns);
+        table.add_row_group(rg);
+
+        // expect only a single entry for each column, in name order
+        let expected = vec![
+            ChunkColumnSummary {
+                name: "count".into(),
+                estimated_bytes: 110,
+            },
+            ChunkColumnSummary {
+                name: "time".into(),
+                estimated_bytes: 107,
+            },
+        ];
+        assert_eq!(table.column_sizes(), expected);
     }
 
     #[test]

--- a/server/src/db/catalog/chunk.rs
+++ b/server/src/db/catalog/chunk.rs
@@ -266,7 +266,7 @@ impl Chunk {
 
         fn to_summary(v: (&str, usize)) -> ChunkColumnSummary {
             ChunkColumnSummary {
-                name: Arc::new(v.0.to_string()),
+                name: v.0.into(),
                 estimated_bytes: v.1,
             }
         }

--- a/server/src/db/catalog/chunk.rs
+++ b/server/src/db/catalog/chunk.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use chrono::{DateTime, Utc};
 use data_types::{
-    chunk::{ChunkStorage, ChunkSummary},
+    chunk::{ChunkColumnSummary, ChunkStorage, ChunkSummary, DetailedChunkSummary},
     partition_metadata::TableSummary,
     server_id::ServerId,
 };
@@ -260,7 +260,34 @@ impl Chunk {
         }
     }
 
-    /// Return TableSummary metadata.
+    /// Return information about the storage in this Chunk
+    pub fn detailed_summary(&self) -> DetailedChunkSummary {
+        let inner = self.summary();
+
+        fn to_summary(v: (&str, usize)) -> ChunkColumnSummary {
+            ChunkColumnSummary {
+                name: Arc::new(v.0.to_string()),
+                estimated_bytes: v.1,
+            }
+        }
+
+        let columns: Vec<ChunkColumnSummary> = match &self.state {
+            ChunkState::Invalid => panic!("invalid chunk state"),
+            ChunkState::Open(chunk) => chunk.column_sizes().map(to_summary).collect(),
+            ChunkState::Closed(chunk) => chunk.column_sizes().map(to_summary).collect(),
+            ChunkState::Moving(chunk) => chunk.column_sizes().map(to_summary).collect(),
+            ChunkState::Moved(chunk) => chunk.column_sizes(&self.table_name),
+            ChunkState::WritingToObjectStore(chunk) => chunk.column_sizes(&self.table_name),
+            ChunkState::WrittenToObjectStore(chunk, _parquet_chunk) => {
+                chunk.column_sizes(&self.table_name)
+            }
+            ChunkState::ObjectStoreOnly(_parquet_chunk) => vec![], // TODO parquet statistics
+        };
+
+        DetailedChunkSummary { inner, columns }
+    }
+
+    /// Return the summary information about the table stored in this Chunk
     pub fn table_summary(&self) -> TableSummary {
         match &self.state {
             ChunkState::Invalid => panic!("invalid chunk state"),

--- a/server/src/db/system_tables.rs
+++ b/server/src/db/system_tables.rs
@@ -278,7 +278,7 @@ fn assemble_chunk_columns(
         .collect();
 
     /// Builds an index from column_name -> size
-    fn make_column_index(summary: &DetailedChunkSummary) -> HashMap<&String, u64> {
+    fn make_column_index(summary: &DetailedChunkSummary) -> HashMap<&str, u64> {
         summary
             .columns
             .iter()
@@ -310,7 +310,11 @@ fn assemble_chunk_columns(
     for partition in partitions {
         for chunk_table in partition.tables {
             let table = &chunk_table.table;
-            let key = (&partition.key, chunk_table.chunk_id, &table.name);
+            let key = (
+                partition.key.as_str(),
+                chunk_table.chunk_id,
+                table.name.as_str(),
+            );
 
             // TODO remove this following code and generate an
             // internal error if chunk_summary_map has no entry for the key
@@ -346,7 +350,7 @@ fn assemble_chunk_columns(
                     max_values.append(false)?;
                 }
 
-                let size = column_index.remove(&column.name);
+                let size = column_index.remove(column.name.as_str());
 
                 estimated_bytes.append_option(size)?;
             }
@@ -721,8 +725,8 @@ mod tests {
         let chunk_summaries = vec![
             DetailedChunkSummary {
                 inner: ChunkSummary {
-                    partition_key: Arc::new("p1".to_string()),
-                    table_name: Arc::new("t1".to_string()),
+                    partition_key: "p1".into(),
+                    table_name: "t1".into(),
                     id: 42,
                     storage: ChunkStorage::OpenMutableBuffer,
                     estimated_bytes: 23754,
@@ -733,19 +737,19 @@ mod tests {
                 },
                 columns: vec![
                     ChunkColumnSummary {
-                        name: Arc::new("c1".to_string()),
+                        name: "c1".into(),
                         estimated_bytes: 11,
                     },
                     ChunkColumnSummary {
-                        name: Arc::new("__other".to_string()),
+                        name: "__other".into(),
                         estimated_bytes: 13,
                     },
                 ],
             },
             DetailedChunkSummary {
                 inner: ChunkSummary {
-                    partition_key: Arc::new("p1".to_string()),
-                    table_name: Arc::new("t1".to_string()),
+                    partition_key: "p1".into(),
+                    table_name: "t1".into(),
                     id: 43,
                     storage: ChunkStorage::OpenMutableBuffer,
                     estimated_bytes: 23754,
@@ -757,11 +761,11 @@ mod tests {
                 // two entries for c2 (they need to be aggregated)
                 columns: vec![
                     ChunkColumnSummary {
-                        name: Arc::new("c2".to_string()),
+                        name: "c2".into(),
                         estimated_bytes: 100,
                     },
                     ChunkColumnSummary {
-                        name: Arc::new("c2".to_string()),
+                        name: "c2".into(),
                         estimated_bytes: 200,
                     },
                 ],

--- a/server/src/db/system_tables.rs
+++ b/server/src/db/system_tables.rs
@@ -1,21 +1,28 @@
-use std::any::Any;
+//! Contains implementation of IOx name: (), stats: () system tabl stats: () stats: ()es (aka tables in the `system` schema)
+//!
+//! For example `SELECT * FROM system.chunks`
+
 use std::convert::AsRef;
 use std::iter::FromIterator;
 use std::sync::Arc;
+use std::{any::Any, collections::HashMap};
 
 use chrono::{DateTime, Utc};
 
 use arrow::{
     array::{
         ArrayRef, StringArray, StringBuilder, Time64NanosecondArray, TimestampNanosecondArray,
-        UInt32Array, UInt64Array,
+        UInt32Array, UInt32Builder, UInt64Array, UInt64Builder,
     },
     datatypes::{DataType, Field, Schema, SchemaRef, TimeUnit},
     error::Result,
     record_batch::RecordBatch,
 };
 use data_types::{
-    chunk::ChunkSummary, error::ErrorLogger, job::Job, partition_metadata::PartitionSummary,
+    chunk::{ChunkSummary, DetailedChunkSummary},
+    error::ErrorLogger,
+    job::Job,
+    partition_metadata::{PartitionSummary, UnaggregatedPartitionSummary},
 };
 use datafusion::{
     catalog::schema::SchemaProvider,
@@ -33,6 +40,7 @@ pub const SYSTEM_SCHEMA: &str = "system";
 
 const CHUNKS: &str = "chunks";
 const COLUMNS: &str = "columns";
+const CHUNK_COLUMNS: &str = "chunk_columns";
 const OPERATIONS: &str = "operations";
 
 #[derive(Debug)]
@@ -66,6 +74,7 @@ impl SchemaProvider for SystemSchemaProvider {
         vec![
             CHUNKS.to_string(),
             COLUMNS.to_string(),
+            CHUNK_COLUMNS.to_string(),
             OPERATIONS.to_string(),
         ]
     }
@@ -77,6 +86,12 @@ impl SchemaProvider for SystemSchemaProvider {
         }
 
         let batch = match name {
+            CHUNK_COLUMNS => assemble_chunk_columns(
+                self.catalog.unaggregated_partition_summaries(),
+                self.catalog.detailed_chunk_summaries(),
+            )
+            .log_if_error("chunk_columns table")
+            .ok()?,
             COLUMNS => from_partition_summaries(self.catalog.partition_summaries())
                 .log_if_error("chunks table")
                 .ok()?,
@@ -239,6 +254,139 @@ fn from_partition_summaries(partitions: Vec<PartitionSummary>) -> Result<RecordB
     ])
 }
 
+fn assemble_chunk_columns(
+    partitions: Vec<UnaggregatedPartitionSummary>,
+    mut chunk_summaries: Vec<DetailedChunkSummary>,
+) -> Result<RecordBatch> {
+    // Collapse down any replicated columns in our detaied chunk
+    // summaries so we have one entry per column
+    chunk_summaries
+        .iter_mut()
+        .for_each(|chunk_summary| chunk_summary.coalesce());
+
+    // maps (partition_key, chunk_id, table_name) --> DetailedChunkSummary
+    let chunk_summary_map: HashMap<_, _> = chunk_summaries
+        .iter()
+        .map(|chunk_summary| {
+            let key = (
+                chunk_summary.inner.partition_key.as_ref(),
+                chunk_summary.inner.id,
+                chunk_summary.inner.table_name.as_ref(),
+            );
+            (key, chunk_summary)
+        })
+        .collect();
+
+    /// Builds an index from column_name -> size
+    fn make_column_index(summary: &DetailedChunkSummary) -> HashMap<&String, u64> {
+        summary
+            .columns
+            .iter()
+            .map(|column_summary| {
+                (
+                    column_summary.name.as_ref(),
+                    column_summary.estimated_bytes as u64,
+                )
+            })
+            .collect()
+    }
+
+    // Assume each partition has roughly 5 tables with 5 columns
+    let row_estimate = partitions.len() * 25;
+
+    let mut partition_key = StringBuilder::new(row_estimate);
+    let mut chunk_id = UInt32Builder::new(row_estimate);
+    let mut table_name = StringBuilder::new(row_estimate);
+    let mut column_name = StringBuilder::new(row_estimate);
+    let mut storage = StringBuilder::new(row_estimate);
+    let mut count = UInt64Builder::new(row_estimate);
+    let mut min_values = StringBuilder::new(row_estimate);
+    let mut max_values = StringBuilder::new(row_estimate);
+    let mut estimated_bytes = UInt64Builder::new(row_estimate);
+
+    // Note no rows are produced for partitions with no tabes, or
+    // tables with no columns: There are other tables to list tables
+    // and columns
+    for partition in partitions {
+        for chunk_table in partition.tables {
+            let table = &chunk_table.table;
+            let key = (&partition.key, chunk_table.chunk_id, &table.name);
+
+            // TODO remove this following code and generate an
+            // internal error if chunk_summary_map has no entry for the key
+            let (chunk_summary, mut column_index) = {
+                if let Some(chunk_summary) = chunk_summary_map.get(&key) {
+                    (Some(chunk_summary), make_column_index(chunk_summary))
+                } else {
+                    (None, HashMap::new())
+                }
+            };
+
+            let storage_value = chunk_summary.map(|s| s.inner.storage.as_str());
+
+            for column in &table.columns {
+                partition_key.append_value(&partition.key)?;
+                chunk_id.append_value(chunk_table.chunk_id)?;
+                table_name.append_value(&table.name)?;
+                column_name.append_value(&column.name)?;
+                if let Some(v) = storage_value {
+                    storage.append_value(v)?;
+                } else {
+                    storage.append(false)?;
+                }
+                count.append_value(column.count())?;
+                if let Some(v) = column.stats.min_as_str() {
+                    min_values.append_value(v)?;
+                } else {
+                    min_values.append(false)?;
+                }
+                if let Some(v) = column.stats.max_as_str() {
+                    max_values.append_value(v)?;
+                } else {
+                    max_values.append(false)?;
+                }
+
+                let size = column_index.remove(&column.name);
+
+                estimated_bytes.append_option(size)?;
+            }
+
+            // now, if there are any left over (special columns, like __dictionary), add them too
+            for (name, size) in column_index {
+                partition_key.append_value(&partition.key)?;
+                chunk_id.append_value(chunk_table.chunk_id)?;
+                table_name.append_value(&table.name)?;
+                column_name.append_value(name)?;
+                if let Some(v) = storage_value {
+                    storage.append_value(v)?;
+                } else {
+                    storage.append(false)?;
+                }
+                count.append_null()?;
+                min_values.append(false)?;
+                max_values.append(false)?;
+                estimated_bytes.append_value(size)?;
+            }
+        }
+    }
+
+    RecordBatch::try_from_iter_with_nullable(vec![
+        (
+            "partition_key",
+            Arc::new(partition_key.finish()) as ArrayRef,
+            false,
+        ),
+        ("chunk_id", Arc::new(chunk_id.finish()), false),
+        ("table_name", Arc::new(table_name.finish()), false),
+        ("column_name", Arc::new(column_name.finish()), false),
+        ("storage", Arc::new(storage.finish()), false),
+        ("count", Arc::new(count.finish()), false),
+        ("min_value", Arc::new(min_values.finish()), true),
+        ("max_value", Arc::new(max_values.finish()), true),
+        ("estimated_bytes", Arc::new(estimated_bytes.finish()), true),
+    ])
+}
+
 fn from_task_trackers(db_name: &str, jobs: Vec<TaskTracker<Job>>) -> Result<RecordBatch> {
     let jobs = jobs
         .into_iter()
@@ -317,9 +465,12 @@ mod tests {
     use super::*;
     use arrow_util::assert_batches_eq;
     use chrono::NaiveDateTime;
-    use data_types::chunk::ChunkStorage;
-    use data_types::partition_metadata::{
-        ColumnSummary, InfluxDbType, StatValues, Statistics, TableSummary,
+    use data_types::{
+        chunk::{ChunkColumnSummary, ChunkStorage},
+        partition_metadata::{
+            ColumnSummary, InfluxDbType, StatValues, Statistics, TableSummary,
+            UnaggregatedTableSummary,
+        },
     };
 
     #[test]
@@ -508,5 +659,128 @@ mod tests {
             "Actual error: {}",
             err_string
         );
+    }
+
+    #[test]
+    fn test_assemble_chunk_columns() {
+        let partitions = vec![
+            UnaggregatedPartitionSummary {
+                key: "p1".to_string(),
+                tables: vec![UnaggregatedTableSummary {
+                    chunk_id: 42,
+                    table: TableSummary {
+                        name: "t1".to_string(),
+                        columns: vec![
+                            ColumnSummary {
+                                name: "c1".to_string(),
+                                influxdb_type: Some(InfluxDbType::Field),
+                                stats: Statistics::String(StatValues::new(
+                                    "bar".to_string(),
+                                    "foo".to_string(),
+                                    55,
+                                )),
+                            },
+                            ColumnSummary {
+                                name: "c2".to_string(),
+                                influxdb_type: Some(InfluxDbType::Field),
+                                stats: Statistics::F64(StatValues::new(11.0, 43.0, 66)),
+                            },
+                        ],
+                    },
+                }],
+            },
+            UnaggregatedPartitionSummary {
+                key: "p1".to_string(),
+                tables: vec![
+                    UnaggregatedTableSummary {
+                        chunk_id: 43,
+                        table: TableSummary {
+                            name: "t1".to_string(),
+                            columns: vec![ColumnSummary {
+                                name: "c2".to_string(),
+                                influxdb_type: Some(InfluxDbType::Field),
+                                stats: Statistics::F64(StatValues::new(110.0, 430.0, 667)),
+                            }],
+                        },
+                    },
+                    UnaggregatedTableSummary {
+                        chunk_id: 44,
+                        table: TableSummary {
+                            name: "t2".to_string(),
+                            columns: vec![ColumnSummary {
+                                name: "c3".to_string(),
+                                influxdb_type: Some(InfluxDbType::Field),
+                                stats: Statistics::F64(StatValues::new(-1.0, 2.0, 4)),
+                            }],
+                        },
+                    },
+                ],
+            },
+        ];
+
+        let chunk_summaries = vec![
+            DetailedChunkSummary {
+                inner: ChunkSummary {
+                    partition_key: Arc::new("p1".to_string()),
+                    table_name: Arc::new("t1".to_string()),
+                    id: 42,
+                    storage: ChunkStorage::OpenMutableBuffer,
+                    estimated_bytes: 23754,
+                    row_count: 11,
+                    time_of_first_write: None,
+                    time_of_last_write: None,
+                    time_closed: None,
+                },
+                columns: vec![
+                    ChunkColumnSummary {
+                        name: Arc::new("c1".to_string()),
+                        estimated_bytes: 11,
+                    },
+                    ChunkColumnSummary {
+                        name: Arc::new("__other".to_string()),
+                        estimated_bytes: 13,
+                    },
+                ],
+            },
+            DetailedChunkSummary {
+                inner: ChunkSummary {
+                    partition_key: Arc::new("p1".to_string()),
+                    table_name: Arc::new("t1".to_string()),
+                    id: 43,
+                    storage: ChunkStorage::OpenMutableBuffer,
+                    estimated_bytes: 23754,
+                    row_count: 11,
+                    time_of_first_write: None,
+                    time_of_last_write: None,
+                    time_closed: None,
+                },
+                // two entries for c2 (they need to be aggregated)
+                columns: vec![
+                    ChunkColumnSummary {
+                        name: Arc::new("c2".to_string()),
+                        estimated_bytes: 100,
+                    },
+                    ChunkColumnSummary {
+                        name: Arc::new("c2".to_string()),
+                        estimated_bytes: 200,
+                    },
+                ],
+            },
+        ];
+
+        let expected = vec![
+            "+---------------+----------+------------+-------------+-------------------+-------+-----------+-----------+-----------------+",
+            "| partition_key | chunk_id | table_name | column_name | storage           | count | min_value | max_value | estimated_bytes |",
+            "+---------------+----------+------------+-------------+-------------------+-------+-----------+-----------+-----------------+",
+            "| p1            | 42       | t1         | c1          | OpenMutableBuffer | 55    | bar       | foo       | 11              |",
+            "| p1            | 42       | t1         | c2          | OpenMutableBuffer | 66    | 11        | 43        |                 |",
+            "| p1            | 42       | t1         | __other     | OpenMutableBuffer |       |           |           | 13              |",
+            "| p1            | 43       | t1         | c2          | OpenMutableBuffer | 667   | 110       | 430       | 300             |",
+            "| p1            | 44       | t2         | c3          |                   | 4     | -1        | 2         |                 |",
+            "+---------------+----------+------------+-------------+-------------------+-------+-----------+-----------+-----------------+",
+        ];
+
+        let batch = assemble_chunk_columns(partitions, chunk_summaries).unwrap();
+        assert_batches_eq!(&expected, &[batch]);
     }
 }

--- a/server/src/db/system_tables.rs
+++ b/server/src/db/system_tables.rs
@@ -1,4 +1,4 @@
-//! Contains implementation of IOx name: (), stats: () system tabl stats: () stats: ()es (aka tables in the `system` schema)
+//! Contains implementation of IOx name: (), stats: () system table stats: () stats: ()es (aka tables in the `system` schema)
 //!
 //! For example `SELECT * FROM system.chunks`
 
@@ -298,7 +298,7 @@ fn assemble_chunk_columns(
     let mut max_values = StringBuilder::new(row_estimate);
     let mut estimated_bytes = UInt64Builder::new(row_estimate);
 
-    // Note no rows are produced for partitions with no tabes, or
+    // Note no rows are produced for partitions with no tables, or
     // tables with no columns: There are other tables to list tables
     // and columns
     for partition in partitions {

--- a/server/src/query_tests/sql.rs
+++ b/server/src/query_tests/sql.rs
@@ -186,17 +186,18 @@ async fn sql_select_from_information_schema_tables() {
     // validate we have access to information schema for listing table
     // names
     let expected = vec![
-        "+---------------+--------------------+------------+------------+",
-        "| table_catalog | table_schema       | table_name | table_type |",
-        "+---------------+--------------------+------------+------------+",
-        "| public        | information_schema | columns    | VIEW       |",
-        "| public        | information_schema | tables     | VIEW       |",
-        "| public        | iox                | h2o        | BASE TABLE |",
-        "| public        | iox                | o2         | BASE TABLE |",
-        "| public        | system             | chunks     | BASE TABLE |",
-        "| public        | system             | columns    | BASE TABLE |",
-        "| public        | system             | operations | BASE TABLE |",
-        "+---------------+--------------------+------------+------------+",
+        "+---------------+--------------------+---------------+------------+",
+        "| table_catalog | table_schema       | table_name    | table_type |",
+        "+---------------+--------------------+---------------+------------+",
+        "| public        | information_schema | columns       | VIEW       |",
+        "| public        | information_schema | tables        | VIEW       |",
+        "| public        | iox                | h2o           | BASE TABLE |",
+        "| public        | iox                | o2            | BASE TABLE |",
+        "| public        | system             | chunk_columns | BASE TABLE |",
+        "| public        | system             | chunks        | BASE TABLE |",
+        "| public        | system             | columns       | BASE TABLE |",
+        "| public        | system             | operations    | BASE TABLE |",
+        "+---------------+--------------------+---------------+------------+",
     ];
     run_sql_test_case!(
         TwoMeasurementsManyFields {},
@@ -307,6 +308,40 @@ async fn sql_select_from_system_columns() {
     run_sql_test_case!(
         TwoMeasurementsManyFieldsOneChunk {},
         "SELECT * from system.columns",
+        &expected
+    );
+}
+
+#[tokio::test]
+async fn sql_select_from_system_chunk_columns() {
+    // system tables reflect the state of chunks, so don't run them
+    // with different chunk configurations.
+
+    let expected = vec![
+    "+---------------+----------+------------+--------------+-------------------+-------+-----------+-----------+-----------------+",
+    "| partition_key | chunk_id | table_name | column_name  | storage           | count | min_value | max_value | estimated_bytes |",
+    "+---------------+----------+------------+--------------+-------------------+-------+-----------+-----------+-----------------+",
+    "| 1970-01-01T00 | 0        | h2o        | city         | ReadBuffer        | 2     | Boston    | time      | 871             |",
+    "| 1970-01-01T00 | 0        | h2o        | other_temp   | ReadBuffer        | 2     | 70.4      | 70.4      | 369             |",
+    "| 1970-01-01T00 | 0        | h2o        | state        | ReadBuffer        | 2     | Boston    | time      | 871             |",
+    "| 1970-01-01T00 | 0        | h2o        | temp         | ReadBuffer        | 2     | 70.4      | 70.4      | 369             |",
+    "| 1970-01-01T00 | 0        | h2o        | time         | ReadBuffer        | 2     | 50        | 250       | 51              |",
+    "| 1970-01-01T00 | 0        | o2         | __dictionary | OpenMutableBuffer |       |           |           | 112             |",
+    "| 1970-01-01T00 | 0        | o2         | city         | OpenMutableBuffer | 1     | Boston    | Boston    | 17              |",
+    "| 1970-01-01T00 | 0        | o2         | reading      | OpenMutableBuffer | 1     | 51        | 51        | 25              |",
+    "| 1970-01-01T00 | 0        | o2         | state        | OpenMutableBuffer | 2     | CA        | MA        | 17              |",
+    "| 1970-01-01T00 | 0        | o2         | temp         | OpenMutableBuffer | 2     | 53.4      | 79        | 25              |",
+    "| 1970-01-01T00 | 0        | o2         | time         | OpenMutableBuffer | 2     | 50        | 300       | 25              |",
+    "| 1970-01-01T00 | 1        | h2o        | __dictionary | OpenMutableBuffer |       |           |           | 94              |",
+    "| 1970-01-01T00 | 1        | h2o        | city         | OpenMutableBuffer | 1     | Boston    | Boston    | 13              |",
+    "| 1970-01-01T00 | 1        | h2o        | other_temp   | OpenMutableBuffer | 1     | 72.4      | 72.4      | 17              |",
+    "| 1970-01-01T00 | 1        | h2o        | state        | OpenMutableBuffer | 1     | CA        | CA        | 13              |",
+    "| 1970-01-01T00 | 1        | h2o        | time         | OpenMutableBuffer | 1     | 350       | 350       | 17              |",
+    "+---------------+----------+------------+--------------+-------------------+-------+-----------+-----------+-----------------+",
+    ];
+    run_sql_test_case!(
+        TwoMeasurementsManyFieldsTwoChunks {},
+        "SELECT * from system.chunk_columns",
         &expected
     );
 }


### PR DESCRIPTION
Closes https://github.com/influxdata/influxdb_iox/issues/1340

# Rationale:
I want to understand:
1. how many bytes are used to store each column in the physical containers (aka MUB Column or RUB column)
2. the actual compression (such as "bytes per row") obtained by the MUB vs RB vs Parquet per column for a particular table so we can contemplate different merging strategies
3. the "shape" of the data in the IOx tools cluster so we can then use the data generator to automatically drive IOx with similarly "shaped" data

# Changes:

Add `system.chunk_columns` system table with one row for each column in each table in each chunk, and exposes low level statistics information 

# Examples

Here is an example output (from the test);
```
+---------------+----------+------------+--------------+-------------------+-------+-----------+-----------+-----------------+
| partition_key | chunk_id | table_name | column_name  | storage           | count | min_value | max_value | estimated_bytes |
+---------------+----------+------------+--------------+-------------------+-------+-----------+-----------+-----------------+
| 1970-01-01T00 | 0        | h2o        | city         | ReadBuffer        | 2     | Boston    | time      | 871             |
| 1970-01-01T00 | 0        | h2o        | other_temp   | ReadBuffer        | 2     | 70.4      | 70.4      | 369             |
| 1970-01-01T00 | 0        | h2o        | state        | ReadBuffer        | 2     | Boston    | time      | 871             |
| 1970-01-01T00 | 0        | h2o        | temp         | ReadBuffer        | 2     | 70.4      | 70.4      | 369             |
| 1970-01-01T00 | 0        | h2o        | time         | ReadBuffer        | 2     | 50        | 250       | 51              |
| 1970-01-01T00 | 0        | o2         | __dictionary | OpenMutableBuffer |       |           |           | 112             |
| 1970-01-01T00 | 0        | o2         | city         | OpenMutableBuffer | 1     | Boston    | Boston    | 17              |
| 1970-01-01T00 | 0        | o2         | reading      | OpenMutableBuffer | 1     | 51        | 51        | 25              |
| 1970-01-01T00 | 0        | o2         | state        | OpenMutableBuffer | 2     | CA        | MA        | 17              |
| 1970-01-01T00 | 0        | o2         | temp         | OpenMutableBuffer | 2     | 53.4      | 79        | 25              |
| 1970-01-01T00 | 0        | o2         | time         | OpenMutableBuffer | 2     | 50        | 300       | 25              |
| 1970-01-01T00 | 1        | h2o        | __dictionary | OpenMutableBuffer |       |           |           | 94              |
| 1970-01-01T00 | 1        | h2o        | city         | OpenMutableBuffer | 1     | Boston    | Boston    | 13              |
| 1970-01-01T00 | 1        | h2o        | other_temp   | OpenMutableBuffer | 1     | 72.4      | 72.4      | 17              |
| 1970-01-01T00 | 1        | h2o        | state        | OpenMutableBuffer | 1     | CA        | CA        | 13              |
| 1970-01-01T00 | 1        | h2o        | time         | OpenMutableBuffer | 1     | 350       | 350       | 17              |
+---------------+----------+------------+--------------+-------------------+-------+-----------+-----------+-----------------+

```

# Notes:
I am not happy with
1. The intermixing of table level "statistics" info (like row count) with schema information (like column type) in data_types::chunk which leads to having to "join" this information in the system table builder
2. The amount of `String` copying that occurs
3. The magic '__dictionary` column

However, I plan to just hold my nose here as I want to get the data and move on

