### PR TITLE
refactor: track ingest metrics in one place

### DIFF
--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -568,18 +568,6 @@ impl<M: ConnectionManager> Server<M> {
         )
         .await?;
 
-        let num_fields: usize = lines.iter().map(|line| line.field_set.len()).sum();
-        let labels = &[
-            metrics::KeyValue::new("status", "ok"),
-            metrics::KeyValue::new("db_name", db_name.to_string()),
-        ];
-        self.metrics
-            .ingest_lines_total
-            .add_with_labels(lines.len() as u64, labels);
-        self.metrics
-            .ingest_fields_total
-            .add_with_labels(num_fields as u64, labels);
-
         Ok(())
     }
 

--- a/src/influxdb_ioxd/http.rs
+++ b/src/influxdb_ioxd/http.rs
@@ -458,7 +458,16 @@ where
 
     let body = str::from_utf8(&body).context(ReadingBodyAsUtf8)?;
 
+    let mut num_fields = 0;
+    let mut num_lines = 0;
+
     let lines = parse_lines(body)
+        .inspect(|line| {
+            if let Ok(line) = line {
+                num_fields += line.field_set.len();
+                num_lines += 1;
+            }
+        })
         .collect::<Result<Vec<_>, influxdb_line_protocol::Error>>()
         .context(ParsingLineProtocol)?;
 
@@ -471,19 +480,21 @@ where
     ];
 
     server.write_lines(&db_name, &lines).await.map_err(|e| {
-        let num_fields: usize = lines.iter().map(|line| line.field_set.len()).sum();
         let labels = &[
             metrics::KeyValue::new("status", "error"),
             metrics::KeyValue::new("db_name", db_name.to_string()),
         ];
+
         server
             .metrics
             .ingest_lines_total
-            .add_with_labels(lines.len() as u64, labels);
+            .add_with_labels(num_lines as u64, labels);
+
         server
             .metrics
             .ingest_fields_total
             .add_with_labels(num_fields as u64, labels);
+
         server.metrics.ingest_points_bytes_total.add_with_labels(
             body.len() as u64,
             &[
@@ -491,7 +502,6 @@ where
                 metrics::KeyValue::new("db_name", db_name.to_string()),
             ],
         );
-        let num_lines = lines.len();
         debug!(?e, ?db_name, ?num_lines, "error writing lines");
 
         obs.client_error_with_labels(&metric_kv); // user error
@@ -506,14 +516,27 @@ where
             },
         }
     })?;
+
+    let labels = &[
+        metrics::KeyValue::new("status", "ok"),
+        metrics::KeyValue::new("db_name", db_name.to_string()),
+    ];
+
+    server
+        .metrics
+        .ingest_lines_total
+        .add_with_labels(num_lines as u64, labels);
+
+    server
+        .metrics
+        .ingest_fields_total
+        .add_with_labels(num_fields as u64, labels);
+
     // line protocol bytes successfully written
-    server.metrics.ingest_points_bytes_total.add_with_labels(
-        body.len() as u64,
-        &[
-            metrics::KeyValue::new("status", "ok"),
-            metrics::KeyValue::new("db_name", db_name.to_string()),
-        ],
-    );
+    server
+        .metrics
+        .ingest_points_bytes_total
+        .add_with_labels(body.len() as u64, labels);
 
     obs.ok_with_labels(&metric_kv); // request completed successfully
     Ok(Response::builder()


### PR DESCRIPTION
This was a slight oddity I noticed whilst plumbing in kinesis, half the ingest metrics are in server and half are in the rpc interface. This moves them to be in one location.

I'm aware there is a gRPC endpoint that is now not instrumented, instead of partly instrumented, but I'm not sure how long that endpoint is for this world and I don't think it is in use...