### PR TITLE
refactor: write buffer testing + better mocking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1677,6 +1677,7 @@ dependencies = [
  "tracker",
  "trogging",
  "uuid",
+ "write_buffer",
 ]
 
 [[package]]
@@ -4955,9 +4956,13 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "data_types",
+ "dotenv",
  "entry",
  "futures",
+ "parking_lot",
  "rdkafka",
+ "tokio",
+ "uuid",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -122,6 +122,7 @@ influxdb_iox_client = { path = "influxdb_iox_client", features = ["flight"] }
 test_helpers = { path = "test_helpers" }
 synchronized-writer = "1"
 parking_lot = "0.11.1"
+write_buffer = { path = "write_buffer" }
 
 # Crates.io dependencies, in alphabetical order
 assert_cmd = "1.0.0"

--- a/docker/Dockerfile.ci.integration
+++ b/docker/Dockerfile.ci.integration
@@ -21,4 +21,4 @@ ENV TEST_INTEGRATION=1
 ENV KAFKA_CONNECT=kafka:9092
 
 # Run the integration tests that connect to Kafka that will be running in another container
-CMD ["sh", "-c", "cargo test -p influxdb_iox --test end_to_end write_buffer -- --nocapture"]
+CMD ["sh", "-c", "./docker/integration_test.sh"]

--- a/docker/integration_test.sh
+++ b/docker/integration_test.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+cargo test -p write_buffer kafka -- --nocapture
+cargo test -p influxdb_iox --test end_to_end write_buffer -- --nocapture

--- a/entry/src/entry.rs
+++ b/entry/src/entry.rs
@@ -1716,7 +1716,7 @@ pub enum SequencedEntryError {
     },
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct SequencedEntry {
     entry: Entry,
     /// The (optional) sequence for this entry.  At the time of
@@ -1774,6 +1774,10 @@ impl SequencedEntry {
 
     pub fn sequence(&self) -> Option<&Sequence> {
         self.sequence.as_ref()
+    }
+
+    pub fn entry(&self) -> &Entry {
+        &self.entry
     }
 }
 

--- a/tests/end_to_end_cases/write_buffer.rs
+++ b/tests/end_to_end_cases/write_buffer.rs
@@ -15,54 +15,11 @@ use rdkafka::{
 };
 use std::convert::TryFrom;
 use test_helpers::assert_contains;
-
-/// If `TEST_INTEGRATION` and `KAFKA_CONNECT` are set, return the Kafka connection URL to the
-/// caller.
-///
-/// If `TEST_INTEGRATION` is set but `KAFKA_CONNECT` is not set, fail the tests and provide
-/// guidance for setting `KAFKA_CONNECTION`.
-///
-/// If `TEST_INTEGRATION` is not set, skip the calling test by returning early.
-macro_rules! maybe_skip_integration {
-    () => {{
-        use std::env;
-        dotenv::dotenv().ok();
-
-        match (
-            env::var("TEST_INTEGRATION").is_ok(),
-            env::var("KAFKA_CONNECT").ok(),
-        ) {
-            (true, Some(kafka_connection)) => kafka_connection,
-            (true, None) => {
-                panic!(
-                    "TEST_INTEGRATION is set which requires running integration tests, but \
-                     KAFKA_CONNECT is not set. Please run Kafka, perhaps by using the command \
-                     `docker-compose -f docker/ci-kafka-docker-compose.yml up kafka`, then \
-                     set KAFKA_CONNECT to the host and port where Kafka is accessible. If \
-                     running the `docker-compose` command and the Rust tests on the host, the \
-                     value for `KAFKA_CONNECT` should be `localhost:9093`. If running the Rust \
-                     tests in another container in the `docker-compose` network as on CI, \
-                     `KAFKA_CONNECT` should be `kafka:9092`."
-                )
-            }
-            (false, Some(_)) => {
-                eprintln!("skipping Kafka integration tests - set TEST_INTEGRATION to run");
-                return;
-            }
-            (false, None) => {
-                eprintln!(
-                    "skipping Kafka integration tests - set TEST_INTEGRATION and KAFKA_CONNECT to \
-                    run"
-                );
-                return;
-            }
-        }
-    }};
-}
+use write_buffer::maybe_skip_kafka_integration;
 
 #[tokio::test]
 async fn writes_go_to_kafka() {
-    let kafka_connection = maybe_skip_integration!();
+    let kafka_connection = maybe_skip_kafka_integration!();
 
     // set up a database with a write buffer pointing at kafka
     let server = ServerFixture::create_shared().await;
@@ -135,7 +92,7 @@ async fn produce_to_kafka_directly(
 
 #[tokio::test]
 async fn reads_come_from_kafka() {
-    let kafka_connection = maybe_skip_integration!();
+    let kafka_connection = maybe_skip_kafka_integration!();
 
     // set up a database to read from Kafka
     let server = ServerFixture::create_shared().await;
@@ -220,7 +177,7 @@ async fn reads_come_from_kafka() {
 
 #[tokio::test]
 async fn cant_write_to_db_reading_from_kafka() {
-    let kafka_connection = maybe_skip_integration!();
+    let kafka_connection = maybe_skip_kafka_integration!();
 
     // set up a database to read from Kafka
     let server = ServerFixture::create_shared().await;

--- a/write_buffer/Cargo.toml
+++ b/write_buffer/Cargo.toml
@@ -8,4 +8,10 @@ async-trait = "0.1"
 data_types = { path = "../data_types" }
 entry = { path = "../entry" }
 futures = "0.3"
+parking_lot = "0.11.1"
 rdkafka = "0.26.0"
+
+[dev-dependencies]
+dotenv = "0.15.0"
+tokio = { version = "1.0", features = ["macros", "fs"] }
+uuid = { version = "0.8", features = ["serde", "v4"] }

--- a/write_buffer/src/core.rs
+++ b/write_buffer/src/core.rs
@@ -11,9 +11,14 @@ pub type WriteBufferError = Box<dyn std::error::Error + Sync + Send>;
 /// entries from the Write Buffer at a later time.
 #[async_trait]
 pub trait WriteBufferWriting: Sync + Send + std::fmt::Debug + 'static {
-    /// Send an `Entry` to the write buffer and return information that can be used to restore
-    /// entries at a later time.
-    async fn store_entry(&self, entry: &Entry) -> Result<Sequence, WriteBufferError>;
+    /// Send an `Entry` to the write buffer using the specified sequencer ID.
+    ///
+    /// Returns information that can be used to restore entries at a later time.
+    async fn store_entry(
+        &self,
+        entry: &Entry,
+        sequencer_id: u32,
+    ) -> Result<Sequence, WriteBufferError>;
 }
 
 /// Produce a stream of `SequencedEntry` that a `Db` can add to the mutable buffer by using
@@ -25,4 +30,152 @@ pub trait WriteBufferReading: Sync + Send + std::fmt::Debug + 'static {
     where
         'life0: 'async_trait,
         Self: 'async_trait;
+}
+
+pub mod test_utils {
+    use async_trait::async_trait;
+    use entry::{test_helpers::lp_to_entry, Entry};
+    use futures::{StreamExt, TryStreamExt};
+
+    use super::{WriteBufferReading, WriteBufferWriting};
+
+    #[async_trait]
+    pub trait TestAdapter: Send + Sync {
+        type Context: TestContext;
+
+        async fn new_context(&self, n_sequencers: u32) -> Self::Context;
+    }
+
+    pub trait TestContext: Send + Sync {
+        type Writing: WriteBufferWriting;
+        type Reading: WriteBufferReading;
+
+        fn writing(&self) -> Self::Writing;
+
+        fn reading(&self) -> Self::Reading;
+    }
+
+    pub async fn perform_generic_tests<T>(adapter: T)
+    where
+        T: TestAdapter,
+    {
+        test_single_stream_io(&adapter).await;
+        test_multi_stream_io(&adapter).await;
+        test_multi_writer_multi_reader(&adapter).await;
+    }
+
+    async fn test_single_stream_io<T>(adapter: &T)
+    where
+        T: TestAdapter,
+    {
+        let context = adapter.new_context(1).await;
+
+        let entry_1 = lp_to_entry("upc user=1 100");
+        let entry_2 = lp_to_entry("upc user=2 200");
+        let entry_3 = lp_to_entry("upc user=3 300");
+
+        let writer = context.writing();
+        let reader = context.reading();
+
+        let mut stream = reader.stream();
+        let waker = futures::task::noop_waker();
+        let mut cx = futures::task::Context::from_waker(&waker);
+
+        // empty stream is pending
+        assert!(stream.poll_next_unpin(&mut cx).is_pending());
+
+        // adding content allows us to get results
+        writer.store_entry(&entry_1, 0).await.unwrap();
+        assert_eq!(stream.next().await.unwrap().unwrap().entry(), &entry_1);
+
+        // stream is pending again
+        assert!(stream.poll_next_unpin(&mut cx).is_pending());
+
+        // adding more data unblocks the stream
+        writer.store_entry(&entry_2, 0).await.unwrap();
+        writer.store_entry(&entry_3, 0).await.unwrap();
+        assert_eq!(stream.next().await.unwrap().unwrap().entry(), &entry_2);
+        assert_eq!(stream.next().await.unwrap().unwrap().entry(), &entry_3);
+
+        // stream is pending again
+        assert!(stream.poll_next_unpin(&mut cx).is_pending());
+    }
+
+    async fn test_multi_stream_io<T>(adapter: &T)
+    where
+        T: TestAdapter,
+    {
+        let context = adapter.new_context(1).await;
+
+        let entry_1 = lp_to_entry("upc user=1 100");
+        let entry_2 = lp_to_entry("upc user=2 200");
+        let entry_3 = lp_to_entry("upc user=3 300");
+
+        let writer = context.writing();
+        let reader = context.reading();
+
+        let mut stream_1 = reader.stream();
+        let mut stream_2 = reader.stream();
+        let waker = futures::task::noop_waker();
+        let mut cx = futures::task::Context::from_waker(&waker);
+
+        // empty streams is pending
+        assert!(stream_1.poll_next_unpin(&mut cx).is_pending());
+        assert!(stream_2.poll_next_unpin(&mut cx).is_pending());
+
+        // streams poll from same source
+        writer.store_entry(&entry_1, 0).await.unwrap();
+        writer.store_entry(&entry_2, 0).await.unwrap();
+        writer.store_entry(&entry_3, 0).await.unwrap();
+        assert_eq!(stream_1.next().await.unwrap().unwrap().entry(), &entry_1);
+        assert_eq!(stream_2.next().await.unwrap().unwrap().entry(), &entry_2);
+        assert_eq!(stream_1.next().await.unwrap().unwrap().entry(), &entry_3);
+
+        // stream1 is pending again
+        assert!(stream_1.poll_next_unpin(&mut cx).is_pending());
+        assert!(stream_2.poll_next_unpin(&mut cx).is_pending());
+    }
+
+    async fn test_multi_writer_multi_reader<T>(adapter: &T)
+    where
+        T: TestAdapter,
+    {
+        let context = adapter.new_context(2).await;
+
+        let entry_east_1 = lp_to_entry("upc,region=east user=1 100");
+        let entry_east_2 = lp_to_entry("upc,region=east user=2 200");
+        let entry_west_1 = lp_to_entry("upc,region=west user=1 200");
+
+        let writer_1 = context.writing();
+        let writer_2 = context.writing();
+        let reader_1 = context.reading();
+        let reader_2 = context.reading();
+
+        // TODO: do not hard-code sequencer IDs here but provide a proper interface
+        writer_1.store_entry(&entry_east_1, 0).await.unwrap();
+        writer_1.store_entry(&entry_west_1, 1).await.unwrap();
+        writer_2.store_entry(&entry_east_2, 0).await.unwrap();
+
+        assert_reader_content(reader_1, &[&entry_east_1, &entry_east_2, &entry_west_1]).await;
+        assert_reader_content(reader_2, &[&entry_east_1, &entry_east_2, &entry_west_1]).await;
+    }
+
+    async fn assert_reader_content<R>(reader: R, expected: &[&Entry])
+    where
+        R: WriteBufferReading,
+    {
+        // we need to limit the stream to `expected.len()` elements, otherwise it might be pending forever
+        let mut results: Vec<_> = reader
+            .stream()
+            .take(expected.len())
+            .try_collect()
+            .await
+            .unwrap();
+        results.sort_by_key(|entry| {
+            let sequence = entry.sequence().unwrap();
+            (sequence.id, sequence.number)
+        });
+        let actual: Vec<_> = results.iter().map(|entry| entry.entry()).collect();
+        assert_eq!(&actual[..], expected);
+    }
 }

--- a/write_buffer/src/core.rs
+++ b/write_buffer/src/core.rs
@@ -131,7 +131,7 @@ pub mod test_utils {
         assert_eq!(stream_2.next().await.unwrap().unwrap().entry(), &entry_2);
         assert_eq!(stream_1.next().await.unwrap().unwrap().entry(), &entry_3);
 
-        // stream1 is pending again
+        // both streams are pending again
         assert!(stream_1.poll_next_unpin(&mut cx).is_pending());
         assert!(stream_2.poll_next_unpin(&mut cx).is_pending());
     }

--- a/write_buffer/src/mock.rs
+++ b/write_buffer/src/mock.rs
@@ -1,4 +1,4 @@
-use std::sync::{Arc, Mutex};
+use std::{collections::BTreeMap, sync::Arc, task::Poll};
 
 use async_trait::async_trait;
 use entry::{Entry, Sequence, SequencedEntry};
@@ -6,25 +6,136 @@ use futures::{
     stream::{self, BoxStream},
     StreamExt,
 };
+use parking_lot::Mutex;
 
 use crate::core::{WriteBufferError, WriteBufferReading, WriteBufferWriting};
 
-#[derive(Debug, Default)]
+type EntryResVec = Vec<Result<SequencedEntry, WriteBufferError>>;
+
+/// Mocked entries for [`MockBufferForWriting`] and [`MockBufferForReading`].
+#[derive(Debug, Clone)]
+pub struct MockBufferSharedState {
+    entries: Arc<Mutex<BTreeMap<u32, EntryResVec>>>,
+}
+
+impl MockBufferSharedState {
+    /// Create new shared state w/ N sequencers.
+    pub fn empty_with_n_sequencers(n_sequencers: u32) -> Self {
+        let entries: BTreeMap<_, _> = (0..n_sequencers)
+            .map(|sequencer_id| (sequencer_id, vec![]))
+            .collect();
+
+        Self {
+            entries: Arc::new(Mutex::new(entries)),
+        }
+    }
+
+    /// Push a new entry to the specified sequencer.
+    ///
+    /// # Panics
+    /// - when given entry is not sequenced
+    /// - when specified sequencer does not exist
+    /// - when sequence number in entry is not larger the current maximum
+    pub fn push_entry(&self, entry: SequencedEntry) {
+        let sequence = entry.sequence().expect("entry must be sequenced");
+        let mut entries = self.entries.lock();
+        let entry_vec = entries.get_mut(&sequence.id).expect("invalid sequencer ID");
+        let max_sequence_number = entry_vec
+            .iter()
+            .filter_map(|entry_res| {
+                entry_res
+                    .as_ref()
+                    .ok()
+                    .map(|entry| entry.sequence().unwrap().number)
+            })
+            .max();
+        if let Some(max_sequence_number) = max_sequence_number {
+            assert!(
+                max_sequence_number < sequence.number,
+                "sequence number {} is less/equal than current max sequencer number {}",
+                sequence.number,
+                max_sequence_number
+            );
+        }
+        entry_vec.push(Ok(entry));
+    }
+
+    /// Push error to specified sequencer.
+    ///
+    /// # Panics
+    /// - when sequencer does not exist
+    pub fn push_error(&self, error: WriteBufferError, sequencer_id: u32) {
+        let mut entries = self.entries.lock();
+        let entry_vec = entries
+            .get_mut(&sequencer_id)
+            .expect("invalid sequencer ID");
+        entry_vec.push(Err(error));
+    }
+
+    /// Get messages (entries and errors) for specified sequencer.
+    ///
+    /// # Panics
+    /// - when sequencer does not exist
+    pub fn get_messages(&self, sequencer_id: u32) -> Vec<Result<SequencedEntry, WriteBufferError>> {
+        let mut entries = self.entries.lock();
+        let entry_vec = entries
+            .get_mut(&sequencer_id)
+            .expect("invalid sequencer ID");
+
+        entry_vec
+            .iter()
+            .map(|entry_res| match entry_res {
+                Ok(entry) => Ok(entry.clone()),
+                Err(e) => Err(e.to_string().into()),
+            })
+            .collect()
+    }
+}
+
+#[derive(Debug)]
 pub struct MockBufferForWriting {
-    pub entries: Arc<Mutex<Vec<Entry>>>,
+    state: MockBufferSharedState,
+}
+
+impl MockBufferForWriting {
+    pub fn new(state: MockBufferSharedState) -> Self {
+        Self { state }
+    }
 }
 
 #[async_trait]
 impl WriteBufferWriting for MockBufferForWriting {
-    async fn store_entry(&self, entry: &Entry) -> Result<Sequence, WriteBufferError> {
-        let mut entries = self.entries.lock().unwrap();
-        let offset = entries.len() as u64;
-        entries.push(entry.clone());
+    async fn store_entry(
+        &self,
+        entry: &Entry,
+        sequencer_id: u32,
+    ) -> Result<Sequence, WriteBufferError> {
+        let mut entries = self.state.entries.lock();
+        let sequencer_entries = entries.get_mut(&sequencer_id).unwrap();
 
-        Ok(Sequence {
-            id: 0,
-            number: offset,
-        })
+        let sequence_number = sequencer_entries
+            .iter()
+            .filter_map(|entry_res| {
+                entry_res
+                    .as_ref()
+                    .ok()
+                    .map(|entry| entry.sequence().unwrap().number)
+            })
+            .max()
+            .map(|n| n + 1)
+            .unwrap_or(0);
+
+        let sequence = Sequence {
+            id: sequencer_id,
+            number: sequence_number,
+        };
+        sequencer_entries.push(Ok(SequencedEntry::new_from_sequence(
+            sequence,
+            entry.clone(),
+        )
+        .unwrap()));
+
+        Ok(sequence)
     }
 }
 
@@ -33,7 +144,11 @@ pub struct MockBufferForWritingThatAlwaysErrors;
 
 #[async_trait]
 impl WriteBufferWriting for MockBufferForWritingThatAlwaysErrors {
-    async fn store_entry(&self, _entry: &Entry) -> Result<Sequence, WriteBufferError> {
+    async fn store_entry(
+        &self,
+        _entry: &Entry,
+        _sequencer_id: u32,
+    ) -> Result<Sequence, WriteBufferError> {
         Err(String::from(
             "Something bad happened on the way to writing an entry in the write buffer",
         )
@@ -41,22 +156,28 @@ impl WriteBufferWriting for MockBufferForWritingThatAlwaysErrors {
     }
 }
 
-type MoveableEntries = Arc<Mutex<Vec<Result<SequencedEntry, WriteBufferError>>>>;
 pub struct MockBufferForReading {
-    entries: MoveableEntries,
+    state: MockBufferSharedState,
+    positions: Arc<Mutex<BTreeMap<u32, usize>>>,
+}
+
+impl MockBufferForReading {
+    pub fn new(state: MockBufferSharedState) -> Self {
+        let n_sequencers = state.entries.lock().len() as u32;
+        let positions: BTreeMap<_, _> = (0..n_sequencers)
+            .map(|sequencer_id| (sequencer_id, 0))
+            .collect();
+
+        Self {
+            state,
+            positions: Arc::new(Mutex::new(positions)),
+        }
+    }
 }
 
 impl std::fmt::Debug for MockBufferForReading {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("MockBufferForReading").finish()
-    }
-}
-
-impl MockBufferForReading {
-    pub fn new(entries: Vec<Result<SequencedEntry, WriteBufferError>>) -> Self {
-        Self {
-            entries: Arc::new(Mutex::new(entries)),
-        }
     }
 }
 
@@ -68,11 +189,129 @@ impl WriteBufferReading for MockBufferForReading {
         'life0: 'async_trait,
         Self: 'async_trait,
     {
-        // move the entries out of `self` to move them into the stream
-        let entries: Vec<_> = self.entries.lock().unwrap().drain(..).collect();
+        let state = self.state.clone();
+        let positions = Arc::clone(&self.positions);
 
-        stream::iter(entries.into_iter())
-            .chain(stream::pending())
-            .boxed()
+        stream::poll_fn(move |_ctx| {
+            let entries = state.entries.lock();
+            let mut positions = positions.lock();
+
+            for (sequencer_id, position) in positions.iter_mut() {
+                let entry_vec = entries.get(sequencer_id).unwrap();
+                if entry_vec.len() > *position {
+                    let entry = match &entry_vec[*position] {
+                        Ok(entry) => Ok(entry.clone()),
+                        Err(e) => Err(e.to_string().into()),
+                    };
+                    *position += 1;
+                    return Poll::Ready(Some(entry));
+                }
+            }
+
+            Poll::Pending
+        })
+        .boxed()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use entry::test_helpers::lp_to_entry;
+
+    use crate::core::test_utils::{perform_generic_tests, TestAdapter, TestContext};
+
+    use super::*;
+
+    struct MockTestAdapter {}
+
+    #[async_trait]
+    impl TestAdapter for MockTestAdapter {
+        type Context = MockTestContext;
+
+        async fn new_context(&self, n_sequencers: u32) -> Self::Context {
+            MockTestContext {
+                state: MockBufferSharedState::empty_with_n_sequencers(n_sequencers),
+            }
+        }
+    }
+
+    struct MockTestContext {
+        state: MockBufferSharedState,
+    }
+
+    impl TestContext for MockTestContext {
+        type Writing = MockBufferForWriting;
+
+        type Reading = MockBufferForReading;
+
+        fn writing(&self) -> Self::Writing {
+            MockBufferForWriting::new(self.state.clone())
+        }
+
+        fn reading(&self) -> Self::Reading {
+            MockBufferForReading::new(self.state.clone())
+        }
+    }
+
+    #[tokio::test]
+    async fn test_generic() {
+        perform_generic_tests(MockTestAdapter {}).await;
+    }
+
+    #[test]
+    #[should_panic(expected = "entry must be sequenced")]
+    fn test_state_push_entry_panic_unsequenced() {
+        let state = MockBufferSharedState::empty_with_n_sequencers(2);
+        let entry = lp_to_entry("upc,region=east user=1 100");
+        state.push_entry(SequencedEntry::new_unsequenced(entry));
+    }
+
+    #[test]
+    #[should_panic(expected = "invalid sequencer ID")]
+    fn test_state_push_entry_panic_wrong_sequencer() {
+        let state = MockBufferSharedState::empty_with_n_sequencers(2);
+        let entry = lp_to_entry("upc,region=east user=1 100");
+        let sequence = Sequence::new(2, 0);
+        state.push_entry(SequencedEntry::new_from_sequence(sequence, entry).unwrap());
+    }
+
+    #[test]
+    #[should_panic(
+        expected = "sequence number 13 is less/equal than current max sequencer number 13"
+    )]
+    fn test_state_push_entry_panic_wrong_sequence_number_equal() {
+        let state = MockBufferSharedState::empty_with_n_sequencers(2);
+        let entry = lp_to_entry("upc,region=east user=1 100");
+        let sequence = Sequence::new(1, 13);
+        state.push_entry(SequencedEntry::new_from_sequence(sequence, entry.clone()).unwrap());
+        state.push_entry(SequencedEntry::new_from_sequence(sequence, entry).unwrap());
+    }
+
+    #[test]
+    #[should_panic(
+        expected = "sequence number 12 is less/equal than current max sequencer number 13"
+    )]
+    fn test_state_push_entry_panic_wrong_sequence_number_less() {
+        let state = MockBufferSharedState::empty_with_n_sequencers(2);
+        let entry = lp_to_entry("upc,region=east user=1 100");
+        let sequence_1 = Sequence::new(1, 13);
+        let sequence_2 = Sequence::new(1, 12);
+        state.push_entry(SequencedEntry::new_from_sequence(sequence_1, entry.clone()).unwrap());
+        state.push_entry(SequencedEntry::new_from_sequence(sequence_2, entry).unwrap());
+    }
+
+    #[test]
+    #[should_panic(expected = "invalid sequencer ID")]
+    fn test_state_push_error_panic_wrong_sequencer() {
+        let state = MockBufferSharedState::empty_with_n_sequencers(2);
+        let error = "foo".to_string().into();
+        state.push_error(error, 2);
+    }
+
+    #[test]
+    #[should_panic(expected = "invalid sequencer ID")]
+    fn test_state_get_messages_panic_wrong_sequencer() {
+        let state = MockBufferSharedState::empty_with_n_sequencers(2);
+        state.get_messages(2);
     }
 }


### PR DESCRIPTION
This refactors the write buffer a bit for:

- **Testing:** Add generic tests for the Kafka and the mocking
  implementation. The same interface can be used easily add new
  implementations (e.g. via Redis, filesystem, ...).
- **Partition on Write:** The caller of the writer operation must now
  specify the partition/sequencer ID. The implicit partitioning of the
  Kafka writer would have lead to broken data since we must never spill
  entries w/ the same primary key over multiple partitions. At the
  moment we will only use partition 0 but we can easily implement
  better logic in the future.
- **Improved Mocking:** The mocked implementation now simulates a system
  that feels more real. Especially the handling around multiple streams
  and "write while read" has been improved. This will be helpful for
  testing and for new features like seeking (during replay). A solid
  realistic mock also helps us to ensure that the tests using the mock
  do not rely on unrealistic behavior too much.
