### PR TITLE
fix(heappy): Prevent re-entering a running heap profile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1521,7 +1521,7 @@ dependencies = [
 [[package]]
 name = "heappy"
 version = "0.1.0"
-source = "git+https://github.com/mkmik/heappy?rev=82a383128e484039cc2f31476e6289bed48a6701#82a383128e484039cc2f31476e6289bed48a6701"
+source = "git+https://github.com/mkmik/heappy?rev=20aa466524ac9ce34a4bae29f27ec11869b50e21#20aa466524ac9ce34a4bae29f27ec11869b50e21"
 dependencies = [
  "backtrace",
  "bytes",
@@ -1530,6 +1530,7 @@ dependencies = [
  "pprof",
  "prost 0.8.0",
  "spin 0.9.2",
+ "thiserror",
  "tikv-jemalloc-sys",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -127,7 +127,7 @@ uuid = { version = "0.8", features = ["v4"] }
 
 # jemalloc-sys with unprefixed_malloc_on_supported_platforms feature and heappy are mutually exclusive
 tikv-jemalloc-sys = { version = "0.4.0", optional = true, features = ["unprefixed_malloc_on_supported_platforms"]}
-heappy = { git = "https://github.com/mkmik/heappy", rev = "82a383128e484039cc2f31476e6289bed48a6701", features = ["enable_heap_profiler", "jemalloc_shim", "measure_free"], optional = true }
+heappy = { git = "https://github.com/mkmik/heappy", rev = "20aa466524ac9ce34a4bae29f27ec11869b50e21", features = ["enable_heap_profiler", "jemalloc_shim", "measure_free"], optional = true }
 
 
 [dev-dependencies]
@@ -166,3 +166,4 @@ otlp = ["trogging/otlp"] # Enable optional open telemetry collector
 # Cargo cannot currently implement mutually exclusive features so let's force every build
 # to pick either heappy or jemalloc_replacing_malloc feature at least until we figure out something better.
 jemalloc_replacing_malloc = ["tikv-jemalloc-sys"]
+

--- a/src/influxdb_ioxd/http/heappy.rs
+++ b/src/influxdb_ioxd/http/heappy.rs
@@ -4,21 +4,41 @@
 
 use heappy::{self, HeapReport};
 use observability_deps::tracing::info;
-use tokio::time::Duration;
+use snafu::{ResultExt, Snafu};
+use std::{thread, time};
 
-pub(crate) async fn dump_heappy_rsprof(seconds: u64, interval: i32) -> HeapReport {
-    let guard = heappy::HeapProfilerGuard::new(interval as usize);
-    info!(
-        "start allocs profiling {} seconds with interval {} bytes",
-        seconds, interval
-    );
+#[derive(Debug, Snafu)]
+pub enum Error {
+    #[snafu(display("{}", source))]
+    HeappyError { source: heappy::Error },
 
-    tokio::time::sleep(Duration::from_secs(seconds)).await;
+    #[snafu(display("{}", source))]
+    JoinError { source: tokio::task::JoinError },
+}
 
-    info!(
-        "done allocs profiling {} seconds with interval {} bytes",
-        seconds, interval
-    );
+pub(crate) async fn dump_heappy_rsprof(seconds: u64, interval: i32) -> Result<HeapReport, Error> {
+    // heap profiler guard is not Send so it can't be used in async code.
+    let report = tokio::task::spawn_blocking(move || {
+        let guard = heappy::HeapProfilerGuard::new(interval as usize)?;
+        info!(
+            "start allocs profiling {} seconds with interval {} bytes",
+            seconds, interval
+        );
 
-    guard.report()
+        thread::sleep(time::Duration::from_secs(seconds));
+
+        info!(
+            "done allocs profiling {} seconds with interval {} bytes, computing report",
+            seconds, interval
+        );
+
+        let report = guard.report();
+        info!("heap allocation report computed",);
+        Ok(report)
+    })
+    .await
+    .context(JoinError)?
+    .context(HeappyError)?;
+
+    Ok(report)
 }


### PR DESCRIPTION
Upgrades heappy to include https://github.com/mkmik/heappy/pull/2
and adapts to the API change.

