### PR TITLE
feat: Calculate all system tables "on demand"

### DIFF
--- a/server/src/db/system_tables.rs
+++ b/server/src/db/system_tables.rs
@@ -71,7 +71,7 @@ impl SystemSchemaProvider {
             inner: ChunkColumnsTable::new(catalog),
         });
         let operations = Arc::new(SystemTableProvider {
-            inner: OperationsTable::new(db_name.into(), jobs),
+            inner: OperationsTable::new(db_name, jobs),
         });
         Self {
             chunks,

--- a/server/src/db/system_tables.rs
+++ b/server/src/db/system_tables.rs
@@ -179,8 +179,8 @@ impl IoxSystemTable for ChunksTable {
     }
 
     fn batch(&self) -> Result<RecordBatch> {
-        let chunks = self.catalog.chunk_summaries();
-        from_chunk_summaries(self.schema(), chunks)
+        from_chunk_summaries(self.schema(), self.catalog.chunk_summaries())
+            .log_if_error("system.chunks table")
     }
 }
 
@@ -255,6 +255,7 @@ impl IoxSystemTable for ColumnsTable {
     }
     fn batch(&self) -> Result<RecordBatch> {
         from_partition_summaries(self.schema(), self.catalog.partition_summaries())
+            .log_if_error("system.columns table")
     }
 }
 
@@ -339,6 +340,7 @@ impl IoxSystemTable for ChunkColumnsTable {
             self.catalog.unaggregated_partition_summaries(),
             self.catalog.detailed_chunk_summaries(),
         )
+        .log_if_error("system.column_chunks table")
     }
 }
 
@@ -502,6 +504,7 @@ impl IoxSystemTable for OperationsTable {
 
     fn batch(&self) -> Result<RecordBatch> {
         from_task_trackers(self.schema(), &self.db_name, self.jobs.tracked())
+            .log_if_error("system.operations table")
     }
 }
 

--- a/server/src/db/system_tables.rs
+++ b/server/src/db/system_tables.rs
@@ -264,7 +264,7 @@ fn partition_summaries_schema() -> SchemaRef {
         Field::new("table_name", DataType::Utf8, false),
         Field::new("column_name", DataType::Utf8, false),
         Field::new("column_type", DataType::Utf8, false),
-        Field::new("influxdb_type", DataType::Utf8, false),
+        Field::new("influxdb_type", DataType::Utf8, true),
     ]))
 }
 
@@ -349,10 +349,10 @@ fn chunk_columns_schema() -> SchemaRef {
         Field::new("table_name", DataType::Utf8, false),
         Field::new("column_name", DataType::Utf8, false),
         Field::new("storage", DataType::Utf8, false),
-        Field::new("count", DataType::UInt64, false),
-        Field::new("min_value", DataType::Utf8, false),
-        Field::new("max_value", DataType::Utf8, false),
-        Field::new("estimated_bytes", DataType::UInt64, false),
+        Field::new("count", DataType::UInt64, true),
+        Field::new("min_value", DataType::Utf8, true),
+        Field::new("max_value", DataType::Utf8, true),
+        Field::new("estimated_bytes", DataType::UInt64, true),
     ]))
 }
 
@@ -514,7 +514,7 @@ fn operations_schema() -> SchemaRef {
         Field::new("wall_time_used", ts, true),
         Field::new("partition_key", DataType::Utf8, true),
         Field::new("chunk_id", DataType::UInt32, true),
-        Field::new("description", DataType::Utf8, false),
+        Field::new("description", DataType::Utf8, true),
     ]))
 }
 


### PR DESCRIPTION
Fixes https://github.com/influxdata/influxdb_iox/issues/1436

# Rationale
See explanation on https://github.com/influxdata/influxdb_iox/pull/1446. TLDR is that the contents of the system table are computed many many times when they are not actually being read.


# Changes
Port `system.chunk_columns`, `system.columns` and `system.operations` so it computes data only when actually needed and only `Arc::clone`s stuff on common operations

# PR sequence
- [x] system.chunks (https://github.com/influxdata/influxdb_iox/pull/1446)
- [x] system.chunk_columns (this PR)
- [x] system.columns (this PR)
- [x] system.operations (this PR)
