### PR TITLE
refactor: Clean up the Catalog API

### DIFF
--- a/ingester/src/data.rs
+++ b/ingester/src/data.rs
@@ -7,8 +7,8 @@ use uuid::Uuid;
 
 use crate::server::IngesterServer;
 use iox_catalog::interface::{
-    KafkaPartition, KafkaTopicId, NamespaceId, PartitionId, RepoCollection, SequenceNumber,
-    SequencerId, TableId, Tombstone,
+    Catalog, KafkaPartition, KafkaTopicId, NamespaceId, PartitionId, SequenceNumber, SequencerId,
+    TableId, Tombstone,
 };
 use mutable_batch::MutableBatch;
 use parking_lot::RwLock;
@@ -54,11 +54,9 @@ pub struct Sequencers {
 
 impl Sequencers {
     /// One time initialize Sequencers of this Ingester
-    pub async fn initialize<T: RepoCollection + Send + Sync>(
-        ingester: &IngesterServer<'_, T>,
-    ) -> Result<Self> {
+    pub async fn initialize<T: Catalog>(ingester: &IngesterServer<'_, T>) -> Result<Self> {
         // Get sequencer ids from the catalog
-        let sequencer_repro = ingester.iox_catalog.sequencer();
+        let sequencer_repro = ingester.iox_catalog.sequencers();
         let mut sequencers = BTreeMap::default();
         let topic = ingester.get_topic();
         for shard in ingester.get_kafka_partitions() {

--- a/ingester/src/server.rs
+++ b/ingester/src/server.rs
@@ -3,13 +3,13 @@
 
 use std::sync::Arc;
 
-use iox_catalog::interface::{KafkaPartition, KafkaTopic, KafkaTopicId, RepoCollection};
+use iox_catalog::interface::{Catalog, KafkaPartition, KafkaTopic, KafkaTopicId};
 
 /// The [`IngesterServer`] manages the lifecycle and contains all state for
 /// an `ingester` server instance.
 pub struct IngesterServer<'a, T>
 where
-    T: RepoCollection + Send + Sync,
+    T: Catalog,
 {
     /// Kafka Topic assigned to this ingester
     kafka_topic: KafkaTopic,
@@ -21,7 +21,7 @@ where
 
 impl<'a, T> IngesterServer<'a, T>
 where
-    T: RepoCollection + Send + Sync,
+    T: Catalog,
 {
     /// Initialize the Ingester
     pub fn new(topic: KafkaTopic, shard_ids: Vec<KafkaPartition>, catalog: &'a Arc<T>) -> Self {


### PR DESCRIPTION
This updates the catalog API to make it easier to work with for consumers. I also found a bug in the MemCatalog implementation while refactoring the tests to work with the new API definition. Consumers will now be able to Arc wrap the catalog and use it across awaits.