### PR TITLE
feat: Add any lifecycle_action to system.chunks and API

### DIFF
--- a/data_types/src/chunk_metadata.rs
+++ b/data_types/src/chunk_metadata.rs
@@ -63,7 +63,7 @@ impl ChunkStorage {
 }
 
 /// Any lifecycle action currently in progress for this chunk
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 pub enum ChunkLifecycleAction {
     /// Chunk is in the process of being moved to the read buffer
     Moving,
@@ -106,6 +106,9 @@ pub struct ChunkSummary {
 
     /// How is this chunk stored?
     pub storage: ChunkStorage,
+
+    /// Is there any outstanding lifecycle action for this chunk?
+    pub lifecycle_action: Option<ChunkLifecycleAction>,
 
     /// The total estimated size of this chunk, in bytes
     pub estimated_bytes: usize,
@@ -154,6 +157,7 @@ impl ChunkSummary {
         table_name: Arc<str>,
         id: u32,
         storage: ChunkStorage,
+        lifecycle_action: Option<ChunkLifecycleAction>,
         estimated_bytes: usize,
         row_count: usize,
     ) -> Self {
@@ -162,6 +166,7 @@ impl ChunkSummary {
             table_name,
             id,
             storage,
+            lifecycle_action,
             estimated_bytes,
             row_count,
             time_of_first_write: None,

--- a/generated_types/protos/influxdata/iox/management/v1/chunk.proto
+++ b/generated_types/protos/influxdata/iox/management/v1/chunk.proto
@@ -24,6 +24,23 @@ enum ChunkStorage {
   CHUNK_STORAGE_OBJECT_STORE_ONLY = 5;
 }
 
+
+// Is there any lifecycle action currently outstanding for this chunk?
+enum ChunkLifecycleAction {
+  // No lifecycle
+  CHUNK_LIFECYCLE_ACTION_UNSPECIFIED = 0;
+
+  // Chunk is in the process of being moved to the read buffer
+  CHUNK_LIFECYCLE_ACTION_MOVING = 1;
+
+  /// Chunk is in the process of being written to object storage
+  CHUNK_LIFECYCLE_ACTION_PERSISTING = 2;
+
+  /// Chunk is in the process of being compacted
+  CHUNK_LIFECYCLE_ACTION_COMPACTING = 3;
+}
+
+
 // `Chunk` represents part of a partition of data in a database.
 // A chunk can contain one or more tables.
 message Chunk {
@@ -38,6 +55,9 @@ message Chunk {
 
   // Which storage system the chunk is located in
   ChunkStorage storage = 3;
+
+  // Is there any outstanding lifecycle action for this chunk?
+  ChunkLifecycleAction lifecycle_action = 10;
 
   // The total estimated size of this chunk, in bytes
   uint64 estimated_bytes = 4;

--- a/server/src/db.rs
+++ b/server/src/db.rs
@@ -2199,6 +2199,7 @@ mod tests {
                     table_name,
                     id,
                     storage,
+                    lifecycle_action,
                     estimated_bytes,
                     row_count,
                     ..
@@ -2208,6 +2209,7 @@ mod tests {
                     table_name,
                     id,
                     storage,
+                    lifecycle_action,
                     estimated_bytes,
                     row_count,
                 )
@@ -2238,6 +2240,7 @@ mod tests {
             Arc::from("cpu"),
             0,
             ChunkStorage::OpenMutableBuffer,
+            None,
             70,
             1,
         )];
@@ -2341,12 +2344,15 @@ mod tests {
         let chunk_summaries = db.chunk_summaries().expect("expected summary to return");
         let chunk_summaries = normalize_summaries(chunk_summaries);
 
+        let lifecycle_action = None;
+
         let expected = vec![
             ChunkSummary::new_without_timestamps(
                 Arc::from("1970-01-01T00"),
                 Arc::from("cpu"),
                 0,
                 ChunkStorage::ReadBufferAndObjectStore,
+                lifecycle_action,
                 2139, // size of RB and OS chunks
                 1,
             ),
@@ -2355,6 +2361,7 @@ mod tests {
                 Arc::from("cpu"),
                 1,
                 ChunkStorage::OpenMutableBuffer,
+                lifecycle_action,
                 64,
                 1,
             ),
@@ -2363,6 +2370,7 @@ mod tests {
                 Arc::from("cpu"),
                 0,
                 ChunkStorage::ClosedMutableBuffer,
+                lifecycle_action,
                 2190,
                 1,
             ),
@@ -2371,6 +2379,7 @@ mod tests {
                 Arc::from("cpu"),
                 1,
                 ChunkStorage::OpenMutableBuffer,
+                lifecycle_action,
                 87,
                 1,
             ),

--- a/server/src/db/catalog/chunk.rs
+++ b/server/src/db/catalog/chunk.rs
@@ -419,11 +419,17 @@ impl CatalogChunk {
     pub fn summary(&self) -> ChunkSummary {
         let (row_count, storage) = self.storage();
 
+        let lifecycle_action = self
+            .lifecycle_action
+            .as_ref()
+            .map(|tracker| *tracker.metadata());
+
         ChunkSummary {
             partition_key: Arc::clone(&self.addr.partition_key),
             table_name: Arc::clone(&self.addr.table_name),
             id: self.addr.chunk_id,
             storage,
+            lifecycle_action,
             estimated_bytes: self.size(),
             row_count,
             time_of_first_write: self.time_of_first_write,

--- a/tests/end_to_end_cases/management_api.rs
+++ b/tests/end_to_end_cases/management_api.rs
@@ -269,7 +269,9 @@ async fn test_create_get_update_database() {
 
 #[tokio::test]
 async fn test_chunk_get() {
-    use generated_types::influxdata::iox::management::v1::{Chunk, ChunkStorage};
+    use generated_types::influxdata::iox::management::v1::{
+        Chunk, ChunkLifecycleAction, ChunkStorage,
+    };
 
     let fixture = ServerFixture::create_shared().await;
     let mut management_client = fixture.management_client();
@@ -308,12 +310,15 @@ async fn test_chunk_get() {
 
     let chunks = normalize_chunks(chunks);
 
+    let lifecycle_action = ChunkLifecycleAction::Unspecified.into();
+
     let expected: Vec<Chunk> = vec![
         Chunk {
             partition_key: "cpu".into(),
             table_name: "cpu".into(),
             id: 0,
-            storage: ChunkStorage::OpenMutableBuffer as i32,
+            storage: ChunkStorage::OpenMutableBuffer.into(),
+            lifecycle_action,
             estimated_bytes: 100,
             row_count: 2,
             time_of_first_write: None,
@@ -324,7 +329,8 @@ async fn test_chunk_get() {
             partition_key: "disk".into(),
             table_name: "disk".into(),
             id: 0,
-            storage: ChunkStorage::OpenMutableBuffer as i32,
+            storage: ChunkStorage::OpenMutableBuffer.into(),
+            lifecycle_action,
             estimated_bytes: 82,
             row_count: 1,
             time_of_first_write: None,
@@ -492,7 +498,8 @@ async fn test_list_partition_chunks() {
         partition_key: "cpu".into(),
         table_name: "cpu".into(),
         id: 0,
-        storage: ChunkStorage::OpenMutableBuffer as i32,
+        storage: ChunkStorage::OpenMutableBuffer.into(),
+        lifecycle_action: ChunkLifecycleAction::Unspecified.into(),
         estimated_bytes: 100,
         row_count: 2,
         time_of_first_write: None,
@@ -813,6 +820,7 @@ fn normalize_chunks(chunks: Vec<Chunk>) -> Vec<Chunk> {
                 table_name,
                 id,
                 storage,
+                lifecycle_action,
                 estimated_bytes,
                 row_count,
                 ..
@@ -822,6 +830,7 @@ fn normalize_chunks(chunks: Vec<Chunk>) -> Vec<Chunk> {
                 table_name,
                 id,
                 storage,
+                lifecycle_action,
                 estimated_bytes,
                 row_count,
                 time_of_first_write: None,


### PR DESCRIPTION
# Rationale:
Make ongoing chunk lifecycle actions observable by operators

Closes #1912

# Changes
1. Add a new `lifecycle_action` field to `ChunkSummary`
1. Add a new `lifecycle_action` field to the management API GRPC
2. Add a new `lifecycle_action` field to system.chunks table


# Testing: 
There are sufficient unit tests, but I don't really have a great way to "end to end" test this PR because it involves catching a chunk while a background lifecycle action is underway. 

So I manually tested it: 

## Run IOx with a single worker thread
```shell
# run with a single worker thread
cargo run -- run  --num-worker-threads=1 --object-store=file --data-dir=$HOME/.influxdb_iox --server-id=42
```

## Setup `my_db` test database
``shell
./target/debug/influxdb_iox database create my_db
./scripts/edit_db_rules localhost:8082 my_db
```

Setup lifecycle rules to compact aggressively:

```
{
  "rules": {
    "name": "my_db",
    "partitionTemplate": {
      "parts": [
        {
          "time": "%Y-%m-%d %H:00:00"
        }
      ]
    },
    "lifecycleRules": {
      "mutableLingerSeconds": 1,
      "bufferSizeSoft": "52428800",
      "bufferSizeHard": "104857600",
      "dropNonPersisted": false,
      "immutable": false,
      "persist": true,
      "workerBackoffMillis": "1000",
      "catalogTransactionsUntilCheckpoint": "100",
      "lateArriveWindowSeconds": 1,
      "persistRowThreshold": "100000",
      "persistAgeThresholdSeconds": 20
    },
    "workerCleanupAvgSleep": "500s"
  }
}
```

##  "flood" with ingest load in one terminal
```shell
alamb@ip-10-0-0-124:~/Software/idpe/cmd/inch$ go build
./inch -bucket db -org my -host "http://localhost:8080" -c 10 -t 1000000,100000,100000,100000 -p 10
```

## And watch the status in system.chunks:
```shell
./target/debug/influxdb_iox  sql
```

```
my_db>  select * from system.chunks;
+----+---------------------+------------+-----------------+------------------------------+-----------------+-----------+----------------------------+----------------------------+-------------+
| id | partition_key       | table_name | storage         | lifecycle_action             | estimated_bytes | row_count | time_of_first_write        | time_of_last_write         | time_closed |
+----+---------------------+------------+-----------------+------------------------------+-----------------+-----------+----------------------------+----------------------------+-------------+
| 3  | 2021-07-09 17:00:00 | m0         | ObjectStoreOnly |                              | 1432            | 100001    | 2021-07-09 17:14:29.856241 | 2021-07-09 17:14:29.856241 |             |
| 8  | 2021-07-09 17:00:00 | m0         | ReadBuffer      | Persisting to Object Storage | 10144770        | 260000    | 2021-07-09 17:14:45.826507 | 2021-07-09 17:14:45.826507 |             |
| 9  | 2021-07-09 17:00:00 | m0         | ReadBuffer      |                              | 7304277         | 100000    | 2021-07-09 17:14:46.768761 | 2021-07-09 17:14:46.768761 |             |
| 11 | 2021-07-09 17:00:00 | m0         | ReadBuffer      |                              | 4294253         | 110000    | 2021-07-09 17:14:52.473572 | 2021-07-09 17:14:52.473572 |             |
| 13 | 2021-07-09 17:00:00 | m0         | ReadBuffer      |                              | 5464355         | 140000    | 2021-07-09 17:14:59.245069 | 2021-07-09 17:14:59.245069 |             |
| 15 | 2021-07-09 17:00:00 | m0         | ReadBuffer      |                              | 7304277         | 100000    | 2021-07-09 17:15:05.060685 | 2021-07-09 17:15:05.060685 |             |
| 17 | 2021-07-09 17:00:00 | m0         | ReadBuffer      |                              | 7511240         | 100000    | 2021-07-09 17:15:11.145688 | 2021-07-09 17:15:11.145688 |             |
| 19 | 2021-07-09 17:00:00 | m0         | ReadBuffer      |                              | 7304277         | 100000    | 2021-07-09 17:15:17.083295 | 2021-07-09 17:15:17.083295 |             |
| 21 | 2021-07-09 17:00:00 | m0         | ReadBuffer      |                              | 4254275         | 110000    | 2021-07-09 17:15:22.800076 | 2021-07-09 17:15:22.800076 |             |
| 23 | 2021-07-09 17:00:00 | m0         | ReadBuffer      |                              | 4294253         | 110000    | 2021-07-09 17:15:28.897181 | 2021-07-09 17:15:28.897181 |             |
| 25 | 2021-07-09 17:00:00 | m0         | ReadBuffer      |                              | 7284299         | 100000    | 2021-07-09 17:15:34.108513 | 2021-07-09 17:15:34.108513 |             |
+----+---------------------+------------+-----------------+------------------------------+-----------------+-----------+----------------------------+----------------------------+-------------+

Returned 11 rows in 6.150879ms
my_db>  select * from system.chunks;
+----+---------------------+------------+-----------------+------------------------------+-----------------+-----------+----------------------------+----------------------------+-------------+
| id | partition_key       | table_name | storage         | lifecycle_action             | estimated_bytes | row_count | time_of_first_write        | time_of_last_write         | time_closed |
+----+---------------------+------------+-----------------+------------------------------+-----------------+-----------+----------------------------+----------------------------+-------------+
| 3  | 2021-07-09 17:00:00 | m0         | ObjectStoreOnly |                              | 1432            | 100001    | 2021-07-09 17:14:29.856241 | 2021-07-09 17:14:29.856241 |             |
| 8  | 2021-07-09 17:00:00 | m0         | ObjectStoreOnly |                              | 1437            | 260000    | 2021-07-09 17:14:45.826507 | 2021-07-09 17:14:45.826507 |             |
| 9  | 2021-07-09 17:00:00 | m0         | ReadBuffer      | Persisting to Object Storage | 7304277         | 100000    | 2021-07-09 17:14:46.768761 | 2021-07-09 17:14:46.768761 |             |
| 11 | 2021-07-09 17:00:00 | m0         | ReadBuffer      | Persisting to Object Storage | 4294253         | 110000    | 2021-07-09 17:14:52.473572 | 2021-07-09 17:14:52.473572 |             |
| 13 | 2021-07-09 17:00:00 | m0         | ReadBuffer      | Persisting to Object Storage | 5464355         | 140000    | 2021-07-09 17:14:59.245069 | 2021-07-09 17:14:59.245069 |             |
| 15 | 2021-07-09 17:00:00 | m0         | ReadBuffer      | Persisting to Object Storage | 7304277         | 100000    | 2021-07-09 17:15:05.060685 | 2021-07-09 17:15:05.060685 |             |
| 17 | 2021-07-09 17:00:00 | m0         | ReadBuffer      | Persisting to Object Storage | 7511240         | 100000    | 2021-07-09 17:15:11.145688 | 2021-07-09 17:15:11.145688 |             |
| 19 | 2021-07-09 17:00:00 | m0         | ReadBuffer      | Persisting to Object Storage | 7304277         | 100000    | 2021-07-09 17:15:17.083295 | 2021-07-09 17:15:17.083295 |             |
| 21 | 2021-07-09 17:00:00 | m0         | ReadBuffer      | Persisting to Object Storage | 4254275         | 110000    | 2021-07-09 17:15:22.800076 | 2021-07-09 17:15:22.800076 |             |
| 23 | 2021-07-09 17:00:00 | m0         | ReadBuffer      | Persisting to Object Storage | 4294253         | 110000    | 2021-07-09 17:15:28.897181 | 2021-07-09 17:15:28.897181 |             |
| 25 | 2021-07-09 17:00:00 | m0         | ReadBuffer      | Persisting to Object Storage | 7284299         | 100000    | 2021-07-09 17:15:34.108513 | 2021-07-09 17:15:34.108513 |             |
+----+---------------------+------------+-----------------+------------------------------+-----------------+-----------+----------------------------+----------------------------+-------------+

