### PR TITLE
refactor: Remove deprecated target field in RoutingConfig

### DIFF
--- a/generated_types/protos/influxdata/iox/management/v1/database_rules.proto
+++ b/generated_types/protos/influxdata/iox/management/v1/database_rules.proto
@@ -118,7 +118,5 @@ message DatabaseRules {
 }
 
 message RoutingConfig {
-  NodeGroup target = 1 [deprecated = true];
-
   Sink sink = 2;
 }

--- a/generated_types/src/database_rules.rs
+++ b/generated_types/src/database_rules.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 use thiserror::Error;
 
 use data_types::database_rules::{
-    DatabaseRules, RoutingConfig, RoutingRules, Sink, WriteBufferConnection,
+    DatabaseRules, RoutingConfig, RoutingRules, WriteBufferConnection,
 };
 use data_types::DatabaseName;
 
@@ -101,9 +101,7 @@ impl TryFrom<management::database_rules::RoutingRules> for RoutingRules {
 
 impl From<RoutingConfig> for management::RoutingConfig {
     fn from(routing_config: RoutingConfig) -> Self {
-        #[allow(deprecated)]
         Self {
-            target: None,
             sink: Some(routing_config.sink.into()),
         }
     }
@@ -113,13 +111,8 @@ impl TryFrom<management::RoutingConfig> for RoutingConfig {
     type Error = FieldViolation;
 
     fn try_from(proto: management::RoutingConfig) -> Result<Self, Self::Error> {
-        #[allow(deprecated)]
         Ok(Self {
-            sink: if proto.target.is_some() {
-                Sink::Iox(proto.target.required("target")?)
-            } else {
-                proto.sink.required("sink")?
-            },
+            sink: proto.sink.required("sink")?,
         })
     }
 }
@@ -218,9 +211,7 @@ mod tests {
 
         assert!(back.routing_rules.is_none());
 
-        #[allow(deprecated)]
         let routing_config_sink = management::RoutingConfig {
-            target: None,
             sink: Some(management::Sink {
                 sink: Some(management::sink::Sink::Iox(management::NodeGroup {
                     nodes: vec![management::node_group::Node { id: 1234 }],
@@ -232,32 +223,6 @@ mod tests {
             name: "database".to_string(),
             routing_rules: Some(management::database_rules::RoutingRules::RoutingConfig(
                 routing_config_sink.clone(),
-            )),
-            ..Default::default()
-        };
-
-        let rules: DatabaseRules = protobuf.try_into().unwrap();
-        let back: management::DatabaseRules = rules.into();
-
-        assert_eq!(
-            back.routing_rules,
-            Some(management::database_rules::RoutingRules::RoutingConfig(
-                routing_config_sink.clone()
-            ))
-        );
-
-        #[allow(deprecated)]
-        let routing_config_target = management::RoutingConfig {
-            target: Some(management::NodeGroup {
-                nodes: vec![management::node_group::Node { id: 1234 }],
-            }),
-            sink: None,
-        };
-
-        let protobuf = management::DatabaseRules {
-            name: "database".to_string(),
-            routing_rules: Some(management::database_rules::RoutingRules::RoutingConfig(
-                routing_config_target,
             )),
             ..Default::default()
         };

--- a/tests/end_to_end_cases/write_api.rs
+++ b/tests/end_to_end_cases/write_api.rs
@@ -513,9 +513,7 @@ async fn test_write_routed_no_shard() {
             .get_database(db_name)
             .await
             .expect("cannot get database on router");
-        #[allow(deprecated)]
         let routing_config = RoutingConfig {
-            target: None,
             sink: Some(Sink {
                 sink: Some(sink::Sink::Iox(NodeGroup {
                     nodes: vec![Node { id: *remote_id }],


### PR DESCRIPTION
Removes backward compatibility layer introduced in the config API refactoring in #2100
