### PR TITLE
feat: make DB catalog work w/ transaction aborts

### DIFF
--- a/parquet_file/src/rebuild.rs
+++ b/parquet_file/src/rebuild.rs
@@ -333,8 +333,7 @@ mod tests {
         // store catalog state
         let paths_expected = {
             let state = catalog.state();
-            let guard = state.inner.lock();
-            let mut tmp: Vec<_> = guard.parquet_files.keys().cloned().collect();
+            let mut tmp: Vec<_> = state.parquet_files.keys().cloned().collect();
             tmp.sort();
             tmp
         };
@@ -361,8 +360,7 @@ mod tests {
         // check match
         let paths_actual = {
             let state = catalog.state();
-            let guard = state.inner.lock();
-            let mut tmp: Vec<_> = guard.parquet_files.keys().cloned().collect();
+            let mut tmp: Vec<_> = state.parquet_files.keys().cloned().collect();
             tmp.sort();
             tmp
         };
@@ -407,8 +405,7 @@ mod tests {
 
         // check match
         let state = catalog.state();
-        let guard = state.inner.lock();
-        assert!(guard.parquet_files.is_empty());
+        assert!(state.parquet_files.is_empty());
         assert_eq!(catalog.revision_counter(), 0);
     }
 
@@ -568,8 +565,7 @@ mod tests {
         .await
         .unwrap();
         let state = catalog.state();
-        let guard = state.inner.lock();
-        assert!(guard.parquet_files.is_empty());
+        assert!(state.parquet_files.is_empty());
         assert_eq!(catalog.revision_counter(), 0);
     }
 
@@ -625,8 +621,7 @@ mod tests {
         // store catalog state
         let paths_expected = {
             let state = catalog.state();
-            let guard = state.inner.lock();
-            let mut tmp: Vec<_> = guard.parquet_files.keys().cloned().collect();
+            let mut tmp: Vec<_> = state.parquet_files.keys().cloned().collect();
             tmp.sort();
             tmp
         };
@@ -686,8 +681,7 @@ mod tests {
         // check match
         let paths_actual = {
             let state = catalog.state();
-            let guard = state.inner.lock();
-            let mut tmp: Vec<_> = guard.parquet_files.keys().cloned().collect();
+            let mut tmp: Vec<_> = state.parquet_files.keys().cloned().collect();
             tmp.sort();
             tmp
         };

--- a/server/src/db.rs
+++ b/server/src/db.rs
@@ -3303,7 +3303,7 @@ mod tests {
             metrics_registry,
             metric_labels: vec![],
         };
-        assert_catalog_state_implementation::<Catalog>(empty_input, false).await;
+        assert_catalog_state_implementation::<Catalog>(empty_input).await;
     }
 
     async fn create_parquet_chunk(db: &Db) -> (String, String, u32) {

--- a/server/src/db.rs
+++ b/server/src/db.rs
@@ -2928,8 +2928,7 @@ mod tests {
             .unwrap();
         let paths_actual = {
             let state = preserved_catalog.state();
-            let guard = state.inner.lock();
-            let mut tmp: Vec<String> = guard.parquet_files.keys().map(|p| p.display()).collect();
+            let mut tmp: Vec<String> = state.parquet_files.keys().map(|p| p.display()).collect();
             tmp.sort();
             tmp
         };

--- a/server/src/db.rs
+++ b/server/src/db.rs
@@ -633,6 +633,11 @@ impl Db {
             let mut transaction = self.preserved_catalog.open_transaction().await;
 
             // Write this table data into the object store
+            //
+            // IMPORTANT: Writing needs to take place during a transaction, otherwise the background cleanup task might
+            //            delete the just written parquet parquet file. Furthermore, the parquet files contains
+            //            information about the transaction (like revision counter and UUID) that are only available
+            //            once the transaction has started.
             let metadata = IoxMetadata {
                 transaction_revision_counter: transaction.revision_counter(),
                 transaction_uuid: transaction.uuid(),

--- a/server/src/db/catalog/chunk.rs
+++ b/server/src/db/catalog/chunk.rs
@@ -352,6 +352,12 @@ impl CatalogChunk {
         self.lifecycle_action.as_ref()
     }
 
+    pub fn is_in_lifecycle(&self, lifecycle_action: ChunkLifecycleAction) -> bool {
+        self.lifecycle_action
+            .as_ref()
+            .map_or(false, |action| action.metadata() == &lifecycle_action)
+    }
+
     pub fn time_of_first_write(&self) -> Option<DateTime<Utc>> {
         self.time_of_first_write
     }


### PR DESCRIPTION
# Abstract
This allows us to handle transaction aborts (e.g. when the write IO for the transaction file fails) correctly. Before this change aborts would lead to an inconsistent in-memory VS persisted state (in-memory says it's persisted while in fact the transaction wasn't written).

# Background
The reason this problem existed was some design mistake and laziness. When I designed the persisted catalog I somewhat assumed that we could just copy the whole managed in-memory state at transaction start, modify it during the transaction and commit it in the end. However this doesn't work for the real DB, so during the integration I made the "copy" step optional. Turns out that breaks the abort semantic :sweat_smile: 

# Fix
So the fix comes basically in 3 steps:

1. Add a generic test for `CatalogState` implementations that tries to check some invariants/features (incl. what happens during aborts). This one passes for test catalog but fails for the real one.
2. Rework the `CatalogState` interface to be more generic on how an implementation wants to handle state changes (allowing for the simple "copy everything", delayed action which is used by the DB now, as well as a rollback mechanic should we ever need this).
3. Fix the real DB catalog to work with the new interface and also to account for aborts correctly. Now the test added in (1) passes.

# References
This should help w/ #1725.