### PR TITLE
feat(iox): Make max http request size configurable

### DIFF
--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -231,6 +231,14 @@ Possible values (case insensitive):
         default_value = "serving"
     )]
     pub initial_serving_state: ServingReadinessState,
+
+    /// Maximum size of HTTP requests.
+    #[structopt(
+        long = "--max-http-request-size",
+        env = "INFLUXDB_IOX_MAX_HTTP_REQUEST_SIZE",
+        default_value = "10485760" // 10 MiB
+    )]
+    pub max_http_request_size: usize,
 }
 
 pub async fn command(config: Config) -> Result<()> {

--- a/src/influxdb_ioxd.rs
+++ b/src/influxdb_ioxd.rs
@@ -195,7 +195,15 @@ pub async fn main(config: Config) -> Result<()> {
     let bind_addr = config.http_bind_address;
     let addr = AddrIncoming::bind(&bind_addr).context(StartListeningHttp { bind_addr })?;
 
-    let http_server = http::serve(addr, Arc::clone(&app_server), frontend_shutdown.clone()).fuse();
+    let max_http_request_size = config.max_http_request_size;
+
+    let http_server = http::serve(
+        addr,
+        Arc::clone(&app_server),
+        frontend_shutdown.clone(),
+        max_http_request_size,
+    )
+    .fuse();
     info!(bind_address=?bind_addr, "HTTP server listening");
 
     info!(git_hash, "InfluxDB IOx server ready");


### PR DESCRIPTION
In prod we see some requests which decompress into 22MB. Let's allow users to configure the maximum request size.