### PR TITLE
chore: Add proper format for SchemaPivotNode

### DIFF
--- a/query/src/exec/schema_pivot.rs
+++ b/query/src/exec/schema_pivot.rs
@@ -36,8 +36,8 @@ use datafusion::{
     error::{DataFusionError as Error, Result},
     logical_plan::{self, DFSchemaRef, Expr, LogicalPlan, ToDFSchema, UserDefinedLogicalNode},
     physical_plan::{
-        common::SizedRecordBatchStream, Distribution, ExecutionPlan, Partitioning,
-        SendableRecordBatchStream,
+        common::SizedRecordBatchStream, DisplayFormatType, Distribution, ExecutionPlan,
+        Partitioning, SendableRecordBatchStream,
     },
 };
 
@@ -279,6 +279,14 @@ impl ExecutionPlan for SchemaPivotExec {
             self.schema(),
             batches,
         )))
+    }
+
+    fn fmt_as(&self, t: DisplayFormatType, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match t {
+            DisplayFormatType::Default => {
+                write!(f, "SchemaPivotExec")
+            }
+        }
     }
 }
 


### PR DESCRIPTION
# Rationale:

The physical plan with one of our extensions printed out by DataFusion looks like this:

```
ExecutionPlan(PlaceHolder)
  ProjectionExec: expr=[borough, city, state]
    RepartitionExec: partitioning=RoundRobinBatch(16)
      IOxReadFilterNode: table_name=o2, chunks=2 predicate=Predicate
```

`ExecutionPlan(PlaceHolder)` is where the `SchemaPivotExec` is but we haven't provided a nice display for it

# Changes
1. Add custom formatting for `SchemaPivotExec` so that it looks more like:

```
SchemaPivotExec
  ProjectionExec: expr=[borough, city, state]
    RepartitionExec: partitioning=RoundRobinBatch(16)
      IOxReadFilterNode: table_name=o2, chunks=2 predicate=Predicate
```
