### PR TITLE
fix: Change database paths to be under /dbs/ instead of under /[server id]/

### DIFF
--- a/influxdb_iox/src/commands/debug/dump_catalog.rs
+++ b/influxdb_iox/src/commands/debug/dump_catalog.rs
@@ -123,7 +123,7 @@ pub async fn command(config: Config) -> Result<()> {
         .context(CantFindDatabase)?;
 
     let iox_object_store =
-        IoxObjectStore::load_at_root_path(Arc::clone(&object_store), server_id, database_location)
+        IoxObjectStore::load_at_root_path(Arc::clone(&object_store), database_location)
             .await
             .context(IoxObjectStoreFailure)?;
 

--- a/influxdb_iox/tests/end_to_end_cases/scenario.rs
+++ b/influxdb_iox/tests/end_to_end_cases/scenario.rs
@@ -613,7 +613,7 @@ pub async fn fixture_broken_catalog(db_name: &str) -> ServerFixture {
         .unwrap();
 
     let mut path = fixture.dir().to_path_buf();
-    path.push(server_id.to_string());
+    path.push("dbs");
     path.push(uuid.to_string());
 
     path.push("transactions");

--- a/iox_object_store/src/paths/parquet_file.rs
+++ b/iox_object_store/src/paths/parquet_file.rs
@@ -137,15 +137,8 @@ pub enum ParquetFilePathParseError {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{IoxObjectStore, RootPath};
-    use data_types::server_id::ServerId;
+    use crate::{paths::ALL_DATABASES_DIRECTORY, IoxObjectStore, RootPath};
     use object_store::{ObjectStore, ObjectStoreApi};
-    use std::num::NonZeroU32;
-
-    /// Creates new test server ID
-    fn make_server_id() -> ServerId {
-        ServerId::new(NonZeroU32::new(1).unwrap())
-    }
 
     /// Creates a new in-memory object store. These tests rely on the `Path`s being of type
     /// `DirsAndFileName` and thus using object_store::path::DELIMITER as the separator
@@ -290,12 +283,10 @@ mod tests {
 
     #[test]
     fn data_path_join_with_parquet_file_path() {
-        let server_id = make_server_id();
         let db_uuid = Uuid::new_v4();
         let object_store = make_object_store();
-        let root_path = RootPath::new(&object_store, server_id, db_uuid);
-        let iox_object_store =
-            IoxObjectStore::existing(Arc::clone(&object_store), server_id, root_path);
+        let root_path = RootPath::new(&object_store, db_uuid);
+        let iox_object_store = IoxObjectStore::existing(Arc::clone(&object_store), root_path);
 
         let pfp = ParquetFilePath {
             table_name: "}*".into(),
@@ -307,7 +298,7 @@ mod tests {
 
         let mut expected_path = object_store.new_path();
         expected_path.push_all_dirs(&[
-            &server_id.to_string(),
+            ALL_DATABASES_DIRECTORY,
             &db_uuid.to_string(),
             "data",
             "}*",

--- a/iox_object_store/src/paths/transaction_file.rs
+++ b/iox_object_store/src/paths/transaction_file.rs
@@ -112,7 +112,7 @@ impl TransactionFilePath {
 
         // The number of `next`s here needs to match the total number of directories in
         // iox_object_store transactions_path
-        absolute_dirs.next(); // server id
+        absolute_dirs.next(); // "dbs"
         absolute_dirs.next(); // database uuid
         absolute_dirs.next(); // "transactions"
 
@@ -195,15 +195,9 @@ impl FromStr for TransactionFileSuffix {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{IoxObjectStore, RootPath};
-    use data_types::server_id::ServerId;
+    use crate::{paths::ALL_DATABASES_DIRECTORY, IoxObjectStore, RootPath};
     use object_store::{ObjectStore, ObjectStoreApi};
-    use std::{num::NonZeroU32, sync::Arc};
-
-    /// Creates new test server ID
-    fn make_server_id() -> ServerId {
-        ServerId::new(NonZeroU32::new(1).unwrap())
-    }
+    use std::sync::Arc;
 
     /// Creates a new in-memory object store. These tests rely on the `Path`s being of type
     /// `DirsAndFileName` and thus using object_store::path::DELIMITER as the separator
@@ -310,7 +304,7 @@ mod tests {
         // Success case
         let uuid = Uuid::new_v4();
         let mut path = object_store.new_path();
-        path.push_all_dirs(&["server", "uuid", "data", "00000000000000000123"]);
+        path.push_all_dirs(&["dbs", "uuid", "data", "00000000000000000123"]);
         path.set_file_name(&format!("{}.{}", uuid, CHECKPOINT_FILE_SUFFIX));
         let result = TransactionFilePath::from_absolute(path);
         assert_eq!(
@@ -338,7 +332,7 @@ mod tests {
         );
 
         let mut path = object_store.new_path();
-        path.push_all_dirs(&["server", "uuid", "data", "00000000000000000123"]);
+        path.push_all_dirs(&["dbs", "uuid", "data", "00000000000000000123"]);
         // missing file name
         let result = TransactionFilePath::from_absolute(path);
         assert!(matches!(result, Err(MissingFileName)), "got: {:?}", result);
@@ -364,12 +358,10 @@ mod tests {
 
     #[test]
     fn transactions_path_join_with_parquet_file_path() {
-        let server_id = make_server_id();
         let db_uuid = Uuid::new_v4();
         let object_store = make_object_store();
-        let root_path = RootPath::new(&object_store, server_id, db_uuid);
-        let iox_object_store =
-            IoxObjectStore::existing(Arc::clone(&object_store), server_id, root_path);
+        let root_path = RootPath::new(&object_store, db_uuid);
+        let iox_object_store = IoxObjectStore::existing(Arc::clone(&object_store), root_path);
 
         let uuid = Uuid::new_v4();
         let tfp = TransactionFilePath {
@@ -382,7 +374,7 @@ mod tests {
 
         let mut expected_path = object_store.new_path();
         expected_path.push_all_dirs(&[
-            &server_id.to_string(),
+            ALL_DATABASES_DIRECTORY,
             &db_uuid.to_string(),
             "transactions",
             "00000000000000000555",

--- a/parquet_file/src/test_utils.rs
+++ b/parquet_file/src/test_utils.rs
@@ -854,15 +854,10 @@ pub fn make_server_id() -> ServerId {
 
 /// Creates new in-memory database iox_object_store for testing.
 pub async fn make_iox_object_store() -> Arc<IoxObjectStore> {
-    let server_id = make_server_id();
     Arc::new(
-        IoxObjectStore::create(
-            Arc::new(ObjectStore::new_in_memory()),
-            server_id,
-            Uuid::new_v4(),
-        )
-        .await
-        .unwrap(),
+        IoxObjectStore::create(Arc::new(ObjectStore::new_in_memory()), Uuid::new_v4())
+            .await
+            .unwrap(),
     )
 }
 

--- a/server/src/database.rs
+++ b/server/src/database.rs
@@ -184,9 +184,7 @@ impl Database {
     ) -> Result<String, InitError> {
         let db_name = provided_rules.db_name().clone();
         let iox_object_store = Arc::new(
-            match IoxObjectStore::create(Arc::clone(application.object_store()), server_id, uuid)
-                .await
-            {
+            match IoxObjectStore::create(Arc::clone(application.object_store()), uuid).await {
                 Ok(ios) => ios,
                 Err(source) => return Err(InitError::IoxObjectStoreError { source }),
             },
@@ -281,12 +279,8 @@ impl Database {
     ) -> Result<String, InitError> {
         info!(%db_name, %uuid, "restoring database");
 
-        let iox_object_store_result = IoxObjectStore::restore_database(
-            Arc::clone(application.object_store()),
-            server_id,
-            uuid,
-        )
-        .await;
+        let iox_object_store_result =
+            IoxObjectStore::restore_database(Arc::clone(application.object_store()), uuid).await;
 
         let iox_object_store = match iox_object_store_result {
             Ok(iox_os) => iox_os,
@@ -1138,7 +1132,6 @@ impl DatabaseStateKnown {
     ) -> Result<DatabaseStateDatabaseObjectStoreFound, InitError> {
         let iox_object_store = IoxObjectStore::load_at_root_path(
             Arc::clone(shared.application.object_store()),
-            shared.config.server_id,
             &shared.config.location,
         )
         .await

--- a/server/src/db/load.rs
+++ b/server/src/db/load.rs
@@ -314,27 +314,22 @@ impl CatalogState for Loader {
 mod tests {
     use super::*;
     use crate::db::checkpoint_data_from_catalog;
-    use data_types::{server_id::ServerId, DatabaseName};
+    use data_types::DatabaseName;
     use object_store::ObjectStore;
     use parquet_catalog::{
         interface::CheckpointData,
         test_helpers::{assert_catalog_state_implementation, new_empty},
     };
-    use std::convert::TryFrom;
     use uuid::Uuid;
 
     #[tokio::test]
     async fn load_or_create_preserved_catalog_recovers_from_error() {
         let object_store = Arc::new(ObjectStore::new_in_memory());
         let time_provider: Arc<dyn TimeProvider> = Arc::new(time::SystemProvider::new());
-        let server_id = ServerId::try_from(1).unwrap();
         let db_name = DatabaseName::new("preserved_catalog_test").unwrap();
         let db_uuid = Uuid::new_v4();
-        let iox_object_store = Arc::new(
-            IoxObjectStore::create(object_store, server_id, db_uuid)
-                .await
-                .unwrap(),
-        );
+        let iox_object_store =
+            Arc::new(IoxObjectStore::create(object_store, db_uuid).await.unwrap());
         let config = PreservedCatalogConfig::new(
             Arc::clone(&iox_object_store),
             db_name.to_string(),

--- a/server/src/utils.rs
+++ b/server/src/utils.rs
@@ -86,11 +86,10 @@ impl TestDbBuilder {
 
         let time_provider = Arc::clone(&self.time_provider);
 
-        let iox_object_store =
-            IoxObjectStore::load(Arc::clone(&object_store), server_id, uuid).await;
+        let iox_object_store = IoxObjectStore::load(Arc::clone(&object_store), uuid).await;
         let iox_object_store = match iox_object_store {
             Ok(ios) => ios,
-            Err(_) => IoxObjectStore::create(Arc::clone(&object_store), server_id, uuid)
+            Err(_) => IoxObjectStore::create(Arc::clone(&object_store), uuid)
                 .await
                 .unwrap(),
         };


### PR DESCRIPTION
Closes #2677.

I wrote tests simulating updating to this code with an existing database under the server ID in object storage that pass; so I **don't** think it will be necessary to wipe object storage when deploying this. Let me know if you'd like anything added to the test!
