### PR TITLE
refactor: Remove `table_name` from PartitionChunk API

### DIFF
--- a/query/src/frontend/influxrpc.rs
+++ b/query/src/frontend/influxrpc.rs
@@ -664,7 +664,7 @@ impl InfluxRpcPlanner {
                     .map_err(|e| Box::new(e) as _)
                     .context(InternalTableNamePlanForDefault)?
                     // unwrap the Option (table didn't match)
-                    .unwrap_or_else(move || no_tables)
+                    .unwrap_or(no_tables)
             }
         };
         Ok(table_names)

--- a/query/src/frontend/influxrpc.rs
+++ b/query/src/frontend/influxrpc.rs
@@ -16,7 +16,7 @@ use internal_types::{
     selection::Selection,
 };
 use observability_deps::tracing::debug;
-use snafu::{ensure, OptionExt, ResultExt, Snafu};
+use snafu::{ensure, ResultExt, Snafu};
 
 use crate::{
     exec::{field::FieldColumns, make_schema_pivot, stringset::StringSet},
@@ -65,9 +65,6 @@ pub enum Error {
     InternalTableNamePlanForDefault {
         source: Box<dyn std::error::Error + Send + Sync>,
     },
-
-    #[snafu(display("gRPC planner could not get table_names with default predicate, which should always return values"))]
-    InternalTableNameCannotGetPlanForDefault {},
 
     #[snafu(display("Unsupported predicate in gRPC table_names: {:?}", predicate))]
     UnsupportedPredicateForTableNames { predicate: Predicate },
@@ -256,7 +253,7 @@ impl InfluxRpcPlanner {
 
                 // get only tag columns from metadata
                 let schema = chunk
-                    .table_schema(&table_name, Selection::All)
+                    .table_schema(Selection::All)
                     .expect("to be able to get table schema");
                 let column_names: Vec<&str> = schema
                     .tags_iter()
@@ -267,7 +264,7 @@ impl InfluxRpcPlanner {
 
                 // filter the columns further from the predicate
                 let maybe_names = chunk
-                    .column_names(&table_name, &predicate, selection)
+                    .column_names(&predicate, selection)
                     .map_err(|e| Box::new(e) as _)
                     .context(FindingColumnNames)?;
 
@@ -360,7 +357,7 @@ impl InfluxRpcPlanner {
 
                 // use schema to validate column type
                 let schema = chunk
-                    .table_schema(&table_name, Selection::All)
+                    .table_schema(Selection::All)
                     .expect("to be able to get table schema");
 
                 // Skip this table if the tag_name is not a column in this table
@@ -391,7 +388,7 @@ impl InfluxRpcPlanner {
 
                 // try and get the list of values directly from metadata
                 let maybe_values = chunk
-                    .column_values(&table_name, tag_name, &predicate)
+                    .column_values(tag_name, &predicate)
                     .map_err(|e| Box::new(e) as _)
                     .context(FindingColumnValues)?;
 
@@ -666,8 +663,8 @@ impl InfluxRpcPlanner {
                     .table_names(&table_name_predicate, &no_tables)
                     .map_err(|e| Box::new(e) as _)
                     .context(InternalTableNamePlanForDefault)?
-                    // unwrap the Option
-                    .context(InternalTableNameCannotGetPlanForDefault)?
+                    // unwrap the Option (table didn't match)
+                    .unwrap_or_else(move || no_tables)
             }
         };
         Ok(table_names)
@@ -1120,7 +1117,7 @@ impl InfluxRpcPlanner {
             );
 
             let chunk_table_schema = chunk
-                .table_schema(table_name, selection)
+                .table_schema(selection)
                 .map_err(|e| Box::new(e) as _)
                 .context(GettingTableSchema {
                     table_name,

--- a/query/src/lib.rs
+++ b/query/src/lib.rs
@@ -92,7 +92,6 @@ pub trait PartitionChunk: Debug + Send + Sync {
     /// this Chunk. Returns `None` otherwise
     fn column_names(
         &self,
-        table_name: &str,
         predicate: &Predicate,
         columns: Selection<'_>,
     ) -> Result<Option<StringSet>, Self::Error>;
@@ -104,7 +103,6 @@ pub trait PartitionChunk: Debug + Send + Sync {
     /// The requested columns must all have String type.
     fn column_values(
         &self,
-        table_name: &str,
         column_name: &str,
         predicate: &Predicate,
     ) -> Result<Option<StringSet>, Self::Error>;
@@ -112,11 +110,7 @@ pub trait PartitionChunk: Debug + Send + Sync {
     /// Returns the Schema for a table in this chunk, with the
     /// specified column selection. An error is returned if the
     /// selection refers to columns that do not exist.
-    fn table_schema(
-        &self,
-        table_name: &str,
-        selection: Selection<'_>,
-    ) -> Result<Schema, Self::Error>;
+    fn table_schema(&self, selection: Selection<'_>) -> Result<Schema, Self::Error>;
 
     /// Provides access to raw `PartitionChunk` data as an
     /// asynchronous stream of `RecordBatch`es filtered by a *required*
@@ -133,7 +127,6 @@ pub trait PartitionChunk: Debug + Send + Sync {
     /// streams from several different `PartitionChunks`.
     fn read_filter(
         &self,
-        table_name: &str,
         predicate: &Predicate,
         selection: Selection<'_>,
     ) -> Result<SendableRecordBatchStream, Self::Error>;

--- a/query/src/provider/physical.rs
+++ b/query/src/provider/physical.rs
@@ -100,16 +100,14 @@ impl<C: PartitionChunk + 'static> ExecutionPlan for IOxReadFilterNode<C> {
         let selection_cols = restrict_selection(selection_cols, &chunk_table_schema);
         let selection = Selection::Some(&selection_cols);
 
-        let stream = chunk
-            .read_filter(&self.table_name, &self.predicate, selection)
-            .map_err(|e| {
-                DataFusionError::Execution(format!(
-                    "Error creating scan for table {} chunk {}: {}",
-                    self.table_name,
-                    chunk.id(),
-                    e
-                ))
-            })?;
+        let stream = chunk.read_filter(&self.predicate, selection).map_err(|e| {
+            DataFusionError::Execution(format!(
+                "Error creating scan for table {} chunk {}: {}",
+                self.table_name,
+                chunk.id(),
+                e
+            ))
+        })?;
 
         let adapter = SchemaAdapterStream::try_new(stream, Arc::clone(&self.schema))
             .map_err(|e| DataFusionError::Internal(e.to_string()))?;

--- a/server/src/db.rs
+++ b/server/src/db.rs
@@ -1672,9 +1672,9 @@ mod tests {
         // cpu").await; assert_batches_eq!(expected, &batches);
     }
 
-    async fn collect_read_filter(chunk: &DbChunk, table_name: &str) -> Vec<RecordBatch> {
+    async fn collect_read_filter(chunk: &DbChunk) -> Vec<RecordBatch> {
         chunk
-            .read_filter(table_name, &Default::default(), Selection::All)
+            .read_filter(&Default::default(), Selection::All)
             .unwrap()
             .collect::<Vec<_>>()
             .await
@@ -1702,7 +1702,7 @@ mod tests {
             .unwrap()
             .unwrap();
 
-        let mb = collect_read_filter(&mb_chunk, "cpu").await;
+        let mb = collect_read_filter(&mb_chunk).await;
 
         let rb_chunk = db
             .load_chunk_to_read_buffer(partition_key, "cpu", mb_chunk.id(), &Default::default())
@@ -1735,7 +1735,7 @@ mod tests {
             .sample_sum_eq(3231.0)
             .unwrap();
 
-        let rb = collect_read_filter(&rb_chunk, "cpu").await;
+        let rb = collect_read_filter(&rb_chunk).await;
 
         // Test that data on load into the read buffer is sorted
 

--- a/server/src/db/catalog.rs
+++ b/server/src/db/catalog.rs
@@ -329,13 +329,11 @@ impl SchemaProvider for Catalog {
             for chunk in partition.chunks() {
                 let chunk = chunk.read();
 
-                if chunk.table_name() == table_name {
+                if chunk.table_name().as_ref() == table_name {
                     let chunk = super::DbChunk::snapshot(&chunk);
 
                     // This should only fail if the table doesn't exist which isn't possible
-                    let schema = chunk
-                        .table_schema(table_name, Selection::All)
-                        .expect("cannot fail");
+                    let schema = chunk.table_schema(Selection::All).expect("cannot fail");
 
                     // This is unfortunate - a table with incompatible chunks ceases to
                     // be visible to the query engine
@@ -431,17 +429,17 @@ mod tests {
         let p1 = p1.write();
 
         let c1_0 = p1.chunk("table1", 0).unwrap();
-        assert_eq!(c1_0.read().table_name(), "table1");
+        assert_eq!(c1_0.read().table_name().as_ref(), "table1");
         assert_eq!(c1_0.read().key(), "p1");
         assert_eq!(c1_0.read().id(), 0);
 
         let c1_1 = p1.chunk("table1", 1).unwrap();
-        assert_eq!(c1_1.read().table_name(), "table1");
+        assert_eq!(c1_1.read().table_name().as_ref(), "table1");
         assert_eq!(c1_1.read().key(), "p1");
         assert_eq!(c1_1.read().id(), 1);
 
         let c2_0 = p1.chunk("table2", 0).unwrap();
-        assert_eq!(c2_0.read().table_name(), "table2");
+        assert_eq!(c2_0.read().table_name().as_ref(), "table2");
         assert_eq!(c2_0.read().key(), "p1");
         assert_eq!(c2_0.read().id(), 0);
 

--- a/server/src/db/catalog/chunk.rs
+++ b/server/src/db/catalog/chunk.rs
@@ -244,8 +244,8 @@ impl Chunk {
         self.partition_key.as_ref()
     }
 
-    pub fn table_name(&self) -> &str {
-        self.table_name.as_ref()
+    pub fn table_name(&self) -> Arc<str> {
+        Arc::clone(&self.table_name)
     }
 
     pub fn state(&self) -> &ChunkState {

--- a/server/src/query_tests/table_schema.rs
+++ b/server/src/query_tests/table_schema.rs
@@ -38,7 +38,7 @@ macro_rules! run_table_schema_test_case {
             for chunk in db.chunks(&predicate) {
                 if chunk.has_table(table_name) {
                     chunks_with_table += 1;
-                    let actual_schema = chunk.table_schema(table_name, selection.clone()).unwrap();
+                    let actual_schema = chunk.table_schema(selection.clone()).unwrap();
 
                     assert_eq!(
                         expected_schema,


### PR DESCRIPTION
Re https://github.com/influxdata/influxdb_iox/issues/1295

# Rationale
Once upon a time, when the world was green and fresh, chunks could have multiple tables. Now that a chunk has a single table, the API for PartitionChunk is akward

# Changes:
1. Remove `table_name` from several PartitionChunk methods and clean up uses.

Note: the `has_table`, `all_table_names` and `table_names` methods are also overly complicated (they can probably be replaced with a `table_name()` and a `could_pass_predicate` type methods, which I plan to do as a follow on PR
