### PR TITLE
refactor: split preserved catalog `api` into `core` and `interface`

### DIFF
--- a/parquet_file/src/catalog/dump.rs
+++ b/parquet_file/src/catalog/dump.rs
@@ -223,8 +223,7 @@ mod tests {
 
     use crate::{
         catalog::{
-            api::{CatalogParquetInfo, PreservedCatalog},
-            test_helpers::TestCatalogState,
+            core::PreservedCatalog, interface::CatalogParquetInfo, test_helpers::TestCatalogState,
         },
         test_utils::{chunk_addr, make_iox_object_store, make_metadata, TestSize},
     };

--- a/parquet_file/src/catalog/interface.rs
+++ b/parquet_file/src/catalog/interface.rs
@@ -1,0 +1,99 @@
+//! Abstract interfaces to make different users work with the perserved catalog.
+use std::{collections::HashMap, sync::Arc};
+
+use iox_object_store::{IoxObjectStore, ParquetFilePath};
+use snafu::Snafu;
+
+use crate::metadata::IoxParquetMetaData;
+
+/// Struct containing all information that a catalog received for a new parquet file.
+#[derive(Debug, Clone)]
+pub struct CatalogParquetInfo {
+    /// Path within this database.
+    pub path: ParquetFilePath,
+
+    /// Size of the parquet file, in bytes
+    pub file_size_bytes: usize,
+
+    /// Associated parquet metadata.
+    pub metadata: Arc<IoxParquetMetaData>,
+}
+
+#[derive(Debug, Snafu)]
+#[snafu(visibility(pub))]
+pub enum CatalogStateAddError {
+    #[snafu(display("Cannot extract metadata from {:?}: {}", path, source))]
+    MetadataExtractFailed {
+        source: crate::metadata::Error,
+        path: ParquetFilePath,
+    },
+
+    #[snafu(display("Schema for {:?} does not work with existing schema: {}", path, source))]
+    SchemaError {
+        source: Box<dyn std::error::Error + Send + Sync>,
+        path: ParquetFilePath,
+    },
+
+    #[snafu(
+        display(
+            "Internal error: Using checkpoints from {:?} leads to broken replay plan: {}, catalog likely broken",
+            path,
+            source
+        ),
+    )]
+    ReplayPlanError {
+        source: Box<dyn std::error::Error + Send + Sync>,
+        path: ParquetFilePath,
+    },
+
+    #[snafu(display("Cannot create parquet chunk from {:?}: {}", path, source))]
+    ChunkCreationFailed {
+        source: crate::chunk::Error,
+        path: ParquetFilePath,
+    },
+
+    #[snafu(display("Parquet already exists in catalog: {:?}", path))]
+    ParquetFileAlreadyExists { path: ParquetFilePath },
+}
+
+#[derive(Debug, Snafu)]
+#[snafu(visibility(pub))]
+pub enum CatalogStateRemoveError {
+    #[snafu(display("Parquet does not exist in catalog: {:?}", path))]
+    ParquetFileDoesNotExist { path: ParquetFilePath },
+}
+
+/// Abstraction over how the in-memory state of the catalog works.
+pub trait CatalogState {
+    /// Input to create a new empty instance.
+    ///
+    /// See [`new_empty`](Self::new_empty) for details.
+    type EmptyInput: Send;
+
+    /// Create empty state w/o any known files.
+    fn new_empty(db_name: &str, data: Self::EmptyInput) -> Self;
+
+    /// Add parquet file to state.
+    fn add(
+        &mut self,
+        iox_object_store: Arc<IoxObjectStore>,
+        info: CatalogParquetInfo,
+    ) -> Result<(), CatalogStateAddError>;
+
+    /// Remove parquet file from state.
+    fn remove(&mut self, path: &ParquetFilePath) -> Result<(), CatalogStateRemoveError>;
+}
+
+/// Structure that holds all information required to create a checkpoint.
+///
+/// Note that while checkpoint are addressed using the same schema as we use for transaction
+/// (revision counter, UUID), they contain the changes at the end (aka including) the transaction
+/// they refer.
+#[derive(Debug)]
+pub struct CheckpointData {
+    /// List of all Parquet files that are currently (i.e. by the current version) tracked by the
+    /// catalog.
+    ///
+    /// If a file was once added but later removed it MUST NOT appear in the result.
+    pub files: HashMap<ParquetFilePath, CatalogParquetInfo>,
+}

--- a/parquet_file/src/catalog/mod.rs
+++ b/parquet_file/src/catalog/mod.rs
@@ -1,6 +1,7 @@
-pub mod api;
 pub mod cleanup;
+pub mod core;
 pub mod dump;
+pub mod interface;
 mod internals;
 pub mod prune;
 pub mod rebuild;

--- a/parquet_file/src/catalog/prune.rs
+++ b/parquet_file/src/catalog/prune.rs
@@ -8,7 +8,7 @@ use object_store::{ObjectStore, ObjectStoreApi};
 use snafu::{ResultExt, Snafu};
 
 use crate::catalog::{
-    api::{ProtoIOError, ProtoParseError},
+    core::{ProtoIOError, ProtoParseError},
     internals::{proto_io::load_transaction_proto, proto_parse::parse_timestamp},
 };
 
@@ -33,7 +33,7 @@ pub enum Error {
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
-/// Prune history of [`PreservedCatalog`](crate::catalog::api::PreservedCatalog).
+/// Prune history of [`PreservedCatalog`](crate::catalog::core::PreservedCatalog).
 ///
 /// This deletes all transactions and checkpoints that were started prior to `before`. Note that this only deletes data
 /// that is safe to delete when time travel to `before` is allowed. For example image the following transactions:
@@ -133,8 +133,7 @@ fn is_checkpoint_or_zero(path: &TransactionFilePath) -> bool {
 mod tests {
     use crate::{
         catalog::{
-            api::{CheckpointData, PreservedCatalog},
-            test_helpers::TestCatalogState,
+            core::PreservedCatalog, interface::CheckpointData, test_helpers::TestCatalogState,
         },
         test_utils::make_iox_object_store,
     };

--- a/parquet_file/src/metadata.rs
+++ b/parquet_file/src/metadata.rs
@@ -120,7 +120,7 @@ use thrift::protocol::{TCompactInputProtocol, TCompactOutputProtocol, TOutputPro
 /// For breaking changes, this will change.
 ///
 /// **Important: When changing this structure, consider bumping the
-///   [catalog transaction version](crate::catalog::api::TRANSACTION_VERSION)!**
+///   [catalog transaction version](crate::catalog::core::TRANSACTION_VERSION)!**
 pub const METADATA_VERSION: u32 = 6;
 
 /// File-level metadata key to store the IOx-specific data.

--- a/server/src/database.rs
+++ b/server/src/database.rs
@@ -18,7 +18,7 @@ use internal_types::freezable::Freezable;
 use iox_object_store::IoxObjectStore;
 use observability_deps::tracing::{error, info, warn};
 use parking_lot::{MappedRwLockReadGuard, RwLock, RwLockReadGuard};
-use parquet_file::catalog::api::PreservedCatalog;
+use parquet_file::catalog::core::PreservedCatalog;
 use persistence_windows::checkpoint::ReplayPlan;
 use snafu::{ensure, OptionExt, ResultExt, Snafu};
 use std::{future::Future, sync::Arc, time::Duration};
@@ -60,7 +60,7 @@ pub enum Error {
     ))]
     WipePreservedCatalog {
         db_name: String,
-        source: Box<parquet_file::catalog::api::Error>,
+        source: Box<parquet_file::catalog::core::Error>,
     },
 
     #[snafu(display("failed to skip replay for database ({}): {}", db_name, source))]

--- a/server/src/db.rs
+++ b/server/src/db.rs
@@ -32,8 +32,9 @@ use iox_object_store::IoxObjectStore;
 use mutable_buffer::chunk::{ChunkMetrics as MutableBufferChunkMetrics, MBChunk};
 use observability_deps::tracing::{debug, error, info};
 use parquet_file::catalog::{
-    api::{CatalogParquetInfo, CheckpointData, PreservedCatalog},
     cleanup::{delete_files as delete_parquet_files, get_unreferenced_parquet_files},
+    core::PreservedCatalog,
+    interface::{CatalogParquetInfo, CheckpointData},
     prune::prune_history as prune_catalog_transaction_history,
 };
 use persistence_windows::{checkpoint::ReplayPlan, persistence_windows::PersistenceWindows};

--- a/server/src/db/lifecycle/error.rs
+++ b/server/src/db/lifecycle/error.rs
@@ -49,7 +49,7 @@ pub enum Error {
 
     #[snafu(display("Error while commiting transaction on preserved catalog: {}", source))]
     CommitError {
-        source: parquet_file::catalog::api::Error,
+        source: parquet_file::catalog::core::Error,
     },
 
     #[snafu(display("Cannot write chunk: {}", addr))]

--- a/server/src/db/lifecycle/write.rs
+++ b/server/src/db/lifecycle/write.rs
@@ -17,7 +17,7 @@ use data_types::{chunk_metadata::ChunkLifecycleAction, job::Job};
 use internal_types::selection::Selection;
 use observability_deps::tracing::{debug, warn};
 use parquet_file::{
-    catalog::api::CatalogParquetInfo,
+    catalog::interface::CatalogParquetInfo,
     chunk::{ChunkMetrics as ParquetChunkMetrics, ParquetChunk},
     metadata::IoxMetadata,
     storage::Storage,

--- a/server/src/db/load.rs
+++ b/server/src/db/load.rs
@@ -1,11 +1,17 @@
 //! Functionality to load a [`Catalog`](crate::db::catalog::Catalog) and other information from a
-//! [`PreservedCatalog`](parquet_file::catalog::api::PreservedCatalog).
+//! [`PreservedCatalog`](parquet_file::catalog::core::PreservedCatalog).
 
 use super::catalog::{chunk::ChunkStage, table::TableSchemaUpsertHandle, Catalog};
 use iox_object_store::{IoxObjectStore, ParquetFilePath};
 use observability_deps::tracing::{error, info};
 use parquet_file::{
-    catalog::api::{CatalogParquetInfo, CatalogState, ChunkCreationFailed, PreservedCatalog},
+    catalog::{
+        core::PreservedCatalog,
+        interface::{
+            CatalogParquetInfo, CatalogState, CatalogStateAddError, CatalogStateRemoveError,
+            ChunkCreationFailed,
+        },
+    },
     chunk::{ChunkMetrics as ParquetChunkMetrics, ParquetChunk},
 };
 use persistence_windows::checkpoint::{ReplayPlan, ReplayPlanner};
@@ -22,17 +28,17 @@ pub enum Error {
 
     #[snafu(display("Cannot create new empty preserved catalog: {}", source))]
     CannotCreateCatalog {
-        source: parquet_file::catalog::api::Error,
+        source: parquet_file::catalog::core::Error,
     },
 
     #[snafu(display("Cannot load preserved catalog: {}", source))]
     CannotLoadCatalog {
-        source: parquet_file::catalog::api::Error,
+        source: parquet_file::catalog::core::Error,
     },
 
     #[snafu(display("Cannot wipe preserved catalog: {}", source))]
     CannotWipeCatalog {
-        source: parquet_file::catalog::api::Error,
+        source: parquet_file::catalog::core::Error,
     },
 }
 pub type Result<T, E = Error> = std::result::Result<T, E>;
@@ -166,8 +172,10 @@ impl CatalogState for Loader {
         &mut self,
         iox_object_store: Arc<IoxObjectStore>,
         info: CatalogParquetInfo,
-    ) -> parquet_file::catalog::api::Result<()> {
-        use parquet_file::catalog::api::{MetadataExtractFailed, ReplayPlanError, SchemaError};
+    ) -> Result<(), CatalogStateAddError> {
+        use parquet_file::catalog::interface::{
+            MetadataExtractFailed, ReplayPlanError, SchemaError,
+        };
 
         // extract relevant bits from parquet file metadata
         let iox_md = info
@@ -212,9 +220,7 @@ impl CatalogState for Loader {
             .get_or_create_partition(&iox_md.table_name, &iox_md.partition_key);
         let mut partition = partition.write();
         if partition.chunk(iox_md.chunk_id).is_some() {
-            return Err(
-                parquet_file::catalog::api::Error::ParquetFileAlreadyExists { path: info.path },
-            );
+            return Err(CatalogStateAddError::ParquetFileAlreadyExists { path: info.path });
         }
         let schema_handle = TableSchemaUpsertHandle::new(&table_schema, &parquet_chunk.schema())
             .map_err(|e| Box::new(e) as _)
@@ -234,7 +240,7 @@ impl CatalogState for Loader {
         Ok(())
     }
 
-    fn remove(&mut self, path: &ParquetFilePath) -> parquet_file::catalog::api::Result<()> {
+    fn remove(&mut self, path: &ParquetFilePath) -> Result<(), CatalogStateRemoveError> {
         let mut removed_any = false;
 
         for partition in self.catalog.partitions() {
@@ -261,7 +267,7 @@ impl CatalogState for Loader {
         if removed_any {
             Ok(())
         } else {
-            Err(parquet_file::catalog::api::Error::ParquetFileDoesNotExist { path: path.clone() })
+            Err(CatalogStateRemoveError::ParquetFileDoesNotExist { path: path.clone() })
         }
     }
 }
@@ -273,7 +279,7 @@ mod tests {
     use data_types::{server_id::ServerId, DatabaseName};
     use object_store::ObjectStore;
     use parquet_file::catalog::{
-        api::CheckpointData,
+        interface::CheckpointData,
         test_helpers::{assert_catalog_state_implementation, TestCatalogState},
     };
     use std::convert::TryFrom;

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -1154,7 +1154,7 @@ mod tests {
         path::{parsed::DirsAndFileName, ObjectStorePath},
         ObjectStore, ObjectStoreApi,
     };
-    use parquet_file::catalog::{api::PreservedCatalog, test_helpers::TestCatalogState};
+    use parquet_file::catalog::{core::PreservedCatalog, test_helpers::TestCatalogState};
     use query::{exec::ExecutionContextProvider, frontend::sql::SqlQueryPlanner, QueryDatabase};
     use std::{
         convert::{TryFrom, TryInto},


### PR DESCRIPTION
This makes it clearer which traits and functions users of the preserved
catalog must implement. This also splits the error types into smaller
enums that are easier to understand.

This change should make it easier to implement new functionality (like
capturing delete predicates).
