### PR TITLE
fix: Use layered tracing

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -20,7 +20,6 @@ use tikv_jemallocator::Jemalloc;
 
 mod commands {
     pub mod database;
-    pub mod layered_tracing;
     pub mod operations;
     pub mod run;
     pub mod server;


### PR DESCRIPTION
The main issue that was preventing us to use open telemetry / jaeger tracing in IOx (and to close #1012) was the "per layer filtering" issue (see https://github.com/influxdata/influxdb_iox/issues/1012#issuecomment-821291660), whose summary is roughly:

> If we enable both logging and OT tracing, then both the logs and the trace output will be filtered with the intersection of the log and trace filters. We don't want our logs to be accidentally miss events because they are excluded from the tracing filter and we usually want the OT/jaeger tracing system to capture events at a higher verbosity (albeit at lower sample rate) than the logs.

This issue has been worked around in #1681 but it hasn't been plumbed in the IOx tracing configuration (which has been in the meantime factored out in the `trogging` crate.

This PR:

* moves the `filtered_layer` module from the `influxdb_iox` crate into the `trogging` crate, and applies a few fixes to please the more restrictive linter there.
* changes the signature of `FilteredLayer::new` from `new(filter_layer, other_layer)` to just `new(Layer)`. This was needed because all the layers in the trogging config are `Option<Layered>`, and you cannot call `.and_then()` on an `Option<T>`
* change the `trogging` subscriber `builder` to actually use two filtering layers, one for the logs (governed by the `log_filter`) and one for the tracing destinations (governed by the `traces_layer_filter`).

Closes #1012

----

Tested manually:

```console
$ cargo run -- run --traces-sampler traceidratio --log-format full --log-filter info --traces-filter=trace --server-id 1 --traces-exporter jaeger --traces-exporter-jaeger-agent-host localhost --traces-sampler-arg 1 --traces-exporter-jaeger-service-name=fooler
Jun 24 17:05:59.036  INFO influxdb_iox::influxdb_ioxd: InfluxDB IOx server starting git_hash="9ca2a08e1094f2dcf710e077b90af9a07cb61d85" num_cpus=12 build_malloc_conf="\u{0}"
Jun 24 17:05:59.036  WARN influxdb_iox::influxdb_ioxd: NO PERSISTENCE: using Memory for object storage
Jun 24 17:05:59.037  INFO server::init: server ID set server_id=1
Jun 24 17:05:59.038  INFO influxdb_iox::influxdb_ioxd: gRPC server listening bind_address=127.0.0.1:8082
Jun 24 17:05:59.038  INFO influxdb_iox::influxdb_ioxd: HTTP server listening bind_address=127.0.0.1:8080
Jun 24 17:05:59.038  INFO influxdb_iox::influxdb_ioxd: InfluxDB IOx server ready git_hash="9ca2a08e1094f2dcf710e077b90af9a07cb61d85"
Jun 24 17:05:59.078  INFO server_worker: server: started background worker
Jun 24 17:05:59.078  INFO server_worker: server::init: loaded databases, server is initalized
OpenTelemetry trace error occurred ExportFailed(ThriftAgentError(ProtocolError { kind: SizeLimit, message: "jaeger exporter payload size of 4505 bytes over max UDP packet size of 1300 bytes. Try setting a smaller batch size." }))
Jun 24 17:08:03.281  INFO server::db: Found NO existing catalog for DB foobar_weather, creating new one
Jun 24 17:08:03.281  INFO parquet_file::catalog: transaction started tkey=TransactionKey { revision_counter: 0, uuid: c9a63cc3-b4d8-4242-87c9-5df224b9f77a }
Jun 24 17:08:03.282  INFO parquet_file::catalog: transaction committed tkey=TransactionKey { revision_counter: 0, uuid: c9a63cc3-b4d8-4242-87c9-5df224b9f77a }
Jun 24 17:08:03.283  INFO db_worker{database=foobar_weather}: server::db: started background worker
```

![image](https://user-images.githubusercontent.com/52673/123287794-4e4fa400-d50f-11eb-9194-e6e79f4f614b.png)
