### PR TITLE
feat: two pass chunk prune

### DIFF
--- a/predicate/src/predicate.rs
+++ b/predicate/src/predicate.rs
@@ -105,7 +105,7 @@ impl Predicate {
         }
     }
 
-    /// Creates a DataFusion predicate for appliying a timestamp range:
+    /// Creates a DataFusion predicate for applying a timestamp range:
     ///
     /// `range.start <= time and time < range.end`
     fn make_timestamp_predicate_expr(&self) -> Option<Expr> {


### PR DESCRIPTION
Currently when pruning chunks the system will collect the statistics for all columns mentioned by any of the predicates across all chunks in a table. It will then evaluate all the predicates against this `RecordBatch` of aggregated statistics. This is fantastic because it gives the most accurate prune possible, handling complex predicate expressions, etc... However, it is relatively expensive to do for every chunk in the table.

As it happens most queries will have some sort of predicate on time, and this will typically prune out large numbers of chunks. We can therefore do an initial pass with just the time predicates, before performing the more expensive prune on what is left.

This is partly an experiment, I'm not entirely sure what difference this will make, but thought it was simple enough to be worth a shot :grin: 