### PR TITLE
refactor: configurable max catalog connections

### DIFF
--- a/influxdb_iox/src/clap_blocks/catalog_dsn.rs
+++ b/influxdb_iox/src/clap_blocks/catalog_dsn.rs
@@ -30,6 +30,14 @@ pub struct CatalogDsnConfig {
     /// Postgres connection string. Required if catalog is set to postgres.
     #[clap(long = "--catalog-dsn", env = "INFLUXDB_IOX_CATALOG_DSN")]
     pub dsn: Option<String>,
+
+    /// Maximum number of connections allowed to the catalog at any one time.
+    #[clap(
+        long = "--catalog-max-connections",
+        env = "INFLUXDB_IOX_CATALOG_MAX_CONNECTIONS",
+        default_value = "10"
+    )]
+    pub max_catalog_connections: u32,
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, clap::ArgEnum)]
@@ -50,6 +58,7 @@ impl CatalogDsnConfig {
                     app_name,
                     iox_catalog::postgres::SCHEMA_NAME,
                     self.dsn.as_ref().context(ConnectionStringRequiredSnafu)?,
+                    self.max_catalog_connections,
                     metrics.unwrap_or_default(),
                 )
                 .await


### PR DESCRIPTION
Quick addition to the shared catalog config block.

---

* refactor: configurable max catalog connections (35792526)

      Allow the maximum number of catalog (postgres) connections to be specified as
      part of the catalog configuration.