### PR TITLE
fix: give xlarge image to perf_image build step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -209,6 +209,7 @@ jobs:
   perf_image:
     docker:
       - image: quay.io/influxdb/rust:ci
+    resource_class: xlarge # use of a smaller executor tends crashes on link
     environment:
         # Disable incremental compilation to avoid overhead. We are not preserving these files anyway.
         CARGO_INCREMENTAL: "0"


### PR DESCRIPTION
the `perf_build` job on circle ci fails very often, e.g. https://app.circleci.com/pipelines/github/influxdata/influxdb_iox/6586/workflows/2ad23ddb-0344-4cbd-a4bc-76eca4eced88/jobs/26677

we use the `xlarge` resource type for all other build jobs on circle ci; we probably forgot to use it for the `perf_image` too