### PR TITLE
feat: Make CatalogChunk first/last write times required

### DIFF
--- a/data_types/src/chunk_metadata.rs
+++ b/data_types/src/chunk_metadata.rs
@@ -140,12 +140,12 @@ pub struct ChunkSummary {
     /// The earliest time at which data contained within this chunk was written
     /// into IOx. Note due to the compaction, etc... this may not be the chunk
     /// that data was originally written into
-    pub time_of_first_write: Option<DateTime<Utc>>,
+    pub time_of_first_write: DateTime<Utc>,
 
     /// The latest time at which data contained within this chunk was written
     /// into IOx. Note due to the compaction, etc... this may not be the chunk
     /// that data was originally written into
-    pub time_of_last_write: Option<DateTime<Utc>>,
+    pub time_of_last_write: DateTime<Utc>,
 
     /// Time at which this chunk was marked as closed. Note this is
     /// not the same as the timestamps on the data itself
@@ -173,66 +173,14 @@ pub struct DetailedChunkSummary {
 }
 
 impl ChunkSummary {
-    /// Construct a ChunkSummary that has None for all timestamps
-    #[allow(clippy::too_many_arguments)]
-    pub fn new_without_timestamps(
-        partition_key: Arc<str>,
-        table_name: Arc<str>,
-        id: u32,
-        storage: ChunkStorage,
-        lifecycle_action: Option<ChunkLifecycleAction>,
-        memory_bytes: usize,
-        object_store_bytes: usize,
-        row_count: usize,
-    ) -> Self {
-        Self {
-            partition_key,
-            table_name,
-            id,
-            storage,
-            lifecycle_action,
-            memory_bytes,
-            object_store_bytes,
-            row_count,
-            time_of_last_access: None,
-            time_of_first_write: None,
-            time_of_last_write: None,
-            time_closed: None,
-        }
-    }
-
-    /// Return a new ChunkSummary with None for all timestamps
-    pub fn normalize(self) -> Self {
-        let ChunkSummary {
-            partition_key,
-            table_name,
-            id,
-            storage,
-            lifecycle_action,
-            memory_bytes,
-            object_store_bytes,
-            row_count,
-            ..
-        } = self;
-        Self::new_without_timestamps(
-            partition_key,
-            table_name,
-            id,
-            storage,
-            lifecycle_action,
-            memory_bytes,
-            object_store_bytes,
-            row_count,
-        )
-    }
-
-    /// Normalizes a set of ChunkSummaries for comparison by removing timestamps
-    pub fn normalize_summaries(summaries: Vec<Self>) -> Vec<Self> {
-        let mut summaries = summaries
-            .into_iter()
-            .map(|summary| summary.normalize())
-            .collect::<Vec<_>>();
-        summaries.sort_unstable();
-        summaries
+    pub fn equal_without_timestamps(&self, other: &Self) -> bool {
+        self.partition_key == other.partition_key
+            && self.table_name == other.table_name
+            && self.id == other.id
+            && self.storage == other.storage
+            && self.lifecycle_action == other.lifecycle_action
+            && self.memory_bytes == other.memory_bytes
+            && self.object_store_bytes == other.object_store_bytes
+            && self.row_count == other.row_count
     }
 }

--- a/data_types/src/chunk_metadata.rs
+++ b/data_types/src/chunk_metadata.rs
@@ -1,9 +1,8 @@
 //! Module contains a representation of chunk metadata
-use std::sync::Arc;
-
 use crate::partition_metadata::PartitionAddr;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+use std::sync::Arc;
 
 /// Address of the chunk within the catalog
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]

--- a/generated_types/src/chunk.rs
+++ b/generated_types/src/chunk.rs
@@ -36,8 +36,8 @@ impl From<ChunkSummary> for management::Chunk {
             object_store_bytes: object_store_bytes as u64,
             row_count: row_count as u64,
             time_of_last_access: time_of_last_access.map(Into::into),
-            time_of_first_write: time_of_first_write.map(Into::into),
-            time_of_last_write: time_of_last_write.map(Into::into),
+            time_of_first_write: Some(time_of_first_write.into()),
+            time_of_last_write: Some(time_of_last_write.into()),
             time_closed: time_closed.map(Into::into),
         }
     }
@@ -83,6 +83,15 @@ impl TryFrom<management::Chunk> for ChunkSummary {
             t.map(|t| convert_timestamp(t, field)).transpose()
         };
 
+        let required_timestamp = |t: Option<google_types::protobuf::Timestamp>,
+                                  field: &'static str| {
+            t.ok_or_else(|| FieldViolation {
+                field: field.to_string(),
+                description: "Timestamp is required".to_string(),
+            })
+            .and_then(|t| convert_timestamp(t, field))
+        };
+
         let management::Chunk {
             partition_key,
             table_name,
@@ -109,8 +118,8 @@ impl TryFrom<management::Chunk> for ChunkSummary {
             object_store_bytes: object_store_bytes as usize,
             row_count: row_count as usize,
             time_of_last_access: timestamp(time_of_last_access, "time_of_last_access")?,
-            time_of_first_write: timestamp(time_of_first_write, "time_of_first_write")?,
-            time_of_last_write: timestamp(time_of_last_write, "time_of_last_write")?,
+            time_of_first_write: required_timestamp(time_of_first_write, "time_of_first_write")?,
+            time_of_last_write: required_timestamp(time_of_last_write, "time_of_last_write")?,
             time_closed: timestamp(time_closed, "time_closed")?,
         })
     }
@@ -158,6 +167,7 @@ mod test {
 
     #[test]
     fn valid_proto_to_summary() {
+        let now = Utc::now();
         let proto = management::Chunk {
             partition_key: "foo".to_string(),
             table_name: "bar".to_string(),
@@ -168,8 +178,8 @@ mod test {
 
             storage: management::ChunkStorage::ObjectStoreOnly.into(),
             lifecycle_action: management::ChunkLifecycleAction::Moving.into(),
-            time_of_first_write: None,
-            time_of_last_write: None,
+            time_of_first_write: Some(now.into()),
+            time_of_last_write: Some(now.into()),
             time_closed: None,
             time_of_last_access: Some(google_types::protobuf::Timestamp {
                 seconds: 50,
@@ -187,8 +197,8 @@ mod test {
             row_count: 321,
             storage: ChunkStorage::ObjectStoreOnly,
             lifecycle_action: Some(ChunkLifecycleAction::Moving),
-            time_of_first_write: None,
-            time_of_last_write: None,
+            time_of_first_write: now,
+            time_of_last_write: now,
             time_closed: None,
             time_of_last_access: Some(Utc.timestamp_nanos(50_000_000_007)),
         };
@@ -202,6 +212,7 @@ mod test {
 
     #[test]
     fn valid_summary_to_proto() {
+        let now = Utc::now();
         let summary = ChunkSummary {
             partition_key: Arc::from("foo"),
             table_name: Arc::from("bar"),
@@ -211,8 +222,8 @@ mod test {
             row_count: 321,
             storage: ChunkStorage::ObjectStoreOnly,
             lifecycle_action: Some(ChunkLifecycleAction::Persisting),
-            time_of_first_write: None,
-            time_of_last_write: None,
+            time_of_first_write: now,
+            time_of_last_write: now,
             time_closed: None,
             time_of_last_access: Some(Utc.timestamp_nanos(12_000_100_007)),
         };
@@ -228,8 +239,8 @@ mod test {
             row_count: 321,
             storage: management::ChunkStorage::ObjectStoreOnly.into(),
             lifecycle_action: management::ChunkLifecycleAction::Persisting.into(),
-            time_of_first_write: None,
-            time_of_last_write: None,
+            time_of_first_write: Some(now.into()),
+            time_of_last_write: Some(now.into()),
             time_closed: None,
             time_of_last_access: Some(google_types::protobuf::Timestamp {
                 seconds: 12,

--- a/generated_types/src/chunk.rs
+++ b/generated_types/src/chunk.rs
@@ -1,8 +1,12 @@
-use crate::google::{FieldViolation, FromFieldOpt};
-use crate::influxdata::iox::management::v1 as management;
+use crate::{
+    google::{FieldViolation, FromFieldOpt},
+    influxdata::iox::management::v1 as management,
+};
 use data_types::chunk_metadata::{ChunkLifecycleAction, ChunkStorage, ChunkSummary};
-use std::convert::{TryFrom, TryInto};
-use std::sync::Arc;
+use std::{
+    convert::{TryFrom, TryInto},
+    sync::Arc,
+};
 
 /// Conversion code to management API chunk structure
 impl From<ChunkSummary> for management::Chunk {

--- a/lifecycle/src/lib.rs
+++ b/lifecycle/src/lib.rs
@@ -9,18 +9,19 @@
 )]
 
 use chrono::{DateTime, Utc};
-
-use data_types::chunk_metadata::{ChunkAddr, ChunkLifecycleAction, ChunkStorage};
-use data_types::database_rules::LifecycleRules;
-use data_types::DatabaseName;
-pub use guard::*;
+use data_types::{
+    chunk_metadata::{ChunkAddr, ChunkLifecycleAction, ChunkStorage},
+    database_rules::LifecycleRules,
+    DatabaseName,
+};
 use internal_types::access::AccessMetrics;
-pub use policy::*;
 use std::time::Instant;
 use tracker::TaskTracker;
 
 mod guard;
+pub use guard::*;
 mod policy;
+pub use policy::*;
 
 /// A trait that encapsulates the database logic that is automated by `LifecyclePolicy`
 pub trait LifecycleDb {

--- a/lifecycle/src/lib.rs
+++ b/lifecycle/src/lib.rs
@@ -178,7 +178,7 @@ pub trait LifecycleChunk {
     /// Returns the access metrics for this chunk
     fn access_metrics(&self) -> AccessMetrics;
 
-    fn time_of_last_write(&self) -> Option<DateTime<Utc>>;
+    fn time_of_last_write(&self) -> DateTime<Utc>;
 
     fn addr(&self) -> &ChunkAddr;
 

--- a/lifecycle/src/policy.rs
+++ b/lifecycle/src/policy.rs
@@ -1,21 +1,22 @@
-use std::convert::TryInto;
-use std::fmt::Debug;
-use std::time::{Duration, Instant};
-
-use chrono::{DateTime, Utc};
-use data_types::DatabaseName;
-use futures::future::BoxFuture;
-
-use data_types::chunk_metadata::{ChunkLifecycleAction, ChunkStorage};
-use data_types::database_rules::LifecycleRules;
-use observability_deps::tracing::{debug, info, trace, warn};
-use tracker::TaskTracker;
-
 use crate::{
     LifecycleChunk, LifecycleDb, LifecyclePartition, LockableChunk, LockablePartition,
     PersistHandle,
 };
+use chrono::{DateTime, Utc};
+use data_types::{
+    chunk_metadata::{ChunkLifecycleAction, ChunkStorage},
+    database_rules::LifecycleRules,
+    DatabaseName,
+};
+use futures::future::BoxFuture;
 use internal_types::access::AccessMetrics;
+use observability_deps::tracing::{debug, info, trace, warn};
+use std::{
+    convert::TryInto,
+    fmt::Debug,
+    time::{Duration, Instant},
+};
+use tracker::TaskTracker;
 
 /// Number of seconds to wait before retying a failed lifecycle action
 pub const LIFECYCLE_ACTION_BACKOFF: Duration = Duration::from_secs(10);
@@ -654,21 +655,20 @@ fn sort_free_candidates<P>(candidates: &mut Vec<FreeCandidate<'_, P>>) {
 
 #[cfg(test)]
 mod tests {
-    use std::cmp::max;
-    use std::collections::BTreeMap;
-    use std::convert::Infallible;
-    use std::num::{NonZeroU32, NonZeroUsize};
-    use std::sync::Arc;
-
-    use data_types::chunk_metadata::{ChunkAddr, ChunkStorage};
-    use tracker::{RwLock, TaskId, TaskRegistration, TaskRegistry};
-
+    use super::*;
     use crate::{
         ChunkLifecycleAction, LifecycleReadGuard, LifecycleWriteGuard, LockableChunk,
         LockablePartition, PersistHandle,
     };
-
-    use super::*;
+    use data_types::chunk_metadata::{ChunkAddr, ChunkStorage};
+    use std::{
+        cmp::max,
+        collections::BTreeMap,
+        convert::Infallible,
+        num::{NonZeroU32, NonZeroUsize},
+        sync::Arc,
+    };
+    use tracker::{RwLock, TaskId, TaskRegistration, TaskRegistry};
 
     #[derive(Debug, Eq, PartialEq)]
     enum MoverEvents {

--- a/server/src/db.rs
+++ b/server/src/db.rs
@@ -1332,7 +1332,7 @@ mod tests {
     use arrow::record_batch::RecordBatch;
     use arrow_util::{assert_batches_eq, assert_batches_sorted_eq};
     use bytes::Bytes;
-    use chrono::DateTime;
+    use chrono::{DateTime, TimeZone};
     use data_types::{
         chunk_metadata::ChunkStorage,
         database_rules::{LifecycleRules, PartitionTemplate, TemplatePart},
@@ -2629,10 +2629,7 @@ mod tests {
             let chunk = partition.open_chunk().unwrap();
             let chunk = chunk.read();
 
-            (
-                partition.last_write_at(),
-                chunk.time_of_last_write().unwrap(),
-            )
+            (partition.last_write_at(), chunk.time_of_last_write())
         };
 
         let entry = lp_to_entry("cpu bar=true 10");
@@ -2644,7 +2641,7 @@ mod tests {
             assert_eq!(last_write_prev, partition.last_write_at());
             let chunk = partition.open_chunk().unwrap();
             let chunk = chunk.read();
-            assert_eq!(chunk_last_write_prev, chunk.time_of_last_write().unwrap());
+            assert_eq!(chunk_last_write_prev, chunk.time_of_last_write());
         }
     }
 
@@ -2788,9 +2785,9 @@ mod tests {
         println!("Chunk: {:#?}", chunk);
 
         // then the chunk creation and rollover times are as expected
-        assert!(start < chunk.time_of_first_write().unwrap());
-        assert!(chunk.time_of_first_write().unwrap() < after_data_load);
-        assert!(chunk.time_of_first_write().unwrap() == chunk.time_of_last_write().unwrap());
+        assert!(start < chunk.time_of_first_write());
+        assert!(chunk.time_of_first_write() < after_data_load);
+        assert!(chunk.time_of_first_write() == chunk.time_of_last_write());
         assert!(after_data_load < chunk.time_closed().unwrap());
         assert!(chunk.time_closed().unwrap() < after_rollover);
     }
@@ -2850,18 +2847,21 @@ mod tests {
         print!("Partitions: {:?}", db.partition_keys().unwrap());
 
         let chunk_summaries = db.partition_chunk_summaries("1970-01-05T15");
-        let chunk_summaries = ChunkSummary::normalize_summaries(chunk_summaries);
 
-        let expected = vec![ChunkSummary::new_without_timestamps(
-            Arc::from("1970-01-05T15"),
-            Arc::from("cpu"),
-            0,
-            ChunkStorage::OpenMutableBuffer,
-            None,
-            70, // memory_size
-            0,  // os_size
-            1,
-        )];
+        let expected = vec![ChunkSummary {
+            partition_key: Arc::from("1970-01-05T15"),
+            table_name: Arc::from("cpu"),
+            id: 0,
+            storage: ChunkStorage::OpenMutableBuffer,
+            lifecycle_action: None,
+            memory_bytes: 70,      // memory_size
+            object_store_bytes: 0, // os_size
+            row_count: 1,
+            time_of_last_access: None,
+            time_of_first_write: Utc.timestamp_nanos(1),
+            time_of_last_write: Utc.timestamp_nanos(1),
+            time_closed: None,
+        }];
 
         let size: usize = db
             .chunk_summaries()
@@ -2872,11 +2872,14 @@ mod tests {
 
         assert_eq!(db.catalog.metrics().memory().mutable_buffer(), size);
 
-        assert_eq!(
-            expected, chunk_summaries,
-            "expected:\n{:#?}\n\nactual:{:#?}\n\n",
-            expected, chunk_summaries
-        );
+        for (expected_summary, actual_summary) in expected.iter().zip(chunk_summaries.iter()) {
+            assert!(
+                expected_summary.equal_without_timestamps(&actual_summary),
+                "expected:\n{:#?}\n\nactual:{:#?}\n\n",
+                expected_summary,
+                actual_summary
+            );
+        }
     }
 
     #[tokio::test]
@@ -2896,23 +2899,23 @@ mod tests {
         let summary = &chunk_summaries[0];
         assert_eq!(summary.id, 0, "summary; {:#?}", summary);
         assert!(
-            summary.time_of_first_write.unwrap() > start,
+            summary.time_of_first_write > start,
             "summary; {:#?}",
             summary
         );
         assert!(
-            summary.time_of_first_write.unwrap() < after_close,
+            summary.time_of_first_write < after_close,
             "summary; {:#?}",
             summary
         );
 
         assert!(
-            summary.time_of_last_write.unwrap() > after_first_write,
+            summary.time_of_last_write > after_first_write,
             "summary; {:#?}",
             summary
         );
         assert!(
-            summary.time_of_last_write.unwrap() < after_close,
+            summary.time_of_last_write < after_close,
             "summary; {:#?}",
             summary
         );
@@ -2930,8 +2933,8 @@ mod tests {
     }
 
     fn assert_first_last_times_eq(chunk_summary: &ChunkSummary) {
-        let first_write = chunk_summary.time_of_first_write.unwrap();
-        let last_write = chunk_summary.time_of_last_write.unwrap();
+        let first_write = chunk_summary.time_of_first_write;
+        let last_write = chunk_summary.time_of_last_write;
 
         assert_eq!(first_write, last_write);
     }
@@ -2941,8 +2944,8 @@ mod tests {
         before: DateTime<Utc>,
         after: DateTime<Utc>,
     ) {
-        let first_write = chunk_summary.time_of_first_write.unwrap();
-        let last_write = chunk_summary.time_of_last_write.unwrap();
+        let first_write = chunk_summary.time_of_first_write;
+        let last_write = chunk_summary.time_of_last_write;
 
         assert!(before < first_write);
         assert!(before < last_write);
@@ -2951,8 +2954,8 @@ mod tests {
     }
 
     fn assert_chunks_times_ordered(before: &ChunkSummary, after: &ChunkSummary) {
-        let before_last_write = before.time_of_last_write.unwrap();
-        let after_first_write = after.time_of_first_write.unwrap();
+        let before_last_write = before.time_of_last_write;
+        let after_first_write = after.time_of_first_write;
 
         assert!(before_last_write < after_first_write);
     }
@@ -2963,14 +2966,14 @@ mod tests {
     }
 
     fn assert_chunks_first_times_eq(a: &ChunkSummary, b: &ChunkSummary) {
-        let a_first_write = a.time_of_first_write.unwrap();
-        let b_first_write = b.time_of_first_write.unwrap();
+        let a_first_write = a.time_of_first_write;
+        let b_first_write = b.time_of_first_write;
         assert_eq!(a_first_write, b_first_write);
     }
 
     fn assert_chunks_last_times_eq(a: &ChunkSummary, b: &ChunkSummary) {
-        let a_last_write = a.time_of_last_write.unwrap();
-        let b_last_write = b.time_of_last_write.unwrap();
+        let a_last_write = a.time_of_last_write;
+        let b_last_write = b.time_of_last_write;
         assert_eq!(a_last_write, b_last_write);
     }
 
@@ -3132,49 +3135,62 @@ mod tests {
         assert_first_last_times_eq(&open_mb_t8);
         assert_first_last_times_between(&open_mb_t8, time7, time8);
 
-        let chunk_summaries = ChunkSummary::normalize_summaries(chunk_summaries);
-
         let lifecycle_action = None;
 
         let expected = vec![
-            ChunkSummary::new_without_timestamps(
-                Arc::from("1970-01-01T00"),
-                Arc::from("cpu"),
-                2,
-                ChunkStorage::ReadBufferAndObjectStore,
+            ChunkSummary {
+                partition_key: Arc::from("1970-01-01T00"),
+                table_name: Arc::from("cpu"),
+                id: 2,
+                storage: ChunkStorage::ReadBufferAndObjectStore,
                 lifecycle_action,
-                3332, // size of RB and OS chunks
-                1523, // size of parquet file
-                2,
-            ),
-            ChunkSummary::new_without_timestamps(
-                Arc::from("1970-01-05T15"),
-                Arc::from("cpu"),
-                0,
-                ChunkStorage::ClosedMutableBuffer,
+                memory_bytes: 3332,       // size of RB and OS chunks
+                object_store_bytes: 1523, // size of parquet file
+                row_count: 2,
+                time_of_last_access: None,
+                time_of_first_write: Utc.timestamp_nanos(1),
+                time_of_last_write: Utc.timestamp_nanos(1),
+                time_closed: None,
+            },
+            ChunkSummary {
+                partition_key: Arc::from("1970-01-05T15"),
+                table_name: Arc::from("cpu"),
+                id: 0,
+                storage: ChunkStorage::ClosedMutableBuffer,
                 lifecycle_action,
-                2510,
-                0, // no OS chunks
-                1,
-            ),
-            ChunkSummary::new_without_timestamps(
-                Arc::from("1970-01-05T15"),
-                Arc::from("cpu"),
-                1,
-                ChunkStorage::OpenMutableBuffer,
+                memory_bytes: 2510,
+                object_store_bytes: 0, // no OS chunks
+                row_count: 1,
+                time_of_last_access: None,
+                time_of_first_write: Utc.timestamp_nanos(1),
+                time_of_last_write: Utc.timestamp_nanos(1),
+                time_closed: None,
+            },
+            ChunkSummary {
+                partition_key: Arc::from("1970-01-05T15"),
+                table_name: Arc::from("cpu"),
+                id: 1,
+                storage: ChunkStorage::OpenMutableBuffer,
                 lifecycle_action,
-                87,
-                0, // no OS chunks
-                1,
-            ),
+                memory_bytes: 87,
+                object_store_bytes: 0, // no OS chunks
+                row_count: 1,
+                time_of_last_access: None,
+                time_of_first_write: Utc.timestamp_nanos(1),
+                time_of_last_write: Utc.timestamp_nanos(1),
+                time_closed: None,
+            },
         ];
 
         for (expected_summary, actual_summary) in expected.iter().zip(chunk_summaries.iter()) {
-            assert_eq!(
-                expected_summary, actual_summary,
+            assert!(
+                expected_summary.equal_without_timestamps(&actual_summary),
                 "\n\nexpected item:\n{:#?}\n\nactual item:\n{:#?}\n\n\
                      all expected:\n{:#?}\n\nall actual:\n{:#?}",
-                expected_summary, actual_summary, expected, chunk_summaries
+                expected_summary,
+                actual_summary,
+                expected,
+                chunk_summaries
             );
         }
 

--- a/server/src/db.rs
+++ b/server/src/db.rs
@@ -1,15 +1,17 @@
 //! This module contains the main IOx Database object which has the
 //! instances of the mutable buffer, read buffer, and object store
 
-use crate::db::catalog::chunk::ChunkStage;
-use crate::db::catalog::table::TableSchemaUpsertHandle;
 pub(crate) use crate::db::chunk::DbChunk;
-use crate::db::lifecycle::ArcDb;
 use crate::{
     db::{
         access::QueryCatalogAccess,
-        catalog::{chunk::CatalogChunk, partition::Partition, Catalog, TableNameFilter},
-        lifecycle::{LockableCatalogChunk, LockableCatalogPartition},
+        catalog::{
+            chunk::{CatalogChunk, ChunkStage},
+            partition::Partition,
+            table::TableSchemaUpsertHandle,
+            Catalog, TableNameFilter,
+        },
+        lifecycle::{ArcDb, LockableCatalogChunk, LockableCatalogPartition},
     },
     JobRegistry,
 };
@@ -31,13 +33,11 @@ use mutable_buffer::chunk::{ChunkMetrics as MutableBufferChunkMetrics, MBChunk};
 use object_store::{path::parsed::DirsAndFileName, ObjectStore};
 use observability_deps::tracing::{debug, error, info};
 use parking_lot::RwLock;
-use parquet_file::catalog::CatalogParquetInfo;
 use parquet_file::{
-    catalog::{CheckpointData, PreservedCatalog},
+    catalog::{CatalogParquetInfo, CheckpointData, PreservedCatalog},
     cleanup::{delete_files as delete_parquet_files, get_unreferenced_parquet_files},
 };
-use persistence_windows::checkpoint::ReplayPlan;
-use persistence_windows::persistence_windows::PersistenceWindows;
+use persistence_windows::{checkpoint::ReplayPlan, persistence_windows::PersistenceWindows};
 use query::{exec::Executor, predicate::Predicate, QueryDatabase};
 use rand_distr::{Distribution, Poisson};
 use snafu::{ensure, OptionExt, ResultExt, Snafu};
@@ -50,8 +50,10 @@ use std::{
     },
     time::{Duration, Instant},
 };
-use write_buffer::config::WriteBufferConfig;
-use write_buffer::core::{FetchHighWatermark, WriteBufferError};
+use write_buffer::{
+    config::WriteBufferConfig,
+    core::{FetchHighWatermark, WriteBufferError},
+};
 
 pub mod access;
 pub mod catalog;
@@ -1331,11 +1333,11 @@ mod tests {
     use arrow_util::{assert_batches_eq, assert_batches_sorted_eq};
     use bytes::Bytes;
     use chrono::DateTime;
-    use data_types::write_summary::TimestampSummary;
     use data_types::{
         chunk_metadata::ChunkStorage,
         database_rules::{LifecycleRules, PartitionTemplate, TemplatePart},
         partition_metadata::{ColumnSummary, InfluxDbType, StatValues, Statistics, TableSummary},
+        write_summary::TimestampSummary,
     };
     use entry::{test_helpers::lp_to_entry, Sequence};
     use futures::{stream, StreamExt, TryStreamExt};

--- a/server/src/db/catalog/chunk.rs
+++ b/server/src/db/catalog/chunk.rs
@@ -200,12 +200,12 @@ pub struct CatalogChunk {
     /// The earliest time at which data contained within this chunk was written
     /// into IOx. Note due to the compaction, etc... this may not be the chunk
     /// that data was originally written into
-    time_of_first_write: Option<DateTime<Utc>>,
+    time_of_first_write: DateTime<Utc>,
 
     /// The latest time at which data contained within this chunk was written
     /// into IOx. Note due to the compaction, etc... this may not be the chunk
     /// that data was originally written into
-    time_of_last_write: Option<DateTime<Utc>>,
+    time_of_last_write: DateTime<Utc>,
 
     /// Time at which this chunk was marked as closed. Note this is
     /// not the same as the timestamps on the data itself
@@ -269,8 +269,9 @@ impl CatalogChunk {
     ) -> Self {
         assert_eq!(chunk.table_name(), &addr.table_name);
 
-        let first_write = chunk.table_summary().time_of_first_write;
-        let last_write = chunk.table_summary().time_of_last_write;
+        let summary = chunk.table_summary();
+        let time_of_first_write = summary.time_of_first_write;
+        let time_of_last_write = summary.time_of_last_write;
 
         let stage = ChunkStage::Open { mb_chunk: chunk };
 
@@ -284,8 +285,8 @@ impl CatalogChunk {
             lifecycle_action: None,
             metrics,
             access_recorder: Default::default(),
-            time_of_first_write: Some(first_write),
-            time_of_last_write: Some(last_write),
+            time_of_first_write,
+            time_of_last_write,
             time_closed: None,
         };
         chunk.update_metrics();
@@ -302,8 +303,8 @@ impl CatalogChunk {
         metrics: ChunkMetrics,
     ) -> Self {
         let summary = chunk.table_summary();
-        let first_write = summary.time_of_first_write;
-        let last_write = summary.time_of_last_write;
+        let time_of_first_write = summary.time_of_first_write;
+        let time_of_last_write = summary.time_of_last_write;
 
         let stage = ChunkStage::Frozen {
             meta: Arc::new(ChunkMetadata {
@@ -323,8 +324,8 @@ impl CatalogChunk {
             lifecycle_action: None,
             metrics,
             access_recorder: Default::default(),
-            time_of_first_write: Some(first_write),
-            time_of_last_write: Some(last_write),
+            time_of_first_write,
+            time_of_last_write,
             time_closed: None,
         };
         chunk.update_metrics();
@@ -341,8 +342,8 @@ impl CatalogChunk {
         assert_eq!(chunk.table_name(), addr.table_name.as_ref());
 
         let summary = chunk.table_summary();
-        let first_write = summary.time_of_first_write;
-        let last_write = summary.time_of_last_write;
+        let time_of_first_write = summary.time_of_first_write;
+        let time_of_last_write = summary.time_of_last_write;
 
         // this is temporary
         let table_summary = TableSummary {
@@ -368,8 +369,8 @@ impl CatalogChunk {
             lifecycle_action: None,
             metrics,
             access_recorder: Default::default(),
-            time_of_first_write: Some(first_write),
-            time_of_last_write: Some(last_write),
+            time_of_first_write,
+            time_of_last_write,
             time_closed: None,
         };
         chunk.update_metrics();
@@ -411,11 +412,11 @@ impl CatalogChunk {
             .map_or(false, |action| action.metadata() == &lifecycle_action)
     }
 
-    pub fn time_of_first_write(&self) -> Option<DateTime<Utc>> {
+    pub fn time_of_first_write(&self) -> DateTime<Utc> {
         self.time_of_first_write
     }
 
-    pub fn time_of_last_write(&self) -> Option<DateTime<Utc>> {
+    pub fn time_of_last_write(&self) -> DateTime<Utc> {
         self.time_of_last_write
     }
 
@@ -478,18 +479,10 @@ impl CatalogChunk {
         self.metrics.timestamp_histogram.add(timestamps);
         self.access_recorder.record_access_now();
 
-        if let Some(t) = self.time_of_first_write {
-            self.time_of_first_write = Some(t.min(time_of_write))
-        } else {
-            self.time_of_first_write = Some(time_of_write)
-        }
+        self.time_of_first_write = self.time_of_first_write.min(time_of_write);
 
         // DateTime<Utc> isn't necessarily monotonic
-        if let Some(t) = self.time_of_last_write {
-            self.time_of_last_write = Some(t.max(time_of_write))
-        } else {
-            self.time_of_last_write = Some(time_of_write)
-        }
+        self.time_of_last_write = self.time_of_last_write.max(time_of_write);
 
         self.update_metrics();
     }
@@ -984,8 +977,6 @@ mod tests {
         let mb_chunk = make_mb_chunk(&addr.table_name);
         let chunk = CatalogChunk::new_open(addr, mb_chunk, ChunkMetrics::new_unregistered());
         assert!(matches!(chunk.stage(), &ChunkStage::Open { .. }));
-        assert!(chunk.time_of_first_write.is_some());
-        assert!(chunk.time_of_last_write.is_some());
     }
 
     #[tokio::test]

--- a/server/src/db/catalog/chunk.rs
+++ b/server/src/db/catalog/chunk.rs
@@ -1,16 +1,15 @@
 use crate::db::catalog::metrics::{StorageGauge, TimestampHistogram};
 use chrono::{DateTime, Utc};
-use data_types::instant::to_approximate_datetime;
-use data_types::write_summary::TimestampSummary;
 use data_types::{
     chunk_metadata::{
         ChunkAddr, ChunkColumnSummary, ChunkLifecycleAction, ChunkStorage, ChunkSummary,
         DetailedChunkSummary,
     },
+    instant::to_approximate_datetime,
     partition_metadata::TableSummary,
+    write_summary::TimestampSummary,
 };
-use internal_types::access::AccessRecorder;
-use internal_types::schema::Schema;
+use internal_types::{access::AccessRecorder, schema::Schema};
 use metrics::{Counter, Histogram, KeyValue};
 use mutable_buffer::chunk::{snapshot::ChunkSnapshot as MBChunkSnapshot, MBChunk};
 use observability_deps::tracing::debug;
@@ -969,14 +968,13 @@ impl CatalogChunk {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
     use entry::test_helpers::lp_to_entry;
     use mutable_buffer::chunk::{ChunkMetrics as MBChunkMetrics, MBChunk};
     use parquet_file::{
         chunk::ParquetChunk,
         test_utils::{make_chunk as make_parquet_chunk_with_store, make_object_store},
     };
-
-    use super::*;
 
     #[test]
     fn test_new_open() {

--- a/server/src/db/chunk.rs
+++ b/server/src/db/chunk.rs
@@ -5,8 +5,8 @@ use chrono::{DateTime, Utc};
 use data_types::partition_metadata;
 use datafusion::physical_plan::SendableRecordBatchStream;
 use datafusion_util::MemoryStream;
-use internal_types::access::AccessRecorder;
 use internal_types::{
+    access::AccessRecorder,
     schema::{sort::SortKey, Schema},
     selection::Selection,
 };

--- a/server/src/db/chunk.rs
+++ b/server/src/db/chunk.rs
@@ -612,8 +612,8 @@ mod tests {
         let chunk = chunks.into_iter().next().unwrap();
         let chunk = chunk.read();
         assert_eq!(chunk.storage().1, ChunkStorage::ObjectStoreOnly);
-        let first_write = chunk.time_of_first_write().unwrap();
-        let last_write = chunk.time_of_last_write().unwrap();
+        let first_write = chunk.time_of_first_write();
+        let last_write = chunk.time_of_last_write();
         assert_eq!(first_write, last_write);
         assert!(before_creation < first_write);
         assert!(last_write < after_creation);

--- a/server/src/db/lifecycle.rs
+++ b/server/src/db/lifecycle.rs
@@ -1,20 +1,23 @@
-use std::fmt::Display;
-use std::sync::Arc;
-use std::time::Instant;
-
-use chrono::{DateTime, TimeZone, Utc};
-
+use super::DbChunk;
+use crate::{
+    db::catalog::{chunk::CatalogChunk, partition::Partition},
+    Db,
+};
 use ::lifecycle::LifecycleDb;
-use data_types::chunk_metadata::{ChunkAddr, ChunkLifecycleAction, ChunkStorage};
-use data_types::database_rules::LifecycleRules;
-use data_types::error::ErrorLogger;
-use data_types::job::Job;
-use data_types::partition_metadata::Statistics;
-use data_types::DatabaseName;
+use chrono::{DateTime, TimeZone, Utc};
+use data_types::{
+    chunk_metadata::{ChunkAddr, ChunkLifecycleAction, ChunkStorage},
+    database_rules::LifecycleRules,
+    error::ErrorLogger,
+    job::Job,
+    partition_metadata::Statistics,
+    DatabaseName,
+};
 use datafusion::physical_plan::SendableRecordBatchStream;
-use internal_types::access::AccessMetrics;
-use internal_types::schema::merge::SchemaMerger;
-use internal_types::schema::{Schema, TIME_COLUMN_NAME};
+use internal_types::{
+    access::AccessMetrics,
+    schema::{merge::SchemaMerger, Schema, TIME_COLUMN_NAME},
+};
 use lifecycle::{
     LifecycleChunk, LifecyclePartition, LifecycleReadGuard, LifecycleWriteGuard, LockableChunk,
     LockablePartition,
@@ -22,11 +25,8 @@ use lifecycle::{
 use observability_deps::tracing::{info, trace};
 use persistence_windows::persistence_windows::FlushHandle;
 use query::QueryChunkMeta;
+use std::{fmt::Display, sync::Arc, time::Instant};
 use tracker::{RwLock, TaskTracker};
-
-use crate::db::catalog::chunk::CatalogChunk;
-use crate::db::catalog::partition::Partition;
-use crate::Db;
 
 pub(crate) use compact::compact_chunks;
 pub(crate) use drop::drop_chunk;
@@ -34,8 +34,6 @@ pub(crate) use error::{Error, Result};
 pub(crate) use move_chunk::move_chunk_to_read_buffer;
 pub(crate) use persist::persist_chunks;
 pub(crate) use unload::unload_read_buffer_chunk;
-
-use super::DbChunk;
 
 mod compact;
 mod drop;

--- a/server/src/db/lifecycle.rs
+++ b/server/src/db/lifecycle.rs
@@ -310,7 +310,7 @@ impl LifecycleChunk for CatalogChunk {
         self.access_recorder().get_metrics()
     }
 
-    fn time_of_last_write(&self) -> Option<DateTime<Utc>> {
+    fn time_of_last_write(&self) -> DateTime<Utc> {
         self.time_of_last_write()
     }
 

--- a/server/src/db/lifecycle/persist.rs
+++ b/server/src/db/lifecycle/persist.rs
@@ -54,17 +54,15 @@ pub fn persist_chunks(
 
         input_rows += chunk.table_summary().total_count();
 
-        time_of_first_write = match (time_of_first_write, chunk.time_of_first_write()) {
-            (Some(prev_first), Some(candidate_first)) => Some(prev_first.min(candidate_first)),
-            (Some(only), None) | (None, Some(only)) => Some(only),
-            (None, None) => None,
-        };
+        let candidate_first = chunk.time_of_first_write();
+        time_of_first_write = time_of_first_write
+            .map(|prev_first| prev_first.min(candidate_first))
+            .or(Some(candidate_first));
 
-        time_of_last_write = match (time_of_last_write, chunk.time_of_last_write()) {
-            (Some(prev_last), Some(candidate_last)) => Some(prev_last.max(candidate_last)),
-            (Some(only), None) | (None, Some(only)) => Some(only),
-            (None, None) => None,
-        };
+        let candidate_last = chunk.time_of_last_write();
+        time_of_last_write = time_of_last_write
+            .map(|prev_last| prev_last.max(candidate_last))
+            .or(Some(candidate_last));
 
         chunk.set_writing_to_object_store(&registration)?;
         query_chunks.push(DbChunk::snapshot(&*chunk));

--- a/server/src/db/lifecycle/persist.rs
+++ b/server/src/db/lifecycle/persist.rs
@@ -168,19 +168,16 @@ pub fn persist_chunks(
 
 #[cfg(test)]
 mod tests {
-    use std::num::{NonZeroU32, NonZeroU64};
-    use std::time::Instant;
-
+    use super::*;
+    use crate::{db::test_helpers::write_lp, utils::TestDb};
     use chrono::{TimeZone, Utc};
-
     use data_types::database_rules::LifecycleRules;
     use lifecycle::{LockableChunk, LockablePartition};
     use query::QueryDatabase;
-
-    use crate::db::test_helpers::write_lp;
-    use crate::utils::TestDb;
-
-    use super::*;
+    use std::{
+        num::{NonZeroU32, NonZeroU64},
+        time::Instant,
+    };
 
     #[tokio::test]
     async fn test_flush_overlapping() {

--- a/server/src/db/system_tables.rs
+++ b/server/src/db/system_tables.rs
@@ -14,7 +14,6 @@ use arrow::{
     error::Result,
     record_batch::RecordBatch,
 };
-use chrono::{DateTime, Utc};
 use datafusion::{
     catalog::schema::SchemaProvider,
     datasource::{datasource::Statistics, TableProvider},
@@ -151,11 +150,6 @@ where
     fn statistics(&self) -> Statistics {
         Statistics::default()
     }
-}
-
-// TODO: Use a custom proc macro or serde to reduce the boilerplate
-fn time_to_ts(time: Option<DateTime<Utc>>) -> Option<i64> {
-    time.map(|ts| ts.timestamp_nanos())
 }
 
 /// Creates a DataFusion ExecutionPlan node that scans a single batch

--- a/server/src/db/system_tables.rs
+++ b/server/src/db/system_tables.rs
@@ -7,26 +7,21 @@
 //!
 //! For example `SELECT * FROM system.chunks`
 
-use std::any::Any;
-use std::sync::Arc;
-
+use super::catalog::Catalog;
+use crate::JobRegistry;
 use arrow::{
     datatypes::{Field, Schema, SchemaRef},
     error::Result,
     record_batch::RecordBatch,
 };
 use chrono::{DateTime, Utc};
-
 use datafusion::{
     catalog::schema::SchemaProvider,
     datasource::{datasource::Statistics, TableProvider},
     error::{DataFusionError, Result as DataFusionResult},
     physical_plan::{memory::MemoryExec, ExecutionPlan},
 };
-
-use crate::JobRegistry;
-
-use super::catalog::Catalog;
+use std::{any::Any, sync::Arc};
 
 mod chunks;
 mod columns;
@@ -205,10 +200,9 @@ fn scan_batch(
 
 #[cfg(test)]
 mod tests {
+    use super::*;
     use arrow::array::{ArrayRef, UInt64Array};
     use arrow_util::assert_batches_eq;
-
-    use super::*;
 
     fn seq_array(start: u64, end: u64) -> ArrayRef {
         Arc::new(UInt64Array::from_iter_values(start..end))

--- a/server/src/db/system_tables/chunks.rs
+++ b/server/src/db/system_tables/chunks.rs
@@ -1,15 +1,15 @@
+use crate::db::{
+    catalog::Catalog,
+    system_tables::{time_to_ts, IoxSystemTable},
+};
+use arrow::{
+    array::{StringArray, TimestampNanosecondArray, UInt32Array, UInt64Array},
+    datatypes::{DataType, Field, Schema, SchemaRef, TimeUnit},
+    error::Result,
+    record_batch::RecordBatch,
+};
+use data_types::{chunk_metadata::ChunkSummary, error::ErrorLogger};
 use std::sync::Arc;
-
-use arrow::array::{StringArray, TimestampNanosecondArray, UInt32Array, UInt64Array};
-use arrow::datatypes::{DataType, Field, Schema, SchemaRef, TimeUnit};
-use arrow::error::Result;
-use arrow::record_batch::RecordBatch;
-
-use data_types::chunk_metadata::ChunkSummary;
-use data_types::error::ErrorLogger;
-
-use crate::db::catalog::Catalog;
-use crate::db::system_tables::{time_to_ts, IoxSystemTable};
 
 /// Implementation of system.chunks table
 #[derive(Debug)]
@@ -128,12 +128,10 @@ fn from_chunk_summaries(schema: SchemaRef, chunks: Vec<ChunkSummary>) -> Result<
 
 #[cfg(test)]
 mod tests {
-    use chrono::{TimeZone, Utc};
-
-    use arrow_util::assert_batches_eq;
-    use data_types::chunk_metadata::{ChunkLifecycleAction, ChunkStorage};
-
     use super::*;
+    use arrow_util::assert_batches_eq;
+    use chrono::{TimeZone, Utc};
+    use data_types::chunk_metadata::{ChunkLifecycleAction, ChunkStorage};
 
     #[test]
     fn test_from_chunk_summaries() {

--- a/server/src/db/system_tables/chunks.rs
+++ b/server/src/db/system_tables/chunks.rs
@@ -1,13 +1,11 @@
-use crate::db::{
-    catalog::Catalog,
-    system_tables::{time_to_ts, IoxSystemTable},
-};
+use crate::db::{catalog::Catalog, system_tables::IoxSystemTable};
 use arrow::{
     array::{StringArray, TimestampNanosecondArray, UInt32Array, UInt64Array},
     datatypes::{DataType, Field, Schema, SchemaRef, TimeUnit},
     error::Result,
     record_batch::RecordBatch,
 };
+use chrono::{DateTime, Utc};
 use data_types::{chunk_metadata::ChunkSummary, error::ErrorLogger};
 use std::sync::Arc;
 
@@ -54,6 +52,11 @@ fn chunk_summaries_schema() -> SchemaRef {
         Field::new("time_of_last_write", ts.clone(), true),
         Field::new("time_closed", ts, true),
     ]))
+}
+
+// TODO: Use a custom proc macro or serde to reduce the boilerplate
+fn time_to_ts(time: Option<DateTime<Utc>>) -> Option<i64> {
+    time.map(|ts| ts.timestamp_nanos())
 }
 
 fn from_chunk_summaries(schema: SchemaRef, chunks: Vec<ChunkSummary>) -> Result<RecordBatch> {

--- a/server/src/db/system_tables/columns.rs
+++ b/server/src/db/system_tables/columns.rs
@@ -1,17 +1,16 @@
-use std::collections::HashMap;
-use std::sync::Arc;
-
-use arrow::array::{ArrayRef, StringBuilder, UInt32Builder, UInt64Builder};
-use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
-use arrow::error::Result;
-use arrow::record_batch::RecordBatch;
-
-use data_types::chunk_metadata::DetailedChunkSummary;
-use data_types::error::ErrorLogger;
-use data_types::partition_metadata::{PartitionSummary, TableSummary};
-
-use crate::db::catalog::Catalog;
-use crate::db::system_tables::IoxSystemTable;
+use crate::db::{catalog::Catalog, system_tables::IoxSystemTable};
+use arrow::{
+    array::{ArrayRef, StringBuilder, UInt32Builder, UInt64Builder},
+    datatypes::{DataType, Field, Schema, SchemaRef},
+    error::Result,
+    record_batch::RecordBatch,
+};
+use data_types::{
+    chunk_metadata::DetailedChunkSummary,
+    error::ErrorLogger,
+    partition_metadata::{PartitionSummary, TableSummary},
+};
+use std::{collections::HashMap, sync::Arc};
 
 /// Implementation of `system.columns` system table
 #[derive(Debug)]
@@ -217,11 +216,12 @@ fn assemble_chunk_columns(
 
 #[cfg(test)]
 mod tests {
-    use arrow_util::assert_batches_eq;
-    use data_types::chunk_metadata::{ChunkColumnSummary, ChunkStorage, ChunkSummary};
-    use data_types::partition_metadata::{ColumnSummary, InfluxDbType, StatValues, Statistics};
-
     use super::*;
+    use arrow_util::assert_batches_eq;
+    use data_types::{
+        chunk_metadata::{ChunkColumnSummary, ChunkStorage, ChunkSummary},
+        partition_metadata::{ColumnSummary, InfluxDbType, StatValues, Statistics},
+    };
 
     #[test]
     fn test_from_partition_summaries() {

--- a/server/src/db/system_tables/columns.rs
+++ b/server/src/db/system_tables/columns.rs
@@ -218,6 +218,7 @@ fn assemble_chunk_columns(
 mod tests {
     use super::*;
     use arrow_util::assert_batches_eq;
+    use chrono::{TimeZone, Utc};
     use data_types::{
         chunk_metadata::{ChunkColumnSummary, ChunkStorage, ChunkSummary},
         partition_metadata::{ColumnSummary, InfluxDbType, StatValues, Statistics},
@@ -317,8 +318,8 @@ mod tests {
                         object_store_bytes: 0,
                         row_count: 11,
                         time_of_last_access: None,
-                        time_of_first_write: None,
-                        time_of_last_write: None,
+                        time_of_first_write: Utc.timestamp_nanos(1),
+                        time_of_last_write: Utc.timestamp_nanos(2),
                         time_closed: None,
                     },
                     columns: vec![
@@ -353,8 +354,8 @@ mod tests {
                         object_store_bytes: 0,
                         row_count: 11,
                         time_of_last_access: None,
-                        time_of_first_write: None,
-                        time_of_last_write: None,
+                        time_of_first_write: Utc.timestamp_nanos(1),
+                        time_of_last_write: Utc.timestamp_nanos(2),
                         time_closed: None,
                     },
                     columns: vec![ChunkColumnSummary {
@@ -383,8 +384,8 @@ mod tests {
                         object_store_bytes: 0,
                         row_count: 11,
                         time_of_last_access: None,
-                        time_of_first_write: None,
-                        time_of_last_write: None,
+                        time_of_first_write: Utc.timestamp_nanos(1),
+                        time_of_last_write: Utc.timestamp_nanos(2),
                         time_closed: None,
                     },
                     columns: vec![ChunkColumnSummary {


### PR DESCRIPTION
This is the actual goal of https://github.com/influxdata/influxdb_iox/issues/1927, aside from some refactoring to see if we can make CatalogChunk the *only* place first/last write times are managed.