### PR TITLE
refactor: use serialized predicates instead of strings for gRPC deletes

### DIFF
--- a/generated_types/protos/influxdata/iox/delete/v1/service.proto
+++ b/generated_types/protos/influxdata/iox/delete/v1/service.proto
@@ -10,24 +10,24 @@ service DeleteService {
 }
 
 // Request to delete data from a table on a specified predicate
-//
-// TODO: Use DeletePayload
 message DeleteRequest {
-  // name of the database
-  string db_name = 1;
+  reserved 1;
+  reserved "db_name";
 
-  // table name
-  string table_name = 2;
+  reserved 2;
+  reserved "table_name";
 
-  // start time range
-  string start_time = 3;
+  reserved 3;
+  reserved "start_time";
 
-  // stop time range
-  string stop_time = 4;
+  reserved 4;
+  reserved "stop_time";
 
-  // predicate
-  // conjunctive expressions of binary 'column_name = literal' or 'column_ame != literal'
-  string predicate = 5;
+  reserved 5;
+  reserved "predicate";
+
+  // Delete payload
+  DeletePayload payload = 6;
 }
 
 message DeleteResponse {

--- a/router/src/grpc_client.rs
+++ b/router/src/grpc_client.rs
@@ -74,9 +74,7 @@ impl GrpcClient for RealClient {
                             .table_name()
                             .map(|s| s.to_owned())
                             .unwrap_or_default(),
-                        delete.predicate().range.start.to_string(),
-                        delete.predicate().range.end.to_string(),
-                        delete.predicate().expr_sql_string(),
+                        delete.predicate().clone().into(),
                     )
                     .await
                     .map_err(|e| Box::new(e) as _)


### PR DESCRIPTION
IOx is the only consumer of this API so we might just use the serialized
form. Cloud2 uses the HTTP API which supports SQL-like predicates.

Fixes #3192.
