### PR TITLE
refactor: clarify intent of applying predicate to Chunk

### DIFF
--- a/query/src/frontend/influxrpc.rs
+++ b/query/src/frontend/influxrpc.rs
@@ -186,7 +186,7 @@ impl InfluxRpcPlanner {
         for chunk in database.chunks(&predicate) {
             // Try and apply the predicate using only metadata
             let pred_result = chunk
-                .apply_predicate(&predicate)
+                .apply_predicate_to_metadata(&predicate)
                 .map_err(|e| Box::new(e) as _)
                 .context(CheckingChunkPredicate {
                     chunk_id: chunk.id(),
@@ -241,7 +241,7 @@ impl InfluxRpcPlanner {
         for chunk in database.chunks(&predicate) {
             // Try and apply the predicate using only metadata
             let pred_result = chunk
-                .apply_predicate(&predicate)
+                .apply_predicate_to_metadata(&predicate)
                 .map_err(|e| Box::new(e) as _)
                 .context(CheckingChunkPredicate {
                     chunk_id: chunk.id(),
@@ -347,7 +347,7 @@ impl InfluxRpcPlanner {
         for chunk in database.chunks(&predicate) {
             // Try and apply the predicate using only metadata
             let pred_result = chunk
-                .apply_predicate(&predicate)
+                .apply_predicate_to_metadata(&predicate)
                 .map_err(|e| Box::new(e) as _)
                 .context(CheckingChunkPredicate {
                     chunk_id: chunk.id(),
@@ -628,7 +628,7 @@ impl InfluxRpcPlanner {
         for chunk in chunks {
             // Try and apply the predicate using only metadata
             let pred_result = chunk
-                .apply_predicate(&predicate)
+                .apply_predicate_to_metadata(&predicate)
                 .map_err(|e| Box::new(e) as _)
                 .context(CheckingChunkPredicate {
                     chunk_id: chunk.id(),

--- a/query/src/lib.rs
+++ b/query/src/lib.rs
@@ -85,7 +85,10 @@ pub trait QueryChunk: QueryChunkMeta + Debug + Send + Sync {
     /// NOTE: This method is suitable for calling during planning, and
     /// may return PredicateMatch::Unknown for certain types of
     /// predicates.
-    fn apply_predicate(&self, predicate: &Predicate) -> Result<PredicateMatch, Self::Error>;
+    fn apply_predicate_to_metadata(
+        &self,
+        predicate: &Predicate,
+    ) -> Result<PredicateMatch, Self::Error>;
 
     /// Returns a set of Strings with column names from the specified
     /// table that have at least one row that matches `predicate`, if

--- a/query/src/test.rs
+++ b/query/src/test.rs
@@ -742,7 +742,7 @@ impl QueryChunk for TestChunk {
         false
     }
 
-    fn apply_predicate(&self, predicate: &Predicate) -> Result<PredicateMatch> {
+    fn apply_predicate_to_metadata(&self, predicate: &Predicate) -> Result<PredicateMatch> {
         self.check_error()?;
 
         // save the predicate

--- a/server/src/db/chunk.rs
+++ b/server/src/db/chunk.rs
@@ -220,7 +220,7 @@ impl QueryChunk for DbChunk {
         true
     }
 
-    fn apply_predicate(&self, predicate: &Predicate) -> Result<PredicateMatch> {
+    fn apply_predicate_to_metadata(&self, predicate: &Predicate) -> Result<PredicateMatch> {
         if !predicate.should_include_table(self.table_name().as_ref()) {
             return Ok(PredicateMatch::Zero);
         }


### PR DESCRIPTION
I was working on catching up on some refactor issues I have for the Read Buffer. One of those was to replace `table_names` in the Read Buffer with something more suitable to a Read Buffer chunk with only one table in it.

As part of that I was reviewing the code that calls `table_names` and got confused by the expected semantics of `apply predicate`. After a bit it became appararent that this was intended to only analyse meta-data.

This PR renames the method on the trait just to make it a bit clearer with the expectation that it might make sense to add a future method like `chunk_satisfies_predicate` or similar that will actually determine if there exists at least one row satisfying the predicate. This would then be useful for the `table_names` implementation. 