### PR TITLE
chore: Update datafusion deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,7 +171,7 @@ version = "0.1.0"
 dependencies = [
  "ahash 0.7.4",
  "arrow",
- "hashbrown 0.11.2",
+ "hashbrown",
  "num-traits",
  "rand 0.8.4",
  "snafu",
@@ -190,13 +190,13 @@ dependencies = [
 
 [[package]]
 name = "assert_cmd"
-version = "1.0.5"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a88b6bd5df287567ffdf4ddf4d33060048e1068308e5f62d81c6f9824a045a48"
+checksum = "3d20831bd004dda4c7c372c19cdabff369f794a95e955b3f13fe460e3e1ae95f"
 dependencies = [
  "bstr",
  "doc-comment",
- "predicates",
+ "predicates 2.0.0",
  "predicates-core",
  "predicates-tree",
  "wait-timeout",
@@ -467,11 +467,11 @@ dependencies = [
 
 [[package]]
 name = "cast"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57cdfa5d50aad6cb4d44dcab6101a7f79925bd59d82ca42f38a9856a28865374"
+checksum = "4c24dab4283a142afa2fdca129b80ad2c6284e073930f964c3a1293c225ee39a"
 dependencies = [
- "rustc_version 0.3.3",
+ "rustc_version 0.4.0",
 ]
 
 [[package]]
@@ -837,17 +837,17 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "4.0.0-SNAPSHOT"
-source = "git+https://github.com/apache/arrow-datafusion.git?rev=4a55364448c81182731f4fa4c3e65aef5b31fa0f#4a55364448c81182731f4fa4c3e65aef5b31fa0f"
+source = "git+https://github.com/apache/arrow-datafusion.git?rev=79d60f9b678e9a2351fc83511399663985e39cf6#79d60f9b678e9a2351fc83511399663985e39cf6"
 dependencies = [
  "ahash 0.7.4",
  "arrow",
  "async-trait",
  "chrono",
  "futures",
- "hashbrown 0.11.2",
+ "hashbrown",
  "log",
  "num_cpus",
- "ordered-float 2.5.1",
+ "ordered-float 2.6.0",
  "parquet",
  "paste 1.0.5",
  "pin-project-lite",
@@ -891,6 +891,12 @@ name = "difference"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
+
+[[package]]
+name = "difflib"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
 
 [[package]]
 name = "digest"
@@ -1406,12 +1412,6 @@ checksum = "62aca2aba2d62b4a7f5b33f3712cb1b0692779a56fb510499d5c0aa594daeaf3"
 
 [[package]]
 name = "hashbrown"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
-
-[[package]]
-name = "hashbrown"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
@@ -1566,12 +1566,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.6.2"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "824845a0bf897a9042383849b02c1bc219c2383772efcd5c6f9766fa4b81aef3"
+checksum = "bc633605454125dec4b66843673f01c7df2b89479b32e0ed634e43a91cff62a5"
 dependencies = [
  "autocfg",
- "hashbrown 0.9.1",
+ "hashbrown",
 ]
 
 [[package]]
@@ -1652,7 +1652,7 @@ dependencies = [
  "parking_lot",
  "parquet",
  "pprof",
- "predicates",
+ "predicates 1.0.8",
  "prettytable-rs",
  "prost",
  "query",
@@ -1751,7 +1751,7 @@ version = "0.1.0"
 dependencies = [
  "arrow",
  "arrow_util",
- "hashbrown 0.11.2",
+ "hashbrown",
  "indexmap",
  "itertools 0.10.1",
  "observability_deps",
@@ -1847,9 +1847,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.97"
+version = "0.2.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12b8adadd720df158f4d70dfe7ccc6adb0472d7c55ca83445f6a5ab3e36f8fb6"
+checksum = "320cfe77175da3a483efed4bc0adc1968ca050b098ce4f2f1c13a56626128790"
 
 [[package]]
 name = "libloading"
@@ -1886,7 +1886,7 @@ dependencies = [
  "chrono",
  "data_types",
  "futures",
- "hashbrown 0.11.2",
+ "hashbrown",
  "observability_deps",
  "tokio",
  "tracker",
@@ -2008,7 +2008,7 @@ name = "metrics"
 version = "0.1.0"
 dependencies = [
  "dashmap",
- "hashbrown 0.11.2",
+ "hashbrown",
  "observability_deps",
  "opentelemetry-prometheus",
  "parking_lot",
@@ -2108,7 +2108,7 @@ dependencies = [
  "chrono",
  "data_types",
  "entry",
- "hashbrown 0.11.2",
+ "hashbrown",
  "influxdb_line_protocol",
  "internal_types",
  "metrics",
@@ -2508,9 +2508,9 @@ dependencies = [
 
 [[package]]
 name = "ordered-float"
-version = "2.5.1"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f100fcfb41e5385e0991f74981732049f9b896821542a219420491046baafdc2"
+checksum = "6dea6388d3d5498ec651701f14edbaf463c924b5d8829fb2848ccf0bcc7b3c69"
 dependencies = [
  "num-traits",
 ]
@@ -2713,15 +2713,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pest"
-version = "2.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10f4872ae94d7b90ae48754df22fd42ad52ce740b8f370b03da4835417403e53"
-dependencies = [
- "ucd-trie",
-]
-
-[[package]]
 name = "petgraph"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2804,15 +2795,15 @@ dependencies = [
 
 [[package]]
 name = "plotters-backend"
-version = "0.3.0"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b07fffcddc1cb3a1de753caa4e4df03b79922ba43cf882acc1bdd7e8df9f4590"
+checksum = "d88417318da0eaf0fdcdb51a0ee6c3bed624333bff8f946733049380be67ac1c"
 
 [[package]]
 name = "plotters-svg"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b38a02e23bd9604b842a812063aec4ef702b57989c37b655254bb61c471ad211"
+checksum = "521fa9638fa597e1dc53e9412a4f9cefb01187ee1f7413076f9e6749e2885ba9"
 dependencies = [
  "plotters-backend",
 ]
@@ -2855,6 +2846,17 @@ dependencies = [
  "normalize-line-endings",
  "predicates-core",
  "regex",
+]
+
+[[package]]
+name = "predicates"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6e46ca79eb4e21e2ec14430340c71250ab69332abf85521c95d3a8bc336aa76"
+dependencies = [
+ "difflib",
+ "itertools 0.10.1",
+ "predicates-core",
 ]
 
 [[package]]
@@ -3026,7 +3028,7 @@ dependencies = [
  "datafusion 0.1.0",
  "datafusion_util",
  "futures",
- "hashbrown 0.11.2",
+ "hashbrown",
  "internal_types",
  "itertools 0.10.1",
  "libc",
@@ -3252,7 +3254,7 @@ dependencies = [
  "data_types",
  "datafusion 0.1.0",
  "either",
- "hashbrown 0.11.2",
+ "hashbrown",
  "internal_types",
  "itertools 0.10.1",
  "metrics",
@@ -3529,11 +3531,11 @@ dependencies = [
 
 [[package]]
 name = "rustc_version"
-version = "0.3.3"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0dfe2087c51c460008730de8b57e6a320782fbfb312e1f4d520e6c6fae155ee"
+checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
- "semver 0.11.0",
+ "semver 1.0.3",
 ]
 
 [[package]]
@@ -3655,32 +3657,20 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 dependencies = [
- "semver-parser 0.7.0",
+ "semver-parser",
 ]
 
 [[package]]
 name = "semver"
-version = "0.11.0"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
-dependencies = [
- "semver-parser 0.10.2",
-]
+checksum = "5f3aac57ee7f3272d8395c6e4f502f434f0e289fcd62876f70daa008c20dcabe"
 
 [[package]]
 name = "semver-parser"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
-
-[[package]]
-name = "semver-parser"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0bef5b7f9e0df16536d3961cfb6e84331c065b4066afb39768d0e319411f7"
-dependencies = [
- "pest",
-]
 
 [[package]]
 name = "serde"
@@ -3779,7 +3769,7 @@ dependencies = [
  "futures",
  "futures-util",
  "generated_types",
- "hashbrown 0.11.2",
+ "hashbrown",
  "influxdb_iox_client",
  "influxdb_line_protocol",
  "internal_types",
@@ -4046,9 +4036,9 @@ checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "structopt"
-version = "0.3.21"
+version = "0.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5277acd7ee46e63e5168a80734c9f6ee81b1367a7d8772a2d765df2a3705d28c"
+checksum = "69b041cdcb67226aca307e6e7be44c8806423d83e018bd662360a93dabce4d71"
 dependencies = [
  "clap",
  "lazy_static",
@@ -4057,9 +4047,9 @@ dependencies = [
 
 [[package]]
 name = "structopt-derive"
-version = "0.4.14"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ba9cdfda491b814720b6b06e0cac513d922fc407582032e8706e9f137976f90"
+checksum = "7813934aecf5f51a54775e00068c237de98489463968231a51746bbbc03f9c10"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -4180,18 +4170,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.25"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa6f76457f59514c7eeb4e59d891395fab0b2fd1d40723ae737d64153392e9c6"
+checksum = "93119e4feac1cbe6c798c34d3a53ea0026b0b1de6a120deef895137c0529bfe2"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.25"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a36768c0fbf1bb15eca10defa29526bda730a2376c2ab4393ccfa16fb1a318d"
+checksum = "060d69a0afe7796bf42e9e2ff91f5ee691fb15c53d38b4b62a9a53eb23164745"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4336,9 +4326,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.7.1"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fb2ed024293bb19f7a5dc54fe83bf86532a44c12a2bb8ba40d64a4509395ca2"
+checksum = "98c8b05dc14c75ea83d63dd391100353789f5f24b8b3866542a5e85c8be8e985"
 dependencies = [
  "autocfg",
  "bytes",
@@ -4356,9 +4346,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c49e3df43841dafb86046472506755d8501c5615673955f6aa17181125d13c37"
+checksum = "54473be61f4ebe4efd09cec9bd5d16fa51d70ea0192213d754d2d500457db110"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4388,9 +4378,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8864d706fdb3cc0843a49647ac892720dac98a6eeb818b77190592cf4994066"
+checksum = "7b2f3f698253f03119ac0102beaa64f67a67e08074d03a22d18784104543727f"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -4615,7 +4605,7 @@ name = "tracker"
 version = "0.1.0"
 dependencies = [
  "futures",
- "hashbrown 0.11.2",
+ "hashbrown",
  "lock_api",
  "metrics",
  "observability_deps",
@@ -4659,12 +4649,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f6906492a7cd215bfa4cf595b600146ccfac0c79bcbd1f3000162af5e8b06"
 
 [[package]]
-name = "ucd-trie"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
-
-[[package]]
 name = "unicode-bidi"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4684,9 +4668,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.7.1"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0d2e7be6ae3a5fa87eed5fb451aff96f2573d2694942e40543ae0bbe19c796"
+checksum = "8895849a949e7845e06bd6dc1aa51731a103c42707010a5b591c0038fb73385b"
 
 [[package]]
 name = "unicode-width"

--- a/datafusion/Cargo.toml
+++ b/datafusion/Cargo.toml
@@ -9,4 +9,4 @@ description = "Re-exports datafusion at a specific version"
 
 # Rename to workaround doctest bug
 # Turn off optional datafusion features (function packages)
-upstream = { git = "https://github.com/apache/arrow-datafusion.git", rev = "4a55364448c81182731f4fa4c3e65aef5b31fa0f", default-features = false, package = "datafusion" }
+upstream = { git = "https://github.com/apache/arrow-datafusion.git", rev = "79d60f9b678e9a2351fc83511399663985e39cf6", default-features = false, package = "datafusion" }

--- a/datafusion_util/src/lib.rs
+++ b/datafusion_util/src/lib.rs
@@ -4,8 +4,6 @@
 use std::sync::Arc;
 use std::task::{Context, Poll};
 
-use datafusion::physical_plan::expressions::Column;
-use datafusion::physical_plan::PhysicalExpr;
 use datafusion::{
     arrow::{datatypes::SchemaRef, error::Result as ArrowResult, record_batch::RecordBatch},
     logical_plan::{binary_expr, col, lit, Expr, Operator},
@@ -28,12 +26,6 @@ pub trait AsExpr {
     }
 }
 
-/// Traits to help creating DataFusion [`PhysicalExpr`]s
-pub trait AsPhysicalExpr {
-    /// creates a DataFusion PhysicalExpr
-    fn as_physical_expr(&self) -> Arc<dyn PhysicalExpr>;
-}
-
 impl AsExpr for Arc<str> {
     fn as_expr(&self) -> Expr {
         col(self.as_ref())
@@ -43,18 +35,6 @@ impl AsExpr for Arc<str> {
 impl AsExpr for str {
     fn as_expr(&self) -> Expr {
         col(self)
-    }
-}
-
-impl AsPhysicalExpr for Arc<str> {
-    fn as_physical_expr(&self) -> Arc<dyn PhysicalExpr> {
-        Arc::new(Column::new(self.as_ref()))
-    }
-}
-
-impl AsPhysicalExpr for str {
-    fn as_physical_expr(&self) -> Arc<dyn PhysicalExpr> {
-        Arc::new(Column::new(self))
     }
 }
 

--- a/query/src/exec.rs
+++ b/query/src/exec.rs
@@ -18,7 +18,7 @@ use std::sync::Arc;
 use arrow::record_batch::RecordBatch;
 use datafusion::{
     self,
-    logical_plan::{Expr, LogicalPlan},
+    logical_plan::{normalize_col, Expr, LogicalPlan},
     physical_plan::ExecutionPlan,
 };
 
@@ -402,6 +402,9 @@ pub fn make_schema_pivot(input: LogicalPlan) -> LogicalPlan {
 ///  b | 4000
 /// ```
 pub fn make_stream_split(input: LogicalPlan, split_expr: Expr) -> LogicalPlan {
+    // rewrite the input expression so that it is fully qualified with the input schema
+    let split_expr = normalize_col(split_expr, &input).expect("normalize is infallable");
+
     let node = Arc::new(StreamSplitNode::new(input, split_expr));
     LogicalPlan::Extension { node }
 }

--- a/query/src/exec/context.rs
+++ b/query/src/exec/context.rs
@@ -8,8 +8,8 @@ use datafusion::{
     execution::context::{ExecutionContextState, QueryPlanner},
     logical_plan::{LogicalPlan, UserDefinedLogicalNode},
     physical_plan::{
+        coalesce_partitions::CoalescePartitionsExec,
         collect, displayable,
-        merge::MergeExec,
         planner::{DefaultPhysicalPlanner, ExtensionPlanner},
         ExecutionPlan, PhysicalPlanner, SendableRecordBatchStream,
     },
@@ -62,32 +62,42 @@ impl ExtensionPlanner for IOxExtensionPlanner {
     /// Create a physical plan for an extension node
     fn plan_extension(
         &self,
+        planner: &dyn PhysicalPlanner,
         node: &dyn UserDefinedLogicalNode,
-        inputs: &[Arc<dyn ExecutionPlan>],
+        logical_inputs: &[&LogicalPlan],
+        physical_inputs: &[Arc<dyn ExecutionPlan>],
         ctx_state: &ExecutionContextState,
     ) -> Result<Option<Arc<dyn ExecutionPlan>>> {
         let any = node.as_any();
         let plan = if let Some(schema_pivot) = any.downcast_ref::<SchemaPivotNode>() {
-            assert_eq!(inputs.len(), 1, "Inconsistent number of inputs");
+            assert_eq!(physical_inputs.len(), 1, "Inconsistent number of inputs");
             Some(Arc::new(SchemaPivotExec::new(
-                Arc::clone(&inputs[0]),
+                Arc::clone(&physical_inputs[0]),
                 schema_pivot.schema().as_ref().clone().into(),
             )) as Arc<dyn ExecutionPlan>)
         } else if let Some(stream_split) = any.downcast_ref::<StreamSplitNode>() {
-            assert_eq!(inputs.len(), 1, "Inconsistent number of inputs");
-            // It is strange to have to make a new physical planner
-            // (when we are already being called via a planner)
-            let physical_planner = DefaultPhysicalPlanner::default();
-            let split_expr = physical_planner.create_physical_expr(
+            assert_eq!(
+                logical_inputs.len(),
+                1,
+                "Inconsistent number of logical inputs"
+            );
+            assert_eq!(
+                physical_inputs.len(),
+                1,
+                "Inconsistent number of physical inputs"
+            );
+
+            let split_expr = planner.create_physical_expr(
                 stream_split.split_expr(),
-                &inputs[0].schema(),
+                &logical_inputs[0].schema(),
+                &physical_inputs[0].schema(),
                 ctx_state,
             )?;
 
-            Some(
-                Arc::new(StreamSplitExec::new(Arc::clone(&inputs[0]), split_expr))
-                    as Arc<dyn ExecutionPlan>,
-            )
+            Some(Arc::new(StreamSplitExec::new(
+                Arc::clone(&physical_inputs[0]),
+                split_expr,
+            )) as Arc<dyn ExecutionPlan>)
         } else {
             None
         };
@@ -201,7 +211,7 @@ impl IOxExecutionContext {
                     physical_plan.execute(0).await
                 } else {
                     // merge into a single partition
-                    let plan = MergeExec::new(physical_plan);
+                    let plan = CoalescePartitionsExec::new(physical_plan);
                     // MergeExec must produce a single partition
                     assert_eq!(1, plan.output_partitioning().partition_count());
                     plan.execute(0).await

--- a/query/src/exec/schema_pivot.rs
+++ b/query/src/exec/schema_pivot.rs
@@ -34,7 +34,7 @@ use arrow::{
 };
 use datafusion::{
     error::{DataFusionError as Error, Result},
-    logical_plan::{self, DFSchemaRef, Expr, LogicalPlan, ToDFSchema, UserDefinedLogicalNode},
+    logical_plan::{DFSchemaRef, Expr, LogicalPlan, ToDFSchema, UserDefinedLogicalNode},
     physical_plan::{
         common::SizedRecordBatchStream, DisplayFormatType, Distribution, ExecutionPlan,
         Partitioning, SendableRecordBatchStream,
@@ -58,12 +58,12 @@ impl SchemaPivotNode {
         let schema = make_schema_pivot_output_schema();
 
         // Form exprs that refer to all of our input columns (so that
-        // datafusion doesn't opimize them away)
+        // datafusion knows not to opimize them away)
         let exprs = input
             .schema()
             .fields()
             .iter()
-            .map(|field| logical_plan::col(field.name()))
+            .map(|field| Expr::Column(field.qualified_column()))
             .collect::<Vec<_>>();
 
         Self {

--- a/query/src/exec/split.rs
+++ b/query/src/exec/split.rs
@@ -394,10 +394,12 @@ fn negate(v: &ColumnarValue) -> Result<ColumnarValue> {
 
 #[cfg(test)]
 mod tests {
+    use std::convert::TryInto;
+
     use arrow::array::{Int64Array, StringArray};
     use arrow_util::assert_batches_sorted_eq;
     use datafusion::{
-        logical_plan::{col, lit},
+        logical_plan::{col, lit, DFSchema},
         physical_plan::{memory::MemoryExec, planner::DefaultPhysicalPlanner},
     };
 
@@ -577,8 +579,20 @@ mod tests {
         // physical planner somehow,..
         let ctx_state = datafusion::execution::context::ExecutionContextState::new();
 
+        let input_physical_schema = input.schema();
+        let input_logical_schema: DFSchema = input_physical_schema
+            .as_ref()
+            .clone()
+            .try_into()
+            .expect("could make logical schema");
+
         physical_planner
-            .create_physical_expr(&expr, &input.schema(), &ctx_state)
+            .create_physical_expr(
+                &expr,
+                &input_logical_schema,
+                &input_physical_schema,
+                &ctx_state,
+            )
             .expect("creating physical expression")
     }
 

--- a/query/src/exec/split.rs
+++ b/query/src/exec/split.rs
@@ -584,7 +584,7 @@ mod tests {
             .as_ref()
             .clone()
             .try_into()
-            .expect("could make logical schema");
+            .expect("could not make logical schema");
 
         physical_planner
             .create_physical_expr(

--- a/query/src/frontend/influxrpc.rs
+++ b/query/src/frontend/influxrpc.rs
@@ -430,7 +430,7 @@ impl InfluxRpcPlanner {
                 schema: _,
             }) = scan_and_filter
             {
-                let tag_name_is_not_null = Expr::Column(tag_name.to_string()).is_not_null();
+                let tag_name_is_not_null = Expr::Column(tag_name.into()).is_not_null();
 
                 // TODO: optimize this to use "DISINCT" or do
                 // something more intelligent that simply fetching all

--- a/query/src/frontend/reorg.rs
+++ b/query/src/frontend/reorg.rs
@@ -352,6 +352,7 @@ mod test {
 
     #[tokio::test]
     async fn test_split_plan() {
+        test_helpers::maybe_start_logging();
         // validate that the plumbing is all hooked up. The logic of
         // the operator is tested in its own module.
         let chunks = get_test_chunks().await;

--- a/query/src/predicate.rs
+++ b/query/src/predicate.rs
@@ -333,7 +333,7 @@ impl PredicateBuilder {
             .into_iter()
             .try_for_each::<_, Result<_, DataFusionError>>(|expr| {
                 let mut columns = HashSet::new();
-                utils::expr_to_column_names(&expr, &mut columns)?;
+                utils::expr_to_columns(&expr, &mut columns)?;
 
                 if columns.len() == 1 && Self::primitive_binary_expr(&expr) {
                     pushdown_exprs.push(expr);

--- a/query/src/provider/deduplicate.rs
+++ b/query/src/provider/deduplicate.rs
@@ -330,7 +330,7 @@ mod test {
         .unwrap();
 
         let sort_keys = vec![PhysicalSortExpr {
-            expr: col("t1"),
+            expr: col("t1", &batch.schema()).unwrap(),
             options: SortOptions {
                 descending: false,
                 nulls_first: false,
@@ -451,14 +451,14 @@ mod test {
 
         let sort_keys = vec![
             PhysicalSortExpr {
-                expr: col("t1"),
+                expr: col("t1", &batch.schema()).unwrap(),
                 options: SortOptions {
                     descending: false,
                     nulls_first: false,
                 },
             },
             PhysicalSortExpr {
-                expr: col("t2"),
+                expr: col("t2", &batch.schema()).unwrap(),
                 options: SortOptions {
                     descending: false,
                     nulls_first: false,
@@ -539,14 +539,14 @@ mod test {
 
         let sort_keys = vec![
             PhysicalSortExpr {
-                expr: col("t1"),
+                expr: col("t1", &batch2.schema()).unwrap(),
                 options: SortOptions {
                     descending: false,
                     nulls_first: false,
                 },
             },
             PhysicalSortExpr {
-                expr: col("t2"),
+                expr: col("t2", &batch2.schema()).unwrap(),
                 options: SortOptions {
                     descending: false,
                     nulls_first: false,
@@ -606,7 +606,7 @@ mod test {
         .unwrap();
 
         let sort_keys = vec![PhysicalSortExpr {
-            expr: col("t1"),
+            expr: col("t1", &batch2.schema()).unwrap(),
             options: SortOptions {
                 descending: false,
                 nulls_first: false,
@@ -657,7 +657,7 @@ mod test {
         .unwrap();
 
         let sort_keys = vec![PhysicalSortExpr {
-            expr: col("t1"),
+            expr: col("t1", &batch.schema()).unwrap(),
             options: SortOptions {
                 descending: false,
                 nulls_first: false,
@@ -709,14 +709,14 @@ mod test {
 
         let sort_keys = vec![
             PhysicalSortExpr {
-                expr: col("t1"),
+                expr: col("t1", &batch.schema()).unwrap(),
                 options: SortOptions {
                     descending: false,
                     nulls_first: false,
                 },
             },
             PhysicalSortExpr {
-                expr: col("t2"),
+                expr: col("t2", &batch.schema()).unwrap(),
                 options: SortOptions {
                     descending: false,
                     nulls_first: false,
@@ -770,7 +770,7 @@ mod test {
         });
 
         let sort_keys = vec![PhysicalSortExpr {
-            expr: col("t1"),
+            expr: col("t1", &schema).unwrap(),
             options: SortOptions {
                 descending: false,
                 nulls_first: false,
@@ -819,14 +819,14 @@ mod test {
 
         let sort_keys = vec![
             PhysicalSortExpr {
-                expr: col("t1"),
+                expr: col("t1", &batch1.schema()).unwrap(),
                 options: SortOptions {
                     descending: false,
                     nulls_first: false,
                 },
             },
             PhysicalSortExpr {
-                expr: col("t2"),
+                expr: col("t2", &batch1.schema()).unwrap(),
                 options: SortOptions {
                     descending: false,
                     nulls_first: false,

--- a/query/src/provider/deduplicate/algo.rs
+++ b/query/src/provider/deduplicate/algo.rs
@@ -436,7 +436,7 @@ mod test {
         .unwrap();
 
         let sort_keys = vec![PhysicalSortExpr {
-            expr: col("t1"),
+            expr: col("t1", &current_batch.schema()).unwrap(),
             options: SortOptions {
                 descending: false,
                 nulls_first: false,
@@ -512,14 +512,14 @@ mod test {
 
         let sort_keys = vec![
             PhysicalSortExpr {
-                expr: col("t1"),
+                expr: col("t1", &current_batch.schema()).unwrap(),
                 options: SortOptions {
                     descending: false,
                     nulls_first: false,
                 },
             },
             PhysicalSortExpr {
-                expr: col("t2"),
+                expr: col("t2", &current_batch.schema()).unwrap(),
                 options: SortOptions {
                     descending: false,
                     nulls_first: false,
@@ -590,7 +590,7 @@ mod test {
         .unwrap();
 
         let sort_keys = vec![PhysicalSortExpr {
-            expr: col("t1"),
+            expr: col("t1", &current_batch.schema()).unwrap(),
             options: SortOptions {
                 descending: false,
                 nulls_first: false,
@@ -651,14 +651,14 @@ mod test {
 
         let sort_keys = vec![
             PhysicalSortExpr {
-                expr: col("t1"),
+                expr: col("t1", &current_batch.schema()).unwrap(),
                 options: SortOptions {
                     descending: false,
                     nulls_first: false,
                 },
             },
             PhysicalSortExpr {
-                expr: col("t2"),
+                expr: col("t2", &current_batch.schema()).unwrap(),
                 options: SortOptions {
                     descending: false,
                     nulls_first: false,
@@ -698,14 +698,14 @@ mod test {
 
         let sort_keys = vec![
             PhysicalSortExpr {
-                expr: col("t1"),
+                expr: col("t1", &current_batch.schema()).unwrap(),
                 options: SortOptions {
                     descending: false,
                     nulls_first: false,
                 },
             },
             PhysicalSortExpr {
-                expr: col("t2"),
+                expr: col("t2", &current_batch.schema()).unwrap(),
                 options: SortOptions {
                     descending: false,
                     nulls_first: false,

--- a/query_tests/cases/in/duplicates.expected
+++ b/query_tests/cases/in/duplicates.expected
@@ -1,114 +1,114 @@
 -- Test Setup: OneMeasurementThreeChunksWithDuplicates
 -- SQL: explain verbose select time, state, city, min_temp, max_temp, area from h2o order by time, state, city;
-+-----------------------------------------+-------------------------------------------------------------------------------------------------+
-| plan_type                               | plan                                                                                            |
-+-----------------------------------------+-------------------------------------------------------------------------------------------------+
-| logical_plan                            | Sort: #time ASC NULLS FIRST, #state ASC NULLS FIRST, #city ASC NULLS FIRST                      |
-|                                         |   Projection: #time, #state, #city, #min_temp, #max_temp, #area                                 |
-|                                         |     TableScan: h2o projection=None                                                              |
-| logical_plan after projection_push_down | Sort: #time ASC NULLS FIRST, #state ASC NULLS FIRST, #city ASC NULLS FIRST                      |
-|                                         |   Projection: #time, #state, #city, #min_temp, #max_temp, #area                                 |
-|                                         |     TableScan: h2o projection=Some([0, 1, 2, 3, 4, 5])                                          |
-| logical_plan after simplify_expressions | Sort: #time ASC NULLS FIRST, #state ASC NULLS FIRST, #city ASC NULLS FIRST                      |
-|                                         |   Projection: #time, #state, #city, #min_temp, #max_temp, #area                                 |
-|                                         |     TableScan: h2o projection=Some([0, 1, 2, 3, 4, 5])                                          |
-| logical_plan after projection_push_down | Sort: #time ASC NULLS FIRST, #state ASC NULLS FIRST, #city ASC NULLS FIRST                      |
-|                                         |   Projection: #time, #state, #city, #min_temp, #max_temp, #area                                 |
-|                                         |     TableScan: h2o projection=Some([0, 1, 2, 3, 4, 5])                                          |
-| logical_plan after simplify_expressions | Sort: #time ASC NULLS FIRST, #state ASC NULLS FIRST, #city ASC NULLS FIRST                      |
-|                                         |   Projection: #time, #state, #city, #min_temp, #max_temp, #area                                 |
-|                                         |     TableScan: h2o projection=Some([0, 1, 2, 3, 4, 5])                                          |
-| physical_plan                           | SortExec: [time ASC,state ASC,city ASC]                                                         |
-|                                         |   ProjectionExec: expr=[time, state, city, min_temp, max_temp, area]                            |
-|                                         |     ExecutionPlan(PlaceHolder)                                                                  |
-|                                         |       DeduplicateExec: [city ASC NULLS LAST,state ASC NULLS LAST,time ASC NULLS LAST]           |
-|                                         |         SortPreservingMergeExec: [city ASC NULLS LAST,state ASC NULLS LAST,time ASC NULLS LAST] |
-|                                         |           ExecutionPlan(PlaceHolder)                                                            |
-|                                         |             SortExec: [city ASC NULLS LAST,state ASC NULLS LAST,time ASC NULLS LAST]            |
-|                                         |               IOxReadFilterNode: table_name=h2o, chunks=1 predicate=Predicate                   |
-|                                         |             SortExec: [city ASC NULLS LAST,state ASC NULLS LAST,time ASC NULLS LAST]            |
-|                                         |               IOxReadFilterNode: table_name=h2o, chunks=1 predicate=Predicate                   |
-|                                         |       IOxReadFilterNode: table_name=h2o, chunks=1 predicate=Predicate                           |
-|                                         |       IOxReadFilterNode: table_name=h2o, chunks=1 predicate=Predicate                           |
-+-----------------------------------------+-------------------------------------------------------------------------------------------------+
++-----------------------------------------+-------------------------------------------------------------------------------------------------------------------------------------------+
+| plan_type                               | plan                                                                                                                                      |
++-----------------------------------------+-------------------------------------------------------------------------------------------------------------------------------------------+
+| logical_plan                            | Sort: #h2o.time ASC NULLS FIRST, #h2o.state ASC NULLS FIRST, #h2o.city ASC NULLS FIRST                                                    |
+|                                         |   Projection: #h2o.time, #h2o.state, #h2o.city, #h2o.min_temp, #h2o.max_temp, #h2o.area                                                   |
+|                                         |     TableScan: h2o projection=None                                                                                                        |
+| logical_plan after projection_push_down | Sort: #h2o.time ASC NULLS FIRST, #h2o.state ASC NULLS FIRST, #h2o.city ASC NULLS FIRST                                                    |
+|                                         |   Projection: #h2o.time, #h2o.state, #h2o.city, #h2o.min_temp, #h2o.max_temp, #h2o.area                                                   |
+|                                         |     TableScan: h2o projection=Some([0, 1, 2, 3, 4, 5])                                                                                    |
+| logical_plan after simplify_expressions | Sort: #h2o.time ASC NULLS FIRST, #h2o.state ASC NULLS FIRST, #h2o.city ASC NULLS FIRST                                                    |
+|                                         |   Projection: #h2o.time, #h2o.state, #h2o.city, #h2o.min_temp, #h2o.max_temp, #h2o.area                                                   |
+|                                         |     TableScan: h2o projection=Some([0, 1, 2, 3, 4, 5])                                                                                    |
+| logical_plan after projection_push_down | Sort: #h2o.time ASC NULLS FIRST, #h2o.state ASC NULLS FIRST, #h2o.city ASC NULLS FIRST                                                    |
+|                                         |   Projection: #h2o.time, #h2o.state, #h2o.city, #h2o.min_temp, #h2o.max_temp, #h2o.area                                                   |
+|                                         |     TableScan: h2o projection=Some([0, 1, 2, 3, 4, 5])                                                                                    |
+| logical_plan after simplify_expressions | Sort: #h2o.time ASC NULLS FIRST, #h2o.state ASC NULLS FIRST, #h2o.city ASC NULLS FIRST                                                    |
+|                                         |   Projection: #h2o.time, #h2o.state, #h2o.city, #h2o.min_temp, #h2o.max_temp, #h2o.area                                                   |
+|                                         |     TableScan: h2o projection=Some([0, 1, 2, 3, 4, 5])                                                                                    |
+| physical_plan                           | SortExec: [time@0 ASC,state@1 ASC,city@2 ASC]                                                                                             |
+|                                         |   ProjectionExec: expr=[time@5 as time, state@4 as state, city@1 as city, min_temp@3 as min_temp, max_temp@2 as max_temp, area@0 as area] |
+|                                         |     ExecutionPlan(PlaceHolder)                                                                                                            |
+|                                         |       DeduplicateExec: [city@1 ASC NULLS LAST,state@4 ASC NULLS LAST,time@5 ASC NULLS LAST]                                               |
+|                                         |         SortPreservingMergeExec: [city@1 ASC NULLS LAST,state@4 ASC NULLS LAST,time@5 ASC NULLS LAST]                                     |
+|                                         |           ExecutionPlan(PlaceHolder)                                                                                                      |
+|                                         |             SortExec: [city@1 ASC NULLS LAST,state@4 ASC NULLS LAST,time@5 ASC NULLS LAST]                                                |
+|                                         |               IOxReadFilterNode: table_name=h2o, chunks=1 predicate=Predicate                                                             |
+|                                         |             SortExec: [city@1 ASC NULLS LAST,state@4 ASC NULLS LAST,time@5 ASC NULLS LAST]                                                |
+|                                         |               IOxReadFilterNode: table_name=h2o, chunks=1 predicate=Predicate                                                             |
+|                                         |       IOxReadFilterNode: table_name=h2o, chunks=1 predicate=Predicate                                                                     |
+|                                         |       IOxReadFilterNode: table_name=h2o, chunks=1 predicate=Predicate                                                                     |
++-----------------------------------------+-------------------------------------------------------------------------------------------------------------------------------------------+
 -- SQL: explain verbose select time, state, city, min_temp, max_temp, area from h2o;
-+-----------------------------------------+-----------------------------------------------------------------------------------------------+
-| plan_type                               | plan                                                                                          |
-+-----------------------------------------+-----------------------------------------------------------------------------------------------+
-| logical_plan                            | Projection: #time, #state, #city, #min_temp, #max_temp, #area                                 |
-|                                         |   TableScan: h2o projection=None                                                              |
-| logical_plan after projection_push_down | Projection: #time, #state, #city, #min_temp, #max_temp, #area                                 |
-|                                         |   TableScan: h2o projection=Some([0, 1, 2, 3, 4, 5])                                          |
-| logical_plan after simplify_expressions | Projection: #time, #state, #city, #min_temp, #max_temp, #area                                 |
-|                                         |   TableScan: h2o projection=Some([0, 1, 2, 3, 4, 5])                                          |
-| logical_plan after projection_push_down | Projection: #time, #state, #city, #min_temp, #max_temp, #area                                 |
-|                                         |   TableScan: h2o projection=Some([0, 1, 2, 3, 4, 5])                                          |
-| logical_plan after simplify_expressions | Projection: #time, #state, #city, #min_temp, #max_temp, #area                                 |
-|                                         |   TableScan: h2o projection=Some([0, 1, 2, 3, 4, 5])                                          |
-| physical_plan                           | ProjectionExec: expr=[time, state, city, min_temp, max_temp, area]                            |
-|                                         |   ExecutionPlan(PlaceHolder)                                                                  |
-|                                         |     DeduplicateExec: [city ASC NULLS LAST,state ASC NULLS LAST,time ASC NULLS LAST]           |
-|                                         |       SortPreservingMergeExec: [city ASC NULLS LAST,state ASC NULLS LAST,time ASC NULLS LAST] |
-|                                         |         ExecutionPlan(PlaceHolder)                                                            |
-|                                         |           SortExec: [city ASC NULLS LAST,state ASC NULLS LAST,time ASC NULLS LAST]            |
-|                                         |             IOxReadFilterNode: table_name=h2o, chunks=1 predicate=Predicate                   |
-|                                         |           SortExec: [city ASC NULLS LAST,state ASC NULLS LAST,time ASC NULLS LAST]            |
-|                                         |             IOxReadFilterNode: table_name=h2o, chunks=1 predicate=Predicate                   |
-|                                         |     IOxReadFilterNode: table_name=h2o, chunks=1 predicate=Predicate                           |
-|                                         |     IOxReadFilterNode: table_name=h2o, chunks=1 predicate=Predicate                           |
-+-----------------------------------------+-----------------------------------------------------------------------------------------------+
++-----------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------+
+| plan_type                               | plan                                                                                                                                    |
++-----------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------+
+| logical_plan                            | Projection: #h2o.time, #h2o.state, #h2o.city, #h2o.min_temp, #h2o.max_temp, #h2o.area                                                   |
+|                                         |   TableScan: h2o projection=None                                                                                                        |
+| logical_plan after projection_push_down | Projection: #h2o.time, #h2o.state, #h2o.city, #h2o.min_temp, #h2o.max_temp, #h2o.area                                                   |
+|                                         |   TableScan: h2o projection=Some([0, 1, 2, 3, 4, 5])                                                                                    |
+| logical_plan after simplify_expressions | Projection: #h2o.time, #h2o.state, #h2o.city, #h2o.min_temp, #h2o.max_temp, #h2o.area                                                   |
+|                                         |   TableScan: h2o projection=Some([0, 1, 2, 3, 4, 5])                                                                                    |
+| logical_plan after projection_push_down | Projection: #h2o.time, #h2o.state, #h2o.city, #h2o.min_temp, #h2o.max_temp, #h2o.area                                                   |
+|                                         |   TableScan: h2o projection=Some([0, 1, 2, 3, 4, 5])                                                                                    |
+| logical_plan after simplify_expressions | Projection: #h2o.time, #h2o.state, #h2o.city, #h2o.min_temp, #h2o.max_temp, #h2o.area                                                   |
+|                                         |   TableScan: h2o projection=Some([0, 1, 2, 3, 4, 5])                                                                                    |
+| physical_plan                           | ProjectionExec: expr=[time@5 as time, state@4 as state, city@1 as city, min_temp@3 as min_temp, max_temp@2 as max_temp, area@0 as area] |
+|                                         |   ExecutionPlan(PlaceHolder)                                                                                                            |
+|                                         |     DeduplicateExec: [city@1 ASC NULLS LAST,state@4 ASC NULLS LAST,time@5 ASC NULLS LAST]                                               |
+|                                         |       SortPreservingMergeExec: [city@1 ASC NULLS LAST,state@4 ASC NULLS LAST,time@5 ASC NULLS LAST]                                     |
+|                                         |         ExecutionPlan(PlaceHolder)                                                                                                      |
+|                                         |           SortExec: [city@1 ASC NULLS LAST,state@4 ASC NULLS LAST,time@5 ASC NULLS LAST]                                                |
+|                                         |             IOxReadFilterNode: table_name=h2o, chunks=1 predicate=Predicate                                                             |
+|                                         |           SortExec: [city@1 ASC NULLS LAST,state@4 ASC NULLS LAST,time@5 ASC NULLS LAST]                                                |
+|                                         |             IOxReadFilterNode: table_name=h2o, chunks=1 predicate=Predicate                                                             |
+|                                         |     IOxReadFilterNode: table_name=h2o, chunks=1 predicate=Predicate                                                                     |
+|                                         |     IOxReadFilterNode: table_name=h2o, chunks=1 predicate=Predicate                                                                     |
++-----------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------+
 -- SQL: EXPLAIN VERBOSE select state as name from h2o UNION ALL select city as name from h2o;
-+-----------------------------------------+---------------------------------------------------------------------------------------------------+
-| plan_type                               | plan                                                                                              |
-+-----------------------------------------+---------------------------------------------------------------------------------------------------+
-| logical_plan                            | Union                                                                                             |
-|                                         |   Projection: #state AS name                                                                      |
-|                                         |     TableScan: h2o projection=None                                                                |
-|                                         |   Projection: #city AS name                                                                       |
-|                                         |     TableScan: h2o projection=None                                                                |
-| logical_plan after projection_push_down | Union                                                                                             |
-|                                         |   Projection: #state AS name                                                                      |
-|                                         |     TableScan: h2o projection=Some([4])                                                           |
-|                                         |   Projection: #city AS name                                                                       |
-|                                         |     TableScan: h2o projection=Some([1])                                                           |
-| logical_plan after simplify_expressions | Union                                                                                             |
-|                                         |   Projection: #state AS name                                                                      |
-|                                         |     TableScan: h2o projection=Some([4])                                                           |
-|                                         |   Projection: #city AS name                                                                       |
-|                                         |     TableScan: h2o projection=Some([1])                                                           |
-| logical_plan after projection_push_down | Union                                                                                             |
-|                                         |   Projection: #state AS name                                                                      |
-|                                         |     TableScan: h2o projection=Some([4])                                                           |
-|                                         |   Projection: #city AS name                                                                       |
-|                                         |     TableScan: h2o projection=Some([1])                                                           |
-| logical_plan after simplify_expressions | Union                                                                                             |
-|                                         |   Projection: #state AS name                                                                      |
-|                                         |     TableScan: h2o projection=Some([4])                                                           |
-|                                         |   Projection: #city AS name                                                                       |
-|                                         |     TableScan: h2o projection=Some([1])                                                           |
-| physical_plan                           | ExecutionPlan(PlaceHolder)                                                                        |
-|                                         |   ProjectionExec: expr=[state as name]                                                            |
-|                                         |     ExecutionPlan(PlaceHolder)                                                                    |
-|                                         |       ProjectionExec: expr=[state]                                                                |
-|                                         |         DeduplicateExec: [city ASC NULLS LAST,state ASC NULLS LAST,time ASC NULLS LAST]           |
-|                                         |           SortPreservingMergeExec: [city ASC NULLS LAST,state ASC NULLS LAST,time ASC NULLS LAST] |
-|                                         |             ExecutionPlan(PlaceHolder)                                                            |
-|                                         |               SortExec: [city ASC NULLS LAST,state ASC NULLS LAST,time ASC NULLS LAST]            |
-|                                         |                 IOxReadFilterNode: table_name=h2o, chunks=1 predicate=Predicate                   |
-|                                         |               SortExec: [city ASC NULLS LAST,state ASC NULLS LAST,time ASC NULLS LAST]            |
-|                                         |                 IOxReadFilterNode: table_name=h2o, chunks=1 predicate=Predicate                   |
-|                                         |       IOxReadFilterNode: table_name=h2o, chunks=1 predicate=Predicate                             |
-|                                         |       IOxReadFilterNode: table_name=h2o, chunks=1 predicate=Predicate                             |
-|                                         |   ProjectionExec: expr=[city as name]                                                             |
-|                                         |     ExecutionPlan(PlaceHolder)                                                                    |
-|                                         |       ProjectionExec: expr=[city]                                                                 |
-|                                         |         DeduplicateExec: [city ASC NULLS LAST,state ASC NULLS LAST,time ASC NULLS LAST]           |
-|                                         |           SortPreservingMergeExec: [city ASC NULLS LAST,state ASC NULLS LAST,time ASC NULLS LAST] |
-|                                         |             ExecutionPlan(PlaceHolder)                                                            |
-|                                         |               SortExec: [city ASC NULLS LAST,state ASC NULLS LAST,time ASC NULLS LAST]            |
-|                                         |                 IOxReadFilterNode: table_name=h2o, chunks=1 predicate=Predicate                   |
-|                                         |               SortExec: [city ASC NULLS LAST,state ASC NULLS LAST,time ASC NULLS LAST]            |
-|                                         |                 IOxReadFilterNode: table_name=h2o, chunks=1 predicate=Predicate                   |
-|                                         |       IOxReadFilterNode: table_name=h2o, chunks=1 predicate=Predicate                             |
-|                                         |       IOxReadFilterNode: table_name=h2o, chunks=1 predicate=Predicate                             |
-+-----------------------------------------+---------------------------------------------------------------------------------------------------+
++-----------------------------------------+---------------------------------------------------------------------------------------------------------+
+| plan_type                               | plan                                                                                                    |
++-----------------------------------------+---------------------------------------------------------------------------------------------------------+
+| logical_plan                            | Union                                                                                                   |
+|                                         |   Projection: #h2o.state AS name                                                                        |
+|                                         |     TableScan: h2o projection=None                                                                      |
+|                                         |   Projection: #h2o.city AS name                                                                         |
+|                                         |     TableScan: h2o projection=None                                                                      |
+| logical_plan after projection_push_down | Union                                                                                                   |
+|                                         |   Projection: #h2o.state AS name                                                                        |
+|                                         |     TableScan: h2o projection=Some([4])                                                                 |
+|                                         |   Projection: #h2o.city AS name                                                                         |
+|                                         |     TableScan: h2o projection=Some([1])                                                                 |
+| logical_plan after simplify_expressions | Union                                                                                                   |
+|                                         |   Projection: #h2o.state AS name                                                                        |
+|                                         |     TableScan: h2o projection=Some([4])                                                                 |
+|                                         |   Projection: #h2o.city AS name                                                                         |
+|                                         |     TableScan: h2o projection=Some([1])                                                                 |
+| logical_plan after projection_push_down | Union                                                                                                   |
+|                                         |   Projection: #h2o.state AS name                                                                        |
+|                                         |     TableScan: h2o projection=Some([4])                                                                 |
+|                                         |   Projection: #h2o.city AS name                                                                         |
+|                                         |     TableScan: h2o projection=Some([1])                                                                 |
+| logical_plan after simplify_expressions | Union                                                                                                   |
+|                                         |   Projection: #h2o.state AS name                                                                        |
+|                                         |     TableScan: h2o projection=Some([4])                                                                 |
+|                                         |   Projection: #h2o.city AS name                                                                         |
+|                                         |     TableScan: h2o projection=Some([1])                                                                 |
+| physical_plan                           | ExecutionPlan(PlaceHolder)                                                                              |
+|                                         |   ProjectionExec: expr=[state@0 as name]                                                                |
+|                                         |     ExecutionPlan(PlaceHolder)                                                                          |
+|                                         |       ProjectionExec: expr=[state@1 as state]                                                           |
+|                                         |         DeduplicateExec: [city@0 ASC NULLS LAST,state@1 ASC NULLS LAST,time@2 ASC NULLS LAST]           |
+|                                         |           SortPreservingMergeExec: [city@0 ASC NULLS LAST,state@1 ASC NULLS LAST,time@2 ASC NULLS LAST] |
+|                                         |             ExecutionPlan(PlaceHolder)                                                                  |
+|                                         |               SortExec: [city@0 ASC NULLS LAST,state@1 ASC NULLS LAST,time@2 ASC NULLS LAST]            |
+|                                         |                 IOxReadFilterNode: table_name=h2o, chunks=1 predicate=Predicate                         |
+|                                         |               SortExec: [city@0 ASC NULLS LAST,state@1 ASC NULLS LAST,time@2 ASC NULLS LAST]            |
+|                                         |                 IOxReadFilterNode: table_name=h2o, chunks=1 predicate=Predicate                         |
+|                                         |       IOxReadFilterNode: table_name=h2o, chunks=1 predicate=Predicate                                   |
+|                                         |       IOxReadFilterNode: table_name=h2o, chunks=1 predicate=Predicate                                   |
+|                                         |   ProjectionExec: expr=[city@0 as name]                                                                 |
+|                                         |     ExecutionPlan(PlaceHolder)                                                                          |
+|                                         |       ProjectionExec: expr=[city@0 as city]                                                             |
+|                                         |         DeduplicateExec: [city@0 ASC NULLS LAST,state@1 ASC NULLS LAST,time@2 ASC NULLS LAST]           |
+|                                         |           SortPreservingMergeExec: [city@0 ASC NULLS LAST,state@1 ASC NULLS LAST,time@2 ASC NULLS LAST] |
+|                                         |             ExecutionPlan(PlaceHolder)                                                                  |
+|                                         |               SortExec: [city@0 ASC NULLS LAST,state@1 ASC NULLS LAST,time@2 ASC NULLS LAST]            |
+|                                         |                 IOxReadFilterNode: table_name=h2o, chunks=1 predicate=Predicate                         |
+|                                         |               SortExec: [city@0 ASC NULLS LAST,state@1 ASC NULLS LAST,time@2 ASC NULLS LAST]            |
+|                                         |                 IOxReadFilterNode: table_name=h2o, chunks=1 predicate=Predicate                         |
+|                                         |       IOxReadFilterNode: table_name=h2o, chunks=1 predicate=Predicate                                   |
+|                                         |       IOxReadFilterNode: table_name=h2o, chunks=1 predicate=Predicate                                   |
++-----------------------------------------+---------------------------------------------------------------------------------------------------------+

--- a/query_tests/cases/in/pushdown.expected
+++ b/query_tests/cases/in/pushdown.expected
@@ -1,294 +1,294 @@
 -- Test Setup: TwoMeasurementsPredicatePushDown
 -- SQL: EXPLAIN VERBOSE SELECT * from restaurant;
-+-----------------------------------------+--------------------------------------------------------------------------+
-| plan_type                               | plan                                                                     |
-+-----------------------------------------+--------------------------------------------------------------------------+
-| logical_plan                            | Projection: #count, #system, #time, #town                                |
-|                                         |   TableScan: restaurant projection=None                                  |
-| logical_plan after projection_push_down | Projection: #count, #system, #time, #town                                |
-|                                         |   TableScan: restaurant projection=Some([0, 1, 2, 3])                    |
-| logical_plan after simplify_expressions | Projection: #count, #system, #time, #town                                |
-|                                         |   TableScan: restaurant projection=Some([0, 1, 2, 3])                    |
-| logical_plan after projection_push_down | Projection: #count, #system, #time, #town                                |
-|                                         |   TableScan: restaurant projection=Some([0, 1, 2, 3])                    |
-| logical_plan after simplify_expressions | Projection: #count, #system, #time, #town                                |
-|                                         |   TableScan: restaurant projection=Some([0, 1, 2, 3])                    |
-| physical_plan                           | ProjectionExec: expr=[count, system, time, town]                         |
-|                                         |   IOxReadFilterNode: table_name=restaurant, chunks=1 predicate=Predicate |
-+-----------------------------------------+--------------------------------------------------------------------------+
++-----------------------------------------+---------------------------------------------------------------------------------------------+
+| plan_type                               | plan                                                                                        |
++-----------------------------------------+---------------------------------------------------------------------------------------------+
+| logical_plan                            | Projection: #restaurant.count, #restaurant.system, #restaurant.time, #restaurant.town       |
+|                                         |   TableScan: restaurant projection=None                                                     |
+| logical_plan after projection_push_down | Projection: #restaurant.count, #restaurant.system, #restaurant.time, #restaurant.town       |
+|                                         |   TableScan: restaurant projection=Some([0, 1, 2, 3])                                       |
+| logical_plan after simplify_expressions | Projection: #restaurant.count, #restaurant.system, #restaurant.time, #restaurant.town       |
+|                                         |   TableScan: restaurant projection=Some([0, 1, 2, 3])                                       |
+| logical_plan after projection_push_down | Projection: #restaurant.count, #restaurant.system, #restaurant.time, #restaurant.town       |
+|                                         |   TableScan: restaurant projection=Some([0, 1, 2, 3])                                       |
+| logical_plan after simplify_expressions | Projection: #restaurant.count, #restaurant.system, #restaurant.time, #restaurant.town       |
+|                                         |   TableScan: restaurant projection=Some([0, 1, 2, 3])                                       |
+| physical_plan                           | ProjectionExec: expr=[count@0 as count, system@1 as system, time@2 as time, town@3 as town] |
+|                                         |   IOxReadFilterNode: table_name=restaurant, chunks=1 predicate=Predicate                    |
++-----------------------------------------+---------------------------------------------------------------------------------------------+
 -- SQL: EXPLAIN VERBOSE SELECT * from restaurant where count > 200;
-+-----------------------------------------+----------------------------------------------------------------------------+
-| plan_type                               | plan                                                                       |
-+-----------------------------------------+----------------------------------------------------------------------------+
-| logical_plan                            | Projection: #count, #system, #time, #town                                  |
-|                                         |   Filter: #count Gt Int64(200)                                             |
-|                                         |     TableScan: restaurant projection=None                                  |
-| logical_plan after projection_push_down | Projection: #count, #system, #time, #town                                  |
-|                                         |   Filter: #count Gt Int64(200)                                             |
-|                                         |     TableScan: restaurant projection=Some([0, 1, 2, 3])                    |
-| logical_plan after simplify_expressions | Projection: #count, #system, #time, #town                                  |
-|                                         |   Filter: #count Gt Int64(200)                                             |
-|                                         |     TableScan: restaurant projection=Some([0, 1, 2, 3])                    |
-| logical_plan after projection_push_down | Projection: #count, #system, #time, #town                                  |
-|                                         |   Filter: #count Gt Int64(200)                                             |
-|                                         |     TableScan: restaurant projection=Some([0, 1, 2, 3])                    |
-| logical_plan after simplify_expressions | Projection: #count, #system, #time, #town                                  |
-|                                         |   Filter: #count Gt Int64(200)                                             |
-|                                         |     TableScan: restaurant projection=Some([0, 1, 2, 3])                    |
-| physical_plan                           | ProjectionExec: expr=[count, system, time, town]                           |
-|                                         |   FilterExec: CAST(count AS Int64) > 200                                   |
-|                                         |     IOxReadFilterNode: table_name=restaurant, chunks=1 predicate=Predicate |
-+-----------------------------------------+----------------------------------------------------------------------------+
++-----------------------------------------+---------------------------------------------------------------------------------------------+
+| plan_type                               | plan                                                                                        |
++-----------------------------------------+---------------------------------------------------------------------------------------------+
+| logical_plan                            | Projection: #restaurant.count, #restaurant.system, #restaurant.time, #restaurant.town       |
+|                                         |   Filter: #restaurant.count Gt Int64(200)                                                   |
+|                                         |     TableScan: restaurant projection=None                                                   |
+| logical_plan after projection_push_down | Projection: #restaurant.count, #restaurant.system, #restaurant.time, #restaurant.town       |
+|                                         |   Filter: #restaurant.count Gt Int64(200)                                                   |
+|                                         |     TableScan: restaurant projection=Some([0, 1, 2, 3])                                     |
+| logical_plan after simplify_expressions | Projection: #restaurant.count, #restaurant.system, #restaurant.time, #restaurant.town       |
+|                                         |   Filter: #restaurant.count Gt Int64(200)                                                   |
+|                                         |     TableScan: restaurant projection=Some([0, 1, 2, 3])                                     |
+| logical_plan after projection_push_down | Projection: #restaurant.count, #restaurant.system, #restaurant.time, #restaurant.town       |
+|                                         |   Filter: #restaurant.count Gt Int64(200)                                                   |
+|                                         |     TableScan: restaurant projection=Some([0, 1, 2, 3])                                     |
+| logical_plan after simplify_expressions | Projection: #restaurant.count, #restaurant.system, #restaurant.time, #restaurant.town       |
+|                                         |   Filter: #restaurant.count Gt Int64(200)                                                   |
+|                                         |     TableScan: restaurant projection=Some([0, 1, 2, 3])                                     |
+| physical_plan                           | ProjectionExec: expr=[count@0 as count, system@1 as system, time@2 as time, town@3 as town] |
+|                                         |   FilterExec: CAST(count@0 AS Int64) > 200                                                  |
+|                                         |     IOxReadFilterNode: table_name=restaurant, chunks=1 predicate=Predicate                  |
++-----------------------------------------+---------------------------------------------------------------------------------------------+
 -- SQL: EXPLAIN VERBOSE SELECT * from restaurant where count > 200.0;
-+-----------------------------------------+----------------------------------------------------------------------------+
-| plan_type                               | plan                                                                       |
-+-----------------------------------------+----------------------------------------------------------------------------+
-| logical_plan                            | Projection: #count, #system, #time, #town                                  |
-|                                         |   Filter: #count Gt Float64(200)                                           |
-|                                         |     TableScan: restaurant projection=None                                  |
-| logical_plan after projection_push_down | Projection: #count, #system, #time, #town                                  |
-|                                         |   Filter: #count Gt Float64(200)                                           |
-|                                         |     TableScan: restaurant projection=Some([0, 1, 2, 3])                    |
-| logical_plan after simplify_expressions | Projection: #count, #system, #time, #town                                  |
-|                                         |   Filter: #count Gt Float64(200)                                           |
-|                                         |     TableScan: restaurant projection=Some([0, 1, 2, 3])                    |
-| logical_plan after projection_push_down | Projection: #count, #system, #time, #town                                  |
-|                                         |   Filter: #count Gt Float64(200)                                           |
-|                                         |     TableScan: restaurant projection=Some([0, 1, 2, 3])                    |
-| logical_plan after simplify_expressions | Projection: #count, #system, #time, #town                                  |
-|                                         |   Filter: #count Gt Float64(200)                                           |
-|                                         |     TableScan: restaurant projection=Some([0, 1, 2, 3])                    |
-| physical_plan                           | ProjectionExec: expr=[count, system, time, town]                           |
-|                                         |   FilterExec: CAST(count AS Float64) > 200                                 |
-|                                         |     IOxReadFilterNode: table_name=restaurant, chunks=1 predicate=Predicate |
-+-----------------------------------------+----------------------------------------------------------------------------+
++-----------------------------------------+---------------------------------------------------------------------------------------------+
+| plan_type                               | plan                                                                                        |
++-----------------------------------------+---------------------------------------------------------------------------------------------+
+| logical_plan                            | Projection: #restaurant.count, #restaurant.system, #restaurant.time, #restaurant.town       |
+|                                         |   Filter: #restaurant.count Gt Float64(200)                                                 |
+|                                         |     TableScan: restaurant projection=None                                                   |
+| logical_plan after projection_push_down | Projection: #restaurant.count, #restaurant.system, #restaurant.time, #restaurant.town       |
+|                                         |   Filter: #restaurant.count Gt Float64(200)                                                 |
+|                                         |     TableScan: restaurant projection=Some([0, 1, 2, 3])                                     |
+| logical_plan after simplify_expressions | Projection: #restaurant.count, #restaurant.system, #restaurant.time, #restaurant.town       |
+|                                         |   Filter: #restaurant.count Gt Float64(200)                                                 |
+|                                         |     TableScan: restaurant projection=Some([0, 1, 2, 3])                                     |
+| logical_plan after projection_push_down | Projection: #restaurant.count, #restaurant.system, #restaurant.time, #restaurant.town       |
+|                                         |   Filter: #restaurant.count Gt Float64(200)                                                 |
+|                                         |     TableScan: restaurant projection=Some([0, 1, 2, 3])                                     |
+| logical_plan after simplify_expressions | Projection: #restaurant.count, #restaurant.system, #restaurant.time, #restaurant.town       |
+|                                         |   Filter: #restaurant.count Gt Float64(200)                                                 |
+|                                         |     TableScan: restaurant projection=Some([0, 1, 2, 3])                                     |
+| physical_plan                           | ProjectionExec: expr=[count@0 as count, system@1 as system, time@2 as time, town@3 as town] |
+|                                         |   FilterExec: CAST(count@0 AS Float64) > 200                                                |
+|                                         |     IOxReadFilterNode: table_name=restaurant, chunks=1 predicate=Predicate                  |
++-----------------------------------------+---------------------------------------------------------------------------------------------+
 -- SQL: EXPLAIN VERBOSE SELECT * from restaurant where system > 4.0;
-+-----------------------------------------+----------------------------------------------------------------------------+
-| plan_type                               | plan                                                                       |
-+-----------------------------------------+----------------------------------------------------------------------------+
-| logical_plan                            | Projection: #count, #system, #time, #town                                  |
-|                                         |   Filter: #system Gt Float64(4)                                            |
-|                                         |     TableScan: restaurant projection=None                                  |
-| logical_plan after projection_push_down | Projection: #count, #system, #time, #town                                  |
-|                                         |   Filter: #system Gt Float64(4)                                            |
-|                                         |     TableScan: restaurant projection=Some([0, 1, 2, 3])                    |
-| logical_plan after simplify_expressions | Projection: #count, #system, #time, #town                                  |
-|                                         |   Filter: #system Gt Float64(4)                                            |
-|                                         |     TableScan: restaurant projection=Some([0, 1, 2, 3])                    |
-| logical_plan after projection_push_down | Projection: #count, #system, #time, #town                                  |
-|                                         |   Filter: #system Gt Float64(4)                                            |
-|                                         |     TableScan: restaurant projection=Some([0, 1, 2, 3])                    |
-| logical_plan after simplify_expressions | Projection: #count, #system, #time, #town                                  |
-|                                         |   Filter: #system Gt Float64(4)                                            |
-|                                         |     TableScan: restaurant projection=Some([0, 1, 2, 3])                    |
-| physical_plan                           | ProjectionExec: expr=[count, system, time, town]                           |
-|                                         |   FilterExec: system > 4                                                   |
-|                                         |     IOxReadFilterNode: table_name=restaurant, chunks=1 predicate=Predicate |
-+-----------------------------------------+----------------------------------------------------------------------------+
++-----------------------------------------+---------------------------------------------------------------------------------------------+
+| plan_type                               | plan                                                                                        |
++-----------------------------------------+---------------------------------------------------------------------------------------------+
+| logical_plan                            | Projection: #restaurant.count, #restaurant.system, #restaurant.time, #restaurant.town       |
+|                                         |   Filter: #restaurant.system Gt Float64(4)                                                  |
+|                                         |     TableScan: restaurant projection=None                                                   |
+| logical_plan after projection_push_down | Projection: #restaurant.count, #restaurant.system, #restaurant.time, #restaurant.town       |
+|                                         |   Filter: #restaurant.system Gt Float64(4)                                                  |
+|                                         |     TableScan: restaurant projection=Some([0, 1, 2, 3])                                     |
+| logical_plan after simplify_expressions | Projection: #restaurant.count, #restaurant.system, #restaurant.time, #restaurant.town       |
+|                                         |   Filter: #restaurant.system Gt Float64(4)                                                  |
+|                                         |     TableScan: restaurant projection=Some([0, 1, 2, 3])                                     |
+| logical_plan after projection_push_down | Projection: #restaurant.count, #restaurant.system, #restaurant.time, #restaurant.town       |
+|                                         |   Filter: #restaurant.system Gt Float64(4)                                                  |
+|                                         |     TableScan: restaurant projection=Some([0, 1, 2, 3])                                     |
+| logical_plan after simplify_expressions | Projection: #restaurant.count, #restaurant.system, #restaurant.time, #restaurant.town       |
+|                                         |   Filter: #restaurant.system Gt Float64(4)                                                  |
+|                                         |     TableScan: restaurant projection=Some([0, 1, 2, 3])                                     |
+| physical_plan                           | ProjectionExec: expr=[count@0 as count, system@1 as system, time@2 as time, town@3 as town] |
+|                                         |   FilterExec: system@1 > 4                                                                  |
+|                                         |     IOxReadFilterNode: table_name=restaurant, chunks=1 predicate=Predicate                  |
++-----------------------------------------+---------------------------------------------------------------------------------------------+
 -- SQL: EXPLAIN VERBOSE SELECT * from restaurant where count > 200 and town != 'tewsbury';
-+-----------------------------------------+-----------------------------------------------------------------------------+
-| plan_type                               | plan                                                                        |
-+-----------------------------------------+-----------------------------------------------------------------------------+
-| logical_plan                            | Projection: #count, #system, #time, #town                                   |
-|                                         |   Filter: #count Gt Int64(200) And #town NotEq Utf8("tewsbury")             |
-|                                         |     TableScan: restaurant projection=None                                   |
-| logical_plan after projection_push_down | Projection: #count, #system, #time, #town                                   |
-|                                         |   Filter: #count Gt Int64(200) And #town NotEq Utf8("tewsbury")             |
-|                                         |     TableScan: restaurant projection=Some([0, 1, 2, 3])                     |
-| logical_plan after simplify_expressions | Projection: #count, #system, #time, #town                                   |
-|                                         |   Filter: #count Gt Int64(200) And #town NotEq Utf8("tewsbury")             |
-|                                         |     TableScan: restaurant projection=Some([0, 1, 2, 3])                     |
-| logical_plan after projection_push_down | Projection: #count, #system, #time, #town                                   |
-|                                         |   Filter: #count Gt Int64(200) And #town NotEq Utf8("tewsbury")             |
-|                                         |     TableScan: restaurant projection=Some([0, 1, 2, 3])                     |
-| logical_plan after simplify_expressions | Projection: #count, #system, #time, #town                                   |
-|                                         |   Filter: #count Gt Int64(200) And #town NotEq Utf8("tewsbury")             |
-|                                         |     TableScan: restaurant projection=Some([0, 1, 2, 3])                     |
-| physical_plan                           | ProjectionExec: expr=[count, system, time, town]                            |
-|                                         |   FilterExec: CAST(count AS Int64) > 200 AND CAST(town AS Utf8) != tewsbury |
-|                                         |     IOxReadFilterNode: table_name=restaurant, chunks=1 predicate=Predicate  |
-+-----------------------------------------+-----------------------------------------------------------------------------+
++-----------------------------------------+---------------------------------------------------------------------------------------------+
+| plan_type                               | plan                                                                                        |
++-----------------------------------------+---------------------------------------------------------------------------------------------+
+| logical_plan                            | Projection: #restaurant.count, #restaurant.system, #restaurant.time, #restaurant.town       |
+|                                         |   Filter: #restaurant.count Gt Int64(200) And #restaurant.town NotEq Utf8("tewsbury")       |
+|                                         |     TableScan: restaurant projection=None                                                   |
+| logical_plan after projection_push_down | Projection: #restaurant.count, #restaurant.system, #restaurant.time, #restaurant.town       |
+|                                         |   Filter: #restaurant.count Gt Int64(200) And #restaurant.town NotEq Utf8("tewsbury")       |
+|                                         |     TableScan: restaurant projection=Some([0, 1, 2, 3])                                     |
+| logical_plan after simplify_expressions | Projection: #restaurant.count, #restaurant.system, #restaurant.time, #restaurant.town       |
+|                                         |   Filter: #restaurant.count Gt Int64(200) And #restaurant.town NotEq Utf8("tewsbury")       |
+|                                         |     TableScan: restaurant projection=Some([0, 1, 2, 3])                                     |
+| logical_plan after projection_push_down | Projection: #restaurant.count, #restaurant.system, #restaurant.time, #restaurant.town       |
+|                                         |   Filter: #restaurant.count Gt Int64(200) And #restaurant.town NotEq Utf8("tewsbury")       |
+|                                         |     TableScan: restaurant projection=Some([0, 1, 2, 3])                                     |
+| logical_plan after simplify_expressions | Projection: #restaurant.count, #restaurant.system, #restaurant.time, #restaurant.town       |
+|                                         |   Filter: #restaurant.count Gt Int64(200) And #restaurant.town NotEq Utf8("tewsbury")       |
+|                                         |     TableScan: restaurant projection=Some([0, 1, 2, 3])                                     |
+| physical_plan                           | ProjectionExec: expr=[count@0 as count, system@1 as system, time@2 as time, town@3 as town] |
+|                                         |   FilterExec: CAST(count@0 AS Int64) > 200 AND CAST(town@3 AS Utf8) != tewsbury             |
+|                                         |     IOxReadFilterNode: table_name=restaurant, chunks=1 predicate=Predicate                  |
++-----------------------------------------+---------------------------------------------------------------------------------------------+
 -- SQL: EXPLAIN VERBOSE SELECT * from restaurant where count > 200 and town != 'tewsbury' and (system =5 or town = 'lawrence');
-+-----------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------------+
-| plan_type                               | plan                                                                                                                                         |
-+-----------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------------+
-| logical_plan                            | Projection: #count, #system, #time, #town                                                                                                    |
-|                                         |   Filter: #count Gt Int64(200) And #town NotEq Utf8("tewsbury") And #system Eq Int64(5) Or #town Eq Utf8("lawrence")                         |
-|                                         |     TableScan: restaurant projection=None                                                                                                    |
-| logical_plan after projection_push_down | Projection: #count, #system, #time, #town                                                                                                    |
-|                                         |   Filter: #count Gt Int64(200) And #town NotEq Utf8("tewsbury") And #system Eq Int64(5) Or #town Eq Utf8("lawrence")                         |
-|                                         |     TableScan: restaurant projection=Some([0, 1, 2, 3])                                                                                      |
-| logical_plan after simplify_expressions | Projection: #count, #system, #time, #town                                                                                                    |
-|                                         |   Filter: #count Gt Int64(200) And #town NotEq Utf8("tewsbury") And #system Eq Int64(5) Or #town Eq Utf8("lawrence")                         |
-|                                         |     TableScan: restaurant projection=Some([0, 1, 2, 3])                                                                                      |
-| logical_plan after projection_push_down | Projection: #count, #system, #time, #town                                                                                                    |
-|                                         |   Filter: #count Gt Int64(200) And #town NotEq Utf8("tewsbury") And #system Eq Int64(5) Or #town Eq Utf8("lawrence")                         |
-|                                         |     TableScan: restaurant projection=Some([0, 1, 2, 3])                                                                                      |
-| logical_plan after simplify_expressions | Projection: #count, #system, #time, #town                                                                                                    |
-|                                         |   Filter: #count Gt Int64(200) And #town NotEq Utf8("tewsbury") And #system Eq Int64(5) Or #town Eq Utf8("lawrence")                         |
-|                                         |     TableScan: restaurant projection=Some([0, 1, 2, 3])                                                                                      |
-| physical_plan                           | ProjectionExec: expr=[count, system, time, town]                                                                                             |
-|                                         |   FilterExec: CAST(count AS Int64) > 200 AND CAST(town AS Utf8) != tewsbury AND system = CAST(5 AS Float64) OR CAST(town AS Utf8) = lawrence |
-|                                         |     IOxReadFilterNode: table_name=restaurant, chunks=1 predicate=Predicate                                                                   |
-+-----------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------------+
++-----------------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| plan_type                               | plan                                                                                                                                                             |
++-----------------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| logical_plan                            | Projection: #restaurant.count, #restaurant.system, #restaurant.time, #restaurant.town                                                                            |
+|                                         |   Filter: #restaurant.count Gt Int64(200) And #restaurant.town NotEq Utf8("tewsbury") And #restaurant.system Eq Int64(5) Or #restaurant.town Eq Utf8("lawrence") |
+|                                         |     TableScan: restaurant projection=None                                                                                                                        |
+| logical_plan after projection_push_down | Projection: #restaurant.count, #restaurant.system, #restaurant.time, #restaurant.town                                                                            |
+|                                         |   Filter: #restaurant.count Gt Int64(200) And #restaurant.town NotEq Utf8("tewsbury") And #restaurant.system Eq Int64(5) Or #restaurant.town Eq Utf8("lawrence") |
+|                                         |     TableScan: restaurant projection=Some([0, 1, 2, 3])                                                                                                          |
+| logical_plan after simplify_expressions | Projection: #restaurant.count, #restaurant.system, #restaurant.time, #restaurant.town                                                                            |
+|                                         |   Filter: #restaurant.count Gt Int64(200) And #restaurant.town NotEq Utf8("tewsbury") And #restaurant.system Eq Int64(5) Or #restaurant.town Eq Utf8("lawrence") |
+|                                         |     TableScan: restaurant projection=Some([0, 1, 2, 3])                                                                                                          |
+| logical_plan after projection_push_down | Projection: #restaurant.count, #restaurant.system, #restaurant.time, #restaurant.town                                                                            |
+|                                         |   Filter: #restaurant.count Gt Int64(200) And #restaurant.town NotEq Utf8("tewsbury") And #restaurant.system Eq Int64(5) Or #restaurant.town Eq Utf8("lawrence") |
+|                                         |     TableScan: restaurant projection=Some([0, 1, 2, 3])                                                                                                          |
+| logical_plan after simplify_expressions | Projection: #restaurant.count, #restaurant.system, #restaurant.time, #restaurant.town                                                                            |
+|                                         |   Filter: #restaurant.count Gt Int64(200) And #restaurant.town NotEq Utf8("tewsbury") And #restaurant.system Eq Int64(5) Or #restaurant.town Eq Utf8("lawrence") |
+|                                         |     TableScan: restaurant projection=Some([0, 1, 2, 3])                                                                                                          |
+| physical_plan                           | ProjectionExec: expr=[count@0 as count, system@1 as system, time@2 as time, town@3 as town]                                                                      |
+|                                         |   FilterExec: CAST(count@0 AS Int64) > 200 AND CAST(town@3 AS Utf8) != tewsbury AND system@1 = CAST(5 AS Float64) OR CAST(town@3 AS Utf8) = lawrence             |
+|                                         |     IOxReadFilterNode: table_name=restaurant, chunks=1 predicate=Predicate                                                                                       |
++-----------------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 -- SQL: EXPLAIN VERBOSE SELECT * from restaurant where count > 200 and town != 'tewsbury' and (system =5 or town = 'lawrence') and count < 40000;
-+-----------------------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| plan_type                               | plan                                                                                                                                                                          |
-+-----------------------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| logical_plan                            | Projection: #count, #system, #time, #town                                                                                                                                     |
-|                                         |   Filter: #count Gt Int64(200) And #town NotEq Utf8("tewsbury") And #system Eq Int64(5) Or #town Eq Utf8("lawrence") And #count Lt Int64(40000)                               |
-|                                         |     TableScan: restaurant projection=None                                                                                                                                     |
-| logical_plan after projection_push_down | Projection: #count, #system, #time, #town                                                                                                                                     |
-|                                         |   Filter: #count Gt Int64(200) And #town NotEq Utf8("tewsbury") And #system Eq Int64(5) Or #town Eq Utf8("lawrence") And #count Lt Int64(40000)                               |
-|                                         |     TableScan: restaurant projection=Some([0, 1, 2, 3])                                                                                                                       |
-| logical_plan after simplify_expressions | Projection: #count, #system, #time, #town                                                                                                                                     |
-|                                         |   Filter: #count Gt Int64(200) And #town NotEq Utf8("tewsbury") And #system Eq Int64(5) Or #town Eq Utf8("lawrence") And #count Lt Int64(40000)                               |
-|                                         |     TableScan: restaurant projection=Some([0, 1, 2, 3])                                                                                                                       |
-| logical_plan after projection_push_down | Projection: #count, #system, #time, #town                                                                                                                                     |
-|                                         |   Filter: #count Gt Int64(200) And #town NotEq Utf8("tewsbury") And #system Eq Int64(5) Or #town Eq Utf8("lawrence") And #count Lt Int64(40000)                               |
-|                                         |     TableScan: restaurant projection=Some([0, 1, 2, 3])                                                                                                                       |
-| logical_plan after simplify_expressions | Projection: #count, #system, #time, #town                                                                                                                                     |
-|                                         |   Filter: #count Gt Int64(200) And #town NotEq Utf8("tewsbury") And #system Eq Int64(5) Or #town Eq Utf8("lawrence") And #count Lt Int64(40000)                               |
-|                                         |     TableScan: restaurant projection=Some([0, 1, 2, 3])                                                                                                                       |
-| physical_plan                           | ProjectionExec: expr=[count, system, time, town]                                                                                                                              |
-|                                         |   FilterExec: CAST(count AS Int64) > 200 AND CAST(town AS Utf8) != tewsbury AND system = CAST(5 AS Float64) OR CAST(town AS Utf8) = lawrence AND CAST(count AS Int64) < 40000 |
-|                                         |     IOxReadFilterNode: table_name=restaurant, chunks=1 predicate=Predicate                                                                                                    |
-+-----------------------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
++-----------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| plan_type                               | plan                                                                                                                                                                                                   |
++-----------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| logical_plan                            | Projection: #restaurant.count, #restaurant.system, #restaurant.time, #restaurant.town                                                                                                                  |
+|                                         |   Filter: #restaurant.count Gt Int64(200) And #restaurant.town NotEq Utf8("tewsbury") And #restaurant.system Eq Int64(5) Or #restaurant.town Eq Utf8("lawrence") And #restaurant.count Lt Int64(40000) |
+|                                         |     TableScan: restaurant projection=None                                                                                                                                                              |
+| logical_plan after projection_push_down | Projection: #restaurant.count, #restaurant.system, #restaurant.time, #restaurant.town                                                                                                                  |
+|                                         |   Filter: #restaurant.count Gt Int64(200) And #restaurant.town NotEq Utf8("tewsbury") And #restaurant.system Eq Int64(5) Or #restaurant.town Eq Utf8("lawrence") And #restaurant.count Lt Int64(40000) |
+|                                         |     TableScan: restaurant projection=Some([0, 1, 2, 3])                                                                                                                                                |
+| logical_plan after simplify_expressions | Projection: #restaurant.count, #restaurant.system, #restaurant.time, #restaurant.town                                                                                                                  |
+|                                         |   Filter: #restaurant.count Gt Int64(200) And #restaurant.town NotEq Utf8("tewsbury") And #restaurant.system Eq Int64(5) Or #restaurant.town Eq Utf8("lawrence") And #restaurant.count Lt Int64(40000) |
+|                                         |     TableScan: restaurant projection=Some([0, 1, 2, 3])                                                                                                                                                |
+| logical_plan after projection_push_down | Projection: #restaurant.count, #restaurant.system, #restaurant.time, #restaurant.town                                                                                                                  |
+|                                         |   Filter: #restaurant.count Gt Int64(200) And #restaurant.town NotEq Utf8("tewsbury") And #restaurant.system Eq Int64(5) Or #restaurant.town Eq Utf8("lawrence") And #restaurant.count Lt Int64(40000) |
+|                                         |     TableScan: restaurant projection=Some([0, 1, 2, 3])                                                                                                                                                |
+| logical_plan after simplify_expressions | Projection: #restaurant.count, #restaurant.system, #restaurant.time, #restaurant.town                                                                                                                  |
+|                                         |   Filter: #restaurant.count Gt Int64(200) And #restaurant.town NotEq Utf8("tewsbury") And #restaurant.system Eq Int64(5) Or #restaurant.town Eq Utf8("lawrence") And #restaurant.count Lt Int64(40000) |
+|                                         |     TableScan: restaurant projection=Some([0, 1, 2, 3])                                                                                                                                                |
+| physical_plan                           | ProjectionExec: expr=[count@0 as count, system@1 as system, time@2 as time, town@3 as town]                                                                                                            |
+|                                         |   FilterExec: CAST(count@0 AS Int64) > 200 AND CAST(town@3 AS Utf8) != tewsbury AND system@1 = CAST(5 AS Float64) OR CAST(town@3 AS Utf8) = lawrence AND CAST(count@0 AS Int64) < 40000                |
+|                                         |     IOxReadFilterNode: table_name=restaurant, chunks=1 predicate=Predicate                                                                                                                             |
++-----------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 -- SQL: EXPLAIN VERBOSE SELECT * from restaurant where count > 200  and count < 40000;
-+-----------------------------------------+----------------------------------------------------------------------------+
-| plan_type                               | plan                                                                       |
-+-----------------------------------------+----------------------------------------------------------------------------+
-| logical_plan                            | Projection: #count, #system, #time, #town                                  |
-|                                         |   Filter: #count Gt Int64(200) And #count Lt Int64(40000)                  |
-|                                         |     TableScan: restaurant projection=None                                  |
-| logical_plan after projection_push_down | Projection: #count, #system, #time, #town                                  |
-|                                         |   Filter: #count Gt Int64(200) And #count Lt Int64(40000)                  |
-|                                         |     TableScan: restaurant projection=Some([0, 1, 2, 3])                    |
-| logical_plan after simplify_expressions | Projection: #count, #system, #time, #town                                  |
-|                                         |   Filter: #count Gt Int64(200) And #count Lt Int64(40000)                  |
-|                                         |     TableScan: restaurant projection=Some([0, 1, 2, 3])                    |
-| logical_plan after projection_push_down | Projection: #count, #system, #time, #town                                  |
-|                                         |   Filter: #count Gt Int64(200) And #count Lt Int64(40000)                  |
-|                                         |     TableScan: restaurant projection=Some([0, 1, 2, 3])                    |
-| logical_plan after simplify_expressions | Projection: #count, #system, #time, #town                                  |
-|                                         |   Filter: #count Gt Int64(200) And #count Lt Int64(40000)                  |
-|                                         |     TableScan: restaurant projection=Some([0, 1, 2, 3])                    |
-| physical_plan                           | ProjectionExec: expr=[count, system, time, town]                           |
-|                                         |   FilterExec: CAST(count AS Int64) > 200 AND CAST(count AS Int64) < 40000  |
-|                                         |     IOxReadFilterNode: table_name=restaurant, chunks=1 predicate=Predicate |
-+-----------------------------------------+----------------------------------------------------------------------------+
++-----------------------------------------+---------------------------------------------------------------------------------------------+
+| plan_type                               | plan                                                                                        |
++-----------------------------------------+---------------------------------------------------------------------------------------------+
+| logical_plan                            | Projection: #restaurant.count, #restaurant.system, #restaurant.time, #restaurant.town       |
+|                                         |   Filter: #restaurant.count Gt Int64(200) And #restaurant.count Lt Int64(40000)             |
+|                                         |     TableScan: restaurant projection=None                                                   |
+| logical_plan after projection_push_down | Projection: #restaurant.count, #restaurant.system, #restaurant.time, #restaurant.town       |
+|                                         |   Filter: #restaurant.count Gt Int64(200) And #restaurant.count Lt Int64(40000)             |
+|                                         |     TableScan: restaurant projection=Some([0, 1, 2, 3])                                     |
+| logical_plan after simplify_expressions | Projection: #restaurant.count, #restaurant.system, #restaurant.time, #restaurant.town       |
+|                                         |   Filter: #restaurant.count Gt Int64(200) And #restaurant.count Lt Int64(40000)             |
+|                                         |     TableScan: restaurant projection=Some([0, 1, 2, 3])                                     |
+| logical_plan after projection_push_down | Projection: #restaurant.count, #restaurant.system, #restaurant.time, #restaurant.town       |
+|                                         |   Filter: #restaurant.count Gt Int64(200) And #restaurant.count Lt Int64(40000)             |
+|                                         |     TableScan: restaurant projection=Some([0, 1, 2, 3])                                     |
+| logical_plan after simplify_expressions | Projection: #restaurant.count, #restaurant.system, #restaurant.time, #restaurant.town       |
+|                                         |   Filter: #restaurant.count Gt Int64(200) And #restaurant.count Lt Int64(40000)             |
+|                                         |     TableScan: restaurant projection=Some([0, 1, 2, 3])                                     |
+| physical_plan                           | ProjectionExec: expr=[count@0 as count, system@1 as system, time@2 as time, town@3 as town] |
+|                                         |   FilterExec: CAST(count@0 AS Int64) > 200 AND CAST(count@0 AS Int64) < 40000               |
+|                                         |     IOxReadFilterNode: table_name=restaurant, chunks=1 predicate=Predicate                  |
++-----------------------------------------+---------------------------------------------------------------------------------------------+
 -- SQL: EXPLAIN VERBOSE SELECT * from restaurant where system > 4.0 and system < 7.0;
-+-----------------------------------------+----------------------------------------------------------------------------+
-| plan_type                               | plan                                                                       |
-+-----------------------------------------+----------------------------------------------------------------------------+
-| logical_plan                            | Projection: #count, #system, #time, #town                                  |
-|                                         |   Filter: #system Gt Float64(4) And #system Lt Float64(7)                  |
-|                                         |     TableScan: restaurant projection=None                                  |
-| logical_plan after projection_push_down | Projection: #count, #system, #time, #town                                  |
-|                                         |   Filter: #system Gt Float64(4) And #system Lt Float64(7)                  |
-|                                         |     TableScan: restaurant projection=Some([0, 1, 2, 3])                    |
-| logical_plan after simplify_expressions | Projection: #count, #system, #time, #town                                  |
-|                                         |   Filter: #system Gt Float64(4) And #system Lt Float64(7)                  |
-|                                         |     TableScan: restaurant projection=Some([0, 1, 2, 3])                    |
-| logical_plan after projection_push_down | Projection: #count, #system, #time, #town                                  |
-|                                         |   Filter: #system Gt Float64(4) And #system Lt Float64(7)                  |
-|                                         |     TableScan: restaurant projection=Some([0, 1, 2, 3])                    |
-| logical_plan after simplify_expressions | Projection: #count, #system, #time, #town                                  |
-|                                         |   Filter: #system Gt Float64(4) And #system Lt Float64(7)                  |
-|                                         |     TableScan: restaurant projection=Some([0, 1, 2, 3])                    |
-| physical_plan                           | ProjectionExec: expr=[count, system, time, town]                           |
-|                                         |   FilterExec: system > 4 AND system < 7                                    |
-|                                         |     IOxReadFilterNode: table_name=restaurant, chunks=1 predicate=Predicate |
-+-----------------------------------------+----------------------------------------------------------------------------+
++-----------------------------------------+---------------------------------------------------------------------------------------------+
+| plan_type                               | plan                                                                                        |
++-----------------------------------------+---------------------------------------------------------------------------------------------+
+| logical_plan                            | Projection: #restaurant.count, #restaurant.system, #restaurant.time, #restaurant.town       |
+|                                         |   Filter: #restaurant.system Gt Float64(4) And #restaurant.system Lt Float64(7)             |
+|                                         |     TableScan: restaurant projection=None                                                   |
+| logical_plan after projection_push_down | Projection: #restaurant.count, #restaurant.system, #restaurant.time, #restaurant.town       |
+|                                         |   Filter: #restaurant.system Gt Float64(4) And #restaurant.system Lt Float64(7)             |
+|                                         |     TableScan: restaurant projection=Some([0, 1, 2, 3])                                     |
+| logical_plan after simplify_expressions | Projection: #restaurant.count, #restaurant.system, #restaurant.time, #restaurant.town       |
+|                                         |   Filter: #restaurant.system Gt Float64(4) And #restaurant.system Lt Float64(7)             |
+|                                         |     TableScan: restaurant projection=Some([0, 1, 2, 3])                                     |
+| logical_plan after projection_push_down | Projection: #restaurant.count, #restaurant.system, #restaurant.time, #restaurant.town       |
+|                                         |   Filter: #restaurant.system Gt Float64(4) And #restaurant.system Lt Float64(7)             |
+|                                         |     TableScan: restaurant projection=Some([0, 1, 2, 3])                                     |
+| logical_plan after simplify_expressions | Projection: #restaurant.count, #restaurant.system, #restaurant.time, #restaurant.town       |
+|                                         |   Filter: #restaurant.system Gt Float64(4) And #restaurant.system Lt Float64(7)             |
+|                                         |     TableScan: restaurant projection=Some([0, 1, 2, 3])                                     |
+| physical_plan                           | ProjectionExec: expr=[count@0 as count, system@1 as system, time@2 as time, town@3 as town] |
+|                                         |   FilterExec: system@1 > 4 AND system@1 < 7                                                 |
+|                                         |     IOxReadFilterNode: table_name=restaurant, chunks=1 predicate=Predicate                  |
++-----------------------------------------+---------------------------------------------------------------------------------------------+
 -- SQL: EXPLAIN VERBOSE SELECT * from restaurant where system > 5.0 and system < 7.0;
-+-----------------------------------------+----------------------------------------------------------------------------+
-| plan_type                               | plan                                                                       |
-+-----------------------------------------+----------------------------------------------------------------------------+
-| logical_plan                            | Projection: #count, #system, #time, #town                                  |
-|                                         |   Filter: #system Gt Float64(5) And #system Lt Float64(7)                  |
-|                                         |     TableScan: restaurant projection=None                                  |
-| logical_plan after projection_push_down | Projection: #count, #system, #time, #town                                  |
-|                                         |   Filter: #system Gt Float64(5) And #system Lt Float64(7)                  |
-|                                         |     TableScan: restaurant projection=Some([0, 1, 2, 3])                    |
-| logical_plan after simplify_expressions | Projection: #count, #system, #time, #town                                  |
-|                                         |   Filter: #system Gt Float64(5) And #system Lt Float64(7)                  |
-|                                         |     TableScan: restaurant projection=Some([0, 1, 2, 3])                    |
-| logical_plan after projection_push_down | Projection: #count, #system, #time, #town                                  |
-|                                         |   Filter: #system Gt Float64(5) And #system Lt Float64(7)                  |
-|                                         |     TableScan: restaurant projection=Some([0, 1, 2, 3])                    |
-| logical_plan after simplify_expressions | Projection: #count, #system, #time, #town                                  |
-|                                         |   Filter: #system Gt Float64(5) And #system Lt Float64(7)                  |
-|                                         |     TableScan: restaurant projection=Some([0, 1, 2, 3])                    |
-| physical_plan                           | ProjectionExec: expr=[count, system, time, town]                           |
-|                                         |   FilterExec: system > 5 AND system < 7                                    |
-|                                         |     IOxReadFilterNode: table_name=restaurant, chunks=1 predicate=Predicate |
-+-----------------------------------------+----------------------------------------------------------------------------+
++-----------------------------------------+---------------------------------------------------------------------------------------------+
+| plan_type                               | plan                                                                                        |
++-----------------------------------------+---------------------------------------------------------------------------------------------+
+| logical_plan                            | Projection: #restaurant.count, #restaurant.system, #restaurant.time, #restaurant.town       |
+|                                         |   Filter: #restaurant.system Gt Float64(5) And #restaurant.system Lt Float64(7)             |
+|                                         |     TableScan: restaurant projection=None                                                   |
+| logical_plan after projection_push_down | Projection: #restaurant.count, #restaurant.system, #restaurant.time, #restaurant.town       |
+|                                         |   Filter: #restaurant.system Gt Float64(5) And #restaurant.system Lt Float64(7)             |
+|                                         |     TableScan: restaurant projection=Some([0, 1, 2, 3])                                     |
+| logical_plan after simplify_expressions | Projection: #restaurant.count, #restaurant.system, #restaurant.time, #restaurant.town       |
+|                                         |   Filter: #restaurant.system Gt Float64(5) And #restaurant.system Lt Float64(7)             |
+|                                         |     TableScan: restaurant projection=Some([0, 1, 2, 3])                                     |
+| logical_plan after projection_push_down | Projection: #restaurant.count, #restaurant.system, #restaurant.time, #restaurant.town       |
+|                                         |   Filter: #restaurant.system Gt Float64(5) And #restaurant.system Lt Float64(7)             |
+|                                         |     TableScan: restaurant projection=Some([0, 1, 2, 3])                                     |
+| logical_plan after simplify_expressions | Projection: #restaurant.count, #restaurant.system, #restaurant.time, #restaurant.town       |
+|                                         |   Filter: #restaurant.system Gt Float64(5) And #restaurant.system Lt Float64(7)             |
+|                                         |     TableScan: restaurant projection=Some([0, 1, 2, 3])                                     |
+| physical_plan                           | ProjectionExec: expr=[count@0 as count, system@1 as system, time@2 as time, town@3 as town] |
+|                                         |   FilterExec: system@1 > 5 AND system@1 < 7                                                 |
+|                                         |     IOxReadFilterNode: table_name=restaurant, chunks=1 predicate=Predicate                  |
++-----------------------------------------+---------------------------------------------------------------------------------------------+
 -- SQL: EXPLAIN VERBOSE SELECT * from restaurant where system > 5.0 and town != 'tewsbury' and 7.0 > system;
-+-----------------------------------------+--------------------------------------------------------------------------------------------+
-| plan_type                               | plan                                                                                       |
-+-----------------------------------------+--------------------------------------------------------------------------------------------+
-| logical_plan                            | Projection: #count, #system, #time, #town                                                  |
-|                                         |   Filter: #system Gt Float64(5) And #town NotEq Utf8("tewsbury") And Float64(7) Gt #system |
-|                                         |     TableScan: restaurant projection=None                                                  |
-| logical_plan after projection_push_down | Projection: #count, #system, #time, #town                                                  |
-|                                         |   Filter: #system Gt Float64(5) And #town NotEq Utf8("tewsbury") And Float64(7) Gt #system |
-|                                         |     TableScan: restaurant projection=Some([0, 1, 2, 3])                                    |
-| logical_plan after simplify_expressions | Projection: #count, #system, #time, #town                                                  |
-|                                         |   Filter: #system Gt Float64(5) And #town NotEq Utf8("tewsbury") And Float64(7) Gt #system |
-|                                         |     TableScan: restaurant projection=Some([0, 1, 2, 3])                                    |
-| logical_plan after projection_push_down | Projection: #count, #system, #time, #town                                                  |
-|                                         |   Filter: #system Gt Float64(5) And #town NotEq Utf8("tewsbury") And Float64(7) Gt #system |
-|                                         |     TableScan: restaurant projection=Some([0, 1, 2, 3])                                    |
-| logical_plan after simplify_expressions | Projection: #count, #system, #time, #town                                                  |
-|                                         |   Filter: #system Gt Float64(5) And #town NotEq Utf8("tewsbury") And Float64(7) Gt #system |
-|                                         |     TableScan: restaurant projection=Some([0, 1, 2, 3])                                    |
-| physical_plan                           | ProjectionExec: expr=[count, system, time, town]                                           |
-|                                         |   FilterExec: system > 5 AND CAST(town AS Utf8) != tewsbury AND 7 > system                 |
-|                                         |     IOxReadFilterNode: table_name=restaurant, chunks=1 predicate=Predicate                 |
-+-----------------------------------------+--------------------------------------------------------------------------------------------+
++-----------------------------------------+-----------------------------------------------------------------------------------------------------------------------------+
+| plan_type                               | plan                                                                                                                        |
++-----------------------------------------+-----------------------------------------------------------------------------------------------------------------------------+
+| logical_plan                            | Projection: #restaurant.count, #restaurant.system, #restaurant.time, #restaurant.town                                       |
+|                                         |   Filter: #restaurant.system Gt Float64(5) And #restaurant.town NotEq Utf8("tewsbury") And Float64(7) Gt #restaurant.system |
+|                                         |     TableScan: restaurant projection=None                                                                                   |
+| logical_plan after projection_push_down | Projection: #restaurant.count, #restaurant.system, #restaurant.time, #restaurant.town                                       |
+|                                         |   Filter: #restaurant.system Gt Float64(5) And #restaurant.town NotEq Utf8("tewsbury") And Float64(7) Gt #restaurant.system |
+|                                         |     TableScan: restaurant projection=Some([0, 1, 2, 3])                                                                     |
+| logical_plan after simplify_expressions | Projection: #restaurant.count, #restaurant.system, #restaurant.time, #restaurant.town                                       |
+|                                         |   Filter: #restaurant.system Gt Float64(5) And #restaurant.town NotEq Utf8("tewsbury") And Float64(7) Gt #restaurant.system |
+|                                         |     TableScan: restaurant projection=Some([0, 1, 2, 3])                                                                     |
+| logical_plan after projection_push_down | Projection: #restaurant.count, #restaurant.system, #restaurant.time, #restaurant.town                                       |
+|                                         |   Filter: #restaurant.system Gt Float64(5) And #restaurant.town NotEq Utf8("tewsbury") And Float64(7) Gt #restaurant.system |
+|                                         |     TableScan: restaurant projection=Some([0, 1, 2, 3])                                                                     |
+| logical_plan after simplify_expressions | Projection: #restaurant.count, #restaurant.system, #restaurant.time, #restaurant.town                                       |
+|                                         |   Filter: #restaurant.system Gt Float64(5) And #restaurant.town NotEq Utf8("tewsbury") And Float64(7) Gt #restaurant.system |
+|                                         |     TableScan: restaurant projection=Some([0, 1, 2, 3])                                                                     |
+| physical_plan                           | ProjectionExec: expr=[count@0 as count, system@1 as system, time@2 as time, town@3 as town]                                 |
+|                                         |   FilterExec: system@1 > 5 AND CAST(town@3 AS Utf8) != tewsbury AND 7 > system@1                                            |
+|                                         |     IOxReadFilterNode: table_name=restaurant, chunks=1 predicate=Predicate                                                  |
++-----------------------------------------+-----------------------------------------------------------------------------------------------------------------------------+
 -- SQL: EXPLAIN VERBOSE SELECT * from restaurant where system > 5.0 and 'tewsbury' != town and system < 7.0 and (count = 632 or town = 'reading');
-+-----------------------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------+
-| plan_type                               | plan                                                                                                                                            |
-+-----------------------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------+
-| logical_plan                            | Projection: #count, #system, #time, #town                                                                                                       |
-|                                         |   Filter: #system Gt Float64(5) And Utf8("tewsbury") NotEq #town And #system Lt Float64(7) And #count Eq Int64(632) Or #town Eq Utf8("reading") |
-|                                         |     TableScan: restaurant projection=None                                                                                                       |
-| logical_plan after projection_push_down | Projection: #count, #system, #time, #town                                                                                                       |
-|                                         |   Filter: #system Gt Float64(5) And Utf8("tewsbury") NotEq #town And #system Lt Float64(7) And #count Eq Int64(632) Or #town Eq Utf8("reading") |
-|                                         |     TableScan: restaurant projection=Some([0, 1, 2, 3])                                                                                         |
-| logical_plan after simplify_expressions | Projection: #count, #system, #time, #town                                                                                                       |
-|                                         |   Filter: #system Gt Float64(5) And Utf8("tewsbury") NotEq #town And #system Lt Float64(7) And #count Eq Int64(632) Or #town Eq Utf8("reading") |
-|                                         |     TableScan: restaurant projection=Some([0, 1, 2, 3])                                                                                         |
-| logical_plan after projection_push_down | Projection: #count, #system, #time, #town                                                                                                       |
-|                                         |   Filter: #system Gt Float64(5) And Utf8("tewsbury") NotEq #town And #system Lt Float64(7) And #count Eq Int64(632) Or #town Eq Utf8("reading") |
-|                                         |     TableScan: restaurant projection=Some([0, 1, 2, 3])                                                                                         |
-| logical_plan after simplify_expressions | Projection: #count, #system, #time, #town                                                                                                       |
-|                                         |   Filter: #system Gt Float64(5) And Utf8("tewsbury") NotEq #town And #system Lt Float64(7) And #count Eq Int64(632) Or #town Eq Utf8("reading") |
-|                                         |     TableScan: restaurant projection=Some([0, 1, 2, 3])                                                                                         |
-| physical_plan                           | ProjectionExec: expr=[count, system, time, town]                                                                                                |
-|                                         |   FilterExec: system > 5 AND tewsbury != CAST(town AS Utf8) AND system < 7 AND CAST(count AS Int64) = 632 OR CAST(town AS Utf8) = reading       |
-|                                         |     IOxReadFilterNode: table_name=restaurant, chunks=1 predicate=Predicate                                                                      |
-+-----------------------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------+
++-----------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| plan_type                               | plan                                                                                                                                                                                                   |
++-----------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| logical_plan                            | Projection: #restaurant.count, #restaurant.system, #restaurant.time, #restaurant.town                                                                                                                  |
+|                                         |   Filter: #restaurant.system Gt Float64(5) And Utf8("tewsbury") NotEq #restaurant.town And #restaurant.system Lt Float64(7) And #restaurant.count Eq Int64(632) Or #restaurant.town Eq Utf8("reading") |
+|                                         |     TableScan: restaurant projection=None                                                                                                                                                              |
+| logical_plan after projection_push_down | Projection: #restaurant.count, #restaurant.system, #restaurant.time, #restaurant.town                                                                                                                  |
+|                                         |   Filter: #restaurant.system Gt Float64(5) And Utf8("tewsbury") NotEq #restaurant.town And #restaurant.system Lt Float64(7) And #restaurant.count Eq Int64(632) Or #restaurant.town Eq Utf8("reading") |
+|                                         |     TableScan: restaurant projection=Some([0, 1, 2, 3])                                                                                                                                                |
+| logical_plan after simplify_expressions | Projection: #restaurant.count, #restaurant.system, #restaurant.time, #restaurant.town                                                                                                                  |
+|                                         |   Filter: #restaurant.system Gt Float64(5) And Utf8("tewsbury") NotEq #restaurant.town And #restaurant.system Lt Float64(7) And #restaurant.count Eq Int64(632) Or #restaurant.town Eq Utf8("reading") |
+|                                         |     TableScan: restaurant projection=Some([0, 1, 2, 3])                                                                                                                                                |
+| logical_plan after projection_push_down | Projection: #restaurant.count, #restaurant.system, #restaurant.time, #restaurant.town                                                                                                                  |
+|                                         |   Filter: #restaurant.system Gt Float64(5) And Utf8("tewsbury") NotEq #restaurant.town And #restaurant.system Lt Float64(7) And #restaurant.count Eq Int64(632) Or #restaurant.town Eq Utf8("reading") |
+|                                         |     TableScan: restaurant projection=Some([0, 1, 2, 3])                                                                                                                                                |
+| logical_plan after simplify_expressions | Projection: #restaurant.count, #restaurant.system, #restaurant.time, #restaurant.town                                                                                                                  |
+|                                         |   Filter: #restaurant.system Gt Float64(5) And Utf8("tewsbury") NotEq #restaurant.town And #restaurant.system Lt Float64(7) And #restaurant.count Eq Int64(632) Or #restaurant.town Eq Utf8("reading") |
+|                                         |     TableScan: restaurant projection=Some([0, 1, 2, 3])                                                                                                                                                |
+| physical_plan                           | ProjectionExec: expr=[count@0 as count, system@1 as system, time@2 as time, town@3 as town]                                                                                                            |
+|                                         |   FilterExec: system@1 > 5 AND tewsbury != CAST(town@3 AS Utf8) AND system@1 < 7 AND CAST(count@0 AS Int64) = 632 OR CAST(town@3 AS Utf8) = reading                                                    |
+|                                         |     IOxReadFilterNode: table_name=restaurant, chunks=1 predicate=Predicate                                                                                                                             |
++-----------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 -- SQL: EXPLAIN VERBOSE SELECT * from restaurant where 5.0 < system and town != 'tewsbury' and system < 7.0 and (count = 632 or town = 'reading') and time > to_timestamp('1970-01-01T00:00:00.000000130+00:00');
-+-----------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| plan_type                               | plan                                                                                                                                                                                                                  |
-+-----------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| logical_plan                            | Projection: #count, #system, #time, #town                                                                                                                                                                             |
-|                                         |   Filter: Float64(5) Lt #system And #town NotEq Utf8("tewsbury") And #system Lt Float64(7) And #count Eq Int64(632) Or #town Eq Utf8("reading") And #time Gt totimestamp(Utf8("1970-01-01T00:00:00.000000130+00:00")) |
-|                                         |     TableScan: restaurant projection=None                                                                                                                                                                             |
-| logical_plan after projection_push_down | Projection: #count, #system, #time, #town                                                                                                                                                                             |
-|                                         |   Filter: Float64(5) Lt #system And #town NotEq Utf8("tewsbury") And #system Lt Float64(7) And #count Eq Int64(632) Or #town Eq Utf8("reading") And #time Gt totimestamp(Utf8("1970-01-01T00:00:00.000000130+00:00")) |
-|                                         |     TableScan: restaurant projection=Some([0, 1, 2, 3])                                                                                                                                                               |
-| logical_plan after simplify_expressions | Projection: #count, #system, #time, #town                                                                                                                                                                             |
-|                                         |   Filter: Float64(5) Lt #system And #town NotEq Utf8("tewsbury") And #system Lt Float64(7) And #count Eq Int64(632) Or #town Eq Utf8("reading") And #time Gt totimestamp(Utf8("1970-01-01T00:00:00.000000130+00:00")) |
-|                                         |     TableScan: restaurant projection=Some([0, 1, 2, 3])                                                                                                                                                               |
-| logical_plan after projection_push_down | Projection: #count, #system, #time, #town                                                                                                                                                                             |
-|                                         |   Filter: Float64(5) Lt #system And #town NotEq Utf8("tewsbury") And #system Lt Float64(7) And #count Eq Int64(632) Or #town Eq Utf8("reading") And #time Gt totimestamp(Utf8("1970-01-01T00:00:00.000000130+00:00")) |
-|                                         |     TableScan: restaurant projection=Some([0, 1, 2, 3])                                                                                                                                                               |
-| logical_plan after simplify_expressions | Projection: #count, #system, #time, #town                                                                                                                                                                             |
-|                                         |   Filter: Float64(5) Lt #system And #town NotEq Utf8("tewsbury") And #system Lt Float64(7) And #count Eq Int64(632) Or #town Eq Utf8("reading") And #time Gt totimestamp(Utf8("1970-01-01T00:00:00.000000130+00:00")) |
-|                                         |     TableScan: restaurant projection=Some([0, 1, 2, 3])                                                                                                                                                               |
-| physical_plan                           | ProjectionExec: expr=[count, system, time, town]                                                                                                                                                                      |
-|                                         |   FilterExec: 5 < system AND CAST(town AS Utf8) != tewsbury AND system < 7 AND CAST(count AS Int64) = 632 OR CAST(town AS Utf8) = reading AND time > totimestamp(1970-01-01T00:00:00.000000130+00:00)                 |
-|                                         |     IOxReadFilterNode: table_name=restaurant, chunks=1 predicate=Predicate                                                                                                                                            |
-+-----------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
++-----------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| plan_type                               | plan                                                                                                                                                                                                                                                                                    |
++-----------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| logical_plan                            | Projection: #restaurant.count, #restaurant.system, #restaurant.time, #restaurant.town                                                                                                                                                                                                   |
+|                                         |   Filter: Float64(5) Lt #restaurant.system And #restaurant.town NotEq Utf8("tewsbury") And #restaurant.system Lt Float64(7) And #restaurant.count Eq Int64(632) Or #restaurant.town Eq Utf8("reading") And #restaurant.time Gt totimestamp(Utf8("1970-01-01T00:00:00.000000130+00:00")) |
+|                                         |     TableScan: restaurant projection=None                                                                                                                                                                                                                                               |
+| logical_plan after projection_push_down | Projection: #restaurant.count, #restaurant.system, #restaurant.time, #restaurant.town                                                                                                                                                                                                   |
+|                                         |   Filter: Float64(5) Lt #restaurant.system And #restaurant.town NotEq Utf8("tewsbury") And #restaurant.system Lt Float64(7) And #restaurant.count Eq Int64(632) Or #restaurant.town Eq Utf8("reading") And #restaurant.time Gt totimestamp(Utf8("1970-01-01T00:00:00.000000130+00:00")) |
+|                                         |     TableScan: restaurant projection=Some([0, 1, 2, 3])                                                                                                                                                                                                                                 |
+| logical_plan after simplify_expressions | Projection: #restaurant.count, #restaurant.system, #restaurant.time, #restaurant.town                                                                                                                                                                                                   |
+|                                         |   Filter: Float64(5) Lt #restaurant.system And #restaurant.town NotEq Utf8("tewsbury") And #restaurant.system Lt Float64(7) And #restaurant.count Eq Int64(632) Or #restaurant.town Eq Utf8("reading") And #restaurant.time Gt totimestamp(Utf8("1970-01-01T00:00:00.000000130+00:00")) |
+|                                         |     TableScan: restaurant projection=Some([0, 1, 2, 3])                                                                                                                                                                                                                                 |
+| logical_plan after projection_push_down | Projection: #restaurant.count, #restaurant.system, #restaurant.time, #restaurant.town                                                                                                                                                                                                   |
+|                                         |   Filter: Float64(5) Lt #restaurant.system And #restaurant.town NotEq Utf8("tewsbury") And #restaurant.system Lt Float64(7) And #restaurant.count Eq Int64(632) Or #restaurant.town Eq Utf8("reading") And #restaurant.time Gt totimestamp(Utf8("1970-01-01T00:00:00.000000130+00:00")) |
+|                                         |     TableScan: restaurant projection=Some([0, 1, 2, 3])                                                                                                                                                                                                                                 |
+| logical_plan after simplify_expressions | Projection: #restaurant.count, #restaurant.system, #restaurant.time, #restaurant.town                                                                                                                                                                                                   |
+|                                         |   Filter: Float64(5) Lt #restaurant.system And #restaurant.town NotEq Utf8("tewsbury") And #restaurant.system Lt Float64(7) And #restaurant.count Eq Int64(632) Or #restaurant.town Eq Utf8("reading") And #restaurant.time Gt totimestamp(Utf8("1970-01-01T00:00:00.000000130+00:00")) |
+|                                         |     TableScan: restaurant projection=Some([0, 1, 2, 3])                                                                                                                                                                                                                                 |
+| physical_plan                           | ProjectionExec: expr=[count@0 as count, system@1 as system, time@2 as time, town@3 as town]                                                                                                                                                                                             |
+|                                         |   FilterExec: 5 < system@1 AND CAST(town@3 AS Utf8) != tewsbury AND system@1 < 7 AND CAST(count@0 AS Int64) = 632 OR CAST(town@3 AS Utf8) = reading AND time@2 > totimestamp(1970-01-01T00:00:00.000000130+00:00)                                                                       |
+|                                         |     IOxReadFilterNode: table_name=restaurant, chunks=1 predicate=Predicate                                                                                                                                                                                                              |
++-----------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+

--- a/read_buffer/src/row_group.rs
+++ b/read_buffer/src/row_group.rs
@@ -1412,8 +1412,8 @@ impl TryFrom<&DfExpr> for BinaryExpr {
         match df_expr {
             DfExpr::BinaryExpr { left, op, right } => {
                 match (&**left, &**right) {
-                    (DfExpr::Column(name), DfExpr::Literal(scalar)) => Ok(Self::new(
-                        name,
+                    (DfExpr::Column(c), DfExpr::Literal(scalar)) => Ok(Self::new(
+                        &c.name,
                         Operator::try_from(op)?,
                         Literal::try_from(scalar)?,
                     )),
@@ -3481,8 +3481,10 @@ west,host-c,pro,10,6
         assert_eq!(result, to_map(vec![]));
     }
 
-    use datafusion::logical_plan::*;
-    use datafusion::scalar::ScalarValue;
+    use datafusion::{
+        logical_plan::{col, Expr},
+        scalar::ScalarValue,
+    };
     use std::convert::TryFrom;
 
     #[test]

--- a/server_benchmarks/benches/read_filter.rs
+++ b/server_benchmarks/benches/read_filter.rs
@@ -1,7 +1,7 @@
 use std::io::Read;
 
 use criterion::{BenchmarkId, Criterion};
-use datafusion::{logical_plan::Expr, scalar::ScalarValue};
+use datafusion::logical_plan::{col, lit};
 // This is a struct that tells Criterion.rs to use the "futures" crate's
 // current-thread executor
 use flate2::read::GzDecoder;
@@ -62,10 +62,7 @@ fn execute_benchmark_group(c: &mut Criterion, scenarios: &[DbScenario]) {
         (PredicateBuilder::default().build(), "no_pred"),
         (
             PredicateBuilder::default()
-                .add_expr(
-                    Expr::Column("tag3".to_owned())
-                        .eq(Expr::Literal(ScalarValue::Utf8(Some("value49".to_owned())))),
-                )
+                .add_expr(col("tag3").eq(lit("value49")))
                 .build(),
             "with_pred_tag_3=value49",
         ),

--- a/server_benchmarks/benches/read_group.rs
+++ b/server_benchmarks/benches/read_group.rs
@@ -1,7 +1,7 @@
 use std::io::Read;
 
 use criterion::{BenchmarkId, Criterion};
-use datafusion::{logical_plan::Expr, scalar::ScalarValue};
+use datafusion::logical_plan::{col, lit};
 // This is a struct that tells Criterion.rs to use the "futures" crate's
 // current-thread executor
 use flate2::read::GzDecoder;
@@ -62,10 +62,7 @@ fn execute_benchmark_group(c: &mut Criterion, scenarios: &[DbScenario]) {
         (PredicateBuilder::default().build(), "no_pred"),
         (
             PredicateBuilder::default()
-                .add_expr(
-                    Expr::Column("tag3".to_owned())
-                        .eq(Expr::Literal(ScalarValue::Utf8(Some("value49".to_owned())))),
-                )
+                .add_expr(col("tag3").eq(lit("value49")))
                 .build(),
             "with_pred_tag_3=value49",
         ),

--- a/server_benchmarks/benches/tag_values.rs
+++ b/server_benchmarks/benches/tag_values.rs
@@ -1,7 +1,7 @@
 use std::io::Read;
 
 use criterion::{BenchmarkId, Criterion};
-use datafusion::{logical_plan::Expr, scalar::ScalarValue};
+use datafusion::logical_plan::{col, lit};
 // This is a struct that tells Criterion.rs to use the "futures" crate's
 // current-thread executor
 use flate2::read::GzDecoder;
@@ -61,11 +61,7 @@ fn execute_benchmark_group(c: &mut Criterion, scenarios: &[DbScenario]) {
         (PredicateBuilder::default().build(), "no_pred"),
         (
             PredicateBuilder::default()
-                .add_expr(
-                    Expr::Column("tag2".to_owned()).eq(Expr::Literal(ScalarValue::Utf8(Some(
-                        "value321".to_owned(),
-                    )))),
-                )
+                .add_expr(col("tag2").eq(lit("value321")))
                 .build(),
             "with_pred",
         ),


### PR DESCRIPTION
# Rationale
https://github.com/apache/arrow-datafusion/pull/55 was a non trivial change to DataFusion (basically to have proper `relation`.`column` identifiers) and it needs to be integrated into IOx (so that we can keep the features flowing)

# Changes
1. Update to https://github.com/apache/arrow-datafusion/commit/f2c01de7d620081eb370966d928673c8d38ac798, to get https://github.com/apache/arrow-datafusion/pull/681 among other things like improved join support. 
2. run `cargo update`
3. Update IOx to use new API

# History
Here are some other items that were needed to be added to DataFusion to get this PR to pass the tests:

- [x] Projection pushdown filtering out columns: https://github.com/apache/arrow-datafusion/pull/617 / https://github.com/apache/arrow-datafusion/pull/619
- [x] Pruning not working with qualified columns (https://github.com/apache/arrow-datafusion/issues/656)
- [x] Extension planner akwardness with qualified names: https://github.com/apache/arrow-datafusion/issues/642 / https://github.com/apache/arrow-datafusion/pull/643

# Misc
Also, TIL "Star Roving" -- https://www.youtube.com/watch?v=ogCih4OavoY -- it's pretty good 👍 
