### PR TITLE
feat: Auto commit cargo hakari generate changes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -170,19 +170,30 @@ jobs:
       - rust_components
       - cache_restore
       - run:
-          name: Check that the workspace hack crate contains all features in use
+          name: Configure git
           command: |
-            cargo hakari generate --diff || {
-              echo "If this fails, fix it by running \`cargo hakari generate\` locally and committing the changes"
-              exit 1
-            }
+            git config user.email "49699333+dependabot[bot]@users.noreply.github.com"
+            git config user.name "dependabot[bot]"
       - run:
-          name: Check that all crates in the workspace depend on the workspace hack crate
+          name: Commit any changes to the features in the workspace hack crate
           command: |
-            cargo hakari manage-deps --dry-run || {
-              echo "If this fails, fix it by running \`cargo hakari manage-deps\` locally and committing the changes"
-              exit 1
-            }
+            cargo hakari generate
+            if [[ $(git status --porcelain) ]] ; then
+              git commit -am "[skip ci] Run cargo hakari generate"
+              git push origin "$CIRCLE_BRANCH"
+            else
+              echo "No changes to commit"
+            fi
+      - run:
+          name: Commit any changes to crates so they all depend on the workspace hack crate
+          command: |
+            cargo hakari manage-deps
+            if [[ $(git status --porcelain) ]] ; then
+              git commit -am "[skip ci] Run cargo hakari manage-deps"
+              git push origin "$CIRCLE_BRANCH"
+            else
+              echo "No changes to commit"
+            fi
 
   test:
     # setup multiple docker images (see https://circleci.com/docs/2.0/configuration-reference/#docker)

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -172,8 +172,8 @@ jobs:
       - run:
           name: Configure git
           command: |
-            git config user.email "49699333+dependabot[bot]@users.noreply.github.com"
-            git config user.name "dependabot[bot]"
+            git config user.email "circleci@influxdata.com"
+            git config user.name "CircleCI[bot]"
       - run:
           name: Commit any changes to the features in the workspace hack crate
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -173,26 +173,26 @@ jobs:
       - rust_components
       - cache_restore
       - run:
+          name: Check git log
+          command: |
+            if [[ $(git rev-list --count --author=CircleCI origin/main..) -ne 0 ]]; then
+              echo "There's already a cargo hakari commit on this branch; stopping'"
+              circleci-agent step halt
+            else
+              echo "No cargo hakari commits here; checking"
+            fi
+      - run:
           name: Configure git
           command: |
             git config user.email "circleci@influxdata.com"
             git config user.name "CircleCI[bot]"
       - run:
-          name: Commit any changes to the features in the workspace hack crate
+          name: Commit any changes from cargo hakari
           command: |
             cargo hakari generate
+            cargo hakari manage-deps -y
             if [[ $(git status --porcelain) ]] ; then
-              git commit -am "chore: Run cargo hakari generate"
-              git push origin "$CIRCLE_BRANCH"
-            else
-              echo "No changes to commit"
-            fi
-      - run:
-          name: Commit any changes to crates so they all depend on the workspace hack crate
-          command: |
-            cargo hakari manage-deps
-            if [[ $(git status --porcelain) ]] ; then
-              git commit -am "chore: Run cargo hakari manage-deps"
+              git commit -am "chore: Run cargo hakari tasks"
               git push origin "$CIRCLE_BRANCH"
             else
               echo "No changes to commit"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -173,15 +173,6 @@ jobs:
       - rust_components
       - cache_restore
       - run:
-          name: Check git log
-          command: |
-            if [[ $(git rev-list --count --author=CircleCI origin/main..) -ne 0 ]]; then
-              echo "There's already a cargo hakari commit on this branch; stopping'"
-              circleci-agent step halt
-            else
-              echo "No cargo hakari commits here; checking"
-            fi
-      - run:
           name: Configure git
           command: |
             git config user.email "circleci@influxdata.com"
@@ -192,9 +183,13 @@ jobs:
             cargo hakari generate
             cargo hakari manage-deps -y
             if [[ $(git status --porcelain) ]] ; then
-              git commit -am "chore: Run cargo hakari tasks"
-              git push origin "$CIRCLE_BRANCH"
-              echo "Cargo hakari changes need to be committed before merging this branch."
+              if [[ $(git rev-list --count --author=CircleCI origin/main..) -ne 0 ]]; then
+                echo "There's already a cargo hakari commit on this branch, but there are cargo hakari changes... something is wrong."
+              else
+                git commit -am "chore: Run cargo hakari tasks"
+                git push origin "$CIRCLE_BRANCH"
+                echo "Cargo hakari changes need to be committed before merging this branch."
+              fi
               exit 1
             else
               echo "No changes to commit"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -166,6 +166,9 @@ jobs:
       # https://github.com/rust-lang/cargo/issues/10280
       CARGO_NET_GIT_FETCH_WITH_CLI: "true"
     steps:
+      - add_ssh_keys:
+          fingerprints:
+            - "77:99:88:4a:ac:1f:55:9e:39:c7:1f:e4:7f:1e:60:4b"
       - checkout
       - rust_components
       - cache_restore
@@ -484,19 +487,19 @@ jobs:
           command: |
             COMMIT_SHA="$(git rev-parse --short HEAD)"
             BRANCH="$(echo "$CIRCLE_BRANCH" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/_/g')"
-            
+
             docker pull quay.io/influxdb/iox:"$COMMIT_SHA"
             docker pull quay.io/influxdb/iox_data_generator:"$COMMIT_SHA"
             docker pull quay.io/influxdb/iox_gitops_adapter:"$COMMIT_SHA"
-            
+
             docker tag quay.io/influxdb/iox:"$COMMIT_SHA" quay.io/influxdb/iox:"$BRANCH"
             docker tag quay.io/influxdb/iox_data_generator:"$COMMIT_SHA" quay.io/influxdb/iox_data_generator:"$BRANCH"
             docker tag quay.io/influxdb/iox_gitops_adapter:"$COMMIT_SHA" quay.io/influxdb/iox_gitops_adapter:"$BRANCH"
-            
+
             docker push quay.io/influxdb/iox:"$BRANCH"
             docker push quay.io/influxdb/iox_data_generator:"$BRANCH"
             docker push quay.io/influxdb/iox_gitops_adapter:"$BRANCH"
-            
+
             echo "export COMMIT_SHA=${COMMIT_SHA}" >> $BASH_ENV
       - run:
           name: Deploy tags

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -194,6 +194,8 @@ jobs:
             if [[ $(git status --porcelain) ]] ; then
               git commit -am "chore: Run cargo hakari tasks"
               git push origin "$CIRCLE_BRANCH"
+              echo "Cargo hakari changes need to be committed before merging this branch."
+              exit 1
             else
               echo "No changes to commit"
             fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -182,7 +182,7 @@ jobs:
           command: |
             cargo hakari generate
             if [[ $(git status --porcelain) ]] ; then
-              git commit -am "[skip ci] Run cargo hakari generate"
+              git commit -am "chore: Run cargo hakari generate"
               git push origin "$CIRCLE_BRANCH"
             else
               echo "No changes to commit"
@@ -192,7 +192,7 @@ jobs:
           command: |
             cargo hakari manage-deps
             if [[ $(git status --porcelain) ]] ; then
-              git commit -am "[skip ci] Run cargo hakari manage-deps"
+              git commit -am "chore: Run cargo hakari manage-deps"
               git push origin "$CIRCLE_BRANCH"
             else
               echo "No changes to commit"


### PR DESCRIPTION
Fixes #3680.

When someone (either dependabot or a person) opens a PR that needs changes to the workspace hack crate to update the features listed, or if other crates need to be changed to make them depend on the workspace hack crate, instead of CI, this will add a commit to the PR.

Take a look at the previous PR for this: https://github.com/influxdata/influxdb_iox/pull/3713

It's this branch plus a commit where I deleted part of the workspace-hack's Cargo.toml, and the hakari CircleCI job was able to push a new commit to the PR that fixed it 🎉 