### PR TITLE
fix: Do not sequence local writes (avoid panic under load)

### DIFF
--- a/entry/src/entry.rs
+++ b/entry/src/entry.rs
@@ -1241,8 +1241,9 @@ pub enum SequencedEntryError {
 #[derive(Debug)]
 pub struct SequencedEntry {
     entry: Entry,
-    // Sequences may not be present when IOx has no serialization
-    // mechanism
+    /// The (optional) sequence for this entry.  At the time of
+    /// writing, sequences will not be present when there is no
+    /// configured mechanism to define the order of all writes.
     sequence: Option<Sequence>,
 }
 

--- a/entry/src/entry.rs
+++ b/entry/src/entry.rs
@@ -1253,6 +1253,15 @@ pub struct Sequence {
     pub number: u64,
 }
 
+impl Sequence {
+    pub fn new(sequencer_id: u32, sequence_number: u64) -> Self {
+        Self {
+            id: sequencer_id,
+            number: sequence_number,
+        }
+    }
+}
+
 impl SequencedEntry {
     pub fn new_from_process_clock(
         process_clock: ClockValue,

--- a/mutable_buffer/src/chunk.rs
+++ b/mutable_buffer/src/chunk.rs
@@ -106,12 +106,7 @@ impl MBChunk {
     /// Write the contents of a [`TableBatch`] into this Chunk.
     ///
     /// Panics if the batch specifies a different name for the table in this Chunk
-    pub fn write_table_batch(
-        &mut self,
-        sequencer_id: u32,
-        sequence_number: u64,
-        batch: TableBatch<'_>,
-    ) -> Result<()> {
+    pub fn write_table_batch(&mut self, batch: TableBatch<'_>) -> Result<()> {
         let table_name = batch.name();
         assert_eq!(
             table_name,
@@ -120,7 +115,7 @@ impl MBChunk {
         );
 
         let columns = batch.columns();
-        self.write_columns(sequencer_id, sequence_number, columns)?;
+        self.write_columns(columns)?;
 
         // Invalidate chunk snapshot
         *self
@@ -273,12 +268,7 @@ impl MBChunk {
 
     /// Validates the schema of the passed in columns, then adds their values to
     /// the associated columns in the table and updates summary statistics.
-    pub fn write_columns(
-        &mut self,
-        _sequencer_id: u32,
-        _sequence_number: u64,
-        columns: Vec<entry::Column<'_>>,
-    ) -> Result<()> {
+    pub fn write_columns(&mut self, columns: Vec<entry::Column<'_>>) -> Result<()> {
         let row_count_before_insert = self.rows();
         let additional_rows = columns.first().map(|x| x.row_count).unwrap_or_default();
         let final_row_count = row_count_before_insert + additional_rows;
@@ -357,7 +347,7 @@ pub mod test_helpers {
             );
 
             for batch in table_batches {
-                chunk.write_table_batch(1, 5, batch)?;
+                chunk.write_table_batch(batch)?;
             }
         }
 
@@ -596,15 +586,11 @@ mod tests {
     #[test]
     fn write_columns_validates_schema() {
         let mut table = MBChunk::new("table_name", ChunkMetrics::new_unregistered());
-        let sequencer_id = 1;
-        let sequence_number = 5;
 
         let lp = "foo,t1=asdf iv=1i,uv=1u,fv=1.0,bv=true,sv=\"hi\" 1";
         let entry = lp_to_entry(&lp);
         table
             .write_columns(
-                sequencer_id,
-                sequence_number,
                 entry
                     .partition_writes()
                     .unwrap()
@@ -621,8 +607,6 @@ mod tests {
         let entry = lp_to_entry(&lp);
         let response = table
             .write_columns(
-                sequencer_id,
-                sequence_number,
                 entry
                     .partition_writes()
                     .unwrap()
@@ -654,8 +638,6 @@ mod tests {
         let entry = lp_to_entry(&lp);
         let response = table
             .write_columns(
-                sequencer_id,
-                sequence_number,
                 entry
                     .partition_writes()
                     .unwrap()
@@ -687,8 +669,6 @@ mod tests {
         let entry = lp_to_entry(&lp);
         let response = table
             .write_columns(
-                sequencer_id,
-                sequence_number,
                 entry
                     .partition_writes()
                     .unwrap()
@@ -720,8 +700,6 @@ mod tests {
         let entry = lp_to_entry(&lp);
         let response = table
             .write_columns(
-                sequencer_id,
-                sequence_number,
                 entry
                     .partition_writes()
                     .unwrap()
@@ -753,8 +731,6 @@ mod tests {
         let entry = lp_to_entry(&lp);
         let response = table
             .write_columns(
-                sequencer_id,
-                sequence_number,
                 entry
                     .partition_writes()
                     .unwrap()
@@ -786,8 +762,6 @@ mod tests {
         let entry = lp_to_entry(&lp);
         let response = table
             .write_columns(
-                sequencer_id,
-                sequence_number,
                 entry
                     .partition_writes()
                     .unwrap()
@@ -828,7 +802,7 @@ mod tests {
             .unwrap()
             .table_batches()
         {
-            table.write_columns(1, 5, batch.columns()).unwrap();
+            table.write_columns(batch.columns()).unwrap();
         }
     }
 }

--- a/server/src/db.rs
+++ b/server/src/db.rs
@@ -1954,7 +1954,6 @@ mod tests {
         let windows = partition.persistence_windows().unwrap();
         let seq = windows.minimum_unpersisted_sequence().unwrap();
 
-        println!("Seq: {:#?}", seq);
         let seq = seq.get(&0).unwrap();
         assert_eq!(seq, &MinMaxSequence { min: 0, max: 2 });
     }

--- a/server/src/db/catalog.rs
+++ b/server/src/db/catalog.rs
@@ -350,7 +350,7 @@ mod tests {
             mutable_buffer::chunk::ChunkMetrics::new_unregistered(),
         );
 
-        mb_chunk.write_table_batch(1, 5, batch).unwrap();
+        mb_chunk.write_table_batch(batch).unwrap();
 
         partition.create_open_chunk(mb_chunk);
     }

--- a/server/src/db/catalog.rs
+++ b/server/src/db/catalog.rs
@@ -334,7 +334,7 @@ impl Catalog {
 
 #[cfg(test)]
 mod tests {
-    use entry::test_helpers::lp_to_entry;
+    use entry::{test_helpers::lp_to_entry, Sequence};
 
     use super::*;
 
@@ -350,7 +350,10 @@ mod tests {
             mutable_buffer::chunk::ChunkMetrics::new_unregistered(),
         );
 
-        mb_chunk.write_table_batch(batch).unwrap();
+        let sequence = Some(Sequence::new(1, 5));
+        mb_chunk
+            .write_table_batch(sequence.as_ref(), batch)
+            .unwrap();
 
         partition.create_open_chunk(mb_chunk);
     }

--- a/server/src/db/catalog/chunk.rs
+++ b/server/src/db/catalog/chunk.rs
@@ -906,12 +906,12 @@ mod tests {
         );
     }
 
-    fn make_mb_chunk(table_name: &str, sequencer_id: u32) -> MBChunk {
+    fn make_mb_chunk(table_name: &str, _sequencer_id: u32) -> MBChunk {
         let mut mb_chunk = MBChunk::new(table_name, MBChunkMetrics::new_unregistered());
         let entry = lp_to_entry(&format!("{} bar=1 10", table_name));
         let write = entry.partition_writes().unwrap().remove(0);
         let batch = write.table_batches().remove(0);
-        mb_chunk.write_table_batch(sequencer_id, 1, batch).unwrap();
+        mb_chunk.write_table_batch(batch).unwrap();
         mb_chunk
     }
 

--- a/server/src/db/catalog/chunk.rs
+++ b/server/src/db/catalog/chunk.rs
@@ -819,7 +819,7 @@ impl CatalogChunk {
 
 #[cfg(test)]
 mod tests {
-    use entry::test_helpers::lp_to_entry;
+    use entry::{test_helpers::lp_to_entry, Sequence};
     use mutable_buffer::chunk::{ChunkMetrics as MBChunkMetrics, MBChunk};
     use parquet_file::{
         chunk::ParquetChunk,
@@ -906,12 +906,15 @@ mod tests {
         );
     }
 
-    fn make_mb_chunk(table_name: &str, _sequencer_id: u32) -> MBChunk {
+    fn make_mb_chunk(table_name: &str, sequencer_id: u32) -> MBChunk {
         let mut mb_chunk = MBChunk::new(table_name, MBChunkMetrics::new_unregistered());
         let entry = lp_to_entry(&format!("{} bar=1 10", table_name));
         let write = entry.partition_writes().unwrap().remove(0);
         let batch = write.table_batches().remove(0);
-        mb_chunk.write_table_batch(batch).unwrap();
+        let sequence = Some(Sequence::new(sequencer_id, 1));
+        mb_chunk
+            .write_table_batch(sequence.as_ref(), batch)
+            .unwrap();
         mb_chunk
     }
 

--- a/server/src/db/process_clock.rs
+++ b/server/src/db/process_clock.rs
@@ -27,6 +27,7 @@ impl ProcessClock {
     ///
     /// We expect that updates to the process clock are not so frequent and the system is slow
     /// enough that the returned value will be incremented by at least 1.
+    #[allow(dead_code)]
     pub fn next(&self) -> ClockValue {
         let next = loop {
             if let Ok(next) = self.try_update() {
@@ -37,6 +38,7 @@ impl ProcessClock {
         ClockValue::try_from(next).expect("process clock should not be 0")
     }
 
+    #[allow(dead_code)]
     fn try_update(&self) -> Result<u64, u64> {
         let now = system_clock_now();
         let current_process_clock = self.inner.load(Ordering::SeqCst);

--- a/server/src/write_buffer.rs
+++ b/server/src/write_buffer.rs
@@ -121,6 +121,8 @@ pub mod test_helpers {
             let offset = entries.len() as u64;
             entries.push(entry.clone());
 
+            println!("Sequencing offset {}", offset);
+
             Ok(Sequence {
                 id: 0,
                 number: offset,

--- a/server/src/write_buffer.rs
+++ b/server/src/write_buffer.rs
@@ -121,8 +121,6 @@ pub mod test_helpers {
             let offset = entries.len() as u64;
             entries.push(entry.clone());
 
-            println!("Sequencing offset {}", offset);
-
             Ok(Sequence {
                 id: 0,
                 number: offset,

--- a/server_benchmarks/benches/snapshot.rs
+++ b/server_benchmarks/benches/snapshot.rs
@@ -22,7 +22,7 @@ fn chunk(count: usize) -> MBChunk {
         for entry in lp_to_entries(&lp) {
             for write in entry.partition_writes().iter().flatten() {
                 for batch in write.table_batches() {
-                    chunk.write_table_batch(1, 5, batch).unwrap();
+                    chunk.write_table_batch(batch).unwrap();
                 }
             }
         }

--- a/server_benchmarks/benches/snapshot.rs
+++ b/server_benchmarks/benches/snapshot.rs
@@ -1,5 +1,5 @@
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
-use entry::test_helpers::lp_to_entries;
+use entry::{test_helpers::lp_to_entries, Sequence};
 use flate2::read::GzDecoder;
 use mutable_buffer::chunk::{ChunkMetrics, MBChunk};
 use std::io::Read;
@@ -18,11 +18,12 @@ fn chunk(count: usize) -> MBChunk {
     let mut lp = String::new();
     gz.read_to_string(&mut lp).unwrap();
 
+    let sequence = Some(Sequence::new(1, 5));
     for _ in 0..count {
         for entry in lp_to_entries(&lp) {
             for write in entry.partition_writes().iter().flatten() {
                 for batch in write.table_batches() {
-                    chunk.write_table_batch(batch).unwrap();
+                    chunk.write_table_batch(sequence.as_ref(), batch).unwrap();
                 }
             }
         }

--- a/server_benchmarks/benches/write.rs
+++ b/server_benchmarks/benches/write.rs
@@ -13,7 +13,7 @@ fn write_chunk(count: usize, entries: &[Entry]) {
         for entry in entries {
             for write in entry.partition_writes().iter().flatten() {
                 for batch in write.table_batches() {
-                    chunk.write_table_batch(1, 5, batch).unwrap();
+                    chunk.write_table_batch(batch).unwrap();
                 }
             }
         }

--- a/server_benchmarks/benches/write.rs
+++ b/server_benchmarks/benches/write.rs
@@ -1,5 +1,5 @@
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
-use entry::{test_helpers::lp_to_entries, Entry};
+use entry::{test_helpers::lp_to_entries, Entry, Sequence};
 use flate2::read::GzDecoder;
 use mutable_buffer::chunk::{ChunkMetrics, MBChunk};
 use std::io::Read;
@@ -9,11 +9,12 @@ fn write_chunk(count: usize, entries: &[Entry]) {
     // m0 is hard coded into tag_values.lp.gz
     let mut chunk = MBChunk::new("m0", ChunkMetrics::new_unregistered());
 
+    let sequence = Some(Sequence::new(1, 5));
     for _ in 0..count {
         for entry in entries {
             for write in entry.partition_writes().iter().flatten() {
                 for batch in write.table_batches() {
-                    chunk.write_table_batch(batch).unwrap();
+                    chunk.write_table_batch(sequence.as_ref(), batch).unwrap();
                 }
             }
         }


### PR DESCRIPTION
# Rationale
Proposed fix for https://github.com/influxdata/influxdb_iox/issues/1817

Aka `panic!` ala

```
level=error msg="thread \'tokio-runtime-worker\' panicked at \'assertion failed: sequence.number > n.max\', mutable_buffer/src/persistence_windows.rs:234:17" target="panic_logging" location="panic_logging/src/lib.rs:110" time=1624875128145767206
```

The problem is the code on master has nothing to ensure writes from the `write` endpoint are written in the same order as they are given sequence nubers. Since the persistence windows assume each write is performed in increasing order it asserts when they get out of order under load.

This is likely a temporary solution to get IOx on tools back to healthy.  When we implement a local write buffer (aka not kafka) we'll have to implement some sort of code that guarantees arrival ordering (to ensure writes to a partition go in order)

# Changes:
Disable sequencing for local writes



# Discussion / Reminder

(Note the partition lock is acquired immediately before writing into a partition, and released thereafter)

What is happening is that we get two writes each with data for two partitions, A and B

```
Write 1 arrives first, given sequence number 1 (A1, B1)
Write 2 arrives, given sequence number 2 (A2, B2)
```

(edit: *updated*) Now the inserts go something like:
```
Task1: Inserts A1
Task1: waits for lock for B
Task2: Inserts A2
Task2: Inserts B2
Task1: Inserts B1 (and gets a failure because that is earlier than 2) (updated)
```
