### PR TITLE
chore: Update datafusion and sqlparser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -781,7 +781,7 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "6.0.0"
-source = "git+https://github.com/apache/arrow-datafusion.git?rev=0338b7336d257bdbdc5eefceda5846e3a5b31409#0338b7336d257bdbdc5eefceda5846e3a5b31409"
+source = "git+https://github.com/apache/arrow-datafusion.git?rev=b17e1b2b60618ba82818846ab079a916248b8c4f#b17e1b2b60618ba82818846ab079a916248b8c4f"
 dependencies = [
  "ahash",
  "arrow",
@@ -4021,9 +4021,9 @@ dependencies = [
 
 [[package]]
 name = "sqlparser"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "760e624412a15d5838ae04fad01037beeff1047781431d74360cddd6b3c1c784"
+checksum = "b9907f54bd0f7b6ce72c2be1e570a614819ee08e3deb66d90480df341d8a12a8"
 dependencies = [
  "log",
 ]

--- a/datafusion/Cargo.toml
+++ b/datafusion/Cargo.toml
@@ -9,5 +9,5 @@ description = "Re-exports datafusion at a specific version"
 
 # Rename to workaround doctest bug
 # Turn off optional datafusion features (e.g. don't get support for crypo functions or avro)
-upstream = { git = "https://github.com/apache/arrow-datafusion.git", rev="0338b7336d257bdbdc5eefceda5846e3a5b31409", default-features = false, package = "datafusion" }
+upstream = { git = "https://github.com/apache/arrow-datafusion.git", rev="b17e1b2b60618ba82818846ab079a916248b8c4f", default-features = false, package = "datafusion" }
 workspace-hack = { path = "../workspace-hack"}

--- a/predicate/Cargo.toml
+++ b/predicate/Cargo.toml
@@ -15,7 +15,7 @@ ordered-float = "2"
 regex = "1"
 serde_json = "1.0.72"
 snafu = "0.6.9"
-sqlparser = "0.12.0"
+sqlparser = "0.13.0"
 workspace-hack = { path = "../workspace-hack"}
 
 [dev-dependencies]


### PR DESCRIPTION

# Rationale:
Keep up with DataFusion.
Notable improvements:
* https://github.com/apache/arrow-datafusion/pull/1375 (Unified simplification)
* https://github.com/apache/arrow-datafusion/pull/1419,
* https://github.com/apache/arrow-datafusion/pull/1415

# Changes:
1. Update DataFusion pin to https://github.com/apache/arrow-datafusion/commit/b17e1b2b60618ba82818846ab079a916248b8c4f
2. Update sqlparser pin

