### PR TITLE
feat: simplify linking of spans

### DIFF
--- a/trace/src/span.rs
+++ b/trace/src/span.rs
@@ -126,7 +126,7 @@ pub struct SpanRecorder {
     span: Option<Span>,
 }
 
-impl<'a> SpanRecorder {
+impl SpanRecorder {
     pub fn new(mut span: Option<Span>) -> Self {
         if let Some(span) = span.as_mut() {
             span.start = Some(Utc::now());
@@ -179,7 +179,7 @@ impl<'a> SpanRecorder {
     }
 }
 
-impl<'a> Drop for SpanRecorder {
+impl Drop for SpanRecorder {
     fn drop(&mut self) {
         if let Some(mut span) = self.span.take() {
             let now = Utc::now();

--- a/trace/src/span.rs
+++ b/trace/src/span.rs
@@ -72,6 +72,11 @@ impl Span {
     pub fn child(&self, name: impl Into<Cow<'static, str>>) -> Self {
         self.ctx.child(name)
     }
+
+    /// Link this span to another context.
+    pub fn link(&mut self, other: &SpanContext) {
+        self.ctx.links.push((other.trace_id, other.span_id));
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -176,6 +181,13 @@ impl SpanRecorder {
     /// or None if there is no active span
     pub fn span(&self) -> Option<&Span> {
         self.span.as_ref()
+    }
+
+    /// Link this span to another context.
+    pub fn link(&mut self, other: &SpanContext) {
+        if let Some(span) = self.span.as_mut() {
+            span.link(other);
+        }
     }
 }
 


### PR DESCRIPTION
Linking of span contexts was introduced in #2803 but the high-level
interface was never used. This adds the missing bits to allow links to
be used with `Span` and `SpanRecorder`.