### PR TITLE
fix: allow setting the same server ID twice

### DIFF
--- a/influxdb_iox/tests/end_to_end_cases/deployment_api.rs
+++ b/influxdb_iox/tests/end_to_end_cases/deployment_api.rs
@@ -129,7 +129,16 @@ async fn assert_set_get_server_id(server_fixture: ServerFixture) {
     let got = client.get_server_id().await.expect("get ID failed");
     assert_eq!(got, Some(test_id));
 
-    // setting server ID a second time should fail
+    // setting server ID to same ID should be OK
+    client
+        .update_server_id(test_id)
+        .await
+        .expect("set ID again failed");
+
+    let got = client.get_server_id().await.expect("get ID failed");
+    assert_eq!(got, Some(test_id));
+
+    // setting server ID to a different ID should fail
     let result = client
         .update_server_id(NonZeroU32::try_from(13).unwrap())
         .await;


### PR DESCRIPTION
This is important for idempotence and simplifies clients and helper
scripts a lot.
