### PR TITLE
refactor: add support for handling `TagValuesGroupedByMeasurementAndTagKeyRequest`

### DIFF
--- a/generated_types/protos/influxdata/platform/storage/service.proto
+++ b/generated_types/protos/influxdata/platform/storage/service.proto
@@ -26,6 +26,8 @@ service Storage {
     // TagValues performs a read operation for tag values
     rpc TagValues (TagValuesRequest) returns (stream StringValuesResponse);
 
+    rpc TagValuesGroupedByMeasurementAndTagKey (TagValuesGroupedByMeasurementAndTagKeyRequest) returns (stream TagValuesResponse);
+
     // ReadSeriesCardinality performs a read operation for series cardinality
     rpc ReadSeriesCardinality (ReadSeriesCardinalityRequest) returns (stream Int64ValuesResponse);
 

--- a/influxdb_iox/src/influxdb_ioxd/server_type/database/rpc/storage/input.rs
+++ b/influxdb_iox/src/influxdb_ioxd/server_type/database/rpc/storage/input.rs
@@ -3,7 +3,8 @@ use tonic::Status;
 use generated_types::{
     google::protobuf::Any, MeasurementFieldsRequest, MeasurementNamesRequest,
     MeasurementTagKeysRequest, MeasurementTagValuesRequest, ReadFilterRequest, ReadGroupRequest,
-    ReadSource, ReadWindowAggregateRequest, TagKeysRequest, TagValuesRequest,
+    ReadSource, ReadWindowAggregateRequest, TagKeysRequest,
+    TagValuesGroupedByMeasurementAndTagKeyRequest, TagValuesRequest,
 };
 
 use super::id::Id;
@@ -67,6 +68,12 @@ impl GrpcInputs for TagKeysRequest {
 impl GrpcInputs for TagValuesRequest {
     fn read_source_field(&self) -> Option<&Any> {
         self.tags_source.as_ref()
+    }
+}
+
+impl GrpcInputs for TagValuesGroupedByMeasurementAndTagKeyRequest {
+    fn read_source_field(&self) -> Option<&Any> {
+        self.source.as_ref()
     }
 }
 

--- a/influxdb_iox/src/influxdb_ioxd/server_type/database/rpc/storage/service.rs
+++ b/influxdb_iox/src/influxdb_ioxd/server_type/database/rpc/storage/service.rs
@@ -1451,7 +1451,7 @@ mod tests {
         grpc_request_metric_has_count(&fixture, "MeasurementTagKeys", "client_error", 1);
     }
 
-    /// test the plumbing of the RPC layer for tag_keys -- specifically that
+    /// test the plumbing of the RPC layer for tag_values -- specifically that
     /// the right parameters are passed into the Database interface
     /// and that the returned values are sent back via gRPC.
     #[tokio::test]
@@ -1640,6 +1640,44 @@ mod tests {
         );
 
         grpc_request_metric_has_count(&fixture, "TagValues", "client_error", 2);
+    }
+
+    #[tokio::test]
+    async fn test_storage_rpc_tag_values_grouped_by_measurement_and_tag_key_error() {
+        test_helpers::maybe_start_logging();
+        // Start a test gRPC server on a randomally allocated port
+        let mut fixture = Fixture::new().await.expect("Connecting to test server");
+
+        let db_info = org_and_bucket();
+        let chunk = TestChunk::new("my_table");
+
+        fixture
+            .test_storage
+            .db_or_create(db_info.db_name())
+            .await
+            .unwrap()
+            .add_chunk("my_partition_key", Arc::new(chunk));
+
+        let source = Some(StorageClient::read_source(&db_info, 1));
+
+        // ---
+        // test error
+        // ---
+        let request = TagValuesGroupedByMeasurementAndTagKeyRequest {
+            source: source.clone(),
+            measurement_patterns: vec![],
+            tag_key_predicate: None,
+            condition: None,
+        };
+
+        let response_string = fixture
+            .storage_client
+            .tag_values_grouped_by_measurement_and_tag_key(request)
+            .await
+            .unwrap_err()
+            .to_string();
+
+        assert_contains!(response_string, "Operation not yet implemented");
     }
 
     /// test the plumbing of the RPC layer for measurement_tag_values

--- a/influxdb_iox/src/influxdb_ioxd/server_type/database/rpc/storage/service.rs
+++ b/influxdb_iox/src/influxdb_ioxd/server_type/database/rpc/storage/service.rs
@@ -470,7 +470,7 @@ where
         Err(Error::NotYetImplemented {
             operation: format!(
                 "tag_values_grouped_by_measurement_and_tag_key. Measurement patterns: {:?} tag key predicates: {:?} condition: {:?}, source: {:?}",
-                measurement_patterns,   
+                measurement_patterns,
                 tag_key_predicate,
                 condition,
                 source,

--- a/influxdb_iox/src/influxdb_ioxd/server_type/database/rpc/storage/service.rs
+++ b/influxdb_iox/src/influxdb_ioxd/server_type/database/rpc/storage/service.rs
@@ -456,10 +456,25 @@ where
 
     async fn tag_values_grouped_by_measurement_and_tag_key(
         &self,
-        _req: tonic::Request<TagValuesGroupedByMeasurementAndTagKeyRequest>,
+        req: tonic::Request<TagValuesGroupedByMeasurementAndTagKeyRequest>,
     ) -> Result<tonic::Response<Self::TagValuesGroupedByMeasurementAndTagKeyStream>, Status> {
+        let req = req.into_inner();
+
+        let TagValuesGroupedByMeasurementAndTagKeyRequest {
+            measurement_patterns,
+            tag_key_predicate,
+            condition,
+            source,
+        } = req;
+
         Err(Error::NotYetImplemented {
-            operation: "tag_values_grouped_by_measurement_and_tag_key".to_string(),
+            operation: format!(
+                "tag_values_grouped_by_measurement_and_tag_key. Measurement patterns: {:?} tag key predicates: {:?} condition: {:?}, source: {:?}",
+                measurement_patterns,   
+                tag_key_predicate,
+                condition,
+                source,
+            ),
         }
         .to_status())
     }

--- a/influxdb_iox/src/influxdb_ioxd/server_type/database/rpc/storage/service.rs
+++ b/influxdb_iox/src/influxdb_ioxd/server_type/database/rpc/storage/service.rs
@@ -16,7 +16,8 @@ use generated_types::{
     MeasurementFieldsResponse, MeasurementNamesRequest, MeasurementTagKeysRequest,
     MeasurementTagValuesRequest, OffsetsResponse, Predicate, ReadFilterRequest, ReadGroupRequest,
     ReadResponse, ReadSeriesCardinalityRequest, ReadWindowAggregateRequest, StringValuesResponse,
-    TagKeyMetaNames, TagKeysRequest, TagValuesRequest, TimestampRange,
+    TagKeyMetaNames, TagKeysRequest, TagValuesGroupedByMeasurementAndTagKeyRequest,
+    TagValuesRequest, TagValuesResponse, TimestampRange,
 };
 use observability_deps::tracing::{error, info, trace};
 use predicate::predicate::PredicateBuilder;
@@ -448,6 +449,19 @@ where
             .expect("sending tag_values response to server");
 
         Ok(tonic::Response::new(ReceiverStream::new(rx)))
+    }
+
+    type TagValuesGroupedByMeasurementAndTagKeyStream =
+        futures::stream::Iter<std::vec::IntoIter<Result<TagValuesResponse, Status>>>;
+
+    async fn tag_values_grouped_by_measurement_and_tag_key(
+        &self,
+        _req: tonic::Request<TagValuesGroupedByMeasurementAndTagKeyRequest>,
+    ) -> Result<tonic::Response<Self::TagValuesGroupedByMeasurementAndTagKeyStream>, Status> {
+        Err(Error::NotYetImplemented {
+            operation: "tag_values_grouped_by_measurement_and_tag_key".to_string(),
+        }
+        .to_status())
     }
 
     type ReadSeriesCardinalityStream = ReceiverStream<Result<Int64ValuesResponse, Status>>;

--- a/influxdb_storage_client/src/lib.rs
+++ b/influxdb_storage_client/src/lib.rs
@@ -201,6 +201,23 @@ impl Client {
         Ok(Self::collect_strings(responses))
     }
 
+    /// Make a request to query::tag_values_grouped_by_measurement_and_tag_key
+    /// and do the required async dance to flatten the resulting stream
+    pub async fn tag_values_grouped_by_measurement_and_tag_key(
+        &mut self,
+        request: TagValuesGroupedByMeasurementAndTagKeyRequest,
+    ) -> Result<Vec<TagValuesResponse>, tonic::Status> {
+        let responses: Vec<_> = self
+            .inner
+            .tag_values_grouped_by_measurement_and_tag_key(request)
+            .await?
+            .into_inner()
+            .try_collect()
+            .await?;
+
+        Ok(responses)
+    }
+
     /// Make a request to query::measurement_tag_values and do the
     /// required async dance to flatten the resulting stream to Strings
     pub async fn measurement_tag_values(


### PR DESCRIPTION
Towards #3372.

This PR adds some initial server and storage client plumbing to handle a `TagValuesGroupedByMeasurementAndTagKeyRequest` message.

If this message is sent over the gRPC API the server used to respond with:

```
actual  : "{\"results\":[{\"statement_id\":0,\"error\":\"rpc error: code = Unimplemented desc = \"}]}"
```

and now will respond with:

```
actual  : "{\"results\":[{\"statement_id\":0,\"error\":\"rpc error: code = Internal desc = Operation not yet implemented:  tag_values_grouped_by_measurement_and_tag_key. Measurement patterns:......
```