### PR TITLE
fix: `perf_image` docker ignore

### DIFF
--- a/docker/Dockerfile.iox.dockerignore
+++ b/docker/Dockerfile.iox.dockerignore
@@ -1,4 +1,5 @@
 # Ignore everything
 **
 # Except
+!docker/entrypoint.sh
 !target/release/influxdb_iox


### PR DESCRIPTION
I have no idea why this didn't occur locally :shrug: 
