### PR TITLE
feat: wire up catalog checkpointing 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3718,6 +3718,7 @@ dependencies = [
  "object_store",
  "observability_deps",
  "parking_lot",
+ "parquet",
  "parquet_file",
  "query",
  "rand 0.8.3",

--- a/data_types/src/database_rules.rs
+++ b/data_types/src/database_rules.rs
@@ -153,7 +153,7 @@ pub struct LifecycleRules {
     pub worker_backoff_millis: Option<NonZeroU64>,
 
     /// After how many transactions should IOx write a new checkpoint?
-    pub catalog_checkpoint_interval: Option<NonZeroU64>,
+    pub catalog_transactions_until_checkpoint: Option<NonZeroU64>,
 }
 
 /// This struct specifies the rules for the order to sort partitions

--- a/data_types/src/database_rules.rs
+++ b/data_types/src/database_rules.rs
@@ -151,6 +151,9 @@ pub struct LifecycleRules {
     /// If the background worker doesn't find anything to do it
     /// will sleep for this many milliseconds before looking again
     pub worker_backoff_millis: Option<NonZeroU64>,
+
+    /// After how many transactions should IOx write a new checkpoint?
+    pub catalog_checkpoint_interval: Option<NonZeroU64>,
 }
 
 /// This struct specifies the rules for the order to sort partitions

--- a/generated_types/protos/influxdata/iox/management/v1/database_rules.proto
+++ b/generated_types/protos/influxdata/iox/management/v1/database_rules.proto
@@ -114,7 +114,7 @@ message LifecycleRules {
   // After how many transactions should IOx write a new checkpoint?
   //
   // If 0 / absent, this default to 100.
-  uint64 catalog_checkpoint_interval = 11;
+  uint64 catalog_transactions_until_checkpoint = 11;
 }
 
 message DatabaseRules {

--- a/generated_types/protos/influxdata/iox/management/v1/database_rules.proto
+++ b/generated_types/protos/influxdata/iox/management/v1/database_rules.proto
@@ -113,7 +113,7 @@ message LifecycleRules {
 
   // After how many transactions should IOx write a new checkpoint?
   //
-  // If 0, no checkpoints will be written.
+  // If 0 / absent, this default to 100.
   uint64 catalog_checkpoint_interval = 11;
 }
 

--- a/generated_types/protos/influxdata/iox/management/v1/database_rules.proto
+++ b/generated_types/protos/influxdata/iox/management/v1/database_rules.proto
@@ -110,6 +110,11 @@ message LifecycleRules {
   // If 0, the default backoff is used
   // See server::db::lifecycle::DEFAULT_LIFECYCLE_BACKOFF
   uint64 worker_backoff_millis = 10;
+
+  // After how many transactions should IOx write a new checkpoint?
+  //
+  // If 0, no checkpoints will be written.
+  uint64 catalog_checkpoint_interval = 11;
 }
 
 message DatabaseRules {

--- a/generated_types/src/database_rules/lifecycle.rs
+++ b/generated_types/src/database_rules/lifecycle.rs
@@ -37,7 +37,7 @@ impl From<LifecycleRules> for management::LifecycleRules {
             worker_backoff_millis: config.worker_backoff_millis.map_or(0, NonZeroU64::get),
             catalog_checkpoint_interval: config
                 .catalog_checkpoint_interval
-                .map_or(0, NonZeroU64::get),
+                .map_or(100, NonZeroU64::get),
         }
     }
 }

--- a/generated_types/src/database_rules/lifecycle.rs
+++ b/generated_types/src/database_rules/lifecycle.rs
@@ -35,6 +35,9 @@ impl From<LifecycleRules> for management::LifecycleRules {
             persist: config.persist,
             immutable: config.immutable,
             worker_backoff_millis: config.worker_backoff_millis.map_or(0, NonZeroU64::get),
+            catalog_checkpoint_interval: config
+                .catalog_checkpoint_interval
+                .map_or(0, NonZeroU64::get),
         }
     }
 }
@@ -54,6 +57,7 @@ impl TryFrom<management::LifecycleRules> for LifecycleRules {
             persist: proto.persist,
             immutable: proto.immutable,
             worker_backoff_millis: NonZeroU64::new(proto.worker_backoff_millis),
+            catalog_checkpoint_interval: NonZeroU64::new(proto.catalog_checkpoint_interval),
         })
     }
 }
@@ -141,6 +145,7 @@ mod tests {
             persist: true,
             immutable: true,
             worker_backoff_millis: 1000,
+            catalog_checkpoint_interval: 10,
         };
 
         let config: LifecycleRules = protobuf.clone().try_into().unwrap();

--- a/generated_types/src/database_rules/lifecycle.rs
+++ b/generated_types/src/database_rules/lifecycle.rs
@@ -35,8 +35,8 @@ impl From<LifecycleRules> for management::LifecycleRules {
             persist: config.persist,
             immutable: config.immutable,
             worker_backoff_millis: config.worker_backoff_millis.map_or(0, NonZeroU64::get),
-            catalog_checkpoint_interval: config
-                .catalog_checkpoint_interval
+            catalog_transactions_until_checkpoint: config
+                .catalog_transactions_until_checkpoint
                 .map_or(100, NonZeroU64::get),
         }
     }
@@ -57,7 +57,9 @@ impl TryFrom<management::LifecycleRules> for LifecycleRules {
             persist: proto.persist,
             immutable: proto.immutable,
             worker_backoff_millis: NonZeroU64::new(proto.worker_backoff_millis),
-            catalog_checkpoint_interval: NonZeroU64::new(proto.catalog_checkpoint_interval),
+            catalog_transactions_until_checkpoint: NonZeroU64::new(
+                proto.catalog_transactions_until_checkpoint,
+            ),
         })
     }
 }
@@ -145,7 +147,7 @@ mod tests {
             persist: true,
             immutable: true,
             worker_backoff_millis: 1000,
-            catalog_checkpoint_interval: 10,
+            catalog_transactions_until_checkpoint: 10,
         };
 
         let config: LifecycleRules = protobuf.clone().try_into().unwrap();

--- a/parquet_file/src/catalog.rs
+++ b/parquet_file/src/catalog.rs
@@ -142,20 +142,11 @@ pub enum Error {
     },
 
     #[snafu(
-        display("Cannot read schema from {:?}: {}", path, source),
+        display("Cannot create parquet chunk from {:?}: {}", path, source),
         visibility(pub)
     )]
-    SchemaReadFailed {
-        source: crate::metadata::Error,
-        path: DirsAndFileName,
-    },
-
-    #[snafu(
-        display("Cannot read statistics from {:?}: {}", path, source),
-        visibility(pub)
-    )]
-    StatisticsReadFailed {
-        source: crate::metadata::Error,
+    ChunkCreationFailed {
+        source: crate::chunk::Error,
         path: DirsAndFileName,
     },
 

--- a/parquet_file/src/test_utils.rs
+++ b/parquet_file/src/test_utils.rs
@@ -146,7 +146,7 @@ pub async fn make_chunk_given_record_batch(
         transaction_revision_counter: 0,
         transaction_uuid: Uuid::nil(),
     };
-    let (path, _metadata) = storage
+    let (path, parquet_metadata) = storage
         .write_to_object_store(
             part_key.to_string(),
             chunk_id,
@@ -157,12 +157,13 @@ pub async fn make_chunk_given_record_batch(
         .await
         .unwrap();
 
-    Chunk::new(
+    Chunk::new_from_parts(
         part_key,
-        table_summary,
+        Arc::new(table_summary),
+        Arc::new(schema),
         path,
         Arc::clone(&store),
-        schema,
+        Arc::new(parquet_metadata),
         ChunkMetrics::new_unregistered(),
     )
 }

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -33,6 +33,7 @@ num_cpus = "1.13.0"
 object_store = { path = "../object_store" }
 observability_deps = { path = "../observability_deps" }
 parking_lot = "0.11.1"
+parquet = "4.0"
 parquet_file = { path = "../parquet_file" }
 query = { path = "../query" }
 rand = "0.8.3"

--- a/server/src/db.rs
+++ b/server/src/db.rs
@@ -656,7 +656,7 @@ impl Db {
                 .rules
                 .read()
                 .lifecycle_rules
-                .catalog_checkpoint_interval
+                .catalog_transactions_until_checkpoint
                 .map_or(false, |interval| {
                     transaction.revision_counter() % interval.get() == 0
                 });
@@ -3030,7 +3030,7 @@ mod tests {
             .object_store(Arc::clone(&object_store))
             .server_id(server_id)
             .db_name(db_name)
-            .catalog_checkpoint_interval(NonZeroU64::try_from(2).unwrap())
+            .catalog_transactions_until_checkpoint(NonZeroU64::try_from(2).unwrap())
             .build()
             .await;
         let db = Arc::new(test_db.db);

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -988,7 +988,7 @@ mod tests {
 
     use arrow_util::assert_batches_eq;
     use data_types::database_rules::{
-        HashRing, PartitionTemplate, ShardConfig, TemplatePart, NO_SHARD_CONFIG,
+        HashRing, LifecycleRules, PartitionTemplate, ShardConfig, TemplatePart, NO_SHARD_CONFIG,
     };
     use influxdb_line_protocol::parse_lines;
     use metrics::MetricRegistry;
@@ -1067,7 +1067,10 @@ mod tests {
             partition_template: PartitionTemplate {
                 parts: vec![TemplatePart::TimeFormat("YYYY-MM".to_string())],
             },
-            lifecycle_rules: Default::default(),
+            lifecycle_rules: LifecycleRules {
+                catalog_transactions_until_checkpoint: Some(13.try_into().unwrap()),
+                ..Default::default()
+            },
             routing_rules: None,
             worker_cleanup_avg_sleep: Duration::from_secs(2),
             write_buffer_connection_string: None,

--- a/server/src/utils.rs
+++ b/server/src/utils.rs
@@ -12,7 +12,7 @@ use crate::{
     write_buffer::WriteBuffer,
     JobRegistry,
 };
-use std::{borrow::Cow, convert::TryFrom, sync::Arc, time::Duration};
+use std::{borrow::Cow, convert::TryFrom, num::NonZeroU64, sync::Arc, time::Duration};
 
 // A wrapper around a Db and a metrics registry allowing for isolated testing
 // of a Db and its metrics.
@@ -35,6 +35,7 @@ pub struct TestDbBuilder {
     db_name: Option<DatabaseName<'static>>,
     worker_cleanup_avg_sleep: Option<Duration>,
     write_buffer: Option<Arc<dyn WriteBuffer>>,
+    catalog_checkpoint_interval: Option<NonZeroU64>,
 }
 
 impl TestDbBuilder {
@@ -72,6 +73,9 @@ impl TestDbBuilder {
             .worker_cleanup_avg_sleep
             .unwrap_or_else(|| Duration::from_secs(1));
 
+        // enable checkpointing
+        rules.lifecycle_rules.catalog_checkpoint_interval = self.catalog_checkpoint_interval;
+
         TestDb {
             metric_registry: metrics::TestMetricRegistry::new(metrics_registry),
             db: Db::new(
@@ -108,6 +112,11 @@ impl TestDbBuilder {
 
     pub fn write_buffer(mut self, write_buffer: Arc<dyn WriteBuffer>) -> Self {
         self.write_buffer = Some(write_buffer);
+        self
+    }
+
+    pub fn catalog_checkpoint_interval(mut self, interval: NonZeroU64) -> Self {
+        self.catalog_checkpoint_interval = Some(interval);
         self
     }
 }

--- a/server/src/utils.rs
+++ b/server/src/utils.rs
@@ -35,7 +35,7 @@ pub struct TestDbBuilder {
     db_name: Option<DatabaseName<'static>>,
     worker_cleanup_avg_sleep: Option<Duration>,
     write_buffer: Option<Arc<dyn WriteBuffer>>,
-    catalog_checkpoint_interval: Option<NonZeroU64>,
+    catalog_transactions_until_checkpoint: Option<NonZeroU64>,
 }
 
 impl TestDbBuilder {
@@ -74,7 +74,8 @@ impl TestDbBuilder {
             .unwrap_or_else(|| Duration::from_secs(1));
 
         // enable checkpointing
-        rules.lifecycle_rules.catalog_checkpoint_interval = self.catalog_checkpoint_interval;
+        rules.lifecycle_rules.catalog_transactions_until_checkpoint =
+            self.catalog_transactions_until_checkpoint;
 
         TestDb {
             metric_registry: metrics::TestMetricRegistry::new(metrics_registry),
@@ -115,8 +116,8 @@ impl TestDbBuilder {
         self
     }
 
-    pub fn catalog_checkpoint_interval(mut self, interval: NonZeroU64) -> Self {
-        self.catalog_checkpoint_interval = Some(interval);
+    pub fn catalog_transactions_until_checkpoint(mut self, interval: NonZeroU64) -> Self {
+        self.catalog_transactions_until_checkpoint = Some(interval);
         self
     }
 }

--- a/server_benchmarks/benches/catalog_persistence.rs
+++ b/server_benchmarks/benches/catalog_persistence.rs
@@ -106,7 +106,7 @@ async fn setup(object_store: Arc<ObjectStore>, done: &Mutex<bool>) {
 async fn create_persisted_db(object_store: Arc<ObjectStore>) -> TestDb {
     TestDb::builder()
         .object_store(object_store)
-        .catalog_checkpoint_interval(NonZeroU64::try_from(CHECKPOINT_INTERVAL).unwrap())
+        .catalog_transactions_until_checkpoint(NonZeroU64::try_from(CHECKPOINT_INTERVAL).unwrap())
         .build()
         .await
 }

--- a/server_benchmarks/benches/catalog_persistence.rs
+++ b/server_benchmarks/benches/catalog_persistence.rs
@@ -45,7 +45,7 @@ fn benchmark_catalog_persistence(c: &mut Criterion) {
                 let table_name = "cpu";
                 let chunk_id = 0;
                 assert!(db
-                    .table_summary(partition_key, table_name, chunk_id)
+                    .table_summary(table_name, partition_key, chunk_id)
                     .is_some());
             },
             BatchSize::SmallInput,
@@ -70,23 +70,23 @@ async fn setup(object_store: Arc<ObjectStore>, done: &Mutex<bool>) {
         let table_names = write_lp(&db, &lp);
 
         for table_name in &table_names {
-            db.rollover_partition(partition_key, &table_name)
+            db.rollover_partition(&table_name, partition_key)
                 .await
                 .unwrap();
 
-            db.load_chunk_to_read_buffer(partition_key, &table_name, chunk_id, &Default::default())
+            db.load_chunk_to_read_buffer(&table_name, partition_key, chunk_id, &Default::default())
                 .await
                 .unwrap();
             db.write_chunk_to_object_store(
-                partition_key,
                 &table_name,
+                partition_key,
                 chunk_id,
                 &Default::default(),
             )
             .await
             .unwrap();
 
-            db.unload_read_buffer(partition_key, &table_name, chunk_id)
+            db.unload_read_buffer(&table_name, partition_key, chunk_id)
                 .await
                 .unwrap();
         }

--- a/src/commands/database.rs
+++ b/src/commands/database.rs
@@ -113,6 +113,12 @@ struct Create {
     /// Do not allow writing new data to this database
     #[structopt(long)]
     immutable: bool,
+
+    /// After how many transactions should IOx write a new checkpoint?
+    ///
+    /// If 0, no checkpoints will be written.
+    #[structopt(long, default_value = "100")]
+    catalog_checkpoint_interval: u64,
 }
 
 /// Get list of databases
@@ -181,6 +187,7 @@ pub async fn command(url: String, config: Config) -> Result<()> {
                     persist: command.persist,
                     immutable: command.immutable,
                     worker_backoff_millis: Default::default(),
+                    catalog_checkpoint_interval: command.catalog_checkpoint_interval,
                 }),
 
                 // Default to hourly partitions

--- a/src/commands/database.rs
+++ b/src/commands/database.rs
@@ -1,5 +1,5 @@
 //! This module implements the `database` CLI command
-use std::{fs::File, io::Read, path::PathBuf, str::FromStr};
+use std::{fs::File, io::Read, num::NonZeroU64, path::PathBuf, str::FromStr};
 
 use influxdb_iox_client::{
     connection::Builder,
@@ -115,10 +115,8 @@ struct Create {
     immutable: bool,
 
     /// After how many transactions should IOx write a new checkpoint?
-    ///
-    /// If 0, no checkpoints will be written.
-    #[structopt(long, default_value = "100")]
-    catalog_checkpoint_interval: u64,
+    #[structopt(long, default_value = "100", parse(try_from_str))]
+    catalog_checkpoint_interval: NonZeroU64,
 }
 
 /// Get list of databases
@@ -187,7 +185,7 @@ pub async fn command(url: String, config: Config) -> Result<()> {
                     persist: command.persist,
                     immutable: command.immutable,
                     worker_backoff_millis: Default::default(),
-                    catalog_checkpoint_interval: command.catalog_checkpoint_interval,
+                    catalog_checkpoint_interval: command.catalog_checkpoint_interval.get(),
                 }),
 
                 // Default to hourly partitions

--- a/src/commands/database.rs
+++ b/src/commands/database.rs
@@ -116,7 +116,7 @@ struct Create {
 
     /// After how many transactions should IOx write a new checkpoint?
     #[structopt(long, default_value = "100", parse(try_from_str))]
-    catalog_checkpoint_interval: NonZeroU64,
+    catalog_transactions_until_checkpoint: NonZeroU64,
 }
 
 /// Get list of databases
@@ -185,7 +185,9 @@ pub async fn command(url: String, config: Config) -> Result<()> {
                     persist: command.persist,
                     immutable: command.immutable,
                     worker_backoff_millis: Default::default(),
-                    catalog_checkpoint_interval: command.catalog_checkpoint_interval.get(),
+                    catalog_transactions_until_checkpoint: command
+                        .catalog_transactions_until_checkpoint
+                        .get(),
                 }),
 
                 // Default to hourly partitions

--- a/tests/end_to_end_cases/management_api.rs
+++ b/tests/end_to_end_cases/management_api.rs
@@ -214,6 +214,7 @@ async fn test_create_get_update_database() {
                 order: Order::Asc as _,
                 sort: Some(lifecycle_rules::sort_order::Sort::CreatedAtTime(Empty {})),
             }),
+            catalog_checkpoint_interval: 13,
             ..Default::default()
         }),
         routing_rules: None,

--- a/tests/end_to_end_cases/management_api.rs
+++ b/tests/end_to_end_cases/management_api.rs
@@ -214,7 +214,7 @@ async fn test_create_get_update_database() {
                 order: Order::Asc as _,
                 sort: Some(lifecycle_rules::sort_order::Sort::CreatedAtTime(Empty {})),
             }),
-            catalog_checkpoint_interval: 13,
+            catalog_transactions_until_checkpoint: 13,
             ..Default::default()
         }),
         routing_rules: None,


### PR DESCRIPTION
Closes #1381.

To quote the last commit message that illustrates the effect using a benchmark:

> test: enable checkpointing in catalog benchmark
> 
> This now creates a checkpoint every 10 transactions. To make it a bit
> more fair increase the chunk count to 109, so we have some transactions
> after the last checkpoint. With that we improve performance from 10.5s
> to 1.2s (or even 0.3s if we would keep the chunk count at 100).