### PR TITLE
feat: abort database initialization (#3368)

### DIFF
--- a/generated_types/protos/influxdata/iox/management/v1/service.proto
+++ b/generated_types/protos/influxdata/iox/management/v1/service.proto
@@ -384,6 +384,9 @@ message DatabaseStatus {
 
     // Error encountered finding the database's directory in object storage
     DATABASE_STATE_DATABASE_OBJECT_STORE_LOOKUP_ERROR = 9;
+
+    // Initialization was aborted
+    DATABASE_STATE_ABORTED = 14;
   }
 
   // Current initialization state of the database.

--- a/generated_types/src/database_state.rs
+++ b/generated_types/src/database_state.rs
@@ -19,6 +19,7 @@ impl DatabaseState {
             DatabaseState::OwnerInfoLoaded => "OwnerInfoLoaded",
             DatabaseState::OwnerInfoLoadError => "OwnerInfoLoadError",
             DatabaseState::Unspecified => "Unspecified",
+            DatabaseState::Aborted => "Aborted",
         }
     }
 }

--- a/server/src/database/init.rs
+++ b/server/src/database/init.rs
@@ -367,17 +367,17 @@ impl DatabaseState {
             }
             Self::RulesLoaded(state) | Self::CatalogLoadError(state, _) => {
                 match state.advance(shared).await {
-                    Ok(state) => DatabaseState::CatalogLoaded(state),
-                    Err(e) => DatabaseState::CatalogLoadError(state, Arc::new(e)),
+                    Ok(state) => Self::CatalogLoaded(state),
+                    Err(e) => Self::CatalogLoadError(state, Arc::new(e)),
                 }
             }
             Self::CatalogLoaded(state) | Self::WriteBufferCreationError(state, _) => {
                 match state.advance(shared).await {
-                    Ok(state) => DatabaseState::Initialized(state),
+                    Ok(state) => Self::Initialized(state),
                     Err(e @ InitError::CreateWriteBuffer { .. }) => {
-                        DatabaseState::WriteBufferCreationError(state, Arc::new(e))
+                        Self::WriteBufferCreationError(state, Arc::new(e))
                     }
-                    Err(e) => DatabaseState::ReplayError(state, Arc::new(e)),
+                    Err(e) => Self::ReplayError(state, Arc::new(e)),
                 }
             }
             Self::ReplayError(state, _) => {

--- a/server/src/database/state.rs
+++ b/server/src/database/state.rs
@@ -39,4 +39,9 @@ pub(crate) struct DatabaseShared {
 
     /// Notify that the database state has changed
     pub(crate) state_notify: Notify,
+
+    /// Abort initialization if any in progress
+    ///
+    /// Unlike [`Self::shutdown`] this will not terminate the background worker
+    pub(crate) abort_initialization: Notify,
 }


### PR DESCRIPTION
The freeze handle within the Database state machine prevents concurrent in-flight mutations to the database state. This is generally a good thing, however, if an initialization process stalls out without returning an error - it will continue to hold this lock, preventing the operator from intervening to recover the system.

We need a mechanism to not only interrupt the current initialization action, but also prevent new ones from being created.

As such this adds a new `Aborted` state to the initialization state machine, along with a `Notify` that can be used to signal the initialization logic to bail out.

The astute may ask, "what about initialized databases", this case is actually already handled and is how the restart process works. Whilst running the database does not hold a freeze handle, so the restart process can acquire one, change the Database state and signal the background loop with `state_notify`. The background worker will exit out of its main loop, after waiting for everything to shutdown, and return to the init loop.