### PR TITLE
refactor: parallel column resolution

### DIFF
--- a/iox_catalog/src/postgres.rs
+++ b/iox_catalog/src/postgres.rs
@@ -19,7 +19,7 @@ use sqlx_hotswap_pool::HotSwapPool;
 use std::{sync::Arc, time::Duration};
 use uuid::Uuid;
 
-const MAX_CONNECTIONS: u32 = 5;
+const MAX_CONNECTIONS: u32 = 10;
 const CONNECT_TIMEOUT: Duration = Duration::from_secs(2);
 const IDLE_TIMEOUT: Duration = Duration::from_secs(500);
 /// the default schema name to use in Postgres

--- a/router2/src/dml_handlers/schema_validation.rs
+++ b/router2/src/dml_handlers/schema_validation.rs
@@ -127,8 +127,6 @@ where
         batches: Self::WriteInput,
         _span_ctx: Option<SpanContext>,
     ) -> Result<Self::WriteOutput, Self::WriteError> {
-        let mut repos = self.catalog.repositories().await;
-
         // Load the namespace schema from the cache, falling back to pulling it
         // from the global catalog (if it exists).
         let schema = self.cache.get_schema(namespace);
@@ -137,6 +135,7 @@ where
             None => {
                 // Pull the schema from the global catalog or error if it does
                 // not exist.
+                let mut repos = self.catalog.repositories().await;
                 let schema = get_schema_by_name(namespace, repos.deref_mut())
                     .await
                     .map_err(|e| {
@@ -156,7 +155,7 @@ where
         let maybe_new_schema = validate_or_insert_schema(
             batches.iter().map(|(k, v)| (k.as_str(), v)),
             &schema,
-            repos.deref_mut(),
+            &*self.catalog,
         )
         .await
         .map_err(|e| {


### PR DESCRIPTION
Make things faster the easy way - by hiding latency with parallelism!

While adding tests to this I noticed the in-mem catalog behaves differently than the postgres impl, and deadlocks when attempting to get two handles to the `RepoCollection` (https://github.com/influxdata/influxdb_iox/issues/3859).

---

* refactor: parallel column resolution (b07f15be)

      A quick change to perform the ColumnRepo::create_or_get() calls in parallel
      (up to a maximum of 3 in-flight at any one time) in order to mitigate the
      latency of the call and reduce the overall schema validation call duration.

      The in-flight limit is enforced to avoid starving the DB connection pool of
      connections.