### PR TITLE
fix: Fix logfmt escaping

### DIFF
--- a/logfmt/src/lib.rs
+++ b/logfmt/src/lib.rs
@@ -265,7 +265,10 @@ fn needs_quotes_and_escaping(value: &str) -> bool {
 /// escape any characters in name as needed, otherwise return string as is
 fn quote_and_escape(value: &'_ str) -> Cow<'_, str> {
     if needs_quotes_and_escaping(value) {
-        Cow::Owned(format!("\"{}\"", value.replace("\"", "\\\"")))
+        Cow::Owned(format!(
+            "\"{}\"",
+            value.replace(r#"\"#, r#"\\"#).replace(r#"""#, r#"\""#)
+        ))
     } else {
         Cow::Borrowed(value)
     }
@@ -337,5 +340,18 @@ mod test {
     #[test]
     fn quote_and_escape_quoted_quotes() {
         assert_eq!(quote_and_escape("foo:\"bar\""), "\"foo:\\\"bar\\\"\"");
+    }
+
+    #[test]
+    fn quote_and_escape_nested_1() {
+        assert_eq!(quote_and_escape(r#"a "b" c"#), r#""a \"b\" c""#);
+    }
+
+    #[test]
+    fn quote_and_escape_nested_2() {
+        assert_eq!(
+            quote_and_escape(r#"a "0 \"1\" 2" c"#),
+            r#""a \"0 \\\"1\\\" 2\" c""#
+        );
     }
 }

--- a/logfmt/tests/logging.rs
+++ b/logfmt/tests/logging.rs
@@ -72,6 +72,18 @@ fn event_fields_strings() {
 }
 
 #[test]
+fn event_fields_strings_quoting() {
+    let capture = CapturedWriter::new();
+    info!(foo = r#"body: Body(Full(b"{\"error\": \"Internal error\"}"))"#,);
+
+    let expected = vec![
+        r#"level=info foo="body: Body(Full(b\"{\\\"error\\\": \\\"Internal error\\\"}\"))" target="logging" location="logfmt/tests/logging.rs:59" time=1612187170712973000"#,
+    ];
+
+    assert_logs!(capture, expected);
+}
+
+#[test]
 fn test_without_normalization() {
     let capture = CapturedWriter::new();
     info!(


### PR DESCRIPTION
Closes #1252

I defer to #1252 for the wider context; the "why" this escaping rule is the likely the right one (the "official" logfmt is particularly light on the spec side)

This PR, implements the following interpretation of the escaping rules:

1. To put a double quote in a double quoted string, you need to escape the double quote with a backslash: `"` -> `"\""`.
2. To put a backslash in a double quoted string, you need to escape the backslash with another backslash: `\` -> `"\\"`.
3. To put a character sequence `\"` inside a double quoted string, you need to combine the previous two rules: `\"` -> `"\\\""`

These rules are quite reasonable and follow the escape rules of most languages.

The test strings are correctly parsed by https://github.com/brandur/hutils

![image](https://user-images.githubusercontent.com/52673/120727481-f0fd9f80-c4da-11eb-8dcf-d567dec30f4c.png)
