### PR TITLE
refactor: Turn mutable_linger_seconds into a non-optional

### DIFF
--- a/data_types/src/database_rules.rs
+++ b/data_types/src/database_rules.rs
@@ -106,6 +106,7 @@ impl Partitioner for DatabaseRules {
     }
 }
 
+pub const DEFAULT_MUTABLE_LINGER_SECONDS: u32 = 300;
 pub const DEFAULT_WORKER_BACKOFF_MILLIS: u64 = 1_000;
 pub const DEFAULT_CATALOG_TRANSACTIONS_UNTIL_CHECKPOINT: u64 = 100;
 pub const DEFAULT_MUB_ROW_THRESHOLD: usize = 100_000;
@@ -121,7 +122,7 @@ pub struct LifecycleRules {
     /// buffer) if the chunk is older than mutable_min_lifetime_seconds
     ///
     /// Represents the chunk transition open -> moving and closed -> moving
-    pub mutable_linger_seconds: Option<NonZeroU32>,
+    pub mutable_linger_seconds: NonZeroU32,
 
     /// A chunk of data within a partition is guaranteed to remain mutable
     /// for at least this number of seconds unless it exceeds the mutable_size_threshold
@@ -177,7 +178,7 @@ impl LifecycleRules {
 impl Default for LifecycleRules {
     fn default() -> Self {
         Self {
-            mutable_linger_seconds: None,
+            mutable_linger_seconds: NonZeroU32::new(DEFAULT_MUTABLE_LINGER_SECONDS).unwrap(),
             mutable_minimum_age_seconds: None,
             mutable_size_threshold: None,
             buffer_size_soft: None,

--- a/generated_types/src/database_rules/lifecycle.rs
+++ b/generated_types/src/database_rules/lifecycle.rs
@@ -3,8 +3,9 @@ use std::num::{NonZeroU32, NonZeroU64, NonZeroUsize};
 
 use data_types::database_rules::{
     LifecycleRules, DEFAULT_CATALOG_TRANSACTIONS_UNTIL_CHECKPOINT,
-    DEFAULT_LATE_ARRIVE_WINDOW_SECONDS, DEFAULT_PERSIST_AGE_THRESHOLD_SECONDS,
-    DEFAULT_PERSIST_ROW_THRESHOLD, DEFAULT_WORKER_BACKOFF_MILLIS,
+    DEFAULT_LATE_ARRIVE_WINDOW_SECONDS, DEFAULT_MUTABLE_LINGER_SECONDS,
+    DEFAULT_PERSIST_AGE_THRESHOLD_SECONDS, DEFAULT_PERSIST_ROW_THRESHOLD,
+    DEFAULT_WORKER_BACKOFF_MILLIS,
 };
 
 use crate::google::FieldViolation;
@@ -13,10 +14,7 @@ use crate::influxdata::iox::management::v1 as management;
 impl From<LifecycleRules> for management::LifecycleRules {
     fn from(config: LifecycleRules) -> Self {
         Self {
-            mutable_linger_seconds: config
-                .mutable_linger_seconds
-                .map(Into::into)
-                .unwrap_or_default(),
+            mutable_linger_seconds: config.mutable_linger_seconds.get(),
             mutable_minimum_age_seconds: config
                 .mutable_minimum_age_seconds
                 .map(Into::into)
@@ -52,7 +50,12 @@ impl TryFrom<management::LifecycleRules> for LifecycleRules {
 
     fn try_from(proto: management::LifecycleRules) -> Result<Self, Self::Error> {
         Ok(Self {
-            mutable_linger_seconds: proto.mutable_linger_seconds.try_into().ok(),
+            mutable_linger_seconds: NonZeroU32::new(if proto.mutable_linger_seconds == 0 {
+                DEFAULT_MUTABLE_LINGER_SECONDS
+            } else {
+                proto.mutable_linger_seconds
+            })
+            .unwrap(),
             mutable_minimum_age_seconds: proto.mutable_minimum_age_seconds.try_into().ok(),
             mutable_size_threshold: (proto.mutable_size_threshold as usize).try_into().ok(),
             buffer_size_soft: (proto.buffer_size_soft as usize).try_into().ok(),
@@ -106,7 +109,7 @@ mod tests {
         let back: management::LifecycleRules = config.clone().into();
 
         assert_eq!(
-            config.mutable_linger_seconds.unwrap().get(),
+            config.mutable_linger_seconds.get(),
             protobuf.mutable_linger_seconds
         );
         assert_eq!(

--- a/tests/end_to_end_cases/management_api.rs
+++ b/tests/end_to_end_cases/management_api.rs
@@ -14,6 +14,7 @@ use super::scenario::{
     create_readable_database, create_two_partition_database, create_unreadable_database, rand_name,
 };
 use crate::common::server_fixture::ServerFixture;
+use data_types::database_rules::DEFAULT_MUTABLE_LINGER_SECONDS;
 use std::time::Instant;
 use tonic::Code;
 
@@ -243,6 +244,10 @@ async fn test_create_get_update_database() {
         ignore_errors: true,
         ..Default::default()
     }));
+    rules.lifecycle_rules = Some(LifecycleRules {
+        mutable_linger_seconds: DEFAULT_MUTABLE_LINGER_SECONDS,
+        ..rules.lifecycle_rules.unwrap()
+    });
 
     let updated_rules = client
         .update_database(rules.clone())


### PR DESCRIPTION
This is a cleanup follow up to #1915