### PR TITLE
feat: Add an iox_object_store API for writing the tombstone file

### DIFF
--- a/generated_types/protos/influxdata/iox/management/v1/service.proto
+++ b/generated_types/protos/influxdata/iox/management/v1/service.proto
@@ -33,6 +33,8 @@ service ManagementService {
   // Roughly follows the <https://google.aip.dev/134> pattern, except we wrap the response
   rpc UpdateDatabase(UpdateDatabaseRequest) returns (UpdateDatabaseResponse);
 
+  rpc DeleteDatabase(DeleteDatabaseRequest) returns (DeleteDatabaseResponse);
+
   // List chunks available on this database
   rpc ListChunks(ListChunksRequest) returns (ListChunksResponse);
 
@@ -159,6 +161,13 @@ message UpdateDatabaseRequest {
 message UpdateDatabaseResponse {
   DatabaseRules rules = 1;
 }
+
+message DeleteDatabaseRequest {
+  // the name of the database
+  string db_name = 1;
+}
+
+message DeleteDatabaseResponse {}
 
 message ListChunksRequest {
   // the name of the database

--- a/iox_object_store/src/paths.rs
+++ b/iox_object_store/src/paths.rs
@@ -83,6 +83,29 @@ impl GenerationPath {
     }
 }
 
+#[derive(Debug, Clone)]
+pub(crate) struct TombstonePath {
+    pub(crate) inner: Path,
+}
+
+impl TombstonePath {
+    const TOMBSTONE_FILE_NAME: &'static str = "DELETED";
+
+    /// How the tombstone path of a database is defined in object storage in terms of the
+    /// generation path.
+    pub(crate) fn new(generation_path: &GenerationPath) -> Self {
+        Self::new_from_object_store_path(&generation_path.inner)
+    }
+
+    /// Creating a potential tombstone file location given an object storage path received from
+    /// an object storage list operation.
+    pub(crate) fn new_from_object_store_path(path: &Path) -> Self {
+        let mut inner = path.clone();
+        inner.set_file_name(Self::TOMBSTONE_FILE_NAME);
+        Self { inner }
+    }
+}
+
 /// A database-specific object store path for all catalog transaction files. This should not be
 /// leaked outside this crate.
 #[derive(Debug, Clone)]
@@ -187,7 +210,7 @@ mod tests {
         let object_store = make_object_store();
         let server_id = make_server_id();
         let database_name = DatabaseName::new("clouds").unwrap();
-        let generation = Generation::new(3);
+        let generation = Generation::active(3);
         let root_path = RootPath::new(&object_store, server_id, &database_name);
         let iox_object_store = IoxObjectStore::existing(
             Arc::clone(&object_store),
@@ -207,7 +230,7 @@ mod tests {
         let object_store = make_object_store();
         let server_id = make_server_id();
         let database_name = DatabaseName::new("clouds").unwrap();
-        let generation = Generation::new(3);
+        let generation = Generation::active(3);
         let root_path = RootPath::new(&object_store, server_id, &database_name);
         let iox_object_store = IoxObjectStore::existing(
             Arc::clone(&object_store),
@@ -227,7 +250,7 @@ mod tests {
         let object_store = make_object_store();
         let server_id = make_server_id();
         let database_name = DatabaseName::new("clouds").unwrap();
-        let generation = Generation::new(3);
+        let generation = Generation::active(3);
         let root_path = RootPath::new(&object_store, server_id, &database_name);
         let iox_object_store = IoxObjectStore::existing(
             Arc::clone(&object_store),

--- a/iox_object_store/src/paths/parquet_file.rs
+++ b/iox_object_store/src/paths/parquet_file.rs
@@ -343,7 +343,7 @@ mod tests {
     fn data_path_join_with_parquet_file_path() {
         let server_id = make_server_id();
         let database_name = DatabaseName::new("clouds").unwrap();
-        let generation = Generation::new(3);
+        let generation = Generation::active(3);
         let object_store = make_object_store();
         let root_path = RootPath::new(&object_store, server_id, &database_name);
         let iox_object_store = IoxObjectStore::existing(

--- a/iox_object_store/src/paths/transaction_file.rs
+++ b/iox_object_store/src/paths/transaction_file.rs
@@ -379,7 +379,7 @@ mod tests {
     fn transactions_path_join_with_parquet_file_path() {
         let server_id = make_server_id();
         let database_name = DatabaseName::new("clouds").unwrap();
-        let generation = Generation::new(3);
+        let generation = Generation::active(3);
         let object_store = make_object_store();
         let root_path = RootPath::new(&object_store, server_id, &database_name);
         let iox_object_store = IoxObjectStore::existing(

--- a/server/src/database.rs
+++ b/server/src/database.rs
@@ -247,6 +247,11 @@ impl Database {
         self.shared.state.read().get_initialized().is_some()
     }
 
+    /// Whether the database is active
+    pub fn is_active(&self) -> bool {
+        self.shared.state.read().is_active()
+    }
+
     /// Returns the database rules if they're loaded
     pub fn provided_rules(&self) -> Option<Arc<ProvidedDatabaseRules>> {
         self.shared.state.read().provided_rules()
@@ -847,7 +852,8 @@ impl DatabaseStateDatabaseObjectStoreFound {
             return RulesDatabaseNameMismatch {
                 actual: rules.db_name(),
                 expected: shared.config.name.as_str(),
-            }.fail();
+            }
+            .fail();
         }
 
         Ok(DatabaseStateRulesLoaded {

--- a/src/influxdb_ioxd/rpc/error.rs
+++ b/src/influxdb_ioxd/rpc/error.rs
@@ -102,6 +102,16 @@ pub fn default_database_error_handler(error: server::database::Error) -> tonic::
             error!(%source, "Unexpected error skipping replay");
             InternalError {}.into()
         }
+        Error::CannotMarkDatabaseDeleted { source, .. } => {
+            error!(%source, "Unexpected error deleting database");
+            InternalError {}.into()
+        }
+        Error::NoActiveDatabaseToDelete { db_name } => NotFound {
+            resource_type: "database".to_string(),
+            resource_name: db_name,
+            ..Default::default()
+        }
+        .into(),
     }
 }
 

--- a/src/influxdb_ioxd/rpc/management.rs
+++ b/src/influxdb_ioxd/rpc/management.rs
@@ -155,6 +155,20 @@ where
         }))
     }
 
+    async fn delete_database(
+        &self,
+        request: Request<DeleteDatabaseRequest>,
+    ) -> Result<Response<DeleteDatabaseResponse>, Status> {
+        let db_name = DatabaseName::new(request.into_inner().db_name).field("db_name")?;
+
+        self.server
+            .delete_database(&db_name)
+            .await
+            .map_err(default_server_error_handler)?;
+
+        Ok(Response::new(DeleteDatabaseResponse {}))
+    }
+
     async fn list_chunks(
         &self,
         request: Request<ListChunksRequest>,

--- a/src/influxdb_ioxd/rpc/management.rs
+++ b/src/influxdb_ioxd/rpc/management.rs
@@ -90,6 +90,15 @@ where
             .database(&name)
             .map_err(default_server_error_handler)?;
 
+        if !database.is_active() {
+            return Err(NotFound {
+                resource_type: "database".to_string(),
+                resource_name: name.to_string(),
+                ..Default::default()
+            }
+            .into());
+        }
+
         let rules = database
             .provided_rules()
             .map(|rules| format_rules(rules, omit_defaults))

--- a/tests/end_to_end_cases/management_api.rs
+++ b/tests/end_to_end_cases/management_api.rs
@@ -258,7 +258,7 @@ async fn test_list_databases() {
 }
 
 #[tokio::test]
-async fn test_create_get_update_database() {
+async fn test_create_get_update_delete_database() {
     let server_fixture = ServerFixture::create_shared().await;
     let mut client = server_fixture.management_client();
 
@@ -326,6 +326,16 @@ async fn test_create_get_update_database() {
             response.routing_rules,
             Some(RoutingRules::ShardConfig(cfg)) if cfg.ignore_errors,
     ));
+
+    client
+        .delete_database(&db_name)
+        .await
+        .expect("delete database failed");
+
+    client
+        .get_database(&db_name, false)
+        .await
+        .expect_err("get database should have failed but didn't");
 }
 
 /// gets configuration both with and without defaults, and verifies

--- a/tests/end_to_end_cases/management_api.rs
+++ b/tests/end_to_end_cases/management_api.rs
@@ -332,10 +332,12 @@ async fn test_create_get_update_delete_database() {
         .await
         .expect("delete database failed");
 
-    client
+    let err = client
         .get_database(&db_name, false)
         .await
         .expect_err("get database should have failed but didn't");
+
+    assert_contains!(err.to_string(), "Database not found");
 }
 
 /// gets configuration both with and without defaults, and verifies


### PR DESCRIPTION
This PR adds a management gRPC API to delete a database, which creates a tombstone file. The code that looks for active generations now checks to see if the tombstone file exists in a generation directory, and if it does exist, that generation is marked as deleted.

I feel like I'm probably doing some snafu things wrong; I'd like to have @shepmaster take a look at it.

Closes #1871.
