### PR TITLE
refactor: use Schema to compute InfluxDB primary keys

### DIFF
--- a/query/src/duplicate.rs
+++ b/query/src/duplicate.rs
@@ -130,7 +130,18 @@ where
     /// Create a new view for the specified chunk at index `index`,
     /// computing the columns to be used in the primary key comparison
     pub fn new(index: usize, chunk: &'a C) -> Self {
-        let key_summaries = chunk.summary().primary_key_columns();
+        // find summaries for each primary key column:
+        let key_summaries = chunk
+            .schema()
+            .primary_key()
+            .into_iter()
+            .map(|key_name| {
+                chunk
+                    .summary()
+                    .column(key_name)
+                    .expect("can not find column in chunk summary")
+            })
+            .collect();
 
         Self {
             index,

--- a/query/src/util.rs
+++ b/query/src/util.rs
@@ -8,7 +8,6 @@ use arrow::{
     record_batch::RecordBatch,
 };
 
-use data_types::partition_metadata::ColumnSummary;
 use datafusion::{
     error::DataFusionError,
     logical_plan::{Expr, LogicalPlan, LogicalPlanBuilder},
@@ -59,11 +58,11 @@ pub fn schema_has_all_expr_columns(schema: &Schema, expr: &Expr) -> bool {
 }
 
 /// Returns the pk in arrow's expression used for data sorting
-pub fn arrow_pk_sort_exprs(key_summaries: Vec<&ColumnSummary>) -> Vec<PhysicalSortExpr> {
+pub fn arrow_pk_sort_exprs(key_columns: Vec<&str>) -> Vec<PhysicalSortExpr> {
     let mut sort_exprs = vec![];
-    for key in key_summaries {
+    for key in key_columns {
         sort_exprs.push(PhysicalSortExpr {
-            expr: physical_col(key.name.as_str()),
+            expr: physical_col(key),
             options: SortOptions {
                 descending: false,
                 nulls_first: false,


### PR DESCRIPTION
# Rationale:

Based on  https://github.com/influxdata/influxdb_iox/pull/1756 (so draft until that is merged)

This is another step towards  https://github.com/influxdata/influxdb_iox/issues/1683 where I need to merge Schemas / subsets of schemas (and partition keys). What I need is the ability to know the primary keys from a merged schema, so in this PR primary keys are computed from Schemas.

# Changes:
1. Move `primary_key` to be in `Schema` rather than `TableSummary`
2. Update `Provider` to use  `Schema` rather than `TableSummary`
3. Update deduplicate detection code to use  `Schema` rather than `TableSummary`

# Next PR:
After this PR I will be able to implement deduplicating for chunks with different schemas (yay!)

# Overall Plan
See full checklist / plan here: https://github.com/influxdata/influxdb_iox/issues/1683#issuecomment-863367715
