### PR TITLE
fix: do not use mutex to change schema

### DIFF
--- a/internal_types/src/schema.rs
+++ b/internal_types/src/schema.rs
@@ -219,7 +219,7 @@ impl Schema {
     }
 
     /// Set the order of sort columns to the primary key id the schema
-    pub fn set_sort_key (&mut self, sort_key: &SortKey<'_>) {
+    pub fn set_sort_key(&mut self, sort_key: &SortKey<'_>) {
         let fields = self.inner.fields();
 
         // create a new_fields that are the fields with their sort keys set
@@ -231,13 +231,13 @@ impl Schema {
                     set_field_metadata(&mut new_field, None, Some(sort));
                 }
                 new_field
-            } )
+            })
             .collect();
 
         let new_meta = self.inner.metadata().clone();
         let new_schema = ArrowSchema::new_with_metadata(new_fields, new_meta);
         self.inner = Arc::new(new_schema);
-    }   
+    }
 
     /// Provide a reference to the underlying Arrow Schema object
     pub fn inner(&self) -> &ArrowSchemaRef {

--- a/query/src/frontend/reorg.rs
+++ b/query/src/frontend/reorg.rs
@@ -77,7 +77,7 @@ impl ReorgPlanner {
 
         let mut schema = provider.iox_schema();
         // Set the sort_key of the schema to the compacted chunk's sort key
-        schema.set_sort_key(&output_sort);        
+        schema.set_sort_key(&output_sort);
 
         let plan = plan_builder.build().context(BuildingPlan)?;
 

--- a/query/src/provider.rs
+++ b/query/src/provider.rs
@@ -678,7 +678,6 @@ impl<C: QueryChunk + 'static> Deduplicater<C> {
         chunk: Arc<C>,
         input: Arc<dyn ExecutionPlan>,
     ) -> Result<Arc<dyn ExecutionPlan>> {
-
         // Todo: check there is sort key and it matches with the given one
         //let sort_key = schema.sort_key();
         if chunk.is_sorted_on_pk() {
@@ -687,7 +686,7 @@ impl<C: QueryChunk + 'static> Deduplicater<C> {
 
         let schema = chunk.schema();
         let sort_exprs = arrow_pk_sort_exprs(schema.primary_key());
-        
+
         // Create SortExec operator
         Ok(Arc::new(
             SortExec::try_new(sort_exprs, input).context(InternalSort)?,

--- a/server/src/db/catalog/chunk.rs
+++ b/server/src/db/catalog/chunk.rs
@@ -1,7 +1,6 @@
 use std::sync::Arc;
 
 use chrono::{DateTime, Utc};
-use parking_lot::Mutex;
 use snafu::Snafu;
 
 use data_types::chunk_metadata::ChunkAddr;
@@ -133,7 +132,7 @@ pub enum ChunkStage {
     /// or more chunks and creates a single new frozen chunk.
     Frozen {
         /// Metadata (statistics, schema) about this chunk
-        meta: Arc<Mutex<ChunkMetadata>>,
+        meta: Arc<ChunkMetadata>,
 
         /// Internal memory representation of the frozen chunk.
         representation: ChunkStageFrozenRepr,
@@ -144,7 +143,7 @@ pub enum ChunkStage {
     /// Chunk cannot receive new data. It is persisted.
     Persisted {
         /// Metadata (statistics, schema) about this chunk
-        meta: Arc<Mutex<ChunkMetadata>>,
+        meta: Arc<ChunkMetadata>,
 
         /// Parquet chunk that lives immutable within the object store.
         parquet: Arc<ParquetChunk>,
@@ -283,10 +282,10 @@ impl CatalogChunk {
         let summary = summaries.into_iter().next().unwrap();
 
         let stage = ChunkStage::Frozen {
-            meta: Arc::new(Mutex::new(ChunkMetadata {
+            meta: Arc::new(ChunkMetadata {
                 table_summary: Arc::new(summary),
                 schema: Arc::new(schema),
-            })),
+            }),
             representation: ChunkStageFrozenRepr::ReadBuffer(Arc::new(chunk)),
         };
 
@@ -316,10 +315,10 @@ impl CatalogChunk {
         assert_eq!(chunk.table_name(), addr.table_name.as_ref());
 
         // Cache table summary + schema
-        let meta = Arc::new(Mutex::new(ChunkMetadata {
+        let meta = Arc::new(ChunkMetadata {
             table_summary: Arc::clone(chunk.table_summary()),
             schema: chunk.schema(),
-        }));
+        });
 
         let stage = ChunkStage::Persisted {
             parquet: chunk,
@@ -473,14 +472,8 @@ impl CatalogChunk {
                 // The stats for open chunks change so can't be cached
                 Arc::new(mb_chunk.table_summary())
             }
-            ChunkStage::Frozen { meta, .. } => {
-                let meta = meta.lock();
-                Arc::clone(&meta.table_summary)
-            }
-            ChunkStage::Persisted { meta, .. } => {
-                let meta = meta.lock();
-                Arc::clone(&meta.table_summary)
-            }
+            ChunkStage::Frozen { meta, .. } => Arc::clone(&meta.table_summary),
+            ChunkStage::Persisted { meta, .. } => Arc::clone(&meta.table_summary),
         }
     }
 
@@ -545,7 +538,7 @@ impl CatalogChunk {
 
                 self.stage = ChunkStage::Frozen {
                     representation: ChunkStageFrozenRepr::MutableBufferSnapshot(Arc::clone(&s)),
-                    meta: Arc::new(Mutex::new(metadata)),
+                    meta: Arc::new(metadata),
                 };
                 Ok(())
             }
@@ -619,10 +612,16 @@ impl CatalogChunk {
     /// storage.
     pub fn set_moved(&mut self, chunk: Arc<RBChunk>, schema: Schema) -> Result<()> {
         match &mut self.stage {
-            ChunkStage::Frozen {meta,  representation, .. } => {
+            ChunkStage::Frozen {
+                meta,
+                representation,
+                ..
+            } => {
                 // after moved, the chunk is sorted and schema need to get updated
-                let mut metadata = meta.lock();
-                *metadata.schema =schema;
+                *meta = Arc::new(ChunkMetadata {
+                    table_summary: Arc::clone(&meta.table_summary),
+                    schema: Arc::new(schema),
+                });
 
                 match &representation {
                     ChunkStageFrozenRepr::MutableBufferSnapshot(_) => {
@@ -646,7 +645,7 @@ impl CatalogChunk {
                     }
                     .fail(),
                 }
-            },
+            }
             _ => {
                 unexpected_state!(self, "setting moved", "Moving", self.stage)
             }

--- a/server/src/db/chunk.rs
+++ b/server/src/db/chunk.rs
@@ -4,7 +4,6 @@ use std::{
 };
 
 use data_types::partition_metadata;
-use parking_lot::Mutex;
 use partition_metadata::TableSummary;
 use snafu::{ResultExt, Snafu};
 
@@ -79,7 +78,7 @@ pub struct DbChunk {
     id: u32,
     table_name: Arc<str>,
     state: State,
-    meta: Arc<Mutex<ChunkMetadata>>,
+    meta: Arc<ChunkMetadata>,
 }
 
 #[derive(Debug)]
@@ -113,7 +112,7 @@ impl DbChunk {
                     table_summary: Arc::new(mb_chunk.table_summary()),
                     schema: snapshot.full_schema(),
                 };
-                (state, Arc::new(Mutex::new(meta)))
+                (state, Arc::new(meta))
             }
             ChunkStage::Frozen {
                 representation,
@@ -449,12 +448,10 @@ impl QueryChunk for DbChunk {
 
 impl QueryChunkMeta for DbChunk {
     fn summary(&self) -> &TableSummary {
-        self.meta.table_summary.as_ref() // original that is no longer working because of the mutex
-        // have tried may other things but if I do not modify the return value as a MutexGaurd, they won't work. But since this is a function of a trait, I do not want to modify it 
+        self.meta.table_summary.as_ref()
     }
 
     fn schema(&self) -> Arc<Schema> {
-        let meta = self.meta.lock();
-        Arc::clone(&meta.schema)
+        Arc::clone(&self.meta.schema)
     }
 }

--- a/server/src/db/lifecycle/move_chunk.rs
+++ b/server/src/db/lifecycle/move_chunk.rs
@@ -72,8 +72,6 @@ pub fn move_chunk_to_read_buffer(
             rb_chunk.upsert_table(batch?)
         }
 
-
-
         // Can drop and re-acquire as lifecycle action prevents concurrent modification
         let mut guard = chunk.write();
 


### PR DESCRIPTION
(note this is a merge into the `ntran/avoid_sort_in_scan` branch)

This is a proposed way to beat the Rust borrow checker into submission and create a shareable ChunkMetadata