### PR TITLE
feat: reading entries from Kafka

### DIFF
--- a/data_types/src/database_rules.rs
+++ b/data_types/src/database_rules.rs
@@ -54,8 +54,14 @@ pub struct DatabaseRules {
     /// Defaults to 500 seconds.
     pub worker_cleanup_avg_sleep: Duration,
 
-    /// An optional connection string to a write buffer.
-    pub write_buffer_connection: Option<String>,
+    /// An optional connection string to a write buffer for either writing or reading.
+    pub write_buffer_connection: Option<WriteBufferConnection>,
+}
+
+#[derive(Debug, Eq, PartialEq, Clone)]
+pub enum WriteBufferConnection {
+    Writing(String),
+    Reading(String),
 }
 
 #[derive(Debug, Eq, PartialEq, Clone)]

--- a/data_types/src/database_rules.rs
+++ b/data_types/src/database_rules.rs
@@ -55,7 +55,7 @@ pub struct DatabaseRules {
     pub worker_cleanup_avg_sleep: Duration,
 
     /// An optional connection string to a write buffer.
-    pub write_buffer_connection_string: Option<String>,
+    pub write_buffer_connection: Option<String>,
 }
 
 #[derive(Debug, Eq, PartialEq, Clone)]
@@ -86,7 +86,7 @@ impl DatabaseRules {
             lifecycle_rules: Default::default(),
             routing_rules: None,
             worker_cleanup_avg_sleep: Duration::from_secs(500),
-            write_buffer_connection_string: None,
+            write_buffer_connection: None,
         }
     }
 

--- a/generated_types/protos/influxdata/iox/management/v1/database_rules.proto
+++ b/generated_types/protos/influxdata/iox/management/v1/database_rules.proto
@@ -106,7 +106,7 @@ message DatabaseRules {
   google.protobuf.Duration worker_cleanup_avg_sleep = 10;
 
   // Optionally, the address of the write buffer
-  string write_buffer_connection_string = 11;
+  string write_buffer_connection = 11;
 }
 
 message RoutingConfig {

--- a/generated_types/protos/influxdata/iox/management/v1/database_rules.proto
+++ b/generated_types/protos/influxdata/iox/management/v1/database_rules.proto
@@ -105,8 +105,11 @@ message DatabaseRules {
   // Defaults to 500 seconds.
   google.protobuf.Duration worker_cleanup_avg_sleep = 10;
 
-  // Optionally, the address of the write buffer
-  string write_buffer_connection = 11;
+  // Optionally, the address of the write buffer for writing or reading/restoring data
+  oneof write_buffer_connection {
+    string writing = 11;
+    string reading = 12;
+  }
 }
 
 message RoutingConfig {

--- a/generated_types/src/database_rules.rs
+++ b/generated_types/src/database_rules.rs
@@ -3,10 +3,12 @@ use std::time::Duration;
 
 use thiserror::Error;
 
-use data_types::database_rules::{DatabaseRules, RoutingConfig, RoutingRules};
+use data_types::database_rules::{
+    DatabaseRules, RoutingConfig, RoutingRules, WriteBufferConnection,
+};
 use data_types::DatabaseName;
 
-use crate::google::{FieldViolation, FieldViolationExt, FromFieldOpt, FromFieldString};
+use crate::google::{FieldViolation, FieldViolationExt, FromFieldOpt};
 use crate::influxdata::iox::management::v1 as management;
 
 mod lifecycle;
@@ -21,7 +23,7 @@ impl From<DatabaseRules> for management::DatabaseRules {
             lifecycle_rules: Some(rules.lifecycle_rules.into()),
             routing_rules: rules.routing_rules.map(Into::into),
             worker_cleanup_avg_sleep: Some(rules.worker_cleanup_avg_sleep.into()),
-            write_buffer_connection: rules.write_buffer_connection.unwrap_or_default(),
+            write_buffer_connection: rules.write_buffer_connection.map(Into::into),
         }
     }
 }
@@ -52,7 +54,10 @@ impl TryFrom<management::DatabaseRules> for DatabaseRules {
             None => Duration::from_secs(500),
         };
 
-        let write_buffer_connection = proto.write_buffer_connection.optional();
+        let write_buffer_connection = match proto.write_buffer_connection {
+            Some(c) => Some(c.try_into().field("write_buffer_connection")?),
+            None => None,
+        };
 
         Ok(Self {
             name,
@@ -137,6 +142,30 @@ pub fn encode_database_rules(
 ) -> Result<(), EncodeError> {
     let encoded: management::DatabaseRules = rules.into();
     Ok(prost::Message::encode(&encoded, bytes)?)
+}
+
+impl From<WriteBufferConnection> for management::database_rules::WriteBufferConnection {
+    fn from(v: WriteBufferConnection) -> Self {
+        match v {
+            WriteBufferConnection::Writing(c) => Self::Writing(c),
+            WriteBufferConnection::Reading(c) => Self::Reading(c),
+        }
+    }
+}
+
+impl TryFrom<management::database_rules::WriteBufferConnection> for WriteBufferConnection {
+    type Error = FieldViolation;
+
+    fn try_from(
+        proto: management::database_rules::WriteBufferConnection,
+    ) -> Result<Self, Self::Error> {
+        use management::database_rules::WriteBufferConnection;
+
+        Ok(match proto {
+            WriteBufferConnection::Writing(c) => Self::Writing(c),
+            WriteBufferConnection::Reading(c) => Self::Reading(c),
+        })
+    }
 }
 
 #[cfg(test)]

--- a/generated_types/src/database_rules.rs
+++ b/generated_types/src/database_rules.rs
@@ -21,9 +21,7 @@ impl From<DatabaseRules> for management::DatabaseRules {
             lifecycle_rules: Some(rules.lifecycle_rules.into()),
             routing_rules: rules.routing_rules.map(Into::into),
             worker_cleanup_avg_sleep: Some(rules.worker_cleanup_avg_sleep.into()),
-            write_buffer_connection_string: rules
-                .write_buffer_connection_string
-                .unwrap_or_default(),
+            write_buffer_connection: rules.write_buffer_connection.unwrap_or_default(),
         }
     }
 }
@@ -54,7 +52,7 @@ impl TryFrom<management::DatabaseRules> for DatabaseRules {
             None => Duration::from_secs(500),
         };
 
-        let write_buffer_connection_string = proto.write_buffer_connection_string.optional();
+        let write_buffer_connection = proto.write_buffer_connection.optional();
 
         Ok(Self {
             name,
@@ -62,7 +60,7 @@ impl TryFrom<management::DatabaseRules> for DatabaseRules {
             lifecycle_rules,
             routing_rules,
             worker_cleanup_avg_sleep,
-            write_buffer_connection_string,
+            write_buffer_connection,
         })
     }
 }

--- a/server/src/config.rs
+++ b/server/src/config.rs
@@ -15,7 +15,7 @@ use query::exec::Executor;
 /// This module contains code for managing the configuration of the server.
 use crate::{
     db::{catalog::Catalog, DatabaseToCommit, Db},
-    write_buffer::WriteBuffer,
+    write_buffer::WriteBufferWriting,
     Error, JobRegistry, Result,
 };
 use observability_deps::tracing::{self, error, info, warn, Instrument};
@@ -628,7 +628,7 @@ impl<'a> DatabaseHandle<'a> {
         &mut self,
         preserved_catalog: PreservedCatalog,
         catalog: Catalog,
-        write_buffer: Option<Arc<dyn WriteBuffer>>,
+        write_buffer: Option<Arc<dyn WriteBufferWriting>>,
     ) -> Result<()> {
         match self.state().as_ref() {
             DatabaseState::RulesLoaded {

--- a/server/src/config.rs
+++ b/server/src/config.rs
@@ -15,7 +15,7 @@ use query::exec::Executor;
 /// This module contains code for managing the configuration of the server.
 use crate::{
     db::{catalog::Catalog, DatabaseToCommit, Db},
-    write_buffer::WriteBufferWriting,
+    write_buffer::WriteBufferConfig,
     Error, JobRegistry, Result,
 };
 use observability_deps::tracing::{self, error, info, warn, Instrument};
@@ -628,7 +628,7 @@ impl<'a> DatabaseHandle<'a> {
         &mut self,
         preserved_catalog: PreservedCatalog,
         catalog: Catalog,
-        write_buffer: Option<Arc<dyn WriteBufferWriting>>,
+        write_buffer: Option<WriteBufferConfig>,
     ) -> Result<()> {
         match self.state().as_ref() {
             DatabaseState::RulesLoaded {

--- a/server/src/db.rs
+++ b/server/src/db.rs
@@ -82,7 +82,9 @@ pub enum Error {
     #[snafu(display("Cannot write to this database: no mutable buffer configured"))]
     DatabaseNotWriteable {},
 
-    #[snafu(display("Cannot write to this database: only reading from write buffer"))]
+    #[snafu(display(
+        "Cannot write to this database, configured to only read from the write buffer"
+    ))]
     WritingOnlyAllowedThroughWriteBuffer {},
 
     #[snafu(display("Hard buffer size limit reached"))]

--- a/server/src/db.rs
+++ b/server/src/db.rs
@@ -950,7 +950,7 @@ mod tests {
         database_rules::{PartitionTemplate, TemplatePart},
         partition_metadata::{ColumnSummary, InfluxDbType, StatValues, Statistics, TableSummary},
     };
-    use entry::test_helpers::lp_to_entry;
+    use entry::{test_helpers::lp_to_entry, Sequence};
     use futures::{stream, StreamExt, TryStreamExt};
     use internal_types::{schema::Schema, selection::Selection};
     use object_store::{
@@ -966,7 +966,7 @@ mod tests {
     use persistence_windows::min_max_sequence::MinMaxSequence;
     use query::{exec::ExecutorType, frontend::sql::SqlQueryPlanner, QueryChunk, QueryDatabase};
     use std::{
-        collections::HashSet,
+        collections::{BTreeMap, HashSet},
         convert::TryFrom,
         iter::Iterator,
         num::{NonZeroU64, NonZeroUsize},
@@ -1041,7 +1041,9 @@ mod tests {
     #[tokio::test]
     async fn read_from_write_buffer_write_to_mutable_buffer() {
         let entry = lp_to_entry("cpu bar=1 10");
-        let write_buffer = Arc::new(MockBufferForReading::new(vec![Ok(entry)]));
+        let write_buffer = Arc::new(MockBufferForReading::new(vec![Ok(
+            SequencedEntry::new_unsequenced(entry),
+        )]));
 
         let db = TestDb::builder()
             .write_buffer(WriteBufferConfig::Reading(Arc::clone(&write_buffer) as _))
@@ -1990,6 +1992,59 @@ mod tests {
         let open_max = windows.open_max_time().unwrap();
         assert_eq!(open_min.timestamp_nanos(), 10);
         assert_eq!(open_max.timestamp_nanos(), 20);
+    }
+
+    #[tokio::test]
+    async fn read_from_write_buffer_updates_persistence_windows() {
+        let entry = lp_to_entry("cpu bar=1 10");
+        let partition_key = "1970-01-01T00";
+
+        let write_buffer = Arc::new(MockBufferForReading::new(vec![
+            Ok(SequencedEntry::new_from_sequence(Sequence::new(0, 0), entry.clone()).unwrap()),
+            Ok(SequencedEntry::new_from_sequence(Sequence::new(1, 0), entry.clone()).unwrap()),
+            Ok(SequencedEntry::new_from_sequence(Sequence::new(1, 2), entry.clone()).unwrap()),
+            Ok(SequencedEntry::new_from_sequence(Sequence::new(0, 1), entry).unwrap()),
+        ]));
+
+        let db = TestDb::builder()
+            .write_buffer(WriteBufferConfig::Reading(Arc::clone(&write_buffer) as _))
+            .build()
+            .await
+            .db;
+
+        // do: start background task loop
+        let shutdown: CancellationToken = Default::default();
+        let shutdown_captured = shutdown.clone();
+        let db_captured = Arc::clone(&db);
+        let join_handle =
+            tokio::spawn(async move { db_captured.background_worker(shutdown_captured).await });
+
+        // check: after a while the persistence windows should have the expected data
+        let t_0 = Instant::now();
+        let min_unpersisted = loop {
+            if let Ok(partition) = db.catalog.partition("cpu", partition_key) {
+                let partition = partition.write();
+                let windows = partition.persistence_windows().unwrap();
+                let min_unpersisted = windows.minimum_unpersisted_sequence();
+
+                if let Some(min_unpersisted) = min_unpersisted {
+                    break min_unpersisted;
+                }
+            }
+
+            assert!(t_0.elapsed() < Duration::from_secs(10));
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        };
+
+        // do: stop background task loop
+        shutdown.cancel();
+        join_handle.await.unwrap();
+
+        let mut expected_unpersisted = BTreeMap::new();
+        expected_unpersisted.insert(0, MinMaxSequence::new(0, 1));
+        expected_unpersisted.insert(1, MinMaxSequence::new(0, 2));
+
+        assert_eq!(min_unpersisted, expected_unpersisted);
     }
 
     #[tokio::test]

--- a/server/src/db.rs
+++ b/server/src/db.rs
@@ -11,7 +11,7 @@ use crate::{
         catalog::{chunk::CatalogChunk, partition::Partition, Catalog, TableNameFilter},
         lifecycle::{LockableCatalogChunk, LockableCatalogPartition},
     },
-    write_buffer::WriteBuffer,
+    write_buffer::WriteBufferWriting,
     JobRegistry,
 };
 use ::lifecycle::{LockableChunk, LockablePartition};
@@ -230,7 +230,7 @@ pub struct Db {
     metric_labels: Vec<KeyValue>,
 
     /// Optionally buffer writes
-    write_buffer: Option<Arc<dyn WriteBuffer>>,
+    write_buffer: Option<Arc<dyn WriteBufferWriting>>,
 
     /// Lock that prevents the cleanup job from deleting files that are written but not yet added to the preserved
     /// catalog.
@@ -249,7 +249,7 @@ pub(crate) struct DatabaseToCommit {
     pub(crate) preserved_catalog: PreservedCatalog,
     pub(crate) catalog: Catalog,
     pub(crate) rules: DatabaseRules,
-    pub(crate) write_buffer: Option<Arc<dyn WriteBuffer>>,
+    pub(crate) write_buffer: Option<Arc<dyn WriteBufferWriting>>,
 }
 
 impl Db {

--- a/server/src/init.rs
+++ b/server/src/init.rs
@@ -1,6 +1,8 @@
 //! Routines to initialize a server.
 use data_types::{
-    database_rules::DatabaseRules, database_state::DatabaseStateCode, server_id::ServerId,
+    database_rules::{DatabaseRules, WriteBufferConnection},
+    database_state::DatabaseStateCode,
+    server_id::ServerId,
     DatabaseName,
 };
 use futures::TryStreamExt;
@@ -27,7 +29,8 @@ use tokio::sync::Semaphore;
 use crate::{
     config::{object_store_path_for_database_config, Config, DatabaseHandle, DB_RULES_FILE_NAME},
     db::load::load_or_create_preserved_catalog,
-    write_buffer, DatabaseError,
+    write_buffer::WriteBufferConfig,
+    DatabaseError,
 };
 
 const STORE_ERROR_PAUSE_SECONDS: u64 = 100;
@@ -75,8 +78,15 @@ pub enum Error {
         source: data_types::DatabaseNameError,
     },
 
-    #[snafu(display("Cannot create write buffer for writing: {}", source))]
-    CreateWriteBufferForWriting { source: DatabaseError },
+    #[snafu(display(
+        "Cannot create write buffer with config: {:?}, error: {}",
+        config,
+        source
+    ))]
+    CreateWriteBuffer {
+        config: Option<WriteBufferConnection>,
+        source: DatabaseError,
+    },
 
     #[snafu(display(
         "Cannot wipe catalog because DB init progress has already read it: {}",
@@ -520,8 +530,9 @@ impl InitStatus {
                 let rules = handle
                     .rules()
                     .expect("in this state rules should be loaded");
-                let write_buffer =
-                    write_buffer::new(&rules).context(CreateWriteBufferForWriting)?;
+                let write_buffer = WriteBufferConfig::new(&rules).context(CreateWriteBuffer {
+                    config: rules.write_buffer_connection.clone(),
+                })?;
 
                 handle
                     .advance_replay(preserved_catalog, catalog, write_buffer)

--- a/server/src/init.rs
+++ b/server/src/init.rs
@@ -530,9 +530,11 @@ impl InitStatus {
                 let rules = handle
                     .rules()
                     .expect("in this state rules should be loaded");
-                let write_buffer = WriteBufferConfig::new(&rules).context(CreateWriteBuffer {
-                    config: rules.write_buffer_connection.clone(),
-                })?;
+                let write_buffer = WriteBufferConfig::new(handle.server_id(), &rules).context(
+                    CreateWriteBuffer {
+                        config: rules.write_buffer_connection.clone(),
+                    },
+                )?;
 
                 handle
                     .advance_replay(preserved_catalog, catalog, write_buffer)

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -1220,7 +1220,7 @@ mod tests {
             },
             routing_rules: None,
             worker_cleanup_avg_sleep: Duration::from_secs(2),
-            write_buffer_connection_string: None,
+            write_buffer_connection: None,
         };
 
         // Create a database
@@ -1312,7 +1312,7 @@ mod tests {
             lifecycle_rules: Default::default(),
             routing_rules: None,
             worker_cleanup_avg_sleep: Duration::from_secs(2),
-            write_buffer_connection_string: None,
+            write_buffer_connection: None,
         };
 
         // Create a database

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -197,6 +197,12 @@ pub enum Error {
     #[snafu(display("hard buffer limit reached"))]
     HardLimitReached {},
 
+    #[snafu(display(
+        "Cannot write to database {}, it's configured to only read from the write buffer",
+        db_name
+    ))]
+    WritingOnlyAllowedThroughWriteBuffer { db_name: String },
+
     #[snafu(display("no remote configured for node group: {:?}", node_group))]
     NoRemoteConfigured { node_group: NodeGroup },
 
@@ -789,6 +795,11 @@ where
             );
             match e {
                 db::Error::HardLimitReached {} => Error::HardLimitReached {},
+                db::Error::WritingOnlyAllowedThroughWriteBuffer {} => {
+                    Error::WritingOnlyAllowedThroughWriteBuffer {
+                        db_name: db_name.into(),
+                    }
+                }
                 _ => Error::UnknownDatabaseError {
                     source: Box::new(e),
                 },

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -552,12 +552,13 @@ where
         .map_err(|e| Box::new(e) as _)
         .context(CannotCreatePreservedCatalog)?;
 
-        let write_buffer = write_buffer::WriteBufferConfig::new(&rules).map_err(|e| {
-            Error::CreatingWriteBuffer {
-                config: rules.write_buffer_connection.clone(),
-                source: e,
-            }
-        })?;
+        let write_buffer =
+            write_buffer::WriteBufferConfig::new(server_id, &rules).map_err(|e| {
+                Error::CreatingWriteBuffer {
+                    config: rules.write_buffer_connection.clone(),
+                    source: e,
+                }
+            })?;
         db_reservation.advance_replay(preserved_catalog, catalog, write_buffer)?;
 
         // no actual replay required

--- a/server/src/utils.rs
+++ b/server/src/utils.rs
@@ -11,7 +11,7 @@ use query::{exec::Executor, QueryDatabase};
 
 use crate::{
     db::{load::load_or_create_preserved_catalog, DatabaseToCommit, Db},
-    write_buffer::WriteBuffer,
+    write_buffer::WriteBufferWriting,
     JobRegistry,
 };
 
@@ -35,7 +35,7 @@ pub struct TestDbBuilder {
     object_store: Option<Arc<ObjectStore>>,
     db_name: Option<DatabaseName<'static>>,
     worker_cleanup_avg_sleep: Option<Duration>,
-    write_buffer: Option<Arc<dyn WriteBuffer>>,
+    write_buffer: Option<Arc<dyn WriteBufferWriting>>,
     catalog_transactions_until_checkpoint: Option<NonZeroU64>,
     partition_template: Option<PartitionTemplate>,
 }
@@ -127,7 +127,7 @@ impl TestDbBuilder {
         self
     }
 
-    pub fn write_buffer(mut self, write_buffer: Arc<dyn WriteBuffer>) -> Self {
+    pub fn write_buffer(mut self, write_buffer: Arc<dyn WriteBufferWriting>) -> Self {
         self.write_buffer = Some(write_buffer);
         self
     }

--- a/server/src/utils.rs
+++ b/server/src/utils.rs
@@ -11,7 +11,7 @@ use query::{exec::Executor, QueryDatabase};
 
 use crate::{
     db::{load::load_or_create_preserved_catalog, DatabaseToCommit, Db},
-    write_buffer::WriteBufferWriting,
+    write_buffer::WriteBufferConfig,
     JobRegistry,
 };
 
@@ -35,7 +35,7 @@ pub struct TestDbBuilder {
     object_store: Option<Arc<ObjectStore>>,
     db_name: Option<DatabaseName<'static>>,
     worker_cleanup_avg_sleep: Option<Duration>,
-    write_buffer: Option<Arc<dyn WriteBufferWriting>>,
+    write_buffer: Option<WriteBufferConfig>,
     catalog_transactions_until_checkpoint: Option<NonZeroU64>,
     partition_template: Option<PartitionTemplate>,
 }
@@ -127,7 +127,7 @@ impl TestDbBuilder {
         self
     }
 
-    pub fn write_buffer(mut self, write_buffer: Arc<dyn WriteBufferWriting>) -> Self {
+    pub fn write_buffer(mut self, write_buffer: WriteBufferConfig) -> Self {
         self.write_buffer = Some(write_buffer);
         self
     }

--- a/server/src/write_buffer.rs
+++ b/server/src/write_buffer.rs
@@ -226,7 +226,7 @@ pub mod test_helpers {
         }
     }
 
-    type MoveableEntries = Arc<Mutex<Option<Vec<Result<Entry, WriteBufferError>>>>>;
+    type MoveableEntries = Arc<Mutex<Vec<Result<Entry, WriteBufferError>>>>;
     pub struct MockBufferForReading {
         entries: MoveableEntries,
     }
@@ -240,7 +240,7 @@ pub mod test_helpers {
     impl MockBufferForReading {
         pub fn new(entries: Vec<Result<Entry, WriteBufferError>>) -> Self {
             Self {
-                entries: Arc::new(Mutex::new(Some(entries))),
+                entries: Arc::new(Mutex::new(entries)),
             }
         }
     }
@@ -254,7 +254,7 @@ pub mod test_helpers {
             Self: 'async_trait,
         {
             // move the entries out of `self` to move them into the stream
-            let entries = self.entries.lock().unwrap().take().unwrap();
+            let entries: Vec<_> = self.entries.lock().unwrap().drain(..).collect();
 
             stream::iter(entries.into_iter())
                 .chain(stream::pending())

--- a/server/src/write_buffer.rs
+++ b/server/src/write_buffer.rs
@@ -17,7 +17,7 @@ pub fn new(rules: &DatabaseRules) -> Result<Option<Arc<dyn WriteBuffer>>, WriteB
     // trait, so always use `KafkaBuffer` when there is a write buffer connection string
     // specified. If/when there are other kinds of write buffers, additional configuration will
     // be needed to determine what kind of write buffer to use here.
-    match rules.write_buffer_connection_string.as_ref() {
+    match rules.write_buffer_connection.as_ref() {
         Some(conn) => {
             let kafka_buffer = KafkaBuffer::new(conn, name)?;
 

--- a/server/src/write_buffer.rs
+++ b/server/src/write_buffer.rs
@@ -1,12 +1,17 @@
 use async_trait::async_trait;
 use data_types::database_rules::{DatabaseRules, WriteBufferConnection};
-use entry::{Entry, Sequence};
+use entry::{Entry, Sequence, SequencedEntry};
+use futures::{stream::BoxStream, StreamExt};
 use rdkafka::{
+    consumer::{Consumer, StreamConsumer},
     error::KafkaError,
     producer::{FutureProducer, FutureRecord},
-    ClientConfig,
+    ClientConfig, Message, Offset, TopicPartitionList,
 };
-use std::{convert::TryInto, sync::Arc};
+use std::{
+    convert::{TryFrom, TryInto},
+    sync::Arc,
+};
 
 pub type WriteBufferError = Box<dyn std::error::Error + Sync + Send>;
 
@@ -30,8 +35,10 @@ impl WriteBufferConfig {
 
                 Ok(Some(Self::Writing(Arc::new(kafka_buffer) as _)))
             }
-            Some(WriteBufferConnection::Reading(_conn)) => {
-                unimplemented!();
+            Some(WriteBufferConnection::Reading(conn)) => {
+                let kafka_buffer = KafkaBufferConsumer::new(conn, name)?;
+
+                Ok(Some(Self::Reading(Arc::new(kafka_buffer) as _)))
             }
             None => Ok(None),
         }
@@ -47,7 +54,16 @@ pub trait WriteBufferWriting: Sync + Send + std::fmt::Debug + 'static {
     async fn store_entry(&self, entry: &Entry) -> Result<Sequence, WriteBufferError>;
 }
 
-pub trait WriteBufferReading: Sync + Send + std::fmt::Debug + 'static {}
+/// Produce a stream of `SequencedEntry` that a `Db` can add to the mutable buffer by using
+/// `Db::stream_in_sequenced_entries`.
+pub trait WriteBufferReading: Sync + Send + std::fmt::Debug + 'static {
+    fn stream<'life0, 'async_trait>(
+        &'life0 self,
+    ) -> BoxStream<'async_trait, Result<SequencedEntry, WriteBufferError>>
+    where
+        'life0: 'async_trait,
+        Self: 'async_trait;
+}
 
 pub struct KafkaBufferProducer {
     conn: String,
@@ -115,9 +131,80 @@ impl KafkaBufferProducer {
     }
 }
 
+pub struct KafkaBufferConsumer {
+    conn: String,
+    database_name: String,
+    consumer: StreamConsumer,
+}
+
+// Needed because rdkafka's StreamConsumer doesn't impl Debug
+impl std::fmt::Debug for KafkaBufferConsumer {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("KafkaBufferConsumer")
+            .field("conn", &self.conn)
+            .field("database_name", &self.database_name)
+            .finish()
+    }
+}
+
+impl WriteBufferReading for KafkaBufferConsumer {
+    fn stream<'life0, 'async_trait>(
+        &'life0 self,
+    ) -> BoxStream<'async_trait, Result<SequencedEntry, WriteBufferError>>
+    where
+        'life0: 'async_trait,
+        Self: 'async_trait,
+    {
+        self.consumer
+            .stream()
+            .map(|message| {
+                let message = message?;
+                let entry = Entry::try_from(message.payload().unwrap().to_vec())?;
+                let sequence = Sequence {
+                    id: message.partition().try_into()?,
+                    number: message.offset().try_into()?,
+                };
+
+                Ok(SequencedEntry::new_from_sequence(sequence, entry)?)
+            })
+            .boxed()
+    }
+}
+
+impl KafkaBufferConsumer {
+    pub fn new(
+        conn: impl Into<String>,
+        database_name: impl Into<String>,
+    ) -> Result<Self, KafkaError> {
+        let conn = conn.into();
+        let database_name = database_name.into();
+
+        let mut cfg = ClientConfig::new();
+        cfg.set("bootstrap.servers", &conn);
+        cfg.set("session.timeout.ms", "6000");
+        cfg.set("enable.auto.commit", "false");
+        cfg.set("group.id", "placeholder");
+
+        let consumer: StreamConsumer = cfg.create()?;
+        let mut topics = TopicPartitionList::new();
+        topics.add_partition(&database_name, 0);
+        topics
+            .set_partition_offset(&database_name, 0, Offset::Beginning)
+            .unwrap();
+        consumer.assign(&topics)?;
+
+        Ok(Self {
+            conn,
+            database_name,
+            consumer,
+        })
+    }
+}
+
 #[cfg(test)]
 pub mod test_helpers {
     use super::*;
+    use futures::stream::{self, StreamExt, TryStreamExt};
     use std::sync::{Arc, Mutex};
 
     #[derive(Debug, Default)]
@@ -136,6 +223,43 @@ pub mod test_helpers {
                 id: 0,
                 number: offset,
             })
+        }
+    }
+
+    type MoveableEntries = Arc<Mutex<Option<Vec<Result<Entry, WriteBufferError>>>>>;
+    pub struct MockBufferForReading {
+        entries: MoveableEntries,
+    }
+
+    impl std::fmt::Debug for MockBufferForReading {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            f.debug_struct("MockBufferForReading").finish()
+        }
+    }
+
+    impl MockBufferForReading {
+        pub fn new(entries: Vec<Result<Entry, WriteBufferError>>) -> Self {
+            Self {
+                entries: Arc::new(Mutex::new(Some(entries))),
+            }
+        }
+    }
+
+    impl WriteBufferReading for MockBufferForReading {
+        fn stream<'life0, 'async_trait>(
+            &'life0 self,
+        ) -> BoxStream<'async_trait, Result<SequencedEntry, WriteBufferError>>
+        where
+            'life0: 'async_trait,
+            Self: 'async_trait,
+        {
+            // move the entries out of `self` to move them into the stream
+            let entries = self.entries.lock().unwrap().take().unwrap();
+
+            stream::iter(entries.into_iter())
+                .chain(stream::pending())
+                .map_ok(SequencedEntry::new_unsequenced)
+                .boxed()
         }
     }
 }

--- a/src/influxdb_ioxd/rpc/error.rs
+++ b/src/influxdb_ioxd/rpc/error.rs
@@ -14,7 +14,7 @@ pub fn default_server_error_handler(error: server::Error) -> tonic::Status {
             description: "Writer ID must be set".to_string(),
         }
         .into(),
-        Error::ServerNotInitialized{server_id} => tonic::Status::unavailable(
+        Error::ServerNotInitialized{ server_id } => tonic::Status::unavailable(
             format!("Server ID is set ({}) but server is not yet initialized (e.g. DBs and remotes are not loaded). Server is not yet ready to read/write data.", server_id)
         ),
         Error::DatabaseNotFound { db_name } => NotFound {
@@ -38,6 +38,7 @@ pub fn default_server_error_handler(error: server::Error) -> tonic::Status {
             description: "hard buffer limit reached".to_string(),
         }
         .into(),
+        source @ Error::WritingOnlyAllowedThroughWriteBuffer { .. } => tonic::Status::failed_precondition(source.to_string()),
         Error::NoRemoteConfigured { node_group } => NotFound {
             resource_type: "remote".to_string(),
             resource_name: format!("{:?}", node_group),

--- a/tests/end_to_end_cases/management_api.rs
+++ b/tests/end_to_end_cases/management_api.rs
@@ -225,7 +225,7 @@ async fn test_create_get_update_database() {
             seconds: 2,
             nanos: 0,
         }),
-        write_buffer_connection: "".into(),
+        write_buffer_connection: None,
     };
 
     client

--- a/tests/end_to_end_cases/management_api.rs
+++ b/tests/end_to_end_cases/management_api.rs
@@ -225,7 +225,7 @@ async fn test_create_get_update_database() {
             seconds: 2,
             nanos: 0,
         }),
-        write_buffer_connection_string: "".into(),
+        write_buffer_connection: "".into(),
     };
 
     client

--- a/tests/end_to_end_cases/write_buffer.rs
+++ b/tests/end_to_end_cases/write_buffer.rs
@@ -60,9 +60,9 @@ async fn writes_go_to_kafka() {
     // set up a database with a write buffer pointing at kafka
     let server = ServerFixture::create_shared().await;
     let db_name = rand_name();
-    let write_buffer_connection_string = kafka_connection.to_string();
+    let write_buffer_connection = kafka_connection.to_string();
     create_readable_database_plus(&db_name, server.grpc_channel(), |mut rules| {
-        rules.write_buffer_connection_string = write_buffer_connection_string;
+        rules.write_buffer_connection = write_buffer_connection;
         rules
     })
     .await;

--- a/tests/end_to_end_cases/write_buffer.rs
+++ b/tests/end_to_end_cases/write_buffer.rs
@@ -3,6 +3,7 @@ use crate::{
     end_to_end_cases::scenario::{create_readable_database_plus, rand_name},
 };
 use entry::Entry;
+use generated_types::influxdata::iox::management::v1::database_rules::WriteBufferConnection;
 use rdkafka::{
     consumer::{Consumer, StreamConsumer},
     ClientConfig, Message, Offset, TopicPartitionList,
@@ -60,9 +61,9 @@ async fn writes_go_to_kafka() {
     // set up a database with a write buffer pointing at kafka
     let server = ServerFixture::create_shared().await;
     let db_name = rand_name();
-    let write_buffer_connection = kafka_connection.to_string();
+    let write_buffer_connection = WriteBufferConnection::Writing(kafka_connection.to_string());
     create_readable_database_plus(&db_name, server.grpc_channel(), |mut rules| {
-        rules.write_buffer_connection = write_buffer_connection;
+        rules.write_buffer_connection = Some(write_buffer_connection);
         rules
     })
     .await;


### PR DESCRIPTION
This adds the reading side of the Kafka write buffer, that streams entries from a Kafka topic into a database's mutable buffer.

This PR is missing:

- Metrics counting the number of failed imports, see the TODO comments
- End-to-end integration tests

I will be adding these in future PRs.