### PR TITLE
feat: wait for task shutdown on DedicatedExecutor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3020,6 +3020,7 @@ dependencies = [
  "test_helpers",
  "tokio",
  "tokio-stream",
+ "tracker",
 ]
 
 [[package]]

--- a/query/Cargo.toml
+++ b/query/Cargo.toml
@@ -32,6 +32,7 @@ snafu = "0.6.3"
 sqlparser = "0.8.0"
 tokio = { version = "1.0", features = ["macros"] }
 tokio-stream = "0.1.2"
+tracker = { path = "../tracker" }
 observability_deps = { path = "../observability_deps" }
 
 # use libc on unix like platforms to set worker priority in DedicatedExecutor

--- a/tracker/src/task.rs
+++ b/tracker/src/task.rs
@@ -340,6 +340,11 @@ impl TaskRegistration {
     pub fn new() -> Self {
         Self::default()
     }
+
+    /// Converts the registration into a tracker with id 0 and no metadata
+    pub fn into_tracker(self) -> TaskTracker<()> {
+        TaskTracker::new(TaskId(0), &self, ())
+    }
 }
 
 impl Drop for TaskRegistration {


### PR DESCRIPTION
The `executor_shutdown_while_task_running` was previously racy as there was nothing to ensure that tasks on DedicatedExecutor actually completed - the tokio runtime blocks on drop waiting for tasks to yield, not to complete.

Fortunately we already have a task tracking system, so the simple fix is just to wire that in :smile: Longer-term we could do something a bit more sophisticated here, e.g. track tasks individually, but this works for now