### PR TITLE
feat: split & assign partition key in router

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3191,7 +3191,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87f5ec2493a61ac0506c0f4199f99070cbe83857b0337006a30f3e6719b8ef58"
 dependencies = [
  "lock_api",
- "parking_lot_core 0.9.0",
+ "parking_lot_core 0.9.1",
 ]
 
 [[package]]
@@ -3210,15 +3210,15 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2f4f894f3865f6c0e02810fc597300f34dc2510f66400da262d8ae10e75767d"
+checksum = "28141e0cc4143da2443301914478dc976a61ffdb3f043058310c70df2fed8954"
 dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-sys 0.29.0",
+ "windows-sys 0.32.0",
 ]
 
 [[package]]
@@ -4082,7 +4082,9 @@ dependencies = [
  "generated_types",
  "hashbrown 0.12.0",
  "hyper",
+ "influxdb_line_protocol",
  "iox_catalog",
+ "lazy_static",
  "metric",
  "mutable_batch",
  "mutable_batch_lp",
@@ -4090,6 +4092,7 @@ dependencies = [
  "parking_lot 0.12.0",
  "paste",
  "predicate",
+ "pretty_assertions",
  "rand",
  "schema",
  "serde",
@@ -5816,19 +5819,6 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ceb069ac8b2117d36924190469735767f0990833935ab430155e71a44bafe148"
-dependencies = [
- "windows_aarch64_msvc 0.29.0",
- "windows_i686_gnu 0.29.0",
- "windows_i686_msvc 0.29.0",
- "windows_x86_64_gnu 0.29.0",
- "windows_x86_64_msvc 0.29.0",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "030b7ff91626e57a05ca64a07c481973cbb2db774e4852c9c7ca342408c6a99a"
@@ -5841,10 +5831,17 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows_aarch64_msvc"
-version = "0.29.0"
+name = "windows-sys"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d027175d00b01e0cbeb97d6ab6ebe03b12330a35786cbaca5252b1c4bf5d9b"
+checksum = "3df6e476185f92a12c072be4a189a0210dcdcf512a1891d6dff9edb874deadc6"
+dependencies = [
+ "windows_aarch64_msvc 0.32.0",
+ "windows_i686_gnu 0.32.0",
+ "windows_i686_msvc 0.32.0",
+ "windows_x86_64_gnu 0.32.0",
+ "windows_x86_64_msvc 0.32.0",
+]
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -5853,10 +5850,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29277a4435d642f775f63c7d1faeb927adba532886ce0287bd985bffb16b6bca"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.29.0"
+name = "windows_aarch64_msvc"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8793f59f7b8e8b01eda1a652b2697d87b93097198ae85f823b969ca5b89bba58"
+checksum = "d8e92753b1c443191654ec532f14c199742964a061be25d77d7a96f09db20bf5"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -5865,10 +5862,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1145e1989da93956c68d1864f32fb97c8f561a8f89a5125f6a2b7ea75524e4b8"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.29.0"
+name = "windows_i686_gnu"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8602f6c418b67024be2996c512f5f995de3ba417f4c75af68401ab8756796ae4"
+checksum = "6a711c68811799e017b6038e0922cb27a5e2f43a2ddb609fe0b6f3eeda9de615"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -5877,10 +5874,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4a09e3a0d4753b73019db171c1339cd4362c8c44baf1bcea336235e955954a6"
 
 [[package]]
-name = "windows_x86_64_gnu"
-version = "0.29.0"
+name = "windows_i686_msvc"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3d615f419543e0bd7d2b3323af0d86ff19cbc4f816e6453f36a2c2ce889c354"
+checksum = "146c11bb1a02615db74680b32a68e2d61f553cc24c4eb5b4ca10311740e44172"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -5889,16 +5886,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ca64fcb0220d58db4c119e050e7af03c69e6f4f415ef69ec1773d9aab422d5a"
 
 [[package]]
-name = "windows_x86_64_msvc"
-version = "0.29.0"
+name = "windows_x86_64_gnu"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11d95421d9ed3672c280884da53201a5c46b7b2765ca6faf34b0d71cf34a3561"
+checksum = "c912b12f7454c6620635bbff3450962753834be2a594819bd5e945af18ec64bc"
 
 [[package]]
 name = "windows_x86_64_msvc"
 version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08cabc9f0066848fef4bc6a1c1668e6efce38b661d2aeec75d18d8617eebb5f1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "504a2476202769977a040c6364301a3f65d0cc9e3fb08600b2bda150a0488316"
 
 [[package]]
 name = "winreg"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1887,6 +1887,7 @@ dependencies = [
  "logfmt",
  "metric",
  "metric_exporters",
+ "mutable_batch",
  "mutable_batch_lp",
  "mutable_batch_pb",
  "mutable_buffer",

--- a/influxdb_iox/Cargo.toml
+++ b/influxdb_iox/Cargo.toml
@@ -24,6 +24,7 @@ job_registry = { path = "../job_registry" }
 logfmt = { path = "../logfmt" }
 metric = { path = "../metric" }
 metric_exporters = { path = "../metric_exporters" }
+mutable_batch = { path = "../mutable_batch" }
 mutable_batch_lp = { path = "../mutable_batch_lp" }
 mutable_batch_pb = { path = "../mutable_batch_pb" }
 mutable_buffer = { path = "../mutable_buffer" }

--- a/influxdb_iox/src/influxdb_ioxd/server_type/router2.rs
+++ b/influxdb_iox/src/influxdb_ioxd/server_type/router2.rs
@@ -4,8 +4,10 @@ use std::{
 };
 
 use async_trait::async_trait;
+use hashbrown::HashMap;
 use hyper::{Body, Request, Response};
 use metric::Registry;
+use mutable_batch::MutableBatch;
 use router2::{dml_handlers::DmlHandler, server::RouterServer};
 use tokio_util::sync::CancellationToken;
 use trace::TraceCollector;
@@ -36,7 +38,7 @@ impl<D> RouterServerType<D> {
 #[async_trait]
 impl<D> ServerType for RouterServerType<D>
 where
-    D: DmlHandler + 'static,
+    D: DmlHandler<WriteInput = HashMap<String, MutableBatch>> + 'static,
 {
     type RouteError = IoxHttpErrorAdaptor;
 

--- a/influxdb_iox/src/influxdb_ioxd/server_type/router2.rs
+++ b/influxdb_iox/src/influxdb_ioxd/server_type/router2.rs
@@ -4,10 +4,8 @@ use std::{
 };
 
 use async_trait::async_trait;
-use hashbrown::HashMap;
 use hyper::{Body, Request, Response};
 use metric::Registry;
-use mutable_batch::MutableBatch;
 use router2::{dml_handlers::DmlHandler, server::RouterServer};
 use tokio_util::sync::CancellationToken;
 use trace::TraceCollector;
@@ -38,7 +36,7 @@ impl<D> RouterServerType<D> {
 #[async_trait]
 impl<D> ServerType for RouterServerType<D>
 where
-    D: DmlHandler<WriteInput = HashMap<String, MutableBatch>> + 'static,
+    D: DmlHandler<WriteInput = String> + 'static,
 {
     type RouteError = IoxHttpErrorAdaptor;
 

--- a/router2/Cargo.toml
+++ b/router2/Cargo.toml
@@ -15,6 +15,7 @@ futures = "0.3.19"
 generated_types = { path = "../generated_types" }
 hashbrown = "0.12"
 hyper = "0.14"
+influxdb_line_protocol = { version = "0.1.0", path = "../influxdb_line_protocol" }
 iox_catalog = { path = "../iox_catalog" }
 metric = { path = "../metric" }
 mutable_batch = { path = "../mutable_batch" }
@@ -36,7 +37,9 @@ write_buffer = { path = "../write_buffer" }
 [dev-dependencies]
 assert_matches = "1.5"
 criterion = { version = "0.3.4", features = ["async_tokio", "html_reports"] }
+lazy_static = "1.4.0"
 paste = "1.0.6"
+pretty_assertions = "1.1.0"
 rand = "0.8.3"
 schema = { path = "../schema" }
 

--- a/router2/src/dml_handlers/mock.rs
+++ b/router2/src/dml_handlers/mock.rs
@@ -71,11 +71,12 @@ macro_rules! record_and_return {
 impl DmlHandler for Arc<MockDmlHandler> {
     type WriteError = DmlError;
     type DeleteError = DmlError;
+    type WriteInput = HashMap<String, MutableBatch>;
 
     async fn write(
         &self,
         namespace: DatabaseName<'static>,
-        batches: HashMap<String, MutableBatch>,
+        batches: Self::WriteInput,
         _span_ctx: Option<SpanContext>,
     ) -> Result<(), Self::WriteError> {
         record_and_return!(

--- a/router2/src/dml_handlers/mock.rs
+++ b/router2/src/dml_handlers/mock.rs
@@ -1,20 +1,18 @@
-use std::{collections::VecDeque, sync::Arc};
+use std::{collections::VecDeque, fmt::Debug, sync::Arc};
 
 use async_trait::async_trait;
 use data_types::{delete_predicate::DeletePredicate, DatabaseName};
 
-use hashbrown::HashMap;
-use mutable_batch::MutableBatch;
 use parking_lot::Mutex;
 use trace::ctx::SpanContext;
 
 use super::{DmlError, DmlHandler};
 
 #[derive(Debug, Clone)]
-pub enum MockDmlHandlerCall {
+pub enum MockDmlHandlerCall<W> {
     Write {
         namespace: String,
-        batches: HashMap<String, MutableBatch>,
+        batches: W,
     },
     Delete {
         namespace: String,
@@ -23,23 +21,42 @@ pub enum MockDmlHandlerCall {
     },
 }
 
-#[derive(Debug, Default)]
-struct Inner {
-    calls: Vec<MockDmlHandlerCall>,
+#[derive(Debug)]
+struct Inner<W> {
+    calls: Vec<MockDmlHandlerCall<W>>,
     write_return: VecDeque<Result<(), DmlError>>,
     delete_return: VecDeque<Result<(), DmlError>>,
 }
 
-impl Inner {
-    fn record_call(&mut self, call: MockDmlHandlerCall) {
+impl<W> Default for Inner<W> {
+    fn default() -> Self {
+        Self {
+            calls: Default::default(),
+            write_return: Default::default(),
+            delete_return: Default::default(),
+        }
+    }
+}
+
+impl<W> Inner<W> {
+    fn record_call(&mut self, call: MockDmlHandlerCall<W>) {
         self.calls.push(call);
     }
 }
 
-#[derive(Debug, Default)]
-pub struct MockDmlHandler(Mutex<Inner>);
+#[derive(Debug)]
+pub struct MockDmlHandler<W>(Mutex<Inner<W>>);
 
-impl MockDmlHandler {
+impl<W> Default for MockDmlHandler<W> {
+    fn default() -> Self {
+        Self(Default::default())
+    }
+}
+
+impl<W> MockDmlHandler<W>
+where
+    W: Clone,
+{
     pub fn with_write_return(self, ret: impl Into<VecDeque<Result<(), DmlError>>>) -> Self {
         self.0.lock().write_return = ret.into();
         self
@@ -50,7 +67,7 @@ impl MockDmlHandler {
         self
     }
 
-    pub fn calls(&self) -> Vec<MockDmlHandlerCall> {
+    pub fn calls(&self) -> Vec<MockDmlHandlerCall<W>> {
         self.0.lock().calls.clone()
     }
 }
@@ -68,10 +85,13 @@ macro_rules! record_and_return {
 }
 
 #[async_trait]
-impl DmlHandler for Arc<MockDmlHandler> {
+impl<W> DmlHandler for Arc<MockDmlHandler<W>>
+where
+    W: Debug + Send + Sync,
+{
     type WriteError = DmlError;
     type DeleteError = DmlError;
-    type WriteInput = HashMap<String, MutableBatch>;
+    type WriteInput = W;
 
     async fn write(
         &self,

--- a/router2/src/dml_handlers/mod.rs
+++ b/router2/src/dml_handlers/mod.rs
@@ -78,5 +78,8 @@ pub use sharded_write_buffer::*;
 mod ns_autocreation;
 pub use ns_autocreation::*;
 
+mod partitioner;
+pub use partitioner::*;
+
 #[cfg(test)]
 pub mod mock;

--- a/router2/src/dml_handlers/nop.rs
+++ b/router2/src/dml_handlers/nop.rs
@@ -18,11 +18,12 @@ pub struct NopDmlHandler;
 impl DmlHandler for NopDmlHandler {
     type WriteError = DmlError;
     type DeleteError = DmlError;
+    type WriteInput = HashMap<String, MutableBatch>;
 
     async fn write(
         &self,
         namespace: DatabaseName<'static>,
-        batches: HashMap<String, MutableBatch>,
+        batches: Self::WriteInput,
         _span_ctx: Option<SpanContext>,
     ) -> Result<(), Self::WriteError> {
         info!(%namespace, ?batches, "dropping write operation");

--- a/router2/src/dml_handlers/ns_autocreation.rs
+++ b/router2/src/dml_handlers/ns_autocreation.rs
@@ -1,10 +1,8 @@
-use std::sync::Arc;
+use std::{fmt::Debug, sync::Arc};
 
 use async_trait::async_trait;
 use data_types::{delete_predicate::DeletePredicate, DatabaseName};
-use hashbrown::HashMap;
 use iox_catalog::interface::{Catalog, KafkaTopicId, QueryPoolId};
-use mutable_batch::MutableBatch;
 use observability_deps::tracing::*;
 use thiserror::Error;
 use trace::ctx::SpanContext;
@@ -71,15 +69,18 @@ impl<D, C> NamespaceAutocreation<D, C> {
 }
 
 #[async_trait]
-impl<D, C> DmlHandler for NamespaceAutocreation<D, C>
+impl<D, C, T> DmlHandler for NamespaceAutocreation<D, C>
 where
-    D: DmlHandler<WriteInput = HashMap<String, MutableBatch>>,
+    D: DmlHandler<WriteInput = T>,
     C: NamespaceCache,
+    T: Debug + Send + Sync + 'static,
 {
     type WriteError = NamespaceCreationError;
     type DeleteError = NamespaceCreationError;
 
-    type WriteInput = HashMap<String, MutableBatch>;
+    // This handler accepts any input type, passing it through to the next
+    // handler unmodified.
+    type WriteInput = T;
 
     /// Write `batches` to `namespace`.
     async fn write(
@@ -183,7 +184,7 @@ mod tests {
         );
 
         let catalog: Arc<dyn Catalog> = Arc::new(MemCatalog::default());
-        let mock_handler = Arc::new(MockDmlHandler::default().with_write_return([Ok(())]));
+        let mock_handler = Arc::new(MockDmlHandler::<()>::default().with_write_return([Ok(())]));
 
         let creator = NamespaceAutocreation::new(
             Arc::clone(&catalog),
@@ -195,7 +196,7 @@ mod tests {
         );
 
         creator
-            .write(ns.clone(), Default::default(), None)
+            .write(ns.clone(), (), None)
             .await
             .expect("handler should succeed");
 
@@ -227,7 +228,7 @@ mod tests {
 
         let cache = Arc::new(MemoryNamespaceCache::default());
         let catalog: Arc<dyn Catalog> = Arc::new(MemCatalog::default());
-        let mock_handler = Arc::new(MockDmlHandler::default().with_write_return([Ok(())]));
+        let mock_handler = Arc::new(MockDmlHandler::<()>::default().with_write_return([Ok(())]));
 
         let creator = NamespaceAutocreation::new(
             Arc::clone(&catalog),
@@ -239,7 +240,7 @@ mod tests {
         );
 
         creator
-            .write(ns.clone(), Default::default(), None)
+            .write(ns.clone(), (), None)
             .await
             .expect("handler should succeed");
 

--- a/router2/src/dml_handlers/ns_autocreation.rs
+++ b/router2/src/dml_handlers/ns_autocreation.rs
@@ -73,17 +73,19 @@ impl<D, C> NamespaceAutocreation<D, C> {
 #[async_trait]
 impl<D, C> DmlHandler for NamespaceAutocreation<D, C>
 where
-    D: DmlHandler,
+    D: DmlHandler<WriteInput = HashMap<String, MutableBatch>>,
     C: NamespaceCache,
 {
     type WriteError = NamespaceCreationError;
     type DeleteError = NamespaceCreationError;
 
+    type WriteInput = HashMap<String, MutableBatch>;
+
     /// Write `batches` to `namespace`.
     async fn write(
         &self,
         namespace: DatabaseName<'static>,
-        batches: HashMap<String, MutableBatch>,
+        batches: Self::WriteInput,
         span_ctx: Option<SpanContext>,
     ) -> Result<(), Self::WriteError> {
         // If the namespace does not exist in the schema cache (populated by the

--- a/router2/src/dml_handlers/partitioner.rs
+++ b/router2/src/dml_handlers/partitioner.rs
@@ -1,0 +1,449 @@
+use async_trait::async_trait;
+use data_types::{delete_predicate::DeletePredicate, DatabaseName};
+use futures::stream::{FuturesUnordered, TryStreamExt};
+use hashbrown::HashMap;
+use influxdb_line_protocol::parse_lines;
+use mutable_batch::MutableBatch;
+use mutable_batch_lp::LinesConverter;
+use observability_deps::tracing::*;
+use thiserror::Error;
+use time::{SystemProvider, TimeProvider};
+use trace::ctx::SpanContext;
+
+use super::{DmlError, DmlHandler};
+
+/// An error raised by the [`Partitioner`] handler.
+#[derive(Debug, Error)]
+pub enum PartitionError {
+    /// Failure to parse line protocol in the request.
+    #[error("error parsing line {line_idx}: {source}")]
+    LineParse {
+        /// The 1-indexed line number that caused the error.
+        line_idx: usize,
+        /// The underlying parser error.
+        source: influxdb_line_protocol::Error,
+    },
+
+    /// The line failed to apply to the batch of writes for the partition.
+    #[error("error batching line {line_idx} into write: {source}")]
+    LineBatchWrite {
+        /// The 1-indexed line number that caused the error.
+        line_idx: usize,
+        /// The underlying batch builder error.
+        source: mutable_batch::writer::Error,
+    },
+
+    /// The inner DML handler returned an error.
+    #[error(transparent)]
+    Inner(Box<DmlError>),
+}
+
+/// A decorator of `T`, tagging it with the partition key derived from it.
+#[derive(Debug, PartialEq, Clone)]
+pub struct Partitioned<T> {
+    key: String,
+    payload: T,
+}
+
+impl<T> Partitioned<T> {
+    /// Wrap `payload` with a partition `key`.
+    pub fn new(key: String, payload: T) -> Self {
+        Self { key, payload }
+    }
+
+    /// Get a reference to the partition payload.
+    pub fn payload(&self) -> &T {
+        &self.payload
+    }
+
+    /// Unwrap `Self` returning the inner payload `T` and the partition key.
+    pub fn into_parts(self) -> (String, T) {
+        (self.key, self.payload)
+    }
+}
+
+/// A [`DmlHandler`] implementation that splits line-protocol strings into
+/// partitioned [`MutableBatch`] instances by date. Deletes pass through
+/// unmodified.
+///
+/// Each partition is passed through to the inner DML handler (or chain of
+/// handlers) concurrently, aborting if an error occurs. This may allow a
+/// partial write to be observable down-stream of the [`Partitioner`] if at
+/// least one partitioned write succeeds and at least one partitioned write
+/// fails. When a partial write occurs, the handler returns an error describing
+/// the failure.
+#[derive(Debug)]
+pub struct Partitioner<D, T = SystemProvider> {
+    time_provider: T,
+    inner: D,
+}
+
+impl<D> Partitioner<D> {
+    /// Initialise a new [`Partitioner`] passing partitioned writes to `inner`.
+    pub fn new(inner: D) -> Self {
+        Self {
+            time_provider: SystemProvider::default(),
+            inner,
+        }
+    }
+}
+
+#[async_trait]
+impl<D, T> DmlHandler for Partitioner<D, T>
+where
+    D: DmlHandler<WriteInput = Partitioned<HashMap<String, MutableBatch>>>,
+    T: TimeProvider,
+{
+    type WriteError = PartitionError;
+    type DeleteError = D::DeleteError;
+
+    type WriteInput = String;
+
+    /// Parse the input line-protocol string and emit partitioned batches to the
+    /// next handler.
+    async fn write(
+        &self,
+        namespace: DatabaseName<'static>,
+        writes: Self::WriteInput,
+        span_ctx: Option<SpanContext>,
+    ) -> Result<(), Self::WriteError> {
+        // The timestamp value applied to writes that do not specify a
+        // timestamp.
+        let default_time = self.time_provider.now().timestamp_nanos();
+
+        // A collection of LineConverter instances keyed by partition (ymd date)
+        let mut partitions: HashMap<_, LinesConverter> = HashMap::default();
+
+        // Collate the individual LP lines into partitions.
+        for (i, line) in parse_lines(&writes).enumerate() {
+            let line = line.map_err(|e| PartitionError::LineParse {
+                line_idx: i + 1, // 1-based
+                source: e,
+            })?;
+
+            // Derive the partition key (the date).
+            let timestamp = line.timestamp.unwrap_or(default_time);
+            let partition_key = time::Time::from_timestamp_nanos(timestamp)
+                .date_time()
+                .date();
+
+            // Push the write into the batch builder for the partition.
+            partitions
+                .entry(partition_key)
+                .or_insert(LinesConverter::new(default_time))
+                .write_parsed_line(line)
+                .map_err(|e| PartitionError::LineBatchWrite {
+                    line_idx: i + 1,
+                    source: e,
+                })?;
+        }
+
+        // Finalise the LineConverter in each partition to produce a set of
+        // per-table MutableBatch, and dispatch all individual partitions into
+        // the next handler in the request pipeline.
+        partitions
+            .into_iter()
+            .map(|(key, batch)| {
+                let (batch, stats) = batch.finish().expect("unexpected empty batch");
+                let p = Partitioned {
+                    key: key.format("%Y-%m-%d").to_string(),
+                    payload: batch,
+                };
+
+                let namespace = namespace.clone();
+                let span_ctx = span_ctx.clone();
+                async move {
+                    self.inner
+                        .write(namespace, p, span_ctx)
+                        .await
+                        .map(|_| stats)
+                }
+            })
+            .collect::<FuturesUnordered<_>>()
+            .try_for_each(|stats| async move {
+                trace!(
+                    lines = stats.num_lines,
+                    fields = stats.num_fields,
+                    "partitioned write complete"
+                );
+                Ok(())
+            })
+            .await
+            .map_err(|e| PartitionError::Inner(Box::new(e.into())))
+    }
+
+    /// Pass the delete request through unmodified to the next handler.
+    async fn delete<'a>(
+        &self,
+        namespace: DatabaseName<'static>,
+        table_name: impl Into<String> + Send + Sync + 'a,
+        predicate: DeletePredicate,
+        span_ctx: Option<SpanContext>,
+    ) -> Result<(), Self::DeleteError> {
+        self.inner
+            .delete(namespace, table_name, predicate, span_ctx)
+            .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use assert_matches::assert_matches;
+    use lazy_static::lazy_static;
+    use time::Time;
+
+    use crate::dml_handlers::mock::{MockDmlHandler, MockDmlHandlerCall};
+
+    use super::*;
+
+    lazy_static! {
+        /// A static default time to use in tests (1971-05-02 UTC).
+        static ref DEFAULT_TIME: Time = Time::from_timestamp_nanos(42000000000000000);
+    }
+
+    // Generate a test case that partitions "lp" and calls a mock inner DML
+    // handler, which returns the values specified in "inner_write_returns".
+    //
+    // Assert the partition-to-table mapping in "want_writes" and assert the
+    // handler write() return value in "want_handler_ret".
+    macro_rules! test_write {
+        (
+            $name:ident,
+            lp = $lp:expr,
+            inner_write_returns = $inner_write_returns:expr,
+            want_writes = [$($want_writes:tt)*], // "partition key" => ["mapped", "tables"] or [unchecked] to skip assert
+            want_handler_ret = $($want_handler_ret:tt)+
+        ) => {
+            paste::paste! {
+                #[tokio::test]
+                async fn [<test_write_ $name>]() {
+                    use pretty_assertions::assert_eq;
+                    let default_time = time::MockProvider::new(*DEFAULT_TIME);
+
+                    let inner = Arc::new(MockDmlHandler::default().with_write_return($inner_write_returns));
+                    let partitioner = Partitioner {
+                        time_provider: default_time,
+                        inner: Arc::clone(&inner),
+                    };
+                    let ns = DatabaseName::new("bananas").expect("valid db name");
+
+                    let writes = $lp.to_string();
+                    let handler_ret = partitioner.write(ns.clone(), writes, None).await;
+                    assert_matches!(handler_ret, $($want_handler_ret)+);
+
+                    // Collect writes into a <partition_key, table_names> map.
+                    let calls = inner.calls().into_iter().map(|v| match v {
+                        MockDmlHandlerCall::Write { namespace, batches, .. } => {
+                            assert_eq!(namespace, *ns);
+
+                            // Extract the table names for comparison
+                            let mut tables = batches
+                                .payload
+                                .keys()
+                                .cloned()
+                                .collect::<Vec<String>>();
+
+                            tables.sort();
+
+                            (batches.key.clone(), tables)
+                        },
+                        MockDmlHandlerCall::Delete { .. } => unreachable!("mock should not observe deletes"),
+                    })
+                    .collect::<HashMap<String, _>>();
+
+                    test_write!(@assert_writes, calls, $($want_writes)*);
+                }
+            }
+        };
+
+        // Generate a NOP that doesn't assert the writes if "unchecked" is
+        // specified.
+        //
+        // This is useful for tests that cause non-deterministic partial writes.
+        (@assert_writes, $got:ident, unchecked) => { let _x = $got; };
+
+        // Generate a block of code that validates tokens in the form of:
+        //
+        //      key => ["table", "names"]
+        //
+        // Matches the partition key / tables names observed by the mock.
+        (@assert_writes, $got:ident, $($partition_key:expr => $want_tables:expr, )*) => {
+            // Construct the desired writes, keyed by partition key
+            #[allow(unused_mut)]
+            let mut want_writes: HashMap<String, _> = Default::default();
+            $(
+                let mut want: Vec<String> = $want_tables.into_iter().map(|t| t.to_string()).collect();
+                want.sort();
+                want_writes.insert($partition_key.to_string(), want);
+            )*
+
+            assert_eq!(want_writes, $got);
+        };
+    }
+
+    test_write!(
+        single_partition_ok,
+        lp = "\
+            bananas,tag1=A,tag2=B val=42i 1\n\
+            platanos,tag1=A,tag2=B value=42i 2\n\
+            another,tag1=A,tag2=B value=42i 3\n\
+            bananas,tag1=A,tag2=B val=42i 2\n\
+            table,tag1=A,tag2=B val=42i 1\n\
+        ",
+        inner_write_returns = [Ok(())],
+        want_writes = [
+            // Attempted write recorded by the mock
+            "1970-01-01" => ["bananas", "platanos", "another", "table"],
+        ],
+        want_handler_ret = Ok(())
+    );
+
+    test_write!(
+        single_partition_err,
+        lp = "\
+            bananas,tag1=A,tag2=B val=42i 1\n\
+            platanos,tag1=A,tag2=B value=42i 2\n\
+            another,tag1=A,tag2=B value=42i 3\n\
+            bananas,tag1=A,tag2=B val=42i 2\n\
+            table,tag1=A,tag2=B val=42i 1\n\
+        ",
+        inner_write_returns = [Err(DmlError::DatabaseNotFound("missing".to_owned()))],
+        want_writes = [
+            // Attempted write recorded by the mock
+            "1970-01-01" => ["bananas", "platanos", "another", "table"],
+        ],
+        want_handler_ret = Err(PartitionError::Inner(e)) => {
+            assert_matches!(*e, DmlError::DatabaseNotFound(_));
+        }
+    );
+
+    test_write!(
+        multiple_partitions_ok,
+        lp = "\
+            bananas,tag1=A,tag2=B val=42i 1\n\
+            platanos,tag1=A,tag2=B value=42i 1465839830100400200\n\
+            another,tag1=A,tag2=B value=42i 1465839830100400200\n\
+            bananas,tag1=A,tag2=B val=42i 2\n\
+            table,tag1=A,tag2=B val=42i 1644347270670952000\n\
+        ",
+        inner_write_returns = [Ok(()), Ok(()), Ok(())],
+        want_writes = [
+            "1970-01-01" => ["bananas"],
+            "2016-06-13" => ["platanos", "another"],
+            "2022-02-08" => ["table"],
+        ],
+        want_handler_ret = Ok(())
+    );
+
+    test_write!(
+        multiple_partitions_total_err,
+        lp = "\
+            bananas,tag1=A,tag2=B val=42i 1\n\
+            platanos,tag1=A,tag2=B value=42i 1465839830100400200\n\
+            another,tag1=A,tag2=B value=42i 1465839830100400200\n\
+            bananas,tag1=A,tag2=B val=42i 2\n\
+            table,tag1=A,tag2=B val=42i 1644347270670952000\n\
+        ",
+        inner_write_returns = [
+            Err(DmlError::DatabaseNotFound("missing".to_owned())),
+            Err(DmlError::DatabaseNotFound("missing".to_owned())),
+            Err(DmlError::DatabaseNotFound("missing".to_owned())),
+        ],
+        want_writes = [unchecked],
+        want_handler_ret = Err(PartitionError::Inner(e)) => {
+            assert_matches!(*e, DmlError::DatabaseNotFound(_));
+        }
+    );
+
+    test_write!(
+        multiple_partitions_partial_err,
+        lp = "\
+            bananas,tag1=A,tag2=B val=42i 1\n\
+            platanos,tag1=A,tag2=B value=42i 1465839830100400200\n\
+            another,tag1=A,tag2=B value=42i 1465839830100400200\n\
+            bananas,tag1=A,tag2=B val=42i 2\n\
+            table,tag1=A,tag2=B val=42i 1644347270670952000\n\
+        ",
+        inner_write_returns = [
+            Err(DmlError::DatabaseNotFound("missing".to_owned())),
+            Ok(()),
+            Ok(()),
+        ],
+        want_writes = [unchecked],
+        want_handler_ret = Err(PartitionError::Inner(e)) => {
+            assert_matches!(*e, DmlError::DatabaseNotFound(_));
+        }
+    );
+
+    test_write!(
+        no_specified_timestamp,
+        lp = "\
+            bananas,tag1=A,tag2=B val=42i\n\
+            platanos,tag1=A,tag2=B value=42i\n\
+            another,tag1=A,tag2=B value=42i\n\
+            bananas,tag1=A,tag2=B val=42i\n\
+            table,tag1=A,tag2=B val=42i\n\
+        ",
+        inner_write_returns = [Ok(())],
+        want_writes = [
+            "1971-05-02" => ["bananas", "platanos", "another", "table"],
+        ],
+        want_handler_ret = Ok(())
+    );
+
+    test_write!(
+        single_partition_conflicting_schema,
+        lp = "\
+            bananas,tag1=A,tag2=B val=42i\n\
+            bananas,tag1=A,tag2=B val=42.0\n\
+        ",
+        inner_write_returns = [],
+        want_writes = [],
+        want_handler_ret = Err(PartitionError::LineBatchWrite{line_idx, source}) => {
+            assert_eq!(line_idx, 2);
+            assert_matches!(source, mutable_batch::writer::Error::TypeMismatch{..});
+        }
+    );
+
+    test_write!(
+        invalid_lp,
+        lp = "platanos is a word that means bananas",
+        inner_write_returns = [],
+        want_writes = [],
+        want_handler_ret = Err(PartitionError::LineParse { .. })
+    );
+
+    // Writes destined for different partitions wind up in different
+    // MutableBatch instances, and therefore conflicting schemas are not
+    // observed in one batch, and the conflicts pass through this handler
+    // without raising an error.
+    //
+    // These conflicting writes will identified and validated once they pass
+    // through the schema validator handler (which is responsible for this kind
+    // of enforcement).
+    test_write!(
+        multiple_partition_conflicting_schema,
+        lp = "\
+            bananas,tag1=A,tag2=B val=42i 1\n\
+            platanos,tag1=A,tag2=B val=42.0 1644347270670952000\n\
+        ",
+        inner_write_returns = [Ok(()), Ok(())],
+        want_writes = [
+            "1970-01-01" => ["bananas"],
+            "2022-02-08" => ["platanos"],
+        ],
+        want_handler_ret = Ok(())
+    );
+
+    // This handler does not treat an empty write as an error, though another
+    // handler in the chain that depends on a non-empty write may.
+    test_write!(
+        empty_write,
+        lp = "",
+        inner_write_returns = [],
+        want_writes = [],
+        want_handler_ret = Ok(())
+    );
+}

--- a/router2/src/dml_handlers/schema_validation.rs
+++ b/router2/src/dml_handlers/schema_validation.rs
@@ -14,7 +14,7 @@ use trace::ctx::SpanContext;
 
 use crate::namespace_cache::{MemoryNamespaceCache, NamespaceCache};
 
-use super::{DmlError, DmlHandler};
+use super::{DmlError, DmlHandler, Partitioned};
 
 /// Errors emitted during schema validation.
 #[derive(Debug, Error)]
@@ -106,13 +106,13 @@ impl<D, C> SchemaValidator<D, C> {
 #[async_trait]
 impl<D, C> DmlHandler for SchemaValidator<D, C>
 where
-    D: DmlHandler<WriteInput = HashMap<String, MutableBatch>>,
+    D: DmlHandler<WriteInput = Partitioned<HashMap<String, MutableBatch>>>,
     C: NamespaceCache,
 {
     type WriteError = SchemaError;
     type DeleteError = D::DeleteError;
 
-    type WriteInput = HashMap<String, MutableBatch>;
+    type WriteInput = Partitioned<HashMap<String, MutableBatch>>;
 
     /// Validate the schema of all the writes in `batches` before passing the
     /// request onto the inner handler.
@@ -168,7 +168,7 @@ where
         };
 
         let maybe_new_schema = validate_or_insert_schema(
-            batches.iter().map(|(k, v)| (k.as_str(), v)),
+            batches.payload().iter().map(|(k, v)| (k.as_str(), v)),
             &schema,
             txn.deref_mut(),
         )
@@ -246,10 +246,10 @@ mod tests {
     }
 
     // Parse `lp` into a table-keyed MutableBatch map.
-    fn lp_to_writes(lp: &str) -> HashMap<String, MutableBatch> {
+    fn lp_to_writes(lp: &str) -> Partitioned<HashMap<String, MutableBatch>> {
         let (writes, _) = mutable_batch_lp::lines_to_batches_stats(lp, 42)
             .expect("failed to build test writes from LP");
-        writes
+        Partitioned::new("key".to_owned(), writes)
     }
 
     /// Initialise an in-memory [`MemCatalog`] and create a single namespace
@@ -374,7 +374,7 @@ mod tests {
         // THe mock should observe exactly one write from the first call.
         assert_matches!(mock.calls().as_slice(), [MockDmlHandlerCall::Write{namespace, batches}] => {
             assert_eq!(namespace, NAMESPACE);
-            let batch = batches.get("bananas").expect("table not found in write");
+            let batch = batches.payload().get("bananas").expect("table not found in write");
             assert_eq!(batch.rows(), 1);
             let col = batch.column("val").expect("column not found in write");
             assert_matches!(col.influx_type(), InfluxColumnType::Field(InfluxFieldType::Integer));

--- a/router2/src/dml_handlers/schema_validation.rs
+++ b/router2/src/dml_handlers/schema_validation.rs
@@ -106,11 +106,13 @@ impl<D, C> SchemaValidator<D, C> {
 #[async_trait]
 impl<D, C> DmlHandler for SchemaValidator<D, C>
 where
-    D: DmlHandler,
+    D: DmlHandler<WriteInput = HashMap<String, MutableBatch>>,
     C: NamespaceCache,
 {
     type WriteError = SchemaError;
     type DeleteError = D::DeleteError;
+
+    type WriteInput = HashMap<String, MutableBatch>;
 
     /// Validate the schema of all the writes in `batches` before passing the
     /// request onto the inner handler.
@@ -132,7 +134,7 @@ where
     async fn write(
         &self,
         namespace: DatabaseName<'static>,
-        batches: HashMap<String, MutableBatch>,
+        batches: Self::WriteInput,
         span_ctx: Option<SpanContext>,
     ) -> Result<(), Self::WriteError> {
         let mut txn = self

--- a/router2/src/dml_handlers/sharded_write_buffer.rs
+++ b/router2/src/dml_handlers/sharded_write_buffer.rs
@@ -81,11 +81,13 @@ where
     type WriteError = ShardError;
     type DeleteError = ShardError;
 
+    type WriteInput = HashMap<String, MutableBatch>;
+
     /// Shard `writes` and dispatch the resultant DML operations.
     async fn write(
         &self,
         namespace: DatabaseName<'static>,
-        writes: HashMap<String, MutableBatch>,
+        writes: Self::WriteInput,
         span_ctx: Option<SpanContext>,
     ) -> Result<(), ShardError> {
         let mut collated: HashMap<_, HashMap<String, MutableBatch>> = HashMap::new();

--- a/router2/src/dml_handlers/sharded_write_buffer.rs
+++ b/router2/src/dml_handlers/sharded_write_buffer.rs
@@ -19,6 +19,8 @@ use write_buffer::core::WriteBufferError;
 
 use crate::{dml_handlers::DmlHandler, sequencer::Sequencer, sharder::Sharder};
 
+use super::Partitioned;
+
 /// Errors occurring while writing to one or more write buffer shards.
 #[derive(Debug, Error)]
 pub enum ShardError {
@@ -81,7 +83,7 @@ where
     type WriteError = ShardError;
     type DeleteError = ShardError;
 
-    type WriteInput = HashMap<String, MutableBatch>;
+    type WriteInput = Partitioned<HashMap<String, MutableBatch>>;
 
     /// Shard `writes` and dispatch the resultant DML operations.
     async fn write(
@@ -91,6 +93,9 @@ where
         span_ctx: Option<SpanContext>,
     ) -> Result<(), ShardError> {
         let mut collated: HashMap<_, HashMap<String, MutableBatch>> = HashMap::new();
+
+        // Extract the partition key & DML writes.
+        let (partition_key, writes) = writes.into_parts();
 
         // Shard each entry in `writes` and collate them into one DML operation
         // per shard to maximise the size of each write, and therefore increase
@@ -110,6 +115,7 @@ where
             let dml = DmlWrite::new(&namespace, batch, DmlMeta::unsequenced(span_ctx.clone()));
 
             trace!(
+                %partition_key,
                 sequencer_id=%sequencer.id(),
                 tables=%dml.table_count(),
                 %namespace,
@@ -201,10 +207,10 @@ mod tests {
     use super::*;
 
     // Parse `lp` into a table-keyed MutableBatch map.
-    fn lp_to_writes(lp: &str) -> HashMap<String, MutableBatch> {
+    fn lp_to_writes(lp: &str) -> Partitioned<HashMap<String, MutableBatch>> {
         let (writes, _) = mutable_batch_lp::lines_to_batches_stats(lp, 42)
             .expect("failed to build test writes from LP");
-        writes
+        Partitioned::new("key".to_owned(), writes)
     }
 
     // Init a mock write buffer with the given number of sequencers.

--- a/router2/src/dml_handlers/trait.rs
+++ b/router2/src/dml_handlers/trait.rs
@@ -6,7 +6,7 @@ use data_types::{delete_predicate::DeletePredicate, DatabaseName};
 use thiserror::Error;
 use trace::ctx::SpanContext;
 
-use super::{NamespaceCreationError, SchemaError, ShardError};
+use super::{partitioner::PartitionError, NamespaceCreationError, SchemaError, ShardError};
 
 /// Errors emitted by a [`DmlHandler`] implementation during DML request
 /// processing.
@@ -27,6 +27,10 @@ pub enum DmlError {
     /// Failed to create the request namespace.
     #[error(transparent)]
     NamespaceCreation(#[from] NamespaceCreationError),
+
+    /// An error partitioning the request.
+    #[error(transparent)]
+    Partition(#[from] PartitionError),
 
     /// An unknown error occured while processing the DML request.
     #[error("internal dml handler error: {0}")]

--- a/router2/src/lib.rs
+++ b/router2/src/lib.rs
@@ -6,6 +6,7 @@
 //! * Handling writes:
 //!     * Receiving IOx write/delete requests via HTTP and gRPC endpoints.
 //!     * Enforcing schema validation & synchronising it within the catalog.
+//!     * Deriving the partition key of each DML operation.
 //!     * Applying sharding logic.
 //!     * Push resulting operations into the appropriate kafka topics.
 //!

--- a/router2/src/server.rs
+++ b/router2/src/server.rs
@@ -3,8 +3,6 @@
 use std::sync::Arc;
 
 use crate::dml_handlers::DmlHandler;
-use hashbrown::HashMap;
-use mutable_batch::MutableBatch;
 use trace::TraceCollector;
 
 use self::{grpc::GrpcDelegate, http::HttpDelegate};
@@ -53,7 +51,7 @@ impl<D> RouterServer<D> {
 
 impl<D> RouterServer<D>
 where
-    D: DmlHandler<WriteInput = HashMap<String, MutableBatch>>,
+    D: DmlHandler<WriteInput = String>,
 {
     /// Get a reference to the router http delegate.
     pub fn http(&self) -> &HttpDelegate<D> {

--- a/router2/src/server.rs
+++ b/router2/src/server.rs
@@ -3,6 +3,8 @@
 use std::sync::Arc;
 
 use crate::dml_handlers::DmlHandler;
+use hashbrown::HashMap;
+use mutable_batch::MutableBatch;
 use trace::TraceCollector;
 
 use self::{grpc::GrpcDelegate, http::HttpDelegate};
@@ -51,7 +53,7 @@ impl<D> RouterServer<D> {
 
 impl<D> RouterServer<D>
 where
-    D: DmlHandler,
+    D: DmlHandler<WriteInput = HashMap<String, MutableBatch>>,
 {
     /// Get a reference to the router http delegate.
     pub fn http(&self) -> &HttpDelegate<D> {

--- a/router2/src/server/http.rs
+++ b/router2/src/server/http.rs
@@ -16,7 +16,7 @@ use thiserror::Error;
 use time::{SystemProvider, TimeProvider};
 use trace::ctx::SpanContext;
 
-use crate::dml_handlers::{DmlError, DmlHandler};
+use crate::dml_handlers::{DmlError, DmlHandler, PartitionError};
 
 /// Errors returned by the `router2` HTTP request handler.
 #[derive(Debug, Error)]
@@ -71,9 +71,7 @@ impl Error {
     /// the end user.
     pub fn as_status_code(&self) -> StatusCode {
         match self {
-            Error::NoHandler | Error::DmlHandler(DmlError::DatabaseNotFound(_)) => {
-                StatusCode::NOT_FOUND
-            }
+            Error::NoHandler => StatusCode::NOT_FOUND,
             Error::InvalidOrgBucket(_) => StatusCode::BAD_REQUEST,
             Error::ClientHangup(_) => StatusCode::BAD_REQUEST,
             Error::InvalidGzip(_) => StatusCode::BAD_REQUEST,
@@ -87,9 +85,23 @@ impl Error {
                 // https://www.rfc-editor.org/rfc/rfc7231#section-6.5.13
                 StatusCode::UNSUPPORTED_MEDIA_TYPE
             }
-            Error::DmlHandler(
-                DmlError::Internal(_) | DmlError::WriteBuffer(_) | DmlError::NamespaceCreation(_),
-            ) => StatusCode::INTERNAL_SERVER_ERROR,
+            Error::DmlHandler(err) => StatusCode::from(err),
+        }
+    }
+}
+
+impl From<&DmlError> for StatusCode {
+    fn from(e: &DmlError) -> Self {
+        match e {
+            DmlError::DatabaseNotFound(_) => StatusCode::NOT_FOUND,
+            DmlError::Schema(_) => StatusCode::BAD_REQUEST,
+            DmlError::Internal(_) | DmlError::WriteBuffer(_) | DmlError::NamespaceCreation(_) => {
+                StatusCode::INTERNAL_SERVER_ERROR
+            }
+            DmlError::Partition(
+                PartitionError::LineParse { .. } | PartitionError::LineBatchWrite { .. },
+            ) => StatusCode::BAD_REQUEST,
+            DmlError::Partition(PartitionError::Inner(err)) => StatusCode::from(&**err),
         }
     }
 }

--- a/router2/src/server/http.rs
+++ b/router2/src/server/http.rs
@@ -6,7 +6,9 @@ use bytes::{Bytes, BytesMut};
 use data_types::names::{org_and_bucket_to_database, OrgBucketMappingError};
 
 use futures::StreamExt;
+use hashbrown::HashMap;
 use hyper::{header::CONTENT_ENCODING, Body, Method, Request, Response, StatusCode};
+use mutable_batch::MutableBatch;
 use observability_deps::tracing::*;
 use predicate::delete_predicate::{parse_delete_predicate, parse_http_delete_request};
 use serde::Deserialize;
@@ -162,7 +164,7 @@ impl<D> HttpDelegate<D, SystemProvider> {
 
 impl<D, T> HttpDelegate<D, T>
 where
-    D: DmlHandler,
+    D: DmlHandler<WriteInput = HashMap<String, MutableBatch>>,
     T: TimeProvider,
 {
     /// Routes `req` to the appropriate handler, if any, returning the handler


### PR DESCRIPTION
This PR adds partitioning to the `router2` implementation by introducing a new `Partitioner` into the request pipeline that operates over row-wise line-protocol writes suitable for use with the HTTP API. We're not currently using the gRPC API, which is column-wise and therefore will need a different partitioning implementation when we wish to enable gRPC writes.

This change keeps the namespace auto-creation (#3628) as the first handler that is called, ensuring we don't bother partitioning a request if the namespace cannot be created.

The partitioned writes are tagged with the generated partition key, and passed through the handler stack until reaching the write buffer where the key is logged and dropped - further work will allow us to pass this partition key across the write-buffer API boundary for use in the ingester in the future.

---

* refactor: parametrise DML handler input type (fc409874)

      Allow a DML handler to specify the write input type on which it operates.

      This allows us to construct a write handler pipeline that transforms the 
      request as it passes through the various handlers. We'll use this to implement
      a handler that annotates a normal set of table writes with the partition key,
      modifying downstream handlers to expect this annotated input.

* test: MockDmlHandler generic over write input (575d8f26)

      Allow the MockDmlHandler to capture any input type given to the write() 
      method. This lets us reuse the mock across all handler implementations, 
      regardless of their expected write input type.

* feat: row-wise line protocol partitioner (748a83bf)

      Implements write partitioning by date for line-protocol strings received by
      the HTTP API.

      This change moves the LP parsing logic out of the HTTP handler (nicer!) and
      into the Partitioner where it is partitioned as each line is parsed to
      minimise overhead - it's cheaper to partition row-wise data than trying to
      split out column-wise data later. The existing MutableBatch builder logic
      (LineConverter) is slightly modified for this use to avoid duplication.

* refactor: namespace auto-creator generic input (2eb2ddb0)

      Changes the NamespaceAutocreation handler to be generic over any WriteInput.

      This allows the NamespaceAutocreation layer to be placed anywhere in the 
      handler stack, without needing a prior transformation or specific write type.

* refactor: enable Partitioner in request pipeline (0415fa13)

      Adds the Partitioner DML handler into the handler stack, modifying the input
      types of down-stream handlers to accept the partitioned data.

