### PR TITLE
fix: fix intermittent failure of end_to_end_cases::persistence::test_full_lifecycle

### DIFF
--- a/tests/end_to_end_cases/persistence.rs
+++ b/tests/end_to_end_cases/persistence.rs
@@ -68,7 +68,7 @@ async fn test_full_lifecycle() {
         })
         .collect();
 
-    // duplicate the payloads
+    // duplicate the payloads the appropriate number of times
     let payloads: Vec<_> = payloads
         .iter()
         .take(num_payloads - 1)
@@ -77,7 +77,8 @@ async fn test_full_lifecycle() {
         .chain(std::iter::once(payloads.last().cloned().unwrap()))
         .collect();
 
-    // Write all the lines in one big chunk
+    // Write all the lines in one big chunk so the lifecycle policy
+    // doesn't act prior to the entire dataset being written
     let num_lines_written = write_client
         .write(&db_name, payloads.join("\n"))
         .await


### PR DESCRIPTION

Closes: https://github.com/influxdata/influxdb_iox/issues/1994

Fixes the second of the two failures seen on [this run](https://app.circleci.com/pipelines/github/influxdata/influxdb_iox/8022/workflows/d8731792-c075-4873-a337-5c1240678651/jobs/40039). Spefifically, this failure:

```
thread 'end_to_end_cases::persistence::test_full_lifecycle' panicked at 'Could not find persisted chunks in exactly [ObjectStoreOnly] within 10s.
Chunks were: [
...
```

# Rationale
The end to end persistence test writes a bunch of partially duplicated data and ensures that it ends up in a single `ObjectStoreOnly` chunk. However, sometimes rather than a single large ObjectStoreOnly chunk, the db ended up with two chunks:  8k rows in `ObjectStoreOnly` and 3k rows in `ReadBufferAndObjectStore`.

What was happening is that in the failure case, the `maybe_persist_chunks` lifecycle policy ran prior to all the writes being  completed and decided to persist what was already there (correctly).

You can reproduce the failure locally with a judicious sleep injection:

```diff
diff --git a/tests/end_to_end_cases/persistence.rs b/tests/end_to_end_cases/persistence.rs
index 9c2e78cc..6368fc18 100644
--- a/tests/end_to_end_cases/persistence.rs
+++ b/tests/end_to_end_cases/persistence.rs
@@ -76,6 +76,7 @@ async fn test_full_lifecycle() {
                 .await
                 .expect("successful write");
             assert_eq!(num_lines_written, payload_size);
+            tokio::time::sleep(std::time::Duration::from_millis(100)).await
         }
     }

```

# Changes
Write the data in one large request rather than multiple smaller ones so the lifecycle manager sees only one chunk
