### PR TITLE
refactor: make `Partition::force_drop_chunk` similar to `Partition::drop_chunk`

### DIFF
--- a/server/src/db/catalog/partition.rs
+++ b/server/src/db/catalog/partition.rs
@@ -284,6 +284,7 @@ impl Partition {
     }
 
     /// Drop the specified chunk even if it has an in-progress lifecycle action
+    /// returning the dropped chunk
     pub fn force_drop_chunk(&mut self, chunk_id: ChunkId) -> Result<Arc<RwLock<CatalogChunk>>> {
         self.chunks
             .remove(&chunk_id)

--- a/server/src/db/lifecycle/compact.rs
+++ b/server/src/db/lifecycle/compact.rs
@@ -111,7 +111,9 @@ pub(crate) fn compact_chunks(
         let (_id, new_chunk) = {
             let mut partition = partition.write();
             for id in chunk_ids {
-                partition.force_drop_chunk(id)
+                partition.force_drop_chunk(id).expect(
+                    "There was a lifecycle action attached to this chunk, who deleted it?!",
+                );
             }
             partition.create_rub_chunk(
                 rb_chunk,

--- a/server/src/db/lifecycle/persist.rs
+++ b/server/src/db/lifecycle/persist.rs
@@ -133,7 +133,9 @@ where
             let partition = LockableCatalogPartition::new(Arc::clone(&db), partition);
             let mut partition_write = partition.write();
             for id in chunk_ids {
-                partition_write.force_drop_chunk(id)
+                partition_write.force_drop_chunk(id).expect(
+                    "There was a lifecycle action attached to this chunk, who deleted it?!",
+                );
             }
 
             // Upsert remainder to catalog


### PR DESCRIPTION
- Bubbles up "not found" error, the caller should reason about it
- Returns deleted chunk

This will be useful if we wanna handle predicates correctly during the lifecycle (at the moment we might loose a few new predicates on the way).