### PR TITLE
test: ensure high enough limit

### DIFF
--- a/lifecycle/src/policy.rs
+++ b/lifecycle/src/policy.rs
@@ -1399,6 +1399,7 @@ mod tests {
         let rules = LifecycleRules {
             late_arrive_window_seconds: NonZeroU32::new(10).unwrap(),
             persist_row_threshold: NonZeroUsize::new(1_000).unwrap(),
+            max_active_compactions: NonZeroU32::new(10).unwrap(),
             ..Default::default()
         };
 
@@ -1538,6 +1539,7 @@ mod tests {
             persist_row_threshold: NonZeroUsize::new(1_000).unwrap(),
             late_arrive_window_seconds: NonZeroU32::new(10).unwrap(),
             persist_age_threshold_seconds: NonZeroU32::new(10).unwrap(),
+            max_active_compactions: NonZeroU32::new(10).unwrap(),
             ..Default::default()
         };
         let now = Instant::now();


### PR DESCRIPTION
@carols10cents noticed that https://github.com/influxdata/influxdb_iox/pull/2048 introduced a failing test when running on her machine. I forgot to update tests to ensure that the ones that test compactions have a high enough compaction limiter set.

The previous change passed my laptop and CI because they had enough CPU cores for the tests.