### PR TITLE
refactor: remove methods from `ManagementService` that were moved to `RemoteService`

### DIFF
--- a/generated_types/protos/influxdata/iox/management/v1/service.proto
+++ b/generated_types/protos/influxdata/iox/management/v1/service.proto
@@ -40,27 +40,6 @@ service ManagementService {
   // List chunks available on this database
   rpc ListChunks(ListChunksRequest) returns (ListChunksResponse);
 
-  // List remote IOx servers we know about.
-  //
-  // This call is deprecated, see <https://github.com/influxdata/influxdb_iox/issues/2980>.
-  rpc ListRemotes(ListRemotesRequest) returns (ListRemotesResponse) {
-    option deprecated = true;
-  };
-
-  // Update information about a remote IOx server (upsert).
-  //
-  // This call is deprecated, see <https://github.com/influxdata/influxdb_iox/issues/2980>.
-  rpc UpdateRemote(UpdateRemoteRequest) returns (UpdateRemoteResponse) {
-    option deprecated = true;
-  };
-
-  // Delete a reference to remote IOx server.
-  //
-  // This call is deprecated, see <https://github.com/influxdata/influxdb_iox/issues/2980>.
-  rpc DeleteRemote(DeleteRemoteRequest) returns (DeleteRemoteResponse) {
-    option deprecated = true;
-  };
-
   // Creates a dummy job that for each value of the nanos field
   // spawns a task that sleeps for that number of nanoseconds before returning
   rpc CreateDummyJob(CreateDummyJobRequest) returns (CreateDummyJobResponse) {
@@ -215,39 +194,6 @@ message CreateDummyJobRequest {
 message CreateDummyJobResponse {
   google.longrunning.Operation operation = 1;
 }
-
-message ListRemotesRequest {}
-
-message ListRemotesResponse {
-  repeated Remote remotes = 1;
-}
-
-// This resource represents a remote IOx server.
-message Remote {
-  // The server ID associated with a remote IOx server.
-  uint32 id = 1;
-
-  // The address of the remote IOx server gRPC endpoint.
-  string connection_string = 2;
-}
-
-// Updates information about a remote IOx server.
-//
-// If a remote for a given `id` already exists, it is updated in place.
-message UpdateRemoteRequest {
-  // If omitted, the remote associated with `id` will be removed.
-  Remote remote = 1;
-
-  // TODO(#917): add an optional flag to test the connection or not before adding it.
-}
-
-message UpdateRemoteResponse {}
-
-message DeleteRemoteRequest{
-  uint32 id = 1;
-}
-
-message DeleteRemoteResponse {}
 
 // Request to list all partitions from a named database
 message ListPartitionsRequest {

--- a/influxdb_iox/tests/end_to_end_cases/management_api.rs
+++ b/influxdb_iox/tests/end_to_end_cases/management_api.rs
@@ -25,66 +25,6 @@ use std::time::Instant;
 use uuid::Uuid;
 
 #[tokio::test]
-async fn test_list_update_remotes() {
-    let server_fixture = ServerFixture::create_single_use(ServerType::Database).await;
-    let mut client = server_fixture.management_client();
-
-    const TEST_REMOTE_ID_1: u32 = 42;
-    const TEST_REMOTE_ADDR_1: &str = "1.2.3.4:1234";
-    const TEST_REMOTE_ID_2: u32 = 84;
-    const TEST_REMOTE_ADDR_2: &str = "4.3.2.1:4321";
-    const TEST_REMOTE_ADDR_2_UPDATED: &str = "40.30.20.10:4321";
-
-    let res = client.list_remotes().await.expect("list remotes failed");
-    assert_eq!(res.len(), 0);
-
-    client
-        .update_remote(TEST_REMOTE_ID_1, TEST_REMOTE_ADDR_1)
-        .await
-        .expect("update failed");
-
-    let res = client.list_remotes().await.expect("list remotes failed");
-    assert_eq!(res.len(), 1);
-
-    client
-        .update_remote(TEST_REMOTE_ID_2, TEST_REMOTE_ADDR_2)
-        .await
-        .expect("update failed");
-
-    let res = client.list_remotes().await.expect("list remotes failed");
-    assert_eq!(res.len(), 2);
-    assert_eq!(res[0].id, TEST_REMOTE_ID_1);
-    assert_eq!(res[0].connection_string, TEST_REMOTE_ADDR_1);
-    assert_eq!(res[1].id, TEST_REMOTE_ID_2);
-    assert_eq!(res[1].connection_string, TEST_REMOTE_ADDR_2);
-
-    client
-        .delete_remote(TEST_REMOTE_ID_1)
-        .await
-        .expect("delete failed");
-
-    client
-        .delete_remote(TEST_REMOTE_ID_1)
-        .await
-        .expect_err("expected delete to fail");
-
-    let res = client.list_remotes().await.expect("list remotes failed");
-    assert_eq!(res.len(), 1);
-    assert_eq!(res[0].id, TEST_REMOTE_ID_2);
-    assert_eq!(res[0].connection_string, TEST_REMOTE_ADDR_2);
-
-    client
-        .update_remote(TEST_REMOTE_ID_2, TEST_REMOTE_ADDR_2_UPDATED)
-        .await
-        .expect("update failed");
-
-    let res = client.list_remotes().await.expect("list remotes failed");
-    assert_eq!(res.len(), 1);
-    assert_eq!(res[0].id, TEST_REMOTE_ID_2);
-    assert_eq!(res[0].connection_string, TEST_REMOTE_ADDR_2_UPDATED);
-}
-
-#[tokio::test]
 async fn test_create_database_duplicate_name() {
     let server_fixture = ServerFixture::create_shared(ServerType::Database).await;
     let mut client = server_fixture.management_client();

--- a/influxdb_iox/tests/end_to_end_cases/write_api.rs
+++ b/influxdb_iox/tests/end_to_end_cases/write_api.rs
@@ -116,6 +116,7 @@ async fn test_write_routed() {
 
     let router = ServerFixture::create_single_use(ServerType::Database).await;
     let mut router_deployment = router.deployment_client();
+    let mut router_remote = router.remote_client();
     let mut router_mgmt = router.management_client();
     router_deployment
         .update_server_id(test_router_id)
@@ -131,7 +132,7 @@ async fn test_write_routed() {
         .expect("set ID failed");
     target_1.wait_server_initialized().await;
 
-    router_mgmt
+    router_remote
         .update_remote(TEST_REMOTE_ID_1, target_1.grpc_base())
         .await
         .expect("set remote failed");
@@ -144,7 +145,7 @@ async fn test_write_routed() {
         .expect("set ID failed");
     target_2.wait_server_initialized().await;
 
-    router_mgmt
+    router_remote
         .update_remote(TEST_REMOTE_ID_2, target_2.grpc_base())
         .await
         .expect("set remote failed");
@@ -157,7 +158,7 @@ async fn test_write_routed() {
         .expect("set ID failed");
     target_3.wait_server_initialized().await;
 
-    router_mgmt
+    router_remote
         .update_remote(TEST_REMOTE_ID_3, target_3.grpc_base())
         .await
         .expect("set remote failed");
@@ -487,6 +488,7 @@ async fn test_write_routed_no_shard() {
     let router = ServerFixture::create_single_use(ServerType::Database).await;
     let mut router_deployment = router.deployment_client();
     let mut router_mgmt = router.management_client();
+    let mut router_remote = router.remote_client();
     router_deployment
         .update_server_id(test_router_id)
         .await
@@ -501,7 +503,7 @@ async fn test_write_routed_no_shard() {
         .expect("set ID failed");
     target_1.wait_server_initialized().await;
 
-    router_mgmt
+    router_remote
         .update_remote(TEST_REMOTE_ID_1, target_1.grpc_base())
         .await
         .expect("set remote failed");
@@ -514,7 +516,7 @@ async fn test_write_routed_no_shard() {
         .expect("set ID failed");
     target_2.wait_server_initialized().await;
 
-    router_mgmt
+    router_remote
         .update_remote(TEST_REMOTE_ID_2, target_2.grpc_base())
         .await
         .expect("set remote failed");
@@ -527,7 +529,7 @@ async fn test_write_routed_no_shard() {
         .expect("set ID failed");
     target_3.wait_server_initialized().await;
 
-    router_mgmt
+    router_remote
         .update_remote(TEST_REMOTE_ID_3, target_3.grpc_base())
         .await
         .expect("set remote failed");

--- a/influxdb_iox_client/src/client/management.rs
+++ b/influxdb_iox_client/src/client/management.rs
@@ -14,34 +14,6 @@ pub mod generated_types {
     pub use generated_types::influxdata::iox::write_buffer::v1::*;
 }
 
-/// Errors returned by Client::update_server_id
-#[derive(Debug, Error)]
-pub enum UpdateServerIdError {
-    /// Client received an unexpected error from the server
-    #[error("Unexpected server error: {}: {}", .0.code(), .0.message())]
-    ServerError(tonic::Status),
-}
-
-/// Errors returned by Client::get_server_id
-#[derive(Debug, Error)]
-pub enum GetServerIdError {
-    /// Server ID is not set
-    #[error("Server ID not set")]
-    NoServerId,
-
-    /// Client received an unexpected error from the server
-    #[error("Unexpected server error: {}: {}", .0.code(), .0.message())]
-    ServerError(tonic::Status),
-}
-
-/// Errors returned by Client::set_serving_readiness
-#[derive(Debug, Error)]
-pub enum SetServingReadinessError {
-    /// Client received an unexpected error from the server
-    #[error("Unexpected server error: {}: {}", .0.code(), .0.message())]
-    ServerError(tonic::Status),
-}
-
 /// Errors returned by Client::create_database
 #[derive(Debug, Error)]
 pub enum CreateDatabaseError {

--- a/influxdb_iox_client/src/client/management.rs
+++ b/influxdb_iox_client/src/client/management.rs
@@ -160,22 +160,6 @@ pub enum ListChunksError {
     ServerError(tonic::Status),
 }
 
-/// Errors returned by Client::list_remotes
-#[derive(Debug, Error)]
-pub enum ListRemotesError {
-    /// Client received an unexpected error from the server
-    #[error("Unexpected server error: {}: {}", .0.code(), .0.message())]
-    ServerError(tonic::Status),
-}
-
-/// Errors returned by Client::update_remote
-#[derive(Debug, Error)]
-pub enum UpdateRemoteError {
-    /// Client received an unexpected error from the server
-    #[error("Unexpected server error: {}: {}", .0.code(), .0.message())]
-    ServerError(tonic::Status),
-}
-
 /// Errors returned by Client::create_dummy_job
 #[derive(Debug, Error)]
 pub enum CreateDummyJobError {
@@ -651,43 +635,6 @@ impl Client {
                 _ => ListChunksError::ServerError(status),
             })?;
         Ok(response.into_inner().chunks)
-    }
-
-    /// List remotes.
-    pub async fn list_remotes(&mut self) -> Result<Vec<generated_types::Remote>, ListRemotesError> {
-        let response = self
-            .inner
-            .list_remotes(ListRemotesRequest {})
-            .await
-            .map_err(ListRemotesError::ServerError)?;
-        Ok(response.into_inner().remotes)
-    }
-
-    /// Update remote
-    pub async fn update_remote(
-        &mut self,
-        id: u32,
-        connection_string: impl Into<String> + Send,
-    ) -> Result<(), UpdateRemoteError> {
-        self.inner
-            .update_remote(UpdateRemoteRequest {
-                remote: Some(generated_types::Remote {
-                    id,
-                    connection_string: connection_string.into(),
-                }),
-            })
-            .await
-            .map_err(UpdateRemoteError::ServerError)?;
-        Ok(())
-    }
-
-    /// Delete remote
-    pub async fn delete_remote(&mut self, id: u32) -> Result<(), UpdateRemoteError> {
-        self.inner
-            .delete_remote(DeleteRemoteRequest { id })
-            .await
-            .map_err(UpdateRemoteError::ServerError)?;
-        Ok(())
     }
 
     /// List all partitions of the database


### PR DESCRIPTION
Tests are covered by `remote_api.rs`.

Ref #2980.
