### PR TITLE
feat: support emitting measurement/field tag keys in binary format

### DIFF
--- a/influxdb_iox/src/influxdb_ioxd/server_type/database/rpc/storage/service.rs
+++ b/influxdb_iox/src/influxdb_ioxd/server_type/database/rpc/storage/service.rs
@@ -869,11 +869,7 @@ where
         })?
         .build();
 
-    // keep original name so we can transfer ownership
-    // to closure below
-    let owned_db_name = db_name;
-
-    let db_name = owned_db_name.as_str();
+    let db_name = db_name.as_str();
     let db = db_store.db(db_name).context(DatabaseNotFound { db_name })?;
     let ctx = db.new_query_context(span_ctx);
 
@@ -893,9 +889,7 @@ where
         .to_series_and_groups(series_plan)
         .await
         .map_err(|e| Box::new(e) as _)
-        .context(FilteringSeries {
-            db_name: owned_db_name.as_str(),
-        })
+        .context(FilteringSeries { db_name })
         .log_if_error("Running series set plan")?;
 
     let response = series_or_groups_to_read_response(series_or_groups);

--- a/query/src/exec/seriesset/series.rs
+++ b/query/src/exec/seriesset/series.rs
@@ -30,7 +30,7 @@ pub enum Error {
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
 /// A name=value pair used to represent a series's tag
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct Tag {
     pub key: Arc<str>,
     pub value: Arc<str>,
@@ -43,7 +43,7 @@ impl fmt::Display for Tag {
 }
 
 /// Represents a single logical TimeSeries
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct Series {
     /// key = value pairs that define this series
     /// (including the _measurement and _field that correspond to table name and column name)
@@ -71,7 +71,7 @@ impl fmt::Display for Series {
 }
 
 /// Typed data for a particular timeseries
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub enum Data {
     FloatPoints {
         timestamps: Vec<i64>,
@@ -287,7 +287,7 @@ impl SeriesSet {
 }
 
 /// Represents a group of `Series`
-#[derive(Debug, Default)]
+#[derive(Clone, Debug, Default)]
 pub struct Group {
     /// Contains *ALL* tag keys (not just those used for grouping)
     pub tag_keys: Vec<Arc<str>>,
@@ -314,7 +314,7 @@ impl fmt::Display for Group {
     }
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub enum Either {
     Series(Series),
     Group(Group),


### PR DESCRIPTION
Closes https://github.com/influxdata/influxdb_iox/issues/3165

This PR adds support to optionally emit the tag keys `_measurement` and `_field` as the special representation of `\x00` and `\xff` respectively.

This feature is needed because as part of the Storage Read API there is an enum on `ReadFilterRequest` that the caller can set to request that tag sets include `\x00` and `\xff` instead of the aforementioned names.

https://github.com/influxdata/influxdb_iox/blob/67c24ccd7e5dbb98ce8dbdf3c2fd6955838c6d09/generated_types/protos/influxdata/platform/storage/storage_common.proto#L35-L58

### Testing

As well as new unit test confirming this behaviour I have ran the internal Flux test suite: *no regressions*. Further, I have ran the internal InfluxQL test suite and reduced the number of failures from `666` to `180`.