### PR TITLE
feat: manual skip replay, part 1/2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5097,6 +5097,7 @@ dependencies = [
  "entry",
  "futures",
  "observability_deps",
+ "once_cell",
  "parking_lot",
  "rdkafka",
  "tokio",

--- a/data_types/src/job.rs
+++ b/data_types/src/job.rs
@@ -39,6 +39,9 @@ pub enum Job {
 
     /// Wipe preserved catalog
     WipePreservedCatalog { db_name: Arc<str> },
+
+    /// Skip replay
+    SkipReplay { db_name: Arc<str> },
 }
 
 impl Job {
@@ -52,6 +55,7 @@ impl Job {
             Self::PersistChunks { partition, .. } => Some(&partition.db_name),
             Self::DropChunk { chunk, .. } => Some(&chunk.db_name),
             Self::WipePreservedCatalog { db_name, .. } => Some(db_name),
+            Self::SkipReplay { db_name, .. } => Some(db_name),
         }
     }
 
@@ -65,6 +69,7 @@ impl Job {
             Self::PersistChunks { partition, .. } => Some(&partition.partition_key),
             Self::DropChunk { chunk, .. } => Some(&chunk.partition_key),
             Self::WipePreservedCatalog { .. } => None,
+            Self::SkipReplay { .. } => None,
         }
     }
 
@@ -78,6 +83,7 @@ impl Job {
             Self::PersistChunks { partition, .. } => Some(&partition.table_name),
             Self::DropChunk { chunk, .. } => Some(&chunk.table_name),
             Self::WipePreservedCatalog { .. } => None,
+            Self::SkipReplay { .. } => None,
         }
     }
 
@@ -91,6 +97,7 @@ impl Job {
             Self::PersistChunks { chunks, .. } => Some(chunks.clone()),
             Self::DropChunk { chunk, .. } => Some(vec![chunk.chunk_id]),
             Self::WipePreservedCatalog { .. } => None,
+            Self::SkipReplay { .. } => None,
         }
     }
 
@@ -104,6 +111,7 @@ impl Job {
             Self::PersistChunks { .. } => "Persisting chunks to object storage",
             Self::DropChunk { .. } => "Drop chunk from memory and (if persisted) from object store",
             Self::WipePreservedCatalog { .. } => "Wipe preserved catalog",
+            Self::SkipReplay { .. } => "Skip replay",
         }
     }
 }

--- a/generated_types/protos/influxdata/iox/management/v1/jobs.proto
+++ b/generated_types/protos/influxdata/iox/management/v1/jobs.proto
@@ -39,6 +39,7 @@ message OperationMetadata {
     CompactChunks compact_chunks = 10;
     PersistChunks persist_chunks = 11;
     DropChunk drop_chunk = 12;
+    SkipReplay skip_replay = 17;
   }
 }
 
@@ -128,6 +129,12 @@ message DropChunk {
 
 // Wipe preserved catalog
 message WipePreservedCatalog {
+  // name of the database
+  string db_name = 1;
+}
+
+// Skip replay
+message SkipReplay {
   // name of the database
   string db_name = 1;
 }

--- a/generated_types/src/job.rs
+++ b/generated_types/src/job.rs
@@ -31,6 +31,9 @@ impl From<Job> for management::operation_metadata::Job {
                     db_name: db_name.to_string(),
                 })
             }
+            Job::SkipReplay { db_name } => Self::SkipReplay(management::SkipReplay {
+                db_name: db_name.to_string(),
+            }),
             Job::CompactChunks { partition, chunks } => {
                 Self::CompactChunks(management::CompactChunks {
                     db_name: partition.db_name.to_string(),
@@ -96,6 +99,9 @@ impl From<management::operation_metadata::Job> for Job {
                     db_name: Arc::from(db_name.as_str()),
                 }
             }
+            Job::SkipReplay(management::SkipReplay { db_name }) => Self::SkipReplay {
+                db_name: Arc::from(db_name.as_str()),
+            },
             Job::CompactChunks(management::CompactChunks {
                 db_name,
                 partition_key,

--- a/write_buffer/Cargo.toml
+++ b/write_buffer/Cargo.toml
@@ -10,10 +10,11 @@ data_types = { path = "../data_types" }
 entry = { path = "../entry" }
 futures = "0.3"
 observability_deps = { path = "../observability_deps" }
+once_cell = { version = "1.4.0", features = ["parking_lot"] }
 parking_lot = "0.11.1"
 rdkafka = "0.26.0"
 tokio = { version = "1.0", features = ["macros", "fs"] }
+uuid = { version = "0.8", features = ["serde", "v4"] }
 
 [dev-dependencies]
 dotenv = "0.15.0"
-uuid = { version = "0.8", features = ["serde", "v4"] }

--- a/write_buffer/src/config.rs
+++ b/write_buffer/src/config.rs
@@ -4,11 +4,15 @@ use data_types::{
     database_rules::{DatabaseRules, WriteBufferConnection},
     server_id::ServerId,
 };
+use uuid::Uuid;
 
 use crate::{
     core::{WriteBufferError, WriteBufferReading, WriteBufferWriting},
     kafka::{KafkaBufferConsumer, KafkaBufferProducer},
+    mock::{MockBufferForReading, MockBufferForWriting, MockBufferSharedState},
 };
+
+const PREFIX_MOCK: &str = "mock://";
 
 #[derive(Debug)]
 pub enum WriteBufferConfig {
@@ -23,24 +27,150 @@ impl WriteBufferConfig {
     ) -> Result<Option<Self>, WriteBufferError> {
         let name = rules.db_name();
 
-        // Right now, the Kafka producer and consumers ar the only production implementations of the
-        // `WriteBufferWriting` and `WriteBufferReading` traits. If/when there are other kinds of
-        // write buffers, additional configuration will be needed to determine what kind of write
-        // buffer to use here.
         match rules.write_buffer_connection.as_ref() {
             Some(WriteBufferConnection::Writing(conn)) => {
-                let kafka_buffer = KafkaBufferProducer::new(conn, name)?;
+                if let Some(conn) = conn.strip_prefix(PREFIX_MOCK) {
+                    let id = Uuid::parse_str(conn)?;
+                    let mock_state = MockBufferSharedState::get(id)
+                        .ok_or_else::<WriteBufferError, _>(|| {
+                            format!("Unknown mock ID: {}", id).into()
+                        })?;
+                    let mock_buffer = MockBufferForWriting::new(mock_state);
 
-                Ok(Some(Self::Writing(Arc::new(kafka_buffer) as _)))
+                    Ok(Some(Self::Writing(Arc::new(mock_buffer) as _)))
+                } else {
+                    let kafka_buffer = KafkaBufferProducer::new(conn, name)?;
+
+                    Ok(Some(Self::Writing(Arc::new(kafka_buffer) as _)))
+                }
             }
             Some(WriteBufferConnection::Reading(conn)) => {
-                let kafka_buffer = KafkaBufferConsumer::new(conn, server_id, name).await?;
+                if let Some(conn) = conn.strip_prefix(PREFIX_MOCK) {
+                    let id = Uuid::parse_str(conn)?;
+                    let mock_state = MockBufferSharedState::get(id)
+                        .ok_or_else::<WriteBufferError, _>(|| {
+                            format!("Unknown mock ID: {}", id).into()
+                        })?;
+                    let mock_buffer = MockBufferForReading::new(mock_state);
 
-                Ok(Some(Self::Reading(Arc::new(tokio::sync::Mutex::new(
-                    Box::new(kafka_buffer) as _,
-                )))))
+                    Ok(Some(Self::Reading(Arc::new(tokio::sync::Mutex::new(
+                        Box::new(mock_buffer) as _,
+                    )))))
+                } else {
+                    let kafka_buffer = KafkaBufferConsumer::new(conn, server_id, name).await?;
+
+                    Ok(Some(Self::Reading(Arc::new(tokio::sync::Mutex::new(
+                        Box::new(kafka_buffer) as _,
+                    )))))
+                }
             }
             None => Ok(None),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::convert::TryFrom;
+
+    use data_types::DatabaseName;
+
+    use crate::mock::MockBufferSharedState;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_none() {
+        let server_id = ServerId::try_from(1).unwrap();
+        let mut rules = DatabaseRules::new(DatabaseName::new("foo").unwrap());
+        rules.write_buffer_connection = None;
+        assert!(WriteBufferConfig::new(server_id, &rules)
+            .await
+            .unwrap()
+            .is_none());
+    }
+
+    #[tokio::test]
+    async fn test_writing_kafka() {
+        let server_id = ServerId::try_from(1).unwrap();
+        let mut rules = DatabaseRules::new(DatabaseName::new("foo").unwrap());
+        rules.write_buffer_connection =
+            Some(WriteBufferConnection::Writing("127.0.0.1:2".to_string()));
+        if let WriteBufferConfig::Writing(conn) = WriteBufferConfig::new(server_id, &rules)
+            .await
+            .unwrap()
+            .unwrap()
+        {
+            assert_eq!(conn.type_name(), "kafka");
+        } else {
+            panic!("not a writing connection");
+        }
+    }
+
+    //  blocks until https://github.com/influxdata/influxdb_iox/issues/2189 is solved
+    // #[tokio::test]
+    // async fn test_reading_kafka() {
+    //     let server_id = ServerId::try_from(1).unwrap();
+    //     let mut rules = DatabaseRules::new(DatabaseName::new("foo").unwrap());
+    //     rules.write_buffer_connection = Some(WriteBufferConnection::Reading("test".to_string()));
+    //     if let WriteBufferConfig::Reading(conn) = WriteBufferConfig::new(server_id, &rules).await.unwrap().unwrap() {
+    //         let conn = conn.lock().await;
+    //         assert_eq!(conn.type_name(), "kafka");
+    //     } else {
+    //         panic!("not a reading connection");
+    //     }
+    // }
+
+    #[tokio::test]
+    async fn test_writing_mock() {
+        let state = MockBufferSharedState::empty_with_n_sequencers(1);
+
+        let server_id = ServerId::try_from(1).unwrap();
+        let mut rules = DatabaseRules::new(DatabaseName::new("foo").unwrap());
+        rules.write_buffer_connection = Some(WriteBufferConnection::Writing(format!(
+            "mock://{}",
+            state.id()
+        )));
+        if let WriteBufferConfig::Writing(conn) = WriteBufferConfig::new(server_id, &rules)
+            .await
+            .unwrap()
+            .unwrap()
+        {
+            assert_eq!(conn.type_name(), "mock");
+        } else {
+            panic!("not a writing connection");
+        }
+
+        // will error when state is unknown
+        drop(state);
+        let err = WriteBufferConfig::new(server_id, &rules).await.unwrap_err();
+        assert!(err.to_string().starts_with("Unknown mock ID:"));
+    }
+
+    #[tokio::test]
+    async fn test_reading_mock() {
+        let state = MockBufferSharedState::empty_with_n_sequencers(1);
+
+        let server_id = ServerId::try_from(1).unwrap();
+        let mut rules = DatabaseRules::new(DatabaseName::new("foo").unwrap());
+        rules.write_buffer_connection = Some(WriteBufferConnection::Reading(format!(
+            "mock://{}",
+            state.id()
+        )));
+        if let WriteBufferConfig::Reading(conn) = WriteBufferConfig::new(server_id, &rules)
+            .await
+            .unwrap()
+            .unwrap()
+        {
+            let conn = conn.lock().await;
+            assert_eq!(conn.type_name(), "mock");
+        } else {
+            panic!("not a reading connection");
+        }
+
+        // will error when state is unknown
+        drop(state);
+        let err = WriteBufferConfig::new(server_id, &rules).await.unwrap_err();
+        assert!(err.to_string().starts_with("Unknown mock ID:"));
     }
 }

--- a/write_buffer/src/core.rs
+++ b/write_buffer/src/core.rs
@@ -22,6 +22,9 @@ pub trait WriteBufferWriting: Sync + Send + Debug + 'static {
         entry: &Entry,
         sequencer_id: u32,
     ) -> Result<(Sequence, DateTime<Utc>), WriteBufferError>;
+
+    /// Return type (like `"mock"` or `"kafka"`) of this writer.
+    fn type_name(&self) -> &'static str;
 }
 
 pub type FetchHighWatermarkFut<'a> = BoxFuture<'a, Result<u64, WriteBufferError>>;
@@ -65,6 +68,9 @@ pub trait WriteBufferReading: Sync + Send + Debug + 'static {
         sequencer_id: u32,
         sequence_number: u64,
     ) -> Result<(), WriteBufferError>;
+
+    /// Return type (like `"mock"` or `"kafka"`) of this reader.
+    fn type_name(&self) -> &'static str;
 }
 
 pub mod test_utils {

--- a/write_buffer/src/kafka.rs
+++ b/write_buffer/src/kafka.rs
@@ -80,6 +80,10 @@ impl WriteBufferWriting for KafkaBufferProducer {
             timestamp,
         ))
     }
+
+    fn type_name(&self) -> &'static str {
+        "kafka"
+    }
 }
 
 impl KafkaBufferProducer {
@@ -229,6 +233,10 @@ impl WriteBufferReading for KafkaBufferConsumer {
         }
 
         Ok(())
+    }
+
+    fn type_name(&self) -> &'static str {
+        "kafka"
     }
 }
 


### PR DESCRIPTION
I want to be able to manually get databases out of a failed replay (e.g. when Kafka already deleted data that we would need for replay). The easiest thing would be to manually trigger "skip replay" in the same way we do that via a env flag at the moment (`INFLUXDB_IOX_SKIP_REPLAY`).

This PR implements the Rust-API-level part of it (`Server::skip_replay`, similar to `Server::wipe_preserved_catalog`). A follow-up PR will do the gRPC and CLI wiring including an end2end test.

This very PR here turned out to be a bit larger because the mocking that is required to test this. Namely we must be able to have some in-memory mocked write buffer that survives server restarts. Since the write buffer is not passed directly (in contrast to the object store) but only as a connection string, some (not too messy) config handling is required for that.
