### PR TITLE
test: restore `write_buffer_errors_propagate`

### DIFF
--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -2235,7 +2235,7 @@ mod tests {
     #[tokio::test]
     async fn write_buffer_errors_propagate() {
         let mut factory = WriteBufferConfigFactory::new();
-        factory.register_alway_fail_mock("my_mock".to_string());
+        factory.register_always_fail_mock("my_mock".to_string());
         let application = Arc::new(ApplicationState::with_write_buffer_factory(
             Arc::new(ObjectStore::new_in_memory()),
             Arc::new(factory),

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -1279,9 +1279,11 @@ mod tests {
     use data_types::{
         chunk_metadata::ChunkAddr,
         database_rules::{
-            HashRing, LifecycleRules, PartitionTemplate, ShardConfig, TemplatePart, NO_SHARD_CONFIG,
+            HashRing, LifecycleRules, PartitionTemplate, ShardConfig, TemplatePart,
+            WriteBufferConnection, NO_SHARD_CONFIG,
         },
     };
+    use entry::test_helpers::lp_to_entry;
     use futures::TryStreamExt;
     use generated_types::database_rules::decode_database_rules;
     use influxdb_line_protocol::parse_lines;
@@ -1299,6 +1301,7 @@ mod tests {
         time::{Duration, Instant},
     };
     use test_helpers::assert_contains;
+    use write_buffer::config::WriteBufferConfigFactory;
 
     const ARBITRARY_DEFAULT_TIME: i64 = 456;
 
@@ -2227,6 +2230,44 @@ mod tests {
         // creating database will now result in an error
         let err = create_simple_database(&server, db_name).await.unwrap_err();
         assert!(matches!(err, Error::CannotCreateDatabase { .. }));
+    }
+
+    #[tokio::test]
+    async fn write_buffer_errors_propagate() {
+        let mut factory = WriteBufferConfigFactory::new();
+        factory.register_alway_fail_mock("my_mock".to_string());
+        let application = Arc::new(ApplicationState::with_write_buffer_factory(
+            Arc::new(ObjectStore::new_in_memory()),
+            Arc::new(factory),
+            None,
+        ));
+        let server = make_server(application);
+        server.set_id(ServerId::try_from(1).unwrap()).unwrap();
+        server.wait_for_init().await.unwrap();
+
+        let db_name = DatabaseName::new("my_db").unwrap();
+        let rules = DatabaseRules {
+            name: db_name.clone(),
+            partition_template: PartitionTemplate {
+                parts: vec![TemplatePart::TimeFormat("YYYY-MM".to_string())],
+            },
+            lifecycle_rules: Default::default(),
+            routing_rules: None,
+            worker_cleanup_avg_sleep: Duration::from_secs(2),
+            write_buffer_connection: Some(WriteBufferConnection::Writing(
+                "mock://my_mock".to_string(),
+            )),
+        };
+        server.create_database(rules.clone()).await.unwrap();
+
+        let entry = lp_to_entry("cpu bar=1 10");
+
+        let res = server.write_entry_local(&db_name, entry).await;
+        assert!(
+            matches!(res, Err(Error::WriteBuffer { .. })),
+            "Expected Err(Error::WriteBuffer {{ .. }}), got: {:?}",
+            res
+        );
     }
 
     // run a sql query against the database, returning the results as record batches

--- a/write_buffer/src/config.rs
+++ b/write_buffer/src/config.rs
@@ -351,39 +351,7 @@ mod tests {
 
     #[test]
     #[should_panic(expected = "Mock with the name 'some_mock' already registered")]
-    fn test_register_mock_twice_panics_normal_normal() {
-        let mut factory = WriteBufferConfigFactory::new();
-
-        let state = MockBufferSharedState::empty_with_n_sequencers(1);
-        let mock_name = "some_mock";
-        factory.register_mock(mock_name.to_string(), state.clone());
-        factory.register_mock(mock_name.to_string(), state);
-    }
-
-    #[test]
-    #[should_panic(expected = "Mock with the name 'some_mock' already registered")]
-    fn test_register_mock_twice_panics_failing_failing() {
-        let mut factory = WriteBufferConfigFactory::new();
-
-        let mock_name = "some_mock";
-        factory.register_always_fail_mock(mock_name.to_string());
-        factory.register_always_fail_mock(mock_name.to_string());
-    }
-
-    #[test]
-    #[should_panic(expected = "Mock with the name 'some_mock' already registered")]
-    fn test_register_mock_twice_panics_normal_failing() {
-        let mut factory = WriteBufferConfigFactory::new();
-
-        let state = MockBufferSharedState::empty_with_n_sequencers(1);
-        let mock_name = "some_mock";
-        factory.register_mock(mock_name.to_string(), state);
-        factory.register_always_fail_mock(mock_name.to_string());
-    }
-
-    #[test]
-    #[should_panic(expected = "Mock with the name 'some_mock' already registered")]
-    fn test_register_mock_twice_panics_failing_normal() {
+    fn test_register_mock_twice_panics() {
         let mut factory = WriteBufferConfigFactory::new();
 
         let state = MockBufferSharedState::empty_with_n_sequencers(1);

--- a/write_buffer/src/config.rs
+++ b/write_buffer/src/config.rs
@@ -58,7 +58,7 @@ impl WriteBufferConfigFactory {
     ///
     /// # Panics
     /// When mock with identical name is already registered.
-    pub fn register_alway_fail_mock(&mut self, name: String) {
+    pub fn register_always_fail_mock(&mut self, name: String) {
         self.set_mock(name, Mock::AlwaysFailing);
     }
 
@@ -287,7 +287,7 @@ mod tests {
         let mut factory = WriteBufferConfigFactory::new();
 
         let mock_name = "some_mock";
-        factory.register_alway_fail_mock(mock_name.to_string());
+        factory.register_always_fail_mock(mock_name.to_string());
 
         let server_id = ServerId::try_from(1).unwrap();
 
@@ -320,7 +320,7 @@ mod tests {
         let mut factory = WriteBufferConfigFactory::new();
 
         let mock_name = "some_mock";
-        factory.register_alway_fail_mock(mock_name.to_string());
+        factory.register_always_fail_mock(mock_name.to_string());
 
         let server_id = ServerId::try_from(1).unwrap();
 
@@ -366,8 +366,8 @@ mod tests {
         let mut factory = WriteBufferConfigFactory::new();
 
         let mock_name = "some_mock";
-        factory.register_alway_fail_mock(mock_name.to_string());
-        factory.register_alway_fail_mock(mock_name.to_string());
+        factory.register_always_fail_mock(mock_name.to_string());
+        factory.register_always_fail_mock(mock_name.to_string());
     }
 
     #[test]
@@ -378,7 +378,7 @@ mod tests {
         let state = MockBufferSharedState::empty_with_n_sequencers(1);
         let mock_name = "some_mock";
         factory.register_mock(mock_name.to_string(), state);
-        factory.register_alway_fail_mock(mock_name.to_string());
+        factory.register_always_fail_mock(mock_name.to_string());
     }
 
     #[test]
@@ -388,7 +388,7 @@ mod tests {
 
         let state = MockBufferSharedState::empty_with_n_sequencers(1);
         let mock_name = "some_mock";
-        factory.register_alway_fail_mock(mock_name.to_string());
+        factory.register_always_fail_mock(mock_name.to_string());
         factory.register_mock(mock_name.to_string(), state);
     }
 }

--- a/write_buffer/src/config.rs
+++ b/write_buffer/src/config.rs
@@ -11,7 +11,10 @@ use data_types::{
 use crate::{
     core::{WriteBufferError, WriteBufferReading, WriteBufferWriting},
     kafka::{KafkaBufferConsumer, KafkaBufferProducer},
-    mock::{MockBufferForReading, MockBufferForWriting, MockBufferSharedState},
+    mock::{
+        MockBufferForReading, MockBufferForReadingThatAlwaysErrors, MockBufferForWriting,
+        MockBufferForWritingThatAlwaysErrors, MockBufferSharedState,
+    },
 };
 
 /// Prefix for mocked connections.
@@ -23,10 +26,16 @@ pub enum WriteBufferConfig {
     Reading(Arc<tokio::sync::Mutex<Box<dyn WriteBufferReading>>>),
 }
 
+#[derive(Debug, Clone)]
+enum Mock {
+    Normal(MockBufferSharedState),
+    AlwaysFailing,
+}
+
 /// Factory that creates [`WriteBufferConfig`] from [`DatabaseRules`].
 #[derive(Debug)]
 pub struct WriteBufferConfigFactory {
-    mocks: BTreeMap<String, MockBufferSharedState>,
+    mocks: BTreeMap<String, Mock>,
 }
 
 impl WriteBufferConfigFactory {
@@ -42,9 +51,21 @@ impl WriteBufferConfigFactory {
     /// # Panics
     /// When mock with identical name is already registered.
     pub fn register_mock(&mut self, name: String, state: MockBufferSharedState) {
+        self.set_mock(name, Mock::Normal(state));
+    }
+
+    /// Registers new mock that always fail.
+    ///
+    /// # Panics
+    /// When mock with identical name is already registered.
+    pub fn register_alway_fail_mock(&mut self, name: String) {
+        self.set_mock(name, Mock::AlwaysFailing);
+    }
+
+    fn set_mock(&mut self, name: String, mock: Mock) {
         match self.mocks.entry(name) {
             Entry::Vacant(v) => {
-                v.insert(state);
+                v.insert(mock);
             }
             Entry::Occupied(o) => {
                 panic!("Mock with the name '{}' already registered", o.key());
@@ -52,7 +73,7 @@ impl WriteBufferConfigFactory {
         }
     }
 
-    fn get_mock(&self, name: &str) -> Result<MockBufferSharedState, WriteBufferError> {
+    fn get_mock(&self, name: &str) -> Result<Mock, WriteBufferError> {
         self.mocks
             .get(name)
             .cloned()
@@ -71,9 +92,16 @@ impl WriteBufferConfigFactory {
             Some(WriteBufferConnection::Writing(conn)) => {
                 let writer: Arc<dyn WriteBufferWriting> =
                     if let Some(conn) = conn.strip_prefix(PREFIX_MOCK) {
-                        let state = self.get_mock(conn)?;
-                        let mock_buffer = MockBufferForWriting::new(state);
-                        Arc::new(mock_buffer) as _
+                        match self.get_mock(conn)? {
+                            Mock::Normal(state) => {
+                                let mock_buffer = MockBufferForWriting::new(state);
+                                Arc::new(mock_buffer) as _
+                            }
+                            Mock::AlwaysFailing => {
+                                let mock_buffer = MockBufferForWritingThatAlwaysErrors {};
+                                Arc::new(mock_buffer) as _
+                            }
+                        }
                     } else {
                         let kafka_buffer = KafkaBufferProducer::new(conn, name)?;
                         Arc::new(kafka_buffer) as _
@@ -84,9 +112,16 @@ impl WriteBufferConfigFactory {
             Some(WriteBufferConnection::Reading(conn)) => {
                 let reader: Box<dyn WriteBufferReading> =
                     if let Some(conn) = conn.strip_prefix(PREFIX_MOCK) {
-                        let state = self.get_mock(conn)?;
-                        let mock_buffer = MockBufferForReading::new(state);
-                        Box::new(mock_buffer) as _
+                        match self.get_mock(conn)? {
+                            Mock::Normal(state) => {
+                                let mock_buffer = MockBufferForReading::new(state);
+                                Box::new(mock_buffer) as _
+                            }
+                            Mock::AlwaysFailing => {
+                                let mock_buffer = MockBufferForReadingThatAlwaysErrors {};
+                                Box::new(mock_buffer) as _
+                            }
+                        }
                     } else {
                         let kafka_buffer = KafkaBufferConsumer::new(conn, server_id, name).await?;
                         Box::new(kafka_buffer) as _
@@ -247,14 +282,113 @@ mod tests {
         assert!(err.to_string().starts_with("Unknown mock ID:"));
     }
 
+    #[tokio::test]
+    async fn test_writing_mock_failing() {
+        let mut factory = WriteBufferConfigFactory::new();
+
+        let mock_name = "some_mock";
+        factory.register_alway_fail_mock(mock_name.to_string());
+
+        let server_id = ServerId::try_from(1).unwrap();
+
+        let mut rules = DatabaseRules::new(DatabaseName::new("foo").unwrap());
+        rules.write_buffer_connection = Some(WriteBufferConnection::Writing(format!(
+            "mock://{}",
+            mock_name,
+        )));
+
+        if let WriteBufferConfig::Writing(conn) = factory
+            .new_config(server_id, &rules)
+            .await
+            .unwrap()
+            .unwrap()
+        {
+            assert_eq!(conn.type_name(), "mock_failing");
+        } else {
+            panic!("not a writing connection");
+        }
+
+        // will error when state is unknown
+        rules.write_buffer_connection =
+            Some(WriteBufferConnection::Writing("mock://bar".to_string()));
+        let err = factory.new_config(server_id, &rules).await.unwrap_err();
+        assert!(err.to_string().starts_with("Unknown mock ID:"));
+    }
+
+    #[tokio::test]
+    async fn test_reading_mock_failing() {
+        let mut factory = WriteBufferConfigFactory::new();
+
+        let mock_name = "some_mock";
+        factory.register_alway_fail_mock(mock_name.to_string());
+
+        let server_id = ServerId::try_from(1).unwrap();
+
+        let mut rules = DatabaseRules::new(DatabaseName::new("foo").unwrap());
+        rules.write_buffer_connection = Some(WriteBufferConnection::Reading(format!(
+            "mock://{}",
+            mock_name,
+        )));
+
+        if let WriteBufferConfig::Reading(conn) = factory
+            .new_config(server_id, &rules)
+            .await
+            .unwrap()
+            .unwrap()
+        {
+            let conn = conn.lock().await;
+            assert_eq!(conn.type_name(), "mock_failing");
+        } else {
+            panic!("not a reading connection");
+        }
+
+        // will error when state is unknown
+        rules.write_buffer_connection =
+            Some(WriteBufferConnection::Reading("mock://bar".to_string()));
+        let err = factory.new_config(server_id, &rules).await.unwrap_err();
+        assert!(err.to_string().starts_with("Unknown mock ID:"));
+    }
+
     #[test]
     #[should_panic(expected = "Mock with the name 'some_mock' already registered")]
-    fn test_register_mock_twice_panics() {
+    fn test_register_mock_twice_panics_normal_normal() {
         let mut factory = WriteBufferConfigFactory::new();
 
         let state = MockBufferSharedState::empty_with_n_sequencers(1);
         let mock_name = "some_mock";
         factory.register_mock(mock_name.to_string(), state.clone());
+        factory.register_mock(mock_name.to_string(), state);
+    }
+
+    #[test]
+    #[should_panic(expected = "Mock with the name 'some_mock' already registered")]
+    fn test_register_mock_twice_panics_failing_failing() {
+        let mut factory = WriteBufferConfigFactory::new();
+
+        let mock_name = "some_mock";
+        factory.register_alway_fail_mock(mock_name.to_string());
+        factory.register_alway_fail_mock(mock_name.to_string());
+    }
+
+    #[test]
+    #[should_panic(expected = "Mock with the name 'some_mock' already registered")]
+    fn test_register_mock_twice_panics_normal_failing() {
+        let mut factory = WriteBufferConfigFactory::new();
+
+        let state = MockBufferSharedState::empty_with_n_sequencers(1);
+        let mock_name = "some_mock";
+        factory.register_mock(mock_name.to_string(), state);
+        factory.register_alway_fail_mock(mock_name.to_string());
+    }
+
+    #[test]
+    #[should_panic(expected = "Mock with the name 'some_mock' already registered")]
+    fn test_register_mock_twice_panics_failing_normal() {
+        let mut factory = WriteBufferConfigFactory::new();
+
+        let state = MockBufferSharedState::empty_with_n_sequencers(1);
+        let mock_name = "some_mock";
+        factory.register_alway_fail_mock(mock_name.to_string());
         factory.register_mock(mock_name.to_string(), state);
     }
 }


### PR DESCRIPTION
This was removed in #2203 due to insufficient mocking capabilities.