### PR TITLE
chore: Store generated rustdoc as circleci artifacts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,8 +103,12 @@ jobs:
       - cache_restore
       - run:
           name: Cargo doc
-          command: cargo doc --document-private-items --no-deps --workspace
+          # excluding datafusion because it's effectively a dependency masqueraded as workspace crate.
+          command: cargo doc --document-private-items --no-deps --workspace --exclude datafusion
       - cache_save
+      - store_artifacts:
+          path: target/doc/
+          destination: rustdoc
   test:
     docker:
       - image: quay.io/influxdb/rust:ci


### PR DESCRIPTION
it's quite slow:

![image](https://user-images.githubusercontent.com/52673/123007784-0408de80-d3ba-11eb-85ff-553e9b987a94.png)

but with `--exclude datafusion` it's not *that* much slower than the kafka integration tests:

![image](https://user-images.githubusercontent.com/52673/123007833-1d118f80-d3ba-11eb-994e-f59260f42b07.png)

It's possible that once we add some more tests to the kafka integration tests, this circleci job will no longer be in the critical path