### PR TITLE
test: regression test for #2185 

### DIFF
--- a/server/src/db.rs
+++ b/server/src/db.rs
@@ -32,7 +32,7 @@ use metrics::KeyValue;
 use mutable_buffer::chunk::{ChunkMetrics as MutableBufferChunkMetrics, MBChunk};
 use object_store::{path::parsed::DirsAndFileName, ObjectStore};
 use observability_deps::tracing::{debug, error, info};
-use parking_lot::RwLock;
+use parking_lot::{Mutex, RwLock};
 use parquet_file::{
     catalog::{CatalogParquetInfo, CheckpointData, PreservedCatalog},
     cleanup::{delete_files as delete_parquet_files, get_unreferenced_parquet_files},
@@ -381,6 +381,9 @@ pub struct Db {
     ///
     /// TODO: Move write buffer read loop out of Db.
     no_write_buffer_read: AtomicBool,
+
+    /// Mocked `Instant::now()` for the background worker
+    background_worker_now_override: Mutex<Option<Instant>>,
 }
 
 /// All the information needed to commit a database
@@ -441,6 +444,7 @@ impl Db {
             cleanup_lock: Default::default(),
             lifecycle_policy: tokio::sync::Mutex::new(None),
             no_write_buffer_read: AtomicBool::new(true),
+            background_worker_now_override: Default::default(),
         };
         let this = Arc::new(this);
         *this.lifecycle_policy.try_lock().expect("not used yet") = Some(
@@ -807,7 +811,7 @@ impl Db {
                         _ = async {
                             let mut guard = self.lifecycle_policy.lock().await;
                             let policy = guard.as_mut().expect("lifecycle policy should be initialized");
-                            policy.check_for_work(Utc::now(), std::time::Instant::now()).await
+                            policy.check_for_work(Utc::now(), self.background_worker_now()).await
                         } => {},
                         _ = shutdown.cancelled() => break,
                     }
@@ -950,8 +954,9 @@ impl Db {
             // maybe update sequencer watermark
             // We are not updating this watermark every round because asking the sequencer for that watermark can be
             // quite expensive.
+            let now = self.background_worker_now();
             if watermark_last_updated
-                .map(|ts| ts.elapsed() > Duration::from_secs(10))
+                .map(|ts| (now - ts) > Duration::from_secs(10))
                 .unwrap_or(true)
             {
                 match f_mark().await {
@@ -967,7 +972,7 @@ impl Db {
                         )
                     }
                 }
-                watermark_last_updated = Some(Instant::now());
+                watermark_last_updated = Some(now);
             }
 
             // update:
@@ -1037,6 +1042,18 @@ impl Db {
             metrics
                 .last_ingest_ts
                 .set(producer_wallclock_timestamp.timestamp_nanos() as usize, &[]);
+        }
+    }
+
+    /// `Instant::now()` that is used by the background worker. Can be mocked for testing.
+    fn background_worker_now(&self) -> Instant {
+        let mut guard = self.background_worker_now_override.lock();
+        match *guard {
+            Some(now) => {
+                *guard = Some(now + Duration::from_nanos(1));
+                now
+            }
+            None => Instant::now(),
         }
     }
 
@@ -1285,20 +1302,21 @@ impl Db {
                                 row_count,
                                 min_time,
                                 max_time,
-                                Instant::now(),
+                                self.background_worker_now(),
                             );
                         }
                         None => {
                             let mut windows = PersistenceWindows::new(
                                 partition.addr().clone(),
                                 late_arrival_window,
+                                self.background_worker_now(),
                             );
                             windows.add_range(
                                 sequence,
                                 row_count,
                                 min_time,
                                 max_time,
-                                Instant::now(),
+                                self.background_worker_now(),
                             );
                             partition.set_persistence_windows(windows);
                         }

--- a/server/src/db.rs
+++ b/server/src/db.rs
@@ -382,7 +382,7 @@ pub struct Db {
     /// TODO: Move write buffer read loop out of Db.
     no_write_buffer_read: AtomicBool,
 
-    /// Mocked `Instant::now()` for the background worker
+    /// TESTING ONLY: Mocked `Instant::now()` for the background worker
     background_worker_now_override: Mutex<Option<Instant>>,
 }
 

--- a/server/src/db/replay.rs
+++ b/server/src/db/replay.rs
@@ -432,7 +432,7 @@ mod tests {
         Persist(Vec<(&'static str, &'static str)>),
 
         /// Advance clock far enough that all ingested entries become persistable.
-        Tick,
+        MakeWritesPersistable,
 
         /// Drop all unpersisted chunks from given partitions.
         ///
@@ -573,7 +573,7 @@ mod tests {
                             }
                         }
                     }
-                    Step::Tick => {
+                    Step::MakeWritesPersistable => {
                         let mut guard = test_db.db.background_worker_now_override.lock();
                         *guard = Some(guard.unwrap() + Duration::from_secs(60));
                     }
@@ -888,7 +888,7 @@ mod tests {
                     ("table_1", "tag_partition_by_a"),
                     ("table_2", "tag_partition_by_a"),
                 ])]),
-                Step::Tick,
+                Step::MakeWritesPersistable,
                 Step::Persist(vec![("table_2", "tag_partition_by_a")]),
                 Step::Restart,
                 Step::Assert(vec![Check::Partitions(vec![(
@@ -994,7 +994,7 @@ mod tests {
                     ("table_1", "tag_partition_by_a"),
                     ("table_2", "tag_partition_by_a"),
                 ])]),
-                Step::Tick,
+                Step::MakeWritesPersistable,
                 Step::Persist(vec![("table_1", "tag_partition_by_a")]),
                 Step::Restart,
                 Step::Assert(vec![Check::Partitions(vec![(
@@ -1146,7 +1146,7 @@ mod tests {
                     ("table_1", "tag_partition_by_a"),
                     ("table_2", "tag_partition_by_a"),
                 ])]),
-                Step::Tick,
+                Step::MakeWritesPersistable,
                 Step::Persist(vec![("table_1", "tag_partition_by_a")]),
                 Step::Restart,
                 Step::Assert(vec![Check::Partitions(vec![(
@@ -1251,7 +1251,7 @@ mod tests {
                     ],
                 )]),
                 // only persist partition a
-                Step::Tick,
+                Step::MakeWritesPersistable,
                 Step::Persist(vec![("table_1", "tag_partition_by_a")]),
                 // ================================================================================
                 // after restart the non-persisted partition (B) is gone
@@ -1306,7 +1306,7 @@ mod tests {
                     ],
                 )]),
                 // ...and only persist partition a (a 2nd time)
-                Step::Tick,
+                Step::MakeWritesPersistable,
                 Step::Persist(vec![("table_1", "tag_partition_by_a")]),
                 // ================================================================================
                 // after restart partition b will be gone again
@@ -1366,7 +1366,7 @@ mod tests {
                     ],
                 )]),
                 // this time only persist partition b
-                Step::Tick,
+                Step::MakeWritesPersistable,
                 Step::Persist(vec![("table_1", "tag_partition_by_b")]),
                 // ================================================================================
                 // after restart partition b will be fully present but the latest data for partition a is gone
@@ -1433,7 +1433,7 @@ mod tests {
                     ],
                 )]),
                 // finally persist both partitions
-                Step::Tick,
+                Step::MakeWritesPersistable,
                 Step::Persist(vec![
                     ("table_1", "tag_partition_by_a"),
                     ("table_1", "tag_partition_by_b"),
@@ -1498,7 +1498,7 @@ mod tests {
                     ("table_1", "tag_partition_by_a"),
                     ("table_2", "tag_partition_by_a"),
                 ])]),
-                Step::Tick,
+                Step::MakeWritesPersistable,
                 Step::Persist(vec![("table_2", "tag_partition_by_a")]),
                 Step::Restart,
                 Step::Assert(vec![Check::Partitions(vec![(
@@ -1546,7 +1546,7 @@ mod tests {
                     ("table_1", "tag_partition_by_a"),
                     ("table_2", "tag_partition_by_a"),
                 ])]),
-                Step::Tick,
+                Step::MakeWritesPersistable,
                 Step::Persist(vec![("table_1", "tag_partition_by_a")]),
                 Step::Restart,
                 Step::Assert(vec![Check::Partitions(vec![
@@ -1641,7 +1641,7 @@ mod tests {
                     ("table_1", "tag_partition_by_a"),
                     ("table_2", "tag_partition_by_a"),
                 ])]),
-                Step::Tick,
+                Step::MakeWritesPersistable,
                 Step::Persist(vec![("table_1", "tag_partition_by_a")]),
                 Step::Ingest(vec![
                     TestSequencedEntry {
@@ -1660,7 +1660,7 @@ mod tests {
                     ("table_2", "tag_partition_by_a"),
                     ("table_3", "tag_partition_by_a"),
                 ])]),
-                Step::Tick,
+                Step::MakeWritesPersistable,
                 Step::Persist(vec![("table_3", "tag_partition_by_a")]),
                 Step::Restart,
                 Step::Replay,
@@ -1720,7 +1720,7 @@ mod tests {
                     ("table_1", "tag_partition_by_a"),
                     ("table_1", "tag_partition_by_b"),
                 ])]),
-                Step::Tick,
+                Step::MakeWritesPersistable,
                 Step::Persist(vec![
                     ("table_1", "tag_partition_by_a"),
                     ("table_1", "tag_partition_by_b"),
@@ -1753,7 +1753,7 @@ mod tests {
                     "select max(bar) as bar from table_1",
                     vec!["+-----+", "| bar |", "+-----+", "| 10  |", "+-----+"],
                 )]),
-                Step::Tick,
+                Step::MakeWritesPersistable,
                 Step::Ingest(vec![TestSequencedEntry {
                     sequencer_id: 0,
                     sequence_number: 2,
@@ -1774,7 +1774,7 @@ mod tests {
                     "select max(bar) as bar from table_1",
                     vec!["+-----+", "| bar |", "+-----+", "| 30  |", "+-----+"],
                 )]),
-                Step::Tick,
+                Step::MakeWritesPersistable,
                 Step::Persist(vec![("table_1", "tag_partition_by_b")]),
                 Step::Restart,
                 Step::Replay,
@@ -1804,7 +1804,7 @@ mod tests {
                     "select max(bar) as bar from table_1",
                     vec!["+-----+", "| bar |", "+-----+", "| 10  |", "+-----+"],
                 )]),
-                Step::Tick,
+                Step::MakeWritesPersistable,
                 Step::Ingest(vec![TestSequencedEntry {
                     sequencer_id: 0,
                     sequence_number: 2,
@@ -1825,7 +1825,7 @@ mod tests {
                     "select max(bar) as bar from table_1",
                     vec!["+-----+", "| bar |", "+-----+", "| 30  |", "+-----+"],
                 )]),
-                Step::Tick,
+                Step::MakeWritesPersistable,
                 Step::Ingest(vec![TestSequencedEntry {
                     sequencer_id: 0,
                     sequence_number: 4,


### PR DESCRIPTION
Someone might wonder why a regression test takes sooo much code:

- we need to mock partially persisted partitions
- for that we need to tightly control the clock
- that requires some wiring in `Db`
- some asserts were a bit messy
- the test framework was flaky for persist operations
- there was some edge case regarding checkpoints that wasn't checked before (and now fails w/ a regression test)

The actual fix will be in a follow-up PR, I want to avoid overlarge PRs.