### PR TITLE
feat: http ingest metrics

### DIFF
--- a/influxdb_iox/src/commands/run/router2.rs
+++ b/influxdb_iox/src/commands/run/router2.rs
@@ -199,7 +199,11 @@ pub async fn command(config: Config) -> Result<()> {
     let handler_stack =
         InstrumentationDecorator::new("request", Arc::clone(&metrics), handler_stack);
 
-    let http = HttpDelegate::new(config.run_config.max_http_request_size, handler_stack);
+    let http = HttpDelegate::new(
+        config.run_config.max_http_request_size,
+        handler_stack,
+        &metrics,
+    );
     let router_server = RouterServer::new(
         http,
         Default::default(),

--- a/router2/benches/e2e.rs
+++ b/router2/benches/e2e.rs
@@ -54,7 +54,7 @@ fn e2e_benchmarks(c: &mut Criterion) {
 
     let delegate = {
         let metrics = Arc::new(metric::Registry::new());
-        let catalog: Arc<dyn Catalog> = Arc::new(MemCatalog::new(metrics));
+        let catalog: Arc<dyn Catalog> = Arc::new(MemCatalog::new(Arc::clone(&metrics)));
         let ns_cache = Arc::new(ShardedCache::new(
             iter::repeat_with(|| Arc::new(MemoryNamespaceCache::default())).take(10),
         ));
@@ -68,7 +68,7 @@ fn e2e_benchmarks(c: &mut Criterion) {
         let handler_stack =
             schema_validator.and_then(partitioner.and_then(FanOutAdaptor::new(write_buffer)));
 
-        HttpDelegate::new(1024, handler_stack)
+        HttpDelegate::new(1024, handler_stack, &metrics)
     };
 
     let body_str = "platanos,tag1=A,tag2=B val=42i 123456";


### PR DESCRIPTION
Quick one to plumb in some handy ingest metrics for the HTTP write endpoint.

---

* feat: http ingest metrics (6d9709be)

      Records LP line count, field count & request body size (decompressed, byte
      size) for writes, and request body byte size for deletes.