### PR TITLE
fix: only warn when partition ckpt and DB ckpt mins are out-of-sync

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2730,7 +2730,9 @@ dependencies = [
  "data_types",
  "entry",
  "internal_types",
+ "observability_deps",
  "snafu",
+ "test_helpers",
 ]
 
 [[package]]

--- a/persistence_windows/Cargo.toml
+++ b/persistence_windows/Cargo.toml
@@ -8,4 +8,8 @@ chrono = "0.4"
 data_types = { path = "../data_types" }
 entry = { path = "../entry" }
 internal_types = { path = "../internal_types" }
+observability_deps = { path = "../observability_deps" }
 snafu = "0.6.2"
+
+[dev-dependencies]
+test_helpers = { path = "../test_helpers" }

--- a/persistence_windows/src/checkpoint.rs
+++ b/persistence_windows/src/checkpoint.rs
@@ -656,7 +656,7 @@ impl ReplayPlanner {
                         sequencer_id,
                         database_checkpoint_range=%database_wide_min_max,
                         partition_checkpoint_range=%min_max,
-                        "Last partition checkpoint states that there is unpersisted data, but the final database state deems is persisted. What happened to these sequence numbers?",
+                        "Last partition checkpoint states that there is unpersisted data, but the final database state deems it fully persisted. What happened to these sequence numbers?",
                     );
                 }
 

--- a/persistence_windows/src/checkpoint.rs
+++ b/persistence_windows/src/checkpoint.rs
@@ -265,6 +265,7 @@ use std::{
 };
 
 use chrono::{DateTime, Utc};
+use observability_deps::tracing::warn;
 use snafu::{OptionExt, Snafu};
 
 use crate::min_max_sequence::OptionalMinMaxSequence;
@@ -298,38 +299,6 @@ pub enum Error {
     PartitionCheckpointMaximumAfterDatabase {
         partition_checkpoint_sequence_number: u64,
         database_checkpoint_sequence_number: u64,
-        table_name: Arc<str>,
-        partition_key: Arc<str>,
-        sequencer_id: u32,
-    },
-
-    #[snafu(
-        display(
-            "Minimum sequence number in partition checkpoint ({}) is lower than database-wide number ({}) for partition {}:{} and sequencer {}",
-            partition_checkpoint_sequence_number,
-            database_checkpoint_sequence_number,
-            table_name,
-            partition_key,
-            sequencer_id,
-        )
-    )]
-    PartitionCheckpointMinimumBeforeDatabase {
-        partition_checkpoint_sequence_number: u64,
-        database_checkpoint_sequence_number: u64,
-        table_name: Arc<str>,
-        partition_key: Arc<str>,
-        sequencer_id: u32,
-    },
-
-    #[snafu(
-        display(
-            "Partition checkpoint for partition {}:{} and sequencer {} has non-empty unpersisted range but database checkpoint indicates empty replay range",
-            table_name,
-            partition_key,
-            sequencer_id,
-        )
-    )]
-    PartitionCheckpointEmptyRangeMismatch {
         table_name: Arc<str>,
         partition_key: Arc<str>,
         sequencer_id: u32,
@@ -675,26 +644,20 @@ impl ReplayPlanner {
                     },
                 )?;
 
-                match (min_max.min(), database_wide_min_max.min()) {
-                    (Some(min), Some(db_min)) => {
-                        if min < db_min {
-                            return Err(Error::PartitionCheckpointMinimumBeforeDatabase {
-                                partition_checkpoint_sequence_number: min,
-                                database_checkpoint_sequence_number: db_min,
-                                table_name: Arc::clone(table_name),
-                                partition_key: Arc::clone(partition_key),
-                                sequencer_id: *sequencer_id,
-                            });
-                        }
-                    }
-                    (Some(_min), None) => {
-                        return Err(Error::PartitionCheckpointEmptyRangeMismatch {
-                            table_name: Arc::clone(table_name),
-                            partition_key: Arc::clone(partition_key),
-                            sequencer_id: *sequencer_id,
-                        });
-                    }
-                    _ => {}
+                let sequence_missing = match (min_max.min(), database_wide_min_max.min()) {
+                    (Some(min), Some(db_min)) => min < db_min,
+                    (Some(_min), None) => true,
+                    _ => false,
+                };
+                if sequence_missing {
+                    warn!(
+                        %table_name,
+                        %partition_key,
+                        sequencer_id,
+                        database_checkpoint_range=%database_wide_min_max,
+                        partition_checkpoint_range=%min_max,
+                        "Last partition checkpoint states that there is unpersisted data, but the final database state deems is persisted. What happened to these sequence numbers?",
+                    );
                 }
 
                 if min_max.max() > database_wide_min_max.max() {
@@ -772,6 +735,8 @@ impl ReplayPlan {
 
 #[cfg(test)]
 mod tests {
+    use test_helpers::{assert_contains, tracing::TracingCapture};
+
     use super::*;
 
     /// Create sequence numbers map.
@@ -1089,35 +1054,33 @@ mod tests {
     }
 
     #[test]
-    fn test_replay_planner_fail_empty_range_out_of_sync() {
-        let mut planner = ReplayPlanner::new();
+    fn test_replay_planner_warns_empty_range_out_of_sync() {
+        let tracing_capture = TracingCapture::new();
 
+        let mut planner = ReplayPlanner::new();
         planner.register_checkpoints(
             &part_ckpt!("table_1", "partition_1", {1 => (Some(10), 12)}),
             &db_ckpt!({1 => (None, 20)}),
         );
+        planner.build().unwrap();
 
-        let err = planner.build().unwrap_err();
-        assert!(matches!(
-            err,
-            Error::PartitionCheckpointEmptyRangeMismatch { .. }
-        ));
+        let output = tracing_capture.to_string();
+        assert_contains!(output, "What happened to these sequence numbers?");
     }
 
     #[test]
-    fn test_replay_planner_fail_minima_out_of_sync() {
-        let mut planner = ReplayPlanner::new();
+    fn test_replay_planner_warns_minima_out_of_sync() {
+        let tracing_capture = TracingCapture::new();
 
+        let mut planner = ReplayPlanner::new();
         planner.register_checkpoints(
             &part_ckpt!("table_1", "partition_1", {1 => (Some(10), 12)}),
             &db_ckpt!({1 => (Some(11), 20)}),
         );
+        planner.build().unwrap();
 
-        let err = planner.build().unwrap_err();
-        assert!(matches!(
-            err,
-            Error::PartitionCheckpointMinimumBeforeDatabase { .. }
-        ));
+        let output = tracing_capture.to_string();
+        assert_contains!(output, "What happened to these sequence numbers?");
     }
 
     #[test]

--- a/persistence_windows/src/min_max_sequence.rs
+++ b/persistence_windows/src/min_max_sequence.rs
@@ -67,6 +67,16 @@ impl OptionalMinMaxSequence {
     }
 }
 
+impl std::fmt::Display for OptionalMinMaxSequence {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if let Some(min) = self.min {
+            write!(f, "[{}, {}]", min, self.max)
+        } else {
+            write!(f, "({}, {}]", self.max, self.max)
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -109,5 +119,21 @@ mod tests {
     #[should_panic(expected = "min (11) is greater than max (10) sequence")]
     fn test_opt_min_max_checks_values() {
         OptionalMinMaxSequence::new(Some(11), 10);
+    }
+
+    #[test]
+    fn test_opt_min_max_display() {
+        assert_eq!(
+            OptionalMinMaxSequence::new(Some(10), 20).to_string(),
+            "[10, 20]".to_string()
+        );
+        assert_eq!(
+            OptionalMinMaxSequence::new(Some(20), 20).to_string(),
+            "[20, 20]".to_string()
+        );
+        assert_eq!(
+            OptionalMinMaxSequence::new(None, 20).to_string(),
+            "(20, 20]".to_string()
+        );
     }
 }

--- a/server/src/db/replay.rs
+++ b/server/src/db/replay.rs
@@ -1713,7 +1713,7 @@ mod tests {
                 Step::Ingest(vec![TestSequencedEntry {
                     sequencer_id: 0,
                     sequence_number: 1,
-                    lp: "table_1,tag_partition_by=a bar=10 0",
+                    lp: "table_1,tag_partition_by=a,tag=1 bar=10 10",
                 }]),
                 Step::Await(vec![Check::Query(
                     "select max(bar) as bar from table_1",
@@ -1723,7 +1723,8 @@ mod tests {
                 Step::Ingest(vec![TestSequencedEntry {
                     sequencer_id: 0,
                     sequence_number: 2,
-                    lp: "table_1,tag_partition_by=a bar=20 0",
+                    // same time as first entry
+                    lp: "table_1,tag_partition_by=a,tag=2 bar=20 10",
                 }]),
                 Step::Await(vec![Check::Query(
                     "select max(bar) as bar from table_1",
@@ -1733,7 +1734,7 @@ mod tests {
                 Step::Ingest(vec![TestSequencedEntry {
                     sequencer_id: 0,
                     sequence_number: 3,
-                    lp: "table_1,tag_partition_by=b bar=30 0",
+                    lp: "table_1,tag_partition_by=b,tag=3 bar=30 30",
                 }]),
                 Step::Await(vec![Check::Query(
                     "select max(bar) as bar from table_1",
@@ -1751,12 +1752,13 @@ mod tests {
                     Check::Query(
                         "select * from table_1 order by bar",
                         vec![
-                            "+-----+------------------+----------------------+",
-                            "| bar | tag_partition_by | time                 |",
-                            "+-----+------------------+----------------------+",
-                            "| 20  | a                | 1970-01-01T00:00:00Z |",
-                            "| 30  | b                | 1970-01-01T00:00:00Z |",
-                            "+-----+------------------+----------------------+",
+                            "+-----+-----+------------------+--------------------------------+",
+                            "| bar | tag | tag_partition_by | time                           |",
+                            "+-----+-----+------------------+--------------------------------+",
+                            "| 10  | 1   | a                | 1970-01-01T00:00:00.000000010Z |",
+                            "| 20  | 2   | a                | 1970-01-01T00:00:00.000000010Z |",
+                            "| 30  | 3   | b                | 1970-01-01T00:00:00.000000030Z |",
+                            "+-----+-----+------------------+--------------------------------+",
                         ],
                     ),
                 ]),
@@ -1782,7 +1784,7 @@ mod tests {
                 Step::Ingest(vec![TestSequencedEntry {
                     sequencer_id: 0,
                     sequence_number: 1,
-                    lp: "table_1,tag_partition_by=a bar=10 0",
+                    lp: "table_1,tag_partition_by=a,tag=1 bar=10 10",
                 }]),
                 Step::Await(vec![Check::Query(
                     "select max(bar) as bar from table_1",
@@ -1792,7 +1794,8 @@ mod tests {
                 Step::Ingest(vec![TestSequencedEntry {
                     sequencer_id: 0,
                     sequence_number: 2,
-                    lp: "table_1,tag_partition_by=a bar=20 0",
+                    // same time as first entry
+                    lp: "table_1,tag_partition_by=a,tag=2 bar=20 10",
                 }]),
                 Step::Await(vec![Check::Query(
                     "select max(bar) as bar from table_1",
@@ -1802,7 +1805,7 @@ mod tests {
                 Step::Ingest(vec![TestSequencedEntry {
                     sequencer_id: 0,
                     sequence_number: 3,
-                    lp: "table_1,tag_partition_by=b bar=30 0",
+                    lp: "table_1,tag_partition_by=b,tag=3 bar=30 30",
                 }]),
                 Step::Await(vec![Check::Query(
                     "select max(bar) as bar from table_1",
@@ -1812,7 +1815,7 @@ mod tests {
                 Step::Ingest(vec![TestSequencedEntry {
                     sequencer_id: 0,
                     sequence_number: 4,
-                    lp: "table_1,tag_partition_by=b bar=40 0",
+                    lp: "table_1,tag_partition_by=b,tag=4 bar=40 40",
                 }]),
                 Step::Await(vec![Check::Query(
                     "select max(bar) as bar from table_1",
@@ -1829,12 +1832,14 @@ mod tests {
                     Check::Query(
                         "select * from table_1 order by bar",
                         vec![
-                            "+-----+------------------+----------------------+",
-                            "| bar | tag_partition_by | time                 |",
-                            "+-----+------------------+----------------------+",
-                            "| 20  | a                | 1970-01-01T00:00:00Z |",
-                            "| 40  | b                | 1970-01-01T00:00:00Z |",
-                            "+-----+------------------+----------------------+",
+                            "+-----+-----+------------------+--------------------------------+",
+                            "| bar | tag | tag_partition_by | time                           |",
+                            "+-----+-----+------------------+--------------------------------+",
+                            "| 10  | 1   | a                | 1970-01-01T00:00:00.000000010Z |",
+                            "| 20  | 2   | a                | 1970-01-01T00:00:00.000000010Z |",
+                            "| 30  | 3   | b                | 1970-01-01T00:00:00.000000030Z |",
+                            "| 40  | 4   | b                | 1970-01-01T00:00:00.000000040Z |",
+                            "+-----+-----+------------------+--------------------------------+",
                         ],
                     ),
                 ]),


### PR DESCRIPTION
There are currently a few bugs and semi-understood edge cases that can
lead to this case. So instead of bailing out, just issue a warning.

Closes #2185.
