### PR TITLE
fix: Make allocs profile record all allocations

### DIFF
--- a/src/influxdb_ioxd/http/heappy.rs
+++ b/src/influxdb_ioxd/http/heappy.rs
@@ -6,18 +6,18 @@ use heappy::{self, HeapReport};
 use observability_deps::tracing::info;
 use tokio::time::Duration;
 
-pub(crate) async fn dump_heappy_rsprof(seconds: u64, frequency: i32) -> HeapReport {
-    let guard = heappy::HeapProfilerGuard::new(frequency as usize);
+pub(crate) async fn dump_heappy_rsprof(seconds: u64, interval: i32) -> HeapReport {
+    let guard = heappy::HeapProfilerGuard::new(interval as usize);
     info!(
-        "start heappy profiling {} seconds with frequency {} /s",
-        seconds, frequency
+        "start allocs profiling {} seconds with interval {} bytes",
+        seconds, interval
     );
 
     tokio::time::sleep(Duration::from_secs(seconds)).await;
 
     info!(
-        "done heappy  profiling {} seconds with frequency {} /s",
-        seconds, frequency
+        "done allocs profiling {} seconds with interval {} bytes",
+        seconds, interval
     );
 
     guard.report()


### PR DESCRIPTION
Rename `frequency` to `interval` and set the default to `1`, which means that
every allocation will be counted.

Before this PR, we were incorrectly reusing the same "frequency" parameter (and related default of 99)
which meant that we were skipping small allocations that.

The sampling interval is a number of bytes that have to cumulatively allocated for a sample to be taken.
For example if the sampling interval is 99, and you're doing a million of 40 bytes allocations, the allocations profile will account for 16MB instead of 40MB. Heappy will adjust the estimate for sampled recordings, but now that feature is not yet implemented.
