### PR TITLE
fix: Set acks=all for kafka writes

### DIFF
--- a/write_buffer/src/kafka.rs
+++ b/write_buffer/src/kafka.rs
@@ -76,7 +76,7 @@ impl KafkaBufferProducer {
         cfg.set("message.timeout.ms", "5000");
         cfg.set("message.max.bytes", "10000000");
         cfg.set("queue.buffering.max.kbytes", "10485760");
-        cfg.set("request.required.acks", "all");
+        cfg.set("request.required.acks", "all");  // equivalent to acks=-1
 
         let producer: FutureProducer = cfg.create()?;
 

--- a/write_buffer/src/kafka.rs
+++ b/write_buffer/src/kafka.rs
@@ -76,6 +76,7 @@ impl KafkaBufferProducer {
         cfg.set("message.timeout.ms", "5000");
         cfg.set("message.max.bytes", "10000000");
         cfg.set("queue.buffering.max.kbytes", "10485760");
+        cfg.set("request.required.acks", "all");
 
         let producer: FutureProducer = cfg.create()?;
 

--- a/write_buffer/src/kafka.rs
+++ b/write_buffer/src/kafka.rs
@@ -76,7 +76,7 @@ impl KafkaBufferProducer {
         cfg.set("message.timeout.ms", "5000");
         cfg.set("message.max.bytes", "10000000");
         cfg.set("queue.buffering.max.kbytes", "10485760");
-        cfg.set("request.required.acks", "all");  // equivalent to acks=-1
+        cfg.set("request.required.acks", "all"); // equivalent to acks=-1
 
         let producer: FutureProducer = cfg.create()?;
 


### PR DESCRIPTION
We're currently running with the default `acks=1`, which causes the replicas to fall out of sync at the minor bump on the road and never catch up again. acks=1 is not for the faint of heart