### PR TITLE
chore: Set default to squash

### DIFF
--- a/.kodiak.toml
+++ b/.kodiak.toml
@@ -1,1 +1,2 @@
 version = 1
+merge.method = "squash"


### PR DESCRIPTION
The team decided to switch to "squash all the commits" 

![image](https://user-images.githubusercontent.com/52673/151000990-00e6a526-1d6a-44b7-a7f2-971218efa41f.png)
