### PR TITLE
fix: Set default line timestamp and default partition time to same value

### DIFF
--- a/entry/benches/benchmark.rs
+++ b/entry/benches/benchmark.rs
@@ -15,7 +15,9 @@ fn sequenced_entry(c: &mut Criterion) {
         .collect::<Result<Vec<_>, _>>()
         .unwrap();
     let shard_config: Option<&ShardConfig> = None;
-    let sharded_entries = lines_to_sharded_entries(&lines, shard_config, &partitioner(1)).unwrap();
+    let default_time = 456;
+    let sharded_entries =
+        lines_to_sharded_entries(&lines, default_time, shard_config, &partitioner(1)).unwrap();
     let entry = &sharded_entries.first().unwrap().entry;
     let data = entry.data();
     assert_eq!(

--- a/tests/end_to_end_cases/write_api.rs
+++ b/tests/end_to_end_cases/write_api.rs
@@ -93,8 +93,10 @@ async fn test_write_entry() {
     let lp_data = vec!["cpu bar=1 10", "cpu bar=2 20"].join("\n");
 
     let lines: Vec<_> = parse_lines(&lp_data).map(|l| l.unwrap()).collect();
+    let default_time = 456;
     let sharded_entries =
-        lines_to_sharded_entries(&lines, sharder(1).as_ref(), &partitioner(1)).unwrap();
+        lines_to_sharded_entries(&lines, default_time, sharder(1).as_ref(), &partitioner(1))
+            .unwrap();
 
     let entry: Vec<u8> = sharded_entries.into_iter().next().unwrap().entry.into();
 


### PR DESCRIPTION
I found this problem while thinking about where to hook in Kafka. I'm not sure that I understand how that all will work yet, but I think this problem is relevant in any case.

# Problem

I think there's a subtle problem with the timestamp assigned to points that don't have one and partitions based on timestamps that has the potential to cause unexpected results.

I was looking at this code from the lens of saving writes before much processing has been done and restoring them later, and the assignment of the default timestamp was happening later than I expected to find it in the course of processing line protocol, and I found [2 calls to `Utc::now`](https://github.com/influxdata/influxdb_iox/blob/76ee9793dd7d4e6f99fd4a402a06d2f1c5bb8de7/entry/src/entry.rs#L71-L94) where I only expected one.

The bug I think I found is illustrated in the "test" commit, which adds a test that fails before the three "fix" commits in this PR. (The first "refactor" commit makes it possible to inject the source of the current time so that I could write the failing test).

The test fails with:

```
---- entry::tests::missing_times_added_should_match_partition stdout ----
thread 'entry::tests::missing_times_added_should_match_partition' panicked at 'assertion failed: `(left == right)`
  left: `"2021-01-01T01"`,
 right: `"2021-01-01T00"`', entry/src/entry.rs:2214:9
```

The problem is that `lines_to_sharded_entries` would:

- Get the current time
- Shard and partition each line, and partitioning rules might be "hour of the time", and the default time would be passed in to `partitioner.partition_key` to use if the line didn't have a timestamp
- Get the current time *again*
- For each shard, call `build_sharded_entry`, which *also* takes a default time, which eventually gets inserted as a point's timestamp if it doesn't have one, and this default time might be different than the default time used for the partition

And if the first default time is in one partition, and the second default time is in another partition, then all the originally-timestampless points in a partition might have timestamps inconsistent with the key of the partition they live in.

I could see this having confusing and subtle results!

These two calls to get the current time were added in [this commit](2a134a3ac1809dd127ab071da6a9c21c9934f1f0), and I don't see anything calling out why it was done that way.

This problem also existed in the old `ReplicatedWrite` code but with even different wrong behavior, [removed here](979f5f9347a80a40b13da62b0cec7c3a50751b59), because [`lines_to_replicated_write` had one default time used for the partition key](https://github.com/influxdata/influxdb_iox/blob/a967ebfabd228e60240de6b6652aae9cceaee2d4/internal_types/src/data.rs#L216-L218), and [`add_line` had a separate default time refetched for *each* point](https://github.com/influxdata/influxdb_iox/blob/a967ebfabd228e60240de6b6652aae9cceaee2d4/internal_types/src/data.rs#L375-L378). With that code, *some* originally-timestampless points might have ended up in the right partition, and some might have ended up in the wrong partition.

# Three possible solutions; which is best?

The first "fix" commit in this PR just removes the second `default_timestamp` assignment, and the test passes.

The second "fix" commit moves the assignment of the default time up a level, to `server.write_lines`. This leaks the default time concept around a bit more, mostly in tests, which I think can be cleaned up separately.

The third "fix" commit moves the assignment up another level to `src/influxdb_ioxd/http.rs` `write` and `src/influxdb_ioxd/rpc/write.rs` `write`, so that we get the current time before even parsing the request body as line protocol and then always use that one time for any default time needed for anything in the request. This is where I originally thought the default time would be set, and would let us replay chunks of line protocol through `server.write_lines` at whatever time in the past they came in.

All 3 of these commits pass the failing test, it's just a matter of which level is the correct place to be capturing the time at which a set of line protocol is being processed and where a past time could be injected if we're re-processing line protocol at a later time.