### PR TITLE
refactor: traitify lifecycle policy

### DIFF
--- a/server/src/db/lifecycle.rs
+++ b/server/src/db/lifecycle.rs
@@ -1,101 +1,178 @@
 use std::convert::TryInto;
 use std::sync::Arc;
+use std::time::{Duration, Instant};
 
 use chrono::{DateTime, Utc};
-use observability_deps::tracing::{debug, info, warn};
-
-use data_types::{database_rules::LifecycleRules, error::ErrorLogger, job::Job};
-
-use super::{
-    catalog::chunk::{CatalogChunk, ChunkStage, ChunkStageFrozenRepr},
-    Db,
-};
-use data_types::database_rules::SortOrder;
 use futures::future::BoxFuture;
-use std::collections::HashSet;
-use std::time::{Duration, Instant};
+use hashbrown::HashSet;
+
+use data_types::chunk_metadata::ChunkStorage;
+use data_types::database_rules::{LifecycleRules, SortOrder};
+use data_types::error::ErrorLogger;
+use observability_deps::tracing::info;
+use observability_deps::tracing::{debug, warn};
 use tracker::{RwLock, TaskTracker};
 
-pub const DEFAULT_LIFECYCLE_BACKOFF: Duration = Duration::from_secs(1);
-/// Number of seconds to wait before retying a failed lifecycle action
-pub const LIFECYCLE_ACTION_BACKOFF: Duration = Duration::from_secs(10);
+use crate::db::catalog::chunk::CatalogChunk;
+use crate::Db;
 
-/// Handles the lifecycle of chunks within a Db
-pub struct LifecycleManager {
-    db: Arc<Db>,
-    db_name: String,
-    move_task: Option<TaskTracker<Job>>,
-    write_task: Option<TaskTracker<Job>>,
+/// Temporary newtype wrapper for Arc<Db>
+///
+/// TODO: Remove the need for Db::*_in_background to take Arc<Db>
+pub struct ArcDb(pub Arc<Db>);
+
+impl LifecycleDb for ArcDb {
+    type Chunk = CatalogChunk;
+
+    fn buffer_size(&self) -> usize {
+        self.0.preserved_catalog.state().metrics().memory().total()
+    }
+
+    fn rules(&self) -> LifecycleRules {
+        self.0.rules.read().lifecycle_rules.clone()
+    }
+
+    fn chunks(&self, sort_order: &SortOrder) -> Vec<Arc<RwLock<CatalogChunk>>> {
+        self.0
+            .preserved_catalog
+            .state()
+            .chunks_sorted_by(sort_order)
+    }
+
+    fn move_to_read_buffer(
+        &self,
+        table_name: String,
+        partition_key: String,
+        chunk_id: u32,
+    ) -> TaskTracker<()> {
+        info!(%partition_key, %chunk_id, "moving chunk to read buffer");
+        self.0
+            .load_chunk_to_read_buffer_in_background(table_name, partition_key, chunk_id)
+            .with_metadata(())
+    }
+
+    fn write_to_object_store(
+        &self,
+        table_name: String,
+        partition_key: String,
+        chunk_id: u32,
+    ) -> TaskTracker<()> {
+        info!(%partition_key, %chunk_id, "write chunk to object store");
+        self.0
+            .write_chunk_to_object_store_in_background(table_name, partition_key, chunk_id)
+            .with_metadata(())
+    }
+
+    fn drop_chunk(&self, table_name: String, partition_key: String, chunk_id: u32) {
+        info!(%partition_key, %chunk_id, "dropping chunk");
+        let _ = self
+            .0
+            .drop_chunk(&table_name, &partition_key, chunk_id)
+            .log_if_error("dropping chunk to free up memory");
+    }
+
+    fn unload_read_buffer(&self, table_name: String, partition_key: String, chunk_id: u32) {
+        info!(%partition_key, %chunk_id, "unloading from readbuffer");
+        let _ = self
+            .0
+            .unload_read_buffer(&table_name, &partition_key, chunk_id)
+            .log_if_error("unloading from read buffer to free up memory");
+    }
 }
 
-impl LifecycleManager {
-    pub fn new(db: Arc<Db>) -> Self {
-        let db_name = db.rules.read().name.clone().into();
+impl LifecycleChunk for CatalogChunk {
+    fn lifecycle_action(&self) -> Option<&TaskTracker<ChunkLifecycleAction>> {
+        self.lifecycle_action()
+    }
 
-        Self {
-            db,
-            db_name,
-            move_task: None,
-            write_task: None,
+    fn clear_lifecycle_action(&mut self) {
+        self.clear_lifecycle_action()
+            .expect("failed to clear lifecycle action")
+    }
+
+    fn time_of_first_write(&self) -> Option<DateTime<Utc>> {
+        self.time_of_first_write()
+    }
+
+    fn time_of_last_write(&self) -> Option<DateTime<Utc>> {
+        self.time_of_last_write()
+    }
+
+    fn table_name(&self) -> String {
+        self.table_name().to_string()
+    }
+
+    fn partition_key(&self) -> String {
+        self.key().to_string()
+    }
+
+    fn chunk_id(&self) -> u32 {
+        self.id()
+    }
+
+    fn storage(&self) -> ChunkStorage {
+        self.storage().1
+    }
+}
+
+// TODO: Split below this point into separate crate
+
+/// Any lifecycle action currently in progress for this chunk
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub enum ChunkLifecycleAction {
+    /// Chunk is in the process of being moved to the read buffer
+    Moving,
+
+    /// Chunk is in the process of being written to object storage
+    Persisting,
+
+    /// Chunk is in the process of being compacted
+    Compacting,
+}
+
+impl ChunkLifecycleAction {
+    pub fn name(&self) -> &'static str {
+        match self {
+            Self::Moving => "Moving to the Read Buffer",
+            Self::Persisting => "Persisting to Object Storage",
+            Self::Compacting => "Compacting",
         }
     }
-
-    /// Polls the lifecycle manager to find and spawn work that needs
-    /// to be done as determined by the database's lifecycle policy
-    ///
-    /// Should be called periodically and should spawn any long-running
-    /// work onto the tokio threadpool and return
-    ///
-    /// Returns a future that resolves when this method should be called next
-    pub fn check_for_work(&mut self) -> BoxFuture<'static, ()> {
-        ChunkMover::check_for_work(self, Utc::now(), Instant::now())
-    }
 }
 
-/// A trait that encapsulates the core chunk lifecycle logic
-///
-/// This is to enable independent testing of the policy logic
-trait ChunkMover {
-    type Job: Send + Sync + 'static;
+/// A trait that encapsulates the database logic that is automated by `LifecyclePolicy`
+pub trait LifecycleDb {
+    type Chunk: LifecycleChunk;
 
     /// Return the in-memory size of the database. We expect this
     /// to change from call to call as chunks are dropped
     fn buffer_size(&self) -> usize;
-
-    /// Return the name of the database
-    fn db_name(&self) -> &str;
 
     /// Returns the lifecycle policy
     fn rules(&self) -> LifecycleRules;
 
     /// Returns a list of chunks sorted in the order
     /// they should prioritised
-    fn chunks(&self, order: &SortOrder) -> Vec<Arc<RwLock<CatalogChunk>>>;
-
-    /// Returns a tracker for the running move task if any
-    fn move_tracker(&self) -> Option<&TaskTracker<Self::Job>>;
-
-    /// Returns a tracker for the running write task if any
-    fn write_tracker(&self) -> Option<&TaskTracker<Self::Job>>;
+    fn chunks(&self, order: &SortOrder) -> Vec<Arc<RwLock<Self::Chunk>>>;
 
     /// Starts an operation to move a chunk to the read buffer
     fn move_to_read_buffer(
-        &mut self,
+        &self,
         table_name: String,
         partition_key: String,
         chunk_id: u32,
-    ) -> TaskTracker<Self::Job>;
+    ) -> TaskTracker<()>;
 
     /// Starts an operation to write a chunk to the object store
     fn write_to_object_store(
-        &mut self,
+        &self,
         table_name: String,
         partition_key: String,
         chunk_id: u32,
-    ) -> TaskTracker<Self::Job>;
+    ) -> TaskTracker<()>;
 
     /// Drops a chunk from the database
-    fn drop_chunk(&mut self, table_name: String, partition_key: String, chunk_id: u32);
+    fn drop_chunk(&self, table_name: String, partition_key: String, chunk_id: u32);
 
     /// Remove the copy of the Chunk's data from the read buffer.
     ///
@@ -103,21 +180,60 @@ trait ChunkMover {
     /// (otherwise the read buffer may contain the *only* copy of this
     /// chunk's data). In order to drop un-persisted chunks,
     /// [`drop_chunk`](Self::drop_chunk) must be used.
-    fn unload_read_buffer(&mut self, table_name: String, partition_key: String, chunk_id: u32);
+    fn unload_read_buffer(&self, table_name: String, partition_key: String, chunk_id: u32);
+}
+
+pub trait LifecycleChunk {
+    fn lifecycle_action(&self) -> Option<&TaskTracker<ChunkLifecycleAction>>;
+
+    fn clear_lifecycle_action(&mut self);
+
+    fn time_of_first_write(&self) -> Option<DateTime<Utc>>;
+
+    fn time_of_last_write(&self) -> Option<DateTime<Utc>>;
+
+    fn table_name(&self) -> String;
+
+    fn partition_key(&self) -> String;
+
+    fn chunk_id(&self) -> u32;
+
+    fn storage(&self) -> ChunkStorage;
+}
+
+pub const DEFAULT_LIFECYCLE_BACKOFF: Duration = Duration::from_secs(1);
+/// Number of seconds to wait before retying a failed lifecycle action
+pub const LIFECYCLE_ACTION_BACKOFF: Duration = Duration::from_secs(10);
+
+pub struct LifecyclePolicy<M: LifecycleDb> {
+    db: Arc<M>,
+    // TODO: Remove these and use values from chunks within partition
+    move_tracker: Option<TaskTracker<()>>,
+    write_tracker: Option<TaskTracker<()>>,
+}
+
+impl<M: LifecycleDb + Sync + Send> LifecyclePolicy<M> {
+    pub fn new(db: Arc<M>) -> Self {
+        Self {
+            db,
+            move_tracker: None,
+            write_tracker: None,
+        }
+    }
 
     /// The core policy logic
     ///
     /// Returns a future that resolves when this method should be called next
-    fn check_for_work(
+    pub fn check_for_work(
         &mut self,
         now: DateTime<Utc>,
         now_instant: Instant,
     ) -> BoxFuture<'static, ()> {
-        let rules = self.rules();
+        let rules = self.db.rules();
 
         // NB the rules for "which to drop/unload first" are defined
         // by rules.sort_order
-        let chunks = self.chunks(&rules.sort_order);
+        let chunks = self.db.chunks(&rules.sort_order);
 
         let mut open_partitions: HashSet<String> = HashSet::new();
 
@@ -131,8 +247,8 @@ trait ChunkMover {
         // workload - i.e. only use one thread for each type of background task.
         //
         // We may want to revisit this in future
-        let mut move_tracker = self.move_tracker().filter(|x| !x.is_complete()).cloned();
-        let mut write_tracker = self.write_tracker().filter(|x| !x.is_complete()).cloned();
+        self.move_tracker = self.move_tracker.take().filter(|x| !x.is_complete());
+        self.write_tracker = self.write_tracker.take().filter(|x| !x.is_complete());
 
         // Loop 1: Determine which chunks need to be driven though the
         // persistence lifecycle to ulitimately be persisted to object storage
@@ -140,7 +256,7 @@ trait ChunkMover {
             let chunk_guard = chunk.read();
 
             let would_move = can_move(&rules, &*chunk_guard, now);
-            let would_write = write_tracker.is_none() && rules.persist;
+            let would_write = self.write_tracker.is_none() && rules.persist;
 
             if let Some(lifecycle_action) = chunk_guard.lifecycle_action() {
                 if lifecycle_action.is_complete()
@@ -148,52 +264,55 @@ trait ChunkMover {
                         >= LIFECYCLE_ACTION_BACKOFF
                 {
                     std::mem::drop(chunk_guard);
-                    chunk
-                        .write()
-                        .clear_lifecycle_action()
-                        .expect("failed to clear lifecycle action");
+                    chunk.write().clear_lifecycle_action();
                 }
                 continue;
             }
 
-            match chunk_guard.stage() {
-                ChunkStage::Open { .. } => {
-                    open_partitions.insert(chunk_guard.key().to_string());
-                    if move_tracker.is_none() && would_move {
-                        let partition_key = chunk_guard.key().to_string();
-                        let table_name = chunk_guard.table_name().to_string();
-                        let chunk_id = chunk_guard.id();
+            match chunk_guard.storage() {
+                ChunkStorage::OpenMutableBuffer => {
+                    open_partitions.insert(chunk_guard.partition_key().to_string());
+                    if self.move_tracker.is_none() && would_move {
+                        let partition_key = chunk_guard.partition_key();
+                        let table_name = chunk_guard.table_name();
+                        let chunk_id = chunk_guard.chunk_id();
 
                         std::mem::drop(chunk_guard);
 
-                        move_tracker =
-                            Some(self.move_to_read_buffer(table_name, partition_key, chunk_id));
+                        self.move_tracker = Some(self.db.move_to_read_buffer(
+                            table_name,
+                            partition_key,
+                            chunk_id,
+                        ));
                     }
                 }
-                ChunkStage::Frozen { representation, .. } => match &representation {
-                    ChunkStageFrozenRepr::MutableBufferSnapshot(_) if move_tracker.is_none() => {
-                        let partition_key = chunk_guard.key().to_string();
-                        let table_name = chunk_guard.table_name().to_string();
-                        let chunk_id = chunk_guard.id();
+                ChunkStorage::ClosedMutableBuffer if self.move_tracker.is_none() => {
+                    let partition_key = chunk_guard.partition_key();
+                    let table_name = chunk_guard.table_name();
+                    let chunk_id = chunk_guard.chunk_id();
 
-                        std::mem::drop(chunk_guard);
+                    std::mem::drop(chunk_guard);
 
-                        move_tracker =
-                            Some(self.move_to_read_buffer(table_name, partition_key, chunk_id));
-                    }
-                    ChunkStageFrozenRepr::ReadBuffer { .. } if would_write => {
-                        let partition_key = chunk_guard.key().to_string();
-                        let table_name = chunk_guard.table_name().to_string();
-                        let chunk_id = chunk_guard.id();
+                    self.move_tracker = Some(self.db.move_to_read_buffer(
+                        table_name,
+                        partition_key,
+                        chunk_id,
+                    ));
+                }
+                ChunkStorage::ReadBuffer if would_write => {
+                    let partition_key = chunk_guard.partition_key();
+                    let table_name = chunk_guard.table_name();
+                    let chunk_id = chunk_guard.chunk_id();
 
-                        std::mem::drop(chunk_guard);
+                    std::mem::drop(chunk_guard);
 
-                        write_tracker =
-                            Some(self.write_to_object_store(table_name, partition_key, chunk_id));
-                    }
-                    _ => {}
-                },
-                ChunkStage::Persisted { .. } => {
+                    self.write_tracker = Some(self.db.write_to_object_store(
+                        table_name,
+                        partition_key,
+                        chunk_id,
+                    ));
+                }
+                _ => {
                     // Chunk is already persisted, no additional work needed to persist it
                 }
             }
@@ -205,7 +324,7 @@ trait ChunkMover {
             let mut chunks = chunks.iter();
 
             loop {
-                let buffer_size = self.buffer_size();
+                let buffer_size = self.db.buffer_size();
                 if buffer_size < soft_limit.get() {
                     debug!(buffer_size, %soft_limit, "memory use under soft limit");
                     break;
@@ -218,8 +337,8 @@ trait ChunkMover {
                     Some(chunk) => {
                         let chunk_guard = chunk.read();
                         if chunk_guard.lifecycle_action().is_some() {
-                            debug!(table_name=%chunk_guard.table_name(), partition_key=%chunk_guard.key(),
-                                   chunk_id=%chunk_guard.id(), lifecycle_action=?chunk_guard.lifecycle_action(),
+                            debug!(table_name=%chunk_guard.table_name(), partition_key=%chunk_guard.partition_key(),
+                                   chunk_id=%chunk_guard.chunk_id(), lifecycle_action=?chunk_guard.lifecycle_action(),
                                    "can not drop chunk with in-progress lifecycle action");
                             continue;
                         }
@@ -230,51 +349,49 @@ trait ChunkMover {
                         }
 
                         // Figure out if we can drop or unload this chunk
-                        let action = match chunk_guard.stage() {
-                            ChunkStage::Frozen { .. } if rules.drop_non_persisted => {
+                        let action = match chunk_guard.storage() {
+                            ChunkStorage::ReadBuffer | ChunkStorage::ClosedMutableBuffer
+                                if rules.drop_non_persisted =>
+                            {
                                 // Chunk isn't yet persisted but we have
                                 // hit the limit so we need to drop it
                                 Action::Drop
                             }
-                            ChunkStage::Persisted { read_buffer, .. } => {
-                                // Chunk is persisted, so try and clear it from in memory buffers
-                                if read_buffer.is_some() {
-                                    Action::Unload
-                                } else {
-                                    // can't free any memory
-                                    continue;
-                                }
-                            }
-                            ChunkStage::Open { .. } | ChunkStage::Frozen { .. } => continue,
+                            ChunkStorage::ReadBufferAndObjectStore => Action::Unload,
+                            _ => continue,
                         };
 
-                        let partition_key = chunk_guard.key().to_string();
-                        let table_name = chunk_guard.table_name().to_string();
-                        let chunk_id = chunk_guard.id();
+                        let partition_key = chunk_guard.partition_key();
+                        let table_name = chunk_guard.table_name();
+                        let chunk_id = chunk_guard.chunk_id();
                         std::mem::drop(chunk_guard);
 
                         match action {
                             Action::Drop => {
                                 if open_partitions.contains(&partition_key) {
-                                    warn!(db_name=self.db_name(), %partition_key, chunk_id, soft_limit, buffer_size,
+                                    warn!(%partition_key, chunk_id, soft_limit, buffer_size,
                                           "dropping chunk prior to persistence. Consider increasing the soft buffer limit");
                                 }
 
-                                self.drop_chunk(table_name, partition_key, chunk_id)
+                                self.db.drop_chunk(table_name, partition_key, chunk_id)
                             }
                             Action::Unload => {
-                                self.unload_read_buffer(table_name, partition_key, chunk_id)
+                                self.db
+                                    .unload_read_buffer(table_name, partition_key, chunk_id)
                             }
                         }
                     }
                     None => {
-                        warn!(db_name=self.db_name(), soft_limit, buffer_size,
+                        warn!(soft_limit, buffer_size,
                               "soft limited exceeded, but no chunks found that can be evicted. Check lifecycle rules");
                         break;
                     }
                 };
             }
         }
+
+        let move_tracker = self.move_tracker.clone();
+        let write_tracker = self.write_tracker.clone();
 
         Box::pin(async move {
             let backoff = rules
@@ -315,81 +432,6 @@ async fn wait_optional_tracker<Job: Send + Sync + 'static>(tracker: Option<TaskT
     }
 }
 
-impl ChunkMover for LifecycleManager {
-    type Job = Job;
-
-    fn buffer_size(&self) -> usize {
-        self.db.preserved_catalog.state().metrics().memory().total()
-    }
-
-    fn db_name(&self) -> &str {
-        &self.db_name
-    }
-
-    fn rules(&self) -> LifecycleRules {
-        self.db.rules.read().lifecycle_rules.clone()
-    }
-
-    fn chunks(&self, sort_order: &SortOrder) -> Vec<Arc<RwLock<CatalogChunk>>> {
-        self.db
-            .preserved_catalog
-            .state()
-            .chunks_sorted_by(sort_order)
-    }
-
-    fn move_tracker(&self) -> Option<&TaskTracker<Job>> {
-        self.move_task.as_ref()
-    }
-
-    fn write_tracker(&self) -> Option<&TaskTracker<Job>> {
-        self.write_task.as_ref()
-    }
-
-    fn move_to_read_buffer(
-        &mut self,
-        table_name: String,
-        partition_key: String,
-        chunk_id: u32,
-    ) -> TaskTracker<Self::Job> {
-        info!(%partition_key, %chunk_id, "moving chunk to read buffer");
-        let tracker =
-            self.db
-                .load_chunk_to_read_buffer_in_background(table_name, partition_key, chunk_id);
-        self.move_task = Some(tracker.clone());
-        tracker
-    }
-
-    fn write_to_object_store(
-        &mut self,
-        table_name: String,
-        partition_key: String,
-        chunk_id: u32,
-    ) -> TaskTracker<Self::Job> {
-        info!(%partition_key, %chunk_id, "write chunk to object store");
-        let tracker =
-            self.db
-                .write_chunk_to_object_store_in_background(table_name, partition_key, chunk_id);
-        self.write_task = Some(tracker.clone());
-        tracker
-    }
-
-    fn drop_chunk(&mut self, table_name: String, partition_key: String, chunk_id: u32) {
-        info!(%partition_key, %chunk_id, "dropping chunk");
-        let _ = self
-            .db
-            .drop_chunk(&table_name, &partition_key, chunk_id)
-            .log_if_error("dropping chunk to free up memory");
-    }
-
-    fn unload_read_buffer(&mut self, table_name: String, partition_key: String, chunk_id: u32) {
-        info!(%partition_key, %chunk_id, "unloading from readbuffer");
-        let _ = self
-            .db
-            .unload_read_buffer(&table_name, &partition_key, chunk_id)
-            .log_if_error("unloading from read buffer to free up memory");
-    }
-}
-
 /// Returns the number of seconds between two times
 ///
 /// Computes a - b
@@ -405,7 +447,7 @@ fn elapsed_seconds(a: DateTime<Utc>, b: DateTime<Utc>) -> u32 {
 /// Returns if the chunk is sufficiently cold and old to move
 ///
 /// Note: Does not check the chunk is the correct state
-fn can_move(rules: &LifecycleRules, chunk: &CatalogChunk, now: DateTime<Utc>) -> bool {
+fn can_move<C: LifecycleChunk>(rules: &LifecycleRules, chunk: &C, now: DateTime<Utc>) -> bool {
     match (rules.mutable_linger_seconds, chunk.time_of_last_write()) {
         (Some(linger), Some(last_write)) if elapsed_seconds(now, last_write) >= linger.get() => {
             match (
@@ -430,88 +472,13 @@ fn can_move(rules: &LifecycleRules, chunk: &CatalogChunk, now: DateTime<Utc>) ->
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::db::catalog::chunk::ChunkMetrics;
-    use entry::test_helpers::lp_to_entry;
-    use object_store::{memory::InMemory, ObjectStore};
-    use parquet_file::test_utils::make_chunk as make_parquet_chunk;
-    use read_buffer::RBChunk;
     use std::num::{NonZeroU32, NonZeroUsize};
-    use tracker::{TaskRegistration, TaskRegistry};
 
-    fn from_secs(secs: i64) -> DateTime<Utc> {
-        DateTime::from_utc(chrono::NaiveDateTime::from_timestamp(secs, 0), Utc)
-    }
+    use data_types::chunk_metadata::ChunkStorage;
+    use data_types::database_rules::SortOrder;
+    use tracker::{RwLock, TaskId, TaskRegistration, TaskRegistry};
 
-    fn new_chunk(
-        id: u32,
-        time_of_first_write: Option<i64>,
-        time_of_last_write: Option<i64>,
-    ) -> CatalogChunk {
-        let entry = lp_to_entry("table1 bar=10 10");
-        let write = entry.partition_writes().unwrap().remove(0);
-        let batch = write.table_batches().remove(0);
-        let mut mb_chunk = mutable_buffer::chunk::MBChunk::new(
-            "table1",
-            mutable_buffer::chunk::ChunkMetrics::new_unregistered(),
-        );
-        mb_chunk.write_table_batch(1, 5, batch).unwrap();
-
-        let mut chunk = CatalogChunk::new_open(id, "", mb_chunk, ChunkMetrics::new_unregistered());
-        chunk.set_timestamps(
-            time_of_first_write.map(from_secs),
-            time_of_last_write.map(from_secs),
-        );
-        chunk
-    }
-
-    /// Transitions a new ("open") chunk into the "moving" state.
-    fn transition_to_moving(mut chunk: CatalogChunk) -> CatalogChunk {
-        chunk.freeze().unwrap();
-        chunk.set_moving(&Default::default()).unwrap();
-        chunk
-    }
-
-    /// Transitions a new ("open") chunk into the "moved" state.
-    fn transition_to_moved(mut chunk: CatalogChunk, rb: &Arc<RBChunk>) -> CatalogChunk {
-        chunk = transition_to_moving(chunk);
-        chunk.set_moved(Arc::clone(&rb)).unwrap();
-        chunk
-    }
-
-    /// Transitions a new ("open") chunk into the "writing to object store"
-    /// state.
-    fn transition_to_writing_to_object_store(
-        mut chunk: CatalogChunk,
-        rb: &Arc<RBChunk>,
-    ) -> CatalogChunk {
-        chunk = transition_to_moved(chunk, rb);
-        chunk
-            .set_writing_to_object_store(&Default::default())
-            .unwrap();
-        chunk
-    }
-
-    /// Transitions a new ("open") chunk into the "written to object store"
-    /// state.
-    async fn transition_to_written_to_object_store(
-        mut chunk: CatalogChunk,
-        rb: &Arc<RBChunk>,
-    ) -> CatalogChunk {
-        chunk = transition_to_writing_to_object_store(chunk, rb);
-        let parquet_chunk = new_parquet_chunk(&chunk).await;
-        chunk
-            .set_written_to_object_store(Arc::new(parquet_chunk))
-            .unwrap();
-        chunk
-    }
-
-    async fn new_parquet_chunk(chunk: &CatalogChunk) -> parquet_file::chunk::ParquetChunk {
-        let in_memory = InMemory::new();
-        let object_store = Arc::new(ObjectStore::new_in_memory(in_memory));
-
-        make_parquet_chunk(object_store, "foo", chunk.id()).await
-    }
+    use super::*;
 
     #[derive(Debug, Eq, PartialEq)]
     enum MoverEvents {
@@ -521,123 +488,165 @@ mod tests {
         Unload(u32),
     }
 
-    /// A dummy mover that is used to test the policy
-    /// logic within ChunkMover::poll
-    struct DummyMover {
-        rules: LifecycleRules,
-        move_tracker: Option<TaskTracker<()>>,
-        write_tracker: Option<TaskTracker<()>>,
-        chunks: Vec<Arc<RwLock<CatalogChunk>>>,
-        events: Vec<MoverEvents>,
+    struct TestChunk {
+        id: u32,
+        time_of_first_write: Option<DateTime<Utc>>,
+        time_of_last_write: Option<DateTime<Utc>>,
+        lifecycle_action: Option<TaskTracker<ChunkLifecycleAction>>,
+        storage: ChunkStorage,
     }
 
-    impl DummyMover {
-        fn new(rules: LifecycleRules, chunks: Vec<CatalogChunk>) -> Self {
+    impl TestChunk {
+        fn new(
+            id: u32,
+            time_of_first_write: Option<i64>,
+            time_of_last_write: Option<i64>,
+            storage: ChunkStorage,
+        ) -> Self {
             Self {
-                rules,
-                chunks: chunks
-                    .into_iter()
-                    .map(|x| Arc::new(RwLock::new(x)))
-                    .collect(),
-                move_tracker: None,
-                write_tracker: None,
-                events: vec![],
+                id,
+                time_of_first_write: time_of_first_write.map(from_secs),
+                time_of_last_write: time_of_last_write.map(from_secs),
+                lifecycle_action: None,
+                storage,
+            }
+        }
+
+        fn with_action(self, action: ChunkLifecycleAction) -> Self {
+            Self {
+                id: self.id,
+                time_of_first_write: self.time_of_first_write,
+                time_of_last_write: self.time_of_last_write,
+                lifecycle_action: Some(TaskTracker::complete(action)),
+                storage: self.storage,
             }
         }
     }
 
-    impl ChunkMover for DummyMover {
-        type Job = ();
+    impl LifecycleChunk for TestChunk {
+        fn lifecycle_action(&self) -> Option<&TaskTracker<ChunkLifecycleAction>> {
+            self.lifecycle_action.as_ref()
+        }
+
+        fn clear_lifecycle_action(&mut self) {
+            self.lifecycle_action = None
+        }
+
+        fn time_of_first_write(&self) -> Option<DateTime<Utc>> {
+            self.time_of_first_write
+        }
+
+        fn time_of_last_write(&self) -> Option<DateTime<Utc>> {
+            self.time_of_last_write
+        }
+
+        fn table_name(&self) -> String {
+            Default::default()
+        }
+
+        fn partition_key(&self) -> String {
+            Default::default()
+        }
+
+        fn chunk_id(&self) -> u32 {
+            self.id
+        }
+
+        fn storage(&self) -> ChunkStorage {
+            self.storage
+        }
+    }
+
+    /// A dummy db that is used to test the policy logic
+    struct TestDb {
+        rules: LifecycleRules,
+        chunks: RwLock<Vec<Arc<RwLock<TestChunk>>>>,
+        events: RwLock<Vec<MoverEvents>>,
+    }
+
+    impl TestDb {
+        fn new(rules: LifecycleRules, chunks: Vec<TestChunk>) -> Self {
+            Self {
+                rules,
+                chunks: RwLock::new(
+                    chunks
+                        .into_iter()
+                        .map(|x| Arc::new(RwLock::new(x)))
+                        .collect(),
+                ),
+                events: RwLock::new(vec![]),
+            }
+        }
+    }
+
+    impl LifecycleDb for TestDb {
+        type Chunk = TestChunk;
 
         fn buffer_size(&self) -> usize {
             // All chunks are 20 bytes
-            self.chunks.len() * 20
-        }
-
-        fn db_name(&self) -> &str {
-            "my_awesome_db"
+            self.chunks.read().len() * 20
         }
 
         fn rules(&self) -> LifecycleRules {
             self.rules.clone()
         }
 
-        fn chunks(&self, _: &SortOrder) -> Vec<Arc<RwLock<CatalogChunk>>> {
-            self.chunks.clone()
-        }
-
-        fn move_tracker(&self) -> Option<&TaskTracker<Self::Job>> {
-            self.move_tracker.as_ref()
-        }
-
-        fn write_tracker(&self) -> Option<&TaskTracker<Self::Job>> {
-            self.write_tracker.as_ref()
+        fn chunks(&self, _: &SortOrder) -> Vec<Arc<RwLock<TestChunk>>> {
+            self.chunks.read().clone()
         }
 
         fn move_to_read_buffer(
-            &mut self,
+            &self,
             _table_name: String,
             _partition_key: String,
             chunk_id: u32,
-        ) -> TaskTracker<Self::Job> {
-            let chunk = self
-                .chunks
+        ) -> TaskTracker<()> {
+            let chunks = self.chunks.read();
+            let chunk = chunks
                 .iter()
-                .find(|x| x.read().id() == chunk_id)
+                .find(|x| x.read().chunk_id() == chunk_id)
                 .unwrap();
-            chunk.write().set_moving(&Default::default()).unwrap();
-            self.events.push(MoverEvents::Move(chunk_id));
-            let tracker = TaskTracker::complete(());
-            self.move_tracker = Some(tracker.clone());
-            tracker
+            chunk.write().storage = ChunkStorage::ReadBuffer;
+            self.events.write().push(MoverEvents::Move(chunk_id));
+            TaskTracker::complete(())
         }
 
         fn write_to_object_store(
-            &mut self,
+            &self,
             _table_name: String,
             _partition_key: String,
             chunk_id: u32,
-        ) -> TaskTracker<Self::Job> {
-            let chunk = self
-                .chunks
+        ) -> TaskTracker<()> {
+            let chunks = self.chunks.read();
+            let chunk = chunks
                 .iter()
-                .find(|x| x.read().id() == chunk_id)
+                .find(|x| x.read().chunk_id() == chunk_id)
                 .unwrap();
-            chunk
-                .write()
-                .set_writing_to_object_store(&Default::default())
-                .unwrap();
-            self.events.push(MoverEvents::Write(chunk_id));
-            let tracker = TaskTracker::complete(());
-            self.write_tracker = Some(tracker.clone());
-            tracker
+            chunk.write().storage = ChunkStorage::ReadBufferAndObjectStore;
+            self.events.write().push(MoverEvents::Write(chunk_id));
+            TaskTracker::complete(())
         }
 
-        fn drop_chunk(&mut self, _table_name: String, _partition_key: String, chunk_id: u32) {
-            self.chunks = self
-                .chunks
-                .drain(..)
-                .filter(|x| x.read().id() != chunk_id)
-                .collect();
-            self.events.push(MoverEvents::Drop(chunk_id))
+        fn drop_chunk(&self, _table_name: String, _partition_key: String, chunk_id: u32) {
+            let mut chunks = self.chunks.write();
+            chunks.retain(|x| x.read().chunk_id() != chunk_id);
+            self.events.write().push(MoverEvents::Drop(chunk_id))
         }
 
-        fn unload_read_buffer(
-            &mut self,
-            _table_name: String,
-            _partition_key: String,
-            chunk_id: u32,
-        ) {
-            let chunk = self
-                .chunks
+        fn unload_read_buffer(&self, _table_name: String, _partition_key: String, chunk_id: u32) {
+            let chunks = self.chunks.read();
+            let chunk = chunks
                 .iter()
-                .find(|x| x.read().id() == chunk_id)
+                .find(|x| x.read().chunk_id() == chunk_id)
                 .unwrap();
 
-            chunk.write().set_unload_from_read_buffer().unwrap();
-
-            self.events.push(MoverEvents::Unload(chunk_id))
+            chunk.write().storage = ChunkStorage::ObjectStoreOnly;
+            self.events.write().push(MoverEvents::Unload(chunk_id))
         }
+    }
+
+    fn from_secs(secs: i64) -> DateTime<Utc> {
+        DateTime::from_utc(chrono::NaiveDateTime::from_timestamp(secs, 0), Utc)
     }
 
     #[test]
@@ -651,7 +660,7 @@ mod tests {
     fn test_can_move() {
         // Cannot move by default
         let rules = LifecycleRules::default();
-        let chunk = new_chunk(0, Some(0), Some(0));
+        let chunk = TestChunk::new(0, Some(0), Some(0), ChunkStorage::OpenMutableBuffer);
         assert!(!can_move(&rules, &chunk, from_secs(20)));
 
         // If only mutable_linger set can move a chunk once passed
@@ -659,7 +668,7 @@ mod tests {
             mutable_linger_seconds: Some(NonZeroU32::new(10).unwrap()),
             ..Default::default()
         };
-        let chunk = new_chunk(0, Some(0), Some(0));
+        let chunk = TestChunk::new(0, Some(0), Some(0), ChunkStorage::OpenMutableBuffer);
         assert!(!can_move(&rules, &chunk, from_secs(9)));
         assert!(can_move(&rules, &chunk, from_secs(11)));
 
@@ -669,12 +678,12 @@ mod tests {
             mutable_minimum_age_seconds: Some(NonZeroU32::new(60).unwrap()),
             ..Default::default()
         };
-        let chunk = new_chunk(0, Some(0), Some(0));
+        let chunk = TestChunk::new(0, Some(0), Some(0), ChunkStorage::OpenMutableBuffer);
         assert!(!can_move(&rules, &chunk, from_secs(9)));
         assert!(!can_move(&rules, &chunk, from_secs(11)));
         assert!(can_move(&rules, &chunk, from_secs(61)));
 
-        let chunk = new_chunk(0, Some(0), Some(70));
+        let chunk = TestChunk::new(0, Some(0), Some(70), ChunkStorage::OpenMutableBuffer);
         assert!(!can_move(&rules, &chunk, from_secs(71)));
         assert!(can_move(&rules, &chunk, from_secs(81)));
     }
@@ -684,14 +693,15 @@ mod tests {
         // The default rules shouldn't do anything
         let rules = LifecycleRules::default();
         let chunks = vec![
-            new_chunk(0, Some(1), Some(1)),
-            new_chunk(1, Some(20), Some(1)),
-            new_chunk(2, Some(30), Some(1)),
+            TestChunk::new(0, Some(1), Some(1), ChunkStorage::OpenMutableBuffer),
+            TestChunk::new(1, Some(20), Some(1), ChunkStorage::OpenMutableBuffer),
+            TestChunk::new(2, Some(30), Some(1), ChunkStorage::OpenMutableBuffer),
         ];
 
-        let mut mover = DummyMover::new(rules, chunks);
-        mover.check_for_work(from_secs(40), Instant::now());
-        assert_eq!(mover.events, vec![]);
+        let db = Arc::new(TestDb::new(rules, chunks));
+        let mut lifecycle = LifecyclePolicy::new(Arc::clone(&db));
+        lifecycle.check_for_work(from_secs(40), Instant::now());
+        assert_eq!(*db.events.read(), vec![]);
     }
 
     #[test]
@@ -701,33 +711,35 @@ mod tests {
             ..Default::default()
         };
         let chunks = vec![
-            new_chunk(0, Some(0), Some(8)),
-            new_chunk(1, Some(0), Some(5)),
-            new_chunk(2, Some(0), Some(0)),
+            TestChunk::new(0, Some(0), Some(8), ChunkStorage::OpenMutableBuffer),
+            TestChunk::new(1, Some(0), Some(5), ChunkStorage::OpenMutableBuffer),
+            TestChunk::new(2, Some(0), Some(0), ChunkStorage::OpenMutableBuffer),
         ];
 
-        let mut mover = DummyMover::new(rules, chunks);
-        mover.check_for_work(from_secs(9), Instant::now());
+        let db = Arc::new(TestDb::new(rules, chunks));
+        let mut lifecycle = LifecyclePolicy::new(Arc::clone(&db));
 
-        assert_eq!(mover.events, vec![]);
+        lifecycle.check_for_work(from_secs(9), Instant::now());
 
-        mover.check_for_work(from_secs(11), Instant::now());
-        assert_eq!(mover.events, vec![MoverEvents::Move(2)]);
+        assert_eq!(*db.events.read(), vec![]);
 
-        mover.check_for_work(from_secs(12), Instant::now());
-        assert_eq!(mover.events, vec![MoverEvents::Move(2)]);
+        lifecycle.check_for_work(from_secs(11), Instant::now());
+        assert_eq!(*db.events.read(), vec![MoverEvents::Move(2)]);
+
+        lifecycle.check_for_work(from_secs(12), Instant::now());
+        assert_eq!(*db.events.read(), vec![MoverEvents::Move(2)]);
 
         // Should move in the order of chunks in the case of multiple candidates
-        mover.check_for_work(from_secs(20), Instant::now());
+        lifecycle.check_for_work(from_secs(20), Instant::now());
         assert_eq!(
-            mover.events,
+            *db.events.read(),
             vec![MoverEvents::Move(2), MoverEvents::Move(0)]
         );
 
-        mover.check_for_work(from_secs(20), Instant::now());
+        lifecycle.check_for_work(from_secs(20), Instant::now());
 
         assert_eq!(
-            mover.events,
+            *db.events.read(),
             vec![
                 MoverEvents::Move(2),
                 MoverEvents::Move(0),
@@ -743,22 +755,27 @@ mod tests {
             mutable_linger_seconds: Some(NonZeroU32::new(10).unwrap()),
             ..Default::default()
         };
-        let chunks = vec![new_chunk(0, Some(0), Some(0))];
+        let chunks = vec![TestChunk::new(
+            0,
+            Some(0),
+            Some(0),
+            ChunkStorage::OpenMutableBuffer,
+        )];
 
-        let mut mover = DummyMover::new(rules, chunks);
+        let db = Arc::new(TestDb::new(rules, chunks));
+        let mut lifecycle = LifecyclePolicy::new(Arc::clone(&db));
 
         let (tracker, registration) = registry.register(());
-        mover.move_tracker = Some(tracker);
+        lifecycle.move_tracker = Some(tracker);
+        lifecycle.check_for_work(from_secs(80), Instant::now());
 
-        mover.check_for_work(from_secs(80), Instant::now());
-
-        assert_eq!(mover.events, vec![]);
+        assert_eq!(*db.events.read(), vec![]);
 
         std::mem::drop(registration);
 
-        mover.check_for_work(from_secs(80), Instant::now());
+        lifecycle.check_for_work(from_secs(80), Instant::now());
 
-        assert_eq!(mover.events, vec![MoverEvents::Move(0)]);
+        assert_eq!(*db.events.read(), vec![MoverEvents::Move(0)]);
     }
 
     #[tokio::test]
@@ -768,20 +785,21 @@ mod tests {
             mutable_linger_seconds: Some(NonZeroU32::new(100).unwrap()),
             ..Default::default()
         };
-        let mut mover = DummyMover::new(rules, vec![]);
+        let db = Arc::new(TestDb::new(rules, vec![]));
+        let mut lifecycle = LifecyclePolicy::new(Arc::clone(&db));
 
         let (tracker, registration) = registry.register(());
 
         // Manually set the move_tracker on the DummyMover as if a previous invocation
         // of check_for_work had started a background move task
-        mover.move_tracker = Some(tracker);
+        lifecycle.move_tracker = Some(tracker);
 
-        let future = mover.check_for_work(from_secs(0), Instant::now());
+        let future = lifecycle.check_for_work(from_secs(0), Instant::now());
         tokio::time::timeout(Duration::from_millis(1), future)
             .await
             .expect_err("expected timeout");
 
-        let future = mover.check_for_work(from_secs(0), Instant::now());
+        let future = lifecycle.check_for_work(from_secs(0), Instant::now());
         std::mem::drop(registration);
         tokio::time::timeout(Duration::from_millis(1), future)
             .await
@@ -796,25 +814,25 @@ mod tests {
             ..Default::default()
         };
         let chunks = vec![
-            new_chunk(0, Some(40), Some(40)),
-            new_chunk(1, Some(0), Some(0)),
+            TestChunk::new(0, Some(40), Some(40), ChunkStorage::OpenMutableBuffer),
+            TestChunk::new(1, Some(0), Some(0), ChunkStorage::OpenMutableBuffer),
         ];
 
-        let mut mover = DummyMover::new(rules, chunks);
+        let db = Arc::new(TestDb::new(rules, chunks));
+        let mut lifecycle = LifecyclePolicy::new(Arc::clone(&db));
 
         // Expect to move chunk_id=1 first, despite it coming second in
         // the order, because chunk_id=0 will only become old enough at t=100
 
-        mover.check_for_work(from_secs(80), Instant::now());
-        assert_eq!(mover.events, vec![MoverEvents::Move(1)]);
+        lifecycle.check_for_work(from_secs(80), Instant::now());
+        assert_eq!(*db.events.read(), vec![MoverEvents::Move(1)]);
 
-        mover.check_for_work(from_secs(90), Instant::now());
-        assert_eq!(mover.events, vec![MoverEvents::Move(1)]);
+        lifecycle.check_for_work(from_secs(90), Instant::now());
+        assert_eq!(*db.events.read(), vec![MoverEvents::Move(1)]);
 
-        mover.check_for_work(from_secs(110), Instant::now());
-
+        lifecycle.check_for_work(from_secs(110), Instant::now());
         assert_eq!(
-            mover.events,
+            *db.events.read(),
             vec![MoverEvents::Move(1), MoverEvents::Move(0)]
         );
     }
@@ -832,32 +850,38 @@ mod tests {
             ..Default::default()
         };
 
-        let rb = Arc::new(RBChunk::new(read_buffer::ChunkMetrics::new_unregistered()));
+        let chunks = vec![TestChunk::new(
+            0,
+            Some(0),
+            Some(0),
+            ChunkStorage::OpenMutableBuffer,
+        )];
 
-        let chunks = vec![new_chunk(0, Some(0), Some(0))];
+        let db = Arc::new(TestDb::new(rules.clone(), chunks));
+        let mut lifecycle = LifecyclePolicy::new(Arc::clone(&db));
 
-        let mut mover = DummyMover::new(rules.clone(), chunks);
-
-        mover.check_for_work(from_secs(10), Instant::now());
-        assert_eq!(mover.events, vec![]);
+        lifecycle.check_for_work(from_secs(10), Instant::now());
+        assert_eq!(*db.events.read(), vec![]);
 
         let chunks = vec![
             // two "open" chunks => they must not be dropped (yet)
-            new_chunk(0, Some(0), Some(0)),
-            new_chunk(1, Some(0), Some(0)),
+            TestChunk::new(0, Some(0), Some(0), ChunkStorage::OpenMutableBuffer),
+            TestChunk::new(1, Some(0), Some(0), ChunkStorage::OpenMutableBuffer),
             // "moved" chunk => can be dropped because `drop_non_persistent=true`
-            transition_to_moved(new_chunk(2, Some(0), Some(0)), &rb),
+            TestChunk::new(2, Some(0), Some(0), ChunkStorage::ReadBuffer),
             // "writing" chunk => cannot be unloaded while write is in-progress
-            transition_to_writing_to_object_store(new_chunk(3, Some(0), Some(0)), &rb),
+            TestChunk::new(3, Some(0), Some(0), ChunkStorage::ReadBuffer)
+                .with_action(ChunkLifecycleAction::Persisting),
             // "written" chunk => can be unloaded
-            transition_to_written_to_object_store(new_chunk(4, Some(0), Some(0)), &rb).await,
+            TestChunk::new(4, Some(0), Some(0), ChunkStorage::ReadBufferAndObjectStore),
         ];
 
-        let mut mover = DummyMover::new(rules, chunks);
+        let db = Arc::new(TestDb::new(rules, chunks));
+        let mut lifecycle = LifecyclePolicy::new(Arc::clone(&db));
 
-        mover.check_for_work(from_secs(10), Instant::now());
+        lifecycle.check_for_work(from_secs(10), Instant::now());
         assert_eq!(
-            mover.events,
+            *db.events.read(),
             vec![MoverEvents::Drop(2), MoverEvents::Unload(4)]
         );
     }
@@ -875,31 +899,37 @@ mod tests {
         };
         assert!(!rules.drop_non_persisted);
 
-        let rb = Arc::new(RBChunk::new(read_buffer::ChunkMetrics::new_unregistered()));
+        let chunks = vec![TestChunk::new(
+            0,
+            Some(0),
+            Some(0),
+            ChunkStorage::OpenMutableBuffer,
+        )];
 
-        let chunks = vec![new_chunk(0, Some(0), Some(0))];
+        let db = Arc::new(TestDb::new(rules.clone(), chunks));
+        let mut lifecycle = LifecyclePolicy::new(Arc::clone(&db));
 
-        let mut mover = DummyMover::new(rules.clone(), chunks);
-
-        mover.check_for_work(from_secs(10), Instant::now());
-        assert_eq!(mover.events, vec![]);
+        lifecycle.check_for_work(from_secs(10), Instant::now());
+        assert_eq!(*db.events.read(), vec![]);
 
         let chunks = vec![
             // two "open" chunks => they must not be dropped (yet)
-            new_chunk(0, Some(0), Some(0)),
-            new_chunk(1, Some(0), Some(0)),
+            TestChunk::new(0, Some(0), Some(0), ChunkStorage::OpenMutableBuffer),
+            TestChunk::new(1, Some(0), Some(0), ChunkStorage::OpenMutableBuffer),
             // "moved" chunk => cannot be dropped because `drop_non_persistent=false`
-            transition_to_moved(new_chunk(2, Some(0), Some(0)), &rb),
+            TestChunk::new(2, Some(0), Some(0), ChunkStorage::ReadBuffer),
             // "writing" chunk => cannot be drop while write is in-progess
-            transition_to_writing_to_object_store(new_chunk(3, Some(0), Some(0)), &rb),
+            TestChunk::new(3, Some(0), Some(0), ChunkStorage::ReadBuffer)
+                .with_action(ChunkLifecycleAction::Persisting),
             // "written" chunk => can be unloaded
-            transition_to_written_to_object_store(new_chunk(4, Some(0), Some(0)), &rb).await,
+            TestChunk::new(4, Some(0), Some(0), ChunkStorage::ReadBufferAndObjectStore),
         ];
 
-        let mut mover = DummyMover::new(rules, chunks);
+        let db = Arc::new(TestDb::new(rules, chunks));
+        let mut lifecycle = LifecyclePolicy::new(Arc::clone(&db));
 
-        mover.check_for_work(from_secs(10), Instant::now());
-        assert_eq!(mover.events, vec![MoverEvents::Unload(4)]);
+        lifecycle.check_for_work(from_secs(10), Instant::now());
+        assert_eq!(*db.events.read(), vec![MoverEvents::Unload(4)]);
     }
 
     #[test]
@@ -910,12 +940,18 @@ mod tests {
             ..Default::default()
         };
 
-        let chunks = vec![new_chunk(0, Some(0), Some(0))];
+        let chunks = vec![TestChunk::new(
+            0,
+            Some(0),
+            Some(0),
+            ChunkStorage::OpenMutableBuffer,
+        )];
 
-        let mut mover = DummyMover::new(rules, chunks);
+        let db = Arc::new(TestDb::new(rules, chunks));
+        let mut lifecycle = LifecyclePolicy::new(Arc::clone(&db));
 
-        mover.check_for_work(from_secs(10), Instant::now());
-        assert_eq!(mover.events, vec![]);
+        lifecycle.check_for_work(from_secs(10), Instant::now());
+        assert_eq!(*db.events.read(), vec![]);
     }
 
     #[test]
@@ -926,22 +962,21 @@ mod tests {
             ..Default::default()
         };
 
-        let rb = Arc::new(RBChunk::new(read_buffer::ChunkMetrics::new_unregistered()));
-
         let chunks = vec![
             // still moving => cannot write
-            transition_to_moving(new_chunk(0, Some(0), Some(0))),
+            TestChunk::new(0, Some(0), Some(0), ChunkStorage::ClosedMutableBuffer)
+                .with_action(ChunkLifecycleAction::Moving),
             // moved => write to object store
-            transition_to_moved(new_chunk(1, Some(0), Some(0)), &rb),
+            TestChunk::new(1, Some(0), Some(0), ChunkStorage::ReadBuffer),
             // moved, but there will be already a write in progress (previous chunk) => don't write
-            transition_to_moved(new_chunk(2, Some(0), Some(0)), &rb),
+            TestChunk::new(2, Some(0), Some(0), ChunkStorage::ReadBufferAndObjectStore),
         ];
 
-        let mut mover = DummyMover::new(rules, chunks);
+        let db = Arc::new(TestDb::new(rules, chunks));
+        let mut lifecycle = LifecyclePolicy::new(Arc::clone(&db));
 
-        mover.check_for_work(from_secs(0), Instant::now());
-
-        assert_eq!(mover.events, vec![MoverEvents::Write(1)]);
+        lifecycle.check_for_work(from_secs(0), Instant::now());
+        assert_eq!(*db.events.read(), vec![MoverEvents::Write(1)]);
     }
 
     #[test]
@@ -951,43 +986,51 @@ mod tests {
             mutable_minimum_age_seconds: Some(NonZeroU32::new(60).unwrap()),
             ..Default::default()
         };
-        let chunks = vec![new_chunk(0, Some(40), Some(40))];
+        let chunks = vec![TestChunk::new(
+            0,
+            Some(40),
+            Some(40),
+            ChunkStorage::OpenMutableBuffer,
+        )];
 
-        let mut mover = DummyMover::new(rules, chunks);
+        let db = Arc::new(TestDb::new(rules, chunks));
+        let mut lifecycle = LifecyclePolicy::new(Arc::clone(&db));
 
         // Initially can't move
-        mover.check_for_work(from_secs(80), Instant::now());
-        assert_eq!(mover.events, vec![]);
+        lifecycle.check_for_work(from_secs(80), Instant::now());
+        assert_eq!(*db.events.read(), vec![]);
 
-        mover.chunks[0].write().freeze().unwrap();
+        db.chunks.read()[0].write().storage = ChunkStorage::ClosedMutableBuffer;
 
         // As soon as closed can move
-        mover.check_for_work(from_secs(80), Instant::now());
-        assert_eq!(mover.events, vec![MoverEvents::Move(0)]);
+        lifecycle.check_for_work(from_secs(80), Instant::now());
+        assert_eq!(*db.events.read(), vec![MoverEvents::Move(0)]);
     }
 
     #[test]
     fn test_recovers_lifecycle_action() {
         let rules = LifecycleRules::default();
-        let chunks = vec![new_chunk(0, None, None)];
-        let mut mover = DummyMover::new(rules, chunks);
+        let chunks = vec![TestChunk::new(
+            0,
+            None,
+            None,
+            ChunkStorage::ClosedMutableBuffer,
+        )];
 
-        let chunk = Arc::clone(&mover.chunks[0]);
-        chunk.write().freeze().unwrap();
+        let db = Arc::new(TestDb::new(rules, chunks));
+        let mut lifecycle = LifecyclePolicy::new(Arc::clone(&db));
+        let chunk = &db.chunks.read()[0];
 
         let r0 = TaskRegistration::default();
-        let tracker = {
-            let mut chunk = chunk.write();
-            chunk.set_moving(&r0).unwrap();
-            chunk.lifecycle_action().unwrap().clone()
-        };
+        let tracker = TaskTracker::new(TaskId(0), &r0, ChunkLifecycleAction::Moving);
+        chunk.write().lifecycle_action = Some(tracker.clone());
 
         // Shouldn't do anything
-        mover.check_for_work(from_secs(0), tracker.start_instant());
+        lifecycle.check_for_work(from_secs(0), tracker.start_instant());
         assert!(chunk.read().lifecycle_action().is_some());
 
         // Shouldn't do anything as job hasn't finished
-        mover.check_for_work(
+        lifecycle.check_for_work(
             from_secs(0),
             tracker.start_instant() + LIFECYCLE_ACTION_BACKOFF,
         );
@@ -997,11 +1040,11 @@ mod tests {
         std::mem::drop(r0);
 
         // Shouldn't do anything as insufficient time passed
-        mover.check_for_work(from_secs(0), tracker.start_instant());
+        lifecycle.check_for_work(from_secs(0), tracker.start_instant());
         assert!(chunk.read().lifecycle_action().is_some());
 
         // Should clear job
-        mover.check_for_work(
+        lifecycle.check_for_work(
             from_secs(0),
             tracker.start_instant() + LIFECYCLE_ACTION_BACKOFF,
         );

--- a/server/src/db/lifecycle.rs
+++ b/server/src/db/lifecycle.rs
@@ -183,6 +183,7 @@ pub trait LifecycleDb {
     fn unload_read_buffer(&self, table_name: String, partition_key: String, chunk_id: u32);
 }
 
+/// The lifecycle operates on chunks implementing this trait
 pub trait LifecycleChunk {
     fn lifecycle_action(&self) -> Option<&TaskTracker<ChunkLifecycleAction>>;
 
@@ -205,6 +206,10 @@ pub const DEFAULT_LIFECYCLE_BACKOFF: Duration = Duration::from_secs(1);
 /// Number of seconds to wait before retying a failed lifecycle action
 pub const LIFECYCLE_ACTION_BACKOFF: Duration = Duration::from_secs(10);
 
+/// A `LifecyclePolicy` is created with a `LifecycleDb`
+///
+/// `LifecyclePolicy::check_for_work` can then be used to drive progress
+/// of the `LifecycleChunk` contained within this `LifecycleDb`
 pub struct LifecyclePolicy<M: LifecycleDb> {
     db: Arc<M>,
     // TODO: Remove these and use values from chunks within partition

--- a/tracker/src/task.rs
+++ b/tracker/src/task.rs
@@ -217,6 +217,15 @@ where
         }
     }
 
+    /// Consumes this `TaskTracker` and produces a new one with the provided metadata
+    pub fn with_metadata<U: Send + Sync>(self, metadata: U) -> TaskTracker<U> {
+        TaskTracker {
+            id: self.id,
+            state: self.state,
+            metadata: Arc::new(metadata),
+        }
+    }
+
     /// Returns a complete task tracker
     pub fn complete(metadata: T) -> Self {
         let registration = TaskRegistration::new();

--- a/tracker/src/task/registry.rs
+++ b/tracker/src/task/registry.rs
@@ -5,7 +5,7 @@ use std::str::FromStr;
 /// Every future registered with a `TaskRegistry` is assigned a unique
 /// `TaskId`
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-pub struct TaskId(pub(super) usize);
+pub struct TaskId(pub usize);
 
 impl FromStr for TaskId {
     type Err = std::num::ParseIntError;


### PR DESCRIPTION
Currently the lifecycle logic, both policy and otherwise, is contained within server. This is unfortunate for a couple of reasons:

* The server crate takes a long time to compile
* There isn't a clear API boundary between the lifecycle policy, lifecycle actions, catalog and the Db 
* `db.rs` is turning into a bit of a monster

All of these complicate making changes to the lifecycle logic, without ending up with a change-the-world PR.

This PR takes the first step to trait-ify the lifecycle policy to not directly depend on any of the catalog, RUB, MUB, parquet, Db, etc... Later PRs can then start to pull parts of it out into a separate crate.