### PR TITLE
fix: undetected gzip HTTP body truncation

### DIFF
--- a/influxdb_iox/src/influxdb_ioxd/http/utils.rs
+++ b/influxdb_iox/src/influxdb_ioxd/http/utils.rs
@@ -87,7 +87,7 @@ pub async fn parse_body(
         // Read at most max_size bytes to prevent a decompression bomb based
         // DoS.
         //
-        // In order to detect if the entire stream ahs been read, or truncated,
+        // In order to detect if the entire stream has been read, or truncated,
         // read an extra byte beyond the limit and check the resulting data
         // length - see test_read_gzipped_body_truncation.
         let mut decoder = decoder.take(max_size as u64 + 1);


### PR DESCRIPTION
If all the stars aligned in just the right way, it was possible to silently drop line protocol fields / timestamp due to truncation of the HTTP body when reading a gzipped request.

---

* fix: undected gzip HTTP body truncation (3d329018)

      When reading the gzip-encoded body of a HTTP request, the stream is read up
      until the configured maximum number of allowable bytes, at which point the
      body was silently trucated. This could allow fields in submitted line protocol
      to be silently lost (amongst other bad things).

      This change ensures that truncation results in a RequestSizeExceeded error.