### PR TITLE
feat: enable not equal operator for the influxrpc frontend

### DIFF
--- a/query/src/frontend/influxrpc.rs
+++ b/query/src/frontend/influxrpc.rs
@@ -1206,6 +1206,7 @@ impl ExpressionVisitor for SupportVisitor {
             Expr::BinaryExpr { op, .. } => {
                 match op {
                     Operator::Eq
+                    | Operator::NotEq
                     | Operator::Lt
                     | Operator::LtEq
                     | Operator::Gt
@@ -1217,7 +1218,7 @@ impl ExpressionVisitor for SupportVisitor {
                     | Operator::And
                     | Operator::Or => Ok(Recursion::Continue(self)),
                     // Unsupported (need to think about ramifications)
-                    Operator::NotEq | Operator::Modulus | Operator::Like | Operator::NotLike => {
+                    Operator::Modulus | Operator::Like | Operator::NotLike => {
                         Err(DataFusionError::NotImplemented(format!(
                             "Unsupported operator in gRPC: {:?} in expression {:?}",
                             op, expr

--- a/query_tests/src/influxrpc/read_filter.rs
+++ b/query_tests/src/influxrpc/read_filter.rs
@@ -160,6 +160,18 @@ async fn test_read_filter_data_filter() {
         "+------+-------+------+-------------------------------+",
     ];
 
+    run_read_filter_test_case!(
+        TwoMeasurementsMultiSeries {},
+        predicate,
+        expected_results.clone()
+    );
+
+    // Same results via a != predicate.
+    let predicate = PredicateBuilder::default()
+        .timestamp_range(200, 300)
+        .add_expr(col("state").not_eq(lit("MA"))) // state=CA
+        .build();
+
     run_read_filter_test_case!(TwoMeasurementsMultiSeries {}, predicate, expected_results);
 }
 


### PR DESCRIPTION
Closes #1655 closes https://github.com/influxdata/influxdb_iox/issues/554

This PR implements the required functionality to enable `!=` operations on tags for the InfluxRPC frontend.