### PR TITLE
refactor: remove unused `mutable_size_threshold` in lifecycle setting

### DIFF
--- a/data_types/src/database_rules.rs
+++ b/data_types/src/database_rules.rs
@@ -127,11 +127,6 @@ pub struct LifecycleRules {
     /// for at least this number of seconds unless it exceeds the mutable_size_threshold
     pub mutable_minimum_age_seconds: Option<NonZeroU32>,
 
-    /// Once a chunk of data within a partition reaches this number of bytes
-    /// writes outside its keyspace will be directed to a new chunk and this
-    /// chunk will be compacted to the read buffer as soon as possible
-    pub mutable_size_threshold: Option<NonZeroUsize>,
-
     /// Once the total amount of buffered data in memory reaches this size start
     /// dropping data from memory
     pub buffer_size_soft: Option<NonZeroUsize>,
@@ -179,7 +174,6 @@ impl Default for LifecycleRules {
         Self {
             mutable_linger_seconds: None,
             mutable_minimum_age_seconds: None,
-            mutable_size_threshold: None,
             buffer_size_soft: None,
             buffer_size_hard: None,
             drop_non_persisted: false,

--- a/generated_types/protos/influxdata/iox/management/v1/database_rules.proto
+++ b/generated_types/protos/influxdata/iox/management/v1/database_rules.proto
@@ -43,11 +43,6 @@ message LifecycleRules {
   // for at least this number of seconds unless it exceeds the mutable_size_threshold
   uint32 mutable_minimum_age_seconds = 2;
 
-  // Once a chunk of data within a partition reaches this number of bytes
-  // writes outside its keyspace will be directed to a new chunk and this
-  // chunk will be compacted to the read buffer as soon as possible
-  uint64 mutable_size_threshold = 3;
-
   // Once the total amount of buffered data in memory reaches this size start
   // dropping data from memory
   uint64 buffer_size_soft = 4;

--- a/generated_types/src/database_rules/lifecycle.rs
+++ b/generated_types/src/database_rules/lifecycle.rs
@@ -21,10 +21,6 @@ impl From<LifecycleRules> for management::LifecycleRules {
                 .mutable_minimum_age_seconds
                 .map(Into::into)
                 .unwrap_or_default(),
-            mutable_size_threshold: config
-                .mutable_size_threshold
-                .map(|x| x.get() as u64)
-                .unwrap_or_default(),
             buffer_size_soft: config
                 .buffer_size_soft
                 .map(|x| x.get() as u64)
@@ -54,7 +50,6 @@ impl TryFrom<management::LifecycleRules> for LifecycleRules {
         Ok(Self {
             mutable_linger_seconds: proto.mutable_linger_seconds.try_into().ok(),
             mutable_minimum_age_seconds: proto.mutable_minimum_age_seconds.try_into().ok(),
-            mutable_size_threshold: (proto.mutable_size_threshold as usize).try_into().ok(),
             buffer_size_soft: (proto.buffer_size_soft as usize).try_into().ok(),
             buffer_size_hard: (proto.buffer_size_hard as usize).try_into().ok(),
             drop_non_persisted: proto.drop_non_persisted,
@@ -89,7 +84,6 @@ mod tests {
         let protobuf = management::LifecycleRules {
             mutable_linger_seconds: 123,
             mutable_minimum_age_seconds: 5345,
-            mutable_size_threshold: 232,
             buffer_size_soft: 353,
             buffer_size_hard: 232,
             drop_non_persisted: true,
@@ -114,10 +108,6 @@ mod tests {
             protobuf.mutable_minimum_age_seconds
         );
         assert_eq!(
-            config.mutable_size_threshold.unwrap().get(),
-            protobuf.mutable_size_threshold as usize
-        );
-        assert_eq!(
             config.buffer_size_soft.unwrap().get(),
             protobuf.buffer_size_soft as usize
         );
@@ -133,7 +123,6 @@ mod tests {
             back.mutable_minimum_age_seconds,
             protobuf.mutable_minimum_age_seconds
         );
-        assert_eq!(back.mutable_size_threshold, protobuf.mutable_size_threshold);
         assert_eq!(back.buffer_size_soft, protobuf.buffer_size_soft);
         assert_eq!(back.buffer_size_hard, protobuf.buffer_size_hard);
         assert_eq!(back.drop_non_persisted, protobuf.drop_non_persisted);

--- a/src/commands/database.rs
+++ b/src/commands/database.rs
@@ -88,14 +88,6 @@ struct Create {
     #[structopt(long, default_value = "0")] // 0 minutes
     mutable_minimum_age_seconds: u32,
 
-    /// Once a chunk of data within a partition reaches this number of bytes
-    /// writes outside its keyspace will be directed to a new chunk
-    ///
-    /// This chunk will be then compacted once it becomes cold for writes
-    /// based on the mutable_linger_seconds and mutable_minimum_age_seconds
-    #[structopt(long, default_value = "10485760")] // 10485760 = 10*1024*1024
-    mutable_size_threshold: usize,
-
     /// Once the total amount of buffered data in memory reaches this size start
     /// dropping data from memory based on the drop_order
     #[structopt(long, default_value = "52428800")] // 52428800 = 50*1024*1024
@@ -195,7 +187,6 @@ pub async fn command(url: String, config: Config) -> Result<()> {
                 lifecycle_rules: Some(LifecycleRules {
                     mutable_linger_seconds: command.mutable_linger_seconds,
                     mutable_minimum_age_seconds: command.mutable_minimum_age_seconds,
-                    mutable_size_threshold: command.mutable_size_threshold as _,
                     buffer_size_soft: command.buffer_size_soft as _,
                     buffer_size_hard: command.buffer_size_hard as _,
                     drop_non_persisted: command.drop_non_persisted,

--- a/tests/end_to_end_cases/scenario.rs
+++ b/tests/end_to_end_cases/scenario.rs
@@ -348,7 +348,6 @@ pub async fn create_quickly_persisting_database(
         }),
         lifecycle_rules: Some(LifecycleRules {
             mutable_linger_seconds: 1,
-            mutable_size_threshold: 100,
             buffer_size_soft: 512 * 1024,       // 512K
             buffer_size_hard: 10 * 1024 * 1024, // 10MB
             persist: true,


### PR DESCRIPTION
# Rationale:
Re https://github.com/influxdata/influxdb_iox/issues/1878 and re https://github.com/influxdata/influxdb_iox/issues/1906

The `mutable_size_threshold` is not connected to any code or policy, and having it in the lifecycle rules is confusing. The PR that removed it was https://github.com/influxdata/influxdb_iox/pull/1875

# Changes:
1. Remove the unused setting
