### PR TITLE
refactor: consolidate Read Buffer scalar encodings

### DIFF
--- a/read_buffer/src/column/encoding/scalar.rs
+++ b/read_buffer/src/column/encoding/scalar.rs
@@ -2,6 +2,368 @@ pub mod fixed;
 pub mod fixed_null;
 pub mod rle;
 
+use crate::column::{cmp, RowIDs};
+use arrow::datatypes::ArrowNumericType;
+use either::Either;
 pub use fixed::Fixed;
 pub use fixed_null::FixedNull;
 pub use rle::RLE;
+use std::{fmt::Debug, mem::size_of, ops::AddAssign};
+
+#[allow(clippy::upper_case_acronyms)]
+#[derive(Debug)]
+pub enum ScalarEncoding<T, A>
+where
+    T: Debug + PartialOrd + Copy,
+    A: ArrowNumericType,
+{
+    Fixed(Fixed<T>),
+    FixedNullable(FixedNull<A>),
+    RLE(RLE<T>),
+}
+
+impl<T, A> ScalarEncoding<T, A>
+where
+    T: Debug + PartialOrd + Copy,
+    A: ArrowNumericType,
+{
+    pub fn name(&self) -> String {
+        format!(
+            "SCALAR_{}",
+            match &self {
+                Self::Fixed(enc) => enc.name(),
+                Self::FixedNullable(enc) => enc.name(),
+                Self::RLE(enc) => enc.name(),
+            }
+        )
+    }
+
+    /// The total size in bytes of to store columnar data in memory.
+    pub fn size(&self) -> usize {
+        match self {
+            Self::Fixed(enc) => enc.size(),
+            Self::FixedNullable(enc) => enc.size(),
+            Self::RLE(enc) => enc.size(),
+        }
+    }
+
+    /// The estimated total size in bytes of the underlying float values in the
+    /// column if they were stored contiguously and uncompressed. `include_nulls`
+    /// will effectively size each NULL value as 8b if `true`.
+    pub fn size_raw(&self, include_nulls: bool) -> usize {
+        match self {
+            // this will be the size of a Vec<T>
+            Self::Fixed(enc) => size_of::<Vec<T>>() + (enc.num_rows() as usize * size_of::<T>()),
+            Self::FixedNullable(enc) => enc.size_raw(include_nulls),
+            Self::RLE(enc) => enc.size_raw(include_nulls),
+        }
+    }
+
+    /// The total number of rows in the column.
+    pub fn num_rows(&self) -> u32 {
+        match self {
+            Self::Fixed(enc) => enc.num_rows(),
+            Self::FixedNullable(enc) => enc.num_rows(),
+            Self::RLE(enc) => enc.num_rows(),
+        }
+    }
+
+    /// Determines if the column contains a NULL value.
+    pub fn contains_null(&self) -> bool {
+        match self {
+            Self::Fixed(_) => false,
+            Self::FixedNullable(enc) => enc.contains_null(),
+            Self::RLE(enc) => enc.contains_null(),
+        }
+    }
+
+    /// The total number of rows in the column.
+    pub fn null_count(&self) -> u32 {
+        match self {
+            Self::Fixed(_) => 0,
+            Self::FixedNullable(enc) => enc.null_count(),
+            Self::RLE(enc) => enc.null_count(),
+        }
+    }
+
+    /// Determines if the column contains a non-null value.
+    pub fn has_any_non_null_value(&self) -> bool {
+        match self {
+            Self::Fixed(_) => true,
+            Self::FixedNullable(enc) => enc.has_any_non_null_value(),
+            Self::RLE(enc) => enc.has_any_non_null_value(),
+        }
+    }
+
+    /// Determines if the column contains a non-null value at one of the
+    /// provided rows.
+    pub fn has_non_null_value(&self, row_ids: &[u32]) -> bool {
+        match self {
+            Self::Fixed(_) => !row_ids.is_empty(), // all rows will be non-null
+            Self::FixedNullable(enc) => enc.has_non_null_value(row_ids),
+            Self::RLE(enc) => enc.has_non_null_value(row_ids),
+        }
+    }
+
+    /// Returns the logical value found at the provided row id.
+    pub fn value<U>(&self, row_id: u32) -> Option<U>
+    where
+        U: From<T> + From<A::Native>,
+    {
+        match &self {
+            Self::Fixed(c) => Some(c.value(row_id)),
+            Self::FixedNullable(c) => c.value(row_id),
+            Self::RLE(c) => c.value(row_id),
+        }
+    }
+
+    /// Returns the logical values found at the provided row ids.
+    ///
+    /// TODO(edd): perf - pooling of destination vectors.
+    pub fn values<U>(&self, row_ids: &[u32]) -> Either<Vec<U>, Vec<Option<U>>>
+    where
+        U: From<T> + From<A::Native>,
+    {
+        match &self {
+            Self::Fixed(c) => Either::Left(c.values::<U>(row_ids, vec![])),
+            Self::FixedNullable(c) => Either::Right(c.values(row_ids, vec![])),
+            Self::RLE(c) => Either::Right(c.values(row_ids, vec![])),
+        }
+    }
+
+    /// Returns all logical values in the column.
+    ///
+    /// TODO(edd): perf - pooling of destination vectors.
+    pub fn all_values<U: Copy>(&self) -> Either<Vec<U>, Vec<Option<U>>>
+    where
+        U: From<T> + From<A::Native>,
+    {
+        match &self {
+            Self::Fixed(c) => Either::Left(c.all_values::<U>(vec![])),
+            Self::FixedNullable(c) => Either::Right(c.all_values(vec![])),
+            Self::RLE(c) => Either::Right(c.all_values(vec![])),
+        }
+    }
+
+    pub fn encoded_values<U>(&self, row_ids: &[u32]) -> Vec<U>
+    where
+        U: From<T> + From<A::Native>,
+    {
+        match &self {
+            Self::Fixed(c) => c.values::<U>(row_ids, vec![]),
+            _ => unreachable!("encoded values on encoding type not currently supported"),
+        }
+    }
+
+    pub fn all_encoded_values<U>(&self) -> Vec<U>
+    where
+        U: From<T> + From<A::Native>,
+    {
+        match &self {
+            Self::Fixed(c) => c.all_values::<U>(vec![]),
+            _ => unreachable!("encoded values on encoding type not currently supported"),
+        }
+    }
+
+    /// Returns the row ids that satisfy the provided predicate.
+    ///
+    /// Note: it is the caller's responsibility to ensure that the provided
+    /// `Scalar` value will fit within the physical type of the encoded column.
+    /// `row_ids_filter` will panic if this invariant is broken.
+    pub fn row_ids_filter(&self, value: T, op: &cmp::Operator, dst: RowIDs) -> RowIDs
+    where
+        T: Into<A::Native>,
+    {
+        match &self {
+            Self::Fixed(c) => c.row_ids_filter(value, op, dst),
+            Self::FixedNullable(c) => c.row_ids_filter(value.into(), op, dst),
+            Self::RLE(c) => c.row_ids_filter(value, op, dst),
+        }
+    }
+
+    /// Returns the row ids that satisfy both the provided predicates.
+    ///
+    /// Note: it is the caller's responsibility to ensure that the provided
+    /// `Scalar` value will fit within the physical type of the encoded column.
+    /// `row_ids_filter` will panic if this invariant is broken.
+    pub fn row_ids_filter_range(
+        &self,
+        low: (T, &cmp::Operator),
+        high: (T, &cmp::Operator),
+        dst: RowIDs,
+    ) -> RowIDs {
+        match &self {
+            Self::Fixed(c) => c.row_ids_filter_range((low.0, &low.1), (high.0, &high.1), dst),
+            Self::FixedNullable(_) => todo!(),
+            Self::RLE(c) => c.row_ids_filter_range((low.0, &low.1), (high.0, &high.1), dst),
+        }
+    }
+
+    pub fn min<U>(&self, row_ids: &[u32]) -> Option<U>
+    where
+        U: From<T> + From<A::Native> + PartialOrd,
+    {
+        match &self {
+            Self::Fixed(c) => Some(c.min(row_ids)),
+            Self::FixedNullable(c) => c.min(row_ids),
+            Self::RLE(c) => c.min(row_ids),
+        }
+    }
+
+    pub fn max<U>(&self, row_ids: &[u32]) -> Option<U>
+    where
+        U: From<T> + From<A::Native> + PartialOrd,
+    {
+        match &self {
+            Self::Fixed(c) => Some(c.max(row_ids)),
+            Self::FixedNullable(c) => c.max(row_ids),
+            Self::RLE(c) => c.max(row_ids),
+        }
+    }
+
+    pub fn sum<U>(&self, row_ids: &[u32]) -> Option<U>
+    where
+        U: AddAssign + Default + From<T> + From<A::Native> + PartialOrd + std::ops::Add<Output = U>,
+    {
+        match &self {
+            Self::Fixed(c) => Some(c.sum(row_ids)),
+            Self::FixedNullable(c) => c.sum(row_ids),
+            Self::RLE(c) => c.sum(row_ids),
+        }
+    }
+
+    pub fn count(&self, row_ids: &[u32]) -> u32 {
+        match &self {
+            Self::Fixed(c) => c.count(row_ids),
+            Self::FixedNullable(c) => c.count(row_ids),
+            Self::RLE(c) => c.count(row_ids),
+        }
+    }
+}
+
+impl<T, A> std::fmt::Display for ScalarEncoding<T, A>
+where
+    T: Debug + PartialOrd + Copy,
+    A: ArrowNumericType + Debug,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Fixed(enc) => enc.fmt(f),
+            Self::FixedNullable(enc) => enc.fmt(f),
+            Self::RLE(enc) => enc.fmt(f),
+        }
+    }
+}
+
+/// Converts a slice of `T` values into a ScalarEncoding, choosing the most
+/// appropriate encoding based on the shape of the data.
+impl<T, A> From<&[T]> for ScalarEncoding<T, A>
+where
+    T: Debug + PartialOrd + Copy,
+    A: ArrowNumericType,
+{
+    fn from(arr: &[T]) -> Self {
+        Self::from(arr.to_vec())
+    }
+}
+
+/// Converts a vec of `T` values into a ScalarEncoding, choosing the most
+/// appropriate encoding based on the shape of the data.
+impl<T, A> From<Vec<T>> for ScalarEncoding<T, A>
+where
+    T: Debug + PartialOrd + Copy,
+    A: ArrowNumericType,
+{
+    fn from(arr: Vec<T>) -> Self {
+        //
+        // TODO(edd): determine if we should RLE this column.
+        //
+        Self::Fixed(arr.into_iter().collect())
+    }
+}
+
+// This macro implements the From trait for slices of various logical types.
+macro_rules! encoding_from_native_opt {
+    ($(($rust_type:ty, $arrow_type:ty),)*) => {
+        $(
+            impl From<Vec<Option<$rust_type>>> for ScalarEncoding<$rust_type, $arrow_type> {
+                fn from(arr: Vec<Option<$rust_type>>) -> Self {
+                    //
+                    // TODO(edd): determine if we should RLE this column.
+                    //
+                    if arr.iter().all(|v| v.is_some()) {
+                        return Self::from(arr.into_iter().map(|v| v.unwrap()).collect::<Vec<_>>());
+                    }
+
+                    // Use a nullable encoding
+                    Self::FixedNullable(FixedNull::from(arr))
+                }
+            }
+
+            impl From<&[Option<$rust_type>]> for ScalarEncoding<$rust_type, $arrow_type> {
+                fn from(arr: &[Option<$rust_type>]) -> Self {
+                    Self::from(arr.to_vec())
+                }
+            }
+        )*
+    };
+}
+
+encoding_from_native_opt! {
+    (i64, arrow::datatypes::Int64Type),
+    (i32, arrow::datatypes::Int32Type),
+    (i16, arrow::datatypes::Int16Type),
+    (i8, arrow::datatypes::Int8Type),
+    (u64, arrow::datatypes::UInt64Type),
+    (u32, arrow::datatypes::UInt32Type),
+    (u16, arrow::datatypes::UInt16Type),
+    (u8, arrow::datatypes::UInt8Type),
+    (f64, arrow::datatypes::Float64Type),
+}
+
+// This macro implements the From trait for Arrow arrays.
+use arrow::array::Array;
+macro_rules! encoding_from_arrow_array {
+    ($(($arrow_arr_type:ty, $arrow_data_type:ty, $rust_type:ty),)*) => {
+        $(
+            impl From<$arrow_arr_type> for ScalarEncoding<$rust_type, $arrow_data_type> {
+                fn from(arr: $arrow_arr_type) -> Self {
+                    // check for null count
+                    if arr.null_count() == 0 {
+                       return Self::from(arr.values());
+                    }
+
+                    Self::FixedNullable(FixedNull::from(arr))
+                }
+            }
+        )*
+    };
+}
+
+encoding_from_arrow_array! {
+    (arrow::array::Int64Array, arrow::datatypes::Int64Type, i64),
+    (arrow::array::Int32Array, arrow::datatypes::Int32Type, i32),
+    (arrow::array::Int16Array, arrow::datatypes::Int16Type, i16),
+    (arrow::array::Int8Array, arrow::datatypes::Int8Type, i8),
+    (arrow::array::UInt64Array, arrow::datatypes::UInt64Type, u64),
+    (arrow::array::UInt32Array, arrow::datatypes::UInt32Type, u32),
+    (arrow::array::UInt16Array, arrow::datatypes::UInt16Type, u16),
+    (arrow::array::UInt8Array, arrow::datatypes::UInt8Type, u8),
+}
+
+#[cfg(test)]
+mod test_super {
+    use arrow::datatypes::UInt32Type;
+    use std::iter::FromIterator;
+
+    use super::*;
+
+    #[test]
+    fn size_raw() {
+        let enc: ScalarEncoding<u32, UInt32Type> =
+            ScalarEncoding::Fixed(Fixed::from_iter(vec![2_u32, 22, 12, 31]));
+        // (4 * 4) + 24
+        assert_eq!(enc.size_raw(true), 40);
+        assert_eq!(enc.size_raw(false), 40);
+    }
+}

--- a/read_buffer/src/column/encoding/scalar/fixed.rs
+++ b/read_buffer/src/column/encoding/scalar/fixed.rs
@@ -12,14 +12,16 @@
 //! The encodings within this module do not concern themselves with choosing the
 //! appropriate physical type for a given logical type; that is the job of the
 //! consumer of these encodings.
-use std::cmp::Ordering;
 use std::fmt::{Debug, Display};
 use std::mem::size_of;
 use std::ops::AddAssign;
+use std::{cmp::Ordering, iter};
 
 use arrow::array::Array;
 
 use crate::column::{cmp, RowIDs};
+
+pub const ENCODING_NAME: &str = "VEC";
 
 #[derive(Debug, Default, PartialEq, PartialOrd)]
 /// A Fixed encoding is one in which every value has a fixed width, and is
@@ -31,7 +33,7 @@ use crate::column::{cmp, RowIDs};
 /// a different datatype `T`, where `size_of::<T>() <= size_of::<U>()`.
 pub struct Fixed<T>
 where
-    T: PartialOrd + std::fmt::Debug,
+    T: PartialOrd + Debug,
 {
     // backing data
     values: Vec<T>,
@@ -48,7 +50,8 @@ where
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "[Array] rows: {:?}, size: {}",
+            "[{}] rows: {:?}, size: {}",
+            self.name(),
             self.num_rows(),
             self.size()
         )
@@ -59,6 +62,11 @@ impl<T> Fixed<T>
 where
     T: std::fmt::Debug + PartialOrd + Copy,
 {
+    /// The name of this encoding.
+    pub fn name(&self) -> &'static str {
+        ENCODING_NAME
+    }
+
     pub fn num_rows(&self) -> u32 {
         self.values.len() as u32
     }
@@ -476,6 +484,17 @@ where
     }
 }
 
+impl<T> iter::FromIterator<T> for Fixed<T>
+where
+    T: PartialOrd + Debug,
+{
+    fn from_iter<I: IntoIterator<Item = T>>(itr: I) -> Self {
+        Self {
+            values: itr.into_iter().collect(),
+        }
+    }
+}
+
 // This macro implements the From trait for slices of various logical types.
 //
 // Here is an example implementation:
@@ -684,7 +703,9 @@ mod test {
         assert_eq!(v.min::<i64>(&[0, 1, 2, 3, 4]), 1);
 
         // Test behaviour with non-real numbers - NaN is not the minimum
-        let v = Fixed::<f64>::from(vec![11.2, 3.32, std::f64::NAN, 34.9].as_slice());
+        let v = vec![11.2, 3.32, std::f64::NAN, 34.9]
+            .into_iter()
+            .collect::<Fixed<f64>>();
         assert!((v.min::<f64>(&[0, 1, 2, 3]) - 3.32).abs() < std::f64::EPSILON);
     }
 

--- a/read_buffer/src/column/encoding/scalar/fixed.rs
+++ b/read_buffer/src/column/encoding/scalar/fixed.rs
@@ -21,7 +21,7 @@ use arrow::array::Array;
 
 use crate::column::{cmp, RowIDs};
 
-pub const ENCODING_NAME: &str = "VEC";
+pub const ENCODING_NAME: &str = "FIXED";
 
 #[derive(Debug, Default, PartialEq, PartialOrd)]
 /// A Fixed encoding is one in which every value has a fixed width, and is

--- a/read_buffer/src/column/encoding/scalar/fixed_null.rs
+++ b/read_buffer/src/column/encoding/scalar/fixed_null.rs
@@ -17,17 +17,19 @@ use std::fmt::Debug;
 use std::iter::FromIterator;
 use std::mem::size_of;
 
+use crate::column::{cmp, RowIDs};
 use arrow::{
     array::{Array, PrimitiveArray},
     datatypes::ArrowNumericType,
 };
 
-use crate::column::{cmp, RowIDs};
+pub const ENCODING_NAME: &str = "VECN";
 
 #[derive(Debug, PartialEq)]
 pub struct FixedNull<T>
 where
     T: ArrowNumericType,
+    T::Native: PartialEq + PartialOrd,
 {
     // backing data
     arr: PrimitiveArray<T>,
@@ -46,7 +48,8 @@ where
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "[Array] rows: {:?}, nulls: {:?}, size: {}",
+            "[{}] rows: {:?}, nulls: {:?}, size: {}",
+            self.name(),
             self.arr.len(),
             self.arr.null_count(),
             self.size()
@@ -57,6 +60,11 @@ impl<T> FixedNull<T>
 where
     T: ArrowNumericType,
 {
+    /// The name of this encoding.
+    pub fn name(&self) -> &'static str {
+        ENCODING_NAME
+    }
+
     pub fn num_rows(&self) -> u32 {
         self.arr.len() as u32
     }
@@ -631,6 +639,12 @@ macro_rules! fixed_null_from_arrow_types {
 fixed_null_from_arrow_types! {
     (arrow::array::Int64Array, arrow::datatypes::Int64Type),
     (arrow::array::UInt64Array, arrow::datatypes::UInt64Type),
+    (arrow::array::Int32Array, arrow::datatypes::Int32Type),
+    (arrow::array::UInt32Array, arrow::datatypes::UInt32Type),
+    (arrow::array::Int16Array, arrow::datatypes::Int16Type),
+    (arrow::array::UInt16Array, arrow::datatypes::UInt16Type),
+    (arrow::array::Int8Array, arrow::datatypes::Int8Type),
+    (arrow::array::UInt8Array, arrow::datatypes::UInt8Type),
     (arrow::array::Float64Array, arrow::datatypes::Float64Type),
 }
 

--- a/read_buffer/src/column/encoding/scalar/fixed_null.rs
+++ b/read_buffer/src/column/encoding/scalar/fixed_null.rs
@@ -23,7 +23,7 @@ use arrow::{
     datatypes::ArrowNumericType,
 };
 
-pub const ENCODING_NAME: &str = "VECN";
+pub const ENCODING_NAME: &str = "FIXEDN";
 
 #[derive(Debug, PartialEq)]
 pub struct FixedNull<T>


### PR DESCRIPTION
No behaviour change in this PR, just code shuffle.

This PR is part one of some work I have been doing to try and re-organise the scalar encodings in the Read Buffer, as I have begun focussing on various scalar encoding strategies.

Whilst this PR adds a bunch of code, the benefit will be realised in the subsequent PRs (hopefully) where I will be able to remove a lot of code so that it can be shared.

Effectively the idea is that `ScalarEncoding` is responsible for deciding _how_ to encode a column of data, which currently means either by not compressing it or by run-length encoding it. 

It will then be the job of higher level types to determine what the logical type of the column values are and how they should/shouldn't be down-casted (byte trimmed) when stored as a `ScalarEncoding`.

This code in this PR will effectively mean that when the `IntegerEncoding` and `FloatEncoding` are hooked up we should be able to have:

- Integer columns that can be byte trimmed;
- Integer columns that can be byte trimmed _and then_ run-length encoded;
- Float columns that can be run-length encoded;
- Float columns that can converted to integers, byte trimmed _and then_ run-length encoded.

The next PRs will:

- [ ] Use the scalar encoding for integers instead of all the current null/non-null variants #1533;
- [ ] Teach the scalar encoding to RLE (this will effectively unlock RLE for integer columns);
- [ ] Use the scalar encoding for float columns (this will unlock Floats as Integers).