### PR TITLE
refactor: set kafka max message size

### DIFF
--- a/write_buffer/src/kafka.rs
+++ b/write_buffer/src/kafka.rs
@@ -68,6 +68,7 @@ impl KafkaBufferProducer {
         let mut cfg = ClientConfig::new();
         cfg.set("bootstrap.servers", &conn);
         cfg.set("message.timeout.ms", "5000");
+        cfg.set("message.max.bytes", "10000000");
 
         let producer: FutureProducer = cfg.create()?;
 


### PR DESCRIPTION
I think that this will set an appropriate configuration setting to increase the maximum size of a message we can produce onto Kafka.