### PR TITLE
feat: cow write format

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1642,6 +1642,7 @@ version = "0.1.0"
 dependencies = [
  "arrow 0.1.0",
  "arrow_util",
+ "hashbrown 0.11.2",
  "observability_deps",
  "snafu",
 ]

--- a/internal_types/Cargo.toml
+++ b/internal_types/Cargo.toml
@@ -8,8 +8,9 @@ readme = "README.md"
 
 [dependencies]
 arrow = { path = "../arrow" }
-snafu = "0.6"
+hashbrown = "0.11"
 observability_deps = { path = "../observability_deps" }
+snafu = "0.6"
 
 [dev-dependencies]
 arrow_util = { path = "../arrow_util" }

--- a/internal_types/src/lib.rs
+++ b/internal_types/src/lib.rs
@@ -10,3 +10,4 @@ pub mod arrow;
 pub mod once;
 pub mod schema;
 pub mod selection;
+pub mod write;

--- a/internal_types/src/write.rs
+++ b/internal_types/src/write.rs
@@ -1,0 +1,100 @@
+//! A generic representation of columnar data that is agnostic to the underlying representation
+
+use crate::schema::InfluxColumnType;
+use hashbrown::HashMap;
+use std::borrow::Cow;
+
+#[derive(Debug, Clone)]
+pub struct TableWrite<'a> {
+    pub columns: HashMap<Cow<'a, str>, ColumnWrite<'a>>,
+}
+
+#[derive(Debug, Clone)]
+pub struct ColumnWrite<'a> {
+    pub row_count: usize,
+    pub influx_type: InfluxColumnType,
+    pub valid_mask: Cow<'a, [u8]>,
+    pub values: ColumnWriteValues<'a>,
+}
+
+#[derive(Debug, Clone)]
+pub enum ColumnWriteValues<'a> {
+    F64(Cow<'a, [f64]>),
+    I64(Cow<'a, [i64]>),
+    U64(Cow<'a, [u64]>),
+    String(Cow<'a, [Cow<'a, str>]>),
+    PackedString(PackedStrings<'a>),
+    Dictionary(Dictionary<'a>),
+    PackedBool(Cow<'a, [u8]>),
+    Bool(Cow<'a, [bool]>),
+}
+
+impl<'a> ColumnWriteValues<'a> {
+    pub fn f64(&self) -> Option<&[f64]> {
+        match &self {
+            Self::F64(data) => Some(data.as_ref()),
+            _ => None,
+        }
+    }
+
+    pub fn i64(&self) -> Option<&[i64]> {
+        match &self {
+            Self::I64(data) => Some(data.as_ref()),
+            _ => None,
+        }
+    }
+
+    pub fn u64(&self) -> Option<&[u64]> {
+        match &self {
+            Self::U64(data) => Some(data.as_ref()),
+            _ => None,
+        }
+    }
+
+    pub fn string(&self) -> Option<&[Cow<'a, str>]> {
+        match &self {
+            Self::String(data) => Some(data.as_ref()),
+            _ => None,
+        }
+    }
+
+    pub fn packed_string(&self) -> Option<&PackedStrings<'a>> {
+        match &self {
+            Self::PackedString(data) => Some(data),
+            _ => None,
+        }
+    }
+
+    pub fn dictionary(&self) -> Option<&Dictionary<'a>> {
+        match &self {
+            Self::Dictionary(data) => Some(data),
+            _ => None,
+        }
+    }
+
+    pub fn packed_bool(&self) -> Option<&[u8]> {
+        match &self {
+            Self::PackedBool(data) => Some(data.as_ref()),
+            _ => None,
+        }
+    }
+
+    pub fn bool(&self) -> Option<&[bool]> {
+        match &self {
+            Self::Bool(data) => Some(data.as_ref()),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct PackedStrings<'a> {
+    pub indexes: Cow<'a, [u16]>,
+    pub values: Cow<'a, str>,
+}
+
+#[derive(Debug, Clone)]
+pub struct Dictionary<'a> {
+    pub keys: Cow<'a, [u16]>,
+    pub values: PackedStrings<'a>,
+}


### PR DESCRIPTION
We already have at least 3 ingest formats and this is only likely to increase:

* Line protocol
* Entry Flatbuffer
* The Protobuf format @jacobmarble is working on

Currently all writes must be converted to an entry flatbuffer before they can be ingested into the MUB. This is unfortunate:

* The ingest path for non-flatbuffer writes ends up rather convoluted
    * Are loaded from whatever wire format they have 
    * Are coalesced into a temporary columnar structure `entry::ColumnRaw`
    * Are then converted from this into an entry flatbuffer
    * Are then sent to the MUB
* It restricts ingest to what the entry flatbuffer can represent - e.g. no dictionary encoded or packed strings
* The flatbuffers are pretty unpleasant to work with and the unsafe is strong... 

This PR adds a cow structure, that can be used to represent data in the manner it arrives. Subsequent PRs (which are written just need polishing if this accepted) can build TableWrites from line protocol, ingest TableWrites to the MUB, convert Entry to/from collections of TableWrites.

This is effectively free, it only ever does less work than before, with one caveat - flatbuffers don't store string arrays contiguously, so there is no efficient way to map this. In practice this means constructing a Vec<&str> for string columns. I would like to propose that the flatbuffer stores packed strings for this and arrow compatibility, but in the short-term the overhead is marginal