### PR TITLE
feat: add metric to track total row groups

### DIFF
--- a/server/src/db.rs
+++ b/server/src/db.rs
@@ -2131,7 +2131,7 @@ mod tests {
 
         // verify chunk size updated (chunk moved from closing to moving to moved)
         catalog_chunk_size_bytes_metric_eq(&test_db.metric_registry, "mutable_buffer", 0).unwrap();
-        let expected_read_buffer_size = 1820;
+        let expected_read_buffer_size = 1916;
         catalog_chunk_size_bytes_metric_eq(
             &test_db.metric_registry,
             "read_buffer",
@@ -2382,7 +2382,7 @@ mod tests {
             .unwrap();
 
         // verify chunk size updated (chunk moved from moved to writing to written)
-        catalog_chunk_size_bytes_metric_eq(&test_db.metric_registry, "read_buffer", 1820).unwrap();
+        catalog_chunk_size_bytes_metric_eq(&test_db.metric_registry, "read_buffer", 1916).unwrap();
 
         // drop, the chunk from the read buffer
         db.drop_chunk("cpu", partition_key, mb_chunk.id())
@@ -2532,7 +2532,7 @@ mod tests {
                 ("svr_id", "1"),
             ])
             .histogram()
-            .sample_sum_eq(3532.0)
+            .sample_sum_eq(3628.0)
             .unwrap();
 
         let rb = collect_read_filter(&rb_chunk).await;
@@ -2642,7 +2642,7 @@ mod tests {
                 ("svr_id", "10"),
             ])
             .histogram()
-            .sample_sum_eq(2499.0)
+            .sample_sum_eq(2595.0)
             .unwrap();
 
         // while MB and RB chunk are identical, the PQ chunk is a new one (split off)
@@ -2763,7 +2763,7 @@ mod tests {
                 ("svr_id", "10"),
             ])
             .histogram()
-            .sample_sum_eq(2499.0)
+            .sample_sum_eq(2595.0)
             .unwrap();
 
         // Unload RB chunk but keep it in OS
@@ -3403,7 +3403,7 @@ mod tests {
                 id: 2,
                 storage: ChunkStorage::ReadBufferAndObjectStore,
                 lifecycle_action,
-                memory_bytes: 3544,       // size of RB and OS chunks
+                memory_bytes: 3640,       // size of RB and OS chunks
                 object_store_bytes: 1577, // size of parquet file
                 row_count: 2,
                 time_of_last_access: None,
@@ -3454,7 +3454,7 @@ mod tests {
         }
 
         assert_eq!(db.catalog.metrics().memory().mutable_buffer(), 2486 + 87);
-        assert_eq!(db.catalog.metrics().memory().read_buffer(), 2670);
+        assert_eq!(db.catalog.metrics().memory().read_buffer(), 2766);
         assert_eq!(db.catalog.metrics().memory().object_store(), 874);
     }
 


### PR DESCRIPTION
Towards #2317

IOx is now utilising a feature of the Read Buffer that allows a chunk to contain multiple row groups. This needs to be observable via metrics. Whilst tracking the distribution of row groups in chunks would be ideal (outlined in #2317) I am starting with just a gauge to track overall number of row groups in the Read Buffer.
