### PR TITLE
chore: Update Rust

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.55"
+channel = "1.56"
 components = [ "rustfmt", "clippy" ]


### PR DESCRIPTION
This just updates us to 1.56 that was released today-- Edition 2021 was also stabilized, probably won't make any impact (the breaking changes were very small), but I'll do that in a separate PR.