### PR TITLE
chore: remove unused dependency in server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3693,7 +3693,6 @@ name = "server"
 version = "0.1.0"
 dependencies = [
  "arrow",
- "arrow-flight",
  "arrow_util",
  "async-trait",
  "bytes",

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -7,7 +7,6 @@ edition = "2018"
 [dependencies] # In alphabetical order
 arrow = { version = "4.0", features = ["prettyprint"] }
 arrow_util = { path = "../arrow_util" }
-arrow-flight = "4.0"
 async-trait = "0.1"
 bytes = { version = "1.0" }
 chrono = "0.4"


### PR DESCRIPTION
Removes unused dependency. 

Sadly, this still gets included as part of `influxdb_iox_client` so this change doesn't really affect compile time