### PR TITLE
docs: add a comment w/ rationale for LineWriter

### DIFF
--- a/src/commands/tracing.rs
+++ b/src/commands/tracing.rs
@@ -65,6 +65,7 @@ pub fn init_logs_and_tracing(
             None => {
                 // Note: Use LineWriter to ensure each log line is
                 // written as a unit and avoid interleaving
+                // see https://github.com/influxdata/influxdb_iox/issues/1615
                 let log_writer = match config.log_destination {
                     LogDestination::Stdout => fmt::writer::BoxMakeWriter::new(|| {
                         std::io::LineWriter::new(std::io::stdout())

--- a/src/commands/tracing.rs
+++ b/src/commands/tracing.rs
@@ -63,6 +63,8 @@ pub fn init_logs_and_tracing(
         match traces_layer_otel {
             Some(_) => (None, None, None, None, None),
             None => {
+                // Note: Use LineWriter to ensure each log line is
+                // written as a unit and avoid interleaving
                 let log_writer = match config.log_destination {
                     LogDestination::Stdout => fmt::writer::BoxMakeWriter::new(|| {
                         std::io::LineWriter::new(std::io::stdout())


### PR DESCRIPTION
Rationale: https://github.com/influxdata/influxdb_iox/pull/1637/files is the result of hard won knowledge from @mkmik 's experience and could be casually removed by accident as there is no test coverage (which is reasonable given how hard this would be to test)

Changes: Add a comment explaining the rationale

