### PR TITLE
feat: implement memory backed iox_catalog

### DIFF
--- a/iox_catalog/src/interface.rs
+++ b/iox_catalog/src/interface.rs
@@ -124,6 +124,9 @@ pub trait SequencerRepo {
 
     /// list all sequencers
     async fn list(&self) -> Result<Vec<Sequencer>>;
+
+    /// list all sequencers for a given kafka topic
+    async fn list_by_kafka_topic(&self, topic: &KafkaTopic) -> Result<Vec<Sequencer>>;
 }
 
 /// Data object for a kafka topic
@@ -145,7 +148,7 @@ pub struct QueryPool {
 }
 
 /// Data object for a namespace
-#[derive(Debug, Clone, sqlx::FromRow)]
+#[derive(Debug, Clone, Eq, PartialEq, sqlx::FromRow)]
 pub struct Namespace {
     /// The id of the namespace
     pub id: i32,
@@ -449,4 +452,187 @@ pub struct Sequencer {
     /// with a higher sequence number than this. However, all data with a sequence number
     /// lower than this must have been persisted to Parquet.
     pub min_unpersisted_sequence_number: i64,
+}
+
+#[cfg(test)]
+pub(crate) mod test_helpers {
+    use super::*;
+    use futures::{stream::FuturesOrdered, StreamExt};
+
+    pub(crate) async fn test_repo<T, F>(new_repo: F)
+    where
+        T: RepoCollection + Send + Sync,
+        F: Fn() -> T + Send + Sync,
+    {
+        test_kafka_topic(&new_repo()).await;
+        test_query_pool(&new_repo()).await;
+        test_namespace(&new_repo()).await;
+        test_table(&new_repo()).await;
+        test_column(&new_repo()).await;
+        test_sequencer(&new_repo()).await;
+    }
+
+    async fn test_kafka_topic<T: RepoCollection + Send + Sync>(repo: &T) {
+        let kafka_repo = repo.kafka_topic();
+        let k = kafka_repo.create_or_get("foo").await.unwrap();
+        assert!(k.id > 0);
+        assert_eq!(k.name, "foo");
+        let k2 = kafka_repo.create_or_get("foo").await.unwrap();
+        assert_eq!(k, k2);
+    }
+
+    async fn test_query_pool<T: RepoCollection + Send + Sync>(repo: &T) {
+        let query_repo = repo.query_pool();
+        let q = query_repo.create_or_get("foo").await.unwrap();
+        assert!(q.id > 0);
+        assert_eq!(q.name, "foo");
+        let q2 = query_repo.create_or_get("foo").await.unwrap();
+        assert_eq!(q, q2);
+    }
+
+    async fn test_namespace<T: RepoCollection + Send + Sync>(repo: &T) {
+        let namespace_repo = repo.namespace();
+        let kafka = repo.kafka_topic().create_or_get("foo").await.unwrap();
+        let pool = repo.query_pool().create_or_get("foo").await.unwrap();
+
+        let namespace_name = "test_namespace";
+        let namespace = namespace_repo
+            .create(namespace_name, "inf", kafka.id, pool.id)
+            .await
+            .unwrap();
+        assert!(namespace.id > 0);
+        assert_eq!(namespace.name, namespace_name);
+
+        let conflict = namespace_repo
+            .create(namespace_name, "inf", kafka.id, pool.id)
+            .await;
+        assert!(matches!(
+            conflict.unwrap_err(),
+            Error::NameExists { name: _ }
+        ));
+
+        let found = namespace_repo
+            .get_by_name(namespace_name)
+            .await
+            .unwrap()
+            .expect("namespace should be there");
+        assert_eq!(namespace, found);
+    }
+
+    async fn test_table<T: RepoCollection + Send + Sync>(repo: &T) {
+        let kafka = repo.kafka_topic().create_or_get("foo").await.unwrap();
+        let pool = repo.query_pool().create_or_get("foo").await.unwrap();
+        let namespace = repo
+            .namespace()
+            .create("namespace_table_test", "inf", kafka.id, pool.id)
+            .await
+            .unwrap();
+
+        // test we can create or get a table
+        let table_repo = repo.table();
+        let t = table_repo
+            .create_or_get("test_table", namespace.id)
+            .await
+            .unwrap();
+        let tt = table_repo
+            .create_or_get("test_table", namespace.id)
+            .await
+            .unwrap();
+        assert!(t.id > 0);
+        assert_eq!(t, tt);
+
+        let tables = table_repo.list_by_namespace_id(namespace.id).await.unwrap();
+        assert_eq!(vec![t], tables);
+    }
+
+    async fn test_column<T: RepoCollection + Send + Sync>(repo: &T) {
+        let kafka = repo.kafka_topic().create_or_get("foo").await.unwrap();
+        let pool = repo.query_pool().create_or_get("foo").await.unwrap();
+        let namespace = repo
+            .namespace()
+            .create("namespace_column_test", "inf", kafka.id, pool.id)
+            .await
+            .unwrap();
+        let table = repo
+            .table()
+            .create_or_get("test_table", namespace.id)
+            .await
+            .unwrap();
+
+        // test we can create or get a column
+        let column_repo = repo.column();
+        let c = column_repo
+            .create_or_get("column_test", table.id, ColumnType::Tag)
+            .await
+            .unwrap();
+        let cc = column_repo
+            .create_or_get("column_test", table.id, ColumnType::Tag)
+            .await
+            .unwrap();
+        assert!(c.id > 0);
+        assert_eq!(c, cc);
+
+        // test that attempting to create an already defined column of a different type returns error
+        let err = column_repo
+            .create_or_get("column_test", table.id, ColumnType::U64)
+            .await
+            .expect_err("should error with wrong column type");
+        assert!(matches!(
+            err,
+            Error::ColumnTypeMismatch {
+                name: _,
+                existing: _,
+                new: _
+            }
+        ));
+
+        // test that we can create a column of the same name under a different table
+        let table2 = repo
+            .table()
+            .create_or_get("test_table_2", namespace.id)
+            .await
+            .unwrap();
+        let ccc = column_repo
+            .create_or_get("column_test", table2.id, ColumnType::U64)
+            .await
+            .unwrap();
+        assert_ne!(c, ccc);
+
+        let columns = column_repo
+            .list_by_namespace_id(namespace.id)
+            .await
+            .unwrap();
+        assert_eq!(vec![c, ccc], columns);
+    }
+
+    async fn test_sequencer<T: RepoCollection + Send + Sync>(repo: &T) {
+        let kafka = repo
+            .kafka_topic()
+            .create_or_get("sequencer_test")
+            .await
+            .unwrap();
+        let sequencer_repo = repo.sequencer();
+
+        // Create 10 sequencers
+        let created = (1..=10)
+            .map(|partition| sequencer_repo.create_or_get(&kafka, partition))
+            .collect::<FuturesOrdered<_>>()
+            .map(|v| {
+                let v = v.expect("failed to create sequencer");
+                (v.id, v)
+            })
+            .collect::<BTreeMap<_, _>>()
+            .await;
+
+        // List them and assert they match
+        let listed = sequencer_repo
+            .list_by_kafka_topic(&kafka)
+            .await
+            .expect("failed to list sequencers")
+            .into_iter()
+            .map(|v| (v.id, v))
+            .collect::<BTreeMap<_, _>>();
+
+        assert_eq!(created, listed);
+    }
 }

--- a/iox_catalog/src/lib.rs
+++ b/iox_catalog/src/lib.rs
@@ -200,6 +200,7 @@ pub async fn create_or_get_default_records<T: RepoCollection + Sync + Send>(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::interface::get_schema_by_name;
     use crate::mem::MemCatalog;
     use influxdb_line_protocol::parse_lines;
     use std::sync::Arc;
@@ -235,7 +236,7 @@ m2,t3=b f1=true 1
         let new_schema = new_schema.unwrap();
 
         // ensure new schema is in the db
-        let schema_from_db = NamespaceSchema::get_by_name(namespace_name, &repo)
+        let schema_from_db = get_schema_by_name(namespace_name, &repo)
             .await
             .unwrap()
             .unwrap();
@@ -260,7 +261,7 @@ new_measurement,t9=a f10=true 1
             ColumnType::Tag,
             new_table.columns.get("t9").unwrap().column_type
         );
-        let schema = NamespaceSchema::get_by_name(namespace_name, &repo)
+        let schema = get_schema_by_name(namespace_name, &repo)
             .await
             .unwrap()
             .unwrap();
@@ -285,7 +286,7 @@ m1,new_tag=c new_field=1i 2
             ColumnType::Tag,
             table.columns.get("new_tag").unwrap().column_type
         );
-        let schema = NamespaceSchema::get_by_name(namespace_name, &repo)
+        let schema = get_schema_by_name(namespace_name, &repo)
             .await
             .unwrap()
             .unwrap();

--- a/iox_catalog/src/lib.rs
+++ b/iox_catalog/src/lib.rs
@@ -25,6 +25,7 @@ const SHARED_QUERY_POOL: &str = SHARED_KAFKA_TOPIC;
 const TIME_COLUMN: &str = "time";
 
 pub mod interface;
+pub mod mem;
 pub mod postgres;
 
 /// Given the lines of a write request and an in memory schema, this will validate the write

--- a/iox_catalog/src/lib.rs
+++ b/iox_catalog/src/lib.rs
@@ -196,3 +196,99 @@ pub async fn create_or_get_default_records<T: RepoCollection + Sync + Send>(
 
     Ok((kafka_topic, query_pool, sequencers))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::mem::MemCatalog;
+    use influxdb_line_protocol::parse_lines;
+    use std::sync::Arc;
+
+    #[tokio::test]
+    async fn test_validate_or_insert_schema() {
+        let repo = Arc::new(MemCatalog::new());
+        let (kafka_topic, query_pool, _) = create_or_get_default_records(2, &repo).await.unwrap();
+
+        let namespace_name = "validate_schema";
+        // now test with a new namespace
+        let namespace = repo
+            .namespace()
+            .create(namespace_name, "inf", kafka_topic.id, query_pool.id)
+            .await
+            .unwrap();
+        let data = r#"
+m1,t1=a,t2=b f1=2i,f2=2.0 1
+m1,t1=a f1=3i 2
+m2,t3=b f1=true 1
+        "#;
+
+        // test that new schema gets returned
+        let lines: Vec<_> = parse_lines(data).map(|l| l.unwrap()).collect();
+        let schema = Arc::new(NamespaceSchema::new(
+            namespace.id,
+            namespace.kafka_topic_id,
+            namespace.query_pool_id,
+        ));
+        let new_schema = validate_or_insert_schema(lines, &schema, &repo)
+            .await
+            .unwrap();
+        let new_schema = new_schema.unwrap();
+
+        // ensure new schema is in the db
+        let schema_from_db = NamespaceSchema::get_by_name(namespace_name, &repo)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(new_schema, schema_from_db);
+
+        // test that a new table will be created
+        let data = r#"
+m1,t1=c f1=1i 2
+new_measurement,t9=a f10=true 1
+        "#;
+        let lines: Vec<_> = parse_lines(data).map(|l| l.unwrap()).collect();
+        let new_schema = validate_or_insert_schema(lines, &schema_from_db, &repo)
+            .await
+            .unwrap()
+            .unwrap();
+        let new_table = new_schema.tables.get("new_measurement").unwrap();
+        assert_eq!(
+            ColumnType::Bool,
+            new_table.columns.get("f10").unwrap().column_type
+        );
+        assert_eq!(
+            ColumnType::Tag,
+            new_table.columns.get("t9").unwrap().column_type
+        );
+        let schema = NamespaceSchema::get_by_name(namespace_name, &repo)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(new_schema, schema);
+
+        // test that a new column for an existing table will be created
+        // test that a new table will be created
+        let data = r#"
+m1,new_tag=c new_field=1i 2
+        "#;
+        let lines: Vec<_> = parse_lines(data).map(|l| l.unwrap()).collect();
+        let new_schema = validate_or_insert_schema(lines, &schema, &repo)
+            .await
+            .unwrap()
+            .unwrap();
+        let table = new_schema.tables.get("m1").unwrap();
+        assert_eq!(
+            ColumnType::I64,
+            table.columns.get("new_field").unwrap().column_type
+        );
+        assert_eq!(
+            ColumnType::Tag,
+            table.columns.get("new_tag").unwrap().column_type
+        );
+        let schema = NamespaceSchema::get_by_name(namespace_name, &repo)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(new_schema, schema);
+    }
+}

--- a/iox_catalog/src/mem.rs
+++ b/iox_catalog/src/mem.rs
@@ -1,0 +1,248 @@
+//! This module implements an in-memory implementation of the iox_catalog interface. It can be
+//! used for testing or for an IOx designed to run without catalog persistence.
+
+use crate::interface::{
+    Column, ColumnRepo, ColumnType, Error, KafkaTopic, KafkaTopicRepo, Namespace, NamespaceRepo,
+    QueryPool, QueryPoolRepo, RepoCollection, Result, Sequencer, SequencerRepo, Table, TableRepo,
+};
+use async_trait::async_trait;
+use std::convert::TryFrom;
+use std::sync::{Arc, Mutex};
+
+struct MemCatalog {
+    collections: Mutex<MemCollections>,
+}
+
+struct MemCollections {
+    kafka_topics: Vec<KafkaTopic>,
+    query_pools: Vec<QueryPool>,
+    namespaces: Vec<Namespace>,
+    tables: Vec<Table>,
+    columns: Vec<Column>,
+    sequencers: Vec<Sequencer>,
+}
+
+impl RepoCollection for Arc<MemCatalog> {
+    fn kafka_topic(&self) -> Arc<dyn KafkaTopicRepo + Sync + Send> {
+        Self::clone(self) as Arc<dyn KafkaTopicRepo + Sync + Send>
+    }
+
+    fn query_pool(&self) -> Arc<dyn QueryPoolRepo + Sync + Send> {
+        Self::clone(self) as Arc<dyn QueryPoolRepo + Sync + Send>
+    }
+
+    fn namespace(&self) -> Arc<dyn NamespaceRepo + Sync + Send> {
+        Self::clone(self) as Arc<dyn NamespaceRepo + Sync + Send>
+    }
+
+    fn table(&self) -> Arc<dyn TableRepo + Sync + Send> {
+        Self::clone(self) as Arc<dyn TableRepo + Sync + Send>
+    }
+
+    fn column(&self) -> Arc<dyn ColumnRepo + Sync + Send> {
+        Self::clone(self) as Arc<dyn ColumnRepo + Sync + Send>
+    }
+
+    fn sequencer(&self) -> Arc<dyn SequencerRepo + Sync + Send> {
+        Self::clone(self) as Arc<dyn SequencerRepo + Sync + Send>
+    }
+}
+
+#[async_trait]
+impl KafkaTopicRepo for MemCatalog {
+    async fn create_or_get(&self, name: &str) -> Result<KafkaTopic> {
+        let mut collections = self.collections.lock().expect("mutex poisoned");
+
+        let topic = match collections.kafka_topics.iter().find(|t| t.name == name) {
+            Some(t) => t,
+            None => {
+                let topic = KafkaTopic {
+                    id: collections.kafka_topics.len() as i32 + 1,
+                    name: name.to_string(),
+                };
+                collections.kafka_topics.push(topic);
+                collections.kafka_topics.last().unwrap()
+            }
+        };
+
+        Ok(topic.clone())
+    }
+}
+
+#[async_trait]
+impl QueryPoolRepo for MemCatalog {
+    async fn create_or_get(&self, name: &str) -> Result<QueryPool> {
+        let mut collections = self.collections.lock().expect("mutex poisoned");
+
+        let pool = match collections.query_pools.iter().find(|t| t.name == name) {
+            Some(t) => t,
+            None => {
+                let pool = QueryPool {
+                    id: collections.query_pools.len() as i16 + 1,
+                    name: name.to_string(),
+                };
+                collections.query_pools.push(pool);
+                collections.query_pools.last().unwrap()
+            }
+        };
+
+        Ok(pool.clone())
+    }
+}
+
+#[async_trait]
+impl NamespaceRepo for MemCatalog {
+    async fn create(
+        &self,
+        name: &str,
+        retention_duration: &str,
+        kafka_topic_id: i32,
+        query_pool_id: i16,
+    ) -> Result<Namespace> {
+        let mut collections = self.collections.lock().expect("mutex poisoned");
+        if collections.namespaces.iter().any(|n| n.name == name) {
+            return Err(Error::NameExists {
+                name: name.to_string(),
+            });
+        }
+
+        let namespace = Namespace {
+            id: collections.namespaces.len() as i32 + 1,
+            name: name.to_string(),
+            kafka_topic_id,
+            query_pool_id,
+            retention_duration: Some(retention_duration.to_string()),
+        };
+        collections.namespaces.push(namespace);
+        Ok(collections.namespaces.last().unwrap().clone())
+    }
+
+    async fn get_by_name(&self, name: &str) -> Result<Option<Namespace>> {
+        let collections = self.collections.lock().expect("mutex poisoned");
+        Ok(collections
+            .namespaces
+            .iter()
+            .find(|n| n.name == name)
+            .cloned())
+    }
+}
+
+#[async_trait]
+impl TableRepo for MemCatalog {
+    async fn create_or_get(&self, name: &str, namespace_id: i32) -> Result<Table> {
+        let mut collections = self.collections.lock().expect("mutex poisoned");
+
+        let table = match collections.tables.iter().find(|t| t.name == name) {
+            Some(t) => t,
+            None => {
+                let table = Table {
+                    id: collections.tables.len() as i32 + 1,
+                    namespace_id,
+                    name: name.to_string(),
+                };
+                collections.tables.push(table);
+                collections.tables.last().unwrap()
+            }
+        };
+
+        Ok(table.clone())
+    }
+
+    async fn list_by_namespace_id(&self, namespace_id: i32) -> Result<Vec<Table>> {
+        let collections = self.collections.lock().expect("mutex poisoned");
+        let tables: Vec<_> = collections
+            .tables
+            .iter()
+            .filter(|t| t.namespace_id == namespace_id)
+            .cloned()
+            .collect();
+        Ok(tables)
+    }
+}
+
+#[async_trait]
+impl ColumnRepo for MemCatalog {
+    async fn create_or_get(
+        &self,
+        name: &str,
+        table_id: i32,
+        column_type: ColumnType,
+    ) -> Result<Column> {
+        let mut collections = self.collections.lock().expect("mutex poisoned");
+
+        let column = match collections.columns.iter().find(|t| t.name == name) {
+            Some(c) => {
+                if column_type as i16 != c.column_type {
+                    return Err(Error::ColumnTypeMismatch {
+                        name: name.to_string(),
+                        existing: ColumnType::try_from(c.column_type).unwrap().to_string(),
+                        new: column_type.to_string(),
+                    });
+                }
+
+                c
+            }
+            None => {
+                let column = Column {
+                    id: collections.columns.len() as i32 + 1,
+                    table_id,
+                    name: name.to_string(),
+                    column_type: column_type as i16,
+                };
+                collections.columns.push(column);
+                collections.columns.last().unwrap()
+            }
+        };
+
+        Ok(column.clone())
+    }
+
+    async fn list_by_namespace_id(&self, namespace_id: i32) -> Result<Vec<Column>> {
+        let mut columns = vec![];
+
+        let collections = self.collections.lock().expect("mutex poisoned");
+        for t in collections
+            .tables
+            .iter()
+            .filter(|t| t.namespace_id == namespace_id)
+        {
+            for c in collections.columns.iter().filter(|c| c.table_id == t.id) {
+                columns.push(c.clone());
+            }
+        }
+
+        Ok(columns)
+    }
+}
+
+#[async_trait]
+impl SequencerRepo for MemCatalog {
+    async fn create_or_get(&self, topic: &KafkaTopic, partition: i32) -> Result<Sequencer> {
+        let mut collections = self.collections.lock().expect("mutex poisoned");
+
+        let sequencer = match collections
+            .sequencers
+            .iter()
+            .find(|s| s.kafka_topic_id == topic.id && s.kafka_partition == partition)
+        {
+            Some(t) => t,
+            None => {
+                let sequencer = Sequencer {
+                    id: collections.sequencers.len() as i16 + 1,
+                    kafka_topic_id: topic.id,
+                    kafka_partition: partition,
+                    min_unpersisted_sequence_number: 0,
+                };
+                collections.sequencers.push(sequencer);
+                collections.sequencers.last().unwrap()
+            }
+        };
+
+        Ok(*sequencer)
+    }
+
+    async fn list(&self) -> Result<Vec<Sequencer>> {
+        let collections = self.collections.lock().expect("mutex poisoned");
+        Ok(collections.sequencers.clone())
+    }
+}

--- a/iox_catalog/src/mem.rs
+++ b/iox_catalog/src/mem.rs
@@ -10,7 +10,7 @@ use std::convert::TryFrom;
 use std::fmt::Formatter;
 use std::sync::{Arc, Mutex};
 
-/// In-memory catalog that implements the `RepoCollection` and individual repo traits fromt
+/// In-memory catalog that implements the `RepoCollection` and individual repo traits from
 /// the catalog interface.
 #[derive(Default)]
 pub struct MemCatalog {

--- a/iox_catalog/src/mem.rs
+++ b/iox_catalog/src/mem.rs
@@ -7,12 +7,31 @@ use crate::interface::{
 };
 use async_trait::async_trait;
 use std::convert::TryFrom;
+use std::fmt::Formatter;
 use std::sync::{Arc, Mutex};
 
-struct MemCatalog {
+/// In-memory catalog that implements the `RepoCollection` and individual repo traits fromt
+/// the catalog interface.
+#[derive(Default)]
+pub struct MemCatalog {
     collections: Mutex<MemCollections>,
 }
 
+impl MemCatalog {
+    /// return new initialized `MemCatalog`
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl std::fmt::Debug for MemCatalog {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let c = self.collections.lock().expect("mutex poisoned");
+        write!(f, "MemCatalog[ {:?} ]", c)
+    }
+}
+
+#[derive(Default, Debug)]
 struct MemCollections {
     kafka_topics: Vec<KafkaTopic>,
     query_pools: Vec<QueryPool>,


### PR DESCRIPTION
* Adds a memory based catalog, useful for testing purposes.
* Separates getting the namespace schema from the namespace and moves the schema code out interface out of postgres.
* Make postgres and mem catalog implementations public
* Make iox_catalog tests generic for any backend implementation
