### PR TITLE
chore: enforce `clippy::future_not_send` for `parquet_file,object_store`

### DIFF
--- a/object_store/src/buffer.rs
+++ b/object_store/src/buffer.rs
@@ -34,7 +34,7 @@ where
 // A stream fully buffered by a backing store..
 pub struct BufferedStream<R>
 where
-    R: AsyncRead + AsyncWrite + AsyncSeek + Unpin,
+    R: AsyncRead + AsyncWrite + AsyncSeek + Send + Unpin,
 {
     size: usize,
     inner: ReaderStream<R>,
@@ -42,7 +42,7 @@ where
 
 impl<R> BufferedStream<R>
 where
-    R: AsyncRead + AsyncWrite + AsyncSeek + Unpin,
+    R: AsyncRead + AsyncWrite + AsyncSeek + Send + Unpin,
 {
     /// Consumes the bytes stream fully and writes its content into file.
     /// It returns a Stream implementation that reads the same content from the
@@ -71,7 +71,7 @@ where
 
 impl<R> Stream for BufferedStream<R>
 where
-    R: AsyncRead + AsyncWrite + AsyncSeek + Unpin,
+    R: AsyncRead + AsyncWrite + AsyncSeek + Send + Unpin,
 {
     type Item = Result<Bytes>;
 
@@ -98,7 +98,7 @@ mod tests {
 
     async fn check_stream<R>(buf_stream: BufferedStream<R>)
     where
-        R: AsyncRead + AsyncWrite + AsyncSeek + Unpin,
+        R: AsyncRead + AsyncWrite + AsyncSeek + Send + Unpin,
     {
         assert_eq!(buf_stream.size(), 9);
         assert_eq!(buf_stream.size_hint(), (9, Some(9)));

--- a/object_store/src/lib.rs
+++ b/object_store/src/lib.rs
@@ -4,6 +4,7 @@
     missing_debug_implementations,
     missing_docs,
     clippy::explicit_iter_loop,
+    clippy::future_not_send,
     clippy::use_self,
     clippy::clone_on_ref_ptr
 )]

--- a/parquet_file/src/cleanup.rs
+++ b/parquet_file/src/cleanup.rs
@@ -45,7 +45,7 @@ pub async fn cleanup_unreferenced_parquet_files<S>(
     max_files: usize,
 ) -> Result<()>
 where
-    S: CatalogState,
+    S: CatalogState + Send + Sync,
 {
     // Create a transaction to prevent parallel modifications of the catalog. This avoids that we delete files there
     // that are about to get added to the catalog.

--- a/parquet_file/src/lib.rs
+++ b/parquet_file/src/lib.rs
@@ -3,6 +3,7 @@
     missing_copy_implementations,
     missing_debug_implementations,
     clippy::explicit_iter_loop,
+    clippy::future_not_send,
     clippy::use_self,
     clippy::clone_on_ref_ptr
 )]

--- a/server/src/db.rs
+++ b/server/src/db.rs
@@ -3021,15 +3021,13 @@ mod tests {
             .await
             .unwrap()
             .unwrap();
-        let mut paths_actual: Vec<String> = preserved_catalog
-            .state()
-            .inner
-            .borrow()
-            .parquet_files
-            .keys()
-            .map(|p| p.display())
-            .collect();
-        paths_actual.sort();
+        let paths_actual = {
+            let state = preserved_catalog.state();
+            let guard = state.inner.lock();
+            let mut tmp: Vec<String> = guard.parquet_files.keys().map(|p| p.display()).collect();
+            tmp.sort();
+            tmp
+        };
         assert_eq!(paths_actual, paths_expected);
 
         // ==================== do: re-load DB ====================


### PR DESCRIPTION
See https://rust-lang.github.io/rust-clippy/stable/index.html#future_not_send . It's super annoying when you write a lib function and later during integration figure out that it doesn't work in all cases because of tokios `Send` requirement. This only addresses two crates for now, will clippify more later.
