### PR TITLE
feat: print operations on wait_for_chunk failure (#1809)

### DIFF
--- a/tests/end_to_end_cases/persistence.rs
+++ b/tests/end_to_end_cases/persistence.rs
@@ -263,13 +263,10 @@ async fn wait_for_chunk(
             );
         }
 
-        assert!(
-            t_start.elapsed() < wait_time,
-            "Could not find chunk in desired state {:?} within {:?}. Chunks were: {:#?}",
-            desired_storage,
-            wait_time,
-            chunks
-        );
+        if t_start.elapsed() >= wait_time {
+            let operations = fixture.operations_client().list_operations().await.unwrap();
+            panic!("Could not find chunk in desired state {:?} within {:?}.\nChunks were: {:#?}\nOperations were: {:#?}", desired_storage, wait_time, chunks, operations)
+        }
 
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
     }


### PR DESCRIPTION
To help with debugging #1809, which I can't reproduce locally, it would be beneficial to dump the state of any in-progress lifecycle actions on failure
