### PR TITLE
feat: wire catalog wiping all the way to the CLI

### DIFF
--- a/data_types/src/job.rs
+++ b/data_types/src/job.rs
@@ -25,6 +25,11 @@ pub enum Job {
         table_name: String,
         chunk_id: u32,
     },
+
+    /// Wipe preserved catalog
+    WipePreservedCatalog {
+        db_name: String,
+    },
 }
 
 impl Job {
@@ -34,6 +39,7 @@ impl Job {
             Self::Dummy { .. } => None,
             Self::CloseChunk { db_name, .. } => Some(db_name),
             Self::WriteChunk { db_name, .. } => Some(db_name),
+            Self::WipePreservedCatalog { db_name, .. } => Some(db_name),
         }
     }
 
@@ -43,6 +49,7 @@ impl Job {
             Self::Dummy { .. } => None,
             Self::CloseChunk { partition_key, .. } => Some(partition_key),
             Self::WriteChunk { partition_key, .. } => Some(partition_key),
+            Self::WipePreservedCatalog { .. } => None,
         }
     }
 
@@ -52,6 +59,7 @@ impl Job {
             Self::Dummy { .. } => None,
             Self::CloseChunk { chunk_id, .. } => Some(*chunk_id),
             Self::WriteChunk { chunk_id, .. } => Some(*chunk_id),
+            Self::WipePreservedCatalog { .. } => None,
         }
     }
 
@@ -61,6 +69,7 @@ impl Job {
             Self::Dummy { .. } => "Dummy Job, for testing",
             Self::CloseChunk { .. } => "Loading chunk to ReadBuffer",
             Self::WriteChunk { .. } => "Writing chunk to Object Storage",
+            Self::WipePreservedCatalog { .. } => "Wipe preserved catalog",
         }
     }
 }

--- a/docs/README.md
+++ b/docs/README.md
@@ -27,3 +27,4 @@ We hold monthly Tech Talks that explain the project's technical underpinnings. Y
 * Protobuf tips and tricks: [Protobuf](protobuf.md).
 * Catalog Persistence: [`catalog_persistence.md`](catalog_persistence.md).
 * SQL command line tips and tricks: [SQL](sql.md).
+* Notes on server startup and error recovery: [`server_startup.md`](server_startup.md)

--- a/docs/server_startup.md
+++ b/docs/server_startup.md
@@ -1,0 +1,56 @@
+# Server Startup
+
+An IOx node can be started from the command line:
+
+```shell
+influxdb_iox run
+```
+
+See help (via `influxdb_iox run --help`) for arguments.
+
+
+## Server ID
+Before the server can do anything useful, it needs to have a server ID. There are multiple ways of doing so:
+
+- **CLI Argument:** Pass `--server-id` to the `run` command.
+- **Environment Variable:** Set `INFLUXDB_IOX_ID` before starting the server.
+- **gRPC:** Use the `UpdateServerId` gRPC call to set the server ID.
+
+
+## Server Init Process
+Once the server ID is know, the server will use the registered object store credentials to load all previously known
+database. If there are any errors during the object store inspection (e.g. due to wrong credentials, IO errors,
+connectivity errors) the server will be in an error state. The error will be logged and can also be inspected via the
+`GetServerStatus` gRPC interface.
+
+You can use the the CLI to wait for the server to be intialized:
+
+```shell
+influxdb_iox server wait-server-initalized ...
+```
+
+
+## Database Init Process
+For every database that the server has found, it will:
+
+1. load the serialized rules
+2. load the preserved catalog
+3. start the database
+
+If there is an error during any of these steps, it will be logged and exposed via the `GetServerStatus` gRPC interface.
+
+
+## Database Recovery
+Some database errors can be recovered.
+
+### Preserved Catalog -- Wiping
+The preserved catalog can be wiped. For this, the database has either be unknown (hence it will be some kind of garbage
+collection / clean up) or the database has to be in an error state. Either use the `WipePreservedCatalog` gRPC interface
+or the CLI:
+
+```shell
+influxdb_iox database catalog wipe ...
+```
+
+Once the catalog is wiped, the server will retry to initialize the database. Process will be logged. If the database
+init process is successful, the error status within the `GetServerStatus` gRPC response will be cleared.

--- a/generated_types/protos/influxdata/iox/management/v1/jobs.proto
+++ b/generated_types/protos/influxdata/iox/management/v1/jobs.proto
@@ -22,6 +22,7 @@ message OperationMetadata {
     */
     CloseChunk close_chunk = 7;
     WriteChunk write_chunk = 8;
+    WipePreservedCatalog wipe_preserved_catalog = 9;
   }
 }
 
@@ -59,4 +60,10 @@ message WriteChunk {
 
   // chunk_id
   uint32 chunk_id = 3;
+}
+
+// Wipe preserved catalog
+message WipePreservedCatalog {
+  // name of the database
+  string db_name = 1;
 }

--- a/generated_types/protos/influxdata/iox/management/v1/service.proto
+++ b/generated_types/protos/influxdata/iox/management/v1/service.proto
@@ -64,6 +64,9 @@ service ManagementService {
 
   // Get server status
   rpc GetServerStatus(GetServerStatusRequest) returns (GetServerStatusResponse);
+
+  // Wipe preserved catalog for given DB.
+  rpc WipePreservedCatalog(WipePreservedCatalogRequest) returns (WipePreservedCatalogResponse);
 }
 
 message GetServerIdRequest {}
@@ -268,4 +271,15 @@ message DatabaseStatus {
 message Error {
   // Message descripting the error.
   string message = 1;
+}
+
+// Request to wipe preserved catalog.
+message WipePreservedCatalogRequest {
+  // the name of the database
+  string db_name = 1;
+}
+
+message WipePreservedCatalogResponse {
+  // The operation that tracks the work for wiping the catalog.
+  google.longrunning.Operation operation = 1;
 }

--- a/generated_types/src/job.rs
+++ b/generated_types/src/job.rs
@@ -30,6 +30,9 @@ impl From<Job> for management::operation_metadata::Job {
                 table_name,
                 chunk_id,
             }),
+            Job::WipePreservedCatalog { db_name } => {
+                Self::WipePreservedCatalog(management::WipePreservedCatalog { db_name })
+            }
         }
     }
 }
@@ -61,6 +64,9 @@ impl From<management::operation_metadata::Job> for Job {
                 table_name,
                 chunk_id,
             },
+            Job::WipePreservedCatalog(management::WipePreservedCatalog { db_name }) => {
+                Self::WipePreservedCatalog { db_name }
+            }
         }
     }
 }

--- a/influxdb_iox_client/src/client/management.rs
+++ b/influxdb_iox_client/src/client/management.rs
@@ -669,7 +669,7 @@ impl Client {
             .ok_or(ClosePartitionChunkError::EmptyResponse)?)
     }
 
-    /// Wipe preserved catalog of specified, but non-existing database.
+    /// Wipe potential preserved catalog of an uninitialized database.
     pub async fn wipe_persisted_catalog(
         &mut self,
         db_name: impl Into<String> + Send,

--- a/parquet_file/src/rebuild.rs
+++ b/parquet_file/src/rebuild.rs
@@ -60,7 +60,7 @@ pub type Result<T, E = Error> = std::result::Result<T, E>;
 
 /// Creates a new catalog from parquet files.
 ///
-/// Users are required to [wipe](crate::catalog::PreservedCatalog::wipe) the existing catalog before running this
+/// Users are required to [wipe](crate::catalog::wipe) the existing catalog before running this
 /// procedure (**after creating a backup!**).
 ///
 /// This will create a catalog checkpoint for the very last transaction.
@@ -261,7 +261,7 @@ mod tests {
 
     use crate::{catalog::test_helpers::TestCatalogState, storage::MemWriter};
     use crate::{
-        catalog::PreservedCatalog,
+        catalog::{wipe, PreservedCatalog},
         storage::Storage,
         test_utils::{make_object_store, make_record_batch},
     };
@@ -340,9 +340,7 @@ mod tests {
 
         // wipe catalog
         drop(catalog);
-        PreservedCatalog::<TestCatalogState>::wipe(&object_store, server_id, db_name)
-            .await
-            .unwrap();
+        wipe(&object_store, server_id, db_name).await.unwrap();
 
         // rebuild
         let path = object_store.new_path();
@@ -386,9 +384,7 @@ mod tests {
 
         // wipe catalog
         drop(catalog);
-        PreservedCatalog::<TestCatalogState>::wipe(&object_store, server_id, db_name)
-            .await
-            .unwrap();
+        wipe(&object_store, server_id, db_name).await.unwrap();
 
         // rebuild
         let path = object_store.new_path();
@@ -430,9 +426,7 @@ mod tests {
 
         // wipe catalog
         drop(catalog);
-        PreservedCatalog::<TestCatalogState>::wipe(&object_store, server_id, db_name)
-            .await
-            .unwrap();
+        wipe(&object_store, server_id, db_name).await.unwrap();
 
         // rebuild
         let path = object_store.new_path();
@@ -495,9 +489,7 @@ mod tests {
 
         // wipe catalog
         drop(catalog);
-        PreservedCatalog::<TestCatalogState>::wipe(&object_store, server_id, db_name)
-            .await
-            .unwrap();
+        wipe(&object_store, server_id, db_name).await.unwrap();
 
         // rebuild
         let path = object_store.new_path();
@@ -535,9 +527,7 @@ mod tests {
 
         // wipe catalog
         drop(catalog);
-        PreservedCatalog::<TestCatalogState>::wipe(&object_store, server_id, db_name)
-            .await
-            .unwrap();
+        wipe(&object_store, server_id, db_name).await.unwrap();
 
         // rebuild (do not ignore errors)
         let path = object_store.new_path();
@@ -628,9 +618,7 @@ mod tests {
 
         // wipe catalog
         drop(catalog);
-        PreservedCatalog::<TestCatalogState>::wipe(&object_store, server_id, db_name)
-            .await
-            .unwrap();
+        wipe(&object_store, server_id, db_name).await.unwrap();
 
         // rebuild
         let path = object_store.new_path();

--- a/server/src/config.rs
+++ b/server/src/config.rs
@@ -65,7 +65,7 @@ impl Config {
 
     /// Get handle to create a database.
     ///
-    /// While the handle is hold, no other operations for the given database can be executed.
+    /// While the handle is held, no other operations for the given database can be executed.
     ///
     /// This only works if the database is not yet known. To recover a database out of an uninitialized state, see
     /// [`recover_db`](Self::recover_db). To do maintainance work on data linked to the database (e.g. the catalog)
@@ -95,7 +95,7 @@ impl Config {
     ///
     /// If there are already rules known for this database, they will be passed to the handle.
     ///
-    /// While the handle is hold, no other operations for the given database can be executed.
+    /// While the handle is held, no other operations for the given database can be executed.
     ///
     /// This only works if the database is known but is uninitialized. To create a new database that is not yet known,
     /// see [`create_db`](Self::create_db). To do maintainance work on data linked to the database (e.g. the catalog)
@@ -128,9 +128,9 @@ impl Config {
 
     /// Get guard that blocks database creations. Useful when messing with the preserved catalog of unregistered DBs.
     ///
-    /// While the handle is hold, no other operations for the given database can be executed.
+    /// While the handle is held, no other operations for the given database can be executed.
     ///
-    /// This only works if the database is not yet register. To create a new database that is not yet known,
+    /// This only works if the database is not yet registered. To create a new database that is not yet known,
     /// see [`create_db`](Self::create_db). To recover a database out of an uninitialized state, see
     /// [`recover_db`](Self::recover_db).
     pub(crate) fn block_db(

--- a/server/src/db.rs
+++ b/server/src/db.rs
@@ -31,7 +31,10 @@ use parking_lot::RwLock;
 use parquet_file::catalog::TransactionEnd;
 use parquet_file::metadata::IoxParquetMetaData;
 use parquet_file::{
-    catalog::{CatalogParquetInfo, CatalogState, ChunkCreationFailed, PreservedCatalog},
+    catalog::{
+        wipe as wipe_preserved_catalog, CatalogParquetInfo, CatalogState, ChunkCreationFailed,
+        PreservedCatalog,
+    },
     chunk::{ChunkMetrics as ParquetChunkMetrics, ParquetChunk},
     cleanup::cleanup_unreferenced_parquet_files,
     metadata::IoxMetadata,
@@ -323,7 +326,7 @@ pub async fn load_or_create_preserved_catalog(
             // https://github.com/influxdata/influxdb_iox/issues/1522)
             // broken => wipe for now (at least during early iterations)
             error!("cannot load catalog, so wipe it: {}", e);
-            PreservedCatalog::<Catalog>::wipe(&object_store, server_id, db_name).await?;
+            wipe_preserved_catalog(&object_store, server_id, db_name).await?;
 
             let metrics_domain =
                 metrics_registry.register_domain_with_labels("catalog", metric_labels.clone());

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -77,6 +77,7 @@ use db::load_or_create_preserved_catalog;
 use init::InitStatus;
 use observability_deps::tracing::{debug, info, warn};
 use parking_lot::Mutex;
+use parquet_file::catalog::wipe as wipe_preserved_catalog;
 use snafu::{OptionExt, ResultExt, Snafu};
 
 use data_types::{
@@ -810,6 +811,30 @@ where
         Ok(db.load_chunk_to_read_buffer_in_background(table_name, partition_key, chunk_id))
     }
 
+    /// Wipe preserved catalog of specific DB.
+    ///
+    /// The DB must not yet exist within this server for this to work! This is done to prevent race conditions between
+    /// DB jobs and this command.
+    pub fn wipe_preserved_catalog(&self, db_name: DatabaseName<'_>) -> Result<TaskTracker<Job>> {
+        if self.config.db(&db_name).is_some() {
+            return Err(Error::DatabaseAlreadyExists {
+                db_name: db_name.to_string(),
+            });
+        }
+
+        let (tracker, registration) = self.jobs.register(Job::WipePreservedCatalog {
+            db_name: db_name.to_string(),
+        });
+        let object_store = Arc::clone(&self.store);
+        let server_id = self.require_id()?;
+        let db_name_string = db_name.to_string();
+        let task =
+            async move { wipe_preserved_catalog(&object_store, server_id, &db_name_string).await };
+        tokio::spawn(task.track(registration));
+
+        Ok(tracker)
+    }
+
     /// Returns a list of all jobs tracked by this server
     pub fn tracked_jobs(&self) -> Vec<TaskTracker<Job>> {
         self.jobs.inner.lock().tracked()
@@ -1026,6 +1051,7 @@ mod tests {
     use bytes::Bytes;
     use futures::TryStreamExt;
     use generated_types::database_rules::decode_database_rules;
+    use parquet_file::catalog::{test_helpers::TestCatalogState, PreservedCatalog};
     use snafu::Snafu;
     use tokio::task::JoinHandle;
     use tokio_util::sync::CancellationToken;
@@ -1855,5 +1881,62 @@ mod tests {
         // creating failed DBs does not work
         let err = create_simple_database(&server, "bar").await.unwrap_err();
         assert_eq!(err.to_string(), "database already exists");
+    }
+
+    #[tokio::test]
+    async fn wipe_preserved_catalog() {
+        let manager = TestConnectionManager::new();
+        let server = Server::new(manager, config());
+        let db_name1 = DatabaseName::new("db1".to_string()).unwrap();
+        let db_name2 = DatabaseName::new("db2".to_string()).unwrap();
+
+        // cannot wipe if server ID is not set
+        assert_eq!(
+            server
+                .wipe_preserved_catalog(db_name1.clone())
+                .unwrap_err()
+                .to_string(),
+            "cannot get id: unable to use server until id is set"
+        );
+
+        server.set_id(ServerId::try_from(1).unwrap()).unwrap();
+        server.maybe_initialize_server().await;
+
+        // wipe just works
+        PreservedCatalog::<TestCatalogState>::new_empty(
+            Arc::clone(&server.store),
+            server.require_id().unwrap(),
+            db_name1.to_string(),
+            (),
+        )
+        .await
+        .unwrap();
+        let tracker = server.wipe_preserved_catalog(db_name1.clone()).unwrap();
+        let metadata = tracker.metadata();
+        let expected_metadata = Job::WipePreservedCatalog {
+            db_name: db_name1.to_string(),
+        };
+        assert_eq!(metadata, &expected_metadata);
+        tracker.join().await;
+        assert!(!PreservedCatalog::<TestCatalogState>::exists(
+            &server.store,
+            server.require_id().unwrap(),
+            &db_name1.to_string()
+        )
+        .await
+        .unwrap());
+
+        // cannot wipe if DB exists
+        server
+            .create_database(DatabaseRules::new(db_name2.clone()))
+            .await
+            .unwrap();
+        assert_eq!(
+            server
+                .wipe_preserved_catalog(db_name2.clone())
+                .unwrap_err()
+                .to_string(),
+            "database already exists"
+        );
     }
 }

--- a/server/src/utils.rs
+++ b/server/src/utils.rs
@@ -62,6 +62,7 @@ impl TestDbBuilder {
             Arc::clone(&object_store),
             server_id,
             Arc::clone(&metrics_registry),
+            true,
         )
         .await
         .unwrap();

--- a/src/commands/database.rs
+++ b/src/commands/database.rs
@@ -13,6 +13,7 @@ use influxdb_iox_client::{
 use structopt::StructOpt;
 use thiserror::Error;
 
+mod catalog;
 mod chunk;
 mod partition;
 
@@ -53,6 +54,9 @@ pub enum Error {
 
     #[error("JSON Serialization error: {0}")]
     Serde(#[from] serde_json::Error),
+
+    #[error("Error in partition subcommand: {0}")]
+    Catalog(#[from] catalog::Error),
 }
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
@@ -164,6 +168,7 @@ enum Command {
     Query(Query),
     Chunk(chunk::Config),
     Partition(partition::Config),
+    Catalog(catalog::Config),
 }
 
 pub async fn command(url: String, config: Config) -> Result<()> {
@@ -264,6 +269,9 @@ pub async fn command(url: String, config: Config) -> Result<()> {
         }
         Command::Partition(config) => {
             partition::command(url, config).await?;
+        }
+        Command::Catalog(config) => {
+            catalog::command(url, config).await?;
         }
     }
 

--- a/src/commands/database/catalog.rs
+++ b/src/commands/database/catalog.rs
@@ -47,7 +47,7 @@ enum Command {
 /// Wipe persisted catalog.
 #[derive(Debug, StructOpt)]
 struct Wipe {
-    /// Force wipe.
+    /// Force wipe. Required option to prevent accidental erasure
     #[structopt(long)]
     force: bool,
 

--- a/src/commands/database/catalog.rs
+++ b/src/commands/database/catalog.rs
@@ -1,0 +1,74 @@
+use std::convert::TryInto;
+
+use data_types::job::Operation;
+use generated_types::google::FieldViolation;
+use influxdb_iox_client::{
+    connection::Builder,
+    management::{self, WipePersistedCatalogError},
+};
+use snafu::{ResultExt, Snafu};
+use structopt::StructOpt;
+
+#[derive(Debug, Snafu)]
+pub enum Error {
+    #[snafu(display("Error connection to IOx: {}", source))]
+    ConnectionError {
+        source: influxdb_iox_client::connection::Error,
+    },
+
+    #[snafu(display("Error wiping persisted catalog: {}", source))]
+    WipeError { source: WipePersistedCatalogError },
+
+    #[snafu(display("Received invalid response: {}", source))]
+    InvalidResponse { source: FieldViolation },
+
+    #[snafu(display("Error rendering response as JSON: {}", source))]
+    WritingJson { source: serde_json::Error },
+}
+pub type Result<T, E = Error> = std::result::Result<T, E>;
+
+/// Manage IOx persisted catalog
+#[derive(Debug, StructOpt)]
+pub struct Config {
+    #[structopt(subcommand)]
+    command: Command,
+}
+
+/// All possible subcommands for catalog
+#[derive(Debug, StructOpt)]
+enum Command {
+    /// Wipe persisted catalog
+    Wipe(Wipe),
+}
+
+/// Wipe persisted catalog.
+#[derive(Debug, StructOpt)]
+struct Wipe {
+    /// The name of the database
+    db_name: String,
+}
+
+pub async fn command(url: String, config: Config) -> Result<()> {
+    let connection = Builder::default()
+        .build(url)
+        .await
+        .context(ConnectionError)?;
+    let mut client = management::Client::new(connection);
+
+    match config.command {
+        Command::Wipe(wipe) => {
+            let Wipe { db_name } = wipe;
+
+            let operation: Operation = client
+                .wipe_persisted_catalog(db_name)
+                .await
+                .context(WipeError)?
+                .try_into()
+                .context(InvalidResponse)?;
+
+            serde_json::to_writer_pretty(std::io::stdout(), &operation).context(WritingJson)?;
+        }
+    }
+
+    Ok(())
+}

--- a/tests/end_to_end_cases/management_cli.rs
+++ b/tests/end_to_end_cases/management_cli.rs
@@ -597,6 +597,7 @@ async fn test_wipe_persisted_catalog() {
             .arg(&db_name)
             .arg("--host")
             .arg(addr)
+            .arg("--force")
             .assert()
             .success()
             .get_output()
@@ -615,7 +616,26 @@ async fn test_wipe_persisted_catalog() {
 }
 
 #[tokio::test]
-async fn test_wipe_persisted_catalog_error() {
+async fn test_wipe_persisted_catalog_error_force() {
+    let server_fixture = ServerFixture::create_shared().await;
+    let addr = server_fixture.grpc_base();
+    let db_name = rand_name();
+
+    Command::cargo_bin("influxdb_iox")
+        .unwrap()
+        .arg("database")
+        .arg("catalog")
+        .arg("wipe")
+        .arg(&db_name)
+        .arg("--host")
+        .arg(addr)
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("Need to pass `--force`"));
+}
+
+#[tokio::test]
+async fn test_wipe_persisted_catalog_error_db_exists() {
     let server_fixture = ServerFixture::create_shared().await;
     let addr = server_fixture.grpc_base();
     let db_name = rand_name();
@@ -630,6 +650,7 @@ async fn test_wipe_persisted_catalog_error() {
         .arg(&db_name)
         .arg("--host")
         .arg(addr)
+        .arg("--force")
         .assert()
         .failure()
         .stderr(predicate::str::contains("Database already exists"));


### PR DESCRIPTION
TBH I am not entirely happy with restricting the wipe to DBs that do not exist, however I don't know what we should do otherwise. Doing it "online" would require that we basically wipe all parquet files from the in-mem catalog as well and pause all object store IOs during the wipe. Since I expect a wipe to be require only if the DB cannot start up because of a broken catalog, I think even with this restriction this CLI command is still very useful.

Note that I have implemented that on the server side because:

- the client (or human operator) might not have storage credentials
- human operators might act over messy connections which can really bottleneck deleting thousands of files from object store quickly to get a DB back up and running
- the client might have not permissions to interact with the object store (I think our current VPN setup and cloud setup allows staff to access the object store, but that might change in the future so that only the K8s cluster is allowed to interact with the buckets)