### PR TITLE
docs: Note that rollover_partition is not automatically called

### DIFF
--- a/server/src/db.rs
+++ b/server/src/db.rs
@@ -291,7 +291,12 @@ impl Db {
     }
 
     /// Rolls over the active chunk in the database's specified
-    /// partition. Returns the previously open (now closed) Chunk if there was any.
+    /// partition. Returns the previously open (now closed) Chunk if
+    /// there was any.
+    ///
+    /// NOTE: this function is only used in tests and can be invoked
+    /// by the management API. It is not called automatically by the
+    /// lifecycle manager during normal operation.
     pub async fn rollover_partition(
         &self,
         table_name: &str,


### PR DESCRIPTION
re https://github.com/influxdata/influxdb_iox/issues/1906 suggested by @mkmik  

# Rationale
This function is not invoked automatically by the lifecycle manager, which may not be obvious to a casual reader. 

# Changes
Add a comment to try and help future readers save some time

