### PR TITLE
feat: Enable freed memory tracking in heappy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1445,7 +1445,7 @@ dependencies = [
 [[package]]
 name = "heappy"
 version = "0.1.0"
-source = "git+https://github.com/mkmik/heappy?rev=39530c987aecda0b2d76503e8b5bb33d8a93f384#39530c987aecda0b2d76503e8b5bb33d8a93f384"
+source = "git+https://github.com/mkmik/heappy?rev=aed37ab50a70c3f0a7a8bd1c51d28d3d8050461f#aed37ab50a70c3f0a7a8bd1c51d28d3d8050461f"
 dependencies = [
  "backtrace",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ datafusion = { path = "datafusion" }
 data_types = { path = "data_types" }
 entry = { path = "entry" }
 generated_types = { path = "generated_types" }
-heappy = { git = "https://github.com/mkmik/heappy", rev = "39530c987aecda0b2d76503e8b5bb33d8a93f384", features = ["enable_heap_profiler", "jemalloc_shim"], optional = true}
+heappy = { git = "https://github.com/mkmik/heappy", rev = "aed37ab50a70c3f0a7a8bd1c51d28d3d8050461f", features = ["enable_heap_profiler", "jemalloc_shim", "measure_free"], optional = true}
 
 influxdb_iox_client = { path = "influxdb_iox_client", features = ["format"] }
 influxdb_line_protocol = { path = "influxdb_line_protocol" }


### PR DESCRIPTION
In https://github.com/mkmik/heappy/commit/aed37ab50a70c3f0a7a8bd1c51d28d3d8050461f I fixed the main
problem that rendered free tracking useless: the allocator was actually allocating more bytes than requested; we were tracking the amount of memory requested by the user and not the size of the block that was returned to the user. However, when we were tracking a call to free we used the size of the memory block which was bigger than the amount that was tracked; this led to negative numbers of "in use memory".

