### PR TITLE
refactor: derive Clone for IOx client builder

### DIFF
--- a/client_util/src/connection.rs
+++ b/client_util/src/connection.rs
@@ -68,7 +68,7 @@ pub type Result<T, E = Error> = std::result::Result<T, E>;
 ///     .expect("connection must succeed");
 /// # }
 /// ```
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Builder {
     user_agent: String,
     headers: Vec<(HeaderName, HeaderValue)>,
@@ -169,5 +169,17 @@ impl Builder {
     /// [`connect_timeout`]: Self::connect_timeout
     pub fn timeout(self, timeout: Duration) -> Self {
         Self { timeout, ..self }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_builder_cloneable() {
+        // Clone is used by Conductor.
+        fn assert_clone<T: Clone>(_t: T) {}
+        assert_clone(Builder::default())
     }
 }


### PR DESCRIPTION
Unblocks https://github.com/influxdata/conductor/issues/577

---

* refactor: derive Clone for IOx client builder (53e49156)

      Allows an IOx client builder (with its associated configuration) to be cloned.