### PR TITLE
feat: Add batching to the data generator

### DIFF
--- a/iox_data_generator/benches/point_generation.rs
+++ b/iox_data_generator/benches/point_generation.rs
@@ -49,6 +49,7 @@ pub fn single_agent(c: &mut Criterion) {
                     end_datetime,
                     0,
                     false,
+                    1,
                 )
             });
             let n_points = r.expect("Could not generate data");

--- a/iox_data_generator/src/agent.rs
+++ b/iox_data_generator/src/agent.rs
@@ -125,11 +125,12 @@ impl<T: DataGenRng> Agent<T> {
     }
 
     /// Generate and write points in batches until `generate` doesn't return any
-    /// points. Meant to be called in a `tokio::task`.
+    /// points. Points will be written to the writer in batches where `generate` is
+    /// called `batch_size` times before writing. Meant to be called in a `tokio::task`.
     pub async fn generate_all(
         &mut self,
         mut points_writer: PointsWriter,
-        batch_size: u16,
+        batch_size: usize,
     ) -> Result<usize> {
         let mut total_points = 0;
 

--- a/iox_data_generator/src/lib.rs
+++ b/iox_data_generator/src/lib.rs
@@ -91,7 +91,7 @@ pub async fn generate<T: DataGenRng>(
     end_datetime: Option<i64>,
     execution_start_time: i64,
     continue_on: bool,
-    batch_size: u16,
+    batch_size: usize,
 ) -> Result<usize> {
     let seed = spec.base_seed.to_owned().unwrap_or_else(|| {
         let mut rng = rand::thread_rng();

--- a/iox_data_generator/src/lib.rs
+++ b/iox_data_generator/src/lib.rs
@@ -91,6 +91,7 @@ pub async fn generate<T: DataGenRng>(
     end_datetime: Option<i64>,
     execution_start_time: i64,
     continue_on: bool,
+    batch_size: u16,
 ) -> Result<usize> {
     let seed = spec.base_seed.to_owned().unwrap_or_else(|| {
         let mut rng = rand::thread_rng();
@@ -134,7 +135,7 @@ pub async fn generate<T: DataGenRng>(
             let agent_points_writer = points_writer_builder.build_for_agent(&agent_name);
 
             handles.push(tokio::task::spawn(async move {
-                agent.generate_all(agent_points_writer).await
+                agent.generate_all(agent_points_writer, batch_size).await
             }));
         }
     }

--- a/iox_data_generator/src/main.rs
+++ b/iox_data_generator/src/main.rs
@@ -148,7 +148,7 @@ Logging:
 
     let batch_size = matches
         .value_of("batch_size")
-        .map(|v| v.parse::<u16>().unwrap())
+        .map(|v| v.parse::<usize>().unwrap())
         .unwrap_or(1);
 
     info!(

--- a/iox_data_generator/src/main.rs
+++ b/iox_data_generator/src/main.rs
@@ -123,6 +123,12 @@ Logging:
             "Generate live data using the intervals from the spec after generating historical  \
               data. This option has no effect if you specify an end time.",
         ))
+        .arg(
+            Arg::with_name("batch_size")
+                .long("batch_size")
+                .help("Generate this many samplings to batch into a single API call. Good for sending a bunch of historical data in quickly if paired with a start time from long ago.")
+                .takes_value(true)
+        )
         .get_matches();
 
     let spec_filename = matches
@@ -139,6 +145,11 @@ Logging:
     let end_display = end_datetime.unwrap_or_else(|| execution_start_time.timestamp_nanos());
 
     let continue_on = matches.is_present("continue");
+
+    let batch_size = matches
+        .value_of("batch_size")
+        .map(|v| v.parse::<u16>().unwrap())
+        .unwrap_or(1);
 
     info!(
         "Starting at {}, ending at {} ({}){}",
@@ -177,6 +188,7 @@ Logging:
         end_datetime,
         execution_start_time.timestamp_nanos(),
         continue_on,
+        batch_size,
     )
     .await;
 


### PR DESCRIPTION
Adds batch_size to the data genrator to optionally gather multiple calls to generate for each agent. For example, if you have a sampling interval of 10 seconds and start at some point back in time with a batch size of 3, it gather 3 samplings before writing to the points writer. For runs against a server API, this will batch them together in a single API call.