### PR TITLE
docs: Update database startup machine diagram

### DIFF
--- a/server/src/database.rs
+++ b/server/src/database.rs
@@ -1069,7 +1069,7 @@ pub enum InitError {
 ///
 /// 3. An error is encountered, in which case it transitions to one of
 /// the error states. Most are Terminal (and thus require operator
-/// intervention) but some (such as `WriteBufferCreationError` may
+/// intervention) but some (such as `WriteBufferCreationError`) may
 /// resolve after some time to the basic initialization sequence
 /// (e.g. `Initialized`)
 ///


### PR DESCRIPTION

# Rationale
As [noted](https://github.com/influxdata/influxdb_iox/pull/3292#pullrequestreview-826159666
) by @crepererum , the diagram (well textual description really) has drifted from the reality

# Changes
Update the docstring of `DatabaseState` enum