### PR TITLE
chore: target architecture with avx2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -250,7 +250,7 @@ jobs:
           command: cargo build --release --features="aws,gcp,azure" --bin print_cpus
       - run:
           name: Cargo release build with target arch set for CRoaring
-          command: ROARING_ARCH=x86-64 cargo build --release --features="aws,gcp,azure"
+          command: ROARING_ARCH=haswell cargo build --release --features="aws,gcp,azure"
       - run: |
           echo sha256sum after build is
           sha256sum target/release/influxdb_iox


### PR DESCRIPTION
Closes https://github.com/influxdata/influxdb_iox/issues/2094

I think that the current setting for `ROARING_ARCH` of `x86-64` may not be specific enough to ensure that things are built with the avx2 instructions. ~Ivy Bridge~ Haswell has those so I think that this should work better. 🤞 