### PR TITLE
feat: Write a server config that lists database names and object storage locations

### DIFF
--- a/generated_types/build.rs
+++ b/generated_types/build.rs
@@ -43,6 +43,7 @@ fn generate_grpc_types(root: &Path) -> Result<()> {
         management_path.join("database_rules.proto"),
         management_path.join("chunk.proto"),
         management_path.join("partition.proto"),
+        management_path.join("server_config.proto"),
         management_path.join("service.proto"),
         management_path.join("shard.proto"),
         management_path.join("jobs.proto"),

--- a/generated_types/protos/influxdata/iox/management/v1/server_config.proto
+++ b/generated_types/protos/influxdata/iox/management/v1/server_config.proto
@@ -4,6 +4,11 @@ option go_package = "github.com/influxdata/iox/management/v1";
 
 // Stores a server's map of the databases it owns. The keys are the database names and the values
 // are the database's location in object storage.
+//
+// Example (current): "foo" => "file:/1/foo" ("[object store root]/[server id]/[database name]")
+// Example (after completing the switch to floating databases):
+//         "foo" => "file:/dbs/3f25185a-0773-4ae8-abda-f9c3786f242b"
+//                  ("[object store root]/dbs/[database uuid]")
 message ServerConfig {
   map<string, string> databases = 1;
 }

--- a/generated_types/protos/influxdata/iox/management/v1/server_config.proto
+++ b/generated_types/protos/influxdata/iox/management/v1/server_config.proto
@@ -1,0 +1,22 @@
+syntax = "proto3";
+package influxdata.iox.management.v1;
+option go_package = "github.com/influxdata/iox/management/v1";
+
+// Stores a server's list of the databases it owns, including the database names and locations
+// in object storage.
+message ServerConfig {
+  repeated Database databases = 1;
+}
+
+message Database {
+  // The unencoded name of the database
+  //
+  // Must be a non-empty string containing no control characters
+  string name = 1;
+
+  // The location of the database's files in object storage relative to the application's
+  // object storage bucket configuration
+  //
+  // Must be a non-empty string
+  string location = 2;
+}

--- a/generated_types/protos/influxdata/iox/management/v1/server_config.proto
+++ b/generated_types/protos/influxdata/iox/management/v1/server_config.proto
@@ -2,21 +2,8 @@ syntax = "proto3";
 package influxdata.iox.management.v1;
 option go_package = "github.com/influxdata/iox/management/v1";
 
-// Stores a server's list of the databases it owns, including the database names and locations
-// in object storage.
+// Stores a server's map of the databases it owns. The keys are the database names and the values
+// are the database's location in object storage.
 message ServerConfig {
-  repeated Database databases = 1;
-}
-
-message Database {
-  // The unencoded name of the database
-  //
-  // Must be a non-empty string containing no control characters
-  string name = 1;
-
-  // The location of the database's files in object storage relative to the application's
-  // object storage bucket configuration
-  //
-  // Must be a non-empty string
-  string location = 2;
+  map<string, string> databases = 1;
 }

--- a/generated_types/src/database_rules.rs
+++ b/generated_types/src/database_rules.rs
@@ -1,7 +1,7 @@
 use crate::{
     google::{FieldViolation, FieldViolationExt, FromFieldOpt},
     influxdata::iox::management::v1 as management,
-    ProstError,
+    DecodeError, EncodeError,
 };
 use data_types::{
     database_rules::{
@@ -125,8 +125,8 @@ impl TryFrom<management::RoutingConfig> for RoutingConfig {
 /// Decode database rules that were encoded using `encode_persisted_database_rules`
 pub fn decode_persisted_database_rules(
     bytes: prost::bytes::Bytes,
-) -> Result<management::PersistedDatabaseRules, ProstError> {
-    Ok(prost::Message::decode(bytes)?)
+) -> Result<management::PersistedDatabaseRules, DecodeError> {
+    prost::Message::decode(bytes)
 }
 
 /// TEMPORARY FOR TRANSITION PURPOSES - if decoding rules file as `PersistedDatabaseRules` (which
@@ -135,16 +135,16 @@ pub fn decode_persisted_database_rules(
 /// `PersistedDatabaseRules`.
 pub fn decode_database_rules(
     bytes: prost::bytes::Bytes,
-) -> Result<management::DatabaseRules, ProstError> {
-    Ok(prost::Message::decode(bytes)?)
+) -> Result<management::DatabaseRules, DecodeError> {
+    prost::Message::decode(bytes)
 }
 
 /// Encode database rules into a serialized format suitable for storage in object store
 pub fn encode_persisted_database_rules(
     rules: &management::PersistedDatabaseRules,
     bytes: &mut prost::bytes::BytesMut,
-) -> Result<(), ProstError> {
-    Ok(prost::Message::encode(rules, bytes)?)
+) -> Result<(), EncodeError> {
+    prost::Message::encode(rules, bytes)
 }
 
 impl From<WriteBufferConnection> for management::WriteBufferConnection {

--- a/generated_types/src/database_rules.rs
+++ b/generated_types/src/database_rules.rs
@@ -1,6 +1,7 @@
 use crate::{
     google::{FieldViolation, FieldViolationExt, FromFieldOpt},
     influxdata::iox::management::v1 as management,
+    ProstError,
 };
 use data_types::{
     database_rules::{
@@ -14,7 +15,6 @@ use std::{
     num::NonZeroU32,
     time::Duration,
 };
-use thiserror::Error;
 
 mod lifecycle;
 mod partition;
@@ -122,18 +122,6 @@ impl TryFrom<management::RoutingConfig> for RoutingConfig {
     }
 }
 
-/// Wrapper around a `prost` error so that
-/// users of this crate do not have a direct dependency
-/// on the prost crate.
-#[derive(Debug, Error)]
-pub enum ProstError {
-    #[error("failed to encode protobuf: {0}")]
-    EncodeError(#[from] prost::EncodeError),
-
-    #[error("failed to decode protobuf: {0}")]
-    DecodeError(#[from] prost::DecodeError),
-}
-
 /// Decode database rules that were encoded using `encode_persisted_database_rules`
 pub fn decode_persisted_database_rules(
     bytes: prost::bytes::Bytes,
@@ -151,8 +139,7 @@ pub fn decode_database_rules(
     Ok(prost::Message::decode(bytes)?)
 }
 
-/// Encode database rules into a serialized format suitable for
-/// storage in objet store
+/// Encode database rules into a serialized format suitable for storage in object store
 pub fn encode_persisted_database_rules(
     rules: &management::PersistedDatabaseRules,
     bytes: &mut prost::bytes::BytesMut,

--- a/generated_types/src/lib.rs
+++ b/generated_types/src/lib.rs
@@ -152,6 +152,8 @@ pub mod database_state;
 pub mod detailed_database;
 #[cfg(feature = "data_types_conversions")]
 pub mod job;
+#[cfg(feature = "data_types_conversions")]
+pub mod server_config;
 
 use thiserror::Error;
 /// Wrapper around a `prost` error so that users of this crate do not have a direct dependency

--- a/generated_types/src/lib.rs
+++ b/generated_types/src/lib.rs
@@ -153,6 +153,18 @@ pub mod detailed_database;
 #[cfg(feature = "data_types_conversions")]
 pub mod job;
 
+use thiserror::Error;
+/// Wrapper around a `prost` error so that users of this crate do not have a direct dependency
+/// on the prost crate.
+#[derive(Debug, Error)]
+pub enum ProstError {
+    #[error("failed to encode protobuf: {0}")]
+    EncodeError(#[from] prost::EncodeError),
+
+    #[error("failed to decode protobuf: {0}")]
+    DecodeError(#[from] prost::DecodeError),
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/generated_types/src/lib.rs
+++ b/generated_types/src/lib.rs
@@ -155,17 +155,7 @@ pub mod job;
 #[cfg(feature = "data_types_conversions")]
 pub mod server_config;
 
-use thiserror::Error;
-/// Wrapper around a `prost` error so that users of this crate do not have a direct dependency
-/// on the prost crate.
-#[derive(Debug, Error)]
-pub enum ProstError {
-    #[error("failed to encode protobuf: {0}")]
-    EncodeError(#[from] prost::EncodeError),
-
-    #[error("failed to decode protobuf: {0}")]
-    DecodeError(#[from] prost::DecodeError),
-}
+pub use prost::{DecodeError, EncodeError};
 
 #[cfg(test)]
 mod tests {

--- a/generated_types/src/server_config.rs
+++ b/generated_types/src/server_config.rs
@@ -1,16 +1,16 @@
-use crate::{influxdata::iox::management::v1 as management, ProstError};
+use crate::{influxdata::iox::management::v1 as management, DecodeError, EncodeError};
 
 /// Decode server config that was encoded using `encode_persisted_server_config`
 pub fn decode_persisted_server_config(
     bytes: prost::bytes::Bytes,
-) -> Result<management::ServerConfig, ProstError> {
-    Ok(prost::Message::decode(bytes)?)
+) -> Result<management::ServerConfig, DecodeError> {
+    prost::Message::decode(bytes)
 }
 
 /// Encode server config into a serialized format suitable for storage in object store
 pub fn encode_persisted_server_config(
     server_config: &management::ServerConfig,
     bytes: &mut prost::bytes::BytesMut,
-) -> Result<(), ProstError> {
-    Ok(prost::Message::encode(server_config, bytes)?)
+) -> Result<(), EncodeError> {
+    prost::Message::encode(server_config, bytes)
 }

--- a/generated_types/src/server_config.rs
+++ b/generated_types/src/server_config.rs
@@ -1,0 +1,16 @@
+use crate::{influxdata::iox::management::v1 as management, ProstError};
+
+/// Decode server config that was encoded using `encode_persisted_server_config`
+pub fn decode_persisted_server_config(
+    bytes: prost::bytes::Bytes,
+) -> Result<management::ServerConfig, ProstError> {
+    Ok(prost::Message::decode(bytes)?)
+}
+
+/// Encode server config into a serialized format suitable for storage in object store
+pub fn encode_persisted_server_config(
+    server_config: &management::ServerConfig,
+    bytes: &mut prost::bytes::BytesMut,
+) -> Result<(), ProstError> {
+    Ok(prost::Message::encode(server_config, bytes)?)
+}

--- a/iox_object_store/src/lib.rs
+++ b/iox_object_store/src/lib.rs
@@ -406,7 +406,8 @@ impl IoxObjectStore {
     }
 
     /// The possibly valid location in object storage for this database. Suitable for serialization
-    /// to use during initial database load, but not parsing, as its format is subject to change!
+    /// to use during initial database load, but not parsing for semantic meaning, as its format is
+    /// subject to change!
     pub fn root_path(&self) -> String {
         self.root_path.inner.to_string()
     }

--- a/iox_object_store/src/paths.rs
+++ b/iox_object_store/src/paths.rs
@@ -13,8 +13,20 @@ use parquet_file::ParquetFilePath;
 pub mod transaction_file;
 use transaction_file::TransactionFilePath;
 
+const SERVER_CONFIG_FILE_NAME: &str = "config.pb";
+
+/// The path to the server file containing the list of databases this server owns.
+// TODO: this is in the process of replacing all_databases_path for the floating databases design
+pub(crate) fn server_config_path(object_store: &ObjectStore, server_id: ServerId) -> Path {
+    let mut path = object_store.new_path();
+    path.push_dir(server_id.to_string());
+    path.set_file_name(SERVER_CONFIG_FILE_NAME);
+    path
+}
+
 /// The path all database root paths should be in. Used for listing all databases and building
 /// database `RootPath`s in the same way. Not its own type because it's only needed ephemerally.
+// TODO: this is in the process of being deprecated in favor of server_config_path
 pub(crate) fn all_databases_path(object_store: &ObjectStore, server_id: ServerId) -> Path {
     let mut path = object_store.new_path();
     path.push_dir(server_id.to_string());

--- a/iox_object_store/src/paths.rs
+++ b/iox_object_store/src/paths.rs
@@ -6,6 +6,7 @@ use object_store::{
     path::{ObjectStorePath, Path},
     ObjectStore, ObjectStoreApi,
 };
+use std::fmt;
 
 pub mod parquet_file;
 use parquet_file::ParquetFilePath;
@@ -33,10 +34,11 @@ pub(crate) fn all_databases_path(object_store: &ObjectStore, server_id: ServerId
     path
 }
 
-/// A database-specific object store path that all `IoxPath`s should be within.
-/// This should not be leaked outside this crate.
+/// A database-specific object store path that all `IoxObjectStore` `Path`s should be within.
+/// This can be serialized to facilitate initial loading of a database from object storage, but
+/// the path should not be parsed into its component parts as the format might change.
 #[derive(Debug, Clone)]
-pub(crate) struct RootPath {
+pub struct RootPath {
     pub(crate) inner: Path,
 }
 
@@ -60,6 +62,12 @@ impl RootPath {
 
     pub(crate) fn generation_path(&self, generation: Generation) -> GenerationPath {
         GenerationPath::new(self, generation)
+    }
+}
+
+impl fmt::Display for RootPath {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.inner)
     }
 }
 

--- a/server/src/database.rs
+++ b/server/src/database.rs
@@ -360,6 +360,16 @@ impl Database {
         self.shared.state.read().provided_rules()
     }
 
+    /// Always-constructable location in object store; may not actually exist yet
+    pub fn location(&self) -> String {
+        IoxObjectStore::root_path_for(
+            self.shared.application.object_store(),
+            self.shared.config.server_id,
+            &self.shared.config.name,
+        )
+        .to_string()
+    }
+
     /// Update the database rules, panic'ing if the state is invalid
     pub async fn update_provided_rules(
         &self,

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -507,10 +507,7 @@ impl ServerStateInitialized {
             databases: self
                 .databases
                 .iter()
-                .map(|(name, database)| management::v1::Database {
-                    name: name.to_string(),
-                    location: database.location(),
-                })
+                .map(|(name, database)| (name.to_string(), database.location()))
                 .collect(),
         };
 
@@ -1425,10 +1422,9 @@ mod tests {
 
         for entry in expected {
             let (expected_name, expected_location) = entry;
-            let db = config
+            let location = config
                 .databases
-                .iter()
-                .find(|db| db.name == expected_name.as_str())
+                .get(expected_name.as_str())
                 .unwrap_or_else(|| {
                     panic!(
                         "Could not find database named {} in server config",
@@ -1436,7 +1432,7 @@ mod tests {
                     )
                 });
 
-            assert_eq!(&db.location, expected_location);
+            assert_eq!(location, expected_location);
         }
     }
 

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -1979,10 +1979,6 @@ mod tests {
         let application = make_application();
         let server_id = ServerId::try_from(1).unwrap();
 
-        let server = make_server(Arc::clone(&application));
-        server.set_id(server_id).unwrap();
-        server.wait_for_init().await.unwrap();
-
         let foo_db_name = DatabaseName::new("foo").unwrap();
 
         // create a directory in object storage that looks like it could

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -355,7 +355,7 @@ struct ServerShared {
 #[derive(Debug, Snafu)]
 pub enum InitError {
     #[snafu(display("error listing databases in object storage: {}", source))]
-    ListRules { source: object_store::Error },
+    ListDatabases { source: object_store::Error },
 }
 
 /// The stage of the server in the startup process
@@ -1159,7 +1159,7 @@ async fn maybe_initialize_server(shared: &ServerShared) {
         }
         Err(e) => {
             error!(server_id=%init_ready.server_id, %e, "error initializing server");
-            ServerState::InitError(init_ready, Arc::new(InitError::ListRules { source: e }))
+            ServerState::InitError(init_ready, Arc::new(InitError::ListDatabases { source: e }))
         }
     };
 
@@ -1886,7 +1886,7 @@ mod tests {
 
         server.set_id(ServerId::try_from(1).unwrap()).unwrap();
         let err = server.wait_for_init().await.unwrap_err();
-        assert!(matches!(err.as_ref(), InitError::ListRules { .. }));
+        assert!(matches!(err.as_ref(), InitError::ListDatabases { .. }));
         assert_contains!(
             server.server_init_error().unwrap().to_string(),
             "error listing databases in object storage:"

--- a/server/src/rules.rs
+++ b/server/src/rules.rs
@@ -20,10 +20,14 @@ pub enum Error {
     },
 
     #[snafu(display("error deserializing database rules: {}", source))]
-    Deserialization { source: generated_types::ProstError },
+    Deserialization {
+        source: generated_types::DecodeError,
+    },
 
     #[snafu(display("error serializing database rules: {}", source))]
-    Serialization { source: generated_types::ProstError },
+    Serialization {
+        source: generated_types::EncodeError,
+    },
 
     #[snafu(display("error fetching rules: {}", source))]
     RulesFetch { source: object_store::Error },

--- a/server/src/rules.rs
+++ b/server/src/rules.rs
@@ -20,14 +20,10 @@ pub enum Error {
     },
 
     #[snafu(display("error deserializing database rules: {}", source))]
-    Deserialization {
-        source: generated_types::database_rules::ProstError,
-    },
+    Deserialization { source: generated_types::ProstError },
 
     #[snafu(display("error serializing database rules: {}", source))]
-    Serialization {
-        source: generated_types::database_rules::ProstError,
-    },
+    Serialization { source: generated_types::ProstError },
 
     #[snafu(display("error fetching rules: {}", source))]
     RulesFetch { source: object_store::Error },


### PR DESCRIPTION
Connects to #2676.

In the course of working on #2675, it became clear that not knowing the database name until reading the db rules wasn't quite the desired API. Instead of reading the db rules to find database names, and instead of storing multiple `link` files, each server will have one `config.pb` file in its `s3://<bucket..>/nodes/<server-id>/` directory that will contain the list of databases it owns with their names and object store locations.

This PR *writes* out the file after starting up the server and after databases are created to transition to using this file. The next PR will switch server startup to reading the file if it exists and falling back to scanning object storage until we've transition to the server config file always existing.