### PR TITLE
refactor: don't generate replay plan for new catalog

### DIFF
--- a/server/src/database.rs
+++ b/server/src/database.rs
@@ -202,7 +202,6 @@ impl Database {
             iox_object_store,
             Arc::clone(application.metric_registry()),
             Arc::clone(application.time_provider()),
-            true,
         )
         .await
         .context(CannotCreatePreservedCatalog)?;


### PR DESCRIPTION
This was just a strange API quirk that I noticed whilst working on #3282. A new catalog by definition cannot have a replay plan as it can't have any chunks with checkpoints