### PR TITLE
chore: Add query tests for compacted chunks

### DIFF
--- a/query_tests/src/influxrpc/tag_values.rs
+++ b/query_tests/src/influxrpc/tag_values.rs
@@ -212,8 +212,15 @@ async fn list_tag_values_table_and_timestamp_and_state_pred_state_col_no_rows() 
         .add_expr(col("state").eq(lit("NY"))) // state=NY
         .build();
     let expected_tag_keys = vec![];
+
+    // Ignore the compact case, until this is fixed:
+    // https://github.com/influxdata/influxdb_iox/issues/1860
+    let filter =
+        |setup: &DbScenario| setup.scenario_name != "Data in one compacted read buffer chunk";
+
     run_tag_values_test_case!(
-        TwoMeasurementsManyNulls {},
+        //TwoMeasurementsManyNulls {},
+        FilteredSetup::new(TwoMeasurementsManyNulls {}, filter),
         tag_name,
         predicate,
         expected_tag_keys

--- a/query_tests/src/scenarios.rs
+++ b/query_tests/src/scenarios.rs
@@ -823,8 +823,32 @@ pub async fn make_two_chunk_scenarios(
         db,
     };
 
+    // Scenario 7: in a single chunk resulting from compacting MUB and RUB
+    let db = make_db().await.db;
+    let table_names = write_lp(&db, data1).await;
+    for table_name in &table_names {
+        // put chunk 1 into RUB
+        db.rollover_partition(&table_name, partition_key)
+            .await
+            .unwrap();
+        db.move_chunk_to_read_buffer(&table_name, partition_key, 0)
+            .await
+            .unwrap();
+    }
+    let table_names = write_lp(&db, data2).await; // write to MUB
+    for table_name in &table_names {
+        // compact chunks into a single RUB chunk
+        db.compact_partition(&table_name, partition_key)
+            .await
+            .unwrap();
+    }
+    let scenario7 = DbScenario {
+        scenario_name: "Data in one compacted read buffer chunk".into(),
+        db,
+    };
+
     vec![
-        scenario1, scenario2, scenario3, scenario4, scenario5, scenario6,
+        scenario1, scenario2, scenario3, scenario4, scenario5, scenario6, scenario7,
     ]
 }
 
@@ -884,4 +908,43 @@ pub(crate) async fn make_one_rub_or_parquet_chunk_scenario(
     };
 
     vec![scenario1, scenario2]
+}
+
+/// This helper filters out scenarios from another setup. If, for
+/// example, one scenario triggers a bug that is not yet fixed
+pub struct FilteredSetup<S, P>
+where
+    S: DbSetup,
+    P: Fn(&DbScenario) -> bool,
+{
+    inner: S,
+    filter: P,
+}
+
+impl<S, P> FilteredSetup<S, P>
+where
+    S: DbSetup,
+    P: Fn(&DbScenario) -> bool + Send + Sync,
+{
+    /// Create a new setup that returns all scenarios from inner if
+    /// filter(scenaro) returns true.
+    pub fn new(inner: S, filter: P) -> Self {
+        Self { inner, filter }
+    }
+}
+
+#[async_trait]
+impl<S, P> DbSetup for FilteredSetup<S, P>
+where
+    S: DbSetup,
+    P: Fn(&DbScenario) -> bool + Send + Sync,
+{
+    async fn make(&self) -> Vec<DbScenario> {
+        self.inner
+            .make()
+            .await
+            .into_iter()
+            .filter(|s| (self.filter)(s))
+            .collect()
+    }
 }

--- a/server/src/db/lifecycle.rs
+++ b/server/src/db/lifecycle.rs
@@ -18,6 +18,7 @@ use crate::db::catalog::chunk::CatalogChunk;
 use crate::db::catalog::partition::Partition;
 use crate::Db;
 
+pub(crate) use compact::compact_chunks;
 pub(crate) use error::{Error, Result};
 pub(crate) use move_chunk::move_chunk_to_read_buffer;
 pub(crate) use unload::unload_read_buffer_chunk;


### PR DESCRIPTION
Re https://github.com/influxdata/influxdb_iox/pull/1855

# Rationale:
The query_tests scenarios do not currently include chunks created via "compaction" (they only test chunks created by load, rollover, etc); As I work to disable over eager deduplication for chunks created in the read buffer in  https://github.com/influxdata/influxdb_iox/pull/1855 and https://github.com/influxdata/influxdb_iox/issues/1763 I want to ensure sufficient coverage.

# Changes
1. Add a function `Db::compact_partition` to trigger a compaction
2. Adds a 7th scenario to two chunk secnarios where the data is compacted into a single large RUB chunk

# Testing FTW
This test has also uncovered a bug in `column_values` implementation of the read buffer, which I have filed as https://github.com/influxdata/influxdb_iox/issues/1860
