### PR TITLE
feat: info-log server ID during init

### DIFF
--- a/server/src/init.rs
+++ b/server/src/init.rs
@@ -71,9 +71,17 @@ pub struct CurrentServerId(OnceNonZeroU32);
 
 impl CurrentServerId {
     pub fn set(&self, id: ServerId) -> Result<()> {
-        self.0.set(id.get()).map_err(|id| Error::IdAlreadySet {
-            id: ServerId::new(id),
-        })
+        let id = id.get();
+
+        match self.0.set(id) {
+            Ok(()) => {
+                info!(server_id = id, "server ID set");
+                Ok(())
+            }
+            Err(id) => Err(Error::IdAlreadySet {
+                id: ServerId::new(id),
+            }),
+        }
     }
 
     pub fn get(&self) -> Result<ServerId> {


### PR DESCRIPTION
Add a info log when the server ID is set. Because this is done where the
server ID is also stored, this automatically affects all ways to set it
(via CLI, via environment variable, via gRPC call).

Closes #1595.
