### PR TITLE
feat: jitter background clean-up job + wait on first job

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3722,6 +3722,7 @@ dependencies = [
  "parquet_file",
  "query",
  "rand 0.8.3",
+ "rand_distr",
  "read_buffer",
  "serde",
  "serde_json",

--- a/data_types/src/database_rules.rs
+++ b/data_types/src/database_rules.rs
@@ -51,7 +51,8 @@ pub struct DatabaseRules {
     /// remote servers.
     pub routing_rules: Option<RoutingRules>,
 
-    /// Duration for which the cleanup loop should sleep on avarage.
+    /// Duration for which the cleanup loop should sleep on average.
+    /// Defaults to 500 seconds.
     pub worker_cleanup_avg_sleep: Duration,
 }
 

--- a/data_types/src/database_rules.rs
+++ b/data_types/src/database_rules.rs
@@ -4,6 +4,7 @@ use influxdb_line_protocol::ParsedLine;
 use regex::Regex;
 use snafu::{OptionExt, Snafu};
 use std::num::NonZeroU64;
+use std::time::Duration;
 use std::{
     collections::HashMap,
     hash::{Hash, Hasher},
@@ -49,6 +50,9 @@ pub struct DatabaseRules {
     /// An optional config to delegate data plane operations to one or more
     /// remote servers.
     pub routing_rules: Option<RoutingRules>,
+
+    /// Duration for which the cleanup loop should sleep on avarage.
+    pub worker_cleanup_avg_sleep: Duration,
 }
 
 #[derive(Debug, Eq, PartialEq, Clone)]
@@ -79,6 +83,7 @@ impl DatabaseRules {
             write_buffer_config: None,
             lifecycle_rules: Default::default(),
             routing_rules: None,
+            worker_cleanup_avg_sleep: Duration::from_secs(500),
         }
     }
 

--- a/generated_types/protos/influxdata/iox/management/v1/database_rules.proto
+++ b/generated_types/protos/influxdata/iox/management/v1/database_rules.proto
@@ -184,6 +184,9 @@ message DatabaseRules {
     // Routing config
     RoutingConfig routing_config = 9;
   }
+
+  // Duration for which the cleanup loop should sleep on avarage.
+  google.protobuf.Duration worker_cleanup_avg_sleep = 10;
 }
 
 message RoutingConfig {

--- a/generated_types/protos/influxdata/iox/management/v1/database_rules.proto
+++ b/generated_types/protos/influxdata/iox/management/v1/database_rules.proto
@@ -185,7 +185,8 @@ message DatabaseRules {
     RoutingConfig routing_config = 9;
   }
 
-  // Duration for which the cleanup loop should sleep on avarage.
+  // Duration for which the cleanup loop should sleep on average.
+  // Defaults to 500 seconds.
   google.protobuf.Duration worker_cleanup_avg_sleep = 10;
 }
 

--- a/generated_types/src/database_rules.rs
+++ b/generated_types/src/database_rules.rs
@@ -1,4 +1,5 @@
 use std::convert::{TryFrom, TryInto};
+use std::time::Duration;
 
 use thiserror::Error;
 
@@ -23,6 +24,7 @@ impl From<DatabaseRules> for management::DatabaseRules {
             write_buffer_config: rules.write_buffer_config.map(Into::into),
             lifecycle_rules: Some(rules.lifecycle_rules.into()),
             routing_rules: rules.routing_rules.map(Into::into),
+            worker_cleanup_avg_sleep: Some(rules.worker_cleanup_avg_sleep.into()),
         }
     }
 }
@@ -50,12 +52,18 @@ impl TryFrom<management::DatabaseRules> for DatabaseRules {
             .optional("routing_rules")
             .unwrap_or_default();
 
+        let worker_cleanup_avg_sleep = match proto.worker_cleanup_avg_sleep {
+            Some(d) => d.try_into().field("worker_cleanup_avg_sleep")?,
+            None => Duration::from_secs(500),
+        };
+
         Ok(Self {
             name,
             partition_template,
             write_buffer_config,
             lifecycle_rules,
             routing_rules,
+            worker_cleanup_avg_sleep,
         })
     }
 }

--- a/parquet_file/src/cleanup.rs
+++ b/parquet_file/src/cleanup.rs
@@ -103,14 +103,14 @@ where
 
     // now that the transaction lock is dropped, perform the actual (and potentially slow) delete operation
     let n_files = to_remove.len();
-    info!("Found {} files to delete, start deletion.", n_files);
+    info!(%n_files, "Found files to delete, start deletion.");
 
     for path in to_remove {
-        info!("Delete file: {}", path.display());
+        info!(path = %path.display(), "Delete file");
         store.delete(&path).await.context(WriteError)?;
     }
 
-    info!("Finished deletion, removed {} files.", n_files);
+    info!(%n_files, "Finished deletion, removed files.");
 
     Ok(())
 }

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -35,6 +35,7 @@ parking_lot = "0.11.1"
 parquet_file = { path = "../parquet_file" }
 query = { path = "../query" }
 rand = "0.8.3"
+rand_distr = "0.4.0"
 read_buffer = { path = "../read_buffer" }
 serde = "1.0"
 serde_json = "1.0"

--- a/server/src/db.rs
+++ b/server/src/db.rs
@@ -954,7 +954,7 @@ impl Db {
                     tokio::select! {
                         _ = async {
                             if let Err(e) = cleanup_unreferenced_parquet_files(&self.catalog).await {
-                                error!("error in background cleanup task: {:?}", e);
+                                error!(%e, "error in background cleanup task");
                             }
                             tokio::time::sleep(Duration::from_secs(500)).await;
                         } => {},

--- a/server/src/db.rs
+++ b/server/src/db.rs
@@ -2677,6 +2677,8 @@ mod tests {
             .server_id(server_id)
             .object_store(Arc::clone(&object_store))
             .db_name(db_name)
+            // "dispable" clean-up by setting it to a very long time to avoid interference with this test
+            .worker_cleanup_avg_sleep(Duration::from_secs(1_000))
             .build()
             .await;
 
@@ -2759,7 +2761,7 @@ mod tests {
             let _ = chunk_a.read();
         });
 
-        // Hold lock for 100 seconds blocking background task
+        // Hold lock for 100 milliseconds blocking background task
         std::thread::sleep(std::time::Duration::from_millis(100));
 
         std::mem::drop(chunk_b);

--- a/server/src/db.rs
+++ b/server/src/db.rs
@@ -957,7 +957,8 @@ impl Db {
                             // Sleep for a duration drawn from a poisson distribution to de-correlate workers.
                             // Perform this sleep BEFORE the actual clean-up so that we don't immediately run a clean-up
                             // on startup.
-                            let dist = Poisson::new(self.rules.read().worker_cleanup_avg_sleep.as_secs_f32().max(1.0)).expect("parameter should be positive and finite");
+                            let avg_sleep_secs = self.rules.read().worker_cleanup_avg_sleep.as_secs_f32().max(1.0);
+                            let dist = Poisson::new(avg_sleep_secs).expect("parameter should be positive and finite");
                             let duration = Duration::from_secs_f32(dist.sample(&mut rand::thread_rng()));
                             debug!(?duration, "cleanup worker sleeps");
                             tokio::time::sleep(duration).await;

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -1112,7 +1112,7 @@ async fn get_database_config_bytes(
 
 #[cfg(test)]
 mod tests {
-    use std::{collections::BTreeMap, convert::TryFrom};
+    use std::{collections::BTreeMap, convert::TryFrom, time::Duration};
 
     use async_trait::async_trait;
     use futures::TryStreamExt;
@@ -1206,6 +1206,7 @@ mod tests {
             write_buffer_config: None,
             lifecycle_rules: Default::default(),
             routing_rules: None,
+            worker_cleanup_avg_sleep: Duration::from_secs(2),
         };
 
         // Create a database
@@ -1302,6 +1303,7 @@ mod tests {
             write_buffer_config: None,
             lifecycle_rules: Default::default(),
             routing_rules: None,
+            worker_cleanup_avg_sleep: Duration::from_secs(2),
         };
 
         // Create a database

--- a/server/src/query_tests/utils.rs
+++ b/server/src/query_tests/utils.rs
@@ -80,7 +80,7 @@ impl TestDbBuilder {
         let mut rules = DatabaseRules::new(db_name);
 
         // make background loop spin a bit faster for tests
-        rules.worker_cleanup_avg_sleep = Duration::from_secs(2);
+        rules.worker_cleanup_avg_sleep = Duration::from_secs(1);
 
         TestDb {
             metric_registry: metrics::TestMetricRegistry::new(metrics_registry),

--- a/server/src/query_tests/utils.rs
+++ b/server/src/query_tests/utils.rs
@@ -34,6 +34,7 @@ pub struct TestDbBuilder {
     object_store: Option<Arc<ObjectStore>>,
     db_name: Option<DatabaseName<'static>>,
     write_buffer: bool,
+    worker_cleanup_avg_sleep: Option<Duration>,
 }
 
 impl TestDbBuilder {
@@ -80,7 +81,9 @@ impl TestDbBuilder {
         let mut rules = DatabaseRules::new(db_name);
 
         // make background loop spin a bit faster for tests
-        rules.worker_cleanup_avg_sleep = Duration::from_secs(1);
+        rules.worker_cleanup_avg_sleep = self
+            .worker_cleanup_avg_sleep
+            .unwrap_or_else(|| Duration::from_secs(1));
 
         TestDb {
             metric_registry: metrics::TestMetricRegistry::new(metrics_registry),
@@ -113,6 +116,11 @@ impl TestDbBuilder {
 
     pub fn write_buffer(mut self, enabled: bool) -> Self {
         self.write_buffer = enabled;
+        self
+    }
+
+    pub fn worker_cleanup_avg_sleep(mut self, d: Duration) -> Self {
+        self.worker_cleanup_avg_sleep = Some(d);
         self
     }
 }

--- a/tests/end_to_end_cases/management_api.rs
+++ b/tests/end_to_end_cases/management_api.rs
@@ -223,6 +223,10 @@ async fn test_create_get_update_database() {
             ..Default::default()
         }),
         routing_rules: None,
+        worker_cleanup_avg_sleep: Some(Duration {
+            seconds: 2,
+            nanos: 0,
+        }),
     };
 
     client


### PR DESCRIPTION
It turned out that eagerly starting the clean-up job on DB startup might be a bit too aggressive, especially since a single IOx node can restore many DBs on start-up.
