### PR TITLE
feat(iox): Enable snappy compression in the producer

### DIFF
--- a/write_buffer/src/kafka.rs
+++ b/write_buffer/src/kafka.rs
@@ -96,6 +96,7 @@ impl KafkaBufferProducer {
         cfg.set("message.max.bytes", "31457280");
         cfg.set("queue.buffering.max.kbytes", "31457280");
         cfg.set("request.required.acks", "all"); // equivalent to acks=-1
+        cfg.set("compression.type", "snappy");
 
         let producer: FutureProducer = cfg.create()?;
 


### PR DESCRIPTION
Setting the "compression.type" in the topic config causes the compression to happen in the broker.

Setting it here will send less data to the broker.