### PR TITLE
build: use rust 1.58.1

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.58"
+channel = "1.58.1"
 components = [ "rustfmt", "clippy" ]


### PR DESCRIPTION
Update to the latest rust.

:wave: @jdstrand 

---

* build: use rust 1.58.1 (5438a4af)

      Security bugfix release, see:
        
      https://groups.google.com/g/rustlang-security-announcements/c/R1fZFDhnJVQ?pli=1