### PR TITLE
feat: Add support to create new traces in IOx via JAEGER_DEBUG_HEADER

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -287,7 +287,7 @@ For IOx to emit traces, the request must have a span context set. You can use th
 # load data
 ./target/debug/influxdb_iox database write my_db tests/fixtures/lineproto/metrics.lp
 # run a query and include a span context
-./target/debug/influxdb_iox database query my_db  'show tables' --header uber-trace-id:4459495:30434:0:1
+./target/debug/influxdb_iox database query my_db  'show tables' --header jaeger-debug-id:tracing-is-a-great-idea
 ```
 
 ### Step 4: Explore Spans in the UI

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -286,7 +286,7 @@ For IOx to emit traces, the request must have a span context set. You can use th
 ./target/debug/influxdb_iox database create my_db
 # load data
 ./target/debug/influxdb_iox database write my_db tests/fixtures/lineproto/metrics.lp
-# run a query and include a span context
+# run a query and start a new trace 
 ./target/debug/influxdb_iox database query my_db  'show tables' --header jaeger-debug-id:tracing-is-a-great-idea
 ```
 

--- a/perf/perf.py
+++ b/perf/perf.py
@@ -663,7 +663,7 @@ def run_test_battery(battery_name, router_id, writer_id, debug=False, do_trace=F
         headers = {}
         if do_trace:
             # TODO remove this after IOx can be configured to sample 100% of traces
-            headers['uber-trace-id'] = '%x:%x:0:1' % (random.randrange(0, 2 ** 64), random.randrange(0, 2 ** 64))
+            headers['jaeger-debug-id'] = 'from-perf'
         response = requests.get(url=query_url, params=params, headers=headers)
         time_delta = '%dms' % math.floor((time.time() - time_start) * 1000)
 

--- a/src/influxdb_ioxd.rs
+++ b/src/influxdb_ioxd.rs
@@ -238,7 +238,12 @@ async fn serve(
     let frontend_shutdown = tokio_util::sync::CancellationToken::new();
 
     let trace_header_parser = TraceHeaderParser::new()
-        .with_jaeger_header_name(config.tracing_config.jaeger_trace_context_header_name);
+        .with_jaeger_trace_context_header_name(
+            config
+                .tracing_config
+                .traces_jaeger_trace_context_header_name,
+        )
+        .with_jaeger_debug_name(config.tracing_config.traces_jaeger_debug_name);
 
     // Construct and start up gRPC server
 

--- a/src/influxdb_ioxd/http.rs
+++ b/src/influxdb_ioxd/http.rs
@@ -1484,7 +1484,8 @@ mod tests {
         let addr = AddrIncoming::bind(&bind_addr).expect("failed to bind server");
         let server_url = format!("http://{}", addr.local_addr());
 
-        let trace_header_parser = trace_http::ctx::TraceHeaderParser::new();
+        let trace_header_parser = trace_http::ctx::TraceHeaderParser::new()
+            .with_jaeger_trace_context_header_name("uber-trace-id");
 
         tokio::task::spawn(serve(
             addr,

--- a/trace_exporters/src/lib.rs
+++ b/trace_exporters/src/lib.rs
@@ -62,7 +62,7 @@ pub struct TracingConfig {
     )]
     pub traces_exporter_jaeger_service_name: String,
 
-    /// Tracing: http request header that contains the Jaeger service name
+    /// Tracing: specifies the header name used for passing trace context
     ///
     /// Only used if `--traces-exporter` is "jaeger".
     #[structopt(
@@ -70,7 +70,17 @@ pub struct TracingConfig {
         env = "JAEGER_TRACE_CONTEXT_HEADER_NAME",
         default_value = "uber-trace-id"
     )]
-    pub jaeger_trace_context_header_name: String,
+    pub traces_jaeger_trace_context_header_name: String,
+
+    /// Tracing: specifies the header name used for force sampling
+    ///
+    /// Only used if `--traces-exporter` is "jaeger".
+    #[structopt(
+        long = "--traces-jaeger-debug-name",
+        env = "JAEGER_DEBUG_NAME",
+        default_value = "jaeger-debug-id"
+    )]
+    pub traces_jaeger_debug_name: String,
 }
 
 impl TracingConfig {


### PR DESCRIPTION
Closes https://github.com/influxdata/influxdb_iox/issues/2367, related to https://github.com/influxdata/influxdb_iox/issues/2549

# Rationale
When making requests to IOx, it would be nice  if we could request tracing without having to make up unique trace ids / spans such as `4459495:30434:0:1` for each request, as described in https://github.com/influxdata/influxdb_iox/blob/main/CONTRIBUTING.md#step-3-send-a-request-with-trace-context

# Changes
1. Add `JAEGER_DEBUG_HEADER` consistent with https://pkg.go.dev/k8s.io/ingress-nginx/internal/ingress/controller/config
2. Remove redundant default values in trace_http (use the defaults from command line)
3. Update the docs
4. Update perf.py

# Behavior
1. If the `jaeger_trace_context_header_name` (defaults to `uber-trace-id`) is specified, then the trace/span from that is used
2. otherwise, if b3 headers are present, use that
3. otherwise, if  `JAEGER_DEBUG_HEADER` (default to `jaeger-debug-id`) is in the request, create a new trace and, and add a `trace-id` to the response, as described in https://github.com/jaegertracing/documentation/issues/349

# Results
I tried this out locally with jaeger via the following command

```shell
./target/debug/influxdb_iox database query   26f7e5a4b7be365b_917b97a92e883afc  'select count(*), avg(available) from mem group by host' --header jaeger-debug-id:my_id
```