### PR TITLE
refactor: explicitly specify the type, more friendly to IDE

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -140,7 +140,7 @@ fn main() -> Result<(), std::io::Error> {
     // load all environment variables from .env before doing anything
     load_dotenv();
 
-    let config = Config::from_args();
+    let config: Config = StructOpt::from_args();
 
     let tokio_runtime = get_runtime(config.num_threads)?;
     tokio_runtime.block_on(async move {


### PR DESCRIPTION
`Config::from_args` from derive flag, and my IDE (CLion + IntelliJ Rust) doesn't recognize its type.

With explicity specify the type, developer can enjoy code highlight and other features from IDE.