### PR TITLE
feat: router2 metrics

### DIFF
--- a/router2/src/dml_handlers/instrumentation.rs
+++ b/router2/src/dml_handlers/instrumentation.rs
@@ -1,0 +1,137 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use data_types::{delete_predicate::DeletePredicate, DatabaseName};
+use metric::{Metric, U64Histogram, U64HistogramOptions};
+use time::{SystemProvider, TimeProvider};
+use trace::ctx::SpanContext;
+
+use super::DmlHandler;
+
+/// An instrumentation decorator recording call latencies for [`DmlHandler`]
+/// implementations.
+///
+/// Metrics are broken down by operation (write/delete) and result
+/// (success/error) with call latency reported in milliseconds.
+///
+/// # Chained / Nested Handlers
+///
+/// Because [`DmlHandler`] implementations are constructed as a chain of
+/// decorators to build up a full request handling pipeline, the reported call
+/// latency of a given handler is a cumulative measure of the execution time for
+/// handler and all of its children.
+#[derive(Debug)]
+pub struct InstrumentationDecorator<T, P = SystemProvider> {
+    inner: T,
+    time_provider: P,
+
+    write_success: U64Histogram,
+    write_error: U64Histogram,
+
+    delete_success: U64Histogram,
+    delete_error: U64Histogram,
+}
+
+impl<T> InstrumentationDecorator<T> {
+    /// Wrap a new [`InstrumentationDecorator`] over `T` exposing metrics
+    /// prefixed by `name`.
+    ///
+    /// # Memory leak
+    ///
+    /// Calling this method constructs a set of metric names derived from `name`
+    /// and leaks them once to acquire a static str for each.
+    pub fn new(name: &'static str, registry: Arc<metric::Registry>, inner: T) -> Self {
+        let buckets = || {
+            U64HistogramOptions::new([5, 10, 20, 40, 80, 160, 320, 640, 1280, 2560, 5120, u64::MAX])
+        };
+
+        let write: Metric<U64Histogram> = registry.register_metric_with_options(
+            leak_concat_name(name, "_write_duration_ms"),
+            "write handler call duration in milliseconds",
+            buckets,
+        );
+        let delete: Metric<U64Histogram> = registry.register_metric_with_options(
+            leak_concat_name(name, "_delete_duration_ms"),
+            "write handler call duration in milliseconds",
+            buckets,
+        );
+
+        let write_success = write.recorder(&[("result", "success")]);
+        let write_error = write.recorder(&[("result", "error")]);
+
+        let delete_success = delete.recorder(&[("result", "success")]);
+        let delete_error = delete.recorder(&[("result", "error")]);
+
+        Self {
+            inner,
+            time_provider: Default::default(),
+            write_success,
+            write_error,
+            delete_success,
+            delete_error,
+        }
+    }
+}
+
+#[async_trait]
+impl<T> DmlHandler for InstrumentationDecorator<T>
+where
+    T: DmlHandler,
+{
+    type WriteInput = T::WriteInput;
+    type WriteError = T::WriteError;
+    type DeleteError = T::DeleteError;
+
+    /// Call the inner `write` method and record the call latency.
+    async fn write(
+        &self,
+        namespace: DatabaseName<'static>,
+        input: Self::WriteInput,
+        span_ctx: Option<SpanContext>,
+    ) -> Result<(), Self::WriteError> {
+        let t = self.time_provider.now();
+        let res = self.inner.write(namespace, input, span_ctx).await;
+
+        // Avoid exploding if time goes backwards - simply drop the measurement
+        // if it happens.
+        if let Some(delta) = self.time_provider.now().checked_duration_since(t) {
+            match &res {
+                Ok(_) => self.write_success.record(delta.as_millis() as _),
+                Err(_) => self.write_error.record(delta.as_millis() as _),
+            };
+        }
+
+        res
+    }
+
+    /// Call the inner `delete` method and record the call latency.
+    async fn delete<'a>(
+        &self,
+        namespace: DatabaseName<'static>,
+        table_name: impl Into<String> + Send + Sync + 'a,
+        predicate: DeletePredicate,
+        span_ctx: Option<SpanContext>,
+    ) -> Result<(), Self::DeleteError> {
+        let t = self.time_provider.now();
+        let res = self
+            .inner
+            .delete(namespace, table_name, predicate, span_ctx)
+            .await;
+
+        // Avoid exploding if time goes backwards - simply drop the measurement
+        // if it happens.
+        if let Some(delta) = self.time_provider.now().checked_duration_since(t) {
+            match &res {
+                Ok(_) => self.delete_success.record(delta.as_millis() as _),
+                Err(_) => self.delete_error.record(delta.as_millis() as _),
+            };
+        }
+
+        res
+    }
+}
+
+fn leak_concat_name(prefix: &str, suffix: &str) -> &'static str {
+    let s = format!("{}{}", prefix, suffix);
+    Box::leak(s.into_boxed_str())
+}

--- a/router2/src/dml_handlers/mod.rs
+++ b/router2/src/dml_handlers/mod.rs
@@ -90,5 +90,8 @@ pub use ns_autocreation::*;
 mod partitioner;
 pub use partitioner::*;
 
+mod instrumentation;
+pub use instrumentation::*;
+
 #[cfg(test)]
 pub mod mock;

--- a/router2/src/namespace_cache.rs
+++ b/router2/src/namespace_cache.rs
@@ -6,6 +6,8 @@ pub use memory::*;
 mod sharded_cache;
 pub use sharded_cache::*;
 
+pub mod metrics;
+
 use std::{fmt::Debug, sync::Arc};
 
 use data_types::DatabaseName;

--- a/router2/src/namespace_cache/metrics.rs
+++ b/router2/src/namespace_cache/metrics.rs
@@ -1,0 +1,84 @@
+//! Metric instrumentation for a [`NamespaceCache`] implementation.
+
+use std::sync::Arc;
+
+use data_types::DatabaseName;
+use iox_catalog::interface::NamespaceSchema;
+use metric::{Metric, U64Counter};
+
+use super::NamespaceCache;
+
+/// An [`InstrumentedCache`] decorates a [`NamespaceCache`] with cache read
+/// hit/miss and cache put insert/update metrics.
+#[derive(Debug)]
+pub struct InstrumentedCache<T> {
+    inner: T,
+
+    /// A cache read hit
+    get_hit_counter: U64Counter,
+    /// A cache read miss
+    get_miss_counter: U64Counter,
+
+    /// A cache put for a namespace that did not previously exist.
+    put_insert_counter: U64Counter,
+    /// A cache put replacing a namespace that previously had a cache entry.
+    put_update_counter: U64Counter,
+}
+
+impl<T> InstrumentedCache<T> {
+    /// Instrument `T`, recording cache operations to `registry`.
+    pub fn new(inner: T, registry: Arc<metric::Registry>) -> Self {
+        let get_counter: Metric<U64Counter> =
+            registry.register_metric("namespace_cache_get_count", "cache read requests");
+        let get_hit_counter = get_counter.recorder(&[("result", "hit")]);
+        let get_miss_counter = get_counter.recorder(&[("result", "miss")]);
+
+        let put_counter: Metric<U64Counter> =
+            registry.register_metric("namespace_cache_put_count", "cache put requests");
+        let put_insert_counter = put_counter.recorder(&[("op", "insert")]);
+        let put_update_counter = put_counter.recorder(&[("op", "update")]);
+
+        Self {
+            inner,
+            get_hit_counter,
+            get_miss_counter,
+            put_insert_counter,
+            put_update_counter,
+        }
+    }
+}
+
+impl<T> NamespaceCache for Arc<InstrumentedCache<T>>
+where
+    T: NamespaceCache,
+{
+    fn get_schema(&self, namespace: &DatabaseName<'_>) -> Option<Arc<NamespaceSchema>> {
+        match self.inner.get_schema(namespace) {
+            Some(v) => {
+                self.get_hit_counter.inc(1);
+                Some(v)
+            }
+            None => {
+                self.get_miss_counter.inc(1);
+                None
+            }
+        }
+    }
+
+    fn put_schema(
+        &self,
+        namespace: DatabaseName<'static>,
+        schema: impl Into<Arc<NamespaceSchema>>,
+    ) -> Option<Arc<NamespaceSchema>> {
+        match self.inner.put_schema(namespace, schema) {
+            Some(v) => {
+                self.put_update_counter.inc(1);
+                Some(v)
+            }
+            None => {
+                self.put_insert_counter.inc(1);
+                None
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR adds instrumentation to each stage of the request handling pipeline to allow us to observe the latencies of the various operations within the router. It adds latency histograms the following stages:

* Submitting ops to the write buffer (inc. waiting for internal buffer flush)
* Schema validation (inc. catalog interactions)
* Write partitioning
* Overall e2e request handling latency

Each metric is broken down by success/error response and operation type (write/delete).

Because the request pipeline is constructed as a chain of nested handlers, the timing for each stage is inclusive of the child handlers it calls:

```
              ┌ ─                                          
                                                           
              │     ┌───────────────┐                      
                    │  NS Creation  │                      
              │     └───────────────┘                      
                            │  ┌───────────────┐           
              │             │  │  Partitioner  │           
                            │  └───────────────┘           
              │             │          │                   
                            │          │                   
 Cumulative   │             │          │  ┌───────────────┐
   Timings                1.5s        1s  │    etc...     │
              │             │          │  └───────────────┘
                            │          │                   
              │             │          │                   
                            │  ┌───────────────┐           
              │             │  │  Partitioner  │           
                            │  └───────────────┘           
              │     ┌───────────────┐                      
                    │  NS Creation  │                      
              │     └───────────────┘                      
                                                           
              └ ─                                          
```

This is temporary, and I'll switch to external chaining (rather than internally nesting) handlers in the next PR to give us better timing data - splitting them up to keep it small.

Additionally the namespace cache is instrumented to measure:

* Get hit/miss count
* Put insert/update count

This will help us measure the incidence of https://github.com/influxdata/influxdb_iox/issues/3578 and https://github.com/influxdata/influxdb_iox/issues/3577 and weight remediation of them appropriately.

---

* feat: instrumented namespace cache (92fe507e)

      Decorates the NamespaceCache with a set of cache get hit/miss counters, and
      put insert/update counters to expose cache behaviour.

* feat: metric instrumentation for DML handlers (40e5b193)

      Adds a decorator type over a DmlHandler implementation that records call 
      latency for writes & deletes, broken down by result (success/error).

* feat: add instrumentation to request pipeline (d6d0ae8d)

      Wraps the sharded write buffer, schema validator, partitioner and overall
      request handler in instrumentation to record call latencies and export them
      via the /metrics endpoint.