### PR TITLE
refactor: use one stream per sequencer/partition

### DIFF
--- a/server/src/init.rs
+++ b/server/src/init.rs
@@ -530,11 +530,11 @@ impl InitStatus {
                 let rules = handle
                     .rules()
                     .expect("in this state rules should be loaded");
-                let write_buffer = WriteBufferConfig::new(handle.server_id(), &rules).context(
-                    CreateWriteBuffer {
+                let write_buffer = WriteBufferConfig::new(handle.server_id(), &rules)
+                    .await
+                    .context(CreateWriteBuffer {
                         config: rules.write_buffer_connection.clone(),
-                    },
-                )?;
+                    })?;
                 info!(write_buffer_enabled=?write_buffer.is_some(), db_name=rules.db_name(), "write buffer config");
 
                 handle

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -555,8 +555,9 @@ where
         .map_err(|e| Box::new(e) as _)
         .context(CannotCreatePreservedCatalog)?;
 
-        let write_buffer =
-            WriteBufferConfig::new(server_id, &rules).map_err(|e| Error::CreatingWriteBuffer {
+        let write_buffer = WriteBufferConfig::new(server_id, &rules)
+            .await
+            .map_err(|e| Error::CreatingWriteBuffer {
                 config: rules.write_buffer_connection.clone(),
                 source: e,
             })?;

--- a/write_buffer/Cargo.toml
+++ b/write_buffer/Cargo.toml
@@ -8,11 +8,11 @@ async-trait = "0.1"
 data_types = { path = "../data_types" }
 entry = { path = "../entry" }
 futures = "0.3"
+observability_deps = { path = "../observability_deps" }
 parking_lot = "0.11.1"
 rdkafka = "0.26.0"
-observability_deps = { path = "../observability_deps" }
+tokio = { version = "1.0", features = ["macros", "fs"] }
 
 [dev-dependencies]
 dotenv = "0.15.0"
-tokio = { version = "1.0", features = ["macros", "fs"] }
 uuid = { version = "0.8", features = ["serde", "v4"] }

--- a/write_buffer/src/config.rs
+++ b/write_buffer/src/config.rs
@@ -17,7 +17,7 @@ pub enum WriteBufferConfig {
 }
 
 impl WriteBufferConfig {
-    pub fn new(
+    pub async fn new(
         server_id: ServerId,
         rules: &DatabaseRules,
     ) -> Result<Option<Self>, WriteBufferError> {
@@ -34,7 +34,7 @@ impl WriteBufferConfig {
                 Ok(Some(Self::Writing(Arc::new(kafka_buffer) as _)))
             }
             Some(WriteBufferConnection::Reading(conn)) => {
-                let kafka_buffer = KafkaBufferConsumer::new(conn, server_id, name)?;
+                let kafka_buffer = KafkaBufferConsumer::new(conn, server_id, name).await?;
 
                 Ok(Some(Self::Reading(Arc::new(kafka_buffer) as _)))
             }

--- a/write_buffer/src/core.rs
+++ b/write_buffer/src/core.rs
@@ -7,7 +7,7 @@ use futures::stream::BoxStream;
 /// The dynamic boxing makes it easier to deal with error from different implementations.
 pub type WriteBufferError = Box<dyn std::error::Error + Sync + Send>;
 
-/// Writing to a Write Buffer takes an `Entry` and returns `Sequence` data that facilitates reading
+/// Writing to a Write Buffer takes an [`Entry`] and returns [`Sequence`] data that facilitates reading
 /// entries from the Write Buffer at a later time.
 #[async_trait]
 pub trait WriteBufferWriting: Sync + Send + std::fmt::Debug + 'static {
@@ -21,12 +21,13 @@ pub trait WriteBufferWriting: Sync + Send + std::fmt::Debug + 'static {
     ) -> Result<Sequence, WriteBufferError>;
 }
 
-/// Produce a stream of `SequencedEntry` that a `Db` can add to the mutable buffer by using
-/// `Db::stream_in_sequenced_entries`.
+/// Output stream of [`WriteBufferReading`].
+pub type EntryStream<'a> = BoxStream<'a, Result<SequencedEntry, WriteBufferError>>;
+
+/// Produce streams (one per sequencer) of [`SequencedEntry`]s.
 pub trait WriteBufferReading: Sync + Send + std::fmt::Debug + 'static {
-    fn stream<'life0, 'async_trait>(
-        &'life0 self,
-    ) -> BoxStream<'async_trait, Result<SequencedEntry, WriteBufferError>>
+    /// Returns a stream per sequencer.
+    fn streams<'life0, 'async_trait>(&'life0 self) -> Vec<(u32, EntryStream<'async_trait>)>
     where
         'life0: 'async_trait,
         Self: 'async_trait;
@@ -46,13 +47,14 @@ pub mod test_utils {
         async fn new_context(&self, n_sequencers: u32) -> Self::Context;
     }
 
+    #[async_trait]
     pub trait TestContext: Send + Sync {
         type Writing: WriteBufferWriting;
         type Reading: WriteBufferReading;
 
         fn writing(&self) -> Self::Writing;
 
-        fn reading(&self) -> Self::Reading;
+        async fn reading(&self) -> Self::Reading;
     }
 
     pub async fn perform_generic_tests<T>(adapter: T)
@@ -61,6 +63,7 @@ pub mod test_utils {
     {
         test_single_stream_io(&adapter).await;
         test_multi_stream_io(&adapter).await;
+        test_multi_sequencer_io(&adapter).await;
         test_multi_writer_multi_reader(&adapter).await;
     }
 
@@ -75,9 +78,12 @@ pub mod test_utils {
         let entry_3 = lp_to_entry("upc user=3 300");
 
         let writer = context.writing();
-        let reader = context.reading();
+        let reader = context.reading().await;
 
-        let mut stream = reader.stream();
+        let mut streams = reader.streams();
+        assert_eq!(streams.len(), 1);
+        let (sequencer_id, mut stream) = streams.pop().unwrap();
+
         let waker = futures::task::noop_waker();
         let mut cx = futures::task::Context::from_waker(&waker);
 
@@ -85,20 +91,64 @@ pub mod test_utils {
         assert!(stream.poll_next_unpin(&mut cx).is_pending());
 
         // adding content allows us to get results
-        writer.store_entry(&entry_1, 0).await.unwrap();
+        writer.store_entry(&entry_1, sequencer_id).await.unwrap();
         assert_eq!(stream.next().await.unwrap().unwrap().entry(), &entry_1);
 
         // stream is pending again
         assert!(stream.poll_next_unpin(&mut cx).is_pending());
 
         // adding more data unblocks the stream
-        writer.store_entry(&entry_2, 0).await.unwrap();
-        writer.store_entry(&entry_3, 0).await.unwrap();
+        writer.store_entry(&entry_2, sequencer_id).await.unwrap();
+        writer.store_entry(&entry_3, sequencer_id).await.unwrap();
         assert_eq!(stream.next().await.unwrap().unwrap().entry(), &entry_2);
         assert_eq!(stream.next().await.unwrap().unwrap().entry(), &entry_3);
 
         // stream is pending again
         assert!(stream.poll_next_unpin(&mut cx).is_pending());
+    }
+
+    async fn test_multi_sequencer_io<T>(adapter: &T)
+    where
+        T: TestAdapter,
+    {
+        let context = adapter.new_context(2).await;
+
+        let entry_1 = lp_to_entry("upc user=1 100");
+        let entry_2 = lp_to_entry("upc user=2 200");
+        let entry_3 = lp_to_entry("upc user=3 300");
+
+        let writer = context.writing();
+        let reader = context.reading().await;
+
+        let mut streams = reader.streams();
+        assert_eq!(streams.len(), 2);
+        let (sequencer_id_1, mut stream_1) = streams.pop().unwrap();
+        let (sequencer_id_2, mut stream_2) = streams.pop().unwrap();
+        assert_ne!(sequencer_id_1, sequencer_id_2);
+
+        let waker = futures::task::noop_waker();
+        let mut cx = futures::task::Context::from_waker(&waker);
+
+        // empty streams are pending
+        assert!(stream_1.poll_next_unpin(&mut cx).is_pending());
+        assert!(stream_2.poll_next_unpin(&mut cx).is_pending());
+
+        // entries arrive at the right target stream
+        writer.store_entry(&entry_1, sequencer_id_1).await.unwrap();
+        assert_eq!(stream_1.next().await.unwrap().unwrap().entry(), &entry_1);
+        assert!(stream_2.poll_next_unpin(&mut cx).is_pending());
+
+        writer.store_entry(&entry_2, sequencer_id_2).await.unwrap();
+        assert!(stream_1.poll_next_unpin(&mut cx).is_pending());
+        assert_eq!(stream_2.next().await.unwrap().unwrap().entry(), &entry_2);
+
+        writer.store_entry(&entry_3, sequencer_id_1).await.unwrap();
+        assert!(stream_2.poll_next_unpin(&mut cx).is_pending());
+        assert_eq!(stream_1.next().await.unwrap().unwrap().entry(), &entry_3);
+
+        // streams are pending again
+        assert!(stream_1.poll_next_unpin(&mut cx).is_pending());
+        assert!(stream_2.poll_next_unpin(&mut cx).is_pending());
     }
 
     async fn test_multi_stream_io<T>(adapter: &T)
@@ -112,10 +162,16 @@ pub mod test_utils {
         let entry_3 = lp_to_entry("upc user=3 300");
 
         let writer = context.writing();
-        let reader = context.reading();
+        let reader = context.reading().await;
 
-        let mut stream_1 = reader.stream();
-        let mut stream_2 = reader.stream();
+        let mut streams_1 = reader.streams();
+        let mut streams_2 = reader.streams();
+        assert_eq!(streams_1.len(), 1);
+        assert_eq!(streams_2.len(), 1);
+        let (sequencer_id_1, mut stream_1) = streams_1.pop().unwrap();
+        let (sequencer_id_2, mut stream_2) = streams_2.pop().unwrap();
+        assert_eq!(sequencer_id_1, sequencer_id_2);
+
         let waker = futures::task::noop_waker();
         let mut cx = futures::task::Context::from_waker(&waker);
 
@@ -124,9 +180,9 @@ pub mod test_utils {
         assert!(stream_2.poll_next_unpin(&mut cx).is_pending());
 
         // streams poll from same source
-        writer.store_entry(&entry_1, 0).await.unwrap();
-        writer.store_entry(&entry_2, 0).await.unwrap();
-        writer.store_entry(&entry_3, 0).await.unwrap();
+        writer.store_entry(&entry_1, sequencer_id_1).await.unwrap();
+        writer.store_entry(&entry_2, sequencer_id_1).await.unwrap();
+        writer.store_entry(&entry_3, sequencer_id_1).await.unwrap();
         assert_eq!(stream_1.next().await.unwrap().unwrap().entry(), &entry_1);
         assert_eq!(stream_2.next().await.unwrap().unwrap().entry(), &entry_2);
         assert_eq!(stream_1.next().await.unwrap().unwrap().entry(), &entry_3);
@@ -148,34 +204,51 @@ pub mod test_utils {
 
         let writer_1 = context.writing();
         let writer_2 = context.writing();
-        let reader_1 = context.reading();
-        let reader_2 = context.reading();
+        let reader_1 = context.reading().await;
+        let reader_2 = context.reading().await;
 
         // TODO: do not hard-code sequencer IDs here but provide a proper interface
         writer_1.store_entry(&entry_east_1, 0).await.unwrap();
         writer_1.store_entry(&entry_west_1, 1).await.unwrap();
         writer_2.store_entry(&entry_east_2, 0).await.unwrap();
 
-        assert_reader_content(reader_1, &[&entry_east_1, &entry_east_2, &entry_west_1]).await;
-        assert_reader_content(reader_2, &[&entry_east_1, &entry_east_2, &entry_west_1]).await;
+        assert_reader_content(
+            reader_1,
+            &[(0, &[&entry_east_1, &entry_east_2]), (1, &[&entry_west_1])],
+        )
+        .await;
+        assert_reader_content(
+            reader_2,
+            &[(0, &[&entry_east_1, &entry_east_2]), (1, &[&entry_west_1])],
+        )
+        .await;
     }
 
-    async fn assert_reader_content<R>(reader: R, expected: &[&Entry])
+    async fn assert_reader_content<R>(reader: R, expected: &[(u32, &[&Entry])])
     where
         R: WriteBufferReading,
     {
-        // we need to limit the stream to `expected.len()` elements, otherwise it might be pending forever
-        let mut results: Vec<_> = reader
-            .stream()
-            .take(expected.len())
-            .try_collect()
-            .await
-            .unwrap();
-        results.sort_by_key(|entry| {
-            let sequence = entry.sequence().unwrap();
-            (sequence.id, sequence.number)
-        });
-        let actual: Vec<_> = results.iter().map(|entry| entry.entry()).collect();
-        assert_eq!(&actual[..], expected);
+        let mut streams = reader.streams();
+        assert_eq!(streams.len(), expected.len());
+        streams.sort_by_key(|(sequencer_id, _stream)| *sequencer_id);
+
+        for ((actual_sequencer_id, actual_stream), (expected_sequencer_id, expected_entries)) in
+            streams.into_iter().zip(expected.iter())
+        {
+            assert_eq!(actual_sequencer_id, *expected_sequencer_id);
+
+            // we need to limit the stream to `expected.len()` elements, otherwise it might be pending forever
+            let mut results: Vec<_> = actual_stream
+                .take(expected_entries.len())
+                .try_collect()
+                .await
+                .unwrap();
+            results.sort_by_key(|entry| {
+                let sequence = entry.sequence().unwrap();
+                (sequence.id, sequence.number)
+            });
+            let actual_entries: Vec<_> = results.iter().map(|entry| entry.entry()).collect();
+            assert_eq!(&&actual_entries[..], expected_entries);
+        }
     }
 }


### PR DESCRIPTION
Advantages are:

- for large DBs w/ many partitions we can ingest data in-parallel
- on top of this change we can implement per-sequencer seeking, which is
  required for replay
