### PR TITLE
fix: Fix typo in print_cpu command name

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -247,7 +247,7 @@ jobs:
       - cache_restore
       - run:
           name: Print rustc target CPU options
-          command: cargo build --release --features="aws,gcp,azure" --bin print_cpus
+          command: cargo build --release --features="aws,gcp,azure" --bin print_cpu
       - run:
           name: Cargo release build with target arch set for CRoaring
           command: ROARING_ARCH=x86-64 cargo build --release --features="aws,gcp,azure"


### PR DESCRIPTION
Typo in introduced in #2114

See https://app.circleci.com/pipelines/github/influxdata/influxdb_iox/8576/workflows/987faa6c-c6ce-41c0-981c-8667c61018b5/jobs/45429