### PR TITLE
refactor: only rebuild a single txn for pres. catalogs

### DIFF
--- a/parquet_file/src/rebuild.rs
+++ b/parquet_file/src/rebuild.rs
@@ -1,9 +1,5 @@
 //! Contains code to rebuild a catalog from files.
-use std::{
-    collections::{hash_map::Entry, HashMap},
-    fmt::Debug,
-    sync::Arc,
-};
+use std::{fmt::Debug, sync::Arc};
 
 use data_types::server_id::ServerId;
 use futures::TryStreamExt;
@@ -13,11 +9,10 @@ use object_store::{
 };
 use observability_deps::tracing::error;
 use snafu::{ResultExt, Snafu};
-use uuid::Uuid;
 
 use crate::{
-    catalog::{CatalogParquetInfo, CatalogState, CheckpointData, PreservedCatalog},
-    metadata::{IoxMetadata, IoxParquetMetaData},
+    catalog::{CatalogParquetInfo, CatalogState, PreservedCatalog},
+    metadata::IoxParquetMetaData,
 };
 #[derive(Debug, Snafu)]
 pub enum Error {
@@ -32,24 +27,6 @@ pub enum Error {
         source: crate::metadata::Error,
         path: Path,
     },
-
-    #[snafu(display(
-        "Found multiple transaction for revision {}: {} and {}",
-        revision_counter,
-        uuid1,
-        uuid2
-    ))]
-    MultipleTransactionsFailure {
-        revision_counter: u64,
-        uuid1: Uuid,
-        uuid2: Uuid,
-    },
-
-    #[snafu(display(
-        "Internal error: Revision cannot be zero (this transaction is always empty): {:?}",
-        path
-    ))]
-    RevisionZeroFailure { path: Path },
 
     #[snafu(display("Cannot add file to transaction: {}", source))]
     FileRecordFailure { source: crate::catalog::Error },
@@ -67,32 +44,25 @@ pub type Result<T, E = Error> = std::result::Result<T, E>;
 /// Users are required to [wipe](PreservedCatalog::wipe) the existing catalog before running this
 /// procedure (**after creating a backup!**).
 ///
-/// This will create a catalog checkpoint for the very last transaction.
-///
 /// # Limitations
 /// Compared to an intact catalog, wiping a catalog and rebuilding it from Parquet files has the following drawbacks:
 ///
 /// - **Garbage Susceptibility:** The rebuild process will stumble over garbage parquet files (i.e. files being present
 ///   in the object store but that were not part of the catalog). For files that where not written by IOx it will likely
-///   report [`Error::MetadataReadFailure`]. For files that are left-overs from previous transactions it will likely
-///   report [`Error::MultipleTransactionsFailure`]. Crafted files (i.e. files with the correct metadata and matching
-///   transaction UUIDs) will blindly be included into the new catalog, because we have no way to distinguish them from
-///   the actual catalog content.
+///   report [`Error::MetadataReadFailure`].
 /// - **No Removals:** The rebuild system cannot recover the fact that files where removed from the catalog during some
 ///   transaction. This might not always be an issue due to "deduplicate while read"-logic in the query engine, but also
 ///   might have unwanted side effects (e.g. performance issues).
+/// - **Single Transaction:** All files are added in a single transaction. Hence time-traveling is NOT possible using
+///   the resulting catalog.
+/// - **Fork Detection:** The rebuild procedure does NOT detects forks (i.e. files written for the same server ID by
+///   multiple IOx instances).
 ///
 /// # Error Handling
 /// This routine will fail if:
 ///
 /// - **Metadata Read Failure:** There is a parquet file with metadata that cannot be read. Set
 ///   `ignore_metadata_read_failure` to `true` to ignore these cases.
-/// - **Parquet With Revision Zero:** One of the parquet files reports it belongs to revision `0`. This should never
-///   happen since the first transaction is always an empty one. This was likely causes by a bug or a file created by
-///   3rd party tooling.
-/// - **Multiple Transactions:** If there are multiple transaction with the same revision but different UUIDs, this
-///   routine cannot reconstruct a single linear revision history. Make sure to
-//    [clean up](crate::cleanup::cleanup_unreferenced_parquet_files) regularly to avoid this case.
 pub async fn rebuild_catalog<S>(
     object_store: Arc<ObjectStore>,
     search_location: &Path,
@@ -105,8 +75,7 @@ where
     S: CatalogState + Debug + Send + Sync,
 {
     // collect all revisions from parquet files
-    let mut revisions =
-        collect_revisions(&object_store, search_location, ignore_metadata_read_failure).await?;
+    let files = collect_files(&object_store, search_location, ignore_metadata_read_failure).await?;
 
     // create new empty catalog
     let (catalog, mut state) = PreservedCatalog::new_empty::<S>(
@@ -118,56 +87,25 @@ where
     .await
     .context(NewEmptyFailure)?;
 
-    // trace all files for final checkpoint
-    let mut collected_files = HashMap::new();
-
-    // simulate all transactions
-    if let Some(max_revision) = revisions.keys().max().cloned() {
-        for revision_counter in 1..=max_revision {
-            assert_eq!(
-                catalog.revision_counter() + 1,
-                revision_counter,
-                "revision counter during transaction simulation out-of-sync"
-            );
-
-            if let Some((uuid, entries)) = revisions.remove(&revision_counter) {
-                // we have files for this particular transaction
-                let mut transaction = catalog.open_transaction_with_uuid(uuid).await;
-                for (path, metadata) in entries {
-                    let path: DirsAndFileName = path.clone().into();
-
-                    state
-                        .add(
-                            Arc::clone(&object_store),
-                            CatalogParquetInfo {
-                                path: path.clone(),
-                                metadata: Arc::new(metadata.clone()),
-                            },
-                        )
-                        .context(FileRecordFailure)?;
-                    transaction
-                        .add_parquet(&path, &metadata)
-                        .context(FileRecordFailure)?;
-                    collected_files.insert(path, Arc::new(metadata));
-                }
-
-                let ckpt_handle = transaction.commit().await.context(CommitFailure)?;
-                if revision_counter == max_revision {
-                    ckpt_handle
-                        .create_checkpoint(CheckpointData {
-                            files: collected_files.clone(),
-                        })
-                        .await
-                        .context(CommitFailure)?;
-                }
-            } else {
-                // we do not have any files for this transaction (there might have been other actions though or it was
-                // an empty transaction) => create new empty transaction
-                // Note that this can never be the last transaction, so we don't need to create a checkpoint here.
-                let transaction = catalog.open_transaction().await;
-                transaction.commit().await.context(CheckpointFailure)?;
-            }
+    // create single transaction with all files
+    if !files.is_empty() {
+        let mut transaction = catalog.open_transaction().await;
+        for (path, parquet_md) in files {
+            let path: DirsAndFileName = path.into();
+            state
+                .add(
+                    Arc::clone(&object_store),
+                    CatalogParquetInfo {
+                        path: path.clone(),
+                        metadata: Arc::new(parquet_md.clone()),
+                    },
+                )
+                .context(FileRecordFailure)?;
+            transaction
+                .add_parquet(&path, &parquet_md)
+                .context(FileRecordFailure)?;
         }
+        transaction.commit().await.context(CheckpointFailure)?;
     }
 
     Ok((catalog, state))
@@ -175,70 +113,37 @@ where
 
 /// Collect all files under the given locations.
 ///
-/// Returns a map of revisions to their UUIDs and a vector of file-metadata tuples.
+/// Returns a vector of file-metadata tuples.
 ///
 /// The file listing is recursive.
-async fn collect_revisions(
+async fn collect_files(
     object_store: &ObjectStore,
     search_location: &Path,
     ignore_metadata_read_failure: bool,
-) -> Result<HashMap<u64, (Uuid, Vec<(Path, IoxParquetMetaData)>)>> {
+) -> Result<Vec<(Path, IoxParquetMetaData)>> {
     let mut stream = object_store
         .list(Some(search_location))
         .await
         .context(ReadFailure)?;
 
-    // revision -> (uuid, [file])
-    let mut revisions: HashMap<u64, (Uuid, Vec<(Path, IoxParquetMetaData)>)> = HashMap::new();
+    let mut files: Vec<(Path, IoxParquetMetaData)> = vec![];
 
     while let Some(paths) = stream.try_next().await.context(ReadFailure)? {
         for path in paths.into_iter().filter(is_parquet) {
-            let (iox_md, parquet_md) = match read_parquet(object_store, &path).await {
-                Ok(res) => res,
+            match read_parquet(object_store, &path).await {
+                Ok(parquet_md) => {
+                    files.push((path, parquet_md));
+                }
                 Err(e @ Error::MetadataReadFailure { .. }) if ignore_metadata_read_failure => {
                     error!("error while reading metdata from parquet, ignoring: {}", e);
                     continue;
                 }
                 Err(e) => return Err(e),
             };
-
-            // revision 0 can never occur because it is always empty
-            if iox_md.transaction_revision_counter == 0 {
-                return Err(Error::RevisionZeroFailure { path });
-            }
-
-            match revisions.entry(iox_md.transaction_revision_counter) {
-                Entry::Vacant(v) => {
-                    // revision not known yet => create it
-                    v.insert((iox_md.transaction_uuid, vec![(path, parquet_md)]));
-                }
-                Entry::Occupied(mut o) => {
-                    // already exist => check UUID
-                    let (uuid, entries) = o.get_mut();
-
-                    if *uuid != iox_md.transaction_uuid {
-                        // found multiple transactions for this revision => cannot rebuild cleanly
-
-                        // sort UUIDs for deterministic error messages
-                        let (uuid1, uuid2) = if *uuid < iox_md.transaction_uuid {
-                            (*uuid, iox_md.transaction_uuid)
-                        } else {
-                            (iox_md.transaction_uuid, *uuid)
-                        };
-                        return Err(Error::MultipleTransactionsFailure {
-                            revision_counter: iox_md.transaction_revision_counter,
-                            uuid1,
-                            uuid2,
-                        });
-                    }
-
-                    entries.push((path, parquet_md));
-                }
-            }
         }
     }
 
-    Ok(revisions)
+    Ok(files)
 }
 
 /// Checks if the given path is (likely) a parquet file.
@@ -252,10 +157,7 @@ fn is_parquet(path: &Path) -> bool {
 }
 
 /// Read Parquet and IOx metadata from given path.
-async fn read_parquet(
-    object_store: &ObjectStore,
-    path: &Path,
-) -> Result<(IoxMetadata, IoxParquetMetaData)> {
+async fn read_parquet(object_store: &ObjectStore, path: &Path) -> Result<IoxParquetMetaData> {
     let data = object_store
         .get(path)
         .await
@@ -267,10 +169,13 @@ async fn read_parquet(
 
     let parquet_metadata = IoxParquetMetaData::from_file_bytes(data)
         .context(MetadataReadFailure { path: path.clone() })?;
-    let iox_metadata = parquet_metadata
+
+    // validate IOxMetadata
+    parquet_metadata
         .read_iox_metadata()
         .context(MetadataReadFailure { path: path.clone() })?;
-    Ok((iox_metadata, parquet_metadata))
+
+    Ok(parquet_metadata)
 }
 
 #[cfg(test)]
@@ -280,10 +185,12 @@ mod tests {
     use datafusion_util::MemoryStream;
     use parquet::arrow::ArrowWriter;
     use tokio_stream::StreamExt;
+    use uuid::Uuid;
 
     use super::*;
     use std::num::NonZeroU32;
 
+    use crate::metadata::IoxMetadata;
     use crate::{catalog::test_helpers::TestCatalogState, storage::MemWriter};
     use crate::{
         catalog::PreservedCatalog,
@@ -397,7 +304,7 @@ mod tests {
             tmp
         };
         assert_eq!(paths_actual, paths_expected);
-        assert_eq!(catalog.revision_counter(), 3);
+        assert_eq!(catalog.revision_counter(), 1);
     }
 
     #[tokio::test]
@@ -438,111 +345,6 @@ mod tests {
         // check match
         assert!(state.parquet_files.is_empty());
         assert_eq!(catalog.revision_counter(), 0);
-    }
-
-    #[tokio::test]
-    async fn test_rebuild_fail_transaction_zero() {
-        let object_store = make_object_store();
-        let server_id = make_server_id();
-        let db_name = "db1";
-
-        // build catalog with same data
-        let catalog = PreservedCatalog::new_empty::<TestCatalogState>(
-            Arc::clone(&object_store),
-            server_id,
-            db_name.to_string(),
-            (),
-        )
-        .await
-        .unwrap();
-
-        // file with illegal revision counter (zero is always an empty transaction)
-        create_parquet_file(&object_store, server_id, db_name, 0, Uuid::new_v4(), 0).await;
-
-        // wipe catalog
-        drop(catalog);
-        PreservedCatalog::wipe(&object_store, server_id, db_name)
-            .await
-            .unwrap();
-
-        // rebuild
-        let path = object_store.new_path();
-        let res = rebuild_catalog::<TestCatalogState>(
-            object_store,
-            &path,
-            server_id,
-            db_name.to_string(),
-            (),
-            false,
-        )
-        .await;
-        assert!(dbg!(res.unwrap_err().to_string()).starts_with(
-            "Internal error: Revision cannot be zero (this transaction is always empty):"
-        ));
-    }
-
-    #[tokio::test]
-    async fn test_rebuild_fail_duplicate_transaction_uuid() {
-        let object_store = make_object_store();
-        let server_id = make_server_id();
-        let db_name = "db1";
-
-        // build catalog with same data
-        let (catalog, _state) = PreservedCatalog::new_empty::<TestCatalogState>(
-            Arc::clone(&object_store),
-            server_id,
-            db_name.to_string(),
-            (),
-        )
-        .await
-        .unwrap();
-        {
-            let mut transaction = catalog.open_transaction().await;
-
-            let (path, md) = create_parquet_file(
-                &object_store,
-                server_id,
-                db_name,
-                transaction.revision_counter(),
-                transaction.uuid(),
-                0,
-            )
-            .await;
-            transaction.add_parquet(&path, &md).unwrap();
-
-            // create parquet file with wrong UUID
-            create_parquet_file(
-                &object_store,
-                server_id,
-                db_name,
-                transaction.revision_counter(),
-                Uuid::new_v4(),
-                1,
-            )
-            .await;
-
-            transaction.commit().await.unwrap();
-        }
-
-        // wipe catalog
-        drop(catalog);
-        PreservedCatalog::wipe(&object_store, server_id, db_name)
-            .await
-            .unwrap();
-
-        // rebuild
-        let path = object_store.new_path();
-        let res = rebuild_catalog::<TestCatalogState>(
-            object_store,
-            &path,
-            server_id,
-            db_name.to_string(),
-            (),
-            false,
-        )
-        .await;
-        assert!(dbg!(res.unwrap_err().to_string())
-            .starts_with("Found multiple transaction for revision 1:"));
     }
 
     #[tokio::test]
@@ -600,13 +402,14 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_rebuild_creates_file_checkpoint() {
+    async fn test_rebuild_creates_no_checkpoint() {
+        // there is no need to create a checkpoint for the single transaction that we will have
         let object_store = make_object_store();
         let server_id = make_server_id();
         let db_name = "db1";
 
         // build catalog with some data (2 transactions + initial empty one)
-        let (catalog, mut state) = PreservedCatalog::new_empty::<TestCatalogState>(
+        let (catalog, _state) = PreservedCatalog::new_empty::<TestCatalogState>(
             Arc::clone(&object_store),
             server_id,
             db_name.to_string(),
@@ -614,52 +417,7 @@ mod tests {
         )
         .await
         .unwrap();
-        {
-            let mut transaction = catalog.open_transaction().await;
-
-            let (path, md) = create_parquet_file(
-                &object_store,
-                server_id,
-                db_name,
-                transaction.revision_counter(),
-                transaction.uuid(),
-                0,
-            )
-            .await;
-            state
-                .parquet_files
-                .insert(path.clone(), Arc::new(md.clone()));
-            transaction.add_parquet(&path, &md).unwrap();
-
-            transaction.commit().await.unwrap();
-        }
-        {
-            let mut transaction = catalog.open_transaction().await;
-
-            let (path, md) = create_parquet_file(
-                &object_store,
-                server_id,
-                db_name,
-                transaction.revision_counter(),
-                transaction.uuid(),
-                2,
-            )
-            .await;
-            state
-                .parquet_files
-                .insert(path.clone(), Arc::new(md.clone()));
-            transaction.add_parquet(&path, &md).unwrap();
-
-            transaction.commit().await.unwrap();
-        }
-        assert_eq!(catalog.revision_counter(), 2);
-
-        // store catalog state
-        let paths_expected = {
-            let mut tmp: Vec<_> = state.parquet_files.keys().cloned().collect();
-            tmp.sort();
-            tmp
-        };
+        assert_eq!(catalog.revision_counter(), 0);
 
         // wipe catalog
         drop(catalog);
@@ -702,25 +460,12 @@ mod tests {
         }
         assert!(deleted);
 
-        // load catalog
-        let (catalog, state) = PreservedCatalog::load::<TestCatalogState>(
-            Arc::clone(&object_store),
-            server_id,
-            db_name.to_string(),
-            (),
-        )
-        .await
-        .unwrap()
-        .unwrap();
-
-        // check match
-        let paths_actual = {
-            let mut tmp: Vec<_> = state.parquet_files.keys().cloned().collect();
-            tmp.sort();
-            tmp
-        };
-        assert_eq!(paths_actual, paths_expected);
-        assert_eq!(catalog.revision_counter(), 2);
+        // catalog gone
+        assert!(
+            !PreservedCatalog::exists(&object_store, server_id, db_name,)
+                .await
+                .unwrap()
+        );
     }
 
     /// Creates new test server ID

--- a/parquet_file/src/rebuild.rs
+++ b/parquet_file/src/rebuild.rs
@@ -403,7 +403,13 @@ mod tests {
 
     #[tokio::test]
     async fn test_rebuild_creates_no_checkpoint() {
-        // there is no need to create a checkpoint for the single transaction that we will have
+        // the rebuild method will create a catalog with the following transactions:
+        // 1. an empty one (done by `PreservedCatalog::new_empty`)
+        // 2. an "add all the files"
+        //
+        // There is no real need to create a checkpoint in this case. So here we delete all transaction files and then
+        // check that rebuilt catalog will be gone afterwards. Note the difference to the `test_rebuild_empty` case
+        // where we can indeed proof the existence of a catalog (even though it is empty aka has no files).
         let object_store = make_object_store();
         let server_id = make_server_id();
         let db_name = "db1";


### PR DESCRIPTION
Stop relying on in-parquet transaction information during catalog
rebuilds. This has some downsides (no fork detection, only a single
transaction hence no time travel) but will allow that we remove
transaction information from parquet files, so that we can finally move
the actual parquet file storage out of the transaction lock.

This will help with #1821.
