### PR TITLE
refactor: write parquet files w/o holding the transaction lock

### DIFF
--- a/parquet_file/src/catalog.rs
+++ b/parquet_file/src/catalog.rs
@@ -31,7 +31,7 @@ use uuid::Uuid;
 /// Current version for serialized transactions.
 ///
 /// For breaking changes, this will change.
-pub const TRANSACTION_VERSION: u32 = 4;
+pub const TRANSACTION_VERSION: u32 = 5;
 
 /// File suffix for transaction files in object store.
 pub const TRANSACTION_FILE_SUFFIX: &str = "txn";

--- a/parquet_file/src/metadata.rs
+++ b/parquet_file/src/metadata.rs
@@ -88,6 +88,7 @@
 //! [Thrift Compact Protocol]: https://github.com/apache/thrift/blob/master/doc/specs/thrift-compact-protocol.md
 use std::{convert::TryInto, sync::Arc};
 
+use chrono::{DateTime, Utc};
 use data_types::partition_metadata::{
     ColumnSummary, InfluxDbType, StatValues, Statistics, TableSummary,
 };
@@ -108,7 +109,6 @@ use parquet::{
 use serde::{Deserialize, Serialize};
 use snafu::{OptionExt, ResultExt, Snafu};
 use thrift::protocol::{TCompactInputProtocol, TCompactOutputProtocol, TOutputProtocol};
-use uuid::Uuid;
 
 /// File-level metadata key to store the IOx-specific data.
 ///
@@ -217,11 +217,8 @@ pub type Result<T, E = Error> = std::result::Result<T, E>;
 #[allow(missing_copy_implementations)] // we want to extend this type in the future
 #[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq)]
 pub struct IoxMetadata {
-    /// Revision counter of the transaction during which the Parquet file was created.
-    pub transaction_revision_counter: u64,
-
-    /// UUID of the transaction during which the Parquet file was created.
-    pub transaction_uuid: Uuid,
+    /// Timestamp when this file was created.
+    pub creation_timestamp: DateTime<Utc>,
 
     /// Table that holds this parquet file.
     pub table_name: String,

--- a/parquet_file/src/storage.rs
+++ b/parquet_file/src/storage.rs
@@ -443,15 +443,14 @@ mod tests {
     use crate::test_utils::{make_object_store, make_record_batch};
     use arrow::array::{ArrayRef, StringArray};
     use arrow_util::assert_batches_eq;
+    use chrono::Utc;
     use datafusion::physical_plan::common::SizedRecordBatchStream;
     use datafusion_util::MemoryStream;
-    use uuid::Uuid;
 
     #[tokio::test]
     async fn test_parquet_contains_key_value_metadata() {
         let metadata = IoxMetadata {
-            transaction_revision_counter: 42,
-            transaction_uuid: Uuid::new_v4(),
+            creation_timestamp: Utc::now(),
             table_name: "table1".to_string(),
             partition_key: "part1".to_string(),
             chunk_id: 1337,
@@ -517,8 +516,7 @@ mod tests {
             vec![Arc::new(batch)],
         ));
         let metadata = IoxMetadata {
-            transaction_revision_counter: 42,
-            transaction_uuid: Uuid::new_v4(),
+            creation_timestamp: Utc::now(),
             table_name: table_name.to_string(),
             partition_key: partition_key.to_string(),
             chunk_id,

--- a/parquet_file/src/test_utils.rs
+++ b/parquet_file/src/test_utils.rs
@@ -8,6 +8,7 @@ use arrow::{
     datatypes::{Int32Type, SchemaRef},
     record_batch::RecordBatch,
 };
+use chrono::{TimeZone, Utc};
 use datafusion::physical_plan::SendableRecordBatchStream;
 
 use data_types::{
@@ -25,7 +26,6 @@ use parquet::{
     arrow::{ArrowReader, ParquetFileArrowReader},
     file::serialized_reader::{SerializedFileReader, SliceableCursor},
 };
-use uuid::Uuid;
 
 use crate::{
     chunk::ChunkMetrics,
@@ -147,8 +147,7 @@ pub async fn make_chunk_given_record_batch(
         Box::pin(MemoryStream::new(record_batches))
     };
     let metadata = IoxMetadata {
-        transaction_revision_counter: 0,
-        transaction_uuid: Uuid::nil(),
+        creation_timestamp: Utc.timestamp(10, 20),
         table_name: addr.table_name.to_string(),
         partition_key: addr.partition_key.to_string(),
         chunk_id: addr.chunk_id,


### PR DESCRIPTION
Closes #1821.
