### PR TITLE
feat: more router metrics

### DIFF
--- a/influxdb_iox/src/commands/run/router2.rs
+++ b/influxdb_iox/src/commands/run/router2.rs
@@ -227,7 +227,7 @@ async fn init_write_buffer(
     let write_buffer = Arc::new(
         config
             .write_buffer_config
-            .writing(metrics, trace_collector)
+            .writing(Arc::clone(&metrics), trace_collector)
             .await?,
     );
 
@@ -248,7 +248,7 @@ async fn init_write_buffer(
     Ok(ShardedWriteBuffer::new(
         shards
             .into_iter()
-            .map(|id| Sequencer::new(id as _, Arc::clone(&write_buffer)))
+            .map(|id| Sequencer::new(id as _, Arc::clone(&write_buffer), &metrics))
             .map(Arc::new)
             .collect::<JumpHash<_>>(),
     ))

--- a/router2/Cargo.toml
+++ b/router2/Cargo.toml
@@ -48,5 +48,9 @@ name = "sharder"
 harness = false
 
 [[bench]]
+name = "schema_validator"
+harness = false
+
+[[bench]]
 name = "e2e"
 harness = false

--- a/router2/benches/e2e.rs
+++ b/router2/benches/e2e.rs
@@ -35,7 +35,7 @@ fn init_write_buffer(n_sequencers: u32) -> ShardedWriteBuffer<JumpHash<Arc<Seque
     ShardedWriteBuffer::new(
         shards
             .into_iter()
-            .map(|id| Sequencer::new(id as _, Arc::clone(&write_buffer)))
+            .map(|id| Sequencer::new(id as _, Arc::clone(&write_buffer), &Default::default()))
             .map(Arc::new)
             .collect::<JumpHash<_>>(),
     )

--- a/router2/benches/schema_validator.rs
+++ b/router2/benches/schema_validator.rs
@@ -1,0 +1,93 @@
+use std::{iter, sync::Arc};
+
+use criterion::{
+    criterion_group, criterion_main, measurement::WallTime, BatchSize, BenchmarkGroup, Criterion,
+    Throughput,
+};
+use data_types2::DatabaseName;
+use hashbrown::HashMap;
+use iox_catalog::mem::MemCatalog;
+use mutable_batch::MutableBatch;
+use router2::{
+    dml_handlers::{DmlHandler, SchemaValidator},
+    namespace_cache::{MemoryNamespaceCache, ShardedCache},
+};
+use schema::selection::Selection;
+use tokio::runtime::Runtime;
+
+lazy_static::lazy_static! {
+    static ref NAMESPACE: DatabaseName<'static> = "bananas".try_into().unwrap();
+}
+
+fn runtime() -> Runtime {
+    tokio::runtime::Builder::new_current_thread()
+        .build()
+        .unwrap()
+}
+
+fn sharder_benchmarks(c: &mut Criterion) {
+    let mut group = c.benchmark_group("schema_validator");
+
+    bench(&mut group, 1, 1);
+
+    bench(&mut group, 1, 100);
+    bench(&mut group, 1, 10000);
+
+    bench(&mut group, 100, 1);
+    bench(&mut group, 10000, 1);
+
+    group.finish();
+}
+
+fn bench(group: &mut BenchmarkGroup<WallTime>, tables: usize, columns_per_table: usize) {
+    let metrics = Arc::new(metric::Registry::default());
+
+    let catalog = Arc::new(MemCatalog::new(Arc::clone(&metrics)));
+    let ns_cache = Arc::new(ShardedCache::new(
+        iter::repeat_with(|| Arc::new(MemoryNamespaceCache::default())).take(10),
+    ));
+    let validator = SchemaValidator::new(catalog, ns_cache);
+
+    for i in 0..65_000 {
+        let write = lp_to_writes(format!("{}{}", i + 10_000_000, generate_lp(1, 1)).as_str());
+        let _ = runtime().block_on(validator.write(&*NAMESPACE, write, None));
+    }
+
+    let write = lp_to_writes(&generate_lp(tables, columns_per_table));
+    let column_count = write
+        .values()
+        .fold(0, |acc, b| acc + b.schema(Selection::All).unwrap().len());
+
+    group.throughput(Throughput::Elements(column_count as _));
+    group.bench_function(format!("{tables}x{columns_per_table}"), |b| {
+        b.to_async(runtime()).iter_batched(
+            || write.clone(),
+            |write| validator.write(&*NAMESPACE, write, None),
+            BatchSize::SmallInput,
+        );
+    });
+}
+
+fn generate_lp(tables: usize, columns_per_table: usize) -> String {
+    (0..tables)
+        .map(|i| {
+            let cols = (0..columns_per_table)
+                .map(|i| format!("val{}=42i", i))
+                .collect::<Vec<_>>()
+                .join(",");
+
+            format!("table{i},tag=A {cols}")
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+// Parse `lp` into a table-keyed MutableBatch map.
+fn lp_to_writes(lp: &str) -> HashMap<String, MutableBatch> {
+    let (writes, _) = mutable_batch_lp::lines_to_batches_stats(lp, 42)
+        .expect("failed to build test writes from LP");
+    writes
+}
+
+criterion_group!(benches, sharder_benchmarks);
+criterion_main!(benches);

--- a/router2/src/dml_handlers/sharded_write_buffer.rs
+++ b/router2/src/dml_handlers/sharded_write_buffer.rs
@@ -237,7 +237,11 @@ mod tests {
 
         // Configure the sharder to return shards containing the mock write
         // buffer.
-        let shard = Arc::new(Sequencer::new(0, Arc::new(write_buffer)));
+        let shard = Arc::new(Sequencer::new(
+            0,
+            Arc::new(write_buffer),
+            &Default::default(),
+        ));
         let sharder = Arc::new(MockSharder::default().with_return([
             Arc::clone(&shard),
             Arc::clone(&shard),
@@ -285,13 +289,21 @@ mod tests {
         // Configure the first shard to write to one write buffer
         let write_buffer1 = init_write_buffer(1);
         let write_buffer1_state = write_buffer1.state();
-        let shard1 = Arc::new(Sequencer::new(0, Arc::new(write_buffer1)));
+        let shard1 = Arc::new(Sequencer::new(
+            0,
+            Arc::new(write_buffer1),
+            &Default::default(),
+        ));
 
         // Configure the second shard to write to a different write buffer in
         // order to see which buffer saw what write.
         let write_buffer2 = init_write_buffer(2);
         let write_buffer2_state = write_buffer2.state();
-        let shard2 = Arc::new(Sequencer::new(1, Arc::new(write_buffer2)));
+        let shard2 = Arc::new(Sequencer::new(
+            1,
+            Arc::new(write_buffer2),
+            &Default::default(),
+        ));
 
         let sharder = Arc::new(MockSharder::default().with_return([
             // 4 tables, 3 mapped to the first shard
@@ -359,12 +371,20 @@ mod tests {
         // Configure the first shard to write to one write buffer
         let write_buffer1 = init_write_buffer(1);
         let write_buffer1_state = write_buffer1.state();
-        let shard1 = Arc::new(Sequencer::new(0, Arc::new(write_buffer1)));
+        let shard1 = Arc::new(Sequencer::new(
+            0,
+            Arc::new(write_buffer1),
+            &Default::default(),
+        ));
 
         // Configure the second shard to write to a write buffer that always fails
         let write_buffer2 = init_write_buffer(1);
         // Non-existant sequencer ID to trigger an error.
-        let shard2 = Arc::new(Sequencer::new(13, Arc::new(write_buffer2)));
+        let shard2 = Arc::new(Sequencer::new(
+            13,
+            Arc::new(write_buffer2),
+            &Default::default(),
+        ));
 
         let sharder = Arc::new(
             MockSharder::default().with_return([Arc::clone(&shard1), Arc::clone(&shard2)]),
@@ -403,7 +423,11 @@ mod tests {
 
         // Configure the sharder to return shards containing the mock write
         // buffer.
-        let shard = Arc::new(Sequencer::new(0, Arc::new(write_buffer)));
+        let shard = Arc::new(Sequencer::new(
+            0,
+            Arc::new(write_buffer),
+            &Default::default(),
+        ));
         let sharder = Arc::new(MockSharder::default().with_return([Arc::clone(&shard)]));
 
         let w = ShardedWriteBuffer::new(Arc::clone(&sharder));

--- a/router2/src/sequencer.rs
+++ b/router2/src/sequencer.rs
@@ -1,15 +1,21 @@
 //! A representation of a single operation sequencer.
 
-use std::{hash::Hash, sync::Arc};
+use std::{borrow::Cow, hash::Hash, sync::Arc};
 
 use dml::{DmlMeta, DmlOperation};
+use metric::{Metric, U64Histogram, U64HistogramOptions};
+use time::{SystemProvider, TimeProvider};
 use write_buffer::core::{WriteBufferError, WriteBufferWriting};
 
 /// A sequencer tags an write buffer with a sequencer ID.
 #[derive(Debug)]
-pub struct Sequencer {
+pub struct Sequencer<P = SystemProvider> {
     id: usize,
     inner: Arc<dyn WriteBufferWriting>,
+    time_provider: P,
+
+    enqueue_success: U64Histogram,
+    enqueue_error: U64Histogram,
 }
 
 impl Eq for Sequencer {}
@@ -28,8 +34,32 @@ impl Hash for Sequencer {
 
 impl Sequencer {
     /// Tag `inner` with the specified `id`.
-    pub fn new(id: usize, inner: Arc<dyn WriteBufferWriting>) -> Self {
-        Self { id, inner }
+    pub fn new(id: usize, inner: Arc<dyn WriteBufferWriting>, metrics: &metric::Registry) -> Self {
+        let buckets = || {
+            U64HistogramOptions::new([5, 10, 20, 40, 80, 160, 320, 640, 1280, 2560, 5120, u64::MAX])
+        };
+        let write: Metric<U64Histogram> = metrics.register_metric_with_options(
+            "sequencer_enqueue_duration_ms",
+            "sequencer enqueue call duration in milliseconds",
+            buckets,
+        );
+
+        let enqueue_success = write.recorder([
+            ("shard_id", Cow::from(id.to_string())),
+            ("result", Cow::from("success")),
+        ]);
+        let enqueue_error = write.recorder([
+            ("shard_id", Cow::from(id.to_string())),
+            ("result", Cow::from("error")),
+        ]);
+
+        Self {
+            id,
+            inner,
+            enqueue_success,
+            enqueue_error,
+            time_provider: Default::default(),
+        }
     }
 
     /// Return the ID of this sequencer.
@@ -43,6 +73,17 @@ impl Sequencer {
     /// behaviour of the [`WriteBufferWriting::store_operation()`]
     /// implementation this [`Sequencer`] wraps.
     pub async fn enqueue<'a>(&self, op: DmlOperation) -> Result<DmlMeta, WriteBufferError> {
-        self.inner.store_operation(self.id as u32, &op).await
+        let t = self.time_provider.now();
+
+        let res = self.inner.store_operation(self.id as u32, &op).await;
+
+        if let Some(delta) = self.time_provider.now().checked_duration_since(t) {
+            match &res {
+                Ok(_) => self.enqueue_success.record(delta.as_millis() as _),
+                Err(_) => self.enqueue_error.record(delta.as_millis() as _),
+            }
+        }
+
+        res
     }
 }


### PR DESCRIPTION
These metrics will help us answer a few questions that have popped up over the last couple days.

More metrics == more insights 👀 

---

* refactor: write table count metric (e00986c56)

      Record the number of tables in each write - this will let us observe the total
      number of tables a router instance has observed, which when combined with the
      existing metrics helps us understand the shape
      (distribution of tables/lines/fields) of the workload hitting the routers.

* refactor: sequencer metrics (bb9b140f4)

      Records per-sequencer (kafka partition) enqueue latency / counts broken down
      by operation success/error.

* refactor: NamespaceCache latency histograms (6b5283bf3)

      Switches the get/put counters to latency histograms to record the duration of
      each call - this might be interesting!

* feat: schema validation benchmarks (14d90d101)

      Useful for confirming the scalability of the schema check algorithm.