### PR TITLE
feat: disallow unsequenced deletes when reading from write buffer

### DIFF
--- a/influxdb_iox/tests/end_to_end_cases/write_buffer.rs
+++ b/influxdb_iox/tests/end_to_end_cases/write_buffer.rs
@@ -10,6 +10,10 @@ use generated_types::influxdata::iox::write_buffer::v1::{
     write_buffer_connection::Direction as WriteBufferDirection, WriteBufferConnection,
 };
 use influxdb_iox_client::{
+    delete::{
+        generated_types::{Predicate, TimestampRange},
+        DeleteError,
+    },
     management::{generated_types::WriteBufferCreationConfig, CreateDatabaseError},
     write::WriteError,
 };
@@ -153,6 +157,23 @@ async fn cant_write_to_db_reading_from_write_buffer() {
 
     assert_contains!(err.to_string(), "only allowed through write buffer");
     assert!(matches!(dbg!(err), WriteError::ServerError(_)));
+
+    // Deleteing from this database is an error; all data comes from write buffer
+    let mut delete_client = server.delete_client();
+    let err = delete_client
+        .delete(
+            &db_name,
+            "temp",
+            Predicate {
+                range: Some(TimestampRange { start: 1, end: 2 }),
+                exprs: vec![],
+            },
+        )
+        .await
+        .expect_err("expected delete to fail");
+
+    assert_contains!(err.to_string(), "only allowed through write buffer");
+    assert!(matches!(dbg!(err), DeleteError::ServerError(_)));
 }
 
 #[tokio::test]

--- a/influxdb_iox/tests/end_to_end_cases/write_buffer.rs
+++ b/influxdb_iox/tests/end_to_end_cases/write_buffer.rs
@@ -158,7 +158,7 @@ async fn cant_write_to_db_reading_from_write_buffer() {
     assert_contains!(err.to_string(), "only allowed through write buffer");
     assert!(matches!(dbg!(err), WriteError::ServerError(_)));
 
-    // Deleteing from this database is an error; all data comes from write buffer
+    // Deleting from this database is an error; all data comes from write buffer
     let mut delete_client = server.delete_client();
     let err = delete_client
         .delete(

--- a/server/src/db.rs
+++ b/server/src/db.rs
@@ -521,12 +521,12 @@ impl Db {
     }
 
     /// Store a delete
-    pub fn store_delete(&self, delete: &DmlDelete) -> Result<()> {
+    pub(crate) fn store_delete(&self, delete: &DmlDelete) -> Result<()> {
         self.store_filtered_delete(delete, DeleteFilterNone::default())
     }
 
     /// Store a delete with the provided [`DeleteFilter`]
-    pub fn store_filtered_delete(
+    pub(crate) fn store_filtered_delete(
         &self,
         delete: &DmlDelete,
         filter: impl DeleteFilter,
@@ -549,6 +549,8 @@ impl Db {
     /// Delete data from a table on a specified predicate
     ///
     /// Returns an error if the table cannot be found in the catalog
+    ///
+    /// **WARNING: Only use that when no write buffer is used.**
     pub fn delete(&self, table_name: &str, delete_predicate: Arc<DeletePredicate>) -> Result<()> {
         self.delete_filtered(table_name, delete_predicate, DeleteFilterNone::default())
     }
@@ -1028,7 +1030,7 @@ impl Db {
     }
 
     /// Writes the provided [`DmlWrite`] to this database with the provided [`WriteFilter`]
-    pub(crate) fn store_filtered_write(
+    pub fn store_filtered_write(
         &self,
         db_write: &DmlWrite,
         filter: impl WriteFilter,


### PR DESCRIPTION
Similar to how writes to a databases that reads from a write buffer are
forbidden deletes should be rejected as well.
