### PR TITLE
refactor: single lifecycle error enumeration

### DIFF
--- a/lifecycle/src/lib.rs
+++ b/lifecycle/src/lib.rs
@@ -78,8 +78,7 @@ pub trait LifecycleDb {
 pub trait LockablePartition: Sized {
     type Partition: LifecyclePartition;
     type Chunk: LockableChunk;
-    type DropError: std::error::Error + Send + Sync;
-    type CompactError: std::error::Error + Send + Sync;
+    type Error: std::error::Error + Send + Sync;
 
     /// Acquire a shared read lock on the chunk
     fn read(&self) -> LifecycleReadGuard<'_, Self::Partition, Self>;
@@ -102,13 +101,13 @@ pub trait LockablePartition: Sized {
     fn compact_chunks(
         partition: LifecycleWriteGuard<'_, Self::Partition, Self>,
         chunks: Vec<LifecycleWriteGuard<'_, <Self::Chunk as LockableChunk>::Chunk, Self::Chunk>>,
-    ) -> Result<TaskTracker<<Self::Chunk as LockableChunk>::Job>, Self::CompactError>;
+    ) -> Result<TaskTracker<<Self::Chunk as LockableChunk>::Job>, Self::Error>;
 
     /// Drops a chunk from the partition
     fn drop_chunk(
         s: LifecycleWriteGuard<'_, Self::Partition, Self>,
         chunk_id: u32,
-    ) -> Result<(), Self::DropError>;
+    ) -> Result<(), Self::Error>;
 }
 
 /// A `LockableChunk` is a wrapper around a `LifecycleChunk` that allows for

--- a/lifecycle/src/policy.rs
+++ b/lifecycle/src/policy.rs
@@ -599,8 +599,7 @@ mod tests {
     impl<'a> LockablePartition for TestLockablePartition<'a> {
         type Partition = TestPartition;
         type Chunk = TestLockableChunk<'a>;
-        type DropError = Infallible;
-        type CompactError = Infallible;
+        type Error = Infallible;
 
         fn read(&self) -> LifecycleReadGuard<'_, Self::Partition, Self> {
             LifecycleReadGuard::new(self.clone(), &self.partition)
@@ -640,7 +639,7 @@ mod tests {
         fn compact_chunks(
             mut partition: LifecycleWriteGuard<'_, TestPartition, Self>,
             chunks: Vec<LifecycleWriteGuard<'_, TestChunk, Self::Chunk>>,
-        ) -> Result<TaskTracker<()>, Self::CompactError> {
+        ) -> Result<TaskTracker<()>, Self::Error> {
             let id = partition.next_id;
             partition.next_id += 1;
 
@@ -665,7 +664,7 @@ mod tests {
         fn drop_chunk(
             mut s: LifecycleWriteGuard<'_, Self::Partition, Self>,
             chunk_id: u32,
-        ) -> Result<(), Self::DropError> {
+        ) -> Result<(), Self::Error> {
             s.chunks.remove(&chunk_id);
             s.data().db.events.write().push(MoverEvents::Drop(chunk_id));
             Ok(())

--- a/server/src/db.rs
+++ b/server/src/db.rs
@@ -365,8 +365,8 @@ impl Db {
         chunk_id: u32,
     ) -> Result<Arc<DbChunk>> {
         let chunk = self.lockable_chunk(table_name, partition_key, chunk_id)?;
-        let (_, fut) = lifecycle::move_chunk_to_read_buffer(chunk.write())
-            .context(LifecycleError)?;
+        let (_, fut) =
+            lifecycle::move_chunk_to_read_buffer(chunk.write()).context(LifecycleError)?;
         fut.await.context(TaskCancelled)?.context(LifecycleError)
     }
 
@@ -379,8 +379,8 @@ impl Db {
         chunk_id: u32,
     ) -> Result<Arc<DbChunk>> {
         let chunk = self.lockable_chunk(table_name, partition_key, chunk_id)?;
-        let (_, fut) = lifecycle::write_chunk_to_object_store(chunk.write())
-            .context(LifecycleError)?;
+        let (_, fut) =
+            lifecycle::write_chunk_to_object_store(chunk.write()).context(LifecycleError)?;
         fut.await.context(TaskCancelled)?.context(LifecycleError)
     }
 

--- a/server/src/db.rs
+++ b/server/src/db.rs
@@ -70,7 +70,7 @@ pub enum Error {
     PartitionError { source: catalog::partition::Error },
 
     #[snafu(display("Lifecycle error: {}", source))]
-    LifecycleError { source: lifecycle::error::Error },
+    LifecycleError { source: lifecycle::Error },
 
     #[snafu(display("Error freeinzing chunk while rolling over partition: {}", source))]
     FreezingChunk { source: catalog::chunk::Error },
@@ -365,7 +365,7 @@ impl Db {
         chunk_id: u32,
     ) -> Result<Arc<DbChunk>> {
         let chunk = self.lockable_chunk(table_name, partition_key, chunk_id)?;
-        let (_, fut) = lifecycle::move_chunk::move_chunk_to_read_buffer_impl(chunk.write())
+        let (_, fut) = lifecycle::move_chunk_to_read_buffer(chunk.write())
             .context(LifecycleError)?;
         fut.await.context(TaskCancelled)?.context(LifecycleError)
     }
@@ -379,7 +379,7 @@ impl Db {
         chunk_id: u32,
     ) -> Result<Arc<DbChunk>> {
         let chunk = self.lockable_chunk(table_name, partition_key, chunk_id)?;
-        let (_, fut) = lifecycle::write::write_chunk_to_object_store_impl(chunk.write())
+        let (_, fut) = lifecycle::write_chunk_to_object_store(chunk.write())
             .context(LifecycleError)?;
         fut.await.context(TaskCancelled)?.context(LifecycleError)
     }
@@ -393,7 +393,7 @@ impl Db {
     ) -> Result<Arc<DbChunk>> {
         let chunk = self.lockable_chunk(table_name, partition_key, chunk_id)?;
         let chunk = chunk.write();
-        lifecycle::unload::unload_read_buffer_impl(chunk).context(LifecycleError)
+        lifecycle::unload_read_buffer_chunk(chunk).context(LifecycleError)
     }
 
     /// Return chunk summary information for all chunks in the specified

--- a/server/src/db/lifecycle/compact.rs
+++ b/server/src/db/lifecycle/compact.rs
@@ -5,44 +5,22 @@ use std::sync::Arc;
 
 use futures::StreamExt;
 use hashbrown::HashMap;
-use snafu::Snafu;
 
 use data_types::job::Job;
 use data_types::partition_metadata::{InfluxDbType, TableSummary};
 use internal_types::schema::sort::SortKey;
 use internal_types::schema::TIME_COLUMN_NAME;
 use lifecycle::LifecycleWriteGuard;
-use query::frontend::reorg::{self, ReorgPlanner};
+use query::frontend::reorg::ReorgPlanner;
 use query::QueryChunkMeta;
 use read_buffer::{ChunkMetrics, RBChunk};
 use tracker::{TaskTracker, TrackedFuture, TrackedFutureExt};
 
-use crate::db::catalog::chunk::{self, CatalogChunk};
-use crate::db::catalog::partition::{self, Partition};
+use crate::db::catalog::chunk::CatalogChunk;
+use crate::db::catalog::partition::Partition;
 use crate::db::DbChunk;
 
-use super::{LockableCatalogChunk, LockableCatalogPartition};
-
-#[derive(Debug, Snafu)]
-pub enum Error {
-    #[snafu(context(false))]
-    PartitionError { source: partition::Error },
-
-    #[snafu(context(false))]
-    ChunkError { source: chunk::Error },
-
-    #[snafu(context(false))]
-    PlannerError { source: reorg::Error },
-
-    #[snafu(context(false))]
-    ArrowError { source: arrow::error::ArrowError },
-
-    #[snafu(context(false))]
-    DataFusionError {
-        source: datafusion::error::DataFusionError,
-    },
-}
-pub type Result<T, E = Error> = std::result::Result<T, E>;
+use super::{error::Result, LockableCatalogChunk, LockableCatalogPartition};
 
 /// Compute a sort key that orders lower cardinality columns first
 ///
@@ -76,7 +54,7 @@ fn compute_sort_key<'a>(summaries: impl Iterator<Item = &'a TableSummary>) -> So
 /// Compact the provided chunks into a single chunk
 ///
 /// TODO: Replace low-level locks with transaction object
-pub(super) fn compact_chunks(
+pub(crate) fn compact_chunks(
     partition: LifecycleWriteGuard<'_, Partition, LockableCatalogPartition<'_>>,
     chunks: Vec<LifecycleWriteGuard<'_, CatalogChunk, LockableCatalogChunk<'_>>>,
 ) -> Result<(

--- a/server/src/db/lifecycle/move_chunk.rs
+++ b/server/src/db/lifecycle/move_chunk.rs
@@ -9,10 +9,7 @@ use read_buffer::{ChunkMetrics as ReadBufferChunkMetrics, RBChunk};
 use std::{future::Future, sync::Arc};
 use tracker::{TaskTracker, TrackedFuture, TrackedFutureExt};
 
-use super::{
-    error::Result,
-    LockableCatalogChunk,
-};
+use super::{error::Result, LockableCatalogChunk};
 
 /// The implementation for moving a chunk to the read buffer
 ///

--- a/server/src/db/lifecycle/move_chunk.rs
+++ b/server/src/db/lifecycle/move_chunk.rs
@@ -6,12 +6,11 @@ use internal_types::{arrow::sort::sort_record_batch, selection::Selection};
 
 use observability_deps::tracing::{debug, info};
 use read_buffer::{ChunkMetrics as ReadBufferChunkMetrics, RBChunk};
-use snafu::ResultExt;
 use std::{future::Future, sync::Arc};
 use tracker::{TaskTracker, TrackedFuture, TrackedFutureExt};
 
 use super::{
-    error::{LifecycleError, Result},
+    error::Result,
     LockableCatalogChunk,
 };
 
@@ -19,7 +18,7 @@ use super::{
 ///
 /// Returns a future registered with the tracker registry, and the corresponding tracker
 /// The caller can either spawn this future to tokio, or block directly on it
-pub fn move_chunk_to_read_buffer_impl(
+pub fn move_chunk_to_read_buffer(
     mut guard: LifecycleWriteGuard<'_, CatalogChunk, LockableCatalogChunk<'_>>,
 ) -> Result<(
     TaskTracker<Job>,
@@ -38,7 +37,7 @@ pub fn move_chunk_to_read_buffer_impl(
     // update the catalog to say we are processing this chunk and
     // then drop the lock while we do the work
     let (mb_chunk, table_summary) = {
-        let mb_chunk = guard.set_moving(&registration).context(LifecycleError)?;
+        let mb_chunk = guard.set_moving(&registration)?;
         (mb_chunk, guard.table_summary())
     };
 

--- a/server/src/db/lifecycle/unload.rs
+++ b/server/src/db/lifecycle/unload.rs
@@ -1,6 +1,5 @@
 //! This module contains the code to unload chunks from the read buffer
 
-use snafu::ResultExt;
 use std::sync::Arc;
 
 use lifecycle::LifecycleWriteGuard;
@@ -10,16 +9,14 @@ use crate::db::{catalog::chunk::CatalogChunk, DbChunk};
 
 use super::LockableCatalogChunk;
 
-use super::error::{LifecycleError, Result};
+use super::error::Result;
 
-pub fn unload_read_buffer_impl(
+pub fn unload_read_buffer_chunk(
     mut chunk: LifecycleWriteGuard<'_, CatalogChunk, LockableCatalogChunk<'_>>,
 ) -> Result<Arc<DbChunk>> {
     debug!(chunk=%chunk.addr(), "unloading chunk from read buffer");
 
-    chunk
-        .set_unload_from_read_buffer()
-        .context(LifecycleError {})?;
+    chunk.set_unload_from_read_buffer()?;
 
     debug!(chunk=%chunk.addr(), "chunk marked UNLOADED from read buffer");
 

--- a/server/src/db/lifecycle/write.rs
+++ b/server/src/db/lifecycle/write.rs
@@ -25,8 +25,7 @@ use std::{future::Future, sync::Arc};
 use tracker::{TaskTracker, TrackedFuture, TrackedFutureExt};
 
 use super::error::{
-    CommitError, Error, ParquetChunkError, Result, TransactionError,
-    WritingToObjectStore,
+    CommitError, Error, ParquetChunkError, Result, TransactionError, WritingToObjectStore,
 };
 
 /// The implementation for writing a chunk to the object store

--- a/server/src/db/lifecycle/write.rs
+++ b/server/src/db/lifecycle/write.rs
@@ -25,7 +25,7 @@ use std::{future::Future, sync::Arc};
 use tracker::{TaskTracker, TrackedFuture, TrackedFutureExt};
 
 use super::error::{
-    CommitError, Error, LifecycleError, ParquetChunkError, Result, TransactionError,
+    CommitError, Error, ParquetChunkError, Result, TransactionError,
     WritingToObjectStore,
 };
 
@@ -33,7 +33,7 @@ use super::error::{
 ///
 /// Returns a future registered with the tracker registry, and the corresponding tracker
 /// The caller can either spawn this future to tokio, or block directly on it
-pub fn write_chunk_to_object_store_impl(
+pub fn write_chunk_to_object_store(
     mut guard: LifecycleWriteGuard<'_, CatalogChunk, LockableCatalogChunk<'_>>,
 ) -> Result<(
     TaskTracker<Job>,
@@ -51,9 +51,7 @@ pub fn write_chunk_to_object_store_impl(
     });
 
     // update the catalog to say we are processing this chunk and
-    let rb_chunk = guard
-        .set_writing_to_object_store(&registration)
-        .context(LifecycleError)?;
+    let rb_chunk = guard.set_writing_to_object_store(&registration)?;
 
     debug!(chunk=%guard.addr(), "chunk marked WRITING , loading tables into object store");
 


### PR DESCRIPTION
This PR follows on from #1858 and brings compact_chunks into alignment with the error handling for the other lifecycle actions.

It also tweaks the db::lifecycle module to not expose its internal module topology, to avoid redundancy