### PR TITLE
fix: time column is alwyas last even if the column is sorted lexicographically

### DIFF
--- a/query/src/provider/overlap.rs
+++ b/query/src/provider/overlap.rs
@@ -181,7 +181,7 @@ where
     fn potential_overlap(&self, other: &Self) -> Result<bool> {
         // This algorithm assumes that the keys are sorted by name (so
         // they can't appear in different orders on the two sides) except
-        // the "time"column which is always the last column
+        // the "time" column which is always the last column
         debug_assert!(self
             .key_summaries
             .windows(2)


### PR DESCRIPTION
Closes #2408 

The fix: If the column is "time", do not need to check if it is sorted in the key because it is always last

- [x] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb_iox/blob/main/README.md).
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
