### PR TITLE
feat: add `initialized` flag to `DatabaseStatus` gRPC msg

### DIFF
--- a/generated_types/protos/influxdata/iox/management/v1/service.proto
+++ b/generated_types/protos/influxdata/iox/management/v1/service.proto
@@ -256,7 +256,7 @@ message ServerStatus {
   // If present, the server reports a global error condition.
   Error error = 2;
 
-  // If `initialized` is true, this contains a complete list of databases.
+  // If `initialized` is true, this contains a complete list of known databases, regardless of their state.
   repeated DatabaseStatus database_statuses = 3;
 }
 
@@ -266,6 +266,9 @@ message DatabaseStatus {
 
   // If present, the database reports an error condition.
   Error error = 2;
+
+  // Database is initialized and fully usable.
+  bool initialized = 3;
 }
 
 message Error {

--- a/src/influxdb_ioxd/rpc/management.rs
+++ b/src/influxdb_ioxd/rpc/management.rs
@@ -383,11 +383,17 @@ where
                 .db_names_sorted()
                 .into_iter()
                 .map(|db_name| {
+                    let db_name_checked = DatabaseName::new(&db_name).expect("invalid DB name?!");
                     let error = self.server.error_database(&db_name).map(|e| ProtobufError {
                         message: e.to_string(),
                     });
+                    let initialized = self.server.db(&db_name_checked).is_some();
 
-                    DatabaseStatus { db_name, error }
+                    DatabaseStatus {
+                        db_name,
+                        error,
+                        initialized,
+                    }
                 })
                 .collect()
         } else {


### PR DESCRIPTION
This allows callers to differentiate between "not yet loaded / loading"
and "ready".
