### PR TITLE
refactor: Unify schema handling in query crate

### DIFF
--- a/query/src/duplicate.rs
+++ b/query/src/duplicate.rs
@@ -4,9 +4,10 @@
 //! DataModel have been written in via multiple distinct line protocol
 //! writes (and thus are stored in separate rows)
 
-use crate::pruning::Prunable;
 use data_types::partition_metadata::{ColumnSummary, StatOverlap, Statistics};
 use snafu::Snafu;
+
+use crate::QueryChunkMeta;
 
 #[derive(Debug, Snafu)]
 pub enum Error {
@@ -29,7 +30,7 @@ pub enum Error {
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
-/// Groups [`Prunable`] objects into disjoint sets using values of
+/// Groups [`ChunkMeta`] objects into disjoint sets using values of
 /// min/max statistics. The groups are formed such that each group
 /// *may* contain InfluxDB data model primary key duplicates with
 /// others in that set.
@@ -47,7 +48,7 @@ pub type Result<T, E = Error> = std::result::Result<T, E>;
 /// any overlap)
 pub fn group_potential_duplicates<C>(chunks: Vec<C>) -> Result<Vec<Vec<C>>>
 where
-    C: Prunable,
+    C: QueryChunkMeta,
 {
     let mut groups: Vec<Vec<KeyStats<'_, _>>> = vec![];
 
@@ -109,7 +110,7 @@ where
 #[derive(Debug)]
 struct KeyStats<'a, C>
 where
-    C: Prunable,
+    C: QueryChunkMeta,
 {
     /// The index of the chunk
     index: usize,
@@ -124,7 +125,7 @@ where
 
 impl<'a, C> KeyStats<'a, C>
 where
-    C: Prunable,
+    C: QueryChunkMeta,
 {
     /// Create a new view for the specified chunk at index `index`,
     /// computing the columns to be used in the primary key comparison
@@ -264,11 +265,11 @@ where
 
 #[cfg(test)]
 mod test {
-    use arrow::datatypes::SchemaRef;
     use data_types::partition_metadata::{
         ColumnSummary, InfluxDbType, StatValues, Statistics, TableSummary,
     };
-    use internal_types::schema::{builder::SchemaBuilder, TIME_COLUMN_NAME};
+    use internal_types::schema::{builder::SchemaBuilder, Schema, TIME_COLUMN_NAME};
+    use std::sync::Arc;
 
     use super::*;
 
@@ -572,7 +573,7 @@ mod test {
         builder: SchemaBuilder,
     }
 
-    /// Implementation of creating a new column with statitics for TestPrunable
+    /// Implementation of creating a new column with statitics for TestChunkMeta
     macro_rules! make_stats {
         ($MIN:expr, $MAX:expr, $STAT_TYPE:ident) => {{
             Statistics::$STAT_TYPE(StatValues {
@@ -653,18 +654,19 @@ mod test {
         }
     }
 
-    impl Prunable for TestChunk {
+    impl QueryChunkMeta for TestChunk {
         fn summary(&self) -> &TableSummary {
             &self.summary
         }
 
-        fn schema(&self) -> SchemaRef {
-            self.builder
+        fn schema(&self) -> Arc<Schema> {
+            let schema = self
+                .builder
                 // need to clone because `build` resets builder state
                 .clone()
                 .build()
-                .expect("created schema")
-                .as_arrow()
+                .expect("created schema");
+            Arc::new(schema)
         }
     }
 }

--- a/query/src/duplicate.rs
+++ b/query/src/duplicate.rs
@@ -30,7 +30,7 @@ pub enum Error {
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
-/// Groups [`ChunkMeta`] objects into disjoint sets using values of
+/// Groups [`QueryChunkMeta`] objects into disjoint sets using values of
 /// min/max statistics. The groups are formed such that each group
 /// *may* contain InfluxDB data model primary key duplicates with
 /// others in that set.

--- a/query/src/test.rs
+++ b/query/src/test.rs
@@ -14,11 +14,11 @@ use data_types::{
 };
 use datafusion::physical_plan::{common::SizedRecordBatchStream, SendableRecordBatchStream};
 
+use crate::exec::Executor;
 use crate::{
     exec::stringset::{StringSet, StringSetRef},
-    DatabaseStore, Predicate, PredicateMatch, QueryChunk, QueryDatabase,
+    DatabaseStore, Predicate, PredicateMatch, QueryChunk, QueryChunkMeta, QueryDatabase,
 };
-use crate::{exec::Executor, pruning::Prunable};
 
 use internal_types::{
     schema::{
@@ -807,17 +807,17 @@ impl QueryChunk for TestChunk {
     }
 }
 
-impl Prunable for TestChunk {
+impl QueryChunkMeta for TestChunk {
     fn summary(&self) -> &TableSummary {
         self.table_summary
             .as_ref()
             .expect("Table summary not configured for TestChunk")
     }
 
-    fn schema(&self) -> arrow::datatypes::SchemaRef {
+    fn schema(&self) -> Arc<Schema> {
         self.table_schema
             .as_ref()
-            .map(|s| s.as_arrow())
+            .map(|s| Arc::new(s.clone()))
             .expect("schema was set")
     }
 }

--- a/server/src/db/access.rs
+++ b/server/src/db/access.rs
@@ -22,8 +22,7 @@ use observability_deps::tracing::debug;
 use query::{
     predicate::{Predicate, PredicateBuilder},
     provider::{self, ChunkPruner, ProviderBuilder},
-    pruning::Prunable,
-    QueryChunk, DEFAULT_SCHEMA,
+    QueryChunk, QueryChunkMeta, DEFAULT_SCHEMA,
 };
 use system_tables::{SystemSchemaProvider, SYSTEM_SCHEMA};
 

--- a/server/src/db/chunk.rs
+++ b/server/src/db/chunk.rs
@@ -3,7 +3,6 @@ use std::{
     sync::Arc,
 };
 
-use arrow::datatypes::SchemaRef;
 use data_types::partition_metadata;
 use partition_metadata::TableSummary;
 use snafu::{ResultExt, Snafu};
@@ -18,8 +17,7 @@ use parquet_file::chunk::ParquetChunk;
 use query::{
     exec::stringset::StringSet,
     predicate::{Predicate, PredicateMatch},
-    pruning::Prunable,
-    QueryChunk,
+    QueryChunk, QueryChunkMeta,
 };
 use read_buffer::RBChunk;
 
@@ -460,12 +458,12 @@ impl QueryChunk for DbChunk {
     }
 }
 
-impl Prunable for DbChunk {
+impl QueryChunkMeta for DbChunk {
     fn summary(&self) -> &TableSummary {
         self.meta.table_summary.as_ref()
     }
 
-    fn schema(&self) -> SchemaRef {
-        self.meta.schema.as_arrow()
+    fn schema(&self) -> Arc<Schema> {
+        Arc::clone(&self.meta.schema)
     }
 }


### PR DESCRIPTION
# Rationale
This is a step of https://github.com/influxdata/influxdb_iox/issues/1683, I need to merge Schemas / subsets of schemas (and partition keys). Right now there are two different ways to get a Schema from a PartitionChunk:

1. table_schema(selection) --> Schema
2. schema() (via `Prunable`) --> ArrowSchema

This is confusing, and it means code that uses `schema()` doesn't have access to the IOx specific functionality (like merging)

# Changes:
Changes:
1. Rename `Prunable` to `QueryChunkMeta` and move it to the main query crate to make it easier to find
2. Update QueryChunkMeta::schema() to return a `Arc<Schema>`
3. Update pruning logic to work on `Schema` rather than `ArrowSchemaRef`


# Next PR:
2. Remove `PartitionChunk::table_schema` (as it is redundant with ChunkMeta)

Then I will move on to getting the InfluxDB PrimaryKey information from a Schema rather than from the TableSummary (and then use merged Schemas in the deduplicate plans)

See full checklist / plan here: https://github.com/influxdata/influxdb_iox/issues/1683#issuecomment-863367715
