### PR TITLE
refactor: move `catalog` protobuf to `preserved_catalog`

### DIFF
--- a/generated_types/build.rs
+++ b/generated_types/build.rs
@@ -19,29 +19,26 @@ fn main() -> Result<()> {
 /// Creates:
 ///
 /// - `com.github.influxdata.idpe.storage.read.rs`
-/// - `influxdata.iox.catalog.v1.rs`
 /// - `influxdata.iox.delete.v1.rs`
 /// - `influxdata.iox.deployment.v1.rs`
 /// - `influxdata.iox.management.v1.rs`
+/// - `influxdata.iox.preserved_catalog.v1.rs`
 /// - `influxdata.iox.remote.v1.rs`
 /// - `influxdata.iox.router.v1.rs`
 /// - `influxdata.iox.write.v1.rs`
 /// - `influxdata.platform.storage.rs`
 fn generate_grpc_types(root: &Path) -> Result<()> {
-    let catalog_path = root.join("influxdata/iox/catalog/v1");
     let delete_path = root.join("influxdata/iox/delete/v1");
     let deployment_path = root.join("influxdata/iox/deployment/v1");
     let idpe_path = root.join("com/github/influxdata/idpe/storage/read");
     let management_path = root.join("influxdata/iox/management/v1");
+    let preserved_catalog_path = root.join("influxdata/iox/preserved_catalog/v1");
     let remote_path = root.join("influxdata/iox/remote/v1");
     let router_path = root.join("influxdata/iox/router/v1");
     let storage_path = root.join("influxdata/platform/storage");
     let write_path = root.join("influxdata/iox/write/v1");
 
     let proto_files = vec![
-        catalog_path.join("catalog.proto"),
-        catalog_path.join("parquet_metadata.proto"),
-        catalog_path.join("predicate.proto"),
         delete_path.join("service.proto"),
         deployment_path.join("service.proto"),
         idpe_path.join("source.proto"),
@@ -54,6 +51,9 @@ fn generate_grpc_types(root: &Path) -> Result<()> {
         management_path.join("service.proto"),
         management_path.join("shard.proto"),
         management_path.join("write_buffer.proto"),
+        preserved_catalog_path.join("catalog.proto"),
+        preserved_catalog_path.join("parquet_metadata.proto"),
+        preserved_catalog_path.join("predicate.proto"),
         root.join("google/longrunning/operations.proto"),
         root.join("google/rpc/error_details.proto"),
         root.join("google/rpc/status.proto"),
@@ -83,11 +83,6 @@ fn generate_grpc_types(root: &Path) -> Result<()> {
         .disable_comments(&[".google"])
         .extern_path(".google.protobuf", "::pbjson_types")
         .bytes(&[
-            ".influxdata.iox.catalog.v1.AddParquet.metadata",
-            ".influxdata.iox.catalog.v1.ChunkAddr.chunk_id",
-            ".influxdata.iox.catalog.v1.IoxMetadata.chunk_id",
-            ".influxdata.iox.catalog.v1.Transaction.previous_uuid",
-            ".influxdata.iox.catalog.v1.Transaction.uuid",
             ".influxdata.iox.management.v1.Chunk.id",
             ".influxdata.iox.management.v1.ClosePartitionChunkRequest.chunk_id",
             ".influxdata.iox.management.v1.CompactChunks.chunks",
@@ -95,11 +90,16 @@ fn generate_grpc_types(root: &Path) -> Result<()> {
             ".influxdata.iox.management.v1.PersistChunks.chunks",
             ".influxdata.iox.management.v1.WriteChunk.chunk_id",
             ".influxdata.iox.management.v1.UnloadPartitionChunkRequest.chunk_id",
+            ".influxdata.iox.preserved_catalog.v1.AddParquet.metadata",
+            ".influxdata.iox.preserved_catalog.v1.ChunkAddr.chunk_id",
+            ".influxdata.iox.preserved_catalog.v1.IoxMetadata.chunk_id",
+            ".influxdata.iox.preserved_catalog.v1.Transaction.previous_uuid",
+            ".influxdata.iox.preserved_catalog.v1.Transaction.uuid",
             ".influxdata.iox.write.v1.WriteEntryRequest.entry",
         ])
         .btree_map(&[
-            ".influxdata.iox.catalog.v1.DatabaseCheckpoint.sequencer_numbers",
-            ".influxdata.iox.catalog.v1.PartitionCheckpoint.sequencer_numbers",
+            ".influxdata.iox.preserved_catalog.v1.DatabaseCheckpoint.sequencer_numbers",
+            ".influxdata.iox.preserved_catalog.v1.PartitionCheckpoint.sequencer_numbers",
         ]);
 
     let descriptor_path = PathBuf::from(env::var("OUT_DIR").unwrap()).join("proto_descriptor.bin");

--- a/generated_types/protos/influxdata/iox/preserved_catalog/v1/catalog.proto
+++ b/generated_types/protos/influxdata/iox/preserved_catalog/v1/catalog.proto
@@ -1,8 +1,8 @@
 syntax = "proto3";
-package influxdata.iox.catalog.v1;
+package influxdata.iox.preserved_catalog.v1;
 
 import "google/protobuf/timestamp.proto";
-import "influxdata/iox/catalog/v1/predicate.proto";
+import "influxdata/iox/preserved_catalog/v1/predicate.proto";
 
 // Path for object store interaction.
 message Path {

--- a/generated_types/protos/influxdata/iox/preserved_catalog/v1/parquet_metadata.proto
+++ b/generated_types/protos/influxdata/iox/preserved_catalog/v1/parquet_metadata.proto
@@ -1,5 +1,5 @@
 syntax = "proto3";
-package influxdata.iox.catalog.v1;
+package influxdata.iox.preserved_catalog.v1;
 
 import "google/protobuf/timestamp.proto";
 

--- a/generated_types/protos/influxdata/iox/preserved_catalog/v1/predicate.proto
+++ b/generated_types/protos/influxdata/iox/preserved_catalog/v1/predicate.proto
@@ -1,5 +1,5 @@
 syntax = "proto3";
-package influxdata.iox.catalog.v1;
+package influxdata.iox.preserved_catalog.v1;
 
 // Represents a parsed predicate for evaluation by the InfluxDB IOx query engine.
 message Predicate {

--- a/generated_types/src/lib.rs
+++ b/generated_types/src/lib.rs
@@ -28,16 +28,6 @@ pub mod influxdata {
     }
 
     pub mod iox {
-        pub mod catalog {
-            pub mod v1 {
-                include!(concat!(env!("OUT_DIR"), "/influxdata.iox.catalog.v1.rs"));
-                include!(concat!(
-                    env!("OUT_DIR"),
-                    "/influxdata.iox.catalog.v1.serde.rs"
-                ));
-            }
-        }
-
         pub mod delete {
             pub mod v1 {
                 include!(concat!(env!("OUT_DIR"), "/influxdata.iox.delete.v1.rs"));
@@ -68,6 +58,19 @@ pub mod influxdata {
                 include!(concat!(
                     env!("OUT_DIR"),
                     "/influxdata.iox.management.v1.serde.rs"
+                ));
+            }
+        }
+
+        pub mod preserved_catalog {
+            pub mod v1 {
+                include!(concat!(
+                    env!("OUT_DIR"),
+                    "/influxdata.iox.preserved_catalog.v1.rs"
+                ));
+                include!(concat!(
+                    env!("OUT_DIR"),
+                    "/influxdata.iox.preserved_catalog.v1.serde.rs"
                 ));
             }
         }

--- a/parquet_catalog/src/core.rs
+++ b/parquet_catalog/src/core.rs
@@ -2,7 +2,7 @@
 
 use bytes::Bytes;
 use futures::{StreamExt, TryStreamExt};
-use generated_types::influxdata::iox::catalog::v1 as proto;
+use generated_types::influxdata::iox::preserved_catalog::v1 as proto;
 use iox_object_store::{IoxObjectStore, ParquetFilePath, TransactionFilePath};
 use object_store::{ObjectStore, ObjectStoreApi};
 use observability_deps::tracing::{info, warn};

--- a/parquet_catalog/src/dump.rs
+++ b/parquet_catalog/src/dump.rs
@@ -3,7 +3,7 @@ use std::{fmt::Debug, sync::Arc};
 
 use bytes::Bytes;
 use futures::TryStreamExt;
-use generated_types::influxdata::iox::catalog::v1 as proto;
+use generated_types::influxdata::iox::preserved_catalog::v1 as proto;
 use iox_object_store::{IoxObjectStore, TransactionFilePath};
 use object_store::{ObjectStore, ObjectStoreApi};
 use parquet_file::metadata::{DecodedIoxParquetMetaData, IoxParquetMetaData};

--- a/parquet_catalog/src/internals/proto_io.rs
+++ b/parquet_catalog/src/internals/proto_io.rs
@@ -1,6 +1,6 @@
 use bytes::Bytes;
 use futures::TryStreamExt;
-use generated_types::influxdata::iox::catalog::v1 as proto;
+use generated_types::influxdata::iox::preserved_catalog::v1 as proto;
 use iox_object_store::{IoxObjectStore, TransactionFilePath};
 use object_store::{ObjectStore, ObjectStoreApi};
 use prost::Message;

--- a/parquet_catalog/src/internals/proto_parse.rs
+++ b/parquet_catalog/src/internals/proto_parse.rs
@@ -1,6 +1,6 @@
 use std::{convert::TryInto, num::TryFromIntError};
 
-use generated_types::influxdata::iox::catalog::v1 as proto;
+use generated_types::influxdata::iox::preserved_catalog::v1 as proto;
 use iox_object_store::{ParquetFilePath, ParquetFilePathParseError};
 use object_store::path::{parsed::DirsAndFileName, parts::PathPart};
 use snafu::{OptionExt, ResultExt, Snafu};

--- a/parquet_catalog/src/internals/types.rs
+++ b/parquet_catalog/src/internals/types.rs
@@ -1,6 +1,6 @@
 use std::fmt::Display;
 
-use generated_types::influxdata::iox::catalog::v1 as proto;
+use generated_types::influxdata::iox::preserved_catalog::v1 as proto;
 use uuid::Uuid;
 
 /// Type of catalog file.

--- a/parquet_file/src/metadata.rs
+++ b/parquet_file/src/metadata.rs
@@ -90,7 +90,7 @@ use data_types::{
     chunk_metadata::{ChunkId, ChunkOrder},
     partition_metadata::{ColumnSummary, InfluxDbType, StatValues, Statistics},
 };
-use generated_types::influxdata::iox::catalog::v1 as proto;
+use generated_types::influxdata::iox::preserved_catalog::v1 as proto;
 use parquet::{
     arrow::parquet_to_arrow_schema,
     file::{

--- a/predicate/src/delete_expr.rs
+++ b/predicate/src/delete_expr.rs
@@ -3,7 +3,7 @@ use std::{
     ops::Deref,
 };
 
-use generated_types::influxdata::iox::catalog::v1 as proto;
+use generated_types::influxdata::iox::preserved_catalog::v1 as proto;
 use ordered_float::OrderedFloat;
 use snafu::{OptionExt, ResultExt, Snafu};
 

--- a/predicate/src/serialize.rs
+++ b/predicate/src/serialize.rs
@@ -9,7 +9,7 @@
 use std::convert::TryInto;
 
 use data_types::timestamp::TimestampRange;
-use generated_types::influxdata::iox::catalog::v1 as proto;
+use generated_types::influxdata::iox::preserved_catalog::v1 as proto;
 use snafu::{ResultExt, Snafu};
 
 use crate::{delete_expr::DeleteExpr, delete_predicate::DeletePredicate};


### PR DESCRIPTION
This makes it clearer what's going since the contained messages are
only for the preserved part, not the in-mem catalog and its management.