### PR TITLE
refactor: Remove last vestiges of multi-table chunks from PartitionChunk API

### DIFF
--- a/mutable_buffer/src/chunk.rs
+++ b/mutable_buffer/src/chunk.rs
@@ -120,13 +120,6 @@ impl Chunk {
         Ok(())
     }
 
-    // Add the table name in this chunk to `names` if it is not already present
-    pub fn all_table_names(&self, names: &mut BTreeSet<String>) {
-        if !names.contains(self.table_name.as_ref()) {
-            names.insert(self.table_name.to_string());
-        }
-    }
-
     /// Returns a queryable snapshot of this chunk
     #[cfg(not(feature = "nocache"))]
     pub fn snapshot(&self) -> Arc<ChunkSnapshot> {

--- a/mutable_buffer/src/chunk/snapshot.rs
+++ b/mutable_buffer/src/chunk/snapshot.rs
@@ -72,11 +72,6 @@ impl ChunkSnapshot {
         self.batch.num_rows() == 0
     }
 
-    /// Return true if this snapshot has the specified table name
-    pub fn has_table(&self, table_name: &str) -> bool {
-        self.table_name.as_ref() == table_name
-    }
-
     /// Return Schema for the specified table / columns
     pub fn table_schema(&self, table_name: &str, selection: Selection<'_>) -> Result<Schema> {
         // Temporary #1295
@@ -102,7 +97,7 @@ impl ChunkSnapshot {
     /// Returns a list of tables with writes matching the given timestamp_range
     pub fn table_names(&self, timestamp_range: Option<TimestampRange>) -> BTreeSet<String> {
         let mut ret = BTreeSet::new();
-        if self.matches_predicate(&timestamp_range) {
+        if self.has_timerange(&timestamp_range) {
             ret.insert(self.table_name.to_string());
         }
         ret
@@ -222,7 +217,7 @@ impl ChunkSnapshot {
         self.batch.num_rows()
     }
 
-    fn matches_predicate(&self, timestamp_range: &Option<TimestampRange>) -> bool {
+    pub fn has_timerange(&self, timestamp_range: &Option<TimestampRange>) -> bool {
         let timestamp_range = match timestamp_range {
             Some(t) => t,
             None => return true,

--- a/parquet_file/src/chunk.rs
+++ b/parquet_file/src/chunk.rs
@@ -134,14 +134,9 @@ impl Chunk {
         self.table.full_schema()
     }
 
-    // Return all tables of this chunk whose timestamp overlaps with the give one
-    pub fn table_names(
-        &self,
-        timestamp_range: Option<TimestampRange>,
-    ) -> impl Iterator<Item = String> + '_ {
-        std::iter::once(&self.table)
-            .filter(move |table| table.matches_predicate(&timestamp_range))
-            .map(|table| table.name().to_string())
+    // Return true if the table in this chunk contains values within the time range
+    pub fn has_timerange(&self, timestamp_range: Option<&TimestampRange>) -> bool {
+        self.table.matches_predicate(timestamp_range)
     }
 
     // Return the columns names that belong to the given column

--- a/parquet_file/src/table.rs
+++ b/parquet_file/src/table.rs
@@ -110,7 +110,7 @@ impl Table {
     }
 
     // Check if 2 time ranges overlap
-    pub fn matches_predicate(&self, timestamp_range: &Option<TimestampRange>) -> bool {
+    pub fn matches_predicate(&self, timestamp_range: Option<&TimestampRange>) -> bool {
         match (self.timestamp_range, timestamp_range) {
             (Some(a), Some(b)) => !a.disjoint(b),
             (None, Some(_)) => false, /* If this chunk doesn't have a time column it can't match */

--- a/query/src/frontend/influxrpc.rs
+++ b/query/src/frontend/influxrpc.rs
@@ -19,7 +19,7 @@ use observability_deps::tracing::debug;
 use snafu::{ensure, ResultExt, Snafu};
 
 use crate::{
-    exec::{field::FieldColumns, make_schema_pivot, stringset::StringSet},
+    exec::{field::FieldColumns, make_schema_pivot},
     func::{
         selectors::{selector_first, selector_last, selector_max, selector_min, SelectorOutput},
         window::make_window_bound_expr,
@@ -30,7 +30,7 @@ use crate::{
         seriesset::{SeriesSetPlan, SeriesSetPlans},
         stringset::{Error as StringSetError, StringSetPlan, StringSetPlanBuilder},
     },
-    predicate::{Predicate, PredicateBuilder},
+    predicate::{Predicate, PredicateMatch},
     provider::ProviderBuilder,
     util::schema_has_all_expr_columns,
     Database, PartitionChunk,
@@ -196,21 +196,23 @@ impl InfluxRpcPlanner {
         let mut builder = StringSetPlanBuilder::new();
 
         for chunk in database.chunks(&predicate) {
-            let new_table_names = chunk
-                .table_names(&predicate, builder.known_strings())
-                .map_err(|e| Box::new(e) as _)
-                .context(TableNamePlan)?;
-
-            builder = match new_table_names {
-                Some(new_table_names) => builder.append(new_table_names.into()),
-                None => {
+            builder = match chunk.apply_predicate(&predicate) {
+                PredicateMatch::AtLeastOne => builder.append_table(chunk.table_name()),
+                // no match, ignore table
+                PredicateMatch::Zero => builder,
+                // can't evaluate predicate, need a new plan
+                PredicateMatch::Unknown => {
                     // TODO: General purpose plans for
-                    // table_names. For now, if we couldn't figure out
-                    // the table names from only metadata, generate an
-                    // error
+                    // table_names. For now, return an error
+                    debug!(
+                        chunk = chunk.id(),
+                        ?predicate,
+                        table_name = chunk.table_name(),
+                        "can not evaluate predicate"
+                    );
                     return UnsupportedPredicateForTableNames { predicate }.fail();
                 }
-            }
+            };
         }
 
         let plan = builder.build().context(CreatingStringSet)?;
@@ -241,51 +243,51 @@ impl InfluxRpcPlanner {
 
         let mut known_columns = BTreeSet::new();
         for chunk in database.chunks(&predicate) {
-            // try and get the table names that have rows that match the predicate
-            let table_names = self.chunk_table_names(chunk.as_ref(), &predicate)?;
+            if matches!(chunk.apply_predicate(&predicate), PredicateMatch::Zero) {
+                continue;
+            }
+            let table_name = chunk.table_name();
 
-            for table_name in table_names {
-                debug!(
-                    table_name = table_name.as_str(),
-                    chunk_id = chunk.id(),
-                    "finding columns in table"
-                );
+            debug!(
+                table_name,
+                chunk_id = chunk.id(),
+                "finding columns in table"
+            );
 
-                // get only tag columns from metadata
-                let schema = chunk
-                    .table_schema(Selection::All)
-                    .expect("to be able to get table schema");
-                let column_names: Vec<&str> = schema
-                    .tags_iter()
-                    .map(|f| f.name().as_str())
-                    .collect::<Vec<&str>>();
+            // get only tag columns from metadata
+            let schema = chunk
+                .table_schema(Selection::All)
+                .expect("to be able to get table schema");
+            let column_names: Vec<&str> = schema
+                .tags_iter()
+                .map(|f| f.name().as_str())
+                .collect::<Vec<&str>>();
 
-                let selection = Selection::Some(&column_names);
+            let selection = Selection::Some(&column_names);
 
-                // filter the columns further from the predicate
-                let maybe_names = chunk
-                    .column_names(&predicate, selection)
-                    .map_err(|e| Box::new(e) as _)
-                    .context(FindingColumnNames)?;
+            // filter the columns further from the predicate
+            let maybe_names = chunk
+                .column_names(&predicate, selection)
+                .map_err(|e| Box::new(e) as _)
+                .context(FindingColumnNames)?;
 
-                match maybe_names {
-                    Some(mut names) => {
-                        debug!(names=?names, chunk_id = chunk.id(), "column names found from metadata");
-                        known_columns.append(&mut names);
-                    }
-                    None => {
-                        debug!(
-                            table_name = table_name.as_str(),
-                            chunk_id = chunk.id(),
-                            "column names need full plan"
-                        );
-                        // can't get columns only from metadata, need
-                        // a general purpose plan
-                        need_full_plans
-                            .entry(table_name)
-                            .or_insert_with(Vec::new)
-                            .push(Arc::clone(&chunk));
-                    }
+            match maybe_names {
+                Some(mut names) => {
+                    debug!(names=?names, chunk_id = chunk.id(), "column names found from metadata");
+                    known_columns.append(&mut names);
+                }
+                None => {
+                    debug!(
+                        table_name,
+                        chunk_id = chunk.id(),
+                        "column names need full plan"
+                    );
+                    // can't get columns only from metadata, need
+                    // a general purpose plan
+                    need_full_plans
+                        .entry(table_name.to_string())
+                        .or_insert_with(Vec::new)
+                        .push(Arc::clone(&chunk));
                 }
             }
         }
@@ -346,70 +348,71 @@ impl InfluxRpcPlanner {
 
         let mut known_values = BTreeSet::new();
         for chunk in database.chunks(&predicate) {
-            let table_names = self.chunk_table_names(chunk.as_ref(), &predicate)?;
+            if matches!(chunk.apply_predicate(&predicate), PredicateMatch::Zero) {
+                continue;
+            }
+            let table_name = chunk.table_name();
 
-            for table_name in table_names {
-                debug!(
-                    table_name = table_name.as_str(),
-                    chunk_id = chunk.id(),
-                    "finding columns in table"
-                );
+            debug!(
+                table_name,
+                chunk_id = chunk.id(),
+                "finding columns in table"
+            );
 
-                // use schema to validate column type
-                let schema = chunk
-                    .table_schema(Selection::All)
-                    .expect("to be able to get table schema");
+            // use schema to validate column type
+            let schema = chunk
+                .table_schema(Selection::All)
+                .expect("to be able to get table schema");
 
-                // Skip this table if the tag_name is not a column in this table
-                let idx = if let Some(idx) = schema.find_index_of(tag_name) {
-                    idx
-                } else {
-                    continue;
-                };
+            // Skip this table if the tag_name is not a column in this table
+            let idx = if let Some(idx) = schema.find_index_of(tag_name) {
+                idx
+            } else {
+                continue;
+            };
 
-                // Validate that this really is a Tag column
-                let (influx_column_type, field) = schema.field(idx);
-                ensure!(
-                    matches!(influx_column_type, Some(InfluxColumnType::Tag)),
-                    InvalidTagColumn {
-                        tag_name,
-                        influx_column_type,
-                    }
-                );
-                ensure!(
-                    influx_column_type
-                        .unwrap()
-                        .valid_arrow_type(field.data_type()),
-                    InternalInvalidTagType {
-                        tag_name,
-                        data_type: field.data_type().clone(),
-                    }
-                );
+            // Validate that this really is a Tag column
+            let (influx_column_type, field) = schema.field(idx);
+            ensure!(
+                matches!(influx_column_type, Some(InfluxColumnType::Tag)),
+                InvalidTagColumn {
+                    tag_name,
+                    influx_column_type,
+                }
+            );
+            ensure!(
+                influx_column_type
+                    .unwrap()
+                    .valid_arrow_type(field.data_type()),
+                InternalInvalidTagType {
+                    tag_name,
+                    data_type: field.data_type().clone(),
+                }
+            );
 
-                // try and get the list of values directly from metadata
-                let maybe_values = chunk
-                    .column_values(tag_name, &predicate)
-                    .map_err(|e| Box::new(e) as _)
-                    .context(FindingColumnValues)?;
+            // try and get the list of values directly from metadata
+            let maybe_values = chunk
+                .column_values(tag_name, &predicate)
+                .map_err(|e| Box::new(e) as _)
+                .context(FindingColumnValues)?;
 
-                match maybe_values {
-                    Some(mut names) => {
-                        debug!(names=?names, chunk_id = chunk.id(), "column values found from metadata");
-                        known_values.append(&mut names);
-                    }
-                    None => {
-                        debug!(
-                            table_name = table_name.as_str(),
-                            chunk_id = chunk.id(),
-                            "need full plan to find column values"
-                        );
-                        // can't get columns only from metadata, need
-                        // a general purpose plan
-                        need_full_plans
-                            .entry(table_name)
-                            .or_insert_with(Vec::new)
-                            .push(Arc::clone(&chunk));
-                    }
+            match maybe_values {
+                Some(mut names) => {
+                    debug!(names=?names, chunk_id = chunk.id(), "column values found from metadata");
+                    known_values.append(&mut names);
+                }
+                None => {
+                    debug!(
+                        table_name,
+                        chunk_id = chunk.id(),
+                        "need full plan to find column values"
+                    );
+                    // can't get columns only from metadata, need
+                    // a general purpose plan
+                    need_full_plans
+                        .entry(table_name.to_string())
+                        .or_insert_with(Vec::new)
+                        .push(Arc::clone(&chunk));
                 }
             }
         }
@@ -609,7 +612,7 @@ impl InfluxRpcPlanner {
         Ok(ss_plans.into())
     }
 
-    /// Creates a map of table_name --> Chunks that have that table
+    /// Creates a map of table_name --> Chunks that have that table that *may* pass the predicate
     fn group_chunks_by_table<C>(
         &self,
         predicate: &Predicate,
@@ -620,54 +623,22 @@ impl InfluxRpcPlanner {
     {
         let mut table_chunks = BTreeMap::new();
         for chunk in chunks {
-            let table_names = self.chunk_table_names(chunk.as_ref(), &predicate)?;
-            for table_name in table_names {
-                table_chunks
-                    .entry(table_name)
-                    .or_insert_with(Vec::new)
-                    .push(Arc::clone(&chunk));
+            match chunk.apply_predicate(predicate) {
+                PredicateMatch::AtLeastOne |
+                // have to include chunk as we can't rule it out
+                PredicateMatch::Unknown => {
+                    let table_name = chunk.table_name().to_string();
+                    table_chunks
+                        .entry(table_name)
+                        .or_insert_with(Vec::new)
+                        .push(Arc::clone(&chunk));
+                }
+                // Skip chunk here based on metadata
+                PredicateMatch::Zero => {
+                }
             }
         }
         Ok(table_chunks)
-    }
-
-    /// Find all the table names in the specified chunk that pass the predicate
-    fn chunk_table_names<C>(&self, chunk: &C, predicate: &Predicate) -> Result<BTreeSet<String>>
-    where
-        C: PartitionChunk + 'static,
-    {
-        let no_tables = StringSet::new();
-
-        // try and get the table names that have rows that match the predicate
-        let table_names = chunk
-            .table_names(&predicate, &no_tables)
-            .map_err(|e| Box::new(e) as _)
-            .context(TableNamePlan)?;
-
-        debug!(table_names=?table_names, chunk_id = chunk.id(), "chunk tables");
-
-        let table_names = match table_names {
-            Some(table_names) => {
-                debug!("found table names with original predicate");
-                table_names
-            }
-            None => {
-                // couldn't find table names with predicate, get all chunk tables,
-                // fall back to filtering ourself
-                let table_name_predicate = if let Some(table_names) = &predicate.table_names {
-                    PredicateBuilder::new().tables(table_names).build()
-                } else {
-                    Predicate::default()
-                };
-                chunk
-                    .table_names(&table_name_predicate, &no_tables)
-                    .map_err(|e| Box::new(e) as _)
-                    .context(InternalTableNamePlanForDefault)?
-                    // unwrap the Option (table didn't match)
-                    .unwrap_or(no_tables)
-            }
-        };
-        Ok(table_names)
     }
 
     /// Creates a DataFusion LogicalPlan that returns column *names* as a
@@ -1109,11 +1080,11 @@ impl InfluxRpcPlanner {
             let chunk_id = chunk.id();
 
             // check that it is consistent with this table_name
-            assert!(
-                chunk.has_table(table_name),
-                "Chunk {} did not have table {}, while trying to make a plan for it",
+            assert_eq!(
+                chunk.table_name(),
+                table_name,
+                "Chunk {} expected table mismatch",
                 chunk.id(),
-                table_name
             );
 
             let chunk_table_schema = chunk

--- a/query/src/lib.rs
+++ b/query/src/lib.rs
@@ -11,6 +11,7 @@ use data_types::chunk_metadata::ChunkSummary;
 use datafusion::physical_plan::SendableRecordBatchStream;
 use exec::{stringset::StringSet, Executor};
 use internal_types::{schema::Schema, selection::Selection};
+use predicate::PredicateMatch;
 
 use std::{fmt::Debug, sync::Arc};
 
@@ -59,32 +60,16 @@ pub trait PartitionChunk: Debug + Send + Sync {
     /// particular partition.
     fn id(&self) -> u32;
 
-    /// Returns true if this chunk contains data for the specified table
-    fn has_table(&self, table_name: &str) -> bool;
+    /// Returns the name of the table stored in this chunk
+    fn table_name(&self) -> &str;
 
-    /// Returns all table names from this chunk that have at least one
-    /// row that matches the `predicate` and are not already in `known_tables`.
+    /// Returns the result of applying the `predicate` to the chunk
+    /// using an efficient, but inexact method, based on metadata.
     ///
-    /// If the predicate cannot be evaluated (e.g it has predicates
-    /// that cannot be directly evaluated in the chunk), `None` is
-    /// returned.
-    ///
-    /// `known_tables` is a list of table names already known to be in
-    /// other chunks from the same partition. It may be empty or
-    /// contain `table_names` not in this chunk.
-    fn table_names(
-        &self,
-        predicate: &Predicate,
-        known_tables: &StringSet,
-    ) -> Result<Option<StringSet>, Self::Error>;
-
-    /// Adds all table names from this chunk without any predicate to
-    /// `known_tables)
-    ///
-    /// `known_tables` is a list of table names already known to be in
-    /// other chunks from the same partition. It may be empty or
-    /// contain `table_names` not in this chunk.
-    fn all_table_names(&self, known_tables: &mut StringSet);
+    /// NOTE: This method is suitable for calling during planning, and
+    /// may return PredicateMatch::Unknown for certain types pf
+    /// predicates.
+    fn apply_predicate(&self, predicate: &Predicate) -> PredicateMatch;
 
     /// Returns a set of Strings with column names from the specified
     /// table that have at least one row that matches `predicate`, if

--- a/query/src/lib.rs
+++ b/query/src/lib.rs
@@ -67,9 +67,9 @@ pub trait PartitionChunk: Debug + Send + Sync {
     /// using an efficient, but inexact method, based on metadata.
     ///
     /// NOTE: This method is suitable for calling during planning, and
-    /// may return PredicateMatch::Unknown for certain types pf
+    /// may return PredicateMatch::Unknown for certain types of
     /// predicates.
-    fn apply_predicate(&self, predicate: &Predicate) -> PredicateMatch;
+    fn apply_predicate(&self, predicate: &Predicate) -> Result<PredicateMatch, Self::Error>;
 
     /// Returns a set of Strings with column names from the specified
     /// table that have at least one row that matches `predicate`, if

--- a/query/src/plan/stringset.rs
+++ b/query/src/plan/stringset.rs
@@ -101,6 +101,14 @@ impl StringSetPlanBuilder {
         &self.strings
     }
 
+    /// Append the name of a table to the known strings
+    pub fn append_table(mut self, table_name: &str) -> Self {
+        if !self.strings.contains(table_name) {
+            self.strings.insert(table_name.to_string());
+        }
+        self
+    }
+
     /// Append the strings from the passed plan into ourselves if possible, or
     /// passes on the plan
     pub fn append(mut self, other: StringSetPlan) -> Self {

--- a/query/src/predicate.rs
+++ b/query/src/predicate.rs
@@ -28,6 +28,20 @@ pub const EMPTY_PREDICATE: Predicate = Predicate {
     partition_key: None,
 };
 
+#[derive(Debug, Clone, Copy)]
+/// The result of evaluating a predicate on a set of rows
+pub enum PredicateMatch {
+    /// There is at least one row that matches the predicate
+    AtLeastOne,
+
+    /// There are exactly zero rows that match the predicate
+    Zero,
+
+    /// There *may* be rows that match, OR there *may* be no rows that
+    /// match
+    Unknown,
+}
+
 /// Represents a parsed predicate for evaluation by the
 /// TSDatabase InfluxDB IOx query engine.
 ///

--- a/query/src/test.rs
+++ b/query/src/test.rs
@@ -317,7 +317,7 @@ impl PartitionChunk for TestChunk {
     }
 
     fn table_name(&self) -> &str {
-        self.table_name.as_ref().map(|s| s.as_str()).unwrap()
+        self.table_name.as_deref().unwrap()
     }
 
     fn read_filter(

--- a/server/src/db/catalog/chunk.rs
+++ b/server/src/db/catalog/chunk.rs
@@ -281,13 +281,7 @@ impl Chunk {
         metrics: ChunkMetrics,
     ) -> Self {
         // workaround until https://github.com/influxdata/influxdb_iox/issues/1295 is fixed
-        let table_name = Arc::from(
-            chunk
-                .table_names(None)
-                .next()
-                .expect("chunk must have exactly 1 table")
-                .as_ref(),
-        );
+        let table_name = Arc::from(chunk.table_name());
 
         // Cache table summary + schema
         let meta = Arc::new(ChunkMetadata {

--- a/server/src/db/catalog/chunk.rs
+++ b/server/src/db/catalog/chunk.rs
@@ -280,7 +280,6 @@ impl Chunk {
         chunk: Arc<parquet_file::chunk::Chunk>,
         metrics: ChunkMetrics,
     ) -> Self {
-        // workaround until https://github.com/influxdata/influxdb_iox/issues/1295 is fixed
         let table_name = Arc::from(chunk.table_name());
 
         // Cache table summary + schema

--- a/server/src/db/catalog/partition.rs
+++ b/server/src/db/catalog/partition.rs
@@ -133,11 +133,7 @@ impl Partition {
         chunk_id: u32,
         chunk: Arc<parquet_file::chunk::Chunk>,
     ) -> Result<Arc<RwLock<Chunk>>> {
-        // workaround until https://github.com/influxdata/influxdb_iox/issues/1295 is fixed
-        let table_name = chunk
-            .table_names(None)
-            .next()
-            .expect("chunk must have exactly 1 table");
+        let table_name = chunk.table_name().to_string();
 
         let chunk = Arc::new(self.metrics.new_lock(Chunk::new_object_store_only(
             chunk_id,

--- a/server/src/db/chunk.rs
+++ b/server/src/db/chunk.rs
@@ -12,7 +12,11 @@ use mutable_buffer::chunk::snapshot::ChunkSnapshot;
 use object_store::path::Path;
 use observability_deps::tracing::debug;
 use parquet_file::chunk::Chunk as ParquetChunk;
-use query::{exec::stringset::StringSet, predicate::Predicate, PartitionChunk};
+use query::{
+    exec::stringset::StringSet,
+    predicate::{Predicate, PredicateMatch},
+    PartitionChunk,
+};
 use read_buffer::Chunk as ReadBufferChunk;
 
 use super::{
@@ -196,26 +200,31 @@ impl PartitionChunk for DbChunk {
         self.id
     }
 
-    fn all_table_names(&self, known_tables: &mut StringSet) {
-        // TODO remove this function (use name from TableSummary directly!)
-        let table_name = &self.meta.table_summary.name;
-        if !known_tables.contains(table_name) {
-            known_tables.insert(table_name.to_string());
-        }
+    fn table_name(&self) -> &str {
+        self.table_name.as_ref()
     }
 
-    fn table_names(
-        &self,
-        predicate: &Predicate,
-        _known_tables: &StringSet, // TODO: Should this be being used?
-    ) -> Result<Option<StringSet>, Self::Error> {
-        let names = match &self.state {
+    fn apply_predicate(&self, predicate: &Predicate) -> PredicateMatch {
+        if !predicate.should_include_table(self.table_name().as_ref()) {
+            return PredicateMatch::Zero;
+        }
+
+        // TODO apply predicate pruning here...
+
+        match &self.state {
             State::MutableBuffer { chunk, .. } => {
                 if predicate.has_exprs() {
                     // TODO: Support more predicates
-                    return Ok(None);
+                    PredicateMatch::Unknown
+                } else if chunk.has_timerange(&predicate.range) {
+                    // TODO: this isn't precise (correct?) -- if the
+                    // chunk has the timerange, some other part of the
+                    // predicate may rule out the rows -- it should
+                    // really be "Unknown"
+                    PredicateMatch::AtLeastOne
+                } else {
+                    PredicateMatch::Zero
                 }
-                chunk.table_names(predicate.range)
             }
             State::ReadBuffer { chunk, .. } => {
                 // If not supported, ReadBuffer can't answer with
@@ -224,23 +233,33 @@ impl PartitionChunk for DbChunk {
                     Ok(rb_predicate) => rb_predicate,
                     Err(e) => {
                         debug!(?predicate, %e, "read buffer predicate not supported for table_names, falling back");
-                        return Ok(None);
+                        return PredicateMatch::Unknown;
                     }
                 };
 
-                chunk.table_names(&rb_predicate, &BTreeSet::new())
+                // TODO align API in read_buffer
+                let table_names = chunk.table_names(&rb_predicate, &BTreeSet::new());
+                if table_names.len() > 0 {
+                    // As above, this should really be "Unknown" rather than AtLeastOne
+                    // for precision / correctness.
+                    PredicateMatch::AtLeastOne
+                } else {
+                    PredicateMatch::Zero
+                }
             }
-            State::ParquetFile { chunk, .. } => chunk.table_names(predicate.range).collect(),
-        };
-
-        // Prune out tables that should not be
-        // present (based on additional table restrictions of the Predicate)
-        Ok(Some(
-            names
-                .into_iter()
-                .filter(|table_name| predicate.should_include_table(table_name))
-                .collect(),
-        ))
+            State::ParquetFile { chunk, .. } => {
+                if predicate.has_exprs() {
+                    // TODO: Support more predicates
+                    PredicateMatch::Unknown
+                } else if chunk.has_timerange(predicate.range.as_ref()) {
+                    // As above, this should really be "Unknown" rather than AtLeastOne
+                    // for precision / correctness.
+                    PredicateMatch::AtLeastOne
+                } else {
+                    PredicateMatch::Zero
+                }
+            }
+        }
     }
 
     fn table_schema(&self, selection: Selection<'_>) -> Result<Schema, Self::Error> {
@@ -251,10 +270,6 @@ impl PartitionChunk for DbChunk {
                 self.meta.schema.project(&columns)
             }
         })
-    }
-
-    fn has_table(&self, table_name: &str) -> bool {
-        table_name == self.meta.table_summary.name
     }
 
     fn read_filter(

--- a/server/src/db/chunk.rs
+++ b/server/src/db/chunk.rs
@@ -243,7 +243,7 @@ impl PartitionChunk for DbChunk {
 
                 // TODO align API in read_buffer
                 let table_names = chunk.table_names(&rb_predicate, &BTreeSet::new());
-                if table_names.len() > 0 {
+                if !table_names.is_empty() {
                     // As above, this should really be "Unknown" rather than AtLeastOne
                     // for precision / correctness.
                     PredicateMatch::AtLeastOne

--- a/server/src/query_tests/table_schema.rs
+++ b/server/src/query_tests/table_schema.rs
@@ -36,7 +36,7 @@ macro_rules! run_table_schema_test_case {
             let predicate = PredicateBuilder::new().table(table_name).build();
 
             for chunk in db.chunks(&predicate) {
-                if chunk.has_table(table_name) {
+                if chunk.table_name().as_ref() == table_name {
                     chunks_with_table += 1;
                     let actual_schema = chunk.table_schema(selection.clone()).unwrap();
 

--- a/src/influxdb_ioxd/rpc/storage/service.rs
+++ b/src/influxdb_ioxd/rpc/storage/service.rs
@@ -1171,7 +1171,7 @@ mod tests {
     use super::*;
     use datafusion::logical_plan::{col, lit, Expr};
     use panic_logging::SendPanicsToTracing;
-    use query::{test::TestChunk, test::TestDatabaseStore};
+    use query::{predicate::PredicateMatch, test::TestChunk, test::TestDatabaseStore};
     use std::{
         convert::TryFrom,
         net::{IpAddr, Ipv4Addr, SocketAddr},
@@ -1252,8 +1252,13 @@ mod tests {
         let db_info = OrgAndBucket::new(123, 456);
         let partition_id = 1;
 
-        let chunk0 = TestChunk::new(0).with_table("h2o");
-        let chunk1 = TestChunk::new(1).with_table("o2");
+        let chunk0 = TestChunk::new(0)
+            .with_predicate_match(PredicateMatch::AtLeastOne)
+            .with_table("h2o");
+
+        let chunk1 = TestChunk::new(1)
+            .with_predicate_match(PredicateMatch::AtLeastOne)
+            .with_table("o2");
 
         fixture
             .test_storage
@@ -1409,7 +1414,9 @@ mod tests {
         let db_info = OrgAndBucket::new(123, 456);
         let partition_id = 1;
 
-        let chunk = TestChunk::new(0).with_error("Sugar we are going down");
+        let chunk = TestChunk::new(0)
+            .with_table("my_table")
+            .with_error("Sugar we are going down");
 
         fixture
             .test_storage
@@ -1535,6 +1542,7 @@ mod tests {
 
         let chunk = TestChunk::new(0)
             // predicate specifies m4, so this is filtered out
+            .with_table("my_table")
             .with_error("This is an error");
 
         fixture
@@ -1640,7 +1648,9 @@ mod tests {
             tag_key: [0].into(),
         };
 
-        let chunk = TestChunk::new(0).with_table("h2o");
+        let chunk = TestChunk::new(0)
+            .with_predicate_match(PredicateMatch::AtLeastOne)
+            .with_table("h2o");
 
         fixture
             .test_storage
@@ -1717,7 +1727,9 @@ mod tests {
         let db_info = OrgAndBucket::new(123, 456);
         let partition_id = 1;
 
-        let chunk = TestChunk::new(0).with_error("Sugar we are going down");
+        let chunk = TestChunk::new(0)
+            .with_table("my_table")
+            .with_error("Sugar we are going down");
 
         fixture
             .test_storage
@@ -1835,7 +1847,9 @@ mod tests {
         let db_info = OrgAndBucket::new(123, 456);
         let partition_id = 1;
 
-        let chunk = TestChunk::new(0).with_error("Sugar we are going down");
+        let chunk = TestChunk::new(0)
+            .with_table("my_table")
+            .with_error("Sugar we are going down");
 
         fixture
             .test_storage
@@ -1985,7 +1999,9 @@ mod tests {
         let db_info = OrgAndBucket::new(123, 456);
         let partition_id = 1;
 
-        let chunk = TestChunk::new(0).with_error("Sugar we are going down");
+        let chunk = TestChunk::new(0)
+            .with_table("my_table")
+            .with_error("Sugar we are going down");
 
         fixture
             .test_storage
@@ -2077,7 +2093,9 @@ mod tests {
         let db_info = OrgAndBucket::new(123, 456);
         let partition_id = 1;
 
-        let chunk = TestChunk::new(0).with_error("Sugar we are going down");
+        let chunk = TestChunk::new(0)
+            .with_table("my_table")
+            .with_error("Sugar we are going down");
 
         fixture
             .test_storage
@@ -2287,7 +2305,9 @@ mod tests {
         let db_info = OrgAndBucket::new(123, 456);
         let partition_id = 1;
 
-        let chunk = TestChunk::new(0).with_error("Sugar we are going down");
+        let chunk = TestChunk::new(0)
+            .with_table("my_table")
+            .with_error("Sugar we are going down");
 
         fixture
             .test_storage
@@ -2383,7 +2403,6 @@ mod tests {
 
         grpc_request_metric_has_count(&fixture, "measurement_fields", "ok", 1).unwrap();
     }
-
 
     fn make_timestamp_range(start: i64, end: i64) -> TimestampRange {
         TimestampRange { start, end }

--- a/src/influxdb_ioxd/rpc/storage/service.rs
+++ b/src/influxdb_ioxd/rpc/storage/service.rs
@@ -2384,48 +2384,6 @@ mod tests {
         grpc_request_metric_has_count(&fixture, "measurement_fields", "ok", 1).unwrap();
     }
 
-    #[tokio::test]
-    async fn test_measurement_fields_error() {
-        test_helpers::maybe_start_logging();
-        // Start a test gRPC server on a randomally allocated port
-        let mut fixture = Fixture::new().await.expect("Connecting to test server");
-
-        let db_info = OrgAndBucket::new(123, 456);
-        let partition_id = 1;
-
-        let chunk = TestChunk::new(0).with_error("Sugar we are going down");
-
-        fixture
-            .test_storage
-            .db_or_create(&db_info.db_name)
-            .await
-            .unwrap()
-            .add_chunk("my_partition_key", Arc::new(chunk));
-
-        let source = Some(StorageClientWrapper::read_source(
-            db_info.org_id,
-            db_info.bucket_id,
-            partition_id,
-        ));
-
-        // ---
-        // test error
-        // ---
-        let request = MeasurementFieldsRequest {
-            source: source.clone(),
-            measurement: "TheMeasurement".into(),
-            range: None,
-            predicate: None,
-        };
-
-        let response_string = fixture
-            .storage_client
-            .measurement_fields(request)
-            .await
-            .unwrap_err()
-            .to_string();
-        assert_contains!(response_string, "Sugar we are going down");
-    }
 
     fn make_timestamp_range(start: i64, end: i64) -> TimestampRange {
         TimestampRange { start, end }

--- a/src/influxdb_ioxd/rpc/storage/service.rs
+++ b/src/influxdb_ioxd/rpc/storage/service.rs
@@ -2404,6 +2404,49 @@ mod tests {
         grpc_request_metric_has_count(&fixture, "measurement_fields", "ok", 1).unwrap();
     }
 
+    #[tokio::test]
+    async fn test_measurement_fields_error() {
+        test_helpers::maybe_start_logging();
+        // Start a test gRPC server on a randomally allocated port
+        let mut fixture = Fixture::new().await.expect("Connecting to test server");
+
+        let db_info = OrgAndBucket::new(123, 456);
+        let partition_id = 1;
+
+        let chunk = TestChunk::new(0).with_error("Sugar we are going down");
+
+        fixture
+            .test_storage
+            .db_or_create(&db_info.db_name)
+            .await
+            .unwrap()
+            .add_chunk("my_partition_key", Arc::new(chunk));
+
+        let source = Some(StorageClientWrapper::read_source(
+            db_info.org_id,
+            db_info.bucket_id,
+            partition_id,
+        ));
+
+        // ---
+        // test error
+        // ---
+        let request = MeasurementFieldsRequest {
+            source: source.clone(),
+            measurement: "TheMeasurement".into(),
+            range: None,
+            predicate: None,
+        };
+
+        let response_string = fixture
+            .storage_client
+            .measurement_fields(request)
+            .await
+            .unwrap_err()
+            .to_string();
+        assert_contains!(response_string, "Sugar we are going down");
+    }
+
     fn make_timestamp_range(start: i64, end: i64) -> TimestampRange {
         TimestampRange { start, end }
     }


### PR DESCRIPTION
Re https://github.com/influxdata/influxdb_iox/issues/1295 and a follow on to https://github.com/influxdata/influxdb_iox/pull/1584

# Rationale
Once upon a time, when the world was green and fresh, chunks could have multiple tables. Now that a chunk has a single table, the API for PartitionChunk is awkward.

I also realize while doing this taht `PartitionChunk::apply_predicate` may also be the perfect place to apply chunk pruning logic (e.g. https://github.com/influxdata/influxdb_iox/pull/1567)

# Changes:
1. Consolidate `has_table`, `all_table_names` and `table_names` methods into a single `table_name()` and a `apply_predicate` method
2. Add a `PredicateMatch` enum to clearly explain what the return value of `apply_predicate` means
2. No functional changes intended

