### PR TITLE
build: pin smallvec

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,3 +13,5 @@ updates:
       # Additionally the thrift-compiler version available in standard repos tends to lag
       # the latest release significantly, and so updating to the latest version adds friction
       - dependency-name: "thrift"
+      # https://github.com/influxdata/influxdb_iox/issues/2735
+      - dependency-name: "smallvec"

--- a/influxdb_line_protocol/Cargo.toml
+++ b/influxdb_line_protocol/Cargo.toml
@@ -6,7 +6,8 @@ edition = "2018"
 
 [dependencies] # In alphabetical order
 nom = "7"
-smallvec = "1.7.0"
+# See https://github.com/influxdata/influxdb_iox/issues/2735 before bumping smallvec
+smallvec = "1.6.1"
 snafu = "0.6.2"
 observability_deps = { path = "../observability_deps" }
 


### PR DESCRIPTION
Ideally we would eliminate the dependency on the line protocol parser for consumers of the IOx API client as it does not functionally depend upon it (and more!) but it fairly intertwined through `data_types` / `generated_types` - this unblocks Conductor work.

Fixes https://github.com/influxdata/influxdb_iox/issues/2735.

---

* build: pin smallvec (5abc5540)

      Pin the smallvec version until the rest of the ecosystem catches up.

      Fixes https://github.com/influxdata/influxdb_iox/issues/2735.

