### PR TITLE
test: show valid line protocol does not get written into IOx

### DIFF
--- a/influxdb_line_protocol/src/lib.rs
+++ b/influxdb_line_protocol/src/lib.rs
@@ -1229,6 +1229,20 @@ mod test {
     }
 
     #[test]
+    fn parse_identical_tag_field_name() {
+        let input = "dupnames,day=monday day=1.2";
+        let vals = parse(input).unwrap();
+
+        assert_eq!(vals[0].series.measurement, "dupnames");
+        assert_eq!(vals[0].series.tag_set.as_ref().unwrap()[0].0, "day");
+        assert_eq!(vals[0].series.tag_set.as_ref().unwrap()[0].1, "monday");
+
+        assert_eq!(vals[0].field_set[0].0, "day");
+        assert_eq!(vals[0].field_set[0].1.unwrap_f64(), 1.2_f64);
+        assert_eq!(vals[0].timestamp, None);
+    }
+
+    #[test]
     fn parse_single_field_unteger() {
         let input = "foo asdf=23u 1234";
         let vals = parse(input).unwrap();

--- a/mutable_batch_lp/src/lib.rs
+++ b/mutable_batch_lp/src/lib.rs
@@ -180,4 +180,17 @@ mod tests {
             &[batch["mem"].to_arrow(Selection::All).unwrap()]
         );
     }
+
+    #[test]
+    fn test_identical_tag_field_name() {
+        let lp = "machine,space=cupboard space=102.87 0";
+
+        let batch = lines_to_batches(lp, 5).expect("accepted valid line protocol");
+
+        assert_eq!(batch.len(), 2);
+        assert_batches_eq!(
+            &["?????",],
+            &[batch["machine"].to_arrow(Selection::All).unwrap()]
+        );
+    }
 }


### PR DESCRIPTION
This PR shows a demonstration of IOx not correctly handling valid line protocol, as described in more detail in #3150 