### PR TITLE
refactor(router2): non-intrusive handler chain

### DIFF
--- a/router2/benches/e2e.rs
+++ b/router2/benches/e2e.rs
@@ -1,14 +1,18 @@
-use std::collections::BTreeSet;
-use std::sync::Arc;
+use std::{collections::BTreeSet, iter, sync::Arc};
 
-use criterion::measurement::WallTime;
-use criterion::{criterion_group, criterion_main, BenchmarkGroup, Criterion, Throughput};
+use criterion::{criterion_group, criterion_main, Criterion, Throughput};
 use data_types::database_rules::{PartitionTemplate, TemplatePart};
 use hyper::{Body, Request};
-use router2::dml_handlers::{Partitioner, ShardedWriteBuffer};
-use router2::sequencer::Sequencer;
-use router2::server::http::HttpDelegate;
-use router2::sharder::JumpHash;
+use iox_catalog::{interface::Catalog, mem::MemCatalog};
+use router2::{
+    dml_handlers::{
+        DmlHandlerChainExt, FanOutAdaptor, Partitioner, SchemaValidator, ShardedWriteBuffer,
+    },
+    namespace_cache::{MemoryNamespaceCache, ShardedCache},
+    sequencer::Sequencer,
+    server::http::HttpDelegate,
+    sharder::JumpHash,
+};
 use tokio::runtime::Runtime;
 use write_buffer::core::WriteBufferWriting;
 use write_buffer::mock::{MockBufferForWriting, MockBufferSharedState};
@@ -37,17 +41,6 @@ fn init_write_buffer(n_sequencers: u32) -> ShardedWriteBuffer<JumpHash<Arc<Seque
     )
 }
 
-fn setup_server() -> HttpDelegate<Partitioner<ShardedWriteBuffer<JumpHash<Arc<Sequencer>>>>> {
-    let handler_stack = init_write_buffer(1);
-    let handler_stack = Partitioner::new(
-        handler_stack,
-        PartitionTemplate {
-            parts: vec![TemplatePart::TimeFormat("%Y-%m-%d".to_owned())],
-        },
-    );
-    HttpDelegate::new(1024, handler_stack)
-}
-
 fn runtime() -> Runtime {
     tokio::runtime::Builder::new_multi_thread()
         .enable_io()
@@ -59,34 +52,39 @@ fn runtime() -> Runtime {
 fn e2e_benchmarks(c: &mut Criterion) {
     let mut group = c.benchmark_group("e2e");
 
-    let delegate = setup_server();
-    benchmark_e2e(
-        &mut group,
-        &delegate,
-        "https://bananas.example/api/v2/write?org=bananas&bucket=test",
-        "platanos,tag1=A,tag2=B val=42i 123456",
-    );
+    let delegate = {
+        let catalog: Arc<dyn Catalog> = Arc::new(MemCatalog::default());
+        let ns_cache = Arc::new(ShardedCache::new(
+            iter::repeat_with(|| Arc::new(MemoryNamespaceCache::default())).take(10),
+        ));
 
-    group.finish();
-}
+        let write_buffer = init_write_buffer(1);
+        let schema_validator = SchemaValidator::new(Arc::clone(&catalog), Arc::clone(&ns_cache));
+        let partitioner = Partitioner::new(PartitionTemplate {
+            parts: vec![TemplatePart::TimeFormat("%Y-%m-%d".to_owned())],
+        });
 
-fn benchmark_e2e(
-    group: &mut BenchmarkGroup<WallTime>,
-    http_delegate: &HttpDelegate<Partitioner<ShardedWriteBuffer<JumpHash<Arc<Sequencer>>>>>,
-    uri: &'static str,
-    body_str: &'static str,
-) {
+        let handler_stack =
+            partitioner.and_then(FanOutAdaptor::new(schema_validator.and_then(write_buffer)));
+
+        HttpDelegate::new(1024, handler_stack)
+    };
+
+    let body_str = "platanos,tag1=A,tag2=B val=42i 123456";
+
     group.throughput(Throughput::Bytes(body_str.len() as u64));
     group.bench_function("e2e", |b| {
         b.to_async(runtime()).iter(|| {
             let request = Request::builder()
-                .uri(uri)
+                .uri("https://bananas.example/api/v2/write?org=bananas&bucket=test")
                 .method("POST")
                 .body(Body::from(body_str.as_bytes()))
                 .unwrap();
-            http_delegate.route(request)
+            delegate.route(request)
         })
     });
+
+    group.finish();
 }
 
 criterion_group!(benches, e2e_benchmarks);

--- a/router2/src/dml_handlers/chain.rs
+++ b/router2/src/dml_handlers/chain.rs
@@ -1,0 +1,95 @@
+use async_trait::async_trait;
+use data_types::{delete_predicate::DeletePredicate, DatabaseName};
+use trace::ctx::SpanContext;
+
+use super::{DmlError, DmlHandler};
+
+/// An extension trait to chain together the execution of a pair of
+/// [`DmlHandler`] implementations.
+pub trait DmlHandlerChainExt: DmlHandler + Sized {
+    /// Chain `next` onto `self`, calling `next` if executing `self` DML
+    /// handler is `Ok`.
+    ///
+    /// If `self` returns an error when executing the DML handler, `next` is not
+    /// called and the error is returned.
+    fn and_then<T>(self, next: T) -> Chain<Self, T>
+    where
+        T: DmlHandler,
+    {
+        Chain::new(self, next)
+    }
+}
+
+impl<T> DmlHandlerChainExt for T where T: DmlHandler {}
+
+/// A combinator type that calls `T` and if successful, calls `U` with the
+/// (potentially transformed) DML operation.
+///
+/// This type is constructed by calling [`DmlHandlerChainExt::and_then()`] on a
+/// [`DmlHandler`] implementation.
+#[derive(Debug)]
+pub struct Chain<T, U> {
+    first: T,
+    second: U,
+}
+
+impl<T, U> Chain<T, U> {
+    fn new(first: T, second: U) -> Self {
+        Self { first, second }
+    }
+}
+
+#[async_trait]
+impl<T, U> DmlHandler for Chain<T, U>
+where
+    T: DmlHandler,
+    U: DmlHandler<WriteInput = T::WriteOutput>,
+{
+    // Take the first input type, and return the possibly transformed second
+    // handler's output type.
+    type WriteInput = T::WriteInput;
+    type WriteOutput = U::WriteOutput;
+
+    // All errors are converted into DML errors before returning to the caller
+    // in order to present a consistent error type for chained handlers.
+    type WriteError = DmlError;
+    type DeleteError = DmlError;
+
+    /// Write `batches` to `namespace`.
+    async fn write(
+        &self,
+        namespace: &DatabaseName<'static>,
+        input: Self::WriteInput,
+        span_ctx: Option<SpanContext>,
+    ) -> Result<Self::WriteOutput, Self::WriteError> {
+        let output = self
+            .first
+            .write(namespace, input, span_ctx.clone())
+            .await
+            .map_err(Into::into)?;
+
+        self.second
+            .write(namespace, output, span_ctx)
+            .await
+            .map_err(Into::into)
+    }
+
+    /// Delete the data specified in `delete`.
+    async fn delete(
+        &self,
+        namespace: &DatabaseName<'static>,
+        table_name: &str,
+        predicate: &DeletePredicate,
+        span_ctx: Option<SpanContext>,
+    ) -> Result<(), Self::DeleteError> {
+        self.first
+            .delete(namespace, table_name, predicate, span_ctx.clone())
+            .await
+            .map_err(Into::into)?;
+
+        self.second
+            .delete(namespace, table_name, predicate, span_ctx)
+            .await
+            .map_err(Into::into)
+    }
+}

--- a/router2/src/dml_handlers/fan_out.rs
+++ b/router2/src/dml_handlers/fan_out.rs
@@ -1,0 +1,82 @@
+use std::{fmt::Debug, future, marker::PhantomData};
+
+use async_trait::async_trait;
+use data_types::{delete_predicate::DeletePredicate, DatabaseName};
+use futures::{stream::FuturesUnordered, TryStreamExt};
+use trace::ctx::SpanContext;
+
+use super::DmlHandler;
+
+/// A [`FanOutAdaptor`] takes an iterator of DML write operation inputs and
+/// executes them concurrently against the inner handler, returning once all
+/// operations are complete.
+///
+/// If handling an operation produces an error the remaining in-flight writes
+/// are aborted and the error is immediately returned.
+///
+/// Deletes are passed through to the inner handler unmodified.
+#[derive(Debug, Default)]
+pub struct FanOutAdaptor<T, I> {
+    inner: T,
+    _iter: PhantomData<I>,
+}
+
+impl<T, I> FanOutAdaptor<T, I> {
+    /// Construct a [`FanOutAdaptor`] that passes DML operations to `inner`
+    /// concurrently.
+    pub fn new(inner: T) -> Self {
+        Self {
+            inner,
+            _iter: Default::default(),
+        }
+    }
+}
+
+#[async_trait]
+impl<T, I, U> DmlHandler for FanOutAdaptor<T, I>
+where
+    T: DmlHandler,
+    I: IntoIterator<IntoIter = U> + Debug + Send + Sync,
+    U: Iterator<Item = T::WriteInput> + Send + Sync,
+{
+    type WriteInput = I;
+    type WriteOutput = ();
+    type WriteError = T::WriteError;
+    type DeleteError = T::DeleteError;
+
+    /// Concurrently execute the write inputs in `input` against the inner
+    /// handler, returning early and aborting in-flight writes if an error
+    /// occurs.
+    async fn write(
+        &self,
+        namespace: &DatabaseName<'static>,
+        input: Self::WriteInput,
+        span_ctx: Option<SpanContext>,
+    ) -> Result<Self::WriteOutput, Self::WriteError> {
+        input
+            .into_iter()
+            .map(|v| {
+                let namespace = namespace.clone();
+                let span_ctx = span_ctx.clone();
+                async move { self.inner.write(&namespace, v, span_ctx).await }
+            })
+            .collect::<FuturesUnordered<_>>()
+            .try_for_each(|_| future::ready(Ok(())))
+            .await?;
+
+        Ok(())
+    }
+
+    /// Pass the delete through to the inner handler.
+    async fn delete(
+        &self,
+        namespace: &DatabaseName<'static>,
+        table_name: &str,
+        predicate: &DeletePredicate,
+        span_ctx: Option<SpanContext>,
+    ) -> Result<(), Self::DeleteError> {
+        self.inner
+            .delete(namespace, table_name, predicate, span_ctx)
+            .await
+    }
+}

--- a/router2/src/dml_handlers/mock.rs
+++ b/router2/src/dml_handlers/mock.rs
@@ -94,13 +94,14 @@ where
     type WriteError = DmlError;
     type DeleteError = DmlError;
     type WriteInput = W;
+    type WriteOutput = ();
 
     async fn write(
         &self,
-        namespace: DatabaseName<'static>,
+        namespace: &DatabaseName<'static>,
         write_input: Self::WriteInput,
         _span_ctx: Option<SpanContext>,
-    ) -> Result<(), Self::WriteError> {
+    ) -> Result<Self::WriteOutput, Self::WriteError> {
         record_and_return!(
             self,
             MockDmlHandlerCall::Write {
@@ -111,19 +112,19 @@ where
         )
     }
 
-    async fn delete<'a>(
+    async fn delete(
         &self,
-        namespace: DatabaseName<'static>,
-        table: impl Into<String> + Send + Sync + 'a,
-        predicate: DeletePredicate,
+        namespace: &DatabaseName<'static>,
+        table_name: &str,
+        predicate: &DeletePredicate,
         _span_ctx: Option<SpanContext>,
     ) -> Result<(), Self::DeleteError> {
         record_and_return!(
             self,
             MockDmlHandlerCall::Delete {
                 namespace: namespace.into(),
-                table: table.into(),
-                predicate,
+                table: table_name.to_owned(),
+                predicate: predicate.clone(),
             },
             delete_return
         )

--- a/router2/src/dml_handlers/mod.rs
+++ b/router2/src/dml_handlers/mod.rs
@@ -93,5 +93,11 @@ pub use partitioner::*;
 mod instrumentation;
 pub use instrumentation::*;
 
+mod chain;
+pub use chain::*;
+
+mod fan_out;
+pub use fan_out::*;
+
 #[cfg(test)]
 pub mod mock;

--- a/router2/src/dml_handlers/partitioner.rs
+++ b/router2/src/dml_handlers/partitioner.rs
@@ -2,14 +2,13 @@ use async_trait::async_trait;
 use data_types::{
     database_rules::PartitionTemplate, delete_predicate::DeletePredicate, DatabaseName,
 };
-use futures::stream::{FuturesUnordered, TryStreamExt};
 use hashbrown::HashMap;
 use mutable_batch::{MutableBatch, PartitionWrite, WritePayload};
 use observability_deps::tracing::*;
 use thiserror::Error;
 use trace::ctx::SpanContext;
 
-use super::{DmlError, DmlHandler};
+use super::DmlHandler;
 
 /// An error raised by the [`Partitioner`] handler.
 #[derive(Debug, Error)]
@@ -17,10 +16,6 @@ pub enum PartitionError {
     /// Failed to write to the partitioned table batch.
     #[error("error batching into partitioned write: {0}")]
     BatchWrite(#[from] mutable_batch::Error),
-
-    /// The inner DML handler returned an error.
-    #[error(transparent)]
-    Inner(Box<DmlError>),
 }
 
 /// A decorator of `T`, tagging it with the partition key derived from it.
@@ -51,47 +46,36 @@ impl<T> Partitioned<T> {
 /// partitioned per-table [`MutableBatch`] instances according to a configured
 /// [`PartitionTemplate`]. Deletes pass through unmodified.
 ///
-/// Each partition is passed through to the inner DML handler (or chain of
-/// handlers) concurrently, aborting if an error occurs. This may allow a
-/// partial write to be observable down-stream of the [`Partitioner`] if at
-/// least one partitioned write succeeds and at least one partitioned write
-/// fails. When a partial write occurs, the handler returns an error describing
-/// the failure.
+/// A vector of partitions are returned to the caller, or the first error that
+/// occurs during partitioning.
 #[derive(Debug)]
-pub struct Partitioner<D> {
+pub struct Partitioner {
     partition_template: PartitionTemplate,
-    inner: D,
 }
 
-impl<D> Partitioner<D> {
+impl Partitioner {
     /// Initialise a new [`Partitioner`], splitting writes according to the
-    /// specified [`PartitionTemplate`] before calling `inner`.
-    pub fn new(inner: D, partition_template: PartitionTemplate) -> Self {
-        Self {
-            partition_template,
-            inner,
-        }
+    /// specified [`PartitionTemplate`].
+    pub fn new(partition_template: PartitionTemplate) -> Self {
+        Self { partition_template }
     }
 }
 
 #[async_trait]
-impl<D> DmlHandler for Partitioner<D>
-where
-    D: DmlHandler<WriteInput = Partitioned<HashMap<String, MutableBatch>>>,
-{
+impl DmlHandler for Partitioner {
     type WriteError = PartitionError;
-    type DeleteError = D::DeleteError;
+    type DeleteError = PartitionError;
 
     type WriteInput = HashMap<String, MutableBatch>;
+    type WriteOutput = Vec<Partitioned<Self::WriteInput>>;
 
-    /// Partition the per-table [`MutableBatch`] and call the inner handler with
-    /// each partition.
+    /// Partition the per-table [`MutableBatch`].
     async fn write(
         &self,
-        namespace: DatabaseName<'static>,
+        _namespace: &DatabaseName<'static>,
         batch: Self::WriteInput,
-        span_ctx: Option<SpanContext>,
-    ) -> Result<(), Self::WriteError> {
+        _span_ctx: Option<SpanContext>,
+    ) -> Result<Self::WriteOutput, Self::WriteError> {
         // A collection of partition-keyed, per-table MutableBatch instances.
         let mut partitions: HashMap<_, HashMap<_, MutableBatch>> = HashMap::default();
 
@@ -111,62 +95,39 @@ where
             }
         }
 
-        partitions
+        Ok(partitions
             .into_iter()
-            .map(|(key, batch)| {
-                let p = Partitioned {
-                    key,
-                    payload: batch,
-                };
-
-                let namespace = namespace.clone();
-                let span_ctx = span_ctx.clone();
-                async move { self.inner.write(namespace, p, span_ctx).await }
+            .map(|(key, batch)| Partitioned {
+                key,
+                payload: batch,
             })
-            .collect::<FuturesUnordered<_>>()
-            .try_for_each(|_| async move {
-                trace!("partitioned write complete");
-                Ok(())
-            })
-            .await
-            .map_err(|e| PartitionError::Inner(Box::new(e.into())))
+            .collect::<Vec<_>>())
     }
 
     /// Pass the delete request through unmodified to the next handler.
-    async fn delete<'a>(
+    async fn delete(
         &self,
-        namespace: DatabaseName<'static>,
-        table_name: impl Into<String> + Send + Sync + 'a,
-        predicate: DeletePredicate,
-        span_ctx: Option<SpanContext>,
+        _namespace: &DatabaseName<'static>,
+        _table_name: &str,
+        _predicate: &DeletePredicate,
+        _span_ctx: Option<SpanContext>,
     ) -> Result<(), Self::DeleteError> {
-        self.inner
-            .delete(namespace, table_name, predicate, span_ctx)
-            .await
+        Ok(())
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
-
     use assert_matches::assert_matches;
     use data_types::database_rules::TemplatePart;
-    use lazy_static::lazy_static;
-    use time::Time;
 
-    use crate::dml_handlers::mock::{MockDmlHandler, MockDmlHandlerCall};
+    /// The default timestamp applied to test LP if the write does not specify
+    /// one.
+    const DEFAULT_TIMESTAMP_NANOS: i64 = 42000000000000000;
 
     use super::*;
 
-    lazy_static! {
-        /// A static default time to use in tests (1971-05-02 UTC).
-        static ref DEFAULT_TIME: Time = Time::from_timestamp_nanos(42000000000000000);
-    }
-
-    // Generate a test case that partitions "lp" and calls a mock inner DML
-    // handler for each partition, which returns the values specified in
-    // "inner_write_returns".
+    // Generate a test case that partitions "lp".
     //
     // Assert the partition-to-table mapping in "want_writes" and assert the
     // handler write() return value in "want_handler_ret".
@@ -174,35 +135,30 @@ mod tests {
         (
             $name:ident,
             lp = $lp:expr,
-            inner_write_returns = $inner_write_returns:expr,
             want_writes = [$($want_writes:tt)*], // "partition key" => ["mapped", "tables"] or [unchecked] to skip assert
             want_handler_ret = $($want_handler_ret:tt)+
         ) => {
             paste::paste! {
                 #[tokio::test]
                 async fn [<test_write_ $name>]() {
-                    use pretty_assertions::assert_eq;
-
                     let partition_template = PartitionTemplate {
                         parts: vec![TemplatePart::TimeFormat("%Y-%m-%d".to_owned())],
                     };
 
-                    let inner = Arc::new(MockDmlHandler::default().with_write_return($inner_write_returns));
-                    let partitioner = Partitioner::new(Arc::clone(&inner), partition_template);
+                    let partitioner = Partitioner::new(partition_template);
                     let ns = DatabaseName::new("bananas").expect("valid db name");
 
-                    let (writes, _) = mutable_batch_lp::lines_to_batches_stats($lp, DEFAULT_TIME.timestamp_nanos()).expect("failed to parse test LP");
+                    let (writes, _) = mutable_batch_lp::lines_to_batches_stats($lp, DEFAULT_TIMESTAMP_NANOS).expect("failed to parse test LP");
 
-                    let handler_ret = partitioner.write(ns.clone(), writes, None).await;
+                    let handler_ret = partitioner.write(&ns, writes, None).await;
                     assert_matches!(handler_ret, $($want_handler_ret)+);
 
-                    // Collect writes into a <partition_key, table_names> map.
-                    let calls = inner.calls().into_iter().map(|v| match v {
-                        MockDmlHandlerCall::Write { namespace, write_input, .. } => {
-                            assert_eq!(namespace, *ns);
-
-                            // Extract the table names for comparison
-                            let mut tables = write_input
+                    // Check the partition -> table mapping.
+                    let got = handler_ret.unwrap_or_default()
+                        .into_iter()
+                        .map(|partition| {
+                            // Extract the table names in this partition
+                            let mut tables = partition
                                 .payload
                                 .keys()
                                 .cloned()
@@ -210,13 +166,11 @@ mod tests {
 
                             tables.sort();
 
-                            (write_input.key.clone(), tables)
-                        },
-                        MockDmlHandlerCall::Delete { .. } => unreachable!("mock should not observe deletes"),
-                    })
-                    .collect::<HashMap<String, _>>();
+                            (partition.key.clone(), tables)
+                        })
+                        .collect::<HashMap<_, _>>();
 
-                    test_write!(@assert_writes, calls, $($want_writes)*);
+                    test_write!(@assert_writes, got, $($want_writes)*);
                 }
             }
         };
@@ -242,12 +196,12 @@ mod tests {
                 want_writes.insert($partition_key.to_string(), want);
             )*
 
-            assert_eq!(want_writes, $got);
+            pretty_assertions::assert_eq!(want_writes, $got);
         };
     }
 
     test_write!(
-        single_partition_ok,
+        single_partition,
         lp = "\
             bananas,tag1=A,tag2=B val=42i 1\n\
             platanos,tag1=A,tag2=B value=42i 2\n\
@@ -255,34 +209,14 @@ mod tests {
             bananas,tag1=A,tag2=B val=42i 2\n\
             table,tag1=A,tag2=B val=42i 1\n\
         ",
-        inner_write_returns = [Ok(())],
         want_writes = [
             "1970-01-01" => ["bananas", "platanos", "another", "table"],
         ],
-        want_handler_ret = Ok(())
+        want_handler_ret = Ok(_)
     );
 
     test_write!(
-        single_partition_err,
-        lp = "\
-            bananas,tag1=A,tag2=B val=42i 1\n\
-            platanos,tag1=A,tag2=B value=42i 2\n\
-            another,tag1=A,tag2=B value=42i 3\n\
-            bananas,tag1=A,tag2=B val=42i 2\n\
-            table,tag1=A,tag2=B val=42i 1\n\
-        ",
-        inner_write_returns = [Err(DmlError::DatabaseNotFound("missing".to_owned()))],
-        want_writes = [
-            // Attempted write recorded by the mock
-            "1970-01-01" => ["bananas", "platanos", "another", "table"],
-        ],
-        want_handler_ret = Err(PartitionError::Inner(e)) => {
-            assert_matches!(*e, DmlError::DatabaseNotFound(_));
-        }
-    );
-
-    test_write!(
-        multiple_partitions_ok,
+        multiple_partitions,
         lp = "\
             bananas,tag1=A,tag2=B val=42i 1\n\
             platanos,tag1=A,tag2=B value=42i 1465839830100400200\n\
@@ -290,68 +224,27 @@ mod tests {
             bananas,tag1=A,tag2=B val=42i 2\n\
             table,tag1=A,tag2=B val=42i 1644347270670952000\n\
         ",
-        inner_write_returns = [Ok(()), Ok(()), Ok(())],
         want_writes = [
             "1970-01-01" => ["bananas"],
             "2016-06-13" => ["platanos", "another"],
             "2022-02-08" => ["table"],
         ],
-        want_handler_ret = Ok(())
+        want_handler_ret = Ok(_)
     );
 
     test_write!(
-        multiple_partitions_total_err,
+        multiple_partitions_upserted,
         lp = "\
             bananas,tag1=A,tag2=B val=42i 1\n\
             platanos,tag1=A,tag2=B value=42i 1465839830100400200\n\
-            another,tag1=A,tag2=B value=42i 1465839830100400200\n\
-            bananas,tag1=A,tag2=B val=42i 2\n\
-            table,tag1=A,tag2=B val=42i 1644347270670952000\n\
+            platanos,tag1=A,tag2=B value=42i 1\n\
+            bananas,tag1=A,tag2=B value=42i 1465839830100400200\n\
+            bananas,tag1=A,tag2=B value=42i 1465839830100400200\n\
         ",
-        inner_write_returns = [
-            Err(DmlError::DatabaseNotFound("missing".to_owned())),
-            Err(DmlError::DatabaseNotFound("missing".to_owned())),
-            Err(DmlError::DatabaseNotFound("missing".to_owned())),
-        ],
-        want_writes = [unchecked],
-        want_handler_ret = Err(PartitionError::Inner(e)) => {
-            assert_matches!(*e, DmlError::DatabaseNotFound(_));
-        }
-    );
-
-    test_write!(
-        multiple_partitions_partial_err,
-        lp = "\
-            bananas,tag1=A,tag2=B val=42i 1\n\
-            platanos,tag1=A,tag2=B value=42i 1465839830100400200\n\
-            another,tag1=A,tag2=B value=42i 1465839830100400200\n\
-            bananas,tag1=A,tag2=B val=42i 2\n\
-            table,tag1=A,tag2=B val=42i 1644347270670952000\n\
-        ",
-        inner_write_returns = [
-            Err(DmlError::DatabaseNotFound("missing".to_owned())),
-            Ok(()),
-            Ok(()),
-        ],
-        want_writes = [unchecked],
-        want_handler_ret = Err(PartitionError::Inner(e)) => {
-            assert_matches!(*e, DmlError::DatabaseNotFound(_));
-        }
-    );
-
-    test_write!(
-        no_specified_timestamp,
-        lp = "\
-            bananas,tag1=A,tag2=B val=42i\n\
-            platanos,tag1=A,tag2=B value=42i\n\
-            another,tag1=A,tag2=B value=42i\n\
-            bananas,tag1=A,tag2=B val=42i\n\
-            table,tag1=A,tag2=B val=42i\n\
-        ",
-        inner_write_returns = [Ok(())],
         want_writes = [
-            "1971-05-02" => ["bananas", "platanos", "another", "table"],
+            "1970-01-01" => ["bananas", "platanos"],
+            "2016-06-13" => ["bananas", "platanos"],
         ],
-        want_handler_ret = Ok(())
+        want_handler_ret = Ok(_)
     );
 }

--- a/router2/src/dml_handlers/trait.rs
+++ b/router2/src/dml_handlers/trait.rs
@@ -47,6 +47,10 @@ pub trait DmlHandler: Debug + Send + Sync {
     /// input request as it progresses through the handler pipeline.
     type WriteInput: Debug + Send + Sync;
 
+    /// The (possibly transformed) output type returned by this handler after
+    /// processing a write.
+    type WriteOutput: Debug + Send + Sync;
+
     /// The type of error a [`DmlHandler`] implementation produces for write
     /// requests.
     ///
@@ -59,17 +63,17 @@ pub trait DmlHandler: Debug + Send + Sync {
     /// Write `batches` to `namespace`.
     async fn write(
         &self,
-        namespace: DatabaseName<'static>,
+        namespace: &DatabaseName<'static>,
         input: Self::WriteInput,
         span_ctx: Option<SpanContext>,
-    ) -> Result<(), Self::WriteError>;
+    ) -> Result<Self::WriteOutput, Self::WriteError>;
 
     /// Delete the data specified in `delete`.
-    async fn delete<'a>(
+    async fn delete(
         &self,
-        namespace: DatabaseName<'static>,
-        table_name: impl Into<String> + Send + Sync + 'a,
-        predicate: DeletePredicate,
+        namespace: &DatabaseName<'static>,
+        table_name: &str,
+        predicate: &DeletePredicate,
         span_ctx: Option<SpanContext>,
     ) -> Result<(), Self::DeleteError>;
 }

--- a/router2/src/server/http.rs
+++ b/router2/src/server/http.rs
@@ -99,7 +99,6 @@ impl From<&DmlError> for StatusCode {
                 StatusCode::INTERNAL_SERVER_ERROR
             }
             DmlError::Partition(PartitionError::BatchWrite(_)) => StatusCode::INTERNAL_SERVER_ERROR,
-            DmlError::Partition(PartitionError::Inner(err)) => StatusCode::from(&**err),
         }
     }
 }
@@ -225,7 +224,7 @@ where
         );
 
         self.dml_handler
-            .write(namespace, batches, span_ctx)
+            .write(&namespace, batches, span_ctx)
             .await
             .map_err(Into::into)?;
 
@@ -266,7 +265,12 @@ where
         );
 
         self.dml_handler
-            .delete(namespace, parsed_delete.table_name, predicate, span_ctx)
+            .delete(
+                &namespace,
+                parsed_delete.table_name.as_str(),
+                &predicate,
+                span_ctx,
+            )
             .await
             .map_err(Into::into)?;
 

--- a/router2/tests/http.rs
+++ b/router2/tests/http.rs
@@ -1,0 +1,213 @@
+use std::{collections::BTreeSet, iter, string::String, sync::Arc};
+
+use assert_matches::assert_matches;
+use data_types::database_rules::{PartitionTemplate, TemplatePart};
+use dml::DmlOperation;
+use hashbrown::HashMap;
+use hyper::{Body, Request, StatusCode};
+use iox_catalog::{
+    interface::{Catalog, KafkaTopicId, QueryPoolId},
+    mem::MemCatalog,
+};
+use metric::{Attributes, Metric, Registry, U64Histogram};
+use mutable_batch::MutableBatch;
+use router2::{
+    dml_handlers::{
+        Chain, DmlHandlerChainExt, FanOutAdaptor, InstrumentationDecorator, NamespaceAutocreation,
+        Partitioned, Partitioner, SchemaValidator, ShardedWriteBuffer,
+    },
+    namespace_cache::{MemoryNamespaceCache, ShardedCache},
+    sequencer::Sequencer,
+    server::http::HttpDelegate,
+    sharder::JumpHash,
+};
+use write_buffer::core::WriteBufferWriting;
+use write_buffer::mock::{MockBufferForWriting, MockBufferSharedState};
+
+/// The kafka topic catalog ID assigned by the namespace auto-creator in the
+/// handler stack for namespaces it has not yet observed.
+const TEST_KAFKA_TOPIC_ID: i32 = 1;
+
+/// The query pool catalog ID assigned by the namespace auto-creator in the
+/// handler stack for namespaces it has not yet observed.
+const TEST_QUERY_POOL_ID: i16 = 1;
+
+pub struct TestContext {
+    delegate: HttpDelegateStack,
+    catalog: Arc<dyn Catalog>,
+    write_buffer_state: Arc<MockBufferSharedState>,
+    metrics: Arc<Registry>,
+}
+
+// This mass of words is certainly a downside of chained handlers.
+//
+// Fortunately the compiler errors are very descriptive and updating this is
+// relatively easy when something changes!
+type HttpDelegateStack = HttpDelegate<
+    InstrumentationDecorator<
+        Chain<
+            Chain<
+                NamespaceAutocreation<
+                    Arc<ShardedCache<Arc<MemoryNamespaceCache>>>,
+                    HashMap<String, MutableBatch>,
+                >,
+                Partitioner,
+            >,
+            FanOutAdaptor<
+                Chain<
+                    SchemaValidator<Arc<ShardedCache<Arc<MemoryNamespaceCache>>>>,
+                    ShardedWriteBuffer<JumpHash<Arc<Sequencer>>>,
+                >,
+                Vec<Partitioned<HashMap<String, MutableBatch>>>,
+            >,
+        >,
+    >,
+>;
+
+/// A [`router2`] stack configured with the various DML handlers using mock
+/// catalog / write buffer backends.
+impl TestContext {
+    pub fn new() -> Self {
+        let metrics = Arc::new(metric::Registry::default());
+        let time = time::MockProvider::new(time::Time::from_timestamp_millis(668563200000));
+
+        let write_buffer = MockBufferForWriting::new(
+            MockBufferSharedState::empty_with_n_sequencers(1.try_into().unwrap()),
+            None,
+            Arc::new(time),
+        )
+        .expect("failed to init mock write buffer");
+        let write_buffer_state = write_buffer.state();
+        let write_buffer: Arc<dyn WriteBufferWriting> = Arc::new(write_buffer);
+
+        let shards: BTreeSet<_> = write_buffer.sequencer_ids();
+        let sharded_write_buffer = ShardedWriteBuffer::new(
+            shards
+                .into_iter()
+                .map(|id| Sequencer::new(id as _, Arc::clone(&write_buffer)))
+                .map(Arc::new)
+                .collect::<JumpHash<_>>(),
+        );
+
+        let catalog: Arc<dyn Catalog> = Arc::new(MemCatalog::default());
+        let ns_cache = Arc::new(ShardedCache::new(
+            iter::repeat_with(|| Arc::new(MemoryNamespaceCache::default())).take(10),
+        ));
+
+        let ns_creator = NamespaceAutocreation::new(
+            Arc::clone(&catalog),
+            Arc::clone(&ns_cache),
+            KafkaTopicId::new(TEST_KAFKA_TOPIC_ID),
+            QueryPoolId::new(TEST_QUERY_POOL_ID),
+            iox_catalog::INFINITE_RETENTION_POLICY.to_owned(),
+        );
+
+        let schema_validator = SchemaValidator::new(Arc::clone(&catalog), ns_cache);
+        let partitioner = Partitioner::new(PartitionTemplate {
+            parts: vec![TemplatePart::TimeFormat("%Y-%m-%d".to_owned())],
+        });
+
+        let handler_stack = ns_creator
+            .and_then(partitioner)
+            .and_then(FanOutAdaptor::new(
+                schema_validator.and_then(sharded_write_buffer),
+            ));
+
+        let handler_stack =
+            InstrumentationDecorator::new("request", Arc::clone(&metrics), handler_stack);
+
+        let delegate = HttpDelegate::new(1024, handler_stack);
+
+        Self {
+            delegate,
+            catalog,
+            write_buffer_state,
+            metrics,
+        }
+    }
+
+    /// Get a reference to the test context's delegate.
+    pub fn delegate(&self) -> &HttpDelegateStack {
+        &self.delegate
+    }
+
+    /// Get a reference to the test context's catalog.
+    pub fn catalog(&self) -> &dyn Catalog {
+        self.catalog.as_ref()
+    }
+
+    /// Get a reference to the test context's write buffer state.
+    pub fn write_buffer_state(&self) -> &Arc<MockBufferSharedState> {
+        &self.write_buffer_state
+    }
+
+    /// Get a reference to the test context's metrics.
+    pub fn metrics(&self) -> &Registry {
+        self.metrics.as_ref()
+    }
+}
+
+impl Default for TestContext {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[tokio::test]
+async fn test_write_ok() {
+    let ctx = TestContext::new();
+
+    let request = Request::builder()
+        .uri("https://bananas.example/api/v2/write?org=bananas&bucket=test")
+        .method("POST")
+        .body(Body::from("platanos,tag1=A,tag2=B val=42i 123456"))
+        .expect("failed to construct HTTP request");
+
+    let response = ctx
+        .delegate()
+        .route(request)
+        .await
+        .expect("LP write request failed");
+
+    assert_eq!(response.status(), StatusCode::NO_CONTENT);
+
+    // Check the write buffer observed the correct write.
+    let writes = ctx.write_buffer_state().get_messages(0);
+    assert_eq!(writes.len(), 1);
+    assert_matches!(writes.as_slice(), [Ok(DmlOperation::Write(w))] => {
+        assert_eq!(w.namespace(), "bananas_test");
+        assert!(w.table("platanos").is_some());
+    });
+
+    // Ensure the catalog saw the namespace creation
+    let ns = ctx
+        .catalog()
+        .repositories()
+        .await
+        .namespaces()
+        .get_by_name("bananas_test")
+        .await
+        .expect("query should succeed")
+        .expect("namespace not found");
+    assert_eq!(ns.name, "bananas_test");
+    assert_eq!(
+        ns.retention_duration.as_deref(),
+        Some(iox_catalog::INFINITE_RETENTION_POLICY)
+    );
+    assert_eq!(ns.kafka_topic_id, KafkaTopicId::new(TEST_KAFKA_TOPIC_ID));
+    assert_eq!(ns.query_pool_id, QueryPoolId::new(TEST_QUERY_POOL_ID));
+
+    // Ensure the metric instrumentation was hit
+    let histogram = ctx
+        .metrics()
+        .get_instrument::<Metric<U64Histogram>>("dml_handler_write_duration_ms")
+        .expect("failed to read metric")
+        .get_observer(&Attributes::from(&[
+            ("handler", "request"),
+            ("result", "success"),
+        ]))
+        .expect("failed to get observer")
+        .fetch();
+    let hit_count = histogram.buckets.iter().fold(0, |acc, v| acc + v.count);
+    assert_eq!(hit_count, 1);
+}


### PR DESCRIPTION
This refactor changes the way DML handlers are chained together in the router in order to produce more useful metrics (see #3764).

While this change caused a fair bit of code churn, the changes are pretty trivial compiler-driven fixups - the result is much nicer to test / work with though! An example of the benefit of this is it moved responsibility for parallelising certain operations (like writes across shards) out from the request handler and into an external type, separating responsiblities and making the parallisation pluggable / configurable / optional.

---

* refactor: chain DML handlers (bb132b61)

      The router is composed of several DML handlers called in sequence in order to
      construct the full request handling pipeline. Prior to this commit, each
      handler nested the next handler it calls internally, producing a nested call
      chain that resulted metrics (added in #3764) recording cumulative latency like
      this:

                    ┌ ─

                    │     ┌───────────────┐
                         │  NS Creation  │
                   │     └───────────────┘
                                 │  ┌───────────────┐
                   │             │  │  Partitioner  │
                                 │  └───────────────┘
                   │             │          │
                                 │          │
      Cumulative   │             │          │  ┌───────────────┐
        Timings                1.5s        1s  │    etc...     │
                   │             │          │  └───────────────┘
                                 │          │
                   │             │          │
                                 │  ┌───────────────┐
                   │             │  │  Partitioner  │
                                 │  └───────────────┘
                   │     ┌───────────────┐
                         │  NS Creation  │
                   │     └───────────────┘

                    └ ─

      This meant it was hard to determine the latency of a single handler without
      knowing (and subtracting the latency of) all the child handlers it calls.

      This commit replaces the intrusive nested handler call chain with an external
      Chain combinator type to compose together individual handlers, resulting in
      correct per-handler timings and simpler code/tests:

                ┌───────────────┐
               │  NS Creation  │
               └───────────────┘
                       │
                      .5s       ┌───────────────┐
                       └───────▶│  Partitioner  │
                                └───────────────┘
                                        │
                                       1s    ┌───────────────┐
                                        └───▶│    etc...     │
                                             └───────────────┘

* test: router handler stack integration test (497615d7)

      Adds an integration test covering the router's HTTP handler stack.

      Given a well-formed HTTP write, the test asserts:

          * Write passes through the stack without error
         * Response code sent to client
         * Write buffer message is enqueued
         * Catalog namespace record is created
         * Metric handler is invoked and the hit is recorded

