### PR TITLE
feat(iox): Implement max_active_compactions_cpu_fraction

### DIFF
--- a/generated_types/protos/influxdata/iox/management/v1/database_rules.proto
+++ b/generated_types/protos/influxdata/iox/management/v1/database_rules.proto
@@ -78,11 +78,14 @@ message LifecycleRules {
   // Maximum number of rows to buffer in a MUB chunk before compacting it
   uint64 mub_row_threshold = 15;
 
-  // The maximum number of concurrent active compactions that can run.
-  //
-  // If 0, compactions are limited to the default number.
-  // See data_types::database_rules::DEFAULT_MAX_ACTIVE_COMPACTIONS
-  uint32 max_active_compactions = 16;
+  oneof max_active_compactions_cfg {
+    // The maximum number of concurrent active compactions that can run.
+    uint32 max_active_compactions = 16;
+
+    // The maximum number of concurrent active compactions that can run
+    // expressed as a fraction of the available cpus (rounded to the next smallest non-zero integer).
+    float max_active_compactions_cpu_fraction = 18;
+  }
 
   // Use up to this amount of space in bytes for caching Parquet files.
   // A value of 0 disables Parquet caching

--- a/lifecycle/src/policy.rs
+++ b/lifecycle/src/policy.rs
@@ -652,6 +652,7 @@ mod tests {
         LockablePartition, PersistHandle,
     };
     use data_types::chunk_metadata::{ChunkAddr, ChunkStorage};
+    use data_types::database_rules::MaxActiveCompactions::MaxActiveCompactions;
     use std::{
         cmp::max,
         collections::BTreeMap,
@@ -1366,7 +1367,7 @@ mod tests {
         let rules = LifecycleRules {
             late_arrive_window_seconds: NonZeroU32::new(10).unwrap(),
             persist_row_threshold: NonZeroUsize::new(1_000).unwrap(),
-            max_active_compactions: NonZeroU32::new(10).unwrap(),
+            max_active_compactions: MaxActiveCompactions(NonZeroU32::new(10).unwrap()),
             ..Default::default()
         };
 
@@ -1450,7 +1451,7 @@ mod tests {
     #[test]
     fn test_compaction_limiter() {
         let rules = LifecycleRules {
-            max_active_compactions: 2.try_into().unwrap(),
+            max_active_compactions: MaxActiveCompactions(2.try_into().unwrap()),
             ..Default::default()
         };
 
@@ -1500,7 +1501,7 @@ mod tests {
             persist_row_threshold: NonZeroUsize::new(1_000).unwrap(),
             late_arrive_window_seconds: NonZeroU32::new(10).unwrap(),
             persist_age_threshold_seconds: NonZeroU32::new(10).unwrap(),
-            max_active_compactions: NonZeroU32::new(10).unwrap(),
+            max_active_compactions: MaxActiveCompactions(NonZeroU32::new(10).unwrap()),
             ..Default::default()
         };
         let now = Instant::now();

--- a/src/commands/database.rs
+++ b/src/commands/database.rs
@@ -190,7 +190,7 @@ pub async fn command(url: String, config: Config) -> Result<()> {
                     persist: command.persist,
                     immutable: command.immutable,
                     worker_backoff_millis: Default::default(),
-                    max_active_compactions: Default::default(),
+                    max_active_compactions_cfg: Default::default(),
                     catalog_transactions_until_checkpoint: command
                         .catalog_transactions_until_checkpoint
                         .get(),

--- a/tests/end_to_end_cases/management_api.rs
+++ b/tests/end_to_end_cases/management_api.rs
@@ -222,7 +222,9 @@ async fn test_create_get_update_database() {
             catalog_transactions_until_checkpoint: 13,
             late_arrive_window_seconds: 423,
             worker_backoff_millis: 15,
-            max_active_compactions: 8,
+            max_active_compactions_cfg: Some(
+                lifecycle_rules::MaxActiveCompactionsCfg::MaxActiveCompactions(8),
+            ),
             persist_row_threshold: 342,
             persist_age_threshold_seconds: 700,
             mub_row_threshold: 1343,


### PR DESCRIPTION
__Rationale__

We noticed that using all the CPUs for compaction starves the other components of the ingestion.

Instead of hardcoding a fraction, this PR introduces a `max_active_compactions_cpu_fraction` config parameter
which can be used instead (mutually exclusive to)`max_active_compactions`. For example, by setting `max_active_compactions_cpu_fraction: 0.5` the maximum number of compactions will be half of the cpus available on the server.

