### PR TITLE
feat: wire up catalog preservation write path

### DIFF
--- a/object_store/src/lib.rs
+++ b/object_store/src/lib.rs
@@ -30,7 +30,7 @@ use azure::MicrosoftAzure;
 use disk::File;
 use gcp::GoogleCloudStorage;
 use memory::InMemory;
-use path::ObjectStorePath;
+use path::{parsed::DirsAndFileName, ObjectStorePath};
 use throttle::ThrottledStore;
 
 use async_trait::async_trait;
@@ -119,6 +119,19 @@ impl ObjectStore {
     /// Configure a connection to Microsoft Azure Blob store.
     pub fn new_microsoft_azure(azure: MicrosoftAzure) -> Self {
         Self(ObjectStoreIntegration::MicrosoftAzure(Box::new(azure)))
+    }
+
+    /// Create implementation-specific path from parsed representation.
+    pub fn path_from_dirs_and_filename(&self, path: DirsAndFileName) -> path::Path {
+        use ObjectStoreIntegration::*;
+        match &self.0 {
+            AmazonS3(_) => path::Path::AmazonS3(path.into()),
+            GoogleCloudStorage(_) => path::Path::GoogleCloudStorage(path.into()),
+            InMemory(_) => path::Path::InMemory(path),
+            InMemoryThrottled(_) => path::Path::InMemory(path),
+            File(_) => path::Path::File(path.into()),
+            MicrosoftAzure(_) => path::Path::MicrosoftAzure(path.into()),
+        }
     }
 }
 

--- a/parquet_file/src/catalog.rs
+++ b/parquet_file/src/catalog.rs
@@ -877,27 +877,21 @@ where
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use std::{cell::RefCell, num::NonZeroU32, ops::Deref};
-
-    use crate::{
-        metadata::{read_parquet_metadata_from_file, read_statistics_from_parquet_metadata},
-        storage::read_schema_from_parquet_metadata,
-        utils::{load_parquet_from_store, make_chunk, make_object_store},
-    };
-    use object_store::parsed_path;
-
+pub mod test_helpers {
     use super::*;
+    use std::{cell::RefCell, ops::Deref};
 
+    /// Part that actually holds the data of [`TestCatalogState`].
     #[derive(Clone, Debug)]
-    struct TestCatalogStateInner {
+    pub struct TestCatalogStateInner {
+        /// Map of all parquet files that are currently registered.
         pub parquet_files: HashMap<DirsAndFileName, ParquetMetaData>,
     }
 
     /// In-memory catalog state, for testing.
     #[derive(Clone, Debug)]
-    struct TestCatalogState {
+    pub struct TestCatalogState {
+        /// Inner mutable state.
         pub inner: RefCell<TestCatalogStateInner>,
     }
 
@@ -950,6 +944,21 @@ mod tests {
             Ok(())
         }
     }
+}
+
+#[cfg(test)]
+pub mod tests {
+    use std::{num::NonZeroU32, ops::Deref};
+
+    use crate::{
+        metadata::{read_parquet_metadata_from_file, read_statistics_from_parquet_metadata},
+        storage::read_schema_from_parquet_metadata,
+        utils::{load_parquet_from_store, make_chunk, make_object_store},
+    };
+    use object_store::parsed_path;
+
+    use super::test_helpers::TestCatalogState;
+    use super::*;
 
     #[tokio::test]
     async fn test_inmem_commit_semantics() {

--- a/parquet_file/src/catalog.rs
+++ b/parquet_file/src/catalog.rs
@@ -582,6 +582,13 @@ where
         }
     }
 
+    /// Handle the given action and populate data to the catalog state.
+    ///
+    /// The deserializes the action state and passes it to the correct method in [`CatalogState`].
+    ///
+    /// Note that this method is primarily for replaying transactions and will NOT append the given action to the
+    /// current transaction. If you also want to store the given action (e.g. during an in-progress transaction), use
+    /// [`handle_action_and_record`](Self::handle_action_and_record).
     fn handle_action(
         state: &S,
         action: &proto::transaction::action::Action,
@@ -615,6 +622,8 @@ where
         Ok(())
     }
 
+    /// Similar to [`handle_action`](Self::handle_action) but this will also append the action to the current
+    /// transaction state.
     fn handle_action_and_record(
         &mut self,
         action: proto::transaction::action::Action,

--- a/parquet_file/src/catalog.rs
+++ b/parquet_file/src/catalog.rs
@@ -254,7 +254,7 @@ where
     pub fn new_empty(
         object_store: Arc<ObjectStore>,
         server_id: ServerId,
-        db_name: String,
+        db_name: impl Into<String>,
         state_data: S::EmptyInput,
     ) -> Self {
         let inner = PreservedCatalogInner {
@@ -267,7 +267,7 @@ where
             transaction_semaphore: Semaphore::new(1),
             object_store,
             server_id,
-            db_name,
+            db_name: db_name.into(),
         }
     }
 

--- a/parquet_file/src/storage.rs
+++ b/parquet_file/src/storage.rs
@@ -11,7 +11,7 @@ use datafusion::physical_plan::{
 };
 use internal_types::{schema::Schema, selection::Selection};
 use object_store::{
-    path::{ObjectStorePath, Path},
+    path::{parsed::DirsAndFileName, ObjectStorePath, Path},
     ObjectStore, ObjectStoreApi,
 };
 use parquet::{
@@ -108,6 +108,9 @@ pub enum Error {
 
     #[snafu(display("Cannot extract Parquet metadata from byte array: {}", source))]
     ExtractingMetadataFailure { source: crate::metadata::Error },
+
+    #[snafu(display("Cannot parse location: {:?}", path))]
+    LocationParsingFailure { path: DirsAndFileName },
 }
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
@@ -151,7 +154,9 @@ impl Storage {
     }
 
     /// Return full path including filename in the object store to save a chunk
-    /// table file
+    /// table file.
+    ///
+    /// See [`parse_location`](Self::parse_location) for parsing.
     pub fn location(
         &self,
         partition_key: String,
@@ -172,6 +177,37 @@ impl Storage {
         path.set_file_name(file_name);
 
         path
+    }
+
+    /// Parse locations and return partition key, chunk ID and table name.
+    ///
+    /// See [`location`](Self::location) for path generation.
+    pub fn parse_location(
+        &self,
+        path: impl Into<DirsAndFileName>,
+    ) -> Result<(String, u32, String)> {
+        let path: DirsAndFileName = path.into();
+
+        let dirs: Vec<_> = path.directories.iter().map(|part| part.encoded()).collect();
+        match (dirs.as_slice(), &path.file_name) {
+            ([server_id, db_name, "data", partition_key, chunk_id], Some(filename))
+                if (server_id == &self.server_id.to_string()) && (db_name == &self.db_name) =>
+            {
+                let chunk_id: u32 = match chunk_id.parse() {
+                    Ok(x) => x,
+                    Err(_) => return Err(Error::LocationParsingFailure { path }),
+                };
+
+                let parts: Vec<_> = filename.encoded().split('.').collect();
+                let table_name = match parts[..] {
+                    [name, "parquet"] => name,
+                    _ => return Err(Error::LocationParsingFailure { path }),
+                };
+
+                Ok((partition_key.to_string(), chunk_id, table_name.to_string()))
+            }
+            _ => Err(Error::LocationParsingFailure { path }),
+        }
     }
 
     /// Write the given stream of data of a specified table of
@@ -462,4 +498,69 @@ pub fn read_schema_from_parquet_metadata(parquet_md: &ParquetMetaData) -> Result
 }
 
 #[cfg(test)]
-mod tests {}
+mod tests {
+    use std::num::NonZeroU32;
+
+    use super::*;
+    use crate::utils::make_object_store;
+    use object_store::parsed_path;
+
+    #[test]
+    fn test_location_to_from_path() {
+        let server_id = ServerId::new(NonZeroU32::new(1).unwrap());
+        let store = Storage::new(make_object_store(), server_id, "my_db".to_string());
+
+        // happy roundtrip
+        let path = store.location("p1".to_string(), 42, "my_table".to_string());
+        assert_eq!(path.display(), "1/my_db/data/p1/42/my_table.parquet");
+        assert_eq!(
+            store.parse_location(path).unwrap(),
+            ("p1".to_string(), 42, "my_table".to_string())
+        );
+
+        // error cases
+        assert!(store.parse_location(parsed_path!()).is_err());
+        assert!(store
+            .parse_location(parsed_path!(["too", "short"], "my_table.parquet"))
+            .is_err());
+        assert!(store
+            .parse_location(parsed_path!(
+                ["this", "is", "way", "way", "too", "long"],
+                "my_table.parquet"
+            ))
+            .is_err());
+        assert!(store
+            .parse_location(parsed_path!(
+                ["1", "my_db", "data", "p1", "not_a_number"],
+                "my_table.parquet"
+            ))
+            .is_err());
+        assert!(store
+            .parse_location(parsed_path!(
+                ["1", "my_db", "not_data", "p1", "42"],
+                "my_table.parquet"
+            ))
+            .is_err());
+        assert!(store
+            .parse_location(parsed_path!(
+                ["1", "other_db", "data", "p1", "42"],
+                "my_table.parquet"
+            ))
+            .is_err());
+        assert!(store
+            .parse_location(parsed_path!(
+                ["2", "my_db", "data", "p1", "42"],
+                "my_table.parquet"
+            ))
+            .is_err());
+        assert!(store
+            .parse_location(parsed_path!(["1", "my_db", "data", "p1", "42"], "my_table"))
+            .is_err());
+        assert!(store
+            .parse_location(parsed_path!(
+                ["1", "my_db", "data", "p1", "42"],
+                "my_table.parquet.tmp"
+            ))
+            .is_err());
+    }
+}

--- a/parquet_file/src/utils.rs
+++ b/parquet_file/src/utils.rs
@@ -169,7 +169,7 @@ async fn make_chunk_common(
     } else {
         Box::pin(MemoryStream::new(record_batches))
     };
-    let path = storage
+    let (path, _metadata) = storage
         .write_to_object_store(
             part_key.to_string(),
             chunk_id,

--- a/parquet_file/src/utils.rs
+++ b/parquet_file/src/utils.rs
@@ -369,6 +369,7 @@ where
 fn create_column_timestamp(
     data: Vec<Vec<i64>>,
     arrow_cols: &mut Vec<Vec<(String, ArrayRef, bool)>>,
+    summaries: &mut Vec<ColumnSummary>,
     schema_builder: SchemaBuilder,
 ) -> (SchemaBuilder, TimestampRange) {
     assert_eq!(data.len(), arrow_cols.len());
@@ -379,10 +380,20 @@ fn create_column_timestamp(
         arrow_cols_sub.push((TIME_COLUMN_NAME.to_string(), Arc::clone(&array), true));
     }
 
-    let timestamp_range = TimestampRange::new(
-        *data.iter().flatten().min().unwrap(),
-        *data.iter().flatten().max().unwrap(),
-    );
+    let min = data.iter().flatten().min().cloned();
+    let max = data.iter().flatten().max().cloned();
+
+    summaries.push(ColumnSummary {
+        name: TIME_COLUMN_NAME.to_string(),
+        influxdb_type: Some(InfluxDbType::Timestamp),
+        stats: Statistics::I64(StatValues {
+            min,
+            max,
+            count: data.iter().map(Vec::len).sum::<usize>() as u64,
+        }),
+    });
+
+    let timestamp_range = TimestampRange::new(min.unwrap(), max.unwrap());
 
     let schema_builder = schema_builder.timestamp();
     (schema_builder, timestamp_range)
@@ -523,6 +534,7 @@ pub fn make_record_batch(
     let (schema_builder, timestamp_range) = create_column_timestamp(
         vec![vec![1000], vec![2000], vec![3000, 4000]],
         &mut arrow_cols,
+        &mut summaries,
         schema_builder,
     );
 

--- a/server/src/db.rs
+++ b/server/src/db.rs
@@ -1062,6 +1062,7 @@ impl CatalogState for Catalog {
 
         // extract all relevant bits for the in-memory catalog
         let storage = Storage::new(Arc::clone(&object_store), server_id, db_name.to_string());
+        // this is temporary until https://github.com/influxdata/influxdb_iox/issues/1506 is fixed.
         let (partition_key, chunk_id, table_name) = storage
             .parse_location(info.path.clone())
             .context(PathParseFailed {

--- a/server/src/db.rs
+++ b/server/src/db.rs
@@ -155,18 +155,6 @@ pub enum Error {
         chunk_id: u32,
     },
 
-    #[snafu(display(
-        "Read Buffer Timestamp Error in chunk {}:{} : {}",
-        chunk_id,
-        table_name,
-        source
-    ))]
-    ReadBufferChunkTimestampError {
-        source: read_buffer::Error,
-        table_name: String,
-        chunk_id: u32,
-    },
-
     #[snafu(display("Error writing to object store: {}", source))]
     WritingToObjectStore {
         source: parquet_file::storage::Error,
@@ -1130,7 +1118,7 @@ impl CatalogState for Catalog {
         let mut chunk = chunk.write();
 
         // update the catalog to say we are done processing
-        let parquet_chunk = Arc::clone(&Arc::new(parquet_chunk));
+        let parquet_chunk = Arc::new(parquet_chunk);
         chunk
             .set_written_to_object_store(parquet_chunk)
             .map_err(|e| Box::new(e) as _)

--- a/server/src/db/catalog.rs
+++ b/server/src/db/catalog.rs
@@ -92,21 +92,30 @@ pub struct Catalog {
     partitions: RwLock<BTreeMap<String, Arc<RwLock<Partition>>>>,
 
     metrics: CatalogMetrics,
+
+    pub(crate) metrics_registry: Arc<::metrics::MetricRegistry>,
+    pub(crate) metric_labels: Vec<::metrics::KeyValue>,
 }
 
 impl Catalog {
     #[cfg(test)]
     fn test() -> Self {
-        let registry = ::metrics::MetricRegistry::new();
-        Self::new(registry.register_domain("catalog"))
+        let registry = Arc::new(::metrics::MetricRegistry::new());
+        Self::new(registry.register_domain("catalog"), registry, vec![])
     }
 
-    pub fn new(metrics_domain: ::metrics::Domain) -> Self {
+    pub fn new(
+        metrics_domain: ::metrics::Domain,
+        metrics_registry: Arc<::metrics::MetricRegistry>,
+        metric_labels: Vec<::metrics::KeyValue>,
+    ) -> Self {
         let metrics = CatalogMetrics::new(metrics_domain);
 
         Self {
             partitions: Default::default(),
             metrics,
+            metrics_registry,
+            metric_labels,
         }
     }
 

--- a/server/src/db/lifecycle.rs
+++ b/server/src/db/lifecycle.rs
@@ -271,7 +271,7 @@ impl ChunkMover for LifecycleManager {
     }
 
     fn chunks(&self, sort_order: &SortOrder) -> Vec<Arc<RwLock<Chunk>>> {
-        self.db.catalog.chunks_sorted_by(sort_order)
+        self.db.catalog.state().chunks_sorted_by(sort_order)
     }
 
     fn move_tracker(&self) -> Option<&TaskTracker<Job>> {


### PR DESCRIPTION
Required a bit of refactoring:

- Extract some observability tools from db into its own file.
- Move some observability helpers into catalog.
- Add an extra layer between DB an catalog which is the "preserved
  catalog" wrapper. This is required to make the ownership model
  somewhat sane, because during the read operations the "preserved
  catalog" is going to act on the in-mem catalog.
- Move "parquet file written" logic into catalog, so we have a single
  place where new parquet files are announced. For now this only works
  for chunks that are already known (i.e. the writing->written
  transation when coming from read buffer), however in the next PR this
  will be extended to also handle totally new parquet files during
  transaction playback.

**NOTE: This does NOT include the read path yet! Also end-to-end tests (write + DB restart + read) will be added with the read-path-PR**

For #1382 .
