### PR TITLE
HACK: return 1 row record batches from IOxReadFilterNode 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -148,7 +148,7 @@ jobs:
       - cache_restore
       - run:
           name: Cargo test
-          command: cargo test --workspace
+          command: cargo test --workspace  --no-fail-fast
       - cache_save
 
   # end to end tests with Heappy (heap profiling enabled)
@@ -401,18 +401,7 @@ workflows:
   # CI for all pull requests.
   ci:
     jobs:
-      - fmt
-      - lint
-      - cargo_audit
-      - protobuf-lint
       - test
-      - test_heappy
-      - test_perf
-      - test_kafka_integration
-      - test_influxdb2_client
-      - build
-      - check-flatbuffers
-      - doc
 
   # Internal pipeline for perf builds.
   #

--- a/query/src/provider.rs
+++ b/query/src/provider.rs
@@ -1001,7 +1001,7 @@ mod test {
     use std::num::NonZeroU64;
 
     use arrow::datatypes::DataType;
-    use arrow_util::assert_batches_eq;
+    use arrow_util::{assert_batches_eq, assert_batches_sorted_eq};
     use datafusion::physical_plan::collect;
     use internal_types::schema::{builder::SchemaBuilder, TIME_COLUMN_NAME};
 
@@ -2193,7 +2193,7 @@ mod test {
             "| 50        | VT   | 1970-01-01T00:00:00.000210Z    |",
             "+-----------+------+--------------------------------+",
         ];
-        assert_batches_eq!(&expected, &raw_data(&chunks).await);
+        assert_batches_sorted_eq!(&expected, &raw_data(&chunks).await);
 
         // Create scan plan whose output data is only partially sorted
         let mut deduplicator = Deduplicater::new();
@@ -2229,7 +2229,7 @@ mod test {
             "| 10        | MT   | 1970-01-01T00:00:00.000007Z    |",
             "+-----------+------+--------------------------------+",
         ];
-        assert_batches_eq!(&expected, &batch);
+        assert_batches_sorted_eq!(&expected, &batch);
     }
 
     #[tokio::test]


### PR DESCRIPTION
Demonstrate that IOx still gets correct answers even when multiple record batches are returned from `IOxReadFilterNode` -- re https://github.com/influxdata/influxdb_iox/issues/2294

NOT FOR MERGING