### PR TITLE
feat: add support for predicates on SHOW TAG VALUES WITH KEY = pred

### DIFF
--- a/influxdb_iox/Cargo.toml
+++ b/influxdb_iox/Cargo.toml
@@ -67,6 +67,7 @@ parquet = "6.0"
 pin-project = "1.0"
 pprof = { version = "^0.5", default-features = false, features = ["flamegraph", "protobuf"], optional = true }
 prost = "0.8"
+regex = "1.5.4"
 rustyline = { version = "9.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.72"

--- a/influxdb_iox/src/influxdb_ioxd/server_type/database/rpc/storage/service.rs
+++ b/influxdb_iox/src/influxdb_ioxd/server_type/database/rpc/storage/service.rs
@@ -913,8 +913,7 @@ async fn tag_values_grouped_by_measurement_and_tag_key_impl<D>(
 where
     D: QueryDatabase + ExecutionContextProvider + 'static,
 {
-    // Extract the tag key string literal.
-    // TODO - currently only eq operation supported, as in `WITH KEY = 'foo'`.
+    // Extract the tag key predicate.
     // See https://docs.influxdata.com/influxdb/v1.8/query_language/explore-schema/#show-tag-values
     // for more details.
     let tag_key_pred = req
@@ -1131,9 +1130,6 @@ where
 
 /// Materialises a collection of measurement names. Typically used as part of
 /// a plan to scope and group multiple plans by measurement name.
-///
-/// TODO(edd): this might be better represented as a plan against the `tables`
-/// system table.
 async fn materialise_measurement_names<D>(
     db: Arc<D>,
     db_name: DatabaseName<'static>,


### PR DESCRIPTION
Closes #3372

**Need to merge this first** https://github.com/influxdata/influxdb_iox/pull/3406 


This PR closes out the known outstanding `SHOW TAG VALUES` InfluxQL support using the newer `TagValuesGroupedByMeasurementAndTagKeyRequest` RPC request.

This PR adds support for applying predicates to the `WITH key ` clause in `SHOW TAG VALUES WITH KEY` statements.

The following operators are supported:

  - literal equality `WITH KEY = "some_column"`
  - literal inequality `WITH KEY != "some_column"`
  - regex match `WITH KEY =~ /foo.+/`
  - regex not match `WITH KEY !~ /foo.+/`
  - list match `WITH KEY IN ("col1", "col2", "col3")

I implemented several of the above by materialising the column names for a table and then applying the appropriate logic to filter away columns (tag keys) that don't match. Because everything has to be materialised currently to support this RPC I think that's OK. In the future we could improve on this by pushing down a plan to the system tables or similar, and let DF handle the application of these tag key predicates.


### Testing

As well as the included tests, this reduces the failures on our internal suite from `90` to `80`.