### PR TITLE
feat: Implement Chunk Pruning

### DIFF
--- a/data_types/src/partition_metadata.rs
+++ b/data_types/src/partition_metadata.rs
@@ -98,6 +98,13 @@ impl TableSummary {
         }
     }
 
+    /// Returns the total number of rows in the columns of this summary
+    pub fn count(&self) -> u64 {
+        // Assumes that all tables have the same number of rows, so
+        // pick the first one
+        self.columns.get(0).map(|c| c.count()).unwrap_or(0)
+    }
+
     pub fn size(&self) -> usize {
         // Total size of all ColumnSummaries that belong to this table which include
         // column names and their stats

--- a/query/src/frontend/influxrpc.rs
+++ b/query/src/frontend/influxrpc.rs
@@ -1109,6 +1109,17 @@ impl InfluxRpcPlanner {
 
         // Prepare the scan of the table
         let mut builder = ProviderBuilder::new(table_name);
+
+        // Since the entire predicate is used in the call to
+        // `database.chunks()` there will not be any additional
+        // predicates that get pushed down here
+        //
+        // However, in the future if DataFusion adds extra synthetic
+        // predicates that could be pushed down and used for
+        // additional pruning we may want to add an extra layer of
+        // pruning here.
+        builder = builder.add_no_op_pruner();
+
         for chunk in chunks {
             let chunk_id = chunk.id();
 

--- a/query/src/lib.rs
+++ b/query/src/lib.rs
@@ -12,6 +12,7 @@ use datafusion::physical_plan::SendableRecordBatchStream;
 use exec::{stringset::StringSet, Executor};
 use internal_types::{schema::Schema, selection::Selection};
 use predicate::PredicateMatch;
+use pruning::Prunable;
 
 use std::{fmt::Debug, sync::Arc};
 
@@ -46,7 +47,7 @@ pub trait Database: Debug + Send + Sync {
 
     /// Returns a set of chunks within the partition with data that may match
     /// the provided predicate. If possible, chunks which have no rows that can
-    /// possibly match the predicate are omitted.
+    /// possibly match the predicate may be omitted.
     fn chunks(&self, predicate: &Predicate) -> Vec<Arc<Self::Chunk>>;
 
     /// Return a summary of all chunks in this database, in all partitions
@@ -54,7 +55,7 @@ pub trait Database: Debug + Send + Sync {
 }
 
 /// Collection of data that shares the same partition key
-pub trait PartitionChunk: Debug + Send + Sync {
+pub trait PartitionChunk: Prunable + Debug + Send + Sync {
     type Error: std::error::Error + Send + Sync + 'static;
 
     /// returns the Id of this chunk. Ids are unique within a

--- a/query/src/predicate.rs
+++ b/query/src/predicate.rs
@@ -42,8 +42,8 @@ pub enum PredicateMatch {
     Unknown,
 }
 
-/// Represents a parsed predicate for evaluation by the
-/// TSDatabase InfluxDB IOx query engine.
+/// Represents a parsed predicate for evaluation by the InfluxDB IOx
+/// query engine.
 ///
 /// Note that the InfluxDB data model (e.g. ParsedLine's)
 /// distinguishes between some types of columns (tags and fields), and

--- a/query/src/test.rs
+++ b/query/src/test.rs
@@ -8,14 +8,14 @@ use arrow::{
     datatypes::{DataType, Int32Type, TimeUnit},
     record_batch::RecordBatch,
 };
-use data_types::chunk_metadata::ChunkSummary;
+use data_types::{chunk_metadata::ChunkSummary, partition_metadata::TableSummary};
 use datafusion::physical_plan::{common::SizedRecordBatchStream, SendableRecordBatchStream};
 
-use crate::exec::Executor;
 use crate::{
     exec::stringset::{StringSet, StringSetRef},
     Database, DatabaseStore, PartitionChunk, Predicate, PredicateMatch,
 };
+use crate::{exec::Executor, pruning::Prunable};
 
 use internal_types::{
     schema::{
@@ -398,6 +398,19 @@ impl PartitionChunk for TestChunk {
         };
 
         Ok(column_names)
+    }
+}
+
+impl Prunable for TestChunk {
+    fn summary(&self) -> &TableSummary {
+        unimplemented!();
+    }
+
+    fn schema(&self) -> arrow::datatypes::SchemaRef {
+        self.table_schema
+            .as_ref()
+            .map(|s| s.as_arrow())
+            .expect("schema was set")
     }
 }
 

--- a/server/src/db/access.rs
+++ b/server/src/db/access.rs
@@ -1,0 +1,277 @@
+//! This module contains the interface to the Catalog / Chunks used by
+//! the query engine
+
+use crate::{db::system_tables, JobRegistry};
+use std::{any::Any, sync::Arc};
+
+use super::{
+    catalog::{Catalog, TableNameFilter},
+    chunk::DbChunk,
+    Error, Result,
+};
+
+use async_trait::async_trait;
+use data_types::{chunk_metadata::ChunkSummary, error::ErrorLogger};
+use datafusion::{
+    catalog::{catalog::CatalogProvider, schema::SchemaProvider},
+    datasource::TableProvider,
+};
+use internal_types::selection::Selection;
+use metrics::{Counter, KeyValue, MetricRegistry};
+use observability_deps::tracing::debug;
+use query::{
+    predicate::{Predicate, PredicateBuilder},
+    provider::{self, ChunkPruner, ProviderBuilder},
+    pruning::Prunable,
+    PartitionChunk, DEFAULT_SCHEMA,
+};
+use system_tables::{SystemSchemaProvider, SYSTEM_SCHEMA};
+
+use query::{
+    pruning::{prune_chunks, PruningObserver},
+    Database,
+};
+
+/// Metrics related to chunk access (pruning specifically)
+#[derive(Debug)]
+struct AccessMetrics {
+    /// Total number of chunks pruned via statistics
+    pruned_chunks: Counter,
+    /// Total number of rows pruned using statistics
+    pruned_rows: Counter,
+}
+
+impl AccessMetrics {
+    fn new(metrics_registry: Arc<metrics::MetricRegistry>, metric_labels: Vec<KeyValue>) -> Self {
+        let pruning_domain =
+            metrics_registry.register_domain_with_labels("query_access", metric_labels);
+
+        let pruned_chunks = pruning_domain.register_counter_metric(
+            "pruned_chunks",
+            None,
+            "Number of chunks pruned using metadata",
+        );
+
+        let pruned_rows = pruning_domain.register_counter_metric(
+            "pruned_rows",
+            None,
+            "Number of rows pruned using metadata",
+        );
+
+        Self {
+            pruned_chunks,
+            pruned_rows,
+        }
+    }
+}
+
+/// `QueryCatalogAccess` implements traits that allow the query engine
+/// (and DataFusion) to access the contents of the IOx catalog.
+#[derive(Debug)]
+pub(crate) struct QueryCatalogAccess {
+    /// The catalog to have access to
+    catalog: Arc<Catalog>,
+
+    /// Handles finding / pruning chunks based on predicates
+    chunk_access: Arc<ChunkAccess>,
+
+    /// Provides access to system tables
+    system_tables: Arc<SystemSchemaProvider>,
+
+    /// Provides access to "normal" user tables
+    user_tables: Arc<DbSchemaProvider>,
+}
+
+impl QueryCatalogAccess {
+    pub fn new(
+        db_name: impl Into<String>,
+        catalog: Arc<Catalog>,
+        jobs: Arc<JobRegistry>,
+        metrics_registry: Arc<MetricRegistry>,
+        metric_labels: Vec<KeyValue>,
+    ) -> Self {
+        let access_metrics = AccessMetrics::new(metrics_registry, metric_labels);
+        let chunk_access = Arc::new(ChunkAccess::new(Arc::clone(&catalog), access_metrics));
+
+        let system_tables = Arc::new(SystemSchemaProvider::new(
+            db_name,
+            Arc::clone(&catalog),
+            jobs,
+        ));
+        let user_tables = Arc::new(DbSchemaProvider::new(
+            Arc::clone(&catalog),
+            Arc::clone(&chunk_access),
+        ));
+
+        Self {
+            catalog,
+            chunk_access,
+            system_tables,
+            user_tables,
+        }
+    }
+}
+
+/// Encapsulates everything needed to find candidate chunks for
+/// queries (including pruning based on metadata)
+#[derive(Debug)]
+struct ChunkAccess {
+    /// The catalog to have access to
+    catalog: Arc<Catalog>,
+
+    /// Metrics about query processing
+    access_metrics: AccessMetrics,
+}
+
+impl ChunkAccess {
+    fn new(catalog: Arc<Catalog>, access_metrics: AccessMetrics) -> Self {
+        Self {
+            catalog,
+            access_metrics,
+        }
+    }
+
+    /// Returns all chunks that may have data that passes the
+    /// specified predicates. The chunks are pruned as aggressively as
+    /// possible based on metadata.
+    fn candidate_chunks(&self, predicate: &Predicate) -> Vec<Arc<DbChunk>> {
+        let partition_key = predicate.partition_key.as_deref();
+        let table_names: TableNameFilter<'_> = predicate.table_names.as_ref().into();
+
+        // Apply initial partition key / table name pruning
+        let chunks = self
+            .catalog
+            .filtered_chunks(partition_key, table_names, DbChunk::snapshot);
+
+        self.prune_chunks(chunks, predicate)
+    }
+}
+
+impl ChunkPruner<DbChunk> for ChunkAccess {
+    fn prune_chunks(&self, chunks: Vec<Arc<DbChunk>>, predicate: &Predicate) -> Vec<Arc<DbChunk>> {
+        // TODO: call "apply_predicate" here too for additional
+        // metadata based pruning
+
+        debug!(num_chunks=chunks.len(), %predicate, "Attempting to prune chunks");
+        prune_chunks(self, chunks, predicate)
+    }
+}
+
+impl PruningObserver for ChunkAccess {
+    type Observed = DbChunk;
+
+    fn was_pruned(&self, chunk: &Self::Observed) {
+        let labels = vec![KeyValue::new("table_name", chunk.table_name().to_string())];
+        let num_rows = chunk.summary().count();
+        self.access_metrics
+            .pruned_chunks
+            .add_with_labels(1, &labels);
+        self.access_metrics
+            .pruned_rows
+            .add_with_labels(num_rows, &labels);
+        debug!(chunk_id = chunk.id(), num_rows, "pruned chunk from query")
+    }
+
+    fn could_not_prune_chunk(&self, chunk: &Self::Observed, reason: &str) {
+        debug!(
+            chunk_id = chunk.id(),
+            reason, "could not prune chunk from query"
+        )
+    }
+}
+
+#[async_trait]
+impl Database for QueryCatalogAccess {
+    type Error = Error;
+    type Chunk = DbChunk;
+
+    /// Return a covering set of chunks for a particular partition
+    fn chunks(&self, predicate: &Predicate) -> Vec<Arc<Self::Chunk>> {
+        self.chunk_access.candidate_chunks(predicate)
+    }
+
+    fn partition_keys(&self) -> Result<Vec<String>, Self::Error> {
+        Ok(self.catalog.partition_keys())
+    }
+
+    fn chunk_summaries(&self) -> Result<Vec<ChunkSummary>> {
+        Ok(self.catalog.chunk_summaries())
+    }
+}
+
+// Datafusion catalog provider interface
+impl CatalogProvider for QueryCatalogAccess {
+    fn as_any(&self) -> &dyn Any {
+        self as &dyn Any
+    }
+
+    fn schema_names(&self) -> Vec<String> {
+        vec![
+            DEFAULT_SCHEMA.to_string(),
+            system_tables::SYSTEM_SCHEMA.to_string(),
+        ]
+    }
+
+    fn schema(&self, name: &str) -> Option<Arc<dyn SchemaProvider>> {
+        match name {
+            DEFAULT_SCHEMA => Some(Arc::clone(&self.user_tables) as Arc<dyn SchemaProvider>),
+            SYSTEM_SCHEMA => Some(Arc::clone(&self.system_tables) as Arc<dyn SchemaProvider>),
+            _ => None,
+        }
+    }
+}
+
+/// Implement the DataFusion schema provider API
+#[derive(Debug)]
+struct DbSchemaProvider {
+    /// The catalog to have access to
+    catalog: Arc<Catalog>,
+
+    /// Handles finding / pruning chunks based on predicates
+    chunk_access: Arc<ChunkAccess>,
+}
+
+impl DbSchemaProvider {
+    fn new(catalog: Arc<Catalog>, chunk_access: Arc<ChunkAccess>) -> Self {
+        Self {
+            catalog,
+            chunk_access,
+        }
+    }
+}
+
+impl SchemaProvider for DbSchemaProvider {
+    fn as_any(&self) -> &dyn Any {
+        self as &dyn Any
+    }
+
+    fn table_names(&self) -> Vec<String> {
+        self.catalog.table_names()
+    }
+
+    /// Create a table provider for the named table
+    fn table(&self, table_name: &str) -> Option<Arc<dyn TableProvider>> {
+        let mut builder = ProviderBuilder::new(table_name)
+            .add_pruner(Arc::clone(&self.chunk_access) as Arc<dyn ChunkPruner<DbChunk>>);
+
+        let predicate = PredicateBuilder::new().table(table_name).build();
+
+        for chunk in self.chunk_access.candidate_chunks(&predicate) {
+            // This should only fail if the table doesn't exist which isn't possible
+            let schema = chunk.table_schema(Selection::All).expect("cannot fail");
+
+            // This is unfortunate - a table with incompatible chunks ceases to
+            // be visible to the query engine
+            builder = builder
+                .add_chunk(chunk, schema)
+                .log_if_error("Adding chunks to table")
+                .ok()?;
+        }
+
+        match builder.build() {
+            Ok(provider) => Some(Arc::new(provider)),
+            Err(provider::Error::InternalNoChunks { .. }) => None,
+            Err(e) => panic!("unexpected error: {:?}", e),
+        }
+    }
+}

--- a/server/src/db/catalog.rs
+++ b/server/src/db/catalog.rs
@@ -1,5 +1,5 @@
 //! This module contains the implementation of the InfluxDB IOx Metadata catalog
-use std::{any::Any, collections::BTreeSet};
+use std::collections::BTreeSet;
 use std::{
     collections::{btree_map::Entry, BTreeMap},
     sync::Arc,
@@ -9,21 +9,13 @@ use snafu::{OptionExt, Snafu};
 
 use crate::db::catalog::metrics::CatalogMetrics;
 use chunk::Chunk;
-use data_types::error::ErrorLogger;
 use data_types::partition_metadata::PartitionSummary;
 use data_types::{chunk_metadata::ChunkSummary, partition_metadata::UnaggregatedPartitionSummary};
 use data_types::{
     chunk_metadata::DetailedChunkSummary,
     database_rules::{Order, Sort, SortOrder},
 };
-use datafusion::{catalog::schema::SchemaProvider, datasource::TableProvider};
-use internal_types::selection::Selection;
 use partition::Partition;
-use query::{
-    exec::stringset::StringSet,
-    provider::{self, ProviderBuilder},
-    PartitionChunk,
-};
 use tracker::RwLock;
 
 pub mod chunk;
@@ -350,18 +342,9 @@ impl Catalog {
         chunks
     }
 
-    pub fn metrics(&self) -> &CatalogMetrics {
-        &self.metrics
-    }
-}
-
-impl SchemaProvider for Catalog {
-    fn as_any(&self) -> &dyn Any {
-        self as &dyn Any
-    }
-
-    fn table_names(&self) -> Vec<String> {
-        let mut names = StringSet::new();
+    /// Return a list of all table names in the catalog
+    pub fn table_names(&self) -> Vec<String> {
+        let mut names = BTreeSet::new();
 
         self.partitions().for_each(|partition| {
             let partition = partition.read();
@@ -373,36 +356,8 @@ impl SchemaProvider for Catalog {
         names.into_iter().collect()
     }
 
-    fn table(&self, table_name: &str) -> Option<Arc<dyn TableProvider>> {
-        let mut builder = ProviderBuilder::new(table_name);
-        let partitions = self.partitions.read();
-
-        for partition in partitions.values() {
-            let partition = partition.read();
-            for chunk in partition.chunks() {
-                let chunk = chunk.read();
-
-                if chunk.table_name().as_ref() == table_name {
-                    let chunk = super::DbChunk::snapshot(&chunk);
-
-                    // This should only fail if the table doesn't exist which isn't possible
-                    let schema = chunk.table_schema(Selection::All).expect("cannot fail");
-
-                    // This is unfortunate - a table with incompatible chunks ceases to
-                    // be visible to the query engine
-                    builder = builder
-                        .add_chunk(chunk, schema)
-                        .log_if_error("Adding chunks to table")
-                        .ok()?
-                }
-            }
-        }
-
-        match builder.build() {
-            Ok(provider) => Some(Arc::new(provider)),
-            Err(provider::Error::InternalNoChunks { .. }) => None,
-            Err(e) => panic!("unexpected error: {:?}", e),
-        }
+    pub fn metrics(&self) -> &CatalogMetrics {
+        &self.metrics
     }
 }
 

--- a/server/src/db/chunk.rs
+++ b/server/src/db/chunk.rs
@@ -3,6 +3,9 @@ use std::{
     sync::Arc,
 };
 
+use arrow::datatypes::SchemaRef;
+use data_types::partition_metadata;
+use partition_metadata::TableSummary;
 use snafu::{ResultExt, Snafu};
 
 use datafusion::physical_plan::SendableRecordBatchStream;
@@ -15,6 +18,7 @@ use parquet_file::chunk::Chunk as ParquetChunk;
 use query::{
     exec::stringset::StringSet,
     predicate::{Predicate, PredicateMatch},
+    pruning::Prunable,
     PartitionChunk,
 };
 use read_buffer::Chunk as ReadBufferChunk;
@@ -437,5 +441,15 @@ impl PartitionChunk for DbChunk {
                 Ok(None)
             }
         }
+    }
+}
+
+impl Prunable for DbChunk {
+    fn summary(&self) -> &TableSummary {
+        self.meta.table_summary.as_ref()
+    }
+
+    fn schema(&self) -> SchemaRef {
+        self.meta.schema.as_arrow()
     }
 }

--- a/server/src/db/lifecycle.rs
+++ b/server/src/db/lifecycle.rs
@@ -284,7 +284,7 @@ impl ChunkMover for LifecycleManager {
     type Job = Job;
 
     fn buffer_size(&self) -> usize {
-        self.db.catalog.state().metrics().memory().total()
+        self.db.preserved_catalog.state().metrics().memory().total()
     }
 
     fn db_name(&self) -> &str {
@@ -296,7 +296,10 @@ impl ChunkMover for LifecycleManager {
     }
 
     fn chunks(&self, sort_order: &SortOrder) -> Vec<Arc<RwLock<Chunk>>> {
-        self.db.catalog.state().chunks_sorted_by(sort_order)
+        self.db
+            .preserved_catalog
+            .state()
+            .chunks_sorted_by(sort_order)
     }
 
     fn move_tracker(&self) -> Option<&TaskTracker<Job>> {

--- a/server/src/query_tests.rs
+++ b/server/src/query_tests.rs
@@ -6,6 +6,7 @@
 //! against it and verifying the same answer is produced in all scenarios
 
 pub mod influxrpc;
+pub mod pruning;
 pub mod scenarios;
 pub mod sql;
 pub mod table_schema;

--- a/server/src/query_tests/pruning.rs
+++ b/server/src/query_tests/pruning.rs
@@ -1,0 +1,156 @@
+#![allow(unused_imports, dead_code, unused_macros)]
+use std::sync::Arc;
+
+use arrow_util::assert_batches_sorted_eq;
+use datafusion::logical_plan::{col, lit};
+use query::{
+    exec::stringset::StringSet,
+    frontend::{influxrpc::InfluxRpcPlanner, sql::SqlQueryPlanner},
+    predicate::PredicateBuilder,
+    PartitionChunk,
+};
+
+use crate::{db::test_helpers::write_lp, query_tests::utils::make_db};
+
+use super::utils::TestDb;
+
+async fn setup() -> TestDb {
+    // Test that partition pruning is connected up
+    let test_db = make_db().await;
+    let db = &test_db.db;
+
+    // Chunk 0 has bar:[1-2]
+    write_lp(db, "cpu bar=1 10");
+    write_lp(db, "cpu bar=2 20");
+
+    let partition_key = "1970-01-01T00";
+    let mb_chunk = db
+        .rollover_partition(partition_key, "cpu")
+        .await
+        .unwrap()
+        .unwrap();
+    db.load_chunk_to_read_buffer(partition_key, "cpu", mb_chunk.id(), &Default::default())
+        .await
+        .unwrap();
+
+    // Chunk 1 has bar:[3-3] (going to get pruned)
+    write_lp(db, "cpu bar=3 10");
+    write_lp(db, "cpu bar=3 100");
+    write_lp(db, "cpu bar=3 1000");
+
+    let partition_key = "1970-01-01T00";
+    let mb_chunk = db
+        .rollover_partition(partition_key, "cpu")
+        .await
+        .unwrap()
+        .unwrap();
+    db.load_chunk_to_read_buffer(partition_key, "cpu", mb_chunk.id(), &Default::default())
+        .await
+        .unwrap();
+
+    test_db
+}
+
+#[tokio::test]
+async fn chunk_pruning_sql() {
+    ::test_helpers::maybe_start_logging();
+    // Test that partition pruning is connected up
+    let TestDb {
+        db,
+        metric_registry,
+    } = setup().await;
+    let db = Arc::new(db);
+
+    let expected = vec![
+        "+-----+-------------------------------+",
+        "| bar | time                          |",
+        "+-----+-------------------------------+",
+        "| 1   | 1970-01-01 00:00:00.000000010 |",
+        "| 2   | 1970-01-01 00:00:00.000000020 |",
+        "+-----+-------------------------------+",
+    ];
+    let query = "select * from cpu where bar < 3.0";
+
+    let executor = db.executor();
+    let physical_plan = SqlQueryPlanner::default()
+        .query(db, query, &executor)
+        .unwrap();
+    let batches = executor.collect(physical_plan).await.unwrap();
+
+    assert_batches_sorted_eq!(&expected, &batches);
+
+    // Validate that the chunk was pruned using the metrics
+    metric_registry
+        .has_metric_family("query_access_pruned_chunks_total")
+        .with_labels(&[
+            ("db_name", "placeholder"),
+            ("table_name", "cpu"),
+            ("svr_id", "1"),
+        ])
+        .counter()
+        .eq(1.0)
+        .unwrap();
+
+    // Validate that the chunk was pruned using the metrics
+    metric_registry
+        .has_metric_family("query_access_pruned_rows_total")
+        .with_labels(&[
+            ("db_name", "placeholder"),
+            ("table_name", "cpu"),
+            ("svr_id", "1"),
+        ])
+        .counter()
+        .eq(3.0)
+        .unwrap();
+}
+
+#[tokio::test]
+async fn chunk_pruning_influxrpc() {
+    ::test_helpers::maybe_start_logging();
+    // Test that partition pruning is connected up
+    let TestDb {
+        db,
+        metric_registry,
+    } = setup().await;
+    let db = Arc::new(db);
+
+    let predicate = PredicateBuilder::new()
+        // bar < 3.0
+        .add_expr(col("bar").lt(lit(3.0)))
+        .build();
+
+    let mut expected = StringSet::new();
+    expected.insert("cpu".into());
+
+    let plan = InfluxRpcPlanner::new()
+        .table_names(db.as_ref(), predicate)
+        .unwrap();
+
+    let result = db.executor().to_string_set(plan).await.unwrap();
+
+    assert_eq!(&expected, result.as_ref());
+
+    // Validate that the chunk was pruned using the metrics
+    metric_registry
+        .has_metric_family("query_access_pruned_chunks_total")
+        .with_labels(&[
+            ("db_name", "placeholder"),
+            ("table_name", "cpu"),
+            ("svr_id", "1"),
+        ])
+        .counter()
+        .eq(1.0)
+        .unwrap();
+
+    // Validate that the chunk was pruned using the metrics
+    metric_registry
+        .has_metric_family("query_access_pruned_rows_total")
+        .with_labels(&[
+            ("db_name", "placeholder"),
+            ("table_name", "cpu"),
+            ("svr_id", "1"),
+        ])
+        .counter()
+        .eq(3.0)
+        .unwrap();
+}


### PR DESCRIPTION
Closes #735, Closes #736

# Rationale

Query performance is critical to IOx's use case and quickly skipping chunks and partitions that can not have data that passes predicates is a key part of this.

# Changes
This PR implements "Pruning" of chunks from query plans. It does so by introducing a `CatalogAccess` layer in the `server` module that handles the interface plumbing between the query layer and the Db / Catalog and teaches this layer how to prune chunks based on Predicates. 

```
┌────────────────────────────┐
│             Db             │
└────────────────────────────┘
               ▲
               │
               │
┌────────────────────────────┐
│       CatalogAccess        │     Predicate based
│           (new)            │   pruning happens at
└────────────────────────────┘       this layer
               ▲
               │
               │
┌────────────────────────────┐      Only table name
│          Catalog           │   filtering happens at
└────────────────────────────┘        this level
```

## Partition Pruning vs Chunk Pruning
It may be advantageous in the future to prune on partition summaries first (for partitions that have a large number of chunks). 

However, given:
1. We already do a limited form of partition pruning (based on table names and timestamp range)
2. We seem to be heading towards a future where most partitions have a small number of chunks

Thus I plan to punt more work on pruning for a while

# History / Related work

This is the final  PR that connects up partition pruning with the `Db` and adds an end to end test. Here are some of the steps that have gone into this work:

- [x] Merge upstream change in DataFusion https://github.com/apache/arrow-datafusion/pull/426
- [x] Clean up parquet reader interface (to use DataFusion parquet exec, rather than Predicate directly) - https://github.com/influxdata/influxdb_iox/pull/1580
- [x] File bugs in DataFusion for pruning https://github.com/apache/arrow-datafusion/issues/490
- [x] ~Fix correctness related bugs in DataFusion for pruning (related to nulls!)~ (I was mistaken)
- [x] Clarify catalog pruning https://github.com/influxdata/influxdb_iox/pull/1608
- [x] Pruning module https://github.com/influxdata/influxdb_iox/pull/1611
- [x] Add the ability to get a `TableSummary` and `Schema` for each DbChunk (https://github.com/influxdata/influxdb_iox/pull/1575)
- [x] Implement pruning (this PR)
- [x] Connect up to db.rs and write end to end test (this PR)
