### PR TITLE
feat: reduce partition fanout

### DIFF
--- a/influxdb_iox/src/influxdb_ioxd/server_type/database/mod.rs
+++ b/influxdb_iox/src/influxdb_ioxd/server_type/database/mod.rs
@@ -536,10 +536,9 @@ mod tests {
         child(prepare_sql_span, "prepare_plan").unwrap();
 
         let execute_span = child(ctx_span, "execute_stream_partitioned").unwrap();
-        let coalesce_span = child(execute_span, "CoalescePartitionsEx").unwrap();
 
         // validate spans from DataFusion ExecutionPlan are present
-        child(coalesce_span, "ProjectionExec: expr").unwrap();
+        child(execute_span, "ProjectionExec: expr").unwrap();
 
         let database_not_found = root_spans[3];
         assert_eq!(database_not_found.status, SpanStatus::Err);

--- a/query/src/exec/context.rs
+++ b/query/src/exec/context.rs
@@ -14,6 +14,7 @@ use datafusion::{
     physical_optimizer::{
         aggregate_statistics::AggregateStatistics, coalesce_batches::CoalesceBatches,
         hash_build_probe_order::HashBuildProbeOrder, merge_exec::AddCoalescePartitionsExec,
+        optimizer::PhysicalOptimizerRule,
     },
     physical_plan::{
         coalesce_partitions::CoalescePartitionsExec,
@@ -168,7 +169,7 @@ const BATCH_SIZE: usize = 1000;
 
 impl IOxExecutionConfig {
     pub(super) fn new(exec: DedicatedExecutor) -> Self {
-        let physical_optimizers = vec![
+        let physical_optimizers: Vec<Arc<dyn PhysicalOptimizerRule + Send + Sync>> = vec![
             Arc::new(AggregateStatistics::new()),
             Arc::new(HashBuildProbeOrder::new()),
             Arc::new(CoalesceBatches::new()),

--- a/query/src/exec/task.rs
+++ b/query/src/exec/task.rs
@@ -71,6 +71,8 @@ impl<T> PinnedDrop for Job<T> {
 /// them) on a separate tokio Executor
 #[derive(Clone)]
 pub struct DedicatedExecutor {
+    num_threads: usize,
+
     state: Arc<Mutex<State>>,
 }
 
@@ -157,6 +159,7 @@ impl DedicatedExecutor {
         };
 
         Self {
+            num_threads,
             state: Arc::new(Mutex::new(state)),
         }
     }
@@ -211,6 +214,11 @@ impl DedicatedExecutor {
         // to quit
         let mut state = self.state.lock();
         state.requests = None;
+    }
+
+    /// Returns the size of the backing thread pool
+    pub fn num_threads(&self) -> usize {
+        self.num_threads
     }
 
     /// Stops all subsequent task executions, and waits for the worker

--- a/query_tests/cases/in/duplicates.expected
+++ b/query_tests/cases/in/duplicates.expected
@@ -10,18 +10,13 @@
 |               |   CoalescePartitionsExec                                                                                                                    |
 |               |     ProjectionExec: expr=[time@5 as time, state@4 as state, city@1 as city, min_temp@3 as min_temp, max_temp@2 as max_temp, area@0 as area] |
 |               |       UnionExec                                                                                                                             |
-|               |         RepartitionExec: partitioning=RoundRobinBatch(4)                                                                                    |
-|               |           DeduplicateExec: [state@4 ASC,city@1 ASC,time@5 ASC]                                                                              |
-|               |             SortPreservingMergeExec: [state@4 ASC,city@1 ASC,time@5 ASC]                                                                    |
-|               |               UnionExec                                                                                                                     |
-|               |                 RepartitionExec: partitioning=RoundRobinBatch(4)                                                                            |
-|               |                   IOxReadFilterNode: table_name=h2o, chunks=1 predicate=Predicate                                                           |
-|               |                 RepartitionExec: partitioning=RoundRobinBatch(4)                                                                            |
-|               |                   IOxReadFilterNode: table_name=h2o, chunks=1 predicate=Predicate                                                           |
-|               |         RepartitionExec: partitioning=RoundRobinBatch(4)                                                                                    |
-|               |           IOxReadFilterNode: table_name=h2o, chunks=1 predicate=Predicate                                                                   |
-|               |         RepartitionExec: partitioning=RoundRobinBatch(4)                                                                                    |
-|               |           IOxReadFilterNode: table_name=h2o, chunks=1 predicate=Predicate                                                                   |
+|               |         DeduplicateExec: [state@4 ASC,city@1 ASC,time@5 ASC]                                                                                |
+|               |           SortPreservingMergeExec: [state@4 ASC,city@1 ASC,time@5 ASC]                                                                      |
+|               |             UnionExec                                                                                                                       |
+|               |               IOxReadFilterNode: table_name=h2o, chunks=1 predicate=Predicate                                                               |
+|               |               IOxReadFilterNode: table_name=h2o, chunks=1 predicate=Predicate                                                               |
+|               |         IOxReadFilterNode: table_name=h2o, chunks=1 predicate=Predicate                                                                     |
+|               |         IOxReadFilterNode: table_name=h2o, chunks=1 predicate=Predicate                                                                     |
 |               |                                                                                                                                             |
 +---------------+---------------------------------------------------------------------------------------------------------------------------------------------+
 -- SQL: EXPLAIN select time, state, city, min_temp, max_temp, area from h2o;
@@ -32,59 +27,44 @@
 |               |   TableScan: h2o projection=Some([0, 1, 2, 3, 4, 5])                                                                                    |
 | physical_plan | ProjectionExec: expr=[time@5 as time, state@4 as state, city@1 as city, min_temp@3 as min_temp, max_temp@2 as max_temp, area@0 as area] |
 |               |   UnionExec                                                                                                                             |
-|               |     RepartitionExec: partitioning=RoundRobinBatch(4)                                                                                    |
-|               |       DeduplicateExec: [state@4 ASC,city@1 ASC,time@5 ASC]                                                                              |
-|               |         SortPreservingMergeExec: [state@4 ASC,city@1 ASC,time@5 ASC]                                                                    |
-|               |           UnionExec                                                                                                                     |
-|               |             RepartitionExec: partitioning=RoundRobinBatch(4)                                                                            |
-|               |               IOxReadFilterNode: table_name=h2o, chunks=1 predicate=Predicate                                                           |
-|               |             RepartitionExec: partitioning=RoundRobinBatch(4)                                                                            |
-|               |               IOxReadFilterNode: table_name=h2o, chunks=1 predicate=Predicate                                                           |
-|               |     RepartitionExec: partitioning=RoundRobinBatch(4)                                                                                    |
-|               |       IOxReadFilterNode: table_name=h2o, chunks=1 predicate=Predicate                                                                   |
-|               |     RepartitionExec: partitioning=RoundRobinBatch(4)                                                                                    |
-|               |       IOxReadFilterNode: table_name=h2o, chunks=1 predicate=Predicate                                                                   |
+|               |     DeduplicateExec: [state@4 ASC,city@1 ASC,time@5 ASC]                                                                                |
+|               |       SortPreservingMergeExec: [state@4 ASC,city@1 ASC,time@5 ASC]                                                                      |
+|               |         UnionExec                                                                                                                       |
+|               |           IOxReadFilterNode: table_name=h2o, chunks=1 predicate=Predicate                                                               |
+|               |           IOxReadFilterNode: table_name=h2o, chunks=1 predicate=Predicate                                                               |
+|               |     IOxReadFilterNode: table_name=h2o, chunks=1 predicate=Predicate                                                                     |
+|               |     IOxReadFilterNode: table_name=h2o, chunks=1 predicate=Predicate                                                                     |
 |               |                                                                                                                                         |
 +---------------+-----------------------------------------------------------------------------------------------------------------------------------------+
 -- SQL: EXPLAIN select state as name from h2o UNION ALL select city as name from h2o;
-+---------------+-----------------------------------------------------------------------------------+
-| plan_type     | plan                                                                              |
-+---------------+-----------------------------------------------------------------------------------+
-| logical_plan  | Union                                                                             |
-|               |   Projection: #h2o.state AS name                                                  |
-|               |     TableScan: h2o projection=Some([4])                                           |
-|               |   Projection: #h2o.city AS name                                                   |
-|               |     TableScan: h2o projection=Some([1])                                           |
-| physical_plan | UnionExec                                                                         |
-|               |   ProjectionExec: expr=[state@0 as name]                                          |
-|               |     UnionExec                                                                     |
-|               |       ProjectionExec: expr=[state@1 as state]                                     |
-|               |         RepartitionExec: partitioning=RoundRobinBatch(4)                          |
-|               |           DeduplicateExec: [state@1 ASC,city@0 ASC,time@2 ASC]                    |
-|               |             SortPreservingMergeExec: [state@1 ASC,city@0 ASC,time@2 ASC]          |
-|               |               UnionExec                                                           |
-|               |                 RepartitionExec: partitioning=RoundRobinBatch(4)                  |
-|               |                   IOxReadFilterNode: table_name=h2o, chunks=1 predicate=Predicate |
-|               |                 RepartitionExec: partitioning=RoundRobinBatch(4)                  |
-|               |                   IOxReadFilterNode: table_name=h2o, chunks=1 predicate=Predicate |
-|               |       RepartitionExec: partitioning=RoundRobinBatch(4)                            |
-|               |         IOxReadFilterNode: table_name=h2o, chunks=1 predicate=Predicate           |
-|               |       RepartitionExec: partitioning=RoundRobinBatch(4)                            |
-|               |         IOxReadFilterNode: table_name=h2o, chunks=1 predicate=Predicate           |
-|               |   ProjectionExec: expr=[city@0 as name]                                           |
-|               |     UnionExec                                                                     |
-|               |       ProjectionExec: expr=[city@0 as city]                                       |
-|               |         RepartitionExec: partitioning=RoundRobinBatch(4)                          |
-|               |           DeduplicateExec: [state@1 ASC,city@0 ASC,time@2 ASC]                    |
-|               |             SortPreservingMergeExec: [state@1 ASC,city@0 ASC,time@2 ASC]          |
-|               |               UnionExec                                                           |
-|               |                 RepartitionExec: partitioning=RoundRobinBatch(4)                  |
-|               |                   IOxReadFilterNode: table_name=h2o, chunks=1 predicate=Predicate |
-|               |                 RepartitionExec: partitioning=RoundRobinBatch(4)                  |
-|               |                   IOxReadFilterNode: table_name=h2o, chunks=1 predicate=Predicate |
-|               |       RepartitionExec: partitioning=RoundRobinBatch(4)                            |
-|               |         IOxReadFilterNode: table_name=h2o, chunks=1 predicate=Predicate           |
-|               |       RepartitionExec: partitioning=RoundRobinBatch(4)                            |
-|               |         IOxReadFilterNode: table_name=h2o, chunks=1 predicate=Predicate           |
-|               |                                                                                   |
-+---------------+-----------------------------------------------------------------------------------+
++---------------+-------------------------------------------------------------------------------+
+| plan_type     | plan                                                                          |
++---------------+-------------------------------------------------------------------------------+
+| logical_plan  | Union                                                                         |
+|               |   Projection: #h2o.state AS name                                              |
+|               |     TableScan: h2o projection=Some([4])                                       |
+|               |   Projection: #h2o.city AS name                                               |
+|               |     TableScan: h2o projection=Some([1])                                       |
+| physical_plan | UnionExec                                                                     |
+|               |   ProjectionExec: expr=[state@0 as name]                                      |
+|               |     UnionExec                                                                 |
+|               |       ProjectionExec: expr=[state@1 as state]                                 |
+|               |         DeduplicateExec: [state@1 ASC,city@0 ASC,time@2 ASC]                  |
+|               |           SortPreservingMergeExec: [state@1 ASC,city@0 ASC,time@2 ASC]        |
+|               |             UnionExec                                                         |
+|               |               IOxReadFilterNode: table_name=h2o, chunks=1 predicate=Predicate |
+|               |               IOxReadFilterNode: table_name=h2o, chunks=1 predicate=Predicate |
+|               |       IOxReadFilterNode: table_name=h2o, chunks=1 predicate=Predicate         |
+|               |       IOxReadFilterNode: table_name=h2o, chunks=1 predicate=Predicate         |
+|               |   ProjectionExec: expr=[city@0 as name]                                       |
+|               |     UnionExec                                                                 |
+|               |       ProjectionExec: expr=[city@0 as city]                                   |
+|               |         DeduplicateExec: [state@1 ASC,city@0 ASC,time@2 ASC]                  |
+|               |           SortPreservingMergeExec: [state@1 ASC,city@0 ASC,time@2 ASC]        |
+|               |             UnionExec                                                         |
+|               |               IOxReadFilterNode: table_name=h2o, chunks=1 predicate=Predicate |
+|               |               IOxReadFilterNode: table_name=h2o, chunks=1 predicate=Predicate |
+|               |       IOxReadFilterNode: table_name=h2o, chunks=1 predicate=Predicate         |
+|               |       IOxReadFilterNode: table_name=h2o, chunks=1 predicate=Predicate         |
+|               |                                                                               |
++---------------+-------------------------------------------------------------------------------+

--- a/query_tests/cases/in/no_stats_plans.expected
+++ b/query_tests/cases/in/no_stats_plans.expected
@@ -7,8 +7,7 @@
 |               |   Aggregate: groupBy=[[]], aggr=[[COUNT(UInt8(1))]]         |
 |               |     TableScan: h2o projection=Some([0])                     |
 | physical_plan | ProjectionExec: expr=[COUNT(UInt8(1))@0 as COUNT(UInt8(1))] |
-|               |   RepartitionExec: partitioning=RoundRobinBatch(4)          |
-|               |     ProjectionExec: expr=[3 as COUNT(UInt8(1))]             |
-|               |       EmptyExec: produce_one_row=true                       |
+|               |   ProjectionExec: expr=[3 as COUNT(UInt8(1))]               |
+|               |     EmptyExec: produce_one_row=true                         |
 |               |                                                             |
 +---------------+-------------------------------------------------------------+

--- a/query_tests/cases/in/pushdown.expected
+++ b/query_tests/cases/in/pushdown.expected
@@ -6,52 +6,48 @@
 | logical_plan  | Projection: #restaurant.count, #restaurant.system, #restaurant.time, #restaurant.town       |
 |               |   TableScan: restaurant projection=Some([0, 1, 2, 3])                                       |
 | physical_plan | ProjectionExec: expr=[count@0 as count, system@1 as system, time@2 as time, town@3 as town] |
-|               |   RepartitionExec: partitioning=RoundRobinBatch(4)                                          |
-|               |     IOxReadFilterNode: table_name=restaurant, chunks=1 predicate=Predicate                  |
+|               |   IOxReadFilterNode: table_name=restaurant, chunks=1 predicate=Predicate                    |
 |               |                                                                                             |
 +---------------+---------------------------------------------------------------------------------------------+
 -- SQL: EXPLAIN SELECT * from restaurant where count > 200;
++---------------+-----------------------------------------------------------------------------------------------------------+
+| plan_type     | plan                                                                                                      |
++---------------+-----------------------------------------------------------------------------------------------------------+
+| logical_plan  | Projection: #restaurant.count, #restaurant.system, #restaurant.time, #restaurant.town                     |
+|               |   Filter: #restaurant.count > Int64(200)                                                                  |
+|               |     TableScan: restaurant projection=Some([0, 1, 2, 3]), filters=[#restaurant.count > Int64(200)]         |
+| physical_plan | ProjectionExec: expr=[count@0 as count, system@1 as system, time@2 as time, town@3 as town]               |
+|               |   CoalesceBatchesExec: target_batch_size=500                                                              |
+|               |     FilterExec: CAST(count@0 AS Int64) > 200                                                              |
+|               |       IOxReadFilterNode: table_name=restaurant, chunks=1 predicate=Predicate exprs: [#count > Int64(200)] |
+|               |                                                                                                           |
++---------------+-----------------------------------------------------------------------------------------------------------+
+-- SQL: EXPLAIN SELECT * from restaurant where count > 200.0;
 +---------------+-------------------------------------------------------------------------------------------------------------+
 | plan_type     | plan                                                                                                        |
 +---------------+-------------------------------------------------------------------------------------------------------------+
 | logical_plan  | Projection: #restaurant.count, #restaurant.system, #restaurant.time, #restaurant.town                       |
-|               |   Filter: #restaurant.count > Int64(200)                                                                    |
-|               |     TableScan: restaurant projection=Some([0, 1, 2, 3]), filters=[#restaurant.count > Int64(200)]           |
+|               |   Filter: #restaurant.count > Float64(200)                                                                  |
+|               |     TableScan: restaurant projection=Some([0, 1, 2, 3]), filters=[#restaurant.count > Float64(200)]         |
 | physical_plan | ProjectionExec: expr=[count@0 as count, system@1 as system, time@2 as time, town@3 as town]                 |
 |               |   CoalesceBatchesExec: target_batch_size=500                                                                |
-|               |     FilterExec: CAST(count@0 AS Int64) > 200                                                                |
-|               |       RepartitionExec: partitioning=RoundRobinBatch(4)                                                      |
-|               |         IOxReadFilterNode: table_name=restaurant, chunks=1 predicate=Predicate exprs: [#count > Int64(200)] |
+|               |     FilterExec: CAST(count@0 AS Float64) > 200                                                              |
+|               |       IOxReadFilterNode: table_name=restaurant, chunks=1 predicate=Predicate exprs: [#count > Float64(200)] |
 |               |                                                                                                             |
 +---------------+-------------------------------------------------------------------------------------------------------------+
--- SQL: EXPLAIN SELECT * from restaurant where count > 200.0;
-+---------------+---------------------------------------------------------------------------------------------------------------+
-| plan_type     | plan                                                                                                          |
-+---------------+---------------------------------------------------------------------------------------------------------------+
-| logical_plan  | Projection: #restaurant.count, #restaurant.system, #restaurant.time, #restaurant.town                         |
-|               |   Filter: #restaurant.count > Float64(200)                                                                    |
-|               |     TableScan: restaurant projection=Some([0, 1, 2, 3]), filters=[#restaurant.count > Float64(200)]           |
-| physical_plan | ProjectionExec: expr=[count@0 as count, system@1 as system, time@2 as time, town@3 as town]                   |
-|               |   CoalesceBatchesExec: target_batch_size=500                                                                  |
-|               |     FilterExec: CAST(count@0 AS Float64) > 200                                                                |
-|               |       RepartitionExec: partitioning=RoundRobinBatch(4)                                                        |
-|               |         IOxReadFilterNode: table_name=restaurant, chunks=1 predicate=Predicate exprs: [#count > Float64(200)] |
-|               |                                                                                                               |
-+---------------+---------------------------------------------------------------------------------------------------------------+
 -- SQL: EXPLAIN SELECT * from restaurant where system > 4.0;
-+---------------+--------------------------------------------------------------------------------------------------------------+
-| plan_type     | plan                                                                                                         |
-+---------------+--------------------------------------------------------------------------------------------------------------+
-| logical_plan  | Projection: #restaurant.count, #restaurant.system, #restaurant.time, #restaurant.town                        |
-|               |   Filter: #restaurant.system > Float64(4)                                                                    |
-|               |     TableScan: restaurant projection=Some([0, 1, 2, 3]), filters=[#restaurant.system > Float64(4)]           |
-| physical_plan | ProjectionExec: expr=[count@0 as count, system@1 as system, time@2 as time, town@3 as town]                  |
-|               |   CoalesceBatchesExec: target_batch_size=500                                                                 |
-|               |     FilterExec: system@1 > 4                                                                                 |
-|               |       RepartitionExec: partitioning=RoundRobinBatch(4)                                                       |
-|               |         IOxReadFilterNode: table_name=restaurant, chunks=1 predicate=Predicate exprs: [#system > Float64(4)] |
-|               |                                                                                                              |
-+---------------+--------------------------------------------------------------------------------------------------------------+
++---------------+------------------------------------------------------------------------------------------------------------+
+| plan_type     | plan                                                                                                       |
++---------------+------------------------------------------------------------------------------------------------------------+
+| logical_plan  | Projection: #restaurant.count, #restaurant.system, #restaurant.time, #restaurant.town                      |
+|               |   Filter: #restaurant.system > Float64(4)                                                                  |
+|               |     TableScan: restaurant projection=Some([0, 1, 2, 3]), filters=[#restaurant.system > Float64(4)]         |
+| physical_plan | ProjectionExec: expr=[count@0 as count, system@1 as system, time@2 as time, town@3 as town]                |
+|               |   CoalesceBatchesExec: target_batch_size=500                                                               |
+|               |     FilterExec: system@1 > 4                                                                               |
+|               |       IOxReadFilterNode: table_name=restaurant, chunks=1 predicate=Predicate exprs: [#system > Float64(4)] |
+|               |                                                                                                            |
++---------------+------------------------------------------------------------------------------------------------------------+
 -- SQL: EXPLAIN SELECT * from restaurant where count > 200 and town != 'tewsbury';
 +---------------+-----------------------------------------------------------------------------------------------------------------------------------------+
 | plan_type     | plan                                                                                                                                    |
@@ -62,8 +58,7 @@
 | physical_plan | ProjectionExec: expr=[count@0 as count, system@1 as system, time@2 as time, town@3 as town]                                             |
 |               |   CoalesceBatchesExec: target_batch_size=500                                                                                            |
 |               |     FilterExec: CAST(count@0 AS Int64) > 200 AND CAST(town@3 AS Utf8) != tewsbury                                                       |
-|               |       RepartitionExec: partitioning=RoundRobinBatch(4)                                                                                  |
-|               |         IOxReadFilterNode: table_name=restaurant, chunks=1 predicate=Predicate exprs: [#count > Int64(200), #town != Utf8("tewsbury")]  |
+|               |       IOxReadFilterNode: table_name=restaurant, chunks=1 predicate=Predicate exprs: [#count > Int64(200), #town != Utf8("tewsbury")]    |
 |               |                                                                                                                                         |
 +---------------+-----------------------------------------------------------------------------------------------------------------------------------------+
 -- SQL: EXPLAIN SELECT * from restaurant where count > 200 and town != 'tewsbury' and (system =5 or town = 'lawrence');
@@ -76,8 +71,7 @@
 | physical_plan | ProjectionExec: expr=[count@0 as count, system@1 as system, time@2 as time, town@3 as town]                                                                                                                   |
 |               |   CoalesceBatchesExec: target_batch_size=500                                                                                                                                                                  |
 |               |     FilterExec: CAST(count@0 AS Int64) > 200 AND CAST(town@3 AS Utf8) != tewsbury AND system@1 = CAST(5 AS Float64) OR CAST(town@3 AS Utf8) = lawrence                                                        |
-|               |       RepartitionExec: partitioning=RoundRobinBatch(4)                                                                                                                                                        |
-|               |         IOxReadFilterNode: table_name=restaurant, chunks=1 predicate=Predicate exprs: [#count > Int64(200), #town != Utf8("tewsbury")]                                                                        |
+|               |       IOxReadFilterNode: table_name=restaurant, chunks=1 predicate=Predicate exprs: [#count > Int64(200), #town != Utf8("tewsbury")]                                                                          |
 |               |                                                                                                                                                                                                               |
 +---------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 -- SQL: EXPLAIN SELECT * from restaurant where count > 200 and town != 'tewsbury' and (system =5 or town = 'lawrence') and count < 40000;
@@ -90,8 +84,7 @@
 | physical_plan | ProjectionExec: expr=[count@0 as count, system@1 as system, time@2 as time, town@3 as town]                                                                                                                                                     |
 |               |   CoalesceBatchesExec: target_batch_size=500                                                                                                                                                                                                    |
 |               |     FilterExec: CAST(count@0 AS Int64) > 200 AND CAST(town@3 AS Utf8) != tewsbury AND system@1 = CAST(5 AS Float64) OR CAST(town@3 AS Utf8) = lawrence AND CAST(count@0 AS Int64) < 40000                                                       |
-|               |       RepartitionExec: partitioning=RoundRobinBatch(4)                                                                                                                                                                                          |
-|               |         IOxReadFilterNode: table_name=restaurant, chunks=1 predicate=Predicate exprs: [#count > Int64(200), #town != Utf8("tewsbury"), #count < Int64(40000)]                                                                                   |
+|               |       IOxReadFilterNode: table_name=restaurant, chunks=1 predicate=Predicate exprs: [#count > Int64(200), #town != Utf8("tewsbury"), #count < Int64(40000)]                                                                                     |
 |               |                                                                                                                                                                                                                                                 |
 +---------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 -- SQL: EXPLAIN SELECT * from restaurant where count > 200  and count < 40000;
@@ -104,8 +97,7 @@
 | physical_plan | ProjectionExec: expr=[count@0 as count, system@1 as system, time@2 as time, town@3 as town]                                         |
 |               |   CoalesceBatchesExec: target_batch_size=500                                                                                        |
 |               |     FilterExec: CAST(count@0 AS Int64) > 200 AND CAST(count@0 AS Int64) < 40000                                                     |
-|               |       RepartitionExec: partitioning=RoundRobinBatch(4)                                                                              |
-|               |         IOxReadFilterNode: table_name=restaurant, chunks=1 predicate=Predicate exprs: [#count > Int64(200), #count < Int64(40000)]  |
+|               |       IOxReadFilterNode: table_name=restaurant, chunks=1 predicate=Predicate exprs: [#count > Int64(200), #count < Int64(40000)]    |
 |               |                                                                                                                                     |
 +---------------+-------------------------------------------------------------------------------------------------------------------------------------+
 -- SQL: EXPLAIN SELECT * from restaurant where system > 4.0 and system < 7.0;
@@ -118,8 +110,7 @@
 | physical_plan | ProjectionExec: expr=[count@0 as count, system@1 as system, time@2 as time, town@3 as town]                                         |
 |               |   CoalesceBatchesExec: target_batch_size=500                                                                                        |
 |               |     FilterExec: system@1 > 4 AND system@1 < 7                                                                                       |
-|               |       RepartitionExec: partitioning=RoundRobinBatch(4)                                                                              |
-|               |         IOxReadFilterNode: table_name=restaurant, chunks=1 predicate=Predicate exprs: [#system > Float64(4), #system < Float64(7)]  |
+|               |       IOxReadFilterNode: table_name=restaurant, chunks=1 predicate=Predicate exprs: [#system > Float64(4), #system < Float64(7)]    |
 |               |                                                                                                                                     |
 +---------------+-------------------------------------------------------------------------------------------------------------------------------------+
 -- SQL: EXPLAIN SELECT * from restaurant where system > 5.0 and system < 7.0;
@@ -132,8 +123,7 @@
 | physical_plan | ProjectionExec: expr=[count@0 as count, system@1 as system, time@2 as time, town@3 as town]                                         |
 |               |   CoalesceBatchesExec: target_batch_size=500                                                                                        |
 |               |     FilterExec: system@1 > 5 AND system@1 < 7                                                                                       |
-|               |       RepartitionExec: partitioning=RoundRobinBatch(4)                                                                              |
-|               |         IOxReadFilterNode: table_name=restaurant, chunks=1 predicate=Predicate exprs: [#system > Float64(5), #system < Float64(7)]  |
+|               |       IOxReadFilterNode: table_name=restaurant, chunks=1 predicate=Predicate exprs: [#system > Float64(5), #system < Float64(7)]    |
 |               |                                                                                                                                     |
 +---------------+-------------------------------------------------------------------------------------------------------------------------------------+
 -- SQL: EXPLAIN SELECT * from restaurant where system > 5.0 and town != 'tewsbury' and 7.0 > system;
@@ -146,8 +136,7 @@
 | physical_plan | ProjectionExec: expr=[count@0 as count, system@1 as system, time@2 as time, town@3 as town]                                                                               |
 |               |   CoalesceBatchesExec: target_batch_size=500                                                                                                                              |
 |               |     FilterExec: system@1 > 5 AND CAST(town@3 AS Utf8) != tewsbury AND 7 > system@1                                                                                        |
-|               |       RepartitionExec: partitioning=RoundRobinBatch(4)                                                                                                                    |
-|               |         IOxReadFilterNode: table_name=restaurant, chunks=1 predicate=Predicate exprs: [#system > Float64(5), #town != Utf8("tewsbury"), Float64(7) > #system]             |
+|               |       IOxReadFilterNode: table_name=restaurant, chunks=1 predicate=Predicate exprs: [#system > Float64(5), #town != Utf8("tewsbury"), Float64(7) > #system]               |
 |               |                                                                                                                                                                           |
 +---------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 -- SQL: EXPLAIN SELECT * from restaurant where system > 5.0 and 'tewsbury' != town and system < 7.0 and (count = 632 or town = 'reading');
@@ -160,8 +149,7 @@
 | physical_plan | ProjectionExec: expr=[count@0 as count, system@1 as system, time@2 as time, town@3 as town]                                                                                                                                                     |
 |               |   CoalesceBatchesExec: target_batch_size=500                                                                                                                                                                                                    |
 |               |     FilterExec: system@1 > 5 AND tewsbury != CAST(town@3 AS Utf8) AND system@1 < 7 AND CAST(count@0 AS Int64) = 632 OR CAST(town@3 AS Utf8) = reading                                                                                           |
-|               |       RepartitionExec: partitioning=RoundRobinBatch(4)                                                                                                                                                                                          |
-|               |         IOxReadFilterNode: table_name=restaurant, chunks=1 predicate=Predicate exprs: [#system > Float64(5), Utf8("tewsbury") != #town, #system < Float64(7)]                                                                                   |
+|               |       IOxReadFilterNode: table_name=restaurant, chunks=1 predicate=Predicate exprs: [#system > Float64(5), Utf8("tewsbury") != #town, #system < Float64(7)]                                                                                     |
 |               |                                                                                                                                                                                                                                                 |
 +---------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 -- SQL: EXPLAIN SELECT * from restaurant where 5.0 < system and town != 'tewsbury' and system < 7.0 and (count = 632 or town = 'reading') and time > to_timestamp('1970-01-01T00:00:00.000000130+00:00');
@@ -174,7 +162,6 @@
 | physical_plan | ProjectionExec: expr=[count@0 as count, system@1 as system, time@2 as time, town@3 as town]                                                                                                                                                                                                        |
 |               |   CoalesceBatchesExec: target_batch_size=500                                                                                                                                                                                                                                                       |
 |               |     FilterExec: 5 < system@1 AND CAST(town@3 AS Utf8) != tewsbury AND system@1 < 7 AND CAST(count@0 AS Int64) = 632 OR CAST(town@3 AS Utf8) = reading AND time@2 > 130                                                                                                                             |
-|               |       RepartitionExec: partitioning=RoundRobinBatch(4)                                                                                                                                                                                                                                             |
-|               |         IOxReadFilterNode: table_name=restaurant, chunks=0 predicate=Predicate exprs: [Float64(5) < #system, #town != Utf8("tewsbury"), #system < Float64(7), #time > TimestampNanosecond(130, None)]                                                                                              |
+|               |       EmptyExec: produce_one_row=false                                                                                                                                                                                                                                                             |
 |               |                                                                                                                                                                                                                                                                                                    |
 +---------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+

--- a/query_tests/cases/in/stats_plans.expected
+++ b/query_tests/cases/in/stats_plans.expected
@@ -7,26 +7,23 @@
 |               |   Aggregate: groupBy=[[]], aggr=[[COUNT(UInt8(1))]]         |
 |               |     TableScan: h2o projection=Some([0])                     |
 | physical_plan | ProjectionExec: expr=[COUNT(UInt8(1))@0 as COUNT(UInt8(1))] |
-|               |   RepartitionExec: partitioning=RoundRobinBatch(4)          |
-|               |     ProjectionExec: expr=[3 as COUNT(UInt8(1))]             |
-|               |       EmptyExec: produce_one_row=true                       |
+|               |   ProjectionExec: expr=[3 as COUNT(UInt8(1))]               |
+|               |     EmptyExec: produce_one_row=true                         |
 |               |                                                             |
 +---------------+-------------------------------------------------------------+
 -- SQL: EXPLAIN SELECT count(*) from h2o where temp > 70.0 and temp < 72.0;
-+---------------+---------------------------------------------------------------------------------------------------------------------------------+
-| plan_type     | plan                                                                                                                            |
-+---------------+---------------------------------------------------------------------------------------------------------------------------------+
-| logical_plan  | Projection: #COUNT(UInt8(1))                                                                                                    |
-|               |   Aggregate: groupBy=[[]], aggr=[[COUNT(UInt8(1))]]                                                                             |
-|               |     Filter: #h2o.temp > Float64(70) AND #h2o.temp < Float64(72)                                                                 |
-|               |       TableScan: h2o projection=Some([3]), filters=[#h2o.temp > Float64(70), #h2o.temp < Float64(72)]                           |
-| physical_plan | ProjectionExec: expr=[COUNT(UInt8(1))@0 as COUNT(UInt8(1))]                                                                     |
-|               |   HashAggregateExec: mode=Final, gby=[], aggr=[COUNT(UInt8(1))]                                                                 |
-|               |     CoalescePartitionsExec                                                                                                      |
-|               |       HashAggregateExec: mode=Partial, gby=[], aggr=[COUNT(UInt8(1))]                                                           |
-|               |         CoalesceBatchesExec: target_batch_size=500                                                                              |
-|               |           FilterExec: temp@0 > 70 AND temp@0 < 72                                                                               |
-|               |             RepartitionExec: partitioning=RoundRobinBatch(4)                                                                    |
-|               |               IOxReadFilterNode: table_name=h2o, chunks=1 predicate=Predicate exprs: [#temp > Float64(70), #temp < Float64(72)] |
-|               |                                                                                                                                 |
-+---------------+---------------------------------------------------------------------------------------------------------------------------------+
++---------------+-----------------------------------------------------------------------------------------------------------------------------+
+| plan_type     | plan                                                                                                                        |
++---------------+-----------------------------------------------------------------------------------------------------------------------------+
+| logical_plan  | Projection: #COUNT(UInt8(1))                                                                                                |
+|               |   Aggregate: groupBy=[[]], aggr=[[COUNT(UInt8(1))]]                                                                         |
+|               |     Filter: #h2o.temp > Float64(70) AND #h2o.temp < Float64(72)                                                             |
+|               |       TableScan: h2o projection=Some([3]), filters=[#h2o.temp > Float64(70), #h2o.temp < Float64(72)]                       |
+| physical_plan | ProjectionExec: expr=[COUNT(UInt8(1))@0 as COUNT(UInt8(1))]                                                                 |
+|               |   HashAggregateExec: mode=Final, gby=[], aggr=[COUNT(UInt8(1))]                                                             |
+|               |     HashAggregateExec: mode=Partial, gby=[], aggr=[COUNT(UInt8(1))]                                                         |
+|               |       CoalesceBatchesExec: target_batch_size=500                                                                            |
+|               |         FilterExec: temp@0 > 70 AND temp@0 < 72                                                                             |
+|               |           IOxReadFilterNode: table_name=h2o, chunks=1 predicate=Predicate exprs: [#temp > Float64(70), #temp < Float64(72)] |
+|               |                                                                                                                             |
++---------------+-----------------------------------------------------------------------------------------------------------------------------+


### PR DESCRIPTION
We are seeing partition fanouts into the thousands in our production workloads, this is in large part due to the `Repartition` physical optimizer being a little bit partition happy. I've filed https://github.com/apache/arrow-datafusion/issues/1731 to track this, but in the meantime I think we should just disable this optimization.

I also took the opportunity to set the target_partitions based on the number of threads in the `DedicatedExecutor` as it otherwise defaults to num_cpus, which in docker-ised context may be larger than what has actually been allocated to the workload.