### PR TITLE
fix: fix flaky test by updating datafusion dep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -904,7 +904,7 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "4.0.0-SNAPSHOT"
-source = "git+https://github.com/apache/arrow-datafusion.git?rev=e3e7e293c4482af1475406bf4e922d5c99e7a792#e3e7e293c4482af1475406bf4e922d5c99e7a792"
+source = "git+https://github.com/apache/arrow-datafusion.git?rev=4a55364448c81182731f4fa4c3e65aef5b31fa0f#4a55364448c81182731f4fa4c3e65aef5b31fa0f"
 dependencies = [
  "ahash 0.7.4",
  "arrow",

--- a/datafusion/Cargo.toml
+++ b/datafusion/Cargo.toml
@@ -9,4 +9,4 @@ description = "Re-exports datafusion at a specific version"
 
 # Rename to workaround doctest bug
 # Turn off optional datafusion features (function packages)
-upstream = { git = "https://github.com/apache/arrow-datafusion.git", rev = "e3e7e293c4482af1475406bf4e922d5c99e7a792", default-features = false, package = "datafusion" }
+upstream = { git = "https://github.com/apache/arrow-datafusion.git", rev = "4a55364448c81182731f4fa4c3e65aef5b31fa0f", default-features = false, package = "datafusion" }

--- a/query_tests/src/influxrpc/tag_keys.rs
+++ b/query_tests/src/influxrpc/tag_keys.rs
@@ -46,8 +46,6 @@ macro_rules! run_tag_keys_test_case {
     };
 }
 
-// ignoring flaky test until https://github.com/influxdata/influxdb_iox/issues/1735 is fixed
-// TODO(1735) re-enable test
 #[tokio::test]
 async fn list_tag_columns_no_predicate() {
     let predicate = PredicateBuilder::default().build();
@@ -55,8 +53,6 @@ async fn list_tag_columns_no_predicate() {
     run_tag_keys_test_case!(TwoMeasurementsManyNulls {}, predicate, expected_tag_keys);
 }
 
-// ignoring flaky test until https://github.com/influxdata/influxdb_iox/issues/1735 is fixed
-// TODO(1735) re-enable test
 #[tokio::test]
 async fn list_tag_columns_timestamp() {
     let predicate = PredicateBuilder::default()
@@ -65,9 +61,6 @@ async fn list_tag_columns_timestamp() {
     let expected_tag_keys = vec!["city", "state"];
     run_tag_keys_test_case!(TwoMeasurementsManyNulls {}, predicate, expected_tag_keys);
 }
-
-// ignoring flaky test until https://github.com/influxdata/influxdb_iox/issues/1735 is fixed
-// TODO(1735) re-enable test
 #[tokio::test]
 async fn list_tag_columns_predicate() {
     let predicate = PredicateBuilder::default()
@@ -77,8 +70,6 @@ async fn list_tag_columns_predicate() {
     run_tag_keys_test_case!(TwoMeasurementsManyNulls {}, predicate, expected_tag_keys);
 }
 
-// ignoring flaky test until https://github.com/influxdata/influxdb_iox/issues/1735 is fixed
-// TODO(1735) re-enable test
 #[tokio::test]
 async fn list_tag_columns_timestamp_and_predicate() {
     let predicate = PredicateBuilder::default()
@@ -89,18 +80,13 @@ async fn list_tag_columns_timestamp_and_predicate() {
     run_tag_keys_test_case!(TwoMeasurementsManyNulls {}, predicate, expected_tag_keys);
 }
 
-// ignoring flaky test until https://github.com/influxdata/influxdb_iox/issues/1735 is fixed
-// TODO(1735) re-enable test
 #[tokio::test]
-#[ignore]
 async fn list_tag_columns_measurement_name() {
     let predicate = PredicateBuilder::default().table("o2").build();
     let expected_tag_keys = vec!["borough", "city", "state"];
     run_tag_keys_test_case!(TwoMeasurementsManyNulls {}, predicate, expected_tag_keys);
 }
 
-// ignoring flaky test until https://github.com/influxdata/influxdb_iox/issues/1735 is fixed
-// TODO(1735) re-enable test
 #[tokio::test]
 async fn list_tag_columns_measurement_name_and_timestamp() {
     let predicate = PredicateBuilder::default()
@@ -111,8 +97,6 @@ async fn list_tag_columns_measurement_name_and_timestamp() {
     run_tag_keys_test_case!(TwoMeasurementsManyNulls {}, predicate, expected_tag_keys);
 }
 
-// ignoring flaky test until https://github.com/influxdata/influxdb_iox/issues/1735 is fixed
-// TODO(1735) re-enable test
 #[tokio::test]
 async fn list_tag_columns_measurement_name_and_predicate() {
     let predicate = PredicateBuilder::default()
@@ -123,8 +107,6 @@ async fn list_tag_columns_measurement_name_and_predicate() {
     run_tag_keys_test_case!(TwoMeasurementsManyNulls {}, predicate, expected_tag_keys);
 }
 
-// ignoring flaky test until https://github.com/influxdata/influxdb_iox/issues/1735 is fixed
-// TODO(1735) re-enable test
 #[tokio::test]
 async fn list_tag_columns_measurement_name_and_predicate_and_timestamp() {
     let predicate = PredicateBuilder::default()
@@ -136,8 +118,6 @@ async fn list_tag_columns_measurement_name_and_predicate_and_timestamp() {
     run_tag_keys_test_case!(TwoMeasurementsManyNulls {}, predicate, expected_tag_keys);
 }
 
-// ignoring flaky test until https://github.com/influxdata/influxdb_iox/issues/1735 is fixed
-// TODO(1735) re-enable test
 #[tokio::test]
 async fn list_tag_name_end_to_end() {
     let predicate = PredicateBuilder::default()


### PR DESCRIPTION
# Rationale

Closes https://github.com/influxdata/influxdb_iox/issues/1735, which was an intermittent test failure due to a race condition in datafusion

# Changes:
1. Update datafusion dependency to https://github.com/apache/arrow-datafusion/commit/4a55364448c81182731f4fa4c3e65aef5b31fa0f
2. Re-enable tests by reverting c63ad0e