### PR TITLE
fix: HTTP server error handling clean up

### DIFF
--- a/influxdb_iox/src/influxdb_ioxd/http/test_utils.rs
+++ b/influxdb_iox/src/influxdb_ioxd/http/test_utils.rs
@@ -1,5 +1,4 @@
 use std::{
-    fmt::Debug,
     net::{IpAddr, Ipv4Addr, SocketAddr},
     sync::Arc,
 };
@@ -7,7 +6,6 @@ use std::{
 use http::header::CONTENT_TYPE;
 use hyper::{server::conn::AddrIncoming, StatusCode};
 use reqwest::Client;
-use serde::de::DeserializeOwned;
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 
@@ -40,32 +38,6 @@ pub async fn check_response(
                 body
             );
         }
-    } else {
-        panic!("Unexpected error response: {:?}", response);
-    }
-}
-
-#[allow(dead_code)]
-pub async fn check_json_response<T: DeserializeOwned + Eq + Debug>(
-    client: &reqwest::Client,
-    url: &str,
-    expected_status: StatusCode,
-) -> T {
-    let response = client.get(url).send().await;
-
-    // Print the response so if the test fails, we have a log of
-    // what went wrong
-    println!("{} response: {:?}", url, response);
-
-    if let Ok(response) = response {
-        let status = response.status();
-        let body: T = response
-            .json()
-            .await
-            .expect("Converting request body to string");
-
-        assert_eq!(status, expected_status);
-        body
     } else {
         panic!("Unexpected error response: {:?}", response);
     }

--- a/influxdb_iox/src/influxdb_ioxd/http/utils.rs
+++ b/influxdb_iox/src/influxdb_ioxd/http/utils.rs
@@ -4,7 +4,7 @@ use http::header::CONTENT_ENCODING;
 use hyper::{Body, Response};
 use snafu::{ResultExt, Snafu};
 
-use crate::influxdb_ioxd::server_type::RouteError;
+use crate::influxdb_ioxd::server_type::{ApiErrorCode, RouteError};
 
 #[allow(clippy::large_enum_variant)]
 #[derive(Debug, Snafu)]
@@ -31,11 +31,11 @@ pub enum ParseBodyError {
 impl RouteError for ParseBodyError {
     fn response(&self) -> Response<Body> {
         match self {
-            Self::RequestSizeExceeded { .. } => self.bad_request(),
-            Self::InvalidContentEncoding { .. } => self.bad_request(),
-            Self::ReadingHeaderAsUtf8 { .. } => self.bad_request(),
-            Self::ReadingBodyAsGzip { .. } => self.bad_request(),
-            Self::ClientHangup { .. } => self.bad_request(),
+            Self::RequestSizeExceeded { .. } => self.bad_request(ApiErrorCode::UNKNOWN),
+            Self::InvalidContentEncoding { .. } => self.bad_request(ApiErrorCode::UNKNOWN),
+            Self::ReadingHeaderAsUtf8 { .. } => self.bad_request(ApiErrorCode::UNKNOWN),
+            Self::ReadingBodyAsGzip { .. } => self.bad_request(ApiErrorCode::UNKNOWN),
+            Self::ClientHangup { .. } => self.bad_request(ApiErrorCode::UNKNOWN),
         }
     }
 }

--- a/influxdb_iox/src/influxdb_ioxd/http/write.rs
+++ b/influxdb_iox/src/influxdb_ioxd/http/write.rs
@@ -66,24 +66,14 @@ pub enum HttpWriteError {
 impl RouteError for HttpWriteError {
     fn response(&self) -> Response<Body> {
         match self {
-            Self::BucketMappingError { .. } => self.internal_error(),
-            Self::WritingPoints { .. } => self.internal_error(),
-            Self::ExpectedQueryString { .. } => self.bad_request(),
-            Self::InvalidQueryString { .. } => self.bad_request(),
-            Self::ReadingBodyAsUtf8 { .. } => self.bad_request(),
-            Self::ParsingLineProtocol { .. } => self.bad_request(),
+            Self::BucketMappingError { .. } => self.internal_error(ApiErrorCode::UNKNOWN),
+            Self::WritingPoints { .. } => self.internal_error(ApiErrorCode::UNKNOWN),
+            Self::ExpectedQueryString { .. } => self.bad_request(ApiErrorCode::UNKNOWN),
+            Self::InvalidQueryString { .. } => self.bad_request(ApiErrorCode::UNKNOWN),
+            Self::ReadingBodyAsUtf8 { .. } => self.bad_request(ApiErrorCode::UNKNOWN),
+            Self::ParsingLineProtocol { .. } => self.bad_request(ApiErrorCode::UNKNOWN),
             Self::DatabaseNotFound { .. } => self.not_found(),
             Self::ParseBody { source } => source.response(),
-        }
-    }
-
-    /// Map the error type into an API error code.
-    fn api_error_code(&self) -> u32 {
-        match self {
-            Self::DatabaseNotFound { .. } => ApiErrorCode::DB_NOT_FOUND.into(),
-            Self::ParseBody { source } => source.api_error_code(),
-            // A "catch all" error code
-            _ => ApiErrorCode::UNKNOWN.into(),
         }
     }
 }


### PR DESCRIPTION
1. Only log on error level for internal errors
2. Get rid of `api_error_code` since its interaction with nested errors
   is really confusing (e.g. not forwarding the correct error code
   doesn't have an effect because the way the actual response body is
   created but when debugging you'll see another error code).

Fixes #3075.
