### PR TITLE
feat: add skeleton `storage` CLI command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1781,6 +1781,7 @@ dependencies = [
  "influxdb_iox_client",
  "influxdb_line_protocol",
  "influxdb_storage_client",
+ "influxrpc_parser",
  "ingester",
  "internal_types",
  "iox_catalog",

--- a/influxdb_iox/Cargo.toml
+++ b/influxdb_iox/Cargo.toml
@@ -16,6 +16,7 @@ influxdb_iox_client = { path = "../influxdb_iox_client", features = ["flight", "
 influxdb_line_protocol = { path = "../influxdb_line_protocol" }
 ingester = { path = "../ingester" }
 internal_types = { path = "../internal_types" }
+influxrpc_parser = { path = "../influxrpc_parser"}
 iox_catalog = { path = "../iox_catalog" }
 iox_object_store = { path = "../iox_object_store" }
 job_registry = { path = "../job_registry" }

--- a/influxdb_iox/src/commands/storage.rs
+++ b/influxdb_iox/src/commands/storage.rs
@@ -1,4 +1,14 @@
+use time;
+
 use snafu::Snafu;
+
+#[derive(Debug, Snafu)]
+pub enum Error {
+    #[snafu(display("Unable to parse timestamp '{:?}'", t))]
+    TimestampParseError { t: String },
+}
+
+pub type Result<T, E = Error> = std::result::Result<T, E>;
 
 /// Craft and submit different types of storage read requests
 #[derive(Debug, clap::Parser)]
@@ -7,19 +17,33 @@ pub struct Config {
     command: Command,
 
     /// The requested start time (inclusive) of the time-range (also accepts RFC3339 format).
-    #[clap(long, default_value = "-9223372036854775806")]
-    start: String,
+    #[clap(long, default_value = "-9223372036854775806", parse(try_from_str = parse_range))]
+    start: i64,
 
     /// The requested stop time (exclusive) of the time-range (also accepts RFC3339 format).
-    #[clap(long, default_value = "9223372036854775806")]
-    stop: String,
+    #[clap(long, default_value = "9223372036854775806", parse(try_from_str = parse_range))]
+    stop: i64,
 
     /// A predicate to filter results by. Effectively InfluxQL predicate format (see examples).
     #[clap(long, default_value = "")]
     predicate: String,
 }
 
-/// All possible subcommands for storage_rpc
+// Attempts to parse either a stringified `i64` value. or alternatively parse an
+// RFC3339 formatted timestamp into an `i64` value representing nanoseconds
+// since the epoch.
+fn parse_range(s: &str) -> Result<i64, Error> {
+    match s.parse::<i64>() {
+        Ok(v) => Ok(v),
+        Err(_) => {
+            // try to parse timestamp
+            let t = time::Time::from_rfc3339(s).or_else(|_| TimestampParseSnafu { t: s }.fail())?;
+            Ok(t.timestamp_nanos())
+        }
+    }
+}
+
+/// All possible subcommands for storage
 #[derive(Debug, clap::Parser)]
 enum Command {
     /// Issue a read_filter request
@@ -30,12 +54,35 @@ enum Command {
 #[derive(Debug, clap::Parser)]
 struct ReadFilter {}
 
-#[derive(Debug, Snafu)]
-pub enum Error {}
-
-pub type Result<T, E = Error> = std::result::Result<T, E>;
-
 /// Create and issue read request
 pub async fn command(config: Config) -> Result<()> {
+    // TODO(edd): handle command/config and execute request
+    println!("Unimplemented: config is {:?}", config);
     Ok(())
+}
+
+#[cfg(test)]
+mod test_super {
+    use super::*;
+
+    #[test]
+    fn test_parse_range() {
+        let cases = vec![
+            ("1965-06-11T15:22:22.1234Z", -143800657876600000),
+            ("1970-01-01T00:00:00Z", 0),
+            ("1970-01-01T00:00:00.00000001Z", 10),
+            ("2028-01-01T15:00:00Z", 1830351600000000000),
+            ("1830351600000000000", 1830351600000000000),
+            ("-12345", -12345),
+        ];
+
+        for (input, exp) in cases {
+            let got = parse_range(input).unwrap();
+            assert_eq!(
+                got, exp,
+                "got {:?} for input {:?}, expected {:?}",
+                got, input, exp
+            );
+        }
+    }
 }

--- a/influxdb_iox/src/commands/storage.rs
+++ b/influxdb_iox/src/commands/storage.rs
@@ -1,0 +1,41 @@
+use snafu::Snafu;
+
+/// Craft and submit different types of storage read requests
+#[derive(Debug, clap::Parser)]
+pub struct Config {
+    #[clap(subcommand)]
+    command: Command,
+
+    /// The requested start time (inclusive) of the time-range (also accepts RFC3339 format).
+    #[clap(long, default_value = "-9223372036854775806")]
+    start: String,
+
+    /// The requested stop time (exclusive) of the time-range (also accepts RFC3339 format).
+    #[clap(long, default_value = "9223372036854775806")]
+    stop: String,
+
+    /// A predicate to filter results by. Effectively InfluxQL predicate format (see examples).
+    #[clap(long, default_value = "")]
+    predicate: String,
+}
+
+/// All possible subcommands for storage_rpc
+#[derive(Debug, clap::Parser)]
+enum Command {
+    /// Issue a read_filter request
+    ReadFilter(ReadFilter),
+}
+
+/// Create a new database
+#[derive(Debug, clap::Parser)]
+struct ReadFilter {}
+
+#[derive(Debug, Snafu)]
+pub enum Error {}
+
+pub type Result<T, E = Error> = std::result::Result<T, E>;
+
+/// Create and issue read request
+pub async fn command(config: Config) -> Result<()> {
+    Ok(())
+}

--- a/influxdb_iox/src/main.rs
+++ b/influxdb_iox/src/main.rs
@@ -26,6 +26,7 @@ mod commands {
     pub mod server;
     pub mod server_remote;
     pub mod sql;
+    pub mod storage;
     pub mod tracing;
 }
 
@@ -165,6 +166,9 @@ enum Command {
 
     /// Interrogate internal database data
     Debug(commands::debug::Config),
+
+    /// Initiate a read request to the gRPC storage service.
+    StorageRPC(commands::storage::Config),
 }
 
 fn main() -> Result<(), std::io::Error> {
@@ -250,6 +254,13 @@ fn main() -> Result<(), std::io::Error> {
                 let _tracing_guard = handle_init_logs(init_simple_logs(log_verbose_count));
                 let connection = connection().await;
                 if let Err(e) = commands::sql::command(connection, config).await {
+                    eprintln!("{}", e);
+                    std::process::exit(ReturnCode::Failure as _)
+                }
+            }
+            Command::StorageRPC(config) => {
+                let _tracing_guard = handle_init_logs(init_simple_logs(log_verbose_count));
+                if let Err(e) = commands::storage::command(config).await {
                     eprintln!("{}", e);
                     std::process::exit(ReturnCode::Failure as _)
                 }

--- a/influxdb_iox/src/main.rs
+++ b/influxdb_iox/src/main.rs
@@ -168,7 +168,7 @@ enum Command {
     Debug(commands::debug::Config),
 
     /// Initiate a read request to the gRPC storage service.
-    StorageRPC(commands::storage::Config),
+    Storage(commands::storage::Config),
 }
 
 fn main() -> Result<(), std::io::Error> {
@@ -258,7 +258,7 @@ fn main() -> Result<(), std::io::Error> {
                     std::process::exit(ReturnCode::Failure as _)
                 }
             }
-            Command::StorageRPC(config) => {
+            Command::Storage(config) => {
                 let _tracing_guard = handle_init_logs(init_simple_logs(log_verbose_count));
                 if let Err(e) = commands::storage::command(config).await {
                     eprintln!("{}", e);


### PR DESCRIPTION
Towards: #3598

This PR adds a new `influxdb_iox` sub-command: `storage`. This sub-command will be responsible for interpreting provided arguments, crafting InfluxRPC read request messages, executing read requests against IOx, and displaying the results to the user of the CLI.

The contribution in this PR is a skeleton CLI sub-command that can deal with necessary arguments for a `ReadFilter` RPC request. It does not issue an RPC request (future PRs).

## Example Usage

Here are some examples of how the CLI can be used. All storage sub-commands will accepts:

 * `start`: an optional starting timestamp. The CLI can parse either integer values representing nanoseconds since (or before) the epoch, or alternatively timestamps in `RFC3339` format.
 * `stop`: see `start` above. Note `stop` is exclusive.
 * `predicate`: an optional predicate that can be used to filter results. The predicate is parsed into a `Predicate` `RPCNode` with the work done in #3594.

These arguments are accepted as options on the `storage` sub-command because all storage RPC requests accept those arguments.

Not providing anything will query all measurements and all time. **Note**: this is an operator tool and some understanding of the consequences of that should be assumed. Having said that I might consider restricting what happens in this case. For example we could default the time range to the last minute, or require a measurement.

```
$ influxdb_iox storage read_filter
```

Query all tables with a time-range:

```
$ influxdb_iox storage --start 2022-02-02T11:30:00Z --stop 2022-02-02T11:35:00Z read-filter
```

You can also use integers if you prefer:

```
$ influxdb_iox storage --start 1643801400000000000 --stop 1643801700000000000 read-filter
```

Query the `temp` field from the `cpu` table:

```
$ influxdb_iox storage --predicate "_measurement=cpu AND _field=temp" read-filter
```

Currently the CLI command just spits the config back out:

```
Unimplemented: config is Config { command: ReadFilter(ReadFilter), start: -9223372036854775806, stop: 9223372036854775806, predicate: Predicate { root: Some(Node { node_type: LogicalExpression, children: [Node { node_type: ComparisonExpression, children: [Node { node_type: TagRef, children: [], value: Some(TagRefValue([0])) }, Node { node_type: TagRef, children: [], value: Some(TagRefValue([99, 112, 117])) }], value: Some(Comparison(Equal)) }, Node { node_type: ComparisonExpression, children: [Node { node_type: TagRef, children: [], value: Some(TagRefValue([255])) }, Node { node_type: TagRef, children: [], value: Some(TagRefValue([116, 101, 109, 112])) }], value: Some(Comparison(Equal)) }], value: Some(Logical(And)) }) } }`
```

You can see that the built up `RPCNode` includes the special tag key for `_measurement` (`[0]`) and `_field` (`[255]`):

```
[
  Node { node_type: TagRef, children: [],  value: Some(TagRefValue([0])) }, 
  Node { node_type: TagRef, children: [], value: Some(TagRefValue([99, 112, 117])) }
]

...

[
  Node { node_type: TagRef, children: [],  value: Some(TagRefValue([255])) }, 
  Node { node_type: TagRef, children: [], value: Some(TagRefValue([116, 101, 109, 112])) }
]
```