### PR TITLE
chore: The k8s-iox promotion is no longer used and can be removed

### DIFF
--- a/.circleci/get-deploy-tags.sh
+++ b/.circleci/get-deploy-tags.sh
@@ -53,7 +53,4 @@ if [[ -z "${IMAGE_PROMOTION_COMMAND}" ]]; then
 else
 	echo "Triggering image promotion"
 	eval "${IMAGE_PROMOTION_COMMAND}" < deploy.json
-	eval "${IMAGE_PROMOTION_COMMAND_K8S_IOX}" < deploy.json || {
-	   echo "experimental k8s_iox promotion failed"
-	}
 fi


### PR DESCRIPTION
Closes #

Describe your proposed changes here.

Removes k8s-iox promotion/image introduction.

- [X] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb_iox/blob/main/README.md).
- [X] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
