### PR TITLE
refactor: influxRPC operation logging

### DIFF
--- a/influxdb_iox/src/influxdb_ioxd/server_type/database/rpc/storage/service.rs
+++ b/influxdb_iox/src/influxdb_ioxd/server_type/database/rpc/storage/service.rs
@@ -280,7 +280,7 @@ where
             aggregate,
         } = req;
 
-        info!(%db_name, ?range, ?group_keys, ?group, ?aggregate,predicate=%predicate.loggable(),"read_group");
+        info!(%db_name, ?range, ?group_keys, ?group, ?aggregate, predicate=%predicate.loggable(), "read_group");
 
         let aggregate_string = format!(
             "aggregate: {:?}, group: {:?}, group_keys: {:?}",
@@ -338,7 +338,7 @@ where
             window,
         } = req;
 
-        info!(%db_name, ?range, ?window_every, ?offset, ?aggregate, ?window, predicate=%predicate.loggable(),"read_window_aggregate");
+        info!(%db_name, ?range, ?window_every, ?offset, ?aggregate, ?window, predicate=%predicate.loggable(), "read_window_aggregate");
 
         let aggregate_string = format!(
             "aggregate: {:?}, window_every: {:?}, offset: {:?}, window: {:?}",
@@ -547,6 +547,7 @@ where
         // idpe/storage/read/capabilities.go (aka window aggregate /
         // pushdown)
         //
+        info!("capabilities");
 
         // For now, hard code our list of support
         let caps = [
@@ -733,7 +734,7 @@ where
             predicate,
         } = req;
 
-        info!(%db_name, ?range, predicate=%predicate.loggable(), "measurement_fields");
+        info!(%db_name, ?range, %measurement, predicate=%predicate.loggable(), "measurement_fields");
 
         let measurement = Some(measurement);
 

--- a/influxdb_iox/src/influxdb_ioxd/server_type/database/rpc/storage/service.rs
+++ b/influxdb_iox/src/influxdb_ioxd/server_type/database/rpc/storage/service.rs
@@ -441,7 +441,7 @@ where
         // Special case a request for 'tag_key=_measurement" means to list all
         // measurements
         let response = if tag_key.is_measurement() {
-            info!(%db_name, ?range, predicate=%predicate.loggable(), "tag_values with tag_key=[x00] (measurement name)");
+            info!(%db_name, ?range, tag_key="_measurement", predicate=%predicate.loggable(), "tag_values");
 
             if predicate.is_some() {
                 return Err(Error::NotYetImplemented {
@@ -452,7 +452,7 @@ where
 
             measurement_name_impl(Arc::clone(&db), db_name, range, predicate, span_ctx).await
         } else if tag_key.is_field() {
-            info!(%db_name, ?range, predicate=%predicate.loggable(), "tag_values with tag_key=[xff] (field name)");
+            info!(%db_name, ?range, tag_key="_field", predicate=%predicate.loggable(), "tag_values");
 
             let fieldlist =
                 field_names_impl(Arc::clone(&db), db_name, None, range, predicate, span_ctx)
@@ -468,8 +468,7 @@ where
             Ok(StringValuesResponse { values })
         } else {
             let tag_key = String::from_utf8(tag_key).context(ConvertingTagKeyInTagValuesSnafu)?;
-
-            info!(%db_name, ?range, %tag_key, predicate=%predicate.loggable(), "tag_values",);
+            info!(%db_name, ?range, %tag_key, predicate=%predicate.loggable(), "tag_values");
 
             tag_values_impl(
                 Arc::clone(&db),


### PR DESCRIPTION
A quick tidy I noticed as I was reviewing logs:

 - log `measurement` name for `measurement_fields`
 - use the same log message for `tag_values`