### PR TITLE
refactor: make object_store construction interface consistent

### DIFF
--- a/object_store/src/disk.rs
+++ b/object_store/src/disk.rs
@@ -301,7 +301,7 @@ mod tests {
     #[tokio::test]
     async fn file_test() {
         let root = TempDir::new().unwrap();
-        let integration = ObjectStore::new_file(File::new(root.path()));
+        let integration = ObjectStore::new_file(root.path());
 
         put_get_delete_list(&integration).await.unwrap();
         list_with_delimiter(&integration).await.unwrap();
@@ -310,7 +310,7 @@ mod tests {
     #[tokio::test]
     async fn length_mismatch_is_an_error() {
         let root = TempDir::new().unwrap();
-        let integration = ObjectStore::new_file(File::new(root.path()));
+        let integration = ObjectStore::new_file(root.path());
 
         let bytes = stream::once(async { Ok(Bytes::from("hello world")) });
         let mut location = integration.new_path();
@@ -331,7 +331,7 @@ mod tests {
     #[tokio::test]
     async fn creates_dir_if_not_present() {
         let root = TempDir::new().unwrap();
-        let integration = ObjectStore::new_file(File::new(root.path()));
+        let integration = ObjectStore::new_file(root.path());
 
         let data = Bytes::from("arbitrary data");
         let mut location = integration.new_path();
@@ -361,7 +361,7 @@ mod tests {
     #[tokio::test]
     async fn unknown_length() {
         let root = TempDir::new().unwrap();
-        let integration = ObjectStore::new_file(File::new(root.path()));
+        let integration = ObjectStore::new_file(root.path());
 
         let data = Bytes::from("arbitrary data");
         let stream_data = std::io::Result::Ok(data.clone());

--- a/object_store/src/memory.rs
+++ b/object_store/src/memory.rs
@@ -184,7 +184,7 @@ mod tests {
 
     #[tokio::test]
     async fn in_memory_test() {
-        let integration = ObjectStore::new_in_memory(InMemory::new());
+        let integration = ObjectStore::new_in_memory();
 
         put_get_delete_list(&integration).await.unwrap();
         list_with_delimiter(&integration).await.unwrap();
@@ -192,7 +192,7 @@ mod tests {
 
     #[tokio::test]
     async fn length_mismatch_is_an_error() {
-        let integration = ObjectStore::new_in_memory(InMemory::new());
+        let integration = ObjectStore::new_in_memory();
 
         let bytes = stream::once(async { Ok(Bytes::from("hello world")) });
         let mut location = integration.new_path();
@@ -212,7 +212,7 @@ mod tests {
 
     #[tokio::test]
     async fn unknown_length() {
-        let integration = ObjectStore::new_in_memory(InMemory::new());
+        let integration = ObjectStore::new_in_memory();
 
         let data = Bytes::from("arbitrary data");
         let stream_data = std::io::Result::Ok(data.clone());

--- a/object_store/src/throttle.rs
+++ b/object_store/src/throttle.rs
@@ -13,12 +13,12 @@ use tokio::{
 /// Configuration settings for throttled store
 #[derive(Debug, Default, Clone, Copy)]
 pub struct ThrottleConfig {
-    /// Sleep duration for every call to [`delete`](Self::delete).
+    /// Sleep duration for every call to [`delete`](ThrottledStore::delete).
     ///
     /// Sleeping is done before the underlying store is called and independently of the success of the operation.
     pub wait_delete_per_call: Duration,
 
-    /// Sleep duration for every byte received during [`get`](Self::get).
+    /// Sleep duration for every byte received during [`get`](ThrottledStore::get).
     ///
     /// Sleeping is performed after the underlying store returned and only for successful gets. The sleep duration is
     /// additive to [`wait_get_per_call`](Self::wait_get_per_call).
@@ -27,19 +27,19 @@ pub struct ThrottleConfig {
     /// intermediate failure (i.e. after partly consuming the output bytes), the resulting sleep time will be partial as well.
     pub wait_get_per_byte: Duration,
 
-    /// Sleep duration for every call to [`get`](Self::get).
+    /// Sleep duration for every call to [`get`](ThrottledStore::get).
     ///
     /// Sleeping is done before the underlying store is called and independently of the success of the operation. The
     /// sleep duration is additive to [`wait_get_per_byte`](Self::wait_get_per_byte).
     pub wait_get_per_call: Duration,
 
-    /// Sleep duration for every call to [`list`](Self::list).
+    /// Sleep duration for every call to [`list`](ThrottledStore::list).
     ///
     /// Sleeping is done before the underlying store is called and independently of the success of the operation. The
     /// sleep duration is additive to [`wait_list_per_entry`](Self::wait_list_per_entry).
     pub wait_list_per_call: Duration,
 
-    /// Sleep duration for every entry received during [`list`](Self::list).
+    /// Sleep duration for every entry received during [`list`](ThrottledStore::list).
     ///
     /// Sleeping is performed after the underlying store returned and only for successful lists. The sleep duration is
     /// additive to [`wait_list_per_call`](Self::wait_list_per_call).
@@ -48,19 +48,19 @@ pub struct ThrottleConfig {
     /// intermediate failure (i.e. after partly consuming the output entries), the resulting sleep time will be partial as well.
     pub wait_list_per_entry: Duration,
 
-    /// Sleep duration for every call to [`list_with_delimiter`](Self::list_with_delimiter).
+    /// Sleep duration for every call to [`list_with_delimiter`](ThrottledStore::list_with_delimiter).
     ///
     /// Sleeping is done before the underlying store is called and independently of the success of the operation. The
     /// sleep duration is additive to [`wait_list_with_delimiter_per_entry`](Self::wait_list_with_delimiter_per_entry).
     pub wait_list_with_delimiter_per_call: Duration,
 
-    /// Sleep duration for every entry received during [`list_with_delimiter`](Self::list_with_delimiter).
+    /// Sleep duration for every entry received during [`list_with_delimiter`](ThrottledStore::list_with_delimiter).
     ///
     /// Sleeping is performed after the underlying store returned and only for successful gets. The sleep duration is
     /// additive to [`wait_list_with_delimiter_per_call`](Self::wait_list_with_delimiter_per_call).
     pub wait_list_with_delimiter_per_entry: Duration,
 
-    /// Sleep duration for every byte send during [`put`](Self::put).
+    /// Sleep duration for every byte send during [`put`](ThrottledStore::put).
     ///
     /// Sleeping is done before the underlying store is called and independently of the complete success of the operation. The
     /// sleep duration is additive to [`wait_put_per_call`](Self::wait_put_per_call).
@@ -69,7 +69,7 @@ pub struct ThrottleConfig {
     /// intermediate failure (i.e. after partly consuming the input bytes), the resulting sleep time will be partial as well.
     pub wait_put_per_byte: Duration,
 
-    /// Sleep duration for every call to [`put`](Self::put).
+    /// Sleep duration for every call to [`put`](ThrottledStore::put).
     ///
     /// Sleeping is done before the underlying store is called and independently of the success of the operation. The
     /// sleep duration is additive to [`wait_put_per_byte`](Self::wait_put_per_byte).

--- a/parquet_file/src/test_utils.rs
+++ b/parquet_file/src/test_utils.rs
@@ -21,7 +21,7 @@ use internal_types::{
     schema::{builder::SchemaBuilder, Schema, TIME_COLUMN_NAME},
     selection::Selection,
 };
-use object_store::{memory::InMemory, path::Path, ObjectStore, ObjectStoreApi};
+use object_store::{path::Path, ObjectStore, ObjectStoreApi};
 use parquet::{
     arrow::{ArrowReader, ParquetFileArrowReader},
     file::serialized_reader::{SerializedFileReader, SliceableCursor},
@@ -697,7 +697,7 @@ pub fn make_record_batch(
 
 /// Creates new in-memory object store for testing.
 pub fn make_object_store() -> Arc<ObjectStore> {
-    Arc::new(ObjectStore::new_in_memory(InMemory::new()))
+    Arc::new(ObjectStore::new_in_memory())
 }
 
 pub fn read_data_from_parquet_data(schema: SchemaRef, parquet_data: Vec<u8>) -> Vec<RecordBatch> {

--- a/server/src/config.rs
+++ b/server/src/config.rs
@@ -725,7 +725,7 @@ impl<'a> Drop for BlockDatabaseGuard<'a> {
 mod test {
     use std::convert::TryFrom;
 
-    use object_store::{memory::InMemory, ObjectStore, ObjectStoreApi};
+    use object_store::{ObjectStore, ObjectStoreApi};
 
     use crate::db::load::load_or_create_preserved_catalog;
 
@@ -736,7 +736,7 @@ mod test {
     async fn create_db() {
         // setup
         let name = DatabaseName::new("foo").unwrap();
-        let store = Arc::new(ObjectStore::new_in_memory(InMemory::new()));
+        let store = Arc::new(ObjectStore::new_in_memory());
         let exec = Arc::new(Executor::new(1));
         let server_id = ServerId::try_from(1).unwrap();
         let metric_registry = Arc::new(metrics::MetricRegistry::new());
@@ -890,7 +890,7 @@ mod test {
     async fn recover_db() {
         // setup
         let name = DatabaseName::new("foo").unwrap();
-        let store = Arc::new(ObjectStore::new_in_memory(InMemory::new()));
+        let store = Arc::new(ObjectStore::new_in_memory());
         let exec = Arc::new(Executor::new(1));
         let server_id = ServerId::try_from(1).unwrap();
         let metric_registry = Arc::new(metrics::MetricRegistry::new());
@@ -1002,7 +1002,7 @@ mod test {
     async fn block_db() {
         // setup
         let name = DatabaseName::new("foo").unwrap();
-        let store = Arc::new(ObjectStore::new_in_memory(InMemory::new()));
+        let store = Arc::new(ObjectStore::new_in_memory());
         let exec = Arc::new(Executor::new(1));
         let server_id = ServerId::try_from(1).unwrap();
         let metric_registry = Arc::new(metrics::MetricRegistry::new());
@@ -1053,7 +1053,7 @@ mod test {
     async fn test_db_drop() {
         // setup
         let name = DatabaseName::new("foo").unwrap();
-        let store = Arc::new(ObjectStore::new_in_memory(InMemory::new()));
+        let store = Arc::new(ObjectStore::new_in_memory());
         let exec = Arc::new(Executor::new(1));
         let server_id = ServerId::try_from(1).unwrap();
         let metric_registry = Arc::new(metrics::MetricRegistry::new());
@@ -1112,7 +1112,7 @@ mod test {
 
     #[test]
     fn object_store_path_for_database_config() {
-        let storage = ObjectStore::new_in_memory(InMemory::new());
+        let storage = ObjectStore::new_in_memory();
         let mut base_path = storage.new_path();
         base_path.push_dir("1");
 

--- a/server/src/db.rs
+++ b/server/src/db.rs
@@ -969,7 +969,6 @@ mod tests {
     use futures::{stream, StreamExt, TryStreamExt};
     use internal_types::{schema::Schema, selection::Selection};
     use object_store::{
-        memory::InMemory,
         path::{parts::PathPart, ObjectStorePath, Path},
         ObjectStore, ObjectStoreApi,
     };
@@ -1727,7 +1726,7 @@ mod tests {
     #[tokio::test]
     async fn write_one_chunk_to_parquet_file() {
         // Test that data can be written into parquet files
-        let object_store = Arc::new(ObjectStore::new_in_memory(InMemory::new()));
+        let object_store = Arc::new(ObjectStore::new_in_memory());
 
         // Create a DB given a server id, an object store and a db name
         let server_id = ServerId::try_from(10).unwrap();
@@ -1826,7 +1825,7 @@ mod tests {
         // be able to read data from object store
 
         // Create an object store in memory
-        let object_store = Arc::new(ObjectStore::new_in_memory(InMemory::new()));
+        let object_store = Arc::new(ObjectStore::new_in_memory());
 
         // Create a DB given a server id, an object store and a db name
         let server_id = ServerId::try_from(10).unwrap();
@@ -2633,7 +2632,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn lock_tracker_metrics() {
-        let object_store = Arc::new(ObjectStore::new_in_memory(InMemory::new()));
+        let object_store = Arc::new(ObjectStore::new_in_memory());
 
         // Create a DB given a server id, an object store and a db name
         let server_id = ServerId::try_from(10).unwrap();
@@ -2773,7 +2772,7 @@ mod tests {
         // Test that parquet data is committed to preserved catalog
 
         // ==================== setup ====================
-        let object_store = Arc::new(ObjectStore::new_in_memory(InMemory::new()));
+        let object_store = Arc::new(ObjectStore::new_in_memory());
         let server_id = ServerId::try_from(1).unwrap();
         let db_name = "preserved_catalog_test";
 
@@ -2881,7 +2880,7 @@ mod tests {
         // Test that stale parquet files are removed from object store
 
         // ==================== setup ====================
-        let object_store = Arc::new(ObjectStore::new_in_memory(InMemory::new()));
+        let object_store = Arc::new(ObjectStore::new_in_memory());
 
         // ==================== do: create DB ====================
         // Create a DB given a server id, an object store and a db name
@@ -2970,7 +2969,7 @@ mod tests {
         // Test that the preserved catalog creates checkpoints
 
         // ==================== setup ====================
-        let object_store = Arc::new(ObjectStore::new_in_memory(InMemory::new()));
+        let object_store = Arc::new(ObjectStore::new_in_memory());
         let server_id = ServerId::try_from(1).unwrap();
         let db_name = "preserved_catalog_test";
 

--- a/server/src/db/load.rs
+++ b/server/src/db/load.rs
@@ -220,7 +220,6 @@ impl CatalogState for Catalog {
 mod tests {
     use std::convert::TryFrom;
 
-    use object_store::memory::InMemory;
     use parquet_file::catalog::test_helpers::{
         assert_catalog_state_implementation, TestCatalogState,
     };
@@ -231,7 +230,7 @@ mod tests {
 
     #[tokio::test]
     async fn load_or_create_preserved_catalog_recovers_from_error() {
-        let object_store = Arc::new(ObjectStore::new_in_memory(InMemory::new()));
+        let object_store = Arc::new(ObjectStore::new_in_memory());
         let server_id = ServerId::try_from(1).unwrap();
         let db_name = "preserved_catalog_test";
 

--- a/server/src/init.rs
+++ b/server/src/init.rs
@@ -621,13 +621,13 @@ fn db_name_from_rules_path(path: &Path) -> Result<DatabaseName<'static>> {
 
 #[cfg(test)]
 mod tests {
-    use object_store::{memory::InMemory, path::ObjectStorePath};
+    use object_store::path::ObjectStorePath;
 
     use super::*;
 
     #[tokio::test]
     async fn test_get_database_config_bytes() {
-        let object_store = ObjectStore::new_in_memory(InMemory::new());
+        let object_store = ObjectStore::new_in_memory();
         let mut rules_path = object_store.new_path();
         rules_path.push_all_dirs(&["1", "foo_bar"]);
         rules_path.set_file_name("rules.pb");

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -1165,7 +1165,7 @@ mod tests {
     };
     use influxdb_line_protocol::parse_lines;
     use metrics::MetricRegistry;
-    use object_store::{memory::InMemory, path::ObjectStorePath};
+    use object_store::path::ObjectStorePath;
     use query::{exec::ExecutorType, frontend::sql::SqlQueryPlanner, QueryDatabase};
 
     use super::*;
@@ -1187,7 +1187,7 @@ mod tests {
     }
 
     fn config_with_metric_registry() -> (metrics::TestMetricRegistry, ServerConfig) {
-        config_with_metric_registry_and_store(ObjectStore::new_in_memory(InMemory::new()))
+        config_with_metric_registry_and_store(ObjectStore::new_in_memory())
     }
 
     fn config() -> ServerConfig {
@@ -1349,7 +1349,7 @@ mod tests {
     async fn load_databases() {
         let temp_dir = TempDir::new().unwrap();
 
-        let store = ObjectStore::new_file(object_store::disk::File::new(temp_dir.path()));
+        let store = ObjectStore::new_file(temp_dir.path());
         let manager = TestConnectionManager::new();
         let config = config_with_store(store);
         let server = Server::new(manager, config);
@@ -1365,7 +1365,7 @@ mod tests {
 
         std::mem::drop(server);
 
-        let store = ObjectStore::new_file(object_store::disk::File::new(temp_dir.path()));
+        let store = ObjectStore::new_file(temp_dir.path());
         let manager = TestConnectionManager::new();
         let config = config_with_store(store);
         let server = Server::new(manager, config);
@@ -1380,7 +1380,7 @@ mod tests {
 
         std::mem::drop(server);
 
-        let store = ObjectStore::new_file(object_store::disk::File::new(temp_dir.path()));
+        let store = ObjectStore::new_file(temp_dir.path());
         store
             .delete(&rules_path)
             .await
@@ -1821,7 +1821,7 @@ mod tests {
     async fn cannot_create_db_until_server_is_initialized() {
         let temp_dir = TempDir::new().unwrap();
 
-        let store = ObjectStore::new_file(object_store::disk::File::new(temp_dir.path()));
+        let store = ObjectStore::new_file(temp_dir.path());
         let manager = TestConnectionManager::new();
         let config = config_with_store(store);
         let server = Server::new(manager, config);
@@ -1887,7 +1887,7 @@ mod tests {
 
     #[tokio::test]
     async fn init_error_database() {
-        let store = ObjectStore::new_in_memory(InMemory::new());
+        let store = ObjectStore::new_in_memory();
         let server_id = ServerId::try_from(1).unwrap();
 
         // Create temporary server to create single database
@@ -1979,7 +1979,7 @@ mod tests {
         let db_name_created = DatabaseName::new("db_created".to_string()).unwrap();
 
         // setup
-        let store = ObjectStore::new_in_memory(InMemory::new());
+        let store = ObjectStore::new_in_memory();
         let server_id = ServerId::try_from(1).unwrap();
 
         // Create temporary server to create existing databases
@@ -2168,7 +2168,7 @@ mod tests {
 
     #[tokio::test]
     async fn cannot_create_db_when_catalog_is_present() {
-        let store = Arc::new(ObjectStore::new_in_memory(InMemory::new()));
+        let store = Arc::new(ObjectStore::new_in_memory());
         let server_id = ServerId::try_from(1).unwrap();
         let db_name = "my_db";
 

--- a/server/src/utils.rs
+++ b/server/src/utils.rs
@@ -6,7 +6,7 @@ use data_types::{
     server_id::ServerId,
     DatabaseName,
 };
-use object_store::{memory::InMemory, ObjectStore};
+use object_store::ObjectStore;
 use query::{exec::Executor, QueryDatabase};
 
 use crate::{
@@ -54,7 +54,7 @@ impl TestDbBuilder {
             .unwrap_or_else(|| DatabaseName::new("placeholder").unwrap());
         let object_store = self
             .object_store
-            .unwrap_or_else(|| Arc::new(ObjectStore::new_in_memory(InMemory::new())));
+            .unwrap_or_else(|| Arc::new(ObjectStore::new_in_memory()));
 
         let exec = Arc::new(Executor::new(1));
         let metrics_registry = Arc::new(metrics::MetricRegistry::new());

--- a/src/influxdb_ioxd/http.rs
+++ b/src/influxdb_ioxd/http.rs
@@ -863,7 +863,7 @@ mod tests {
     use reqwest::{Client, Response};
 
     use data_types::{database_rules::DatabaseRules, server_id::ServerId, DatabaseName};
-    use object_store::{memory::InMemory, ObjectStore};
+    use object_store::ObjectStore;
     use serde::de::DeserializeOwned;
     use server::{db::Db, ConnectionManagerImpl, ServerConfig as AppServerConfig};
 
@@ -872,12 +872,8 @@ mod tests {
         let test_registry = metrics::TestMetricRegistry::new(Arc::clone(&registry));
         (
             test_registry,
-            AppServerConfig::new(
-                Arc::new(ObjectStore::new_in_memory(InMemory::new())),
-                registry,
-                None,
-            )
-            .with_num_worker_threads(1),
+            AppServerConfig::new(Arc::new(ObjectStore::new_in_memory()), registry, None)
+                .with_num_worker_threads(1),
         )
     }
 


### PR DESCRIPTION

# Rationale
1. Keeping the object store construction interface consistent is a good thing
2. Keeping the implementation details of object_store encapsulated is also a good thing

# Changes
1. Make `memory`, `disk` and `throttle` modules object store private
2. Update the object store constructor interface for disk, memory, and throttled the same as for AWS, S3 and GCP (which were changed in https://github.com/influxdata/influxdb_iox/pull/1932
