### PR TITLE
feat: Implement service readiness API

### DIFF
--- a/generated_types/protos/influxdata/iox/management/v1/service.proto
+++ b/generated_types/protos/influxdata/iox/management/v1/service.proto
@@ -13,6 +13,8 @@ service ManagementService {
 
   rpc UpdateServerId(UpdateServerIdRequest) returns (UpdateServerIdResponse);
 
+  rpc SetServingReadiness(SetServingReadinessRequest) returns (SetServingReadinessResponse);
+
   rpc ListDatabases(ListDatabasesRequest) returns (ListDatabasesResponse);
 
   rpc GetDatabase(GetDatabaseRequest) returns (GetDatabaseResponse);
@@ -72,6 +74,13 @@ message UpdateServerIdRequest {
 }
 
 message UpdateServerIdResponse {}
+
+message SetServingReadinessRequest {
+  // If false, the IOx server will respond with UNAVAILABLE to all data plane requests.
+  bool ready = 1;
+}
+
+message SetServingReadinessResponse {}
 
 message ListDatabasesRequest {}
 

--- a/influxdb_iox_client/src/client/management.rs
+++ b/influxdb_iox_client/src/client/management.rs
@@ -33,6 +33,14 @@ pub enum GetServerIdError {
     ServerError(tonic::Status),
 }
 
+/// Errors returned by Client::set_serving_readiness
+#[derive(Debug, Error)]
+pub enum SetServingReadinessError {
+    /// Client received an unexpected error from the server
+    #[error("Unexpected server error: {}: {}", .0.code(), .0.message())]
+    ServerError(tonic::Status),
+}
+
 /// Errors returned by Client::create_database
 #[derive(Debug, Error)]
 pub enum CreateDatabaseError {
@@ -271,6 +279,18 @@ impl Client {
             .map_err(|_| GetServerIdError::NoServerId)?;
 
         Ok(id)
+    }
+
+    /// Set serving readiness.
+    pub async fn set_serving_readiness(
+        &mut self,
+        ready: bool,
+    ) -> Result<(), SetServingReadinessError> {
+        self.inner
+            .set_serving_readiness(SetServingReadinessRequest { ready })
+            .await
+            .map_err(SetServingReadinessError::ServerError)?;
+        Ok(())
     }
 
     /// Creates a new IOx database.

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -1,7 +1,7 @@
 //! Implementation of command line option for running server
 
 use crate::commands::tracing;
-use crate::influxdb_ioxd;
+use crate::influxdb_ioxd::{self, serving_readiness::ServingReadinessState};
 use clap::arg_enum;
 use core::num::NonZeroU16;
 use data_types::server_id::ServerId;
@@ -406,6 +406,15 @@ Possible values (case insensitive):
     /// Example: http://node-{id}.ioxmydomain.com:8082
     #[structopt(long = "--remote-template", env = "INFLUXDB_IOX_REMOTE_TEMPLATE")]
     pub remote_template: Option<String>,
+
+    /// After startup the IOx server can either accept serving data plane traffic right away
+    /// or require a SetServingReadiness call from the Management API to enable serving.
+    #[structopt(
+        long = "--initial-serving-readiness-state",
+        env = "INFLUXDB_IOX_INITIAL_SERVING_READINESS_STATE",
+        default_value = "serving"
+    )]
+    pub initial_serving_state: ServingReadinessState,
 }
 
 pub async fn command(config: Config) -> Result<()> {

--- a/src/influxdb_ioxd.rs
+++ b/src/influxdb_ioxd.rs
@@ -17,6 +17,7 @@ use tokio::time::Duration;
 mod http;
 mod planner;
 mod rpc;
+pub(crate) mod serving_readiness;
 
 #[derive(Debug, Snafu)]
 pub enum Error {
@@ -163,7 +164,13 @@ pub async fn main(config: Config) -> Result<()> {
         .await
         .context(StartListeningGrpc { grpc_bind_addr })?;
 
-    let grpc_server = rpc::serve(socket, Arc::clone(&app_server), frontend_shutdown.clone()).fuse();
+    let grpc_server = rpc::serve(
+        socket,
+        Arc::clone(&app_server),
+        frontend_shutdown.clone(),
+        config.initial_serving_state.into(),
+    )
+    .fuse();
 
     info!(bind_address=?grpc_bind_addr, "gRPC server listening");
 

--- a/src/influxdb_ioxd/rpc/flight.rs
+++ b/src/influxdb_ioxd/rpc/flight.rs
@@ -5,7 +5,7 @@ use futures::Stream;
 use observability_deps::tracing::error;
 use serde::Deserialize;
 use snafu::{OptionExt, ResultExt, Snafu};
-use tonic::{Request, Response, Streaming};
+use tonic::{Interceptor, Request, Response, Streaming};
 
 use arrow::{
     array::{make_array, ArrayRef, MutableArrayData},
@@ -109,11 +109,14 @@ struct FlightService<M: ConnectionManager> {
     server: Arc<Server<M>>,
 }
 
-pub fn make_server<M>(server: Arc<Server<M>>) -> FlightServer<impl Flight>
+pub fn make_server<M>(
+    server: Arc<Server<M>>,
+    interceptor: impl Into<Interceptor>,
+) -> FlightServer<impl Flight>
 where
     M: ConnectionManager + Send + Sync + Debug + 'static,
 {
-    FlightServer::new(FlightService { server })
+    FlightServer::with_interceptor(FlightService { server }, interceptor)
 }
 
 #[tonic::async_trait]

--- a/src/influxdb_ioxd/rpc/storage/service.rs
+++ b/src/influxdb_ioxd/rpc/storage/service.rs
@@ -1165,6 +1165,7 @@ where
 
 #[cfg(test)]
 mod tests {
+    use super::super::super::ServingReadinessInterceptor;
     use super::super::id::Id;
 
     use super::*;
@@ -1188,6 +1189,7 @@ mod tests {
         Window as RPCWindow,
     };
 
+    use crate::influxdb_ioxd::serving_readiness::ServingReadinessState;
     use generated_types::google::protobuf::Any;
     use prost::Message;
     use tokio_stream::wrappers::TcpListenerStream;
@@ -2807,6 +2809,7 @@ mod tests {
                 .add_service(crate::influxdb_ioxd::rpc::storage::make_server(
                     Arc::clone(&test_storage),
                     test_storage.metrics_registry.registry(),
+                    ServingReadinessInterceptor(ServingReadinessState::Serving.into()),
                 ));
 
             let server = async move {

--- a/src/influxdb_ioxd/rpc/write.rs
+++ b/src/influxdb_ioxd/rpc/write.rs
@@ -6,7 +6,7 @@ use influxdb_line_protocol::parse_lines;
 use observability_deps::tracing::debug;
 use server::{ConnectionManager, Server};
 use std::fmt::Debug;
-use tonic::Response;
+use tonic::{Interceptor, Response};
 
 use super::error::default_server_error_handler;
 
@@ -74,9 +74,10 @@ where
 /// Instantiate the write service
 pub fn make_server<M>(
     server: Arc<Server<M>>,
+    interceptor: impl Into<Interceptor>,
 ) -> write_service_server::WriteServiceServer<impl write_service_server::WriteService>
 where
     M: ConnectionManager + Send + Sync + Debug + 'static,
 {
-    write_service_server::WriteServiceServer::new(WriteService { server })
+    write_service_server::WriteServiceServer::with_interceptor(WriteService { server }, interceptor)
 }

--- a/src/influxdb_ioxd/serving_readiness.rs
+++ b/src/influxdb_ioxd/serving_readiness.rs
@@ -1,0 +1,78 @@
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc,
+};
+
+#[derive(Debug, Clone)]
+pub enum ServingReadinessState {
+    Unavailable,
+    Serving,
+}
+
+impl std::str::FromStr for ServingReadinessState {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_ascii_lowercase().as_str() {
+            "unavailable" => Ok(Self::Unavailable),
+            "serving" => Ok(Self::Serving),
+            _ => Err(format!(
+                "Invalid serving readiness format '{}'. Valid options: unavailable, serving",
+                s
+            )),
+        }
+    }
+}
+
+impl From<bool> for ServingReadinessState {
+    fn from(v: bool) -> Self {
+        match v {
+            true => Self::Serving,
+            false => Self::Unavailable,
+        }
+    }
+}
+
+impl From<ServingReadinessState> for bool {
+    fn from(state: ServingReadinessState) -> Self {
+        match state {
+            ServingReadinessState::Unavailable => false,
+            ServingReadinessState::Serving => true,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ServingReadiness(Arc<AtomicBool>);
+
+impl ServingReadiness {
+    pub fn new(value: Arc<AtomicBool>) -> Self {
+        Self(value)
+    }
+
+    pub fn get(&self) -> ServingReadinessState {
+        self.0.load(Ordering::SeqCst).into()
+    }
+
+    pub fn set(&self, state: ServingReadinessState) {
+        self.0.store(state.into(), Ordering::SeqCst)
+    }
+}
+
+impl From<Arc<AtomicBool>> for ServingReadiness {
+    fn from(value: Arc<AtomicBool>) -> Self {
+        Self::new(value)
+    }
+}
+
+impl From<AtomicBool> for ServingReadiness {
+    fn from(value: AtomicBool) -> Self {
+        Arc::new(value).into()
+    }
+}
+
+impl From<ServingReadinessState> for ServingReadiness {
+    fn from(value: ServingReadinessState) -> Self {
+        AtomicBool::new(value.into()).into()
+    }
+}

--- a/tests/end_to_end_cases/management_api.rs
+++ b/tests/end_to_end_cases/management_api.rs
@@ -2,7 +2,7 @@ use generated_types::{
     google::protobuf::{Duration, Empty},
     influxdata::iox::management::v1::*,
 };
-use influxdb_iox_client::{management::CreateDatabaseError, operations};
+use influxdb_iox_client::{management::CreateDatabaseError, operations, write::WriteError};
 
 use test_helpers::assert_contains;
 
@@ -10,6 +10,40 @@ use super::scenario::{
     create_readable_database, create_two_partition_database, create_unreadable_database, rand_name,
 };
 use crate::common::server_fixture::ServerFixture;
+use tonic::Code;
+
+#[tokio::test]
+async fn test_serving_readiness() {
+    let server_fixture = ServerFixture::create_single_use().await;
+    let mut mgmt_client = server_fixture.management_client();
+    let mut write_client = server_fixture.write_client();
+
+    let name = "foo";
+    let lp_data = "bar baz=1 10";
+
+    mgmt_client
+        .update_server_id(42)
+        .await
+        .expect("set ID failed");
+    mgmt_client
+        .create_database(DatabaseRules {
+            name: name.to_string(),
+            ..Default::default()
+        })
+        .await
+        .expect("create database failed");
+
+    mgmt_client.set_serving_readiness(false).await.unwrap();
+    let err = write_client.write(name, lp_data).await.unwrap_err();
+    assert!(
+        matches!(&err, WriteError::ServerError(status) if status.code() == Code::Unavailable),
+        "{}",
+        &err
+    );
+
+    mgmt_client.set_serving_readiness(true).await.unwrap();
+    write_client.write(name, lp_data).await.unwrap();
+}
 
 #[tokio::test]
 async fn test_list_update_remotes() {


### PR DESCRIPTION
__Rationale__

When IOx is orchestrated by a controller such as Conductor, we want to avoid serving traffic before the controller has had a chance to finalize the configuration of the IOx node. 

The controller must be able able to set server id, push configuration for all the databases and other server settings and only once that is done the node can accept incoming traffic.

__This change__

This PR implements a "serving_readiness" flag, that can be set and cleared via a Management API call.

The flag controls a gRPC interceptor which gets installed into all the data plane gRPC services, causing
any calls to them to fail with the gRPC "[UNAVAILABLE](https://grpc.github.io/grpc/core/md_doc_statuscodes.html)" status code.

__Next steps__

1. Connect the serving state to the HealthReporter.
2. Make the HTTP data plane API also honour the serving_readiness flag.

