### PR TITLE
feat: improve `Debug`/`Display` for test `ChunkId`s

### DIFF
--- a/parquet_file/src/catalog/dump.rs
+++ b/parquet_file/src/catalog/dump.rs
@@ -467,7 +467,7 @@ File {
                             table_name: "table1",
                             partition_key: "part1",
                             chunk_id: ChunkId(
-                                00000000-0000-0000-0000-000000000000,
+                                0,
                             ),
                             partition_checkpoint: PartitionCheckpoint {
                                 table_name: "table1",


### PR DESCRIPTION
The full UUIDs are a bit annoying for test ChunkIds, esp. since they are hex-based.