### PR TITLE
fix: limit number of S3 connections

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2486,6 +2486,8 @@ dependencies = [
  "dotenv",
  "futures",
  "futures-test",
+ "hyper",
+ "hyper-tls",
  "indexmap",
  "itertools",
  "observability_deps",

--- a/influxdb_iox/src/structopt_blocks/object_store.rs
+++ b/influxdb_iox/src/structopt_blocks/object_store.rs
@@ -1,5 +1,5 @@
 //! CLI handling for object store config (via CLI arguments and environment variables).
-use std::{convert::TryFrom, fs, path::PathBuf, time::Duration};
+use std::{convert::TryFrom, fs, num::NonZeroUsize, path::PathBuf, time::Duration};
 
 use clap::arg_enum;
 use futures::TryStreamExt;
@@ -172,6 +172,14 @@ Possible values (case insensitive):
     /// environments.
     #[structopt(long = "--azure-storage-access-key", env = "AZURE_STORAGE_ACCESS_KEY")]
     pub azure_storage_access_key: Option<String>,
+
+    /// When using a network-based object store, limit the number of connection to this value.
+    #[structopt(
+        long = "--object-store-connection-limit",
+        env = "OBJECT_STORE_CONNECTION_LIMIT",
+        default_value = "16"
+    )]
+    pub object_store_connection_limit: NonZeroUsize,
 }
 
 arg_enum! {
@@ -267,6 +275,7 @@ impl TryFrom<&ObjectStoreConfig> for ObjectStore {
                             bucket,
                             endpoint,
                             session_token,
+                            config.object_store_connection_limit,
                         )
                         .context(InvalidS3Config)
                     }

--- a/object_store/Cargo.toml
+++ b/object_store/Cargo.toml
@@ -15,6 +15,10 @@ chrono = { version = "0.4", default-features = false, features = ["clock"] }
 # Google Cloud Storage integration
 cloud-storage = {version = "0.10.3", optional = true}
 futures = "0.3"
+# for rusoto
+hyper = { version = "0.14", optional = true, default-features = false }
+# for rusoto
+hyper-tls = { version = "0.5.0", optional = true, default-features = false }
 indexmap = { version = "1.7", optional = true, features = ["std"] }
 itertools = "0.10.1"
 observability_deps = { path = "../observability_deps" }
@@ -36,7 +40,7 @@ workspace-hack = { path = "../workspace-hack"}
 [features]
 azure = ["azure_core", "azure_storage", "indexmap", "reqwest"]
 gcp = ["cloud-storage"]
-aws = ["rusoto_core", "rusoto_credential", "rusoto_s3"]
+aws = ["rusoto_core", "rusoto_credential", "rusoto_s3", "hyper", "hyper-tls"]
 
 [dev-dependencies] # In alphabetical order
 dotenv = "0.15.0"

--- a/object_store/src/dummy.rs
+++ b/object_store/src/dummy.rs
@@ -1,5 +1,7 @@
 //! Crate that mimics the interface of the the various object stores
 //! but does nothing if they are not enabled.
+use std::num::NonZeroUsize;
+
 use async_trait::async_trait;
 use bytes::Bytes;
 use snafu::Snafu;
@@ -89,6 +91,7 @@ pub(crate) fn new_s3(
     _bucket_name: impl Into<String>,
     _endpoint: Option<impl Into<String>>,
     _session_token: Option<impl Into<String>>,
+    _max_connections: NonZeroUsize,
 ) -> Result<DummyObjectStore> {
     NotSupported { name: "aws" }.fail()
 }

--- a/object_store/src/lib.rs
+++ b/object_store/src/lib.rs
@@ -59,7 +59,7 @@ use bytes::Bytes;
 use chrono::{DateTime, Utc};
 use futures::{stream::BoxStream, StreamExt, TryFutureExt, TryStreamExt};
 use snafu::{ResultExt, Snafu};
-use std::fmt::Formatter;
+use std::{fmt::Formatter, num::NonZeroUsize};
 use std::{path::PathBuf, sync::Arc};
 
 /// Universal API to multiple object store services.
@@ -118,6 +118,7 @@ impl ObjectStore {
         bucket_name: impl Into<String>,
         endpoint: Option<impl Into<String>>,
         session_token: Option<impl Into<String>>,
+        max_connections: NonZeroUsize,
     ) -> Result<Self> {
         let s3 = aws::new_s3(
             access_key_id,
@@ -126,6 +127,7 @@ impl ObjectStore {
             bucket_name,
             endpoint,
             session_token,
+            max_connections,
         )?;
         Ok(Self {
             integration: ObjectStoreIntegration::AmazonS3(s3),


### PR DESCRIPTION
Otherwise the whole thing blows up when starting a server that has many
DBs registered, because we potentially create 1 connection per DB (e.g.
to read out the preserved catalog).

Fixes #3336.

Work for other backends is tracked under #3341.
