### PR TITLE
fix: make "persist partition" a bit more stable

### DIFF
--- a/server/src/db/replay.rs
+++ b/server/src/db/replay.rs
@@ -640,7 +640,7 @@ mod tests {
                                     .await
                                 {
                                     Ok(_) => break,
-                                    Err(crate::db::Error::LifecycleError { .. }) => {
+                                    Err(crate::db::Error::CannotFlushPartition { .. }) => {
                                         // cannot persist right now because of some lifecycle action, so wait a bit
                                         tokio::time::sleep(Duration::from_millis(100)).await;
                                         continue;

--- a/tests/end_to_end_cases/management_api.rs
+++ b/tests/end_to_end_cases/management_api.rs
@@ -1416,7 +1416,7 @@ async fn test_persist_partition() {
     assert_eq!(chunks.len(), 1);
     let partition_key = &chunks[0].partition_key;
 
-    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+    tokio::time::sleep(std::time::Duration::from_millis(1500)).await;
 
     management_client
         .persist_partition(&db_name, "data", &partition_key[..])

--- a/tests/end_to_end_cases/management_cli.rs
+++ b/tests/end_to_end_cases/management_cli.rs
@@ -924,7 +924,7 @@ async fn test_persist_partition() {
     )
     .await;
 
-    tokio::time::sleep(Duration::from_secs(1)).await;
+    tokio::time::sleep(Duration::from_millis(1500)).await;
 
     Command::cargo_bin("influxdb_iox")
         .unwrap()


### PR DESCRIPTION
- add longer wait times to tests
- exclude chunks that have active lifecycle actions early (instead of
  failing the whole set)
- properly catch the "no chunks" case

Fixes #2434.