### PR TITLE
feat: add regex to bucket writers assignment in data generator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1725,6 +1725,7 @@ dependencies = [
  "influxdb_iox_client",
  "itertools",
  "rand",
+ "regex",
  "serde",
  "serde_json",
  "snafu",

--- a/iox_data_generator/Cargo.toml
+++ b/iox_data_generator/Cargo.toml
@@ -17,6 +17,7 @@ influxdb2_client = { path = "../influxdb2_client" }
 influxdb_iox_client = { path = "../influxdb_iox_client" }
 itertools = "0.10.0"
 rand = { version = "0.8.3", features = ["small_rng"] }
+regex = "1.5"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.72"
 snafu = "0.6.8"

--- a/iox_data_generator/benches/point_generation.rs
+++ b/iox_data_generator/benches/point_generation.rs
@@ -30,7 +30,8 @@ pub fn single_agent(c: &mut Criterion) {
             tag_pairs: vec![],
         }],
         bucket_writers: vec![BucketWriterSpec {
-            ratio: 1.0,
+            ratio: Some(1.0),
+            regex: None,
             agents: vec![AgentAssignmentSpec {
                 name: "foo".to_string(),
                 count: None,

--- a/iox_data_generator/benches/point_generation.rs
+++ b/iox_data_generator/benches/point_generation.rs
@@ -1,6 +1,6 @@
 use criterion::{criterion_group, criterion_main, Criterion, Throughput};
 use iox_data_generator::agent::Agent;
-use iox_data_generator::specification::{AgentAssignmentSpec, BucketWriterSpec, OrgBucket};
+use iox_data_generator::specification::{AgentAssignmentSpec, DatabaseWriterSpec};
 use iox_data_generator::{
     specification::{AgentSpec, DataSpec, FieldSpec, FieldValueSpec, MeasurementSpec},
     tag_set::GeneratedTagSets,
@@ -29,9 +29,9 @@ pub fn single_agent(c: &mut Criterion) {
             has_one: vec![],
             tag_pairs: vec![],
         }],
-        bucket_writers: vec![BucketWriterSpec {
-            ratio: Some(1.0),
-            regex: None,
+        database_writers: vec![DatabaseWriterSpec {
+            database_ratio: Some(1.0),
+            database_regex: None,
             agents: vec![AgentAssignmentSpec {
                 name: "foo".to_string(),
                 count: None,
@@ -56,10 +56,7 @@ pub fn single_agent(c: &mut Criterion) {
         b.iter(|| {
             let r = block_on(iox_data_generator::generate(
                 &spec,
-                vec![OrgBucket {
-                    org: "foo".to_string(),
-                    bucket: "bar".to_string(),
-                }],
+                vec!["foo_bar".to_string()],
                 &mut points_writer,
                 start_datetime,
                 end_datetime,
@@ -154,8 +151,7 @@ tag_pairs = [
 name = "gauge"
 i64_range = [1, 8147240]
 
-[[bucket_writers]]
-ratio = 1.0
+[[database_writers]]
 agents = [{name = "foo", sampling_interval = "1s", count = 3}]
 "#).unwrap();
 

--- a/iox_data_generator/schemas/cap-write.toml
+++ b/iox_data_generator/schemas/cap-write.toml
@@ -2,8 +2,8 @@
 # https://github.com/influxdata/idpe/tree/e493a8e9b6b773e9374a8542ddcab7d8174d320d/performance/capacity/write
 name = "cap_write"
 
-[[bucket_writers]]
-ratio = 1.0
+[[database_writers]]
+database_ratio = 1.0
 agents = [{name = "telegraf", count = 3, sampling_interval = "10s"}]
 
 [[agents]]

--- a/iox_data_generator/schemas/full_example.toml
+++ b/iox_data_generator/schemas/full_example.toml
@@ -169,20 +169,20 @@ count = 2
 name = "f1"
 bool = true
 
-# bucket_writers specify how to split up the list of supplied buckets to write to. If
+# database_writers specify how to split up the list of supplied buckets to write to. If
 # only a single one is specified via the CLI flags, then you'd want only a single bucket_writer
 # with a percent of 1.0.
 #
 # These make it possible to split up a large list of buckets to write to and send different
 # amounts of write load as well as different schemas through specifying different agents.
-[[bucket_writers]]
-# 20% of the buckets specified in the --bucket_list file will have these agents writing to them
-ratio = 0.2
-# for each of those buckets, have 3 of the first_agent writing every 10s, and 1 of the another_example writing every minute.
+[[database_writers]]
+# the first 20% of the databases specified in the --bucket_list file will have these agents writing to them
+database_ratio = 0.2
+# for each of those databases, have 3 of the first_agent writing every 10s, and 1 of the another_example writing every minute.
 agents = [{name = "first_agent", count = 3, sampling_interval = "10s"}, {name = "another_example", sampling_interval = "1m"}]
 
-[[bucket_writers]]
-# the remaining 80% of the buckeets specified will write using these agents
-ratio = 0.8
+[[database_writers]]
+# the remaining 80% of the databases specified will write using these agents
+database_ratio = 0.8
 # we'll only have a single agent of another_example for each database
 agents = [{name = "another_example", sampling_interval = "1s"}]

--- a/iox_data_generator/schemas/storage_cardinality_example.toml
+++ b/iox_data_generator/schemas/storage_cardinality_example.toml
@@ -58,8 +58,8 @@ for_each = [
     "partition_id",
 ]
 
-[[bucket_writers]]
-ratio = 1.0
+[[database_writers]]
+database_ratio = 1.0
 agents = [{name = "sender", sampling_interval = "10s"}]
 
 [[agents]]

--- a/iox_data_generator/schemas/tracing-spec.toml
+++ b/iox_data_generator/schemas/tracing-spec.toml
@@ -30,6 +30,6 @@ tag_pairs = [
 name = "timing"
 f64_range = [0.0, 500.0]
 
-[[bucket_writers]]
-ratio = 1.0
+[[database_writers]]
+database_ratio = 1.0
 agents = [{name = "tracing_agent", sampling_interval = "1s"}]

--- a/iox_data_generator/src/measurement.rs
+++ b/iox_data_generator/src/measurement.rs
@@ -547,8 +547,7 @@ mod test {
             name = "val"
             i64_range = [3, 3]
 
-            [[bucket_writers]]
-            ratio = 1.0
+            [[database_writers]]
             agents = [{name = "foo", sampling_interval = "10s"}]"#,
         )
             .unwrap();
@@ -610,8 +609,8 @@ mod test {
             name = "val"
             i64_range = [3, 3]
 
-            [[bucket_writers]]
-            ratio = 1.0
+            [[database_writers]]
+            database_ratio = 1.0
             agents = [{name = "foo", sampling_interval = "10s"}]"#,
         )
         .unwrap();

--- a/iox_data_generator/src/tag_set.rs
+++ b/iox_data_generator/src/tag_set.rs
@@ -493,8 +493,7 @@ name = "cpu"
 name = "f1"
 i64_range = [0, 23]
 
-[[bucket_writers]]
-ratio = 1.0
+[[database_writers]]
 agents = [{name = "foo", sampling_interval = "10s"}]"#;
 
         let spec = DataSpec::from_str(toml).unwrap();
@@ -541,8 +540,7 @@ name = "cpu"
 name = "f1"
 i64_range = [0, 23]
 
-[[bucket_writers]]
-ratio = 1.0
+[[database_writers]]
 agents = [{name = "foo", sampling_interval = "10s"}]"#;
 
         let spec = DataSpec::from_str(toml).unwrap();
@@ -610,8 +608,8 @@ name = "cpu"
 name = "f1"
 i64_range = [0, 23]
 
-[[bucket_writers]]
-ratio = 1.0
+[[database_writers]]
+database_ratio = 1.0
 agents = [{name = "foo", sampling_interval = "10s"}]"#;
 
         let spec = DataSpec::from_str(toml).unwrap();

--- a/iox_data_generator/src/write.rs
+++ b/iox_data_generator/src/write.rs
@@ -342,8 +342,7 @@ name = "cpu"
 name = "val"
 i64_range = [3,3]
 
-[[bucket_writers]]
-ratio = 1.0
+[[database_writers]]
 agents = [{name = "foo", sampling_interval = "1s"}]
 "#;
 
@@ -354,10 +353,7 @@ agents = [{name = "foo", sampling_interval = "1s"}]
 
         generate(
             &data_spec,
-            vec![OrgBucket {
-                org: "foo".to_string(),
-                bucket: "bar".to_string(),
-            }],
+            vec!["foo_bar".to_string()],
             &mut points_writer_builder,
             Some(now),
             Some(now),
@@ -395,8 +391,7 @@ name = "cpu"
 name = "val"
 i64_range = [2, 2]
 
-[[bucket_writers]]
-ratio = 1.0
+[[database_writers]]
 agents = [{name = "foo", sampling_interval = "1s"}]
 "#;
 
@@ -407,10 +402,7 @@ agents = [{name = "foo", sampling_interval = "1s"}]
 
         generate(
             &data_spec,
-            vec![OrgBucket {
-                org: "foo".to_string(),
-                bucket: "bar".to_string(),
-            }],
+            vec!["foo_bar".to_string()],
             &mut points_writer_builder,
             Some(now - 1_000_000_000),
             Some(now),

--- a/perf/battery-0/datagen.toml
+++ b/perf/battery-0/datagen.toml
@@ -13,6 +13,6 @@ tag_pairs = [
 name = "usage_user"
 f64_range = [0.0, 100.0]
 
-[[bucket_writers]]
-ratio = 1.0
+[[database_writers]]
+database_ratio = 1.0
 agents = [{name = "foo", count = 3, sampling_interval = "10s"}]


### PR DESCRIPTION
This adds the ability to specify a regex to match against database names when specifying what agents should write to which buckets in the data generator.

A default has also been added for ratio so that it doesn't need to be specified if only a single database writer is defined.

Closes #3344 