### PR TITLE
refactor: rework builder pattern

### DIFF
--- a/query/src/frontend/influxrpc.rs
+++ b/query/src/frontend/influxrpc.rs
@@ -1095,7 +1095,7 @@ impl InfluxRpcPlanner {
         // predicates that could be pushed down and used for
         // additional pruning we may want to add an extra layer of
         // pruning here.
-        builder.add_no_op_pruner();
+        builder = builder.add_no_op_pruner();
 
         for chunk in chunks {
             // check that it is consistent with this table_name
@@ -1106,7 +1106,7 @@ impl InfluxRpcPlanner {
                 chunk.id(),
             );
 
-            builder
+            builder = builder
                 .add_chunk(chunk)
                 .context(CreatingProvider { table_name })?;
         }

--- a/query/src/frontend/reorg.rs
+++ b/query/src/frontend/reorg.rs
@@ -184,7 +184,7 @@ impl ReorgPlanner {
         let mut builder = ProviderBuilder::new(table_name);
 
         // There are no predicates in these plans, so no need to prune them
-        builder.add_no_op_pruner();
+        builder = builder.add_no_op_pruner();
 
         for chunk in chunks {
             // check that it is consistent with this table_name
@@ -195,7 +195,7 @@ impl ReorgPlanner {
                 chunk.id(),
             );
 
-            builder
+            builder = builder
                 .add_chunk(chunk)
                 .context(CreatingProvider { table_name })?;
         }

--- a/query/src/provider.rs
+++ b/query/src/provider.rs
@@ -101,9 +101,6 @@ pub struct ProviderBuilder<C: QueryChunk + 'static> {
     schema_merger: SchemaMerger,
     chunk_pruner: Option<Arc<dyn ChunkPruner<C>>>,
     chunks: Vec<Arc<C>>,
-
-    /// If the builder has been consumed
-    finished: bool,
 }
 
 impl<C: QueryChunk> ProviderBuilder<C> {
@@ -113,18 +110,15 @@ impl<C: QueryChunk> ProviderBuilder<C> {
             schema_merger: SchemaMerger::new(),
             chunk_pruner: None,
             chunks: Vec::new(),
-            finished: false,
         }
     }
 
     /// Add a new chunk to this provider
-    pub fn add_chunk(&mut self, chunk: Arc<C>) -> Result<&mut Self> {
+    pub fn add_chunk(mut self, chunk: Arc<C>) -> Result<Self> {
         let chunk_table_schema = chunk.schema();
 
-        // TODO: avoid this clone call by making ProviderBuilder a self-consuming builder
         self.schema_merger = self
             .schema_merger
-            .clone()
             .merge(&chunk_table_schema.as_ref())
             .context(ChunkSchemaNotCompatible {
                 table_name: self.table_name.as_ref(),
@@ -137,7 +131,7 @@ impl<C: QueryChunk> ProviderBuilder<C> {
 
     /// Specify a `ChunkPruner` for the provider that will apply
     /// additional chunk level pruning based on pushed down predicates
-    pub fn add_pruner(&mut self, chunk_pruner: Arc<dyn ChunkPruner<C>>) -> &mut Self {
+    pub fn add_pruner(mut self, chunk_pruner: Arc<dyn ChunkPruner<C>>) -> Self {
         assert!(
             self.chunk_pruner.is_none(),
             "Chunk pruner already specified"
@@ -152,18 +146,14 @@ impl<C: QueryChunk> ProviderBuilder<C> {
     /// Some planners, such as InfluxRPC which apply all predicates
     /// when they get the initial list of chunks, do not need an
     /// additional pass.
-    pub fn add_no_op_pruner(&mut self) -> &mut Self {
+    pub fn add_no_op_pruner(self) -> Self {
         let chunk_pruner = Arc::new(NoOpPruner {});
         self.add_pruner(chunk_pruner)
     }
 
     /// Create the Provider
-    pub fn build(&mut self) -> Result<ChunkTableProvider<C>> {
-        assert!(!self.finished, "build called multiple times");
-        self.finished = true;
-
-        // TODO: avoid this clone call by making ProviderBuilder a self-consuming builder
-        let iox_schema = self.schema_merger.clone().build();
+    pub fn build(self) -> Result<ChunkTableProvider<C>> {
+        let iox_schema = self.schema_merger.build();
 
         // if the table was reported to exist, it should not be empty
         if self.chunks.is_empty() {
@@ -173,7 +163,7 @@ impl<C: QueryChunk> ProviderBuilder<C> {
             .fail();
         }
 
-        let chunk_pruner = match self.chunk_pruner.take() {
+        let chunk_pruner = match self.chunk_pruner {
             Some(chunk_pruner) => chunk_pruner,
             None => {
                 return InternalNoChunkPruner {
@@ -186,8 +176,8 @@ impl<C: QueryChunk> ProviderBuilder<C> {
         Ok(ChunkTableProvider {
             iox_schema,
             chunk_pruner,
-            table_name: Arc::clone(&self.table_name),
-            chunks: std::mem::take(&mut self.chunks),
+            table_name: self.table_name,
+            chunks: self.chunks,
         })
     }
 }

--- a/query/src/test.rs
+++ b/query/src/test.rs
@@ -337,10 +337,10 @@ impl TestChunk {
         };
 
         let mut merger = SchemaMerger::new();
-        merger.merge(&new_column_schema).unwrap();
+        merger = merger.merge(&new_column_schema).unwrap();
 
         if let Some(existing_schema) = self.table_schema.as_ref() {
-            merger
+            merger = merger
                 .merge(existing_schema)
                 .expect("merging was successful");
         }

--- a/server/src/db/access.rs
+++ b/server/src/db/access.rs
@@ -250,7 +250,8 @@ impl SchemaProvider for DbSchemaProvider {
     /// Create a table provider for the named table
     fn table(&self, table_name: &str) -> Option<Arc<dyn TableProvider>> {
         let mut builder = ProviderBuilder::new(table_name);
-        builder.add_pruner(Arc::clone(&self.chunk_access) as Arc<dyn ChunkPruner<DbChunk>>);
+        builder =
+            builder.add_pruner(Arc::clone(&self.chunk_access) as Arc<dyn ChunkPruner<DbChunk>>);
 
         let predicate = PredicateBuilder::new().table(table_name).build();
 
@@ -260,7 +261,7 @@ impl SchemaProvider for DbSchemaProvider {
             //
             // It is also potentially ill-formed as continuing to use the builder
             // after it has errored may not yield entirely sensible results
-            builder
+            builder = builder
                 .add_chunk(chunk)
                 .log_if_error("Adding chunks to table")
                 .ok()?;


### PR DESCRIPTION
I'm probably going to need the `SchemaMerger` for #1897 , so here is a little fix/cleanup:

The error handling in `merge` was incomplete, aka it could leave the
merger in a half-modified state in case of an error. That's generally a
bad idea and can lead to ugly bugs. Also the "builder" pattern that is
used here usually consumes itself (and provides a clone impl), so it is
easier to reason about modifications. So this commit just changes it to
self-consuming builder.

A nice side effect of the new pattern is also that it is build-time
checked and does not contain a runtime assert any longer.