### PR TITLE
feat: add write buffer delete encoding (#2731)

### DIFF
--- a/generated_types/build.rs
+++ b/generated_types/build.rs
@@ -53,6 +53,7 @@ fn generate_grpc_types(root: &Path) -> Result<()> {
         management_path.join("service.proto"),
         management_path.join("shard.proto"),
         predicate_path.join("predicate.proto"),
+        predicate_path.join("shard.proto"),
         preserved_catalog_path.join("catalog.proto"),
         preserved_catalog_path.join("parquet_metadata.proto"),
         root.join("google/longrunning/operations.proto"),

--- a/generated_types/protos/influxdata/iox/delete/v1/service.proto
+++ b/generated_types/protos/influxdata/iox/delete/v1/service.proto
@@ -2,12 +2,17 @@ syntax = "proto3";
 package influxdata.iox.delete.v1;
 option go_package = "github.com/influxdata/iox/delete/v1";
 
+import "influxdata/iox/predicate/v1/predicate.proto";
+import "influxdata/iox/predicate/v1/shard.proto";
+
 service DeleteService {
   // Delete data for a table on a specified predicate
   rpc Delete(DeleteRequest) returns (DeleteResponse);
 }
 
 // Request to delete data from a table on a specified predicate
+//
+// TODO: Use Delete
 message DeleteRequest {
   // name of the database
   string db_name = 1;
@@ -27,4 +32,16 @@ message DeleteRequest {
 }
 
 message DeleteResponse {
+}
+
+// A delete payload
+message DeletePayload {
+  // The name of the database
+  string db_name = 1;
+
+  // The predicate identifying data to delete
+  influxdata.iox.predicate.v1.Predicate predicate = 2;
+
+  // An optional conjunctive list of ShardPredicate restricting this delete to a specific shard
+  repeated influxdata.iox.predicate.v1.ShardPredicate shard_predicates = 3;
 }

--- a/generated_types/protos/influxdata/iox/predicate/v1/shard.proto
+++ b/generated_types/protos/influxdata/iox/predicate/v1/shard.proto
@@ -3,19 +3,11 @@ package influxdata.iox.predicate.v1;
 
 import "influxdata/iox/router/v1/shard.proto";
 
-// Represents a predicate that identifies the writes for a specific shard
+// A predicate that identifies the writes for a specific shard
 message ShardPredicate {
-  // An optional list of matchers for this shard
-  repeated influxdata.iox.router.v1.Matcher matchers = 1;
+  // The shard config
+  repeated influxdata.iox.router.v1.ShardConfig config = 1;
 
-  // An optional hash predicate
-  HashPredicate hash = 2;
-}
-
-// A HashPredicate matches if the SipHash 1-3 of the table name lies in
-// the inclusive range `start..=end`
-message HashPredicate {
-  uint64 start = 1;
-
-  uint64 end = 2;
+  // The shard ID
+  uint32 shard = 2;
 }

--- a/generated_types/protos/influxdata/iox/predicate/v1/shard.proto
+++ b/generated_types/protos/influxdata/iox/predicate/v1/shard.proto
@@ -1,0 +1,21 @@
+syntax = "proto3";
+package influxdata.iox.predicate.v1;
+
+import "influxdata/iox/router/v1/shard.proto";
+
+// Represents a predicate that identifies the writes for a specific shard
+message ShardPredicate {
+  // An optional list of matchers for this shard
+  repeated influxdata.iox.router.v1.Matcher matchers = 1;
+
+  // An optional hash predicate
+  HashPredicate hash = 2;
+}
+
+// A HashPredicate matches if the SipHash 1-3 of the table name lies in
+// the inclusive range `start..=end`
+message HashPredicate {
+  uint64 start = 1;
+
+  uint64 end = 2;
+}

--- a/generated_types/protos/influxdata/iox/write_buffer/v1/write_buffer.proto
+++ b/generated_types/protos/influxdata/iox/write_buffer/v1/write_buffer.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 package influxdata.iox.write_buffer.v1;
 option go_package = "github.com/influxdata/iox/write_buffer/v1";
 
+import "influxdata/iox/delete/v1/service.proto";
 import "influxdata/pbdata/v1/influxdb_pb_data_protocol.proto";
 
 // Configures the use of a write buffer.
@@ -63,5 +64,6 @@ message WriteBufferCreationConfig {
 message WriteBufferPayload {
   oneof payload {
     influxdata.pbdata.v1.DatabaseBatch write = 1;
+    influxdata.iox.delete.v1.DeletePayload delete = 2;
   }
 }

--- a/write_buffer/src/codec.rs
+++ b/write_buffer/src/codec.rs
@@ -142,7 +142,7 @@ pub fn decode(
             let tables = match &payload {
                 Payload::Write(write) => decode_database_batch(write)
                     .map_err(|e| format!("failed to decode database batch: {}", e))?,
-                Payload::Delete(_) => return Err("delete payload not supported".into())
+                Payload::Delete(_) => return Err("delete payload not supported".into()),
             };
 
             Ok(DbWrite::new(

--- a/write_buffer/src/codec.rs
+++ b/write_buffer/src/codec.rs
@@ -142,6 +142,7 @@ pub fn decode(
             let tables = match &payload {
                 Payload::Write(write) => decode_database_batch(write)
                     .map_err(|e| format!("failed to decode database batch: {}", e))?,
+                Payload::Delete(_) => return Err("delete payload not supported".into())
             };
 
             Ok(DbWrite::new(


### PR DESCRIPTION
An RFC for how to represent deletes within the write buffer, and in particular how to handle delete distribution.

**Background**

Currently we have two closely related concepts, shards and sequencers. There are at least two possible models for how these interact:

* Single sequencer per shard, multiple shards per instance
* Single shard per instance, multiple sequencer per shard

Additionally IOx currently permits topologies with multiple layers of HTTP and gRPC routing. I'm not sure if this is intentional but I think it is...

When routing a delete, if it has a single destination the problem is straightforward - the delete is sent to the single destination. This would be the case where a delete specified a table name, and data is being distributed based on table. 

This gets more complex when the delete has multiple destinations. If the router simply cloned the delete to all possible destinations we could end up in a situation where the ordering of writes and deletes is ambiguous. 

Consider a situation where there is a single router server and a single query server, and writes are being distributed across two sequencers. If the delete is blindly sent to both sequencers, depending on the order the query server interleaves the reads from the two sequencers, the deletes will delete different data.

**Proposal**

The key invariant that simple cloning is violating is that a sequenced delete must only modify data that would have been sent to the same sequencer. The fix is therefore relatively straightforward, package information along with the delete that restricts them to exactly this data. This is what this PR does.

