### PR TITLE
refactor: remove display methods, use fmt::Display instead.

### DIFF
--- a/iox_object_store/src/lib.rs
+++ b/iox_object_store/src/lib.rs
@@ -186,7 +186,7 @@ mod tests {
         let iox_object_store = IoxObjectStore::new(make_object_store(), server_id, &database_name);
         assert_eq!(
             iox_object_store.catalog_path().to_string(),
-            "1/clouds/transactions/"
+            "mem:1/clouds/transactions/"
         );
     }
 
@@ -195,6 +195,6 @@ mod tests {
         let server_id = make_server_id();
         let database_name = DatabaseName::new("clouds").unwrap();
         let iox_object_store = IoxObjectStore::new(make_object_store(), server_id, &database_name);
-        assert_eq!(iox_object_store.data_path().to_string(), "1/clouds/data/");
+        assert_eq!(iox_object_store.data_path().to_string(), "mem:1/clouds/data/");
     }
 }

--- a/iox_object_store/src/lib.rs
+++ b/iox_object_store/src/lib.rs
@@ -185,7 +185,7 @@ mod tests {
         let database_name = DatabaseName::new("clouds").unwrap();
         let iox_object_store = IoxObjectStore::new(make_object_store(), server_id, &database_name);
         assert_eq!(
-            iox_object_store.catalog_path().display(),
+            iox_object_store.catalog_path().to_string(),
             "1/clouds/transactions/"
         );
     }
@@ -195,6 +195,6 @@ mod tests {
         let server_id = make_server_id();
         let database_name = DatabaseName::new("clouds").unwrap();
         let iox_object_store = IoxObjectStore::new(make_object_store(), server_id, &database_name);
-        assert_eq!(iox_object_store.data_path().display(), "1/clouds/data/");
+        assert_eq!(iox_object_store.data_path().to_string(), "1/clouds/data/");
     }
 }

--- a/iox_object_store/src/lib.rs
+++ b/iox_object_store/src/lib.rs
@@ -195,6 +195,9 @@ mod tests {
         let server_id = make_server_id();
         let database_name = DatabaseName::new("clouds").unwrap();
         let iox_object_store = IoxObjectStore::new(make_object_store(), server_id, &database_name);
-        assert_eq!(iox_object_store.data_path().to_string(), "mem:1/clouds/data/");
+        assert_eq!(
+            iox_object_store.data_path().to_string(),
+            "mem:1/clouds/data/"
+        );
     }
 }

--- a/object_store/src/memory.rs
+++ b/object_store/src/memory.rs
@@ -80,7 +80,7 @@ impl ObjectStoreApi for InMemory {
             .get(location)
             .cloned()
             .context(NoDataInMemory {
-                location: format!("{}", location),
+                location: location.to_string(),
             })?;
 
         Ok(futures::stream::once(async move { Ok(data) }).boxed())

--- a/object_store/src/memory.rs
+++ b/object_store/src/memory.rs
@@ -1,8 +1,6 @@
 //! This module contains the IOx implementation for using memory as the object
 //! store.
-use crate::{
-    path::parsed::DirsAndFileName, ListResult, ObjectMeta, ObjectStoreApi, ObjectStorePath,
-};
+use crate::{path::parsed::DirsAndFileName, ListResult, ObjectMeta, ObjectStoreApi};
 use async_trait::async_trait;
 use bytes::Bytes;
 use chrono::Utc;
@@ -82,7 +80,7 @@ impl ObjectStoreApi for InMemory {
             .get(location)
             .cloned()
             .context(NoDataInMemory {
-                location: location.display(),
+                location: format!("{}", location),
             })?;
 
         Ok(futures::stream::once(async move { Ok(data) }).boxed())

--- a/object_store/src/path.rs
+++ b/object_store/src/path.rs
@@ -41,11 +41,6 @@ pub trait ObjectStorePath:
 
     /// Push a bunch of parts as directories in one go.
     fn push_all_dirs<'a>(&mut self, parts: impl AsRef<[&'a str]>);
-
-    /// Like `std::path::Path::display, converts an `ObjectStorePath` to a
-    /// `String` suitable for printing; not suitable for sending to
-    /// APIs.
-    fn display(&self) -> String;
 }
 
 /// Defines which object stores use which path logic.
@@ -99,16 +94,6 @@ impl ObjectStorePath for Path {
             Self::GoogleCloudStorage(path) => path.push_all_dirs(parts),
             Self::InMemory(path) => path.push_all_dirs(parts),
             Self::MicrosoftAzure(path) => path.push_all_dirs(parts),
-        }
-    }
-
-    fn display(&self) -> String {
-        match self {
-            Self::AmazonS3(path) => path.display(),
-            Self::File(path) => path.display(),
-            Self::GoogleCloudStorage(path) => path.display(),
-            Self::InMemory(path) => path.display(),
-            Self::MicrosoftAzure(path) => path.display(),
         }
     }
 }

--- a/object_store/src/path/cloud.rs
+++ b/object_store/src/path/cloud.rs
@@ -23,10 +23,6 @@ impl ObjectStorePath for CloudPath {
     fn push_all_dirs<'a>(&mut self, parts: impl AsRef<[&'a str]>) {
         self.inner = mem::take(&mut self.inner).push_all_dirs(parts);
     }
-
-    fn display(&self) -> String {
-        self.to_raw()
-    }
 }
 
 impl CloudPath {

--- a/object_store/src/path/file.rs
+++ b/object_store/src/path/file.rs
@@ -24,10 +24,6 @@ impl ObjectStorePath for FilePath {
     fn push_all_dirs<'a>(&mut self, parts: impl AsRef<[&'a str]>) {
         self.inner = mem::take(&mut self.inner).push_all_dirs(parts);
     }
-
-    fn display(&self) -> String {
-        self.to_raw().display().to_string()
-    }
 }
 
 impl Ord for FilePath {
@@ -129,7 +125,7 @@ impl From<DirsAndFileName> for FilePath {
 
 impl fmt::Display for FilePath {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
-        write!(f, "{}", self.display())
+        write!(f, "{}", self.to_raw().display().to_string())
     }
 }
 
@@ -489,12 +485,12 @@ mod tests {
         let expected_display = a_path_buf.display().to_string();
         let a_file_path = FilePath::raw(&a_path_buf, false);
 
-        assert_eq!(a_file_path.display(), expected_display);
+        assert_eq!(a_file_path.to_string(), expected_display);
 
         let a_parts: DirsAndFileName = a_file_path.into();
         let a_parsed: FilePath = a_parts.into();
 
-        assert_eq!(a_parsed.display(), expected_display);
+        assert_eq!(a_parsed.to_string(), expected_display);
     }
 
     #[test]

--- a/object_store/src/path/parsed.rs
+++ b/object_store/src/path/parsed.rs
@@ -29,8 +29,10 @@ impl ObjectStorePath for DirsAndFileName {
         self.directories
             .extend(parts.as_ref().iter().map(|&v| v.into()));
     }
+}
 
-    fn display(&self) -> String {
+impl fmt::Display for DirsAndFileName {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         let mut s = self
             .directories
             .iter()
@@ -43,13 +45,8 @@ impl ObjectStorePath for DirsAndFileName {
         if let Some(file_name) = &self.file_name {
             s.push_str(file_name.encoded());
         }
-        s
-    }
-}
 
-impl fmt::Display for DirsAndFileName {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
-        write!(f, "{}", self.display())
+        write!(f, "{}", s)
     }
 }
 

--- a/parquet_file/src/catalog.rs
+++ b/parquet_file/src/catalog.rs
@@ -2275,7 +2275,7 @@ mod tests {
         let mut files: Vec<(String, IoxParquetMetaData)> = state
             .parquet_files
             .values()
-            .map(|info| (info.path.display(), info.metadata.as_ref().clone()))
+            .map(|info| (info.path.to_string(), info.metadata.as_ref().clone()))
             .collect();
         files.sort_by_key(|(path, _)| path.clone());
         files
@@ -2607,9 +2607,9 @@ mod tests {
             .try_concat()
             .await
             .unwrap();
-        let mut files: Vec<_> = files.iter().map(|path| path.display()).collect();
+        let mut files: Vec<_> = files.iter().map(|path| path.to_string()).collect();
         files.sort();
-        assert_eq!(files, vec![path.display()]);
+        assert_eq!(files, vec![path.to_string()]);
     }
 
     #[tokio::test]

--- a/parquet_file/src/cleanup.rs
+++ b/parquet_file/src/cleanup.rs
@@ -109,7 +109,7 @@ pub async fn delete_files(catalog: &PreservedCatalog, files: &[Path]) -> Result<
     let store = catalog.iox_object_store();
 
     for path in files {
-        info!(path = %path.to_string(), "Delete file");
+        info!(%path, "Delete file");
         store.delete(path).await.context(WriteError)?;
     }
 

--- a/parquet_file/src/cleanup.rs
+++ b/parquet_file/src/cleanup.rs
@@ -5,7 +5,7 @@ use crate::catalog::{CatalogParquetInfo, CatalogState, PreservedCatalog};
 use futures::TryStreamExt;
 use iox_object_store::IoxObjectStore;
 use object_store::{
-    path::{parsed::DirsAndFileName, ObjectStorePath, Path},
+    path::{parsed::DirsAndFileName, Path},
     ObjectStore, ObjectStoreApi,
 };
 use observability_deps::tracing::info;
@@ -109,7 +109,7 @@ pub async fn delete_files(catalog: &PreservedCatalog, files: &[Path]) -> Result<
     let store = catalog.iox_object_store();
 
     for path in files {
-        info!(path = %path.display(), "Delete file");
+        info!(path = %path.to_string(), "Delete file");
         store.delete(path).await.context(WriteError)?;
     }
 

--- a/parquet_file/src/cleanup.rs
+++ b/parquet_file/src/cleanup.rs
@@ -152,8 +152,7 @@ mod tests {
     use std::{collections::HashSet, sync::Arc};
 
     use bytes::Bytes;
-    use data_types::server_id::ServerId;
-    use object_store::path::{ObjectStorePath, Path};
+    use object_store::path::Path;
     use tokio::sync::RwLock;
 
     use super::*;
@@ -217,7 +216,7 @@ mod tests {
             };
             transaction.add_parquet(&info).unwrap();
             transaction.remove_parquet(&info.path);
-            let path_string = object_store
+            let path_string = iox_object_store
                 .path_from_dirs_and_filename(info.path.clone())
                 .to_string();
             paths_keep.push(path_string);
@@ -230,7 +229,7 @@ mod tests {
             paths_keep.push(path.to_string());
 
             // an untracked parquet file => delete
-            let (path, _md) = make_metadata(&object_store, "foo", chunk_addr(3)).await;
+            let (path, _md) = make_metadata(&iox_object_store, "foo", chunk_addr(3)).await;
             paths_delete.push(path.to_string());
 
             transaction.commit().await.unwrap();
@@ -292,7 +291,7 @@ mod tests {
 
                     drop(guard);
 
-                    object_store
+                    iox_object_store
                         .path_from_dirs_and_filename(info.path)
                         .to_string()
                 },

--- a/server/src/database.rs
+++ b/server/src/database.rs
@@ -104,7 +104,7 @@ impl Database {
     ///
     /// This is backed by an existing database, which was [created](Self::create) some time in the past.
     pub fn new(application: Arc<ApplicationState>, config: DatabaseConfig) -> Self {
-        info!(db_name=%config.name, store_prefix=%config.store_prefix.display(), "new database");
+        info!(db_name=%config.name, store_prefix=%config.store_prefix.to_string(), "new database");
 
         let iox_object_store = Arc::new(IoxObjectStore::new(
             Arc::clone(application.object_store()),

--- a/server/src/db.rs
+++ b/server/src/db.rs
@@ -3910,7 +3910,9 @@ mod tests {
                 .parquet_files
                 .keys()
                 .map(|p| {
-                    object_store.path_from_dirs_and_filename(p.clone()).to_string()
+                    object_store
+                        .path_from_dirs_and_filename(p.clone())
+                        .to_string()
                 })
                 .collect();
             tmp.sort();

--- a/server/src/db.rs
+++ b/server/src/db.rs
@@ -3909,7 +3909,9 @@ mod tests {
             let mut tmp: Vec<String> = catalog
                 .parquet_files
                 .keys()
-                .map(|p| p.to_string())
+                .map(|p| {
+                    object_store.path_from_dirs_and_filename(p.clone()).to_string()
+                })
                 .collect();
             tmp.sort();
             tmp

--- a/server/src/db.rs
+++ b/server/src/db.rs
@@ -1500,7 +1500,7 @@ mod tests {
     use futures::{stream, StreamExt, TryStreamExt};
     use internal_types::{schema::Schema, selection::Selection};
     use object_store::{
-        path::{parts::PathPart, ObjectStorePath, Path},
+        path::{parts::PathPart, Path},
         ObjectStore, ObjectStoreApi,
     };
     use parquet_file::{
@@ -3894,7 +3894,7 @@ mod tests {
             let chunk = db.chunk(table_name, partition_key, *chunk_id).unwrap();
             let chunk = chunk.read();
             if let ChunkStage::Persisted { parquet, .. } = chunk.stage() {
-                paths_expected.push(parquet.path().display());
+                paths_expected.push(parquet.path().to_string());
             } else {
                 panic!("Wrong chunk state.");
             }
@@ -3906,7 +3906,11 @@ mod tests {
                 .unwrap()
                 .unwrap();
         let paths_actual = {
-            let mut tmp: Vec<String> = catalog.parquet_files.keys().map(|p| p.display()).collect();
+            let mut tmp: Vec<String> = catalog
+                .parquet_files
+                .keys()
+                .map(|p| p.to_string())
+                .collect();
             tmp.sort();
             tmp
         };
@@ -4009,12 +4013,12 @@ mod tests {
         ));
         let path_delete = object_store.path_from_dirs_and_filename(path);
         create_empty_file(&object_store, &path_delete).await;
-        let path_delete = path_delete.display();
+        let path_delete = path_delete.to_string();
 
         // ==================== check: all files are there ====================
         let all_files = get_object_store_files(&object_store).await;
         for path in &paths_keep {
-            assert!(all_files.contains(&path.display()));
+            assert!(all_files.contains(&path.to_string()));
         }
 
         // ==================== do: start background task loop ====================
@@ -4043,7 +4047,7 @@ mod tests {
         let all_files = get_object_store_files(&object_store).await;
         assert!(!all_files.contains(&path_delete));
         for path in &paths_keep {
-            assert!(all_files.contains(&path.display()));
+            assert!(all_files.contains(&path.to_string()));
         }
     }
 
@@ -4262,7 +4266,7 @@ mod tests {
             .await
             .unwrap()
             .iter()
-            .map(|p| p.display())
+            .map(|p| p.to_string())
             .collect()
     }
 


### PR DESCRIPTION
This is follow up of #2223  that removes obsolete `display` methods and use `fmt::Display` instead.

- [x] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb_iox/blob/main/README.md).
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
