### PR TITLE
fix: server IDs for routers on startup + improve client error handling

### DIFF
--- a/influxdb_iox/src/commands/run/router.rs
+++ b/influxdb_iox/src/commands/run/router.rs
@@ -12,6 +12,7 @@ use crate::{
     },
     structopt_blocks::run_config::RunConfig,
 };
+use observability_deps::tracing::warn;
 use router::{resolver::RemoteTemplate, server::RouterServer};
 use structopt::StructOpt;
 use thiserror::Error;
@@ -73,6 +74,13 @@ pub async fn command(config: Config) -> Result<()> {
         )
         .await,
     );
+    if let Some(id) = config.run_config.server_id_config.server_id {
+        router_server
+            .set_server_id(id)
+            .expect("server id already set");
+    } else {
+        warn!("server ID not set. ID must be set via the INFLUXDB_IOX_ID config or API before writing or querying data.");
+    }
     let server_type = Arc::new(RouterServerType::new(router_server, &common_state));
 
     Ok(influxdb_ioxd::main(common_state, server_type).await?)

--- a/influxdb_iox/tests/common/server_fixture.rs
+++ b/influxdb_iox/tests/common/server_fixture.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 use std::net::SocketAddrV4;
+use std::num::NonZeroU32;
 use std::sync::atomic::{AtomicU16, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
@@ -539,7 +540,7 @@ impl TestServer {
                 let id = DEFAULT_SERVER_ID;
 
                 deployment_client
-                    .update_server_id(id)
+                    .update_server_id(NonZeroU32::try_from(id).unwrap())
                     .await
                     .expect("set ID failed");
 

--- a/influxdb_iox/tests/common/server_fixture.rs
+++ b/influxdb_iox/tests/common/server_fixture.rs
@@ -94,6 +94,9 @@ enum InitialConfig {
     /// Set the writer id to something so it can accept writes
     SetWriterId,
 
+    /// Server ID already set (e.g. via environment variable)
+    ServerIdAlreadySet,
+
     /// leave the writer id empty so the test can set it
     None,
 }
@@ -155,11 +158,17 @@ impl ServerFixture {
     /// and wait for it to be ready. The database is left unconfigured (no writer id)
     /// and is not shared with any other tests.
     pub async fn create_single_use_with_config(test_config: TestConfig) -> Self {
+        let initial_config = if test_config.server_id.is_some() {
+            InitialConfig::ServerIdAlreadySet
+        } else {
+            InitialConfig::None
+        };
+
         let server = TestServer::new(test_config);
         let server = Arc::new(server);
 
         // ensure the server is ready
-        server.wait_until_ready(InitialConfig::None).await;
+        server.wait_until_ready(initial_config).await;
         Self::create_common(server).await
     }
 
@@ -344,6 +353,9 @@ pub struct TestConfig {
     /// Headers to add to all client requests
     client_headers: Vec<(HeaderName, HeaderValue)>,
 
+    /// Server ID
+    server_id: Option<NonZeroU32>,
+
     /// Server type
     server_type: ServerType,
 }
@@ -353,6 +365,7 @@ impl TestConfig {
         Self {
             env: vec![],
             client_headers: vec![],
+            server_id: None,
             server_type,
         }
     }
@@ -368,6 +381,12 @@ impl TestConfig {
             name.as_ref().parse().expect("valid header name"),
             value.as_ref().parse().expect("valid header value"),
         ));
+        self
+    }
+
+    /// Set server ID on startup.
+    pub fn with_server_id(mut self, server_id: NonZeroU32) -> Self {
+        self.server_id = Some(server_id);
         self
     }
 }
@@ -388,6 +407,7 @@ impl TestServer {
             &addrs,
             &dir,
             &test_config.env,
+            test_config.server_id,
             test_config.server_type,
         ));
 
@@ -409,6 +429,7 @@ impl TestServer {
             &self.addrs,
             &self.dir,
             &self.test_config.env,
+            self.test_config.server_id,
             self.test_config.server_type,
         );
         *ready_guard = ServerState::Started;
@@ -418,6 +439,7 @@ impl TestServer {
         addrs: &BindAddresses,
         dir: &TempDir,
         env: &[(String, String)],
+        server_id: Option<NonZeroU32>,
         server_type: ServerType,
     ) -> Process {
         // Create a new file each time and keep it around to aid debugging
@@ -458,6 +480,7 @@ impl TestServer {
             .env("INFLUXDB_IOX_DB_DIR", dir.path())
             .env("INFLUXDB_IOX_BIND_ADDR", addrs.http_bind_addr())
             .env("INFLUXDB_IOX_GRPC_BIND_ADDR", addrs.grpc_bind_addr())
+            .envs(server_id.map(|id| ("INFLUXDB_IOX_ID", id.get().to_string())))
             .envs(env.iter().map(|(a, b)| (a.as_str(), b.as_str())))
             // redirect output to log file
             .stdout(stdout_log_file)
@@ -525,11 +548,13 @@ impl TestServer {
         let channel = self.grpc_channel().await.expect("gRPC should be running");
         let mut deployment_client = influxdb_iox_client::deployment::Client::new(channel.clone());
 
-        if let Ok(id) = deployment_client.get_server_id().await {
-            // tell others that this server had some problem
-            *ready = ServerState::Error;
-            std::mem::drop(ready);
-            panic!("Server already has an ID ({}); possibly a stray/orphan server from another test run.", id);
+        if !matches!(initial_config, InitialConfig::ServerIdAlreadySet) {
+            if let Ok(id) = deployment_client.get_server_id().await {
+                // tell others that this server had some problem
+                *ready = ServerState::Error;
+                std::mem::drop(ready);
+                panic!("Server already has an ID ({}); possibly a stray/orphan server from another test run.", id);
+            }
         }
 
         // Set the server id, if requested
@@ -577,7 +602,7 @@ impl TestServer {
                     }
                 }
             }
-            InitialConfig::None => {}
+            InitialConfig::ServerIdAlreadySet | InitialConfig::None => {}
         };
     }
 

--- a/influxdb_iox/tests/common/server_fixture.rs
+++ b/influxdb_iox/tests/common/server_fixture.rs
@@ -124,10 +124,7 @@ impl ServerFixture {
             Some(server) => server,
             None => {
                 // if not, create one
-                let test_config = TestConfig {
-                    server_type,
-                    ..Default::default()
-                };
+                let test_config = TestConfig::new(server_type);
                 let server = TestServer::new(test_config);
                 let server = Arc::new(server);
 
@@ -150,10 +147,7 @@ impl ServerFixture {
     /// waits. The server is left unconfigured (e.g. no server id) and
     /// is not shared with any other tests.
     pub async fn create_single_use(server_type: ServerType) -> Self {
-        let test_config = TestConfig {
-            server_type,
-            ..Default::default()
-        };
+        let test_config = TestConfig::new(server_type);
         Self::create_single_use_with_config(test_config).await
     }
 
@@ -342,7 +336,7 @@ impl Default for ServerType {
 }
 
 // Options for creating test servers
-#[derive(Default, Debug, Clone)]
+#[derive(Debug, Clone)]
 pub struct TestConfig {
     /// Additional environment variables
     env: Vec<(String, String)>,
@@ -355,8 +349,12 @@ pub struct TestConfig {
 }
 
 impl TestConfig {
-    pub fn new() -> Self {
-        Default::default()
+    pub fn new(server_type: ServerType) -> Self {
+        Self {
+            env: vec![],
+            client_headers: vec![],
+            server_type,
+        }
     }
     // add a name=value environment variable when starting the server
     pub fn with_env(mut self, name: impl Into<String>, value: impl Into<String>) -> Self {

--- a/influxdb_iox/tests/end_to_end_cases/deployment_api.rs
+++ b/influxdb_iox/tests/end_to_end_cases/deployment_api.rs
@@ -95,16 +95,16 @@ async fn test_serving_readiness_router() {
 }
 
 #[tokio::test]
-async fn test_set_get_writer_id_database() {
-    assert_set_get_writer_id(ServerFixture::create_single_use(ServerType::Database).await).await;
+async fn test_set_get_server_id_database() {
+    assert_set_get_server_id(ServerFixture::create_single_use(ServerType::Database).await).await;
 }
 
 #[tokio::test]
-async fn test_set_get_writer_id_router() {
-    assert_set_get_writer_id(ServerFixture::create_single_use(ServerType::Router).await).await;
+async fn test_set_get_server_id_router() {
+    assert_set_get_server_id(ServerFixture::create_single_use(ServerType::Router).await).await;
 }
 
-async fn assert_set_get_writer_id(server_fixture: ServerFixture) {
+async fn assert_set_get_server_id(server_fixture: ServerFixture) {
     let mut client = server_fixture.deployment_client();
 
     let test_id = NonZeroU32::try_from(42).unwrap();

--- a/influxdb_iox/tests/end_to_end_cases/deployment_api.rs
+++ b/influxdb_iox/tests/end_to_end_cases/deployment_api.rs
@@ -1,4 +1,6 @@
-use influxdb_iox_client::{management::generated_types::DatabaseRules, write::WriteError};
+use influxdb_iox_client::{
+    management::generated_types::DatabaseRules, router::generated_types::Router, write::WriteError,
+};
 use tonic::Code;
 
 use crate::common::server_fixture::{ServerFixture, ServerType};
@@ -46,7 +48,47 @@ async fn test_serving_readiness_database() {
     write_client.write_lp(name, lp_data, 0).await.unwrap();
 }
 
-// TODO(marco): add `test_serving_readiness_router` once we have some other API that we could use for testing
+#[tokio::test]
+async fn test_serving_readiness_router() {
+    let server_fixture = ServerFixture::create_single_use(ServerType::Router).await;
+    let mut deployment_client = server_fixture.deployment_client();
+    let mut router_client = server_fixture.router_client();
+    let mut write_client = server_fixture.write_client();
+
+    let name = "foo";
+    let lp_data = "bar baz=1 10";
+
+    deployment_client
+        .update_server_id(42)
+        .await
+        .expect("set ID failed");
+    router_client
+        .update_router(Router {
+            name: name.to_string(),
+            ..Default::default()
+        })
+        .await
+        .expect("create router failed");
+
+    assert!(deployment_client.get_serving_readiness().await.unwrap());
+
+    deployment_client
+        .set_serving_readiness(false)
+        .await
+        .unwrap();
+    let err = write_client.write_lp(name, lp_data, 0).await.unwrap_err();
+    assert!(
+        matches!(&err, WriteError::ServerError(status) if status.code() == Code::Unavailable),
+        "{}",
+        &err
+    );
+
+    assert!(!deployment_client.get_serving_readiness().await.unwrap());
+
+    deployment_client.set_serving_readiness(true).await.unwrap();
+    assert!(deployment_client.get_serving_readiness().await.unwrap());
+    write_client.write_lp(name, lp_data, 0).await.unwrap();
+}
 
 #[tokio::test]
 async fn test_set_get_writer_id_database() {

--- a/influxdb_iox/tests/end_to_end_cases/deployment_api.rs
+++ b/influxdb_iox/tests/end_to_end_cases/deployment_api.rs
@@ -7,7 +7,7 @@ use influxdb_iox_client::{
 use test_helpers::assert_error;
 use tonic::Code;
 
-use crate::common::server_fixture::{ServerFixture, ServerType};
+use crate::common::server_fixture::{ServerFixture, ServerType, TestConfig};
 
 #[tokio::test]
 async fn test_serving_readiness_database() {
@@ -104,6 +104,28 @@ async fn test_set_get_server_id_router() {
     assert_set_get_server_id(ServerFixture::create_single_use(ServerType::Router).await).await;
 }
 
+#[tokio::test]
+async fn test_set_get_server_id_already_set_database() {
+    let server_id = NonZeroU32::new(42).unwrap();
+    let test_config = TestConfig::new(ServerType::Database).with_server_id(server_id);
+    assert_set_get_server_id_already_set(
+        ServerFixture::create_single_use_with_config(test_config).await,
+        server_id,
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn test_set_get_server_id_already_set_router() {
+    let server_id = NonZeroU32::new(42).unwrap();
+    let test_config = TestConfig::new(ServerType::Router).with_server_id(server_id);
+    assert_set_get_server_id_already_set(
+        ServerFixture::create_single_use_with_config(test_config).await,
+        server_id,
+    )
+    .await;
+}
+
 async fn assert_set_get_server_id(server_fixture: ServerFixture) {
     let mut client = server_fixture.deployment_client();
 
@@ -116,6 +138,22 @@ async fn assert_set_get_server_id(server_fixture: ServerFixture) {
 
     let got = client.get_server_id().await.expect("get ID failed");
     assert_eq!(got, test_id);
+
+    // setting server ID a second time should fail
+    let result = client
+        .update_server_id(NonZeroU32::try_from(13).unwrap())
+        .await;
+    assert_error!(result, UpdateServerIdError::AlreadySet);
+}
+
+async fn assert_set_get_server_id_already_set(
+    server_fixture: ServerFixture,
+    server_id: NonZeroU32,
+) {
+    let mut client = server_fixture.deployment_client();
+
+    let got = client.get_server_id().await.expect("get ID failed");
+    assert_eq!(got, server_id);
 
     // setting server ID a second time should fail
     let result = client

--- a/influxdb_iox/tests/end_to_end_cases/metrics.rs
+++ b/influxdb_iox/tests/end_to_end_cases/metrics.rs
@@ -4,7 +4,8 @@ use test_helpers::assert_contains;
 
 #[tokio::test]
 pub async fn test_row_timestamp() {
-    let test_config = TestConfig::new().with_env("INFLUXDB_IOX_ROW_TIMESTAMP_METRICS", "system");
+    let test_config = TestConfig::new(ServerType::Database)
+        .with_env("INFLUXDB_IOX_ROW_TIMESTAMP_METRICS", "system");
     let server_fixture = ServerFixture::create_single_use_with_config(test_config).await;
     let mut management_client = server_fixture.management_client();
 

--- a/influxdb_iox/tests/end_to_end_cases/scenario.rs
+++ b/influxdb_iox/tests/end_to_end_cases/scenario.rs
@@ -39,7 +39,7 @@ use time::SystemProvider;
 use write_buffer::core::{WriteBufferReading, WriteBufferWriting};
 use write_buffer::file::{FileBufferConsumer, FileBufferProducer};
 
-use crate::common::server_fixture::{ServerFixture, TestConfig, DEFAULT_SERVER_ID};
+use crate::common::server_fixture::{ServerFixture, ServerType, TestConfig, DEFAULT_SERVER_ID};
 
 type Error = Box<dyn std::error::Error + Send + Sync + 'static>;
 type Result<T, E = Error> = std::result::Result<T, E>;
@@ -592,7 +592,8 @@ pub async fn list_chunks(fixture: &ServerFixture, db_name: &str) -> Vec<ChunkSum
 pub async fn fixture_broken_catalog(db_name: &str) -> ServerFixture {
     let server_id = DEFAULT_SERVER_ID;
 
-    let test_config = TestConfig::new().with_env("INFLUXDB_IOX_WIPE_CATALOG_ON_ERROR", "no");
+    let test_config =
+        TestConfig::new(ServerType::Database).with_env("INFLUXDB_IOX_WIPE_CATALOG_ON_ERROR", "no");
 
     let fixture = ServerFixture::create_single_use_with_config(test_config).await;
     fixture
@@ -648,7 +649,8 @@ pub async fn fixture_broken_catalog(db_name: &str) -> ServerFixture {
 pub async fn fixture_replay_broken(db_name: &str, write_buffer_path: &Path) -> ServerFixture {
     let server_id = DEFAULT_SERVER_ID;
 
-    let test_config = TestConfig::new().with_env("INFLUXDB_IOX_SKIP_REPLAY", "no");
+    let test_config =
+        TestConfig::new(ServerType::Database).with_env("INFLUXDB_IOX_SKIP_REPLAY", "no");
 
     let fixture = ServerFixture::create_single_use_with_config(test_config).await;
     fixture

--- a/influxdb_iox/tests/end_to_end_cases/tracing.rs
+++ b/influxdb_iox/tests/end_to_end_cases/tracing.rs
@@ -1,6 +1,6 @@
 use super::scenario::{collect_query, Scenario};
 use crate::common::{
-    server_fixture::{ServerFixture, TestConfig},
+    server_fixture::{ServerFixture, ServerType, TestConfig},
     udp_listener::UdpCapture,
 };
 use futures::TryStreamExt;
@@ -9,7 +9,7 @@ use generated_types::{storage_client::StorageClient, ReadFilterRequest};
 async fn setup() -> (UdpCapture, ServerFixture) {
     let udp_capture = UdpCapture::new().await;
 
-    let test_config = TestConfig::new()
+    let test_config = TestConfig::new(ServerType::Database)
         .with_env("TRACES_EXPORTER", "jaeger")
         .with_env("TRACES_EXPORTER_JAEGER_AGENT_HOST", udp_capture.ip())
         .with_env("TRACES_EXPORTER_JAEGER_AGENT_PORT", udp_capture.port())
@@ -116,7 +116,7 @@ pub async fn test_tracing_storage_api() {
 pub async fn test_tracing_create_trace() {
     let udp_capture = UdpCapture::new().await;
 
-    let test_config = TestConfig::new()
+    let test_config = TestConfig::new(ServerType::Database)
         .with_env("TRACES_EXPORTER", "jaeger")
         .with_env("TRACES_EXPORTER_JAEGER_AGENT_HOST", udp_capture.ip())
         .with_env("TRACES_EXPORTER_JAEGER_AGENT_PORT", udp_capture.port())

--- a/influxdb_iox/tests/end_to_end_cases/write_buffer.rs
+++ b/influxdb_iox/tests/end_to_end_cases/write_buffer.rs
@@ -295,7 +295,7 @@ pub async fn test_cross_write_buffer_tracing() {
 
     // setup tracing
     let udp_capture = UdpCapture::new().await;
-    let test_config = TestConfig::new()
+    let test_config = TestConfig::new(ServerType::Database)
         .with_env("TRACES_EXPORTER", "jaeger")
         .with_env("TRACES_EXPORTER_JAEGER_AGENT_HOST", udp_capture.ip())
         .with_env("TRACES_EXPORTER_JAEGER_AGENT_PORT", udp_capture.port())

--- a/influxdb_iox_client/Cargo.toml
+++ b/influxdb_iox_client/Cargo.toml
@@ -34,4 +34,4 @@ uuid = { version = "0.8", features = ["v4"] }
 
 [dev-dependencies] # In alphabetical order
 serde_json = "1.0"
-tokio = { version = "1.13", features = ["macros"] }
+tokio = { version = "1.13", features = ["macros", "rt-multi-thread"] }


### PR DESCRIPTION
See commits (it's mostly prep work for the actual fix).
