### PR TITLE
chore: remove (moar!) unused dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -169,7 +169,6 @@ version = "0.1.0"
 dependencies = [
  "ahash 0.7.4",
  "arrow",
- "futures",
  "hashbrown 0.11.2",
  "num-traits",
  "rand 0.8.3",
@@ -890,7 +889,6 @@ dependencies = [
  "percent-encoding",
  "regex",
  "serde",
- "serde_regex",
  "snafu",
  "test_helpers",
 ]
@@ -1340,7 +1338,6 @@ version = "0.1.0"
 dependencies = [
  "bytes",
  "data_types",
- "flatbuffers",
  "futures",
  "google_types",
  "observability_deps",
@@ -1408,7 +1405,6 @@ dependencies = [
  "prost",
  "prost-build",
  "serde",
- "serde_json",
 ]
 
 [[package]]
@@ -1681,7 +1677,6 @@ dependencies = [
  "internal_types",
  "itertools 0.9.0",
  "logfmt",
- "mem_qe",
  "metrics",
  "mutable_buffer",
  "num_cpus",
@@ -1723,7 +1718,6 @@ dependencies = [
  "tonic-reflection",
  "tracing-opentelemetry",
  "tracker",
- "write_buffer",
 ]
 
 [[package]]
@@ -2147,7 +2141,6 @@ dependencies = [
  "snafu",
  "test_helpers",
  "tokio",
- "tracker",
 ]
 
 [[package]]
@@ -2641,7 +2634,6 @@ dependencies = [
  "parquet",
  "parquet-format",
  "prost",
- "prost-types",
  "query",
  "serde",
  "serde_json",
@@ -3193,14 +3185,12 @@ dependencies = [
  "itertools 0.9.0",
  "metrics",
  "observability_deps",
- "packers",
  "parking_lot",
  "permutation",
  "rand 0.8.3",
  "rand_distr",
  "snafu",
  "test_helpers",
- "tracker",
 ]
 
 [[package]]
@@ -3671,16 +3661,6 @@ dependencies = [
  "indexmap",
  "itoa",
  "ryu",
- "serde",
-]
-
-[[package]]
-name = "serde_regex"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8136f1a4ea815d7eac4101cfd0b16dc0cb5e1fe1b8609dfd728058656b7badf"
-dependencies = [
- "regex",
  "serde",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,6 @@ influxdb_tsm = { path = "influxdb_tsm" }
 internal_types = { path = "internal_types" }
 ingest = { path = "ingest" }
 logfmt = { path = "logfmt" }
-mem_qe = { path = "mem_qe" }
 metrics = { path = "metrics" }
 mutable_buffer = { path = "mutable_buffer" }
 num_cpus = "1.13.0"
@@ -65,7 +64,6 @@ query = { path = "query" }
 read_buffer = { path = "read_buffer" }
 server = { path = "server" }
 tracker = { path = "tracker" }
-write_buffer = { path = "write_buffer" }
 
 # Crates.io dependencies, in alphabetical order
 arrow = { version = "4.0", features = ["prettyprint"] }

--- a/arrow_util/Cargo.toml
+++ b/arrow_util/Cargo.toml
@@ -10,7 +10,6 @@ description = "Apache Arrow utilities"
 arrow = { version = "4.0", features = ["prettyprint"] }
 ahash = "0.7.2"
 num-traits = "0.2"
-futures = "0.3"
 snafu = "0.6"
 hashbrown = "0.11"
 

--- a/data_types/Cargo.toml
+++ b/data_types/Cargo.toml
@@ -12,7 +12,6 @@ influxdb_line_protocol = { path = "../influxdb_line_protocol" }
 percent-encoding = "2.1.0"
 regex = "1.4"
 serde = { version = "1.0", features = ["rc", "derive"] }
-serde_regex = "1.1"
 snafu = "0.6"
 observability_deps = { path = "../observability_deps" }
 

--- a/generated_types/Cargo.toml
+++ b/generated_types/Cargo.toml
@@ -9,7 +9,7 @@ bytes = { version = "1.0", features = ["serde"] }
 data_types = { path = "../data_types" }
 # See docs/regenerating_flatbuffers.md about updating generated code when updating the
 # version of the flatbuffers crate
-flatbuffers = "0.8"
+#flatbuffers = "0.8"
 futures = "0.3"
 google_types = { path = "../google_types" }
 observability_deps = { path = "../observability_deps" }

--- a/google_types/Cargo.toml
+++ b/google_types/Cargo.toml
@@ -10,7 +10,6 @@ bytes = { version = "1.0", features = ["serde"] }
 chrono = "0.4"
 prost = "0.7"
 serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0.44"
 
 [build-dependencies] # In alphabetical order
 prost-build = "0.7"

--- a/mutable_buffer/Cargo.toml
+++ b/mutable_buffer/Cargo.toml
@@ -27,7 +27,6 @@ observability_deps = { path = "../observability_deps" }
 parking_lot = "0.11.1"
 snafu = "0.6.2"
 tokio = { version = "1.0", features = ["macros"] }
-tracker = { path = "../tracker" }
 
 [dev-dependencies] # In alphabetical order
 test_helpers = { path = "../test_helpers" }

--- a/parquet_file/Cargo.toml
+++ b/parquet_file/Cargo.toml
@@ -22,7 +22,6 @@ parquet = "4.0"
 parquet-format = "2.6"
 parking_lot = "0.11.1"
 prost = "0.7"
-prost-types = "0.7"
 query = { path = "../query" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/read_buffer/Cargo.toml
+++ b/read_buffer/Cargo.toml
@@ -22,11 +22,9 @@ internal_types = { path = "../internal_types" }
 itertools = "0.9.0"
 metrics = { path = "../metrics" }
 observability_deps = { path = "../observability_deps" }
-packers = { path = "../packers" }
 parking_lot = "0.11"
 permutation = "0.2.5"
 snafu = "0.6"
-tracker = { path = "../tracker" }
 
 [dev-dependencies] # In alphabetical order
 criterion = "0.3.3"


### PR DESCRIPTION
Removes some unused dependencies (found with https://github.com/est31/cargo-udeps) in a hail-mary attempt to reduce compile times
