### PR TITLE
feat: wire span context frontent=>WriteBuffer

### DIFF
--- a/src/influxdb_ioxd/http.rs
+++ b/src/influxdb_ioxd/http.rs
@@ -493,6 +493,7 @@ async fn write<M>(
 where
     M: ConnectionManager + Send + Sync + Debug + 'static,
 {
+    let span_ctx = req.extensions().get().cloned();
     let Server {
         app_server: server,
         lp_metrics,
@@ -535,7 +536,10 @@ where
     let num_lines = lines.len();
     debug!(num_lines, num_fields, body_size=body.len(), %db_name, org=%write_info.org, bucket=%write_info.bucket, "inserting lines into database");
 
-    match server.write_lines(&db_name, &lines, default_time).await {
+    match server
+        .write_lines(&db_name, &lines, default_time, span_ctx)
+        .await
+    {
         Ok(_) => {
             lp_metrics.record_write(&db_name, lines.len(), num_fields, body.len(), true);
             Ok(Response::builder()

--- a/src/influxdb_ioxd/rpc/write.rs
+++ b/src/influxdb_ioxd/rpc/write.rs
@@ -30,6 +30,7 @@ where
         &self,
         request: tonic::Request<WriteRequest>,
     ) -> Result<tonic::Response<WriteResponse>, tonic::Status> {
+        let span_ctx = request.extensions().get().cloned();
         let request = request.into_inner();
 
         // The time, in nanoseconds since the epoch, to assign to any points that don't
@@ -57,7 +58,7 @@ where
         debug!(%db_name, %lp_chars, lp_line_count, body_size=lp_data.len(), num_fields, "Writing lines into database");
 
         self.server
-            .write_lines(&db_name, &lines, default_time)
+            .write_lines(&db_name, &lines, default_time, span_ctx)
             .await
             .map_err(default_server_error_handler)?;
 
@@ -69,6 +70,7 @@ where
         &self,
         request: tonic::Request<WriteEntryRequest>,
     ) -> Result<tonic::Response<WriteEntryResponse>, tonic::Status> {
+        let span_ctx = request.extensions().get().cloned();
         let request = request.into_inner();
         let db_name = DatabaseName::new(&request.db_name).field("db_name")?;
 
@@ -79,7 +81,7 @@ where
         let entry = entry::Entry::try_from(request.entry).field("entry")?;
 
         self.server
-            .write_entry_local(&db_name, entry)
+            .write_entry_local(&db_name, entry, span_ctx)
             .await
             .map_err(default_server_error_handler)?;
 

--- a/src/influxdb_ioxd/rpc/write_pb.rs
+++ b/src/influxdb_ioxd/rpc/write_pb.rs
@@ -18,13 +18,14 @@ where
         &self,
         request: tonic::Request<WriteRequest>,
     ) -> Result<tonic::Response<WriteResponse>, tonic::Status> {
+        let span_ctx = request.extensions().get().cloned();
         let database_batch = request
             .into_inner()
             .database_batch
             .ok_or_else(|| FieldViolation::required("database_batch"))?;
 
         self.server
-            .write_pb(database_batch)
+            .write_pb(database_batch, span_ctx)
             .await
             .map_err(default_server_error_handler)?;
 


### PR DESCRIPTION
This doesn't do anything really useful yet because the consumer side cannot really use it (yet) due to missing wiring. Hence the end2end test is missing.