### PR TITLE
fix: bump catalog version

### DIFF
--- a/parquet_file/src/catalog.rs
+++ b/parquet_file/src/catalog.rs
@@ -31,7 +31,7 @@ use uuid::Uuid;
 /// Current version for serialized transactions.
 ///
 /// For breaking changes, this will change.
-pub const TRANSACTION_VERSION: u32 = 3;
+pub const TRANSACTION_VERSION: u32 = 4;
 
 /// File suffix for transaction files in object store.
 pub const TRANSACTION_FILE_SUFFIX: &str = "txn";

--- a/parquet_file/src/metadata.rs
+++ b/parquet_file/src/metadata.rs
@@ -210,6 +210,9 @@ pub type Result<T, E = Error> = std::result::Result<T, E>;
 ///
 /// This will serialized as [JSON] into the file-level key-value Parquet metadata (under [`METADATA_KEY`]).
 ///
+/// **Important: When changing this structure, consider bumping the
+///   [catalog transaction version](crate::catalog::TRANSACTION_VERSION)!**
+///
 /// [JSON]: https://www.json.org/
 #[allow(missing_copy_implementations)] // we want to extend this type in the future
 #[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq)]


### PR DESCRIPTION
This should have been done in #1714. Also add a note so that future devs
might hopefully not forget. In any case though the code also works w/o
this bump, it's just that the error message is a bit less nice ("cannot
parse IOxMetadata" instead of "unsupported catalog version").
