### PR TITLE
fix: make pruning debug log less confusing

### DIFF
--- a/query/src/pruning.rs
+++ b/query/src/pruning.rs
@@ -77,9 +77,11 @@ where
         .filter(|c| must_keep(observer, c.as_ref(), &filter_expr))
         .collect();
 
+    let num_remaining_chunks = pruned_summaries.len();
     debug!(
         num_chunks,
-        num_pruned_chunks = pruned_summaries.len(),
+        num_pruned_chunks = num_chunks - num_remaining_chunks,
+        num_remaining_chunks,
         "Pruned chunks"
     );
     pruned_summaries


### PR DESCRIPTION

# Rationale
As noted by @e-dard, the message produced for pruning looks like :

```
level=debug msg="Pruned chunks" num_chunks=17 num_pruned_chunks=14 target="query::pruning" location="query/src/pruning.rs:80" time=1623347902889392098
```

A reasonable person might conclude that `num_chunks=17 num_pruned_chunks=14` means 14 chunks were pruned, and 3 remain after pruning. It actually means 14 chunks remain *after* pruning.


# Changes
Make the message explicit for the three numbers: `num_chunks`, `num_pruned_chunks`, and `num_remaining_chunks`
