### PR TITLE
chore: Reduce debug logging in query crate

### DIFF
--- a/query/src/exec/seriesset.rs
+++ b/query/src/exec/seriesset.rs
@@ -27,7 +27,7 @@ use arrow::{
 };
 use datafusion::physical_plan::SendableRecordBatchStream;
 
-use observability_deps::tracing::debug;
+use observability_deps::tracing::trace;
 use snafu::{ResultExt, Snafu};
 use std::sync::Arc;
 use tokio::sync::mpsc::error::SendError;
@@ -313,7 +313,7 @@ impl SeriesSetConverter {
         // for now, always treat the last row as ending a series
         bitmap.add(num_rows as u32);
 
-        debug!(
+        trace!(
             rows = ?bitmap.to_vec(),
             ?col_idx,
             "row transitions for results"

--- a/query/src/provider/deduplicate/algo.rs
+++ b/query/src/provider/deduplicate/algo.rs
@@ -12,7 +12,7 @@ use arrow::{
 use datafusion::physical_plan::{
     coalesce_batches::concat_batches, expressions::PhysicalSortExpr, PhysicalExpr, SQLMetric,
 };
-use observability_deps::tracing::debug;
+use observability_deps::tracing::trace;
 
 // Handles the deduplication across potentially multiple
 // [`RecordBatch`]es which are already sorted on a primary key,
@@ -141,10 +141,10 @@ impl RecordBatchDeduplicator {
 
         // Special case when no ranges are duplicated (so just emit input as output)
         if num_dupes == 0 {
-            debug!(num_rows = batch.num_rows(), "No dupes");
+            trace!(num_rows = batch.num_rows(), "No dupes");
             Self::slice_record_batch(&batch, 0, ranges.len())
         } else {
-            debug!(num_dupes, num_rows = batch.num_rows(), "dupes");
+            trace!(num_dupes, num_rows = batch.num_rows(), "dupes");
 
             // Use take kernel
             let sort_key_indices = self.compute_sort_key_indices(&ranges);

--- a/query/src/pruning.rs
+++ b/query/src/pruning.rs
@@ -34,7 +34,7 @@ where
     O: PruningObserver<Observed = P>,
 {
     let num_chunks = summaries.len();
-    debug!(num_chunks, %predicate, "Pruning chunks");
+    trace!(num_chunks, %predicate, "Pruning chunks");
 
     let filter_expr = match predicate.filter_expr() {
         Some(expr) => expr,
@@ -55,6 +55,7 @@ where
 
     let num_remaining_chunks = pruned_summaries.len();
     debug!(
+        %predicate,
         num_chunks,
         num_pruned_chunks = num_chunks - num_remaining_chunks,
         num_remaining_chunks,


### PR DESCRIPTION
# Rationale
We recently had a log-aplosion when `debug` logging was enabled due to the high volume of spew. We have reduced the logging level so debug is not generated anymore but @e-dard notes it is useful to maintain the ability to have some debug information.

# Changes
Reduce several `debug!` calls to `trace!` to reduce said spew
