### PR TITLE
(WIP) feat: Only create columns for system tables that are requested

### DIFF
--- a/server/src/db/system_tables/chunks.rs
+++ b/server/src/db/system_tables/chunks.rs
@@ -9,6 +9,8 @@ use data_types::{chunk_metadata::ChunkSummary, error::ErrorLogger};
 use std::sync::Arc;
 use time::Time;
 
+use super::CreationOptions;
+
 /// Implementation of system.chunks table
 #[derive(Debug)]
 pub(super) struct ChunksTable {
@@ -30,7 +32,7 @@ impl IoxSystemTable for ChunksTable {
         Arc::clone(&self.schema)
     }
 
-    fn batch(&self) -> Result<RecordBatch> {
+    fn batch(&self, options: CreationOptions) -> Result<RecordBatch> {
         from_chunk_summaries(self.schema(), self.catalog.chunk_summaries())
             .log_if_error("system.chunks table")
     }

--- a/server/src/db/system_tables/chunks.rs
+++ b/server/src/db/system_tables/chunks.rs
@@ -20,6 +20,9 @@ pub(super) struct ChunksTable {
 
 impl ChunksTable {
     pub(super) fn new(catalog: Arc<Catalog>) -> Self {
+        // let builder = SystemTableCreator::new()
+        //     .with_column(...);
+
         Self {
             schema: chunk_summaries_schema(),
             catalog,
@@ -37,6 +40,9 @@ impl IoxSystemTable for ChunksTable {
             .log_if_error("system.chunks table")
     }
 }
+
+
+
 
 fn chunk_summaries_schema() -> SchemaRef {
     let ts = DataType::Timestamp(TimeUnit::Nanosecond, None);

--- a/server/src/db/system_tables/columns.rs
+++ b/server/src/db/system_tables/columns.rs
@@ -12,6 +12,8 @@ use data_types::{
 };
 use std::{collections::HashMap, sync::Arc};
 
+use super::CreationOptions;
+
 /// Implementation of `system.columns` system table
 #[derive(Debug)]
 pub(super) struct ColumnsTable {
@@ -32,7 +34,7 @@ impl IoxSystemTable for ColumnsTable {
     fn schema(&self) -> SchemaRef {
         Arc::clone(&self.schema)
     }
-    fn batch(&self) -> Result<RecordBatch> {
+    fn batch(&self, options: CreationOptions) -> Result<RecordBatch> {
         from_partition_summaries(self.schema(), self.catalog.partition_summaries())
             .log_if_error("system.columns table")
     }
@@ -112,7 +114,7 @@ impl IoxSystemTable for ChunkColumnsTable {
         Arc::clone(&self.schema)
     }
 
-    fn batch(&self) -> Result<RecordBatch> {
+    fn batch(&self, options: CreationOptions) -> Result<RecordBatch> {
         assemble_chunk_columns(self.schema(), self.catalog.detailed_chunk_summaries())
             .log_if_error("system.column_chunks table")
     }

--- a/server/src/db/system_tables/operations.rs
+++ b/server/src/db/system_tables/operations.rs
@@ -13,6 +13,8 @@ use tracker::TaskTracker;
 use crate::db::system_tables::IoxSystemTable;
 use crate::JobRegistry;
 
+use super::CreationOptions;
+
 /// Implementation of system.operations table
 #[derive(Debug)]
 pub(super) struct OperationsTable {
@@ -36,7 +38,7 @@ impl IoxSystemTable for OperationsTable {
         Arc::clone(&self.schema)
     }
 
-    fn batch(&self) -> Result<RecordBatch> {
+    fn batch(&self, options: CreationOptions) -> Result<RecordBatch> {
         from_task_trackers(self.schema(), &self.db_name, self.jobs.tracked())
             .log_if_error("system.operations table")
     }

--- a/server/src/db/system_tables/persistence.rs
+++ b/server/src/db/system_tables/persistence.rs
@@ -12,6 +12,8 @@ use data_types::write_summary::WriteSummary;
 use crate::db::catalog::Catalog;
 use crate::db::system_tables::IoxSystemTable;
 
+use super::CreationOptions;
+
 /// Implementation of system.persistence_windows table
 #[derive(Debug)]
 pub(super) struct PersistenceWindowsTable {
@@ -33,7 +35,7 @@ impl IoxSystemTable for PersistenceWindowsTable {
         Arc::clone(&self.schema)
     }
 
-    fn batch(&self) -> Result<RecordBatch> {
+    fn batch(&self, options: CreationOptions) -> Result<RecordBatch> {
         from_write_summaries(self.schema(), self.catalog.persistence_summaries())
             .log_if_error("system.persistence_windows table")
     }


### PR DESCRIPTION
Editor's note: throwing this up as I switch to something else -- I sketched out an interface I would like but it needs some touch up and then to refactor system table creation to use it


Builds on https://github.com/influxdata/influxdb_iox/pull/3155

Related to  https://github.com/influxdata/influxdb_iox/issues/2477


# Rationale
1. Creating the raw data for the `RecordBatch` for system tables takes significant time for large databases
2. DataFusion already does "projection pushdown" (aka specifies what columns are needed)


Changes:
1. Interpret and use projection from DataFusion
2. XXX
