### PR TITLE
refactor: make `time_of_write` a parameter

### DIFF
--- a/server/src/db/replay.rs
+++ b/server/src/db/replay.rs
@@ -236,6 +236,7 @@ pub async fn perform_replay(
                         |sequence, partition_key, table_batch| {
                             filter_entry(sequence, partition_key, table_batch, replay_plan)
                         },
+                        Utc::now(),
                     ) {
                         Ok(_) => {
                             break;

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -69,6 +69,7 @@
 )]
 
 use async_trait::async_trait;
+use chrono::Utc;
 use data_types::{
     database_rules::{NodeGroup, RoutingRules, ShardConfig, ShardId, Sink},
     deleted_database::DeletedDatabase,
@@ -950,7 +951,7 @@ where
         };
 
         let bytes = entry.data().len() as u64;
-        db.store_entry(entry).await.map_err(|e| {
+        db.store_entry(entry, Utc::now()).await.map_err(|e| {
             self.metrics.ingest_entries_bytes_total.add_with_attributes(
                 bytes,
                 &[

--- a/server/src/write_buffer.rs
+++ b/server/src/write_buffer.rs
@@ -2,6 +2,7 @@ use std::future::Future;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
+use chrono::Utc;
 use futures::future::{BoxFuture, Shared};
 use futures::stream::{BoxStream, FuturesUnordered};
 use futures::{FutureExt, StreamExt, TryFutureExt};
@@ -123,6 +124,7 @@ async fn stream_in_sequenced_entries<'a>(
             match db.store_sequenced_entry(
                 Arc::clone(&sequenced_entry),
                 crate::db::filter_table_batch_keep_all,
+                Utc::now(),
             ) {
                 Ok(_) => {
                     red_observation.ok();


### PR DESCRIPTION
Instead of depending on the `chrono` clock implicitly via `Utc::now()`
we should make it an explicit parameter. This is essential for testing:

1. We have many tests guessing around this value by taking `Utc::now()`
   directly before or after the write (this commit doesn't fix that, but
   allows us to fix it in a follow-up).
2. We have some tests that ignore the `time_of_write` values in some
   comparisons because they cannot control that value (fix not included
   here but left as a follow-up).
3. The upcoming compression (#2528) needs to control timestamps within
   the compressed payload (and `time_of_write` is embedded in the
   parquet metadata) because the compressed size depends on it (even if
   the uncompressed size is stable).

In general I argue that a "clock" is always data and should be passed
(either as a value or as a "now"-function) from the API layer. Hidden
clock checks just make mocking and tests a nightmare (we've seen this w/
replay tests as well).
