### PR TITLE
feat: construct entry from TableWrite

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1650,7 +1650,9 @@ version = "0.1.0"
 dependencies = [
  "arrow 0.1.0",
  "arrow_util",
+ "chrono",
  "hashbrown 0.11.2",
+ "influxdb_line_protocol",
  "observability_deps",
  "snafu",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1593,7 +1593,7 @@ version = "0.1.0"
 dependencies = [
  "nom",
  "observability_deps",
- "smallvec",
+ "ouroboros",
  "snafu",
  "test_helpers",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -952,10 +952,12 @@ checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
 name = "entry"
 version = "0.1.0"
 dependencies = [
+ "arrow_util",
  "chrono",
  "criterion",
  "data_types",
  "flatbuffers",
+ "hashbrown 0.11.2",
  "influxdb_line_protocol",
  "internal_types",
  "ouroboros",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1650,6 +1650,7 @@ version = "0.1.0"
 dependencies = [
  "arrow 0.1.0",
  "arrow_util",
+ "hashbrown 0.11.2",
  "observability_deps",
  "snafu",
 ]

--- a/entry/Cargo.toml
+++ b/entry/Cargo.toml
@@ -6,11 +6,13 @@ edition = "2018"
 description = "The entry format used by the write buffer"
 
 [dependencies]
+arrow_util = { path = "../arrow_util" }
 chrono = { version = "0.4", features = ["serde"] }
 data_types = { path = "../data_types" }
 # See docs/regenerating_flatbuffers.md about updating generated code when updating the
 # version of the flatbuffers crate
 flatbuffers = "0.8"
+hashbrown = "0.11"
 snafu = "0.6"
 influxdb_line_protocol = { path = "../influxdb_line_protocol" }
 ouroboros = "0.8.3"

--- a/entry/src/lib.rs
+++ b/entry/src/lib.rs
@@ -1,4 +1,5 @@
 mod entry;
+mod write;
 
 #[allow(unused_imports)]
 mod entry_generated;

--- a/entry/src/write.rs
+++ b/entry/src/write.rs
@@ -1,0 +1,109 @@
+use crate::entry;
+use crate::entry_fb::ColumnValues;
+use internal_types::write::{ColumnWrite, ColumnWriteValues, TableWrite};
+
+impl<'a> From<entry::TableBatch<'a>> for TableWrite<'a> {
+    fn from(batch: entry::TableBatch<'a>) -> Self {
+        (&batch).into()
+    }
+}
+
+impl<'a> From<&entry::TableBatch<'a>> for TableWrite<'a> {
+    fn from(batch: &entry::TableBatch<'a>) -> Self {
+        Self {
+            columns: batch
+                .columns()
+                .into_iter()
+                .map(|batch| {
+                    let column = batch.name().into();
+                    (column, batch.into())
+                })
+                .collect(),
+        }
+    }
+}
+
+impl<'a> From<entry::Column<'a>> for ColumnWrite<'a> {
+    fn from(batch: entry::Column<'a>) -> Self {
+        let values = match batch.inner().values_type() {
+            ColumnValues::I64Values => ColumnWriteValues::I64(
+                batch
+                    .inner()
+                    .values_as_i64values()
+                    .unwrap()
+                    .values()
+                    .unwrap()
+                    .safe_slice()
+                    .into(),
+            ),
+            ColumnValues::F64Values => ColumnWriteValues::F64(
+                batch
+                    .inner()
+                    .values_as_f64values()
+                    .unwrap()
+                    .values()
+                    .unwrap()
+                    .safe_slice()
+                    .into(),
+            ),
+            ColumnValues::U64Values => ColumnWriteValues::U64(
+                batch
+                    .inner()
+                    .values_as_u64values()
+                    .unwrap()
+                    .values()
+                    .unwrap()
+                    .safe_slice()
+                    .into(),
+            ),
+            ColumnValues::StringValues => ColumnWriteValues::String(
+                // TODO: This is unfortunate, perhaps the FlatBuffer should be packed and/or dictionary encoded
+                batch
+                    .inner()
+                    .values_as_string_values()
+                    .unwrap()
+                    .values()
+                    .unwrap()
+                    .iter()
+                    .map(Into::into)
+                    .collect::<Vec<_>>()
+                    .into(),
+            ),
+            ColumnValues::BoolValues => ColumnWriteValues::Bool(
+                batch
+                    .inner()
+                    .values_as_bool_values()
+                    .unwrap()
+                    .values()
+                    .unwrap()
+                    .into(),
+            ),
+            _ => unreachable!(),
+        };
+
+        Self {
+            row_count: batch.row_count,
+            influx_type: batch.influx_type(),
+            valid_mask: construct_valid_mask(batch.inner().null_mask(), batch.row_count).into(),
+            values,
+        }
+    }
+}
+
+/// Construct a validity mask from the given column's null mask
+fn construct_valid_mask(mask: Option<&[u8]>, row_count: usize) -> Vec<u8> {
+    let buf_len = (row_count + 7) >> 3;
+    match mask {
+        Some(data) => {
+            debug_assert!(data.len() == buf_len);
+
+            data.iter().map(|x| !x).collect()
+        }
+        None => {
+            // If no null mask they're all valid
+            let mut data = Vec::new();
+            data.resize(buf_len, 0xFF);
+            data
+        }
+    }
+}

--- a/influxdb_line_protocol/Cargo.toml
+++ b/influxdb_line_protocol/Cargo.toml
@@ -6,9 +6,9 @@ edition = "2018"
 
 [dependencies] # In alphabetical order
 nom = "5.1.1"
-smallvec = "1.2.0"
 snafu = "0.6.2"
 observability_deps = { path = "../observability_deps" }
+ouroboros = "0.8.3"
 
 [dev-dependencies] # In alphabetical order
 test_helpers = { path = "../test_helpers" }

--- a/influxdb_line_protocol/src/lib.rs
+++ b/influxdb_line_protocol/src/lib.rs
@@ -453,6 +453,27 @@ impl From<EscapedStr<'_>> for String {
     }
 }
 
+impl<'a> From<EscapedStr<'a>> for Cow<'a, str> {
+    fn from(other: EscapedStr<'a>) -> Self {
+        match other {
+            EscapedStr::SingleSlice(s) => Self::Borrowed(s),
+            EscapedStr::CopiedValue(s) => Self::Owned(s),
+        }
+    }
+}
+
+impl<'a, 'b> From<&'b EscapedStr<'a>> for Cow<'a, str>
+where
+    'a: 'b,
+{
+    fn from(other: &'b EscapedStr<'a>) -> Self {
+        match other {
+            EscapedStr::SingleSlice(s) => Self::Borrowed(s),
+            EscapedStr::CopiedValue(s) => Self::Owned(s.clone()),
+        }
+    }
+}
+
 impl From<&EscapedStr<'_>> for String {
     fn from(other: &EscapedStr<'_>) -> Self {
         other.to_string()
@@ -1034,7 +1055,7 @@ const FIELD_KEY_DELIMITERS: &[char] = TAG_KEY_DELIMITERS;
 /// Characters to escape when writing string values in fields
 const FIELD_VALUE_STRING_DELIMITERS: &[char] = &['"'];
 
-/// Writes a str value to f, escaping all caracters in
+/// Writes a str value to f, escaping all characters in
 /// escaping_escaping specificiation.
 ///
 /// Use the constants defined in this module

--- a/internal_types/Cargo.toml
+++ b/internal_types/Cargo.toml
@@ -8,7 +8,10 @@ readme = "README.md"
 
 [dependencies]
 arrow = { path = "../arrow" }
+arrow_util = { path = "../arrow_util" }
+chrono = "0.4"
 hashbrown = "0.11"
+influxdb_line_protocol = { path = "../influxdb_line_protocol" }
 observability_deps = { path = "../observability_deps" }
 snafu = "0.6"
 

--- a/internal_types/Cargo.toml
+++ b/internal_types/Cargo.toml
@@ -8,8 +8,9 @@ readme = "README.md"
 
 [dependencies]
 arrow = { path = "../arrow" }
-snafu = "0.6"
+hashbrown = "0.11"
 observability_deps = { path = "../observability_deps" }
+snafu = "0.6"
 
 [dev-dependencies]
 arrow_util = { path = "../arrow_util" }

--- a/internal_types/src/lib.rs
+++ b/internal_types/src/lib.rs
@@ -10,3 +10,4 @@ pub mod arrow;
 pub mod once;
 pub mod schema;
 pub mod selection;
+pub mod write;

--- a/internal_types/src/write.rs
+++ b/internal_types/src/write.rs
@@ -4,6 +4,9 @@ use crate::schema::InfluxColumnType;
 use hashbrown::HashMap;
 use std::borrow::Cow;
 
+pub mod builder;
+pub mod line_protocol;
+
 #[derive(Debug, Clone)]
 pub struct TableWrite<'a> {
     pub columns: HashMap<Cow<'a, str>, ColumnWrite<'a>>,

--- a/internal_types/src/write.rs
+++ b/internal_types/src/write.rs
@@ -1,0 +1,100 @@
+//! A generic representation of columnar data that is agnostic to the underlying representation
+
+use crate::schema::InfluxColumnType;
+use hashbrown::HashMap;
+use std::borrow::Cow;
+
+#[derive(Debug, Clone)]
+pub struct TableWrite<'a> {
+    pub columns: HashMap<Cow<'a, str>, ColumnWrite<'a>>,
+}
+
+#[derive(Debug, Clone)]
+pub struct ColumnWrite<'a> {
+    pub row_count: usize,
+    pub influx_type: InfluxColumnType,
+    pub valid_mask: Cow<'a, [u8]>,
+    pub values: ColumnWriteValues<'a>,
+}
+
+#[derive(Debug, Clone)]
+pub enum ColumnWriteValues<'a> {
+    F64(Cow<'a, [f64]>),
+    I64(Cow<'a, [i64]>),
+    U64(Cow<'a, [u64]>),
+    String(Cow<'a, [Cow<'a, str>]>),
+    PackedString(PackedStrings<'a>),
+    Dictionary(Dictionary<'a>),
+    PackedBool(Cow<'a, [u8]>),
+    Bool(Cow<'a, [bool]>),
+}
+
+impl<'a> ColumnWriteValues<'a> {
+    pub fn f64(&self) -> Option<&[f64]> {
+        match &self {
+            Self::F64(data) => Some(data.as_ref()),
+            _ => None,
+        }
+    }
+
+    pub fn i64(&self) -> Option<&[i64]> {
+        match &self {
+            Self::I64(data) => Some(data.as_ref()),
+            _ => None,
+        }
+    }
+
+    pub fn u64(&self) -> Option<&[u64]> {
+        match &self {
+            Self::U64(data) => Some(data.as_ref()),
+            _ => None,
+        }
+    }
+
+    pub fn string(&self) -> Option<&[Cow<'a, str>]> {
+        match &self {
+            Self::String(data) => Some(data.as_ref()),
+            _ => None,
+        }
+    }
+
+    pub fn packed_string(&self) -> Option<&PackedStrings<'a>> {
+        match &self {
+            Self::PackedString(data) => Some(data),
+            _ => None,
+        }
+    }
+
+    pub fn dictionary(&self) -> Option<&Dictionary<'a>> {
+        match &self {
+            Self::Dictionary(data) => Some(data),
+            _ => None,
+        }
+    }
+
+    pub fn packed_bool(&self) -> Option<&[u8]> {
+        match &self {
+            Self::PackedBool(data) => Some(data.as_ref()),
+            _ => None,
+        }
+    }
+
+    pub fn bool(&self) -> Option<&[bool]> {
+        match &self {
+            Self::Bool(data) => Some(data.as_ref()),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct PackedStrings<'a> {
+    pub indexes: Cow<'a, [u16]>,
+    pub values: Cow<'a, str>,
+}
+
+#[derive(Debug, Clone)]
+pub struct Dictionary<'a> {
+    pub keys: Cow<'a, [u16]>,
+    pub values: PackedStrings<'a>,
+}

--- a/internal_types/src/write/builder.rs
+++ b/internal_types/src/write/builder.rs
@@ -1,0 +1,307 @@
+use snafu::{ensure, Snafu};
+
+use arrow_util::bitset::BitSet;
+use arrow_util::dictionary::StringDictionary;
+use arrow_util::string::PackedStringArray;
+
+use crate::schema::{InfluxColumnType, InfluxFieldType};
+use crate::write::{ColumnWrite, ColumnWriteValues, Dictionary, PackedStrings};
+use std::borrow::Cow;
+
+#[derive(Debug, Snafu)]
+pub enum Error {
+    #[snafu(display("influx type mismatch: expected {} but got {}", expected, new))]
+    InfluxTypeMismatch {
+        new: InfluxColumnType,
+        expected: InfluxColumnType,
+    },
+
+    #[snafu(display("physical type mismatch: expected {} but got {}", expected, new))]
+    PhysicalTypeMismatch {
+        new: &'static str,
+        expected: &'static str,
+    },
+}
+
+pub type Result<T, E = Error> = std::result::Result<T, E>;
+
+#[derive(Debug)]
+pub struct ColumnWriteBuilder<'a> {
+    influx_type: InfluxColumnType,
+    valid_mask: BitSet,
+    values: ColumnValues<'a>,
+}
+
+impl<'a> ColumnWriteBuilder<'a> {
+    pub fn new_tag_column(dictionary: bool, packed: bool, initial_nulls: usize) -> Self {
+        Self {
+            influx_type: InfluxColumnType::Tag,
+            valid_mask: BitSet::new_with_unset(initial_nulls),
+            values: ColumnValues::new_str(dictionary, packed),
+        }
+    }
+
+    pub fn new_string_column(dictionary: bool, packed: bool, initial_nulls: usize) -> Self {
+        Self {
+            influx_type: InfluxColumnType::Field(InfluxFieldType::String),
+            valid_mask: BitSet::new_with_unset(initial_nulls),
+            values: ColumnValues::new_str(dictionary, packed),
+        }
+    }
+
+    pub fn new_time_column(initial_nulls: usize) -> Self {
+        Self {
+            influx_type: InfluxColumnType::Timestamp,
+            valid_mask: BitSet::new_with_unset(initial_nulls),
+            values: ColumnValues::I64(Vec::new()),
+        }
+    }
+
+    pub fn new_bool_column(packed: bool, initial_nulls: usize) -> Self {
+        let values = match packed {
+            true => ColumnValues::PackedBool(BitSet::new()),
+            false => ColumnValues::Bool(Vec::new()),
+        };
+
+        Self {
+            influx_type: InfluxColumnType::Field(InfluxFieldType::Boolean),
+            valid_mask: BitSet::new_with_unset(initial_nulls),
+            values,
+        }
+    }
+
+    pub fn new_u64_column(initial_nulls: usize) -> Self {
+        Self {
+            influx_type: InfluxColumnType::Field(InfluxFieldType::UInteger),
+            valid_mask: BitSet::new_with_unset(initial_nulls),
+            values: ColumnValues::U64(Vec::new()),
+        }
+    }
+
+    pub fn new_f64_column(initial_nulls: usize) -> Self {
+        Self {
+            influx_type: InfluxColumnType::Field(InfluxFieldType::Float),
+            valid_mask: BitSet::new_with_unset(initial_nulls),
+            values: ColumnValues::F64(Vec::new()),
+        }
+    }
+
+    pub fn new_i64_column(initial_nulls: usize) -> Self {
+        Self {
+            influx_type: InfluxColumnType::Field(InfluxFieldType::Integer),
+            valid_mask: BitSet::new_with_unset(initial_nulls),
+            values: ColumnValues::I64(Vec::new()),
+        }
+    }
+
+    // ensures there are at least as many rows (or nulls) to idx
+    pub fn null_to_idx(&mut self, idx: usize) {
+        if idx > self.valid_mask.len() {
+            self.valid_mask.append_unset(idx - self.valid_mask.len())
+        }
+    }
+
+    pub fn push_tag(&mut self, value: Cow<'a, str>) -> Result<()> {
+        self.verify_type(InfluxColumnType::Tag)?;
+        self.values.push_str(value)?;
+        self.valid_mask.push(true);
+        Ok(())
+    }
+
+    pub fn push_string(&mut self, value: Cow<'a, str>) -> Result<()> {
+        self.verify_type(InfluxColumnType::Field(InfluxFieldType::String))?;
+        self.values.push_str(value)?;
+        self.valid_mask.push(true);
+        Ok(())
+    }
+
+    pub fn push_time(&mut self, value: i64) -> Result<()> {
+        self.verify_type(InfluxColumnType::Timestamp)?;
+        self.values.push_i64(value)?;
+        self.valid_mask.push(true);
+        Ok(())
+    }
+
+    pub fn push_bool(&mut self, value: bool) -> Result<()> {
+        self.verify_type(InfluxColumnType::Field(InfluxFieldType::Boolean))?;
+        self.values.push_bool(value)?;
+        self.valid_mask.push(true);
+        Ok(())
+    }
+
+    pub fn push_u64(&mut self, value: u64) -> Result<()> {
+        self.verify_type(InfluxColumnType::Field(InfluxFieldType::UInteger))?;
+        self.values.push_u64(value)?;
+        self.valid_mask.push(true);
+        Ok(())
+    }
+
+    pub fn push_f64(&mut self, value: f64) -> Result<()> {
+        self.verify_type(InfluxColumnType::Field(InfluxFieldType::Float))?;
+        self.values.push_f64(value)?;
+        self.valid_mask.push(true);
+        Ok(())
+    }
+
+    pub fn push_i64(&mut self, value: i64) -> Result<()> {
+        self.verify_type(InfluxColumnType::Field(InfluxFieldType::Integer))?;
+        self.values.push_i64(value)?;
+        self.valid_mask.push(true);
+        Ok(())
+    }
+
+    pub fn verify_type(&self, influx_type: InfluxColumnType) -> Result<()> {
+        ensure!(
+            self.influx_type == influx_type,
+            InfluxTypeMismatch {
+                new: influx_type,
+                expected: self.influx_type,
+            }
+        );
+        Ok(())
+    }
+
+    pub fn build(self) -> ColumnWrite<'a> {
+        ColumnWrite {
+            row_count: self.valid_mask.len(),
+            influx_type: self.influx_type,
+            valid_mask: self.valid_mask.take_bytes().into(),
+            values: self.values.into(),
+        }
+    }
+}
+
+#[derive(Debug)]
+enum ColumnValues<'a> {
+    F64(Vec<f64>),
+    I64(Vec<i64>),
+    U64(Vec<u64>),
+    String(Vec<Cow<'a, str>>),
+    PackedString(PackedStringArray<u16>),
+    Dictionary(StringDictionary<u16>, Vec<u16>),
+    PackedBool(BitSet),
+    Bool(Vec<bool>),
+}
+
+impl<'a> From<ColumnValues<'a>> for ColumnWriteValues<'a> {
+    fn from(raw: ColumnValues<'a>) -> Self {
+        match raw {
+            ColumnValues::F64(data) => Self::F64(data.into()),
+            ColumnValues::I64(data) => Self::I64(data.into()),
+            ColumnValues::U64(data) => Self::U64(data.into()),
+            ColumnValues::String(data) => Self::String(data.into()),
+            ColumnValues::PackedString(data) => {
+                let (indexes, values) = data.into_inner();
+                Self::PackedString(PackedStrings {
+                    indexes: indexes.into(),
+                    values: values.into(),
+                })
+            }
+            ColumnValues::Dictionary(dictionary, keys) => {
+                let (indexes, values) = dictionary.into_inner().into_inner();
+                Self::Dictionary(Dictionary {
+                    keys: keys.into(),
+                    values: PackedStrings {
+                        indexes: indexes.into(),
+                        values: values.into(),
+                    },
+                })
+            }
+            ColumnValues::PackedBool(data) => Self::PackedBool(data.take_bytes().into()),
+            ColumnValues::Bool(data) => Self::Bool(data.into()),
+        }
+    }
+}
+
+impl<'a> ColumnValues<'a> {
+    fn new_str(dictionary: bool, packed: bool) -> Self {
+        match (dictionary, packed) {
+            (true, _) => ColumnValues::Dictionary(StringDictionary::new(), Vec::new()),
+            (false, true) => ColumnValues::PackedString(PackedStringArray::new()),
+            (false, false) => ColumnValues::String(Vec::new()),
+        }
+    }
+
+    fn push_str(&mut self, value: Cow<'a, str>) -> Result<()> {
+        match self {
+            ColumnValues::String(data) => {
+                data.push(value);
+            }
+            ColumnValues::PackedString(data) => {
+                data.append(value.as_ref());
+            }
+            ColumnValues::Dictionary(dictionary, values) => {
+                let id = dictionary.lookup_value_or_insert(value.as_ref());
+                values.push(id);
+            }
+            _ => PhysicalTypeMismatch {
+                new: "str",
+                expected: self.type_description(),
+            }
+            .fail()?,
+        }
+        Ok(())
+    }
+
+    fn push_i64(&mut self, value: i64) -> Result<()> {
+        match self {
+            ColumnValues::I64(data) => data.push(value),
+            _ => PhysicalTypeMismatch {
+                new: "i64",
+                expected: self.type_description(),
+            }
+            .fail()?,
+        }
+        Ok(())
+    }
+
+    fn push_u64(&mut self, value: u64) -> Result<()> {
+        match self {
+            ColumnValues::U64(data) => data.push(value),
+            _ => PhysicalTypeMismatch {
+                new: "u64",
+                expected: self.type_description(),
+            }
+            .fail()?,
+        }
+        Ok(())
+    }
+
+    fn push_f64(&mut self, value: f64) -> Result<()> {
+        match self {
+            ColumnValues::F64(data) => data.push(value),
+            _ => PhysicalTypeMismatch {
+                new: "f64",
+                expected: self.type_description(),
+            }
+            .fail()?,
+        }
+        Ok(())
+    }
+
+    fn push_bool(&mut self, value: bool) -> Result<()> {
+        match self {
+            ColumnValues::Bool(data) => data.push(value),
+            ColumnValues::PackedBool(data) => data.push(value),
+            _ => PhysicalTypeMismatch {
+                new: "bool",
+                expected: self.type_description(),
+            }
+            .fail()?,
+        }
+        Ok(())
+    }
+
+    fn type_description(&self) -> &'static str {
+        match &self {
+            Self::F64(_) => "f64",
+            Self::I64(_) => "i64",
+            Self::U64(_) => "u64",
+            Self::String(_) => "str",
+            Self::PackedString(_) => "packed_str",
+            Self::Dictionary(_, _) => "dict",
+            Self::PackedBool(_) => "packed_bool",
+            Self::Bool(_) => "bool",
+        }
+    }
+}

--- a/internal_types/src/write/line_protocol.rs
+++ b/internal_types/src/write/line_protocol.rs
@@ -1,0 +1,459 @@
+use std::borrow::Cow;
+use std::hash::Hash;
+
+use chrono::Utc;
+use hashbrown::HashMap;
+use snafu::{ResultExt, Snafu};
+
+use influxdb_line_protocol::{parse_lines, FieldValue, ParsedLine};
+
+use crate::schema::TIME_COLUMN_NAME;
+use crate::write::builder::ColumnWriteBuilder;
+use crate::write::TableWrite;
+
+#[derive(Debug, Snafu)]
+pub enum Error<E: std::error::Error + Sized + 'static> {
+    #[snafu(display("Parse error at line {}: {}", line_number, source))]
+    ParseError { line_number: usize, source: E },
+
+    #[snafu(display("Column error at line {}: {}", line_number, source))]
+    ColumnError {
+        line_number: usize,
+        source: crate::write::builder::Error,
+    },
+}
+
+#[derive(Debug)]
+pub struct Options {
+    pub default_time: i64,
+    pub tag_dictionary: bool,
+    pub tag_packed: bool,
+    pub string_dictionary: bool,
+    pub string_packed: bool,
+    pub bool_packed: bool,
+}
+
+impl Default for Options {
+    fn default() -> Self {
+        Self {
+            default_time: Utc::now().timestamp_nanos(),
+            tag_dictionary: false,
+            tag_packed: false,
+            string_dictionary: false,
+            string_packed: false,
+            bool_packed: false,
+        }
+    }
+}
+
+pub fn lp_to_table_writes<'a>(
+    lp: &'a str,
+    options: &Options,
+) -> Result<HashMap<Cow<'a, str>, TableWrite<'a>>, Error<influxdb_line_protocol::Error>> {
+    let collected = parse_lines(lp)
+        .enumerate()
+        .map(|(idx, res)| {
+            let line = res.context(ParseError {
+                line_number: idx + 1,
+            })?;
+            Ok(line)
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+
+    let mut partitioned = lines_to_table_writes(
+        collected
+            .iter()
+            .map(|line| Ok::<_, influxdb_line_protocol::Error>(((), line))),
+        options,
+    )?;
+
+    Ok(partitioned.remove(&()).unwrap())
+}
+
+pub fn lines_to_table_writes<'a, 'b, K, I, E>(
+    lines: I,
+    options: &Options,
+) -> Result<HashMap<K, HashMap<Cow<'a, str>, TableWrite<'a>>>, Error<E>>
+where
+    'a: 'b,
+    K: 'a + PartialEq + Eq + Hash,
+    I: Iterator<Item = Result<(K, &'b ParsedLine<'a>), E>>,
+    E: std::error::Error + Send + Sync + 'static,
+{
+    let mut partitioned_builders: HashMap<
+        K,
+        HashMap<Cow<'a, str>, (usize, HashMap<Cow<'a, str>, ColumnWriteBuilder<'a>>)>,
+    > = Default::default();
+
+    for (idx, line) in lines.enumerate() {
+        let (key, line) = line.context(ParseError {
+            line_number: idx + 1,
+        })?;
+
+        let builders = partitioned_builders.entry(key).or_default();
+        let (rows, table) = builders
+            .entry((&line.series.measurement).into())
+            .or_default();
+        let start_rows = *rows;
+        *rows += 1;
+
+        if let Some(tagset) = &line.series.tag_set {
+            for (key, value) in tagset {
+                let builder = table.entry(key.into()).or_insert_with(|| {
+                    ColumnWriteBuilder::new_tag_column(
+                        options.tag_dictionary,
+                        options.tag_packed,
+                        start_rows,
+                    )
+                });
+                builder.push_tag(value.into()).context(ColumnError {
+                    line_number: idx + 1,
+                })?
+            }
+        }
+
+        for (key, value) in &line.field_set {
+            match value {
+                FieldValue::I64(data) => {
+                    let builder = table
+                        .entry(key.into())
+                        .or_insert_with(|| ColumnWriteBuilder::new_i64_column(start_rows));
+                    builder.push_i64(*data).context(ColumnError {
+                        line_number: idx + 1,
+                    })?;
+                }
+                FieldValue::U64(data) => {
+                    let builder = table
+                        .entry(key.into())
+                        .or_insert_with(|| ColumnWriteBuilder::new_u64_column(start_rows));
+                    builder.push_u64(*data).context(ColumnError {
+                        line_number: idx + 1,
+                    })?;
+                }
+                FieldValue::F64(data) => {
+                    let builder = table
+                        .entry(key.into())
+                        .or_insert_with(|| ColumnWriteBuilder::new_f64_column(start_rows));
+                    builder.push_f64(*data).context(ColumnError {
+                        line_number: idx + 1,
+                    })?;
+                }
+                FieldValue::String(data) => {
+                    let builder = table.entry(key.into()).or_insert_with(|| {
+                        ColumnWriteBuilder::new_string_column(
+                            options.string_dictionary,
+                            options.string_packed,
+                            start_rows,
+                        )
+                    });
+                    builder.push_string(data.into()).context(ColumnError {
+                        line_number: idx + 1,
+                    })?;
+                }
+                FieldValue::Boolean(data) => {
+                    let builder = table.entry(key.into()).or_insert_with(|| {
+                        ColumnWriteBuilder::new_bool_column(options.bool_packed, start_rows)
+                    });
+                    builder.push_bool(*data).context(ColumnError {
+                        line_number: idx + 1,
+                    })?;
+                }
+            }
+        }
+
+        let builder = table
+            .entry(TIME_COLUMN_NAME.into())
+            .or_insert_with(|| ColumnWriteBuilder::new_time_column(start_rows));
+
+        builder
+            .push_time(line.timestamp.unwrap_or_else(|| options.default_time))
+            .unwrap();
+
+        for builder in table.values_mut() {
+            builder.null_to_idx(*rows)
+        }
+    }
+
+    Ok(partitioned_builders
+        .into_iter()
+        .map(|(k, builders)| {
+            (
+                k,
+                builders
+                    .into_iter()
+                    .map(|(name, (_, columns))| {
+                        (
+                            name,
+                            TableWrite {
+                                columns: columns
+                                    .into_iter()
+                                    .map(|(column_name, builder)| (column_name, builder.build()))
+                                    .collect(),
+                            },
+                        )
+                    })
+                    .collect(),
+            )
+        })
+        .collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::schema::{InfluxColumnType, InfluxFieldType};
+
+    use super::*;
+
+    #[test]
+    fn test_basic() {
+        let lp = r#"
+            a,host=a ival=23i,fval=1.2,uval=7u,sval="hi",bval=true 1
+            a,host=b ival=22i,fval=2.2,uval=1u,sval="world",bval=false 2
+        "#;
+
+        let writes = lp_to_table_writes(lp, &Options::default()).unwrap();
+
+        assert_eq!(writes.len(), 1);
+        assert_eq!(writes["a"].columns.len(), 7);
+
+        let columns = &writes["a"].columns;
+
+        assert_eq!(columns["host"].influx_type, InfluxColumnType::Tag);
+        assert_eq!(columns["host"].valid_mask.as_ref(), &[0b00000011]);
+        assert_eq!(columns["host"].values.string().unwrap(), &["a", "b"]);
+
+        assert_eq!(
+            columns["ival"].influx_type,
+            InfluxColumnType::Field(InfluxFieldType::Integer)
+        );
+        assert_eq!(columns["ival"].valid_mask.as_ref(), &[0b00000011]);
+        assert_eq!(columns["ival"].values.i64().unwrap(), &[23, 22]);
+
+        assert_eq!(
+            columns["fval"].influx_type,
+            InfluxColumnType::Field(InfluxFieldType::Float)
+        );
+        assert_eq!(columns["fval"].valid_mask.as_ref(), &[0b00000011]);
+        assert_eq!(columns["fval"].values.f64().unwrap(), &[1.2, 2.2]);
+
+        assert_eq!(
+            columns["uval"].influx_type,
+            InfluxColumnType::Field(InfluxFieldType::UInteger)
+        );
+        assert_eq!(columns["uval"].valid_mask.as_ref(), &[0b00000011]);
+        assert_eq!(columns["uval"].values.u64().unwrap(), &[7, 1]);
+
+        assert_eq!(
+            columns["sval"].influx_type,
+            InfluxColumnType::Field(InfluxFieldType::String)
+        );
+        assert_eq!(columns["sval"].valid_mask.as_ref(), &[0b00000011]);
+        assert_eq!(columns["sval"].values.string().unwrap(), &["hi", "world"]);
+
+        assert_eq!(
+            columns["bval"].influx_type,
+            InfluxColumnType::Field(InfluxFieldType::Boolean)
+        );
+        assert_eq!(columns["bval"].valid_mask.as_ref(), &[0b00000011]);
+        assert_eq!(columns["bval"].values.bool().unwrap(), &[true, false]);
+
+        assert_eq!(
+            columns[TIME_COLUMN_NAME].influx_type,
+            InfluxColumnType::Timestamp
+        );
+        assert_eq!(columns[TIME_COLUMN_NAME].valid_mask.as_ref(), &[0b00000011]);
+        assert_eq!(columns[TIME_COLUMN_NAME].values.i64().unwrap(), &[1, 2]);
+    }
+
+    #[test]
+    fn test_nulls() {
+        let lp = r#"
+            a,host=a val=23i 983
+            a val=21i,bool=true,string="hello" 222
+            a,host=a,region=west val2=23.2
+        "#;
+
+        let options = Options {
+            default_time: 32,
+            ..Default::default()
+        };
+
+        let writes = lp_to_table_writes(lp, &options).unwrap();
+
+        assert_eq!(writes.len(), 1);
+        assert_eq!(writes["a"].columns.len(), 7);
+
+        let columns = &writes["a"].columns;
+
+        assert_eq!(
+            columns[TIME_COLUMN_NAME].influx_type,
+            InfluxColumnType::Timestamp
+        );
+        assert_eq!(columns[TIME_COLUMN_NAME].valid_mask.as_ref(), &[0b00000111]);
+        assert_eq!(
+            columns[TIME_COLUMN_NAME].values.i64().unwrap(),
+            &[983, 222, options.default_time]
+        );
+
+        assert_eq!(columns["host"].influx_type, InfluxColumnType::Tag);
+        assert_eq!(columns["host"].valid_mask.as_ref(), &[0b00000101]);
+        assert_eq!(columns["host"].values.string().unwrap(), &["a", "a"]);
+
+        assert_eq!(
+            columns["val"].influx_type,
+            InfluxColumnType::Field(InfluxFieldType::Integer)
+        );
+        assert_eq!(columns["val"].valid_mask.as_ref(), &[0b00000011]);
+        assert_eq!(columns["val"].values.i64().unwrap(), &[23, 21]);
+    }
+
+    #[test]
+    fn test_multiple_table() {
+        let lp = r#"
+            cpu val=1 55
+            mem val=23 10
+            cpu val=88 100
+            disk foo=23.2 110
+            mem val=55 111
+        "#;
+        let writes = lp_to_table_writes(lp, &Options::default()).unwrap();
+        assert_eq!(writes.len(), 3);
+        assert!(writes.contains_key("cpu"));
+        assert!(writes.contains_key("mem"));
+        assert!(writes.contains_key("disk"));
+    }
+
+    #[test]
+    fn test_packed_strings() {
+        let lp = r#"
+            a,foo=bar val="cupcakes" 1
+            a,foo=bar val="bongo" 2
+            a,foo=banana val="cupcakes" 3
+            a,foo=bar val="cupcakes" 4
+            a,foo=bar val="bongo" 5
+        "#;
+        let options = Options {
+            string_packed: true,
+            tag_dictionary: true,
+            ..Default::default()
+        };
+
+        let writes = lp_to_table_writes(lp, &options).unwrap();
+        assert_eq!(writes.len(), 1);
+        let columns = &writes["a"].columns;
+
+        assert_eq!(
+            columns["val"].influx_type,
+            InfluxColumnType::Field(InfluxFieldType::String)
+        );
+        let val = columns["val"].values.packed_string().unwrap();
+        assert_eq!(val.values.as_ref(), "cupcakesbongocupcakescupcakesbongo");
+        assert_eq!(val.indexes.as_ref(), &[0, 8, 13, 21, 29, 34]);
+
+        assert_eq!(columns["foo"].influx_type, InfluxColumnType::Tag);
+        let foo = columns["foo"].values.dictionary().unwrap();
+        assert_eq!(foo.keys.as_ref(), &[0, 0, 1, 0, 0]);
+        assert_eq!(foo.values.values.as_ref(), "barbanana");
+        assert_eq!(foo.values.indexes.as_ref(), &[0, 3, 9]);
+    }
+
+    #[test]
+    fn test_packed_bool() {
+        let lp = r#"
+            a,foo=bar val=true 1
+            a,foo=bar val=true 2
+            a,foo=banana val=false 3
+            a,foo=bar val=true 4
+            a,foo=bar val=false 5
+        "#;
+        let options = Options {
+            tag_packed: true,
+            bool_packed: true,
+            ..Default::default()
+        };
+
+        let writes = lp_to_table_writes(lp, &options).unwrap();
+        assert_eq!(writes.len(), 1);
+        let columns = &writes["a"].columns;
+
+        assert_eq!(
+            columns["val"].influx_type,
+            InfluxColumnType::Field(InfluxFieldType::Boolean)
+        );
+        assert_eq!(columns["val"].values.packed_bool().unwrap(), &[0b00001011]);
+
+        assert_eq!(columns["foo"].influx_type, InfluxColumnType::Tag);
+        let foo = columns["foo"].values.packed_string().unwrap();
+        assert_eq!(foo.values.as_ref(), "barbarbananabarbar");
+        assert_eq!(foo.indexes.as_ref(), &[0, 3, 6, 12, 15, 18]);
+    }
+
+    #[test]
+    fn test_partition() {
+        let lp = r#"
+            a,foo=bar val="cupcakes" 1
+            a,foo=bar val="bongo" 2
+            a,foo=banana val="cupcakes" 3
+            a,foo=bar val="cupcakes" 4
+            a,foo=bar val="bongo" 5
+            b,foo=bar val="bongo" 6
+            a,foo=bar val="bongo" 7
+            a,foo=bar val="bongo" 8
+            a,foo=banana val="cupcakes" 9
+            a,foo=bar val="cupcakes" 10
+            a,foo=banana val="cupcakes" 11
+        "#;
+        let options = Options {
+            string_packed: true,
+            tag_dictionary: true,
+            ..Default::default()
+        };
+
+        let lines = parse_lines(lp).collect::<Result<Vec<_>, _>>().unwrap();
+
+        let writes = lines_to_table_writes::<Cow<'_, str>, _, _>(
+            lines.iter().map(|line| {
+                Ok::<_, std::convert::Infallible>((
+                    line.series.tag_set.as_ref().unwrap()[0].1.clone().into(),
+                    line,
+                ))
+            }),
+            &options,
+        )
+        .unwrap();
+
+        assert_eq!(writes.len(), 2);
+        assert_eq!(writes["bar"].len(), 2);
+        assert_eq!(writes["banana"].len(), 1);
+
+        assert_eq!(writes["bar"]["a"].columns.len(), 3);
+        assert_eq!(writes["bar"]["b"].columns.len(), 3);
+        assert_eq!(writes["banana"]["a"].columns.len(), 3);
+
+        assert_eq!(writes["bar"]["a"].columns["val"].row_count, 7);
+        assert_eq!(writes["bar"]["b"].columns["val"].row_count, 1);
+        assert_eq!(writes["banana"]["a"].columns["val"].row_count, 3);
+
+        assert_eq!(
+            writes["bar"]["a"].columns[TIME_COLUMN_NAME]
+                .values
+                .i64()
+                .unwrap(),
+            &[1, 2, 4, 5, 7, 8, 10]
+        );
+        assert_eq!(
+            writes["bar"]["b"].columns[TIME_COLUMN_NAME]
+                .values
+                .i64()
+                .unwrap(),
+            &[6]
+        );
+        assert_eq!(
+            writes["banana"]["a"].columns[TIME_COLUMN_NAME]
+                .values
+                .i64()
+                .unwrap(),
+            &[3, 9, 11]
+        );
+    }
+}

--- a/mutable_buffer/src/column.rs
+++ b/mutable_buffer/src/column.rs
@@ -368,13 +368,7 @@ fn construct_valid_mask(column: &EntryColumn<'_>) -> Result<Vec<u8>> {
                 }
             );
 
-            Ok(data
-                .iter()
-                .map(|x| {
-                    // Currently the bit mask is backwards
-                    !x.reverse_bits()
-                })
-                .collect())
+            Ok(data.iter().map(|x| !x).collect())
         }
         None => {
             // If no null mask they're all valid

--- a/server/src/db.rs
+++ b/server/src/db.rs
@@ -2459,7 +2459,7 @@ mod tests {
 
         print!("Partitions: {:?}", db.partition_keys().unwrap());
 
-        let partition_summaries = vec![
+        let mut partition_summaries = vec![
             db.partition_summary("1970-01-01T00"),
             db.partition_summary("1970-01-05T15"),
         ];
@@ -2481,21 +2481,21 @@ mod tests {
                                 }),
                             },
                             ColumnSummary {
-                                name: "time".into(),
-                                influxdb_type: Some(InfluxDbType::Timestamp),
-                                stats: Statistics::I64(StatValues {
-                                    min: Some(1),
-                                    max: Some(2),
-                                    count: 2,
-                                }),
-                            },
-                            ColumnSummary {
                                 name: "baz".into(),
                                 influxdb_type: Some(InfluxDbType::Field),
                                 stats: Statistics::F64(StatValues {
                                     min: Some(3.0),
                                     max: Some(3.0),
                                     count: 1,
+                                }),
+                            },
+                            ColumnSummary {
+                                name: "time".into(),
+                                influxdb_type: Some(InfluxDbType::Timestamp),
+                                stats: Statistics::I64(StatValues {
+                                    min: Some(1),
+                                    max: Some(2),
+                                    count: 2,
                                 }),
                             },
                         ],
@@ -2577,6 +2577,12 @@ mod tests {
                 ],
             },
         ];
+
+        for partition in partition_summaries.iter_mut() {
+            for table in partition.tables.iter_mut() {
+                table.columns.sort_by(|a, b| a.name.cmp(&b.name))
+            }
+        }
 
         assert_eq!(
             expected, partition_summaries,


### PR DESCRIPTION
Builds on top of https://github.com/influxdata/influxdb_iox/pull/1478 and adds the ability to create an Entry from a TableWrite, allowing a significant amount of code removal.

Unfortunately this depends on the change away from SmallVec in #1460 as it relies on covariant lifetimes (I'm not entirely sure what is going on here, it may be possible to make work but in its current formulation it needs it :shrug: )