### PR TITLE
fix: auto-wipe should still be enabled

### DIFF
--- a/server/src/init.rs
+++ b/server/src/init.rs
@@ -136,7 +136,7 @@ impl InitStatus {
             initialize_semaphore: Semaphore::new(1),
             error_generic: Default::default(),
             errors_databases: Default::default(),
-            wipe_on_error: Default::default(),
+            wipe_on_error: AtomicBool::new(true),
         }
     }
 


### PR DESCRIPTION
Auto-wipe broken catalogs should be enabled until #1522 is closed.
