### PR TITLE
refactor: Move ChunkLifecycleAction to the data_types crate

### DIFF
--- a/data_types/src/chunk_metadata.rs
+++ b/data_types/src/chunk_metadata.rs
@@ -62,6 +62,35 @@ impl ChunkStorage {
     }
 }
 
+/// Any lifecycle action currently in progress for this chunk
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub enum ChunkLifecycleAction {
+    /// Chunk is in the process of being moved to the read buffer
+    Moving,
+
+    /// Chunk is in the process of being written to object storage
+    Persisting,
+
+    /// Chunk is in the process of being compacted
+    Compacting,
+}
+
+impl std::fmt::Display for ChunkLifecycleAction {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.name())
+    }
+}
+
+impl ChunkLifecycleAction {
+    pub fn name(&self) -> &'static str {
+        match self {
+            Self::Moving => "Moving to the Read Buffer",
+            Self::Persisting => "Persisting to Object Storage",
+            Self::Compacting => "Compacting",
+        }
+    }
+}
+
 /// Represents metadata about the physical storage of a chunk in a
 /// database.
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Serialize, Deserialize)]

--- a/lifecycle/src/lib.rs
+++ b/lifecycle/src/lib.rs
@@ -10,7 +10,7 @@
 
 use chrono::{DateTime, Utc};
 
-use data_types::chunk_metadata::{ChunkAddr, ChunkStorage};
+use data_types::chunk_metadata::{ChunkAddr, ChunkLifecycleAction, ChunkStorage};
 use data_types::database_rules::LifecycleRules;
 use data_types::DatabaseName;
 pub use guard::*;
@@ -19,35 +19,6 @@ use tracker::TaskTracker;
 
 mod guard;
 mod policy;
-
-/// Any lifecycle action currently in progress for this chunk
-#[derive(Debug, Copy, Clone, PartialEq)]
-pub enum ChunkLifecycleAction {
-    /// Chunk is in the process of being moved to the read buffer
-    Moving,
-
-    /// Chunk is in the process of being written to object storage
-    Persisting,
-
-    /// Chunk is in the process of being compacted
-    Compacting,
-}
-
-impl std::fmt::Display for ChunkLifecycleAction {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.name())
-    }
-}
-
-impl ChunkLifecycleAction {
-    pub fn name(&self) -> &'static str {
-        match self {
-            Self::Moving => "Moving to the Read Buffer",
-            Self::Persisting => "Persisting to Object Storage",
-            Self::Compacting => "Compacting",
-        }
-    }
-}
 
 /// A trait that encapsulates the database logic that is automated by `LifecyclePolicy`
 pub trait LifecycleDb {

--- a/lifecycle/src/policy.rs
+++ b/lifecycle/src/policy.rs
@@ -6,15 +6,12 @@ use chrono::{DateTime, Utc};
 use data_types::DatabaseName;
 use futures::future::BoxFuture;
 
-use data_types::chunk_metadata::ChunkStorage;
+use data_types::chunk_metadata::{ChunkLifecycleAction, ChunkStorage};
 use data_types::database_rules::{LifecycleRules, DEFAULT_MUB_ROW_THRESHOLD};
 use observability_deps::tracing::{debug, info, warn};
 use tracker::TaskTracker;
 
-use crate::{
-    ChunkLifecycleAction, LifecycleChunk, LifecycleDb, LifecyclePartition, LockableChunk,
-    LockablePartition,
-};
+use crate::{LifecycleChunk, LifecycleDb, LifecyclePartition, LockableChunk, LockablePartition};
 
 /// Number of seconds to wait before retying a failed lifecycle action
 pub const LIFECYCLE_ACTION_BACKOFF: Duration = Duration::from_secs(10);

--- a/server/src/db/catalog/chunk.rs
+++ b/server/src/db/catalog/chunk.rs
@@ -3,13 +3,12 @@ use std::sync::Arc;
 use chrono::{DateTime, Utc};
 use snafu::Snafu;
 
-use data_types::chunk_metadata::ChunkAddr;
+use data_types::chunk_metadata::{ChunkAddr, ChunkLifecycleAction};
 use data_types::{
     chunk_metadata::{ChunkColumnSummary, ChunkStorage, ChunkSummary, DetailedChunkSummary},
     partition_metadata::TableSummary,
 };
 use internal_types::schema::Schema;
-use lifecycle::ChunkLifecycleAction;
 use metrics::{Counter, Histogram, KeyValue};
 use mutable_buffer::chunk::{snapshot::ChunkSnapshot as MBChunkSnapshot, MBChunk};
 use parquet_file::chunk::ParquetChunk;

--- a/server/src/db/catalog/partition.rs
+++ b/server/src/db/catalog/partition.rs
@@ -8,7 +8,7 @@ use std::{
 
 use chrono::{DateTime, Utc};
 
-use data_types::partition_metadata::PartitionSummary;
+use data_types::{chunk_metadata::ChunkLifecycleAction, partition_metadata::PartitionSummary};
 use tracker::RwLock;
 
 use crate::db::catalog::metrics::PartitionMetrics;
@@ -16,7 +16,6 @@ use crate::db::catalog::metrics::PartitionMetrics;
 use super::chunk::{CatalogChunk, ChunkStage};
 use data_types::chunk_metadata::{ChunkAddr, ChunkSummary};
 use internal_types::schema::Schema;
-use lifecycle::ChunkLifecycleAction;
 use observability_deps::tracing::info;
 use persistence_windows::persistence_windows::PersistenceWindows;
 use snafu::Snafu;

--- a/server/src/db/lifecycle.rs
+++ b/server/src/db/lifecycle.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use chrono::{DateTime, Utc};
 
 use ::lifecycle::LifecycleDb;
-use data_types::chunk_metadata::{ChunkAddr, ChunkStorage};
+use data_types::chunk_metadata::{ChunkAddr, ChunkLifecycleAction, ChunkStorage};
 use data_types::database_rules::LifecycleRules;
 use data_types::error::ErrorLogger;
 use data_types::job::Job;
@@ -15,8 +15,8 @@ use hashbrown::HashMap;
 use internal_types::schema::sort::SortKey;
 use internal_types::schema::TIME_COLUMN_NAME;
 use lifecycle::{
-    ChunkLifecycleAction, LifecycleChunk, LifecyclePartition, LifecycleReadGuard,
-    LifecycleWriteGuard, LockableChunk, LockablePartition,
+    LifecycleChunk, LifecyclePartition, LifecycleReadGuard, LifecycleWriteGuard, LockableChunk,
+    LockablePartition,
 };
 use observability_deps::tracing::info;
 use tracker::{RwLock, TaskTracker};

--- a/server/src/db/lifecycle/write.rs
+++ b/server/src/db/lifecycle/write.rs
@@ -9,7 +9,7 @@ use crate::db::{
 use ::lifecycle::LifecycleWriteGuard;
 
 use chrono::Utc;
-use data_types::job::Job;
+use data_types::{chunk_metadata::ChunkLifecycleAction, job::Job};
 use internal_types::selection::Selection;
 use object_store::path::parsed::DirsAndFileName;
 use observability_deps::tracing::{debug, warn};
@@ -83,7 +83,7 @@ pub fn write_chunk_to_object_store(
             // re-lock
             let guard = chunk.read();
             if matches!(guard.stage(), &ChunkStage::Persisted { .. })
-                || !guard.is_in_lifecycle(::lifecycle::ChunkLifecycleAction::Persisting)
+                || !guard.is_in_lifecycle(ChunkLifecycleAction::Persisting)
             {
                 return Err(Error::CannotWriteChunk {
                     addr: guard.addr().clone(),

--- a/server/src/db/system_tables.rs
+++ b/server/src/db/system_tables.rs
@@ -1,4 +1,9 @@
-//! Contains implementation of IOx name: (), stats: () system table stats: () stats: ()es (aka tables in the `system` schema)
+//! Contains implementation of IOx system tables:
+//!
+//! system.chunks
+//! system.columns
+//! system.chunk_columns
+//! system.operations
 //!
 //! For example `SELECT * FROM system.chunks`
 


### PR DESCRIPTION
refactor: Move ChunkLifecycleAction to the data_types crate

# Rationale
Re: https://github.com/influxdata/influxdb_iox/issues/1912, we want to add external (API and system table) visibility about any lifecycle actions that might be happening

To add to both the API and system tables, I plan to add the the outstanding lifecycle action to `ChunkSummary`.

# Changes
1. Move `ChunkLifecycleAction` to `data_types` crate so that in a follow on PR I can add it to `ChunkSummary` which is also in that crate.
