### PR TITLE
chore: revert panic commit

### DIFF
--- a/data_types/src/partition_metadata.rs
+++ b/data_types/src/partition_metadata.rs
@@ -1,6 +1,7 @@
 //! This module contains structs that describe the metadata for a partition
 //! including schema, summary statistics, and file locations in storage.
 
+use observability_deps::tracing::warn;
 use serde::{Deserialize, Serialize};
 use std::{
     borrow::{Borrow, Cow},
@@ -106,15 +107,12 @@ impl TableSummary {
 
         // Validate that the counts are consistent across columns
         for c in &self.columns {
-            assert_eq!(
-                c.total_count(),
-                count,
-                "Mismatch counts in table {} column {}, expected {} got {}",
-                self.name,
-                c.name,
-                count,
-                c.total_count()
-            )
+            // Restore to assert when https://github.com/influxdata/influxdb_iox/issues/2124 is fixed
+            if c.total_count() != count {
+                warn!(table_name=%self.name, column_name=%c.name,
+                      column_count=c.total_count(), previous_count=count,
+                      "Mismatch in statistics count, see #2124");
+            }
         }
         count
     }


### PR DESCRIPTION
Closes #

 git revert -n db5fd935dd37ca8dec34a86e525dcd5e5823c9c5
that revert [this PR](https://github.com/influxdata/influxdb_iox/pull/2250/commits/03da4dee6fbb19b4530fabcd8f8ff026820b2387) that cause panic in Query-3000


- [x] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb_iox/blob/main/README.md).
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
