### PR TITLE
feat: add per-db in-memory compaction limiter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -824,6 +824,7 @@ version = "0.1.0"
 dependencies = [
  "chrono",
  "influxdb_line_protocol",
+ "num_cpus",
  "observability_deps",
  "percent-encoding",
  "regex",
@@ -1278,6 +1279,7 @@ dependencies = [
  "data_types",
  "futures",
  "google_types",
+ "num_cpus",
  "observability_deps",
  "proc-macro2",
  "prost",

--- a/data_types/Cargo.toml
+++ b/data_types/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 [dependencies] # In alphabetical order
 chrono = { version = "0.4", features = ["serde"] }
 influxdb_line_protocol = { path = "../influxdb_line_protocol" }
+num_cpus = "1.13.0"
 percent-encoding = "2.1.0"
 regex = "1.4"
 serde = { version = "1.0", features = ["rc", "derive"] }

--- a/data_types/src/database_rules.rs
+++ b/data_types/src/database_rules.rs
@@ -118,6 +118,7 @@ pub const DEFAULT_MUB_ROW_THRESHOLD: usize = 100_000;
 pub const DEFAULT_PERSIST_ROW_THRESHOLD: usize = 1_000_000;
 pub const DEFAULT_PERSIST_AGE_THRESHOLD_SECONDS: u32 = 30 * 60;
 pub const DEFAULT_LATE_ARRIVE_WINDOW_SECONDS: u32 = 5 * 60;
+pub const DEFAULT_MAX_ACTIVE_COMPACTIONS: u32 = 14;
 
 /// Configures how data automatically flows through the system
 #[derive(Debug, Eq, PartialEq, Clone)]
@@ -143,6 +144,11 @@ pub struct LifecycleRules {
     /// If the background worker doesn't find anything to do it
     /// will sleep for this many milliseconds before looking again
     pub worker_backoff_millis: NonZeroU64,
+
+    /// The maximum number of permitted concurrently executing compactions.
+    /// It is not currently possible to set a limit that disables compactions
+    /// entirely, nor is it possible to set an "unlimited" value.
+    pub max_active_compactions: NonZeroU32,
 
     /// After how many transactions should IOx write a new checkpoint?
     pub catalog_transactions_until_checkpoint: NonZeroU64,
@@ -179,6 +185,7 @@ impl Default for LifecycleRules {
             persist: false,
             immutable: false,
             worker_backoff_millis: NonZeroU64::new(DEFAULT_WORKER_BACKOFF_MILLIS).unwrap(),
+            max_active_compactions: NonZeroU32::new(DEFAULT_MAX_ACTIVE_COMPACTIONS).unwrap(),
             catalog_transactions_until_checkpoint: NonZeroU64::new(
                 DEFAULT_CATALOG_TRANSACTIONS_UNTIL_CHECKPOINT,
             )

--- a/data_types/src/database_rules.rs
+++ b/data_types/src/database_rules.rs
@@ -118,7 +118,6 @@ pub const DEFAULT_MUB_ROW_THRESHOLD: usize = 100_000;
 pub const DEFAULT_PERSIST_ROW_THRESHOLD: usize = 1_000_000;
 pub const DEFAULT_PERSIST_AGE_THRESHOLD_SECONDS: u32 = 30 * 60;
 pub const DEFAULT_LATE_ARRIVE_WINDOW_SECONDS: u32 = 5 * 60;
-pub const DEFAULT_MAX_ACTIVE_COMPACTIONS: u32 = 14;
 
 /// Configures how data automatically flows through the system
 #[derive(Debug, Eq, PartialEq, Clone)]
@@ -185,7 +184,7 @@ impl Default for LifecycleRules {
             persist: false,
             immutable: false,
             worker_backoff_millis: NonZeroU64::new(DEFAULT_WORKER_BACKOFF_MILLIS).unwrap(),
-            max_active_compactions: NonZeroU32::new(DEFAULT_MAX_ACTIVE_COMPACTIONS).unwrap(),
+            max_active_compactions: NonZeroU32::new(num_cpus::get() as u32).unwrap(), // defaults to number of CPU threads
             catalog_transactions_until_checkpoint: NonZeroU64::new(
                 DEFAULT_CATALOG_TRANSACTIONS_UNTIL_CHECKPOINT,
             )

--- a/generated_types/Cargo.toml
+++ b/generated_types/Cargo.toml
@@ -13,6 +13,7 @@ data_types = { path = "../data_types" }
 futures = "0.3"
 google_types = { path = "../google_types" }
 observability_deps = { path = "../observability_deps" }
+num_cpus = "1.13.0"
 prost = "0.7"
 prost-types = "0.7"
 regex = "1.4"

--- a/generated_types/protos/influxdata/iox/management/v1/database_rules.proto
+++ b/generated_types/protos/influxdata/iox/management/v1/database_rules.proto
@@ -76,6 +76,12 @@ message LifecycleRules {
 
   // Maximum number of rows to buffer in a MUB chunk before compacting it
   uint64 mub_row_threshold = 15;
+
+  // The maximum number of concurrent active compactions that can run.
+  //
+  // If 0, compactions are limited to the default number.
+  // See data_types::database_rules::DEFAULT_MAX_ACTIVE_COMPACTIONS
+  uint32 max_active_compactions = 16;
 }
 
 message DatabaseRules {

--- a/generated_types/src/database_rules/lifecycle.rs
+++ b/generated_types/src/database_rules/lifecycle.rs
@@ -3,7 +3,7 @@ use std::num::{NonZeroU32, NonZeroU64, NonZeroUsize};
 
 use data_types::database_rules::{
     LifecycleRules, DEFAULT_CATALOG_TRANSACTIONS_UNTIL_CHECKPOINT,
-    DEFAULT_LATE_ARRIVE_WINDOW_SECONDS, DEFAULT_MUB_ROW_THRESHOLD,
+    DEFAULT_LATE_ARRIVE_WINDOW_SECONDS, DEFAULT_MAX_ACTIVE_COMPACTIONS, DEFAULT_MUB_ROW_THRESHOLD,
     DEFAULT_PERSIST_AGE_THRESHOLD_SECONDS, DEFAULT_PERSIST_ROW_THRESHOLD,
     DEFAULT_WORKER_BACKOFF_MILLIS,
 };
@@ -27,6 +27,7 @@ impl From<LifecycleRules> for management::LifecycleRules {
             persist: config.persist,
             immutable: config.immutable,
             worker_backoff_millis: config.worker_backoff_millis.get(),
+            max_active_compactions: config.max_active_compactions.get(),
             catalog_transactions_until_checkpoint: config
                 .catalog_transactions_until_checkpoint
                 .get(),
@@ -50,6 +51,8 @@ impl TryFrom<management::LifecycleRules> for LifecycleRules {
             immutable: proto.immutable,
             worker_backoff_millis: NonZeroU64::new(proto.worker_backoff_millis)
                 .unwrap_or_else(|| NonZeroU64::new(DEFAULT_WORKER_BACKOFF_MILLIS).unwrap()),
+            max_active_compactions: NonZeroU32::new(proto.max_active_compactions)
+                .unwrap_or_else(|| NonZeroU32::new(DEFAULT_MAX_ACTIVE_COMPACTIONS).unwrap()),
             catalog_transactions_until_checkpoint: NonZeroU64::new(
                 proto.catalog_transactions_until_checkpoint,
             )
@@ -84,6 +87,7 @@ mod tests {
             persist: true,
             immutable: true,
             worker_backoff_millis: 1000,
+            max_active_compactions: 8,
             catalog_transactions_until_checkpoint: 10,
             late_arrive_window_seconds: 23,
             persist_row_threshold: 57,
@@ -110,6 +114,7 @@ mod tests {
         assert_eq!(back.drop_non_persisted, protobuf.drop_non_persisted);
         assert_eq!(back.immutable, protobuf.immutable);
         assert_eq!(back.worker_backoff_millis, protobuf.worker_backoff_millis);
+        assert_eq!(back.max_active_compactions, protobuf.max_active_compactions);
         assert_eq!(
             back.late_arrive_window_seconds,
             protobuf.late_arrive_window_seconds

--- a/generated_types/src/database_rules/lifecycle.rs
+++ b/generated_types/src/database_rules/lifecycle.rs
@@ -3,7 +3,7 @@ use std::num::{NonZeroU32, NonZeroU64, NonZeroUsize};
 
 use data_types::database_rules::{
     LifecycleRules, DEFAULT_CATALOG_TRANSACTIONS_UNTIL_CHECKPOINT,
-    DEFAULT_LATE_ARRIVE_WINDOW_SECONDS, DEFAULT_MAX_ACTIVE_COMPACTIONS, DEFAULT_MUB_ROW_THRESHOLD,
+    DEFAULT_LATE_ARRIVE_WINDOW_SECONDS, DEFAULT_MUB_ROW_THRESHOLD,
     DEFAULT_PERSIST_AGE_THRESHOLD_SECONDS, DEFAULT_PERSIST_ROW_THRESHOLD,
     DEFAULT_WORKER_BACKOFF_MILLIS,
 };
@@ -52,7 +52,7 @@ impl TryFrom<management::LifecycleRules> for LifecycleRules {
             worker_backoff_millis: NonZeroU64::new(proto.worker_backoff_millis)
                 .unwrap_or_else(|| NonZeroU64::new(DEFAULT_WORKER_BACKOFF_MILLIS).unwrap()),
             max_active_compactions: NonZeroU32::new(proto.max_active_compactions)
-                .unwrap_or_else(|| NonZeroU32::new(DEFAULT_MAX_ACTIVE_COMPACTIONS).unwrap()),
+                .unwrap_or_else(|| NonZeroU32::new(num_cpus::get() as u32).unwrap()), // default to num CPU threads
             catalog_transactions_until_checkpoint: NonZeroU64::new(
                 proto.catalog_transactions_until_checkpoint,
             )

--- a/lifecycle/src/policy.rs
+++ b/lifecycle/src/policy.rs
@@ -530,12 +530,13 @@ where
         // Clear out completed tasks
         let mut completed_compactions = 0;
         self.trackers.retain(|x| {
-            if x.is_complete() && matches!(x.metadata(), ChunkLifecycleAction::Compacting) {
+            let completed = x.is_complete();
+            if completed && matches!(x.metadata(), ChunkLifecycleAction::Compacting) {
                 // free up slot for another compaction
                 completed_compactions += 1;
             }
 
-            !x.is_complete()
+            !completed
         });
 
         // update active compactions

--- a/lifecycle/src/policy.rs
+++ b/lifecycle/src/policy.rs
@@ -255,7 +255,6 @@ where
 
         if to_compact.len() >= 2 || has_mub_snapshot {
             // caller's responsibility to determine if we can maybe compact.
-
             assert!(self.active_compactions < rules.max_active_compactions.get() as usize);
 
             // Upgrade partition first

--- a/lifecycle/src/policy.rs
+++ b/lifecycle/src/policy.rs
@@ -30,6 +30,9 @@ where
     /// The `LifecycleDb` this policy is automating
     db: M,
 
+    /// The current number of active compactions.
+    active_compactions: usize,
+
     /// Background tasks spawned by this `LifecyclePolicy`
     trackers: Vec<TaskTracker<ChunkLifecycleAction>>,
 }
@@ -42,6 +45,7 @@ where
         Self {
             db,
             trackers: vec![],
+            active_compactions: 0,
         }
     }
 
@@ -250,6 +254,10 @@ where
         }
 
         if to_compact.len() >= 2 || has_mub_snapshot {
+            // caller's responsibility to determine if we can maybe compact.
+
+            assert!(self.active_compactions < rules.max_active_compactions.get() as usize);
+
             // Upgrade partition first
             let partition = partition.upgrade();
             let chunks = to_compact
@@ -261,6 +269,7 @@ where
                 .expect("failed to compact chunks")
                 .with_metadata(ChunkLifecycleAction::Compacting);
 
+            self.active_compactions += 1;
             self.trackers.push(tracker);
         }
     }
@@ -475,17 +484,39 @@ where
             // if the criteria for persistence have been satisfied,
             // but persistence cannot proceed because of in-progress
             // compactions
-            let stall_compaction = if rules.persist {
-                self.maybe_persist_chunks(&db_name, partition, &rules, now_instant)
+            let stall_compaction_persisting = if rules.persist {
+                let persisting =
+                    self.maybe_persist_chunks(&db_name, partition, &rules, now_instant);
+                if persisting {
+                    debug!(%db_name, %partition, reason="persisting", "stalling compaction");
+                }
+                persisting
             } else {
                 false
             };
 
-            if !stall_compaction {
-                self.maybe_compact_chunks(partition, &rules, now);
-            } else {
-                debug!(%db_name, %partition, "stalling compaction to allow persist");
+            // Until we have a more sophisticated compaction policy that can
+            // allocate resources appropriately, we limit the number of
+            // compactions that may run concurrently. Compactions are
+            // completely disabled if max_compactions is Some(0), whilst if
+            // it is None then the compaction limiter is disabled (unlimited
+            // concurrent compactions).
+            let stall_compaction_no_slots = {
+                let max_compactions = self.db.rules().max_active_compactions.get();
+                let slots_full = self.active_compactions >= max_compactions as usize;
+                if slots_full {
+                    debug!(%db_name, %partition, ?max_compactions, reason="slots_full", "stalling compaction");
+                }
+                slots_full
+            };
+
+            // conditions where no compactions will be scheduled.
+            if stall_compaction_persisting || stall_compaction_no_slots {
+                continue;
             }
+
+            // possibly do a compaction
+            self.maybe_compact_chunks(partition, &rules, now);
         }
 
         if let Some(soft_limit) = rules.buffer_size_soft {
@@ -498,7 +529,24 @@ where
         }
 
         // Clear out completed tasks
-        self.trackers.retain(|x| !x.is_complete());
+        let mut completed_compactions = 0;
+        self.trackers.retain(|x| {
+            if x.is_complete() && matches!(x.metadata(), ChunkLifecycleAction::Compacting) {
+                // free up slot for another compaction
+                completed_compactions += 1;
+            }
+
+            !x.is_complete()
+        });
+
+        // update active compactions
+        if completed_compactions > 0 {
+            debug!(?completed_compactions, active_compactions=?self.active_compactions,
+                max_compactions=?self.db.rules().max_active_compactions, "releasing compaction slots")
+        }
+
+        assert!(completed_compactions <= self.active_compactions);
+        self.active_compactions -= completed_compactions;
 
         let tracker_fut = match self.trackers.is_empty() {
             false => futures::future::Either::Left(futures::future::select_all(
@@ -1435,6 +1483,52 @@ mod tests {
         db.events.write().clear();
         lifecycle.check_for_work(now, Instant::now());
         assert_eq!(*db.events.read(), vec![MoverEvents::Compact(vec![17, 18])]);
+    }
+
+    #[test]
+    fn test_compaction_limiter() {
+        let rules = LifecycleRules {
+            max_active_compactions: 2.try_into().unwrap(),
+            ..Default::default()
+        };
+
+        let now = from_secs(50);
+        let partitions = vec![
+            TestPartition::new(vec![
+                // closed => can compact
+                TestChunk::new(0, Some(0), Some(20), ChunkStorage::ClosedMutableBuffer),
+                // closed => can compact
+                TestChunk::new(10, Some(0), Some(30), ChunkStorage::ClosedMutableBuffer),
+                // closed => can compact
+                TestChunk::new(12, Some(0), Some(40), ChunkStorage::ClosedMutableBuffer),
+            ]),
+            TestPartition::new(vec![
+                // closed => can compact
+                TestChunk::new(1, Some(0), Some(20), ChunkStorage::ClosedMutableBuffer),
+            ]),
+            TestPartition::new(vec![
+                // closed => can compact
+                TestChunk::new(200, Some(0), Some(10), ChunkStorage::ClosedMutableBuffer),
+            ]),
+        ];
+
+        let db = TestDb::from_partitions(rules, partitions);
+        let mut lifecycle = LifecyclePolicy::new(&db);
+
+        lifecycle.check_for_work(now, Instant::now());
+        assert_eq!(
+            *db.events.read(),
+            vec![
+                MoverEvents::Compact(vec![0, 10, 12]),
+                MoverEvents::Compact(vec![1]),
+            ],
+        );
+
+        db.events.write().clear();
+
+        // Compaction slots freed up, other partition can now compact.
+        lifecycle.check_for_work(now, Instant::now());
+        assert_eq!(*db.events.read(), vec![MoverEvents::Compact(vec![200]),],);
     }
 
     #[test]

--- a/src/commands/database.rs
+++ b/src/commands/database.rs
@@ -185,6 +185,7 @@ pub async fn command(url: String, config: Config) -> Result<()> {
                     persist: command.persist,
                     immutable: command.immutable,
                     worker_backoff_millis: Default::default(),
+                    max_active_compactions: Default::default(),
                     catalog_transactions_until_checkpoint: command
                         .catalog_transactions_until_checkpoint
                         .get(),

--- a/tests/end_to_end_cases/management_api.rs
+++ b/tests/end_to_end_cases/management_api.rs
@@ -218,6 +218,7 @@ async fn test_create_get_update_database() {
             catalog_transactions_until_checkpoint: 13,
             late_arrive_window_seconds: 423,
             worker_backoff_millis: 15,
+            max_active_compactions: 8,
             persist_row_threshold: 342,
             persist_age_threshold_seconds: 700,
             mub_row_threshold: 1343,


### PR DESCRIPTION
Hopefully closes out https://github.com/influxdata/influxdb_iox/issues/1983.

## Rationale

Currently IOx does not place any limits on the number of in-memory compactions that can run concurrently. Given compactions happen on a per-partition basis, and given the large numbers of partitions driven by many IOx tables/measurements, it is common to see this sort of thing:

```
⇒  ./target/debug/influxdb_iox --host http://Alameda.local:1234 database query mydb "select count(*), storage, lifecycle_action from system.chunks group by storage,lifecycle_action"
+-----------------+---------------------+------------------+
| COUNT(UInt8(1)) | storage             | lifecycle_action |
+-----------------+---------------------+------------------+
| 649             | OpenMutableBuffer   |                  |
| 168             | ClosedMutableBuffer | Compacting       |
| 147             | ReadBuffer          | Compacting       |
+-----------------+---------------------+------------------+
```

An IOx in-memory compaction is effectively a piece of CPU (or memory) bound work. At this point in time I would put money on it being CPU-bound. Compactions run on the "data re-organisation" tokio executor. Having hundreds of them running at once is likely to reduce the overall performance of compactions because it is a lot less efficient to move work on and off CPU constantly, than to run it to completion on the thread.

Of course, there are advantages to yielding long-running work periodically, e.g., when you want to consider the tail latencies of all the queued up work. However, given compactions are effectively _background work_, with nobody directly waiting on them, I think that it makes a lot more sense to process them to completion before starting on the next (across as many threads as are available in the executor pool).

## Approach

This PR adds a _compaction limiter_ to a database's rules/config, via  a `max_active_compactions` field. Right now it defaults to `14`, but in the future it might make more sense to default it to the number of threads available on the data reorganisation execution pool.

The logic is encapsulated in the current Data Lifecycle manager. As we check for any outstanding work to do we also check how many active compactions are happening within the DB. We do not let any more compactions start if we have reached the limit of `max_active_compactions`. 

When we clear out completed trackers we check for any completed compactions and free up available slots for other compactions to start the next time we check for work.