### PR TITLE
fix: use correct row group size when updating table meta data

### DIFF
--- a/read_buffer/src/row_group.rs
+++ b/read_buffer/src/row_group.rs
@@ -1566,7 +1566,7 @@ impl std::fmt::Display for &MetaData {
 impl MetaData {
     /// Returns the estimated size in bytes of the meta data and all column data
     /// associated with a `RowGroup`.
-    pub fn size(&self) -> usize {
+    fn size(&self) -> usize {
         let base_size = std::mem::size_of::<Self>();
 
         (base_size

--- a/read_buffer/src/table.rs
+++ b/read_buffer/src/table.rs
@@ -1054,6 +1054,31 @@ mod test {
     }
 
     #[test]
+    fn meta_data_new_or_update_with_same_size() {
+        let columns = vec![
+            (
+                "time".to_string(),
+                ColumnType::create_time(&[100, 200, 300]),
+            ),
+            (
+                "region".to_string(),
+                ColumnType::create_tag(&["west", "west", "north"]),
+            ),
+        ];
+        let rg = RowGroup::new(3, columns);
+
+        let meta_new = MetaData::new(&rg);
+
+        let meta_default = MetaData::default();
+        let meta_default = MetaData::update_with(meta_default, &rg);
+
+        // The size field is the part that was failing
+        assert_eq!(meta_new.size, meta_default.size);
+        // The value from the size method should match too
+        assert_eq!(meta_new.size(), meta_default.size());
+    }
+
+    #[test]
     fn add_remove_row_groups() {
         let tc = ColumnType::Time(Column::from(&[0_i64, 2, 3][..]));
         let columns = vec![("time".to_string(), tc)];

--- a/read_buffer/src/table.rs
+++ b/read_buffer/src/table.rs
@@ -570,6 +570,7 @@ pub struct MetaData {
 impl MetaData {
     pub fn new(rg: &row_group::RowGroup) -> Self {
         Self {
+            // This uses RowGroup.size()...
             size: rg.size(),
             rows: rg.rows() as u64,
             columns: rg.metadata().columns.clone(),
@@ -597,6 +598,7 @@ impl MetaData {
 
         // first row group added to the table.
         if this.columns.is_empty() {
+            // ... but this is using RowGroup.metadata().size()!
             this.size = other.size();
             this.rows = other.rows as u64;
             this.columns = other.columns.clone();

--- a/server/src/db.rs
+++ b/server/src/db.rs
@@ -1475,7 +1475,7 @@ mod tests {
 
         // verify chunk size updated (chunk moved from closing to moving to moved)
         catalog_chunk_size_bytes_metric_eq(&test_db.metric_registry, "mutable_buffer", 0).unwrap();
-        let expected_read_buffer_size = 1468;
+        let expected_read_buffer_size = 1611;
         catalog_chunk_size_bytes_metric_eq(
             &test_db.metric_registry,
             "read_buffer",
@@ -1678,7 +1678,7 @@ mod tests {
             .unwrap();
 
         // verify chunk size updated (chunk moved from moved to writing to written)
-        catalog_chunk_size_bytes_metric_eq(&test_db.metric_registry, "read_buffer", 1470).unwrap();
+        catalog_chunk_size_bytes_metric_eq(&test_db.metric_registry, "read_buffer", 1613).unwrap();
 
         // drop, the chunk from the read buffer
         db.drop_chunk("cpu", partition_key, mb_chunk.id())
@@ -1809,7 +1809,7 @@ mod tests {
                 ("svr_id", "1"),
             ])
             .histogram()
-            .sample_sum_eq(3024.0)
+            .sample_sum_eq(3191.0)
             .unwrap();
 
         let rb = collect_read_filter(&rb_chunk).await;
@@ -1919,7 +1919,7 @@ mod tests {
                 ("svr_id", "10"),
             ])
             .histogram()
-            .sample_sum_eq(2117.0)
+            .sample_sum_eq(2260.0)
             .unwrap();
 
         // while MB and RB chunk are identical, the PQ chunk is a new one (split off)
@@ -2039,7 +2039,7 @@ mod tests {
                 ("svr_id", "10"),
             ])
             .histogram()
-            .sample_sum_eq(2117.0)
+            .sample_sum_eq(2260.0)
             .unwrap();
 
         // Unload RB chunk but keep it in OS
@@ -2501,7 +2501,7 @@ mod tests {
                 2,
                 ChunkStorage::ReadBufferAndObjectStore,
                 lifecycle_action,
-                3082,
+                3236,
                 1528,
                 2,
             ),
@@ -2534,7 +2534,7 @@ mod tests {
         );
 
         assert_eq!(db.catalog.metrics().memory().mutable_buffer(), 2398 + 87);
-        assert_eq!(db.catalog.metrics().memory().read_buffer(), 2256);
+        assert_eq!(db.catalog.metrics().memory().read_buffer(), 2410);
         assert_eq!(db.catalog.metrics().memory().parquet(), 826);
     }
 


### PR DESCRIPTION
I tried to do what I thought was a refactoring (I want to make it so that `MetaData` is never empty, it always starts with a row group), but tests started failing. I've isolated the problem, but I'm not sure what the right fix is.

I've isolated the problem in a new failing test in this PR-- I thought that this:

```
let meta_new = MetaData::new(&rg);
```

and this:

```
let meta_default = MetaData::default();
let meta_default = MetaData::update_with(meta_default, &rg);
```

would be equivalent, but they result in different values in the `size` field. This assertion fails:

```
assert_eq!(meta_new.size, meta_default.size);
```

I've added some comments pointing to where the problem is: `MetaData::new` sets the `size` field to the result of `rg.size()`. `MetaData::default` sets size to 0, then adds the result of `rg.metadata().size()`. [`RowGroup.size()`](https://github.com/influxdata/influxdb_iox/blob/6182c0974bfd3a3c65f406ef4d28303b80b2cf2d/read_buffer/src/row_group.rs#L145) is the base size *plus* [`RowGroup.metadata().size()`](https://github.com/influxdata/influxdb_iox/blob/6182c0974bfd3a3c65f406ef4d28303b80b2cf2d/read_buffer/src/row_group.rs#L175-L176).

The part I don't know is what value for row group size should `MetaData`'s `size` field use?
