### PR TITLE
fix: limit kafka consumer queue to 100MB

### DIFF
--- a/write_buffer/src/kafka.rs
+++ b/write_buffer/src/kafka.rs
@@ -255,6 +255,7 @@ impl KafkaBufferConsumer {
         cfg.set("session.timeout.ms", "6000");
         cfg.set("enable.auto.commit", "false");
         cfg.set("statistics.interval.ms", "15000");
+        cfg.set("queued.max.messages.kbytes", "100000");
 
         // Create a unique group ID for this database's consumer as we don't want to create
         // consumer groups.


### PR DESCRIPTION
By default the queue will be filled to up to 1GB which makes finding
memory leaks quite hard.
