### PR TITLE
refactor: remove `ChunkState::Invalid`

### DIFF
--- a/server/src/db/chunk.rs
+++ b/server/src/db/chunk.rs
@@ -93,9 +93,6 @@ impl DbChunk {
         use super::catalog::chunk::ChunkState;
 
         let state = match chunk.state() {
-            ChunkState::Invalid => {
-                panic!("Invalid internal state");
-            }
             ChunkState::Open(chunk) => State::MutableBuffer {
                 chunk: chunk.snapshot(),
             },


### PR DESCRIPTION
This seems to only exist to fight the borrow checker and we can actually
live without it.
