### PR TITLE
refactor: use field metadata to store influx types

### DIFF
--- a/internal_types/src/schema.rs
+++ b/internal_types/src/schema.rs
@@ -1,7 +1,7 @@
 //! This module contains the schema definiton for IOx
 use snafu::{ResultExt, Snafu};
 use std::{
-    collections::{BTreeSet, HashMap, HashSet},
+    collections::{BTreeSet, HashMap},
     convert::{TryFrom, TryInto},
     fmt,
     sync::Arc,
@@ -165,6 +165,7 @@ impl TryFrom<ArrowSchemaRef> for Schema {
 }
 
 const MEASUREMENT_METADATA_KEY: &str = "iox::measurement::name";
+const COLUMN_METADATA_KEY: &str = "iox::column::type";
 
 impl Schema {
     /// Create a new Schema wrapper over the schema
@@ -212,46 +213,11 @@ impl Schema {
     /// Create and validate a new Schema, creating metadata to
     /// represent the the various parts. This method is intended to be
     /// used only by the SchemaBuilder.
-    ///
-    /// fields: the column definitions, in order
-    ///
-    /// tag columns: names of any columns which are tags
-    ///
-    /// field columns: names of any columns which are fields, and
-    /// their associated InfluxDB data model types
     pub(crate) fn new_from_parts(
         measurement: Option<String>,
         fields: Vec<ArrowField>,
-        tag_cols: HashSet<String>,
-        field_cols: HashMap<String, InfluxColumnType>,
-        time_col: Option<String>,
     ) -> Result<Self> {
         let mut metadata = HashMap::new();
-
-        for tag_name in tag_cols.into_iter() {
-            metadata.insert(tag_name, InfluxColumnType::Tag.to_string());
-        }
-
-        // Ensure we don't have columns that were specified to be both fields and tags
-        for (column_name, influxdb_column_type) in field_cols.into_iter() {
-            if metadata.get(&column_name).is_some() {
-                return BothFieldAndTag { column_name }.fail();
-            }
-            metadata.insert(column_name, influxdb_column_type.to_string());
-        }
-
-        // Ensure we didn't ask the field to be both a timestamp and a field or tag
-        if let Some(column_name) = time_col {
-            if let Some(existing_type) = metadata.get(&column_name) {
-                let existing_type: InfluxColumnType = existing_type.as_str().try_into().unwrap();
-                return InvalidTimestamp {
-                    column_name,
-                    existing_type,
-                }
-                .fail();
-            }
-            metadata.insert(column_name, InfluxColumnType::Timestamp.to_string());
-        }
 
         if let Some(measurement) = measurement {
             metadata.insert(MEASUREMENT_METADATA_KEY.to_string(), measurement);
@@ -278,11 +244,10 @@ impl Schema {
 
         // Lookup and translate metadata type, if present
         // invalid metadata was detected and reported as part of the constructor
-        let influxdb_column_type = self
-            .inner
+        let influxdb_column_type: Option<InfluxColumnType> = field
             .metadata()
-            .get(field.name())
-            .and_then(|influxdb_column_type_str| influxdb_column_type_str.as_str().try_into().ok());
+            .as_ref()
+            .and_then(|metadata| metadata.get(COLUMN_METADATA_KEY)?.as_str().try_into().ok());
 
         (influxdb_column_type, field)
     }
@@ -400,7 +365,7 @@ impl Schema {
 
                     // for now, insist the types are exactly the same
                     // (e.g. None and Some(..) don't match). We could
-                    // consider relaxing this constrait
+                    // consider relaxing this constraint
                     if existing_influx_column_type != influx_column_type {
                         TryMergeBadColumnType {
                             field_name,
@@ -500,19 +465,14 @@ impl Schema {
 
     /// Returns the schema for a given set of column projects
     pub fn project(&self, projection: &[usize]) -> Self {
-        let mut metadata = HashMap::with_capacity(projection.len() + 1);
         let mut fields = Vec::with_capacity(projection.len());
-        let current_metadata = self.inner.metadata();
         for idx in projection {
-            let (_, field) = self.field(*idx);
+            let field = self.inner.field(*idx);
             fields.push(field.clone());
-
-            if let Some(value) = current_metadata.get(field.name()) {
-                metadata.insert(field.name().clone(), value.clone());
-            }
         }
 
-        if let Some(measurement) = current_metadata.get(MEASUREMENT_METADATA_KEY).cloned() {
+        let mut metadata = HashMap::with_capacity(1);
+        if let Some(measurement) = self.inner.metadata().get(MEASUREMENT_METADATA_KEY).cloned() {
             metadata.insert(MEASUREMENT_METADATA_KEY.to_string(), measurement);
         }
 
@@ -728,6 +688,21 @@ mod test {
     use InfluxColumnType::*;
     use InfluxFieldType::*;
 
+    fn make_field(
+        name: &str,
+        data_type: arrow::datatypes::DataType,
+        nullable: bool,
+        column_type: &str,
+    ) -> ArrowField {
+        let mut field = ArrowField::new(name, data_type, nullable);
+        field.set_metadata(Some(
+            vec![(COLUMN_METADATA_KEY.to_string(), column_type.to_string())]
+                .into_iter()
+                .collect(),
+        ));
+        field
+    }
+
     #[test]
     fn new_from_arrow_no_metadata() {
         let arrow_schema = ArrowSchemaRef::new(ArrowSchema::new(vec![
@@ -754,27 +729,55 @@ mod test {
     #[test]
     fn new_from_arrow_metadata_good() {
         let fields = vec![
-            ArrowField::new("tag_col", ArrowDataType::Utf8, false),
-            ArrowField::new("int_col", ArrowDataType::Int64, false),
-            ArrowField::new("uint_col", ArrowDataType::UInt64, false),
-            ArrowField::new("float_col", ArrowDataType::Float64, false),
-            ArrowField::new("str_col", ArrowDataType::Utf8, false),
-            ArrowField::new("bool_col", ArrowDataType::Boolean, false),
-            ArrowField::new("time_col", TIME_DATA_TYPE(), false),
+            make_field(
+                "tag_col",
+                ArrowDataType::Utf8,
+                false,
+                "iox::column_type::tag",
+            ),
+            make_field(
+                "int_col",
+                ArrowDataType::Int64,
+                false,
+                "iox::column_type::field::integer",
+            ),
+            make_field(
+                "uint_col",
+                ArrowDataType::UInt64,
+                false,
+                "iox::column_type::field::uinteger",
+            ),
+            make_field(
+                "float_col",
+                ArrowDataType::Float64,
+                false,
+                "iox::column_type::field::float",
+            ),
+            make_field(
+                "str_col",
+                ArrowDataType::Utf8,
+                false,
+                "iox::column_type::field::string",
+            ),
+            make_field(
+                "bool_col",
+                ArrowDataType::Boolean,
+                false,
+                "iox::column_type::field::boolean",
+            ),
+            make_field(
+                "time_col",
+                TIME_DATA_TYPE(),
+                false,
+                "iox::column_type::timestamp",
+            ),
         ];
 
-        let metadata: HashMap<_, _> = vec![
-            ("tag_col", "iox::column_type::tag"),
-            ("int_col", "iox::column_type::field::integer"),
-            ("uint_col", "iox::column_type::field::uinteger"),
-            ("float_col", "iox::column_type::field::float"),
-            ("str_col", "iox::column_type::field::string"),
-            ("bool_col", "iox::column_type::field::boolean"),
-            ("time_col", "iox::column_type::timestamp"),
-            ("iox::measurement::name", "the_measurement"),
-        ]
+        let metadata: HashMap<_, _> = vec![(
+            "iox::measurement::name".to_string(),
+            "the_measurement".to_string(),
+        )]
         .into_iter()
-        .map(|i| (i.0.to_string(), i.1.to_string()))
         .collect();
 
         let arrow_schema = ArrowSchemaRef::new(ArrowSchema::new_with_metadata(fields, metadata));
@@ -795,21 +798,25 @@ mod test {
     #[test]
     fn new_from_arrow_metadata_extra() {
         let fields = vec![
-            ArrowField::new("tag_col", ArrowDataType::Utf8, false),
-            ArrowField::new("int_col", ArrowDataType::Int64, false),
+            make_field(
+                "tag_col",
+                ArrowDataType::Utf8,
+                false,
+                "something_other_than_iox",
+            ),
+            make_field(
+                "int_col",
+                ArrowDataType::Int64,
+                false,
+                "iox::column_type::field::some_new_exotic_type",
+            ),
         ];
 
         // This metadata models metadata that was not created by this
         // rust module itself
-        let metadata: HashMap<_, _> = vec![
-            ("tag_col", "something_other_than_iox"),
-            ("int_col", "iox::column_type::field::some_new_exotic_type"),
-            ("non_existent_col", "iox::column_type::field::float"),
-            ("iox::some::new::key", "foo"),
-        ]
-        .into_iter()
-        .map(|i| (i.0.to_string(), i.1.to_string()))
-        .collect();
+        let metadata: HashMap<_, _> = vec![("iox::some::new::key".to_string(), "foo".to_string())]
+            .into_iter()
+            .collect();
 
         let arrow_schema = ArrowSchemaRef::new(ArrowSchema::new_with_metadata(fields, metadata));
 
@@ -829,18 +836,15 @@ mod test {
     #[test]
     fn new_from_arrow_metadata_mismatched_tag() {
         let fields = vec![
-            ArrowField::new("tag_col", ArrowDataType::Int64, false), // not a valid tag type
+            make_field(
+                "tag_col",
+                ArrowDataType::Int64,
+                false,
+                "iox::column_type::tag",
+            ), // not a valid tag type
         ];
 
-        let metadata: HashMap<_, _> = vec![
-            ("tag_col", "iox::column_type::tag"), /* claims that tag_col is a tag, but it is an
-                                                   * integer */
-        ]
-        .into_iter()
-        .map(|i| (i.0.to_string(), i.1.to_string()))
-        .collect();
-
-        let arrow_schema = ArrowSchemaRef::new(ArrowSchema::new_with_metadata(fields, metadata));
+        let arrow_schema = ArrowSchemaRef::new(ArrowSchema::new(fields));
 
         let res = Schema::try_from_arrow(arrow_schema);
         assert_eq!(res.unwrap_err().to_string(), "Error: Incompatible metadata type found in schema for column 'tag_col'. Metadata specified Tag which is incompatible with actual type Int64");
@@ -849,16 +853,13 @@ mod test {
     // mismatched metadata / arrow types
     #[test]
     fn new_from_arrow_metadata_mismatched_field() {
-        let fields = vec![ArrowField::new("int_col", ArrowDataType::Int64, false)];
-
-        let metadata: HashMap<_, _> = vec![
-            ("int_col", "iox::column_type::field::float"), // metadata claims it is a float
-        ]
-        .into_iter()
-        .map(|i| (i.0.to_string(), i.1.to_string()))
-        .collect();
-
-        let arrow_schema = ArrowSchemaRef::new(ArrowSchema::new_with_metadata(fields, metadata));
+        let fields = vec![make_field(
+            "int_col",
+            ArrowDataType::Int64,
+            false,
+            "iox::column_type::field::float",
+        )];
+        let arrow_schema = ArrowSchemaRef::new(ArrowSchema::new(fields));
 
         let res = Schema::try_from_arrow(arrow_schema);
         assert_eq!(res.unwrap_err().to_string(), "Error: Incompatible metadata type found in schema for column 'int_col'. Metadata specified Field(Float) which is incompatible with actual type Int64");
@@ -868,17 +869,15 @@ mod test {
     #[test]
     fn new_from_arrow_metadata_mismatched_timestamp() {
         let fields = vec![
-            ArrowField::new("time", ArrowDataType::Utf8, false), // timestamp can't be strings
+            make_field(
+                "time",
+                ArrowDataType::Utf8,
+                false,
+                "iox::column_type::timestamp",
+            ), // timestamp can't be strings
         ];
 
-        let metadata: HashMap<_, _> = vec![
-            ("time", "iox::column_type::timestamp"), // metadata claims it is a timstam
-        ]
-        .into_iter()
-        .map(|i| (i.0.to_string(), i.1.to_string()))
-        .collect();
-
-        let arrow_schema = ArrowSchemaRef::new(ArrowSchema::new_with_metadata(fields, metadata));
+        let arrow_schema = ArrowSchemaRef::new(ArrowSchema::new(fields));
 
         let res = Schema::try_from_arrow(arrow_schema);
         assert_eq!(res.unwrap_err().to_string(), "Error: Incompatible metadata type found in schema for column 'time'. Metadata specified Timestamp which is incompatible with actual type Utf8");

--- a/internal_types/src/schema.rs
+++ b/internal_types/src/schema.rs
@@ -37,15 +37,12 @@ pub mod builder;
 /// Database schema creation / validation errors.
 #[derive(Debug, Snafu)]
 pub enum Error {
-    #[snafu(display("Error validating schema: '{}' is both a field and a tag", column_name,))]
-    BothFieldAndTag { column_name: String },
-
     #[snafu(display("Error: Duplicate column name found in schema: '{}'", column_name,))]
     DuplicateColumnName { column_name: String },
 
     #[snafu(display(
-        "Error: Incompatible metadata type found in schema for column '{}'. Metadata specified {:?} which is incompatible with actual type {:?}",
-        column_name, influxdb_column_type, actual_type
+    "Error: Incompatible metadata type found in schema for column '{}'. Metadata specified {:?} which is incompatible with actual type {:?}",
+    column_name, influxdb_column_type, actual_type
     ))]
     IncompatibleMetadata {
         column_name: String,
@@ -54,18 +51,8 @@ pub enum Error {
     },
 
     #[snafu(display(
-        "Duplicate column name: '{}' was specified to be {:?} as well as timestamp",
-        column_name,
-        existing_type
-    ))]
-    InvalidTimestamp {
-        column_name: String,
-        existing_type: InfluxColumnType,
-    },
-
-    #[snafu(display(
-        "Schema Merge Error: Incompatible measurement names. Existing measurement name '{}', new measurement name '{}'",
-        existing_measurement, new_measurement
+    "Schema Merge Error: Incompatible measurement names. Existing measurement name '{}', new measurement name '{}'",
+    existing_measurement, new_measurement
     ))]
     TryMergeDifferentMeasurementNames {
         existing_measurement: String,

--- a/internal_types/src/schema/builder.rs
+++ b/internal_types/src/schema/builder.rs
@@ -1,13 +1,11 @@
-use snafu::{ResultExt, Snafu};
-use std::{
-    collections::{HashMap, HashSet},
-    convert::TryInto,
-};
+use std::convert::TryInto;
 
 use arrow::datatypes::{DataType as ArrowDataType, Field as ArrowField};
+use snafu::{ResultExt, Snafu};
+
+use crate::schema::COLUMN_METADATA_KEY;
 
 use super::{InfluxColumnType, InfluxFieldType, Schema, TIME_COLUMN_NAME};
-use crate::schema::COLUMN_METADATA_KEY;
 
 /// Database schema creation / validation errors.
 #[derive(Debug, Snafu)]
@@ -222,11 +220,12 @@ impl SchemaMerger {
 
 #[cfg(test)]
 mod test {
+    use InfluxColumnType::*;
+    use InfluxFieldType::*;
+
     use crate::assert_column_eq;
 
     use super::*;
-    use InfluxColumnType::*;
-    use InfluxFieldType::*;
 
     #[test]
     fn test_builder_basic() {

--- a/internal_types/src/schema/builder.rs
+++ b/internal_types/src/schema/builder.rs
@@ -7,6 +7,7 @@ use std::{
 use arrow::datatypes::{DataType as ArrowDataType, Field as ArrowField};
 
 use super::{InfluxColumnType, InfluxFieldType, Schema, TIME_COLUMN_NAME};
+use crate::schema::COLUMN_METADATA_KEY;
 
 /// Database schema creation / validation errors.
 #[derive(Debug, Snafu)]
@@ -31,15 +32,6 @@ pub struct SchemaBuilder {
 
     /// The fields, in order
     fields: Vec<ArrowField>,
-
-    /// which columns represent tags
-    tag_cols: HashSet<String>,
-
-    /// which columns represent fields
-    field_cols: HashMap<String, InfluxColumnType>,
-
-    /// which field was the time column, if any
-    time_col: Option<String>,
 }
 
 impl SchemaBuilder {
@@ -50,7 +42,7 @@ impl SchemaBuilder {
     /// Add a new tag column to this schema. By default tags are
     /// potentially nullable as they are not guaranteed to be present
     /// for all rows
-    pub fn tag(self, column_name: &str) -> Self {
+    pub fn tag(&mut self, column_name: &str) -> &mut Self {
         let influxdb_column_type = InfluxColumnType::Tag;
         let arrow_type = (&influxdb_column_type).into();
 
@@ -59,7 +51,7 @@ impl SchemaBuilder {
 
     /// Add a new tag column to this schema that is known (somehow) to
     /// have no nulls for all rows
-    pub fn non_null_tag(self, column_name: &str) -> Self {
+    pub fn non_null_tag(&mut self, column_name: &str) -> &mut Self {
         let influxdb_column_type = InfluxColumnType::Tag;
         let arrow_type = (&influxdb_column_type).into();
 
@@ -67,7 +59,11 @@ impl SchemaBuilder {
     }
 
     /// Add a new field column with the specified InfluxDB data model type
-    pub fn influx_field(self, column_name: &str, influxdb_field_type: InfluxFieldType) -> Self {
+    pub fn influx_field(
+        &mut self,
+        column_name: &str,
+        influxdb_field_type: InfluxFieldType,
+    ) -> &mut Self {
         let arrow_type: ArrowDataType = influxdb_field_type.into();
         self.add_column(
             column_name,
@@ -78,7 +74,7 @@ impl SchemaBuilder {
     }
 
     /// Add a new field column with the specified InfluxDB data model type
-    pub fn influx_column(self, column_name: &str, column_type: InfluxColumnType) -> Self {
+    pub fn influx_column(&mut self, column_name: &str, column_type: InfluxColumnType) -> &mut Self {
         match column_type {
             InfluxColumnType::Tag => self.tag(column_name),
             InfluxColumnType::Field(field) => self.field(column_name, field.into()),
@@ -87,7 +83,7 @@ impl SchemaBuilder {
     }
 
     /// Add a new nullable field column with the specified Arrow datatype.
-    pub fn field(self, column_name: &str, arrow_type: ArrowDataType) -> Self {
+    pub fn field(&mut self, column_name: &str, arrow_type: ArrowDataType) -> &mut Self {
         let influxdb_column_type = arrow_type
             .clone()
             .try_into()
@@ -99,7 +95,7 @@ impl SchemaBuilder {
 
     /// Add a new field column with the specified Arrow datatype that can not be
     /// null
-    pub fn non_null_field(self, column_name: &str, arrow_type: ArrowDataType) -> Self {
+    pub fn non_null_field(&mut self, column_name: &str, arrow_type: ArrowDataType) -> &mut Self {
         let influxdb_column_type = arrow_type
             .clone()
             .try_into()
@@ -110,7 +106,7 @@ impl SchemaBuilder {
     }
 
     /// Add the InfluxDB data model timestamp column
-    pub fn timestamp(self) -> Self {
+    pub fn timestamp(&mut self) -> &mut Self {
         let influxdb_column_type = InfluxColumnType::Timestamp;
         let arrow_type = (&influxdb_column_type).into();
         self.add_column(
@@ -122,7 +118,7 @@ impl SchemaBuilder {
     }
 
     /// Set optional InfluxDB data model measurement name
-    pub fn measurement(mut self, measurement_name: impl Into<String>) -> Self {
+    pub fn measurement(&mut self, measurement_name: impl Into<String>) -> &mut Self {
         self.measurement = Some(measurement_name.into());
         self
     }
@@ -152,43 +148,29 @@ impl SchemaBuilder {
     /// assert_eq!(arrow_field.name(), "time");
     /// assert_eq!(influxdb_column_type, Some(InfluxColumnType::Timestamp));
     /// ```
-    pub fn build(self) -> Result<Schema> {
-        let Self {
-            measurement,
-            fields,
-            tag_cols,
-            field_cols,
-            time_col,
-        } = self;
-
-        Schema::new_from_parts(measurement, fields, tag_cols, field_cols, time_col)
+    pub fn build(&mut self) -> Result<Schema> {
+        Schema::new_from_parts(self.measurement.take(), std::mem::take(&mut self.fields))
             .context(ValidatingSchema)
     }
 
     /// Internal helper method to add a column definition
     fn add_column(
-        mut self,
+        &mut self,
         column_name: &str,
         nullable: bool,
         influxdb_column_type: Option<InfluxColumnType>,
         arrow_type: ArrowDataType,
-    ) -> Self {
-        self.fields
-            .push(ArrowField::new(column_name, arrow_type, nullable));
-
-        match &influxdb_column_type {
-            Some(InfluxColumnType::Tag) => {
-                self.tag_cols.insert(column_name.to_string());
-            }
-            Some(InfluxColumnType::Field(_)) => {
-                self.field_cols
-                    .insert(column_name.to_string(), influxdb_column_type.unwrap());
-            }
-            Some(InfluxColumnType::Timestamp) => {
-                self.time_col = Some(column_name.to_string());
-            }
-            None => {}
+    ) -> &mut Self {
+        let mut field = ArrowField::new(column_name, arrow_type, nullable);
+        if let Some(column_type) = influxdb_column_type {
+            field.set_metadata(Some(
+                vec![(COLUMN_METADATA_KEY.to_string(), column_type.to_string())]
+                    .into_iter()
+                    .collect(),
+            ))
         }
+
+        self.fields.push(field);
         self
     }
 }
@@ -397,14 +379,20 @@ mod test {
             .influx_field("the name", Integer)
             .build();
 
-        assert_eq!(res.unwrap_err().to_string(), "Error validating schema: Error validating schema: 'the name' is both a field and a tag");
+        assert_eq!(
+            res.unwrap_err().to_string(),
+            "Error validating schema: Error: Duplicate column name found in schema: 'the name'"
+        );
     }
 
     #[test]
     fn test_builder_dupe_field_and_timestamp() {
         let res = SchemaBuilder::new().tag("time").timestamp().build();
 
-        assert_eq!(res.unwrap_err().to_string(), "Error validating schema: Duplicate column name: 'time' was specified to be Tag as well as timestamp");
+        assert_eq!(
+            res.unwrap_err().to_string(),
+            "Error validating schema: Error: Duplicate column name found in schema: 'time'"
+        );
     }
 
     #[test]

--- a/mutable_buffer/src/table.rs
+++ b/mutable_buffer/src/table.rs
@@ -180,8 +180,7 @@ impl Table {
         let schema = match selection {
             Selection::All => {
                 for (column_name, column) in self.columns.iter() {
-                    schema_builder =
-                        schema_builder.influx_column(column_name, column.influx_type());
+                    schema_builder.influx_column(column_name, column.influx_type());
                 }
 
                 schema_builder
@@ -192,7 +191,7 @@ impl Table {
             Selection::Some(cols) => {
                 for col in cols {
                     let column = self.column(col)?;
-                    schema_builder = schema_builder.influx_column(col, column.influx_type());
+                    schema_builder.influx_column(col, column.influx_type());
                 }
                 schema_builder.build().context(InternalSchema)?
             }

--- a/parquet_file/src/test_utils.rs
+++ b/parquet_file/src/test_utils.rs
@@ -172,8 +172,8 @@ fn create_column_tag(
     data: Vec<Vec<&str>>,
     arrow_cols: &mut Vec<Vec<(String, ArrayRef, bool)>>,
     summaries: &mut Vec<ColumnSummary>,
-    schema_builder: SchemaBuilder,
-) -> SchemaBuilder {
+    schema_builder: &mut SchemaBuilder,
+) {
     assert_eq!(data.len(), arrow_cols.len());
 
     for (arrow_cols_sub, data_sub) in arrow_cols.iter_mut().zip(data.iter()) {
@@ -193,7 +193,7 @@ fn create_column_tag(
         }),
     });
 
-    schema_builder.tag(name)
+    schema_builder.tag(name);
 }
 
 fn create_column_field_string(
@@ -201,8 +201,8 @@ fn create_column_field_string(
     data: Vec<Vec<&str>>,
     arrow_cols: &mut Vec<Vec<(String, ArrayRef, bool)>>,
     summaries: &mut Vec<ColumnSummary>,
-    schema_builder: SchemaBuilder,
-) -> SchemaBuilder {
+    schema_builder: &mut SchemaBuilder,
+) {
     create_column_field_generic::<StringArray, _, _>(
         name,
         data,
@@ -230,8 +230,8 @@ fn create_column_field_i64(
     data: Vec<Vec<i64>>,
     arrow_cols: &mut Vec<Vec<(String, ArrayRef, bool)>>,
     summaries: &mut Vec<ColumnSummary>,
-    schema_builder: SchemaBuilder,
-) -> SchemaBuilder {
+    schema_builder: &mut SchemaBuilder,
+) {
     create_column_field_generic::<Int64Array, _, _>(
         name,
         data,
@@ -247,8 +247,8 @@ fn create_column_field_u64(
     data: Vec<Vec<u64>>,
     arrow_cols: &mut Vec<Vec<(String, ArrayRef, bool)>>,
     summaries: &mut Vec<ColumnSummary>,
-    schema_builder: SchemaBuilder,
-) -> SchemaBuilder {
+    schema_builder: &mut SchemaBuilder,
+) {
     create_column_field_generic::<UInt64Array, _, _>(
         name,
         data,
@@ -264,8 +264,8 @@ fn create_column_field_f64(
     data: Vec<Vec<f64>>,
     arrow_cols: &mut Vec<Vec<(String, ArrayRef, bool)>>,
     summaries: &mut Vec<ColumnSummary>,
-    schema_builder: SchemaBuilder,
-) -> SchemaBuilder {
+    schema_builder: &mut SchemaBuilder,
+) {
     assert_eq!(data.len(), arrow_cols.len());
 
     let mut array_data_type = None;
@@ -296,7 +296,7 @@ fn create_column_field_f64(
         }),
     });
 
-    schema_builder.field(name, array_data_type.unwrap())
+    schema_builder.field(name, array_data_type.unwrap());
 }
 
 fn create_column_field_bool(
@@ -304,8 +304,8 @@ fn create_column_field_bool(
     data: Vec<Vec<bool>>,
     arrow_cols: &mut Vec<Vec<(String, ArrayRef, bool)>>,
     summaries: &mut Vec<ColumnSummary>,
-    schema_builder: SchemaBuilder,
-) -> SchemaBuilder {
+    schema_builder: &mut SchemaBuilder,
+) {
     create_column_field_generic::<BooleanArray, _, _>(
         name,
         data,
@@ -321,10 +321,9 @@ fn create_column_field_generic<A, T, F>(
     data: Vec<Vec<T>>,
     arrow_cols: &mut Vec<Vec<(String, ArrayRef, bool)>>,
     summaries: &mut Vec<ColumnSummary>,
-    schema_builder: SchemaBuilder,
+    schema_builder: &mut SchemaBuilder,
     f: F,
-) -> SchemaBuilder
-where
+) where
     A: 'static + Array,
     A: From<Vec<T>>,
     T: Clone + Ord,
@@ -350,15 +349,15 @@ where
         }),
     });
 
-    schema_builder.field(name, array_data_type.unwrap())
+    schema_builder.field(name, array_data_type.unwrap());
 }
 
 fn create_column_timestamp(
     data: Vec<Vec<i64>>,
     arrow_cols: &mut Vec<Vec<(String, ArrayRef, bool)>>,
     summaries: &mut Vec<ColumnSummary>,
-    schema_builder: SchemaBuilder,
-) -> SchemaBuilder {
+    schema_builder: &mut SchemaBuilder,
+) {
     assert_eq!(data.len(), arrow_cols.len());
 
     for (arrow_cols_sub, data_sub) in arrow_cols.iter_mut().zip(data.iter()) {
@@ -381,7 +380,7 @@ fn create_column_timestamp(
         }),
     });
 
-    schema_builder.timestamp()
+    schema_builder.timestamp();
 }
 
 /// Creates an Arrow RecordBatches with schema and IOx statistics.
@@ -400,60 +399,60 @@ pub fn make_record_batch(
     let mut schema_builder = SchemaBuilder::new();
 
     // tag
-    schema_builder = create_column_tag(
+    create_column_tag(
         &format!("{}_tag_nonempty", column_prefix),
         vec![vec!["foo"], vec!["bar"], vec!["baz", "foo"]],
         &mut arrow_cols,
         &mut summaries,
-        schema_builder,
+        &mut schema_builder,
     );
-    schema_builder = create_column_tag(
+    create_column_tag(
         &format!("{}_tag_empty", column_prefix),
         vec![vec![""], vec![""], vec!["", ""]],
         &mut arrow_cols,
         &mut summaries,
-        schema_builder,
+        &mut schema_builder,
     );
 
     // field: string
-    schema_builder = create_column_field_string(
+    create_column_field_string(
         &format!("{}_field_string_nonempty", column_prefix),
         vec![vec!["foo"], vec!["bar"], vec!["baz", "foo"]],
         &mut arrow_cols,
         &mut summaries,
-        schema_builder,
+        &mut schema_builder,
     );
-    schema_builder = create_column_field_string(
+    create_column_field_string(
         &format!("{}_field_string_empty", column_prefix),
         vec![vec![""], vec![""], vec!["", ""]],
         &mut arrow_cols,
         &mut summaries,
-        schema_builder,
+        &mut schema_builder,
     );
 
     // field: i64
-    schema_builder = create_column_field_i64(
+    create_column_field_i64(
         &format!("{}_field_i64_normal", column_prefix),
         vec![vec![-1], vec![2], vec![3, 4]],
         &mut arrow_cols,
         &mut summaries,
-        schema_builder,
+        &mut schema_builder,
     );
-    schema_builder = create_column_field_i64(
+    create_column_field_i64(
         &format!("{}_field_i64_range", column_prefix),
         vec![vec![i64::MIN], vec![i64::MAX], vec![i64::MIN, i64::MAX]],
         &mut arrow_cols,
         &mut summaries,
-        schema_builder,
+        &mut schema_builder,
     );
 
     // field: u64
-    schema_builder = create_column_field_u64(
+    create_column_field_u64(
         &format!("{}_field_u64_normal", column_prefix),
         vec![vec![1u64], vec![2], vec![3, 4]],
         &mut arrow_cols,
         &mut summaries,
-        schema_builder,
+        &mut schema_builder,
     );
     // TODO: broken due to https://github.com/apache/arrow-rs/issues/254
     // schema_builder = create_column_field_u64(
@@ -465,26 +464,26 @@ pub fn make_record_batch(
     // );
 
     // field: f64
-    schema_builder = create_column_field_f64(
+    create_column_field_f64(
         &format!("{}_field_f64_normal", column_prefix),
         vec![vec![10.1], vec![20.1], vec![30.1, 40.1]],
         &mut arrow_cols,
         &mut summaries,
-        schema_builder,
+        &mut schema_builder,
     );
-    schema_builder = create_column_field_f64(
+    create_column_field_f64(
         &format!("{}_field_f64_inf", column_prefix),
         vec![vec![0.0], vec![f64::INFINITY], vec![f64::NEG_INFINITY, 1.0]],
         &mut arrow_cols,
         &mut summaries,
-        schema_builder,
+        &mut schema_builder,
     );
-    schema_builder = create_column_field_f64(
+    create_column_field_f64(
         &format!("{}_field_f64_zero", column_prefix),
         vec![vec![0.0], vec![-0.0], vec![0.0, -0.0]],
         &mut arrow_cols,
         &mut summaries,
-        schema_builder,
+        &mut schema_builder,
     );
 
     // TODO: NaNs are broken until https://github.com/apache/arrow-rs/issues/255 is fixed
@@ -501,20 +500,20 @@ pub fn make_record_batch(
     // );
 
     // field: bool
-    schema_builder = create_column_field_bool(
+    create_column_field_bool(
         &format!("{}_field_bool", column_prefix),
         vec![vec![true], vec![false], vec![true, false]],
         &mut arrow_cols,
         &mut summaries,
-        schema_builder,
+        &mut schema_builder,
     );
 
     // time
-    let schema_builder = create_column_timestamp(
+    create_column_timestamp(
         vec![vec![1000], vec![2000], vec![3000, 4000]],
         &mut arrow_cols,
         &mut summaries,
-        schema_builder,
+        &mut schema_builder,
     );
 
     // build record batches

--- a/read_buffer/src/schema.rs
+++ b/read_buffer/src/schema.rs
@@ -103,38 +103,30 @@ impl TryFrom<&ResultSchema> for internal_types::schema::Schema {
         let mut builder = internal_types::schema::builder::SchemaBuilder::new();
         for (col_type, data_type) in &rs.select_columns {
             match col_type {
-                ColumnType::Tag(name) => builder = builder.tag(name.as_str()),
-                ColumnType::Field(name) => {
-                    builder = builder.influx_field(name.as_str(), data_type.into())
-                }
-                ColumnType::Timestamp(_) => builder = builder.timestamp(),
-                ColumnType::Other(name) => builder = builder.field(name.as_str(), data_type.into()),
-            }
+                ColumnType::Tag(name) => builder.tag(name.as_str()),
+                ColumnType::Field(name) => builder.influx_field(name.as_str(), data_type.into()),
+                ColumnType::Timestamp(_) => builder.timestamp(),
+                ColumnType::Other(name) => builder.field(name.as_str(), data_type.into()),
+            };
         }
 
         for (col_type, data_type) in &rs.group_columns {
             match col_type {
-                ColumnType::Tag(name) => builder = builder.tag(name.as_str()),
-                ColumnType::Field(name) => {
-                    builder = builder.influx_field(name.as_str(), data_type.into())
-                }
-                ColumnType::Timestamp(_) => builder = builder.timestamp(),
-                ColumnType::Other(name) => builder = builder.field(name.as_str(), data_type.into()),
-            }
+                ColumnType::Tag(name) => builder.tag(name.as_str()),
+                ColumnType::Field(name) => builder.influx_field(name.as_str(), data_type.into()),
+                ColumnType::Timestamp(_) => builder.timestamp(),
+                ColumnType::Other(name) => builder.field(name.as_str(), data_type.into()),
+            };
         }
 
         for (i, (col_type, _, data_type)) in rs.aggregate_columns.iter().enumerate() {
             let col_name = rs.aggregate_result_column_name(i);
 
             match col_type {
-                ColumnType::Field(_) => {
-                    builder = builder.influx_field(col_name.as_str(), data_type.into())
-                }
-                ColumnType::Other(_) => {
-                    builder = builder.field(col_name.as_str(), data_type.into())
-                }
+                ColumnType::Field(_) => builder.influx_field(col_name.as_str(), data_type.into()),
+                ColumnType::Other(_) => builder.field(col_name.as_str(), data_type.into()),
                 ct => unreachable!("not possible to aggregate {:?} columns", ct),
-            }
+            };
         }
 
         builder.build()


### PR DESCRIPTION
As part of #1357 I want to add a new piece of per-column metadata. Additionally I would like this metadata to transparently continue to work through projections, column re-orderings, etc... The simplest option would be to store the sort information for each column in the schema metadata with the column name plus some prefix as the key. This feels a bit rubbish though, so moving to use field metadata for all field-specific information seems like a better solution.

NB: THIS WILL BREAK ALL CURRENTLY PERSISTED PARQUET. This is possibly a further reason to get this change in now before we need to maintain backwards-compatibility for persisted data

This PR also makes SchemaBuilder non-consuming so it is a bit easier to work with