### PR TITLE
perf: optimise table_names when using Read Buffer chunks

### DIFF
--- a/query/src/lib.rs
+++ b/query/src/lib.rs
@@ -90,6 +90,16 @@ pub trait QueryChunk: QueryChunkMeta + Debug + Send + Sync {
         predicate: &Predicate,
     ) -> Result<PredicateMatch, Self::Error>;
 
+    /// Returns the result of applying the `predicate` to the chunk
+    /// using a precise method by finding at least one row that satisfies the
+    /// predicate. The main advantage of `satisfies_predicate` is to know that
+    /// there exists row data satisfying a predicate without having to
+    /// materialise it.
+    ///
+    /// Implementations should return `PredicateMatch::Unknown` if they are
+    /// unable to fully apply a predicate.
+    fn satisfies_predicate(&self, predicate: &Predicate) -> PredicateMatch;
+
     /// Returns a set of Strings with column names from the specified
     /// table that have at least one row that matches `predicate`, if
     /// the predicate can be evaluated entirely on the metadata of

--- a/query/src/test.rs
+++ b/query/src/test.rs
@@ -796,6 +796,10 @@ impl QueryChunk for TestChunk {
 
         Ok(column_names)
     }
+
+    fn satisfies_predicate(&self, predicate: &Predicate) -> PredicateMatch {
+        todo!()
+    }
 }
 
 impl QueryChunkMeta for TestChunk {

--- a/query_tests/src/influxrpc/table_names.rs
+++ b/query_tests/src/influxrpc/table_names.rs
@@ -1,4 +1,5 @@
 //! Tests for the Influx gRPC queries
+use datafusion::logical_plan::{col, lit};
 use query::{
     exec::stringset::{IntoStringSet, StringSetRef},
     frontend::influxrpc::InfluxRpcPlanner,


### PR DESCRIPTION
This PR is a proposed performance bump to the `table_names` API used by the Influx meta query that shows matching measurements.

This PR utilises the Read Buffer's ability to determine if rows satisfy a predicate without having to materialise those rows. It does this by using the Read Buffer's internal API for working directly on compressed representations of the columnar data.

The PR is currently in draft at the moment however as it looks like there is no way yet for us to run a general plan against a chunk in order to determine if it has rows matching a predicate. 
