### PR TITLE
chore: Update DataFusion again

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -837,7 +837,7 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "4.0.0-SNAPSHOT"
-source = "git+https://github.com/apache/arrow-datafusion.git?rev=79d60f9b678e9a2351fc83511399663985e39cf6#79d60f9b678e9a2351fc83511399663985e39cf6"
+source = "git+https://github.com/apache/arrow-datafusion.git?rev=024bd89603dea13e63b70c92274116edbe36c4f9#024bd89603dea13e63b70c92274116edbe36c4f9"
 dependencies = [
  "ahash 0.7.4",
  "arrow",
@@ -1501,9 +1501,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.9"
+version = "0.14.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07d6baa1b441335f3ce5098ac421fb6547c46dda735ca1bc6d0153c838f9dd83"
+checksum = "7728a72c4c7d72665fde02204bcbd93b247721025b222ef78606f14513e0fd03"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -4066,9 +4066,9 @@ checksum = "1e81da0851ada1f3e9d4312c704aa4f8806f0f9d69faaf8df2f3464b4a9437c2"
 
 [[package]]
 name = "symbolic-common"
-version = "8.2.1"
+version = "8.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47ff4840b3bc0674313dcb4e6d5afc15b2d3fd4269716f06fcf581037645a56e"
+checksum = "348885c332e7d0784d661844b13b198464144a5ebcd3bfc047a6c441867ea467"
 dependencies = [
  "debugid",
  "memmap",
@@ -4078,9 +4078,9 @@ dependencies = [
 
 [[package]]
 name = "symbolic-demangle"
-version = "8.2.1"
+version = "8.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34248c3797477de8fe190615c3f50d69ef79edd65179324f11ffec2ec922cb48"
+checksum = "6780c62bfbd609bffaa13d6959715850578aa43caaae7aee14f1f24ceb64f433"
 dependencies = [
  "rustc-demangle",
  "symbolic-common",

--- a/datafusion/Cargo.toml
+++ b/datafusion/Cargo.toml
@@ -9,4 +9,4 @@ description = "Re-exports datafusion at a specific version"
 
 # Rename to workaround doctest bug
 # Turn off optional datafusion features (function packages)
-upstream = { git = "https://github.com/apache/arrow-datafusion.git", rev = "79d60f9b678e9a2351fc83511399663985e39cf6", default-features = false, package = "datafusion" }
+upstream = { git = "https://github.com/apache/arrow-datafusion.git", rev = "024bd89603dea13e63b70c92274116edbe36c4f9", default-features = false, package = "datafusion" }


### PR DESCRIPTION

# Rationale
Pick up @e-dard 's performance improvement for https://github.com/apache/arrow-datafusion/pull/691

# Changes
1. Update to https://github.com/apache/arrow-datafusion/commit/024bd89603dea13e63b70c92274116edbe36c4f9
2. Run `cargo update`
3. Check in results
