### PR TITLE
fix: Fix garbled log lines

### DIFF
--- a/src/commands/tracing.rs
+++ b/src/commands/tracing.rs
@@ -64,8 +64,12 @@ pub fn init_logs_and_tracing(
             Some(_) => (None, None, None, None, None),
             None => {
                 let log_writer = match config.log_destination {
-                    LogDestination::Stdout => fmt::writer::BoxMakeWriter::new(std::io::stdout),
-                    LogDestination::Stderr => fmt::writer::BoxMakeWriter::new(std::io::stderr),
+                    LogDestination::Stdout => fmt::writer::BoxMakeWriter::new(|| {
+                        std::io::LineWriter::new(std::io::stdout())
+                    }),
+                    LogDestination::Stderr => fmt::writer::BoxMakeWriter::new(|| {
+                        std::io::LineWriter::new(std::io::stderr())
+                    }),
                 };
                 let (log_format_full, log_format_pretty, log_format_json, log_format_logfmt) =
                     match config.log_format {


### PR DESCRIPTION
CC: @jacobmarble 

Closes #1615

w.r.t testing: lazy cause ETOOMANYYAKS: this is not easy to test as it involves non determinism to reproduce the issue.

I tested it manually by comparing,,

before:

```console
$ LOG_FORMAT=logfmt LOG_FILTER=debug ./target/debug/influxdb_iox run \
  | awk -F 'level=' '{print (NF?NF-1:0)}' \
  | sort | uniq -c
11543 0
12193 1
1116 2
 150 3
  25 4
   8 5
   3 6
   1 7
```

after:

```console
$ LOG_FORMAT=logfmt LOG_FILTER=debug ./target/debug/influxdb_iox run \
  | awk -F 'level=' '{print (NF?NF-1:0)}' \
  | sort | uniq -c
14029 1
```

Closes #

Describe your proposed changes here.

- [ ] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb_iox/blob/main/README.md).
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
