### PR TITLE
refactor: clean-up chunk structure + add tests

### DIFF
--- a/server/src/db.rs
+++ b/server/src/db.rs
@@ -470,7 +470,7 @@ impl Db {
             })?
         {
             let mut chunk = chunk.write();
-            chunk.set_closed().context(RollingOverPartition {
+            chunk.freeze().context(RollingOverPartition {
                 partition_key,
                 table_name,
             })?;
@@ -1091,7 +1091,7 @@ fn check_chunk_closed(chunk: &mut CatalogChunk, mutable_size_threshold: Option<N
             let size = mb_chunk.size();
 
             if size > threshold.get() {
-                chunk.set_closed().expect("cannot close open chunk");
+                chunk.freeze().expect("cannot close open chunk");
             }
         }
     }

--- a/server/src/db.rs
+++ b/server/src/db.rs
@@ -1298,9 +1298,7 @@ mod tests {
         test_helpers::{try_write_lp, write_lp},
         *,
     };
-    use crate::db::catalog::chunk::{
-        ChunkStage, ChunkStageFrozen, ChunkStageFrozenRepr, ChunkStagePersisted,
-    };
+    use crate::db::catalog::chunk::{ChunkStage, ChunkStageFrozenRepr};
     use crate::query_tests::utils::{make_db, TestDb};
     use ::test_helpers::assert_contains;
     use arrow::record_batch::RecordBatch;
@@ -2094,17 +2092,17 @@ mod tests {
         assert_eq!(chunks.len(), 2);
         assert!(matches!(
             chunks[0].read().stage(),
-            ChunkStage::Frozen(ChunkStageFrozen {
-                meta: _,
-                representation: ChunkStageFrozenRepr::MutableBufferSnapshot(_)
-            })
+            ChunkStage::Frozen {
+                representation: ChunkStageFrozenRepr::MutableBufferSnapshot(_),
+                ..
+            }
         ));
         assert!(matches!(
             chunks[1].read().stage(),
-            ChunkStage::Frozen(ChunkStageFrozen {
-                meta: _,
-                representation: ChunkStageFrozenRepr::MutableBufferSnapshot(_)
-            })
+            ChunkStage::Frozen {
+                representation: ChunkStageFrozenRepr::MutableBufferSnapshot(_),
+                ..
+            }
         ));
     }
 
@@ -2901,8 +2899,8 @@ mod tests {
                 partition.chunk(table_name, *chunk_id).unwrap()
             };
             let chunk = chunk.read();
-            if let ChunkStage::Persisted(stage) = chunk.stage() {
-                paths_expected.push(stage.parquet.table_path().display());
+            if let ChunkStage::Persisted { parquet, .. } = chunk.stage() {
+                paths_expected.push(parquet.table_path().display());
             } else {
                 panic!("Wrong chunk state.");
             }
@@ -2952,11 +2950,10 @@ mod tests {
             let chunk = chunk.read();
             assert!(matches!(
                 chunk.stage(),
-                ChunkStage::Persisted(ChunkStagePersisted {
-                    parquet: _,
+                ChunkStage::Persisted {
                     read_buffer: None,
-                    meta: _,
-                })
+                    ..
+                }
             ));
         }
 
@@ -2994,8 +2991,8 @@ mod tests {
                 partition.chunk(table_name.clone(), chunk_id).unwrap()
             };
             let chunk = chunk.read();
-            if let ChunkStage::Persisted(stage) = chunk.stage() {
-                paths_keep.push(stage.parquet.table_path());
+            if let ChunkStage::Persisted { parquet, .. } = chunk.stage() {
+                paths_keep.push(parquet.table_path());
             } else {
                 panic!("Wrong chunk state.");
             }

--- a/server/src/db/catalog.rs
+++ b/server/src/db/catalog.rs
@@ -98,12 +98,14 @@ pub enum Error {
     },
 
     #[snafu(display(
-        "Can not add an empty chunk to the catalog {}:{}",
+        "Cannot add an empty chunk to the catalog {}:{}:{}",
         partition_key,
+        table_name,
         chunk_id
     ))]
     ChunkIsEmpty {
         partition_key: String,
+        table_name: String,
         chunk_id: u32,
     },
 

--- a/server/src/db/catalog/partition.rs
+++ b/server/src/db/catalog/partition.rs
@@ -197,7 +197,7 @@ impl Partition {
                 .values()
                 .find(|chunk| {
                     let chunk = chunk.read();
-                    matches!(chunk.stage(), ChunkStage::Open(_))
+                    matches!(chunk.stage(), ChunkStage::Open { .. })
                 })
                 .cloned()),
             None => UnknownTable {

--- a/server/src/db/lifecycle.rs
+++ b/server/src/db/lifecycle.rs
@@ -416,7 +416,7 @@ mod tests {
 
     /// Transitions a new ("open") chunk into the "moving" state.
     fn transition_to_moving(mut chunk: Chunk) -> Chunk {
-        chunk.set_closed().unwrap();
+        chunk.freeze().unwrap();
         chunk.set_moving(&Default::default()).unwrap();
         chunk
     }
@@ -907,7 +907,7 @@ mod tests {
         mover.check_for_work(from_secs(80));
         assert_eq!(mover.events, vec![]);
 
-        mover.chunks[0].write().set_closed().unwrap();
+        mover.chunks[0].write().freeze().unwrap();
 
         // As soon as closed can move
         mover.check_for_work(from_secs(80));


### PR DESCRIPTION
Some things that came up in #1585. Another idea came from @alamb who proposed to inline the extra structs into the enum.

Note that there is still a bit of work to do (like addressing [this comment](https://github.com/influxdata/influxdb_iox/pull/1585/files#r642476096)) however I think this change is sufficiently large for now.