### PR TITLE
ci: use CLI-driven SSH for cargo

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,6 +71,8 @@ jobs:
       # Disable full debug symbol generation to speed up CI build
       # "1" means line tables only, which is useful for panic tracebacks.
       RUSTFLAGS: "-C debuginfo=1"
+      # https://github.com/rust-lang/cargo/issues/10280
+      CARGO_NET_GIT_FETCH_WITH_CLI: "true"
     steps:
       - checkout
       - rust_components
@@ -88,6 +90,8 @@ jobs:
       # Disable full debug symbol generation to speed up CI build
       # "1" means line tables only, which is useful for panic tracebacks.
       RUSTFLAGS: "-C debuginfo=1"
+      # https://github.com/rust-lang/cargo/issues/10280
+      CARGO_NET_GIT_FETCH_WITH_CLI: "true"
     steps:
       - checkout
       - rust_components
@@ -111,6 +115,8 @@ jobs:
       # Disable full debug symbol generation to speed up CI build
       # "1" means line tables only, which is useful for panic tracebacks.
       RUSTFLAGS: "-C debuginfo=1"
+      # https://github.com/rust-lang/cargo/issues/10280
+      CARGO_NET_GIT_FETCH_WITH_CLI: "true"
     steps:
       - checkout
       - rust_components
@@ -118,9 +124,15 @@ jobs:
       - run:
           name: Install Cargo Audit
           command: cargo install --force cargo-audit
+      # https://github.com/rust-lang/cargo/issues/10280 but `cargo audit` doesn't support `CARGO_NET_GIT_FETCH_WITH_CLI`
+      - run:
+          name: Workaround SSH issues
+          command: |
+            cd /usr/local/cargo
+            git clone https://github.com/RustSec/advisory-db.git
       - run:
           name: Cargo Audit
-          command: cargo audit
+          command: cargo audit --no-fetch
       - cache_save
   doc:
     docker:
@@ -131,6 +143,8 @@ jobs:
       # Disable full debug symbol generation to speed up CI build
       # "1" means line tables only, which is useful for panic tracebacks.
       RUSTFLAGS: "-C debuginfo=1"
+      # https://github.com/rust-lang/cargo/issues/10280
+      CARGO_NET_GIT_FETCH_WITH_CLI: "true"
     steps:
       - checkout
       - rust_components
@@ -148,6 +162,9 @@ jobs:
   workspace_hack_checks:
     docker:
       - image: quay.io/influxdb/rust:ci
+    environment:
+      # https://github.com/rust-lang/cargo/issues/10280
+      CARGO_NET_GIT_FETCH_WITH_CLI: "true"
     steps:
       - checkout
       - rust_components
@@ -182,6 +199,8 @@ jobs:
       # Disable full debug symbol generation to speed up CI build
       # "1" means line tables only, which is useful for panic tracebacks.
       RUSTFLAGS: "-C debuginfo=1"
+      # https://github.com/rust-lang/cargo/issues/10280
+      CARGO_NET_GIT_FETCH_WITH_CLI: "true"
       RUST_BACKTRACE: "1"
       # Run integration tests
       TEST_INTEGRATION: 1
@@ -227,6 +246,8 @@ jobs:
       # Disable full debug symbol generation to speed up CI build
       # "1" means line tables only, which is useful for panic tracebacks.
       RUSTFLAGS: "-C debuginfo=1"
+      # https://github.com/rust-lang/cargo/issues/10280
+      CARGO_NET_GIT_FETCH_WITH_CLI: "true"
       RUST_BACKTRACE: "1"
     steps:
       - checkout
@@ -247,6 +268,8 @@ jobs:
       # Disable full debug symbol generation to speed up CI build
       # "1" means line tables only, which is useful for panic tracebacks.
       RUSTFLAGS: "-C debuginfo=1"
+      # https://github.com/rust-lang/cargo/issues/10280
+      CARGO_NET_GIT_FETCH_WITH_CLI: "true"
       RUST_BACKTRACE: "1"
     steps:
       - run: sudo apt update
@@ -294,6 +317,8 @@ jobs:
       # Disable full debug symbol generation to speed up CI build
       # "1" means line tables only, which is useful for panic tracebacks.
       RUSTFLAGS: "-C debuginfo=1"
+      # https://github.com/rust-lang/cargo/issues/10280
+      CARGO_NET_GIT_FETCH_WITH_CLI: "true"
     steps:
       - checkout
       - rust_components
@@ -340,6 +365,13 @@ jobs:
     docker:
       - image: python:3-slim-bullseye
     steps:
+      # need a proper SSH client for checkout
+      # https://discuss.circleci.com/t/circleci-user-key-uses-rsa-with-sha1-which-github-has-deprecated/42548
+      - run:
+          name: Install GIT and SSH
+          command: |
+            apt-get update
+            apt-get install -y git ssh
       - checkout
       - run:
           name: Lint docs
@@ -375,6 +407,8 @@ jobs:
       ROARING_ARCH: "haswell"
       # Use avx512 instructions to take full advantage of the CPUs instruction set
       RUSTFLAGS: "-C target-feature=+avx2"
+      # https://github.com/rust-lang/cargo/issues/10280
+      CARGO_NET_GIT_FETCH_WITH_CLI: "true"
     steps:
       - checkout
       - run: |


### PR DESCRIPTION
Workaround for <https://github.com/rust-lang/cargo/issues/10280>.
