### PR TITLE
feat: transactional lifecycle API

### DIFF
--- a/lifecycle/src/guard.rs
+++ b/lifecycle/src/guard.rs
@@ -1,0 +1,153 @@
+//! This module contains lock guards for use in the lifecycle traits
+//!
+//! Specifically they exist to work around a lack of support for generic associated
+//! types within traits. https://github.com/rust-lang/rust/issues/44265
+//!
+//! ```ignore
+//! trait MyTrait {
+//!     type Guard;
+//!
+//!     fn read(&self) -> Self::Guard<'_> <-- this is not valid rust
+//! }
+//! ```
+//!
+//! The structs in this module therefore provide concrete types that can be
+//! used in their place
+//!
+//! ```
+//! use lifecycle::LifecycleReadGuard;
+//! trait MyTrait {
+//!     type AdditionalData;
+//!     type LockedType;
+//!
+//!     fn read(&self) -> LifecycleReadGuard<'_, Self::LockedType, Self::AdditionalData>;
+//! }
+//! ```
+//!
+//! One drawback of this approach is that the type returned from the read() method can't
+//! be a user-provided type that implements a trait
+//!
+//! ```ignore
+//! trait MyTrait {
+//!     type Guard: GuardTrait; <-- this makes for a nice API
+//!
+//!     fn read(&self) -> Self::Guard<'_> <-- this is not valid rust
+//! }
+//! ```
+//!
+//! Instead we have to use associated functions, which are a bit more cumbersome
+//!
+//! ```
+//! use lifecycle::LifecycleReadGuard;
+//! trait MyTrait {
+//!     type AdditionalData;
+//!     type LockedType;
+//!
+//!     fn read(&self) -> LifecycleReadGuard<'_, Self::LockedType, Self::AdditionalData>;
+//!
+//!     fn guard_func(s: LifecycleReadGuard<'_, Self::LockedType, Self::AdditionalData>);
+//! }
+//!
+//! fn test<T: MyTrait>(t: T) {
+//!     let read = t.read();
+//!     T::guard_func(read);
+//! }
+//! ```
+//!
+
+use std::ops::{Deref, DerefMut};
+
+use tracker::{RwLock, RwLockUpgradableReadGuard, RwLockWriteGuard};
+
+/// The `LifecycleReadGuard` combines a `RwLockUpgradableReadGuard` with an arbitrary
+/// data payload of type `D`.
+///
+/// The data of `P` can be immutably accessed through `std::ops::Deref` akin
+/// to a normal read guard or smart pointer
+///
+/// Note: The `LifecycleReadGuard` will not block other readers to `RwLock<P>` but
+/// they will block other upgradeable readers, e.g. other `LifecycleReadGuard`
+pub struct LifecycleReadGuard<'a, P, D> {
+    data: D,
+    guard: RwLockUpgradableReadGuard<'a, P>,
+}
+
+impl<'a, P, D> LifecycleReadGuard<'a, P, D> {
+    /// Create a new `LifecycleReadGuard` from the provided lock
+    pub fn new(data: D, lock: &'a RwLock<P>) -> Self {
+        let guard = lock.upgradable_read();
+        Self { data, guard }
+    }
+
+    /// Upgrades this to a `LifecycleWriteGuard`
+    pub fn upgrade(self) -> LifecycleWriteGuard<'a, P, D> {
+        let guard = RwLockUpgradableReadGuard::upgrade(self.guard);
+        LifecycleWriteGuard {
+            data: self.data,
+            guard,
+        }
+    }
+
+    /// Returns a reference to the contained data payload
+    pub fn data(&self) -> &D {
+        &self.data
+    }
+
+    /// Drops the locks held by this guard and returns the data payload
+    pub fn unwrap(self) -> D {
+        self.data
+    }
+}
+
+impl<'a, P, D> Deref for LifecycleReadGuard<'a, P, D> {
+    type Target = P;
+    #[inline]
+    fn deref(&self) -> &P {
+        &self.guard
+    }
+}
+
+/// A `LifecycleWriteGuard` combines a `RwLockWriteGuard` with an arbitrary
+/// data payload of type `D`.
+///
+/// The data of `P` can be immutably accessed through `std::ops::Deref` akin to
+/// a normal read guard or smart pointer, and also mutably through
+/// `std::ops::DerefMut` akin to a normal write guard
+///
+pub struct LifecycleWriteGuard<'a, P, D> {
+    data: D,
+    guard: RwLockWriteGuard<'a, P>,
+}
+
+impl<'a, P, D> LifecycleWriteGuard<'a, P, D> {
+    /// Create a new `LifecycleWriteGuard` from the provided lock
+    pub fn new(data: D, lock: &'a RwLock<P>) -> Self {
+        let guard = lock.write();
+        Self { data, guard }
+    }
+
+    /// Returns a reference to the contained data payload
+    pub fn data(&self) -> &D {
+        &self.data
+    }
+
+    /// Drops the locks held by this guard and returns the data payload
+    pub fn unwrap(self) -> D {
+        self.data
+    }
+}
+
+impl<'a, P, D> Deref for LifecycleWriteGuard<'a, P, D> {
+    type Target = P;
+    #[inline]
+    fn deref(&self) -> &P {
+        &self.guard
+    }
+}
+
+impl<'a, P, D> DerefMut for LifecycleWriteGuard<'a, P, D> {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut P {
+        &mut self.guard
+    }
+}

--- a/lifecycle/src/lib.rs
+++ b/lifecycle/src/lib.rs
@@ -1,12 +1,13 @@
-use data_types::database_rules::{LifecycleRules, SortOrder};
-use std::sync::Arc;
-use tracker::{RwLock, TaskTracker};
-
-mod policy;
-
 use chrono::{DateTime, Utc};
+
 use data_types::chunk_metadata::ChunkStorage;
+use data_types::database_rules::{LifecycleRules, SortOrder};
+pub use guard::*;
 pub use policy::*;
+use tracker::TaskTracker;
+
+mod guard;
+mod policy;
 
 /// Any lifecycle action currently in progress for this chunk
 #[derive(Debug, Copy, Clone, PartialEq)]
@@ -32,38 +33,57 @@ impl ChunkLifecycleAction {
 }
 
 /// A trait that encapsulates the database logic that is automated by `LifecyclePolicy`
+///
+/// Note: This trait is meant to be implemented for references to types allowing them
+/// to yield `LifecycleDb::Chunk` with non-static lifetimes
 pub trait LifecycleDb {
-    type Chunk: LifecycleChunk;
+    type Chunk: LockableChunk;
 
     /// Return the in-memory size of the database. We expect this
     /// to change from call to call as chunks are dropped
-    fn buffer_size(&self) -> usize;
+    fn buffer_size(self) -> usize;
 
     /// Returns the lifecycle policy
-    fn rules(&self) -> LifecycleRules;
+    fn rules(self) -> LifecycleRules;
 
-    /// Returns a list of chunks sorted in the order
+    /// Returns a list of lockable chunks sorted in the order
     /// they should prioritised
-    fn chunks(&self, order: &SortOrder) -> Vec<Arc<RwLock<Self::Chunk>>>;
+    fn chunks(self, order: &SortOrder) -> Vec<Self::Chunk>;
+
+    /// Drops a chunk from the database
+    ///
+    /// TODO: Transaction-ify this
+    fn drop_chunk(self, table_name: String, partition_key: String, chunk_id: u32);
+}
+
+/// A `LockableChunk` is a wrapper around a `LifecycleChunk` that allows for
+/// planning and executing lifecycle actions on the chunk
+///
+/// Specifically a read lock can be obtained, a decision made based on the chunk's
+/// data, and then a lifecycle action optionally triggered, all without allowing
+/// concurrent modification
+///
+/// See the module level documentation for the guard module for more information
+/// on why this trait is the way it is
+///
+pub trait LockableChunk: Sized {
+    type Chunk: LifecycleChunk;
+    type Job: Sized + Send + Sync + 'static;
+
+    /// Acquire a shared read lock on the chunk
+    fn read(&self) -> LifecycleReadGuard<'_, Self::Chunk, Self>;
+
+    /// Acquire an exclusive write lock on the chunk
+    fn write(&self) -> LifecycleWriteGuard<'_, Self::Chunk, Self>;
 
     /// Starts an operation to move a chunk to the read buffer
-    fn move_to_read_buffer(
-        &self,
-        table_name: String,
-        partition_key: String,
-        chunk_id: u32,
-    ) -> TaskTracker<()>;
+    fn move_to_read_buffer(s: LifecycleWriteGuard<'_, Self::Chunk, Self>)
+        -> TaskTracker<Self::Job>;
 
     /// Starts an operation to write a chunk to the object store
     fn write_to_object_store(
-        &self,
-        table_name: String,
-        partition_key: String,
-        chunk_id: u32,
-    ) -> TaskTracker<()>;
-
-    /// Drops a chunk from the database
-    fn drop_chunk(&self, table_name: String, partition_key: String, chunk_id: u32);
+        s: LifecycleWriteGuard<'_, Self::Chunk, Self>,
+    ) -> TaskTracker<Self::Job>;
 
     /// Remove the copy of the Chunk's data from the read buffer.
     ///
@@ -71,7 +91,7 @@ pub trait LifecycleDb {
     /// (otherwise the read buffer may contain the *only* copy of this
     /// chunk's data). In order to drop un-persisted chunks,
     /// [`drop_chunk`](Self::drop_chunk) must be used.
-    fn unload_read_buffer(&self, table_name: String, partition_key: String, chunk_id: u32);
+    fn unload_read_buffer(s: LifecycleWriteGuard<'_, Self::Chunk, Self>);
 }
 
 /// The lifecycle operates on chunks implementing this trait

--- a/lifecycle/src/policy.rs
+++ b/lifecycle/src/policy.rs
@@ -1,5 +1,4 @@
 use std::convert::TryInto;
-use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use chrono::{DateTime, Utc};
@@ -10,7 +9,7 @@ use data_types::database_rules::LifecycleRules;
 use observability_deps::tracing::{debug, warn};
 use tracker::TaskTracker;
 
-use crate::{LifecycleChunk, LifecycleDb};
+use crate::{LifecycleChunk, LifecycleDb, LockableChunk};
 use data_types::chunk_metadata::ChunkStorage;
 
 pub const DEFAULT_LIFECYCLE_BACKOFF: Duration = Duration::from_secs(1);
@@ -21,15 +20,21 @@ pub const LIFECYCLE_ACTION_BACKOFF: Duration = Duration::from_secs(10);
 ///
 /// `LifecyclePolicy::check_for_work` can then be used to drive progress
 /// of the `LifecycleChunk` contained within this `LifecycleDb`
-pub struct LifecyclePolicy<M: LifecycleDb> {
-    db: Arc<M>,
+pub struct LifecyclePolicy<'a, M>
+where
+    &'a M: LifecycleDb,
+{
+    db: &'a M,
     // TODO: Remove these and use values from chunks within partition
-    move_tracker: Option<TaskTracker<()>>,
-    write_tracker: Option<TaskTracker<()>>,
+    move_tracker: Option<TaskTracker<<<&'a M as LifecycleDb>::Chunk as LockableChunk>::Job>>,
+    write_tracker: Option<TaskTracker<<<&'a M as LifecycleDb>::Chunk as LockableChunk>::Job>>,
 }
 
-impl<M: LifecycleDb + Sync + Send> LifecyclePolicy<M> {
-    pub fn new(db: Arc<M>) -> Self {
+impl<'a, M> LifecyclePolicy<'a, M>
+where
+    &'a M: LifecycleDb,
+{
+    pub fn new(db: &'a M) -> Self {
         Self {
             db,
             move_tracker: None,
@@ -79,8 +84,7 @@ impl<M: LifecycleDb + Sync + Send> LifecyclePolicy<M> {
                     && now_instant.duration_since(lifecycle_action.start_instant())
                         >= LIFECYCLE_ACTION_BACKOFF
                 {
-                    std::mem::drop(chunk_guard);
-                    chunk.write().clear_lifecycle_action();
+                    chunk_guard.upgrade().clear_lifecycle_action();
                 }
                 continue;
             }
@@ -89,44 +93,17 @@ impl<M: LifecycleDb + Sync + Send> LifecyclePolicy<M> {
                 ChunkStorage::OpenMutableBuffer => {
                     open_partitions.insert(chunk_guard.partition_key().to_string());
                     if self.move_tracker.is_none() && would_move {
-                        let partition_key = chunk_guard.partition_key();
-                        let table_name = chunk_guard.table_name();
-                        let chunk_id = chunk_guard.chunk_id();
-
-                        std::mem::drop(chunk_guard);
-
-                        self.move_tracker = Some(self.db.move_to_read_buffer(
-                            table_name,
-                            partition_key,
-                            chunk_id,
-                        ));
+                        self.move_tracker =
+                            Some(LockableChunk::move_to_read_buffer(chunk_guard.upgrade()));
                     }
                 }
                 ChunkStorage::ClosedMutableBuffer if self.move_tracker.is_none() => {
-                    let partition_key = chunk_guard.partition_key();
-                    let table_name = chunk_guard.table_name();
-                    let chunk_id = chunk_guard.chunk_id();
-
-                    std::mem::drop(chunk_guard);
-
-                    self.move_tracker = Some(self.db.move_to_read_buffer(
-                        table_name,
-                        partition_key,
-                        chunk_id,
-                    ));
+                    self.move_tracker =
+                        Some(LockableChunk::move_to_read_buffer(chunk_guard.upgrade()));
                 }
                 ChunkStorage::ReadBuffer if would_write => {
-                    let partition_key = chunk_guard.partition_key();
-                    let table_name = chunk_guard.table_name();
-                    let chunk_id = chunk_guard.chunk_id();
-
-                    std::mem::drop(chunk_guard);
-
-                    self.write_tracker = Some(self.db.write_to_object_store(
-                        table_name,
-                        partition_key,
-                        chunk_id,
-                    ));
+                    self.write_tracker =
+                        Some(LockableChunk::write_to_object_store(chunk_guard.upgrade()));
                 }
                 _ => {
                     // Chunk is already persisted, no additional work needed to persist it
@@ -180,7 +157,6 @@ impl<M: LifecycleDb + Sync + Send> LifecyclePolicy<M> {
                         let partition_key = chunk_guard.partition_key();
                         let table_name = chunk_guard.table_name();
                         let chunk_id = chunk_guard.chunk_id();
-                        std::mem::drop(chunk_guard);
 
                         match action {
                             Action::Drop => {
@@ -192,8 +168,7 @@ impl<M: LifecycleDb + Sync + Send> LifecyclePolicy<M> {
                                 self.db.drop_chunk(table_name, partition_key, chunk_id)
                             }
                             Action::Unload => {
-                                self.db
-                                    .unload_read_buffer(table_name, partition_key, chunk_id)
+                                LockableChunk::unload_read_buffer(chunk_guard.upgrade())
                             }
                         }
                     }
@@ -295,7 +270,8 @@ mod tests {
     use tracker::{RwLock, TaskId, TaskRegistration, TaskRegistry};
 
     use super::*;
-    use crate::ChunkLifecycleAction;
+    use crate::{ChunkLifecycleAction, LifecycleReadGuard, LifecycleWriteGuard, LockableChunk};
+    use std::sync::Arc;
 
     #[derive(Debug, Eq, PartialEq)]
     enum MoverEvents {
@@ -337,6 +313,58 @@ mod tests {
                 lifecycle_action: Some(TaskTracker::complete(action)),
                 storage: self.storage,
             }
+        }
+    }
+
+    #[derive(Clone)]
+    struct TestLockableChunk<'a> {
+        db: &'a TestDb,
+        chunk: Arc<RwLock<TestChunk>>,
+    }
+
+    impl<'a> LockableChunk for TestLockableChunk<'a> {
+        type Chunk = TestChunk;
+        type Job = ();
+
+        fn read(&self) -> LifecycleReadGuard<'_, Self::Chunk, Self> {
+            LifecycleReadGuard::new(self.clone(), &self.chunk)
+        }
+
+        fn write(&self) -> LifecycleWriteGuard<'_, Self::Chunk, Self> {
+            LifecycleWriteGuard::new(self.clone(), &self.chunk)
+        }
+
+        fn move_to_read_buffer(
+            mut s: LifecycleWriteGuard<'_, Self::Chunk, Self>,
+        ) -> TaskTracker<()> {
+            s.storage = ChunkStorage::ReadBuffer;
+            s.data()
+                .db
+                .events
+                .write()
+                .push(MoverEvents::Move(s.chunk_id()));
+            TaskTracker::complete(())
+        }
+
+        fn write_to_object_store(
+            mut s: LifecycleWriteGuard<'_, Self::Chunk, Self>,
+        ) -> TaskTracker<()> {
+            s.storage = ChunkStorage::ReadBufferAndObjectStore;
+            s.data()
+                .db
+                .events
+                .write()
+                .push(MoverEvents::Write(s.chunk_id()));
+            TaskTracker::complete(())
+        }
+
+        fn unload_read_buffer(mut s: LifecycleWriteGuard<'_, Self::Chunk, Self>) {
+            s.storage = ChunkStorage::ObjectStoreOnly;
+            s.data()
+                .db
+                .events
+                .write()
+                .push(MoverEvents::Unload(s.chunk_id()))
         }
     }
 
@@ -396,69 +424,33 @@ mod tests {
         }
     }
 
-    impl LifecycleDb for TestDb {
-        type Chunk = TestChunk;
+    impl<'a> LifecycleDb for &'a TestDb {
+        type Chunk = TestLockableChunk<'a>;
 
-        fn buffer_size(&self) -> usize {
+        fn buffer_size(self) -> usize {
             // All chunks are 20 bytes
             self.chunks.read().len() * 20
         }
 
-        fn rules(&self) -> LifecycleRules {
+        fn rules(self) -> LifecycleRules {
             self.rules.clone()
         }
 
-        fn chunks(&self, _: &SortOrder) -> Vec<Arc<RwLock<TestChunk>>> {
-            self.chunks.read().clone()
-        }
-
-        fn move_to_read_buffer(
-            &self,
-            _table_name: String,
-            _partition_key: String,
-            chunk_id: u32,
-        ) -> TaskTracker<()> {
-            let chunks = self.chunks.read();
-            let chunk = chunks
+        fn chunks(self, _: &SortOrder) -> Vec<Self::Chunk> {
+            self.chunks
+                .read()
                 .iter()
-                .find(|x| x.read().chunk_id() == chunk_id)
-                .unwrap();
-            chunk.write().storage = ChunkStorage::ReadBuffer;
-            self.events.write().push(MoverEvents::Move(chunk_id));
-            TaskTracker::complete(())
+                .map(|x| TestLockableChunk {
+                    db: self,
+                    chunk: Arc::clone(x),
+                })
+                .collect()
         }
 
-        fn write_to_object_store(
-            &self,
-            _table_name: String,
-            _partition_key: String,
-            chunk_id: u32,
-        ) -> TaskTracker<()> {
-            let chunks = self.chunks.read();
-            let chunk = chunks
-                .iter()
-                .find(|x| x.read().chunk_id() == chunk_id)
-                .unwrap();
-            chunk.write().storage = ChunkStorage::ReadBufferAndObjectStore;
-            self.events.write().push(MoverEvents::Write(chunk_id));
-            TaskTracker::complete(())
-        }
-
-        fn drop_chunk(&self, _table_name: String, _partition_key: String, chunk_id: u32) {
+        fn drop_chunk(self, _table_name: String, _partition_key: String, chunk_id: u32) {
             let mut chunks = self.chunks.write();
             chunks.retain(|x| x.read().chunk_id() != chunk_id);
             self.events.write().push(MoverEvents::Drop(chunk_id))
-        }
-
-        fn unload_read_buffer(&self, _table_name: String, _partition_key: String, chunk_id: u32) {
-            let chunks = self.chunks.read();
-            let chunk = chunks
-                .iter()
-                .find(|x| x.read().chunk_id() == chunk_id)
-                .unwrap();
-
-            chunk.write().storage = ChunkStorage::ObjectStoreOnly;
-            self.events.write().push(MoverEvents::Unload(chunk_id))
         }
     }
 
@@ -515,8 +507,8 @@ mod tests {
             TestChunk::new(2, Some(30), Some(1), ChunkStorage::OpenMutableBuffer),
         ];
 
-        let db = Arc::new(TestDb::new(rules, chunks));
-        let mut lifecycle = LifecyclePolicy::new(Arc::clone(&db));
+        let db = TestDb::new(rules, chunks);
+        let mut lifecycle = LifecyclePolicy::new(&db);
         lifecycle.check_for_work(from_secs(40), Instant::now());
         assert_eq!(*db.events.read(), vec![]);
     }
@@ -533,8 +525,8 @@ mod tests {
             TestChunk::new(2, Some(0), Some(0), ChunkStorage::OpenMutableBuffer),
         ];
 
-        let db = Arc::new(TestDb::new(rules, chunks));
-        let mut lifecycle = LifecyclePolicy::new(Arc::clone(&db));
+        let db = TestDb::new(rules, chunks);
+        let mut lifecycle = LifecyclePolicy::new(&db);
 
         lifecycle.check_for_work(from_secs(9), Instant::now());
 
@@ -579,8 +571,8 @@ mod tests {
             ChunkStorage::OpenMutableBuffer,
         )];
 
-        let db = Arc::new(TestDb::new(rules, chunks));
-        let mut lifecycle = LifecyclePolicy::new(Arc::clone(&db));
+        let db = TestDb::new(rules, chunks);
+        let mut lifecycle = LifecyclePolicy::new(&db);
 
         let (tracker, registration) = registry.register(());
         lifecycle.move_tracker = Some(tracker);
@@ -602,8 +594,8 @@ mod tests {
             mutable_linger_seconds: Some(NonZeroU32::new(100).unwrap()),
             ..Default::default()
         };
-        let db = Arc::new(TestDb::new(rules, vec![]));
-        let mut lifecycle = LifecyclePolicy::new(Arc::clone(&db));
+        let db = TestDb::new(rules, vec![]);
+        let mut lifecycle = LifecyclePolicy::new(&db);
 
         let (tracker, registration) = registry.register(());
 
@@ -635,8 +627,8 @@ mod tests {
             TestChunk::new(1, Some(0), Some(0), ChunkStorage::OpenMutableBuffer),
         ];
 
-        let db = Arc::new(TestDb::new(rules, chunks));
-        let mut lifecycle = LifecyclePolicy::new(Arc::clone(&db));
+        let db = TestDb::new(rules, chunks);
+        let mut lifecycle = LifecyclePolicy::new(&db);
 
         // Expect to move chunk_id=1 first, despite it coming second in
         // the order, because chunk_id=0 will only become old enough at t=100
@@ -674,8 +666,8 @@ mod tests {
             ChunkStorage::OpenMutableBuffer,
         )];
 
-        let db = Arc::new(TestDb::new(rules.clone(), chunks));
-        let mut lifecycle = LifecyclePolicy::new(Arc::clone(&db));
+        let db = TestDb::new(rules.clone(), chunks);
+        let mut lifecycle = LifecyclePolicy::new(&db);
 
         lifecycle.check_for_work(from_secs(10), Instant::now());
         assert_eq!(*db.events.read(), vec![]);
@@ -693,8 +685,8 @@ mod tests {
             TestChunk::new(4, Some(0), Some(0), ChunkStorage::ReadBufferAndObjectStore),
         ];
 
-        let db = Arc::new(TestDb::new(rules, chunks));
-        let mut lifecycle = LifecyclePolicy::new(Arc::clone(&db));
+        let db = TestDb::new(rules, chunks);
+        let mut lifecycle = LifecyclePolicy::new(&db);
 
         lifecycle.check_for_work(from_secs(10), Instant::now());
         assert_eq!(
@@ -723,8 +715,8 @@ mod tests {
             ChunkStorage::OpenMutableBuffer,
         )];
 
-        let db = Arc::new(TestDb::new(rules.clone(), chunks));
-        let mut lifecycle = LifecyclePolicy::new(Arc::clone(&db));
+        let db = TestDb::new(rules.clone(), chunks);
+        let mut lifecycle = LifecyclePolicy::new(&db);
 
         lifecycle.check_for_work(from_secs(10), Instant::now());
         assert_eq!(*db.events.read(), vec![]);
@@ -742,8 +734,8 @@ mod tests {
             TestChunk::new(4, Some(0), Some(0), ChunkStorage::ReadBufferAndObjectStore),
         ];
 
-        let db = Arc::new(TestDb::new(rules, chunks));
-        let mut lifecycle = LifecyclePolicy::new(Arc::clone(&db));
+        let db = TestDb::new(rules, chunks);
+        let mut lifecycle = LifecyclePolicy::new(&db);
 
         lifecycle.check_for_work(from_secs(10), Instant::now());
         assert_eq!(*db.events.read(), vec![MoverEvents::Unload(4)]);
@@ -764,8 +756,8 @@ mod tests {
             ChunkStorage::OpenMutableBuffer,
         )];
 
-        let db = Arc::new(TestDb::new(rules, chunks));
-        let mut lifecycle = LifecyclePolicy::new(Arc::clone(&db));
+        let db = TestDb::new(rules, chunks);
+        let mut lifecycle = LifecyclePolicy::new(&db);
 
         lifecycle.check_for_work(from_secs(10), Instant::now());
         assert_eq!(*db.events.read(), vec![]);
@@ -789,8 +781,8 @@ mod tests {
             TestChunk::new(2, Some(0), Some(0), ChunkStorage::ReadBufferAndObjectStore),
         ];
 
-        let db = Arc::new(TestDb::new(rules, chunks));
-        let mut lifecycle = LifecyclePolicy::new(Arc::clone(&db));
+        let db = TestDb::new(rules, chunks);
+        let mut lifecycle = LifecyclePolicy::new(&db);
 
         lifecycle.check_for_work(from_secs(0), Instant::now());
         assert_eq!(*db.events.read(), vec![MoverEvents::Write(1)]);
@@ -810,8 +802,8 @@ mod tests {
             ChunkStorage::OpenMutableBuffer,
         )];
 
-        let db = Arc::new(TestDb::new(rules, chunks));
-        let mut lifecycle = LifecyclePolicy::new(Arc::clone(&db));
+        let db = TestDb::new(rules, chunks);
+        let mut lifecycle = LifecyclePolicy::new(&db);
 
         // Initially can't move
         lifecycle.check_for_work(from_secs(80), Instant::now());
@@ -834,8 +826,8 @@ mod tests {
             ChunkStorage::ClosedMutableBuffer,
         )];
 
-        let db = Arc::new(TestDb::new(rules, chunks));
-        let mut lifecycle = LifecyclePolicy::new(Arc::clone(&db));
+        let db = TestDb::new(rules, chunks);
+        let mut lifecycle = LifecyclePolicy::new(&db);
         let chunk = &db.chunks.read()[0];
 
         let r0 = TaskRegistration::default();

--- a/query_tests/src/pruning.rs
+++ b/query_tests/src/pruning.rs
@@ -28,7 +28,7 @@ async fn setup() -> TestDb {
         .await
         .unwrap()
         .unwrap();
-    db.load_chunk_to_read_buffer("cpu", partition_key, mb_chunk.id(), &Default::default())
+    db.load_chunk_to_read_buffer("cpu", partition_key, mb_chunk.id())
         .await
         .unwrap();
 
@@ -43,7 +43,7 @@ async fn setup() -> TestDb {
         .await
         .unwrap()
         .unwrap();
-    db.load_chunk_to_read_buffer("cpu", partition_key, mb_chunk.id(), &Default::default())
+    db.load_chunk_to_read_buffer("cpu", partition_key, mb_chunk.id())
         .await
         .unwrap();
 

--- a/query_tests/src/scenarios.rs
+++ b/query_tests/src/scenarios.rs
@@ -72,7 +72,7 @@ impl DbSetup for NoData {
         assert_eq!(count_object_store_chunks(&db), 0); // nothing yet
 
         // Now load the closed chunk into the RB
-        db.load_chunk_to_read_buffer(table_name, partition_key, 0, &Default::default())
+        db.load_chunk_to_read_buffer(table_name, partition_key, 0)
             .await
             .unwrap();
         assert_eq!(count_mutable_buffer_chunks(&db), 0); // open chunk only
@@ -110,7 +110,7 @@ impl DbSetup for NoData {
         assert_eq!(count_object_store_chunks(&db), 0); // nothing yet
 
         // Now load the closed chunk into the RB
-        db.load_chunk_to_read_buffer(table_name, partition_key, 0, &Default::default())
+        db.load_chunk_to_read_buffer(table_name, partition_key, 0)
             .await
             .unwrap();
         assert_eq!(count_mutable_buffer_chunks(&db), 0); // open chunk only
@@ -118,7 +118,7 @@ impl DbSetup for NoData {
         assert_eq!(count_object_store_chunks(&db), 0); // nothing yet
 
         // Now write the data in RB to object store but keep it in RB
-        db.write_chunk_to_object_store("cpu", partition_key, 0, &Default::default())
+        db.write_chunk_to_object_store("cpu", partition_key, 0)
             .await
             .unwrap();
         // it should be the same chunk!
@@ -309,7 +309,7 @@ impl DbSetup for TwoMeasurementsManyFieldsTwoChunks {
         ];
         write_lp(&db, &lp_lines.join("\n"));
         db.rollover_partition("h2o", partition_key).await.unwrap();
-        db.load_chunk_to_read_buffer("h2o", partition_key, 0, &Default::default())
+        db.load_chunk_to_read_buffer("h2o", partition_key, 0)
             .await
             .unwrap();
 
@@ -344,7 +344,7 @@ impl DbSetup for OneMeasurementTwoChunksDifferentTagSet {
         ];
         write_lp(&db, &lp_lines.join("\n"));
         db.rollover_partition("h2o", partition_key).await.unwrap();
-        db.load_chunk_to_read_buffer("h2o", partition_key, 0, &Default::default())
+        db.load_chunk_to_read_buffer("h2o", partition_key, 0)
             .await
             .unwrap();
 
@@ -355,7 +355,7 @@ impl DbSetup for OneMeasurementTwoChunksDifferentTagSet {
         ];
         write_lp(&db, &lp_lines.join("\n"));
         db.rollover_partition("h2o", partition_key).await.unwrap();
-        db.load_chunk_to_read_buffer("h2o", partition_key, 1, &Default::default())
+        db.load_chunk_to_read_buffer("h2o", partition_key, 1)
             .await
             .unwrap();
 
@@ -387,7 +387,7 @@ impl DbSetup for OneMeasurementThreeChunksWithDuplicates {
         ];
         write_lp(&db, &lp_lines.join("\n"));
         db.rollover_partition("h2o", partition_key).await.unwrap();
-        db.load_chunk_to_read_buffer("h2o", partition_key, 0, &Default::default())
+        db.load_chunk_to_read_buffer("h2o", partition_key, 0)
             .await
             .unwrap();
 
@@ -404,7 +404,7 @@ impl DbSetup for OneMeasurementThreeChunksWithDuplicates {
         ];
         write_lp(&db, &lp_lines.join("\n"));
         db.rollover_partition("h2o", partition_key).await.unwrap();
-        db.load_chunk_to_read_buffer("h2o", partition_key, 1, &Default::default())
+        db.load_chunk_to_read_buffer("h2o", partition_key, 1)
             .await
             .unwrap();
 
@@ -421,7 +421,7 @@ impl DbSetup for OneMeasurementThreeChunksWithDuplicates {
         ];
         write_lp(&db, &lp_lines.join("\n"));
         db.rollover_partition("h2o", partition_key).await.unwrap();
-        db.load_chunk_to_read_buffer("h2o", partition_key, 2, &Default::default())
+        db.load_chunk_to_read_buffer("h2o", partition_key, 2)
             .await
             .unwrap();
 
@@ -438,7 +438,7 @@ impl DbSetup for OneMeasurementThreeChunksWithDuplicates {
         ];
         write_lp(&db, &lp_lines.join("\n"));
         db.rollover_partition("h2o", partition_key).await.unwrap();
-        db.load_chunk_to_read_buffer("h2o", partition_key, 3, &Default::default())
+        db.load_chunk_to_read_buffer("h2o", partition_key, 3)
             .await
             .unwrap();
 
@@ -472,24 +472,18 @@ impl DbSetup for TwoMeasurementsManyFieldsLifecycle {
         // Use a background task to do the work note when I used
         // TaskTracker::join, it ended up hanging for reasons I don't
         // now
-        let job = db.load_chunk_to_read_buffer_in_background(
-            "h2o".to_string(),
-            partition_key.to_string(),
-            0,
-        );
-        job.join().await;
+        db.load_chunk_to_read_buffer("h2o", partition_key, 0)
+            .await
+            .unwrap();
 
         write_lp(
             &db,
             &vec!["h2o,state=CA,city=Boston other_temp=72.4 350"].join("\n"),
         );
 
-        let job = db.write_chunk_to_object_store_in_background(
-            "h2o".to_string(),
-            partition_key.to_string(),
-            0,
-        );
-        job.join().await;
+        db.write_chunk_to_object_store("h2o", partition_key, 0)
+            .await
+            .unwrap();
 
         let db =
             std::sync::Arc::try_unwrap(db).expect("All background handles to db should be done");
@@ -584,7 +578,7 @@ pub(crate) async fn make_one_chunk_scenarios(partition_key: &str, data: &str) ->
         db.rollover_partition(&table_name, partition_key)
             .await
             .unwrap();
-        db.load_chunk_to_read_buffer(&table_name, partition_key, 0, &Default::default())
+        db.load_chunk_to_read_buffer(&table_name, partition_key, 0)
             .await
             .unwrap();
     }
@@ -600,11 +594,11 @@ pub(crate) async fn make_one_chunk_scenarios(partition_key: &str, data: &str) ->
         db.rollover_partition(&table_name, partition_key)
             .await
             .unwrap();
-        db.load_chunk_to_read_buffer(&table_name, partition_key, 0, &Default::default())
+        db.load_chunk_to_read_buffer(&table_name, partition_key, 0)
             .await
             .unwrap();
 
-        db.write_chunk_to_object_store(&table_name, partition_key, 0, &Default::default())
+        db.write_chunk_to_object_store(&table_name, partition_key, 0)
             .await
             .unwrap();
     }
@@ -620,10 +614,10 @@ pub(crate) async fn make_one_chunk_scenarios(partition_key: &str, data: &str) ->
         db.rollover_partition(&table_name, partition_key)
             .await
             .unwrap();
-        db.load_chunk_to_read_buffer(&table_name, partition_key, 0, &Default::default())
+        db.load_chunk_to_read_buffer(&table_name, partition_key, 0)
             .await
             .unwrap();
-        db.write_chunk_to_object_store(&table_name, partition_key, 0, &Default::default())
+        db.write_chunk_to_object_store(&table_name, partition_key, 0)
             .await
             .unwrap();
         db.unload_read_buffer(&table_name, partition_key, 0)
@@ -677,7 +671,7 @@ pub async fn make_two_chunk_scenarios(
         db.rollover_partition(&table_name, partition_key)
             .await
             .unwrap();
-        db.load_chunk_to_read_buffer(&table_name, partition_key, 0, &Default::default())
+        db.load_chunk_to_read_buffer(&table_name, partition_key, 0)
             .await
             .unwrap();
     }
@@ -701,11 +695,11 @@ pub async fn make_two_chunk_scenarios(
             .await
             .unwrap();
 
-        db.load_chunk_to_read_buffer(&table_name, partition_key, 0, &Default::default())
+        db.load_chunk_to_read_buffer(&table_name, partition_key, 0)
             .await
             .unwrap();
 
-        db.load_chunk_to_read_buffer(&table_name, partition_key, 1, &Default::default())
+        db.load_chunk_to_read_buffer(&table_name, partition_key, 1)
             .await
             .unwrap();
     }
@@ -728,19 +722,19 @@ pub async fn make_two_chunk_scenarios(
             .await
             .unwrap();
 
-        db.load_chunk_to_read_buffer(&table_name, partition_key, 0, &Default::default())
+        db.load_chunk_to_read_buffer(&table_name, partition_key, 0)
             .await
             .unwrap();
 
-        db.load_chunk_to_read_buffer(&table_name, partition_key, 1, &Default::default())
+        db.load_chunk_to_read_buffer(&table_name, partition_key, 1)
             .await
             .unwrap();
 
-        db.write_chunk_to_object_store(&table_name, partition_key, 0, &Default::default())
+        db.write_chunk_to_object_store(&table_name, partition_key, 0)
             .await
             .unwrap();
 
-        db.write_chunk_to_object_store(&table_name, partition_key, 1, &Default::default())
+        db.write_chunk_to_object_store(&table_name, partition_key, 1)
             .await
             .unwrap();
     }
@@ -763,19 +757,19 @@ pub async fn make_two_chunk_scenarios(
             .await
             .unwrap();
 
-        db.load_chunk_to_read_buffer(&table_name, partition_key, 0, &Default::default())
+        db.load_chunk_to_read_buffer(&table_name, partition_key, 0)
             .await
             .unwrap();
 
-        db.load_chunk_to_read_buffer(&table_name, partition_key, 1, &Default::default())
+        db.load_chunk_to_read_buffer(&table_name, partition_key, 1)
             .await
             .unwrap();
 
-        db.write_chunk_to_object_store(&table_name, partition_key, 0, &Default::default())
+        db.write_chunk_to_object_store(&table_name, partition_key, 0)
             .await
             .unwrap();
 
-        db.write_chunk_to_object_store(&table_name, partition_key, 1, &Default::default())
+        db.write_chunk_to_object_store(&table_name, partition_key, 1)
             .await
             .unwrap();
         db.unload_read_buffer(&table_name, partition_key, 0)
@@ -798,10 +792,10 @@ pub async fn rollover_and_load(db: &Db, partition_key: &str, table_name: &str) {
     db.rollover_partition(table_name, partition_key)
         .await
         .unwrap();
-    db.load_chunk_to_read_buffer(table_name, partition_key, 0, &Default::default())
+    db.load_chunk_to_read_buffer(table_name, partition_key, 0)
         .await
         .unwrap();
-    db.write_chunk_to_object_store(table_name, partition_key, 0, &Default::default())
+    db.write_chunk_to_object_store(table_name, partition_key, 0)
         .await
         .unwrap();
 }
@@ -818,7 +812,7 @@ pub(crate) async fn make_one_rub_or_parquet_chunk_scenario(
         db.rollover_partition(&table_name, partition_key)
             .await
             .unwrap();
-        db.load_chunk_to_read_buffer(&table_name, partition_key, 0, &Default::default())
+        db.load_chunk_to_read_buffer(&table_name, partition_key, 0)
             .await
             .unwrap();
     }
@@ -834,10 +828,10 @@ pub(crate) async fn make_one_rub_or_parquet_chunk_scenario(
         db.rollover_partition(&table_name, partition_key)
             .await
             .unwrap();
-        db.load_chunk_to_read_buffer(&table_name, partition_key, 0, &Default::default())
+        db.load_chunk_to_read_buffer(&table_name, partition_key, 0)
             .await
             .unwrap();
-        db.write_chunk_to_object_store(&table_name, partition_key, 0, &Default::default())
+        db.write_chunk_to_object_store(&table_name, partition_key, 0)
             .await
             .unwrap();
         db.unload_read_buffer(&table_name, partition_key, 0)

--- a/server/src/db.rs
+++ b/server/src/db.rs
@@ -2,10 +2,12 @@
 //! instances of the mutable buffer, read buffer, and object store
 
 use self::access::QueryCatalogAccess;
-use self::catalog::chunk::ChunkStage;
 use self::catalog::TableNameFilter;
 use super::{write_buffer::WriteBuffer, JobRegistry};
+use crate::db::catalog::chunk::ChunkStage;
 use crate::db::catalog::partition::Partition;
+use crate::db::lifecycle::LockableCatalogChunk;
+use ::lifecycle::{LifecycleWriteGuard, LockableChunk};
 use arrow::datatypes::SchemaRef as ArrowSchemaRef;
 use async_trait::async_trait;
 use catalog::{chunk::CatalogChunk, Catalog};
@@ -42,6 +44,7 @@ use rand_distr::{Distribution, Poisson};
 use read_buffer::{ChunkMetrics as ReadBufferChunkMetrics, RBChunk};
 use snafu::{ResultExt, Snafu};
 use std::collections::{HashMap, HashSet};
+use std::future::Future;
 use std::{
     any::Any,
     num::NonZeroUsize,
@@ -51,7 +54,7 @@ use std::{
     },
     time::Duration,
 };
-use tracker::{TaskRegistration, TaskTracker, TrackedFutureExt};
+use tracker::{TaskTracker, TrackedFuture, TrackedFutureExt};
 
 pub mod access;
 pub mod catalog;
@@ -67,19 +70,8 @@ pub enum Error {
     #[snafu(context(false))]
     CatalogError { source: catalog::Error },
 
-    #[snafu(display(
-        "Lifecycle error: {}:{}:{} {}",
-        partition_key,
-        table_name,
-        chunk_id,
-        source
-    ))]
-    LifecycleError {
-        partition_key: String,
-        table_name: String,
-        chunk_id: u32,
-        source: catalog::chunk::Error,
-    },
+    #[snafu(display("Lifecycle error: {}", source))]
+    LifecycleError { source: catalog::chunk::Error },
 
     #[snafu(display(
         "Can not drop chunk {}:{}:{} which has an in-progress lifecycle action {}. Wait for this to complete",
@@ -153,6 +145,9 @@ pub enum Error {
     TransactionError {
         source: parquet_file::catalog::Error,
     },
+
+    #[snafu(display("background task cancelled: {}", source))]
+    TaskCancelled { source: futures::future::Aborted },
 }
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
@@ -232,7 +227,7 @@ pub struct Db {
     ///  - The Read Buffer where chunks are immutable and stored in an optimised
     ///    compressed form for small footprint and fast query execution; and
     ///  - The Parquet Buffer where chunks are backed by Parquet file data.
-    preserved_catalog: PreservedCatalog<Catalog>,
+    preserved_catalog: Arc<PreservedCatalog<Catalog>>,
 
     /// A handle to the global jobs registry for long running tasks
     jobs: Arc<JobRegistry>,
@@ -377,7 +372,7 @@ impl Db {
             server_id,
             store,
             exec,
-            preserved_catalog,
+            preserved_catalog: Arc::new(preserved_catalog),
             jobs,
             metrics_registry,
             catalog_access,
@@ -408,11 +403,7 @@ impl Db {
 
         if let Some(chunk) = chunk {
             let mut chunk = chunk.write();
-            chunk.freeze().context(LifecycleError {
-                partition_key,
-                table_name,
-                chunk_id: chunk.id(),
-            })?;
+            chunk.freeze().context(LifecycleError)?;
 
             Ok(Some(DbChunk::snapshot(&chunk)))
         } else {
@@ -424,7 +415,7 @@ impl Db {
         &self,
         table_name: &str,
         partition_key: &str,
-    ) -> Result<Arc<tracker::RwLock<Partition>>> {
+    ) -> catalog::Result<Arc<tracker::RwLock<Partition>>> {
         let partition = self
             .preserved_catalog
             .state()
@@ -437,11 +428,20 @@ impl Db {
         table_name: &str,
         partition_key: &str,
         chunk_id: u32,
-    ) -> Result<Arc<tracker::RwLock<CatalogChunk>>> {
-        Ok(self
-            .preserved_catalog
+    ) -> catalog::Result<Arc<tracker::RwLock<CatalogChunk>>> {
+        self.preserved_catalog
             .state()
-            .chunk(table_name, partition_key, chunk_id)?)
+            .chunk(table_name, partition_key, chunk_id)
+    }
+
+    pub fn lockable_chunk(
+        &self,
+        table_name: &str,
+        partition_key: &str,
+        chunk_id: u32,
+    ) -> catalog::Result<LockableCatalogChunk<'_>> {
+        let chunk = self.chunk(table_name, partition_key, chunk_id)?;
+        Ok(LockableCatalogChunk { db: self, chunk })
     }
 
     /// Drops the specified chunk from the catalog and all storage systems
@@ -503,179 +503,217 @@ impl Db {
         table_name: &str,
         partition_key: &str,
         chunk_id: u32,
-        tracker: &TaskRegistration,
     ) -> Result<Arc<DbChunk>> {
-        let chunk = self.chunk(table_name, partition_key, chunk_id)?;
+        let chunk = self.lockable_chunk(table_name, partition_key, chunk_id)?;
+        let (_, fut) = Self::load_chunk_to_read_buffer_impl(chunk.write())?;
+        fut.await.context(TaskCancelled)?
+    }
+
+    /// The implementation for moving a chunk to the read buffer
+    ///
+    /// Returns a future registered with the tracker registry, and the corresponding tracker
+    /// The caller can either spawn this future to tokio, or block directly on it
+    fn load_chunk_to_read_buffer_impl(
+        mut guard: LifecycleWriteGuard<'_, CatalogChunk, LockableCatalogChunk<'_>>,
+    ) -> Result<(
+        TaskTracker<Job>,
+        TrackedFuture<impl Future<Output = Result<Arc<DbChunk>>> + Send>,
+    )> {
+        let db = guard.data().db;
+        let addr = guard.addr().clone();
+        // TODO: Use ChunkAddr within Job
+        let (tracker, registration) = db.jobs.register(Job::CloseChunk {
+            db_name: addr.db_name.to_string(),
+            partition_key: addr.partition_key.to_string(),
+            table_name: addr.table_name.to_string(),
+            chunk_id: addr.chunk_id,
+        });
 
         // update the catalog to say we are processing this chunk and
         // then drop the lock while we do the work
         let (mb_chunk, table_summary) = {
-            let mut chunk = chunk.write();
-
-            let mb_chunk = chunk.set_moving(tracker).context(LifecycleError {
-                partition_key,
-                table_name,
-                chunk_id,
-            })?;
-            (mb_chunk, chunk.table_summary())
+            let mb_chunk = guard.set_moving(&registration).context(LifecycleError)?;
+            (mb_chunk, guard.table_summary())
         };
 
-        info!(%table_name, %partition_key, %chunk_id, "chunk marked MOVING, loading tables into read buffer");
+        // Drop locks
+        let chunk = guard.unwrap().chunk;
 
         // create a new read buffer chunk with memory tracking
-        let metrics = self
+        let metrics = db
             .metrics_registry
-            .register_domain_with_labels("read_buffer", self.metric_labels.clone());
+            .register_domain_with_labels("read_buffer", db.metric_labels.clone());
+
         let mut rb_chunk = RBChunk::new(ReadBufferChunkMetrics::new(
             &metrics,
-            self.preserved_catalog
+            db.preserved_catalog
                 .state()
                 .metrics()
                 .memory()
                 .read_buffer(),
         ));
 
-        // load table into the new chunk one by one.
-        debug!(%table_name, %partition_key, %chunk_id, table=%table_summary.name, "loading table to read buffer");
-        let batch = mb_chunk
-            .read_filter(Selection::All)
-            // It is probably reasonable to recover from this error
-            // (reset the chunk state to Open) but until that is
-            // implemented (and tested) just panic
-            .expect("Loading chunk to mutable buffer");
+        let fut = async move {
+            info!(chunk=%addr, "chunk marked MOVING, loading tables into read buffer");
 
-        let sorted = sort_record_batch(batch).expect("failed to sort");
-        rb_chunk.upsert_table(&table_summary.name, sorted);
+            // load table into the new chunk one by one.
+            debug!(chunk=%addr, "loading table to read buffer");
+            let batch = mb_chunk
+                .read_filter(Selection::All)
+                // It is probably reasonable to recover from this error
+                // (reset the chunk state to Open) but until that is
+                // implemented (and tested) just panic
+                .expect("Loading chunk to mutable buffer");
 
-        // Relock the chunk again (nothing else should have been able
-        // to modify the chunk state while we were moving it
-        let mut chunk = chunk.write();
+            let sorted = sort_record_batch(batch).expect("failed to sort");
+            rb_chunk.upsert_table(&table_summary.name, sorted);
 
-        // update the catalog to say we are done processing
-        chunk
-            .set_moved(Arc::new(rb_chunk))
-            .context(LifecycleError {
-                partition_key,
-                table_name,
-                chunk_id,
-            })?;
+            // Can drop and re-acquire as lifecycle action prevents concurrent modification
+            let mut guard = chunk.write();
 
-        debug!(%table_name, %partition_key, %chunk_id, "chunk marked MOVED. loading complete");
+            // update the catalog to say we are done processing
+            guard
+                .set_moved(Arc::new(rb_chunk))
+                .expect("failed to move chunk");
 
-        Ok(DbChunk::snapshot(&chunk))
+            debug!(chunk=%addr, "chunk marked MOVED. loading complete");
+
+            Ok(DbChunk::snapshot(&guard))
+        };
+
+        Ok((tracker, fut.track(registration)))
     }
 
     /// Write given table of a given chunk to object store.
     /// The writing only happen if that chunk already in read buffer
-
     pub async fn write_chunk_to_object_store(
         &self,
         table_name: &str,
         partition_key: &str,
         chunk_id: u32,
-        tracker: &TaskRegistration,
     ) -> Result<Arc<DbChunk>> {
-        // Get the chunk from the catalog
-        let chunk = self.chunk(table_name, partition_key, chunk_id)?;
+        let chunk = self.lockable_chunk(table_name, partition_key, chunk_id)?;
+        let (_, fut) = Self::write_chunk_to_object_store_impl(chunk.write())?;
+        fut.await.context(TaskCancelled)?
+    }
+
+    /// The implementation for writing a chunk to the object store
+    ///
+    /// Returns a future registered with the tracker registry, and the corresponding tracker
+    /// The caller can either spawn this future to tokio, or block directly on it
+    fn write_chunk_to_object_store_impl(
+        mut guard: LifecycleWriteGuard<'_, CatalogChunk, LockableCatalogChunk<'_>>,
+    ) -> Result<(
+        TaskTracker<Job>,
+        TrackedFuture<impl Future<Output = Result<Arc<DbChunk>>> + Send>,
+    )> {
+        let db = guard.data().db;
+        let addr = guard.addr().clone();
+
+        // TODO: Use ChunkAddr within Job
+        let (tracker, registration) = db.jobs.register(Job::WriteChunk {
+            db_name: addr.db_name.to_string(),
+            partition_key: addr.partition_key.to_string(),
+            table_name: addr.table_name.to_string(),
+            chunk_id: addr.chunk_id,
+        });
 
         // update the catalog to say we are processing this chunk and
-        // then drop the lock while we do the work
-        let (rb_chunk, table_summary) = {
-            let mut chunk = chunk.write();
+        let rb_chunk = guard
+            .set_writing_to_object_store(&registration)
+            .context(LifecycleError)?;
 
-            let rb_chunk = chunk
-                .set_writing_to_object_store(tracker)
-                .context(LifecycleError {
-                    partition_key,
-                    table_name,
-                    chunk_id,
-                })?;
+        let table_summary = guard.table_summary();
 
-            (rb_chunk, chunk.table_summary())
-        };
+        debug!(chunk=%guard.addr(), "chunk marked WRITING , loading tables into object store");
 
-        debug!(%table_name, %partition_key, %chunk_id, "chunk marked WRITING , loading tables into object store");
+        // Drop locks
+        let chunk = guard.unwrap().chunk;
 
         // Create a storage to save data of this chunk
         let storage = Storage::new(
-            Arc::clone(&self.store),
-            self.server_id,
-            self.rules.read().name.to_string(),
+            Arc::clone(&db.store),
+            db.server_id,
+            db.rules.read().name.to_string(),
         );
 
-        let table_name = table_summary.name.as_str();
-        debug!(%table_name, %partition_key, %chunk_id, table=table_name, "loading table to object store");
+        let catalog_transactions_until_checkpoint = db
+            .rules
+            .read()
+            .lifecycle_rules
+            .catalog_transactions_until_checkpoint;
 
-        let predicate = read_buffer::Predicate::default();
+        let catalog = Arc::clone(&db.preserved_catalog);
 
-        // Get RecordBatchStream of data from the read buffer chunk
-        let read_results = rb_chunk
-            .read_filter(table_name, predicate, Selection::All)
-            .context(ReadBufferChunkError {
-                table_name,
-                chunk_id,
-            })?;
+        let fut = async move {
+            let table_name = table_summary.name.as_str();
+            debug!(chunk=%addr, "loading table to object store");
 
-        let arrow_schema: ArrowSchemaRef = rb_chunk
-            .read_filter_table_schema(table_name, Selection::All)
-            .context(ReadBufferChunkSchemaError {
-                table_name,
-                chunk_id,
-            })?
-            .into();
-        let stream: SendableRecordBatchStream = Box::pin(streams::ReadFilterResultsStream::new(
-            read_results,
-            Arc::clone(&arrow_schema),
-        ));
+            let predicate = read_buffer::Predicate::default();
 
-        // catalog-level transaction for preseveration layer
-        {
-            let mut transaction = self.preserved_catalog.open_transaction().await;
+            // Get RecordBatchStream of data from the read buffer chunk
+            let read_results = rb_chunk
+                .read_filter(table_name, predicate, Selection::All)
+                .expect("read buffer is infallible");
 
-            // Write this table data into the object store
-            //
-            // IMPORTANT: Writing needs to take place during a transaction, otherwise the background cleanup task might
-            //            delete the just written parquet parquet file. Furthermore, the parquet files contains
-            //            information about the transaction (like revision counter and UUID) that are only available
-            //            once the transaction has started.
-            let metadata = IoxMetadata {
-                transaction_revision_counter: transaction.revision_counter(),
-                transaction_uuid: transaction.uuid(),
-                table_name: table_name.to_string(),
-                partition_key: partition_key.to_string(),
-                chunk_id,
-            };
-            let (path, parquet_metadata) = storage
-                .write_to_object_store(
-                    partition_key.to_string(),
-                    chunk_id,
-                    table_name.to_string(),
-                    stream,
-                    metadata,
-                )
-                .await
-                .context(WritingToObjectStore)?;
+            let arrow_schema: ArrowSchemaRef = rb_chunk
+                .read_filter_table_schema(table_name, Selection::All)
+                .expect("read buffer is infallible")
+                .into();
 
-            transaction
-                .add_parquet(&path.into(), &parquet_metadata)
-                .context(TransactionError)?;
-            let create_checkpoint = self
-                .rules
-                .read()
-                .lifecycle_rules
-                .catalog_transactions_until_checkpoint
-                .map_or(false, |interval| {
-                    transaction.revision_counter() % interval.get() == 0
-                });
-            transaction
-                .commit(create_checkpoint)
-                .await
-                .context(TransactionError)?;
-        }
+            let stream: SendableRecordBatchStream = Box::pin(
+                streams::ReadFilterResultsStream::new(read_results, Arc::clone(&arrow_schema)),
+            );
 
-        // We know this chunk is ParquetFile type
-        let chunk = chunk.read();
-        Ok(DbChunk::parquet_file_snapshot(&chunk))
+            // catalog-level transaction for preservation layer
+            {
+                let mut transaction = catalog.open_transaction().await;
+
+                // Write this table data into the object store
+                //
+                // IMPORTANT: Writing needs to take place during a transaction, otherwise the background cleanup task might
+                //            delete the just written parquet parquet file. Furthermore, the parquet files contains
+                //            information about the transaction (like revision counter and UUID) that are only available
+                //            once the transaction has started.let metadata = IoxMetadata {
+                let metadata = IoxMetadata {
+                    transaction_revision_counter: transaction.revision_counter(),
+                    transaction_uuid: transaction.uuid(),
+                    table_name: addr.table_name.to_string(),
+                    partition_key: addr.partition_key.to_string(),
+                    chunk_id: addr.chunk_id,
+                };
+                let (path, parquet_metadata) = storage
+                    .write_to_object_store(
+                        addr.partition_key.to_string(),
+                        addr.chunk_id,
+                        table_name.to_string(),
+                        stream,
+                        metadata,
+                    )
+                    .await
+                    .context(WritingToObjectStore)?;
+
+                transaction
+                    .add_parquet(&path.into(), &parquet_metadata)
+                    .context(TransactionError)?;
+
+                let create_checkpoint = catalog_transactions_until_checkpoint
+                    .map_or(false, |interval| {
+                        transaction.revision_counter() % interval.get() == 0
+                    });
+
+                transaction
+                    .commit(create_checkpoint)
+                    .await
+                    .context(TransactionError)?;
+            }
+
+            // We know this chunk is ParquetFile type
+            let chunk = chunk.read();
+            Ok(DbChunk::parquet_file_snapshot(&chunk))
+        };
+
+        Ok((tracker, fut.track(registration)))
     }
 
     /// Unload chunk from read buffer but keep it in object store
@@ -685,113 +723,23 @@ impl Db {
         partition_key: &str,
         chunk_id: u32,
     ) -> Result<Arc<DbChunk>> {
-        debug!(%table_name, %partition_key, %chunk_id, "unloading chunk from read buffer");
+        let chunk = self.lockable_chunk(table_name, partition_key, chunk_id)?;
+        let chunk = chunk.read().upgrade();
+        Self::unload_read_buffer_impl(chunk)
+    }
 
-        // Get the chunk from the catalog
-        let chunk = self.chunk(table_name, partition_key, chunk_id)?;
-
-        // update the catalog to no longer use read buffer chunk if any
-        let mut chunk = chunk.write();
+    pub fn unload_read_buffer_impl(
+        mut chunk: LifecycleWriteGuard<'_, CatalogChunk, LockableCatalogChunk<'_>>,
+    ) -> Result<Arc<DbChunk>> {
+        debug!(chunk=%chunk.addr(), "unloading chunk from read buffer");
 
         chunk
             .set_unload_from_read_buffer()
-            .context(LifecycleError {
-                partition_key,
-                table_name,
-                chunk_id,
-            })?;
+            .context(LifecycleError {})?;
 
-        debug!(%table_name, %partition_key, %chunk_id, "chunk marked UNLOADED from read buffer");
+        debug!(chunk=%chunk.addr(), "chunk marked UNLOADED from read buffer");
 
         Ok(DbChunk::snapshot(&chunk))
-    }
-
-    /// Spawns a task to perform
-    /// [`load_chunk_to_read_buffer`](Self::load_chunk_to_read_buffer)
-    pub fn load_chunk_to_read_buffer_in_background(
-        self: &Arc<Self>,
-        table_name: String,
-        partition_key: String,
-        chunk_id: u32,
-    ) -> TaskTracker<Job> {
-        let db_name = self.rules.read().name.clone();
-        let (tracker, registration) = self.jobs.register(Job::CloseChunk {
-            db_name: db_name.to_string(),
-            partition_key: partition_key.clone(),
-            table_name: table_name.clone(),
-            chunk_id,
-        });
-
-        let captured_registration = registration.clone();
-        let captured_db = Arc::clone(&self);
-        let task = async move {
-            debug!(%db_name, %table_name, %partition_key, %chunk_id, "background task loading chunk to read buffer");
-            let result = captured_db
-                .load_chunk_to_read_buffer(
-                    &table_name,
-                    &partition_key,
-                    chunk_id,
-                    &captured_registration,
-                )
-                .await;
-
-            if let Err(e) = result {
-                info!(%e, %db_name, %table_name, %partition_key, %chunk_id, "background task error loading read buffer chunk");
-                return Err(e);
-            }
-
-            debug!(%db_name, %table_name, %partition_key, %chunk_id, "background task completed loading chunk to read buffer");
-
-            Ok(())
-        };
-
-        tokio::spawn(task.track(registration));
-
-        tracker
-    }
-
-    /// Spawns a task to perform
-    /// [`write_chunk_to_object_store`](Self::write_chunk_to_object_store)
-    pub fn write_chunk_to_object_store_in_background(
-        self: &Arc<Self>,
-        table_name: String,
-        partition_key: String,
-        chunk_id: u32,
-    ) -> TaskTracker<Job> {
-        let db_name = self.rules.read().name.clone();
-        let (tracker, registration) = self.jobs.register(Job::WriteChunk {
-            db_name: db_name.to_string(),
-            partition_key: partition_key.clone(),
-            table_name: table_name.clone(),
-            chunk_id,
-        });
-
-        let captured_registration = registration.clone();
-        let captured_db = Arc::clone(&self);
-        let task = async move {
-            debug!(%db_name, %table_name, %partition_key, %chunk_id, "background task loading chunk to object store");
-            let result = captured_db
-                .write_chunk_to_object_store(
-                    &table_name,
-                    &partition_key,
-                    chunk_id,
-                    &captured_registration,
-                )
-                .await;
-
-            if let Err(e) = result {
-                info!(%e, %db_name, %table_name, %partition_key, %chunk_id, "background task error loading object store chunk");
-                return Err(e);
-            }
-
-            debug!(%db_name, %table_name, %partition_key, %chunk_id, "background task completed writing chunk to object store");
-
-            Ok(())
-        };
-
-        tokio::spawn(task.track(registration));
-
-        tracker
     }
 
     /// Return chunk summary information for all chunks in the specified
@@ -856,9 +804,7 @@ impl Db {
         tokio::join!(
             // lifecycle policy loop
             async {
-                // TODO: Remove this newtype hack
-                let arc_db = lifecycle::ArcDb(Arc::clone(&self));
-                let mut policy = ::lifecycle::LifecyclePolicy::new(Arc::new(arc_db));
+                let mut policy = ::lifecycle::LifecyclePolicy::new(&self);
 
                 while !shutdown.is_cancelled() {
                     self.worker_iterations_lifecycle
@@ -1645,7 +1591,7 @@ mod tests {
         catalog_chunk_size_bytes_metric_eq(&test_db.metric_registry, "mutable_buffer", 1143)
             .unwrap();
 
-        db.load_chunk_to_read_buffer("cpu", "1970-01-01T00", 0, &Default::default())
+        db.load_chunk_to_read_buffer("cpu", "1970-01-01T00", 0)
             .await
             .unwrap();
 
@@ -1666,7 +1612,7 @@ mod tests {
         catalog_chunk_size_bytes_metric_eq(&test_db.metric_registry, "mutable_buffer", 0).unwrap();
         catalog_chunk_size_bytes_metric_eq(&test_db.metric_registry, "read_buffer", 1616).unwrap();
 
-        db.write_chunk_to_object_store("cpu", "1970-01-01T00", 0, &Default::default())
+        db.write_chunk_to_object_store("cpu", "1970-01-01T00", 0)
             .await
             .unwrap();
 
@@ -1815,7 +1761,7 @@ mod tests {
             .unwrap()
             .unwrap();
         let rb_chunk = db
-            .load_chunk_to_read_buffer("cpu", partition_key, mb_chunk.id(), &Default::default())
+            .load_chunk_to_read_buffer("cpu", partition_key, mb_chunk.id())
             .await
             .unwrap();
 
@@ -1908,7 +1854,7 @@ mod tests {
         let mb = collect_read_filter(&mb_chunk).await;
 
         let rb_chunk = db
-            .load_chunk_to_read_buffer("cpu", partition_key, mb_chunk.id(), &Default::default())
+            .load_chunk_to_read_buffer("cpu", partition_key, mb_chunk.id())
             .await
             .unwrap();
 
@@ -2018,12 +1964,12 @@ mod tests {
             .unwrap();
         // Move that MB chunk to RB chunk and drop it from MB
         let rb_chunk = db
-            .load_chunk_to_read_buffer("cpu", partition_key, mb_chunk.id(), &Default::default())
+            .load_chunk_to_read_buffer("cpu", partition_key, mb_chunk.id())
             .await
             .unwrap();
         // Write the RB chunk to Object Store but keep it in RB
         let pq_chunk = db
-            .write_chunk_to_object_store("cpu", partition_key, mb_chunk.id(), &Default::default())
+            .write_chunk_to_object_store("cpu", partition_key, mb_chunk.id())
             .await
             .unwrap();
 
@@ -2117,12 +2063,12 @@ mod tests {
             .unwrap();
         // Move that MB chunk to RB chunk and drop it from MB
         let rb_chunk = db
-            .load_chunk_to_read_buffer("cpu", partition_key, mb_chunk.id(), &Default::default())
+            .load_chunk_to_read_buffer("cpu", partition_key, mb_chunk.id())
             .await
             .unwrap();
         // Write the RB chunk to Object Store but keep it in RB
         let pq_chunk = db
-            .write_chunk_to_object_store("cpu", partition_key, mb_chunk.id(), &Default::default())
+            .write_chunk_to_object_store("cpu", partition_key, mb_chunk.id())
             .await
             .unwrap();
 
@@ -2388,7 +2334,7 @@ mod tests {
             .await
             .unwrap()
             .unwrap();
-        db.load_chunk_to_read_buffer("cpu", partition_key, mb_chunk.id(), &Default::default())
+        db.load_chunk_to_read_buffer("cpu", partition_key, mb_chunk.id())
             .await
             .unwrap();
 
@@ -2539,11 +2485,11 @@ mod tests {
 
         print!("Partitions: {:?}", db.partition_keys().unwrap());
 
-        db.load_chunk_to_read_buffer("cpu", "1970-01-01T00", 0, &Default::default())
+        db.load_chunk_to_read_buffer("cpu", "1970-01-01T00", 0)
             .await
             .unwrap();
 
-        db.write_chunk_to_object_store("cpu", "1970-01-01T00", 0, &Default::default())
+        db.write_chunk_to_object_store("cpu", "1970-01-01T00", 0)
             .await
             .unwrap();
 
@@ -2641,12 +2587,12 @@ mod tests {
         write_lp(&db, "mem foo=1 1");
 
         // load a chunk to the read buffer
-        db.load_chunk_to_read_buffer("cpu", "1970-01-01T00", chunk_id, &Default::default())
+        db.load_chunk_to_read_buffer("cpu", "1970-01-01T00", chunk_id)
             .await
             .unwrap();
 
         // write the read buffer chunk to object store
-        db.write_chunk_to_object_store("cpu", "1970-01-01T00", chunk_id, &Default::default())
+        db.write_chunk_to_object_store("cpu", "1970-01-01T00", chunk_id)
             .await
             .unwrap();
 
@@ -2829,30 +2775,15 @@ mod tests {
             .unwrap()
             .unwrap();
         let rb_chunk = db
-            .load_chunk_to_read_buffer(
-                table_name,
-                partition_key,
-                mb_chunk.id(),
-                &Default::default(),
-            )
+            .load_chunk_to_read_buffer(table_name, partition_key, mb_chunk.id())
             .await
             .unwrap();
         assert_eq!(mb_chunk.id(), rb_chunk.id());
 
         // RB => OS
-        let task = db.write_chunk_to_object_store_in_background(
-            table_name.to_string(),
-            partition_key.to_string(),
-            rb_chunk.id(),
-        );
-        let t_start = std::time::Instant::now();
-        while !task.is_complete() {
-            tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
-            assert!(
-                std::time::Instant::now() - t_start < std::time::Duration::from_secs(10),
-                "task deadline exceeded"
-            );
-        }
+        db.write_chunk_to_object_store(table_name, partition_key, 0)
+            .await
+            .unwrap();
 
         // we should have chunks in both the read buffer only
         assert!(mutable_chunk_ids(&db, partition_key).is_empty());
@@ -3329,12 +3260,12 @@ mod tests {
             mb_chunk.id()
         };
         // Move that MB chunk to RB chunk and drop it from MB
-        db.load_chunk_to_read_buffer(table_name, partition_key, chunk_id, &Default::default())
+        db.load_chunk_to_read_buffer(table_name, partition_key, chunk_id)
             .await
             .unwrap();
 
         // Write the RB chunk to Object Store but keep it in RB
-        db.write_chunk_to_object_store(table_name, partition_key, chunk_id, &Default::default())
+        db.write_chunk_to_object_store(table_name, partition_key, chunk_id)
             .await
             .unwrap();
 

--- a/server/src/db.rs
+++ b/server/src/db.rs
@@ -724,7 +724,7 @@ impl Db {
         chunk_id: u32,
     ) -> Result<Arc<DbChunk>> {
         let chunk = self.lockable_chunk(table_name, partition_key, chunk_id)?;
-        let chunk = chunk.read().upgrade();
+        let chunk = chunk.write();
         Self::unload_read_buffer_impl(chunk)
     }
 

--- a/server/src/db/lifecycle.rs
+++ b/server/src/db/lifecycle.rs
@@ -6,74 +6,91 @@ use ::lifecycle::LifecycleDb;
 use data_types::chunk_metadata::ChunkStorage;
 use data_types::database_rules::{LifecycleRules, SortOrder};
 use data_types::error::ErrorLogger;
+use lifecycle::{
+    ChunkLifecycleAction, LifecycleChunk, LifecycleReadGuard, LifecycleWriteGuard, LockableChunk,
+};
 use observability_deps::tracing::info;
 use tracker::{RwLock, TaskTracker};
 
 use crate::db::catalog::chunk::CatalogChunk;
 use crate::Db;
-use lifecycle::{ChunkLifecycleAction, LifecycleChunk};
+use data_types::job::Job;
 
-/// Temporary newtype wrapper for Arc<Db>
 ///
-/// TODO: Remove the need for Db::*_in_background to take Arc<Db>
-pub struct ArcDb(pub Arc<Db>);
+/// A LockableCatalogChunk combines a `CatalogChunk` with its owning `Db`
+///
+/// This provides the `lifecycle::LockableChunk` trait which can be used to lock
+/// the chunk, determine what to do, and then optionally trigger an action, all
+/// without allowing concurrent modification
+///
+#[derive(Debug, Clone)]
+pub struct LockableCatalogChunk<'a> {
+    pub db: &'a Db,
+    pub chunk: Arc<RwLock<CatalogChunk>>,
+}
 
-impl LifecycleDb for ArcDb {
+impl<'a> LockableChunk for LockableCatalogChunk<'a> {
     type Chunk = CatalogChunk;
+    type Job = Job;
 
-    fn buffer_size(&self) -> usize {
-        self.0.preserved_catalog.state().metrics().memory().total()
+    fn read(&self) -> LifecycleReadGuard<'_, Self::Chunk, Self> {
+        LifecycleReadGuard::new(self.clone(), self.chunk.as_ref())
     }
 
-    fn rules(&self) -> LifecycleRules {
-        self.0.rules.read().lifecycle_rules.clone()
-    }
-
-    fn chunks(&self, sort_order: &SortOrder) -> Vec<Arc<RwLock<CatalogChunk>>> {
-        self.0
-            .preserved_catalog
-            .state()
-            .chunks_sorted_by(sort_order)
+    fn write(&self) -> LifecycleWriteGuard<'_, Self::Chunk, Self> {
+        LifecycleWriteGuard::new(self.clone(), self.chunk.as_ref())
     }
 
     fn move_to_read_buffer(
-        &self,
-        table_name: String,
-        partition_key: String,
-        chunk_id: u32,
-    ) -> TaskTracker<()> {
-        info!(%partition_key, %chunk_id, "moving chunk to read buffer");
-        self.0
-            .load_chunk_to_read_buffer_in_background(table_name, partition_key, chunk_id)
-            .with_metadata(())
+        s: LifecycleWriteGuard<'_, Self::Chunk, Self>,
+    ) -> TaskTracker<Self::Job> {
+        info!(chunk=%s.addr(), "move to read buffer");
+        let (tracker, fut) = Db::load_chunk_to_read_buffer_impl(s).expect("preparation failed");
+        let _ = tokio::spawn(async move { fut.await.log_if_error("move to read buffer") });
+        tracker
     }
 
     fn write_to_object_store(
-        &self,
-        table_name: String,
-        partition_key: String,
-        chunk_id: u32,
-    ) -> TaskTracker<()> {
-        info!(%partition_key, %chunk_id, "write chunk to object store");
-        self.0
-            .write_chunk_to_object_store_in_background(table_name, partition_key, chunk_id)
-            .with_metadata(())
+        s: LifecycleWriteGuard<'_, Self::Chunk, Self>,
+    ) -> TaskTracker<Self::Job> {
+        info!(chunk=%s.addr(), "writing to object store");
+        let (tracker, fut) = Db::write_chunk_to_object_store_impl(s).expect("preparation failed");
+        let _ = tokio::spawn(async move { fut.await.log_if_error("writing to object store") });
+        tracker
     }
 
-    fn drop_chunk(&self, table_name: String, partition_key: String, chunk_id: u32) {
-        info!(%partition_key, %chunk_id, "dropping chunk");
-        let _ = self
-            .0
-            .drop_chunk(&table_name, &partition_key, chunk_id)
-            .log_if_error("dropping chunk to free up memory");
-    }
+    fn unload_read_buffer(s: LifecycleWriteGuard<'_, Self::Chunk, Self>) {
+        info!(chunk=%s.addr(), "unloading from readbuffer");
 
-    fn unload_read_buffer(&self, table_name: String, partition_key: String, chunk_id: u32) {
-        info!(%partition_key, %chunk_id, "unloading from readbuffer");
-        let _ = self
-            .0
-            .unload_read_buffer(&table_name, &partition_key, chunk_id)
+        let _ = Db::unload_read_buffer_impl(s)
             .log_if_error("unloading from read buffer to free up memory");
+    }
+}
+
+impl<'a> LifecycleDb for &'a Db {
+    type Chunk = LockableCatalogChunk<'a>;
+
+    fn buffer_size(self) -> usize {
+        self.preserved_catalog.state().metrics().memory().total()
+    }
+
+    fn rules(self) -> LifecycleRules {
+        self.rules.read().lifecycle_rules.clone()
+    }
+
+    fn chunks(self, sort_order: &SortOrder) -> Vec<Self::Chunk> {
+        self.preserved_catalog
+            .state()
+            .chunks_sorted_by(sort_order)
+            .into_iter()
+            .map(|chunk| LockableCatalogChunk { db: self, chunk })
+            .collect()
+    }
+
+    fn drop_chunk(self, table_name: String, partition_key: String, chunk_id: u32) {
+        info!(%partition_key, %chunk_id, "dropping chunk");
+        let _ = Db::drop_chunk(self, &table_name, &partition_key, chunk_id)
+            .log_if_error("dropping chunk to free up memory");
     }
 }
 

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -816,7 +816,7 @@ where
             .lockable_chunk(&table_name, &partition_key, chunk_id)
             .context(ChunkNotFound)?;
 
-        let guard = chunk.read().upgrade();
+        let guard = chunk.write();
 
         Ok(LockableChunk::move_to_read_buffer(guard))
     }

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -818,7 +818,9 @@ where
 
         let guard = chunk.write();
 
-        Ok(LockableChunk::move_to_read_buffer(guard))
+        LockableChunk::move_to_read_buffer(guard).map_err(|e| Error::UnknownDatabaseError {
+            source: Box::new(e),
+        })
     }
 
     /// Returns a list of all jobs tracked by this server

--- a/server_benchmarks/benches/catalog_persistence.rs
+++ b/server_benchmarks/benches/catalog_persistence.rs
@@ -80,17 +80,13 @@ async fn setup(object_store: Arc<ObjectStore>, done: &Mutex<bool>) {
                 .await
                 .unwrap();
 
-            db.load_chunk_to_read_buffer(&table_name, partition_key, chunk_id, &Default::default())
+            db.load_chunk_to_read_buffer(&table_name, partition_key, chunk_id)
                 .await
                 .unwrap();
-            db.write_chunk_to_object_store(
-                &table_name,
-                partition_key,
-                chunk_id,
-                &Default::default(),
-            )
-            .await
-            .unwrap();
+
+            db.write_chunk_to_object_store(&table_name, partition_key, chunk_id)
+                .await
+                .unwrap();
 
             db.unload_read_buffer(&table_name, partition_key, chunk_id)
                 .unwrap();


### PR DESCRIPTION
As described in #1732 we wish to be able to plan and execute lifecycle actions under the same lock, however, this isn't possible with the current functionality exposed by `Db` - there is no way to plan an action and then start it executing under the same lock.

As this is a critical piece of making the lifecycle function correctly in the presence of multiple components initiating lifecycle actions, e.g. `LifecycleManager`, the write path, etc... I wanted to get something working with the current chunk-based lifecycle, to prove out the concepts. The same approach can then be adapted as we move to a partition-based lifecycle.

Unfortunately this turns into a bit of a pain when it comes to the lifecycle traits, see the docs at the top of `lifecycle/src/gaurd.rs`, because of the lack of support for generic associated types - but hopefully the solution I've come up with isn't too offensive.