### PR TITLE
feat: Crate that wraps object store for a particular database

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1799,6 +1799,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "iox_object_store"
+version = "0.1.0"
+dependencies = [
+ "bytes",
+ "data_types",
+ "futures",
+ "object_store",
+ "tokio",
+ "tokio-stream",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2675,6 +2687,7 @@ dependencies = [
  "futures",
  "generated_types",
  "internal_types",
+ "iox_object_store",
  "metrics",
  "object_store",
  "observability_deps",
@@ -3879,6 +3892,7 @@ dependencies = [
  "influxdb_iox_client",
  "influxdb_line_protocol",
  "internal_types",
+ "iox_object_store",
  "itertools 0.10.1",
  "lifecycle",
  "metrics",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ members = [
     "influxdb_line_protocol",
     "influxdb_tsm",
     "internal_types",
+    "iox_object_store",
     "logfmt",
     "lifecycle",
     "mem_qe",

--- a/iox_object_store/Cargo.toml
+++ b/iox_object_store/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "iox_object_store"
+version = "0.1.0"
+edition = "2018"
+description = "IOx-specific semantics wrapping the general-purpose object store crate"
+
+[dependencies]
+bytes = "1.0"
+data_types = { path = "../data_types" }
+futures = "0.3"
+object_store = { path = "../object_store" }
+tokio = { version = "1.0", features = ["macros", "time"] }
+tokio-stream = "0.1"

--- a/iox_object_store/src/lib.rs
+++ b/iox_object_store/src/lib.rs
@@ -1,0 +1,198 @@
+#![deny(broken_intra_doc_links, rustdoc::bare_urls, rust_2018_idioms)]
+#![warn(
+    missing_copy_implementations,
+    missing_debug_implementations,
+    missing_docs,
+    clippy::explicit_iter_loop,
+    clippy::future_not_send,
+    clippy::use_self,
+    clippy::clone_on_ref_ptr
+)]
+
+//! Wraps the object_store crate with IOx-specific semantics.
+
+// TODO: Create an IoxPath type and only take/return paths of those types, and wrap in the
+// database's root path before sending to the underlying object_store.
+
+use bytes::Bytes;
+use data_types::{server_id::ServerId, DatabaseName};
+use futures::{stream::BoxStream, Stream, StreamExt};
+use object_store::{
+    path::{parsed::DirsAndFileName, ObjectStorePath, Path},
+    ObjectStore, ObjectStoreApi, Result,
+};
+use std::{io, sync::Arc};
+use tokio::sync::mpsc::channel;
+use tokio_stream::wrappers::ReceiverStream;
+
+/// Handles persistence of data for a particular database. Writes within its directory/prefix.
+#[derive(Debug)]
+pub struct IoxObjectStore {
+    store: Arc<ObjectStore>,
+    server_id: ServerId,
+    database_name: String, // TODO: use data_types DatabaseName?
+    root_path: RootPath,
+}
+
+impl IoxObjectStore {
+    /// Create a database-specific wrapper. Takes all the information needed to create the
+    /// root directory of a database.
+    pub fn new(
+        store: Arc<ObjectStore>,
+        server_id: ServerId,
+        database_name: &DatabaseName<'_>,
+    ) -> Self {
+        let root_path = RootPath::new(store.new_path(), server_id, database_name);
+        Self {
+            store,
+            server_id,
+            database_name: database_name.into(),
+            root_path,
+        }
+    }
+
+    /// The name of the database this object store is for.
+    pub fn database_name(&self) -> &str {
+        &self.database_name
+    }
+
+    /// Path where transactions are stored.
+    ///
+    /// The format is:
+    ///
+    /// ```text
+    /// <server_id>/<db_name>/transactions/
+    /// ```
+    // TODO: avoid leaking this outside this crate
+    pub fn catalog_path(&self) -> Path {
+        let mut path = self.store.new_path();
+        path.push_dir(self.server_id.to_string());
+        path.push_dir(&self.database_name);
+        path.push_dir("transactions");
+        path
+    }
+
+    /// Location where parquet data goes to.
+    ///
+    /// Schema currently is:
+    ///
+    /// ```text
+    /// <server_id>/<db_name>/data/
+    /// ```
+    // TODO: avoid leaking this outside this crate
+    pub fn data_path(&self) -> Path {
+        let mut path = self.store.new_path();
+        path.push_dir(self.server_id.to_string());
+        path.push_dir(&self.database_name);
+        path.push_dir("data");
+        path
+    }
+
+    /// Store this data in this database's object store.
+    pub async fn put<S>(&self, location: &Path, bytes: S, length: Option<usize>) -> Result<()>
+    where
+        S: Stream<Item = io::Result<Bytes>> + Send + Sync + 'static,
+    {
+        self.store.put(location, bytes, length).await
+    }
+
+    /// List all the catalog transaction files in object storage for this database.
+    pub async fn catalog_transaction_files(&self) -> Result<BoxStream<'static, Result<Vec<Path>>>> {
+        Ok(self.list(Some(&self.catalog_path())).await?.boxed())
+    }
+
+    /// List the relative paths in this database's object store.
+    pub async fn list(
+        &self,
+        prefix: Option<&Path>,
+    ) -> Result<BoxStream<'static, Result<Vec<Path>>>> {
+        let (tx, rx) = channel(4);
+        let store = Arc::clone(&self.store);
+        let prefix = prefix.cloned();
+
+        // This is necessary because of the lifetime restrictions on the ObjectStoreApi trait's
+        // methods, which might not actually be necessary but fixing it involves changes to the
+        // cloud_storage crate that are longer term.
+        tokio::spawn(async move {
+            match store.list(prefix.as_ref()).await {
+                Err(e) => {
+                    tx.send(Err(e)).await.expect("sending over channel failed");
+                }
+                Ok(mut stream) => {
+                    while let Some(list) = stream.next().await {
+                        tx.send(list).await.expect("sending over channel failed");
+                    }
+                }
+            }
+        });
+
+        Ok(ReceiverStream::new(rx).boxed())
+    }
+
+    /// Get the data in this relative path in this database's object store.
+    pub async fn get(&self, location: &Path) -> Result<BoxStream<'static, Result<Bytes>>> {
+        self.store.get(location).await
+    }
+
+    /// Delete the relative paths in this database's object store.
+    pub async fn delete(&self, location: &Path) -> Result<()> {
+        self.store.delete(location).await
+    }
+
+    /// Create implementation-specific path from parsed representation.
+    /// This might not be needed eventually
+    pub fn path_from_dirs_and_filename(&self, path: DirsAndFileName) -> Path {
+        self.store.path_from_dirs_and_filename(path)
+    }
+}
+
+/// A database-specific object store path that all `IoxPath`s should be within.
+#[derive(Debug, Clone)]
+struct RootPath {
+    root: Path,
+}
+
+impl RootPath {
+    /// How the root of a database is defined in object storage.
+    fn new(mut root: Path, server_id: ServerId, database_name: &DatabaseName<'_>) -> Self {
+        root.push_dir(server_id.to_string());
+        root.push_dir(database_name.as_str());
+        Self { root }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::num::NonZeroU32;
+
+    /// Creates new test server ID
+    fn make_server_id() -> ServerId {
+        ServerId::new(NonZeroU32::new(1).unwrap())
+    }
+
+    /// Creates a new in-memory object store. These tests rely on the `Path`s being of type
+    /// `DirsAndFileName` and thus using object_store::path::DELIMITER as the separator
+    fn make_object_store() -> Arc<ObjectStore> {
+        Arc::new(ObjectStore::new_in_memory())
+    }
+
+    #[test]
+    fn catalog_path_is_relative_to_db_root() {
+        let server_id = make_server_id();
+        let database_name = DatabaseName::new("clouds").unwrap();
+        let iox_object_store = IoxObjectStore::new(make_object_store(), server_id, &database_name);
+        assert_eq!(
+            iox_object_store.catalog_path().display(),
+            "1/clouds/transactions/"
+        );
+    }
+
+    #[test]
+    fn data_path_is_relative_to_db_root() {
+        let server_id = make_server_id();
+        let database_name = DatabaseName::new("clouds").unwrap();
+        let iox_object_store = IoxObjectStore::new(make_object_store(), server_id, &database_name);
+        assert_eq!(iox_object_store.data_path().display(), "1/clouds/data/");
+    }
+}

--- a/iox_object_store/src/lib.rs
+++ b/iox_object_store/src/lib.rs
@@ -26,6 +26,8 @@ use tokio::sync::mpsc::channel;
 use tokio_stream::wrappers::ReceiverStream;
 
 /// Handles persistence of data for a particular database. Writes within its directory/prefix.
+///
+/// This wrapper on top of an `ObjectStore` maps IOx specific concepts to ObjectStore locations
 #[derive(Debug)]
 pub struct IoxObjectStore {
     store: Arc<ObjectStore>,

--- a/iox_object_store/src/lib.rs
+++ b/iox_object_store/src/lib.rs
@@ -118,11 +118,11 @@ impl IoxObjectStore {
         tokio::spawn(async move {
             match inner.list(prefix.as_ref()).await {
                 Err(e) => {
-                    tx.send(Err(e)).await.expect("sending over channel failed");
+                    let _ = tx.send(Err(e)).await;
                 }
                 Ok(mut stream) => {
                     while let Some(list) = stream.next().await {
-                        tx.send(list).await.expect("sending over channel failed");
+                        let _ = tx.send(list).await;
                     }
                 }
             }

--- a/object_store/src/path/parsed.rs
+++ b/object_store/src/path/parsed.rs
@@ -130,7 +130,7 @@ impl DirsAndFileName {
     }
 
     /// Add a `PathPart` to the end of the path's directories.
-    pub(crate) fn push_part_as_dir(&mut self, part: &PathPart) {
+    pub fn push_part_as_dir(&mut self, part: &PathPart) {
         self.directories.push(part.to_owned());
     }
 

--- a/parquet_file/Cargo.toml
+++ b/parquet_file/Cargo.toml
@@ -14,9 +14,10 @@ datafusion = { path = "../datafusion" }
 datafusion_util = { path = "../datafusion_util" }
 futures = "0.3.7"
 generated_types = { path = "../generated_types" }
-internal_types = {path = "../internal_types"}
+internal_types = { path = "../internal_types" }
+iox_object_store = { path = "../iox_object_store" }
 metrics = { path = "../metrics" }
-object_store = {path = "../object_store"}
+object_store = { path = "../object_store" }
 observability_deps = { path = "../observability_deps" }
 parquet = "5.0"
 parquet-format = "2.6"

--- a/parquet_file/src/catalog.rs
+++ b/parquet_file/src/catalog.rs
@@ -1,16 +1,4 @@
 //! Catalog preservation and transaction handling.
-use std::{
-    collections::{
-        hash_map::Entry::{Occupied, Vacant},
-        HashMap,
-    },
-    convert::TryInto,
-    fmt::{Debug, Display},
-    num::TryFromIntError,
-    str::FromStr,
-    sync::Arc,
-};
-
 use crate::metadata::IoxParquetMetaData;
 use bytes::Bytes;
 use chrono::{DateTime, Utc};
@@ -25,6 +13,17 @@ use observability_deps::tracing::{info, warn};
 use parking_lot::RwLock;
 use prost::{DecodeError, EncodeError, Message};
 use snafu::{OptionExt, ResultExt, Snafu};
+use std::{
+    collections::{
+        hash_map::Entry::{Occupied, Vacant},
+        HashMap,
+    },
+    convert::TryInto,
+    fmt::{Debug, Display},
+    num::TryFromIntError,
+    str::FromStr,
+    sync::Arc,
+};
 use tokio::sync::{Semaphore, SemaphorePermit};
 use uuid::Uuid;
 
@@ -1563,13 +1562,14 @@ pub mod test_helpers {
 
 #[cfg(test)]
 mod tests {
+    use super::{
+        test_helpers::{
+            assert_catalog_state_implementation, break_catalog_with_weird_version, TestCatalogState,
+        },
+        *,
+    };
     use crate::test_utils::{chunk_addr, make_iox_object_store, make_metadata};
     use object_store::parsed_path;
-
-    use super::test_helpers::{
-        assert_catalog_state_implementation, break_catalog_with_weird_version, TestCatalogState,
-    };
-    use super::*;
 
     #[tokio::test]
     async fn test_create_empty() {

--- a/parquet_file/src/catalog.rs
+++ b/parquet_file/src/catalog.rs
@@ -14,9 +14,9 @@ use std::{
 use crate::metadata::IoxParquetMetaData;
 use bytes::Bytes;
 use chrono::{DateTime, Utc};
-use data_types::server_id::ServerId;
 use futures::TryStreamExt;
 use generated_types::influxdata::iox::catalog::v1 as proto;
+use iox_object_store::IoxObjectStore;
 use object_store::{
     path::{parsed::DirsAndFileName, parts::PathPart, ObjectStorePath, Path},
     ObjectStore, ObjectStoreApi,
@@ -208,7 +208,7 @@ pub type Result<T, E = Error> = std::result::Result<T, E>;
 /// Struct containing all information that a catalog received for a new parquet file.
 #[derive(Debug, Clone)]
 pub struct CatalogParquetInfo {
-    /// Full path.
+    /// Path within this database.
     pub path: DirsAndFileName,
 
     /// Size of the parquet file, in bytes
@@ -229,7 +229,11 @@ pub trait CatalogState {
     fn new_empty(db_name: &str, data: Self::EmptyInput) -> Self;
 
     /// Add parquet file to state.
-    fn add(&mut self, object_store: Arc<ObjectStore>, info: CatalogParquetInfo) -> Result<()>;
+    fn add(
+        &mut self,
+        iox_object_store: Arc<IoxObjectStore>,
+        info: CatalogParquetInfo,
+    ) -> Result<()>;
 
     /// Remove parquet file from state.
     fn remove(&mut self, path: DirsAndFileName) -> Result<()>;
@@ -258,35 +262,25 @@ pub struct PreservedCatalog {
     previous_tkey: RwLock<Option<TransactionKey>>,
     transaction_semaphore: Semaphore,
 
-    object_store: Arc<ObjectStore>,
-    server_id: ServerId,
-    db_name: String,
+    iox_object_store: Arc<IoxObjectStore>,
 }
 
 impl PreservedCatalog {
     /// Checks if a preserved catalog exists.
-    pub async fn exists(
-        object_store: &ObjectStore,
-        server_id: ServerId,
-        db_name: &str,
-    ) -> Result<bool> {
-        Ok(!list_files(object_store, server_id, db_name)
-            .await?
-            .is_empty())
+    pub async fn exists(iox_object_store: &IoxObjectStore) -> Result<bool> {
+        Ok(!list_files(iox_object_store).await?.is_empty())
     }
 
     /// Find last transaction-start-timestamp.
     ///
     /// This method is designed to read and verify as little as possible and should also work on most broken catalogs.
     pub async fn find_last_transaction_timestamp(
-        object_store: &ObjectStore,
-        server_id: ServerId,
-        db_name: &str,
+        iox_object_store: &IoxObjectStore,
     ) -> Result<Option<DateTime<Utc>>> {
         let mut res = None;
-        for transaction in list_files(object_store, server_id, db_name).await? {
+        for transaction in list_files(iox_object_store).await? {
             let path = transaction.file_path();
-            match load_transaction_proto(object_store, &path).await {
+            match load_transaction_proto(iox_object_store, &path).await {
                 Ok(proto) => match parse_timestamp(&proto.start_timestamp) {
                     Ok(ts) => {
                         res = Some(res.map_or(ts, |res: DateTime<Utc>| res.max(ts)));
@@ -310,14 +304,10 @@ impl PreservedCatalog {
     /// This also works for broken catalogs. Also succeeds if no catalog is present.
     ///
     /// Note that wiping the catalog will NOT wipe any referenced parquet files.
-    pub async fn wipe(
-        object_store: &ObjectStore,
-        server_id: ServerId,
-        db_name: &str,
-    ) -> Result<()> {
-        for transaction in list_files(object_store, server_id, db_name).await? {
+    pub async fn wipe(iox_object_store: &IoxObjectStore) -> Result<()> {
+        for transaction in list_files(iox_object_store).await? {
             let path = transaction.file_path();
-            object_store.delete(&path).await.context(Write)?;
+            iox_object_store.delete(&path).await.context(Write)?;
         }
 
         Ok(())
@@ -328,25 +318,21 @@ impl PreservedCatalog {
     /// An empty transaction will be used to mark the catalog start so that concurrent open but still-empty catalogs can
     /// easily be detected.
     pub async fn new_empty<S>(
-        object_store: Arc<ObjectStore>,
-        server_id: ServerId,
-        db_name: String,
+        iox_object_store: Arc<IoxObjectStore>,
         state_data: S::EmptyInput,
     ) -> Result<(Self, S)>
     where
         S: CatalogState + Send + Sync,
     {
-        if Self::exists(&object_store, server_id, &db_name).await? {
+        if Self::exists(&iox_object_store).await? {
             return Err(Error::AlreadyExists {});
         }
-        let state = S::new_empty(&db_name, state_data);
+        let state = S::new_empty(iox_object_store.database_name(), state_data);
 
         let catalog = Self {
             previous_tkey: RwLock::new(None),
             transaction_semaphore: Semaphore::new(1),
-            object_store,
-            server_id,
-            db_name,
+            iox_object_store,
         };
 
         // add empty transaction
@@ -365,9 +351,7 @@ impl PreservedCatalog {
     /// Loading starts at the latest checkpoint or -- if none exists -- at transaction `0`. Transactions before that
     /// point are neither verified nor are they required to exist.
     pub async fn load<S>(
-        object_store: Arc<ObjectStore>,
-        server_id: ServerId,
-        db_name: String,
+        iox_object_store: Arc<IoxObjectStore>,
         state_data: S::EmptyInput,
     ) -> Result<Option<(Self, S)>>
     where
@@ -377,7 +361,7 @@ impl PreservedCatalog {
         let mut transactions: HashMap<u64, Uuid> = HashMap::new();
         let mut max_revision = None;
         let mut last_checkpoint = None;
-        for transaction in list_files(&object_store, server_id, &db_name).await? {
+        for transaction in list_files(&iox_object_store).await? {
             // keep track of the max
             max_revision = Some(
                 max_revision
@@ -425,7 +409,7 @@ impl PreservedCatalog {
         }
 
         // setup empty state
-        let mut state = S::new_empty(&db_name, state_data);
+        let mut state = S::new_empty(iox_object_store.database_name(), state_data);
         let mut last_tkey = None;
 
         // detect replay start
@@ -449,9 +433,7 @@ impl PreservedCatalog {
                 FileType::Transaction
             };
             OpenTransaction::load_and_apply(
-                &object_store,
-                server_id,
-                &db_name,
+                &iox_object_store,
                 tkey,
                 &mut state,
                 &last_tkey,
@@ -465,9 +447,7 @@ impl PreservedCatalog {
             Self {
                 previous_tkey: RwLock::new(last_tkey),
                 transaction_semaphore: Semaphore::new(1),
-                object_store,
-                server_id,
-                db_name,
+                iox_object_store,
             },
             state,
         )))
@@ -498,18 +478,8 @@ impl PreservedCatalog {
     }
 
     /// Object store used by this catalog.
-    pub fn object_store(&self) -> Arc<ObjectStore> {
-        Arc::clone(&self.object_store)
-    }
-
-    /// Server ID used by this catalog.
-    pub fn server_id(&self) -> ServerId {
-        self.server_id
-    }
-
-    /// Database name used by this catalog.
-    pub fn db_name(&self) -> &str {
-        &self.db_name
+    pub fn iox_object_store(&self) -> Arc<IoxObjectStore> {
+        Arc::clone(&self.iox_object_store)
     }
 }
 
@@ -517,22 +487,6 @@ impl Debug for PreservedCatalog {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "PreservedCatalog{{..}}")
     }
-}
-
-/// Creates object store path where transactions are stored.
-///
-/// The format is:
-///
-/// ```text
-/// <server_id>/<db_name>/transactions/
-/// ```
-fn catalog_path(object_store: &ObjectStore, server_id: ServerId, db_name: &str) -> Path {
-    let mut path = object_store.new_path();
-    path.push_dir(server_id.to_string());
-    path.push_dir(db_name.to_string());
-    path.push_dir("transactions");
-
-    path
 }
 
 /// Type of catalog file.
@@ -578,14 +532,8 @@ impl FileType {
 /// ```text
 /// <server_id>/<db_name>/transactions/<revision_counter>/<uuid>.{txn,ckpt}
 /// ```
-fn file_path(
-    object_store: &ObjectStore,
-    server_id: ServerId,
-    db_name: &str,
-    tkey: TransactionKey,
-    file_type: FileType,
-) -> Path {
-    let path = catalog_path(object_store, server_id, db_name);
+fn file_path(iox_object_store: &IoxObjectStore, tkey: TransactionKey, file_type: FileType) -> Path {
+    let path = iox_object_store.catalog_path();
 
     let transaction = TransactionFile {
         catalog_root: Some(path),
@@ -669,14 +617,9 @@ impl TransactionFile {
 /// Load a list of all transaction file from object store. Also parse revision counter and transaction UUID.
 ///
 /// The files are in no particular order!
-async fn list_files(
-    object_store: &ObjectStore,
-    server_id: ServerId,
-    db_name: &str,
-) -> Result<Vec<TransactionFile>> {
-    let list_path = catalog_path(object_store, server_id, db_name);
-    let paths = object_store
-        .list(Some(&list_path))
+async fn list_files(iox_object_store: &IoxObjectStore) -> Result<Vec<TransactionFile>> {
+    let paths = iox_object_store
+        .catalog_transaction_files()
         .await
         .context(Read {})?
         .map_ok(|paths| {
@@ -693,7 +636,7 @@ async fn list_files(
 
 /// Serialize and store protobuf-encoded transaction.
 async fn store_transaction_proto(
-    object_store: &ObjectStore,
+    iox_object_store: &IoxObjectStore,
     path: &Path,
     proto: &proto::Transaction,
 ) -> Result<()> {
@@ -702,7 +645,7 @@ async fn store_transaction_proto(
     let data = Bytes::from(data);
     let len = data.len();
 
-    object_store
+    iox_object_store
         .put(
             path,
             futures::stream::once(async move { Ok(data) }),
@@ -716,10 +659,10 @@ async fn store_transaction_proto(
 
 /// Load and deserialize protobuf-encoded transaction from store.
 async fn load_transaction_proto(
-    object_store: &ObjectStore,
+    iox_object_store: &IoxObjectStore,
     path: &Path,
 ) -> Result<proto::Transaction> {
-    let data = object_store
+    let data = iox_object_store
         .get(path)
         .await
         .context(Read {})?
@@ -853,7 +796,7 @@ impl OpenTransaction {
     fn handle_action<S>(
         state: &mut S,
         action: &proto::transaction::action::Action,
-        object_store: &Arc<ObjectStore>,
+        iox_object_store: &Arc<IoxObjectStore>,
     ) -> Result<()>
     where
         S: CatalogState,
@@ -874,7 +817,7 @@ impl OpenTransaction {
                 let metadata = Arc::new(metadata);
 
                 state.add(
-                    Arc::clone(object_store),
+                    Arc::clone(iox_object_store),
                     CatalogParquetInfo {
                         path,
                         file_size_bytes,
@@ -907,27 +850,14 @@ impl OpenTransaction {
     /// Abort transaction
     fn abort(self) {}
 
-    async fn store(
-        &self,
-        object_store: &ObjectStore,
-        server_id: ServerId,
-        db_name: &str,
-    ) -> Result<()> {
-        let path = file_path(
-            object_store,
-            server_id,
-            db_name,
-            self.tkey(),
-            FileType::Transaction,
-        );
-        store_transaction_proto(object_store, &path, &self.proto).await?;
+    async fn store(&self, iox_object_store: &IoxObjectStore) -> Result<()> {
+        let path = file_path(iox_object_store, self.tkey(), FileType::Transaction);
+        store_transaction_proto(iox_object_store, &path, &self.proto).await?;
         Ok(())
     }
 
     async fn load_and_apply<S>(
-        object_store: &Arc<ObjectStore>,
-        server_id: ServerId,
-        db_name: &str,
+        iox_object_store: &Arc<IoxObjectStore>,
         tkey: TransactionKey,
         state: &mut S,
         last_tkey: &Option<TransactionKey>,
@@ -937,8 +867,8 @@ impl OpenTransaction {
         S: CatalogState + Send,
     {
         // recover state from store
-        let path = file_path(object_store, server_id, db_name, tkey, file_type);
-        let proto = load_transaction_proto(object_store, &path).await?;
+        let path = file_path(iox_object_store, tkey, file_type);
+        let proto = load_transaction_proto(iox_object_store, &path).await?;
 
         // sanity-check file content
         if proto.version != TRANSACTION_VERSION {
@@ -993,7 +923,7 @@ impl OpenTransaction {
         // apply
         for action in &proto.actions {
             if let Some(action) = action.action.as_ref() {
-                Self::handle_action(state, action, object_store)?;
+                Self::handle_action(state, action, iox_object_store)?;
             }
         }
 
@@ -1083,14 +1013,7 @@ impl<'c> TransactionHandle<'c> {
         let tkey = t.tkey();
 
         // write to object store
-        match t
-            .store(
-                &self.catalog.object_store,
-                self.catalog.server_id,
-                &self.catalog.db_name,
-            )
-            .await
-        {
+        match t.store(&self.catalog.iox_object_store).await {
             Ok(()) => {
                 // commit to catalog
                 let previous_tkey = self.commit_inner(t);
@@ -1215,9 +1138,7 @@ impl<'c> CheckpointHandle<'c> {
     /// If the checkpoint creation fails, the commit will still be treated as completed since the checkpoint is a mere
     /// optimization to speed up transaction replay and allow to prune the history.
     pub async fn create_checkpoint(self, checkpoint_data: CheckpointData) -> Result<()> {
-        let object_store = self.catalog.object_store();
-        let server_id = self.catalog.server_id();
-        let db_name = self.catalog.db_name();
+        let iox_object_store = self.catalog.iox_object_store();
 
         // sort by key (= path) for deterministic output
         let files = {
@@ -1261,14 +1182,8 @@ impl<'c> CheckpointHandle<'c> {
             start_timestamp: Some(Utc::now().into()),
             encoding: proto::transaction::Encoding::Full.into(),
         };
-        let path = file_path(
-            &object_store,
-            server_id,
-            db_name,
-            self.tkey,
-            FileType::Checkpoint,
-        );
-        store_transaction_proto(&object_store, &path, &proto).await?;
+        let path = file_path(&iox_object_store, self.tkey, FileType::Checkpoint);
+        store_transaction_proto(&iox_object_store, &path, &proto).await?;
 
         Ok(())
     }
@@ -1293,12 +1208,9 @@ impl<'c> Debug for CheckpointHandle<'c> {
 }
 
 pub mod test_helpers {
-    use object_store::parsed_path;
-
-    use crate::test_utils::{chunk_addr, make_metadata, make_object_store};
-
     use super::*;
-    use std::convert::TryFrom;
+    use crate::test_utils::{chunk_addr, make_iox_object_store, make_metadata};
+    use object_store::parsed_path;
 
     /// In-memory catalog state, for testing.
     #[derive(Clone, Debug)]
@@ -1325,7 +1237,11 @@ pub mod test_helpers {
             }
         }
 
-        fn add(&mut self, _object_store: Arc<ObjectStore>, info: CatalogParquetInfo) -> Result<()> {
+        fn add(
+            &mut self,
+            _iox_object_store: Arc<IoxObjectStore>,
+            info: CatalogParquetInfo,
+        ) -> Result<()> {
             match self.parquet_files.entry(info.path.clone()) {
                 Occupied(o) => {
                     return Err(Error::ParquetFileAlreadyExists {
@@ -1357,18 +1273,12 @@ pub mod test_helpers {
     /// Break preserved catalog by moving one of the transaction files into a weird unknown version.
     pub async fn break_catalog_with_weird_version(catalog: &PreservedCatalog) {
         let tkey = get_tkey(catalog);
-        let path = file_path(
-            &catalog.object_store,
-            catalog.server_id,
-            &catalog.db_name,
-            tkey,
-            FileType::Transaction,
-        );
-        let mut proto = load_transaction_proto(&catalog.object_store, &path)
+        let path = file_path(&catalog.iox_object_store, tkey, FileType::Transaction);
+        let mut proto = load_transaction_proto(&catalog.iox_object_store, &path)
             .await
             .unwrap();
         proto.version = 42;
-        store_transaction_proto(&catalog.object_store, &path, &proto)
+        store_transaction_proto(&catalog.iox_object_store, &path, &proto)
             .await
             .unwrap();
     }
@@ -1388,15 +1298,11 @@ pub mod test_helpers {
         F: Fn(&S) -> CheckpointData + Send,
     {
         // empty state
-        let object_store = make_object_store();
-        let (_catalog, mut state) = PreservedCatalog::new_empty::<S>(
-            Arc::clone(&object_store),
-            ServerId::try_from(1).unwrap(),
-            "db1".to_string(),
-            state_data,
-        )
-        .await
-        .unwrap();
+        let iox_object_store = make_iox_object_store();
+        let (_catalog, mut state) =
+            PreservedCatalog::new_empty::<S>(Arc::clone(&iox_object_store), state_data)
+                .await
+                .unwrap();
         let mut expected = HashMap::new();
         assert_checkpoint(&state, &f, &expected);
 
@@ -1405,10 +1311,11 @@ pub mod test_helpers {
         {
             for chunk_id in 0..chunk_id_watermark {
                 let path = parsed_path!(format!("chunk_{}", chunk_id).as_ref());
-                let (_, metadata) = make_metadata(&object_store, "ok", chunk_addr(chunk_id)).await;
+                let (_, metadata) =
+                    make_metadata(&iox_object_store, "ok", chunk_addr(chunk_id)).await;
                 state
                     .add(
-                        Arc::clone(&object_store),
+                        Arc::clone(&iox_object_store),
                         CatalogParquetInfo {
                             path: path.clone(),
                             file_size_bytes: 33,
@@ -1433,10 +1340,10 @@ pub mod test_helpers {
         {
             let path = parsed_path!(format!("chunk_{}", chunk_id_watermark).as_ref());
             let (_, metadata) =
-                make_metadata(&object_store, "ok", chunk_addr(chunk_id_watermark)).await;
+                make_metadata(&iox_object_store, "ok", chunk_addr(chunk_id_watermark)).await;
             state
                 .add(
-                    Arc::clone(&object_store),
+                    Arc::clone(&iox_object_store),
                     CatalogParquetInfo {
                         path: path.clone(),
                         file_size_bytes: 33,
@@ -1452,11 +1359,11 @@ pub mod test_helpers {
         // remove and add in the same transaction
         {
             let path = parsed_path!("chunk_2");
-            let (_, metadata) = make_metadata(&object_store, "ok", chunk_addr(2)).await;
+            let (_, metadata) = make_metadata(&iox_object_store, "ok", chunk_addr(2)).await;
             state.remove(path.clone()).unwrap();
             state
                 .add(
-                    Arc::clone(&object_store),
+                    Arc::clone(&iox_object_store),
                     CatalogParquetInfo {
                         path: path.clone(),
                         file_size_bytes: 33,
@@ -1471,10 +1378,10 @@ pub mod test_helpers {
         {
             let path = parsed_path!(format!("chunk_{}", chunk_id_watermark).as_ref());
             let (_, metadata) =
-                make_metadata(&object_store, "ok", chunk_addr(chunk_id_watermark)).await;
+                make_metadata(&iox_object_store, "ok", chunk_addr(chunk_id_watermark)).await;
             state
                 .add(
-                    Arc::clone(&object_store),
+                    Arc::clone(&iox_object_store),
                     CatalogParquetInfo {
                         path: path.clone(),
                         file_size_bytes: 33,
@@ -1485,7 +1392,7 @@ pub mod test_helpers {
             state.remove(path.clone()).unwrap();
             state
                 .add(
-                    Arc::clone(&object_store),
+                    Arc::clone(&iox_object_store),
                     CatalogParquetInfo {
                         path: path.clone(),
                         file_size_bytes: 33,
@@ -1501,11 +1408,11 @@ pub mod test_helpers {
         // remove, add, remove in same transaction
         {
             let path = parsed_path!("chunk_2");
-            let (_, metadata) = make_metadata(&object_store, "ok", chunk_addr(2)).await;
+            let (_, metadata) = make_metadata(&iox_object_store, "ok", chunk_addr(2)).await;
             state.remove(path.clone()).unwrap();
             state
                 .add(
-                    Arc::clone(&object_store),
+                    Arc::clone(&iox_object_store),
                     CatalogParquetInfo {
                         path: path.clone(),
                         file_size_bytes: 33,
@@ -1522,10 +1429,10 @@ pub mod test_helpers {
         {
             // already exists (should also not change the metadata)
             let path = parsed_path!("chunk_0");
-            let (_, metadata) = make_metadata(&object_store, "fail", chunk_addr(0)).await;
+            let (_, metadata) = make_metadata(&iox_object_store, "fail", chunk_addr(0)).await;
             let err = state
                 .add(
-                    Arc::clone(&object_store),
+                    Arc::clone(&iox_object_store),
                     CatalogParquetInfo {
                         path: path.clone(),
                         file_size_bytes: 33,
@@ -1547,10 +1454,10 @@ pub mod test_helpers {
         {
             // already exists (should also not change the metadata)
             let path = parsed_path!("chunk_0");
-            let (_, metadata) = make_metadata(&object_store, "fail", chunk_addr(0)).await;
+            let (_, metadata) = make_metadata(&iox_object_store, "fail", chunk_addr(0)).await;
             let err = state
                 .add(
-                    Arc::clone(&object_store),
+                    Arc::clone(&iox_object_store),
                     CatalogParquetInfo {
                         path: path.clone(),
                         file_size_bytes: 33,
@@ -1563,10 +1470,10 @@ pub mod test_helpers {
             // this transaction will still work
             let path = parsed_path!(format!("chunk_{}", chunk_id_watermark).as_ref());
             let (_, metadata) =
-                make_metadata(&object_store, "ok", chunk_addr(chunk_id_watermark)).await;
+                make_metadata(&iox_object_store, "ok", chunk_addr(chunk_id_watermark)).await;
             state
                 .add(
-                    Arc::clone(&object_store),
+                    Arc::clone(&iox_object_store),
                     CatalogParquetInfo {
                         path: path.clone(),
                         file_size_bytes: 33,
@@ -1580,7 +1487,7 @@ pub mod test_helpers {
             // recently added
             let err = state
                 .add(
-                    Arc::clone(&object_store),
+                    Arc::clone(&iox_object_store),
                     CatalogParquetInfo {
                         path: path.clone(),
                         file_size_bytes: 33,
@@ -1656,9 +1563,7 @@ pub mod test_helpers {
 
 #[cfg(test)]
 mod tests {
-    use std::num::NonZeroU32;
-
-    use crate::test_utils::{chunk_addr, make_metadata, make_object_store};
+    use crate::test_utils::{chunk_addr, make_iox_object_store, make_metadata};
     use object_store::parsed_path;
 
     use super::test_helpers::{
@@ -1668,188 +1573,133 @@ mod tests {
 
     #[tokio::test]
     async fn test_create_empty() {
-        let object_store = make_object_store();
-        let server_id = make_server_id();
-        let db_name = "db1";
+        let iox_object_store = make_iox_object_store();
 
+        assert!(!PreservedCatalog::exists(&iox_object_store).await.unwrap());
         assert!(
-            !PreservedCatalog::exists(&object_store, server_id, db_name,)
+            PreservedCatalog::load::<TestCatalogState>(Arc::clone(&iox_object_store), ())
                 .await
                 .unwrap()
+                .is_none()
         );
-        assert!(PreservedCatalog::load::<TestCatalogState>(
-            Arc::clone(&object_store),
-            server_id,
-            db_name.to_string(),
-            ()
-        )
-        .await
-        .unwrap()
-        .is_none());
 
-        PreservedCatalog::new_empty::<TestCatalogState>(
-            Arc::clone(&object_store),
-            server_id,
-            db_name.to_string(),
-            (),
-        )
-        .await
-        .unwrap();
-
-        assert!(PreservedCatalog::exists(&object_store, server_id, db_name,)
+        PreservedCatalog::new_empty::<TestCatalogState>(Arc::clone(&iox_object_store), ())
             .await
-            .unwrap());
-        assert!(PreservedCatalog::load::<TestCatalogState>(
-            Arc::clone(&object_store),
-            server_id,
-            db_name.to_string(),
-            ()
-        )
-        .await
-        .unwrap()
-        .is_some());
+            .unwrap();
+
+        assert!(PreservedCatalog::exists(&iox_object_store).await.unwrap());
+        assert!(
+            PreservedCatalog::load::<TestCatalogState>(Arc::clone(&iox_object_store), ())
+                .await
+                .unwrap()
+                .is_some()
+        );
     }
 
     #[tokio::test]
     async fn test_inmem_commit_semantics() {
-        let object_store = make_object_store();
-        assert_single_catalog_inmem_works(&object_store, make_server_id(), "db1").await;
+        let iox_object_store = make_iox_object_store();
+        assert_single_catalog_inmem_works(&iox_object_store).await;
     }
 
     #[tokio::test]
     async fn test_store_roundtrip() {
-        let object_store = make_object_store();
-        assert_catalog_roundtrip_works(&object_store, make_server_id(), "db1").await;
+        let iox_object_store = make_iox_object_store();
+        assert_catalog_roundtrip_works(&iox_object_store).await;
     }
 
     #[tokio::test]
     async fn test_load_from_empty_store() {
-        let object_store = make_object_store();
-        let option = PreservedCatalog::load::<TestCatalogState>(
-            object_store,
-            make_server_id(),
-            "db1".to_string(),
-            (),
-        )
-        .await
-        .unwrap();
+        let iox_object_store = make_iox_object_store();
+        let option = PreservedCatalog::load::<TestCatalogState>(iox_object_store, ())
+            .await
+            .unwrap();
         assert!(option.is_none());
     }
 
     #[tokio::test]
     async fn test_load_from_dirty_store() {
-        let object_store = make_object_store();
-        let server_id = make_server_id();
-        let db_name = "db1".to_string();
+        let iox_object_store = make_iox_object_store();
 
         // wrong file extension
-        let mut path = catalog_path(&object_store, server_id, &db_name);
+        let mut path = iox_object_store.catalog_path();
         path.push_dir("0");
         path.set_file_name(format!("{}.foo", Uuid::new_v4()));
-        create_empty_file(&object_store, &path).await;
+        create_empty_file(&iox_object_store, &path).await;
 
         // no file extension
-        let mut path = catalog_path(&object_store, server_id, &db_name);
+        let mut path = iox_object_store.catalog_path();
         path.push_dir("0");
         path.set_file_name(Uuid::new_v4().to_string());
-        create_empty_file(&object_store, &path).await;
+        create_empty_file(&iox_object_store, &path).await;
 
         // broken UUID
-        let mut path = catalog_path(&object_store, server_id, &db_name);
+        let mut path = iox_object_store.catalog_path();
         path.push_dir("0");
         path.set_file_name(format!("foo.{}", TRANSACTION_FILE_SUFFIX));
-        create_empty_file(&object_store, &path).await;
+        create_empty_file(&iox_object_store, &path).await;
 
         // broken revision counter
-        let mut path = catalog_path(&object_store, server_id, &db_name);
+        let mut path = iox_object_store.catalog_path();
         path.push_dir("foo");
         path.set_file_name(format!("{}.{}", Uuid::new_v4(), TRANSACTION_FILE_SUFFIX));
-        create_empty_file(&object_store, &path).await;
+        create_empty_file(&iox_object_store, &path).await;
 
         // file is folder
-        let mut path = catalog_path(&object_store, server_id, &db_name);
+        let mut path = iox_object_store.catalog_path();
         path.push_dir("0");
         path.push_dir(format!("{}.{}", Uuid::new_v4(), TRANSACTION_FILE_SUFFIX));
         path.set_file_name("foo");
-        create_empty_file(&object_store, &path).await;
+        create_empty_file(&iox_object_store, &path).await;
 
         // top-level file
-        let mut path = catalog_path(&object_store, server_id, &db_name);
+        let mut path = iox_object_store.catalog_path();
         path.set_file_name(format!("{}.{}", Uuid::new_v4(), TRANSACTION_FILE_SUFFIX));
-        create_empty_file(&object_store, &path).await;
+        create_empty_file(&iox_object_store, &path).await;
 
         // no data present
-        let option = PreservedCatalog::load::<TestCatalogState>(
-            Arc::clone(&object_store),
-            server_id,
-            db_name.clone(),
-            (),
-        )
-        .await
-        .unwrap();
+        let option = PreservedCatalog::load::<TestCatalogState>(Arc::clone(&iox_object_store), ())
+            .await
+            .unwrap();
         assert!(option.is_none());
 
         // can still write + read
-        assert_catalog_roundtrip_works(&object_store, server_id, &db_name).await;
+        assert_catalog_roundtrip_works(&iox_object_store).await;
     }
 
     #[tokio::test]
     async fn test_missing_transaction() {
-        let object_store = make_object_store();
-        let server_id = make_server_id();
-        let db_name = "db1";
-        let trace = assert_single_catalog_inmem_works(&object_store, server_id, db_name).await;
+        let iox_object_store = make_iox_object_store();
+        let trace = assert_single_catalog_inmem_works(&iox_object_store).await;
 
         // remove transaction file
         assert!(trace.tkeys.len() >= 2);
         let tkey = trace.tkeys[0];
-        let path = file_path(
-            &object_store,
-            server_id,
-            db_name,
-            tkey,
-            FileType::Transaction,
-        );
-        checked_delete(&object_store, &path).await;
+        let path = file_path(&iox_object_store, tkey, FileType::Transaction);
+        checked_delete(&iox_object_store, &path).await;
 
         // loading catalog should fail now
-        let res = PreservedCatalog::load::<TestCatalogState>(
-            Arc::clone(&object_store),
-            server_id,
-            db_name.to_string(),
-            (),
-        )
-        .await;
+        let res =
+            PreservedCatalog::load::<TestCatalogState>(Arc::clone(&iox_object_store), ()).await;
         assert_eq!(res.unwrap_err().to_string(), "Missing transaction: 0",);
     }
 
     #[tokio::test]
     async fn test_transaction_version_mismatch() {
-        let object_store = make_object_store();
-        let server_id = make_server_id();
-        let db_name = "db1";
-        assert_single_catalog_inmem_works(&object_store, server_id, db_name).await;
+        let iox_object_store = make_iox_object_store();
+        assert_single_catalog_inmem_works(&iox_object_store).await;
 
         // break transaction file
-        let (catalog, _state) = PreservedCatalog::load::<TestCatalogState>(
-            Arc::clone(&object_store),
-            server_id,
-            db_name.to_string(),
-            (),
-        )
-        .await
-        .unwrap()
-        .unwrap();
+        let (catalog, _state) =
+            PreservedCatalog::load::<TestCatalogState>(Arc::clone(&iox_object_store), ())
+                .await
+                .unwrap()
+                .unwrap();
         break_catalog_with_weird_version(&catalog).await;
 
         // loading catalog should fail now
-        let res = PreservedCatalog::load::<TestCatalogState>(
-            Arc::clone(&object_store),
-            server_id,
-            db_name.to_string(),
-            (),
-        )
-        .await;
+        let res =
+            PreservedCatalog::load::<TestCatalogState>(Arc::clone(&iox_object_store), ()).await;
         assert_eq!(
             res.unwrap_err().to_string(),
             format!("Format version of transaction file for revision 2 is 42 but only [{}] are supported", TRANSACTION_VERSION)
@@ -1858,35 +1708,24 @@ mod tests {
 
     #[tokio::test]
     async fn test_wrong_transaction_revision() {
-        let object_store = make_object_store();
-        let server_id = make_server_id();
-        let db_name = "db1";
-        let trace = assert_single_catalog_inmem_works(&object_store, server_id, db_name).await;
+        let iox_object_store = make_iox_object_store();
+        let trace = assert_single_catalog_inmem_works(&iox_object_store).await;
 
         // break transaction file
         assert!(trace.tkeys.len() >= 2);
         let tkey = trace.tkeys[0];
-        let path = file_path(
-            &object_store,
-            server_id,
-            db_name,
-            tkey,
-            FileType::Transaction,
-        );
-        let mut proto = load_transaction_proto(&object_store, &path).await.unwrap();
+        let path = file_path(&iox_object_store, tkey, FileType::Transaction);
+        let mut proto = load_transaction_proto(&iox_object_store, &path)
+            .await
+            .unwrap();
         proto.revision_counter = 42;
-        store_transaction_proto(&object_store, &path, &proto)
+        store_transaction_proto(&iox_object_store, &path, &proto)
             .await
             .unwrap();
 
         // loading catalog should fail now
-        let res = PreservedCatalog::load::<TestCatalogState>(
-            Arc::clone(&object_store),
-            server_id,
-            db_name.to_string(),
-            (),
-        )
-        .await;
+        let res =
+            PreservedCatalog::load::<TestCatalogState>(Arc::clone(&iox_object_store), ()).await;
         assert_eq!(
             res.unwrap_err().to_string(),
             "Wrong revision counter in transaction file: expected 0 but found 42"
@@ -1895,37 +1734,26 @@ mod tests {
 
     #[tokio::test]
     async fn test_wrong_transaction_uuid() {
-        let object_store = make_object_store();
-        let server_id = make_server_id();
-        let db_name = "db1";
-        let trace = assert_single_catalog_inmem_works(&object_store, server_id, db_name).await;
+        let iox_object_store = make_iox_object_store();
+        let trace = assert_single_catalog_inmem_works(&iox_object_store).await;
 
         // break transaction file
         assert!(trace.tkeys.len() >= 2);
         let tkey = trace.tkeys[0];
-        let path = file_path(
-            &object_store,
-            server_id,
-            db_name,
-            tkey,
-            FileType::Transaction,
-        );
-        let mut proto = load_transaction_proto(&object_store, &path).await.unwrap();
+        let path = file_path(&iox_object_store, tkey, FileType::Transaction);
+        let mut proto = load_transaction_proto(&iox_object_store, &path)
+            .await
+            .unwrap();
         let uuid_expected = Uuid::parse_str(&proto.uuid).unwrap();
         let uuid_actual = Uuid::nil();
         proto.uuid = uuid_actual.to_string();
-        store_transaction_proto(&object_store, &path, &proto)
+        store_transaction_proto(&iox_object_store, &path, &proto)
             .await
             .unwrap();
 
         // loading catalog should fail now
-        let res = PreservedCatalog::load::<TestCatalogState>(
-            Arc::clone(&object_store),
-            server_id,
-            db_name.to_string(),
-            (),
-        )
-        .await;
+        let res =
+            PreservedCatalog::load::<TestCatalogState>(Arc::clone(&iox_object_store), ()).await;
         assert_eq!(
             res.unwrap_err().to_string(),
             format!(
@@ -1937,35 +1765,24 @@ mod tests {
 
     #[tokio::test]
     async fn test_missing_transaction_uuid() {
-        let object_store = make_object_store();
-        let server_id = make_server_id();
-        let db_name = "db1";
-        let trace = assert_single_catalog_inmem_works(&object_store, server_id, db_name).await;
+        let iox_object_store = make_iox_object_store();
+        let trace = assert_single_catalog_inmem_works(&iox_object_store).await;
 
         // break transaction file
         assert!(trace.tkeys.len() >= 2);
         let tkey = trace.tkeys[0];
-        let path = file_path(
-            &object_store,
-            server_id,
-            db_name,
-            tkey,
-            FileType::Transaction,
-        );
-        let mut proto = load_transaction_proto(&object_store, &path).await.unwrap();
+        let path = file_path(&iox_object_store, tkey, FileType::Transaction);
+        let mut proto = load_transaction_proto(&iox_object_store, &path)
+            .await
+            .unwrap();
         proto.uuid = String::new();
-        store_transaction_proto(&object_store, &path, &proto)
+        store_transaction_proto(&iox_object_store, &path, &proto)
             .await
             .unwrap();
 
         // loading catalog should fail now
-        let res = PreservedCatalog::load::<TestCatalogState>(
-            Arc::clone(&object_store),
-            server_id,
-            db_name.to_string(),
-            (),
-        )
-        .await;
+        let res =
+            PreservedCatalog::load::<TestCatalogState>(Arc::clone(&iox_object_store), ()).await;
         assert_eq!(
             res.unwrap_err().to_string(),
             "UUID required but not provided"
@@ -1974,35 +1791,24 @@ mod tests {
 
     #[tokio::test]
     async fn test_broken_transaction_uuid() {
-        let object_store = make_object_store();
-        let server_id = make_server_id();
-        let db_name = "db1";
-        let trace = assert_single_catalog_inmem_works(&object_store, server_id, db_name).await;
+        let iox_object_store = make_iox_object_store();
+        let trace = assert_single_catalog_inmem_works(&iox_object_store).await;
 
         // break transaction file
         assert!(trace.tkeys.len() >= 2);
         let tkey = trace.tkeys[0];
-        let path = file_path(
-            &object_store,
-            server_id,
-            db_name,
-            tkey,
-            FileType::Transaction,
-        );
-        let mut proto = load_transaction_proto(&object_store, &path).await.unwrap();
+        let path = file_path(&iox_object_store, tkey, FileType::Transaction);
+        let mut proto = load_transaction_proto(&iox_object_store, &path)
+            .await
+            .unwrap();
         proto.uuid = "foo".to_string();
-        store_transaction_proto(&object_store, &path, &proto)
+        store_transaction_proto(&iox_object_store, &path, &proto)
             .await
             .unwrap();
 
         // loading catalog should fail now
-        let res = PreservedCatalog::load::<TestCatalogState>(
-            Arc::clone(&object_store),
-            server_id,
-            db_name.to_string(),
-            (),
-        )
-        .await;
+        let res =
+            PreservedCatalog::load::<TestCatalogState>(Arc::clone(&iox_object_store), ()).await;
         assert_eq!(
             res.unwrap_err().to_string(),
             "Cannot parse UUID: invalid length: expected one of [36, 32], found 3"
@@ -2011,103 +1817,70 @@ mod tests {
 
     #[tokio::test]
     async fn test_wrong_transaction_link_start() {
-        let object_store = make_object_store();
-        let server_id = make_server_id();
-        let db_name = "db1";
-        let trace = assert_single_catalog_inmem_works(&object_store, server_id, db_name).await;
+        let iox_object_store = make_iox_object_store();
+        let trace = assert_single_catalog_inmem_works(&iox_object_store).await;
 
         // break transaction file
         assert!(trace.tkeys.len() >= 2);
         let tkey = trace.tkeys[0];
-        let path = file_path(
-            &object_store,
-            server_id,
-            db_name,
-            tkey,
-            FileType::Transaction,
-        );
-        let mut proto = load_transaction_proto(&object_store, &path).await.unwrap();
+        let path = file_path(&iox_object_store, tkey, FileType::Transaction);
+        let mut proto = load_transaction_proto(&iox_object_store, &path)
+            .await
+            .unwrap();
         proto.previous_uuid = Uuid::nil().to_string();
-        store_transaction_proto(&object_store, &path, &proto)
+        store_transaction_proto(&iox_object_store, &path, &proto)
             .await
             .unwrap();
 
         // loading catalog should fail now
-        let res = PreservedCatalog::load::<TestCatalogState>(
-            Arc::clone(&object_store),
-            server_id,
-            db_name.to_string(),
-            (),
-        )
-        .await;
+        let res =
+            PreservedCatalog::load::<TestCatalogState>(Arc::clone(&iox_object_store), ()).await;
         assert_eq!(res.unwrap_err().to_string(), "Wrong link to previous UUID in revision 0: expected None but found Some(00000000-0000-0000-0000-000000000000)");
     }
 
     #[tokio::test]
     async fn test_wrong_transaction_link_middle() {
-        let object_store = make_object_store();
-        let server_id = make_server_id();
-        let db_name = "db1";
-        let trace = assert_single_catalog_inmem_works(&object_store, server_id, db_name).await;
+        let iox_object_store = make_iox_object_store();
+        let trace = assert_single_catalog_inmem_works(&iox_object_store).await;
 
         // break transaction file
         assert!(trace.tkeys.len() >= 2);
         let tkey = trace.tkeys[1];
-        let path = file_path(
-            &object_store,
-            server_id,
-            db_name,
-            tkey,
-            FileType::Transaction,
-        );
-        let mut proto = load_transaction_proto(&object_store, &path).await.unwrap();
+        let path = file_path(&iox_object_store, tkey, FileType::Transaction);
+        let mut proto = load_transaction_proto(&iox_object_store, &path)
+            .await
+            .unwrap();
         proto.previous_uuid = Uuid::nil().to_string();
-        store_transaction_proto(&object_store, &path, &proto)
+        store_transaction_proto(&iox_object_store, &path, &proto)
             .await
             .unwrap();
 
         // loading catalog should fail now
-        let res = PreservedCatalog::load::<TestCatalogState>(
-            Arc::clone(&object_store),
-            server_id,
-            db_name.to_string(),
-            (),
-        )
-        .await;
+        let res =
+            PreservedCatalog::load::<TestCatalogState>(Arc::clone(&iox_object_store), ()).await;
         assert_eq!(res.unwrap_err().to_string(), format!("Wrong link to previous UUID in revision 1: expected Some({}) but found Some(00000000-0000-0000-0000-000000000000)", trace.tkeys[0].uuid));
     }
 
     #[tokio::test]
     async fn test_wrong_transaction_link_broken() {
-        let object_store = make_object_store();
-        let server_id = make_server_id();
-        let db_name = "db1";
-        let trace = assert_single_catalog_inmem_works(&object_store, server_id, db_name).await;
+        let iox_object_store = make_iox_object_store();
+        let trace = assert_single_catalog_inmem_works(&iox_object_store).await;
 
         // break transaction file
         assert!(trace.tkeys.len() >= 2);
         let tkey = trace.tkeys[0];
-        let path = file_path(
-            &object_store,
-            server_id,
-            db_name,
-            tkey,
-            FileType::Transaction,
-        );
-        let mut proto = load_transaction_proto(&object_store, &path).await.unwrap();
+        let path = file_path(&iox_object_store, tkey, FileType::Transaction);
+        let mut proto = load_transaction_proto(&iox_object_store, &path)
+            .await
+            .unwrap();
         proto.previous_uuid = "foo".to_string();
-        store_transaction_proto(&object_store, &path, &proto)
+        store_transaction_proto(&iox_object_store, &path, &proto)
             .await
             .unwrap();
 
         // loading catalog should fail now
-        let res = PreservedCatalog::load::<TestCatalogState>(
-            Arc::clone(&object_store),
-            server_id,
-            db_name.to_string(),
-            (),
-        )
-        .await;
+        let res =
+            PreservedCatalog::load::<TestCatalogState>(Arc::clone(&iox_object_store), ()).await;
         assert_eq!(
             res.unwrap_err().to_string(),
             "Cannot parse UUID: invalid length: expected one of [36, 32], found 3"
@@ -2116,24 +1889,16 @@ mod tests {
 
     #[tokio::test]
     async fn test_broken_protobuf() {
-        let object_store = make_object_store();
-        let server_id = make_server_id();
-        let db_name = "db1";
-        let trace = assert_single_catalog_inmem_works(&object_store, server_id, db_name).await;
+        let iox_object_store = make_iox_object_store();
+        let trace = assert_single_catalog_inmem_works(&iox_object_store).await;
 
         // break transaction file
         assert!(trace.tkeys.len() >= 2);
         let tkey = trace.tkeys[0];
-        let path = file_path(
-            &object_store,
-            server_id,
-            db_name,
-            tkey,
-            FileType::Transaction,
-        );
+        let path = file_path(&iox_object_store, tkey, FileType::Transaction);
         let data = Bytes::from("foo");
         let len = data.len();
-        object_store
+        iox_object_store
             .put(
                 &path,
                 futures::stream::once(async move { Ok(data) }),
@@ -2143,13 +1908,8 @@ mod tests {
             .unwrap();
 
         // loading catalog should fail now
-        let res = PreservedCatalog::load::<TestCatalogState>(
-            Arc::clone(&object_store),
-            server_id,
-            db_name.to_string(),
-            (),
-        )
-        .await;
+        let res =
+            PreservedCatalog::load::<TestCatalogState>(Arc::clone(&iox_object_store), ()).await;
         assert_eq!(
             res.unwrap_err().to_string(),
             "Error during deserialization: failed to decode Protobuf message: invalid wire type value: 6"
@@ -2158,15 +1918,11 @@ mod tests {
 
     #[tokio::test]
     async fn test_transaction_handle_debug() {
-        let object_store = make_object_store();
-        let (catalog, _state) = PreservedCatalog::new_empty::<TestCatalogState>(
-            object_store,
-            make_server_id(),
-            "db1".to_string(),
-            (),
-        )
-        .await
-        .unwrap();
+        let iox_object_store = make_iox_object_store();
+        let (catalog, _state) =
+            PreservedCatalog::new_empty::<TestCatalogState>(iox_object_store, ())
+                .await
+                .unwrap();
         let mut t = catalog.open_transaction().await;
 
         // open transaction
@@ -2183,46 +1939,29 @@ mod tests {
 
     #[tokio::test]
     async fn test_fork_transaction() {
-        let object_store = make_object_store();
-        let server_id = make_server_id();
-        let db_name = "db1";
-        let trace = assert_single_catalog_inmem_works(&object_store, server_id, db_name).await;
+        let iox_object_store = make_iox_object_store();
+        let trace = assert_single_catalog_inmem_works(&iox_object_store).await;
 
         // re-create transaction file with different UUID
         assert!(trace.tkeys.len() >= 2);
         let mut tkey = trace.tkeys[1];
-        let path = file_path(
-            &object_store,
-            server_id,
-            db_name,
-            tkey,
-            FileType::Transaction,
-        );
-        let mut proto = load_transaction_proto(&object_store, &path).await.unwrap();
+        let path = file_path(&iox_object_store, tkey, FileType::Transaction);
+        let mut proto = load_transaction_proto(&iox_object_store, &path)
+            .await
+            .unwrap();
         let old_uuid = tkey.uuid;
 
         let new_uuid = Uuid::new_v4();
         tkey.uuid = new_uuid;
-        let path = file_path(
-            &object_store,
-            server_id,
-            db_name,
-            tkey,
-            FileType::Transaction,
-        );
+        let path = file_path(&iox_object_store, tkey, FileType::Transaction);
         proto.uuid = new_uuid.to_string();
-        store_transaction_proto(&object_store, &path, &proto)
+        store_transaction_proto(&iox_object_store, &path, &proto)
             .await
             .unwrap();
 
         // loading catalog should fail now
-        let res = PreservedCatalog::load::<TestCatalogState>(
-            Arc::clone(&object_store),
-            server_id,
-            db_name.to_string(),
-            (),
-        )
-        .await;
+        let res =
+            PreservedCatalog::load::<TestCatalogState>(Arc::clone(&iox_object_store), ()).await;
         let (uuid1, uuid2) = if old_uuid < new_uuid {
             (old_uuid, new_uuid)
         } else {
@@ -2233,47 +1972,30 @@ mod tests {
 
     #[tokio::test]
     async fn test_fork_checkpoint() {
-        let object_store = make_object_store();
-        let server_id = make_server_id();
-        let db_name = "db1";
-        let trace = assert_single_catalog_inmem_works(&object_store, server_id, db_name).await;
+        let iox_object_store = make_iox_object_store();
+        let trace = assert_single_catalog_inmem_works(&iox_object_store).await;
 
         // create checkpoint file with different UUID
         assert!(trace.tkeys.len() >= 2);
         let mut tkey = trace.tkeys[1];
-        let path = file_path(
-            &object_store,
-            server_id,
-            db_name,
-            tkey,
-            FileType::Transaction,
-        );
-        let mut proto = load_transaction_proto(&object_store, &path).await.unwrap();
+        let path = file_path(&iox_object_store, tkey, FileType::Transaction);
+        let mut proto = load_transaction_proto(&iox_object_store, &path)
+            .await
+            .unwrap();
         let old_uuid = tkey.uuid;
 
         let new_uuid = Uuid::new_v4();
         tkey.uuid = new_uuid;
-        let path = file_path(
-            &object_store,
-            server_id,
-            db_name,
-            tkey,
-            FileType::Checkpoint,
-        );
+        let path = file_path(&iox_object_store, tkey, FileType::Checkpoint);
         proto.uuid = new_uuid.to_string();
         proto.encoding = proto::transaction::Encoding::Full.into();
-        store_transaction_proto(&object_store, &path, &proto)
+        store_transaction_proto(&iox_object_store, &path, &proto)
             .await
             .unwrap();
 
         // loading catalog should fail now
-        let res = PreservedCatalog::load::<TestCatalogState>(
-            Arc::clone(&object_store),
-            server_id,
-            db_name.to_string(),
-            (),
-        )
-        .await;
+        let res =
+            PreservedCatalog::load::<TestCatalogState>(Arc::clone(&iox_object_store), ()).await;
         let (uuid1, uuid2) = if old_uuid < new_uuid {
             (old_uuid, new_uuid)
         } else {
@@ -2284,22 +2006,16 @@ mod tests {
 
     #[tokio::test]
     async fn test_unsupported_upgrade() {
-        let object_store = make_object_store();
-        let server_id = make_server_id();
-        let db_name = "db1";
-        let trace = assert_single_catalog_inmem_works(&object_store, server_id, db_name).await;
+        let iox_object_store = make_iox_object_store();
+        let trace = assert_single_catalog_inmem_works(&iox_object_store).await;
 
         // break transaction file
         assert!(trace.tkeys.len() >= 2);
         let tkey = trace.tkeys[0];
-        let path = file_path(
-            &object_store,
-            server_id,
-            db_name,
-            tkey,
-            FileType::Transaction,
-        );
-        let mut proto = load_transaction_proto(&object_store, &path).await.unwrap();
+        let path = file_path(&iox_object_store, tkey, FileType::Transaction);
+        let mut proto = load_transaction_proto(&iox_object_store, &path)
+            .await
+            .unwrap();
         proto.actions.push(proto::transaction::Action {
             action: Some(proto::transaction::action::Action::Upgrade(
                 proto::Upgrade {
@@ -2307,18 +2023,13 @@ mod tests {
                 },
             )),
         });
-        store_transaction_proto(&object_store, &path, &proto)
+        store_transaction_proto(&iox_object_store, &path, &proto)
             .await
             .unwrap();
 
         // loading catalog should fail now
-        let res = PreservedCatalog::load::<TestCatalogState>(
-            Arc::clone(&object_store),
-            server_id,
-            db_name.to_string(),
-            (),
-        )
-        .await;
+        let res =
+            PreservedCatalog::load::<TestCatalogState>(Arc::clone(&iox_object_store), ()).await;
         assert_eq!(
             res.unwrap_err().to_string(),
             "Upgrade path not implemented/supported: foo",
@@ -2327,35 +2038,24 @@ mod tests {
 
     #[tokio::test]
     async fn test_missing_start_timestamp() {
-        let object_store = make_object_store();
-        let server_id = make_server_id();
-        let db_name = "db1";
-        let trace = assert_single_catalog_inmem_works(&object_store, server_id, db_name).await;
+        let iox_object_store = make_iox_object_store();
+        let trace = assert_single_catalog_inmem_works(&iox_object_store).await;
 
         // break transaction file
         assert!(trace.tkeys.len() >= 2);
         let tkey = trace.tkeys[0];
-        let path = file_path(
-            &object_store,
-            server_id,
-            db_name,
-            tkey,
-            FileType::Transaction,
-        );
-        let mut proto = load_transaction_proto(&object_store, &path).await.unwrap();
+        let path = file_path(&iox_object_store, tkey, FileType::Transaction);
+        let mut proto = load_transaction_proto(&iox_object_store, &path)
+            .await
+            .unwrap();
         proto.start_timestamp = None;
-        store_transaction_proto(&object_store, &path, &proto)
+        store_transaction_proto(&iox_object_store, &path, &proto)
             .await
             .unwrap();
 
         // loading catalog should fail now
-        let res = PreservedCatalog::load::<TestCatalogState>(
-            Arc::clone(&object_store),
-            server_id,
-            db_name.to_string(),
-            (),
-        )
-        .await;
+        let res =
+            PreservedCatalog::load::<TestCatalogState>(Arc::clone(&iox_object_store), ()).await;
         assert_eq!(
             res.unwrap_err().to_string(),
             "Internal: Datetime required but missing in serialized catalog"
@@ -2364,38 +2064,27 @@ mod tests {
 
     #[tokio::test]
     async fn test_broken_start_timestamp() {
-        let object_store = make_object_store();
-        let server_id = make_server_id();
-        let db_name = "db1";
-        let trace = assert_single_catalog_inmem_works(&object_store, server_id, db_name).await;
+        let iox_object_store = make_iox_object_store();
+        let trace = assert_single_catalog_inmem_works(&iox_object_store).await;
 
         // break transaction file
         assert!(trace.tkeys.len() >= 2);
         let tkey = trace.tkeys[0];
-        let path = file_path(
-            &object_store,
-            server_id,
-            db_name,
-            tkey,
-            FileType::Transaction,
-        );
-        let mut proto = load_transaction_proto(&object_store, &path).await.unwrap();
+        let path = file_path(&iox_object_store, tkey, FileType::Transaction);
+        let mut proto = load_transaction_proto(&iox_object_store, &path)
+            .await
+            .unwrap();
         proto.start_timestamp = Some(generated_types::google::protobuf::Timestamp {
             seconds: 0,
             nanos: -1,
         });
-        store_transaction_proto(&object_store, &path, &proto)
+        store_transaction_proto(&iox_object_store, &path, &proto)
             .await
             .unwrap();
 
         // loading catalog should fail now
-        let res = PreservedCatalog::load::<TestCatalogState>(
-            Arc::clone(&object_store),
-            server_id,
-            db_name.to_string(),
-            (),
-        )
-        .await;
+        let res =
+            PreservedCatalog::load::<TestCatalogState>(Arc::clone(&iox_object_store), ()).await;
         assert_eq!(
             res.unwrap_err().to_string(),
             "Internal: Cannot parse datetime in serialized catalog: out of range integral type conversion attempted"
@@ -2404,35 +2093,24 @@ mod tests {
 
     #[tokio::test]
     async fn test_broken_encoding() {
-        let object_store = make_object_store();
-        let server_id = make_server_id();
-        let db_name = "db1";
-        let trace = assert_single_catalog_inmem_works(&object_store, server_id, db_name).await;
+        let iox_object_store = make_iox_object_store();
+        let trace = assert_single_catalog_inmem_works(&iox_object_store).await;
 
         // break transaction file
         assert!(trace.tkeys.len() >= 2);
         let tkey = trace.tkeys[0];
-        let path = file_path(
-            &object_store,
-            server_id,
-            db_name,
-            tkey,
-            FileType::Transaction,
-        );
-        let mut proto = load_transaction_proto(&object_store, &path).await.unwrap();
+        let path = file_path(&iox_object_store, tkey, FileType::Transaction);
+        let mut proto = load_transaction_proto(&iox_object_store, &path)
+            .await
+            .unwrap();
         proto.encoding = -1;
-        store_transaction_proto(&object_store, &path, &proto)
+        store_transaction_proto(&iox_object_store, &path, &proto)
             .await
             .unwrap();
 
         // loading catalog should fail now
-        let res = PreservedCatalog::load::<TestCatalogState>(
-            Arc::clone(&object_store),
-            server_id,
-            db_name.to_string(),
-            (),
-        )
-        .await;
+        let res =
+            PreservedCatalog::load::<TestCatalogState>(Arc::clone(&iox_object_store), ()).await;
         assert_eq!(
             res.unwrap_err().to_string(),
             "Internal: Cannot parse encoding in serialized catalog: -1 is not a valid, specified variant"
@@ -2441,35 +2119,24 @@ mod tests {
 
     #[tokio::test]
     async fn test_wrong_encoding_in_transaction_file() {
-        let object_store = make_object_store();
-        let server_id = make_server_id();
-        let db_name = "db1";
-        let trace = assert_single_catalog_inmem_works(&object_store, server_id, db_name).await;
+        let iox_object_store = make_iox_object_store();
+        let trace = assert_single_catalog_inmem_works(&iox_object_store).await;
 
         // break transaction file
         assert!(trace.tkeys.len() >= 2);
         let tkey = trace.tkeys[0];
-        let path = file_path(
-            &object_store,
-            server_id,
-            db_name,
-            tkey,
-            FileType::Transaction,
-        );
-        let mut proto = load_transaction_proto(&object_store, &path).await.unwrap();
+        let path = file_path(&iox_object_store, tkey, FileType::Transaction);
+        let mut proto = load_transaction_proto(&iox_object_store, &path)
+            .await
+            .unwrap();
         proto.encoding = proto::transaction::Encoding::Full.into();
-        store_transaction_proto(&object_store, &path, &proto)
+        store_transaction_proto(&iox_object_store, &path, &proto)
             .await
             .unwrap();
 
         // loading catalog should fail now
-        let res = PreservedCatalog::load::<TestCatalogState>(
-            Arc::clone(&object_store),
-            server_id,
-            db_name.to_string(),
-            (),
-        )
-        .await;
+        let res =
+            PreservedCatalog::load::<TestCatalogState>(Arc::clone(&iox_object_store), ()).await;
         assert_eq!(
             res.unwrap_err().to_string(),
             "Internal: Found wrong encoding in serialized catalog file: Expected Delta but got Full"
@@ -2478,35 +2145,24 @@ mod tests {
 
     #[tokio::test]
     async fn test_missing_encoding_in_transaction_file() {
-        let object_store = make_object_store();
-        let server_id = make_server_id();
-        let db_name = "db1";
-        let trace = assert_single_catalog_inmem_works(&object_store, server_id, db_name).await;
+        let iox_object_store = make_iox_object_store();
+        let trace = assert_single_catalog_inmem_works(&iox_object_store).await;
 
         // break transaction file
         assert!(trace.tkeys.len() >= 2);
         let tkey = trace.tkeys[0];
-        let path = file_path(
-            &object_store,
-            server_id,
-            db_name,
-            tkey,
-            FileType::Transaction,
-        );
-        let mut proto = load_transaction_proto(&object_store, &path).await.unwrap();
+        let path = file_path(&iox_object_store, tkey, FileType::Transaction);
+        let mut proto = load_transaction_proto(&iox_object_store, &path)
+            .await
+            .unwrap();
         proto.encoding = 0;
-        store_transaction_proto(&object_store, &path, &proto)
+        store_transaction_proto(&iox_object_store, &path, &proto)
             .await
             .unwrap();
 
         // loading catalog should fail now
-        let res = PreservedCatalog::load::<TestCatalogState>(
-            Arc::clone(&object_store),
-            server_id,
-            db_name.to_string(),
-            (),
-        )
-        .await;
+        let res =
+            PreservedCatalog::load::<TestCatalogState>(Arc::clone(&iox_object_store), ()).await;
         assert_eq!(
             res.unwrap_err().to_string(),
             "Internal: Cannot parse encoding in serialized catalog: 0 is not a valid, specified variant"
@@ -2515,41 +2171,24 @@ mod tests {
 
     #[tokio::test]
     async fn test_wrong_encoding_in_checkpoint_file() {
-        let object_store = make_object_store();
-        let server_id = make_server_id();
-        let db_name = "db1";
-        let trace = assert_single_catalog_inmem_works(&object_store, server_id, db_name).await;
+        let iox_object_store = make_iox_object_store();
+        let trace = assert_single_catalog_inmem_works(&iox_object_store).await;
 
         // break transaction file
         assert!(trace.tkeys.len() >= 2);
         let tkey = trace.tkeys[0];
-        let path = file_path(
-            &object_store,
-            server_id,
-            db_name,
-            tkey,
-            FileType::Transaction,
-        );
-        let proto = load_transaction_proto(&object_store, &path).await.unwrap();
-        let path = file_path(
-            &object_store,
-            server_id,
-            db_name,
-            tkey,
-            FileType::Checkpoint,
-        );
-        store_transaction_proto(&object_store, &path, &proto)
+        let path = file_path(&iox_object_store, tkey, FileType::Transaction);
+        let proto = load_transaction_proto(&iox_object_store, &path)
+            .await
+            .unwrap();
+        let path = file_path(&iox_object_store, tkey, FileType::Checkpoint);
+        store_transaction_proto(&iox_object_store, &path, &proto)
             .await
             .unwrap();
 
         // loading catalog should fail now
-        let res = PreservedCatalog::load::<TestCatalogState>(
-            Arc::clone(&object_store),
-            server_id,
-            db_name.to_string(),
-            (),
-        )
-        .await;
+        let res =
+            PreservedCatalog::load::<TestCatalogState>(Arc::clone(&iox_object_store), ()).await;
         assert_eq!(
             res.unwrap_err().to_string(),
             "Internal: Found wrong encoding in serialized catalog file: Expected Full but got Delta"
@@ -2558,26 +2197,20 @@ mod tests {
 
     #[tokio::test]
     async fn test_checkpoint() {
-        let object_store = make_object_store();
-        let server_id = make_server_id();
+        let iox_object_store = make_iox_object_store();
         let addr = chunk_addr(1337);
-        let db_name = &addr.db_name;
-        let (_, metadata) = make_metadata(&object_store, "foo", addr.clone()).await;
+        let (_, metadata) = make_metadata(&iox_object_store, "foo", addr.clone()).await;
         let metadata = Arc::new(metadata);
 
         // use common test as baseline
-        let mut trace = assert_single_catalog_inmem_works(&object_store, server_id, db_name).await;
+        let mut trace = assert_single_catalog_inmem_works(&iox_object_store).await;
 
         // re-open catalog
-        let (catalog, mut state) = PreservedCatalog::load::<TestCatalogState>(
-            Arc::clone(&object_store),
-            server_id,
-            db_name.to_string(),
-            (),
-        )
-        .await
-        .unwrap()
-        .unwrap();
+        let (catalog, mut state) =
+            PreservedCatalog::load::<TestCatalogState>(Arc::clone(&iox_object_store), ())
+                .await
+                .unwrap()
+                .unwrap();
 
         // create empty transaction w/ checkpoint (the delta transaction file is not required for catalog loading)
         {
@@ -2618,26 +2251,15 @@ mod tests {
                 continue;
             }
             let tkey = trace.tkeys[i];
-            let path = file_path(
-                &object_store,
-                server_id,
-                db_name,
-                tkey,
-                FileType::Transaction,
-            );
-            checked_delete(&object_store, &path).await;
+            let path = file_path(&iox_object_store, tkey, FileType::Transaction);
+            checked_delete(&iox_object_store, &path).await;
         }
 
         // load catalog from store and check replayed state
-        let (catalog, state) = PreservedCatalog::load(
-            Arc::clone(&object_store),
-            server_id,
-            db_name.to_string(),
-            (),
-        )
-        .await
-        .unwrap()
-        .unwrap();
+        let (catalog, state) = PreservedCatalog::load(Arc::clone(&iox_object_store), ())
+            .await
+            .unwrap()
+            .unwrap();
         assert_eq!(
             catalog.revision_counter(),
             trace.tkeys.last().unwrap().revision_counter
@@ -2682,16 +2304,11 @@ mod tests {
         }
     }
 
-    /// Creates new test server ID
-    fn make_server_id() -> ServerId {
-        ServerId::new(NonZeroU32::new(1).unwrap())
-    }
-
-    async fn create_empty_file(object_store: &ObjectStore, path: &Path) {
+    async fn create_empty_file(iox_object_store: &IoxObjectStore, path: &Path) {
         let data = Bytes::default();
         let len = data.len();
 
-        object_store
+        iox_object_store
             .put(
                 path,
                 futures::stream::once(async move { Ok(data) }),
@@ -2701,9 +2318,9 @@ mod tests {
             .unwrap();
     }
 
-    async fn checked_delete(object_store: &ObjectStore, path: &Path) {
+    async fn checked_delete(iox_object_store: &IoxObjectStore, path: &Path) {
         // issue full GET operation to check if object is preset
-        object_store
+        iox_object_store
             .get(path)
             .await
             .unwrap()
@@ -2713,7 +2330,7 @@ mod tests {
             .unwrap();
 
         // delete it
-        object_store.delete(path).await.unwrap();
+        iox_object_store.delete(path).await.unwrap();
     }
 
     /// Result of [`assert_single_catalog_inmem_works`].
@@ -2750,23 +2367,16 @@ mod tests {
     }
 
     async fn assert_single_catalog_inmem_works(
-        object_store: &Arc<ObjectStore>,
-        server_id: ServerId,
-        db_name: &str,
+        iox_object_store: &Arc<IoxObjectStore>,
     ) -> TestTrace {
-        let (catalog, mut state) = PreservedCatalog::new_empty(
-            Arc::clone(object_store),
-            server_id,
-            db_name.to_string(),
-            (),
-        )
-        .await
-        .unwrap();
+        let (catalog, mut state) = PreservedCatalog::new_empty(Arc::clone(iox_object_store), ())
+            .await
+            .unwrap();
 
         // get some test metadata
-        let (_, metadata1) = make_metadata(object_store, "foo", chunk_addr(1)).await;
+        let (_, metadata1) = make_metadata(iox_object_store, "foo", chunk_addr(1)).await;
         let metadata1 = Arc::new(metadata1);
-        let (_, metadata2) = make_metadata(object_store, "bar", chunk_addr(1)).await;
+        let (_, metadata2) = make_metadata(iox_object_store, "bar", chunk_addr(1)).await;
         let metadata2 = Arc::new(metadata2);
 
         // track all the intermediate results
@@ -2895,157 +2505,102 @@ mod tests {
 
     #[tokio::test]
     async fn test_create_twice() {
-        let object_store = make_object_store();
-        let server_id = make_server_id();
-        let db_name = "db1";
+        let iox_object_store = make_iox_object_store();
 
-        PreservedCatalog::new_empty::<TestCatalogState>(
-            Arc::clone(&object_store),
-            server_id,
-            db_name.to_string(),
-            (),
-        )
-        .await
-        .unwrap();
+        PreservedCatalog::new_empty::<TestCatalogState>(Arc::clone(&iox_object_store), ())
+            .await
+            .unwrap();
 
-        let res = PreservedCatalog::new_empty::<TestCatalogState>(
-            Arc::clone(&object_store),
-            server_id,
-            db_name.to_string(),
-            (),
-        )
-        .await;
+        let res =
+            PreservedCatalog::new_empty::<TestCatalogState>(Arc::clone(&iox_object_store), ())
+                .await;
         assert_eq!(res.unwrap_err().to_string(), "Catalog already exists");
     }
 
     #[tokio::test]
     async fn test_wipe_nothing() {
-        let object_store = make_object_store();
-        let server_id = make_server_id();
-        let db_name = "db1";
+        let iox_object_store = make_iox_object_store();
 
-        PreservedCatalog::wipe(&object_store, server_id, db_name)
-            .await
-            .unwrap();
+        PreservedCatalog::wipe(&iox_object_store).await.unwrap();
     }
 
     #[tokio::test]
     async fn test_wipe_normal() {
-        let object_store = make_object_store();
-        let server_id = make_server_id();
-        let db_name = "db1";
+        let iox_object_store = make_iox_object_store();
 
         // create a real catalog
-        assert_single_catalog_inmem_works(&object_store, make_server_id(), "db1").await;
+        assert_single_catalog_inmem_works(&iox_object_store).await;
 
         // wipe
-        PreservedCatalog::wipe(&object_store, server_id, db_name)
-            .await
-            .unwrap();
+        PreservedCatalog::wipe(&iox_object_store).await.unwrap();
 
         // `exists` and `load` both report "no data"
+        assert!(!PreservedCatalog::exists(&iox_object_store).await.unwrap());
         assert!(
-            !PreservedCatalog::exists(&object_store, server_id, db_name,)
+            PreservedCatalog::load::<TestCatalogState>(Arc::clone(&iox_object_store), ())
                 .await
                 .unwrap()
+                .is_none()
         );
-        assert!(PreservedCatalog::load::<TestCatalogState>(
-            Arc::clone(&object_store),
-            server_id,
-            db_name.to_string(),
-            ()
-        )
-        .await
-        .unwrap()
-        .is_none());
 
         // can create new catalog
-        PreservedCatalog::new_empty::<TestCatalogState>(
-            Arc::clone(&object_store),
-            server_id,
-            db_name.to_string(),
-            (),
-        )
-        .await
-        .unwrap();
+        PreservedCatalog::new_empty::<TestCatalogState>(Arc::clone(&iox_object_store), ())
+            .await
+            .unwrap();
     }
 
     #[tokio::test]
     async fn test_wipe_broken_catalog() {
-        let object_store = make_object_store();
-        let server_id = make_server_id();
-        let db_name = "db1";
+        let iox_object_store = make_iox_object_store();
 
         // create a real catalog
-        assert_single_catalog_inmem_works(&object_store, make_server_id(), "db1").await;
+        assert_single_catalog_inmem_works(&iox_object_store).await;
 
         // break
-        let (catalog, _state) = PreservedCatalog::load::<TestCatalogState>(
-            Arc::clone(&object_store),
-            server_id,
-            db_name.to_string(),
-            (),
-        )
-        .await
-        .unwrap()
-        .unwrap();
+        let (catalog, _state) =
+            PreservedCatalog::load::<TestCatalogState>(Arc::clone(&iox_object_store), ())
+                .await
+                .unwrap()
+                .unwrap();
         break_catalog_with_weird_version(&catalog).await;
 
         // wipe
-        PreservedCatalog::wipe(&object_store, server_id, db_name)
-            .await
-            .unwrap();
+        PreservedCatalog::wipe(&iox_object_store).await.unwrap();
 
         // `exists` and `load` both report "no data"
+        assert!(!PreservedCatalog::exists(&iox_object_store).await.unwrap());
         assert!(
-            !PreservedCatalog::exists(&object_store, server_id, db_name,)
+            PreservedCatalog::load::<TestCatalogState>(Arc::clone(&iox_object_store), ())
                 .await
                 .unwrap()
+                .is_none()
         );
-        assert!(PreservedCatalog::load::<TestCatalogState>(
-            Arc::clone(&object_store),
-            server_id,
-            db_name.to_string(),
-            ()
-        )
-        .await
-        .unwrap()
-        .is_none());
 
         // can create new catalog
-        PreservedCatalog::new_empty::<TestCatalogState>(
-            Arc::clone(&object_store),
-            server_id,
-            db_name.to_string(),
-            (),
-        )
-        .await
-        .unwrap();
+        PreservedCatalog::new_empty::<TestCatalogState>(Arc::clone(&iox_object_store), ())
+            .await
+            .unwrap();
     }
 
     #[tokio::test]
     async fn test_wipe_ignores_unknown_files() {
-        let object_store = make_object_store();
-        let server_id = make_server_id();
-        let db_name = "db1";
+        let iox_object_store = make_iox_object_store();
 
         // create a real catalog
-        assert_single_catalog_inmem_works(&object_store, make_server_id(), "db1").await;
+        assert_single_catalog_inmem_works(&iox_object_store).await;
 
         // create junk
-        let mut path = catalog_path(&object_store, server_id, db_name);
+        let mut path = iox_object_store.catalog_path();
         path.push_dir("0");
         path.set_file_name(format!("{}.foo", Uuid::new_v4()));
-        create_empty_file(&object_store, &path).await;
+        create_empty_file(&iox_object_store, &path).await;
 
         // wipe
-        PreservedCatalog::wipe(&object_store, server_id, db_name)
-            .await
-            .unwrap();
+        PreservedCatalog::wipe(&iox_object_store).await.unwrap();
 
         // check file is still there
-        let prefix = catalog_path(&object_store, server_id, db_name);
-        let files = object_store
+        let prefix = iox_object_store.catalog_path();
+        let files = iox_object_store
             .list(Some(&prefix))
             .await
             .unwrap()
@@ -3059,15 +2614,11 @@ mod tests {
 
     #[tokio::test]
     async fn test_transaction_handle_revision_counter() {
-        let object_store = make_object_store();
-        let (catalog, _state) = PreservedCatalog::new_empty::<TestCatalogState>(
-            object_store,
-            make_server_id(),
-            "db1".to_string(),
-            (),
-        )
-        .await
-        .unwrap();
+        let iox_object_store = make_iox_object_store();
+        let (catalog, _state) =
+            PreservedCatalog::new_empty::<TestCatalogState>(iox_object_store, ())
+                .await
+                .unwrap();
         let t = catalog.open_transaction().await;
 
         assert_eq!(t.revision_counter(), 1);
@@ -3075,15 +2626,11 @@ mod tests {
 
     #[tokio::test]
     async fn test_transaction_handle_uuid() {
-        let object_store = make_object_store();
-        let (catalog, _state) = PreservedCatalog::new_empty::<TestCatalogState>(
-            object_store,
-            make_server_id(),
-            "db1".to_string(),
-            (),
-        )
-        .await
-        .unwrap();
+        let iox_object_store = make_iox_object_store();
+        let (catalog, _state) =
+            PreservedCatalog::new_empty::<TestCatalogState>(iox_object_store, ())
+                .await
+                .unwrap();
         let mut t = catalog.open_transaction().await;
 
         t.transaction.as_mut().unwrap().proto.uuid = Uuid::nil().to_string();
@@ -3092,16 +2639,13 @@ mod tests {
 
     #[tokio::test]
     async fn test_find_last_transaction_timestamp_ok() {
-        let object_store = make_object_store();
-        let server_id = make_server_id();
-        let db_name = "db1";
-        let trace = assert_single_catalog_inmem_works(&object_store, server_id, db_name).await;
+        let iox_object_store = make_iox_object_store();
+        let trace = assert_single_catalog_inmem_works(&iox_object_store).await;
 
-        let ts =
-            PreservedCatalog::find_last_transaction_timestamp(&object_store, server_id, db_name)
-                .await
-                .unwrap()
-                .unwrap();
+        let ts = PreservedCatalog::find_last_transaction_timestamp(&iox_object_store)
+            .await
+            .unwrap()
+            .unwrap();
 
         // last trace entry is an aborted transaction, so the valid transaction timestamp is the third last
         assert!(trace.aborted[trace.aborted.len() - 1]);
@@ -3124,48 +2668,37 @@ mod tests {
 
     #[tokio::test]
     async fn test_find_last_transaction_timestamp_empty() {
-        let object_store = make_object_store();
-        let server_id = make_server_id();
-        let db_name = "db1";
+        let iox_object_store = make_iox_object_store();
 
-        assert!(PreservedCatalog::find_last_transaction_timestamp(
-            &object_store,
-            server_id,
-            db_name
-        )
-        .await
-        .unwrap()
-        .is_none());
+        assert!(
+            PreservedCatalog::find_last_transaction_timestamp(&iox_object_store)
+                .await
+                .unwrap()
+                .is_none()
+        );
     }
 
     #[tokio::test]
     async fn test_find_last_transaction_timestamp_datetime_broken() {
-        let object_store = make_object_store();
-        let server_id = make_server_id();
-        let db_name = "db1";
-        let trace = assert_single_catalog_inmem_works(&object_store, server_id, db_name).await;
+        let iox_object_store = make_iox_object_store();
+        let trace = assert_single_catalog_inmem_works(&iox_object_store).await;
 
         // break transaction file
         assert!(trace.tkeys.len() >= 2);
         let tkey = trace.tkeys[0];
-        let path = file_path(
-            &object_store,
-            server_id,
-            db_name,
-            tkey,
-            FileType::Transaction,
-        );
-        let mut proto = load_transaction_proto(&object_store, &path).await.unwrap();
+        let path = file_path(&iox_object_store, tkey, FileType::Transaction);
+        let mut proto = load_transaction_proto(&iox_object_store, &path)
+            .await
+            .unwrap();
         proto.start_timestamp = None;
-        store_transaction_proto(&object_store, &path, &proto)
+        store_transaction_proto(&iox_object_store, &path, &proto)
             .await
             .unwrap();
 
-        let ts =
-            PreservedCatalog::find_last_transaction_timestamp(&object_store, server_id, db_name)
-                .await
-                .unwrap()
-                .unwrap();
+        let ts = PreservedCatalog::find_last_transaction_timestamp(&iox_object_store)
+            .await
+            .unwrap()
+            .unwrap();
 
         // last trace entry is an aborted transaction, so the valid transaction timestamp is the third last
         assert!(trace.aborted[trace.aborted.len() - 1]);
@@ -3188,24 +2721,16 @@ mod tests {
 
     #[tokio::test]
     async fn test_find_last_transaction_timestamp_protobuf_broken() {
-        let object_store = make_object_store();
-        let server_id = make_server_id();
-        let db_name = "db1";
-        let trace = assert_single_catalog_inmem_works(&object_store, server_id, db_name).await;
+        let iox_object_store = make_iox_object_store();
+        let trace = assert_single_catalog_inmem_works(&iox_object_store).await;
 
         // break transaction file
         assert!(trace.tkeys.len() >= 2);
         let tkey = trace.tkeys[0];
-        let path = file_path(
-            &object_store,
-            server_id,
-            db_name,
-            tkey,
-            FileType::Transaction,
-        );
+        let path = file_path(&iox_object_store, tkey, FileType::Transaction);
         let data = Bytes::from("foo");
         let len = data.len();
-        object_store
+        iox_object_store
             .put(
                 &path,
                 futures::stream::once(async move { Ok(data) }),
@@ -3214,11 +2739,10 @@ mod tests {
             .await
             .unwrap();
 
-        let ts =
-            PreservedCatalog::find_last_transaction_timestamp(&object_store, server_id, db_name)
-                .await
-                .unwrap()
-                .unwrap();
+        let ts = PreservedCatalog::find_last_transaction_timestamp(&iox_object_store)
+            .await
+            .unwrap()
+            .unwrap();
 
         // last trace entry is an aborted transaction, so the valid transaction timestamp is the third last
         assert!(trace.aborted[trace.aborted.len() - 1]);
@@ -3241,20 +2765,14 @@ mod tests {
 
     #[tokio::test]
     async fn test_find_last_transaction_timestamp_checkpoints_only() {
-        let object_store = make_object_store();
-        let server_id = make_server_id();
-        let db_name = "db1";
-        let mut trace = assert_single_catalog_inmem_works(&object_store, server_id, db_name).await;
+        let iox_object_store = make_iox_object_store();
+        let mut trace = assert_single_catalog_inmem_works(&iox_object_store).await;
 
-        let (catalog, state) = PreservedCatalog::load::<TestCatalogState>(
-            Arc::clone(&object_store),
-            server_id,
-            db_name.to_string(),
-            (),
-        )
-        .await
-        .unwrap()
-        .unwrap();
+        let (catalog, state) =
+            PreservedCatalog::load::<TestCatalogState>(Arc::clone(&iox_object_store), ())
+                .await
+                .unwrap()
+                .unwrap();
 
         // create empty transaction w/ checkpoint
         {
@@ -3272,22 +2790,15 @@ mod tests {
             if *aborted {
                 continue;
             }
-            let path = file_path(
-                &object_store,
-                server_id,
-                db_name,
-                tkey,
-                FileType::Transaction,
-            );
-            checked_delete(&object_store, &path).await;
+            let path = file_path(&iox_object_store, tkey, FileType::Transaction);
+            checked_delete(&iox_object_store, &path).await;
         }
         drop(catalog);
 
-        let ts =
-            PreservedCatalog::find_last_transaction_timestamp(&object_store, server_id, db_name)
-                .await
-                .unwrap()
-                .unwrap();
+        let ts = PreservedCatalog::find_last_transaction_timestamp(&iox_object_store)
+            .await
+            .unwrap()
+            .unwrap();
 
         // check timestamps
         assert!(!trace.aborted[trace.aborted.len() - 1]);
@@ -3308,20 +2819,15 @@ mod tests {
         );
     }
 
-    async fn assert_catalog_roundtrip_works(
-        object_store: &Arc<ObjectStore>,
-        server_id: ServerId,
-        db_name: &str,
-    ) {
+    async fn assert_catalog_roundtrip_works(iox_object_store: &Arc<IoxObjectStore>) {
         // use single-catalog test case as base
-        let trace = assert_single_catalog_inmem_works(object_store, server_id, db_name).await;
+        let trace = assert_single_catalog_inmem_works(iox_object_store).await;
 
         // load catalog from store and check replayed state
-        let (catalog, state) =
-            PreservedCatalog::load(Arc::clone(object_store), server_id, db_name.to_string(), ())
-                .await
-                .unwrap()
-                .unwrap();
+        let (catalog, state) = PreservedCatalog::load(Arc::clone(iox_object_store), ())
+            .await
+            .unwrap()
+            .unwrap();
         assert_eq!(
             catalog.revision_counter(),
             trace.tkeys.last().unwrap().revision_counter
@@ -3334,35 +2840,19 @@ mod tests {
 
     #[tokio::test]
     async fn test_exists_considers_checkpoints() {
-        let object_store = make_object_store();
-        let server_id = make_server_id();
-        let db_name = "db1";
+        let iox_object_store = make_iox_object_store();
 
-        assert!(
-            !PreservedCatalog::exists(&object_store, server_id, db_name,)
+        assert!(!PreservedCatalog::exists(&iox_object_store).await.unwrap());
+
+        let (catalog, state) =
+            PreservedCatalog::new_empty::<TestCatalogState>(Arc::clone(&iox_object_store), ())
                 .await
-                .unwrap()
-        );
-
-        let (catalog, state) = PreservedCatalog::new_empty::<TestCatalogState>(
-            Arc::clone(&object_store),
-            server_id,
-            db_name.to_string(),
-            (),
-        )
-        .await
-        .unwrap();
+                .unwrap();
 
         // delete transaction file
         let tkey = catalog.previous_tkey.read().unwrap();
-        let path = file_path(
-            &object_store,
-            server_id,
-            db_name,
-            tkey,
-            FileType::Transaction,
-        );
-        checked_delete(&object_store, &path).await;
+        let path = file_path(&iox_object_store, tkey, FileType::Transaction);
+        checked_delete(&iox_object_store, &path).await;
 
         // create empty transaction w/ checkpoint
         {
@@ -3376,29 +2866,18 @@ mod tests {
 
         // delete transaction file
         let tkey = catalog.previous_tkey.read().unwrap();
-        let path = file_path(
-            &object_store,
-            server_id,
-            db_name,
-            tkey,
-            FileType::Transaction,
-        );
-        checked_delete(&object_store, &path).await;
+        let path = file_path(&iox_object_store, tkey, FileType::Transaction);
+        checked_delete(&iox_object_store, &path).await;
 
         drop(catalog);
 
-        assert!(PreservedCatalog::exists(&object_store, server_id, db_name,)
-            .await
-            .unwrap());
-        assert!(PreservedCatalog::load::<TestCatalogState>(
-            Arc::clone(&object_store),
-            server_id,
-            db_name.to_string(),
-            ()
-        )
-        .await
-        .unwrap()
-        .is_some());
+        assert!(PreservedCatalog::exists(&iox_object_store).await.unwrap());
+        assert!(
+            PreservedCatalog::load::<TestCatalogState>(Arc::clone(&iox_object_store), ())
+                .await
+                .unwrap()
+                .is_some()
+        );
     }
 
     #[tokio::test]

--- a/parquet_file/src/chunk.rs
+++ b/parquet_file/src/chunk.rs
@@ -8,7 +8,8 @@ use internal_types::{
     schema::{Schema, TIME_COLUMN_NAME},
     selection::Selection,
 };
-use object_store::{path::Path, ObjectStore};
+use iox_object_store::IoxObjectStore;
+use object_store::path::Path;
 use query::predicate::Predicate;
 use snafu::{ResultExt, Snafu};
 use std::{collections::BTreeSet, mem, sync::Arc};
@@ -91,8 +92,8 @@ pub struct ParquetChunk {
     /// (extracted from TableSummary)
     timestamp_range: Option<TimestampRange>,
 
-    /// Object store of the above relative path to open and read the file
-    object_store: Arc<ObjectStore>,
+    /// Persists the parquet file within a database's relative path
+    iox_object_store: Arc<IoxObjectStore>,
 
     /// Path in the object store. Format:
     ///  <writer id>/<database>/data/<partition key>/<chunk
@@ -112,7 +113,7 @@ impl ParquetChunk {
     /// Creates new chunk from given parquet metadata.
     pub fn new(
         file_location: Path,
-        store: Arc<ObjectStore>,
+        iox_object_store: Arc<IoxObjectStore>,
         file_size_bytes: usize,
         parquet_metadata: Arc<IoxParquetMetaData>,
         table_name: Arc<str>,
@@ -137,7 +138,7 @@ impl ParquetChunk {
             Arc::new(table_summary),
             schema,
             file_location,
-            store,
+            iox_object_store,
             file_size_bytes,
             parquet_metadata,
             metrics,
@@ -152,7 +153,7 @@ impl ParquetChunk {
         table_summary: Arc<TableSummary>,
         schema: Arc<Schema>,
         file_location: Path,
-        store: Arc<ObjectStore>,
+        iox_object_store: Arc<IoxObjectStore>,
         file_size_bytes: usize,
         parquet_metadata: Arc<IoxParquetMetaData>,
         metrics: ChunkMetrics,
@@ -164,7 +165,7 @@ impl ParquetChunk {
             table_summary,
             schema,
             timestamp_range,
-            object_store: store,
+            iox_object_store,
             object_store_path: file_location,
             file_size_bytes,
             parquet_metadata,
@@ -247,7 +248,7 @@ impl ParquetChunk {
             selection,
             Arc::clone(&self.schema.as_arrow()),
             self.object_store_path.clone(),
-            Arc::clone(&self.object_store),
+            Arc::clone(&self.iox_object_store),
         )
         .context(ReadParquet)
     }

--- a/parquet_file/src/metadata.rs
+++ b/parquet_file/src/metadata.rs
@@ -811,15 +811,17 @@ mod tests {
 
     use crate::test_utils::{
         chunk_addr, create_partition_and_database_checkpoint, load_parquet_from_store, make_chunk,
-        make_chunk_no_row_group, make_object_store,
+        make_chunk_no_row_group, make_iox_object_store,
     };
 
     #[tokio::test]
     async fn test_restore_from_file() {
         // setup: preserve chunk to object store
-        let store = make_object_store();
-        let chunk = make_chunk(Arc::clone(&store), "foo", chunk_addr(1)).await;
-        let parquet_data = load_parquet_from_store(&chunk, store).await.unwrap();
+        let iox_object_store = make_iox_object_store();
+        let chunk = make_chunk(Arc::clone(&iox_object_store), "foo", chunk_addr(1)).await;
+        let parquet_data = load_parquet_from_store(&chunk, iox_object_store)
+            .await
+            .unwrap();
         let parquet_metadata = IoxParquetMetaData::from_file_bytes(parquet_data).unwrap();
 
         // step 1: read back schema
@@ -841,9 +843,11 @@ mod tests {
     #[tokio::test]
     async fn test_restore_from_thrift() {
         // setup: write chunk to object store and only keep thrift-encoded metadata
-        let store = make_object_store();
-        let chunk = make_chunk(Arc::clone(&store), "foo", chunk_addr(1)).await;
-        let parquet_data = load_parquet_from_store(&chunk, store).await.unwrap();
+        let iox_object_store = make_iox_object_store();
+        let chunk = make_chunk(Arc::clone(&iox_object_store), "foo", chunk_addr(1)).await;
+        let parquet_data = load_parquet_from_store(&chunk, iox_object_store)
+            .await
+            .unwrap();
         let parquet_metadata = IoxParquetMetaData::from_file_bytes(parquet_data).unwrap();
         let data = parquet_metadata.to_thrift().unwrap();
         let parquet_metadata = IoxParquetMetaData::from_thrift(&data).unwrap();
@@ -862,9 +866,12 @@ mod tests {
     #[tokio::test]
     async fn test_restore_from_file_no_row_group() {
         // setup: preserve chunk to object store
-        let store = make_object_store();
-        let chunk = make_chunk_no_row_group(Arc::clone(&store), "foo", chunk_addr(1)).await;
-        let parquet_data = load_parquet_from_store(&chunk, store).await.unwrap();
+        let iox_object_store = make_iox_object_store();
+        let chunk =
+            make_chunk_no_row_group(Arc::clone(&iox_object_store), "foo", chunk_addr(1)).await;
+        let parquet_data = load_parquet_from_store(&chunk, iox_object_store)
+            .await
+            .unwrap();
         let parquet_metadata = IoxParquetMetaData::from_file_bytes(parquet_data).unwrap();
 
         // step 1: read back schema
@@ -883,9 +890,12 @@ mod tests {
     #[tokio::test]
     async fn test_restore_from_thrift_no_row_group() {
         // setup: write chunk to object store and only keep thrift-encoded metadata
-        let store = make_object_store();
-        let chunk = make_chunk_no_row_group(Arc::clone(&store), "foo", chunk_addr(1)).await;
-        let parquet_data = load_parquet_from_store(&chunk, store).await.unwrap();
+        let iox_object_store = make_iox_object_store();
+        let chunk =
+            make_chunk_no_row_group(Arc::clone(&iox_object_store), "foo", chunk_addr(1)).await;
+        let parquet_data = load_parquet_from_store(&chunk, iox_object_store)
+            .await
+            .unwrap();
         let parquet_metadata = IoxParquetMetaData::from_file_bytes(parquet_data).unwrap();
         let data = parquet_metadata.to_thrift().unwrap();
         let parquet_metadata = IoxParquetMetaData::from_thrift(&data).unwrap();
@@ -905,9 +915,11 @@ mod tests {
 
     #[tokio::test]
     async fn test_make_chunk() {
-        let store = make_object_store();
-        let chunk = make_chunk(Arc::clone(&store), "foo", chunk_addr(1)).await;
-        let parquet_data = load_parquet_from_store(&chunk, store).await.unwrap();
+        let iox_object_store = make_iox_object_store();
+        let chunk = make_chunk(Arc::clone(&iox_object_store), "foo", chunk_addr(1)).await;
+        let parquet_data = load_parquet_from_store(&chunk, iox_object_store)
+            .await
+            .unwrap();
         let parquet_metadata = IoxParquetMetaData::from_file_bytes(parquet_data).unwrap();
 
         assert!(parquet_metadata.md.num_row_groups() > 1);
@@ -945,9 +957,12 @@ mod tests {
 
     #[tokio::test]
     async fn test_make_chunk_no_row_group() {
-        let store = make_object_store();
-        let chunk = make_chunk_no_row_group(Arc::clone(&store), "foo", chunk_addr(1)).await;
-        let parquet_data = load_parquet_from_store(&chunk, store).await.unwrap();
+        let iox_object_store = make_iox_object_store();
+        let chunk =
+            make_chunk_no_row_group(Arc::clone(&iox_object_store), "foo", chunk_addr(1)).await;
+        let parquet_data = load_parquet_from_store(&chunk, iox_object_store)
+            .await
+            .unwrap();
         let parquet_metadata = IoxParquetMetaData::from_file_bytes(parquet_data).unwrap();
 
         assert_eq!(parquet_metadata.md.num_row_groups(), 0);

--- a/parquet_file/src/storage.rs
+++ b/parquet_file/src/storage.rs
@@ -5,16 +5,18 @@ use arrow::{
     error::{ArrowError, Result as ArrowResult},
     record_batch::RecordBatch,
 };
+use bytes::Bytes;
+use data_types::chunk_metadata::ChunkAddr;
 use datafusion::{
     logical_plan::Expr,
     physical_plan::{parquet::ParquetExec, ExecutionPlan, Partitioning, SendableRecordBatchStream},
 };
+use futures::StreamExt;
 use internal_types::selection::Selection;
-use object_store::{
-    path::{parsed::DirsAndFileName, ObjectStorePath, Path},
-    ObjectStore, ObjectStoreApi,
-};
+use iox_object_store::IoxObjectStore;
+use object_store::path::{parsed::DirsAndFileName, ObjectStorePath, Path};
 use observability_deps::tracing::debug;
+use parking_lot::Mutex;
 use parquet::{
     self,
     arrow::ArrowWriter,
@@ -22,11 +24,6 @@ use parquet::{
     file::{metadata::KeyValue, properties::WriterProperties, writer::TryClone},
 };
 use query::{exec::stream::AdapterStream, predicate::Predicate};
-
-use bytes::Bytes;
-use data_types::{chunk_metadata::ChunkAddr, server_id::ServerId};
-use futures::StreamExt;
-use parking_lot::Mutex;
 use snafu::{ensure, OptionExt, ResultExt, Snafu};
 use std::{
     io::{Cursor, Seek, SeekFrom, Write},
@@ -132,16 +129,12 @@ pub type Result<T, E = Error> = std::result::Result<T, E>;
 
 #[derive(Debug, Clone)]
 pub struct Storage {
-    object_store: Arc<ObjectStore>,
-    server_id: ServerId,
+    iox_object_store: Arc<IoxObjectStore>,
 }
 
 impl Storage {
-    pub fn new(object_store: Arc<ObjectStore>, server_id: ServerId) -> Self {
-        Self {
-            object_store,
-            server_id,
-        }
+    pub fn new(iox_object_store: Arc<IoxObjectStore>) -> Self {
+        Self { iox_object_store }
     }
 
     /// Return full path including filename in the object store to save a chunk
@@ -156,7 +149,7 @@ impl Storage {
         // generate random UUID so that files are unique and never overwritten
         let uuid = Uuid::new_v4();
 
-        let mut path = data_location(&self.object_store, self.server_id, &chunk_addr.db_name);
+        let mut path = self.iox_object_store.data_path();
         path.push_dir(chunk_addr.table_name.as_ref());
         path.push_dir(chunk_addr.partition_key.as_ref());
         path.set_file_name(format!(
@@ -236,7 +229,7 @@ impl Storage {
         let data = Bytes::from(data);
         let stream_data = Result::Ok(data);
 
-        self.object_store
+        self.iox_object_store
             .put(
                 file_name,
                 futures::stream::once(async move { stream_data }),
@@ -274,7 +267,7 @@ impl Storage {
         predicate: Option<Expr>,
         projection: Vec<usize>,
         path: Path,
-        store: Arc<ObjectStore>,
+        store: Arc<IoxObjectStore>,
         tx: tokio::sync::mpsc::Sender<ArrowResult<RecordBatch>>,
     ) -> Result<()> {
         // Size of each batch
@@ -353,7 +346,7 @@ impl Storage {
         selection: Selection<'_>,
         schema: SchemaRef,
         path: Path,
-        store: Arc<ObjectStore>,
+        store: Arc<IoxObjectStore>,
     ) -> Result<SendableRecordBatchStream> {
         // fire up a async task that will fetch the parquet file
         // locally, start it executing and send results
@@ -439,32 +432,11 @@ impl TryClone for MemWriter {
     }
 }
 
-/// Location where parquet data goes to.
-///
-/// Schema currently is:
-///
-/// ```text
-/// <writer_id>/<database>/data
-/// ```
-pub(crate) fn data_location(
-    object_store: &ObjectStore,
-    server_id: ServerId,
-    db_name: &str,
-) -> Path {
-    let mut path = object_store.new_path();
-    path.push_dir(server_id.to_string());
-    path.push_dir(db_name.to_string());
-    path.push_dir("data");
-    path
-}
-
 #[cfg(test)]
 mod tests {
-    use std::convert::TryFrom;
-
     use super::*;
     use crate::test_utils::{
-        create_partition_and_database_checkpoint, make_object_store, make_record_batch,
+        create_partition_and_database_checkpoint, make_iox_object_store, make_record_batch,
     };
     use arrow::array::{ArrayRef, StringArray};
     use arrow_util::assert_batches_eq;
@@ -538,12 +510,11 @@ mod tests {
         assert_batches_eq!(&expected, &input_batches);
 
         // create Storage
-        let server_id = ServerId::try_from(1).unwrap();
-        let db_name = Arc::from("my_db");
         let table_name = Arc::from("my_table");
         let partition_key = Arc::from("my_partition");
         let chunk_id = 33;
-        let storage = Storage::new(make_object_store(), server_id);
+        let iox_object_store = make_iox_object_store();
+        let storage = Storage::new(Arc::clone(&iox_object_store));
 
         // write the data in
         let schema = batch.schema();
@@ -569,7 +540,7 @@ mod tests {
         let (path, _file_size_bytes, _metadata) = storage
             .write_to_object_store(
                 ChunkAddr {
-                    db_name,
+                    db_name: iox_object_store.database_name().into(),
                     table_name,
                     partition_key,
                     chunk_id,
@@ -580,13 +551,13 @@ mod tests {
             .await
             .expect("successfully wrote to object store");
 
-        let object_store = Arc::clone(&storage.object_store);
+        let iox_object_store = Arc::clone(&storage.iox_object_store);
         let read_stream = Storage::read_filter(
             &Predicate::default(),
             Selection::All,
             schema,
             path,
-            object_store,
+            iox_object_store,
         )
         .expect("successfully called read_filter");
 
@@ -599,10 +570,10 @@ mod tests {
 
     #[test]
     fn test_locations_are_unique() {
-        let server_id = ServerId::try_from(1).unwrap();
-        let storage = Storage::new(make_object_store(), server_id);
+        let iox_object_store = make_iox_object_store();
+        let storage = Storage::new(Arc::clone(&iox_object_store));
         let chunk_addr = ChunkAddr {
-            db_name: Arc::from("my_db"),
+            db_name: iox_object_store.database_name().into(),
             table_name: Arc::from("my_table"),
             partition_key: Arc::from("my_partition"),
             chunk_id: 13,

--- a/parquet_file/src/storage_testing.rs
+++ b/parquet_file/src/storage_testing.rs
@@ -12,8 +12,8 @@ mod tests {
     use crate::{
         metadata::IoxParquetMetaData,
         test_utils::{
-            chunk_addr, load_parquet_from_store, make_chunk_given_record_batch, make_object_store,
-            make_record_batch, read_data_from_parquet_data,
+            chunk_addr, load_parquet_from_store, make_chunk_given_record_batch,
+            make_iox_object_store, make_record_batch, read_data_from_parquet_data,
         },
     };
 
@@ -31,7 +31,7 @@ mod tests {
 
         ////////////////////
         // Make an OS in memory
-        let store = make_object_store();
+        let store = make_iox_object_store();
 
         ////////////////////
         // Store the data as a chunk and write it to in the object store

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -26,6 +26,7 @@ hashbrown = "0.11"
 influxdb_iox_client = { path = "../influxdb_iox_client" }
 influxdb_line_protocol = { path = "../influxdb_line_protocol" }
 internal_types = { path = "../internal_types" }
+iox_object_store = { path = "../iox_object_store" }
 itertools = "0.10.1"
 lifecycle = { path = "../lifecycle" }
 metrics = { path = "../metrics" }

--- a/server/src/db/catalog/chunk.rs
+++ b/server/src/db/catalog/chunk.rs
@@ -953,7 +953,7 @@ mod tests {
     use mutable_buffer::chunk::ChunkMetrics as MBChunkMetrics;
     use parquet_file::{
         chunk::ParquetChunk,
-        test_utils::{make_chunk as make_parquet_chunk_with_store, make_object_store},
+        test_utils::{make_chunk as make_parquet_chunk_with_store, make_iox_object_store},
     };
 
     #[test]
@@ -1120,8 +1120,8 @@ mod tests {
     }
 
     async fn make_parquet_chunk(addr: ChunkAddr) -> ParquetChunk {
-        let object_store = make_object_store();
-        make_parquet_chunk_with_store(object_store, "foo", addr).await
+        let iox_object_store = make_iox_object_store();
+        make_parquet_chunk_with_store(iox_object_store, "foo", addr).await
     }
 
     fn chunk_addr() -> ChunkAddr {

--- a/server/src/db/lifecycle/write.rs
+++ b/server/src/db/lifecycle/write.rs
@@ -74,7 +74,7 @@ pub(super) fn write_chunk_to_object_store(
     let partition = partition.into_data().partition;
 
     // Create a storage to save data of this chunk
-    let storage = Storage::new(Arc::clone(&db.store), db.server_id);
+    let storage = Storage::new(Arc::clone(&db.iox_object_store));
 
     let catalog_transactions_until_checkpoint = db
         .rules
@@ -140,7 +140,7 @@ pub(super) fn write_chunk_to_object_store(
             let parquet_chunk = Arc::new(
                 ParquetChunk::new(
                     path.clone(),
-                    Arc::clone(&db.store),
+                    Arc::clone(&db.iox_object_store),
                     file_size_bytes,
                     Arc::clone(&parquet_metadata),
                     Arc::clone(&table_name),

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -671,7 +671,7 @@ where
     /// Tells the server the set of rules for a database.
     ///
     /// Waits until the database has initialized or failed to do so
-    pub async fn create_database(&self, rules: DatabaseRules) -> Result<()> {
+    pub async fn create_database(&self, rules: DatabaseRules) -> Result<Arc<Database>> {
         let db_name = rules.name.clone();
         let object_store = self.shared.application.object_store().as_ref();
 
@@ -727,7 +727,7 @@ where
 
         database.wait_for_init().await.context(DatabaseInit)?;
 
-        Ok(())
+        Ok(database)
     }
 
     pub async fn write_pb(&self, database_batch: pb::DatabaseBatch) -> Result<()> {
@@ -1295,6 +1295,7 @@ mod tests {
     };
     use generated_types::database_rules::decode_database_rules;
     use influxdb_line_protocol::parse_lines;
+    use iox_object_store::IoxObjectStore;
     use metrics::TestMetricRegistry;
     use object_store::{path::ObjectStorePath, ObjectStore};
     use parquet_file::catalog::{test_helpers::TestCatalogState, PreservedCatalog};
@@ -1440,7 +1441,7 @@ mod tests {
     async fn create_simple_database<M>(
         server: &Server<M>,
         name: impl Into<String> + Send,
-    ) -> Result<()>
+    ) -> Result<Arc<Database>>
     where
         M: ConnectionManager + Send + Sync,
     {
@@ -2013,11 +2014,11 @@ mod tests {
         // 3. existing one, but rules file is broken => can be wiped, will not exist afterwards
         // 4. existing one, but catalog is broken => can be wiped, will exist afterwards
         // 5. recently (during server lifecycle) created one => cannot be wiped
-        let db_name_existing = DatabaseName::new("db_existing".to_string()).unwrap();
-        let db_name_non_existing = DatabaseName::new("db_non_existing".to_string()).unwrap();
-        let db_name_rules_broken = DatabaseName::new("db_broken_rules".to_string()).unwrap();
-        let db_name_catalog_broken = DatabaseName::new("db_broken_catalog".to_string()).unwrap();
-        let db_name_created = DatabaseName::new("db_created".to_string()).unwrap();
+        let db_name_existing = DatabaseName::new("db_existing").unwrap();
+        let db_name_non_existing = DatabaseName::new("db_non_existing").unwrap();
+        let db_name_rules_broken = DatabaseName::new("db_broken_rules").unwrap();
+        let db_name_catalog_broken = DatabaseName::new("db_broken_catalog").unwrap();
+        let db_name_created = DatabaseName::new("db_created").unwrap();
 
         // setup
         let application = make_application();
@@ -2029,7 +2030,7 @@ mod tests {
         server.set_id(server_id).unwrap();
         server.wait_for_init().await.unwrap();
 
-        create_simple_database(&server, db_name_existing.clone())
+        let existing = create_simple_database(&server, db_name_existing.clone())
             .await
             .expect("failed to create database");
 
@@ -2037,7 +2038,7 @@ mod tests {
             .await
             .expect("failed to create database");
 
-        create_simple_database(&server, db_name_catalog_broken.clone())
+        let catalog_broken = create_simple_database(&server, db_name_catalog_broken.clone())
             .await
             .expect("failed to create database");
 
@@ -2057,15 +2058,11 @@ mod tests {
             .await
             .unwrap();
 
-        let (preserved_catalog, _catalog) = PreservedCatalog::load::<TestCatalogState>(
-            Arc::clone(&store),
-            server_id,
-            db_name_catalog_broken.to_string(),
-            (),
-        )
-        .await
-        .unwrap()
-        .unwrap();
+        let (preserved_catalog, _catalog) =
+            PreservedCatalog::load::<TestCatalogState>(catalog_broken.iox_object_store(), ())
+                .await
+                .unwrap()
+                .unwrap();
 
         parquet_file::catalog::test_helpers::break_catalog_with_weird_version(&preserved_catalog)
             .await;
@@ -2121,27 +2118,23 @@ mod tests {
                 .to_string(),
             "error wiping preserved catalog: database (db_existing) in invalid state (Initialized) for transition (WipePreservedCatalog)"
         );
-        assert!(PreservedCatalog::exists(
-            application.object_store().as_ref(),
-            server_id,
-            db_name_existing.as_str()
-        )
-        .await
-        .unwrap());
+        assert!(PreservedCatalog::exists(&existing.iox_object_store(),)
+            .await
+            .unwrap());
 
         // 2. cannot wipe non-existent DB
         assert!(matches!(
             server.database(&db_name_non_existing).unwrap_err(),
             Error::DatabaseNotFound { .. }
         ));
-        PreservedCatalog::new_empty::<TestCatalogState>(
+        let non_existing_iox_object_store = Arc::new(IoxObjectStore::new(
             Arc::clone(application.object_store()),
             server_id,
-            db_name_non_existing.to_string(),
-            (),
-        )
-        .await
-        .unwrap();
+            &db_name_non_existing,
+        ));
+        PreservedCatalog::new_empty::<TestCatalogState>(non_existing_iox_object_store, ())
+            .await
+            .unwrap();
         assert_eq!(
             server
                 .wipe_preserved_catalog(&db_name_non_existing)
@@ -2182,13 +2175,9 @@ mod tests {
 
         database.wait_for_init().await.unwrap();
 
-        assert!(PreservedCatalog::exists(
-            application.object_store().as_ref(),
-            server_id,
-            &db_name_catalog_broken.to_string()
-        )
-        .await
-        .unwrap());
+        assert!(PreservedCatalog::exists(&catalog_broken.iox_object_store())
+            .await
+            .unwrap());
         assert!(database.init_error().is_none());
 
         assert!(server.db(&db_name_catalog_broken).is_ok());
@@ -2200,7 +2189,7 @@ mod tests {
             .expect("DB writable");
 
         // 5. cannot wipe if DB was just created
-        server
+        let created = server
             .create_database(DatabaseRules::new(db_name_created.clone()))
             .await
             .unwrap();
@@ -2212,35 +2201,32 @@ mod tests {
                 .to_string(),
             "error wiping preserved catalog: database (db_created) in invalid state (Initialized) for transition (WipePreservedCatalog)"
         );
-        assert!(PreservedCatalog::exists(
-            application.object_store().as_ref(),
-            server_id,
-            &db_name_created.to_string()
-        )
-        .await
-        .unwrap());
+        assert!(PreservedCatalog::exists(&created.iox_object_store())
+            .await
+            .unwrap());
     }
 
     #[tokio::test]
     async fn cannot_create_db_when_catalog_is_present() {
         let application = make_application();
         let server_id = ServerId::try_from(1).unwrap();
-        let db_name = "my_db";
+        let db_name = DatabaseName::new("my_db").unwrap();
 
         // setup server
         let server = make_server(Arc::clone(&application));
         server.set_id(server_id).unwrap();
         server.wait_for_init().await.unwrap();
 
-        // create catalog
-        PreservedCatalog::new_empty::<TestCatalogState>(
+        let iox_object_store = Arc::new(IoxObjectStore::new(
             Arc::clone(application.object_store()),
             server_id,
-            db_name.to_string(),
-            (),
-        )
-        .await
-        .unwrap();
+            &db_name,
+        ));
+
+        // create catalog
+        PreservedCatalog::new_empty::<TestCatalogState>(iox_object_store, ())
+            .await
+            .unwrap();
 
         // creating database will now result in an error
         let err = create_simple_database(&server, db_name).await.unwrap_err();


### PR DESCRIPTION
Connects to #2193.

This is a step towards making parquet files relative to the database directory so that we can easily change the database directory.

The weirdest part of this is the `tokio::spawn` with the channel for listing from the object store... this is because in the next step, I'm going to change the iox_object_store's API to only use and return `IoxPath`s that are created within this crate. The current object_store trait API has lifetime restrictions that the output stream's lifetime is tied to the input.... which I don't think is actually needed, but is proving tricky to resolve (I think the cloud_storage crate has some overly restrictive lifetimes, and Rust might need generators to understand what I'm trying to tell it...)
