### PR TITLE
fix: also export `write_buffer` gRPC types from router client

### DIFF
--- a/influxdb_iox_client/src/client/router.rs
+++ b/influxdb_iox_client/src/client/router.rs
@@ -7,6 +7,7 @@ use crate::connection::Connection;
 /// Re-export generated_types
 pub mod generated_types {
     pub use generated_types::influxdata::iox::router::v1::*;
+    pub use generated_types::influxdata::iox::write_buffer::v1::*;
 }
 
 /// Errors returned by Client::list_routers


### PR DESCRIPTION
This is required to construct a write-buffer-based router config.

This will make the conductor code a bit cleaner.