### PR TITLE
chore: move persistence windows related code into own crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2630,12 +2630,12 @@ dependencies = [
  "generated_types",
  "internal_types",
  "metrics",
- "mutable_buffer",
  "object_store",
  "observability_deps",
  "parking_lot",
  "parquet",
  "parquet-format",
+ "persistence_windows",
  "prost",
  "query",
  "snafu",
@@ -2701,6 +2701,16 @@ name = "permutation"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9978962f8a4b158e97447a6d09d2d75e206d2994eff056c894019f362b27142"
+
+[[package]]
+name = "persistence_windows"
+version = "0.1.0"
+dependencies = [
+ "chrono",
+ "entry",
+ "internal_types",
+ "snafu",
+]
 
 [[package]]
 name = "pest"
@@ -3781,6 +3791,7 @@ dependencies = [
  "observability_deps",
  "parking_lot",
  "parquet_file",
+ "persistence_windows",
  "query",
  "rand 0.8.4",
  "rand_distr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ members = [
     "observability_deps",
     "packers",
     "panic_logging",
+    "persistence_windows",
     "query",
     "query_tests",
     "read_buffer",

--- a/mutable_buffer/src/lib.rs
+++ b/mutable_buffer/src/lib.rs
@@ -59,8 +59,6 @@
     clippy::clone_on_ref_ptr
 )]
 
-pub mod checkpoint;
 pub mod chunk;
 mod column;
 mod dictionary;
-pub mod persistence_windows;

--- a/parquet_file/Cargo.toml
+++ b/parquet_file/Cargo.toml
@@ -16,7 +16,6 @@ futures = "0.3.7"
 generated_types = { path = "../generated_types" }
 internal_types = {path = "../internal_types"}
 metrics = { path = "../metrics" }
-mutable_buffer = { path = "../mutable_buffer" }
 object_store = {path = "../object_store"}
 observability_deps = { path = "../observability_deps" }
 # Turn off the "arrow" feature; it currently has a bug that causes the crate to rebuild every time
@@ -24,6 +23,7 @@ observability_deps = { path = "../observability_deps" }
 parquet = "4.0"
 parquet-format = "2.6"
 parking_lot = "0.11.1"
+persistence_windows = { path = "../persistence_windows" }
 prost = "0.7"
 query = { path = "../query" }
 snafu = "0.6"

--- a/parquet_file/src/metadata.rs
+++ b/parquet_file/src/metadata.rs
@@ -94,10 +94,6 @@ use data_types::partition_metadata::{
 };
 use generated_types::influxdata::iox::catalog::v1 as proto;
 use internal_types::schema::{InfluxColumnType, InfluxFieldType, Schema};
-use mutable_buffer::{
-    checkpoint::{DatabaseCheckpoint, PartitionCheckpoint},
-    persistence_windows::MinMaxSequence,
-};
 use parquet::{
     arrow::parquet_to_arrow_schema,
     file::{
@@ -110,6 +106,10 @@ use parquet::{
         statistics::Statistics as ParquetStatistics,
     },
     schema::types::SchemaDescriptor as ParquetSchemaDescriptor,
+};
+use persistence_windows::{
+    checkpoint::{DatabaseCheckpoint, PartitionCheckpoint},
+    min_max_sequence::MinMaxSequence,
 };
 use prost::Message;
 use snafu::{OptionExt, ResultExt, Snafu};

--- a/parquet_file/src/test_utils.rs
+++ b/parquet_file/src/test_utils.rs
@@ -21,14 +21,14 @@ use internal_types::{
     schema::{builder::SchemaBuilder, Schema, TIME_COLUMN_NAME},
     selection::Selection,
 };
-use mutable_buffer::{
-    checkpoint::{DatabaseCheckpoint, PartitionCheckpoint, PersistCheckpointBuilder},
-    persistence_windows::MinMaxSequence,
-};
 use object_store::{memory::InMemory, path::Path, ObjectStore, ObjectStoreApi};
 use parquet::{
     arrow::{ArrowReader, ParquetFileArrowReader},
     file::serialized_reader::{SerializedFileReader, SliceableCursor},
+};
+use persistence_windows::{
+    checkpoint::{DatabaseCheckpoint, PartitionCheckpoint, PersistCheckpointBuilder},
+    min_max_sequence::MinMaxSequence,
 };
 
 use crate::{

--- a/persistence_windows/Cargo.toml
+++ b/persistence_windows/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "persistence_windows"
+version = "0.1.0"
+edition = "2018"
+
+[dependencies]
+chrono = "0.4"
+entry = { path = "../entry" }
+internal_types = { path = "../internal_types" }
+snafu = "0.6.2"

--- a/persistence_windows/src/checkpoint.rs
+++ b/persistence_windows/src/checkpoint.rs
@@ -13,7 +13,7 @@
 //!
 //! ```
 //! use std::sync::{Arc, RwLock};
-//! use mutable_buffer::checkpoint::{PersistCheckpointBuilder, PartitionCheckpoint};
+//! use persistence_windows::checkpoint::{PersistCheckpointBuilder, PartitionCheckpoint};
 //!
 //! # // mocking for the example below
 //! # use chrono::Utc;
@@ -108,11 +108,11 @@
 //! Here is an example on how to organize replay:
 //!
 //! ```
-//! use mutable_buffer::checkpoint::ReplayPlanner;
+//! use persistence_windows::checkpoint::ReplayPlanner;
 //!
 //! # // mocking for the example below
 //! # use chrono::Utc;
-//! # use mutable_buffer::checkpoint::{DatabaseCheckpoint, PartitionCheckpoint, PersistCheckpointBuilder};
+//! # use persistence_windows::checkpoint::{DatabaseCheckpoint, PartitionCheckpoint, PersistCheckpointBuilder};
 //! #
 //! # struct File {}
 //! #
@@ -196,7 +196,7 @@ use std::collections::{
 use chrono::{DateTime, Utc};
 use snafu::Snafu;
 
-use crate::persistence_windows::MinMaxSequence;
+use crate::min_max_sequence::MinMaxSequence;
 
 #[derive(Debug, Snafu)]
 pub enum Error {

--- a/persistence_windows/src/lib.rs
+++ b/persistence_windows/src/lib.rs
@@ -1,0 +1,3 @@
+pub mod checkpoint;
+pub mod min_max_sequence;
+pub mod persistence_windows;

--- a/persistence_windows/src/min_max_sequence.rs
+++ b/persistence_windows/src/min_max_sequence.rs
@@ -1,0 +1,52 @@
+/// The minimum and maximum sequence numbers seen for a given sequencer
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub struct MinMaxSequence {
+    min: u64,
+    max: u64,
+}
+
+impl MinMaxSequence {
+    /// Create new min-max sequence range.
+    ///
+    /// This panics if `min > max`.
+    pub fn new(min: u64, max: u64) -> Self {
+        assert!(
+            min <= max,
+            "min ({}) is greater than max ({}) sequence",
+            min,
+            max
+        );
+        Self { min, max }
+    }
+
+    pub fn min(&self) -> u64 {
+        self.min
+    }
+
+    pub fn max(&self) -> u64 {
+        self.max
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_getters() {
+        let min_max = MinMaxSequence::new(10, 20);
+        assert_eq!(min_max.min(), 10);
+        assert_eq!(min_max.max(), 20);
+    }
+
+    #[test]
+    fn test_accepts_equal_values() {
+        MinMaxSequence::new(10, 10);
+    }
+
+    #[test]
+    #[should_panic(expected = "min (11) is greater than max (10) sequence")]
+    fn test_checks_values() {
+        MinMaxSequence::new(11, 10);
+    }
+}

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -35,6 +35,7 @@ object_store = { path = "../object_store" }
 observability_deps = { path = "../observability_deps" }
 parking_lot = "0.11.1"
 parquet_file = { path = "../parquet_file" }
+persistence_windows = { path = "../persistence_windows" }
 query = { path = "../query" }
 rand = "0.8.3"
 rand_distr = "0.4.0"

--- a/server/src/db.rs
+++ b/server/src/db.rs
@@ -29,7 +29,6 @@ use datafusion::catalog::{catalog::CatalogProvider, schema::SchemaProvider};
 use entry::{Entry, SequencedEntry};
 use metrics::KeyValue;
 use mutable_buffer::chunk::{ChunkMetrics as MutableBufferChunkMetrics, MBChunk};
-use mutable_buffer::persistence_windows::PersistenceWindows;
 use object_store::{path::parsed::DirsAndFileName, ObjectStore};
 use observability_deps::tracing::{debug, error, info};
 use parking_lot::RwLock;
@@ -37,6 +36,7 @@ use parquet_file::{
     catalog::{CheckpointData, PreservedCatalog},
     cleanup::{delete_files as delete_parquet_files, get_unreferenced_parquet_files},
 };
+use persistence_windows::persistence_windows::PersistenceWindows;
 use query::{exec::Executor, predicate::Predicate, QueryDatabase};
 use rand_distr::{Distribution, Poisson};
 use snafu::{ensure, ResultExt, Snafu};
@@ -824,7 +824,6 @@ mod tests {
     use bytes::Bytes;
     use futures::{stream, StreamExt, TryStreamExt};
     use internal_types::selection::Selection;
-    use mutable_buffer::persistence_windows::MinMaxSequence;
     use tokio_util::sync::CancellationToken;
 
     use ::test_helpers::assert_contains;
@@ -844,6 +843,7 @@ mod tests {
         metadata::IoxParquetMetaData,
         test_utils::{load_parquet_from_store_for_path, read_data_from_parquet_data},
     };
+    use persistence_windows::min_max_sequence::MinMaxSequence;
     use query::{exec::ExecutorType, frontend::sql::SqlQueryPlanner, QueryChunk, QueryDatabase};
 
     use crate::{

--- a/server/src/db/catalog/partition.rs
+++ b/server/src/db/catalog/partition.rs
@@ -16,7 +16,7 @@ use super::chunk::{CatalogChunk, ChunkStage};
 use data_types::chunk_metadata::{ChunkAddr, ChunkSummary};
 use internal_types::schema::Schema;
 use lifecycle::ChunkLifecycleAction;
-use mutable_buffer::persistence_windows::PersistenceWindows;
+use persistence_windows::persistence_windows::PersistenceWindows;
 use snafu::Snafu;
 
 #[derive(Debug, Snafu)]

--- a/server/src/db/lifecycle/write.rs
+++ b/server/src/db/lifecycle/write.rs
@@ -13,15 +13,15 @@ use chrono::Utc;
 use data_types::job::Job;
 use datafusion::physical_plan::SendableRecordBatchStream;
 use internal_types::selection::Selection;
-use mutable_buffer::checkpoint::{
-    DatabaseCheckpoint, PartitionCheckpoint, PersistCheckpointBuilder,
-};
 use object_store::path::parsed::DirsAndFileName;
 use observability_deps::tracing::{debug, warn};
 use parquet_file::{
     chunk::{ChunkMetrics as ParquetChunkMetrics, ParquetChunk},
     metadata::IoxMetadata,
     storage::Storage,
+};
+use persistence_windows::checkpoint::{
+    DatabaseCheckpoint, PartitionCheckpoint, PersistCheckpointBuilder,
 };
 use snafu::ResultExt;
 use std::{collections::BTreeMap, future::Future, sync::Arc};


### PR DESCRIPTION
The entire persistence windows data structures (including the
checkpoints) have nothing to do with the mutable buffer per se. So lets
move them into their own crate. This also makes `parquet_file` not
longer depend on `mutable_buffer`.