### PR TITLE
fix: always remember max seen sequ. numbers during replay

### DIFF
--- a/server/src/utils.rs
+++ b/server/src/utils.rs
@@ -71,7 +71,7 @@ impl TestDbBuilder {
             Arc::clone(&object_store),
             server_id,
             Arc::clone(&metrics_registry),
-            true,
+            false,
             false,
         )
         .await


### PR DESCRIPTION
Do not forget max seen sequence numbers for partition-sequencer
combinations that can be skipped during replay.

Fixes #2215.
