### PR TITLE
build: bump regex

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4309,9 +4309,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.5.4"
+version = "1.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
+checksum = "1a11647b6b25ff05a515cb92c365cec08801e83423a235b51e231e1808747286"
 dependencies = [
  "aho-corasick",
  "memchr",


### PR DESCRIPTION
Unblocks CI.

See https://rustsec.org/advisories/RUSTSEC-2022-0013.

---

* build: bump regex (3278e35b4)

      Bump regex version due to RUSTSEC-2022-0013, see:

          https://rustsec.org/advisories/RUSTSEC-2022-0013