### PR TITLE
feat: Add logfmts script to humanize timestamps

### DIFF
--- a/scripts/logfmts
+++ b/scripts/logfmts
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+#
+# Human readable logfmt timestamps (ts)
+#
+# Usage:
+#
+# kubectl logs deploy/iox-router-1000 -c iox -f | ./scripts/logfmts
+#
+#
+# If you want to render into UTC timestamps:
+#
+# kubectl logs deploy/iox-router-1000 -c iox -f | TZ=UTC ./scripts/logfmts
+#
+#
+
+set -eu -o pipefail
+
+if ! command -v gawk &> /dev/null; then
+  echo "GNU awk required"
+  echo "  brew install gawk"
+  echo "  apt-get install gawk"
+  echo "  ...."
+fi
+
+exec gawk -F"time=" '{print strftime("%Y-%m-%d %H:%M:%S", $2/1000000000), $1 }'


### PR DESCRIPTION
```console
$ kubectl logs deploy/iox-router-1000 -c iox -f | TZ=UTC ./scripts/logfmts
2021-06-04 10:25:46 level=debug msg="Successfully processed request" response="Response { status: 204, version: HTTP/1.1, headers: {\"x-powered-by\": \"Routerify v2.0.0-beta-2\"}, body: Body(Empty) }" target="influxdb_iox::influxdb_ioxd::http" location="src/influxdb_ioxd/http.rs:359"
```
