### PR TITLE
refactor: make `ChunkOrder` non-zero

### DIFF
--- a/lifecycle/src/policy.rs
+++ b/lifecycle/src/policy.rs
@@ -754,7 +754,7 @@ mod tests {
                 time_of_last_write: from_secs(time_of_last_write),
                 lifecycle_action: None,
                 storage,
-                order: ChunkOrder::new(0),
+                order: ChunkOrder::MIN,
             }
         }
 
@@ -1517,23 +1517,23 @@ mod tests {
                 // blocked by action below
                 TestChunk::new(ChunkId::new(19), 20, ChunkStorage::ReadBuffer)
                     .with_row_count(400)
-                    .with_order(ChunkOrder::new(4)),
+                    .with_order(ChunkOrder::new(5).unwrap()),
                 // has an action
                 TestChunk::new(ChunkId::new(20), 20, ChunkStorage::ReadBuffer)
                     .with_row_count(400)
-                    .with_order(ChunkOrder::new(3))
+                    .with_order(ChunkOrder::new(4).unwrap())
                     .with_action(ChunkLifecycleAction::Compacting),
                 // closed => can compact
                 TestChunk::new(ChunkId::new(21), 20, ChunkStorage::ReadBuffer)
                     .with_row_count(400)
-                    .with_order(ChunkOrder::new(2)),
+                    .with_order(ChunkOrder::new(3).unwrap()),
                 TestChunk::new(ChunkId::new(22), 20, ChunkStorage::ReadBuffer)
                     .with_row_count(400)
-                    .with_order(ChunkOrder::new(1)),
+                    .with_order(ChunkOrder::new(2).unwrap()),
                 // has an action, but doesn't block because it's first
                 TestChunk::new(ChunkId::new(23), 20, ChunkStorage::ReadBuffer)
                     .with_row_count(400)
-                    .with_order(ChunkOrder::new(0))
+                    .with_order(ChunkOrder::new(1).unwrap())
                     .with_action(ChunkLifecycleAction::Compacting),
             ]),
         ];

--- a/parquet_file/src/catalog/core.rs
+++ b/parquet_file/src/catalog/core.rs
@@ -39,7 +39,7 @@ pub use crate::catalog::internals::proto_parse::Error as ProtoParseError;
 /// Current version for serialized transactions.
 ///
 /// For breaking changes, this will change.
-pub const TRANSACTION_VERSION: u32 = 15;
+pub const TRANSACTION_VERSION: u32 = 16;
 
 #[derive(Debug, Snafu)]
 pub enum Error {

--- a/parquet_file/src/catalog/dump.rs
+++ b/parquet_file/src/catalog/dump.rs
@@ -272,7 +272,7 @@ File {
     is_checkpoint: false,
     proto: Ok(
         Transaction {
-            version: 15,
+            version: 16,
             actions: [],
             revision_counter: 0,
             uuid: "00000000-0000-0000-0000-000000000000",
@@ -297,7 +297,7 @@ File {
     is_checkpoint: false,
     proto: Ok(
         Transaction {
-            version: 15,
+            version: 16,
             actions: [
                 Action {
                     action: Some(
@@ -396,7 +396,7 @@ File {
     is_checkpoint: false,
     proto: Ok(
         Transaction {
-            version: 15,
+            version: 16,
             actions: [],
             revision_counter: 0,
             uuid: "00000000-0000-0000-0000-000000000000",
@@ -421,7 +421,7 @@ File {
     is_checkpoint: false,
     proto: Ok(
         Transaction {
-            version: 15,
+            version: 16,
             actions: [
                 Action {
                     action: Some(

--- a/parquet_file/src/catalog/rebuild.rs
+++ b/parquet_file/src/catalog/rebuild.rs
@@ -379,7 +379,7 @@ mod tests {
             database_checkpoint,
             time_of_first_write: Utc::now(),
             time_of_last_write: Utc::now(),
-            chunk_order: ChunkOrder::new(5),
+            chunk_order: ChunkOrder::new(5).unwrap(),
         };
         let stream: SendableRecordBatchStream = Box::pin(MemoryStream::new(record_batches));
         let (path, file_size_bytes, metadata) = storage

--- a/parquet_file/src/storage.rs
+++ b/parquet_file/src/storage.rs
@@ -450,7 +450,7 @@ mod tests {
             database_checkpoint,
             time_of_first_write: Utc::now(),
             time_of_last_write: Utc::now(),
-            chunk_order: ChunkOrder::new(5),
+            chunk_order: ChunkOrder::new(5).unwrap(),
         };
 
         // create parquet file
@@ -525,7 +525,7 @@ mod tests {
             database_checkpoint,
             time_of_first_write: Utc::now(),
             time_of_last_write: Utc::now(),
-            chunk_order: ChunkOrder::new(5),
+            chunk_order: ChunkOrder::new(5).unwrap(),
         };
 
         let (path, _file_size_bytes, _metadata) = storage

--- a/parquet_file/src/test_utils.rs
+++ b/parquet_file/src/test_utils.rs
@@ -189,7 +189,7 @@ pub async fn make_chunk_given_record_batch(
         database_checkpoint,
         time_of_first_write: Utc.timestamp(30, 40),
         time_of_last_write: Utc.timestamp(50, 60),
-        chunk_order: ChunkOrder::new(5),
+        chunk_order: ChunkOrder::new(5).unwrap(),
     };
     let (path, file_size_bytes, parquet_metadata) = storage
         .write_to_object_store(addr.clone(), stream, metadata)

--- a/query/src/test.rs
+++ b/query/src/test.rs
@@ -254,7 +254,7 @@ impl TestChunk {
             saved_error: Default::default(),
             predicate_match: Default::default(),
             delete_predicates: Default::default(),
-            order: ChunkOrder::new(0),
+            order: ChunkOrder::MIN,
         }
     }
 

--- a/server/src/db.rs
+++ b/server/src/db.rs
@@ -1773,7 +1773,7 @@ mod tests {
             .id();
 
         // A chunk is now in the object store and still in read buffer
-        let expected_parquet_size = 1243;
+        let expected_parquet_size = 1245;
         catalog_chunk_size_bytes_metric_eq(registry, "read_buffer", expected_read_buffer_size);
         // now also in OS
         catalog_chunk_size_bytes_metric_eq(registry, "object_store", expected_parquet_size);
@@ -2212,7 +2212,7 @@ mod tests {
         // Read buffer + Parquet chunk size
         catalog_chunk_size_bytes_metric_eq(registry, "mutable_buffer", 0);
         catalog_chunk_size_bytes_metric_eq(registry, "read_buffer", 1700);
-        catalog_chunk_size_bytes_metric_eq(registry, "object_store", 1241);
+        catalog_chunk_size_bytes_metric_eq(registry, "object_store", 1243);
 
         // All the chunks should have different IDs
         assert_ne!(mb_chunk.id(), rb_chunk.id());
@@ -2327,7 +2327,7 @@ mod tests {
         // Read buffer + Parquet chunk size
         catalog_chunk_size_bytes_metric_eq(registry, "mutable_buffer", 0);
         catalog_chunk_size_bytes_metric_eq(registry, "read_buffer", 1700);
-        catalog_chunk_size_bytes_metric_eq(registry, "object_store", 1241);
+        catalog_chunk_size_bytes_metric_eq(registry, "object_store", 1243);
 
         // Unload RB chunk but keep it in OS
         let pq_chunk = db
@@ -2348,7 +2348,7 @@ mod tests {
         // Parquet chunk size only
         catalog_chunk_size_bytes_metric_eq(registry, "mutable_buffer", 0);
         catalog_chunk_size_bytes_metric_eq(registry, "read_buffer", 0);
-        catalog_chunk_size_bytes_metric_eq(registry, "object_store", 1241);
+        catalog_chunk_size_bytes_metric_eq(registry, "object_store", 1243);
 
         // Verify data written to the parquet file in object store
         //
@@ -2594,7 +2594,7 @@ mod tests {
             time_of_first_write: Utc.timestamp_nanos(1),
             time_of_last_write: Utc.timestamp_nanos(1),
             time_closed: None,
-            order: ChunkOrder::new(5),
+            order: ChunkOrder::new(5).unwrap(),
         }];
 
         let size: usize = db
@@ -2829,7 +2829,7 @@ mod tests {
                 storage: ChunkStorage::ReadBufferAndObjectStore,
                 lifecycle_action,
                 memory_bytes: 4085,       // size of RB and OS chunks
-                object_store_bytes: 1533, // size of parquet file
+                object_store_bytes: 1537, // size of parquet file
                 row_count: 2,
                 time_of_last_access: None,
                 time_of_first_write: Utc.timestamp_nanos(1),

--- a/server/src/db/catalog/chunk.rs
+++ b/server/src/db/catalog/chunk.rs
@@ -1162,7 +1162,7 @@ mod tests {
             mb_chunk,
             time_of_write,
             ChunkMetrics::new_unregistered(),
-            ChunkOrder::new(5),
+            ChunkOrder::new(5).unwrap(),
         )
     }
 
@@ -1180,7 +1180,7 @@ mod tests {
             now,
             ChunkMetrics::new_unregistered(),
             vec![],
-            ChunkOrder::new(6),
+            ChunkOrder::new(6).unwrap(),
         )
     }
 }

--- a/server/src/db/catalog/partition.rs
+++ b/server/src/db/catalog/partition.rs
@@ -154,7 +154,7 @@ impl Partition {
             next_chunk_id: ChunkId::new(0),
             metrics: Arc::new(metrics),
             persistence_windows: None,
-            next_chunk_order: ChunkOrder::new(0),
+            next_chunk_order: ChunkOrder::MIN,
         }
     }
 

--- a/server/src/db/system_tables/chunks.rs
+++ b/server/src/db/system_tables/chunks.rs
@@ -165,7 +165,7 @@ mod tests {
                 time_of_first_write: Utc.timestamp_nanos(10_000_000_000),
                 time_of_last_write: Utc.timestamp_nanos(10_000_000_000),
                 time_closed: None,
-                order: ChunkOrder::new(5),
+                order: ChunkOrder::new(5).unwrap(),
             },
             ChunkSummary {
                 partition_key: Arc::from("p1"),
@@ -180,7 +180,7 @@ mod tests {
                 time_of_first_write: Utc.timestamp_nanos(80_000_000_000),
                 time_of_last_write: Utc.timestamp_nanos(80_000_000_000),
                 time_closed: None,
-                order: ChunkOrder::new(6),
+                order: ChunkOrder::new(6).unwrap(),
             },
             ChunkSummary {
                 partition_key: Arc::from("p1"),
@@ -195,7 +195,7 @@ mod tests {
                 time_of_first_write: Utc.timestamp_nanos(100_000_000_000),
                 time_of_last_write: Utc.timestamp_nanos(200_000_000_000),
                 time_closed: None,
-                order: ChunkOrder::new(7),
+                order: ChunkOrder::new(7).unwrap(),
             },
         ];
 

--- a/server/src/db/system_tables/columns.rs
+++ b/server/src/db/system_tables/columns.rs
@@ -321,7 +321,7 @@ mod tests {
                         time_of_first_write: Utc.timestamp_nanos(1),
                         time_of_last_write: Utc.timestamp_nanos(2),
                         time_closed: None,
-                        order: ChunkOrder::new(5),
+                        order: ChunkOrder::new(5).unwrap(),
                     },
                     columns: vec![
                         ChunkColumnSummary {
@@ -358,7 +358,7 @@ mod tests {
                         time_of_first_write: Utc.timestamp_nanos(1),
                         time_of_last_write: Utc.timestamp_nanos(2),
                         time_closed: None,
-                        order: ChunkOrder::new(6),
+                        order: ChunkOrder::new(6).unwrap(),
                     },
                     columns: vec![ChunkColumnSummary {
                         name: "c1".into(),
@@ -389,7 +389,7 @@ mod tests {
                         time_of_first_write: Utc.timestamp_nanos(1),
                         time_of_last_write: Utc.timestamp_nanos(2),
                         time_closed: None,
-                        order: ChunkOrder::new(5),
+                        order: ChunkOrder::new(5).unwrap(),
                     },
                     columns: vec![ChunkColumnSummary {
                         name: "c3".into(),

--- a/tests/end_to_end_cases/management_api.rs
+++ b/tests/end_to_end_cases/management_api.rs
@@ -535,7 +535,7 @@ async fn test_chunk_get() {
             time_of_first_write: None,
             time_of_last_write: None,
             time_closed: None,
-            order: 0,
+            order: 1,
         },
         Chunk {
             partition_key: "disk".into(),
@@ -550,7 +550,7 @@ async fn test_chunk_get() {
             time_of_first_write: None,
             time_of_last_write: None,
             time_closed: None,
-            order: 0,
+            order: 1,
         },
     ];
     assert_eq!(
@@ -722,7 +722,7 @@ async fn test_list_partition_chunks() {
         time_of_first_write: None,
         time_of_last_write: None,
         time_closed: None,
-        order: 0,
+        order: 1,
     }];
 
     assert_eq!(

--- a/tests/end_to_end_cases/management_cli.rs
+++ b/tests/end_to_end_cases/management_cli.rs
@@ -709,7 +709,7 @@ async fn test_list_partition_chunks() {
     let expected = r#"
     "partition_key": "cpu",
     "table_name": "cpu",
-    "order": 0,
+    "order": 1,
     "id": 0,
     "storage": "OpenMutableBuffer",
 "#;


### PR DESCRIPTION
This will make it easier to handle missing values.

Helps with #2633.
