### PR TITLE
feat: Record first and last write times on MUB chunks

### DIFF
--- a/mutable_buffer/src/chunk.rs
+++ b/mutable_buffer/src/chunk.rs
@@ -272,7 +272,7 @@ impl MBChunk {
 
     /// Validates the schema of the passed in columns, then adds their values to
     /// the associated columns in the table and updates summary statistics.
-    pub fn write_columns(
+    fn write_columns(
         &mut self,
         _sequence: Option<&Sequence>,
         columns: Vec<entry::Column<'_>>,

--- a/mutable_buffer/src/chunk.rs
+++ b/mutable_buffer/src/chunk.rs
@@ -1,20 +1,19 @@
-use std::{collections::BTreeSet, sync::Arc};
-
+use crate::{
+    chunk::snapshot::ChunkSnapshot,
+    column::{self, Column},
+};
 use arrow::record_batch::RecordBatch;
-use hashbrown::HashMap;
-use parking_lot::Mutex;
-use snafu::{ensure, OptionExt, ResultExt, Snafu};
-
 use data_types::partition_metadata::{ColumnSummary, InfluxDbType, TableSummary};
 use entry::{Sequence, TableBatch};
+use hashbrown::HashMap;
 use internal_types::{
     schema::{builder::SchemaBuilder, InfluxColumnType, Schema},
     selection::Selection,
 };
 use metrics::GaugeValue;
-
-use crate::column;
-use crate::{chunk::snapshot::ChunkSnapshot, column::Column};
+use parking_lot::Mutex;
+use snafu::{ensure, OptionExt, ResultExt, Snafu};
+use std::{collections::BTreeSet, sync::Arc};
 
 pub mod snapshot;
 
@@ -367,18 +366,13 @@ pub mod test_helpers {
 
 #[cfg(test)]
 mod tests {
+    use super::{test_helpers::write_lp_to_chunk, *};
     use arrow::datatypes::DataType as ArrowDataType;
-
-    use entry::test_helpers::lp_to_entry;
-    use internal_types::schema::{InfluxColumnType, InfluxFieldType};
-
-    use super::*;
-    use std::num::NonZeroU64;
-
     use arrow_util::assert_batches_eq;
     use data_types::partition_metadata::{ColumnSummary, InfluxDbType, StatValues, Statistics};
-
-    use super::test_helpers::write_lp_to_chunk;
+    use entry::test_helpers::lp_to_entry;
+    use internal_types::schema::{InfluxColumnType, InfluxFieldType};
+    use std::num::NonZeroU64;
 
     #[test]
     fn writes_table_batches() {

--- a/server/src/db/catalog.rs
+++ b/server/src/db/catalog.rs
@@ -323,15 +323,13 @@ mod tests {
         let write = entry.partition_writes().unwrap().remove(0);
         let batch = write.table_batches().remove(0);
 
-        let mut mb_chunk = mutable_buffer::chunk::MBChunk::new(
-            batch.name(),
-            mutable_buffer::chunk::ChunkMetrics::new_unregistered(),
-        );
-
         let sequence = Some(Sequence::new(1, 5));
-        mb_chunk
-            .write_table_batch(sequence.as_ref(), batch)
-            .unwrap();
+        let mb_chunk = mutable_buffer::chunk::MBChunk::new(
+            mutable_buffer::chunk::ChunkMetrics::new_unregistered(),
+            sequence.as_ref(),
+            batch,
+        )
+        .unwrap();
 
         partition.create_open_chunk(mb_chunk);
     }

--- a/server/src/db/catalog/chunk.rs
+++ b/server/src/db/catalog/chunk.rs
@@ -1,11 +1,9 @@
-use std::sync::Arc;
-
 use chrono::{DateTime, Utc};
-use snafu::Snafu;
-
-use data_types::chunk_metadata::{ChunkAddr, ChunkLifecycleAction};
 use data_types::{
-    chunk_metadata::{ChunkColumnSummary, ChunkStorage, ChunkSummary, DetailedChunkSummary},
+    chunk_metadata::{
+        ChunkAddr, ChunkColumnSummary, ChunkLifecycleAction, ChunkStorage, ChunkSummary,
+        DetailedChunkSummary,
+    },
     partition_metadata::TableSummary,
 };
 use internal_types::schema::Schema;
@@ -13,6 +11,8 @@ use metrics::{Counter, Histogram, KeyValue};
 use mutable_buffer::chunk::{snapshot::ChunkSnapshot as MBChunkSnapshot, MBChunk};
 use parquet_file::chunk::ParquetChunk;
 use read_buffer::RBChunk;
+use snafu::Snafu;
+use std::sync::Arc;
 use tracker::{TaskRegistration, TaskTracker};
 
 #[derive(Debug, Snafu)]

--- a/server/src/db/catalog/chunk.rs
+++ b/server/src/db/catalog/chunk.rs
@@ -65,8 +65,7 @@ pub type Result<T, E = Error> = std::result::Result<T, E>;
 // Closed chunks have cached information about their schema and statistics
 #[derive(Debug, Clone)]
 pub struct ChunkMetadata {
-    /// The TableSummary, including statistics, for the table in this
-    /// Chunk
+    /// The TableSummary, including statistics, for the table in this Chunk
     pub table_summary: Arc<TableSummary>,
 
     /// The schema for the table in this Chunk
@@ -76,9 +75,9 @@ pub struct ChunkMetadata {
 /// Different memory representations of a frozen chunk.
 #[derive(Debug)]
 pub enum ChunkStageFrozenRepr {
-    /// Snapshot from the Mutable Buffer, freshly created from the former _open_ chunk. Not ideal for memory consumption
-    /// but good enough for the frozen stage. Should ideally be converted into the
-    /// [`ReadBuffer`](ChunkStageFrozenRepr::ReadBuffer) rather quickly.
+    /// Snapshot from the Mutable Buffer, freshly created from the former _open_ chunk. Not ideal
+    /// for memory consumption but good enough for the frozen stage. Should ideally be converted
+    /// into the [`ReadBuffer`](ChunkStageFrozenRepr::ReadBuffer) rather quickly.
     MutableBufferSnapshot(Arc<MBChunkSnapshot>),
 
     /// Read Buffer that is optimized for in-memory data processing.
@@ -109,12 +108,14 @@ pub enum ChunkStageFrozenRepr {
 ///       └────────────►drop◄─────────────┘
 /// ```
 ///
-/// A chunk stage lifecycle is linear, i.e. it can never go back. Also note that the _peristed_ stage is the only one
-/// that can be restored on node startup (from the persisted catalog). Furthermore, multiple _frozen_ chunks can be
-/// compacted into a single one. Nodes at any stage can be dropped via API calls and according to lifecycle policies.
+/// A chunk stage lifecycle is linear, i.e. it can never go back. Also note that the _peristed_
+/// stage is the only one that can be restored on node startup (from the persisted catalog).
+/// Furthermore, multiple _frozen_ chunks can be compacted into a single one. Nodes at any stage
+/// can be dropped via API calls and according to lifecycle policies.
 ///
-/// A chunk can be in-transit when there is a lifecycle job active. A lifecycle job can change the stage once finished
-/// (according to the diagram shown above). The chunk stage is considered unchanged as long as the job is running.
+/// A chunk can be in-transit when there is a lifecycle job active. A lifecycle job can change the
+/// stage once finished (according to the diagram shown above). The chunk stage is considered
+/// unchanged as long as the job is running.
 #[derive(Debug)]
 pub enum ChunkStage {
     /// A chunk in an _open_ stage.
@@ -125,10 +126,10 @@ pub enum ChunkStage {
         mb_chunk: MBChunk,
     },
 
-    /// A chunk in an _frozen stage.
+    /// A chunk in a _frozen_ stage.
     ///
-    /// Chunks in this stage cannot be modified but are not yet persisted. They can however be compacted which will take two
-    /// or more chunks and creates a single new frozen chunk.
+    /// Chunks in this stage cannot be modified but are not yet persisted. They can, however, be
+    /// compacted, which will take two or more chunks and creates a single new frozen chunk.
     Frozen {
         /// Metadata (statistics, schema) about this chunk
         meta: Arc<ChunkMetadata>,
@@ -137,7 +138,7 @@ pub enum ChunkStage {
         representation: ChunkStageFrozenRepr,
     },
 
-    /// Chunk in _persisted_ stage.
+    /// Chunk in a _persisted_ stage.
     ///
     /// Chunk cannot receive new data. It is persisted.
     Persisted {
@@ -167,10 +168,11 @@ impl ChunkStage {
 /// mutable buffer and in read buffer)
 ///
 /// # State Handling
-/// The actual chunk _state_ consistest of multiple parts. First there is the [lifecycle _stage_](ChunkStage)
-/// which captures the grant movement of a chunk from a unoptimized mutable object to an optimized immutable one. Within
-/// these stages there are multiple ways to represent or cache data. This fact is captured by the _stage_-specific chunk
-/// _representation_ (e.g. a persisted chunk may have data cached in-memory).
+/// The actual chunk _state_ consistest of multiple parts. First there is the
+/// [lifecycle _stage_](ChunkStage) which captures the grant movement of a chunk from a unoptimized
+/// mutable object to an optimized immutable one. Within these stages there are multiple ways to
+/// represent or cache data. This fact is captured by the _stage_-specific chunk _representation_
+/// (e.g. a persisted chunk may have data cached in-memory).
 #[derive(Debug)]
 pub struct CatalogChunk {
     addr: ChunkAddr,
@@ -236,8 +238,8 @@ impl ChunkMetrics {
 impl CatalogChunk {
     /// Creates a new open chunk from the provided MUB chunk.
     ///
-    /// Panics if the provided chunk is empty, otherwise creates a new open chunk and records a write at the
-    /// current time.
+    /// Panics if the provided chunk is empty, otherwise creates a new open chunk and records a
+    /// write at the current time.
     pub(super) fn new_open(
         addr: ChunkAddr,
         chunk: mutable_buffer::chunk::MBChunk,
@@ -264,7 +266,7 @@ impl CatalogChunk {
         chunk
     }
 
-    /// Creates a new rub chunk from the provided RUB chunk and metadata
+    /// Creates a new RUB chunk from the provided RUB chunk and metadata
     ///
     /// Panics if the provided chunk is empty
     pub(super) fn new_rub_chunk(
@@ -305,7 +307,8 @@ impl CatalogChunk {
         chunk
     }
 
-    /// Creates a new chunk that is only registered via an object store reference (= only exists in parquet).
+    /// Creates a new chunk that is only registered via an object store reference (= only exists in
+    /// parquet).
     pub(super) fn new_object_store_only(
         addr: ChunkAddr,
         chunk: Arc<parquet_file::chunk::ParquetChunk>,
@@ -476,8 +479,7 @@ impl CatalogChunk {
         }
     }
 
-    /// Returns an approximation of the amount of process memory consumed by the
-    /// chunk
+    /// Returns an approximation of the amount of process memory consumed by the chunk
     pub fn size(&self) -> usize {
         match &self.stage {
             ChunkStage::Open { mb_chunk, .. } => mb_chunk.size(),
@@ -499,10 +501,7 @@ impl CatalogChunk {
         }
     }
 
-    /// Returns a mutable reference to the mutable buffer storage for
-    /// chunks in the Open state
-    ///
-    /// Must be in open or closed state
+    /// Returns a mutable reference to the mutable buffer storage for chunks in the Open state
     pub fn mutable_buffer(&mut self) -> Result<&mut MBChunk> {
         match &mut self.stage {
             ChunkStage::Open { mb_chunk, .. } => Ok(mb_chunk),
@@ -512,8 +511,8 @@ impl CatalogChunk {
 
     /// Set chunk to _frozen_ state.
     ///
-    /// This only works for chunks in the _open_ stage (chunk is converted) and the _frozen_ stage (no-op) and will
-    /// fail for other stages.
+    /// This only works for chunks in the _open_ stage (chunk is converted) and the _frozen_ stage
+    /// (no-op) and will fail for other stages.
     pub fn freeze(&mut self) -> Result<()> {
         match &self.stage {
             ChunkStage::Open { mb_chunk, .. } => {
@@ -551,8 +550,7 @@ impl CatalogChunk {
         }
     }
 
-    /// Set the chunk to the Moving state, returning a handle to the underlying
-    /// storage
+    /// Set the chunk to the Moving state, returning a handle to the underlying storage
     ///
     /// If called on an open chunk will first [`freeze`](Self::freeze) the chunk
     pub fn set_moving(&mut self, registration: &TaskRegistration) -> Result<Arc<MBChunkSnapshot>> {
@@ -606,9 +604,8 @@ impl CatalogChunk {
         }
     }
 
-    /// Set the chunk in the Moved state, setting the underlying
-    /// storage handle to db, and discarding the underlying mutable buffer
-    /// storage.
+    /// Set the chunk in the Moved state, setting the underlying storage handle to db, and
+    /// discarding the underlying mutable buffer storage.
     pub fn set_moved(&mut self, chunk: Arc<RBChunk>, schema: Schema) -> Result<()> {
         match &mut self.stage {
             ChunkStage::Frozen {
@@ -673,8 +670,7 @@ impl CatalogChunk {
         }
     }
 
-    /// Set the chunk to the MovedToObjectStore state, returning a handle to the
-    /// underlying storage
+    /// Set the chunk to the MovedToObjectStore state, returning a handle to the underlying storage
     pub fn set_written_to_object_store(&mut self, chunk: Arc<ParquetChunk>) -> Result<()> {
         match &self.stage {
             ChunkStage::Frozen {
@@ -746,7 +742,8 @@ impl CatalogChunk {
 
                     Ok(rub_chunk)
                 } else {
-                    // TODO: do we really need to error here or should unloading an unloaded chunk be a no-op?
+                    // TODO: do we really need to error here or should unloading an unloaded chunk
+                    // be a no-op?
                     InternalChunkState {
                         chunk: self.addr.clone(),
                         operation: "setting unload",
@@ -860,7 +857,11 @@ mod tests {
 
         // closing a chunk in persisted state will fail
         let mut chunk = make_persisted_chunk().await;
-        assert_eq!(chunk.freeze().unwrap_err().to_string(), "Internal Error: unexpected chunk state for Chunk('db':'table1':'part1':0) during setting closed. Expected Open or Frozen, got Persisted");
+        assert_eq!(
+            chunk.freeze().unwrap_err().to_string(),
+            "Internal Error: unexpected chunk state for Chunk('db':'table1':'part1':0) \
+            during setting closed. Expected Open or Frozen, got Persisted"
+        );
     }
 
     #[test]
@@ -881,10 +882,24 @@ mod tests {
         );
 
         // setting an action while there is one running fails
-        assert_eq!(chunk.set_lifecycle_action(ChunkLifecycleAction::Moving, &registration).unwrap_err().to_string(), "Internal Error: A lifecycle action \'Moving to the Read Buffer\' is already in progress for Chunk('db':'table1':'part1':0)");
+        assert_eq!(
+            chunk
+                .set_lifecycle_action(ChunkLifecycleAction::Moving, &registration)
+                .unwrap_err()
+                .to_string(),
+            "Internal Error: A lifecycle action \'Moving to the Read Buffer\' is already in \
+            progress for Chunk('db':'table1':'part1':0)"
+        );
 
         // finishing the wrong action fails
-        assert_eq!(chunk.finish_lifecycle_action(ChunkLifecycleAction::Compacting).unwrap_err().to_string(), "Internal Error: Unexpected chunk state for Chunk('db':'table1':'part1':0). Expected Compacting, got Moving to the Read Buffer");
+        assert_eq!(
+            chunk
+                .finish_lifecycle_action(ChunkLifecycleAction::Compacting)
+                .unwrap_err()
+                .to_string(),
+            "Internal Error: Unexpected chunk state for Chunk('db':'table1':'part1':0). Expected \
+            Compacting, got Moving to the Read Buffer"
+        );
 
         // finish some action
         chunk
@@ -892,7 +907,14 @@ mod tests {
             .unwrap();
 
         // finishing w/o any action in progress will fail
-        assert_eq!(chunk.finish_lifecycle_action(ChunkLifecycleAction::Moving).unwrap_err().to_string(), "Internal Error: Unexpected chunk state for Chunk('db':'table1':'part1':0). Expected Moving to the Read Buffer, got None");
+        assert_eq!(
+            chunk
+                .finish_lifecycle_action(ChunkLifecycleAction::Moving)
+                .unwrap_err()
+                .to_string(),
+            "Internal Error: Unexpected chunk state for Chunk('db':'table1':'part1':0). Expected \
+            Moving to the Read Buffer, got None"
+        );
 
         // now we can set another action
         chunk

--- a/server/src/db/catalog/partition.rs
+++ b/server/src/db/catalog/partition.rs
@@ -73,9 +73,8 @@ pub struct Partition {
 impl Partition {
     /// Create a new partition catalog object.
     ///
-    /// This function is not pub because `Partition`s should be
-    /// created using the interfaces on [`Catalog`](crate::db::catalog::Catalog) and not
-    /// instantiated directly.
+    /// This function is not pub because `Partition`s should be created using the interfaces on
+    /// [`Catalog`](crate::db::catalog::Catalog) and not instantiated directly.
     pub(super) fn new(
         db_name: Arc<str>,
         partition_key: Arc<str>,
@@ -128,8 +127,8 @@ impl Partition {
 
     /// Create a new Chunk in the open state.
     ///
-    /// This will add a new chunk to the catalog and increases the chunk ID counter for that table-partition
-    /// combination.
+    /// This will add a new chunk to the catalog and increases the chunk ID counter for that
+    /// table-partition combination.
     ///
     /// Returns an error if the chunk is empty.
     pub fn create_open_chunk(
@@ -197,8 +196,7 @@ impl Partition {
 
     /// Create new chunk that is only in object store (= parquet file).
     ///
-    /// The table-specific chunk ID counter will be set to
-    /// `max(current, chunk_id + 1)`.
+    /// The table-specific chunk ID counter will be set to `max(current, chunk_id + 1)`.
     ///
     /// Returns the previous chunk with the given chunk_id if any
     pub fn insert_object_store_only_chunk(
@@ -262,7 +260,7 @@ impl Partition {
         self.chunks.remove(&chunk_id);
     }
 
-    /// return the first currently open chunk, if any
+    /// Return the first currently open chunk, if any
     pub fn open_chunk(&self) -> Option<Arc<RwLock<CatalogChunk>>> {
         self.chunks
             .values()

--- a/server/src/db/catalog/partition.rs
+++ b/server/src/db/catalog/partition.rs
@@ -1,24 +1,23 @@
 //! The catalog representation of a Partition
 
+use super::chunk::{CatalogChunk, ChunkStage};
+use crate::db::catalog::metrics::PartitionMetrics;
+use chrono::{DateTime, Utc};
+use data_types::{
+    chunk_metadata::{ChunkAddr, ChunkLifecycleAction, ChunkSummary},
+    partition_metadata::PartitionSummary,
+};
+use internal_types::schema::Schema;
+use observability_deps::tracing::info;
+use persistence_windows::persistence_windows::PersistenceWindows;
+use snafu::Snafu;
 use std::{
     collections::{btree_map::Entry, BTreeMap},
     fmt::Display,
     sync::Arc,
 };
-
-use chrono::{DateTime, Utc};
-
-use data_types::{chunk_metadata::ChunkLifecycleAction, partition_metadata::PartitionSummary};
 use tracker::RwLock;
 
-use crate::db::catalog::metrics::PartitionMetrics;
-
-use super::chunk::{CatalogChunk, ChunkStage};
-use data_types::chunk_metadata::{ChunkAddr, ChunkSummary};
-use internal_types::schema::Schema;
-use observability_deps::tracing::info;
-use persistence_windows::persistence_windows::PersistenceWindows;
-use snafu::Snafu;
 #[derive(Debug, Snafu)]
 pub enum Error {
     #[snafu(display("chunk not found: {}", chunk))]
@@ -34,6 +33,7 @@ pub enum Error {
         action: ChunkLifecycleAction,
     },
 }
+
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
 /// IOx Catalog Partition

--- a/server_benchmarks/benches/snapshot.rs
+++ b/server_benchmarks/benches/snapshot.rs
@@ -13,8 +13,7 @@ fn snapshot_chunk(chunk: &MBChunk) {
 }
 
 fn chunk(count: usize) -> MBChunk {
-    // m0 is hard coded into tag_values.lp.gz
-    let mut chunk = MBChunk::new("m0", ChunkMetrics::new_unregistered());
+    let mut chunk: Option<MBChunk> = None;
 
     let raw = include_bytes!("../../tests/fixtures/lineproto/tag_values.lp.gz");
     let mut gz = GzDecoder::new(&raw[..]);
@@ -26,13 +25,27 @@ fn chunk(count: usize) -> MBChunk {
         for entry in lp_to_entries(&lp, &hour_partitioner()) {
             for write in entry.partition_writes().iter().flatten() {
                 for batch in write.table_batches() {
-                    chunk.write_table_batch(sequence.as_ref(), batch).unwrap();
+                    match chunk {
+                        Some(ref mut c) => {
+                            c.write_table_batch(sequence.as_ref(), batch).unwrap();
+                        }
+                        None => {
+                            chunk = Some(
+                                MBChunk::new(
+                                    ChunkMetrics::new_unregistered(),
+                                    sequence.as_ref(),
+                                    batch,
+                                )
+                                .unwrap(),
+                            );
+                        }
+                    }
                 }
             }
         }
     }
 
-    chunk
+    chunk.expect("Must write at least one table batch to create a chunk")
 }
 
 pub fn snapshot_mb(c: &mut Criterion) {

--- a/server_benchmarks/benches/write.rs
+++ b/server_benchmarks/benches/write.rs
@@ -9,15 +9,28 @@ use std::io::Read;
 
 #[inline]
 fn write_chunk(count: usize, entries: &[Entry]) {
-    // m0 is hard coded into tag_values.lp.gz
-    let mut chunk = MBChunk::new("m0", ChunkMetrics::new_unregistered());
+    let mut chunk: Option<MBChunk> = None;
 
     let sequence = Some(Sequence::new(1, 5));
     for _ in 0..count {
         for entry in entries {
             for write in entry.partition_writes().iter().flatten() {
                 for batch in write.table_batches() {
-                    chunk.write_table_batch(sequence.as_ref(), batch).unwrap();
+                    match chunk {
+                        Some(ref mut c) => {
+                            c.write_table_batch(sequence.as_ref(), batch).unwrap();
+                        }
+                        None => {
+                            chunk = Some(
+                                MBChunk::new(
+                                    ChunkMetrics::new_unregistered(),
+                                    sequence.as_ref(),
+                                    batch,
+                                )
+                                .unwrap(),
+                            );
+                        }
+                    }
                 }
             }
         }


### PR DESCRIPTION
Connects to #1927, this is just one part of completing that but it seemed pretty separate and a good reviewable chunk (pun intended).

This also makes it so that you can't have an empty `mutable_buffer::chunk::MBChunk` because the only constructor takes a `TableBatch`.