### PR TITLE
feat: workardound bug/limitation in OT handling of observers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1863,6 +1863,7 @@ dependencies = [
  "dashmap",
  "observability_deps",
  "opentelemetry-prometheus",
+ "parking_lot",
  "prometheus",
  "snafu",
 ]

--- a/metrics/Cargo.toml
+++ b/metrics/Cargo.toml
@@ -15,6 +15,7 @@ edition = "2018"
 
 [dependencies] # In alphabetical order
 observability_deps = { path = "../observability_deps" }
+parking_lot = "0.11.1"
 prometheus = "0.12"
 opentelemetry-prometheus = "0.6"
 snafu = "0.6"

--- a/metrics/src/metrics.rs
+++ b/metrics/src/metrics.rs
@@ -8,7 +8,7 @@ use std::{
 use dashmap::DashMap;
 use observability_deps::opentelemetry::{
     labels,
-    metrics::{Counter as OTCounter, ValueObserver as OTGauge, ValueRecorder as OTHistogram},
+    metrics::{Counter as OTCounter, ValueRecorder as OTHistogram},
 };
 
 pub use observability_deps::opentelemetry::KeyValue;
@@ -284,19 +284,16 @@ impl Counter {
 /// (e.g. current memory usage)
 #[derive(Debug)]
 pub struct Gauge {
-    gauge: OTGauge<f64>,
     default_labels: Vec<KeyValue>,
     values: Arc<DashMap<String, (f64, Vec<KeyValue>)>>,
 }
 
 impl Gauge {
     pub(crate) fn new(
-        gauge: OTGauge<f64>,
         default_labels: Vec<KeyValue>,
         values: Arc<DashMap<String, (f64, Vec<KeyValue>)>>,
     ) -> Self {
         Self {
-            gauge,
             default_labels,
             values,
         }

--- a/metrics/src/observer.rs
+++ b/metrics/src/observer.rs
@@ -1,0 +1,173 @@
+//! This module is a gnarly hack around the fact opentelemetry doesn't currently let you
+//! register an observer multiple times with the same name
+//!
+//! See https://github.com/open-telemetry/opentelemetry-rust/issues/541
+
+use std::collections::hash_map::Entry;
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use parking_lot::Mutex;
+
+use observability_deps::opentelemetry::metrics::{Meter, ObserverResult};
+
+type CallbackFunc<T> = Box<dyn Fn(&ObserverResult<T>) + Send + Sync + 'static>;
+
+#[derive(Clone)]
+struct CallbackCollection<T>(Arc<Mutex<Vec<CallbackFunc<T>>>>);
+
+impl<T> CallbackCollection<T> {
+    fn new<F>(f: F) -> Self
+    where
+        F: Fn(&ObserverResult<T>) + Send + Sync + 'static,
+    {
+        Self(Arc::new(Mutex::new(vec![Box::new(f)])))
+    }
+
+    fn push<F>(&self, f: F)
+    where
+        F: Fn(&ObserverResult<T>) + Send + Sync + 'static,
+    {
+        self.0.lock().push(Box::new(f))
+    }
+
+    fn invoke(&self, observer: ObserverResult<T>) {
+        let callbacks = self.0.lock();
+        for callback in callbacks.iter() {
+            callback(&observer)
+        }
+    }
+}
+
+enum Callbacks {
+    U64Value(CallbackCollection<u64>),
+    U64Sum(CallbackCollection<u64>),
+    F64Value(CallbackCollection<f64>),
+    F64Sum(CallbackCollection<f64>),
+}
+
+impl std::fmt::Debug for Callbacks {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match &self {
+            Callbacks::U64Value(_) => write!(f, "U64Value"),
+            Callbacks::U64Sum(_) => write!(f, "U64Sum"),
+            Callbacks::F64Value(_) => write!(f, "F64Value"),
+            Callbacks::F64Sum(_) => write!(f, "F64Sum"),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct ObserverCollection {
+    callbacks: Mutex<HashMap<String, Callbacks>>,
+    meter: Meter,
+}
+
+impl ObserverCollection {
+    pub fn new(meter: Meter) -> Self {
+        Self {
+            callbacks: Default::default(),
+            meter,
+        }
+    }
+
+    pub fn u64_value_observer<F>(
+        &self,
+        name: impl Into<String>,
+        description: impl Into<String>,
+        callback: F,
+    ) where
+        F: Fn(&ObserverResult<u64>) + Send + Sync + 'static,
+    {
+        match self.callbacks.lock().entry(name.into()) {
+            Entry::Occupied(occupied) => match occupied.get() {
+                Callbacks::U64Value(callbacks) => callbacks.push(Box::new(callback)),
+                c => panic!("metric type mismatch, expected U64Value got {:?}", c),
+            },
+            Entry::Vacant(vacant) => {
+                let name = vacant.key().clone();
+                let callbacks = CallbackCollection::new(callback);
+                vacant.insert(Callbacks::U64Value(callbacks.clone()));
+                self.meter
+                    .u64_value_observer(name, move |observer| callbacks.invoke(observer))
+                    .with_description(description)
+                    .init();
+            }
+        }
+    }
+
+    pub fn u64_sum_observer<F>(
+        &self,
+        name: impl Into<String>,
+        description: impl Into<String>,
+        callback: F,
+    ) where
+        F: Fn(&ObserverResult<u64>) + Send + Sync + 'static,
+    {
+        match self.callbacks.lock().entry(name.into()) {
+            Entry::Occupied(occupied) => match occupied.get() {
+                Callbacks::U64Sum(callbacks) => callbacks.push(Box::new(callback)),
+                c => panic!("metric type mismatch, expected U64Sum got {:?}", c),
+            },
+            Entry::Vacant(vacant) => {
+                let name = vacant.key().clone();
+                let callbacks = CallbackCollection::new(callback);
+                vacant.insert(Callbacks::U64Sum(callbacks.clone()));
+                self.meter
+                    .u64_sum_observer(name, move |observer| callbacks.invoke(observer))
+                    .with_description(description)
+                    .init();
+            }
+        }
+    }
+
+    pub fn f64_value_observer<F>(
+        &self,
+        name: impl Into<String>,
+        description: impl Into<String>,
+        callback: F,
+    ) where
+        F: Fn(&ObserverResult<f64>) + Send + Sync + 'static,
+    {
+        match self.callbacks.lock().entry(name.into()) {
+            Entry::Occupied(occupied) => match occupied.get() {
+                Callbacks::F64Value(callbacks) => callbacks.push(Box::new(callback)),
+                c => panic!("metric type mismatch, expected F64Value got {:?}", c),
+            },
+            Entry::Vacant(vacant) => {
+                let name = vacant.key().clone();
+                let callbacks = CallbackCollection::new(callback);
+                vacant.insert(Callbacks::F64Value(callbacks.clone()));
+                self.meter
+                    .f64_value_observer(name, move |observer| callbacks.invoke(observer))
+                    .with_description(description)
+                    .init();
+            }
+        }
+    }
+
+    pub fn f64_sum_observer<F>(
+        &self,
+        name: impl Into<String>,
+        description: impl Into<String>,
+        callback: F,
+    ) where
+        F: Fn(&ObserverResult<f64>) + Send + Sync + 'static,
+    {
+        match self.callbacks.lock().entry(name.into()) {
+            Entry::Occupied(occupied) => match occupied.get() {
+                Callbacks::F64Sum(callbacks) => callbacks.push(Box::new(callback)),
+                c => panic!("metric type mismatch, expected F64Sum got {:?}", c),
+            },
+            Entry::Vacant(vacant) => {
+                let name = vacant.key().clone();
+                let callbacks = CallbackCollection::new(callback);
+                vacant.insert(Callbacks::F64Sum(callbacks.clone()));
+                self.meter
+                    .f64_sum_observer(name, move |observer| callbacks.invoke(observer))
+                    .with_description(description)
+                    .init();
+            }
+        }
+    }
+}


### PR DESCRIPTION
I spent the entire afternoon trying to avoid this, but believe it or not, this was the cleanest way I could devise to workaround the OpenTelemetry bug/limitation that prevents registering multiple observers with the same name. I've filed an upstream bug [here](https://github.com/open-telemetry/opentelemetry-rust/issues/541).

The shim feels like it shouldn't be necessary, but despite digging into the guts of OpenTelemetry I couldn't work out a way to bypass the UniqueInstrumentMeterCore behaviour
