### PR TITLE
refactor: make `ChunkId` a UUID

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -805,6 +805,7 @@ dependencies = [
 name = "data_types"
 version = "0.1.0"
 dependencies = [
+ "bytes",
  "chrono",
  "influxdb_line_protocol",
  "num_cpus",
@@ -815,6 +816,7 @@ dependencies = [
  "serde_regex",
  "snafu",
  "test_helpers",
+ "uuid",
 ]
 
 [[package]]
@@ -1721,6 +1723,7 @@ dependencies = [
  "arrow",
  "arrow-flight",
  "arrow_util",
+ "bytes",
  "client_util",
  "futures-util",
  "generated_types",

--- a/data_types/Cargo.toml
+++ b/data_types/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 readme = "README.md"
 
 [dependencies] # In alphabetical order
+bytes = "1.0"
 chrono = { version = "0.4", features = ["serde"] }
 influxdb_line_protocol = { path = "../influxdb_line_protocol" }
 num_cpus = "1.13.0"
@@ -16,6 +17,7 @@ regex = "1.4"
 serde = { version = "1.0", features = ["rc", "derive"] }
 serde_regex = "1.1"
 snafu = "0.6"
+uuid = { version = "0.8", features = ["serde", "v4"] }
 
 [dev-dependencies] # In alphabetical order
 test_helpers = { path = "../test_helpers" }

--- a/data_types/src/chunk_metadata.rs
+++ b/data_types/src/chunk_metadata.rs
@@ -206,14 +206,21 @@ impl ChunkSummary {
 pub struct ChunkId(Uuid);
 
 impl ChunkId {
-    pub fn new_random() -> Self {
+    /// Create new, random ID.
+    #[allow(clippy::new_without_default)] // `new` creates non-deterministic result
+    pub fn new() -> Self {
         Self(Uuid::new_v4())
     }
 
+    /// **TESTING ONLY:** Create new ID from integer.
+    ///
+    /// Since this can easily lead to ID collissions (which in turn can lead to panics), this must only be used for
+    /// testing purposes!
     pub fn new_test(id: u128) -> Self {
         Self(Uuid::from_u128(id))
     }
 
+    /// Get inner UUID.
     pub fn get(&self) -> Uuid {
         self.0
     }

--- a/data_types/src/chunk_metadata.rs
+++ b/data_types/src/chunk_metadata.rs
@@ -1,11 +1,16 @@
 //! Module contains a representation of chunk metadata
-use crate::partition_metadata::PartitionAddr;
+use std::{convert::TryFrom, num::NonZeroU32, sync::Arc};
+
+use bytes::Bytes;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
-use std::{num::NonZeroU32, sync::Arc};
+use snafu::{ResultExt, Snafu};
+use uuid::Uuid;
+
+use crate::partition_metadata::PartitionAddr;
 
 /// Address of the chunk within the catalog
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq, PartialOrd, Ord, Serialize, Deserialize)]
 pub struct ChunkAddr {
     /// Database name
     pub db_name: Arc<str>,
@@ -183,10 +188,9 @@ pub struct DetailedChunkSummary {
 }
 
 impl ChunkSummary {
-    pub fn equal_without_timestamps(&self, other: &Self) -> bool {
+    pub fn equal_without_timestamps_and_ids(&self, other: &Self) -> bool {
         self.partition_key == other.partition_key
             && self.table_name == other.table_name
-            && self.id == other.id
             && self.storage == other.storage
             && self.lifecycle_action == other.lifecycle_action
             && self.memory_bytes == other.memory_bytes
@@ -199,31 +203,51 @@ impl ChunkSummary {
 ///
 /// This ID is unique within a single partition.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
-pub struct ChunkId(u32);
+pub struct ChunkId(Uuid);
 
 impl ChunkId {
-    pub const MAX: Self = Self(u32::MAX);
-
-    pub fn new(id: u32) -> Self {
-        Self(id)
+    pub fn new_random() -> Self {
+        Self(Uuid::new_v4())
     }
 
-    pub fn get(&self) -> u32 {
+    pub fn new_test(id: u128) -> Self {
+        Self(Uuid::from_u128(id))
+    }
+
+    pub fn get(&self) -> Uuid {
         self.0
-    }
-
-    /// Get next chunk ID.
-    ///
-    /// # Panic
-    /// Panics if `self` is already [max](Self::MAX).
-    pub fn next(&self) -> Self {
-        Self(self.0.checked_add(1).expect("chunk ID overflow"))
     }
 }
 
 impl std::fmt::Display for ChunkId {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_tuple("ChunkId").field(&self.0).finish()
+    }
+}
+
+impl From<ChunkId> for Bytes {
+    fn from(id: ChunkId) -> Self {
+        id.get().as_bytes().to_vec().into()
+    }
+}
+
+#[derive(Debug, Snafu)]
+pub enum BytesToChunkIdError {
+    #[snafu(display("Cannot convert bytes to chunk ID: {}", source))]
+    CannotConvertBytes { source: uuid::Error },
+}
+
+impl TryFrom<Bytes> for ChunkId {
+    type Error = BytesToChunkIdError;
+
+    fn try_from(value: Bytes) -> Result<Self, Self::Error> {
+        Ok(Self(Uuid::from_slice(&value).context(CannotConvertBytes)?))
+    }
+}
+
+impl From<Uuid> for ChunkId {
+    fn from(uuid: Uuid) -> Self {
+        Self(uuid)
     }
 }
 

--- a/generated_types/build.rs
+++ b/generated_types/build.rs
@@ -67,8 +67,17 @@ fn generate_grpc_types(root: &Path) -> Result<()> {
         .extern_path(".google.protobuf", "::pbjson_types")
         .bytes(&[
             ".influxdata.iox.catalog.v1.AddParquet.metadata",
+            ".influxdata.iox.catalog.v1.ChunkAddr.chunk_id",
+            ".influxdata.iox.catalog.v1.IoxMetadata.chunk_id",
             ".influxdata.iox.catalog.v1.Transaction.previous_uuid",
             ".influxdata.iox.catalog.v1.Transaction.uuid",
+            ".influxdata.iox.management.v1.Chunk.id",
+            ".influxdata.iox.management.v1.ClosePartitionChunkRequest.chunk_id",
+            ".influxdata.iox.management.v1.CompactChunks.chunks",
+            ".influxdata.iox.management.v1.DropChunk.chunk_id",
+            ".influxdata.iox.management.v1.PersistChunks.chunks",
+            ".influxdata.iox.management.v1.WriteChunk.chunk_id",
+            ".influxdata.iox.management.v1.UnloadPartitionChunkRequest.chunk_id",
         ])
         .btree_map(&[
             ".influxdata.iox.catalog.v1.DatabaseCheckpoint.sequencer_numbers",

--- a/generated_types/protos/influxdata/iox/catalog/v1/catalog.proto
+++ b/generated_types/protos/influxdata/iox/catalog/v1/catalog.proto
@@ -56,8 +56,13 @@ message ChunkAddr {
   // Partition key.
   string partition_key = 2;
 
+  // Was uint32-based chunk ID.
+  reserved 3;
+
   // Chunk ID.
-  uint32 chunk_id = 3;
+  //
+  // UUID is stored as 16 bytes in big-endian order.
+  bytes chunk_id = 4;
 }
 
 // Register new delete predicate

--- a/generated_types/protos/influxdata/iox/catalog/v1/parquet_metadata.proto
+++ b/generated_types/protos/influxdata/iox/catalog/v1/parquet_metadata.proto
@@ -17,8 +17,13 @@ message IoxMetadata {
   // Partition key of the partition that holds this parquet file.
   string partition_key = 4;
 
+  // Was uint32-based chunk ID.
+  reserved 5;
+
   // Chunk ID.
-  uint32 chunk_id = 5;
+  //
+  // UUID is stored as 16 bytes in big-endian order.
+  bytes chunk_id = 11;
 
   // Partition checkpoint with pre-split data for the in this file.
   PartitionCheckpoint partition_checkpoint = 6;

--- a/generated_types/protos/influxdata/iox/management/v1/chunk.proto
+++ b/generated_types/protos/influxdata/iox/management/v1/chunk.proto
@@ -54,8 +54,13 @@ message Chunk {
   // The table of this chunk
   string table_name = 8;
 
-  // The id of this chunk
-  uint32 id = 2;
+  // was uint32-based ID
+  reserved 2;
+
+  // The id of this chunk.
+  //
+  // UUID is stored as 16 bytes in big-endian order.
+  bytes id = 14;
 
   // Which storage system the chunk is located in
   ChunkStorage storage = 3;

--- a/generated_types/protos/influxdata/iox/management/v1/jobs.proto
+++ b/generated_types/protos/influxdata/iox/management/v1/jobs.proto
@@ -62,8 +62,13 @@ message WriteChunk {
   // table name
   string table_name = 4;
 
+  // was uint32-based chunk ID
+  reserved 3;
+
   // chunk_id
-  uint32 chunk_id = 3;
+  //
+  // UUID is stored as 16 bytes in big-endian order.
+  bytes chunk_id = 5;
 }
 
 // Compact chunks into a single chunk
@@ -77,8 +82,13 @@ message CompactChunks {
   // table name
   string table_name = 4;
 
+  // was uint32-based chunk IDs
+  reserved 3;
+
   // chunk_id
-  repeated uint32 chunks = 3;
+  //
+  // UUID is stored as 16 bytes in big-endian order.
+  repeated bytes chunks = 5;
 }
 
 // Split and write chunks to object store
@@ -92,8 +102,13 @@ message PersistChunks {
   // table name
   string table_name = 4;
 
+  // was uint32-based chunk IDs
+  reserved 3;
+
   // chunk_id
-  repeated uint32 chunks = 3;
+  //
+  // UUID is stored as 16 bytes in big-endian order.
+  repeated bytes chunks = 5;
 }
 
 // Drop chunk from memory and (if persisted) from object store.
@@ -107,8 +122,13 @@ message DropChunk {
   // table name
   string table_name = 4;
 
+  // was uint32-based chunk ID
+  reserved 3;
+
   // chunk_id
-  uint32 chunk_id = 3;
+  //
+  // UUID is stored as 16 bytes in big-endian order.
+  bytes chunk_id = 5;
 }
 
 // Drop partition from memory and (if persisted) from object store.

--- a/generated_types/protos/influxdata/iox/management/v1/service.proto
+++ b/generated_types/protos/influxdata/iox/management/v1/service.proto
@@ -328,8 +328,13 @@ message ClosePartitionChunkRequest {
   // the table name
   string table_name = 4;
 
+  // Was uint32-based chunk ID.
+  reserved 3;
+
   // the chunk id
-  uint32 chunk_id = 3;
+  //
+  // UUID is stored as 16 bytes in big-endian order.
+  bytes chunk_id = 5;
 }
 
 message ClosePartitionChunkResponse {
@@ -348,8 +353,13 @@ message UnloadPartitionChunkRequest {
   // the table name
   string table_name = 4;
 
+  // Was uint32-based chunk ID.
+  reserved 3;
+
   // the chunk id
-  uint32 chunk_id = 3;
+  //
+  // UUID is stored as 16 bytes in big-endian order.
+  bytes chunk_id = 5;
 }
 
 message UnloadPartitionChunkResponse {

--- a/generated_types/src/job.rs
+++ b/generated_types/src/job.rs
@@ -12,7 +12,7 @@ impl From<Job> for management::operation_metadata::Job {
                 db_name: chunk.db_name.to_string(),
                 partition_key: chunk.partition_key.to_string(),
                 table_name: chunk.table_name.to_string(),
-                chunk_id: chunk.chunk_id.get(),
+                chunk_id: chunk.chunk_id.into(),
             }),
             Job::WipePreservedCatalog { db_name } => {
                 Self::WipePreservedCatalog(management::WipePreservedCatalog {
@@ -24,7 +24,7 @@ impl From<Job> for management::operation_metadata::Job {
                     db_name: partition.db_name.to_string(),
                     partition_key: partition.partition_key.to_string(),
                     table_name: partition.table_name.to_string(),
-                    chunks: chunks.into_iter().map(|chunk_id| chunk_id.get()).collect(),
+                    chunks: chunks.into_iter().map(|chunk_id| chunk_id.into()).collect(),
                 })
             }
             Job::PersistChunks { partition, chunks } => {
@@ -32,14 +32,14 @@ impl From<Job> for management::operation_metadata::Job {
                     db_name: partition.db_name.to_string(),
                     partition_key: partition.partition_key.to_string(),
                     table_name: partition.table_name.to_string(),
-                    chunks: chunks.into_iter().map(|chunk_id| chunk_id.get()).collect(),
+                    chunks: chunks.into_iter().map(|chunk_id| chunk_id.into()).collect(),
                 })
             }
             Job::DropChunk { chunk } => Self::DropChunk(management::DropChunk {
                 db_name: chunk.db_name.to_string(),
                 partition_key: chunk.partition_key.to_string(),
                 table_name: chunk.table_name.to_string(),
-                chunk_id: chunk.chunk_id.get(),
+                chunk_id: chunk.chunk_id.into(),
             }),
             Job::DropPartition { partition } => Self::DropPartition(management::DropPartition {
                 db_name: partition.db_name.to_string(),

--- a/influxdb_iox_client/Cargo.toml
+++ b/influxdb_iox_client/Cargo.toml
@@ -17,6 +17,7 @@ generated_types = { path = "../generated_types" }
 # Crates.io dependencies, in alphabetical order
 arrow = { version = "5.5", optional = true }
 arrow-flight = { version = "5.5", optional = true }
+bytes = "1.0"
 futures-util = { version = "0.3.1", optional = true }
 prost = "0.8"
 rand = "0.8.3"

--- a/influxdb_iox_client/src/client/management.rs
+++ b/influxdb_iox_client/src/client/management.rs
@@ -1,3 +1,4 @@
+use bytes::Bytes;
 use thiserror::Error;
 
 use self::generated_types::{management_service_client::ManagementServiceClient, *};
@@ -892,7 +893,7 @@ impl Client {
         db_name: impl Into<String> + Send,
         table_name: impl Into<String> + Send,
         partition_key: impl Into<String> + Send,
-        chunk_id: u32,
+        chunk_id: Bytes,
     ) -> Result<IoxOperation, ClosePartitionChunkError> {
         let db_name = db_name.into();
         let partition_key = partition_key.into();
@@ -926,7 +927,7 @@ impl Client {
         db_name: impl Into<String> + Send,
         table_name: impl Into<String> + Send,
         partition_key: impl Into<String> + Send,
-        chunk_id: u32,
+        chunk_id: Bytes,
     ) -> Result<(), UnloadPartitionChunkError> {
         let db_name = db_name.into();
         let partition_key = partition_key.into();

--- a/iox_object_store/src/lib.rs
+++ b/iox_object_store/src/lib.rs
@@ -710,7 +710,7 @@ mod tests {
             db_name: "clouds".into(),
             table_name: "my_table".into(),
             partition_key: "my_partition".into(),
-            chunk_id: ChunkId::new(13),
+            chunk_id: ChunkId::new_test(13),
         };
         let p1 = ParquetFilePath::new(&chunk_addr);
         add_parquet_file(&iox_object_store, &p1).await;

--- a/parquet_file/src/catalog/dump.rs
+++ b/parquet_file/src/catalog/dump.rs
@@ -272,7 +272,7 @@ File {
     is_checkpoint: false,
     proto: Ok(
         Transaction {
-            version: 17,
+            version: 18,
             actions: [],
             revision_counter: 0,
             uuid: b"\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0",
@@ -297,7 +297,7 @@ File {
     is_checkpoint: false,
     proto: Ok(
         Transaction {
-            version: 17,
+            version: 18,
             actions: [
                 Action {
                     action: Some(
@@ -309,11 +309,11 @@ File {
                                             "table1",
                                             "part1",
                                         ],
-                                        file_name: "0.00000000-0000-0000-0000-000000000000.parquet",
+                                        file_name: "00000000-0000-0000-0000-000000000000.parquet",
                                     },
                                 ),
                                 file_size_bytes: 33,
-                                metadata: b"metadata omitted (933 bytes)",
+                                metadata: b"metadata omitted (937 bytes)",
                             },
                         ),
                     ),
@@ -396,7 +396,7 @@ File {
     is_checkpoint: false,
     proto: Ok(
         Transaction {
-            version: 17,
+            version: 18,
             actions: [],
             revision_counter: 0,
             uuid: b"\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0",
@@ -421,7 +421,7 @@ File {
     is_checkpoint: false,
     proto: Ok(
         Transaction {
-            version: 17,
+            version: 18,
             actions: [
                 Action {
                     action: Some(
@@ -433,11 +433,11 @@ File {
                                             "table1",
                                             "part1",
                                         ],
-                                        file_name: "0.00000000-0000-0000-0000-000000000000.parquet",
+                                        file_name: "00000000-0000-0000-0000-000000000000.parquet",
                                     },
                                 ),
                                 file_size_bytes: 33,
-                                metadata: b"metadata omitted (933 bytes)",
+                                metadata: b"metadata omitted (937 bytes)",
                             },
                         ),
                     ),
@@ -467,7 +467,7 @@ File {
                             table_name: "table1",
                             partition_key: "part1",
                             chunk_id: ChunkId(
-                                0,
+                                00000000-0000-0000-0000-000000000000,
                             ),
                             partition_checkpoint: PartitionCheckpoint {
                                 table_name: "table1",

--- a/parquet_file/src/catalog/rebuild.rs
+++ b/parquet_file/src/catalog/rebuild.rs
@@ -197,11 +197,11 @@ mod tests {
         {
             let mut transaction = catalog.open_transaction().await;
 
-            let info = create_parquet_file(&iox_object_store, ChunkId::new(0)).await;
+            let info = create_parquet_file(&iox_object_store, ChunkId::new_test(0)).await;
             state.insert(info.clone()).unwrap();
             transaction.add_parquet(&info);
 
-            let info = create_parquet_file(&iox_object_store, ChunkId::new(1)).await;
+            let info = create_parquet_file(&iox_object_store, ChunkId::new_test(1)).await;
             state.insert(info.clone()).unwrap();
             transaction.add_parquet(&info);
 
@@ -215,7 +215,7 @@ mod tests {
         {
             let mut transaction = catalog.open_transaction().await;
 
-            let info = create_parquet_file(&iox_object_store, ChunkId::new(2)).await;
+            let info = create_parquet_file(&iox_object_store, ChunkId::new_test(2)).await;
             state.insert(info.clone()).unwrap();
             transaction.add_parquet(&info);
 
@@ -283,7 +283,7 @@ mod tests {
                 .unwrap();
 
         // file w/o metadata
-        create_parquet_file_without_metadata(&iox_object_store, ChunkId::new(0)).await;
+        create_parquet_file_without_metadata(&iox_object_store, ChunkId::new_test(0)).await;
 
         // wipe catalog
         drop(catalog);

--- a/parquet_file/src/metadata.rs
+++ b/parquet_file/src/metadata.rs
@@ -121,7 +121,7 @@ use thrift::protocol::{TCompactInputProtocol, TCompactOutputProtocol, TOutputPro
 ///
 /// **Important: When changing this structure, consider bumping the
 ///   [catalog transaction version](crate::catalog::core::TRANSACTION_VERSION)!**
-pub const METADATA_VERSION: u32 = 8;
+pub const METADATA_VERSION: u32 = 9;
 
 /// File-level metadata key to store the IOx-specific data.
 ///
@@ -237,6 +237,11 @@ pub enum Error {
 
     #[snafu(display("Cannot decode ZSTD message for parquet metadata: {}", source))]
     ZstdDecodeFailure { source: std::io::Error },
+
+    #[snafu(display("Cannot decode chunk id: {}", source))]
+    CannotDecodeChunkId {
+        source: data_types::chunk_metadata::BytesToChunkIdError,
+    },
 }
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
@@ -372,7 +377,7 @@ impl IoxMetadata {
             time_of_last_write,
             table_name,
             partition_key,
-            chunk_id: ChunkId::new(proto_msg.chunk_id),
+            chunk_id: proto_msg.chunk_id.try_into().context(CannotDecodeChunkId)?,
             partition_checkpoint,
             database_checkpoint,
             chunk_order: ChunkOrder::new(proto_msg.chunk_order).ok_or_else(|| {
@@ -431,7 +436,7 @@ impl IoxMetadata {
             time_of_last_write: Some(self.time_of_last_write.into()),
             table_name: self.table_name.to_string(),
             partition_key: self.partition_key.to_string(),
-            chunk_id: self.chunk_id.get(),
+            chunk_id: self.chunk_id.into(),
             partition_checkpoint: Some(proto_partition_checkpoint),
             database_checkpoint: Some(proto_database_checkpoint),
             chunk_order: self.chunk_order.get(),
@@ -1073,7 +1078,7 @@ mod tests {
             creation_timestamp: Utc::now(),
             table_name,
             partition_key,
-            chunk_id: ChunkId::new(1337),
+            chunk_id: ChunkId::new_test(1337),
             partition_checkpoint,
             database_checkpoint,
             time_of_first_write: Utc::now(),
@@ -1116,6 +1121,6 @@ mod tests {
             .await
             .unwrap();
         let parquet_metadata = IoxParquetMetaData::from_file_bytes(parquet_data).unwrap();
-        assert_eq!(parquet_metadata.size(), 3716);
+        assert_eq!(parquet_metadata.size(), 3730);
     }
 }

--- a/parquet_file/src/storage.rs
+++ b/parquet_file/src/storage.rs
@@ -29,7 +29,6 @@ use std::{
     io::{Cursor, Seek, SeekFrom, Write},
     sync::Arc,
 };
-use uuid::Uuid;
 
 use crate::metadata::{IoxMetadata, IoxParquetMetaData, METADATA_KEY};
 
@@ -127,23 +126,11 @@ pub type Result<T, E = Error> = std::result::Result<T, E>;
 #[derive(Debug, Clone)]
 pub struct Storage {
     iox_object_store: Arc<IoxObjectStore>,
-    fixed_uuid: Option<Uuid>,
 }
 
 impl Storage {
     pub fn new(iox_object_store: Arc<IoxObjectStore>) -> Self {
-        Self {
-            iox_object_store,
-            fixed_uuid: None,
-        }
-    }
-
-    /// Create new instance for testing w/ a fixed UUID.
-    pub fn new_for_testing(iox_object_store: Arc<IoxObjectStore>, uuid: Uuid) -> Self {
-        Self {
-            iox_object_store,
-            fixed_uuid: Some(uuid),
-        }
+        Self { iox_object_store }
     }
 
     /// Write the given stream of data of a specified table of
@@ -158,10 +145,7 @@ impl Storage {
         metadata: IoxMetadata,
     ) -> Result<(ParquetFilePath, usize, IoxParquetMetaData)> {
         // Create full path location of this file in object store
-        let path = match self.fixed_uuid {
-            Some(uuid) => ParquetFilePath::new_for_testing(&chunk_addr, uuid),
-            None => ParquetFilePath::new(&chunk_addr),
-        };
+        let path = ParquetFilePath::new(&chunk_addr);
 
         let schema = stream.schema();
         let data = Self::parquet_stream_to_bytes(stream, schema, metadata).await?;
@@ -445,7 +429,7 @@ mod tests {
             creation_timestamp: Utc::now(),
             table_name,
             partition_key,
-            chunk_id: ChunkId::new(1337),
+            chunk_id: ChunkId::new_test(1337),
             partition_checkpoint,
             database_checkpoint,
             time_of_first_write: Utc::now(),
@@ -502,7 +486,7 @@ mod tests {
         // create Storage
         let table_name = Arc::from("my_table");
         let partition_key = Arc::from("my_partition");
-        let chunk_id = ChunkId::new(33);
+        let chunk_id = ChunkId::new_test(33);
         let iox_object_store = make_iox_object_store().await;
         let storage = Storage::new(Arc::clone(&iox_object_store));
 
@@ -595,7 +579,6 @@ mod tests {
             schema.clone(),
             addr,
             column_summaries.clone(),
-            TestSize::Full,
         )
         .await;
 

--- a/query/src/frontend/influxrpc.rs
+++ b/query/src/frontend/influxrpc.rs
@@ -209,9 +209,9 @@ impl InfluxRpcPlanner {
                     // TODO: General purpose plans for
                     // table_names. For now, return an error
                     debug!(
-                        chunk = chunk.id().get(),
+                        chunk=%chunk.id().get(),
                         ?predicate,
-                        table_name = chunk.table_name(),
+                        table_name=%chunk.table_name(),
                         "can not evaluate predicate"
                     );
                     return UnsupportedPredicateForTableNames { predicate }.fail();
@@ -281,7 +281,7 @@ impl InfluxRpcPlanner {
                     debug!(
                         table_name,
                         names=?names,
-                        chunk_id=chunk.id().get(),
+                        chunk_id=%chunk.id().get(),
                         "column names found from metadata",
                     );
                     known_columns.append(&mut names);
@@ -289,7 +289,7 @@ impl InfluxRpcPlanner {
                 None => {
                     debug!(
                         table_name,
-                        chunk_id = chunk.id().get(),
+                        chunk_id=%chunk.id().get(),
                         "column names need full plan"
                     );
                     // can't get columns only from metadata, need
@@ -414,7 +414,7 @@ impl InfluxRpcPlanner {
                     debug!(
                         table_name,
                         names=?names,
-                        chunk_id=chunk.id().get(),
+                        chunk_id=%chunk.id().get(),
                         "column values found from metadata",
                     );
                     known_values.append(&mut names);
@@ -422,7 +422,7 @@ impl InfluxRpcPlanner {
                 None => {
                     debug!(
                         table_name,
-                        chunk_id = chunk.id().get(),
+                        chunk_id=%chunk.id().get(),
                         "need full plan to find column values"
                     );
                     // can't get columns only from metadata, need

--- a/query/src/provider.rs
+++ b/query/src/provider.rs
@@ -1058,10 +1058,16 @@ mod test {
 
         assert_eq!(
             chunk_group_ids(&deduplicator.overlapped_chunks_set),
-            vec!["Group 0: 2, 3"]
+            vec!["Group 0: 00000000-0000-0000-0000-000000000002, 00000000-0000-0000-0000-000000000003"]
         );
-        assert_eq!(chunk_ids(&deduplicator.in_chunk_duplicates_chunks), "4");
-        assert_eq!(chunk_ids(&deduplicator.no_duplicates_chunks), "1");
+        assert_eq!(
+            chunk_ids(&deduplicator.in_chunk_duplicates_chunks),
+            "00000000-0000-0000-0000-000000000004"
+        );
+        assert_eq!(
+            chunk_ids(&deduplicator.no_duplicates_chunks),
+            "00000000-0000-0000-0000-000000000001"
+        );
     }
 
     #[tokio::test]

--- a/query/src/test.rs
+++ b/query/src/test.rs
@@ -247,7 +247,7 @@ impl TestChunk {
             table_name: table_name.clone(),
             schema: Arc::new(SchemaBuilder::new().build().unwrap()),
             table_summary: TableSummary::new(table_name),
-            id: ChunkId::new(0),
+            id: ChunkId::new_test(0),
             may_contain_pk_duplicates: Default::default(),
             predicates: Default::default(),
             table_data: Default::default(),
@@ -258,8 +258,8 @@ impl TestChunk {
         }
     }
 
-    pub fn with_id(mut self, id: u32) -> Self {
-        self.id = ChunkId::new(id);
+    pub fn with_id(mut self, id: u128) -> Self {
+        self.id = ChunkId::new_test(id);
         self
     }
 

--- a/query_tests/src/scenarios/delete.rs
+++ b/query_tests/src/scenarios/delete.rs
@@ -1,12 +1,11 @@
 //! This module contains testing scenarios for Delete
 
-use data_types::chunk_metadata::ChunkId;
 use data_types::timestamp::TimestampRange;
 use predicate::delete_expr::DeleteExpr;
 use predicate::delete_predicate::DeletePredicate;
 
 use async_trait::async_trait;
-use query::QueryChunk;
+use query::{QueryChunk, QueryDatabase};
 use std::fmt::Display;
 use std::sync::Arc;
 
@@ -560,7 +559,7 @@ async fn make_chunk_with_deletes_at_different_stages(
     // Make an open MUB
     write_lp(&db, &lp_lines.join("\n")).await;
     // 0 does not represent the real chunk id. It is here just to initialize the chunk_id  variable for later assignment
-    let mut chunk_id = ChunkId::new(0);
+    let mut chunk_id = db.chunk_summaries().unwrap()[0].id;
     // Apply delete predicate
     let mut deleted = false;
     let mut display = "".to_string();
@@ -738,7 +737,7 @@ async fn make_different_stage_chunks_with_deletes_scenario(
         // Make an open MUB
         write_lp(&db, &chunk_data.lp_lines.join("\n")).await;
         // 0 does not represent the real chunk id. It is here just to initialize the chunk_id  variable for later assignment
-        let mut chunk_id = ChunkId::new(0);
+        let mut chunk_id = db.chunk_summaries().unwrap()[0].id;
 
         // ----------
         // freeze MUB

--- a/query_tests/src/sql.rs
+++ b/query_tests/src/sql.rs
@@ -328,16 +328,16 @@ async fn sql_select_from_system_chunks() {
     //  test timestamps, etc)
 
     let expected = vec![
-        "+----+---------------+------------+-------------------+--------------+-----------+",
-        "| id | partition_key | table_name | storage           | memory_bytes | row_count |",
-        "+----+---------------+------------+-------------------+--------------+-----------+",
-        "| 0  | 1970-01-01T00 | h2o        | OpenMutableBuffer | 1639         | 3         |",
-        "| 0  | 1970-01-01T00 | o2         | OpenMutableBuffer | 1635         | 2         |",
-        "+----+---------------+------------+-------------------+--------------+-----------+",
+        "+---------------+------------+-------------------+--------------+-----------+",
+        "| partition_key | table_name | storage           | memory_bytes | row_count |",
+        "+---------------+------------+-------------------+--------------+-----------+",
+        "| 1970-01-01T00 | h2o        | OpenMutableBuffer | 1639         | 3         |",
+        "| 1970-01-01T00 | o2         | OpenMutableBuffer | 1635         | 2         |",
+        "+---------------+------------+-------------------+--------------+-----------+",
     ];
     run_sql_test_case(
         TwoMeasurementsManyFieldsOneChunk {},
-        "SELECT id, partition_key, table_name, storage, memory_bytes, row_count from system.chunks",
+        "SELECT partition_key, table_name, storage, memory_bytes, row_count from system.chunks",
         &expected,
     )
     .await;

--- a/server/src/db.rs
+++ b/server/src/db.rs
@@ -307,6 +307,9 @@ pub struct Db {
 
     /// To-be-written delete predicates.
     delete_predicates_mailbox: Mutex<Vec<(Arc<DeletePredicate>, Vec<ChunkAddrWithoutDatabase>)>>,
+
+    /// TESTING ONLY: Override of IDs for persisted chunks.
+    persisted_chunk_id_override: Mutex<Option<ChunkId>>,
 }
 
 /// All the information needed to commit a database
@@ -361,6 +364,7 @@ impl Db {
             lifecycle_policy: tokio::sync::Mutex::new(None),
             now_override: Default::default(),
             delete_predicates_mailbox: Default::default(),
+            persisted_chunk_id_override: Default::default(),
         };
         let this = Arc::new(this);
         *this.lifecycle_policy.try_lock().expect("not used yet") = Some(
@@ -1794,6 +1798,7 @@ mod tests {
 
         let t6_write = t5_write + chrono::Duration::seconds(1);
         *db.now_override.lock() = Some(t6_write);
+        *db.persisted_chunk_id_override.lock() = Some(ChunkId::new_test(1337));
         let chunk_id = db
             .persist_partition("cpu", "1970-01-01T00", true)
             .await
@@ -1802,7 +1807,7 @@ mod tests {
             .id();
 
         // A chunk is now in the object store and still in read buffer
-        let expected_parquet_size = 1245;
+        let expected_parquet_size = 1234;
         catalog_chunk_size_bytes_metric_eq(registry, "read_buffer", expected_read_buffer_size);
         // now also in OS
         catalog_chunk_size_bytes_metric_eq(registry, "object_store", expected_parquet_size);
@@ -1883,7 +1888,6 @@ mod tests {
             .await
             .unwrap()
             .unwrap();
-        assert_eq!(mb_chunk.id(), ChunkId::new(0));
 
         let expected = vec![
             "+-----+--------------------------------+",
@@ -1914,7 +1918,7 @@ mod tests {
             .await
             .unwrap()
             .unwrap();
-        assert_eq!(chunk.id(), ChunkId::new(1));
+        assert_ne!(chunk.id(), mb_chunk.id());
 
         let batches = run_query(db, "select * from cpu").await;
         assert_batches_sorted_eq!(&expected, &batches);
@@ -1936,12 +1940,10 @@ mod tests {
         write_lp(db.as_ref(), &lines.join("\n")).await;
         assert_eq!(vec!["1970-01-01T00"], db.partition_keys().unwrap());
 
-        let mb_chunk = db
-            .rollover_partition("cpu", "1970-01-01T00")
+        db.rollover_partition("cpu", "1970-01-01T00")
             .await
             .unwrap()
             .unwrap();
-        assert_eq!(mb_chunk.id(), ChunkId::new(0));
 
         let expected = vec![
             "+------+--------+--------------------------------+------+",
@@ -2226,6 +2228,7 @@ mod tests {
         // Write the RB chunk to Object Store but keep it in RB
         let t3_persist = t2_write + chrono::Duration::seconds(1);
         *db.now_override.lock() = Some(t3_persist);
+        *db.persisted_chunk_id_override.lock() = Some(ChunkId::new_test(1337));
         let pq_chunk = db
             .persist_partition("cpu", partition_key, true)
             .await
@@ -2237,7 +2240,7 @@ mod tests {
         // Read buffer + Parquet chunk size
         catalog_chunk_size_bytes_metric_eq(registry, "mutable_buffer", 0);
         catalog_chunk_size_bytes_metric_eq(registry, "read_buffer", 1700);
-        catalog_chunk_size_bytes_metric_eq(registry, "object_store", 1243);
+        catalog_chunk_size_bytes_metric_eq(registry, "object_store", 1233);
 
         // All the chunks should have different IDs
         assert_ne!(mb_chunk.id(), rb_chunk.id());
@@ -2324,6 +2327,7 @@ mod tests {
         // Write the RB chunk to Object Store but keep it in RB
         let t3_persist = t2_write + chrono::Duration::seconds(1);
         *db.now_override.lock() = Some(t3_persist);
+        *db.persisted_chunk_id_override.lock() = Some(ChunkId::new_test(1337));
         let pq_chunk = db
             .persist_partition("cpu", partition_key, true)
             .await
@@ -2346,9 +2350,10 @@ mod tests {
         let registry = test_db.metric_registry.as_ref();
 
         // Read buffer + Parquet chunk size
+        let object_store_bytes = 1233;
         catalog_chunk_size_bytes_metric_eq(registry, "mutable_buffer", 0);
         catalog_chunk_size_bytes_metric_eq(registry, "read_buffer", 1700);
-        catalog_chunk_size_bytes_metric_eq(registry, "object_store", 1243);
+        catalog_chunk_size_bytes_metric_eq(registry, "object_store", object_store_bytes);
 
         // Unload RB chunk but keep it in OS
         let pq_chunk = db
@@ -2369,7 +2374,7 @@ mod tests {
         // Parquet chunk size only
         catalog_chunk_size_bytes_metric_eq(registry, "mutable_buffer", 0);
         catalog_chunk_size_bytes_metric_eq(registry, "read_buffer", 0);
-        catalog_chunk_size_bytes_metric_eq(registry, "object_store", 1243);
+        catalog_chunk_size_bytes_metric_eq(registry, "object_store", object_store_bytes);
 
         // Verify data written to the parquet file in object store
         //
@@ -2562,19 +2567,17 @@ mod tests {
         write_lp(&db, "cpu bar=1 10").await;
         write_lp(&db, "cpu bar=1 20").await;
 
-        assert_eq!(mutable_chunk_ids(&db, partition_key), vec![ChunkId::new(0)]);
+        assert_eq!(mutable_chunk_ids(&db, partition_key).len(), 1);
         assert_eq!(
             read_buffer_chunk_ids(&db, partition_key),
             vec![] as Vec<ChunkId>
         );
 
         let partition_key = "1970-01-01T00";
-        let mb_chunk = db
-            .rollover_partition("cpu", "1970-01-01T00")
+        db.rollover_partition("cpu", "1970-01-01T00")
             .await
             .unwrap()
             .unwrap();
-        assert_eq!(mb_chunk.id(), ChunkId::new(0));
 
         // add a new chunk in mutable buffer, and move chunk1 (but
         // not chunk 0) to read buffer
@@ -2605,7 +2608,7 @@ mod tests {
         let expected = vec![ChunkSummary {
             partition_key: Arc::from("1970-01-05T15"),
             table_name: Arc::from("cpu"),
-            id: ChunkId::new(0),
+            id: ChunkId::new_test(0),
             storage: ChunkStorage::OpenMutableBuffer,
             lifecycle_action: None,
             memory_bytes: 1006,    // memory_size
@@ -2629,7 +2632,7 @@ mod tests {
 
         for (expected_summary, actual_summary) in expected.iter().zip(chunk_summaries.iter()) {
             assert!(
-                expected_summary.equal_without_timestamps(actual_summary),
+                expected_summary.equal_without_timestamps_and_ids(actual_summary),
                 "expected:\n{:#?}\n\nactual:{:#?}\n\n",
                 expected_summary,
                 actual_summary
@@ -2656,7 +2659,6 @@ mod tests {
         chunk_summaries.sort_by_key(|s| s.id);
 
         let summary = &chunk_summaries[0];
-        assert_eq!(summary.id, ChunkId::new(0), "summary; {:#?}", summary);
         assert_eq!(summary.time_of_first_write, t_first_write);
         assert_eq!(summary.time_of_last_write, t_second_write);
         assert!(t_close_before <= summary.time_closed.unwrap());
@@ -2774,6 +2776,7 @@ mod tests {
         // Persist rb to parquet os
         let t4_persist = t3_write + chrono::Duration::seconds(1);
         *db.now_override.lock() = Some(t4_persist);
+        *db.persisted_chunk_id_override.lock() = Some(ChunkId::new_test(1337));
         db.persist_partition("cpu", "1970-01-01T00", true)
             .await
             .unwrap()
@@ -2846,8 +2849,8 @@ mod tests {
                 id: chunk_summaries[0].id,
                 storage: ChunkStorage::ReadBufferAndObjectStore,
                 lifecycle_action,
-                memory_bytes: 4085,       // size of RB and OS chunks
-                object_store_bytes: 1537, // size of parquet file
+                memory_bytes: 4079,       // size of RB and OS chunks
+                object_store_bytes: 1557, // size of parquet file
                 row_count: 2,
                 time_of_last_access: None,
                 time_of_first_write: Utc.timestamp_nanos(1),
@@ -2888,7 +2891,7 @@ mod tests {
 
         for (expected_summary, actual_summary) in expected.iter().zip(chunk_summaries.iter()) {
             assert!(
-                expected_summary.equal_without_timestamps(actual_summary),
+                expected_summary.equal_without_timestamps_and_ids(actual_summary),
                 "\n\nexpected item:\n{:#?}\n\nactual item:\n{:#?}\n\n\
                      all expected:\n{:#?}\n\nall actual:\n{:#?}",
                 expected_summary,
@@ -2900,7 +2903,7 @@ mod tests {
 
         assert_eq!(db.catalog.metrics().memory().mutable_buffer(), 2486 + 1303);
         assert_eq!(db.catalog.metrics().memory().read_buffer(), 2550);
-        assert_eq!(db.catalog.metrics().memory().object_store(), 1535);
+        assert_eq!(db.catalog.metrics().memory().object_store(), 1529);
     }
 
     #[tokio::test]
@@ -3434,7 +3437,7 @@ mod tests {
         let path_delete = ParquetFilePath::new(&ChunkAddr {
             table_name: "cpu".into(),
             partition_key: "123".into(),
-            chunk_id: ChunkId::new(3),
+            chunk_id: ChunkId::new_test(3),
             db_name: "not used".into(),
         });
         create_empty_file(&db.iox_object_store, &path_delete).await;

--- a/server/src/db/access.rs
+++ b/server/src/db/access.rs
@@ -198,8 +198,9 @@ impl PruningObserver for ChunkAccess {
 
     fn could_not_prune_chunk(&self, chunk: &Self::Observed, reason: &str) {
         debug!(
-            chunk_id = chunk.id().get(),
-            reason, "could not prune chunk from query"
+            chunk_id=%chunk.id().get(),
+            reason,
+            "could not prune chunk from query",
         )
     }
 }

--- a/server/src/db/catalog.rs
+++ b/server/src/db/catalog.rs
@@ -421,7 +421,7 @@ mod tests {
 
         assert_eq!(
             chunk_addrs(&catalog),
-            sorted(vec![addr1, addr2, addr3, addr4,]),
+            as_sorted(vec![addr1, addr2, addr3, addr4,]),
         );
     }
 
@@ -504,7 +504,7 @@ mod tests {
         let addr2 = create_open_chunk(&p1);
         assert_eq!(
             chunk_addrs(&catalog),
-            sorted(vec![addr1.clone(), addr2.clone(),]),
+            as_sorted(vec![addr1.clone(), addr2.clone(),]),
         );
 
         {
@@ -515,7 +515,7 @@ mod tests {
 
         // should be ok to "re-create", it gets another chunk_id though
         let addr3 = create_open_chunk(&p1);
-        assert_eq!(chunk_addrs(&catalog), sorted(vec![addr2, addr3,]),);
+        assert_eq!(chunk_addrs(&catalog), as_sorted(vec![addr2, addr3,]),);
     }
 
     #[test]
@@ -548,7 +548,7 @@ mod tests {
         std::iter::once(s.into()).collect()
     }
 
-    fn sorted<T>(mut v: Vec<T>) -> Vec<T>
+    fn as_sorted<T>(mut v: Vec<T>) -> Vec<T>
     where
         T: Ord,
     {

--- a/server/src/db/catalog.rs
+++ b/server/src/db/catalog.rs
@@ -313,12 +313,13 @@ impl Catalog {
 
 #[cfg(test)]
 mod tests {
+    use data_types::chunk_metadata::ChunkAddr;
     use entry::test_helpers::lp_to_entry;
 
     use super::*;
     use chrono::Utc;
 
-    fn create_open_chunk(partition: &Arc<RwLock<Partition>>) {
+    fn create_open_chunk(partition: &Arc<RwLock<Partition>>) -> ChunkAddr {
         let mut partition = partition.write();
         let table = partition.table_name();
         let entry = lp_to_entry(&format!("{} bar=1 10", table));
@@ -333,7 +334,9 @@ mod tests {
         )
         .unwrap();
 
-        partition.create_open_chunk(mb_chunk, time_of_write);
+        let chunk = partition.create_open_chunk(mb_chunk, time_of_write);
+        let chunk = chunk.read();
+        chunk.addr().clone()
     }
 
     #[test]
@@ -378,29 +381,29 @@ mod tests {
         let (p1, _schema) = catalog.get_or_create_partition("t1", "p1");
         let (p2, _schema) = catalog.get_or_create_partition("t2", "p2");
 
-        create_open_chunk(&p1);
-        create_open_chunk(&p1);
-        create_open_chunk(&p2);
+        let addr1 = create_open_chunk(&p1);
+        let addr2 = create_open_chunk(&p1);
+        let addr3 = create_open_chunk(&p2);
 
         let p1 = p1.write();
         let p2 = p2.write();
 
-        let (c1_0, _order) = p1.chunk(ChunkId::new(0)).unwrap();
+        let (c1_0, _order) = p1.chunk(addr1.chunk_id).unwrap();
         assert_eq!(c1_0.read().table_name().as_ref(), "t1");
         assert_eq!(c1_0.read().key(), "p1");
-        assert_eq!(c1_0.read().id(), ChunkId::new(0));
+        assert_eq!(c1_0.read().id(), addr1.chunk_id);
 
-        let (c1_1, _order) = p1.chunk(ChunkId::new(1)).unwrap();
+        let (c1_1, _order) = p1.chunk(addr2.chunk_id).unwrap();
         assert_eq!(c1_1.read().table_name().as_ref(), "t1");
         assert_eq!(c1_1.read().key(), "p1");
-        assert_eq!(c1_1.read().id(), ChunkId::new(1));
+        assert_eq!(c1_1.read().id(), addr2.chunk_id);
 
-        let (c2_0, _order) = p2.chunk(ChunkId::new(0)).unwrap();
+        let (c2_0, _order) = p2.chunk(addr3.chunk_id).unwrap();
         assert_eq!(c2_0.read().table_name().as_ref(), "t2");
         assert_eq!(c2_0.read().key(), "p2");
-        assert_eq!(c2_0.read().id(), ChunkId::new(0));
+        assert_eq!(c2_0.read().id(), addr3.chunk_id);
 
-        assert!(p1.chunk(ChunkId::new(100)).is_none());
+        assert!(p1.chunk(ChunkId::new_test(100)).is_none());
     }
 
     #[test]
@@ -409,26 +412,21 @@ mod tests {
 
         let (p1, _schema) = catalog.get_or_create_partition("table1", "p1");
         let (p2, _schema) = catalog.get_or_create_partition("table2", "p1");
-        create_open_chunk(&p1);
-        create_open_chunk(&p1);
-        create_open_chunk(&p2);
+        let addr1 = create_open_chunk(&p1);
+        let addr2 = create_open_chunk(&p1);
+        let addr3 = create_open_chunk(&p2);
 
         let (p3, _schema) = catalog.get_or_create_partition("table1", "p2");
-        create_open_chunk(&p3);
+        let addr4 = create_open_chunk(&p3);
 
         assert_eq!(
-            chunk_strings(&catalog),
-            vec![
-                "Chunk p1:table1:0",
-                "Chunk p1:table1:1",
-                "Chunk p1:table2:0",
-                "Chunk p2:table1:0"
-            ]
+            chunk_addrs(&catalog),
+            sorted(vec![addr1, addr2, addr3, addr4,]),
         );
     }
 
-    fn chunk_strings(catalog: &Catalog) -> Vec<String> {
-        let mut chunks: Vec<String> = catalog
+    fn chunk_addrs(catalog: &Catalog) -> Vec<ChunkAddr> {
+        let mut chunks: Vec<_> = catalog
             .partitions()
             .into_iter()
             .flat_map(|p| {
@@ -437,14 +435,14 @@ mod tests {
                     .into_iter()
                     .map(|c| {
                         let c = c.read();
-                        format!("Chunk {}:{}:{}", c.key(), c.table_name(), c.id().get())
+                        c.addr().clone()
                     })
                     .collect::<Vec<_>>()
                     .into_iter()
             })
             .collect();
 
-        chunks.sort_unstable();
+        chunks.sort();
         chunks
     }
 
@@ -454,35 +452,35 @@ mod tests {
 
         let (p1, _schema) = catalog.get_or_create_partition("p1", "table1");
         let (p2, _schema) = catalog.get_or_create_partition("p1", "table2");
-        create_open_chunk(&p1);
-        create_open_chunk(&p1);
-        create_open_chunk(&p2);
+        let addr1 = create_open_chunk(&p1);
+        let addr2 = create_open_chunk(&p1);
+        let addr3 = create_open_chunk(&p2);
 
         let (p3, _schema) = catalog.get_or_create_partition("p2", "table1");
-        create_open_chunk(&p3);
+        let _addr4 = create_open_chunk(&p3);
 
-        assert_eq!(chunk_strings(&catalog).len(), 4);
+        assert_eq!(chunk_addrs(&catalog).len(), 4);
 
         {
             let mut p2 = p2.write();
-            p2.drop_chunk(ChunkId::new(0)).unwrap();
-            assert!(p2.chunk(ChunkId::new(0)).is_none()); // chunk is gone
+            p2.drop_chunk(addr3.chunk_id).unwrap();
+            assert!(p2.chunk(addr3.chunk_id).is_none()); // chunk is gone
         }
-        assert_eq!(chunk_strings(&catalog).len(), 3);
+        assert_eq!(chunk_addrs(&catalog).len(), 3);
 
         {
             let mut p1 = p1.write();
-            p1.drop_chunk(ChunkId::new(1)).unwrap();
-            assert!(p1.chunk(ChunkId::new(1)).is_none()); // chunk is gone
+            p1.drop_chunk(addr2.chunk_id).unwrap();
+            assert!(p1.chunk(addr2.chunk_id).is_none()); // chunk is gone
         }
-        assert_eq!(chunk_strings(&catalog).len(), 2);
+        assert_eq!(chunk_addrs(&catalog).len(), 2);
 
         {
             let mut p1 = p1.write();
-            p1.drop_chunk(ChunkId::new(0)).unwrap();
-            assert!(p1.chunk(ChunkId::new(0)).is_none()); // chunk is gone
+            p1.drop_chunk(addr1.chunk_id).unwrap();
+            assert!(p1.chunk(addr1.chunk_id).is_none()); // chunk is gone
         }
-        assert_eq!(chunk_strings(&catalog).len(), 1);
+        assert_eq!(chunk_addrs(&catalog).len(), 1);
     }
 
     #[test]
@@ -492,7 +490,7 @@ mod tests {
         create_open_chunk(&p3);
 
         let mut p3 = p3.write();
-        let err = p3.drop_chunk(ChunkId::new(2)).unwrap_err();
+        let err = p3.drop_chunk(ChunkId::new_test(1337)).unwrap_err();
 
         assert!(matches!(err, partition::Error::ChunkNotFound { .. }))
     }
@@ -502,25 +500,22 @@ mod tests {
         let catalog = Catalog::test();
 
         let (p1, _schema) = catalog.get_or_create_partition("table1", "p1");
-        create_open_chunk(&p1);
-        create_open_chunk(&p1);
+        let addr1 = create_open_chunk(&p1);
+        let addr2 = create_open_chunk(&p1);
         assert_eq!(
-            chunk_strings(&catalog),
-            vec!["Chunk p1:table1:0", "Chunk p1:table1:1"]
+            chunk_addrs(&catalog),
+            sorted(vec![addr1.clone(), addr2.clone(),]),
         );
 
         {
             let mut p1 = p1.write();
-            p1.drop_chunk(ChunkId::new(0)).unwrap();
+            p1.drop_chunk(addr1.chunk_id).unwrap();
         }
-        assert_eq!(chunk_strings(&catalog), vec!["Chunk p1:table1:1"]);
+        assert_eq!(chunk_addrs(&catalog), vec![addr2.clone()]);
 
         // should be ok to "re-create", it gets another chunk_id though
-        create_open_chunk(&p1);
-        assert_eq!(
-            chunk_strings(&catalog),
-            vec!["Chunk p1:table1:1", "Chunk p1:table1:2"]
-        );
+        let addr3 = create_open_chunk(&p1);
+        assert_eq!(chunk_addrs(&catalog), sorted(vec![addr2, addr3,]),);
     }
 
     #[test]
@@ -551,5 +546,13 @@ mod tests {
 
     fn make_set(s: impl Into<String>) -> BTreeSet<String> {
         std::iter::once(s.into()).collect()
+    }
+
+    fn sorted<T>(mut v: Vec<T>) -> Vec<T>
+    where
+        T: Ord,
+    {
+        v.sort();
+        v
     }
 }

--- a/server/src/db/catalog/chunk.rs
+++ b/server/src/db/catalog/chunk.rs
@@ -935,7 +935,7 @@ mod tests {
         let mut chunk = make_persisted_chunk().await;
         assert_eq!(
             chunk.freeze().unwrap_err().to_string(),
-            "Internal Error: unexpected chunk state for Chunk('db':'table1':'part1':0) \
+            "Internal Error: unexpected chunk state for Chunk('db':'table1':'part1':00000000-0000-0000-0000-000000000000) \
             during setting closed. Expected Open or Frozen, got Persisted"
         );
     }
@@ -1005,7 +1005,7 @@ mod tests {
                 .unwrap_err()
                 .to_string(),
             "Internal Error: A lifecycle action \'Compacting\' is already in \
-            progress for Chunk('db':'table1':'part1':0)"
+            progress for Chunk('db':'table1':'part1':00000000-0000-0000-0000-000000000000)"
         );
 
         // finishing the wrong action fails
@@ -1014,7 +1014,7 @@ mod tests {
                 .finish_lifecycle_action(ChunkLifecycleAction::Persisting)
                 .unwrap_err()
                 .to_string(),
-            "Internal Error: Unexpected chunk state for Chunk('db':'table1':'part1':0). Expected \
+            "Internal Error: Unexpected chunk state for Chunk('db':'table1':'part1':00000000-0000-0000-0000-000000000000). Expected \
             Persisting to Object Storage, got Compacting"
         );
 
@@ -1029,7 +1029,7 @@ mod tests {
                 .finish_lifecycle_action(ChunkLifecycleAction::Compacting)
                 .unwrap_err()
                 .to_string(),
-            "Internal Error: Unexpected chunk state for Chunk('db':'table1':'part1':0). Expected \
+            "Internal Error: Unexpected chunk state for Chunk('db':'table1':'part1':00000000-0000-0000-0000-000000000000). Expected \
             Compacting, got None"
         );
 
@@ -1059,7 +1059,7 @@ mod tests {
         // clearing now fails because task is still in progress
         assert_eq!(
             chunk.clear_lifecycle_action().unwrap_err().to_string(),
-            "Internal Error: Cannot clear a lifecycle action 'Compacting' for chunk Chunk('db':'table1':'part1':0) that is still running",
+            "Internal Error: Cannot clear a lifecycle action 'Compacting' for chunk Chunk('db':'table1':'part1':00000000-0000-0000-0000-000000000000) that is still running",
         );
 
         // "finish" task
@@ -1137,7 +1137,7 @@ mod tests {
             db_name: Arc::from("db"),
             table_name: Arc::from("table1"),
             partition_key: Arc::from("part1"),
-            chunk_id: ChunkId::new(0),
+            chunk_id: ChunkId::new_test(0),
         }
     }
 

--- a/server/src/db/catalog/partition.rs
+++ b/server/src/db/catalog/partition.rs
@@ -202,7 +202,7 @@ impl Partition {
     ) -> &Arc<RwLock<CatalogChunk>> {
         assert_eq!(chunk.table_name().as_ref(), self.table_name());
 
-        let chunk_id = ChunkId::new_random();
+        let chunk_id = ChunkId::new();
         let chunk_order = self.next_chunk_order();
 
         let addr = ChunkAddr::new(&self.addr, chunk_id);
@@ -232,7 +232,7 @@ impl Partition {
         chunk_order: ChunkOrder,
         chunk_id: Option<ChunkId>,
     ) -> (ChunkId, &Arc<RwLock<CatalogChunk>>) {
-        let chunk_id = chunk_id.unwrap_or_else(ChunkId::new_random);
+        let chunk_id = chunk_id.unwrap_or_else(ChunkId::new);
         assert!(
             chunk_order < self.next_chunk_order,
             "chunk order for new RUB chunk ({}) is out of range [0, {})",

--- a/server/src/db/lifecycle.rs
+++ b/server/src/db/lifecycle.rs
@@ -228,7 +228,7 @@ impl LockablePartition for LockableCatalogPartition {
         info!(
             table=%partition.table_name(),
             partition=%partition.partition_key(),
-            chunk_id=chunk.addr().chunk_id.get(),
+            chunk_id=%chunk.addr().chunk_id.get(),
             "drop chunk",
         );
         let (tracker, fut) = drop::drop_chunk(partition, chunk)?;

--- a/server/src/db/lifecycle/compact.rs
+++ b/server/src/db/lifecycle/compact.rs
@@ -133,6 +133,7 @@ pub(crate) fn compact_chunks(
             // TODO: Filter out predicates applied by the query (#2666)
             delete_predicates,
             min_order,
+            None,
         );
 
         // input rows per second

--- a/server/src/db/lifecycle/persist.rs
+++ b/server/src/db/lifecycle/persist.rs
@@ -156,6 +156,7 @@ pub fn persist_chunks(
                     // TODO: Filter out predicates applied by the query (#2666)
                     delete_predicates.clone(),
                     min_order,
+                    None,
                 );
             }
 
@@ -178,6 +179,7 @@ pub fn persist_chunks(
                 schema,
                 delete_predicates,
                 min_order,
+                db.persisted_chunk_id_override.lock().as_ref().cloned(),
             );
             let to_persist = LockableCatalogChunk {
                 db,
@@ -359,7 +361,8 @@ mod tests {
             Utc.timestamp_nanos(24)
         );
 
-        let chunks: Vec<_> = partition.read().chunk_summaries().collect();
+        let mut chunks: Vec<_> = partition.read().chunk_summaries().collect();
+        chunks.sort_by_key(|c| c.storage);
         assert_eq!(chunks.len(), 2);
         assert_eq!(chunks[0].storage, ChunkStorage::ReadBuffer);
         assert_eq!(chunks[0].row_count, 1);

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -1697,12 +1697,18 @@ mod tests {
             .await
             .unwrap();
 
+        // get chunk ID
+        let db = server.db(&db_name).unwrap();
+        let chunks = db.chunk_summaries().unwrap();
+        assert_eq!(chunks.len(), 1);
+        let chunk_id = chunks[0].id;
+
         // start the close (note this is not an async)
         let chunk_addr = ChunkAddr {
             db_name: Arc::from(db_name.as_str()),
             table_name: Arc::from("cpu"),
             partition_key: Arc::from(""),
-            chunk_id: ChunkId::new(0),
+            chunk_id,
         };
         let tracker = server
             .close_chunk(

--- a/src/influxdb_ioxd/rpc/management.rs
+++ b/src/influxdb_ioxd/rpc/management.rs
@@ -421,7 +421,7 @@ where
         // Validate that the database name is legit
         let db_name = DatabaseName::new(db_name).field("db_name")?;
 
-        let chunk_id = ChunkId::new(chunk_id);
+        let chunk_id = ChunkId::try_from(chunk_id).field("chunk_id")?;
 
         let tracker = self
             .server
@@ -451,7 +451,7 @@ where
             .db(&db_name)
             .map_err(default_server_error_handler)?;
 
-        let chunk_id = ChunkId::new(chunk_id);
+        let chunk_id = ChunkId::try_from(chunk_id).field("chunk_id")?;
 
         db.unload_read_buffer(&table_name, &partition_key, chunk_id)
             .map_err(default_db_error_handler)?;

--- a/src/influxdb_ioxd/rpc/storage/service.rs
+++ b/src/influxdb_ioxd/rpc/storage/service.rs
@@ -1185,7 +1185,7 @@ mod tests {
             .db_or_create(db_info.db_name())
             .await
             .expect("getting db")
-            .get_chunk("my_partition_key", ChunkId::new(0))
+            .get_chunk("my_partition_key", ChunkId::new_test(0))
             .unwrap()
             .predicates();
 
@@ -1253,7 +1253,7 @@ mod tests {
             .db_or_create(db_info.db_name())
             .await
             .expect("getting db")
-            .get_chunk("my_partition_key", ChunkId::new(0))
+            .get_chunk("my_partition_key", ChunkId::new_test(0))
             .unwrap()
             .predicates();
 
@@ -1366,7 +1366,7 @@ mod tests {
             .db_or_create(db_info.db_name())
             .await
             .expect("getting db")
-            .get_chunk("my_partition_key", ChunkId::new(0))
+            .get_chunk("my_partition_key", ChunkId::new_test(0))
             .unwrap()
             .predicates();
 

--- a/tests/end_to_end_cases/freeze.rs
+++ b/tests/end_to_end_cases/freeze.rs
@@ -41,10 +41,11 @@ async fn test_mub_freeze() {
     assert_eq!(num_lines_written, 10);
 
     // Not exceeded row threshold - shouldn't freeze
-    let chunks = list_chunks(&fixture, &db_name).await;
+    let mut chunks = list_chunks(&fixture, &db_name).await;
+    chunks.sort_by_key(|chunk| chunk.storage);
     assert_eq!(chunks.len(), 2);
-    assert_eq!(chunks[0].storage, ChunkStorage::ClosedMutableBuffer);
-    assert_eq!(chunks[1].storage, ChunkStorage::OpenMutableBuffer);
+    assert_eq!(chunks[0].storage, ChunkStorage::OpenMutableBuffer);
+    assert_eq!(chunks[1].storage, ChunkStorage::ClosedMutableBuffer);
 
     let num_lines_written = write_client
         .write(&db_name, lp_lines.iter().take(10).join("\n"))
@@ -53,7 +54,8 @@ async fn test_mub_freeze() {
     assert_eq!(num_lines_written, 10);
 
     // Exceeded row threshold - should freeze
-    let chunks = list_chunks(&fixture, &db_name).await;
+    let mut chunks = list_chunks(&fixture, &db_name).await;
+    chunks.sort_by_key(|chunk| chunk.storage);
     assert_eq!(chunks.len(), 2);
     assert_eq!(chunks[0].storage, ChunkStorage::ClosedMutableBuffer);
     assert_eq!(chunks[1].storage, ChunkStorage::ClosedMutableBuffer);

--- a/tests/end_to_end_cases/management_api.rs
+++ b/tests/end_to_end_cases/management_api.rs
@@ -1,6 +1,7 @@
 use std::{fs::set_permissions, os::unix::fs::PermissionsExt};
 
 use arrow_util::assert_batches_sorted_eq;
+use data_types::chunk_metadata::ChunkId;
 use generated_types::{
     google::protobuf::{Duration, Empty},
     influxdata::iox::management::v1::{
@@ -13,7 +14,6 @@ use influxdb_iox_client::{
 };
 
 use test_helpers::assert_contains;
-use uuid::Uuid;
 
 use super::scenario::{
     create_readable_database, create_two_partition_database, create_unreadable_database, rand_name,
@@ -526,7 +526,7 @@ async fn test_chunk_get() {
         Chunk {
             partition_key: "cpu".into(),
             table_name: "cpu".into(),
-            id: Uuid::from_u128(0).as_bytes().to_vec().into(),
+            id: ChunkId::new_test(0).into(),
             storage: ChunkStorage::OpenMutableBuffer.into(),
             lifecycle_action,
             memory_bytes: 1016,
@@ -541,7 +541,7 @@ async fn test_chunk_get() {
         Chunk {
             partition_key: "disk".into(),
             table_name: "disk".into(),
-            id: Uuid::from_u128(0).as_bytes().to_vec().into(),
+            id: ChunkId::new_test(0).into(),
             storage: ChunkStorage::OpenMutableBuffer.into(),
             lifecycle_action,
             memory_bytes: 1018,
@@ -713,7 +713,7 @@ async fn test_list_partition_chunks() {
     let expected: Vec<Chunk> = vec![Chunk {
         partition_key: "cpu".into(),
         table_name: "cpu".into(),
-        id: Uuid::from_u128(0).as_bytes().to_vec().into(),
+        id: ChunkId::new_test(0).into(),
         storage: ChunkStorage::OpenMutableBuffer.into(),
         lifecycle_action: ChunkLifecycleAction::Unspecified.into(),
         memory_bytes: 1016,
@@ -926,7 +926,7 @@ async fn test_close_partition_chunk_error() {
             "this database does not exist",
             "nor_does_this_table",
             "nor_does_this_partition",
-            Uuid::from_u128(0).as_bytes().to_vec().into(),
+            ChunkId::new_test(0).into(),
         )
         .await
         .expect_err("expected error");
@@ -1062,7 +1062,7 @@ fn normalize_chunks(chunks: Vec<Chunk>) -> Vec<Chunk> {
             Chunk {
                 partition_key,
                 table_name,
-                id: Uuid::from_u128(0).as_bytes().to_vec().into(),
+                id: ChunkId::new_test(0).into(),
                 storage,
                 lifecycle_action,
                 row_count,

--- a/tests/end_to_end_cases/persistence.rs
+++ b/tests/end_to_end_cases/persistence.rs
@@ -269,7 +269,7 @@ async fn create_readbuffer_chunk(fixture: &ServerFixture, db_name: &str) -> Chun
 
     // Move the chunk to read buffer
     let iox_operation = management_client
-        .close_partition_chunk(db_name, table_name, partition_key, 0)
+        .close_partition_chunk(db_name, table_name, partition_key, chunk_id.into())
         .await
         .expect("new partition chunk");
 


### PR DESCRIPTION
**I originally planned to split this change into two (moving the type to UUIDs, introduce random UUIDs instead of linear counters). However this PR is the FULL change set, because along the way I've also removed the UUIDs from the parquet paths and already fixed most of the tests that assumed linear IDs.**

Reasons:

1. Helps w/ #2633 
2. Future-proof chunks IDs: we likely want to support catalog merges in the future (to re-configure sharding) and then chunks from multiple catalogs must have different IDs. UUIDs are an elegant way to archive that
3. Cleans up a lot of tests that are silently assuming chunk IDs start at 0 (which is an abstraction layer leak)
4. Removes the somewhat hacky UUID from our parquet files, because new chunk IDs can no longer collide w/ existing chunk IDs, hence we're never overwriting existing files
5. Manual catalog merges (copy + paste files from multiple catalogs) should "just work" using the catalog  rebuild, assuming you're not caring too much about the chunk ordering
6. As a small side-effect (that isn't used yet), chunk IDs are globally unique so in theory you could use the ID alone to address a chunk. However we don't have a global lookup table for that, but at least it prevents you from silly CLI typos (like you've meant to drop a chunk for `table1` but ended up dropping a chunk from `table2`).
7. IDs aren't really ordered anyways due to compaction. That's why we've introduced the chunk order a while ago (multiple chunks can have the same order, but as long as they originate from the same DB, they won't overlap in that case). So making assumption about ordering is somewhat fragile.

For low-level tests, `ChunkId::new_test` can be used to construct IDs from integers (this is sometimes helpful to make tests easier to read, see lifecycle tests for example). For high-level tests (e.g. tests that query the DB, use the CLI etc.), you must either work w/o chunk IDs (that's possible for most operations) or you need to retrieve the list of chunks before performing an action.

For IO, we use:

- **protobuf:** `bytes`
- **logging:** UUIDs emitted as strings (e.g. `3e5a1adf-3f17-4f93-8063-6fd6e09b2805`)
- **SQL:** same as logging