### PR TITLE
chore: upgrade rust to 1.56.1

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.56"
+channel = "1.56.1"
 components = [ "rustfmt", "clippy" ]


### PR DESCRIPTION
See <https://blog.rust-lang.org/2021/11/01/cve-2021-42574.html>.