### PR TITLE
chore: `iox_data_generator` QA

### DIFF
--- a/iox_data_generator/src/bin/create_database.rs
+++ b/iox_data_generator/src/bin/create_database.rs
@@ -1,9 +1,13 @@
-#![deny(rust_2018_idioms)]
+//! CLI to create databases.
+#![deny(rustdoc::broken_intra_doc_links, rustdoc::bare_urls, rust_2018_idioms)]
 #![warn(
     missing_copy_implementations,
     missing_debug_implementations,
+    missing_docs,
     clippy::explicit_iter_loop,
-    clippy::use_self
+    clippy::future_not_send,
+    clippy::use_self,
+    clippy::clone_on_ref_ptr
 )]
 
 use clap::{App, Arg};

--- a/iox_data_generator/src/bin/iox_data_generator.rs
+++ b/iox_data_generator/src/bin/iox_data_generator.rs
@@ -1,9 +1,13 @@
-#![deny(rust_2018_idioms)]
+//! Entry point for generator CLI.
+#![deny(rustdoc::broken_intra_doc_links, rustdoc::bare_urls, rust_2018_idioms)]
 #![warn(
     missing_copy_implementations,
     missing_debug_implementations,
+    missing_docs,
     clippy::explicit_iter_loop,
-    clippy::use_self
+    clippy::future_not_send,
+    clippy::use_self,
+    clippy::clone_on_ref_ptr
 )]
 
 use chrono::prelude::*;

--- a/iox_data_generator/src/lib.rs
+++ b/iox_data_generator/src/lib.rs
@@ -16,13 +16,15 @@
 //!
 //! [go-gen]: https://github.com/influxdata/influxdb/pull/12710
 
-#![deny(rust_2018_idioms)]
+#![deny(rustdoc::broken_intra_doc_links, rustdoc::bare_urls, rust_2018_idioms)]
 #![warn(
     missing_copy_implementations,
     missing_debug_implementations,
     missing_docs,
     clippy::explicit_iter_loop,
-    clippy::use_self
+    clippy::future_not_send,
+    clippy::use_self,
+    clippy::clone_on_ref_ptr
 )]
 
 use crate::substitution::Substitute;

--- a/iox_data_generator/src/substitution.rs
+++ b/iox_data_generator/src/substitution.rs
@@ -122,7 +122,7 @@ pub struct Substitute {
 
 impl Substitute {
     /// Compile and evaluate a template once. If you need to evaluate
-    /// it multiple times, construct an instance via [`new`].
+    /// it multiple times, construct an instance via [`new`](Self::new).
     ///
     /// If a placeholder appears in a template but not in the list of
     /// substitution values, this will return an error.
@@ -136,8 +136,8 @@ impl Substitute {
     }
 
     /// Compiles the handlebars template once, then allows reusing the
-    /// template multiple times via [`evaluate`]. If you don't need to
-    /// reuse the template, you can use [`once`].
+    /// template multiple times via [`evaluate`](Self::evaluate). If you don't need to
+    /// reuse the template, you can use [`once`](Self::once).
     pub fn new<T: DataGenRng>(
         template: impl Into<String>,
         rng: RandomNumberGenerator<T>,

--- a/iox_data_generator/src/write.rs
+++ b/iox_data_generator/src/write.rs
@@ -101,10 +101,10 @@ impl PointsWriterBuilder {
     /// Write points to the API at the specified host and put them in the
     /// specified org and bucket.
     pub async fn new_api(
-        host: impl Into<String>,
-        org: impl Into<String>,
-        bucket: impl Into<String>,
-        token: impl Into<String>,
+        host: impl Into<String> + Send,
+        org: impl Into<String> + Send,
+        bucket: impl Into<String> + Send,
+        token: impl Into<String> + Send,
         create_bucket: bool,
         org_id: Option<&str>,
     ) -> Result<Self> {
@@ -302,10 +302,10 @@ mod test {
         fn written_data(self, agent_name: &str) -> String {
             match self.config {
                 PointsWriterConfig::Vector(agents_by_name) => {
-                    let bytes_ref = agents_by_name
-                        .get(agent_name)
-                        .expect("Should have written some data, did not find any for this agent")
-                        .clone();
+                    let bytes_ref =
+                        Arc::clone(agents_by_name.get(agent_name).expect(
+                            "Should have written some data, did not find any for this agent",
+                        ));
                     let bytes = bytes_ref
                         .lock()
                         .expect("Should have been able to get a lock");


### PR DESCRIPTION
- Move main binary to `src/bin`. It's easier to reason about when all
  binaries are in a single directory and the other files in `src` just
  belong to the lib. Note that `cargo run [-p iox_data_generator]` still
  works.
- Enable lints that we use elsewhere. Fix the few issues that were found
  by this (e.g. broken intradoc links).
