### PR TITLE
fix: don't test snapshotting when disabled (#1496)

### DIFF
--- a/mutable_buffer/src/chunk.rs
+++ b/mutable_buffer/src/chunk.rs
@@ -319,6 +319,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(not(feature = "nocache"))]
     fn test_snapshot() {
         let mr = MemRegistry::new();
         let mut chunk = Chunk::new(1, "cpu", &mr);


### PR DESCRIPTION
When running cargo test with the nocache feature enabled, don't run a test that asserts that caching is taking place.

Identified by @domodwyer and @carols10cents in #1496 