### PR TITLE
feat: associate tracker with lifecycle action (#1099)

### DIFF
--- a/query/src/exec/task.rs
+++ b/query/src/exec/task.rs
@@ -87,7 +87,7 @@ impl DedicatedExecutor {
                 }
 
                 // Wait for all tasks to finish
-                registration.into_tracker().join().await;
+                registration.into_tracker(()).join().await;
             })
         });
 

--- a/server/src/db/catalog/chunk.rs
+++ b/server/src/db/catalog/chunk.rs
@@ -92,6 +92,10 @@ pub struct Chunk {
     state: ChunkState,
 
     /// The active lifecycle task if any
+    ///
+    /// This is stored as a TaskTracker to allow monitoring the progress of the
+    /// action, detecting if the task failed, waiting for the task to complete
+    /// or even triggering graceful termination of it
     lifecycle_action: Option<TaskTracker<ChunkLifecycleAction>>,
 
     /// The metrics for this chunk

--- a/server/src/db/catalog/chunk.rs
+++ b/server/src/db/catalog/chunk.rs
@@ -12,6 +12,7 @@ use read_buffer::Chunk as ReadBufferChunk;
 use super::{ChunkIsEmpty, Error, InternalChunkState, Result};
 use metrics::{Counter, Histogram, KeyValue};
 use snafu::ensure;
+use tracker::{TaskRegistration, TaskTracker};
 
 /// Any lifecycle action currently in progress for this chunk
 #[derive(Debug, Copy, Clone, PartialEq)]
@@ -91,7 +92,7 @@ pub struct Chunk {
     state: ChunkState,
 
     /// The active lifecycle task if any
-    lifecycle_action: Option<ChunkLifecycleAction>,
+    lifecycle_action: Option<TaskTracker<ChunkLifecycleAction>>,
 
     /// The metrics for this chunk
     metrics: ChunkMetrics,
@@ -246,7 +247,7 @@ impl Chunk {
     }
 
     pub fn lifecycle_action(&self) -> Option<&ChunkLifecycleAction> {
-        self.lifecycle_action.as_ref()
+        self.lifecycle_action.as_ref().map(|x| x.metadata())
     }
 
     pub fn time_of_first_write(&self) -> Option<DateTime<Utc>> {
@@ -415,7 +416,7 @@ impl Chunk {
     /// storage
     ///
     /// If called on an open chunk will first close the chunk
-    pub fn set_moving(&mut self) -> Result<Arc<MBChunk>> {
+    pub fn set_moving(&mut self, registration: &TaskRegistration) -> Result<Arc<MBChunk>> {
         // This ensures the closing logic is consistent but doesn't break code that
         // assumes a chunk can be moved from open
         if matches!(self.state, ChunkState::Open(_)) {
@@ -425,7 +426,7 @@ impl Chunk {
         match &self.state {
             ChunkState::Closed(chunk) => {
                 let chunk = Arc::clone(chunk);
-                self.set_lifecycle_action(ChunkLifecycleAction::Moving)?;
+                self.set_lifecycle_action(ChunkLifecycleAction::Moving, registration)?;
 
                 self.metrics
                     .state
@@ -468,11 +469,14 @@ impl Chunk {
     }
 
     /// Set the chunk to the MovingToObjectStore state
-    pub fn set_writing_to_object_store(&mut self) -> Result<Arc<ReadBufferChunk>> {
+    pub fn set_writing_to_object_store(
+        &mut self,
+        registration: &TaskRegistration,
+    ) -> Result<Arc<ReadBufferChunk>> {
         match &self.state {
             ChunkState::Moved(db) => {
                 let db = Arc::clone(db);
-                self.set_lifecycle_action(ChunkLifecycleAction::Persisting)?;
+                self.set_lifecycle_action(ChunkLifecycleAction::Persisting, registration)?;
                 self.metrics
                     .state
                     .inc_with_labels(&[KeyValue::new("state", "writing_os")]);
@@ -536,30 +540,38 @@ impl Chunk {
     }
 
     /// Set the chunk's in progress lifecycle action or return an error if already in-progress
-    fn set_lifecycle_action(&mut self, lifecycle_action: ChunkLifecycleAction) -> Result<()> {
+    fn set_lifecycle_action(
+        &mut self,
+        lifecycle_action: ChunkLifecycleAction,
+        registration: &TaskRegistration,
+    ) -> Result<()> {
         if let Some(lifecycle_action) = &self.lifecycle_action {
             return Err(Error::LifecycleActionAlreadyInProgress {
                 partition_key: self.partition_key.to_string(),
                 table_name: self.table_name.to_string(),
                 chunk_id: self.id,
-                lifecycle_action: lifecycle_action.name().to_string(),
+                lifecycle_action: lifecycle_action.metadata().name().to_string(),
             });
         }
-        self.lifecycle_action = Some(lifecycle_action);
+        self.lifecycle_action = Some(registration.clone().into_tracker(lifecycle_action));
         Ok(())
     }
 
     /// Clear the chunk's lifecycle action or return an error if it doesn't match that provided
     fn finish_lifecycle_action(&mut self, lifecycle_action: ChunkLifecycleAction) -> Result<()> {
         match &self.lifecycle_action {
-            Some(actual) if actual == &lifecycle_action => {}
+            Some(actual) if actual.metadata() == &lifecycle_action => {}
             actual => {
                 return Err(Error::UnexpectedLifecycleAction {
                     partition_key: self.partition_key.to_string(),
                     table_name: self.table_name.to_string(),
                     chunk_id: self.id,
                     expected: lifecycle_action.name().to_string(),
-                    actual: actual.map(|x| x.name()).unwrap_or("None").to_string(),
+                    actual: actual
+                        .as_ref()
+                        .map(|x| x.metadata().name())
+                        .unwrap_or("None")
+                        .to_string(),
                 })
             }
         }

--- a/server/src/db/lifecycle.rs
+++ b/server/src/db/lifecycle.rs
@@ -415,7 +415,7 @@ mod tests {
     /// Transitions a new ("open") chunk into the "moving" state.
     fn transition_to_moving(mut chunk: Chunk) -> Chunk {
         chunk.set_closed().unwrap();
-        chunk.set_moving().unwrap();
+        chunk.set_moving(&Default::default()).unwrap();
         chunk
     }
 
@@ -433,7 +433,9 @@ mod tests {
         rb: &Arc<read_buffer::Chunk>,
     ) -> Chunk {
         chunk = transition_to_moved(chunk, rb);
-        chunk.set_writing_to_object_store().unwrap();
+        chunk
+            .set_writing_to_object_store(&Default::default())
+            .unwrap();
         chunk
     }
 
@@ -543,7 +545,7 @@ mod tests {
                 .iter()
                 .find(|x| x.read().id() == chunk_id)
                 .unwrap();
-            chunk.write().set_moving().unwrap();
+            chunk.write().set_moving(&Default::default()).unwrap();
             self.events.push(MoverEvents::Move(chunk_id));
             let tracker = TaskTracker::complete(());
             self.move_tracker = Some(tracker.clone());
@@ -561,7 +563,10 @@ mod tests {
                 .iter()
                 .find(|x| x.read().id() == chunk_id)
                 .unwrap();
-            chunk.write().set_writing_to_object_store().unwrap();
+            chunk
+                .write()
+                .set_writing_to_object_store(&Default::default())
+                .unwrap();
             self.events.push(MoverEvents::Write(chunk_id));
             let tracker = TaskTracker::complete(());
             self.write_tracker = Some(tracker.clone());

--- a/server/src/query_tests/scenarios.rs
+++ b/server/src/query_tests/scenarios.rs
@@ -73,7 +73,7 @@ impl DbSetup for NoData {
         assert_eq!(count_object_store_chunks(&db), 0); // nothing yet
 
         // Now load the closed chunk into the RB
-        db.load_chunk_to_read_buffer(partition_key, table_name, 0)
+        db.load_chunk_to_read_buffer(partition_key, table_name, 0, &Default::default())
             .await
             .unwrap();
         assert_eq!(count_mutable_buffer_chunks(&db), 0); // open chunk only
@@ -111,7 +111,7 @@ impl DbSetup for NoData {
         assert_eq!(count_object_store_chunks(&db), 0); // nothing yet
 
         // Now load the closed chunk into the RB
-        db.load_chunk_to_read_buffer(partition_key, table_name, 0)
+        db.load_chunk_to_read_buffer(partition_key, table_name, 0, &Default::default())
             .await
             .unwrap();
         assert_eq!(count_mutable_buffer_chunks(&db), 0); // open chunk only
@@ -119,7 +119,7 @@ impl DbSetup for NoData {
         assert_eq!(count_object_store_chunks(&db), 0); // nothing yet
 
         // Now write the data in RB to object store but keep it in RB
-        db.write_chunk_to_object_store(partition_key, "cpu", 0)
+        db.write_chunk_to_object_store(partition_key, "cpu", 0, &Default::default())
             .await
             .unwrap();
         // it should be the same chunk!
@@ -310,7 +310,7 @@ impl DbSetup for TwoMeasurementsManyFieldsTwoChunks {
         ];
         write_lp(&db, &lp_lines.join("\n"));
         db.rollover_partition(partition_key, "h2o").await.unwrap();
-        db.load_chunk_to_read_buffer(partition_key, "h2o", 0)
+        db.load_chunk_to_read_buffer(partition_key, "h2o", 0, &Default::default())
             .await
             .unwrap();
 
@@ -463,7 +463,7 @@ pub(crate) async fn make_one_chunk_scenarios(partition_key: &str, data: &str) ->
         db.rollover_partition(partition_key, &table_name)
             .await
             .unwrap();
-        db.load_chunk_to_read_buffer(partition_key, &table_name, 0)
+        db.load_chunk_to_read_buffer(partition_key, &table_name, 0, &Default::default())
             .await
             .unwrap();
     }
@@ -479,10 +479,11 @@ pub(crate) async fn make_one_chunk_scenarios(partition_key: &str, data: &str) ->
         db.rollover_partition(partition_key, &table_name)
             .await
             .unwrap();
-        db.load_chunk_to_read_buffer(partition_key, &table_name, 0)
+        db.load_chunk_to_read_buffer(partition_key, &table_name, 0, &Default::default())
             .await
             .unwrap();
-        db.write_chunk_to_object_store(partition_key, &table_name, 0)
+
+        db.write_chunk_to_object_store(partition_key, &table_name, 0, &Default::default())
             .await
             .unwrap();
     }
@@ -498,10 +499,10 @@ pub(crate) async fn make_one_chunk_scenarios(partition_key: &str, data: &str) ->
         db.rollover_partition(partition_key, &table_name)
             .await
             .unwrap();
-        db.load_chunk_to_read_buffer(partition_key, &table_name, 0)
+        db.load_chunk_to_read_buffer(partition_key, &table_name, 0, &Default::default())
             .await
             .unwrap();
-        db.write_chunk_to_object_store(partition_key, &table_name, 0)
+        db.write_chunk_to_object_store(partition_key, &table_name, 0, &Default::default())
             .await
             .unwrap();
         db.unload_read_buffer(partition_key, &table_name, 0)
@@ -556,7 +557,7 @@ pub async fn make_two_chunk_scenarios(
         db.rollover_partition(partition_key, &table_name)
             .await
             .unwrap();
-        db.load_chunk_to_read_buffer(partition_key, &table_name, 0)
+        db.load_chunk_to_read_buffer(partition_key, &table_name, 0, &Default::default())
             .await
             .unwrap();
     }
@@ -580,11 +581,11 @@ pub async fn make_two_chunk_scenarios(
             .await
             .unwrap();
 
-        db.load_chunk_to_read_buffer(partition_key, &table_name, 0)
+        db.load_chunk_to_read_buffer(partition_key, &table_name, 0, &Default::default())
             .await
             .unwrap();
 
-        db.load_chunk_to_read_buffer(partition_key, &table_name, 1)
+        db.load_chunk_to_read_buffer(partition_key, &table_name, 1, &Default::default())
             .await
             .unwrap();
     }
@@ -607,19 +608,19 @@ pub async fn make_two_chunk_scenarios(
             .await
             .unwrap();
 
-        db.load_chunk_to_read_buffer(partition_key, &table_name, 0)
+        db.load_chunk_to_read_buffer(partition_key, &table_name, 0, &Default::default())
             .await
             .unwrap();
 
-        db.load_chunk_to_read_buffer(partition_key, &table_name, 1)
+        db.load_chunk_to_read_buffer(partition_key, &table_name, 1, &Default::default())
             .await
             .unwrap();
 
-        db.write_chunk_to_object_store(partition_key, &table_name, 0)
+        db.write_chunk_to_object_store(partition_key, &table_name, 0, &Default::default())
             .await
             .unwrap();
 
-        db.write_chunk_to_object_store(partition_key, &table_name, 1)
+        db.write_chunk_to_object_store(partition_key, &table_name, 1, &Default::default())
             .await
             .unwrap();
     }
@@ -642,19 +643,19 @@ pub async fn make_two_chunk_scenarios(
             .await
             .unwrap();
 
-        db.load_chunk_to_read_buffer(partition_key, &table_name, 0)
+        db.load_chunk_to_read_buffer(partition_key, &table_name, 0, &Default::default())
             .await
             .unwrap();
 
-        db.load_chunk_to_read_buffer(partition_key, &table_name, 1)
+        db.load_chunk_to_read_buffer(partition_key, &table_name, 1, &Default::default())
             .await
             .unwrap();
 
-        db.write_chunk_to_object_store(partition_key, &table_name, 0)
+        db.write_chunk_to_object_store(partition_key, &table_name, 0, &Default::default())
             .await
             .unwrap();
 
-        db.write_chunk_to_object_store(partition_key, &table_name, 1)
+        db.write_chunk_to_object_store(partition_key, &table_name, 1, &Default::default())
             .await
             .unwrap();
         db.unload_read_buffer(partition_key, &table_name, 0)
@@ -679,10 +680,10 @@ pub async fn rollover_and_load(db: &Db, partition_key: &str, table_name: &str) {
     db.rollover_partition(partition_key, table_name)
         .await
         .unwrap();
-    db.load_chunk_to_read_buffer(partition_key, table_name, 0)
+    db.load_chunk_to_read_buffer(partition_key, table_name, 0, &Default::default())
         .await
         .unwrap();
-    db.write_chunk_to_object_store(partition_key, table_name, 0)
+    db.write_chunk_to_object_store(partition_key, table_name, 0, &Default::default())
         .await
         .unwrap();
 }
@@ -699,7 +700,7 @@ pub(crate) async fn make_one_rub_or_parquet_chunk_scenario(
         db.rollover_partition(partition_key, &table_name)
             .await
             .unwrap();
-        db.load_chunk_to_read_buffer(partition_key, &table_name, 0)
+        db.load_chunk_to_read_buffer(partition_key, &table_name, 0, &Default::default())
             .await
             .unwrap();
     }
@@ -715,10 +716,10 @@ pub(crate) async fn make_one_rub_or_parquet_chunk_scenario(
         db.rollover_partition(partition_key, &table_name)
             .await
             .unwrap();
-        db.load_chunk_to_read_buffer(partition_key, &table_name, 0)
+        db.load_chunk_to_read_buffer(partition_key, &table_name, 0, &Default::default())
             .await
             .unwrap();
-        db.write_chunk_to_object_store(partition_key, &table_name, 0)
+        db.write_chunk_to_object_store(partition_key, &table_name, 0, &Default::default())
             .await
             .unwrap();
         db.unload_read_buffer(partition_key, &table_name, 0)

--- a/tracker/src/task.rs
+++ b/tracker/src/task.rs
@@ -341,7 +341,7 @@ impl TaskRegistration {
         Self::default()
     }
 
-    /// Converts the registration into a tracker with id 0 and no metadata
+    /// Converts the registration into a tracker with id 0 and specified metadata
     pub fn into_tracker<T>(self, metadata: T) -> TaskTracker<T> {
         TaskTracker::new(TaskId(0), &self, metadata)
     }

--- a/tracker/src/task.rs
+++ b/tracker/src/task.rs
@@ -342,8 +342,8 @@ impl TaskRegistration {
     }
 
     /// Converts the registration into a tracker with id 0 and no metadata
-    pub fn into_tracker(self) -> TaskTracker<()> {
-        TaskTracker::new(TaskId(0), &self, ())
+    pub fn into_tracker<T>(self, metadata: T) -> TaskTracker<T> {
+        TaskTracker::new(TaskId(0), &self, metadata)
     }
 }
 


### PR DESCRIPTION
Currently whilst performing a lifeycle action if an error is encountered, or the task is aborted via the longrunning operations API, the chunk effectively gets orphaned in this state. This came up again when plumbing in error handling for compaction, where the abort logic for multiple chunks ends up pretty painful, and so I thought it pertinent to get proper handling for it in.

This PR proposes storing a `TaskTracker` inside the catalog for the lifecycle action.  A future PR would then extend the lifecycle manager to find chunks with lifecycle actions that have finished, and reset them, as this implies the operation failed as it never cleared the lifecycle action and is no longer running. This could potentially only reset the action a certain number of seconds from when the task was started as a sort of failure backoff.

An alternative that I did consider was an RAII transaction handle for the lifecycle action, however, this runs into problems as it needs the ability to mutate the chunk state and depending on when the transaction handle is dropped, this could easily result in a deadlock as a write/read lock may be being held by the lifecycle logic. Additionally there is no obvious way to implement failure backoff with this approach.
