### PR TITLE
refactor: use protobuf bytes for transaction UUIDs

### DIFF
--- a/generated_types/build.rs
+++ b/generated_types/build.rs
@@ -65,7 +65,11 @@ fn generate_grpc_types(root: &Path) -> Result<()> {
         .compile_well_known_types()
         .disable_comments(&[".google"])
         .extern_path(".google.protobuf", "::pbjson_types")
-        .bytes(&[".influxdata.iox.catalog.v1.AddParquet.metadata"])
+        .bytes(&[
+            ".influxdata.iox.catalog.v1.AddParquet.metadata",
+            ".influxdata.iox.catalog.v1.Transaction.previous_uuid",
+            ".influxdata.iox.catalog.v1.Transaction.uuid",
+        ])
         .btree_map(&[
             ".influxdata.iox.catalog.v1.DatabaseCheckpoint.sequencer_numbers",
             ".influxdata.iox.catalog.v1.PartitionCheckpoint.sequencer_numbers",

--- a/generated_types/protos/influxdata/iox/catalog/v1/catalog.proto
+++ b/generated_types/protos/influxdata/iox/catalog/v1/catalog.proto
@@ -93,12 +93,19 @@ message Transaction {
     // Revision counter, must by "previous revision" + 1 or 0 for the first transaction.
     uint64 revision_counter = 3;
 
+    // Was string-formatted UUID and previous UUID.
+    reserved 4, 5;
+
     // UUID unique to this transaction. Used to detect concurrent transactions. For the first transaction this field is
     // empty.
-    string uuid = 4;
+    //
+    // UUID is stored as 16 bytes in big-endian order.
+    bytes uuid = 8;
 
     // UUID of last commit.
-    string previous_uuid = 5;
+    //
+    // UUID is stored as 16 bytes in big-endian order.
+    bytes previous_uuid = 9;
 
     // Start timestamp.
     //

--- a/parquet_file/src/catalog/core.rs
+++ b/parquet_file/src/catalog/core.rs
@@ -39,7 +39,7 @@ pub use crate::catalog::internals::proto_parse::Error as ProtoParseError;
 /// Current version for serialized transactions.
 ///
 /// For breaking changes, this will change.
-pub const TRANSACTION_VERSION: u32 = 16;
+pub const TRANSACTION_VERSION: u32 = 17;
 
 #[derive(Debug, Snafu)]
 pub enum Error {
@@ -492,15 +492,18 @@ impl OpenTransaction {
         start_timestamp: DateTime<Utc>,
     ) -> Self {
         let (revision_counter, previous_uuid) = match previous_tkey {
-            Some(tkey) => (tkey.revision_counter + 1, tkey.uuid.to_string()),
-            None => (0, String::new()),
+            Some(tkey) => (
+                tkey.revision_counter + 1,
+                tkey.uuid.as_bytes().to_vec().into(),
+            ),
+            None => (0, Bytes::new()),
         };
 
         Self {
             proto: proto::Transaction {
                 actions: vec![],
                 version: TRANSACTION_VERSION,
-                uuid: uuid.to_string(),
+                uuid: uuid.as_bytes().to_vec().into(),
                 revision_counter,
                 previous_uuid,
                 start_timestamp: Some(start_timestamp.into()),
@@ -512,7 +515,7 @@ impl OpenTransaction {
     fn tkey(&self) -> TransactionKey {
         TransactionKey {
             revision_counter: self.proto.revision_counter,
-            uuid: Uuid::parse_str(&self.proto.uuid).expect("UUID was checked before"),
+            uuid: Uuid::from_slice(&self.proto.uuid).expect("UUID was checked before"),
         }
     }
 
@@ -935,11 +938,11 @@ impl<'c> CheckpointHandle<'c> {
         let proto = proto::Transaction {
             actions,
             version: TRANSACTION_VERSION,
-            uuid: self.tkey.uuid.to_string(),
+            uuid: self.tkey.uuid.as_bytes().to_vec().into(),
             revision_counter: self.tkey.revision_counter,
             previous_uuid: self
                 .previous_tkey
-                .map_or_else(String::new, |tkey| tkey.uuid.to_string()),
+                .map_or_else(Bytes::new, |tkey| tkey.uuid.as_bytes().to_vec().into()),
             start_timestamp: Some(Utc::now().into()),
             encoding: proto::transaction::Encoding::Full.into(),
         };
@@ -1161,9 +1164,9 @@ mod tests {
         let mut proto = load_transaction_proto(&iox_object_store, &path)
             .await
             .unwrap();
-        let uuid_expected = Uuid::parse_str(&proto.uuid).unwrap();
+        let uuid_expected = Uuid::from_slice(&proto.uuid).unwrap();
         let uuid_actual = Uuid::nil();
-        proto.uuid = uuid_actual.to_string();
+        proto.uuid = uuid_actual.as_bytes().to_vec().into();
         store_transaction_proto(&iox_object_store, &path, &proto)
             .await
             .unwrap();
@@ -1192,7 +1195,7 @@ mod tests {
         let mut proto = load_transaction_proto(&iox_object_store, &path)
             .await
             .unwrap();
-        proto.uuid = String::new();
+        proto.uuid = Bytes::new();
         store_transaction_proto(&iox_object_store, &path, &proto)
             .await
             .unwrap();
@@ -1218,7 +1221,7 @@ mod tests {
         let mut proto = load_transaction_proto(&iox_object_store, &path)
             .await
             .unwrap();
-        proto.uuid = "foo".to_string();
+        proto.uuid = Bytes::from("foo");
         store_transaction_proto(&iox_object_store, &path, &proto)
             .await
             .unwrap();
@@ -1228,7 +1231,7 @@ mod tests {
             PreservedCatalog::load::<TestCatalogState>(Arc::clone(&iox_object_store), ()).await;
         assert_eq!(
             res.unwrap_err().to_string(),
-            "Internal: Error while parsing protobuf: Cannot parse UUID: invalid length: expected one of [36, 32], found 3"
+            "Internal: Error while parsing protobuf: Cannot parse UUID: invalid bytes length: expected 16, found 3"
         );
     }
 
@@ -1244,7 +1247,7 @@ mod tests {
         let mut proto = load_transaction_proto(&iox_object_store, &path)
             .await
             .unwrap();
-        proto.previous_uuid = Uuid::nil().to_string();
+        proto.previous_uuid = Uuid::nil().as_bytes().to_vec().into();
         store_transaction_proto(&iox_object_store, &path, &proto)
             .await
             .unwrap();
@@ -1267,7 +1270,7 @@ mod tests {
         let mut proto = load_transaction_proto(&iox_object_store, &path)
             .await
             .unwrap();
-        proto.previous_uuid = Uuid::nil().to_string();
+        proto.previous_uuid = Uuid::nil().as_bytes().to_vec().into();
         store_transaction_proto(&iox_object_store, &path, &proto)
             .await
             .unwrap();
@@ -1290,7 +1293,7 @@ mod tests {
         let mut proto = load_transaction_proto(&iox_object_store, &path)
             .await
             .unwrap();
-        proto.previous_uuid = "foo".to_string();
+        proto.previous_uuid = Bytes::from("foo");
         store_transaction_proto(&iox_object_store, &path, &proto)
             .await
             .unwrap();
@@ -1300,7 +1303,7 @@ mod tests {
             PreservedCatalog::load::<TestCatalogState>(Arc::clone(&iox_object_store), ()).await;
         assert_eq!(
             res.unwrap_err().to_string(),
-            "Internal: Error while parsing protobuf: Cannot parse UUID: invalid length: expected one of [36, 32], found 3"
+            "Internal: Error while parsing protobuf: Cannot parse UUID: invalid bytes length: expected 16, found 3"
         );
     }
 
@@ -1339,7 +1342,7 @@ mod tests {
         let mut t = catalog.open_transaction().await;
 
         // open transaction
-        t.transaction.as_mut().unwrap().proto.uuid = Uuid::nil().to_string();
+        t.transaction.as_mut().unwrap().proto.uuid = Uuid::nil().as_bytes().to_vec().into();
         assert_eq!(
             format!("{:?}", t),
             "TransactionHandle(open, 1.00000000-0000-0000-0000-000000000000)"
@@ -1367,7 +1370,7 @@ mod tests {
         let new_uuid = Uuid::new_v4();
         tkey.uuid = new_uuid;
         let path = TransactionFilePath::new_transaction(tkey.revision_counter, tkey.uuid);
-        proto.uuid = new_uuid.to_string();
+        proto.uuid = new_uuid.as_bytes().to_vec().into();
         store_transaction_proto(&iox_object_store, &path, &proto)
             .await
             .unwrap();
@@ -1400,7 +1403,7 @@ mod tests {
         let new_uuid = Uuid::new_v4();
         tkey.uuid = new_uuid;
         let path = TransactionFilePath::new_checkpoint(tkey.revision_counter, tkey.uuid);
-        proto.uuid = new_uuid.to_string();
+        proto.uuid = new_uuid.as_bytes().to_vec().into();
         proto.encoding = proto::transaction::Encoding::Full.into();
         store_transaction_proto(&iox_object_store, &path, &proto)
             .await
@@ -2075,7 +2078,7 @@ mod tests {
                 .unwrap();
         let mut t = catalog.open_transaction().await;
 
-        t.transaction.as_mut().unwrap().proto.uuid = Uuid::nil().to_string();
+        t.transaction.as_mut().unwrap().proto.uuid = Uuid::nil().as_bytes().to_vec().into();
         assert_eq!(t.uuid(), Uuid::nil());
     }
 

--- a/parquet_file/src/catalog/dump.rs
+++ b/parquet_file/src/catalog/dump.rs
@@ -272,11 +272,11 @@ File {
     is_checkpoint: false,
     proto: Ok(
         Transaction {
-            version: 16,
+            version: 17,
             actions: [],
             revision_counter: 0,
-            uuid: "00000000-0000-0000-0000-000000000000",
-            previous_uuid: "",
+            uuid: b"\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0",
+            previous_uuid: b"",
             start_timestamp: Some(
                 Timestamp {
                     seconds: 10,
@@ -297,7 +297,7 @@ File {
     is_checkpoint: false,
     proto: Ok(
         Transaction {
-            version: 16,
+            version: 17,
             actions: [
                 Action {
                     action: Some(
@@ -320,8 +320,8 @@ File {
                 },
             ],
             revision_counter: 1,
-            uuid: "00000000-0000-0000-0000-000000000000",
-            previous_uuid: "00000000-0000-0000-0000-000000000000",
+            uuid: b"\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0",
+            previous_uuid: b"\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0",
             start_timestamp: Some(
                 Timestamp {
                     seconds: 10,
@@ -396,11 +396,11 @@ File {
     is_checkpoint: false,
     proto: Ok(
         Transaction {
-            version: 16,
+            version: 17,
             actions: [],
             revision_counter: 0,
-            uuid: "00000000-0000-0000-0000-000000000000",
-            previous_uuid: "",
+            uuid: b"\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0",
+            previous_uuid: b"",
             start_timestamp: Some(
                 Timestamp {
                     seconds: 10,
@@ -421,7 +421,7 @@ File {
     is_checkpoint: false,
     proto: Ok(
         Transaction {
-            version: 16,
+            version: 17,
             actions: [
                 Action {
                     action: Some(
@@ -444,8 +444,8 @@ File {
                 },
             ],
             revision_counter: 1,
-            uuid: "00000000-0000-0000-0000-000000000000",
-            previous_uuid: "00000000-0000-0000-0000-000000000000",
+            uuid: b"\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0",
+            previous_uuid: b"\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0",
             start_timestamp: Some(
                 Timestamp {
                     seconds: 10,

--- a/parquet_file/src/catalog/internals/proto_parse.rs
+++ b/parquet_file/src/catalog/internals/proto_parse.rs
@@ -1,4 +1,4 @@
-use std::{convert::TryInto, num::TryFromIntError, str::FromStr};
+use std::{convert::TryInto, num::TryFromIntError};
 
 use chrono::{DateTime, Utc};
 use generated_types::influxdata::iox::catalog::v1 as proto;
@@ -33,19 +33,19 @@ pub enum Error {
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
-/// Parse UUID from protobuf.
-pub fn parse_uuid(s: &str) -> Result<Option<Uuid>> {
-    if s.is_empty() {
+/// Parse big-endian UUID from protobuf.
+pub fn parse_uuid(bytes: &[u8]) -> Result<Option<Uuid>> {
+    if bytes.is_empty() {
         Ok(None)
     } else {
-        let uuid = Uuid::from_str(s).context(UuidParse {})?;
+        let uuid = Uuid::from_slice(bytes).context(UuidParse {})?;
         Ok(Some(uuid))
     }
 }
 
-/// Parse UUID from protobuf and fail if protobuf did not provide data.
-pub fn parse_uuid_required(s: &str) -> Result<Uuid> {
-    parse_uuid(s)?.context(UuidRequired {})
+/// Parse big-endian UUID from protobuf and fail if protobuf did not provide data.
+pub fn parse_uuid_required(bytes: &[u8]) -> Result<Uuid> {
+    parse_uuid(bytes)?.context(UuidRequired {})
 }
 
 /// Parse [`ParquetFilePath`](iox_object_store::ParquetFilePath) from protobuf.


### PR DESCRIPTION
It's slightly more efficient and I plan to use the same format for UUID-based chunk IDs.