### PR TITLE
feat: preserve and read timestamps to/from preserved catalog

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2619,6 +2619,7 @@ dependencies = [
  "arrow",
  "arrow_util",
  "bytes",
+ "chrono",
  "data_types",
  "datafusion 0.1.0",
  "datafusion_util",

--- a/generated_types/protos/influxdata/iox/catalog/v1/catalog.proto
+++ b/generated_types/protos/influxdata/iox/catalog/v1/catalog.proto
@@ -1,6 +1,8 @@
 syntax = "proto3";
 package influxdata.iox.catalog.v1;
 
+import "google/protobuf/timestamp.proto";
+
 // Path for object store interaction.
 message Path {
     // Directory hierarchy.
@@ -72,8 +74,6 @@ message Transaction {
 
     // Start timestamp.
     //
-    // Timestamp of the start of the transaction encoded as [RFC 3339].
-    //
-    // [RFC 3339]: https://datatracker.ietf.org/doc/html/rfc3339
-    string start_timestamp = 6;
+    // Timestamp of the start of the transaction.
+    google.protobuf.Timestamp start_timestamp = 6;
 }

--- a/generated_types/protos/influxdata/iox/catalog/v1/catalog.proto
+++ b/generated_types/protos/influxdata/iox/catalog/v1/catalog.proto
@@ -69,4 +69,11 @@ message Transaction {
 
     // UUID of last commit.
     string previous_uuid = 5;
+
+    // Start timestamp.
+    //
+    // Timestamp of the start of the transaction encoded as [RFC 3339].
+    //
+    // [RFC 3339]: https://datatracker.ietf.org/doc/html/rfc3339
+    string start_timestamp = 6;
 }

--- a/parquet_file/Cargo.toml
+++ b/parquet_file/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 [dependencies] # In alphabetical order
 arrow = { version = "4.0", features = ["prettyprint"] }
 bytes = "1.0"
+chrono = "0.4"
 data_types = { path = "../data_types" }
 datafusion = { path = "../datafusion" }
 datafusion_util = { path = "../datafusion_util" }

--- a/parquet_file/src/catalog.rs
+++ b/parquet_file/src/catalog.rs
@@ -167,7 +167,7 @@ pub enum Error {
     #[snafu(display("Catalog already exists"))]
     AlreadyExists {},
 
-    #[snafu(display("Datetime required but missing"))]
+    #[snafu(display("Internal: Datetime required but missing in serialized catalog"))]
     DateTimeRequired {},
 
     #[snafu(display("Cannot parse datetime: {}", source))]
@@ -1712,7 +1712,7 @@ mod tests {
         .await;
         assert_eq!(
             res.unwrap_err().to_string(),
-            "Datetime required but missing"
+            "Internal: Datetime required but missing in serialized catalog"
         );
     }
 

--- a/parquet_file/src/catalog.rs
+++ b/parquet_file/src/catalog.rs
@@ -866,6 +866,7 @@ where
             }
             .fail()?;
         }
+        // verify we can parse the timestamp (checking that no error is raised)
         parse_timestamp(&proto.start_timestamp)?;
 
         // apply

--- a/parquet_file/src/catalog.rs
+++ b/parquet_file/src/catalog.rs
@@ -234,13 +234,13 @@ pub async fn find_last_transaction_timestamp(
                 Ok(ts) => {
                     res = Some(res.map_or(ts, |res: DateTime<Utc>| res.max(ts)));
                 }
-                Err(e) => warn!("Cannot parse timestamp from {:?}: {}", path, e),
+                Err(e) => warn!(%e, ?path, "Cannot parse timestamp"),
             },
             Err(e @ Error::Read { .. }) => {
                 // bubble up IO error
                 return Err(e);
             }
-            Err(e) => warn!("Cannot read transaction from {:?}: {}", path, e),
+            Err(e) => warn!(%e, ?path, "Cannot read transaction"),
         }
     }
     Ok(res)

--- a/parquet_file/src/catalog.rs
+++ b/parquet_file/src/catalog.rs
@@ -30,7 +30,7 @@ use uuid::Uuid;
 /// Current version for serialized transactions.
 ///
 /// For breaking changes, this will change.
-pub const TRANSACTION_VERSION: u32 = 1;
+pub const TRANSACTION_VERSION: u32 = 2;
 
 /// File suffix for transaction files in object store.
 pub const TRANSACTION_FILE_SUFFIX: &str = "txn";
@@ -1323,7 +1323,7 @@ mod tests {
         .await;
         assert_eq!(
             res.unwrap_err().to_string(),
-            "Format version of transaction file for revision 2 is 42 but only [1] are supported"
+            format!("Format version of transaction file for revision 2 is 42 but only [{}] are supported", TRANSACTION_VERSION)
         );
     }
 


### PR DESCRIPTION
During #1572 we concluded that having some kind of declarative way to wipe catalogs would be helpful. I think that "a catalog last touched/written before X" would be a helpful way to implement that. So this PR implements the underlying tracking to achieve that:

1. store transaction timestamps
2. a way to get the last known transaction timestamp from a potentially broken catalog

CC @mkmik 