### PR TITLE
feat: add timed/quiet output for storage CLI

### DIFF
--- a/influxdb_iox/src/commands/storage/response.rs
+++ b/influxdb_iox/src/commands/storage/response.rs
@@ -43,9 +43,8 @@ pub fn pretty_print_frames(frames: &[Data]) -> Result<()> {
     let rbs = frames_to_record_batches(frames)?;
     for (k, rb) in rbs {
         println!("\n_measurement: {}", k);
-        println!("rows: {:?}", &rb.num_rows());
+        println!("rows: {:?}\n", &rb.num_rows());
         print_batches(&[rb]).context(ArrowSnafu)?;
-        println!("\n");
     }
     Ok(())
 }


### PR DESCRIPTION
This PR adds a new flag to the storage CLI command: `--format`. This flag accepts two options right now: `pretty` (emit pretty printed tables) and `quiet` (don't emit anything).

Naturally, a future format might be "raw frames" or some other formats that could help with debugging.

In all cases, the execution time to get the results from the query engine are timed and emitted.

```
⇒  influxdb_iox storage 0000000000000123_0000000000000123 read-filter 

_measurement: air_temperature
rows: 12

+--------------+-------+-------------------+------------------------+-------------------------------+
| location     | state | sea_level_degrees | tenk_feet_feet_degrees | time                          |
+--------------+-------+-------------------+------------------------+-------------------------------+
| coyote_creek | CA    | 77.2              |                        | 1970-01-01 00:00:01.568756160 |
| coyote_creek | CA    | 77.1              |                        | 1970-01-01 00:00:01.600756160 |
| coyote_creek | CA    |                   | 40.8                   | 1970-01-01 00:00:01.568756160 |
| coyote_creek | CA    |                   | 41                     | 1970-01-01 00:00:01.600756160 |
| puget_sound  | WA    | 77.5              |                        | 1970-01-01 00:00:01.568756160 |
| puget_sound  | WA    | 78                |                        | 1970-01-01 00:00:01.600756160 |
| puget_sound  | WA    |                   | 41.1                   | 1970-01-01 00:00:01.568756160 |
| puget_sound  | WA    |                   | 40.9                   | 1970-01-01 00:00:01.600756160 |
| santa_monica | CA    | 77.3              |                        | 1970-01-01 00:00:01.568756160 |
| santa_monica | CA    | 77.6              |                        | 1970-01-01 00:00:01.600756160 |
| santa_monica | CA    |                   | 40                     | 1970-01-01 00:00:01.568756160 |
| santa_monica | CA    |                   | 40.9                   | 1970-01-01 00:00:01.600756160 |
+--------------+-------+-------------------+------------------------+-------------------------------+

_measurement: h2o_temperature
rows: 12

+--------------+-------+----------------+-----------------+-------------------------------+
| location     | state | bottom_degrees | surface_degrees | time                          |
+--------------+-------+----------------+-----------------+-------------------------------+
| coyote_creek | CA    | 51.3           |                 | 1970-01-01 00:00:01.568756160 |
| coyote_creek | CA    | 50.9           |                 | 1970-01-01 00:00:01.600756160 |
| coyote_creek | CA    |                | 55.1            | 1970-01-01 00:00:01.568756160 |
| coyote_creek | CA    |                | 50.2            | 1970-01-01 00:00:01.600756160 |
| puget_sound  | WA    | 40.2           |                 | 1970-01-01 00:00:01.568756160 |
| puget_sound  | WA    | 40.1           |                 | 1970-01-01 00:00:01.600756160 |
| puget_sound  | WA    |                | 55.8            | 1970-01-01 00:00:01.568756160 |
| puget_sound  | WA    |                | 54.7            | 1970-01-01 00:00:01.600756160 |
| santa_monica | CA    | 50.4           |                 | 1970-01-01 00:00:01.568756160 |
| santa_monica | CA    | 49.2           |                 | 1970-01-01 00:00:01.600756160 |
| santa_monica | CA    |                | 65.2            | 1970-01-01 00:00:01.568756160 |
| santa_monica | CA    |                | 63.6            | 1970-01-01 00:00:01.600756160 |
+--------------+-------+----------------+-----------------+-------------------------------+
Query execution: 7.355833ms
```

and with `--format quiet`:

```
⇒  influxdb_iox storage 0000000000000123_0000000000000123 read-filter --format quiet
Query execution: 5.044416ms
```