### PR TITLE
test: isolated catalog tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2118,6 +2118,7 @@ dependencies = [
  "observability_deps",
  "paste",
  "pretty_assertions",
+ "rand",
  "schema",
  "snafu",
  "sqlx",

--- a/iox_catalog/Cargo.toml
+++ b/iox_catalog/Cargo.toml
@@ -23,6 +23,7 @@ dotenv = "0.15.0"
 mutable_batch_lp = { path = "../mutable_batch_lp" }
 paste = "1.0.6"
 pretty_assertions = "1.0.0"
+rand = "0.8"
 test_helpers = { path = "../test_helpers" }
 
 [features]

--- a/iox_catalog/migrations/20210217134322_create_schema.sql
+++ b/iox_catalog/migrations/20210217134322_create_schema.sql
@@ -1,0 +1,1 @@
+CREATE SCHEMA IF NOT EXISTS iox_catalog;

--- a/iox_catalog/migrations/20211229171744_initial_schema.sql
+++ b/iox_catalog/migrations/20211229171744_initial_schema.sql
@@ -2,7 +2,7 @@
 -- iox_shared schema
 CREATE SCHEMA IF NOT EXISTS iox_catalog;
 
-CREATE TABLE IF NOT EXISTS iox_catalog.kafka_topic
+CREATE TABLE IF NOT EXISTS kafka_topic
 (
     id INT GENERATED ALWAYS AS IDENTITY,
     name VARCHAR NOT NULL,
@@ -10,7 +10,7 @@ CREATE TABLE IF NOT EXISTS iox_catalog.kafka_topic
     CONSTRAINT kafka_topic_name_unique UNIQUE (name)
     );
 
-CREATE TABLE IF NOT EXISTS iox_catalog.query_pool
+CREATE TABLE IF NOT EXISTS query_pool
 (
     id SMALLINT GENERATED ALWAYS AS IDENTITY,
     name VARCHAR NOT NULL,
@@ -18,7 +18,7 @@ CREATE TABLE IF NOT EXISTS iox_catalog.query_pool
     CONSTRAINT query_pool_name_unique UNIQUE (name)
     );
 
-CREATE TABLE IF NOT EXISTS iox_catalog.namespace
+CREATE TABLE IF NOT EXISTS namespace
 (
     id INT GENERATED ALWAYS AS IDENTITY,
     name VARCHAR NOT NULL,
@@ -29,7 +29,7 @@ CREATE TABLE IF NOT EXISTS iox_catalog.namespace
     CONSTRAINT namespace_name_unique UNIQUE (name)
     );
 
-CREATE TABLE IF NOT EXISTS iox_catalog.table_name
+CREATE TABLE IF NOT EXISTS table_name
 (
     id INT GENERATED ALWAYS AS IDENTITY,
     namespace_id integer NOT NULL,
@@ -38,7 +38,7 @@ CREATE TABLE IF NOT EXISTS iox_catalog.table_name
     CONSTRAINT table_name_unique UNIQUE (namespace_id, name)
     );
 
-CREATE TABLE IF NOT EXISTS iox_catalog.column_name
+CREATE TABLE IF NOT EXISTS column_name
 (
     id INT GENERATED ALWAYS AS IDENTITY,
     table_id INT NOT NULL,
@@ -48,7 +48,7 @@ CREATE TABLE IF NOT EXISTS iox_catalog.column_name
     CONSTRAINT column_name_unique UNIQUE (table_id, name)
     );
 
-CREATE TABLE IF NOT EXISTS iox_catalog.sequencer
+CREATE TABLE IF NOT EXISTS sequencer
 (
     id SMALLINT GENERATED ALWAYS AS IDENTITY,
     kafka_topic_id INT NOT NULL,
@@ -58,7 +58,7 @@ CREATE TABLE IF NOT EXISTS iox_catalog.sequencer
     CONSTRAINT sequencer_unique UNIQUE (kafka_topic_id, kafka_partition)
     );
 
-CREATE TABLE IF NOT EXISTS iox_catalog.sharding_rule_override
+CREATE TABLE IF NOT EXISTS sharding_rule_override
 (
     id INT GENERATED ALWAYS AS IDENTITY,
     namespace_id INT NOT NULL,
@@ -67,7 +67,7 @@ CREATE TABLE IF NOT EXISTS iox_catalog.sharding_rule_override
     PRIMARY KEY (id)
     );
 
-CREATE TABLE IF NOT EXISTS iox_catalog.partition
+CREATE TABLE IF NOT EXISTS partition
 (
     id BIGINT GENERATED ALWAYS AS IDENTITY,
     sequencer_id SMALLINT NOT NULL,
@@ -77,7 +77,7 @@ CREATE TABLE IF NOT EXISTS iox_catalog.partition
     CONSTRAINT partition_key_unique UNIQUE (table_id, partition_key)
     );
 
-CREATE TABLE IF NOT EXISTS iox_catalog.parquet_file
+CREATE TABLE IF NOT EXISTS parquet_file
 (
     id BIGINT GENERATED ALWAYS AS IDENTITY,
     sequencer_id SMALLINT NOT NULL,
@@ -93,7 +93,7 @@ CREATE TABLE IF NOT EXISTS iox_catalog.parquet_file
     CONSTRAINT parquet_location_unique UNIQUE (object_store_id)
     );
 
-CREATE TABLE IF NOT EXISTS iox_catalog.tombstone
+CREATE TABLE IF NOT EXISTS tombstone
 (
     id BIGINT GENERATED ALWAYS AS IDENTITY,
     table_id INT NOT NULL,
@@ -106,128 +106,128 @@ CREATE TABLE IF NOT EXISTS iox_catalog.tombstone
     CONSTRAINT tombstone_unique UNIQUE (table_id, sequencer_id, sequence_number)
     );
 
-CREATE TABLE IF NOT EXISTS iox_catalog.processed_tombstone
+CREATE TABLE IF NOT EXISTS processed_tombstone
 (
     tombstone_id BIGINT NOT NULL,
     parquet_file_id BIGINT NOT NULL,
     PRIMARY KEY (tombstone_id, parquet_file_id)
     );
 
-ALTER TABLE IF EXISTS iox_catalog.namespace
+ALTER TABLE IF EXISTS namespace
     ADD FOREIGN KEY (kafka_topic_id)
-    REFERENCES iox_catalog.kafka_topic (id) MATCH SIMPLE
+    REFERENCES kafka_topic (id) MATCH SIMPLE
     ON UPDATE NO ACTION
        ON DELETE NO ACTION
 	NOT VALID;
 
-ALTER TABLE IF EXISTS iox_catalog.namespace
+ALTER TABLE IF EXISTS namespace
     ADD FOREIGN KEY (query_pool_id)
-    REFERENCES iox_catalog.query_pool (id) MATCH SIMPLE
+    REFERENCES query_pool (id) MATCH SIMPLE
     ON UPDATE NO ACTION
        ON DELETE NO ACTION
 	NOT VALID;
 
-ALTER TABLE IF EXISTS iox_catalog.table_name
+ALTER TABLE IF EXISTS table_name
     ADD FOREIGN KEY (namespace_id)
-    REFERENCES iox_catalog.namespace (id) MATCH SIMPLE
+    REFERENCES namespace (id) MATCH SIMPLE
     ON UPDATE NO ACTION
        ON DELETE NO ACTION
 	NOT VALID;
 
-ALTER TABLE IF EXISTS iox_catalog.column_name
+ALTER TABLE IF EXISTS column_name
     ADD FOREIGN KEY (table_id)
-    REFERENCES iox_catalog.table_name (id) MATCH SIMPLE
+    REFERENCES table_name (id) MATCH SIMPLE
     ON UPDATE NO ACTION
        ON DELETE NO ACTION
 	NOT VALID;
 
-ALTER TABLE IF EXISTS iox_catalog.sequencer
+ALTER TABLE IF EXISTS sequencer
     ADD FOREIGN KEY (kafka_topic_id)
-    REFERENCES iox_catalog.kafka_topic (id) MATCH SIMPLE
+    REFERENCES kafka_topic (id) MATCH SIMPLE
     ON UPDATE NO ACTION
        ON DELETE NO ACTION
 	NOT VALID;
 
-ALTER TABLE IF EXISTS iox_catalog.sharding_rule_override
+ALTER TABLE IF EXISTS sharding_rule_override
     ADD FOREIGN KEY (namespace_id)
-    REFERENCES iox_catalog.namespace (id) MATCH SIMPLE
+    REFERENCES namespace (id) MATCH SIMPLE
     ON UPDATE NO ACTION
        ON DELETE NO ACTION
 	NOT VALID;
 
-ALTER TABLE IF EXISTS iox_catalog.sharding_rule_override
+ALTER TABLE IF EXISTS sharding_rule_override
     ADD FOREIGN KEY (table_id)
-    REFERENCES iox_catalog.table_name (id) MATCH SIMPLE
+    REFERENCES table_name (id) MATCH SIMPLE
     ON UPDATE NO ACTION
        ON DELETE NO ACTION
 	NOT VALID;
 
-ALTER TABLE IF EXISTS iox_catalog.sharding_rule_override
+ALTER TABLE IF EXISTS sharding_rule_override
     ADD FOREIGN KEY (column_id)
-    REFERENCES iox_catalog.column_name (id) MATCH SIMPLE
+    REFERENCES column_name (id) MATCH SIMPLE
     ON UPDATE NO ACTION
        ON DELETE NO ACTION
 	NOT VALID;
 
-ALTER TABLE IF EXISTS iox_catalog.partition
+ALTER TABLE IF EXISTS partition
     ADD FOREIGN KEY (sequencer_id)
-    REFERENCES iox_catalog.sequencer (id) MATCH SIMPLE
+    REFERENCES sequencer (id) MATCH SIMPLE
     ON UPDATE NO ACTION
        ON DELETE NO ACTION
 	NOT VALID;
 
-ALTER TABLE IF EXISTS iox_catalog.partition
+ALTER TABLE IF EXISTS partition
     ADD FOREIGN KEY (table_id)
-    REFERENCES iox_catalog.table_name (id) MATCH SIMPLE
+    REFERENCES table_name (id) MATCH SIMPLE
     ON UPDATE NO ACTION
        ON DELETE NO ACTION
 	NOT VALID;
 
-ALTER TABLE IF EXISTS iox_catalog.parquet_file
+ALTER TABLE IF EXISTS parquet_file
     ADD FOREIGN KEY (sequencer_id)
-    REFERENCES iox_catalog.sequencer (id) MATCH SIMPLE
+    REFERENCES sequencer (id) MATCH SIMPLE
     ON UPDATE NO ACTION
        ON DELETE NO ACTION
 	NOT VALID;
 
-ALTER TABLE IF EXISTS iox_catalog.parquet_file
+ALTER TABLE IF EXISTS parquet_file
     ADD FOREIGN KEY (table_id)
-    REFERENCES iox_catalog.table_name (id) MATCH SIMPLE
+    REFERENCES table_name (id) MATCH SIMPLE
     ON UPDATE NO ACTION
        ON DELETE NO ACTION
 	NOT VALID;
 
-ALTER TABLE IF EXISTS iox_catalog.parquet_file
+ALTER TABLE IF EXISTS parquet_file
     ADD FOREIGN KEY (partition_id)
-    REFERENCES iox_catalog.partition (id) MATCH SIMPLE
+    REFERENCES partition (id) MATCH SIMPLE
     ON UPDATE NO ACTION
        ON DELETE NO ACTION
 	NOT VALID;
 
-ALTER TABLE IF EXISTS iox_catalog.tombstone
+ALTER TABLE IF EXISTS tombstone
     ADD FOREIGN KEY (sequencer_id)
-    REFERENCES iox_catalog.sequencer (id) MATCH SIMPLE
+    REFERENCES sequencer (id) MATCH SIMPLE
     ON UPDATE NO ACTION
        ON DELETE NO ACTION
 	NOT VALID;
 
-ALTER TABLE IF EXISTS iox_catalog.tombstone
+ALTER TABLE IF EXISTS tombstone
     ADD FOREIGN KEY (table_id)
-    REFERENCES iox_catalog.table_name (id) MATCH SIMPLE
+    REFERENCES table_name (id) MATCH SIMPLE
     ON UPDATE NO ACTION
        ON DELETE NO ACTION
 	NOT VALID;
 
-ALTER TABLE IF EXISTS iox_catalog.processed_tombstone
+ALTER TABLE IF EXISTS processed_tombstone
     ADD FOREIGN KEY (tombstone_id)
-    REFERENCES iox_catalog.tombstone (id) MATCH SIMPLE
+    REFERENCES tombstone (id) MATCH SIMPLE
     ON UPDATE NO ACTION
        ON DELETE NO ACTION
 	NOT VALID;
 
-ALTER TABLE IF EXISTS iox_catalog.processed_tombstone
+ALTER TABLE IF EXISTS processed_tombstone
     ADD FOREIGN KEY (parquet_file_id)
-    REFERENCES iox_catalog.parquet_file (id) MATCH SIMPLE
+    REFERENCES parquet_file (id) MATCH SIMPLE
     ON UPDATE NO ACTION
        ON DELETE NO ACTION
 	NOT VALID;

--- a/iox_catalog/migrations/20211229171744_initial_schema.sql
+++ b/iox_catalog/migrations/20211229171744_initial_schema.sql
@@ -1,25 +1,19 @@
--- Add migration script here
 -- iox_shared schema
-CREATE SCHEMA IF NOT EXISTS iox_catalog;
-
-CREATE TABLE IF NOT EXISTS kafka_topic
-(
+CREATE TABLE IF NOT EXISTS kafka_topic (
     id INT GENERATED ALWAYS AS IDENTITY,
     name VARCHAR NOT NULL,
     PRIMARY KEY (id),
     CONSTRAINT kafka_topic_name_unique UNIQUE (name)
-    );
+);
 
-CREATE TABLE IF NOT EXISTS query_pool
-(
+CREATE TABLE IF NOT EXISTS query_pool (
     id SMALLINT GENERATED ALWAYS AS IDENTITY,
     name VARCHAR NOT NULL,
     PRIMARY KEY (id),
     CONSTRAINT query_pool_name_unique UNIQUE (name)
-    );
+);
 
-CREATE TABLE IF NOT EXISTS namespace
-(
+CREATE TABLE IF NOT EXISTS namespace (
     id INT GENERATED ALWAYS AS IDENTITY,
     name VARCHAR NOT NULL,
     retention_duration VARCHAR,
@@ -27,58 +21,52 @@ CREATE TABLE IF NOT EXISTS namespace
     query_pool_id SMALLINT NOT NULL,
     PRIMARY KEY (id),
     CONSTRAINT namespace_name_unique UNIQUE (name)
-    );
+);
 
-CREATE TABLE IF NOT EXISTS table_name
-(
+CREATE TABLE IF NOT EXISTS table_name (
     id INT GENERATED ALWAYS AS IDENTITY,
     namespace_id integer NOT NULL,
     name VARCHAR NOT NULL,
     PRIMARY KEY (id),
     CONSTRAINT table_name_unique UNIQUE (namespace_id, name)
-    );
+);
 
-CREATE TABLE IF NOT EXISTS column_name
-(
+CREATE TABLE IF NOT EXISTS column_name (
     id INT GENERATED ALWAYS AS IDENTITY,
     table_id INT NOT NULL,
     name VARCHAR NOT NULL,
     column_type SMALLINT NOT NULL,
     PRIMARY KEY (id),
     CONSTRAINT column_name_unique UNIQUE (table_id, name)
-    );
+);
 
-CREATE TABLE IF NOT EXISTS sequencer
-(
+CREATE TABLE IF NOT EXISTS sequencer (
     id SMALLINT GENERATED ALWAYS AS IDENTITY,
     kafka_topic_id INT NOT NULL,
     kafka_partition INT NOT NULL,
     min_unpersisted_sequence_number BIGINT,
     PRIMARY KEY (id),
     CONSTRAINT sequencer_unique UNIQUE (kafka_topic_id, kafka_partition)
-    );
+);
 
-CREATE TABLE IF NOT EXISTS sharding_rule_override
-(
+CREATE TABLE IF NOT EXISTS sharding_rule_override (
     id INT GENERATED ALWAYS AS IDENTITY,
     namespace_id INT NOT NULL,
     table_id INT NOT NULL,
     column_id INT NOT NULL,
     PRIMARY KEY (id)
-    );
+);
 
-CREATE TABLE IF NOT EXISTS partition
-(
+CREATE TABLE IF NOT EXISTS PARTITION (
     id BIGINT GENERATED ALWAYS AS IDENTITY,
     sequencer_id SMALLINT NOT NULL,
     table_id INT NOT NULL,
     partition_key VARCHAR NOT NULL,
     PRIMARY KEY (id),
     CONSTRAINT partition_key_unique UNIQUE (table_id, partition_key)
-    );
+);
 
-CREATE TABLE IF NOT EXISTS parquet_file
-(
+CREATE TABLE IF NOT EXISTS parquet_file (
     id BIGINT GENERATED ALWAYS AS IDENTITY,
     sequencer_id SMALLINT NOT NULL,
     table_id INT NOT NULL,
@@ -91,10 +79,9 @@ CREATE TABLE IF NOT EXISTS parquet_file
     to_delete BOOLEAN,
     PRIMARY KEY (id),
     CONSTRAINT parquet_location_unique UNIQUE (object_store_id)
-    );
+);
 
-CREATE TABLE IF NOT EXISTS tombstone
-(
+CREATE TABLE IF NOT EXISTS tombstone (
     id BIGINT GENERATED ALWAYS AS IDENTITY,
     table_id INT NOT NULL,
     sequencer_id SMALLINT NOT NULL,
@@ -104,130 +91,95 @@ CREATE TABLE IF NOT EXISTS tombstone
     serialized_predicate TEXT NOT NULL,
     PRIMARY KEY (id),
     CONSTRAINT tombstone_unique UNIQUE (table_id, sequencer_id, sequence_number)
-    );
+);
 
-CREATE TABLE IF NOT EXISTS processed_tombstone
-(
+CREATE TABLE IF NOT EXISTS processed_tombstone (
     tombstone_id BIGINT NOT NULL,
     parquet_file_id BIGINT NOT NULL,
     PRIMARY KEY (tombstone_id, parquet_file_id)
-    );
+);
 
-ALTER TABLE IF EXISTS namespace
-    ADD FOREIGN KEY (kafka_topic_id)
-    REFERENCES kafka_topic (id) MATCH SIMPLE
-    ON UPDATE NO ACTION
-       ON DELETE NO ACTION
-	NOT VALID;
+ALTER TABLE
+    IF EXISTS namespace
+ADD
+    FOREIGN KEY (kafka_topic_id) REFERENCES kafka_topic (id) MATCH SIMPLE ON UPDATE NO ACTION ON DELETE NO ACTION NOT VALID;
 
-ALTER TABLE IF EXISTS namespace
-    ADD FOREIGN KEY (query_pool_id)
-    REFERENCES query_pool (id) MATCH SIMPLE
-    ON UPDATE NO ACTION
-       ON DELETE NO ACTION
-	NOT VALID;
+ALTER TABLE
+    IF EXISTS namespace
+ADD
+    FOREIGN KEY (query_pool_id) REFERENCES query_pool (id) MATCH SIMPLE ON UPDATE NO ACTION ON DELETE NO ACTION NOT VALID;
 
-ALTER TABLE IF EXISTS table_name
-    ADD FOREIGN KEY (namespace_id)
-    REFERENCES namespace (id) MATCH SIMPLE
-    ON UPDATE NO ACTION
-       ON DELETE NO ACTION
-	NOT VALID;
+ALTER TABLE
+    IF EXISTS table_name
+ADD
+    FOREIGN KEY (namespace_id) REFERENCES namespace (id) MATCH SIMPLE ON UPDATE NO ACTION ON DELETE NO ACTION NOT VALID;
 
-ALTER TABLE IF EXISTS column_name
-    ADD FOREIGN KEY (table_id)
-    REFERENCES table_name (id) MATCH SIMPLE
-    ON UPDATE NO ACTION
-       ON DELETE NO ACTION
-	NOT VALID;
+ALTER TABLE
+    IF EXISTS column_name
+ADD
+    FOREIGN KEY (table_id) REFERENCES table_name (id) MATCH SIMPLE ON UPDATE NO ACTION ON DELETE NO ACTION NOT VALID;
 
-ALTER TABLE IF EXISTS sequencer
-    ADD FOREIGN KEY (kafka_topic_id)
-    REFERENCES kafka_topic (id) MATCH SIMPLE
-    ON UPDATE NO ACTION
-       ON DELETE NO ACTION
-	NOT VALID;
+ALTER TABLE
+    IF EXISTS sequencer
+ADD
+    FOREIGN KEY (kafka_topic_id) REFERENCES kafka_topic (id) MATCH SIMPLE ON UPDATE NO ACTION ON DELETE NO ACTION NOT VALID;
 
-ALTER TABLE IF EXISTS sharding_rule_override
-    ADD FOREIGN KEY (namespace_id)
-    REFERENCES namespace (id) MATCH SIMPLE
-    ON UPDATE NO ACTION
-       ON DELETE NO ACTION
-	NOT VALID;
+ALTER TABLE
+    IF EXISTS sharding_rule_override
+ADD
+    FOREIGN KEY (namespace_id) REFERENCES namespace (id) MATCH SIMPLE ON UPDATE NO ACTION ON DELETE NO ACTION NOT VALID;
 
-ALTER TABLE IF EXISTS sharding_rule_override
-    ADD FOREIGN KEY (table_id)
-    REFERENCES table_name (id) MATCH SIMPLE
-    ON UPDATE NO ACTION
-       ON DELETE NO ACTION
-	NOT VALID;
+ALTER TABLE
+    IF EXISTS sharding_rule_override
+ADD
+    FOREIGN KEY (table_id) REFERENCES table_name (id) MATCH SIMPLE ON UPDATE NO ACTION ON DELETE NO ACTION NOT VALID;
 
-ALTER TABLE IF EXISTS sharding_rule_override
-    ADD FOREIGN KEY (column_id)
-    REFERENCES column_name (id) MATCH SIMPLE
-    ON UPDATE NO ACTION
-       ON DELETE NO ACTION
-	NOT VALID;
+ALTER TABLE
+    IF EXISTS sharding_rule_override
+ADD
+    FOREIGN KEY (column_id) REFERENCES column_name (id) MATCH SIMPLE ON UPDATE NO ACTION ON DELETE NO ACTION NOT VALID;
 
-ALTER TABLE IF EXISTS partition
-    ADD FOREIGN KEY (sequencer_id)
-    REFERENCES sequencer (id) MATCH SIMPLE
-    ON UPDATE NO ACTION
-       ON DELETE NO ACTION
-	NOT VALID;
+ALTER TABLE
+    IF EXISTS PARTITION
+ADD
+    FOREIGN KEY (sequencer_id) REFERENCES sequencer (id) MATCH SIMPLE ON UPDATE NO ACTION ON DELETE NO ACTION NOT VALID;
 
-ALTER TABLE IF EXISTS partition
-    ADD FOREIGN KEY (table_id)
-    REFERENCES table_name (id) MATCH SIMPLE
-    ON UPDATE NO ACTION
-       ON DELETE NO ACTION
-	NOT VALID;
+ALTER TABLE
+    IF EXISTS PARTITION
+ADD
+    FOREIGN KEY (table_id) REFERENCES table_name (id) MATCH SIMPLE ON UPDATE NO ACTION ON DELETE NO ACTION NOT VALID;
 
-ALTER TABLE IF EXISTS parquet_file
-    ADD FOREIGN KEY (sequencer_id)
-    REFERENCES sequencer (id) MATCH SIMPLE
-    ON UPDATE NO ACTION
-       ON DELETE NO ACTION
-	NOT VALID;
+ALTER TABLE
+    IF EXISTS parquet_file
+ADD
+    FOREIGN KEY (sequencer_id) REFERENCES sequencer (id) MATCH SIMPLE ON UPDATE NO ACTION ON DELETE NO ACTION NOT VALID;
 
-ALTER TABLE IF EXISTS parquet_file
-    ADD FOREIGN KEY (table_id)
-    REFERENCES table_name (id) MATCH SIMPLE
-    ON UPDATE NO ACTION
-       ON DELETE NO ACTION
-	NOT VALID;
+ALTER TABLE
+    IF EXISTS parquet_file
+ADD
+    FOREIGN KEY (table_id) REFERENCES table_name (id) MATCH SIMPLE ON UPDATE NO ACTION ON DELETE NO ACTION NOT VALID;
 
-ALTER TABLE IF EXISTS parquet_file
-    ADD FOREIGN KEY (partition_id)
-    REFERENCES partition (id) MATCH SIMPLE
-    ON UPDATE NO ACTION
-       ON DELETE NO ACTION
-	NOT VALID;
+ALTER TABLE
+    IF EXISTS parquet_file
+ADD
+    FOREIGN KEY (partition_id) REFERENCES PARTITION (id) MATCH SIMPLE ON UPDATE NO ACTION ON DELETE NO ACTION NOT VALID;
 
-ALTER TABLE IF EXISTS tombstone
-    ADD FOREIGN KEY (sequencer_id)
-    REFERENCES sequencer (id) MATCH SIMPLE
-    ON UPDATE NO ACTION
-       ON DELETE NO ACTION
-	NOT VALID;
+ALTER TABLE
+    IF EXISTS tombstone
+ADD
+    FOREIGN KEY (sequencer_id) REFERENCES sequencer (id) MATCH SIMPLE ON UPDATE NO ACTION ON DELETE NO ACTION NOT VALID;
 
-ALTER TABLE IF EXISTS tombstone
-    ADD FOREIGN KEY (table_id)
-    REFERENCES table_name (id) MATCH SIMPLE
-    ON UPDATE NO ACTION
-       ON DELETE NO ACTION
-	NOT VALID;
+ALTER TABLE
+    IF EXISTS tombstone
+ADD
+    FOREIGN KEY (table_id) REFERENCES table_name (id) MATCH SIMPLE ON UPDATE NO ACTION ON DELETE NO ACTION NOT VALID;
 
-ALTER TABLE IF EXISTS processed_tombstone
-    ADD FOREIGN KEY (tombstone_id)
-    REFERENCES tombstone (id) MATCH SIMPLE
-    ON UPDATE NO ACTION
-       ON DELETE NO ACTION
-	NOT VALID;
+ALTER TABLE
+    IF EXISTS processed_tombstone
+ADD
+    FOREIGN KEY (tombstone_id) REFERENCES tombstone (id) MATCH SIMPLE ON UPDATE NO ACTION ON DELETE NO ACTION NOT VALID;
 
-ALTER TABLE IF EXISTS processed_tombstone
-    ADD FOREIGN KEY (parquet_file_id)
-    REFERENCES parquet_file (id) MATCH SIMPLE
-    ON UPDATE NO ACTION
-       ON DELETE NO ACTION
-	NOT VALID;
+ALTER TABLE
+    IF EXISTS processed_tombstone
+ADD
+    FOREIGN KEY (parquet_file_id) REFERENCES parquet_file (id) MATCH SIMPLE ON UPDATE NO ACTION ON DELETE NO ACTION NOT VALID;


### PR DESCRIPTION
This PR enables catalog tests to run in parallel without interfering with each other.

While working on the catalog I added a couple tests and (eventually) discovered they were trashing each other's global catalog state as it was shared across tests. This is currently avoided by running all the test code runs in one test (`test_catalog`).

The test code paths now generate a random schema name for each catalog test (or more specifically, for each call to [`setup_db`](https://github.com/influxdata/influxdb_iox/blob/44e9eaf92b0740af5e2087fc03cf0220cea7323c/iox_catalog/src/postgres.rs#L928-L968)). The prod code paths [continue to use `iox_catalog`](https://github.com/influxdata/influxdb_iox/blob/44e9eaf92b0740af5e2087fc03cf0220cea7323c/influxdb_iox/src/clap_blocks/catalog_dsn.rs#L47) as the schema name.

A list of schmeas after running `TEST_INTEGRATION=1 cargo test` 3 times against a clean PG:

```
       List of schemas
         Name         | Owner
----------------------+-------
 bxnrwtwjigvjapwowyda | dom
 iox_catalog          | dom
 lrzbxfrakfnkkmnahyoc | dom
 pbxwasxwfjbgqmavanju | dom
 public               | dom
(5 rows)
```

---

* refactor: do not specify schema in migrations (3b378418)

      Allow the caller to set the Postgres schema a migration should be applied to,
      rather than restricting the migration to a specific, hard-coded schema.

      BREAKING CHANGE: manually adds a new migration that precedes the existing
      migration to ensure the iox_catalog schema exists before applying the
      migration. You'll probably have to drop any existing databases and migrate
      from scratch:

          sqlx database drop; sqlx database create;

* test(iox_catalog): isolated catalog tests (44e9eaf9)

      This commit changes the iox_catalog test harness so that each test is run in
      an independent, randomly generated schema to avoid concurrent tests
      interfering with each other.

      Each test creates a randomly-named schema, grants permissions to the new 
      schema, runs the full migration stack against the new schema, and then 
      executes the code under test.