### PR TITLE
fix: incorrect speculation of post-persist sequence ranges

### DIFF
--- a/persistence_windows/src/persistence_windows.rs
+++ b/persistence_windows/src/persistence_windows.rs
@@ -411,6 +411,7 @@ impl PersistenceWindows {
     }
 }
 
+/// Get new minimum row time that will be left unpersisted after the given persistable window has been persisted.
 fn new_min_time_from_persistable(persistable: &Window) -> DateTime<Utc> {
     persistable.max_time + chrono::Duration::nanoseconds(1)
 }

--- a/server/src/db/catalog/partition.rs
+++ b/server/src/db/catalog/partition.rs
@@ -310,7 +310,7 @@ impl Partition {
     pub fn sequencer_numbers(&self) -> Option<BTreeMap<u32, OptionalMinMaxSequence>> {
         self.persistence_windows
             .as_ref()
-            .map(|persistence_windows| persistence_windows.sequencer_numbers(false))
+            .map(|persistence_windows| persistence_windows.sequencer_numbers())
     }
 }
 

--- a/server/src/db/replay.rs
+++ b/server/src/db/replay.rs
@@ -1791,8 +1791,6 @@ mod tests {
     #[tokio::test]
     async fn replay_works_partially_persisted_1() {
         // regression test for https://github.com/influxdata/influxdb_iox/issues/2185
-        let tracing_capture = TracingCapture::new();
-
         ReplayTest {
             steps: vec![
                 Step::Ingest(vec![TestSequencedEntry {
@@ -1852,18 +1850,11 @@ mod tests {
         }
         .run()
         .await;
-
-        assert_contains!(
-            tracing_capture.to_string(),
-            "What happened to these sequence numbers?"
-        );
     }
 
     #[tokio::test]
     async fn replay_works_partially_persisted_2() {
         // regression test for https://github.com/influxdata/influxdb_iox/issues/2185
-        let tracing_capture = TracingCapture::new();
-
         ReplayTest {
             steps: vec![
                 Step::Ingest(vec![TestSequencedEntry {
@@ -1933,11 +1924,6 @@ mod tests {
         }
         .run()
         .await;
-
-        assert_contains!(
-            tracing_capture.to_string(),
-            "What happened to these sequence numbers?"
-        );
     }
 
     #[tokio::test]

--- a/server/src/db/replay.rs
+++ b/server/src/db/replay.rs
@@ -361,7 +361,7 @@ mod tests {
         min_max_sequence::OptionalMinMaxSequence,
     };
     use query::{exec::ExecutorType, frontend::sql::SqlQueryPlanner};
-    use test_helpers::{assert_contains, tracing::TracingCapture};
+    use test_helpers::{assert_contains, assert_not_contains, tracing::TracingCapture};
     use tokio::task::JoinHandle;
     use tokio_util::sync::CancellationToken;
     use write_buffer::{
@@ -1791,6 +1791,8 @@ mod tests {
     #[tokio::test]
     async fn replay_works_partially_persisted_1() {
         // regression test for https://github.com/influxdata/influxdb_iox/issues/2185
+        let tracing_capture = TracingCapture::new();
+
         ReplayTest {
             steps: vec![
                 Step::Ingest(vec![TestSequencedEntry {
@@ -1850,11 +1852,18 @@ mod tests {
         }
         .run()
         .await;
+
+        assert_not_contains!(
+            tracing_capture.to_string(),
+            "What happened to these sequence numbers?"
+        );
     }
 
     #[tokio::test]
     async fn replay_works_partially_persisted_2() {
         // regression test for https://github.com/influxdata/influxdb_iox/issues/2185
+        let tracing_capture = TracingCapture::new();
+
         ReplayTest {
             steps: vec![
                 Step::Ingest(vec![TestSequencedEntry {
@@ -1924,6 +1933,11 @@ mod tests {
         }
         .run()
         .await;
+
+        assert_not_contains!(
+            tracing_capture.to_string(),
+            "What happened to these sequence numbers?"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
This fixes an edge case where the speculated sequence ranges that can be
obtained from flush handles do not account for overlapping windows. The
symptom being that the resulting partition checkpoint marked sequence
numbers as unpersisted that where already persisted.

Fixes #2206.
