### PR TITLE
chore: Update Rust and fix or allow new Rust+clippy warnings

### DIFF
--- a/data_types/src/partition_metadata.rs
+++ b/data_types/src/partition_metadata.rs
@@ -353,7 +353,7 @@ impl Statistics {
             Self::U64(v) => v.min.map(|x| Cow::Owned(x.to_string())),
             Self::F64(v) => v.min.map(|x| Cow::Owned(x.to_string())),
             Self::Bool(v) => v.min.map(|x| Cow::Owned(x.to_string())),
-            Self::String(v) => v.min.as_deref().map(|x| Cow::Borrowed(x)),
+            Self::String(v) => v.min.as_deref().map(Cow::Borrowed),
         }
     }
 
@@ -364,7 +364,7 @@ impl Statistics {
             Self::U64(v) => v.max.map(|x| Cow::Owned(x.to_string())),
             Self::F64(v) => v.max.map(|x| Cow::Owned(x.to_string())),
             Self::Bool(v) => v.max.map(|x| Cow::Owned(x.to_string())),
-            Self::String(v) => v.max.as_deref().map(|x| Cow::Borrowed(x)),
+            Self::String(v) => v.max.as_deref().map(Cow::Borrowed),
         }
     }
 

--- a/influxdb_iox/src/commands/debug/mod.rs
+++ b/influxdb_iox/src/commands/debug/mod.rs
@@ -22,7 +22,7 @@ pub struct Config {
 #[derive(Debug, StructOpt)]
 enum Command {
     /// Dump preserved catalog.
-    DumpCatalog(dump_catalog::Config),
+    DumpCatalog(Box<dump_catalog::Config>),
 
     /// Prints what CPU features are used by the compiler by default.
     PrintCpu,
@@ -30,7 +30,7 @@ enum Command {
 
 pub async fn command(config: Config) -> Result<()> {
     match config.command {
-        Command::DumpCatalog(dump_catalog) => dump_catalog::command(dump_catalog)
+        Command::DumpCatalog(dump_catalog) => dump_catalog::command(*dump_catalog)
             .await
             .context(DumpCatalogError),
         Command::PrintCpu => {

--- a/influxdb_iox/src/influxdb_ioxd/http/mod.rs
+++ b/influxdb_iox/src/influxdb_ioxd/http/mod.rs
@@ -201,8 +201,10 @@ async fn pprof_home(req: Request<Body>) -> Result<Response<Body>, ApplicationErr
 #[derive(Debug, Deserialize)]
 struct PProfArgs {
     #[serde(default = "PProfArgs::default_seconds")]
+    #[allow(dead_code)]
     seconds: u64,
     #[serde(default = "PProfArgs::default_frequency")]
+    #[allow(dead_code)]
     frequency: NonZeroI32,
 }
 
@@ -220,6 +222,7 @@ impl PProfArgs {
 #[derive(Debug, Deserialize)]
 struct PProfAllocsArgs {
     #[serde(default = "PProfAllocsArgs::default_seconds")]
+    #[allow(dead_code)]
     seconds: u64,
     // The sampling interval is a number of bytes that have to cumulatively allocated for a sample to be taken.
     //
@@ -227,6 +230,7 @@ struct PProfAllocsArgs {
     // the allocations profile will account for 16MB instead of 40MB.
     // Heappy will adjust the estimate for sampled recordings, but now that feature is not yet implemented.
     #[serde(default = "PProfAllocsArgs::default_interval")]
+    #[allow(dead_code)]
     interval: NonZeroI32,
 }
 

--- a/influxdb_iox/tests/common/udp_listener.rs
+++ b/influxdb_iox/tests/common/udp_listener.rs
@@ -115,14 +115,14 @@ impl UdpCapture {
     }
 
     // wait for a message to appear that passes `pred` or the timeout expires
-    pub async fn wait_for<P>(&self, mut pred: P)
+    pub async fn wait_for<P>(&self, pred: P)
     where
-        P: FnMut(&Message) -> bool,
+        P: FnMut(&Message) -> bool + Copy,
     {
         let end = Instant::now() + Duration::from_secs(MAX_WAIT_TIME_SEC);
 
         while Instant::now() < end {
-            if self.messages.lock().iter().any(|m| pred(m)) {
+            if self.messages.lock().iter().any(pred) {
                 return;
             }
             tokio::time::sleep(Duration::from_millis(200)).await

--- a/influxdb_iox/tests/end_to_end_cases/storage_api.rs
+++ b/influxdb_iox/tests/end_to_end_cases/storage_api.rs
@@ -867,7 +867,7 @@ async fn do_read_group_request(
 }
 
 fn dump_data_frames(frames: &[Data]) -> Vec<String> {
-    frames.iter().map(|f| dump_data(f)).collect()
+    frames.iter().map(dump_data).collect()
 }
 
 fn dump_data(data: &Data) -> String {

--- a/iox_data_generator/src/measurement.rs
+++ b/iox_data_generator/src/measurement.rs
@@ -644,8 +644,8 @@ mod test {
                 split.next();
                 let after_space = split.next().unwrap();
                 let prefix = format!(",{}=", field_name);
-                let after = after_space.rsplitn(2, &prefix).next().unwrap();
-                after.splitn(2, ',').next().unwrap()
+                let after = after_space.rsplit_once(&prefix).unwrap().1;
+                after.split_once(',').map_or(after, |x| x.0)
             })
             .collect()
     }

--- a/iox_data_generator/src/measurement.rs
+++ b/iox_data_generator/src/measurement.rs
@@ -207,6 +207,7 @@ impl MeasurementGenerator {
 #[derive(Debug)]
 pub struct Measurement {
     name: String,
+    #[allow(dead_code)]
     id: usize,
     tag_pairs: Vec<Arc<TagPair>>,
     generated_tag_sets: Arc<Vec<TagSet>>,

--- a/iox_data_generator/src/tag_set.rs
+++ b/iox_data_generator/src/tag_set.rs
@@ -57,7 +57,9 @@ type Result<T, E = Error> = std::result::Result<T, E>;
 /// A collection of pre-generated values.
 #[derive(Debug)]
 pub struct GeneratedValueCollection {
+    #[allow(dead_code)]
     name: String,
+    #[allow(dead_code)]
     values: Vec<GeneratedValue>,
 }
 

--- a/metric/src/lib.rs
+++ b/metric/src/lib.rs
@@ -566,6 +566,6 @@ mod tests {
     #[test]
     #[should_panic(expected = "string must be [0-9a-z_]+ got: \"foo bar\"")]
     fn illegal_attribute_name() {
-        Attributes::from(&[("foo bar", "value")]);
+        let _ = Attributes::from(&[("foo bar", "value")]);
     }
 }

--- a/mutable_batch_tests/src/lib.rs
+++ b/mutable_batch_tests/src/lib.rs
@@ -10,7 +10,7 @@ pub fn benchmark_lp() -> Vec<(String, String)> {
     let env = std::env::var("BENCHMARK_LP")
         .expect("set BENCHMARK_LP to a semicolon-delimited list of source files");
 
-    env.split(';').map(|path| read_path(path)).collect()
+    env.split(';').map(read_path).collect()
 }
 
 fn read_path(path: &str) -> (String, String) {

--- a/mutable_buffer/src/lib.rs
+++ b/mutable_buffer/src/lib.rs
@@ -56,6 +56,7 @@ pub struct MBChunk {
     table_name: Arc<str>,
 
     /// Metrics tracked by this chunk
+    #[allow(dead_code)]
     metrics: ChunkMetrics,
 
     /// Map of column id from the chunk dictionary to the column

--- a/mutable_buffer/src/snapshot.rs
+++ b/mutable_buffer/src/snapshot.rs
@@ -31,6 +31,7 @@ pub type Result<T, E = Error> = std::result::Result<T, E>;
 pub struct ChunkSnapshot {
     schema: Arc<Schema>,
     batch: RecordBatch,
+    #[allow(dead_code)]
     table_name: Arc<str>,
     summary: TableSummary,
 }

--- a/object_store/src/azure.rs
+++ b/object_store/src/azure.rs
@@ -54,6 +54,7 @@ pub enum Error {
 #[derive(Debug)]
 pub struct MicrosoftAzure {
     container_client: Arc<ContainerClient>,
+    #[allow(dead_code)]
     container_name: String,
 }
 

--- a/parquet_file/src/chunk.rs
+++ b/parquet_file/src/chunk.rs
@@ -102,6 +102,7 @@ pub struct ParquetChunk {
     /// Number of rows
     rows: usize,
 
+    #[allow(dead_code)]
     metrics: ChunkMetrics,
 }
 

--- a/persistence_windows/src/persistence_windows.rs
+++ b/persistence_windows/src/persistence_windows.rs
@@ -50,6 +50,7 @@ pub struct PersistenceWindows {
     closed_window_period: Duration,
 
     /// The instant this PersistenceWindows was created
+    #[allow(dead_code)]
     time_of_first_write: Time,
 
     /// The maximum Wall timestamp that has been passed to PersistenceWindows::add_range

--- a/query/src/provider/overlap.rs
+++ b/query/src/provider/overlap.rs
@@ -118,6 +118,7 @@ where
     index: usize,
 
     /// The underlying chunk
+    #[allow(dead_code)]
     chunk: &'a C,
 
     /// the ColumnSummaries for the chunk's 'primary_key' columns, in

--- a/query_tests/src/scenarios.rs
+++ b/query_tests/src/scenarios.rs
@@ -81,9 +81,7 @@ pub fn get_all_setups() -> &'static HashMap<String, Arc<dyn DbSetup>> {
 
 /// Return a reference to the specified scenario
 pub fn get_db_setup(setup_name: impl AsRef<str>) -> Option<Arc<dyn DbSetup>> {
-    get_all_setups()
-        .get(setup_name.as_ref())
-        .map(|setup| Arc::clone(setup))
+    get_all_setups().get(setup_name.as_ref()).map(Arc::clone)
 }
 
 /// No data

--- a/read_buffer/src/column/encoding/scalar/transcoders.rs
+++ b/read_buffer/src/column/encoding/scalar/transcoders.rs
@@ -190,22 +190,11 @@ use std::{sync::atomic, sync::atomic::AtomicUsize, sync::Arc};
 #[cfg(test)]
 /// A mock implementation of Transcoder that tracks calls to encode and decode.
 /// This is useful for testing encoder implementations.
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct MockTranscoder {
     encoding_calls: AtomicUsize,
     decoding_calls: AtomicUsize,
     partial_cmp_calls: AtomicUsize,
-}
-
-#[cfg(test)]
-impl Default for MockTranscoder {
-    fn default() -> Self {
-        Self {
-            encoding_calls: AtomicUsize::default(),
-            decoding_calls: AtomicUsize::default(),
-            partial_cmp_calls: AtomicUsize::default(),
-        }
-    }
 }
 
 #[cfg(test)]

--- a/read_buffer/src/row_group.rs
+++ b/read_buffer/src/row_group.rs
@@ -1909,7 +1909,7 @@ impl Display for &ReadFilterResult<'_> {
         let mut iter_map = self
             .data
             .iter()
-            .map(|v| ValuesIterator::new(v))
+            .map(ValuesIterator::new)
             .collect::<Vec<_>>();
 
         let columns = iter_map.len();

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.56"
+channel = "1.57"
 components = [ "rustfmt", "clippy" ]

--- a/server/src/db.rs
+++ b/server/src/db.rs
@@ -209,6 +209,7 @@ pub struct Db {
 
     name: Arc<str>,
 
+    #[allow(dead_code)]
     server_id: ServerId, // this is also the Query Server ID
 
     /// Interface to use for persistence

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -226,20 +226,11 @@ pub trait DatabaseStore: std::fmt::Debug + Send + Sync {
 }
 
 /// Configuration options for `Server`
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct ServerConfig {
     pub wipe_catalog_on_error: bool,
 
     pub skip_replay_and_seek_instead: bool,
-}
-
-impl Default for ServerConfig {
-    fn default() -> Self {
-        Self {
-            wipe_catalog_on_error: false,
-            skip_replay_and_seek_instead: false,
-        }
-    }
 }
 
 /// `Server` is the container struct for how servers store data internally, as

--- a/test_helpers/src/tracing.rs
+++ b/test_helpers/src/tracing.rs
@@ -19,6 +19,7 @@ use parking_lot::Mutex;
 pub struct TracingCapture {
     /// The raw logs are captured as a list of strings
     logs: Arc<Mutex<Vec<String>>>,
+    #[allow(dead_code)]
     guard: DefaultGuard,
 }
 

--- a/write_buffer/src/file.rs
+++ b/write_buffer/src/file.rs
@@ -279,7 +279,7 @@ impl FileBufferConsumer {
             .collect();
         Ok(Self {
             dirs,
-            trace_collector: trace_collector.map(|x| Arc::clone(x)),
+            trace_collector: trace_collector.map(Arc::clone),
         })
     }
 }

--- a/write_buffer/src/kafka.rs
+++ b/write_buffer/src/kafka.rs
@@ -492,7 +492,7 @@ impl KafkaBufferConsumer {
             consumer,
             callback_background_task,
             queues,
-            trace_collector: trace_collector.map(|x| Arc::clone(x)),
+            trace_collector: trace_collector.map(Arc::clone),
             write_buffer_ingest_entry_size,
         })
     }


### PR DESCRIPTION
The biggest change is probably that Rust is now able to detect that fields are unread. I marked all those with `#[allow(dead_code)]` because I'm not sure if they're valid or if they're signs of work to come or if they're old code that can be cleaned up.