### PR TITLE
feat: Implement optional SOCKS5 client proxy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -195,6 +195,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-socks5"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d54fb9d0cef966d8067cf271af71cbcab017f691b1a134fcbd8a7aaecdae4a0"
+dependencies = [
+ "async-trait",
+ "thiserror",
+ "tokio",
+]
+
+[[package]]
 name = "async-stream"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -565,6 +576,8 @@ name = "client_util"
 version = "0.1.0"
 dependencies = [
  "http",
+ "hyper",
+ "hyper-socks2",
  "prost",
  "thiserror",
  "tokio",
@@ -1543,6 +1556,20 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "webpki",
+]
+
+[[package]]
+name = "hyper-socks2"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01b408a306f4e49b1eac23dd88f0852c0abb2b1d162d498cd889cfcd56d8eec"
+dependencies = [
+ "async-socks5",
+ "futures",
+ "http",
+ "hyper",
+ "thiserror",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -195,3 +195,4 @@ aws = ["object_store/aws"] # Optional AWS / S3 object store support
 # to pick either heappy or jemalloc_replacing_malloc feature at least until we figure out something better.
 jemalloc_replacing_malloc = ["tikv-jemalloc-sys"]
 
+socks5 = [ "influxdb_iox_client/socks5" ]

--- a/client_util/Cargo.toml
+++ b/client_util/Cargo.toml
@@ -5,12 +5,20 @@ authors = ["Raphael Taylor-Davies <r.taylordavies@googlemail.com>"]
 description = "Shared code for IOx clients"
 edition = "2018"
 
+[features]
+default = []
+
+socks5 = [ "hyper-socks2" , "hyper" ]
+
 [dependencies]
 http = "0.2.3"
 prost = "0.8"
 thiserror = "1.0.28"
 tonic = { version = "0.5.0" }
 tower = "0.4"
+hyper-socks2 = { version = "0.6", optional = true, default-features = false }
+hyper = {version = "0.14", optional = true }
 
 [dev-dependencies]
 tokio = { version = "1.11", features = ["macros"] }
+

--- a/influxdb_iox_client/Cargo.toml
+++ b/influxdb_iox_client/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 [features]
 flight = ["arrow", "arrow-flight", "arrow_util", "serde/derive", "serde_json", "futures-util"]
 format = ["arrow"]
+socks5 = [ "client_util/socks5" ]
 
 [dependencies]
 # Workspace dependencies, in alphabetical order


### PR DESCRIPTION
Implement (optional) socks5 proxy in the iox client library.

This allows a local IOx client (e.g. a development version of conductor) to talk to IOx servers
running in a local k8s cluster even if the pod networking is not directly routable.

Among other things, this offers a simpler way to develop on a mac and test conductor locally
without having to cross-compile it for linux and run it in a container (or using complicated things
like teleport).

Demo:

```console
$ kubectl krew install socks5-proxy
...
$ kubectl socks5-proxy &
...
$ ALL_PROXY=socks5://127.0.0.1:1080 ./target/debug/influxdb_iox -h http://10.1.0.7:8082 server get
132072
```
