### PR TITLE
fix: Add more logging context to panic

### DIFF
--- a/data_types/src/error.rs
+++ b/data_types/src/error.rs
@@ -4,8 +4,8 @@ use std::fmt::Debug;
 use observability_deps::tracing::error;
 
 /// Add ability for Results to log error messages via `error!` logs.
-/// This is useful when using async tasks that may not have a natural
-/// return error
+/// This is useful when using async tasks that may not have any code
+/// checking their return values.
 pub trait ErrorLogger {
     /// Log the contents of self with a string of context. The context
     /// should appear in a message such as


### PR DESCRIPTION
re #1465

# Rationale

I saw this `panic` happen on tools -- I don't know the root cause yet so gathering more context is my first step towards fixing it.

FWIW here is the query I was running:
```
select count(distinct workqueue_retries_total) as num_distinct, count(distinct case when workqueue_retries_total is NOT NULL then workqueue_retries_total else 'Nan' end) from prometheus;
```

# Changes

Add some extra error logging when the panic's happen

Note I also tried making these return proper errors rather than panic, but that got invasive quickly (as creating a `snapshot` is treated as infallible). This is as far as I got: https://github.com/influxdata/influxdb_iox/pull/new/alamb/less_panic

Since I am not convinced this is a real "error" (It seems more like some internal bug) I opted for the quicker and dirtier fix of adding more logging
