### PR TITLE
refactor: remove multiple tables from Read Buffer Chunk

### DIFF
--- a/read_buffer/benches/database.rs
+++ b/read_buffer/benches/database.rs
@@ -14,7 +14,7 @@ const ONE_MS: i64 = 1_000_000;
 
 fn table_names(c: &mut Criterion) {
     let rb = generate_row_group(500_000);
-    let mut chunk = RBChunk::new(ChunkMetrics::new_unregistered());
+    let mut chunk = RBChunk::new("table_a", ChunkMetrics::new_unregistered());
     chunk.upsert_table("table_a", rb);
 
     // no predicate - return all the tables

--- a/read_buffer/benches/read_filter.rs
+++ b/read_buffer/benches/read_filter.rs
@@ -17,7 +17,7 @@ const ONE_MS: i64 = 1_000_000;
 pub fn read_filter(c: &mut Criterion) {
     let mut rng = rand::thread_rng();
 
-    let mut chunk = RBChunk::new(read_buffer::ChunkMetrics::new_unregistered());
+    let mut chunk = RBChunk::new("table", read_buffer::ChunkMetrics::new_unregistered());
     let row_group = generate_row_group(200_000, &mut rng);
     read_buffer::benchmarks::upsert_table_with_row_group(&mut chunk, "table", row_group);
 
@@ -48,9 +48,7 @@ fn read_filter_no_pred_vary_proj(c: &mut Criterion, chunk: &RBChunk) {
             &exp_card,
             |b, _| {
                 b.iter(|| {
-                    let result = chunk
-                        .read_filter("table", Predicate::default(), projection)
-                        .unwrap();
+                    let result = chunk.read_filter("table", Predicate::default(), projection);
                     let rbs = result.collect::<Vec<_>>();
                     assert_eq!(rbs.len(), 1);
                     assert_eq!(rbs[0].num_rows(), 200_000);
@@ -85,9 +83,7 @@ fn read_filter_with_pred_vary_proj(c: &mut Criterion, chunk: &RBChunk) {
             &exp_rows,
             |b, _| {
                 b.iter(|| {
-                    let result = chunk
-                        .read_filter("table", predicate.clone(), Selection::All)
-                        .unwrap();
+                    let result = chunk.read_filter("table", predicate.clone(), Selection::All);
                     let rbs = result.collect::<Vec<_>>();
                     assert_eq!(rbs.len(), 1);
                     assert!(rbs[0].num_rows() > 0); // data randomly generated so row numbers not exact

--- a/read_buffer/src/lib.rs
+++ b/read_buffer/src/lib.rs
@@ -34,9 +34,9 @@ pub mod benchmarks {
     // Allow external benchmarks to use this crate-only test method
     pub fn upsert_table_with_row_group(
         chunk: &mut RBChunk,
-        table_name: impl Into<String>,
+        _table_name: impl Into<String>,
         row_group: RowGroup,
     ) {
-        chunk.upsert_table_with_row_group(table_name, row_group)
+        chunk.upsert_table_with_row_group(row_group)
     }
 }

--- a/read_buffer/src/table.rs
+++ b/read_buffer/src/table.rs
@@ -72,14 +72,23 @@ pub struct Table {
 }
 
 // Tie data and meta-data together so that they can be wrapped in RWLock.
+#[derive(Default)]
 struct RowGroupData {
     meta: Arc<MetaData>,
     data: Vec<Arc<RowGroup>>,
 }
 
 impl Table {
+    /// Create a new empty table.
+    pub fn new(name: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            table_data: Default::default(),
+        }
+    }
+
     /// Create a new table with the provided row_group.
-    pub fn new(name: impl Into<String>, rg: RowGroup) -> Self {
+    pub fn with_row_group(name: impl Into<String>, rg: RowGroup) -> Self {
         Self {
             name: name.into(),
             table_data: RwLock::new(RowGroupData {
@@ -541,7 +550,7 @@ impl Table {
 }
 
 // TODO(edd): reduce owned strings here by, e.g., using references as keys.
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct MetaData {
     // The total size of the table in bytes.
     size: usize,
@@ -585,17 +594,24 @@ impl MetaData {
     /// Create a new `MetaData` by consuming `this` and incorporating `other`.
     pub fn update_with(mut this: Self, rg: &row_group::RowGroup) -> Self {
         let other = rg.metadata();
-        // The incoming row group must have exactly the same schema as the
+
+        // first row group added to the table.
+        if this.columns.is_empty() {
+            this.size = other.size();
+            this.rows = other.rows as u64;
+            this.columns = other.columns.clone();
+            this.column_names = other.column_names.clone();
+
+            return this;
+        }
+
+        // The incoming row group must have exactly the same schema as any
         // existing row groups in the table.
         assert_eq!(&this.columns, &other.columns);
 
         // update size, rows, column ranges, time range
         this.size += rg.size();
         this.rows += other.rows as u64;
-
-        // The incoming row group must have exactly the same schema as the
-        // existing row groups in the table.
-        assert_eq!(&this.columns, &other.columns);
 
         // Update the table schema using the incoming row group schema
         for (column_name, column_meta) in &other.columns {
@@ -1043,7 +1059,8 @@ mod test {
         let columns = vec![("time".to_string(), tc)];
 
         let rg = RowGroup::new(3, columns);
-        let mut table = Table::new("cpu".to_owned(), rg);
+        let mut table = Table::new("cpu".to_owned());
+        table.add_row_group(rg);
 
         assert_eq!(table.rows(), 3);
 
@@ -1085,7 +1102,8 @@ mod test {
         let fc = ColumnType::Field(Column::from(&[1000_u64, 1002, 1200][..]));
         let columns = vec![("time".to_string(), tc), ("count".to_string(), fc)];
         let row_group = RowGroup::new(3, columns);
-        let mut table = Table::new("cpu".to_owned(), row_group);
+        let mut table = Table::new("cpu");
+        table.add_row_group(row_group);
 
         // add another row group
         let tc = ColumnType::Time(Column::from(&[1_i64, 2, 3, 4, 5, 6][..]));
@@ -1120,7 +1138,8 @@ mod test {
         ];
         let row_group = RowGroup::new(3, columns);
 
-        let mut table = Table::new("cpu".to_owned(), row_group);
+        let mut table = Table::new("cpu");
+        table.add_row_group(row_group);
 
         // add another row group
         let tc = ColumnType::Time(Column::from(&[1_i64, 2, 3, 4, 5, 6][..]));
@@ -1200,7 +1219,9 @@ mod test {
 
         let rg = RowGroup::new(6, columns);
 
-        let mut table = Table::new("cpu".to_owned(), rg);
+        let mut table = Table::new("cpu");
+        table.add_row_group(rg);
+
         let exp_col_types = vec![
             ("region", LogicalDataType::String),
             ("count", LogicalDataType::Unsigned),
@@ -1326,7 +1347,8 @@ mod test {
             ),
         ];
         let rg = RowGroup::new(3, columns);
-        let mut table = Table::new("cpu", rg);
+        let mut table = Table::new("cpu");
+        table.add_row_group(rg);
 
         // Build another row group.
         let columns = vec![
@@ -1468,7 +1490,8 @@ west,host-b,100
         let columns = vec![("time".to_string(), tc), ("region".to_string(), rc)];
 
         let rg = RowGroup::new(3, columns);
-        let mut table = Table::new("cpu".to_owned(), rg);
+        let mut table = Table::new("cpu".to_owned());
+        table.add_row_group(rg);
 
         // add another row group
         let tc = ColumnType::Time(Column::from(&[200_i64, 300, 400][..]));
@@ -1540,7 +1563,8 @@ west,host-b,100
         ];
 
         let rg = RowGroup::new(4, columns);
-        let table = Table::new("cpu".to_owned(), rg);
+        let mut table = Table::new("cpu".to_owned());
+        table.add_row_group(rg);
 
         assert_eq!(table.time_range().unwrap(), (-100, 3));
     }

--- a/server/src/db.rs
+++ b/server/src/db.rs
@@ -553,7 +553,7 @@ impl Db {
             .register_domain_with_labels("read_buffer", db.metric_labels.clone());
 
         let mut rb_chunk = RBChunk::new(
-            table_name,
+            &table_summary.name,
             ReadBufferChunkMetrics::new(
                 &metrics,
                 db.preserved_catalog
@@ -667,6 +667,7 @@ impl Db {
 
             let arrow_schema: ArrowSchemaRef = rb_chunk
                 .read_filter_table_schema(table_name, Selection::All)
+                .expect("read buffer is infallible")
                 .into();
 
             let stream: SendableRecordBatchStream = Box::pin(

--- a/server/src/db/catalog/chunk.rs
+++ b/server/src/db/catalog/chunk.rs
@@ -413,11 +413,11 @@ impl CatalogChunk {
                 ChunkStageFrozenRepr::MutableBufferSnapshot(repr) => {
                     repr.column_sizes().map(to_summary).collect()
                 }
-                ChunkStageFrozenRepr::ReadBuffer(repr) => repr.column_sizes(&self.addr.table_name),
+                ChunkStageFrozenRepr::ReadBuffer(repr) => repr.column_sizes(),
             },
             ChunkStage::Persisted { read_buffer, .. } => {
                 if let Some(read_buffer) = &read_buffer {
-                    read_buffer.column_sizes(&self.addr.table_name)
+                    read_buffer.column_sizes()
                 } else {
                     // TODO parquet statistics
                     vec![]

--- a/server/src/db/chunk.rs
+++ b/server/src/db/chunk.rs
@@ -308,12 +308,7 @@ impl QueryChunk for DbChunk {
 
                 debug!(?rb_predicate, "Predicate pushed down to RUB");
 
-                let read_results = chunk
-                    .read_filter(table_name, rb_predicate, selection)
-                    .context(ReadBufferChunkError {
-                        chunk_id: self.id(),
-                    })?;
-
+                let read_results = chunk.read_filter(table_name, rb_predicate, selection);
                 let schema = chunk
                     .read_filter_table_schema(table_name, selection)
                     .context(ReadBufferChunkError {


### PR DESCRIPTION
Contributes to #1613 #1295 

## Rationale 

It has been decided that a `Chunk` should be thought of as a horizontal partition of data for a single table. Therefore chunks should only have data for one table and not many tables.

## PR Details

This PR makes a minimal amount of changes outside of the Read Buffer, and of focusses on remove the data structures that supported holding multiple tables of data in a single chunk. 

Rather than break the API, which would cause lots of changes to the rest of IOx I have left the API as it is. Follow on PRs will make the breaking changes and fix any broken code as a result.

I have the following tickets to track this work:

 - #1716
 - #1717
 - #1718

