### PR TITLE
ci: add `yamllint` and `shellcheck` to CI image

### DIFF
--- a/docker/Dockerfile.ci
+++ b/docker/Dockerfile.ci
@@ -28,7 +28,7 @@ RUN apt-get update \
   && apt-get install -y \
     git locales sudo openssh-client ca-certificates tar gzip parallel \
     unzip zip bzip2 gnupg curl make pkg-config libssl-dev \
-    jq clang lld g++ \
+    jq clang lld g++ shellcheck yamllint \
     --no-install-recommends \
   && apt-get clean autoclean \
 	&& apt-get autoremove --yes \


### PR DESCRIPTION
This prepares a PR to run these two tools as linters.