### PR TITLE
refactor: improve string storage and sizing metrics for Read Buffer columns

### DIFF
--- a/read_buffer/src/column/encoding/string/dictionary.rs
+++ b/read_buffer/src/column/encoding/string/dictionary.rs
@@ -71,7 +71,10 @@ impl Dictionary {
             .entries
             .iter()
             .map(|k| match k {
-                Some(v) => v.len(),
+                Some(v) =>  match buffers {
+                    true => v.capacity(),
+                    false => v.len(),
+                },
                 None => 0,
             } + size_of::<Option<String>>())
             .sum::<usize>();

--- a/read_buffer/src/column/encoding/string/rle.rs
+++ b/read_buffer/src/column/encoding/string/rle.rs
@@ -231,7 +231,7 @@ impl RLE {
                     panic!("out of order dictionary insertion");
                 }
                 v.shrink_to_fit();
-                self.index_entries.push(v.clone());
+                self.index_entries.push(v);
 
                 self.index_row_ids.insert(next_id, RowIDs::new_bitmap());
 

--- a/read_buffer/src/column/encoding/string/rle.rs
+++ b/read_buffer/src/column/encoding/string/rle.rs
@@ -109,11 +109,6 @@ impl RLE {
             false => 0,
         };
 
-        self.index_row_ids
-            .values()
-            .map(|row_ids| row_ids.size())
-            .sum::<usize>();
-
         let index_row_ids_size =
             (size_of::<u32>() * self.index_row_ids.len()) + row_ids_bitmaps_size;
 

--- a/read_buffer/src/column/encoding/string/rle.rs
+++ b/read_buffer/src/column/encoding/string/rle.rs
@@ -91,9 +91,9 @@ impl RLE {
         index_entries_size += self
             .index_entries
             .iter()
-            .map(|k| {
-                debug_assert_eq!(k.len(), k.capacity());
-                k.len()
+            .map(|k| match buffers {
+                true => k.capacity(),
+                false => k.len(),
             })
             .sum::<usize>();
 

--- a/read_buffer/src/column/encoding/string/rle.rs
+++ b/read_buffer/src/column/encoding/string/rle.rs
@@ -158,7 +158,8 @@ impl RLE {
 
     /// Adds the provided string value to the encoded data. It is the caller's
     /// responsibility to ensure that the dictionary encoded remains sorted.
-    pub fn push(&mut self, v: String) {
+    pub fn push(&mut self, mut v: String) {
+        v.shrink_to_fit();
         self.push_additional(Some(v), 1);
     }
 
@@ -194,7 +195,7 @@ impl RLE {
         self.index_entries.iter().skip(1)
     }
 
-    fn push_additional_some(&mut self, v: String, additional: u32) {
+    fn push_additional_some(&mut self, mut v: String, additional: u32) {
         match self.lookup_entry(&v) {
             // existing dictionary entry for value.
             Some(id) => {
@@ -229,6 +230,7 @@ impl RLE {
                 {
                     panic!("out of order dictionary insertion");
                 }
+                v.shrink_to_fit();
                 self.index_entries.push(v.clone());
 
                 self.index_row_ids.insert(next_id, RowIDs::new_bitmap());


### PR DESCRIPTION
Following on from https://github.com/influxdata/influxdb_iox/pull/2379

This is a belt and braces type of PR.

This PR updates the capacity-based size metrics to include any excess capacity in allocated strings stored in dictionary encodings. It also ensures strings are minimally sized when using some APIs.

