### PR TITLE
ci: update CI images from docker buster to bullseye

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -336,7 +336,7 @@ jobs:
           # Disabling for now, and tracked further investigations
           # in https://github.com/influxdata/k8s-idpe/issues/3038
           docker_layer_caching: false
-          version: 19.03.14
+          version: 20.10.7
       - run: |
           sudo apt-get update
           sudo apt-get install -y docker.io
@@ -355,7 +355,7 @@ jobs:
           BRANCH=$(git rev-parse --abbrev-ref HEAD | tr '/' '.')
           COMMIT_SHA=$(git rev-parse --short HEAD)
           docker build -t quay.io/influxdb/iox:$COMMIT_SHA -t quay.io/influxdb/iox:main -f docker/Dockerfile.iox .
-          docker push quay.io/influxdb/iox
+          docker push --all-tags quay.io/influxdb/iox
           echo "export COMMIT_SHA=${COMMIT_SHA}" >> $BASH_ENV
       - run:
           name: Deploy tags

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN \
   cp /influxdb_iox/target/release/influxdb_iox /root/influxdb_iox && \
   du -cshx /usr/local/cargo/registry /usr/local/cargo/git /influxdb_iox/target
 
-FROM debian:buster-slim
+FROM debian:bullseye-slim
 
 RUN apt-get update \
     && apt-get install -y libssl1.1 libgcc1 libc6 ca-certificates --no-install-recommends \

--- a/docker/Dockerfile.ci
+++ b/docker/Dockerfile.ci
@@ -12,7 +12,7 @@
 
 ARG RUST_VERSION
 # Build actual image used for CI pipeline
-FROM rust:${RUST_VERSION}-slim-buster
+FROM rust:${RUST_VERSION}-slim-bullseye
 
 # When https://github.com/rust-lang/rustup/issues/2686 is fixed, run the command added that
 # will install everything in rust-toolchain.toml here so that components are in the container
@@ -42,7 +42,7 @@ COPY docker/redpanda.gpg /tmp/redpanda.gpg
 # Generated from https://packages.vectorized.io/nzc4ZYQK3WRGd9sy/redpanda/cfg/setup/bash.deb.sh
 RUN apt-key add /tmp/redpanda.gpg \
     && rm /tmp/redpanda.gpg \
-    && curl ${CURL_FLAGS} "https://packages.vectorized.io/nzc4ZYQK3WRGd9sy/redpanda/config.deb.txt?distro=debian&codename=buster&version=10&arch=x86_64" \
+    && curl ${CURL_FLAGS} "https://packages.vectorized.io/nzc4ZYQK3WRGd9sy/redpanda/config.deb.txt?distro=debian&codename=bullseye&version=10&arch=x86_64" \
       > /etc/apt/sources.list.d/vectorized-redpanda.list \
     && apt-get update \
     && apt-get install -y redpanda \

--- a/docker/Dockerfile.iox
+++ b/docker/Dockerfile.iox
@@ -1,7 +1,7 @@
 ###
 # Dockerfile used for deploying IOx
 ##
-FROM debian:buster-slim
+FROM debian:bullseye-slim
 
 RUN apt-get update \
   && apt-get install -y libssl1.1 libgcc1 libc6 ca-certificates gettext-base --no-install-recommends \


### PR DESCRIPTION
This will break `perf_image` until the new CI image is built due to the
newly required `--all-tags` parameter to `docker push` that isn't
available for the docker version we run on buster.
