### PR TITLE
feat: compact_object_store_chunks : initial implementation that also lists steps to complete

### DIFF
--- a/data_types/src/chunk_metadata.rs
+++ b/data_types/src/chunk_metadata.rs
@@ -97,6 +97,9 @@ pub enum ChunkLifecycleAction {
     /// Chunk is in the process of being compacted
     Compacting,
 
+    /// Object Store Chunk is in the process of being compacted
+    CompactingObjectStore,
+
     /// Chunk is about to be dropped from memory and (if persisted) from object store
     Dropping,
 }
@@ -112,6 +115,7 @@ impl ChunkLifecycleAction {
         match self {
             Self::Persisting => "Persisting to Object Storage",
             Self::Compacting => "Compacting",
+            Self::CompactingObjectStore => "Compacting Object Store",
             Self::Dropping => "Dropping",
         }
     }

--- a/data_types/src/job.rs
+++ b/data_types/src/job.rs
@@ -24,6 +24,12 @@ pub enum Job {
         chunks: Vec<ChunkId>,
     },
 
+    /// Compact a set of object store chunks
+    CompactObjectStoreChunks {
+        partition: PartitionAddr,
+        chunks: Vec<ChunkId>,
+    },
+
     /// Split and persist a set of chunks
     PersistChunks {
         partition: PartitionAddr,
@@ -47,6 +53,7 @@ impl Job {
             Self::Dummy { db_name, .. } => db_name.as_ref(),
             Self::WriteChunk { chunk, .. } => Some(&chunk.db_name),
             Self::CompactChunks { partition, .. } => Some(&partition.db_name),
+            Self::CompactObjectStoreChunks { partition, .. } => Some(&partition.db_name),
             Self::PersistChunks { partition, .. } => Some(&partition.db_name),
             Self::DropChunk { chunk, .. } => Some(&chunk.db_name),
             Self::DropPartition { partition, .. } => Some(&partition.db_name),
@@ -60,6 +67,7 @@ impl Job {
             Self::Dummy { .. } => None,
             Self::WriteChunk { chunk, .. } => Some(&chunk.partition_key),
             Self::CompactChunks { partition, .. } => Some(&partition.partition_key),
+            Self::CompactObjectStoreChunks { partition, .. } => Some(&partition.partition_key),
             Self::PersistChunks { partition, .. } => Some(&partition.partition_key),
             Self::DropChunk { chunk, .. } => Some(&chunk.partition_key),
             Self::DropPartition { partition, .. } => Some(&partition.partition_key),
@@ -73,6 +81,7 @@ impl Job {
             Self::Dummy { .. } => None,
             Self::WriteChunk { chunk, .. } => Some(&chunk.table_name),
             Self::CompactChunks { partition, .. } => Some(&partition.table_name),
+            Self::CompactObjectStoreChunks { partition, .. } => Some(&partition.table_name),
             Self::PersistChunks { partition, .. } => Some(&partition.table_name),
             Self::DropChunk { chunk, .. } => Some(&chunk.table_name),
             Self::DropPartition { partition, .. } => Some(&partition.table_name),
@@ -86,6 +95,7 @@ impl Job {
             Self::Dummy { .. } => None,
             Self::WriteChunk { chunk, .. } => Some(vec![chunk.chunk_id]),
             Self::CompactChunks { chunks, .. } => Some(chunks.clone()),
+            Self::CompactObjectStoreChunks { chunks, .. } => Some(chunks.clone()),
             Self::PersistChunks { chunks, .. } => Some(chunks.clone()),
             Self::DropChunk { chunk, .. } => Some(vec![chunk.chunk_id]),
             Self::DropPartition { .. } => None,
@@ -99,6 +109,9 @@ impl Job {
             Self::Dummy { .. } => "Dummy Job, for testing",
             Self::WriteChunk { .. } => "Writing chunk to Object Storage",
             Self::CompactChunks { .. } => "Compacting chunks to ReadBuffer",
+            Self::CompactObjectStoreChunks { .. } => {
+                "Compacting Object Store chunks to an Object Store chunk"
+            }
             Self::PersistChunks { .. } => "Persisting chunks to object storage",
             Self::DropChunk { .. } => "Drop chunk from memory and (if persisted) from object store",
             Self::DropPartition { .. } => {
@@ -115,6 +128,9 @@ impl std::fmt::Display for Job {
             Job::Dummy { .. } => write!(f, "Job::Dummy"),
             Job::WriteChunk { chunk } => write!(f, "Job::WriteChunk({}))", chunk),
             Job::CompactChunks { partition, .. } => write!(f, "Job::CompactChunks({})", partition),
+            Job::CompactObjectStoreChunks { partition, .. } => {
+                write!(f, "Job::CompactObjectStoreChunks({})", partition)
+            }
             Job::PersistChunks { partition, .. } => write!(f, "Job::PersistChunks({})", partition),
             Job::DropChunk { chunk } => write!(f, "Job::DropChunk({})", chunk),
             Job::DropPartition { partition } => write!(f, "Job::DropPartition({})", partition),

--- a/generated_types/build.rs
+++ b/generated_types/build.rs
@@ -88,6 +88,7 @@ fn generate_grpc_types(root: &Path) -> Result<()> {
             ".influxdata.iox.management.v1.Chunk.id",
             ".influxdata.iox.management.v1.ClosePartitionChunkRequest.chunk_id",
             ".influxdata.iox.management.v1.CompactChunks.chunks",
+            ".influxdata.iox.management.v1.CompactObjectStoreChunks.chunks",
             ".influxdata.iox.management.v1.DropChunk.chunk_id",
             ".influxdata.iox.management.v1.PersistChunks.chunks",
             ".influxdata.iox.management.v1.WriteChunk.chunk_id",

--- a/generated_types/protos/influxdata/iox/management/v1/chunk.proto
+++ b/generated_types/protos/influxdata/iox/management/v1/chunk.proto
@@ -42,6 +42,9 @@ enum ChunkLifecycleAction {
 
   /// Chunk is about to be dropped from memory and (if persisted) from object store.
   CHUNK_LIFECYCLE_ACTION_DROPPING = 4;
+
+  /// Chunk is in the process of being compacted
+  CHUNK_LIFECYCLE_ACTION_COMPACTING_OBJECT_STORE = 5;
 }
 
 

--- a/generated_types/protos/influxdata/iox/management/v1/jobs.proto
+++ b/generated_types/protos/influxdata/iox/management/v1/jobs.proto
@@ -39,6 +39,7 @@ message OperationMetadata {
     PersistChunks persist_chunks = 11;
     DropChunk drop_chunk = 12;
     DropPartition drop_partition = 17;
+    CompactObjectStoreChunks compact_object_store_chunks = 18;
   }
 }
 
@@ -91,6 +92,23 @@ message CompactChunks {
   repeated bytes chunks = 5;
 }
 
+// Compact chunks into a single chunk
+message CompactObjectStoreChunks {
+    // name of the database
+    string db_name = 1;
+ 
+    // partition key
+    string partition_key = 2;
+ 
+    // table name
+    string table_name = 3;
+ 
+    // chunk_id
+    // UUID is stored as 16 bytes in big-endian order.
+    repeated bytes chunks = 4;
+  }
+
+  
 // Split and write chunks to object store
 message PersistChunks {
   // name of the database

--- a/generated_types/src/chunk.rs
+++ b/generated_types/src/chunk.rs
@@ -64,6 +64,7 @@ impl From<Option<ChunkLifecycleAction>> for management::ChunkLifecycleAction {
         match lifecycle_action {
             Some(ChunkLifecycleAction::Persisting) => Self::Persisting,
             Some(ChunkLifecycleAction::Compacting) => Self::Compacting,
+            Some(ChunkLifecycleAction::CompactingObjectStore) => Self::CompactingObjectStore,
             Some(ChunkLifecycleAction::Dropping) => Self::Dropping,
             None => Self::Unspecified,
         }
@@ -152,6 +153,9 @@ impl TryFrom<management::ChunkLifecycleAction> for Option<ChunkLifecycleAction> 
             }
             management::ChunkLifecycleAction::Compacting => {
                 Ok(Some(ChunkLifecycleAction::Compacting))
+            }
+            management::ChunkLifecycleAction::CompactingObjectStore => {
+                Ok(Some(ChunkLifecycleAction::CompactingObjectStore))
             }
             management::ChunkLifecycleAction::Dropping => Ok(Some(ChunkLifecycleAction::Dropping)),
             management::ChunkLifecycleAction::Unspecified => Ok(None),

--- a/generated_types/src/job.rs
+++ b/generated_types/src/job.rs
@@ -27,6 +27,14 @@ impl From<Job> for management::operation_metadata::Job {
                     chunks: chunks.into_iter().map(|chunk_id| chunk_id.into()).collect(),
                 })
             }
+            Job::CompactObjectStoreChunks { partition, chunks } => {
+                Self::CompactObjectStoreChunks(management::CompactObjectStoreChunks {
+                    db_name: partition.db_name.to_string(),
+                    partition_key: partition.partition_key.to_string(),
+                    table_name: partition.table_name.to_string(),
+                    chunks: chunks.into_iter().map(|chunk_id| chunk_id.into()).collect(),
+                })
+            }
             Job::PersistChunks { partition, chunks } => {
                 Self::PersistChunks(management::PersistChunks {
                     db_name: partition.db_name.to_string(),

--- a/lifecycle/src/lib.rs
+++ b/lifecycle/src/lib.rs
@@ -79,6 +79,12 @@ pub trait LockablePartition: Sized + std::fmt::Display {
         chunks: Vec<LifecycleWriteGuard<'_, <Self::Chunk as LockableChunk>::Chunk, Self::Chunk>>,
     ) -> Result<TaskTracker<<Self::Chunk as LockableChunk>::Job>, Self::Error>;
 
+    /// Compact object store chunks into a single object store chunk
+    fn compact_object_store_chunks(
+        partition: LifecycleWriteGuard<'_, Self::Partition, Self>,
+        chunks: Vec<LifecycleWriteGuard<'_, <Self::Chunk as LockableChunk>::Chunk, Self::Chunk>>,
+    ) -> Result<TaskTracker<<Self::Chunk as LockableChunk>::Job>, Self::Error>;
+
     /// Returns a PersistHandle for the provided partition, and the
     /// timestamp up to which to to flush
     ///

--- a/lifecycle/src/policy.rs
+++ b/lifecycle/src/policy.rs
@@ -706,7 +706,6 @@ mod tests {
         Drop(ChunkId),
         Unload(ChunkId),
         Compact(Vec<ChunkId>),
-        CompactOS(Vec<ChunkId>),
         Persist(Vec<ChunkId>),
     }
 
@@ -913,8 +912,7 @@ mod tests {
             _partition: LifecycleWriteGuard<'_, TestPartition, Self>,
             _chunks: Vec<LifecycleWriteGuard<'_, TestChunk, Self::Chunk>>,
         ) -> Result<TaskTracker<()>, Self::Error> {
-            // This is just a trait function that this test may not need
-            unimplemented!();
+            unimplemented!("The test does not need compact os chunks");
         }
 
         fn prepare_persist(

--- a/lifecycle/src/policy.rs
+++ b/lifecycle/src/policy.rs
@@ -910,17 +910,11 @@ mod tests {
         }
 
         fn compact_object_store_chunks(
-            partition: LifecycleWriteGuard<'_, TestPartition, Self>,
-            chunks: Vec<LifecycleWriteGuard<'_, TestChunk, Self::Chunk>>,
+            _partition: LifecycleWriteGuard<'_, TestPartition, Self>,
+            _chunks: Vec<LifecycleWriteGuard<'_, TestChunk, Self::Chunk>>,
         ) -> Result<TaskTracker<()>, Self::Error> {
             // This is just a trait function that this test may not need
-            // Nothing is compacted in this function yet
-            // If you want this functionality, import and invoke compact_object_store_chunks
-            let event = MoverEvents::CompactOS(chunks.iter().map(|x| x.addr.chunk_id).collect());
-            let db = partition.data().db;
-            db.events.write().push(event);
-
-            Ok(db.registry.lock().complete(()))
+            unimplemented!();
         }
 
         fn prepare_persist(

--- a/lifecycle/src/policy.rs
+++ b/lifecycle/src/policy.rs
@@ -706,6 +706,7 @@ mod tests {
         Drop(ChunkId),
         Unload(ChunkId),
         Compact(Vec<ChunkId>),
+        CompactOS(Vec<ChunkId>),
         Persist(Vec<ChunkId>),
     }
 
@@ -902,6 +903,20 @@ mod tests {
 
             let event = MoverEvents::Compact(chunks.iter().map(|x| x.addr.chunk_id).collect());
 
+            let db = partition.data().db;
+            db.events.write().push(event);
+
+            Ok(db.registry.lock().complete(()))
+        }
+
+        fn compact_object_store_chunks(
+            partition: LifecycleWriteGuard<'_, TestPartition, Self>,
+            chunks: Vec<LifecycleWriteGuard<'_, TestChunk, Self::Chunk>>,
+        ) -> Result<TaskTracker<()>, Self::Error> {
+            // This is just a trait function that this test may not need
+            // Nothing is compacted in this function yet
+            // If you want this functionality, import and invoke compact_object_store_chunks
+            let event = MoverEvents::CompactOS(chunks.iter().map(|x| x.addr.chunk_id).collect());
             let db = partition.data().db;
             db.events.write().push(event);
 

--- a/server/src/db.rs
+++ b/server/src/db.rs
@@ -676,7 +676,9 @@ impl Db {
             let partition = partition.upgrade();
 
             // invoke compact
-            let (_, fut) = lifecycle::compact_object_store::compact_object_store_chunks(partition, chunks).context(LifecycleError)?;
+            let (_, fut) =
+                lifecycle::compact_object_store::compact_object_store_chunks(partition, chunks)
+                    .context(LifecycleError)?;
             fut
         };
 

--- a/server/src/db.rs
+++ b/server/src/db.rs
@@ -651,6 +651,38 @@ impl Db {
         fut.await.context(TaskCancelled)?.context(LifecycleError)
     }
 
+    /// Compact all provided persisted chunks
+    pub async fn compact_object_store_chunks(
+        self: &Arc<Self>,
+        table_name: &str,
+        partition_key: &str,
+        chunk_ids: Vec<ChunkId>,
+    ) -> Result<Option<Arc<DbChunk>>> {
+        if chunk_ids.is_empty() {
+            return Ok(None);
+        }
+
+        // Use explicit scope to ensure the async generator doesn't
+        // assume the locks have to possibly live across the `await`
+        let fut = {
+            let partition = self.partition(table_name, partition_key)?;
+            let partition = LockableCatalogPartition::new(Arc::clone(self), partition);
+            let partition = partition.read();
+
+            // todo: set these chunks
+            let chunks = vec![];
+
+            // Lock partition for write
+            let partition = partition.upgrade();
+
+            // invoke compact
+            let (_, fut) = lifecycle::compact_object_store::compact_object_store_chunks(partition, chunks).context(LifecycleError)?;
+            fut
+        };
+
+        fut.await.context(TaskCancelled)?.context(LifecycleError)
+    }
+
     /// Persist given partition.
     ///
     /// If `force` is `true` will persist all unpersisted data regardless of arrival time

--- a/server/src/db/lifecycle.rs
+++ b/server/src/db/lifecycle.rs
@@ -33,6 +33,7 @@ pub(crate) use persist::persist_chunks;
 pub(crate) use unload::unload_read_buffer_chunk;
 
 mod compact;
+pub(crate) mod compact_object_store;
 mod drop;
 mod error;
 mod persist;
@@ -198,6 +199,17 @@ impl LockablePartition for LockableCatalogPartition {
         info!(table=%partition.table_name(), partition=%partition.partition_key(), "compacting chunks");
         let (tracker, fut) = compact::compact_chunks(partition, chunks)?;
         let _ = tokio::spawn(async move { fut.await.log_if_error("compacting chunks") });
+        Ok(tracker)
+    }
+
+    fn compact_object_store_chunks(
+        partition: LifecycleWriteGuard<'_, Partition, Self>,
+        chunks: Vec<LifecycleWriteGuard<'_, CatalogChunk, Self::Chunk>>,
+    ) -> Result<TaskTracker<Job>, Self::Error> { 
+        info!(table=%partition.table_name(), partition=%partition.partition_key(), "compacting object store chunks");
+        let (tracker, fut) = compact_object_store::compact_object_store_chunks(partition, chunks)?;
+        let _ =
+            tokio::spawn(async move { fut.await.log_if_error("compacting object store chunks") });
         Ok(tracker)
     }
 

--- a/server/src/db/lifecycle.rs
+++ b/server/src/db/lifecycle.rs
@@ -205,7 +205,7 @@ impl LockablePartition for LockableCatalogPartition {
     fn compact_object_store_chunks(
         partition: LifecycleWriteGuard<'_, Partition, Self>,
         chunks: Vec<LifecycleWriteGuard<'_, CatalogChunk, Self::Chunk>>,
-    ) -> Result<TaskTracker<Job>, Self::Error> { 
+    ) -> Result<TaskTracker<Job>, Self::Error> {
         info!(table=%partition.table_name(), partition=%partition.partition_key(), "compacting object store chunks");
         let (tracker, fut) = compact_object_store::compact_object_store_chunks(partition, chunks)?;
         let _ =

--- a/server/src/db/lifecycle/compact_object_store.rs
+++ b/server/src/db/lifecycle/compact_object_store.rs
@@ -1,0 +1,357 @@
+//! This module compact object store chunks (aka persisted chunks)
+
+use super::{
+    error::{ChunksNotContiguous, ChunksNotInPartition, EmptyChunks},
+    LockableCatalogChunk, LockableCatalogPartition, Result,
+};
+use crate::{Db, db::{DbChunk, catalog::{chunk::CatalogChunk, partition::Partition}, lifecycle::merge_schemas}};
+use data_types::{chunk_metadata::ChunkOrder, delete_predicate::DeletePredicate, job::Job};
+use datafusion::physical_plan::SendableRecordBatchStream;
+use futures::Future;
+use lifecycle::LifecycleWriteGuard;
+use observability_deps::tracing::info;
+use query::{compute_sort_key, exec::ExecutorType, frontend::reorg::ReorgPlanner, QueryChunkMeta};
+use schema::Schema;
+use std::{
+    collections::{BTreeSet, HashSet},
+    sync::Arc,
+};
+use time::Time;
+use tracker::{TaskRegistration, TaskTracker, TrackedFuture, TrackedFutureExt};
+
+// Compact the provided object store chunks into a single object store chunk,
+/// returning the newly created chunk
+///
+/// The function will error if
+///    . No chunks are provided
+///    . provided chunk(s) not belong to the provided partition
+///    . not all provided chunks are persisted
+///    . the provided chunks are not contiguous
+/// Implementation steps
+///   . Verify the eligible of the input OS chunks and mark them for ready to compact
+///   . Compact the chunks
+///   . Persist the compacted output into an OS chunk
+///   . Drop old chunks and make the new chunk available in one transaction
+pub(crate) fn compact_object_store_chunks(
+    partition: LifecycleWriteGuard<'_, Partition, LockableCatalogPartition>,
+    chunks: Vec<LifecycleWriteGuard<'_, CatalogChunk, LockableCatalogChunk>>,
+) ->Result<(
+    TaskTracker<Job>,
+    TrackedFuture<impl Future<Output = Result<Option<Arc<DbChunk>>>> + Send>,
+)> {
+    // Track compaction duration
+    let now = std::time::Instant::now();
+    // Register the  compacting job
+    let db = Arc::clone(&partition.data().db);
+    let partition_addr = partition.addr().clone();
+    let chunk_ids: Vec<_> = chunks.iter().map(|x| x.id()).collect();
+    info!(%partition_addr, ?chunk_ids, "compacting object store chunks");
+    let (tracker, registration) = db.jobs.register(Job::CompactObjectStoreChunks {
+        partition: partition.addr().clone(),
+        chunks: chunk_ids.clone(),
+    });
+
+    // Verify input while marking and snapshoting the chunks for compacting
+    let (
+        _time_of_first_write,
+        _time_of_last_write,
+        input_rows,
+        _delete_predicates_before,
+        _query_chunks,
+        _min_order,
+    ) = mark_chunks_to_compact(partition, chunks, &registration)?;
+
+    let fut = async move {
+        // track future runtime
+        let fut_now = std::time::Instant::now();
+
+        // Compact & persist the chunks into one chunk
+        // let (_compacted_stream, _schema, sort_key) = compact_chunks(&db, &query_chunks).await?;
+        let compacted_rows = 0; // todo: set it here
+
+        // Persist the newly created chunk
+        // todo
+
+        // Drop old chunks and make the new chunk available in one transaction
+        // todo
+
+        // Log the summary
+        let elapsed = now.elapsed();
+        // input rows per second
+        let throughput = (input_rows as u128 * 1_000_000_000) / elapsed.as_nanos();
+        info!(input_chunks=chunk_ids.len(),
+            %input_rows, %compacted_rows,
+            //%sort_key, 
+            compaction_took = ?elapsed,
+            fut_execution_duration= ?fut_now.elapsed(),
+            rows_per_sec=?throughput,
+            "object store chunk(s) compacted");
+
+        // todo: remove these temp lines when the todos above done
+        // Temp chunk to avoid compile error
+        // let metric_registry = Arc::clone(&db.metric_registry);
+        // let chunk = collect_rub(compacted_stream, &partition_addr, metric_registry.as_ref()).await.unwrap().unwrap();
+        // let (_, new_chunk) = partition.create_rub_chunk(
+        //     chunk,
+        //     time_of_first_write,
+        //     time_of_last_write,
+        //     schema,
+        //     vec![],
+        //     min_order,
+        //     None,
+        // );
+        // let chunk = DbChunk::snapshot(&new_chunk.read());
+        // Ok(Some(chunk))
+        Ok(None)
+    };
+
+    Ok((tracker, fut.track(registration)))
+}
+
+/// Verify eligible compacting chunks, mark and snapshot them to get ready for compacting
+/// Throws error if
+///    . provided chunks do not belong to the provided partition
+///    . not all provided chunks are persisted
+///    . the provided chunks are not contiguous
+/// Returns:
+///    . min (time_of_first_write) of provided chunks
+///    . max (time_of_last_write) of provided chunks
+///    . total rows of the provided chunks to be compacted
+///    . all delete predicates of the provided chunks
+///    . snapshot of the provided chunks
+///    . min(order) of the provided chunks
+#[warn(clippy::type_complexity)]
+fn mark_chunks_to_compact(
+    partition: LifecycleWriteGuard<'_, Partition, LockableCatalogPartition>,
+    chunks: Vec<LifecycleWriteGuard<'_, CatalogChunk, LockableCatalogChunk>>,
+    registration: &TaskRegistration,
+) -> Result<(
+    Time,
+    Time,
+    u64,
+    HashSet<Arc<DeletePredicate>>,
+    Vec<Arc<DbChunk>>,
+    ChunkOrder,
+)> {
+    // no chunks provided
+    if chunks.is_empty() {
+        return EmptyChunks {}.fail();
+    }
+
+    let db = Arc::clone(&partition.data().db);
+    let partition_addr = partition.addr().clone();
+
+    // Mark and snapshot chunks, then drop locks
+    let mut time_of_first_write: Option<Time> = None;
+    let mut time_of_last_write: Option<Time> = None;
+    let mut chunk_orders = BTreeSet::new();
+    let mut input_rows = 0;
+    let mut delete_predicates: HashSet<Arc<DeletePredicate>> = HashSet::new();
+    let mut min_order = ChunkOrder::MAX;
+
+    let query_chunks = chunks
+        .into_iter()
+        .map(|mut chunk| {
+            // Sanity-check
+            assert!(Arc::ptr_eq(&db, &chunk.data().db));
+            assert_eq!(
+                chunk.table_name().as_ref(),
+                partition_addr.table_name.as_ref()
+            );
+
+            // provided chunks not in the provided partition
+            if chunk.key() != partition_addr.partition_key.as_ref() {
+                return ChunksNotInPartition {}.fail();
+            }
+
+            input_rows += chunk.table_summary().total_count();
+
+            let candidate_first = chunk.time_of_first_write();
+            time_of_first_write = time_of_first_write
+                .map(|prev_first| prev_first.min(candidate_first))
+                .or(Some(candidate_first));
+
+            let candidate_last = chunk.time_of_last_write();
+            time_of_last_write = time_of_last_write
+                .map(|prev_last| prev_last.max(candidate_last))
+                .or(Some(candidate_last));
+
+            delete_predicates.extend(chunk.delete_predicates().iter().cloned());
+
+            min_order = min_order.min(chunk.order());
+            chunk_orders.insert(chunk.order());
+
+            // Set chunk in the right action which is compacting object store
+            // This function will also error out if the chunk is not yet persisted
+            chunk.set_compacting_object_store(registration)?;
+            Ok(DbChunk::snapshot(&*chunk))
+        })
+        .collect::<Result<Vec<_>>>()?;
+
+    // Verify if all the provided chunks are contiguous
+    if !partition.contiguous_object_store_chunks(&chunk_orders) {
+        return ChunksNotContiguous {}.fail();
+    }
+
+    let time_of_first_write = time_of_first_write.expect("Should have had a first write somewhere");
+    let time_of_last_write = time_of_last_write.expect("Should have had a last write somewhere");
+
+    // drop partition lock
+    let _partition = partition.into_data().partition;
+
+    Ok((
+        time_of_first_write,
+        time_of_last_write,
+        input_rows,
+        delete_predicates,
+        query_chunks,
+        min_order,
+    ))
+}
+
+/// Create query plan to compact the given DbChunks and return its output stream
+/// Return:
+///    . stream of output record batch of the scanned chunks Result<SendableRecordBatchStream>
+///        Deleted and duplicated data will be eliminated during the scan
+///    . Output schema of the compact plan
+///    . Sort Key of the output data
+async fn compact_chunks(
+    db: &Db,
+    query_chunks: &[Arc<DbChunk>],
+) -> Result<(SendableRecordBatchStream, Arc<Schema>, String)> {
+    // Tracking metric
+    let ctx = db.exec.new_context(ExecutorType::Reorg);
+
+    // Compute the sorted output of the compacting result
+    let sort_key = compute_sort_key(query_chunks.iter().map(|x| x.summary()));
+    let sort_key_str = format!("\"{}\"", sort_key); // for logging
+
+    // Merge schema of the compacting chunks
+    let merged_schema = merge_schemas(query_chunks);
+
+    // Build compact query plan
+    let (plan_schema, plan) = ReorgPlanner::new().compact_plan(
+        Arc::clone(&merged_schema),
+        query_chunks.iter().map(Arc::clone),
+        sort_key,
+    )?;
+    let physical_plan = ctx.prepare_plan(&plan).await?;
+
+    // run the plan
+    let stream = ctx.execute_stream(physical_plan).await?;
+
+    Ok((stream, plan_schema, sort_key_str))
+}
+
+////////////////////////////////////////////////////////////
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{db::test_helpers::write_lp, utils::TestDb, Db};
+
+    use data_types::database_rules::LifecycleRules;
+    use lifecycle::{LockableChunk, LockablePartition};
+    use query::{QueryChunk, QueryDatabase};
+    use std::{
+        num::{NonZeroU32, NonZeroU64},
+        time::Duration,
+    };
+
+    // Todo: this as copied from persist.rs and should be revived to match the needs here
+    async fn test_db() -> (Arc<Db>, Arc<time::MockProvider>) {
+        let time_provider = Arc::new(time::MockProvider::new(Time::from_timestamp(3409, 45)));
+        let test_db = TestDb::builder()
+            .lifecycle_rules(LifecycleRules {
+                late_arrive_window_seconds: NonZeroU32::new(1).unwrap(),
+                worker_backoff_millis: NonZeroU64::new(u64::MAX).unwrap(),
+                ..Default::default()
+            })
+            .time_provider(Arc::<time::MockProvider>::clone(&time_provider))
+            .build()
+            .await;
+
+        (test_db.db, time_provider)
+    }
+
+    #[tokio::test]
+    async fn test_compact_os_negative() {
+        // Tests that nothing will get compacted
+
+        test_helpers::maybe_start_logging();
+
+        let (db, time) = test_db().await;
+        let late_arrival = Duration::from_secs(1);
+        write_lp(db.as_ref(), "cpu,tag1=cupcakes bar=1 10").await;
+        time.inc(late_arrival);
+
+        let partition_keys = db.partition_keys().unwrap();
+        assert_eq!(partition_keys.len(), 1);
+        let db_partition = db.partition("cpu", &partition_keys[0]).unwrap();
+
+        // Test 1: no chunks provided
+        let partition = LockableCatalogPartition::new(Arc::clone(&db), Arc::clone(&db_partition));
+        let partition = partition.read().upgrade();
+        let compact_no_chunks = compact_object_store_chunks(partition, vec![]);
+        assert!(compact_no_chunks.is_err());
+
+        // test 2: persisted non persisted chunks
+        let partition = LockableCatalogPartition::new(Arc::clone(&db), Arc::clone(&db_partition));
+        let partition = partition.read();
+        let chunks = LockablePartition::chunks(&partition);
+        assert_eq!(chunks.len(), 1);
+        let partition = partition.upgrade();
+        let chunk = chunks[0].read();
+        let compact_non_persisted_chunks =
+            compact_object_store_chunks(partition, vec![chunk.upgrade()]);
+        assert!(compact_non_persisted_chunks.is_err());
+
+        // test 3: persisted non-contiguous chunks
+        // persist chunk 1
+        db.persist_partition("cpu", partition_keys[0].as_str(), true)
+            .await
+            .unwrap()
+            .unwrap()
+            .id();
+        //
+        // persist chunk 2
+        write_lp(db.as_ref(), "cpu,tag1=chunk2,tag2=a bar=2 10").await;
+        db.persist_partition("cpu", partition_keys[0].as_str(), true)
+            .await
+            .unwrap()
+            .unwrap()
+            .id();
+        //
+        // persist chunk 3
+        write_lp(db.as_ref(), "cpu,tag1=chunk3,tag2=a bar=2 30").await;
+        db.persist_partition("cpu", partition_keys[0].as_str(), true)
+            .await
+            .unwrap()
+            .unwrap()
+            .id();
+        //
+        // Add a MUB
+        write_lp(db.as_ref(), "cpu,tag1=chunk4,tag2=a bar=2 40").await;
+        // todo: Need to ask Marco why there is no handle created here
+        time.inc(Duration::from_secs(40));
+        //
+        // let compact 2 non contiguous chunk 1 and chunk 3
+        let partition = LockableCatalogPartition::new(Arc::clone(&db), Arc::clone(&db_partition));
+        let partition = partition.read();
+        let chunks = LockablePartition::chunks(&partition);
+        assert_eq!(chunks.len(), 4);
+        let partition = partition.upgrade();
+        let chunk1 = chunks[0].read();
+        let chunk3 = chunks[2].read();
+        let compact_non_persisted_chunks =
+            compact_object_store_chunks(partition, vec![chunk1.upgrade(), chunk3.upgrade()]);
+        assert!(compact_non_persisted_chunks.is_err());
+    }
+
+    // todo: add tests
+    //   . compact 2 contiguous OS chunks
+    //   . compact 3 chunks with duplicated data
+    //  . compact with deletes before compacting
+    //  . compact with deletes happening during compaction
+    //   . replay
+}

--- a/server/src/db/lifecycle/error.rs
+++ b/server/src/db/lifecycle/error.rs
@@ -57,6 +57,17 @@ pub enum Error {
 
     #[snafu(display("Cannot drop unpersisted chunk: {}", addr))]
     CannotDropUnpersistedChunk { addr: ChunkAddr },
+
+    #[snafu(display("No object store chunks provided for compacting"))]
+    EmptyChunks {},
+
+    #[snafu(display(
+        "Cannot compact chunks because at least one does not belong to the given partition"
+    ))]
+    ChunksNotInPartition {},
+
+    #[snafu(display("Cannot compact the provided persisted chunks. They are not contiguous"))]
+    ChunksNotContiguous {},
 }
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;

--- a/server/src/db/lifecycle/error.rs
+++ b/server/src/db/lifecycle/error.rs
@@ -39,6 +39,11 @@ pub enum Error {
         chunk_id: u32,
     },
 
+    #[snafu(display("Error reading from object store: {}", source))]
+    ReadingObjectStore {
+        source: parquet_file::storage::Error,
+    },
+
     #[snafu(display("Error writing to object store: {}", source))]
     WritingToObjectStore {
         source: parquet_file::storage::Error,


### PR DESCRIPTION
This is the first part of  #3089. The function is available but only step 1 is implemented and tested. Step 2-4 will be in the following PRs

- [x] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb_iox/blob/main/README.md).
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
