### PR TITLE
fix: Ensure mutable_linger_seconds can not be None

### DIFF
--- a/data_types/src/database_rules.rs
+++ b/data_types/src/database_rules.rs
@@ -106,6 +106,7 @@ impl Partitioner for DatabaseRules {
     }
 }
 
+pub const DEFAULT_MUTABLE_LINGER_SECONDS: u32 = 300;
 pub const DEFAULT_WORKER_BACKOFF_MILLIS: u64 = 1_000;
 pub const DEFAULT_CATALOG_TRANSACTIONS_UNTIL_CHECKPOINT: u64 = 100;
 pub const DEFAULT_MUB_ROW_THRESHOLD: usize = 100_000;
@@ -121,7 +122,7 @@ pub struct LifecycleRules {
     /// buffer) if the chunk is older than mutable_min_lifetime_seconds
     ///
     /// Represents the chunk transition open -> moving and closed -> moving
-    pub mutable_linger_seconds: Option<NonZeroU32>,
+    pub mutable_linger_seconds: NonZeroU32,
 
     /// A chunk of data within a partition is guaranteed to remain mutable
     /// for at least this number of seconds unless it exceeds the mutable_size_threshold
@@ -172,7 +173,7 @@ impl LifecycleRules {
 impl Default for LifecycleRules {
     fn default() -> Self {
         Self {
-            mutable_linger_seconds: None,
+            mutable_linger_seconds: NonZeroU32::new(DEFAULT_MUTABLE_LINGER_SECONDS).unwrap(),
             mutable_minimum_age_seconds: None,
             buffer_size_soft: None,
             buffer_size_hard: None,

--- a/lifecycle/src/policy.rs
+++ b/lifecycle/src/policy.rs
@@ -15,7 +15,6 @@ use crate::{
     ChunkLifecycleAction, LifecycleChunk, LifecycleDb, LifecyclePartition, LockableChunk,
     LockablePartition,
 };
-use std::num::NonZeroU32;
 
 /// Number of seconds to wait before retying a failed lifecycle action
 pub const LIFECYCLE_ACTION_BACKOFF: Duration = Duration::from_secs(10);
@@ -484,15 +483,10 @@ fn can_move<C: LifecycleChunk>(rules: &LifecycleRules, chunk: &C, now: DateTime<
         return true;
     }
 
-    // minimum value for linuger is 1 second.
-    // TODO: turn mutable_linger_seconds into a u32 because it being Option<NonZeroU32>
-    // is an unnecessary complication.
-    // TODO: move the default to the configuration layer.
-    let linger = rules
-        .mutable_linger_seconds
-        .unwrap_or_else(|| NonZeroU32::new(300).unwrap());
     match chunk.time_of_last_write() {
-        Some(last_write) if elapsed_seconds(now, last_write) >= linger.get() => {
+        Some(last_write)
+            if elapsed_seconds(now, last_write) >= rules.mutable_linger_seconds.get() =>
+        {
             match (
                 rules.mutable_minimum_age_seconds,
                 chunk.time_of_first_write(),
@@ -898,7 +892,7 @@ mod tests {
     fn test_can_move() {
         // If only mutable_linger set can move a chunk once passed
         let rules = LifecycleRules {
-            mutable_linger_seconds: Some(NonZeroU32::new(10).unwrap()),
+            mutable_linger_seconds: NonZeroU32::new(10).unwrap(),
             ..Default::default()
         };
         let chunk = TestChunk::new(0, Some(0), Some(0), ChunkStorage::OpenMutableBuffer);
@@ -912,7 +906,7 @@ mod tests {
 
         // If mutable_minimum_age_seconds set must also take this into account
         let rules = LifecycleRules {
-            mutable_linger_seconds: Some(NonZeroU32::new(10).unwrap()),
+            mutable_linger_seconds: NonZeroU32::new(10).unwrap(),
             mutable_minimum_age_seconds: Some(NonZeroU32::new(60).unwrap()),
             ..Default::default()
         };
@@ -946,31 +940,6 @@ mod tests {
         let chunk = TestChunk::new(0, None, None, ChunkStorage::OpenMutableBuffer)
             .with_row_count(DEFAULT_MUB_ROW_THRESHOLD - 1);
         assert!(!can_move(&rules, &chunk, from_secs(0)));
-
-        // Also check that a "None" linger time is treated like a zero.
-
-        // If mutable_minimum_age_seconds set must also take this into account
-        let rules = LifecycleRules {
-            mutable_linger_seconds: None,
-            mutable_minimum_age_seconds: Some(NonZeroU32::new(60).unwrap()),
-            ..Default::default()
-        };
-        let chunk = TestChunk::new(0, Some(0), Some(0), ChunkStorage::OpenMutableBuffer);
-        assert!(!can_move(&rules, &chunk, from_secs(9)));
-        assert!(!can_move(&rules, &chunk, from_secs(11)));
-        assert!(can_move(&rules, &chunk, from_secs(301)));
-
-        let chunk = TestChunk::new(0, Some(0), Some(0), ChunkStorage::OpenMutableBuffer)
-            .with_row_count(DEFAULT_MUB_ROW_THRESHOLD - 1);
-        assert!(!can_move(&rules, &chunk, from_secs(9)));
-        assert!(!can_move(&rules, &chunk, from_secs(11)));
-        assert!(can_move(&rules, &chunk, from_secs(301)));
-
-        let chunk = TestChunk::new(0, Some(0), Some(0), ChunkStorage::OpenMutableBuffer)
-            .with_row_count(DEFAULT_MUB_ROW_THRESHOLD + 1);
-        assert!(can_move(&rules, &chunk, from_secs(9)));
-        assert!(can_move(&rules, &chunk, from_secs(11)));
-        assert!(can_move(&rules, &chunk, from_secs(301)));
     }
 
     #[test]
@@ -1049,7 +1018,7 @@ mod tests {
     #[test]
     fn test_mutable_linger() {
         let rules = LifecycleRules {
-            mutable_linger_seconds: Some(NonZeroU32::new(10).unwrap()),
+            mutable_linger_seconds: NonZeroU32::new(10).unwrap(),
             ..Default::default()
         };
         let chunks = vec![
@@ -1093,7 +1062,7 @@ mod tests {
     async fn test_backoff() {
         let mut registry = TaskRegistry::new();
         let rules = LifecycleRules {
-            mutable_linger_seconds: Some(NonZeroU32::new(100).unwrap()),
+            mutable_linger_seconds: NonZeroU32::new(100).unwrap(),
             ..Default::default()
         };
         let db = TestDb::new(rules, vec![]);
@@ -1120,7 +1089,7 @@ mod tests {
     #[test]
     fn test_minimum_age() {
         let rules = LifecycleRules {
-            mutable_linger_seconds: Some(NonZeroU32::new(10).unwrap()),
+            mutable_linger_seconds: NonZeroU32::new(10).unwrap(),
             mutable_minimum_age_seconds: Some(NonZeroU32::new(60).unwrap()),
             ..Default::default()
         };
@@ -1278,7 +1247,7 @@ mod tests {
     #[test]
     fn test_compact() {
         let rules = LifecycleRules {
-            mutable_linger_seconds: Some(NonZeroU32::new(10).unwrap()),
+            mutable_linger_seconds: NonZeroU32::new(10).unwrap(),
             persist_row_threshold: NonZeroUsize::new(1_000).unwrap(),
             ..Default::default()
         };
@@ -1369,7 +1338,7 @@ mod tests {
     #[test]
     fn test_persist() {
         let rules = LifecycleRules {
-            mutable_linger_seconds: Some(NonZeroU32::new(10).unwrap()),
+            mutable_linger_seconds: NonZeroU32::new(10).unwrap(),
             persist: true,
             persist_row_threshold: NonZeroUsize::new(1_000).unwrap(),
             late_arrive_window_seconds: NonZeroU32::new(10).unwrap(),
@@ -1433,7 +1402,7 @@ mod tests {
     #[test]
     fn test_moves_closed() {
         let rules = LifecycleRules {
-            mutable_linger_seconds: Some(NonZeroU32::new(10).unwrap()),
+            mutable_linger_seconds: NonZeroU32::new(10).unwrap(),
             mutable_minimum_age_seconds: Some(NonZeroU32::new(60).unwrap()),
             ..Default::default()
         };

--- a/tests/end_to_end_cases/management_api.rs
+++ b/tests/end_to_end_cases/management_api.rs
@@ -14,6 +14,7 @@ use super::scenario::{
     create_readable_database, create_two_partition_database, create_unreadable_database, rand_name,
 };
 use crate::common::server_fixture::ServerFixture;
+use data_types::database_rules::DEFAULT_MUTABLE_LINGER_SECONDS;
 use std::time::Instant;
 use tonic::Code;
 
@@ -243,6 +244,10 @@ async fn test_create_get_update_database() {
         ignore_errors: true,
         ..Default::default()
     }));
+    rules.lifecycle_rules = Some(LifecycleRules {
+        mutable_linger_seconds: DEFAULT_MUTABLE_LINGER_SECONDS,
+        ..rules.lifecycle_rules.unwrap()
+    });
 
     let updated_rules = client
         .update_database(rules.clone())


### PR DESCRIPTION
Follow up cleanup PR: https://github.com/influxdata/influxdb_iox/pull/1917 (no longer make mutable_linger_seconds an option and move the defaulting to the configuration layer)

Closes #1899
Closes https://github.com/influxdata/influxdb_iox/issues/1914