### PR TITLE
chore: Improve DataFusion plan logging

### DIFF
--- a/query/src/provider/physical.rs
+++ b/query/src/provider/physical.rs
@@ -1,11 +1,11 @@
 //! Implementation of a DataFusion PhysicalPlan node across partition chunks
 
-use std::sync::Arc;
+use std::{fmt, sync::Arc};
 
 use arrow::datatypes::SchemaRef;
 use datafusion::{
     error::DataFusionError,
-    physical_plan::{ExecutionPlan, Partitioning, SendableRecordBatchStream},
+    physical_plan::{DisplayFormatType, ExecutionPlan, Partitioning, SendableRecordBatchStream},
 };
 use internal_types::{schema::Schema, selection::Selection};
 
@@ -115,6 +115,20 @@ impl<C: PartitionChunk + 'static> ExecutionPlan for IOxReadFilterNode<C> {
             .map_err(|e| DataFusionError::Internal(e.to_string()))?;
 
         Ok(Box::pin(adapter))
+    }
+
+    fn fmt_as(&self, t: DisplayFormatType, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match t {
+            DisplayFormatType::Default => {
+                // Note Predicate doesn't implement Display so punt on showing that now
+                write!(
+                    f,
+                    "IOxReadFilterNode: table_name={}, chunks={} predicate=TODO",
+                    self.table_name,
+                    self.chunk_and_infos.len()
+                )
+            }
+        }
     }
 }
 


### PR DESCRIPTION
# Rationale
Have better debug for visibility into what plans are being run, so I can quickly answer questions like "are we sure projection pushdown is happening"

# Changes
Use `debug!` logging to log both the
1. original plan (produced by the IOx planners)
2. The optimized *physical* plan (what is about to be executed) -- and now has a reasonable format after https://github.com/apache/arrow-datafusion/pull/337

# Example logs:

Here is a log  snippet from my local IOx server when running a gRPC query

```
cargo run -- run --server-id=1 --object-store=file --data-dir=$HOME/.influxdb_iox -vv
```

```
cat /Users/alamb/Documents/lp_query_plans/read_request.json | grep -v _COMMENT | ./scripts/grpcurl  -d @ -plaintext localhost:8082 influxdata.platform.storage.Storage.ReadFilter
```

(using this file: [read_request.zip](https://github.com/influxdata/influxdb_iox/files/6496046/read_request.zip))

The logs are:

```
May 17 14:22:26.266 DEBUG query::exec::context: initial plan text=Projection: #cpu, #host, #usage_user, #time [cpu:Dictionary(Int32, Utf8);N, host:Dictionary(Int32, Utf8);N, usage_user:Float64;N, time:Timestamp(Nanosecond, None)]
  Sort: #cpu ASC NULLS FIRST, #host ASC NULLS FIRST, #time ASC NULLS FIRST [cpu:Dictionary(Int32, Utf8);N, host:Dictionary(Int32, Utf8);N, time:Timestamp(Nanosecond, None), usage_guest:Float64;N, usage_guest_nice:Float64;N, usage_idle:Float64;N, usage_iowait:Float64;N, usage_irq:Float64;N, usage_nice:Float64;N, usage_softirq:Float64;N, usage_steal:Float64;N, usage_system:Float64;N, usage_user:Float64;N]
    Filter: TimestampNanosecond(1619804414105040931) LtEq #time And #time Lt TimestampNanosecond(1619808014105040931) And #cpu Eq Utf8("cpu1") [cpu:Dictionary(Int32, Utf8);N, host:Dictionary(Int32, Utf8);N, time:Timestamp(Nanosecond, None), usage_guest:Float64;N, usage_guest_nice:Float64;N, usage_idle:Float64;N, usage_iowait:Float64;N, usage_irq:Float64;N, usage_nice:Float64;N, usage_softirq:Float64;N, usage_steal:Float64;N, usage_system:Float64;N, usage_user:Float64;N]
      TableScan: cpu projection=None [cpu:Dictionary(Int32, Utf8);N, host:Dictionary(Int32, Utf8);N, time:Timestamp(Nanosecond, None), usage_guest:Float64;N, usage_guest_nice:Float64;N, usage_idle:Float64;N, usage_iowait:Float64;N, usage_irq:Float64;N, usage_nice:Float64;N, usage_softirq:Float64;N, usage_steal:Float64;N, usage_system:Float64;N, usage_user:Float64;N]
May 17 14:22:26.267 DEBUG query::exec::context: optimized plan text=Projection: #cpu, #host, #usage_user, #time [cpu:Dictionary(Int32, Utf8);N, host:Dictionary(Int32, Utf8);N, usage_user:Float64;N, time:Timestamp(Nanosecond, None)]
  Sort: #cpu ASC NULLS FIRST, #host ASC NULLS FIRST, #time ASC NULLS FIRST [cpu:Dictionary(Int32, Utf8);N, host:Dictionary(Int32, Utf8);N, time:Timestamp(Nanosecond, None), usage_user:Float64;N]
    Filter: TimestampNanosecond(1619804414105040931) LtEq #time And #time Lt TimestampNanosecond(1619808014105040931) And #cpu Eq Utf8("cpu1") [cpu:Dictionary(Int32, Utf8);N, host:Dictionary(Int32, Utf8);N, time:Timestamp(Nanosecond, None), usage_user:Float64;N]
      TableScan: cpu projection=Some([0, 1, 2, 12]) [cpu:Dictionary(Int32, Utf8);N, host:Dictionary(Int32, Utf8);N, time:Timestamp(Nanosecond, None), usage_user:Float64;N] graphviz=// Begin DataFusion GraphViz Plan (see https://graphviz.org)
digraph {
  subgraph cluster_1
  {
    graph[label="LogicalPlan"]
    2[shape=box label="Projection: #cpu, #host, #usage_user, #time"]
    3[shape=box label="Sort: #cpu ASC NULLS FIRST, #host ASC NULLS FIRST, #time ASC NULLS FIRST"]
    2 -> 3 [arrowhead=none, arrowtail=normal, dir=back]
    4[shape=box label="Filter: TimestampNanosecond(1619804414105040931) LtEq #time And #time Lt TimestampNanosecond(1619808014105040931) And #cpu Eq Utf8(_cpu1_)"]
    3 -> 4 [arrowhead=none, arrowtail=normal, dir=back]
    5[shape=box label="TableScan: cpu projection=Some([0, 1, 2, 12])"]
    4 -> 5 [arrowhead=none, arrowtail=normal, dir=back]
  }
  subgraph cluster_6
  {
    graph[label="Detailed LogicalPlan"]
    7[shape=box label="Projection: #cpu, #host, #usage_user, #time\nSchema: [cpu:Dictionary(Int32, Utf8);N, host:Dictionary(Int32, Utf8);N, usage_user:Float64;N, time:Timestamp(Nanosecond, None)]"]
    8[shape=box label="Sort: #cpu ASC NULLS FIRST, #host ASC NULLS FIRST, #time ASC NULLS FIRST\nSchema: [cpu:Dictionary(Int32, Utf8);N, host:Dictionary(Int32, Utf8);N, time:Timestamp(Nanosecond, None), usage_user:Float64;N]"]
    7 -> 8 [arrowhead=none, arrowtail=normal, dir=back]
    9[shape=box label="Filter: TimestampNanosecond(1619804414105040931) LtEq #time And #time Lt TimestampNanosecond(1619808014105040931) And #cpu Eq Utf8(_cpu1_)\nSchema: [cpu:Dictionary(Int32, Utf8);N, host:Dictionary(Int32, Utf8);N, time:Timestamp(Nanosecond, None), usage_user:Float64;N]"]
    8 -> 9 [arrowhead=none, arrowtail=normal, dir=back]
    10[shape=box label="TableScan: cpu projection=Some([0, 1, 2, 12])\nSchema: [cpu:Dictionary(Int32, Utf8);N, host:Dictionary(Int32, Utf8);N, time:Timestamp(Nanosecond, None), usage_user:Float64;N]"]
    9 -> 10 [arrowhead=none, arrowtail=normal, dir=back]
  }
}
// End DataFusion GraphViz Plan

May 17 14:22:26.268 DEBUG query::exec::context: optimized physical plan text=ProjectionExec: expr=[cpu, host, usage_user, time]
  RepartitionExec: partitioning=RoundRobinBatch(16)
    SortExec: [cpu ASC,host ASC,time ASC]
      MergeExec
        CoalesceBatchesExec: target_batch_size=500
          FilterExec: 1619804414105040931 <= time AND time < 1619808014105040931 AND CAST(cpu AS Utf8) = cpu1
            RepartitionExec: partitioning=RoundRobinBatch(16)
              IOxReadFilterNode: table_name=cpu, chunks=1 predicate=TODO
```

(Btw @e-dard  this logging shows projection pushdown is happening -- note the optimized plan only scans a subset of the columns - namely `[0, 1, 2, 12]`)

Original plan (that came from the gRPC Planner):
```
May 17 14:22:26.266 DEBUG query::exec::context: initial plan text=Projection: #cpu, #host, #usage_user, #time [cpu:Dictionary(Int32, Utf8);N, host:Dictionary(Int32, Utf8);N, usage_user:Float64;N, time:Timestamp(Nanosecond, None)]
  Sort: #cpu ASC NULLS FIRST, #host ASC NULLS FIRST, #time ASC NULLS FIRST [cpu:Dictionary(Int32, Utf8);N, host:Dictionary(Int32, Utf8);N, time:Timestamp(Nanosecond, None), usage_guest:Float64;N, usage_guest_nice:Float64;N, usage_idle:Float64;N, usage_iowait:Float64;N, usage_irq:Float64;N, usage_nice:Float64;N, usage_softirq:Float64;N, usage_steal:Float64;N, usage_system:Float64;N, usage_user:Float64;N]
    Filter: TimestampNanosecond(1619804414105040931) LtEq #time And #time Lt TimestampNanosecond(1619808014105040931) And #cpu Eq Utf8("cpu1") [cpu:Dictionary(Int32, Utf8);N, host:Dictionary(Int32, Utf8);N, time:Timestamp(Nanosecond, None), usage_guest:Float64;N, usage_guest_nice:Float64;N, usage_idle:Float64;N, usage_iowait:Float64;N, usage_irq:Float64;N, usage_nice:Float64;N, usage_softirq:Float64;N, usage_steal:Float64;N, usage_system:Float64;N, usage_user:Float64;N]
      TableScan: cpu projection=None [cpu:Dictionary(Int32, Utf8);N, host:Dictionary(Int32, Utf8);N, time:Timestamp(Nanosecond, None), usage_guest:Float64;N, usage_guest_nice:Float64;N, usage_idle:Float64;N, usage_iowait:Float64;N, usage_irq:Float64;N, usage_nice:Float64;N, usage_softirq:Float64;N, usage_steal:Float64;N, usage_system:Float64;N, usage_user:Float64;N]
```

Optimized plan
```
May 17 14:22:26.267 DEBUG query::exec::context: optimized plan text=Projection: #cpu, #host, #usage_user, #time [cpu:Dictionary(Int32, Utf8);N, host:Dictionary(Int32, Utf8);N, usage_user:Float64;N, time:Timestamp(Nanosecond, None)]
  Sort: #cpu ASC NULLS FIRST, #host ASC NULLS FIRST, #time ASC NULLS FIRST [cpu:Dictionary(Int32, Utf8);N, host:Dictionary(Int32, Utf8);N, time:Timestamp(Nanosecond, None), usage_user:Float64;N]
    Filter: TimestampNanosecond(1619804414105040931) LtEq #time And #time Lt TimestampNanosecond(1619808014105040931) And #cpu Eq Utf8("cpu1") [cpu:Dictionary(Int32, Utf8);N, host:Dictionary(Int32, Utf8);N, time:Timestamp(Nanosecond, None), usage_user:Float64;N]
      TableScan: cpu projection=Some([0, 1, 2, 12]) [cpu:Dictionary(Int32, Utf8);N, host:Dictionary(Int32, Utf8);N, time:Tim

```
