### PR TITLE
refactor: re-export google proto types

### DIFF
--- a/influxdb_iox_client/src/client/management.rs
+++ b/influxdb_iox_client/src/client/management.rs
@@ -10,7 +10,6 @@ use std::num::NonZeroU32;
 
 /// Re-export generated_types
 pub mod generated_types {
-    pub use generated_types::google;
     pub use generated_types::influxdata::iox::management::v1::*;
 }
 

--- a/influxdb_iox_client/src/client/management.rs
+++ b/influxdb_iox_client/src/client/management.rs
@@ -10,6 +10,7 @@ use std::num::NonZeroU32;
 
 /// Re-export generated_types
 pub mod generated_types {
+    pub use generated_types::google;
     pub use generated_types::influxdata::iox::management::v1::*;
 }
 

--- a/influxdb_iox_client/src/lib.rs
+++ b/influxdb_iox_client/src/lib.rs
@@ -15,7 +15,7 @@
 )]
 #![allow(clippy::missing_docs_in_private_items)]
 
-pub use generated_types::{protobuf_type_url, protobuf_type_url_eq};
+pub use generated_types::{google, protobuf_type_url, protobuf_type_url_eq};
 
 pub use client::*;
 


### PR DESCRIPTION
Previously a consumer of the API client would have to import both `influxdb_iox_client` and `generated_types` in order to access some types used in the API client - this change makes everything accessible from the `influxdb_iox_client` crate 👍 

---

* refactor: re-export google proto types (87beefa9)

      The TemplatePart::Table() variant contains a google::protobuf::Empty type
      which is defined in the generated_types crate.

      Rather than force consumers to import two crates which have to be kept in
      sync, this commit re-exports the google types within the influxdb_iox_client
      crate as it's already a dependency, and makes using types like protobuf's
      Duration or long-running-operation API easier for the consumer.

