### PR TITLE
feat: add read_window_aggregate storage sub-command

### DIFF
--- a/influxdb_iox/src/commands/storage/request.rs
+++ b/influxdb_iox/src/commands/storage/request.rs
@@ -2,11 +2,21 @@ pub mod generated_types {
     pub use generated_types::influxdata::platform::storage::*;
 }
 
+use snafu::Snafu;
+
 use self::generated_types::*;
 use super::response::{
     tag_key_is_field, tag_key_is_measurement, FIELD_TAG_KEY_BIN, MEASUREMENT_TAG_KEY_BIN,
 };
 use ::generated_types::google::protobuf::*;
+
+#[derive(Debug, Snafu)]
+pub enum Request {
+    #[snafu(display("duration {:?} too large", d))]
+    Duration { d: std::time::Duration },
+}
+
+pub type Result<T, E = Request> = std::result::Result<T, E>;
 
 pub fn read_filter(
     org_bucket: Any,
@@ -21,6 +31,39 @@ pub fn read_filter(
         key_sort: read_filter_request::KeySort::Unspecified as i32, // IOx doesn't support any other sort
         tag_key_meta_names: TagKeyMetaNames::Text as i32,
     }
+}
+
+pub fn read_window_aggregate(
+    org_bucket: Any,
+    start: i64,
+    stop: i64,
+    predicate: std::option::Option<Predicate>,
+    every: std::time::Duration,
+    offset: std::time::Duration,
+    aggregates: Vec<Aggregate>,
+    window: std::option::Option<Window>,
+) -> Result<ReadWindowAggregateRequest, Request> {
+    let window_every = if every.as_nanos() > i64::MAX as u128 {
+        return DurationSnafu { d: every }.fail();
+    } else {
+        every.as_nanos() as i64
+    };
+
+    let offset = if offset.as_nanos() > i64::MAX as u128 {
+        return DurationSnafu { d: offset }.fail();
+    } else {
+        offset.as_nanos() as i64
+    };
+
+    Ok(generated_types::ReadWindowAggregateRequest {
+        predicate,
+        read_source: Some(org_bucket),
+        range: Some(TimestampRange { start, end: stop }),
+        window_every,
+        offset,
+        aggregate: aggregates,
+        window,
+    })
 }
 
 pub fn tag_values(
@@ -46,10 +89,68 @@ pub fn tag_values(
     }
 }
 
+#[cfg(test)]
+mod test_super {
+    use std::num::NonZeroU64;
+
+    use influxdb_storage_client::{Client, OrgAndBucket};
+
+    use super::*;
+
+    #[test]
+    fn test_read_window_aggregate_durations() {
+        let org_bucket = Client::read_source(
+            &OrgAndBucket::new(
+                NonZeroU64::new(123_u64).unwrap(),
+                NonZeroU64::new(456_u64).unwrap(),
+            ),
+            0,
+        );
+
+        let got = read_window_aggregate(
+            org_bucket.clone(),
+            1,
+            10,
+            None,
+            std::time::Duration::from_millis(3),
+            std::time::Duration::from_millis(2),
+            vec![],
+            None,
+        )
+        .unwrap();
+
+        assert_eq!(got.window_every, 3_000_000);
+        assert_eq!(got.offset, 2_000_000);
+
+        let got = read_window_aggregate(
+            org_bucket.clone(),
+            1,
+            10,
+            None,
+            std::time::Duration::from_secs(u64::MAX),
+            std::time::Duration::from_millis(2),
+            vec![],
+            None,
+        );
+        assert!(got.is_err());
+
+        let got = read_window_aggregate(
+            org_bucket,
+            1,
+            10,
+            None,
+            std::time::Duration::from_secs(3),
+            std::time::Duration::from_secs(u64::MAX),
+            vec![],
+            None,
+        );
+        assert!(got.is_err());
+    }
+}
+
 // TODO Add the following helpers for building requests:
 //
 // * read_group
-// * read_window_aggregate
 // * tag_keys
 // * tag_values_with_measurement_and_key
 // * measurement_names


### PR DESCRIPTION
Towards #3598

This PR adds support for `read_window_aggregate` to the `storage` CLI tool. Since the responses from this RPC call don't include any group frames they can be emitted via the `pretty` output format that `read_filter` uses.

## Notes

* One thing note here is that the operator can provide human readable durations for the windowing and offset properties, e.g., `--window-every 23m` or `--offset 46ms`.
* Another thing of note is that I'm not sure if we need to set one of the `window` (enum) properties of the RPC message if we are already setting the `every` and `offset` fields anyway. I think one overrides the other. I added the ability to easily hook up the other one though if needed in the future.

## Example:

```
⇒  influxdb_iox storage 0000000000000123_0000000000000123 read-window-aggregate --window-every 1h --offset 0s --aggregate count 

_measurement: air_temperature
rows: 6

+--------------+-------+-------------------+------------------------+---------------------+
| location     | state | sea_level_degrees | tenk_feet_feet_degrees | time                |
+--------------+-------+-------------------+------------------------+---------------------+
| coyote_creek | CA    | 2                 |                        | 1970-01-01 01:00:00 |
| coyote_creek | CA    |                   | 2                      | 1970-01-01 01:00:00 |
| puget_sound  | WA    | 2                 |                        | 1970-01-01 01:00:00 |
| puget_sound  | WA    |                   | 2                      | 1970-01-01 01:00:00 |
| santa_monica | CA    | 2                 |                        | 1970-01-01 01:00:00 |
| santa_monica | CA    |                   | 2                      | 1970-01-01 01:00:00 |
+--------------+-------+-------------------+------------------------+---------------------+

_measurement: h2o_temperature
rows: 6

+--------------+-------+----------------+-----------------+---------------------+
| location     | state | bottom_degrees | surface_degrees | time                |
+--------------+-------+----------------+-----------------+---------------------+
| coyote_creek | CA    | 2              |                 | 1970-01-01 01:00:00 |
| coyote_creek | CA    |                | 2               | 1970-01-01 01:00:00 |
| puget_sound  | WA    | 2              |                 | 1970-01-01 01:00:00 |
| puget_sound  | WA    |                | 2               | 1970-01-01 01:00:00 |
| santa_monica | CA    | 2              |                 | 1970-01-01 01:00:00 |
| santa_monica | CA    |                | 2               | 1970-01-01 01:00:00 |
+--------------+-------+----------------+-----------------+---------------------+
Query execution: 53.277666ms
```