### PR TITLE
refactor: early schema validation

### DIFF
--- a/influxdb_iox/src/commands/run/router2.rs
+++ b/influxdb_iox/src/commands/run/router2.rs
@@ -181,6 +181,7 @@ pub async fn command(config: Config) -> Result<()> {
     // pipeline, starting with the namespace creator (for testing purposes) and
     // write partitioner that yields a set of partitioned batches.
     let handler_stack = ns_creator
+        .and_then(schema_validator)
         .and_then(partitioner)
         // Once writes have been partitioned, they are processed in parallel.
         //
@@ -191,7 +192,7 @@ pub async fn command(config: Config) -> Result<()> {
         .and_then(InstrumentationDecorator::new(
             "parallel_write",
             Arc::clone(&metrics),
-            FanOutAdaptor::new(schema_validator.and_then(write_buffer)),
+            FanOutAdaptor::new(write_buffer),
         ));
 
     // Record the overall request handling latency

--- a/router2/benches/e2e.rs
+++ b/router2/benches/e2e.rs
@@ -65,7 +65,7 @@ fn e2e_benchmarks(c: &mut Criterion) {
         });
 
         let handler_stack =
-            partitioner.and_then(FanOutAdaptor::new(schema_validator.and_then(write_buffer)));
+            schema_validator.and_then(partitioner.and_then(FanOutAdaptor::new(write_buffer)));
 
         HttpDelegate::new(1024, handler_stack)
     };


### PR DESCRIPTION
A quick and easy reduction in cache overwrites and unnecessary PG load due to concurrent schema validation across partitions.

---

* refactor: early schema validation (d7eda885)

      Changes the configuration of the router request pipeline to move schema 
      validation before partitioning.

      This reduces the concurrency of callsm into the schema validator when a single
      write is split into one or more partitions, reducing contention and cash
      thrashing. It also ensures we don't bother partitioning the writes if the
      request will fail.