### PR TITLE
docs: Remove the description of unused commands in cli

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -74,15 +74,6 @@ Examples:
     # Run InfluxDB IOx with full debug logging specified with RUST_LOG
     RUST_LOG=debug influxdb_iox run
 
-    # converts line protocol formatted data in temperature.lp to out.parquet
-    influxdb_iox convert temperature.lp out.parquet
-
-    # Dumps metadata information about 000000000013.tsm to stdout
-    influxdb_iox meta 000000000013.tsm
-
-    # Dumps storage statistics about out.parquet to stdout
-    influxdb_iox stats out.parquet
-
 Command are generally structured in the form:
     <type of object> <action> <arguments>
 


### PR DESCRIPTION
Describe your proposed changes here.

The commands `convert`, `meta` and `stats` have been removed by #1639. 
This PR removes the description in the command line. 

- [x] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb_iox/blob/main/README.md).
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
