### PR TITLE
feat: namespace issues in git-log-prs

### DIFF
--- a/scripts/git-log-prs
+++ b/scripts/git-log-prs
@@ -103,7 +103,7 @@ main() {
 
       local title=""
       if [ -n "${titles}" ]; then
-        title=$(get_title "${sha}" "${pr}")
+        title=$(get_title "${sha}" "${pr}" | sed 's;(#\([0-9]\+\));(influxdata/influxdb_iox#\1);g')
       fi
 
       local commit=""


### PR DESCRIPTION
Previously this script would print

```
'1825 fix: remove shared dictionary concept from ChunkSnapshot (#1570) (#1820)'
```

This would then get bundled into changelogs in other repositories, where these issues would refer to different things. I wasn't sure whether to fix this here or in the other repo, the sed expression can be applied in either.

The output would now be

```
1825 fix: remove shared dictionary concept from ChunkSnapshot (influxdata/influxdb_iox#1570) (influxdata/influxdb_iox#1820)
```