### PR TITLE
feat(router2): implement delete API handler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3649,6 +3649,7 @@ dependencies = [
  "observability_deps",
  "parking_lot",
  "paste",
+ "predicate",
  "serde",
  "serde_urlencoded",
  "thiserror",

--- a/router2/Cargo.toml
+++ b/router2/Cargo.toml
@@ -20,6 +20,7 @@ mutable_batch = { path = "../mutable_batch" }
 mutable_batch_lp = { path = "../mutable_batch_lp" }
 observability_deps = { path = "../observability_deps" }
 parking_lot = "0.11"
+predicate = { path = "../predicate" }
 serde = "1.0"
 serde_urlencoded = "0.7"
 thiserror = "1.0"

--- a/router2/src/dml_handler/nop.rs
+++ b/router2/src/dml_handler/nop.rs
@@ -17,8 +17,8 @@ pub struct NopDmlHandler;
 
 #[async_trait]
 impl DmlHandler for NopDmlHandler {
-    async fn write<'a>(
-        &'a self,
+    async fn write(
+        &self,
         namespace: DatabaseName<'_>,
         batches: HashMap<String, MutableBatch>,
         _payload_stats: PayloadStatistics,
@@ -26,6 +26,15 @@ impl DmlHandler for NopDmlHandler {
         _span_ctx: Option<SpanContext>,
     ) -> Result<(), DmlError> {
         info!(%namespace, ?batches, "dropping write operation");
+        Ok(())
+    }
+
+    async fn delete(
+        &self,
+        delete: predicate::delete_predicate::HttpDeleteRequest,
+        _span_ctx: Option<SpanContext>,
+    ) -> Result<(), DmlError> {
+        info!(?delete, "dropping delete operation");
         Ok(())
     }
 }

--- a/router2/src/dml_handler/trait.rs
+++ b/router2/src/dml_handler/trait.rs
@@ -6,6 +6,7 @@ use data_types::DatabaseName;
 use hashbrown::HashMap;
 use mutable_batch::MutableBatch;
 use mutable_batch_lp::PayloadStatistics;
+use predicate::delete_predicate::HttpDeleteRequest;
 use thiserror::Error;
 use trace::ctx::SpanContext;
 
@@ -26,12 +27,19 @@ pub enum DmlError {
 #[async_trait]
 pub trait DmlHandler: Debug + Send + Sync {
     /// Write `batches` to `namespace`.
-    async fn write<'a>(
-        &'a self,
+    async fn write(
+        &self,
         namespace: DatabaseName<'_>,
         batches: HashMap<String, MutableBatch>,
         payload_stats: PayloadStatistics,
         body_len: usize,
+        span_ctx: Option<SpanContext>,
+    ) -> Result<(), DmlError>;
+
+    /// Delete the data specified in `delete`.
+    async fn delete(
+        &self,
+        delete: HttpDeleteRequest,
         span_ctx: Option<SpanContext>,
     ) -> Result<(), DmlError>;
 }


### PR DESCRIPTION
Follows on from #3468 adding a HTTP handler for the `/api/v2/delete` endpoint.

---

* feat(router2): implement delete API handler (6f2e10ca)

      Adds support for the HTTP v2 delete API endpoint.


