### PR TITLE
fix: fix flaky `test_unload_partition_chunk`

### DIFF
--- a/tests/end_to_end_cases/management_cli.rs
+++ b/tests/end_to_end_cases/management_cli.rs
@@ -722,13 +722,14 @@ async fn test_unload_partition_chunk() {
     let lp_data = vec!["cpu,region=west user=23.2 10"];
     load_lp(addr, &db_name, lp_data);
 
-    wait_for_exact_chunk_states(
+    let mut chunks = wait_for_exact_chunk_states(
         &fixture,
         &db_name,
         vec![ChunkStorage::ReadBufferAndObjectStore],
         std::time::Duration::from_secs(5),
     )
     .await;
+    let chunk = chunks.pop().unwrap();
 
     Command::cargo_bin("influxdb_iox")
         .unwrap()
@@ -738,7 +739,7 @@ async fn test_unload_partition_chunk() {
         .arg(&db_name)
         .arg("cpu")
         .arg("cpu")
-        .arg("1")
+        .arg(chunk.id.to_string())
         .arg("--host")
         .arg(addr)
         .assert()

--- a/tests/end_to_end_cases/scenario.rs
+++ b/tests/end_to_end_cases/scenario.rs
@@ -432,7 +432,7 @@ pub async fn wait_for_exact_chunk_states(
     db_name: &str,
     mut desired_storages: Vec<ChunkStorage>,
     wait_time: std::time::Duration,
-) {
+) -> Vec<ChunkSummary> {
     // ensure consistent order
     desired_storages.sort();
 
@@ -452,7 +452,8 @@ async fn wait_for_state<P>(
     mut pred: P,
     fail_message: String,
     wait_time: std::time::Duration,
-) where
+) -> Vec<ChunkSummary>
+where
     P: FnMut(&[ChunkSummary]) -> bool,
 {
     let t_start = std::time::Instant::now();
@@ -461,7 +462,7 @@ async fn wait_for_state<P>(
         let chunks = list_chunks(fixture, db_name).await;
 
         if pred(&chunks) {
-            return;
+            return chunks;
         }
 
         // Log the current status of the chunks


### PR DESCRIPTION
Do not rely on the fact that the chunk ID is 1, because compaction and
other mechanisms might create chunks using different IDs.

Closes #2109.