### PR TITLE
refactor: Rename parquet_file::Chunk --> ParquetChunk

### DIFF
--- a/parquet_file/src/chunk.rs
+++ b/parquet_file/src/chunk.rs
@@ -83,7 +83,7 @@ impl ChunkMetrics {
 }
 
 #[derive(Debug)]
-pub struct Chunk {
+pub struct ParquetChunk {
     /// Partition this chunk belongs to
     partition_key: String,
 
@@ -111,7 +111,7 @@ pub struct Chunk {
     metrics: ChunkMetrics,
 }
 
-impl Chunk {
+impl ParquetChunk {
     /// Creates new chunk from given parquet metadata.
     pub fn new(
         file_location: Path,

--- a/parquet_file/src/test_utils.rs
+++ b/parquet_file/src/test_utils.rs
@@ -32,7 +32,7 @@ use crate::{
     metadata::{IoxMetadata, IoxParquetMetaData},
 };
 use crate::{
-    chunk::{self, Chunk},
+    chunk::{self, ParquetChunk},
     storage::Storage,
 };
 use snafu::{ResultExt, Snafu};
@@ -53,14 +53,14 @@ pub type Result<T, E = Error> = std::result::Result<T, E>;
 /// Load parquet from store and return table name and parquet bytes.
 // This function is for test only
 pub async fn load_parquet_from_store(
-    chunk: &Chunk,
+    chunk: &ParquetChunk,
     store: Arc<ObjectStore>,
 ) -> Result<(String, Vec<u8>)> {
     load_parquet_from_store_for_chunk(chunk, store).await
 }
 
 pub async fn load_parquet_from_store_for_chunk(
-    chunk: &Chunk,
+    chunk: &ParquetChunk,
     store: Arc<ObjectStore>,
 ) -> Result<(String, Vec<u8>)> {
     let path = chunk.path();
@@ -88,7 +88,11 @@ pub async fn load_parquet_from_store_for_path(
 }
 
 /// Same as [`make_chunk`] but parquet file does not contain any row group.
-pub async fn make_chunk(store: Arc<ObjectStore>, column_prefix: &str, chunk_id: u32) -> Chunk {
+pub async fn make_chunk(
+    store: Arc<ObjectStore>,
+    column_prefix: &str,
+    chunk_id: u32,
+) -> ParquetChunk {
     let (record_batches, schema, column_summaries, _num_rows) = make_record_batch(column_prefix);
     make_chunk_given_record_batch(
         store,
@@ -106,7 +110,7 @@ pub async fn make_chunk_no_row_group(
     store: Arc<ObjectStore>,
     column_prefix: &str,
     chunk_id: u32,
-) -> Chunk {
+) -> ParquetChunk {
     let (_, schema, column_summaries, _num_rows) = make_record_batch(column_prefix);
     make_chunk_given_record_batch(store, vec![], schema, "table1", column_summaries, chunk_id).await
 }
@@ -121,7 +125,7 @@ pub async fn make_chunk_given_record_batch(
     table: &str,
     column_summaries: Vec<ColumnSummary>,
     chunk_id: u32,
-) -> Chunk {
+) -> ParquetChunk {
     let server_id = ServerId::new(NonZeroU32::new(1).unwrap());
     let db_name = "db1";
     let partition_key = "part1";
@@ -157,7 +161,7 @@ pub async fn make_chunk_given_record_batch(
         .await
         .unwrap();
 
-    Chunk::new_from_parts(
+    ParquetChunk::new_from_parts(
         partition_key,
         Arc::new(table_summary),
         Arc::new(schema),

--- a/server/src/db.rs
+++ b/server/src/db.rs
@@ -31,7 +31,7 @@ use parking_lot::RwLock;
 use parquet_file::metadata::IoxParquetMetaData;
 use parquet_file::{
     catalog::{CatalogParquetInfo, CatalogState, ChunkCreationFailed, PreservedCatalog},
-    chunk::{Chunk as ParquetChunk, ChunkMetrics as ParquetChunkMetrics},
+    chunk::{ChunkMetrics as ParquetChunkMetrics, ParquetChunk},
     cleanup::cleanup_unreferenced_parquet_files,
     metadata::IoxMetadata,
     storage::Storage,

--- a/server/src/db/catalog/chunk.rs
+++ b/server/src/db/catalog/chunk.rs
@@ -10,7 +10,7 @@ use data_types::{
 use internal_types::schema::Schema;
 use metrics::{Counter, Histogram, KeyValue};
 use mutable_buffer::chunk::{snapshot::ChunkSnapshot as MBChunkSnapshot, MBChunk};
-use parquet_file::chunk::Chunk as ParquetChunk;
+use parquet_file::chunk::ParquetChunk;
 use read_buffer::RBChunk;
 use tracker::{TaskRegistration, TaskTracker};
 
@@ -324,7 +324,7 @@ impl CatalogChunk {
     pub(crate) fn new_object_store_only(
         chunk_id: u32,
         partition_key: impl AsRef<str>,
-        chunk: Arc<parquet_file::chunk::Chunk>,
+        chunk: Arc<parquet_file::chunk::ParquetChunk>,
         metrics: ChunkMetrics,
     ) -> Self {
         let table_name = Arc::from(chunk.table_name());
@@ -839,7 +839,7 @@ mod tests {
     use entry::test_helpers::lp_to_entry;
     use mutable_buffer::chunk::{ChunkMetrics as MBChunkMetrics, MBChunk};
     use parquet_file::{
-        chunk::Chunk as ParquetChunk,
+        chunk::ParquetChunk,
         test_utils::{make_chunk as make_parquet_chunk_with_store, make_object_store},
     };
 

--- a/server/src/db/catalog/partition.rs
+++ b/server/src/db/catalog/partition.rs
@@ -134,7 +134,7 @@ impl Partition {
     pub fn insert_object_store_only_chunk(
         &mut self,
         chunk_id: u32,
-        chunk: Arc<parquet_file::chunk::Chunk>,
+        chunk: Arc<parquet_file::chunk::ParquetChunk>,
     ) -> Arc<RwLock<CatalogChunk>> {
         assert_eq!(chunk.table_name(), self.table_name.as_ref());
 

--- a/server/src/db/chunk.rs
+++ b/server/src/db/chunk.rs
@@ -14,7 +14,7 @@ use internal_types::{schema::Schema, selection::Selection};
 use mutable_buffer::chunk::snapshot::ChunkSnapshot;
 use object_store::path::Path;
 use observability_deps::tracing::debug;
-use parquet_file::chunk::Chunk as ParquetChunk;
+use parquet_file::chunk::ParquetChunk;
 use query::{
     exec::stringset::StringSet,
     predicate::{Predicate, PredicateMatch},

--- a/server/src/db/lifecycle.rs
+++ b/server/src/db/lifecycle.rs
@@ -506,7 +506,7 @@ mod tests {
         chunk
     }
 
-    async fn new_parquet_chunk(chunk: &CatalogChunk) -> parquet_file::chunk::Chunk {
+    async fn new_parquet_chunk(chunk: &CatalogChunk) -> parquet_file::chunk::ParquetChunk {
         let in_memory = InMemory::new();
         let object_store = Arc::new(ObjectStore::new_in_memory(in_memory));
 


### PR DESCRIPTION
re https://github.com/influxdata/influxdb_iox/issues/1699, follow on PR to https://github.com/influxdata/influxdb_iox/pull/1702 (rename MB chunk)

# Rationale
1. We have too many things named Chunk which is confusing for people new to the code base as well as when doing code reviews.

While more typing (if your editor doesn't autocomplete for you) making the code easier to read (rather than write) is a better metric to optimize (as the code is read many more times than written).

@pauldix  notes calling it `XChunk` may be still be misleading as it might not be correct to call this a "Chunk" at all...
