### PR TITLE
fix: flaky incrementing_i64_that_resets (#3197)

### DIFF
--- a/iox_data_generator/src/field.rs
+++ b/iox_data_generator/src/field.rs
@@ -454,7 +454,7 @@ mod test {
         let reset_after = Some(3);
         let mut i64fg = I64FieldGenerator::new(
             "i64fg",
-            &(3..10),
+            &(3..8),
             true,
             reset_after,
             SmallRng::from_entropy(),


### PR DESCRIPTION
This generates 4 samples of a incrementing metric with a range of 3..10.

If the value for the first 3 "intervals" is 3, and the last is 9, the assertion can fail.

i.e. val1 = 3, val2 = 6, val3 = 9, val4 = 9

The simple fix is to make the range 3..8