### PR TITLE
feat: allow write buffer producers to read sequencer IDs

### DIFF
--- a/write_buffer/src/mock.rs
+++ b/write_buffer/src/mock.rs
@@ -221,6 +221,12 @@ impl MockBufferForWriting {
 
 #[async_trait]
 impl WriteBufferWriting for MockBufferForWriting {
+    fn sequencer_ids(&self) -> Vec<u32> {
+        let mut guard = self.state.entries.lock();
+        let entries = guard.as_mut().unwrap();
+        entries.keys().copied().collect()
+    }
+
     async fn store_entry(
         &self,
         entry: &Entry,
@@ -257,6 +263,10 @@ pub struct MockBufferForWritingThatAlwaysErrors;
 
 #[async_trait]
 impl WriteBufferWriting for MockBufferForWritingThatAlwaysErrors {
+    fn sequencer_ids(&self) -> Vec<u32> {
+        vec![0]
+    }
+
     async fn store_entry(
         &self,
         _entry: &Entry,


### PR DESCRIPTION
Pulled out of #2497. I would like to do a bit of write buffer work (e.g. adding a format header for a potential transition to protobuf-based messages), and would like to merge this change beforehand. No matter how we implement message distribution, this feature here is going to be required anyways (since the producer side needs to detect the number of partitions).