### PR TITLE
feat: extend AWS configs for prod and test

### DIFF
--- a/docs/env.example
+++ b/docs/env.example
@@ -34,6 +34,9 @@
 # AWS_DEFAULT_REGION=us-east-2
 # INFLUXDB_IOX_BUCKET=bucket-name
 #
+# Optionally:
+# AWS_SESSION_TOKEN=token
+#
 # If using an s3 compatible storage
 # AWS_ENDPOINT = http://localhost:9000
 #

--- a/object_store/src/aws.rs
+++ b/object_store/src/aws.rs
@@ -450,6 +450,7 @@ mod tests {
         secret_access_key: String,
         region: String,
         bucket: String,
+        endpoint: Option<String>,
     }
 
     // Helper macro to skip tests if TEST_INTEGRATION and the AWS environment variables are not set.
@@ -500,6 +501,7 @@ mod tests {
                         .expect("already checked AWS_DEFAULT_REGION"),
                     bucket: env::var("INFLUXDB_IOX_BUCKET")
                         .expect("already checked INFLUXDB_IOX_BUCKET"),
+                    endpoint: env::var("AWS_ENDPOINT").ok(),
                 }
             }
         }};
@@ -530,7 +532,7 @@ mod tests {
                 Some(config.secret_access_key),
                 config.region,
                 config.bucket,
-                Option::<String>::None,
+                config.endpoint,
             )
             .expect("Valid S3 config"),
         );
@@ -551,7 +553,7 @@ mod tests {
                 Some(config.secret_access_key),
                 config.region,
                 &config.bucket,
-                Option::<String>::None,
+                config.endpoint,
             )
             .expect("Valid S3 config"),
         );
@@ -582,7 +584,7 @@ mod tests {
                 Some(config.secret_access_key),
                 config.region,
                 &config.bucket,
-                Option::<String>::None,
+                config.endpoint,
             )
             .expect("Valid S3 config"),
         );
@@ -624,7 +626,7 @@ mod tests {
                 Some(config.secret_access_key),
                 config.region,
                 &config.bucket,
-                Option::<String>::None,
+                config.endpoint,
             )
             .expect("Valid S3 config"),
         );
@@ -661,7 +663,7 @@ mod tests {
                 Some(config.secret_access_key),
                 config.region,
                 &config.bucket,
-                Option::<String>::None,
+                config.endpoint,
             )
             .expect("Valid S3 config"),
         );
@@ -708,7 +710,7 @@ mod tests {
                 Some(config.secret_access_key),
                 config.region,
                 &config.bucket,
-                Option::<String>::None,
+                config.endpoint,
             )
             .expect("Valid S3 config"),
         );
@@ -753,7 +755,7 @@ mod tests {
                 Some(config.secret_access_key),
                 config.region,
                 config.bucket,
-                Option::<String>::None,
+                config.endpoint,
             )
             .expect("Valid S3 config"),
         );
@@ -778,7 +780,7 @@ mod tests {
                 Some(config.secret_access_key),
                 config.region,
                 &config.bucket,
-                Option::<String>::None,
+                config.endpoint,
             )
             .expect("Valid S3 config"),
         );
@@ -815,7 +817,7 @@ mod tests {
                 Some(config.secret_access_key),
                 config.region,
                 &config.bucket,
-                Option::<String>::None,
+                config.endpoint,
             )
             .expect("Valid S3 config"),
         );

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -361,7 +361,7 @@ Possible values (case insensitive):
     )]
     pub aws_default_region: String,
 
-    /// When using Amazon s3 compatibility storage service, set this to the
+    /// When using Amazon S3 compatibility storage service, set this to the
     /// endpoint.
     ///
     /// Must also set `--object-store=s3`, `--bucket`. Can also set `--aws-default-region`
@@ -371,6 +371,16 @@ Possible values (case insensitive):
     /// environments.
     #[structopt(long = "--aws-endpoint", env = "AWS_ENDPOINT")]
     pub aws_endpoint: Option<String>,
+
+    /// When using Amazon S3 as an object store, set this to the session token. This is handy when using a federated
+    /// login / SSO and you fetch credentials via the UI.
+    ///
+    /// Is it assumed that the session is valid as long as the IOx server is running.
+    ///
+    /// Prefer the environment variable over the command line flag in shared
+    /// environments.
+    #[structopt(long = "--aws-session-token", env = "AWS_SESSION_TOKEN")]
+    pub aws_session_token: Option<String>,
 
     /// When using Google Cloud Storage as the object store, set this to the
     /// path to the JSON file that contains the Google credentials.

--- a/src/influxdb_ioxd.rs
+++ b/src/influxdb_ioxd.rs
@@ -336,14 +336,22 @@ impl TryFrom<&Config> for ObjectStore {
                     config.aws_secret_access_key.as_ref(),
                     config.aws_default_region.as_str(),
                     config.aws_endpoint.as_ref(),
+                    config.aws_session_token.as_ref(),
                 ) {
-                    (Some(bucket), key_id, secret_key, region, endpoint) => {
+                    (Some(bucket), key_id, secret_key, region, endpoint, session_token) => {
                         Ok(Self::new_amazon_s3(
-                            AmazonS3::new(key_id, secret_key, region, bucket, endpoint)
-                                .context(InvalidS3Config)?,
+                            AmazonS3::new(
+                                key_id,
+                                secret_key,
+                                region,
+                                bucket,
+                                endpoint,
+                                session_token,
+                            )
+                            .context(InvalidS3Config)?,
                         ))
                     }
-                    (bucket, _, _, _, _) => {
+                    (bucket, _, _, _, _, _) => {
                         let mut missing_args = vec![];
 
                         if bucket.is_none() {


### PR DESCRIPTION
That's what accumulated so far in #1461 and is helpful even if we won't use emulators. At least you can now test+run:

- against an emulator
- against AWS using a session token
