### PR TITLE
build: feature-gate arrow dep for mgmt client

### DIFF
--- a/influxdb_iox_client/Cargo.toml
+++ b/influxdb_iox_client/Cargo.toml
@@ -5,12 +5,12 @@ authors = ["Dom Dwyer <dom@itsallbroken.com>"]
 edition = "2018"
 
 [features]
-flight = ["arrow", "arrow-flight", "serde/derive", "serde_json", "futures-util"]
+flight = ["arrow", "arrow-flight", "arrow_util", "serde/derive", "serde_json", "futures-util"]
 format = ["arrow"]
 
 [dependencies]
 # Workspace dependencies, in alphabetical order
-arrow_util = { path = "../arrow_util" }
+arrow_util = { path = "../arrow_util", optional = true }
 client_util = { path = "../client_util" }
 generated_types = { path = "../generated_types" }
 


### PR DESCRIPTION
This was forcing Conductor to pull in and compile all of the `arrow` crate, adding 22 compilation units - we spent more time compiling arrow than `libconductor`!

Looks like an oversight added in #2098  @alamb ?

---

* build: feature-gate arrow dep for mgmt client (dd88b5ed)

      Avoid pulling in & compiling arrow for consumers of the managemnt client.

      PR #2098 added arrow_util as a dependency of this crate which in turn pulls in
      all of arrow, however it is only used in the flight client.

      This commit feature-gates arrow_util behind "flight" with the rest of the
      arrow deps.

