### PR TITLE
refactor: Remove PartitionChunk::table_schema

### DIFF
--- a/internal_types/src/schema.rs
+++ b/internal_types/src/schema.rs
@@ -326,9 +326,9 @@ impl Schema {
         }
     }
 
-    /// Returns the Schema for a table in this chunk, with the
-    /// specified column selection. An error is returned if the
-    /// selection refers to columns that do not exist.
+    /// Returns a Schema that represents selecting some of the columns
+    /// in this schema. An error is returned if the selection refers to
+    /// columns that do not exist.
     pub fn select(&self, selection: Selection<'_>) -> Result<Self> {
         Ok(match selection {
             Selection::All => self.clone(),

--- a/internal_types/src/schema.rs
+++ b/internal_types/src/schema.rs
@@ -12,7 +12,10 @@ use arrow::datatypes::{
 };
 use snafu::Snafu;
 
-use crate::schema::sort::{ColumnSort, SortKey};
+use crate::{
+    schema::sort::{ColumnSort, SortKey},
+    selection::Selection,
+};
 use hashbrown::HashSet;
 
 /// The name of the timestamp column in the InfluxDB datamodel
@@ -323,10 +326,23 @@ impl Schema {
         }
     }
 
+    /// Returns the Schema for a table in this chunk, with the
+    /// specified column selection. An error is returned if the
+    /// selection refers to columns that do not exist.
+    pub fn select(&self, selection: Selection<'_>) -> Result<Self> {
+        Ok(match selection {
+            Selection::All => self.clone(),
+            Selection::Some(columns) => {
+                let columns = self.select_indicies(columns)?;
+                self.project_indices(&columns)
+            }
+        })
+    }
+
     /// Returns the field indexes for a given selection
     ///
     /// Returns an error if a corresponding column isn't found
-    pub fn select(&self, columns: &[&str]) -> Result<Vec<usize>> {
+    pub fn select_indicies(&self, columns: &[&str]) -> Result<Vec<usize>> {
         columns
             .iter()
             .map(|column_name| {
@@ -339,7 +355,7 @@ impl Schema {
     }
 
     /// Returns the schema for a given set of column projects
-    pub fn project(&self, projection: &[usize]) -> Self {
+    pub fn project_indices(&self, projection: &[usize]) -> Self {
         let mut fields = Vec::with_capacity(projection.len());
         for idx in projection {
             let field = self.inner.field(*idx);
@@ -1011,9 +1027,9 @@ mod test {
             .build()
             .unwrap();
 
-        let projection = schema1.select(&[TIME_COLUMN_NAME]).unwrap();
+        let projection = schema1.select_indicies(&[TIME_COLUMN_NAME]).unwrap();
 
-        let schema2 = schema1.project(&projection);
+        let schema2 = schema1.project_indices(&projection);
         let schema3 = Schema::try_from_arrow(Arc::clone(&schema2.inner)).unwrap();
 
         assert_eq!(schema1.measurement(), schema2.measurement());
@@ -1075,9 +1091,9 @@ mod test {
             .build_with_sort_key(&sort_key)
             .unwrap();
 
-        let projected = schema1.project(
+        let projected = schema1.project_indices(
             schema1
-                .select(&["tag4", "tag2", "tag3", "time"])
+                .select_indicies(&["tag4", "tag2", "tag3", "time"])
                 .unwrap()
                 .as_slice(),
         );

--- a/mutable_buffer/src/chunk/snapshot.rs
+++ b/mutable_buffer/src/chunk/snapshot.rs
@@ -77,8 +77,11 @@ impl ChunkSnapshot {
         Ok(match selection {
             Selection::All => self.schema.as_ref().clone(),
             Selection::Some(columns) => {
-                let columns = self.schema.select(columns).context(SelectColumns)?;
-                self.schema.project(&columns)
+                let columns = self
+                    .schema
+                    .select_indicies(columns)
+                    .context(SelectColumns)?;
+                self.schema.project_indices(&columns)
             }
         })
     }
@@ -102,8 +105,11 @@ impl ChunkSnapshot {
         Ok(match selection {
             Selection::All => self.batch.clone(),
             Selection::Some(columns) => {
-                let projection = self.schema.select(columns).context(SelectColumns)?;
-                let schema = self.schema.project(&projection).into();
+                let projection = self
+                    .schema
+                    .select_indicies(columns)
+                    .context(SelectColumns)?;
+                let schema = self.schema.project_indices(&projection).into();
                 let columns = projection
                     .into_iter()
                     .map(|x| Arc::clone(self.batch.column(x)))

--- a/parquet_file/src/chunk.rs
+++ b/parquet_file/src/chunk.rs
@@ -207,8 +207,11 @@ impl ParquetChunk {
         Ok(match selection {
             Selection::All => self.schema.as_ref().clone(),
             Selection::Some(columns) => {
-                let columns = self.schema.select(columns).context(SelectColumns)?;
-                self.schema.project(&columns)
+                let columns = self
+                    .schema
+                    .select_indicies(columns)
+                    .context(SelectColumns)?;
+                self.schema.project_indices(&columns)
             }
         })
     }

--- a/query/src/lib.rs
+++ b/query/src/lib.rs
@@ -109,11 +109,6 @@ pub trait QueryChunk: QueryChunkMeta + Debug + Send + Sync {
         predicate: &Predicate,
     ) -> Result<Option<StringSet>, Self::Error>;
 
-    /// Returns the Schema for a table in this chunk, with the
-    /// specified column selection. An error is returned if the
-    /// selection refers to columns that do not exist.
-    fn table_schema(&self, selection: Selection<'_>) -> Result<Schema, Self::Error>;
-
     /// Provides access to raw `QueryChunk` data as an
     /// asynchronous stream of `RecordBatch`es filtered by a *required*
     /// predicate. Note that not all chunks can evaluate all types of

--- a/query/src/provider/physical.rs
+++ b/query/src/provider/physical.rs
@@ -90,9 +90,7 @@ impl<C: QueryChunk + 'static> ExecutionPlan for IOxReadFilterNode<C> {
 
         let chunk = Arc::clone(&self.chunks[partition]);
 
-        let chunk_table_schema = chunk
-            .table_schema(Selection::All)
-            .expect("can get table schema");
+        let chunk_table_schema = chunk.schema();
 
         // The output selection is all the columns in the schema.
         //

--- a/query/src/test.rs
+++ b/query/src/test.rs
@@ -29,7 +29,7 @@ use internal_types::{
 
 use async_trait::async_trait;
 use parking_lot::Mutex;
-use snafu::{OptionExt, Snafu};
+use snafu::Snafu;
 use std::{collections::BTreeMap, sync::Arc};
 
 #[derive(Debug, Default)]
@@ -766,16 +766,6 @@ impl QueryChunk for TestChunk {
             .unwrap_or(PredicateMatch::Unknown);
 
         Ok(predicate_match)
-    }
-
-    fn table_schema(&self, selection: Selection<'_>) -> Result<Schema, Self::Error> {
-        if !matches!(selection, Selection::All) {
-            unimplemented!("Selection in TestChunk::table_schema");
-        }
-
-        self.table_schema.as_ref().cloned().context(General {
-            message: "TestChunk had no schema".to_string(),
-        })
     }
 
     fn column_values(

--- a/query_tests/src/table_schema.rs
+++ b/query_tests/src/table_schema.rs
@@ -2,7 +2,7 @@
 
 use arrow::datatypes::DataType;
 use internal_types::{schema::builder::SchemaBuilder, selection::Selection};
-use query::{QueryChunk, QueryDatabase};
+use query::{QueryChunk, QueryChunkMeta, QueryDatabase};
 
 use super::scenarios::*;
 use query::predicate::PredicateBuilder;
@@ -36,7 +36,7 @@ macro_rules! run_table_schema_test_case {
             for chunk in db.chunks(&predicate) {
                 if chunk.table_name().as_ref() == table_name {
                     chunks_with_table += 1;
-                    let actual_schema = chunk.table_schema(selection.clone()).unwrap();
+                    let actual_schema = chunk.schema().select(selection.clone()).unwrap();
 
                     assert_eq!(
                         expected_schema,

--- a/server/src/db/chunk.rs
+++ b/server/src/db/chunk.rs
@@ -66,11 +66,6 @@ pub enum Error {
         source: datafusion::error::DataFusionError,
     },
 
-    #[snafu(display("Failed to select columns: {}", source))]
-    SelectColumns {
-        source: internal_types::schema::Error,
-    },
-
     #[snafu(display("arrow conversion error: {}", source))]
     ArrowConversion { source: arrow::error::ArrowError },
 }
@@ -284,16 +279,6 @@ impl QueryChunk for DbChunk {
         };
 
         Ok(pred_result)
-    }
-
-    fn table_schema(&self, selection: Selection<'_>) -> Result<Schema, Self::Error> {
-        Ok(match selection {
-            Selection::All => self.meta.schema.as_ref().clone(),
-            Selection::Some(columns) => {
-                let columns = self.meta.schema.select(columns).context(SelectColumns)?;
-                self.meta.schema.project(&columns)
-            }
-        })
     }
 
     fn read_filter(


### PR DESCRIPTION
# Rationale:

Follow on from  https://github.com/influxdata/influxdb_iox/pull/1755

This is another step towards  https://github.com/influxdata/influxdb_iox/issues/1683 where I need to merge Schemas / subsets of schemas (and partition keys). As there are two redundant ways to get schema from chunks now (and I want one so it is always consistent)

# Changes:
1. Remove PartitionChunk::table_schema
2. Implement Schema::selection() in terms of `Selection`

This also removes a bunch of mess where getting a chunk's schema is infallible (but getting a selection is not)

# Overall Plan
See full checklist / plan here: https://github.com/influxdata/influxdb_iox/issues/1683#issuecomment-863367715
