### PR TITLE
feat: Report num_cpus seen by IOx on startup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1531,6 +1531,7 @@ dependencies = [
  "mem_qe",
  "metrics",
  "mutable_buffer",
+ "num_cpus",
  "object_store",
  "observability_deps",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,7 @@ logfmt = { path = "logfmt" }
 mem_qe = { path = "mem_qe" }
 metrics = { path = "metrics" }
 mutable_buffer = { path = "mutable_buffer" }
+num_cpus = "1.13.0"
 object_store = { path = "object_store" }
 observability_deps = { path = "observability_deps" }
 packers = { path = "packers" }

--- a/src/influxdb_ioxd.rs
+++ b/src/influxdb_ioxd.rs
@@ -99,7 +99,8 @@ async fn wait_for_signal() {
 /// command line arguments, if any.
 pub async fn main(config: Config) -> Result<()> {
     let git_hash = option_env!("GIT_HASH").unwrap_or("UNKNOWN");
-    info!(git_hash, "InfluxDB IOx server starting");
+    let num_cpus = num_cpus::get();
+    info!(git_hash, num_cpus, "InfluxDB IOx server starting");
 
     // Install custom panic handler and forget about it.
     //


### PR DESCRIPTION
# Rationale
There is some discussion on https://github.com/influxdata/influxdb_iox/issues/1362#issuecomment-839737377 about if IOx sees the number of CPUs assigned to its kubernetes container or on the host machine. Let's stop guessing and get IOx to just tell us

# Changes:
Log the `num_cpus` as seen by IOx in the "InfluxDB IOx Server Starting" message

# Example of this on my local machine:
```
     Running `target/debug/influxdb_iox run -vv`
May 12 09:13:16.547  INFO influxdb_iox::influxdb_ioxd: InfluxDB IOx server starting git_hash="0b1ef524817d0c72b42d84196aebbf0a3edc806e" num_cpus=16
```

cc @tustvold  @crepererum 
