### PR TITLE
feat: Add tag_set and tag_pairs to measurements in Data Generator

### DIFF
--- a/iox_data_generator/benches/point_generation.rs
+++ b/iox_data_generator/benches/point_generation.rs
@@ -7,6 +7,7 @@ use iox_data_generator::{
 pub fn single_agent(c: &mut Criterion) {
     let spec = DataSpec {
         base_seed: Some("faster faster faster".into()),
+        include_spec_tag: Some(true),
         name: "benchmark".into(),
         values: vec![],
         tag_sets: vec![],
@@ -25,6 +26,8 @@ pub fn single_agent(c: &mut Criterion) {
                     field_value_spec: FieldValueSpec::Bool(true),
                     count: None,
                 }],
+                tag_set: None,
+                tag_pairs: vec![],
             }],
         }],
     };
@@ -52,6 +55,7 @@ pub fn single_agent(c: &mut Criterion) {
                     0,
                     false,
                     1,
+                    false,
                 )
             });
             let n_points = r.expect("Could not generate data");

--- a/iox_data_generator/schemas/storage_cardinality_example.toml
+++ b/iox_data_generator/schemas/storage_cardinality_example.toml
@@ -1,9 +1,16 @@
 name = "storage_cardinality_example"
 base_seed = "this is a demo"
 
+# Values are automatically generated before the agents are intialized. They generate tag key/value pairs
+# with the name of the value as the tag key and the evaluated template as the value. These pairs
+# are Arc wrapped so they can be shared across tagsets and used in the agents as pre-generated data.
 [[values]]
+# the name must not have a . in it, which is used to access children later. Otherwise it's open.
 name = "role"
+# the template can use a number of helpers to get an id, a random string and the name, see below for examples
 template = "storage"
+# this number of tag pairs will be generated. If this is > 1, the id or a random character string should be
+# used in the template to ensure that the tag key/value pairs are unique.
 cardinality = 1
 
 [[values]]
@@ -15,7 +22,7 @@ cardinality = 1
 name = "org_id"
 # Fill in the value with the cardinality counter and 15 random alphanumeric characters
 template = "{{id}}_{{random 15}}"
-cardinality = 1
+cardinality = 2
 has_one = ["env"]
 
 [[values]]
@@ -25,36 +32,22 @@ cardinality = 10
 
 [[values]]
 name = "bucket_id"
+# a bucket belongs to an org. With this, you would be able to access the org.id or org.value in the template
 belongs_to = "org_id"
-# each bucket will have a unique value so it can be used here to guarantee uniqueness even across orgs
+# each bucket will have a unique id, which is used here to guarantee uniqueness even across orgs. We also
+# have a random 15 character alphanumeric sequence to pad out the value length.
 template = "{{id}}_{{random 15}}"
 # For each org, 3 buckets will be generated
 cardinality = 3
-
-[[values]]
-name = "node_id"
-template = "{{id}}"
-cardinality = 100
-
-[[values]]
-name = "host"
-template = "storage-{{node_id.value}}"
-belongs_to = "node_id"
-cardinality = 1
-
-[[values]]
-name = "hostname"
-template = "{{node_id.value}}"
-belongs_to = "node_id"
-cardinality = 1
 
 [[values]]
 name = "partition_id"
 template = "{{id}}"
 cardinality = 10
 
-# makes a tagset so every bucket exists on every node with every partition.
-# So count(bucket) * count(node) * count(partition) cardinality.
+# makes a tagset so every bucket appears in every partition. The other tags are descriptive and don't
+# increase the cardiality beyond count(bucket) * count(partition). Later this example will use the
+# agent and measurement generation to take this base tagset and increase cardinality on a per-agent basis.
 [[tag_sets]]
 name = "bucket_set"
 for_each = [
@@ -63,19 +56,24 @@ for_each = [
     "org_id",
     "org_id.env",
     "org_id.bucket_id",
-    "node_id",
-    "node_id.hostname",
-    "node_id.host",
     "partition_id",
 ]
 
 [[agents]]
 name = "metric-scraper"
-# sampling_interval = "1s"
+# create this many agents
+count = 3
 
 [[agents.measurements]]
 name = "storage_usage_bucket_cardinality"
-# TODO: new syntax to make use of tag sets here
+# each sampling will have all the tag sets from this collection in addition to the tags and tag_pairs specified
+tag_set = "bucket_set"
+# for each agent, this specific measurement will be decorated with these additional tags.
+tag_pairs = [
+    {key = "node_id", template = "{{agent.id}}"},
+    {key = "hostname", template = "{{agent.id}}"},
+    {key = "host", template = "storage-{{agent.id}}"},
+]
 
 [[agents.measurements.fields]]
 name = "gauge"

--- a/iox_data_generator/src/agent.rs
+++ b/iox_data_generator/src/agent.rs
@@ -5,6 +5,7 @@ use crate::{
     DataGenRng, RandomNumberGenerator,
 };
 
+use crate::tag_set::GeneratedTagSets;
 use influxdb2_client::models::DataPoint;
 use parse_duration;
 use snafu::{ResultExt, Snafu};
@@ -87,6 +88,7 @@ impl<T: DataGenRng> Agent<T> {
         end_datetime: Option<i64>,   // also in nanoseconds since the epoch, defaults to now
         execution_start_time: i64,
         continue_on: bool, // If true, run in "continue" mode after historical data is generated
+        generated_tag_sets: &GeneratedTagSets,
     ) -> Result<Self> {
         let name = agent_name.into();
         // Will agents actually need rngs? Might just need seeds...
@@ -104,6 +106,7 @@ impl<T: DataGenRng> Agent<T> {
                     &seed,
                     &agent_tags,
                     execution_start_time,
+                    generated_tag_sets,
                 )
             })
             .collect::<crate::measurement::Result<_>>()
@@ -241,11 +244,22 @@ mod test {
                     },
                     count: Some(2),
                 }],
+                tag_pairs: vec![],
+                tag_set: None,
             };
 
-            let measurement_generator_set =
-                MeasurementGeneratorSet::new("test", 42, &measurement_spec, "spec-test", &[], 0)
-                    .unwrap();
+            let generated_tag_sets = GeneratedTagSets::default();
+
+            let measurement_generator_set = MeasurementGeneratorSet::new(
+                "test",
+                42,
+                &measurement_spec,
+                "spec-test",
+                &[],
+                0,
+                &generated_tag_sets,
+            )
+            .unwrap();
 
             Self {
                 agent_id: 0,

--- a/iox_data_generator/src/bin/iox_data_generator.rs
+++ b/iox_data_generator/src/bin/iox_data_generator.rs
@@ -202,6 +202,7 @@ Logging:
         execution_start_time.timestamp_nanos(),
         continue_on,
         batch_size,
+        disable_log_output,
     )
     .await;
 

--- a/iox_data_generator/src/specification.rs
+++ b/iox_data_generator/src/specification.rs
@@ -28,11 +28,14 @@ type Result<T, E = Error> = std::result::Result<T, E>;
 #[derive(Deserialize, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct DataSpec {
-    /// Every point generated from this configuration will contain a tag
-    /// `data_spec=[this value]` to identify what generated that data. This
-    /// name can also be used in string replacements by using the
-    /// placeholder `{{data_spec}}`.
+    /// If `include_spec_tag` is set to true, eveyr point generated from this
+    /// configuration will contain a tag `data_spec=[this value]` to identify
+    /// what generated that data. This name can also be used in string replacements
+    /// by using the placeholder `{{data_spec}}`.
     pub name: String,
+    /// If set to true, all samples generated will include a `data_spec=[name]`
+    /// key/value pair.
+    pub include_spec_tag: Option<bool>,
     /// A string to be used as the seed to the random number generators.
     ///
     /// When specified, this is used as a base seed propagated through all
@@ -197,9 +200,27 @@ pub struct MeasurementSpec {
     /// Specification of the tags for this measurement
     #[serde(default)]
     pub tags: Vec<TagSpec>,
+    /// Specifies a tag set to include in every sampling in addition to tags specified
+    pub tag_set: Option<String>,
+    /// Specification of tag key/value pairs that get generated once and reused for
+    /// every sampling.
+    #[serde(default)]
+    pub tag_pairs: Vec<TagPairSpec>,
     /// Specification of the fields for this measurement. At least one field is
     /// required.
     pub fields: Vec<FieldSpec>,
+}
+
+/// Specification of a tag key/value pair whose template will be evaluated once and
+/// the value will be reused across every sampling.
+#[derive(Deserialize, Debug)]
+#[cfg_attr(test, derive(Default))]
+#[serde(deny_unknown_fields)]
+pub struct TagPairSpec {
+    /// The tag key
+    pub key: String,
+    /// The template the generate the tag value
+    pub template: String,
 }
 
 /// The specification of how to generate tag keys and values for a particular

--- a/iox_data_generator/src/tag_set.rs
+++ b/iox_data_generator/src/tag_set.rs
@@ -75,7 +75,7 @@ pub struct GeneratedTagSets {
     has_one_values: BTreeMap<String, ParentToHasOnes>,
     // this maps the name of the tag set specified in the spec to the collection of tag
     // sets that were pre-generated.
-    tag_sets: BTreeMap<String, Vec<TagSet>>,
+    tag_sets: BTreeMap<String, Arc<Vec<TagSet>>>,
 }
 
 #[derive(Debug, Default)]
@@ -86,7 +86,6 @@ pub struct ParentToHasOnes {
 }
 
 impl GeneratedTagSets {
-    #[allow(dead_code)]
     pub fn from_spec(spec: &DataSpec) -> Result<Self> {
         let mut generated_tag_sets = Self::default();
 
@@ -119,8 +118,7 @@ impl GeneratedTagSets {
         Ok(generated_tag_sets)
     }
 
-    #[allow(dead_code)]
-    pub fn sets_for(&self, name: &str) -> Option<&Vec<TagSet>> {
+    pub fn sets_for(&self, name: &str) -> Option<&Arc<Vec<TagSet>>> {
         self.tag_sets.get(name)
     }
 
@@ -183,7 +181,8 @@ impl GeneratedTagSets {
             })
             .collect();
         let tag_sets = self.for_each_tag_set(None, &tag_set_keys, &mut tag_pairs, 0)?;
-        self.tag_sets.insert(set_name.to_string(), tag_sets);
+        self.tag_sets
+            .insert(set_name.to_string(), Arc::new(tag_sets));
 
         Ok(())
     }
@@ -461,8 +460,8 @@ impl std::fmt::Display for TagSet {
 
 #[derive(Debug, PartialEq, PartialOrd)]
 pub struct TagPair {
-    key: Arc<String>,
-    value: Arc<String>,
+    pub key: Arc<String>,
+    pub value: Arc<String>,
 }
 
 impl std::fmt::Display for TagPair {

--- a/iox_data_generator/src/write.rs
+++ b/iox_data_generator/src/write.rs
@@ -372,6 +372,7 @@ bool = true"#;
             now,
             false,
             1,
+            false,
         )
         .await?;
 
@@ -417,6 +418,7 @@ bool = true"#;
             now,
             false,
             2,
+            false,
         )
         .await?;
 


### PR DESCRIPTION
This adds the ability to specify a tag_set and a collection of tag_pairs to measurements in the data generator. Tag pairs are evaluated once when the generator is created. This avoids re-running handlebars evaluations while generating data for tags that don't change value.

This commit also fixes an issue when printing the generation output to stdout while generating from more than one agent. Previously it would be garbled together.

Follow on PRs will update the tag generation code in measurement specs to be more consistent and optimized for performance. I'll be removing the restriction of using different options while using tag_set and tag_pairs. I wanted to get this in first to show the structure of what is output.

Running this from the project root will show the example output for the included schema that uses this new feature:
```
 cargo run -p iox_data_generator -- --spec ./iox_data_generator/schemas/storage_cardinality_example.toml --print
```

And a snippet of that output looks like this:
```
storage_usage_bucket_cardinality,bucket_id=1_2Q2iaNH0Y6qpCHo,env=whatever-environment-1,host=storage-0,hostname=0,node_id=0,org_id=1_00nRAqX0VxfOBEl,partition_id=1,role=storage,url=http://127.0.0.1:6060/metrics/usage gauge=721566i 1631909529018737000
storage_usage_bucket_cardinality,bucket_id=1_2Q2iaNH0Y6qpCHo,env=whatever-environment-1,host=storage-0,hostname=0,node_id=0,org_id=1_00nRAqX0VxfOBEl,partition_id=2,role=storage,url=http://127.0.0.1:6060/metrics/usage gauge=1415953i 1631909529018737000
storage_usage_bucket_cardinality,bucket_id=1_2Q2iaNH0Y6qpCHo,env=whatever-environment-1,host=storage-0,hostname=0,node_id=0,org_id=1_00nRAqX0VxfOBEl,partition_id=3,role=storage,url=http://127.0.0.1:6060/metrics/usage gauge=5762156i 1631909529018737000
```