### PR TITLE
feat: Cache TableSummary, Schema in chunks

### DIFF
--- a/parquet_file/src/chunk.rs
+++ b/parquet_file/src/chunk.rs
@@ -122,11 +122,16 @@ impl Chunk {
         self.table.size() + self.partition_key.len() + mem::size_of::<Self>()
     }
 
-    /// Return Schema for the table in this chunk
+    /// Return possibly restricted Schema for the table in this chunk
     pub fn table_schema(&self, selection: Selection<'_>) -> Result<Schema> {
         self.table.schema(selection).context(NamedTableError {
             table_name: self.table_name(),
         })
+    }
+
+    /// Infallably return the full schema (for all columns) for this chunk
+    pub fn full_schema(&self) -> Arc<Schema> {
+        self.table.full_schema()
     }
 
     // Return all tables of this chunk whose timestamp overlaps with the give one

--- a/parquet_file/src/table.rs
+++ b/parquet_file/src/table.rs
@@ -42,7 +42,7 @@ pub struct Table {
     object_store: Arc<ObjectStore>,
 
     /// Schema that goes with this table's parquet file
-    table_schema: Schema,
+    table_schema: Arc<Schema>,
 
     /// Timestamp range of this table's parquet file
     /// (extracted from TableSummary)
@@ -62,7 +62,7 @@ impl Table {
             table_summary: Arc::new(table_summary),
             object_store_path: path,
             object_store: store,
-            table_schema: schema,
+            table_schema: Arc::new(schema),
             timestamp_range,
         }
     }
@@ -80,7 +80,7 @@ impl Table {
         mem::size_of::<Self>()
             + self.table_summary.size()
             + mem::size_of_val(&self.object_store_path)
-            + mem::size_of_val(&self.table_schema)
+            + mem::size_of_val(&self.table_schema.as_ref())
     }
 
     /// Return name of this table
@@ -96,12 +96,17 @@ impl Table {
     /// Return schema of this table for specified selection columns
     pub fn schema(&self, selection: Selection<'_>) -> Result<Schema> {
         Ok(match selection {
-            Selection::All => self.table_schema.clone(),
+            Selection::All => self.table_schema.as_ref().clone(),
             Selection::Some(columns) => {
                 let columns = self.table_schema.select(columns).context(SelectColumns)?;
                 self.table_schema.project(&columns)
             }
         })
+    }
+
+    /// Infallably return the full schema (for all columns) for this chunk
+    pub fn full_schema(&self) -> Arc<Schema> {
+        Arc::clone(&self.table_schema)
     }
 
     // Check if 2 time ranges overlap

--- a/server/src/db.rs
+++ b/server/src/db.rs
@@ -2095,12 +2095,14 @@ mod tests {
         assert!(matches!(
             chunks[0].read().stage(),
             ChunkStage::Frozen(ChunkStageFrozen {
+                meta: _,
                 representation: ChunkStageFrozenRepr::MutableBufferSnapshot(_)
             })
         ));
         assert!(matches!(
             chunks[1].read().stage(),
             ChunkStage::Frozen(ChunkStageFrozen {
+                meta: _,
                 representation: ChunkStageFrozenRepr::MutableBufferSnapshot(_)
             })
         ));
@@ -2952,7 +2954,8 @@ mod tests {
                 chunk.stage(),
                 ChunkStage::Persisted(ChunkStagePersisted {
                     parquet: _,
-                    read_buffer: None
+                    read_buffer: None,
+                    meta: _,
                 })
             ));
         }

--- a/server/src/db/lifecycle.rs
+++ b/server/src/db/lifecycle.rs
@@ -198,7 +198,8 @@ trait ChunkMover {
                             && matches!(
                                 chunk_guard.stage(),
                                 ChunkStage::Frozen(ChunkStageFrozen {
-                                    representation: ChunkStageFrozenRepr::ReadBuffer(_)
+                                    representation: ChunkStageFrozenRepr::ReadBuffer(_),
+                                    meta: _,
                                 })
                             ))
                             || matches!(chunk_guard.stage(), ChunkStage::Persisted(_))


### PR DESCRIPTION
# Rationale
In order to prune chunks in https://github.com/influxdata/influxdb_iox/pull/1567 I need access to the `TableSummary` (statistics) and `Schema` for `DbChunk`. I don't want to re-compute these structures once per chunk considered for query and 

My longer term plan / vision is to answer all "metadata" queries (that don't have predicates) in DbChunk using the metadata in `ChunkMetadata`.

# Changes
1. Cache `ChunkMetadata` on each `catalog::Chunk` and copy it to `DbChunk`
2. Use   `ChunkMetadata` in DBChunk for schema queries

