### PR TITLE
refactor: pass schema arcs from catalog to query engine (instead of creating them on-demand)

### DIFF
--- a/query/src/frontend/influxrpc.rs
+++ b/query/src/frontend/influxrpc.rs
@@ -581,7 +581,7 @@ impl InfluxRpcPlanner {
             let ss_plan = match agg {
                 Aggregate::None => self.read_filter_plan(
                     table_name,
-                    schema.clone(),
+                    Arc::clone(&schema),
                     Some(group_columns),
                     &predicate,
                     chunks,
@@ -699,7 +699,7 @@ impl InfluxRpcPlanner {
     fn tag_keys_plan<C>(
         &self,
         table_name: &str,
-        schema: Schema,
+        schema: Arc<Schema>,
         predicate: &Predicate,
         chunks: Vec<Arc<C>>,
     ) -> Result<Option<StringSetPlan>>
@@ -762,7 +762,7 @@ impl InfluxRpcPlanner {
     fn field_columns_plan<C>(
         &self,
         table_name: &str,
-        schema: Schema,
+        schema: Arc<Schema>,
         predicate: &Predicate,
         chunks: Vec<Arc<C>>,
     ) -> Result<Option<LogicalPlan>>
@@ -813,7 +813,7 @@ impl InfluxRpcPlanner {
     fn read_filter_plan<C>(
         &self,
         table_name: impl AsRef<str>,
-        schema: Schema,
+        schema: Arc<Schema>,
         prefix_columns: Option<&[impl AsRef<str>]>,
         predicate: &Predicate,
         chunks: Vec<Arc<C>>,
@@ -934,7 +934,7 @@ impl InfluxRpcPlanner {
     fn read_group_plan<C>(
         &self,
         table_name: impl Into<String>,
-        schema: Schema,
+        schema: Arc<Schema>,
         predicate: &Predicate,
         agg: Aggregate,
         group_columns: &[impl AsRef<str>],
@@ -1026,7 +1026,7 @@ impl InfluxRpcPlanner {
     fn read_window_aggregate_plan<C>(
         &self,
         table_name: impl Into<String>,
-        schema: Schema,
+        schema: Arc<Schema>,
         predicate: &Predicate,
         agg: Aggregate,
         every: &WindowDuration,
@@ -1114,7 +1114,7 @@ impl InfluxRpcPlanner {
     fn scan_and_filter<C>(
         &self,
         table_name: &str,
-        schema: Schema,
+        schema: Arc<Schema>,
         predicate: &Predicate,
         chunks: Vec<Arc<C>>,
     ) -> Result<Option<TableScanAndFilter>>
@@ -1256,7 +1256,7 @@ struct TableScanAndFilter {
     /// Represents plan that scans a table and applies optional filtering
     plan_builder: LogicalPlanBuilder,
     /// The IOx schema of the result
-    schema: Schema,
+    schema: Arc<Schema>,
 }
 
 /// Reorders tag_columns so that its prefix matches exactly

--- a/query/src/lib.rs
+++ b/query/src/lib.rs
@@ -55,6 +55,9 @@ pub trait QueryDatabase: Debug + Send + Sync {
     /// Return the partition keys for data in this DB
     fn partition_keys(&self) -> Result<Vec<String>, Self::Error>;
 
+    /// Schema for a specific table if the table exists.
+    fn table_schema(&self, table_name: &str) -> Option<Schema>;
+
     /// Returns a set of chunks within the partition with data that may match
     /// the provided predicate. If possible, chunks which have no rows that can
     /// possibly match the predicate may be omitted.

--- a/query/src/lib.rs
+++ b/query/src/lib.rs
@@ -56,7 +56,7 @@ pub trait QueryDatabase: Debug + Send + Sync {
     fn partition_keys(&self) -> Result<Vec<String>, Self::Error>;
 
     /// Schema for a specific table if the table exists.
-    fn table_schema(&self, table_name: &str) -> Option<Schema>;
+    fn table_schema(&self, table_name: &str) -> Option<Arc<Schema>>;
 
     /// Returns a set of chunks within the partition with data that may match
     /// the provided predicate. If possible, chunks which have no rows that can

--- a/query/src/test.rs
+++ b/query/src/test.rs
@@ -117,7 +117,7 @@ impl QueryDatabase for TestDatabase {
         unimplemented!("summaries not implemented TestDatabase")
     }
 
-    fn table_schema(&self, table_name: &str) -> Option<Schema> {
+    fn table_schema(&self, table_name: &str) -> Option<Arc<Schema>> {
         let mut merger = SchemaMerger::new();
         let mut found_one = false;
 
@@ -131,7 +131,7 @@ impl QueryDatabase for TestDatabase {
             }
         }
 
-        found_one.then(|| merger.build())
+        found_one.then(|| Arc::new(merger.build()))
     }
 }
 

--- a/query_tests/cases/in/all_chunks_dropped.expected
+++ b/query_tests/cases/in/all_chunks_dropped.expected
@@ -1,0 +1,25 @@
+-- Test Setup: OneMeasurementAllChunksDropped
+-- SQL: SELECT * from information_schema.tables;
++---------------+--------------------+---------------+------------+
+| table_catalog | table_schema       | table_name    | table_type |
++---------------+--------------------+---------------+------------+
+| public        | iox                | h2o           | BASE TABLE |
+| public        | system             | chunks        | BASE TABLE |
+| public        | system             | columns       | BASE TABLE |
+| public        | system             | chunk_columns | BASE TABLE |
+| public        | system             | operations    | BASE TABLE |
+| public        | information_schema | tables        | VIEW       |
+| public        | information_schema | columns       | VIEW       |
++---------------+--------------------+---------------+------------+
+-- SQL: SHOW TABLES;
++---------------+--------------------+---------------+------------+
+| table_catalog | table_schema       | table_name    | table_type |
++---------------+--------------------+---------------+------------+
+| public        | iox                | h2o           | BASE TABLE |
+| public        | system             | chunks        | BASE TABLE |
+| public        | system             | columns       | BASE TABLE |
+| public        | system             | chunk_columns | BASE TABLE |
+| public        | system             | operations    | BASE TABLE |
+| public        | information_schema | tables        | VIEW       |
+| public        | information_schema | columns       | VIEW       |
++---------------+--------------------+---------------+------------+

--- a/query_tests/cases/in/all_chunks_dropped.sql
+++ b/query_tests/cases/in/all_chunks_dropped.sql
@@ -1,0 +1,8 @@
+-- Test for predicate push down explains
+-- IOX_SETUP: OneMeasurementAllChunksDropped
+
+-- list information schema
+SELECT * from information_schema.tables;
+
+-- same but shorter
+SHOW TABLES;

--- a/query_tests/src/cases.rs
+++ b/query_tests/src/cases.rs
@@ -5,6 +5,20 @@ use std::path::Path;
 use crate::runner::Runner;
 
 #[tokio::test]
+// Tests from "all_chunks_dropped.sql",
+async fn test_cases_all_chunks_dropped_sql() {
+    let input_path = Path::new("cases").join("in").join("all_chunks_dropped.sql");
+    let mut runner = Runner::new();
+    runner
+        .run(input_path)
+        .await
+        .expect("test failed");
+    runner
+        .flush()
+        .expect("flush worked");
+}
+
+#[tokio::test]
 // Tests from "duplicates.sql",
 async fn test_cases_duplicates_sql() {
     let input_path = Path::new("cases").join("in").join("duplicates.sql");

--- a/query_tests/src/runner.rs
+++ b/query_tests/src/runner.rs
@@ -294,6 +294,8 @@ impl<W: Write> Runner<W> {
 }
 
 /// Return output path for input path.
+///
+/// This converts `some/prefix/in/foo.sql` (or other file extensions) to `some/prefix/out/foo.out`.
 fn make_output_path(input: &Path) -> Result<PathBuf> {
     let stem = input.file_stem().context(NoFileStem { path: input })?;
 
@@ -306,7 +308,10 @@ fn make_output_path(input: &Path) -> Result<PathBuf> {
     out.push("out");
 
     // set file name and ext
-    out.push("placeholder"); // really confusing API
+    // The PathBuf API is somewhat confusing: `set_file_name` will replace the last component (which at this point is
+    // the "out"). However we wanna create a file out of the stem and the extension. So as a somewhat hackish
+    // workaround first push a placeholder that is then replaced.
+    out.push("placeholder");
     out.set_file_name(stem);
     out.set_extension("out");
 

--- a/query_tests/src/runner.rs
+++ b/query_tests/src/runner.rs
@@ -306,6 +306,7 @@ fn make_output_path(input: &Path) -> Result<PathBuf> {
     out.push("out");
 
     // set file name and ext
+    out.push("placeholder"); // really confusing API
     out.set_file_name(stem);
     out.set_extension("out");
 
@@ -417,8 +418,11 @@ SELECT * from disk;
         let in_dir = dir.path().join("in");
         std::fs::create_dir(&in_dir).expect("create in-dir");
 
+        let out_dir = dir.path().join("out");
+        std::fs::create_dir(&out_dir).expect("create out-dir");
+
         let mut file = in_dir;
-        file.set_file_name("foo.sql");
+        file.push("foo.sql");
 
         std::fs::write(&file, contents).expect("writing data to temp file");
         (dir, file)

--- a/server/src/db.rs
+++ b/server/src/db.rs
@@ -26,6 +26,7 @@ use data_types::{
 use datafusion::catalog::{catalog::CatalogProvider, schema::SchemaProvider};
 use entry::{Entry, SequencedEntry};
 use futures::{stream::BoxStream, StreamExt};
+use internal_types::schema::Schema;
 use metrics::KeyValue;
 use mutable_buffer::chunk::{ChunkMetrics as MutableBufferChunkMetrics, MBChunk};
 use object_store::{path::parsed::DirsAndFileName, ObjectStore};
@@ -849,6 +850,10 @@ impl QueryDatabase for Db {
 
     fn chunk_summaries(&self) -> Result<Vec<ChunkSummary>> {
         self.catalog_access.chunk_summaries()
+    }
+
+    fn table_schema(&self, table_name: &str) -> Option<Schema> {
+        self.catalog_access.table_schema(table_name)
     }
 }
 

--- a/server/src/db/access.rs
+++ b/server/src/db/access.rs
@@ -11,16 +11,17 @@ use super::{
 };
 
 use async_trait::async_trait;
-use data_types::{chunk_metadata::ChunkSummary, error::ErrorLogger};
+use data_types::chunk_metadata::ChunkSummary;
 use datafusion::{
     catalog::{catalog::CatalogProvider, schema::SchemaProvider},
     datasource::TableProvider,
 };
+use internal_types::schema::Schema;
 use metrics::{Counter, KeyValue, MetricRegistry};
 use observability_deps::tracing::debug;
 use query::{
     predicate::{Predicate, PredicateBuilder},
-    provider::{self, ChunkPruner, ProviderBuilder},
+    provider::{ChunkPruner, ProviderBuilder},
     QueryChunk, QueryChunkMeta, DEFAULT_SCHEMA,
 };
 use system_tables::{SystemSchemaProvider, SYSTEM_SCHEMA};
@@ -195,6 +196,13 @@ impl QueryDatabase for QueryCatalogAccess {
     fn chunk_summaries(&self) -> Result<Vec<ChunkSummary>> {
         Ok(self.catalog.chunk_summaries())
     }
+
+    fn table_schema(&self, table_name: &str) -> Option<Schema> {
+        self.catalog
+            .table(table_name)
+            .ok()
+            .map(|table| table.schema().read().clone())
+    }
 }
 
 // Datafusion catalog provider interface
@@ -249,27 +257,23 @@ impl SchemaProvider for DbSchemaProvider {
 
     /// Create a table provider for the named table
     fn table(&self, table_name: &str) -> Option<Arc<dyn TableProvider>> {
-        let mut builder = ProviderBuilder::new(table_name);
+        let schema = {
+            let table = self.catalog.table(table_name).ok()?;
+            table.schema().read().clone()
+        };
+
+        let mut builder = ProviderBuilder::new(table_name, schema);
         builder =
             builder.add_pruner(Arc::clone(&self.chunk_access) as Arc<dyn ChunkPruner<DbChunk>>);
 
         let predicate = PredicateBuilder::new().table(table_name).build();
 
         for chunk in self.chunk_access.candidate_chunks(&predicate) {
-            // This is unfortunate - a table with incompatible chunks ceases to
-            // be visible to the query engine
-            //
-            // It is also potentially ill-formed as continuing to use the builder
-            // after it has errored may not yield entirely sensible results
-            builder = builder
-                .add_chunk(chunk)
-                .log_if_error("Adding chunks to table")
-                .ok()?;
+            builder = builder.add_chunk(chunk);
         }
 
         match builder.build() {
             Ok(provider) => Some(Arc::new(provider)),
-            Err(provider::Error::InternalNoRowsInTable { .. }) => None,
             Err(e) => panic!("unexpected error: {:?}", e),
         }
     }

--- a/server/src/db/access.rs
+++ b/server/src/db/access.rs
@@ -197,11 +197,11 @@ impl QueryDatabase for QueryCatalogAccess {
         Ok(self.catalog.chunk_summaries())
     }
 
-    fn table_schema(&self, table_name: &str) -> Option<Schema> {
+    fn table_schema(&self, table_name: &str) -> Option<Arc<Schema>> {
         self.catalog
             .table(table_name)
             .ok()
-            .map(|table| table.schema().read().clone())
+            .map(|table| Arc::clone(&table.schema().read()))
     }
 }
 
@@ -259,7 +259,7 @@ impl SchemaProvider for DbSchemaProvider {
     fn table(&self, table_name: &str) -> Option<Arc<dyn TableProvider>> {
         let schema = {
             let table = self.catalog.table(table_name).ok()?;
-            table.schema().read().clone()
+            Arc::clone(&table.schema().read())
         };
 
         let mut builder = ProviderBuilder::new(table_name, schema);

--- a/server/src/db/catalog.rs
+++ b/server/src/db/catalog.rs
@@ -199,7 +199,7 @@ impl Catalog {
         &self,
         table_name: impl AsRef<str>,
         partition_key: impl AsRef<str>,
-    ) -> (Arc<RwLock<Partition>>, Arc<RwLock<Schema>>) {
+    ) -> (Arc<RwLock<Partition>>, Arc<RwLock<Arc<Schema>>>) {
         let mut tables = self.tables.write();
         let (_, table) = tables
             .raw_entry_mut()

--- a/server/src/db/catalog/chunk.rs
+++ b/server/src/db/catalog/chunk.rs
@@ -271,7 +271,7 @@ impl CatalogChunk {
     pub(super) fn new_rub_chunk(
         addr: ChunkAddr,
         chunk: read_buffer::RBChunk,
-        schema: Schema,
+        schema: Arc<Schema>,
         metrics: ChunkMetrics,
     ) -> Self {
         // TODO: Move RUB to single table (#1295)
@@ -282,7 +282,7 @@ impl CatalogChunk {
         let stage = ChunkStage::Frozen {
             meta: Arc::new(ChunkMetadata {
                 table_summary: Arc::new(summary),
-                schema: Arc::new(schema),
+                schema,
             }),
             representation: ChunkStageFrozenRepr::ReadBuffer(Arc::new(chunk)),
         };
@@ -603,7 +603,7 @@ impl CatalogChunk {
 
     /// Set the chunk in the Moved state, setting the underlying storage handle to db, and
     /// discarding the underlying mutable buffer storage.
-    pub fn set_moved(&mut self, chunk: Arc<RBChunk>, schema: Schema) -> Result<()> {
+    pub fn set_moved(&mut self, chunk: Arc<RBChunk>, schema: Arc<Schema>) -> Result<()> {
         match &mut self.stage {
             ChunkStage::Frozen {
                 meta,
@@ -613,7 +613,7 @@ impl CatalogChunk {
                 // after moved, the chunk is sorted and its schema needs to get updated
                 *meta = Arc::new(ChunkMetadata {
                     table_summary: Arc::clone(&meta.table_summary),
-                    schema: Arc::new(schema),
+                    schema,
                 });
 
                 match &representation {

--- a/server/src/db/catalog/partition.rs
+++ b/server/src/db/catalog/partition.rs
@@ -166,7 +166,7 @@ impl Partition {
     pub fn create_rub_chunk(
         &mut self,
         chunk: read_buffer::RBChunk,
-        schema: Schema,
+        schema: Arc<Schema>,
     ) -> Arc<RwLock<CatalogChunk>> {
         let chunk_id = self.next_chunk_id;
         assert_ne!(self.next_chunk_id, u32::MAX, "Chunk ID Overflow");

--- a/server/src/db/lifecycle/compact.rs
+++ b/server/src/db/lifecycle/compact.rs
@@ -68,7 +68,7 @@ pub(crate) fn compact_chunks(
             .merge(&db_chunk.schema())
             .expect("schemas compatible");
     }
-    let schema = merger.build();
+    let schema = Arc::new(merger.build());
 
     // drop partition lock
     let partition = partition.unwrap().partition;

--- a/server/src/db/lifecycle/move_chunk.rs
+++ b/server/src/db/lifecycle/move_chunk.rs
@@ -55,11 +55,8 @@ pub fn move_chunk_to_read_buffer(
         let key = compute_sort_key(query_chunks.iter().map(|x| x.summary()));
 
         // Cannot move query_chunks as the sort key borrows the column names
-        let (schema, plan) = ReorgPlanner::new().compact_plan(
-            schema.as_ref().clone(),
-            query_chunks.iter().map(Arc::clone),
-            key,
-        )?;
+        let (schema, plan) =
+            ReorgPlanner::new().compact_plan(schema, query_chunks.iter().map(Arc::clone), key)?;
 
         let physical_plan = ctx.prepare_plan(&plan)?;
         let stream = ctx.execute(physical_plan).await?;


### PR DESCRIPTION
Do no longer scan chunks during query planning to determine the schema
(except for the lifetime jobs where we have a good reason to do so).
Instead pass the schema down to from whoever is triggering the query.
For real SQL queries, we then just use the the table-wide schemas
introduced in #1913.

Apart from avoiding schema merges we now also don't crash any longer
when no chunks are left in the table (aka columns are present but all
rows are gone).

Fixes #1768.
Fixes #1884.