### PR TITLE
feat(iox): Upgrade heappy to present free memory events

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1445,7 +1445,7 @@ dependencies = [
 [[package]]
 name = "heappy"
 version = "0.1.0"
-source = "git+https://github.com/mkmik/heappy?rev=aed37ab50a70c3f0a7a8bd1c51d28d3d8050461f#aed37ab50a70c3f0a7a8bd1c51d28d3d8050461f"
+source = "git+https://github.com/mkmik/heappy?rev=c8fe1fefbaefd536b0137435fce8d90a98a184de#c8fe1fefbaefd536b0137435fce8d90a98a184de"
 dependencies = [
  "backtrace",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,7 @@ datafusion = { path = "datafusion" }
 data_types = { path = "data_types" }
 entry = { path = "entry" }
 generated_types = { path = "generated_types" }
-heappy = { git = "https://github.com/mkmik/heappy", rev = "aed37ab50a70c3f0a7a8bd1c51d28d3d8050461f", features = ["enable_heap_profiler", "jemalloc_shim", "measure_free"], optional = true }
+heappy = { git = "https://github.com/mkmik/heappy", rev = "c8fe1fefbaefd536b0137435fce8d90a98a184de", features = ["enable_heap_profiler", "jemalloc_shim", "measure_free"], optional = true}
 
 influxdb_iox_client = { path = "influxdb_iox_client", features = ["format"] }
 influxdb_line_protocol = { path = "influxdb_line_protocol" }


### PR DESCRIPTION
Currently heappy is reporting "bytes allocated" and "inuse_bytes" ("bytes allocated - freed bytes").

Since the allocation site and free site can be wildly different, it's very hard to correlate these events
and have a meaningful "inuse_bytes" graph.

I have a plan for how to fix this for good, but in the meantime I'd like to report raw "freed bytes".

