### PR TITLE
fix: improve "server not initialized" error

### DIFF
--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -146,9 +146,9 @@ pub enum Error {
     ErrorReplicating { source: DatabaseError },
 
     #[snafu(display(
-        "server ID is set but DBs are not yet loaded. Server is not yet ready to read/write data."
+        "Server ID is set ({}) but server is not yet initialized (e.g. DBs and remotes are not loaded). Server is not yet ready to read/write data.", server_id
     ))]
-    DatabasesNotLoaded,
+    ServerNotInitialized { server_id: ServerId },
 
     #[snafu(display("error serializing database rules to protobuf: {}", source))]
     ErrorSerializingRulesProtobuf {
@@ -474,7 +474,7 @@ where
         if self.initialized() {
             Ok(server_id)
         } else {
-            Err(Error::DatabasesNotLoaded)
+            Err(Error::ServerNotInitialized { server_id })
         }
     }
 
@@ -1783,7 +1783,7 @@ mod tests {
         let err = create_simple_database(&server, "bananas")
             .await
             .unwrap_err();
-        assert!(matches!(err, Error::DatabasesNotLoaded));
+        assert!(matches!(err, Error::ServerNotInitialized { .. }));
     }
 
     #[tokio::test]

--- a/src/influxdb_ioxd/rpc/error.rs
+++ b/src/influxdb_ioxd/rpc/error.rs
@@ -14,8 +14,8 @@ pub fn default_server_error_handler(error: server::Error) -> tonic::Status {
             description: "Writer ID must be set".to_string(),
         }
         .into(),
-        Error::DatabasesNotLoaded => tonic::Status::unavailable(
-            "Server ID set but DBs not yet loaded. Server cannot accept reads/writes yet.",
+        Error::ServerNotInitialized{server_id} => tonic::Status::unavailable(
+            format!("Server ID is set ({}) but server is not yet initialized (e.g. DBs and remotes are not loaded). Server is not yet ready to read/write data.", server_id)
         ),
         Error::DatabaseNotFound { db_name } => NotFound {
             resource_type: "database".to_string(),


### PR DESCRIPTION
We've reported "databases not loaded" which is a bit confusing for
router nodes, so change the description to "server not initialized".
