### PR TITLE
fix: checkpoint collection (replay preparation)

### DIFF
--- a/generated_types/protos/influxdata/iox/catalog/v1/parquet_metadata.proto
+++ b/generated_types/protos/influxdata/iox/catalog/v1/parquet_metadata.proto
@@ -51,8 +51,11 @@ message PartitionCheckpoint {
 // This effectively contains the minimum sequence numbers over the whole database that are the starting point for
 // replay.
 message DatabaseCheckpoint {
-  // Maps `sequencer_id` to the minimum sequence numbers seen.
-  map<uint32, uint64> min_sequencer_numbers = 1;
+  // was `min_sequence_numbers`
+  reserved 1;
+
+  // Maps sequencer_id to the minimum and maximum sequence numbers seen.
+  map<uint32, MinMaxSequence> sequencer_numbers = 2;
 }
 
 // The minimum and maximum sequence numbers seen for a given sequencer.

--- a/parquet_file/src/catalog.rs
+++ b/parquet_file/src/catalog.rs
@@ -31,7 +31,7 @@ use uuid::Uuid;
 /// Current version for serialized transactions.
 ///
 /// For breaking changes, this will change.
-pub const TRANSACTION_VERSION: u32 = 8;
+pub const TRANSACTION_VERSION: u32 = 9;
 
 /// File suffix for transaction files in object store.
 pub const TRANSACTION_FILE_SUFFIX: &str = "txn";

--- a/parquet_file/src/test_utils.rs
+++ b/parquet_file/src/test_utils.rs
@@ -756,12 +756,24 @@ pub fn create_partition_and_database_checkpoint(
     table_name: Arc<str>,
     partition_key: Arc<str>,
 ) -> (PartitionCheckpoint, DatabaseCheckpoint) {
-    // create partition checkpoint
+    // create first partition checkpoint
     let mut sequencer_numbers = BTreeMap::new();
     sequencer_numbers.insert(1, MinMaxSequence::new(15, 18));
     sequencer_numbers.insert(2, MinMaxSequence::new(25, 28));
     let min_unpersisted_timestamp = Utc.timestamp(10, 20);
-    let partition_checkpoint = PartitionCheckpoint::new(
+    let partition_checkpoint_1 = PartitionCheckpoint::new(
+        Arc::clone(&table_name),
+        Arc::clone(&partition_key),
+        sequencer_numbers,
+        min_unpersisted_timestamp,
+    );
+
+    // create second partition checkpoint
+    let mut sequencer_numbers = BTreeMap::new();
+    sequencer_numbers.insert(2, MinMaxSequence::new(24, 29));
+    sequencer_numbers.insert(3, MinMaxSequence::new(35, 38));
+    let min_unpersisted_timestamp = Utc.timestamp(20, 30);
+    let partition_checkpoint_2 = PartitionCheckpoint::new(
         table_name,
         partition_key,
         sequencer_numbers,
@@ -769,6 +781,7 @@ pub fn create_partition_and_database_checkpoint(
     );
 
     // build database checkpoint
-    let builder = PersistCheckpointBuilder::new(partition_checkpoint);
+    let mut builder = PersistCheckpointBuilder::new(partition_checkpoint_1);
+    builder.register_other_partition(&partition_checkpoint_2);
     builder.build()
 }

--- a/server/src/db/lifecycle/write.rs
+++ b/server/src/db/lifecycle/write.rs
@@ -219,17 +219,18 @@ fn collect_checkpoints(
     // calculate checkpoint
     let mut checkpoint_builder = PersistCheckpointBuilder::new(partition_checkpoint);
 
-    // collect checkpoints of all other partitions
-    if let Ok(table) = catalog.table(table_name) {
-        for partition in table.partitions() {
-            let partition = partition.read();
-            if partition.key() == partition_key.as_ref() {
-                continue;
-            }
+    // collect checkpoints of all other partitions of all tables
+    for partition in catalog.partitions() {
+        let partition = partition.read();
+        if (partition.table_name() == table_name.as_ref())
+            && (partition.key() == partition_key.as_ref())
+        {
+            // same partition as the one that we're currently persisting => skip
+            continue;
+        }
 
-            if let Some(partition_checkpoint) = partition.partition_checkpoint() {
-                checkpoint_builder.register_other_partition(&partition_checkpoint);
-            }
+        if let Some(partition_checkpoint) = partition.partition_checkpoint() {
+            checkpoint_builder.register_other_partition(&partition_checkpoint);
         }
     }
 


### PR DESCRIPTION
# 1. fix: collect checkpoint data from all tables

# 2. fix: collect min AND max in database checkpoints
1. There are two partitions A and B w/ a single write each (from the same
   sequencer).
2. We persist A:
   - The partition checkpoint for A will be empty because after persistence
     there will be nothing to replay (the single write is persisted and
     we're ready).
   - The database checkpoint that contains the global minimum of all ranges
     recognizes that for the sequencer there is indeed something left (the
     minimum sequence number from B).
3. DB restart happens, replay starts
4. We scan all persisted files, figure out that we have a DB checkpoint
   with a sequence minimum but (w/o the change in this commit) there is no
   maximum. Only partition checkpoints contain maxima, and the only partition
   checkpoint that was persisted was the one for partition A and that one was
   empty (see above).
5. So now how do we recover partition B?