### PR TITLE
fix: Retry S3 requests that fail with 5xx and remove streaming put API that wasn't used

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1203,6 +1203,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-retry"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fde5a672a61f96552aa5ed9fd9c81c3fbdae4be9b1e205d6eaf17c83705adc0f"
+dependencies = [
+ "futures",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "futures-sink"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2484,6 +2495,7 @@ dependencies = [
  "cloud-storage",
  "dotenv",
  "futures",
+ "futures-retry",
  "futures-test",
  "indexmap",
  "itertools",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1203,17 +1203,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "futures-retry"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fde5a672a61f96552aa5ed9fd9c81c3fbdae4be9b1e205d6eaf17c83705adc0f"
-dependencies = [
- "futures",
- "pin-project-lite",
- "tokio",
-]
-
-[[package]]
 name = "futures-sink"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2495,7 +2484,6 @@ dependencies = [
  "cloud-storage",
  "dotenv",
  "futures",
- "futures-retry",
  "futures-test",
  "indexmap",
  "itertools",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2487,6 +2487,7 @@ dependencies = [
  "futures-test",
  "indexmap",
  "itertools",
+ "observability_deps",
  "percent-encoding",
  "reqwest",
  "rusoto_core",

--- a/iox_object_store/src/lib.rs
+++ b/iox_object_store/src/lib.rs
@@ -22,17 +22,14 @@ use data_types::{
     server_id::ServerId,
     DatabaseName,
 };
-use futures::{
-    stream::{self, BoxStream},
-    Stream, StreamExt, TryStreamExt,
-};
+use futures::{stream::BoxStream, StreamExt, TryStreamExt};
 use object_store::{
     path::{parsed::DirsAndFileName, ObjectStorePath, Path},
     ObjectStore, ObjectStoreApi, Result,
 };
 use observability_deps::tracing::warn;
 use snafu::{ensure, OptionExt, ResultExt, Snafu};
-use std::{collections::BTreeMap, io, sync::Arc};
+use std::{collections::BTreeMap, sync::Arc};
 use tokio::sync::mpsc::channel;
 use tokio_stream::wrappers::ReceiverStream;
 
@@ -382,12 +379,7 @@ impl IoxObjectStore {
     /// Write the file in the database directory that indicates this database is marked as deleted,
     /// without yet actually deleting this directory or any files it contains in object storage.
     pub async fn write_tombstone(&self) -> Result<()> {
-        let stream = move || stream::once(async move { Ok(Bytes::new()) });
-        let len = 0;
-
-        self.inner
-            .put(&self.tombstone_path(), stream, Some(len))
-            .await
+        self.inner.put(&self.tombstone_path(), Bytes::new()).await
     }
 
     /// Remove the tombstone file to restore a database generation. Will return an error if this
@@ -472,19 +464,14 @@ impl IoxObjectStore {
     }
 
     /// Store the data for this parquet file in this database's object store.
-    pub async fn put_catalog_transaction_file<F, S>(
+    pub async fn put_catalog_transaction_file(
         &self,
         location: &TransactionFilePath,
-        bytes: F,
-        length: Option<usize>,
-    ) -> Result<()>
-    where
-        F: Fn() -> S + Clone + Send + Sync + Unpin + 'static,
-        S: Stream<Item = io::Result<Bytes>> + Send + Sync + 'static,
-    {
+        bytes: Bytes,
+    ) -> Result<()> {
         let full_path = self.transactions_path.join(location);
 
-        self.inner.put(&full_path, bytes, length).await
+        self.inner.put(&full_path, bytes).await
     }
 
     /// Delete all catalog transaction files for this database.
@@ -539,19 +526,10 @@ impl IoxObjectStore {
     }
 
     /// Store the data for this parquet file in this database's object store.
-    pub async fn put_parquet_file<F, S>(
-        &self,
-        location: &ParquetFilePath,
-        bytes: F,
-        length: Option<usize>,
-    ) -> Result<()>
-    where
-        F: Fn() -> S + Clone + Send + Sync + Unpin + 'static,
-        S: Stream<Item = io::Result<Bytes>> + Send + Sync + 'static,
-    {
+    pub async fn put_parquet_file(&self, location: &ParquetFilePath, bytes: Bytes) -> Result<()> {
         let full_path = self.data_path.join(location);
 
-        self.inner.put(&full_path, bytes, length).await
+        self.inner.put(&full_path, bytes).await
     }
 
     /// Remove the data for this parquet file from this database's object store
@@ -586,15 +564,7 @@ impl IoxObjectStore {
 
     /// Store the data for the database rules
     pub async fn put_database_rules_file(&self, bytes: Bytes) -> Result<()> {
-        let len = bytes.len();
-        let stream = move || {
-            let bytes = bytes.clone();
-            stream::once(async move { Ok(bytes) })
-        };
-
-        self.inner
-            .put(&self.db_rules_path(), stream, Some(len))
-            .await
+        self.inner.put(&self.db_rules_path(), bytes).await
     }
 
     /// Delete the data for the database rules
@@ -653,12 +623,8 @@ mod tests {
 
     async fn add_file(object_store: &ObjectStore, location: &Path) {
         let data = Bytes::from("arbitrary data");
-        let stream_fn = move || {
-            let stream_data = std::io::Result::Ok(data.clone());
-            futures::stream::once(async move { stream_data })
-        };
 
-        object_store.put(location, stream_fn, None).await.unwrap();
+        object_store.put(location, data).await.unwrap();
     }
 
     async fn parquet_files(iox_object_store: &IoxObjectStore) -> Vec<ParquetFilePath> {
@@ -676,13 +642,9 @@ mod tests {
 
     async fn add_parquet_file(iox_object_store: &IoxObjectStore, location: &ParquetFilePath) {
         let data = Bytes::from("arbitrary data");
-        let stream_fn = move || {
-            let stream_data = std::io::Result::Ok(data.clone());
-            futures::stream::once(async move { stream_data })
-        };
 
         iox_object_store
-            .put_parquet_file(location, stream_fn, None)
+            .put_parquet_file(location, data)
             .await
             .unwrap();
     }
@@ -778,13 +740,9 @@ mod tests {
         location: &TransactionFilePath,
     ) {
         let data = Bytes::from("arbitrary data");
-        let stream_fn = move || {
-            let stream_data = std::io::Result::Ok(data.clone());
-            futures::stream::once(async move { stream_data })
-        };
 
         iox_object_store
-            .put_catalog_transaction_file(location, stream_fn, None)
+            .put_catalog_transaction_file(location, data)
             .await
             .unwrap();
     }
@@ -898,14 +856,9 @@ mod tests {
         // GET
         let updated_file_content = Bytes::from("goodbye moon");
         let expected_content = updated_file_content.clone();
-        let updated_file_stream = move || {
-            stream::once({
-                let bytes = updated_file_content.clone();
-                async move { Ok(bytes) }
-            })
-        };
+
         object_store
-            .put(&rules_path, updated_file_stream, None)
+            .put(&rules_path, updated_file_content)
             .await
             .unwrap();
 
@@ -1068,11 +1021,7 @@ mod tests {
         not_rules_path.push_all_dirs(&[&server_id.to_string(), not_a_db.as_str(), "0"]);
         not_rules_path.set_file_name("not_rules.txt");
         object_store
-            .put(
-                &not_rules_path,
-                move || stream::once(async move { Ok(Bytes::new()) }),
-                None,
-            )
+            .put(&not_rules_path, Bytes::new())
             .await
             .unwrap();
 
@@ -1082,11 +1031,7 @@ mod tests {
         invalid_db_name_rules_path.push_all_dirs(&[&server_id.to_string(), &invalid_db_name, "0"]);
         invalid_db_name_rules_path.set_file_name("rules.pb");
         object_store
-            .put(
-                &invalid_db_name_rules_path,
-                move || stream::once(async move { Ok(Bytes::new()) }),
-                None,
-            )
+            .put(&invalid_db_name_rules_path, Bytes::new())
             .await
             .unwrap();
 
@@ -1126,11 +1071,7 @@ mod tests {
         not_rules_path.push_all_dirs(&[&server_id.to_string(), not_a_db.as_str(), "0"]);
         not_rules_path.set_file_name("not_rules.txt");
         object_store
-            .put(
-                &not_rules_path,
-                move || stream::once(async move { Ok(Bytes::new()) }),
-                None,
-            )
+            .put(&not_rules_path, Bytes::new())
             .await
             .unwrap();
 
@@ -1140,11 +1081,7 @@ mod tests {
         invalid_db_name_rules_path.push_all_dirs(&[&server_id.to_string(), &invalid_db_name, "0"]);
         invalid_db_name_rules_path.set_file_name("rules.pb");
         object_store
-            .put(
-                &invalid_db_name_rules_path,
-                move || stream::once(async move { Ok(Bytes::new()) }),
-                None,
-            )
+            .put(&invalid_db_name_rules_path, Bytes::new())
             .await
             .unwrap();
 
@@ -1160,11 +1097,7 @@ mod tests {
         ]);
         no_generations_path.set_file_name("not_rules.txt");
         object_store
-            .put(
-                &no_generations_path,
-                move || stream::once(async move { Ok(Bytes::new()) }),
-                None,
-            )
+            .put(&no_generations_path, Bytes::new())
             .await
             .unwrap();
 
@@ -1258,11 +1191,7 @@ mod tests {
         not_rules_path.push_all_dirs(&[&server_id.to_string(), not_a_db.as_str(), "0"]);
         not_rules_path.set_file_name("not_rules.txt");
         object_store
-            .put(
-                &not_rules_path,
-                move || stream::once(async move { Ok(Bytes::new()) }),
-                None,
-            )
+            .put(&not_rules_path, Bytes::new())
             .await
             .unwrap();
 
@@ -1272,11 +1201,7 @@ mod tests {
         invalid_db_name_rules_path.push_all_dirs(&[&server_id.to_string(), &invalid_db_name, "0"]);
         invalid_db_name_rules_path.set_file_name("rules.pb");
         object_store
-            .put(
-                &invalid_db_name_rules_path,
-                move || stream::once(async move { Ok(Bytes::new()) }),
-                None,
-            )
+            .put(&invalid_db_name_rules_path, Bytes::new())
             .await
             .unwrap();
 
@@ -1291,11 +1216,7 @@ mod tests {
         ]);
         no_generations_path.set_file_name("not_rules.txt");
         object_store
-            .put(
-                &no_generations_path,
-                move || stream::once(async move { Ok(Bytes::new()) }),
-                None,
-            )
+            .put(&no_generations_path, Bytes::new())
             .await
             .unwrap();
 

--- a/object_store/Cargo.toml
+++ b/object_store/Cargo.toml
@@ -15,7 +15,6 @@ chrono = "0.4"
 # Google Cloud Storage integration
 cloud-storage = {version = "0.10.2", optional = true}
 futures = "0.3"
-futures-retry = "0.6"
 # https://github.com/tkaitchuck/aHash/issues/95
 indexmap = { version = "~1.6.2", optional = true }
 itertools = "0.10.1"

--- a/object_store/Cargo.toml
+++ b/object_store/Cargo.toml
@@ -15,6 +15,7 @@ chrono = "0.4"
 # Google Cloud Storage integration
 cloud-storage = {version = "0.10.2", optional = true}
 futures = "0.3"
+futures-retry = "0.6"
 # https://github.com/tkaitchuck/aHash/issues/95
 indexmap = { version = "~1.6.2", optional = true }
 itertools = "0.10.1"

--- a/object_store/Cargo.toml
+++ b/object_store/Cargo.toml
@@ -18,6 +18,7 @@ futures = "0.3"
 # https://github.com/tkaitchuck/aHash/issues/95
 indexmap = { version = "~1.6.2", optional = true }
 itertools = "0.10.1"
+observability_deps = { path = "../observability_deps" }
 percent-encoding = "2.1"
 # rusoto crates are for Amazon S3 integration
 rusoto_core = { version = "0.47.0", optional = true}

--- a/object_store/src/aws.rs
+++ b/object_store/src/aws.rs
@@ -448,11 +448,11 @@ impl AmazonS3 {
     }
 }
 
-async fn s3_request<F, G, H>(future_factory: F) -> Result<rusoto_s3::ListObjectsV2Output>
+async fn s3_request<F, G, H, R>(future_factory: F) -> Result<R>
 where
     F: Fn() -> G + Unpin + Clone + Send + Sync + 'static,
     G: Future<Output = Result<H, Error>> + Send,
-    H: Future<Output = Result<rusoto_s3::ListObjectsV2Output>> + Send,
+    H: Future<Output = Result<R>> + Send,
 {
     let mut attempts = 0;
     // TODO: configurable

--- a/object_store/src/aws.rs
+++ b/object_store/src/aws.rs
@@ -477,9 +477,8 @@ where
     H: Future<Output = Result<R, rusoto_core::RusotoError<E>>> + Send,
 {
     let mut attempts = 0;
-    // TODO: configurable
+    // TODO: make the number of retries configurable
     let n_retries = 10;
-    // TODO: let backoff =
 
     FutureRetry::new(
         move || {
@@ -504,7 +503,7 @@ where
                 if attempts > n_retries || !should_retry {
                     RetryPolicy::ForwardError(e)
                 } else {
-                    RetryPolicy::WaitRetry(Duration::from_millis(200))
+                    RetryPolicy::WaitRetry(Duration::from_millis(2u64.pow(attempts) * 50))
                 }
             }
         },

--- a/object_store/src/aws.rs
+++ b/object_store/src/aws.rs
@@ -22,7 +22,7 @@ use std::{convert::TryFrom, fmt, time::Duration};
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
 /// The maximum number of times a request will be retried in the case of an AWS server error
-pub const MAX_NUM_RETRIES: u32 = 10;
+pub const MAX_NUM_RETRIES: u32 = 3;
 
 /// A specialized `Error` for object store-related errors
 #[derive(Debug, Snafu)]

--- a/object_store/src/azure.rs
+++ b/object_store/src/azure.rs
@@ -70,12 +70,13 @@ impl ObjectStoreApi for MicrosoftAzure {
         CloudPath::default()
     }
 
-    async fn put<S>(&self, location: &Self::Path, bytes: S, length: Option<usize>) -> Result<()>
+    async fn put<F, S>(&self, location: &Self::Path, bytes: F, length: Option<usize>) -> Result<()>
     where
+        F: Fn() -> S + Clone + Send + Sync + Unpin + 'static,
         S: Stream<Item = io::Result<Bytes>> + Send + Sync + 'static,
     {
         let location = location.to_raw();
-        let temporary_non_streaming = bytes
+        let temporary_non_streaming = bytes()
             .map_ok(|b| bytes::BytesMut::from(&b[..]))
             .try_concat()
             .await

--- a/object_store/src/azure.rs
+++ b/object_store/src/azure.rs
@@ -14,11 +14,10 @@ use azure_storage::{
 use bytes::Bytes;
 use futures::{
     stream::{self, BoxStream},
-    FutureExt, Stream, StreamExt, TryStreamExt,
+    FutureExt, StreamExt,
 };
-use snafu::{ensure, ResultExt, Snafu};
-use std::sync::Arc;
-use std::{convert::TryInto, io};
+use snafu::{ResultExt, Snafu};
+use std::{convert::TryInto, sync::Arc};
 
 /// A specialized `Result` for Azure object store-related errors
 pub type Result<T, E = Error> = std::result::Result<T, E>;
@@ -27,9 +26,6 @@ pub type Result<T, E = Error> = std::result::Result<T, E>;
 #[derive(Debug, Snafu)]
 #[allow(missing_docs)]
 pub enum Error {
-    #[snafu(display("Expected streamed data to have length {}, got {}", expected, actual))]
-    DataDoesNotMatchLength { expected: usize, actual: usize },
-
     #[snafu(display("Unable to DELETE data. Location: {}, Error: {}", location, source,))]
     UnableToDeleteData {
         source: Box<dyn std::error::Error + Send + Sync>,
@@ -70,31 +66,14 @@ impl ObjectStoreApi for MicrosoftAzure {
         CloudPath::default()
     }
 
-    async fn put<F, S>(&self, location: &Self::Path, bytes: F, length: Option<usize>) -> Result<()>
-    where
-        F: Fn() -> S + Clone + Send + Sync + Unpin + 'static,
-        S: Stream<Item = io::Result<Bytes>> + Send + Sync + 'static,
-    {
+    async fn put(&self, location: &Self::Path, bytes: Bytes) -> Result<()> {
         let location = location.to_raw();
-        let temporary_non_streaming = bytes()
-            .map_ok(|b| bytes::BytesMut::from(&b[..]))
-            .try_concat()
-            .await
-            .expect("Should have been able to collect streaming data");
 
-        if let Some(length) = length {
-            ensure!(
-                temporary_non_streaming.len() == length,
-                DataDoesNotMatchLength {
-                    actual: temporary_non_streaming.len(),
-                    expected: length,
-                }
-            );
-        }
+        let bytes = bytes::BytesMut::from(&*bytes);
 
         self.container_client
             .as_blob_client(&location)
-            .put_block_blob(temporary_non_streaming)
+            .put_block_blob(bytes)
             .execute()
             .await
             .context(UnableToPutData {

--- a/object_store/src/disk.rs
+++ b/object_store/src/disk.rs
@@ -79,11 +79,12 @@ impl ObjectStoreApi for File {
         FilePath::default()
     }
 
-    async fn put<S>(&self, location: &Self::Path, bytes: S, length: Option<usize>) -> Result<()>
+    async fn put<F, S>(&self, location: &Self::Path, bytes: F, length: Option<usize>) -> Result<()>
     where
+        F: Fn() -> S + Clone + Send + Sync + Unpin + 'static,
         S: Stream<Item = io::Result<Bytes>> + Send + Sync + 'static,
     {
-        let content = bytes
+        let content = bytes()
             .map_ok(|b| bytes::BytesMut::from(&b[..]))
             .try_concat()
             .await
@@ -341,9 +342,11 @@ mod tests {
         let root = TempDir::new().unwrap();
         let integration = ObjectStore::new_file(root.path());
 
-        let bytes = stream::once(async { Ok(Bytes::from("hello world")) });
+        let bytes = move || stream::once(async { Ok(Bytes::from("hello world")) });
+
         let mut location = integration.new_path();
         location.set_file_name("junk");
+
         let res = integration.put(&location, bytes, Some(0)).await;
 
         assert!(matches!(
@@ -362,17 +365,19 @@ mod tests {
         let root = TempDir::new().unwrap();
         let integration = ObjectStore::new_file(root.path());
 
-        let data = Bytes::from("arbitrary data");
         let mut location = integration.new_path();
         location.push_all_dirs(&["nested", "file", "test_file"]);
 
-        let stream_data = std::io::Result::Ok(data.clone());
+        let data = Bytes::from("arbitrary data");
+        let expected_data = data.clone();
+        let data_len = data.len();
+        let stream_fn = move || {
+            let stream_data = std::io::Result::Ok(data.clone());
+            futures::stream::once(async move { stream_data })
+        };
+
         integration
-            .put(
-                &location,
-                futures::stream::once(async move { stream_data }),
-                Some(data.len()),
-            )
+            .put(&location, stream_fn, Some(data_len))
             .await
             .unwrap();
 
@@ -384,7 +389,7 @@ mod tests {
             .try_concat()
             .await
             .unwrap();
-        assert_eq!(&*read_data, data);
+        assert_eq!(&*read_data, expected_data);
     }
 
     #[tokio::test]
@@ -392,19 +397,17 @@ mod tests {
         let root = TempDir::new().unwrap();
         let integration = ObjectStore::new_file(root.path());
 
-        let data = Bytes::from("arbitrary data");
-        let stream_data = std::io::Result::Ok(data.clone());
-
         let mut location = integration.new_path();
         location.set_file_name("some_file");
-        integration
-            .put(
-                &location,
-                futures::stream::once(async move { stream_data }),
-                None,
-            )
-            .await
-            .unwrap();
+
+        let data = Bytes::from("arbitrary data");
+        let expected_data = data.clone();
+        let stream_fn = move || {
+            let stream_data = std::io::Result::Ok(data.clone());
+            futures::stream::once(async move { stream_data })
+        };
+
+        integration.put(&location, stream_fn, None).await.unwrap();
 
         let read_data = integration
             .get(&location)
@@ -414,7 +417,7 @@ mod tests {
             .try_concat()
             .await
             .unwrap();
-        assert_eq!(&*read_data, data);
+        assert_eq!(&*read_data, expected_data);
     }
 
     #[tokio::test]

--- a/object_store/src/dummy.rs
+++ b/object_store/src/dummy.rs
@@ -42,13 +42,14 @@ impl ObjectStoreApi for DummyObjectStore {
         CloudPath::default()
     }
 
-    async fn put<S>(
+    async fn put<F, S>(
         &self,
         _location: &Self::Path,
-        _bytes: S,
+        _bytes: F,
         _length: Option<usize>,
     ) -> crate::Result<(), Self::Error>
     where
+        F: Fn() -> S + Clone + Send + Sync + Unpin + 'static,
         S: futures::Stream<Item = std::io::Result<bytes::Bytes>> + Send + Sync + 'static,
     {
         NotSupported { name: &self.name }.fail()

--- a/object_store/src/dummy.rs
+++ b/object_store/src/dummy.rs
@@ -1,6 +1,7 @@
 //! Crate that mimics the interface of the the various object stores
 //! but does nothing if they are not enabled.
 use async_trait::async_trait;
+use bytes::Bytes;
 use snafu::Snafu;
 
 use crate::{path::cloud::CloudPath, ObjectStoreApi};
@@ -42,16 +43,7 @@ impl ObjectStoreApi for DummyObjectStore {
         CloudPath::default()
     }
 
-    async fn put<F, S>(
-        &self,
-        _location: &Self::Path,
-        _bytes: F,
-        _length: Option<usize>,
-    ) -> crate::Result<(), Self::Error>
-    where
-        F: Fn() -> S + Clone + Send + Sync + Unpin + 'static,
-        S: futures::Stream<Item = std::io::Result<bytes::Bytes>> + Send + Sync + 'static,
-    {
+    async fn put(&self, _location: &Self::Path, _bytes: Bytes) -> crate::Result<(), Self::Error> {
         NotSupported { name: &self.name }.fail()
     }
 

--- a/object_store/src/gcp.rs
+++ b/object_store/src/gcp.rs
@@ -342,7 +342,11 @@ mod test {
                 },
         }) = err.downcast_ref::<ObjectStoreError>()
         {
-            assert!(matches!(source, cloud_storage::Error::Reqwest(_)));
+            assert!(
+                matches!(source, cloud_storage::Error::Other(_)),
+                "got: {:?}",
+                source
+            );
             assert_eq!(bucket, &config.bucket);
             assert_eq!(location, NON_EXISTENT_NAME);
         } else {

--- a/object_store/src/gcp.rs
+++ b/object_store/src/gcp.rs
@@ -86,11 +86,12 @@ impl ObjectStoreApi for GoogleCloudStorage {
         CloudPath::default()
     }
 
-    async fn put<S>(&self, location: &Self::Path, bytes: S, length: Option<usize>) -> Result<()>
+    async fn put<F, S>(&self, location: &Self::Path, bytes: F, length: Option<usize>) -> Result<()>
     where
+        F: Fn() -> S + Clone + Send + Sync + Unpin + 'static,
         S: Stream<Item = io::Result<Bytes>> + Send + Sync + 'static,
     {
-        let temporary_non_streaming = bytes
+        let temporary_non_streaming = bytes()
             .map_ok(|b| bytes::BytesMut::from(&b[..]))
             .try_concat()
             .await

--- a/parquet_file/src/catalog/core.rs
+++ b/parquet_file/src/catalog/core.rs
@@ -1329,7 +1329,10 @@ mod tests {
         iox_object_store
             .put_catalog_transaction_file(
                 &path,
-                futures::stream::once(async move { Ok(data) }),
+                move || {
+                    let data = data.clone();
+                    futures::stream::once(async move { Ok(data) })
+                },
                 Some(len),
             )
             .await
@@ -2190,7 +2193,10 @@ mod tests {
         iox_object_store
             .put_catalog_transaction_file(
                 &path,
-                futures::stream::once(async move { Ok(data) }),
+                move || {
+                    let data = data.clone();
+                    futures::stream::once(async move { Ok(data) })
+                },
                 Some(len),
             )
             .await

--- a/parquet_file/src/catalog/core.rs
+++ b/parquet_file/src/catalog/core.rs
@@ -1325,16 +1325,9 @@ mod tests {
         let tkey = trace.tkeys[0];
         let path = TransactionFilePath::new_transaction(tkey.revision_counter, tkey.uuid);
         let data = Bytes::from("foo");
-        let len = data.len();
+
         iox_object_store
-            .put_catalog_transaction_file(
-                &path,
-                move || {
-                    let data = data.clone();
-                    futures::stream::once(async move { Ok(data) })
-                },
-                Some(len),
-            )
+            .put_catalog_transaction_file(&path, data)
             .await
             .unwrap();
 
@@ -2189,16 +2182,9 @@ mod tests {
         let tkey = trace.tkeys[0];
         let path = TransactionFilePath::new_transaction(tkey.revision_counter, tkey.uuid);
         let data = Bytes::from("foo");
-        let len = data.len();
+
         iox_object_store
-            .put_catalog_transaction_file(
-                &path,
-                move || {
-                    let data = data.clone();
-                    futures::stream::once(async move { Ok(data) })
-                },
-                Some(len),
-            )
+            .put_catalog_transaction_file(&path, data)
             .await
             .unwrap();
 

--- a/parquet_file/src/catalog/internals/proto_io.rs
+++ b/parquet_file/src/catalog/internals/proto_io.rs
@@ -36,17 +36,9 @@ pub async fn store_transaction_proto(
     let mut data = Vec::new();
     proto.encode(&mut data).context(Serialization {})?;
     let data = Bytes::from(data);
-    let len = data.len();
 
     iox_object_store
-        .put_catalog_transaction_file(
-            path,
-            move || {
-                let data = data.clone();
-                futures::stream::once(async move { Ok(data) })
-            },
-            Some(len),
-        )
+        .put_catalog_transaction_file(path, data)
         .await
         .context(Write {})?;
 

--- a/parquet_file/src/catalog/internals/proto_io.rs
+++ b/parquet_file/src/catalog/internals/proto_io.rs
@@ -41,7 +41,10 @@ pub async fn store_transaction_proto(
     iox_object_store
         .put_catalog_transaction_file(
             path,
-            futures::stream::once(async move { Ok(data) }),
+            move || {
+                let data = data.clone();
+                futures::stream::once(async move { Ok(data) })
+            },
             Some(len),
         )
         .await

--- a/parquet_file/src/storage.rs
+++ b/parquet_file/src/storage.rs
@@ -212,12 +212,14 @@ impl Storage {
     pub async fn to_object_store(&self, data: Vec<u8>, path: &ParquetFilePath) -> Result<()> {
         let len = data.len();
         let data = Bytes::from(data);
-        let stream_data = Result::Ok(data);
 
         self.iox_object_store
             .put_parquet_file(
                 path,
-                futures::stream::once(async move { stream_data }),
+                move || {
+                    let data = data.clone();
+                    futures::stream::once(async move { Result::Ok(data) })
+                },
                 Some(len),
             )
             .await

--- a/parquet_file/src/storage.rs
+++ b/parquet_file/src/storage.rs
@@ -210,18 +210,10 @@ impl Storage {
 
     /// Put the given vector of bytes to the specified location
     pub async fn to_object_store(&self, data: Vec<u8>, path: &ParquetFilePath) -> Result<()> {
-        let len = data.len();
         let data = Bytes::from(data);
 
         self.iox_object_store
-            .put_parquet_file(
-                path,
-                move || {
-                    let data = data.clone();
-                    futures::stream::once(async move { Result::Ok(data) })
-                },
-                Some(len),
-            )
+            .put_parquet_file(path, data)
             .await
             .context(WritingToObjectStore)
     }

--- a/server/src/db.rs
+++ b/server/src/db.rs
@@ -4093,7 +4093,10 @@ mod tests {
         iox_object_store
             .put_parquet_file(
                 path,
-                futures::stream::once(async move { Ok(data) }),
+                move || {
+                    let data = data.clone();
+                    futures::stream::once(async move { Ok(data) })
+                },
                 Some(len),
             )
             .await

--- a/server/src/db.rs
+++ b/server/src/db.rs
@@ -4087,18 +4087,8 @@ mod tests {
     }
 
     async fn create_empty_file(iox_object_store: &IoxObjectStore, path: &ParquetFilePath) {
-        let data = Bytes::default();
-        let len = data.len();
-
         iox_object_store
-            .put_parquet_file(
-                path,
-                move || {
-                    let data = data.clone();
-                    futures::stream::once(async move { Ok(data) })
-                },
-                Some(len),
-            )
+            .put_parquet_file(path, Bytes::new())
             .await
             .unwrap();
     }

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -1947,11 +1947,7 @@ mod tests {
         fake_db_path.set_file_name("not-a-generation");
         application
             .object_store()
-            .put(
-                &fake_db_path,
-                move || futures::stream::once(async move { Ok(Bytes::new()) }),
-                None,
-            )
+            .put(&fake_db_path, Bytes::new())
             .await
             .unwrap();
 

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -1949,7 +1949,7 @@ mod tests {
             .object_store()
             .put(
                 &fake_db_path,
-                futures::stream::once(async move { Ok(Bytes::new()) }),
+                move || futures::stream::once(async move { Ok(Bytes::new()) }),
                 None,
             )
             .await

--- a/server_benchmarks/benches/catalog_persistence.rs
+++ b/server_benchmarks/benches/catalog_persistence.rs
@@ -160,7 +160,6 @@ fn create_throttled_store() -> Arc<ObjectStore> {
 
         // for upload/download: assume 1GByte/s
         wait_get_per_byte: Duration::from_secs(1) / 1_000_000_000,
-        wait_put_per_byte: Duration::from_secs(1) / 1_000_000_000,
     };
 
     Arc::new(ObjectStore::new_in_memory_throttled(config))

--- a/src/object_store.rs
+++ b/src/object_store.rs
@@ -218,7 +218,6 @@ impl TryFrom<&ObjectStoreConfig> for ObjectStore {
 
                     // for upload/download: assume 1GByte/s
                     wait_get_per_byte: Duration::from_secs(1) / 1_000_000_000,
-                    wait_put_per_byte: Duration::from_secs(1) / 1_000_000_000,
                 };
 
                 Ok(Self::new_in_memory_throttled(config))


### PR DESCRIPTION
Closes #2483 

The future is here! And they're evenly distributed, all over!

This borrows heavily from [the s3-algo crate's retry of rusoto requests](https://github.com/openanalytics/s3-algo/blob/464f7481b644ea8b5f21ea2d943002a8ee90db06/src/lib.rs#L133) and wraps all S3 requests in the `s3_request` function, that uses the [futures-retry crate](https://crates.io/crates/futures_retry) to clone the future and run it again if it fails and certain conditions are met.

There's a lot of minor rearranging of the API to make futures and closures that make futures and closures... I hope it'll make sense if you look commit-by-commit, but please ask if anything is confusing. 

The `ObjectStore` trait needed to change, so there's a tiny bit of changes in all the object store implementations, but this only retries S3 requests. I haven't had a chance to investigate the other object store crates' retry implementations (or lack thereof) yet.

Some questions I have:

- Currently I've [hardcoded the number of times a request is retried to 10](https://github.com/influxdata/influxdb_iox/pull/2625/files#diff-44002b1abe67569142529e6752131b4327abb349c51dfe8ba3d5f3f30035ab3bR489). Should this be configurable via a command-line option/env var, or is this fine for now?
- What logging would be useful? Every time a request is retried? The error that prompted the retry? How many times a request was retried? Something else? Nothing?