### PR TITLE
perf: get_table_persist_info indexes for joins

### DIFF
--- a/iox_catalog/migrations/20220308120917_ingester-missing-indexes.sql
+++ b/iox_catalog/migrations/20220308120917_ingester-missing-indexes.sql
@@ -1,0 +1,5 @@
+-- Add indexes to support JOINs in TableRepo::get_table_persist_info
+-- https://github.com/influxdata/influxdb_iox/blob/aaec1c7828139e47296665c84aeea4c974026118/iox_catalog/src/postgres.rs#L717-L734
+CREATE INDEX IF NOT EXISTS table_name_namespace_idx ON table_name (namespace_id);
+
+CREATE INDEX IF NOT EXISTS parquet_file_table_idx ON parquet_file (table_id);


### PR DESCRIPTION
Adds a couple of indexes to the catalog to support the [`TabelRepo::get_table_persist_info()`](https://github.com/influxdata/influxdb_iox/blob/aaec1c7828139e47296665c84aeea4c974026118/iox_catalog/src/postgres.rs#L717-L734) calls.

Plan before indexes:

```
 Hash Left Join  (cost=80844.84..80913.72 rows=2500 width=24)
   Hash Cond: (tid.id = parquet_file.table_id)
   CTE tid
     ->  Seq Scan on table_name  (cost=0.00..195.75 rows=2500 width=4)
           Filter: (namespace_id = 1)
   ->  Hash Left Join  (cost=58.19..117.69 rows=2500 width=12)
         Hash Cond: (tid.id = tombstone.table_id)
         ->  CTE Scan on tid  (cost=0.00..50.00 rows=2500 width=4)
         ->  Hash  (cost=58.18..58.18 rows=1 width=12)
               ->  Subquery Scan on tombstone  (cost=50.15..58.18 rows=1 width=12)
                     ->  Limit  (cost=50.15..58.17 rows=1 width=12)
                           InitPlan 2 (returns $1)
                             ->  CTE Scan on tid tid_1  (cost=0.00..50.00 rows=2500 width=4)
                           ->  Index Only Scan Backward using tombstone_unique on tombstone tombstone_1  (cost=0.15..8.17 rows=1 width=12)
                                 Index Cond: ((table_id = $1) AND (sequencer_id = 1))
   ->  Hash  (cost=80590.88..80590.88 rows=1 width=12)
         ->  Subquery Scan on parquet_file  (cost=80590.76..80590.88 rows=1 width=12)
               ->  Limit  (cost=80590.76..80590.87 rows=1 width=12)
                     InitPlan 3 (returns $2)
                       ->  CTE Scan on tid tid_2  (cost=0.00..50.00 rows=2500 width=4)
                     ->  Gather Merge  (cost=80540.76..80543.09 rows=20 width=12)
                           Workers Planned: 2
                           Params Evaluated: $2
                           ->  Sort  (cost=79540.73..79540.76 rows=10 width=12)
                                 Sort Key: parquet_file_1.max_sequence_number DESC
                                 ->  Parallel Seq Scan on parquet_file parquet_file_1  (cost=0.00..79540.68 rows=10 width=12)
                                       Filter: ((sequencer_id = 1) AND (table_id = $2))
```

Plan after indexes:

```
 Hash Left Join  (cost=459.34..528.22 rows=2500 width=24)
   Hash Cond: (tid.id = parquet_file.table_id)
   CTE tid
     ->  Bitmap Heap Scan on table_name  (cost=31.66..164.91 rows=2500 width=4)
           Recheck Cond: (namespace_id = 1)
           ->  Bitmap Index Scan on table_name_namespace_idx  (cost=0.00..31.03 rows=2500 width=0)
                 Index Cond: (namespace_id = 1)
   ->  Hash Left Join  (cost=58.19..117.69 rows=2500 width=12)
         Hash Cond: (tid.id = tombstone.table_id)
         ->  CTE Scan on tid  (cost=0.00..50.00 rows=2500 width=4)
         ->  Hash  (cost=58.18..58.18 rows=1 width=12)
               ->  Subquery Scan on tombstone  (cost=50.15..58.18 rows=1 width=12)
                     ->  Limit  (cost=50.15..58.17 rows=1 width=12)
                           InitPlan 2 (returns $1)
                             ->  CTE Scan on tid tid_1  (cost=0.00..50.00 rows=2500 width=4)
                           ->  Index Only Scan Backward using tombstone_unique on tombstone tombstone_1  (cost=0.15..8.17 rows=1 width=12)
                                 Index Cond: ((table_id = $1) AND (sequencer_id = 1))
   ->  Hash  (cost=236.23..236.23 rows=1 width=12)
         ->  Subquery Scan on parquet_file  (cost=236.21..236.23 rows=1 width=12)
               ->  Limit  (cost=236.21..236.22 rows=1 width=12)
                     InitPlan 3 (returns $2)
                       ->  CTE Scan on tid tid_2  (cost=0.00..50.00 rows=2500 width=4)
                     ->  Sort  (cost=186.21..186.27 rows=23 width=12)
                           Sort Key: parquet_file_1.max_sequence_number DESC
                           ->  Bitmap Heap Scan on parquet_file parquet_file_1  (cost=4.77..186.10 rows=23 width=12)
                                 Recheck Cond: (table_id = $2)
                                 Filter: (sequencer_id = 1)
                                 ->  Bitmap Index Scan on parquet_file_table_idx  (cost=0.00..4.77 rows=46 width=0)
                                       Index Cond: (table_id = $2)
```

---

* perf: get_table_persist_info indexes for joins (d31576b90)

      Adds indexes to the JOINed fields to reduce execution cost, as the 
      TableRepo::get_table_persist_info() is currently by far the most expensive
      catalog operation.