### PR TITLE
feat: Include `system.chunk_columns` in the tables that are scraped by observer mode

### DIFF
--- a/src/commands/sql/observer.rs
+++ b/src/commands/sql/observer.rs
@@ -101,7 +101,7 @@ async fn load_remote_system_tables(
     connection: Connection,
 ) -> Result<()> {
     // all prefixed with "system."
-    let table_names = vec!["chunks", "columns", "operations"];
+    let table_names = vec!["chunks", "chunk_columns", "columns", "operations"];
 
     let start = Instant::now();
 


### PR DESCRIPTION
# Rationale
 I want to look at column statistics from the snapshot rather than each individual database (where the data changes over time)