### PR TITLE
fix: correct row count for object store chunks

### DIFF
--- a/parquet_file/src/chunk.rs
+++ b/parquet_file/src/chunk.rs
@@ -254,8 +254,7 @@ impl ParquetChunk {
 
     /// The total number of rows in all row groups in this chunk.
     pub fn rows(&self) -> usize {
-        // All columns have the same rows, so return get row count of the first column
-        self.table_summary.columns[0].count() as usize
+        self.parquet_metadata.row_count()
     }
 
     /// Parquet metadata from the underlying file.

--- a/parquet_file/src/metadata.rs
+++ b/parquet_file/src/metadata.rs
@@ -249,6 +249,11 @@ impl IoxParquetMetaData {
         Ok(Self { md })
     }
 
+    /// Return the number of rows in the parquet file
+    pub fn row_count(&self) -> usize {
+        self.md.file_metadata().num_rows() as usize
+    }
+
     /// Read IOx metadata from file-level key-value parquet metadata.
     pub fn read_iox_metadata(&self) -> Result<IoxMetadata> {
         let kv = self

--- a/server/src/db/catalog/chunk.rs
+++ b/server/src/db/catalog/chunk.rs
@@ -686,7 +686,7 @@ impl CatalogChunk {
                 read_buffer,
                 ..
             } => {
-                if let Some(read_buffer_inner) = &read_buffer {
+                if let Some(rub_chunk) = read_buffer.take() {
                     self.metrics
                         .state
                         .inc_with_labels(&[KeyValue::new("state", "os")]);
@@ -696,8 +696,6 @@ impl CatalogChunk {
                         &[KeyValue::new("state", "os")],
                     );
 
-                    let rub_chunk = Arc::clone(read_buffer_inner);
-                    *read_buffer = None;
                     Ok(rub_chunk)
                 } else {
                     // TODO: do we really need to error here or should unloading an unloaded chunk be a no-op?


### PR DESCRIPTION
Previously IOx would report the non-null count of the first column as the row count for the chunk, this is incorrect.