### PR TITLE
refactor: Infrastructure for persistence

### DIFF
--- a/data_types/src/job.rs
+++ b/data_types/src/job.rs
@@ -34,6 +34,14 @@ pub enum Job {
         chunks: Vec<u32>,
     },
 
+    /// Split and persist a set of chunks
+    PersistChunks {
+        db_name: String,
+        partition_key: String,
+        table_name: String,
+        chunks: Vec<u32>,
+    },
+
     /// Wipe preserved catalog
     WipePreservedCatalog {
         db_name: String,
@@ -48,6 +56,7 @@ impl Job {
             Self::CloseChunk { db_name, .. } => Some(db_name),
             Self::WriteChunk { db_name, .. } => Some(db_name),
             Self::CompactChunks { db_name, .. } => Some(db_name),
+            Self::PersistChunks { db_name, .. } => Some(db_name),
             Self::WipePreservedCatalog { db_name, .. } => Some(db_name),
         }
     }
@@ -59,17 +68,19 @@ impl Job {
             Self::CloseChunk { partition_key, .. } => Some(partition_key),
             Self::WriteChunk { partition_key, .. } => Some(partition_key),
             Self::CompactChunks { partition_key, .. } => Some(partition_key),
+            Self::PersistChunks { partition_key, .. } => Some(partition_key),
             Self::WipePreservedCatalog { .. } => None,
         }
     }
 
-    /// Returns the chunk_id assocated with this job, if any
+    /// Returns the chunk_id associated with this job, if any
     pub fn chunk_id(&self) -> Option<u32> {
         match self {
             Self::Dummy { .. } => None,
             Self::CloseChunk { chunk_id, .. } => Some(*chunk_id),
             Self::WriteChunk { chunk_id, .. } => Some(*chunk_id),
             Self::CompactChunks { .. } => None,
+            Self::PersistChunks { .. } => None,
             Self::WipePreservedCatalog { .. } => None,
         }
     }
@@ -81,6 +92,7 @@ impl Job {
             Self::CloseChunk { .. } => "Loading chunk to ReadBuffer",
             Self::WriteChunk { .. } => "Writing chunk to Object Storage",
             Self::CompactChunks { .. } => "Compacting chunks to ReadBuffer",
+            Self::PersistChunks { .. } => "Persisting chunks to object storage",
             Self::WipePreservedCatalog { .. } => "Wipe preserved catalog",
         }
     }

--- a/entry/src/entry.rs
+++ b/entry/src/entry.rs
@@ -863,7 +863,7 @@ impl<'a> TableBatch<'a> {
                     .values_as_i64values()
                     .context(TimeColumnWrongType)?
                     .values()
-                    .expect("invalid flatbuffers: time columm values must be present");
+                    .expect("invalid flatbuffers: time column values must be present");
 
                 let min = vals.iter().min().context(TimeValueMissing)?;
                 let max = vals.iter().max().context(TimeValueMissing)?;

--- a/generated_types/protos/influxdata/iox/management/v1/jobs.proto
+++ b/generated_types/protos/influxdata/iox/management/v1/jobs.proto
@@ -24,6 +24,7 @@ message OperationMetadata {
     WriteChunk write_chunk = 8;
     WipePreservedCatalog wipe_preserved_catalog = 9;
     CompactChunks compact_chunks = 10;
+    PersistChunks persist_chunks = 11;
   }
 }
 
@@ -63,8 +64,23 @@ message WriteChunk {
   uint32 chunk_id = 3;
 }
 
-// Write a chunk from read buffer to object store
+// Compact chunks into a single chunk
 message CompactChunks {
+  // name of the database
+  string db_name = 1;
+
+  // partition key
+  string partition_key = 2;
+
+  // table name
+  string table_name = 4;
+
+  // chunk_id
+  repeated uint32 chunks = 3;
+}
+
+// Split and write chunks to object store
+message PersistChunks {
   // name of the database
   string db_name = 1;
 

--- a/generated_types/src/job.rs
+++ b/generated_types/src/job.rs
@@ -44,6 +44,17 @@ impl From<Job> for management::operation_metadata::Job {
                 table_name,
                 chunks,
             }),
+            Job::PersistChunks {
+                db_name,
+                partition_key,
+                table_name,
+                chunks,
+            } => Self::PersistChunks(management::PersistChunks {
+                db_name,
+                partition_key,
+                table_name,
+                chunks,
+            }),
         }
     }
 }
@@ -84,6 +95,17 @@ impl From<management::operation_metadata::Job> for Job {
                 table_name,
                 chunks,
             }) => Self::CompactChunks {
+                db_name,
+                partition_key,
+                table_name,
+                chunks,
+            },
+            Job::PersistChunks(management::PersistChunks {
+                db_name,
+                partition_key,
+                table_name,
+                chunks,
+            }) => Self::PersistChunks {
                 db_name,
                 partition_key,
                 table_name,

--- a/server/src/db/catalog/partition.rs
+++ b/server/src/db/catalog/partition.rs
@@ -2,6 +2,7 @@
 
 use std::{
     collections::{btree_map::Entry, BTreeMap},
+    fmt::Display,
     sync::Arc,
 };
 
@@ -16,9 +17,9 @@ use super::chunk::{CatalogChunk, ChunkStage};
 use data_types::chunk_metadata::{ChunkAddr, ChunkSummary};
 use internal_types::schema::Schema;
 use lifecycle::ChunkLifecycleAction;
+use observability_deps::tracing::info;
 use persistence_windows::persistence_windows::PersistenceWindows;
 use snafu::Snafu;
-
 #[derive(Debug, Snafu)]
 pub enum Error {
     #[snafu(display("chunk not found: {}", chunk))]
@@ -179,6 +180,7 @@ impl Partition {
             partition_key: Arc::clone(&self.partition_key),
             chunk_id,
         };
+        info!(%addr, row_count=chunk.rows(), "inserting RUB chunk to catalog");
 
         let chunk = Arc::new(self.metrics.new_chunk_lock(CatalogChunk::new_rub_chunk(
             addr,
@@ -306,11 +308,25 @@ impl Partition {
         &self.metrics
     }
 
-    pub fn persistence_windows(&mut self) -> Option<&mut PersistenceWindows> {
+    pub fn persistence_windows(&self) -> Option<&PersistenceWindows> {
+        self.persistence_windows.as_ref()
+    }
+
+    pub fn persistence_windows_mut(&mut self) -> Option<&mut PersistenceWindows> {
         self.persistence_windows.as_mut()
     }
 
     pub fn set_persistence_windows(&mut self, windows: PersistenceWindows) {
         self.persistence_windows = Some(windows);
+    }
+}
+
+impl Display for Partition {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "Partition {}:{}:{}",
+            self.db_name, self.table_name, self.partition_key
+        )
     }
 }

--- a/server/src/db/lifecycle.rs
+++ b/server/src/db/lifecycle.rs
@@ -1,3 +1,4 @@
+use std::fmt::Display;
 use std::sync::Arc;
 
 use chrono::{DateTime, Utc};
@@ -9,6 +10,7 @@ use data_types::error::ErrorLogger;
 use data_types::job::Job;
 use data_types::partition_metadata::{InfluxDbType, TableSummary};
 use data_types::DatabaseName;
+use datafusion::physical_plan::SendableRecordBatchStream;
 use hashbrown::HashMap;
 use internal_types::schema::sort::SortKey;
 use internal_types::schema::TIME_COLUMN_NAME;
@@ -114,6 +116,31 @@ impl LockableChunk for LockableCatalogChunk {
 pub struct LockableCatalogPartition {
     pub db: Arc<Db>,
     pub partition: Arc<RwLock<Partition>>,
+    /// Human readable description of what this CatalogPartiton is
+    pub display_string: String,
+}
+
+impl LockableCatalogPartition {
+    pub fn new(db: Arc<Db>, partition: Arc<RwLock<Partition>>) -> Self {
+        let display_string = {
+            partition
+                .try_read()
+                .map(|partition| partition.to_string())
+                .unwrap_or_else(|| "UNKNOWN (could not get lock)".into())
+        };
+
+        Self {
+            db,
+            partition,
+            display_string,
+        }
+    }
+}
+
+impl Display for LockableCatalogPartition {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.display_string)
+    }
 }
 
 impl LockablePartition for LockableCatalogPartition {
@@ -190,10 +217,7 @@ impl LifecycleDb for ArcDb {
         self.catalog
             .partitions()
             .into_iter()
-            .map(|partition| LockableCatalogPartition {
-                db: Arc::clone(&self.0),
-                partition,
-            })
+            .map(|partition| LockableCatalogPartition::new(Arc::clone(&self.0), partition))
             .collect()
     }
 
@@ -266,4 +290,33 @@ fn compute_sort_key<'a>(summaries: impl Iterator<Item = &'a TableSummary>) -> So
     }
     key.push(TIME_COLUMN_NAME, Default::default());
     key
+}
+
+/// Creates a new RUB chunk
+fn new_rub_chunk(db: &Db, table_name: &str) -> read_buffer::RBChunk {
+    // create a new read buffer chunk with memory tracking
+    let metrics = db
+        .metrics_registry
+        .register_domain_with_labels("read_buffer", db.metric_labels.clone());
+
+    read_buffer::RBChunk::new(
+        table_name,
+        read_buffer::ChunkMetrics::new(&metrics, db.catalog.metrics().memory().read_buffer()),
+    )
+}
+
+/// Executes a plan and collects the results into a read buffer chunk
+async fn collect_rub(
+    mut stream: SendableRecordBatchStream,
+    chunk: &mut read_buffer::RBChunk,
+) -> Result<()> {
+    use futures::StreamExt;
+
+    while let Some(batch) = stream.next().await {
+        let batch = batch?;
+        if batch.num_rows() > 0 {
+            chunk.upsert_table(batch)
+        }
+    }
+    Ok(())
 }

--- a/server/src/db/lifecycle/error.rs
+++ b/server/src/db/lifecycle/error.rs
@@ -28,6 +28,9 @@ pub enum Error {
         source: datafusion::error::DataFusionError,
     },
 
+    #[snafu(context(false))]
+    Aborted { source: futures::future::Aborted },
+
     #[snafu(display("Read Buffer Error in chunk {}{} : {}", chunk_id, table_name, source))]
     ReadBufferChunkError {
         source: read_buffer::Error,

--- a/server/src/db/lifecycle/move_chunk.rs
+++ b/server/src/db/lifecycle/move_chunk.rs
@@ -2,15 +2,14 @@ pub(crate) use crate::db::chunk::DbChunk;
 use crate::db::{catalog::chunk::CatalogChunk, lifecycle::compute_sort_key};
 use ::lifecycle::LifecycleWriteGuard;
 use data_types::job::Job;
-use futures::StreamExt;
 
 use observability_deps::tracing::{debug, info};
 use query::{exec::ExecutorType, frontend::reorg::ReorgPlanner, QueryChunkMeta};
-use read_buffer::{ChunkMetrics as ReadBufferChunkMetrics, RBChunk};
 use std::{future::Future, sync::Arc};
 use tracker::{TaskTracker, TrackedFuture, TrackedFutureExt};
 
 use super::{error::Result, LockableCatalogChunk};
+use crate::db::lifecycle::{collect_rub, new_rub_chunk};
 
 /// The implementation for moving a chunk to the read buffer
 ///
@@ -42,16 +41,7 @@ pub fn move_chunk_to_read_buffer(
 
     // Drop locks
     let chunk = guard.unwrap().chunk;
-
-    // create a new read buffer chunk with memory tracking
-    let metrics = db
-        .metrics_registry
-        .register_domain_with_labels("read_buffer", db.metric_labels.clone());
-
-    let mut rb_chunk = RBChunk::new(
-        &table_summary.name,
-        ReadBufferChunkMetrics::new(&metrics, db.catalog.metrics().memory().read_buffer()),
-    );
+    let mut rb_chunk = new_rub_chunk(db.as_ref(), &table_summary.name);
 
     let ctx = db.exec.new_context(ExecutorType::Reorg);
 
@@ -65,12 +55,8 @@ pub fn move_chunk_to_read_buffer(
             ReorgPlanner::new().compact_plan(query_chunks.iter().map(Arc::clone), key)?;
 
         let physical_plan = ctx.prepare_plan(&plan)?;
-        let mut stream = ctx.execute(physical_plan).await?;
-
-        // Collect results into RUB chunk
-        while let Some(batch) = stream.next().await {
-            rb_chunk.upsert_table(batch?)
-        }
+        let stream = ctx.execute(physical_plan).await?;
+        collect_rub(stream, &mut rb_chunk).await?;
 
         // Can drop and re-acquire as lifecycle action prevents concurrent modification
         let mut guard = chunk.write();

--- a/server/src/db/lifecycle/write.rs
+++ b/server/src/db/lifecycle/write.rs
@@ -3,15 +3,13 @@ use crate::db::{
     catalog::chunk::{CatalogChunk, ChunkStage},
     checkpoint_data_from_catalog,
     lifecycle::LockableCatalogChunk,
-    streams, DbChunk,
+    DbChunk,
 };
 
 use ::lifecycle::LifecycleWriteGuard;
 
-use arrow::datatypes::SchemaRef as ArrowSchemaRef;
 use chrono::Utc;
 use data_types::job::Job;
-use datafusion::physical_plan::SendableRecordBatchStream;
 use internal_types::selection::Selection;
 use object_store::path::parsed::DirsAndFileName;
 use observability_deps::tracing::{debug, warn};
@@ -23,6 +21,7 @@ use parquet_file::{
 use persistence_windows::checkpoint::{
     DatabaseCheckpoint, PartitionCheckpoint, PersistCheckpointBuilder,
 };
+use query::QueryChunk;
 use snafu::ResultExt;
 use std::{collections::BTreeMap, future::Future, sync::Arc};
 use tracker::{TaskTracker, TrackedFuture, TrackedFutureExt};
@@ -53,9 +52,13 @@ pub fn write_chunk_to_object_store(
     });
 
     // update the catalog to say we are processing this chunk and
-    let rb_chunk = guard.set_writing_to_object_store(&registration)?;
+    guard.set_writing_to_object_store(&registration)?;
+    let db_chunk = DbChunk::snapshot(&*guard);
 
     debug!(chunk=%guard.addr(), "chunk marked WRITING , loading tables into object store");
+
+    // Drop locks
+    let chunk = guard.unwrap().chunk;
 
     // Create a storage to save data of this chunk
     let storage = Storage::new(Arc::clone(&db.store), db.server_id);
@@ -67,26 +70,13 @@ pub fn write_chunk_to_object_store(
         .catalog_transactions_until_checkpoint
         .get();
 
-    // Drop locks
-    let chunk = guard.unwrap().chunk;
-
     let fut = async move {
         debug!(chunk=%addr, "loading table to object store");
 
-        let predicate = read_buffer::Predicate::default();
-
         // Get RecordBatchStream of data from the read buffer chunk
-        let read_results = rb_chunk.read_filter(&addr.table_name, predicate, Selection::All);
-
-        let arrow_schema: ArrowSchemaRef = rb_chunk
-            .read_filter_table_schema(Selection::All)
-            .expect("read buffer is infallible")
-            .into();
-
-        let stream: SendableRecordBatchStream = Box::pin(streams::ReadFilterResultsStream::new(
-            read_results,
-            Arc::clone(&arrow_schema),
-        ));
+        let stream = db_chunk
+            .read_filter(&Default::default(), Selection::All)
+            .expect("read filter should be infallible");
 
         // check that the upcoming state change will very likely succeed
         {


### PR DESCRIPTION
feat: Infrastructure for persistence

# Rationale
re https://github.com/influxdata/conductor/issues/360

This is part of the persist lifecycle action PR https://github.com/influxdata/influxdb_iox/pull/1888 which I am splitting into multiple PRs for easier review. It is therefore somewhat of a potpourri of various refactorings

There are no functional changes intended in this PR (it is setup for the next one where there are functional changes)

This code was largely written by @tustvold 

# Changes
1. Add in Job and Job related proto bugs (could be its own PR)
2. Twiddle with persist window API
3. Add in `Display` formatting for various `LockablePartitions` (which I was using to get understandable logs)
3. Refactor the server's lifecycle crates to reduce code duplication creating rub chunks


# PR Sequence
- [x] Add persist guard to prevent ongoing mutations to persitence windows: https://github.com/influxdata/influxdb_iox/pull/1883
- [x] Infrastructure for jobs / protobufs / persistence windows: This PR
- [ ] Actual persistence lifecycle