### PR TITLE
feat: Implement split_plans

### DIFF
--- a/query/src/exec/schema_pivot.rs
+++ b/query/src/exec/schema_pivot.rs
@@ -43,7 +43,7 @@ use datafusion::{
 
 use tokio_stream::StreamExt;
 
-/// Implementes the SchemaPivot operation described in make_schema_pivot,
+/// Implements the SchemaPivot operation described in `make_schema_pivot`
 pub struct SchemaPivotNode {
     input: LogicalPlan,
     schema: DFSchemaRef,

--- a/query/src/exec/split.rs
+++ b/query/src/exec/split.rs
@@ -435,7 +435,7 @@ mod tests {
         let split_expr = compile_expr(input.as_ref(), col("int_col").lt(lit(3)));
         let split_exec = StreamSplitExec::new(input, split_expr);
 
-        let output0 = run_and_get_putput(&split_exec, 0).await.unwrap();
+        let output0 = run_and_get_output(&split_exec, 0).await.unwrap();
         let expected = vec![
             "+---------+------------+",
             "| int_col | str_col    |",
@@ -447,7 +447,7 @@ mod tests {
         ];
         assert_batches_sorted_eq!(&expected, &output0);
 
-        let output1 = run_and_get_putput(&split_exec, 1).await.unwrap();
+        let output1 = run_and_get_output(&split_exec, 1).await.unwrap();
         let expected = vec![
             "+---------+---------+",
             "| int_col | str_col |",
@@ -474,11 +474,11 @@ mod tests {
         let split_expr = compile_expr(input.as_ref(), lit(false));
         let split_exec = StreamSplitExec::new(input, split_expr);
 
-        let output0 = run_and_get_putput(&split_exec, 0).await.unwrap();
+        let output0 = run_and_get_output(&split_exec, 0).await.unwrap();
         let expected = vec!["++", "||", "++", "++"];
         assert_batches_sorted_eq!(&expected, &output0);
 
-        let output1 = run_and_get_putput(&split_exec, 1).await.unwrap();
+        let output1 = run_and_get_output(&split_exec, 1).await.unwrap();
         let expected = vec![
             "+---------+",
             "| int_col |",
@@ -507,7 +507,7 @@ mod tests {
         let split_expr = compile_expr(input.as_ref(), col("int_col").lt(lit(3)));
         let split_exec = StreamSplitExec::new(input, split_expr);
 
-        let output0 = run_and_get_putput(&split_exec, 0).await.unwrap();
+        let output0 = run_and_get_output(&split_exec, 0).await.unwrap();
         let expected = vec![
             "+---------+",
             "| int_col |",
@@ -518,7 +518,7 @@ mod tests {
         ];
         assert_batches_sorted_eq!(&expected, &output0);
 
-        let output1 = run_and_get_putput(&split_exec, 1).await.unwrap();
+        let output1 = run_and_get_output(&split_exec, 1).await.unwrap();
         let expected = vec![
             "+---------+",
             "| int_col |",
@@ -546,7 +546,7 @@ mod tests {
         let split_expr = compile_expr(input.as_ref(), col("int_col"));
         let split_exec = StreamSplitExec::new(input, split_expr);
 
-        let output0 = run_and_get_putput(&split_exec, 0)
+        let output0 = run_and_get_output(&split_exec, 0)
             .await
             .unwrap_err()
             .to_string();

--- a/query/src/exec/split.rs
+++ b/query/src/exec/split.rs
@@ -336,7 +336,7 @@ async fn split_the_stream(
                 match (val0, val1) {
                     (Some(true), Some(false)) => (batch, empty_record_batch),
                     (Some(false), Some(true)) => (empty_record_batch, batch),
-                    _ => panic!("mismatched boolean values"),
+                    _ => panic!("mismatched boolean values: {:?}, {:?}", val0, val1),
                 }
             }
             _ => {

--- a/query/src/exec/split.rs
+++ b/query/src/exec/split.rs
@@ -1,0 +1,593 @@
+//! This module contains a DataFusion extension node to "split" schemas
+
+use std::{
+    any::Any,
+    fmt::{self, Debug},
+    sync::Arc,
+};
+
+use async_trait::async_trait;
+
+use arrow::{
+    array::{Array, ArrayRef, BooleanArray},
+    compute::{self, filter_record_batch},
+    datatypes::SchemaRef,
+    error::Result as ArrowResult,
+    record_batch::RecordBatch,
+};
+use datafusion::{
+    error::{DataFusionError, Result},
+    logical_plan::{DFSchemaRef, Expr, LogicalPlan, UserDefinedLogicalNode},
+    physical_plan::{
+        ColumnarValue, DisplayFormatType, Distribution, ExecutionPlan, Partitioning, PhysicalExpr,
+        SendableRecordBatchStream,
+    },
+    scalar::ScalarValue,
+};
+
+use futures::StreamExt;
+use observability_deps::tracing::debug;
+use tokio::sync::{mpsc::Sender, Mutex};
+
+use crate::exec::stream::AdapterStream;
+
+/// Implements stream splitting described in `make_stream_split`
+///
+/// The resulting execution plan always produces exactly 2 partitions:
+///
+/// * partition 0 are the rows for which the split_expr evaluates to true
+/// * partition 1 are the rows for which the split_expr does not evaluate to true (e.g. Null or false)
+pub struct StreamSplitNode {
+    input: LogicalPlan,
+    split_expr: Expr,
+}
+
+impl StreamSplitNode {
+    /// Create a new `StreamSplitNode` using `split_expr` to divide the
+    /// rows. `split_expr` must evaluate to a boolean otherwise a
+    /// runtime error will occur.
+    pub fn new(input: LogicalPlan, split_expr: Expr) -> Self {
+        Self { input, split_expr }
+    }
+
+    pub fn split_expr(&self) -> &Expr {
+        &self.split_expr
+    }
+}
+
+impl Debug for StreamSplitNode {
+    /// Use explain format for the Debug format.
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.fmt_for_explain(f)
+    }
+}
+
+impl UserDefinedLogicalNode for StreamSplitNode {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn inputs(&self) -> Vec<&LogicalPlan> {
+        vec![&self.input]
+    }
+
+    /// Schema is the same as the input schema
+    fn schema(&self) -> &DFSchemaRef {
+        &self.input.schema()
+    }
+
+    fn expressions(&self) -> Vec<Expr> {
+        vec![self.split_expr.clone()]
+    }
+
+    fn fmt_for_explain(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "StreamSplit split_expr={:?}", self.split_expr)
+    }
+
+    fn from_template(
+        &self,
+        exprs: &[Expr],
+        inputs: &[LogicalPlan],
+    ) -> Arc<dyn UserDefinedLogicalNode + Send + Sync> {
+        assert_eq!(inputs.len(), 1, "StreamSplitNode: input sizes inconistent");
+        assert_eq!(
+            exprs.len(),
+            1,
+            "StreamSplitNode: expression sizes inconistent"
+        );
+        Arc::new(Self {
+            input: inputs[0].clone(),
+            split_expr: exprs[0].clone(),
+        })
+    }
+}
+
+/// Tracks the state of the physical operator
+enum State {
+    New,
+    Running {
+        /// Stream for which split_expr is true. Set to `None` after
+        /// execute(0) is called
+        stream0: Option<SendableRecordBatchStream>,
+        /// Stream for which split_expr is not true (false or NONE).
+        /// Set to `None` after execute(0) is called
+        stream1: Option<SendableRecordBatchStream>,
+    },
+}
+
+/// Physical operator that implements steam splitting operation
+pub struct StreamSplitExec {
+    state: Mutex<State>,
+    input: Arc<dyn ExecutionPlan>,
+    split_expr: Arc<dyn PhysicalExpr>,
+}
+
+impl StreamSplitExec {
+    pub fn new(input: Arc<dyn ExecutionPlan>, split_expr: Arc<dyn PhysicalExpr>) -> Self {
+        let state = Mutex::new(State::New);
+        Self {
+            state,
+            input,
+            split_expr,
+        }
+    }
+}
+
+impl Debug for StreamSplitExec {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "StreamSplitExec {:?}", self.split_expr)
+    }
+}
+
+#[async_trait]
+impl ExecutionPlan for StreamSplitExec {
+    fn as_any(&self) -> &(dyn std::any::Any + 'static) {
+        self
+    }
+
+    fn schema(&self) -> SchemaRef {
+        self.input.schema()
+    }
+
+    /// Always produces exactly two outputs
+    fn output_partitioning(&self) -> Partitioning {
+        Partitioning::UnknownPartitioning(2)
+    }
+
+    /// Always require a single input (eventually we might imagine
+    /// running this on multiple partitions concurrently to compute
+    /// the splits in parallel, but not now)
+    fn required_child_distribution(&self) -> Distribution {
+        Distribution::SinglePartition
+    }
+
+    fn children(&self) -> Vec<Arc<dyn ExecutionPlan>> {
+        vec![Arc::clone(&self.input)]
+    }
+
+    fn with_new_children(
+        &self,
+        children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        match children.len() {
+            1 => Ok(Arc::new(Self {
+                state: Mutex::new(State::New),
+                input: Arc::clone(&children[0]),
+                split_expr: Arc::clone(&self.split_expr),
+            })),
+            _ => Err(DataFusionError::Internal(
+                "StreamSplitExec wrong number of children".to_string(),
+            )),
+        }
+    }
+
+    /// Stream split has two partitions:
+    ///
+    /// * partition 0 are the rows for which the split_expr evaluates to true
+    /// * partition 1 are the rows for which the split_expr does not evaluate to true (e.g. Null or false)
+    async fn execute(&self, partition: usize) -> Result<SendableRecordBatchStream> {
+        debug!(partition, "SplitExec::execute");
+        self.start_if_needed().await?;
+
+        let mut state = self.state.lock().await;
+        match &mut (*state) {
+            State::New => panic!("should have been initialized"),
+            State::Running { stream0, stream1 } => {
+                let stream = match partition {
+                    0 => stream0.take().expect("execute previously called with 0"),
+                    1 => stream1.take().expect("execute previously called with 1"),
+                    _ => panic!(
+                        "Only partition 0 or partition 1 are valid. Got {}",
+                        partition
+                    ),
+                };
+                Ok(stream)
+            }
+        }
+    }
+
+    fn fmt_as(&self, t: DisplayFormatType, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match t {
+            DisplayFormatType::Default => {
+                write!(f, "StreamSplitExec")
+            }
+        }
+    }
+}
+
+impl StreamSplitExec {
+    /// if in State::New, sets up the output running and sets self.state --> `Running`
+    async fn start_if_needed(&self) -> Result<()> {
+        let mut state = self.state.lock().await;
+        if matches!(*state, State::Running { .. }) {
+            return Ok(());
+        }
+
+        let num_input_streams = self.input.output_partitioning().partition_count();
+        assert_eq!(
+            num_input_streams, 1,
+            "need at least one input partition for stream split exec"
+        );
+
+        debug!("Setting up SplitStreamExec state");
+
+        let input_stream = self.input.execute(0).await?;
+        let (tx0, rx0) = tokio::sync::mpsc::channel(2);
+        let (tx1, rx1) = tokio::sync::mpsc::channel(2);
+        let split_expr = Arc::clone(&self.split_expr);
+
+        // launch the work on a different task, with a task to handle its output values
+        tokio::task::spawn(async move {
+            // wait for completion, and propagate errors
+            // note we ignore errors on send (.ok) as that means the receiver has already shutdown.
+            let worker = tokio::task::spawn(split_the_stream(
+                input_stream,
+                split_expr,
+                tx0.clone(),
+                tx1.clone(),
+            ));
+
+            let txs = [tx0, tx1];
+            match worker.await {
+                Err(e) => {
+                    debug!(%e, "error joining task");
+                    for tx in &txs {
+                        let err = DataFusionError::Execution(format!("Join Error: {}", e));
+                        let err = Err(err.into_arrow_external_error());
+                        tx.send(err).await.ok();
+                    }
+                }
+                Ok(Err(e)) => {
+                    debug!(%e, "error in work function");
+                    for tx in &txs {
+                        let err = DataFusionError::Execution(e.to_string());
+                        let err = Err(err.into_arrow_external_error());
+                        tx.send(err).await.ok();
+                    }
+                }
+                // Input task completed successfully
+                Ok(Ok(())) => {
+                    debug!("All input tasks completed successfully");
+                }
+            }
+        });
+
+        *state = State::Running {
+            stream0: Some(AdapterStream::adapt(self.input.schema(), rx0)),
+            stream1: Some(AdapterStream::adapt(self.input.schema(), rx1)),
+        };
+        Ok(())
+    }
+}
+
+/// This function does the actual splitting: evaluates `split_expr` on
+/// each input [`RecordBatch`], and then sends the rows to the correct
+/// output: tx0 (when split_expr is true) and tx0 otherwise
+async fn split_the_stream(
+    mut input_stream: SendableRecordBatchStream,
+    split_expr: Arc<dyn PhysicalExpr>,
+    tx0: Sender<ArrowResult<RecordBatch>>,
+    tx1: Sender<ArrowResult<RecordBatch>>,
+) -> Result<()> {
+    while let Some(batch) = input_stream.next().await {
+        let batch = batch?;
+        debug!(num_rows = batch.num_rows(), "Processing batch");
+        let mut tx0_done = false;
+        let mut tx1_done = false;
+
+        let true_indices = split_expr.evaluate(&batch)?;
+        let not_true_indices = negate(&true_indices)?;
+
+        let (true_batch, not_true_batch) = match (true_indices, not_true_indices) {
+            (ColumnarValue::Array(true_indices), ColumnarValue::Array(not_true_indices)) => {
+                let true_indices = true_indices
+                    .as_any()
+                    .downcast_ref::<BooleanArray>()
+                    .unwrap();
+                let true_batch = filter_record_batch(&batch, true_indices)?;
+
+                let not_true_indices = not_true_indices
+                    .as_any()
+                    .downcast_ref::<BooleanArray>()
+                    .unwrap();
+
+                let not_true_batch = if not_true_indices.null_count() > 0 {
+                    // since !Null --> Null, but we want all the
+                    // remaining rows, that are not in true_indicies,
+                    // transform any nulls into true for this one
+                    let mapped_indicies = not_true_indices
+                        .iter()
+                        .map(|v| v.or(Some(true)))
+                        .collect::<Vec<_>>();
+
+                    filter_record_batch(&batch, &BooleanArray::from(mapped_indicies))
+                } else {
+                    filter_record_batch(&batch, not_true_indices)
+                }?;
+
+                (true_batch, not_true_batch)
+            }
+            // handle when the user provided a constant predicate
+            (
+                ColumnarValue::Scalar(ScalarValue::Boolean(val0)),
+                ColumnarValue::Scalar(ScalarValue::Boolean(val1)),
+            ) => {
+                let empty_record_batch = RecordBatch::new_empty(batch.schema());
+                match (val0, val1) {
+                    (Some(true), Some(false)) => (batch, empty_record_batch),
+                    (Some(false), Some(true)) => (empty_record_batch, batch),
+                    _ => panic!("mismatched boolean values"),
+                }
+            }
+            _ => {
+                panic!("mismatched array types");
+            }
+        };
+
+        // don't treat a hangup as an error, as it can also be caused
+        // by a LIMIT operation where the entire stream is not
+        // consumed)
+        if let Err(e) = tx0.send(Ok(true_batch)).await {
+            debug!(%e, "Split tx0 hung up, ignoring");
+            tx0_done = true;
+        }
+        if let Err(e) = tx1.send(Ok(not_true_batch)).await {
+            debug!(%e, "Split tx1 hung up, ignoring");
+            tx1_done = true;
+        }
+
+        if tx0_done && tx1_done {
+            debug!("Split both tx ends have hung up, stopping loop");
+            return Ok(());
+        }
+    }
+
+    debug!("Splitting done successfully");
+    Ok(())
+}
+
+/// compute the boolean compliment of the columnar value (which must be boolean)
+fn negate(v: &ColumnarValue) -> Result<ColumnarValue> {
+    match v {
+        ColumnarValue::Array(arr) => {
+            let arr = arr.as_any().downcast_ref::<BooleanArray>().ok_or_else(|| {
+                let msg = format!("Expected boolean array, but had type {:?}", arr.data_type());
+                DataFusionError::Internal(msg)
+            })?;
+            let neg_array = Arc::new(compute::not(arr)?) as ArrayRef;
+            Ok(ColumnarValue::Array(neg_array))
+        }
+        ColumnarValue::Scalar(val) => {
+            if let ScalarValue::Boolean(v) = val {
+                let not_v = v.map(|v| !v);
+                Ok(ColumnarValue::Scalar(ScalarValue::Boolean(not_v)))
+            } else {
+                let msg = format!(
+                    "Expected boolean literal, but got type {:?}",
+                    val.get_datatype()
+                );
+                Err(DataFusionError::Internal(msg))
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use arrow::array::{Int64Array, StringArray};
+    use arrow_util::assert_batches_sorted_eq;
+    use datafusion::{
+        logical_plan::{col, lit},
+        physical_plan::{memory::MemoryExec, planner::DefaultPhysicalPlanner},
+    };
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_basic_split() {
+        test_helpers::maybe_start_logging();
+        let batch0 = RecordBatch::try_from_iter(vec![
+            (
+                "int_col",
+                Arc::new(Int64Array::from(vec![1, 2, 3])) as ArrayRef,
+            ),
+            (
+                "str_col",
+                Arc::new(StringArray::from(vec!["one", "two", "three"])) as ArrayRef,
+            ),
+        ])
+        .unwrap();
+
+        let batch1 = RecordBatch::try_from_iter(vec![
+            (
+                "int_col",
+                Arc::new(Int64Array::from(vec![4, -2])) as ArrayRef,
+            ),
+            (
+                "str_col",
+                Arc::new(StringArray::from(vec!["four", "negative 2"])) as ArrayRef,
+            ),
+        ])
+        .unwrap();
+
+        let input = make_input(vec![vec![batch0, batch1]]);
+        // int_col < 3
+        let split_expr = compile_expr(input.as_ref(), col("int_col").lt(lit(3)));
+        let split_exec = StreamSplitExec::new(input, split_expr);
+
+        let output0 = run_and_get_putput(&split_exec, 0).await.unwrap();
+        let expected = vec![
+            "+---------+------------+",
+            "| int_col | str_col    |",
+            "+---------+------------+",
+            "| -2      | negative 2 |",
+            "| 1       | one        |",
+            "| 2       | two        |",
+            "+---------+------------+",
+        ];
+        assert_batches_sorted_eq!(&expected, &output0);
+
+        let output1 = run_and_get_putput(&split_exec, 1).await.unwrap();
+        let expected = vec![
+            "+---------+---------+",
+            "| int_col | str_col |",
+            "+---------+---------+",
+            "| 3       | three   |",
+            "| 4       | four    |",
+            "+---------+---------+",
+        ];
+        assert_batches_sorted_eq!(&expected, &output1);
+    }
+
+    #[tokio::test]
+    async fn test_constant_split() {
+        // test that it works with a constant expression
+        test_helpers::maybe_start_logging();
+        let batch0 = RecordBatch::try_from_iter(vec![(
+            "int_col",
+            Arc::new(Int64Array::from(vec![1, 2, 3])) as ArrayRef,
+        )])
+        .unwrap();
+
+        let input = make_input(vec![vec![batch0]]);
+        // use `false` to send all outputs to second stream
+        let split_expr = compile_expr(input.as_ref(), lit(false));
+        let split_exec = StreamSplitExec::new(input, split_expr);
+
+        let output0 = run_and_get_putput(&split_exec, 0).await.unwrap();
+        let expected = vec!["++", "||", "++", "++"];
+        assert_batches_sorted_eq!(&expected, &output0);
+
+        let output1 = run_and_get_putput(&split_exec, 1).await.unwrap();
+        let expected = vec![
+            "+---------+",
+            "| int_col |",
+            "+---------+",
+            "| 1       |",
+            "| 2       |",
+            "| 3       |",
+            "+---------+",
+        ];
+        assert_batches_sorted_eq!(&expected, &output1);
+    }
+
+    #[tokio::test]
+    async fn test_nulls() {
+        // test with null inputs (so rows evaluate to null)
+
+        test_helpers::maybe_start_logging();
+        let batch0 = RecordBatch::try_from_iter(vec![(
+            "int_col",
+            Arc::new(Int64Array::from(vec![Some(1), None, Some(2), Some(3)])) as ArrayRef,
+        )])
+        .unwrap();
+
+        let input = make_input(vec![vec![batch0]]);
+        // int_col < 3
+        let split_expr = compile_expr(input.as_ref(), col("int_col").lt(lit(3)));
+        let split_exec = StreamSplitExec::new(input, split_expr);
+
+        let output0 = run_and_get_putput(&split_exec, 0).await.unwrap();
+        let expected = vec![
+            "+---------+",
+            "| int_col |",
+            "+---------+",
+            "| 1       |",
+            "| 2       |",
+            "+---------+",
+        ];
+        assert_batches_sorted_eq!(&expected, &output0);
+
+        let output1 = run_and_get_putput(&split_exec, 1).await.unwrap();
+        let expected = vec![
+            "+---------+",
+            "| int_col |",
+            "+---------+",
+            "|         |",
+            "| 3       |",
+            "+---------+",
+        ];
+        assert_batches_sorted_eq!(&expected, &output1);
+    }
+
+    #[tokio::test]
+    async fn test_non_bool() {
+        // test non boolean expression (expect error)
+
+        test_helpers::maybe_start_logging();
+        let batch0 = RecordBatch::try_from_iter(vec![(
+            "int_col",
+            Arc::new(Int64Array::from(vec![Some(1), None, Some(2), Some(3)])) as ArrayRef,
+        )])
+        .unwrap();
+
+        let input = make_input(vec![vec![batch0]]);
+        // int_col (not a boolean)
+        let split_expr = compile_expr(input.as_ref(), col("int_col"));
+        let split_exec = StreamSplitExec::new(input, split_expr);
+
+        let output0 = run_and_get_putput(&split_exec, 0)
+            .await
+            .unwrap_err()
+            .to_string();
+        assert!(
+            output0.contains("Expected boolean array, but had type Int64"),
+            "error was: {}",
+            output0
+        );
+    }
+
+    fn make_input(partitions: Vec<Vec<RecordBatch>>) -> Arc<dyn ExecutionPlan> {
+        let schema = partitions
+            .iter()
+            .flat_map(|p| p.iter())
+            .map(|batch| batch.schema())
+            .next()
+            .expect("must be at least one batch");
+
+        let projection = None;
+        let input =
+            MemoryExec::try_new(&partitions, schema, projection).expect("Created MemoryExec");
+        Arc::new(input)
+    }
+
+    fn compile_expr(input: &dyn ExecutionPlan, expr: Expr) -> Arc<dyn PhysicalExpr> {
+        let physical_planner = DefaultPhysicalPlanner::default();
+        // we should probably get a handle to the one in the default
+        // physical planner somehow,..
+        let ctx_state = datafusion::execution::context::ExecutionContextState::new();
+
+        physical_planner
+            .create_physical_expr(&expr, &input.schema(), &ctx_state)
+            .expect("creating physical expression")
+    }
+
+    /// Runs the `output_num` output of the stream and returns the results
+    async fn run_and_get_putput(
+        split_exec: &StreamSplitExec,
+        output_num: usize,
+    ) -> Result<Vec<RecordBatch>> {
+        let stream = split_exec.execute(output_num).await?;
+        datafusion::physical_plan::common::collect(stream).await
+    }
+}

--- a/query/src/exec/split.rs
+++ b/query/src/exec/split.rs
@@ -226,7 +226,7 @@ impl StreamSplitExec {
         let num_input_streams = self.input.output_partitioning().partition_count();
         assert_eq!(
             num_input_streams, 1,
-            "need at least one input partition for stream split exec"
+            "need exactly one input partition for stream split exec"
         );
 
         debug!("Setting up SplitStreamExec state");
@@ -583,7 +583,7 @@ mod tests {
     }
 
     /// Runs the `output_num` output of the stream and returns the results
-    async fn run_and_get_putput(
+    async fn run_and_get_output(
         split_exec: &StreamSplitExec,
         output_num: usize,
     ) -> Result<Vec<RecordBatch>> {

--- a/query/src/frontend/reorg.rs
+++ b/query/src/frontend/reorg.rs
@@ -63,7 +63,6 @@ impl ReorgPlanner {
     ///   (Scan chunks) <-- any needed deduplication happens here
     pub fn compact_plan<C, I>(
         &self,
-        table_name: &str,
         chunks: I,
         output_sort: SortKey<'_>,
     ) -> Result<(Schema, LogicalPlan)>
@@ -310,7 +309,7 @@ mod test {
         );
 
         let (_, compact_plan) = ReorgPlanner::new()
-            .compact_plan("t", chunks, sort_key)
+            .compact_plan(chunks, sort_key)
             .expect("created compact plan");
 
         let executor = Executor::new(1);

--- a/query/src/frontend/reorg.rs
+++ b/query/src/frontend/reorg.rs
@@ -2,15 +2,20 @@
 
 use std::sync::Arc;
 
-use snafu::{ResultExt, Snafu};
-
-use datafusion::logical_plan::{Expr, LogicalPlan, LogicalPlanBuilder};
+use datafusion::{
+    logical_plan::{col, Expr, LogicalPlan, LogicalPlanBuilder},
+    scalar::ScalarValue,
+};
 use datafusion_util::AsExpr;
-use internal_types::schema::sort::SortKey;
+use internal_types::schema::{sort::SortKey, Schema, TIME_COLUMN_NAME};
 use observability_deps::tracing::debug;
 
-use crate::{provider::ProviderBuilder, QueryChunk};
-use internal_types::schema::Schema;
+use crate::{
+    exec::make_stream_split,
+    provider::{ChunkTableProvider, ProviderBuilder},
+    QueryChunk,
+};
+use snafu::{ResultExt, Snafu};
 
 #[derive(Debug, Snafu)]
 pub enum Error {
@@ -66,7 +71,121 @@ impl ReorgPlanner {
         C: QueryChunk + 'static,
         I: IntoIterator<Item = Arc<C>>,
     {
-        debug!(%table_name, "Creating compact plan");
+        let ScanPlan {
+            plan_builder,
+            provider,
+        } = self.scan_plan(chunks)?;
+
+        // figure out the sort expression
+        let sort_exprs = output_sort
+            .iter()
+            .map(|(column_name, sort_options)| Expr::Sort {
+                expr: Box::new(column_name.as_expr()),
+                asc: !sort_options.descending,
+                nulls_first: sort_options.nulls_first,
+            });
+
+        // TODO: Set sort key on schema
+        let schema = provider.iox_schema();
+
+        let plan = plan_builder
+            .sort(sort_exprs)
+            .context(BuildingPlan)?
+            .build()
+            .context(BuildingPlan)?;
+
+        debug!(table_name=provider.table_name(), plan=%plan.display_indent_schema(),
+               "created compact plan for table");
+
+        Ok((schema, plan))
+    }
+
+    /// Creates an execution plan for the SPLIT operations which does the following:
+    ///
+    /// 1. Merges chunks together into a single stream
+    /// 2. Deduplicates via PK as necessary
+    /// 3. Sorts the result according to the requested key
+    /// 4. Splits the stream on value of the `time` column: Those
+    ///    rows that are on or before the time and those that are after
+    ///
+    /// The plan looks like:
+    ///
+    /// (Split on Time)
+    ///   (Sort on output_sort)
+    ///     (Scan chunks) <-- any needed deduplication happens here
+    ///
+    /// The output execution plan has two "output streams" (DataFusion partition):
+    /// 1. Rows that have `time` *on or before* the split_time
+    /// 2. Rows that have `time` *after* the split_time
+    ///
+    /// For example, if the input looks like:
+    /// ```text
+    ///  X | time
+    /// ---+-----
+    ///  a | 1000
+    ///  b | 2000
+    ///  c | 4000
+    ///  d | 2000
+    ///  e | 3000
+    /// ```
+    /// A split plan with `split_time=2000` will produce the following two output streams
+    ///
+    /// ```text
+    ///  X | time
+    /// ---+-----
+    ///  a | 1000
+    ///  b | 2000
+    ///  d | 2000
+    /// ```
+    /// and
+    /// ```text
+    ///  X | time
+    /// ---+-----
+    ///  c | 4000
+    ///  e | 3000
+    /// ```
+    pub fn split_plan<C>(&self, chunks: Vec<Arc<C>>, split_time: i64) -> Result<LogicalPlan>
+    where
+        C: QueryChunk + 'static,
+    {
+        let ScanPlan {
+            plan_builder,
+            provider,
+        } = self.scan_plan(chunks)?;
+
+        // time <= split_time
+        let ts_literal = Expr::Literal(ScalarValue::TimestampNanosecond(Some(split_time)));
+        let split_expr = col(TIME_COLUMN_NAME).lt_eq(ts_literal);
+
+        let plan = plan_builder.build().context(BuildingPlan)?;
+
+        let plan = make_stream_split(plan, split_expr);
+
+        debug!(table_name=provider.table_name(), plan=%plan.display_indent_schema(),
+               "created split plan for table");
+
+        Ok(plan)
+    }
+
+    /// Creates a scan plan for the set of chunks that:
+    ///
+    /// 1. Merges chunks together into a single stream
+    /// 2. Deduplicates via PK as necessary
+    ///
+    /// The plan looks like:
+    ///
+    /// (Scan chunks) <-- any needed deduplication happens here
+    fn scan_plan<C, I>(&self, chunks: I) -> Result<ScanPlan<C>>
+    where
+        C: QueryChunk + 'static,
+        I: IntoIterator<Item = Arc<C>>,
+    {
+        let mut chunks = chunks.into_iter().peekable();
+        let table_name = match chunks.peek() {
+            Some(chunk) => chunk.table_name().to_string(),
+            None => panic!("No chunks provided to compact plan"),
+        };
+        let table_name = &table_name;
 
         // Prepare the plan for the table
         let mut builder = ProviderBuilder::new(table_name);
@@ -94,101 +213,35 @@ impl ReorgPlanner {
         // Scan all columns
         let projection = None;
 
-        // figure out the sort expression
-        let sort_exprs = output_sort
-            .iter()
-            .map(|(column_name, sort_options)| Expr::Sort {
-                expr: Box::new(column_name.as_expr()),
-                asc: !sort_options.descending,
-                nulls_first: sort_options.nulls_first,
-            });
+        let plan_builder =
+            LogicalPlanBuilder::scan(table_name, Arc::clone(&provider) as _, projection)
+                .context(BuildingPlan)?;
 
-        // TODO: Set sort key on schema
-        let schema = provider.iox_schema();
-
-        let plan = LogicalPlanBuilder::scan(table_name, provider, projection)
-            .context(BuildingPlan)?
-            // Add the appropriate sort
-            .sort(sort_exprs)
-            .context(BuildingPlan)?
-            .build()
-            .context(BuildingPlan)?;
-
-        Ok((schema, plan))
+        Ok(ScanPlan {
+            plan_builder,
+            provider,
+        })
     }
+}
 
-    /// Creates an execution plan for the SPLIT operations which does the following:
-    ///
-    /// 1. Merges chunks together into a single stream
-    /// 2. Deduplicates via PK as necessary
-    /// 3. Sorts the result according to the requested key
-    /// 4. Splits the stream on value of the `time` column: Those
-    ///    rows that are on or before the time and those that are after
-    ///
-    /// The plan looks like:
-    ///
-    /// (Split on Time)
-    ///   (Sort on output_sort)
-    ///     (Scan chunks) <-- any needed deduplication happens here
-    ///
-    /// The output execution plan has two "output streams" (DataFusion partition):
-    /// 1. Rows that have `time` *on or before* the split_time
-    /// 2. Rows that have `time` *after* the split_time
-    ///
-    /// For example, if the input looks like:
-    /// ```text
-    ///  a | time
-    /// ---+-----
-    ///  a | 1000
-    ///  b | 2000
-    ///  c | 4000
-    ///  d | 2000
-    ///  e | 3000
-    /// ```
-    /// A split plan with `split_time=2000` will produce the following two output streams
-    ///
-    /// ```text
-    ///  a | time
-    /// ---+-----
-    ///  a | 1000
-    ///  b | 2000
-    ///  d | 2000
-    /// ```
-    /// and
-    /// ```text
-    ///  a | time
-    /// ---+-----
-    ///  c | 4000
-    ///  e | 3000
-    /// ```
-
-    pub fn split_plan<C>(
-        &self,
-        table_name: &str,
-        chunks: Vec<Arc<C>>,
-        output_sort: SortKey<'_>,
-        _split_time: i64,
-    ) -> Result<LogicalPlan>
-    where
-        C: QueryChunk + 'static,
-    {
-        let (_, _base_plan) = self.compact_plan(table_name, chunks, output_sort)?;
-        todo!("Add in the split node and return");
-    }
+struct ScanPlan<C: QueryChunk + 'static> {
+    plan_builder: LogicalPlanBuilder,
+    provider: Arc<ChunkTableProvider<C>>,
 }
 
 #[cfg(test)]
 mod test {
-    use arrow_util::assert_batches_eq;
-    use datafusion::prelude::ExecutionContext;
+    use arrow_util::{assert_batches_eq, assert_batches_sorted_eq};
     use internal_types::schema::sort::SortOptions;
 
-    use crate::test::{raw_data, TestChunk};
+    use crate::{
+        exec::Executor,
+        test::{raw_data, TestChunk},
+    };
 
     use super::*;
 
-    #[tokio::test]
-    async fn deduplicate_plan_for_overlapped_chunks() {
+    async fn get_test_chunks() -> Vec<Arc<TestChunk>> {
         // Chunk 1 with 5 rows of data on 2 tags
         let chunk1 = Arc::new(
             TestChunk::new(1)
@@ -208,8 +261,6 @@ mod test {
                 .with_four_rows_of_data("t"),
         );
 
-        let chunks = vec![chunk1, chunk2];
-
         let expected = vec![
             "+-----------+------+-------------------------------+",
             "| field_int | tag1 | time                          |",
@@ -221,7 +272,7 @@ mod test {
             "| 5         | MT   | 1970-01-01 00:00:00.000005    |",
             "+-----------+------+-------------------------------+",
         ];
-        assert_batches_eq!(&expected, &raw_data(&[Arc::clone(&chunks[0])]).await);
+        assert_batches_eq!(&expected, &raw_data(&[Arc::clone(&chunk1)]).await);
 
         let expected = vec![
             "+-----------+------------+------+----------------------------+",
@@ -233,7 +284,14 @@ mod test {
             "| 50        | 50         | VT   | 1970-01-01 00:00:00.000010 |",
             "+-----------+------------+------+----------------------------+",
         ];
-        assert_batches_eq!(&expected, &raw_data(&[Arc::clone(&chunks[1])]).await);
+        assert_batches_eq!(&expected, &raw_data(&[Arc::clone(&chunk2)]).await);
+
+        vec![chunk1, chunk2]
+    }
+
+    #[tokio::test]
+    async fn test_compact_plan() {
+        let chunks = get_test_chunks().await;
 
         let mut sort_key = SortKey::with_capacity(2);
         sort_key.push(
@@ -255,8 +313,8 @@ mod test {
             .compact_plan("t", chunks, sort_key)
             .expect("created compact plan");
 
-        let ctx = ExecutionContext::new();
-        let physical_plan = ctx.create_physical_plan(&compact_plan).unwrap();
+        let executor = Executor::new(1);
+        let physical_plan = executor.new_context().prepare_plan(&compact_plan).unwrap();
         assert_eq!(
             physical_plan.output_partitioning().partition_count(),
             1,
@@ -283,5 +341,61 @@ mod test {
             "+-----------+------------+------+-------------------------------+",
         ];
         assert_batches_eq!(&expected, &batches);
+    }
+
+    #[tokio::test]
+    async fn test_split_plan() {
+        // validate that the plumbing is all hooked up. The logic of
+        // the operator is tested in its own module.
+        let chunks = get_test_chunks().await;
+
+        // split on 1000 should have timestamps 1000, 5000, and 7000
+        let split_plan = ReorgPlanner::new()
+            .split_plan(chunks, 1000)
+            .expect("created compact plan");
+
+        let executor = Executor::new(1);
+        let physical_plan = executor.new_context().prepare_plan(&split_plan).unwrap();
+
+        assert_eq!(
+            physical_plan.output_partitioning().partition_count(),
+            2,
+            "{:?}",
+            physical_plan.output_partitioning()
+        );
+
+        // verify that the stream was split
+        let stream0 = physical_plan.execute(0).await.expect("ran the plan");
+        let batches0 = datafusion::physical_plan::common::collect(stream0)
+            .await
+            .expect("plan ran without error");
+
+        let expected = vec![
+            "+-----------+------------+------+-------------------------------+",
+            "| field_int | field_int2 | tag1 | time                          |",
+            "+-----------+------------+------+-------------------------------+",
+            "| 1000      |            | MT   | 1970-01-01 00:00:00.000001    |",
+            "| 70        |            | CT   | 1970-01-01 00:00:00.000000100 |",
+            "| 100       |            | AL   | 1970-01-01 00:00:00.000000050 |",
+            "+-----------+------------+------+-------------------------------+",
+        ];
+        assert_batches_sorted_eq!(&expected, &batches0);
+
+        let stream1 = physical_plan.execute(1).await.expect("ran the plan");
+        let batches1 = datafusion::physical_plan::common::collect(stream1)
+            .await
+            .expect("plan ran without error");
+        let expected = vec![
+            "+-----------+------------+------+----------------------------+",
+            "| field_int | field_int2 | tag1 | time                       |",
+            "+-----------+------------+------+----------------------------+",
+            "| 10        |            | MT   | 1970-01-01 00:00:00.000007 |",
+            "| 1000      | 1000       | WA   | 1970-01-01 00:00:00.000008 |",
+            "| 5         |            | MT   | 1970-01-01 00:00:00.000005 |",
+            "| 50        | 50         | VT   | 1970-01-01 00:00:00.000010 |",
+            "| 70        | 70         | UT   | 1970-01-01 00:00:00.000020 |",
+            "+-----------+------------+------+----------------------------+",
+        ];
+        assert_batches_sorted_eq!(&expected, &batches1);
     }
 }

--- a/query/src/provider.rs
+++ b/query/src/provider.rs
@@ -213,6 +213,11 @@ impl<C: QueryChunk + 'static> ChunkTableProvider<C> {
     pub fn arrow_schema(&self) -> ArrowSchemaRef {
         self.iox_schema.as_arrow()
     }
+
+    /// Return the table name
+    pub fn table_name(&self) -> &str {
+        self.table_name.as_ref()
+    }
 }
 
 impl<C: QueryChunk + 'static> TableProvider for ChunkTableProvider<C> {

--- a/server/src/db/lifecycle/compact.rs
+++ b/server/src/db/lifecycle/compact.rs
@@ -126,11 +126,8 @@ pub(super) fn compact_chunks(
         let key = compute_sort_key(query_chunks.iter().map(|x| x.summary()));
 
         // Cannot move query_chunks as the sort key borrows the column names
-        let (schema, plan) = ReorgPlanner::new().compact_plan(
-            &table_name,
-            query_chunks.iter().map(Arc::clone),
-            key,
-        )?;
+        let (schema, plan) =
+            ReorgPlanner::new().compact_plan(query_chunks.iter().map(Arc::clone), key)?;
 
         let physical_plan = ctx.prepare_plan(&plan)?;
         let mut stream = ctx.execute(physical_plan).await?;


### PR DESCRIPTION
# Rationale:

re https://github.com/influxdata/conductor/issues/360

Needed for the persist operation where a chunk needs to be split on time.

For example, if the input looks like:
```text
 X | time
---+-----
 a | 1000
 b | 2000
 c | 4000
 d | 2000
 e | 3000
```

A split plan with `split_time=2000` will produce the following two output streams

```text
 X | time
---+-----
 a | 1000
 b | 2000
 d | 2000
```

```text
 X | time
---+-----
 c | 4000
 e | 3000
```


# Changes
1. Implement `SplitStream` operator and tests
2. Connect to split_plan
3. tests for same

# Notes
It agree it seems like a lot of ceremony / plumbing to do the actual work... :shrug:
