### PR TITLE
refactor: stricter delete predicate TS parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3323,7 +3323,6 @@ dependencies = [
  "datafusion_util",
  "futures",
  "hashbrown",
- "influxdb_line_protocol",
  "internal_types",
  "itertools 0.10.1",
  "libc",

--- a/query/Cargo.toml
+++ b/query/Cargo.toml
@@ -24,7 +24,6 @@ datafusion = { path = "../datafusion" }
 datafusion_util = { path = "../datafusion_util" }
 futures = "0.3"
 hashbrown = "0.11"
-influxdb_line_protocol = { path = "../influxdb_line_protocol" }
 internal_types = { path = "../internal_types" }
 observability_deps = { path = "../observability_deps" }
 parking_lot = "0.11.2"


### PR DESCRIPTION
As a a nice side effect, the parser no longer depends on the line
protocol parser.
