### PR TITLE
feat: Add a process clock to Db and use it for Sequenced Entries

### DIFF
--- a/server/src/db.rs
+++ b/server/src/db.rs
@@ -1378,8 +1378,8 @@ mod tests {
     type Error = Box<dyn std::error::Error + Send + Sync + 'static>;
     type Result<T, E = Error> = std::result::Result<T, E>;
 
-    #[tokio::test]
-    async fn write_no_mutable_buffer() {
+    #[test]
+    fn write_no_mutable_buffer() {
         // Validate that writes are rejected if there is no mutable buffer
         let db = make_db().db;
         db.rules.write().lifecycle_rules.immutable = true;
@@ -2074,8 +2074,8 @@ mod tests {
         assert_batches_eq!(expected, &content);
     }
 
-    #[tokio::test]
-    async fn write_updates_last_write_at() {
+    #[test]
+    fn write_updates_last_write_at() {
         let db = Arc::new(make_db().db);
         let before_create = Utc::now();
 
@@ -2139,8 +2139,8 @@ mod tests {
         assert!(chunk.time_closed().unwrap() < after_rollover);
     }
 
-    #[tokio::test]
-    async fn test_chunk_closing() {
+    #[test]
+    fn test_chunk_closing() {
         let db = Arc::new(make_db().db);
         db.rules.write().lifecycle_rules.mutable_size_threshold =
             Some(NonZeroUsize::new(2).unwrap());
@@ -2160,8 +2160,8 @@ mod tests {
         assert!(matches!(chunks[1].read().state(), ChunkState::Closed(_)));
     }
 
-    #[tokio::test]
-    async fn chunks_sorted_by_times() {
+    #[test]
+    fn chunks_sorted_by_times() {
         let db = Arc::new(make_db().db);
         write_lp(&db, "cpu val=1 1");
         write_lp(&db, "mem val=2 400000000000001");
@@ -2682,8 +2682,8 @@ mod tests {
         assert_eq!(read_parquet_file_chunk_ids(&db, partition_key), vec![0]);
     }
 
-    #[tokio::test]
-    async fn write_hard_limit() {
+    #[test]
+    fn write_hard_limit() {
         let db = Arc::new(make_db().db);
         db.rules.write().lifecycle_rules.buffer_size_hard = Some(NonZeroUsize::new(10).unwrap());
 
@@ -2697,8 +2697,8 @@ mod tests {
         ));
     }
 
-    #[tokio::test]
-    async fn write_goes_to_write_buffer_if_configured() {
+    #[test]
+    fn write_goes_to_write_buffer_if_configured() {
         let db = Arc::new(TestDb::builder().write_buffer(true).build().db);
 
         assert_eq!(db.write_buffer.as_ref().unwrap().lock().size(), 0);

--- a/server/src/db.rs
+++ b/server/src/db.rs
@@ -303,6 +303,8 @@ pub struct Db {
     system_tables: Arc<SystemSchemaProvider>,
 
     /// Process clock used in establishing a partial ordering of operations via a Lamport Clock.
+    ///
+    /// Value is nanoseconds since the Unix Epoch.
     process_clock: Arc<Mutex<NonZeroU64>>,
 
     /// Number of iterations of the worker loop for this Db

--- a/server/src/db.rs
+++ b/server/src/db.rs
@@ -2901,12 +2901,12 @@ mod tests {
 
     #[test]
     fn process_clock_defaults_to_current_time_in_ns() {
-        let before: u64 = Utc::now().timestamp_nanos().try_into().unwrap();
+        let before = now_nanos();
 
         let db = Arc::new(TestDb::builder().build().db);
         let db_process_clock = db.process_clock.lock();
 
-        let after: u64 = Utc::now().timestamp_nanos().try_into().unwrap();
+        let after = now_nanos();
 
         assert!(
             before < db_process_clock.get(),
@@ -2924,7 +2924,7 @@ mod tests {
 
     #[test]
     fn process_clock_incremented_and_set_on_sequenced_entry() {
-        let before: u64 = Utc::now().timestamp_nanos().try_into().unwrap();
+        let before = now_nanos();
         let before = ClockValue::try_from(before).unwrap();
 
         let db = Arc::new(TestDb::builder().write_buffer(true).build().db);
@@ -2932,13 +2932,13 @@ mod tests {
         let entry = lp_to_entry("cpu bar=1 10");
         db.store_entry(entry).unwrap();
 
-        let between: u64 = Utc::now().timestamp_nanos().try_into().unwrap();
+        let between = now_nanos();
         let between = ClockValue::try_from(between).unwrap();
 
         let entry = lp_to_entry("cpu foo=2 10");
         db.store_entry(entry).unwrap();
 
-        let after: u64 = Utc::now().timestamp_nanos().try_into().unwrap();
+        let after = now_nanos();
         let after = ClockValue::try_from(after).unwrap();
 
         let sequenced_entries = db

--- a/server/src/db/process_clock.rs
+++ b/server/src/db/process_clock.rs
@@ -24,6 +24,9 @@ impl ProcessClock {
     /// nanoseconds or the previous process clock value plus 1. Every operation that needs a
     /// process clock value should be incrementing it as well, so there should never be a read of
     /// the process clock without an accompanying increment of at least 1 nanosecond.
+    ///
+    /// We expect that updates to the process clock are not so frequent and the system is slow
+    /// enough that the returned value will be incremented by at least 1.
     pub fn next(&self) -> ClockValue {
         let next = loop {
             if let Ok(next) = self.try_update() {
@@ -54,6 +57,10 @@ impl ProcessClock {
 
 // Convenience function for getting the current time in a `u64` represented as nanoseconds since
 // the epoch
+//
+// While this might jump backwards, the logic above that takes the maximum of the current process
+// clock and the value returned from this function should ensure that the process clock is
+// strictly increasing.
 fn system_clock_now() -> u64 {
     Utc::now()
         .timestamp_nanos()

--- a/server/src/db/process_clock.rs
+++ b/server/src/db/process_clock.rs
@@ -1,0 +1,168 @@
+//! Process clock used in establishing a partial ordering of operations via a Lamport Clock.
+
+use chrono::Utc;
+use entry::ClockValue;
+use std::{
+    convert::{TryFrom, TryInto},
+    sync::atomic::{AtomicU64, Ordering},
+};
+
+#[derive(Debug)]
+pub struct ProcessClock {
+    inner: AtomicU64,
+}
+
+impl ProcessClock {
+    /// Create a new process clock value initialized to the current system time.
+    pub fn new() -> Self {
+        Self {
+            inner: AtomicU64::new(now_nanos()),
+        }
+    }
+
+    /// Returns the next process clock value, which will be the maximum of the system time in
+    /// nanoseconds or the previous process clock value plus 1. Every operation that needs a
+    /// process clock value should be incrementing it as well, so there should never be a read of
+    /// the process clock without an accompanying increment of at least 1 nanosecond.
+    pub fn next(&self) -> ClockValue {
+        let next = loop {
+            if let Ok(next) = self.try_update() {
+                break next;
+            }
+        };
+
+        ClockValue::try_from(next).expect("process clock should not be 0")
+    }
+
+    fn try_update(&self) -> Result<u64, u64> {
+        let now = now_nanos();
+        let current_process_clock = self.inner.load(Ordering::SeqCst);
+        let next_candidate = current_process_clock + 1;
+
+        let next = now.max(next_candidate);
+
+        self.inner
+            .compare_exchange(
+                current_process_clock,
+                next,
+                Ordering::SeqCst,
+                Ordering::SeqCst,
+            )
+            .map(|_| next)
+    }
+}
+
+// Convenience function for getting the current time in a `u64` represented as nanoseconds since
+// the epoch
+fn now_nanos() -> u64 {
+    Utc::now()
+        .timestamp_nanos()
+        .try_into()
+        .expect("current time since the epoch should be positive")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::query_tests::utils::TestDb;
+    use entry::test_helpers::lp_to_entry;
+    use std::sync::Arc;
+
+    #[test]
+    fn process_clock_defaults_to_current_time_in_ns() {
+        let before = now_nanos();
+
+        let db = Arc::new(TestDb::builder().build().db);
+        let db_process_clock = db.process_clock.inner.load(Ordering::SeqCst);
+
+        let after = now_nanos();
+
+        assert!(
+            before < db_process_clock,
+            "expected {} to be less than {}",
+            before,
+            db_process_clock
+        );
+        assert!(
+            db_process_clock < after,
+            "expected {} to be less than {}",
+            db_process_clock,
+            after
+        );
+    }
+
+    #[test]
+    fn process_clock_incremented_and_set_on_sequenced_entry() {
+        let before = now_nanos();
+        let before = ClockValue::try_from(before).unwrap();
+
+        let db = Arc::new(TestDb::builder().write_buffer(true).build().db);
+
+        let entry = lp_to_entry("cpu bar=1 10");
+        db.store_entry(entry).unwrap();
+
+        let between = now_nanos();
+        let between = ClockValue::try_from(between).unwrap();
+
+        let entry = lp_to_entry("cpu foo=2 10");
+        db.store_entry(entry).unwrap();
+
+        let after = now_nanos();
+        let after = ClockValue::try_from(after).unwrap();
+
+        let sequenced_entries = db
+            .write_buffer
+            .as_ref()
+            .unwrap()
+            .lock()
+            .writes_since(before);
+        assert_eq!(sequenced_entries.len(), 2);
+
+        assert!(
+            sequenced_entries[0].clock_value() < between,
+            "expected {:?} to be before {:?}",
+            sequenced_entries[0].clock_value(),
+            between
+        );
+
+        assert!(
+            between < sequenced_entries[1].clock_value(),
+            "expected {:?} to be before {:?}",
+            between,
+            sequenced_entries[1].clock_value(),
+        );
+
+        assert!(
+            sequenced_entries[1].clock_value() < after,
+            "expected {:?} to be before {:?}",
+            sequenced_entries[1].clock_value(),
+            after
+        );
+    }
+
+    #[test]
+    fn next_process_clock_always_increments() {
+        // Process clock defaults to the current time
+        let db = Arc::new(TestDb::builder().write_buffer(true).build().db);
+
+        // Set the process clock value to a time in the future, so that when compared to the
+        // current time, the process clock value will be greater
+        let later: u64 = (Utc::now() + chrono::Duration::weeks(4))
+            .timestamp_nanos()
+            .try_into()
+            .unwrap();
+
+        db.process_clock.inner.store(later, Ordering::SeqCst);
+
+        // Every call to next_process_clock should increment at least 1, even in this case
+        // where the system time will be less than the process clock
+        assert_eq!(
+            db.process_clock.next(),
+            ClockValue::try_from(later + 1).unwrap()
+        );
+        assert_eq!(
+            db.process_clock.next(),
+            ClockValue::try_from(later + 2).unwrap()
+        );
+    }
+}


### PR DESCRIPTION
This connects to #1157. I *think* it might finish it, except the ticket mentions the logical clock having the ability to be "updated to a new value (if passed value is > the current one)", but that ability wouldn't be used anywhere just yet, so I'd rather add it when it's needed. If I should do it now instead, let me know!

I tried having the `process_clock` field be an `AtomicU64`, but I don't think it works because there's not a way to read the value, compare it + 1 to another value, and possibly set the value with a guarantee that the value hasn't been modified between the read + set. Let me know if I'm missing some trick with atomics, this is a lower level than I usually work at 😬