### PR TITLE
refactor: export Read Buffer Chunk as RBChunk

### DIFF
--- a/read_buffer/benches/database.rs
+++ b/read_buffer/benches/database.rs
@@ -7,14 +7,14 @@ use arrow::{
     record_batch::RecordBatch,
 };
 use internal_types::schema::builder::SchemaBuilder;
-use read_buffer::{BinaryExpr, Chunk, ChunkMetrics, Predicate};
+use read_buffer::{BinaryExpr, ChunkMetrics, Predicate, RBChunk};
 
 const BASE_TIME: i64 = 1351700038292387000_i64;
 const ONE_MS: i64 = 1_000_000;
 
 fn table_names(c: &mut Criterion) {
     let rb = generate_row_group(500_000);
-    let mut chunk = Chunk::new(ChunkMetrics::new_unregistered());
+    let mut chunk = RBChunk::new(ChunkMetrics::new_unregistered());
     chunk.upsert_table("table_a", rb);
 
     // no predicate - return all the tables
@@ -61,7 +61,7 @@ fn table_names(c: &mut Criterion) {
 fn benchmark_table_names(
     c: &mut Criterion,
     bench_name: &str,
-    chunk: &Chunk,
+    chunk: &RBChunk,
     predicate: Predicate,
     expected_rows: usize,
 ) {

--- a/read_buffer/benches/read_filter.rs
+++ b/read_buffer/benches/read_filter.rs
@@ -8,7 +8,7 @@ use internal_types::selection::Selection;
 use packers::{sorter, Packers};
 use read_buffer::{
     benchmarks::{Column, ColumnType, RowGroup},
-    Chunk,
+    RBChunk,
 };
 use read_buffer::{BinaryExpr, Predicate};
 
@@ -17,7 +17,7 @@ const ONE_MS: i64 = 1_000_000;
 pub fn read_filter(c: &mut Criterion) {
     let mut rng = rand::thread_rng();
 
-    let mut chunk = Chunk::new(read_buffer::ChunkMetrics::new_unregistered());
+    let mut chunk = RBChunk::new(read_buffer::ChunkMetrics::new_unregistered());
     let row_group = generate_row_group(200_000, &mut rng);
     read_buffer::benchmarks::upsert_table_with_row_group(&mut chunk, "table", row_group);
 
@@ -27,7 +27,7 @@ pub fn read_filter(c: &mut Criterion) {
 
 // These benchmarks track the performance of read_filter without any predicate
 // but varying the size of projection (columns) requested
-fn read_filter_no_pred_vary_proj(c: &mut Criterion, chunk: &Chunk) {
+fn read_filter_no_pred_vary_proj(c: &mut Criterion, chunk: &RBChunk) {
     let mut group = c.benchmark_group("read_filter/no_pred");
 
     // All these projections involve the same number of rows but with varying
@@ -63,7 +63,7 @@ fn read_filter_no_pred_vary_proj(c: &mut Criterion, chunk: &Chunk) {
 }
 
 // These benchmarks track the performance of read_filter with different predicates
-fn read_filter_with_pred_vary_proj(c: &mut Criterion, chunk: &Chunk) {
+fn read_filter_with_pred_vary_proj(c: &mut Criterion, chunk: &RBChunk) {
     let mut group = c.benchmark_group("read_filter/with_pred");
 
     // these predicates vary the number of rows returned

--- a/read_buffer/src/lib.rs
+++ b/read_buffer/src/lib.rs
@@ -9,7 +9,7 @@ mod table;
 mod value;
 
 // Identifiers that are exported as part of the public API.
-pub use chunk::{Chunk, ChunkMetrics, Error};
+pub use chunk::{Chunk as RBChunk, ChunkMetrics, Error};
 pub use row_group::{BinaryExpr, Predicate};
 pub use schema::*;
 pub use table::ReadFilterResults;
@@ -29,11 +29,11 @@ pub mod benchmarks {
         Column, RowIDs,
     };
     pub use crate::row_group::{ColumnType, RowGroup};
-    use crate::Chunk;
+    use crate::RBChunk;
 
     // Allow external benchmarks to use this crate-only test method
     pub fn upsert_table_with_row_group(
-        chunk: &mut Chunk,
+        chunk: &mut RBChunk,
         table_name: impl Into<String>,
         row_group: RowGroup,
     ) {

--- a/server/src/db.rs
+++ b/server/src/db.rs
@@ -41,7 +41,7 @@ use parquet_file::{
 };
 use query::{exec::Executor, predicate::Predicate, Database};
 use rand_distr::{Distribution, Poisson};
-use read_buffer::{Chunk as ReadBufferChunk, ChunkMetrics as ReadBufferChunkMetrics};
+use read_buffer::{ChunkMetrics as ReadBufferChunkMetrics, RBChunk};
 use snafu::{ResultExt, Snafu};
 use std::{
     any::Any,
@@ -527,7 +527,7 @@ impl Db {
         let metrics = self
             .metrics_registry
             .register_domain_with_labels("read_buffer", self.metric_labels.clone());
-        let mut rb_chunk = ReadBufferChunk::new(ReadBufferChunkMetrics::new(
+        let mut rb_chunk = RBChunk::new(ReadBufferChunkMetrics::new(
             &metrics,
             self.preserved_catalog
                 .state()

--- a/server/src/db/chunk.rs
+++ b/server/src/db/chunk.rs
@@ -21,7 +21,7 @@ use query::{
     pruning::Prunable,
     PartitionChunk,
 };
-use read_buffer::Chunk as ReadBufferChunk;
+use read_buffer::RBChunk;
 
 use super::{
     catalog::chunk::ChunkMetadata, pred::to_read_buffer_predicate, streams::ReadFilterResultsStream,
@@ -94,7 +94,7 @@ enum State {
         chunk: Arc<ChunkSnapshot>,
     },
     ReadBuffer {
-        chunk: Arc<ReadBufferChunk>,
+        chunk: Arc<RBChunk>,
         partition_key: Arc<str>,
     },
     ParquetFile {


### PR DESCRIPTION
Helps with #1699

It makes sense for a chunk in the Read Buffer crate to be `Chunk` (as it does in parquet of MUB) but outside of the crates, where they intermingle, it's helpful if the exported symbol is something distinguishable. This PR exports a Read Buffer chunk as `RBChunk`.