### PR TITLE
fix: Ensure byte trimmed floats can handle arbitrary float literals

### DIFF
--- a/read_buffer/src/column.rs
+++ b/read_buffer/src/column.rs
@@ -2068,6 +2068,40 @@ mod test {
     }
 
     #[test]
+    fn row_ids_filter_float_trimmed() {
+        let input = &[100.0, 200.0, 300.0, 2.0, 22.0, 30.0];
+
+        let col = Column::from(&input[..]);
+        let mut row_ids = col.row_ids_filter(
+            &cmp::Operator::Equal,
+            &Value::from(200.0),
+            RowIDs::new_bitmap(),
+        );
+        assert_eq!(row_ids.unwrap().to_vec(), vec![1]);
+
+        row_ids = col.row_ids_filter(
+            &cmp::Operator::LT,
+            &Value::from(64000.0),
+            RowIDs::new_bitmap(),
+        );
+        assert!(matches!(row_ids, RowIDsOption::All(_)));
+
+        row_ids = col.row_ids_filter(
+            &cmp::Operator::GTE,
+            &Value::from(-1_000_000.0),
+            RowIDs::new_bitmap(),
+        );
+        assert!(matches!(row_ids, RowIDsOption::All(_)));
+
+        row_ids = col.row_ids_filter(
+            &cmp::Operator::NotEqual,
+            &Value::from(1_000_000.3),
+            RowIDs::new_bitmap(),
+        );
+        assert!(matches!(row_ids, RowIDsOption::All(_)));
+    }
+
+    #[test]
     fn row_ids_range() {
         let input = &[100_i64, 200, 300, 2, 200, 22, 30];
 

--- a/read_buffer/src/column/encoding/scalar/fixed.rs
+++ b/read_buffer/src/column/encoding/scalar/fixed.rs
@@ -413,8 +413,16 @@ where
         right: (L, &cmp::Operator),
         dst: RowIDs,
     ) -> RowIDs {
-        let left = (self.transcoder.encode(left.0), left.1);
-        let right = (self.transcoder.encode(right.0), right.1);
+        debug!(left=?left, right=?right, encoding=?ENCODING_NAME, "row_ids_filter_range");
+        let left = self
+            .transcoder
+            .encode_comparable(left.0, *left.1)
+            .expect("transcoder must return Some variant");
+        let right = self
+            .transcoder
+            .encode_comparable(right.0, *right.1)
+            .expect("transcoder must return Some variant");
+        debug!(left=?left, right=?right, encoding=?ENCODING_NAME, "row_ids_filter_range encoded expr");
 
         match (&left.1, &right.1) {
             (cmp::Operator::GT, cmp::Operator::LT)
@@ -425,8 +433,8 @@ where
             | (cmp::Operator::LT, cmp::Operator::GTE)
             | (cmp::Operator::LTE, cmp::Operator::GT)
             | (cmp::Operator::LTE, cmp::Operator::GTE) => self.row_ids_cmp_range_order(
-                (&left.0, Self::ord_from_op(left.1)),
-                (&right.0, Self::ord_from_op(right.1)),
+                (&left.0, Self::ord_from_op(&left.1)),
+                (&right.0, Self::ord_from_op(&right.1)),
                 dst,
             ),
 

--- a/read_buffer/src/column/encoding/scalar/fixed_null.rs
+++ b/read_buffer/src/column/encoding/scalar/fixed_null.rs
@@ -241,14 +241,14 @@ where
         let mut found = false;
         let mut count = 0;
         for i in 0..self.num_rows() as usize {
-            if self.arr.is_null(i) && found {
-                // add the non-null range
-                let (min, max) = (i as u32 - count, i as u32);
-                dst.add_range(min, max);
-                found = false;
-                count = 0;
-                continue;
-            } else if self.arr.is_null(i) {
+            if self.arr.is_null(i) {
+                if found {
+                    // add the non-null range
+                    let (min, max) = (i as u32 - count, i as u32);
+                    dst.add_range(min, max);
+                    found = false;
+                    count = 0;
+                }
                 continue;
             }
 

--- a/read_buffer/src/column/encoding/scalar/fixed_null.rs
+++ b/read_buffer/src/column/encoding/scalar/fixed_null.rs
@@ -486,8 +486,16 @@ where
         right: (L, &cmp::Operator),
         dst: RowIDs,
     ) -> RowIDs {
-        let left = (self.transcoder.encode(left.0), left.1);
-        let right = (self.transcoder.encode(right.0), right.1);
+        debug!(left=?left, right=?right, encoding=?ENCODING_NAME, "row_ids_filter_range");
+        let left = self
+            .transcoder
+            .encode_comparable(left.0, *left.1)
+            .expect("transcoder must return Some variant");
+        let right = self
+            .transcoder
+            .encode_comparable(right.0, *right.1)
+            .expect("transcoder must return Some variant");
+        debug!(left=?left, right=?right, encoding=?ENCODING_NAME, "row_ids_filter_range encoded expr");
 
         match (left.1, right.1) {
             (cmp::Operator::GT, cmp::Operator::LT)
@@ -498,8 +506,8 @@ where
             | (cmp::Operator::LT, cmp::Operator::GTE)
             | (cmp::Operator::LTE, cmp::Operator::GT)
             | (cmp::Operator::LTE, cmp::Operator::GTE) => self.row_ids_cmp_range_order(
-                (left.0, Self::ord_from_op(left.1)),
-                (right.0, Self::ord_from_op(right.1)),
+                (left.0, Self::ord_from_op(&left.1)),
+                (right.0, Self::ord_from_op(&right.1)),
                 dst,
             ),
 

--- a/read_buffer/src/column/encoding/scalar/rle.rs
+++ b/read_buffer/src/column/encoding/scalar/rle.rs
@@ -430,8 +430,16 @@ where
         right: (L, &cmp::Operator),
         dst: RowIDs,
     ) -> RowIDs {
-        let left = (self.transcoder.encode(left.0), left.1);
-        let right = (self.transcoder.encode(right.0), right.1);
+        debug!(left=?left, right=?right, encoding=?ENCODING_NAME, "row_ids_filter_range");
+        let left = self
+            .transcoder
+            .encode_comparable(left.0, *left.1)
+            .expect("transcoder must return Some variant");
+        let right = self
+            .transcoder
+            .encode_comparable(right.0, *right.1)
+            .expect("transcoder must return Some variant");
+        debug!(left=?left, right=?right, encoding=?ENCODING_NAME, "row_ids_filter_range encoded expr");
 
         match (&left.1, &right.1) {
             (cmp::Operator::GT, cmp::Operator::LT)
@@ -442,8 +450,8 @@ where
             | (cmp::Operator::LT, cmp::Operator::GTE)
             | (cmp::Operator::LTE, cmp::Operator::GT)
             | (cmp::Operator::LTE, cmp::Operator::GTE) => self.row_ids_cmp_range(
-                (&left.0, Self::ord_from_op(left.1)),
-                (&right.0, Self::ord_from_op(right.1)),
+                (&left.0, Self::ord_from_op(&left.1)),
+                (&right.0, Self::ord_from_op(&right.1)),
                 dst,
             ),
 

--- a/read_buffer/src/column/float.rs
+++ b/read_buffer/src/column/float.rs
@@ -787,8 +787,6 @@ mod test {
     }
 
     fn _row_ids_filter_float_trimmer(enc: Box<dyn ScalarEncoding<f64>>) {
-        // These cases replicate the behaviour in PG.
-        //
         // [100.0, 200.0, 100.0, 300.0, 400.0]
         let cases = vec![
             (100.0, Operator::Equal, vec![0, 2]),          // 100.0, 100.0
@@ -877,8 +875,6 @@ mod test {
     }
 
     fn _row_ids_filter_float_trimmer_with_nulls(enc: Box<dyn ScalarEncoding<f64>>) {
-        // These cases replicate the behaviour in PG.
-        //
         // [100.0, NULL, NULL, 200.0]
         let cases = vec![
             (100.0, Operator::Equal, vec![0]),    // 100.0
@@ -929,6 +925,131 @@ mod test {
                 op,
                 v,
                 enc.name()
+            );
+        }
+    }
+
+    #[test]
+    fn row_ids_filter_range_float_trimmer() {
+        let data = vec![100.0, 200.0, 100.0, 300.0, 400.0];
+
+        let float_trimmer = FloatByteTrimmer {};
+        let data_float_trimmed = data
+            .iter()
+            .cloned()
+            .map::<u16, _>(|x| float_trimmer.encode(x))
+            .collect::<Vec<u16>>();
+
+        let cases: Vec<Box<dyn ScalarEncoding<f64>>> = vec![
+            Box::new(RLE::<u16, f64, _>::new_from_iter(
+                data_float_trimmed.iter().cloned(),
+                float_trimmer,
+            )),
+            Box::new(Fixed::<u16, f64, _>::new(
+                data_float_trimmed.clone(),
+                FloatByteTrimmer {},
+            )),
+            Box::new(FixedNull::<UInt16Type, f64, _>::new(
+                PrimitiveArray::from(data_float_trimmed),
+                FloatByteTrimmer {},
+            )),
+        ];
+
+        for enc in cases {
+            _row_ids_filter_range_float_trimmer(enc)
+        }
+    }
+
+    fn _row_ids_filter_range_float_trimmer(enc: Box<dyn ScalarEncoding<f64>>) {
+        // [100.0, 200.0, 100.0, 300.0, 400.0]
+        let cases = vec![
+            ((100.0, &Operator::LT), (99.0, &Operator::GT), vec![]), //
+            ((100.0, &Operator::LTE), (100.0, &Operator::GTE), vec![0, 2]), // 100.0, 100.0
+            (
+                (100.0, &Operator::GT),
+                (400.0, &Operator::LTE),
+                vec![1, 3, 4],
+            ), // 200.0, 300.0, 400.0
+            (
+                (100.0, &Operator::GTE),
+                (401.0, &Operator::LTE),
+                vec![0, 1, 2, 3, 4],
+            ), // 100.0, 200.0, 100.0, 300.0, 400.0
+            ((200.0, &Operator::LT), (99.6, &Operator::GT), vec![0, 2]), // 100.0, 100.0
+            ((200.0, &Operator::GT), (401.2, &Operator::LTE), vec![3, 4]), // 300.0, 400.0
+            (
+                (200.0, &Operator::GTE),
+                (400.9, &Operator::LT),
+                vec![1, 3, 4],
+            ), // 200.0, 300.0, 400.0
+            (
+                (99.8, &Operator::GT),
+                (500.87, &Operator::LT),
+                vec![0, 1, 2, 3, 4],
+            ), // 100.0, 200.0, 100.0, 300.0, 400.0
+        ];
+
+        for (left, right, exp) in cases {
+            let dst = enc.row_ids_filter_range(left, right, RowIDs::new_vector());
+            assert_eq!(
+                dst.unwrap_vector(),
+                &exp,
+                "example '{:?} {:?}' failed for {:?}",
+                left,
+                right,
+                enc.name(),
+            );
+        }
+    }
+
+    #[test]
+    fn row_ids_filter_range_float_trimmer_with_nulls() {
+        let data = vec![Some(100.0), None, None, Some(200.0), None];
+
+        let float_trimmer = FloatByteTrimmer {};
+
+        let cases: Vec<Box<dyn ScalarEncoding<f64>>> = vec![
+            Box::new(RLE::<u16, f64, _>::new_from_iter_opt(
+                data.iter()
+                    .cloned()
+                    .map(|x| x.map(|v| float_trimmer.encode(v))),
+                FloatByteTrimmer {},
+            )),
+            Box::new(FixedNull::<UInt16Type, f64, _>::new(
+                data.iter()
+                    .cloned()
+                    .map(|v| v.map(|v| float_trimmer.encode(v)))
+                    .collect(),
+                FloatByteTrimmer {},
+            )),
+        ];
+
+        for enc in cases {
+            _row_ids_filter_range_float_trimmer_with_nulls(enc)
+        }
+    }
+
+    fn _row_ids_filter_range_float_trimmer_with_nulls(enc: Box<dyn ScalarEncoding<f64>>) {
+        // [100.0, NULL, NULL, 200.0, NULL]
+        let cases = vec![
+            ((100.0, &Operator::LT), (99.0, &Operator::GT), vec![]), //
+            ((100.0, &Operator::LTE), (100.0, &Operator::GTE), vec![0]), // 100.0
+            ((100.0, &Operator::GT), (400.0, &Operator::LTE), vec![3]), // 200.0
+            ((100.0, &Operator::GTE), (401.0, &Operator::LTE), vec![0, 3]), // 100.0, 200.0
+            ((200.0, &Operator::LT), (99.6, &Operator::GT), vec![0]), // 100.0
+            ((200.0, &Operator::GT), (401.2, &Operator::LTE), vec![]), //
+            ((99.8, &Operator::GT), (500.87, &Operator::LT), vec![0, 3]), // 100.0, 200.0
+        ];
+
+        for (left, right, exp) in cases {
+            let dst = enc.row_ids_filter_range(left, right, RowIDs::new_vector());
+            assert_eq!(
+                dst.unwrap_vector(),
+                &exp,
+                "example '{:?} {:?}' failed for {:?}",
+                left,
+                right,
+                enc.name(),
             );
         }
     }

--- a/read_buffer/src/column/float.rs
+++ b/read_buffer/src/column/float.rs
@@ -767,13 +767,13 @@ mod test {
             .collect::<Vec<u16>>();
 
         let cases: Vec<Box<dyn ScalarEncoding<f64>>> = vec![
-            Box::new(RLE::<_, _, _>::new_from_iter(
-                data.iter().cloned(),
-                NoOpTranscoder {},
+            Box::new(RLE::<u16, f64, _>::new_from_iter(
+                data_float_trimmed.iter().cloned(),
+                float_trimmer,
             )),
             Box::new(Fixed::<u16, f64, _>::new(
                 data_float_trimmed.clone(),
-                float_trimmer,
+                FloatByteTrimmer {},
             )),
             Box::new(FixedNull::<UInt16Type, f64, _>::new(
                 PrimitiveArray::from(data_float_trimmed),
@@ -838,7 +838,98 @@ mod test {
 
         for (v, op, exp) in cases {
             let dst = enc.row_ids_filter(v, &op, RowIDs::new_vector());
-            assert_eq!(dst.unwrap_vector(), &exp, "example '{} {:?}' failed", op, v);
+            assert_eq!(
+                dst.unwrap_vector(),
+                &exp,
+                "example '{} {:?}' failed for {:?}",
+                op,
+                v,
+                enc.name()
+            );
+        }
+    }
+
+    #[test]
+    fn row_ids_filter_float_trimmer_with_nulls() {
+        let data = vec![Some(100.0), None, None, Some(200.0), None];
+
+        let float_trimmer = FloatByteTrimmer {};
+
+        let cases: Vec<Box<dyn ScalarEncoding<f64>>> = vec![
+            Box::new(RLE::<u16, f64, _>::new_from_iter_opt(
+                data.iter()
+                    .cloned()
+                    .map(|x| x.map(|v| float_trimmer.encode(v))),
+                FloatByteTrimmer {},
+            )),
+            Box::new(FixedNull::<UInt16Type, f64, _>::new(
+                data.iter()
+                    .cloned()
+                    .map(|v| v.map(|v| float_trimmer.encode(v)))
+                    .collect(),
+                FloatByteTrimmer {},
+            )),
+        ];
+
+        for enc in cases {
+            _row_ids_filter_float_trimmer_with_nulls(enc)
+        }
+    }
+
+    fn _row_ids_filter_float_trimmer_with_nulls(enc: Box<dyn ScalarEncoding<f64>>) {
+        // These cases replicate the behaviour in PG.
+        //
+        // [100.0, NULL, NULL, 200.0]
+        let cases = vec![
+            (100.0, Operator::Equal, vec![0]),    // 100.0
+            (100.0, Operator::NotEqual, vec![3]), // 200.0
+            (100.0, Operator::LT, vec![]),        //
+            (100.0, Operator::LTE, vec![0]),      // 100.0
+            (100.0, Operator::GT, vec![3]),       // 200.0
+            (100.0, Operator::GTE, vec![0, 3]),   // 100.0, 200.0
+            (200.0, Operator::Equal, vec![3]),    // 200.0
+            (200.0, Operator::NotEqual, vec![0]), // 100.0
+            (200.0, Operator::LT, vec![0]),       // 100.0
+            (200.0, Operator::LTE, vec![0, 3]),   // 100.0, 200.0
+            (200.0, Operator::GT, vec![]),        //
+            (200.0, Operator::GTE, vec![3]),      // 200.0
+            // Values not present in the column
+            (99.0, Operator::Equal, vec![]),         //
+            (99.0, Operator::NotEqual, vec![0, 3]),  // 100.0, 200.0
+            (99.0, Operator::LT, vec![]),            //
+            (99.0, Operator::LTE, vec![]),           //
+            (99.0, Operator::GT, vec![0, 3]),        // 100.0, 200.0
+            (99.0, Operator::GTE, vec![0, 3]),       // 100.0, 200.0
+            (200.4, Operator::Equal, vec![]),        //
+            (200.4, Operator::NotEqual, vec![0, 3]), // 100.0, 200.0
+            (200.4, Operator::LT, vec![0, 3]),       // 100.0,200.0
+            (200.4, Operator::LTE, vec![0, 3]),      // 100.0, 200.0
+            (200.4, Operator::GT, vec![]),           //
+            (200.4, Operator::GTE, vec![]),          //
+            (201.0, Operator::Equal, vec![]),        //
+            (201.0, Operator::NotEqual, vec![0, 3]), // 100.0, 200.0
+            (201.0, Operator::LT, vec![0, 3]),       // 100.0, 200.0
+            (201.0, Operator::LTE, vec![0, 3]),      // 100.0, 200.0
+            (201.0, Operator::GT, vec![]),           //
+            (201.0, Operator::GTE, vec![]),          //
+            (401.0, Operator::Equal, vec![]),        //
+            (401.0, Operator::NotEqual, vec![0, 3]), // 100.0, 200.0
+            (401.0, Operator::LT, vec![0, 3]),       // 100.0, 200.0
+            (401.0, Operator::LTE, vec![0, 3]),      // 100.0, 200.0
+            (401.0, Operator::GT, vec![]),           //
+            (401.0, Operator::GTE, vec![]),          //
+        ];
+
+        for (v, op, exp) in cases {
+            let dst = enc.row_ids_filter(v, &op, RowIDs::new_vector());
+            assert_eq!(
+                dst.unwrap_vector(),
+                &exp,
+                "example '{} {:?}' failed for {:?}",
+                op,
+                v,
+                enc.name()
+            );
         }
     }
 }


### PR DESCRIPTION
This PR addresses a defect I identified when working on a new timestamp compression feature.

As far as I'm aware we have not hit upon this defect during internal testing yet, likely because we primarily test via the gRPC API, and with that API you generally do not filter on field columns.

The defect applies to `f64` columns in the Read Buffer that have been encoded using the Byte Trimming encoder. Recall that this encoding can store a column of `f64` values as integers with a smaller physical footprint, subject to the input values all being natural numbers.

For example: `[1.0, 20.0, 30.0] -> [1_u8, 2, 30]`.

The defect is as follows: prior to this change, if you provided a predicate along these lines to the read buffer `WHERE my_col >= 20.4` the column encoding would first convert the logical representation of the literal (an `f64` with a value of `20.4`) into the encoded physical representation (a `u8` with a value of `20`). The values `[20.0, 30.0]` would then satisfy this predicate. This is clearly incorrect. 

Realising that this will also be a problem for some future encodings I am working on I decided the best course of action would be to add a new method to the `transcoder` trait that would allow a transcoder to describe how to encode a literal used for a predicate. This method is called `encode_comparable`.

For the `FloatByteTrimmer` encoding in question the implementation of `encode_comparable` considers the comparison operator and returns a physical representation and comparison operator that ensures that the correct values are evaluated on the column. This allows us to continue working direclty on the compressed represenation. In the above example of `WHERE my_col >= 20.4` the encoding would convert the predicate operator and literal to `> 20_u8` ensuring the correct values satisfy the predicate (`[30.0]`).

