### PR TITLE
feat: Write entries to Kafka

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3748,6 +3748,7 @@ dependencies = [
  "query",
  "rand 0.8.3",
  "rand_distr",
+ "rdkafka",
  "read_buffer",
  "serde",
  "serde_json",

--- a/query_tests/src/influxrpc/read_window_aggregate.rs
+++ b/query_tests/src/influxrpc/read_window_aggregate.rs
@@ -163,7 +163,7 @@ impl DbSetup for MeasurementForWindowAggregateMonths {
 
         let db = make_db().await.db;
         let data = lp_lines.join("\n");
-        write_lp(&db, &data);
+        write_lp(&db, &data).await;
         let scenario1 = DbScenario {
             scenario_name: "Data in 4 partitions, open chunks of mutable buffer".into(),
             db,
@@ -171,7 +171,7 @@ impl DbSetup for MeasurementForWindowAggregateMonths {
 
         let db = make_db().await.db;
         let data = lp_lines.join("\n");
-        write_lp(&db, &data);
+        write_lp(&db, &data).await;
         db.rollover_partition("h2o", "2020-03-01T00").await.unwrap();
         db.rollover_partition("h2o", "2020-03-02T00").await.unwrap();
         let scenario2 = DbScenario {
@@ -183,7 +183,7 @@ impl DbSetup for MeasurementForWindowAggregateMonths {
 
         let db = make_db().await.db;
         let data = lp_lines.join("\n");
-        write_lp(&db, &data);
+        write_lp(&db, &data).await;
         // roll over and load chunks into both RUB and OS
         rollover_and_load(&db, "2020-03-01T00", "h2o").await;
         rollover_and_load(&db, "2020-03-02T00", "h2o").await;

--- a/query_tests/src/pruning.rs
+++ b/query_tests/src/pruning.rs
@@ -19,8 +19,8 @@ async fn setup() -> TestDb {
     let db = &test_db.db;
 
     // Chunk 0 has bar:[1-2]
-    write_lp(db, "cpu bar=1 10");
-    write_lp(db, "cpu bar=2 20");
+    write_lp(db, "cpu bar=1 10").await;
+    write_lp(db, "cpu bar=2 20").await;
 
     let partition_key = "1970-01-01T00";
     let mb_chunk = db
@@ -33,9 +33,9 @@ async fn setup() -> TestDb {
         .unwrap();
 
     // Chunk 1 has bar:[3-3] (going to get pruned)
-    write_lp(db, "cpu bar=3 10");
-    write_lp(db, "cpu bar=3 100");
-    write_lp(db, "cpu bar=3 1000");
+    write_lp(db, "cpu bar=3 10").await;
+    write_lp(db, "cpu bar=3 100").await;
+    write_lp(db, "cpu bar=3 1000").await;
 
     let partition_key = "1970-01-01T00";
     let mb_chunk = db

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -38,7 +38,7 @@ parquet_file = { path = "../parquet_file" }
 query = { path = "../query" }
 rand = "0.8.3"
 rand_distr = "0.4.0"
-rdkafka = "0.26.0" # TODO: Put behind a feature?
+rdkafka = "0.26.0"
 read_buffer = { path = "../read_buffer" }
 serde = "1.0"
 serde_json = "1.0"

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -38,6 +38,7 @@ parquet_file = { path = "../parquet_file" }
 query = { path = "../query" }
 rand = "0.8.3"
 rand_distr = "0.4.0"
+rdkafka = "0.26.0" # TODO: Put behind a feature?
 read_buffer = { path = "../read_buffer" }
 serde = "1.0"
 serde_json = "1.0"

--- a/server/src/config.rs
+++ b/server/src/config.rs
@@ -255,7 +255,7 @@ impl Config {
         let write_buffer = rules
             .write_buffer_connection_string
             .as_ref()
-            .map(|conn| Arc::new(KafkaBuffer::new(conn)) as _);
+            .map(|conn| Arc::new(KafkaBuffer::new(conn, &name)) as _);
 
         let db = Arc::new(Db::new(
             rules,

--- a/server/src/config.rs
+++ b/server/src/config.rs
@@ -11,9 +11,8 @@ use query::exec::Executor;
 
 /// This module contains code for managing the configuration of the server.
 use crate::{
-    db::{catalog::Catalog, Db},
-    write_buffer::{self, WriteBuffer},
-    Error, JobRegistry, Result,
+    db::{catalog::Catalog, DatabaseToCommit, Db},
+    write_buffer, Error, JobRegistry, Result,
 };
 use observability_deps::tracing::{self, error, info, warn, Instrument};
 use tokio::task::JoinHandle;
@@ -231,34 +230,16 @@ impl Config {
     }
 
     /// Creates database in initialized state.
-    fn commit_db(
-        &self,
-        rules: DatabaseRules,
-        server_id: ServerId,
-        object_store: Arc<ObjectStore>,
-        exec: Arc<Executor>,
-        preserved_catalog: PreservedCatalog,
-        catalog: Catalog,
-        write_buffer: Option<Arc<dyn WriteBuffer>>,
-    ) {
+    fn commit_db(&self, database_to_commit: DatabaseToCommit) {
         let mut state = self.state.write().expect("mutex poisoned");
-        let name = rules.name.clone();
+        let name = database_to_commit.rules.name.clone();
 
         if self.shutdown.is_cancelled() {
             error!("server is shutting down");
             return;
         }
 
-        let db = Arc::new(Db::new(
-            rules,
-            server_id,
-            object_store,
-            exec,
-            Arc::clone(&self.jobs),
-            preserved_catalog,
-            catalog,
-            write_buffer,
-        ));
+        let db = Arc::new(Db::new(database_to_commit, Arc::clone(&self.jobs)));
 
         let shutdown = self.shutdown.child_token();
         let shutdown_captured = shutdown.clone();
@@ -439,34 +420,17 @@ impl<'a> CreateDatabaseHandle<'a> {
     ///
     /// Will fail if database name used to create this handle and the name within `rules` do not match. In this case,
     /// the database will be de-registered.
-    pub(crate) fn commit_db(
-        mut self,
-        server_id: ServerId,
-        object_store: Arc<ObjectStore>,
-        exec: Arc<Executor>,
-        preserved_catalog: PreservedCatalog,
-        catalog: Catalog,
-        rules: DatabaseRules,
-        write_buffer: Option<Arc<dyn WriteBuffer>>,
-    ) -> Result<()> {
+    pub(crate) fn commit_db(mut self, database_to_commit: DatabaseToCommit) -> Result<()> {
         let db_name = self.db_name.take().expect("not committed");
-        if db_name != rules.name {
+        if db_name != database_to_commit.rules.name {
             self.config.forget_reservation(&db_name);
             return Err(Error::RulesDatabaseNameMismatch {
-                actual: rules.name.to_string(),
+                actual: database_to_commit.rules.name.to_string(),
                 expected: db_name.to_string(),
             });
         }
 
-        self.config.commit_db(
-            rules,
-            server_id,
-            object_store,
-            exec,
-            preserved_catalog,
-            catalog,
-            write_buffer,
-        );
+        self.config.commit_db(database_to_commit);
 
         Ok(())
     }
@@ -554,15 +518,17 @@ impl<'a> RecoverDatabaseHandle<'a> {
         let write_buffer = write_buffer::new(&rules)
             .map_err(|e| Error::CreatingWriteBufferForWriting { source: e })?;
 
-        self.config.commit_db(
-            rules,
+        let database_to_commit = DatabaseToCommit {
             server_id,
             object_store,
             exec,
             preserved_catalog,
             catalog,
+            rules,
             write_buffer,
-        );
+        };
+
+        self.config.commit_db(database_to_commit);
 
         Ok(())
     }
@@ -650,17 +616,17 @@ mod test {
 
         {
             let db_reservation = config.create_db(DatabaseName::new("bar").unwrap()).unwrap();
-            let err = db_reservation
-                .commit_db(
-                    server_id,
-                    Arc::clone(&store),
-                    Arc::clone(&exec),
-                    preserved_catalog,
-                    catalog,
-                    rules.clone(),
-                    None,
-                )
-                .unwrap_err();
+            let database_to_commit = DatabaseToCommit {
+                server_id,
+                object_store: Arc::clone(&store),
+                exec: Arc::clone(&exec),
+                preserved_catalog,
+                catalog,
+                rules: rules.clone(),
+                write_buffer: None,
+            };
+
+            let err = db_reservation.commit_db(database_to_commit).unwrap_err();
             assert!(matches!(err, Error::RulesDatabaseNameMismatch { .. }));
         }
 
@@ -674,17 +640,16 @@ mod test {
         .await
         .unwrap();
         let db_reservation = config.create_db(name.clone()).unwrap();
-        db_reservation
-            .commit_db(
-                server_id,
-                store,
-                exec,
-                preserved_catalog,
-                catalog,
-                rules,
-                None,
-            )
-            .unwrap();
+        let database_to_commit = DatabaseToCommit {
+            server_id,
+            object_store: store,
+            exec,
+            preserved_catalog,
+            catalog,
+            rules,
+            write_buffer: None,
+        };
+        db_reservation.commit_db(database_to_commit).unwrap();
         assert!(config.db(&name).is_some());
         assert_eq!(config.db_names_sorted(), vec![name.clone()]);
 
@@ -863,17 +828,18 @@ mod test {
         )
         .await
         .unwrap();
-        db_reservation
-            .commit_db(
-                server_id,
-                store,
-                exec,
-                preserved_catalog,
-                catalog,
-                rules,
-                None,
-            )
-            .unwrap();
+
+        let database_to_commit = DatabaseToCommit {
+            server_id,
+            object_store: store,
+            exec,
+            preserved_catalog,
+            catalog,
+            rules,
+            write_buffer: None,
+        };
+
+        db_reservation.commit_db(database_to_commit).unwrap();
 
         let token = config
             .state

--- a/server/src/db.rs
+++ b/server/src/db.rs
@@ -862,7 +862,7 @@ impl Db {
     }
 
     /// Stores an entry based on the configuration.
-    pub fn store_entry(&self, entry: Entry) -> Result<()> {
+    pub async fn store_entry(&self, entry: Entry) -> Result<()> {
         let immutable = {
             let rules = self.rules.read();
             rules.lifecycle_rules.immutable
@@ -873,13 +873,19 @@ impl Db {
                 // If only the write buffer is configured, this is passing the data through to
                 // the write buffer, and it's not an error. We ignore the returned metadata; it
                 // will get picked up when data is read from the write buffer.
-                let _ = write_buffer.store_entry(&entry).context(WriteBufferError)?;
+                let _ = write_buffer
+                    .store_entry(&entry)
+                    .await
+                    .context(WriteBufferError)?;
                 Ok(())
             }
             (Some(write_buffer), false) => {
                 // If using both write buffer and mutable buffer, we want to wait for the write
                 // buffer to return success before adding the entry to the mutable buffer.
-                let sequence = write_buffer.store_entry(&entry).context(WriteBufferError)?;
+                let sequence = write_buffer
+                    .store_entry(&entry)
+                    .await
+                    .context(WriteBufferError)?;
                 let sequenced_entry = Arc::new(
                     SequencedEntry::new_from_sequence(sequence, entry)
                         .context(SequencedEntryError)?,
@@ -1169,23 +1175,20 @@ pub mod test_helpers {
     use std::collections::HashSet;
 
     /// Try to write lineprotocol data and return all tables that where written.
-    pub fn try_write_lp(db: &Db, lp: &str) -> Result<Vec<String>> {
+    pub async fn try_write_lp(db: &Db, lp: &str) -> Result<Vec<String>> {
         let entries = lp_to_entries(lp);
 
         let mut tables = HashSet::new();
-        for entry in &entries {
+        for entry in entries {
             if let Some(writes) = entry.partition_writes() {
                 for write in writes {
                     for batch in write.table_batches() {
                         tables.insert(batch.name().to_string());
                     }
                 }
+                db.store_entry(entry).await?;
             }
         }
-
-        entries
-            .into_iter()
-            .try_for_each(|entry| db.store_entry(entry))?;
 
         let mut tables: Vec<_> = tables.into_iter().collect();
         tables.sort();
@@ -1193,8 +1196,8 @@ pub mod test_helpers {
     }
 
     /// Same was [`try_write_lp`](try_write_lp) but will panic on failure.
-    pub fn write_lp(db: &Db, lp: &str) -> Vec<String> {
-        try_write_lp(db, lp).unwrap()
+    pub async fn write_lp(db: &Db, lp: &str) -> Vec<String> {
+        try_write_lp(db, lp).await.unwrap()
     }
 }
 
@@ -1251,7 +1254,7 @@ mod tests {
         let db = make_db().await.db;
         db.rules.write().lifecycle_rules.immutable = true;
         let entry = lp_to_entry("cpu bar=1 10");
-        let res = db.store_entry(entry);
+        let res = db.store_entry(entry).await;
         assert_contains!(
             res.unwrap_err().to_string(),
             "Cannot write to this database: no mutable buffer configured"
@@ -1272,7 +1275,7 @@ mod tests {
         test_db.rules.write().lifecycle_rules.immutable = true;
 
         let entry = lp_to_entry("cpu bar=1 10");
-        test_db.store_entry(entry).unwrap();
+        test_db.store_entry(entry).await.unwrap();
 
         assert_eq!(write_buffer.entries.lock().unwrap().len(), 1);
     }
@@ -1289,7 +1292,7 @@ mod tests {
             .db;
 
         let entry = lp_to_entry("cpu bar=1 10");
-        test_db.store_entry(entry).unwrap();
+        test_db.store_entry(entry).await.unwrap();
 
         assert_eq!(write_buffer.entries.lock().unwrap().len(), 1);
 
@@ -1310,7 +1313,7 @@ mod tests {
     async fn read_write() {
         // This test also exercises the path without a write buffer.
         let db = Arc::new(make_db().await.db);
-        write_lp(&db, "cpu bar=1 10");
+        write_lp(&db, "cpu bar=1 10").await;
 
         let batches = run_query(db, "select * from cpu").await;
 
@@ -1344,7 +1347,7 @@ mod tests {
         let test_db = make_db().await;
         let db = Arc::new(test_db.db);
 
-        write_lp(db.as_ref(), "cpu bar=1 10");
+        write_lp(db.as_ref(), "cpu bar=1 10").await;
 
         // A chunk has been opened
         test_db
@@ -1363,7 +1366,7 @@ mod tests {
         catalog_chunk_size_bytes_metric_eq(&test_db.metric_registry, "mutable_buffer", 44).unwrap();
 
         // write into same chunk again.
-        write_lp(db.as_ref(), "cpu bar=2 10");
+        write_lp(db.as_ref(), "cpu bar=2 10").await;
 
         // verify chunk size updated
         catalog_chunk_size_bytes_metric_eq(&test_db.metric_registry, "mutable_buffer", 60).unwrap();
@@ -1472,7 +1475,7 @@ mod tests {
     #[tokio::test]
     async fn write_with_rollover() {
         let db = Arc::new(make_db().await.db);
-        write_lp(db.as_ref(), "cpu bar=1 10");
+        write_lp(db.as_ref(), "cpu bar=1 10").await;
         assert_eq!(vec!["1970-01-01T00"], db.partition_keys().unwrap());
 
         let mb_chunk = db
@@ -1493,7 +1496,7 @@ mod tests {
         assert_batches_sorted_eq!(expected, &batches);
 
         // add new data
-        write_lp(db.as_ref(), "cpu bar=2 20");
+        write_lp(db.as_ref(), "cpu bar=2 20").await;
         let expected = vec![
             "+-----+-------------------------------+",
             "| bar | time                          |",
@@ -1530,7 +1533,7 @@ mod tests {
             "cpu,core=one user=10.0 11",
         ];
 
-        write_lp(db.as_ref(), &lines.join("\n"));
+        write_lp(db.as_ref(), &lines.join("\n")).await;
         assert_eq!(vec!["1970-01-01T00"], db.partition_keys().unwrap());
 
         let mb_chunk = db
@@ -1559,8 +1562,8 @@ mod tests {
         let test_db = make_db().await;
         let db = Arc::new(test_db.db);
 
-        write_lp(db.as_ref(), "cpu bar=1 10");
-        write_lp(db.as_ref(), "cpu bar=2 20");
+        write_lp(db.as_ref(), "cpu bar=1 10").await;
+        write_lp(db.as_ref(), "cpu bar=2 20").await;
 
         let partition_key = "1970-01-01T00";
         let mb_chunk = db
@@ -1645,12 +1648,12 @@ mod tests {
         let test_db = make_db().await;
         let db = Arc::new(test_db.db);
 
-        write_lp(db.as_ref(), "cpu,tag1=cupcakes bar=1 10");
-        write_lp(db.as_ref(), "cpu,tag1=asfd,tag2=foo bar=2 20");
-        write_lp(db.as_ref(), "cpu,tag1=bingo,tag2=foo bar=2 10");
-        write_lp(db.as_ref(), "cpu,tag1=bongo,tag2=a bar=2 20");
-        write_lp(db.as_ref(), "cpu,tag1=bongo,tag2=a bar=2 10");
-        write_lp(db.as_ref(), "cpu,tag2=a bar=3 5");
+        write_lp(db.as_ref(), "cpu,tag1=cupcakes bar=1 10").await;
+        write_lp(db.as_ref(), "cpu,tag1=asfd,tag2=foo bar=2 20").await;
+        write_lp(db.as_ref(), "cpu,tag1=bingo,tag2=foo bar=2 10").await;
+        write_lp(db.as_ref(), "cpu,tag1=bongo,tag2=a bar=2 20").await;
+        write_lp(db.as_ref(), "cpu,tag1=bongo,tag2=a bar=2 10").await;
+        write_lp(db.as_ref(), "cpu,tag2=a bar=3 5").await;
 
         let partition_key = "1970-01-01T00";
         let mb_chunk = db
@@ -1760,8 +1763,8 @@ mod tests {
         let db = Arc::new(test_db.db);
 
         // Write some line protocols in Mutable buffer of the DB
-        write_lp(db.as_ref(), "cpu bar=1 10");
-        write_lp(db.as_ref(), "cpu bar=2 20");
+        write_lp(db.as_ref(), "cpu bar=1 10").await;
+        write_lp(db.as_ref(), "cpu bar=2 20").await;
 
         //Now mark the MB chunk close
         let partition_key = "1970-01-01T00";
@@ -1859,8 +1862,8 @@ mod tests {
         let db = Arc::new(test_db.db);
 
         // Write some line protocols in Mutable buffer of the DB
-        write_lp(db.as_ref(), "cpu bar=1 10");
-        write_lp(db.as_ref(), "cpu bar=2 20");
+        write_lp(db.as_ref(), "cpu bar=1 10").await;
+        write_lp(db.as_ref(), "cpu bar=2 20").await;
 
         // Now mark the MB chunk close
         let partition_key = "1970-01-01T00";
@@ -1970,7 +1973,7 @@ mod tests {
         let before_create = Utc::now();
 
         let partition_key = "1970-01-01T00";
-        write_lp(&db, "cpu bar=1 10");
+        write_lp(&db, "cpu bar=1 10").await;
         let after_write = Utc::now();
 
         let last_write_prev = {
@@ -1983,7 +1986,7 @@ mod tests {
             partition.last_write_at()
         };
 
-        write_lp(&db, "cpu bar=1 20");
+        write_lp(&db, "cpu bar=1 20").await;
         {
             let partition = db.catalog.partition("cpu", partition_key).unwrap();
             let partition = partition.read();
@@ -1997,7 +2000,7 @@ mod tests {
         let db = Arc::new(make_db().await.db);
 
         // Given data loaded into two chunks
-        write_lp(&db, "cpu bar=1 10");
+        write_lp(&db, "cpu bar=1 10").await;
         let after_data_load = Utc::now();
 
         // When the chunk is rolled over
@@ -2035,8 +2038,8 @@ mod tests {
         db.rules.write().lifecycle_rules.mutable_size_threshold =
             Some(NonZeroUsize::new(2).unwrap());
 
-        write_lp(&db, "cpu bar=1 10");
-        write_lp(&db, "cpu bar=1 20");
+        write_lp(&db, "cpu bar=1 10").await;
+        write_lp(&db, "cpu bar=1 20").await;
 
         let partitions = db.catalog.partition_keys();
         assert_eq!(partitions.len(), 1);
@@ -2066,10 +2069,10 @@ mod tests {
     #[tokio::test]
     async fn chunks_sorted_by_times() {
         let db = Arc::new(make_db().await.db);
-        write_lp(&db, "cpu val=1 1");
-        write_lp(&db, "mem val=2 400000000000001");
-        write_lp(&db, "cpu val=1 2");
-        write_lp(&db, "mem val=2 400000000000002");
+        write_lp(&db, "cpu val=1 1").await;
+        write_lp(&db, "mem val=2 400000000000001").await;
+        write_lp(&db, "cpu val=1 2").await;
+        write_lp(&db, "mem val=2 400000000000002").await;
 
         let sort_rules = SortOrder {
             order: Order::Desc,
@@ -2101,8 +2104,8 @@ mod tests {
         let db = Arc::new(make_db().await.db);
         let partition_key = "1970-01-01T00";
 
-        write_lp(&db, "cpu bar=1 10");
-        write_lp(&db, "cpu bar=1 20");
+        write_lp(&db, "cpu bar=1 10").await;
+        write_lp(&db, "cpu bar=1 20").await;
 
         assert_eq!(mutable_chunk_ids(&db, partition_key), vec![0]);
         assert_eq!(
@@ -2120,7 +2123,7 @@ mod tests {
 
         // add a new chunk in mutable buffer, and move chunk1 (but
         // not chunk 0) to read buffer
-        write_lp(&db, "cpu bar=1 30");
+        write_lp(&db, "cpu bar=1 30").await;
         let mb_chunk = db
             .rollover_partition("cpu", "1970-01-01T00")
             .await
@@ -2130,7 +2133,7 @@ mod tests {
             .await
             .unwrap();
 
-        write_lp(&db, "cpu bar=1 40");
+        write_lp(&db, "cpu bar=1 40").await;
 
         assert_eq!(mutable_chunk_ids(&db, partition_key), vec![0, 2]);
         assert_eq!(read_buffer_chunk_ids(&db, partition_key), vec![1]);
@@ -2169,11 +2172,11 @@ mod tests {
         // Test that chunk id listing is hooked up
         let db = Arc::new(make_db().await.db);
 
-        write_lp(&db, "cpu bar=1 1");
+        write_lp(&db, "cpu bar=1 1").await;
         db.rollover_partition("cpu", "1970-01-01T00").await.unwrap();
 
         // write into a separate partitiion
-        write_lp(&db, "cpu bar=1,baz2,frob=3 400000000000000");
+        write_lp(&db, "cpu bar=1,baz2,frob=3 400000000000000").await;
 
         print!("Partitions: {:?}", db.partition_keys().unwrap());
 
@@ -2212,9 +2215,9 @@ mod tests {
     async fn partition_chunk_summaries_timestamp() {
         let db = Arc::new(make_db().await.db);
         let start = Utc::now();
-        write_lp(&db, "cpu bar=1 1");
+        write_lp(&db, "cpu bar=1 1").await;
         let after_first_write = Utc::now();
-        write_lp(&db, "cpu bar=2 2");
+        write_lp(&db, "cpu bar=2 2").await;
         db.rollover_partition("cpu", "1970-01-01T00").await.unwrap();
         let after_close = Utc::now();
 
@@ -2264,11 +2267,11 @@ mod tests {
         let db = Arc::new(make_db().await.db);
 
         // get three chunks: one open, one closed in mb and one close in rb
-        write_lp(&db, "cpu bar=1 1");
+        write_lp(&db, "cpu bar=1 1").await;
         db.rollover_partition("cpu", "1970-01-01T00").await.unwrap();
 
-        write_lp(&db, "cpu bar=1,baz=2 2");
-        write_lp(&db, "cpu bar=1,baz=2,frob=3 400000000000000");
+        write_lp(&db, "cpu bar=1,baz=2 2").await;
+        write_lp(&db, "cpu bar=1,baz=2,frob=3 400000000000000").await;
 
         print!("Partitions: {:?}", db.partition_keys().unwrap());
 
@@ -2283,7 +2286,7 @@ mod tests {
         print!("Partitions2: {:?}", db.partition_keys().unwrap());
 
         db.rollover_partition("cpu", "1970-01-05T15").await.unwrap();
-        write_lp(&db, "cpu bar=1,baz=3,blargh=3 400000000000000");
+        write_lp(&db, "cpu bar=1,baz=3,blargh=3 400000000000000").await;
 
         let chunk_summaries = db.chunk_summaries().expect("expected summary to return");
         let chunk_summaries = normalize_summaries(chunk_summaries);
@@ -2345,15 +2348,15 @@ mod tests {
         // Test that chunk id listing is hooked up
         let db = Arc::new(make_db().await.db);
 
-        write_lp(&db, "cpu bar=1 1");
+        write_lp(&db, "cpu bar=1 1").await;
         let chunk_id = db
             .rollover_partition("cpu", "1970-01-01T00")
             .await
             .unwrap()
             .unwrap()
             .id();
-        write_lp(&db, "cpu bar=2,baz=3.0 2");
-        write_lp(&db, "mem foo=1 1");
+        write_lp(&db, "cpu bar=2,baz=3.0 2").await;
+        write_lp(&db, "mem foo=1 1").await;
 
         // load a chunk to the read buffer
         db.load_chunk_to_read_buffer("cpu", "1970-01-01T00", chunk_id)
@@ -2366,8 +2369,8 @@ mod tests {
             .unwrap();
 
         // write into a separate partition
-        write_lp(&db, "cpu bar=1 400000000000000");
-        write_lp(&db, "mem frob=3 400000000000001");
+        write_lp(&db, "cpu bar=1 400000000000000").await;
+        write_lp(&db, "mem frob=3 400000000000001").await;
 
         print!("Partitions: {:?}", db.partition_keys().unwrap());
 
@@ -2532,8 +2535,8 @@ mod tests {
         let db = Arc::new(make_db().await.db);
 
         // create MB partition
-        write_lp(db.as_ref(), "cpu bar=1 10");
-        write_lp(db.as_ref(), "cpu bar=2 20");
+        write_lp(db.as_ref(), "cpu bar=1 10").await;
+        write_lp(db.as_ref(), "cpu bar=2 20").await;
 
         // MB => RB
         let partition_key = "1970-01-01T00";
@@ -2566,11 +2569,11 @@ mod tests {
         db.rules.write().lifecycle_rules.buffer_size_hard = Some(NonZeroUsize::new(10).unwrap());
 
         // inserting first line does not trigger hard buffer limit
-        write_lp(db.as_ref(), "cpu bar=1 10");
+        write_lp(db.as_ref(), "cpu bar=1 10").await;
 
         // but second line will
         assert!(matches!(
-            try_write_lp(db.as_ref(), "cpu bar=2 20"),
+            try_write_lp(db.as_ref(), "cpu bar=2 20").await,
             Err(super::Error::HardLimitReached {})
         ));
     }
@@ -2593,7 +2596,7 @@ mod tests {
 
         let db = Arc::new(test_db.db);
 
-        write_lp(db.as_ref(), "cpu bar=1 10");
+        write_lp(db.as_ref(), "cpu bar=1 10").await;
 
         test_db
             .metric_registry
@@ -2829,7 +2832,7 @@ mod tests {
         }
 
         // ==================== check: DB still writable ====================
-        write_lp(db.as_ref(), "cpu bar=1 10");
+        write_lp(db.as_ref(), "cpu bar=1 10").await;
     }
 
     #[tokio::test]
@@ -2996,7 +2999,7 @@ mod tests {
         }
 
         // ==================== check: DB still writable ====================
-        write_lp(db.as_ref(), "cpu bar=1 10");
+        write_lp(db.as_ref(), "cpu bar=1 10").await;
     }
 
     #[tokio::test]
@@ -3015,7 +3018,7 @@ mod tests {
     }
 
     async fn create_parquet_chunk(db: &Db) -> (String, String, u32) {
-        write_lp(db, "cpu bar=1 10");
+        write_lp(db, "cpu bar=1 10").await;
         let partition_key = "1970-01-01T00";
         let table_name = "cpu";
 

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -714,7 +714,7 @@ where
 
     pub async fn write_entry_local(&self, db_name: &str, db: &Db, entry: Entry) -> Result<()> {
         let bytes = entry.data().len() as u64;
-        db.store_entry(entry).map_err(|e| {
+        db.store_entry(entry).await.map_err(|e| {
             self.metrics.ingest_entries_bytes_total.add_with_labels(
                 bytes,
                 &[

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -207,6 +207,9 @@ pub enum Error {
 
     #[snafu(display("cannot get id: {}", source))]
     GetIdError { source: crate::init::Error },
+
+    #[snafu(display("cannot create write buffer for writing: {}", source))]
+    CreatingWriteBufferForWriting { source: DatabaseError },
 }
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -501,6 +501,9 @@ where
         .map_err(|e| Box::new(e) as _)
         .context(CatalogLoadError)?;
 
+        let write_buffer = write_buffer::new(&rules)
+            .map_err(|e| Error::CreatingWriteBufferForWriting { source: e })?;
+
         db_reservation.commit_db(
             server_id,
             Arc::clone(&self.store),
@@ -508,6 +511,7 @@ where
             preserved_catalog,
             catalog,
             rules,
+            write_buffer,
         )?;
 
         Ok(())

--- a/server/src/write_buffer.rs
+++ b/server/src/write_buffer.rs
@@ -1,17 +1,19 @@
+use async_trait::async_trait;
 use entry::{Entry, Sequence};
 
 /// A Write Buffer takes an `Entry` and returns `Sequence` data that facilitates reading entries
 /// from the Write Buffer at a later time.
+#[async_trait]
 pub trait WriteBuffer: Sync + Send + std::fmt::Debug + 'static {
     /// Send an `Entry` to the write buffer and return information that can be used to restore
     /// entries at a later time.
-    fn store_entry(
+    async fn store_entry(
         &self,
         entry: &Entry,
     ) -> Result<Sequence, Box<dyn std::error::Error + Sync + Send>>;
 
     // TODO: interface for restoring, will look something like:
-    // fn restore_from(&self, sequence: &Sequence) -> Result<Stream<Entry>, Err>;
+    // async fn restore_from(&self, sequence: &Sequence) -> Result<Stream<Entry>, Err>;
 }
 
 #[derive(Debug)]
@@ -19,8 +21,9 @@ pub struct KafkaBuffer {
     conn: String,
 }
 
+#[async_trait]
 impl WriteBuffer for KafkaBuffer {
-    fn store_entry(
+    async fn store_entry(
         &self,
         _entry: &Entry,
     ) -> Result<Sequence, Box<dyn std::error::Error + Sync + Send>> {
@@ -43,8 +46,9 @@ pub mod test_helpers {
         pub entries: Arc<Mutex<Vec<Entry>>>,
     }
 
+    #[async_trait]
     impl WriteBuffer for MockBuffer {
-        fn store_entry(
+        async fn store_entry(
             &self,
             entry: &Entry,
         ) -> Result<Sequence, Box<dyn std::error::Error + Sync + Send>> {

--- a/server/src/write_buffer.rs
+++ b/server/src/write_buffer.rs
@@ -19,6 +19,7 @@ pub trait WriteBuffer: Sync + Send + std::fmt::Debug + 'static {
 #[derive(Debug)]
 pub struct KafkaBuffer {
     conn: String,
+    database_name: String,
 }
 
 #[async_trait]
@@ -32,8 +33,11 @@ impl WriteBuffer for KafkaBuffer {
 }
 
 impl KafkaBuffer {
-    pub fn new(conn: impl Into<String>) -> Self {
-        Self { conn: conn.into() }
+    pub fn new(conn: impl Into<String>, database_name: impl Into<String>) -> Self {
+        Self {
+            conn: conn.into(),
+            database_name: database_name.into(),
+        }
     }
 }
 

--- a/server/src/write_buffer.rs
+++ b/server/src/write_buffer.rs
@@ -1,6 +1,7 @@
 use async_trait::async_trait;
 use entry::{Entry, Sequence};
 use rdkafka::{
+    error::KafkaError,
     producer::{FutureProducer, FutureRecord},
     ClientConfig,
 };
@@ -65,7 +66,10 @@ impl WriteBuffer for KafkaBuffer {
 }
 
 impl KafkaBuffer {
-    pub fn new(conn: impl Into<String>, database_name: impl Into<String>) -> Self {
+    pub fn new(
+        conn: impl Into<String>,
+        database_name: impl Into<String>,
+    ) -> Result<Self, KafkaError> {
         let conn = conn.into();
         let database_name = database_name.into();
 
@@ -73,13 +77,13 @@ impl KafkaBuffer {
         cfg.set("bootstrap.servers", &conn);
         cfg.set("message.timeout.ms", "5000");
 
-        let producer: FutureProducer = cfg.create().unwrap();
+        let producer: FutureProducer = cfg.create()?;
 
-        Self {
+        Ok(Self {
             conn,
             database_name,
             producer,
-        }
+        })
     }
 }
 

--- a/server/src/write_buffer.rs
+++ b/server/src/write_buffer.rs
@@ -1,16 +1,15 @@
 use async_trait::async_trait;
 use entry::{Entry, Sequence};
 
+pub type WriteBufferError = Box<dyn std::error::Error + Sync + Send>;
+
 /// A Write Buffer takes an `Entry` and returns `Sequence` data that facilitates reading entries
 /// from the Write Buffer at a later time.
 #[async_trait]
 pub trait WriteBuffer: Sync + Send + std::fmt::Debug + 'static {
     /// Send an `Entry` to the write buffer and return information that can be used to restore
     /// entries at a later time.
-    async fn store_entry(
-        &self,
-        entry: &Entry,
-    ) -> Result<Sequence, Box<dyn std::error::Error + Sync + Send>>;
+    async fn store_entry(&self, entry: &Entry) -> Result<Sequence, WriteBufferError>;
 
     // TODO: interface for restoring, will look something like:
     // async fn restore_from(&self, sequence: &Sequence) -> Result<Stream<Entry>, Err>;
@@ -24,10 +23,7 @@ pub struct KafkaBuffer {
 
 #[async_trait]
 impl WriteBuffer for KafkaBuffer {
-    async fn store_entry(
-        &self,
-        _entry: &Entry,
-    ) -> Result<Sequence, Box<dyn std::error::Error + Sync + Send>> {
+    async fn store_entry(&self, _entry: &Entry) -> Result<Sequence, WriteBufferError> {
         unimplemented!()
     }
 }
@@ -52,10 +48,7 @@ pub mod test_helpers {
 
     #[async_trait]
     impl WriteBuffer for MockBuffer {
-        async fn store_entry(
-            &self,
-            entry: &Entry,
-        ) -> Result<Sequence, Box<dyn std::error::Error + Sync + Send>> {
+        async fn store_entry(&self, entry: &Entry) -> Result<Sequence, WriteBufferError> {
             let mut entries = self.entries.lock().unwrap();
             let offset = entries.len() as u64;
             entries.push(entry.clone());

--- a/server_benchmarks/benches/catalog_persistence.rs
+++ b/server_benchmarks/benches/catalog_persistence.rs
@@ -73,7 +73,7 @@ async fn setup(object_store: Arc<ObjectStore>, done: &Mutex<bool>) {
     let partition_key = "1970-01-01T00";
 
     for chunk_id in 0..N_CHUNKS {
-        let table_names = write_lp(&db, &lp);
+        let table_names = write_lp(&db, &lp).await;
 
         for table_name in &table_names {
             db.rollover_partition(&table_name, partition_key)

--- a/tests/end_to_end_cases/write_buffer.rs
+++ b/tests/end_to_end_cases/write_buffer.rs
@@ -1,16 +1,13 @@
-use futures::{stream::FuturesUnordered, StreamExt};
+use crate::{
+    common::server_fixture::ServerFixture,
+    end_to_end_cases::scenario::{create_readable_database_plus, rand_name},
+};
+use entry::Entry;
 use rdkafka::{
-    admin::{AdminClient, AdminOptions, NewTopic, TopicReplication},
-    client::DefaultClientContext,
     consumer::{Consumer, StreamConsumer},
-    producer::{FutureProducer, FutureRecord},
     ClientConfig, Message, Offset, TopicPartitionList,
 };
-use std::{
-    array,
-    convert::TryInto,
-    time::{SystemTime, UNIX_EPOCH},
-};
+use std::convert::TryFrom;
 
 /// If `TEST_INTEGRATION` and `KAFKA_CONNECT` are set, return the Kafka connection URL to the
 /// caller.
@@ -56,111 +53,54 @@ macro_rules! maybe_skip_integration {
     }};
 }
 
-// This is the test I actually want to write but can't yet because the code doesn't exist
-// #[tokio::test]
-// async fn writes_go_to_kafka() {
-//     // start up kafka
-//
-//     // set up a database with a write buffer pointing at kafka
-//
-//     // write some points
-//
-//     // check the data is in kafka
-//
-//     // stop kafka
-// }
-
-// This test validates the Kafka/Docker Compose setup and that the Rust tests can use it
-
 #[tokio::test]
-async fn can_connect_to_kafka() {
-    // TODO: this should be the database name and managed by IOx
-    const TOPIC: &str = "my-topic22227";
-    // TODO: this should go away
-    const NUM_MSGS: usize = 10;
-
+async fn writes_go_to_kafka() {
     let kafka_connection = maybe_skip_integration!();
 
-    // connect to kafka, produce, and consume
+    // set up a database with a write buffer pointing at kafka
+    let server = ServerFixture::create_shared().await;
+    let db_name = rand_name();
+    let write_buffer_connection_string = kafka_connection.to_string();
+    create_readable_database_plus(&db_name, server.grpc_channel(), |mut rules| {
+        rules.write_buffer_connection_string = write_buffer_connection_string;
+        rules
+    })
+    .await;
+
+    // write some points
+    let mut write_client = server.write_client();
+
+    let lp_lines = [
+        "cpu,region=west user=23.2 100",
+        "cpu,region=west user=21.0 150",
+        "disk,region=east bytes=99i 200",
+    ];
+
+    let num_lines_written = write_client
+        .write(&db_name, lp_lines.join("\n"))
+        .await
+        .expect("cannot write");
+    assert_eq!(num_lines_written, 3);
+
+    // check the data is in kafka
     let mut cfg = ClientConfig::new();
     cfg.set("bootstrap.servers", kafka_connection);
+    cfg.set("session.timeout.ms", "6000");
+    cfg.set("enable.auto.commit", "false");
+    cfg.set("group.id", "placeholder");
 
-    let admin_cfg = cfg.clone();
-
-    let mut producer_cfg = cfg.clone();
-    producer_cfg.set("message.timeout.ms", "5000");
-
-    let mut consumer_cfg = cfg.clone();
-    consumer_cfg.set("session.timeout.ms", "6000");
-    consumer_cfg.set("enable.auto.commit", "false");
-    consumer_cfg.set("group.id", "placeholder");
-
-    let admin: AdminClient<DefaultClientContext> = admin_cfg.create().unwrap();
-    let producer: FutureProducer = producer_cfg.create().unwrap();
-    let consumer: StreamConsumer = consumer_cfg.create().unwrap();
-
-    let topic = NewTopic::new(TOPIC, 1, TopicReplication::Fixed(1));
-    let opts = AdminOptions::default();
-    admin.create_topics(&[topic], &opts).await.unwrap();
-
+    let consumer: StreamConsumer = cfg.create().unwrap();
     let mut topics = TopicPartitionList::new();
-    topics.add_partition(TOPIC, 0);
+    topics.add_partition(&db_name, 0);
     topics
-        .set_partition_offset(TOPIC, 0, Offset::Beginning)
+        .set_partition_offset(&db_name, 0, Offset::Beginning)
         .unwrap();
     consumer.assign(&topics).unwrap();
 
-    let consumer_task = tokio::spawn(async move {
-        eprintln!("Consumer task starting");
+    let message = consumer.recv().await.unwrap();
+    assert_eq!(message.topic(), db_name);
 
-        let mut counter = NUM_MSGS;
-
-        loop {
-            let p = consumer.recv().await.unwrap();
-            eprintln!("Received a {:?}", p.payload().map(String::from_utf8_lossy));
-            counter -= 1;
-            if counter == 0 {
-                break;
-            }
-        }
-        assert_eq!(counter, 0);
-        eprintln!("Exiting Consumer");
-    });
-
-    // TODO all the producing should move to server/src/write_buffer.rs
-    let producer_task = tokio::spawn(async move {
-        eprintln!("Producer task starting");
-        for i in 0..NUM_MSGS {
-            let s = format!("hello! {}", i);
-            let record = FutureRecord::to(TOPIC).key(&s).payload(&s).timestamp(now());
-            match producer.send_result(record) {
-                Ok(x) => match x.await.unwrap() {
-                    Ok((partition, offset)) => {
-                        // TODO remove all the dbg
-                        dbg!(&s, partition, offset);
-                    }
-                    Err((e, msg)) => panic!("oh no {}, {:?}", e, msg),
-                },
-                Err((e, msg)) => panic!("oh no {}, {:?}", e, msg),
-            }
-            eprintln!("Sent {}", i);
-        }
-        eprintln!("exiting producer");
-    });
-
-    let mut tasks: FuturesUnordered<_> =
-        array::IntoIter::new([consumer_task, producer_task]).collect();
-
-    while let Some(t) = tasks.next().await {
-        t.unwrap();
-    }
-}
-
-fn now() -> i64 {
-    SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap()
-        .as_millis()
-        .try_into()
-        .unwrap()
+    let entry = Entry::try_from(message.payload().unwrap().to_vec()).unwrap();
+    let partition_writes = entry.partition_writes().unwrap();
+    assert_eq!(partition_writes.len(), 2);
 }


### PR DESCRIPTION
This PR lets you configure a write buffer for a database to write to, and when you've done that, the entry will be written to the write buffer and the sequence sent to the mutable buffer.

This does not handle consuming data from Kafka as it's written or restoring from Kafka.