### PR TITLE
feat: Create a build-time-optimized release build profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,3 +85,8 @@ lto = "thin"
 
 [profile.bench]
 debug = true
+
+[profile.quick-release]
+inherits = "release"
+codegen-units = 16
+lto = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,6 +78,8 @@ exclude = [
     "tools/",
 ]
 
+# This profile optimizes for runtime performance and small binary size at the expense of longer
+# build times. It's most suitable for final release builds.
 [profile.release]
 codegen-units = 1
 debug = true
@@ -86,6 +88,8 @@ lto = "thin"
 [profile.bench]
 debug = true
 
+# This profile optimizes for short build times at the expense of larger binary size and slower
+# runtime performance. It's most suitable for development iterations.
 [profile.quick-release]
 inherits = "release"
 codegen-units = 16

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,3 +94,4 @@ debug = true
 inherits = "release"
 codegen-units = 16
 lto = false
+incremental = true

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,8 +30,8 @@ RUN \
   --mount=type=cache,id=influxdb_iox_target,sharing=locked,target=/influxdb_iox/target \
     du -cshx /usr/local/cargo/registry /usr/local/cargo/git /influxdb_iox/target && \
     cargo build --target-dir /influxdb_iox/target --profile="$PROFILE" --no-default-features --features="$FEATURES" && \
-    objcopy --compress-debug-sections target/release/influxdb_iox && \
-    cp /influxdb_iox/target/release/influxdb_iox /root/influxdb_iox && \
+    objcopy --compress-debug-sections "target/$PROFILE/influxdb_iox" && \
+    cp "/influxdb_iox/target/$PROFILE/influxdb_iox" /root/influxdb_iox && \
     du -cshx /usr/local/cargo/registry /usr/local/cargo/git /influxdb_iox/target
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,14 +14,12 @@ COPY . /influxdb_iox
 WORKDIR /influxdb_iox
 
 ARG CARGO_INCREMENTAL=yes
-ARG CARGO_PROFILE_RELEASE_CODEGEN_UNITS=1
-ARG CARGO_PROFILE_RELEASE_LTO=thin
+ARG PROFILE=release
 ARG FEATURES=aws,gcp,azure,jemalloc_replacing_malloc
 ARG ROARING_ARCH="haswell"
 ARG RUSTFLAGS=""
 ENV CARGO_INCREMENTAL=$CARGO_INCREMENTAL \
-    CARGO_PROFILE_RELEASE_CODEGEN_UNITS=$CARGO_PROFILE_RELEASE_CODEGEN_UNITS \
-    CARGO_PROFILE_RELEASE_LTO=$CARGO_PROFILE_RELEASE_LTO \
+    PROFILE=$PROFILE \
     FEATURES=$FEATURES \
     ROARING_ARCH=$ROARING_ARCH \
     RUSTFLAGS=$RUSTFLAGS
@@ -31,7 +29,7 @@ RUN \
   --mount=type=cache,id=influxdb_iox_git,sharing=locked,target=/usr/local/cargo/git \
   --mount=type=cache,id=influxdb_iox_target,sharing=locked,target=/influxdb_iox/target \
     du -cshx /usr/local/cargo/registry /usr/local/cargo/git /influxdb_iox/target && \
-    cargo build --target-dir /influxdb_iox/target --release --no-default-features --features="$FEATURES" && \
+    cargo build --target-dir /influxdb_iox/target --profile="$PROFILE" --no-default-features --features="$FEATURES" && \
     objcopy --compress-debug-sections target/release/influxdb_iox && \
     cp /influxdb_iox/target/release/influxdb_iox /root/influxdb_iox && \
     du -cshx /usr/local/cargo/registry /usr/local/cargo/git /influxdb_iox/target


### PR DESCRIPTION
Closes #3316

A "full build" was me deleting `/target` and then running the command. A "rebuild" was me changing a particular `unreachable!` to a `panic!` in the `read_buffer` crate.

| Command | Full build | Rebuild |
|-----------|-----------|---------|
| `cargo build --release` |  7m 24s | 5m 13s |
| `cargo build --profile quick-release` | 4m 11s | 2m 06s |

Bikeshed time:

- Should the profile optimizing for compile time be `--release` or should the profile optimizing for binary size be `--release`?
- What should the name of the non-`--release` profile be?
- Any other comparison stats you want to see?
- Any other settings that should be changed?