### PR TITLE
fix: catalog spurious writes

### DIFF
--- a/iox_catalog/src/postgres.rs
+++ b/iox_catalog/src/postgres.rs
@@ -882,11 +882,12 @@ fn is_fk_violation(e: &sqlx::Error) -> bool {
 
 #[cfg(test)]
 mod tests {
+    use crate::create_or_get_default_records;
+
     use super::*;
 
     use rand::Rng;
-    use std::env;
-    use std::sync::Arc;
+    use std::{env, ops::DerefMut, sync::Arc};
 
     // Helper macro to skip tests if TEST_INTEGRATION and the AWS environment variables are not set.
     macro_rules! maybe_skip_integration {
@@ -978,5 +979,285 @@ mod tests {
         let postgres: Arc<dyn Catalog> = Arc::new(postgres);
 
         crate::interface::test_helpers::test_catalog(postgres).await;
+    }
+
+    #[tokio::test]
+    async fn test_tombstone_create_or_get_idempotent() {
+        // If running an integration test on your laptop, this requires that you have Postgres
+        // running and that you've done the sqlx migrations. See the README in this crate for
+        // info to set it up.
+        maybe_skip_integration!();
+
+        let postgres = setup_db().await;
+        let postgres: Arc<dyn Catalog> = Arc::new(postgres);
+
+        let mut txn = postgres.start_transaction().await.expect("txn start");
+        let (kafka, query, sequencers) = create_or_get_default_records(1, txn.deref_mut())
+            .await
+            .expect("db init failed");
+        txn.commit().await.expect("txn commit");
+
+        let namespace_id = postgres
+            .repositories()
+            .await
+            .namespaces()
+            .create("ns", crate::INFINITE_RETENTION_POLICY, kafka.id, query.id)
+            .await
+            .expect("namespace create failed")
+            .id;
+        let table_id = postgres
+            .repositories()
+            .await
+            .tables()
+            .create_or_get("table", namespace_id)
+            .await
+            .expect("create table failed")
+            .id;
+
+        let sequencer_id = *sequencers.keys().next().expect("no sequencer");
+        let sequence_number = SequenceNumber::new(3);
+        let min_timestamp = Timestamp::new(10);
+        let max_timestamp = Timestamp::new(100);
+        let predicate = "bananas";
+
+        let a = postgres
+            .repositories()
+            .await
+            .tombstones()
+            .create_or_get(
+                table_id,
+                sequencer_id,
+                sequence_number,
+                min_timestamp,
+                max_timestamp,
+                predicate,
+            )
+            .await
+            .expect("should create OK");
+
+        // Call create_or_get for the same (table_id, sequencer_id,
+        // sequence_number) triplet, setting the same metadata to ensure the
+        // write is idempotent.
+        let b = postgres
+            .repositories()
+            .await
+            .tombstones()
+            .create_or_get(
+                table_id,
+                sequencer_id,
+                sequence_number,
+                min_timestamp,
+                max_timestamp,
+                predicate,
+            )
+            .await
+            .expect("idempotent write should succeed");
+
+        assert_eq!(a, b);
+    }
+
+    #[tokio::test]
+    #[should_panic = "attempted to overwrite predicate"]
+    async fn test_tombstone_create_or_get_no_overwrite() {
+        // If running an integration test on your laptop, this requires that you have Postgres
+        // running and that you've done the sqlx migrations. See the README in this crate for
+        // info to set it up.
+        maybe_skip_integration!();
+
+        let postgres = setup_db().await;
+        let postgres: Arc<dyn Catalog> = Arc::new(postgres);
+
+        let mut txn = postgres.start_transaction().await.expect("txn start");
+        let (kafka, query, sequencers) = create_or_get_default_records(1, txn.deref_mut())
+            .await
+            .expect("db init failed");
+        txn.commit().await.expect("txn commit");
+
+        let namespace_id = postgres
+            .repositories()
+            .await
+            .namespaces()
+            .create("ns2", crate::INFINITE_RETENTION_POLICY, kafka.id, query.id)
+            .await
+            .expect("namespace create failed")
+            .id;
+        let table_id = postgres
+            .repositories()
+            .await
+            .tables()
+            .create_or_get("table2", namespace_id)
+            .await
+            .expect("create table failed")
+            .id;
+
+        let sequencer_id = *sequencers.keys().next().expect("no sequencer");
+        let sequence_number = SequenceNumber::new(3);
+        let min_timestamp = Timestamp::new(10);
+        let max_timestamp = Timestamp::new(100);
+
+        let a = postgres
+            .repositories()
+            .await
+            .tombstones()
+            .create_or_get(
+                table_id,
+                sequencer_id,
+                sequence_number,
+                min_timestamp,
+                max_timestamp,
+                "bananas",
+            )
+            .await
+            .expect("should create OK");
+
+        // Call create_or_get for the same (table_id, sequencer_id,
+        // sequence_number) triplet with different metadata.
+        //
+        // The caller should not falsely believe it has persisted the incorrect
+        // predicate.
+        let b = postgres
+            .repositories()
+            .await
+            .tombstones()
+            .create_or_get(
+                table_id,
+                sequencer_id,
+                sequence_number,
+                min_timestamp,
+                max_timestamp,
+                "some other serialised predicate which is different",
+            )
+            .await
+            .expect("should panic before result evaluated");
+
+        assert_eq!(a, b);
+    }
+
+    #[tokio::test]
+    async fn test_partition_create_or_get_idempotent() {
+        // If running an integration test on your laptop, this requires that you have Postgres
+        // running and that you've done the sqlx migrations. See the README in this crate for
+        // info to set it up.
+        maybe_skip_integration!();
+
+        let postgres = setup_db().await;
+
+        let postgres: Arc<dyn Catalog> = Arc::new(postgres);
+        let mut txn = postgres.start_transaction().await.expect("txn start");
+        let (kafka, query, sequencers) = create_or_get_default_records(1, txn.deref_mut())
+            .await
+            .expect("db init failed");
+        txn.commit().await.expect("txn commit");
+
+        let namespace_id = postgres
+            .repositories()
+            .await
+            .namespaces()
+            .create("ns4", crate::INFINITE_RETENTION_POLICY, kafka.id, query.id)
+            .await
+            .expect("namespace create failed")
+            .id;
+        let table_id = postgres
+            .repositories()
+            .await
+            .tables()
+            .create_or_get("table", namespace_id)
+            .await
+            .expect("create table failed")
+            .id;
+
+        let key = "bananas";
+        let sequencer_id = *sequencers.keys().next().expect("no sequencer");
+
+        let a = postgres
+            .repositories()
+            .await
+            .partitions()
+            .create_or_get(key, sequencer_id, table_id)
+            .await
+            .expect("should create OK");
+
+        // Call create_or_get for the same (key, table_id, sequencer_id)
+        // triplet, setting the same sequencer ID to ensure the write is
+        // idempotent.
+        let b = postgres
+            .repositories()
+            .await
+            .partitions()
+            .create_or_get(key, sequencer_id, table_id)
+            .await
+            .expect("idempotent write should succeed");
+
+        assert_eq!(a, b);
+    }
+
+    #[tokio::test]
+    #[should_panic = "attempted to overwrite partition"]
+    async fn test_partition_create_or_get_no_overwrite() {
+        // If running an integration test on your laptop, this requires that you have Postgres
+        // running and that you've done the sqlx migrations. See the README in this crate for
+        // info to set it up.
+        maybe_skip_integration!();
+
+        let postgres = setup_db().await;
+
+        let postgres: Arc<dyn Catalog> = Arc::new(postgres);
+        let mut txn = postgres.start_transaction().await.expect("txn start");
+        let (kafka, query, _) = create_or_get_default_records(2, txn.deref_mut())
+            .await
+            .expect("db init failed");
+        txn.commit().await.expect("txn commit");
+
+        let namespace_id = postgres
+            .repositories()
+            .await
+            .namespaces()
+            .create("ns3", crate::INFINITE_RETENTION_POLICY, kafka.id, query.id)
+            .await
+            .expect("namespace create failed")
+            .id;
+        let table_id = postgres
+            .repositories()
+            .await
+            .tables()
+            .create_or_get("table", namespace_id)
+            .await
+            .expect("create table failed")
+            .id;
+
+        let key = "bananas";
+
+        let sequencers = postgres
+            .repositories()
+            .await
+            .sequencers()
+            .list()
+            .await
+            .expect("failed to list sequencers");
+        assert!(
+            sequencers.len() > 1,
+            "expected more sequencers to be created, got {}",
+            sequencers.len()
+        );
+
+        let a = postgres
+            .repositories()
+            .await
+            .partitions()
+            .create_or_get(key, sequencers[0].id, table_id)
+            .await
+            .expect("should create OK");
+
+        // Call create_or_get for the same (key, table_id) tuple, setting a
+        // different sequencer ID
+        let b = postgres
+            .repositories()
+            .await
+            .partitions()
+            .create_or_get(key, sequencers[1].id, table_id)
+            .await
+            .expect("result should not be evaluated");
+
+        assert_eq!(a, b);
     }
 }


### PR DESCRIPTION
Adds a couple invariant asserts to ensure we're not accidentally proceeding under the assumption a write has succeeded, when in fact the data in the catalog does not match.

---

* test(iox_catalog): assert no spurious writes (4b72b40d)

      This commit introduces test cases that ensure that for each of the tombstone &
      partition repos:

          * create_or_get() is idempotent
          * create_or_get() does not silently drop conflicting writes

      The former covers the expected use case: callers issuing potentially multiple
      calls to create_or_get() with the same args, causing the catalog impl to
      transparently turn the subsequent calls into NOPs.

      The latter illustrates an issue where multiple calls to create_or_get() with
      differing arguments is silently accepted by the catalog, causing both callers
      to believe they have committed the (differing) details they provided. This
      test is expected to pass but fails in this commit.

* fix: assert on conflicting partition creation (334eb88a)

      If two callers call create_or_get() for a partition, providing the same 
      partition key & table ID, but different sequence numbers the catalog MUST NOT
      continue silently.

      As this is unexpected, this behaviour causes a panic.

* fix: assert on conflicting tombstone creation (16d4312b)

      If two callers call create_or_get() for a tombstone, providing the same
      (table_id, sequencer_id, sequence_number) triplet but a different predicate /
      timestamps the catalog MUST NOT silently continue.

      As this is unexpected, this behaviour causes a panic.