### PR TITLE
WIP: refactoring writes to be owned by partition

### DIFF
--- a/server/src/db/chunk.rs
+++ b/server/src/db/chunk.rs
@@ -110,17 +110,6 @@ impl DbChunk {
         use super::catalog::chunk::{ChunkStage, ChunkStageFrozenRepr};
 
         let (state, meta) = match chunk.stage() {
-            ChunkStage::Open { mb_chunk, .. } => {
-                let snapshot = mb_chunk.snapshot();
-                let state = State::MutableBuffer {
-                    chunk: Arc::clone(&snapshot),
-                };
-                let meta = ChunkMetadata {
-                    table_summary: Arc::new(mb_chunk.table_summary()),
-                    schema: snapshot.full_schema(),
-                };
-                (state, Arc::new(meta))
-            }
             ChunkStage::Frozen {
                 representation,
                 meta,


### PR DESCRIPTION
This is the start of my attempt to refactor writes to go through the partition. I started pulling on this thread and it necessitated a significant amount of change elsewhere. I also wanted to completely remove the idea of "open chunks" as we'd need to get rid of those anyway to remove locks on chunks.

This was work I felt had to be done to get to bringing in persistence windows in a way that made sense to me.

I think there's a larger thing to be done here with respect to the lifecycle as well. My feeling is that chunks should be immutable and Arc wrapped in the catalog. Tracking of the lifecycle of chunks should happen in an alternate data structure within the catalog, but it should be separate from the data structure that holds the actual chunk metadata and data.

This compiles, but fails a bunch of tests. I started working them down but ran out of time.

In order to get this farther along, it would obviously need the tests fixed, and likely additional tests along with some comments putting everything together.

Separately, I found how metrics are plumbed into the Catalog to be a bit confusing. Perhaps the chunk metrics need to be refactored as part of this since chunks are created from within a partition and not within a Db. And the partition doesn't have the pointers to the right things to create chunk metrics. There also seems to be `ChunkMetrics` within the catalog and then `Metrics` within a `MBChunk` which I found quite confusing as they're not the same thing.

Anyway, I'm guessing this will be easier to step through in a call, but any thoughts on this approach would be appreciated.