### PR TITLE
refactor: remove write buffer producer logic from `Db`

### DIFF
--- a/influxdb_iox/src/influxdb_ioxd/server_type/database/http.rs
+++ b/influxdb_iox/src/influxdb_ioxd/server_type/database/http.rs
@@ -185,8 +185,7 @@ impl HttpDrivenDml for DatabaseServerType {
                 })?;
 
                 database
-                    .route_operation(&DmlOperation::Write(write))
-                    .await
+                    .store_operation(&DmlOperation::Write(write))
                     .map_err(|e| InnerDmlError::InternalError {
                         db_name: db_name.to_string(),
                         source: Box::new(e),
@@ -200,8 +199,7 @@ impl HttpDrivenDml for DatabaseServerType {
                 })?;
 
                 database
-                    .route_operation(&DmlOperation::Delete(delete))
-                    .await
+                    .store_operation(&DmlOperation::Delete(delete))
                     .map_err(|e| match e {
                         WriteError::DbError { source } => match source {
                             server::db::Error::DeleteFromTable { table_name, .. } => {

--- a/influxdb_iox/src/influxdb_ioxd/server_type/database/rpc/delete.rs
+++ b/influxdb_iox/src/influxdb_ioxd/server_type/database/rpc/delete.rs
@@ -41,8 +41,7 @@ impl delete_service_server::DeleteService for DeleteService {
             .map_err(default_server_error_handler)?;
 
         database
-            .route_operation(&DmlOperation::Delete(delete))
-            .await
+            .store_operation(&DmlOperation::Delete(delete))
             .map_err(default_database_write_error_handler)?;
 
         Ok(Response::new(DeleteResponse {}))

--- a/influxdb_iox/src/influxdb_ioxd/server_type/database/rpc/write_pb.rs
+++ b/influxdb_iox/src/influxdb_ioxd/server_type/database/rpc/write_pb.rs
@@ -41,8 +41,7 @@ impl write_service_server::WriteService for PBWriteService {
             .map_err(default_server_error_handler)?;
 
         database
-            .route_operation(&DmlOperation::Write(write))
-            .await
+            .store_operation(&DmlOperation::Write(write))
             .map_err(default_database_write_error_handler)?;
 
         Ok(tonic::Response::new(WriteResponse {}))

--- a/query_tests/src/cancellation.rs
+++ b/query_tests/src/cancellation.rs
@@ -31,7 +31,7 @@ async fn test_query_cancellation_slow_store() {
 
     // create persisted chunk
     let data = "cpu,region=west user=23.2 100";
-    write_lp(&db, data).await;
+    write_lp(&db, data);
     db.rollover_partition(table_name, partition_key)
         .await
         .unwrap();
@@ -51,7 +51,7 @@ async fn test_query_cancellation_slow_store() {
 
     // create in-memory chunk
     let data = "cpu,region=east user=0.1 42";
-    write_lp(&db, data).await;
+    write_lp(&db, data);
 
     // make store access really slow
     if let ObjectStoreIntegration::InMemoryThrottled(inner) = &object_store.integration {

--- a/query_tests/src/influxrpc/read_window_aggregate.rs
+++ b/query_tests/src/influxrpc/read_window_aggregate.rs
@@ -208,7 +208,7 @@ impl DbSetup for MeasurementForWindowAggregateMonths {
 
         let db = make_db().await.db;
         let data = lp_lines.join("\n");
-        write_lp(&db, &data).await;
+        write_lp(&db, &data);
         let scenario1 = DbScenario {
             scenario_name: "Data in 4 partitions, open chunks of mutable buffer".into(),
             db,
@@ -216,7 +216,7 @@ impl DbSetup for MeasurementForWindowAggregateMonths {
 
         let db = make_db().await.db;
         let data = lp_lines.join("\n");
-        write_lp(&db, &data).await;
+        write_lp(&db, &data);
         db.rollover_partition("h2o", "2020-03-01T00").await.unwrap();
         db.rollover_partition("h2o", "2020-03-02T00").await.unwrap();
         let scenario2 = DbScenario {
@@ -228,7 +228,7 @@ impl DbSetup for MeasurementForWindowAggregateMonths {
 
         let db = make_db().await.db;
         let data = lp_lines.join("\n");
-        write_lp(&db, &data).await;
+        write_lp(&db, &data);
         // roll over and load chunks into both RUB and OS
         rollover_and_load(&db, "2020-03-01T00", "h2o").await;
         rollover_and_load(&db, "2020-03-02T00", "h2o").await;

--- a/query_tests/src/pruning.rs
+++ b/query_tests/src/pruning.rs
@@ -20,16 +20,16 @@ async fn setup() -> TestDb {
     let db = &test_db.db;
 
     // Chunk 0 has bar:[1-2]
-    write_lp(db, "cpu bar=1 10").await;
-    write_lp(db, "cpu bar=2 20").await;
+    write_lp(db, "cpu bar=1 10");
+    write_lp(db, "cpu bar=2 20");
 
     let partition_key = "1970-01-01T00";
     db.compact_open_chunk("cpu", partition_key).await.unwrap();
 
     // Chunk 1 has bar:[3-3] (going to get pruned)
-    write_lp(db, "cpu bar=3 10").await;
-    write_lp(db, "cpu bar=3 100").await;
-    write_lp(db, "cpu bar=3 1000").await;
+    write_lp(db, "cpu bar=3 10");
+    write_lp(db, "cpu bar=3 100");
+    write_lp(db, "cpu bar=3 1000");
 
     let partition_key = "1970-01-01T00";
     db.compact_open_chunk("cpu", partition_key).await.unwrap();

--- a/query_tests/src/scenarios.rs
+++ b/query_tests/src/scenarios.rs
@@ -119,7 +119,7 @@ impl DbSetup for NoData {
         //
         let db = make_db().await.db;
         let data = "cpu,region=west user=23.2 100";
-        write_lp(&db, data).await;
+        write_lp(&db, data);
         // move data out of open chunk
         db.rollover_partition(table_name, partition_key)
             .await
@@ -157,7 +157,7 @@ impl DbSetup for NoData {
         //
         let db = make_db().await.db;
         let data = "cpu,region=west user=23.2 100";
-        write_lp(&db, data).await;
+        write_lp(&db, data);
         // move data out of open chunk
         db.rollover_partition(table_name, partition_key)
             .await
@@ -621,7 +621,7 @@ impl DbSetup for TwoMeasurementsManyFieldsOneChunk {
             "o2,state=CA temp=79.0 300",
         ];
 
-        write_lp(&db, &lp_lines.join("\n")).await;
+        write_lp(&db, &lp_lines.join("\n"));
         vec![DbScenario {
             scenario_name: "Data in open chunk of mutable buffer".into(),
             db,
@@ -646,7 +646,7 @@ impl DbSetup for TwoMeasurementsManyFieldsOneRubChunk {
             "o2,state=CA temp=79.0 300",
         ];
 
-        write_lp(&db, &lp_lines.join("\n")).await;
+        write_lp(&db, &lp_lines.join("\n"));
 
         // move all data to RUB
         db.compact_open_chunk("h2o", partition_key).await.unwrap();
@@ -672,7 +672,7 @@ impl DbSetup for TwoMeasurementsManyFieldsTwoChunks {
             "h2o,state=MA,city=Boston temp=70.4 50",
             "h2o,state=MA,city=Boston other_temp=70.4 250",
         ];
-        write_lp(&db, &lp_lines.join("\n")).await;
+        write_lp(&db, &lp_lines.join("\n"));
         db.compact_partition("h2o", partition_key).await.unwrap();
 
         let lp_lines = vec![
@@ -680,7 +680,7 @@ impl DbSetup for TwoMeasurementsManyFieldsTwoChunks {
             "o2,state=MA,city=Boston temp=53.4,reading=51 50",
             "o2,state=CA temp=79.0 300",
         ];
-        write_lp(&db, &lp_lines.join("\n")).await;
+        write_lp(&db, &lp_lines.join("\n"));
 
         assert_eq!(count_mutable_buffer_chunks(&db), 2);
         assert_eq!(count_read_buffer_chunks(&db), 1);
@@ -708,7 +708,7 @@ impl DbSetup for OneMeasurementTwoChunksDifferentTagSet {
             "h2o,state=MA temp=70.4 50",
             "h2o,state=MA other_temp=70.4 250",
         ];
-        write_lp(&db, &lp_lines.join("\n")).await;
+        write_lp(&db, &lp_lines.join("\n"));
         db.compact_partition("h2o", partition_key).await.unwrap();
 
         // tag: city
@@ -716,7 +716,7 @@ impl DbSetup for OneMeasurementTwoChunksDifferentTagSet {
             "h2o,city=Boston other_temp=72.4 350",
             "h2o,city=Boston temp=53.4,reading=51 50",
         ];
-        write_lp(&db, &lp_lines.join("\n")).await;
+        write_lp(&db, &lp_lines.join("\n"));
         db.compact_open_chunk("h2o", partition_key).await.unwrap();
 
         assert_eq!(count_mutable_buffer_chunks(&db), 0);
@@ -749,7 +749,7 @@ impl DbSetup for OneMeasurementFourChunksWithDuplicates {
             "h2o,state=MA,city=Boston max_temp=75.4 250",
             "h2o,state=MA,city=Andover max_temp=69.2, 250",
         ];
-        write_lp(&db, &lp_lines.join("\n")).await;
+        write_lp(&db, &lp_lines.join("\n"));
         db.compact_open_chunk("h2o", partition_key).await.unwrap();
 
         // Chunk 2: overlaps with chunk 1
@@ -763,7 +763,7 @@ impl DbSetup for OneMeasurementFourChunksWithDuplicates {
             "h2o,state=CA,city=SJ min_temp=78.5,max_temp=88.0 300",
             "h2o,state=CA,city=SJ min_temp=75.5,max_temp=84.08 350",
         ];
-        write_lp(&db, &lp_lines.join("\n")).await;
+        write_lp(&db, &lp_lines.join("\n"));
         db.compact_open_chunk("h2o", partition_key).await.unwrap();
 
         // Chunk 3: no overlap
@@ -777,7 +777,7 @@ impl DbSetup for OneMeasurementFourChunksWithDuplicates {
             "h2o,state=CA,city=SJ min_temp=77.0,max_temp=90.7 450",
             "h2o,state=CA,city=SJ min_temp=69.5,max_temp=88.2 500",
         ];
-        write_lp(&db, &lp_lines.join("\n")).await;
+        write_lp(&db, &lp_lines.join("\n"));
         db.compact_open_chunk("h2o", partition_key).await.unwrap();
 
         // Chunk 4: no overlap
@@ -791,7 +791,7 @@ impl DbSetup for OneMeasurementFourChunksWithDuplicates {
             "h2o,state=CA,city=SJ min_temp=69.5,max_temp=89.2 650",
             "h2o,state=CA,city=SJ min_temp=75.5,max_temp=84.08 700",
         ];
-        write_lp(&db, &lp_lines.join("\n")).await;
+        write_lp(&db, &lp_lines.join("\n"));
         db.compact_open_chunk("h2o", partition_key).await.unwrap();
 
         assert_eq!(count_mutable_buffer_chunks(&db), 0);
@@ -823,8 +823,7 @@ impl DbSetup for TwoMeasurementsManyFieldsLifecycle {
                 "h2o,state=MA,city=Boston other_temp=70.4 250",
             ]
             .join("\n"),
-        )
-        .await;
+        );
 
         db.compact_open_chunk("h2o", partition_key).await.unwrap();
 
@@ -835,8 +834,7 @@ impl DbSetup for TwoMeasurementsManyFieldsLifecycle {
         write_lp(
             &db,
             &vec!["h2o,state=CA,city=Boston other_temp=72.4 350"].join("\n"),
-        )
-        .await;
+        );
 
         assert_eq!(count_mutable_buffer_chunks(&db), 1);
         assert_eq!(count_read_buffer_chunks(&db), 1);
@@ -984,7 +982,7 @@ impl DbSetup for EndToEndTestWithDelete {
 pub(crate) async fn make_one_chunk_mub_scenario(data: &str) -> Vec<DbScenario> {
     // Scenario 1: One open chunk in MUB
     let db = make_db().await.db;
-    write_lp(&db, data).await;
+    write_lp(&db, data);
     let scenario = DbScenario {
         scenario_name: "Data in open chunk of mutable buffer".into(),
         db,
@@ -1001,7 +999,7 @@ pub(crate) async fn make_one_chunk_rub_scenario(
 ) -> Vec<DbScenario> {
     // Scenario 1: One closed chunk in RUB
     let db = make_db().await.db;
-    let table_names = write_lp(&db, data).await;
+    let table_names = write_lp(&db, data);
     for table_name in &table_names {
         db.rollover_partition(table_name, partition_key)
             .await
@@ -1030,7 +1028,7 @@ impl DbSetup for OneMeasurementAllChunksDropped {
         let table_name = "h2o";
 
         let lp_lines = vec!["h2o,state=MA temp=70.4 50"];
-        write_lp(&db, &lp_lines.join("\n")).await;
+        write_lp(&db, &lp_lines.join("\n"));
         let chunk_id = db
             .compact_open_chunk(table_name, partition_key)
             .await
@@ -1060,8 +1058,8 @@ pub async fn make_two_chunk_scenarios(
     data2: &str,
 ) -> Vec<DbScenario> {
     let db = make_db().await.db;
-    write_lp(&db, data1).await;
-    write_lp(&db, data2).await;
+    write_lp(&db, data1);
+    write_lp(&db, data2);
     let scenario1 = DbScenario {
         scenario_name: "Data in single open chunk of mutable buffer".into(),
         db,
@@ -1069,13 +1067,13 @@ pub async fn make_two_chunk_scenarios(
 
     // spread across 2 mutable buffer chunks
     let db = make_db().await.db;
-    let table_names = write_lp(&db, data1).await;
+    let table_names = write_lp(&db, data1);
     for table_name in &table_names {
         db.rollover_partition(table_name, partition_key)
             .await
             .unwrap();
     }
-    write_lp(&db, data2).await;
+    write_lp(&db, data2);
     let scenario2 = DbScenario {
         scenario_name: "Data in one open chunk and one closed chunk of mutable buffer".into(),
         db,
@@ -1083,13 +1081,13 @@ pub async fn make_two_chunk_scenarios(
 
     // spread across 1 mutable buffer, 1 read buffer chunks
     let db = make_db().await.db;
-    let table_names = write_lp(&db, data1).await;
+    let table_names = write_lp(&db, data1);
     for table_name in &table_names {
         db.compact_partition(table_name, partition_key)
             .await
             .unwrap();
     }
-    write_lp(&db, data2).await;
+    write_lp(&db, data2);
     let scenario3 = DbScenario {
         scenario_name: "Data in open chunk of mutable buffer, and one chunk of read buffer".into(),
         db,
@@ -1097,13 +1095,13 @@ pub async fn make_two_chunk_scenarios(
 
     // in 2 read buffer chunks
     let db = make_db().await.db;
-    let table_names = write_lp(&db, data1).await;
+    let table_names = write_lp(&db, data1);
     for table_name in &table_names {
         db.compact_partition(table_name, partition_key)
             .await
             .unwrap();
     }
-    let table_names = write_lp(&db, data2).await;
+    let table_names = write_lp(&db, data2);
     for table_name in &table_names {
         // Compact just the last chunk
         db.compact_open_chunk(table_name, partition_key)
@@ -1117,13 +1115,13 @@ pub async fn make_two_chunk_scenarios(
 
     // in 2 read buffer chunks that also loaded into object store
     let db = make_db().await.db;
-    let table_names = write_lp(&db, data1).await;
+    let table_names = write_lp(&db, data1);
     for table_name in &table_names {
         db.persist_partition(table_name, partition_key, true)
             .await
             .unwrap();
     }
-    let table_names = write_lp(&db, data2).await;
+    let table_names = write_lp(&db, data2);
     for table_name in &table_names {
         db.persist_partition(table_name, partition_key, true)
             .await
@@ -1136,7 +1134,7 @@ pub async fn make_two_chunk_scenarios(
 
     // Scenario 6: Two closed chunk in OS only
     let db = make_db().await.db;
-    let table_names = write_lp(&db, data1).await;
+    let table_names = write_lp(&db, data1);
     for table_name in &table_names {
         let id = db
             .persist_partition(table_name, partition_key, true)
@@ -1147,7 +1145,7 @@ pub async fn make_two_chunk_scenarios(
         db.unload_read_buffer(table_name, partition_key, id)
             .unwrap();
     }
-    let table_names = write_lp(&db, data2).await;
+    let table_names = write_lp(&db, data2);
     for table_name in &table_names {
         let id = db
             .persist_partition(table_name, partition_key, true)
@@ -1166,14 +1164,14 @@ pub async fn make_two_chunk_scenarios(
 
     // Scenario 7: in a single chunk resulting from compacting MUB and RUB
     let db = make_db().await.db;
-    let table_names = write_lp(&db, data1).await;
+    let table_names = write_lp(&db, data1);
     for table_name in &table_names {
         // put chunk 1 into RUB
         db.compact_partition(table_name, partition_key)
             .await
             .unwrap();
     }
-    let table_names = write_lp(&db, data2).await; // write to MUB
+    let table_names = write_lp(&db, data2); // write to MUB
     for table_name in &table_names {
         // compact chunks into a single RUB chunk
         db.compact_partition(table_name, partition_key)
@@ -1204,7 +1202,7 @@ pub(crate) async fn make_one_rub_or_parquet_chunk_scenario(
 ) -> Vec<DbScenario> {
     // Scenario 1: One closed chunk in RUB
     let db = make_db().await.db;
-    let table_names = write_lp(&db, data).await;
+    let table_names = write_lp(&db, data);
     for table_name in &table_names {
         db.compact_partition(table_name, partition_key)
             .await
@@ -1217,7 +1215,7 @@ pub(crate) async fn make_one_rub_or_parquet_chunk_scenario(
 
     // Scenario 2: One closed chunk in Parquet only
     let db = make_db().await.db;
-    let table_names = write_lp(&db, data).await;
+    let table_names = write_lp(&db, data);
     for table_name in &table_names {
         let id = db
             .persist_partition(table_name, partition_key, true)
@@ -1287,7 +1285,7 @@ impl DbSetup for ChunkOrder {
         let db = make_db().await.db;
 
         // create first chunk: data->MUB->RUB
-        write_lp(&db, "cpu,region=west user=1 100").await;
+        write_lp(&db, "cpu,region=west user=1 100");
         assert_eq!(count_mutable_buffer_chunks(&db), 1);
         assert_eq!(count_read_buffer_chunks(&db), 0);
         assert_eq!(count_object_store_chunks(&db), 0);
@@ -1313,7 +1311,7 @@ impl DbSetup for ChunkOrder {
         };
 
         // create second chunk: data->MUB
-        write_lp(&db, "cpu,region=west user=2 100").await;
+        write_lp(&db, "cpu,region=west user=2 100");
         assert_eq!(count_mutable_buffer_chunks(&db), 1);
         assert_eq!(count_read_buffer_chunks(&db), 1);
         assert_eq!(count_object_store_chunks(&db), 0);

--- a/query_tests/src/scenarios/util.rs
+++ b/query_tests/src/scenarios/util.rs
@@ -189,7 +189,7 @@ pub async fn make_chunk_with_deletes_at_different_stages(
     // Make an open MUB
     //
     // There may be more than one tables in the lp data
-    let tables = write_lp(&db, &lp_lines.join("\n")).await;
+    let tables = write_lp(&db, &lp_lines.join("\n"));
     for table in &tables {
         let num_mubs = count_mub_table_chunks(&db, table.as_str(), partition_key);
         // must be one MUB per table
@@ -434,7 +434,7 @@ pub async fn make_different_stage_chunks_with_deletes_scenario(
 
         // ----------
         // Make an open MUB
-        write_lp(&db, &chunk_data.lp_lines.join("\n")).await;
+        write_lp(&db, &chunk_data.lp_lines.join("\n"));
         // 0 does not represent the real chunk id. It is here just to initialize the chunk_id  variable for later assignment
         let mut chunk_id = db.chunk_summaries().unwrap()[0].id;
 

--- a/server/src/db/chunk.rs
+++ b/server/src/db/chunk.rs
@@ -635,7 +635,7 @@ mod tests {
     async fn mub_records_access() {
         let (db, time) = make_db_time().await;
 
-        write_lp(&db, "cpu,tag=1 bar=1 1").await;
+        write_lp(&db, "cpu,tag=1 bar=1 1");
 
         let chunks = db.catalog.chunks();
         assert_eq!(chunks.len(), 1);
@@ -650,7 +650,7 @@ mod tests {
     async fn rub_records_access() {
         let (db, time) = make_db_time().await;
 
-        write_lp(&db, "cpu,tag=1 bar=1 1").await;
+        write_lp(&db, "cpu,tag=1 bar=1 1");
         db.compact_partition("cpu", "1970-01-01T00").await.unwrap();
 
         let chunks = db.catalog.chunks();
@@ -667,7 +667,7 @@ mod tests {
         let (db, time) = make_db_time().await;
 
         let t0 = time.inc(Duration::from_secs(324));
-        write_lp(&db, "cpu,tag=1 bar=1 1").await;
+        write_lp(&db, "cpu,tag=1 bar=1 1");
 
         let id = db
             .persist_partition("cpu", "1970-01-01T00", true)
@@ -697,10 +697,10 @@ mod tests {
         let (db, time) = make_db_time().await;
 
         let w0 = time.inc(Duration::from_secs(10));
-        write_lp(&db, "cpu,tag=1 bar=1 1").await;
+        write_lp(&db, "cpu,tag=1 bar=1 1");
 
         let w1 = time.inc(Duration::from_secs(10));
-        write_lp(&db, "cpu,tag=2 bar=2 2").await;
+        write_lp(&db, "cpu,tag=2 bar=2 2");
 
         db.persist_partition("cpu", "1970-01-01T00", true)
             .await

--- a/server/src/db/lifecycle/compact.rs
+++ b/server/src/db/lifecycle/compact.rs
@@ -180,13 +180,13 @@ mod tests {
         let (db, time) = make_db_time().await;
 
         let t_first_write = time.inc(Duration::from_secs(1));
-        write_lp(db.as_ref(), "cpu,tag1=cupcakes bar=1 10").await;
-        write_lp(db.as_ref(), "cpu,tag1=asfd,tag2=foo bar=2 20").await;
-        write_lp(db.as_ref(), "cpu,tag1=bingo,tag2=foo bar=2 10").await;
-        write_lp(db.as_ref(), "cpu,tag1=bongo,tag2=a bar=2 20").await;
+        write_lp(db.as_ref(), "cpu,tag1=cupcakes bar=1 10");
+        write_lp(db.as_ref(), "cpu,tag1=asfd,tag2=foo bar=2 20");
+        write_lp(db.as_ref(), "cpu,tag1=bingo,tag2=foo bar=2 10");
+        write_lp(db.as_ref(), "cpu,tag1=bongo,tag2=a bar=2 20");
 
         let t_last_write = time.inc(Duration::from_secs(1));
-        write_lp(db.as_ref(), "cpu,tag1=bongo,tag2=a bar=2 10").await;
+        write_lp(db.as_ref(), "cpu,tag1=bongo,tag2=a bar=2 10");
 
         let partition_keys = db.partition_keys().unwrap();
         assert_eq!(partition_keys.len(), 1);
@@ -201,7 +201,7 @@ mod tests {
         let (_, fut) = compact_chunks(partition_guard.upgrade(), vec![chunk.upgrade()]).unwrap();
         // NB: perform the write before spawning the background task that performs the compaction
         let t_later_write = time.inc(Duration::from_secs(1));
-        write_lp(db.as_ref(), "cpu,tag1=bongo,tag2=a bar=2 40").await;
+        write_lp(db.as_ref(), "cpu,tag1=bongo,tag2=a bar=2 40");
         tokio::spawn(fut).await.unwrap().unwrap().unwrap();
 
         let mut chunk_summaries: Vec<_> = partition.read().chunk_summaries().collect();
@@ -240,9 +240,9 @@ mod tests {
     async fn test_compact_delete_all() {
         let db = make_db().await.db;
 
-        write_lp(db.as_ref(), "cpu,tag1=cupcakes bar=1 10").await;
-        write_lp(db.as_ref(), "cpu,tag1=cupcakes bar=3 23").await;
-        write_lp(db.as_ref(), "cpu,tag1=cupcakes bar=2 26").await;
+        write_lp(db.as_ref(), "cpu,tag1=cupcakes bar=1 10");
+        write_lp(db.as_ref(), "cpu,tag1=cupcakes bar=3 23");
+        write_lp(db.as_ref(), "cpu,tag1=cupcakes bar=2 26");
 
         let partition_keys = db.partition_keys().unwrap();
         assert_eq!(partition_keys.len(), 1);
@@ -277,10 +277,10 @@ mod tests {
         // |   2 |                      yes |                      yes |
         // |   3 |                       no |                      yes |
         // |   4 |                       no |                       no |
-        write_lp(db.as_ref(), "cpu foo=1 10").await;
-        write_lp(db.as_ref(), "cpu foo=2 20").await;
-        write_lp(db.as_ref(), "cpu foo=3 20").await;
-        write_lp(db.as_ref(), "cpu foo=4 20").await;
+        write_lp(db.as_ref(), "cpu foo=1 10");
+        write_lp(db.as_ref(), "cpu foo=2 20");
+        write_lp(db.as_ref(), "cpu foo=3 20");
+        write_lp(db.as_ref(), "cpu foo=4 20");
 
         let range = TimestampRange {
             start: 0,

--- a/server/src/db/lifecycle/compact_object_store.rs
+++ b/server/src/db/lifecycle/compact_object_store.rs
@@ -390,7 +390,7 @@ mod tests {
 
         let db = make_db().await.db;
         let partition_key = "1970-01-01T00";
-        write_lp(&db, "cpu,tag1=cupcakes bar=1 10").await;
+        write_lp(&db, "cpu,tag1=cupcakes bar=1 10");
 
         let partition = db.lockable_partition("cpu", partition_key).unwrap();
         let partition = partition.write();
@@ -415,7 +415,7 @@ mod tests {
 
         let db = make_db().await.db;
         let partition_key = "1970-01-01T00";
-        write_lp(&db, "cpu,tag1=cupcakes bar=1 10").await;
+        write_lp(&db, "cpu,tag1=cupcakes bar=1 10");
 
         // persisted non persisted chunks
         let partition = db.lockable_partition("cpu", partition_key).unwrap();
@@ -446,7 +446,7 @@ mod tests {
 
         let db = make_db().await.db;
         let partition_key = "1970-01-01T00";
-        write_lp(&db, "cpu,tag1=cupcakes bar=1 10").await;
+        write_lp(&db, "cpu,tag1=cupcakes bar=1 10");
 
         // persist chunk 1
         db.persist_partition("cpu", partition_key, true)
@@ -456,7 +456,7 @@ mod tests {
             .id();
         //
         // persist chunk 2
-        write_lp(db.as_ref(), "cpu,tag1=chunk2,tag2=a bar=2 10").await;
+        write_lp(db.as_ref(), "cpu,tag1=chunk2,tag2=a bar=2 10");
         db.persist_partition("cpu", partition_key, true)
             .await
             .unwrap()
@@ -464,7 +464,7 @@ mod tests {
             .id();
         //
         // persist chunk 3
-        write_lp(db.as_ref(), "cpu,tag1=chunk3,tag2=a bar=2 30").await;
+        write_lp(db.as_ref(), "cpu,tag1=chunk3,tag2=a bar=2 30");
         db.persist_partition("cpu", partition_key, true)
             .await
             .unwrap()
@@ -472,7 +472,7 @@ mod tests {
             .id();
         //
         // Add a MUB
-        write_lp(db.as_ref(), "cpu,tag1=chunk4,tag2=a bar=2 40").await;
+        write_lp(db.as_ref(), "cpu,tag1=chunk4,tag2=a bar=2 40");
 
         // let compact 2 non contiguous chunk 1 and chunk 3
         let partition = db.lockable_partition("cpu", partition_key).unwrap();

--- a/server/src/db/lifecycle/persist.rs
+++ b/server/src/db/lifecycle/persist.rs
@@ -267,7 +267,7 @@ mod tests {
     #[tokio::test]
     async fn test_flush_overlapping() {
         let (db, time) = test_db().await;
-        write_lp(db.as_ref(), "cpu,tag1=cupcakes bar=1 10").await;
+        write_lp(db.as_ref(), "cpu,tag1=cupcakes bar=1 10");
 
         let partition_keys = db.partition_keys().unwrap();
         assert_eq!(partition_keys.len(), 1);
@@ -275,7 +275,7 @@ mod tests {
         // Close window
         time.inc(Duration::from_secs(2));
 
-        write_lp(db.as_ref(), "cpu,tag1=lagged bar=1 10").await;
+        write_lp(db.as_ref(), "cpu,tag1=lagged bar=1 10");
 
         let partition = db.lockable_partition("cpu", &partition_keys[0]).unwrap();
         let partition_guard = partition.read();
@@ -314,10 +314,10 @@ mod tests {
         let late_arrival = Duration::from_secs(1);
 
         time.inc(Duration::from_secs(32));
-        write_lp(db.as_ref(), "cpu,tag1=cupcakes bar=1 10").await;
+        write_lp(db.as_ref(), "cpu,tag1=cupcakes bar=1 10");
 
         time.inc(late_arrival);
-        write_lp(db.as_ref(), "cpu,tag1=cupcakes bar=3 23").await;
+        write_lp(db.as_ref(), "cpu,tag1=cupcakes bar=3 23");
 
         let partition_keys = db.partition_keys().unwrap();
         assert_eq!(partition_keys.len(), 1);
@@ -357,8 +357,8 @@ mod tests {
 
         // Add a second set of writes one of which overlaps the above chunk
         time.inc(late_arrival * 10);
-        write_lp(db.as_ref(), "cpu,tag1=foo bar=2 23").await;
-        write_lp(db.as_ref(), "cpu,tag1=cupcakes bar=2 26").await;
+        write_lp(db.as_ref(), "cpu,tag1=foo bar=2 23");
+        write_lp(db.as_ref(), "cpu,tag1=cupcakes bar=2 26");
 
         // Persist second write but not third
         let maybe_chunk = db
@@ -422,7 +422,7 @@ mod tests {
         let (db, time) = test_db().await;
 
         let late_arrival = Duration::from_secs(1);
-        write_lp(db.as_ref(), "cpu,tag1=cupcakes bar=1 10").await;
+        write_lp(db.as_ref(), "cpu,tag1=cupcakes bar=1 10");
 
         let partition_keys = db.partition_keys().unwrap();
         assert_eq!(partition_keys.len(), 1);
@@ -491,10 +491,10 @@ mod tests {
         // |   2 |                   yes |                   yes |
         // |   3 |                    no |                   yes |
         // |   4 |                    no |                    no |
-        write_lp(db.as_ref(), "cpu foo=1 10").await;
-        write_lp(db.as_ref(), "cpu foo=2 20").await;
-        write_lp(db.as_ref(), "cpu foo=3 20").await;
-        write_lp(db.as_ref(), "cpu foo=4 20").await;
+        write_lp(db.as_ref(), "cpu foo=1 10");
+        write_lp(db.as_ref(), "cpu foo=2 20");
+        write_lp(db.as_ref(), "cpu foo=3 20");
+        write_lp(db.as_ref(), "cpu foo=4 20");
 
         let range = TimestampRange {
             start: 0,

--- a/server/src/utils.rs
+++ b/server/src/utils.rs
@@ -19,7 +19,6 @@ use std::{
 };
 use time::{Time, TimeProvider};
 use uuid::Uuid;
-use write_buffer::core::WriteBufferWriting;
 
 // A wrapper around a Db and a metric registry allowing for isolated testing
 // of a Db and its metrics.
@@ -43,7 +42,6 @@ pub struct TestDbBuilder {
     db_name: DatabaseName<'static>,
     uuid: Uuid,
     worker_cleanup_avg_sleep: Duration,
-    write_buffer_producer: Option<Arc<dyn WriteBufferWriting>>,
     lifecycle_rules: LifecycleRules,
     partition_template: PartitionTemplate,
     time_provider: Arc<dyn TimeProvider>,
@@ -58,7 +56,6 @@ impl Default for TestDbBuilder {
             uuid: Uuid::new_v4(),
             // make background loop spin a bit faster for tests
             worker_cleanup_avg_sleep: Duration::from_secs(1),
-            write_buffer_producer: None,
             // default to quick lifecycle rules for faster tests
             lifecycle_rules: LifecycleRules {
                 late_arrive_window_seconds: NonZeroU32::try_from(1).unwrap(),
@@ -130,7 +127,6 @@ impl TestDbBuilder {
             iox_object_store,
             preserved_catalog,
             catalog,
-            write_buffer_producer: self.write_buffer_producer.clone(),
             exec,
             metric_registry: Arc::clone(&metric_registry),
             time_provider,
@@ -160,14 +156,6 @@ impl TestDbBuilder {
 
     pub fn worker_cleanup_avg_sleep(mut self, d: Duration) -> Self {
         self.worker_cleanup_avg_sleep = d;
-        self
-    }
-
-    pub fn write_buffer_producer(
-        mut self,
-        write_buffer_producer: Arc<dyn WriteBufferWriting>,
-    ) -> Self {
-        self.write_buffer_producer = Some(write_buffer_producer);
         self
     }
 

--- a/server/tests/delete.rs
+++ b/server/tests/delete.rs
@@ -64,29 +64,29 @@ async fn delete_predicate_preservation() {
 
     // 1: preserved
     let partition_key = "part_a";
-    write_lp(&db, "cpu,part=a row=10,selector=0i 10").await;
-    write_lp(&db, "cpu,part=a row=11,selector=1i 11").await;
+    write_lp(&db, "cpu,part=a row=10,selector=0i 10");
+    write_lp(&db, "cpu,part=a row=11,selector=1i 11");
     db.persist_partition(table_name, partition_key, true)
         .await
         .unwrap();
 
     // 2: RUB
     let partition_key = "part_b";
-    write_lp(&db, "cpu,part=b row=20,selector=0i 20").await;
-    write_lp(&db, "cpu,part=b row=21,selector=1i 21").await;
+    write_lp(&db, "cpu,part=b row=20,selector=0i 20");
+    write_lp(&db, "cpu,part=b row=21,selector=1i 21");
     db.compact_partition(table_name, partition_key)
         .await
         .unwrap();
 
     // 3: MUB
     let _partition_key = "part_c";
-    write_lp(&db, "cpu,part=c row=30,selector=0i 30").await;
-    write_lp(&db, "cpu,part=c row=31,selector=1i 31").await;
+    write_lp(&db, "cpu,part=c row=30,selector=0i 30");
+    write_lp(&db, "cpu,part=c row=31,selector=1i 31");
 
     // 4: preserved and unloaded
     let partition_key = "part_d";
-    write_lp(&db, "cpu,part=d row=40,selector=0i 40").await;
-    write_lp(&db, "cpu,part=d row=41,selector=1i 41").await;
+    write_lp(&db, "cpu,part=d row=40,selector=0i 40");
+    write_lp(&db, "cpu,part=d row=41,selector=1i 41");
 
     let chunk_id = db
         .persist_partition(table_name, partition_key, true)

--- a/server_benchmarks/benches/catalog_persistence.rs
+++ b/server_benchmarks/benches/catalog_persistence.rs
@@ -88,7 +88,7 @@ async fn setup(
     let mut chunk_ids = vec![];
 
     for _ in 0..N_CHUNKS {
-        let table_names = write_lp(&db, &lp).await;
+        let table_names = write_lp(&db, &lp);
 
         for table_name in &table_names {
             db.compact_open_chunk(table_name, partition_key)


### PR DESCRIPTION
As a side effect, writing to database no longer requires `async`.

Closes #2243.
