### PR TITLE
refactor: make CatalogChunk (almost) only place that cares about first/last write times

### DIFF
--- a/data_types/src/partition_metadata.rs
+++ b/data_types/src/partition_metadata.rs
@@ -1,7 +1,6 @@
 //! This module contains structs that describe the metadata for a partition
 //! including schema, summary statistics, and file locations in storage.
 
-use chrono::{DateTime, Utc};
 use observability_deps::tracing::warn;
 use serde::{Deserialize, Serialize};
 use std::{
@@ -77,52 +76,6 @@ impl FromIterator<Self> for TableSummary {
             s.update_from(&other)
         }
         s
-    }
-}
-
-/// Temporary transition struct that has times of first/last write. Will eventually replace
-/// TableSummary entirely.
-#[derive(Debug)]
-pub struct TableSummaryAndTimes {
-    /// Table name
-    pub name: String,
-
-    /// Per column statistics
-    pub columns: Vec<ColumnSummary>,
-
-    /// Time at which the first data was written into this table. Note
-    /// this is not the same as the timestamps on the data itself
-    pub time_of_first_write: DateTime<Utc>,
-
-    /// Most recent time at which data write was initiated into this
-    /// chunk. Note this is not the same as the timestamps on the data
-    /// itself
-    pub time_of_last_write: DateTime<Utc>,
-}
-
-impl From<TableSummaryAndTimes> for TableSummary {
-    fn from(other: TableSummaryAndTimes) -> Self {
-        Self {
-            name: other.name,
-            columns: other.columns,
-        }
-    }
-}
-
-impl TableSummaryAndTimes {
-    pub fn size(&self) -> usize {
-        // Total size of all ColumnSummaries that belong to this table which include
-        // column names and their stats
-        let size: usize = self.columns.iter().map(|c| c.size()).sum();
-        size
-            + self.name.len() // Add size of the table name
-            + mem::size_of::<Self>() // Add size of this struct that points to
-                                     // table, ColumnSummary, and times
-    }
-
-    /// Get the column summary by name.
-    pub fn column(&self, name: &str) -> Option<&ColumnSummary> {
-        self.columns.iter().find(|c| c.name == name)
     }
 }
 

--- a/data_types/src/write_summary.rs
+++ b/data_types/src/write_summary.rs
@@ -4,7 +4,7 @@ use chrono::{DateTime, Timelike, Utc};
 /// A description of a set of writes
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct WriteSummary {
-    /// The wall clock timestamp of the last write in this summary
+    /// The wall clock timestamp of the first write in this summary
     pub time_of_first_write: DateTime<Utc>,
 
     /// The wall clock timestamp of the last write in this summary

--- a/mutable_buffer/src/chunk/snapshot.rs
+++ b/mutable_buffer/src/chunk/snapshot.rs
@@ -2,7 +2,7 @@ use super::MBChunk;
 use arrow::record_batch::RecordBatch;
 use data_types::{
     error::ErrorLogger,
-    partition_metadata::{Statistics, TableSummaryAndTimes},
+    partition_metadata::{Statistics, TableSummary},
     timestamp::TimestampRange,
 };
 use internal_types::{
@@ -31,7 +31,7 @@ pub struct ChunkSnapshot {
     schema: Arc<Schema>,
     batch: RecordBatch,
     table_name: Arc<str>,
-    summary: TableSummaryAndTimes,
+    summary: TableSummary,
 }
 
 impl ChunkSnapshot {
@@ -100,7 +100,7 @@ impl ChunkSnapshot {
     }
 
     /// Returns a table summary for this chunk
-    pub fn table_summary(&self) -> &TableSummaryAndTimes {
+    pub fn table_summary(&self) -> &TableSummary {
         &self.summary
     }
 

--- a/parquet_file/src/chunk.rs
+++ b/parquet_file/src/chunk.rs
@@ -1,7 +1,4 @@
-use crate::{
-    metadata::{IoxMetadata, IoxParquetMetaData},
-    storage::Storage,
-};
+use crate::{metadata::IoxParquetMetaData, storage::Storage};
 use data_types::{
     partition_metadata::{Statistics, TableSummary},
     timestamp::TimestampRange,
@@ -118,20 +115,10 @@ impl ParquetChunk {
         store: Arc<ObjectStore>,
         file_size_bytes: usize,
         parquet_metadata: Arc<IoxParquetMetaData>,
+        table_name: Arc<str>,
+        partition_key: Arc<str>,
         metrics: ChunkMetrics,
     ) -> Result<Self> {
-        let iox_md = parquet_metadata
-            .read_iox_metadata()
-            .context(IoxMetadataReadFailed {
-                path: &file_location,
-            })?;
-
-        let IoxMetadata {
-            table_name,
-            partition_key,
-            ..
-        } = iox_md;
-
         let schema = parquet_metadata.read_schema().context(SchemaReadFailed {
             path: &file_location,
         })?;

--- a/parquet_file/src/test_utils.rs
+++ b/parquet_file/src/test_utils.rs
@@ -14,9 +14,7 @@ use arrow::{
 use chrono::{TimeZone, Utc};
 use data_types::{
     chunk_metadata::ChunkAddr,
-    partition_metadata::{
-        ColumnSummary, InfluxDbType, StatValues, Statistics, TableSummaryAndTimes,
-    },
+    partition_metadata::{ColumnSummary, InfluxDbType, StatValues, Statistics, TableSummary},
     server_id::ServerId,
 };
 use datafusion::physical_plan::SendableRecordBatchStream;
@@ -132,11 +130,9 @@ pub async fn make_chunk_given_record_batch(
     let server_id = ServerId::new(NonZeroU32::new(1).unwrap());
     let storage = Storage::new(Arc::clone(&store), server_id);
 
-    let table_summary = TableSummaryAndTimes {
+    let table_summary = TableSummary {
         name: addr.table_name.to_string(),
         columns: column_summaries,
-        time_of_first_write: Utc.timestamp(30, 40),
-        time_of_last_write: Utc.timestamp(50, 60),
     };
     let stream: SendableRecordBatchStream = if record_batches.is_empty() {
         Box::pin(MemoryStream::new_with_schema(

--- a/read_buffer/benches/database.rs
+++ b/read_buffer/benches/database.rs
@@ -2,7 +2,6 @@ use arrow::{
     array::{ArrayRef, Int64Array, StringArray},
     record_batch::RecordBatch,
 };
-use chrono::Utc;
 use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
 use internal_types::schema::builder::SchemaBuilder;
 use read_buffer::{BinaryExpr, ChunkMetrics, Predicate, RBChunk};
@@ -13,8 +12,7 @@ const ONE_MS: i64 = 1_000_000;
 
 fn satisfies_predicate(c: &mut Criterion) {
     let rb = generate_row_group(500_000);
-    let now = Utc::now();
-    let chunk = RBChunk::new("table_a", rb, ChunkMetrics::new_unregistered(), now, now);
+    let chunk = RBChunk::new("table_a", rb, ChunkMetrics::new_unregistered());
 
     // no predicate
     benchmark_satisfies_predicate(

--- a/server/src/db.rs
+++ b/server/src/db.rs
@@ -1111,9 +1111,8 @@ impl Db {
                             let mb_chunk =
                                 chunk.mutable_buffer().expect("cannot mutate open chunk");
 
-                            if let Err(e) = mb_chunk
-                                .write_table_batch(table_batch, time_of_write)
-                                .context(WriteEntry {
+                            if let Err(e) =
+                                mb_chunk.write_table_batch(table_batch).context(WriteEntry {
                                     partition_key,
                                     chunk_id,
                                 })
@@ -1882,7 +1881,7 @@ mod tests {
         assert_metric("catalog_loaded_rows", "read_buffer", 0.0);
         assert_metric("catalog_loaded_rows", "object_store", 0.0);
 
-        catalog_chunk_size_bytes_metric_eq(&test_db.metric_registry, "mutable_buffer", 1319)
+        catalog_chunk_size_bytes_metric_eq(&test_db.metric_registry, "mutable_buffer", 1295)
             .unwrap();
 
         db.move_chunk_to_read_buffer("cpu", "1970-01-01T00", 0)
@@ -3194,7 +3193,7 @@ mod tests {
                 id: 0,
                 storage: ChunkStorage::ClosedMutableBuffer,
                 lifecycle_action,
-                memory_bytes: 2510,
+                memory_bytes: 2486,
                 object_store_bytes: 0, // no OS chunks
                 row_count: 1,
                 time_of_last_access: None,
@@ -3230,7 +3229,7 @@ mod tests {
             );
         }
 
-        assert_eq!(db.catalog.metrics().memory().mutable_buffer(), 2510 + 87);
+        assert_eq!(db.catalog.metrics().memory().mutable_buffer(), 2486 + 87);
         assert_eq!(db.catalog.metrics().memory().read_buffer(), 2434);
         assert_eq!(db.catalog.metrics().memory().object_store(), 898);
     }

--- a/server/src/db.rs
+++ b/server/src/db.rs
@@ -29,7 +29,7 @@ use entry::{Entry, SequencedEntry};
 use futures::{stream::BoxStream, StreamExt};
 use internal_types::schema::Schema;
 use metrics::KeyValue;
-use mutable_buffer::chunk::ChunkMetrics as MutableBufferChunkMetrics;
+use mutable_buffer::chunk::{ChunkMetrics as MutableBufferChunkMetrics, MBChunk};
 use object_store::{path::parsed::DirsAndFileName, ObjectStore};
 use observability_deps::tracing::{debug, error, info};
 use parking_lot::RwLock;
@@ -107,7 +107,7 @@ pub enum Error {
     #[snafu(display("Cannot write entry to new open chunk {}: {}", partition_key, source))]
     WriteEntryInitial {
         partition_key: String,
-        source: catalog::partition::Error,
+        source: mutable_buffer::chunk::Error,
     },
 
     #[snafu(display(
@@ -1129,17 +1129,16 @@ impl Db {
                                 "mutable_buffer",
                                 self.metric_labels.clone(),
                             );
-                            let chunk_result = partition
-                                .create_open_chunk(
-                                    MutableBufferChunkMetrics::new(&metrics),
-                                    table_batch,
-                                    time_of_write,
-                                )
-                                .context(WriteEntryInitial { partition_key });
+
+                            let chunk_result =
+                                MBChunk::new(MutableBufferChunkMetrics::new(&metrics), table_batch)
+                                    .context(WriteEntryInitial { partition_key });
 
                             match chunk_result {
                                 Ok(mb_chunk) => {
-                                    let mut chunk = mb_chunk
+                                    let chunk =
+                                        partition.create_open_chunk(mb_chunk, time_of_write);
+                                    let mut chunk = chunk
                                         .try_write()
                                         .expect("partition lock should prevent contention");
                                     handle_chunk_write(&mut *chunk)

--- a/server/src/db.rs
+++ b/server/src/db.rs
@@ -1939,7 +1939,7 @@ mod tests {
             .eq(1.0)
             .unwrap();
 
-        let expected_parquet_size = 703;
+        let expected_parquet_size = 679;
         catalog_chunk_size_bytes_metric_eq(
             &test_db.metric_registry,
             "read_buffer",
@@ -2421,7 +2421,7 @@ mod tests {
                 ("svr_id", "10"),
             ])
             .histogram()
-            .sample_sum_eq(2316.0)
+            .sample_sum_eq(2292.0)
             .unwrap();
 
         // while MB and RB chunk are identical, the PQ chunk is a new one (split off)
@@ -2541,7 +2541,7 @@ mod tests {
                 ("svr_id", "10"),
             ])
             .histogram()
-            .sample_sum_eq(2316.0)
+            .sample_sum_eq(2292.0)
             .unwrap();
 
         // Unload RB chunk but keep it in OS
@@ -2571,7 +2571,7 @@ mod tests {
                 ("svr_id", "10"),
             ])
             .histogram()
-            .sample_sum_eq(703.0)
+            .sample_sum_eq(679.0)
             .unwrap();
 
         // Verify data written to the parquet file in object store
@@ -3179,7 +3179,7 @@ mod tests {
                 id: 2,
                 storage: ChunkStorage::ReadBufferAndObjectStore,
                 lifecycle_action,
-                memory_bytes: 3308,       // size of RB and OS chunks
+                memory_bytes: 3284,       // size of RB and OS chunks
                 object_store_bytes: 1523, // size of parquet file
                 row_count: 2,
                 time_of_last_access: None,
@@ -3231,7 +3231,7 @@ mod tests {
 
         assert_eq!(db.catalog.metrics().memory().mutable_buffer(), 2486 + 87);
         assert_eq!(db.catalog.metrics().memory().read_buffer(), 2410);
-        assert_eq!(db.catalog.metrics().memory().object_store(), 898);
+        assert_eq!(db.catalog.metrics().memory().object_store(), 874);
     }
 
     #[tokio::test]

--- a/server/src/db.rs
+++ b/server/src/db.rs
@@ -1910,7 +1910,7 @@ mod tests {
 
         // verify chunk size updated (chunk moved from closing to moving to moved)
         catalog_chunk_size_bytes_metric_eq(&test_db.metric_registry, "mutable_buffer", 0).unwrap();
-        let expected_read_buffer_size = 1637;
+        let expected_read_buffer_size = 1613;
         catalog_chunk_size_bytes_metric_eq(
             &test_db.metric_registry,
             "read_buffer",
@@ -2161,7 +2161,7 @@ mod tests {
             .unwrap();
 
         // verify chunk size updated (chunk moved from moved to writing to written)
-        catalog_chunk_size_bytes_metric_eq(&test_db.metric_registry, "read_buffer", 1637).unwrap();
+        catalog_chunk_size_bytes_metric_eq(&test_db.metric_registry, "read_buffer", 1613).unwrap();
 
         // drop, the chunk from the read buffer
         db.drop_chunk("cpu", partition_key, mb_chunk.id())
@@ -2311,7 +2311,7 @@ mod tests {
                 ("svr_id", "1"),
             ])
             .histogram()
-            .sample_sum_eq(3215.0)
+            .sample_sum_eq(3191.0)
             .unwrap();
 
         let rb = collect_read_filter(&rb_chunk).await;
@@ -2421,7 +2421,7 @@ mod tests {
                 ("svr_id", "10"),
             ])
             .histogram()
-            .sample_sum_eq(2340.0)
+            .sample_sum_eq(2316.0)
             .unwrap();
 
         // while MB and RB chunk are identical, the PQ chunk is a new one (split off)
@@ -2541,7 +2541,7 @@ mod tests {
                 ("svr_id", "10"),
             ])
             .histogram()
-            .sample_sum_eq(2340.0)
+            .sample_sum_eq(2316.0)
             .unwrap();
 
         // Unload RB chunk but keep it in OS
@@ -3179,7 +3179,7 @@ mod tests {
                 id: 2,
                 storage: ChunkStorage::ReadBufferAndObjectStore,
                 lifecycle_action,
-                memory_bytes: 3332,       // size of RB and OS chunks
+                memory_bytes: 3308,       // size of RB and OS chunks
                 object_store_bytes: 1523, // size of parquet file
                 row_count: 2,
                 time_of_last_access: None,
@@ -3230,7 +3230,7 @@ mod tests {
         }
 
         assert_eq!(db.catalog.metrics().memory().mutable_buffer(), 2486 + 87);
-        assert_eq!(db.catalog.metrics().memory().read_buffer(), 2434);
+        assert_eq!(db.catalog.metrics().memory().read_buffer(), 2410);
         assert_eq!(db.catalog.metrics().memory().object_store(), 898);
     }
 

--- a/server/src/db/catalog.rs
+++ b/server/src/db/catalog.rs
@@ -340,14 +340,13 @@ mod tests {
         let write = entry.partition_writes().unwrap().remove(0);
         let batch = write.table_batches().remove(0);
 
-        let mb_chunk = mutable_buffer::chunk::MBChunk::new(
-            mutable_buffer::chunk::ChunkMetrics::new_unregistered(),
-            batch,
-            time_of_write,
-        )
-        .unwrap();
-
-        partition.create_open_chunk(mb_chunk);
+        partition
+            .create_open_chunk(
+                mutable_buffer::chunk::ChunkMetrics::new_unregistered(),
+                batch,
+                time_of_write,
+            )
+            .unwrap();
     }
 
     #[test]

--- a/server/src/db/catalog.rs
+++ b/server/src/db/catalog.rs
@@ -340,13 +340,13 @@ mod tests {
         let write = entry.partition_writes().unwrap().remove(0);
         let batch = write.table_batches().remove(0);
 
-        partition
-            .create_open_chunk(
-                mutable_buffer::chunk::ChunkMetrics::new_unregistered(),
-                batch,
-                time_of_write,
-            )
-            .unwrap();
+        let mb_chunk = mutable_buffer::chunk::MBChunk::new(
+            mutable_buffer::chunk::ChunkMetrics::new_unregistered(),
+            batch,
+        )
+        .unwrap();
+
+        partition.create_open_chunk(mb_chunk, time_of_write);
     }
 
     #[test]

--- a/server/src/db/catalog/chunk.rs
+++ b/server/src/db/catalog/chunk.rs
@@ -307,16 +307,14 @@ impl CatalogChunk {
     pub(super) fn new_rub_chunk(
         addr: ChunkAddr,
         chunk: read_buffer::RBChunk,
+        time_of_first_write: DateTime<Utc>,
+        time_of_last_write: DateTime<Utc>,
         schema: Arc<Schema>,
         metrics: ChunkMetrics,
     ) -> Self {
-        let summary = chunk.table_summary();
-        let time_of_first_write = summary.time_of_first_write;
-        let time_of_last_write = summary.time_of_last_write;
-
         let stage = ChunkStage::Frozen {
             meta: Arc::new(ChunkMetadata {
-                table_summary: Arc::new(summary.into()),
+                table_summary: Arc::new(chunk.table_summary()),
                 schema,
             }),
             representation: ChunkStageFrozenRepr::ReadBuffer(Arc::new(chunk)),

--- a/server/src/db/catalog/partition.rs
+++ b/server/src/db/catalog/partition.rs
@@ -165,6 +165,8 @@ impl Partition {
     pub fn create_rub_chunk(
         &mut self,
         chunk: read_buffer::RBChunk,
+        time_of_first_write: DateTime<Utc>,
+        time_of_last_write: DateTime<Utc>,
         schema: Arc<Schema>,
     ) -> Arc<RwLock<CatalogChunk>> {
         let chunk_id = self.next_chunk_id;
@@ -177,6 +179,8 @@ impl Partition {
         let chunk = Arc::new(self.metrics.new_chunk_lock(CatalogChunk::new_rub_chunk(
             addr,
             chunk,
+            time_of_first_write,
+            time_of_last_write,
             schema,
             self.metrics.new_chunk_metrics(),
         )));

--- a/server/src/db/catalog/partition.rs
+++ b/server/src/db/catalog/partition.rs
@@ -201,6 +201,8 @@ impl Partition {
         &mut self,
         chunk_id: u32,
         chunk: Arc<parquet_file::chunk::ParquetChunk>,
+        time_of_first_write: DateTime<Utc>,
+        time_of_last_write: DateTime<Utc>,
     ) -> Arc<RwLock<CatalogChunk>> {
         assert_eq!(chunk.table_name(), self.table_name());
 
@@ -211,6 +213,8 @@ impl Partition {
                 .new_chunk_lock(CatalogChunk::new_object_store_only(
                     addr,
                     chunk,
+                    time_of_first_write,
+                    time_of_last_write,
                     self.metrics.new_chunk_metrics(),
                 )),
         );

--- a/server/src/db/chunk.rs
+++ b/server/src/db/chunk.rs
@@ -82,6 +82,8 @@ pub struct DbChunk {
     access_recorder: AccessRecorder,
     state: State,
     meta: Arc<ChunkMetadata>,
+    time_of_first_write: DateTime<Utc>,
+    time_of_last_write: DateTime<Utc>,
 }
 
 #[derive(Debug)]
@@ -159,6 +161,8 @@ impl DbChunk {
             access_recorder: chunk.access_recorder().clone(),
             state,
             meta,
+            time_of_first_write: chunk.time_of_first_write(),
+            time_of_last_write: chunk.time_of_last_write(),
         })
     }
 
@@ -186,6 +190,8 @@ impl DbChunk {
             meta,
             state,
             access_recorder: chunk.access_recorder().clone(),
+            time_of_first_write: chunk.time_of_first_write(),
+            time_of_last_write: chunk.time_of_last_write(),
         })
     }
 
@@ -204,19 +210,11 @@ impl DbChunk {
     }
 
     pub fn time_of_first_write(&self) -> DateTime<Utc> {
-        match &self.state {
-            State::MutableBuffer { chunk } => chunk.table_summary().time_of_first_write,
-            State::ReadBuffer { chunk, .. } => chunk.table_summary().time_of_first_write,
-            State::ParquetFile { chunk } => chunk.table_summary().time_of_first_write,
-        }
+        self.time_of_first_write
     }
 
     pub fn time_of_last_write(&self) -> DateTime<Utc> {
-        match &self.state {
-            State::MutableBuffer { chunk } => chunk.table_summary().time_of_last_write,
-            State::ReadBuffer { chunk, .. } => chunk.table_summary().time_of_last_write,
-            State::ParquetFile { chunk } => chunk.table_summary().time_of_last_write,
-        }
+        self.time_of_last_write
     }
 }
 

--- a/server/src/db/chunk.rs
+++ b/server/src/db/chunk.rs
@@ -114,7 +114,7 @@ impl DbChunk {
                     chunk: Arc::clone(&snapshot),
                 };
                 let meta = ChunkMetadata {
-                    table_summary: Arc::new(mb_chunk.table_summary().into()),
+                    table_summary: Arc::new(mb_chunk.table_summary()),
                     schema: snapshot.full_schema(),
                 };
                 (state, Arc::new(meta))

--- a/server/src/db/lifecycle.rs
+++ b/server/src/db/lifecycle.rs
@@ -334,8 +334,6 @@ fn collect_rub(
     stream: SendableRecordBatchStream,
     db: &Db,
     table_name: &str,
-    time_of_first_write: DateTime<Utc>,
-    time_of_last_write: DateTime<Utc>,
 ) -> impl futures::Future<Output = Result<Option<read_buffer::RBChunk>>> {
     use futures::{future, StreamExt, TryStreamExt};
 
@@ -353,13 +351,7 @@ fn collect_rub(
             // At least one RecordBatch is required to create a read_buffer::Chunk
             None => return Ok(None),
         };
-        let mut chunk = read_buffer::RBChunk::new(
-            table_name,
-            first_batch,
-            chunk_metrics,
-            time_of_first_write,
-            time_of_last_write,
-        );
+        let mut chunk = read_buffer::RBChunk::new(table_name, first_batch, chunk_metrics);
 
         adapted_stream
             .try_for_each(|batch| {

--- a/server/src/db/lifecycle/compact.rs
+++ b/server/src/db/lifecycle/compact.rs
@@ -90,15 +90,9 @@ pub(crate) fn compact_chunks(
 
         let physical_plan = ctx.prepare_plan(&plan)?;
         let stream = ctx.execute(physical_plan).await?;
-        let rb_chunk = collect_rub(
-            stream,
-            &db,
-            &table_name,
-            time_of_first_write,
-            time_of_last_write,
-        )
-        .await?
-        .expect("chunk has zero rows");
+        let rb_chunk = collect_rub(stream, &db, &table_name)
+            .await?
+            .expect("chunk has zero rows");
         let rb_row_groups = rb_chunk.row_groups();
 
         let new_chunk = {
@@ -106,7 +100,7 @@ pub(crate) fn compact_chunks(
             for id in chunk_ids {
                 partition.force_drop_chunk(id)
             }
-            partition.create_rub_chunk(rb_chunk, schema)
+            partition.create_rub_chunk(rb_chunk, time_of_first_write, time_of_last_write, schema)
         };
 
         let guard = new_chunk.read();

--- a/server/src/db/lifecycle/move_chunk.rs
+++ b/server/src/db/lifecycle/move_chunk.rs
@@ -37,8 +37,6 @@ pub fn move_chunk_to_read_buffer(
     // local operation that should only need to deal with the columns that are really present.
     let db_chunk = DbChunk::snapshot(&*guard);
     let schema = db_chunk.schema();
-    let time_of_first_write = db_chunk.time_of_first_write();
-    let time_of_last_write = db_chunk.time_of_last_write();
     let query_chunks = vec![db_chunk];
 
     // Drop locks
@@ -57,14 +55,7 @@ pub fn move_chunk_to_read_buffer(
 
         let physical_plan = ctx.prepare_plan(&plan)?;
         let stream = ctx.execute(physical_plan).await?;
-        let rb_chunk = collect_rub(
-            stream,
-            db.as_ref(),
-            &table_summary.name,
-            time_of_first_write,
-            time_of_last_write,
-        )
-        .await?;
+        let rb_chunk = collect_rub(stream, db.as_ref(), &table_summary.name).await?;
 
         // Can drop and re-acquire as lifecycle action prevents concurrent modification
         let mut guard = chunk.write();

--- a/server/src/db/lifecycle/write.rs
+++ b/server/src/db/lifecycle/write.rs
@@ -53,6 +53,8 @@ pub(super) fn write_chunk_to_object_store(
 )> {
     let db = Arc::clone(&chunk.data().db);
     let addr = chunk.addr().clone();
+    let table_name = Arc::clone(&addr.table_name);
+    let partition_key = Arc::clone(&addr.partition_key);
 
     let (tracker, registration) = db.jobs.register(Job::WriteChunk {
         chunk: addr.clone(),
@@ -116,8 +118,8 @@ pub(super) fn write_chunk_to_object_store(
             //            between creation and the transaction commit.
             let metadata = IoxMetadata {
                 creation_timestamp: Utc::now(),
-                table_name: Arc::clone(&addr.table_name),
-                partition_key: Arc::clone(&addr.partition_key),
+                table_name: Arc::clone(&table_name),
+                partition_key: Arc::clone(&partition_key),
                 chunk_id: addr.chunk_id,
                 partition_checkpoint,
                 database_checkpoint,
@@ -141,6 +143,8 @@ pub(super) fn write_chunk_to_object_store(
                     Arc::clone(&db.store),
                     file_size_bytes,
                     Arc::clone(&parquet_metadata),
+                    Arc::clone(&table_name),
+                    Arc::clone(&partition_key),
                     metrics,
                 )
                 .context(ParquetChunkError)?,

--- a/server/src/db/load.rs
+++ b/server/src/db/load.rs
@@ -229,7 +229,12 @@ impl CatalogState for Loader {
         let schema_handle = TableSchemaUpsertHandle::new(&table_schema, &parquet_chunk.schema())
             .map_err(|e| Box::new(e) as _)
             .context(SchemaError { path: info.path })?;
-        partition.insert_object_store_only_chunk(iox_md.chunk_id, parquet_chunk);
+        partition.insert_object_store_only_chunk(
+            iox_md.chunk_id,
+            parquet_chunk,
+            iox_md.time_of_first_write,
+            iox_md.time_of_last_write,
+        );
         schema_handle.commit();
 
         Ok(())

--- a/server/src/db/load.rs
+++ b/server/src/db/load.rs
@@ -210,6 +210,8 @@ impl CatalogState for Loader {
             object_store,
             info.file_size_bytes,
             info.metadata,
+            Arc::clone(&iox_md.table_name),
+            Arc::clone(&iox_md.partition_key),
             metrics,
         )
         .context(ChunkCreationFailed {

--- a/server_benchmarks/benches/snapshot.rs
+++ b/server_benchmarks/benches/snapshot.rs
@@ -17,23 +17,17 @@ fn chunk(count: usize) -> MBChunk {
     let mut lp = String::new();
     gz.read_to_string(&mut lp).unwrap();
 
-    let time_of_write = chrono::Utc::now();
     for _ in 0..count {
         for entry in lp_to_entries(&lp, &hour_partitioner()) {
             for write in entry.partition_writes().iter().flatten() {
                 for batch in write.table_batches() {
                     match chunk {
                         Some(ref mut c) => {
-                            c.write_table_batch(batch, time_of_write).unwrap();
+                            c.write_table_batch(batch).unwrap();
                         }
                         None => {
                             chunk = Some(
-                                MBChunk::new(
-                                    ChunkMetrics::new_unregistered(),
-                                    batch,
-                                    time_of_write,
-                                )
-                                .unwrap(),
+                                MBChunk::new(ChunkMetrics::new_unregistered(), batch).unwrap(),
                             );
                         }
                     }

--- a/server_benchmarks/benches/write.rs
+++ b/server_benchmarks/benches/write.rs
@@ -11,23 +11,17 @@ use std::io::Read;
 fn write_chunk(count: usize, entries: &[Entry]) {
     let mut chunk: Option<MBChunk> = None;
 
-    let time_of_write = chrono::Utc::now();
     for _ in 0..count {
         for entry in entries {
             for write in entry.partition_writes().iter().flatten() {
                 for batch in write.table_batches() {
                     match chunk {
                         Some(ref mut c) => {
-                            c.write_table_batch(batch, time_of_write).unwrap();
+                            c.write_table_batch(batch).unwrap();
                         }
                         None => {
                             chunk = Some(
-                                MBChunk::new(
-                                    ChunkMetrics::new_unregistered(),
-                                    batch,
-                                    time_of_write,
-                                )
-                                .unwrap(),
+                                MBChunk::new(ChunkMetrics::new_unregistered(), batch).unwrap(),
                             );
                         }
                     }


### PR DESCRIPTION
In addition to `CatalogChunk` having `time_of_first_write`/`time_of_last_write` fields, they also still need to be stored:

- In the Parquet [`IoxMetadata`](https://github.com/influxdata/influxdb_iox/blob/23a331b1334714473cc77f2f0967bfeb8a20519c/parquet_file/src/metadata.rs#L255-L256) so that they can round trip through object storage
- In [`WriteSummary`](https://github.com/influxdata/influxdb_iox/blob/23a331b1334714473cc77f2f0967bfeb8a20519c/data_types/src/write_summary.rs#L8-L11)
- In [`ChunkSummary`](https://github.com/influxdata/influxdb_iox/blob/23a331b1334714473cc77f2f0967bfeb8a20519c/data_types/src/chunk_metadata.rs#L143-L148)
- In the `DbChunk` snapshots taken from `CatalogChunk` (added in this PR) 

But most noticeably, the `TableSummaryAndTimes` type goes away in this PR, with all the code that threaded those values through. 

There are a few other small fixes included that I found along the way.

Closes #1927.