### PR TITLE
refactor: improve locking around the parquet file cleanup

### DIFF
--- a/parquet_file/src/cleanup.rs
+++ b/parquet_file/src/cleanup.rs
@@ -102,7 +102,7 @@ pub async fn get_unreferenced_parquet_files(
 
     info!(
         n_files = to_remove.len(),
-        "Found files to delete, start deletion."
+        "Found files to delete"
     );
 
     Ok(to_remove)

--- a/parquet_file/src/cleanup.rs
+++ b/parquet_file/src/cleanup.rs
@@ -48,8 +48,7 @@ pub type Result<T, E = Error> = std::result::Result<T, E>;
 /// To limit the time the exclusive access is required use `max_files` which will limit the number of files to be
 /// detected in this cleanup round.
 ///
-/// The exclusive access can be downgraded to shared access after this method returned and before calling
-/// [`delete_files`].
+/// The exclusive access can be dropped after this method returned and before calling [`delete_files`].
 pub async fn get_unreferenced_parquet_files(
     catalog: &PreservedCatalog,
     max_files: usize,


### PR DESCRIPTION
Instead of (ab)using the transaction lock to prevent the cleanup job
from removing just-written parquet files, use a dedicated lock. This
will later allow us to write parquet files before starting a transaction
(i.e. w/o holding the transaction lock).

This will help with #1821.
