### PR TITLE
refactor: empty transaction during catalog creation

### DIFF
--- a/server/src/db/process_clock.rs
+++ b/server/src/db/process_clock.rs
@@ -75,11 +75,11 @@ mod tests {
     use entry::test_helpers::lp_to_entry;
     use std::{sync::Arc, thread, time::Duration};
 
-    #[test]
-    fn process_clock_defaults_to_current_time_in_ns() {
+    #[tokio::test]
+    async fn process_clock_defaults_to_current_time_in_ns() {
         let before = system_clock_now();
 
-        let db = Arc::new(TestDb::builder().build().db);
+        let db = Arc::new(TestDb::builder().build().await.db);
         let db_process_clock = db.process_clock.inner.load(Ordering::SeqCst);
 
         let after = system_clock_now();
@@ -98,12 +98,12 @@ mod tests {
         );
     }
 
-    #[test]
-    fn process_clock_incremented_and_set_on_sequenced_entry() {
+    #[tokio::test]
+    async fn process_clock_incremented_and_set_on_sequenced_entry() {
         let before = system_clock_now();
         let before = ClockValue::try_from(before).unwrap();
 
-        let db = Arc::new(TestDb::builder().write_buffer(true).build().db);
+        let db = Arc::new(TestDb::builder().write_buffer(true).build().await.db);
 
         let entry = lp_to_entry("cpu bar=1 10");
         db.store_entry(entry).unwrap();
@@ -147,10 +147,10 @@ mod tests {
         );
     }
 
-    #[test]
-    fn next_process_clock_always_increments() {
+    #[tokio::test]
+    async fn next_process_clock_always_increments() {
         // Process clock defaults to the current time
-        let db = Arc::new(TestDb::builder().write_buffer(true).build().db);
+        let db = Arc::new(TestDb::builder().write_buffer(true).build().await.db);
 
         // Set the process clock value to a time in the future, so that when compared to the
         // current time, the process clock value will be greater

--- a/server/src/query_tests/influxrpc/read_window_aggregate.rs
+++ b/server/src/query_tests/influxrpc/read_window_aggregate.rs
@@ -162,7 +162,7 @@ impl DbSetup for MeasurementForWindowAggregateMonths {
         // partition keys are: ["2020-03-02T00", "2020-03-01T00", "2020-04-01T00",
         // "2020-04-02T00"]
 
-        let db = make_db().db;
+        let db = make_db().await.db;
         let data = lp_lines.join("\n");
         write_lp(&db, &data);
         let scenario1 = DbScenario {
@@ -170,7 +170,7 @@ impl DbSetup for MeasurementForWindowAggregateMonths {
             db,
         };
 
-        let db = make_db().db;
+        let db = make_db().await.db;
         let data = lp_lines.join("\n");
         write_lp(&db, &data);
         db.rollover_partition("2020-03-01T00", "h2o").await.unwrap();
@@ -182,7 +182,7 @@ impl DbSetup for MeasurementForWindowAggregateMonths {
             db,
         };
 
-        let db = make_db().db;
+        let db = make_db().await.db;
         let data = lp_lines.join("\n");
         write_lp(&db, &data);
         // roll over and load chunks into both RUB and OS

--- a/server/src/snapshot.rs
+++ b/server/src/snapshot.rs
@@ -279,6 +279,7 @@ cpu,host=B,region=east user=10.0,system=74.1 1
         let db = TestDb::builder()
             .object_store(Arc::new(ObjectStore::new_in_memory(InMemory::new())))
             .build()
+            .await
             .db;
         write_lp(&db, &lp);
 


### PR DESCRIPTION
That involves some refactoring which we are going to need anyway for
hooking up the "read" path of the catalog into the DB startup, namely:

- make `Db::new` async and failable
- as a consequence, make the handling in `server::config` async as well
 (since the old lock wasn't `Send`)

This prepares for #1382.

**The PR was actually meant to contain more stuff (namely a bit safer handling of the preserved catalog so you don't overwrite existing ones), but that goes into the next PR because this one is really merge-conflict-prone.**
