### PR TITLE
refactor: "min unpersisted ts" => "max persisted ts"

### DIFF
--- a/generated_types/protos/influxdata/iox/catalog/v1/parquet_metadata.proto
+++ b/generated_types/protos/influxdata/iox/catalog/v1/parquet_metadata.proto
@@ -50,8 +50,11 @@ message PartitionCheckpoint {
   // Maps `sequencer_id` to the to-be-persisted minimum and seen maximum sequence numbers.
   map<uint32, OptionalMinMaxSequence> sequencer_numbers = 1;
 
-  // Minimum unpersisted timestamp.
-  google.protobuf.Timestamp min_unpersisted_timestamp = 2;
+  // Was Minimum unpersisted timestamp.
+  reserved 2;
+
+  // Maximum persisted timestamp.
+  google.protobuf.Timestamp max_persisted_timestamp = 3;
 }
 
 // Record of the playback state for the whole database.

--- a/parquet_file/src/catalog/core.rs
+++ b/parquet_file/src/catalog/core.rs
@@ -39,7 +39,7 @@ pub use crate::catalog::internals::proto_parse::Error as ProtoParseError;
 /// Current version for serialized transactions.
 ///
 /// For breaking changes, this will change.
-pub const TRANSACTION_VERSION: u32 = 18;
+pub const TRANSACTION_VERSION: u32 = 19;
 
 #[derive(Debug, Snafu)]
 pub enum Error {

--- a/parquet_file/src/catalog/dump.rs
+++ b/parquet_file/src/catalog/dump.rs
@@ -272,7 +272,7 @@ File {
     is_checkpoint: false,
     proto: Ok(
         Transaction {
-            version: 18,
+            version: 19,
             actions: [],
             revision_counter: 0,
             uuid: b"\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0",
@@ -297,7 +297,7 @@ File {
     is_checkpoint: false,
     proto: Ok(
         Transaction {
-            version: 18,
+            version: 19,
             actions: [
                 Action {
                     action: Some(
@@ -396,7 +396,7 @@ File {
     is_checkpoint: false,
     proto: Ok(
         Transaction {
-            version: 18,
+            version: 19,
             actions: [],
             revision_counter: 0,
             uuid: b"\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0",
@@ -421,7 +421,7 @@ File {
     is_checkpoint: false,
     proto: Ok(
         Transaction {
-            version: 18,
+            version: 19,
             actions: [
                 Action {
                     action: Some(
@@ -484,7 +484,7 @@ File {
                                         max: 28,
                                     },
                                 },
-                                min_unpersisted_timestamp: 1970-01-01T00:00:10.000000020Z,
+                                max_persisted_timestamp: 1970-01-01T00:00:10.000000020Z,
                             },
                             database_checkpoint: DatabaseCheckpoint {
                                 sequencer_numbers: {

--- a/parquet_file/src/metadata.rs
+++ b/parquet_file/src/metadata.rs
@@ -121,7 +121,7 @@ use thrift::protocol::{TCompactInputProtocol, TCompactOutputProtocol, TOutputPro
 ///
 /// **Important: When changing this structure, consider bumping the
 ///   [catalog transaction version](crate::catalog::core::TRANSACTION_VERSION)!**
-pub const METADATA_VERSION: u32 = 9;
+pub const METADATA_VERSION: u32 = 10;
 
 /// File-level metadata key to store the IOx-specific data.
 ///
@@ -338,15 +338,15 @@ impl IoxMetadata {
                 }
             })
             .collect::<Result<BTreeMap<u32, OptionalMinMaxSequence>>>()?;
-        let min_unpersisted_timestamp = decode_timestamp_from_field(
-            proto_partition_checkpoint.min_unpersisted_timestamp,
-            "partition_checkpoint.min_unpersisted_timestamp",
+        let max_persisted_timestamp = decode_timestamp_from_field(
+            proto_partition_checkpoint.max_persisted_timestamp,
+            "partition_checkpoint.max_persisted_timestamp",
         )?;
         let partition_checkpoint = PartitionCheckpoint::new(
             Arc::clone(&table_name),
             Arc::clone(&partition_key),
             sequencer_numbers,
-            min_unpersisted_timestamp,
+            max_persisted_timestamp,
         );
 
         // extract database checkpoint
@@ -406,8 +406,8 @@ impl IoxMetadata {
                     )
                 })
                 .collect(),
-            min_unpersisted_timestamp: Some(
-                self.partition_checkpoint.min_unpersisted_timestamp().into(),
+            max_persisted_timestamp: Some(
+                self.partition_checkpoint.max_persisted_timestamp().into(),
             ),
         };
 

--- a/parquet_file/src/test_utils.rs
+++ b/parquet_file/src/test_utils.rs
@@ -929,12 +929,12 @@ pub fn create_partition_and_database_checkpoint(
     let mut sequencer_numbers_1 = BTreeMap::new();
     sequencer_numbers_1.insert(1, OptionalMinMaxSequence::new(None, 18));
     sequencer_numbers_1.insert(2, OptionalMinMaxSequence::new(Some(25), 28));
-    let min_unpersisted_timestamp = Utc.timestamp(10, 20);
+    let max_persisted_timestamp = Utc.timestamp(10, 20);
     let partition_checkpoint_1 = PartitionCheckpoint::new(
         Arc::clone(&table_name),
         Arc::clone(&partition_key),
         sequencer_numbers_1,
-        min_unpersisted_timestamp,
+        max_persisted_timestamp,
     );
 
     // create second partition

--- a/server/src/db.rs
+++ b/server/src/db.rs
@@ -1807,7 +1807,7 @@ mod tests {
             .id();
 
         // A chunk is now in the object store and still in read buffer
-        let expected_parquet_size = 1234;
+        let expected_parquet_size = 1233;
         catalog_chunk_size_bytes_metric_eq(registry, "read_buffer", expected_read_buffer_size);
         // now also in OS
         catalog_chunk_size_bytes_metric_eq(registry, "object_store", expected_parquet_size);
@@ -2240,7 +2240,7 @@ mod tests {
         // Read buffer + Parquet chunk size
         catalog_chunk_size_bytes_metric_eq(registry, "mutable_buffer", 0);
         catalog_chunk_size_bytes_metric_eq(registry, "read_buffer", 1700);
-        catalog_chunk_size_bytes_metric_eq(registry, "object_store", 1233);
+        catalog_chunk_size_bytes_metric_eq(registry, "object_store", 1231);
 
         // All the chunks should have different IDs
         assert_ne!(mb_chunk.id(), rb_chunk.id());
@@ -2350,7 +2350,7 @@ mod tests {
         let registry = test_db.metric_registry.as_ref();
 
         // Read buffer + Parquet chunk size
-        let object_store_bytes = 1233;
+        let object_store_bytes = 1231;
         catalog_chunk_size_bytes_metric_eq(registry, "mutable_buffer", 0);
         catalog_chunk_size_bytes_metric_eq(registry, "read_buffer", 1700);
         catalog_chunk_size_bytes_metric_eq(registry, "object_store", object_store_bytes);

--- a/server/src/db/replay.rs
+++ b/server/src/db/replay.rs
@@ -311,17 +311,17 @@ fn filter_entry(
     let table_name = table_batch.name();
 
     // Check if we have a partition checkpoint that contains data for this specific sequencer
-    let min_unpersisted_ts_and_sequence_range = replay_plan
+    let max_persisted_ts_and_sequence_range = replay_plan
         .last_partition_checkpoint(table_name, partition_key)
         .map(|partition_checkpoint| {
             partition_checkpoint
                 .sequencer_numbers(sequence.id)
-                .map(|min_max| (partition_checkpoint.min_unpersisted_timestamp(), min_max))
+                .map(|min_max| (partition_checkpoint.max_persisted_timestamp(), min_max))
         })
         .flatten();
 
-    match min_unpersisted_ts_and_sequence_range {
-        Some((min_unpersisted_ts, min_max)) => {
+    match max_persisted_ts_and_sequence_range {
+        Some((max_persisted_ts, min_max)) => {
             // Figure out what the sequence number tells us about the entire batch
             match SequenceNumberSection::compare(sequence.number, min_max) {
                 SequenceNumberSection::Persisted => {
@@ -331,10 +331,10 @@ fn filter_entry(
                 SequenceNumberSection::PartiallyPersisted => {
                     // TODO: implement row filtering, for now replay the entire batch
                     let maybe_mask = table_batch.timestamps().ok().map(|timestamps| {
-                        let min_unpersisted_ts = min_unpersisted_ts.timestamp_nanos();
+                        let max_persisted_ts = max_persisted_ts.timestamp_nanos();
                         timestamps
                             .into_iter()
-                            .map(|ts_row| ts_row >= min_unpersisted_ts)
+                            .map(|ts_row| ts_row > max_persisted_ts)
                             .collect::<Vec<bool>>()
                     });
                     (true, maybe_mask)


### PR DESCRIPTION
Store the "maximum persisted timestamp" instead of the "minimum
unpersisted timestamp". This avoids the need to calculate the next
timestamp from the current one (which was done via "max TS + 1ns").

The old calculation was prone to overflow panics. Since the
timestamps in this calculation originate from user-provided data (and
not the wall clock), this was an easy DoS vector that could be triggered
via the following line protocol:

```text
table_1 foo=1 <i64::MAX>
```

which is

```text
table_1 foo=1 9223372036854775807
```

Bonus points: the timestamp persisted in the partition
checkpoints is now the very same that was used by the split query during
persistence. Consistence FTW!

Fixes #2225.
