### PR TITLE
fix: ensure `ConsistenHasher` is consistent

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -792,6 +792,7 @@ dependencies = [
  "ordered-float 2.8.0",
  "percent-encoding",
  "regex",
+ "siphasher",
  "snafu",
  "test_helpers",
  "time 0.1.0",
@@ -3973,6 +3974,12 @@ dependencies = [
  "num-bigint 0.2.6",
  "num-traits",
 ]
+
+[[package]]
+name = "siphasher"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "533494a8f9b724d33625ab53c6c4800f7cc445895924a8ef649222dcb76e938b"
 
 [[package]]
 name = "slab"

--- a/data_types/Cargo.toml
+++ b/data_types/Cargo.toml
@@ -13,6 +13,7 @@ observability_deps = { path = "../observability_deps" }
 ordered-float = "2"
 percent-encoding = "2.1.0"
 regex = "1.4"
+siphasher = "0.3"
 snafu = "0.6"
 time = { path = "../time" }
 uuid = { version = "0.8", features = ["v4"] }

--- a/data_types/src/consistent_hasher.rs
+++ b/data_types/src/consistent_hasher.rs
@@ -1,5 +1,6 @@
-use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
+
+use siphasher::sip::SipHasher13;
 
 /// A ConsistentHasher implements a simple consistent hashing mechanism
 /// that maps a point to the nearest "node" N.
@@ -47,7 +48,7 @@ where
     }
 
     fn hash<H: Hash>(h: H) -> u64 {
-        let mut hasher = DefaultHasher::new();
+        let mut hasher = SipHasher13::new();
         h.hash(&mut hasher);
         hasher.finish()
     }
@@ -85,9 +86,6 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn test_roundtrip() {}
 
     #[test]
     fn test_consistent_hasher() {


### PR DESCRIPTION
The std `DefaultHasher` is NOT guaranteed to stay the same, so let's
directly use the `SipHasher13` which at the moment (2021-11-15) is used
by the standard lib.

Fixes #3063.
