### PR TITLE
fix: ensure time column not returned

### DIFF
--- a/query/src/frontend/influxrpc.rs
+++ b/query/src/frontend/influxrpc.rs
@@ -895,6 +895,11 @@ impl InfluxRpcPlanner {
             })
             .collect::<Vec<_>>();
 
+        // If the projection is empty then there is no plan to execute.
+        if select_exprs.is_empty() {
+            return Ok(None);
+        }
+
         let plan = plan_builder
             .project(select_exprs)
             .context(BuildingPlan)?

--- a/query_tests/src/influxrpc/tag_keys.rs
+++ b/query_tests/src/influxrpc/tag_keys.rs
@@ -47,6 +47,15 @@ where
 }
 
 #[tokio::test]
+async fn list_tag_columns_with_no_tags() {
+    let predicate = PredicateBuilder::default().build();
+    run_tag_keys_test_case(OneMeasurementNoTags {}, predicate, vec![]).await;
+
+    let predicate = PredicateBuilder::default().timestamp_range(0, 1000).build();
+    run_tag_keys_test_case(OneMeasurementNoTags {}, predicate, vec![]).await;
+}
+
+#[tokio::test]
 async fn list_tag_columns_no_predicate() {
     let predicate = PredicateBuilder::default().build();
     let expected_tag_keys = vec!["borough", "city", "county", "state"];

--- a/query_tests/src/scenarios.rs
+++ b/query_tests/src/scenarios.rs
@@ -224,6 +224,25 @@ impl DbSetup for OneMeasurementRealisticTimes {
 }
 
 #[derive(Debug)]
+pub struct OneMeasurementNoTags {}
+#[async_trait]
+impl DbSetup for OneMeasurementNoTags {
+    async fn make(&self) -> Vec<DbScenario> {
+        let partition_key = "1970-01-01T00";
+
+        let lp_lines = vec![
+            "h2o temp=70.4 100",
+            "h2o temp=72.4 250",
+            "h2o temp=50.4 200",
+            "h2o level=200.0 300",
+        ];
+
+        // return all possible scenarios a chunk: MUB open, MUB frozen, RUB, RUB & OS, OS
+        all_scenarios_for_one_chunk(vec![], vec![], lp_lines, "h2o", partition_key).await
+    }
+}
+
+#[derive(Debug)]
 pub struct OneMeasurementManyNullTags {}
 #[async_trait]
 impl DbSetup for OneMeasurementManyNullTags {


### PR DESCRIPTION
Closes #3202

### Defect

This PR fixes a defect in the `tag_keys` implementation on the InfluxRPC frontend. The semantics of a Tag Keys meta query are to return to the caller the distinct set of tag keys (column names for InfluxDB tags). 

If a table did not contain any tag columns (i.e., only contained field columns and a time column) *and* if a full general purpose plan was required to determine which columns contained rows passing some predicate, then the implementation would build a logical plan containing a projection of all tag columns. Since this projection would be empty (no tag columns in table) then the logical plan would effectively not have any specific projections and would select _all_ columns, including the `"time"` column. 

This results in `"time"` being sent back to the InfluxQL query engine as a tag key, which is incorrect.

### Fix

If there are no tag columns in the table then we don't execute the plan and just return an empty set of results to the frontend. 

### Tests

- I ran the internal Flux test suite and observed *no regressions*.
- I ran the internal InfluxQL test suite and observed that the number of failing tests reduced from `180` to `148`.