### PR TITLE
fix: perf build cache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -201,20 +201,11 @@ jobs:
           name: Install perf.py dependencies
           command: python3 -m pip install -r perf/requirements.txt
 
-      - restore_cache:
-          keys:
-            - cargo-lock-{{ checksum "Cargo.lock" }}
-      - run:
-          name: Prime Rust build cache
-          command: cargo build --package influxdb_iox --bin influxdb_iox --package iox_data_generator --bin iox_data_generator
-      - save_cache:
-          key: cargo-lock-{{ checksum "Cargo.lock" }}
-          paths:
-            - target
-
+      - cache_restore
       - run:
           name: Run basic perf test to ensure that perf.py works
           command: perf/perf.py --debug --no-volumes --object-store memory battery-0
+      - cache_save
 
   test_kafka_integration:
     machine: true


### PR DESCRIPTION
Caching and restoring "/target" will just cause it to grow indefinitely over time, this changes the perf CI to use the same caching mechanism as all the other jobs