### PR TITLE
refactor: correctly track "seen" ranges in persistence checkpoints

### DIFF
--- a/generated_types/protos/influxdata/iox/catalog/v1/parquet_metadata.proto
+++ b/generated_types/protos/influxdata/iox/catalog/v1/parquet_metadata.proto
@@ -39,8 +39,8 @@ message IoxMetadata {
 // checkpoint is usually serialized as part of `IoxMetadata`, the partition information is NOT repeated as part of this
 // message.
 message PartitionCheckpoint {
-  // Maps sequencer_id to the minimum and maximum sequence numbers seen.
-  map<uint32, MinMaxSequence> sequencer_numbers = 1;
+  // Maps `sequencer_id` to the to-be-persisted minimum and seen maximum sequence numbers.
+  map<uint32, OptionalMinMaxSequence> sequencer_numbers = 1;
 
   // Minimum unpersisted timestamp.
   FixedSizeTimestamp min_unpersisted_timestamp = 2;
@@ -54,12 +54,19 @@ message DatabaseCheckpoint {
   // was `min_sequence_numbers`
   reserved 1;
 
-  // Maps sequencer_id to the minimum and maximum sequence numbers seen.
-  map<uint32, MinMaxSequence> sequencer_numbers = 2;
+  // Maps `sequencer_id` to the to-be-persisted minimum and seen maximum sequence numbers.
+  map<uint32, OptionalMinMaxSequence> sequencer_numbers = 2;
 }
 
-// The minimum and maximum sequence numbers seen for a given sequencer.
-message MinMaxSequence {
-  uint64 min = 1;
+// An optional uint64.
+message OptionalUint64 {
+  uint64 value = 1;
+}
+
+// The optional to-be-replayed minimum and seen maximum sequence numbers for a given sequencer.
+//
+// If the minimum value is missing, no replay is required for this sequencer.
+message OptionalMinMaxSequence {
+  OptionalUint64 min = 1;
   uint64 max = 2;
 }

--- a/parquet_file/src/catalog.rs
+++ b/parquet_file/src/catalog.rs
@@ -31,7 +31,7 @@ use uuid::Uuid;
 /// Current version for serialized transactions.
 ///
 /// For breaking changes, this will change.
-pub const TRANSACTION_VERSION: u32 = 9;
+pub const TRANSACTION_VERSION: u32 = 10;
 
 /// File suffix for transaction files in object store.
 pub const TRANSACTION_FILE_SUFFIX: &str = "txn";

--- a/parquet_file/src/metadata.rs
+++ b/parquet_file/src/metadata.rs
@@ -311,14 +311,10 @@ impl IoxMetadata {
             .sequencer_numbers
             .into_iter()
             .map(|(sequencer_id, min_max)| {
-                let min = match min_max.min {
-                    u64::MAX => None,
-                    min => Some(min),
-                };
-                let max = min_max.max;
+                let min = min_max.min.as_ref().map(|min| min.value);
 
-                if min.map(|min| min <= max).unwrap_or(true) {
-                    Ok((sequencer_id, OptionalMinMaxSequence::new(min, max)))
+                if min.map(|min| min <= min_max.max).unwrap_or(true) {
+                    Ok((sequencer_id, OptionalMinMaxSequence::new(min, min_max.max)))
                 } else {
                     Err(Error::IoxMetadataMinMax)
                 }
@@ -349,14 +345,10 @@ impl IoxMetadata {
             .sequencer_numbers
             .into_iter()
             .map(|(sequencer_id, min_max)| {
-                let min = match min_max.min {
-                    u64::MAX => None,
-                    min => Some(min),
-                };
-                let max = min_max.max;
+                let min = min_max.min.as_ref().map(|min| min.value);
 
-                if min.map(|min| min <= max).unwrap_or(true) {
-                    Ok((sequencer_id, OptionalMinMaxSequence::new(min, max)))
+                if min.map(|min| min <= min_max.max).unwrap_or(true) {
+                    Ok((sequencer_id, OptionalMinMaxSequence::new(min, min_max.max)))
                 } else {
                     Err(Error::IoxMetadataMinMax)
                 }
@@ -383,8 +375,10 @@ impl IoxMetadata {
                 .map(|(sequencer_id, min_max)| {
                     (
                         sequencer_id,
-                        proto::MinMaxSequence {
-                            min: min_max.min().unwrap_or(u64::MAX),
+                        proto::OptionalMinMaxSequence {
+                            min: min_max
+                                .min()
+                                .map(|min| proto::OptionalUint64 { value: min }),
                             max: min_max.max(),
                         },
                     )
@@ -402,8 +396,10 @@ impl IoxMetadata {
                 .map(|(sequencer_id, min_max)| {
                     (
                         sequencer_id,
-                        proto::MinMaxSequence {
-                            min: min_max.min().unwrap_or(u64::MAX),
+                        proto::OptionalMinMaxSequence {
+                            min: min_max
+                                .min()
+                                .map(|min| proto::OptionalUint64 { value: min }),
                             max: min_max.max(),
                         },
                     )

--- a/parquet_file/src/test_utils.rs
+++ b/parquet_file/src/test_utils.rs
@@ -28,7 +28,7 @@ use parquet::{
 };
 use persistence_windows::{
     checkpoint::{DatabaseCheckpoint, PartitionCheckpoint, PersistCheckpointBuilder},
-    min_max_sequence::MinMaxSequence,
+    min_max_sequence::OptionalMinMaxSequence,
 };
 
 use crate::{
@@ -758,8 +758,8 @@ pub fn create_partition_and_database_checkpoint(
 ) -> (PartitionCheckpoint, DatabaseCheckpoint) {
     // create first partition checkpoint
     let mut sequencer_numbers = BTreeMap::new();
-    sequencer_numbers.insert(1, MinMaxSequence::new(15, 18));
-    sequencer_numbers.insert(2, MinMaxSequence::new(25, 28));
+    sequencer_numbers.insert(1, OptionalMinMaxSequence::new(None, 18));
+    sequencer_numbers.insert(2, OptionalMinMaxSequence::new(Some(25), 28));
     let min_unpersisted_timestamp = Utc.timestamp(10, 20);
     let partition_checkpoint_1 = PartitionCheckpoint::new(
         Arc::clone(&table_name),
@@ -770,8 +770,8 @@ pub fn create_partition_and_database_checkpoint(
 
     // create second partition checkpoint
     let mut sequencer_numbers = BTreeMap::new();
-    sequencer_numbers.insert(2, MinMaxSequence::new(24, 29));
-    sequencer_numbers.insert(3, MinMaxSequence::new(35, 38));
+    sequencer_numbers.insert(2, OptionalMinMaxSequence::new(Some(24), 29));
+    sequencer_numbers.insert(3, OptionalMinMaxSequence::new(Some(35), 38));
     let min_unpersisted_timestamp = Utc.timestamp(20, 30);
     let partition_checkpoint_2 = PartitionCheckpoint::new(
         table_name,

--- a/persistence_windows/src/checkpoint.rs
+++ b/persistence_windows/src/checkpoint.rs
@@ -206,21 +206,60 @@ use std::{
 };
 
 use chrono::{DateTime, Utc};
-use snafu::Snafu;
+use snafu::{OptionExt, Snafu};
 
-use crate::min_max_sequence::MinMaxSequence;
+use crate::min_max_sequence::OptionalMinMaxSequence;
 
 #[derive(Debug, Snafu)]
 pub enum Error {
-    #[snafu(display("Did not find a DatabaseCheckpoint for sequencer {}", sequencer_id))]
-    NoDatabaseCheckpointFound { sequencer_id: u32 },
+    #[snafu(
+        display(
+            "Got sequence range in partition checkpoint but no database-wide number for partition {}:{} and sequencer {}",
+            table_name,
+            partition_key,
+            sequencer_id,
+        )
+    )]
+    PartitionCheckpointWithoutDatabase {
+        table_name: Arc<str>,
+        partition_key: Arc<str>,
+        sequencer_id: u32,
+    },
 
-    #[snafu(display("Minimum sequence number in partition checkpoint ({}) is lower than database-wide number ({}) for partition {}:{}", partition_checkpoint_sequence_number, database_checkpoint_sequence_number, table_name, partition_key))]
+    #[snafu(
+        display(
+            "Minimum sequence number in partition checkpoint ({}) is larger than database-wide number ({}) for partition {}:{} and sequencer {}",
+            partition_checkpoint_sequence_number,
+            database_checkpoint_sequence_number,
+            table_name,
+            partition_key,
+            sequencer_id,
+        )
+    )]
+    PartitionCheckpointMaximumAfterDatabase {
+        partition_checkpoint_sequence_number: u64,
+        database_checkpoint_sequence_number: u64,
+        table_name: Arc<str>,
+        partition_key: Arc<str>,
+        sequencer_id: u32,
+    },
+
+    #[snafu(
+        display(
+            "Minimum sequence number in partition checkpoint ({}) is lower than database-wide number ({}) for partition {}:{} and sequencer {}",
+            partition_checkpoint_sequence_number,
+            database_checkpoint_sequence_number,
+            table_name,
+            partition_key,
+            sequencer_id,
+        )
+    )]
     PartitionCheckpointMinimumBeforeDatabase {
         partition_checkpoint_sequence_number: u64,
         database_checkpoint_sequence_number: u64,
         table_name: Arc<str>,
         partition_key: Arc<str>,
+        sequencer_id: u32,
     },
 }
 
@@ -235,8 +274,8 @@ pub struct PartitionCheckpoint {
     /// Partition key.
     partition_key: Arc<str>,
 
-    /// Maps `sequencer_id` to the minimum and maximum sequence numbers seen.
-    sequencer_numbers: BTreeMap<u32, MinMaxSequence>,
+    /// Maps `sequencer_id` to the to-be-persisted minimum and seen maximum sequence numbers.
+    sequencer_numbers: BTreeMap<u32, OptionalMinMaxSequence>,
 
     /// Minimum unpersisted timestamp.
     min_unpersisted_timestamp: DateTime<Utc>,
@@ -247,7 +286,7 @@ impl PartitionCheckpoint {
     pub fn new(
         table_name: Arc<str>,
         partition_key: Arc<str>,
-        sequencer_numbers: BTreeMap<u32, MinMaxSequence>,
+        sequencer_numbers: BTreeMap<u32, OptionalMinMaxSequence>,
         min_unpersisted_timestamp: DateTime<Utc>,
     ) -> Self {
         Self {
@@ -268,11 +307,11 @@ impl PartitionCheckpoint {
         &self.partition_key
     }
 
-    /// Maps `sequencer_id` to the minimum and maximum sequence numbers seen.
+    /// Maps `sequencer_id` to the to-be-persisted minimum and seen maximum sequence numbers.
     ///
     /// Will return `None` if the sequencer was not yet seen in which case there is not need to replay data from this
     /// sequencer for this partition.
-    pub fn sequencer_numbers(&self, sequencer_id: u32) -> Option<MinMaxSequence> {
+    pub fn sequencer_numbers(&self, sequencer_id: u32) -> Option<OptionalMinMaxSequence> {
         self.sequencer_numbers.get(&sequencer_id).copied()
     }
 
@@ -282,7 +321,9 @@ impl PartitionCheckpoint {
     }
 
     /// Iterate over sequencer numbers.
-    pub fn sequencer_numbers_iter(&self) -> impl Iterator<Item = (u32, MinMaxSequence)> + '_ {
+    pub fn sequencer_numbers_iter(
+        &self,
+    ) -> impl Iterator<Item = (u32, OptionalMinMaxSequence)> + '_ {
         self.sequencer_numbers
             .iter()
             .map(|(sequencer_id, min_max)| (*sequencer_id, *min_max))
@@ -300,7 +341,7 @@ impl PartitionCheckpoint {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DatabaseCheckpoint {
     /// Maps `sequencer_id` to the minimum and maximum sequence numbers seen.
-    sequencer_numbers: BTreeMap<u32, MinMaxSequence>,
+    sequencer_numbers: BTreeMap<u32, OptionalMinMaxSequence>,
 }
 
 impl DatabaseCheckpoint {
@@ -308,18 +349,21 @@ impl DatabaseCheckpoint {
     ///
     /// **This should only rarely be be used directly. Consider using [`PersistCheckpointBuilder`] to collect
     /// database-wide checkpoints!**
-    pub fn new(sequencer_numbers: BTreeMap<u32, MinMaxSequence>) -> Self {
+    pub fn new(sequencer_numbers: BTreeMap<u32, OptionalMinMaxSequence>) -> Self {
         Self { sequencer_numbers }
     }
 
     /// Get sequence number range that should be used during replay of the given sequencer.
+    ///
+    /// If the range only has the maximum but not the minimum set, then no replay is required but the sequencer must be
+    /// seeked to the maximum plus 1.
     ///
     /// This will return `None` for unknown sequencer. This might have multiple reasons, e.g. in case of Apache Kafka it
     /// might be that a partition has not delivered any data yet (for a quite young database) or that the partitioning
     /// was wrongly reconfigured (to more partitions in which case the ordering would be wrong). The latter case MUST be
     /// detected by another layer, e.g. using persisted database rules. The reaction to `None` in this layer should be
     /// "no replay required for this sequencer, just continue with normal playback".
-    pub fn sequencer_number(&self, sequencer_id: u32) -> Option<MinMaxSequence> {
+    pub fn sequencer_number(&self, sequencer_id: u32) -> Option<OptionalMinMaxSequence> {
         self.sequencer_numbers.get(&sequencer_id).copied()
     }
 
@@ -329,7 +373,9 @@ impl DatabaseCheckpoint {
     }
 
     /// Iterate over sequencer numbers
-    pub fn sequencer_numbers_iter(&self) -> impl Iterator<Item = (u32, MinMaxSequence)> + '_ {
+    pub fn sequencer_numbers_iter(
+        &self,
+    ) -> impl Iterator<Item = (u32, OptionalMinMaxSequence)> + '_ {
         self.sequencer_numbers
             .iter()
             .map(|(sequencer_id, min_max)| (*sequencer_id, *min_max))
@@ -376,10 +422,14 @@ impl PersistCheckpointBuilder {
                 }
                 Occupied(mut o) => {
                     let existing_min_max = o.get_mut();
-                    *existing_min_max = MinMaxSequence::new(
-                        existing_min_max.min().min(min_max.min()),
-                        existing_min_max.max().max(min_max.max()),
-                    );
+                    let min = match (existing_min_max.min(), min_max.min()) {
+                        (Some(a), Some(b)) => Some(a.min(b)),
+                        (Some(a), None) => Some(a),
+                        (None, Some(b)) => Some(b),
+                        (None, None) => None,
+                    };
+                    let max = existing_min_max.max().max(min_max.max());
+                    *existing_min_max = OptionalMinMaxSequence::new(min, max);
                 }
             }
         }
@@ -403,7 +453,7 @@ impl PersistCheckpointBuilder {
 #[derive(Debug)]
 pub struct ReplayPlanner {
     /// Range (inclusive minimum, inclusive maximum) of sequence number to be replayed for each sequencer.
-    replay_ranges: BTreeMap<u32, (Option<u64>, u64)>,
+    replay_ranges: BTreeMap<u32, OptionalMinMaxSequence>,
 
     /// Last known partition checkpoint, mapped via table name and partition key.
     last_partition_checkpoints: BTreeMap<(Arc<str>, Arc<str>), PartitionCheckpoint>,
@@ -418,25 +468,12 @@ impl ReplayPlanner {
         }
     }
 
-    /// Register a partition checkpoint that was found in the catalog.
-    pub fn register_partition_checkpoint(&mut self, partition_checkpoint: &PartitionCheckpoint) {
-        for (sequencer_id, min_max) in &partition_checkpoint.sequencer_numbers {
-            match self.replay_ranges.entry(*sequencer_id) {
-                Vacant(v) => {
-                    // unknown sequencer => just store max value for now
-                    v.insert((None, min_max.max()));
-                }
-                Occupied(mut o) => {
-                    // known sequencer => fold in:
-                    // - max value (we take the max of all maximums!)
-                    //
-                    // We are NOT folding in the min value here since other partitions might not be that far yet.
-                    let existing_min_max = o.get_mut();
-                    existing_min_max.1 = existing_min_max.1.max(min_max.max());
-                }
-            }
-        }
-
+    /// Register a partition and database checkpoint that was found in the catalog.
+    pub fn register_checkpoints(
+        &mut self,
+        partition_checkpoint: &PartitionCheckpoint,
+        database_checkpoint: &DatabaseCheckpoint,
+    ) {
         match self.last_partition_checkpoints.entry((
             Arc::clone(partition_checkpoint.table_name()),
             Arc::clone(partition_checkpoint.partition_key()),
@@ -454,28 +491,27 @@ impl ReplayPlanner {
                 }
             }
         }
-    }
 
-    /// Register a database checkpoint that was found in the catalog.
-    pub fn register_database_checkpoint(&mut self, database_checkpoint: &DatabaseCheckpoint) {
         for (sequencer_id, min_max) in &database_checkpoint.sequencer_numbers {
             match self.replay_ranges.entry(*sequencer_id) {
                 Vacant(v) => {
                     // unknown sequencer => store min value (we keep the latest value for that one) and max value (in
                     // case when we don't find another partition checkpoint for this sequencer, so we have a fallback)
-                    v.insert((Some(min_max.min()), min_max.max()));
+                    v.insert(*min_max);
                 }
                 Occupied(mut o) => {
                     // known sequencer => fold in:
                     // - min value (we take the max of all mins!)
                     // - max value (we take the max of all max!)
                     let existing_min_max = o.get_mut();
-                    existing_min_max.0 = Some(
-                        existing_min_max
-                            .0
-                            .map_or(min_max.min(), |min2| min2.max(min_max.min())),
-                    );
-                    existing_min_max.1 = existing_min_max.1.max(min_max.max());
+                    let min = match (existing_min_max.min(), min_max.min()) {
+                        (Some(a), Some(b)) => Some(a.max(b)),
+                        (Some(a), None) => Some(a),
+                        (None, Some(b)) => Some(b),
+                        (None, None) => None,
+                    };
+                    let max = existing_min_max.max().max(min_max.max());
+                    *existing_min_max = OptionalMinMaxSequence::new(min, max);
                 }
             }
         }
@@ -483,34 +519,41 @@ impl ReplayPlanner {
 
     /// Build plan that is then used for replay.
     pub fn build(self) -> Result<ReplayPlan> {
-        let mut replay_ranges = BTreeMap::new();
-        for (sequencer_id, min_max) in self.replay_ranges {
-            match min_max {
-                (Some(min), max) => {
-                    replay_ranges.insert(sequencer_id, MinMaxSequence::new(min, max));
-                }
-                (None, _max) => {
-                    // We've got data for this sequencer via a PartitionCheckpoint but did not see corresponding data in
-                    // any of the DatabaseCheckpoints. This is clearly a data error, because for the PartitionCheckpoint
-                    // in question we should have persisted (and read back) a DatabaseCheckpoint in the very same
-                    // Parquet file that contains a value for that sequencer.
-                    return Err(Error::NoDatabaseCheckpointFound { sequencer_id });
-                }
-            }
-        }
+        let Self {
+            replay_ranges,
+            last_partition_checkpoints,
+        } = self;
 
         // sanity-check partition checkpoints
-        for ((table_name, partition_key), partition_checkpoint) in &self.last_partition_checkpoints
-        {
+        for ((table_name, partition_key), partition_checkpoint) in &last_partition_checkpoints {
             for (sequencer_id, min_max) in &partition_checkpoint.sequencer_numbers {
-                let database_wide_min_max = replay_ranges.get(sequencer_id).expect("every partition checkpoint should have resulted in a replay range or an error by now");
-
-                if min_max.min() < database_wide_min_max.min() {
-                    return Err(Error::PartitionCheckpointMinimumBeforeDatabase {
-                        partition_checkpoint_sequence_number: min_max.min(),
-                        database_checkpoint_sequence_number: database_wide_min_max.min(),
+                let database_wide_min_max = replay_ranges.get(sequencer_id).context(
+                    PartitionCheckpointWithoutDatabase {
                         table_name: Arc::clone(table_name),
                         partition_key: Arc::clone(partition_key),
+                        sequencer_id: *sequencer_id,
+                    },
+                )?;
+
+                if let (Some(min), Some(db_min)) = (min_max.min(), database_wide_min_max.min()) {
+                    if min < db_min {
+                        return Err(Error::PartitionCheckpointMinimumBeforeDatabase {
+                            partition_checkpoint_sequence_number: min,
+                            database_checkpoint_sequence_number: db_min,
+                            table_name: Arc::clone(table_name),
+                            partition_key: Arc::clone(partition_key),
+                            sequencer_id: *sequencer_id,
+                        });
+                    }
+                }
+
+                if min_max.max() > database_wide_min_max.max() {
+                    return Err(Error::PartitionCheckpointMaximumAfterDatabase {
+                        partition_checkpoint_sequence_number: min_max.max(),
+                        database_checkpoint_sequence_number: database_wide_min_max.max(),
+                        table_name: Arc::clone(table_name),
+                        partition_key: Arc::clone(partition_key),
+                        sequencer_id: *sequencer_id,
                     });
                 }
             }
@@ -518,7 +561,7 @@ impl ReplayPlanner {
 
         Ok(ReplayPlan {
             replay_ranges,
-            last_partition_checkpoints: self.last_partition_checkpoints,
+            last_partition_checkpoints,
         })
     }
 }
@@ -534,8 +577,9 @@ impl Default for ReplayPlanner {
 pub struct ReplayPlan {
     /// Replay range (inclusive minimum sequence number, inclusive maximum sequence number) for every sequencer.
     ///
-    /// For sequencers not included in this map, no replay is required.
-    replay_ranges: BTreeMap<u32, MinMaxSequence>,
+    /// For sequencers not included in this map, no replay is required. For sequencer that only have a maximum, only
+    /// seeking to maximum plus 1 is required (but no replay).
+    replay_ranges: BTreeMap<u32, OptionalMinMaxSequence>,
 
     /// Last known partition checkpoint, mapped via table name and partition key.
     last_partition_checkpoints: BTreeMap<(Arc<str>, Arc<str>), PartitionCheckpoint>,
@@ -544,8 +588,11 @@ pub struct ReplayPlan {
 impl ReplayPlan {
     /// Get replay range for a sequencer.
     ///
-    /// When this returns `None`, no replay is required for this sequencer and we can just start to playback normally.
-    pub fn replay_range(&self, sequencer_id: u32) -> Option<MinMaxSequence> {
+    /// If only a maximum but no minimum is returned, then no replay is required but the caller must seek the sequencer
+    /// to maximum plus 1.
+    ///
+    /// If this returns `None`, no replay is required for this sequencer and we can just start to playback normally.
+    pub fn replay_range(&self, sequencer_id: u32) -> Option<OptionalMinMaxSequence> {
         self.replay_ranges.get(&sequencer_id).copied()
     }
 
@@ -583,7 +630,7 @@ mod tests {
             {
                 let mut sequencer_numbers = BTreeMap::new();
                 $(
-                    sequencer_numbers.insert($sequencer_number, MinMaxSequence::new($min, $max));
+                    sequencer_numbers.insert($sequencer_number, OptionalMinMaxSequence::new($min, $max));
                 )*
 
                 let min_unpersisted_timestamp = DateTime::from_utc(chrono::NaiveDateTime::from_timestamp(0, 0), Utc);
@@ -599,7 +646,7 @@ mod tests {
             {
                 let mut sequencer_numbers = BTreeMap::new();
                 $(
-                    sequencer_numbers.insert($sequencer_number, MinMaxSequence::new($min, $max));
+                    sequencer_numbers.insert($sequencer_number, OptionalMinMaxSequence::new($min, $max));
                 )*
                 DatabaseCheckpoint{sequencer_numbers}
             }
@@ -608,72 +655,95 @@ mod tests {
 
     #[test]
     fn test_partition_checkpoint() {
-        let pckpt = part_ckpt!("table_1", "partition_1", {1 => (10, 20), 2 => (5, 15)});
+        let pckpt = part_ckpt!("table_1", "partition_1", {1 => (Some(10), 20), 2 => (None, 15)});
 
         assert_eq!(pckpt.table_name().as_ref(), "table_1");
         assert_eq!(pckpt.partition_key().as_ref(), "partition_1");
         assert_eq!(
             pckpt.sequencer_numbers(1).unwrap(),
-            MinMaxSequence::new(10, 20)
+            OptionalMinMaxSequence::new(Some(10), 20)
         );
         assert_eq!(
             pckpt.sequencer_numbers(2).unwrap(),
-            MinMaxSequence::new(5, 15)
+            OptionalMinMaxSequence::new(None, 15)
         );
         assert!(pckpt.sequencer_numbers(3).is_none());
         assert_eq!(pckpt.sequencer_ids(), vec![1, 2]);
 
         assert_eq!(
             pckpt,
-            part_ckpt!("table_1", "partition_1", {1 => (10, 20), 2 => (5, 15)})
+            part_ckpt!("table_1", "partition_1", {1 => (Some(10), 20), 2 => (None, 15)})
         );
     }
 
     #[test]
     fn test_database_checkpoint() {
-        let dckpt = db_ckpt!({1 => (10, 20), 2 => (5, 15)});
+        let dckpt = db_ckpt!({1 => (Some(10), 20), 2 => (None, 15)});
 
         assert_eq!(
             dckpt.sequencer_number(1).unwrap(),
-            MinMaxSequence::new(10, 20)
+            OptionalMinMaxSequence::new(Some(10), 20)
         );
         assert_eq!(
             dckpt.sequencer_number(2).unwrap(),
-            MinMaxSequence::new(5, 15)
+            OptionalMinMaxSequence::new(None, 15)
         );
         assert!(dckpt.sequencer_number(3).is_none());
         assert_eq!(dckpt.sequencer_ids(), vec![1, 2]);
 
-        assert_eq!(dckpt, db_ckpt!({1 => (10, 20), 2 => (5, 15)}));
+        assert_eq!(dckpt, db_ckpt!({1 => (Some(10), 20), 2 => (None, 15)}));
     }
 
     #[test]
     fn test_persist_checkpoint_builder_no_other() {
-        let pckpt_orig = part_ckpt!("table_1", "partition_1", {1 => (10, 20), 2 => (5, 15)});
+        let pckpt_orig =
+            part_ckpt!("table_1", "partition_1", {1 => (Some(10), 20), 2 => (None, 15)});
         let builder = PersistCheckpointBuilder::new(pckpt_orig.clone());
 
         let (pckpt, dckpt) = builder.build();
 
         assert_eq!(pckpt, pckpt_orig);
-        assert_eq!(dckpt, db_ckpt!({1 => (10, 20), 2 => (5, 15)}));
+        assert_eq!(dckpt, db_ckpt!({1 => (Some(10), 20), 2 => (None, 15)}));
     }
 
     #[test]
     fn test_persist_checkpoint_builder_others() {
-        let pckpt_orig =
-            part_ckpt!("table_1", "partition_1", {1 => (10, 20), 2 => (5, 15), 3 => (15, 26)});
+        let pckpt_orig = part_ckpt!(
+            "table_1",
+            "partition_1",
+            {
+                1 => (Some(10), 20),
+                2 => (Some(5), 15),
+                3 => (Some(15), 26),
+                5 => (None, 10)
+            }
+        );
         let mut builder = PersistCheckpointBuilder::new(pckpt_orig.clone());
 
-        builder.register_other_partition(
-            &part_ckpt!("table_1", "partition_2", {2 => (2, 16), 3 => (20, 25), 4 => (13, 14)}),
-        );
+        builder.register_other_partition(&part_ckpt!(
+            "table_1",
+            "partition_2",
+            {
+                2 => (Some(2), 16),
+                3 => (Some(20), 25),
+                4 => (Some(13), 14),
+                6 => (None, 10)
+            }
+        ));
 
         let (pckpt, dckpt) = builder.build();
 
         assert_eq!(pckpt, pckpt_orig);
         assert_eq!(
             dckpt,
-            db_ckpt!({1 => (10, 20), 2 => (2, 16), 3 => (15, 26), 4 => (13, 14)})
+            db_ckpt!({
+                1 => (Some(10), 20),
+                2 => (Some(2), 16),
+                3 => (Some(15), 26),
+                4 => (Some(13), 14),
+                5 => (None, 10),
+                6 => (None, 10)
+            })
         );
     }
 
@@ -695,25 +765,68 @@ mod tests {
     fn test_replay_planner_normal() {
         let mut planner = ReplayPlanner::new();
 
-        planner.register_partition_checkpoint(
-            &part_ckpt!("table_1", "partition_1", {1 => (15, 19), 2 => (21, 28)}),
+        planner.register_checkpoints(
+            &part_ckpt!(
+                "table_1",
+                "partition_1",
+                {
+                    1 => (Some(15), 19),
+                    2 => (Some(21), 27),
+                    5 => (None, 50)
+                }
+            ),
+            &db_ckpt!({
+                1 => (Some(10), 19),
+                2 => (Some(20), 28),
+                5 => (None, 51),
+                6 => (None, 60)
+            }),
         );
-        planner.register_database_checkpoint(&db_ckpt!({1 => (10, 19), 2 => (20, 27)}));
 
-        planner.register_partition_checkpoint(
-            &part_ckpt!("table_1", "partition_2", {2 => (22, 27), 3 => (35, 39)}),
+        planner.register_checkpoints(
+            &part_ckpt!(
+                "table_1",
+                "partition_2",
+                {
+                    2 => (Some(22), 26),
+                    3 => (Some(35), 39)
+                }
+            ),
+            &db_ckpt!({
+                1 => (Some(11), 20),
+                3 => (Some(30), 40),
+                4 => (Some(40), 50)
+            }),
         );
-        planner
-            .register_database_checkpoint(&db_ckpt!({1 => (11, 20), 3 => (30, 40), 4 => (40, 50)}));
 
         let plan = planner.build().unwrap();
 
-        assert_eq!(plan.sequencer_ids(), vec![1, 2, 3, 4]);
-        assert_eq!(plan.replay_range(1).unwrap(), MinMaxSequence::new(11, 20));
-        assert_eq!(plan.replay_range(2).unwrap(), MinMaxSequence::new(20, 28));
-        assert_eq!(plan.replay_range(3).unwrap(), MinMaxSequence::new(30, 40));
-        assert_eq!(plan.replay_range(4).unwrap(), MinMaxSequence::new(40, 50));
-        assert!(plan.replay_range(5).is_none());
+        assert_eq!(plan.sequencer_ids(), vec![1, 2, 3, 4, 5, 6]);
+        assert_eq!(
+            plan.replay_range(1).unwrap(),
+            OptionalMinMaxSequence::new(Some(11), 20)
+        );
+        assert_eq!(
+            plan.replay_range(2).unwrap(),
+            OptionalMinMaxSequence::new(Some(20), 28)
+        );
+        assert_eq!(
+            plan.replay_range(3).unwrap(),
+            OptionalMinMaxSequence::new(Some(30), 40)
+        );
+        assert_eq!(
+            plan.replay_range(4).unwrap(),
+            OptionalMinMaxSequence::new(Some(40), 50)
+        );
+        assert_eq!(
+            plan.replay_range(5).unwrap(),
+            OptionalMinMaxSequence::new(None, 51)
+        );
+        assert_eq!(
+            plan.replay_range(6).unwrap(),
+            OptionalMinMaxSequence::new(None, 60)
+        );
+        assert!(plan.replay_range(7).is_none());
 
         assert_eq!(
             plan.partitions(),
@@ -725,12 +838,27 @@ mod tests {
         assert_eq!(
             plan.last_partition_checkpoint("table_1", "partition_1")
                 .unwrap(),
-            &part_ckpt!("table_1", "partition_1", {1 => (15, 19), 2 => (21, 28)})
+            &part_ckpt!(
+                "table_1",
+                "partition_1",
+                {
+                    1 => (Some(15), 19),
+                    2 => (Some(21), 27),
+                    5 => (None, 50)
+                }
+            ),
         );
         assert_eq!(
             plan.last_partition_checkpoint("table_1", "partition_2")
                 .unwrap(),
-            &part_ckpt!("table_1", "partition_2", {2 => (22, 27), 3 => (35, 39)})
+            &part_ckpt!(
+                "table_1",
+                "partition_2",
+                {
+                    2 => (Some(22), 26),
+                    3 => (Some(35), 39)
+                }
+            ),
         );
         assert!(plan
             .last_partition_checkpoint("table_1", "partition_3")
@@ -741,27 +869,47 @@ mod tests {
     fn test_replay_planner_fail_missing_database_checkpoint() {
         let mut planner = ReplayPlanner::new();
 
-        planner.register_partition_checkpoint(
-            &part_ckpt!("table_1", "partition_1", {1 => (11, 12), 2 => (21, 22)}),
+        planner.register_checkpoints(
+            &part_ckpt!("table_1", "partition_1", {1 => (Some(11), 12), 2 => (Some(21), 22)}),
+            &db_ckpt!({1 => (Some(10), 20), 3 => (Some(30), 40)}),
         );
-        planner.register_database_checkpoint(&db_ckpt!({1 => (10, 20), 3 => (30, 40)}));
 
         let err = planner.build().unwrap_err();
-        assert!(matches!(err, Error::NoDatabaseCheckpointFound { .. }));
+        assert!(matches!(
+            err,
+            Error::PartitionCheckpointWithoutDatabase { .. }
+        ));
     }
 
     #[test]
     fn test_replay_planner_fail_minima_out_of_sync() {
         let mut planner = ReplayPlanner::new();
 
-        planner
-            .register_partition_checkpoint(&part_ckpt!("table_1", "partition_1", {1 => (10, 12)}));
-        planner.register_database_checkpoint(&db_ckpt!({1 => (11, 20)}));
+        planner.register_checkpoints(
+            &part_ckpt!("table_1", "partition_1", {1 => (Some(10), 12)}),
+            &db_ckpt!({1 => (Some(11), 20)}),
+        );
 
         let err = planner.build().unwrap_err();
         assert!(matches!(
             err,
             Error::PartitionCheckpointMinimumBeforeDatabase { .. }
+        ));
+    }
+
+    #[test]
+    fn test_replay_planner_fail_maximum_out_of_sync() {
+        let mut planner = ReplayPlanner::new();
+
+        planner.register_checkpoints(
+            &part_ckpt!("table_1", "partition_1", {1 => (Some(11), 20)}),
+            &db_ckpt!({1 => (Some(10), 12)}),
+        );
+
+        let err = planner.build().unwrap_err();
+        assert!(matches!(
+            err,
+            Error::PartitionCheckpointMaximumAfterDatabase { .. }
         ));
     }
 }

--- a/persistence_windows/src/min_max_sequence.rs
+++ b/persistence_windows/src/min_max_sequence.rs
@@ -30,25 +30,81 @@ impl MinMaxSequence {
     }
 }
 
+/// The optional minimum and maximum sequence numbers seen for a given sequencer.
+///
+/// **IMPORTANT: These ranges include their start and their end (aka `[start, end]`)!**
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub struct OptionalMinMaxSequence {
+    min: Option<u64>,
+    max: u64,
+}
+
+impl OptionalMinMaxSequence {
+    /// Create new min-max sequence range.
+    ///
+    /// This panics if `min > max`.
+    pub fn new(min: Option<u64>, max: u64) -> Self {
+        if let Some(min) = min {
+            assert!(
+                min <= max,
+                "min ({}) is greater than max ({}) sequence",
+                min,
+                max
+            );
+        }
+        Self { min, max }
+    }
+
+    pub fn min(&self) -> Option<u64> {
+        self.min
+    }
+
+    pub fn max(&self) -> u64 {
+        self.max
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
-    fn test_getters() {
+    fn test_min_max_getters() {
         let min_max = MinMaxSequence::new(10, 20);
         assert_eq!(min_max.min(), 10);
         assert_eq!(min_max.max(), 20);
     }
 
     #[test]
-    fn test_accepts_equal_values() {
+    fn test_opt_min_max_getters() {
+        let min_max = OptionalMinMaxSequence::new(Some(10), 20);
+        assert_eq!(min_max.min(), Some(10));
+        assert_eq!(min_max.max(), 20);
+
+        let min_max = OptionalMinMaxSequence::new(None, 20);
+        assert_eq!(min_max.min(), None);
+        assert_eq!(min_max.max(), 20);
+    }
+
+    #[test]
+    fn test_min_max_accepts_equal_values() {
         MinMaxSequence::new(10, 10);
     }
 
     #[test]
+    fn test_opt_min_max_accepts_equal_values() {
+        OptionalMinMaxSequence::new(Some(10), 10);
+    }
+
+    #[test]
     #[should_panic(expected = "min (11) is greater than max (10) sequence")]
-    fn test_checks_values() {
+    fn test_min_max_checks_values() {
         MinMaxSequence::new(11, 10);
+    }
+
+    #[test]
+    #[should_panic(expected = "min (11) is greater than max (10) sequence")]
+    fn test_opt_min_max_checks_values() {
+        OptionalMinMaxSequence::new(Some(11), 10);
     }
 }

--- a/persistence_windows/src/persistence_windows.rs
+++ b/persistence_windows/src/persistence_windows.rs
@@ -250,12 +250,10 @@ impl PersistenceWindows {
                     .filter_map(|window| window.sequencer_numbers.get(sequencer_id))
                     .next();
 
-                let min = if let Some(window) = window {
+                let min = window.map(|window| {
                     assert!(window.max() <= *max_sequence_number);
-                    Some(window.min())
-                } else {
-                    None
-                };
+                    window.min()
+                });
 
                 (
                     *sequencer_id,


### PR DESCRIPTION
Now we can handle all these cases:

There are two partitions w/ a single write each:

1. A reads sequence number 1
2. B reads sequence number 2
3. we persist A which only knows the sequences up until 1

=> the DB checkpoint needs the global max, otherwise we forget sequences
   during replay (2 in this case, so B would be gone)

----

1. B reads sequence number 1
2. A reads sequence number 2
3. we persist A which (w/o this commit) would not track the sequencer at
   all in this checkpoint (since there is nothing to replay)

=> we MUST also remember that we already read up until 2, otherwise we'll
   re-read 2 after replay

=> the partition checkpoint needs the local seen max (no matter if there's
   something to to persist)
