### PR TITLE
refactor: Make it clear only partition_key and table name pruning happens in catalog

### DIFF
--- a/server/src/db.rs
+++ b/server/src/db.rs
@@ -1116,7 +1116,7 @@ impl Database for Db {
     /// Note there could/should be an error here (if the partition
     /// doesn't exist... but the trait doesn't have an error)
     fn chunks(&self, predicate: &Predicate) -> Vec<Arc<Self::Chunk>> {
-        let partition_key = predicate.partition_key.as_ref().map(|s| s.as_str());
+        let partition_key = predicate.partition_key.as_deref();
         let table_names = predicate.table_names.as_ref();
         self.catalog
             .state()

--- a/server/src/db.rs
+++ b/server/src/db.rs
@@ -39,8 +39,7 @@ use parquet_file::{
     },
     storage::Storage,
 };
-use query::predicate::{Predicate, PredicateBuilder};
-use query::{exec::Executor, Database, DEFAULT_SCHEMA};
+use query::{exec::Executor, predicate::Predicate, Database, DEFAULT_SCHEMA};
 use rand_distr::{Distribution, Poisson};
 use read_buffer::{Chunk as ReadBufferChunk, ChunkMetrics as ReadBufferChunkMetrics};
 use snafu::{ResultExt, Snafu};
@@ -880,10 +879,11 @@ impl Db {
     /// Return chunk summary information for all chunks in the specified
     /// partition across all storage systems
     pub fn partition_chunk_summaries(&self, partition_key: &str) -> Vec<ChunkSummary> {
-        self.catalog.state().filtered_chunks(
-            &PredicateBuilder::new().partition_key(partition_key).build(),
-            CatalogChunk::summary,
-        )
+        let partition_key = Some(partition_key);
+        let table_name = None;
+        self.catalog
+            .state()
+            .filtered_chunks(partition_key, table_name, CatalogChunk::summary)
     }
 
     /// Return Summary information for all columns in all chunks in the
@@ -1116,9 +1116,11 @@ impl Database for Db {
     /// Note there could/should be an error here (if the partition
     /// doesn't exist... but the trait doesn't have an error)
     fn chunks(&self, predicate: &Predicate) -> Vec<Arc<Self::Chunk>> {
+        let partition_key = predicate.partition_key.as_ref().map(|s| s.as_str());
+        let table_names = predicate.table_names.as_ref();
         self.catalog
             .state()
-            .filtered_chunks(predicate, DbChunk::snapshot)
+            .filtered_chunks(partition_key, table_names, DbChunk::snapshot)
     }
 
     fn partition_keys(&self) -> Result<Vec<String>, Self::Error> {

--- a/server/src/db.rs
+++ b/server/src/db.rs
@@ -1,6 +1,8 @@
 //! This module contains the main IOx Database object which has the
 //! instances of the mutable buffer, read buffer, and object store
 
+use self::catalog::TableNameFilter;
+
 use super::{
     buffer::{self, Buffer},
     JobRegistry,
@@ -880,10 +882,10 @@ impl Db {
     /// partition across all storage systems
     pub fn partition_chunk_summaries(&self, partition_key: &str) -> Vec<ChunkSummary> {
         let partition_key = Some(partition_key);
-        let table_name = None;
+        let table_names = TableNameFilter::AllTables;
         self.catalog
             .state()
-            .filtered_chunks(partition_key, table_name, CatalogChunk::summary)
+            .filtered_chunks(partition_key, table_names, CatalogChunk::summary)
     }
 
     /// Return Summary information for all columns in all chunks in the
@@ -1117,7 +1119,7 @@ impl Database for Db {
     /// doesn't exist... but the trait doesn't have an error)
     fn chunks(&self, predicate: &Predicate) -> Vec<Arc<Self::Chunk>> {
         let partition_key = predicate.partition_key.as_deref();
-        let table_names = predicate.table_names.as_ref();
+        let table_names: TableNameFilter<'_> = predicate.table_names.as_ref().into();
         self.catalog
             .state()
             .filtered_chunks(partition_key, table_names, DbChunk::snapshot)

--- a/server/src/db/catalog.rs
+++ b/server/src/db/catalog.rs
@@ -122,7 +122,8 @@ pub enum Error {
 }
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
-/// A way to specify which tables are to be matched when filtering catalog chunks
+/// Specify which tables are to be matched when filtering
+/// catalog chunks
 #[derive(Debug, Clone, Copy)]
 pub enum TableNameFilter<'a> {
     /// Include all tables
@@ -132,6 +133,15 @@ pub enum TableNameFilter<'a> {
 }
 
 impl<'a> From<Option<&'a BTreeSet<String>>> for TableNameFilter<'a> {
+    /// Creates a [`TableNameFilter`] from an [`Option`].
+    ///
+    /// If the Option is `None`, all table names will be included in
+    /// the results.
+    ///
+    /// If the Option is `Some(set)`, only table names which apear in
+    /// `set` will be included in the results.
+    ///
+    /// Note `Some(empty set)` will not match anything
     fn from(v: Option<&'a BTreeSet<String>>) -> Self {
         match v {
             Some(names) => Self::NamedTables(names),

--- a/server/src/db/catalog.rs
+++ b/server/src/db/catalog.rs
@@ -623,11 +623,11 @@ mod tests {
 
         let a = catalog.filtered_chunks(None, None, |_| ());
 
-        let b = catalog.filtered_chunks(None, make_set("table1").as_ref(), |_| ());
+        let b = catalog.filtered_chunks(None, Some(&make_set("table1")), |_| ());
 
-        let c = catalog.filtered_chunks(None, make_set("table2").as_ref(), |_| ());
+        let c = catalog.filtered_chunks(None, Some(&make_set("table2")), |_| ());
 
-        let d = catalog.filtered_chunks(Some("p2"), make_set("table2").as_ref(), |_| ());
+        let d = catalog.filtered_chunks(Some("p2"), Some(&make_set("table2")), |_| ());
 
         assert_eq!(a.len(), 3);
         assert_eq!(b.len(), 1);
@@ -635,7 +635,7 @@ mod tests {
         assert_eq!(d.len(), 1);
     }
 
-    fn make_set(s: impl Into<String>) -> Option<BTreeSet<String>> {
-        Some(std::iter::once(s.into()).collect::<BTreeSet<_>>())
+    fn make_set(s: impl Into<String>) -> BTreeSet<String> {
+        std::iter::once(s.into()).collect::<BTreeSet<_>>()
     }
 }

--- a/server/src/db/catalog.rs
+++ b/server/src/db/catalog.rs
@@ -636,6 +636,6 @@ mod tests {
     }
 
     fn make_set(s: impl Into<String>) -> BTreeSet<String> {
-        std::iter::once(s.into()).collect::<BTreeSet<_>>()
+        std::iter::once(s.into()).collect()
     }
 }

--- a/server/src/db/catalog/partition.rs
+++ b/server/src/db/catalog/partition.rs
@@ -242,13 +242,9 @@ impl Partition {
             .filter_map(
                 move |(partition_table_name, partition_table)| match table_names {
                     TableNameFilter::AllTables => Some(partition_table.chunks.values()),
-                    TableNameFilter::NamedTables(table_names) => {
-                        if table_names.contains(partition_table_name) {
-                            Some(partition_table.chunks.values())
-                        } else {
-                            None
-                        }
-                    }
+                    TableNameFilter::NamedTables(table_names) => table_names
+                        .contains(partition_table_name)
+                        .then(|| partition_table.chunks.values()),
                 },
             )
             .flatten()


### PR DESCRIPTION
re https://github.com/influxdata/influxdb_iox/issues/735

# Rationale

As part of and https://github.com/influxdata/influxdb_iox/pull/1567 I am making predicate based pruning happen in a new layer like the following

```
┌────────────────────────────┐
│             Db             │
└────────────────────────────┘
               ▲
               │
               │
┌────────────────────────────┐
│       CatalogAccess        │     Predicate based
│           (new)            │   pruning happens at
└────────────────────────────┘       this layer
               ▲
               │
               │
┌────────────────────────────┐      Only table name
│          Catalog           │   filtering happens at
└────────────────────────────┘        this level
```

Right now, the `Predicate` structure is pushed all the way down
into the Catalog, but only `partition_key` and `table_name` filtering is applied. This
makes it potentially unclear that the rest of the predicate structure is unused

# Changes

1. Pass an `Option<&str>` to Catalog to make it clear only table name pruning is happening at this level
