### PR TITLE
feat: add persistence windows to partition and update on write

### DIFF
--- a/data_types/src/database_rules.rs
+++ b/data_types/src/database_rules.rs
@@ -170,6 +170,13 @@ pub struct LifecycleRules {
     pub persist_row_threshold: NonZeroUsize,
 }
 
+impl LifecycleRules {
+    /// The max timestamp skew across concurrent writers before persisted chunks might overlap
+    pub fn late_arrive_window(&self) -> Duration {
+        Duration::from_secs(self.late_arrive_window_seconds.get() as u64)
+    }
+}
+
 impl Default for LifecycleRules {
     fn default() -> Self {
         Self {

--- a/entry/src/entry.rs
+++ b/entry/src/entry.rs
@@ -3,7 +3,7 @@
 
 use std::{collections::BTreeMap, convert::TryFrom, fmt::Formatter, num::NonZeroU64};
 
-use chrono::Utc;
+use chrono::{DateTime, TimeZone, Utc};
 use flatbuffers::{FlatBufferBuilder, Follow, ForwardsUOffset, Vector, VectorIter, WIPOffset};
 use ouroboros::self_referencing;
 use snafu::{OptionExt, ResultExt, Snafu};
@@ -41,6 +41,15 @@ pub enum Error {
 
     #[snafu(display("invalid flatbuffers: field {} is required", field))]
     FlatbufferFieldMissing { field: String },
+
+    #[snafu(display("'time' column is required"))]
+    TimeColumnMissing,
+
+    #[snafu(display("time value missing from batch"))]
+    TimeValueMissing,
+
+    #[snafu(display("'time' column must be i64 type"))]
+    TimeColumnWrongType,
 }
 
 #[derive(Debug, Snafu)]
@@ -391,6 +400,34 @@ impl<'a> TableBatch<'a> {
         }
     }
 
+    pub fn min_max_time(&self) -> Result<(DateTime<Utc>, DateTime<Utc>)> {
+        match self
+            .fb
+            .columns()
+            .as_ref()
+            .expect("invalid flatbuffers: table batch must have columns")
+            .iter()
+            .find(|fb| {
+                fb.name()
+                    .expect("invalid flatbuffers: column must have name")
+                    == TIME_COLUMN_NAME
+            }) {
+            Some(c) => {
+                let vals = c
+                    .values_as_i64values()
+                    .context(TimeColumnWrongType)?
+                    .values()
+                    .expect("invalid flatbuffers: time columm values must be present");
+
+                let min = vals.iter().min().context(TimeValueMissing)?;
+                let max = vals.iter().max().context(TimeValueMissing)?;
+
+                Ok((timestamp_to_datetime(min), timestamp_to_datetime(max)))
+            }
+            None => TimeColumnMissing.fail(),
+        }
+    }
+
     pub fn row_count(&self) -> usize {
         if let Some(cols) = self.fb.columns() {
             if let Some(c) = cols.iter().next() {
@@ -427,6 +464,12 @@ impl<'a> TableBatch<'a> {
 
         0
     }
+}
+
+fn timestamp_to_datetime(ts: i64) -> DateTime<Utc> {
+    let secs = ts / 1_000_000_000;
+    let nsec = ts % 1_000_000_000;
+    Utc.timestamp(secs, nsec as u32)
 }
 
 /// Wrapper struct for the flatbuffers Column. Has a convenience method to
@@ -1978,5 +2021,23 @@ mod tests {
         );
 
         assert!(sharded_entries.is_err());
+    }
+
+    #[test]
+    fn min_max_time() {
+        let entry = lp_to_entry("m val=1 10000000123");
+        let (min, max) = entry.partition_writes().unwrap()[0].table_batches()[0]
+            .min_max_time()
+            .unwrap();
+        let ts = Utc.timestamp(10, 123);
+        assert_eq!(min, ts);
+        assert_eq!(max, ts);
+
+        let entry = lp_to_entry("m val=1 10000000123\nm val=12 12000000003");
+        let (min, max) = entry.partition_writes().unwrap()[0].table_batches()[0]
+            .min_max_time()
+            .unwrap();
+        assert_eq!(min, ts);
+        assert_eq!(max, Utc.timestamp(12, 3));
     }
 }

--- a/entry/src/entry.rs
+++ b/entry/src/entry.rs
@@ -45,7 +45,7 @@ pub enum Error {
     #[snafu(display("'time' column is required"))]
     TimeColumnMissing,
 
-    #[snafu(display("time value missing from batch"))]
+    #[snafu(display("time value missing from batch or no rows in batch"))]
     TimeValueMissing,
 
     #[snafu(display("'time' column must be i64 type"))]
@@ -422,7 +422,7 @@ impl<'a> TableBatch<'a> {
                 let min = vals.iter().min().context(TimeValueMissing)?;
                 let max = vals.iter().max().context(TimeValueMissing)?;
 
-                Ok((timestamp_to_datetime(min), timestamp_to_datetime(max)))
+                Ok((Utc.timestamp_nanos(min), Utc.timestamp_nanos(max)))
             }
             None => TimeColumnMissing.fail(),
         }
@@ -464,12 +464,6 @@ impl<'a> TableBatch<'a> {
 
         0
     }
-}
-
-fn timestamp_to_datetime(ts: i64) -> DateTime<Utc> {
-    let secs = ts / 1_000_000_000;
-    let nsec = ts % 1_000_000_000;
-    Utc.timestamp(secs, nsec as u32)
 }
 
 /// Wrapper struct for the flatbuffers Column. Has a convenience method to

--- a/mutable_buffer/src/lib.rs
+++ b/mutable_buffer/src/lib.rs
@@ -60,5 +60,4 @@
 pub mod chunk;
 mod column;
 mod dictionary;
-#[allow(dead_code)]
-mod persistence_windows;
+pub mod persistence_windows;

--- a/mutable_buffer/src/persistence_windows.rs
+++ b/mutable_buffer/src/persistence_windows.rs
@@ -7,21 +7,8 @@ use std::{
 };
 
 use chrono::{DateTime, Utc};
-use snafu::Snafu;
 
-#[derive(Debug, Copy, Clone, Snafu)]
-pub enum Error {
-    #[snafu(display(
-        "Late arrival window {:#?} too short. Minimum value should be >= {:#?}",
-        value,
-        CLOSED_WINDOW_PERIOD
-    ))]
-    ArrivalWindowTooShort { value: Duration },
-}
-
-pub type Result<T, E = Error> = std::result::Result<T, E>;
-
-const CLOSED_WINDOW_PERIOD: Duration = Duration::from_secs(30);
+const DEFAULT_CLOSED_WINDOW_PERIOD: Duration = Duration::from_secs(30);
 
 /// PersistenceWindows keep track of ingested data within a partition to determine when it
 /// can be persisted. This allows IOx to receive out of order writes (in their timestamps) while
@@ -36,28 +23,29 @@ pub struct PersistenceWindows {
     closed: VecDeque<Window>,
     open: Option<Window>,
     late_arrival_period: Duration,
+    closed_window_period: Duration,
 }
 
 impl PersistenceWindows {
-    pub fn new(late_arrival_period: Duration) -> Result<Self> {
-        let late_arrival_seconds = late_arrival_period.as_secs();
-        let closed_window_seconds = CLOSED_WINDOW_PERIOD.as_secs();
+    pub fn new(late_arrival_period: Duration) -> Self {
+        let closed_window_period = if late_arrival_period > DEFAULT_CLOSED_WINDOW_PERIOD {
+            DEFAULT_CLOSED_WINDOW_PERIOD
+        } else {
+            late_arrival_period
+        };
 
-        if late_arrival_seconds < closed_window_seconds {
-            return ArrivalWindowTooShort {
-                value: late_arrival_period,
-            }
-            .fail();
-        }
+        let late_arrival_seconds = late_arrival_period.as_secs();
+        let closed_window_seconds = closed_window_period.as_secs();
 
         let closed_window_count = late_arrival_seconds / closed_window_seconds;
 
-        Ok(Self {
+        Self {
             persistable: None,
             closed: VecDeque::with_capacity(closed_window_count as usize),
             open: None,
             late_arrival_period,
-        })
+            closed_window_period,
+        }
     }
 
     /// Updates the windows with the information from a batch of rows from a single sequencer
@@ -125,7 +113,7 @@ impl PersistenceWindows {
         let rotate = self
             .open
             .as_ref()
-            .map(|w| now.duration_since(w.created_at) >= CLOSED_WINDOW_PERIOD)
+            .map(|w| now.duration_since(w.created_at) >= self.closed_window_period)
             .unwrap_or(false);
 
         if rotate {
@@ -291,7 +279,7 @@ mod tests {
 
     #[test]
     fn starts_open_window() {
-        let mut w = PersistenceWindows::new(Duration::from_secs(60)).unwrap();
+        let mut w = PersistenceWindows::new(Duration::from_secs(60));
 
         let i = Instant::now();
         let start_time = Utc::now();
@@ -340,7 +328,7 @@ mod tests {
 
     #[test]
     fn closes_open_window() {
-        let mut w = PersistenceWindows::new(Duration::from_secs(60)).unwrap();
+        let mut w = PersistenceWindows::new(Duration::from_secs(60));
         let created_at = Instant::now();
         let start_time = Utc::now();
         let last_time = Utc::now();
@@ -359,7 +347,9 @@ mod tests {
             last_time,
             Instant::now(),
         );
-        let after_close_threshold = created_at.checked_add(CLOSED_WINDOW_PERIOD).unwrap();
+        let after_close_threshold = created_at
+            .checked_add(DEFAULT_CLOSED_WINDOW_PERIOD)
+            .unwrap();
         let open_time = Utc::now();
         w.add_range(
             &Sequence { id: 1, number: 6 },
@@ -392,7 +382,7 @@ mod tests {
 
     #[test]
     fn moves_to_persistable() {
-        let mut w = PersistenceWindows::new(Duration::from_secs(120)).unwrap();
+        let mut w = PersistenceWindows::new(Duration::from_secs(120));
         let created_at = Instant::now();
         let start_time = Utc::now();
 
@@ -405,7 +395,9 @@ mod tests {
             created_at,
         );
 
-        let second_created_at = created_at.checked_add(CLOSED_WINDOW_PERIOD).unwrap();
+        let second_created_at = created_at
+            .checked_add(DEFAULT_CLOSED_WINDOW_PERIOD)
+            .unwrap();
         let second_end = Utc::now();
         w.add_range(
             &Sequence { id: 1, number: 3 },
@@ -415,7 +407,9 @@ mod tests {
             second_created_at,
         );
 
-        let third_created_at = second_created_at.checked_add(CLOSED_WINDOW_PERIOD).unwrap();
+        let third_created_at = second_created_at
+            .checked_add(DEFAULT_CLOSED_WINDOW_PERIOD)
+            .unwrap();
         let third_end = Utc::now();
         w.add_range(
             &Sequence { id: 1, number: 4 },
@@ -446,7 +440,7 @@ mod tests {
         assert_eq!(c.max_time, third_end);
 
         let fourth_created_at = third_created_at
-            .checked_add(CLOSED_WINDOW_PERIOD * 3)
+            .checked_add(DEFAULT_CLOSED_WINDOW_PERIOD * 3)
             .unwrap();
         let fourth_end = Utc::now();
         w.add_range(
@@ -475,7 +469,7 @@ mod tests {
         assert_eq!(c.max_time, third_end);
 
         let fifth_created_at = fourth_created_at
-            .checked_add(CLOSED_WINDOW_PERIOD * 100)
+            .checked_add(DEFAULT_CLOSED_WINDOW_PERIOD * 100)
             .unwrap();
         w.add_range(
             &Sequence { id: 1, number: 9 },
@@ -497,14 +491,20 @@ mod tests {
 
     #[test]
     fn flush_persistable_keeps_open_and_closed() {
-        let mut w = PersistenceWindows::new(Duration::from_secs(120)).unwrap();
+        let mut w = PersistenceWindows::new(Duration::from_secs(120));
 
         // these instants represent when the server received the data. Here we have a window that
         // should be in the persistable group, a closed window, and an open window that is closed on flush.
         let created_at = Instant::now();
-        let second_created_at = created_at.checked_add(CLOSED_WINDOW_PERIOD * 2).unwrap();
-        let third_created_at = second_created_at.checked_add(CLOSED_WINDOW_PERIOD).unwrap();
-        let end_at = third_created_at.checked_add(CLOSED_WINDOW_PERIOD).unwrap();
+        let second_created_at = created_at
+            .checked_add(DEFAULT_CLOSED_WINDOW_PERIOD * 2)
+            .unwrap();
+        let third_created_at = second_created_at
+            .checked_add(DEFAULT_CLOSED_WINDOW_PERIOD)
+            .unwrap();
+        let end_at = third_created_at
+            .checked_add(DEFAULT_CLOSED_WINDOW_PERIOD)
+            .unwrap();
 
         // these times represent the value of the time column for the rows of data. Here we have
         // non-overlapping windows.
@@ -569,14 +569,20 @@ mod tests {
 
     #[test]
     fn flush_persistable_overlaps_closed() {
-        let mut w = PersistenceWindows::new(Duration::from_secs(120)).unwrap();
+        let mut w = PersistenceWindows::new(Duration::from_secs(120));
 
         // these instants represent when data is received by the server. Here we have a persistable
         // window followed by two closed windows.
         let created_at = Instant::now();
-        let second_created_at = created_at.checked_add(CLOSED_WINDOW_PERIOD * 2).unwrap();
-        let third_created_at = second_created_at.checked_add(CLOSED_WINDOW_PERIOD).unwrap();
-        let end_at = third_created_at.checked_add(CLOSED_WINDOW_PERIOD).unwrap();
+        let second_created_at = created_at
+            .checked_add(DEFAULT_CLOSED_WINDOW_PERIOD * 2)
+            .unwrap();
+        let third_created_at = second_created_at
+            .checked_add(DEFAULT_CLOSED_WINDOW_PERIOD)
+            .unwrap();
+        let end_at = third_created_at
+            .checked_add(DEFAULT_CLOSED_WINDOW_PERIOD)
+            .unwrap();
 
         // the times of the rows of data. this will create overlapping windows where persistable
         // overlaps with the oldest closed window.
@@ -642,13 +648,17 @@ mod tests {
 
     #[test]
     fn flush_persistable_overlaps_open() {
-        let mut w = PersistenceWindows::new(Duration::from_secs(120)).unwrap();
+        let mut w = PersistenceWindows::new(Duration::from_secs(120));
 
         // these instants represent when data is received by the server. Here we have a persistable
         // window followed by two closed windows.
         let created_at = Instant::now();
-        let second_created_at = created_at.checked_add(CLOSED_WINDOW_PERIOD * 3).unwrap();
-        let third_created_at = second_created_at.checked_add(CLOSED_WINDOW_PERIOD).unwrap();
+        let second_created_at = created_at
+            .checked_add(DEFAULT_CLOSED_WINDOW_PERIOD * 3)
+            .unwrap();
+        let third_created_at = second_created_at
+            .checked_add(DEFAULT_CLOSED_WINDOW_PERIOD)
+            .unwrap();
         let end_at = third_created_at.checked_add(Duration::new(1, 0)).unwrap();
 
         // the times of the rows of data. this will create overlapping windows where persistable
@@ -715,13 +725,17 @@ mod tests {
 
     #[test]
     fn flush_persistable_overlaps_open_and_closed() {
-        let mut w = PersistenceWindows::new(Duration::from_secs(120)).unwrap();
+        let mut w = PersistenceWindows::new(Duration::from_secs(120));
 
         // these instants represent when data is received by the server. Here we have a persistable
         // window followed by two closed windows.
         let created_at = Instant::now();
-        let second_created_at = created_at.checked_add(CLOSED_WINDOW_PERIOD * 3).unwrap();
-        let third_created_at = second_created_at.checked_add(CLOSED_WINDOW_PERIOD).unwrap();
+        let second_created_at = created_at
+            .checked_add(DEFAULT_CLOSED_WINDOW_PERIOD * 3)
+            .unwrap();
+        let third_created_at = second_created_at
+            .checked_add(DEFAULT_CLOSED_WINDOW_PERIOD)
+            .unwrap();
         let end_at = third_created_at.checked_add(Duration::new(1, 0)).unwrap();
 
         // the times of the rows of data. this will create overlapping windows where persistable

--- a/mutable_buffer/src/persistence_windows.rs
+++ b/mutable_buffer/src/persistence_windows.rs
@@ -28,11 +28,7 @@ pub struct PersistenceWindows {
 
 impl PersistenceWindows {
     pub fn new(late_arrival_period: Duration) -> Self {
-        let closed_window_period = if late_arrival_period > DEFAULT_CLOSED_WINDOW_PERIOD {
-            DEFAULT_CLOSED_WINDOW_PERIOD
-        } else {
-            late_arrival_period
-        };
+        let closed_window_period = late_arrival_period.min(DEFAULT_CLOSED_WINDOW_PERIOD);
 
         let late_arrival_seconds = late_arrival_period.as_secs();
         let closed_window_seconds = closed_window_period.as_secs();

--- a/server/src/db.rs
+++ b/server/src/db.rs
@@ -171,11 +171,6 @@ pub enum Error {
 
     #[snafu(display("error finding min/max time on table batch: {}", source))]
     TableBatchTimeError { source: entry::Error },
-
-    #[snafu(display("error creating persistence windows: {}", source))]
-    PersistenceWindowsError {
-        source: mutable_buffer::persistence_windows::Error,
-    },
 }
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
@@ -1032,8 +1027,7 @@ impl Db {
                             );
                         }
                         None => {
-                            let mut windows = PersistenceWindows::new(late_arrival_window)
-                                .context(PersistenceWindowsError)?;
+                            let mut windows = PersistenceWindows::new(late_arrival_window);
                             windows.add_range(
                                 sequenced_entry.as_ref().sequence(),
                                 row_count,

--- a/server/src/db.rs
+++ b/server/src/db.rs
@@ -10,7 +10,7 @@ use std::{
         atomic::{AtomicUsize, Ordering},
         Arc,
     },
-    time::Duration,
+    time::{Duration, Instant},
 };
 
 use arrow::datatypes::SchemaRef as ArrowSchemaRef;
@@ -38,6 +38,7 @@ use entry::{Entry, SequencedEntry};
 use internal_types::{arrow::sort::sort_record_batch, selection::Selection};
 use metrics::{KeyValue, MetricRegistry};
 use mutable_buffer::chunk::{ChunkMetrics as MutableBufferChunkMetrics, MBChunk};
+use mutable_buffer::persistence_windows::PersistenceWindows;
 use object_store::{path::parsed::DirsAndFileName, ObjectStore};
 use observability_deps::tracing::{debug, error, info, warn};
 use parquet_file::catalog::CheckpointData;
@@ -167,6 +168,14 @@ pub enum Error {
 
     #[snafu(display("background task cancelled: {}", source))]
     TaskCancelled { source: futures::future::Aborted },
+
+    #[snafu(display("error finding min/max time on table batch: {}", source))]
+    TableBatchTimeError { source: entry::Error },
+
+    #[snafu(display("error creating persistence windows: {}", source))]
+    PersistenceWindowsError {
+        source: mutable_buffer::persistence_windows::Error,
+    },
 }
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
@@ -929,6 +938,7 @@ impl Db {
         let mutable_size_threshold = rules.lifecycle_rules.mutable_size_threshold;
         let immutable = rules.lifecycle_rules.immutable;
         let buffer_size_hard = rules.lifecycle_rules.buffer_size_hard;
+        let late_arrival_window = rules.lifecycle_rules.late_arrive_window();
         std::mem::drop(rules);
 
         // We may have gotten here through `store_entry`, in which case this is checking the
@@ -947,7 +957,9 @@ impl Db {
             for write in partitioned_writes {
                 let partition_key = write.key();
                 for table_batch in write.table_batches() {
-                    if table_batch.row_count() == 0 {
+                    let row_count = table_batch.row_count();
+
+                    if row_count == 0 {
                         continue;
                     }
 
@@ -957,6 +969,9 @@ impl Db {
 
                     let mut partition = partition.write();
                     partition.update_last_write_at();
+
+                    let (min_time, max_time) =
+                        table_batch.min_max_time().context(TableBatchTimeError)?;
 
                     match partition.open_chunk() {
                         Some(chunk) => {
@@ -1005,6 +1020,30 @@ impl Db {
                             check_chunk_closed(&mut *new_chunk.write(), mutable_size_threshold);
                         }
                     };
+
+                    match partition.persistence_windows() {
+                        Some(windows) => {
+                            windows.add_range(
+                                sequenced_entry.as_ref().sequence(),
+                                row_count,
+                                min_time,
+                                max_time,
+                                Instant::now(),
+                            );
+                        }
+                        None => {
+                            let mut windows = PersistenceWindows::new(late_arrival_window)
+                                .context(PersistenceWindowsError)?;
+                            windows.add_range(
+                                sequenced_entry.as_ref().sequence(),
+                                row_count,
+                                min_time,
+                                max_time,
+                                Instant::now(),
+                            );
+                            partition.set_persistence_windows(windows);
+                        }
+                    }
                 }
             }
         }
@@ -2004,6 +2043,26 @@ mod tests {
             let partition = partition.read();
             assert!(last_write_prev < partition.last_write_at());
         }
+    }
+
+    #[tokio::test]
+    async fn write_updates_persistence_windows() {
+        let db = Arc::new(make_db().await.db);
+
+        let now = Utc::now().timestamp_nanos() as u64;
+
+        let partition_key = "1970-01-01T00";
+        write_lp(&db, "cpu bar=1 10").await;
+
+        let later = Utc::now().timestamp_nanos() as u64;
+
+        let partition = db.catalog.partition("cpu", partition_key).unwrap();
+        let mut partition = partition.write();
+        let windows = partition.persistence_windows().unwrap();
+        let seq = windows.minimum_unpersisted_sequence().unwrap();
+
+        let seq = seq.get(&1).unwrap();
+        assert!(now < seq.min && later > seq.min);
     }
 
     #[tokio::test]

--- a/server/src/db/catalog/partition.rs
+++ b/server/src/db/catalog/partition.rs
@@ -16,6 +16,7 @@ use super::chunk::{CatalogChunk, ChunkStage};
 use data_types::chunk_metadata::{ChunkAddr, ChunkSummary};
 use internal_types::schema::Schema;
 use lifecycle::ChunkLifecycleAction;
+use mutable_buffer::persistence_windows::PersistenceWindows;
 use snafu::Snafu;
 
 #[derive(Debug, Snafu)]
@@ -64,6 +65,9 @@ pub struct Partition {
 
     /// Partition metrics
     metrics: PartitionMetrics,
+
+    /// Ingest tracking for persisting data from memory to Parquet
+    persistence_windows: Option<PersistenceWindows>,
 }
 
 impl Partition {
@@ -88,6 +92,7 @@ impl Partition {
             last_write_at: now,
             next_chunk_id: 0,
             metrics,
+            persistence_windows: None,
         }
     }
 
@@ -299,5 +304,13 @@ impl Partition {
 
     pub fn metrics(&self) -> &PartitionMetrics {
         &self.metrics
+    }
+
+    pub fn persistence_windows(&mut self) -> Option<&mut PersistenceWindows> {
+        self.persistence_windows.as_mut()
+    }
+
+    pub fn set_persistence_windows(&mut self, windows: PersistenceWindows) {
+        self.persistence_windows = Some(windows);
     }
 }


### PR DESCRIPTION
This brings the persistence windows into the catalog partition. It adds a helper method on TableBatch to get the min and max times for a given write. Finally, it adds this logic to the db to update persistence windows on every write while the partition write lock is being held.