### PR TITLE
refactor: rename mutable_buffer::Chunk --> mutable_buffer::MBChunk

### DIFF
--- a/mutable_buffer/src/chunk/snapshot.rs
+++ b/mutable_buffer/src/chunk/snapshot.rs
@@ -17,7 +17,7 @@ use data_types::{
 use internal_types::schema::{Schema, TIME_COLUMN_NAME};
 use internal_types::selection::Selection;
 
-use super::Chunk;
+use super::MBChunk;
 
 #[derive(Debug, Snafu)]
 pub enum Error {
@@ -43,7 +43,7 @@ pub struct ChunkSnapshot {
 }
 
 impl ChunkSnapshot {
-    pub(crate) fn new(chunk: &Chunk, memory: metrics::GaugeValue) -> Self {
+    pub(crate) fn new(chunk: &MBChunk, memory: metrics::GaugeValue) -> Self {
         let schema = chunk
             .schema(Selection::All)
             .log_if_error("ChunkSnapshot getting table schema")

--- a/server/src/db.rs
+++ b/server/src/db.rs
@@ -25,7 +25,7 @@ use internal_types::{arrow::sort::sort_record_batch, selection::Selection};
 use lifecycle::LifecycleManager;
 use metrics::{KeyValue, MetricRegistry};
 use mutable_buffer::chunk::{
-    Chunk as MutableBufferChunk, ChunkMetrics as MutableBufferChunkMetrics,
+    ChunkMetrics as MutableBufferChunkMetrics, MBChunk,
 };
 use object_store::{path::parsed::DirsAndFileName, ObjectStore};
 use observability_deps::tracing::{debug, error, info};
@@ -1002,7 +1002,7 @@ impl Db {
                                 "mutable_buffer",
                                 self.metric_labels.clone(),
                             );
-                            let mut mb_chunk = MutableBufferChunk::new(
+                            let mut mb_chunk = MBChunk::new(
                                 table_batch.name(),
                                 MutableBufferChunkMetrics::new(
                                     &metrics,

--- a/server/src/db.rs
+++ b/server/src/db.rs
@@ -24,9 +24,7 @@ use entry::{Entry, SequencedEntry};
 use internal_types::{arrow::sort::sort_record_batch, selection::Selection};
 use lifecycle::LifecycleManager;
 use metrics::{KeyValue, MetricRegistry};
-use mutable_buffer::chunk::{
-    ChunkMetrics as MutableBufferChunkMetrics, MBChunk,
-};
+use mutable_buffer::chunk::{ChunkMetrics as MutableBufferChunkMetrics, MBChunk};
 use object_store::{path::parsed::DirsAndFileName, ObjectStore};
 use observability_deps::tracing::{debug, error, info};
 use parking_lot::RwLock;

--- a/server/src/db/catalog.rs
+++ b/server/src/db/catalog.rs
@@ -335,7 +335,7 @@ mod tests {
         let write = entry.partition_writes().unwrap().remove(0);
         let batch = write.table_batches().remove(0);
 
-        let mut mb_chunk = mutable_buffer::chunk::Chunk::new(
+        let mut mb_chunk = mutable_buffer::chunk::MBChunk::new(
             batch.name(),
             mutable_buffer::chunk::ChunkMetrics::new_unregistered(),
         );

--- a/server/src/db/catalog/chunk.rs
+++ b/server/src/db/catalog/chunk.rs
@@ -9,7 +9,7 @@ use data_types::{
 };
 use internal_types::schema::Schema;
 use metrics::{Counter, Histogram, KeyValue};
-use mutable_buffer::chunk::{snapshot::ChunkSnapshot as MBChunkSnapshot, Chunk as MBChunk};
+use mutable_buffer::chunk::{snapshot::ChunkSnapshot as MBChunkSnapshot, MBChunk};
 use parquet_file::chunk::Chunk as ParquetChunk;
 use read_buffer::RBChunk;
 use tracker::{TaskRegistration, TaskTracker};
@@ -291,7 +291,7 @@ impl CatalogChunk {
     pub(crate) fn new_open(
         chunk_id: u32,
         partition_key: impl AsRef<str>,
-        chunk: mutable_buffer::chunk::Chunk,
+        chunk: mutable_buffer::chunk::MBChunk,
         metrics: ChunkMetrics,
     ) -> Self {
         assert!(chunk.rows() > 0, "chunk must not be empty");
@@ -837,7 +837,7 @@ impl CatalogChunk {
 #[cfg(test)]
 mod tests {
     use entry::test_helpers::lp_to_entry;
-    use mutable_buffer::chunk::{Chunk as MBChunk, ChunkMetrics as MBChunkMetrics};
+    use mutable_buffer::chunk::{ChunkMetrics as MBChunkMetrics, MBChunk};
     use parquet_file::{
         chunk::Chunk as ParquetChunk,
         test_utils::{make_chunk as make_parquet_chunk_with_store, make_object_store},

--- a/server/src/db/catalog/partition.rs
+++ b/server/src/db/catalog/partition.rs
@@ -99,7 +99,7 @@ impl Partition {
     /// Returns an error if the chunk is empty.
     pub fn create_open_chunk(
         &mut self,
-        chunk: mutable_buffer::chunk::Chunk,
+        chunk: mutable_buffer::chunk::MBChunk,
     ) -> Arc<RwLock<CatalogChunk>> {
         assert_eq!(chunk.table_name().as_ref(), self.table_name.as_ref());
 

--- a/server/src/db/lifecycle.rs
+++ b/server/src/db/lifecycle.rs
@@ -451,7 +451,7 @@ mod tests {
         let entry = lp_to_entry("table1 bar=10 10");
         let write = entry.partition_writes().unwrap().remove(0);
         let batch = write.table_batches().remove(0);
-        let mut mb_chunk = mutable_buffer::chunk::Chunk::new(
+        let mut mb_chunk = mutable_buffer::chunk::MBChunk::new(
             "table1",
             mutable_buffer::chunk::ChunkMetrics::new_unregistered(),
         );

--- a/server_benchmarks/benches/snapshot.rs
+++ b/server_benchmarks/benches/snapshot.rs
@@ -1,17 +1,17 @@
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 use entry::test_helpers::lp_to_entries;
 use flate2::read::GzDecoder;
-use mutable_buffer::chunk::{Chunk, ChunkMetrics};
+use mutable_buffer::chunk::{ChunkMetrics, MBChunk};
 use std::io::Read;
 
 #[inline]
-fn snapshot_chunk(chunk: &Chunk) {
+fn snapshot_chunk(chunk: &MBChunk) {
     let _ = chunk.snapshot();
 }
 
-fn chunk(count: usize) -> Chunk {
+fn chunk(count: usize) -> MBChunk {
     // m0 is hard coded into tag_values.lp.gz
-    let mut chunk = Chunk::new("m0", ChunkMetrics::new_unregistered());
+    let mut chunk = MBChunk::new("m0", ChunkMetrics::new_unregistered());
 
     let raw = include_bytes!("../../tests/fixtures/lineproto/tag_values.lp.gz");
     let mut gz = GzDecoder::new(&raw[..]);

--- a/server_benchmarks/benches/write.rs
+++ b/server_benchmarks/benches/write.rs
@@ -1,13 +1,13 @@
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 use entry::{test_helpers::lp_to_entries, Entry};
 use flate2::read::GzDecoder;
-use mutable_buffer::chunk::{Chunk, ChunkMetrics};
+use mutable_buffer::chunk::{ChunkMetrics, MBChunk};
 use std::io::Read;
 
 #[inline]
 fn write_chunk(count: usize, entries: &[Entry]) {
     // m0 is hard coded into tag_values.lp.gz
-    let mut chunk = Chunk::new("m0", ChunkMetrics::new_unregistered());
+    let mut chunk = MBChunk::new("m0", ChunkMetrics::new_unregistered());
 
     for _ in 0..count {
         for entry in entries {


### PR DESCRIPTION
re https://github.com/influxdata/influxdb_iox/issues/1699

# Rationale
1. We have too many things named Chunk which is confusing for people new to the code base as well as when doing code reviews.

While this change results in more typing, we feel making the code easier to read rather than write is a better metric to optimize. 

Code is read many more times than written).
