### PR TITLE
chore: remove unused sqlparser dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -921,7 +921,7 @@ dependencies = [
  "pin-project-lite",
  "rand 0.8.3",
  "smallvec",
- "sqlparser 0.9.0",
+ "sqlparser",
  "tokio",
  "tokio-stream",
 ]
@@ -3020,7 +3020,6 @@ dependencies = [
  "parking_lot",
  "regex",
  "snafu",
- "sqlparser 0.8.0",
  "test_helpers",
  "tokio",
  "tokio-stream",
@@ -3870,15 +3869,6 @@ name = "spin"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
-
-[[package]]
-name = "sqlparser"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b929a9577d01ee7cddb820696ed536868d81557d3c14363a7514d71add1d058"
-dependencies = [
- "log",
-]
 
 [[package]]
 name = "sqlparser"

--- a/query/Cargo.toml
+++ b/query/Cargo.toml
@@ -29,7 +29,6 @@ metrics = { path = "../metrics" }
 parking_lot = "0.11.1"
 regex = "1"
 snafu = "0.6.3"
-sqlparser = "0.8.0"
 tokio = { version = "1.0", features = ["macros"] }
 tokio-stream = "0.1.2"
 tracker = { path = "../tracker" }

--- a/query/src/frontend/sql.rs
+++ b/query/src/frontend/sql.rs
@@ -12,12 +12,6 @@ pub enum Error {
     #[snafu(display("Error preparing query {}", source))]
     Preparing { source: crate::exec::context::Error },
 
-    #[snafu(display("Invalid sql query: {} : {}", query, source))]
-    InvalidSqlQuery {
-        query: String,
-        source: sqlparser::parser::ParserError,
-    },
-
     #[snafu(display("Internal Error creating memtable for table {}: {}", table, source))]
     InternalMemTableCreation {
         table: String,


### PR DESCRIPTION
# Rationale
While waiting for `server` to compile, I am trying to reduce compile times...

The `sqlparser` dependency is no longer used directly in IOx (it is used indirectly via datafusion). Furthermore IOx used a different version than pinned in `datafusion` so this reduces (by one) the number of things to compile

