### PR TITLE
feat: add to-be-created-chunk-id for compacting OS chunks in CatalogChunk

### DIFF
--- a/data_types/src/chunk_metadata.rs
+++ b/data_types/src/chunk_metadata.rs
@@ -98,9 +98,7 @@ pub enum ChunkLifecycleAction {
     Compacting,
 
     /// Object Store Chunk is in the process of being compacted
-    /// The ChunkId is the ID of the new chunk that will replace this chunk
-    /// after the compaction is completed
-    CompactingObjectStore(ChunkId),
+    CompactingObjectStore,
 
     /// Chunk is about to be dropped from memory and (if persisted) from object store
     Dropping,
@@ -120,7 +118,7 @@ impl ChunkLifecycleAction {
         match self {
             Self::Persisting => "Persisting to Object Storage",
             Self::Compacting => "Compacting",
-            Self::CompactingObjectStore(_chunk_id) => "Compacting Object Store",
+            Self::CompactingObjectStore => "Compacting Object Store",
             Self::Dropping => "Dropping",
             Self::LoadingReadBuffer => "Loading to Read Buffer",
         }
@@ -149,6 +147,10 @@ pub struct ChunkSummary {
     /// Is there any outstanding lifecycle action for this chunk?
     pub lifecycle_action: Option<ChunkLifecycleAction>,
 
+    // todo: I am debating whether to add to_be_created_chunk_id here.
+    // If we want this to fully reflect CatalogChunk, then we should add it.
+    // However if we do, we also need to add it to management::Chunk API which I found maybe better to
+    // go with the other solution https://github.com/influxdata/influxdb_iox/pull/3275#pullrequestreview-821179885
     /// The number of bytes used to store this chunk in memory
     pub memory_bytes: usize,
 

--- a/generated_types/src/chunk.rs
+++ b/generated_types/src/chunk.rs
@@ -64,9 +64,7 @@ impl From<Option<ChunkLifecycleAction>> for management::ChunkLifecycleAction {
         match lifecycle_action {
             Some(ChunkLifecycleAction::Persisting) => Self::Persisting,
             Some(ChunkLifecycleAction::Compacting) => Self::Compacting,
-            Some(ChunkLifecycleAction::CompactingObjectStore(_chunk_id)) => {
-                Self::CompactingObjectStore
-            } // todo: use chunk_id
+            Some(ChunkLifecycleAction::CompactingObjectStore) => Self::CompactingObjectStore,
             Some(ChunkLifecycleAction::Dropping) => Self::Dropping,
             Some(ChunkLifecycleAction::LoadingReadBuffer) => Self::LoadingReadBuffer,
             None => Self::Unspecified,
@@ -158,8 +156,7 @@ impl TryFrom<management::ChunkLifecycleAction> for Option<ChunkLifecycleAction> 
                 Ok(Some(ChunkLifecycleAction::Compacting))
             }
             management::ChunkLifecycleAction::CompactingObjectStore => {
-                let chunk_id = ChunkId::new_test(1); // todo: need to replace 1 with a meaningful chunk_id
-                Ok(Some(ChunkLifecycleAction::CompactingObjectStore(chunk_id)))
+                Ok(Some(ChunkLifecycleAction::CompactingObjectStore))
             }
             management::ChunkLifecycleAction::LoadingReadBuffer => {
                 Ok(Some(ChunkLifecycleAction::LoadingReadBuffer))


### PR DESCRIPTION
Another piece of #3089 

As a followup of #3252 to have the chunkID of ChunkLifeCycleAction::CompactingObjectStore(ChunkID) mapped to its proto, this #3275 does that. However, we think it may be better not to do so and add the chunkID in CatalogChunk instead. This PR does that.

The funny thing is `CatalogChunk`  has a mapping `ChunkSummary` that also has a protocol counterpart. See the detail comment for this. 

- [ ] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb_iox/blob/main/README.md).
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
