### PR TITLE
feat: store schemas per table, enforce schema on write

### DIFF
--- a/entry/src/entry.rs
+++ b/entry/src/entry.rs
@@ -1813,7 +1813,7 @@ pub mod test_helpers {
     /// Converts the line protocol to a collection of `Entry` with a single
     /// shard and a single partition, which is useful for testing when `lp` is
     /// large. Batches are sized according to LP_BATCH_SIZE.
-    pub fn lp_to_entries(lp: &str) -> Vec<Entry> {
+    pub fn lp_to_entries(lp: &str, partitioner: &impl Partitioner) -> Vec<Entry> {
         let lines: Vec<_> = parse_lines(&lp).map(|l| l.unwrap()).collect();
 
         let default_time = Utc::now().timestamp_nanos();
@@ -1821,16 +1821,11 @@ pub mod test_helpers {
         lines
             .chunks(LP_BATCH_SIZE)
             .map(|batch| {
-                lines_to_sharded_entries(
-                    batch,
-                    default_time,
-                    sharder(1).as_ref(),
-                    &hour_partitioner(),
-                )
-                .unwrap()
-                .pop()
-                .unwrap()
-                .entry
+                lines_to_sharded_entries(batch, default_time, sharder(1).as_ref(), partitioner)
+                    .unwrap()
+                    .pop()
+                    .unwrap()
+                    .entry
             })
             .collect::<Vec<_>>()
     }

--- a/parquet_file/src/catalog.rs
+++ b/parquet_file/src/catalog.rs
@@ -144,6 +144,15 @@ pub enum Error {
     },
 
     #[snafu(
+        display("Schema for {:?} does not work with existing schema: {}", path, source),
+        visibility(pub)
+    )]
+    SchemaError {
+        source: Box<dyn std::error::Error + Send + Sync>,
+        path: DirsAndFileName,
+    },
+
+    #[snafu(
         display("Cannot create parquet chunk from {:?}: {}", path, source),
         visibility(pub)
     )]

--- a/server/src/db.rs
+++ b/server/src/db.rs
@@ -795,7 +795,10 @@ pub mod test_helpers {
 
     /// Try to write lineprotocol data and return all tables that where written.
     pub async fn try_write_lp(db: &Db, lp: &str) -> Result<Vec<String>> {
-        let entries = lp_to_entries(lp);
+        let entries = {
+            let partitioner = &db.rules.read().partition_template;
+            lp_to_entries(lp, partitioner)
+        };
 
         let mut tables = HashSet::new();
         for entry in entries {

--- a/server/src/db/catalog/table.rs
+++ b/server/src/db/catalog/table.rs
@@ -125,7 +125,7 @@ impl<'a> TableSchemaUpsertHandle<'a> {
         table_schema: &'a RwLock<Schema>,
         new_schema: &Schema,
     ) -> Result<Self, SchemaMergerError> {
-        // Be optimistic and only get a read lock. It is rather rate that the schema will change when new data arrives
+        // Be optimistic and only get a read lock. It is rather rare that the schema will change when new data arrives
         // and we do NOT want to serialize all writes on a single lock.
         let table_schema_read = table_schema.read();
 

--- a/server_benchmarks/benches/snapshot.rs
+++ b/server_benchmarks/benches/snapshot.rs
@@ -1,5 +1,8 @@
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
-use entry::{test_helpers::lp_to_entries, Sequence};
+use entry::{
+    test_helpers::{hour_partitioner, lp_to_entries},
+    Sequence,
+};
 use flate2::read::GzDecoder;
 use mutable_buffer::chunk::{ChunkMetrics, MBChunk};
 use std::io::Read;
@@ -20,7 +23,7 @@ fn chunk(count: usize) -> MBChunk {
 
     let sequence = Some(Sequence::new(1, 5));
     for _ in 0..count {
-        for entry in lp_to_entries(&lp) {
+        for entry in lp_to_entries(&lp, &hour_partitioner()) {
             for write in entry.partition_writes().iter().flatten() {
                 for batch in write.table_batches() {
                     chunk.write_table_batch(sequence.as_ref(), batch).unwrap();

--- a/server_benchmarks/benches/write.rs
+++ b/server_benchmarks/benches/write.rs
@@ -1,5 +1,8 @@
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
-use entry::{test_helpers::lp_to_entries, Entry, Sequence};
+use entry::{
+    test_helpers::{hour_partitioner, lp_to_entries},
+    Entry, Sequence,
+};
 use flate2::read::GzDecoder;
 use mutable_buffer::chunk::{ChunkMetrics, MBChunk};
 use std::io::Read;
@@ -26,7 +29,7 @@ fn load_entries() -> Vec<Entry> {
     let mut gz = GzDecoder::new(&raw[..]);
     let mut lp = String::new();
     gz.read_to_string(&mut lp).unwrap();
-    lp_to_entries(&lp)
+    lp_to_entries(&lp, &hour_partitioner())
 }
 
 pub fn write_mb(c: &mut Criterion) {


### PR DESCRIPTION
This way we can:

- check for schema matches even for writes going into different
  partitions
- solve #1768 and #1884 in some future PR

I have put some special care into the locking, so we don't serialize on table-wide schema.

Closes #1897.
Closes https://github.com/influxdata/influxdb_iox/issues/636
