### PR TITLE
refactor: more flexible writer buffer config

### DIFF
--- a/data_types/src/database_rules.rs
+++ b/data_types/src/database_rules.rs
@@ -98,6 +98,10 @@ pub struct WriteBufferConnection {
     ///
     /// This depends on [`type_`](Self::type_) and can configure aspects like timeouts.
     pub connection_config: HashMap<String, String>,
+
+    /// Specifies if the sequencers (e.g. for Kafka in form of a topic w/ [`n_sequencers`](Self::n_sequencers)
+    /// partitions) should be automatically created if they do not existing prior to reading or writing.
+    pub auto_create_sequencers: bool,
 }
 
 impl Default for WriteBufferConnection {
@@ -109,6 +113,7 @@ impl Default for WriteBufferConnection {
             n_sequencers: DEFAULT_N_SEQUENCERS,
             creation_config: Default::default(),
             connection_config: Default::default(),
+            auto_create_sequencers: Default::default(),
         }
     }
 }

--- a/data_types/src/database_rules.rs
+++ b/data_types/src/database_rules.rs
@@ -59,10 +59,58 @@ pub struct DatabaseRules {
     pub write_buffer_connection: Option<WriteBufferConnection>,
 }
 
+/// If the buffer is used for reading or writing.
 #[derive(Debug, Eq, PartialEq, Clone, Serialize, Deserialize)]
-pub enum WriteBufferConnection {
-    Writing(String),
-    Reading(String),
+pub enum WriteBufferDirection {
+    /// Writes into the buffer aka "producer".
+    Write,
+
+    /// Reads from the buffer aka "consumer".
+    Read,
+}
+
+pub const DEFAULT_N_SEQUENCERS: u32 = 1;
+
+/// Configures the use of a write buffer.
+#[derive(Debug, Eq, PartialEq, Clone, Serialize, Deserialize)]
+pub struct WriteBufferConnection {
+    /// If the buffer is used for reading or writing.
+    pub direction: WriteBufferDirection,
+
+    /// Which type should be used (e.g. "kafka", "mock")
+    pub type_: String,
+
+    /// Connection string, depends on [`type_`](Self::type_).
+    pub connection: String,
+
+    /// Number of sequencers.
+    ///
+    /// How they are implemented depends on [`type_`](Self::type_), e.g. for Kafka this is mapped to the number of
+    /// partitions.
+    pub n_sequencers: u32,
+
+    /// Special configs to by applied when sequencers are created.
+    ///
+    /// This depends on [`type_`](Self::type_) and can setup parameters like retention policy.
+    pub creation_config: HashMap<String, String>,
+
+    /// Special configs to be applied when establishing the connection.
+    ///
+    /// This depends on [`type_`](Self::type_) and can configure aspects like timeouts.
+    pub connection_config: HashMap<String, String>,
+}
+
+impl Default for WriteBufferConnection {
+    fn default() -> Self {
+        Self {
+            direction: WriteBufferDirection::Read,
+            type_: "unspecified".to_string(),
+            connection: Default::default(),
+            n_sequencers: DEFAULT_N_SEQUENCERS,
+            creation_config: Default::default(),
+            connection_config: Default::default(),
+        }
+    }
 }
 
 #[derive(Debug, Eq, PartialEq, Clone, Serialize, Deserialize)]

--- a/generated_types/protos/influxdata/iox/management/v1/database_rules.proto
+++ b/generated_types/protos/influxdata/iox/management/v1/database_rules.proto
@@ -113,11 +113,51 @@ message DatabaseRules {
   // Defaults to 500 seconds.
   google.protobuf.Duration worker_cleanup_avg_sleep = 10;
 
-  // Optionally, the address of the write buffer for writing or reading/restoring data
-  oneof write_buffer_connection {
-    string writing = 11;
-    string reading = 12;
+  // These were the old write buffer connection strings.
+  reserved 11, 12;
+
+  // Optionally, the connection for the write buffer for writing or reading/restoring data.
+  WriteBufferConnection write_buffer_connection = 13;
+}
+
+// Configures the use of a write buffer.
+message WriteBufferConnection {
+  enum Direction {
+    // Unspecified direction, will be treated as an error.
+    DIRECTION_UNSPECIFIED = 0;
+
+    // Writes into the buffer aka "producer".
+    DIRECTION_WRITE = 1;
+
+    // Reads from the buffer aka "consumer".
+    DIRECTION_READ = 2;
   }
+
+  // If the buffer is used for reading or writing.
+  Direction direction = 1;
+
+  // Which type should be used (e.g. "kafka", "mock")
+  string type = 2;
+
+  // Connection string, depends on `type`.
+  string connection = 3;
+
+  // Number of sequencers.
+  //
+  // Defaults to 1.
+  //
+  // How they are implemented depends on `type`, e.g. for Kafka this is mapped to the number of partitions.
+  uint32 n_sequencers = 4;
+
+  // Special configs to by applied when sequencers are created.
+  //
+  // This depends on `type` and can setup parameters like retention policy.
+  map<string, string> creation_config = 5;
+
+  // Special configs to be applied when establishing the connection.
+  //
+  // This depends on `type` and can configure aspects like timeouts.
+  map<string, string> connection_config = 6;
 }
 
 message RoutingConfig {

--- a/generated_types/protos/influxdata/iox/management/v1/database_rules.proto
+++ b/generated_types/protos/influxdata/iox/management/v1/database_rules.proto
@@ -158,6 +158,10 @@ message WriteBufferConnection {
   //
   // This depends on `type` and can configure aspects like timeouts.
   map<string, string> connection_config = 6;
+
+  // Specifies if the sequencers (e.g. for Kafka in form of a topic w/ `n_sequencers` partitions) should be
+  // automatically created if they do not existing prior to reading or writing.
+  bool auto_create_sequencers = 7;
 }
 
 message RoutingConfig {

--- a/generated_types/src/database_rules.rs
+++ b/generated_types/src/database_rules.rs
@@ -156,6 +156,7 @@ impl From<WriteBufferConnection> for management::WriteBufferConnection {
             n_sequencers: v.n_sequencers,
             creation_config: v.creation_config,
             connection_config: v.connection_config,
+            auto_create_sequencers: v.auto_create_sequencers,
         }
     }
 }
@@ -192,6 +193,7 @@ impl TryFrom<management::WriteBufferConnection> for WriteBufferConnection {
             n_sequencers,
             creation_config: proto.creation_config,
             connection_config: proto.connection_config,
+            auto_create_sequencers: proto.auto_create_sequencers,
         })
     }
 }

--- a/iox_data_generator/src/bin/create_database.rs
+++ b/iox_data_generator/src/bin/create_database.rs
@@ -85,7 +85,12 @@ Examples:
                 sink: Some(management::sink::Sink::Kafka(KafkaProducer {})),
             }),
         })),
-        write_buffer_connection: Some(WriteBufferConnection::Writing(kafka.to_string())),
+        write_buffer_connection: Some(WriteBufferConnection {
+            direction: write_buffer_connection::Direction::Write.into(),
+            r#type: "kafka".to_string(),
+            connection: kafka.to_string(),
+            ..Default::default()
+        }),
     };
     let reader_database_rules = DatabaseRules {
         name: db_name.clone(),
@@ -111,7 +116,12 @@ Examples:
                 sink: Some(management::sink::Sink::Kafka(KafkaProducer {})),
             }),
         })),
-        write_buffer_connection: Some(WriteBufferConnection::Reading(kafka.to_string())),
+        write_buffer_connection: Some(WriteBufferConnection {
+            direction: write_buffer_connection::Direction::Read.into(),
+            r#type: "kafka".to_string(),
+            connection: kafka.to_string(),
+            ..Default::default()
+        }),
     };
 
     // Create the writer db

--- a/server/src/database.rs
+++ b/server/src/database.rs
@@ -955,7 +955,9 @@ struct DatabaseStateInitialized {
 #[cfg(test)]
 mod tests {
     use chrono::Utc;
-    use data_types::database_rules::{PartitionTemplate, TemplatePart, WriteBufferConnection};
+    use data_types::database_rules::{
+        PartitionTemplate, TemplatePart, WriteBufferConnection, WriteBufferDirection,
+    };
     use entry::{test_helpers::lp_to_entries, Sequence, SequencedEntry};
     use object_store::ObjectStore;
     use write_buffer::{config::WriteBufferConfigFactory, mock::MockBufferSharedState};
@@ -1071,9 +1073,12 @@ mod tests {
             },
             routing_rules: None,
             worker_cleanup_avg_sleep: Duration::from_secs(2),
-            write_buffer_connection: Some(WriteBufferConnection::Reading(
-                "mock://my_mock".to_string(),
-            )),
+            write_buffer_connection: Some(WriteBufferConnection {
+                direction: WriteBufferDirection::Read,
+                type_: "mock".to_string(),
+                connection: "my_mock".to_string(),
+                ..Default::default()
+            }),
         };
         Database::create(
             Arc::clone(&application),

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -1253,7 +1253,7 @@ mod tests {
         chunk_metadata::ChunkAddr,
         database_rules::{
             DatabaseRules, HashRing, LifecycleRules, PartitionTemplate, ShardConfig, TemplatePart,
-            WriteBufferConnection, NO_SHARD_CONFIG,
+            WriteBufferConnection, WriteBufferDirection, NO_SHARD_CONFIG,
         },
     };
     use entry::test_helpers::lp_to_entry;
@@ -2395,9 +2395,12 @@ mod tests {
             lifecycle_rules: Default::default(),
             routing_rules: None,
             worker_cleanup_avg_sleep: Duration::from_secs(2),
-            write_buffer_connection: Some(WriteBufferConnection::Writing(
-                "mock://my_mock".to_string(),
-            )),
+            write_buffer_connection: Some(WriteBufferConnection {
+                direction: WriteBufferDirection::Write,
+                type_: "mock".to_string(),
+                connection: "my_mock".to_string(),
+                ..Default::default()
+            }),
         };
         server
             .create_database(make_provided_rules(rules))

--- a/tests/end_to_end_cases/write_buffer.rs
+++ b/tests/end_to_end_cases/write_buffer.rs
@@ -4,7 +4,9 @@ use crate::{
 };
 use arrow_util::assert_batches_sorted_eq;
 use entry::{test_helpers::lp_to_entry, Entry};
-use generated_types::influxdata::iox::management::v1::database_rules::WriteBufferConnection;
+use generated_types::influxdata::iox::management::v1::{
+    write_buffer_connection::Direction as WriteBufferDirection, WriteBufferConnection,
+};
 use influxdb_iox_client::write::WriteError;
 use rdkafka::{
     consumer::{Consumer, StreamConsumer},
@@ -22,7 +24,12 @@ async fn writes_go_to_kafka() {
     // set up a database with a write buffer pointing at kafka
     let server = ServerFixture::create_shared().await;
     let db_name = rand_name();
-    let write_buffer_connection = WriteBufferConnection::Writing(kafka_connection.to_string());
+    let write_buffer_connection = WriteBufferConnection {
+        direction: WriteBufferDirection::Write.into(),
+        r#type: "kafka".to_string(),
+        connection: kafka_connection.to_string(),
+        ..Default::default()
+    };
 
     DatabaseBuilder::new(db_name.clone())
         .write_buffer(write_buffer_connection)
@@ -74,7 +81,12 @@ async fn writes_go_to_kafka_whitelist() {
     // set up a database with a write buffer pointing at kafka
     let server = ServerFixture::create_shared().await;
     let db_name = rand_name();
-    let write_buffer_connection = WriteBufferConnection::Writing(kafka_connection.to_string());
+    let write_buffer_connection = WriteBufferConnection {
+        direction: WriteBufferDirection::Write.into(),
+        r#type: "kafka".to_string(),
+        connection: kafka_connection.to_string(),
+        ..Default::default()
+    };
 
     DatabaseBuilder::new(db_name.clone())
         .write_buffer(write_buffer_connection)
@@ -149,7 +161,12 @@ async fn reads_come_from_kafka() {
     // set up a database to read from Kafka
     let server = ServerFixture::create_shared().await;
     let db_name = rand_name();
-    let write_buffer_connection = WriteBufferConnection::Reading(kafka_connection.to_string());
+    let write_buffer_connection = WriteBufferConnection {
+        direction: WriteBufferDirection::Read.into(),
+        r#type: "kafka".to_string(),
+        connection: kafka_connection.to_string(),
+        ..Default::default()
+    };
 
     // Common Kafka config
     let mut cfg = ClientConfig::new();
@@ -238,7 +255,12 @@ async fn cant_write_to_db_reading_from_kafka() {
     // set up a database to read from Kafka
     let server = ServerFixture::create_shared().await;
     let db_name = rand_name();
-    let write_buffer_connection = WriteBufferConnection::Reading(kafka_connection.to_string());
+    let write_buffer_connection = WriteBufferConnection {
+        direction: WriteBufferDirection::Read.into(),
+        r#type: "kafka".to_string(),
+        connection: kafka_connection.to_string(),
+        ..Default::default()
+    };
 
     DatabaseBuilder::new(db_name.clone())
         .write_buffer(write_buffer_connection)


### PR DESCRIPTION
This allows:

- different types (instead of guessing through the connection URL)
- sequencer counts (not used yet but will be by #2455)
- extensible configs (e.g. to configure Kafka in a more granular way,
  not wired up yet)
- future extensions (since we use a message now instead of a single
  string)

**BREAKING: This requires changes for deployed systems / existing DBs!**
