### PR TITLE
fix: Report error to stderr in git-log-prs

### DIFF
--- a/scripts/git-log-prs
+++ b/scripts/git-log-prs
@@ -30,7 +30,7 @@ ensure_command_gh() {
     echo "Other OS:"
     echo "  see https://github.com/cli/cli"
     exit 1
-  }
+  } >&2
 }
 
 get_title() {


### PR DESCRIPTION
When a user runs the `git-log-prs --titles` script without the `gh` utility, the script exited swallowing the error message.
