### PR TITLE
refactor: decouple error types for DmlHandler

### DIFF
--- a/router2/src/dml_handlers/mock.rs
+++ b/router2/src/dml_handlers/mock.rs
@@ -69,14 +69,15 @@ macro_rules! record_and_return {
 
 #[async_trait]
 impl DmlHandler for Arc<MockDmlHandler> {
-    type Error = DmlError;
+    type WriteError = DmlError;
+    type DeleteError = DmlError;
 
     async fn write(
         &self,
         namespace: DatabaseName<'static>,
         batches: HashMap<String, MutableBatch>,
         _span_ctx: Option<SpanContext>,
-    ) -> Result<(), Self::Error> {
+    ) -> Result<(), Self::WriteError> {
         record_and_return!(
             self,
             MockDmlHandlerCall::Write {
@@ -93,7 +94,7 @@ impl DmlHandler for Arc<MockDmlHandler> {
         table: impl Into<String> + Send + Sync + 'a,
         predicate: DeletePredicate,
         _span_ctx: Option<SpanContext>,
-    ) -> Result<(), Self::Error> {
+    ) -> Result<(), Self::DeleteError> {
         record_and_return!(
             self,
             MockDmlHandlerCall::Delete {

--- a/router2/src/dml_handlers/nop.rs
+++ b/router2/src/dml_handlers/nop.rs
@@ -16,14 +16,15 @@ pub struct NopDmlHandler;
 
 #[async_trait]
 impl DmlHandler for NopDmlHandler {
-    type Error = DmlError;
+    type WriteError = DmlError;
+    type DeleteError = DmlError;
 
     async fn write(
         &self,
         namespace: DatabaseName<'static>,
         batches: HashMap<String, MutableBatch>,
         _span_ctx: Option<SpanContext>,
-    ) -> Result<(), Self::Error> {
+    ) -> Result<(), Self::WriteError> {
         info!(%namespace, ?batches, "dropping write operation");
         Ok(())
     }
@@ -34,7 +35,7 @@ impl DmlHandler for NopDmlHandler {
         table: impl Into<String> + Send + Sync + 'a,
         predicate: DeletePredicate,
         _span_ctx: Option<SpanContext>,
-    ) -> Result<(), Self::Error> {
+    ) -> Result<(), Self::DeleteError> {
         let table = table.into();
         info!(%namespace, %table, ?predicate, "dropping delete operation");
         Ok(())

--- a/router2/src/dml_handlers/sharded_write_buffer.rs
+++ b/router2/src/dml_handlers/sharded_write_buffer.rs
@@ -78,7 +78,8 @@ where
     S: Sharder<MutableBatch, Item = Arc<Sequencer>>
         + Sharder<DeletePredicate, Item = Arc<Sequencer>>,
 {
-    type Error = ShardError;
+    type WriteError = ShardError;
+    type DeleteError = ShardError;
 
     /// Shard `writes` and dispatch the resultant DML operations.
     async fn write(

--- a/router2/src/dml_handlers/trait.rs
+++ b/router2/src/dml_handlers/trait.rs
@@ -30,10 +30,13 @@ pub enum DmlError {
 /// A composable, abstract handler of DML requests.
 #[async_trait]
 pub trait DmlHandler: Debug + Send + Sync {
-    /// The type of error a [`DmlHandler`] implementation produces.
+    /// The type of error a [`DmlHandler`] implementation produces for write
+    /// requests.
     ///
     /// All errors must be mappable into the concrete [`DmlError`] type.
-    type Error: Into<DmlError>;
+    type WriteError: Into<DmlError>;
+    /// The error type of the delete handler.
+    type DeleteError: Into<DmlError>;
 
     /// Write `batches` to `namespace`.
     async fn write(
@@ -41,7 +44,7 @@ pub trait DmlHandler: Debug + Send + Sync {
         namespace: DatabaseName<'static>,
         batches: HashMap<String, MutableBatch>,
         span_ctx: Option<SpanContext>,
-    ) -> Result<(), Self::Error>;
+    ) -> Result<(), Self::WriteError>;
 
     /// Delete the data specified in `delete`.
     async fn delete<'a>(
@@ -50,5 +53,5 @@ pub trait DmlHandler: Debug + Send + Sync {
         table_name: impl Into<String> + Send + Sync + 'a,
         predicate: DeletePredicate,
         span_ctx: Option<SpanContext>,
-    ) -> Result<(), Self::Error>;
+    ) -> Result<(), Self::DeleteError>;
 }


### PR DESCRIPTION
This commit was supposed to be part of https://github.com/influxdata/influxdb_iox/issues/3549 but was lost during a rebase and is part of the same end goal - refactoring the `DmlHandler` to be an easily-composable trait.

---

* refactor: decouple error types for DmlHandler (b38deaa7)

      Allows the DmlHandler to return different types for each method.

      This enables a DmlHandler implementation decorating an inner handler to return
      the inner handler's error directly, avoiding any "wrapper" errors.