### PR TITLE
refactor: increase compaction batch size

### DIFF
--- a/query/src/provider.rs
+++ b/query/src/provider.rs
@@ -510,7 +510,9 @@ impl<C: QueryChunk + 'static> Deduplicater<C> {
         let plan = Arc::new(SortPreservingMergeExec::new(
             sort_exprs.clone(),
             Arc::new(plan),
-            1024,
+            // TODO(edd): temp experiment - should wire in `_batch_size` in the
+            // table provider.
+            1024 * 25,
         ));
 
         // Add DeduplicateExc


### PR DESCRIPTION
This increases the record batch size used in the `SortPreservingMergeExec` operator to 25600 rows. I am experimenting with the impact that this has on compaction performance, with the theory that it should improve it.

Longer term we need to do this ticket here and then we should have something more configurable.

https://github.com/influxdata/influxdb_iox/issues/2001