### PR TITLE
feat: Implement Display for query::predicate to improve debug printing of plans

### DIFF
--- a/query/src/predicate.rs
+++ b/query/src/predicate.rs
@@ -135,7 +135,7 @@ impl fmt::Display for Predicate {
             write!(f, " range: [{} - {}]", range.start, range.end)?;
         }
 
-        if self.exprs.len() > 0 {
+        if !self.exprs.is_empty() {
             // Expr doesn't implement `Display` yet, so just the debug version
             // See https://github.com/apache/arrow-datafusion/issues/347
             let display_exprs = self.exprs.iter().map(|e| format!("{:?}", e));

--- a/query/src/predicate.rs
+++ b/query/src/predicate.rs
@@ -3,7 +3,7 @@
 //! mode as well as for arbitrary other predicates that are expressed
 //! by DataFusion's `Expr` type.
 
-use std::collections::BTreeSet;
+use std::{collections::BTreeSet, fmt};
 
 use data_types::timestamp::TimestampRange;
 use datafusion::logical_plan::{col, Expr};
@@ -23,9 +23,9 @@ pub const EMPTY_PREDICATE: Predicate = Predicate {
 /// Represents a parsed predicate for evaluation by the
 /// TSDatabase InfluxDB IOx query engine.
 ///
-/// Note that the data model of TSDatabase (e.g. ParsedLine's)
+/// Note that the InfluxDB data model (e.g. ParsedLine's)
 /// distinguishes between some types of columns (tags and fields), and
-/// likewise the semantics of this structure has some types of
+/// likewise the semantics of this structure can express some types of
 /// restrictions that only apply to certain types of columns.
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct Predicate {
@@ -33,9 +33,16 @@ pub struct Predicate {
     /// to only tables whose names are in `table_names`
     pub table_names: Option<BTreeSet<String>>,
 
-    // Optional field restriction. If present, restricts the results to only
-    // tables which have *at least one* of the fields in field_columns.
+    /// Optional field restriction. If present, restricts the results to only
+    /// tables which have *at least one* of the fields in field_columns.
     pub field_columns: Option<BTreeSet<String>>,
+
+    /// Optional partition key filter
+    pub partition_key: Option<String>,
+
+    /// Optional timestamp range: only rows within this range are included in
+    /// results. Other rows are excluded
+    pub range: Option<TimestampRange>,
 
     /// Optional arbitrary predicates, represented as list of
     /// DataFusion expressions applied a logical conjunction (aka they
@@ -43,13 +50,6 @@ pub struct Predicate {
     /// these expressions should be returned. Other rows are excluded
     /// from the results.
     pub exprs: Vec<Expr>,
-
-    /// Optional timestamp range: only rows within this range are included in
-    /// results. Other rows are excluded
-    pub range: Option<TimestampRange>,
-
-    /// Optional partition key filter
-    pub partition_key: Option<String>,
 }
 
 impl Predicate {
@@ -104,8 +104,66 @@ impl Predicate {
     }
 }
 
+impl fmt::Display for Predicate {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fn iter_to_str<S>(s: impl IntoIterator<Item = S>) -> String
+        where
+            S: ToString,
+        {
+            s.into_iter()
+                .map(|v| v.to_string())
+                .collect::<Vec<_>>()
+                .join(", ")
+        }
+
+        write!(f, "Predicate")?;
+
+        if let Some(table_names) = &self.table_names {
+            write!(f, " table_names: {{{}}}", iter_to_str(table_names))?;
+        }
+
+        if let Some(field_columns) = &self.field_columns {
+            write!(f, " field_columns: {{{}}}", iter_to_str(field_columns))?;
+        }
+
+        if let Some(partition_key) = &self.partition_key {
+            write!(f, " partition_key: '{}'", partition_key)?;
+        }
+
+        if let Some(range) = &self.range {
+            // TODO: could be nice to show this as actual timestamps (not just numbers)?
+            write!(f, " range: [{} - {}]", range.start, range.end)?;
+        }
+
+        if self.exprs.len() > 0 {
+            // Expr doesn't implement `Display` yet, so just the debug version
+            // See https://github.com/apache/arrow-datafusion/issues/347
+            let display_exprs = self.exprs.iter().map(|e| format!("{:?}", e));
+            write!(f, " exprs: [{}]", iter_to_str(display_exprs))?;
+        }
+
+        Ok(())
+    }
+}
+
 #[derive(Debug, Default)]
-/// Structure for building `Predicate`s
+/// Structure for building [`Predicate`]s
+///
+/// Example:
+/// ```
+/// use query::predicate::PredicateBuilder;
+/// use datafusion::logical_plan::{col, lit};
+///
+/// let p = PredicateBuilder::new()
+///    .timestamp_range(1, 100)
+///    .add_expr(col("foo").eq(lit(42)))
+///    .build();
+///
+/// assert_eq!(
+///   p.to_string(),
+///   "Predicate range: [1 - 100] exprs: [#foo Eq Int32(42)]"
+/// );
+/// ```
 pub struct PredicateBuilder {
     inner: Predicate,
 }
@@ -240,6 +298,8 @@ impl PredicateBuilder {
 
 #[cfg(test)]
 mod tests {
+    use datafusion::logical_plan::lit;
+
     use super::*;
 
     #[test]
@@ -253,5 +313,39 @@ mod tests {
         let p = PredicateBuilder::new().timestamp_range(1, 100).build();
 
         assert!(!p.is_empty());
+    }
+
+    #[test]
+    fn predicate_display_ts() {
+        // TODO make this a doc example?
+        let p = PredicateBuilder::new().timestamp_range(1, 100).build();
+
+        assert_eq!(p.to_string(), "Predicate range: [1 - 100]");
+    }
+
+    #[test]
+    fn predicate_display_ts_and_expr() {
+        let p = PredicateBuilder::new()
+            .timestamp_range(1, 100)
+            .add_expr(col("foo").eq(lit(42)).and(col("bar").lt(lit(11))))
+            .build();
+
+        assert_eq!(
+            p.to_string(),
+            "Predicate range: [1 - 100] exprs: [#foo Eq Int32(42) And #bar Lt Int32(11)]"
+        );
+    }
+
+    #[test]
+    fn predicate_display_full() {
+        let p = PredicateBuilder::new()
+            .timestamp_range(1, 100)
+            .add_expr(col("foo").eq(lit(42)))
+            .table("my_table")
+            .field_columns(vec!["f1", "f2"])
+            .partition_key("the_key")
+            .build();
+
+        assert_eq!(p.to_string(), "Predicate table_names: {my_table} field_columns: {f1, f2} partition_key: 'the_key' range: [1 - 100] exprs: [#foo Eq Int32(42)]");
     }
 }

--- a/query/src/provider/physical.rs
+++ b/query/src/provider/physical.rs
@@ -123,9 +123,10 @@ impl<C: PartitionChunk + 'static> ExecutionPlan for IOxReadFilterNode<C> {
                 // Note Predicate doesn't implement Display so punt on showing that now
                 write!(
                     f,
-                    "IOxReadFilterNode: table_name={}, chunks={} predicate=TODO",
+                    "IOxReadFilterNode: table_name={}, chunks={} predicate={}",
                     self.table_name,
-                    self.chunk_and_infos.len()
+                    self.chunk_and_infos.len(),
+                    self.predicate,
                 )
             }
         }


### PR DESCRIPTION
Closes https://github.com/influxdata/influxdb_iox/issues/1516

# Rationale:
The ability to see what the predicates actually are will help implement and debug various predicate pushdown and pruning fetures.

# Changes
1. `impl Display for Predicate`
2. Use this display in plan debug code (rather than `predicate=TODO`). See https://github.com/influxdata/influxdb_iox/pull/1508#discussion_r634118915

# Example improved debug output
prior to this PR, the output showed `predicate=TODO`. Now it shows `predicate=Predicate` which I think is an improvement (it shows that no predicates were pushed down) :) and :(

```
May 19 07:09:17.593 DEBUG query::exec::context: optimized physical plan text=ProjectionExec: expr=[cpu, host, usage_user, time]
  RepartitionExec: partitioning=RoundRobinBatch(16)
    SortExec: [cpu ASC,host ASC,time ASC]
      MergeExec
        CoalesceBatchesExec: target_batch_size=500
          FilterExec: 1619804414105040931 <= time AND time < 1619808014105040931 AND CAST(cpu AS Utf8) = cpu1
            RepartitionExec: partitioning=RoundRobinBatch(16)
              IOxReadFilterNode: table_name=cpu, chunks=1 predicate=Predicate
```


# Notes:
Here is the ticket in datafusion that tracks better expr display: https://github.com/apache/arrow-datafusion/issues/347
