### PR TITLE
feat: Group chunks by potential overlap

### DIFF
--- a/data_types/src/partition_metadata.rs
+++ b/data_types/src/partition_metadata.rs
@@ -673,6 +673,23 @@ mod tests {
     }
 
     #[test]
+    fn statistics_overlaps_mixed_none() {
+        let stat1 = StatValues {
+            min: Some(10),
+            max: None,
+            ..Default::default()
+        };
+
+        let stat2 = StatValues {
+            min: None,
+            max: Some(5),
+            ..Default::default()
+        };
+        assert_eq!(stat1.overlaps(&stat2), StatOverlap::Unknown);
+        assert_eq!(stat2.overlaps(&stat1), StatOverlap::Unknown);
+    }
+
+    #[test]
     fn update_string() {
         let mut stat = StatValues::new_with_value("bbb".to_string());
         assert_eq!(stat.min, Some("bbb".to_string()));

--- a/data_types/src/partition_metadata.rs
+++ b/data_types/src/partition_metadata.rs
@@ -267,6 +267,17 @@ impl Statistics {
         }
     }
 
+    /// Returns true if both the min and max values are None (aka not known)
+    pub fn is_none(&self) -> bool {
+        match self {
+            Self::I64(v) => v.is_none(),
+            Self::U64(v) => v.is_none(),
+            Self::F64(v) => v.is_none(),
+            Self::Bool(v) => v.is_none(),
+            Self::String(v) => v.is_none(),
+        }
+    }
+
     /// Return the minimum value, if any, formatted as a string
     pub fn min_as_str(&self) -> Option<Cow<'_, str>> {
         match self {
@@ -391,6 +402,11 @@ where
             }
         };
     }
+
+    /// Returns true if both the min and max values are None (aka not known)
+    pub fn is_none(&self) -> bool {
+        self.min.is_none() && self.max.is_none()
+    }
 }
 
 impl<T> StatValues<T> {
@@ -433,6 +449,40 @@ impl StatValues<String> {
     pub fn string_size(&self) -> usize {
         self.min.as_ref().map(|x| x.len()).unwrap_or(0)
             + self.max.as_ref().map(|x| x.len()).unwrap_or(0)
+    }
+}
+
+/// Represents the result of comparing the min/max ranges of two [`StatValues`]
+#[derive(Debug, PartialEq)]
+pub enum StatOverlap {
+    /// There is at least one value that exists in both ranges
+    NonZero,
+
+    /// There are zero values that exists in both ranges
+    Zero,
+
+    /// It is not known if there are any intersections (e.g. because
+    /// one of the bounds is not Known / is None)
+    Unknown,
+}
+
+impl<T> StatValues<T>
+where
+    T: PartialOrd,
+{
+    /// returns information about the overlap between two `StatValues`
+    pub fn overlaps(&self, other: &Self) -> StatOverlap {
+        match (&self.min, &self.max, &other.min, &other.max) {
+            (Some(self_min), Some(self_max), Some(other_min), Some(other_max)) => {
+                if self_min <= other_max && self_max >= other_min {
+                    StatOverlap::NonZero
+                } else {
+                    StatOverlap::Zero
+                }
+            }
+            // At least one of the values was None
+            _ => StatOverlap::Unknown,
+        }
     }
 }
 
@@ -530,6 +580,99 @@ mod tests {
     }
 
     #[test]
+    fn statistics_is_none() {
+        let mut stat = StatValues::default();
+        assert!(stat.is_none());
+        stat.min = Some(0);
+        assert!(!stat.is_none());
+        stat.max = Some(1);
+        assert!(!stat.is_none());
+    }
+
+    #[test]
+    fn statistics_overlaps() {
+        let stat1 = StatValues {
+            min: Some(10),
+            max: Some(20),
+            ..Default::default()
+        };
+        assert_eq!(stat1.overlaps(&stat1), StatOverlap::NonZero);
+
+        //    [--stat1--]
+        // [--stat2--]
+        let stat2 = StatValues {
+            min: Some(5),
+            max: Some(15),
+            ..Default::default()
+        };
+        assert_eq!(stat1.overlaps(&stat2), StatOverlap::NonZero);
+        assert_eq!(stat2.overlaps(&stat1), StatOverlap::NonZero);
+
+        //    [--stat1--]
+        //        [--stat3--]
+        let stat3 = StatValues {
+            min: Some(15),
+            max: Some(25),
+            ..Default::default()
+        };
+        assert_eq!(stat1.overlaps(&stat3), StatOverlap::NonZero);
+        assert_eq!(stat3.overlaps(&stat1), StatOverlap::NonZero);
+
+        //    [--stat1--]
+        //                [--stat4--]
+        let stat4 = StatValues {
+            min: Some(25),
+            max: Some(35),
+            ..Default::default()
+        };
+        assert_eq!(stat1.overlaps(&stat4), StatOverlap::Zero);
+        assert_eq!(stat4.overlaps(&stat1), StatOverlap::Zero);
+
+        //              [--stat1--]
+        // [--stat5--]
+        let stat5 = StatValues {
+            min: Some(0),
+            max: Some(5),
+            ..Default::default()
+        };
+        assert_eq!(stat1.overlaps(&stat5), StatOverlap::Zero);
+        assert_eq!(stat5.overlaps(&stat1), StatOverlap::Zero);
+    }
+
+    #[test]
+    fn statistics_overlaps_none() {
+        let stat1 = StatValues {
+            min: Some(10),
+            max: Some(20),
+            ..Default::default()
+        };
+
+        let stat2 = StatValues {
+            min: None,
+            max: Some(20),
+            ..Default::default()
+        };
+        assert_eq!(stat1.overlaps(&stat2), StatOverlap::Unknown);
+        assert_eq!(stat2.overlaps(&stat1), StatOverlap::Unknown);
+
+        let stat3 = StatValues {
+            min: Some(10),
+            max: None,
+            ..Default::default()
+        };
+        assert_eq!(stat1.overlaps(&stat3), StatOverlap::Unknown);
+        assert_eq!(stat3.overlaps(&stat1), StatOverlap::Unknown);
+
+        let stat4 = StatValues {
+            min: None,
+            max: None,
+            ..Default::default()
+        };
+        assert_eq!(stat1.overlaps(&stat4), StatOverlap::Unknown);
+        assert_eq!(stat4.overlaps(&stat1), StatOverlap::Unknown);
+    }
+
+    #[test]
     fn update_string() {
         let mut stat = StatValues::new_with_value("bbb".to_string());
         assert_eq!(stat.min, Some("bbb".to_string()));
@@ -550,6 +693,18 @@ mod tests {
         assert_eq!(stat.min, Some("aaa".to_string()));
         assert_eq!(stat.max, Some("z".to_string()));
         assert_eq!(stat.count, 4);
+    }
+
+    #[test]
+    fn stats_is_none() {
+        let stat = Statistics::I64(StatValues::new(Some(-1), Some(100), 1));
+        assert!(!stat.is_none());
+
+        let stat = Statistics::I64(StatValues::new(None, Some(100), 1));
+        assert!(!stat.is_none());
+
+        let stat = Statistics::I64(StatValues::new(None, None, 0));
+        assert!(stat.is_none());
     }
 
     #[test]

--- a/internal_types/src/schema/builder.rs
+++ b/internal_types/src/schema/builder.rs
@@ -23,7 +23,7 @@ pub enum Error {
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
 /// Builder for a Schema
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct SchemaBuilder {
     /// Optional measurement name
     measurement: Option<String>,
@@ -121,9 +121,10 @@ impl SchemaBuilder {
         self
     }
 
-    /// Creates an Arrow schema with embedded metadata, consuming self. All
-    /// schema validation happens at this time.
-
+    /// Creates an Arrow schema with embedded metadata, resetting the
+    /// builder back to `default`. All schema validation happens at
+    /// this time.
+    ///
     /// ```
     /// use internal_types::schema::{builder::SchemaBuilder, InfluxColumnType, InfluxFieldType};
     ///

--- a/query/src/duplicate.rs
+++ b/query/src/duplicate.rs
@@ -32,9 +32,14 @@ pub enum Error {
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
 /// Groups [`Prunable`] objects into disjoint sets using values of
-/// min/max statistics. The groups are formed such that each group may
-/// contain InfluxDB data model primary key duplicates with others
-/// in that set.
+/// min/max statistics. The groups are formed such that each group
+/// *may* contain InfluxDB data model primary key duplicates with
+/// others in that set.
+///
+/// The *may* overlap calculation is conservative -- that is it may
+/// flag two chunks as having overlapping data when in reality they do
+/// not. If chunks are split into different groups, then they are
+/// guaranteed not to contain any rows with the same primary key.
 ///
 /// Note 1: since this algorithm is based on statistics, it may have
 /// false positives (flag that two objects may have overlap when in

--- a/query/src/duplicate.rs
+++ b/query/src/duplicate.rs
@@ -1,0 +1,602 @@
+//! Contains the algorithm to determine which chunks may contain
+//! "duplicate" primary keys (that is where data with the same
+//! combination of "tag" columns and timestamp in the InfluxDB
+//! DataModel have been written in via multiple distinct line protocol
+//! writes (and thus are stored in separate rows)
+
+use std::cmp::Ordering;
+
+use crate::pruning::Prunable;
+use data_types::partition_metadata::{ColumnSummary, InfluxDbType, StatOverlap, Statistics};
+use snafu::Snafu;
+
+#[derive(Debug, Snafu)]
+pub enum Error {
+    #[snafu(display(
+        "Mismatched type when comparing statistics for column '{}'",
+        column_name
+    ))]
+    MismatchedStatsTypes { column_name: String },
+
+    #[snafu(display(
+        "Internal error. Partial statistics found for column '{}' looking for duplicates. s1: '{:?}' s2: '{:?}'",
+        column_name, s1, s2
+    ))]
+    InternalPartialStatistics {
+        column_name: String,
+        s1: Statistics,
+        s2: Statistics,
+    },
+}
+
+pub type Result<T, E = Error> = std::result::Result<T, E>;
+
+/// Groups [`Prunable`] objects into disjoint sets using values of
+/// min/max statistics. The groups are formed such that each group may
+/// contain InfluxDB data model primary key duplicates with others
+/// in that set.
+///
+/// Note 1: since this algorithm is based on statistics, it may have
+/// false positives (flag that two objects may have overlap when in
+/// reality they do not)
+///
+/// Note 2: this algorithm is O(n^2) worst case (when no chunks have
+/// any overlap)
+pub fn group_potential_duplicates<C>(chunks: Vec<C>) -> Result<Vec<Vec<C>>>
+where
+    C: Prunable,
+{
+    let mut groups: Vec<Vec<KeyStats<'_, _>>> = vec![];
+
+    // Step 1: find the up groups using references to `chunks` stored
+    // in KeyStats views
+    for (idx, chunk) in chunks.iter().enumerate() {
+        // try to find a place to put this chunk
+        let mut key_stats = Some(KeyStats::new(idx, chunk));
+
+        'outer: for group in &mut groups {
+            // If this chunk overlaps any existing chunk in group add
+            // it to group
+            for ks in group.iter() {
+                if ks.potential_overlap(key_stats.as_ref().unwrap())? {
+                    group.push(key_stats.take().unwrap());
+                    break 'outer;
+                }
+            }
+        }
+
+        if let Some(key_stats) = key_stats {
+            // couldn't place key_stats in any existing group, needs a
+            // new group
+            groups.push(vec![key_stats])
+        }
+    }
+
+    // Now some shenanigans to rearrange the actual input chunks into
+    // the final resulting groups corresponding to the groups of
+    // KeyStats
+
+    // drop all references to chunks, and only keep indicides
+    let groups: Vec<Vec<usize>> = groups
+        .into_iter()
+        .map(|group| group.into_iter().map(|key_stats| key_stats.index).collect())
+        .collect();
+
+    let mut chunks: Vec<Option<C>> = chunks.into_iter().map(Some).collect();
+
+    let groups = groups
+        .into_iter()
+        .map(|group| {
+            group
+                .into_iter()
+                .map(|index| {
+                    chunks[index]
+                        .take()
+                        .expect("Internal mismatch while gathering into groups")
+                })
+                .collect::<Vec<C>>()
+        })
+        .collect::<Vec<Vec<C>>>();
+
+    Ok(groups)
+}
+
+/// Holds a view to a chunk along with information about its columns
+/// in an easy to compare form
+#[derive(Debug)]
+struct KeyStats<'a, C>
+where
+    C: Prunable,
+{
+    /// The index of the chunk
+    index: usize,
+
+    /// The underlying chunk
+    chunk: &'a C,
+
+    /// the ColumnSummaries for the chunk's 'primary_key' columns, in
+    /// "lexographical" order (aka sorted by name)
+    key_summaries: Vec<&'a ColumnSummary>,
+}
+
+impl<'a, C> KeyStats<'a, C>
+where
+    C: Prunable,
+{
+    /// Create a new view for the specified chunk at index `index`,
+    /// computing the columns to be used in the primary key comparison
+    pub fn new(index: usize, chunk: &'a C) -> Self {
+        use InfluxDbType::*;
+        let mut key_summaries: Vec<&'a ColumnSummary> = chunk
+            .summary()
+            .columns
+            .iter()
+            .filter(|s| match s.influxdb_type {
+                Some(Tag) => true,
+                Some(Field) => false,
+                Some(Timestamp) => true,
+                None => false,
+            })
+            .collect();
+
+        // Now, sort lexographically (but put timestamp last)
+        key_summaries.sort_by(
+            |a, b| match (a.influxdb_type.as_ref(), b.influxdb_type.as_ref()) {
+                (Some(Tag), Some(Tag)) => a.name.cmp(&b.name),
+                (Some(Timestamp), Some(Tag)) => Ordering::Greater,
+                (Some(Tag), Some(Timestamp)) => Ordering::Less,
+                (Some(Timestamp), Some(Timestamp)) => panic!("multiple timestamps in summary"),
+                _ => panic!("Unexpected types in key summary"),
+            },
+        );
+
+        Self {
+            index,
+            chunk,
+            key_summaries,
+        }
+    }
+
+    /// Returns true if the chunk has a potential primary key overlap with the other chunk
+    fn potential_overlap(&self, other: &Self) -> Result<bool> {
+        // in order to have overlap, *all* the columns in the sort order
+        // need to be the same. Note gaps in the sort order mean they
+        // are for different parts of the keyspace
+        if self.key_summaries.len() != other.key_summaries.len() {
+            // Short circuit on different lengths
+            return Ok(false);
+        }
+
+        let iter = self.key_summaries.iter().zip(other.key_summaries.iter());
+        for (s1, s2) in iter {
+            if s1.name != s2.name || !Self::columns_might_overlap(s1, s2)? {
+                return Ok(false);
+            }
+        }
+
+        Ok(true)
+    }
+
+    /// Returns true if the two columns MAY overlap other, based on
+    /// statistics
+    pub fn columns_might_overlap(s1: &ColumnSummary, s2: &ColumnSummary) -> Result<bool> {
+        use Statistics::*;
+        let overlap = match (&s1.stats, &s2.stats) {
+            (I64(s1), I64(s2)) => s1.overlaps(s2),
+            (U64(s1), U64(s2)) => s1.overlaps(s2),
+            (F64(s1), F64(s2)) => s1.overlaps(s2),
+            (Bool(s1), Bool(s2)) => s1.overlaps(s2),
+            (String(s1), String(s2)) => s1.overlaps(s2),
+            _ => {
+                return MismatchedStatsTypes {
+                    column_name: s1.name.clone(),
+                }
+                .fail()
+            }
+        };
+
+        // If either column has no min/max, treat the column as
+        // being entirely null
+        let is_none = s1.stats.is_none() || s2.stats.is_none();
+
+        match overlap {
+            StatOverlap::NonZero => Ok(true),
+            StatOverlap::Zero => Ok(false),
+            StatOverlap::Unknown if is_none => Ok(false), // no stats means no values
+            // This case means there some stats, but not all.
+            // Unclear how this could happen, so throw an error for now
+            StatOverlap::Unknown => InternalPartialStatistics {
+                column_name: s1.name.clone(),
+                s1: s1.stats.clone(),
+                s2: s2.stats.clone(),
+            }
+            .fail(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use arrow::datatypes::SchemaRef;
+    use data_types::partition_metadata::{
+        ColumnSummary, InfluxDbType, StatValues, Statistics, TableSummary,
+    };
+    use internal_types::schema::{builder::SchemaBuilder, TIME_COLUMN_NAME};
+
+    use super::*;
+
+    #[macro_export]
+    macro_rules! assert_groups_eq {
+        ($EXPECTED_LINES: expr, $GROUPS: expr) => {
+            let expected_lines: Vec<String> =
+                $EXPECTED_LINES.into_iter().map(|s| s.to_string()).collect();
+
+            let actual_lines = to_string($GROUPS);
+
+            assert_eq!(
+                expected_lines, actual_lines,
+                "\n\nexpected:\n\n{:#?}\nactual:\n\n{:#?}\n\n",
+                expected_lines, actual_lines
+            );
+        };
+    }
+
+    // Test cases:
+
+    #[test]
+    fn one_column_no_overlap() {
+        let c1 = TestChunk::new("chunk1").with_tag("tag1", Some("boston"), Some("mumbai"));
+
+        let c2 = TestChunk::new("chunk2").with_tag("tag1", Some("new york"), Some("zoo york"));
+
+        let groups = group_potential_duplicates(vec![c1, c2]).expect("grouping succeeded");
+
+        let expected = vec!["Group 0: [chunk1]", "Group 1: [chunk2]"];
+        assert_groups_eq!(expected, groups);
+    }
+
+    #[test]
+    fn one_column_overlap() {
+        let c1 = TestChunk::new("chunk1").with_tag("tag1", Some("boston"), Some("new york"));
+
+        let c2 = TestChunk::new("chunk2").with_tag("tag1", Some("denver"), Some("zoo york"));
+
+        let groups = group_potential_duplicates(vec![c1, c2]).expect("grouping succeeded");
+
+        let expected = vec!["Group 0: [chunk1, chunk2]"];
+        assert_groups_eq!(expected, groups);
+    }
+
+    #[test]
+    fn multi_columns() {
+        let c1 = TestChunk::new("chunk1").with_timestamp(0, 1000).with_tag(
+            "tag1",
+            Some("boston"),
+            Some("new york"),
+        );
+
+        // Overlaps in tag1, but not in time
+        let c2 = TestChunk::new("chunk2")
+            .with_tag("tag1", Some("denver"), Some("zoo york"))
+            .with_timestamp(2000, 3000);
+
+        // Overlaps in time, but not in tag1
+        let c3 = TestChunk::new("chunk3")
+            .with_tag("tag1", Some("zzx"), Some("zzy"))
+            .with_timestamp(500, 1500);
+
+        // Overlaps in time, and in tag1
+        let c4 = TestChunk::new("chunk4")
+            .with_tag("tag1", Some("aaa"), Some("zzz"))
+            .with_timestamp(500, 1500);
+
+        let groups = group_potential_duplicates(vec![c1, c2, c3, c4]).expect("grouping succeeded");
+
+        let expected = vec![
+            "Group 0: [chunk1, chunk4]",
+            "Group 1: [chunk2]",
+            "Group 2: [chunk3]",
+        ];
+        assert_groups_eq!(expected, groups);
+    }
+
+    #[test]
+    fn boundary() {
+        // check that overlap calculations include the bound
+        let c1 = TestChunk::new("chunk1").with_tag("tag1", Some("aaa"), Some("bbb"));
+        let c2 = TestChunk::new("chunk2").with_tag("tag1", Some("bbb"), Some("ccc"));
+
+        let groups = group_potential_duplicates(vec![c1, c2]).expect("grouping succeeded");
+
+        let expected = vec!["Group 0: [chunk1, chunk2]"];
+        assert_groups_eq!(expected, groups);
+    }
+
+    #[test]
+    fn same() {
+        // check that if chunks overlap exactly on the boundaries they are still grouped
+        let c1 = TestChunk::new("chunk1").with_tag("tag1", Some("aaa"), Some("bbb"));
+        let c2 = TestChunk::new("chunk2").with_tag("tag1", Some("aaa"), Some("bbb"));
+
+        let groups = group_potential_duplicates(vec![c1, c2]).expect("grouping succeeded");
+
+        let expected = vec!["Group 0: [chunk1, chunk2]"];
+        assert_groups_eq!(expected, groups);
+    }
+
+    #[test]
+    fn different_tag_names() {
+        // check that if chunks overlap but in different tag names
+        let c1 = TestChunk::new("chunk1").with_tag("tag1", Some("aaa"), Some("bbb"));
+        let c2 = TestChunk::new("chunk2").with_tag("tag2", Some("aaa"), Some("bbb"));
+
+        let groups = group_potential_duplicates(vec![c1, c2]).expect("grouping succeeded");
+
+        let expected = vec!["Group 0: [chunk1]", "Group 1: [chunk2]"];
+        assert_groups_eq!(expected, groups);
+    }
+
+    #[test]
+    fn three_column() {
+        let c1 = TestChunk::new("chunk1")
+            .with_tag("tag1", Some("aaa"), Some("bbb"))
+            .with_tag("tag2", Some("xxx"), Some("yyy"))
+            .with_timestamp(0, 1000);
+
+        let c2 = TestChunk::new("chunk2")
+            .with_tag("tag1", Some("aaa"), Some("bbb"))
+            .with_tag("tag2", Some("xxx"), Some("yyy"))
+            // Timestamp doesn't overlap, but the two tags do
+            .with_timestamp(2001, 3000);
+
+        let c3 = TestChunk::new("chunk3")
+            .with_tag("tag1", Some("aaa"), Some("bbb"))
+            .with_tag("tag2", Some("aaa"), Some("zzz"))
+            // all three overlap
+            .with_timestamp(1000, 2000);
+
+        let groups = group_potential_duplicates(vec![c1, c2, c3]).expect("grouping succeeded");
+
+        let expected = vec!["Group 0: [chunk1, chunk3]", "Group 1: [chunk2]"];
+        assert_groups_eq!(expected, groups);
+    }
+
+    #[test]
+    fn tag_order() {
+        let c1 = TestChunk::new("chunk1")
+            .with_tag("tag1", Some("aaa"), Some("bbb"))
+            .with_tag("tag2", Some("xxx"), Some("yyy"))
+            .with_timestamp(0, 1000);
+
+        let c2 = TestChunk::new("chunk2")
+            .with_tag("tag2", Some("aaa"), Some("zzz"))
+            .with_tag("tag1", Some("aaa"), Some("bbb"))
+            // all three overlap, but tags in different order
+            .with_timestamp(500, 1000);
+
+        let groups = group_potential_duplicates(vec![c1, c2]).expect("grouping succeeded");
+
+        let expected = vec!["Group 0: [chunk1, chunk2]"];
+        assert_groups_eq!(expected, groups);
+    }
+
+    #[test]
+    fn tag_order_no_tags() {
+        let c1 = TestChunk::new("chunk1")
+            .with_tag("tag1", Some("aaa"), Some("bbb"))
+            .with_tag("tag2", Some("xxx"), Some("yyy"))
+            .with_timestamp(0, 1000);
+
+        let c2 = TestChunk::new("chunk2")
+            // tag1 and timestamp overlap, but no tag2 (aka it is all null)
+            .with_tag("tag1", Some("aaa"), Some("bbb"))
+            .with_timestamp(500, 1000);
+
+        let groups = group_potential_duplicates(vec![c1, c2]).expect("grouping succeeded");
+
+        let expected = vec!["Group 0: [chunk1]", "Group 1: [chunk2]"];
+        assert_groups_eq!(expected, groups);
+    }
+
+    #[test]
+    fn tag_order_null_stats() {
+        let c1 = TestChunk::new("chunk1")
+            .with_tag("tag1", Some("aaa"), Some("bbb"))
+            .with_tag("tag2", Some("xxx"), Some("yyy"))
+            .with_timestamp(0, 1000);
+
+        let c2 = TestChunk::new("chunk2")
+            // tag1 and timestamp overlap, tag2 has no stats (null)
+            // so we say they can't overlap
+            .with_tag("tag1", Some("aaa"), Some("bbb"))
+            .with_tag("tag2", None, None)
+            .with_timestamp(500, 1000);
+
+        let groups = group_potential_duplicates(vec![c1, c2]).expect("grouping succeeded");
+
+        let expected = vec!["Group 0: [chunk1]", "Group 1: [chunk2]"];
+        assert_groups_eq!(expected, groups);
+    }
+
+    #[test]
+    fn tag_order_partial_stats() {
+        let c1 = TestChunk::new("chunk1")
+            .with_tag("tag1", Some("aaa"), Some("bbb"))
+            .with_timestamp(0, 1000);
+
+        let c2 = TestChunk::new("chunk2")
+            // tag1 has a min but not a max. Should result in error
+            .with_tag("tag1", Some("aaa"), None)
+            .with_timestamp(500, 1000);
+
+        let result = group_potential_duplicates(vec![c1, c2]).unwrap_err();
+
+        let result = result.to_string();
+        let expected =
+            "Internal error. Partial statistics found for column 'tag1' looking for duplicates";
+        assert!(
+            result.contains(expected),
+            "can not find {} in {}",
+            expected,
+            result
+        );
+    }
+
+    #[test]
+    fn tag_fields_not_counted() {
+        let c1 = TestChunk::new("chunk1")
+            .with_tag("tag1", Some("aaa"), Some("bbb"))
+            .with_int_field("field", Some(0), Some(2))
+            .with_timestamp(0, 1000);
+
+        let c2 = TestChunk::new("chunk2")
+            // tag1 and timestamp overlap, but field value does not
+            // should still overlap
+            .with_tag("tag1", Some("aaa"), Some("bbb"))
+            .with_int_field("field", Some(100), Some(200))
+            .with_timestamp(500, 1000);
+
+        let groups = group_potential_duplicates(vec![c1, c2]).expect("grouping succeeded");
+
+        let expected = vec!["Group 0: [chunk1, chunk2]"];
+        assert_groups_eq!(expected, groups);
+    }
+
+    #[test]
+    fn mismatched_types() {
+        // Test if same column has different types in different
+        // chunks; this will likely cause errors elsewhere in practice
+        // as the schemas are incompatible (and can't be merged)
+        let c1 = TestChunk::new("chunk1")
+            .with_tag("tag1", Some("aaa"), Some("bbb"))
+            .with_timestamp(0, 1000);
+
+        let c2 = TestChunk::new("chunk2")
+            // tag1 column is actually a field is different in chunk
+            // 2, so even though the timestamps overlap these chunks
+            // don't have duplicates
+            .with_int_field("tag1", Some(100), Some(200))
+            .with_timestamp(0, 1000);
+
+        let groups = group_potential_duplicates(vec![c1, c2]).expect("grouping succeeded");
+
+        let expected = vec!["Group 0: [chunk1]", "Group 1: [chunk2]"];
+        assert_groups_eq!(expected, groups);
+    }
+
+    // --- Test infrastructure --
+
+    fn to_string(groups: Vec<Vec<TestChunk>>) -> Vec<String> {
+        let mut s = vec![];
+        for (idx, group) in groups.iter().enumerate() {
+            let names = group.iter().map(|c| c.name.as_str()).collect::<Vec<_>>();
+            s.push(format!("Group {}: [{}]", idx, names.join(", ")));
+        }
+        s
+    }
+
+    /// Mocked out prunable provider to use testing overlaps
+    #[derive(Debug)]
+    struct TestChunk {
+        // The name of this chunk
+        name: String,
+        summary: TableSummary,
+        builder: SchemaBuilder,
+    }
+
+    /// Implementation of creating a new column with statitics for TestPrunable
+    macro_rules! make_stats {
+        ($MIN:expr, $MAX:expr, $STAT_TYPE:ident) => {{
+            Statistics::$STAT_TYPE(StatValues {
+                distinct_count: None,
+                min: $MIN,
+                max: $MAX,
+                count: 42,
+            })
+        }};
+    }
+
+    impl TestChunk {
+        /// Create a new TestChunk with a specified name
+        fn new(name: impl Into<String>) -> Self {
+            let name = name.into();
+            let summary = TableSummary::new(name.clone());
+            let builder = SchemaBuilder::new();
+            Self {
+                name,
+                summary,
+                builder,
+            }
+        }
+
+        /// Adds a tag column with the specified min/max values
+        fn with_tag(
+            mut self,
+            name: impl Into<String>,
+            min: Option<&str>,
+            max: Option<&str>,
+        ) -> Self {
+            let min = min.map(|v| v.to_string());
+            let max = max.map(|v| v.to_string());
+
+            let tag_name = name.into();
+            self.builder.tag(&tag_name);
+
+            self.summary.columns.push(ColumnSummary {
+                name: tag_name,
+                influxdb_type: Some(InfluxDbType::Tag),
+                stats: make_stats!(min, max, String),
+            });
+            self
+        }
+
+        /// Adds a timestamp column with the specified min/max values
+        fn with_timestamp(mut self, min: i64, max: i64) -> Self {
+            self.builder.timestamp();
+
+            let min = Some(min);
+            let max = Some(max);
+
+            self.summary.columns.push(ColumnSummary {
+                name: TIME_COLUMN_NAME.into(),
+                influxdb_type: Some(InfluxDbType::Timestamp),
+                stats: make_stats!(min, max, I64),
+            });
+            self
+        }
+
+        /// Adds an I64 field column with the specified min/max values
+        fn with_int_field(
+            mut self,
+            name: impl Into<String>,
+            min: Option<i64>,
+            max: Option<i64>,
+        ) -> Self {
+            let field_name = name.into();
+            self.builder
+                .field(&field_name, arrow::datatypes::DataType::Int64);
+
+            self.summary.columns.push(ColumnSummary {
+                name: field_name,
+                influxdb_type: Some(InfluxDbType::Field),
+                stats: make_stats!(min, max, I64),
+            });
+            self
+        }
+    }
+
+    impl Prunable for TestChunk {
+        fn summary(&self) -> &TableSummary {
+            &self.summary
+        }
+
+        fn schema(&self) -> SchemaRef {
+            self.builder
+                // need to clone because `build` resets builder state
+                .clone()
+                .build()
+                .expect("created schema")
+                .as_arrow()
+        }
+    }
+}

--- a/query/src/lib.rs
+++ b/query/src/lib.rs
@@ -16,6 +16,7 @@ use pruning::Prunable;
 
 use std::{fmt::Debug, sync::Arc};
 
+pub mod duplicate;
 pub mod exec;
 pub mod frontend;
 pub mod func;


### PR DESCRIPTION
Re https://github.com/influxdata/influxdb_iox/issues/1645 
# Rationale:
As part of #600 we need to combine chunks which *may* contain "duplicate" primary keys in the InfluxDB Data Model. Duplicate primary key in this case means where data with the same combination of `tag` and `timestamp` columns   have been written in via multiple line protocol writes.

You can read more background in the [design document](https://docs.google.com/document/d/1iD_Q2kpC2Kopo4DEq_Oym4jEvaz-SfUUVmr_dpMcikc/edit#)

# Changes:
1. Introduce a new module, `duplicates.rs` 
2. Implement a `group_potential_duplicates` function in terms of min/max statistics (can feed in `PartitionChunks` directly)
3. Add code in `Statistics` and `StatValues` to compute min/max overlaps

# Open Questions
1. As written, the chunk grouping code relies on the InfluxDB data model (aka it looks at tags and timestamp columns directly). We could make this more general by implementing it in terms of a more general "primary key" concept. However, such a concept does not yet exist and thus I am not sure how that would work

# Future work:
Here are two more parts I think are needed to complete https://github.com/influxdata/influxdb_iox/issues/1645:
1. Add a "may_contain_pk_duplicate" function in PartitionChunk to signify if the chunk has potential duplicates *within* itself
3. Implement `split_overlapped_chunks` in terms of group_duplicates and may_contain_duplicates

