### PR TITLE
fix: Remove some unneeded lifetimes

### DIFF
--- a/object_store/src/aws.rs
+++ b/object_store/src/aws.rs
@@ -218,10 +218,10 @@ impl ObjectStoreApi for AmazonS3 {
         Ok(())
     }
 
-    async fn list<'a>(
-        &'a self,
-        prefix: Option<&'a Self::Path>,
-    ) -> Result<BoxStream<'a, Result<Vec<Self::Path>>>> {
+    async fn list(
+        &self,
+        prefix: Option<&Self::Path>,
+    ) -> Result<BoxStream<'static, Result<Vec<Self::Path>>>> {
         #[derive(Clone)]
         enum ListState {
             Start,

--- a/object_store/src/azure.rs
+++ b/object_store/src/azure.rs
@@ -137,10 +137,10 @@ impl ObjectStoreApi for MicrosoftAzure {
         Ok(())
     }
 
-    async fn list<'a>(
-        &'a self,
-        prefix: Option<&'a Self::Path>,
-    ) -> Result<BoxStream<'a, Result<Vec<Self::Path>>>> {
+    async fn list(
+        &self,
+        prefix: Option<&Self::Path>,
+    ) -> Result<BoxStream<'static, Result<Vec<Self::Path>>>> {
         #[derive(Clone)]
         enum ListState {
             Start,

--- a/object_store/src/dummy.rs
+++ b/object_store/src/dummy.rs
@@ -68,11 +68,11 @@ impl ObjectStoreApi for DummyObjectStore {
         NotSupported { name: &self.name }.fail()
     }
 
-    async fn list<'a>(
-        &'a self,
-        _prefix: Option<&'a Self::Path>,
+    async fn list(
+        &self,
+        _prefix: Option<&Self::Path>,
     ) -> crate::Result<
-        futures::stream::BoxStream<'a, crate::Result<Vec<Self::Path>, Self::Error>>,
+        futures::stream::BoxStream<'static, crate::Result<Vec<Self::Path>, Self::Error>>,
         Self::Error,
     > {
         NotSupported { name: &self.name }.fail()

--- a/object_store/src/gcp.rs
+++ b/object_store/src/gcp.rs
@@ -163,10 +163,10 @@ impl ObjectStoreApi for GoogleCloudStorage {
         Ok(())
     }
 
-    async fn list<'a>(
-        &'a self,
-        prefix: Option<&'a Self::Path>,
-    ) -> Result<BoxStream<'a, Result<Vec<Self::Path>>>> {
+    async fn list(
+        &self,
+        prefix: Option<&Self::Path>,
+    ) -> Result<BoxStream<'static, Result<Vec<Self::Path>>>> {
         let converted_prefix = prefix.map(|p| p.to_raw());
         let list_request = cloud_storage::ListRequest {
             prefix: converted_prefix,

--- a/object_store/src/lib.rs
+++ b/object_store/src/lib.rs
@@ -92,10 +92,10 @@ pub trait ObjectStoreApi: Send + Sync + 'static {
     async fn delete(&self, location: &Self::Path) -> Result<(), Self::Error>;
 
     /// List all the objects with the given prefix.
-    async fn list<'a>(
-        &'a self,
-        prefix: Option<&'a Self::Path>,
-    ) -> Result<BoxStream<'a, Result<Vec<Self::Path>, Self::Error>>, Self::Error>;
+    async fn list(
+        &self,
+        prefix: Option<&Self::Path>,
+    ) -> Result<BoxStream<'static, Result<Vec<Self::Path>, Self::Error>>, Self::Error>;
 
     /// List objects with the given prefix and an implementation specific
     /// delimiter. Returns common prefixes (directories) in addition to object
@@ -320,10 +320,10 @@ impl ObjectStoreApi for ObjectStore {
         Ok(())
     }
 
-    async fn list<'a>(
-        &'a self,
-        prefix: Option<&'a Self::Path>,
-    ) -> Result<BoxStream<'a, Result<Vec<Self::Path>>>> {
+    async fn list(
+        &self,
+        prefix: Option<&Self::Path>,
+    ) -> Result<BoxStream<'static, Result<Vec<Self::Path>>>> {
         use ObjectStoreIntegration::*;
         Ok(match (&self.integration, prefix) {
             (AmazonS3(s3), Some(path::Path::AmazonS3(prefix))) => s3

--- a/object_store/src/memory.rs
+++ b/object_store/src/memory.rs
@@ -93,10 +93,10 @@ impl ObjectStoreApi for InMemory {
         Ok(())
     }
 
-    async fn list<'a>(
-        &'a self,
-        prefix: Option<&'a Self::Path>,
-    ) -> Result<BoxStream<'a, Result<Vec<Self::Path>>>> {
+    async fn list(
+        &self,
+        prefix: Option<&Self::Path>,
+    ) -> Result<BoxStream<'static, Result<Vec<Self::Path>>>> {
         let list = if let Some(prefix) = &prefix {
             self.storage
                 .read()

--- a/object_store/src/throttle.rs
+++ b/object_store/src/throttle.rs
@@ -184,10 +184,10 @@ impl<T: ObjectStoreApi> ObjectStoreApi for ThrottledStore<T> {
         self.inner.delete(location).await
     }
 
-    async fn list<'a>(
-        &'a self,
-        prefix: Option<&'a Self::Path>,
-    ) -> Result<BoxStream<'a, Result<Vec<Self::Path>, Self::Error>>, Self::Error> {
+    async fn list(
+        &self,
+        prefix: Option<&Self::Path>,
+    ) -> Result<BoxStream<'static, Result<Vec<Self::Path>, Self::Error>>, Self::Error> {
         sleep(self.config.wait_list_per_call).await;
 
         // need to copy to avoid moving / referencing `self`


### PR DESCRIPTION
I can't remember why I added these, but with just a few little clones in
the disk-based object store, this works great!

This is interfering with the object store wrapper for relative paths I'm working on.