### PR TITLE
fix: do not print test output to logs except on failure

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -120,15 +120,15 @@ RUST_LOG=debug,hyper::proto::h1=info,h2=info cargo test --workspace
 
 ### End-to-End Tests
 
-There are end-to-end tests that spin up a server and make requests via the client library and API. They can be found in `tests/end_to_end_cases` 
+There are end-to-end tests that spin up a server and make requests via the client library and API. They can be found in `tests/end_to_end_cases`
 
 They are run by `cargo test --workspace` command but can be run exclusively with:
 
 ```
 cargo test --test end-to-end
-``` 
+```
 
-Each server writes its logs to a temporary file and this is printed to stdout on shutdown, bypassing the default test log capturing. 
+Each server writes its logs to a temporary file and this is captured when the server shutsdown.
 
 If you are debugging a failing end-to-end test, you will likely want to run with `--nocapture` to also get the logs from the test execution in addition to the server:
 
@@ -139,7 +139,7 @@ cargo test --test end-to-end -- my_failing_test --nocapture
 If running multiple tests in parallel:
 
 * The output may be interleaved
-* Multiple tests may share the same server instance
+* Multiple tests may share the same server instance and thus the server logs may be captured in the output of a different test than the one that is failing.
 
 When debugging a failing test it is therefore recommended you run a single test, or disable parallel test execution
 

--- a/tests/common/server_fixture.rs
+++ b/tests/common/server_fixture.rs
@@ -504,7 +504,7 @@ impl std::fmt::Display for TestServer {
 
 impl Drop for TestServer {
     fn drop(&mut self) {
-        use std::io::{Read, Write};
+        use std::io::Read;
 
         let mut server_lock = self
             .server_process
@@ -521,23 +521,29 @@ impl Drop for TestServer {
             .wait()
             .expect("Should have been able to wait for shutdown");
 
-        let mut out = std::io::stdout();
         let mut f = std::fs::File::open(&server_lock.log_path).expect("failed to open log file");
         let mut buffer = [0_u8; 8 * 1024];
 
-        writeln!(out, "****************").unwrap();
-        writeln!(out, "Start TestServer Output").unwrap();
-        writeln!(out, "****************").unwrap();
+        println!("****************");
+        println!("Start TestServer Output");
+        println!("****************");
 
         while let Ok(read) = f.read(&mut buffer) {
             if read == 0 {
                 break;
             }
-            out.write_all(&buffer[..read]).unwrap();
+            if let Ok(str) = std::str::from_utf8(&buffer[..read]) {
+                print!("{}", str);
+            } else {
+                println!(
+                    "\n\n-- ERROR IN TRANSFER -- please see {:?} for raw contents ---\n\n",
+                    &server_lock.log_path
+                );
+            }
         }
 
-        writeln!(out, "****************").unwrap();
-        writeln!(out, "End TestServer Output").unwrap();
-        writeln!(out, "****************").unwrap();
+        println!("****************");
+        println!("End TestServer Output");
+        println!("****************");
     }
 }


### PR DESCRIPTION
Turn off so much logging

# Rationale:
After https://github.com/influxdata/influxdb_iox/pull/1838 was merged, when I run `cargo test --all` logs of INFO logging is spewed to my screen during the end to end tests even when there is no failure:

```
****************
Start TestServer Output
****************
Jun 29 15:58:23.605  INFO influxdb_iox::influxdb_ioxd: InfluxDB IOx server starting git_hash="f04835eaea3fd0c9892b1c39a47d415186537636" num_cpus=16 build_malloc_conf="\u{0}"
Jun 29 15:58:23.606  INFO influxdb_iox::influxdb_ioxd: Using File for object storage
Jun 29 15:58:23.608  WARN influxdb_iox::influxdb_ioxd: server ID not set. ID must be set via the INFLUXDB_IOX_ID config or API before writing or querying data.
Jun 29 15:58:23.609  INFO influxdb_iox::influxdb_ioxd: gRPC server listening bind_address=127.0.0.1:8105
Jun 29 15:58:23.609  INFO influxdb_iox::influxdb_ioxd: HTTP server listening bind_address=127.0.0.1:8104
Jun 29 15:58:23.609  INFO influxdb_iox::influxdb_ioxd: InfluxDB IOx server ready git_hash="f04835eaea3fd0c9892b1c39a47d415186537636"
Jun 29 15:58:23.659  INFO server_worker: server: started background worker
Jun 29 15:58:23.677  INFO influxdb_iox::influxdb_ioxd: InfluxDB IOx server starting git_hash="f04835eaea3fd0c9892b1c39a47d415186537636" num_cpus=16 build_malloc_conf="\u{0}"
Jun 29 15:58:23.678  INFO influxdb_iox::influxdb_ioxd: Using File for object storage
Jun 29 15:58:23.680  WARN influxdb_iox::influxdb_ioxd: server ID not set. ID must be set via the INFLUXDB_IOX_ID config or API before writing or querying data.
Jun 29 15:58:23.681  INFO influxdb_iox::influxdb_ioxd: gRPC server listening bind_address=127.0.0.1:8115
Jun 29 15:58:23.681  INFO influxdb_iox::influxdb_ioxd: HTTP server listening bind_address=127.0.0.1:8114
Jun 29 15:58:23.681  INFO influxdb_iox::influxdb_ioxd: InfluxDB IOx server ready git_hash="f04835eaea3fd0c9892b1c39a47d415186537636"
Jun 29 15:58:23.726  INFO server_worker: server: started background worker
```

This behavior annoys me.

# Changes
1. Only print to output that the rust test runner captures (apparently it doesn't redirect the process wide stdout):
```
cd /Users/alamb/Software/influxdb_iox2 && cargo test --test end-to-end -- flight_api::test --nocapture
    Finished test [unoptimized + debuginfo] target(s) in 0.38s
     Running tests/end-to-end.rs (target/debug/deps/end_to_end-ddd920388df7c21d)

running 2 tests
****************
Server 127.0.0.1:8090 Logging to "/var/folders/s3/h5hgj43j0bv83shtmz_t_w400000gn/T/.tmpZARXwB"
****************
Waiting for HTTP server to be up: error sending request for url (http://127.0.0.1:8090/health): error trying to connect: tcp connect error: Connection refused (os error 61)
Waiting for gRPC API to be up: Connection error: transport error: error trying to connect: tcp connect error: Connection refused (os error 61)
Waiting for HTTP server to be up: error sending request for url (http://127.0.0.1:8090/health): error trying to connect: tcp connect error: Connection refused (os error 61)
Waiting for gRPC API to be up: Connection error: transport error: error trying to connect: tcp connect error: Connection refused (os error 61)
Successfully connected to server
Successfully got a response from HTTP: Response { url: Url { scheme: "http", cannot_be_a_base: false, username: "", password: None, host: Some(Ipv4(127.0.0.1)), port: Some(8090), path: "/health", query: None, fragment: None }, status: 200, headers: {"x-powered-by": "Routerify v2.0.0-beta-2", "content-length": "2", "date": "Tue, 29 Jun 2021 20:37:10 GMT"} }
Storage service is running
Successfully started TestServer (grpc http://127.0.0.1:8091, http http://127.0.0.1:8090)
Set writer_id to 42
Databases loaded
test end_to_end_cases::flight_api::test_no_rows ... ok
****************
Start TestServer Output
****************
Jun 29 16:37:09.978  INFO influxdb_iox::influxdb_ioxd: InfluxDB IOx server starting git_hash="fe713de7bf6bce93b68018fc2fbcaf4e556514a7" num_cpus=16 build_malloc_conf="\u{0}"
Jun 29 16:37:09.979  INFO influxdb_iox::influxdb_ioxd: Using File for object storage
Jun 29 16:37:09.980  WARN influxdb_iox::influxdb_ioxd: server ID not set. ID must be set via the INFLUXDB_IOX_ID config or API before writing or querying data.
Jun 29 16:37:09.981  INFO influxdb_iox::influxdb_ioxd: gRPC server listening bind_address=127.0.0.1:8091
Jun 29 16:37:09.981  INFO influxdb_iox::influxdb_ioxd: HTTP server listening bind_address=127.0.0.1:8090
Jun 29 16:37:09.981  INFO influxdb_iox::influxdb_ioxd: InfluxDB IOx server ready git_hash="fe713de7bf6bce93b68018fc2fbcaf4e556514a7"
Jun 29 16:37:10.015  INFO server_worker: server: started background worker
Jun 29 16:37:10.469  INFO server::init: server ID set server_id=42
Jun 29 16:37:11.019  INFO server_worker: server::init: loaded databases, server is initalized
Jun 29 16:37:11.483  INFO server::db::load: Found NO existing catalog for DB 4813865809387845_8216049791253145, creating new one
Jun 29 16:37:11.483  INFO server::db::load: Found NO existing catalog for DB Fr7TbZ4xOi, creating new one
Jun 29 16:37:11.483  INFO parquet_file::catalog: transaction started tkey=TransactionKey { revision_counter: 0, uuid: bdc9f4dc-6232-486b-9830-b6454967fcb1 }
Jun 29 16:37:11.483  INFO parquet_file::catalog: transaction started tkey=TransactionKey { revision_counter: 0, uuid: 50b9e245-d669-4d3c-9c05-9700100dab2b }
Jun 29 16:37:11.485  INFO parquet_file::catalog: transaction committed tkey=TransactionKey { revision_counter: 0, uuid: 50b9e245-d669-4d3c-9c05-9700100dab2b }
Jun 29 16:37:11.485  INFO parquet_file::catalog: transaction committed tkey=TransactionKey { revision_counter: 0, uuid: bdc9f4dc-6232-486b-9830-b6454967fcb1 }
Jun 29 16:37:11.485  INFO db_worker{database=Fr7TbZ4xOi}: server::db: started background worker
Jun 29 16:37:11.485  INFO db_worker{database=4813865809387845_8216049791253145}: server::db: started background worker
****************
End TestServer Output
****************
test end_to_end_cases::flight_api::test ... ok

```