### PR TITLE
feat: prune old transactions from preserved catalog

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1753,6 +1753,7 @@ dependencies = [
  "parking_lot",
  "parquet",
  "parquet_file",
+ "parse_duration",
  "pprof",
  "predicates",
  "prettytable-rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -131,6 +131,7 @@ once_cell = { version = "1.4.0", features = ["parking_lot"] }
 parking_lot = "0.11.2"
 itertools = "0.10.1"
 parquet = "5.3"
+parse_duration = "2.1.1"
 # used by arrow/datafusion anyway
 prettytable-rs = "0.8"
 pprof = { version = "^0.5", default-features = false, features = ["flamegraph", "protobuf"], optional = true }

--- a/data_types/src/database_rules.rs
+++ b/data_types/src/database_rules.rs
@@ -183,6 +183,7 @@ impl Partitioner for DatabaseRules {
 
 pub const DEFAULT_WORKER_BACKOFF_MILLIS: u64 = 1_000;
 pub const DEFAULT_CATALOG_TRANSACTIONS_UNTIL_CHECKPOINT: u64 = 100;
+pub const DEFAULT_CATALOG_TRANSACTION_PRUNE_AGE: Duration = Duration::from_secs(24 * 60 * 60);
 pub const DEFAULT_MUB_ROW_THRESHOLD: usize = 100_000;
 pub const DEFAULT_PERSIST_ROW_THRESHOLD: usize = 1_000_000;
 pub const DEFAULT_PERSIST_AGE_THRESHOLD_SECONDS: u32 = 30 * 60;
@@ -214,6 +215,11 @@ pub struct LifecycleRules {
 
     /// After how many transactions should IOx write a new checkpoint?
     pub catalog_transactions_until_checkpoint: NonZeroU64,
+
+    /// Prune catalog transactions older than the given age.
+    ///
+    /// Keeping old transaction can be useful for debugging.
+    pub catalog_transaction_prune_age: Duration,
 
     /// Once a partition hasn't received a write for this period of time,
     /// it will be compacted and, if set, persisted. Writers will generally
@@ -301,6 +307,7 @@ impl Default for LifecycleRules {
                 DEFAULT_CATALOG_TRANSACTIONS_UNTIL_CHECKPOINT,
             )
             .unwrap(),
+            catalog_transaction_prune_age: DEFAULT_CATALOG_TRANSACTION_PRUNE_AGE,
             late_arrive_window_seconds: NonZeroU32::new(DEFAULT_LATE_ARRIVE_WINDOW_SECONDS)
                 .unwrap(),
             persist_row_threshold: NonZeroUsize::new(DEFAULT_PERSIST_ROW_THRESHOLD).unwrap(),

--- a/generated_types/protos/influxdata/iox/management/v1/database_rules.proto
+++ b/generated_types/protos/influxdata/iox/management/v1/database_rules.proto
@@ -62,6 +62,13 @@ message LifecycleRules {
   // If 0 / absent, this default to 100.
   uint64 catalog_transactions_until_checkpoint = 11;
 
+  // Prune catalog transactions older than the given age.
+  //
+  // Keeping old transaction can be useful for debugging.
+  //
+  // Defaults to 1 day.
+  google.protobuf.Duration catalog_transaction_prune_age = 19;
+
   /// Once a partition hasn't received a write for this period of time,
   /// it will be compacted and, if set, persisted. Writers will generally
   /// have this amount of time to send late arriving writes or this could

--- a/parquet_file/src/catalog/mod.rs
+++ b/parquet_file/src/catalog/mod.rs
@@ -2,5 +2,6 @@ pub mod api;
 pub mod cleanup;
 pub mod dump;
 mod internals;
+pub mod prune;
 pub mod rebuild;
 pub mod test_helpers;

--- a/parquet_file/src/catalog/prune.rs
+++ b/parquet_file/src/catalog/prune.rs
@@ -1,0 +1,260 @@
+//! Tooling to remove parts of the preserved catalog that are no longer needed.
+use std::{collections::BTreeMap, sync::Arc};
+
+use chrono::{DateTime, Utc};
+use futures::TryStreamExt;
+use iox_object_store::{IoxObjectStore, TransactionFilePath};
+use object_store::{ObjectStore, ObjectStoreApi};
+use snafu::{ResultExt, Snafu};
+
+use crate::catalog::{
+    api::{ProtoIOError, ProtoParseError},
+    internals::{proto_io::load_transaction_proto, proto_parse::parse_timestamp},
+};
+
+#[derive(Debug, Snafu)]
+pub enum Error {
+    #[snafu(display("Error during store read operation: {}", source))]
+    Read {
+        source: <ObjectStore as ObjectStoreApi>::Error,
+    },
+
+    #[snafu(display("Error during store delete operation: {}", source))]
+    Delete {
+        source: <ObjectStore as ObjectStoreApi>::Error,
+    },
+
+    #[snafu(display("Error during protobuf IO: {}", source))]
+    ProtobufIOError { source: ProtoIOError },
+
+    #[snafu(display("Internal: Error while parsing protobuf: {}", source))]
+    ProtobufParseError { source: ProtoParseError },
+}
+
+pub type Result<T, E = Error> = std::result::Result<T, E>;
+
+/// Prune history of [`PreservedCatalog`](crate::catalog::api::PreservedCatalog).
+///
+/// This deletes all transactions and checkpoints that were started prior to `before`. Note that this only deletes data
+/// that is safe to delete when time travel to `before` is allowed. For example image the following transactions:
+///
+/// | Timestamp | What                      |
+/// | --------- | ------------------------- |
+/// | C1        | Checkpoint                |
+/// | T2        | Transaction               |
+/// | T3, C3    | Transaction + Checkpoint  |
+/// | T4        | Transaction               |
+/// | `before`  |                           |
+/// | T5        | Transaction               |
+/// | T6, C6    | Transaction + Checkpoint  |
+/// | T7        | Transaction               |
+/// | T9, C9    | Transaction + Checkpoint  |
+///
+/// This will delete the following content: C1, T2, and T3. C3 and T4 cannot be deleted because it is required to
+/// recover T5 which is AFTER `before`.
+pub async fn prune_history(
+    iox_object_store: Arc<IoxObjectStore>,
+    before: DateTime<Utc>,
+) -> Result<()> {
+    // collect all files so we can quickly filter them later for deletion
+    // Use a btree-map so we can iterate from oldest to newest revision.
+    let mut files: BTreeMap<u64, Vec<TransactionFilePath>> = Default::default();
+
+    // remember latest checkpoint is <= before
+    let mut latest_in_prune_range: Option<u64> = None;
+
+    // remember known checkpoint
+    let mut latest_known: Option<u64> = None;
+
+    let mut stream = iox_object_store
+        .catalog_transaction_files()
+        .await
+        .context(Read)?;
+
+    while let Some(transaction_file_list) = stream.try_next().await.context(Read)? {
+        for transaction_file_path in transaction_file_list {
+            if is_checkpoint_or_zero(&transaction_file_path) {
+                let proto = load_transaction_proto(&iox_object_store, &transaction_file_path)
+                    .await
+                    .context(ProtobufIOError)?;
+                let start_timestamp =
+                    parse_timestamp(&proto.start_timestamp).context(ProtobufParseError)?;
+
+                if start_timestamp <= before {
+                    latest_in_prune_range = Some(
+                        latest_in_prune_range.map_or(transaction_file_path.revision_counter, |x| {
+                            x.max(transaction_file_path.revision_counter)
+                        }),
+                    );
+                }
+
+                latest_known = Some(
+                    latest_known.map_or(transaction_file_path.revision_counter, |x| {
+                        x.max(transaction_file_path.revision_counter)
+                    }),
+                );
+            }
+
+            files
+                .entry(transaction_file_path.revision_counter)
+                .and_modify(|known| known.push(transaction_file_path))
+                .or_insert_with(|| vec![transaction_file_path]);
+        }
+    }
+
+    if let Some(earliest_keep) = latest_in_prune_range.or(latest_known) {
+        for (revision, files) in files {
+            if revision > earliest_keep {
+                break;
+            }
+
+            for file in files {
+                if (file.revision_counter < earliest_keep) || !is_checkpoint_or_zero(&file) {
+                    iox_object_store
+                        .delete_catalog_transaction_file(&file)
+                        .await
+                        .context(Delete)?;
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Check if given path is represents a checkpoint or is revision zero.
+///
+/// For both cases this file can be used to start to read a catalog.
+fn is_checkpoint_or_zero(path: &TransactionFilePath) -> bool {
+    path.is_checkpoint() || (path.revision_counter == 0)
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        catalog::{
+            api::{CheckpointData, PreservedCatalog},
+            test_helpers::TestCatalogState,
+        },
+        test_utils::make_iox_object_store,
+    };
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_empty_store() {
+        let iox_object_store = make_iox_object_store().await;
+
+        prune_history(iox_object_store, Utc::now()).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_do_delete_wipe_last_checkpoint() {
+        let iox_object_store = make_iox_object_store().await;
+
+        PreservedCatalog::new_empty::<TestCatalogState>(Arc::clone(&iox_object_store), ())
+            .await
+            .unwrap();
+
+        prune_history(Arc::clone(&iox_object_store), Utc::now())
+            .await
+            .unwrap();
+
+        PreservedCatalog::load::<TestCatalogState>(iox_object_store, ())
+            .await
+            .unwrap()
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_complex_1() {
+        let iox_object_store = make_iox_object_store().await;
+
+        let (catalog, _state) =
+            PreservedCatalog::new_empty::<TestCatalogState>(Arc::clone(&iox_object_store), ())
+                .await
+                .unwrap();
+        create_transaction(&catalog).await;
+        create_transaction_and_checkpoint(&catalog).await;
+        let before = Utc::now();
+        create_transaction(&catalog).await;
+
+        prune_history(Arc::clone(&iox_object_store), before)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            known_revisions(&iox_object_store).await,
+            vec![(2, true), (3, false)],
+        );
+    }
+
+    #[tokio::test]
+    async fn test_complex_2() {
+        let iox_object_store = make_iox_object_store().await;
+
+        let (catalog, _state) =
+            PreservedCatalog::new_empty::<TestCatalogState>(Arc::clone(&iox_object_store), ())
+                .await
+                .unwrap();
+        create_transaction(&catalog).await;
+        create_transaction_and_checkpoint(&catalog).await;
+        create_transaction(&catalog).await;
+        let before = Utc::now();
+        create_transaction(&catalog).await;
+        create_transaction_and_checkpoint(&catalog).await;
+        create_transaction(&catalog).await;
+
+        prune_history(Arc::clone(&iox_object_store), before)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            known_revisions(&iox_object_store).await,
+            vec![
+                (2, true),
+                (3, false),
+                (4, false),
+                (5, false),
+                (5, true),
+                (6, false)
+            ],
+        );
+    }
+
+    async fn create_transaction(catalog: &PreservedCatalog) {
+        let t = catalog.open_transaction().await;
+        t.commit().await.unwrap();
+    }
+
+    async fn create_transaction_and_checkpoint(catalog: &PreservedCatalog) {
+        let t = catalog.open_transaction().await;
+        let ckpt_handle = t.commit().await.unwrap();
+        ckpt_handle
+            .create_checkpoint(CheckpointData {
+                files: Default::default(),
+            })
+            .await
+            .unwrap();
+    }
+
+    async fn known_revisions(iox_object_store: &IoxObjectStore) -> Vec<(u64, bool)> {
+        let mut revisions = iox_object_store
+            .catalog_transaction_files()
+            .await
+            .unwrap()
+            .map_ok(|files| {
+                files
+                    .into_iter()
+                    .map(|f| (f.revision_counter, f.is_checkpoint()))
+                    .collect::<Vec<(u64, bool)>>()
+            })
+            .try_concat()
+            .await
+            .unwrap();
+
+        revisions.sort_unstable();
+
+        revisions
+    }
+}

--- a/tests/end_to_end_cases/management_api.rs
+++ b/tests/end_to_end_cases/management_api.rs
@@ -334,6 +334,10 @@ async fn test_create_get_update_delete_database() {
         lifecycle_rules: Some(LifecycleRules {
             buffer_size_hard: 553,
             catalog_transactions_until_checkpoint: 13,
+            catalog_transaction_prune_age: Some(generated_types::google::protobuf::Duration {
+                seconds: 11,
+                nanos: 22,
+            }),
             late_arrive_window_seconds: 423,
             worker_backoff_millis: 15,
             max_active_compactions_cfg: Some(


### PR DESCRIPTION
Through checkpoints, the preserved catalog is currently growing quadratic since each new checkpoint lists all files of the previous one plus the new files since then. Since we probably only wanna "go back in time" for a limited time span, let's just delete old transactions.

In the future, we could extend the pruning to be more sophisticated, e.g. keep checkpoints in different granularity depending on the age (e.g. hourly for checkpoints aged >1d, daily for checkpoints aged >1W, ...). I deem this simple approach here good enough for now though.