### PR TITLE
feat: teach preserved catalog to handle delete predicates

### DIFF
--- a/generated_types/protos/influxdata/iox/catalog/v1/catalog.proto
+++ b/generated_types/protos/influxdata/iox/catalog/v1/catalog.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 package influxdata.iox.catalog.v1;
 
 import "google/protobuf/timestamp.proto";
+import "influxdata/iox/catalog/v1/predicate.proto";
 
 // Path for object store interaction.
 message Path {
@@ -47,6 +48,27 @@ message RemoveParquet {
     Path path = 1;
 }
 
+// Chunk within the preserved part of the catalog.
+message ChunkAddr {
+  // Table name.
+  string table_name = 1;
+
+  // Partition key.
+  string partition_key = 2;
+
+  // Chunk ID.
+  uint32 chunk_id = 3;
+}
+
+// Register new delete predicate
+message DeletePredicate {
+  // Predicate to be applied.
+  Predicate predicate = 1;
+
+  // Chunks that are affected by the predicate.
+  repeated ChunkAddr chunks = 2;
+}
+
 // Single, self-contained transaction.
 message Transaction {
     // Transaction format version.
@@ -60,6 +82,8 @@ message Transaction {
 
             AddParquet add_parquet = 2;
             RemoveParquet remove_parquet = 3;
+
+            DeletePredicate delete_predicate = 4;
         }
     }
 

--- a/parquet_file/src/catalog/dump.rs
+++ b/parquet_file/src/catalog/dump.rs
@@ -272,7 +272,7 @@ File {
     is_checkpoint: false,
     proto: Ok(
         Transaction {
-            version: 14,
+            version: 15,
             actions: [],
             revision_counter: 0,
             uuid: "00000000-0000-0000-0000-000000000000",
@@ -297,7 +297,7 @@ File {
     is_checkpoint: false,
     proto: Ok(
         Transaction {
-            version: 14,
+            version: 15,
             actions: [
                 Action {
                     action: Some(
@@ -396,7 +396,7 @@ File {
     is_checkpoint: false,
     proto: Ok(
         Transaction {
-            version: 14,
+            version: 15,
             actions: [],
             revision_counter: 0,
             uuid: "00000000-0000-0000-0000-000000000000",
@@ -421,7 +421,7 @@ File {
     is_checkpoint: false,
     proto: Ok(
         Transaction {
-            version: 14,
+            version: 15,
             actions: [
                 Action {
                     action: Some(

--- a/parquet_file/src/catalog/test_helpers.rs
+++ b/parquet_file/src/catalog/test_helpers.rs
@@ -654,7 +654,7 @@ fn get_sorted_keys<'a>(
 }
 
 /// Helper to create a simple delete predicate.
-fn create_delete_predicate(table_name: &str, value: i64) -> Arc<Predicate> {
+pub fn create_delete_predicate(table_name: &str, value: i64) -> Arc<Predicate> {
     use datafusion::{
         logical_plan::{Column, Expr, Operator},
         scalar::ScalarValue,
@@ -670,7 +670,7 @@ fn create_delete_predicate(table_name: &str, value: i64) -> Arc<Predicate> {
         range: None,
         exprs: vec![Expr::BinaryExpr {
             left: Box::new(Expr::Column(Column {
-                relation: Some(table_name.to_string()),
+                relation: None,
                 name: "foo".to_string(),
             })),
             op: Operator::Eq,


### PR DESCRIPTION
~Based on #2572 because this PR here uses the fact that predicates are not carrying table names any longer.~

For #2518. There will be one last PR on top of this that adds the `Db` => `PreservedCatalog` wiring + testing.