### PR TITLE
chore: print end-to-end output

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -120,15 +120,37 @@ RUST_LOG=debug,hyper::proto::h1=info,h2=info cargo test --workspace
 
 ### End-to-End Tests
 
-There are end-to-end tests that spin up a server and make requests via the client library and API. 
-These aren't run via the `cargo test --workspace` command. 
-They can be found in `tests/end_to_end_cases` and can be run with:
+There are end-to-end tests that spin up a server and make requests via the client library and API. They can be found in `tests/end_to_end_cases` 
+
+They are run by `cargo test --workspace` command but can be run exclusively with:
+
 ```
 cargo test --test end-to-end
 ``` 
-If you are debugging a failing end-to-end test, you'll likely want to see what's happening by running it like so:
+
+Each server writes its logs to a temporary file and this is printed to stdout on shutdown, bypassing the default test log capturing. 
+
+If you are debugging a failing end-to-end test, you will likely want to run with `--nocapture` to also get the logs from the test execution in addition to the server:
+
 ```
 cargo test --test end-to-end -- my_failing_test --nocapture
+```
+
+If running multiple tests in parallel:
+
+* The output may be interleaved
+* Multiple tests may share the same server instance
+
+When debugging a failing test it is therefore recommended you run a single test, or disable parallel test execution
+
+```
+cargo test --test end-to-end -- --test-threads 1
+```
+
+Finally, if you wish to increase the verbosity of the server logging, you can set `LOG_FILTER` as you would for a normal IOx instance.
+
+```
+env LOG_FILTER=debug cargo test --package influxdb_iox --test end-to-end end_to_end_cases::operations_api::test_operations -- --nocapture
 ```
 
 ### Visually showing explain plans

--- a/tests/common/server_fixture.rs
+++ b/tests/common/server_fixture.rs
@@ -1,6 +1,6 @@
-use assert_cmd::prelude::*;
+use std::sync::Arc;
+use std::time::Duration;
 use std::{
-    fs::OpenOptions,
     path::Path,
     process::{Child, Command},
     str,
@@ -11,9 +11,11 @@ use std::{
     time::Instant,
 };
 
+use assert_cmd::prelude::*;
 use futures::prelude::*;
-use std::time::Duration;
-use tempfile::TempDir;
+use once_cell::sync::OnceCell;
+use tempfile::{NamedTempFile, TempDir};
+use tokio::sync::Mutex;
 
 // These port numbers are chosen to not collide with a development ioxd server
 // running locally.
@@ -23,9 +25,6 @@ static NEXT_PORT: AtomicUsize = AtomicUsize::new(8090);
 
 /// This structure contains all the addresses a test server should use
 pub struct BindAddresses {
-    http_port: usize,
-    grpc_port: usize,
-
     http_bind_addr: String,
     grpc_bind_addr: String,
 
@@ -58,8 +57,6 @@ impl Default for BindAddresses {
         let grpc_base = format!("http://{}", grpc_bind_addr);
 
         Self {
-            http_port,
-            grpc_port,
             http_bind_addr,
             grpc_bind_addr,
             http_base,
@@ -70,11 +67,6 @@ impl Default for BindAddresses {
 }
 
 const TOKEN: &str = "InfluxDB IOx doesn't have authentication yet";
-
-use std::sync::Arc;
-
-use once_cell::sync::OnceCell;
-use tokio::sync::Mutex;
 
 /// Represents a server that has been started and is available for
 /// testing.
@@ -259,7 +251,7 @@ struct TestServer {
     ready: Mutex<ServerState>,
 
     /// Handle to the server process being controlled
-    server_process: Mutex<Child>,
+    server_process: Mutex<Process>,
 
     /// Which ports this server should use
     addrs: BindAddresses,
@@ -267,6 +259,11 @@ struct TestServer {
     // The temporary directory **must** be last so that it is
     // dropped after the database closes.
     dir: TempDir,
+}
+
+struct Process {
+    child: Child,
+    log_path: Box<Path>,
 }
 
 impl TestServer {
@@ -289,40 +286,41 @@ impl TestServer {
     async fn restart(&self) {
         let mut ready_guard = self.ready.lock().await;
         let mut server_process = self.server_process.lock().await;
-        server_process.kill().unwrap();
-        server_process.wait().unwrap();
+        server_process.child.kill().unwrap();
+        server_process.child.wait().unwrap();
         *server_process = Self::create_server_process(&self.addrs, &self.dir);
         *ready_guard = ServerState::Started;
     }
 
-    fn create_server_process(addrs: &BindAddresses, dir: &TempDir) -> Child {
-        // Make a log file in the temporary dir (don't auto delete it to help debugging
-        // efforts)
-        let mut log_path = std::env::temp_dir();
-        log_path.push(format!(
-            "server_fixture_{}_{}.log",
-            addrs.http_port, addrs.grpc_port
-        ));
-
-        println!("****************");
-        println!("Server Logging to {:?}", log_path);
-        println!("****************");
-        let log_file = OpenOptions::new()
-            .append(true)
-            .create(true)
-            .open(log_path)
-            .expect("Opening log file");
+    fn create_server_process(addrs: &BindAddresses, dir: &TempDir) -> Process {
+        // Create a new file each time and keep it around to aid debugging
+        let (log_file, log_path) = NamedTempFile::new()
+            .expect("opening log file")
+            .keep()
+            .expect("expected to keep");
 
         let stdout_log_file = log_file
             .try_clone()
             .expect("cloning file handle for stdout");
         let stderr_log_file = log_file;
 
-        Command::cargo_bin("influxdb_iox")
+        println!("****************");
+        println!(
+            "Server {} Logging to {:?}",
+            addrs.http_bind_addr(),
+            log_path
+        );
+        println!("****************");
+
+        // If set in test environment, use that value, else default to info
+        let log_filter = std::env::var("LOG_FILTER").unwrap_or("info".to_string());
+
+        // This will inherit environment from the test runner
+        // in particular `LOG_FILTER`
+        let child = Command::cargo_bin("influxdb_iox")
             .unwrap()
             .arg("run")
-            // Run in high verbosity debugging
-            .arg("-vv")
+            .env("LOG_FILTER", log_filter)
             .env("INFLUXDB_IOX_OBJECT_STORE", "file")
             .env("INFLUXDB_IOX_DB_DIR", dir.path())
             .env("INFLUXDB_IOX_BIND_ADDR", addrs.http_bind_addr())
@@ -331,7 +329,12 @@ impl TestServer {
             .stdout(stdout_log_file)
             .stderr(stderr_log_file)
             .spawn()
-            .unwrap()
+            .unwrap();
+
+        Process {
+            child,
+            log_path: log_path.into_boxed_path(),
+        }
     }
 
     async fn wait_until_ready(&self, initial_config: InitialConfig) {
@@ -501,10 +504,40 @@ impl std::fmt::Display for TestServer {
 
 impl Drop for TestServer {
     fn drop(&mut self) {
-        self.server_process
+        use std::io::{Read, Write};
+
+        let mut server_lock = self
+            .server_process
             .try_lock()
-            .expect("should be able to get a server process lock")
+            .expect("should be able to get a server process lock");
+
+        server_lock
+            .child
             .kill()
             .expect("Should have been able to kill the test server");
+
+        server_lock
+            .child
+            .wait()
+            .expect("Should have been able to wait for shutdown");
+
+        let mut out = std::io::stdout();
+        let mut f = std::fs::File::open(&server_lock.log_path).expect("failed to open log file");
+        let mut buffer = [0_u8; 8 * 1024];
+
+        writeln!(out, "****************").unwrap();
+        writeln!(out, "Start TestServer Output").unwrap();
+        writeln!(out, "****************").unwrap();
+
+        while let Ok(read) = f.read(&mut buffer) {
+            if read == 0 {
+                break;
+            }
+            out.write_all(&buffer[..read]).unwrap();
+        }
+
+        writeln!(out, "****************").unwrap();
+        writeln!(out, "End TestServer Output").unwrap();
+        writeln!(out, "****************").unwrap();
     }
 }

--- a/tests/common/server_fixture.rs
+++ b/tests/common/server_fixture.rs
@@ -313,7 +313,7 @@ impl TestServer {
         println!("****************");
 
         // If set in test environment, use that value, else default to info
-        let log_filter = std::env::var("LOG_FILTER").unwrap_or("info".to_string());
+        let log_filter = std::env::var("LOG_FILTER").unwrap_or_else(|_| "info".to_string());
 
         // This will inherit environment from the test runner
         // in particular `LOG_FILTER`


### PR DESCRIPTION
This makes a couple of changes to the end-to-end logging setup to help with debugging #1809 in particular

1. Each new server is given its own named temporary log file
2. On server shutdown it prints the output of the server
3. The default log level is `info` but it will respect `LOG_FILTER` in the environment

Together these should make it easier to debug end-to-end test failures in general, but in particular in CI - where currently there is no easy way to get at the server output.

Regarding the new temporary files, on Linux system-tmpfiles will clean them up periodically (normally a day). I'm not sure about OS X, but given we weren't truncating the logs before this should be no worse than before in terms of total file footprint.

Example output might be

```
****************
Server 127.0.0.1:8090 Logging to "/tmp/.tmpkSrizE"
****************
Waiting for HTTP server to be up: error sending request for url (http://127.0.0.1:8090/health): error trying to connect: tcp connect error: Connection refused (os error 111)
Waiting for gRPC API to be up: Connection error: transport error: error trying to connect: tcp connect error: Connection refused (os error 111)
Waiting for HTTP server to be up: error sending request for url (http://127.0.0.1:8090/health): error trying to connect: tcp connect error: Connection refused (os error 111)
Waiting for gRPC API to be up: Connection error: transport error: error trying to connect: tcp connect error: Connection refused (os error 111)
Successfully connected to server
Successfully got a response from HTTP: Response { url: Url { scheme: "http", cannot_be_a_base: false, username: "", password: None, host: Some(Ipv4(127.0.0.1)), port: Some(8090), path: "/health", query: None, fragment: None }, status: 200, headers: {"x-powered-by": "Routerify v2.0.0-beta-2", "content-length": "2", "date": "Tue, 29 Jun 2021 13:46:36 GMT"} }
Storage service is running
Successfully started TestServer (grpc http://127.0.0.1:8091, http http://127.0.0.1:8090)
****************
Start TestServer Output
****************
Jun 29 14:46:35.669  INFO influxdb_iox::influxdb_ioxd: InfluxDB IOx server starting git_hash="e04f75dea2f50a807dc93ed8d2a04ea6337ced3b" num_cpus=32 build_malloc_conf="\u{0}"
Jun 29 14:46:35.670  INFO influxdb_iox::influxdb_ioxd: Using File for object storage
Jun 29 14:46:35.670  WARN influxdb_iox::influxdb_ioxd: server ID not set. ID must be set via the INFLUXDB_IOX_ID config or API before writing or querying data.
Jun 29 14:46:35.671  INFO influxdb_iox::influxdb_ioxd: gRPC server listening bind_address=127.0.0.1:8091
Jun 29 14:46:35.671  INFO influxdb_iox::influxdb_ioxd: HTTP server listening bind_address=127.0.0.1:8090
Jun 29 14:46:35.671  INFO influxdb_iox::influxdb_ioxd: InfluxDB IOx server ready git_hash="e04f75dea2f50a807dc93ed8d2a04ea6337ced3b"
Jun 29 14:46:35.694  INFO server_worker: server: started background worker
****************
End TestServer Output
****************
test end_to_end_cases::operations_api::test_operations ... ok
```

NB: This does nothing to prevent interleaved output, this was a problem before and will continue to be a problem. Without support within the cargo test harness itself for this, I'm not sure how this can be avoided when running tests in parallel.