### PR TITLE
test: select non-key from 2 chunks with different key/tag sets

### DIFF
--- a/query/src/provider.rs
+++ b/query/src/provider.rs
@@ -240,6 +240,10 @@ impl<C: PartitionChunk + 'static> TableProvider for ChunkTableProvider<C> {
         // Figure out the schema of the requested output
         let scan_schema = project_schema(self.arrow_schema(), projection);
 
+        // This debug shows the self.arrow_schema() includes all columns in all chunks
+        // which means the schema of all chunks are merged before invoking this scan
+        debug!("all chunks schema: {:#?}", self.arrow_schema());
+
         let mut deduplicate = Deduplicater::new();
         let plan = deduplicate.build_scan_plan(
             Arc::clone(&self.table_name),

--- a/query_tests/src/sql.rs
+++ b/query_tests/src/sql.rs
@@ -1265,3 +1265,16 @@ async fn sql_deduplicate_4() {
     ];
     run_sql_explain_test_case!(OneMeasurementThreeChunksWithDuplicates {}, sql, &expected);
 }
+
+#[tokio::test]
+async fn sql_select_non_keys() {
+    let expected = vec![
+        "+------+", "| temp |", "+------+", "|      |", "|      |", "| 53.4 |", "| 70.4 |",
+        "+------+",
+    ];
+    run_sql_test_case!(
+        OneMeasurementTwoChunksDifferentTagSet {},
+        "SELECT temp from h2o",
+        &expected
+    );
+}


### PR DESCRIPTION
Closes #

This is a test to verify the work needed for #1682 and #1683. All the column info from all chunks is already merged into [self.arrow_schema()](https://github.com/influxdata/influxdb_iox/blob/1c7b13f0a5b2d583cc613800313af219ce05f357/query/src/provider.rs#L241) so I think the work needed for #1683 is, likely, inside this function [project_schema](https://github.com/influxdata/influxdb_iox/blob/1c7b13f0a5b2d583cc613800313af219ce05f357/query/src/util.rs#L33) ,  we also add key columns in the return list.

The work for #1682 is very minimal reusing the result above


- [ ] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb_iox/blob/main/README.md).
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
