### PR TITLE
refactor: avoid copying encoding name for stats

### DIFF
--- a/read_buffer/src/column.rs
+++ b/read_buffer/src/column.rs
@@ -5,7 +5,7 @@ pub mod float;
 pub mod integer;
 pub mod string;
 
-use std::{collections::BTreeSet, mem::size_of};
+use std::{borrow::Cow, collections::BTreeSet, mem::size_of};
 
 use croaring::Bitmap;
 use either::Either;
@@ -1384,7 +1384,7 @@ impl Iterator for RowIDsIterator<'_> {
 
 // Statistics about the composition of a column
 pub(crate) struct Statistics {
-    pub enc_type: String,            // The encoding type
+    pub enc_type: Cow<'static, str>, // The encoding type
     pub log_data_type: &'static str, // The logical data-type
     pub values: u32,                 // Number of values present (NULL and non-NULL)
     pub nulls: u32,                  // Number of NULL values present

--- a/read_buffer/src/column/boolean.rs
+++ b/read_buffer/src/column/boolean.rs
@@ -36,7 +36,7 @@ impl BooleanEncoding {
     // Returns statistics about the physical layout of columns
     pub(crate) fn storage_stats(&self) -> Statistics {
         Statistics {
-            enc_type: self.name().to_string(),
+            enc_type: self.name().into(),
             log_data_type: "bool",
             values: self.num_rows(),
             nulls: self.null_count(),

--- a/read_buffer/src/column/float.rs
+++ b/read_buffer/src/column/float.rs
@@ -48,7 +48,7 @@ impl FloatEncoding {
     // Returns statistics about the physical layout of columns
     pub(crate) fn storage_stats(&self) -> Statistics {
         Statistics {
-            enc_type: self.name().to_string(),
+            enc_type: self.name().into(),
             log_data_type: self.logical_datatype(),
             values: self.num_rows(),
             nulls: self.null_count(),

--- a/read_buffer/src/column/integer.rs
+++ b/read_buffer/src/column/integer.rs
@@ -53,7 +53,7 @@ impl IntegerEncoding {
     // Returns statistics about the physical layout of columns
     pub(crate) fn storage_stats(&self) -> Statistics {
         Statistics {
-            enc_type: self.name(),
+            enc_type: self.name().into(),
             log_data_type: self.logical_datatype(),
             values: self.num_rows(),
             nulls: self.null_count(),
@@ -224,8 +224,8 @@ impl IntegerEncoding {
     /// The name of this encoding.
     pub fn name(&self) -> String {
         match self {
-            Self::I64(_, name) => name.clone(),
-            Self::U64(_, name) => name.clone(),
+            Self::I64(_, name) => name.to_string(),
+            Self::U64(_, name) => name.to_string(),
         }
     }
 

--- a/read_buffer/src/column/string.rs
+++ b/read_buffer/src/column/string.rs
@@ -73,8 +73,8 @@ impl StringEncoding {
     pub(crate) fn storage_stats(&self) -> Statistics {
         Statistics {
             enc_type: match self {
-                Self::RleDictionary(_) => rle::ENCODING_NAME.to_string(),
-                Self::Dictionary(_) => dictionary::ENCODING_NAME.to_string(),
+                Self::RleDictionary(_) => rle::ENCODING_NAME.into(),
+                Self::Dictionary(_) => dictionary::ENCODING_NAME.into(),
             },
             log_data_type: "string",
             values: self.num_rows(),


### PR DESCRIPTION
I already had this on a branch from when I tried out the idea in the PR review.

---

* refactor: avoid copying encoding name for stats (aca00a50)

      Swaps the encoding name String type for a Cow in the column Statistics, 
      avoiding having to copy the encoding name where it is a static string already.

