### PR TITLE
refactor: Chunks can have at most one object store path

### DIFF
--- a/server/src/db.rs
+++ b/server/src/db.rs
@@ -1849,7 +1849,7 @@ mod tests {
         // Verify data written to the parquet file in object store
         //
         // First, there must be one path of object store in the catalog
-        let paths = pq_chunk.object_store_paths();
+        let paths = pq_chunk.object_store_path();
         assert_eq!(paths.len(), 1);
 
         // Check that the path must exist in the object store
@@ -1977,7 +1977,7 @@ mod tests {
         // Verify data written to the parquet file in object store
         //
         // First, there must be one path of object store in the catalog
-        let paths = pq_chunk.object_store_paths();
+        let paths = pq_chunk.object_store_path();
         assert_eq!(paths.len(), 1);
 
         // Check that the path must exist in the object store

--- a/server/src/db.rs
+++ b/server/src/db.rs
@@ -1849,15 +1849,14 @@ mod tests {
         // Verify data written to the parquet file in object store
         //
         // First, there must be one path of object store in the catalog
-        let paths = pq_chunk.object_store_path();
-        assert_eq!(paths.len(), 1);
+        let path = pq_chunk.object_store_path().unwrap();
 
         // Check that the path must exist in the object store
-        let path_list = flatten_list_stream(Arc::clone(&object_store), Some(&paths[0]))
+        let path_list = flatten_list_stream(Arc::clone(&object_store), Some(&path))
             .await
             .unwrap();
         assert_eq!(path_list.len(), 1);
-        assert_eq!(path_list, paths.clone());
+        assert_eq!(path_list[0], path);
 
         // Now read data from that path
         let parquet_data = load_parquet_from_store_for_path(&path_list[0], object_store)
@@ -1977,16 +1976,15 @@ mod tests {
         // Verify data written to the parquet file in object store
         //
         // First, there must be one path of object store in the catalog
-        let paths = pq_chunk.object_store_path();
-        assert_eq!(paths.len(), 1);
+        let path = pq_chunk.object_store_path().unwrap();
 
         // Check that the path must exist in the object store
-        let path_list = flatten_list_stream(Arc::clone(&object_store), Some(&paths[0]))
+        let path_list = flatten_list_stream(Arc::clone(&object_store), Some(&path))
             .await
             .unwrap();
         println!("path_list: {:#?}", path_list);
         assert_eq!(path_list.len(), 1);
-        assert_eq!(path_list, paths.clone());
+        assert_eq!(path_list[0], path);
 
         // Now read data from that path
         let parquet_data = load_parquet_from_store_for_path(&path_list[0], object_store)

--- a/server/src/db/chunk.rs
+++ b/server/src/db/chunk.rs
@@ -146,11 +146,12 @@ impl DbChunk {
         })
     }
 
-    /// Return object store paths
-    pub fn object_store_paths(&self) -> Vec<Path> {
+    /// Return the Path in ObjectStorage where this chunk is
+    /// persisted, if any
+    pub fn object_store_path(&self) -> Option<Path> {
         match &self.state {
-            State::ParquetFile { chunk } => vec![chunk.table_path()],
-            _ => vec![],
+            State::ParquetFile { chunk } => Some(chunk.table_path()),
+            _ => None,
         }
     }
 }


### PR DESCRIPTION

# Rationale
Ran into this while preparing to cache schema

# Changes
Make it clear chunk can have at most 1 path in object store
