### PR TITLE
chore: enable arrow prettyprint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,7 +68,7 @@ tracker = { path = "tracker" }
 write_buffer = { path = "write_buffer" }
 
 # Crates.io dependencies, in alphabetical order
-arrow = "4.0"
+arrow = { version = "4.0", features = ["prettyprint"] }
 arrow-flight = "4.0"
 byteorder = "1.3.4"
 bytes = "1.0"

--- a/arrow_util/Cargo.toml
+++ b/arrow_util/Cargo.toml
@@ -7,7 +7,7 @@ description = "Apache Arrow utilities"
 
 [dependencies]
 
-arrow = "4.0"
+arrow = { version = "4.0", features = ["prettyprint"] }
 ahash = "0.7.2"
 num-traits = "0.2"
 futures = "0.3"

--- a/ingest/Cargo.toml
+++ b/ingest/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Andrew Lamb <andrew@nerdnetworks.org>"]
 edition = "2018"
 
 [dependencies] # In alphabetical order
-arrow = "4.0"
+arrow = { version = "4.0", features = ["prettyprint"] }
 influxdb_line_protocol = { path = "../influxdb_line_protocol" }
 influxdb_tsm = { path = "../influxdb_tsm" }
 internal_types = { path = "../internal_types" }

--- a/internal_types/Cargo.toml
+++ b/internal_types/Cargo.toml
@@ -7,7 +7,7 @@ description = "InfluxDB IOx internal types, shared between IOx instances"
 readme = "README.md"
 
 [dependencies]
-arrow = "4.0"
+arrow = { version = "4.0", features = ["prettyprint"] }
 snafu = "0.6"
 observability_deps = { path = "../observability_deps" }
 

--- a/mem_qe/Cargo.toml
+++ b/mem_qe/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Edd Robinson <me@edd.io>"]
 edition = "2018"
 
 [dependencies] # In alphabetical order
-arrow = "4.0"
+arrow = { version = "4.0", features = ["prettyprint"] }
 chrono = "0.4"
 croaring = "0.4.5"
 crossbeam = "0.8"

--- a/mutable_buffer/Cargo.toml
+++ b/mutable_buffer/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2018"
 # 2. Keep change/compile/link time down during development when working on just this crate
 
 [dependencies] # In alphabetical order
-arrow = { version = "4.0" }
+arrow = { version = "4.0", features = ["prettyprint"] }
 arrow_util = { path = "../arrow_util" }
 async-trait = "0.1"
 data_types = { path = "../data_types" }

--- a/packers/Cargo.toml
+++ b/packers/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Andrew Lamb <andrew@nerdnetworks.org>"]
 edition = "2018"
 
 [dependencies] # In alphabetical order
-arrow = "4.0"
+arrow = { version = "4.0", features = ["prettyprint"] }
 human_format = "1.0.3"
 influxdb_tsm = { path = "../influxdb_tsm" }
 internal_types = { path = "../internal_types" }

--- a/parquet_file/Cargo.toml
+++ b/parquet_file/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Nga Tran <nga-tran@live.com>"]
 edition = "2018"
 
 [dependencies] # In alphabetical order
-arrow = "4.0"
+arrow = { version = "4.0", features = ["prettyprint"] }
 bytes = "1.0"
 data_types = { path = "../data_types" }
 datafusion = { path = "../datafusion" }

--- a/query/Cargo.toml
+++ b/query/Cargo.toml
@@ -14,7 +14,7 @@ description = "IOx Query Interface and Executor"
 # 2. Allow for query logic testing without bringing in all the storage systems.
 
 [dependencies] # In alphabetical order
-arrow = "4.0"
+arrow = { version = "4.0", features = ["prettyprint"] }
 arrow_util = { path = "../arrow_util" }
 async-trait = "0.1"
 chrono = "0.4"

--- a/read_buffer/Cargo.toml
+++ b/read_buffer/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 # 2. Keep change/compile/link time down during development when working on just this crate
 
 [dependencies] # In alphabetical order
-arrow = "4.0"
+arrow = { version = "4.0", features = ["prettyprint"] }
 arrow_util = { path = "../arrow_util" }
 croaring = "0.4.5"
 data_types = { path = "../data_types" }

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["pauldix <paul@pauldix.net>"]
 edition = "2018"
 
 [dependencies] # In alphabetical order
-arrow = "4.0"
+arrow = { version = "4.0", features = ["prettyprint"] }
 arrow_util = { path = "../arrow_util" }
 arrow-flight = "4.0"
 async-trait = "0.1"


### PR DESCRIPTION
When building a crate that also brings in DataFusion, the `prettyprint` feature flag is enabled, as DataFusion depends on it, but when building crates that don't bring in DataFusion (e.g. mutable_buffer) the test fail to compile as the feature isn't enabled.

As the feature is almost always enabled anyway, it made sense, at least to me, to just enable it everywhere. The alternative would be to give the crates that need it an additional dev-dependency on arrow that enables the feature just for their tests.