### PR TITLE
feat: handle delete responses

### DIFF
--- a/generated_types/protos/influxdata/iox/management/v1/service.proto
+++ b/generated_types/protos/influxdata/iox/management/v1/service.proto
@@ -494,5 +494,4 @@ message DeleteRequest {
 }
 
 message DeleteResponse {
-  // NGA todo: define an appropriate response
 }

--- a/influxdb_iox_client/src/client/management.rs
+++ b/influxdb_iox_client/src/client/management.rs
@@ -1057,7 +1057,6 @@ impl Client {
                 _ => DeleteError::ServerError(status),
             })?;
 
-        // NGA todo: return a handle to the delete?
         Ok(())
     }
 

--- a/predicate/src/delete_predicate.rs
+++ b/predicate/src/delete_predicate.rs
@@ -705,7 +705,6 @@ mod tests {
         assert_eq!(expected, result);
     }
 
-    // NGA todo: check content of error messages
     #[test]
     fn test_parse_delete_negative() {
         // invalid key

--- a/src/influxdb_ioxd/rpc/error.rs
+++ b/src/influxdb_ioxd/rpc/error.rs
@@ -177,6 +177,12 @@ pub fn default_db_error_handler(error: server::db::Error) -> tonic::Status {
             ),
         }
         .into(),
+        Error::DeleteFromTable { source, table_name } => PreconditionViolation {
+            category: "database".to_string(),
+            subject: "influxdata.com/iox".to_string(),
+            description: format!("Cannot delete data from table: {} : {}", table_name, source),
+        }
+        .into(),
         Error::CatalogError { source } => default_catalog_error_handler(source),
         error => {
             error!(?error, "Unexpected error");

--- a/src/influxdb_ioxd/rpc/management.rs
+++ b/src/influxdb_ioxd/rpc/management.rs
@@ -623,6 +623,7 @@ where
             .db(&db_name)
             .map_err(default_server_error_handler)?;
 
+        // Parse input strings and build delete predicate
         let del_predicate_result = ParseDeletePredicate::build_delete_predicate(
             start_time.clone(),
             stop_time.clone(),
@@ -637,14 +638,13 @@ where
                 }))
             }
             Ok(del_predicate) => {
-                //execute delete
+                // execute delete
                 db.delete(&table_name, Arc::new(del_predicate))
                     .await
                     .map_err(default_db_error_handler)?;
             }
         }
 
-        // NGA todo: return a delete handle with the response?
         Ok(Response::new(DeleteResponse {}))
     }
 }

--- a/tests/end_to_end_cases/management_api.rs
+++ b/tests/end_to_end_cases/management_api.rs
@@ -1587,8 +1587,10 @@ async fn test_delete() {
     let pred = "region = west";
     let del = management_client
         .delete(db_name.clone(), table, start, stop, pred)
-        .await;
-    assert!(del.is_err());
+        .await
+        .unwrap_err()
+        .to_string();
+    assert!(del.contains("Cannot delete data from table"));
 
     // Verify both existing tables still have the same data
     // query to verify data deleted


### PR DESCRIPTION
Closes #2703 
Now the delete process is clear, this PR handles the responses that were  unclear before

- [x] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb_iox/blob/main/README.md).
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
