### PR TITLE
feat: Persist lifecycle action

### DIFF
--- a/lifecycle/src/guard.rs
+++ b/lifecycle/src/guard.rs
@@ -83,7 +83,7 @@
 //!
 
 use std::{
-    fmt::Debug,
+    fmt::{Debug, Display},
     ops::{Deref, DerefMut},
 };
 
@@ -124,7 +124,7 @@ impl<'a, P, D> LifecycleReadGuard<'a, P, D> {
     }
 
     /// Drops the locks held by this guard and returns the data payload
-    pub fn unwrap(self) -> D {
+    pub fn into_data(self) -> D {
         self.data
     }
 }
@@ -132,6 +132,12 @@ impl<'a, P, D> LifecycleReadGuard<'a, P, D> {
 impl<'a, P, D> Debug for LifecycleReadGuard<'a, P, D> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "LifecycleReadGuard{{..}}")
+    }
+}
+
+impl<'a, P, D: Display> Display for LifecycleReadGuard<'a, P, D> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{} locked for read", self.data)
     }
 }
 
@@ -168,7 +174,7 @@ impl<'a, P, D> LifecycleWriteGuard<'a, P, D> {
     }
 
     /// Drops the locks held by this guard and returns the data payload
-    pub fn unwrap(self) -> D {
+    pub fn into_data(self) -> D {
         self.data
     }
 }
@@ -176,6 +182,11 @@ impl<'a, P, D> LifecycleWriteGuard<'a, P, D> {
 impl<'a, P, D> Debug for LifecycleWriteGuard<'a, P, D> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "LifecycleWriteGuard{{..}}")
+    }
+}
+impl<'a, P, D: Display> Display for LifecycleWriteGuard<'a, P, D> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{} locked for write", self.data)
     }
 }
 

--- a/lifecycle/src/lib.rs
+++ b/lifecycle/src/lib.rs
@@ -88,7 +88,7 @@ pub trait LockablePartition: Sized + std::fmt::Display {
     /// Combines and deduplicates the data in `chunks` into two new chunks:
     ///
     /// 1. A read buffer chunk that contains any rows with timestamps
-    /// prior to the partition's `max_persistable_timestamp`
+    /// prior to `max_persistable_timestamp`
     ///
     /// 2. A read buffer chunk (also written to the object store) with
     /// all other rows
@@ -97,6 +97,7 @@ pub trait LockablePartition: Sized + std::fmt::Display {
     fn persist_chunks(
         partition: LifecycleWriteGuard<'_, Self::Partition, Self>,
         chunks: Vec<LifecycleWriteGuard<'_, <Self::Chunk as LockableChunk>::Chunk, Self::Chunk>>,
+        max_persistable_timestamp: DateTime<Utc>,
         handle: Self::PersistHandle,
     ) -> Result<TaskTracker<<Self::Chunk as LockableChunk>::Job>, Self::Error>;
 

--- a/lifecycle/src/lib.rs
+++ b/lifecycle/src/lib.rs
@@ -15,6 +15,7 @@ use data_types::database_rules::LifecycleRules;
 use data_types::DatabaseName;
 pub use guard::*;
 pub use policy::*;
+use std::time::Instant;
 use tracker::TaskTracker;
 
 mod guard;
@@ -41,9 +42,11 @@ pub trait LifecycleDb {
 
 /// A `LockablePartition` is a wrapper around a `LifecyclePartition` that allows
 /// for planning and executing lifecycle actions on the partition
-pub trait LockablePartition: Sized {
+pub trait LockablePartition: Sized + std::fmt::Display {
     type Partition: LifecyclePartition;
     type Chunk: LockableChunk;
+    type PersistHandle: Send + Sync + 'static;
+
     type Error: std::error::Error + Send + Sync;
 
     /// Acquire a shared read lock on the chunk
@@ -67,6 +70,26 @@ pub trait LockablePartition: Sized {
     fn compact_chunks(
         partition: LifecycleWriteGuard<'_, Self::Partition, Self>,
         chunks: Vec<LifecycleWriteGuard<'_, <Self::Chunk as LockableChunk>::Chunk, Self::Chunk>>,
+    ) -> Result<TaskTracker<<Self::Chunk as LockableChunk>::Job>, Self::Error>;
+
+    /// Returns a PersistHandle for the provided partition, and the
+    /// timestamp up to which to to flush
+    ///
+    /// Returns None if there is a persistence operation in flight, or
+    /// if there are no persistable windows.
+    ///
+    /// TODO: This interface is nasty
+    fn prepare_persist(
+        partition: &mut LifecycleWriteGuard<'_, Self::Partition, Self>,
+    ) -> Option<(Self::PersistHandle, DateTime<Utc>)>;
+
+    /// Split and persist chunks
+    ///
+    /// TODO: Encapsulate these locks into a CatalogTransaction object
+    fn persist_chunks(
+        partition: LifecycleWriteGuard<'_, Self::Partition, Self>,
+        chunks: Vec<LifecycleWriteGuard<'_, <Self::Chunk as LockableChunk>::Chunk, Self::Chunk>>,
+        handle: Self::PersistHandle,
     ) -> Result<TaskTracker<<Self::Chunk as LockableChunk>::Job>, Self::Error>;
 
     /// Drops a chunk from the partition
@@ -98,11 +121,17 @@ pub trait LockableChunk: Sized {
     fn write(&self) -> LifecycleWriteGuard<'_, Self::Chunk, Self>;
 
     /// Starts an operation to move a chunk to the read buffer
+    ///
+    /// TODO: Remove this function from the trait as it is
+    /// not called from the lifecycle manager
     fn move_to_read_buffer(
         s: LifecycleWriteGuard<'_, Self::Chunk, Self>,
     ) -> Result<TaskTracker<Self::Job>, Self::Error>;
 
     /// Starts an operation to write a chunk to the object store
+    ///
+    /// TODO: Remove this function from the trait as it is
+    /// not called from the lifecycle manager
     fn write_to_object_store(
         s: LifecycleWriteGuard<'_, Self::Chunk, Self>,
     ) -> Result<TaskTracker<Self::Job>, Self::Error>;
@@ -119,6 +148,12 @@ pub trait LockableChunk: Sized {
 
 pub trait LifecyclePartition {
     fn partition_key(&self) -> &str;
+
+    /// Returns an approximation of the number of rows that can be persisted
+    fn persistable_row_count(&self) -> usize;
+
+    /// Returns the age of the oldest unpersisted write
+    fn minimum_unpersisted_age(&self) -> Option<Instant>;
 }
 
 /// The lifecycle operates on chunks implementing this trait
@@ -126,6 +161,9 @@ pub trait LifecycleChunk {
     fn lifecycle_action(&self) -> Option<&TaskTracker<ChunkLifecycleAction>>;
 
     fn clear_lifecycle_action(&mut self);
+
+    /// Returns the min timestamp contained within this chunk
+    fn min_timestamp(&self) -> DateTime<Utc>;
 
     fn time_of_first_write(&self) -> Option<DateTime<Utc>>;
 

--- a/lifecycle/src/policy.rs
+++ b/lifecycle/src/policy.rs
@@ -8,7 +8,7 @@ use futures::future::BoxFuture;
 
 use data_types::chunk_metadata::{ChunkLifecycleAction, ChunkStorage};
 use data_types::database_rules::{LifecycleRules, DEFAULT_MUB_ROW_THRESHOLD};
-use observability_deps::tracing::{debug, info, warn};
+use observability_deps::tracing::{debug, info, trace, warn};
 use tracker::TaskTracker;
 
 use crate::{LifecycleChunk, LifecycleDb, LifecyclePartition, LockableChunk, LockablePartition};
@@ -121,7 +121,7 @@ where
                                 info!(
                                     %db_name,
                                     chunk_id = candidate.chunk_id,
-                                    partition = partition.partition_key(),
+                                    %partition,
                                     "cannot mutate chunk with in-progress lifecycle action"
                                 );
                                 continue;
@@ -140,7 +140,7 @@ where
                                     storage => warn!(
                                         %db_name,
                                         chunk_id = candidate.chunk_id,
-                                        partition = partition.partition_key(),
+                                        %partition,
                                         ?storage,
                                         "unexpected storage for drop"
                                     ),
@@ -153,7 +153,7 @@ where
                                     storage => warn!(
                                         %db_name,
                                         chunk_id = candidate.chunk_id,
-                                        partition = partition.partition_key(),
+                                        %partition,
                                         ?storage,
                                         "unexpected storage for unload"
                                     ),
@@ -163,7 +163,7 @@ where
                         None => info!(
                             %db_name,
                             chunk_id = candidate.chunk_id,
-                            partition = partition.partition_key(),
+                            %partition,
                             "cannot drop chunk that no longer exists on partition"
                         ),
                     }
@@ -233,7 +233,7 @@ where
             }
             let has_added_to_compact = to_compact.len() > to_compact_len_before;
             debug!(db_name = %self.db.name(),
-                   partition_key = %partition.partition_key(),
+                   %partition,
                    ?has_added_to_compact,
                    chunk_storage = ?storage,
                    ?has_mub_snapshot,
@@ -260,78 +260,109 @@ where
     ///
     /// Looks for read buffer chunks to persist
     ///
-    /// A chunk will be persisted if it has more than `persist_row_threshold` rows
-    /// or it was last written to more than `late_arrive_window_seconds` ago
+    /// A chunk will be persisted if either:
     ///
-    /// Returns a boolean to indicate if it should stall compaction to allow
-    /// persistence to make progress
+    /// 1. it has more than `persist_row_threshold` rows
+    /// 2. it was last written to more than `late_arrive_window_seconds` ago
+    ///
+    /// Returns true if persistence is being blocked by compaction,
+    /// signaling compaction should be stalled to allow persistence to
+    /// make progress
     fn maybe_persist_chunks<P: LockablePartition>(
         &mut self,
         db_name: &DatabaseName<'static>,
         partition: &P,
         rules: &LifecycleRules,
-        now: DateTime<Utc>,
+        now: Instant,
     ) -> bool {
-        // TODO: Use PersistenceWindows, split chunks, etc...
-
-        let row_threshold = rules.persist_row_threshold.get();
-        let late_arrive_window_seconds = rules.late_arrive_window_seconds.get();
-
+        // TODO: Encapsulate locking into a CatalogTransaction type
         let partition = partition.read();
-        let chunks = LockablePartition::chunks(&partition);
 
-        // The candidate RUB chunk to persist
-        let mut persist_candidate = None;
+        let persistable_age_seconds = partition
+            .minimum_unpersisted_age()
+            .map(|x| now.duration_since(x).as_secs())
+            .unwrap_or_default() as u32;
 
-        // If there are other unpersisted chunks in the partition
-        let mut has_other_unpersisted = false;
+        debug!(%db_name, %partition,
+               partition_persist_row_count=partition.persistable_row_count(),
+               rules_persist_row_count=%rules.persist_row_threshold.get(),
+               partition_persistable_age_seconds=persistable_age_seconds,
+               rules_persist_age_threshold_seconds=%rules.persist_age_threshold_seconds.get(),
+               "considering for persistence");
 
+        if partition.persistable_row_count() < rules.persist_row_threshold.get()
+            && persistable_age_seconds < rules.persist_age_threshold_seconds.get()
+        {
+            debug!(%db_name, %partition, "partition not eligible for persist");
+            return false;
+        }
+
+        let mut chunks = LockablePartition::chunks(&partition);
+
+        // Upgrade partition to be able to rotate persistence windows
+        let mut partition = partition.upgrade();
+
+        let (persist_handle, flush_timestamp) = match LockablePartition::prepare_persist(
+            &mut partition,
+        ) {
+            Some(x) => x,
+            None => {
+                debug!(%db_name, %partition, "no persistable windows or previous outstanding persist");
+                return false;
+            }
+        };
+
+        // Sort by chunk ID to ensure a stable lock order
+        chunks.sort_by_key(|x| x.0);
+        let mut to_persist = Vec::new();
         for (_, chunk) in &chunks {
             let chunk = chunk.read();
+            trace!(%db_name, %partition, chunk=%chunk.addr(), "considering chunk for persistence");
+
+            // Check if chunk is eligible for persistence
             match chunk.storage() {
-                ChunkStorage::ReadBuffer => {}
-                ChunkStorage::OpenMutableBuffer | ChunkStorage::ClosedMutableBuffer => {
-                    has_other_unpersisted = true;
+                ChunkStorage::OpenMutableBuffer
+                | ChunkStorage::ClosedMutableBuffer
+                | ChunkStorage::ReadBuffer => {}
+                ChunkStorage::ReadBufferAndObjectStore | ChunkStorage::ObjectStoreOnly => {
+                    debug!(%db_name, %partition, chunk=%chunk.addr(), storage=?chunk.storage(),
+                           "chunk not eligible due to storage");
                     continue;
                 }
-                ChunkStorage::ReadBufferAndObjectStore | ChunkStorage::ObjectStoreOnly => continue,
             }
 
-            if chunk.lifecycle_action().is_some() {
+            // Chunk's data is entirely after the time we are flushing
+            // up to, and thus there is reason to include it in the
+            // plan
+            if chunk.min_timestamp() > flush_timestamp {
+                // Can safely ignore chunk
+                debug!(%db_name, %partition, chunk=%chunk.addr(),
+                       "chunk does not contain data eligible for persistence");
                 continue;
             }
 
-            if persist_candidate.is_some() {
-                debug!(
-                    %db_name,
-                    partition = partition.partition_key(),
-                    "found multiple read buffer chunks"
-                );
-
-                has_other_unpersisted = true;
-                continue;
+            // If the chunk has an outstanding lifecycle action
+            if let Some(action) = chunk.lifecycle_action() {
+                // see if we should stall subsequent pull it is
+                // preventing us from persisting
+                let stall = action.metadata() == &ChunkLifecycleAction::Compacting;
+                info!(%db_name, ?action, chunk=%chunk.addr(), "Chunk to persist has outstanding action");
+                return stall;
             }
 
-            persist_candidate = Some(chunk);
+            to_persist.push(chunk);
         }
 
-        if let Some(chunk) = persist_candidate {
-            let mut should_persist = chunk.row_count() >= row_threshold;
-            if !should_persist && !has_other_unpersisted {
-                if let Some(last_write) = chunk.time_of_last_write() {
-                    should_persist = elapsed_seconds(now, last_write) > late_arrive_window_seconds;
-                }
-            }
+        let chunks = to_persist
+            .into_iter()
+            .map(|chunk| chunk.upgrade())
+            .collect();
 
-            if should_persist {
-                let tracker = LockableChunk::write_to_object_store(chunk.upgrade())
-                    .expect("task preparation failed")
-                    .with_metadata(ChunkLifecycleAction::Persisting);
+        let tracker = LockablePartition::persist_chunks(partition, chunks, persist_handle)
+            .expect("failed to persist chunks")
+            .with_metadata(ChunkLifecycleAction::Persisting);
 
-                self.trackers.push(tracker);
-            }
-        }
-
+        self.trackers.push(tracker);
         false
     }
 
@@ -356,8 +387,10 @@ where
             let chunk = chunk.read();
             if let Some(lifecycle_action) = chunk.lifecycle_action() {
                 if lifecycle_action.is_complete()
-                    && now.duration_since(lifecycle_action.start_instant())
-                        >= LIFECYCLE_ACTION_BACKOFF
+                    && now
+                        .checked_duration_since(lifecycle_action.start_instant())
+                        .map(|x| x >= LIFECYCLE_ACTION_BACKOFF)
+                        .unwrap_or(false)
                 {
                     info!(%db_name, chunk=%chunk.addr(), action=?lifecycle_action.metadata(), "clearing failed lifecycle action");
                     chunk.upgrade().clear_lifecycle_action();
@@ -386,21 +419,23 @@ where
         for partition in &partitions {
             self.maybe_cleanup_failed(&db_name, partition, now_instant);
 
-            // TODO: Skip partitions with no PersistenceWindows (i.e. fully persisted)
-
             // Persistence cannot split chunks if they are currently being compacted
             //
-            // To avoid compaction "starving" persistence we employ a heavy-handed approach
-            // of temporarily pausing compaction if the criteria for persistence have been
-            // satisfied, but persistence cannot proceed because of in-progress compactions
+            // To avoid compaction "starving" persistence we employ a
+            // possibly overly heavy-handed approach and temporarily
+            // pause compaction if the criteria for persistence have
+            // been satisfied, but persistence cannot proceed because
+            // of in-progress compactions
             let stall_compaction = if rules.persist {
-                self.maybe_persist_chunks(&db_name, partition, &rules, now)
+                self.maybe_persist_chunks(&db_name, partition, &rules, now_instant)
             } else {
                 false
             };
 
             if !stall_compaction {
                 self.maybe_compact_chunks(partition, &rules, now);
+            } else {
+                debug!(%db_name, %partition, "stalling compaction to allow persist");
             }
         }
 
@@ -541,21 +576,43 @@ mod tests {
 
     #[derive(Debug, Eq, PartialEq)]
     enum MoverEvents {
-        Move(u32),
-        Persist(u32),
         Drop(u32),
         Unload(u32),
         Compact(Vec<u32>),
+        Persist(Vec<u32>),
     }
 
+    #[derive(Debug)]
     struct TestPartition {
         chunks: BTreeMap<u32, Arc<RwLock<TestChunk>>>,
+        persistable_row_count: usize,
+        minimum_unpersisted_age: Option<Instant>,
+        max_persistable_timestamp: Option<DateTime<Utc>>,
         next_id: u32,
     }
 
+    impl TestPartition {
+        fn with_persistence(
+            self,
+            persistable_row_count: usize,
+            minimum_unpersisted_age: Instant,
+            max_persistable_timestamp: DateTime<Utc>,
+        ) -> Self {
+            Self {
+                chunks: self.chunks,
+                persistable_row_count,
+                minimum_unpersisted_age: Some(minimum_unpersisted_age),
+                max_persistable_timestamp: Some(max_persistable_timestamp),
+                next_id: self.next_id,
+            }
+        }
+    }
+
+    #[derive(Debug)]
     struct TestChunk {
         addr: ChunkAddr,
         row_count: usize,
+        min_timestamp: Option<DateTime<Utc>>,
         time_of_first_write: Option<DateTime<Utc>>,
         time_of_last_write: Option<DateTime<Utc>>,
         lifecycle_action: Option<TaskTracker<ChunkLifecycleAction>>,
@@ -579,6 +636,7 @@ mod tests {
             Self {
                 addr,
                 row_count: 10,
+                min_timestamp: None,
                 time_of_first_write: time_of_first_write.map(from_secs),
                 time_of_last_write: time_of_last_write.map(from_secs),
                 lifecycle_action: None,
@@ -590,6 +648,7 @@ mod tests {
             Self {
                 addr: self.addr,
                 row_count,
+                min_timestamp: self.min_timestamp,
                 time_of_first_write: self.time_of_first_write,
                 time_of_last_write: self.time_of_last_write,
                 lifecycle_action: self.lifecycle_action,
@@ -601,18 +660,37 @@ mod tests {
             Self {
                 addr: self.addr,
                 row_count: self.row_count,
+                min_timestamp: self.min_timestamp,
                 time_of_first_write: self.time_of_first_write,
                 time_of_last_write: self.time_of_last_write,
                 lifecycle_action: Some(TaskTracker::complete(action)),
                 storage: self.storage,
             }
         }
+
+        fn with_min_timestamp(self, min_timestamp: DateTime<Utc>) -> Self {
+            Self {
+                addr: self.addr,
+                row_count: self.row_count,
+                min_timestamp: Some(min_timestamp),
+                time_of_first_write: self.time_of_first_write,
+                time_of_last_write: self.time_of_last_write,
+                lifecycle_action: self.lifecycle_action,
+                storage: self.storage,
+            }
+        }
     }
 
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     struct TestLockablePartition<'a> {
         db: &'a TestDb,
         partition: Arc<RwLock<TestPartition>>,
+    }
+
+    impl<'a> std::fmt::Display for TestLockablePartition<'a> {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "{}", self)
+        }
     }
 
     #[derive(Clone)]
@@ -624,6 +702,7 @@ mod tests {
     impl<'a> LockablePartition for TestLockablePartition<'a> {
         type Partition = TestPartition;
         type Chunk = TestLockableChunk<'a>;
+        type PersistHandle = ();
         type Error = Infallible;
 
         fn read(&self) -> LifecycleReadGuard<'_, Self::Partition, Self> {
@@ -686,6 +765,38 @@ mod tests {
             Ok(TaskTracker::complete(()))
         }
 
+        fn prepare_persist(
+            partition: &mut LifecycleWriteGuard<'_, Self::Partition, Self>,
+        ) -> Option<(Self::PersistHandle, DateTime<Utc>)> {
+            Some(((), partition.max_persistable_timestamp.unwrap()))
+        }
+
+        fn persist_chunks(
+            mut partition: LifecycleWriteGuard<'_, TestPartition, Self>,
+            chunks: Vec<LifecycleWriteGuard<'_, TestChunk, Self::Chunk>>,
+            _handle: Self::PersistHandle,
+        ) -> Result<TaskTracker<()>, Self::Error> {
+            let flush_timestamp = partition.max_persistable_timestamp.unwrap();
+            for chunk in &chunks {
+                partition.chunks.remove(&chunk.addr.chunk_id);
+            }
+
+            let id = partition.next_id;
+            partition.next_id += 1;
+
+            // The remainder left behind after the split
+            let new_chunk = TestChunk::new(id, None, None, ChunkStorage::ReadBuffer)
+                .with_min_timestamp(flush_timestamp);
+
+            partition
+                .chunks
+                .insert(id, Arc::new(RwLock::new(new_chunk)));
+
+            let event = MoverEvents::Persist(chunks.iter().map(|x| x.addr.chunk_id).collect());
+            partition.data().db.events.write().push(event);
+            Ok(TaskTracker::complete(()))
+        }
+
         fn drop_chunk(
             mut s: LifecycleWriteGuard<'_, Self::Partition, Self>,
             chunk_id: u32,
@@ -710,27 +821,19 @@ mod tests {
         }
 
         fn move_to_read_buffer(
-            mut s: LifecycleWriteGuard<'_, Self::Chunk, Self>,
-        ) -> Result<TaskTracker<()>, Self::Error> {
-            s.storage = ChunkStorage::ReadBuffer;
-            s.data()
-                .db
-                .events
-                .write()
-                .push(MoverEvents::Move(s.addr.chunk_id));
-            Ok(TaskTracker::complete(()))
+            _s: LifecycleWriteGuard<'_, Self::Chunk, Self>,
+        ) -> Result<TaskTracker<Self::Job>, Self::Error> {
+            // Isn't used by the lifecycle policy
+            // TODO: Remove this
+            unreachable!()
         }
 
         fn write_to_object_store(
-            mut s: LifecycleWriteGuard<'_, Self::Chunk, Self>,
-        ) -> Result<TaskTracker<()>, Self::Error> {
-            s.storage = ChunkStorage::ReadBufferAndObjectStore;
-            s.data()
-                .db
-                .events
-                .write()
-                .push(MoverEvents::Persist(s.addr.chunk_id));
-            Ok(TaskTracker::complete(()))
+            _s: LifecycleWriteGuard<'_, Self::Chunk, Self>,
+        ) -> Result<TaskTracker<Self::Job>, Self::Error> {
+            // Isn't used by the lifecycle policy
+            // TODO: Remove this
+            unreachable!()
         }
 
         fn unload_read_buffer(
@@ -750,6 +853,14 @@ mod tests {
         fn partition_key(&self) -> &str {
             "test"
         }
+
+        fn persistable_row_count(&self) -> usize {
+            self.persistable_row_count
+        }
+
+        fn minimum_unpersisted_age(&self) -> Option<Instant> {
+            self.minimum_unpersisted_age
+        }
     }
 
     impl LifecycleChunk for TestChunk {
@@ -759,6 +870,10 @@ mod tests {
 
         fn clear_lifecycle_action(&mut self) {
             self.lifecycle_action = None
+        }
+
+        fn min_timestamp(&self) -> DateTime<Utc> {
+            self.min_timestamp.unwrap()
         }
 
         fn time_of_first_write(&self) -> Option<DateTime<Utc>> {
@@ -795,12 +910,16 @@ mod tests {
 
             Self {
                 chunks,
+                persistable_row_count: 0,
+                minimum_unpersisted_age: None,
+                max_persistable_timestamp: None,
                 next_id: max_id + 1,
             }
         }
     }
 
     /// A dummy db that is used to test the policy logic
+    #[derive(Debug)]
     struct TestDb {
         rules: LifecycleRules,
         partitions: RwLock<Vec<Arc<RwLock<TestPartition>>>>,
@@ -1050,7 +1169,7 @@ mod tests {
         // test that chunk mover can drop non persisted chunks
         // if limit has been exceeded
 
-        // IMPORTANT: the lifecycle rules have the default `persist` flag (false) so NOT
+        // IMPORTANT: the lifecycle rules have the default `persist` flag (false) so NO
         // "write" events will be triggered
         let rules = LifecycleRules {
             buffer_size_soft: Some(NonZeroUsize::new(5).unwrap()),
@@ -1260,59 +1379,92 @@ mod tests {
             persist: true,
             persist_row_threshold: NonZeroUsize::new(1_000).unwrap(),
             late_arrive_window_seconds: NonZeroU32::new(10).unwrap(),
+            persist_age_threshold_seconds: NonZeroU32::new(10).unwrap(),
             ..Default::default()
         };
+        let now = Instant::now();
 
         let partitions = vec![
+            // Insufficient rows and not old enough => don't persist but can compact
             TestPartition::new(vec![
-                // not compacted => cannot write
-                TestChunk::new(0, Some(0), Some(0), ChunkStorage::ClosedMutableBuffer),
-                // not enough rows
-                TestChunk::new(1, Some(0), Some(0), ChunkStorage::ReadBuffer),
-                // already moved
-                TestChunk::new(2, Some(0), Some(0), ChunkStorage::ReadBufferAndObjectStore),
-            ]),
+                TestChunk::new(0, Some(0), Some(0), ChunkStorage::ClosedMutableBuffer)
+                    .with_min_timestamp(from_secs(10)),
+                TestChunk::new(1, Some(0), Some(0), ChunkStorage::ReadBuffer)
+                    .with_min_timestamp(from_secs(5)),
+            ])
+            .with_persistence(10, now, from_secs(20)),
+            // Sufficient rows => persist
             TestPartition::new(vec![
-                TestChunk::new(3, Some(0), Some(0), ChunkStorage::ClosedMutableBuffer)
+                TestChunk::new(2, Some(0), Some(0), ChunkStorage::ClosedMutableBuffer)
+                    .with_min_timestamp(from_secs(10)),
+                TestChunk::new(3, Some(0), Some(0), ChunkStorage::ReadBuffer)
+                    .with_min_timestamp(from_secs(5)),
+            ])
+            .with_persistence(1_000, now, from_secs(20)),
+            // Writes too old => persist
+            TestPartition::new(vec![
+                // Should split open chunks irrespective of mutable_linger_seconds
+                TestChunk::new(4, Some(0), Some(20), ChunkStorage::OpenMutableBuffer)
+                    .with_min_timestamp(from_secs(10)),
+                TestChunk::new(5, Some(0), Some(0), ChunkStorage::ReadBuffer)
+                    .with_min_timestamp(from_secs(5)),
+                TestChunk::new(6, Some(0), Some(0), ChunkStorage::ObjectStoreOnly)
+                    .with_min_timestamp(from_secs(5)),
+            ])
+            .with_persistence(10, now - Duration::from_secs(10), from_secs(20)),
+            // Sufficient rows but conflicting compaction => prevent compaction
+            TestPartition::new(vec![
+                TestChunk::new(7, Some(0), Some(0), ChunkStorage::ClosedMutableBuffer)
+                    .with_min_timestamp(from_secs(10))
                     .with_action(ChunkLifecycleAction::Compacting),
-                // reached row count => write
-                TestChunk::new(4, Some(0), Some(0), ChunkStorage::ReadBuffer).with_row_count(1_000),
-            ]),
+                // This chunk would be a compaction candidate, but we want to persist it
+                TestChunk::new(8, Some(0), Some(0), ChunkStorage::ClosedMutableBuffer)
+                    .with_min_timestamp(from_secs(10)),
+                TestChunk::new(9, Some(0), Some(0), ChunkStorage::ReadBuffer)
+                    .with_min_timestamp(from_secs(5)),
+            ])
+            .with_persistence(1_000, now, from_secs(20)),
+            // Sufficient rows and non-conflicting compaction => persist
             TestPartition::new(vec![
-                TestChunk::new(5, Some(0), Some(0), ChunkStorage::ClosedMutableBuffer)
+                TestChunk::new(10, Some(0), Some(0), ChunkStorage::ClosedMutableBuffer)
+                    .with_min_timestamp(from_secs(21))
                     .with_action(ChunkLifecycleAction::Compacting),
-                // still compacting => cannot write
-                TestChunk::new(6, Some(0), Some(0), ChunkStorage::ReadBuffer)
-                    .with_row_count(1_000)
+                TestChunk::new(11, Some(0), Some(0), ChunkStorage::ClosedMutableBuffer)
+                    .with_min_timestamp(from_secs(10)),
+                TestChunk::new(12, Some(0), Some(0), ChunkStorage::ReadBuffer)
+                    .with_min_timestamp(from_secs(5)),
+            ])
+            .with_persistence(1_000, now, from_secs(20)),
+            // Sufficient rows, non-conflicting compaction and compact-able chunk => persist + compact
+            TestPartition::new(vec![
+                TestChunk::new(13, Some(0), Some(0), ChunkStorage::ClosedMutableBuffer)
+                    .with_min_timestamp(from_secs(21))
                     .with_action(ChunkLifecycleAction::Compacting),
-            ]),
-            TestPartition::new(vec![
-                // chunk cold => write
-                TestChunk::new(7, Some(0), Some(0), ChunkStorage::ReadBuffer).with_row_count(20),
-            ]),
-            TestPartition::new(vec![
-                // reached row count => write
-                TestChunk::new(8, Some(0), Some(0), ChunkStorage::ReadBuffer).with_row_count(1_000),
-                // could persist, but already persisting above
-                TestChunk::new(9, Some(0), Some(0), ChunkStorage::ReadBuffer).with_row_count(1_000),
-            ]),
-            TestPartition::new(vec![
-                // chunk not cold => cannot write
-                TestChunk::new(10, Some(0), Some(11), ChunkStorage::ReadBuffer).with_row_count(20),
-            ]),
+                TestChunk::new(14, Some(0), Some(0), ChunkStorage::ClosedMutableBuffer)
+                    .with_min_timestamp(from_secs(21)),
+                TestChunk::new(15, Some(0), Some(0), ChunkStorage::ClosedMutableBuffer)
+                    .with_min_timestamp(from_secs(10)),
+                TestChunk::new(16, Some(0), Some(0), ChunkStorage::ReadBuffer)
+                    .with_min_timestamp(from_secs(5)),
+            ])
+            .with_persistence(1_000, now, from_secs(20)),
         ];
 
         let db = TestDb::from_partitions(rules, partitions);
         let mut lifecycle = LifecyclePolicy::new(&db);
 
-        lifecycle.check_for_work(from_secs(20), Instant::now());
+        lifecycle.check_for_work(from_secs(0), now);
         assert_eq!(
             *db.events.read(),
             vec![
                 MoverEvents::Compact(vec![0, 1]),
-                MoverEvents::Persist(4),
-                MoverEvents::Persist(7),
-                MoverEvents::Persist(8),
+                MoverEvents::Persist(vec![2, 3]),
+                MoverEvents::Persist(vec![4, 5]),
+                MoverEvents::Persist(vec![11, 12]),
+                MoverEvents::Persist(vec![15, 16]),
+                // 17 is the resulting chunk from the persist split above
+                // This is "quirk" of TestPartition operations being instantaneous
+                MoverEvents::Compact(vec![14, 17])
             ]
         );
     }

--- a/lifecycle/src/policy.rs
+++ b/lifecycle/src/policy.rs
@@ -258,9 +258,14 @@ where
 
     /// Check persistence
     ///
-    /// Looks for read buffer chunks to persist
+    /// Looks for chunks to combine together in the "persist"
+    /// operation. The "persist" operation combines the data from a
+    /// list chunks and creates two new chunks: one persisted, with
+    /// all data that eligible for persistence, and the second with
+    /// all data that is not yet eligible for persistence (it was
+    /// written to recently)
     ///
-    /// A chunk will be persisted if either:
+    /// A chunk will be chosen for the persist operation if either:
     ///
     /// 1. it has more than `persist_row_threshold` rows
     /// 2. it was last written to more than `late_arrive_window_seconds` ago

--- a/server/src/db/lifecycle.rs
+++ b/server/src/db/lifecycle.rs
@@ -209,10 +209,12 @@ impl LockablePartition for LockableCatalogPartition {
     fn persist_chunks(
         partition: LifecycleWriteGuard<'_, Partition, Self>,
         chunks: Vec<LifecycleWriteGuard<'_, CatalogChunk, Self::Chunk>>,
+        max_persistable_timestamp: DateTime<Utc>,
         handle: FlushHandle,
     ) -> Result<TaskTracker<Job>, Self::Error> {
         info!(table=%partition.table_name(), partition=%partition.partition_key(), "persisting chunks");
-        let (tracker, fut) = persist::persist_chunks(partition, chunks, handle)?;
+        let (tracker, fut) =
+            persist::persist_chunks(partition, chunks, max_persistable_timestamp, handle)?;
         let _ = tokio::spawn(async move { fut.await.log_if_error("persisting chunks") });
         Ok(tracker)
     }

--- a/server/src/db/lifecycle.rs
+++ b/server/src/db/lifecycle.rs
@@ -1,14 +1,15 @@
 use std::fmt::Display;
 use std::sync::Arc;
+use std::time::Instant;
 
-use chrono::{DateTime, Utc};
+use chrono::{DateTime, TimeZone, Utc};
 
 use ::lifecycle::LifecycleDb;
 use data_types::chunk_metadata::{ChunkAddr, ChunkLifecycleAction, ChunkStorage};
 use data_types::database_rules::LifecycleRules;
 use data_types::error::ErrorLogger;
 use data_types::job::Job;
-use data_types::partition_metadata::{InfluxDbType, TableSummary};
+use data_types::partition_metadata::{InfluxDbType, Statistics, TableSummary};
 use data_types::DatabaseName;
 use datafusion::physical_plan::SendableRecordBatchStream;
 use hashbrown::HashMap;
@@ -18,7 +19,7 @@ use lifecycle::{
     LifecycleChunk, LifecyclePartition, LifecycleReadGuard, LifecycleWriteGuard, LockableChunk,
     LockablePartition,
 };
-use observability_deps::tracing::info;
+use observability_deps::tracing::{info, trace};
 use tracker::{RwLock, TaskTracker};
 
 use crate::db::catalog::chunk::CatalogChunk;
@@ -28,12 +29,14 @@ use crate::Db;
 pub(crate) use compact::compact_chunks;
 pub(crate) use error::{Error, Result};
 pub(crate) use move_chunk::move_chunk_to_read_buffer;
+use persistence_windows::persistence_windows::FlushHandle;
 pub(crate) use unload::unload_read_buffer_chunk;
 pub(crate) use write::write_chunk_to_object_store;
 
 mod compact;
 mod error;
 mod move_chunk;
+mod persist;
 mod unload;
 mod write;
 
@@ -148,27 +151,26 @@ impl LockablePartition for LockableCatalogPartition {
 
     type Chunk = LockableCatalogChunk;
 
+    type PersistHandle = FlushHandle;
+
     type Error = super::lifecycle::Error;
 
-    fn read(&self) -> LifecycleReadGuard<'_, Self::Partition, Self> {
+    fn read(&self) -> LifecycleReadGuard<'_, Partition, Self> {
         LifecycleReadGuard::new(self.clone(), self.partition.as_ref())
     }
 
-    fn write(&self) -> LifecycleWriteGuard<'_, Self::Partition, Self> {
+    fn write(&self) -> LifecycleWriteGuard<'_, Partition, Self> {
         LifecycleWriteGuard::new(self.clone(), self.partition.as_ref())
     }
 
-    fn chunk(
-        s: &LifecycleReadGuard<'_, Self::Partition, Self>,
-        chunk_id: u32,
-    ) -> Option<Self::Chunk> {
+    fn chunk(s: &LifecycleReadGuard<'_, Partition, Self>, chunk_id: u32) -> Option<Self::Chunk> {
         s.chunk(chunk_id).map(|chunk| LockableCatalogChunk {
             db: Arc::clone(&s.data().db),
             chunk: Arc::clone(chunk),
         })
     }
 
-    fn chunks(s: &LifecycleReadGuard<'_, Self::Partition, Self>) -> Vec<(u32, Self::Chunk)> {
+    fn chunks(s: &LifecycleReadGuard<'_, Partition, Self>) -> Vec<(u32, Self::Chunk)> {
         s.keyed_chunks()
             .map(|(id, chunk)| {
                 (
@@ -183,12 +185,35 @@ impl LockablePartition for LockableCatalogPartition {
     }
 
     fn compact_chunks(
-        partition: LifecycleWriteGuard<'_, Self::Partition, Self>,
+        partition: LifecycleWriteGuard<'_, Partition, Self>,
         chunks: Vec<LifecycleWriteGuard<'_, CatalogChunk, Self::Chunk>>,
     ) -> Result<TaskTracker<Job>, Self::Error> {
         info!(table=%partition.table_name(), partition=%partition.partition_key(), "compacting chunks");
         let (tracker, fut) = compact::compact_chunks(partition, chunks)?;
         let _ = tokio::spawn(async move { fut.await.log_if_error("compacting chunks") });
+        Ok(tracker)
+    }
+
+    fn prepare_persist(
+        partition: &mut LifecycleWriteGuard<'_, Self::Partition, Self>,
+    ) -> Option<(Self::PersistHandle, DateTime<Utc>)> {
+        let window = partition.persistence_windows_mut().unwrap();
+        window.rotate(Instant::now());
+
+        let max_persistable_timestamp = window.max_persistable_timestamp();
+        let handle = window.flush_handle();
+        trace!(?max_persistable_timestamp, ?handle, "preparing for persist");
+        Some((handle?, max_persistable_timestamp?))
+    }
+
+    fn persist_chunks(
+        partition: LifecycleWriteGuard<'_, Partition, Self>,
+        chunks: Vec<LifecycleWriteGuard<'_, CatalogChunk, Self::Chunk>>,
+        handle: FlushHandle,
+    ) -> Result<TaskTracker<Job>, Self::Error> {
+        info!(table=%partition.table_name(), partition=%partition.partition_key(), "persisting chunks");
+        let (tracker, fut) = persist::persist_chunks(partition, chunks, handle)?;
+        let _ = tokio::spawn(async move { fut.await.log_if_error("persisting chunks") });
         Ok(tracker)
     }
 
@@ -230,6 +255,17 @@ impl LifecyclePartition for Partition {
     fn partition_key(&self) -> &str {
         self.key()
     }
+
+    fn persistable_row_count(&self) -> usize {
+        self.persistence_windows()
+            .map(|w| w.persistable_row_count())
+            .unwrap_or(0)
+    }
+
+    fn minimum_unpersisted_age(&self) -> Option<Instant> {
+        self.persistence_windows()
+            .and_then(|w| w.minimum_unpersisted_age())
+    }
 }
 
 impl LifecycleChunk for CatalogChunk {
@@ -260,6 +296,22 @@ impl LifecycleChunk for CatalogChunk {
 
     fn row_count(&self) -> usize {
         self.storage().0
+    }
+
+    fn min_timestamp(&self) -> DateTime<Utc> {
+        let table_summary = self.table_summary();
+        let col = table_summary
+            .columns
+            .iter()
+            .find(|x| x.name == TIME_COLUMN_NAME)
+            .expect("time column expected");
+
+        let min = match &col.stats {
+            Statistics::I64(stats) => stats.min.expect("time column cannot be empty"),
+            _ => panic!("unexpected time column type"),
+        };
+
+        Utc.timestamp_nanos(min)
     }
 }
 

--- a/server/src/db/lifecycle/compact.rs
+++ b/server/src/db/lifecycle/compact.rs
@@ -71,7 +71,7 @@ pub(crate) fn compact_chunks(
     let schema = Arc::new(merger.build());
 
     // drop partition lock
-    let partition = partition.unwrap().partition;
+    let partition = partition.into_data().partition;
 
     // create a new read buffer chunk with memory tracking
     let metrics = db
@@ -114,7 +114,7 @@ pub(crate) fn compact_chunks(
         let throughput = (input_rows as u128 * 1_000_000_000) / elapsed.as_nanos();
 
         info!(input_chunks=query_chunks.len(), rub_row_groups=rb_row_groups,
-                input_rows=input_rows, output_rows=guard.table_summary().count(), 
+                input_rows=input_rows, output_rows=guard.table_summary().count(),
                 sort_key=%key_str, compaction_took = ?elapsed, rows_per_sec=?throughput,  "chunk(s) compacted");
 
         Ok(DbChunk::snapshot(&guard))

--- a/server/src/db/lifecycle/compact.rs
+++ b/server/src/db/lifecycle/compact.rs
@@ -4,7 +4,6 @@ use std::future::Future;
 use std::sync::Arc;
 
 use data_types::job::Job;
-use internal_types::schema::merge::SchemaMerger;
 use lifecycle::LifecycleWriteGuard;
 use observability_deps::tracing::info;
 use query::exec::ExecutorType;
@@ -17,7 +16,7 @@ use crate::db::catalog::chunk::CatalogChunk;
 use crate::db::catalog::partition::Partition;
 use crate::db::DbChunk;
 
-use super::compute_sort_key;
+use super::{compute_sort_key, merge_schemas};
 use super::{error::Result, LockableCatalogChunk, LockableCatalogPartition};
 use crate::db::lifecycle::collect_rub;
 
@@ -59,17 +58,6 @@ pub(crate) fn compact_chunks(
         })
         .collect::<Result<Vec<_>>>()?;
 
-    // build schema
-    // Note: we only use the merged schema from the to-be-compacted chunks - not the table-wide schema, since we don't
-    // need to bother with other columns (e.g. ones that only exist in other partitions).
-    let mut merger = SchemaMerger::new();
-    for db_chunk in &query_chunks {
-        merger = merger
-            .merge(&db_chunk.schema())
-            .expect("schemas compatible");
-    }
-    let schema = Arc::new(merger.build());
-
     // drop partition lock
     let partition = partition.into_data().partition;
 
@@ -88,6 +76,14 @@ pub(crate) fn compact_chunks(
     let fut = async move {
         let key = compute_sort_key(query_chunks.iter().map(|x| x.summary()));
         let key_str = format!("\"{}\"", key); // for logging
+
+        // build schema
+        //
+        // Note: we only use the merged schema from the to-be-compacted
+        // chunks - not the table-wide schema, since we don't need to
+        // bother with other columns (e.g. ones that only exist in other
+        // partitions).
+        let schema = merge_schemas(&query_chunks);
 
         // Cannot move query_chunks as the sort key borrows the column names
         let (schema, plan) =

--- a/server/src/db/lifecycle/move_chunk.rs
+++ b/server/src/db/lifecycle/move_chunk.rs
@@ -44,7 +44,7 @@ pub fn move_chunk_to_read_buffer(
     let query_chunks = vec![db_chunk];
 
     // Drop locks
-    let chunk = guard.unwrap().chunk;
+    let chunk = guard.into_data().chunk;
     let mut rb_chunk = new_rub_chunk(db.as_ref(), &table_summary.name);
 
     let ctx = db.exec.new_context(ExecutorType::Reorg);

--- a/server/src/db/lifecycle/persist.rs
+++ b/server/src/db/lifecycle/persist.rs
@@ -1,0 +1,163 @@
+//! This module contains the code that splits and persist chunks
+
+use std::future::Future;
+use std::sync::Arc;
+
+use data_types::job::Job;
+use lifecycle::{LifecycleWriteGuard, LockableChunk};
+use observability_deps::tracing::info;
+use query::exec::ExecutorType;
+use query::frontend::reorg::ReorgPlanner;
+use query::QueryChunkMeta;
+use tracker::{TaskTracker, TrackedFuture, TrackedFutureExt};
+
+use crate::db::catalog::chunk::CatalogChunk;
+use crate::db::catalog::partition::Partition;
+use crate::db::lifecycle::{
+    collect_rub, compute_sort_key, new_rub_chunk, write_chunk_to_object_store,
+};
+use crate::db::DbChunk;
+
+use super::{LockableCatalogChunk, LockableCatalogPartition, Result};
+use persistence_windows::persistence_windows::FlushHandle;
+
+/// Split and then persist the provided chunks
+///
+/// TODO: Replace low-level locks with transaction object
+pub(super) fn persist_chunks(
+    mut partition: LifecycleWriteGuard<'_, Partition, LockableCatalogPartition>,
+    chunks: Vec<LifecycleWriteGuard<'_, CatalogChunk, LockableCatalogChunk>>,
+    flush_handle: FlushHandle,
+) -> Result<(
+    TaskTracker<Job>,
+    TrackedFuture<impl Future<Output = Result<()>> + Send>,
+)> {
+    let now = std::time::Instant::now(); // time persist duration.
+    let db = Arc::clone(&partition.data().db);
+    let table_name = partition.table_name().to_string();
+    let partition_key = partition.key().to_string();
+    let chunk_ids: Vec<_> = chunks.iter().map(|x| x.id()).collect();
+
+    info!(%table_name, %partition_key, ?chunk_ids, "splitting and persisting chunks");
+
+    let persistence_windows = partition
+        .persistence_windows_mut()
+        .expect("expected persistence windows");
+
+    let max_persistable_timestamp = persistence_windows.max_persistable_timestamp();
+
+    let flush_timestamp = max_persistable_timestamp
+        .expect("expected persistable data")
+        .timestamp_nanos();
+
+    let (tracker, registration) = db.jobs.register(Job::PersistChunks {
+        db_name: partition.db_name().to_string(),
+        partition_key: partition.key().to_string(),
+        table_name: table_name.clone(),
+        chunks: chunk_ids.clone(),
+    });
+
+    // Mark and snapshot chunks, then drop locks
+    let mut input_rows = 0;
+    let query_chunks = chunks
+        .into_iter()
+        .map(|mut chunk| {
+            // Sanity-check
+            assert!(Arc::ptr_eq(&db, &chunk.data().db));
+            assert_eq!(chunk.table_name().as_ref(), table_name.as_str());
+
+            input_rows += chunk.table_summary().count();
+            chunk.set_writing_to_object_store(&registration)?;
+            Ok(DbChunk::snapshot(&*chunk))
+        })
+        .collect::<Result<Vec<_>>>()?;
+
+    // drop partition lock guard
+    let partition = partition.into_data().partition;
+    let mut to_persist = new_rub_chunk(db.as_ref(), &table_name);
+    let mut remainder = new_rub_chunk(db.as_ref(), &table_name);
+
+    let ctx = db.exec.new_context(ExecutorType::Reorg);
+
+    let fut = async move {
+        let key = compute_sort_key(query_chunks.iter().map(|x| x.summary()));
+        let key_str = format!("\"{}\"", key); // for logging
+
+        // Cannot move query_chunks as the sort key borrows the column names
+        let (schema, plan) = ReorgPlanner::new().split_plan(
+            query_chunks.iter().map(Arc::clone),
+            key,
+            flush_timestamp,
+        )?;
+
+        let physical_plan = ctx.prepare_plan(&plan)?;
+        assert_eq!(
+            physical_plan.output_partitioning().partition_count(),
+            2,
+            "Expected split plan to produce exactly 2 partitions"
+        );
+
+        let to_persist_stream = ctx.execute_partition(Arc::clone(&physical_plan), 0).await?;
+        let remainder_stream = ctx.execute_partition(physical_plan, 1).await?;
+
+        futures::future::try_join(
+            collect_rub(to_persist_stream, &mut to_persist),
+            collect_rub(remainder_stream, &mut remainder),
+        )
+        .await?;
+
+        let persisted_rows = to_persist.rows();
+        let remainder_rows = remainder.rows();
+
+        let persist_fut = {
+            let mut partition = partition.write();
+            for id in chunk_ids {
+                partition.force_drop_chunk(id)
+            }
+
+            // Upsert remainder to catalog
+            if remainder.rows() > 0 {
+                partition.create_rub_chunk(remainder, schema.clone());
+            }
+
+            assert!(to_persist.rows() > 0);
+
+            let to_persist = LockableCatalogChunk {
+                db,
+                chunk: partition.create_rub_chunk(to_persist, schema),
+            };
+            let to_persist = to_persist.write();
+
+            // Drop partition lock guard after locking chunk
+            std::mem::drop(partition);
+
+            write_chunk_to_object_store(to_persist)?.1
+        };
+
+        // Wait for write operation to complete
+        persist_fut.await??;
+
+        {
+            // Flush persisted data from persistence windows
+            let mut partition = partition.write();
+            partition
+                .persistence_windows_mut()
+                .expect("persistence windows removed")
+                .flush(flush_handle);
+        }
+
+        let elapsed = now.elapsed();
+        // input rows per second
+        let throughput = (input_rows as u128 * 1_000_000_000) / elapsed.as_nanos();
+
+        info!(input_chunks=query_chunks.len(),
+              input_rows, persisted_rows, remainder_rows,
+              sort_key=%key_str, compaction_took = ?elapsed,
+              ?max_persistable_timestamp,
+              rows_per_sec=?throughput,  "chunk(s) persisted");
+
+        Ok(())
+    };
+
+    Ok((tracker, fut.track(registration)))
+}

--- a/server/src/db/lifecycle/persist.rs
+++ b/server/src/db/lifecycle/persist.rs
@@ -113,7 +113,7 @@ pub(super) fn persist_chunks(
 
             // Upsert remainder to catalog
             if remainder.rows() > 0 {
-                partition.create_rub_chunk(remainder, schema.clone());
+                partition.create_rub_chunk(remainder, Arc::clone(&schema));
             }
 
             assert!(to_persist.rows() > 0);

--- a/server/src/db/lifecycle/write.rs
+++ b/server/src/db/lifecycle/write.rs
@@ -58,7 +58,7 @@ pub fn write_chunk_to_object_store(
     debug!(chunk=%guard.addr(), "chunk marked WRITING , loading tables into object store");
 
     // Drop locks
-    let chunk = guard.unwrap().chunk;
+    let chunk = guard.into_data().chunk;
 
     // Create a storage to save data of this chunk
     let storage = Storage::new(Arc::clone(&db.store), db.server_id);

--- a/tests/end_to_end_cases/scenario.rs
+++ b/tests/end_to_end_cases/scenario.rs
@@ -352,8 +352,9 @@ pub async fn create_quickly_persisting_database(
             buffer_size_hard: 10 * 1024 * 1024, // 10MB
             persist: true,
             worker_backoff_millis: 100,
-            persist_row_threshold: 10_000,
             late_arrive_window_seconds,
+            persist_row_threshold: 10_000,
+            persist_age_threshold_seconds: late_arrive_window_seconds,
             ..Default::default()
         }),
         ..Default::default()


### PR DESCRIPTION
Closes https://github.com/influxdata/conductor/issues/360 closes https://github.com/influxdata/influxdb_iox/issues/1943

Adds the policy and implementation to split and persist chunks based on the persistence windows.

# Notes
@tustvold  notes that he doesn't like the interface with the persistence windows. Since I (@alamb) don't have anything better to offer, I have picked this PR up and gotten it ready for review.

# PR Sequence
- [x] Add persist guard to prevent ongoing mutations to persistence windows: https://github.com/influxdata/influxdb_iox/pull/1883
- [x] Infrastructure for jobs / protobufs / persistence windows: https://github.com/influxdata/influxdb_iox/pull/1925
- [x] Actual persistence lifecycle (this PR)