### PR TITLE
refactor: Go from 3 mock chunks to 1

### DIFF
--- a/data_types/src/partition_metadata.rs
+++ b/data_types/src/partition_metadata.rs
@@ -45,11 +45,7 @@ pub struct PartitionChunkSummary {
 impl FromIterator<Self> for TableSummary {
     fn from_iter<T: IntoIterator<Item = Self>>(iter: T) -> Self {
         let mut iter = iter.into_iter();
-        let first = iter.next().expect("must contain at least one element");
-        let mut s = Self {
-            name: first.name,
-            columns: first.columns,
-        };
+        let mut s = iter.next().expect("must contain at least one element");
 
         for other in iter {
             s.update_from(&other)

--- a/data_types/src/partition_metadata.rs
+++ b/data_types/src/partition_metadata.rs
@@ -1,12 +1,13 @@
 //! This module contains structs that describe the metadata for a partition
 //! including schema, summary statistics, and file locations in storage.
 
-use std::{borrow::Cow, mem};
-
 use serde::{Deserialize, Serialize};
-use std::borrow::Borrow;
-use std::iter::FromIterator;
-use std::num::NonZeroU64;
+use std::{
+    borrow::{Borrow, Cow},
+    iter::FromIterator,
+    mem,
+    num::NonZeroU64,
+};
 
 /// Describes the aggregated (across all chunks) summary
 /// statistics for each column in a partition

--- a/query/src/frontend/reorg.rs
+++ b/query/src/frontend/reorg.rs
@@ -271,8 +271,8 @@ mod test {
         // Chunk 1 with 5 rows of data on 2 tags
         let chunk1 = Arc::new(
             TestChunk::new("t")
-                .with_time_column_with_stats(5, 7000)
-                .with_tag_column_with_stats("tag1", "AL", "MT")
+                .with_time_column_with_stats(Some(5), Some(7000))
+                .with_tag_column_with_stats("tag1", Some("AL"), Some("MT"))
                 .with_int_field_column("field_int")
                 .with_five_rows_of_data(),
         );
@@ -280,8 +280,8 @@ mod test {
         // Chunk 2 has an extra field, and only 4 fields
         let chunk2 = Arc::new(
             TestChunk::new("t")
-                .with_time_column_with_stats(5, 7000)
-                .with_tag_column_with_stats("tag1", "AL", "MT")
+                .with_time_column_with_stats(Some(5), Some(7000))
+                .with_tag_column_with_stats("tag1", Some("AL"), Some("MT"))
                 .with_int_field_column("field_int")
                 .with_int_field_column("field_int2")
                 .with_four_rows_of_data(),

--- a/query/src/frontend/reorg.rs
+++ b/query/src/frontend/reorg.rs
@@ -270,21 +270,21 @@ mod test {
     async fn get_test_chunks() -> (Arc<Schema>, Vec<Arc<TestChunk>>) {
         // Chunk 1 with 5 rows of data on 2 tags
         let chunk1 = Arc::new(
-            TestChunk::new(1)
-                .with_time_column_with_stats("t", 5, 7000)
-                .with_tag_column_with_stats("t", "tag1", "AL", "MT")
-                .with_int_field_column("t", "field_int")
-                .with_five_rows_of_data("t"),
+            TestChunk::new("t")
+                .with_time_column_with_stats(5, 7000)
+                .with_tag_column_with_stats("tag1", "AL", "MT")
+                .with_int_field_column("field_int")
+                .with_five_rows_of_data(),
         );
 
         // Chunk 2 has an extra field, and only 4 fields
         let chunk2 = Arc::new(
-            TestChunk::new(1)
-                .with_time_column_with_stats("t", 5, 7000)
-                .with_tag_column_with_stats("t", "tag1", "AL", "MT")
-                .with_int_field_column("t", "field_int")
-                .with_int_field_column("t", "field_int2")
-                .with_four_rows_of_data("t"),
+            TestChunk::new("t")
+                .with_time_column_with_stats(5, 7000)
+                .with_tag_column_with_stats("tag1", "AL", "MT")
+                .with_int_field_column("field_int")
+                .with_int_field_column("field_int2")
+                .with_four_rows_of_data(),
         );
 
         let expected = vec![

--- a/query/src/frontend/reorg.rs
+++ b/query/src/frontend/reorg.rs
@@ -273,7 +273,7 @@ mod test {
             TestChunk::new("t")
                 .with_time_column_with_stats(Some(5), Some(7000))
                 .with_tag_column_with_stats("tag1", Some("AL"), Some("MT"))
-                .with_int_field_column("field_int")
+                .with_i64_field_column("field_int")
                 .with_five_rows_of_data(),
         );
 
@@ -282,8 +282,8 @@ mod test {
             TestChunk::new("t")
                 .with_time_column_with_stats(Some(5), Some(7000))
                 .with_tag_column_with_stats("tag1", Some("AL"), Some("MT"))
-                .with_int_field_column("field_int")
-                .with_int_field_column("field_int2")
+                .with_i64_field_column("field_int")
+                .with_i64_field_column("field_int2")
                 .with_four_rows_of_data(),
         );
 

--- a/query/src/provider.rs
+++ b/query/src/provider.rs
@@ -765,31 +765,31 @@ mod test {
         // in the duplicate module
 
         // c1: no overlaps
-        let c1 = Arc::new(
-            TestChunk::new("t")
-                .with_id(1)
-                .with_tag_column_with_stats("tag1", "a", "b"),
-        );
+        let c1 = Arc::new(TestChunk::new("t").with_id(1).with_tag_column_with_stats(
+            "tag1",
+            Some("a"),
+            Some("b"),
+        ));
 
         // c2: over lap with c3
-        let c2 = Arc::new(
-            TestChunk::new("t")
-                .with_id(2)
-                .with_tag_column_with_stats("tag1", "c", "d"),
-        );
+        let c2 = Arc::new(TestChunk::new("t").with_id(2).with_tag_column_with_stats(
+            "tag1",
+            Some("c"),
+            Some("d"),
+        ));
 
         // c3: overlap with c2
-        let c3 = Arc::new(
-            TestChunk::new("t")
-                .with_id(3)
-                .with_tag_column_with_stats("tag1", "c", "d"),
-        );
+        let c3 = Arc::new(TestChunk::new("t").with_id(3).with_tag_column_with_stats(
+            "tag1",
+            Some("c"),
+            Some("d"),
+        ));
 
         // c4: self overlap
         let c4 = Arc::new(
             TestChunk::new("t")
                 .with_id(4)
-                .with_tag_column_with_stats("tag1", "e", "f")
+                .with_tag_column_with_stats("tag1", Some("e"), Some("f"))
                 .with_may_contain_pk_duplicates(true),
         );
 
@@ -1295,8 +1295,8 @@ mod test {
         // Test no duplicate at all
         let chunk = Arc::new(
             TestChunk::new("t")
-                .with_time_column_with_stats(5, 7000)
-                .with_tag_column_with_stats("tag1", "AL", "MT")
+                .with_time_column_with_stats(Some(5), Some(7000))
+                .with_tag_column_with_stats("tag1", Some("AL"), Some("MT"))
                 .with_int_field_column("field_int")
                 .with_five_rows_of_data(),
         );
@@ -1343,8 +1343,8 @@ mod test {
         // Test one chunk with duplicate within
         let chunk = Arc::new(
             TestChunk::new("t")
-                .with_time_column_with_stats(5, 7000)
-                .with_tag_column_with_stats("tag1", "AL", "MT")
+                .with_time_column_with_stats(Some(5), Some(7000))
+                .with_tag_column_with_stats("tag1", Some("AL"), Some("MT"))
                 .with_int_field_column("field_int")
                 .with_may_contain_pk_duplicates(true)
                 .with_ten_rows_of_data_some_duplicates(),
@@ -1399,8 +1399,8 @@ mod test {
         // Test one chunk with duplicate within
         let chunk = Arc::new(
             TestChunk::new("t")
-                .with_time_column_with_stats(5, 7000)
-                .with_tag_column_with_stats("tag1", "AL", "MT")
+                .with_time_column_with_stats(Some(5), Some(7000))
+                .with_tag_column_with_stats("tag1", Some("AL"), Some("MT"))
                 .with_int_field_column("field_int")
                 .with_may_contain_pk_duplicates(true)
                 .with_ten_rows_of_data_some_duplicates(),
@@ -1464,16 +1464,16 @@ mod test {
         // test overlapped chunks
         let chunk1 = Arc::new(
             TestChunk::new("t")
-                .with_time_column_with_stats(5, 7000)
-                .with_tag_column_with_stats("tag1", "AL", "MT")
+                .with_time_column_with_stats(Some(5), Some(7000))
+                .with_tag_column_with_stats("tag1", Some("AL"), Some("MT"))
                 .with_int_field_column("field_int")
                 .with_ten_rows_of_data_some_duplicates(),
         );
 
         let chunk2 = Arc::new(
             TestChunk::new("t")
-                .with_time_column_with_stats(5, 7000)
-                .with_tag_column_with_stats("tag1", "AL", "MT")
+                .with_time_column_with_stats(Some(5), Some(7000))
+                .with_tag_column_with_stats("tag1", Some("AL"), Some("MT"))
                 .with_int_field_column("field_int")
                 .with_five_rows_of_data(),
         );
@@ -1534,8 +1534,8 @@ mod test {
         let chunk1 = Arc::new(
             TestChunk::new("t")
                 .with_id(1)
-                .with_time_column_with_stats(5, 7000)
-                .with_tag_column_with_stats("tag1", "AL", "MT")
+                .with_time_column_with_stats(Some(5), Some(7000))
+                .with_tag_column_with_stats("tag1", Some("AL"), Some("MT"))
                 .with_int_field_column("field_int")
                 .with_ten_rows_of_data_some_duplicates(),
         );
@@ -1544,8 +1544,8 @@ mod test {
         let chunk2 = Arc::new(
             TestChunk::new("t")
                 .with_id(2)
-                .with_time_column_with_stats(5, 7000)
-                .with_tag_column_with_stats("tag1", "AL", "MT")
+                .with_time_column_with_stats(Some(5), Some(7000))
+                .with_tag_column_with_stats("tag1", Some("AL"), Some("MT"))
                 .with_int_field_column("field_int")
                 .with_five_rows_of_data(),
         );
@@ -1554,8 +1554,8 @@ mod test {
         let chunk3 = Arc::new(
             TestChunk::new("t")
                 .with_id(3)
-                .with_time_column_with_stats(8000, 20000)
-                .with_tag_column_with_stats("tag1", "UT", "WA")
+                .with_time_column_with_stats(Some(8000), Some(20000))
+                .with_tag_column_with_stats("tag1", Some("UT"), Some("WA"))
                 .with_int_field_column("field_int")
                 .with_three_rows_of_data(),
         );
@@ -1564,8 +1564,8 @@ mod test {
         let chunk4 = Arc::new(
             TestChunk::new("t")
                 .with_id(4)
-                .with_time_column_with_stats(28000, 220000)
-                .with_tag_column_with_stats("tag1", "UT", "WA")
+                .with_time_column_with_stats(Some(28000), Some(220000))
+                .with_tag_column_with_stats("tag1", Some("UT"), Some("WA"))
                 .with_int_field_column("field_int")
                 .with_may_contain_pk_duplicates(true)
                 .with_four_rows_of_data(),

--- a/query/src/provider.rs
+++ b/query/src/provider.rs
@@ -765,18 +765,31 @@ mod test {
         // in the duplicate module
 
         // c1: no overlaps
-        let c1 = Arc::new(TestChunk::new(1).with_tag_column_with_stats("t", "tag1", "a", "b"));
+        let c1 = Arc::new(
+            TestChunk::new("t")
+                .with_id(1)
+                .with_tag_column_with_stats("tag1", "a", "b"),
+        );
 
         // c2: over lap with c3
-        let c2 = Arc::new(TestChunk::new(2).with_tag_column_with_stats("t", "tag1", "c", "d"));
+        let c2 = Arc::new(
+            TestChunk::new("t")
+                .with_id(2)
+                .with_tag_column_with_stats("tag1", "c", "d"),
+        );
 
         // c3: overlap with c2
-        let c3 = Arc::new(TestChunk::new(3).with_tag_column_with_stats("t", "tag1", "c", "d"));
+        let c3 = Arc::new(
+            TestChunk::new("t")
+                .with_id(3)
+                .with_tag_column_with_stats("tag1", "c", "d"),
+        );
 
         // c4: self overlap
         let c4 = Arc::new(
-            TestChunk::new(4)
-                .with_tag_column_with_stats("t", "tag1", "e", "f")
+            TestChunk::new("t")
+                .with_id(4)
+                .with_tag_column_with_stats("tag1", "e", "f")
                 .with_may_contain_pk_duplicates(true),
         );
 
@@ -797,11 +810,11 @@ mod test {
     async fn sort_planning_one_tag_with_time() {
         // Chunk 1 with 5 rows of data
         let chunk = Arc::new(
-            TestChunk::new(1)
-                .with_time_column("t")
-                .with_tag_column("t", "tag1")
-                .with_int_field_column("t", "field_int")
-                .with_five_rows_of_data("t"),
+            TestChunk::new("t")
+                .with_time_column()
+                .with_tag_column("tag1")
+                .with_int_field_column("field_int")
+                .with_five_rows_of_data(),
         );
 
         // Datafusion schema of the chunk
@@ -851,12 +864,12 @@ mod test {
     async fn sort_planning_two_tags_with_time() {
         // Chunk 1 with 5 rows of data
         let chunk = Arc::new(
-            TestChunk::new(1)
-                .with_time_column("t")
-                .with_tag_column("t", "tag1")
-                .with_tag_column("t", "tag2")
-                .with_int_field_column("t", "field_int")
-                .with_five_rows_of_data("t"),
+            TestChunk::new("t")
+                .with_time_column()
+                .with_tag_column("tag1")
+                .with_tag_column("tag2")
+                .with_int_field_column("field_int")
+                .with_five_rows_of_data(),
         );
 
         // Datafusion schema of the chunk
@@ -906,12 +919,12 @@ mod test {
     async fn sort_read_filter_plan_for_two_tags_with_time() {
         // Chunk 1 with 5 rows of data
         let chunk = Arc::new(
-            TestChunk::new(1)
-                .with_time_column("t")
-                .with_tag_column("t", "tag1")
-                .with_tag_column("t", "tag2")
-                .with_int_field_column("t", "field_int")
-                .with_five_rows_of_data("t"),
+            TestChunk::new("t")
+                .with_time_column()
+                .with_tag_column("tag1")
+                .with_tag_column("tag2")
+                .with_int_field_column("field_int")
+                .with_five_rows_of_data(),
         );
 
         // Datafusion schema of the chunk
@@ -943,22 +956,24 @@ mod test {
     async fn deduplicate_plan_for_overlapped_chunks() {
         // Chunk 1 with 5 rows of data on 2 tags
         let chunk1 = Arc::new(
-            TestChunk::new(1)
-                .with_time_column("t")
-                .with_tag_column("t", "tag1")
-                .with_tag_column("t", "tag2")
-                .with_int_field_column("t", "field_int")
-                .with_five_rows_of_data("t"),
+            TestChunk::new("t")
+                .with_id(1)
+                .with_time_column()
+                .with_tag_column("tag1")
+                .with_tag_column("tag2")
+                .with_int_field_column("field_int")
+                .with_five_rows_of_data(),
         );
 
         // Chunk 2 exactly the same with Chunk 1
         let chunk2 = Arc::new(
-            TestChunk::new(2)
-                .with_time_column("t")
-                .with_tag_column("t", "tag1")
-                .with_tag_column("t", "tag2")
-                .with_int_field_column("t", "field_int")
-                .with_five_rows_of_data("t"),
+            TestChunk::new("t")
+                .with_id(2)
+                .with_time_column()
+                .with_tag_column("tag1")
+                .with_tag_column("tag2")
+                .with_int_field_column("field_int")
+                .with_five_rows_of_data(),
         );
         // Datafusion schema of the chunk
         // the same for 2 chunks
@@ -1011,22 +1026,24 @@ mod test {
         // Same two chunks but only select the field and timestamp, not the tag values
         // Chunk 1 with 5 rows of data on 2 tags
         let chunk1 = Arc::new(
-            TestChunk::new(1)
-                .with_time_column("t")
-                .with_tag_column("t", "tag1")
-                .with_tag_column("t", "tag2")
-                .with_int_field_column("t", "field_int")
-                .with_five_rows_of_data("t"),
+            TestChunk::new("t")
+                .with_id(1)
+                .with_time_column()
+                .with_tag_column("tag1")
+                .with_tag_column("tag2")
+                .with_int_field_column("field_int")
+                .with_five_rows_of_data(),
         );
 
         // Chunk 2 exactly the same with Chunk 1
         let chunk2 = Arc::new(
-            TestChunk::new(2)
-                .with_time_column("t")
-                .with_tag_column("t", "tag1")
-                .with_tag_column("t", "tag2")
-                .with_int_field_column("t", "field_int")
-                .with_five_rows_of_data("t"),
+            TestChunk::new("t")
+                .with_id(2)
+                .with_time_column()
+                .with_tag_column("tag1")
+                .with_tag_column("tag2")
+                .with_int_field_column("field_int")
+                .with_five_rows_of_data(),
         );
         let chunks = vec![chunk1, chunk2];
 
@@ -1083,30 +1100,33 @@ mod test {
         // Chunks with different fields / tags, and select a subset
         // Chunk 1 with 5 rows of data on 2 tags
         let chunk1 = Arc::new(
-            TestChunk::new(1)
-                .with_time_column("t")
-                .with_tag_column("t", "tag1")
-                .with_tag_column("t", "tag2")
-                .with_int_field_column("t", "field_int")
-                .with_five_rows_of_data("t"),
+            TestChunk::new("t")
+                .with_id(1)
+                .with_time_column()
+                .with_tag_column("tag1")
+                .with_tag_column("tag2")
+                .with_int_field_column("field_int")
+                .with_five_rows_of_data(),
         );
 
         // Chunk 2 same tags, but different fields
         let chunk2 = Arc::new(
-            TestChunk::new(2)
-                .with_time_column("t")
-                .with_tag_column("t", "tag1")
-                .with_int_field_column("t", "other_field_int")
-                .with_five_rows_of_data("t"),
+            TestChunk::new("t")
+                .with_id(2)
+                .with_time_column()
+                .with_tag_column("tag1")
+                .with_int_field_column("other_field_int")
+                .with_five_rows_of_data(),
         );
 
         // Chunk 3 exactly the same with Chunk 2
         let chunk3 = Arc::new(
-            TestChunk::new(3)
-                .with_time_column("t")
-                .with_tag_column("t", "tag1")
-                .with_int_field_column("t", "other_field_int")
-                .with_five_rows_of_data("t"),
+            TestChunk::new("t")
+                .with_id(3)
+                .with_time_column()
+                .with_tag_column("tag1")
+                .with_int_field_column("other_field_int")
+                .with_five_rows_of_data(),
         );
 
         let chunks = vec![chunk1, chunk2, chunk3];
@@ -1172,32 +1192,35 @@ mod test {
     async fn deduplicate_plan_for_overlapped_chunks_with_different_schemas() {
         // Chunk 1 with 5 rows of data on 2 tags
         let chunk1 = Arc::new(
-            TestChunk::new(1)
-                .with_time_column("t")
-                .with_tag_column("t", "tag1")
-                .with_tag_column("t", "tag2")
-                .with_int_field_column("t", "field_int")
-                .with_five_rows_of_data("t"),
+            TestChunk::new("t")
+                .with_id(1)
+                .with_time_column()
+                .with_tag_column("tag1")
+                .with_tag_column("tag2")
+                .with_int_field_column("field_int")
+                .with_five_rows_of_data(),
         );
 
         // Chunk 2 has two different tags
         let chunk2 = Arc::new(
-            TestChunk::new(2)
-                .with_time_column("t")
-                .with_tag_column("t", "tag3")
-                .with_tag_column("t", "tag1")
-                .with_int_field_column("t", "field_int")
-                .with_five_rows_of_data("t"),
+            TestChunk::new("t")
+                .with_id(2)
+                .with_time_column()
+                .with_tag_column("tag3")
+                .with_tag_column("tag1")
+                .with_int_field_column("field_int")
+                .with_five_rows_of_data(),
         );
 
         // Chunk 3 has just tag3
         let chunk3 = Arc::new(
-            TestChunk::new(3)
-                .with_time_column("t")
-                .with_tag_column("t", "tag3")
-                .with_int_field_column("t", "field_int")
-                .with_int_field_column("t", "field_int2")
-                .with_five_rows_of_data("t"),
+            TestChunk::new("t")
+                .with_id(3)
+                .with_time_column()
+                .with_tag_column("tag3")
+                .with_int_field_column("field_int")
+                .with_int_field_column("field_int2")
+                .with_five_rows_of_data(),
         );
 
         // Requested output schema == the schema for all three
@@ -1271,11 +1294,11 @@ mod test {
     async fn scan_plan_with_one_chunk_no_duplicates() {
         // Test no duplicate at all
         let chunk = Arc::new(
-            TestChunk::new(1)
-                .with_time_column_with_stats("t", 5, 7000)
-                .with_tag_column_with_stats("t", "tag1", "AL", "MT")
-                .with_int_field_column("t", "field_int")
-                .with_five_rows_of_data("t"),
+            TestChunk::new("t")
+                .with_time_column_with_stats(5, 7000)
+                .with_tag_column_with_stats("tag1", "AL", "MT")
+                .with_int_field_column("field_int")
+                .with_five_rows_of_data(),
         );
 
         // Datafusion schema of the chunk
@@ -1319,12 +1342,12 @@ mod test {
     async fn scan_plan_with_one_chunk_with_duplicates() {
         // Test one chunk with duplicate within
         let chunk = Arc::new(
-            TestChunk::new(1)
-                .with_time_column_with_stats("t", 5, 7000)
-                .with_tag_column_with_stats("t", "tag1", "AL", "MT")
-                .with_int_field_column("t", "field_int")
+            TestChunk::new("t")
+                .with_time_column_with_stats(5, 7000)
+                .with_tag_column_with_stats("tag1", "AL", "MT")
+                .with_int_field_column("field_int")
                 .with_may_contain_pk_duplicates(true)
-                .with_ten_rows_of_data_some_duplicates("t"),
+                .with_ten_rows_of_data_some_duplicates(),
         );
 
         // Datafusion schema of the chunk
@@ -1375,12 +1398,12 @@ mod test {
     async fn scan_plan_with_one_chunk_with_duplicates_subset() {
         // Test one chunk with duplicate within
         let chunk = Arc::new(
-            TestChunk::new(1)
-                .with_time_column_with_stats("t", 5, 7000)
-                .with_tag_column_with_stats("t", "tag1", "AL", "MT")
-                .with_int_field_column("t", "field_int")
+            TestChunk::new("t")
+                .with_time_column_with_stats(5, 7000)
+                .with_tag_column_with_stats("tag1", "AL", "MT")
+                .with_int_field_column("field_int")
                 .with_may_contain_pk_duplicates(true)
-                .with_ten_rows_of_data_some_duplicates("t"),
+                .with_ten_rows_of_data_some_duplicates(),
         );
 
         let chunks = vec![chunk];
@@ -1440,19 +1463,19 @@ mod test {
     async fn scan_plan_with_two_overlapped_chunks_with_duplicates() {
         // test overlapped chunks
         let chunk1 = Arc::new(
-            TestChunk::new(1)
-                .with_time_column_with_stats("t", 5, 7000)
-                .with_tag_column_with_stats("t", "tag1", "AL", "MT")
-                .with_int_field_column("t", "field_int")
-                .with_ten_rows_of_data_some_duplicates("t"),
+            TestChunk::new("t")
+                .with_time_column_with_stats(5, 7000)
+                .with_tag_column_with_stats("tag1", "AL", "MT")
+                .with_int_field_column("field_int")
+                .with_ten_rows_of_data_some_duplicates(),
         );
 
         let chunk2 = Arc::new(
-            TestChunk::new(1)
-                .with_time_column_with_stats("t", 5, 7000)
-                .with_tag_column_with_stats("t", "tag1", "AL", "MT")
-                .with_int_field_column("t", "field_int")
-                .with_five_rows_of_data("t"),
+            TestChunk::new("t")
+                .with_time_column_with_stats(5, 7000)
+                .with_tag_column_with_stats("tag1", "AL", "MT")
+                .with_int_field_column("field_int")
+                .with_five_rows_of_data(),
         );
 
         // Datafusion schema of the chunk
@@ -1509,39 +1532,43 @@ mod test {
     async fn scan_plan_with_four_chunks() {
         // This test covers all kind of chunks: overlap, non-overlap without duplicates within, non-overlap with duplicates within
         let chunk1 = Arc::new(
-            TestChunk::new(1)
-                .with_time_column_with_stats("t", 5, 7000)
-                .with_tag_column_with_stats("t", "tag1", "AL", "MT")
-                .with_int_field_column("t", "field_int")
-                .with_ten_rows_of_data_some_duplicates("t"),
+            TestChunk::new("t")
+                .with_id(1)
+                .with_time_column_with_stats(5, 7000)
+                .with_tag_column_with_stats("tag1", "AL", "MT")
+                .with_int_field_column("field_int")
+                .with_ten_rows_of_data_some_duplicates(),
         );
 
         // chunk2 overlaps with chunk 1
         let chunk2 = Arc::new(
-            TestChunk::new(1)
-                .with_time_column_with_stats("t", 5, 7000)
-                .with_tag_column_with_stats("t", "tag1", "AL", "MT")
-                .with_int_field_column("t", "field_int")
-                .with_five_rows_of_data("t"),
+            TestChunk::new("t")
+                .with_id(2)
+                .with_time_column_with_stats(5, 7000)
+                .with_tag_column_with_stats("tag1", "AL", "MT")
+                .with_int_field_column("field_int")
+                .with_five_rows_of_data(),
         );
 
         // chunk3 no overlap, no duplicates within
         let chunk3 = Arc::new(
-            TestChunk::new(1)
-                .with_time_column_with_stats("t", 8000, 20000)
-                .with_tag_column_with_stats("t", "tag1", "UT", "WA")
-                .with_int_field_column("t", "field_int")
-                .with_three_rows_of_data("t"),
+            TestChunk::new("t")
+                .with_id(3)
+                .with_time_column_with_stats(8000, 20000)
+                .with_tag_column_with_stats("tag1", "UT", "WA")
+                .with_int_field_column("field_int")
+                .with_three_rows_of_data(),
         );
 
         // chunk3 no overlap, duplicates within
         let chunk4 = Arc::new(
-            TestChunk::new(1)
-                .with_time_column_with_stats("t", 28000, 220000)
-                .with_tag_column_with_stats("t", "tag1", "UT", "WA")
-                .with_int_field_column("t", "field_int")
+            TestChunk::new("t")
+                .with_id(4)
+                .with_time_column_with_stats(28000, 220000)
+                .with_tag_column_with_stats("tag1", "UT", "WA")
+                .with_int_field_column("field_int")
                 .with_may_contain_pk_duplicates(true)
-                .with_four_rows_of_data("t"),
+                .with_four_rows_of_data(),
         );
 
         // Datafusion schema of the chunk

--- a/query/src/provider.rs
+++ b/query/src/provider.rs
@@ -813,7 +813,7 @@ mod test {
             TestChunk::new("t")
                 .with_time_column()
                 .with_tag_column("tag1")
-                .with_int_field_column("field_int")
+                .with_i64_field_column("field_int")
                 .with_five_rows_of_data(),
         );
 
@@ -868,7 +868,7 @@ mod test {
                 .with_time_column()
                 .with_tag_column("tag1")
                 .with_tag_column("tag2")
-                .with_int_field_column("field_int")
+                .with_i64_field_column("field_int")
                 .with_five_rows_of_data(),
         );
 
@@ -923,7 +923,7 @@ mod test {
                 .with_time_column()
                 .with_tag_column("tag1")
                 .with_tag_column("tag2")
-                .with_int_field_column("field_int")
+                .with_i64_field_column("field_int")
                 .with_five_rows_of_data(),
         );
 
@@ -961,7 +961,7 @@ mod test {
                 .with_time_column()
                 .with_tag_column("tag1")
                 .with_tag_column("tag2")
-                .with_int_field_column("field_int")
+                .with_i64_field_column("field_int")
                 .with_five_rows_of_data(),
         );
 
@@ -972,7 +972,7 @@ mod test {
                 .with_time_column()
                 .with_tag_column("tag1")
                 .with_tag_column("tag2")
-                .with_int_field_column("field_int")
+                .with_i64_field_column("field_int")
                 .with_five_rows_of_data(),
         );
         // Datafusion schema of the chunk
@@ -1031,7 +1031,7 @@ mod test {
                 .with_time_column()
                 .with_tag_column("tag1")
                 .with_tag_column("tag2")
-                .with_int_field_column("field_int")
+                .with_i64_field_column("field_int")
                 .with_five_rows_of_data(),
         );
 
@@ -1042,7 +1042,7 @@ mod test {
                 .with_time_column()
                 .with_tag_column("tag1")
                 .with_tag_column("tag2")
-                .with_int_field_column("field_int")
+                .with_i64_field_column("field_int")
                 .with_five_rows_of_data(),
         );
         let chunks = vec![chunk1, chunk2];
@@ -1105,7 +1105,7 @@ mod test {
                 .with_time_column()
                 .with_tag_column("tag1")
                 .with_tag_column("tag2")
-                .with_int_field_column("field_int")
+                .with_i64_field_column("field_int")
                 .with_five_rows_of_data(),
         );
 
@@ -1115,7 +1115,7 @@ mod test {
                 .with_id(2)
                 .with_time_column()
                 .with_tag_column("tag1")
-                .with_int_field_column("other_field_int")
+                .with_i64_field_column("other_field_int")
                 .with_five_rows_of_data(),
         );
 
@@ -1125,7 +1125,7 @@ mod test {
                 .with_id(3)
                 .with_time_column()
                 .with_tag_column("tag1")
-                .with_int_field_column("other_field_int")
+                .with_i64_field_column("other_field_int")
                 .with_five_rows_of_data(),
         );
 
@@ -1197,7 +1197,7 @@ mod test {
                 .with_time_column()
                 .with_tag_column("tag1")
                 .with_tag_column("tag2")
-                .with_int_field_column("field_int")
+                .with_i64_field_column("field_int")
                 .with_five_rows_of_data(),
         );
 
@@ -1208,7 +1208,7 @@ mod test {
                 .with_time_column()
                 .with_tag_column("tag3")
                 .with_tag_column("tag1")
-                .with_int_field_column("field_int")
+                .with_i64_field_column("field_int")
                 .with_five_rows_of_data(),
         );
 
@@ -1218,8 +1218,8 @@ mod test {
                 .with_id(3)
                 .with_time_column()
                 .with_tag_column("tag3")
-                .with_int_field_column("field_int")
-                .with_int_field_column("field_int2")
+                .with_i64_field_column("field_int")
+                .with_i64_field_column("field_int2")
                 .with_five_rows_of_data(),
         );
 
@@ -1297,7 +1297,7 @@ mod test {
             TestChunk::new("t")
                 .with_time_column_with_stats(Some(5), Some(7000))
                 .with_tag_column_with_stats("tag1", Some("AL"), Some("MT"))
-                .with_int_field_column("field_int")
+                .with_i64_field_column("field_int")
                 .with_five_rows_of_data(),
         );
 
@@ -1345,7 +1345,7 @@ mod test {
             TestChunk::new("t")
                 .with_time_column_with_stats(Some(5), Some(7000))
                 .with_tag_column_with_stats("tag1", Some("AL"), Some("MT"))
-                .with_int_field_column("field_int")
+                .with_i64_field_column("field_int")
                 .with_may_contain_pk_duplicates(true)
                 .with_ten_rows_of_data_some_duplicates(),
         );
@@ -1401,7 +1401,7 @@ mod test {
             TestChunk::new("t")
                 .with_time_column_with_stats(Some(5), Some(7000))
                 .with_tag_column_with_stats("tag1", Some("AL"), Some("MT"))
-                .with_int_field_column("field_int")
+                .with_i64_field_column("field_int")
                 .with_may_contain_pk_duplicates(true)
                 .with_ten_rows_of_data_some_duplicates(),
         );
@@ -1466,7 +1466,7 @@ mod test {
             TestChunk::new("t")
                 .with_time_column_with_stats(Some(5), Some(7000))
                 .with_tag_column_with_stats("tag1", Some("AL"), Some("MT"))
-                .with_int_field_column("field_int")
+                .with_i64_field_column("field_int")
                 .with_ten_rows_of_data_some_duplicates(),
         );
 
@@ -1474,7 +1474,7 @@ mod test {
             TestChunk::new("t")
                 .with_time_column_with_stats(Some(5), Some(7000))
                 .with_tag_column_with_stats("tag1", Some("AL"), Some("MT"))
-                .with_int_field_column("field_int")
+                .with_i64_field_column("field_int")
                 .with_five_rows_of_data(),
         );
 
@@ -1536,7 +1536,7 @@ mod test {
                 .with_id(1)
                 .with_time_column_with_stats(Some(5), Some(7000))
                 .with_tag_column_with_stats("tag1", Some("AL"), Some("MT"))
-                .with_int_field_column("field_int")
+                .with_i64_field_column("field_int")
                 .with_ten_rows_of_data_some_duplicates(),
         );
 
@@ -1546,7 +1546,7 @@ mod test {
                 .with_id(2)
                 .with_time_column_with_stats(Some(5), Some(7000))
                 .with_tag_column_with_stats("tag1", Some("AL"), Some("MT"))
-                .with_int_field_column("field_int")
+                .with_i64_field_column("field_int")
                 .with_five_rows_of_data(),
         );
 
@@ -1556,7 +1556,7 @@ mod test {
                 .with_id(3)
                 .with_time_column_with_stats(Some(8000), Some(20000))
                 .with_tag_column_with_stats("tag1", Some("UT"), Some("WA"))
-                .with_int_field_column("field_int")
+                .with_i64_field_column("field_int")
                 .with_three_rows_of_data(),
         );
 
@@ -1566,7 +1566,7 @@ mod test {
                 .with_id(4)
                 .with_time_column_with_stats(Some(28000), Some(220000))
                 .with_tag_column_with_stats("tag1", Some("UT"), Some("WA"))
-                .with_int_field_column("field_int")
+                .with_i64_field_column("field_int")
                 .with_may_contain_pk_duplicates(true)
                 .with_four_rows_of_data(),
         );

--- a/query/src/pruning.rs
+++ b/query/src/pruning.rs
@@ -167,9 +167,8 @@ mod test {
     use super::*;
     use std::{cell::RefCell, fmt, sync::Arc};
 
-    use arrow::datatypes::DataType;
     use datafusion::logical_plan::{col, lit};
-    use internal_types::schema::{builder::SchemaBuilder, Schema};
+    use internal_types::schema::Schema;
 
     use crate::{predicate::PredicateBuilder, test::TestChunk, QueryChunk};
 
@@ -738,16 +737,7 @@ mod test {
         fn with_i64_column_no_stats(self, column_name: impl Into<String>) -> Self {
             let Self { test_chunk } = self;
 
-            let column_name = column_name.into();
-
-            // make a new schema with the specified column and
-            // merge it in to any existing schema
-            let new_column_schema = SchemaBuilder::new()
-                .field(&column_name, DataType::Int64)
-                .build()
-                .unwrap();
-
-            let test_chunk = test_chunk.add_schema_to_table(new_column_schema, false, None);
+            let test_chunk = test_chunk.with_i64_field_column_no_stats(column_name);
 
             Self { test_chunk }
         }

--- a/query/src/pruning.rs
+++ b/query/src/pruning.rs
@@ -729,7 +729,7 @@ mod test {
         ) -> Self {
             let Self { test_chunk } = self;
 
-            let test_chunk = test_chunk.with_int_field_column_with_stats(column_name, min, max);
+            let test_chunk = test_chunk.with_i64_field_column_with_stats(column_name, min, max);
 
             Self { test_chunk }
         }

--- a/query/src/test.rs
+++ b/query/src/test.rs
@@ -26,7 +26,7 @@ use internal_types::{
 };
 use parking_lot::Mutex;
 use snafu::Snafu;
-use std::{collections::BTreeMap, sync::Arc};
+use std::{collections::BTreeMap, fmt, sync::Arc};
 
 #[derive(Debug, Default)]
 pub struct TestDatabase {
@@ -452,7 +452,7 @@ impl TestChunk {
     /// Adds the specified schema and optionally a column summary containing optional stats.
     /// If `add_column_summary` is false, `stats` is ignored. If `add_column_summary` is true but
     /// `stats` is `None`, default stats will be added to the column summary.
-    pub fn add_schema_to_table(
+    fn add_schema_to_table(
         mut self,
         new_column_schema: Schema,
         add_column_summary: bool,
@@ -825,6 +825,12 @@ impl TestChunk {
             .map(|(_, field)| field.name().to_string())
             .filter(|col| columns.contains(&col.as_str()))
             .collect()
+    }
+}
+
+impl fmt::Display for TestChunk {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.table_name())
     }
 }
 

--- a/query/src/test.rs
+++ b/query/src/test.rs
@@ -223,8 +223,8 @@ impl TestChunk {
     pub fn with_tag_column_with_stats(
         self,
         column_name: impl Into<String>,
-        min: &str,
-        max: &str,
+        min: Option<&str>,
+        max: Option<&str>,
     ) -> Self {
         let column_name = column_name.into();
 
@@ -234,8 +234,8 @@ impl TestChunk {
 
         // Construct stats
         let stats = Statistics::String(StatValues {
-            min: Some(min.to_string()),
-            max: Some(max.to_string()),
+            min: min.map(ToString::to_string),
+            max: max.map(ToString::to_string),
             ..Default::default()
         });
 
@@ -252,15 +252,15 @@ impl TestChunk {
     }
 
     /// Register a timestamp column with the test chunk
-    pub fn with_time_column_with_stats(self, min: i64, max: i64) -> Self {
+    pub fn with_time_column_with_stats(self, min: Option<i64>, max: Option<i64>) -> Self {
         // make a new schema with the specified column and
         // merge it in to any existing schema
         let new_column_schema = SchemaBuilder::new().timestamp().build().unwrap();
 
         // Construct stats
         let stats = Statistics::I64(StatValues {
-            min: Some(min),
-            max: Some(max),
+            min,
+            max,
             ..Default::default()
         });
 

--- a/query/src/test.rs
+++ b/query/src/test.rs
@@ -3,32 +3,29 @@
 //!
 //! AKA it is a Mock
 
+use crate::exec::Executor;
+use crate::{
+    exec::stringset::{StringSet, StringSetRef},
+    DatabaseStore, Predicate, PredicateMatch, QueryChunk, QueryChunkMeta, QueryDatabase,
+};
 use arrow::{
     array::{ArrayRef, DictionaryArray, Int64Array, StringArray, TimestampNanosecondArray},
     datatypes::{DataType, Int32Type, TimeUnit},
     record_batch::RecordBatch,
 };
+use async_trait::async_trait;
 use data_types::{
     chunk_metadata::ChunkSummary,
     partition_metadata::{ColumnSummary, InfluxDbType, StatValues, Statistics, TableSummary},
 };
 use datafusion::physical_plan::{common::SizedRecordBatchStream, SendableRecordBatchStream};
 use futures::StreamExt;
-
-use crate::exec::Executor;
-use crate::{
-    exec::stringset::{StringSet, StringSetRef},
-    DatabaseStore, Predicate, PredicateMatch, QueryChunk, QueryChunkMeta, QueryDatabase,
-};
-
 use internal_types::{
     schema::{
         builder::SchemaBuilder, merge::SchemaMerger, InfluxColumnType, Schema, TIME_COLUMN_NAME,
     },
     selection::Selection,
 };
-
-use async_trait::async_trait;
 use parking_lot::Mutex;
 use snafu::Snafu;
 use std::{collections::BTreeMap, sync::Arc};

--- a/query/src/test.rs
+++ b/query/src/test.rs
@@ -343,7 +343,7 @@ impl TestChunk {
 
     /// Prepares this chunk to return a specific record batch with one
     /// row of non null data.
-    pub fn with_one_row_of_null_data(mut self) -> Self {
+    pub fn with_one_row_of_data(mut self) -> Self {
         // create arrays
         let columns = self
             .schema

--- a/query/src/test.rs
+++ b/query/src/test.rs
@@ -268,7 +268,7 @@ impl TestChunk {
     }
 
     /// Register an int field column with the test chunk with default stats
-    pub fn with_int_field_column(self, column_name: impl Into<String>) -> Self {
+    pub fn with_i64_field_column(self, column_name: impl Into<String>) -> Self {
         let column_name = column_name.into();
 
         // make a new schema with the specified column and
@@ -280,7 +280,7 @@ impl TestChunk {
         self.add_schema_to_table(new_column_schema, true, None)
     }
 
-    pub fn with_int_field_column_with_stats(
+    pub fn with_i64_field_column_with_stats(
         self,
         column_name: impl Into<String>,
         min: Option<i64>,

--- a/query/src/test.rs
+++ b/query/src/test.rs
@@ -280,6 +280,20 @@ impl TestChunk {
         self.add_schema_to_table(new_column_schema, true, None)
     }
 
+    /// Adds an i64 column named into the schema, but with no stats
+    pub fn with_i64_field_column_no_stats(self, column_name: impl Into<String>) -> Self {
+        let column_name = column_name.into();
+
+        // make a new schema with the specified column and
+        // merge it in to any existing schema
+        let new_column_schema = SchemaBuilder::new()
+            .field(&column_name, DataType::Int64)
+            .build()
+            .unwrap();
+
+        self.add_schema_to_table(new_column_schema, false, None)
+    }
+
     pub fn with_i64_field_column_with_stats(
         self,
         column_name: impl Into<String>,

--- a/query/src/test.rs
+++ b/query/src/test.rs
@@ -146,7 +146,7 @@ pub struct TestChunk {
     table_name: String,
 
     /// Schema of the table
-    table_schema: Option<Schema>,
+    schema: Arc<Schema>,
 
     /// RecordBatches that are returned on each request
     table_data: Vec<Arc<RecordBatch>>,
@@ -165,6 +165,7 @@ impl TestChunk {
     pub fn new(table_name: impl Into<String>) -> Self {
         Self {
             table_name: table_name.into(),
+            schema: Arc::new(SchemaBuilder::new().build().unwrap()),
             ..Default::default()
         }
     }

--- a/query/src/test.rs
+++ b/query/src/test.rs
@@ -280,10 +280,165 @@ impl TestChunk {
         self.add_schema_to_table(new_column_schema, true, None)
     }
 
+    pub fn with_int_field_column_with_stats(
+        self,
+        column_name: impl Into<String>,
+        min: Option<i64>,
+        max: Option<i64>,
+    ) -> Self {
+        let column_name = column_name.into();
+
+        // make a new schema with the specified column and
+        // merge it in to any existing schema
+        let new_column_schema = SchemaBuilder::new()
+            .field(&column_name, DataType::Int64)
+            .build()
+            .unwrap();
+
+        // Construct stats
+        let stats = Statistics::I64(StatValues {
+            min,
+            max,
+            ..Default::default()
+        });
+
+        self.add_schema_to_table(new_column_schema, true, Some(stats))
+    }
+
+    /// Register a u64 field column with the test chunk with default stats
+    pub fn with_u64_field_column(self, column_name: impl Into<String>) -> Self {
+        let column_name = column_name.into();
+
+        // make a new schema with the specified column and
+        // merge it in to any existing schema
+        let new_column_schema = SchemaBuilder::new()
+            .field(&column_name, DataType::UInt64)
+            .build()
+            .unwrap();
+        self.add_schema_to_table(new_column_schema, true, None)
+    }
+
+    pub fn with_u64_field_column_with_stats(
+        self,
+        column_name: impl Into<String>,
+        min: Option<u64>,
+        max: Option<u64>,
+    ) -> Self {
+        let column_name = column_name.into();
+
+        // make a new schema with the specified column and
+        // merge it in to any existing schema
+        let new_column_schema = SchemaBuilder::new()
+            .field(&column_name, DataType::UInt64)
+            .build()
+            .unwrap();
+
+        // Construct stats
+        let stats = Statistics::U64(StatValues {
+            min,
+            max,
+            ..Default::default()
+        });
+
+        self.add_schema_to_table(new_column_schema, true, Some(stats))
+    }
+
+    /// Register an f64 field column with the test chunk with default stats
+    pub fn with_f64_field_column(self, column_name: impl Into<String>) -> Self {
+        let column_name = column_name.into();
+
+        // make a new schema with the specified column and
+        // merge it in to any existing schema
+        let new_column_schema = SchemaBuilder::new()
+            .field(&column_name, DataType::Float64)
+            .build()
+            .unwrap();
+
+        self.add_schema_to_table(new_column_schema, true, None)
+    }
+
+    /// Register an f64 field column with the test chunk
+    pub fn with_f64_field_column_with_stats(
+        self,
+        column_name: impl Into<String>,
+        min: Option<f64>,
+        max: Option<f64>,
+    ) -> Self {
+        let column_name = column_name.into();
+
+        // make a new schema with the specified column and
+        // merge it in to any existing schema
+        let new_column_schema = SchemaBuilder::new()
+            .field(&column_name, DataType::Float64)
+            .build()
+            .unwrap();
+
+        // Construct stats
+        let stats = Statistics::F64(StatValues {
+            min,
+            max,
+            ..Default::default()
+        });
+
+        self.add_schema_to_table(new_column_schema, true, Some(stats))
+    }
+
+    /// Register a bool field column with the test chunk
+    pub fn with_bool_field_column_with_stats(
+        self,
+        column_name: impl Into<String>,
+        min: Option<bool>,
+        max: Option<bool>,
+    ) -> Self {
+        let column_name = column_name.into();
+
+        // make a new schema with the specified column and
+        // merge it in to any existing schema
+        let new_column_schema = SchemaBuilder::new()
+            .field(&column_name, DataType::Boolean)
+            .build()
+            .unwrap();
+
+        // Construct stats
+        let stats = Statistics::Bool(StatValues {
+            min,
+            max,
+            ..Default::default()
+        });
+
+        self.add_schema_to_table(new_column_schema, true, Some(stats))
+    }
+
+    /// Register a string field column with the test chunk
+    pub fn with_string_field_column_with_stats(
+        self,
+        column_name: impl Into<String>,
+        min: Option<&str>,
+        max: Option<&str>,
+    ) -> Self {
+        let column_name = column_name.into();
+
+        // make a new schema with the specified column and
+        // merge it in to any existing schema
+        let new_column_schema = SchemaBuilder::new()
+            .field(&column_name, DataType::Utf8)
+            .build()
+            .unwrap();
+
+        // Construct stats
+        let stats = Statistics::String(StatValues {
+            min: min.map(ToString::to_string),
+            max: max.map(ToString::to_string),
+            ..Default::default()
+        });
+
+        self.add_schema_to_table(new_column_schema, true, Some(stats))
+    }
+
     /// Adds the specified schema and optionally a column summary containing optional stats.
     /// If `add_column_summary` is false, `stats` is ignored. If `add_column_summary` is true but
     /// `stats` is `None`, default stats will be added to the column summary.
-    fn add_schema_to_table(
+    pub fn add_schema_to_table(
         mut self,
         new_column_schema: Schema,
         add_column_summary: bool,
@@ -317,7 +472,7 @@ impl TestChunk {
                     assert!(matches!(**value_type, DataType::Utf8));
                     Statistics::String(StatValues::default())
                 }
-                DataType::Float64 => Statistics::String(StatValues::default()),
+                DataType::Float64 => Statistics::F64(StatValues::default()),
                 DataType::Timestamp(_, _) => Statistics::I64(StatValues::default()),
                 _ => panic!("Unsupported type in TestChunk: {:?}", new_field.data_type()),
             });

--- a/src/influxdb_ioxd/rpc/storage/service.rs
+++ b/src/influxdb_ioxd/rpc/storage/service.rs
@@ -1588,7 +1588,7 @@ mod tests {
         let chunk = TestChunk::new("TheMeasurement")
             .with_time_column()
             .with_tag_column("state")
-            .with_one_row_of_null_data();
+            .with_one_row_of_data();
 
         fixture
             .test_storage
@@ -1679,7 +1679,7 @@ mod tests {
             .with_int_field_column("Field1")
             .with_time_column()
             .with_tag_column("state")
-            .with_one_row_of_null_data();
+            .with_one_row_of_data();
 
         fixture
             .test_storage
@@ -1795,7 +1795,7 @@ mod tests {
         let chunk = TestChunk::new("TheMeasurement")
             .with_time_column()
             .with_tag_column("state")
-            .with_one_row_of_null_data();
+            .with_one_row_of_data();
 
         fixture
             .test_storage
@@ -1948,7 +1948,7 @@ mod tests {
         let chunk = TestChunk::new("TheMeasurement")
             .with_time_column()
             .with_tag_column("state")
-            .with_one_row_of_null_data();
+            .with_one_row_of_data();
 
         fixture
             .test_storage
@@ -2034,7 +2034,7 @@ mod tests {
         let chunk = TestChunk::new("TheMeasurement")
             .with_time_column()
             .with_tag_column("state")
-            .with_one_row_of_null_data();
+            .with_one_row_of_data();
 
         fixture
             .test_storage
@@ -2168,7 +2168,7 @@ mod tests {
         let chunk = TestChunk::new("TheMeasurement")
             .with_time_column()
             .with_tag_column("state")
-            .with_one_row_of_null_data();
+            .with_one_row_of_data();
 
         fixture
             .test_storage
@@ -2228,7 +2228,7 @@ mod tests {
         let chunk = TestChunk::new("TheMeasurement")
             .with_time_column()
             .with_tag_column("state")
-            .with_one_row_of_null_data();
+            .with_one_row_of_data();
 
         fixture
             .test_storage
@@ -2353,7 +2353,7 @@ mod tests {
             .with_int_field_column("Field1")
             .with_time_column()
             .with_tag_column("state")
-            .with_one_row_of_null_data();
+            .with_one_row_of_data();
 
         fixture
             .test_storage

--- a/src/influxdb_ioxd/rpc/storage/service.rs
+++ b/src/influxdb_ioxd/rpc/storage/service.rs
@@ -1252,13 +1252,13 @@ mod tests {
         let db_info = OrgAndBucket::new(123, 456);
         let partition_id = 1;
 
-        let chunk0 = TestChunk::new(0)
-            .with_predicate_match(PredicateMatch::AtLeastOne)
-            .with_table("h2o");
+        let chunk0 = TestChunk::new("h2o")
+            .with_id(0)
+            .with_predicate_match(PredicateMatch::AtLeastOne);
 
-        let chunk1 = TestChunk::new(1)
-            .with_predicate_match(PredicateMatch::AtLeastOne)
-            .with_table("o2");
+        let chunk1 = TestChunk::new("o2")
+            .with_id(1)
+            .with_predicate_match(PredicateMatch::AtLeastOne);
 
         fixture
             .test_storage
@@ -1346,13 +1346,15 @@ mod tests {
         let partition_id = 1;
 
         // Note multiple tables / measureemnts:
-        let chunk0 = TestChunk::new(0)
-            .with_tag_column("m1", "k1")
-            .with_tag_column("m1", "k2");
+        let chunk0 = TestChunk::new("m1")
+            .with_id(0)
+            .with_tag_column("k1")
+            .with_tag_column("k2");
 
-        let chunk1 = TestChunk::new(1)
-            .with_tag_column("m2", "k3")
-            .with_tag_column("m2", "k4");
+        let chunk1 = TestChunk::new("m2")
+            .with_id(1)
+            .with_tag_column("k3")
+            .with_tag_column("k4");
 
         fixture
             .test_storage
@@ -1414,9 +1416,7 @@ mod tests {
         let db_info = OrgAndBucket::new(123, 456);
         let partition_id = 1;
 
-        let chunk = TestChunk::new(0)
-            .with_table("my_table")
-            .with_error("Sugar we are going down");
+        let chunk = TestChunk::new("my_table").with_error("Sugar we are going down");
 
         fixture
             .test_storage
@@ -1458,15 +1458,15 @@ mod tests {
         let db_info = OrgAndBucket::new(123, 456);
         let partition_id = 1;
 
-        let chunk0 = TestChunk::new(0)
+        let chunk0 = TestChunk::new("m1")
             // predicate specifies m4, so this is filtered out
-            .with_tag_column("m1", "k0");
+            .with_tag_column("k0");
 
-        let chunk1 = TestChunk::new(1)
-            .with_tag_column("m4", "k1")
-            .with_tag_column("m4", "k2")
-            .with_tag_column("m4", "k3")
-            .with_tag_column("m4", "k4");
+        let chunk1 = TestChunk::new("m4")
+            .with_tag_column("k1")
+            .with_tag_column("k2")
+            .with_tag_column("k3")
+            .with_tag_column("k4");
 
         fixture
             .test_storage
@@ -1540,10 +1540,8 @@ mod tests {
         let db_info = OrgAndBucket::new(123, 456);
         let partition_id = 1;
 
-        let chunk = TestChunk::new(0)
-            // predicate specifies m4, so this is filtered out
-            .with_table("my_table")
-            .with_error("This is an error");
+        // predicate specifies m4, so this is filtered out
+        let chunk = TestChunk::new("my_table").with_error("This is an error");
 
         fixture
             .test_storage
@@ -1587,10 +1585,10 @@ mod tests {
         let partition_id = 1;
 
         // Add a chunk with a field
-        let chunk = TestChunk::new(0)
-            .with_time_column("TheMeasurement")
-            .with_tag_column("TheMeasurement", "state")
-            .with_one_row_of_null_data("TheMeasurement");
+        let chunk = TestChunk::new("TheMeasurement")
+            .with_time_column()
+            .with_tag_column("state")
+            .with_one_row_of_null_data();
 
         fixture
             .test_storage
@@ -1648,9 +1646,7 @@ mod tests {
             tag_key: [0].into(),
         };
 
-        let chunk = TestChunk::new(0)
-            .with_predicate_match(PredicateMatch::AtLeastOne)
-            .with_table("h2o");
+        let chunk = TestChunk::new("h2o").with_predicate_match(PredicateMatch::AtLeastOne);
 
         fixture
             .test_storage
@@ -1679,11 +1675,11 @@ mod tests {
         let partition_id = 1;
 
         // Add a chunk with a field
-        let chunk = TestChunk::new(0)
-            .with_int_field_column("TheMeasurement", "Field1")
-            .with_time_column("TheMeasurement")
-            .with_tag_column("TheMeasurement", "state")
-            .with_one_row_of_null_data("TheMeasurement");
+        let chunk = TestChunk::new("TheMeasurement")
+            .with_int_field_column("Field1")
+            .with_time_column()
+            .with_tag_column("state")
+            .with_one_row_of_null_data();
 
         fixture
             .test_storage
@@ -1727,9 +1723,7 @@ mod tests {
         let db_info = OrgAndBucket::new(123, 456);
         let partition_id = 1;
 
-        let chunk = TestChunk::new(0)
-            .with_table("my_table")
-            .with_error("Sugar we are going down");
+        let chunk = TestChunk::new("my_table").with_error("Sugar we are going down");
 
         fixture
             .test_storage
@@ -1798,10 +1792,10 @@ mod tests {
         let partition_id = 1;
 
         // Add a chunk with a field
-        let chunk = TestChunk::new(0)
-            .with_time_column("TheMeasurement")
-            .with_tag_column("TheMeasurement", "state")
-            .with_one_row_of_null_data("TheMeasurement");
+        let chunk = TestChunk::new("TheMeasurement")
+            .with_time_column()
+            .with_tag_column("state")
+            .with_one_row_of_null_data();
 
         fixture
             .test_storage
@@ -1847,9 +1841,7 @@ mod tests {
         let db_info = OrgAndBucket::new(123, 456);
         let partition_id = 1;
 
-        let chunk = TestChunk::new(0)
-            .with_table("my_table")
-            .with_error("Sugar we are going down");
+        let chunk = TestChunk::new("my_table").with_error("Sugar we are going down");
 
         fixture
             .test_storage
@@ -1953,10 +1945,10 @@ mod tests {
         let partition_id = 1;
 
         // Add a chunk with a field
-        let chunk = TestChunk::new(0)
-            .with_time_column("TheMeasurement")
-            .with_tag_column("TheMeasurement", "state")
-            .with_one_row_of_null_data("TheMeasurement");
+        let chunk = TestChunk::new("TheMeasurement")
+            .with_time_column()
+            .with_tag_column("state")
+            .with_one_row_of_null_data();
 
         fixture
             .test_storage
@@ -1999,9 +1991,7 @@ mod tests {
         let db_info = OrgAndBucket::new(123, 456);
         let partition_id = 1;
 
-        let chunk = TestChunk::new(0)
-            .with_table("my_table")
-            .with_error("Sugar we are going down");
+        let chunk = TestChunk::new("my_table").with_error("Sugar we are going down");
 
         fixture
             .test_storage
@@ -2041,10 +2031,10 @@ mod tests {
         let db_info = OrgAndBucket::new(123, 456);
         let partition_id = 1;
 
-        let chunk = TestChunk::new(0)
-            .with_time_column("TheMeasurement")
-            .with_tag_column("TheMeasurement", "state")
-            .with_one_row_of_null_data("TheMeasurement");
+        let chunk = TestChunk::new("TheMeasurement")
+            .with_time_column()
+            .with_tag_column("state")
+            .with_one_row_of_null_data();
 
         fixture
             .test_storage
@@ -2093,9 +2083,7 @@ mod tests {
         let db_info = OrgAndBucket::new(123, 456);
         let partition_id = 1;
 
-        let chunk = TestChunk::new(0)
-            .with_table("my_table")
-            .with_error("Sugar we are going down");
+        let chunk = TestChunk::new("my_table").with_error("Sugar we are going down");
 
         fixture
             .test_storage
@@ -2177,10 +2165,10 @@ mod tests {
         let partition_id = 1;
 
         // Add a chunk with a field
-        let chunk = TestChunk::new(0)
-            .with_time_column("TheMeasurement")
-            .with_tag_column("TheMeasurement", "state")
-            .with_one_row_of_null_data("TheMeasurement");
+        let chunk = TestChunk::new("TheMeasurement")
+            .with_time_column()
+            .with_tag_column("state")
+            .with_one_row_of_null_data();
 
         fixture
             .test_storage
@@ -2237,10 +2225,10 @@ mod tests {
         let partition_id = 1;
 
         // Add a chunk with a field
-        let chunk = TestChunk::new(0)
-            .with_time_column("TheMeasurement")
-            .with_tag_column("TheMeasurement", "state")
-            .with_one_row_of_null_data("TheMeasurement");
+        let chunk = TestChunk::new("TheMeasurement")
+            .with_time_column()
+            .with_tag_column("state")
+            .with_one_row_of_null_data();
 
         fixture
             .test_storage
@@ -2305,9 +2293,7 @@ mod tests {
         let db_info = OrgAndBucket::new(123, 456);
         let partition_id = 1;
 
-        let chunk = TestChunk::new(0)
-            .with_table("my_table")
-            .with_error("Sugar we are going down");
+        let chunk = TestChunk::new("my_table").with_error("Sugar we are going down");
 
         fixture
             .test_storage
@@ -2363,11 +2349,11 @@ mod tests {
         let partition_id = 1;
 
         // Add a chunk with a field
-        let chunk = TestChunk::new(0)
-            .with_int_field_column("TheMeasurement", "Field1")
-            .with_time_column("TheMeasurement")
-            .with_tag_column("TheMeasurement", "state")
-            .with_one_row_of_null_data("TheMeasurement");
+        let chunk = TestChunk::new("TheMeasurement")
+            .with_int_field_column("Field1")
+            .with_time_column()
+            .with_tag_column("state")
+            .with_one_row_of_null_data();
 
         fixture
             .test_storage
@@ -2413,7 +2399,7 @@ mod tests {
         let db_info = OrgAndBucket::new(123, 456);
         let partition_id = 1;
 
-        let chunk = TestChunk::new(0).with_error("Sugar we are going down");
+        let chunk = TestChunk::new("t").with_error("Sugar we are going down");
 
         fixture
             .test_storage

--- a/src/influxdb_ioxd/rpc/storage/service.rs
+++ b/src/influxdb_ioxd/rpc/storage/service.rs
@@ -1676,7 +1676,7 @@ mod tests {
 
         // Add a chunk with a field
         let chunk = TestChunk::new("TheMeasurement")
-            .with_int_field_column("Field1")
+            .with_i64_field_column("Field1")
             .with_time_column()
             .with_tag_column("state")
             .with_one_row_of_data();
@@ -2350,7 +2350,7 @@ mod tests {
 
         // Add a chunk with a field
         let chunk = TestChunk::new("TheMeasurement")
-            .with_int_field_column("Field1")
+            .with_i64_field_column("Field1")
             .with_time_column()
             .with_tag_column("state")
             .with_one_row_of_data();


### PR DESCRIPTION
While working towards #1927, in the query crate, I found 2 `TestChunk`s and 1 `TestChunkMeta` that looked like they were doing similar things, so I unified them into one `query::test::TestChunk`. The diff stats aren't quite as dramatic as I was hoping for, but it's still a net negative :)