### PR TITLE
feat: add parquet cache size setting to database rules

### DIFF
--- a/data_types/src/database_rules.rs
+++ b/data_types/src/database_rules.rs
@@ -166,6 +166,9 @@ pub struct LifecycleRules {
 
     /// Maximum number of rows to buffer in a MUB chunk before compacting it
     pub mub_row_threshold: NonZeroUsize,
+
+    /// Use up to this amount of space in bytes for caching Parquet files
+    pub parquet_cache_limit: Option<NonZeroUsize>,
 }
 
 impl LifecycleRules {
@@ -195,6 +198,7 @@ impl Default for LifecycleRules {
             persist_age_threshold_seconds: NonZeroU32::new(DEFAULT_PERSIST_AGE_THRESHOLD_SECONDS)
                 .unwrap(),
             mub_row_threshold: NonZeroUsize::new(DEFAULT_MUB_ROW_THRESHOLD).unwrap(),
+            parquet_cache_limit: None,
         }
     }
 }

--- a/data_types/src/database_rules.rs
+++ b/data_types/src/database_rules.rs
@@ -167,8 +167,9 @@ pub struct LifecycleRules {
     /// Maximum number of rows to buffer in a MUB chunk before compacting it
     pub mub_row_threshold: NonZeroUsize,
 
-    /// Use up to this amount of space in bytes for caching Parquet files
-    pub parquet_cache_limit: Option<NonZeroUsize>,
+    /// Use up to this amount of space in bytes for caching Parquet files. None
+    /// will disable Parquet file caching.
+    pub parquet_cache_limit: Option<NonZeroU64>,
 }
 
 impl LifecycleRules {

--- a/generated_types/protos/influxdata/iox/management/v1/database_rules.proto
+++ b/generated_types/protos/influxdata/iox/management/v1/database_rules.proto
@@ -82,6 +82,13 @@ message LifecycleRules {
   // If 0, compactions are limited to the default number.
   // See data_types::database_rules::DEFAULT_MAX_ACTIVE_COMPACTIONS
   uint32 max_active_compactions = 16;
+
+  // Use up to this amount of space in bytes for caching Parquet files
+  ParquetCacheLimit parquet_cache_limit = 17;
+}
+
+message ParquetCacheLimit {
+  uint64 value = 1;
 }
 
 message DatabaseRules {

--- a/generated_types/protos/influxdata/iox/management/v1/database_rules.proto
+++ b/generated_types/protos/influxdata/iox/management/v1/database_rules.proto
@@ -83,12 +83,9 @@ message LifecycleRules {
   // See data_types::database_rules::DEFAULT_MAX_ACTIVE_COMPACTIONS
   uint32 max_active_compactions = 16;
 
-  // Use up to this amount of space in bytes for caching Parquet files
-  ParquetCacheLimit parquet_cache_limit = 17;
-}
-
-message ParquetCacheLimit {
-  uint64 value = 1;
+  // Use up to this amount of space in bytes for caching Parquet files.
+  // A value of 0 disables Parquet caching
+  uint64 parquet_cache_limit = 17;
 }
 
 message DatabaseRules {

--- a/src/commands/database.rs
+++ b/src/commands/database.rs
@@ -13,7 +13,6 @@ use influxdb_iox_client::{
     },
     write::{self, WriteError},
 };
-use std::num::NonZeroUsize;
 
 mod catalog;
 mod chunk;
@@ -121,9 +120,10 @@ struct Create {
     #[structopt(long, default_value = "100000")]
     mub_row_threshold: u64,
 
-    /// Use up to this amount of space in bytes for caching Parquet files
-    #[structopt(long, parse(try_from_str))]
-    pub parquet_cache_limit: Option<NonZeroUsize>,
+    /// Use up to this amount of space in bytes for caching Parquet files. A
+    /// value of zero disables Parquet file caching.
+    #[structopt(long, default_value = "0")]
+    parquet_cache_limit: u64,
 }
 
 /// Get list of databases
@@ -198,7 +198,7 @@ pub async fn command(url: String, config: Config) -> Result<()> {
                     persist_row_threshold: command.persist_row_threshold,
                     persist_age_threshold_seconds: command.persist_age_threshold_seconds,
                     mub_row_threshold: command.mub_row_threshold,
-                    parquet_cache_limit: command.parquet_cache_limit.map(|l| ParquetCacheLimit{value: l.get() as u64}),
+                    parquet_cache_limit: command.parquet_cache_limit,
                 }),
 
                 // Default to hourly partitions

--- a/src/commands/database.rs
+++ b/src/commands/database.rs
@@ -13,6 +13,7 @@ use influxdb_iox_client::{
     },
     write::{self, WriteError},
 };
+use std::num::NonZeroUsize;
 
 mod catalog;
 mod chunk;
@@ -119,6 +120,10 @@ struct Create {
     /// Maximum number of rows to buffer in a MUB chunk before compacting it
     #[structopt(long, default_value = "100000")]
     mub_row_threshold: u64,
+
+    /// Use up to this amount of space in bytes for caching Parquet files
+    #[structopt(long, parse(try_from_str))]
+    pub parquet_cache_limit: Option<NonZeroUsize>,
 }
 
 /// Get list of databases
@@ -193,6 +198,7 @@ pub async fn command(url: String, config: Config) -> Result<()> {
                     persist_row_threshold: command.persist_row_threshold,
                     persist_age_threshold_seconds: command.persist_age_threshold_seconds,
                     mub_row_threshold: command.mub_row_threshold,
+                    parquet_cache_limit: command.parquet_cache_limit.map(|l| ParquetCacheLimit{value: l.get() as u64}),
                 }),
 
                 // Default to hourly partitions


### PR DESCRIPTION
This is the first part of adding the ability to use the locally attached disk as a cache for Parquet files. Follow on work will include:
* [ ] Add ParquetCache backed by an ObjectStore configured for local filesystem
* [ ] Update ParquetChunk and DbChunk to call `read_filter` with necessary information to either cache the file or download
* [ ] Plumb through some sort of locking above DbChunk that can be passed down so concurrent queries to the same chunk don't trigger simultaneous downloads
* [ ] Load ParquetCache state on startup (lists everything so it knows what is cached and has a size)