### PR TITLE
refactor: introduce to_string clippy lints in read buffer

### DIFF
--- a/read_buffer/src/chunk.rs
+++ b/read_buffer/src/chunk.rs
@@ -264,7 +264,7 @@ impl Chunk {
                 if !table_meta.has_column(column_name) {
                     return ColumnDoesNotExistSnafu {
                         column_name: column_name.to_string(),
-                        table_name: self.table.name().to_string(),
+                        table_name: self.table.name().to_owned(),
                     }
                     .fail();
                 }

--- a/read_buffer/src/column.rs
+++ b/read_buffer/src/column.rs
@@ -1543,7 +1543,7 @@ mod test {
             assert_eq!(
                 meta,
                 super::MetaData::<String> {
-                    range: Some(("hello".to_string(), "world".to_string())),
+                    range: Some(("hello".to_owned(), "world".to_owned())),
                     properties: ColumnProperties {
                         has_pre_computed_row_ids: true
                     }
@@ -1569,7 +1569,7 @@ mod test {
             assert_eq!(
                 meta,
                 super::MetaData::<String> {
-                    range: Some(("hello".to_string(), "world".to_string())),
+                    range: Some(("hello".to_owned(), "world".to_owned())),
                     properties: ColumnProperties {
                         has_pre_computed_row_ids: true
                     }

--- a/read_buffer/src/column/encoding/string.rs
+++ b/read_buffer/src/column/encoding/string.rs
@@ -320,9 +320,9 @@ mod test {
     }
 
     fn _push(mut enc: Encoding) {
-        enc.push_additional(Some("hello".to_string()), 1);
+        enc.push_additional(Some("hello".to_owned()), 1);
         enc.push_additional(None, 3);
-        enc.push("world".to_string());
+        enc.push("world".to_owned());
 
         let name = enc.debug_name();
         assert_eq!(
@@ -342,7 +342,7 @@ mod test {
             name
         );
 
-        enc.push_additional(Some("zoo".to_string()), 3);
+        enc.push_additional(Some("zoo".to_owned()), 3);
         enc.push_none();
         assert_eq!(
             enc.all_values(vec![]),
@@ -369,7 +369,7 @@ mod test {
     // tests a defect I discovered.
     #[test]
     fn push_additional_first_run_length() {
-        let dictionary = vec!["world".to_string(), "hello".to_string()]
+        let dictionary = vec!["world".to_owned(), "hello".to_owned()]
             .into_iter()
             .collect::<BTreeSet<String>>();
 
@@ -386,8 +386,8 @@ mod test {
     fn _push_additional_first_run_length(mut enc: Encoding) {
         let name = enc.debug_name();
 
-        enc.push_additional(Some("world".to_string()), 1);
-        enc.push_additional(Some("hello".to_string()), 1);
+        enc.push_additional(Some("world".to_owned()), 1);
+        enc.push_additional(Some("hello".to_owned()), 1);
 
         assert_eq!(
             enc.all_values(vec![]),
@@ -398,8 +398,8 @@ mod test {
         assert_eq!(enc.all_encoded_values(vec![]), vec![2, 1], "{}", name);
 
         enc = Encoding::RLE(RLE::default());
-        enc.push_additional(Some("hello".to_string()), 1);
-        enc.push_additional(Some("world".to_string()), 1);
+        enc.push_additional(Some("hello".to_owned()), 1);
+        enc.push_additional(Some("world".to_owned()), 1);
 
         assert_eq!(
             enc.all_values(vec![]),
@@ -424,11 +424,11 @@ mod test {
 
     fn _row_ids_filter_equal(mut enc: Encoding) {
         let name = enc.debug_name();
-        enc.push_additional(Some("east".to_string()), 3); // 0, 1, 2
-        enc.push_additional(Some("north".to_string()), 1); // 3
-        enc.push_additional(Some("east".to_string()), 5); // 4, 5, 6, 7, 8
+        enc.push_additional(Some("east".to_owned()), 3); // 0, 1, 2
+        enc.push_additional(Some("north".to_owned()), 1); // 3
+        enc.push_additional(Some("east".to_owned()), 5); // 4, 5, 6, 7, 8
         enc.push_none(); // 9
-        enc.push_additional(Some("south".to_string()), 2); // 10, 11
+        enc.push_additional(Some("south".to_owned()), 2); // 10, 11
 
         let ids = enc.row_ids_filter("east", &cmp::Operator::Equal, RowIDs::Vector(vec![]));
         assert_eq!(
@@ -471,8 +471,8 @@ mod test {
 
     fn _row_ids_filter_equal_no_null(mut enc: Encoding) {
         let name = enc.debug_name();
-        enc.push_additional(Some("east".to_string()), 2);
-        enc.push_additional(Some("west".to_string()), 1);
+        enc.push_additional(Some("east".to_owned()), 2);
+        enc.push_additional(Some("west".to_owned()), 1);
 
         let ids = enc.row_ids_filter("abba", &cmp::Operator::NotEqual, RowIDs::Vector(vec![]));
         assert_eq!(ids, RowIDs::Vector(vec![0, 1, 2]), "{}", name);
@@ -493,14 +493,14 @@ mod test {
     fn _row_ids_filter_cmp(mut enc: Encoding) {
         let name = enc.debug_name();
 
-        enc.push_additional(Some("east".to_string()), 3); // 0, 1, 2
-        enc.push_additional(Some("north".to_string()), 1); // 3
-        enc.push_additional(Some("east".to_string()), 5); // 4, 5, 6, 7, 8
-        enc.push_additional(Some("south".to_string()), 2); // 9, 10
-        enc.push_additional(Some("west".to_string()), 1); // 11
-        enc.push_additional(Some("north".to_string()), 1); // 12
+        enc.push_additional(Some("east".to_owned()), 3); // 0, 1, 2
+        enc.push_additional(Some("north".to_owned()), 1); // 3
+        enc.push_additional(Some("east".to_owned()), 5); // 4, 5, 6, 7, 8
+        enc.push_additional(Some("south".to_owned()), 2); // 9, 10
+        enc.push_additional(Some("west".to_owned()), 1); // 11
+        enc.push_additional(Some("north".to_owned()), 1); // 12
         enc.push_none(); // 13
-        enc.push_additional(Some("west".to_string()), 5); // 14, 15, 16, 17, 18
+        enc.push_additional(Some("west".to_owned()), 5); // 14, 15, 16, 17, 18
 
         let ids = enc.row_ids_filter("east", &cmp::Operator::LTE, RowIDs::Vector(vec![]));
         assert_eq!(
@@ -625,7 +625,7 @@ mod test {
 
         for enc in encodings.iter_mut() {
             let name = enc.debug_name();
-            enc.push("east".to_string());
+            enc.push("east".to_owned());
 
             let ids = enc.row_ids_filter("east", &cmp::Operator::GT, RowIDs::Vector(vec![]));
             assert!(ids.is_empty(), "{}", name);
@@ -661,7 +661,7 @@ mod test {
 
     #[test]
     fn row_ids_filter_cmp_with_null() {
-        let dictionary = vec!["east".to_string(), "south".to_string(), "west".to_string()]
+        let dictionary = vec!["east".to_owned(), "south".to_owned(), "west".to_owned()]
             .into_iter()
             .collect::<BTreeSet<String>>();
 
@@ -672,10 +672,10 @@ mod test {
 
         for enc in encodings.iter_mut() {
             let name = enc.debug_name();
-            enc.push("south".to_string());
-            enc.push("west".to_string());
+            enc.push("south".to_owned());
+            enc.push("west".to_owned());
             enc.push_none();
-            enc.push("east".to_string());
+            enc.push("east".to_owned());
 
             let ids = enc.row_ids_filter("west", &cmp::Operator::GT, RowIDs::Vector(vec![]));
             assert!(ids.is_empty(), "{}", name);
@@ -723,11 +723,11 @@ mod test {
 
     fn _row_ids_null(mut enc: Encoding) {
         let name = enc.debug_name();
-        enc.push_additional(Some("east".to_string()), 3); // 0, 1, 2
+        enc.push_additional(Some("east".to_owned()), 3); // 0, 1, 2
         enc.push_additional(None, 3); // 3, 4, 5
-        enc.push_additional(Some("north".to_string()), 1); // 6
+        enc.push_additional(Some("north".to_owned()), 1); // 6
         enc.push_additional(None, 2); // 7, 8
-        enc.push_additional(Some("south".to_string()), 2); // 9, 10
+        enc.push_additional(Some("south".to_owned()), 2); // 9, 10
 
         // essentially `WHERE value IS NULL`
         let ids = enc.row_ids_null(RowIDs::Vector(vec![]));
@@ -753,10 +753,10 @@ mod test {
     fn _group_row_ids(mut enc: Encoding) {
         let name = enc.debug_name();
 
-        enc.push_additional(Some("east".to_string()), 4); // 0, 1, 2, 3
-        enc.push_additional(Some("west".to_string()), 2); // 4, 5
+        enc.push_additional(Some("east".to_owned()), 4); // 0, 1, 2, 3
+        enc.push_additional(Some("west".to_owned()), 2); // 4, 5
         enc.push_none(); // 6
-        enc.push_additional(Some("zoo".to_string()), 1); // 7
+        enc.push_additional(Some("zoo".to_owned()), 1); // 7
 
         match enc {
             Encoding::RLE(_) => {
@@ -804,10 +804,10 @@ mod test {
         let name = enc.debug_name();
         assert!(enc.dictionary().is_empty());
 
-        enc.push_additional(Some("east".to_string()), 23);
-        enc.push_additional(Some("west".to_string()), 2);
+        enc.push_additional(Some("east".to_owned()), 23);
+        enc.push_additional(Some("west".to_owned()), 2);
         enc.push_none();
-        enc.push_additional(Some("zoo".to_string()), 1);
+        enc.push_additional(Some("zoo".to_owned()), 1);
 
         assert_eq!(enc.dictionary(), vec!["east", "west", "zoo"], "{}", name);
     }
@@ -825,15 +825,15 @@ mod test {
     }
 
     fn _value(mut enc: Encoding) {
-        enc.push_additional(Some("east".to_string()), 3); // 0, 1, 2
-        enc.push_additional(Some("north".to_string()), 1); // 3
-        enc.push_additional(Some("east".to_string()), 5); // 4, 5, 6, 7, 8
-        enc.push_additional(Some("south".to_string()), 2); // 9, 10
+        enc.push_additional(Some("east".to_owned()), 3); // 0, 1, 2
+        enc.push_additional(Some("north".to_owned()), 1); // 3
+        enc.push_additional(Some("east".to_owned()), 5); // 4, 5, 6, 7, 8
+        enc.push_additional(Some("south".to_owned()), 2); // 9, 10
         enc.push_none(); // 11
 
-        assert_eq!(enc.value(3), Some(&"north".to_string()));
-        assert_eq!(enc.value(0), Some(&"east".to_string()));
-        assert_eq!(enc.value(10), Some(&"south".to_string()));
+        assert_eq!(enc.value(3), Some(&"north".to_owned()));
+        assert_eq!(enc.value(0), Some(&"east".to_owned()));
+        assert_eq!(enc.value(10), Some(&"south".to_owned()));
         assert_eq!(enc.value(11), None);
     }
 
@@ -841,11 +841,11 @@ mod test {
     #[should_panic]
     fn value_bounds() {
         let mut enc = RLE::default();
-        enc.push("b".to_string());
+        enc.push("b".to_owned());
         enc.value(100);
 
         let mut enc = Dictionary::default();
-        enc.push("b".to_string());
+        enc.push("b".to_owned());
         enc.value(100);
     }
 
@@ -864,10 +864,10 @@ mod test {
     fn _values(mut enc: Encoding) {
         let name = enc.debug_name();
 
-        enc.push_additional(Some("east".to_string()), 3); // 0, 1, 2
-        enc.push_additional(Some("north".to_string()), 1); // 3
-        enc.push_additional(Some("east".to_string()), 5); // 4, 5, 6, 7, 8
-        enc.push_additional(Some("south".to_string()), 2); // 9, 10
+        enc.push_additional(Some("east".to_owned()), 3); // 0, 1, 2
+        enc.push_additional(Some("north".to_owned()), 1); // 3
+        enc.push_additional(Some("east".to_owned()), 5); // 4, 5, 6, 7, 8
+        enc.push_additional(Some("south".to_owned()), 2); // 9, 10
         enc.push_none(); // 11
 
         let mut dst = Vec::with_capacity(1000);
@@ -925,10 +925,10 @@ mod test {
     fn _encoded_values(mut enc: Encoding) {
         let name = enc.debug_name();
 
-        enc.push_additional(Some("east".to_string()), 3); // 0, 1, 2
-        enc.push_additional(Some("north".to_string()), 1); // 3
-        enc.push_additional(Some("east".to_string()), 5); // 4, 5, 6, 7, 8
-        enc.push_additional(Some("south".to_string()), 2); // 9, 10
+        enc.push_additional(Some("east".to_owned()), 3); // 0, 1, 2
+        enc.push_additional(Some("north".to_owned()), 1); // 3
+        enc.push_additional(Some("east".to_owned()), 5); // 4, 5, 6, 7, 8
+        enc.push_additional(Some("south".to_owned()), 2); // 9, 10
         enc.push_none(); // 11
 
         let mut encoded = enc.encoded_values(&[0], vec![]);
@@ -956,9 +956,9 @@ mod test {
     fn _all_encoded_values(mut enc: Encoding) {
         let name = enc.debug_name();
 
-        enc.push_additional(Some("east".to_string()), 3);
+        enc.push_additional(Some("east".to_owned()), 3);
         enc.push_additional(None, 2);
-        enc.push_additional(Some("north".to_string()), 2);
+        enc.push_additional(Some("north".to_owned()), 2);
 
         let dst = Vec::with_capacity(100);
         let dst = enc.all_encoded_values(dst);
@@ -1026,7 +1026,7 @@ mod test {
     fn _distinct_values(mut enc: Encoding) {
         let name = enc.debug_name();
 
-        enc.push_additional(Some("east".to_string()), 3);
+        enc.push_additional(Some("east".to_owned()), 3);
 
         let values = enc.distinct_values((0..3).collect::<Vec<_>>().into_iter(), BTreeSet::new());
         assert_eq!(
@@ -1036,9 +1036,9 @@ mod test {
             name,
         );
 
-        enc.push_additional(Some("north".to_string()), 1); // 3
-        enc.push_additional(Some("east".to_string()), 5); // 4, 5, 6, 7, 8
-        enc.push_additional(Some("south".to_string()), 2); // 9, 10
+        enc.push_additional(Some("north".to_owned()), 1); // 3
+        enc.push_additional(Some("east".to_owned()), 5); // 4, 5, 6, 7, 8
+        enc.push_additional(Some("south".to_owned()), 2); // 9, 10
         enc.push_none(); // 11
 
         let values = enc.distinct_values((0..12).collect::<Vec<_>>().into_iter(), BTreeSet::new());
@@ -1112,10 +1112,10 @@ mod test {
     #[test]
     fn has_non_null_value() {
         let mut enc = Encoding::RLE(RLE::default());
-        enc.push_additional(Some("east".to_string()), 3); // 0, 1, 2
-        enc.push_additional(Some("north".to_string()), 1); // 3
-        enc.push_additional(Some("east".to_string()), 5); // 4, 5, 6, 7, 8
-        enc.push_additional(Some("south".to_string()), 2); // 9, 10
+        enc.push_additional(Some("east".to_owned()), 3); // 0, 1, 2
+        enc.push_additional(Some("north".to_owned()), 1); // 3
+        enc.push_additional(Some("east".to_owned()), 5); // 4, 5, 6, 7, 8
+        enc.push_additional(Some("south".to_owned()), 2); // 9, 10
         enc.push_none(); // 11
 
         assert!(enc.has_non_null_value(&[0]));
@@ -1135,13 +1135,13 @@ mod test {
     #[test]
     fn min() {
         let mut enc = Encoding::RLE(RLE::default());
-        enc.push_additional(Some("east".to_string()), 3); // 0, 1, 2
+        enc.push_additional(Some("east".to_owned()), 3); // 0, 1, 2
         enc.push_additional(None, 2); // 3, 4
-        enc.push_additional(Some("north".to_string()), 2); // 5, 6
+        enc.push_additional(Some("north".to_owned()), 2); // 5, 6
 
-        assert_eq!(enc.min(&[0, 1, 2]), Some(&"east".to_string()));
-        assert_eq!(enc.min(&[0, 1, 2, 3, 4, 5, 6]), Some(&"east".to_string()));
-        assert_eq!(enc.min(&[4, 5, 6]), Some(&"north".to_string()));
+        assert_eq!(enc.min(&[0, 1, 2]), Some(&"east".to_owned()));
+        assert_eq!(enc.min(&[0, 1, 2, 3, 4, 5, 6]), Some(&"east".to_owned()));
+        assert_eq!(enc.min(&[4, 5, 6]), Some(&"north".to_owned()));
         assert_eq!(enc.min(&[3]), None);
         assert_eq!(enc.min(&[3, 4]), None);
 
@@ -1153,13 +1153,13 @@ mod test {
     #[test]
     fn max() {
         let mut enc = Encoding::RLE(RLE::default());
-        enc.push_additional(Some("east".to_string()), 3); // 0, 1, 2
+        enc.push_additional(Some("east".to_owned()), 3); // 0, 1, 2
         enc.push_additional(None, 2); // 3, 4
-        enc.push_additional(Some("north".to_string()), 2); // 5, 6
+        enc.push_additional(Some("north".to_owned()), 2); // 5, 6
 
-        assert_eq!(enc.max(&[0, 1, 2]), Some(&"east".to_string()));
-        assert_eq!(enc.max(&[0, 1, 2, 3, 4, 5, 6]), Some(&"north".to_string()));
-        assert_eq!(enc.max(&[4, 5, 6]), Some(&"north".to_string()));
+        assert_eq!(enc.max(&[0, 1, 2]), Some(&"east".to_owned()));
+        assert_eq!(enc.max(&[0, 1, 2, 3, 4, 5, 6]), Some(&"north".to_owned()));
+        assert_eq!(enc.max(&[4, 5, 6]), Some(&"north".to_owned()));
         assert_eq!(enc.max(&[3]), None);
         assert_eq!(enc.max(&[3, 4]), None);
 
@@ -1174,9 +1174,9 @@ mod test {
     #[test]
     fn count() {
         let mut enc = Encoding::RLE(RLE::default());
-        enc.push_additional(Some("east".to_string()), 3); // 0, 1, 2
+        enc.push_additional(Some("east".to_owned()), 3); // 0, 1, 2
         enc.push_additional(None, 2); // 3, 4
-        enc.push_additional(Some("north".to_string()), 2); // 5, 6
+        enc.push_additional(Some("north".to_owned()), 2); // 5, 6
 
         assert_eq!(enc.count(&[0, 1, 2]), 3);
         assert_eq!(enc.count(&[0, 1, 2, 3, 4, 5, 6]), 5);

--- a/read_buffer/src/column/encoding/string/dictionary.rs
+++ b/read_buffer/src/column/encoding/string/dictionary.rs
@@ -796,7 +796,7 @@ impl<'a> From<Vec<&str>> for Dictionary {
     fn from(vec: Vec<&str>) -> Self {
         let mut enc = Self::default();
         for v in vec {
-            enc.push(v.to_string());
+            enc.push(v.to_owned());
         }
         enc
     }
@@ -817,7 +817,7 @@ impl<'a> From<Vec<Option<&str>>> for Dictionary {
         let mut drle = Self::default();
         for v in vec {
             match v {
-                Some(x) => drle.push(x.to_string()),
+                Some(x) => drle.push(x.to_owned()),
                 None => drle.push_none(),
             }
         }
@@ -874,23 +874,23 @@ mod test {
     #[test]
     fn with_dictionary() {
         let mut dictionary = BTreeSet::new();
-        dictionary.insert("hello".to_string());
-        dictionary.insert("world".to_string());
+        dictionary.insert("hello".to_owned());
+        dictionary.insert("world".to_owned());
 
         let enc = Dictionary::with_dictionary(dictionary);
         assert_eq!(
             enc.entries,
-            vec![None, Some("hello".to_string()), Some("world".to_string()),]
+            vec![None, Some("hello".to_owned()), Some("world".to_owned()),]
         );
     }
 
     #[test]
     fn size() {
         let mut enc = Dictionary::default();
-        enc.push_additional(Some("east".to_string()), 3);
-        enc.push_additional(Some("north".to_string()), 1);
-        enc.push_additional(Some("east".to_string()), 5);
-        enc.push_additional(Some("south".to_string()), 2);
+        enc.push_additional(Some("east".to_owned()), 3);
+        enc.push_additional(Some("north".to_owned()), 1);
+        enc.push_additional(Some("east".to_owned()), 5);
+        enc.push_additional(Some("south".to_owned()), 2);
         enc.push_none();
         enc.push_none();
         enc.push_none();
@@ -909,9 +909,9 @@ mod test {
             enc.entries,
             vec![
                 None,
-                Some("east".to_string()),
-                Some("north".to_string()),
-                Some("south".to_string())
+                Some("east".to_owned()),
+                Some("north".to_owned()),
+                Some("south".to_owned())
             ]
         );
         assert_eq!(
@@ -923,10 +923,10 @@ mod test {
         let mut enc = Dictionary::default();
         enc.encoded_data.reserve_exact(40);
         enc.entries.reserve_exact(39); // account for already-allocated NULL element
-        enc.push_additional(Some("east".to_string()), 3);
-        enc.push_additional(Some("north".to_string()), 1);
-        enc.push_additional(Some("east".to_string()), 5);
-        enc.push_additional(Some("south".to_string()), 2);
+        enc.push_additional(Some("east".to_owned()), 3);
+        enc.push_additional(Some("north".to_owned()), 1);
+        enc.push_additional(Some("east".to_owned()), 5);
+        enc.push_additional(Some("south".to_owned()), 2);
         enc.push_additional(None, 4);
 
         // Self - 24+24+8 = 56 bytes (two vectors, a bool and padding)
@@ -941,10 +941,10 @@ mod test {
     #[test]
     fn null_count() {
         let mut enc = Dictionary::default();
-        enc.push_additional(Some("east".to_string()), 3);
+        enc.push_additional(Some("east".to_owned()), 3);
         assert_eq!(enc.null_count(), 0);
 
-        enc.push_additional(Some("west".to_string()), 1);
+        enc.push_additional(Some("west".to_owned()), 1);
         assert_eq!(enc.null_count(), 0);
 
         enc.push_none();
@@ -958,8 +958,8 @@ mod test {
     #[test]
     fn size_raw() {
         let mut enc = Dictionary::default();
-        enc.push_additional(Some("a longer string".to_string()), 3);
-        enc.push_additional(Some("south".to_string()), 2);
+        enc.push_additional(Some("a longer string".to_owned()), 3);
+        enc.push_additional(Some("south".to_owned()), 2);
         enc.push_none();
         enc.push_none();
         enc.push_none();
@@ -984,8 +984,8 @@ mod test {
     #[should_panic]
     fn push_wrong_order() {
         let mut enc = Dictionary::default();
-        enc.push("b".to_string());
-        enc.push("a".to_string());
+        enc.push("b".to_owned());
+        enc.push("a".to_owned());
     }
 
     #[test]
@@ -996,7 +996,7 @@ mod test {
 
         assert!(!enc.has_non_null_value(&[0, 1]));
 
-        enc.push("b".to_string());
+        enc.push("b".to_owned());
         assert!(enc.has_non_null_value(&[0, 1, 2]));
         assert!(enc.has_non_null_value(&[2]));
         assert!(!enc.has_non_null_value(&[0, 1]));
@@ -1010,7 +1010,7 @@ mod test {
 
         assert!(!enc.has_any_non_null_value());
 
-        enc.push("b".to_string());
+        enc.push("b".to_owned());
         assert!(enc.has_any_non_null_value());
     }
 }

--- a/read_buffer/src/column/encoding/string/rle.rs
+++ b/read_buffer/src/column/encoding/string/rle.rs
@@ -44,7 +44,7 @@ impl Default for RLE {
         assert_eq!(NULL_ID, 0);
 
         Self {
-            index_entries: vec!["".to_string()],
+            index_entries: vec!["".to_owned()],
             index_row_ids: vec![RowIDs::new_bitmap()], // index 0 for NULL value
             run_lengths: Vec::new(),
             contains_null: false,
@@ -910,7 +910,7 @@ impl<'a> From<Vec<&str>> for RLE {
     fn from(vec: Vec<&str>) -> Self {
         let mut drle = Self::default();
         for v in vec {
-            drle.push(v.to_string());
+            drle.push(v.to_owned());
         }
         drle
     }
@@ -931,7 +931,7 @@ impl<'a> From<Vec<Option<&str>>> for RLE {
         let mut drle = Self::default();
         for v in vec {
             match v {
-                Some(x) => drle.push(x.to_string()),
+                Some(x) => drle.push(x.to_owned()),
                 None => drle.push_none(),
             }
         }
@@ -959,7 +959,7 @@ impl<'a> From<StringArray> for RLE {
             if arr.is_null(i) {
                 drle.push_none();
             } else {
-                drle.push(arr.value(i).to_string());
+                drle.push(arr.value(i).to_owned());
             }
         }
         drle
@@ -990,8 +990,8 @@ mod test {
     #[test]
     fn with_dictionary() {
         let mut dictionary = BTreeSet::new();
-        dictionary.insert("hello".to_string());
-        dictionary.insert("world".to_string());
+        dictionary.insert("hello".to_owned());
+        dictionary.insert("world".to_owned());
 
         let drle = RLE::with_dictionary(dictionary);
         assert_eq!(drle.index_entries.as_slice(), &["", "hello", "world"]);
@@ -1001,10 +1001,10 @@ mod test {
     #[test]
     fn size() {
         let mut enc = RLE::default();
-        enc.push_additional(Some("east".to_string()), 3);
-        enc.push_additional(Some("north".to_string()), 1);
-        enc.push_additional(Some("east".to_string()), 5);
-        enc.push_additional(Some("south".to_string()), 2);
+        enc.push_additional(Some("east".to_owned()), 3);
+        enc.push_additional(Some("north".to_owned()), 1);
+        enc.push_additional(Some("east".to_owned()), 5);
+        enc.push_additional(Some("south".to_owned()), 2);
         enc.push_none();
         enc.push_none();
         enc.push_none();
@@ -1022,10 +1022,10 @@ mod test {
         enc.index_entries.reserve_exact(39); // account for already-allocated NULL element
         enc.run_lengths.reserve_exact(40);
 
-        enc.push_additional(Some("east".to_string()), 3);
-        enc.push_additional(Some("north".to_string()), 1);
-        enc.push_additional(Some("east".to_string()), 5);
-        enc.push_additional(Some("south".to_string()), 2);
+        enc.push_additional(Some("east".to_owned()), 3);
+        enc.push_additional(Some("north".to_owned()), 1);
+        enc.push_additional(Some("east".to_owned()), 5);
+        enc.push_additional(Some("south".to_owned()), 2);
         enc.push_none();
         enc.push_none();
         enc.push_none();
@@ -1042,10 +1042,10 @@ mod test {
     #[test]
     fn null_count() {
         let mut enc = RLE::default();
-        enc.push_additional(Some("east".to_string()), 3);
+        enc.push_additional(Some("east".to_owned()), 3);
         assert_eq!(enc.null_count(), 0);
 
-        enc.push_additional(Some("west".to_string()), 1);
+        enc.push_additional(Some("west".to_owned()), 1);
         assert_eq!(enc.null_count(), 0);
 
         enc.push_none();
@@ -1059,8 +1059,8 @@ mod test {
     #[test]
     fn size_raw() {
         let mut enc = RLE::default();
-        enc.push_additional(Some("a longer string".to_string()), 3);
-        enc.push_additional(Some("south".to_string()), 2);
+        enc.push_additional(Some("a longer string".to_owned()), 3);
+        enc.push_additional(Some("south".to_owned()), 2);
         enc.push_none();
         enc.push_none();
         enc.push_none();
@@ -1085,7 +1085,7 @@ mod test {
     #[should_panic]
     fn push_wrong_order() {
         let mut enc = RLE::default();
-        enc.push("b".to_string());
-        enc.push("a".to_string());
+        enc.push("b".to_owned());
+        enc.push("a".to_owned());
     }
 }

--- a/read_buffer/src/column/float.rs
+++ b/read_buffer/src/column/float.rs
@@ -271,7 +271,7 @@ impl From<&[f64]> for FloatEncoding {
                 NoOpTranscoder {}, // No transcoding of values (store as physical type f64)
             ));
             let name = enc.name();
-            return Self::F64(enc, name.to_string());
+            return Self::F64(enc, name.to_owned());
         }
 
         // Don't apply a compression encoding to the column

--- a/read_buffer/src/column/string.rs
+++ b/read_buffer/src/column/string.rs
@@ -445,7 +445,7 @@ impl From<arrow::array::StringArray> for StringEncoding {
             }
 
             match prev {
-                Some(x) => data.push_additional(Some(x.to_string()), count),
+                Some(x) => data.push_additional(Some(x.to_owned()), count),
                 None => data.push_additional(None, count),
             }
             prev = next;
@@ -454,7 +454,7 @@ impl From<arrow::array::StringArray> for StringEncoding {
 
         // Add final batch to column if any
         match prev {
-            Some(x) => data.push_additional(Some(x.to_string()), count),
+            Some(x) => data.push_additional(Some(x.to_owned()), count),
             None => data.push_additional(None, count),
         };
 
@@ -510,7 +510,7 @@ impl From<arrow::array::DictionaryArray<arrow::datatypes::Int32Type>> for String
             }
 
             match prev {
-                Some(x) => data.push_additional(Some(values.value(x as usize).to_string()), count),
+                Some(x) => data.push_additional(Some(values.value(x as usize).to_owned()), count),
                 None => data.push_additional(None, count),
             }
             prev = next;
@@ -519,7 +519,7 @@ impl From<arrow::array::DictionaryArray<arrow::datatypes::Int32Type>> for String
 
         // Add final batch to column if any
         match prev {
-            Some(x) => data.push_additional(Some(values.value(x as usize).to_string()), count),
+            Some(x) => data.push_additional(Some(values.value(x as usize).to_owned()), count),
             None => data.push_additional(None, count),
         };
 

--- a/read_buffer/src/lib.rs
+++ b/read_buffer/src/lib.rs
@@ -1,5 +1,10 @@
 #![deny(rustdoc::broken_intra_doc_links, rustdoc::bare_urls, rust_2018_idioms)]
-#![warn(clippy::clone_on_ref_ptr, clippy::use_self)]
+#![warn(
+    clippy::clone_on_ref_ptr,
+    clippy::use_self,
+    clippy::str_to_string,
+    clippy::string_to_string
+)]
 #![allow(dead_code, clippy::too_many_arguments)]
 mod chunk;
 mod column;

--- a/read_buffer/src/row_group.rs
+++ b/read_buffer/src/row_group.rs
@@ -2552,9 +2552,9 @@ mod test {
     fn size() {
         let mut columns = vec![];
         let rc = ColumnType::Tag(Column::from(&[Some("west"), Some("west"), None, None][..]));
-        columns.push(("region".to_string(), rc));
+        columns.push(("region".to_owned(), rc));
         let tc = ColumnType::Time(Column::from(&[100_i64, 200, 500, 600][..]));
-        columns.push(("time".to_string(), tc));
+        columns.push(("time".to_owned(), tc));
 
         let row_group = RowGroup::new(4, columns);
 
@@ -2566,9 +2566,9 @@ mod test {
         let track = ColumnType::Tag(Column::from(
             &[Some("Thinking"), Some("of"), Some("a"), Some("place")][..],
         ));
-        columns.push(("track".to_string(), track));
+        columns.push(("track".to_owned(), track));
         let tc = ColumnType::Time(Column::from(&[100_i64, 200, 500, 600][..]));
-        columns.push(("time".to_string(), tc));
+        columns.push(("time".to_owned(), tc));
 
         let row_group = RowGroup::new(4, columns);
 
@@ -2579,11 +2579,11 @@ mod test {
     fn row_ids_from_predicates() {
         let mut columns = vec![];
         let tc = ColumnType::Time(Column::from(&[100_i64, 200, 500, 600, 300, 300][..]));
-        columns.push(("time".to_string(), tc));
+        columns.push(("time".to_owned(), tc));
         let rc = ColumnType::Tag(Column::from(
             &["west", "west", "east", "west", "south", "north"][..],
         ));
-        columns.push(("region".to_string(), rc));
+        columns.push(("region".to_owned(), rc));
         let row_group = RowGroup::new(6, columns);
 
         // Closed partially covering "time range" predicate
@@ -2662,11 +2662,11 @@ mod test {
     fn row_ids_from_delete_predicates() {
         let mut columns = vec![];
         let tc = ColumnType::Time(Column::from(&[100_i64, 200, 500, 600, 300, 300][..]));
-        columns.push(("time".to_string(), tc));
+        columns.push(("time".to_owned(), tc));
         let rc = ColumnType::Tag(Column::from(
             &["west", "west", "east", "west", "south", "north"][..],
         ));
-        columns.push(("region".to_string(), rc));
+        columns.push(("region".to_owned(), rc));
         let row_group = RowGroup::new(6, columns);
 
         // No predicates means nothing to delete
@@ -2759,7 +2759,7 @@ mod test {
     fn _read_filter_setup() -> RowGroup {
         let mut columns = vec![];
         let tc = ColumnType::Time(Column::from(&[1_i64, 2, 3, 4, 5, 6, 8][..]));
-        columns.push(("time".to_string(), tc));
+        columns.push(("time".to_owned(), tc));
 
         let rc = ColumnType::Tag(Column::from(
             &[
@@ -2772,15 +2772,15 @@ mod test {
                 None,
             ][..],
         ));
-        columns.push(("region".to_string(), rc));
+        columns.push(("region".to_owned(), rc));
 
         let mc = ColumnType::Tag(Column::from(
             &["GET", "POST", "POST", "POST", "PUT", "GET", "PATCH"][..],
         ));
-        columns.push(("method".to_string(), mc));
+        columns.push(("method".to_owned(), mc));
 
         let fc = ColumnType::Field(Column::from(&[100_u64, 101, 200, 203, 203, 10, 29][..]));
-        columns.push(("count".to_string(), fc));
+        columns.push(("count".to_owned(), fc));
 
         RowGroup::new(7, columns)
     }
@@ -2918,25 +2918,25 @@ POST,west,2
     fn read_filter_bug_1860() {
         let mut columns = vec![];
         let tc = ColumnType::Time(Column::from(&[200_i64, 300, 400, 500, 600][..]));
-        columns.push(("time".to_string(), tc));
+        columns.push(("time".to_owned(), tc));
 
         let city = ColumnType::Tag(Column::from(
             &[Some("Boston"), None, None, Some("NYC"), Some("NYC")][..],
         ));
-        columns.push(("city".to_string(), city));
+        columns.push(("city".to_owned(), city));
 
         let state = ColumnType::Tag(Column::from(
             &[Some("MA"), Some("CA"), Some("NY"), Some("NY"), Some("NY")][..],
         ));
-        columns.push(("state".to_string(), state));
+        columns.push(("state".to_owned(), state));
 
         let borough = ColumnType::Tag(Column::from(
             &[None, None, None, None, Some("Brooklyn")][..],
         ));
-        columns.push(("borough".to_string(), borough));
+        columns.push(("borough".to_owned(), borough));
 
         let temp = ColumnType::Field(Column::from(&[50.4, 79.0, 60.8, 61.0, 61.0][..]));
-        columns.push(("temp".to_string(), temp));
+        columns.push(("temp".to_owned(), temp));
 
         let row_group = RowGroup::new(5, columns);
 
@@ -3019,17 +3019,17 @@ POST,west,2
     fn read_aggregate() {
         let mut columns = vec![];
         let tc = ColumnType::Time(Column::from(&[1_i64, 2, 3, 4, 5, 6][..]));
-        columns.push(("time".to_string(), tc));
+        columns.push(("time".to_owned(), tc));
 
         let rc = ColumnType::Tag(Column::from(
             &["west", "west", "east", "west", "south", "north"][..],
         ));
-        columns.push(("region".to_string(), rc));
+        columns.push(("region".to_owned(), rc));
 
         let mc = ColumnType::Tag(Column::from(
             &["GET", "POST", "POST", "POST", "PUT", "GET"][..],
         ));
-        columns.push(("method".to_string(), mc));
+        columns.push(("method".to_owned(), mc));
 
         let ec = ColumnType::Tag(Column::from(
             &[
@@ -3041,20 +3041,20 @@ POST,west,2
                 None,
             ][..],
         ));
-        columns.push(("env".to_string(), ec));
+        columns.push(("env".to_owned(), ec));
 
         let c = ColumnType::Tag(Column::from(
             &["Alpha", "Alpha", "Bravo", "Bravo", "Alpha", "Alpha"][..],
         ));
-        columns.push(("letters".to_string(), c));
+        columns.push(("letters".to_owned(), c));
 
         let c = ColumnType::Tag(Column::from(
             &["one", "two", "two", "two", "one", "three"][..],
         ));
-        columns.push(("numbers".to_string(), c));
+        columns.push(("numbers".to_owned(), c));
 
         let fc = ColumnType::Field(Column::from(&[100_u64, 101, 200, 203, 203, 10][..]));
-        columns.push(("counter".to_string(), fc));
+        columns.push(("counter".to_owned(), fc));
 
         let row_group = RowGroup::new(6, columns);
 
@@ -3251,17 +3251,17 @@ west,POST,304,101,203
     fn row_aggregate_could_satisfy_predicate() {
         let mut columns = vec![];
         let tc = ColumnType::Time(Column::from(&[1_i64, 2, 3, 4, 5, 6][..]));
-        columns.push(("time".to_string(), tc));
+        columns.push(("time".to_owned(), tc));
 
         let rc = ColumnType::Tag(Column::from(
             &["west", "west", "east", "west", "south", "north"][..],
         ));
-        columns.push(("region".to_string(), rc));
+        columns.push(("region".to_owned(), rc));
 
         let mc = ColumnType::Tag(Column::from(
             &["GET", "GET", "GET", "GET", "GET", "GET"][..],
         ));
-        columns.push(("method".to_string(), mc));
+        columns.push(("method".to_owned(), mc));
 
         let row_group = RowGroup::new(6, columns);
 
@@ -3307,17 +3307,17 @@ west,POST,304,101,203
     fn row_aggregate_satisfies_predicate() {
         let mut columns = vec![];
         let tc = ColumnType::Time(Column::from(&[1_i64, 2, 3, 4, 5, 6][..]));
-        columns.push(("time".to_string(), tc));
+        columns.push(("time".to_owned(), tc));
 
         let rc = ColumnType::Tag(Column::from(
             &["west", "west", "east", "west", "south", "north"][..],
         ));
-        columns.push(("region".to_string(), rc));
+        columns.push(("region".to_owned(), rc));
 
         let mc = ColumnType::Tag(Column::from(
             &["GET", "GET", "GET", "GET", "GET", "GET"][..],
         ));
-        columns.push(("method".to_string(), mc));
+        columns.push(("method".to_owned(), mc));
 
         let row_group = RowGroup::new(6, columns);
 
@@ -3723,18 +3723,18 @@ west,host-c,pro,10,6
     fn column_names_setup() -> RowGroup {
         let mut columns = vec![];
         let rc = ColumnType::Tag(Column::from(&[Some("west"), Some("west"), None, None][..]));
-        columns.push(("region".to_string(), rc));
+        columns.push(("region".to_owned(), rc));
         let track = ColumnType::Tag(Column::from(
             &[Some("Thinking"), Some("of"), Some("a"), Some("place")][..],
         ));
-        columns.push(("track".to_string(), track));
+        columns.push(("track".to_owned(), track));
         let temp = ColumnType::Field(Column::from(
             &[Some("hot"), Some("cold"), Some("cold"), Some("warm")][..],
         ));
-        columns.push(("temp".to_string(), temp));
+        columns.push(("temp".to_owned(), temp));
 
         let tc = ColumnType::Time(Column::from(&[100_i64, 200, 500, 600][..]));
-        columns.push(("time".to_string(), tc));
+        columns.push(("time".to_owned(), tc));
         RowGroup::new(4, columns)
     }
 
@@ -3789,12 +3789,12 @@ west,host-c,pro,10,6
         // part of the result-set from the row group.
         let mut columns = vec![];
         let rc = ColumnType::Tag(Column::from(&[Some("prod")][..]));
-        columns.push(("env".to_string(), rc));
+        columns.push(("env".to_owned(), rc));
         let tc = ColumnType::Time(Column::from(&[100_i64][..]));
         let temp = ColumnType::Field(Column::from(&[Some("hot")][..]));
-        columns.push(("temp".to_string(), temp));
+        columns.push(("temp".to_owned(), temp));
 
-        columns.push(("time".to_string(), tc));
+        columns.push(("time".to_owned(), tc));
         let row_group = RowGroup::new(1, columns);
 
         row_group.column_names(&Predicate::default(), &[], Selection::All, &mut dst);
@@ -3960,13 +3960,13 @@ west,host-c,pro,10,6
     }
 
     fn to_map(arr: Vec<(&str, &[&str])>) -> BTreeMap<String, BTreeSet<String>> {
-        arr.iter()
+        arr.into_iter()
             .map(|(k, values)| {
                 (
-                    k.to_string(),
+                    k.to_owned(),
                     values
                         .iter()
-                        .map(|s| s.to_string())
+                        .map(|&s| s.to_owned())
                         .collect::<BTreeSet<_>>(),
                 )
             })
@@ -3978,13 +3978,13 @@ west,host-c,pro,10,6
         // Build a row group.
         let mut columns = vec![];
         let tc = ColumnType::Time(Column::from(&[1_i64, 2, 3][..]));
-        columns.push(("time".to_string(), tc));
+        columns.push(("time".to_owned(), tc));
 
         let rc = ColumnType::Tag(Column::from(&["west", "south", "north"][..]));
-        columns.push(("region".to_string(), rc));
+        columns.push(("region".to_owned(), rc));
 
         let ec = ColumnType::Tag(Column::from(&["prod", "stag", "stag"][..]));
-        columns.push(("env".to_string(), ec));
+        columns.push(("env".to_owned(), ec));
 
         let rg = RowGroup::new(3, columns);
 

--- a/read_buffer/src/table.rs
+++ b/read_buffer/src/table.rs
@@ -370,7 +370,7 @@ impl Table {
                 matches!(ct, ColumnType::Tag(_)),
                 UnsupportedColumnOperationSnafu {
                     msg: format!("column type must be ColumnType::Tag, got {:?}", ct),
-                    column_name: ct.as_str().to_string(),
+                    column_name: ct.as_str().to_owned(),
                 },
             )
         }
@@ -1121,12 +1121,9 @@ mod test {
     #[test]
     fn meta_data_update_with() {
         let columns = vec![
+            ("time".to_owned(), ColumnType::create_time(&[100, 200, 300])),
             (
-                "time".to_string(),
-                ColumnType::create_time(&[100, 200, 300]),
-            ),
-            (
-                "region".to_string(),
+                "region".to_owned(),
                 ColumnType::create_tag(&["west", "west", "north"]),
             ),
         ];
@@ -1145,9 +1142,9 @@ mod test {
         );
 
         let columns = vec![
-            ("time".to_string(), ColumnType::create_time(&[10, 400])),
+            ("time".to_owned(), ColumnType::create_time(&[10, 400])),
             (
-                "region".to_string(),
+                "region".to_owned(),
                 ColumnType::create_tag(&["east", "south"]),
             ),
         ];
@@ -1175,12 +1172,12 @@ mod test {
         let col_e = ColumnType::Field(Column::from(BooleanArray::from(vec![true])));
 
         let columns = vec![
-            ("time".to_string(), time),
-            ("i64_col".to_string(), col_a),
-            ("u64_col".to_string(), col_b),
-            ("f64_col".to_string(), col_c),
-            ("str_col".to_string(), col_d),
-            ("bool_col".to_string(), col_e),
+            ("time".to_owned(), time),
+            ("i64_col".to_owned(), col_a),
+            ("u64_col".to_owned(), col_b),
+            ("f64_col".to_owned(), col_c),
+            ("str_col".to_owned(), col_d),
+            ("bool_col".to_owned(), col_e),
         ];
         let row_group = RowGroup::new(1, columns);
 
@@ -1233,12 +1230,9 @@ mod test {
     #[test]
     fn meta_data_update_with_null() {
         let columns = vec![
+            ("time".to_owned(), ColumnType::create_time(&[100, 200, 300])),
             (
-                "time".to_string(),
-                ColumnType::create_time(&[100, 200, 300]),
-            ),
-            (
-                "region".to_string(),
+                "region".to_owned(),
                 ColumnType::create_tag_opt(&[None, None, None]),
             ),
         ];
@@ -1249,9 +1243,9 @@ mod test {
 
         // add a second column
         let columns = vec![
-            ("time".to_string(), ColumnType::create_time(&[10, 400])),
+            ("time".to_owned(), ColumnType::create_time(&[10, 400])),
             (
-                "region".to_string(),
+                "region".to_owned(),
                 ColumnType::create_tag(&["east", "south"]),
             ),
         ];
@@ -1271,7 +1265,7 @@ mod test {
     #[test]
     fn add_remove_row_groups() {
         let tc = ColumnType::Time(Column::from(&[0_i64, 2, 3][..]));
-        let columns = vec![("time".to_string(), tc)];
+        let columns = vec![("time".to_owned(), tc)];
 
         let rg = RowGroup::new(3, columns);
         let mut table = Table::with_row_group("cpu", rg);
@@ -1280,7 +1274,7 @@ mod test {
 
         // add another row group
         let tc = ColumnType::Time(Column::from(&[1_i64, 2, 3, 4, 5][..]));
-        let columns = vec![("time".to_string(), tc)];
+        let columns = vec![("time".to_owned(), tc)];
         let rg = RowGroup::new(5, columns);
         table.add_row_group(rg);
 
@@ -1314,14 +1308,14 @@ mod test {
     fn column_sizes() {
         let tc = ColumnType::Time(Column::from(&[10_i64, 20, 30][..]));
         let fc = ColumnType::Field(Column::from(&[1000_u64, 1002, 1200][..]));
-        let columns = vec![("time".to_string(), tc), ("count".to_string(), fc)];
+        let columns = vec![("time".to_owned(), tc), ("count".to_owned(), fc)];
         let row_group = RowGroup::new(3, columns);
         let mut table = Table::with_row_group("cpu", row_group);
 
         // add another row group
         let tc = ColumnType::Time(Column::from(&[1_i64, 2, 3, 4, 5, 6][..]));
         let fc = ColumnType::Field(Column::from(&[100_u64, 101, 200, 203, 203, 10][..]));
-        let columns = vec![("time".to_string(), tc), ("count".to_string(), fc)];
+        let columns = vec![("time".to_owned(), tc), ("count".to_owned(), fc)];
         let rg = RowGroup::new(6, columns);
         table.add_row_group(rg);
 
@@ -1345,9 +1339,9 @@ mod test {
         let rc = ColumnType::Tag(Column::from(&["south", "north", "east"][..]));
         let fc = ColumnType::Field(Column::from(&[1000_u64, 1002, 1200][..]));
         let columns = vec![
-            ("time".to_string(), tc),
-            ("region".to_string(), rc),
-            ("count".to_string(), fc),
+            ("time".to_owned(), tc),
+            ("region".to_owned(), rc),
+            ("count".to_owned(), fc),
         ];
         let row_group = RowGroup::new(3, columns);
         let mut table = Table::with_row_group("cpu", row_group);
@@ -1359,9 +1353,9 @@ mod test {
         ));
         let fc = ColumnType::Field(Column::from(&[100_u64, 101, 200, 203, 203, 10][..]));
         let columns = vec![
-            ("time".to_string(), tc),
-            ("region".to_string(), rc),
-            ("count".to_string(), fc),
+            ("time".to_owned(), tc),
+            ("region".to_owned(), rc),
+            ("count".to_owned(), fc),
         ];
         let rg = RowGroup::new(6, columns);
         table.add_row_group(rg);
@@ -1427,9 +1421,9 @@ mod test {
         ));
         let fc = ColumnType::Field(Column::from(&[100_u64, 101, 200, 203, 203, 10][..]));
         let columns = vec![
-            ("time".to_string(), tc),
-            ("region".to_string(), rc),
-            ("count".to_string(), fc),
+            ("time".to_owned(), tc),
+            ("region".to_owned(), rc),
+            ("count".to_owned(), fc),
         ];
 
         let rg = RowGroup::new(6, columns);
@@ -1457,9 +1451,9 @@ mod test {
         let rc = ColumnType::Tag(Column::from(&["south", "north", "east"][..]));
         let fc = ColumnType::Field(Column::from(&[1000_u64, 1002, 1200][..]));
         let columns = vec![
-            ("time".to_string(), tc),
-            ("region".to_string(), rc),
-            ("count".to_string(), fc),
+            ("time".to_owned(), tc),
+            ("region".to_owned(), rc),
+            ("count".to_owned(), fc),
         ];
         let row_group = RowGroup::new(3, columns);
         table.add_row_group(row_group);
@@ -1558,12 +1552,9 @@ mod test {
     fn read_aggregate_no_groups() {
         // Build first row group.
         let columns = vec![
+            ("time".to_owned(), ColumnType::create_time(&[100, 200, 300])),
             (
-                "time".to_string(),
-                ColumnType::create_time(&[100, 200, 300]),
-            ),
-            (
-                "region".to_string(),
+                "region".to_owned(),
                 ColumnType::create_tag(&["west", "west", "east"]),
             ),
         ];
@@ -1572,9 +1563,9 @@ mod test {
 
         // Build another row group.
         let columns = vec![
-            ("time".to_string(), ColumnType::create_time(&[2, 3])),
+            ("time".to_owned(), ColumnType::create_time(&[2, 3])),
             (
-                "region".to_string(),
+                "region".to_owned(),
                 ColumnType::create_tag(&["north", "north"]),
             ),
         ];
@@ -1707,7 +1698,7 @@ west,host-b,100
         // Build a row group.
         let tc = ColumnType::Time(Column::from(&[1_i64, 2, 3][..]));
         let rc = ColumnType::Tag(Column::from(&["west", "south", "north"][..]));
-        let columns = vec![("time".to_string(), tc), ("region".to_string(), rc)];
+        let columns = vec![("time".to_owned(), tc), ("region".to_owned(), rc)];
 
         let rg = RowGroup::new(3, columns);
         let mut table = Table::with_row_group("cpu", rg);
@@ -1715,7 +1706,7 @@ west,host-b,100
         // add another row group
         let tc = ColumnType::Time(Column::from(&[200_i64, 300, 400][..]));
         let rc = ColumnType::Tag(Column::from(vec![Some("north"), None, None].as_slice()));
-        let columns = vec![("time".to_string(), tc), ("region".to_string(), rc)];
+        let columns = vec![("time".to_owned(), tc), ("region".to_owned(), rc)];
 
         let rg = RowGroup::new(3, columns);
         table.add_row_group(rg);
@@ -1797,8 +1788,8 @@ west,host-b,100
         let tc = ColumnType::Time(Column::from(&[-29_i64, -100, 3, 2][..]));
         let rc = ColumnType::Tag(Column::from(&["west", "south", "north", "west"][..]));
         let columns = vec![
-            (row_group::TIME_COLUMN_NAME.to_string(), tc),
-            ("region".to_string(), rc),
+            (row_group::TIME_COLUMN_NAME.to_owned(), tc),
+            ("region".to_owned(), rc),
         ];
 
         let rg = RowGroup::new(4, columns);

--- a/read_buffer/src/value.rs
+++ b/read_buffer/src/value.rs
@@ -1912,9 +1912,9 @@ mod test {
 
         // bytes
         let arr = vec![
-            "Pop Song 89".to_string(),
-            "Orange Crush".to_string(),
-            "Stand".to_string(),
+            "Pop Song 89".to_owned(),
+            "Orange Crush".to_owned(),
+            "Stand".to_owned(),
         ];
         let values = Values::ByteArray(vec![
             Some(arr[0].as_bytes()),
@@ -1990,7 +1990,7 @@ mod test {
         let eleven = OwnedValue::Scalar(Scalar::I64(11));
         let twenty_two = OwnedValue::Scalar(Scalar::I64(22));
         let thirty_three = OwnedValue::Scalar(Scalar::I64(33));
-        let string = OwnedValue::String("foo".to_string());
+        let string = OwnedValue::String("foo".to_owned());
 
         let mut v1 = OwnedValue::new_null();
 
@@ -2020,7 +2020,7 @@ mod test {
         let eleven = OwnedValue::Scalar(Scalar::I64(11));
         let twenty_two = OwnedValue::Scalar(Scalar::I64(22));
         let thirty_three = OwnedValue::Scalar(Scalar::I64(33));
-        let string = OwnedValue::String("foo".to_string());
+        let string = OwnedValue::String("foo".to_owned());
 
         let mut v1 = OwnedValue::new_null();
 


### PR DESCRIPTION
Following on a little bit from the discussion in https://github.com/influxdata/influxdb_iox/issues/553 I added the following lints to the `read_buffer` crate as a little experiment:

* [str_to_string](https://rust-lang.github.io/rust-clippy/master/#str_to_string)
* [string_string](https://rust-lang.github.io/rust-clippy/master/)

These lints encourage the use of `to_owned` rather than `to_string` for `&str` and `String` types. And I'm all about the consistency...

Unfortunately `clippy --fix` did not pick these up as being automatically fixable, which would make handling the whole code-base a bit arduous. I also tried the imaginatively called ` __CARGO_FIX_YOLO=1  cargo clippy --fix` incantation but that didn't help either.

I'm tempted to just try a massive rename on the code base and deal with incorrect `to_owned` calls manually, but I'm not sure if it will pan out.