### PR TITLE
refactor: remove redundant optimisation

### DIFF
--- a/query/src/exec/context.rs
+++ b/query/src/exec/context.rs
@@ -153,12 +153,9 @@ impl IOxExecutionContext {
     pub fn prepare_plan(&self, plan: &LogicalPlan) -> Result<Arc<dyn ExecutionPlan>> {
         debug!(text=%plan.display_indent_schema(), "initial plan");
 
-        let plan = self.inner.optimize(&plan)?;
-        debug!(text=%plan.display_indent_schema(), graphviz=%plan.display_graphviz(), "optimized plan");
-
         let physical_plan = self.inner.create_physical_plan(&plan)?;
-
         debug!(text=%displayable(physical_plan.as_ref()).indent(), "optimized physical plan");
+
         Ok(physical_plan)
     }
 

--- a/server/src/query_tests/sql.rs
+++ b/server/src/query_tests/sql.rs
@@ -89,6 +89,7 @@ async fn sql_select_from_cpu_pred() {
 
 #[tokio::test]
 async fn sql_select_from_cpu_with_projection_and_pred() {
+    test_helpers::maybe_start_logging();
     // expect that to get a subset of the columns and in the order specified
     let expected = vec![
         "+------+--------+",


### PR DESCRIPTION
Closes #1544

This PR removes the explicit call to DataFusion's logical plan optimiser because I belive that the logical plan is already being optimised elsewhere. The basis for this belief is that I have added debugging inside of data fusion and can see the pushdown filters being applied twice (which I have fixed in https://github.com/apache/arrow-datafusion/pull/409).

When I remove the line `self.inner.optimize(&plan)?` I still see the DF filter optimiser rule running, but only once rather than twice.

You can see here the result of this PR is still that the logical plan is already optimised when it is passed into `prepare_plan`:

```May 24 14:06:47.446 DEBUG query::exec::context: initial plan text=

Projection: #user, #region [user:Float64;N, region:Dictionary(Int32, Utf8);N]
  Filter: #time Gt totimestamp(Utf8("1970-01-01T00:00:00.000000120+00:00")) [region:Dictionary(Int32, Utf8);N, time:Timestamp(Nanosecond, None), user:Float64;N]
    TableScan: cpu projection=Some([0, 1, 2]), filters=[#time Gt totimestamp(Utf8("1970-01-01T00:00:00.000000120+00:00"))] [region:Dictionary(Int32, Utf8);N, time:Timestamp(Nanosecond, None), user:Float64;N]

May 24 14:06:47.447 DEBUG query::exec::context: optimized physical plan text=
ProjectionExec: expr=[user, region]
  CoalesceBatchesExec: target_batch_size=500
    FilterExec: time > totimestamp(1970-01-01T00:00:00.000000120+00:00)
      RepartitionExec: partitioning=RoundRobinBatch(8)
        IOxReadFilterNode: table_name=cpu, chunks=1 predicate=Predicate
```

Note the filters are already present on the `TableScan` part of the initial logical plan