### PR TITLE
chore: Split LoggingConfig out of TracingConfig

### DIFF
--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -6,7 +6,7 @@ use data_types::server_id::ServerId;
 use std::{net::SocketAddr, net::ToSocketAddrs, path::PathBuf};
 use structopt::StructOpt;
 use thiserror::Error;
-use trogging::cli::TracingConfig;
+use trogging::cli::{LoggingConfig, TracingConfig};
 
 /// The default bind address for the HTTP API.
 pub const DEFAULT_API_BIND_ADDR: &str = "127.0.0.1:8080";
@@ -42,7 +42,11 @@ Configuration is loaded from the following sources (highest precedence first):
         - pre-configured default values"
 )]
 pub struct Config {
-    // logging and tracing options
+    // logging options
+    #[structopt(flatten)]
+    pub(crate) logging_config: LoggingConfig,
+
+    // tracing options
     #[structopt(flatten)]
     pub(crate) tracing_config: TracingConfig,
 

--- a/src/commands/tracing.rs
+++ b/src/commands/tracing.rs
@@ -1,6 +1,7 @@
 //! Log and trace initialization and setup
 
 use std::cmp::max;
+use trogging::cli::{LoggingConfigBuilderExt, TracingConfigBuilderExt};
 pub use trogging::config::*;
 pub use trogging::TracingGuard;
 
@@ -16,11 +17,15 @@ pub fn init_logs_and_tracing(
     log_verbose_count: u8,
     config: &crate::commands::run::Config,
 ) -> Result<TracingGuard, trogging::Error> {
-    let mut config = config.tracing_config.clone();
+    let tracing_config = &config.tracing_config;
+    let mut logging_config = config.logging_config.clone();
 
     // Handle the case if -v/-vv is specified both before and after the server
     // command
-    config.log_verbose_count = max(config.log_verbose_count, log_verbose_count);
+    logging_config.log_verbose_count = max(logging_config.log_verbose_count, log_verbose_count);
 
-    config.to_builder().install_global()
+    trogging::Builder::new()
+        .with_tracing_config(tracing_config)
+        .with_logging_config(&logging_config)
+        .install_global()
 }


### PR DESCRIPTION
Client CLI utils only need LoggingConfig. Servers need also the TracingConfig

Closes #influxdata/conductor#346
