### PR TITLE
ci: add cargo audit

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,33 @@
+[advisories]
+ignore = [
+    # title: term is looking for a new maintainer
+    # why needed: used by `prettytable-rs` which is directly used by IOx but also by arrow
+    # upstream issue: https://github.com/phsym/prettytable-rs/issues/119
+    "RUSTSEC-2018-0015",
+
+    # title: memmap is unmaintained
+    # why needed: used by `symbolic` which is used by `pprof`
+    # upstream issue: https://github.com/getsentry/symbolic/issues/304
+    "RUSTSEC-2020-0077",
+
+    # title: difference is unmaintained
+    # why needed: used by `mockito`
+    # upstream issue: https://github.com/lipanski/mockito/issues/132
+    "RUSTSEC-2020-0095",
+]
+
+[output]
+deny = [
+    "unmaintained",
+    "unsound",
+    "yanked",
+]
+quiet = false
+
+[yanked]
+# interaction of workspace-local crates and crates.io is currently broken (e.g. for `query`)
+# see https://github.com/rustsec/rustsec/issues/232
+enabled = false
+
+# currently broken on CircleCI due to https://github.com/rustsec/rustsec/issues/292
+update_index = false

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,6 +89,26 @@ jobs:
           name: Clippy
           command: cargo clippy --all-targets --workspace -- -D warnings
       - cache_save
+  cargo_audit:
+    docker:
+      - image: quay.io/influxdb/rust:ci
+    environment:
+      # Disable incremental compilation to avoid overhead. We are not preserving these files anyway.
+      CARGO_INCREMENTAL: "0"
+      # Disable full debug symbol generation to speed up CI build
+      # "1" means line tables only, which is useful for panic tracebacks.
+      RUSTFLAGS: "-C debuginfo=1"
+    steps:
+      - checkout
+      - rust_components
+      - cache_restore
+      - run:
+          name: Install Cargo Audit
+          command: cargo install --force cargo-audit
+      - run:
+          name: Cargo Audit
+          command: cargo audit
+      - cache_save
   doc:
     docker:
       - image: quay.io/influxdb/rust:ci
@@ -383,6 +403,7 @@ workflows:
     jobs:
       - fmt
       - lint
+      - cargo_audit
       - protobuf-lint
       - test
       - test_heappy
@@ -406,6 +427,10 @@ workflows:
           filters:
             branches:
               only: main
+      - cargo_audit:
+          filters:
+            branches:
+              only: main
       - test:
           filters:
             branches:
@@ -421,6 +446,7 @@ workflows:
           requires: # Only do a release build if all tests have passed
             - fmt
             - lint
+            - cargo_audit
             - test
             - build
 


### PR DESCRIPTION
For now we ignore warnings (e.g. "crate is yanked" or "crate is
unmaintained") because:

- internal crates w/ names of crates.io crates (e.g. `query`) are
  treated like crates.io-crates even though they shouldn't, see
  https://github.com/rustsec/rustsec/issues/232
- many crates are currently unmaintained and require a bit of upstream
  work (e.g. `chrono` is currently not very active but uses an old
  version of `time` which uses the unmaintained `stdweb`)

Closes #2575.
