### PR TITLE
chore: Log whether the write buffer is enabled

### DIFF
--- a/server/src/init.rs
+++ b/server/src/init.rs
@@ -535,6 +535,7 @@ impl InitStatus {
                         config: rules.write_buffer_connection.clone(),
                     },
                 )?;
+                info!(write_buffer_enabled=?write_buffer.is_some(), db_name=rules.db_name(), "write buffer config");
 
                 handle
                     .advance_replay(preserved_catalog, catalog, write_buffer)

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -562,6 +562,7 @@ where
                     source: e,
                 }
             })?;
+        info!(write_buffer_enabled=?write_buffer.is_some(), db_name=rules.db_name(), "write buffer config");
         db_reservation.advance_replay(preserved_catalog, catalog, write_buffer)?;
 
         // no actual replay required


### PR DESCRIPTION
When a node starts, it initializes the existing databases when it reads the persisted rules file.
If a database rules file is later updated, it doesn't (currently) apply the write buffer config.
We'll address that in another commit, but let's just log this now because it's important to know the effective
personality configuration of a database (i.e. whether it acts as an in-memory database or as a router!)