### PR TITLE
fix: perf CI cache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -200,16 +200,9 @@ jobs:
           name: Install perf.py dependencies
           command: python3 -m pip install -r perf/requirements.txt
 
-      - restore_cache:
-          keys:
-            - cargo-lock-{{ checksum "Cargo.lock" }}
       - run:
           name: Prime Rust build cache
           command: cargo build --package influxdb_iox --bin influxdb_iox --package iox_data_generator --bin iox_data_generator
-      - save_cache:
-          key: cargo-lock-{{ checksum "Cargo.lock" }}
-          paths:
-            - target
 
       - run:
           name: Run basic perf test to ensure that perf.py works

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -201,10 +201,6 @@ jobs:
           command: python3 -m pip install -r perf/requirements.txt
 
       - run:
-          name: Prime Rust build cache
-          command: cargo build --package influxdb_iox --bin influxdb_iox --package iox_data_generator --bin iox_data_generator
-
-      - run:
           name: Run basic perf test to ensure that perf.py works
           command: perf/perf.py --debug --no-volumes --object-store memory battery-0
 


### PR DESCRIPTION
Blindly caching the /target directory will grow indefinitely over time. Cache retrieval is now starting to take a non-trivial amount of time in CI jobs.

This CI job is not running in docker like the others and so cannot use the same caching mechanism, but given this is re-installing all the components each time I'm inclined to think that caching the cargo registry is not going to net a meaningful return. If this CI job starts to take too long, we should probably look at reusing the build artifacts of other jobs and/or dockerising the dependencies.