### PR TITLE
refactor: remove table name from upsert_table (#1295)

### DIFF
--- a/read_buffer/benches/database.rs
+++ b/read_buffer/benches/database.rs
@@ -15,7 +15,7 @@ const ONE_MS: i64 = 1_000_000;
 fn satisfies_predicate(c: &mut Criterion) {
     let rb = generate_row_group(500_000);
     let mut chunk = RBChunk::new("table_a", ChunkMetrics::new_unregistered());
-    chunk.upsert_table("table_a", rb);
+    chunk.upsert_table(rb);
 
     // no predicate
     benchmark_satisfies_predicate(

--- a/server/src/db/lifecycle/compact.rs
+++ b/server/src/db/lifecycle/compact.rs
@@ -82,7 +82,7 @@ pub(crate) fn compact_chunks(
 
         // Collect results into RUB chunk
         while let Some(batch) = stream.next().await {
-            rb_chunk.upsert_table(&table_name, batch?)
+            rb_chunk.upsert_table(batch?)
         }
 
         let new_chunk = {

--- a/server/src/db/lifecycle/move_chunk.rs
+++ b/server/src/db/lifecycle/move_chunk.rs
@@ -69,7 +69,7 @@ pub fn move_chunk_to_read_buffer(
 
         // Collect results into RUB chunk
         while let Some(batch) = stream.next().await {
-            rb_chunk.upsert_table(&table_summary.name, batch?)
+            rb_chunk.upsert_table(batch?)
         }
 
         // Can drop and re-acquire as lifecycle action prevents concurrent modification


### PR DESCRIPTION
Drive by refactor to remove redundant table name from read buffer API