### PR TITLE
fix: do not forget outputs of file-based write buffer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5130,6 +5130,7 @@ dependencies = [
  "tempfile",
  "time 0.1.0",
  "tokio",
+ "tokio-util",
  "trace",
  "trace_http",
  "uuid",

--- a/write_buffer/Cargo.toml
+++ b/write_buffer/Cargo.toml
@@ -22,6 +22,7 @@ prost = "0.8"
 rdkafka = "0.27.0"
 time = { path = "../time" }
 tokio = { version = "1.13", features = ["macros", "fs"] }
+tokio-util = "0.6.9"
 trace = { path = "../trace" }
 trace_http = { path = "../trace_http" }
 uuid = { version = "0.8", features = ["serde", "v4"] }

--- a/write_buffer/src/core.rs
+++ b/write_buffer/src/core.rs
@@ -287,7 +287,7 @@ pub mod test_utils {
 
         // re-creating stream after reading remembers offset, but wait a bit to provoke the stream to buffer some
         // entries
-        tokio::time::sleep(Duration::from_millis(100)).await;
+        tokio::time::sleep(Duration::from_millis(10)).await;
         drop(stream);
         drop(streams);
         let mut streams = reader.streams();

--- a/write_buffer/src/core.rs
+++ b/write_buffer/src/core.rs
@@ -285,7 +285,9 @@ pub mod test_utils {
         let (_sequencer_id, mut stream) = map_pop_first(&mut streams).unwrap();
         assert_write_op_eq(&stream.stream.next().await.unwrap().unwrap(), &w1);
 
-        // re-creating stream after reading remembers offset
+        // re-creating stream after reading remembers offset, but wait a bit to provoke the stream to buffer some
+        // entries
+        tokio::time::sleep(Duration::from_millis(100)).await;
         drop(stream);
         drop(streams);
         let mut streams = reader.streams();

--- a/write_buffer/src/file.rs
+++ b/write_buffer/src/file.rs
@@ -123,9 +123,10 @@ use crate::codec::{ContentType, IoxHeaders};
 use async_trait::async_trait;
 use data_types::{sequence::Sequence, write_buffer::WriteBufferCreationConfig};
 use dml::{DmlMeta, DmlOperation};
-use futures::{future::BoxFuture, Future, FutureExt, Stream, StreamExt};
+use futures::{FutureExt, Stream, StreamExt};
 use pin_project::pin_project;
 use time::{Time, TimeProvider};
+use tokio_util::sync::ReusableBoxFuture;
 use trace::TraceCollector;
 use uuid::Uuid;
 
@@ -344,9 +345,7 @@ impl WriteBufferReading for FileBufferConsumer {
 
 #[pin_project]
 struct ConsumerStream {
-    #[pin]
-    fut: Option<BoxFuture<'static, Result<DmlOperation, WriteBufferError>>>,
-    was_ready: bool,
+    fut: ReusableBoxFuture<Result<DmlOperation, WriteBufferError>>,
     sequencer_id: u32,
     path: PathBuf,
     next_sequence_number: Arc<AtomicU64>,
@@ -361,8 +360,12 @@ impl ConsumerStream {
         trace_collector: Option<Arc<dyn TraceCollector>>,
     ) -> Self {
         Self {
-            fut: None,
-            was_ready: false,
+            fut: ReusableBoxFuture::new(Self::poll_next_inner(
+                sequencer_id,
+                path.clone(),
+                Arc::clone(&next_sequence_number),
+                trace_collector.clone(),
+            )),
             sequencer_id,
             path,
             next_sequence_number,
@@ -370,53 +373,57 @@ impl ConsumerStream {
         }
     }
 
-    fn create_future(
+    async fn poll_next_inner(
         sequencer_id: u32,
         path: PathBuf,
         next_sequence_number: Arc<AtomicU64>,
         trace_collector: Option<Arc<dyn TraceCollector>>,
-    ) -> BoxFuture<'static, Result<DmlOperation, WriteBufferError>> {
-        let fut = async move {
-            loop {
-                let sequence_number = next_sequence_number.load(Ordering::SeqCst);
+    ) -> Result<DmlOperation, WriteBufferError> {
+        loop {
+            let sequence_number = next_sequence_number.load(Ordering::SeqCst);
 
-                // read file
-                let file_path = path.join(sequence_number.to_string());
-                let msg = match tokio::fs::read(&file_path).await {
-                    Ok(data) => {
-                        // decode file
-                        let sequence = Sequence {
-                            id: sequencer_id,
-                            number: sequence_number,
-                        };
-                        match Self::decode_file(data, sequence, trace_collector.clone()) {
-                            Ok(write) => {
-                                match next_sequence_number.compare_exchange(
-                                    sequence_number,
-                                    sequence_number + 1,
-                                    Ordering::SeqCst,
-                                    Ordering::SeqCst,
-                                ) {
-                                    Ok(_) => {
-                                        // can send to output
-                                        Ok(write)
-                                    }
-                                    Err(_) => {
-                                        // interleaving change, retry
-                                        continue;
-                                    }
+            // read file
+            let file_path = path.join(sequence_number.to_string());
+            let msg = match tokio::fs::read(&file_path).await {
+                Ok(data) => {
+                    // decode file
+                    let sequence = Sequence {
+                        id: sequencer_id,
+                        number: sequence_number,
+                    };
+                    match Self::decode_file(data, sequence, trace_collector.clone()) {
+                        Ok(write) => {
+                            match next_sequence_number.compare_exchange(
+                                sequence_number,
+                                sequence_number + 1,
+                                Ordering::SeqCst,
+                                Ordering::SeqCst,
+                            ) {
+                                Ok(_) => {
+                                    // can send to output
+                                    Ok(write)
+                                }
+                                Err(_) => {
+                                    // interleaving change, retry
+                                    continue;
                                 }
                             }
-                            Err(e) => Err(e),
                         }
+                        Err(e) => Err(e),
                     }
-                    Err(error) => {
-                        match error.kind() {
-                            std::io::ErrorKind::NotFound => {
-                                // figure out watermark and see if there's a gap in the stream
-                                if let Ok(watermark) = watermark(&path).await {
-                                    // watermark is "last sequence number + 1", so substract 1 before comparing
-                                    if watermark.saturating_sub(1) > sequence_number {
+                }
+                Err(error) => {
+                    match error.kind() {
+                        std::io::ErrorKind::NotFound => {
+                            // figure out watermark and see if there's a gap in the stream
+                            if let Ok(watermark) = watermark(&path).await {
+                                // watermark is "last sequence number + 1", so substract 1 before comparing
+                                if watermark.saturating_sub(1) > sequence_number {
+                                    // while generating the watermark, a writer might have created the file that we've
+                                    // tried to read, so we need to double-check
+                                    if let Err(std::io::ErrorKind::NotFound) =
+                                        tokio::fs::metadata(&file_path).await.map_err(|e| e.kind())
+                                    {
                                         // update position
                                         // failures are OK here since we'll re-read this value next round
                                         next_sequence_number
@@ -429,25 +436,23 @@ impl ConsumerStream {
                                             .ok();
                                         continue;
                                     }
-                                };
+                                }
+                            };
 
-                                // no gap detected, just wait a bit for new data
-                                tokio::time::sleep(std::time::Duration::from_secs(1)).await;
-                                continue;
-                            }
-                            _ => {
-                                // cannot read file => communicate to user
-                                Err(Box::new(error) as WriteBufferError)
-                            }
+                            // no gap detected, just wait a bit for new data
+                            tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+                            continue;
+                        }
+                        _ => {
+                            // cannot read file => communicate to user
+                            Err(Box::new(error) as WriteBufferError)
                         }
                     }
-                };
+                }
+            };
 
-                return msg;
-            }
-        };
-
-        fut.boxed()
+            return msg;
+        }
     }
 
     fn decode_file(
@@ -497,21 +502,16 @@ impl Stream for ConsumerStream {
         self: Pin<&mut Self>,
         cx: &mut std::task::Context<'_>,
     ) -> std::task::Poll<Option<Self::Item>> {
-        let mut this = self.project();
-        if this.fut.is_none() || *this.was_ready {
-            *this.fut = Some(Self::create_future(
-                *this.sequencer_id,
-                this.path.clone(),
-                Arc::clone(this.next_sequence_number),
-                this.trace_collector.clone(),
-            ));
-        }
-        let fut = this.fut.as_pin_mut();
-        let fut = fut.expect("just assigned");
+        let this = self.project();
 
-        match fut.poll(cx) {
+        match this.fut.poll(cx) {
             std::task::Poll::Ready(res) => {
-                *this.was_ready = true;
+                this.fut.set(Self::poll_next_inner(
+                    *this.sequencer_id,
+                    this.path.clone(),
+                    Arc::clone(this.next_sequence_number),
+                    this.trace_collector.clone(),
+                ));
                 std::task::Poll::Ready(Some(res))
             }
             std::task::Poll::Pending => std::task::Poll::Pending,


### PR DESCRIPTION
The existing channel construction could lead to cases where streams
would consume messages, put them into the channel but then when the
stream gets dropped the message would be gone forever. So lets move from
a channel-based implementation to directly invoke the generator future,
so this buffering doesn't occur.

Fixes #3179.
