### PR TITLE
refactor: convert some table name and part. key String to Arcs

### DIFF
--- a/parquet_file/src/chunk.rs
+++ b/parquet_file/src/chunk.rs
@@ -85,7 +85,7 @@ impl ChunkMetrics {
 #[derive(Debug)]
 pub struct ParquetChunk {
     /// Partition this chunk belongs to
-    partition_key: String,
+    partition_key: Arc<str>,
 
     /// Meta data of the table
     table_summary: Arc<TableSummary>,
@@ -146,7 +146,7 @@ impl ParquetChunk {
 
     /// Creates a new chunk from given parts w/o parsing anything from the provided parquet metadata.
     pub(crate) fn new_from_parts(
-        part_key: impl Into<String>,
+        partition_key: Arc<str>,
         table_summary: Arc<TableSummary>,
         schema: Arc<Schema>,
         file_location: Path,
@@ -157,7 +157,7 @@ impl ParquetChunk {
         let timestamp_range = extract_range(&table_summary);
 
         let mut chunk = Self {
-            partition_key: part_key.into(),
+            partition_key,
             table_summary,
             schema,
             timestamp_range,

--- a/parquet_file/src/storage.rs
+++ b/parquet_file/src/storage.rs
@@ -453,14 +453,16 @@ mod tests {
 
     #[tokio::test]
     async fn test_parquet_contains_key_value_metadata() {
-        let table_name = "table1";
-        let partition_key = "part1";
-        let (partition_checkpoint, database_checkpoint) =
-            create_partition_and_database_checkpoint(table_name, partition_key);
+        let table_name = Arc::from("table1");
+        let partition_key = Arc::from("part1");
+        let (partition_checkpoint, database_checkpoint) = create_partition_and_database_checkpoint(
+            Arc::clone(&table_name),
+            Arc::clone(&partition_key),
+        );
         let metadata = IoxMetadata {
             creation_timestamp: Utc::now(),
-            table_name: table_name.to_string(),
-            partition_key: partition_key.to_string(),
+            table_name,
+            partition_key,
             chunk_id: 1337,
             partition_checkpoint,
             database_checkpoint,
@@ -513,9 +515,9 @@ mod tests {
 
         // create Storage
         let server_id = ServerId::try_from(1).unwrap();
-        let db_name = "my_db";
-        let table_name = "my_table";
-        let partition_key = "my_partition";
+        let db_name = Arc::from("my_db");
+        let table_name = Arc::from("my_table");
+        let partition_key = Arc::from("my_partition");
         let chunk_id = 33;
         let storage = Storage::new(make_object_store(), server_id);
 
@@ -525,12 +527,14 @@ mod tests {
             batch.schema(),
             vec![Arc::new(batch)],
         ));
-        let (partition_checkpoint, database_checkpoint) =
-            create_partition_and_database_checkpoint(table_name, partition_key);
+        let (partition_checkpoint, database_checkpoint) = create_partition_and_database_checkpoint(
+            Arc::clone(&table_name),
+            Arc::clone(&partition_key),
+        );
         let metadata = IoxMetadata {
             creation_timestamp: Utc::now(),
-            table_name: table_name.to_string(),
-            partition_key: partition_key.to_string(),
+            table_name: Arc::clone(&table_name),
+            partition_key: Arc::clone(&partition_key),
             chunk_id,
             partition_checkpoint,
             database_checkpoint,
@@ -539,9 +543,9 @@ mod tests {
         let (path, _) = storage
             .write_to_object_store(
                 ChunkAddr {
-                    db_name: Arc::from(db_name),
-                    table_name: Arc::from(table_name),
-                    partition_key: Arc::from(partition_key),
+                    db_name,
+                    table_name,
+                    partition_key,
                     chunk_id,
                 },
                 input_stream,

--- a/parquet_file/src/test_utils.rs
+++ b/parquet_file/src/test_utils.rs
@@ -150,12 +150,14 @@ pub async fn make_chunk_given_record_batch(
     } else {
         Box::pin(MemoryStream::new(record_batches))
     };
-    let (partition_checkpoint, database_checkpoint) =
-        create_partition_and_database_checkpoint(&addr.table_name, &addr.partition_key);
+    let (partition_checkpoint, database_checkpoint) = create_partition_and_database_checkpoint(
+        Arc::clone(&addr.table_name),
+        Arc::clone(&addr.partition_key),
+    );
     let metadata = IoxMetadata {
         creation_timestamp: Utc.timestamp(10, 20),
-        table_name: addr.table_name.to_string(),
-        partition_key: addr.partition_key.to_string(),
+        table_name: Arc::clone(&addr.table_name),
+        partition_key: Arc::clone(&addr.partition_key),
         chunk_id: addr.chunk_id,
         partition_checkpoint,
         database_checkpoint,
@@ -166,7 +168,7 @@ pub async fn make_chunk_given_record_batch(
         .unwrap();
 
     ParquetChunk::new_from_parts(
-        addr.partition_key.to_string(),
+        addr.partition_key,
         Arc::new(table_summary),
         Arc::new(schema),
         path,
@@ -750,8 +752,8 @@ pub async fn make_metadata(
 
 /// Create [`PartitionCheckpoint`] and [`DatabaseCheckpoint`] for testing.
 pub fn create_partition_and_database_checkpoint(
-    table_name: &str,
-    partition_key: &str,
+    table_name: Arc<str>,
+    partition_key: Arc<str>,
 ) -> (PartitionCheckpoint, DatabaseCheckpoint) {
     // create partition checkpoint
     let mut sequencer_numbers = BTreeMap::new();
@@ -759,8 +761,8 @@ pub fn create_partition_and_database_checkpoint(
     sequencer_numbers.insert(2, MinMaxSequence::new(25, 28));
     let min_unpersisted_timestamp = Utc.timestamp(10, 20);
     let partition_checkpoint = PartitionCheckpoint::new(
-        table_name.to_string(),
-        partition_key.to_string(),
+        table_name,
+        partition_key,
         sequencer_numbers,
         min_unpersisted_timestamp,
     );

--- a/server/src/db.rs
+++ b/server/src/db.rs
@@ -1183,7 +1183,7 @@ mod tests {
             .eq(1.0)
             .unwrap();
 
-        let expected_parquet_size = 663;
+        let expected_parquet_size = 655;
         catalog_chunk_size_bytes_metric_eq(
             &test_db.metric_registry,
             "read_buffer",
@@ -1587,7 +1587,7 @@ mod tests {
                 ("svr_id", "10"),
             ])
             .histogram()
-            .sample_sum_eq(2149.0)
+            .sample_sum_eq(2141.0)
             .unwrap();
 
         // it should be the same chunk!
@@ -1695,7 +1695,7 @@ mod tests {
                 ("svr_id", "10"),
             ])
             .histogram()
-            .sample_sum_eq(2149.0)
+            .sample_sum_eq(2141.0)
             .unwrap();
 
         // Unload RB chunk but keep it in OS
@@ -1722,7 +1722,7 @@ mod tests {
                 ("svr_id", "10"),
             ])
             .histogram()
-            .sample_sum_eq(663.0)
+            .sample_sum_eq(655.0)
             .unwrap();
 
         // Verify data written to the parquet file in object store
@@ -2108,7 +2108,7 @@ mod tests {
                 Arc::from("cpu"),
                 0,
                 ChunkStorage::ReadBufferAndObjectStore,
-                2147, // size of RB and OS chunks
+                2139, // size of RB and OS chunks
                 1,
             ),
             ChunkSummary::new_without_timestamps(
@@ -2151,7 +2151,7 @@ mod tests {
             db.catalog.metrics().memory().read_buffer().get_total(),
             1484
         );
-        assert_eq!(db.catalog.metrics().memory().parquet().get_total(), 663);
+        assert_eq!(db.catalog.metrics().memory().parquet().get_total(), 655);
     }
 
     #[tokio::test]

--- a/server/src/db/lifecycle/write.rs
+++ b/server/src/db/lifecycle/write.rs
@@ -101,11 +101,14 @@ pub fn write_chunk_to_object_store(
             // IMPORTANT: Writing must take place while holding the cleanup lock, otherwise the file might be deleted
             //            between creation and the transaction commit.
             let (partition_checkpoint, database_checkpoint) =
-                fake_partition_and_database_checkpoint(&addr.table_name, &addr.partition_key);
+                fake_partition_and_database_checkpoint(
+                    Arc::clone(&addr.table_name),
+                    Arc::clone(&addr.partition_key),
+                );
             let metadata = IoxMetadata {
                 creation_timestamp: Utc::now(),
-                table_name: addr.table_name.to_string(),
-                partition_key: addr.partition_key.to_string(),
+                table_name: Arc::clone(&addr.table_name),
+                partition_key: Arc::clone(&addr.partition_key),
                 chunk_id: addr.chunk_id,
                 partition_checkpoint,
                 database_checkpoint,
@@ -184,15 +187,15 @@ pub fn write_chunk_to_object_store(
 
 /// Fake until we have the split implementation in-place.
 fn fake_partition_and_database_checkpoint(
-    table_name: &str,
-    partition_key: &str,
+    table_name: Arc<str>,
+    partition_key: Arc<str>,
 ) -> (PartitionCheckpoint, DatabaseCheckpoint) {
     // create partition checkpoint
     let sequencer_numbers = BTreeMap::new();
     let min_unpersisted_timestamp = Utc::now();
     let partition_checkpoint = PartitionCheckpoint::new(
-        table_name.to_string(),
-        partition_key.to_string(),
+        table_name,
+        partition_key,
         sequencer_numbers,
         min_unpersisted_timestamp,
     );


### PR DESCRIPTION
This has the (somewhat nice) side effect that it shrinks the in-mem
catalog a bit as well because now `ParquetChunk` is a bit smaller making
the chunk stage enum smaller as well.
