### PR TITLE
fix: change timeout to have all tests passed on slow laptop

### DIFF
--- a/src/influxdb_ioxd/rpc/storage/service.rs
+++ b/src/influxdb_ioxd/rpc/storage/service.rs
@@ -2762,16 +2762,16 @@ mod tests {
         }
     }
 
-    /// loop and try to make a client connection for 5 seconds,
+    /// loop and try to make a client connection for 30 seconds,
     /// returning the result of the connection
     async fn connect_to_server<T>(bind_addr: SocketAddr) -> Result<T, tonic::transport::Error>
     where
         T: NewClient,
     {
-        const MAX_RETRIES: u32 = 10;
+        const MAX_RETRIES: u32 = 30;
         let mut retry_count = 0;
         loop {
-            let mut interval = tokio::time::interval(Duration::from_millis(500));
+            let mut interval = tokio::time::interval(Duration::from_millis(1000));
 
             match T::connect(format!("http://{}", bind_addr)).await {
                 Ok(client) => {

--- a/tests/common/server_fixture.rs
+++ b/tests/common/server_fixture.rs
@@ -356,7 +356,7 @@ impl TestServer {
         let try_http_connect = async {
             let client = reqwest::Client::new();
             let url = format!("{}/health", self.addrs().http_base);
-            let mut interval = tokio::time::interval(Duration::from_millis(500));
+            let mut interval = tokio::time::interval(Duration::from_millis(1000));
             loop {
                 match client.get(&url).send().await {
                     Ok(resp) => {
@@ -373,7 +373,7 @@ impl TestServer {
 
         let pair = future::join(try_http_connect, try_grpc_connect);
 
-        let capped_check = tokio::time::timeout(Duration::from_secs(3), pair);
+        let capped_check = tokio::time::timeout(Duration::from_secs(30), pair);
 
         match capped_check.await {
             Ok(_) => {
@@ -412,7 +412,7 @@ impl TestServer {
 
                 // if server ID was set, we can also wait until DBs are loaded
                 let check_dbs_loaded = async {
-                    let mut interval = tokio::time::interval(Duration::from_millis(500));
+                    let mut interval = tokio::time::interval(Duration::from_millis(1000));
 
                     while !management_client
                         .get_server_status()
@@ -424,7 +424,7 @@ impl TestServer {
                     }
                 };
 
-                let capped_check = tokio::time::timeout(Duration::from_secs(3), check_dbs_loaded);
+                let capped_check = tokio::time::timeout(Duration::from_secs(30), check_dbs_loaded);
 
                 match capped_check.await {
                     Ok(_) => {
@@ -464,7 +464,7 @@ pub async fn grpc_channel(
 }
 
 pub async fn wait_for_grpc(addrs: &BindAddresses) {
-    let mut interval = tokio::time::interval(Duration::from_millis(500));
+    let mut interval = tokio::time::interval(Duration::from_millis(1000));
 
     loop {
         match grpc_channel(addrs).await {


### PR DESCRIPTION
Closes #

Make intervals and timeout longer for all the tests pass on my laptop

- [x] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb_iox/blob/main/README.md).
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
