### PR TITLE
fix: support converse binary expressions

### DIFF
--- a/read_buffer/src/column/cmp.rs
+++ b/read_buffer/src/column/cmp.rs
@@ -33,7 +33,6 @@ impl TryFrom<&str> for Operator {
     type Error = String;
 
     fn try_from(value: &str) -> Result<Self, Self::Error> {
-        println!("--- Operator: {}", value);
         match value {
             "=" => Ok(Self::Equal),
             "!=" => Ok(Self::NotEqual),
@@ -50,7 +49,6 @@ impl TryFrom<&datafusion::logical_plan::Operator> for Operator {
     type Error = String;
 
     fn try_from(op: &datafusion::logical_plan::Operator) -> Result<Self, Self::Error> {
-        println!("--- Operator: {}", op);
         match op {
             datafusion::logical_plan::Operator::Eq => Ok(Self::Equal),
             datafusion::logical_plan::Operator::NotEq => Ok(Self::NotEqual),


### PR DESCRIPTION
This PR contributes to #734.

Currently the Read Buffer knows how to build predicates from expressions like:

```
"a" > 22
"b" = "hello"
```

Now it can reorder certain expressions, so it can handle:

```
11 < "a" (rewrites as "a" > 11)
```

Also it can not handle specific timestamp nanosecond precision data fusion scalars, which are really just wrappers around `i64`.