### PR TITLE
refactor: decouple preserved and in-mem catalog (part 2)

### DIFF
--- a/parquet_file/src/cleanup.rs
+++ b/parquet_file/src/cleanup.rs
@@ -40,7 +40,7 @@ pub type Result<T, E = Error> = std::result::Result<T, E>;
 /// This will hold the transaction lock while the list of files is being gathered. To limit the time the lock is held
 /// use `max_files` which will limit the number of files to delete in this cleanup round.
 pub async fn cleanup_unreferenced_parquet_files<S>(
-    catalog: &PreservedCatalog<S>,
+    catalog: &PreservedCatalog,
     state: Arc<S>,
     max_files: usize,
 ) -> Result<()>
@@ -56,7 +56,7 @@ where
     let db_name = catalog.db_name();
     let all_known = {
         // replay catalog transactions to track ALL (even dropped) files that are referenced
-        let (_catalog, state) = PreservedCatalog::<TracerCatalogState>::load(
+        let (_catalog, state) = PreservedCatalog::load::<TracerCatalogState>(
             Arc::clone(&store),
             server_id,
             db_name.to_string(),
@@ -184,10 +184,10 @@ mod tests {
         let server_id = make_server_id();
         let db_name = "db1";
 
-        let (catalog, state) = PreservedCatalog::<TestCatalogState>::new_empty(
+        let (catalog, state) = PreservedCatalog::new_empty::<TestCatalogState>(
             Arc::clone(&object_store),
             server_id,
-            db_name,
+            db_name.to_string(),
             (),
         )
         .await
@@ -205,10 +205,10 @@ mod tests {
         let server_id = make_server_id();
         let db_name = db_name();
 
-        let (catalog, mut state) = PreservedCatalog::<TestCatalogState>::new_empty(
+        let (catalog, mut state) = PreservedCatalog::new_empty::<TestCatalogState>(
             Arc::clone(&object_store),
             server_id,
-            db_name,
+            db_name.to_string(),
             (),
         )
         .await
@@ -266,10 +266,10 @@ mod tests {
         let server_id = make_server_id();
         let db_name = db_name();
 
-        let (catalog, state) = PreservedCatalog::<TestCatalogState>::new_empty(
+        let (catalog, state) = PreservedCatalog::new_empty::<TestCatalogState>(
             Arc::clone(&object_store),
             server_id,
-            db_name,
+            db_name.to_string(),
             (),
         )
         .await
@@ -306,10 +306,10 @@ mod tests {
         let server_id = make_server_id();
         let db_name = db_name();
 
-        let (catalog, state) = PreservedCatalog::<TestCatalogState>::new_empty(
+        let (catalog, state) = PreservedCatalog::new_empty::<TestCatalogState>(
             Arc::clone(&object_store),
             server_id,
-            db_name,
+            db_name.to_string(),
             (),
         )
         .await

--- a/server/src/config.rs
+++ b/server/src/config.rs
@@ -237,7 +237,7 @@ impl Config {
         server_id: ServerId,
         object_store: Arc<ObjectStore>,
         exec: Arc<Executor>,
-        preserved_catalog: PreservedCatalog<Catalog>,
+        preserved_catalog: PreservedCatalog,
         catalog: Arc<Catalog>,
     ) {
         let mut state = self.state.write().expect("mutex poisoned");
@@ -452,7 +452,7 @@ impl<'a> CreateDatabaseHandle<'a> {
         server_id: ServerId,
         object_store: Arc<ObjectStore>,
         exec: Arc<Executor>,
-        preserved_catalog: PreservedCatalog<Catalog>,
+        preserved_catalog: PreservedCatalog,
         catalog: Arc<Catalog>,
         rules: DatabaseRules,
     ) -> Result<()> {
@@ -539,7 +539,7 @@ impl<'a> RecoverDatabaseHandle<'a> {
         server_id: ServerId,
         object_store: Arc<ObjectStore>,
         exec: Arc<Executor>,
-        preserved_catalog: PreservedCatalog<Catalog>,
+        preserved_catalog: PreservedCatalog,
         catalog: Arc<Catalog>,
         rules: Option<DatabaseRules>,
     ) -> Result<()> {

--- a/server/src/init.rs
+++ b/server/src/init.rs
@@ -9,7 +9,7 @@ use object_store::{
 };
 use observability_deps::tracing::{debug, error, info, warn};
 use parking_lot::Mutex;
-use parquet_file::catalog::wipe as wipe_preserved_catalog;
+use parquet_file::catalog::PreservedCatalog;
 use query::exec::Executor;
 use snafu::{OptionExt, ResultExt, Snafu};
 use std::{
@@ -397,7 +397,7 @@ impl InitStatus {
                 .map_err(|e| Arc::new(e) as _)
                 .context(RecoverDbError)?;
 
-            wipe_preserved_catalog(&store, server_id, &db_name)
+            PreservedCatalog::wipe(&store, server_id, &db_name)
                 .await
                 .map_err(Box::new)
                 .context(PreservedCatalogWipeError)?;
@@ -455,7 +455,7 @@ impl InitStatus {
                 .map_err(|e| Arc::new(e) as _)
                 .context(RecoverDbError)?;
 
-            wipe_preserved_catalog(&store, server_id, &db_name)
+            PreservedCatalog::wipe(&store, server_id, &db_name)
                 .await
                 .map_err(Box::new)
                 .context(PreservedCatalogWipeError)?;

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -1963,7 +1963,7 @@ mod tests {
             )
             .await
             .unwrap();
-        let (preserved_catalog, _catalog) = PreservedCatalog::<TestCatalogState>::load(
+        let (preserved_catalog, _catalog) = PreservedCatalog::load::<TestCatalogState>(
             Arc::clone(&store),
             server_id,
             db_name_catalog_broken.to_string(),
@@ -2009,7 +2009,7 @@ mod tests {
                 .to_string(),
             "database already exists"
         );
-        assert!(PreservedCatalog::<TestCatalogState>::exists(
+        assert!(PreservedCatalog::exists(
             &server.store,
             server.require_id().unwrap(),
             &db_name_existing.to_string()
@@ -2019,7 +2019,7 @@ mod tests {
 
         // 2. wiping a non-existing DB just works, but won't bring DB into existence
         assert!(server.error_database(&db_name_non_existing).is_none());
-        PreservedCatalog::<TestCatalogState>::new_empty(
+        PreservedCatalog::new_empty::<TestCatalogState>(
             Arc::clone(&server.store),
             server.require_id().unwrap(),
             db_name_non_existing.to_string(),
@@ -2036,7 +2036,7 @@ mod tests {
         };
         assert_eq!(metadata, &expected_metadata);
         tracker.join().await;
-        assert!(!PreservedCatalog::<TestCatalogState>::exists(
+        assert!(!PreservedCatalog::exists(
             &server.store,
             server.require_id().unwrap(),
             &db_name_non_existing.to_string()
@@ -2057,7 +2057,7 @@ mod tests {
         };
         assert_eq!(metadata, &expected_metadata);
         tracker.join().await;
-        assert!(!PreservedCatalog::<TestCatalogState>::exists(
+        assert!(!PreservedCatalog::exists(
             &server.store,
             server.require_id().unwrap(),
             &db_name_rules_broken.to_string()
@@ -2078,7 +2078,7 @@ mod tests {
         };
         assert_eq!(metadata, &expected_metadata);
         tracker.join().await;
-        assert!(PreservedCatalog::<TestCatalogState>::exists(
+        assert!(PreservedCatalog::exists(
             &server.store,
             server.require_id().unwrap(),
             &db_name_catalog_broken.to_string()
@@ -2106,7 +2106,7 @@ mod tests {
                 .to_string(),
             "database already exists"
         );
-        assert!(PreservedCatalog::<TestCatalogState>::exists(
+        assert!(PreservedCatalog::exists(
             &server.store,
             server.require_id().unwrap(),
             &db_name_created.to_string()


### PR DESCRIPTION
For #1740.

# Outlook
- move type parameters around / API clean-up (this PR)
- move in-mem catalog out of the transaction, this will be a HUGE simplification (next PR)
- cleanups (e.g. remove some `Arc`s that are no longer needed) (the PR after)