### PR TITLE
refactor: make object store prefixes segment based

### DIFF
--- a/object_store/src/azure.rs
+++ b/object_store/src/azure.rs
@@ -127,6 +127,8 @@ impl ObjectStoreApi for MicrosoftAzure {
         &'a self,
         prefix: Option<&'a Self::Path>,
     ) -> Result<BoxStream<'a, Result<Vec<Self::Path>>>> {
+        let prefix_is_dir = prefix.map(|path| path.is_dir()).unwrap_or(true);
+
         #[derive(Clone)]
         enum ListState {
             Start,
@@ -137,8 +139,8 @@ impl ObjectStoreApi for MicrosoftAzure {
         Ok(stream::unfold(ListState::Start, move |state| async move {
             let mut request = self.container_client.list_blobs();
 
-            let prefix = prefix.map(|p| p.to_raw());
-            if let Some(ref p) = prefix {
+            let prefix_raw = prefix.map(|p| p.to_raw());
+            if let Some(ref p) = prefix_raw {
                 request = request.prefix(p as &str);
             }
 
@@ -168,6 +170,9 @@ impl ObjectStoreApi for MicrosoftAzure {
                 .blobs
                 .into_iter()
                 .map(|blob| CloudPath::raw(blob.name))
+                .filter(move |path| {
+                    prefix_is_dir || prefix.map(|prefix| prefix == path).unwrap_or_default()
+                })
                 .collect();
 
             Some((Ok(names), next_state))
@@ -176,12 +181,13 @@ impl ObjectStoreApi for MicrosoftAzure {
     }
 
     async fn list_with_delimiter(&self, prefix: &Self::Path) -> Result<ListResult<Self::Path>> {
+        let prefix_is_dir = prefix.is_dir();
         let mut request = self.container_client.list_blobs();
 
-        let prefix = prefix.to_raw();
+        let prefix_raw = prefix.to_raw();
 
         request = request.delimiter(Delimiter::new(DELIMITER));
-        request = request.prefix(&*prefix);
+        request = request.prefix(&*prefix_raw);
 
         let resp = request.execute().await.context(List)?;
 
@@ -217,6 +223,7 @@ impl ObjectStoreApi for MicrosoftAzure {
                     size,
                 }
             })
+            .filter(move |object| prefix_is_dir || prefix == &object.location)
             .collect();
 
         Ok(ListResult {
@@ -258,7 +265,7 @@ pub fn new_azure(
 
 #[cfg(test)]
 mod tests {
-    use crate::tests::{list_with_delimiter, put_get_delete_list};
+    use crate::tests::{list_uses_directories_correctly, list_with_delimiter, put_get_delete_list};
     use crate::ObjectStore;
     use std::env;
 
@@ -331,6 +338,7 @@ mod tests {
         .unwrap();
 
         put_get_delete_list(&integration).await.unwrap();
+        list_uses_directories_correctly(&integration).await.unwrap();
         list_with_delimiter(&integration).await.unwrap();
     }
 }

--- a/object_store/src/disk.rs
+++ b/object_store/src/disk.rs
@@ -326,7 +326,10 @@ impl File {
 mod tests {
     use super::*;
     use crate::{
-        tests::{get_nonexistent_object, list_with_delimiter, put_get_delete_list},
+        tests::{
+            get_nonexistent_object, list_uses_directories_correctly, list_with_delimiter,
+            put_get_delete_list,
+        },
         Error as ObjectStoreError, ObjectStore, ObjectStoreApi, ObjectStorePath,
     };
     use std::{fs::set_permissions, os::unix::prelude::PermissionsExt};
@@ -338,6 +341,7 @@ mod tests {
         let integration = ObjectStore::new_file(root.path());
 
         put_get_delete_list(&integration).await.unwrap();
+        list_uses_directories_correctly(&integration).await.unwrap();
         list_with_delimiter(&integration).await.unwrap();
     }
 

--- a/object_store/src/lib.rs
+++ b/object_store/src/lib.rs
@@ -87,6 +87,9 @@ pub trait ObjectStoreApi: Send + Sync + 'static {
     async fn delete(&self, location: &Self::Path) -> Result<(), Self::Error>;
 
     /// List all the objects with the given prefix.
+    ///
+    /// Prefixes are evaluated on a path segment basis, i.e. `foo/bar/` is a prefix of `foo/bar/x` but not of
+    /// `foo/bar_baz/x`.
     async fn list<'a>(
         &'a self,
         prefix: Option<&'a Self::Path>,
@@ -95,6 +98,9 @@ pub trait ObjectStoreApi: Send + Sync + 'static {
     /// List objects with the given prefix and an implementation specific
     /// delimiter. Returns common prefixes (directories) in addition to object
     /// metadata.
+    ///
+    /// Prefixes are evaluated on a path segment basis, i.e. `foo/bar/` is a prefix of `foo/bar/x` but not of
+    /// `foo/bar_baz/x`.
     async fn list_with_delimiter(
         &self,
         prefix: &Self::Path,
@@ -800,6 +806,42 @@ mod tests {
         Ok(())
     }
 
+    pub(crate) async fn list_uses_directories_correctly(storage: &ObjectStore) -> Result<()> {
+        delete_fixtures(storage).await;
+
+        let content_list = flatten_list_stream(storage, None).await?;
+        assert!(
+            content_list.is_empty(),
+            "Expected list to be empty; found: {:?}",
+            content_list
+        );
+
+        let mut location1 = storage.new_path();
+        location1.push_dir("foo");
+        location1.set_file_name("x.json");
+
+        let mut location2 = storage.new_path();
+        location2.push_dir("foo.bar");
+        location2.set_file_name("y.json");
+
+        let data = Bytes::from("arbitrary data");
+        storage.put(&location1, data.clone()).await?;
+        storage.put(&location2, data).await?;
+
+        let mut prefix = storage.new_path();
+        prefix.push_dir("foo");
+        let content_list = flatten_list_stream(storage, Some(&prefix)).await?;
+        assert_eq!(content_list, &[location1.clone()]);
+
+        let mut prefix = storage.new_path();
+        prefix.push_dir("foo");
+        prefix.set_file_name("x");
+        let content_list = flatten_list_stream(storage, Some(&prefix)).await?;
+        assert_eq!(content_list, &[]);
+
+        Ok(())
+    }
+
     pub(crate) async fn list_with_delimiter(storage: &ObjectStore) -> Result<()> {
         delete_fixtures(storage).await;
 
@@ -850,7 +892,7 @@ mod tests {
         assert_eq!(object.location, expected_location);
         assert_eq!(object.size, data.len());
 
-        // ==================== check: prefix-list `mydb/wb/000/000/001` (partial filename) ====================
+        // ==================== check: prefix-list `mydb/wb/000/000/001` (partial filename doesn't match) ====================
         let mut prefix = storage.new_path();
         prefix.push_all_dirs(&["mydb", "wb", "000", "000"]);
         prefix.set_file_name("001");
@@ -861,11 +903,7 @@ mod tests {
 
         let result = storage.list_with_delimiter(&prefix).await.unwrap();
         assert!(result.common_prefixes.is_empty());
-        assert_eq!(result.objects.len(), 1);
-
-        let object = &result.objects[0];
-
-        assert_eq!(object.location, expected_location);
+        assert_eq!(result.objects.len(), 0);
 
         // ==================== check: prefix-list `not_there` (non-existing prefix) ====================
         let mut prefix = storage.new_path();
@@ -926,12 +964,16 @@ mod tests {
     async fn delete_fixtures(storage: &ObjectStore) {
         let files: Vec<_> = [
             "test_file",
+            "test_dir/test_file.json",
             "mydb/wb/000/000/000.segment",
             "mydb/wb/000/000/001.segment",
             "mydb/wb/000/000/002.segment",
             "mydb/wb/001/001/000.segment",
             "mydb/wb/foo.json",
             "mydb/data/whatevs",
+            "mydb/wbwbwb/111/222/333.segment",
+            "foo/x.json",
+            "foo.bar/y.json",
         ]
         .iter()
         .map(|&s| str_to_path(storage, s))

--- a/object_store/src/memory.rs
+++ b/object_store/src/memory.rs
@@ -161,7 +161,10 @@ mod tests {
     use super::*;
 
     use crate::{
-        tests::{get_nonexistent_object, list_with_delimiter, put_get_delete_list},
+        tests::{
+            get_nonexistent_object, list_uses_directories_correctly, list_with_delimiter,
+            put_get_delete_list,
+        },
         Error as ObjectStoreError, ObjectStore, ObjectStoreApi, ObjectStorePath,
     };
 
@@ -170,6 +173,7 @@ mod tests {
         let integration = ObjectStore::new_in_memory();
 
         put_get_delete_list(&integration).await.unwrap();
+        list_uses_directories_correctly(&integration).await.unwrap();
         list_with_delimiter(&integration).await.unwrap();
     }
 

--- a/object_store/src/path/cloud.rs
+++ b/object_store/src/path/cloud.rs
@@ -62,7 +62,7 @@ impl CloudPath {
         }
     }
 
-    // Only being use d by some features
+    // Only being used by some features
     #[allow(dead_code)]
     pub(crate) fn is_dir(&self) -> bool {
         match &self.inner {

--- a/object_store/src/path/parsed.rs
+++ b/object_store/src/path/parsed.rs
@@ -75,7 +75,7 @@ impl DirsAndFileName {
                 // `self` doesn't have a file name but the prefix has, so it's not really a prefix
                 (None, Some(_prefix_file)) => false,
 
-                // both `self` and teh  prefix have not filename, perfect match
+                // both `self` and the prefix have no filename, perfect match
                 (None, None) => true,
             },
 
@@ -261,7 +261,7 @@ mod tests {
             needle
         );
 
-        // partial dir prefix matches
+        // partial dir prefix doesn't match
         let mut needle = DirsAndFileName::default();
         needle.push_dir("f");
         assert!(
@@ -271,7 +271,7 @@ mod tests {
             needle
         );
 
-        // one dir and one partial dir matches
+        // one dir and one partial dir doesn't match
         let mut needle = DirsAndFileName::default();
         needle.push_all_dirs(&["foo/bar", "baz"]);
         assert!(
@@ -311,7 +311,7 @@ mod tests {
         );
 
         // Not all directories match; file name is a prefix of the next directory; this
-        // matches
+        // does not match
         let mut needle = DirsAndFileName::default();
         needle.push_all_dirs(&["foo/bar", "baz%2Ftest"]);
         needle.set_file_name("s");

--- a/object_store/src/path/parsed.rs
+++ b/object_store/src/path/parsed.rs
@@ -64,37 +64,27 @@ impl DirsAndFileName {
 
         use itertools::Diff;
         match diff {
+            // directories match perfectly, now we need to look at the filenames
             None => match (self.file_name.as_ref(), prefix.file_name.as_ref()) {
-                (Some(self_file), Some(prefix_file)) => {
-                    self_file.encoded().starts_with(prefix_file.encoded())
-                }
+                // both `self` and the prefix have a filename, they have to match
+                (Some(self_file), Some(prefix_file)) => self_file == prefix_file,
+
+                // `self` has a file name but the prefix doesn't, that's a match
                 (Some(_self_file), None) => true,
+
+                // `self` doesn't have a file name but the prefix has, so it's not really a prefix
                 (None, Some(_prefix_file)) => false,
+
+                // both `self` and teh  prefix have not filename, perfect match
                 (None, None) => true,
             },
-            Some(Diff::Shorter(_, mut remaining_self)) => {
-                let next_dir = remaining_self
-                    .next()
-                    .expect("must have at least one mismatch to be in this case");
-                match prefix.file_name.as_ref() {
-                    Some(prefix_file) => next_dir.encoded().starts_with(prefix_file.encoded()),
-                    None => true,
-                }
-            }
-            Some(Diff::FirstMismatch(_, mut remaining_self, mut remaining_prefix)) => {
-                let first_prefix = remaining_prefix
-                    .next()
-                    .expect("must have at least one mismatch to be in this case");
 
-                // There must not be any other remaining parts in the prefix
-                remaining_prefix.next().is_none()
-                // and the next item in self must start with the last item in the prefix
-                    && remaining_self
-                        .next()
-                        .expect("must be at least one value")
-                        .encoded()
-                        .starts_with(first_prefix.encoded())
-            }
+            // the prefix directories are a prefix of `self.directories` (or in other words "prefix is shorter than
+            // self"), it's a prefix if the prefix doesn't have a file (because we don't wanna match a filename w/ a
+            // directory element)
+            Some(Diff::Shorter(_, _remaining_self)) => prefix.file_name.is_none(),
+
+            // no real match
             _ => false,
         }
     }
@@ -275,8 +265,8 @@ mod tests {
         let mut needle = DirsAndFileName::default();
         needle.push_dir("f");
         assert!(
-            haystack.prefix_matches(&needle),
-            "{:?} should have started with {:?}",
+            !haystack.prefix_matches(&needle),
+            "{:?} should not have started with {:?}",
             haystack,
             needle
         );
@@ -285,8 +275,8 @@ mod tests {
         let mut needle = DirsAndFileName::default();
         needle.push_all_dirs(&["foo/bar", "baz"]);
         assert!(
-            haystack.prefix_matches(&needle),
-            "{:?} should have started with {:?}",
+            !haystack.prefix_matches(&needle),
+            "{:?} should not have started with {:?}",
             haystack,
             needle
         );
@@ -304,8 +294,8 @@ mod tests {
         needle.set_file_name("foo");
 
         assert!(
-            haystack.prefix_matches(&needle),
-            "{:?} should have started with {:?}",
+            !haystack.prefix_matches(&needle),
+            "{:?} should not have started with {:?}",
             haystack,
             needle
         );
@@ -327,8 +317,8 @@ mod tests {
         needle.set_file_name("s");
 
         assert!(
-            haystack.prefix_matches(&needle),
-            "{:?} should have started with {:?}",
+            !haystack.prefix_matches(&needle),
+            "{:?} should not have started with {:?}",
             haystack,
             needle
         );

--- a/object_store/src/throttle.rs
+++ b/object_store/src/throttle.rs
@@ -216,7 +216,7 @@ mod tests {
     use crate::{
         memory::InMemory,
         path::ObjectStorePath,
-        tests::{list_with_delimiter, put_get_delete_list},
+        tests::{list_uses_directories_correctly, list_with_delimiter, put_get_delete_list},
         ObjectStore,
     };
     use bytes::Bytes;
@@ -246,6 +246,7 @@ mod tests {
         let integration = ObjectStore::new_in_memory_throttled(config);
 
         put_get_delete_list(&integration).await.unwrap();
+        list_uses_directories_correctly(&integration).await.unwrap();
         list_with_delimiter(&integration).await.unwrap();
     }
 


### PR DESCRIPTION
Don't use string prefixes, e.g. `foo/bar/` is a prefix of `foo/bar/x`
but NOT of `foo/bar_baz/y`.

This also removes some heuristics during the cloud storage parsing that
assumed that file names always contain a dot but directories don't.

Technically we should now always be able to know whether a path points
to a file or a directory:

- Rust (manually constructed): we use `DirsAndFileName` which knows the
  difference (i.e. if `file_name` is set)
- in-mem store: we also use `DirsAndFileName`
- file system: this was fixed by #1523
  (ccd094dfcfca6e27fec97835f233a86dadd54272 and 464667d8b8d571718392c0e1f970e8f9c4d44376)
- cloud: cloud doesn't know about directories. So all paths that these
  APIs return and that end with a `/` are directories (can only occur in
  `list_with_delimiter`); everyting else is a file

Path string representations are now acting occurdingly (i.e. always end
with an `/` if they point to a directory).

Fixes #3226.
