### PR TITLE
refactor: reduce some repetition in http tests

### DIFF
--- a/src/influxdb_ioxd/http.rs
+++ b/src/influxdb_ioxd/http.rs
@@ -1168,17 +1168,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_gzip_write() {
-        let (_, config) = config();
-        let app_server = Arc::new(AppServer::new(ConnectionManagerImpl::new(), config));
-        app_server.set_id(ServerId::try_from(1).unwrap()).unwrap();
-        app_server.maybe_initialize_server().await;
-        app_server
-            .create_database(DatabaseRules::new(
-                DatabaseName::new("MyOrg_MyBucket").unwrap(),
-            ))
-            .await
-            .unwrap();
-        let server_url = test_server(Arc::clone(&app_server));
+        let (app_server, server_url) = setup_server().await;
 
         let client = Client::new();
         let lp_data = "h2o_temperature,location=santa_monica,state=CA surface_degrees=65.2,bottom_degrees=50.4 1617286224000000000";
@@ -1217,17 +1207,7 @@ mod tests {
 
     #[tokio::test]
     async fn write_to_invalid_database() {
-        let (_, config) = config();
-        let app_server = Arc::new(AppServer::new(ConnectionManagerImpl::new(), config));
-        app_server.set_id(ServerId::try_from(1).unwrap()).unwrap();
-        app_server.maybe_initialize_server().await;
-        app_server
-            .create_database(DatabaseRules::new(
-                DatabaseName::new("MyOrg_MyBucket").unwrap(),
-            ))
-            .await
-            .unwrap();
-        let server_url = test_server(Arc::clone(&app_server));
+        let (_, server_url) = setup_server().await;
 
         let client = Client::new();
 
@@ -1341,5 +1321,22 @@ mod tests {
             .collect(physical_plan, ExecutorType::Query)
             .await
             .unwrap()
+    }
+
+    /// return a test server and the url to contact it for `MyOrg_MyBucket`
+    async fn setup_server() -> (Arc<AppServer<ConnectionManagerImpl>>, String) {
+        let (_, config) = config();
+        let app_server = Arc::new(AppServer::new(ConnectionManagerImpl::new(), config));
+        app_server.set_id(ServerId::try_from(1).unwrap()).unwrap();
+        app_server.maybe_initialize_server().await;
+        app_server
+            .create_database(DatabaseRules::new(
+                DatabaseName::new("MyOrg_MyBucket").unwrap(),
+            ))
+            .await
+            .unwrap();
+        let server_url = test_server(Arc::clone(&app_server));
+
+        (app_server, server_url)
     }
 }


### PR DESCRIPTION
I noticed this on https://github.com/influxdata/influxdb_iox/pull/1968 and refactored it while writing a version of the test for #1968 that did not make it into the final PR, but it seemed useful anyways to reduce some copy/pasta
