### PR TITLE
fix: "catalog setup" migrations in non-public schema

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -237,6 +237,7 @@ jobs:
       - cache_restore
       - run: cargo install sqlx-cli
       - run: sqlx database create
+      - run: INFLUXDB_IOX_CATALOG_DSN=${DATABASE_URL} cargo run -- catalog setup
       - run:
           name: Cargo test
           command: cargo test --workspace --features=aws,azure,azure_test

--- a/iox_catalog/src/postgres.rs
+++ b/iox_catalog/src/postgres.rs
@@ -253,7 +253,7 @@ async fn new_raw_pool(
                         .execute(&mut *c)
                         .await?;
                 }
-                let search_path_query = format!("SET search_path TO {}", schema_name);
+                let search_path_query = format!("SET search_path TO {},public", schema_name);
                 c.execute(sqlx::query(&search_path_query)).await?;
                 Ok(())
             })


### PR DESCRIPTION
Fix the explicit `catalog setup` command broken as part of #3776.

This command wasn't run as part of the CI process so the breakage wasn't noticed, and all the tests worked fine as they bootstrapped their own schema before running the migrations.

Adds `catalog setup` as part of the CI checks.

---

* fix: add public to schema search path (f49c9c46)

      The _sql_migrations table cannot be created by the `catalog setup` bootstrap
      command because it is created before the migrations run, one of which creates
      the iox_catalog namespace the catalog operates in.

      This change allows the _sql_migrations table to be created in the public 
      schema to start the migration process, with everything else living in the
      iox_catalog schema.

* build: run "catalog setup" in CI (22ac2e3b)

      Ensures the "catalog setup" command executes successfully by executing it in
      CI.