### PR TITLE
feat: catalog CLI command with update subcommand

### DIFF
--- a/influxdb_iox/src/commands/catalog.rs
+++ b/influxdb_iox/src/commands/catalog.rs
@@ -1,5 +1,6 @@
 //! This module implements the `catalog` CLI command
 
+use crate::clap_blocks::catalog_dsn::CatalogDsnConfig;
 use thiserror::Error;
 
 mod topic;
@@ -27,9 +28,8 @@ pub struct Config {
 /// Run database migrations
 #[derive(Debug, clap::Parser)]
 struct Setup {
-    /// Postgres connection string
-    #[clap(long = "--catalog-dsn", env = "INFLUXDB_IOX_CATALOG_DSN")]
-    catalog_dsn: String,
+    #[clap(flatten)]
+    catalog_dsn: CatalogDsnConfig,
 }
 
 /// All possible subcommands for catalog

--- a/influxdb_iox/src/commands/catalog.rs
+++ b/influxdb_iox/src/commands/catalog.rs
@@ -1,0 +1,56 @@
+//! This module implements the `catalog` CLI command
+
+use thiserror::Error;
+
+mod topic;
+
+#[allow(clippy::enum_variant_names)]
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error("Error formatting: {0}")]
+    FormattingError(#[from] influxdb_iox_client::format::Error),
+
+    #[error("Error in topic subcommand: {0}")]
+    Topic(#[from] topic::Error),
+
+    #[error("Client error: {0}")]
+    ClientError(#[from] influxdb_iox_client::error::Error),
+}
+
+/// Various commands for catalog manipulation
+#[derive(Debug, clap::Parser)]
+pub struct Config {
+    #[clap(subcommand)]
+    command: Command,
+}
+
+/// Run database migrations
+#[derive(Debug, clap::Parser)]
+struct Setup {
+    /// Postgres connection string
+    #[clap(long = "--catalog-dsn", env = "INFLUXDB_IOX_CATALOG_DSN")]
+    catalog_dsn: String,
+}
+
+/// All possible subcommands for catalog
+#[derive(Debug, clap::Parser)]
+enum Command {
+    /// Run database migrations
+    Setup(Setup),
+
+    /// Manage kafka topic
+    Topic(topic::Config),
+}
+
+pub async fn command(config: Config) -> Result<(), Error> {
+    match config.command {
+        Command::Setup(_command) => {
+            unimplemented!();
+        }
+        Command::Topic(config) => {
+            topic::command(config).await?;
+        }
+    }
+
+    Ok(())
+}

--- a/influxdb_iox/src/commands/catalog/topic.rs
+++ b/influxdb_iox/src/commands/catalog/topic.rs
@@ -1,0 +1,53 @@
+//! This module implements the `catalog topic` CLI subcommand
+
+use thiserror::Error;
+
+use crate::clap_blocks::catalog_dsn::CatalogDsnConfig;
+
+#[allow(clippy::enum_variant_names)]
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error("Error connecting to IOx: {0}")]
+    ConnectionError(#[from] influxdb_iox_client::connection::Error),
+
+    #[error("Error updating catalog: {0}")]
+    UpdateCatalogError(#[from] iox_catalog::interface::Error),
+
+    #[error("Client error: {0}")]
+    ClientError(#[from] influxdb_iox_client::error::Error),
+}
+
+/// Manage IOx chunks
+#[derive(Debug, clap::Parser)]
+pub struct Config {
+    #[clap(subcommand)]
+    command: Command,
+}
+
+/// Create or update a topic
+#[derive(Debug, clap::Parser)]
+struct Update {
+    #[clap(flatten)]
+    catalog_dsn: CatalogDsnConfig,
+
+    /// The name of the topic
+    db_name: String,
+}
+
+/// All possible subcommands for topic
+#[derive(Debug, clap::Parser)]
+enum Command {
+    Update(Update),
+}
+
+pub async fn command(config: Config) -> Result<(), Error> {
+    match config.command {
+        Command::Update(update) => {
+            let catalog = update.catalog_dsn.get_catalog("cli").await?;
+            let topics_repo = catalog.kafka_topics();
+            let topic = topics_repo.create_or_get(&update.db_name).await?;
+            println!("Topic ID {}", topic.id);
+            Ok(())
+        }
+    }
+}

--- a/influxdb_iox/src/commands/catalog/topic.rs
+++ b/influxdb_iox/src/commands/catalog/topic.rs
@@ -46,7 +46,7 @@ pub async fn command(config: Config) -> Result<(), Error> {
             let catalog = update.catalog_dsn.get_catalog("cli").await?;
             let topics_repo = catalog.kafka_topics();
             let topic = topics_repo.create_or_get(&update.db_name).await?;
-            println!("Topic ID {}", topic.id);
+            println!("{}", topic.id);
             Ok(())
         }
     }

--- a/influxdb_iox/src/main.rs
+++ b/influxdb_iox/src/main.rs
@@ -18,6 +18,7 @@ use std::str::FromStr;
 use tokio::runtime::Runtime;
 
 mod commands {
+    pub mod catalog;
     pub mod database;
     pub mod debug;
     pub mod operations;
@@ -164,6 +165,9 @@ enum Command {
     /// Start IOx interactive SQL REPL loop
     Sql(commands::sql::Config),
 
+    /// Various commands for catalog manipulation
+    Catalog(commands::catalog::Config),
+
     /// Interrogate internal database data
     Debug(commands::debug::Config),
 
@@ -261,6 +265,13 @@ fn main() -> Result<(), std::io::Error> {
             Command::Storage(config) => {
                 let _tracing_guard = handle_init_logs(init_simple_logs(log_verbose_count));
                 if let Err(e) = commands::storage::command(config).await {
+                    eprintln!("{}", e);
+                    std::process::exit(ReturnCode::Failure as _)
+                }
+            }
+            Command::Catalog(config) => {
+                let _tracing_guard = handle_init_logs(init_simple_logs(log_verbose_count));
+                if let Err(e) = commands::catalog::command(config).await {
                     eprintln!("{}", e);
                     std::process::exit(ReturnCode::Failure as _)
                 }


### PR DESCRIPTION
This PR adds the `catalog` command which has an `unimplemented` `setup` command, and a `topic` subcommand which is implemented in this PR.

Part of #3509. The `setup` command will be implemented in a separate PR, which will close that issue.