### PR TITLE
feat: increase support for TagValuesGroupedByMeasurementAndTagKey

### DIFF
--- a/influxdb_iox/src/influxdb_ioxd/server_type/database/rpc/storage/service.rs
+++ b/influxdb_iox/src/influxdb_ioxd/server_type/database/rpc/storage/service.rs
@@ -1071,7 +1071,6 @@ mod tests {
     use tokio_stream::wrappers::TcpListenerStream;
 
     use datafusion::logical_plan::{col, lit, Expr};
-    use generated_types::i_ox_testing_client::IOxTestingClient;
     use influxdb_storage_client::{
         connection::{Builder as ConnectionBuilder, Connection},
         generated_types::*,


### PR DESCRIPTION
Towards #3372

This PR implements the functionality in IOx to support many instantiations of a `TagValuesGroupedByMeasurementAndTagKey` RPC call.

Specifically, this PR adds support for 

* specifying measurements as literals or regex matches;
* providing arbitrary predicates that at least one returned tag value must satisfy;
* specifying a tag key as a literal match.

The following types of InfluxQL meta-queries are covered:

```
SHOW TAG VALUES FROM measurement WITH KEY = 'column'
SHOW TAG VALUES FROM measurement WITH KEY = 'column' WHERE 'other_column' = 'foo'
SHOW TAG VALUES FROM measurement WITH KEY = 'column' WHERE 'other_column' ~= /^.*a$/'
SHOW TAG VALUES FROM measurement1,measurement2 WITH KEY = 'column' WHERE 'other_column' ~= /^.*a$/'
SHOW TAG VALUES FROM /^Foo.+/ WITH KEY = 'column' WHERE 'other_column' != 'bar'
```

### Testing

As well as the included unit tests I also ran the internal InfluxQL compatibility tests and determined that this PR reduces the number of failures from **106** to **90**.

### TODO

There is still no support for predicates on the tag key. For example, in InfluxQL you can do the following:

```
SHOW TAG VALUES FROM measurement WITH KEY ~= /Ab.+c$/ WHERE 'other_column' = 'foo'
```

I will likely tackle that in the same way I tackled the measurements with regexes - by pre-materialising matching tag keys. This seems reasonable given everything currently gets fully materialised anyway.
