### PR TITLE
feat: add uncompressed read buffer size metric

### DIFF
--- a/read_buffer/src/column.rs
+++ b/read_buffer/src/column.rs
@@ -1343,11 +1343,13 @@ impl Iterator for RowIDsIterator<'_> {
 
 // Statistics about the composition of a column
 pub(crate) struct Statistics {
-    pub enc_type: &'static str,
-    pub log_data_type: &'static str,
-    pub values: u32,
-    pub nulls: u32,
-    pub bytes: usize,
+    pub enc_type: &'static str,      // The encoding type
+    pub log_data_type: &'static str, // The logical data-type
+    pub values: u32,                 // Number of values present (NULL and non-NULL)
+    pub nulls: u32,                  // Number of NULL values present
+    pub bytes: usize,                // Total size of data
+    pub raw_bytes: usize,            // Estimated "uncompressed" size
+    pub raw_bytes_no_null: usize,    // Estimated "uncompressed" size ignoring NULL values
 }
 
 #[cfg(test)]

--- a/read_buffer/src/column.rs
+++ b/read_buffer/src/column.rs
@@ -49,7 +49,7 @@ impl Column {
     //  Meta information about the column
     //
 
-    /// The estimated size in bytes of the column.
+    /// The estimated size in bytes of the column that is held in memory.
     pub fn size(&self) -> usize {
         // Since `MetaData` is generic each value in the range can have a
         // different size, so just do the calculations here where we know each
@@ -88,6 +88,26 @@ impl Column {
 
                 meta_size + data.size()
             }
+        }
+    }
+
+    /// The estimated size in bytes of the contents of the column if it was not
+    /// compressed, and was stored as a contiguous collection of elements. This
+    /// method can provide a good approximation for the size of the column at
+    /// the point of ingest in IOx.
+    ///
+    /// The `include_null` when set to true will result in any NULL values in
+    /// the column having a fixed size for fixed-width data types, or the size
+    /// of a pointer for heap-allocated data types such as strings. When set to
+    /// `false` all NULL values are ignored from calculations.
+    pub fn size_raw(&self, include_null: bool) -> usize {
+        match &self {
+            Self::String(_, data) => data.size_raw(include_null),
+            Self::Float(_, data) => data.size_raw(include_null),
+            Self::Integer(_, data) => data.size_raw(include_null),
+            Self::Unsigned(_, data) => data.size_raw(include_null),
+            Self::Bool(_, data) => data.size_raw(include_null),
+            Self::ByteArray(_, data) => data.size_raw(include_null),
         }
     }
 

--- a/read_buffer/src/column/boolean.rs
+++ b/read_buffer/src/column/boolean.rs
@@ -15,6 +15,15 @@ impl BooleanEncoding {
         }
     }
 
+    /// The estimated total size in bytes of the underlying bool values in the
+    /// column if they were stored contiguously and uncompressed. `include_nulls`
+    /// will effectively size each NULL value as 1b if `true`.
+    pub fn size_raw(&self, include_nulls: bool) -> usize {
+        match self {
+            Self::BooleanNull(enc) => enc.size_raw(include_nulls),
+        }
+    }
+
     /// The total number of rows in the column.
     pub fn num_rows(&self) -> u32 {
         match self {

--- a/read_buffer/src/column/boolean.rs
+++ b/read_buffer/src/column/boolean.rs
@@ -39,6 +39,8 @@ impl BooleanEncoding {
             values: self.num_rows(),
             nulls: self.null_count(),
             bytes: self.size(),
+            raw_bytes: self.size_raw(true),
+            raw_bytes_no_null: self.size_raw(false),
         }
     }
 

--- a/read_buffer/src/column/boolean.rs
+++ b/read_buffer/src/column/boolean.rs
@@ -16,8 +16,10 @@ impl BooleanEncoding {
     }
 
     /// The estimated total size in bytes of the underlying bool values in the
-    /// column if they were stored contiguously and uncompressed. `include_nulls`
-    /// will effectively size each NULL value as 1b if `true`.
+    /// column if they were stored contiguously and uncompressed. If
+    /// `include_nulls` is false, NULL values will be excluded from the count;
+    /// otherwise NULL values will still occupy the space of a slot of the
+    /// underlying type, in bool's case 1b.
     pub fn size_raw(&self, include_nulls: bool) -> usize {
         match self {
             Self::BooleanNull(enc) => enc.size_raw(include_nulls),

--- a/read_buffer/src/column/encoding/scalar/fixed_null.rs
+++ b/read_buffer/src/column/encoding/scalar/fixed_null.rs
@@ -631,7 +631,7 @@ mod test {
         assert_eq!(v.size_raw(false), 40);
 
         let v = FixedNull::<Int64Type>::from(vec![None, None].as_slice());
-        assert_eq!(v.size_raw(true), 32);
+        assert_eq!(v.size_raw(true), 40);
         assert_eq!(v.size_raw(false), 24);
 
         let v = FixedNull::<Float64Type>::from(vec![None, None, Some(22.3)].as_slice());

--- a/read_buffer/src/column/encoding/scalar/fixed_null.rs
+++ b/read_buffer/src/column/encoding/scalar/fixed_null.rs
@@ -14,6 +14,7 @@
 //! consumer of these encodings.
 use std::cmp::Ordering;
 use std::fmt::Debug;
+use std::mem::size_of;
 
 use arrow::{
     array::{Array, PrimitiveArray},
@@ -74,7 +75,21 @@ where
     /// Returns an estimation of the total size in bytes used by this column
     /// encoding.
     pub fn size(&self) -> usize {
-        std::mem::size_of::<PrimitiveArray<T>>() + self.arr.get_array_memory_size()
+        size_of::<PrimitiveArray<T>>() + self.arr.get_array_memory_size()
+    }
+
+    /// The estimated total size in bytes of the underlying values in the
+    /// column if they were stored contiguously and uncompressed. `include_nulls`
+    /// will effectively size each NULL value as 8b if `true` because the logical
+    /// size of all types of `T` is 8b
+    pub fn size_raw(&self, include_nulls: bool) -> usize {
+        // hmmm whilst Vec<i64> is probably accurate it's not really correct if
+        // T is not i64.
+        let base_size = size_of::<Vec<i64>>();
+        if !self.contains_null() || include_nulls {
+            return base_size + (self.num_rows() as usize * 8);
+        }
+        base_size + ((self.num_rows() as usize - self.arr.null_count()) * 8)
     }
 
     //
@@ -605,6 +620,23 @@ mod test {
     fn size() {
         let v = FixedNull::<UInt64Type>::from(vec![None, None, Some(100), Some(2222)].as_slice());
         assert_eq!(v.size(), 344);
+    }
+
+    #[test]
+    fn size_raw() {
+        let v = FixedNull::<UInt64Type>::from(vec![None, None, Some(100), Some(2222)].as_slice());
+        // values   = 4 * 8 = 32b
+        // Vec<u64> = 24b
+        assert_eq!(v.size_raw(true), 56);
+        assert_eq!(v.size_raw(false), 40);
+
+        let v = FixedNull::<Int64Type>::from(vec![None, None].as_slice());
+        assert_eq!(v.size_raw(true), 32);
+        assert_eq!(v.size_raw(false), 24);
+
+        let v = FixedNull::<Float64Type>::from(vec![None, None, Some(22.3)].as_slice());
+        assert_eq!(v.size_raw(true), 48);
+        assert_eq!(v.size_raw(false), 32);
     }
 
     #[test]

--- a/read_buffer/src/column/float.rs
+++ b/read_buffer/src/column/float.rs
@@ -1,3 +1,5 @@
+use std::mem::size_of;
+
 use arrow::{self, array::Array};
 
 use super::encoding::{scalar::Fixed, scalar::FixedNull};
@@ -10,11 +12,24 @@ pub enum FloatEncoding {
 }
 
 impl FloatEncoding {
-    /// The total size in bytes of the store columnar data.
+    /// The total size in bytes of to store columnar data in memory.
     pub fn size(&self) -> usize {
         match self {
             Self::Fixed64(enc) => enc.size(),
             Self::FixedNull64(enc) => enc.size(),
+        }
+    }
+
+    /// The estimated total size in bytes of the underlying float values in the
+    /// column if they were stored contiguously and uncompressed. `include_nulls`
+    /// will effectively size each NULL value as 8b if `true`.
+    pub fn size_raw(&self, include_nulls: bool) -> usize {
+        match self {
+            // this will be the size of a Vec<f64>
+            Self::Fixed64(enc) => {
+                size_of::<Vec<f64>>() + (enc.num_rows() as usize * size_of::<f64>())
+            }
+            Self::FixedNull64(enc) => enc.size_raw(include_nulls),
         }
     }
 
@@ -210,5 +225,32 @@ impl From<arrow::array::Float64Array> for FloatEncoding {
             return Self::from(arr.values());
         }
         Self::FixedNull64(FixedNull::<arrow::datatypes::Float64Type>::from(arr))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn size_raw() {
+        let enc = FloatEncoding::from(&[2.2, 22.2, 12.2, 31.2][..]);
+        // (4 * 8) + 24
+        assert_eq!(enc.size_raw(true), 56);
+        assert_eq!(enc.size_raw(false), 56);
+
+        let enc = FloatEncoding::FixedNull64(FixedNull::<arrow::datatypes::Float64Type>::from(
+            &[2.0, 2.02, 1.02, 3.01][..],
+        ));
+        // (4 * 8) + 24
+        assert_eq!(enc.size_raw(true), 56);
+        assert_eq!(enc.size_raw(false), 56);
+
+        let enc = FloatEncoding::FixedNull64(FixedNull::<arrow::datatypes::Float64Type>::from(
+            &[Some(2.0), Some(2.02), None, Some(1.02), Some(3.01)][..],
+        ));
+        // (5 * 8) + 24
+        assert_eq!(enc.size_raw(true), 64);
+        assert_eq!(enc.size_raw(false), 56);
     }
 }

--- a/read_buffer/src/column/float.rs
+++ b/read_buffer/src/column/float.rs
@@ -49,6 +49,8 @@ impl FloatEncoding {
             values: self.num_rows(),
             nulls: self.null_count(),
             bytes: self.size(),
+            raw_bytes: self.size_raw(true),
+            raw_bytes_no_null: self.size_raw(false),
         }
     }
 

--- a/read_buffer/src/column/integer.rs
+++ b/read_buffer/src/column/integer.rs
@@ -99,6 +99,8 @@ impl IntegerEncoding {
             values: self.num_rows(),
             nulls: self.null_count(),
             bytes: self.size(),
+            raw_bytes: self.size_raw(true),
+            raw_bytes_no_null: self.size_raw(false),
         }
     }
 

--- a/read_buffer/src/column/string.rs
+++ b/read_buffer/src/column/string.rs
@@ -80,6 +80,8 @@ impl StringEncoding {
             values: self.num_rows(),
             nulls: self.null_count(),
             bytes: self.size(),
+            raw_bytes: self.size_raw(true),
+            raw_bytes_no_null: self.size_raw(false),
         }
     }
 

--- a/read_buffer/src/column/string.rs
+++ b/read_buffer/src/column/string.rs
@@ -27,11 +27,21 @@ pub enum StringEncoding {
 /// This implementation is concerned with how to produce string columns with
 /// different encodings.
 impl StringEncoding {
-    /// The total size in bytes of the store columnar data.
+    /// The estimated total size in bytes of the in-memory columnar data.
     pub fn size(&self) -> usize {
         match self {
             Self::RleDictionary(enc) => enc.size(),
             Self::Dictionary(enc) => enc.size(),
+        }
+    }
+
+    /// The estimated total size in bytes of the underlying string values in the
+    /// column if they were stored contiguously and uncompressed. `include_nulls`
+    /// will effectively size each NULL value as a pointer if `true`.
+    pub fn size_raw(&self, include_nulls: bool) -> usize {
+        match self {
+            Self::RleDictionary(enc) => enc.size_raw(include_nulls),
+            Self::Dictionary(enc) => enc.size_raw(include_nulls),
         }
     }
 

--- a/read_buffer/src/row_group.rs
+++ b/read_buffer/src/row_group.rs
@@ -127,7 +127,7 @@ impl RowGroup {
         }
     }
 
-    /// The total estimated size in bytes of the row group
+    /// The total estimated size in bytes of the row group in memory
     pub fn size(&self) -> usize {
         let base_size = std::mem::size_of::<Self>()
             + self
@@ -145,6 +145,17 @@ impl RowGroup {
             let column = &self.columns[*idx];
             (name.as_str(), column.size())
         })
+    }
+
+    /// The total estimated size in bytes of all columns in the row group if
+    /// the values within were stored contiguously with no compression.
+    /// `include_nulls` controls whether to size NULL values according to the
+    /// base size of the data-type or to ignore them from the calculation.
+    pub fn size_raw(&self, include_nulls: bool) -> usize {
+        self.columns
+            .iter()
+            .map(|c| c.size_raw(include_nulls))
+            .sum::<usize>()
     }
 
     /// The number of rows in the `RowGroup` (all columns have the same number

--- a/read_buffer/src/table.rs
+++ b/read_buffer/src/table.rs
@@ -137,7 +137,7 @@ impl Table {
         self.table_data.read().data.len()
     }
 
-    /// The total size of the table in bytes.
+    /// An estimation of the total size of the table in bytes in memory
     pub fn size(&self) -> usize {
         let base_size = std::mem::size_of::<Self>() + self.name.len();
         // meta.size accounts for all the row group data.
@@ -164,6 +164,18 @@ impl Table {
                 estimated_bytes,
             })
             .collect()
+    }
+
+    /// An estimation of the total size of the table in bytes if all values were
+    /// stored contiguously and uncompressed. This size is useful to determine
+    /// a rough compression that the table is under.
+    pub fn size_raw(&self, include_nulls: bool) -> usize {
+        self.table_data
+            .read()
+            .data
+            .iter()
+            .map(|rg| rg.size_raw(include_nulls))
+            .sum::<usize>()
     }
 
     // Returns the total number of row groups in this table.


### PR DESCRIPTION
This PR contributes to the observability of IOx by adding a new metric to the Read Buffer that lets us track an estimated uncompressed size. Specifically, this PR adds a metric `read_buffer_column_raw_bytes` that keeps track of the size of data in the read buffer were it to be held in `Vec<T>` for each column.

The metric can be segmented by "nullness", meaning it tracks sizes for NULL values separately from non-null values. Excluding NULL values is probably closer to line-protocol size, and including it is closer to an uncompressed record batch or basic table structure in memory.

The metric will be useful for getting an idea about overall compression rates in the Read Buffer.