### PR TITLE
refactor: use protobuf for in-parquet metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2619,6 +2619,7 @@ version = "0.1.0"
 dependencies = [
  "arrow",
  "arrow_util",
+ "base64 0.13.0",
  "bytes",
  "chrono",
  "data_types",
@@ -2635,8 +2636,6 @@ dependencies = [
  "parquet-format",
  "prost",
  "query",
- "serde",
- "serde_json",
  "snafu",
  "tempfile",
  "test_helpers",

--- a/generated_types/build.rs
+++ b/generated_types/build.rs
@@ -38,6 +38,7 @@ fn generate_grpc_types(root: &Path) -> Result<()> {
         storage_path.join("storage_common_idpe.proto"),
         idpe_path.join("source.proto"),
         catalog_path.join("catalog.proto"),
+        catalog_path.join("parquet_metadata.proto"),
         management_path.join("base_types.proto"),
         management_path.join("database_rules.proto"),
         management_path.join("chunk.proto"),

--- a/generated_types/protos/influxdata/iox/catalog/v1/parquet_metadata.proto
+++ b/generated_types/protos/influxdata/iox/catalog/v1/parquet_metadata.proto
@@ -1,0 +1,22 @@
+syntax = "proto3";
+package influxdata.iox.catalog.v1;
+
+import "google/protobuf/timestamp.proto";
+
+// IOx-specific metadata that will be serialized into the file-level key-value Parquet metadata under a single key.
+message IoxMetadata {
+  // Metadata format version.
+  uint32 version = 1;
+
+  // Timestamp when this file was created.
+  google.protobuf.Timestamp creation_timestamp = 2;
+
+  // Table that holds this parquet file.
+  string table_name = 3;
+
+  // Partition key of the partition that holds this parquet file.
+  string partition_key = 4;
+
+  // Chunk ID.
+  uint32 chunk_id = 5;
+}

--- a/parquet_file/Cargo.toml
+++ b/parquet_file/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 
 [dependencies] # In alphabetical order
 arrow = { version = "4.0", features = ["prettyprint"] }
+base64 = "0.13"
 bytes = "1.0"
 chrono = "0.4"
 data_types = { path = "../data_types" }
@@ -24,8 +25,6 @@ parquet-format = "2.6"
 parking_lot = "0.11.1"
 prost = "0.7"
 query = { path = "../query" }
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
 snafu = "0.6"
 tempfile = "3.1.0"
 thrift = "0.13"

--- a/parquet_file/src/catalog.rs
+++ b/parquet_file/src/catalog.rs
@@ -31,7 +31,7 @@ use uuid::Uuid;
 /// Current version for serialized transactions.
 ///
 /// For breaking changes, this will change.
-pub const TRANSACTION_VERSION: u32 = 5;
+pub const TRANSACTION_VERSION: u32 = 6;
 
 /// File suffix for transaction files in object store.
 pub const TRANSACTION_FILE_SUFFIX: &str = "txn";


### PR DESCRIPTION
In preparation for more complex types (e.g. replay checkpoints).