### PR TITLE
feat: Wire database deletion through the CLI, add tests for not including deleted databases in database list

### DIFF
--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -646,7 +646,7 @@ where
         let mut databases: Vec<_> = initialized.databases.iter().collect();
 
         // ensure the databases come back sorted by name
-        databases.sort_by_key(|(name, _db)| (*name).clone());
+        databases.sort_by_key(|(name, _db)| name.as_str());
 
         let databases = databases
             .into_iter()

--- a/src/influxdb_ioxd/rpc/error.rs
+++ b/src/influxdb_ioxd/rpc/error.rs
@@ -14,12 +14,14 @@ pub fn default_server_error_handler(error: server::Error) -> tonic::Status {
             description: "Writer ID must be set".to_string(),
         }
         .into(),
-        Error::DatabaseNotInitialized { db_name } => tonic::Status::unavailable(
-            format!("Database ({}) is not yet initialized", db_name)
-        ),
-        Error::ServerNotInitialized{ server_id } => tonic::Status::unavailable(
-            format!("Server ID is set ({}) but server is not yet initialized (e.g. DBs and remotes are not loaded). Server is not yet ready to read/write data.", server_id)
-        ),
+        Error::DatabaseNotInitialized { db_name } => {
+            tonic::Status::unavailable(format!("Database ({}) is not yet initialized", db_name))
+        }
+        Error::ServerNotInitialized { server_id } => tonic::Status::unavailable(format!(
+            "Server ID is set ({}) but server is not yet initialized (e.g. DBs and remotes \
+                     are not loaded). Server is not yet ready to read/write data.",
+            server_id
+        )),
         Error::DatabaseNotFound { db_name } => NotFound {
             resource_type: "database".to_string(),
             resource_name: db_name,
@@ -36,8 +38,10 @@ pub fn default_server_error_handler(error: server::Error) -> tonic::Status {
             description: "hard buffer limit reached".to_string(),
         }
         .into(),
-        source @ Error::WritingOnlyAllowedThroughWriteBuffer { .. } |
-            source @ Error::LineConversion { .. } => tonic::Status::failed_precondition(source.to_string()),
+        source @ Error::WritingOnlyAllowedThroughWriteBuffer { .. }
+        | source @ Error::LineConversion { .. } => {
+            tonic::Status::failed_precondition(source.to_string())
+        }
         Error::NoRemoteConfigured { node_group } => NotFound {
             resource_type: "remote".to_string(),
             resource_name: format!("{:?}", node_group),
@@ -45,7 +49,9 @@ pub fn default_server_error_handler(error: server::Error) -> tonic::Status {
         }
         .into(),
         Error::RemoteError { source } => tonic::Status::unavailable(source.to_string()),
-        Error::WipePreservedCatalog { source } => default_database_error_handler(source),
+        Error::WipePreservedCatalog { source } | Error::CannotMarkDatabaseDeleted { source } => {
+            default_database_error_handler(source)
+        }
         error => {
             error!(?error, "Unexpected error");
             InternalError {}.into()


### PR DESCRIPTION
Fixes #2432 and #2197.

Turns out with the changes in 2f49e47a2362f6b30774f278a88b09eabe24aaab to filter out databases that don't returned provided rules, listing databases without listing deleted databases Just Works because deleted databases don't return provided rules!

Not sure if this feels too coincidental?