### PR TITLE
chore: remove references to perf_image in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -322,7 +322,7 @@ jobs:
   #
   # Compiles a binary with the default ("dev") cargo profile from the iox source
   # using the latest ci_image.
-  build:
+  build_dev:
     docker:
       - image: quay.io/influxdb/rust:ci
     resource_class: xlarge  # use of a smaller executor tends crashes on link
@@ -392,22 +392,12 @@ jobs:
           name: Lint docs
           command: ./scripts/lint_docs.py ./docs
 
-  # Compile a cargo "release" profile binary for branches that end in `/perf`
+  # Compile a cargo "release" profile binaries for iox &data generator
   #
   # Uses the latest ci_image (influxdb/rust below) to build a release binary and
   # copies it to a minimal container image based upon `rust:slim-buster`. This
-  # minimal image is then pushed to `quay.io/influxdb/iox:${BRANCH}` with '/'
-  # repaced by '.' - as an example:
-  #
-  #   git branch: dom/my-awesome-feature/perf
-  #   container: quay.io/influxdb/iox:dom.my-awesome-feature.perf
-  #
-  # Subsequent CI runs will overwrite the tag if you push more changes, so watch
-  # out for parallel CI runs!
-  #
-  # To change the contents of the build container, modify docker/Dockerfile.ci
-  # To change the final release container, modify docker/Dockerfile.iox
-  perf_image:
+  # minimal image is then pushed to `quay.io/influxdb/iox:${BRANCH}`.
+  build_release:
     # need a machine executor to have a full-powered docker daemon (the `setup_remote_docker` system just provides a
     # kinda small node)
     machine:
@@ -500,10 +490,6 @@ parameters:
     description: "Trigger build of CI image"
     type: boolean
     default: false
-  perf_image:
-    description: "Trigger build of perf image"
-    type: boolean
-    default: false
 
 workflows:
   version: 2
@@ -521,10 +507,10 @@ workflows:
       - test
       - test_heappy
       - test_perf
-      - build
+      - build_dev
       - doc
       - workspace_hack_checks
-      - perf_image:
+      - build_release:
           filters:
             branches:
               only: main
@@ -537,7 +523,7 @@ workflows:
             - test
             - test_heappy
             - test_perf
-            - build
+            - build_dev
             - doc
 
   # Manual build of CI image
@@ -545,12 +531,6 @@ workflows:
     when: << pipeline.parameters.ci_image >>
     jobs:
       - ci_image
-
-  # Manual build of perf image
-  perf_image:
-    when: << pipeline.parameters.perf_image >>
-    jobs:
-      - perf_image
 
   # Nightly rebuild of the build container
   ci_image_nightly:


### PR DESCRIPTION
Removing outdated references to perf job and branches. It's now "build_release".