### PR TITLE
chore: improve wait_for_chunk failure output

### DIFF
--- a/influxdb_iox_client/src/client/operations.rs
+++ b/influxdb_iox_client/src/client/operations.rs
@@ -165,8 +165,8 @@ impl ClientOperation {
     }
 
     /// Return name of this operation
-    pub fn name(&self) -> String {
-        self.inner.name.clone()
+    pub fn name(&self) -> &str {
+        &self.inner.name
     }
 
     /// Return the inner's Operation

--- a/tests/end_to_end_cases/persistence.rs
+++ b/tests/end_to_end_cases/persistence.rs
@@ -265,6 +265,12 @@ async fn wait_for_chunk(
 
         if t_start.elapsed() >= wait_time {
             let operations = fixture.operations_client().list_operations().await.unwrap();
+            let mut operations: Vec<_> = operations
+                .into_iter()
+                .map(|x| (x.name().parse::<usize>().unwrap(), x.metadata()))
+                .collect();
+            operations.sort_by_key(|x| x.0);
+
             panic!("Could not find chunk in desired state {:?} within {:?}.\nChunks were: {:#?}\nOperations were: {:#?}", desired_storage, wait_time, chunks, operations)
         }
 


### PR DESCRIPTION
Improves the logging added by #1833 to render the internal protobuf and print the operations in order. Serves me right for not testing this properly :facepalm: 