### PR TITLE
refactor: swap order of partition and table in in-memory catalog

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3706,6 +3706,7 @@ dependencies = [
  "futures",
  "futures-util",
  "generated_types",
+ "hashbrown 0.11.2",
  "influxdb_iox_client",
  "influxdb_line_protocol",
  "internal_types",

--- a/data_types/src/partition_metadata.rs
+++ b/data_types/src/partition_metadata.rs
@@ -44,7 +44,7 @@ pub struct PartitionChunkSummary {
 impl FromIterator<TableSummary> for TableSummary {
     fn from_iter<T: IntoIterator<Item = TableSummary>>(iter: T) -> Self {
         let mut iter = iter.into_iter();
-        let first = iter.next().expect("must contain one element");
+        let first = iter.next().expect("must contain at least one element");
         let mut s = Self {
             name: first.name,
             columns: first.columns,

--- a/data_types/src/partition_metadata.rs
+++ b/data_types/src/partition_metadata.rs
@@ -5,18 +5,17 @@ use std::{borrow::Cow, cmp::Ordering, mem};
 
 use serde::{Deserialize, Serialize};
 use std::borrow::Borrow;
+use std::iter::FromIterator;
 use std::num::NonZeroU64;
 
 /// Describes the aggregated (across all chunks) summary
-/// statistics for each column in each table in a partition
+/// statistics for each column in a partition
 #[derive(Debug, Deserialize, Serialize, PartialEq)]
 pub struct PartitionSummary {
     /// The identifier for the partition, the partition key computed from
     /// PartitionRules
     pub key: String,
-
-    /// The tables in this partition
-    pub tables: Vec<TableSummary>,
+    pub table: TableSummary,
 }
 
 impl PartitionSummary {
@@ -28,55 +27,34 @@ impl PartitionSummary {
         key: impl Into<String>,
         summaries: impl IntoIterator<Item = TableSummary>,
     ) -> Self {
-        let mut summaries: Vec<_> = summaries.into_iter().collect();
-        summaries.sort_by(|a, b| a.name.cmp(&b.name));
-
-        let mut tables = Vec::with_capacity(summaries.len());
-
-        let mut summaries = summaries.into_iter();
-
-        if let Some(mut table) = summaries.next() {
-            for t in summaries {
-                if table.name != t.name {
-                    tables.push(table);
-                    table = t;
-                } else {
-                    table.update_from(&t);
-                }
-            }
-
-            tables.push(table);
-        }
-
         Self {
             key: key.into(),
-            tables,
+            table: TableSummary::from_iter(summaries),
         }
     }
-
-    /// Returns the table summary for the table name
-    pub fn table(&self, name: &str) -> Option<&TableSummary> {
-        self.tables.iter().find(|t| t.name == name)
-    }
-}
-
-/// Describes the (unaggregated) summary statistics for
-/// each column in each table in each chunk of a Partition.
-#[derive(Debug, Deserialize, Serialize, PartialEq)]
-pub struct UnaggregatedPartitionSummary {
-    /// The identifier for the partition, the partition key computed from
-    /// PartitionRules
-    pub key: String,
-
-    /// The chunks of the tables in this partition
-    pub tables: Vec<UnaggregatedTableSummary>,
 }
 
 /// Metadata and statistics for a Chunk *within* a partition
 #[derive(Debug, Deserialize, Serialize, PartialEq, Clone)]
-pub struct UnaggregatedTableSummary {
+pub struct PartitionChunkSummary {
     pub chunk_id: u32,
     pub table: TableSummary,
+}
+
+impl FromIterator<TableSummary> for TableSummary {
+    fn from_iter<T: IntoIterator<Item = TableSummary>>(iter: T) -> Self {
+        let mut iter = iter.into_iter();
+        let first = iter.next().expect("must contain one element");
+        let mut s = Self {
+            name: first.name,
+            columns: first.columns,
+        };
+
+        for other in iter {
+            s.update_from(&other)
+        }
+        s
+    }
 }
 
 /// Metadata and statistics information for a table. This can be
@@ -125,6 +103,8 @@ impl TableSummary {
     /// on that column. Columns that only exist in the other are cloned into
     /// this table summary.
     pub fn update_from(&mut self, other: &Self) {
+        assert_eq!(self.name, other.name);
+
         for col in &mut self.columns {
             if let Some(other_col) = other.column(&col.name) {
                 col.update_from(other_col);
@@ -945,31 +925,12 @@ mod tests {
             influxdb_type: None,
             stats: Statistics::I64(StatValues::new_with_value(10)),
         };
-        let table_b = TableSummary {
-            name: "b".to_string(),
-            columns: vec![int_col.clone()],
-        };
-
         let table_a_2 = TableSummary {
             name: "a".to_string(),
             columns: vec![int_col],
         };
-
-        let int_col = ColumnSummary {
-            name: "int".to_string(),
-            influxdb_type: None,
-            stats: Statistics::I64(StatValues::new_with_value(203)),
-        };
-        let table_b_2 = TableSummary {
-            name: "b".to_string(),
-            columns: vec![int_col],
-        };
-
-        let partition = PartitionSummary::from_table_summaries(
-            "key",
-            vec![table_b_2, table_a, table_b, table_a_2],
-        );
-        let t = partition.table("a").unwrap();
+        let partition = PartitionSummary::from_table_summaries("key", vec![table_a, table_a_2]);
+        let t = partition.table;
         let col = t.column("string").unwrap();
         assert_eq!(
             col.stats,
@@ -983,12 +944,6 @@ mod tests {
         assert_eq!(
             col.stats,
             Statistics::I64(StatValues::new(Some(1), Some(10), 3))
-        );
-        let t = partition.table("b").unwrap();
-        let col = t.column("int").unwrap();
-        assert_eq!(
-            col.stats,
-            Statistics::I64(StatValues::new(Some(10), Some(203), 2))
         );
     }
 

--- a/influxdb_iox_client/src/client/management.rs
+++ b/influxdb_iox_client/src/client/management.rs
@@ -561,12 +561,12 @@ impl Client {
         Ok(response.into_inner().chunks)
     }
 
-    /// Create a new chunk in a partittion
+    /// Create a new chunk in a partition
     pub async fn new_partition_chunk(
         &mut self,
         db_name: impl Into<String> + Send,
-        partition_key: impl Into<String> + Send,
         table_name: impl Into<String> + Send,
+        partition_key: impl Into<String> + Send,
     ) -> Result<(), NewPartitionChunkError> {
         let db_name = db_name.into();
         let partition_key = partition_key.into();
@@ -616,8 +616,8 @@ impl Client {
     pub async fn close_partition_chunk(
         &mut self,
         db_name: impl Into<String> + Send,
-        partition_key: impl Into<String> + Send,
         table_name: impl Into<String> + Send,
+        partition_key: impl Into<String> + Send,
         chunk_id: u32,
     ) -> Result<Operation, ClosePartitionChunkError> {
         let db_name = db_name.into();

--- a/query_tests/src/influxrpc/read_window_aggregate.rs
+++ b/query_tests/src/influxrpc/read_window_aggregate.rs
@@ -172,8 +172,8 @@ impl DbSetup for MeasurementForWindowAggregateMonths {
         let db = make_db().await.db;
         let data = lp_lines.join("\n");
         write_lp(&db, &data);
-        db.rollover_partition("2020-03-01T00", "h2o").await.unwrap();
-        db.rollover_partition("2020-03-02T00", "h2o").await.unwrap();
+        db.rollover_partition("h2o", "2020-03-01T00").await.unwrap();
+        db.rollover_partition("h2o", "2020-03-02T00").await.unwrap();
         let scenario2 = DbScenario {
             scenario_name:
                 "Data in 4 partitions, two open chunk and two closed chunks of mutable buffer"

--- a/query_tests/src/pruning.rs
+++ b/query_tests/src/pruning.rs
@@ -24,11 +24,11 @@ async fn setup() -> TestDb {
 
     let partition_key = "1970-01-01T00";
     let mb_chunk = db
-        .rollover_partition(partition_key, "cpu")
+        .rollover_partition("cpu", partition_key)
         .await
         .unwrap()
         .unwrap();
-    db.load_chunk_to_read_buffer(partition_key, "cpu", mb_chunk.id(), &Default::default())
+    db.load_chunk_to_read_buffer("cpu", partition_key, mb_chunk.id(), &Default::default())
         .await
         .unwrap();
 
@@ -39,11 +39,11 @@ async fn setup() -> TestDb {
 
     let partition_key = "1970-01-01T00";
     let mb_chunk = db
-        .rollover_partition(partition_key, "cpu")
+        .rollover_partition("cpu", partition_key)
         .await
         .unwrap()
         .unwrap();
-    db.load_chunk_to_read_buffer(partition_key, "cpu", mb_chunk.id(), &Default::default())
+    db.load_chunk_to_read_buffer("cpu", partition_key, mb_chunk.id(), &Default::default())
         .await
         .unwrap();
 

--- a/query_tests/src/scenarios.rs
+++ b/query_tests/src/scenarios.rs
@@ -60,7 +60,7 @@ impl DbSetup for NoData {
         write_lp(&db, data);
         // move data out of open chunk
         assert_eq!(
-            db.rollover_partition(partition_key, table_name)
+            db.rollover_partition(table_name, partition_key)
                 .await
                 .unwrap()
                 .unwrap()
@@ -72,7 +72,7 @@ impl DbSetup for NoData {
         assert_eq!(count_object_store_chunks(&db), 0); // nothing yet
 
         // Now load the closed chunk into the RB
-        db.load_chunk_to_read_buffer(partition_key, table_name, 0, &Default::default())
+        db.load_chunk_to_read_buffer(table_name, partition_key, 0, &Default::default())
             .await
             .unwrap();
         assert_eq!(count_mutable_buffer_chunks(&db), 0); // open chunk only
@@ -80,7 +80,7 @@ impl DbSetup for NoData {
         assert_eq!(count_object_store_chunks(&db), 0); // nothing yet
 
         // drop chunk 0
-        db.drop_chunk(partition_key, table_name, 0).unwrap();
+        db.drop_chunk(table_name, partition_key, 0).unwrap();
 
         assert_eq!(count_mutable_buffer_chunks(&db), 0); // open chunk only
         assert_eq!(count_read_buffer_chunks(&db), 0); // nothing after dropping chunk 0
@@ -98,7 +98,7 @@ impl DbSetup for NoData {
         write_lp(&db, data);
         // move data out of open chunk
         assert_eq!(
-            db.rollover_partition(partition_key, table_name)
+            db.rollover_partition(table_name, partition_key)
                 .await
                 .unwrap()
                 .unwrap()
@@ -110,7 +110,7 @@ impl DbSetup for NoData {
         assert_eq!(count_object_store_chunks(&db), 0); // nothing yet
 
         // Now load the closed chunk into the RB
-        db.load_chunk_to_read_buffer(partition_key, table_name, 0, &Default::default())
+        db.load_chunk_to_read_buffer(table_name, partition_key, 0, &Default::default())
             .await
             .unwrap();
         assert_eq!(count_mutable_buffer_chunks(&db), 0); // open chunk only
@@ -118,7 +118,7 @@ impl DbSetup for NoData {
         assert_eq!(count_object_store_chunks(&db), 0); // nothing yet
 
         // Now write the data in RB to object store but keep it in RB
-        db.write_chunk_to_object_store(partition_key, "cpu", 0, &Default::default())
+        db.write_chunk_to_object_store("cpu", partition_key, 0, &Default::default())
             .await
             .unwrap();
         // it should be the same chunk!
@@ -127,7 +127,7 @@ impl DbSetup for NoData {
         assert_eq!(count_object_store_chunks(&db), 1); // close chunk only
 
         // drop chunk 0
-        db.drop_chunk(partition_key, table_name, 0).unwrap();
+        db.drop_chunk(table_name, partition_key, 0).unwrap();
 
         assert_eq!(count_mutable_buffer_chunks(&db), 0);
         assert_eq!(count_read_buffer_chunks(&db), 0);
@@ -308,8 +308,8 @@ impl DbSetup for TwoMeasurementsManyFieldsTwoChunks {
             "h2o,state=MA,city=Boston other_temp=70.4 250",
         ];
         write_lp(&db, &lp_lines.join("\n"));
-        db.rollover_partition(partition_key, "h2o").await.unwrap();
-        db.load_chunk_to_read_buffer(partition_key, "h2o", 0, &Default::default())
+        db.rollover_partition("h2o", partition_key).await.unwrap();
+        db.load_chunk_to_read_buffer("h2o", partition_key, 0, &Default::default())
             .await
             .unwrap();
 
@@ -347,8 +347,8 @@ impl DbSetup for OneMeasurementThreeChunksWithDuplicates {
             "h2o,state=MA,city=Andover max_temp=69.2, 250",
         ];
         write_lp(&db, &lp_lines.join("\n"));
-        db.rollover_partition(partition_key, "h2o").await.unwrap();
-        db.load_chunk_to_read_buffer(partition_key, "h2o", 0, &Default::default())
+        db.rollover_partition("h2o", partition_key).await.unwrap();
+        db.load_chunk_to_read_buffer("h2o", partition_key, 0, &Default::default())
             .await
             .unwrap();
 
@@ -364,8 +364,8 @@ impl DbSetup for OneMeasurementThreeChunksWithDuplicates {
             "h2o,state=CA,city=SJ min_temp=75.5,max_temp=84.08 350",
         ];
         write_lp(&db, &lp_lines.join("\n"));
-        db.rollover_partition(partition_key, "h2o").await.unwrap();
-        db.load_chunk_to_read_buffer(partition_key, "h2o", 1, &Default::default())
+        db.rollover_partition("h2o", partition_key).await.unwrap();
+        db.load_chunk_to_read_buffer("h2o", partition_key, 1, &Default::default())
             .await
             .unwrap();
 
@@ -381,8 +381,8 @@ impl DbSetup for OneMeasurementThreeChunksWithDuplicates {
             "h2o,state=CA,city=SJ min_temp=69.5,max_temp=88.2 500",
         ];
         write_lp(&db, &lp_lines.join("\n"));
-        db.rollover_partition(partition_key, "h2o").await.unwrap();
-        db.load_chunk_to_read_buffer(partition_key, "h2o", 2, &Default::default())
+        db.rollover_partition("h2o", partition_key).await.unwrap();
+        db.load_chunk_to_read_buffer("h2o", partition_key, 2, &Default::default())
             .await
             .unwrap();
 
@@ -398,8 +398,8 @@ impl DbSetup for OneMeasurementThreeChunksWithDuplicates {
             "h2o,state=CA,city=SJ min_temp=75.5,max_temp=84.08 700",
         ];
         write_lp(&db, &lp_lines.join("\n"));
-        db.rollover_partition(partition_key, "h2o").await.unwrap();
-        db.load_chunk_to_read_buffer(partition_key, "h2o", 3, &Default::default())
+        db.rollover_partition("h2o", partition_key).await.unwrap();
+        db.load_chunk_to_read_buffer("h2o", partition_key, 3, &Default::default())
             .await
             .unwrap();
 
@@ -434,8 +434,8 @@ impl DbSetup for TwoMeasurementsManyFieldsLifecycle {
         // TaskTracker::join, it ended up hanging for reasons I don't
         // now
         let job = db.load_chunk_to_read_buffer_in_background(
-            partition_key.to_string(),
             "h2o".to_string(),
+            partition_key.to_string(),
             0,
         );
         job.join().await;
@@ -446,8 +446,8 @@ impl DbSetup for TwoMeasurementsManyFieldsLifecycle {
         );
 
         let job = db.write_chunk_to_object_store_in_background(
-            partition_key.to_string(),
             "h2o".to_string(),
+            partition_key.to_string(),
             0,
         );
         job.join().await;
@@ -529,7 +529,7 @@ pub(crate) async fn make_one_chunk_scenarios(partition_key: &str, data: &str) ->
     let db = make_db().await.db;
     let table_names = write_lp(&db, data);
     for table_name in &table_names {
-        db.rollover_partition(partition_key, &table_name)
+        db.rollover_partition(&table_name, partition_key)
             .await
             .unwrap();
     }
@@ -542,10 +542,10 @@ pub(crate) async fn make_one_chunk_scenarios(partition_key: &str, data: &str) ->
     let db = make_db().await.db;
     let table_names = write_lp(&db, data);
     for table_name in &table_names {
-        db.rollover_partition(partition_key, &table_name)
+        db.rollover_partition(&table_name, partition_key)
             .await
             .unwrap();
-        db.load_chunk_to_read_buffer(partition_key, &table_name, 0, &Default::default())
+        db.load_chunk_to_read_buffer(&table_name, partition_key, 0, &Default::default())
             .await
             .unwrap();
     }
@@ -558,14 +558,14 @@ pub(crate) async fn make_one_chunk_scenarios(partition_key: &str, data: &str) ->
     let db = make_db().await.db;
     let table_names = write_lp(&db, data);
     for table_name in &table_names {
-        db.rollover_partition(partition_key, &table_name)
+        db.rollover_partition(&table_name, partition_key)
             .await
             .unwrap();
-        db.load_chunk_to_read_buffer(partition_key, &table_name, 0, &Default::default())
+        db.load_chunk_to_read_buffer(&table_name, partition_key, 0, &Default::default())
             .await
             .unwrap();
 
-        db.write_chunk_to_object_store(partition_key, &table_name, 0, &Default::default())
+        db.write_chunk_to_object_store(&table_name, partition_key, 0, &Default::default())
             .await
             .unwrap();
     }
@@ -578,16 +578,16 @@ pub(crate) async fn make_one_chunk_scenarios(partition_key: &str, data: &str) ->
     let db = make_db().await.db;
     let table_names = write_lp(&db, data);
     for table_name in &table_names {
-        db.rollover_partition(partition_key, &table_name)
+        db.rollover_partition(&table_name, partition_key)
             .await
             .unwrap();
-        db.load_chunk_to_read_buffer(partition_key, &table_name, 0, &Default::default())
+        db.load_chunk_to_read_buffer(&table_name, partition_key, 0, &Default::default())
             .await
             .unwrap();
-        db.write_chunk_to_object_store(partition_key, &table_name, 0, &Default::default())
+        db.write_chunk_to_object_store(&table_name, partition_key, 0, &Default::default())
             .await
             .unwrap();
-        db.unload_read_buffer(partition_key, &table_name, 0)
+        db.unload_read_buffer(&table_name, partition_key, 0)
             .await
             .unwrap();
     }
@@ -622,7 +622,7 @@ pub async fn make_two_chunk_scenarios(
     let db = make_db().await.db;
     let table_names = write_lp(&db, data1);
     for table_name in &table_names {
-        db.rollover_partition(partition_key, &table_name)
+        db.rollover_partition(&table_name, partition_key)
             .await
             .unwrap();
     }
@@ -636,10 +636,10 @@ pub async fn make_two_chunk_scenarios(
     let db = make_db().await.db;
     let table_names = write_lp(&db, data1);
     for table_name in &table_names {
-        db.rollover_partition(partition_key, &table_name)
+        db.rollover_partition(&table_name, partition_key)
             .await
             .unwrap();
-        db.load_chunk_to_read_buffer(partition_key, &table_name, 0, &Default::default())
+        db.load_chunk_to_read_buffer(&table_name, partition_key, 0, &Default::default())
             .await
             .unwrap();
     }
@@ -653,21 +653,21 @@ pub async fn make_two_chunk_scenarios(
     let db = make_db().await.db;
     let table_names = write_lp(&db, data1);
     for table_name in &table_names {
-        db.rollover_partition(partition_key, &table_name)
+        db.rollover_partition(&table_name, partition_key)
             .await
             .unwrap();
     }
     let table_names = write_lp(&db, data2);
     for table_name in &table_names {
-        db.rollover_partition(partition_key, &table_name)
+        db.rollover_partition(&table_name, partition_key)
             .await
             .unwrap();
 
-        db.load_chunk_to_read_buffer(partition_key, &table_name, 0, &Default::default())
+        db.load_chunk_to_read_buffer(&table_name, partition_key, 0, &Default::default())
             .await
             .unwrap();
 
-        db.load_chunk_to_read_buffer(partition_key, &table_name, 1, &Default::default())
+        db.load_chunk_to_read_buffer(&table_name, partition_key, 1, &Default::default())
             .await
             .unwrap();
     }
@@ -680,29 +680,29 @@ pub async fn make_two_chunk_scenarios(
     let db = make_db().await.db;
     let table_names = write_lp(&db, data1);
     for table_name in &table_names {
-        db.rollover_partition(partition_key, &table_name)
+        db.rollover_partition(&table_name, partition_key)
             .await
             .unwrap();
     }
     let table_names = write_lp(&db, data2);
     for table_name in &table_names {
-        db.rollover_partition(partition_key, &table_name)
+        db.rollover_partition(&table_name, partition_key)
             .await
             .unwrap();
 
-        db.load_chunk_to_read_buffer(partition_key, &table_name, 0, &Default::default())
+        db.load_chunk_to_read_buffer(&table_name, partition_key, 0, &Default::default())
             .await
             .unwrap();
 
-        db.load_chunk_to_read_buffer(partition_key, &table_name, 1, &Default::default())
+        db.load_chunk_to_read_buffer(&table_name, partition_key, 1, &Default::default())
             .await
             .unwrap();
 
-        db.write_chunk_to_object_store(partition_key, &table_name, 0, &Default::default())
+        db.write_chunk_to_object_store(&table_name, partition_key, 0, &Default::default())
             .await
             .unwrap();
 
-        db.write_chunk_to_object_store(partition_key, &table_name, 1, &Default::default())
+        db.write_chunk_to_object_store(&table_name, partition_key, 1, &Default::default())
             .await
             .unwrap();
     }
@@ -715,35 +715,35 @@ pub async fn make_two_chunk_scenarios(
     let db = make_db().await.db;
     let table_names = write_lp(&db, data1);
     for table_name in &table_names {
-        db.rollover_partition(partition_key, &table_name)
+        db.rollover_partition(&table_name, partition_key)
             .await
             .unwrap();
     }
     let table_names = write_lp(&db, data2);
     for table_name in &table_names {
-        db.rollover_partition(partition_key, &table_name)
+        db.rollover_partition(&table_name, partition_key)
             .await
             .unwrap();
 
-        db.load_chunk_to_read_buffer(partition_key, &table_name, 0, &Default::default())
+        db.load_chunk_to_read_buffer(&table_name, partition_key, 0, &Default::default())
             .await
             .unwrap();
 
-        db.load_chunk_to_read_buffer(partition_key, &table_name, 1, &Default::default())
+        db.load_chunk_to_read_buffer(&table_name, partition_key, 1, &Default::default())
             .await
             .unwrap();
 
-        db.write_chunk_to_object_store(partition_key, &table_name, 0, &Default::default())
+        db.write_chunk_to_object_store(&table_name, partition_key, 0, &Default::default())
             .await
             .unwrap();
 
-        db.write_chunk_to_object_store(partition_key, &table_name, 1, &Default::default())
+        db.write_chunk_to_object_store(&table_name, partition_key, 1, &Default::default())
             .await
             .unwrap();
-        db.unload_read_buffer(partition_key, &table_name, 0)
+        db.unload_read_buffer(&table_name, partition_key, 0)
             .await
             .unwrap();
-        db.unload_read_buffer(partition_key, &table_name, 1)
+        db.unload_read_buffer(&table_name, partition_key, 1)
             .await
             .unwrap();
     }
@@ -759,13 +759,13 @@ pub async fn make_two_chunk_scenarios(
 
 /// Rollover the mutable buffer and load chunk 0 to the read buffer and object store
 pub async fn rollover_and_load(db: &Db, partition_key: &str, table_name: &str) {
-    db.rollover_partition(partition_key, table_name)
+    db.rollover_partition(table_name, partition_key)
         .await
         .unwrap();
-    db.load_chunk_to_read_buffer(partition_key, table_name, 0, &Default::default())
+    db.load_chunk_to_read_buffer(table_name, partition_key, 0, &Default::default())
         .await
         .unwrap();
-    db.write_chunk_to_object_store(partition_key, table_name, 0, &Default::default())
+    db.write_chunk_to_object_store(table_name, partition_key, 0, &Default::default())
         .await
         .unwrap();
 }
@@ -779,10 +779,10 @@ pub(crate) async fn make_one_rub_or_parquet_chunk_scenario(
     let db = make_db().await.db;
     let table_names = write_lp(&db, data);
     for table_name in &table_names {
-        db.rollover_partition(partition_key, &table_name)
+        db.rollover_partition(&table_name, partition_key)
             .await
             .unwrap();
-        db.load_chunk_to_read_buffer(partition_key, &table_name, 0, &Default::default())
+        db.load_chunk_to_read_buffer(&table_name, partition_key, 0, &Default::default())
             .await
             .unwrap();
     }
@@ -795,16 +795,16 @@ pub(crate) async fn make_one_rub_or_parquet_chunk_scenario(
     let db = make_db().await.db;
     let table_names = write_lp(&db, data);
     for table_name in &table_names {
-        db.rollover_partition(partition_key, &table_name)
+        db.rollover_partition(&table_name, partition_key)
             .await
             .unwrap();
-        db.load_chunk_to_read_buffer(partition_key, &table_name, 0, &Default::default())
+        db.load_chunk_to_read_buffer(&table_name, partition_key, 0, &Default::default())
             .await
             .unwrap();
-        db.write_chunk_to_object_store(partition_key, &table_name, 0, &Default::default())
+        db.write_chunk_to_object_store(&table_name, partition_key, 0, &Default::default())
             .await
             .unwrap();
-        db.unload_read_buffer(partition_key, &table_name, 0)
+        db.unload_read_buffer(&table_name, partition_key, 0)
             .await
             .unwrap();
     }

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -21,11 +21,12 @@ entry = { path = "../entry" }
 flatbuffers = "0.8"
 futures = "0.3"
 futures-util = { version = "0.3.1" }
-itertools = "0.9.0"
 generated_types = { path = "../generated_types" }
+hashbrown = "0.11"
 influxdb_iox_client = { path = "../influxdb_iox_client" }
 influxdb_line_protocol = { path = "../influxdb_line_protocol" }
 internal_types = { path = "../internal_types" }
+itertools = "0.9.0"
 metrics = { path = "../metrics" }
 mutable_buffer = { path = "../mutable_buffer" }
 num_cpus = "1.13.0"

--- a/server/src/db.rs
+++ b/server/src/db.rs
@@ -4,6 +4,7 @@
 use self::access::QueryCatalogAccess;
 use self::catalog::TableNameFilter;
 use super::{write_buffer::WriteBuffer, JobRegistry};
+use crate::db::catalog::partition::Partition;
 use arrow::datatypes::SchemaRef as ArrowSchemaRef;
 use async_trait::async_trait;
 use catalog::{chunk::Chunk as CatalogChunk, Catalog};
@@ -64,30 +65,21 @@ mod system_tables;
 
 #[derive(Debug, Snafu)]
 pub enum Error {
+    #[snafu(context(false))]
+    CatalogError { source: catalog::Error },
+
     #[snafu(display(
-        "Can not drop chunk {}:{}:{} from catalog: {}",
+        "Lifecycle error: {}:{}:{} {}",
         partition_key,
         table_name,
         chunk_id,
         source
     ))]
-    DroppingChunk {
+    LifecycleError {
         partition_key: String,
         table_name: String,
         chunk_id: u32,
-        source: catalog::Error,
-    },
-
-    #[snafu(display(
-        "Can not rollover partition {}:{} : {}",
-        partition_key,
-        table_name,
-        source
-    ))]
-    RollingOverPartition {
-        partition_key: String,
-        table_name: String,
-        source: catalog::Error,
+        source: catalog::chunk::Error,
     },
 
     #[snafu(display(
@@ -102,41 +94,6 @@ pub enum Error {
         table_name: String,
         chunk_id: u32,
         action: String,
-    },
-
-    #[snafu(display(
-        "Can not load partition chunk {}:{}:{} to read buffer: {}",
-        partition_key,
-        table_name,
-        chunk_id,
-        source
-    ))]
-    LoadingChunk {
-        partition_key: String,
-        table_name: String,
-        chunk_id: u32,
-        source: catalog::Error,
-    },
-
-    #[snafu(display(
-        "Can not load partition chunk {}:{},{} to parquet format in memory: {}",
-        partition_key,
-        table_name,
-        chunk_id,
-        source
-    ))]
-    LoadingChunkToParquet {
-        partition_key: String,
-        table_name: String,
-        chunk_id: u32,
-        source: catalog::Error,
-    },
-
-    UnloadingChunkFromReadBuffer {
-        partition_key: String,
-        table_name: String,
-        chunk_id: u32,
-        source: catalog::Error,
     },
 
     #[snafu(display("Read Buffer Error in chunk {}{} : {}", chunk_id, table_name, source))]
@@ -188,12 +145,6 @@ pub enum Error {
     WriteEntryInitial {
         partition_key: String,
         source: mutable_buffer::chunk::Error,
-    },
-
-    #[snafu(display("Can not create open entry {} : {}", partition_key, source))]
-    OpenEntry {
-        partition_key: String,
-        source: catalog::Error,
     },
 
     #[snafu(display("Error building sequenced entry: {}", source))]
@@ -448,30 +399,20 @@ impl Db {
     /// partition. Returns the previously open (now closed) Chunk if there was any.
     pub async fn rollover_partition(
         &self,
-        partition_key: &str,
         table_name: &str,
+        partition_key: &str,
     ) -> Result<Option<Arc<DbChunk>>> {
-        let partition = self
-            .preserved_catalog
-            .state()
-            .valid_partition(partition_key)
-            .context(RollingOverPartition {
-                partition_key,
-                table_name,
-            })?;
+        let chunk = self
+            .partition(table_name, partition_key)?
+            .read()
+            .open_chunk();
 
-        let partition = partition.write();
-        if let Some(chunk) = partition
-            .open_chunk(table_name)
-            .context(RollingOverPartition {
-                partition_key,
-                table_name,
-            })?
-        {
+        if let Some(chunk) = chunk {
             let mut chunk = chunk.write();
-            chunk.freeze().context(RollingOverPartition {
+            chunk.freeze().context(LifecycleError {
                 partition_key,
                 table_name,
+                chunk_id: chunk.id(),
             })?;
 
             Ok(Some(DbChunk::snapshot(&chunk)))
@@ -480,19 +421,35 @@ impl Db {
         }
     }
 
-    /// Drops the specified chunk from the catalog and all storage systems
-    pub fn drop_chunk(&self, partition_key: &str, table_name: &str, chunk_id: u32) -> Result<()> {
-        debug!(%partition_key, %table_name, %chunk_id, "dropping chunk");
-
+    fn partition(
+        &self,
+        table_name: &str,
+        partition_key: &str,
+    ) -> Result<Arc<tracker::RwLock<Partition>>> {
         let partition = self
             .preserved_catalog
             .state()
-            .valid_partition(partition_key)
-            .context(DroppingChunk {
-                partition_key,
-                table_name,
-                chunk_id,
-            })?;
+            .partition(table_name, partition_key)?;
+        Ok(Arc::clone(&partition))
+    }
+
+    fn chunk(
+        &self,
+        table_name: &str,
+        partition_key: &str,
+        chunk_id: u32,
+    ) -> Result<Arc<tracker::RwLock<CatalogChunk>>> {
+        Ok(self
+            .preserved_catalog
+            .state()
+            .chunk(table_name, partition_key, chunk_id)?)
+    }
+
+    /// Drops the specified chunk from the catalog and all storage systems
+    pub fn drop_chunk(&self, table_name: &str, partition_key: &str, chunk_id: u32) -> Result<()> {
+        debug!(%table_name, %partition_key, %chunk_id, "dropping chunk");
+
+        let partition = self.partition(table_name, partition_key)?;
 
         // lock the partition so that no one else can be messing /
         // with it while we drop the chunk
@@ -500,11 +457,11 @@ impl Db {
 
         {
             let chunk = partition
-                .chunk(table_name, chunk_id)
-                .context(DroppingChunk {
-                    partition_key,
-                    table_name,
+                .chunk(chunk_id)
+                .ok_or(catalog::Error::ChunkNotFound {
                     chunk_id,
+                    partition: partition_key.to_string(),
+                    table: table_name.to_string(),
                 })?;
             let chunk = chunk.read();
             let chunk_state = chunk.stage().name();
@@ -524,16 +481,12 @@ impl Db {
                 .fail();
             }
 
-            debug!(%partition_key, %table_name, %chunk_id, %chunk_state, "dropping chunk");
+            debug!(%table_name, %partition_key, %chunk_id, %chunk_state, "dropping chunk");
         }
 
-        partition
-            .drop_chunk(table_name, chunk_id)
-            .context(DroppingChunk {
-                partition_key,
-                table_name,
-                chunk_id,
-            })
+        partition.drop_chunk(chunk_id).unwrap();
+
+        Ok(())
     }
 
     /// Copies a chunk in the Closed state into the ReadBuffer from
@@ -548,38 +501,19 @@ impl Db {
     /// Returns a handle to the newly loaded chunk in the read buffer
     pub async fn load_chunk_to_read_buffer(
         &self,
-        partition_key: &str,
         table_name: &str,
+        partition_key: &str,
         chunk_id: u32,
         tracker: &TaskRegistration,
     ) -> Result<Arc<DbChunk>> {
-        let chunk = {
-            let partition = self
-                .preserved_catalog
-                .state()
-                .valid_partition(partition_key)
-                .context(LoadingChunk {
-                    partition_key,
-                    table_name,
-                    chunk_id,
-                })?;
-            let partition = partition.read();
-
-            partition
-                .chunk(table_name, chunk_id)
-                .context(LoadingChunk {
-                    partition_key,
-                    table_name,
-                    chunk_id,
-                })?
-        };
+        let chunk = self.chunk(table_name, partition_key, chunk_id)?;
 
         // update the catalog to say we are processing this chunk and
         // then drop the lock while we do the work
         let (mb_chunk, table_summary) = {
             let mut chunk = chunk.write();
 
-            let mb_chunk = chunk.set_moving(tracker).context(LoadingChunk {
+            let mb_chunk = chunk.set_moving(tracker).context(LifecycleError {
                 partition_key,
                 table_name,
                 chunk_id,
@@ -587,7 +521,7 @@ impl Db {
             (mb_chunk, chunk.table_summary())
         };
 
-        info!(%partition_key, %table_name, %chunk_id, "chunk marked MOVING, loading tables into read buffer");
+        info!(%table_name, %partition_key, %chunk_id, "chunk marked MOVING, loading tables into read buffer");
 
         // create a new read buffer chunk with memory tracking
         let metrics = self
@@ -603,7 +537,7 @@ impl Db {
         ));
 
         // load table into the new chunk one by one.
-        debug!(%partition_key, %table_name, %chunk_id, table=%table_summary.name, "loading table to read buffer");
+        debug!(%table_name, %partition_key, %chunk_id, table=%table_summary.name, "loading table to read buffer");
         let batch = mb_chunk
             .read_filter(Selection::All)
             // It is probably reasonable to recover from this error
@@ -619,13 +553,15 @@ impl Db {
         let mut chunk = chunk.write();
 
         // update the catalog to say we are done processing
-        chunk.set_moved(Arc::new(rb_chunk)).context(LoadingChunk {
-            partition_key,
-            table_name,
-            chunk_id,
-        })?;
+        chunk
+            .set_moved(Arc::new(rb_chunk))
+            .context(LifecycleError {
+                partition_key,
+                table_name,
+                chunk_id,
+            })?;
 
-        debug!(%partition_key, %table_name, %chunk_id, "chunk marked MOVED. loading complete");
+        debug!(%table_name, %partition_key, %chunk_id, "chunk marked MOVED. loading complete");
 
         Ok(DbChunk::snapshot(&chunk))
     }
@@ -635,51 +571,31 @@ impl Db {
 
     pub async fn write_chunk_to_object_store(
         &self,
-        partition_key: &str,
         table_name: &str,
+        partition_key: &str,
         chunk_id: u32,
         tracker: &TaskRegistration,
     ) -> Result<Arc<DbChunk>> {
         // Get the chunk from the catalog
-        let chunk = {
-            let partition = self
-                .preserved_catalog
-                .state()
-                .valid_partition(partition_key)
-                .context(LoadingChunkToParquet {
-                    partition_key,
-                    table_name,
-                    chunk_id,
-                })?;
-            let partition = partition.read();
-
-            partition
-                .chunk(table_name, chunk_id)
-                .context(LoadingChunkToParquet {
-                    partition_key,
-                    table_name,
-                    chunk_id,
-                })?
-        };
+        let chunk = self.chunk(table_name, partition_key, chunk_id)?;
 
         // update the catalog to say we are processing this chunk and
         // then drop the lock while we do the work
         let (rb_chunk, table_summary) = {
             let mut chunk = chunk.write();
 
-            let rb_chunk =
-                chunk
-                    .set_writing_to_object_store(tracker)
-                    .context(LoadingChunkToParquet {
-                        partition_key,
-                        table_name,
-                        chunk_id,
-                    })?;
+            let rb_chunk = chunk
+                .set_writing_to_object_store(tracker)
+                .context(LifecycleError {
+                    partition_key,
+                    table_name,
+                    chunk_id,
+                })?;
 
             (rb_chunk, chunk.table_summary())
         };
 
-        debug!(%partition_key, %table_name, %chunk_id, "chunk marked WRITING , loading tables into object store");
+        debug!(%table_name, %partition_key, %chunk_id, "chunk marked WRITING , loading tables into object store");
 
         // Create a storage to save data of this chunk
         let storage = Storage::new(
@@ -689,7 +605,7 @@ impl Db {
         );
 
         let table_name = table_summary.name.as_str();
-        debug!(%partition_key, %table_name, %chunk_id, table=table_name, "loading table to object store");
+        debug!(%table_name, %partition_key, %chunk_id, table=table_name, "loading table to object store");
 
         let predicate = read_buffer::Predicate::default();
 
@@ -747,46 +663,27 @@ impl Db {
     /// Unload chunk from read buffer but keep it in object store
     pub async fn unload_read_buffer(
         &self,
-        partition_key: &str,
         table_name: &str,
+        partition_key: &str,
         chunk_id: u32,
     ) -> Result<Arc<DbChunk>> {
-        debug!(%partition_key, %table_name, %chunk_id, "unloading chunk from read buffer");
+        debug!(%table_name, %partition_key, %chunk_id, "unloading chunk from read buffer");
 
         // Get the chunk from the catalog
-        let chunk = {
-            let partition = self
-                .preserved_catalog
-                .state()
-                .valid_partition(partition_key)
-                .context(UnloadingChunkFromReadBuffer {
-                    partition_key,
-                    table_name,
-                    chunk_id,
-                })?;
-            let partition = partition.read();
-
-            partition
-                .chunk(table_name, chunk_id)
-                .context(UnloadingChunkFromReadBuffer {
-                    partition_key,
-                    table_name,
-                    chunk_id,
-                })?
-        };
+        let chunk = self.chunk(table_name, partition_key, chunk_id)?;
 
         // update the catalog to no longer use read buffer chunk if any
         let mut chunk = chunk.write();
 
         chunk
             .set_unload_from_read_buffer()
-            .context(UnloadingChunkFromReadBuffer {
+            .context(LifecycleError {
                 partition_key,
                 table_name,
                 chunk_id,
             })?;
 
-        debug!(%partition_key, %table_name, %chunk_id, "chunk marked UNLOADED from read buffer");
+        debug!(%table_name, %partition_key, %chunk_id, "chunk marked UNLOADED from read buffer");
 
         Ok(DbChunk::snapshot(&chunk))
     }
@@ -795,8 +692,8 @@ impl Db {
     /// [`load_chunk_to_read_buffer`](Self::load_chunk_to_read_buffer)
     pub fn load_chunk_to_read_buffer_in_background(
         self: &Arc<Self>,
-        partition_key: String,
         table_name: String,
+        partition_key: String,
         chunk_id: u32,
     ) -> TaskTracker<Job> {
         let name = self.rules.read().name.clone();
@@ -810,11 +707,11 @@ impl Db {
         let captured_registration = registration.clone();
         let captured_db = Arc::clone(&self);
         let task = async move {
-            debug!(%name, %partition_key, %table_name, %chunk_id, "background task loading chunk to read buffer");
+            debug!(%name, %table_name, %partition_key, %chunk_id, "background task loading chunk to read buffer");
             let result = captured_db
                 .load_chunk_to_read_buffer(
-                    &partition_key,
                     &table_name,
+                    &partition_key,
                     chunk_id,
                     &captured_registration,
                 )
@@ -825,7 +722,7 @@ impl Db {
                 return Err(e);
             }
 
-            debug!(%name, %partition_key, %table_name, %chunk_id, "background task completed loading chunk to read buffer");
+            debug!(%name, %table_name, %partition_key, %chunk_id, "background task completed loading chunk to read buffer");
 
             Ok(())
         };
@@ -839,8 +736,8 @@ impl Db {
     /// [`write_chunk_to_object_store`](Self::write_chunk_to_object_store)
     pub fn write_chunk_to_object_store_in_background(
         self: &Arc<Self>,
-        partition_key: String,
         table_name: String,
+        partition_key: String,
         chunk_id: u32,
     ) -> TaskTracker<Job> {
         let name = self.rules.read().name.clone();
@@ -854,11 +751,11 @@ impl Db {
         let captured_registration = registration.clone();
         let captured_db = Arc::clone(&self);
         let task = async move {
-            debug!(%name, %partition_key, %table_name, %chunk_id, "background task loading chunk to object store");
+            debug!(%name, %table_name, %partition_key, %chunk_id, "background task loading chunk to object store");
             let result = captured_db
                 .write_chunk_to_object_store(
-                    &partition_key,
                     &table_name,
+                    &partition_key,
                     chunk_id,
                     &captured_registration,
                 )
@@ -869,7 +766,7 @@ impl Db {
                 return Err(e);
             }
 
-            debug!(%name, %partition_key, %table_name, %chunk_id, "background task completed writing chunk to object store");
+            debug!(%name, %table_name, %partition_key, %chunk_id, "background task completed writing chunk to object store");
 
             Ok(())
         };
@@ -885,40 +782,40 @@ impl Db {
         let partition_key = Some(partition_key);
         let table_names = TableNameFilter::AllTables;
         self.preserved_catalog.state().filtered_chunks(
-            partition_key,
             table_names,
+            partition_key,
             CatalogChunk::summary,
         )
     }
 
     /// Return Summary information for all columns in all chunks in the
     /// partition across all storage systems
-    pub fn partition_summary(&self, partition_key: &str) -> PartitionSummary {
+    pub fn partition_summary(
+        &self,
+        table_name: &str,
+        partition_key: &str,
+    ) -> Option<PartitionSummary> {
         self.preserved_catalog
             .state()
-            .partition(partition_key)
+            .partition(table_name, partition_key)
             .map(|partition| partition.read().summary())
-            .unwrap_or_else(|| PartitionSummary {
-                key: partition_key.to_string(),
-                tables: vec![],
-            })
+            .ok()
     }
 
     /// Return table summary information for the given chunk in the specified
     /// partition
     pub fn table_summary(
         &self,
-        partition_key: &str,
         table_name: &str,
+        partition_key: &str,
         chunk_id: u32,
     ) -> Option<Arc<TableSummary>> {
-        if let Some(partition) = self.preserved_catalog.state().partition(partition_key) {
-            let partition = partition.read();
-            if let Ok(chunk) = partition.chunk(table_name, chunk_id) {
-                return Some(chunk.read().table_summary());
-            }
-        }
-        None
+        Some(
+            self.chunk(table_name, partition_key, chunk_id)
+                .ok()?
+                .read()
+                .table_summary(),
+        )
     }
 
     /// Returns the number of iterations of the background worker lifecycle loop
@@ -1051,20 +948,23 @@ impl Db {
             }
         }
 
-        // TODO: Direct writes to closing chunks
-
         if let Some(partitioned_writes) = sequenced_entry.partition_writes() {
             for write in partitioned_writes {
                 let partition_key = write.key();
-                let partition = self
-                    .preserved_catalog
-                    .state()
-                    .get_or_create_partition(partition_key);
-                let mut partition = partition.write();
-                partition.update_last_write_at();
-
                 for table_batch in write.table_batches() {
-                    match partition.open_chunk(table_batch.name()).ok().flatten() {
+                    if table_batch.row_count() == 0 {
+                        continue;
+                    }
+
+                    let partition = self
+                        .preserved_catalog
+                        .state()
+                        .get_or_create_partition(table_batch.name(), partition_key);
+
+                    let mut partition = partition.write();
+                    partition.update_last_write_at();
+
+                    match partition.open_chunk() {
                         Some(chunk) => {
                             let mut chunk = chunk.write();
                             chunk.record_write();
@@ -1111,10 +1011,7 @@ impl Db {
                                 )
                                 .context(WriteEntryInitial { partition_key })?;
 
-                            let new_chunk = partition
-                                .create_open_chunk(mb_chunk)
-                                .context(OpenEntry { partition_key })?;
-
+                            let new_chunk = partition.create_open_chunk(mb_chunk);
                             check_chunk_closed(&mut *new_chunk.write(), mutable_size_threshold);
                         }
                     };
@@ -1245,12 +1142,12 @@ impl CatalogState for Catalog {
 
         // Get partition from the catalog
         // Note that the partition might not exist yet if the chunk is loaded from an existing preserved catalog.
-        let partition = self.get_or_create_partition(&partition_key);
+        let partition = self.get_or_create_partition(&table_name, &partition_key);
         let partition_guard = partition.read();
 
         // Get the chunk from the catalog
-        match partition_guard.chunk(table_name.clone(), chunk_id) {
-            Ok(chunk) => {
+        match partition_guard.chunk(chunk_id) {
+            Some(chunk) => {
                 // Chunk exists => should be in frozen stage and will transition from there
 
                 // Relock the chunk again (nothing else should have been able
@@ -1262,25 +1159,17 @@ impl CatalogState for Catalog {
                     .set_written_to_object_store(parquet_chunk)
                     .map_err(|e| Box::new(e) as _)
                     .context(CatalogStateFailure { path: info.path })?;
-                debug!(%partition_key, %table_name, %chunk_id, "chunk marked WRITTEN. Persisting to object store complete");
+                debug!(%table_name, %partition_key, %chunk_id, "chunk marked WRITTEN. Persisting to object store complete");
             }
-            Err(catalog::Error::UnknownTable { .. }) | Err(catalog::Error::UnknownChunk { .. }) => {
+            None => {
                 // table unknown => that's ok, create chunk in "object store only" stage which will also create the table
                 // table chunk, but table already known => that's ok, create chunk in "object store only" stage
                 drop(partition_guard);
                 let mut partition_guard = partition.write();
-                partition_guard
-                    .create_object_store_only_chunk(chunk_id, parquet_chunk)
-                    .map_err(|e| Box::new(e) as _)
-                    .context(CatalogStateFailure { path: info.path })?;
-                debug!(%partition_key, %table_name, %chunk_id, "recovered chunk from persisted catalog");
-            }
-            Err(e) => {
-                // Other unknown error => bail
-                return Err(parquet_file::catalog::Error::CatalogStateFailure {
-                    source: Box::new(e),
-                    path: info.path,
-                });
+                let previous_chunk =
+                    partition_guard.insert_object_store_only_chunk(chunk_id, parquet_chunk);
+                assert!(previous_chunk.is_none());
+                debug!(%table_name, %partition_key, %chunk_id, "recovered chunk from persisted catalog");
             }
         }
 
@@ -1509,7 +1398,7 @@ mod tests {
             .eq(1.0)
             .unwrap();
 
-        db.rollover_partition("1970-01-01T00", "cpu").await.unwrap();
+        db.rollover_partition("cpu", "1970-01-01T00").await.unwrap();
 
         // A chunk is now closed
         test_db
@@ -1527,7 +1416,7 @@ mod tests {
         catalog_chunk_size_bytes_metric_eq(&test_db.metric_registry, "mutable_buffer", 1143)
             .unwrap();
 
-        db.load_chunk_to_read_buffer("1970-01-01T00", "cpu", 0, &Default::default())
+        db.load_chunk_to_read_buffer("cpu", "1970-01-01T00", 0, &Default::default())
             .await
             .unwrap();
 
@@ -1548,7 +1437,7 @@ mod tests {
         catalog_chunk_size_bytes_metric_eq(&test_db.metric_registry, "mutable_buffer", 0).unwrap();
         catalog_chunk_size_bytes_metric_eq(&test_db.metric_registry, "read_buffer", 1616).unwrap();
 
-        db.write_chunk_to_object_store("1970-01-01T00", "cpu", 0, &Default::default())
+        db.write_chunk_to_object_store("cpu", "1970-01-01T00", 0, &Default::default())
             .await
             .unwrap();
 
@@ -1575,7 +1464,7 @@ mod tests {
         )
         .unwrap(); // TODO: #1311
 
-        db.unload_read_buffer("1970-01-01T00", "cpu", 0)
+        db.unload_read_buffer("cpu", "1970-01-01T00", 0)
             .await
             .unwrap();
 
@@ -1606,7 +1495,7 @@ mod tests {
         assert_eq!(vec!["1970-01-01T00"], db.partition_keys().unwrap());
 
         let mb_chunk = db
-            .rollover_partition("1970-01-01T00", "cpu")
+            .rollover_partition("cpu", "1970-01-01T00")
             .await
             .unwrap()
             .unwrap();
@@ -1637,7 +1526,7 @@ mod tests {
 
         // And expect that we still get the same thing when data is rolled over again
         let chunk = db
-            .rollover_partition("1970-01-01T00", "cpu")
+            .rollover_partition("cpu", "1970-01-01T00")
             .await
             .unwrap()
             .unwrap();
@@ -1664,7 +1553,7 @@ mod tests {
         assert_eq!(vec!["1970-01-01T00"], db.partition_keys().unwrap());
 
         let mb_chunk = db
-            .rollover_partition("1970-01-01T00", "cpu")
+            .rollover_partition("cpu", "1970-01-01T00")
             .await
             .unwrap()
             .unwrap();
@@ -1694,12 +1583,12 @@ mod tests {
 
         let partition_key = "1970-01-01T00";
         let mb_chunk = db
-            .rollover_partition(partition_key, "cpu")
+            .rollover_partition("cpu", partition_key)
             .await
             .unwrap()
             .unwrap();
         let rb_chunk = db
-            .load_chunk_to_read_buffer(partition_key, "cpu", mb_chunk.id(), &Default::default())
+            .load_chunk_to_read_buffer("cpu", partition_key, mb_chunk.id(), &Default::default())
             .await
             .unwrap();
 
@@ -1739,7 +1628,7 @@ mod tests {
         catalog_chunk_size_bytes_metric_eq(&test_db.metric_registry, "read_buffer", 1616).unwrap();
 
         // drop, the chunk from the read buffer
-        db.drop_chunk(partition_key, "cpu", mb_chunk.id()).unwrap();
+        db.drop_chunk("cpu", partition_key, mb_chunk.id()).unwrap();
         assert_eq!(
             read_buffer_chunk_ids(db.as_ref(), partition_key),
             vec![] as Vec<u32>
@@ -1784,7 +1673,7 @@ mod tests {
 
         let partition_key = "1970-01-01T00";
         let mb_chunk = db
-            .rollover_partition(partition_key, "cpu")
+            .rollover_partition("cpu", partition_key)
             .await
             .unwrap()
             .unwrap();
@@ -1792,7 +1681,7 @@ mod tests {
         let mb = collect_read_filter(&mb_chunk).await;
 
         let rb_chunk = db
-            .load_chunk_to_read_buffer(partition_key, "cpu", mb_chunk.id(), &Default::default())
+            .load_chunk_to_read_buffer("cpu", partition_key, mb_chunk.id(), &Default::default())
             .await
             .unwrap();
 
@@ -1896,18 +1785,18 @@ mod tests {
         //Now mark the MB chunk close
         let partition_key = "1970-01-01T00";
         let mb_chunk = db
-            .rollover_partition("1970-01-01T00", "cpu")
+            .rollover_partition("cpu", "1970-01-01T00")
             .await
             .unwrap()
             .unwrap();
         // Move that MB chunk to RB chunk and drop it from MB
         let rb_chunk = db
-            .load_chunk_to_read_buffer(partition_key, "cpu", mb_chunk.id(), &Default::default())
+            .load_chunk_to_read_buffer("cpu", partition_key, mb_chunk.id(), &Default::default())
             .await
             .unwrap();
         // Write the RB chunk to Object Store but keep it in RB
         let pq_chunk = db
-            .write_chunk_to_object_store(partition_key, "cpu", mb_chunk.id(), &Default::default())
+            .write_chunk_to_object_store("cpu", partition_key, mb_chunk.id(), &Default::default())
             .await
             .unwrap();
 
@@ -1995,18 +1884,18 @@ mod tests {
         // Now mark the MB chunk close
         let partition_key = "1970-01-01T00";
         let mb_chunk = db
-            .rollover_partition("1970-01-01T00", "cpu")
+            .rollover_partition("cpu", "1970-01-01T00")
             .await
             .unwrap()
             .unwrap();
         // Move that MB chunk to RB chunk and drop it from MB
         let rb_chunk = db
-            .load_chunk_to_read_buffer(partition_key, "cpu", mb_chunk.id(), &Default::default())
+            .load_chunk_to_read_buffer("cpu", partition_key, mb_chunk.id(), &Default::default())
             .await
             .unwrap();
         // Write the RB chunk to Object Store but keep it in RB
         let pq_chunk = db
-            .write_chunk_to_object_store(partition_key, "cpu", mb_chunk.id(), &Default::default())
+            .write_chunk_to_object_store("cpu", partition_key, mb_chunk.id(), &Default::default())
             .await
             .unwrap();
 
@@ -2034,7 +1923,7 @@ mod tests {
 
         // Unload RB chunk but keep it in OS
         let pq_chunk = db
-            .unload_read_buffer(partition_key, "cpu", mb_chunk.id())
+            .unload_read_buffer("cpu", partition_key, mb_chunk.id())
             .await
             .unwrap();
 
@@ -2108,7 +1997,7 @@ mod tests {
             let partition = db
                 .preserved_catalog
                 .state()
-                .valid_partition(partition_key)
+                .partition("cpu", partition_key)
                 .unwrap();
             let partition = partition.read();
 
@@ -2123,7 +2012,7 @@ mod tests {
             let partition = db
                 .preserved_catalog
                 .state()
-                .valid_partition(partition_key)
+                .partition("cpu", partition_key)
                 .unwrap();
             let partition = partition.read();
             assert!(last_write_prev < partition.last_write_at());
@@ -2142,7 +2031,7 @@ mod tests {
         // When the chunk is rolled over
         let partition_key = "1970-01-01T00";
         let chunk_id = db
-            .rollover_partition("1970-01-01T00", "cpu")
+            .rollover_partition("cpu", "1970-01-01T00")
             .await
             .unwrap()
             .unwrap()
@@ -2152,10 +2041,10 @@ mod tests {
         let partition = db
             .preserved_catalog
             .state()
-            .valid_partition(partition_key)
+            .partition("cpu", partition_key)
             .unwrap();
         let partition = partition.read();
-        let chunk = partition.chunk("cpu", chunk_id).unwrap();
+        let chunk = partition.chunk(chunk_id).unwrap();
         let chunk = chunk.read();
 
         println!(
@@ -2183,11 +2072,12 @@ mod tests {
 
         let partitions = db.preserved_catalog.state().partition_keys();
         assert_eq!(partitions.len(), 1);
+        let partition_key = partitions.into_iter().next().unwrap();
 
         let partition = db
             .preserved_catalog
             .state()
-            .partition(&partitions[0])
+            .partition("cpu", &partition_key)
             .unwrap();
         let partition = partition.read();
 
@@ -2258,7 +2148,7 @@ mod tests {
 
         let partition_key = "1970-01-01T00";
         let mb_chunk = db
-            .rollover_partition("1970-01-01T00", "cpu")
+            .rollover_partition("cpu", "1970-01-01T00")
             .await
             .unwrap()
             .unwrap();
@@ -2268,11 +2158,11 @@ mod tests {
         // not chunk 0) to read buffer
         write_lp(&db, "cpu bar=1 30");
         let mb_chunk = db
-            .rollover_partition("1970-01-01T00", "cpu")
+            .rollover_partition("cpu", "1970-01-01T00")
             .await
             .unwrap()
             .unwrap();
-        db.load_chunk_to_read_buffer(partition_key, "cpu", mb_chunk.id(), &Default::default())
+        db.load_chunk_to_read_buffer("cpu", partition_key, mb_chunk.id(), &Default::default())
             .await
             .unwrap();
 
@@ -2316,7 +2206,7 @@ mod tests {
         let db = Arc::new(make_db().await.db);
 
         write_lp(&db, "cpu bar=1 1");
-        db.rollover_partition("1970-01-01T00", "cpu").await.unwrap();
+        db.rollover_partition("cpu", "1970-01-01T00").await.unwrap();
 
         // write into a separate partitiion
         write_lp(&db, "cpu bar=1,baz2,frob=3 400000000000000");
@@ -2366,7 +2256,7 @@ mod tests {
         write_lp(&db, "cpu bar=1 1");
         let after_first_write = Utc::now();
         write_lp(&db, "cpu bar=2 2");
-        db.rollover_partition("1970-01-01T00", "cpu").await.unwrap();
+        db.rollover_partition("cpu", "1970-01-01T00").await.unwrap();
         let after_close = Utc::now();
 
         let mut chunk_summaries = db.chunk_summaries().unwrap();
@@ -2416,24 +2306,24 @@ mod tests {
 
         // get three chunks: one open, one closed in mb and one close in rb
         write_lp(&db, "cpu bar=1 1");
-        db.rollover_partition("1970-01-01T00", "cpu").await.unwrap();
+        db.rollover_partition("cpu", "1970-01-01T00").await.unwrap();
 
         write_lp(&db, "cpu bar=1,baz=2 2");
         write_lp(&db, "cpu bar=1,baz=2,frob=3 400000000000000");
 
         print!("Partitions: {:?}", db.partition_keys().unwrap());
 
-        db.load_chunk_to_read_buffer("1970-01-01T00", "cpu", 0, &Default::default())
+        db.load_chunk_to_read_buffer("cpu", "1970-01-01T00", 0, &Default::default())
             .await
             .unwrap();
 
-        db.write_chunk_to_object_store("1970-01-01T00", "cpu", 0, &Default::default())
+        db.write_chunk_to_object_store("cpu", "1970-01-01T00", 0, &Default::default())
             .await
             .unwrap();
 
         print!("Partitions2: {:?}", db.partition_keys().unwrap());
 
-        db.rollover_partition("1970-01-05T15", "cpu").await.unwrap();
+        db.rollover_partition("cpu", "1970-01-05T15").await.unwrap();
         write_lp(&db, "cpu bar=1,baz=3,blargh=3 400000000000000");
 
         let chunk_summaries = db.chunk_summaries().expect("expected summary to return");
@@ -2516,7 +2406,7 @@ mod tests {
 
         write_lp(&db, "cpu bar=1 1");
         let chunk_id = db
-            .rollover_partition("1970-01-01T00", "cpu")
+            .rollover_partition("cpu", "1970-01-01T00")
             .await
             .unwrap()
             .unwrap()
@@ -2525,12 +2415,12 @@ mod tests {
         write_lp(&db, "mem foo=1 1");
 
         // load a chunk to the read buffer
-        db.load_chunk_to_read_buffer("1970-01-01T00", "cpu", chunk_id, &Default::default())
+        db.load_chunk_to_read_buffer("cpu", "1970-01-01T00", chunk_id, &Default::default())
             .await
             .unwrap();
 
         // write the read buffer chunk to object store
-        db.write_chunk_to_object_store("1970-01-01T00", "cpu", chunk_id, &Default::default())
+        db.write_chunk_to_object_store("cpu", "1970-01-01T00", chunk_id, &Default::default())
             .await
             .unwrap();
 
@@ -2541,93 +2431,97 @@ mod tests {
         print!("Partitions: {:?}", db.partition_keys().unwrap());
 
         let partition_summaries = vec![
-            db.partition_summary("1970-01-01T00"),
-            db.partition_summary("1970-01-05T15"),
+            db.partition_summary("cpu", "1970-01-01T00").unwrap(),
+            db.partition_summary("mem", "1970-01-01T00").unwrap(),
+            db.partition_summary("cpu", "1970-01-05T15").unwrap(),
+            db.partition_summary("mem", "1970-01-05T15").unwrap(),
         ];
 
         let expected = vec![
             PartitionSummary {
                 key: "1970-01-01T00".into(),
-                tables: vec![
-                    TableSummary {
-                        name: "cpu".into(),
-                        columns: vec![
-                            ColumnSummary {
-                                name: "bar".into(),
-                                influxdb_type: Some(InfluxDbType::Field),
-                                stats: Statistics::F64(StatValues::new(Some(1.0), Some(2.0), 2)),
-                            },
-                            ColumnSummary {
-                                name: "time".into(),
-                                influxdb_type: Some(InfluxDbType::Timestamp),
-                                stats: Statistics::I64(StatValues::new(Some(1), Some(2), 2)),
-                            },
-                            ColumnSummary {
-                                name: "baz".into(),
-                                influxdb_type: Some(InfluxDbType::Field),
-                                stats: Statistics::F64(StatValues::new(Some(3.0), Some(3.0), 1)),
-                            },
-                        ],
-                    },
-                    TableSummary {
-                        name: "mem".into(),
-                        columns: vec![
-                            ColumnSummary {
-                                name: "foo".into(),
-                                influxdb_type: Some(InfluxDbType::Field),
-                                stats: Statistics::F64(StatValues::new(Some(1.0), Some(1.0), 1)),
-                            },
-                            ColumnSummary {
-                                name: "time".into(),
-                                influxdb_type: Some(InfluxDbType::Timestamp),
-                                stats: Statistics::I64(StatValues::new(Some(1), Some(1), 1)),
-                            },
-                        ],
-                    },
-                ],
+                table: TableSummary {
+                    name: "cpu".into(),
+                    columns: vec![
+                        ColumnSummary {
+                            name: "bar".into(),
+                            influxdb_type: Some(InfluxDbType::Field),
+                            stats: Statistics::F64(StatValues::new(Some(1.0), Some(2.0), 2)),
+                        },
+                        ColumnSummary {
+                            name: "time".into(),
+                            influxdb_type: Some(InfluxDbType::Timestamp),
+                            stats: Statistics::I64(StatValues::new(Some(1), Some(2), 2)),
+                        },
+                        ColumnSummary {
+                            name: "baz".into(),
+                            influxdb_type: Some(InfluxDbType::Field),
+                            stats: Statistics::F64(StatValues::new(Some(3.0), Some(3.0), 1)),
+                        },
+                    ],
+                },
+            },
+            PartitionSummary {
+                key: "1970-01-01T00".into(),
+                table: TableSummary {
+                    name: "mem".into(),
+                    columns: vec![
+                        ColumnSummary {
+                            name: "foo".into(),
+                            influxdb_type: Some(InfluxDbType::Field),
+                            stats: Statistics::F64(StatValues::new(Some(1.0), Some(1.0), 1)),
+                        },
+                        ColumnSummary {
+                            name: "time".into(),
+                            influxdb_type: Some(InfluxDbType::Timestamp),
+                            stats: Statistics::I64(StatValues::new(Some(1), Some(1), 1)),
+                        },
+                    ],
+                },
             },
             PartitionSummary {
                 key: "1970-01-05T15".into(),
-                tables: vec![
-                    TableSummary {
-                        name: "cpu".into(),
-                        columns: vec![
-                            ColumnSummary {
-                                name: "bar".into(),
-                                influxdb_type: Some(InfluxDbType::Field),
-                                stats: Statistics::F64(StatValues::new(Some(1.0), Some(1.0), 1)),
-                            },
-                            ColumnSummary {
-                                name: "time".into(),
-                                influxdb_type: Some(InfluxDbType::Timestamp),
-                                stats: Statistics::I64(StatValues::new(
-                                    Some(400000000000000),
-                                    Some(400000000000000),
-                                    1,
-                                )),
-                            },
-                        ],
-                    },
-                    TableSummary {
-                        name: "mem".into(),
-                        columns: vec![
-                            ColumnSummary {
-                                name: "frob".into(),
-                                influxdb_type: Some(InfluxDbType::Field),
-                                stats: Statistics::F64(StatValues::new(Some(3.0), Some(3.0), 1)),
-                            },
-                            ColumnSummary {
-                                name: "time".into(),
-                                influxdb_type: Some(InfluxDbType::Timestamp),
-                                stats: Statistics::I64(StatValues::new(
-                                    Some(400000000000001),
-                                    Some(400000000000001),
-                                    1,
-                                )),
-                            },
-                        ],
-                    },
-                ],
+                table: TableSummary {
+                    name: "cpu".into(),
+                    columns: vec![
+                        ColumnSummary {
+                            name: "bar".into(),
+                            influxdb_type: Some(InfluxDbType::Field),
+                            stats: Statistics::F64(StatValues::new(Some(1.0), Some(1.0), 1)),
+                        },
+                        ColumnSummary {
+                            name: "time".into(),
+                            influxdb_type: Some(InfluxDbType::Timestamp),
+                            stats: Statistics::I64(StatValues::new(
+                                Some(400000000000000),
+                                Some(400000000000000),
+                                1,
+                            )),
+                        },
+                    ],
+                },
+            },
+            PartitionSummary {
+                key: "1970-01-05T15".into(),
+                table: TableSummary {
+                    name: "mem".into(),
+                    columns: vec![
+                        ColumnSummary {
+                            name: "frob".into(),
+                            influxdb_type: Some(InfluxDbType::Field),
+                            stats: Statistics::F64(StatValues::new(Some(3.0), Some(3.0), 1)),
+                        },
+                        ColumnSummary {
+                            name: "time".into(),
+                            influxdb_type: Some(InfluxDbType::Timestamp),
+                            stats: Statistics::I64(StatValues::new(
+                                Some(400000000000001),
+                                Some(400000000000001),
+                                1,
+                            )),
+                        },
+                    ],
+                },
             },
         ];
 
@@ -2704,14 +2598,14 @@ mod tests {
         let partition_key = "1970-01-01T00";
         let table_name = "cpu";
         let mb_chunk = db
-            .rollover_partition(partition_key, table_name)
+            .rollover_partition(table_name, partition_key)
             .await
             .unwrap()
             .unwrap();
         let rb_chunk = db
             .load_chunk_to_read_buffer(
-                partition_key,
                 table_name,
+                partition_key,
                 mb_chunk.id(),
                 &Default::default(),
             )
@@ -2721,8 +2615,8 @@ mod tests {
 
         // RB => OS
         let task = db.write_chunk_to_object_store_in_background(
-            partition_key.to_string(),
             table_name.to_string(),
+            partition_key.to_string(),
             rb_chunk.id(),
         );
         let t_start = std::time::Instant::now();
@@ -2773,33 +2667,6 @@ mod tests {
 
         let db = Arc::new(test_db.db);
 
-        // Expect partition lock registry to have been created
-        test_db
-            .metric_registry
-            .has_metric_family("catalog_lock_total")
-            .with_labels(&[
-                ("db_name", "lock_tracker"),
-                ("lock", "partition"),
-                ("svr_id", "10"),
-                ("access", "exclusive"),
-            ])
-            .counter()
-            .eq(0.)
-            .unwrap();
-
-        test_db
-            .metric_registry
-            .has_metric_family("catalog_lock_total")
-            .with_labels(&[
-                ("db_name", "lock_tracker"),
-                ("lock", "partition"),
-                ("svr_id", "10"),
-                ("access", "shared"),
-            ])
-            .counter()
-            .eq(0.)
-            .unwrap();
-
         write_lp(db.as_ref(), "cpu bar=1 10");
 
         test_db
@@ -2808,6 +2675,7 @@ mod tests {
             .with_labels(&[
                 ("db_name", "lock_tracker"),
                 ("lock", "partition"),
+                ("table", "cpu"),
                 ("svr_id", "10"),
                 ("access", "exclusive"),
             ])
@@ -2821,22 +2689,13 @@ mod tests {
             .with_labels(&[
                 ("db_name", "lock_tracker"),
                 ("lock", "partition"),
+                ("table", "cpu"),
                 ("svr_id", "10"),
                 ("access", "shared"),
             ])
             .counter()
             .eq(0.)
             .unwrap();
-
-        let partition_key = db
-            .preserved_catalog
-            .state()
-            .partitions()
-            .next()
-            .unwrap()
-            .read()
-            .key()
-            .to_string();
 
         let chunks = db.preserved_catalog.state().chunks();
         assert_eq!(chunks.len(), 1);
@@ -2862,6 +2721,7 @@ mod tests {
             .with_labels(&[
                 ("db_name", "lock_tracker"),
                 ("lock", "partition"),
+                ("table", "cpu"),
                 ("svr_id", "10"),
                 ("access", "exclusive"),
             ])
@@ -2875,11 +2735,12 @@ mod tests {
             .with_labels(&[
                 ("db_name", "lock_tracker"),
                 ("lock", "partition"),
+                ("table", "cpu"),
                 ("svr_id", "10"),
                 ("access", "shared"),
             ])
             .counter()
-            .eq(2.)
+            .eq(1.)
             .unwrap();
 
         test_db
@@ -2888,7 +2749,7 @@ mod tests {
             .with_labels(&[
                 ("db_name", "lock_tracker"),
                 ("lock", "chunk"),
-                ("partition", &partition_key),
+                ("table", "cpu"),
                 ("svr_id", "10"),
                 ("access", "exclusive"),
             ])
@@ -2902,7 +2763,7 @@ mod tests {
             .with_labels(&[
                 ("db_name", "lock_tracker"),
                 ("lock", "chunk"),
-                ("partition", &partition_key),
+                ("table", "cpu"),
                 ("svr_id", "10"),
                 ("access", "shared"),
             ])
@@ -2917,7 +2778,7 @@ mod tests {
                 ("db_name", "lock_tracker"),
                 ("lock", "chunk"),
                 ("svr_id", "10"),
-                ("partition", &partition_key),
+                ("table", "cpu"),
                 ("access", "shared"),
             ])
             .counter()
@@ -2951,7 +2812,7 @@ mod tests {
 
     #[tokio::test]
     async fn write_one_chunk_to_preserved_catalog() {
-        // Test that parquet data is commited to preserved catalog
+        // Test that parquet data is committed to preserved catalog
 
         // ==================== setup ====================
         let object_store = Arc::new(ObjectStore::new_in_memory(InMemory::new()));
@@ -2992,17 +2853,8 @@ mod tests {
         // ==================== check: catalog state ====================
         // the preserved catalog should now register a single file
         let mut paths_expected = vec![];
-        for (partition_key, table_name, chunk_id) in &chunks {
-            let chunk = {
-                let partition = db
-                    .preserved_catalog
-                    .state()
-                    .valid_partition(&partition_key)
-                    .unwrap();
-                let partition = partition.read();
-
-                partition.chunk(table_name, *chunk_id).unwrap()
-            };
+        for (table_name, partition_key, chunk_id) in &chunks {
+            let chunk = db.chunk(table_name, partition_key, *chunk_id).unwrap();
             let chunk = chunk.read();
             if let ChunkStage::Persisted { parquet, .. } = chunk.stage() {
                 paths_expected.push(parquet.table_path().display());
@@ -3043,17 +2895,8 @@ mod tests {
 
         // ==================== check: DB state ====================
         // Re-created DB should have an "object store only"-chunk
-        for (partition_key, table_name, chunk_id) in &chunks {
-            let chunk = {
-                let partition = db
-                    .preserved_catalog
-                    .state()
-                    .valid_partition(&partition_key)
-                    .unwrap();
-                let partition = partition.read();
-
-                partition.chunk(table_name, *chunk_id).unwrap()
-            };
+        for (table_name, partition_key, chunk_id) in &chunks {
+            let chunk = db.chunk(table_name, partition_key, *chunk_id).unwrap();
             let chunk = chunk.read();
             assert!(matches!(
                 chunk.stage(),
@@ -3090,17 +2933,8 @@ mod tests {
         //   2: dropped (not in current catalog but parquet file still present for time travel)
         let mut paths_keep = vec![];
         for i in 0..3i8 {
-            let (partition_key, table_name, chunk_id) = create_parquet_chunk(db.as_ref()).await;
-            let chunk = {
-                let partition = db
-                    .preserved_catalog
-                    .state()
-                    .valid_partition(&partition_key)
-                    .unwrap();
-                let partition = partition.read();
-
-                partition.chunk(table_name.clone(), chunk_id).unwrap()
-            };
+            let (table_name, partition_key, chunk_id) = create_parquet_chunk(db.as_ref()).await;
+            let chunk = db.chunk(&table_name, &partition_key, chunk_id).unwrap();
             let chunk = chunk.read();
             if let ChunkStage::Persisted { parquet, .. } = chunk.stage() {
                 paths_keep.push(parquet.table_path());
@@ -3112,12 +2946,12 @@ mod tests {
             drop(chunk);
 
             if i == 1 {
-                db.unload_read_buffer(&partition_key, &table_name, chunk_id)
+                db.unload_read_buffer(&table_name, &partition_key, chunk_id)
                     .await
                     .unwrap();
             }
             if i == 2 {
-                db.drop_chunk(&partition_key, &table_name, chunk_id)
+                db.drop_chunk(&table_name, &partition_key, chunk_id)
                     .unwrap();
             }
         }
@@ -3175,23 +3009,23 @@ mod tests {
         //Now mark the MB chunk close
         let chunk_id = {
             let mb_chunk = db
-                .rollover_partition(partition_key, table_name)
+                .rollover_partition(table_name, partition_key)
                 .await
                 .unwrap()
                 .unwrap();
             mb_chunk.id()
         };
         // Move that MB chunk to RB chunk and drop it from MB
-        db.load_chunk_to_read_buffer(partition_key, table_name, chunk_id, &Default::default())
+        db.load_chunk_to_read_buffer(table_name, partition_key, chunk_id, &Default::default())
             .await
             .unwrap();
 
         // Write the RB chunk to Object Store but keep it in RB
-        db.write_chunk_to_object_store(partition_key, table_name, chunk_id, &Default::default())
+        db.write_chunk_to_object_store(table_name, partition_key, chunk_id, &Default::default())
             .await
             .unwrap();
 
-        (partition_key.to_string(), table_name.to_string(), chunk_id)
+        (table_name.to_string(), partition_key.to_string(), chunk_id)
     }
 
     async fn get_object_store_files(object_store: &ObjectStore) -> HashSet<String> {

--- a/server/src/db.rs
+++ b/server/src/db.rs
@@ -1166,9 +1166,7 @@ impl CatalogState for Catalog {
                 // table chunk, but table already known => that's ok, create chunk in "object store only" stage
                 drop(partition_guard);
                 let mut partition_guard = partition.write();
-                let previous_chunk =
-                    partition_guard.insert_object_store_only_chunk(chunk_id, parquet_chunk);
-                assert!(previous_chunk.is_none());
+                partition_guard.insert_object_store_only_chunk(chunk_id, parquet_chunk);
                 debug!(%table_name, %partition_key, %chunk_id, "recovered chunk from persisted catalog");
             }
         }

--- a/server/src/db/access.rs
+++ b/server/src/db/access.rs
@@ -141,7 +141,7 @@ impl ChunkAccess {
         // Apply initial partition key / table name pruning
         let chunks = self
             .catalog
-            .filtered_chunks(partition_key, table_names, DbChunk::snapshot);
+            .filtered_chunks(table_names, partition_key, DbChunk::snapshot);
 
         self.prune_chunks(chunks, predicate)
     }
@@ -191,7 +191,7 @@ impl Database for QueryCatalogAccess {
     }
 
     fn partition_keys(&self) -> Result<Vec<String>, Self::Error> {
-        Ok(self.catalog.partition_keys())
+        Ok(self.catalog.partition_keys().into_iter().collect())
     }
 
     fn chunk_summaries(&self) -> Result<Vec<ChunkSummary>> {

--- a/server/src/db/catalog/chunk.rs
+++ b/server/src/db/catalog/chunk.rs
@@ -864,7 +864,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic]
+    #[should_panic(expected = "chunk must not be empty")]
     fn test_new_open_empty() {
         // fails with empty MBChunk
         let mb_chunk = MBChunk::new("t1", MBChunkMetrics::new_unregistered());

--- a/server/src/db/catalog/chunk.rs
+++ b/server/src/db/catalog/chunk.rs
@@ -1,19 +1,82 @@
 use std::sync::Arc;
 
 use chrono::{DateTime, Utc};
+use snafu::Snafu;
+
 use data_types::{
     chunk_metadata::{ChunkColumnSummary, ChunkStorage, ChunkSummary, DetailedChunkSummary},
     partition_metadata::TableSummary,
 };
 use internal_types::schema::Schema;
+use metrics::{Counter, Histogram, KeyValue};
 use mutable_buffer::chunk::{snapshot::ChunkSnapshot as MBChunkSnapshot, Chunk as MBChunk};
 use parquet_file::chunk::Chunk as ParquetChunk;
 use read_buffer::Chunk as ReadBufferChunk;
-
-use super::{ChunkIsEmpty, Error, InternalChunkState, Result};
-use metrics::{Counter, Histogram, KeyValue};
-use snafu::ensure;
 use tracker::{TaskRegistration, TaskTracker};
+
+#[derive(Debug, Snafu)]
+pub enum Error {
+    #[snafu(display(
+        "Internal Error: unexpected chunk state for {}:{}:{}  during {}. Expected {}, got {}",
+        partition_key,
+        table_name,
+        chunk_id,
+        operation,
+        expected,
+        actual
+    ))]
+    InternalChunkState {
+        partition_key: String,
+        table_name: String,
+        chunk_id: u32,
+        operation: String,
+        expected: String,
+        actual: String,
+    },
+
+    #[snafu(display(
+        "Internal Error: A lifecycle action '{}' is already in progress for  {}:{}:{}",
+        lifecycle_action,
+        partition_key,
+        table_name,
+        chunk_id,
+    ))]
+    LifecycleActionAlreadyInProgress {
+        partition_key: String,
+        table_name: String,
+        chunk_id: u32,
+        lifecycle_action: String,
+    },
+
+    #[snafu(display(
+        "Internal Error: Unexpected chunk state for {}:{}:{}. Expected {}, got {}",
+        partition_key,
+        table_name,
+        chunk_id,
+        expected,
+        actual
+    ))]
+    UnexpectedLifecycleAction {
+        partition_key: String,
+        table_name: String,
+        chunk_id: u32,
+        expected: String,
+        actual: String,
+    },
+
+    #[snafu(display(
+        "Internal Error: Cannot clear a lifecycle action '{}' for chunk {}:{} that is still running",
+        action,
+        partition_key,
+        chunk_id
+    ))]
+    IncompleteLifecycleAction {
+        partition_key: String,
+        chunk_id: u32,
+        action: String,
+    },
+}
+pub type Result<T, E = Error> = std::result::Result<T, E>;
 
 /// Any lifecycle action currently in progress for this chunk
 #[derive(Debug, Copy, Clone, PartialEq)]
@@ -230,15 +293,8 @@ impl Chunk {
         partition_key: impl AsRef<str>,
         chunk: mutable_buffer::chunk::Chunk,
         metrics: ChunkMetrics,
-    ) -> Result<Self> {
-        ensure!(
-            chunk.rows() > 0,
-            ChunkIsEmpty {
-                partition_key: partition_key.as_ref(),
-                table_name: chunk.table_name().as_ref(),
-                chunk_id,
-            }
-        );
+    ) -> Self {
+        assert!(chunk.rows() > 0, "chunk must not be empty");
 
         let table_name = Arc::clone(&chunk.table_name());
         let stage = ChunkStage::Open { mb_chunk: chunk };
@@ -259,7 +315,7 @@ impl Chunk {
             time_closed: None,
         };
         chunk.record_write();
-        Ok(chunk)
+        chunk
     }
 
     /// Creates a new chunk that is only registered via an object store reference (= only exists in parquet).
@@ -780,13 +836,14 @@ impl Chunk {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use entry::test_helpers::lp_to_entry;
     use mutable_buffer::chunk::{Chunk as MBChunk, ChunkMetrics as MBChunkMetrics};
     use parquet_file::{
         chunk::Chunk as ParquetChunk,
         test_utils::{make_chunk as make_parquet_chunk_with_store, make_object_store},
     };
+
+    use super::*;
 
     #[test]
     fn test_new_open() {
@@ -802,23 +859,16 @@ mod tests {
             partition_key,
             mb_chunk,
             ChunkMetrics::new_unregistered(),
-        )
-        .unwrap();
-        assert!(matches!(chunk.stage(), &ChunkStage::Open { .. }));
-
-        // fails with empty MBChunk
-        let mb_chunk = MBChunk::new(table_name, MBChunkMetrics::new_unregistered());
-        assert_eq!(
-            Chunk::new_open(
-                chunk_id,
-                partition_key,
-                mb_chunk,
-                ChunkMetrics::new_unregistered(),
-            )
-            .unwrap_err()
-            .to_string(),
-            "Cannot add an empty chunk to the catalog part1:table1:0"
         );
+        assert!(matches!(chunk.stage(), &ChunkStage::Open { .. }));
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_new_open_empty() {
+        // fails with empty MBChunk
+        let mb_chunk = MBChunk::new("t1", MBChunkMetrics::new_unregistered());
+        Chunk::new_open(0, "p1", mb_chunk, ChunkMetrics::new_unregistered());
     }
 
     #[tokio::test]
@@ -908,7 +958,6 @@ mod tests {
             mb_chunk,
             ChunkMetrics::new_unregistered(),
         )
-        .unwrap()
     }
 
     async fn make_persisted_chunk() -> Chunk {

--- a/server/src/db/catalog/partition.rs
+++ b/server/src/db/catalog/partition.rs
@@ -3,31 +3,28 @@
 use std::{collections::BTreeMap, sync::Arc};
 
 use chrono::{DateTime, Utc};
-use snafu::OptionExt;
 
-use data_types::chunk_metadata::ChunkSummary;
-use data_types::partition_metadata::{
-    PartitionSummary, UnaggregatedPartitionSummary, UnaggregatedTableSummary,
-};
+use data_types::partition_metadata::PartitionSummary;
 use tracker::RwLock;
 
 use crate::db::catalog::metrics::PartitionMetrics;
 
-use super::{
-    chunk::{Chunk, ChunkStage},
-    Error, Result, TableNameFilter, UnknownChunk, UnknownTable,
-};
+use super::chunk::{Chunk, ChunkStage};
+use data_types::chunk_metadata::ChunkSummary;
 
 /// IOx Catalog Partition
 ///
-/// A partition contains multiple Chunks.
+/// A partition contains multiple Chunks for a given table
 #[derive(Debug)]
 pub struct Partition {
     /// The partition key
-    key: String,
+    partition_key: Arc<str>,
 
-    /// Tables within this partition
-    tables: BTreeMap<String, PartitionTable>,
+    /// The table name
+    table_name: Arc<str>,
+
+    /// The chunks that make up this partition, indexed by id
+    chunks: BTreeMap<u32, Arc<RwLock<Chunk>>>,
 
     /// When this partition was created
     created_at: DateTime<Utc>,
@@ -36,15 +33,11 @@ pub struct Partition {
     /// partition. Partition::new initializes this to now.
     last_write_at: DateTime<Utc>,
 
+    /// What the next chunk id is
+    next_chunk_id: u32,
+
     /// Partition metrics
     metrics: PartitionMetrics,
-}
-
-impl Partition {
-    /// Return the partition_key of this Partition
-    pub fn key(&self) -> &str {
-        &self.key
-    }
 }
 
 impl Partition {
@@ -53,17 +46,31 @@ impl Partition {
     /// This function is not pub because `Partition`s should be
     /// created using the interfaces on [`Catalog`](crate::db::catalog::Catalog) and not
     /// instantiated directly.
-    pub(crate) fn new(key: impl Into<String>, metrics: PartitionMetrics) -> Self {
-        let key = key.into();
-
+    pub(crate) fn new(
+        partition_key: Arc<str>,
+        table_name: Arc<str>,
+        metrics: PartitionMetrics,
+    ) -> Self {
         let now = Utc::now();
         Self {
-            key,
-            tables: BTreeMap::new(),
+            partition_key,
+            table_name,
+            chunks: Default::default(),
             created_at: now,
             last_write_at: now,
+            next_chunk_id: 0,
             metrics,
         }
+    }
+
+    /// Return the partition_key of this Partition
+    pub fn key(&self) -> &str {
+        &self.partition_key
+    }
+
+    /// Return the table name of this partition
+    pub fn table_name(&self) -> &str {
+        &self.table_name
     }
 
     /// Update the last write time to now
@@ -87,38 +94,29 @@ impl Partition {
     /// combination.
     ///
     /// Returns an error if the chunk is empty.
-    pub fn create_open_chunk(
-        &mut self,
-        chunk: mutable_buffer::chunk::Chunk,
-    ) -> Result<Arc<RwLock<Chunk>>> {
-        let table_name: String = chunk.table_name().to_string();
+    pub fn create_open_chunk(&mut self, chunk: mutable_buffer::chunk::Chunk) -> Arc<RwLock<Chunk>> {
+        assert_eq!(chunk.table_name().as_ref(), self.table_name.as_ref());
 
-        let table = self
-            .tables
-            .entry(table_name)
-            .or_insert_with(PartitionTable::new);
-
-        let chunk_id = table.next_chunk_id;
-
+        let chunk_id = self.next_chunk_id;
         // Technically this only causes an issue on the next upsert but
         // the MUB treats u32::MAX as a sentinel value
-        assert_ne!(table.next_chunk_id, u32::MAX, "Chunk ID Overflow");
+        assert_ne!(self.next_chunk_id, u32::MAX, "Chunk ID Overflow");
 
-        table.next_chunk_id += 1;
+        self.next_chunk_id += 1;
 
-        let chunk = Arc::new(self.metrics.new_lock(Chunk::new_open(
+        let chunk = Arc::new(self.metrics.new_chunk_lock(Chunk::new_open(
             chunk_id,
-            &self.key,
+            &self.partition_key,
             chunk,
             self.metrics.new_chunk_metrics(),
-        )?));
+        )));
 
-        if table.chunks.insert(chunk_id, Arc::clone(&chunk)).is_some() {
+        if self.chunks.insert(chunk_id, Arc::clone(&chunk)).is_some() {
             // A fundamental invariant has been violated - abort
             panic!("chunk already existed with id {}", chunk_id)
         }
 
-        Ok(chunk)
+        chunk
     }
 
     /// Create new chunk that is only in object store (= parquet file).
@@ -126,158 +124,59 @@ impl Partition {
     /// The table-specific chunk ID counter will be set to
     /// `max(current, chunk_id + 1)`.
     ///
-    /// Fails if the chunk already exists.
-    pub fn create_object_store_only_chunk(
+    /// Returns the previous chunk with the given chunk_id if any
+    pub fn insert_object_store_only_chunk(
         &mut self,
         chunk_id: u32,
         chunk: Arc<parquet_file::chunk::Chunk>,
-    ) -> Result<Arc<RwLock<Chunk>>> {
-        let table_name = chunk.table_name().to_string();
+    ) -> Option<Arc<RwLock<Chunk>>> {
+        assert_eq!(chunk.table_name(), self.table_name.as_ref());
 
-        let chunk = Arc::new(self.metrics.new_lock(Chunk::new_object_store_only(
+        let chunk = Arc::new(self.metrics.new_chunk_lock(Chunk::new_object_store_only(
             chunk_id,
-            &self.key,
+            &self.partition_key,
             chunk,
             self.metrics.new_chunk_metrics(),
         )));
 
-        let table = self
-            .tables
-            .entry(table_name.clone())
-            .or_insert_with(PartitionTable::new);
-        match table.chunks.insert(chunk_id, Arc::clone(&chunk)) {
-            Some(_) => Err(Error::ChunkAlreadyExists {
-                partition_key: self.key.clone(),
-                table_name,
-                chunk_id,
-            }),
-            None => {
-                // bump chunk ID counter
-                table.next_chunk_id = table.next_chunk_id.max(chunk_id + 1);
-
-                Ok(chunk)
-            }
-        }
+        self.next_chunk_id = self.next_chunk_id.max(chunk_id + 1);
+        self.chunks.insert(chunk_id, Arc::clone(&chunk))
     }
 
     /// Drop the specified chunk
-    pub fn drop_chunk(&mut self, table_name: impl Into<String>, chunk_id: u32) -> Result<()> {
-        let table_name = table_name.into();
-
-        match self.tables.get_mut(&table_name) {
-            Some(table) => match table.chunks.remove(&chunk_id) {
-                Some(_) => Ok(()),
-                None => UnknownChunk {
-                    partition_key: self.key(),
-                    table_name,
-                    chunk_id,
-                }
-                .fail(),
-            },
-            None => UnknownTable {
-                partition_key: self.key(),
-                table_name,
-            }
-            .fail(),
-        }
+    pub fn drop_chunk(&mut self, chunk_id: u32) -> Option<Arc<RwLock<Chunk>>> {
+        self.chunks.remove(&chunk_id)
     }
 
     /// return the first currently open chunk, if any
-    pub fn open_chunk(&self, table_name: impl Into<String>) -> Result<Option<Arc<RwLock<Chunk>>>> {
-        let table_name = table_name.into();
-
-        match self.tables.get(&table_name) {
-            Some(table) => Ok(table
-                .chunks
-                .values()
-                .find(|chunk| {
-                    let chunk = chunk.read();
-                    matches!(chunk.stage(), ChunkStage::Open { .. })
-                })
-                .cloned()),
-            None => UnknownTable {
-                partition_key: self.key(),
-                table_name,
-            }
-            .fail(),
-        }
+    pub fn open_chunk(&self) -> Option<Arc<RwLock<Chunk>>> {
+        self.chunks
+            .values()
+            .find(|chunk| {
+                let chunk = chunk.read();
+                matches!(chunk.stage(), ChunkStage::Open { .. })
+            })
+            .cloned()
     }
 
     /// Return an immutable chunk reference by chunk id
-    pub fn chunk(
-        &self,
-        table_name: impl Into<String>,
-        chunk_id: u32,
-    ) -> Result<Arc<RwLock<Chunk>>> {
-        let table_name = table_name.into();
-
-        match self.tables.get(&table_name) {
-            Some(table) => table.chunks.get(&chunk_id).cloned().context(UnknownChunk {
-                partition_key: self.key(),
-                table_name,
-                chunk_id,
-            }),
-            None => UnknownTable {
-                partition_key: self.key(),
-                table_name,
-            }
-            .fail(),
-        }
+    pub fn chunk(&self, chunk_id: u32) -> Option<&Arc<RwLock<Chunk>>> {
+        self.chunks.get(&chunk_id)
     }
 
     /// Return a iterator over chunks in this partition
     pub fn chunks(&self) -> impl Iterator<Item = &Arc<RwLock<Chunk>>> {
-        self.tables.values().flat_map(|table| table.chunks.values())
-    }
-
-    /// Return an iterator over chunks in this partition
-    ///
-    /// `table_names` specifies which tables to include
-    pub fn filtered_chunks<'a>(
-        &'a self,
-        table_names: TableNameFilter<'a>,
-    ) -> impl Iterator<Item = &Arc<RwLock<Chunk>>> + 'a {
-        self.tables
-            .iter()
-            .filter_map(
-                move |(partition_table_name, partition_table)| match table_names {
-                    TableNameFilter::AllTables => Some(partition_table.chunks.values()),
-                    TableNameFilter::NamedTables(table_names) => table_names
-                        .contains(partition_table_name)
-                        .then(|| partition_table.chunks.values()),
-                },
-            )
-            .flatten()
-    }
-
-    /// Return the unaggregated chunk summary information for tables
-    /// in this partition
-    pub fn unaggregated_summary(&self) -> UnaggregatedPartitionSummary {
-        let tables = self
-            .chunks()
-            .map(|chunk| {
-                let chunk = chunk.read();
-                UnaggregatedTableSummary {
-                    chunk_id: chunk.id(),
-                    // Note: makes a deep copy of the TableSummary
-                    table: chunk.table_summary().as_ref().clone(),
-                }
-            })
-            .collect();
-
-        UnaggregatedPartitionSummary {
-            key: self.key.to_string(),
-            tables,
-        }
+        self.chunks.values()
     }
 
     /// Return a PartitionSummary for this partition
     pub fn summary(&self) -> PartitionSummary {
-        let UnaggregatedPartitionSummary { key, tables } = self.unaggregated_summary();
-
-        let table_summaries = tables.into_iter().map(|t| t.table);
-
-        PartitionSummary::from_table_summaries(key, table_summaries)
+        PartitionSummary::from_table_summaries(
+            self.partition_key.to_string(),
+            self.chunks
+                .values()
+                .map(|x| x.read().table_summary().as_ref().clone()),
+        )
     }
 
     /// Return chunk summaries for all chunks in this partition
@@ -287,23 +186,5 @@ impl Partition {
 
     pub fn metrics(&self) -> &PartitionMetrics {
         &self.metrics
-    }
-}
-
-#[derive(Debug)]
-struct PartitionTable {
-    /// What the next chunk id is
-    next_chunk_id: u32,
-
-    /// The chunks that make up this partition, indexed by id
-    chunks: BTreeMap<u32, Arc<RwLock<Chunk>>>,
-}
-
-impl PartitionTable {
-    fn new() -> Self {
-        Self {
-            next_chunk_id: 0,
-            chunks: BTreeMap::new(),
-        }
     }
 }

--- a/server/src/db/catalog/table.rs
+++ b/server/src/db/catalog/table.rs
@@ -1,0 +1,72 @@
+use super::partition::Partition;
+use crate::db::catalog::metrics::TableMetrics;
+use data_types::partition_metadata::PartitionSummary;
+use hashbrown::HashMap;
+use std::sync::Arc;
+use tracker::RwLock;
+
+/// A `Table` is a collection of `Partition` each of which is a collection of `Chunk`
+#[derive(Debug)]
+pub struct Table {
+    /// Table name
+    table_name: Arc<str>,
+    /// key is partition key
+    partitions: HashMap<Arc<str>, Arc<RwLock<Partition>>>,
+    /// Table metrics
+    metrics: TableMetrics,
+}
+
+impl Table {
+    /// Create a new table catalog object.
+    ///
+    /// This function is not pub because `Table`s should be
+    /// created using the interfaces on [`Catalog`](crate::db::catalog::Catalog) and not
+    /// instantiated directly.
+    pub(crate) fn new(table_name: Arc<str>, metrics: TableMetrics) -> Self {
+        Self {
+            table_name,
+            partitions: Default::default(),
+            metrics,
+        }
+    }
+
+    pub fn partition(&self, partition_key: impl AsRef<str>) -> Option<&Arc<RwLock<Partition>>> {
+        self.partitions.get(partition_key.as_ref())
+    }
+
+    pub fn partitions(&self) -> impl Iterator<Item = &Arc<RwLock<Partition>>> + '_ {
+        self.partitions.values()
+    }
+
+    pub fn get_or_create_partition(
+        &mut self,
+        partition_key: impl AsRef<str>,
+    ) -> &Arc<RwLock<Partition>> {
+        let metrics = &self.metrics;
+        let table_name = &self.table_name;
+        let (_, partition) = self
+            .partitions
+            .raw_entry_mut()
+            .from_key(partition_key.as_ref())
+            .or_insert_with(|| {
+                let partition_key = Arc::from(partition_key.as_ref());
+                let partition_metrics = metrics.new_partition_metrics();
+                let partition = Partition::new(
+                    Arc::clone(&partition_key),
+                    Arc::clone(&table_name),
+                    partition_metrics,
+                );
+                let partition = Arc::new(metrics.new_partition_lock(partition));
+                (partition_key, partition)
+            });
+        partition
+    }
+
+    pub fn partition_keys(&self) -> impl Iterator<Item = &Arc<str>> + '_ {
+        self.partitions.keys()
+    }
+
+    pub fn partition_summaries(&self) -> impl Iterator<Item = PartitionSummary> + '_ {
+        self.partitions.values().map(|x| x.read().summary())
+    }
+}

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -769,8 +769,8 @@ impl<M: ConnectionManager> Server<M> {
     pub fn close_chunk(
         &self,
         db_name: DatabaseName<'_>,
-        partition_key: impl Into<String>,
         table_name: impl Into<String>,
+        partition_key: impl Into<String>,
         chunk_id: u32,
     ) -> Result<TaskTracker<Job>> {
         let db_name = db_name.to_string();
@@ -784,7 +784,7 @@ impl<M: ConnectionManager> Server<M> {
             .db(&name)
             .context(DatabaseNotFound { db_name: &db_name })?;
 
-        Ok(db.load_chunk_to_read_buffer_in_background(partition_key, table_name, chunk_id))
+        Ok(db.load_chunk_to_read_buffer_in_background(table_name, partition_key, chunk_id))
     }
 
     /// Returns a list of all jobs tracked by this server
@@ -1467,7 +1467,7 @@ mod tests {
         let table_name = "cpu";
         let db_name_string = db_name.to_string();
         let tracker = server
-            .close_chunk(db_name, partition_key, table_name, 0)
+            .close_chunk(db_name, table_name, partition_key, 0)
             .unwrap();
 
         let metadata = tracker.metadata();

--- a/src/commands/database/partition.rs
+++ b/src/commands/database/partition.rs
@@ -179,7 +179,7 @@ pub async fn command(url: String, config: Config) -> Result<()> {
 
             // Ignore response for now
             client
-                .new_partition_chunk(db_name, partition_key, table_name)
+                .new_partition_chunk(db_name, table_name, partition_key)
                 .await?;
             println!("Ok");
         }
@@ -192,7 +192,7 @@ pub async fn command(url: String, config: Config) -> Result<()> {
             } = close_chunk;
 
             let operation: Operation = client
-                .close_partition_chunk(db_name, partition_key, table_name, chunk_id)
+                .close_partition_chunk(db_name, table_name, partition_key, chunk_id)
                 .await?
                 .try_into()?;
 

--- a/src/influxdb_ioxd/rpc/error.rs
+++ b/src/influxdb_ioxd/rpc/error.rs
@@ -56,35 +56,28 @@ pub fn default_server_error_handler(error: server::Error) -> tonic::Status {
 pub fn default_catalog_error_handler(error: server::db::catalog::Error) -> tonic::Status {
     use server::db::catalog::Error;
     match error {
-        Error::UnknownPartition { partition_key } => NotFound {
-            resource_type: "partition".to_string(),
-            resource_name: partition_key,
-            ..Default::default()
-        }
-        .into(),
-        Error::UnknownTable {
-            partition_key,
-            table_name,
-        } => NotFound {
+        Error::TableNotFound { table } => NotFound {
             resource_type: "table".to_string(),
-            resource_name: format!("{}:{}", partition_key, table_name),
+            resource_name: table,
             ..Default::default()
         }
         .into(),
-        Error::UnknownChunk {
-            partition_key,
-            table_name,
+        Error::PartitionNotFound { partition, table } => NotFound {
+            resource_type: "partition".to_string(),
+            resource_name: format!("{}:{}", table, partition),
+            ..Default::default()
+        }
+        .into(),
+        Error::ChunkNotFound {
             chunk_id,
+            partition,
+            table,
         } => NotFound {
             resource_type: "chunk".to_string(),
-            resource_name: format!("{}:{}:{}", partition_key, table_name, chunk_id),
+            resource_name: format!("{}:{}:{}", table, partition, chunk_id),
             ..Default::default()
         }
         .into(),
-        error => {
-            error!(?error, "Unexpected error");
-            InternalError {}.into()
-        }
     }
 }
 
@@ -98,7 +91,7 @@ pub fn default_db_error_handler(error: server::db::Error) -> tonic::Status {
             description: "Cannot write to database: no mutable buffer configured".to_string(),
         }
         .into(),
-        Error::RollingOverPartition { source, .. } => default_catalog_error_handler(source),
+        Error::CatalogError { source } => default_catalog_error_handler(source),
         error => {
             error!(?error, "Unexpected error");
             InternalError {}.into()

--- a/src/influxdb_ioxd/rpc/management.rs
+++ b/src/influxdb_ioxd/rpc/management.rs
@@ -332,7 +332,7 @@ where
             ..Default::default()
         })?;
 
-        db.rollover_partition(&partition_key, &table_name)
+        db.rollover_partition(&table_name, &partition_key)
             .await
             .map_err(default_db_error_handler)?;
 
@@ -355,7 +355,7 @@ where
 
         let tracker = self
             .server
-            .close_chunk(db_name, partition_key, table_name, chunk_id)
+            .close_chunk(db_name, table_name, partition_key, chunk_id)
             .map_err(default_server_error_handler)?;
 
         let operation = Some(super::operations::encode_tracker(tracker)?);

--- a/tests/end_to_end_cases/management_api.rs
+++ b/tests/end_to_end_cases/management_api.rs
@@ -543,7 +543,7 @@ async fn test_new_partition_chunk() {
 
     // Rollover the a second chunk
     management_client
-        .new_partition_chunk(&db_name, partition_key, table_name)
+        .new_partition_chunk(&db_name, table_name, partition_key)
         .await
         .expect("new partition chunk");
 
@@ -554,7 +554,7 @@ async fn test_new_partition_chunk() {
     write_client
         .write(&db_name, lp_lines.join("\n"))
         .await
-        .expect("write succeded");
+        .expect("write succeeded");
 
     let chunks = management_client
         .list_chunks(&db_name)
@@ -573,23 +573,23 @@ async fn test_new_partition_chunk() {
 
     // Rollover a (currently non existent) partition which is not OK
     let err = management_client
-        .new_partition_chunk(&db_name, "non_existent_partition", table_name)
+        .new_partition_chunk(&db_name, table_name, "non_existent_partition")
         .await
         .expect_err("new partition chunk");
 
     assert_eq!(
-        "Resource partition/non_existent_partition not found",
+        "Resource partition/cpu:non_existent_partition not found",
         err.to_string()
     );
 
     // Rollover a (currently non existent) table in an existing partition which is not OK
     let err = management_client
-        .new_partition_chunk(&db_name, partition_key, "non_existing_table")
+        .new_partition_chunk(&db_name, "non_existing_table", partition_key)
         .await
         .expect_err("new partition chunk");
 
     assert_eq!(
-        "Resource table/cpu:non_existing_table not found",
+        "Resource table/non_existing_table not found",
         err.to_string()
     );
 }
@@ -602,8 +602,8 @@ async fn test_new_partition_chunk_error() {
     let err = management_client
         .new_partition_chunk(
             "this database does not exist",
-            "nor_does_this_partition",
             "nor_does_this_table",
+            "nor_does_this_partition",
         )
         .await
         .expect_err("expected error");
@@ -647,7 +647,7 @@ async fn test_close_partition_chunk() {
 
     // Move the chunk to read buffer
     let operation = management_client
-        .close_partition_chunk(&db_name, partition_key, table_name, 0)
+        .close_partition_chunk(&db_name, table_name, partition_key, 0)
         .await
         .expect("new partition chunk");
 
@@ -693,8 +693,8 @@ async fn test_close_partition_chunk_error() {
     let err = management_client
         .close_partition_chunk(
             "this database does not exist",
-            "nor_does_this_partition",
             "nor_does_this_table",
+            "nor_does_this_partition",
             0,
         )
         .await

--- a/tests/end_to_end_cases/preservation.rs
+++ b/tests/end_to_end_cases/preservation.rs
@@ -80,7 +80,7 @@ async fn create_readbuffer_chunk(fixture: &ServerFixture, db_name: &str) -> u32 
 
     // Move the chunk to read buffer
     let operation = management_client
-        .close_partition_chunk(db_name, partition_key, table_name, 0)
+        .close_partition_chunk(db_name, table_name, partition_key, 0)
         .await
         .expect("new partition chunk");
 

--- a/tests/end_to_end_cases/sql_cli.rs
+++ b/tests/end_to_end_cases/sql_cli.rs
@@ -307,7 +307,7 @@ async fn test_sql_observer_operations() {
     let table_name = "cpu";
     // Move the chunk to read buffer
     let operation = management_client
-        .close_partition_chunk(&db_name, partition_key, table_name, 0)
+        .close_partition_chunk(&db_name, table_name, partition_key, 0)
         .await
         .expect("new partition chunk");
 

--- a/tests/end_to_end_cases/system_tables.rs
+++ b/tests/end_to_end_cases/system_tables.rs
@@ -28,7 +28,7 @@ async fn test_operations() {
 
     // Move the chunk to read buffer
     let operation = management_client
-        .close_partition_chunk(&db_name1, partition_key, table_name, 0)
+        .close_partition_chunk(&db_name1, table_name, partition_key, 0)
         .await
         .expect("new partition chunk");
 


### PR DESCRIPTION
This PR swaps the order of partitions and tables within the in-memory catalog. This will be the first in a number of PRs to simplify the in-memory catalog and bring it closer to @pauldix 's vision (which i share) of a less concurrent but simpler catalog and accompanying lifecycle.

This PR looks a lot longer than it is, because it swaps the order of partition key and table name in a number of methods
