### PR TITLE
refactor: convert macros in `query_tests` to functions

### DIFF
--- a/query_tests/src/influxrpc/table_names.rs
+++ b/query_tests/src/influxrpc/table_names.rs
@@ -9,68 +9,68 @@ use crate::scenarios::*;
 
 /// runs table_names(predicate) and compares it to the expected
 /// output
-macro_rules! run_table_names_test_case {
-    ($DB_SETUP:expr, $PREDICATE:expr, $EXPECTED_NAMES:expr) => {
-        test_helpers::maybe_start_logging();
-        let predicate = $PREDICATE;
-        for scenario in $DB_SETUP.make().await {
-            let DbScenario {
-                scenario_name, db, ..
-            } = scenario;
-            println!("Running scenario '{}'", scenario_name);
-            println!("Predicate: '{:#?}'", predicate);
-            let planner = InfluxRpcPlanner::new();
-            let ctx = db.executor().new_context(query::exec::ExecutorType::Query);
+async fn run_table_names_test_case<D>(db_setup: D, predicate: Predicate, expected_names: Vec<&str>)
+where
+    D: DbSetup,
+{
+    test_helpers::maybe_start_logging();
 
-            let plan = planner
-                .table_names(db.as_ref(), predicate.clone())
-                .expect("built plan successfully");
-            let names = ctx
-                .to_string_set(plan)
-                .await
-                .expect("converted plan to strings successfully");
+    for scenario in db_setup.make().await {
+        let DbScenario {
+            scenario_name, db, ..
+        } = scenario;
+        println!("Running scenario '{}'", scenario_name);
+        println!("Predicate: '{:#?}'", predicate);
+        let planner = InfluxRpcPlanner::new();
+        let ctx = db.executor().new_context(query::exec::ExecutorType::Query);
 
-            let expected_names = $EXPECTED_NAMES;
-            assert_eq!(
-                names,
-                to_stringset(&expected_names),
-                "Error in  scenario '{}'\n\nexpected:\n{:?}\nactual:\n{:?}",
-                scenario_name,
-                expected_names,
-                names
-            );
-        }
-    };
+        let plan = planner
+            .table_names(db.as_ref(), predicate.clone())
+            .expect("built plan successfully");
+        let names = ctx
+            .to_string_set(plan)
+            .await
+            .expect("converted plan to strings successfully");
+
+        assert_eq!(
+            names,
+            to_stringset(&expected_names),
+            "Error in  scenario '{}'\n\nexpected:\n{:?}\nactual:\n{:?}",
+            scenario_name,
+            expected_names,
+            names
+        );
+    }
 }
 
 #[tokio::test]
 async fn list_table_names_no_data_no_pred() {
-    run_table_names_test_case!(NoData {}, EMPTY_PREDICATE, vec![]);
+    run_table_names_test_case(NoData {}, EMPTY_PREDICATE, vec![]).await;
 }
 
 #[tokio::test]
 async fn list_table_names_no_data_pred() {
-    run_table_names_test_case!(TwoMeasurements {}, EMPTY_PREDICATE, vec!["cpu", "disk"]);
+    run_table_names_test_case(TwoMeasurements {}, EMPTY_PREDICATE, vec!["cpu", "disk"]).await;
 }
 
 #[tokio::test]
 async fn list_table_names_data_pred_0_201() {
-    run_table_names_test_case!(TwoMeasurements {}, tsp(0, 201), vec!["cpu", "disk"]);
+    run_table_names_test_case(TwoMeasurements {}, tsp(0, 201), vec!["cpu", "disk"]).await;
 }
 
 #[tokio::test]
 async fn list_table_names_data_pred_0_200() {
-    run_table_names_test_case!(TwoMeasurements {}, tsp(0, 200), vec!["cpu"]);
+    run_table_names_test_case(TwoMeasurements {}, tsp(0, 200), vec!["cpu"]).await;
 }
 
 #[tokio::test]
 async fn list_table_names_data_pred_50_101() {
-    run_table_names_test_case!(TwoMeasurements {}, tsp(50, 101), vec!["cpu"]);
+    run_table_names_test_case(TwoMeasurements {}, tsp(50, 101), vec!["cpu"]).await;
 }
 
 #[tokio::test]
 async fn list_table_names_data_pred_250_300() {
-    run_table_names_test_case!(TwoMeasurements {}, tsp(250, 300), vec![]);
+    run_table_names_test_case(TwoMeasurements {}, tsp(250, 300), vec![]).await;
 }
 
 // make a single timestamp predicate between r1 and r2


### PR DESCRIPTION
The compile times of `query_tests` are currently rather long. Since macros are expended rather early in the compilation process they are rather costly. Also they are "not nice" for IDEs since type-checking is done on the expansion side (rather than in the macro body). Luckily the macros here can easily be replaced by ordinary functions.

**Before:**

```text
+--------------------------------------------------+-----------+-----------------+----------+------------+---------------------------------+
| Item                                             | Self time | % of total time | Time     | Item count | Incremental result hashing time |
+--------------------------------------------------+-----------+-----------------+----------+------------+---------------------------------+
| evaluate_obligation                              | 13.70s    | 71.965          | 13.74s   | 23421      | 4.74ms                          |
+--------------------------------------------------+-----------+-----------------+----------+------------+---------------------------------+
| LLVM_module_codegen_emit_obj                     | 1.43s     | 7.487           | 1.43s    | 87         | 0.00ns                          |
+--------------------------------------------------+-----------+-----------------+----------+------------+---------------------------------+
| LLVM_passes                                      | 799.97ms  | 4.201           | 799.97ms | 1          | 0.00ns                          |
+--------------------------------------------------+-----------+-----------------+----------+------------+---------------------------------+
| codegen_module                                   | 730.72ms  | 3.837           | 874.00ms | 87         | 0.00ns                          |
+--------------------------------------------------+-----------+-----------------+----------+------------+---------------------------------+
| typeck                                           | 316.29ms  | 1.661           | 27.96s   | 150        | 5.30ms                          |
+--------------------------------------------------+-----------+-----------------+----------+------------+---------------------------------+
| codegen_fulfill_obligation                       | 213.27ms  | 1.120           | 284.46ms | 717        | 384.15µs                        |
+--------------------------------------------------+-----------+-----------------+----------+------------+---------------------------------+
| metadata_decode_entry_exported_symbols           | 144.21ms  | 0.757           | 149.04ms | 205        | 0.00ns                          |
+--------------------------------------------------+-----------+-----------------+----------+------------+---------------------------------+
| type_op_prove_predicate                          | 141.76ms  | 0.744           | 143.49ms | 1776       | 1.13ms                          |
+--------------------------------------------------+-----------+-----------------+----------+------------+---------------------------------+
| expand_crate                                     | 131.63ms  | 0.691           | 185.64ms | 1          | 0.00ns                          |
+--------------------------------------------------+-----------+-----------------+----------+------------+---------------------------------+
| mir_borrowck                                     | 103.07ms  | 0.541           | 467.47ms | 150        | 141.58µs                        |
+--------------------------------------------------+-----------+-----------------+----------+------------+---------------------------------+
| optimized_mir                                    | 91.19ms   | 0.479           | 239.47ms | 639        | 22.29ms                         |
+--------------------------------------------------+-----------+-----------------+----------+------------+---------------------------------+
| upstream_monomorphizations                       | 75.63ms   | 0.397           | 278.48ms | 1          | 60.47ms                         |
+--------------------------------------------------+-----------+-----------------+----------+------------+---------------------------------+
| LLVM_module_codegen                              | 72.34ms   | 0.380           | 1.50s    | 87         | 0.00ns                          |
+--------------------------------------------------+-----------+-----------------+----------+------------+---------------------------------+
| exported_symbols                                 | 54.29ms   | 0.285           | 1.04s    | 206        | 53.38ms                         |
+--------------------------------------------------+-----------+-----------------+----------+------------+---------------------------------+
| normalize_generic_arg_after_erasing_regions      | 53.15ms   | 0.279           | 66.73ms  | 2158       | 1.45ms                          |
+--------------------------------------------------+-----------+-----------------+----------+------------+---------------------------------+
| metadata_register_crate                          | 52.89ms   | 0.278           | 226.98ms | 205        | 0.00ns                          |
+--------------------------------------------------+-----------+-----------------+----------+------------+---------------------------------+
| monomorphization_collector_graph_walk            | 51.05ms   | 0.268           | 819.42ms | 1          | 0.00ns                          |
+--------------------------------------------------+-----------+-----------------+----------+------------+---------------------------------+
| incr_comp_intern_dep_graph_node                  | 47.96ms   | 0.252           | 81.25ms  | 196340     | 0.00ns                          |
+--------------------------------------------------+-----------+-----------------+----------+------------+---------------------------------+
...
Total cpu time: 19.042505497s
```

**After:**

```text
+--------------------------------------------------+-----------+-----------------+----------+------------+---------------------------------+
| Item                                             | Self time | % of total time | Time     | Item count | Incremental result hashing time |
+--------------------------------------------------+-----------+-----------------+----------+------------+---------------------------------+
| evaluate_obligation                              | 13.43s    | 74.639          | 13.47s   | 23421      | 4.47ms                          |
+--------------------------------------------------+-----------+-----------------+----------+------------+---------------------------------+
| LLVM_module_codegen_emit_obj                     | 1.24s     | 6.863           | 1.24s    | 87         | 0.00ns                          |
+--------------------------------------------------+-----------+-----------------+----------+------------+---------------------------------+
| LLVM_passes                                      | 694.85ms  | 3.861           | 694.85ms | 1          | 0.00ns                          |
+--------------------------------------------------+-----------+-----------------+----------+------------+---------------------------------+
| codegen_module                                   | 622.21ms  | 3.458           | 745.82ms | 87         | 0.00ns                          |
+--------------------------------------------------+-----------+-----------------+----------+------------+---------------------------------+
| typeck                                           | 295.01ms  | 1.639           | 27.39s   | 150        | 5.00ms                          |
+--------------------------------------------------+-----------+-----------------+----------+------------+---------------------------------+
| codegen_fulfill_obligation                       | 152.79ms  | 0.849           | 209.98ms | 717        | 252.86µs                        |
+--------------------------------------------------+-----------+-----------------+----------+------------+---------------------------------+
| type_op_prove_predicate                          | 125.89ms  | 0.700           | 127.41ms | 1776       | 1.05ms                          |
+--------------------------------------------------+-----------+-----------------+----------+------------+---------------------------------+
| expand_crate                                     | 125.41ms  | 0.697           | 180.65ms | 1          | 0.00ns                          |
+--------------------------------------------------+-----------+-----------------+----------+------------+---------------------------------+
| metadata_decode_entry_exported_symbols           | 105.57ms  | 0.587           | 109.57ms | 205        | 0.00ns                          |
+--------------------------------------------------+-----------+-----------------+----------+------------+---------------------------------+
| mir_borrowck                                     | 93.78ms   | 0.521           | 423.52ms | 150        | 110.57µs                        |
+--------------------------------------------------+-----------+-----------------+----------+------------+---------------------------------+
| optimized_mir                                    | 76.01ms   | 0.422           | 187.90ms | 639        | 18.45ms                         |
+--------------------------------------------------+-----------+-----------------+----------+------------+---------------------------------+
| LLVM_module_codegen                              | 57.71ms   | 0.321           | 1.29s    | 87         | 0.00ns                          |
+--------------------------------------------------+-----------+-----------------+----------+------------+---------------------------------+
| upstream_monomorphizations                       | 54.53ms   | 0.303           | 210.25ms | 1          | 42.23ms                         |
+--------------------------------------------------+-----------+-----------------+----------+------------+---------------------------------+
| metadata_register_crate                          | 54.02ms   | 0.300           | 226.59ms | 205        | 0.00ns                          |
+--------------------------------------------------+-----------+-----------------+----------+------------+---------------------------------+
| exported_symbols                                 | 46.52ms   | 0.258           | 784.47ms | 206        | 45.83ms                         |
+--------------------------------------------------+-----------+-----------------+----------+------------+---------------------------------+
| incr_comp_intern_dep_graph_node                  | 45.15ms   | 0.251           | 74.26ms  | 196340     | 0.00ns                          |
+--------------------------------------------------+-----------+-----------------+----------+------------+---------------------------------+
| monomorphization_collector_graph_walk            | 43.07ms   | 0.239           | 616.01ms | 1          | 0.00ns                          |
+--------------------------------------------------+-----------+-----------------+----------+------------+---------------------------------+
| compute_debuginfo_type_name                      | 38.15ms   | 0.212           | 38.33ms  | 62911      | 0.00ns                          |
+--------------------------------------------------+-----------+-----------------+----------+------------+---------------------------------+
| mir_drops_elaborated_and_const_checked           | 37.60ms   | 0.209           | 59.20ms  | 150        | 24.56µs                         |
+--------------------------------------------------+-----------+-----------------+----------+------------+---------------------------------+
| normalize_generic_arg_after_erasing_regions      | 35.90ms   | 0.200           | 47.09ms  | 2158       | 1.11ms                          |
+--------------------------------------------------+-----------+-----------------+----------+------------+---------------------------------+
| upstream_monomorphizations_for                   | 32.81ms   | 0.182           | 243.17ms | 443        | 32.61ms                         |
+--------------------------------------------------+-----------+-----------------+----------+------------+---------------------------------+
| mir_built                                        | 30.88ms   | 0.172           | 128.59ms | 150        | 8.72ms                          |
+--------------------------------------------------+-----------+-----------------+----------+------------+---------------------------------+
| incr_comp_encode_dep_graph                       | 29.99ms   | 0.167           | 29.99ms  | 201446     | 0.00ns                          |
+--------------------------------------------------+-----------+-----------------+----------+------------+---------------------------------+
...
Total cpu time: 17.995231325s
```

The big elephant is still `evaluate_obligation` which is likely https://github.com/rust-lang/rust/issues/87012. I might try to workaround this in a future attempt.