### PR TITLE
fix: Return a more helpful error message for no matching sharding rule

### DIFF
--- a/src/influxdb_ioxd/rpc/error.rs
+++ b/src/influxdb_ioxd/rpc/error.rs
@@ -38,7 +38,8 @@ pub fn default_server_error_handler(error: server::Error) -> tonic::Status {
             description: "hard buffer limit reached".to_string(),
         }
         .into(),
-        source @ Error::WritingOnlyAllowedThroughWriteBuffer { .. } => tonic::Status::failed_precondition(source.to_string()),
+        source @ Error::WritingOnlyAllowedThroughWriteBuffer { .. } |
+            source @ Error::LineConversion { .. } => tonic::Status::failed_precondition(source.to_string()),
         Error::NoRemoteConfigured { node_group } => NotFound {
             resource_type: "remote".to_string(),
             resource_name: format!("{:?}", node_group),

--- a/tests/end_to_end_cases/write_api.rs
+++ b/tests/end_to_end_cases/write_api.rs
@@ -498,7 +498,9 @@ async fn test_write_dev_null() {
 
     assert_eq!(
         err.to_string(),
-        "Unexpected server error: Internal error: Internal Error"
+        "Unexpected server error: The system is not in a state required for the operation's \
+         execution: error converting line protocol to flatbuffers: Error getting shard id No \
+         sharding rule matches line: mem bar=1 1"
     );
 }
 


### PR DESCRIPTION
Fixes #2127.

I went with "failed precondition" because the fix for no matching sharding rule might be to fix the sharding rules or fix the line protocol. Let me know if you'd rather have this send a different tonic status!