### PR TITLE
fix: Raise kafka max request size to 10M

### DIFF
--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -203,8 +203,8 @@ pub enum Error {
     ))]
     WritingOnlyAllowedThroughWriteBuffer { db_name: String },
 
-    #[snafu(display("Cannot write to write buffer: {}", source))]
-    WriteBuffer { source: db::Error },
+    #[snafu(display("Cannot write to write buffer, bytes {}: {}", bytes, source))]
+    WriteBuffer { source: db::Error, bytes: u64 },
 
     #[snafu(display("no remote configured for node group: {:?}", node_group))]
     NoRemoteConfigured { node_group: NodeGroup },
@@ -805,7 +805,9 @@ where
                         db_name: db_name.into(),
                     }
                 }
-                db::Error::WriteBufferWritingError { .. } => Error::WriteBuffer { source: e },
+                db::Error::WriteBufferWritingError { .. } => {
+                    Error::WriteBuffer { source: e, bytes }
+                }
                 _ => Error::UnknownDatabaseError {
                     source: Box::new(e),
                 },

--- a/server/src/write_buffer.rs
+++ b/server/src/write_buffer.rs
@@ -126,6 +126,7 @@ impl KafkaBufferProducer {
         let mut cfg = ClientConfig::new();
         cfg.set("bootstrap.servers", &conn);
         cfg.set("message.timeout.ms", "5000");
+        cfg.set("max.request.size", "10000000");
 
         let producer: FutureProducer = cfg.create()?;
 


### PR DESCRIPTION
And log message size on kafka write error.

Turns out the kafka partition message size limit default is 1MB, but also the
client side "max request size" default is also 1MB.
The error message we get from our kafka client is misleading: it says

```
KafkaError (Message production error: MessageSizeTooLarge (Broker: Message size too large)) }
```

which to my mind it seemed like if ("Broker:") the broker said "Message size too large".
That was a lie; I killed the broker and the client kept saying the same error message which means
it didn't even try to send the message out.

TODO: make this a proper parameter. (but let's unblock)