### PR TITLE
fix(logfmts): Use UTC for ./scripts/logfmts

### DIFF
--- a/scripts/logfmts
+++ b/scripts/logfmts
@@ -23,4 +23,6 @@ if ! command -v gawk &> /dev/null; then
   echo "  ...."
 fi
 
+export TZ=C
+
 exec gawk -F"time=" '{print strftime("%Y-%m-%d %H:%M:%S", $2/1000000000), $1 }'


### PR DESCRIPTION
Local timezones and sharing logs with geographically distributed colleagues don't mix together.