### PR TITLE
refactor: Generailize routing sinks

### DIFF
--- a/data_types/src/database_rules.rs
+++ b/data_types/src/database_rules.rs
@@ -329,12 +329,12 @@ pub struct ShardConfig {
     pub ignore_errors: bool,
     /// Mapping between shard IDs and node groups. Other sharding rules use
     /// ShardId as targets.
-    pub shards: Arc<HashMap<ShardId, Shard>>,
+    pub shards: Arc<HashMap<ShardId, Sink>>,
 }
 
-/// Configuration for a specific IOx shard
+/// Configuration for a specific IOx sink
 #[derive(Debug, Eq, PartialEq, Clone)]
-pub enum Shard {
+pub enum Sink {
     Iox(NodeGroup),
 }
 

--- a/data_types/src/database_rules.rs
+++ b/data_types/src/database_rules.rs
@@ -336,6 +336,7 @@ pub struct ShardConfig {
 #[derive(Debug, Eq, PartialEq, Clone)]
 pub enum Sink {
     Iox(NodeGroup),
+    Kafka(KafkaProducer),
 }
 
 struct LineHasher<'a, 'b, 'c> {
@@ -390,6 +391,9 @@ pub struct MatcherToShard {
 
 /// A collection of IOx nodes
 pub type NodeGroup = Vec<ServerId>;
+
+#[derive(Debug, Eq, PartialEq, Clone)]
+pub struct KafkaProducer {}
 
 /// HashRing is a rule for creating a hash key for a row and mapping that to
 /// an individual node on a ring.

--- a/data_types/src/database_rules.rs
+++ b/data_types/src/database_rules.rs
@@ -287,9 +287,9 @@ pub struct StrftimeColumn {
 
 /// A routing config defines the destination where to route all data plane operations
 /// for a given database.
-#[derive(Debug, Eq, PartialEq, Clone, Default)]
+#[derive(Debug, Eq, PartialEq, Clone)]
 pub struct RoutingConfig {
-    pub target: NodeGroup,
+    pub sink: Sink,
 }
 
 /// ShardId maps to a nodegroup that holds the the shard.

--- a/generated_types/protos/influxdata/iox/management/v1/database_rules.proto
+++ b/generated_types/protos/influxdata/iox/management/v1/database_rules.proto
@@ -118,5 +118,7 @@ message DatabaseRules {
 }
 
 message RoutingConfig {
-  NodeGroup target = 1;
+  NodeGroup target = 1 [deprecated = true];
+
+  Sink sink = 2;
 }

--- a/generated_types/protos/influxdata/iox/management/v1/shard.proto
+++ b/generated_types/protos/influxdata/iox/management/v1/shard.proto
@@ -33,7 +33,7 @@ message ShardConfig {
 
   /// Mapping between shard IDs and node groups. Other sharding rules use
   /// ShardId as targets.
-  map<uint32, Shard> shards = 4;
+  map<uint32, Sink> shards = 4;
 }
 
 // Maps a matcher with specific shard. If the line/row matches
@@ -53,7 +53,7 @@ message Matcher {
 }
 
 // Configuration for a specific shard
-message Shard {
+message Sink {
   oneof sink {
     NodeGroup iox = 1;
   }

--- a/generated_types/protos/influxdata/iox/management/v1/shard.proto
+++ b/generated_types/protos/influxdata/iox/management/v1/shard.proto
@@ -52,10 +52,11 @@ message Matcher {
   string predicate = 2;
 }
 
-// Configuration for a specific shard
+// Configuration for a specific sink
 message Sink {
   oneof sink {
     NodeGroup iox = 1;
+    KafkaProducer kafka = 2;
   }
 }
 
@@ -65,6 +66,11 @@ message NodeGroup {
     uint32 id = 1;
   }
   repeated Node nodes = 1;
+}
+
+// Kafka producer configuration
+message KafkaProducer {
+
 }
 
 // HashRing is a rule for creating a hash key for a row and mapping that to

--- a/generated_types/src/database_rules.rs
+++ b/generated_types/src/database_rules.rs
@@ -14,6 +14,7 @@ use crate::influxdata::iox::management::v1 as management;
 mod lifecycle;
 mod partition;
 mod shard;
+mod sink;
 
 impl From<DatabaseRules> for management::DatabaseRules {
     fn from(rules: DatabaseRules) -> Self {

--- a/generated_types/src/database_rules.rs
+++ b/generated_types/src/database_rules.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 use thiserror::Error;
 
 use data_types::database_rules::{
-    DatabaseRules, RoutingConfig, RoutingRules, WriteBufferConnection,
+    DatabaseRules, RoutingConfig, RoutingRules, Sink, WriteBufferConnection,
 };
 use data_types::DatabaseName;
 
@@ -101,8 +101,10 @@ impl TryFrom<management::database_rules::RoutingRules> for RoutingRules {
 
 impl From<RoutingConfig> for management::RoutingConfig {
     fn from(routing_config: RoutingConfig) -> Self {
+        #[allow(deprecated)]
         Self {
-            target: Some(routing_config.target.into()),
+            target: None,
+            sink: Some(routing_config.sink.into()),
         }
     }
 }
@@ -111,8 +113,13 @@ impl TryFrom<management::RoutingConfig> for RoutingConfig {
     type Error = FieldViolation;
 
     fn try_from(proto: management::RoutingConfig) -> Result<Self, Self::Error> {
+        #[allow(deprecated)]
         Ok(Self {
-            target: proto.target.required("target")?,
+            sink: if proto.target.is_some() {
+                Sink::Iox(proto.target.required("target")?)
+            } else {
+                proto.sink.required("sink")?
+            },
         })
     }
 }
@@ -196,5 +203,63 @@ mod tests {
 
         // These should be none as preserved on non-protobuf DatabaseRules
         assert!(back.routing_rules.is_none());
+    }
+
+    #[test]
+    fn test_routing_rules_conversion() {
+        let protobuf = management::DatabaseRules {
+            name: "database".to_string(),
+            routing_rules: None,
+            ..Default::default()
+        };
+
+        let rules: DatabaseRules = protobuf.try_into().unwrap();
+        let back: management::DatabaseRules = rules.into();
+
+        assert!(back.routing_rules.is_none());
+
+        #[allow(deprecated)]
+        let routing_config = management::RoutingConfig {
+            target: Some(management::NodeGroup {
+                nodes: vec![management::node_group::Node { id: 1234 }],
+            }),
+            sink: None,
+        };
+
+        let protobuf = management::DatabaseRules {
+            name: "database".to_string(),
+            routing_rules: Some(management::database_rules::RoutingRules::RoutingConfig(
+                routing_config,
+            )),
+            ..Default::default()
+        };
+
+        let rules: DatabaseRules = protobuf.try_into().unwrap();
+        let back: management::DatabaseRules = rules.into();
+
+        assert!(back.routing_rules.is_some());
+
+        #[allow(deprecated)]
+        let routing_config = management::RoutingConfig {
+            target: None,
+            sink: Some(management::Sink {
+                sink: Some(management::sink::Sink::Iox(management::NodeGroup {
+                    nodes: vec![management::node_group::Node { id: 1234 }],
+                })),
+            }),
+        };
+
+        let protobuf = management::DatabaseRules {
+            name: "database".to_string(),
+            routing_rules: Some(management::database_rules::RoutingRules::RoutingConfig(
+                routing_config,
+            )),
+            ..Default::default()
+        };
+
+        let rules: DatabaseRules = protobuf.try_into().unwrap();
+        let back: management::DatabaseRules = rules.into();
+
+        assert!(back.routing_rules.is_some());
     }
 }

--- a/generated_types/src/database_rules.rs
+++ b/generated_types/src/database_rules.rs
@@ -219,28 +219,7 @@ mod tests {
         assert!(back.routing_rules.is_none());
 
         #[allow(deprecated)]
-        let routing_config = management::RoutingConfig {
-            target: Some(management::NodeGroup {
-                nodes: vec![management::node_group::Node { id: 1234 }],
-            }),
-            sink: None,
-        };
-
-        let protobuf = management::DatabaseRules {
-            name: "database".to_string(),
-            routing_rules: Some(management::database_rules::RoutingRules::RoutingConfig(
-                routing_config,
-            )),
-            ..Default::default()
-        };
-
-        let rules: DatabaseRules = protobuf.try_into().unwrap();
-        let back: management::DatabaseRules = rules.into();
-
-        assert!(back.routing_rules.is_some());
-
-        #[allow(deprecated)]
-        let routing_config = management::RoutingConfig {
+        let routing_config_sink = management::RoutingConfig {
             target: None,
             sink: Some(management::Sink {
                 sink: Some(management::sink::Sink::Iox(management::NodeGroup {
@@ -252,7 +231,7 @@ mod tests {
         let protobuf = management::DatabaseRules {
             name: "database".to_string(),
             routing_rules: Some(management::database_rules::RoutingRules::RoutingConfig(
-                routing_config,
+                routing_config_sink.clone(),
             )),
             ..Default::default()
         };
@@ -260,6 +239,37 @@ mod tests {
         let rules: DatabaseRules = protobuf.try_into().unwrap();
         let back: management::DatabaseRules = rules.into();
 
-        assert!(back.routing_rules.is_some());
+        assert_eq!(
+            back.routing_rules,
+            Some(management::database_rules::RoutingRules::RoutingConfig(
+                routing_config_sink.clone()
+            ))
+        );
+
+        #[allow(deprecated)]
+        let routing_config_target = management::RoutingConfig {
+            target: Some(management::NodeGroup {
+                nodes: vec![management::node_group::Node { id: 1234 }],
+            }),
+            sink: None,
+        };
+
+        let protobuf = management::DatabaseRules {
+            name: "database".to_string(),
+            routing_rules: Some(management::database_rules::RoutingRules::RoutingConfig(
+                routing_config_target,
+            )),
+            ..Default::default()
+        };
+
+        let rules: DatabaseRules = protobuf.try_into().unwrap();
+        let back: management::DatabaseRules = rules.into();
+
+        assert_eq!(
+            back.routing_rules,
+            Some(management::database_rules::RoutingRules::RoutingConfig(
+                routing_config_sink
+            ))
+        );
     }
 }

--- a/generated_types/src/database_rules/sink.rs
+++ b/generated_types/src/database_rules/sink.rs
@@ -1,0 +1,26 @@
+use std::convert::TryFrom;
+
+use data_types::database_rules::Sink;
+
+use crate::google::{FieldViolation, FromField};
+use crate::influxdata::iox::management::v1 as management;
+
+impl From<Sink> for management::Sink {
+    fn from(shard: Sink) -> Self {
+        let sink = match shard {
+            Sink::Iox(node_group) => management::sink::Sink::Iox(node_group.into()),
+        };
+        management::Sink { sink: Some(sink) }
+    }
+}
+
+impl TryFrom<management::Sink> for Sink {
+    type Error = FieldViolation;
+
+    fn try_from(proto: management::Sink) -> Result<Self, Self::Error> {
+        let sink = proto.sink.ok_or_else(|| FieldViolation::required(""))?;
+        Ok(match sink {
+            management::sink::Sink::Iox(node_group) => Sink::Iox(node_group.scope("node_group")?),
+        })
+    }
+}

--- a/generated_types/src/database_rules/sink.rs
+++ b/generated_types/src/database_rules/sink.rs
@@ -1,6 +1,6 @@
 use std::convert::TryFrom;
 
-use data_types::database_rules::Sink;
+use data_types::database_rules::{KafkaProducer, Sink};
 
 use crate::google::{FieldViolation, FromField};
 use crate::influxdata::iox::management::v1 as management;
@@ -9,6 +9,7 @@ impl From<Sink> for management::Sink {
     fn from(shard: Sink) -> Self {
         let sink = match shard {
             Sink::Iox(node_group) => management::sink::Sink::Iox(node_group.into()),
+            Sink::Kafka(kafka) => management::sink::Sink::Kafka(kafka.into()),
         };
         management::Sink { sink: Some(sink) }
     }
@@ -21,6 +22,21 @@ impl TryFrom<management::Sink> for Sink {
         let sink = proto.sink.ok_or_else(|| FieldViolation::required(""))?;
         Ok(match sink {
             management::sink::Sink::Iox(node_group) => Sink::Iox(node_group.scope("node_group")?),
+            management::sink::Sink::Kafka(kafka) => Sink::Kafka(kafka.scope("kafka")?),
         })
+    }
+}
+
+impl From<KafkaProducer> for management::KafkaProducer {
+    fn from(_: KafkaProducer) -> Self {
+        Self {}
+    }
+}
+
+impl TryFrom<management::KafkaProducer> for KafkaProducer {
+    type Error = FieldViolation;
+
+    fn try_from(_: management::KafkaProducer) -> Result<Self, Self::Error> {
+        Ok(Self {})
     }
 }

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -80,7 +80,7 @@ use snafu::{OptionExt, ResultExt, Snafu};
 
 use data_types::{
     database_rules::{
-        DatabaseRules, NodeGroup, RoutingRules, Shard, ShardConfig, ShardId, WriteBufferConnection,
+        DatabaseRules, NodeGroup, RoutingRules, ShardConfig, ShardId, Sink, WriteBufferConnection,
     },
     database_state::DatabaseStateCode,
     job::Job,
@@ -848,14 +848,14 @@ where
         &self,
         db_name: &str,
         db: &Db,
-        shards: Arc<HashMap<u32, Shard>>,
+        shards: Arc<HashMap<u32, Sink>>,
         sharded_entry: ShardedEntry,
     ) -> Result<()> {
         match sharded_entry.shard_id {
             Some(shard_id) => {
                 let shard = shards.get(&shard_id).context(ShardNotFound { shard_id })?;
                 match shard {
-                    Shard::Iox(node_group) => {
+                    Sink::Iox(node_group) => {
                         self.write_entry_downstream(db_name, node_group, sharded_entry.entry)
                             .await?
                     }
@@ -1741,7 +1741,7 @@ mod tests {
                     ..Default::default()
                 }),
                 shards: Arc::new(
-                    vec![(TEST_SHARD_ID, Shard::Iox(remote_ids.clone()))]
+                    vec![(TEST_SHARD_ID, Sink::Iox(remote_ids.clone()))]
                         .into_iter()
                         .collect(),
                 ),

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -870,6 +870,9 @@ where
                 self.write_entry_downstream(db_name, node_group, entry)
                     .await
             }
+            Sink::Kafka(_) => {
+                todo!("write to write buffer")
+            }
         }
     }
 

--- a/src/influxdb_ioxd/rpc/management.rs
+++ b/src/influxdb_ioxd/rpc/management.rs
@@ -148,7 +148,6 @@ where
             .update_db_rules(&db_name, |_orig| Ok(rules))
             .await
             .map_err(UpdateError::from)?;
-
         Ok(Response::new(UpdateDatabaseResponse {
             rules: Some(updated_rules.as_ref().clone().into()),
         }))

--- a/tests/end_to_end_cases/write_api.rs
+++ b/tests/end_to_end_cases/write_api.rs
@@ -513,9 +513,13 @@ async fn test_write_routed_no_shard() {
             .get_database(db_name)
             .await
             .expect("cannot get database on router");
+        #[allow(deprecated)]
         let routing_config = RoutingConfig {
-            target: Some(NodeGroup {
-                nodes: vec![Node { id: *remote_id }],
+            target: None,
+            sink: Some(Sink {
+                sink: Some(sink::Sink::Iox(NodeGroup {
+                    nodes: vec![Node { id: *remote_id }],
+                })),
             }),
         };
         router_db_rules.routing_rules = Some(RoutingRules::RoutingConfig(routing_config));

--- a/tests/end_to_end_cases/write_api.rs
+++ b/tests/end_to_end_cases/write_api.rs
@@ -11,8 +11,8 @@ use entry::{
 };
 use generated_types::influxdata::iox::management::v1::database_rules::RoutingRules;
 use generated_types::influxdata::iox::management::v1::{
-    node_group::Node, shard, HashRing, Matcher, MatcherToShard, NodeGroup, RoutingConfig, Shard,
-    ShardConfig,
+    node_group::Node, sink, HashRing, Matcher, MatcherToShard, NodeGroup, RoutingConfig,
+    ShardConfig, Sink,
 };
 use influxdb_line_protocol::parse_lines;
 use std::collections::HashMap;
@@ -225,8 +225,8 @@ async fn test_write_routed() {
         shards: vec![
             (
                 TEST_SHARD_ID_1,
-                Shard {
-                    sink: Some(shard::Sink::Iox(NodeGroup {
+                Sink {
+                    sink: Some(sink::Sink::Iox(NodeGroup {
                         nodes: vec![Node {
                             id: TEST_REMOTE_ID_1,
                         }],
@@ -235,8 +235,8 @@ async fn test_write_routed() {
             ),
             (
                 TEST_SHARD_ID_2,
-                Shard {
-                    sink: Some(shard::Sink::Iox(NodeGroup {
+                Sink {
+                    sink: Some(sink::Sink::Iox(NodeGroup {
                         nodes: vec![Node {
                             id: TEST_REMOTE_ID_2,
                         }],
@@ -245,8 +245,8 @@ async fn test_write_routed() {
             ),
             (
                 TEST_SHARD_ID_3,
-                Shard {
-                    sink: Some(shard::Sink::Iox(NodeGroup {
+                Sink {
+                    sink: Some(sink::Sink::Iox(NodeGroup {
                         nodes: vec![Node {
                             id: TEST_REMOTE_ID_3,
                         }],
@@ -398,8 +398,8 @@ async fn test_write_routed_errors() {
         }],
         shards: vec![(
             TEST_SHARD_ID,
-            Shard {
-                sink: Some(shard::Sink::Iox(NodeGroup {
+            Sink {
+                sink: Some(sink::Sink::Iox(NodeGroup {
                     nodes: vec![Node { id: TEST_REMOTE_ID }],
                 })),
             },


### PR DESCRIPTION
__Context and rationale__

We can currently mirror the full ingest traffic of a large internal bucket. However, we don't want to process the full bucket because it contains a lot of irrelevant tables.

The current "sharding config" mechanism allows to achieve that. The sharding config can split an input batch into output batches according to matching rules which can match on table names. All matching tables can go into one shard while everything else can be dropped by mapping it to a shard connected to a "devnull" destination (currently there is no such devnull destination and we return an error, but the mirroring mechanism ignores the error and doesn't retry).

It's also possible to ignore some tables while routing everything else to a given destination. We're already doing both things in our staging environment using the sharding config.

However, sharding config currently only works with gRPC routing. The kafka router config has not been hooked up to the router/sharding config and instead uses database-global configuration.

The goal of this PR is to prepare the ground for having a per-shard/per-route kafka configuration so that we'll be able to receive a full bucket as input and write to kafka only the subset that we care about.

To complicate things a bit, we have two ways of defining routing config: sharding config and routing config. The routing config is a simplified sharding config for when you only have a single shard and you don't want to learn a complicated config just to route all the rows of a database into one single destination.

__Steps__

This PR:

commit 1) Rename protobuf message Shard to Sink.  The shard message type was a wrapper around a "nodegroup" and was intended to represent a "destination" of the sharding operation. Sink is a better name since defining a destination does not depend on the routing mechanism (sharding config vs direct routing config)

commit 2) Add Sink to RoutingConfig. This aligns the routing config and the sharding config's approach on how a destination (sink) is defined.

This PR preserves backwards compatibility with configs and clients pushing configs.
Once we land this PR we can update our config pushers in staging and then we can remove deprecated config fields.

__Next step__

Next step: Add kafka variant to Sink, so that both RoutingConfig and ShardingConfig can either write directly to an iox node via gRPC or write to a kafka topic.