### PR TITLE
fix: Fix doc build warnings

### DIFF
--- a/arrow_util/src/lib.rs
+++ b/arrow_util/src/lib.rs
@@ -1,4 +1,4 @@
-#![deny(broken_intra_doc_links, rust_2018_idioms)]
+#![deny(broken_intra_doc_links, rustdoc::bare_urls, rust_2018_idioms)]
 #![allow(clippy::clone_on_ref_ptr)]
 
 pub mod bitset;

--- a/data_types/src/lib.rs
+++ b/data_types/src/lib.rs
@@ -2,7 +2,7 @@
 //! servers including replicated data, rules for how data is split up and
 //! queried, and what gets stored in the write buffer database.
 
-#![deny(broken_intra_doc_links, rust_2018_idioms)]
+#![deny(broken_intra_doc_links, rustdoc::bare_urls, rust_2018_idioms)]
 #![warn(
     missing_debug_implementations,
     clippy::explicit_iter_loop,

--- a/datafusion_util/src/lib.rs
+++ b/datafusion_util/src/lib.rs
@@ -1,4 +1,4 @@
-#![deny(broken_intra_doc_links, rust_2018_idioms)]
+#![deny(broken_intra_doc_links, rustdoc::bare_urls, rust_2018_idioms)]
 #![allow(clippy::clone_on_ref_ptr)]
 
 use std::sync::Arc;

--- a/generated_types/protos/influxdata/iox/management/v1/service.proto
+++ b/generated_types/protos/influxdata/iox/management/v1/service.proto
@@ -23,7 +23,7 @@ service ManagementService {
 
   // Update a database.
   //
-  // Roughly follows the https://google.aip.dev/134 pattern, except we wrap the response
+  // Roughly follows the <https://google.aip.dev/134> pattern, except we wrap the response
   rpc UpdateDatabase(UpdateDatabaseRequest) returns (UpdateDatabaseResponse);
 
   // List chunks available on this database

--- a/generated_types/src/lib.rs
+++ b/generated_types/src/lib.rs
@@ -1,7 +1,7 @@
 // This crate deliberately does not use the same linting rules as the other
 // crates because of all the generated code it contains that we don't have much
 // control over.
-#![deny(broken_intra_doc_links)]
+#![deny(broken_intra_doc_links, rustdoc::bare_urls)]
 
 /// This module imports the generated protobuf code into a Rust module
 /// hierarchy that matches the namespace hierarchy of the protobuf

--- a/google_types/src/lib.rs
+++ b/google_types/src/lib.rs
@@ -1,7 +1,7 @@
 // This crate deliberately does not use the same linting rules as the other
 // crates because of all the generated code it contains that we don't have much
 // control over.
-#![deny(broken_intra_doc_links, rust_2018_idioms)]
+#![deny(broken_intra_doc_links, rustdoc::bare_urls, rust_2018_idioms)]
 #![allow(
     unused_imports,
     clippy::redundant_static_lifetimes,

--- a/grpc-router/src/connection_manager.rs
+++ b/grpc-router/src/connection_manager.rs
@@ -27,7 +27,8 @@ pub trait ConnectionManager<T, E = Error> {
 ///
 /// It caches connected gRPC clients of type T (not operations performed over the connection).
 /// Each cache access returns a clone of the tonic gRPC client. Cloning clients is cheap
-/// and allows them to communicate through the same channel, see https://docs.rs/tonic/0.4.2/tonic/client/index.html#concurrent-usage
+/// and allows them to communicate through the same channel, see
+/// <https://docs.rs/tonic/0.4.2/tonic/client/index.html#concurrent-usage>
 ///
 /// The `CachingConnectionManager` implements a blocking cache-loading mechanism, that is, it guarantees that once a
 /// connection request for a given connection string is in flight, subsequent cache access requests

--- a/grpc-router/src/lib.rs
+++ b/grpc-router/src/lib.rs
@@ -4,7 +4,7 @@
 //! that same service interface or to a remote service. The tonic gRPC client used to talk to the
 //! remote service is provided by the user by implementing the [`Router`] trait for the router service type.
 //! The [`Router`] trait allows the user to provide a different gRPC client per request, or to just
-//! fall-back to serving the request from a local service implementation (without any further gRPC overhead).   
+//! fall-back to serving the request from a local service implementation (without any further gRPC overhead).
 //!
 //! This crate also offers an optional caching [`connection_manager`], which can be useful for
 //! implementing the [`Router`] trait.
@@ -124,7 +124,7 @@
 //!                 self.connection_manager
 //!                     .remote_server(remote_addr.clone())
 //!                     .await?,
-//!             ),         
+//!             ),
 //!         })
 //!     }
 //! }
@@ -166,7 +166,7 @@
 //! # }
 //! ```
 
-#![deny(broken_intra_doc_links, rust_2018_idioms)]
+#![deny(broken_intra_doc_links, rustdoc::bare_urls, rust_2018_idioms)]
 #![warn(
     missing_copy_implementations,
     missing_debug_implementations,

--- a/influxdb2_client/src/lib.rs
+++ b/influxdb2_client/src/lib.rs
@@ -1,4 +1,4 @@
-#![deny(broken_intra_doc_links, rust_2018_idioms)]
+#![deny(broken_intra_doc_links, rustdoc::bare_urls, rust_2018_idioms)]
 #![warn(
     missing_copy_implementations,
     missing_debug_implementations,

--- a/influxdb2_client/src/models/ast/dialect.rs
+++ b/influxdb2_client/src/models/ast/dialect.rs
@@ -2,7 +2,8 @@
 
 use serde::{Deserialize, Serialize};
 
-/// Dialect are options to change the default CSV output format; https://www.w3.org/TR/2015/REC-tabular-metadata-20151217/#dialect-descriptions
+/// Dialect are options to change the default CSV output format;
+/// <https://www.w3.org/TR/2015/REC-tabular-metadata-20151217/#dialect-descriptions>
 #[derive(Clone, Debug, PartialEq, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Dialect {
@@ -12,7 +13,7 @@ pub struct Dialect {
     /// Separator between cells; the default is ,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub delimiter: Option<String>,
-    /// https://www.w3.org/TR/2015/REC-tabular-data-model-20151217/#columns
+    /// <https://www.w3.org/TR/2015/REC-tabular-data-model-20151217/#columns>
     #[serde(skip_serializing_if = "Option::is_none")]
     pub annotations: Option<Annotations>,
     /// Character prefixed to comment strings
@@ -24,13 +25,14 @@ pub struct Dialect {
 }
 
 impl Dialect {
-    /// Dialect are options to change the default CSV output format; https://www.w3.org/TR/2015/REC-tabular-metadata-20151217/#dialect-descriptions
+    /// Dialect are options to change the default CSV output format;
+    /// <https://www.w3.org/TR/2015/REC-tabular-metadata-20151217/#dialect-descriptions>
     pub fn new() -> Self {
         Self::default()
     }
 }
 
-/// https://www.w3.org/TR/2015/REC-tabular-data-model-20151217/#columns
+/// <https://www.w3.org/TR/2015/REC-tabular-data-model-20151217/#columns>
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub enum Annotations {

--- a/influxdb_iox_client/src/lib.rs
+++ b/influxdb_iox_client/src/lib.rs
@@ -1,6 +1,7 @@
 //! An InfluxDB IOx API client.
 #![deny(
     broken_intra_doc_links,
+    rustdoc::bare_urls,
     rust_2018_idioms,
     missing_debug_implementations,
     unreachable_pub

--- a/influxdb_line_protocol/src/lib.rs
+++ b/influxdb_line_protocol/src/lib.rs
@@ -7,7 +7,7 @@
 //! However, this implementation uses a nom combinator based parser
 //! rather than attempting to port the imperative Go logic.
 
-#![deny(broken_intra_doc_links, rust_2018_idioms)]
+#![deny(broken_intra_doc_links, rustdoc::bare_urls, rust_2018_idioms)]
 #![warn(
     missing_copy_implementations,
     missing_debug_implementations,

--- a/influxdb_line_protocol/src/lib.rs
+++ b/influxdb_line_protocol/src/lib.rs
@@ -1,8 +1,8 @@
 //! This module contains a pure rust implementation of a parser for InfluxDB
-//! Line Protocol https://v2.docs.influxdata.com/v2.0/reference/syntax/line-protocol/
+//! Line Protocol <https://v2.docs.influxdata.com/v2.0/reference/syntax/line-protocol>
 //!
 //! This implementation is intended to be compatible with the Go implementation,
-//! https://github.com/influxdata/influxdb/blob/217eddc87e14a79b01d0c22994fc139f530094a2/models/points_parser.go
+//! <https://github.com/influxdata/influxdb/blob/217eddc87e14a79b01d0c22994fc139f530094a2/models/points_parser.go>
 //!
 //! However, this implementation uses a nom combinator based parser
 //! rather than attempting to port the imperative Go logic.
@@ -332,7 +332,7 @@ pub type FieldSet<'a> = SmallVec<[(EscapedStr<'a>, FieldValue<'a>); 4]>;
 pub type TagSet<'a> = SmallVec<[(EscapedStr<'a>, EscapedStr<'a>); 8]>;
 
 /// Allowed types of Fields in a `ParsedLine`. One of the types described in
-/// https://docs.influxdata.com/influxdb/v2.0/reference/syntax/line-protocol/#data-types-and-format
+/// <https://docs.influxdata.com/influxdb/v2.0/reference/syntax/line-protocol/#data-types-and-format>
 #[derive(Debug, Clone, PartialEq)]
 pub enum FieldValue<'a> {
     I64(i64),
@@ -343,7 +343,7 @@ pub enum FieldValue<'a> {
 }
 
 /// Converts FieldValue back to LineProtocol
-/// See https://docs.influxdata.com/influxdb/v2.0/reference/syntax/line-protocol/
+/// See <https://docs.influxdata.com/influxdb/v2.0/reference/syntax/line-protocol/>
 /// for more detail.
 impl<'a> Display for FieldValue<'a> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/influxdb_tsm/src/lib.rs
+++ b/influxdb_tsm/src/lib.rs
@@ -1,4 +1,4 @@
-#![deny(broken_intra_doc_links, rust_2018_idioms)]
+#![deny(broken_intra_doc_links, rustdoc::bare_urls, rust_2018_idioms)]
 #![warn(
     missing_copy_implementations,
     missing_debug_implementations,

--- a/internal_types/src/lib.rs
+++ b/internal_types/src/lib.rs
@@ -1,4 +1,4 @@
-#![deny(broken_intra_doc_links, rust_2018_idioms)]
+#![deny(broken_intra_doc_links, rustdoc::bare_urls, rust_2018_idioms)]
 #![warn(
     missing_debug_implementations,
     clippy::explicit_iter_loop,

--- a/internal_types/src/schema.rs
+++ b/internal_types/src/schema.rs
@@ -564,7 +564,7 @@ impl TryFrom<ArrowDataType> for IOxValueType {
 }
 
 /// Field value types for InfluxDB 2.0 data model, as defined in
-/// [the documentation]: https://docs.influxdata.com/influxdb/v2.0/reference/syntax/line-protocol/
+/// [the documentation]: <https://docs.influxdata.com/influxdb/v2.0/reference/syntax/line-protocol/>
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum InfluxFieldType {
     /// 64-bit floating point number (TDB if NULLs / Nans are allowed)

--- a/internal_types/src/schema/sort.rs
+++ b/internal_types/src/schema/sort.rs
@@ -23,7 +23,7 @@ pub enum Error {
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
-/// Temporary - https://github.com/apache/arrow-rs/pull/425
+/// Temporary - <https://github.com/apache/arrow-rs/pull/425>
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub struct SortOptions {
     /// Whether to sort in descending order

--- a/lifecycle/src/guard.rs
+++ b/lifecycle/src/guard.rs
@@ -1,7 +1,7 @@
 //! This module contains lock guards for use in the lifecycle traits
 //!
 //! Specifically they exist to work around a lack of support for generic associated
-//! types within traits. https://github.com/rust-lang/rust/issues/44265
+//! types within traits. <https://github.com/rust-lang/rust/issues/44265>
 //!
 //! ```ignore
 //! trait MyTrait {

--- a/lifecycle/src/lib.rs
+++ b/lifecycle/src/lib.rs
@@ -1,4 +1,4 @@
-#![deny(broken_intra_doc_links, rust_2018_idioms)]
+#![deny(broken_intra_doc_links, rustdoc::bare_urls, rust_2018_idioms)]
 #![warn(
     missing_copy_implementations,
     missing_debug_implementations,

--- a/logfmt/src/lib.rs
+++ b/logfmt/src/lib.rs
@@ -17,7 +17,7 @@ use std::{io::Write, time::SystemTime};
 ///
 /// At time of writing, I could find no good existing crate
 ///
-/// https://github.com/mcountryman/logfmt_logger from @mcountryman
+/// <https://github.com/mcountryman/logfmt_logger> from @mcountryman
 /// looked very small and did not (obviously) work with the tracing subscriber
 ///
 /// [logfmt]: https://brandur.org/logfmt

--- a/logfmt/src/lib.rs
+++ b/logfmt/src/lib.rs
@@ -1,4 +1,4 @@
-#![deny(broken_intra_doc_links, rust_2018_idioms)]
+#![deny(broken_intra_doc_links, rustdoc::bare_urls, rust_2018_idioms)]
 
 use observability_deps::{
     tracing::{

--- a/mem_qe/src/lib.rs
+++ b/mem_qe/src/lib.rs
@@ -1,4 +1,4 @@
-#![deny(broken_intra_doc_links, rust_2018_idioms)]
+#![deny(broken_intra_doc_links, rustdoc::bare_urls, rust_2018_idioms)]
 #![allow(clippy::type_complexity)]
 pub mod adapter;
 pub mod column;

--- a/metrics/src/lib.rs
+++ b/metrics/src/lib.rs
@@ -1,4 +1,4 @@
-#![deny(broken_intra_doc_links, rust_2018_idioms)]
+#![deny(broken_intra_doc_links, rustdoc::bare_urls, rust_2018_idioms)]
 #![warn(
     missing_debug_implementations,
     clippy::explicit_iter_loop,

--- a/metrics/src/lib.rs
+++ b/metrics/src/lib.rs
@@ -77,7 +77,7 @@ impl MetricRegistry {
     /// Returns the current metrics state, in UTF-8 encoded Prometheus
     /// Exposition Format.
     ///
-    /// https://prometheus.io/docs/instrumenting/exposition_formats/
+    /// <https://prometheus.io/docs/instrumenting/exposition_formats/>
     ///
     /// For example:
     ///
@@ -290,7 +290,7 @@ impl Domain {
     ///
     /// `unit` is optional and will appear in the metric name before a final
     /// `total` suffix. Consider reviewing
-    /// https://prometheus.io/docs/practices/naming/#base-units for appropriate
+    /// <https://prometheus.io/docs/practices/naming/#base-units> for appropriate
     /// units.
     pub fn register_counter_metric(
         &self,
@@ -331,7 +331,7 @@ impl Domain {
     ///
     /// `unit` is required and will appear at the end of the metric name.
     /// Consider reviewing
-    /// https://prometheus.io/docs/practices/naming/#base-units for appropriate
+    /// <https://prometheus.io/docs/practices/naming/#base-units> for appropriate
     /// units. Examples include "bytes", "seconds", "celsius"
     ///
     pub fn register_histogram_metric(
@@ -360,7 +360,7 @@ impl Domain {
     ///
     /// `unit` is optional and will appear in the metric name before a final
     /// `total` suffix. Consider reviewing
-    /// https://prometheus.io/docs/practices/naming/#base-units for appropriate
+    /// <https://prometheus.io/docs/practices/naming/#base-units> for appropriate
     pub fn register_gauge_metric(
         &self,
         name: &str,

--- a/metrics/src/metrics.rs
+++ b/metrics/src/metrics.rs
@@ -73,7 +73,7 @@ pub struct RedMetric {
 }
 
 /// Workaround self-recursive OT instruments
-/// https://github.com/open-telemetry/opentelemetry-rust/issues/550
+/// <https://github.com/open-telemetry/opentelemetry-rust/issues/550>
 impl std::fmt::Debug for RedMetric {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("RedMetric")
@@ -239,7 +239,7 @@ pub struct Counter {
 }
 
 /// Workaround self-recursive OT instruments
-/// https://github.com/open-telemetry/opentelemetry-rust/issues/550
+/// <https://github.com/open-telemetry/opentelemetry-rust/issues/550>
 impl std::fmt::Debug for Counter {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Counter")
@@ -316,7 +316,7 @@ pub struct Histogram {
 }
 
 /// Workaround self-recursive OT instruments
-/// https://github.com/open-telemetry/opentelemetry-rust/issues/550
+/// <https://github.com/open-telemetry/opentelemetry-rust/issues/550>
 impl std::fmt::Debug for Histogram {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Histogram")

--- a/metrics/src/observer.rs
+++ b/metrics/src/observer.rs
@@ -1,7 +1,7 @@
 //! This module is a gnarly hack around the fact opentelemetry doesn't currently let you
 //! register an observer multiple times with the same name
 //!
-//! See https://github.com/open-telemetry/opentelemetry-rust/issues/541
+//! See <https://github.com/open-telemetry/opentelemetry-rust/issues/541>
 
 use std::collections::hash_map::Entry;
 use std::collections::HashMap;

--- a/mutable_buffer/src/lib.rs
+++ b/mutable_buffer/src/lib.rs
@@ -50,7 +50,7 @@
 //! is done on a per-Chunk basis, so that as soon as the chunk is
 //! closed the corresponding dictionary also becomes immutable
 
-#![deny(broken_intra_doc_links, rust_2018_idioms)]
+#![deny(broken_intra_doc_links, rustdoc::bare_urls, rust_2018_idioms)]
 #![warn(
     missing_copy_implementations,
     missing_debug_implementations,

--- a/object_store/src/lib.rs
+++ b/object_store/src/lib.rs
@@ -1,4 +1,4 @@
-#![deny(broken_intra_doc_links, rust_2018_idioms)]
+#![deny(broken_intra_doc_links, rustdoc::bare_urls, rust_2018_idioms)]
 #![warn(
     missing_copy_implementations,
     missing_debug_implementations,

--- a/packers/src/lib.rs
+++ b/packers/src/lib.rs
@@ -1,4 +1,4 @@
-#![deny(broken_intra_doc_links, rust_2018_idioms)]
+#![deny(broken_intra_doc_links, rustdoc::bare_urls, rust_2018_idioms)]
 #![warn(
     missing_copy_implementations,
     missing_debug_implementations,

--- a/panic_logging/src/lib.rs
+++ b/panic_logging/src/lib.rs
@@ -1,7 +1,7 @@
 //! Custom panic hook that sends the panic information to a tracing
 //! span
 
-#![deny(broken_intra_doc_links, rust_2018_idioms)]
+#![deny(broken_intra_doc_links, rustdoc::bare_urls, rust_2018_idioms)]
 #![warn(
     missing_debug_implementations,
     clippy::explicit_iter_loop,

--- a/parquet_file/src/lib.rs
+++ b/parquet_file/src/lib.rs
@@ -1,4 +1,4 @@
-#![deny(broken_intra_doc_links, rust_2018_idioms)]
+#![deny(broken_intra_doc_links, rustdoc::bare_urls, rust_2018_idioms)]
 #![warn(
     missing_copy_implementations,
     missing_debug_implementations,

--- a/query/src/exec/task.rs
+++ b/query/src/exec/task.rs
@@ -54,7 +54,7 @@ impl DedicatedExecutor {
     ///
     /// Follows the example from to stack overflow and spawns a new
     /// thread to install a Tokio runtime "context"
-    /// https://stackoverflow.com/questions/62536566
+    /// <https://stackoverflow.com/questions/62536566>
     ///
     /// If you try to do this from a async context you see something like
     /// thread 'plan::stringset::tests::test_builder_plan' panicked at 'Cannot

--- a/query/src/func/selectors.rs
+++ b/query/src/func/selectors.rs
@@ -41,7 +41,7 @@ use internal_types::schema::TIME_DATA_TYPE;
 /// Returns a DataFusion user defined aggregate function for computing
 /// one field of the first() selector function.
 ///
-/// Note that until https://issues.apache.org/jira/browse/ARROW-10945
+/// Note that until <https://issues.apache.org/jira/browse/ARROW-10945>
 /// is fixed, selector functions must be computed using two separate
 /// function calls, one each for the value and time part
 ///
@@ -71,7 +71,7 @@ pub fn selector_first(data_type: &DataType, output: SelectorOutput) -> Aggregate
 /// Returns a DataFusion user defined aggregate function for computing
 /// one field of the last() selector function.
 ///
-/// Note that until https://issues.apache.org/jira/browse/ARROW-10945
+/// Note that until <https://issues.apache.org/jira/browse/ARROW-10945>
 /// is fixed, selector functions must be computed using two separate
 /// function calls, one each for the value and time part
 ///
@@ -101,7 +101,7 @@ pub fn selector_last(data_type: &DataType, output: SelectorOutput) -> AggregateU
 /// Returns a DataFusion user defined aggregate function for computing
 /// one field of the min() selector function.
 ///
-/// Note that until https://issues.apache.org/jira/browse/ARROW-10945
+/// Note that until <https://issues.apache.org/jira/browse/ARROW-10945>
 /// is fixed, selector functions must be computed using two separate
 /// function calls, one each for the value and time part
 ///
@@ -131,7 +131,7 @@ pub fn selector_min(data_type: &DataType, output: SelectorOutput) -> AggregateUD
 /// Returns a DataFusion user defined aggregate function for computing
 /// one field of the max() selector function.
 ///
-/// Note that until https://issues.apache.org/jira/browse/ARROW-10945
+/// Note that until <https://issues.apache.org/jira/browse/ARROW-10945>
 /// is fixed, selector functions must be computed using two separate
 /// function calls, one each for the value and time part
 ///

--- a/query/src/func/window/internal.rs
+++ b/query/src/func/window/internal.rs
@@ -10,7 +10,7 @@ use std::ops::{Add, Mul};
 
 /// Duration is a vector representing the duration unit components.
 ///
-/// Original: https://github.com/influxdata/flux/blob/1e9bfd49f21c0e679b42acf6fc515ce05c6dec2b/values/time.go#L18
+/// Original: <https://github.com/influxdata/flux/blob/1e9bfd49f21c0e679b42acf6fc515ce05c6dec2b/values/time.go#L18>
 #[derive(Debug, Clone, Copy)]
 pub struct Duration {
     /// months is the number of months for the duration.
@@ -29,7 +29,7 @@ impl Duration {
     /// Port of values.ConvertDurationNsecs. Creates a Duration that
     /// representing a fixed number of nanoseconds.
     ///
-    /// Original: https://github.com/influxdata/flux/blob/1e9bfd49f21c0e679b42acf6fc515ce05c6dec2b/values/time.go#L40
+    /// Original: <https://github.com/influxdata/flux/blob/1e9bfd49f21c0e679b42acf6fc515ce05c6dec2b/values/time.go#L40>
     pub fn from_nsecs(v: i64) -> Self {
         let (negative, nsecs) = if v < 0 { (true, -v) } else { (false, v) };
 
@@ -44,7 +44,7 @@ impl Duration {
     /// representing a fixed number of months (which vary in absolute
     /// number of nanoseconds).
     ///
-    /// Original: https://github.com/influxdata/flux/blob/1e9bfd49f21c0e679b42acf6fc515ce05c6dec2b/values/time.go#L52
+    /// Original: <https://github.com/influxdata/flux/blob/1e9bfd49f21c0e679b42acf6fc515ce05c6dec2b/values/time.go#L52>
     pub fn from_months(v: i64) -> Self {
         let (negative, months) = if v < 0 { (true, -v) } else { (false, v) };
 
@@ -68,7 +68,7 @@ impl Duration {
 
     /// IsZero returns true if this is a zero duration.
     ///
-    /// Original: https://github.com/influxdata/flux/blob/1e9bfd49f21c0e679b42acf6fc515ce05c6dec2b/values/time.go#L204
+    /// Original: <https://github.com/influxdata/flux/blob/1e9bfd49f21c0e679b42acf6fc515ce05c6dec2b/values/time.go#L204>
     fn is_zero(&self) -> bool {
         self.months == 0 && self.nsecs == 0
     }
@@ -87,7 +87,7 @@ impl Duration {
     /// the only two ways to create a duration in this `impl` ensures
     /// that invariant)
     ///
-    /// Original: https://github.com/influxdata/flux/blob/1e9bfd49f21c0e679b42acf6fc515ce05c6dec2b/execute/window.go#L52
+    /// Original: <https://github.com/influxdata/flux/blob/1e9bfd49f21c0e679b42acf6fc515ce05c6dec2b/execute/window.go#L52>
     fn truncate(&self, t: i64) -> i64 {
         let months = self.months;
         let nsec = self.nsecs;
@@ -111,7 +111,7 @@ impl Mul<i64> for Duration {
     /// Mul will multiply the Duration by a scalar.
     /// This multiplies each component of the vector.
     ///
-    /// Original: https://github.com/influxdata/flux/blob/1e9bfd49f21c0e679b42acf6fc515ce05c6dec2b/values/time.go#L175
+    /// Original: <https://github.com/influxdata/flux/blob/1e9bfd49f21c0e679b42acf6fc515ce05c6dec2b/values/time.go#L175>
     fn mul(self, rhs: i64) -> Self {
         let mut scale = rhs;
         let mut d = self;
@@ -136,7 +136,7 @@ impl Mul<i64> for Duration {
 /// (which can have year, month, etc. extracted)
 ///
 /// This is roughly equivelnt to ConvertTime
-/// from https://github.com/influxdata/flux/blob/1e9bfd49f21c0e679b42acf6fc515ce05c6dec2b/values/time.go#L35-L37
+/// from <https://github.com/influxdata/flux/blob/1e9bfd49f21c0e679b42acf6fc515ce05c6dec2b/values/time.go#L35-L37>
 fn timestamp_to_datetime(ts: i64) -> DateTime<Utc> {
     let secs = ts / 1_000_000_000;
     let nsec = ts % 1_000_000_000;
@@ -146,7 +146,7 @@ fn timestamp_to_datetime(ts: i64) -> DateTime<Utc> {
     DateTime::from_utc(datetime, Utc)
 }
 
-/// Original: https://github.com/influxdata/flux/blob/1e9bfd49f21c0e679b42acf6fc515ce05c6dec2b/values/time.go#L491
+/// Original: <https://github.com/influxdata/flux/blob/1e9bfd49f21c0e679b42acf6fc515ce05c6dec2b/values/time.go#L491>
 const LAST_DAYS: [u32; 12] = [
     31, // time.January:   31,
     28, // time.February:  28,
@@ -169,7 +169,7 @@ fn last_day_of_month(month: i32) -> u32 {
 }
 
 // port of fun isLeapYear(year int) bool {
-/// Original: https://github.com/influxdata/flux/blob/1e9bfd49f21c0e679b42acf6fc515ce05c6dec2b/values/time.go#L506
+/// Original: <https://github.com/influxdata/flux/blob/1e9bfd49f21c0e679b42acf6fc515ce05c6dec2b/values/time.go#L506>
 fn is_leap_year(year: i32) -> bool {
     year % 400 == 0 || (year % 4 == 0 && year % 100 != 0)
 }
@@ -203,7 +203,7 @@ impl Add<Duration> for i64 {
 
     /// Adds a duration to a nanosecond timestamp
     ///
-    /// Original: https://github.com/influxdata/flux/blob/1e9bfd49f21c0e679b42acf6fc515ce05c6dec2b/values/time.go#L84
+    /// Original: <https://github.com/influxdata/flux/blob/1e9bfd49f21c0e679b42acf6fc515ce05c6dec2b/values/time.go#L84>
     fn add(self, rhs: Duration) -> Self {
         let t = self;
         let d = rhs;
@@ -264,7 +264,7 @@ impl Add<Duration> for i64 {
 
 /// The bounds of a window
 ///
-/// Original: https://github.com/influxdata/flux/blob/1e9bfd49f21c0e679b42acf6fc515ce05c6dec2b/execute/bounds.go#L19
+/// Original: <https://github.com/influxdata/flux/blob/1e9bfd49f21c0e679b42acf6fc515ce05c6dec2b/execute/bounds.go#L19>
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Bounds {
     pub start: i64,
@@ -273,7 +273,7 @@ pub struct Bounds {
 
 /// Represents a window in time
 ///
-/// Original: https://github.com/influxdata/flux/blob/1e9bfd49f21c0e679b42acf6fc515ce05c6dec2b/execute/window.go#L11
+/// Original: <https://github.com/influxdata/flux/blob/1e9bfd49f21c0e679b42acf6fc515ce05c6dec2b/execute/window.go#L11>
 #[derive(Debug, Clone, Copy)]
 pub struct Window {
     every: Duration,
@@ -296,7 +296,7 @@ impl Window {
     /// do not contain time t, the window directly after time t will be
     /// returned.
     ///
-    /// Original: https://github.com/influxdata/flux/blob/1e9bfd49f21c0e679b42acf6fc515ce05c6dec2b/execute/window.go#L70
+    /// Original: <https://github.com/influxdata/flux/blob/1e9bfd49f21c0e679b42acf6fc515ce05c6dec2b/execute/window.go#L70>
     pub fn get_earliest_bounds(&self, t: i64) -> Bounds {
         // translate to not-offset coordinate
         // t = t.Add(w.Offset.Mul(-1))
@@ -317,7 +317,7 @@ impl Window {
 
     /// truncate the time using the duration.
     ///
-    /// Original: https://github.com/influxdata/flux/blob/1e9bfd49f21c0e679b42acf6fc515ce05c6dec2b/execute/window.go#L52
+    /// Original: <https://github.com/influxdata/flux/blob/1e9bfd49f21c0e679b42acf6fc515ce05c6dec2b/execute/window.go#L52>
     fn truncate(&self, t: i64) -> i64 {
         self.every.truncate(t)
     }
@@ -326,7 +326,7 @@ impl Window {
 /// truncateByNsecs will truncate the time to the given number
 /// of nanoseconds.
 ///
-/// Original: https://github.com/influxdata/flux/blob/1e9bfd49f21c0e679b42acf6fc515ce05c6dec2b/execute/window.go#L108
+/// Original: <https://github.com/influxdata/flux/blob/1e9bfd49f21c0e679b42acf6fc515ce05c6dec2b/execute/window.go#L108>
 fn truncate_by_nsecs(t: i64, d: &Duration) -> i64 {
     let dur = d.nanoseconds();
     let mut remainder = t % dur;
@@ -341,7 +341,7 @@ fn truncate_by_nsecs(t: i64, d: &Duration) -> i64 {
 /// truncateByMonths will truncate the time to the given
 /// number of months.
 ///
-/// Original: https://github.com/influxdata/flux/blob/1e9bfd49f21c0e679b42acf6fc515ce05c6dec2b/execute/window.go#L119
+/// Original: <https://github.com/influxdata/flux/blob/1e9bfd49f21c0e679b42acf6fc515ce05c6dec2b/execute/window.go#L119>
 fn truncate_by_months(t: i64, d: &Duration) -> i64 {
     let ts = timestamp_to_datetime(t);
     let (year, month) = (ts.year(), ts.month());

--- a/query/src/lib.rs
+++ b/query/src/lib.rs
@@ -1,4 +1,4 @@
-#![deny(broken_intra_doc_links, rust_2018_idioms)]
+#![deny(broken_intra_doc_links, rustdoc::bare_urls, rust_2018_idioms)]
 #![warn(
     missing_debug_implementations,
     clippy::explicit_iter_loop,

--- a/query/src/provider/deduplicate/algo.rs
+++ b/query/src/provider/deduplicate/algo.rs
@@ -340,7 +340,7 @@ impl RecordBatchDeduplicator {
 
     /// Create a new record batch from offset --> len
     ///
-    /// https://github.com/apache/arrow-rs/issues/460 for adding this upstream
+    /// <https://github.com/apache/arrow-rs/issues/460> for adding this upstream
     fn slice_record_batch(
         batch: &RecordBatch,
         offset: usize,

--- a/read_buffer/src/lib.rs
+++ b/read_buffer/src/lib.rs
@@ -1,4 +1,4 @@
-#![deny(broken_intra_doc_links, rust_2018_idioms)]
+#![deny(broken_intra_doc_links, rustdoc::bare_urls, rust_2018_idioms)]
 #![warn(clippy::clone_on_ref_ptr, clippy::use_self)]
 #![allow(dead_code, clippy::too_many_arguments)]
 mod chunk;

--- a/server/src/db/load.rs
+++ b/server/src/db/load.rs
@@ -21,7 +21,8 @@ use super::catalog::Catalog;
 ///
 /// If no catalog exists yet, a new one will be created.
 ///
-/// **For now, if the catalog is broken, it will be wiped! (https://github.com/influxdata/influxdb_iox/issues/1522)**
+/// **For now, if the catalog is broken, it will be wiped!**
+/// <https://github.com/influxdata/influxdb_iox/issues/1522>
 pub async fn load_or_create_preserved_catalog(
     db_name: &str,
     object_store: Arc<ObjectStore>,

--- a/server/src/init.rs
+++ b/server/src/init.rs
@@ -144,7 +144,7 @@ pub struct InitStatus {
 
     /// Automatic wipe-on-error recovery
     ///
-    /// See https://github.com/influxdata/influxdb_iox/issues/1522)
+    /// See <https://github.com/influxdata/influxdb_iox/issues/1522>
     pub(crate) wipe_on_error: AtomicBool,
 }
 

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -59,7 +59,7 @@
 //!   └────────────┘  └ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─
 //! ```
 
-#![deny(broken_intra_doc_links, rust_2018_idioms)]
+#![deny(broken_intra_doc_links, rustdoc::bare_urls, rust_2018_idioms)]
 #![warn(
     missing_debug_implementations,
     clippy::explicit_iter_loop,

--- a/src/influxdb_ioxd/rpc/flight.rs
+++ b/src/influxdb_ioxd/rpc/flight.rs
@@ -281,7 +281,7 @@ where
 /// into a smaller buffer while we have to copy stuff around anyway.
 ///
 /// See rationale and discussions about future improvements on
-/// https://github.com/influxdata/influxdb_iox/issues/1133
+/// <https://github.com/influxdata/influxdb_iox/issues/1133>
 fn optimize_record_batch(batch: &RecordBatch, schema: SchemaRef) -> Result<RecordBatch, Error> {
     let max_buf_len = batch
         .columns()

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
 //! Entrypoint of InfluxDB IOx binary
-#![deny(broken_intra_doc_links, rust_2018_idioms)]
+#![deny(broken_intra_doc_links, rustdoc::bare_urls, rust_2018_idioms)]
 #![warn(
     missing_debug_implementations,
     clippy::explicit_iter_loop,

--- a/test_helpers/src/lib.rs
+++ b/test_helpers/src/lib.rs
@@ -1,4 +1,4 @@
-#![deny(broken_intra_doc_links, rust_2018_idioms)]
+#![deny(broken_intra_doc_links, rustdoc::bare_urls, rust_2018_idioms)]
 #![warn(
     missing_copy_implementations,
     missing_debug_implementations,

--- a/tracker/src/lib.rs
+++ b/tracker/src/lib.rs
@@ -1,4 +1,4 @@
-#![deny(broken_intra_doc_links, rust_2018_idioms)]
+#![deny(broken_intra_doc_links, rustdoc::bare_urls, rust_2018_idioms)]
 #![warn(
     missing_debug_implementations,
     clippy::explicit_iter_loop,

--- a/trogging/src/lib.rs
+++ b/trogging/src/lib.rs
@@ -1,6 +1,6 @@
 //! Log and trace initialization and setup
 
-#![deny(broken_intra_doc_links, rust_2018_idioms)]
+#![deny(broken_intra_doc_links, rustdoc::bare_urls, rust_2018_idioms)]
 #![warn(
     missing_copy_implementations,
     missing_debug_implementations,


### PR DESCRIPTION

# Rationale
This was bugging me locally:

```
warning: this URL is not a hyperlink
  --> logfmt/src/lib.rs:20:5
   |
20 | /// https://github.com/mcountryman/logfmt_logger from @mcountryman
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use an automatic link instead: `<https://github.com/mcountryman/logfmt_logger>`
   |
   = note: `#[warn(rustdoc::bare_urls)]` on by default
   = note: bare URLs are not automatically turned into clickable links
```

# Changes:
Fix warnings by making automatic links
