### PR TITLE
chore: enforce `clippy::future_not_send` for `influxdb_iox_client,influxdb2_client,query,tracker`

### DIFF
--- a/influxdb2_client/src/api/write.rs
+++ b/influxdb2_client/src/api/write.rs
@@ -14,7 +14,7 @@ impl Client {
         &self,
         org: &str,
         bucket: &str,
-        body: impl Into<Body>,
+        body: impl Into<Body> + Send,
     ) -> Result<(), RequestError> {
         let body = body.into();
         let write_url = format!("{}/api/v2/write", self.url);

--- a/influxdb2_client/src/lib.rs
+++ b/influxdb2_client/src/lib.rs
@@ -5,7 +5,8 @@
     missing_docs,
     clippy::explicit_iter_loop,
     clippy::use_self,
-    clippy::clone_on_ref_ptr
+    clippy::clone_on_ref_ptr,
+    clippy::future_not_send
 )]
 
 //! # influxdb2_client

--- a/influxdb_iox_client/src/client/flight.rs
+++ b/influxdb_iox_client/src/client/flight.rs
@@ -94,8 +94,8 @@ impl Client {
     /// [`PerformQuery`] instance that streams Arrow `RecordBatch` results.
     pub async fn perform_query(
         &mut self,
-        database_name: impl Into<String>,
-        sql_query: impl Into<String>,
+        database_name: impl Into<String> + Send,
+        sql_query: impl Into<String> + Send,
     ) -> Result<PerformQuery, Error> {
         PerformQuery::new(self, database_name.into(), sql_query.into()).await
     }

--- a/influxdb_iox_client/src/client/health.rs
+++ b/influxdb_iox_client/src/client/health.rs
@@ -44,7 +44,7 @@ impl Client {
     }
 
     /// Returns `Ok()` if the corresponding service is serving
-    pub async fn check(&mut self, service: impl Into<String>) -> Result<()> {
+    pub async fn check(&mut self, service: impl Into<String> + Send) -> Result<()> {
         use health_check_response::ServingStatus;
 
         let status = self

--- a/influxdb_iox_client/src/client/management.rs
+++ b/influxdb_iox_client/src/client/management.rs
@@ -415,7 +415,7 @@ impl Client {
     /// Get database configuration
     pub async fn get_database(
         &mut self,
-        name: impl Into<String>,
+        name: impl Into<String> + Send,
     ) -> Result<DatabaseRules, GetDatabaseError> {
         let response = self
             .inner
@@ -438,7 +438,7 @@ impl Client {
     /// List chunks in a database.
     pub async fn list_chunks(
         &mut self,
-        db_name: impl Into<String>,
+        db_name: impl Into<String> + Send,
     ) -> Result<Vec<Chunk>, ListChunksError> {
         let db_name = db_name.into();
 
@@ -467,7 +467,7 @@ impl Client {
     pub async fn update_remote(
         &mut self,
         id: u32,
-        connection_string: impl Into<String>,
+        connection_string: impl Into<String> + Send,
     ) -> Result<(), UpdateRemoteError> {
         self.inner
             .update_remote(UpdateRemoteRequest {
@@ -493,7 +493,7 @@ impl Client {
     /// List all partitions of the database
     pub async fn list_partitions(
         &mut self,
-        db_name: impl Into<String>,
+        db_name: impl Into<String> + Send,
     ) -> Result<Vec<Partition>, ListPartitionsError> {
         let db_name = db_name.into();
         let response = self
@@ -514,8 +514,8 @@ impl Client {
     /// Get details about a specific partition
     pub async fn get_partition(
         &mut self,
-        db_name: impl Into<String>,
-        partition_key: impl Into<String>,
+        db_name: impl Into<String> + Send,
+        partition_key: impl Into<String> + Send,
     ) -> Result<Partition, GetPartitionError> {
         let db_name = db_name.into();
         let partition_key = partition_key.into();
@@ -541,8 +541,8 @@ impl Client {
     /// List chunks in a partition
     pub async fn list_partition_chunks(
         &mut self,
-        db_name: impl Into<String>,
-        partition_key: impl Into<String>,
+        db_name: impl Into<String> + Send,
+        partition_key: impl Into<String> + Send,
     ) -> Result<Vec<Chunk>, ListPartitionChunksError> {
         let db_name = db_name.into();
         let partition_key = partition_key.into();
@@ -564,9 +564,9 @@ impl Client {
     /// Create a new chunk in a partittion
     pub async fn new_partition_chunk(
         &mut self,
-        db_name: impl Into<String>,
-        partition_key: impl Into<String>,
-        table_name: impl Into<String>,
+        db_name: impl Into<String> + Send,
+        partition_key: impl Into<String> + Send,
+        table_name: impl Into<String> + Send,
     ) -> Result<(), NewPartitionChunkError> {
         let db_name = db_name.into();
         let partition_key = partition_key.into();
@@ -615,9 +615,9 @@ impl Client {
     /// Returns the job tracking the data's movement
     pub async fn close_partition_chunk(
         &mut self,
-        db_name: impl Into<String>,
-        partition_key: impl Into<String>,
-        table_name: impl Into<String>,
+        db_name: impl Into<String> + Send,
+        partition_key: impl Into<String> + Send,
+        table_name: impl Into<String> + Send,
         chunk_id: u32,
     ) -> Result<Operation, ClosePartitionChunkError> {
         let db_name = db_name.into();

--- a/influxdb_iox_client/src/client/write.rs
+++ b/influxdb_iox_client/src/client/write.rs
@@ -61,8 +61,8 @@ impl Client {
     /// [LineProtocol]: https://docs.influxdata.com/influxdb/v2.0/reference/syntax/line-protocol/#data-types-and-format
     pub async fn write(
         &mut self,
-        db_name: impl Into<String>,
-        lp_data: impl Into<String>,
+        db_name: impl Into<String> + Send,
+        lp_data: impl Into<String> + Send,
     ) -> Result<usize, WriteError> {
         let db_name = db_name.into();
         let lp_data = lp_data.into();
@@ -83,8 +83,8 @@ impl Client {
     /// [Entry]: https://github.com/influxdata/influxdb_iox/blob/main/entry/src/entry.fbs
     pub async fn write_entry(
         &mut self,
-        db_name: impl Into<String>,
-        entry: impl Into<Vec<u8>>,
+        db_name: impl Into<String> + Send,
+        entry: impl Into<Vec<u8>> + Send,
     ) -> Result<(), WriteError> {
         let db_name = db_name.into();
         let entry = entry.into();

--- a/influxdb_iox_client/src/connection.rs
+++ b/influxdb_iox_client/src/connection.rs
@@ -69,7 +69,7 @@ impl Builder {
     /// Construct the [`Connection`] instance using the specified base URL.
     pub async fn build<D>(self, dst: D) -> Result<Connection>
     where
-        D: TryInto<Uri, Error = InvalidUri>,
+        D: TryInto<Uri, Error = InvalidUri> + Send,
     {
         let endpoint = Endpoint::from(dst.try_into()?)
             .user_agent(self.user_agent)?

--- a/influxdb_iox_client/src/lib.rs
+++ b/influxdb_iox_client/src/lib.rs
@@ -9,7 +9,8 @@
     missing_docs,
     clippy::todo,
     clippy::dbg_macro,
-    clippy::clone_on_ref_ptr
+    clippy::clone_on_ref_ptr,
+    clippy::future_not_send
 )]
 #![allow(clippy::missing_docs_in_private_items)]
 

--- a/query/src/lib.rs
+++ b/query/src/lib.rs
@@ -3,7 +3,8 @@
     missing_debug_implementations,
     clippy::explicit_iter_loop,
     clippy::use_self,
-    clippy::clone_on_ref_ptr
+    clippy::clone_on_ref_ptr,
+    clippy::future_not_send
 )]
 
 use async_trait::async_trait;

--- a/tracker/src/lib.rs
+++ b/tracker/src/lib.rs
@@ -3,7 +3,8 @@
     missing_debug_implementations,
     clippy::explicit_iter_loop,
     clippy::use_self,
-    clippy::clone_on_ref_ptr
+    clippy::clone_on_ref_ptr,
+    clippy::future_not_send
 )]
 
 mod lock;

--- a/tracker/src/task.rs
+++ b/tracker/src/task.rs
@@ -182,13 +182,19 @@ impl TaskStatus {
 
 /// A Tracker can be used to monitor/cancel/wait for a set of associated futures
 #[derive(Debug)]
-pub struct TaskTracker<T> {
+pub struct TaskTracker<T>
+where
+    T: Send + Sync,
+{
     id: TaskId,
     state: Arc<TrackerState>,
     metadata: Arc<T>,
 }
 
-impl<T> Clone for TaskTracker<T> {
+impl<T> Clone for TaskTracker<T>
+where
+    T: Send + Sync,
+{
     fn clone(&self) -> Self {
         Self {
             id: self.id,
@@ -198,7 +204,10 @@ impl<T> Clone for TaskTracker<T> {
     }
 }
 
-impl<T> TaskTracker<T> {
+impl<T> TaskTracker<T>
+where
+    T: Send + Sync,
+{
     /// Creates a new task tracker from the provided registration
     pub fn new(id: TaskId, registration: &TaskRegistration, metadata: T) -> Self {
         Self {
@@ -347,7 +356,10 @@ impl TaskRegistration {
     }
 
     /// Converts the registration into a tracker with id 0 and specified metadata
-    pub fn into_tracker<T>(self, metadata: T) -> TaskTracker<T> {
+    pub fn into_tracker<T>(self, metadata: T) -> TaskTracker<T>
+    where
+        T: Send + Sync,
+    {
         TaskTracker::new(TaskId(0), &self, metadata)
     }
 }

--- a/tracker/src/task/history.rs
+++ b/tracker/src/task/history.rs
@@ -6,12 +6,18 @@ use std::hash::Hash;
 
 /// A wrapper around a TaskRegistry that automatically retains a history
 #[derive(Debug)]
-pub struct TaskRegistryWithHistory<T> {
+pub struct TaskRegistryWithHistory<T>
+where
+    T: Send + Sync,
+{
     registry: TaskRegistry<T>,
     history: SizeLimitedHashMap<TaskId, TaskTracker<T>>,
 }
 
-impl<T: std::fmt::Debug> TaskRegistryWithHistory<T> {
+impl<T: std::fmt::Debug> TaskRegistryWithHistory<T>
+where
+    T: Send + Sync,
+{
     pub fn new(capacity: usize) -> Self {
         Self {
             history: SizeLimitedHashMap::new(capacity),

--- a/tracker/src/task/registry.rs
+++ b/tracker/src/task/registry.rs
@@ -26,12 +26,18 @@ impl ToString for TaskId {
 ///
 /// Additionally can trigger graceful cancellation of registered futures
 #[derive(Debug)]
-pub struct TaskRegistry<T> {
+pub struct TaskRegistry<T>
+where
+    T: Send + Sync,
+{
     next_id: usize,
     tasks: HashMap<TaskId, TaskTracker<T>>,
 }
 
-impl<T> Default for TaskRegistry<T> {
+impl<T> Default for TaskRegistry<T>
+where
+    T: Send + Sync,
+{
     fn default() -> Self {
         Self {
             next_id: 0,
@@ -40,7 +46,10 @@ impl<T> Default for TaskRegistry<T> {
     }
 }
 
-impl<T> TaskRegistry<T> {
+impl<T> TaskRegistry<T>
+where
+    T: Send + Sync,
+{
     pub fn new() -> Self {
         Default::default()
     }


### PR DESCRIPTION
Same as #1671 for a few more crates. Notable future work are `server` and the top-level `src` which I'll do after this PR.