### PR TITLE
feat: validate Read Buffer predicates

### DIFF
--- a/read_buffer/benches/read_filter.rs
+++ b/read_buffer/benches/read_filter.rs
@@ -47,7 +47,9 @@ fn read_filter_no_pred_vary_proj(c: &mut Criterion, chunk: &RBChunk) {
             &exp_card,
             |b, _| {
                 b.iter(|| {
-                    let result = chunk.read_filter(Predicate::default(), projection, vec![]);
+                    let result = chunk
+                        .read_filter(Predicate::default(), projection, vec![])
+                        .unwrap();
                     let rbs = result.collect::<Vec<_>>();
                     assert_eq!(rbs.len(), 1);
                     assert_eq!(rbs[0].num_rows(), 200_000);
@@ -82,7 +84,9 @@ fn read_filter_with_pred_vary_proj(c: &mut Criterion, chunk: &RBChunk) {
             &exp_rows,
             |b, _| {
                 b.iter(|| {
-                    let result = chunk.read_filter(predicate.clone(), Selection::All, vec![]);
+                    let result = chunk
+                        .read_filter(predicate.clone(), Selection::All, vec![])
+                        .unwrap();
                     let rbs = result.collect::<Vec<_>>();
                     assert_eq!(rbs.len(), 1);
                     assert!(rbs[0].num_rows() > 0); // data randomly generated so row numbers not exact

--- a/read_buffer/src/chunk.rs
+++ b/read_buffer/src/chunk.rs
@@ -280,7 +280,9 @@ impl Chunk {
         only_columns: Selection<'_>,
         dst: BTreeSet<String>,
     ) -> Result<BTreeSet<String>> {
-        Ok(self.table.column_names(&predicate, only_columns, dst))
+        self.table
+            .column_names(&predicate, only_columns, dst)
+            .context(TableError)
     }
 
     /// Returns the distinct set of column values for each provided column,

--- a/read_buffer/src/chunk.rs
+++ b/read_buffer/src/chunk.rs
@@ -1255,6 +1255,16 @@ mod test {
         // sketchy_sensor won't be returned because it has a NULL value for the
         // only matching row.
         assert_eq!(result, to_set(&["counter", "region", "time"]));
+
+        // Error when invalid predicate provided.
+        assert!(matches!(
+            chunk.column_names(
+                Predicate::new(vec![BinaryExpr::from(("time", "=", "not a number"))]),
+                Selection::Some(&["region", "env"]),
+                BTreeSet::new()
+            ),
+            Err(Error::TableError { .. })
+        ));
     }
 
     fn to_map(arr: Vec<(&str, &[&str])>) -> BTreeMap<String, BTreeSet<String>> {
@@ -1345,6 +1355,16 @@ mod test {
         assert!(matches!(
             chunk.column_values(Predicate::default(), Selection::All, BTreeMap::new()),
             Err(Error::UnsupportedOperation { .. })
+        ));
+
+        // Error when invalid predicate provided.
+        assert!(matches!(
+            chunk.column_values(
+                Predicate::new(vec![BinaryExpr::from(("time", "=", "not a number"))]),
+                Selection::Some(&["region", "env"]),
+                BTreeMap::new()
+            ),
+            Err(Error::TableError { .. })
         ));
     }
 }

--- a/read_buffer/src/chunk.rs
+++ b/read_buffer/src/chunk.rs
@@ -214,7 +214,8 @@ impl Chunk {
     /// match the provided predicate.
     ///
     /// If the provided table does not exist then `could_pass_predicate` returns
-    /// `false`.
+    /// `false`. If the predicate is incompatible with chunk's schema
+    /// `could_pass_predicate` returns false.
     pub fn could_pass_predicate(&self, predicate: Predicate) -> bool {
         self.table.could_pass_predicate(&predicate)
     }
@@ -1194,6 +1195,13 @@ mod test {
         assert!(
             !chunk.satisfies_predicate(&Predicate::new(vec![BinaryExpr::from((
                 "region", ">", "west"
+            ))]),)
+        );
+
+        // invalid predicate so no rows can match
+        assert!(
+            !chunk.satisfies_predicate(&Predicate::new(vec![BinaryExpr::from((
+                "region", "=", 33.2
             ))]),)
         );
     }

--- a/read_buffer/src/table.rs
+++ b/read_buffer/src/table.rs
@@ -495,6 +495,7 @@ impl Table {
         mut dst: BTreeMap<String, BTreeSet<String>>,
     ) -> Result<BTreeMap<String, BTreeSet<String>>> {
         let (meta, row_groups) = self.filter_row_groups(predicate);
+        meta.validate_exprs(predicate.iter())?;
 
         // Validate that only supported columns present in `columns`.
         for (name, (ct, _)) in columns.iter().zip(meta.schema_for_column_names(columns)) {

--- a/read_buffer/src/table.rs
+++ b/read_buffer/src/table.rs
@@ -327,6 +327,7 @@ impl Table {
         aggregates: &'input [(ColumnName<'input>, AggregateType)],
     ) -> Result<ReadAggregateResults> {
         let (meta, row_groups) = self.filter_row_groups(&predicate);
+        meta.validate_exprs(predicate.iter())?;
 
         // Filter out any column names that we do not have data for.
         let schema = ResultSchema {

--- a/server/src/db/chunk.rs
+++ b/server/src/db/chunk.rs
@@ -374,7 +374,11 @@ impl QueryChunk for DbChunk {
                     "Negated Predicate pushed down to RUB"
                 );
 
-                let read_results = chunk.read_filter(rb_predicate, selection, negated_delete_exprs);
+                let read_results = chunk
+                    .read_filter(rb_predicate, selection, negated_delete_exprs)
+                    .context(ReadBufferChunkError {
+                        chunk_id: self.id(),
+                    })?;
                 let schema =
                     chunk
                         .read_filter_table_schema(selection)


### PR DESCRIPTION
Related to #1603.

This PR adds some validation checks on the expressions within predicates supplied to the Read Buffer. This ensures that invalid predicates cannot cause the Read Buffer to panic, but instead result in an error that is propogated back to the query engine.

Currently, invalid predicates are those where making a comparison between the values and the column and the provided literal are not obvious, e.g., trying to apply the expression `region > 33` to a `region` column that has a string datatype.

This PR does not resolve https://github.com/influxdata/influxdb_iox/issues/1603 - in fact a predicate `temp = 22.2` for a `temp` column with a physical type `u64` is considered valid within the logic of this PR.

A follow on PR will teach the Read Buffer to coalesce compatible types into the column type automatically, which will ensure expressions like `temp > 100.3` will work when the `temp` column is `i64` or `u64`.