### PR TITLE
fix: Kafka queueing

### DIFF
--- a/write_buffer/src/kafka.rs
+++ b/write_buffer/src/kafka.rs
@@ -70,6 +70,7 @@ impl KafkaBufferProducer {
         cfg.set("bootstrap.servers", &conn);
         cfg.set("message.timeout.ms", "5000");
         cfg.set("message.max.bytes", "10000000");
+        cfg.set("queue.buffering.max.kbytes", "10485760");
 
         let producer: FutureProducer = cfg.create()?;
 

--- a/write_buffer/src/kafka.rs
+++ b/write_buffer/src/kafka.rs
@@ -8,6 +8,7 @@ use rdkafka::{
     consumer::{Consumer, StreamConsumer},
     error::KafkaError,
     producer::{FutureProducer, FutureRecord},
+    util::Timeout,
     ClientConfig, Message,
 };
 
@@ -46,9 +47,8 @@ impl WriteBufferWriting for KafkaBufferProducer {
 
         let (partition, offset) = self
             .producer
-            .send_result(record)
-            .map_err(|(e, _future_record)| Box::new(e))?
-            .await?
+            .send(record, Timeout::Never)
+            .await
             .map_err(|(e, _owned_message)| Box::new(e))?;
 
         Ok(Sequence {


### PR DESCRIPTION
I have 2 changes that I think will help with #2007 (I'm hesitant to say "fixed" until we've tried this out). 

The first uses a different Rust method that will retry rather than return a `QueueFull` error, and I've told it to never time out.

The second change is to bump up the max size of the librdkafka producer queue so that we'll be retrying less, hopefully-- because we bumped up the max message size by a factor of 10, it makes sense to me to also bump up the max queue size by a factor of 10.

If you want to try these out separately, I'm happy to split into 2 PRs that we can merge at different times!