### PR TITLE
refactor: tidy up debug CLI help

### DIFF
--- a/src/commands/debug.rs
+++ b/src/commands/debug.rs
@@ -38,7 +38,7 @@ pub enum Error {
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
-/// Manage long-running IOx operations
+/// Interrogate internal database data
 #[derive(Debug, StructOpt)]
 pub struct Config {
     #[structopt(subcommand)]


### PR DESCRIPTION
I noticed running `influxdb_iox --help`:

```
SUBCOMMANDS:
    database     All possible subcommands for database
    debug        Manage long-running IOx operations
    help         Prints this message or the help of the given subcommand(s)
    operation    Manage long-running IOx operations
    run          CLI config for server ID
    server       IOx server commands
    sql          Start IOx interactive SQL REPL loop
```

This PR updates the description for the `debug` sub-command.

So now:

```
SUBCOMMANDS:
    database     All possible subcommands for database
    debug        Interrogate internal database data
    help         Prints this message or the help of the given subcommand(s)
    operation    Manage long-running IOx operations
    run          CLI config for server ID
    server       IOx server commands
    sql          Start IOx interactive SQL REPL loop
```