### PR TITLE
feat: add ability to merge sorted arrow record batches

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1654,7 +1654,9 @@ version = "0.1.0"
 dependencies = [
  "arrow 0.1.0",
  "arrow_util",
+ "hashbrown 0.11.2",
  "observability_deps",
+ "rand 0.8.3",
  "snafu",
 ]
 

--- a/arrow_util/Cargo.toml
+++ b/arrow_util/Cargo.toml
@@ -7,12 +7,16 @@ description = "Apache Arrow utilities"
 
 [dependencies]
 
-arrow = { path = "../arrow" }
 ahash = "0.7.2"
-num-traits = "0.2"
+arrow = { path = "../arrow" }
 futures = "0.3"
-snafu = "0.6"
 hashbrown = "0.11"
+num-traits = "0.2"
+rand = { version = "0.8.3", optional = true }
+snafu = "0.6"
 
 [dev-dependencies]
 rand = "0.8.3"
+
+[features]
+fuzz = ["rand"]

--- a/arrow_util/src/fuzz.rs
+++ b/arrow_util/src/fuzz.rs
@@ -1,0 +1,88 @@
+//! A collection of testing functions for arrow based code
+use arrow::{
+    array::{
+        Array, ArrayDataBuilder, ArrayRef, DictionaryArray, Float64Array, Int32Array, StringArray,
+        TimestampNanosecondArray, UInt64Array,
+    },
+    datatypes::{DataType, Int32Type, TimeUnit},
+};
+use rand::Rng;
+use std::sync::Arc;
+
+pub fn make_random_array(
+    datatype: DataType,
+    dictionary_values: Option<usize>,
+    num_rows: usize,
+    valid_probability: f64,
+) -> ArrayRef {
+    let mut rng = rand::thread_rng();
+
+    match dictionary_values {
+        Some(dictionary_values) => {
+            let values = make_random_array(datatype.clone(), None, dictionary_values, 1.);
+            let indexes: Int32Array = std::iter::from_fn(|| {
+                Some(
+                    rng.gen_bool(valid_probability)
+                        .then(|| rng.gen_range(0..(dictionary_values as i32))),
+                )
+            })
+            .take(num_rows)
+            .collect();
+
+            let data = ArrayDataBuilder::new(DataType::Dictionary(
+                Box::new(DataType::Int32),
+                Box::new(datatype),
+            ))
+            .len(indexes.len())
+            .add_buffer(indexes.data().buffers()[0].clone())
+            .null_bit_buffer(indexes.data().null_buffer().unwrap().clone())
+            .add_child_data(values.data().clone())
+            .build();
+
+            Arc::new(DictionaryArray::<Int32Type>::from(data))
+        }
+        None => match datatype {
+            DataType::UInt64 => {
+                let array: UInt64Array =
+                    std::iter::from_fn(|| Some(rng.gen_bool(valid_probability).then(|| rng.gen())))
+                        .take(num_rows)
+                        .collect();
+
+                Arc::new(array)
+            }
+            DataType::Float64 => {
+                let array: Float64Array =
+                    std::iter::from_fn(|| Some(rng.gen_bool(valid_probability).then(|| rng.gen())))
+                        .take(num_rows)
+                        .collect();
+
+                Arc::new(array)
+            }
+            DataType::Timestamp(TimeUnit::Nanosecond, None) => {
+                let array: TimestampNanosecondArray = std::iter::from_fn(|| {
+                    Some(
+                        rng.gen_bool(valid_probability)
+                            .then(|| rng.gen_range(0..500000)),
+                    )
+                })
+                .take(num_rows)
+                .collect();
+
+                Arc::new(array)
+            }
+            DataType::Utf8 => {
+                let array: StringArray = std::iter::from_fn(|| {
+                    Some(
+                        rng.gen_bool(valid_probability)
+                            .then(|| rng.gen::<usize>().to_string()),
+                    )
+                })
+                .take(num_rows)
+                .collect();
+
+                Arc::new(array)
+            }
+            _ => unimplemented!(),
+        },
+    }
+}

--- a/arrow_util/src/lib.rs
+++ b/arrow_util/src/lib.rs
@@ -6,5 +6,8 @@ pub mod dictionary;
 pub mod string;
 pub mod util;
 
+#[cfg(feature = "fuzz")]
+pub mod fuzz;
+
 /// This has a collection of testing helper functions
 pub mod test_util;

--- a/internal_types/Cargo.toml
+++ b/internal_types/Cargo.toml
@@ -8,8 +8,10 @@ readme = "README.md"
 
 [dependencies]
 arrow = { path = "../arrow" }
-snafu = "0.6"
+hashbrown = "0.11"
 observability_deps = { path = "../observability_deps" }
+snafu = "0.6"
 
 [dev-dependencies]
-arrow_util = { path = "../arrow_util" }
+arrow_util = { path = "../arrow_util", features = ["fuzz"] }
+rand = "0.8.3"

--- a/internal_types/src/arrow.rs
+++ b/internal_types/src/arrow.rs
@@ -1,1 +1,4 @@
+pub mod concat;
+pub mod cursor;
+pub mod merge;
 pub mod sort;

--- a/internal_types/src/arrow/concat.rs
+++ b/internal_types/src/arrow/concat.rs
@@ -1,0 +1,55 @@
+use crate::schema;
+use crate::schema::Schema;
+use arrow::record_batch::RecordBatch;
+use snafu::Snafu;
+use std::convert::TryFrom;
+use std::sync::Arc;
+
+/// Database schema creation / validation errors.
+#[derive(Debug, Snafu)]
+pub enum Error {
+    #[snafu(context(false))]
+    SchemaError { source: schema::Error },
+
+    #[snafu(context(false))]
+    ArrowError { source: arrow::error::ArrowError },
+}
+
+pub type Result<T, E = Error> = std::result::Result<T, E>;
+
+/// Concatenates multiple batches together
+pub fn concat_batches(batches: &[RecordBatch]) -> Result<RecordBatch, arrow::error::ArrowError> {
+    let schema = compute_schema(batches).unwrap();
+
+    let columns = schema
+        .iter()
+        .map(|(_, field)| {
+            let arrays: Vec<_> = batches
+                .iter()
+                .map(|x| match x.schema().column_with_name(field.name()) {
+                    Some((idx, _)) => Arc::clone(x.column(idx)),
+                    None => arrow::array::new_null_array(field.data_type(), x.num_rows()),
+                })
+                .collect();
+
+            // This is nasty
+            let array_refs: Vec<_> = arrays.iter().map(|x| x.as_ref()).collect();
+
+            arrow::compute::concat(array_refs.as_slice())
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+
+    RecordBatch::try_new(schema.as_arrow(), columns)
+}
+
+/// Computes the aggregate schema across all provided record batches
+pub fn compute_schema(batches: &[RecordBatch]) -> Result<Schema> {
+    let mut aggregated_schema = Schema::try_from(batches[0].schema())?;
+
+    for batch in &batches[1..] {
+        let schema = Schema::try_from(batch.schema())?;
+        aggregated_schema = aggregated_schema.try_merge(schema)?;
+    }
+
+    Ok(aggregated_schema)
+}

--- a/internal_types/src/arrow/cursor.rs
+++ b/internal_types/src/arrow/cursor.rs
@@ -1,0 +1,393 @@
+use crate::arrow::sort::SortOrder;
+use arrow::array::{Array, DictionaryArray, Int32Array, StringArray, TimestampNanosecondArray};
+use arrow::datatypes::{DataType, Int32Type, TimeUnit};
+use arrow::record_batch::RecordBatch;
+use std::cmp::Ordering;
+
+/// A value that can be used in a primary key
+#[derive(Debug, PartialOrd, PartialEq, Ord, Eq)]
+enum FieldValue<'a> {
+    String(&'a str),
+    Time(i64),
+}
+
+/// A column that forms part of a primary key
+#[derive(Debug)]
+enum ColumnValues<'a> {
+    Tag(&'a arrow::array::Int32Array, StringArray),
+    Time(&'a TimestampNanosecondArray),
+}
+
+impl<'a> ColumnValues<'a> {
+    fn get(&self, idx: usize) -> Option<FieldValue<'_>> {
+        match &self {
+            ColumnValues::Tag(keys, values) => {
+                if !keys.is_valid(idx) {
+                    return None;
+                }
+                Some(FieldValue::String(values.value(keys.value(idx) as usize)))
+            }
+            ColumnValues::Time(time) => {
+                if !time.is_valid(idx) {
+                    return None;
+                }
+                Some(FieldValue::Time(time.value(idx)))
+            }
+        }
+    }
+}
+
+/// A PrimaryKeyCursor is created from a RecordBatch and a list of columns that comprise
+/// its primary key. It also contains a list of row indices to advance through
+///
+/// When created the cursor points to the first row index in the provided indices row.
+///
+/// Calling PrimaryKeyCursor::advance will move the cursor to point to the next row index
+/// identified by the indices, and returns the row index it previously pointed to
+///
+/// When compared PrimaryKeyCursor's compare the primary keys the cursor currently
+/// points to
+///
+#[derive(Debug)]
+struct PrimaryKeyCursor<'a> {
+    columns: Vec<Option<ColumnValues<'a>>>,
+    // TODO: Make this optional
+    indices: &'a [u32],
+    row: usize,
+}
+
+impl<'a> PrimaryKeyCursor<'a> {
+    pub fn new(batch: &'a RecordBatch, indices: &'a [u32], column_names: &[String]) -> Self {
+        let schema = batch.schema();
+        let columns = column_names
+            .iter()
+            .map(|column_name| {
+                let (idx, field) = schema.column_with_name(column_name)?;
+                let column = batch.column(idx);
+                Some(match field.data_type() {
+                    DataType::Dictionary(key, value)
+                        if key.as_ref() == &DataType::Int32
+                            && value.as_ref() == &DataType::Utf8 =>
+                    {
+                        let dictionary = column
+                            .as_any()
+                            .downcast_ref::<DictionaryArray<Int32Type>>()
+                            .unwrap();
+
+                        let keys = dictionary
+                            .keys()
+                            .as_any()
+                            .downcast_ref::<Int32Array>()
+                            .unwrap();
+
+                        // This is a pretty grim workaround for https://github.com/apache/arrow-rs/issues/313
+                        let values = dictionary
+                            .values()
+                            .as_any()
+                            .downcast_ref::<StringArray>()
+                            .unwrap()
+                            .data()
+                            .clone();
+                        let values = StringArray::from(values);
+
+                        ColumnValues::Tag(keys, values)
+                    }
+                    DataType::Timestamp(TimeUnit::Nanosecond, None) => {
+                        let times = column
+                            .as_any()
+                            .downcast_ref::<TimestampNanosecondArray>()
+                            .unwrap();
+
+                        ColumnValues::Time(times)
+                    }
+                    _ => unreachable!(),
+                })
+            })
+            .collect();
+
+        Self {
+            row: 0,
+            indices,
+            columns,
+        }
+    }
+
+    pub fn remaining(&self) -> usize {
+        self.indices.len() - self.row
+    }
+
+    pub fn is_finished(&self) -> bool {
+        self.remaining() == 0
+    }
+
+    pub fn advance(&mut self) -> usize {
+        assert!(!self.is_finished());
+        let idx = self.indices[self.row];
+        self.row += 1;
+        idx as usize
+    }
+}
+
+impl<'a> Eq for PrimaryKeyCursor<'a> {}
+impl<'a> PartialEq for PrimaryKeyCursor<'a> {
+    fn eq(&self, other: &Self) -> bool {
+        assert!(!self.is_finished());
+        assert!(!other.is_finished());
+        assert_eq!(self.columns.len(), other.columns.len());
+
+        let l_idx = self.indices[self.row] as usize;
+        let r_idx = other.indices[other.row] as usize;
+
+        for (l, r) in self.columns.iter().zip(other.columns.iter()) {
+            match (l, r) {
+                (Some(l), Some(r)) => match (l.get(l_idx), r.get(r_idx)) {
+                    (Some(l), Some(r)) => {
+                        if l.ne(&r) {
+                            return false;
+                        }
+                    }
+                    _ => return false,
+                },
+                _ => return false,
+            }
+        }
+        true
+    }
+}
+
+impl<'a> PartialOrd for PrimaryKeyCursor<'a> {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl<'a> Ord for PrimaryKeyCursor<'a> {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        assert!(!self.is_finished());
+        assert!(!other.is_finished());
+        assert_eq!(self.columns.len(), other.columns.len());
+
+        let l_idx = self.indices[self.row] as usize;
+        let r_idx = other.indices[other.row] as usize;
+
+        for (l, r) in self.columns.iter().zip(other.columns.iter()) {
+            let l = l.as_ref().and_then(|x| x.get(l_idx));
+            let r = r.as_ref().and_then(|x| x.get(r_idx));
+
+            match (l, r) {
+                // Sort order is ascending with nulls first
+                (None, Some(_)) => return Ordering::Less,
+                (Some(_), None) => return Ordering::Greater,
+                (None, None) => {}
+                (Some(l), Some(r)) => match l.cmp(&r) {
+                    Ordering::Equal => {}
+                    o => return o,
+                },
+            }
+        }
+        Ordering::Equal
+    }
+}
+
+/// A BatchIndex identifies a row within an ordered collection of RecordBatches
+#[derive(Debug, Clone, PartialOrd, PartialEq, Ord, Eq)]
+pub struct BatchIndex {
+    pub batch_idx: usize,
+    pub row_idx: usize,
+}
+
+/// A `SortedBatchIterator` is created from a collection of RecordBatches
+/// with corresponding indices, and a SortOrder
+///
+/// The `indices` array for each batch must yield an iteration that corresponds to
+/// the provided `SortOrder` within that batch
+///
+/// The `SortedBatchIterator` will then yield the sequence of `BatchIndex` that correctly
+/// interleaves the source rows with respect to the provided SortOrder
+#[derive(Debug)]
+pub struct SortedBatchIterator<'a> {
+    cursors: Vec<PrimaryKeyCursor<'a>>,
+}
+
+impl<'a> SortedBatchIterator<'a> {
+    pub fn new(
+        batch: impl IntoIterator<Item = &'a RecordBatch>,
+        indices: impl IntoIterator<Item = &'a [u32]>,
+        sort_order: &'a SortOrder,
+    ) -> Self {
+        let cursors = batch
+            .into_iter()
+            .zip(indices.into_iter())
+            .map(|(batch, sort_indices)| {
+                PrimaryKeyCursor::new(batch, sort_indices, sort_order.primary_key.as_slice())
+            })
+            .collect();
+        Self { cursors }
+    }
+}
+
+impl<'a> Iterator for SortedBatchIterator<'a> {
+    type Item = BatchIndex;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        // TODO: Implement de-duplication
+
+        let mut min_cursor = None;
+        for (idx, candidate) in self.cursors.iter_mut().enumerate() {
+            if candidate.is_finished() {
+                continue;
+            }
+            match min_cursor {
+                None => min_cursor = Some((idx, candidate)),
+                Some((_, ref min)) => {
+                    if min.cmp(&candidate) == Ordering::Greater {
+                        min_cursor = Some((idx, candidate))
+                    }
+                }
+            }
+        }
+        let (batch_idx, min_cursor) = min_cursor?;
+        let row_idx = min_cursor.advance();
+
+        Some(BatchIndex { batch_idx, row_idx })
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let total = self.cursors.iter().map(|x| x.remaining()).sum();
+        (total, Some(total))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::arrow::sort::{compute_sort_indices, SortOrder};
+    use arrow::array::ArrayRef;
+    use std::iter::FromIterator;
+    use std::sync::Arc;
+
+    #[test]
+    fn test_cursor_single() {
+        let a: ArrayRef = Arc::new(Int32Array::from(vec![1, 2, 7, 9, 3]));
+        let b: ArrayRef = Arc::new(DictionaryArray::<Int32Type>::from_iter(vec![
+            "a", "d", "b", "c", "a",
+        ]));
+        let c: ArrayRef = Arc::new(TimestampNanosecondArray::from(vec![8, 7, 6, 5, 4]));
+
+        let batch = RecordBatch::try_from_iter(vec![("a", a), ("b", b), ("c", c)]).unwrap();
+
+        let sort = SortOrder {
+            primary_key: vec!["b".to_string(), "c".to_string()],
+        };
+
+        let sort_indices = compute_sort_indices(&batch, &sort).unwrap();
+        let collected: Vec<_> =
+            SortedBatchIterator::new(&[batch], std::iter::once(sort_indices.values()), &sort)
+                .collect();
+
+        assert_eq!(
+            collected,
+            &[
+                BatchIndex {
+                    batch_idx: 0,
+                    row_idx: 4
+                },
+                BatchIndex {
+                    batch_idx: 0,
+                    row_idx: 0
+                },
+                BatchIndex {
+                    batch_idx: 0,
+                    row_idx: 2
+                },
+                BatchIndex {
+                    batch_idx: 0,
+                    row_idx: 3
+                },
+                BatchIndex {
+                    batch_idx: 0,
+                    row_idx: 1
+                },
+            ]
+        )
+    }
+
+    #[test]
+    fn test_cursor_two() {
+        let a: ArrayRef = Arc::new(Int32Array::from(vec![1, 2, 7, 9, 3]));
+        let b: ArrayRef = Arc::new(DictionaryArray::<Int32Type>::from_iter(vec![
+            "a", "d", "b", "c", "a",
+        ]));
+        let c: ArrayRef = Arc::new(TimestampNanosecondArray::from(vec![8, 7, 6, 5, 4]));
+
+        let b1 = RecordBatch::try_from_iter(vec![("a", a), ("b", b), ("c", c)]).unwrap();
+
+        let a: ArrayRef = Arc::new(Int32Array::from(vec![1, 2, 3, 4, 5]));
+        let b: ArrayRef = Arc::new(DictionaryArray::<Int32Type>::from_iter(vec![
+            "f", "c", "e", "b", "a",
+        ]));
+        let c: ArrayRef = Arc::new(TimestampNanosecondArray::from(vec![4, 6, 2, 2, 6]));
+
+        let b2 = RecordBatch::try_from_iter(vec![("a", a), ("b", b), ("c", c)]).unwrap();
+
+        let sort = SortOrder {
+            primary_key: vec!["b".to_string(), "c".to_string()],
+        };
+
+        let s1 = compute_sort_indices(&b1, &sort).unwrap();
+        let s2 = compute_sort_indices(&b2, &sort).unwrap();
+
+        let collected: Vec<_> = SortedBatchIterator::new(
+            &[b1, b2],
+            std::array::IntoIter::new([s1.values(), s2.values()]),
+            &sort,
+        )
+        .collect();
+
+        assert_eq!(
+            collected,
+            &[
+                BatchIndex {
+                    batch_idx: 0,
+                    row_idx: 4
+                },
+                BatchIndex {
+                    batch_idx: 1,
+                    row_idx: 4
+                },
+                BatchIndex {
+                    batch_idx: 0,
+                    row_idx: 0
+                },
+                BatchIndex {
+                    batch_idx: 1,
+                    row_idx: 3
+                },
+                BatchIndex {
+                    batch_idx: 0,
+                    row_idx: 2
+                },
+                BatchIndex {
+                    batch_idx: 0,
+                    row_idx: 3
+                },
+                BatchIndex {
+                    batch_idx: 1,
+                    row_idx: 1
+                },
+                BatchIndex {
+                    batch_idx: 0,
+                    row_idx: 1
+                },
+                BatchIndex {
+                    batch_idx: 1,
+                    row_idx: 2
+                },
+                BatchIndex {
+                    batch_idx: 1,
+                    row_idx: 0
+                },
+            ]
+        )
+    }
+}

--- a/internal_types/src/arrow/merge.rs
+++ b/internal_types/src/arrow/merge.rs
@@ -1,0 +1,429 @@
+use snafu::Snafu;
+
+use arrow::array::MutableArrayData;
+use arrow::record_batch::RecordBatch;
+
+use crate::arrow::cursor::SortedBatchIterator;
+use crate::arrow::sort::{compute_sort_indices, SortOrder};
+use crate::arrow::{concat, sort};
+use crate::schema;
+use std::cmp::min;
+
+/// Database schema creation / validation errors.
+#[derive(Debug, Snafu)]
+pub enum Error {
+    #[snafu(context(false))]
+    SchemaError { source: schema::Error },
+
+    #[snafu(context(false))]
+    SortError { source: sort::Error },
+
+    #[snafu(context(false))]
+    ArrowError { source: arrow::error::ArrowError },
+
+    #[snafu(context(false))]
+    ConcatError { source: concat::Error },
+}
+
+pub type Result<T, E = Error> = std::result::Result<T, E>;
+
+/// Merges a collection of RecordBatches according to a given sort order producing a list
+/// of batches of at most `batch_size` rows
+pub fn merge(
+    batches: &[RecordBatch],
+    batch_size: usize,
+    sort_order: &SortOrder,
+) -> Result<Vec<RecordBatch>> {
+    if batches.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    // This also validates that the batches are compatible
+    let schema = concat::compute_schema(batches)?;
+
+    let total_rows: usize = batches.iter().map(|x| x.num_rows()).sum();
+
+    // TODO: Avoid sorting data if it is already sorted
+    let sort_indices = batches
+        .iter()
+        .map(|x| compute_sort_indices(x, &sort_order))
+        .collect::<Result<Vec<_>, _>>()?;
+
+    let mut batch_indexes = SortedBatchIterator::new(
+        batches,
+        sort_indices.iter().map(|x| x.values()),
+        &sort_order,
+    );
+
+    let mut ret = vec![];
+    let mut has_more = true;
+
+    while has_more {
+        // Creates a MutableArrayData for each column in schema
+        // Because not all record batches contain all columns also contains a lookup
+        // table from batch index to index within the MutableArrayData's buffers
+        let mut column_builders: Vec<_> = schema
+            .iter()
+            .map(|(_, field)| {
+                let mut builder_offset = 0_usize;
+                let mut builder_offsets = vec![None; batches.len()];
+
+                let arrays: Vec<_> = batches
+                    .iter()
+                    .enumerate()
+                    .flat_map(|(batch_idx, batch)| {
+                        let (idx, _) = batch.schema().column_with_name(field.name())?;
+
+                        builder_offsets[batch_idx] = Some(builder_offset);
+                        builder_offset += 1;
+
+                        Some(batch.column(idx).data())
+                    })
+                    .collect();
+
+                assert_eq!(builder_offset, arrays.len());
+
+                (
+                    MutableArrayData::new(arrays, true, min(batch_size, total_rows)),
+                    builder_offsets,
+                )
+            })
+            .collect();
+
+        // TODO: Could coalesce multiple consecutive reads from the same batch into a single extend
+
+        for _ in 0..batch_size {
+            match batch_indexes.next() {
+                Some(batch_idx) => {
+                    for (builder, lookup) in &mut column_builders {
+                        match lookup[batch_idx.batch_idx] {
+                            Some(builder_idx) => builder.extend(
+                                builder_idx,
+                                batch_idx.row_idx,
+                                batch_idx.row_idx + 1,
+                            ),
+                            None => builder.extend_nulls(1),
+                        }
+                    }
+                }
+                None => {
+                    has_more = false;
+                    break;
+                }
+            }
+        }
+
+        let arrays: Vec<_> = column_builders
+            .into_iter()
+            .map(|(builder, _)| arrow::array::make_array(builder.freeze()))
+            .collect();
+
+        ret.push(RecordBatch::try_new(schema.as_arrow(), arrays)?);
+    }
+
+    Ok(ret)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::arrow::sort::sort_record_batch_by;
+    use crate::schema::TIME_DATA_TYPE;
+    use arrow::array::{ArrayRef, DictionaryArray, Int32Array, TimestampNanosecondArray};
+    use arrow::datatypes::{DataType, Int32Type};
+    use arrow_util::{assert_batches_eq, fuzz::make_random_array};
+    use std::iter::FromIterator;
+    use std::sync::Arc;
+
+    #[test]
+    fn test_merge() {
+        let a: ArrayRef = Arc::new(Int32Array::from(vec![1, 2, 7, 9, 3]));
+        let b: ArrayRef = Arc::new(DictionaryArray::<Int32Type>::from_iter(vec![
+            "a", "d", "b", "c", "a",
+        ]));
+        let c: ArrayRef = Arc::new(TimestampNanosecondArray::from(vec![8, 7, 6, 5, 4]));
+
+        let b1 = RecordBatch::try_from_iter(vec![("a", a), ("b", b), ("c", c)]).unwrap();
+
+        let a: ArrayRef = Arc::new(Int32Array::from(vec![1, 2, 3, 4, 5]));
+        let b: ArrayRef = Arc::new(DictionaryArray::<Int32Type>::from_iter(vec![
+            "f", "c", "e", "b", "a",
+        ]));
+        let c: ArrayRef = Arc::new(TimestampNanosecondArray::from(vec![4, 6, 2, 2, 6]));
+
+        let b2 = RecordBatch::try_from_iter(vec![("a", a), ("b", b), ("c", c)]).unwrap();
+
+        let sort = SortOrder {
+            primary_key: vec!["b".to_string(), "c".to_string()],
+        };
+
+        let merged = merge(&[b1, b2], usize::MAX, &sort).unwrap();
+        assert_eq!(merged.len(), 1);
+        let merged = merged.into_iter().next().unwrap();
+
+        assert_batches_eq!(
+            &[
+                "+---+---+-------------------------------+",
+                "| a | b | c                             |",
+                "+---+---+-------------------------------+",
+                "| 3 | a | 1970-01-01 00:00:00.000000004 |",
+                "| 5 | a | 1970-01-01 00:00:00.000000006 |",
+                "| 1 | a | 1970-01-01 00:00:00.000000008 |",
+                "| 4 | b | 1970-01-01 00:00:00.000000002 |",
+                "| 7 | b | 1970-01-01 00:00:00.000000006 |",
+                "| 9 | c | 1970-01-01 00:00:00.000000005 |",
+                "| 2 | c | 1970-01-01 00:00:00.000000006 |",
+                "| 2 | d | 1970-01-01 00:00:00.000000007 |",
+                "| 3 | e | 1970-01-01 00:00:00.000000002 |",
+                "| 1 | f | 1970-01-01 00:00:00.000000004 |",
+                "+---+---+-------------------------------+",
+            ],
+            &[merged]
+        );
+    }
+
+    #[test]
+    fn test_merge_nulls() {
+        let a: ArrayRef = Arc::new(Int32Array::from(vec![1, 2, 7, 9, 3]));
+        let b: ArrayRef = Arc::new(DictionaryArray::<Int32Type>::from_iter(vec![
+            Some("a"),
+            Some("d"),
+            Some("b"),
+            None,
+            Some("c"),
+        ]));
+        let c: ArrayRef = Arc::new(TimestampNanosecondArray::from(vec![8, 7, 6, 5, 4]));
+
+        let b1 = RecordBatch::try_from_iter(vec![("a", a), ("b", b), ("c", c)]).unwrap();
+
+        let a: ArrayRef = Arc::new(Int32Array::from(vec![1, 2, 3, 4, 5]));
+        let b: ArrayRef = Arc::new(DictionaryArray::<Int32Type>::from_iter(vec![
+            None,
+            Some("c"),
+            Some("e"),
+            Some("b"),
+            Some("a"),
+        ]));
+        let c: ArrayRef = Arc::new(TimestampNanosecondArray::from(vec![4, 6, 2, 2, 6]));
+
+        let b2 = RecordBatch::try_from_iter(vec![("a", a), ("b", b), ("c", c)]).unwrap();
+
+        let sort = SortOrder {
+            primary_key: vec!["b".to_string(), "c".to_string()],
+        };
+
+        let merged = merge(&[b1, b2], usize::MAX, &sort).unwrap();
+        assert_eq!(merged.len(), 1);
+        let merged = merged.into_iter().next().unwrap();
+
+        assert_batches_eq!(
+            &[
+                "+---+---+-------------------------------+",
+                "| a | b | c                             |",
+                "+---+---+-------------------------------+",
+                "| 1 |   | 1970-01-01 00:00:00.000000004 |",
+                "| 9 |   | 1970-01-01 00:00:00.000000005 |",
+                "| 5 | a | 1970-01-01 00:00:00.000000006 |",
+                "| 1 | a | 1970-01-01 00:00:00.000000008 |",
+                "| 4 | b | 1970-01-01 00:00:00.000000002 |",
+                "| 7 | b | 1970-01-01 00:00:00.000000006 |",
+                "| 3 | c | 1970-01-01 00:00:00.000000004 |",
+                "| 2 | c | 1970-01-01 00:00:00.000000006 |",
+                "| 2 | d | 1970-01-01 00:00:00.000000007 |",
+                "| 3 | e | 1970-01-01 00:00:00.000000002 |",
+                "+---+---+-------------------------------+",
+            ],
+            &[merged]
+        );
+    }
+
+    #[test]
+    fn test_fuzz() {
+        let const_array = |val: i32, len: usize| {
+            Arc::new(
+                std::iter::repeat(Some(val))
+                    .take(len)
+                    .collect::<Int32Array>(),
+            )
+        };
+
+        let index_array =
+            |len: i32| Arc::new((0..len).into_iter().map(Some).collect::<Int32Array>());
+
+        let batches = &[
+            RecordBatch::try_from_iter_with_nullable(vec![
+                (
+                    "a_u64",
+                    make_random_array(DataType::UInt64, None, 10, 0.7),
+                    true,
+                ),
+                (
+                    "a_f64",
+                    make_random_array(DataType::Float64, None, 10, 0.3),
+                    true,
+                ),
+                (
+                    "a",
+                    make_random_array(DataType::Utf8, Some(32), 10, 1.),
+                    true,
+                ),
+                (
+                    "b",
+                    make_random_array(DataType::Utf8, Some(5), 10, 0.5),
+                    true,
+                ),
+                (
+                    "c",
+                    make_random_array(DataType::Utf8, Some(10), 10, 0.9),
+                    true,
+                ),
+                (
+                    "time",
+                    make_random_array(TIME_DATA_TYPE(), None, 10, 1.0),
+                    false,
+                ),
+                ("batch", const_array(0, 10), false),
+                ("idx", index_array(10), false),
+            ])
+            .unwrap(),
+            RecordBatch::try_from_iter_with_nullable(vec![
+                (
+                    "a_u64",
+                    make_random_array(DataType::UInt64, None, 100, 0.7),
+                    true,
+                ),
+                (
+                    "a_f64",
+                    make_random_array(DataType::Float64, None, 100, 0.3),
+                    true,
+                ),
+                (
+                    "b",
+                    make_random_array(DataType::Utf8, Some(5), 100, 0.5),
+                    true,
+                ),
+                (
+                    "c",
+                    make_random_array(DataType::Utf8, Some(10), 100, 0.9),
+                    true,
+                ),
+                (
+                    "d",
+                    make_random_array(DataType::Utf8, Some(10), 100, 0.9),
+                    true,
+                ),
+                (
+                    "time",
+                    make_random_array(TIME_DATA_TYPE(), None, 100, 1.0),
+                    false,
+                ),
+                ("batch", const_array(1, 100), false),
+                ("idx", index_array(100), false),
+            ])
+            .unwrap(),
+            RecordBatch::try_from_iter_with_nullable(vec![
+                (
+                    "a_u64",
+                    make_random_array(DataType::UInt64, None, 50, 0.7),
+                    true,
+                ),
+                (
+                    "a_f64",
+                    make_random_array(DataType::Float64, None, 50, 0.3),
+                    true,
+                ),
+                (
+                    "a",
+                    make_random_array(DataType::Utf8, Some(12), 50, 0.5),
+                    true,
+                ),
+                (
+                    "c",
+                    make_random_array(DataType::Utf8, Some(5), 50, 0.9),
+                    true,
+                ),
+                (
+                    "d",
+                    make_random_array(DataType::Utf8, Some(7), 50, 0.9),
+                    true,
+                ),
+                (
+                    "time",
+                    make_random_array(TIME_DATA_TYPE(), None, 50, 1.0),
+                    false,
+                ),
+                ("batch", const_array(2, 50), false),
+                ("idx", index_array(50), false),
+            ])
+            .unwrap(),
+            RecordBatch::try_from_iter_with_nullable(vec![
+                (
+                    "a_u64",
+                    make_random_array(DataType::UInt64, None, 9, 0.7),
+                    true,
+                ),
+                (
+                    "a_f64",
+                    make_random_array(DataType::Float64, None, 9, 0.3),
+                    true,
+                ),
+                (
+                    "d",
+                    make_random_array(DataType::Utf8, Some(2), 9, 0.9),
+                    true,
+                ),
+                (
+                    "time",
+                    make_random_array(TIME_DATA_TYPE(), None, 9, 1.0),
+                    false,
+                ),
+                ("batch", const_array(3, 9), false),
+                ("idx", index_array(9), false),
+            ])
+            .unwrap(),
+        ];
+
+        let sort_order = SortOrder {
+            primary_key: vec!["b", "c", "d", "a", "time"]
+                .into_iter()
+                .map(ToString::to_string)
+                .collect(),
+        };
+
+        let merged = merge(batches, usize::MAX, &sort_order).unwrap();
+        assert_eq!(merged.len(), 1);
+        let merged = merged.into_iter().next().unwrap();
+
+        let merge_limited = merge(batches, 100, &sort_order).unwrap();
+
+        let concat = concat::concat_batches(batches).unwrap();
+        let sorted = sort_record_batch_by(concat, &sort_order).unwrap();
+
+        assert_eq!((merged.num_rows() + 99) / 100, merge_limited.len());
+
+        for batch in &merge_limited[0..(merge_limited.len() - 1)] {
+            assert_eq!(batch.num_rows(), 100)
+        }
+
+        let merged = arrow::util::pretty::pretty_format_batches(&[merged]).unwrap();
+        let merged = merged.trim().split('\n').collect::<Vec<_>>();
+
+        let limited = arrow::util::pretty::pretty_format_batches(&merge_limited).unwrap();
+        let limited = limited.trim().split('\n').collect::<Vec<_>>();
+
+        let sorted = arrow::util::pretty::pretty_format_batches(&[sorted]).unwrap();
+        let sorted = sorted.trim().split('\n').collect::<Vec<_>>();
+
+        assert_eq!(
+            sorted, merged,
+            "\n\nexpected:\n\n{:#?}\nactual:\n\n{:#?}\n\n",
+            sorted, merged
+        );
+
+        assert_eq!(
+            sorted, limited,
+            "\n\nexpected:\n\n{:#?}\nactual:\n\n{:#?}\n\n",
+            sorted, limited
+        )
+    }
+}


### PR DESCRIPTION
This adds the ability to merge together record batches into one or more sorted record batches. It also adds an extremely basic arrow fuzzer, and some utility structs to assist with iterating through the primary keys of record batches.

I don't think the performance of this will be spectacular, but there is some relatively low-hanging fruit that could be addressed in future. I've highlighted many of these with TODO comments, and also highlighted where de-duplication could be performed.

@alamb raised the possibility of extending this to handle merging streams of record batches, I think this could be done but would require modifications to make MutableArrayData more flexible (you would need to be able to swap in new buffers)