### PR TITLE
refactor: add debug logging for meta queries

### DIFF
--- a/influxdb_iox/src/influxdb_ioxd/server_type/database/rpc/storage/service.rs
+++ b/influxdb_iox/src/influxdb_ioxd/server_type/database/rpc/storage/service.rs
@@ -214,8 +214,6 @@ where
         let span_ctx = req.extensions().get().cloned();
 
         let read_filter_request = req.into_inner();
-        println!("REQUEST {:?}", &read_filter_request);
-
         let db_name = get_database_name(&read_filter_request)?;
         info!(%db_name, ?read_filter_request.range, predicate=%read_filter_request.predicate.loggable(), "read filter");
 


### PR DESCRIPTION
Adds some trace output to see the contents of meta query responses before they're sent over the wire.