### PR TITLE
refactor: cancel executor jobs on drop

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3152,6 +3152,7 @@ dependencies = [
  "libc",
  "observability_deps",
  "parking_lot",
+ "pin-project",
  "predicate",
  "regex",
  "schema",
@@ -3159,6 +3160,7 @@ dependencies = [
  "test_helpers",
  "tokio",
  "tokio-stream",
+ "tokio-util",
  "trace",
 ]
 

--- a/query/Cargo.toml
+++ b/query/Cargo.toml
@@ -26,11 +26,13 @@ futures = "0.3"
 hashbrown = "0.11"
 observability_deps = { path = "../observability_deps" }
 parking_lot = "0.11.2"
+pin-project = "1.0"
 regex = "1"
 schema = { path = "../schema" }
 snafu = "0.6.9"
 tokio = { version = "1.11", features = ["macros"] }
 tokio-stream = "0.1.2"
+tokio-util = { version = "0.6.3" }
 trace = { path = "../trace" }
 predicate = { path = "../predicate" }
 


### PR DESCRIPTION
Our executor is not meant as a fire-and-forget system. Instead the
submitter should always poll the result. Dropping the receiver side (aka
the job handle) should cancel the job.

Note that this is NOT sufficient to fix #2027 since datafusion also has a few places involving `spawn` where dropping the receiver doesn't cancel the spawned task.