### PR TITLE
refactor: add ChunkAddr to describe location of chunk in catalog

### DIFF
--- a/data_types/src/chunk_metadata.rs
+++ b/data_types/src/chunk_metadata.rs
@@ -4,9 +4,9 @@ use std::sync::Arc;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
-/// Path to the chunk within the catalog
+/// Address of the chunk within the catalog
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
-pub struct ChunkPath {
+pub struct ChunkAddr {
     /// Database name
     pub db_name: Arc<str>,
 
@@ -20,7 +20,7 @@ pub struct ChunkPath {
     pub chunk_id: u32,
 }
 
-impl std::fmt::Display for ChunkPath {
+impl std::fmt::Display for ChunkAddr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,

--- a/data_types/src/chunk_metadata.rs
+++ b/data_types/src/chunk_metadata.rs
@@ -4,6 +4,32 @@ use std::sync::Arc;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
+/// Path to the chunk within the catalog
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+pub struct ChunkPath {
+    /// Database name
+    pub db_name: Arc<str>,
+
+    /// What table does the chunk belong to?
+    pub table_name: Arc<str>,
+
+    /// What partition does the chunk belong to?
+    pub partition_key: Arc<str>,
+
+    /// The ID of the chunk
+    pub chunk_id: u32,
+}
+
+impl std::fmt::Display for ChunkPath {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "Chunk('{}':'{}':'{}':{})",
+            self.db_name, self.table_name, self.partition_key, self.chunk_id
+        )
+    }
+}
+
 /// Which storage system is a chunk located in?
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Serialize, Deserialize)]
 pub enum ChunkStorage {

--- a/parquet_file/src/catalog.rs
+++ b/parquet_file/src/catalog.rs
@@ -221,7 +221,7 @@ pub trait CatalogState {
     type EmptyInput: Send;
 
     /// Create empty state w/o any known files.
-    fn new_empty(data: Self::EmptyInput) -> Self;
+    fn new_empty(db_name: &str, data: Self::EmptyInput) -> Self;
 
     /// Helper struct that can be used to remember/cache actions that happened during a transaction.
     ///
@@ -363,7 +363,7 @@ where
 
         let inner = PreservedCatalogInner {
             previous_tkey: None,
-            state: Arc::new(S::new_empty(state_data)),
+            state: Arc::new(S::new_empty(&db_name, state_data)),
         };
 
         let catalog = Self {
@@ -445,7 +445,7 @@ where
         }
 
         // setup empty state
-        let mut state = Arc::new(CatalogState::new_empty(state_data));
+        let mut state = Arc::new(CatalogState::new_empty(&db_name, state_data));
         let mut last_tkey = None;
 
         // detect replay start
@@ -1284,7 +1284,7 @@ where
 pub mod test_helpers {
     use object_store::parsed_path;
 
-    use crate::test_utils::{make_metadata, make_object_store};
+    use crate::test_utils::{chunk_path, make_metadata, make_object_store};
 
     use super::*;
     use std::{convert::TryFrom, ops::Deref};
@@ -1305,7 +1305,7 @@ pub mod test_helpers {
     impl CatalogState for TestCatalogState {
         type EmptyInput = ();
 
-        fn new_empty(_data: Self::EmptyInput) -> Self {
+        fn new_empty(_db_name: &str, _data: Self::EmptyInput) -> Self {
             Self {
                 parquet_files: HashMap::new(),
             }
@@ -1424,7 +1424,7 @@ pub mod test_helpers {
 
             for chunk_id in 0..chunk_id_watermark {
                 let path = parsed_path!(format!("chunk_{}", chunk_id).as_ref());
-                let (_, metadata) = make_metadata(&object_store, "ok", chunk_id).await;
+                let (_, metadata) = make_metadata(&object_store, "ok", chunk_path(chunk_id)).await;
                 transaction.add_parquet(&path, &metadata).unwrap();
                 expected.insert(path, Arc::new(metadata));
             }
@@ -1450,7 +1450,8 @@ pub mod test_helpers {
             let mut transaction = catalog.open_transaction().await;
 
             let path = parsed_path!(format!("chunk_{}", chunk_id_watermark).as_ref());
-            let (_, metadata) = make_metadata(&object_store, "ok", chunk_id_watermark).await;
+            let (_, metadata) =
+                make_metadata(&object_store, "ok", chunk_path(chunk_id_watermark)).await;
             transaction.add_parquet(&path, &metadata).unwrap();
             transaction.remove_parquet(&path).unwrap();
             chunk_id_watermark += 1;
@@ -1464,7 +1465,7 @@ pub mod test_helpers {
             let mut transaction = catalog.open_transaction().await;
 
             let path = parsed_path!("chunk_2");
-            let (_, metadata) = make_metadata(&object_store, "ok", 2).await;
+            let (_, metadata) = make_metadata(&object_store, "ok", chunk_path(2)).await;
             transaction.remove_parquet(&path).unwrap();
             transaction.add_parquet(&path, &metadata).unwrap();
 
@@ -1477,7 +1478,8 @@ pub mod test_helpers {
             let mut transaction = catalog.open_transaction().await;
 
             let path = parsed_path!(format!("chunk_{}", chunk_id_watermark).as_ref());
-            let (_, metadata) = make_metadata(&object_store, "ok", chunk_id_watermark).await;
+            let (_, metadata) =
+                make_metadata(&object_store, "ok", chunk_path(chunk_id_watermark)).await;
             transaction.add_parquet(&path, &metadata).unwrap();
             transaction.remove_parquet(&path).unwrap();
             transaction.add_parquet(&path, &metadata).unwrap();
@@ -1493,7 +1495,7 @@ pub mod test_helpers {
             let mut transaction = catalog.open_transaction().await;
 
             let path = parsed_path!("chunk_2");
-            let (_, metadata) = make_metadata(&object_store, "ok", 2).await;
+            let (_, metadata) = make_metadata(&object_store, "ok", chunk_path(2)).await;
             transaction.remove_parquet(&path).unwrap();
             transaction.add_parquet(&path, &metadata).unwrap();
             transaction.remove_parquet(&path).unwrap();
@@ -1509,7 +1511,7 @@ pub mod test_helpers {
 
             // already exists (should also not change the metadata)
             let path = parsed_path!("chunk_0");
-            let (_, metadata) = make_metadata(&object_store, "fail", 0).await;
+            let (_, metadata) = make_metadata(&object_store, "fail", chunk_path(0)).await;
             let err = transaction.add_parquet(&path, &metadata).unwrap_err();
             assert!(matches!(err, Error::ParquetFileAlreadyExists { .. }));
 
@@ -1529,13 +1531,14 @@ pub mod test_helpers {
 
             // already exists (should also not change the metadata)
             let path = parsed_path!("chunk_0");
-            let (_, metadata) = make_metadata(&object_store, "fail", 0).await;
+            let (_, metadata) = make_metadata(&object_store, "fail", chunk_path(0)).await;
             let err = transaction.add_parquet(&path, &metadata).unwrap_err();
             assert!(matches!(err, Error::ParquetFileAlreadyExists { .. }));
 
             // this transaction will still work
             let path = parsed_path!(format!("chunk_{}", chunk_id_watermark).as_ref());
-            let (_, metadata) = make_metadata(&object_store, "ok", chunk_id_watermark).await;
+            let (_, metadata) =
+                make_metadata(&object_store, "ok", chunk_path(chunk_id_watermark)).await;
             transaction.add_parquet(&path, &metadata).unwrap();
             expected.insert(path.clone(), Arc::new(metadata.clone()));
             chunk_id_watermark += 1;
@@ -1569,7 +1572,8 @@ pub mod test_helpers {
 
             // add
             let path = parsed_path!(format!("chunk_{}", chunk_id_watermark).as_ref());
-            let (_, metadata) = make_metadata(&object_store, "ok", chunk_id_watermark).await;
+            let (_, metadata) =
+                make_metadata(&object_store, "ok", chunk_path(chunk_id_watermark)).await;
             transaction.add_parquet(&path, &metadata).unwrap();
             chunk_id_watermark += 1;
 
@@ -1579,7 +1583,8 @@ pub mod test_helpers {
 
             // add and remove
             let path = parsed_path!(format!("chunk_{}", chunk_id_watermark).as_ref());
-            let (_, metadata) = make_metadata(&object_store, "ok", chunk_id_watermark).await;
+            let (_, metadata) =
+                make_metadata(&object_store, "ok", chunk_path(chunk_id_watermark)).await;
             transaction.add_parquet(&path, &metadata).unwrap();
             transaction.remove_parquet(&path).unwrap();
             chunk_id_watermark += 1;
@@ -1592,7 +1597,7 @@ pub mod test_helpers {
 
             // already exists (should also not change the metadata)
             let path = parsed_path!("chunk_0");
-            let (_, metadata) = make_metadata(&object_store, "fail", 0).await;
+            let (_, metadata) = make_metadata(&object_store, "fail", chunk_path(0)).await;
             let err = transaction.add_parquet(&path, &metadata).unwrap_err();
             assert!(matches!(err, Error::ParquetFileAlreadyExists { .. }));
 
@@ -1651,7 +1656,7 @@ pub mod test_helpers {
 mod tests {
     use std::{num::NonZeroU32, ops::Deref};
 
-    use crate::test_utils::{make_metadata, make_object_store};
+    use crate::test_utils::{chunk_path, make_metadata, make_object_store};
     use object_store::parsed_path;
 
     use super::test_helpers::{
@@ -2555,8 +2560,9 @@ mod tests {
     async fn test_checkpoint() {
         let object_store = make_object_store();
         let server_id = make_server_id();
-        let db_name = "db1";
-        let (_, metadata) = make_metadata(&object_store, "foo", 1337).await;
+        let path = chunk_path(1337);
+        let db_name = &path.db_name;
+        let (_, metadata) = make_metadata(&object_store, "foo", path.clone()).await;
 
         // use common test as baseline
         let mut trace = assert_single_catalog_inmem_works(&object_store, server_id, db_name).await;
@@ -2747,8 +2753,8 @@ mod tests {
         .unwrap();
 
         // get some test metadata
-        let (_, metadata1) = make_metadata(object_store, "foo", 1).await;
-        let (_, metadata2) = make_metadata(object_store, "bar", 1).await;
+        let (_, metadata1) = make_metadata(object_store, "foo", chunk_path(1)).await;
+        let (_, metadata2) = make_metadata(object_store, "bar", chunk_path(1)).await;
 
         // track all the intermediate results
         let mut trace = TestTrace::new();

--- a/parquet_file/src/catalog.rs
+++ b/parquet_file/src/catalog.rs
@@ -2560,9 +2560,9 @@ mod tests {
     async fn test_checkpoint() {
         let object_store = make_object_store();
         let server_id = make_server_id();
-        let path = chunk_addr(1337);
-        let db_name = &path.db_name;
-        let (_, metadata) = make_metadata(&object_store, "foo", path.clone()).await;
+        let addr = chunk_addr(1337);
+        let db_name = &addr.db_name;
+        let (_, metadata) = make_metadata(&object_store, "foo", addr.clone()).await;
 
         // use common test as baseline
         let mut trace = assert_single_catalog_inmem_works(&object_store, server_id, db_name).await;

--- a/parquet_file/src/cleanup.rs
+++ b/parquet_file/src/cleanup.rs
@@ -127,7 +127,7 @@ struct TracerCatalogState {
 impl CatalogState for TracerCatalogState {
     type EmptyInput = ();
 
-    fn new_empty(_data: Self::EmptyInput) -> Self {
+    fn new_empty(_db_name: &str, _data: Self::EmptyInput) -> Self {
         Self {
             files: Default::default(),
         }
@@ -182,7 +182,7 @@ mod tests {
     use super::*;
     use crate::{
         catalog::test_helpers::TestCatalogState,
-        test_utils::{make_metadata, make_object_store},
+        test_utils::{chunk_path, db_name, make_metadata, make_object_store},
     };
 
     #[tokio::test]
@@ -210,7 +210,7 @@ mod tests {
     async fn test_cleanup_rules() {
         let object_store = make_object_store();
         let server_id = make_server_id();
-        let db_name = "db1";
+        let db_name = db_name();
 
         let catalog = PreservedCatalog::<TestCatalogState>::new_empty(
             Arc::clone(&object_store),
@@ -228,12 +228,12 @@ mod tests {
             let mut transaction = catalog.open_transaction().await;
 
             // an ordinary tracked parquet file => keep
-            let (path, md) = make_metadata(&object_store, "foo", 1).await;
+            let (path, md) = make_metadata(&object_store, "foo", chunk_path(1)).await;
             transaction.add_parquet(&path.clone().into(), &md).unwrap();
             paths_keep.push(path.display());
 
             // another ordinary tracked parquet file that was added and removed => keep (for time travel)
-            let (path, md) = make_metadata(&object_store, "foo", 2).await;
+            let (path, md) = make_metadata(&object_store, "foo", chunk_path(2)).await;
             transaction.add_parquet(&path.clone().into(), &md).unwrap();
             transaction.remove_parquet(&path.clone().into()).unwrap();
             paths_keep.push(path.display());
@@ -246,7 +246,7 @@ mod tests {
             paths_keep.push(path.display());
 
             // an untracked parquet file => delete
-            let (path, _md) = make_metadata(&object_store, "foo", 3).await;
+            let (path, _md) = make_metadata(&object_store, "foo", chunk_path(3)).await;
             paths_delete.push(path.display());
 
             transaction.commit(false).await.unwrap();
@@ -271,7 +271,7 @@ mod tests {
     async fn test_cleanup_with_parallel_transaction() {
         let object_store = make_object_store();
         let server_id = make_server_id();
-        let db_name = "db1";
+        let db_name = db_name();
 
         let catalog = PreservedCatalog::<TestCatalogState>::new_empty(
             Arc::clone(&object_store),
@@ -288,7 +288,7 @@ mod tests {
                 async {
                     let mut transaction = catalog.open_transaction().await;
 
-                    let (path, md) = make_metadata(&object_store, "foo", i).await;
+                    let (path, md) = make_metadata(&object_store, "foo", chunk_path(i)).await;
                     transaction.add_parquet(&path.clone().into(), &md).unwrap();
 
                     transaction.commit(false).await.unwrap();
@@ -311,7 +311,7 @@ mod tests {
     async fn test_cleanup_max_files() {
         let object_store = make_object_store();
         let server_id = make_server_id();
-        let db_name = "db1";
+        let db_name = db_name();
 
         let catalog = PreservedCatalog::<TestCatalogState>::new_empty(
             Arc::clone(&object_store),
@@ -325,7 +325,7 @@ mod tests {
         // create some files
         let mut to_remove: HashSet<String> = Default::default();
         for chunk_id in 0..3 {
-            let (path, _md) = make_metadata(&object_store, "foo", chunk_id).await;
+            let (path, _md) = make_metadata(&object_store, "foo", chunk_path(chunk_id)).await;
             to_remove.insert(path.display());
         }
 

--- a/parquet_file/src/cleanup.rs
+++ b/parquet_file/src/cleanup.rs
@@ -182,7 +182,7 @@ mod tests {
     use super::*;
     use crate::{
         catalog::test_helpers::TestCatalogState,
-        test_utils::{chunk_path, db_name, make_metadata, make_object_store},
+        test_utils::{chunk_addr, db_name, make_metadata, make_object_store},
     };
 
     #[tokio::test]
@@ -228,12 +228,12 @@ mod tests {
             let mut transaction = catalog.open_transaction().await;
 
             // an ordinary tracked parquet file => keep
-            let (path, md) = make_metadata(&object_store, "foo", chunk_path(1)).await;
+            let (path, md) = make_metadata(&object_store, "foo", chunk_addr(1)).await;
             transaction.add_parquet(&path.clone().into(), &md).unwrap();
             paths_keep.push(path.display());
 
             // another ordinary tracked parquet file that was added and removed => keep (for time travel)
-            let (path, md) = make_metadata(&object_store, "foo", chunk_path(2)).await;
+            let (path, md) = make_metadata(&object_store, "foo", chunk_addr(2)).await;
             transaction.add_parquet(&path.clone().into(), &md).unwrap();
             transaction.remove_parquet(&path.clone().into()).unwrap();
             paths_keep.push(path.display());
@@ -246,7 +246,7 @@ mod tests {
             paths_keep.push(path.display());
 
             // an untracked parquet file => delete
-            let (path, _md) = make_metadata(&object_store, "foo", chunk_path(3)).await;
+            let (path, _md) = make_metadata(&object_store, "foo", chunk_addr(3)).await;
             paths_delete.push(path.display());
 
             transaction.commit(false).await.unwrap();
@@ -288,7 +288,7 @@ mod tests {
                 async {
                     let mut transaction = catalog.open_transaction().await;
 
-                    let (path, md) = make_metadata(&object_store, "foo", chunk_path(i)).await;
+                    let (path, md) = make_metadata(&object_store, "foo", chunk_addr(i)).await;
                     transaction.add_parquet(&path.clone().into(), &md).unwrap();
 
                     transaction.commit(false).await.unwrap();
@@ -325,7 +325,7 @@ mod tests {
         // create some files
         let mut to_remove: HashSet<String> = Default::default();
         for chunk_id in 0..3 {
-            let (path, _md) = make_metadata(&object_store, "foo", chunk_path(chunk_id)).await;
+            let (path, _md) = make_metadata(&object_store, "foo", chunk_addr(chunk_id)).await;
             to_remove.insert(path.display());
         }
 

--- a/parquet_file/src/metadata.rs
+++ b/parquet_file/src/metadata.rs
@@ -566,14 +566,14 @@ mod tests {
     use internal_types::{schema::TIME_COLUMN_NAME, selection::Selection};
 
     use crate::test_utils::{
-        chunk_path, load_parquet_from_store, make_chunk, make_chunk_no_row_group, make_object_store,
+        chunk_addr, load_parquet_from_store, make_chunk, make_chunk_no_row_group, make_object_store,
     };
 
     #[tokio::test]
     async fn test_restore_from_file() {
         // setup: preserve chunk to object store
         let store = make_object_store();
-        let chunk = make_chunk(Arc::clone(&store), "foo", chunk_path(1)).await;
+        let chunk = make_chunk(Arc::clone(&store), "foo", chunk_addr(1)).await;
         let (table, parquet_data) = load_parquet_from_store(&chunk, store).await.unwrap();
         let parquet_metadata = IoxParquetMetaData::from_file_bytes(parquet_data).unwrap();
 
@@ -594,7 +594,7 @@ mod tests {
     async fn test_restore_from_thrift() {
         // setup: write chunk to object store and only keep thrift-encoded metadata
         let store = make_object_store();
-        let chunk = make_chunk(Arc::clone(&store), "foo", chunk_path(1)).await;
+        let chunk = make_chunk(Arc::clone(&store), "foo", chunk_addr(1)).await;
         let (table, parquet_data) = load_parquet_from_store(&chunk, store).await.unwrap();
         let parquet_metadata = IoxParquetMetaData::from_file_bytes(parquet_data).unwrap();
         let data = parquet_metadata.to_thrift().unwrap();
@@ -617,7 +617,7 @@ mod tests {
     async fn test_restore_from_file_no_row_group() {
         // setup: preserve chunk to object store
         let store = make_object_store();
-        let chunk = make_chunk_no_row_group(Arc::clone(&store), "foo", chunk_path(1)).await;
+        let chunk = make_chunk_no_row_group(Arc::clone(&store), "foo", chunk_addr(1)).await;
         let (table, parquet_data) = load_parquet_from_store(&chunk, store).await.unwrap();
         let parquet_metadata = IoxParquetMetaData::from_file_bytes(parquet_data).unwrap();
 
@@ -638,7 +638,7 @@ mod tests {
     async fn test_restore_from_thrift_no_row_group() {
         // setup: write chunk to object store and only keep thrift-encoded metadata
         let store = make_object_store();
-        let chunk = make_chunk_no_row_group(Arc::clone(&store), "foo", chunk_path(1)).await;
+        let chunk = make_chunk_no_row_group(Arc::clone(&store), "foo", chunk_addr(1)).await;
         let (table, parquet_data) = load_parquet_from_store(&chunk, store).await.unwrap();
         let parquet_metadata = IoxParquetMetaData::from_file_bytes(parquet_data).unwrap();
         let data = parquet_metadata.to_thrift().unwrap();
@@ -660,7 +660,7 @@ mod tests {
     #[tokio::test]
     async fn test_make_chunk() {
         let store = make_object_store();
-        let chunk = make_chunk(Arc::clone(&store), "foo", chunk_path(1)).await;
+        let chunk = make_chunk(Arc::clone(&store), "foo", chunk_addr(1)).await;
         let (_, parquet_data) = load_parquet_from_store(&chunk, store).await.unwrap();
         let parquet_metadata = IoxParquetMetaData::from_file_bytes(parquet_data).unwrap();
 
@@ -700,7 +700,7 @@ mod tests {
     #[tokio::test]
     async fn test_make_chunk_no_row_group() {
         let store = make_object_store();
-        let chunk = make_chunk_no_row_group(Arc::clone(&store), "foo", chunk_path(1)).await;
+        let chunk = make_chunk_no_row_group(Arc::clone(&store), "foo", chunk_addr(1)).await;
         let (_, parquet_data) = load_parquet_from_store(&chunk, store).await.unwrap();
         let parquet_metadata = IoxParquetMetaData::from_file_bytes(parquet_data).unwrap();
 

--- a/parquet_file/src/metadata.rs
+++ b/parquet_file/src/metadata.rs
@@ -566,14 +566,14 @@ mod tests {
     use internal_types::{schema::TIME_COLUMN_NAME, selection::Selection};
 
     use crate::test_utils::{
-        load_parquet_from_store, make_chunk, make_chunk_no_row_group, make_object_store,
+        chunk_path, load_parquet_from_store, make_chunk, make_chunk_no_row_group, make_object_store,
     };
 
     #[tokio::test]
     async fn test_restore_from_file() {
         // setup: preserve chunk to object store
         let store = make_object_store();
-        let chunk = make_chunk(Arc::clone(&store), "foo", 1).await;
+        let chunk = make_chunk(Arc::clone(&store), "foo", chunk_path(1)).await;
         let (table, parquet_data) = load_parquet_from_store(&chunk, store).await.unwrap();
         let parquet_metadata = IoxParquetMetaData::from_file_bytes(parquet_data).unwrap();
 
@@ -594,7 +594,7 @@ mod tests {
     async fn test_restore_from_thrift() {
         // setup: write chunk to object store and only keep thrift-encoded metadata
         let store = make_object_store();
-        let chunk = make_chunk(Arc::clone(&store), "foo", 1).await;
+        let chunk = make_chunk(Arc::clone(&store), "foo", chunk_path(1)).await;
         let (table, parquet_data) = load_parquet_from_store(&chunk, store).await.unwrap();
         let parquet_metadata = IoxParquetMetaData::from_file_bytes(parquet_data).unwrap();
         let data = parquet_metadata.to_thrift().unwrap();
@@ -617,7 +617,7 @@ mod tests {
     async fn test_restore_from_file_no_row_group() {
         // setup: preserve chunk to object store
         let store = make_object_store();
-        let chunk = make_chunk_no_row_group(Arc::clone(&store), "foo", 1).await;
+        let chunk = make_chunk_no_row_group(Arc::clone(&store), "foo", chunk_path(1)).await;
         let (table, parquet_data) = load_parquet_from_store(&chunk, store).await.unwrap();
         let parquet_metadata = IoxParquetMetaData::from_file_bytes(parquet_data).unwrap();
 
@@ -638,7 +638,7 @@ mod tests {
     async fn test_restore_from_thrift_no_row_group() {
         // setup: write chunk to object store and only keep thrift-encoded metadata
         let store = make_object_store();
-        let chunk = make_chunk_no_row_group(Arc::clone(&store), "foo", 1).await;
+        let chunk = make_chunk_no_row_group(Arc::clone(&store), "foo", chunk_path(1)).await;
         let (table, parquet_data) = load_parquet_from_store(&chunk, store).await.unwrap();
         let parquet_metadata = IoxParquetMetaData::from_file_bytes(parquet_data).unwrap();
         let data = parquet_metadata.to_thrift().unwrap();
@@ -660,7 +660,7 @@ mod tests {
     #[tokio::test]
     async fn test_make_chunk() {
         let store = make_object_store();
-        let chunk = make_chunk(Arc::clone(&store), "foo", 1).await;
+        let chunk = make_chunk(Arc::clone(&store), "foo", chunk_path(1)).await;
         let (_, parquet_data) = load_parquet_from_store(&chunk, store).await.unwrap();
         let parquet_metadata = IoxParquetMetaData::from_file_bytes(parquet_data).unwrap();
 
@@ -700,7 +700,7 @@ mod tests {
     #[tokio::test]
     async fn test_make_chunk_no_row_group() {
         let store = make_object_store();
-        let chunk = make_chunk_no_row_group(Arc::clone(&store), "foo", 1).await;
+        let chunk = make_chunk_no_row_group(Arc::clone(&store), "foo", chunk_path(1)).await;
         let (_, parquet_data) = load_parquet_from_store(&chunk, store).await.unwrap();
         let parquet_metadata = IoxParquetMetaData::from_file_bytes(parquet_data).unwrap();
 

--- a/parquet_file/src/storage_testing.rs
+++ b/parquet_file/src/storage_testing.rs
@@ -12,7 +12,7 @@ mod tests {
     use crate::{
         metadata::IoxParquetMetaData,
         test_utils::{
-            load_parquet_from_store, make_chunk_given_record_batch, make_object_store,
+            chunk_path, load_parquet_from_store, make_chunk_given_record_batch, make_object_store,
             make_record_batch, read_data_from_parquet_data,
         },
     };
@@ -21,10 +21,10 @@ mod tests {
     async fn test_write_read() {
         ////////////////////
         // Create test data which is also the expected data
-        let table = "table1";
-        let chunk_id = 1;
+        let path = chunk_path(1);
+        let table = Arc::clone(&path.table_name);
         let (record_batches, schema, column_summaries, num_rows) = make_record_batch("foo");
-        let mut table_summary = TableSummary::new(table);
+        let mut table_summary = TableSummary::new(table.to_string());
         table_summary.columns = column_summaries.clone();
         let record_batch = record_batches[0].clone(); // Get the first one to compare key-value meta data that would be the same for all batches
         let key_value_metadata = record_batch.schema().metadata().clone();
@@ -40,9 +40,8 @@ mod tests {
             Arc::clone(&store),
             record_batches.clone(),
             schema.clone(),
-            table,
+            path,
             column_summaries.clone(),
-            chunk_id,
         )
         .await;
 

--- a/parquet_file/src/storage_testing.rs
+++ b/parquet_file/src/storage_testing.rs
@@ -21,8 +21,8 @@ mod tests {
     async fn test_write_read() {
         ////////////////////
         // Create test data which is also the expected data
-        let path = chunk_addr(1);
-        let table = Arc::clone(&path.table_name);
+        let addr = chunk_addr(1);
+        let table = Arc::clone(&addr.table_name);
         let (record_batches, schema, column_summaries, num_rows) = make_record_batch("foo");
         let mut table_summary = TableSummary::new(table.to_string());
         table_summary.columns = column_summaries.clone();
@@ -40,7 +40,7 @@ mod tests {
             Arc::clone(&store),
             record_batches.clone(),
             schema.clone(),
-            path,
+            addr,
             column_summaries.clone(),
         )
         .await;

--- a/parquet_file/src/storage_testing.rs
+++ b/parquet_file/src/storage_testing.rs
@@ -12,7 +12,7 @@ mod tests {
     use crate::{
         metadata::IoxParquetMetaData,
         test_utils::{
-            chunk_path, load_parquet_from_store, make_chunk_given_record_batch, make_object_store,
+            chunk_addr, load_parquet_from_store, make_chunk_given_record_batch, make_object_store,
             make_record_batch, read_data_from_parquet_data,
         },
     };
@@ -21,7 +21,7 @@ mod tests {
     async fn test_write_read() {
         ////////////////////
         // Create test data which is also the expected data
-        let path = chunk_path(1);
+        let path = chunk_addr(1);
         let table = Arc::clone(&path.table_name);
         let (record_batches, schema, column_summaries, num_rows) = make_record_batch("foo");
         let mut table_summary = TableSummary::new(table.to_string());

--- a/parquet_file/src/test_utils.rs
+++ b/parquet_file/src/test_utils.rs
@@ -35,6 +35,7 @@ use crate::{
     chunk::{self, ParquetChunk},
     storage::Storage,
 };
+use data_types::chunk_metadata::ChunkPath;
 use snafu::{ResultExt, Snafu};
 
 #[derive(Debug, Snafu)]
@@ -87,32 +88,39 @@ pub async fn load_parquet_from_store_for_path(
     Ok(parquet_data)
 }
 
+/// The db name to use for testing
+pub fn db_name() -> &'static str {
+    "db1"
+}
+
+/// Creates a test chunk path for a given chunk id
+pub fn chunk_path(id: u32) -> ChunkPath {
+    ChunkPath {
+        db_name: Arc::from(db_name()),
+        table_name: Arc::from("table1"),
+        partition_key: Arc::from("part1"),
+        chunk_id: id,
+    }
+}
+
 /// Same as [`make_chunk`] but parquet file does not contain any row group.
 pub async fn make_chunk(
     store: Arc<ObjectStore>,
     column_prefix: &str,
-    chunk_id: u32,
+    path: ChunkPath,
 ) -> ParquetChunk {
     let (record_batches, schema, column_summaries, _num_rows) = make_record_batch(column_prefix);
-    make_chunk_given_record_batch(
-        store,
-        record_batches,
-        schema,
-        "table1",
-        column_summaries,
-        chunk_id,
-    )
-    .await
+    make_chunk_given_record_batch(store, record_batches, schema, path, column_summaries).await
 }
 
 /// Same as [`make_chunk`] but parquet file does not contain any row group.
 pub async fn make_chunk_no_row_group(
     store: Arc<ObjectStore>,
     column_prefix: &str,
-    chunk_id: u32,
+    path: ChunkPath,
 ) -> ParquetChunk {
     let (_, schema, column_summaries, _num_rows) = make_record_batch(column_prefix);
-    make_chunk_given_record_batch(store, vec![], schema, "table1", column_summaries, chunk_id).await
+    make_chunk_given_record_batch(store, vec![], schema, path, column_summaries).await
 }
 
 /// Create a test chunk by writing data to object store.
@@ -122,14 +130,14 @@ pub async fn make_chunk_given_record_batch(
     store: Arc<ObjectStore>,
     record_batches: Vec<RecordBatch>,
     schema: Schema,
-    table: &str,
+    path: ChunkPath,
     column_summaries: Vec<ColumnSummary>,
-    chunk_id: u32,
 ) -> ParquetChunk {
     let server_id = ServerId::new(NonZeroU32::new(1).unwrap());
-    let db_name = "db1";
-    let partition_key = "part1";
-    let table_name = table;
+    let db_name = &path.db_name;
+    let partition_key = &path.partition_key;
+    let table_name = &path.table_name;
+    let chunk_id = path.chunk_id;
 
     let storage = Storage::new(Arc::clone(&store), server_id, db_name.to_string());
 
@@ -162,7 +170,7 @@ pub async fn make_chunk_given_record_batch(
         .unwrap();
 
     ParquetChunk::new_from_parts(
-        partition_key,
+        partition_key.to_string(),
         Arc::new(table_summary),
         Arc::new(schema),
         path,
@@ -732,9 +740,9 @@ pub fn read_data_from_parquet_data(schema: SchemaRef, parquet_data: Vec<u8>) -> 
 pub async fn make_metadata(
     object_store: &Arc<ObjectStore>,
     column_prefix: &str,
-    chunk_id: u32,
+    path: ChunkPath,
 ) -> (Path, IoxParquetMetaData) {
-    let chunk = make_chunk(Arc::clone(object_store), column_prefix, chunk_id).await;
+    let chunk = make_chunk(Arc::clone(object_store), column_prefix, path).await;
     let (_, parquet_data) = load_parquet_from_store(&chunk, Arc::clone(object_store))
         .await
         .unwrap();

--- a/parquet_file/src/test_utils.rs
+++ b/parquet_file/src/test_utils.rs
@@ -93,7 +93,7 @@ pub fn db_name() -> &'static str {
     "db1"
 }
 
-/// Creates a test chunk path for a given chunk id
+/// Creates a test chunk address for a given chunk id
 pub fn chunk_addr(id: u32) -> ChunkAddr {
     ChunkAddr {
         db_name: Arc::from(db_name()),
@@ -117,10 +117,10 @@ pub async fn make_chunk(
 pub async fn make_chunk_no_row_group(
     store: Arc<ObjectStore>,
     column_prefix: &str,
-    path: ChunkAddr,
+    addr: ChunkAddr,
 ) -> ParquetChunk {
     let (_, schema, column_summaries, _num_rows) = make_record_batch(column_prefix);
-    make_chunk_given_record_batch(store, vec![], schema, path, column_summaries).await
+    make_chunk_given_record_batch(store, vec![], schema, addr, column_summaries).await
 }
 
 /// Create a test chunk by writing data to object store.
@@ -130,14 +130,14 @@ pub async fn make_chunk_given_record_batch(
     store: Arc<ObjectStore>,
     record_batches: Vec<RecordBatch>,
     schema: Schema,
-    path: ChunkAddr,
+    addr: ChunkAddr,
     column_summaries: Vec<ColumnSummary>,
 ) -> ParquetChunk {
     let server_id = ServerId::new(NonZeroU32::new(1).unwrap());
-    let db_name = &path.db_name;
-    let partition_key = &path.partition_key;
-    let table_name = &path.table_name;
-    let chunk_id = path.chunk_id;
+    let db_name = &addr.db_name;
+    let partition_key = &addr.partition_key;
+    let table_name = &addr.table_name;
+    let chunk_id = addr.chunk_id;
 
     let storage = Storage::new(Arc::clone(&store), server_id, db_name.to_string());
 
@@ -740,9 +740,9 @@ pub fn read_data_from_parquet_data(schema: SchemaRef, parquet_data: Vec<u8>) -> 
 pub async fn make_metadata(
     object_store: &Arc<ObjectStore>,
     column_prefix: &str,
-    path: ChunkAddr,
+    addr: ChunkAddr,
 ) -> (Path, IoxParquetMetaData) {
-    let chunk = make_chunk(Arc::clone(object_store), column_prefix, path).await;
+    let chunk = make_chunk(Arc::clone(object_store), column_prefix, addr).await;
     let (_, parquet_data) = load_parquet_from_store(&chunk, Arc::clone(object_store))
         .await
         .unwrap();

--- a/server/src/db.rs
+++ b/server/src/db.rs
@@ -1146,8 +1146,13 @@ pub struct TransactionState {
 impl CatalogState for Catalog {
     type EmptyInput = CatalogEmptyInput;
 
-    fn new_empty(data: Self::EmptyInput) -> Self {
-        Self::new(data.domain, data.metrics_registry, data.metric_labels)
+    fn new_empty(db_name: &str, data: Self::EmptyInput) -> Self {
+        Self::new(
+            Arc::from(db_name),
+            data.domain,
+            data.metrics_registry,
+            data.metric_labels,
+        )
     }
 
     type TransactionState = TransactionState;
@@ -1298,9 +1303,7 @@ impl CatalogState for Catalog {
                     return Err(parquet_file::catalog::Error::CatalogStateFailure {
                         source: Box::new(
                             crate::db::catalog::chunk::Error::UnexpectedLifecycleAction {
-                                partition_key: iox_md.partition_key,
-                                table_name: iox_md.table_name,
-                                chunk_id: iox_md.chunk_id,
+                                chunk: chunk.path().clone(),
                                 expected: "persisting".to_string(),
                                 actual: chunk
                                     .lifecycle_action()

--- a/server/src/db.rs
+++ b/server/src/db.rs
@@ -1303,7 +1303,7 @@ impl CatalogState for Catalog {
                     return Err(parquet_file::catalog::Error::CatalogStateFailure {
                         source: Box::new(
                             crate::db::catalog::chunk::Error::UnexpectedLifecycleAction {
-                                chunk: chunk.path().clone(),
+                                chunk: chunk.addr().clone(),
                                 expected: "persisting".to_string(),
                                 actual: chunk
                                     .lifecycle_action()

--- a/server/src/db/catalog/chunk.rs
+++ b/server/src/db/catalog/chunk.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use chrono::{DateTime, Utc};
 use snafu::Snafu;
 
+use data_types::chunk_metadata::ChunkPath;
 use data_types::{
     chunk_metadata::{ChunkColumnSummary, ChunkStorage, ChunkSummary, DetailedChunkSummary},
     partition_metadata::TableSummary,
@@ -18,64 +19,47 @@ use tracker::{TaskRegistration, TaskTracker};
 #[derive(Debug, Snafu)]
 pub enum Error {
     #[snafu(display(
-        "Internal Error: unexpected chunk state for {}:{}:{}  during {}. Expected {}, got {}",
-        partition_key,
-        table_name,
-        chunk_id,
+        "Internal Error: unexpected chunk state for {} during {}. Expected {}, got {}",
+        chunk,
         operation,
         expected,
         actual
     ))]
     InternalChunkState {
-        partition_key: String,
-        table_name: String,
-        chunk_id: u32,
+        chunk: ChunkPath,
         operation: String,
         expected: String,
         actual: String,
     },
 
     #[snafu(display(
-        "Internal Error: A lifecycle action '{}' is already in progress for  {}:{}:{}",
+        "Internal Error: A lifecycle action '{}' is already in progress for {}",
         lifecycle_action,
-        partition_key,
-        table_name,
-        chunk_id,
+        chunk,
     ))]
     LifecycleActionAlreadyInProgress {
-        partition_key: String,
-        table_name: String,
-        chunk_id: u32,
+        chunk: ChunkPath,
         lifecycle_action: String,
     },
 
     #[snafu(display(
-        "Internal Error: Unexpected chunk state for {}:{}:{}. Expected {}, got {}",
-        partition_key,
-        table_name,
-        chunk_id,
+        "Internal Error: Unexpected chunk state for {}. Expected {}, got {}",
+        chunk,
         expected,
         actual
     ))]
     UnexpectedLifecycleAction {
-        partition_key: String,
-        table_name: String,
-        chunk_id: u32,
+        chunk: ChunkPath,
         expected: String,
         actual: String,
     },
 
     #[snafu(display(
-        "Internal Error: Cannot clear a lifecycle action '{}' for chunk {}:{} that is still running",
+        "Internal Error: Cannot clear a lifecycle action '{}' for chunk {} that is still running",
         action,
-        partition_key,
-        chunk_id
+        chunk
     ))]
-    IncompleteLifecycleAction {
-        partition_key: String,
-        chunk_id: u32,
-        action: String,
-    },
+    IncompleteLifecycleAction { chunk: ChunkPath, action: String },
 }
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
@@ -190,14 +174,7 @@ impl ChunkStage {
 /// _representation_ (e.g. a persisted chunk may have data cached in-memory).
 #[derive(Debug)]
 pub struct CatalogChunk {
-    /// What partition does the chunk belong to?
-    partition_key: Arc<str>,
-
-    /// What table does the chunk belong to?
-    table_name: Arc<str>,
-
-    /// The ID of the chunk
-    id: u32,
+    path: ChunkPath,
 
     /// The lifecycle stage this chunk is in.
     stage: ChunkStage,
@@ -229,9 +206,7 @@ pub struct CatalogChunk {
 macro_rules! unexpected_state {
     ($SELF: expr, $OP: expr, $EXPECTED: expr, $STATE: expr) => {
         InternalChunkState {
-            partition_key: $SELF.partition_key.as_ref(),
-            table_name: $SELF.table_name.as_ref(),
-            chunk_id: $SELF.id,
+            chunk: $SELF.path.clone(),
             operation: $OP,
             expected: $EXPECTED,
             actual: $STATE.name(),
@@ -266,15 +241,13 @@ impl CatalogChunk {
     /// current time.
     ///
     /// Apart from [`new_object_store_only`](Self::new_object_store_only) this is the only way to create new chunks.
-    pub(crate) fn new_open(
-        chunk_id: u32,
-        partition_key: impl AsRef<str>,
+    pub(super) fn new_open(
+        path: ChunkPath,
         chunk: mutable_buffer::chunk::MBChunk,
         metrics: ChunkMetrics,
     ) -> Self {
         assert!(chunk.rows() > 0, "chunk must not be empty");
-
-        let table_name = Arc::clone(&chunk.table_name());
+        assert_eq!(chunk.table_name(), &path.table_name);
         let stage = ChunkStage::Open { mb_chunk: chunk };
 
         metrics
@@ -282,9 +255,7 @@ impl CatalogChunk {
             .inc_with_labels(&[KeyValue::new("state", "open")]);
 
         let mut chunk = Self {
-            partition_key: Arc::from(partition_key.as_ref()),
-            table_name,
-            id: chunk_id,
+            path,
             stage,
             lifecycle_action: None,
             metrics,
@@ -299,13 +270,12 @@ impl CatalogChunk {
     /// Creates a new chunk that is only registered via an object store reference (= only exists in parquet).
     ///
     /// Apart from [`new_open`](Self::new_open) this is the only way to create new chunks.
-    pub(crate) fn new_object_store_only(
-        chunk_id: u32,
-        partition_key: impl AsRef<str>,
+    pub(super) fn new_object_store_only(
+        path: ChunkPath,
         chunk: Arc<parquet_file::chunk::ParquetChunk>,
         metrics: ChunkMetrics,
     ) -> Self {
-        let table_name = Arc::from(chunk.table_name());
+        assert_eq!(chunk.table_name(), path.table_name.as_ref());
 
         // Cache table summary + schema
         let meta = Arc::new(ChunkMetadata {
@@ -320,9 +290,7 @@ impl CatalogChunk {
         };
 
         Self {
-            partition_key: Arc::from(partition_key.as_ref()),
-            table_name,
-            id: chunk_id,
+            path,
             stage,
             lifecycle_action: None,
             metrics,
@@ -332,16 +300,20 @@ impl CatalogChunk {
         }
     }
 
+    pub fn path(&self) -> &ChunkPath {
+        &self.path
+    }
+
     pub fn id(&self) -> u32 {
-        self.id
+        self.path.chunk_id
     }
 
     pub fn key(&self) -> &str {
-        self.partition_key.as_ref()
+        self.path.partition_key.as_ref()
     }
 
     pub fn table_name(&self) -> Arc<str> {
-        Arc::clone(&self.table_name)
+        Arc::clone(&self.path.table_name)
     }
 
     pub fn stage(&self) -> &ChunkStage {
@@ -412,9 +384,9 @@ impl CatalogChunk {
         let (row_count, storage) = self.storage();
 
         ChunkSummary {
-            partition_key: Arc::clone(&self.partition_key),
-            table_name: Arc::clone(&self.table_name),
-            id: self.id,
+            partition_key: Arc::clone(&self.path.partition_key),
+            table_name: Arc::clone(&self.path.table_name),
+            id: self.path.chunk_id,
             storage,
             estimated_bytes: self.size(),
             row_count,
@@ -441,11 +413,11 @@ impl CatalogChunk {
                 ChunkStageFrozenRepr::MutableBufferSnapshot(repr) => {
                     repr.column_sizes().map(to_summary).collect()
                 }
-                ChunkStageFrozenRepr::ReadBuffer(repr) => repr.column_sizes(&self.table_name),
+                ChunkStageFrozenRepr::ReadBuffer(repr) => repr.column_sizes(&self.path.table_name),
             },
             ChunkStage::Persisted { read_buffer, .. } => {
                 if let Some(read_buffer) = &read_buffer {
-                    read_buffer.column_sizes(&self.table_name)
+                    read_buffer.column_sizes(&self.path.table_name)
                 } else {
                     // TODO parquet statistics
                     vec![]
@@ -572,9 +544,7 @@ impl CatalogChunk {
                     Ok(chunk)
                 }
                 ChunkStageFrozenRepr::ReadBuffer(_) => InternalChunkState {
-                    partition_key: self.partition_key.as_ref(),
-                    table_name: self.table_name.as_ref(),
-                    chunk_id: self.id,
+                    chunk: self.path.clone(),
                     operation: "setting moving",
                     expected: "Frozen with MutableBufferSnapshot",
                     actual: "Frozen with ReadBuffer",
@@ -608,9 +578,7 @@ impl CatalogChunk {
                     Ok(())
                 }
                 ChunkStageFrozenRepr::ReadBuffer(_) => InternalChunkState {
-                    partition_key: self.partition_key.as_ref(),
-                    table_name: self.table_name.as_ref(),
-                    chunk_id: self.id,
+                    chunk: self.path.clone(),
                     operation: "setting moved",
                     expected: "Frozen with MutableBufferSnapshot",
                     actual: "Frozen with ReadBuffer",
@@ -634,9 +602,7 @@ impl CatalogChunk {
                     ChunkStageFrozenRepr::MutableBufferSnapshot(_) => {
                         // TODO: ideally we would support all Frozen representations
                         InternalChunkState {
-                            partition_key: self.partition_key.as_ref(),
-                            table_name: self.table_name.as_ref(),
-                            chunk_id: self.id,
+                            chunk: self.path.clone(),
                             operation: "setting object store",
                             expected: "Frozen with ReadBuffer",
                             actual: "Frozen with MutableBufferSnapshot",
@@ -673,9 +639,7 @@ impl CatalogChunk {
                     ChunkStageFrozenRepr::MutableBufferSnapshot(_) => {
                         // TODO: ideally we would support all Frozen representations
                         InternalChunkState {
-                            partition_key: self.partition_key.as_ref(),
-                            table_name: self.table_name.as_ref(),
-                            chunk_id: self.id,
+                            chunk: self.path.clone(),
                             operation: "setting object store",
                             expected: "Frozen with ReadBuffer",
                             actual: "Frozen with MutableBufferSnapshot",
@@ -738,9 +702,7 @@ impl CatalogChunk {
                 } else {
                     // TODO: do we really need to error here or should unloading an unloaded chunk be a no-op?
                     InternalChunkState {
-                        partition_key: self.partition_key.as_ref(),
-                        table_name: self.table_name.as_ref(),
-                        chunk_id: self.id,
+                        chunk: self.path.clone(),
                         operation: "setting unload",
                         expected: "Persisted with ReadBuffer",
                         actual: "Persisted without ReadBuffer",
@@ -762,9 +724,7 @@ impl CatalogChunk {
     ) -> Result<()> {
         if let Some(lifecycle_action) = &self.lifecycle_action {
             return Err(Error::LifecycleActionAlreadyInProgress {
-                partition_key: self.partition_key.to_string(),
-                table_name: self.table_name.to_string(),
-                chunk_id: self.id,
+                chunk: self.path.clone(),
                 lifecycle_action: lifecycle_action.metadata().name().to_string(),
             });
         }
@@ -778,9 +738,7 @@ impl CatalogChunk {
             Some(actual) if actual.metadata() == &lifecycle_action => {}
             actual => {
                 return Err(Error::UnexpectedLifecycleAction {
-                    partition_key: self.partition_key.to_string(),
-                    table_name: self.table_name.to_string(),
-                    chunk_id: self.id,
+                    chunk: self.path.clone(),
                     expected: lifecycle_action.name().to_string(),
                     actual: actual
                         .as_ref()
@@ -801,8 +759,7 @@ impl CatalogChunk {
         if let Some(tracker) = &self.lifecycle_action {
             if !tracker.is_complete() {
                 return Err(Error::IncompleteLifecycleAction {
-                    partition_key: self.partition_key.to_string(),
-                    chunk_id: self.id,
+                    chunk: self.path.clone(),
                     action: tracker.metadata().name().to_string(),
                 });
             }
@@ -826,27 +783,21 @@ mod tests {
     #[test]
     fn test_new_open() {
         let sequencer_id = 1;
-        let table_name = "table1";
-        let partition_key = "part1";
-        let chunk_id = 0;
+        let path = chunk_path();
 
         // works with non-empty MBChunk
-        let mb_chunk = make_mb_chunk(table_name, sequencer_id);
-        let chunk = CatalogChunk::new_open(
-            chunk_id,
-            partition_key,
-            mb_chunk,
-            ChunkMetrics::new_unregistered(),
-        );
+        let mb_chunk = make_mb_chunk(&path.table_name, sequencer_id);
+        let chunk = CatalogChunk::new_open(path, mb_chunk, ChunkMetrics::new_unregistered());
         assert!(matches!(chunk.stage(), &ChunkStage::Open { .. }));
     }
 
     #[test]
     #[should_panic(expected = "chunk must not be empty")]
     fn test_new_open_empty() {
+        let path = chunk_path();
         // fails with empty MBChunk
-        let mb_chunk = MBChunk::new("t1", MBChunkMetrics::new_unregistered());
-        CatalogChunk::new_open(0, "p1", mb_chunk, ChunkMetrics::new_unregistered());
+        let mb_chunk = MBChunk::new(&path.table_name, MBChunkMetrics::new_unregistered());
+        CatalogChunk::new_open(path, mb_chunk, ChunkMetrics::new_unregistered());
     }
 
     #[tokio::test]
@@ -863,7 +814,7 @@ mod tests {
 
         // closing a chunk in persisted state will fail
         let mut chunk = make_persisted_chunk().await;
-        assert_eq!(chunk.freeze().unwrap_err().to_string(), "Internal Error: unexpected chunk state for part1:table1:0  during setting closed. Expected Open or Frozen, got Persisted");
+        assert_eq!(chunk.freeze().unwrap_err().to_string(), "Internal Error: unexpected chunk state for Chunk('db':'table1':'part1':0) during setting closed. Expected Open or Frozen, got Persisted");
     }
 
     #[test]
@@ -884,10 +835,10 @@ mod tests {
         );
 
         // setting an action while there is one running fails
-        assert_eq!(chunk.set_lifecycle_action(ChunkLifecycleAction::Moving, &registration).unwrap_err().to_string(), "Internal Error: A lifecycle action \'Moving to the Read Buffer\' is already in progress for  part1:table1:0");
+        assert_eq!(chunk.set_lifecycle_action(ChunkLifecycleAction::Moving, &registration).unwrap_err().to_string(), "Internal Error: A lifecycle action \'Moving to the Read Buffer\' is already in progress for Chunk('db':'table1':'part1':0)");
 
         // finishing the wrong action fails
-        assert_eq!(chunk.finish_lifecycle_action(ChunkLifecycleAction::Compacting).unwrap_err().to_string(), "Internal Error: Unexpected chunk state for part1:table1:0. Expected Compacting, got Moving to the Read Buffer");
+        assert_eq!(chunk.finish_lifecycle_action(ChunkLifecycleAction::Compacting).unwrap_err().to_string(), "Internal Error: Unexpected chunk state for Chunk('db':'table1':'part1':0). Expected Compacting, got Moving to the Read Buffer");
 
         // finish some action
         chunk
@@ -895,7 +846,7 @@ mod tests {
             .unwrap();
 
         // finishing w/o any action in progress will fail
-        assert_eq!(chunk.finish_lifecycle_action(ChunkLifecycleAction::Moving).unwrap_err().to_string(), "Internal Error: Unexpected chunk state for part1:table1:0. Expected Moving to the Read Buffer, got None");
+        assert_eq!(chunk.finish_lifecycle_action(ChunkLifecycleAction::Moving).unwrap_err().to_string(), "Internal Error: Unexpected chunk state for Chunk('db':'table1':'part1':0). Expected Moving to the Read Buffer, got None");
 
         // now we can set another action
         chunk
@@ -916,38 +867,37 @@ mod tests {
         mb_chunk
     }
 
-    async fn make_parquet_chunk(chunk_id: u32) -> ParquetChunk {
+    async fn make_parquet_chunk(path: ChunkPath) -> ParquetChunk {
         let object_store = make_object_store();
-        make_parquet_chunk_with_store(object_store, "foo", chunk_id).await
+        make_parquet_chunk_with_store(object_store, "foo", path).await
+    }
+
+    fn chunk_path() -> ChunkPath {
+        ChunkPath {
+            db_name: Arc::from("db"),
+            table_name: Arc::from("table1"),
+            partition_key: Arc::from("part1"),
+            chunk_id: 0,
+        }
     }
 
     fn make_open_chunk() -> CatalogChunk {
         let sequencer_id = 1;
-        let table_name = "table1";
-        let partition_key = "part1";
-        let chunk_id = 0;
+        let path = chunk_path();
 
         // assemble MBChunk
-        let mb_chunk = make_mb_chunk(table_name, sequencer_id);
+        let mb_chunk = make_mb_chunk(&path.table_name, sequencer_id);
 
-        CatalogChunk::new_open(
-            chunk_id,
-            partition_key,
-            mb_chunk,
-            ChunkMetrics::new_unregistered(),
-        )
+        CatalogChunk::new_open(path, mb_chunk, ChunkMetrics::new_unregistered())
     }
 
     async fn make_persisted_chunk() -> CatalogChunk {
-        let partition_key = "part1";
-        let chunk_id = 0;
-
+        let path = chunk_path();
         // assemble ParquetChunk
-        let parquet_chunk = make_parquet_chunk(chunk_id).await;
+        let parquet_chunk = make_parquet_chunk(path.clone()).await;
 
         CatalogChunk::new_object_store_only(
-            chunk_id,
-            partition_key,
+            path,
             Arc::new(parquet_chunk),
             ChunkMetrics::new_unregistered(),
         )

--- a/server/src/db/catalog/chunk.rs
+++ b/server/src/db/catalog/chunk.rs
@@ -783,21 +783,21 @@ mod tests {
     #[test]
     fn test_new_open() {
         let sequencer_id = 1;
-        let path = chunk_addr();
+        let addr = chunk_addr();
 
         // works with non-empty MBChunk
-        let mb_chunk = make_mb_chunk(&path.table_name, sequencer_id);
-        let chunk = CatalogChunk::new_open(path, mb_chunk, ChunkMetrics::new_unregistered());
+        let mb_chunk = make_mb_chunk(&addr.table_name, sequencer_id);
+        let chunk = CatalogChunk::new_open(addr, mb_chunk, ChunkMetrics::new_unregistered());
         assert!(matches!(chunk.stage(), &ChunkStage::Open { .. }));
     }
 
     #[test]
     #[should_panic(expected = "chunk must not be empty")]
     fn test_new_open_empty() {
-        let path = chunk_addr();
+        let addr = chunk_addr();
         // fails with empty MBChunk
-        let mb_chunk = MBChunk::new(&path.table_name, MBChunkMetrics::new_unregistered());
-        CatalogChunk::new_open(path, mb_chunk, ChunkMetrics::new_unregistered());
+        let mb_chunk = MBChunk::new(&addr.table_name, MBChunkMetrics::new_unregistered());
+        CatalogChunk::new_open(addr, mb_chunk, ChunkMetrics::new_unregistered());
     }
 
     #[tokio::test]
@@ -892,12 +892,12 @@ mod tests {
     }
 
     async fn make_persisted_chunk() -> CatalogChunk {
-        let path = chunk_addr();
+        let addr = chunk_addr();
         // assemble ParquetChunk
-        let parquet_chunk = make_parquet_chunk(path.clone()).await;
+        let parquet_chunk = make_parquet_chunk(addr.clone()).await;
 
         CatalogChunk::new_object_store_only(
-            path,
+            addr,
             Arc::new(parquet_chunk),
             ChunkMetrics::new_unregistered(),
         )

--- a/server/src/db/catalog/partition.rs
+++ b/server/src/db/catalog/partition.rs
@@ -13,7 +13,7 @@ use tracker::RwLock;
 use crate::db::catalog::metrics::PartitionMetrics;
 
 use super::chunk::{CatalogChunk, ChunkStage};
-use data_types::chunk_metadata::{ChunkPath, ChunkSummary};
+use data_types::chunk_metadata::{ChunkAddr, ChunkSummary};
 
 /// IOx Catalog Partition
 ///
@@ -114,7 +114,7 @@ impl Partition {
 
         self.next_chunk_id += 1;
 
-        let path = ChunkPath {
+        let addr = ChunkAddr {
             db_name: Arc::clone(&self.db_name),
             table_name: Arc::clone(&self.table_name),
             partition_key: Arc::clone(&self.partition_key),
@@ -122,7 +122,7 @@ impl Partition {
         };
 
         let chunk = Arc::new(self.metrics.new_chunk_lock(CatalogChunk::new_open(
-            path,
+            addr,
             chunk,
             self.metrics.new_chunk_metrics(),
         )));
@@ -148,7 +148,7 @@ impl Partition {
     ) -> Arc<RwLock<CatalogChunk>> {
         assert_eq!(chunk.table_name(), self.table_name.as_ref());
 
-        let path = ChunkPath {
+        let addr = ChunkAddr {
             db_name: Arc::clone(&self.db_name),
             table_name: Arc::clone(&self.table_name),
             partition_key: Arc::clone(&self.partition_key),
@@ -158,7 +158,7 @@ impl Partition {
         let chunk = Arc::new(
             self.metrics
                 .new_chunk_lock(CatalogChunk::new_object_store_only(
-                    path,
+                    addr,
                     chunk,
                     self.metrics.new_chunk_metrics(),
                 )),

--- a/server/src/db/catalog/partition.rs
+++ b/server/src/db/catalog/partition.rs
@@ -13,13 +13,15 @@ use tracker::RwLock;
 use crate::db::catalog::metrics::PartitionMetrics;
 
 use super::chunk::{CatalogChunk, ChunkStage};
-use data_types::chunk_metadata::ChunkSummary;
+use data_types::chunk_metadata::{ChunkPath, ChunkSummary};
 
 /// IOx Catalog Partition
 ///
 /// A partition contains multiple Chunks for a given table
 #[derive(Debug)]
 pub struct Partition {
+    /// Database name
+    db_name: Arc<str>,
     /// The partition key
     partition_key: Arc<str>,
 
@@ -49,13 +51,15 @@ impl Partition {
     /// This function is not pub because `Partition`s should be
     /// created using the interfaces on [`Catalog`](crate::db::catalog::Catalog) and not
     /// instantiated directly.
-    pub(crate) fn new(
+    pub(super) fn new(
+        db_name: Arc<str>,
         partition_key: Arc<str>,
         table_name: Arc<str>,
         metrics: PartitionMetrics,
     ) -> Self {
         let now = Utc::now();
         Self {
+            db_name,
             partition_key,
             table_name,
             chunks: Default::default(),
@@ -110,9 +114,15 @@ impl Partition {
 
         self.next_chunk_id += 1;
 
-        let chunk = Arc::new(self.metrics.new_chunk_lock(CatalogChunk::new_open(
+        let path = ChunkPath {
+            db_name: Arc::clone(&self.db_name),
+            table_name: Arc::clone(&self.table_name),
+            partition_key: Arc::clone(&self.partition_key),
             chunk_id,
-            &self.partition_key,
+        };
+
+        let chunk = Arc::new(self.metrics.new_chunk_lock(CatalogChunk::new_open(
+            path,
             chunk,
             self.metrics.new_chunk_metrics(),
         )));
@@ -138,11 +148,17 @@ impl Partition {
     ) -> Arc<RwLock<CatalogChunk>> {
         assert_eq!(chunk.table_name(), self.table_name.as_ref());
 
+        let path = ChunkPath {
+            db_name: Arc::clone(&self.db_name),
+            table_name: Arc::clone(&self.table_name),
+            partition_key: Arc::clone(&self.partition_key),
+            chunk_id,
+        };
+
         let chunk = Arc::new(
             self.metrics
                 .new_chunk_lock(CatalogChunk::new_object_store_only(
-                    chunk_id,
-                    &self.partition_key,
+                    path,
                     chunk,
                     self.metrics.new_chunk_metrics(),
                 )),

--- a/server/src/db/catalog/table.rs
+++ b/server/src/db/catalog/table.rs
@@ -8,6 +8,8 @@ use tracker::RwLock;
 /// A `Table` is a collection of `Partition` each of which is a collection of `Chunk`
 #[derive(Debug)]
 pub struct Table {
+    /// Database name
+    db_name: Arc<str>,
     /// Table name
     table_name: Arc<str>,
     /// key is partition key
@@ -22,8 +24,9 @@ impl Table {
     /// This function is not pub because `Table`s should be
     /// created using the interfaces on [`Catalog`](crate::db::catalog::Catalog) and not
     /// instantiated directly.
-    pub(crate) fn new(table_name: Arc<str>, metrics: TableMetrics) -> Self {
+    pub(super) fn new(db_name: Arc<str>, table_name: Arc<str>, metrics: TableMetrics) -> Self {
         Self {
+            db_name,
             table_name,
             partitions: Default::default(),
             metrics,
@@ -43,6 +46,7 @@ impl Table {
         partition_key: impl AsRef<str>,
     ) -> &Arc<RwLock<Partition>> {
         let metrics = &self.metrics;
+        let db_name = &self.db_name;
         let table_name = &self.table_name;
         let (_, partition) = self
             .partitions
@@ -52,6 +56,7 @@ impl Table {
                 let partition_key = Arc::from(partition_key.as_ref());
                 let partition_metrics = metrics.new_partition_metrics();
                 let partition = Partition::new(
+                    Arc::clone(&db_name),
                     Arc::clone(&partition_key),
                     Arc::clone(&table_name),
                     partition_metrics,


### PR DESCRIPTION
I started this PR to push the database name into the catalog, but I ended up splitting out the information that identifies the location of a chunk into a separate struct called `ChunkPath` (flexible on naming).

This was for a number of reasons:

* Propagating all 4 items at every function call, log statement, error construction, etc... is cumbersome
* Different callsites would print different subsets of the information, sometimes in different orders
* Eliminates a load of unnecessary string conversions

This is currently only plumbed in a couple of places, but other obvious candidates would be the Task metadata and the other chunk metadata structures. Most of the churn is in the persisted catalog tests