### PR TITLE
test: Add a test that hitting the soft limit does not drop all chunks

### DIFF
--- a/data_types/src/chunk_metadata.rs
+++ b/data_types/src/chunk_metadata.rs
@@ -5,7 +5,7 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
 /// Which storage system is a chunk located in?
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Serialize, Deserialize, Hash)]
 pub enum ChunkStorage {
     /// The chunk is still open for new writes, in the Mutable Buffer
     OpenMutableBuffer,

--- a/server/src/db/lifecycle.rs
+++ b/server/src/db/lifecycle.rs
@@ -202,7 +202,7 @@ trait ChunkMover {
         // Loop 2: Determine which chunks to clear from memory when
         // the overall database buffer size is exceeded
         if let Some(soft_limit) = rules.buffer_size_soft {
-            let mut chunks = chunks.iter();
+            let mut chunks = chunks.into_iter();
 
             loop {
                 let buffer_size = self.buffer_size();
@@ -210,7 +210,6 @@ trait ChunkMover {
                     debug!(buffer_size, %soft_limit, "memory use under soft limit");
                     break;
                 }
-                debug!(buffer_size, %soft_limit, "memory use over soft limit");
 
                 // Dropping chunks that are currently in use by
                 // queries frees no memory until the query completes
@@ -242,6 +241,11 @@ trait ChunkMover {
                                     Action::Unload
                                 } else {
                                     // can't free any memory
+                                    debug!(table_name=%chunk_guard.table_name(),
+                                           partition_key=%chunk_guard.key(),
+                                           chunk_id=%chunk_guard.id(),
+                                           buffer_size, %soft_limit,
+                                           "memory use over soft limit, but chunk is already unloaded");
                                     continue;
                                 }
                             }

--- a/tests/end_to_end_cases/persistence.rs
+++ b/tests/end_to_end_cases/persistence.rs
@@ -123,7 +123,7 @@ async fn test_chunks_are_removed_only_until_soft_limit() {
         assert_eq!(num_lines_written, 1000);
     }
 
-    // Ensure ensure that 10 chunks have been persisted
+    // Ensure that 10 chunks have been persisted
     let expected: HashMap<ChunkStorage, usize> = vec![(ChunkStorage::ReadBufferAndObjectStore, 10)]
         .into_iter()
         .collect();
@@ -134,7 +134,7 @@ async fn test_chunks_are_removed_only_until_soft_limit() {
     rules.lifecycle_rules = Some(lifecycle_rules);
     management_client.update_database(rules).await.unwrap();
 
-    // Ensure ensure that only the chunks needed to hit the soft limit
+    // Ensure that only the chunks needed to hit the soft limit
     // were unloaded -- there should still be some in the read buffer.
     let expected: HashMap<ChunkStorage, usize> = vec![
         (ChunkStorage::ObjectStoreOnly, 4),
@@ -151,7 +151,6 @@ async fn wait_for_counts(
     db_name: &str,
     expected_counts: HashMap<ChunkStorage, usize>,
 ) {
-    // make sure that at least one is in object store
     wait_for_chunks(
         &fixture,
         &db_name,


### PR DESCRIPTION
Re https://github.com/influxdata/influxdb_iox/issues/1698 (which I thought was a bug by inspection, but seems to be fine after some testing). 

The theory was when the soft buffer limit is hit, the life cycle manager was dropping too many chunks. However, I could not replicate this behavior but the test I prepared I thought was valuable from a "document the end to end behavior" perspective