### PR TITLE
feat: add CLI command for loading chunks to Read Buffer

### DIFF
--- a/data_types/src/chunk_metadata.rs
+++ b/data_types/src/chunk_metadata.rs
@@ -256,7 +256,7 @@ impl From<ChunkId> for Bytes {
 }
 
 #[derive(Debug, Snafu)]
-pub enum ChunkConversionError {
+pub enum ChunkIdConversionError {
     #[snafu(display("Cannot convert bytes to chunk ID: {}", source))]
     CannotConvertBytes { source: uuid::Error },
 
@@ -265,7 +265,7 @@ pub enum ChunkConversionError {
 }
 
 impl TryFrom<Bytes> for ChunkId {
-    type Error = ChunkConversionError;
+    type Error = ChunkIdConversionError;
 
     fn try_from(value: Bytes) -> Result<Self, Self::Error> {
         Ok(Self(Uuid::from_slice(&value).context(CannotConvertBytes)?))
@@ -281,7 +281,7 @@ impl From<Uuid> for ChunkId {
 /// Implements conversion from the canonical textual representation of a UUID
 /// into a `ChunkId`.
 impl FromStr for ChunkId {
-    type Err = ChunkConversionError;
+    type Err = ChunkIdConversionError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let uuid = Uuid::parse_str(s).context(CannotConvertUUIDText)?;

--- a/data_types/src/chunk_metadata.rs
+++ b/data_types/src/chunk_metadata.rs
@@ -1,5 +1,5 @@
 //! Module contains a representation of chunk metadata
-use std::{convert::TryFrom, num::NonZeroU32, sync::Arc};
+use std::{convert::TryFrom, num::NonZeroU32, str::FromStr, sync::Arc};
 
 use bytes::Bytes;
 use snafu::{ResultExt, Snafu};
@@ -256,13 +256,16 @@ impl From<ChunkId> for Bytes {
 }
 
 #[derive(Debug, Snafu)]
-pub enum BytesToChunkIdError {
+pub enum ChunkConversionError {
     #[snafu(display("Cannot convert bytes to chunk ID: {}", source))]
     CannotConvertBytes { source: uuid::Error },
+
+    #[snafu(display("Cannot convert UUID text to chunk ID: {}", source))]
+    CannotConvertUUIDText { source: uuid::Error },
 }
 
 impl TryFrom<Bytes> for ChunkId {
-    type Error = BytesToChunkIdError;
+    type Error = ChunkConversionError;
 
     fn try_from(value: Bytes) -> Result<Self, Self::Error> {
         Ok(Self(Uuid::from_slice(&value).context(CannotConvertBytes)?))
@@ -272,6 +275,17 @@ impl TryFrom<Bytes> for ChunkId {
 impl From<Uuid> for ChunkId {
     fn from(uuid: Uuid) -> Self {
         Self(uuid)
+    }
+}
+
+/// Implements conversion from the canonical textual representation of a UUID
+/// into a `ChunkId`.
+impl FromStr for ChunkId {
+    type Err = ChunkConversionError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let uuid = Uuid::parse_str(s).context(CannotConvertUUIDText)?;
+        Ok(Self::from(uuid))
     }
 }
 

--- a/influxdb_iox/src/commands/database/chunk.rs
+++ b/influxdb_iox/src/commands/database/chunk.rs
@@ -1,8 +1,11 @@
 //! This module implements the `chunk` CLI command
+use std::str::FromStr;
+
+use data_types::chunk_metadata::{ChunkConversionError, ChunkId};
 use generated_types::google::FieldViolation;
 use influxdb_iox_client::{
     connection::Connection,
-    management::{self, ListChunksError},
+    management::{self, generated_types::Chunk, ListChunksError, LoadPartitionChunkError},
 };
 use structopt::StructOpt;
 use thiserror::Error;
@@ -21,6 +24,15 @@ pub enum Error {
 
     #[error("Error connecting to IOx: {0}")]
     ConnectionError(#[from] influxdb_iox_client::connection::Error),
+
+    #[error("Error loading chunks: {0}")]
+    LoadChunkError(#[from] LoadPartitionChunkError),
+
+    #[error("Chunk {value:?} not found")]
+    ChunkNotFound { value: String },
+
+    #[error("Invalid chunk ID: {0}")]
+    InvalidChunkIDError(#[from] ChunkConversionError),
 }
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
@@ -39,10 +51,21 @@ struct List {
     db_name: String,
 }
 
+/// Loads the specified chunk in the specified database from the Object Store to the Read Buffer.
+#[derive(Debug, StructOpt)]
+struct Load {
+    /// The name of the database
+    db_name: String,
+
+    /// The ID of the chunk
+    chunk_id: String,
+}
+
 /// All possible subcommands for chunk
 #[derive(Debug, StructOpt)]
 enum Command {
     List(List),
+    Load(Load),
 }
 
 pub async fn command(connection: Connection, config: Config) -> Result<()> {
@@ -56,7 +79,42 @@ pub async fn command(connection: Connection, config: Config) -> Result<()> {
 
             serde_json::to_writer_pretty(std::io::stdout(), &chunks)?;
         }
+        Command::Load(load) => {
+            let Load { db_name, chunk_id } = load;
+
+            let mut client = management::Client::new(connection);
+            let chunks = client.list_chunks(&db_name).await?;
+
+            let load_chunk_id = ChunkId::from_str(&chunk_id)?;
+            for chunk in chunks {
+                let id: ChunkId = chunk
+                    .id
+                    .clone()
+                    .try_into()
+                    .expect("catalog chunk IDs to be valid");
+                if id == load_chunk_id {
+                    return load_chunk_to_read_buffer(&mut client, &db_name, chunk).await;
+                }
+            }
+
+            return Err(Error::ChunkNotFound {
+                value: load_chunk_id.to_string(),
+            });
+        }
     }
 
+    Ok(())
+}
+
+async fn load_chunk_to_read_buffer(
+    client: &mut management::Client,
+    db_name: &str,
+    chunk: Chunk,
+) -> Result<()> {
+    let operation = client
+        .load_partition_chunk(db_name, chunk.table_name, chunk.partition_key, chunk.id)
+        .await?;
+
+    serde_json::to_writer_pretty(std::io::stdout(), &operation)?;
     Ok(())
 }

--- a/influxdb_iox/src/commands/database/chunk.rs
+++ b/influxdb_iox/src/commands/database/chunk.rs
@@ -1,7 +1,7 @@
 //! This module implements the `chunk` CLI command
 use std::str::FromStr;
 
-use data_types::chunk_metadata::{ChunkConversionError, ChunkId};
+use data_types::chunk_metadata::{ChunkId, ChunkIdConversionError};
 use generated_types::google::FieldViolation;
 use influxdb_iox_client::{
     connection::Connection,
@@ -32,7 +32,7 @@ pub enum Error {
     ChunkNotFound { value: String },
 
     #[error("Invalid chunk ID: {0}")]
-    InvalidChunkIDError(#[from] ChunkConversionError),
+    InvalidChunkIDError(#[from] ChunkIdConversionError),
 }
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;

--- a/influxdb_iox/tests/end_to_end_cases/management_cli.rs
+++ b/influxdb_iox/tests/end_to_end_cases/management_cli.rs
@@ -7,7 +7,7 @@ use crate::{
     },
 };
 use assert_cmd::Command;
-use data_types::chunk_metadata::{ChunkStorage, ChunkSummary};
+use data_types::chunk_metadata::ChunkStorage;
 use generated_types::{
     google::longrunning::IoxOperation,
     influxdata::iox::management::v1::{operation_metadata::Job, WipePreservedCatalog},

--- a/influxdb_iox_client/src/client/management.rs
+++ b/influxdb_iox_client/src/client/management.rs
@@ -284,7 +284,7 @@ pub enum UnloadPartitionChunkError {
     ServerError(tonic::Status),
 }
 
-/// Errors returned by [`Client::unload_partition_chunk`]
+/// Errors returned by [`Client::load_partition_chunk`]
 #[derive(Debug, Error)]
 pub enum LoadPartitionChunkError {
     /// Database not found
@@ -880,7 +880,7 @@ impl Client {
         Ok(())
     }
 
-    /// Unload chunk from read buffer but keep it in object store.
+    /// Load a chunk from the object store into the Read Buffer.
     pub async fn load_partition_chunk(
         &mut self,
         db_name: impl Into<String> + Send,

--- a/parquet_catalog/src/core.rs
+++ b/parquet_catalog/src/core.rs
@@ -155,7 +155,7 @@ pub enum Error {
 
     #[snafu(display("Cannot decode chunk id: {}", source))]
     CannotDecodeChunkId {
-        source: data_types::chunk_metadata::ChunkConversionError,
+        source: data_types::chunk_metadata::ChunkIdConversionError,
     },
 }
 

--- a/parquet_catalog/src/core.rs
+++ b/parquet_catalog/src/core.rs
@@ -155,7 +155,7 @@ pub enum Error {
 
     #[snafu(display("Cannot decode chunk id: {}", source))]
     CannotDecodeChunkId {
-        source: data_types::chunk_metadata::BytesToChunkIdError,
+        source: data_types::chunk_metadata::ChunkConversionError,
     },
 }
 

--- a/parquet_file/src/metadata.rs
+++ b/parquet_file/src/metadata.rs
@@ -238,7 +238,7 @@ pub enum Error {
 
     #[snafu(display("Cannot decode chunk id: {}", source))]
     CannotDecodeChunkId {
-        source: data_types::chunk_metadata::ChunkConversionError,
+        source: data_types::chunk_metadata::ChunkIdConversionError,
     },
 }
 pub type Result<T, E = Error> = std::result::Result<T, E>;

--- a/parquet_file/src/metadata.rs
+++ b/parquet_file/src/metadata.rs
@@ -238,7 +238,7 @@ pub enum Error {
 
     #[snafu(display("Cannot decode chunk id: {}", source))]
     CannotDecodeChunkId {
-        source: data_types::chunk_metadata::BytesToChunkIdError,
+        source: data_types::chunk_metadata::ChunkConversionError,
     },
 }
 pub type Result<T, E = Error> = std::result::Result<T, E>;


### PR DESCRIPTION
Closes #3267

This PR follows on the work that @tustvold has been doing to teach IOx to load chunks from object storage back into the Read Buffer.

### CLI command

```
$ influxdb_iox database chunk load NAME_OF_DATABASE CHUNK_ID_IN_BASE_16
```

### Testing

I have tested this locally. Start IOx with some persisted chunks and note:

```
influxdb_iox database query query_log "select * from system.chunks"

+--------------------------------------+---------------------+------------+-----------------+------------------+--------------+--------------------+-----------+---------------------+-----------------------------+-----------------------------+-------+
| id                                   | partition_key       | table_name | storage         | lifecycle_action | memory_bytes | object_store_bytes | row_count | time_of_last_access | time_of_first_write         | time_of_last_write          | order |
+--------------------------------------+---------------------+------------+-----------------+------------------+--------------+--------------------+-----------+---------------------+-----------------------------+-----------------------------+-------+
| 47f7d3a6-714e-4ffc-b8f6-0d144c7653d8 | 2021-11-30 10:00:00 | query_log  | ObjectStoreOnly |                  | 17791        | 31740929           | 409920    |                     | 2021-11-30T13:01:56.252683Z | 2021-11-30T13:02:26.684201Z | 1     |
| 5fafd0c1-0d0d-4798-87a0-6accb7d54ec1 | 2021-11-30 10:00:00 | query_log  | ObjectStoreOnly |                  | 33165        | 47253465           | 1022972   |                     | 2021-11-30T13:01:56.252683Z | 2021-11-30T13:02:54.778474Z | 1     |
| fb425523-c822-486c-b317-72a3ba7dbe57 | 2021-11-30 07:00:00 | query_log  | ObjectStoreOnly |                  | 28896        | 47654142           | 870285    |                     | 2021-11-30T13:00:22.754526Z | 2021-11-30T13:00:52.815853Z | 1     |
| 48642d71-1206-42a6-a5d8-5bc0faa752d4 | 2021-11-30 07:00:00 | query_log  | ObjectStoreOnly |                  | 21172        | 25529331           | 450712    |                     | 2021-11-30T13:00:53.403215Z | 2021-11-30T13:01:23.441424Z | 7     |
| 012e9c79-65c8-419c-8a60-c26fbe0bb913 | 2021-11-30 07:00:00 | query_log  | ObjectStoreOnly |                  | 8535         | 3034732            | 44656     |                     | 2021-11-30T13:01:23.879715Z | 2021-11-30T13:01:28.491953Z | 10    |
| 91be1c79-d7da-41f0-b52f-f8816fe1bc7c | 2021-11-30 09:00:00 | query_log  | ObjectStoreOnly |                  | 22652        | 50540440           | 655490    |                     | 2021-11-30T13:01:28.801387Z | 2021-11-30T13:02:01.241539Z | 1     |
| 4e265d94-1479-43f4-8699-7b35738c0d30 | 2021-11-30 09:00:00 | query_log  | ObjectStoreOnly |                  | 29555        | 36484629           | 741147    |                     | 2021-11-30T13:02:01.674413Z | 2021-11-30T13:02:24.800429Z | 6     |
| 2612a9fe-e823-432c-bc65-5c840fd21a08 | 2021-11-30 08:00:00 | query_log  | ObjectStoreOnly |                  | 24563        | 68062178           | 832540    |                     | 2021-11-30T13:00:56.568057Z | 2021-11-30T13:01:27.162309Z | 1     |
| b2152255-5ca8-455d-bbc2-59cdbfbf6818 | 2021-11-30 08:00:00 | query_log  | ObjectStoreOnly |                  | 23672        | 59992826           | 765536    |                     | 2021-11-30T13:00:56.568057Z | 2021-11-30T13:01:55.907730Z | 1     |
| 33837661-7501-460a-9b66-e64549b25b1c | 2021-11-30 05:00:00 | query_log  | ObjectStoreOnly |                  | 15202        | 18005733           | 214902    |                     | 2021-11-30T12:59:53.829897Z | 2021-11-30T13:00:22.399715Z | 1     |
| d2071087-31ab-4e69-90b8-b4e9d81c97fb | 2021-11-30 11:00:00 | query_log  | ObjectStoreOnly |                  | 18198        | 24025063           | 292940    |                     | 2021-11-30T13:02:25.133301Z | 2021-11-30T13:02:54.779559Z | 1     |
| 9b8985bb-0a1e-4c85-b4df-564d9e43f079 | 2021-11-30 06:00:00 | query_log  | ObjectStoreOnly |                  | 16665        | 23570552           | 275732    |                     | 2021-11-30T12:59:53.829199Z | 2021-11-30T13:00:56.207493Z | 1     |
| dddb3c40-15ca-4c02-9360-d865094ee092 | 2021-11-30 06:00:00 | query_log  | ObjectStoreOnly |                  | 28181        | 73027282           | 962017    |                     | 2021-11-30T12:59:53.829199Z | 2021-11-30T13:00:24.552314Z | 1     |
+--------------------------------------+---------------------+------------+-----------------+------------------+--------------+--------------------+-----------+---------------------+-----------------------------+-----------------------------+-------+
```

Then load a chunk:

```
$ influxdb_iox database chunk load query_log "5fafd0c1-0d0d-4798-87a0-6accb7d54ec1"
{
  "operation": {
    "name": "0",
    "metadata": {
      "typeUrl": "type.googleapis.com/influxdata.iox.management.v1.OperationMetadata",
      "value": "GAEgAZoBPQoJcXVlcnlfbG9nEhMyMDIxLTExLTMwIDEwOjAwOjAwGglxdWVyeV9sb2ciEF+v0MENDUeYh6BqzLfVTsE="
    }
  },
  "metadata": {
    "totalCount": "1",
    "pendingCount": "1",
    "loadReadBufferChunk": {
      "dbName": "query_log",
      "partitionKey": "2021-11-30 10:00:00",
      "tableName": "query_log",
      "chunkId": "X6/QwQ0NR5iHoGrMt9VOwQ=="
    }
  }
}%
```

Finally note:

```
+--------------------------------------+---------------------+------------+--------------------------+------------------+--------------+--------------------+-----------+-----------------------------+-----------------------------+-----------------------------+-------+
| id                                   | partition_key       | table_name | storage                  | lifecycle_action | memory_bytes | object_store_bytes | row_count | time_of_last_access         | time_of_first_write         | time_of_last_write          | order |
+--------------------------------------+---------------------+------------+--------------------------+------------------+--------------+--------------------+-----------+-----------------------------+-----------------------------+-----------------------------+-------+
| 47f7d3a6-714e-4ffc-b8f6-0d144c7653d8 | 2021-11-30 10:00:00 | query_log  | ObjectStoreOnly          |                  | 17791        | 31740929           | 409920    |                             | 2021-11-30T13:01:56.252683Z | 2021-11-30T13:02:26.684201Z | 1     |
| 5fafd0c1-0d0d-4798-87a0-6accb7d54ec1 | 2021-11-30 10:00:00 | query_log  | ReadBufferAndObjectStore |                  | 1638014408   | 47253465           | 1022972   | 2021-12-01T11:17:05.306057Z | 2021-11-30T13:01:56.252683Z | 2021-11-30T13:02:54.778474Z | 1     |
| fb425523-c822-486c-b317-72a3ba7dbe57 | 2021-11-30 07:00:00 | query_log  | ObjectStoreOnly          |                  | 28896        | 47654142           | 870285    |                             | 2021-11-30T13:00:22.754526Z | 2021-11-30T13:00:52.815853Z | 1     |
| 48642d71-1206-42a6-a5d8-5bc0faa752d4 | 2021-11-30 07:00:00 | query_log  | ObjectStoreOnly          |                  | 21172        | 25529331           | 450712    |                             | 2021-11-30T13:00:53.403215Z | 2021-11-30T13:01:23.441424Z | 7     |
| 012e9c79-65c8-419c-8a60-c26fbe0bb913 | 2021-11-30 07:00:00 | query_log  | ObjectStoreOnly          |                  | 8535         | 3034732            | 44656     |                             | 2021-11-30T13:01:23.879715Z | 2021-11-30T13:01:28.491953Z | 10    |
| 91be1c79-d7da-41f0-b52f-f8816fe1bc7c | 2021-11-30 09:00:00 | query_log  | ObjectStoreOnly          |                  | 22652        | 50540440           | 655490    |                             | 2021-11-30T13:01:28.801387Z | 2021-11-30T13:02:01.241539Z | 1     |
| 4e265d94-1479-43f4-8699-7b35738c0d30 | 2021-11-30 09:00:00 | query_log  | ObjectStoreOnly          |                  | 29555        | 36484629           | 741147    |                             | 2021-11-30T13:02:01.674413Z | 2021-11-30T13:02:24.800429Z | 6     |
| 2612a9fe-e823-432c-bc65-5c840fd21a08 | 2021-11-30 08:00:00 | query_log  | ObjectStoreOnly          |                  | 24563        | 68062178           | 832540    |                             | 2021-11-30T13:00:56.568057Z | 2021-11-30T13:01:27.162309Z | 1     |
| b2152255-5ca8-455d-bbc2-59cdbfbf6818 | 2021-11-30 08:00:00 | query_log  | ObjectStoreOnly          |                  | 23672        | 59992826           | 765536    |                             | 2021-11-30T13:00:56.568057Z | 2021-11-30T13:01:55.907730Z | 1     |
| 33837661-7501-460a-9b66-e64549b25b1c | 2021-11-30 05:00:00 | query_log  | ObjectStoreOnly          |                  | 15202        | 18005733           | 214902    |                             | 2021-11-30T12:59:53.829897Z | 2021-11-30T13:00:22.399715Z | 1     |
| d2071087-31ab-4e69-90b8-b4e9d81c97fb | 2021-11-30 11:00:00 | query_log  | ObjectStoreOnly          |                  | 18198        | 24025063           | 292940    |                             | 2021-11-30T13:02:25.133301Z | 2021-11-30T13:02:54.779559Z | 1     |
| 9b8985bb-0a1e-4c85-b4df-564d9e43f079 | 2021-11-30 06:00:00 | query_log  | ObjectStoreOnly          |                  | 16665        | 23570552           | 275732    |                             | 2021-11-30T12:59:53.829199Z | 2021-11-30T13:00:56.207493Z | 1     |
| dddb3c40-15ca-4c02-9360-d865094ee092 | 2021-11-30 06:00:00 | query_log  | ObjectStoreOnly          |                  | 28181        | 73027282           | 962017    |                             | 2021-11-30T12:59:53.829199Z | 2021-11-30T13:00:24.552314Z | 1     |
+--------------------------------------+---------------------+------------+--------------------------+------------------+--------------+--------------------+-----------+-----------------------------+-----------------------------+-----------------------------+-------+
```

Showing the chunk is now in both the object store and the Read Buffer.