### PR TITLE
ci: LLD linking +docker image for data generator

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -350,7 +350,7 @@ jobs:
 
             docker buildx build \
               --build-arg RUST_VERSION="$RUST_VERSION" \
-              --build-arg RUSTFLAGS="-C target-feature=+avx2" \
+              --build-arg RUSTFLAGS="-C target-feature=+avx2 -C link-arg=-fuse-ld=lld" \
               --progress plain \
               --tag quay.io/influxdb/iox:"$COMMIT_SHA" \
               --tag quay.io/influxdb/iox:"$(echo "$CIRCLE_BRANCH" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/_/g')" \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -344,21 +344,32 @@ jobs:
       - run:
           name: Cargo release build with target arch set for CRoaring
           command: |
-            COMMIT_SHA=$(git rev-parse --short HEAD)
+            COMMIT_SHA="$(git rev-parse --short HEAD)"
 
-            RUST_VERSION=$(sed -E -ne 's/channel = "(.*)"/\1/p' rust-toolchain.toml)
+            RUST_VERSION="$(sed -E -ne 's/channel = "(.*)"/\1/p' rust-toolchain.toml)"
+            BRANCH="$(echo "$CIRCLE_BRANCH" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/_/g')"
 
             docker buildx build \
               --build-arg RUST_VERSION="$RUST_VERSION" \
               --build-arg RUSTFLAGS="-C target-feature=+avx2 -C link-arg=-fuse-ld=lld" \
               --progress plain \
               --tag quay.io/influxdb/iox:"$COMMIT_SHA" \
-              --tag quay.io/influxdb/iox:"$(echo "$CIRCLE_BRANCH" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/_/g')" \
+              --tag quay.io/influxdb/iox:"$BRANCH" \
+              .
+            docker buildx build \
+              --build-arg FEATURES="" \
+              --build-arg PACKAGE="iox_data_generator" \
+              --build-arg RUST_VERSION="$RUST_VERSION" \
+              --build-arg RUSTFLAGS="-C target-feature=+avx2 -C link-arg=-fuse-ld=lld" \
+              --progress plain \
+              --tag quay.io/influxdb/iox_data_generator:"$COMMIT_SHA" \
+              --tag quay.io/influxdb/iox_data_generator:"$BRANCH" \
               .
 
             docker run -it --rm quay.io/influxdb/iox:$COMMIT_SHA debug print-cpu
 
             docker push --all-tags quay.io/influxdb/iox
+            docker push --all-tags quay.io/influxdb/iox_data_generator
 
             echo "export COMMIT_SHA=${COMMIT_SHA}" >> $BASH_ENV
           # linking might take a while and doesn't produce CLI output

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,11 +16,13 @@ WORKDIR /influxdb_iox
 ARG CARGO_INCREMENTAL=yes
 ARG PROFILE=release
 ARG FEATURES=aws,gcp,azure,jemalloc_replacing_malloc,kafka
+ARG PACKAGE=influxdb_iox
 ARG ROARING_ARCH="haswell"
 ARG RUSTFLAGS=""
 ENV CARGO_INCREMENTAL=$CARGO_INCREMENTAL \
     PROFILE=$PROFILE \
     FEATURES=$FEATURES \
+    PACKAGE=$PACKAGE \
     ROARING_ARCH=$ROARING_ARCH \
     RUSTFLAGS=$RUSTFLAGS
 
@@ -29,9 +31,9 @@ RUN \
   --mount=type=cache,id=influxdb_iox_git,sharing=locked,target=/usr/local/cargo/git \
   --mount=type=cache,id=influxdb_iox_target,sharing=locked,target=/influxdb_iox/target \
     du -cshx /usr/local/cargo/registry /usr/local/cargo/git /influxdb_iox/target && \
-    cargo build --target-dir /influxdb_iox/target --profile="$PROFILE" --no-default-features --features="$FEATURES" && \
-    objcopy --compress-debug-sections "target/$PROFILE/influxdb_iox" && \
-    cp "/influxdb_iox/target/$PROFILE/influxdb_iox" /root/influxdb_iox && \
+    cargo build --target-dir /influxdb_iox/target --package="$PACKAGE" --profile="$PROFILE" --no-default-features --features="$FEATURES" && \
+    objcopy --compress-debug-sections "target/$PROFILE/$PACKAGE" && \
+    cp "/influxdb_iox/target/$PROFILE/$PACKAGE" /root/$PACKAGE && \
     du -cshx /usr/local/cargo/registry /usr/local/cargo/git /influxdb_iox/target
 
 
@@ -50,7 +52,10 @@ USER iox
 RUN mkdir ~/.influxdb_iox
 RUN ls -la ~/.influxdb_iox
 
-COPY --from=build /root/influxdb_iox /usr/bin/influxdb_iox
+ARG PACKAGE=influxdb_iox
+ENV PACKAGE=$PACKAGE
+
+COPY --from=build "/root/$PACKAGE" "/usr/bin/$PACKAGE"
 COPY docker/entrypoint.sh /usr/bin/entrypoint.sh
 
 ENV INFLUXDB_IOX_SERVER_MODE=database

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ FROM rust:${RUST_VERSION}-slim-bullseye as build
 USER root
 
 RUN apt update \
-    && apt install --yes binutils build-essential pkg-config libssl-dev clang \
+    && apt install --yes binutils build-essential pkg-config libssl-dev clang lld \
     && rm -rf /var/lib/{apt,dpkg,cache,log}
 
 # Build influxdb_iox

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -7,4 +7,4 @@ for i in "${!args[@]}"; do
     args[$i]="$(echo "${args[$i]}" | envsubst)"
 done
 
-exec influxdb_iox "${args[@]}"
+exec "$PACKAGE" "${args[@]}"


### PR DESCRIPTION
# LLD
Also includes a patch to speed up linking a bit by using `lld`. We tried to do this for a long time already (introduced in #1022):

https://github.com/influxdata/influxdb_iox/blob/95f907efd8f7de900eb2cca8c3165e19abb9554f/.cargo/config#L1-L4

The issue was that since #2118 we are setting the `RUSTFLAGS` environment variable which overrides the cargo config. The patch combines both flags into single env var and also installs `lld` (otherwise linking obviously fails).

# Data Generator Image

Closes #3322.

## Test Build
Triggered via CircleCI REST API.

- **Job:** <https://app.circleci.com/pipelines/github/influxdata/influxdb_iox/13696/workflows/02cdd6a2-3d8b-458e-8503-95ce4abc38cd/jobs/102100>
- **IOx Image:** <https://quay.io/repository/influxdb/iox?tab=tags> (`crepererum_issue3322`/`2f2ef97f`)
- **Data Generator Image:** <https://quay.io/repository/influxdb/iox_data_generator?tab=tags> (`crepererum_issue3322`/`2f2ef97f`)