### PR TITLE
fix: write buffer traces

### DIFF
--- a/trace/src/ctx.rs
+++ b/trace/src/ctx.rs
@@ -4,12 +4,9 @@ use std::sync::Arc;
 
 use rand::Rng;
 
-use crate::{
-    span::{Span, SpanStatus},
-    TraceCollector,
-};
+use crate::{span::Span, TraceCollector};
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct TraceId(pub NonZeroU128);
 
 impl TraceId {
@@ -22,7 +19,7 @@ impl TraceId {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct SpanId(pub NonZeroU64);
 
 impl SpanId {
@@ -79,21 +76,14 @@ impl SpanContext {
 
     /// Creates a new child of the Span described by this TraceContext
     pub fn child(&self, name: impl Into<Cow<'static, str>>) -> Span {
-        Span {
-            name: name.into(),
-            ctx: Self {
-                trace_id: self.trace_id,
-                span_id: SpanId::gen(),
-                collector: self.collector.clone(),
-                links: vec![],
-                parent_span_id: Some(self.span_id),
-            },
-            start: None,
-            end: None,
-            status: SpanStatus::Unknown,
-            metadata: Default::default(),
-            events: Default::default(),
-        }
+        let ctx = Self {
+            trace_id: self.trace_id,
+            span_id: SpanId::gen(),
+            collector: self.collector.clone(),
+            links: vec![],
+            parent_span_id: Some(self.span_id),
+        };
+        Span::new(name, ctx)
     }
 
     /// Return the approximate memory size of the span, in bytes.

--- a/write_buffer/src/core.rs
+++ b/write_buffer/src/core.rs
@@ -131,7 +131,11 @@ pub mod test_utils {
     use dml::{test_util::assert_write_op_eq, DmlMeta, DmlOperation, DmlWrite};
     use futures::{stream::FuturesUnordered, StreamExt, TryStreamExt};
     use std::{
-        collections::BTreeSet, convert::TryFrom, num::NonZeroU32, sync::Arc, time::Duration,
+        collections::{BTreeSet, HashSet},
+        convert::TryFrom,
+        num::NonZeroU32,
+        sync::Arc,
+        time::Duration,
     };
     use time::{Time, TimeProvider};
     use trace::{ctx::SpanContext, span::Span, RingBufferTraceCollector};
@@ -706,6 +710,9 @@ pub mod test_utils {
         let write_3 = stream.next().await.unwrap().unwrap();
         let actual_context_2 = write_3.meta().span_context().unwrap();
         assert_span_context_eq_or_linked(&span_context_2, actual_context_2, collector.spans());
+
+        // check that links / parents make sense
+        assert_span_relations_closed(&collector.spans(), &[span_context_1, span_context_2]);
     }
 
     /// Test that writing to an unknown sequencer produces an error
@@ -851,6 +858,24 @@ pub mod test_utils {
         assert_eq!(first.trace_id, second.trace_id);
         assert_eq!(first.span_id, second.span_id);
         assert_eq!(first.parent_span_id, second.parent_span_id);
+    }
+
+    /// Assert that all span relations (parents, links) are found within the set of spans or within the set of roots.
+    fn assert_span_relations_closed(spans: &[Span], roots: &[SpanContext]) {
+        let all_ids: HashSet<_> = spans
+            .iter()
+            .map(|span| (span.ctx.trace_id, span.ctx.span_id))
+            .chain(roots.iter().map(|ctx| (ctx.trace_id, ctx.span_id)))
+            .collect();
+
+        for span in spans {
+            if let Some(parent_span_id) = span.ctx.parent_span_id {
+                assert!(all_ids.contains(&(span.ctx.trace_id, parent_span_id)));
+            }
+            for link in &span.ctx.links {
+                assert!(all_ids.contains(link));
+            }
+        }
     }
 
     /// Pops first entry from set.

--- a/write_buffer/src/core.rs
+++ b/write_buffer/src/core.rs
@@ -666,8 +666,15 @@ pub mod test_utils {
         // 1: no context
         write("namespace", &writer, entry, sequencer_id, None).await;
 
-        // 2: some context
+        // check write 1
+        let write_1 = stream.next().await.unwrap().unwrap();
+        assert!(write_1.meta().span_context().is_none());
+
+        // no spans emitted yet
         let collector = context.trace_collector();
+        assert!(collector.spans().is_empty());
+
+        // 2: some context
         let span_context_1 = SpanContext::new(Arc::clone(&collector) as Arc<_>);
         write(
             "namespace",
@@ -689,10 +696,6 @@ pub mod test_utils {
             Some(&span_context_2),
         )
         .await;
-
-        // check write 1
-        let write_1 = stream.next().await.unwrap().unwrap();
-        assert!(write_1.meta().span_context().is_none());
 
         // check write 2
         let write_2 = stream.next().await.unwrap().unwrap();

--- a/write_buffer/src/kafka/aggregator.rs
+++ b/write_buffer/src/kafka/aggregator.rs
@@ -11,7 +11,11 @@ use rskafka::{
 };
 use schema::selection::Selection;
 use time::{Time, TimeProvider};
-use trace::{ctx::SpanContext, span::SpanRecorder, TraceCollector};
+use trace::{
+    ctx::SpanContext,
+    span::{Span, SpanRecorder},
+    TraceCollector,
+};
 
 use crate::codec::{ContentType, IoxHeaders};
 
@@ -77,9 +81,10 @@ impl WriteAggregator {
             }
             (None, Some(ctx)) => {
                 // got a context but don't have a recorder yet => create a recorder and record span
-                let mut recorder_inner = SpanRecorder::new(collector.as_ref().map(|collector| {
-                    SpanContext::new(Arc::clone(collector)).child("write buffer aggregator")
-                }));
+                let mut recorder_inner =
+                    SpanRecorder::new(collector.as_ref().map(|collector| {
+                        Span::root("write buffer aggregator", Arc::clone(collector))
+                    }));
                 recorder_inner.link(ctx);
                 *recorder = Some(recorder_inner);
             }

--- a/write_buffer/src/kafka/aggregator.rs
+++ b/write_buffer/src/kafka/aggregator.rs
@@ -33,10 +33,13 @@ struct WriteAggregator {
     tables: HashMap<String, MutableBatch>,
 
     /// Span recorder to link spans from incoming writes to aggregated write.
-    span_recorder: SpanRecorder,
+    span_recorder: Option<SpanRecorder>,
 
     /// Tag, so we can later find the offset of the produced record.
     tag: Tag,
+
+    /// Trace collector
+    collector: Option<Arc<dyn TraceCollector>>,
 }
 
 impl WriteAggregator {
@@ -46,19 +49,44 @@ impl WriteAggregator {
             .tables()
             .map(|(name, batch)| (name.to_owned(), batch.clone()))
             .collect();
-        let mut span_recorder = SpanRecorder::new(
-            collector.map(|collector| SpanContext::new(collector).child("write buffer aggregator")),
-        );
 
-        if let Some(ctx) = write.meta().span_context() {
-            span_recorder.link(ctx);
-        }
+        let mut span_recorder = None;
+        Self::record_span(&mut span_recorder, write.meta().span_context(), &collector);
 
         Self {
             namespace: write.namespace().to_owned(),
             tables,
             span_recorder,
             tag,
+            collector,
+        }
+    }
+
+    /// Fold new trace into existing one
+    fn record_span(
+        recorder: &mut Option<SpanRecorder>,
+        ctx: Option<&SpanContext>,
+        collector: &Option<Arc<dyn TraceCollector>>,
+    ) {
+        match (recorder.as_mut(), ctx) {
+            (None, None) => {
+                // no existing recorder and no context => nothing to trace
+            }
+            (Some(_recorder), None) => {
+                // existing recorder but no context => just keep the existing recorder
+            }
+            (None, Some(ctx)) => {
+                // got a context but don't have a recorder yet => create a recorder and record span
+                let mut recorder_inner = SpanRecorder::new(collector.as_ref().map(|collector| {
+                    SpanContext::new(Arc::clone(collector)).child("write buffer aggregator")
+                }));
+                recorder_inner.link(ctx);
+                *recorder = Some(recorder_inner);
+            }
+            (Some(recorder), Some(ctx)) => {
+                // got context and already has a recorder => just record it
+                recorder.link(ctx);
+            }
         }
     }
 
@@ -101,22 +129,24 @@ impl WriteAggregator {
                 .or_insert_with(|| batch.clone());
         }
 
-        if let Some(ctx) = write.meta().span_context() {
-            self.span_recorder.link(ctx);
-        }
+        Self::record_span(
+            &mut self.span_recorder,
+            write.meta().span_context(),
+            &self.collector,
+        );
     }
 
     /// Flush aggregator to a ready-to-use DML write.
     fn flush(mut self) -> DmlWrite {
-        self.span_recorder.ok("aggregated");
-
         // attach a span if there is at least 1 active link
-        let meta = DmlMeta::unsequenced(
-            self.span_recorder
-                .span()
-                .map(|span| (!span.ctx.links.is_empty()).then(|| span.ctx.clone()))
-                .flatten(),
-        );
+        let ctx = if let Some(span_recorder) = self.span_recorder.as_mut() {
+            span_recorder.ok("aggregated");
+            span_recorder.span().map(|span| span.ctx.clone())
+        } else {
+            None
+        };
+
+        let meta = DmlMeta::unsequenced(ctx);
         DmlWrite::new(self.namespace, self.tables, meta)
     }
 


### PR DESCRIPTION
Fix a few edge cases in our traces that came up when using this functionality in our test bench. Jaeger is now a bit more happy. Sadly it doesn't really like our links due to https://github.com/jaegertracing/jaeger-ui/issues/662 and it's a bit cumbersome to navigate them.