### PR TITLE
feat: implement Read Buffer run-length encoding for scalars

### DIFF
--- a/read_buffer/src/column.rs
+++ b/read_buffer/src/column.rs
@@ -15,7 +15,7 @@ use arrow::array::Array;
 use crate::schema::LogicalDataType;
 use crate::value::{EncodedValues, OwnedValue, Scalar, Value, Values};
 use boolean::BooleanEncoding;
-use encoding::{bool, scalar};
+use encoding::bool;
 use float::FloatEncoding;
 use integer::IntegerEncoding;
 use string::StringEncoding;
@@ -1088,13 +1088,13 @@ impl From<arrow::array::Float64Array> for Column {
             _ => unreachable!("min/max must both be Some or None"),
         };
 
-        let data = scalar::FixedNull::<arrow::datatypes::Float64Type>::from(arr);
+        let data = FloatEncoding::from(arr);
         let meta = MetaData {
             range,
             ..MetaData::default()
         };
 
-        Self::Float(meta, FloatEncoding::FixedNull64(data))
+        Self::Float(meta, data)
     }
 }
 
@@ -1285,6 +1285,7 @@ impl RowIDs {
         }
     }
 
+    // Add all row IDs in the domain `[from, to)` to the collection.
     pub fn add_range(&mut self, from: u32, to: u32) {
         match self {
             Self::Bitmap(ids) => ids.add_range(from as u64..to as u64),

--- a/read_buffer/src/column/cmp.rs
+++ b/read_buffer/src/column/cmp.rs
@@ -1,4 +1,4 @@
-use std::convert::TryFrom;
+use std::{convert::TryFrom, fmt::Display};
 
 /// Possible comparison operators
 #[derive(Debug, PartialEq, Copy, Clone)]
@@ -10,6 +10,23 @@ pub enum Operator {
     GTE,
     LT,
     LTE,
+}
+
+impl Display for Operator {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                Self::Equal => "=",
+                Self::NotEqual => "!=",
+                Self::GT => ">",
+                Self::GTE => ">=",
+                Self::LT => "<",
+                Self::LTE => "<=",
+            }
+        )
+    }
 }
 
 impl TryFrom<&str> for Operator {

--- a/read_buffer/src/column/encoding/scalar.rs
+++ b/read_buffer/src/column/encoding/scalar.rs
@@ -1,5 +1,7 @@
 pub mod fixed;
 pub mod fixed_null;
+pub mod rle;
 
 pub use fixed::Fixed;
 pub use fixed_null::FixedNull;
+pub use rle::RLE;

--- a/read_buffer/src/column/encoding/scalar/rle.rs
+++ b/read_buffer/src/column/encoding/scalar/rle.rs
@@ -1,0 +1,429 @@
+use crate::column::cmp;
+use crate::column::RowIDs;
+use std::{
+    cmp::Ordering,
+    fmt::{Debug, Display},
+};
+
+pub const ENCODING_NAME: &str = "RLE";
+
+#[allow(clippy::upper_case_acronyms)] // this looks weird as `Rle`
+/// An RLE encoding is one where identical "runs" of values in the column are
+/// stored as a tuple: `(run_length, value)`, where `run_length` indicates the
+/// number of times the value is to be repeated.
+#[derive(Debug, Default)]
+pub struct RLE<T>
+where
+    T: PartialOrd + Debug,
+{
+    // stores tuples of run-lengths. Each value is repeats the total number of
+    // times the second value should is repeated within the column.
+    //
+    // TODO(edd): can likely improve on 4B for run-length storage
+    //
+    // TODO(edd): Option<T> effectively doubles the size of storing `T` for many
+    //            `T`. I am not overly concerned about this right now because of
+    //            the massive savings the encoding can already provide. Further
+    //            when `T` is a `NonZeroX` then we get the niche optimisation
+    //            that makes `Option<T>` the same size as `T`.
+    //
+    // TODO(edd): another obvious thing that might be worth doing in the future
+    //            is to store all the run-lengths contiguously rather than in
+    //            `Vec<(,)>`. One advantage of this is that it is possible to
+    //            avoid a tuple "overhead" when there is only a single
+    //            occurrence of a value by using a specific marker to represent
+    //            when something is a run-length or something is just a single
+    //            value.
+    run_lengths: Vec<(u32, Option<T>)>,
+
+    // number of NULL values in the column
+    null_count: u32,
+
+    // number of total logical rows (values) in the columns.
+    num_rows: u32,
+}
+
+impl<T> std::fmt::Display for RLE<T>
+where
+    T: std::fmt::Debug + Display + PartialOrd + Copy,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "[{}] size: {:?} rows: {:?} cardinality: {}, nulls: {} runs: {} ",
+            self.name(),
+            self.size(),
+            self.num_rows(),
+            self.cardinality(),
+            self.null_count(),
+            self.run_lengths.len()
+        )
+    }
+}
+
+impl<T: PartialOrd + Debug + Copy> RLE<T> {
+    /// The name of this encoding.
+    pub fn name(&self) -> &'static str {
+        ENCODING_NAME
+    }
+
+    /// A reasonable estimation of the on-heap size this encoding takes up.
+    pub fn size(&self) -> usize {
+        todo!()
+    }
+
+    /// The number of distinct logical values in this column encoding.
+    pub fn cardinality(&self) -> u32 {
+        todo!()
+    }
+
+    /// The number of NULL values in this column.
+    pub fn null_count(&self) -> u32 {
+        todo!()
+    }
+
+    /// The number of logical rows encoded in this column.
+    pub fn num_rows(&self) -> u32 {
+        todo!()
+    }
+
+    /// Determine if NULL is encoded in the column.
+    pub fn contains_null(&self) -> bool {
+        todo!()
+    }
+
+    /// Determines if the column contains a non-null value.
+    pub fn has_any_non_null_value(&self) -> bool {
+        todo!()
+    }
+
+    //
+    //
+    // ---- Helper methods for constructing an instance of the encoding
+    //
+    //
+
+    /// Adds the provided string value to the encoded data. It is the caller's
+    /// responsibility to ensure that the dictionary encoded remains sorted.
+    pub fn push(&mut self, v: T) {
+        self.push_additional(Some(v), 1);
+    }
+
+    /// Adds a NULL value to the encoded data. It is the caller's
+    /// responsibility to ensure that the dictionary encoded remains sorted.
+    pub fn push_none(&mut self) {
+        self.push_additional(None, 1);
+    }
+
+    /// Adds additional repetitions of the provided value to the encoded data.
+    /// It is the caller's responsibility to ensure that the dictionary encoded
+    /// remains sorted.
+    pub fn push_additional(&mut self, v: Option<T>, additional: u32) {
+        match v {
+            Some(v) => self.push_additional_some(v, additional),
+            None => self.push_additional_none(additional),
+        }
+    }
+
+    fn push_additional_some(&mut self, v: T, additional: u32) {
+        if let Some((rl, rlv)) = self.run_lengths.last_mut() {
+            if rlv.as_ref() == Some(&v) {
+                *rl += additional; // update run-length
+            } else {
+                // new run-length
+                self.run_lengths.push((additional, Some(v)));
+            }
+        } else {
+            //First entry in the encoding
+            self.run_lengths.push((additional, Some(v)));
+        }
+
+        self.null_count += additional;
+        self.num_rows += additional;
+    }
+
+    fn push_additional_none(&mut self, additional: u32) {
+        if let Some((rl, v)) = self.run_lengths.last_mut() {
+            if v.is_none() {
+                *rl += additional; // update run-length
+            } else {
+                // new run-length
+                self.run_lengths.push((additional, None));
+            }
+        } else {
+            //First entry in the encoding
+            self.run_lengths.push((additional, None));
+        }
+
+        self.null_count += additional;
+        self.num_rows += additional;
+    }
+
+    //
+    //
+    // ---- Methods for getting row ids from values.
+    //
+    //
+
+    /// Populates the provided destination container with the row ids satisfying
+    /// the provided predicate.
+    pub fn row_ids_filter(&self, _value: T, _op: &cmp::Operator, _dst: RowIDs) -> RowIDs {
+        todo!()
+    }
+
+    /// Returns the set of row ids that satisfy a pair of binary operators
+    /// against two values of the same physical type.
+    ///
+    /// This method is a special case optimisation for common cases where one
+    /// wishes to do the equivalent of WHERE x > y AND x <= y` for example.
+    ///
+    /// Essentially, this supports:
+    ///     `x {>, >=, <, <=} value1 AND x {>, >=, <, <=} value2`.
+    pub fn row_ids_filter_range(
+        &self,
+        left: (T, &cmp::Operator),
+        right: (T, &cmp::Operator),
+        dst: RowIDs,
+    ) -> RowIDs {
+        match (&left.1, &right.1) {
+            (cmp::Operator::GT, cmp::Operator::LT)
+            | (cmp::Operator::GT, cmp::Operator::LTE)
+            | (cmp::Operator::GTE, cmp::Operator::LT)
+            | (cmp::Operator::GTE, cmp::Operator::LTE)
+            | (cmp::Operator::LT, cmp::Operator::GT)
+            | (cmp::Operator::LT, cmp::Operator::GTE)
+            | (cmp::Operator::LTE, cmp::Operator::GT)
+            | (cmp::Operator::LTE, cmp::Operator::GTE) => self.row_ids_cmp_range_order(
+                (&left.0, Self::ord_from_op(&left.1)),
+                (&right.0, Self::ord_from_op(&right.1)),
+                dst,
+            ),
+
+            (_, _) => panic!("unsupported operators provided"),
+        }
+    }
+
+    // Finds row ids based on = or != operator.
+    fn row_ids_equal(&self, _value: T, _op: &cmp::Operator, mut _dst: RowIDs) -> RowIDs {
+        todo!()
+    }
+
+    // Finds row ids based on <, <=, > or >= operator.
+    fn row_ids_cmp(&self, _value: T, _op: &cmp::Operator, mut _dst: RowIDs) -> RowIDs {
+        todo!()
+    }
+
+    // Special case function for finding all rows that satisfy two operators on
+    // two values.
+    //
+    // This function exists because it is more performant than calling
+    // `row_ids_cmp_order_bm` twice and predicates like `WHERE X > y and X <= x`
+    // are very common, e.g., for timestamp columns.
+    //
+    // The method accepts two orderings for each predicate. If the predicate is
+    // `x < y` then the orderings provided should be
+    // `(Ordering::Less, Ordering::Less)`. This does lead to a slight overhead
+    // in checking non-matching values, but it means that the predicate `x <= y`
+    // can be supported by providing the ordering
+    // `(Ordering::Less, Ordering::Equal)`.
+    //
+    // For performance reasons ranges of matching values are collected up and
+    // added in bulk to the bitmap.
+    //
+    fn row_ids_cmp_range_order(
+        &self,
+        _left: (&T, (std::cmp::Ordering, std::cmp::Ordering)),
+        _right: (&T, (std::cmp::Ordering, std::cmp::Ordering)),
+        mut _dst: RowIDs,
+    ) -> RowIDs {
+        todo!()
+    }
+
+    // Helper function to convert comparison operators to cmp orderings.
+    fn ord_from_op(op: &cmp::Operator) -> (Ordering, Ordering) {
+        match op {
+            cmp::Operator::GT => (Ordering::Greater, Ordering::Greater),
+            cmp::Operator::GTE => (Ordering::Greater, Ordering::Equal),
+            cmp::Operator::LT => (Ordering::Less, Ordering::Less),
+            cmp::Operator::LTE => (Ordering::Less, Ordering::Equal),
+            _ => panic!("cannot convert operator to ordering"),
+        }
+    }
+
+    /// Populates the provided destination container with the row ids for rows
+    /// that null.
+    pub fn row_ids_null(&self, dst: RowIDs) -> RowIDs {
+        self.row_ids_is_null(true, dst)
+    }
+
+    /// Populates the provided destination container with the row ids for rows
+    /// that are not null.
+    pub fn row_ids_not_null(&self, dst: RowIDs) -> RowIDs {
+        self.row_ids_is_null(false, dst)
+    }
+
+    // All row ids that have either NULL or not NULL values.
+    fn row_ids_is_null(&self, _is_null: bool, mut _dst: RowIDs) -> RowIDs {
+        todo!()
+    }
+
+    //
+    //
+    // ---- Methods for getting materialised values from row IDs.
+    //
+    //
+
+    /// Returns the logical value present at the provided row id.
+    ///
+    /// N.B right now this doesn't discern between an invalid row id and a NULL
+    /// value at a valid location.
+    pub fn value(&self, _row_id: u32) -> Option<T> {
+        todo!()
+    }
+
+    /// Materialises a vector of references to the decoded values in the
+    /// provided row ids.
+    ///
+    /// NULL values are represented by None. It is the caller's responsibility
+    /// to ensure row ids are a monotonically increasing set.
+    pub fn values<'a>(
+        &'a self,
+        _row_ids: &[u32],
+        mut _dst: Vec<Option<&'a str>>,
+    ) -> Vec<Option<T>> {
+        todo!()
+    }
+
+    /// Returns references to the logical (decoded) values for all the rows in
+    /// the column.
+    ///
+    /// NULL values are represented by None.
+    pub fn all_values<'a>(&'a self, mut _dst: Vec<Option<&'a str>>) -> Vec<Option<T>> {
+        todo!()
+    }
+
+    /// Returns true if a non-null value exists at any of the row ids.
+    pub fn has_non_null_value(&self, _row_ids: &[u32]) -> bool {
+        todo!()
+    }
+
+    //
+    //
+    // ---- Methods for aggregation.
+    //
+    //
+
+    /// Returns the count of the values for the provided
+    /// row IDs.
+    ///
+    /// Since this encoding cannot have NULL values this is just the number of
+    /// rows requested.
+    pub fn count(&self, _row_ids: &[u32]) -> u32 {
+        todo!()
+    }
+
+    /// Returns the summation of the logical (decoded) values for the provided
+    /// row IDs.
+    pub fn sum(&self, _row_ids: &[u32]) -> Option<T> {
+        todo!()
+    }
+
+    /// Returns the first logical (decoded) value from the provided
+    /// row IDs.
+    pub fn first(&self, _row_ids: &[u32]) -> Option<T> {
+        todo!()
+    }
+
+    /// Returns the last logical (decoded) value from the provided
+    /// row IDs.
+    pub fn last(&self, _row_ids: &[u32]) -> Option<T> {
+        todo!()
+    }
+
+    /// Returns the minimum logical (decoded) value from the provided
+    /// row IDs.
+    pub fn min(&self, _row_ids: &[u32]) -> Option<T> {
+        todo!()
+    }
+
+    /// Returns the maximum logical (decoded) value from the provided
+    /// row IDs.
+    pub fn max(&self, _row_ids: &[u32]) -> Option<T> {
+        todo!()
+    }
+}
+
+impl<T> From<&[T]> for RLE<T>
+where
+    T: PartialOrd + Debug,
+{
+    fn from(_v: &[T]) -> Self {
+        todo!()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn push() {
+        let mut enc = RLE::default();
+        enc.push_additional(Some(45), 3);
+        enc.push_additional(Some(-1), 1);
+        enc.push_additional(Some(45), 5);
+        enc.push_additional(Some(45), 1);
+        enc.push_additional(Some(336), 2);
+        enc.push_additional(None, 2);
+        enc.push_none();
+        enc.push(22);
+
+        assert_eq!(
+            enc.run_lengths,
+            vec![
+                (3, Some(45)),
+                (1, Some(-1)),
+                (6, Some(45)),
+                (2, Some(336)),
+                (3, None),
+                (1, Some(22))
+            ]
+        );
+    }
+
+    #[test]
+    fn size() {}
+
+    #[test]
+    fn null_count() {}
+
+    #[test]
+    fn value() {}
+
+    #[test]
+    fn values() {}
+
+    #[test]
+    fn all_values() {}
+
+    #[test]
+    fn row_ids_filter_eq() {}
+
+    #[test]
+    fn row_ids_filter_neq() {}
+
+    #[test]
+    fn row_ids_filter_lt() {}
+
+    #[test]
+    fn row_ids_filter_lte() {}
+
+    #[test]
+    fn row_ids_filter_gt() {}
+
+    #[test]
+    fn row_ids_filter_gte() {}
+
+    #[test]
+    fn row_ids_filter_range() {}
+}

--- a/read_buffer/src/column/encoding/scalar/rle.rs
+++ b/read_buffer/src/column/encoding/scalar/rle.rs
@@ -50,11 +50,10 @@ where
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "[{}] size: {:?} rows: {:?} cardinality: {}, nulls: {} runs: {} ",
+            "[{}] size: {:?} rows: {:?} nulls: {} runs: {} ",
             self.name(),
             self.size(),
             self.num_rows(),
-            self.cardinality(),
             self.null_count(),
             self.run_lengths.len()
         )
@@ -72,29 +71,26 @@ impl<T: PartialOrd + Debug + Copy> RLE<T> {
         todo!()
     }
 
-    /// The number of distinct logical values in this column encoding.
-    pub fn cardinality(&self) -> u32 {
-        todo!()
-    }
-
     /// The number of NULL values in this column.
     pub fn null_count(&self) -> u32 {
-        todo!()
+        self.null_count
     }
 
     /// The number of logical rows encoded in this column.
     pub fn num_rows(&self) -> u32 {
-        todo!()
+        self.num_rows
     }
 
     /// Determine if NULL is encoded in the column.
     pub fn contains_null(&self) -> bool {
-        todo!()
+        self.null_count() > 0
     }
 
     /// Determines if the column contains a non-null value.
+    ///
+    /// TODO: remove this and just use contains_null().
     pub fn has_any_non_null_value(&self) -> bool {
-        todo!()
+        !self.contains_null()
     }
 
     //
@@ -138,7 +134,6 @@ impl<T: PartialOrd + Debug + Copy> RLE<T> {
             self.run_lengths.push((additional, Some(v)));
         }
 
-        self.null_count += additional;
         self.num_rows += additional;
     }
 
@@ -392,10 +387,40 @@ mod test {
     }
 
     #[test]
-    fn size() {}
+    fn null_count() {
+        let mut enc = RLE::default();
+        enc.push_additional(Some(45), 3);
+        assert_eq!(enc.null_count(), 0);
+
+        enc.push_none();
+        assert_eq!(enc.null_count(), 1);
+
+        enc.push_none();
+        assert_eq!(enc.null_count(), 2);
+    }
 
     #[test]
-    fn null_count() {}
+    fn num_rows() {
+        let mut enc = RLE::default();
+        enc.push_additional(Some(45), 3);
+        assert_eq!(enc.num_rows(), 3);
+
+        enc.push_none();
+        assert_eq!(enc.num_rows(), 4);
+    }
+
+    #[test]
+    fn contains_null() {
+        let mut enc = RLE::default();
+        enc.push_additional(Some(45), 3);
+        assert!(!enc.contains_null());
+
+        enc.push_none();
+        assert!(enc.contains_null());
+    }
+
+    #[test]
+    fn size() {}
 
     #[test]
     fn value() {}

--- a/read_buffer/src/column/encoding/scalar/rle.rs
+++ b/read_buffer/src/column/encoding/scalar/rle.rs
@@ -82,9 +82,7 @@ impl<T: PartialOrd + Debug + Copy> RLE<T> {
 
     /// A reasonable estimation of the on-heap size this encoding takes up.
     pub fn size(&self) -> usize {
-        size_of::<Vec<(u32, Option<T>)>>() // run length container size
-            + (self.run_lengths.len() * size_of::<(u32, Option<T>)>()) // run lengths
-            + size_of::<u32>()+size_of::<u32>() // null count, num rows
+        std::mem::size_of::<Self>() + (self.run_lengths.len() * size_of::<(u32, Option<T>)>())
     }
 
     /// The estimated total size in bytes of the underlying values in the

--- a/read_buffer/src/column/float.rs
+++ b/read_buffer/src/column/float.rs
@@ -1,5 +1,4 @@
-use std::cmp::Ordering;
-use std::mem::size_of;
+use std::{cmp::Ordering, mem::size_of};
 
 use arrow::{self, array::Array};
 
@@ -13,8 +12,13 @@ use crate::column::{RowIDs, Scalar, Value, Values};
 #[allow(clippy::upper_case_acronyms)] // TODO(edd): these will be OK in 1.52
 #[derive(Debug)]
 pub enum FloatEncoding {
+    // A fixed-width "no compression" vector of non-nullable values
     Fixed64(Fixed<f64>),
+
+    // A fixed-width "no compression" vector of nullable values (as Arrow array)
     FixedNull64(FixedNull<arrow::datatypes::Float64Type>),
+
+    // A RLE compressed encoding of nullable values.
     RLE64(RLE<f64>),
 }
 
@@ -253,30 +257,44 @@ impl std::fmt::Display for FloatEncoding {
     }
 }
 
-fn check_run_lengths_above(arr: &[f64], min_rl: usize) -> usize {
-    if min_rl < 1 || arr.len() < min_rl {
-        return 0;
-    }
-
-    let (mut rl, mut v) = (1, arr[0]);
-    let mut total_matching_rl = 0;
+fn rle_rows(arr: &[f64]) -> usize {
+    let mut v = arr[0];
+    let mut total_rows = 0;
     for next in arr.iter().skip(1) {
         if let Some(Ordering::Equal) = v.partial_cmp(next) {
-            rl += 1;
             continue;
         }
 
-        // run length was big enough to be considered
-        if rl > min_rl {
-            total_matching_rl += 1;
-        }
-
-        rl = 1;
+        total_rows += 1;
         v = *next;
     }
 
-    total_matching_rl
+    total_rows + 1 // account for original run
 }
+
+fn rle_rows_opt(mut itr: impl Iterator<Item = Option<f64>>) -> usize {
+    let mut v = match itr.next() {
+        Some(v) => v,
+        None => return 0,
+    };
+
+    let mut total_rows = 0;
+    for next in itr {
+        if let Some(Ordering::Equal) = v.partial_cmp(&next) {
+            continue;
+        }
+
+        total_rows += 1;
+        v = next;
+    }
+
+    total_rows + 1 // account for original run
+}
+
+/// A lever to decide the minimum size in bytes that RLE the column needs to
+/// reduce the overall footprint by. 0.1 means that the size of the column must
+/// be reduced by 10%
+pub const MIN_RLE_SIZE_REDUCTION: f64 = 0.3; // 30%
 
 /// Converts a slice of `f64` values into a `FloatEncoding`.
 ///
@@ -290,12 +308,11 @@ fn check_run_lengths_above(arr: &[f64], min_rl: usize) -> usize {
 /// The encoding is chosen based on the heuristics in the `From` implementation
 impl From<&[f64]> for FloatEncoding {
     fn from(arr: &[f64]) -> Self {
-        // The total number of run-lengths to find in order to decide to RLE
-        // this column is in the range `[10, 1/10th column size]`
-        // For example, if the columns is 1000 rows then we need to find 100
-        // run lengths to RLE encode it.
-        let total_rl_required = 10.max(arr.len() / 10);
-        if check_run_lengths_above(arr, 3) >= total_rl_required {
+        // The number of rows we would reduce the column by if we encoded it
+        // as RLE.
+        let base_size = arr.len() * size_of::<f64>();
+        let rle_size = rle_rows(arr) * size_of::<(u32, Option<f64>)>(); // size of a run length
+        if (base_size as f64 - rle_size as f64) / base_size as f64 >= MIN_RLE_SIZE_REDUCTION {
             return Self::RLE64(RLE::from(arr));
         }
 
@@ -320,9 +337,11 @@ impl From<arrow::array::Float64Array> for FloatEncoding {
             return Self::from(arr.values());
         }
 
-        // TODO(edd) Right now let's just RLE encode the column if it is 50% NULL.
-        // and has at least 100 values in it.
-        if arr.len() >= 100 && arr.null_count() >= arr.len() / 2 {
+        // The number of rows we would reduce the column by if we encoded it
+        // as RLE.
+        let base_size = arr.len() * size_of::<f64>();
+        let rle_size = rle_rows_opt(arr.iter()) * size_of::<(u32, Option<f64>)>(); // size of a run length
+        if (base_size as f64 - rle_size as f64) / base_size as f64 >= MIN_RLE_SIZE_REDUCTION {
             return Self::RLE64(RLE::from(arr));
         }
 
@@ -332,7 +351,10 @@ impl From<arrow::array::Float64Array> for FloatEncoding {
 
 #[cfg(test)]
 mod test {
+    use std::iter;
+
     use super::*;
+    use arrow::array::Float64Array;
     use cmp::Operator;
 
     #[test]
@@ -355,6 +377,60 @@ mod test {
         // (5 * 8) + 24
         assert_eq!(enc.size_raw(true), 64);
         assert_eq!(enc.size_raw(false), 56);
+    }
+
+    fn rle_rows() {
+        let cases = vec![
+            (vec![0.0, 0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0], 9),
+            (vec![0.0, 0.0], 1),
+            (vec![1.0, 2.0, 1.0], 3),
+            (vec![1.0, 2.0, 1.0, 1.0], 3),
+            (vec![1.0], 1),
+        ];
+
+        for (input, exp) in cases {
+            assert_eq!(super::rle_rows(input.as_slice()), exp);
+        }
+    }
+
+    #[test]
+    fn rle_rows_opt() {
+        let cases = vec![
+            (vec![Some(0.0), Some(2.0), Some(1.0)], 3),
+            (vec![Some(0.0), Some(0.0)], 1),
+        ];
+
+        for (input, exp) in cases {
+            assert_eq!(super::rle_rows_opt(input.into_iter()), exp);
+        }
+    }
+
+    #[test]
+    fn from_arrow_array() {
+        // Rows not reduced
+        let input: Vec<Option<f64>> = vec![Some(33.2), Some(1.2), Some(2.2), None, Some(3.2)];
+        let arr = Float64Array::from(input);
+        let enc = FloatEncoding::from(arr);
+        assert!(matches!(enc, FloatEncoding::FixedNull64(_)));
+
+        // Rows not reduced and no nulls so can go in `Fixed64`.
+        let input: Vec<Option<f64>> = vec![Some(33.2), Some(1.2), Some(2.2), Some(3.2)];
+        let arr = Float64Array::from(input);
+        let enc = FloatEncoding::from(arr);
+        assert!(matches!(enc, FloatEncoding::Fixed64(_)));
+
+        // Goldilocks - encode as RLE
+        let input: Vec<Option<f64>> = vec![Some(33.2); 10];
+        let arr = Float64Array::from(input);
+        let enc = FloatEncoding::from(arr);
+        assert!(matches!(enc, FloatEncoding::RLE64(_)));
+
+        // Goldilocks - encode as RLE
+        let mut input: Vec<Option<f64>> = vec![Some(33.2); 10];
+        input.extend(iter::repeat(None).take(10));
+        let arr = Float64Array::from(input);
+        let enc = FloatEncoding::from(arr);
+        assert!(matches!(enc, FloatEncoding::RLE64(_)));
     }
 
     #[test]

--- a/read_buffer/src/column/float.rs
+++ b/read_buffer/src/column/float.rs
@@ -258,18 +258,12 @@ impl std::fmt::Display for FloatEncoding {
 }
 
 fn rle_rows(arr: &[f64]) -> usize {
-    let mut v = arr[0];
-    let mut total_rows = 0;
-    for next in arr.iter().skip(1) {
-        if let Some(Ordering::Equal) = v.partial_cmp(next) {
-            continue;
-        }
-
-        total_rows += 1;
-        v = *next;
-    }
-
-    total_rows + 1 // account for original run
+    arr.len()
+        - arr
+            .iter()
+            .zip(arr.iter().skip(1))
+            .filter(|(curr, next)| curr == next)
+            .count()
 }
 
 fn rle_rows_opt(mut itr: impl Iterator<Item = Option<f64>>) -> usize {

--- a/read_buffer/src/column/float.rs
+++ b/read_buffer/src/column/float.rs
@@ -11,6 +11,7 @@ use super::{cmp, Statistics};
 use crate::column::{RowIDs, Scalar, Value, Values};
 
 #[allow(clippy::upper_case_acronyms)] // TODO(edd): these will be OK in 1.52
+#[derive(Debug)]
 pub enum FloatEncoding {
     Fixed64(Fixed<f64>),
     FixedNull64(FixedNull<arrow::datatypes::Float64Type>),
@@ -320,8 +321,9 @@ impl From<arrow::array::Float64Array> for FloatEncoding {
         }
 
         // TODO(edd) Right now let's just RLE encode the column if it is 50% NULL.
-        if arr.null_count() >= arr.len() / 2 {
-            return Self::RLE64(RLE::from(arr.values()));
+        // and has at least 100 values in it.
+        if arr.len() >= 100 && arr.null_count() >= arr.len() / 2 {
+            return Self::RLE64(RLE::from(arr));
         }
 
         Self::FixedNull64(FixedNull::<arrow::datatypes::Float64Type>::from(arr))


### PR DESCRIPTION
This PR introduces a new encoding to the Read Buffer: run-length encoding of scalar values.

## Rationale

As the primary in-memory execution engine within IOx the Read Buffer needs to aggresively compress data to maximise the total number of rows that can be held. However, this must be done whilst balancing read performance; compressions schemes that result in significant expense to access values harm query execution performance.

This PR adds a new RLE encoding scheme for compressing columns of scalar values (integers and floats). It allows us to significantly reduce the footprint of columns of these values for time-series data where it is often the case that there are many runs of repeated values.

Further, the encoding scheme compliments the existing design of the Read Buffer, which uses compressed bitsets to hold intermediate row offsets when applying predicates across columns within a table. Within RLE encoded columns, all row IDs for values matching predicates can be efficiently added to bitset results using range-based operations, keeping intermediate state compressed for longer.

## Background

Up to now a lot of the focus within the Read Buffer has been on compressing string (tag) columns for the following reasons:

 - each value is of variable size;
 - often tags have relatively low cardinality compared to the number of rows in a column;
 - compression allows for execution directly on the compressed representations; and 
 - compressed representations are integers which opens up more vectorised CPU instructions (SIMD).

Since IOx has been deployed within one of our internal Cloud 2 clusters we have been able to feed it a significant volume of meaningful time-series data. An analysis of that has shown that there is a significant amount of scalar data that is being stored with little compression. Further, a lot of this data is very sparse in nature, and due to the existing scalar encodings is stored uncompressed with `NULL` values taking up as much space as non-null values.

Therfore, by run-length encoding this data where it makes sense to we hope to see significant reductions without making query performance significantly worse. Indeed, in many cases predicate evaluation will be _improved_ because we can evaluate predicates directly on the compressed representation.

## Implementation Notes

 - The RLE implementation is generic over all of the logical scalar types we support (`i64`, `f64` etc), but it's only wired up to support float columns right now. I will extend support in following PRs.
 - The implementation is relatively straightforward, e.g., I have used `(u32, Option<T>)` for storing run-lengths. Naturally that can be improved upon, but this PR is following the 80/20 rule and trying to get the majority of the value added more quickly.
 - I have not wired up aggregate functions within this encoding. I will do that for completeness, but since DataFusion can't yet push aggregates down to the Read Buffer it's not vital yet.
 - I have added some heuristics to decide when to RLE a float column. We can tweak and improve these over time, but for now - if applying RLE to a float column reduces the number of rows by 30% or more then that encoding gets chosen.
 - Recently we have been thinking about how we want ordering/predicate evaluation/aggregation to happen with respect to certain floating point values (`NaN`, `infinity`, `-infinity`). This time around I have written tests that will assert that the Read Buffer behaves in the same way as PostgreSQL in terms of predicate evaluation. However, I have left the assertions in the test commented out because we need customer comparators and that isn't necessary for what this PR is trying to achieve.

## Empirical Testing

Internally we have a known "problematic" table in IOx, which presents a pathological case for sparse scalar encodings with no compression, which is that we have to spend 8 bytes on every NULL value in a column. Some columns within this table have `97-99%` sparsity (NULL values). Therefore compressiong those NULL values down with RLE results in a significantly smaller footprint.

I have tested this PR on an extract of that dataset:

### Compression

|  | Before | RLE PR |
| --- | --- | -- |
| Float columns | 47 | ..
| Float values | 7,074,111 | ..
| Sparsity (NULLS) | 6,923,598 (97%) | ..
| Size (Bytes) | 58,139,752 | **6,331,768**

For this dataset the RLE scheme compresses the columnar data by **89%** from `~58MB~ to `~6.3MB`.

### Predicate evaluation

I also tested how quickly a column encoded with this scalar run-lengtrh encoding was able to find all rows that satisfied a predicate compared to the existing scheme where float values were effectively held in a `Vec<T>`.

I tested the equivalent of following query against the above dataset:

```
SELECT "container_file_descriptors" FROM "prometheus" WHERE "container_file_descriptors" > 300;
```

There are `150,513` values in the "container_file_descriptors" column in the range `[0, 701]`, however `~99%` of them are `NULL` so the query is very selective. In total `27` rows were returned.

|  | Before | RLE PR |
| --- | --- | -- |
| Execution Time | `630μs` | `70μs`

For this dataset the RLE scheme improves predicate evauation by **88%** from `630μs` down to `70μs`. This performance improvement is realised primarily because the predicate can be evaluated on the compressed representation directly (the run-lengths).

### Row Materialisation

Finally I tested how quickly a column encoded with this scalar run-lengtrh encoding was able to materialise compared to the existing scheme, where float values were effectively held in a `Vec<T>`.

A simple way to look at this is with the equivalent of:

```
SELECT "container_file_descriptors" FROM "prometheus";
```

which for the RLE case forces the entire column to be decompressed and materialised.

|  | Before | RLE PR |
| --- | --- | -- |
| Execution Time | `901μs` | `966μs`

These results show that the RLE scheme is not significantly slower (about 7%) to materialise values than a simple `Vec<T>`. I haven't dug in too deeply into this yet but it's certainly not terribly worse given then space improvements.

## Next Steps

I have a lot of next steps! 

Here is a good first one... As mentioned, this RLE implementation uses `(u32, Option<T>)` to store run-lengths, which for `T = f64` means each run-length requires `24b`. One thing I want to do is to detect when a Float column contains only _natural numbers_ because then that means we can encode the column as integers. This is good for two reasons:

 (1) we can take advantage of the byte trimming functionality in the Read Buffer, which allows us to store a column of i64 as, e.g., u8 if all the values are in range;
 (2) more imporantly for RLE, if the values allow then we can make use of `NonZeroX` and friends. These will be very helpful because it will mean that `Option<T>` effectively becomes free and we can reduce the size of, e.g., ``(u32, Option<i64>)` from `24b` to `(u32, Option<NonZeroI64>)`, which is only `16b`.
