### PR TITLE
fix: treat early server worker exit as proper error

### DIFF
--- a/influxdb_iox/src/commands/run/mod.rs
+++ b/influxdb_iox/src/commands/run/mod.rs
@@ -5,14 +5,19 @@ use crate::structopt_blocks::run_config::RunConfig;
 
 pub mod database;
 pub mod router;
+pub mod test;
 
 #[derive(Debug, Snafu)]
+#[allow(clippy::enum_variant_names)]
 pub enum Error {
     #[snafu(display("Error in database subcommand: {}", source))]
     DatabaseError { source: database::Error },
 
     #[snafu(display("Error in router subcommand: {}", source))]
     RouterError { source: router::Error },
+
+    #[snafu(display("Error in test subcommand: {}", source))]
+    TestError { source: test::Error },
 }
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
@@ -34,6 +39,7 @@ impl Config {
             None => &self.database_config.run_config,
             Some(Command::Database(config)) => &config.run_config,
             Some(Command::Router(config)) => &config.run_config,
+            Some(Command::Test(config)) => &config.run_config,
         }
     }
 }
@@ -42,6 +48,7 @@ impl Config {
 enum Command {
     Database(database::Config),
     Router(router::Config),
+    Test(test::Config),
 }
 
 pub async fn command(config: Config) -> Result<()> {
@@ -56,5 +63,6 @@ pub async fn command(config: Config) -> Result<()> {
         }
         Some(Command::Database(config)) => database::command(config).await.context(DatabaseError),
         Some(Command::Router(config)) => router::command(config).await.context(RouterError),
+        Some(Command::Test(config)) => test::command(config).await.context(TestError),
     }
 }

--- a/influxdb_iox/src/commands/run/test.rs
+++ b/influxdb_iox/src/commands/run/test.rs
@@ -1,0 +1,67 @@
+//! Implementation of command line option for running server
+
+use std::sync::Arc;
+
+use crate::{
+    influxdb_ioxd::{
+        self,
+        server_type::{
+            common_state::{CommonServerState, CommonServerStateError},
+            test::{TestAction, TestServerType},
+        },
+    },
+    structopt_blocks::run_config::RunConfig,
+};
+use metric::Registry;
+use structopt::StructOpt;
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error("Run: {0}")]
+    Run(#[from] influxdb_ioxd::Error),
+
+    #[error("Invalid config: {0}")]
+    InvalidConfig(#[from] CommonServerStateError),
+}
+
+pub type Result<T, E = Error> = std::result::Result<T, E>;
+
+#[derive(Debug, StructOpt)]
+#[structopt(
+    name = "run",
+    about = "Runs in test mode",
+    long_about = "Run the IOx test server.\n\nThe configuration options below can be \
+    set either with the command line flags or with the specified environment \
+    variable. If there is a file named '.env' in the current working directory, \
+    it is sourced before loading the configuration.
+
+Configuration is loaded from the following sources (highest precedence first):
+        - command line arguments
+        - user set environment variables
+        - .env file contents
+        - pre-configured default values"
+)]
+pub struct Config {
+    #[structopt(flatten)]
+    pub(crate) run_config: RunConfig,
+
+    /// Test action
+    #[structopt(
+        long = "--test-action",
+        env = "IOX_TEST_ACTION",
+        default_value = "none"
+    )]
+    test_action: TestAction,
+}
+
+pub async fn command(config: Config) -> Result<()> {
+    let common_state = CommonServerState::from_config(config.run_config.clone())?;
+    let server_type = Arc::new(TestServerType::new(
+        Arc::new(Registry::new()),
+        common_state.trace_collector(),
+        config.test_action,
+    ));
+
+    Ok(influxdb_ioxd::main(common_state, server_type).await?)
+}

--- a/influxdb_iox/src/commands/run/test.rs
+++ b/influxdb_iox/src/commands/run/test.rs
@@ -50,7 +50,9 @@ pub struct Config {
     #[structopt(
         long = "--test-action",
         env = "IOX_TEST_ACTION",
-        default_value = "none"
+        default_value = "None",
+        possible_values = &TestAction::variants(),
+        case_insensitive = true,
     )]
     test_action: TestAction,
 }

--- a/influxdb_iox/src/influxdb_ioxd/rpc.rs
+++ b/influxdb_iox/src/influxdb_ioxd/rpc.rs
@@ -102,6 +102,7 @@ pub(crate) use add_gated_service;
 /// be used w/ [`serve_builder`].
 macro_rules! setup_builder {
     ($input:ident, $server_type:ident) => {{
+        #[allow(unused_imports)]
         use $crate::influxdb_ioxd::{
             rpc::{add_service, testing, RpcBuilder},
             server_type::ServerType,

--- a/influxdb_iox/src/influxdb_ioxd/server_type/mod.rs
+++ b/influxdb_iox/src/influxdb_ioxd/server_type/mod.rs
@@ -11,6 +11,7 @@ use crate::influxdb_ioxd::{http::error::HttpApiErrorSource, rpc::RpcBuilderInput
 pub mod common_state;
 pub mod database;
 pub mod router;
+pub mod test;
 
 #[derive(Debug, Snafu)]
 pub enum RpcError {

--- a/influxdb_iox/src/influxdb_ioxd/server_type/test.rs
+++ b/influxdb_iox/src/influxdb_ioxd/server_type/test.rs
@@ -1,0 +1,127 @@
+use std::{str::FromStr, sync::Arc};
+
+use crate::influxdb_ioxd::{
+    http::error::{HttpApiError, HttpApiErrorExt, HttpApiErrorSource},
+    rpc::{serve_builder, setup_builder, RpcBuilderInput},
+};
+use async_trait::async_trait;
+use hyper::{Body, Method, Request, Response};
+use metric::Registry;
+use snafu::Snafu;
+use tokio_util::sync::CancellationToken;
+use trace::TraceCollector;
+
+use super::{RpcError, ServerType};
+
+#[derive(Debug, Snafu)]
+pub enum ApplicationError {
+    #[snafu(display("No handler for {:?} {}", method, path))]
+    RouteNotFound { method: Method, path: String },
+}
+
+impl HttpApiErrorSource for ApplicationError {
+    fn to_http_api_error(&self) -> HttpApiError {
+        match self {
+            e @ Self::RouteNotFound { .. } => e.not_found(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TestAction {
+    None,
+    EarlyReturnFromGrpcWorker,
+    EarlyReturnFromServerWorker,
+    PanicInGrpcWorker,
+    PanicInServerWorker,
+}
+
+impl FromStr for TestAction {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_lowercase().as_ref() {
+            "none" => Ok(Self::None),
+            "early-return-from-grpc-worker" => Ok(Self::EarlyReturnFromGrpcWorker),
+            "early-return-from-server-worker" => Ok(Self::EarlyReturnFromServerWorker),
+            "panic-in-grpc-worker" => Ok(Self::PanicInGrpcWorker),
+            "panic-in-server-worker" => Ok(Self::PanicInServerWorker),
+            _ => Err(format!("Invalid test action: {}", s)),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct TestServerType {
+    metric_registry: Arc<Registry>,
+    trace_collector: Option<Arc<dyn TraceCollector>>,
+    shutdown: CancellationToken,
+    test_action: TestAction,
+}
+
+impl TestServerType {
+    pub fn new(
+        metric_registry: Arc<Registry>,
+        trace_collector: Option<Arc<dyn TraceCollector>>,
+        test_action: TestAction,
+    ) -> Self {
+        Self {
+            metric_registry,
+            trace_collector,
+            shutdown: CancellationToken::new(),
+            test_action,
+        }
+    }
+}
+
+#[async_trait]
+impl ServerType for TestServerType {
+    type RouteError = ApplicationError;
+
+    fn metric_registry(&self) -> Arc<Registry> {
+        Arc::clone(&self.metric_registry)
+    }
+
+    fn trace_collector(&self) -> Option<Arc<dyn TraceCollector>> {
+        self.trace_collector.clone()
+    }
+
+    async fn route_http_request(
+        &self,
+        req: Request<Body>,
+    ) -> Result<Response<Body>, Self::RouteError> {
+        Err(ApplicationError::RouteNotFound {
+            method: req.method().clone(),
+            path: req.uri().path().to_string(),
+        })
+    }
+
+    async fn server_grpc(self: Arc<Self>, builder_input: RpcBuilderInput) -> Result<(), RpcError> {
+        if self.test_action == TestAction::PanicInGrpcWorker {
+            panic!("Test panic in gRPC worker");
+        }
+        if self.test_action == TestAction::EarlyReturnFromGrpcWorker {
+            return Ok(());
+        }
+
+        let builder = setup_builder!(builder_input, self);
+        serve_builder!(builder);
+
+        Ok(())
+    }
+
+    async fn join(self: Arc<Self>) {
+        if self.test_action == TestAction::PanicInServerWorker {
+            panic!("Test panic in server worker");
+        }
+        if self.test_action == TestAction::EarlyReturnFromServerWorker {
+            return;
+        }
+
+        self.shutdown.cancelled().await;
+    }
+
+    fn shutdown(&self) {
+        self.shutdown.cancel();
+    }
+}

--- a/influxdb_iox/src/influxdb_ioxd/server_type/test.rs
+++ b/influxdb_iox/src/influxdb_ioxd/server_type/test.rs
@@ -1,10 +1,11 @@
-use std::{str::FromStr, sync::Arc};
+use std::sync::Arc;
 
 use crate::influxdb_ioxd::{
     http::error::{HttpApiError, HttpApiErrorExt, HttpApiErrorSource},
     rpc::{serve_builder, setup_builder, RpcBuilderInput},
 };
 use async_trait::async_trait;
+use clap::arg_enum;
 use hyper::{Body, Method, Request, Response};
 use metric::Registry;
 use snafu::Snafu;
@@ -27,27 +28,14 @@ impl HttpApiErrorSource for ApplicationError {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum TestAction {
-    None,
-    EarlyReturnFromGrpcWorker,
-    EarlyReturnFromServerWorker,
-    PanicInGrpcWorker,
-    PanicInServerWorker,
-}
-
-impl FromStr for TestAction {
-    type Err = String;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s.to_lowercase().as_ref() {
-            "none" => Ok(Self::None),
-            "early-return-from-grpc-worker" => Ok(Self::EarlyReturnFromGrpcWorker),
-            "early-return-from-server-worker" => Ok(Self::EarlyReturnFromServerWorker),
-            "panic-in-grpc-worker" => Ok(Self::PanicInGrpcWorker),
-            "panic-in-server-worker" => Ok(Self::PanicInServerWorker),
-            _ => Err(format!("Invalid test action: {}", s)),
-        }
+arg_enum! {
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    pub enum TestAction {
+        None,
+        EarlyReturnFromGrpcWorker,
+        EarlyReturnFromServerWorker,
+        PanicInGrpcWorker,
+        PanicInServerWorker,
     }
 }
 

--- a/influxdb_iox/src/influxdb_ioxd/server_type/test.rs
+++ b/influxdb_iox/src/influxdb_ioxd/server_type/test.rs
@@ -97,17 +97,16 @@ impl ServerType for TestServerType {
     }
 
     async fn server_grpc(self: Arc<Self>, builder_input: RpcBuilderInput) -> Result<(), RpcError> {
-        if self.test_action == TestAction::PanicInGrpcWorker {
-            panic!("Test panic in gRPC worker");
-        }
-        if self.test_action == TestAction::EarlyReturnFromGrpcWorker {
-            return Ok(());
-        }
+        match self.test_action {
+            TestAction::PanicInGrpcWorker => panic!("Test panic in gRPC worker"),
+            TestAction::EarlyReturnFromGrpcWorker => Ok(()),
+            _ => {
+                let builder = setup_builder!(builder_input, self);
+                serve_builder!(builder);
 
-        let builder = setup_builder!(builder_input, self);
-        serve_builder!(builder);
-
-        Ok(())
+                Ok(())
+            }
+        }
     }
 
     async fn join(self: Arc<Self>) {

--- a/influxdb_iox/tests/end_to_end_cases/run_cli.rs
+++ b/influxdb_iox/tests/end_to_end_cases/run_cli.rs
@@ -96,22 +96,22 @@ fn test_deprecated_cli_without_server_type() {
 
 #[test]
 fn test_early_return_from_grpc_worker() {
-    assert_early_exit_return_code("early-return-from-grpc-worker");
+    assert_early_exit_return_code("EarlyReturnFromGrpcWorker");
 }
 
 #[test]
 fn test_early_return_from_server_worker() {
-    assert_early_exit_return_code("early-return-from-server-worker");
+    assert_early_exit_return_code("EarlyReturnFromServerWorker");
 }
 
 #[test]
 fn test_panic_in_grpc_worker() {
-    assert_early_exit_return_code("panic-in-grpc-worker");
+    assert_early_exit_return_code("PanicInGrpcWorker");
 }
 
 #[test]
 fn test_panic_in_server_worker() {
-    assert_early_exit_return_code("panic-in-server-worker");
+    assert_early_exit_return_code("PanicInServerWorker");
 }
 
 fn assert_early_exit_return_code(test_action: &str) {


### PR DESCRIPTION
Instead of just logging the issue, also make sure the error gets
propagated all the way up to the exit code.

Fixes #3375.

