### PR TITLE
fix: fallback to DataFusion predicates if unable to execute on RUB

### DIFF
--- a/query_tests/src/sql.rs
+++ b/query_tests/src/sql.rs
@@ -779,6 +779,28 @@ async fn sql_predicate_pushdown_correctness_13() {
 }
 
 #[tokio::test]
+async fn sql_predicate_pushdown_correctness_14() {
+    // Test 14: on push-down expression with a literal type different from the
+    // column type.
+    //
+    // Check correctness
+    let expected = vec![
+        "+-------+--------+--------------------------------+---------+",
+        "| count | system | time                           | town    |",
+        "+-------+--------+--------------------------------+---------+",
+        "| 632   | 5      | 1970-01-01T00:00:00.000000120Z | reading |",
+        "| 632   | 6      | 1970-01-01T00:00:00.000000130Z | reading |",
+        "+-------+--------+--------------------------------+---------+",
+    ];
+    run_sql_test_case(
+        TwoMeasurementsPredicatePushDown {},
+        "SELECT * from restaurant where count > 500.76 and count < 640.0",
+        &expected,
+    )
+    .await;
+}
+
+#[tokio::test]
 async fn sql_deduplicate_1() {
     // This current expected is wrong because deduplicate is not available yet
     let sql =

--- a/read_buffer/src/chunk.rs
+++ b/read_buffer/src/chunk.rs
@@ -210,6 +210,13 @@ impl Chunk {
     // ---- Schema queries
     //
 
+    /// Validates if the predicate can be applied to the table based on the
+    /// schema and the predicate's expressions. Returns an error if the
+    /// predicate cannot be applied.
+    pub fn validate_predicate(&self, predicate: Predicate) -> Result<Predicate, Error> {
+        self.table.validate_predicate(predicate).context(TableError)
+    }
+
     /// Determines if one of more rows in the provided table could possibly
     /// match the provided predicate.
     ///

--- a/read_buffer/src/row_group.rs
+++ b/read_buffer/src/row_group.rs
@@ -1355,6 +1355,21 @@ impl Predicate {
     }
 }
 
+impl From<Vec<BinaryExpr>> for Predicate {
+    fn from(arr: Vec<BinaryExpr>) -> Self {
+        Self(arr)
+    }
+}
+
+impl IntoIterator for Predicate {
+    type Item = BinaryExpr;
+    type IntoIter = std::vec::IntoIter<Self::Item>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
+    }
+}
+
 /// Supported literal values for expressions. These map to a sub-set of logical
 /// datatypes supported by the `ReadBuffer`.
 #[derive(Clone, Debug, PartialEq)]

--- a/read_buffer/src/table.rs
+++ b/read_buffer/src/table.rs
@@ -234,6 +234,14 @@ impl Table {
         Arc::clone(&self.table_data.read().meta)
     }
 
+    /// Validates if the predicate can be applied to the table based on the
+    /// schema and the predicate's expressions. Returns an error if the
+    /// predicate cannot be applied.
+    pub fn validate_predicate(&self, predicate: Predicate) -> Result<Predicate, Error> {
+        let table_data = self.table_data.read();
+        Ok(table_data.meta.validate_exprs(predicate)?.into())
+    }
+
     /// Determines if one of more row groups in the `Table` could possibly
     /// contain one or more rows that satisfy the provided predicate.
     pub fn could_pass_predicate(&self, predicate: &Predicate) -> bool {

--- a/server/src/db/pred.rs
+++ b/server/src/db/pred.rs
@@ -16,6 +16,13 @@ pub type Result<T, E = Error> = std::result::Result<T, E>;
 
 /// Converts a [`predicate::predicate::Predicate`] into [`read_buffer::Predicate`],
 /// suitable for evaluating on the ReadBuffer.
+///
+/// NOTE: a valid Read Buffer predicate is not guaranteed to be applicable to an
+/// arbitrary Read Buffer chunk, because the applicability of a predicate
+/// depends on the schema of the chunk.
+///
+/// Callers should validate predicates against chunks they are to be executed
+/// against using `read_buffer::Chunk::validate_predicate`
 pub fn to_read_buffer_predicate(predicate: &Predicate) -> Result<read_buffer::Predicate> {
     // Try to convert non-time column expressions into binary expressions
     // that are compatible with the read buffer.


### PR DESCRIPTION
Closes #1603 

This PR restricts the validation of predicates against the Read Buffer to only those that contain the same literal type as the column specified in the chunk schema.

For cases where the expression's literal differs in type (e.g., it's a float) from the column (e.g., it's an integer column) the new `validate_predicate` API will return an error. This API is used to validate predicates againts read buffer chunks before execution begins, which gives us the opportunity to fall-back to using the `Filter` step in the DF plan.

*Note* - I have a follow-on PR planned that will allow us to push expressions like `col_int > 3.2` down to the RUB, but I wanted to split it out of the "fix" step.

This PR fixes the issue of wrong query results, the follow on will allow us to push more types of predicate down (without breaking query results). 