### PR TITLE
feat: add tag_values to storage cli

### DIFF
--- a/influxdb_iox/src/commands/storage.rs
+++ b/influxdb_iox/src/commands/storage.rs
@@ -110,12 +110,11 @@ fn parse_db_name(db_name: &str) -> Result<OrgAndBucket, ParseError> {
 #[derive(Debug, clap::Parser)]
 enum Command {
     /// Issue a read_filter request
-    ReadFilter(ReadFilter),
+    ReadFilter,
 }
 
-/// Create a new database
-#[derive(Debug, clap::Parser)]
-struct ReadFilter {}
+// #[derive(Debug, clap::Parser)]
+// struct ReadFilter {}
 
 /// Create and issue read request
 pub async fn command(connection: Connection, config: Config) -> Result<()> {
@@ -126,7 +125,7 @@ pub async fn command(connection: Connection, config: Config) -> Result<()> {
 
     let source = Client::read_source(&config.db_name, 0);
     let result = match config.command {
-        Command::ReadFilter(_) => {
+        Command::ReadFilter => {
             client
                 .read_filter(request::read_filter(
                     source,

--- a/influxdb_iox/src/commands/storage.rs
+++ b/influxdb_iox/src/commands/storage.rs
@@ -109,12 +109,14 @@ fn parse_db_name(db_name: &str) -> Result<OrgAndBucket, ParseError> {
 /// All possible subcommands for storage
 #[derive(Debug, clap::Parser)]
 enum Command {
-    /// Issue a read_filter request
     ReadFilter,
+    TagValues(TagValues),
 }
 
-// #[derive(Debug, clap::Parser)]
-// struct ReadFilter {}
+#[derive(Debug, clap::Parser)]
+struct TagValues {
+    tag_key: String,
+}
 
 /// Create and issue read request
 pub async fn command(connection: Connection, config: Config) -> Result<()> {
@@ -124,9 +126,9 @@ pub async fn command(connection: Connection, config: Config) -> Result<()> {
     let predicate = config.predicate.root.is_some().then(|| config.predicate);
 
     let source = Client::read_source(&config.db_name, 0);
-    let result = match config.command {
+    match config.command {
         Command::ReadFilter => {
-            client
+            let result = client
                 .read_filter(request::read_filter(
                     source,
                     config.start,
@@ -134,11 +136,23 @@ pub async fn command(connection: Connection, config: Config) -> Result<()> {
                     predicate,
                 ))
                 .await
+                .context(ServerSnafu)?;
+            response::pretty_print_frames(&result).context(ResponseSnafu)
+        }
+        Command::TagValues(tv) => {
+            let result = client
+                .tag_values(request::tag_values(
+                    source,
+                    config.start,
+                    config.stop,
+                    predicate,
+                    tv.tag_key,
+                ))
+                .await
+                .context(ServerSnafu)?;
+            response::pretty_print_strings(result).context(ResponseSnafu)
         }
     }
-    .context(ServerSnafu)?;
-
-    response::pretty_print(&result).context(ResponseSnafu)
 }
 
 #[cfg(test)]

--- a/influxdb_iox/src/commands/storage.rs
+++ b/influxdb_iox/src/commands/storage.rs
@@ -115,6 +115,7 @@ enum Command {
 
 #[derive(Debug, clap::Parser)]
 struct TagValues {
+    // The tag key value to interrogate for tag values.
     tag_key: String,
 }
 

--- a/influxdb_iox/src/commands/storage/request.rs
+++ b/influxdb_iox/src/commands/storage/request.rs
@@ -3,6 +3,9 @@ pub mod generated_types {
 }
 
 use self::generated_types::*;
+use super::response::{
+    tag_key_is_field, tag_key_is_measurement, FIELD_TAG_KEY_BIN, MEASUREMENT_TAG_KEY_BIN,
+};
 use ::generated_types::google::protobuf::*;
 
 pub fn read_filter(
@@ -27,11 +30,19 @@ pub fn tag_values(
     predicate: std::option::Option<Predicate>,
     tag_key: String,
 ) -> TagValuesRequest {
+    let tag_key = if tag_key_is_measurement(tag_key.as_bytes()) {
+        MEASUREMENT_TAG_KEY_BIN.to_vec()
+    } else if tag_key_is_field(tag_key.as_bytes()) {
+        FIELD_TAG_KEY_BIN.to_vec()
+    } else {
+        tag_key.as_bytes().to_vec()
+    };
+
     generated_types::TagValuesRequest {
         predicate,
         tags_source: Some(org_bucket),
         range: Some(TimestampRange { start, end: stop }),
-        tag_key: tag_key.into(),
+        tag_key,
     }
 }
 

--- a/influxdb_iox/src/commands/storage/request.rs
+++ b/influxdb_iox/src/commands/storage/request.rs
@@ -20,12 +20,26 @@ pub fn read_filter(
     }
 }
 
+pub fn tag_values(
+    org_bucket: Any,
+    start: i64,
+    stop: i64,
+    predicate: std::option::Option<Predicate>,
+    tag_key: String,
+) -> TagValuesRequest {
+    generated_types::TagValuesRequest {
+        predicate,
+        tags_source: Some(org_bucket),
+        range: Some(TimestampRange { start, end: stop }),
+        tag_key: tag_key.into(),
+    }
+}
+
 // TODO Add the following helpers for building requests:
 //
 // * read_group
 // * read_window_aggregate
 // * tag_keys
-// * tag_values
 // * tag_values_with_measurement_and_key
 // * measurement_names
 // * measurement_tag_keys

--- a/influxdb_iox/src/commands/storage/response.rs
+++ b/influxdb_iox/src/commands/storage/response.rs
@@ -483,9 +483,9 @@ impl TryFrom<IntermediateTable> for RecordBatch {
 const MEASUREMENT_TAG_KEY_TEXT: [u8; 12] = [
     b'_', b'm', b'e', b'a', b's', b'u', b'r', b'e', b'm', b'e', b'n', b't',
 ];
-const MEASUREMENT_TAG_KEY_BIN: [u8; 1] = [0_u8];
+pub(crate) const MEASUREMENT_TAG_KEY_BIN: [u8; 1] = [0_u8];
 const FIELD_TAG_KEY_TEXT: [u8; 6] = [b'_', b'f', b'i', b'e', b'l', b'd'];
-const FIELD_TAG_KEY: [u8; 1] = [255_u8];
+pub(crate) const FIELD_TAG_KEY_BIN: [u8; 1] = [255_u8];
 
 // Store a collection of column names and types for a single table (measurement).
 #[derive(Debug, Default, PartialEq, Eq)]
@@ -534,12 +534,12 @@ fn field_name(frame: &SeriesFrame) -> &Vec<u8> {
     &frame.tags[idx].value
 }
 
-fn tag_key_is_measurement(key: &[u8]) -> bool {
+pub(crate) fn tag_key_is_measurement(key: &[u8]) -> bool {
     (key == MEASUREMENT_TAG_KEY_TEXT) || (key == MEASUREMENT_TAG_KEY_BIN)
 }
 
-fn tag_key_is_field(key: &[u8]) -> bool {
-    (key == FIELD_TAG_KEY_TEXT) || (key == FIELD_TAG_KEY)
+pub(crate) fn tag_key_is_field(key: &[u8]) -> bool {
+    (key == FIELD_TAG_KEY_TEXT) || (key == FIELD_TAG_KEY_BIN)
 }
 
 #[cfg(test)]
@@ -746,7 +746,7 @@ mod test_super {
     }
 
     #[test]
-    fn test_into_record_batches() {
+    fn test_frames_to_into_record_batches() {
         let frames = gen_frames();
 
         let rbs = frames_to_record_batches(&frames);


### PR DESCRIPTION
Towards #3598.

This PR adds support for `tag_values` to the storage CLI. The tag values RPC requires that a column (tag key) is specified. Thus, the command us used as follows:

```
⇒  influxdb_iox storage db_name tag-values host

tag values: 3
+-----------------------+
| values                |
+-----------------------+
| -                     |
| foo                   |
| bar                   |
+-----------------------+
```

If you specify `_measurement` or `_field` the value will be correctly transformed into the byte-specific format used by the storage read API (`\x00` or `\xff` respectively).


```
⇒  influxdb_iox storage db_name tag-values _measurement

tag values: 3
+-----------------------+
| values                |
+-----------------------+
| m1                    |
| m2                    |
| m3                    |
+-----------------------+
```