### PR TITLE
feat: Optionally build Kafka

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -185,7 +185,7 @@ jobs:
       - cache_restore
       - run:
           name: Cargo test
-          command: cargo test --workspace
+          command: cargo test --workspace --features=kafka
       - cache_save
 
   # end to end tests with Heappy (heap profiling enabled)
@@ -240,7 +240,7 @@ jobs:
             - cargo-lock-{{ checksum "Cargo.lock" }}
       - run:
           name: Prime Rust build cache
-          command: cargo build --package influxdb_iox --bin influxdb_iox --package iox_data_generator --bin iox_data_generator
+          command: cargo build --package influxdb_iox --bin influxdb_iox --package iox_data_generator --bin iox_data_generator --features=kafka
       - save_cache:
           key: cargo-lock-{{ checksum "Cargo.lock" }}
           paths:
@@ -277,8 +277,8 @@ jobs:
           name: Build benches
           command: cargo test --workspace --benches --no-run
       - run:
-          name: Build with object store + exporter support + HEAP profiling
-          command: cargo build --no-default-features --features="aws,gcp,azure,heappy,pprof"
+          name: Build with object store + exporter support + HEAP profiling + kafka
+          command: cargo build --no-default-features --features="aws,gcp,azure,heappy,pprof,kafka"
       - cache_save
 
   # Lint protobufs.

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ WORKDIR /influxdb_iox
 
 ARG CARGO_INCREMENTAL=yes
 ARG PROFILE=release
-ARG FEATURES=aws,gcp,azure,jemalloc_replacing_malloc
+ARG FEATURES=aws,gcp,azure,jemalloc_replacing_malloc,kafka
 ARG ROARING_ARCH="haswell"
 ARG RUSTFLAGS=""
 ENV CARGO_INCREMENTAL=$CARGO_INCREMENTAL \

--- a/influxdb_iox/Cargo.toml
+++ b/influxdb_iox/Cargo.toml
@@ -124,3 +124,7 @@ jemalloc_replacing_malloc = ["tikv-jemalloc-sys"]
 # Implicit feature selected when running under `clippy --all-features` to accept mutable exclusive features during
 # linting
 clippy = []
+
+# Enable the write buffer implemented with Kafka. Disabled by default to save build time when not
+# working on Kafka write buffer-related code.
+kafka = ["router/kafka", "server/kafka"]

--- a/influxdb_iox/tests/end_to_end_cases/kafka.rs
+++ b/influxdb_iox/tests/end_to_end_cases/kafka.rs
@@ -1,0 +1,34 @@
+use crate::common::server_fixture::{ServerFixture, ServerType};
+use influxdb_iox_client::management::generated_types::*;
+use std::time::Instant;
+use test_helpers::assert_contains;
+
+#[tokio::test]
+async fn test_create_database_invalid_kafka() {
+    let server_fixture = ServerFixture::create_shared(ServerType::Database).await;
+    let mut client = server_fixture.management_client();
+
+    let rules = DatabaseRules {
+        name: "db_with_bad_kafka_address".into(),
+        write_buffer_connection: Some(WriteBufferConnection {
+            r#type: "kafka".into(),
+            connection: "i_am_not_a_kafka_server:1234".into(),
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+
+    let start = Instant::now();
+    let err = client
+        .create_database(rules)
+        .await
+        .expect_err("expected request to fail");
+
+    println!("Failed after {:?}", Instant::now() - start);
+
+    // expect that this error has a useful error related to kafka (not "timeout")
+    assert_contains!(
+        err.to_string(),
+        "error creating write buffer: Meta data fetch error: BrokerTransportFailure"
+    );
+}

--- a/influxdb_iox/tests/end_to_end_cases/management_api.rs
+++ b/influxdb_iox/tests/end_to_end_cases/management_api.rs
@@ -1,3 +1,10 @@
+use crate::{
+    common::server_fixture::{ServerFixture, ServerType, TestConfig, DEFAULT_SERVER_ID},
+    end_to_end_cases::scenario::{
+        create_readable_database, create_two_partition_database, create_unreadable_database,
+        fixture_broken_catalog, rand_name, wait_for_exact_chunk_states, DatabaseBuilder,
+    },
+};
 use data_types::chunk_metadata::ChunkId;
 use generated_types::google::protobuf::{Duration, Empty};
 use influxdb_iox_client::{
@@ -8,20 +15,8 @@ use influxdb_iox_client::{
         Client,
     },
 };
-use std::{fs::set_permissions, num::NonZeroU32, os::unix::fs::PermissionsExt};
+use std::{fs::set_permissions, num::NonZeroU32, os::unix::fs::PermissionsExt, time::Instant};
 use test_helpers::{assert_contains, assert_error};
-
-use super::scenario::{
-    create_readable_database, create_two_partition_database, create_unreadable_database, rand_name,
-};
-use crate::common::server_fixture::{TestConfig, DEFAULT_SERVER_ID};
-use crate::{
-    common::server_fixture::{ServerFixture, ServerType},
-    end_to_end_cases::scenario::{
-        fixture_broken_catalog, wait_for_exact_chunk_states, DatabaseBuilder,
-    },
-};
-use std::time::Instant;
 use uuid::Uuid;
 
 #[tokio::test]

--- a/influxdb_iox/tests/end_to_end_cases/management_api.rs
+++ b/influxdb_iox/tests/end_to_end_cases/management_api.rs
@@ -7,7 +7,6 @@ use influxdb_iox_client::{
         generated_types::{database_status::DatabaseState, operation_metadata::Job, *},
         Client,
     },
-    router::generated_types::WriteBufferConnection,
 };
 use std::{fs::set_permissions, num::NonZeroU32, os::unix::fs::PermissionsExt};
 use test_helpers::{assert_contains, assert_error};
@@ -83,36 +82,6 @@ async fn test_create_database_invalid_name() {
         }
         _ => panic!("unexpected response: {:?}", r),
     }
-}
-
-#[tokio::test]
-async fn test_create_database_invalid_kafka() {
-    let server_fixture = ServerFixture::create_shared(ServerType::Database).await;
-    let mut client = server_fixture.management_client();
-
-    let rules = DatabaseRules {
-        name: "db_with_bad_kafka_address".into(),
-        write_buffer_connection: Some(WriteBufferConnection {
-            r#type: "kafka".into(),
-            connection: "i_am_not_a_kafka_server:1234".into(),
-            ..Default::default()
-        }),
-        ..Default::default()
-    };
-
-    let start = Instant::now();
-    let err = client
-        .create_database(rules)
-        .await
-        .expect_err("expected request to fail");
-
-    println!("Failed after {:?}", Instant::now() - start);
-
-    // expect that this error has a useful error related to kafka (not "timeout")
-    assert_contains!(
-        err.to_string(),
-        "error creating write buffer: Meta data fetch error: BrokerTransportFailure"
-    );
 }
 
 #[tokio::test]

--- a/influxdb_iox/tests/end_to_end_cases/mod.rs
+++ b/influxdb_iox/tests/end_to_end_cases/mod.rs
@@ -8,6 +8,10 @@ mod flight_api;
 mod freeze;
 mod http;
 mod influxdb_ioxd;
+
+#[cfg(feature = "kafka")]
+mod kafka;
+
 mod management_api;
 mod management_cli;
 mod metrics;

--- a/perf/perf.py
+++ b/perf/perf.py
@@ -397,7 +397,7 @@ def cargo_build_iox(debug=False, build_with_aws=True):
     t = time.time()
     print('building IOx')
 
-    features = []
+    features = ['kafka']
     if build_with_aws:
         features.append('aws')
     features = ','.join(features)

--- a/router/Cargo.toml
+++ b/router/Cargo.toml
@@ -25,3 +25,6 @@ workspace-hack = { path = "../workspace-hack"}
 mutable_batch_lp = { path = "../mutable_batch_lp" }
 regex = "1"
 tokio = { version = "1.13", features = ["macros", "parking_lot"] }
+
+[features]
+kafka = ["write_buffer/kafka"]

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -65,5 +65,8 @@ test_helpers = { path = "../test_helpers" }
 
 [features]
 default = []
+
 # Enable features for benchmarking
 bench = ["mutable_buffer/nocache"]
+
+kafka = ["write_buffer/kafka"]

--- a/write_buffer/Cargo.toml
+++ b/write_buffer/Cargo.toml
@@ -19,7 +19,7 @@ observability_deps = { path = "../observability_deps" }
 parking_lot = "0.11.2"
 pin-project = "1.0"
 prost = "0.8"
-rdkafka = "0.28.0"
+rdkafka = { version = "0.28.0", optional = true }
 time = { path = "../time" }
 tokio = { version = "1.13", features = ["fs", "macros", "parking_lot", "rt", "sync", "time"] }
 tokio-util = "0.6.9"
@@ -27,6 +27,9 @@ trace = { path = "../trace" }
 trace_http = { path = "../trace_http" }
 uuid = { version = "0.8", features = ["v4"] }
 workspace-hack = { path = "../workspace-hack"}
+
+[features]
+kafka = ["rdkafka"]
 
 [dev-dependencies]
 tempfile = "3.1.0"

--- a/write_buffer/src/codec.rs
+++ b/write_buffer/src/codec.rs
@@ -100,11 +100,13 @@ impl IoxHeaders {
     }
 
     /// Gets the content type
+    #[allow(dead_code)] // this function is only used in optionally-compiled kafka code
     pub fn content_type(&self) -> ContentType {
         self.content_type
     }
 
     /// Gets the span context if any
+    #[allow(dead_code)] // this function is only used in optionally-compiled kafka code
     pub fn span_context(&self) -> Option<&SpanContext> {
         self.span_context.as_ref()
     }

--- a/write_buffer/src/config.rs
+++ b/write_buffer/src/config.rs
@@ -1,14 +1,3 @@
-use parking_lot::RwLock;
-use std::{
-    collections::{btree_map::Entry, BTreeMap},
-    path::PathBuf,
-    sync::Arc,
-};
-
-use data_types::{server_id::ServerId, write_buffer::WriteBufferConnection};
-use time::TimeProvider;
-use trace::TraceCollector;
-
 use crate::{
     core::{WriteBufferError, WriteBufferReading, WriteBufferWriting},
     file::{FileBufferConsumer, FileBufferProducer},
@@ -17,6 +6,15 @@ use crate::{
         MockBufferForWritingThatAlwaysErrors, MockBufferSharedState,
     },
 };
+use data_types::{server_id::ServerId, write_buffer::WriteBufferConnection};
+use parking_lot::RwLock;
+use std::{
+    collections::{btree_map::Entry, BTreeMap},
+    path::PathBuf,
+    sync::Arc,
+};
+use time::TimeProvider;
+use trace::TraceCollector;
 
 #[derive(Debug)]
 pub enum WriteBufferConfig {
@@ -244,14 +242,11 @@ impl WriteBufferConfigFactory {
 
 #[cfg(test)]
 mod tests {
-    use std::{convert::TryFrom, num::NonZeroU32};
-
-    use data_types::{write_buffer::WriteBufferCreationConfig, DatabaseName};
-    use tempfile::TempDir;
-
-    use crate::{core::test_utils::random_topic_name, mock::MockBufferSharedState};
-
     use super::*;
+    use crate::{core::test_utils::random_topic_name, mock::MockBufferSharedState};
+    use data_types::{write_buffer::WriteBufferCreationConfig, DatabaseName};
+    use std::{convert::TryFrom, num::NonZeroU32};
+    use tempfile::TempDir;
 
     #[tokio::test]
     async fn test_writing_file() {

--- a/write_buffer/src/core.rs
+++ b/write_buffer/src/core.rs
@@ -112,8 +112,14 @@ pub mod test_utils {
     use futures::{StreamExt, TryStreamExt};
     use time::{Time, TimeProvider};
     use trace::{ctx::SpanContext, RingBufferTraceCollector, TraceCollector};
+    use uuid::Uuid;
 
     use super::{WriteBufferError, WriteBufferReading, WriteBufferWriting};
+
+    /// Generated random topic name for testing.
+    pub fn random_topic_name() -> String {
+        format!("test_topic_{}", Uuid::new_v4())
+    }
 
     /// Adapter to make a concrete write buffer implementation work w/ [`perform_generic_tests`].
     #[async_trait]

--- a/write_buffer/src/core.rs
+++ b/write_buffer/src/core.rs
@@ -99,6 +99,10 @@ pub trait WriteBufferReading: Sync + Send + Debug + 'static {
 
 pub mod test_utils {
     //! Generic tests for all write buffer implementations.
+    use super::{WriteBufferError, WriteBufferReading, WriteBufferWriting};
+    use async_trait::async_trait;
+    use dml::{test_util::assert_write_op_eq, DmlMeta, DmlOperation, DmlWrite};
+    use futures::{StreamExt, TryStreamExt};
     use std::{
         collections::{BTreeMap, BTreeSet},
         convert::TryFrom,
@@ -106,15 +110,9 @@ pub mod test_utils {
         sync::Arc,
         time::Duration,
     };
-
-    use async_trait::async_trait;
-    use dml::{test_util::assert_write_op_eq, DmlMeta, DmlOperation, DmlWrite};
-    use futures::{StreamExt, TryStreamExt};
     use time::{Time, TimeProvider};
     use trace::{ctx::SpanContext, RingBufferTraceCollector, TraceCollector};
     use uuid::Uuid;
-
-    use super::{WriteBufferError, WriteBufferReading, WriteBufferWriting};
 
     /// Generated random topic name for testing.
     pub fn random_topic_name() -> String {

--- a/write_buffer/src/kafka.rs
+++ b/write_buffer/src/kafka.rs
@@ -748,7 +748,6 @@ pub mod test_utils {
     use std::{collections::BTreeMap, time::Duration};
 
     use rdkafka::admin::{AdminOptions, AlterConfig, ResourceSpecifier};
-    use uuid::Uuid;
 
     use super::admin_client;
 
@@ -829,11 +828,6 @@ pub mod test_utils {
         let result = results.pop().expect("just checked the vector length");
         result.unwrap();
     }
-
-    /// Generated random topic name for testing.
-    pub fn random_kafka_topic() -> String {
-        format!("test_topic_{}", Uuid::new_v4())
-    }
 }
 
 /// Kafka tests (only run when in integration test mode and kafka is running).
@@ -850,11 +844,11 @@ mod tests {
 
     use crate::codec::HEADER_CONTENT_TYPE;
     use crate::{
+        core::test_utils::random_topic_name,
         core::test_utils::{
             map_pop_first, perform_generic_tests, set_pop_first, write as write_to_writer,
             TestAdapter, TestContext,
         },
-        kafka::test_utils::random_kafka_topic,
         maybe_skip_kafka_integration,
     };
 
@@ -881,7 +875,7 @@ mod tests {
         ) -> Self::Context {
             KafkaTestContext {
                 conn: self.conn.clone(),
-                database_name: random_kafka_topic(),
+                database_name: random_topic_name(),
                 server_id_counter: AtomicU32::new(1),
                 n_sequencers,
                 time_provider,
@@ -964,7 +958,7 @@ mod tests {
     #[tokio::test]
     async fn topic_create_twice() {
         let conn = maybe_skip_kafka_integration!();
-        let database_name = random_kafka_topic();
+        let database_name = random_topic_name();
 
         create_kafka_topic(
             &conn,

--- a/write_buffer/src/kafka.rs
+++ b/write_buffer/src/kafka.rs
@@ -1,11 +1,3 @@
-use std::{
-    collections::{BTreeMap, BTreeSet},
-    convert::{TryFrom, TryInto},
-    num::NonZeroU32,
-    sync::Arc,
-    time::Duration,
-};
-
 use async_trait::async_trait;
 use futures::{FutureExt, StreamExt};
 use metric::{Metric, U64Gauge, U64Histogram, U64HistogramOptions};
@@ -23,15 +15,13 @@ use rdkafka::{
     util::Timeout,
     ClientConfig, ClientContext, Message, Offset, TopicPartitionList,
 };
-
-use data_types::{
-    sequence::Sequence, server_id::ServerId, write_buffer::WriteBufferCreationConfig,
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    convert::{TryFrom, TryInto},
+    num::NonZeroU32,
+    sync::Arc,
+    time::Duration,
 };
-use dml::{DmlMeta, DmlOperation};
-use observability_deps::tracing::{debug, info};
-use time::{Time, TimeProvider};
-use tokio::task::JoinHandle;
-use trace::TraceCollector;
 
 use crate::{
     codec::{ContentType, IoxHeaders},
@@ -40,6 +30,14 @@ use crate::{
         WriteBufferWriting, WriteStream,
     },
 };
+use data_types::{
+    sequence::Sequence, server_id::ServerId, write_buffer::WriteBufferCreationConfig,
+};
+use dml::{DmlMeta, DmlOperation};
+use observability_deps::tracing::{debug, info};
+use time::{Time, TimeProvider};
+use tokio::task::JoinHandle;
+use trace::TraceCollector;
 
 /// Default timeout supplied to rdkafka client for kafka operations.
 ///
@@ -745,11 +743,9 @@ impl ClientContext for ClientContextImpl {
 impl ConsumerContext for ClientContextImpl {}
 
 pub mod test_utils {
-    use std::{collections::BTreeMap, time::Duration};
-
-    use rdkafka::admin::{AdminOptions, AlterConfig, ResourceSpecifier};
-
     use super::admin_client;
+    use rdkafka::admin::{AdminOptions, AlterConfig, ResourceSpecifier};
+    use std::{collections::BTreeMap, time::Duration};
 
     /// Get the testing Kafka connection string or return current scope.
     ///
@@ -834,25 +830,21 @@ pub mod test_utils {
 /// see [`crate::maybe_skip_kafka_integration`] for more details.
 #[cfg(test)]
 mod tests {
+    use super::{test_utils::kafka_sequencer_options, *};
+    use crate::{
+        codec::HEADER_CONTENT_TYPE,
+        core::test_utils::{
+            map_pop_first, perform_generic_tests, random_topic_name, set_pop_first,
+            write as write_to_writer, TestAdapter, TestContext,
+        },
+        maybe_skip_kafka_integration,
+    };
     use std::{
         num::NonZeroU32,
         sync::atomic::{AtomicU32, Ordering},
     };
-
     use time::TimeProvider;
     use trace::{RingBufferTraceCollector, TraceCollector};
-
-    use crate::codec::HEADER_CONTENT_TYPE;
-    use crate::{
-        core::test_utils::random_topic_name,
-        core::test_utils::{
-            map_pop_first, perform_generic_tests, set_pop_first, write as write_to_writer,
-            TestAdapter, TestContext,
-        },
-        maybe_skip_kafka_integration,
-    };
-
-    use super::{test_utils::kafka_sequencer_options, *};
 
     struct KafkaTestAdapter {
         conn: String,

--- a/write_buffer/src/lib.rs
+++ b/write_buffer/src/lib.rs
@@ -12,5 +12,8 @@ pub(crate) mod codec;
 pub mod config;
 pub mod core;
 pub mod file;
+
+#[cfg(feature = "kafka")]
 pub mod kafka;
+
 pub mod mock;


### PR DESCRIPTION
Closes #3315.

This saves me ~15 seconds on a release build. According to the Cargo timings analysis, on this branch:

```
$ cargo build --release 
```

builds 441 total units (crates?) in 7m 59.2s.

```
$ cargo build --release --features kafka
```

builds 455 total units in 8m 13.6s.