### PR TITLE
chore: Reduce output spew during query tests

### DIFF
--- a/query_tests/src/runner.rs
+++ b/query_tests/src/runner.rs
@@ -7,7 +7,7 @@ use arrow::record_batch::RecordBatch;
 use query::{exec::ExecutorType, frontend::sql::SqlQueryPlanner};
 use snafu::{OptionExt, ResultExt, Snafu};
 use std::{
-    io::BufWriter,
+    io::LineWriter,
     io::Write,
     path::{Path, PathBuf},
 };
@@ -97,7 +97,7 @@ impl From<std::io::Error> for Error {
 /// The case runner. It writes its test log output to the `Write`
 /// output stream
 pub struct Runner<W: Write> {
-    log: BufWriter<W>,
+    log: LineWriter<W>,
 }
 
 impl<W: Write> std::fmt::Debug for Runner<W> {
@@ -106,10 +106,25 @@ impl<W: Write> std::fmt::Debug for Runner<W> {
     }
 }
 
-impl Runner<std::io::Stdout> {
+/// Struct that calls println! to print out its data. Used rather than
+/// `std::io::stdout` which is not captured by the resut test runner
+/// for some reason. This writer expects to get valid utf8 sequences
+pub struct PrintlnWriter {}
+impl Write for PrintlnWriter {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        println!("{}", String::from_utf8_lossy(buf));
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+impl Runner<PrintlnWriter> {
     /// Create a new runner which writes to std::out
     pub fn new() -> Self {
-        let log = BufWriter::new(std::io::stdout());
+        let log = LineWriter::new(PrintlnWriter {});
         Self { log }
     }
 
@@ -121,7 +136,7 @@ impl Runner<std::io::Stdout> {
 
 impl<W: Write> Runner<W> {
     pub fn new_with_writer(log: W) -> Self {
-        let log = BufWriter::new(log);
+        let log = LineWriter::new(log);
         Self { log }
     }
 
@@ -179,7 +194,7 @@ impl<W: Write> Runner<W> {
             output.append(&mut self.run_query(q, db_setup.as_ref()).await?);
         }
 
-        let mut output_file = BufWriter::new(output_file);
+        let mut output_file = LineWriter::new(output_file);
         for o in &output {
             writeln!(&mut output_file, "{}", o).with_context(|| WritingToOutputFile {
                 output_path: output_path.clone(),

--- a/query_tests/src/runner.rs
+++ b/query_tests/src/runner.rs
@@ -107,7 +107,7 @@ impl<W: Write> std::fmt::Debug for Runner<W> {
 }
 
 /// Struct that calls println! to print out its data. Used rather than
-/// `std::io::stdout` which is not captured by the resut test runner
+/// `std::io::stdout` which is not captured by the result test runner
 /// for some reason. This writer expects to get valid utf8 sequences
 pub struct PrintlnWriter {}
 impl Write for PrintlnWriter {


### PR DESCRIPTION
# Rationale
(this is definitely an itch I have wanted to scratch)

Today, when you run `cargo test -p query_tests` you get the spew shown in the "example output before change" section below. 

This is due to the fact that whatever redirection mechanism used in the Rust test runner seems to only work on `println!` rather than things that are sent to `stdout` directly

# Changes
1. Use println rather than `std::io::stdout()` to write log output


# Example output *before* change

```
running 112 tests
test influxrpc::field_columns::test_field_columns_empty_database ... ok
test influxrpc::read_filter::test_read_filter_data_pred_refers_to_non_existent_column ... ok
test influxrpc::read_filter::test_read_filter_data_pred_refers_to_good_and_non_existent_columns ... ok
test influxrpc::read_filter::test_read_filter_no_data_no_pred ... ok
test influxrpc::field_columns::test_field_name_plan ... ok
test influxrpc::read_filter::test_read_filter_data_pred_no_columns ... ok
test influxrpc::read_filter::test_read_filter_data_plan_order ... ok
Running case in "cases/in/duplicates.sql"
  writing output to "cases/duplicates.out"
  expected output in "cases/in/duplicates.expected"
Processing contents:
-- Test for predicate push down explains
-- IOX_SETUP: OneMeasurementThreeChunksWithDuplicates

-- Plan with order by
explain verbose select time, state, city, min_temp, max_temp, area from h2o order by time, state, city;


-- plan without order by
explain verbose select time, state, city, min_temp, max_temp, area from h2o;

-- Union plan
EXPLAIN VERBOSE select state as name from h2o UNION ALL select city as name from h2o;

Using test setup:
TestSetup
  Setup: OneMeasurementThreeChunksWithDuplicates

Running scenario 'Data in open chunk of mutable buffer and read buffer'
SQL: '"explain verbose select time, state, city, min_temp, max_temp, area from h2o order by time, state, city;"'
Running scenario 'Data in open chunk of mutable buffer and read buffer'
SQL: '"explain verbose select time, state, city, min_temp, max_temp, area from h2o;"'
Running scenario 'Data in open chunk of mutable buffer and read buffer'
SQL: '"EXPLAIN VERBOSE select state as name from h2o UNION ALL select city as name from h2o;"'
test influxrpc::read_filter::test_read_filter_data_pred_unsupported_in_scan ... ok
test influxrpc::field_columns::test_field_columns_no_predicate ... ok
...
```


# Example output *after* change

```shell
running 112 tests
test influxrpc::field_columns::test_field_columns_empty_database ... ok
test influxrpc::read_filter::test_read_filter_data_pred_refers_to_non_existent_column ... ok
test influxrpc::read_filter::test_read_filter_data_pred_refers_to_good_and_non_existent_columns ... ok
test influxrpc::read_filter::test_read_filter_no_data_no_pred ... ok
test influxrpc::field_columns::test_field_name_plan ... ok
test influxrpc::read_filter::test_read_filter_data_pred_no_columns ... ok
test influxrpc::read_filter::test_read_filter_data_plan_order ... ok
....
test sql::sql_select_with_schema_merge ... ok
test sql::sql_select_with_schema_merge_subset ... ok
test sql::sql_select_from_information_schema_columns ... ok
test sql::sql_show_columns ... ok
test sql::sql_union_all ... ok
test sql::sql_select_from_information_schema_tables ... ok

```

Now you only see the output when there is a real error:

```shell


failures:

---- cases::test_cases_duplicates_sql stdout ----
Running case in "cases/in/duplicates.sql"

  writing output to "cases/duplicates.out"

  expected output in "cases/in/duplicates.expected"

Processing contents:

-- Test for predicate push down explains
-- IOX_SETUP: OneMeasurementThreeChunksWithDuplicates

-- Plan with order by
explain verbose select time, state, city, min_temp, max_temp, area from h2o order by time, state, city;


-- plan without order by
explain verbose select time, state, city, min_temp, max_temp, area from h2o;

-- Union plan
EXPLAIN VERBOSE select state as name from h2o UNION ALL select city as name from h2o;



Using test setup:

TestSetup

  Setup: OneMeasurementThreeChunksWithDuplicates


```

