### PR TITLE
feat: full foundation for deduplicate with todo functions to finish

### DIFF
--- a/data_types/src/partition_metadata.rs
+++ b/data_types/src/partition_metadata.rs
@@ -98,6 +98,15 @@ impl TableSummary {
         }
     }
 
+    /// Returns the primary key of this table
+    pub fn primary_key(&self) -> Vec<String> {
+        self.columns
+            .iter()
+            .filter(|c| c.key_part())
+            .map(|c| c.name.clone())
+            .collect()
+    }
+
     /// Returns the total number of rows in the columns of this summary
     pub fn count(&self) -> u64 {
         // Assumes that all tables have the same number of rows, so
@@ -184,6 +193,15 @@ impl ColumnSummary {
     /// data type
     pub fn type_name(&self) -> &'static str {
         self.stats.type_name()
+    }
+
+    /// Return true if this column is a part of the primary key which
+    /// means it is either a tag or timestamp
+    pub fn key_part(&self) -> bool {
+        matches!(
+            self.influxdb_type,
+            Some(InfluxDbType::Tag) | Some(InfluxDbType::Timestamp)
+        )
     }
 
     /// Return size in bytes of this Column metadata (not the underlying column)

--- a/server/src/db/catalog/chunk.rs
+++ b/server/src/db/catalog/chunk.rs
@@ -49,6 +49,12 @@ pub struct ChunkMetadata {
     pub schema: Arc<Schema>,
 }
 
+impl ChunkMetadata {
+    pub fn primary_key(&self) -> Vec<String> {
+        self.table_summary.primary_key()
+    }
+}
+
 /// Different memory representations of a frozen chunk.
 #[derive(Debug)]
 pub enum ChunkStageFrozenRepr {

--- a/server/src/db/chunk.rs
+++ b/server/src/db/chunk.rs
@@ -165,6 +165,10 @@ impl DbChunk {
         })
     }
 
+    pub fn primary_key(&self) -> Vec<String> {
+        self.meta.primary_key()
+    }
+
     /// Return the snapshot of the chunk with type ParquetFile
     /// This function should be only invoked when you know your chunk
     /// is ParquetFile type whose state is  WrittenToObjectStore. The


### PR DESCRIPTION
Closes #

The second code implementation for deduplicate read #600 

# CheckList
- [x] Code up full deduplicate foundation
- [ ] Add primary key in `Schema`
- [ ] Implement is_sorted for DbChunk (or PartitionChunk)
- [ ] Implement is_sorted for DbChunk (or PartitionChunk)
- [ ] Add UnionExec inside function build_scan_plan  -- Nga
- [ ] Implement split_overlapped_chunks function
- [ ] Implement DeduplicateExec needed in the 2 functions below
- [ ] Implement build_deduplicate_plan_for_overlapped_chunks function -- Nga
- [ ] Implement build_deduplicate_plan_for_chunk_with_duplicates. -- Nga

- [x] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb_iox/blob/main/README.md).
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
