### PR TITLE
WIP refactor: Extract a database persister type that wraps object store

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1775,6 +1775,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "iox_object_store"
+version = "0.1.0"
+dependencies = [
+ "bytes",
+ "data_types",
+ "futures",
+ "object_store",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2651,6 +2661,7 @@ dependencies = [
  "futures",
  "generated_types",
  "internal_types",
+ "iox_object_store",
  "metrics",
  "object_store",
  "observability_deps",
@@ -3855,6 +3866,7 @@ dependencies = [
  "influxdb_iox_client",
  "influxdb_line_protocol",
  "internal_types",
+ "iox_object_store",
  "itertools 0.10.1",
  "lifecycle",
  "metrics",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ members = [
     "influxdb_line_protocol",
     "influxdb_tsm",
     "internal_types",
+    "iox_object_store",
     "logfmt",
     "lifecycle",
     "mem_qe",

--- a/iox_object_store/Cargo.toml
+++ b/iox_object_store/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "iox_object_store"
+version = "0.1.0"
+edition = "2018"
+description = "IOx-specific semantics wrapping the general-purpose object store crate"
+
+[dependencies]
+bytes = "1.0"
+data_types = { path = "../data_types" }
+futures = "0.3"
+object_store = { path = "../object_store" }

--- a/iox_object_store/src/lib.rs
+++ b/iox_object_store/src/lib.rs
@@ -1,0 +1,201 @@
+#![deny(broken_intra_doc_links, rustdoc::bare_urls, rust_2018_idioms)]
+#![warn(
+    missing_copy_implementations,
+    missing_debug_implementations,
+    missing_docs,
+    clippy::explicit_iter_loop,
+    clippy::future_not_send,
+    clippy::use_self,
+    clippy::clone_on_ref_ptr
+)]
+
+//! Wraps the object_store crate with IOx-specific semantics.
+
+use bytes::Bytes;
+use data_types::{server_id::ServerId, DatabaseName};
+use futures::{stream::BoxStream, Stream};
+use object_store::{
+    path::{parsed::DirsAndFileName, ObjectStorePath, Path},
+    ListResult, ObjectStore, ObjectStoreApi, Result,
+};
+use std::{io, sync::Arc};
+
+/// Handles persistence of data for a particular database. Writes within its directory/prefix.
+#[derive(Debug)]
+pub struct IoxObjectStore {
+    store: Arc<ObjectStore>,
+    server_id: ServerId,
+    database_name: String, // data_types DatabaseName?
+    root_path: RootPath,
+}
+
+impl IoxObjectStore {
+    /// Create a database-specific wrapper. Takes all the information needed to create the
+    /// root directory of a database.
+    pub fn new(
+        store: Arc<ObjectStore>,
+        server_id: ServerId,
+        database_name: &DatabaseName<'_>,
+    ) -> Self {
+        let root_path = RootPath::new(store.new_path(), server_id, database_name);
+        Self {
+            store,
+            server_id,
+            database_name: database_name.into(),
+            root_path,
+        }
+    }
+
+    pub fn database_name(&self) -> &str {
+        &self.database_name
+    }
+
+    /// Path where transactions are stored.
+    ///
+    /// The format is:
+    ///
+    /// ```text
+    /// <server_id>/<db_name>/transactions/
+    /// ```
+    pub fn catalog_path(&self) -> Path {
+        let mut path = self.store.new_path();
+        path.push_dir(self.server_id.to_string());
+        path.push_dir(&self.database_name);
+        path.push_dir("transactions");
+        path
+    }
+
+    /// Location where parquet data goes to.
+    ///
+    /// Schema currently is:
+    ///
+    /// ```text
+    /// <server_id>/<db_name>/data/
+    /// ```
+    pub fn data_path(&self) -> Path {
+        let mut path = self.store.new_path();
+        path.push_dir(self.server_id.to_string());
+        path.push_dir(&self.database_name);
+        path.push_dir("data");
+        path
+    }
+
+    pub async fn put<S>(&self, _location: &Path, _bytes: S, _length: Option<usize>) -> Result<()>
+    where
+        S: Stream<Item = io::Result<Bytes>> + Send + Sync + 'static,
+    {
+        unimplemented!();
+    }
+
+    pub async fn list<'a>(
+        &'a self,
+        _prefix: Option<&'a Path>,
+    ) -> Result<BoxStream<'a, Result<Vec<Path>>>> {
+        unimplemented!();
+    }
+
+    pub async fn list_with_delimiter(&self, _prefix: &Path) -> Result<ListResult<Path>> {
+        unimplemented!();
+    }
+
+    pub async fn get(&self, _location: &Path) -> Result<BoxStream<'static, Result<Bytes>>> {
+        unimplemented!();
+    }
+
+    pub async fn delete(&self, _location: &Path) -> Result<()> {
+        unimplemented!();
+    }
+
+    pub fn path_from_dirs_and_filename(&self, _path: DirsAndFileName) -> Path {
+        unimplemented!();
+    }
+}
+
+/// A database-specific object store path that all `RelativePath`s should be within.
+#[derive(Debug)]
+struct RootPath {
+    root: Path,
+}
+
+impl RootPath {
+    /// How the root of a database is defined in object storage.
+    fn new(mut root: Path, server_id: ServerId, database_name: &DatabaseName<'_>) -> Self {
+        root.push_dir(server_id.to_string());
+        root.push_dir(database_name.as_str());
+        Self { root }
+    }
+
+    /// Create an object storage path relative to `self` with the given relative path.
+    fn join(&self, relative: &RelativePath) -> Path {
+        let mut path = self.root.clone();
+
+        for part in &relative.parts {
+            path.push_dir(part);
+        }
+
+        path
+    }
+}
+
+/// A path within a database's object store directory. Must be combined with a database root path
+/// to get an object store path.
+#[derive(Debug)]
+pub struct RelativePath {
+    parts: Vec<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::num::NonZeroU32;
+
+    /// Creates new test server ID
+    fn make_server_id() -> ServerId {
+        ServerId::new(NonZeroU32::new(1).unwrap())
+    }
+
+    /// Creates a new in-memory object store. These tests rely on the `Path`s being of type
+    /// `DirsAndFileName` and thus using object_store::path::DELIMITER as the separator
+    fn make_object_store() -> Arc<ObjectStore> {
+        Arc::new(ObjectStore::new_in_memory())
+    }
+
+    #[test]
+    fn catalog_path_is_relative_to_db_root() {
+        let server_id = make_server_id();
+        let database_name = DatabaseName::new("clouds").unwrap();
+        let iox_object_store = IoxObjectStore::new(make_object_store(), server_id, &database_name);
+        assert_eq!(
+            iox_object_store.catalog_path().display(),
+            "1/clouds/transactions/"
+        );
+    }
+
+    #[test]
+    fn data_path_is_relative_to_db_root() {
+        let server_id = make_server_id();
+        let database_name = DatabaseName::new("clouds").unwrap();
+        let iox_object_store = IoxObjectStore::new(make_object_store(), server_id, &database_name);
+        assert_eq!(iox_object_store.data_path().display(), "1/clouds/data/");
+    }
+
+    #[test]
+    fn root_path_adds_itself_to_all_object_store_paths() {
+        let object_store = make_object_store();
+        let server_id = make_server_id();
+        let database_name = DatabaseName::new("clouds").unwrap();
+        let root = RootPath::new(object_store.new_path(), server_id, &database_name);
+
+        let relative = RelativePath {
+            parts: vec![String::from("foo"), String::from("bar")],
+        };
+
+        let mut expected = object_store.new_path();
+        expected.push_dir(server_id.to_string());
+        expected.push_dir(&database_name);
+        expected.push_dir("foo");
+        expected.push_dir("bar");
+
+        assert_eq!(expected, root.join(&relative));
+    }
+}

--- a/object_store/src/path/parsed.rs
+++ b/object_store/src/path/parsed.rs
@@ -130,7 +130,7 @@ impl DirsAndFileName {
     }
 
     /// Add a `PathPart` to the end of the path's directories.
-    pub(crate) fn push_part_as_dir(&mut self, part: &PathPart) {
+    pub fn push_part_as_dir(&mut self, part: &PathPart) {
         self.directories.push(part.to_owned());
     }
 

--- a/object_store/src/path/parsed.rs
+++ b/object_store/src/path/parsed.rs
@@ -101,7 +101,7 @@ impl DirsAndFileName {
     /// Returns all directory and file name `PathParts` in `self` after the
     /// specified `prefix`. Ignores any `file_name` part of `prefix`.
     /// Returns `None` if `self` dosen't start with `prefix`.
-    pub(crate) fn parts_after_prefix(&self, prefix: &Self) -> Option<Vec<PathPart>> {
+    pub fn parts_after_prefix(&self, prefix: &Self) -> Option<Vec<PathPart>> {
         let mut dirs_iter = self.directories.iter();
         let mut prefix_dirs_iter = prefix.directories.iter();
 

--- a/parquet_file/Cargo.toml
+++ b/parquet_file/Cargo.toml
@@ -14,9 +14,10 @@ datafusion = { path = "../datafusion" }
 datafusion_util = { path = "../datafusion_util" }
 futures = "0.3.7"
 generated_types = { path = "../generated_types" }
-internal_types = {path = "../internal_types"}
+internal_types = { path = "../internal_types" }
+iox_object_store = { path = "../iox_object_store" }
 metrics = { path = "../metrics" }
-object_store = {path = "../object_store"}
+object_store = { path = "../object_store" }
 observability_deps = { path = "../observability_deps" }
 parquet = "5.0"
 parquet-format = "2.6"

--- a/parquet_file/src/chunk.rs
+++ b/parquet_file/src/chunk.rs
@@ -8,7 +8,8 @@ use internal_types::{
     schema::{Schema, TIME_COLUMN_NAME},
     selection::Selection,
 };
-use object_store::{path::Path, ObjectStore};
+use iox_object_store::IoxObjectStore;
+use object_store::path::Path;
 use query::predicate::Predicate;
 use snafu::{ResultExt, Snafu};
 use std::{collections::BTreeSet, mem, sync::Arc};
@@ -91,8 +92,8 @@ pub struct ParquetChunk {
     /// (extracted from TableSummary)
     timestamp_range: Option<TimestampRange>,
 
-    /// Object store of the above relative path to open and read the file
-    object_store: Arc<ObjectStore>,
+    /// Persists the parquet file within a database's relative path
+    iox_object_store: Arc<IoxObjectStore>,
 
     /// Path in the object store. Format:
     ///  <writer id>/<database>/data/<partition key>/<chunk
@@ -112,7 +113,7 @@ impl ParquetChunk {
     /// Creates new chunk from given parquet metadata.
     pub fn new(
         file_location: Path,
-        store: Arc<ObjectStore>,
+        iox_object_store: Arc<IoxObjectStore>,
         file_size_bytes: usize,
         parquet_metadata: Arc<IoxParquetMetaData>,
         table_name: Arc<str>,
@@ -137,7 +138,7 @@ impl ParquetChunk {
             Arc::new(table_summary),
             schema,
             file_location,
-            store,
+            iox_object_store,
             file_size_bytes,
             parquet_metadata,
             metrics,
@@ -152,7 +153,7 @@ impl ParquetChunk {
         table_summary: Arc<TableSummary>,
         schema: Arc<Schema>,
         file_location: Path,
-        store: Arc<ObjectStore>,
+        iox_object_store: Arc<IoxObjectStore>,
         file_size_bytes: usize,
         parquet_metadata: Arc<IoxParquetMetaData>,
         metrics: ChunkMetrics,
@@ -164,7 +165,7 @@ impl ParquetChunk {
             table_summary,
             schema,
             timestamp_range,
-            object_store: store,
+            iox_object_store,
             object_store_path: file_location,
             file_size_bytes,
             parquet_metadata,
@@ -247,7 +248,7 @@ impl ParquetChunk {
             selection,
             Arc::clone(&self.schema.as_arrow()),
             self.object_store_path.clone(),
-            Arc::clone(&self.object_store),
+            Arc::clone(&self.iox_object_store),
         )
         .context(ReadParquet)
     }

--- a/parquet_file/src/metadata.rs
+++ b/parquet_file/src/metadata.rs
@@ -811,15 +811,17 @@ mod tests {
 
     use crate::test_utils::{
         chunk_addr, create_partition_and_database_checkpoint, load_parquet_from_store, make_chunk,
-        make_chunk_no_row_group, make_object_store,
+        make_chunk_no_row_group, make_iox_object_store,
     };
 
     #[tokio::test]
     async fn test_restore_from_file() {
         // setup: preserve chunk to object store
-        let store = make_object_store();
-        let chunk = make_chunk(Arc::clone(&store), "foo", chunk_addr(1)).await;
-        let parquet_data = load_parquet_from_store(&chunk, store).await.unwrap();
+        let iox_object_store = make_iox_object_store();
+        let chunk = make_chunk(Arc::clone(&iox_object_store), "foo", chunk_addr(1)).await;
+        let parquet_data = load_parquet_from_store(&chunk, iox_object_store)
+            .await
+            .unwrap();
         let parquet_metadata = IoxParquetMetaData::from_file_bytes(parquet_data).unwrap();
 
         // step 1: read back schema
@@ -841,9 +843,11 @@ mod tests {
     #[tokio::test]
     async fn test_restore_from_thrift() {
         // setup: write chunk to object store and only keep thrift-encoded metadata
-        let store = make_object_store();
-        let chunk = make_chunk(Arc::clone(&store), "foo", chunk_addr(1)).await;
-        let parquet_data = load_parquet_from_store(&chunk, store).await.unwrap();
+        let iox_object_store = make_iox_object_store();
+        let chunk = make_chunk(Arc::clone(&iox_object_store), "foo", chunk_addr(1)).await;
+        let parquet_data = load_parquet_from_store(&chunk, iox_object_store)
+            .await
+            .unwrap();
         let parquet_metadata = IoxParquetMetaData::from_file_bytes(parquet_data).unwrap();
         let data = parquet_metadata.to_thrift().unwrap();
         let parquet_metadata = IoxParquetMetaData::from_thrift(&data).unwrap();
@@ -862,9 +866,12 @@ mod tests {
     #[tokio::test]
     async fn test_restore_from_file_no_row_group() {
         // setup: preserve chunk to object store
-        let store = make_object_store();
-        let chunk = make_chunk_no_row_group(Arc::clone(&store), "foo", chunk_addr(1)).await;
-        let parquet_data = load_parquet_from_store(&chunk, store).await.unwrap();
+        let iox_object_store = make_iox_object_store();
+        let chunk =
+            make_chunk_no_row_group(Arc::clone(&iox_object_store), "foo", chunk_addr(1)).await;
+        let parquet_data = load_parquet_from_store(&chunk, iox_object_store)
+            .await
+            .unwrap();
         let parquet_metadata = IoxParquetMetaData::from_file_bytes(parquet_data).unwrap();
 
         // step 1: read back schema
@@ -883,9 +890,12 @@ mod tests {
     #[tokio::test]
     async fn test_restore_from_thrift_no_row_group() {
         // setup: write chunk to object store and only keep thrift-encoded metadata
-        let store = make_object_store();
-        let chunk = make_chunk_no_row_group(Arc::clone(&store), "foo", chunk_addr(1)).await;
-        let parquet_data = load_parquet_from_store(&chunk, store).await.unwrap();
+        let iox_object_store = make_iox_object_store();
+        let chunk =
+            make_chunk_no_row_group(Arc::clone(&iox_object_store), "foo", chunk_addr(1)).await;
+        let parquet_data = load_parquet_from_store(&chunk, iox_object_store)
+            .await
+            .unwrap();
         let parquet_metadata = IoxParquetMetaData::from_file_bytes(parquet_data).unwrap();
         let data = parquet_metadata.to_thrift().unwrap();
         let parquet_metadata = IoxParquetMetaData::from_thrift(&data).unwrap();
@@ -905,9 +915,11 @@ mod tests {
 
     #[tokio::test]
     async fn test_make_chunk() {
-        let store = make_object_store();
-        let chunk = make_chunk(Arc::clone(&store), "foo", chunk_addr(1)).await;
-        let parquet_data = load_parquet_from_store(&chunk, store).await.unwrap();
+        let iox_object_store = make_iox_object_store();
+        let chunk = make_chunk(Arc::clone(&iox_object_store), "foo", chunk_addr(1)).await;
+        let parquet_data = load_parquet_from_store(&chunk, iox_object_store)
+            .await
+            .unwrap();
         let parquet_metadata = IoxParquetMetaData::from_file_bytes(parquet_data).unwrap();
 
         assert!(parquet_metadata.md.num_row_groups() > 1);
@@ -945,9 +957,12 @@ mod tests {
 
     #[tokio::test]
     async fn test_make_chunk_no_row_group() {
-        let store = make_object_store();
-        let chunk = make_chunk_no_row_group(Arc::clone(&store), "foo", chunk_addr(1)).await;
-        let parquet_data = load_parquet_from_store(&chunk, store).await.unwrap();
+        let iox_object_store = make_iox_object_store();
+        let chunk =
+            make_chunk_no_row_group(Arc::clone(&iox_object_store), "foo", chunk_addr(1)).await;
+        let parquet_data = load_parquet_from_store(&chunk, iox_object_store)
+            .await
+            .unwrap();
         let parquet_metadata = IoxParquetMetaData::from_file_bytes(parquet_data).unwrap();
 
         assert_eq!(parquet_metadata.md.num_row_groups(), 0);

--- a/parquet_file/src/storage.rs
+++ b/parquet_file/src/storage.rs
@@ -5,16 +5,18 @@ use arrow::{
     error::{ArrowError, Result as ArrowResult},
     record_batch::RecordBatch,
 };
+use bytes::Bytes;
+use data_types::chunk_metadata::ChunkAddr;
 use datafusion::{
     logical_plan::Expr,
     physical_plan::{parquet::ParquetExec, ExecutionPlan, Partitioning, SendableRecordBatchStream},
 };
+use futures::StreamExt;
 use internal_types::selection::Selection;
-use object_store::{
-    path::{parsed::DirsAndFileName, ObjectStorePath, Path},
-    ObjectStore, ObjectStoreApi,
-};
+use iox_object_store::IoxObjectStore;
+use object_store::path::{parsed::DirsAndFileName, ObjectStorePath, Path};
 use observability_deps::tracing::debug;
+use parking_lot::Mutex;
 use parquet::{
     self,
     arrow::ArrowWriter,
@@ -22,11 +24,6 @@ use parquet::{
     file::{metadata::KeyValue, properties::WriterProperties, writer::TryClone},
 };
 use query::{exec::stream::AdapterStream, predicate::Predicate};
-
-use bytes::Bytes;
-use data_types::{chunk_metadata::ChunkAddr, server_id::ServerId};
-use futures::StreamExt;
-use parking_lot::Mutex;
 use snafu::{ensure, OptionExt, ResultExt, Snafu};
 use std::{
     io::{Cursor, Seek, SeekFrom, Write},
@@ -132,16 +129,12 @@ pub type Result<T, E = Error> = std::result::Result<T, E>;
 
 #[derive(Debug, Clone)]
 pub struct Storage {
-    object_store: Arc<ObjectStore>,
-    server_id: ServerId,
+    iox_object_store: Arc<IoxObjectStore>,
 }
 
 impl Storage {
-    pub fn new(object_store: Arc<ObjectStore>, server_id: ServerId) -> Self {
-        Self {
-            object_store,
-            server_id,
-        }
+    pub fn new(iox_object_store: Arc<IoxObjectStore>) -> Self {
+        Self { iox_object_store }
     }
 
     /// Return full path including filename in the object store to save a chunk
@@ -156,7 +149,7 @@ impl Storage {
         // generate random UUID so that files are unique and never overwritten
         let uuid = Uuid::new_v4();
 
-        let mut path = data_location(&self.object_store, self.server_id, &chunk_addr.db_name);
+        let mut path = self.iox_object_store.data_path();
         path.push_dir(chunk_addr.table_name.as_ref());
         path.push_dir(chunk_addr.partition_key.as_ref());
         path.set_file_name(format!(
@@ -236,7 +229,7 @@ impl Storage {
         let data = Bytes::from(data);
         let stream_data = Result::Ok(data);
 
-        self.object_store
+        self.iox_object_store
             .put(
                 file_name,
                 futures::stream::once(async move { stream_data }),
@@ -274,7 +267,7 @@ impl Storage {
         predicate: Option<Expr>,
         projection: Vec<usize>,
         path: Path,
-        store: Arc<ObjectStore>,
+        store: Arc<IoxObjectStore>,
         tx: tokio::sync::mpsc::Sender<ArrowResult<RecordBatch>>,
     ) -> Result<()> {
         // Size of each batch
@@ -353,7 +346,7 @@ impl Storage {
         selection: Selection<'_>,
         schema: SchemaRef,
         path: Path,
-        store: Arc<ObjectStore>,
+        store: Arc<IoxObjectStore>,
     ) -> Result<SendableRecordBatchStream> {
         // fire up a async task that will fetch the parquet file
         // locally, start it executing and send results
@@ -439,32 +432,11 @@ impl TryClone for MemWriter {
     }
 }
 
-/// Location where parquet data goes to.
-///
-/// Schema currently is:
-///
-/// ```text
-/// <writer_id>/<database>/data
-/// ```
-pub(crate) fn data_location(
-    object_store: &ObjectStore,
-    server_id: ServerId,
-    db_name: &str,
-) -> Path {
-    let mut path = object_store.new_path();
-    path.push_dir(server_id.to_string());
-    path.push_dir(db_name.to_string());
-    path.push_dir("data");
-    path
-}
-
 #[cfg(test)]
 mod tests {
-    use std::convert::TryFrom;
-
     use super::*;
     use crate::test_utils::{
-        create_partition_and_database_checkpoint, make_object_store, make_record_batch,
+        create_partition_and_database_checkpoint, make_iox_object_store, make_record_batch,
     };
     use arrow::array::{ArrayRef, StringArray};
     use arrow_util::assert_batches_eq;
@@ -538,12 +510,11 @@ mod tests {
         assert_batches_eq!(&expected, &input_batches);
 
         // create Storage
-        let server_id = ServerId::try_from(1).unwrap();
-        let db_name = Arc::from("my_db");
         let table_name = Arc::from("my_table");
         let partition_key = Arc::from("my_partition");
         let chunk_id = 33;
-        let storage = Storage::new(make_object_store(), server_id);
+        let iox_object_store = make_iox_object_store();
+        let storage = Storage::new(Arc::clone(&iox_object_store));
 
         // write the data in
         let schema = batch.schema();
@@ -569,7 +540,7 @@ mod tests {
         let (path, _file_size_bytes, _metadata) = storage
             .write_to_object_store(
                 ChunkAddr {
-                    db_name,
+                    db_name: iox_object_store.database_name().into(),
                     table_name,
                     partition_key,
                     chunk_id,
@@ -580,13 +551,13 @@ mod tests {
             .await
             .expect("successfully wrote to object store");
 
-        let object_store = Arc::clone(&storage.object_store);
+        let iox_object_store = Arc::clone(&storage.iox_object_store);
         let read_stream = Storage::read_filter(
             &Predicate::default(),
             Selection::All,
             schema,
             path,
-            object_store,
+            iox_object_store,
         )
         .expect("successfully called read_filter");
 
@@ -599,10 +570,10 @@ mod tests {
 
     #[test]
     fn test_locations_are_unique() {
-        let server_id = ServerId::try_from(1).unwrap();
-        let storage = Storage::new(make_object_store(), server_id);
+        let iox_object_store = make_iox_object_store();
+        let storage = Storage::new(Arc::clone(&iox_object_store));
         let chunk_addr = ChunkAddr {
-            db_name: Arc::from("my_db"),
+            db_name: iox_object_store.database_name().into(),
             table_name: Arc::from("my_table"),
             partition_key: Arc::from("my_partition"),
             chunk_id: 13,

--- a/parquet_file/src/storage_testing.rs
+++ b/parquet_file/src/storage_testing.rs
@@ -12,8 +12,8 @@ mod tests {
     use crate::{
         metadata::IoxParquetMetaData,
         test_utils::{
-            chunk_addr, load_parquet_from_store, make_chunk_given_record_batch, make_object_store,
-            make_record_batch, read_data_from_parquet_data,
+            chunk_addr, load_parquet_from_store, make_chunk_given_record_batch,
+            make_iox_object_store, make_record_batch, read_data_from_parquet_data,
         },
     };
 
@@ -31,7 +31,7 @@ mod tests {
 
         ////////////////////
         // Make an OS in memory
-        let store = make_object_store();
+        let store = make_iox_object_store();
 
         ////////////////////
         // Store the data as a chunk and write it to in the object store

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -26,6 +26,7 @@ hashbrown = "0.11"
 influxdb_iox_client = { path = "../influxdb_iox_client" }
 influxdb_line_protocol = { path = "../influxdb_line_protocol" }
 internal_types = { path = "../internal_types" }
+iox_object_store = { path = "../iox_object_store" }
 itertools = "0.10.1"
 lifecycle = { path = "../lifecycle" }
 metrics = { path = "../metrics" }

--- a/server/src/database.rs
+++ b/server/src/database.rs
@@ -8,6 +8,7 @@ use data_types::{database_rules::DatabaseRules, DatabaseName};
 use futures::future::{BoxFuture, Shared};
 use futures::{FutureExt, TryFutureExt};
 use internal_types::freezable::Freezable;
+use iox_object_store::IoxObjectStore;
 use object_store::path::{ObjectStorePath, Path};
 use observability_deps::tracing::{error, info};
 use parking_lot::RwLock;
@@ -92,12 +93,18 @@ impl Database {
     pub fn new(application: Arc<ApplicationState>, config: DatabaseConfig) -> Self {
         info!(db_name=%config.name, store_prefix=%config.store_prefix.display(), "new database");
 
+        let iox_object_store = Arc::new(IoxObjectStore::new(
+            Arc::clone(application.object_store()),
+            config.server_id,
+            &config.name,
+        ));
         let shared = Arc::new(DatabaseShared {
             config,
             application,
             shutdown: Default::default(),
             state: RwLock::new(Freezable::new(DatabaseState::Known(DatabaseStateKnown {}))),
             state_notify: Default::default(),
+            iox_object_store,
         });
 
         let handle = tokio::spawn(background_worker(Arc::clone(&shared)));
@@ -149,6 +156,10 @@ impl Database {
             .read()
             .get_initialized()
             .map(|state| Arc::clone(&state.db))
+    }
+
+    pub fn iox_object_store(&self) -> Arc<IoxObjectStore> {
+        Arc::clone(&self.shared.iox_object_store)
     }
 
     /// Returns Ok(()) when the Database is initialized, or the error
@@ -204,14 +215,10 @@ impl Database {
         Ok(async move {
             let db_name = &shared.config.name;
 
-            PreservedCatalog::wipe(
-                shared.application.object_store().as_ref(),
-                shared.config.server_id,
-                db_name,
-            )
-            .await
-            .map_err(Box::new)
-            .context(WipePreservedCatalog { db_name })?;
+            PreservedCatalog::wipe(&shared.iox_object_store)
+                .await
+                .map_err(Box::new)
+                .context(WipePreservedCatalog { db_name })?;
 
             {
                 let mut state = shared.state.write();
@@ -240,6 +247,9 @@ struct DatabaseShared {
 
     /// Notify that the database state has changed
     state_notify: Notify,
+
+    /// The object store interface for this database
+    iox_object_store: Arc<IoxObjectStore>,
 }
 
 /// The background worker for `Database` - there should only ever be one
@@ -492,7 +502,7 @@ impl DatabaseStateRulesLoaded {
     ) -> Result<DatabaseStateCatalogLoaded, InitError> {
         let (preserved_catalog, catalog, replay_plan) = load_or_create_preserved_catalog(
             shared.config.name.as_str(),
-            Arc::clone(shared.application.object_store()),
+            Arc::clone(&shared.iox_object_store),
             shared.config.server_id,
             Arc::clone(shared.application.metric_registry()),
             shared.config.wipe_catalog_on_error,
@@ -507,7 +517,11 @@ impl DatabaseStateRulesLoaded {
 
         let database_to_commit = DatabaseToCommit {
             server_id: shared.config.server_id,
-            object_store: Arc::clone(shared.application.object_store()),
+            iox_object_store: Arc::new(IoxObjectStore::new(
+                Arc::clone(shared.application.object_store()),
+                shared.config.server_id,
+                &shared.config.name,
+            )),
             exec: Arc::clone(shared.application.executor()),
             rules: Arc::clone(&self.rules),
             preserved_catalog,

--- a/server/src/db.rs
+++ b/server/src/db.rs
@@ -28,9 +28,10 @@ use datafusion::catalog::{catalog::CatalogProvider, schema::SchemaProvider};
 use entry::{Entry, Sequence, SequencedEntry, TableBatch};
 use futures::{stream::BoxStream, StreamExt};
 use internal_types::schema::Schema;
+use iox_object_store::IoxObjectStore;
 use metrics::KeyValue;
 use mutable_buffer::chunk::{ChunkMetrics as MutableBufferChunkMetrics, MBChunk};
-use object_store::{path::parsed::DirsAndFileName, ObjectStore};
+use object_store::path::parsed::DirsAndFileName;
 use observability_deps::tracing::{debug, error, info};
 use parking_lot::{Mutex, RwLock};
 use parquet_file::{
@@ -317,7 +318,7 @@ pub struct Db {
     server_id: ServerId, // this is also the Query Server ID
 
     /// Interface to use for persistence
-    store: Arc<ObjectStore>,
+    iox_object_store: Arc<IoxObjectStore>,
 
     /// Executor for running queries
     exec: Arc<Executor>,
@@ -394,7 +395,7 @@ pub struct Db {
 #[derive(Debug)]
 pub(crate) struct DatabaseToCommit {
     pub(crate) server_id: ServerId,
-    pub(crate) object_store: Arc<ObjectStore>,
+    pub(crate) iox_object_store: Arc<IoxObjectStore>,
     pub(crate) exec: Arc<Executor>,
     pub(crate) preserved_catalog: PreservedCatalog,
     pub(crate) catalog: Catalog,
@@ -408,7 +409,7 @@ impl Db {
 
         let rules = RwLock::new(database_to_commit.rules);
         let server_id = database_to_commit.server_id;
-        let store = Arc::clone(&database_to_commit.object_store);
+        let iox_object_store = Arc::clone(&database_to_commit.iox_object_store);
         let metrics_registry = Arc::clone(&database_to_commit.catalog.metrics_registry);
         let metric_labels = database_to_commit.catalog.metric_labels.clone();
 
@@ -432,7 +433,7 @@ impl Db {
         let this = Self {
             rules,
             server_id,
-            store,
+            iox_object_store,
             exec: database_to_commit.exec,
             preserved_catalog: Arc::new(database_to_commit.preserved_catalog),
             catalog,
@@ -2666,9 +2667,10 @@ mod tests {
         assert_eq!(path_list[0], path);
 
         // Now read data from that path
-        let parquet_data = load_parquet_from_store_for_path(&path_list[0], object_store)
-            .await
-            .unwrap();
+        let parquet_data =
+            load_parquet_from_store_for_path(&path_list[0], Arc::clone(&db.iox_object_store))
+                .await
+                .unwrap();
         let parquet_metadata = IoxParquetMetaData::from_file_bytes(parquet_data.clone()).unwrap();
         // Read metadata at file level
         let schema = parquet_metadata.read_schema().unwrap();
@@ -2808,9 +2810,10 @@ mod tests {
         assert_eq!(path_list[0], path);
 
         // Now read data from that path
-        let parquet_data = load_parquet_from_store_for_path(&path_list[0], object_store)
-            .await
-            .unwrap();
+        let parquet_data =
+            load_parquet_from_store_for_path(&path_list[0], Arc::clone(&db.iox_object_store))
+                .await
+                .unwrap();
         let parquet_metadata = IoxParquetMetaData::from_file_bytes(parquet_data.clone()).unwrap();
         // Read metadata at file level
         let schema = parquet_metadata.read_schema().unwrap();
@@ -3858,14 +3861,10 @@ mod tests {
 
         // ==================== check: empty catalog created ====================
         // at this point, an empty preserved catalog exists
-        let maybe_preserved_catalog = PreservedCatalog::load::<TestCatalogState>(
-            Arc::clone(&object_store),
-            server_id,
-            db_name.to_string(),
-            (),
-        )
-        .await
-        .unwrap();
+        let maybe_preserved_catalog =
+            PreservedCatalog::load::<TestCatalogState>(Arc::clone(&db.iox_object_store), ())
+                .await
+                .unwrap();
         assert!(maybe_preserved_catalog.is_some());
 
         // ==================== do: write data to parquet ====================
@@ -3895,15 +3894,11 @@ mod tests {
             }
         }
         paths_expected.sort();
-        let (_preserved_catalog, catalog) = PreservedCatalog::load::<TestCatalogState>(
-            Arc::clone(&object_store),
-            server_id,
-            db_name.to_string(),
-            (),
-        )
-        .await
-        .unwrap()
-        .unwrap();
+        let (_preserved_catalog, catalog) =
+            PreservedCatalog::load::<TestCatalogState>(Arc::clone(&db.iox_object_store), ())
+                .await
+                .unwrap()
+                .unwrap();
         let paths_actual = {
             let mut tmp: Vec<String> = catalog.parquet_files.keys().map(|p| p.display()).collect();
             tmp.sort();

--- a/server/src/db/catalog/chunk.rs
+++ b/server/src/db/catalog/chunk.rs
@@ -953,7 +953,7 @@ mod tests {
     use mutable_buffer::chunk::ChunkMetrics as MBChunkMetrics;
     use parquet_file::{
         chunk::ParquetChunk,
-        test_utils::{make_chunk as make_parquet_chunk_with_store, make_object_store},
+        test_utils::{make_chunk as make_parquet_chunk_with_store, make_iox_object_store},
     };
 
     #[test]
@@ -1120,8 +1120,8 @@ mod tests {
     }
 
     async fn make_parquet_chunk(addr: ChunkAddr) -> ParquetChunk {
-        let object_store = make_object_store();
-        make_parquet_chunk_with_store(object_store, "foo", addr).await
+        let iox_object_store = make_iox_object_store();
+        make_parquet_chunk_with_store(iox_object_store, "foo", addr).await
     }
 
     fn chunk_addr() -> ChunkAddr {

--- a/server/src/db/lifecycle/write.rs
+++ b/server/src/db/lifecycle/write.rs
@@ -74,7 +74,7 @@ pub(super) fn write_chunk_to_object_store(
     let partition = partition.into_data().partition;
 
     // Create a storage to save data of this chunk
-    let storage = Storage::new(Arc::clone(&db.store), db.server_id);
+    let storage = Storage::new(Arc::clone(&db.iox_object_store));
 
     let catalog_transactions_until_checkpoint = db
         .rules
@@ -140,7 +140,7 @@ pub(super) fn write_chunk_to_object_store(
             let parquet_chunk = Arc::new(
                 ParquetChunk::new(
                     path.clone(),
-                    Arc::clone(&db.store),
+                    Arc::clone(&db.iox_object_store),
                     file_size_bytes,
                     Arc::clone(&parquet_metadata),
                     Arc::clone(&table_name),

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -89,6 +89,7 @@ use generated_types::influxdata::pbdata::v1 as pb;
 use hashbrown::HashMap;
 use influxdb_line_protocol::ParsedLine;
 use internal_types::freezable::Freezable;
+use iox_object_store::IoxObjectStore;
 use lifecycle::LockableChunk;
 use metrics::{KeyValue, MetricObserverBuilder};
 use object_store::{ObjectStore, ObjectStoreApi};
@@ -622,7 +623,7 @@ where
     /// Tells the server the set of rules for a database.
     ///
     /// Waits until the database has initialized or failed to do so
-    pub async fn create_database(&self, rules: DatabaseRules) -> Result<()> {
+    pub async fn create_database(&self, rules: DatabaseRules) -> Result<Arc<Database>> {
         let db_name = rules.name.clone();
         let object_store = self.shared.application.object_store().as_ref();
 
@@ -647,7 +648,11 @@ where
 
         create_preserved_catalog(
             db_name.as_str(),
-            Arc::clone(self.shared.application.object_store()),
+            Arc::new(IoxObjectStore::new(
+                Arc::clone(self.shared.application.object_store()),
+                server_id,
+                &db_name,
+            )),
             server_id,
             Arc::clone(self.shared.application.metric_registry()),
             true,
@@ -687,7 +692,7 @@ where
 
         database.wait_for_init().await.context(DatabaseInit)?;
 
-        Ok(())
+        Ok(database)
     }
 
     pub async fn write_pb(&self, database_batch: pb::DatabaseBatch) -> Result<()> {
@@ -1425,7 +1430,7 @@ mod tests {
     async fn create_simple_database<M>(
         server: &Server<M>,
         name: impl Into<String> + Send,
-    ) -> Result<()>
+    ) -> Result<Arc<Database>>
     where
         M: ConnectionManager + Send + Sync,
     {
@@ -1996,11 +2001,11 @@ mod tests {
         // 3. existing one, but rules file is broken => can be wiped, will not exist afterwards
         // 4. existing one, but catalog is broken => can be wiped, will exist afterwards
         // 5. recently (during server lifecycle) created one => cannot be wiped
-        let db_name_existing = DatabaseName::new("db_existing".to_string()).unwrap();
-        let db_name_non_existing = DatabaseName::new("db_non_existing".to_string()).unwrap();
-        let db_name_rules_broken = DatabaseName::new("db_broken_rules".to_string()).unwrap();
-        let db_name_catalog_broken = DatabaseName::new("db_broken_catalog".to_string()).unwrap();
-        let db_name_created = DatabaseName::new("db_created".to_string()).unwrap();
+        let db_name_existing = DatabaseName::new("db_existing").unwrap();
+        let db_name_non_existing = DatabaseName::new("db_non_existing").unwrap();
+        let db_name_rules_broken = DatabaseName::new("db_broken_rules").unwrap();
+        let db_name_catalog_broken = DatabaseName::new("db_broken_catalog").unwrap();
+        let db_name_created = DatabaseName::new("db_created").unwrap();
 
         // setup
         let application = make_application();
@@ -2012,7 +2017,7 @@ mod tests {
         server.set_id(server_id).unwrap();
         server.wait_for_init().await.unwrap();
 
-        create_simple_database(&server, db_name_existing.clone())
+        let existing = create_simple_database(&server, db_name_existing.clone())
             .await
             .expect("failed to create database");
 
@@ -2020,7 +2025,7 @@ mod tests {
             .await
             .expect("failed to create database");
 
-        create_simple_database(&server, db_name_catalog_broken.clone())
+        let catalog_broken = create_simple_database(&server, db_name_catalog_broken.clone())
             .await
             .expect("failed to create database");
 
@@ -2040,15 +2045,11 @@ mod tests {
             .await
             .unwrap();
 
-        let (preserved_catalog, _catalog) = PreservedCatalog::load::<TestCatalogState>(
-            Arc::clone(&store),
-            server_id,
-            db_name_catalog_broken.to_string(),
-            (),
-        )
-        .await
-        .unwrap()
-        .unwrap();
+        let (preserved_catalog, _catalog) =
+            PreservedCatalog::load::<TestCatalogState>(catalog_broken.iox_object_store(), ())
+                .await
+                .unwrap()
+                .unwrap();
 
         parquet_file::catalog::test_helpers::break_catalog_with_weird_version(&preserved_catalog)
             .await;
@@ -2104,27 +2105,23 @@ mod tests {
                 .to_string(),
             "error wiping preserved catalog: database (db_existing) in invalid state (Initialized) for transition (WipePreservedCatalog)"
         );
-        assert!(PreservedCatalog::exists(
-            application.object_store().as_ref(),
-            server_id,
-            db_name_existing.as_str()
-        )
-        .await
-        .unwrap());
+        assert!(PreservedCatalog::exists(&existing.iox_object_store(),)
+            .await
+            .unwrap());
 
         // 2. cannot wipe non-existent DB
         assert!(matches!(
             server.database(&db_name_non_existing).unwrap_err(),
             Error::DatabaseNotFound { .. }
         ));
-        PreservedCatalog::new_empty::<TestCatalogState>(
+        let non_existing_iox_object_store = Arc::new(IoxObjectStore::new(
             Arc::clone(application.object_store()),
             server_id,
-            db_name_non_existing.to_string(),
-            (),
-        )
-        .await
-        .unwrap();
+            &db_name_non_existing,
+        ));
+        PreservedCatalog::new_empty::<TestCatalogState>(non_existing_iox_object_store, ())
+            .await
+            .unwrap();
         assert_eq!(
             server
                 .wipe_preserved_catalog(&db_name_non_existing)
@@ -2165,13 +2162,9 @@ mod tests {
 
         database.wait_for_init().await.unwrap();
 
-        assert!(PreservedCatalog::exists(
-            application.object_store().as_ref(),
-            server_id,
-            &db_name_catalog_broken.to_string()
-        )
-        .await
-        .unwrap());
+        assert!(PreservedCatalog::exists(&catalog_broken.iox_object_store())
+            .await
+            .unwrap());
         assert!(database.init_error().is_none());
 
         assert!(server.db(&db_name_catalog_broken).is_ok());
@@ -2183,7 +2176,7 @@ mod tests {
             .expect("DB writable");
 
         // 5. cannot wipe if DB was just created
-        server
+        let created = server
             .create_database(DatabaseRules::new(db_name_created.clone()))
             .await
             .unwrap();
@@ -2195,35 +2188,32 @@ mod tests {
                 .to_string(),
             "error wiping preserved catalog: database (db_created) in invalid state (Initialized) for transition (WipePreservedCatalog)"
         );
-        assert!(PreservedCatalog::exists(
-            application.object_store().as_ref(),
-            server_id,
-            &db_name_created.to_string()
-        )
-        .await
-        .unwrap());
+        assert!(PreservedCatalog::exists(&created.iox_object_store())
+            .await
+            .unwrap());
     }
 
     #[tokio::test]
     async fn cannot_create_db_when_catalog_is_present() {
         let application = make_application();
         let server_id = ServerId::try_from(1).unwrap();
-        let db_name = "my_db";
+        let db_name = DatabaseName::new("my_db").unwrap();
 
         // setup server
         let server = make_server(Arc::clone(&application));
         server.set_id(server_id).unwrap();
         server.wait_for_init().await.unwrap();
 
-        // create catalog
-        PreservedCatalog::new_empty::<TestCatalogState>(
+        let iox_object_store = Arc::new(IoxObjectStore::new(
             Arc::clone(application.object_store()),
             server_id,
-            db_name.to_string(),
-            (),
-        )
-        .await
-        .unwrap();
+            &db_name,
+        ));
+
+        // create catalog
+        PreservedCatalog::new_empty::<TestCatalogState>(iox_object_store, ())
+            .await
+            .unwrap();
 
         // creating database will now result in an error
         let err = create_simple_database(&server, db_name).await.unwrap_err();

--- a/server/src/utils.rs
+++ b/server/src/utils.rs
@@ -1,21 +1,19 @@
-use std::{borrow::Cow, convert::TryFrom, num::NonZeroU32, sync::Arc, time::Duration};
-
-use data_types::{
-    chunk_metadata::{ChunkStorage, ChunkSummary},
-    database_rules::{DatabaseRules, PartitionTemplate, TemplatePart},
-    server_id::ServerId,
-    DatabaseName,
-};
-use object_store::ObjectStore;
-use persistence_windows::checkpoint::ReplayPlan;
-use query::{exec::Executor, QueryDatabase};
-use write_buffer::config::WriteBufferConfig;
-
 use crate::{
     db::{load::load_or_create_preserved_catalog, DatabaseToCommit, Db},
     JobRegistry,
 };
-use data_types::database_rules::LifecycleRules;
+use data_types::{
+    chunk_metadata::{ChunkStorage, ChunkSummary},
+    database_rules::{DatabaseRules, LifecycleRules, PartitionTemplate, TemplatePart},
+    server_id::ServerId,
+    DatabaseName,
+};
+use iox_object_store::IoxObjectStore;
+use object_store::ObjectStore;
+use persistence_windows::checkpoint::ReplayPlan;
+use query::{exec::Executor, QueryDatabase};
+use std::{borrow::Cow, convert::TryFrom, num::NonZeroU32, sync::Arc, time::Duration};
+use write_buffer::config::WriteBufferConfig;
 
 // A wrapper around a Db and a metrics registry allowing for isolated testing
 // of a Db and its metrics.
@@ -55,9 +53,12 @@ impl TestDbBuilder {
         let db_name = self
             .db_name
             .unwrap_or_else(|| DatabaseName::new("placeholder").unwrap());
-        let object_store = self
-            .object_store
-            .unwrap_or_else(|| Arc::new(ObjectStore::new_in_memory()));
+        let iox_object_store = Arc::new(IoxObjectStore::new(
+            self.object_store
+                .unwrap_or_else(|| Arc::new(ObjectStore::new_in_memory())),
+            server_id,
+            &db_name,
+        ));
 
         // deterministic thread and concurrency count
         let mut exec = Executor::new(1);
@@ -68,7 +69,7 @@ impl TestDbBuilder {
 
         let (preserved_catalog, catalog, replay_plan) = load_or_create_preserved_catalog(
             db_name.as_str(),
-            Arc::clone(&object_store),
+            Arc::clone(&iox_object_store),
             server_id,
             Arc::clone(&metrics_registry),
             true,
@@ -103,7 +104,7 @@ impl TestDbBuilder {
         let database_to_commit = DatabaseToCommit {
             rules: Arc::new(rules),
             server_id,
-            object_store,
+            iox_object_store,
             preserved_catalog,
             catalog,
             write_buffer: self.write_buffer,


### PR DESCRIPTION
Connects to #2193.

This is not compiling yet, but this is the direction I'm going in. I decided to make a new type for a database (and eventually for a particular database generation) that wraps an object store so that we don't miss anyplace that we need to change the path.

Bonus, this should eliminate a *lot* of current duplication where we're currently passing around an object store, server id, and database name by encapsulating those together!