### PR TITLE
refactor: remove mutable_linger_seconds from lifecycle

### DIFF
--- a/data_types/src/database_rules.rs
+++ b/data_types/src/database_rules.rs
@@ -147,9 +147,10 @@ pub struct LifecycleRules {
     /// After how many transactions should IOx write a new checkpoint?
     pub catalog_transactions_until_checkpoint: NonZeroU64,
 
-    /// Writers will generally have this amount of time to send late arriving writes
-    /// or this could be their clock skew. Once a partition hasn't recieved a write
-    /// for this period of time, it will be compacted and, if set, persisted.
+    /// Once a partition hasn't received a write for this period of time,
+    /// it will be compacted and, if set, persisted. Writers will generally
+    /// have this amount of time to send late arriving writes or this could
+    /// be their clock skew.
     pub late_arrive_window_seconds: NonZeroU32,
 
     /// Maximum number of rows before triggering persistence

--- a/data_types/src/database_rules.rs
+++ b/data_types/src/database_rules.rs
@@ -112,7 +112,6 @@ impl Partitioner for DatabaseRules {
     }
 }
 
-pub const DEFAULT_MUTABLE_LINGER_SECONDS: u32 = 300;
 pub const DEFAULT_WORKER_BACKOFF_MILLIS: u64 = 1_000;
 pub const DEFAULT_CATALOG_TRANSACTIONS_UNTIL_CHECKPOINT: u64 = 100;
 pub const DEFAULT_MUB_ROW_THRESHOLD: usize = 100_000;
@@ -123,13 +122,6 @@ pub const DEFAULT_LATE_ARRIVE_WINDOW_SECONDS: u32 = 5 * 60;
 /// Configures how data automatically flows through the system
 #[derive(Debug, Eq, PartialEq, Clone)]
 pub struct LifecycleRules {
-    /// A chunk of data within a partition that has been cold for writes for
-    /// this many seconds will be frozen and compacted (moved to the read
-    /// buffer) if the chunk is older than mutable_min_lifetime_seconds
-    ///
-    /// Represents the chunk transition open -> moving and closed -> moving
-    pub mutable_linger_seconds: NonZeroU32,
-
     /// Once the total amount of buffered data in memory reaches this size start
     /// dropping data from memory
     pub buffer_size_soft: Option<NonZeroUsize>,
@@ -155,7 +147,9 @@ pub struct LifecycleRules {
     /// After how many transactions should IOx write a new checkpoint?
     pub catalog_transactions_until_checkpoint: NonZeroU64,
 
-    /// The average timestamp skew across concurrent writers
+    /// Writers will generally have this amount of time to send late arriving writes
+    /// or this could be their clock skew. Once a partition hasn't recieved a write
+    /// for this period of time, it will be compacted and, if set, persisted.
     pub late_arrive_window_seconds: NonZeroU32,
 
     /// Maximum number of rows before triggering persistence
@@ -175,7 +169,6 @@ impl LifecycleRules {
 impl Default for LifecycleRules {
     fn default() -> Self {
         Self {
-            mutable_linger_seconds: NonZeroU32::new(DEFAULT_MUTABLE_LINGER_SECONDS).unwrap(),
             buffer_size_soft: None,
             buffer_size_hard: None,
             drop_non_persisted: false,

--- a/generated_types/protos/influxdata/iox/management/v1/database_rules.proto
+++ b/generated_types/protos/influxdata/iox/management/v1/database_rules.proto
@@ -32,13 +32,6 @@ message PartitionTemplate {
 }
 
 message LifecycleRules {
-  // A chunk of data within a partition that has been cold for writes for this
-  // many seconds will be frozen and compacted (moved to the read buffer)
-  // if the chunk is older than mutable_min_lifetime_seconds
-  //
-  // Represents the chunk transition open -> moving and closed -> moving
-  uint32 mutable_linger_seconds = 1;
-
   // Once the total amount of buffered data in memory reaches this size start
   // dropping data from memory
   uint64 buffer_size_soft = 4;
@@ -69,7 +62,9 @@ message LifecycleRules {
   // If 0 / absent, this default to 100.
   uint64 catalog_transactions_until_checkpoint = 11;
 
-  // The average timestamp skew across concurrent writers
+  /// Writers will generally have this amount of time to send late arriving writes
+  /// or this could be their clock skew. Once a partition hasn't recieved a write
+  /// for this period of time, it will be compacted and, if set, persisted.
   uint32 late_arrive_window_seconds = 12;
 
   // Maximum number of rows before triggering persistence

--- a/generated_types/protos/influxdata/iox/management/v1/database_rules.proto
+++ b/generated_types/protos/influxdata/iox/management/v1/database_rules.proto
@@ -64,9 +64,10 @@ message LifecycleRules {
   // If 0 / absent, this default to 100.
   uint64 catalog_transactions_until_checkpoint = 11;
 
-  /// Writers will generally have this amount of time to send late arriving writes
-  /// or this could be their clock skew. Once a partition hasn't recieved a write
-  /// for this period of time, it will be compacted and, if set, persisted.
+  /// Once a partition hasn't received a write for this period of time,
+  /// it will be compacted and, if set, persisted. Writers will generally
+  /// have this amount of time to send late arriving writes or this could
+  /// be their clock skew.
   uint32 late_arrive_window_seconds = 12;
 
   // Maximum number of rows before triggering persistence

--- a/generated_types/protos/influxdata/iox/management/v1/database_rules.proto
+++ b/generated_types/protos/influxdata/iox/management/v1/database_rules.proto
@@ -32,6 +32,8 @@ message PartitionTemplate {
 }
 
 message LifecycleRules {
+  uint32 mutable_linger_seconds = 1 [deprecated = true];
+
   // Once the total amount of buffered data in memory reaches this size start
   // dropping data from memory
   uint64 buffer_size_soft = 4;

--- a/generated_types/src/database_rules/lifecycle.rs
+++ b/generated_types/src/database_rules/lifecycle.rs
@@ -12,7 +12,9 @@ use crate::influxdata::iox::management::v1 as management;
 
 impl From<LifecycleRules> for management::LifecycleRules {
     fn from(config: LifecycleRules) -> Self {
+        #[allow(deprecated)]
         Self {
+            mutable_linger_seconds: 0, // deprecated, not in use.
             buffer_size_soft: config
                 .buffer_size_soft
                 .map(|x| x.get() as u64)
@@ -71,7 +73,10 @@ mod tests {
 
     #[test]
     fn lifecycle_rules() {
+        #[allow(deprecated)]
         let protobuf = management::LifecycleRules {
+            // deprecated, not in use.
+            mutable_linger_seconds: 0,
             buffer_size_soft: 353,
             buffer_size_hard: 232,
             drop_non_persisted: true,

--- a/src/commands/database.rs
+++ b/src/commands/database.rs
@@ -74,15 +74,6 @@ pub struct Config {
 struct Create {
     /// The name of the database
     name: String,
-
-    /// A chunk of data within a partition that has been cold for writes for
-    /// this many seconds will be frozen and compacted (moved to the read
-    /// buffer) if the chunk is older than mutable_min_lifetime_seconds
-    ///
-    /// Represents the chunk transition open -> moving and closed -> moving
-    #[structopt(long, default_value = "300")] // 5 minutes
-    mutable_linger_seconds: u32,
-
     /// Once the total amount of buffered data in memory reaches this size start
     /// dropping data from memory based on the drop_order
     #[structopt(long, default_value = "52428800")] // 52428800 = 50*1024*1024
@@ -110,7 +101,9 @@ struct Create {
     #[structopt(long, default_value = "100", parse(try_from_str))]
     catalog_transactions_until_checkpoint: NonZeroU64,
 
-    /// The average timestamp skew across concurrent writers
+    /// Writers will generally have this amount of time to send late arriving writes
+    /// or this could be their clock skew. Once a partition hasn't recieved a write
+    /// for this period of time, it will be compacted and, if set, persisted.
     #[structopt(long, default_value = "300")]
     late_arrive_window_seconds: u32,
 
@@ -180,7 +173,6 @@ pub async fn command(url: String, config: Config) -> Result<()> {
             let rules = DatabaseRules {
                 name: command.name,
                 lifecycle_rules: Some(LifecycleRules {
-                    mutable_linger_seconds: command.mutable_linger_seconds,
                     buffer_size_soft: command.buffer_size_soft as _,
                     buffer_size_hard: command.buffer_size_hard as _,
                     drop_non_persisted: command.drop_non_persisted,

--- a/src/commands/database.rs
+++ b/src/commands/database.rs
@@ -170,9 +170,11 @@ pub async fn command(url: String, config: Config) -> Result<()> {
     match config.command {
         Command::Create(command) => {
             let mut client = management::Client::new(connection);
+            #[allow(deprecated)]
             let rules = DatabaseRules {
                 name: command.name,
                 lifecycle_rules: Some(LifecycleRules {
+                    mutable_linger_seconds: 0,  // deprecated, not in use
                     buffer_size_soft: command.buffer_size_soft as _,
                     buffer_size_hard: command.buffer_size_hard as _,
                     drop_non_persisted: command.drop_non_persisted,

--- a/src/commands/database.rs
+++ b/src/commands/database.rs
@@ -101,9 +101,10 @@ struct Create {
     #[structopt(long, default_value = "100", parse(try_from_str))]
     catalog_transactions_until_checkpoint: NonZeroU64,
 
-    /// Writers will generally have this amount of time to send late arriving writes
-    /// or this could be their clock skew. Once a partition hasn't recieved a write
-    /// for this period of time, it will be compacted and, if set, persisted.
+    /// Once a partition hasn't received a write for this period of time,
+    /// it will be compacted and, if set, persisted. Writers will generally
+    /// have this amount of time to send late arriving writes or this could
+    /// be their clock skew.
     #[structopt(long, default_value = "300")]
     late_arrive_window_seconds: u32,
 

--- a/tests/end_to_end_cases/management_api.rs
+++ b/tests/end_to_end_cases/management_api.rs
@@ -14,7 +14,6 @@ use super::scenario::{
     create_readable_database, create_two_partition_database, create_unreadable_database, rand_name,
 };
 use crate::common::server_fixture::ServerFixture;
-use data_types::database_rules::DEFAULT_MUTABLE_LINGER_SECONDS;
 use std::time::Instant;
 use tonic::Code;
 
@@ -244,11 +243,6 @@ async fn test_create_get_update_database() {
         ignore_errors: true,
         ..Default::default()
     }));
-    rules.lifecycle_rules = Some(LifecycleRules {
-        mutable_linger_seconds: DEFAULT_MUTABLE_LINGER_SECONDS,
-        ..rules.lifecycle_rules.unwrap()
-    });
-
     let updated_rules = client
         .update_database(rules.clone())
         .await
@@ -731,7 +725,7 @@ async fn test_chunk_lifecycle() {
         .create_database(DatabaseRules {
             name: db_name.clone(),
             lifecycle_rules: Some(LifecycleRules {
-                mutable_linger_seconds: 1,
+                late_arrive_window_seconds: 1,
                 ..Default::default()
             }),
             ..Default::default()

--- a/tests/end_to_end_cases/scenario.rs
+++ b/tests/end_to_end_cases/scenario.rs
@@ -347,7 +347,6 @@ pub async fn create_quickly_persisting_database(
             }],
         }),
         lifecycle_rules: Some(LifecycleRules {
-            mutable_linger_seconds: 1,
             buffer_size_soft: 512 * 1024,       // 512K
             buffer_size_hard: 10 * 1024 * 1024, // 10MB
             persist: true,


### PR DESCRIPTION
The interplay between mutable_linger_seconds, late_arrive_window and persist_age_threshold_seconds can be tricky to reason about. I realized that the lifecycle rules can be simplified by removing mutable_linger_seconds and instead using late_arrive_window_seconds for the same purpose. Semantically, they basically mean the same thing. We want to give data around this amount of time to arrive before the system persists it, which gives it more of an opportunity to persist non-overlapping data.

When a partition goes cold for writes, after we've waiting past this window, we should compact and persist that partition. This removes one unnecessary knob from the lifecycle configuration and also removes the potential for conflicting configuration options.