### PR TITLE
feat: Hook up chunk grouping into provider

### DIFF
--- a/query/src/lib.rs
+++ b/query/src/lib.rs
@@ -66,6 +66,10 @@ pub trait PartitionChunk: Prunable + Debug + Send + Sync {
     /// Returns the name of the table stored in this chunk
     fn table_name(&self) -> &str;
 
+    /// Returns true if the chunk may contain a duplicate "primary
+    /// key" within itself
+    fn may_contain_pk_duplicates(&self) -> bool;
+
     /// Returns the result of applying the `predicate` to the chunk
     /// using an efficient, but inexact method, based on metadata.
     ///

--- a/query/src/provider.rs
+++ b/query/src/provider.rs
@@ -369,7 +369,7 @@ impl<C: PartitionChunk + 'static> Deduplicater<C> {
         // merge all plans into the same
         self.no_duplicates_chunks
             .append(&mut self.in_chunk_duplicates_chunks);
-        for mut group in self.overlapped_chunks_set.iter_mut() {
+        for mut group in &mut self.overlapped_chunks_set {
             self.no_duplicates_chunks.append(&mut group);
         }
         self.overlapped_chunks_set.clear();

--- a/query/src/provider.rs
+++ b/query/src/provider.rs
@@ -321,38 +321,38 @@ impl<C: PartitionChunk + 'static> Deduplicater<C> {
     /// The final UnionExec on top is to union the streams below. If there is only one stream, UnionExec
     ///   will not be added into the plan.
     /// ```text
-    ///                                      ┌─────────────────┐
-    ///                                      │    UnionExec    │
-    ///                                      │                 │
-    ///                                      └─────────────────┘
-    ///                                               ▲
-    ///                                               │
-    ///                        ┌──────────────────────┴───────────┬─────────────────────┐
-    ///                        │                                  │                     │
-    ///                        │                                  │                     │
+    ///                                      ┌─────────────────┐                                  
+    ///                                      │    UnionExec    │                                  
+    ///                                      │                 │                                  
+    ///                                      └─────────────────┘                                  
+    ///                                               ▲                                           
+    ///                                               │                                           
+    ///                        ┌──────────────────────┴───────────┬─────────────────────┐         
+    ///                        │                                  │                     │         
+    ///                        │                                  │                     │         
     ///               ┌─────────────────┐                ┌─────────────────┐   ┌─────────────────┐
     ///               │ DeduplicateExec │                │ DeduplicateExec │   │IOxReadFilterNode│
     ///               └─────────────────┘                └─────────────────┘   │    (Chunk 4)    │
     ///                        ▲                                  ▲            └─────────────────┘
-    ///                        │                                  │
-    ///            ┌───────────────────────┐                      │
-    ///            │SortPreservingMergeExec│                      │
-    ///            └───────────────────────┘                      │
+    ///                        │                                  │                               
+    ///            ┌───────────────────────┐                      │                               
+    ///            │SortPreservingMergeExec│                      │                               
+    ///            └───────────────────────┘                      │                               
     ///                       ▲                                   |
     ///                       │                                   |
-    ///           ┌───────────┴───────────┐                       │
-    ///           │                       │                       │
-    ///  ┌─────────────────┐     ┌─────────────────┐    ┌─────────────────┐
-    ///  │    SortExec     │     │    SortExec     │    │    SortExec     │
-    ///  │   (optional)    │     │   (optional)    │    │   (optional)    │
-    ///  └─────────────────┘     └─────────────────┘    └─────────────────┘
-    ///           ▲                       ▲                      ▲
-    ///           │                       │                      │
-    ///           │                       │                      │
-    ///  ┌─────────────────┐     ┌─────────────────┐    ┌─────────────────┐
-    ///  │IOxReadFilterNode│     │IOxReadFilterNode│    │IOxReadFilterNode│
-    ///  │    (Chunk 1)    │     │    (Chunk 2)    │    │    (Chunk 3)    │
-    ///  └─────────────────┘     └─────────────────┘    └─────────────────┘
+    ///           ┌───────────┴───────────┐                       │                               
+    ///           │                       │                       │                               
+    ///  ┌─────────────────┐     ┌─────────────────┐    ┌─────────────────┐                      
+    ///  │    SortExec     │     │    SortExec     │    │    SortExec     │                      
+    ///  │   (optional)    │     │   (optional)    │    │   (optional)    │                      
+    ///  └─────────────────┘     └─────────────────┘    └─────────────────┘                      
+    ///           ▲                       ▲                      ▲                               
+    ///           │                       │                      │                               
+    ///           │                       │                      │                               
+    ///  ┌─────────────────┐     ┌─────────────────┐    ┌─────────────────┐                      
+    ///  │IOxReadFilterNode│     │IOxReadFilterNode│    │IOxReadFilterNode│                      
+    ///  │    (Chunk 1)    │     │    (Chunk 2)    │    │    (Chunk 3)    │                      
+    ///  └─────────────────┘     └─────────────────┘    └─────────────────┘                      
     ///```
 
     fn build_scan_plan(
@@ -459,29 +459,29 @@ impl<C: PartitionChunk + 'static> Deduplicater<C> {
     /// Return deduplicate plan for the given overlapped chunks
     /// The plan will look like this
     /// ```text
-    ///               ┌─────────────────┐
-    ///               │ DeduplicateExec │
-    ///               └─────────────────┘
-    ///                        ▲
-    ///                        │
-    ///            ┌───────────────────────┐
-    ///            │SortPreservingMergeExec│
-    ///            └───────────────────────┘
-    ///                       ▲
-    ///                       │
-    ///           ┌───────────┴───────────┐
-    ///           │                       │
-    ///  ┌─────────────────┐        ┌─────────────────┐
-    ///  │    SortExec     │ ...    │    SortExec     │
-    ///  │   (optional)    │        │   (optional)    │
-    ///  └─────────────────┘        └─────────────────┘
-    ///           ▲                          ▲
-    ///           │          ...             │
-    ///           │                          │
-    ///  ┌─────────────────┐        ┌─────────────────┐
-    ///  │IOxReadFilterNode│        │IOxReadFilterNode│
-    ///  │    (Chunk 1)    │ ...    │    (Chunk n)    │
-    ///  └─────────────────┘        └─────────────────┘
+    ///               ┌─────────────────┐       
+    ///               │ DeduplicateExec │         
+    ///               └─────────────────┘        
+    ///                        ▲                            
+    ///                        │                                                                 
+    ///            ┌───────────────────────┐                                                   
+    ///            │SortPreservingMergeExec│                                                     
+    ///            └───────────────────────┘                                                    
+    ///                       ▲                                   
+    ///                       │                                   
+    ///           ┌───────────┴───────────┐                                                     
+    ///           │                       │                                                     
+    ///  ┌─────────────────┐        ┌─────────────────┐                        
+    ///  │    SortExec     │ ...    │    SortExec     │                        
+    ///  │   (optional)    │        │   (optional)    │                        
+    ///  └─────────────────┘        └─────────────────┘                      
+    ///           ▲                          ▲                                                  
+    ///           │          ...             │                                                   
+    ///           │                          │                                                 
+    ///  ┌─────────────────┐        ┌─────────────────┐                         
+    ///  │IOxReadFilterNode│        │IOxReadFilterNode│                        
+    ///  │    (Chunk 1)    │ ...    │    (Chunk n)    │                         
+    ///  └─────────────────┘        └─────────────────┘                          
     ///```
     fn build_deduplicate_plan_for_overlapped_chunks(
         table_name: Arc<str>,
@@ -502,22 +502,22 @@ impl<C: PartitionChunk + 'static> Deduplicater<C> {
     /// Return deduplicate plan for a given chunk with duplicates
     /// The plan will look like this
     /// ```text
-    ///                ┌─────────────────┐
-    ///                │ DeduplicateExec │
-    ///                └─────────────────┘
-    ///                        ▲
-    ///                        │
-    ///                ┌─────────────────┐
-    ///                │    SortExec     │
-    ///                │   (optional)    │
-    ///                └─────────────────┘
-    ///                          ▲
-    ///                          │
-    ///                          │
-    ///                ┌─────────────────┐
-    ///                │IOxReadFilterNode│
-    ///                │    (Chunk)      │
-    ///                └─────────────────┘
+    ///                ┌─────────────────┐   
+    ///                │ DeduplicateExec │   
+    ///                └─────────────────┘   
+    ///                        ▲             
+    ///                        │             
+    ///                ┌─────────────────┐   
+    ///                │    SortExec     │   
+    ///                │   (optional)    │   
+    ///                └─────────────────┘   
+    ///                          ▲           
+    ///                          │           
+    ///                          │           
+    ///                ┌─────────────────┐   
+    ///                │IOxReadFilterNode│   
+    ///                │    (Chunk)      │   
+    ///                └─────────────────┘   
     ///```
     fn build_deduplicate_plan_for_chunk_with_duplicates(
         table_name: Arc<str>,
@@ -537,10 +537,10 @@ impl<C: PartitionChunk + 'static> Deduplicater<C> {
 
     /// Return the simplest IOx scan plan of a given chunk which is IOxReadFilterNode
     /// ```text
-    ///                ┌─────────────────┐
-    ///                │IOxReadFilterNode│
-    ///                │    (Chunk)      │
-    ///                └─────────────────┘
+    ///                ┌─────────────────┐   
+    ///                │IOxReadFilterNode│   
+    ///                │    (Chunk)      │   
+    ///                └─────────────────┘   
     ///```
     fn build_plan_for_non_duplicates_chunk(
         table_name: Arc<str>,
@@ -558,10 +558,10 @@ impl<C: PartitionChunk + 'static> Deduplicater<C> {
 
     /// Return the simplest IOx scan plan for many chunks which is IOxReadFilterNode
     /// ```text
-    ///                ┌─────────────────┐
-    ///                │IOxReadFilterNode│
-    ///                │    (Chunk)      │
-    ///                └─────────────────┘
+    ///                ┌─────────────────┐   
+    ///                │IOxReadFilterNode│   
+    ///                │    (Chunk)      │   
+    ///                └─────────────────┘   
     ///```
     fn build_plans_for_non_duplicates_chunk(
         table_name: Arc<str>,

--- a/query/src/pruning.rs
+++ b/query/src/pruning.rs
@@ -1,4 +1,6 @@
 //! Implementation of statistics based pruning
+use std::sync::Arc;
+
 use arrow::{array::ArrayRef, datatypes::SchemaRef};
 use data_types::partition_metadata::{ColumnSummary, Statistics, TableSummary};
 use datafusion::{
@@ -18,6 +20,19 @@ pub trait Prunable: Sized {
 
     /// return the schema of the data in this [`Prunable`]
     fn schema(&self) -> SchemaRef;
+}
+
+impl<P> Prunable for Arc<P>
+where
+    P: Prunable,
+{
+    fn summary(&self) -> &TableSummary {
+        self.as_ref().summary()
+    }
+
+    fn schema(&self) -> SchemaRef {
+        self.as_ref().schema()
+    }
 }
 
 /// Something that cares to be notified when pruning of chunks occurs

--- a/query/src/test.rs
+++ b/query/src/test.rs
@@ -224,7 +224,7 @@ impl TestChunk {
             .expect("had table summary")
             .columns
             .iter_mut()
-            .find(|c| &c.name == &column_name)
+            .find(|c| c.name == column_name)
             .expect("had column");
 
         column_summary.stats = Statistics::String(StatValues {

--- a/server/src/db/chunk.rs
+++ b/server/src/db/chunk.rs
@@ -217,6 +217,13 @@ impl PartitionChunk for DbChunk {
         self.table_name.as_ref()
     }
 
+    fn may_contain_pk_duplicates(&self) -> bool {
+        // Assume that the MUB can contain duplicates as it has the
+        // raw incoming stream of writes, but that all other types of
+        // chunks are deduplicated as part of creation
+        matches!(self.state, State::ReadBuffer { .. })
+    }
+
     fn apply_predicate(&self, predicate: &Predicate) -> Result<PredicateMatch> {
         if !predicate.should_include_table(self.table_name().as_ref()) {
             return Ok(PredicateMatch::Zero);


### PR DESCRIPTION
Closes https://github.com/influxdata/influxdb_iox/issues/1645

# Rationale:
As part of #600 we need to combine chunks which may contain "duplicate" primary keys. You can read more background in the [design document](https://docs.google.com/document/d/1iD_Q2kpC2Kopo4DEq_Oym4jEvaz-SfUUVmr_dpMcikc/edit#)

Kudos to @NGA-TRAN for making it so clear what was needed.c

# Changes:
1. Add a `may_contain_pk_duplicates` function in PartitionChunk to signify if the chunk has potential duplicates *within* itself
2. Implement `split_overlapped_chunks` in terms of group_duplicates and may_contain_duplicates
3. tests for same

