### PR TITLE
feat: Add simpler RoutingConfig

### DIFF
--- a/generated_types/protos/influxdata/iox/management/v1/database_rules.proto
+++ b/generated_types/protos/influxdata/iox/management/v1/database_rules.proto
@@ -177,6 +177,15 @@ message DatabaseRules {
   // Write Buffer configuration for this database
   WriteBufferConfig write_buffer_config = 6;
 
-  // Shard  config
-  ShardConfig shard_config = 8;
+  oneof routing_rules {
+    // Shard config
+    ShardConfig shard_config = 8;
+
+    // Routing config
+    RoutingConfig routing_config = 9;
+  }
+}
+
+message RoutingConfig {
+  NodeGroup target = 1;
 }

--- a/generated_types/src/database_rules/shard.rs
+++ b/generated_types/src/database_rules/shard.rs
@@ -319,16 +319,22 @@ mod tests {
     fn test_database_rules_shard_config() {
         let protobuf = management::DatabaseRules {
             name: "database".to_string(),
-            shard_config: Some(management::ShardConfig {
-                ..Default::default()
-            }),
+            routing_rules: Some(management::database_rules::RoutingRules::ShardConfig(
+                management::ShardConfig {
+                    ..Default::default()
+                },
+            )),
             ..Default::default()
         };
 
         let rules: DatabaseRules = protobuf.try_into().unwrap();
         let back: management::DatabaseRules = rules.into();
 
-        assert!(back.shard_config.is_some());
+        assert!(back.routing_rules.is_some());
+        assert!(matches!(
+            back.routing_rules,
+            Some(management::database_rules::RoutingRules::ShardConfig(_))
+        ));
     }
 
     #[test]

--- a/tests/end_to_end_cases/write_api.rs
+++ b/tests/end_to_end_cases/write_api.rs
@@ -9,8 +9,10 @@ use entry::{
     lines_to_sharded_entries,
     test_helpers::{partitioner, sharder},
 };
+use generated_types::influxdata::iox::management::v1::database_rules::RoutingRules;
 use generated_types::influxdata::iox::management::v1::{
-    node_group::Node, shard, HashRing, Matcher, MatcherToShard, NodeGroup, Shard, ShardConfig,
+    node_group::Node, shard, HashRing, Matcher, MatcherToShard, NodeGroup, RoutingConfig, Shard,
+    ShardConfig,
 };
 use influxdb_line_protocol::parse_lines;
 use std::collections::HashMap;
@@ -194,7 +196,7 @@ async fn test_write_routed() {
         .get_database(&db_name)
         .await
         .expect("cannot get database on router");
-    router_db_rules.shard_config = Some(ShardConfig {
+    let shard_config = ShardConfig {
         specific_targets: vec![
             MatcherToShard {
                 matcher: Some(Matcher {
@@ -251,7 +253,9 @@ async fn test_write_routed() {
         .into_iter()
         .collect::<HashMap<_, _>>(),
         ..Default::default()
-    });
+    };
+    router_db_rules.routing_rules = Some(RoutingRules::ShardConfig(shard_config));
+
     router_mgmt
         .update_database(router_db_rules)
         .await
@@ -379,7 +383,7 @@ async fn test_write_routed_errors() {
         .get_database(&db_name)
         .await
         .expect("cannot get database on router");
-    router_db_rules.shard_config = Some(ShardConfig {
+    let shard_config = ShardConfig {
         specific_targets: vec![MatcherToShard {
             matcher: Some(Matcher {
                 table_name_regex: "^cpu$".to_string(),
@@ -398,7 +402,8 @@ async fn test_write_routed_errors() {
         .into_iter()
         .collect::<HashMap<_, _>>(),
         ..Default::default()
-    });
+    };
+    router_db_rules.routing_rules = Some(RoutingRules::ShardConfig(shard_config));
     router_mgmt
         .update_database(router_db_rules)
         .await
@@ -424,4 +429,184 @@ async fn test_write_routed_errors() {
 
     // TODO(mkm): check connection error and successful communication with a
     // target that replies with an error...
+}
+
+#[tokio::test]
+async fn test_write_routed_no_shard() {
+    const TEST_ROUTER_ID: u32 = 1;
+
+    const TEST_TARGET_ID_1: u32 = 2;
+    const TEST_TARGET_ID_2: u32 = 3;
+    const TEST_TARGET_ID_3: u32 = 4;
+
+    const TEST_REMOTE_ID_1: u32 = 2;
+    const TEST_REMOTE_ID_2: u32 = 3;
+    const TEST_REMOTE_ID_3: u32 = 4;
+
+    let router = ServerFixture::create_single_use().await;
+    let mut router_mgmt = router.management_client();
+    router_mgmt
+        .update_server_id(TEST_ROUTER_ID)
+        .await
+        .expect("set ID failed");
+
+    let target_1 = ServerFixture::create_single_use().await;
+    let mut target_1_mgmt = target_1.management_client();
+    target_1_mgmt
+        .update_server_id(TEST_TARGET_ID_1)
+        .await
+        .expect("set ID failed");
+
+    router_mgmt
+        .update_remote(TEST_REMOTE_ID_1, target_1.grpc_base())
+        .await
+        .expect("set remote failed");
+
+    let target_2 = ServerFixture::create_single_use().await;
+    let mut target_2_mgmt = target_2.management_client();
+    target_2_mgmt
+        .update_server_id(TEST_TARGET_ID_2)
+        .await
+        .expect("set ID failed");
+
+    router_mgmt
+        .update_remote(TEST_REMOTE_ID_2, target_2.grpc_base())
+        .await
+        .expect("set remote failed");
+
+    let target_3 = ServerFixture::create_single_use().await;
+    let mut target_3_mgmt = target_3.management_client();
+    target_3_mgmt
+        .update_server_id(TEST_TARGET_ID_3)
+        .await
+        .expect("set ID failed");
+
+    router_mgmt
+        .update_remote(TEST_REMOTE_ID_3, target_3.grpc_base())
+        .await
+        .expect("set remote failed");
+
+    let db_name_1 = rand_name();
+    let db_name_2 = rand_name();
+    for &db_name in &[&db_name_1, &db_name_2] {
+        create_readable_database(db_name, router.grpc_channel()).await;
+        create_readable_database(db_name, target_1.grpc_channel()).await;
+        create_readable_database(db_name, target_2.grpc_channel()).await;
+        create_readable_database(db_name, target_3.grpc_channel()).await;
+    }
+
+    // Set routing rules on the router:
+    for (db_name, remote_id) in &[
+        (db_name_1.clone(), TEST_REMOTE_ID_1),
+        (db_name_2.clone(), TEST_REMOTE_ID_2),
+    ] {
+        let mut router_db_rules = router_mgmt
+            .get_database(db_name)
+            .await
+            .expect("cannot get database on router");
+        let routing_config = RoutingConfig {
+            target: Some(NodeGroup {
+                nodes: vec![Node { id: *remote_id }],
+            }),
+        };
+        router_db_rules.routing_rules = Some(RoutingRules::RoutingConfig(routing_config));
+
+        router_mgmt
+            .update_database(router_db_rules)
+            .await
+            .expect("cannot update router db rules");
+    }
+
+    // Write some data
+    let line_1 = "cpu bar=1 100";
+    let line_2 = "disk bar=2 100";
+
+    let mut write_client = router.write_client();
+
+    for (&ref db_name, &ref line) in &[(&db_name_1, line_1), (&db_name_2, line_2)] {
+        let num_lines_written = write_client
+            .write(db_name, line)
+            .await
+            .expect("cannot write");
+        assert_eq!(num_lines_written, 1);
+    }
+
+    // The router will have split the write request by database name.
+    // Target 1 will have received only the "cpu" table.
+    // Target 2 will have received only the "disk" table.
+    // Target 3 won't get any writes.
+
+    let mut query_results = target_1
+        .flight_client()
+        .perform_query(&db_name_1, "select * from cpu")
+        .await
+        .expect("failed to query target 1");
+
+    let mut batches = Vec::new();
+    while let Some(data) = query_results.next().await.unwrap() {
+        batches.push(data);
+    }
+
+    let expected = vec![
+        "+-----+-------------------------------+",
+        "| bar | time                          |",
+        "+-----+-------------------------------+",
+        "| 1   | 1970-01-01 00:00:00.000000100 |",
+        "+-----+-------------------------------+",
+    ];
+    assert_batches_sorted_eq!(&expected, &batches);
+
+    assert!(target_1
+        .flight_client()
+        .perform_query(&db_name_1, "select * from disk")
+        .await
+        .unwrap_err()
+        .to_string()
+        .contains("Table or CTE with name \\\'disk\\\' not found\""));
+
+    let mut query_results = target_2
+        .flight_client()
+        .perform_query(&db_name_2, "select * from disk")
+        .await
+        .expect("failed to query target 2");
+
+    let mut batches = Vec::new();
+    while let Some(data) = query_results.next().await.unwrap() {
+        batches.push(data);
+    }
+
+    let expected = vec![
+        "+-----+-------------------------------+",
+        "| bar | time                          |",
+        "+-----+-------------------------------+",
+        "| 2   | 1970-01-01 00:00:00.000000100 |",
+        "+-----+-------------------------------+",
+    ];
+    assert_batches_sorted_eq!(&expected, &batches);
+
+    assert!(target_2
+        .flight_client()
+        .perform_query(&db_name_1, "select * from cpu")
+        .await
+        .unwrap_err()
+        .to_string()
+        .contains("Table or CTE with name \\\'cpu\\\' not found\""));
+
+    // Ensure that target_3 didn't get any writes.
+
+    assert!(target_3
+        .flight_client()
+        .perform_query(&db_name_1, "select * from cpu")
+        .await
+        .unwrap_err()
+        .to_string()
+        .contains("Table or CTE with name \\\'cpu\\\' not found\""));
+
+    assert!(target_3
+        .flight_client()
+        .perform_query(&db_name_2, "select * from disk")
+        .await
+        .unwrap_err()
+        .to_string()
+        .contains("Table or CTE with name \\\'disk\\\' not found\""));
 }


### PR DESCRIPTION
__Rationale__

Currently IOx lacks a distributed query engine. That doesn't prevent us from spreading the load on multiple nodes, provided that queries never join across tables residing on different nodes.

The easiest way to guarantee that is to assign a whole DB to a node. We can do this with current "ShardConfig"s:

```json
  {
    "shardConfig": {
      "shards": {
        "42": {
          "iox": {
            "nodes": [
              {
                "id": 3002
              }
            ]
          }
        }
      },
      "specificTargets": [
        {
          "matcher": {
            "tableNameRegex": ".*"
          },
          "shard": 42
        }
      ]
    }
  }
```

But there are two problems with that:

1. It's a very complicated config snippet to basically just say "send all to node 3002"
2. It's not trivial to implement a simple query router that just routes all queries for a db to one node. 

__Proposal__

We don't way to get rid of the Sharding code yet since eventually we'll have a full distributed query engine, but at the same time we want a "routing configuration" with a simpler semantics that can be used to route writes and queries.

This routing config currently just indicates the targets where the all processing responsibility for a given DB is delegated to:

```protobuf
message RoutingConfig {
  NodeGroup target = 1;
}
```

(In future this could be the home for other "destination" configs, such as a kafka topic)

This config coexists with the ShardConfig in a mutually-exclusive group:

```protobuf
message DatabaseRules {
...
  oneof routing_rules {
    // Shard config
    ShardConfig shard_config = 8;

    // Routing config
    RoutingConfig routing_config = 9;
  }
}
```

This change is backward compatible according to the protobuf binary and json encoding rules, so no changes to the catalog are needed.

The codepath still constructs a dummy "ShardedEntry" because that's the codepath that builds an Entry from a ParsedLine, but there is no actual sharding involved.