### PR TITLE
feat: emit object store metrics

### DIFF
--- a/clap_blocks/src/object_store.rs
+++ b/clap_blocks/src/object_store.rs
@@ -2,7 +2,7 @@
 use std::{convert::TryFrom, fs, num::NonZeroUsize, path::PathBuf, time::Duration};
 
 use futures::TryStreamExt;
-use object_store::{path::ObjectStorePath, ObjectStoreImpl, ObjectStoreApi, ThrottleConfig};
+use object_store::{path::ObjectStorePath, DynObjectStore, ObjectStoreImpl, ThrottleConfig};
 use observability_deps::tracing::{info, warn};
 use snafu::{ResultExt, Snafu};
 use uuid::Uuid;
@@ -352,7 +352,7 @@ pub enum CheckError {
 /// Check if object store is properly configured and accepts writes and reads.
 ///
 /// Note: This does NOT test if the object store is writable!
-pub async fn check_object_store(object_store: &ObjectStoreImpl) -> Result<(), CheckError> {
+pub async fn check_object_store(object_store: &DynObjectStore) -> Result<(), CheckError> {
     // Use some prefix that will very likely end in an empty result, so we don't pull too much actual data here.
     let uuid = Uuid::new_v4().to_string();
     let mut prefix = object_store.new_path();

--- a/clap_blocks/src/object_store.rs
+++ b/clap_blocks/src/object_store.rs
@@ -2,7 +2,7 @@
 use std::{convert::TryFrom, fs, num::NonZeroUsize, path::PathBuf, time::Duration};
 
 use futures::TryStreamExt;
-use object_store::{path::ObjectStorePath, ObjectStore, ObjectStoreApi, ThrottleConfig};
+use object_store::{path::ObjectStorePath, ObjectStoreImpl, ObjectStoreApi, ThrottleConfig};
 use observability_deps::tracing::{info, warn};
 use snafu::{ResultExt, Snafu};
 use uuid::Uuid;
@@ -205,7 +205,7 @@ pub fn warn_about_inmem_store(config: &ObjectStoreConfig) {
     }
 }
 
-impl TryFrom<&ObjectStoreConfig> for ObjectStore {
+impl TryFrom<&ObjectStoreConfig> for ObjectStoreImpl {
     type Error = ParseError;
 
     fn try_from(config: &ObjectStoreConfig) -> Result<Self, Self::Error> {
@@ -352,7 +352,7 @@ pub enum CheckError {
 /// Check if object store is properly configured and accepts writes and reads.
 ///
 /// Note: This does NOT test if the object store is writable!
-pub async fn check_object_store(object_store: &ObjectStore) -> Result<(), CheckError> {
+pub async fn check_object_store(object_store: &ObjectStoreImpl) -> Result<(), CheckError> {
     // Use some prefix that will very likely end in an empty result, so we don't pull too much actual data here.
     let uuid = Uuid::new_v4().to_string();
     let mut prefix = object_store.new_path();
@@ -386,8 +386,8 @@ mod tests {
     fn default_object_store_is_memory() {
         let config = ObjectStoreConfig::try_parse_from(&["server"]).unwrap();
 
-        let object_store = ObjectStore::try_from(&config).unwrap();
-        let ObjectStore { integration, .. } = object_store;
+        let object_store = ObjectStoreImpl::try_from(&config).unwrap();
+        let ObjectStoreImpl { integration, .. } = object_store;
 
         assert!(matches!(integration, ObjectStoreIntegration::InMemory(_)));
     }
@@ -397,8 +397,8 @@ mod tests {
         let config =
             ObjectStoreConfig::try_parse_from(&["server", "--object-store", "memory"]).unwrap();
 
-        let object_store = ObjectStore::try_from(&config).unwrap();
-        let ObjectStore { integration, .. } = object_store;
+        let object_store = ObjectStoreImpl::try_from(&config).unwrap();
+        let ObjectStoreImpl { integration, .. } = object_store;
 
         assert!(matches!(integration, ObjectStoreIntegration::InMemory(_)));
     }
@@ -419,7 +419,7 @@ mod tests {
         ])
         .unwrap();
 
-        let object_store = ObjectStore::try_from(&config).unwrap();
+        let object_store = ObjectStoreImpl::try_from(&config).unwrap();
         let ObjectStore { integration, .. } = object_store;
 
         assert!(matches!(integration, ObjectStoreIntegration::AmazonS3(_)));
@@ -433,7 +433,7 @@ mod tests {
         // clean out eventual leaks via env variables
         config.bucket = None;
 
-        let err = ObjectStore::try_from(&config).unwrap_err().to_string();
+        let err = ObjectStoreImpl::try_from(&config).unwrap_err().to_string();
 
         assert_eq!(
             err,
@@ -455,7 +455,7 @@ mod tests {
         ])
         .unwrap();
 
-        let object_store = ObjectStore::try_from(&config).unwrap();
+        let object_store = ObjectStoreImpl::try_from(&config).unwrap();
         let ObjectStore { integration, .. } = object_store;
 
         assert!(matches!(
@@ -472,7 +472,7 @@ mod tests {
         // clean out eventual leaks via env variables
         config.bucket = None;
 
-        let err = ObjectStore::try_from(&config).unwrap_err().to_string();
+        let err = ObjectStoreImpl::try_from(&config).unwrap_err().to_string();
 
         assert_eq!(
             err,
@@ -497,7 +497,7 @@ mod tests {
         ])
         .unwrap();
 
-        let object_store = ObjectStore::try_from(&config).unwrap();
+        let object_store = ObjectStoreImpl::try_from(&config).unwrap();
         let ObjectStore { integration, .. } = object_store;
 
         assert!(matches!(
@@ -514,7 +514,7 @@ mod tests {
         // clean out eventual leaks via env variables
         config.bucket = None;
 
-        let err = ObjectStore::try_from(&config).unwrap_err().to_string();
+        let err = ObjectStoreImpl::try_from(&config).unwrap_err().to_string();
 
         assert_eq!(
             err,
@@ -536,8 +536,8 @@ mod tests {
         ])
         .unwrap();
 
-        let object_store = ObjectStore::try_from(&config).unwrap();
-        let ObjectStore { integration, .. } = object_store;
+        let object_store = ObjectStoreImpl::try_from(&config).unwrap();
+        let ObjectStoreImpl { integration, .. } = object_store;
 
         assert!(matches!(integration, ObjectStoreIntegration::File(_)));
     }
@@ -547,7 +547,7 @@ mod tests {
         let config =
             ObjectStoreConfig::try_parse_from(&["server", "--object-store", "file"]).unwrap();
 
-        let err = ObjectStore::try_from(&config).unwrap_err().to_string();
+        let err = ObjectStoreImpl::try_from(&config).unwrap_err().to_string();
 
         assert_eq!(
             err,

--- a/compactor/src/compact.rs
+++ b/compactor/src/compact.rs
@@ -11,13 +11,12 @@ use data_types2::{
 };
 use datafusion::error::DataFusionError;
 use iox_catalog::interface::Catalog;
-use object_store::ObjectStore;
+use object_store::ObjectStoreImpl;
 use observability_deps::tracing::warn;
 use parquet_file::metadata::IoxMetadata;
+use query::exec::Executor;
 use query::{
-    compute_sort_key_for_chunks,
-    exec::{Executor, ExecutorType},
-    frontend::reorg::ReorgPlanner,
+    compute_sort_key_for_chunks, exec::ExecutorType, frontend::reorg::ReorgPlanner,
     util::compute_timenanosecond_min_max,
 };
 use snafu::{ensure, ResultExt, Snafu};
@@ -121,7 +120,7 @@ pub struct Compactor {
     /// Sequencers assigned to this compactor
     sequencers: Vec<SequencerId>,
     /// Object store for reading and persistence of parquet files
-    object_store: Arc<ObjectStore>,
+    object_store: Arc<ObjectStoreImpl>,
     /// The global catalog for schema, parquet files and tombstones
     catalog: Arc<dyn Catalog>,
 
@@ -139,7 +138,7 @@ impl Compactor {
     pub fn new(
         sequencers: Vec<SequencerId>,
         catalog: Arc<dyn Catalog>,
-        object_store: Arc<ObjectStore>,
+        object_store: Arc<ObjectStoreImpl>,
         exec: Arc<Executor>,
         time_provider: Arc<dyn TimeProvider>,
         backoff_config: BackoffConfig,

--- a/compactor/src/compact.rs
+++ b/compactor/src/compact.rs
@@ -11,7 +11,7 @@ use data_types2::{
 };
 use datafusion::error::DataFusionError;
 use iox_catalog::interface::Catalog;
-use object_store::ObjectStoreImpl;
+use object_store::DynObjectStore;
 use observability_deps::tracing::warn;
 use parquet_file::metadata::IoxMetadata;
 use query::exec::Executor;
@@ -120,7 +120,7 @@ pub struct Compactor {
     /// Sequencers assigned to this compactor
     sequencers: Vec<SequencerId>,
     /// Object store for reading and persistence of parquet files
-    object_store: Arc<ObjectStoreImpl>,
+    object_store: Arc<DynObjectStore>,
     /// The global catalog for schema, parquet files and tombstones
     catalog: Arc<dyn Catalog>,
 
@@ -138,7 +138,7 @@ impl Compactor {
     pub fn new(
         sequencers: Vec<SequencerId>,
         catalog: Arc<dyn Catalog>,
-        object_store: Arc<ObjectStoreImpl>,
+        object_store: Arc<DynObjectStore>,
         exec: Arc<Executor>,
         time_provider: Arc<dyn TimeProvider>,
         backoff_config: BackoffConfig,

--- a/compactor/src/handler.rs
+++ b/compactor/src/handler.rs
@@ -9,7 +9,7 @@ use futures::{
     FutureExt, StreamExt, TryFutureExt,
 };
 use iox_catalog::interface::Catalog;
-use object_store::ObjectStoreImpl;
+use object_store::DynObjectStore;
 use observability_deps::tracing::warn;
 use query::exec::Executor;
 use std::sync::Arc;
@@ -62,7 +62,7 @@ impl CompactorHandlerImpl {
     pub fn new(
         sequencers: Vec<SequencerId>,
         catalog: Arc<dyn Catalog>,
-        object_store: Arc<ObjectStoreImpl>,
+        object_store: Arc<DynObjectStore>,
         exec: Arc<Executor>,
         time_provider: Arc<dyn TimeProvider>,
         _registry: &metric::Registry,

--- a/compactor/src/handler.rs
+++ b/compactor/src/handler.rs
@@ -9,7 +9,7 @@ use futures::{
     FutureExt, StreamExt, TryFutureExt,
 };
 use iox_catalog::interface::Catalog;
-use object_store::ObjectStore;
+use object_store::ObjectStoreImpl;
 use observability_deps::tracing::warn;
 use query::exec::Executor;
 use std::sync::Arc;
@@ -62,7 +62,7 @@ impl CompactorHandlerImpl {
     pub fn new(
         sequencers: Vec<SequencerId>,
         catalog: Arc<dyn Catalog>,
-        object_store: Arc<ObjectStore>,
+        object_store: Arc<ObjectStoreImpl>,
         exec: Arc<Executor>,
         time_provider: Arc<dyn TimeProvider>,
         _registry: &metric::Registry,

--- a/compactor/src/utils.rs
+++ b/compactor/src/utils.rs
@@ -4,7 +4,7 @@ use crate::query::QueryableParquetChunk;
 use arrow::record_batch::RecordBatch;
 use data_types2::{ParquetFile, ParquetFileId, Tombstone, TombstoneId};
 use iox_object_store::IoxObjectStore;
-use object_store::ObjectStore;
+use object_store::ObjectStoreImpl;
 use parquet_file::{
     chunk::{new_parquet_chunk, ChunkMetrics, DecodedParquetFile},
     metadata::IoxMetadata,
@@ -50,7 +50,7 @@ impl ParquetFileWithTombstone {
     /// Convert to a QueryableParquetChunk
     pub fn to_queryable_parquet_chunk(
         &self,
-        object_store: Arc<ObjectStore>,
+        object_store: Arc<ObjectStoreImpl>,
         table_name: String,
         partition_key: String,
     ) -> QueryableParquetChunk {

--- a/compactor/src/utils.rs
+++ b/compactor/src/utils.rs
@@ -4,7 +4,7 @@ use crate::query::QueryableParquetChunk;
 use arrow::record_batch::RecordBatch;
 use data_types2::{ParquetFile, ParquetFileId, Tombstone, TombstoneId};
 use iox_object_store::IoxObjectStore;
-use object_store::ObjectStoreImpl;
+use object_store::DynObjectStore;
 use parquet_file::{
     chunk::{new_parquet_chunk, ChunkMetrics, DecodedParquetFile},
     metadata::IoxMetadata,
@@ -50,12 +50,12 @@ impl ParquetFileWithTombstone {
     /// Convert to a QueryableParquetChunk
     pub fn to_queryable_parquet_chunk(
         &self,
-        object_store: Arc<ObjectStoreImpl>,
+        object_store: Arc<DynObjectStore>,
         table_name: String,
         partition_key: String,
     ) -> QueryableParquetChunk {
         let decoded_parquet_file = DecodedParquetFile::new((*self.data).clone());
-        let root_path = IoxObjectStore::root_path_for(&object_store, self.data.object_store_id);
+        let root_path = IoxObjectStore::root_path_for(&*object_store, self.data.object_store_id);
         let iox_object_store = IoxObjectStore::existing(object_store, root_path);
         let parquet_chunk = new_parquet_chunk(
             &decoded_parquet_file,

--- a/db/src/lib.rs
+++ b/db/src/lib.rs
@@ -1447,7 +1447,7 @@ mod tests {
     use iox_object_store::ParquetFilePath;
     use metric::{Attributes, CumulativeGauge, Metric, Observation};
     use mutable_batch_lp::lines_to_batches;
-    use object_store::ObjectStore;
+    use object_store::ObjectStoreImpl;
     use parquet_catalog::test_helpers::load_ok;
     use parquet_file::{
         metadata::IoxParquetMetaData,
@@ -2086,7 +2086,7 @@ mod tests {
     #[tokio::test]
     async fn write_one_chunk_to_parquet_file() {
         // Test that data can be written into parquet files
-        let object_store = Arc::new(ObjectStore::new_in_memory());
+        let object_store = Arc::new(ObjectStoreImpl::new_in_memory());
         let time = Arc::new(time::MockProvider::new(Time::from_timestamp(11, 22)));
 
         let test_db = TestDb::builder()
@@ -2187,7 +2187,7 @@ mod tests {
         // be able to read data from object store
 
         // Create an object store in memory
-        let object_store = Arc::new(ObjectStore::new_in_memory());
+        let object_store = Arc::new(ObjectStoreImpl::new_in_memory());
         let time = Arc::new(time::MockProvider::new(Time::from_timestamp(11, 22)));
 
         let test_db = TestDb::builder()
@@ -2973,7 +2973,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn lock_tracker_metrics() {
-        let object_store = Arc::new(ObjectStore::new_in_memory());
+        let object_store = Arc::new(ObjectStoreImpl::new_in_memory());
 
         // Create a DB given a server id, an object store and a db name
         let server_id = ServerId::try_from(10).unwrap();
@@ -3106,7 +3106,7 @@ mod tests {
         // Test that parquet data is committed to preserved catalog
 
         // ==================== setup ====================
-        let object_store = Arc::new(ObjectStore::new_in_memory());
+        let object_store = Arc::new(ObjectStoreImpl::new_in_memory());
         let server_id = ServerId::try_from(1).unwrap();
         let db_name = "preserved_catalog_test";
 
@@ -3205,7 +3205,7 @@ mod tests {
         // Test that stale parquet files are removed from object store
 
         // ==================== setup ====================
-        let object_store = Arc::new(ObjectStore::new_in_memory());
+        let object_store = Arc::new(ObjectStoreImpl::new_in_memory());
 
         // ==================== do: create DB ====================
         let test_db = TestDb::builder()
@@ -3298,7 +3298,7 @@ mod tests {
         // Test that the preserved catalog creates checkpoints
 
         // ==================== setup ====================
-        let object_store = Arc::new(ObjectStore::new_in_memory());
+        let object_store = Arc::new(ObjectStoreImpl::new_in_memory());
         let server_id = ServerId::try_from(1).unwrap();
         let db_name = "preserved_catalog_test";
 
@@ -3374,7 +3374,7 @@ mod tests {
         // Test that the background worker prunes transactions
 
         // ==================== setup ====================
-        let object_store = Arc::new(ObjectStore::new_in_memory());
+        let object_store = Arc::new(ObjectStoreImpl::new_in_memory());
         let server_id = ServerId::try_from(1).unwrap();
         let db_name = "transaction_pruning_test";
 

--- a/db/src/lib.rs
+++ b/db/src/lib.rs
@@ -1447,7 +1447,7 @@ mod tests {
     use iox_object_store::ParquetFilePath;
     use metric::{Attributes, CumulativeGauge, Metric, Observation};
     use mutable_batch_lp::lines_to_batches;
-    use object_store::ObjectStoreImpl;
+    use object_store::{DynObjectStore, ObjectStoreImpl};
     use parquet_catalog::test_helpers::load_ok;
     use parquet_file::{
         metadata::IoxParquetMetaData,
@@ -2086,7 +2086,7 @@ mod tests {
     #[tokio::test]
     async fn write_one_chunk_to_parquet_file() {
         // Test that data can be written into parquet files
-        let object_store = Arc::new(ObjectStoreImpl::new_in_memory());
+        let object_store: Arc<DynObjectStore> = Arc::new(ObjectStoreImpl::new_in_memory());
         let time = Arc::new(time::MockProvider::new(Time::from_timestamp(11, 22)));
 
         let test_db = TestDb::builder()
@@ -2187,7 +2187,7 @@ mod tests {
         // be able to read data from object store
 
         // Create an object store in memory
-        let object_store = Arc::new(ObjectStoreImpl::new_in_memory());
+        let object_store: Arc<DynObjectStore> = Arc::new(ObjectStoreImpl::new_in_memory());
         let time = Arc::new(time::MockProvider::new(Time::from_timestamp(11, 22)));
 
         let test_db = TestDb::builder()
@@ -2973,7 +2973,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn lock_tracker_metrics() {
-        let object_store = Arc::new(ObjectStoreImpl::new_in_memory());
+        let object_store: Arc<DynObjectStore> = Arc::new(ObjectStoreImpl::new_in_memory());
 
         // Create a DB given a server id, an object store and a db name
         let server_id = ServerId::try_from(10).unwrap();
@@ -3106,7 +3106,7 @@ mod tests {
         // Test that parquet data is committed to preserved catalog
 
         // ==================== setup ====================
-        let object_store = Arc::new(ObjectStoreImpl::new_in_memory());
+        let object_store: Arc<DynObjectStore> = Arc::new(ObjectStoreImpl::new_in_memory());
         let server_id = ServerId::try_from(1).unwrap();
         let db_name = "preserved_catalog_test";
 
@@ -3205,7 +3205,7 @@ mod tests {
         // Test that stale parquet files are removed from object store
 
         // ==================== setup ====================
-        let object_store = Arc::new(ObjectStoreImpl::new_in_memory());
+        let object_store: Arc<DynObjectStore> = Arc::new(ObjectStoreImpl::new_in_memory());
 
         // ==================== do: create DB ====================
         let test_db = TestDb::builder()
@@ -3298,7 +3298,7 @@ mod tests {
         // Test that the preserved catalog creates checkpoints
 
         // ==================== setup ====================
-        let object_store = Arc::new(ObjectStoreImpl::new_in_memory());
+        let object_store: Arc<DynObjectStore> = Arc::new(ObjectStoreImpl::new_in_memory());
         let server_id = ServerId::try_from(1).unwrap();
         let db_name = "preserved_catalog_test";
 
@@ -3374,7 +3374,7 @@ mod tests {
         // Test that the background worker prunes transactions
 
         // ==================== setup ====================
-        let object_store = Arc::new(ObjectStoreImpl::new_in_memory());
+        let object_store: Arc<DynObjectStore> = Arc::new(ObjectStoreImpl::new_in_memory());
         let server_id = ServerId::try_from(1).unwrap();
         let db_name = "transaction_pruning_test";
 

--- a/db/src/lifecycle/persist.rs
+++ b/db/src/lifecycle/persist.rs
@@ -250,7 +250,7 @@ mod tests {
         timestamp::TimestampRange,
     };
     use lifecycle::{LockableChunk, LockablePartition};
-    use object_store::ObjectStore;
+    use object_store::ObjectStoreImpl;
     use std::{
         convert::TryFrom,
         num::{NonZeroU32, NonZeroU64},
@@ -470,7 +470,7 @@ mod tests {
     #[tokio::test]
     async fn test_delete_predicate_propagation() {
         // setup DB
-        let object_store = Arc::new(ObjectStore::new_in_memory());
+        let object_store = Arc::new(ObjectStoreImpl::new_in_memory());
         let server_id = ServerId::try_from(1).unwrap();
         let db_name = "delete_predicate_propagation";
         let test_db = TestDb::builder()

--- a/db/src/lifecycle/persist.rs
+++ b/db/src/lifecycle/persist.rs
@@ -250,7 +250,7 @@ mod tests {
         timestamp::TimestampRange,
     };
     use lifecycle::{LockableChunk, LockablePartition};
-    use object_store::ObjectStoreImpl;
+    use object_store::{DynObjectStore, ObjectStoreImpl};
     use std::{
         convert::TryFrom,
         num::{NonZeroU32, NonZeroU64},
@@ -470,7 +470,7 @@ mod tests {
     #[tokio::test]
     async fn test_delete_predicate_propagation() {
         // setup DB
-        let object_store = Arc::new(ObjectStoreImpl::new_in_memory());
+        let object_store: Arc<DynObjectStore> = Arc::new(ObjectStoreImpl::new_in_memory());
         let server_id = ServerId::try_from(1).unwrap();
         let db_name = "delete_predicate_propagation";
         let test_db = TestDb::builder()

--- a/db/src/load.rs
+++ b/db/src/load.rs
@@ -325,7 +325,7 @@ mod tests {
     use super::*;
     use crate::checkpoint_data_from_catalog;
     use data_types::DatabaseName;
-    use object_store::ObjectStore;
+    use object_store::ObjectStoreImpl;
     use parquet_catalog::{
         interface::CheckpointData,
         test_helpers::{assert_catalog_state_implementation, new_empty},
@@ -334,7 +334,7 @@ mod tests {
 
     #[tokio::test]
     async fn load_or_create_preserved_catalog_recovers_from_error() {
-        let object_store = Arc::new(ObjectStore::new_in_memory());
+        let object_store = Arc::new(ObjectStoreImpl::new_in_memory());
         let time_provider: Arc<dyn TimeProvider> = Arc::new(time::SystemProvider::new());
         let db_name = DatabaseName::new("preserved_catalog_test").unwrap();
         let db_uuid = Uuid::new_v4();

--- a/db/src/replay.rs
+++ b/db/src/replay.rs
@@ -467,7 +467,7 @@ mod tests {
         timestamp::TimestampRange,
     };
     use dml::{DmlDelete, DmlMeta};
-    use object_store::ObjectStore;
+    use object_store::ObjectStoreImpl;
     use persistence_windows::{
         checkpoint::{PartitionCheckpoint, PersistCheckpointBuilder, ReplayPlanner},
         min_max_sequence::OptionalMinMaxSequence,
@@ -603,7 +603,7 @@ mod tests {
             // Test that data is replayed from write buffers
 
             // ==================== setup ====================
-            let object_store = Arc::new(ObjectStore::new_in_memory());
+            let object_store = Arc::new(ObjectStoreImpl::new_in_memory());
             let time = Arc::new(time::MockProvider::new(Time::from_timestamp(12, 0)));
             let server_id = ServerId::try_from(1).unwrap();
             let db_name = "replay_test";
@@ -851,7 +851,7 @@ mod tests {
         }
 
         fn create_test_db_builder(
-            object_store: Arc<ObjectStore>,
+            object_store: Arc<ObjectStoreImpl>,
             server_id: ServerId,
             db_name: &'static str,
             partition_template: PartitionTemplate,

--- a/db/src/replay.rs
+++ b/db/src/replay.rs
@@ -467,7 +467,7 @@ mod tests {
         timestamp::TimestampRange,
     };
     use dml::{DmlDelete, DmlMeta};
-    use object_store::ObjectStoreImpl;
+    use object_store::{DynObjectStore, ObjectStoreImpl};
     use persistence_windows::{
         checkpoint::{PartitionCheckpoint, PersistCheckpointBuilder, ReplayPlanner},
         min_max_sequence::OptionalMinMaxSequence,
@@ -603,7 +603,7 @@ mod tests {
             // Test that data is replayed from write buffers
 
             // ==================== setup ====================
-            let object_store = Arc::new(ObjectStoreImpl::new_in_memory());
+            let object_store: Arc<DynObjectStore> = Arc::new(ObjectStoreImpl::new_in_memory());
             let time = Arc::new(time::MockProvider::new(Time::from_timestamp(12, 0)));
             let server_id = ServerId::try_from(1).unwrap();
             let db_name = "replay_test";
@@ -851,7 +851,7 @@ mod tests {
         }
 
         fn create_test_db_builder(
-            object_store: Arc<ObjectStoreImpl>,
+            object_store: Arc<DynObjectStore>,
             server_id: ServerId,
             db_name: &'static str,
             partition_template: PartitionTemplate,

--- a/db/src/utils.rs
+++ b/db/src/utils.rs
@@ -7,7 +7,7 @@ use data_types::{
 };
 use iox_object_store::IoxObjectStore;
 use job_registry::JobRegistry;
-use object_store::ObjectStore;
+use object_store::ObjectStoreImpl;
 use persistence_windows::checkpoint::ReplayPlan;
 use query::exec::Executor;
 use query::exec::ExecutorConfig;
@@ -33,7 +33,7 @@ impl TestDb {
 #[derive(Debug)]
 pub struct TestDbBuilder {
     server_id: ServerId,
-    object_store: Arc<ObjectStore>,
+    object_store: Arc<ObjectStoreImpl>,
     db_name: DatabaseName<'static>,
     uuid: Uuid,
     worker_cleanup_avg_sleep: Duration,
@@ -46,7 +46,7 @@ impl Default for TestDbBuilder {
     fn default() -> Self {
         Self {
             server_id: ServerId::try_from(1).unwrap(),
-            object_store: Arc::new(ObjectStore::new_in_memory()),
+            object_store: Arc::new(ObjectStoreImpl::new_in_memory()),
             db_name: DatabaseName::new("placeholder").unwrap(),
             uuid: Uuid::new_v4(),
             // make background loop spin a bit faster for tests
@@ -139,7 +139,7 @@ impl TestDbBuilder {
         self
     }
 
-    pub fn object_store(mut self, object_store: Arc<ObjectStore>) -> Self {
+    pub fn object_store(mut self, object_store: Arc<ObjectStoreImpl>) -> Self {
         self.object_store = object_store;
         self
     }

--- a/db/src/utils.rs
+++ b/db/src/utils.rs
@@ -7,7 +7,7 @@ use data_types::{
 };
 use iox_object_store::IoxObjectStore;
 use job_registry::JobRegistry;
-use object_store::ObjectStoreImpl;
+use object_store::{DynObjectStore, ObjectStoreImpl};
 use persistence_windows::checkpoint::ReplayPlan;
 use query::exec::Executor;
 use query::exec::ExecutorConfig;
@@ -33,7 +33,7 @@ impl TestDb {
 #[derive(Debug)]
 pub struct TestDbBuilder {
     server_id: ServerId,
-    object_store: Arc<ObjectStoreImpl>,
+    object_store: Arc<DynObjectStore>,
     db_name: DatabaseName<'static>,
     uuid: Uuid,
     worker_cleanup_avg_sleep: Duration,
@@ -139,7 +139,7 @@ impl TestDbBuilder {
         self
     }
 
-    pub fn object_store(mut self, object_store: Arc<ObjectStoreImpl>) -> Self {
+    pub fn object_store(mut self, object_store: Arc<DynObjectStore>) -> Self {
         self.object_store = object_store;
         self
     }

--- a/influxdb_iox/src/commands/debug/dump_catalog.rs
+++ b/influxdb_iox/src/commands/debug/dump_catalog.rs
@@ -1,6 +1,6 @@
 use clap_blocks::{object_store::ObjectStoreConfig, server_id::ServerIdConfig};
 use iox_object_store::IoxObjectStore;
-use object_store::ObjectStore;
+use object_store::ObjectStoreImpl;
 use snafu::{OptionExt, ResultExt, Snafu};
 use std::{convert::TryFrom, sync::Arc};
 
@@ -106,7 +106,7 @@ impl From<DumpOptions> for parquet_catalog::dump::DumpOptions {
 
 pub async fn command(config: Config) -> Result<()> {
     let object_store = Arc::new(
-        ObjectStore::try_from(&config.object_store_config).context(ObjectStoreParsingSnafu)?,
+        ObjectStoreImpl::try_from(&config.object_store_config).context(ObjectStoreParsingSnafu)?,
     );
     let server_id = config.server_id_config.server_id.context(NoServerIdSnafu)?;
     let server_config_bytes = IoxObjectStore::get_server_config_file(&object_store, server_id)

--- a/influxdb_iox/src/commands/debug/dump_catalog.rs
+++ b/influxdb_iox/src/commands/debug/dump_catalog.rs
@@ -1,6 +1,6 @@
 use clap_blocks::{object_store::ObjectStoreConfig, server_id::ServerIdConfig};
 use iox_object_store::IoxObjectStore;
-use object_store::ObjectStoreImpl;
+use object_store::{DynObjectStore, ObjectStoreImpl};
 use snafu::{OptionExt, ResultExt, Snafu};
 use std::{convert::TryFrom, sync::Arc};
 
@@ -105,11 +105,11 @@ impl From<DumpOptions> for parquet_catalog::dump::DumpOptions {
 }
 
 pub async fn command(config: Config) -> Result<()> {
-    let object_store = Arc::new(
+    let object_store: Arc<DynObjectStore> = Arc::new(
         ObjectStoreImpl::try_from(&config.object_store_config).context(ObjectStoreParsingSnafu)?,
     );
     let server_id = config.server_id_config.server_id.context(NoServerIdSnafu)?;
-    let server_config_bytes = IoxObjectStore::get_server_config_file(&object_store, server_id)
+    let server_config_bytes = IoxObjectStore::get_server_config_file(&*object_store, server_id)
         .await
         .context(CantReadServerConfigSnafu)?;
 

--- a/influxdb_iox/src/commands/run/all_in_one.rs
+++ b/influxdb_iox/src/commands/run/all_in_one.rs
@@ -19,7 +19,7 @@ use influxdb_ioxd::{
     },
     Service,
 };
-use object_store::ObjectStore;
+use object_store::{DynObjectStore, ObjectStoreImpl};
 use observability_deps::tracing::*;
 use query::exec::Executor;
 use thiserror::Error;
@@ -293,8 +293,8 @@ pub async fn command(config: Config) -> Result<()> {
         .create_or_get(query_pool_name)
         .await?;
 
-    let object_store = Arc::new(
-        ObjectStore::try_from(router_run_config.object_store_config())
+    let object_store: Arc<DynObjectStore> = Arc::new(
+        ObjectStoreImpl::try_from(router_run_config.object_store_config())
             .map_err(Error::ObjectStoreParsing)?,
     );
 

--- a/influxdb_iox/src/commands/run/compactor.rs
+++ b/influxdb_iox/src/commands/run/compactor.rs
@@ -67,13 +67,6 @@ pub struct Config {
     pub query_exect_thread_count: usize,
 }
 
-impl Config {
-    /// Get a reference to the config's run config.
-    pub fn run_config(&self) -> &RunConfig {
-        &self.run_config
-    }
-}
-
 pub async fn command(config: Config) -> Result<(), Error> {
     let common_state = CommonServerState::from_config(config.run_config.clone())?;
 

--- a/influxdb_iox/src/commands/run/compactor.rs
+++ b/influxdb_iox/src/commands/run/compactor.rs
@@ -1,7 +1,7 @@
 //! Implementation of command line option for running the compactor
 
 use data_types2::SequencerId;
-use object_store::ObjectStore;
+use object_store::ObjectStoreImpl;
 use observability_deps::tracing::*;
 use query::exec::Executor;
 use std::sync::Arc;
@@ -84,7 +84,7 @@ pub async fn command(config: Config) -> Result<(), Error> {
         .await?;
 
     let object_store = Arc::new(
-        ObjectStore::try_from(config.run_config().object_store_config())
+        ObjectStoreImpl::try_from(config.run_config().object_store_config())
             .map_err(Error::ObjectStoreParsing)?,
     );
 

--- a/influxdb_iox/src/commands/run/ingester.rs
+++ b/influxdb_iox/src/commands/run/ingester.rs
@@ -12,7 +12,7 @@ use influxdb_ioxd::{
     },
     Service,
 };
-use object_store::ObjectStoreImpl;
+use object_store::{instrumentation::ObjectStoreMetrics, DynObjectStore, ObjectStoreImpl};
 use observability_deps::tracing::*;
 use query::exec::Executor;
 use std::{convert::TryFrom, sync::Arc};
@@ -83,10 +83,11 @@ pub async fn command(config: Config) -> Result<()> {
         .get_catalog("ingester", Arc::clone(&metric_registry))
         .await?;
 
-    let object_store = Arc::new(
-        ObjectStoreImpl::try_from(config.run_config.object_store_config())
-            .map_err(Error::ObjectStoreParsing)?,
-    );
+    let object_store = ObjectStoreImpl::try_from(config.run_config.object_store_config())
+        .map_err(Error::ObjectStoreParsing)?;
+    // Decorate the object store with a metric recorder.
+    let object_store: Arc<DynObjectStore> =
+        Arc::new(ObjectStoreMetrics::new(object_store, &*metric_registry));
 
     let exec = Arc::new(Executor::new(config.query_exec_thread_count));
     let server_type = create_ingester_server_type(

--- a/influxdb_iox/src/commands/run/ingester.rs
+++ b/influxdb_iox/src/commands/run/ingester.rs
@@ -12,7 +12,7 @@ use influxdb_ioxd::{
     },
     Service,
 };
-use object_store::ObjectStore;
+use object_store::ObjectStoreImpl;
 use observability_deps::tracing::*;
 use query::exec::Executor;
 use std::{convert::TryFrom, sync::Arc};
@@ -84,7 +84,7 @@ pub async fn command(config: Config) -> Result<()> {
         .await?;
 
     let object_store = Arc::new(
-        ObjectStore::try_from(config.run_config.object_store_config())
+        ObjectStoreImpl::try_from(config.run_config.object_store_config())
             .map_err(Error::ObjectStoreParsing)?,
     );
 

--- a/influxdb_iox/src/commands/run/querier.rs
+++ b/influxdb_iox/src/commands/run/querier.rs
@@ -1,6 +1,6 @@
 //! Implementation of command line option for running the querier
 
-use object_store::ObjectStore;
+use object_store::ObjectStoreImpl;
 use observability_deps::tracing::*;
 use query::exec::Executor;
 use std::sync::Arc;
@@ -74,7 +74,7 @@ pub async fn command(config: Config) -> Result<(), Error> {
         .await?;
 
     let object_store = Arc::new(
-        ObjectStore::try_from(config.run_config.object_store_config())
+        ObjectStoreImpl::try_from(config.run_config.object_store_config())
             .map_err(Error::ObjectStoreParsing)?,
     );
 

--- a/influxdb_iox/src/commands/run/querier.rs
+++ b/influxdb_iox/src/commands/run/querier.rs
@@ -1,6 +1,6 @@
 //! Implementation of command line option for running the querier
 
-use object_store::ObjectStoreImpl;
+use object_store::{instrumentation::ObjectStoreMetrics, DynObjectStore, ObjectStoreImpl};
 use observability_deps::tracing::*;
 use query::exec::Executor;
 use std::sync::Arc;
@@ -73,10 +73,11 @@ pub async fn command(config: Config) -> Result<(), Error> {
         .get_catalog("querier", Arc::clone(&metric_registry))
         .await?;
 
-    let object_store = Arc::new(
-        ObjectStoreImpl::try_from(config.run_config.object_store_config())
-            .map_err(Error::ObjectStoreParsing)?,
-    );
+    let object_store = ObjectStoreImpl::try_from(config.run_config.object_store_config())
+        .map_err(Error::ObjectStoreParsing)?;
+    // Decorate the object store with a metric recorder.
+    let object_store: Arc<DynObjectStore> =
+        Arc::new(ObjectStoreMetrics::new(object_store, &*metric_registry));
 
     let time_provider = Arc::new(SystemProvider::new());
 

--- a/influxdb_ioxd/src/server_type/compactor.rs
+++ b/influxdb_ioxd/src/server_type/compactor.rs
@@ -12,7 +12,7 @@ use data_types2::SequencerId;
 use hyper::{Body, Request, Response};
 use iox_catalog::interface::Catalog;
 use metric::Registry;
-use object_store::ObjectStoreImpl;
+use object_store::DynObjectStore;
 use query::exec::Executor;
 use time::TimeProvider;
 use tokio_util::sync::CancellationToken;
@@ -112,7 +112,7 @@ pub async fn create_compactor_server_type(
     common_state: &CommonServerState,
     metric_registry: Arc<metric::Registry>,
     catalog: Arc<dyn Catalog>,
-    object_store: Arc<ObjectStoreImpl>,
+    object_store: Arc<DynObjectStore>,
     exec: Arc<Executor>,
     time_provider: Arc<dyn TimeProvider>,
     sequencers: Vec<SequencerId>,

--- a/influxdb_ioxd/src/server_type/compactor.rs
+++ b/influxdb_ioxd/src/server_type/compactor.rs
@@ -12,7 +12,7 @@ use data_types2::SequencerId;
 use hyper::{Body, Request, Response};
 use iox_catalog::interface::Catalog;
 use metric::Registry;
-use object_store::ObjectStore;
+use object_store::ObjectStoreImpl;
 use query::exec::Executor;
 use time::TimeProvider;
 use tokio_util::sync::CancellationToken;
@@ -112,7 +112,7 @@ pub async fn create_compactor_server_type(
     common_state: &CommonServerState,
     metric_registry: Arc<metric::Registry>,
     catalog: Arc<dyn Catalog>,
-    object_store: Arc<ObjectStore>,
+    object_store: Arc<ObjectStoreImpl>,
     exec: Arc<Executor>,
     time_provider: Arc<dyn TimeProvider>,
     sequencers: Vec<SequencerId>,

--- a/influxdb_ioxd/src/server_type/database/http.rs
+++ b/influxdb_ioxd/src/server_type/database/http.rs
@@ -303,7 +303,7 @@ mod tests {
     use db::Db;
     use dml::DmlWrite;
     use http::StatusCode;
-    use object_store::ObjectStore;
+    use object_store::ObjectStoreImpl;
     use reqwest::Client;
     use schema::selection::Selection;
     use server::{rules::ProvidedDatabaseRules, ApplicationState, Server};
@@ -312,7 +312,7 @@ mod tests {
 
     fn make_application() -> Arc<ApplicationState> {
         Arc::new(ApplicationState::new(
-            Arc::new(ObjectStore::new_in_memory()),
+            Arc::new(ObjectStoreImpl::new_in_memory()),
             None,
             Some(Arc::new(RingBufferTraceCollector::new(5))),
             None,

--- a/influxdb_ioxd/src/server_type/database/setup.rs
+++ b/influxdb_ioxd/src/server_type/database/setup.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use clap_blocks::run_config::RunConfig;
-use object_store::ObjectStore;
+use object_store::ObjectStoreImpl;
 use observability_deps::tracing::warn;
 use server::config::ConfigProvider;
 use server::{ApplicationState, Server, ServerConfig};
@@ -35,7 +35,7 @@ pub async fn make_application(
     let object_store_config = run_config.object_store_config();
     warn_about_inmem_store(object_store_config);
     let object_store =
-        ObjectStore::try_from(object_store_config).context(ObjectStoreParsingSnafu)?;
+        ObjectStoreImpl::try_from(object_store_config).context(ObjectStoreParsingSnafu)?;
 
     check_object_store(&object_store)
         .await

--- a/influxdb_ioxd/src/server_type/ingester.rs
+++ b/influxdb_ioxd/src/server_type/ingester.rs
@@ -16,7 +16,7 @@ use ingester::{
 };
 use iox_catalog::interface::Catalog;
 use metric::Registry;
-use object_store::ObjectStoreImpl;
+use object_store::DynObjectStore;
 use query::exec::Executor;
 use trace::TraceCollector;
 
@@ -134,7 +134,7 @@ pub async fn create_ingester_server_type(
     common_state: &CommonServerState,
     metric_registry: Arc<metric::Registry>,
     catalog: Arc<dyn Catalog>,
-    object_store: Arc<ObjectStoreImpl>,
+    object_store: Arc<DynObjectStore>,
     exec: Arc<Executor>,
     write_buffer_config: &WriteBufferConfig,
     ingester_config: IngesterConfig,

--- a/influxdb_ioxd/src/server_type/ingester.rs
+++ b/influxdb_ioxd/src/server_type/ingester.rs
@@ -16,7 +16,7 @@ use ingester::{
 };
 use iox_catalog::interface::Catalog;
 use metric::Registry;
-use object_store::ObjectStore;
+use object_store::ObjectStoreImpl;
 use query::exec::Executor;
 use trace::TraceCollector;
 
@@ -134,7 +134,7 @@ pub async fn create_ingester_server_type(
     common_state: &CommonServerState,
     metric_registry: Arc<metric::Registry>,
     catalog: Arc<dyn Catalog>,
-    object_store: Arc<ObjectStore>,
+    object_store: Arc<ObjectStoreImpl>,
     exec: Arc<Executor>,
     write_buffer_config: &WriteBufferConfig,
     ingester_config: IngesterConfig,

--- a/influxdb_ioxd/src/server_type/querier/mod.rs
+++ b/influxdb_ioxd/src/server_type/querier/mod.rs
@@ -7,7 +7,7 @@ use async_trait::async_trait;
 use hyper::{Body, Request, Response};
 use iox_catalog::interface::Catalog;
 use metric::Registry;
-use object_store::ObjectStore;
+use object_store::ObjectStoreImpl;
 use querier::{
     database::QuerierDatabase,
     handler::{QuerierHandler, QuerierHandlerImpl},
@@ -127,7 +127,7 @@ pub async fn create_querier_server_type(
     common_state: &CommonServerState,
     metric_registry: Arc<metric::Registry>,
     catalog: Arc<dyn Catalog>,
-    object_store: Arc<ObjectStore>,
+    object_store: Arc<ObjectStoreImpl>,
     time_provider: Arc<dyn TimeProvider>,
     exec: Arc<Executor>,
 ) -> Arc<dyn ServerType> {

--- a/influxdb_ioxd/src/server_type/querier/mod.rs
+++ b/influxdb_ioxd/src/server_type/querier/mod.rs
@@ -7,7 +7,7 @@ use async_trait::async_trait;
 use hyper::{Body, Request, Response};
 use iox_catalog::interface::Catalog;
 use metric::Registry;
-use object_store::ObjectStoreImpl;
+use object_store::DynObjectStore;
 use querier::{
     database::QuerierDatabase,
     handler::{QuerierHandler, QuerierHandlerImpl},
@@ -127,7 +127,7 @@ pub async fn create_querier_server_type(
     common_state: &CommonServerState,
     metric_registry: Arc<metric::Registry>,
     catalog: Arc<dyn Catalog>,
-    object_store: Arc<ObjectStoreImpl>,
+    object_store: Arc<DynObjectStore>,
     time_provider: Arc<dyn TimeProvider>,
     exec: Arc<Executor>,
 ) -> Arc<dyn ServerType> {

--- a/ingester/src/data.rs
+++ b/ingester/src/data.rs
@@ -16,7 +16,7 @@ use datafusion::physical_plan::SendableRecordBatchStream;
 use dml::DmlOperation;
 use iox_catalog::interface::Catalog;
 use mutable_batch::{column::ColumnData, MutableBatch};
-use object_store::ObjectStore;
+use object_store::ObjectStoreImpl;
 use observability_deps::tracing::warn;
 use parking_lot::RwLock;
 use predicate::Predicate;
@@ -91,7 +91,7 @@ pub type Result<T, E = Error> = std::result::Result<T, E>;
 #[derive(Debug)]
 pub struct IngesterData {
     /// Object store for persistence of parquet files
-    pub(crate) object_store: Arc<ObjectStore>,
+    pub(crate) object_store: Arc<ObjectStoreImpl>,
     /// The global catalog for schema, parquet files and tombstones
     pub(crate) catalog: Arc<dyn Catalog>,
     /// This map gets set up on initialization of the ingester so it won't ever be modified.
@@ -1420,7 +1420,7 @@ mod tests {
         let mut sequencers = BTreeMap::new();
         sequencers.insert(sequencer1.id, SequencerData::default());
 
-        let object_store = Arc::new(ObjectStore::new_in_memory());
+        let object_store = Arc::new(ObjectStoreImpl::new_in_memory());
 
         let data = Arc::new(IngesterData {
             object_store: Arc::clone(&object_store),
@@ -1501,7 +1501,7 @@ mod tests {
         sequencers.insert(sequencer1.id, SequencerData::default());
         sequencers.insert(sequencer2.id, SequencerData::default());
 
-        let object_store = Arc::new(ObjectStore::new_in_memory());
+        let object_store = Arc::new(ObjectStoreImpl::new_in_memory());
 
         let data = Arc::new(IngesterData {
             object_store: Arc::clone(&object_store),

--- a/ingester/src/data.rs
+++ b/ingester/src/data.rs
@@ -16,7 +16,7 @@ use datafusion::physical_plan::SendableRecordBatchStream;
 use dml::DmlOperation;
 use iox_catalog::interface::Catalog;
 use mutable_batch::{column::ColumnData, MutableBatch};
-use object_store::ObjectStoreImpl;
+use object_store::DynObjectStore;
 use observability_deps::tracing::warn;
 use parking_lot::RwLock;
 use predicate::Predicate;
@@ -91,7 +91,7 @@ pub type Result<T, E = Error> = std::result::Result<T, E>;
 #[derive(Debug)]
 pub struct IngesterData {
     /// Object store for persistence of parquet files
-    pub(crate) object_store: Arc<ObjectStoreImpl>,
+    pub(crate) object_store: Arc<DynObjectStore>,
     /// The global catalog for schema, parquet files and tombstones
     pub(crate) catalog: Arc<dyn Catalog>,
     /// This map gets set up on initialization of the ingester so it won't ever be modified.
@@ -1252,7 +1252,7 @@ mod tests {
     use futures::TryStreamExt;
     use iox_catalog::{mem::MemCatalog, validate_or_insert_schema};
     use mutable_batch_lp::{lines_to_batches, test_helpers::lp_to_mutable_batch};
-    use object_store::ObjectStoreApi;
+    use object_store::ObjectStoreImpl;
     use std::{ops::DerefMut, time::Duration};
     use test_helpers::assert_error;
     use time::Time;
@@ -1420,7 +1420,7 @@ mod tests {
         let mut sequencers = BTreeMap::new();
         sequencers.insert(sequencer1.id, SequencerData::default());
 
-        let object_store = Arc::new(ObjectStoreImpl::new_in_memory());
+        let object_store: Arc<DynObjectStore> = Arc::new(ObjectStoreImpl::new_in_memory());
 
         let data = Arc::new(IngesterData {
             object_store: Arc::clone(&object_store),
@@ -1501,7 +1501,7 @@ mod tests {
         sequencers.insert(sequencer1.id, SequencerData::default());
         sequencers.insert(sequencer2.id, SequencerData::default());
 
-        let object_store = Arc::new(ObjectStoreImpl::new_in_memory());
+        let object_store: Arc<DynObjectStore> = Arc::new(ObjectStoreImpl::new_in_memory());
 
         let data = Arc::new(IngesterData {
             object_store: Arc::clone(&object_store),

--- a/ingester/src/handler.rs
+++ b/ingester/src/handler.rs
@@ -17,7 +17,7 @@ use futures::{
     FutureExt, StreamExt, TryFutureExt,
 };
 use iox_catalog::interface::Catalog;
-use object_store::ObjectStoreImpl;
+use object_store::DynObjectStore;
 use observability_deps::tracing::{debug, error, info, warn};
 use query::exec::Executor;
 use snafu::{ResultExt, Snafu};
@@ -114,7 +114,7 @@ impl IngestHandlerImpl {
         topic: KafkaTopic,
         sequencer_states: BTreeMap<KafkaPartition, Sequencer>,
         catalog: Arc<dyn Catalog>,
-        object_store: Arc<ObjectStoreImpl>,
+        object_store: Arc<DynObjectStore>,
         write_buffer: Arc<dyn WriteBufferReading>,
         exec: Arc<Executor>,
         metric_registry: Arc<metric::Registry>,
@@ -416,6 +416,7 @@ mod tests {
     use iox_catalog::{mem::MemCatalog, validate_or_insert_schema};
     use metric::{Attributes, Metric, U64Counter, U64Gauge};
     use mutable_batch_lp::lines_to_batches;
+    use object_store::ObjectStoreImpl;
     use std::{num::NonZeroU32, ops::DerefMut};
     use time::Time;
     use write_buffer::mock::{MockBufferForReading, MockBufferSharedState};

--- a/ingester/src/handler.rs
+++ b/ingester/src/handler.rs
@@ -17,7 +17,7 @@ use futures::{
     FutureExt, StreamExt, TryFutureExt,
 };
 use iox_catalog::interface::Catalog;
-use object_store::ObjectStore;
+use object_store::ObjectStoreImpl;
 use observability_deps::tracing::{debug, error, info, warn};
 use query::exec::Executor;
 use snafu::{ResultExt, Snafu};
@@ -114,7 +114,7 @@ impl IngestHandlerImpl {
         topic: KafkaTopic,
         sequencer_states: BTreeMap<KafkaPartition, Sequencer>,
         catalog: Arc<dyn Catalog>,
-        object_store: Arc<ObjectStore>,
+        object_store: Arc<ObjectStoreImpl>,
         write_buffer: Arc<dyn WriteBufferReading>,
         exec: Arc<Executor>,
         metric_registry: Arc<metric::Registry>,
@@ -713,7 +713,7 @@ mod tests {
 
         let reading: Arc<dyn WriteBufferReading> =
             Arc::new(MockBufferForReading::new(write_buffer_state.clone(), None).unwrap());
-        let object_store = Arc::new(ObjectStore::new_in_memory());
+        let object_store = Arc::new(ObjectStoreImpl::new_in_memory());
 
         let lifecycle_config = LifecycleConfig::new(
             1000000,
@@ -813,7 +813,7 @@ mod tests {
                 MockBufferSharedState::empty_with_n_sequencers(NonZeroU32::try_from(1).unwrap());
             let reading: Arc<dyn WriteBufferReading> =
                 Arc::new(MockBufferForReading::new(write_buffer_state.clone(), None).unwrap());
-            let object_store = Arc::new(ObjectStore::new_in_memory());
+            let object_store = Arc::new(ObjectStoreImpl::new_in_memory());
 
             let lifecycle_config = LifecycleConfig::new(
                 1000000,

--- a/ingester/src/persist.rs
+++ b/ingester/src/persist.rs
@@ -3,7 +3,7 @@
 use arrow::record_batch::RecordBatch;
 use bytes::Bytes;
 use iox_object_store::ParquetFilePath;
-use object_store::ObjectStore;
+use object_store::ObjectStoreImpl;
 use parquet_file::metadata::{IoxMetadata, IoxParquetMetaData};
 use snafu::{ResultExt, Snafu};
 use std::sync::Arc;
@@ -29,7 +29,7 @@ pub type Result<T, E = Error> = std::result::Result<T, E>;
 pub async fn persist(
     metadata: &IoxMetadata,
     record_batches: Vec<RecordBatch>,
-    object_store: &Arc<ObjectStore>,
+    object_store: &Arc<ObjectStoreImpl>,
 ) -> Result<Option<(usize, IoxParquetMetaData)>> {
     if record_batches.is_empty() {
         return Ok(None);
@@ -98,11 +98,11 @@ mod tests {
         Time::from_timestamp(0, 0)
     }
 
-    fn object_store() -> Arc<ObjectStore> {
-        Arc::new(ObjectStore::new_in_memory())
+    fn object_store() -> Arc<ObjectStoreImpl> {
+        Arc::new(ObjectStoreImpl::new_in_memory())
     }
 
-    async fn list_all(object_store: &ObjectStore) -> Result<Vec<Path>, object_store::Error> {
+    async fn list_all(object_store: &ObjectStoreImpl) -> Result<Vec<Path>, object_store::Error> {
         object_store
             .list(None)
             .await?

--- a/ingester/src/test_util.rs
+++ b/ingester/src/test_util.rs
@@ -607,7 +607,7 @@ pub fn make_ingester_data(two_partitions: bool, loc: DataLocation) -> IngesterDa
     // Whatever data because they won't be used in the tests
     let metrics: Arc<metric::Registry> = Default::default();
     let catalog: Arc<dyn Catalog> = Arc::new(MemCatalog::new(metrics));
-    let object_store = Arc::new(object_store::ObjectStore::new_in_memory());
+    let object_store = Arc::new(object_store::ObjectStoreImpl::new_in_memory());
     let exec = Arc::new(query::exec::Executor::new(1));
 
     // Make data for one sequencer/shard and two tables
@@ -660,7 +660,7 @@ pub async fn make_ingester_data_with_tombstones(loc: DataLocation) -> IngesterDa
     // Whatever data because they won't be used in the tests
     let metrics: Arc<metric::Registry> = Default::default();
     let catalog: Arc<dyn Catalog> = Arc::new(MemCatalog::new(metrics));
-    let object_store = Arc::new(object_store::ObjectStore::new_in_memory());
+    let object_store = Arc::new(object_store::ObjectStoreImpl::new_in_memory());
     let exec = Arc::new(query::exec::Executor::new(1));
 
     // Make data for one sequencer/shard and two tables

--- a/iox_object_store/src/lib.rs
+++ b/iox_object_store/src/lib.rs
@@ -17,10 +17,10 @@
 use bytes::Bytes;
 use data_types::server_id::ServerId;
 use futures::{stream::BoxStream, StreamExt, TryStreamExt};
-use object_store::{path::Path, GetResult, ObjectStoreImpl, ObjectStoreApi, Result};
+use object_store::{path::Path, DynObjectStore, GetResult, Result};
 use observability_deps::tracing::warn;
 use snafu::{ensure, ResultExt, Snafu};
-use std::sync::Arc;
+use std::{ops::Deref, sync::Arc};
 use tokio::sync::mpsc::channel;
 use tokio_stream::wrappers::ReceiverStream;
 use uuid::Uuid;
@@ -50,7 +50,7 @@ pub enum IoxObjectStoreError {
 /// This wrapper on top of an `ObjectStore` maps IOx specific concepts to ObjectStore locations
 #[derive(Debug)]
 pub struct IoxObjectStore {
-    inner: Arc<ObjectStoreImpl>,
+    inner: Arc<DynObjectStore>,
     root_path: RootPath,
     data_path: DataPath,
     transactions_path: TransactionsPath,
@@ -63,7 +63,10 @@ impl IoxObjectStore {
     /// TEMPORARY: Server config used to be at the top level instead of beneath `/nodes/`. Until
     /// all deployments have transitioned, check both locations before reporting that the server
     /// config is not found.
-    pub async fn get_server_config_file(inner: &ObjectStoreImpl, server_id: ServerId) -> Result<Bytes> {
+    pub async fn get_server_config_file(
+        inner: &DynObjectStore,
+        server_id: ServerId,
+    ) -> Result<Bytes> {
         let path = paths::server_config_path(inner, server_id);
         let result = match inner.get(&path).await {
             Err(object_store::Error::NotFound { .. }) => {
@@ -83,7 +86,7 @@ impl IoxObjectStore {
     /// Store the data for the server config with the names and locations of the databases
     /// that this server owns.
     pub async fn put_server_config_file(
-        inner: &ObjectStoreImpl,
+        inner: &DynObjectStore,
         server_id: ServerId,
         bytes: Bytes,
     ) -> Result<()> {
@@ -93,13 +96,13 @@ impl IoxObjectStore {
 
     /// Return the path to the server config file to be used in database ownership information to
     /// identify the current server that a database thinks is its owner.
-    pub fn server_config_path(inner: &ObjectStoreImpl, server_id: ServerId) -> Path {
+    pub fn server_config_path(inner: &DynObjectStore, server_id: ServerId) -> Path {
         paths::server_config_path(inner, server_id)
     }
 
     /// Returns what the root path would be for a given database. Does not check existence or
     /// validity of the path in object storage.
-    pub fn root_path_for(inner: &ObjectStoreImpl, uuid: Uuid) -> RootPath {
+    pub fn root_path_for(inner: &DynObjectStore, uuid: Uuid) -> RootPath {
         RootPath::new(inner, uuid)
     }
 
@@ -109,8 +112,11 @@ impl IoxObjectStore {
     ///
     /// Caller *MUST* ensure there is at most 1 concurrent call of this function with the same
     /// parameters; this function does *NOT* do any locking.
-    pub async fn create(inner: Arc<ObjectStoreImpl>, uuid: Uuid) -> Result<Self, IoxObjectStoreError> {
-        let root_path = Self::root_path_for(&inner, uuid);
+    pub async fn create(
+        inner: Arc<DynObjectStore>,
+        uuid: Uuid,
+    ) -> Result<Self, IoxObjectStoreError> {
+        let root_path = Self::root_path_for(&*inner, uuid);
 
         let list_result = inner
             .list_with_delimiter(&root_path.inner)
@@ -126,8 +132,8 @@ impl IoxObjectStore {
     }
 
     /// Look in object storage for an existing, active database with this UUID.
-    pub async fn load(inner: Arc<ObjectStoreImpl>, uuid: Uuid) -> Result<Self, IoxObjectStoreError> {
-        let root_path = Self::root_path_for(&inner, uuid);
+    pub async fn load(inner: Arc<DynObjectStore>, uuid: Uuid) -> Result<Self, IoxObjectStoreError> {
+        let root_path = Self::root_path_for(&*inner, uuid);
 
         Self::find(inner, root_path).await
     }
@@ -135,16 +141,16 @@ impl IoxObjectStore {
     /// Look in object storage for an existing database with this name and the given root path
     /// that was retrieved from a server config
     pub async fn load_at_root_path(
-        inner: Arc<ObjectStoreImpl>,
+        inner: Arc<DynObjectStore>,
         root_path_str: &str,
     ) -> Result<Self, IoxObjectStoreError> {
-        let root_path = RootPath::from_str(&inner, root_path_str);
+        let root_path = RootPath::from_str(&*inner, root_path_str);
 
         Self::find(inner, root_path).await
     }
 
     async fn find(
-        inner: Arc<ObjectStoreImpl>,
+        inner: Arc<DynObjectStore>,
         root_path: RootPath,
     ) -> Result<Self, IoxObjectStoreError> {
         let list_result = inner
@@ -165,7 +171,7 @@ impl IoxObjectStore {
 
     /// Access the database-specific object storage files for an existing database that has
     /// already been located and verified to be active. Does not check object storage.
-    pub fn existing(inner: Arc<ObjectStoreImpl>, root_path: RootPath) -> Self {
+    pub fn existing(inner: Arc<DynObjectStore>, root_path: RootPath) -> Self {
         let data_path = root_path.data_path();
         let transactions_path = root_path.transactions_path();
 
@@ -317,6 +323,7 @@ impl IoxObjectStore {
     fn full_parquet_path(&self, location: &ParquetFilePath) -> Path {
         if location.is_new_gen() {
             self.inner
+                .deref()
                 .path_from_dirs_and_filename(location.absolute_dirs_and_file_name())
         } else {
             self.data_path.join(location)
@@ -342,8 +349,8 @@ impl IoxObjectStore {
     /// when restoring a database given a UUID to check existence of the specified database and
     /// get information such as the database name from the rules before proceeding with restoring
     /// and initializing the database.
-    pub async fn load_database_rules(inner: Arc<ObjectStoreImpl>, uuid: Uuid) -> Result<Bytes> {
-        let root_path = Self::root_path_for(&inner, uuid);
+    pub async fn load_database_rules(inner: Arc<DynObjectStore>, uuid: Uuid) -> Result<Bytes> {
+        let root_path = Self::root_path_for(&*inner, uuid);
         let db_rules_path = root_path.rules_path().inner;
 
         Ok(inner.get(&db_rules_path).await?.bytes().await?.into())
@@ -396,16 +403,16 @@ mod tests {
     use crate::paths::ALL_DATABASES_DIRECTORY;
     use data_types::chunk_metadata::{ChunkAddr, ChunkId};
     use data_types2::{NamespaceId, PartitionId, SequencerId, TableId};
-    use object_store::{parsed_path, path::ObjectStorePath, ObjectStoreImpl, ObjectStoreApi};
+    use object_store::{parsed_path, path::ObjectStorePath, ObjectStoreImpl};
     use test_helpers::assert_error;
     use uuid::Uuid;
 
     /// Creates a new in-memory object store
-    fn make_object_store() -> Arc<ObjectStoreImpl> {
+    fn make_object_store() -> Arc<DynObjectStore> {
         Arc::new(ObjectStoreImpl::new_in_memory())
     }
 
-    async fn add_file(object_store: &ObjectStoreImpl, location: &Path) {
+    async fn add_file(object_store: &DynObjectStore, location: &Path) {
         let data = Bytes::from("arbitrary data");
 
         object_store.put(location, data).await.unwrap();
@@ -448,11 +455,11 @@ mod tests {
 
         // Put a non-database file in
         let path = object_store.path_from_dirs_and_filename(parsed_path!(["foo"]));
-        add_file(&object_store, &path).await;
+        add_file(&*object_store, &path).await;
 
         // Put a file for some other server in
         let path = object_store.path_from_dirs_and_filename(parsed_path!(["12345"]));
-        add_file(&object_store, &path).await;
+        add_file(&*object_store, &path).await;
 
         // Put a file for some other database in
         let other_db_uuid = Uuid::new_v4().to_string();
@@ -460,23 +467,23 @@ mod tests {
             ALL_DATABASES_DIRECTORY,
             other_db_uuid.as_str()
         ]));
-        add_file(&object_store, &path).await;
+        add_file(&*object_store, &path).await;
 
         // Put a file in the database dir but not the data dir
         let path = object_store.path_from_dirs_and_filename(parsed_path!(
             [ALL_DATABASES_DIRECTORY, uuid_str],
             good_filename_str
         ));
-        add_file(&object_store, &path).await;
+        add_file(&*object_store, &path).await;
 
         // Put files in the data dir whose names are in the wrong format
         let mut path = object_store.path_from_dirs_and_filename(parsed_path!(
             [ALL_DATABASES_DIRECTORY, uuid_str, "data"],
             "111.parquet"
         ));
-        add_file(&object_store, &path).await;
+        add_file(&*object_store, &path).await;
         path.set_file_name(&format!("111.{}.xls", parquet_uuid));
-        add_file(&object_store, &path).await;
+        add_file(&*object_store, &path).await;
 
         // Parquet files should be empty
         let pf = parquet_files(&iox_object_store).await;
@@ -539,11 +546,11 @@ mod tests {
 
         // Put a non-database file in
         let path = object_store.path_from_dirs_and_filename(parsed_path!(["foo"]));
-        add_file(&object_store, &path).await;
+        add_file(&*object_store, &path).await;
 
         // Put a file in a directory other than the databases directory
         let path = object_store.path_from_dirs_and_filename(parsed_path!(["12345"]));
-        add_file(&object_store, &path).await;
+        add_file(&*object_store, &path).await;
 
         // Put a file for some other database in
         let other_db_uuid = Uuid::new_v4().to_string();
@@ -551,23 +558,23 @@ mod tests {
             ALL_DATABASES_DIRECTORY,
             other_db_uuid.as_str()
         ]));
-        add_file(&object_store, &path).await;
+        add_file(&*object_store, &path).await;
 
         // Put a file in the database dir but not the transactions dir
         let path = object_store.path_from_dirs_and_filename(parsed_path!(
             [ALL_DATABASES_DIRECTORY, uuid_str],
             good_txn_filename_str
         ));
-        add_file(&object_store, &path).await;
+        add_file(&*object_store, &path).await;
 
         // Put files in the transactions dir whose names are in the wrong format
         let mut path = object_store.path_from_dirs_and_filename(parsed_path!(
             [ALL_DATABASES_DIRECTORY, uuid_str],
             "111.parquet"
         ));
-        add_file(&object_store, &path).await;
+        add_file(&*object_store, &path).await;
         path.set_file_name(&format!("{}.xls", txn_uuid));
-        add_file(&object_store, &path).await;
+        add_file(&*object_store, &path).await;
 
         // Catalog transaction files should be empty
         let ctf = catalog_transaction_files(&iox_object_store).await;
@@ -587,7 +594,7 @@ mod tests {
         assert!(ctf.contains(&t2));
     }
 
-    fn make_db_rules_path(object_store: &ObjectStoreImpl, uuid: Uuid) -> Path {
+    fn make_db_rules_path(object_store: &DynObjectStore, uuid: Uuid) -> Path {
         let mut p = object_store.new_path();
         p.push_all_dirs(&[ALL_DATABASES_DIRECTORY, uuid.to_string().as_str()]);
         p.set_file_name("rules.pb");
@@ -598,7 +605,7 @@ mod tests {
     async fn db_rules_should_be_a_file() {
         let object_store = make_object_store();
         let uuid = Uuid::new_v4();
-        let rules_path = make_db_rules_path(&object_store, uuid);
+        let rules_path = make_db_rules_path(&*object_store, uuid);
         let iox_object_store = IoxObjectStore::create(Arc::clone(&object_store), uuid)
             .await
             .unwrap();
@@ -647,7 +654,7 @@ mod tests {
         assert_eq!(file_count, 0);
     }
 
-    fn make_owner_path(object_store: &ObjectStoreImpl, uuid: Uuid) -> Path {
+    fn make_owner_path(object_store: &DynObjectStore, uuid: Uuid) -> Path {
         let mut p = object_store.new_path();
         p.push_all_dirs(&[ALL_DATABASES_DIRECTORY, uuid.to_string().as_str()]);
         p.set_file_name("owner.pb");
@@ -658,7 +665,7 @@ mod tests {
     async fn owner_should_be_a_file() {
         let object_store = make_object_store();
         let uuid = Uuid::new_v4();
-        let owner_path = make_owner_path(&object_store, uuid);
+        let owner_path = make_owner_path(&*object_store, uuid);
         let iox_object_store = IoxObjectStore::create(Arc::clone(&object_store), uuid)
             .await
             .unwrap();
@@ -733,7 +740,7 @@ mod tests {
         );
     }
 
-    async fn create_database(object_store: Arc<ObjectStoreImpl>, uuid: Uuid) -> IoxObjectStore {
+    async fn create_database(object_store: Arc<DynObjectStore>, uuid: Uuid) -> IoxObjectStore {
         let iox_object_store = IoxObjectStore::create(Arc::clone(&object_store), uuid)
             .await
             .unwrap();
@@ -806,7 +813,7 @@ mod tests {
 
         // This should also equal root_path_for, which can be constructed even if a database
         // hasn't been fully initialized yet
-        let alternate = IoxObjectStore::root_path_for(&object_store, uuid).to_string();
+        let alternate = IoxObjectStore::root_path_for(&*object_store, uuid).to_string();
         assert_eq!(alternate, saved_root_path);
     }
 
@@ -815,7 +822,7 @@ mod tests {
         let object_store = make_object_store();
         let iox_object_store = Arc::new(IoxObjectStore::existing(
             Arc::clone(&object_store),
-            IoxObjectStore::root_path_for(&object_store, uuid::Uuid::new_v4()),
+            IoxObjectStore::root_path_for(&*object_store, uuid::Uuid::new_v4()),
         ));
 
         let pfp = ParquetFilePath::new_new_gen(

--- a/iox_object_store/src/paths.rs
+++ b/iox_object_store/src/paths.rs
@@ -3,7 +3,7 @@
 use data_types::server_id::ServerId;
 use object_store::{
     path::{ObjectStorePath, Path},
-    ObjectStoreImpl, ObjectStoreApi,
+    DynObjectStore,
 };
 use std::fmt;
 use uuid::Uuid;
@@ -21,7 +21,7 @@ const DATABASE_OWNER_FILE_NAME: &str = "owner.pb";
 
 /// The path to the server file containing the list of databases this server owns.
 // TODO: this is in the process of replacing all_databases_path for the floating databases design
-pub(crate) fn server_config_path(object_store: &ObjectStoreImpl, server_id: ServerId) -> Path {
+pub(crate) fn server_config_path(object_store: &DynObjectStore, server_id: ServerId) -> Path {
     let mut path = object_store.new_path();
     path.push_dir(ALL_SERVERS_DIRECTORY);
     path.push_dir(server_id.to_string());
@@ -39,14 +39,14 @@ pub struct RootPath {
 
 impl RootPath {
     /// How the root of a database is defined in object storage.
-    pub(crate) fn new(object_store: &ObjectStoreImpl, uuid: Uuid) -> Self {
+    pub(crate) fn new(object_store: &DynObjectStore, uuid: Uuid) -> Self {
         let mut inner = object_store.new_path();
         inner.push_dir(ALL_DATABASES_DIRECTORY);
         inner.push_dir(uuid.to_string());
         Self { inner }
     }
 
-    pub(crate) fn from_str(object_store: &ObjectStoreImpl, raw: &str) -> Self {
+    pub(crate) fn from_str(object_store: &DynObjectStore, raw: &str) -> Self {
         Self {
             inner: object_store.path_from_raw(raw),
         }
@@ -178,7 +178,7 @@ mod tests {
 
     /// Creates a new in-memory object store. These tests rely on the `Path`s being of type
     /// `DirsAndFileName` and thus using object_store::path::DELIMITER as the separator
-    fn make_object_store() -> Arc<ObjectStoreImpl> {
+    fn make_object_store() -> Arc<DynObjectStore> {
         Arc::new(ObjectStoreImpl::new_in_memory())
     }
 
@@ -186,7 +186,7 @@ mod tests {
     fn root_path_contains_dbs_and_db_uuid() {
         let object_store = make_object_store();
         let uuid = Uuid::new_v4();
-        let root_path = RootPath::new(&object_store, uuid);
+        let root_path = RootPath::new(&*object_store, uuid);
 
         assert_eq!(
             root_path.inner.to_string(),
@@ -198,7 +198,7 @@ mod tests {
     fn root_path_join_concatenates() {
         let object_store = make_object_store();
         let uuid = Uuid::new_v4();
-        let root_path = RootPath::new(&object_store, uuid);
+        let root_path = RootPath::new(&*object_store, uuid);
 
         let path = root_path.join("foo");
         assert_eq!(
@@ -211,7 +211,7 @@ mod tests {
     fn transactions_path_is_relative_to_root_path() {
         let object_store = make_object_store();
         let uuid = Uuid::new_v4();
-        let root_path = RootPath::new(&object_store, uuid);
+        let root_path = RootPath::new(&*object_store, uuid);
         let iox_object_store = IoxObjectStore::existing(Arc::clone(&object_store), root_path);
         assert_eq!(
             iox_object_store.transactions_path.inner.to_string(),
@@ -223,7 +223,7 @@ mod tests {
     fn data_path_is_relative_to_root_path() {
         let object_store = make_object_store();
         let uuid = Uuid::new_v4();
-        let root_path = RootPath::new(&object_store, uuid);
+        let root_path = RootPath::new(&*object_store, uuid);
         let iox_object_store = IoxObjectStore::existing(Arc::clone(&object_store), root_path);
         assert_eq!(
             iox_object_store.data_path.inner.to_string(),

--- a/iox_object_store/src/paths.rs
+++ b/iox_object_store/src/paths.rs
@@ -3,7 +3,7 @@
 use data_types::server_id::ServerId;
 use object_store::{
     path::{ObjectStorePath, Path},
-    ObjectStore, ObjectStoreApi,
+    ObjectStoreImpl, ObjectStoreApi,
 };
 use std::fmt;
 use uuid::Uuid;
@@ -21,7 +21,7 @@ const DATABASE_OWNER_FILE_NAME: &str = "owner.pb";
 
 /// The path to the server file containing the list of databases this server owns.
 // TODO: this is in the process of replacing all_databases_path for the floating databases design
-pub(crate) fn server_config_path(object_store: &ObjectStore, server_id: ServerId) -> Path {
+pub(crate) fn server_config_path(object_store: &ObjectStoreImpl, server_id: ServerId) -> Path {
     let mut path = object_store.new_path();
     path.push_dir(ALL_SERVERS_DIRECTORY);
     path.push_dir(server_id.to_string());
@@ -39,14 +39,14 @@ pub struct RootPath {
 
 impl RootPath {
     /// How the root of a database is defined in object storage.
-    pub(crate) fn new(object_store: &ObjectStore, uuid: Uuid) -> Self {
+    pub(crate) fn new(object_store: &ObjectStoreImpl, uuid: Uuid) -> Self {
         let mut inner = object_store.new_path();
         inner.push_dir(ALL_DATABASES_DIRECTORY);
         inner.push_dir(uuid.to_string());
         Self { inner }
     }
 
-    pub(crate) fn from_str(object_store: &ObjectStore, raw: &str) -> Self {
+    pub(crate) fn from_str(object_store: &ObjectStoreImpl, raw: &str) -> Self {
         Self {
             inner: object_store.path_from_raw(raw),
         }
@@ -173,13 +173,13 @@ impl DataPath {
 mod tests {
     use super::*;
     use crate::IoxObjectStore;
-    use object_store::ObjectStore;
+    use object_store::ObjectStoreImpl;
     use std::sync::Arc;
 
     /// Creates a new in-memory object store. These tests rely on the `Path`s being of type
     /// `DirsAndFileName` and thus using object_store::path::DELIMITER as the separator
-    fn make_object_store() -> Arc<ObjectStore> {
-        Arc::new(ObjectStore::new_in_memory())
+    fn make_object_store() -> Arc<ObjectStoreImpl> {
+        Arc::new(ObjectStoreImpl::new_in_memory())
     }
 
     #[test]

--- a/iox_object_store/src/paths/parquet_file.rs
+++ b/iox_object_store/src/paths/parquet_file.rs
@@ -216,13 +216,13 @@ pub enum ParquetFilePathParseError {
 mod tests {
     use super::*;
     use crate::{paths::ALL_DATABASES_DIRECTORY, IoxObjectStore, RootPath};
-    use object_store::{ObjectStore, ObjectStoreApi};
+    use object_store::{ObjectStoreApi, ObjectStoreImpl};
     use test_helpers::assert_error;
 
     /// Creates a new in-memory object store. These tests rely on the `Path`s being of type
     /// `DirsAndFileName` and thus using object_store::path::DELIMITER as the separator
-    fn make_object_store() -> Arc<ObjectStore> {
-        Arc::new(ObjectStore::new_in_memory())
+    fn make_object_store() -> Arc<ObjectStoreImpl> {
+        Arc::new(ObjectStoreImpl::new_in_memory())
     }
 
     #[test]

--- a/iox_object_store/src/paths/parquet_file.rs
+++ b/iox_object_store/src/paths/parquet_file.rs
@@ -216,12 +216,12 @@ pub enum ParquetFilePathParseError {
 mod tests {
     use super::*;
     use crate::{paths::ALL_DATABASES_DIRECTORY, IoxObjectStore, RootPath};
-    use object_store::{ObjectStoreApi, ObjectStoreImpl};
+    use object_store::{DynObjectStore, ObjectStoreImpl};
     use test_helpers::assert_error;
 
     /// Creates a new in-memory object store. These tests rely on the `Path`s being of type
     /// `DirsAndFileName` and thus using object_store::path::DELIMITER as the separator
-    fn make_object_store() -> Arc<ObjectStoreImpl> {
+    fn make_object_store() -> Arc<DynObjectStore> {
         Arc::new(ObjectStoreImpl::new_in_memory())
     }
 
@@ -417,7 +417,7 @@ mod tests {
     fn data_path_join_with_parquet_file_path() {
         let db_uuid = Uuid::new_v4();
         let object_store = make_object_store();
-        let root_path = RootPath::new(&object_store, db_uuid);
+        let root_path = RootPath::new(&*object_store, db_uuid);
         let iox_object_store = IoxObjectStore::existing(Arc::clone(&object_store), root_path);
 
         let pfp = ParquetFilePath(Variant::Old {

--- a/iox_object_store/src/paths/transaction_file.rs
+++ b/iox_object_store/src/paths/transaction_file.rs
@@ -196,13 +196,13 @@ impl FromStr for TransactionFileSuffix {
 mod tests {
     use super::*;
     use crate::{paths::ALL_DATABASES_DIRECTORY, IoxObjectStore, RootPath};
-    use object_store::{ObjectStoreImpl, ObjectStoreApi};
+    use object_store::{DynObjectStore, ObjectStoreImpl};
     use std::sync::Arc;
     use test_helpers::assert_error;
 
     /// Creates a new in-memory object store. These tests rely on the `Path`s being of type
     /// `DirsAndFileName` and thus using object_store::path::DELIMITER as the separator
-    fn make_object_store() -> Arc<ObjectStoreImpl> {
+    fn make_object_store() -> Arc<DynObjectStore> {
         Arc::new(ObjectStoreImpl::new_in_memory())
     }
 
@@ -358,7 +358,7 @@ mod tests {
     fn transactions_path_join_with_parquet_file_path() {
         let db_uuid = Uuid::new_v4();
         let object_store = make_object_store();
-        let root_path = RootPath::new(&object_store, db_uuid);
+        let root_path = RootPath::new(&*object_store, db_uuid);
         let iox_object_store = IoxObjectStore::existing(Arc::clone(&object_store), root_path);
 
         let uuid = Uuid::new_v4();

--- a/iox_object_store/src/paths/transaction_file.rs
+++ b/iox_object_store/src/paths/transaction_file.rs
@@ -196,14 +196,14 @@ impl FromStr for TransactionFileSuffix {
 mod tests {
     use super::*;
     use crate::{paths::ALL_DATABASES_DIRECTORY, IoxObjectStore, RootPath};
-    use object_store::{ObjectStore, ObjectStoreApi};
+    use object_store::{ObjectStoreImpl, ObjectStoreApi};
     use std::sync::Arc;
     use test_helpers::assert_error;
 
     /// Creates a new in-memory object store. These tests rely on the `Path`s being of type
     /// `DirsAndFileName` and thus using object_store::path::DELIMITER as the separator
-    fn make_object_store() -> Arc<ObjectStore> {
-        Arc::new(ObjectStore::new_in_memory())
+    fn make_object_store() -> Arc<ObjectStoreImpl> {
+        Arc::new(ObjectStoreImpl::new_in_memory())
     }
 
     #[test]

--- a/iox_tests/src/util.rs
+++ b/iox_tests/src/util.rs
@@ -10,7 +10,7 @@ use data_types2::{
 use iox_catalog::{interface::Catalog, mem::MemCatalog};
 use iox_object_store::{IoxObjectStore, ParquetFilePath};
 use mutable_batch_lp::test_helpers::lp_to_mutable_batch;
-use object_store::ObjectStore;
+use object_store::ObjectStoreImpl;
 use parquet_file::metadata::{IoxMetadata, IoxParquetMetaData};
 use query::exec::Executor;
 use schema::selection::Selection;
@@ -23,7 +23,7 @@ use uuid::Uuid;
 pub struct TestCatalog {
     pub catalog: Arc<dyn Catalog>,
     pub metric_registry: Arc<metric::Registry>,
-    pub object_store: Arc<ObjectStore>,
+    pub object_store: Arc<ObjectStoreImpl>,
     pub time_provider: Arc<MockProvider>,
     pub exec: Arc<Executor>,
 }
@@ -33,7 +33,7 @@ impl TestCatalog {
     pub fn new() -> Arc<Self> {
         let metric_registry = Arc::new(metric::Registry::new());
         let catalog: Arc<dyn Catalog> = Arc::new(MemCatalog::new(Arc::clone(&metric_registry)));
-        let object_store = Arc::new(ObjectStore::new_in_memory());
+        let object_store = Arc::new(ObjectStoreImpl::new_in_memory());
         let time_provider = Arc::new(MockProvider::new(Time::from_timestamp(0, 0)));
         let exec = Arc::new(Executor::new(1));
 
@@ -57,7 +57,7 @@ impl TestCatalog {
     }
 
     /// Return the catalog's  object store
-    pub fn object_store(&self) -> Arc<ObjectStore> {
+    pub fn object_store(&self) -> Arc<ObjectStoreImpl> {
         Arc::clone(&self.object_store)
     }
 
@@ -353,7 +353,7 @@ impl TestPartition {
 
 /// Create parquet file and return thrift-encoded and zstd-compressed parquet metadata as well as the file size.
 async fn create_parquet_file(
-    object_store: &Arc<ObjectStore>,
+    object_store: &Arc<ObjectStoreImpl>,
     metadata: &IoxMetadata,
     record_batch: RecordBatch,
 ) -> (Vec<u8>, usize) {

--- a/iox_tests/src/util.rs
+++ b/iox_tests/src/util.rs
@@ -10,7 +10,7 @@ use data_types2::{
 use iox_catalog::{interface::Catalog, mem::MemCatalog};
 use iox_object_store::{IoxObjectStore, ParquetFilePath};
 use mutable_batch_lp::test_helpers::lp_to_mutable_batch;
-use object_store::ObjectStoreImpl;
+use object_store::{DynObjectStore, ObjectStoreImpl};
 use parquet_file::metadata::{IoxMetadata, IoxParquetMetaData};
 use query::exec::Executor;
 use schema::selection::Selection;
@@ -23,7 +23,7 @@ use uuid::Uuid;
 pub struct TestCatalog {
     pub catalog: Arc<dyn Catalog>,
     pub metric_registry: Arc<metric::Registry>,
-    pub object_store: Arc<ObjectStoreImpl>,
+    pub object_store: Arc<DynObjectStore>,
     pub time_provider: Arc<MockProvider>,
     pub exec: Arc<Executor>,
 }
@@ -57,7 +57,7 @@ impl TestCatalog {
     }
 
     /// Return the catalog's  object store
-    pub fn object_store(&self) -> Arc<ObjectStoreImpl> {
+    pub fn object_store(&self) -> Arc<DynObjectStore> {
         Arc::clone(&self.object_store)
     }
 
@@ -353,13 +353,13 @@ impl TestPartition {
 
 /// Create parquet file and return thrift-encoded and zstd-compressed parquet metadata as well as the file size.
 async fn create_parquet_file(
-    object_store: &Arc<ObjectStoreImpl>,
+    object_store: &Arc<DynObjectStore>,
     metadata: &IoxMetadata,
     record_batch: RecordBatch,
 ) -> (Vec<u8>, usize) {
     let iox_object_store = Arc::new(IoxObjectStore::existing(
         Arc::clone(object_store),
-        IoxObjectStore::root_path_for(object_store, uuid::Uuid::new_v4()),
+        IoxObjectStore::root_path_for(&**object_store, uuid::Uuid::new_v4()),
     ));
 
     let schema = record_batch.schema();

--- a/object_store/src/aws.rs
+++ b/object_store/src/aws.rs
@@ -1,7 +1,7 @@
 //! This module contains the IOx implementation for using S3 as the object
 //! store.
 use crate::{
-    path::{cloud::CloudPath, DELIMITER},
+    path::{cloud::CloudPath, parsed::DirsAndFileName, DELIMITER},
     GetResult, ListResult, ObjectMeta, ObjectStoreApi, ObjectStorePath,
 };
 use async_trait::async_trait;
@@ -174,6 +174,10 @@ impl ObjectStoreApi for AmazonS3 {
 
     fn path_from_raw(&self, raw: &str) -> Self::Path {
         CloudPath::raw(raw)
+    }
+
+    fn path_from_dirs_and_filename(&self, path: DirsAndFileName) -> Self::Path {
+        path.into()
     }
 
     async fn put(&self, location: &Self::Path, bytes: Bytes) -> Result<()> {

--- a/object_store/src/aws.rs
+++ b/object_store/src/aws.rs
@@ -666,7 +666,7 @@ mod tests {
             get_nonexistent_object, list_uses_directories_correctly, list_with_delimiter,
             put_get_delete_list,
         },
-        Error as ObjectStoreError, ObjectStore, ObjectStoreApi, ObjectStorePath,
+        Error as ObjectStoreError, ObjectStoreImpl, ObjectStoreApi, ObjectStorePath,
     };
     use bytes::Bytes;
     use std::env;
@@ -760,7 +760,7 @@ mod tests {
     #[tokio::test]
     async fn s3_test() {
         let config = maybe_skip_integration!();
-        let integration = ObjectStore::new_amazon_s3(
+        let integration = ObjectStoreImpl::new_amazon_s3(
             Some(config.access_key_id),
             Some(config.secret_access_key),
             config.region,
@@ -780,7 +780,7 @@ mod tests {
     #[tokio::test]
     async fn s3_test_get_nonexistent_location() {
         let config = maybe_skip_integration!();
-        let integration = ObjectStore::new_amazon_s3(
+        let integration = ObjectStoreImpl::new_amazon_s3(
             Some(config.access_key_id),
             Some(config.secret_access_key),
             config.region,
@@ -823,7 +823,7 @@ mod tests {
         let mut config = maybe_skip_integration!();
         config.bucket = NON_EXISTENT_NAME.into();
 
-        let integration = ObjectStore::new_amazon_s3(
+        let integration = ObjectStoreImpl::new_amazon_s3(
             Some(config.access_key_id),
             Some(config.secret_access_key),
             config.region,
@@ -860,7 +860,7 @@ mod tests {
         let mut config = maybe_skip_integration!();
         config.bucket = NON_EXISTENT_NAME.into();
 
-        let integration = ObjectStore::new_amazon_s3(
+        let integration = ObjectStoreImpl::new_amazon_s3(
             Some(config.access_key_id),
             Some(config.secret_access_key),
             config.region,
@@ -898,7 +898,7 @@ mod tests {
     #[tokio::test]
     async fn s3_test_delete_nonexistent_location() {
         let config = maybe_skip_integration!();
-        let integration = ObjectStore::new_amazon_s3(
+        let integration = ObjectStoreImpl::new_amazon_s3(
             Some(config.access_key_id),
             Some(config.secret_access_key),
             config.region,
@@ -923,7 +923,7 @@ mod tests {
         let mut config = maybe_skip_integration!();
         config.bucket = NON_EXISTENT_NAME.into();
 
-        let integration = ObjectStore::new_amazon_s3(
+        let integration = ObjectStoreImpl::new_amazon_s3(
             Some(config.access_key_id),
             Some(config.secret_access_key),
             config.region,

--- a/object_store/src/aws.rs
+++ b/object_store/src/aws.rs
@@ -670,7 +670,7 @@ mod tests {
             get_nonexistent_object, list_uses_directories_correctly, list_with_delimiter,
             put_get_delete_list,
         },
-        Error as ObjectStoreError, ObjectStoreImpl, ObjectStoreApi, ObjectStorePath,
+        Error as ObjectStoreError, ObjectStoreApi, ObjectStoreImpl, ObjectStorePath,
     };
     use bytes::Bytes;
     use std::env;

--- a/object_store/src/azure.rs
+++ b/object_store/src/azure.rs
@@ -1,7 +1,7 @@
 //! This module contains the IOx implementation for using Azure Blob storage as
 //! the object store.
 use crate::{
-    path::{cloud::CloudPath, DELIMITER},
+    path::{cloud::CloudPath, parsed::DirsAndFileName, DELIMITER},
     GetResult, ListResult, ObjectMeta, ObjectStoreApi, ObjectStorePath,
 };
 use async_trait::async_trait;
@@ -75,6 +75,10 @@ impl ObjectStoreApi for MicrosoftAzure {
 
     fn path_from_raw(&self, raw: &str) -> Self::Path {
         CloudPath::raw(raw)
+    }
+
+    fn path_from_dirs_and_filename(&self, path: DirsAndFileName) -> Self::Path {
+        path.into()
     }
 
     async fn put(&self, location: &Self::Path, bytes: Bytes) -> Result<()> {

--- a/object_store/src/azure.rs
+++ b/object_store/src/azure.rs
@@ -287,7 +287,7 @@ pub fn new_azure(
 #[cfg(test)]
 mod tests {
     use crate::tests::{list_uses_directories_correctly, list_with_delimiter, put_get_delete_list};
-    use crate::ObjectStore;
+    use crate::ObjectStoreImpl;
     use std::env;
 
     #[derive(Debug)]
@@ -353,7 +353,7 @@ mod tests {
     #[tokio::test]
     async fn azure_blob_test() {
         let config = maybe_skip_integration!();
-        let integration = ObjectStore::new_microsoft_azure(
+        let integration = ObjectStoreImpl::new_microsoft_azure(
             config.storage_account,
             config.access_key,
             config.bucket,

--- a/object_store/src/cache.rs
+++ b/object_store/src/cache.rs
@@ -2,8 +2,7 @@
 //! in the local filesystem. In the case of the disk backed object store implementation,
 //! it yields locations to its files for cache locations and no-ops any cache modifications.
 
-use crate::path::Path;
-use crate::ObjectStoreImpl;
+use crate::{path::Path, DynObjectStore};
 use async_trait::async_trait;
 use snafu::Snafu;
 use std::sync::Arc;
@@ -29,7 +28,7 @@ pub trait Cache {
     /// will get the object from object storage and write it to the local filesystem cache.
     /// If the cache is over its limit, it will evict other cached objects based on an LRU
     /// policy.
-    async fn fs_path_or_cache(&self, path: &Path, store: Arc<ObjectStoreImpl>) -> Result<&str>;
+    async fn fs_path_or_cache(&self, path: &Path, store: Arc<DynObjectStore>) -> Result<&str>;
 
     /// The size in bytes of all files in the cache.
     fn size(&self) -> u64;
@@ -50,7 +49,7 @@ impl Cache for LocalFSCache {
         todo!()
     }
 
-    async fn fs_path_or_cache(&self, _path: &Path, _store: Arc<ObjectStoreImpl>) -> Result<&str> {
+    async fn fs_path_or_cache(&self, _path: &Path, _store: Arc<DynObjectStore>) -> Result<&str> {
         todo!()
     }
 

--- a/object_store/src/cache.rs
+++ b/object_store/src/cache.rs
@@ -3,7 +3,7 @@
 //! it yields locations to its files for cache locations and no-ops any cache modifications.
 
 use crate::path::Path;
-use crate::ObjectStore;
+use crate::ObjectStoreImpl;
 use async_trait::async_trait;
 use snafu::Snafu;
 use std::sync::Arc;
@@ -29,7 +29,7 @@ pub trait Cache {
     /// will get the object from object storage and write it to the local filesystem cache.
     /// If the cache is over its limit, it will evict other cached objects based on an LRU
     /// policy.
-    async fn fs_path_or_cache(&self, path: &Path, store: Arc<ObjectStore>) -> Result<&str>;
+    async fn fs_path_or_cache(&self, path: &Path, store: Arc<ObjectStoreImpl>) -> Result<&str>;
 
     /// The size in bytes of all files in the cache.
     fn size(&self) -> u64;
@@ -50,7 +50,7 @@ impl Cache for LocalFSCache {
         todo!()
     }
 
-    async fn fs_path_or_cache(&self, _path: &Path, _store: Arc<ObjectStore>) -> Result<&str> {
+    async fn fs_path_or_cache(&self, _path: &Path, _store: Arc<ObjectStoreImpl>) -> Result<&str> {
         todo!()
     }
 

--- a/object_store/src/disk.rs
+++ b/object_store/src/disk.rs
@@ -1,10 +1,8 @@
 //! This module contains the IOx implementation for using local disk as the
 //! object store.
-use crate::cache::Cache;
 use crate::path::{parsed::DirsAndFileName, Path};
-use crate::{
-    path::file::FilePath, GetResult, ListResult, ObjectMeta, ObjectStoreApi, ObjectStoreImpl,
-};
+use crate::{cache::Cache, DynObjectStore};
+use crate::{path::file::FilePath, GetResult, ListResult, ObjectMeta, ObjectStoreApi};
 use async_trait::async_trait;
 use bytes::Bytes;
 use futures::{
@@ -278,7 +276,7 @@ impl Cache for File {
     async fn fs_path_or_cache(
         &self,
         _path: &Path,
-        _store: Arc<ObjectStoreImpl>,
+        _store: Arc<DynObjectStore>,
     ) -> crate::cache::Result<&str> {
         todo!()
     }

--- a/object_store/src/disk.rs
+++ b/object_store/src/disk.rs
@@ -1,8 +1,10 @@
 //! This module contains the IOx implementation for using local disk as the
 //! object store.
 use crate::cache::Cache;
-use crate::path::Path;
-use crate::{path::file::FilePath, GetResult, ListResult, ObjectMeta, ObjectStoreImpl, ObjectStoreApi};
+use crate::path::{parsed::DirsAndFileName, Path};
+use crate::{
+    path::file::FilePath, GetResult, ListResult, ObjectMeta, ObjectStoreApi, ObjectStoreImpl,
+};
 use async_trait::async_trait;
 use bytes::Bytes;
 use futures::{
@@ -98,6 +100,10 @@ impl ObjectStoreApi for File {
 
     fn path_from_raw(&self, raw: &str) -> Self::Path {
         FilePath::raw(raw, true)
+    }
+
+    fn path_from_dirs_and_filename(&self, path: DirsAndFileName) -> Self::Path {
+        path.into()
     }
 
     async fn put(&self, location: &Self::Path, bytes: Bytes) -> Result<()> {
@@ -330,7 +336,7 @@ mod tests {
             get_nonexistent_object, list_uses_directories_correctly, list_with_delimiter,
             put_get_delete_list,
         },
-        Error as ObjectStoreError, ObjectStoreImpl, ObjectStoreApi, ObjectStorePath,
+        Error as ObjectStoreError, ObjectStoreApi, ObjectStoreImpl, ObjectStorePath,
     };
     use std::{fs::set_permissions, os::unix::prelude::PermissionsExt};
     use tempfile::TempDir;

--- a/object_store/src/disk.rs
+++ b/object_store/src/disk.rs
@@ -2,7 +2,7 @@
 //! object store.
 use crate::cache::Cache;
 use crate::path::Path;
-use crate::{path::file::FilePath, GetResult, ListResult, ObjectMeta, ObjectStore, ObjectStoreApi};
+use crate::{path::file::FilePath, GetResult, ListResult, ObjectMeta, ObjectStoreImpl, ObjectStoreApi};
 use async_trait::async_trait;
 use bytes::Bytes;
 use futures::{
@@ -272,7 +272,7 @@ impl Cache for File {
     async fn fs_path_or_cache(
         &self,
         _path: &Path,
-        _store: Arc<ObjectStore>,
+        _store: Arc<ObjectStoreImpl>,
     ) -> crate::cache::Result<&str> {
         todo!()
     }
@@ -330,7 +330,7 @@ mod tests {
             get_nonexistent_object, list_uses_directories_correctly, list_with_delimiter,
             put_get_delete_list,
         },
-        Error as ObjectStoreError, ObjectStore, ObjectStoreApi, ObjectStorePath,
+        Error as ObjectStoreError, ObjectStoreImpl, ObjectStoreApi, ObjectStorePath,
     };
     use std::{fs::set_permissions, os::unix::prelude::PermissionsExt};
     use tempfile::TempDir;
@@ -338,7 +338,7 @@ mod tests {
     #[tokio::test]
     async fn file_test() {
         let root = TempDir::new().unwrap();
-        let integration = ObjectStore::new_file(root.path());
+        let integration = ObjectStoreImpl::new_file(root.path());
 
         put_get_delete_list(&integration).await.unwrap();
         list_uses_directories_correctly(&integration).await.unwrap();
@@ -348,7 +348,7 @@ mod tests {
     #[tokio::test]
     async fn creates_dir_if_not_present() {
         let root = TempDir::new().unwrap();
-        let integration = ObjectStore::new_file(root.path());
+        let integration = ObjectStoreImpl::new_file(root.path());
 
         let mut location = integration.new_path();
         location.push_all_dirs(&["nested", "file", "test_file"]);
@@ -371,7 +371,7 @@ mod tests {
     #[tokio::test]
     async fn unknown_length() {
         let root = TempDir::new().unwrap();
-        let integration = ObjectStore::new_file(root.path());
+        let integration = ObjectStoreImpl::new_file(root.path());
 
         let mut location = integration.new_path();
         location.set_file_name("some_file");
@@ -428,7 +428,7 @@ mod tests {
     #[tokio::test]
     async fn get_nonexistent_location() {
         let root = TempDir::new().unwrap();
-        let integration = ObjectStore::new_file(root.path());
+        let integration = ObjectStoreImpl::new_file(root.path());
 
         let mut location = integration.new_path();
         location.set_file_name(NON_EXISTENT_NAME);

--- a/object_store/src/dummy.rs
+++ b/object_store/src/dummy.rs
@@ -6,7 +6,10 @@ use async_trait::async_trait;
 use bytes::Bytes;
 use snafu::Snafu;
 
-use crate::{path::cloud::CloudPath, GetResult, ObjectStoreApi};
+use crate::{
+    path::{cloud::CloudPath, parsed::DirsAndFileName},
+    GetResult, ObjectStoreApi,
+};
 
 /// A specialized `Error` for Azure object store-related errors
 #[derive(Debug, Snafu, Clone)]
@@ -47,6 +50,10 @@ impl ObjectStoreApi for DummyObjectStore {
 
     fn path_from_raw(&self, raw: &str) -> Self::Path {
         CloudPath::raw(raw)
+    }
+
+    fn path_from_dirs_and_filename(&self, path: DirsAndFileName) -> Self::Path {
+        path.into()
     }
 
     async fn put(&self, _location: &Self::Path, _bytes: Bytes) -> crate::Result<(), Self::Error> {

--- a/object_store/src/gcp.rs
+++ b/object_store/src/gcp.rs
@@ -281,7 +281,7 @@ mod test {
             get_nonexistent_object, list_uses_directories_correctly, list_with_delimiter,
             put_get_delete_list,
         },
-        Error as ObjectStoreError, ObjectStore, ObjectStoreApi, ObjectStorePath,
+        Error as ObjectStoreError, ObjectStoreImpl, ObjectStoreApi, ObjectStorePath,
     };
     use bytes::Bytes;
     use std::env;
@@ -342,7 +342,7 @@ mod test {
     async fn gcs_test() {
         let config = maybe_skip_integration!();
         let integration =
-            ObjectStore::new_google_cloud_storage(config.service_account, config.bucket).unwrap();
+            ObjectStoreImpl::new_google_cloud_storage(config.service_account, config.bucket).unwrap();
 
         put_get_delete_list(&integration).await.unwrap();
         list_uses_directories_correctly(&integration).await.unwrap();
@@ -353,7 +353,7 @@ mod test {
     async fn gcs_test_get_nonexistent_location() {
         let config = maybe_skip_integration!();
         let integration =
-            ObjectStore::new_google_cloud_storage(config.service_account, &config.bucket).unwrap();
+            ObjectStoreImpl::new_google_cloud_storage(config.service_account, &config.bucket).unwrap();
 
         let mut location = integration.new_path();
         location.set_file_name(NON_EXISTENT_NAME);
@@ -382,7 +382,7 @@ mod test {
         let mut config = maybe_skip_integration!();
         config.bucket = NON_EXISTENT_NAME.into();
         let integration =
-            ObjectStore::new_google_cloud_storage(config.service_account, &config.bucket).unwrap();
+            ObjectStoreImpl::new_google_cloud_storage(config.service_account, &config.bucket).unwrap();
 
         let mut location = integration.new_path();
         location.set_file_name(NON_EXISTENT_NAME);
@@ -406,7 +406,7 @@ mod test {
     async fn gcs_test_delete_nonexistent_location() {
         let config = maybe_skip_integration!();
         let integration =
-            ObjectStore::new_google_cloud_storage(config.service_account, &config.bucket).unwrap();
+            ObjectStoreImpl::new_google_cloud_storage(config.service_account, &config.bucket).unwrap();
 
         let mut location = integration.new_path();
         location.set_file_name(NON_EXISTENT_NAME);
@@ -435,7 +435,7 @@ mod test {
         let mut config = maybe_skip_integration!();
         config.bucket = NON_EXISTENT_NAME.into();
         let integration =
-            ObjectStore::new_google_cloud_storage(config.service_account, &config.bucket).unwrap();
+            ObjectStoreImpl::new_google_cloud_storage(config.service_account, &config.bucket).unwrap();
 
         let mut location = integration.new_path();
         location.set_file_name(NON_EXISTENT_NAME);
@@ -464,7 +464,7 @@ mod test {
         let mut config = maybe_skip_integration!();
         config.bucket = NON_EXISTENT_NAME.into();
         let integration =
-            ObjectStore::new_google_cloud_storage(config.service_account, &config.bucket).unwrap();
+            ObjectStoreImpl::new_google_cloud_storage(config.service_account, &config.bucket).unwrap();
 
         let mut location = integration.new_path();
         location.set_file_name(NON_EXISTENT_NAME);

--- a/object_store/src/gcp.rs
+++ b/object_store/src/gcp.rs
@@ -285,7 +285,7 @@ mod test {
             get_nonexistent_object, list_uses_directories_correctly, list_with_delimiter,
             put_get_delete_list,
         },
-        Error as ObjectStoreError, ObjectStoreImpl, ObjectStoreApi, ObjectStorePath,
+        Error as ObjectStoreError, ObjectStoreApi, ObjectStoreImpl, ObjectStorePath,
     };
     use bytes::Bytes;
     use std::env;
@@ -346,7 +346,8 @@ mod test {
     async fn gcs_test() {
         let config = maybe_skip_integration!();
         let integration =
-            ObjectStoreImpl::new_google_cloud_storage(config.service_account, config.bucket).unwrap();
+            ObjectStoreImpl::new_google_cloud_storage(config.service_account, config.bucket)
+                .unwrap();
 
         put_get_delete_list(&integration).await.unwrap();
         list_uses_directories_correctly(&integration).await.unwrap();
@@ -357,7 +358,8 @@ mod test {
     async fn gcs_test_get_nonexistent_location() {
         let config = maybe_skip_integration!();
         let integration =
-            ObjectStoreImpl::new_google_cloud_storage(config.service_account, &config.bucket).unwrap();
+            ObjectStoreImpl::new_google_cloud_storage(config.service_account, &config.bucket)
+                .unwrap();
 
         let mut location = integration.new_path();
         location.set_file_name(NON_EXISTENT_NAME);
@@ -386,7 +388,8 @@ mod test {
         let mut config = maybe_skip_integration!();
         config.bucket = NON_EXISTENT_NAME.into();
         let integration =
-            ObjectStoreImpl::new_google_cloud_storage(config.service_account, &config.bucket).unwrap();
+            ObjectStoreImpl::new_google_cloud_storage(config.service_account, &config.bucket)
+                .unwrap();
 
         let mut location = integration.new_path();
         location.set_file_name(NON_EXISTENT_NAME);
@@ -410,7 +413,8 @@ mod test {
     async fn gcs_test_delete_nonexistent_location() {
         let config = maybe_skip_integration!();
         let integration =
-            ObjectStoreImpl::new_google_cloud_storage(config.service_account, &config.bucket).unwrap();
+            ObjectStoreImpl::new_google_cloud_storage(config.service_account, &config.bucket)
+                .unwrap();
 
         let mut location = integration.new_path();
         location.set_file_name(NON_EXISTENT_NAME);
@@ -439,7 +443,8 @@ mod test {
         let mut config = maybe_skip_integration!();
         config.bucket = NON_EXISTENT_NAME.into();
         let integration =
-            ObjectStoreImpl::new_google_cloud_storage(config.service_account, &config.bucket).unwrap();
+            ObjectStoreImpl::new_google_cloud_storage(config.service_account, &config.bucket)
+                .unwrap();
 
         let mut location = integration.new_path();
         location.set_file_name(NON_EXISTENT_NAME);
@@ -468,7 +473,8 @@ mod test {
         let mut config = maybe_skip_integration!();
         config.bucket = NON_EXISTENT_NAME.into();
         let integration =
-            ObjectStoreImpl::new_google_cloud_storage(config.service_account, &config.bucket).unwrap();
+            ObjectStoreImpl::new_google_cloud_storage(config.service_account, &config.bucket)
+                .unwrap();
 
         let mut location = integration.new_path();
         location.set_file_name(NON_EXISTENT_NAME);

--- a/object_store/src/gcp.rs
+++ b/object_store/src/gcp.rs
@@ -1,7 +1,7 @@
 //! This module contains the IOx implementation for using Google Cloud Storage
 //! as the object store.
 use crate::{
-    path::{cloud::CloudPath, DELIMITER},
+    path::{cloud::CloudPath, parsed::DirsAndFileName, DELIMITER},
     GetResult, ListResult, ObjectMeta, ObjectStoreApi, ObjectStorePath,
 };
 use async_trait::async_trait;
@@ -93,6 +93,10 @@ impl ObjectStoreApi for GoogleCloudStorage {
 
     fn path_from_raw(&self, raw: &str) -> Self::Path {
         CloudPath::raw(raw)
+    }
+
+    fn path_from_dirs_and_filename(&self, path: DirsAndFileName) -> Self::Path {
+        path.into()
     }
 
     async fn put(&self, location: &Self::Path, bytes: Bytes) -> Result<()> {

--- a/object_store/src/instrumentation.rs
+++ b/object_store/src/instrumentation.rs
@@ -13,7 +13,7 @@ use metric::{Metric, U64Counter, U64Histogram, U64HistogramOptions};
 use pin_project::{pin_project, pinned_drop};
 use time::{SystemProvider, Time, TimeProvider};
 
-use crate::{GetResult, ListResult, ObjectStoreApi};
+use crate::{path::parsed::DirsAndFileName, GetResult, ListResult, ObjectStoreApi};
 
 /// An instrumentation decorator, wrapping an underlying [`ObjectStoreApi`]
 /// implementation and recording bytes transferred and call latency.
@@ -162,6 +162,10 @@ where
 
     fn path_from_raw(&self, raw: &str) -> Self::Path {
         self.inner.path_from_raw(raw)
+    }
+
+    fn path_from_dirs_and_filename(&self, path: DirsAndFileName) -> Self::Path {
+        self.inner.path_from_dirs_and_filename(path)
     }
 
     async fn put(&self, location: &Self::Path, bytes: Bytes) -> Result<(), Self::Error> {

--- a/object_store/src/instrumentation.rs
+++ b/object_store/src/instrumentation.rs
@@ -514,7 +514,7 @@ mod tests {
     use metric::Attributes;
     use tokio::io::AsyncReadExt;
 
-    use crate::{dummy, ObjectStore};
+    use crate::{dummy, ObjectStoreImpl};
 
     use super::*;
 
@@ -552,7 +552,7 @@ mod tests {
     #[tokio::test]
     async fn test_put() {
         let metrics = Arc::new(metric::Registry::default());
-        let store = ObjectStore::new_in_memory();
+        let store = ObjectStoreImpl::new_in_memory();
         let store = ObjectStoreMetrics::new(store, &metrics);
 
         store
@@ -596,7 +596,7 @@ mod tests {
     #[tokio::test]
     async fn test_list() {
         let metrics = Arc::new(metric::Registry::default());
-        let store = ObjectStore::new_in_memory();
+        let store = ObjectStoreImpl::new_in_memory();
         let store = ObjectStoreMetrics::new(store, &metrics);
 
         store.list(None).await.expect("list should succeed");
@@ -626,7 +626,7 @@ mod tests {
     #[tokio::test]
     async fn test_list_with_delimiter() {
         let metrics = Arc::new(metric::Registry::default());
-        let store = ObjectStore::new_in_memory();
+        let store = ObjectStoreImpl::new_in_memory();
         let store = ObjectStoreMetrics::new(store, &metrics);
 
         store
@@ -683,7 +683,7 @@ mod tests {
     #[tokio::test]
     async fn test_put_get_delete_file() {
         let metrics = Arc::new(metric::Registry::default());
-        let store = ObjectStore::new_file("./");
+        let store = ObjectStoreImpl::new_file("./");
         let store = ObjectStoreMetrics::new(store, &metrics);
 
         let data = [42_u8, 42, 42, 42, 42];
@@ -727,7 +727,7 @@ mod tests {
     #[tokio::test]
     async fn test_get_stream() {
         let metrics = Arc::new(metric::Registry::default());
-        let store = ObjectStore::new_in_memory();
+        let store = ObjectStoreImpl::new_in_memory();
         let store = ObjectStoreMetrics::new(store, &metrics);
 
         let data = [42_u8, 42, 42, 42, 42];

--- a/object_store/src/memory.rs
+++ b/object_store/src/memory.rs
@@ -165,12 +165,12 @@ mod tests {
             get_nonexistent_object, list_uses_directories_correctly, list_with_delimiter,
             put_get_delete_list,
         },
-        Error as ObjectStoreError, ObjectStore, ObjectStoreApi, ObjectStorePath,
+        Error as ObjectStoreError, ObjectStoreImpl, ObjectStoreApi, ObjectStorePath,
     };
 
     #[tokio::test]
     async fn in_memory_test() {
-        let integration = ObjectStore::new_in_memory();
+        let integration = ObjectStoreImpl::new_in_memory();
 
         put_get_delete_list(&integration).await.unwrap();
         list_uses_directories_correctly(&integration).await.unwrap();
@@ -179,7 +179,7 @@ mod tests {
 
     #[tokio::test]
     async fn unknown_length() {
-        let integration = ObjectStore::new_in_memory();
+        let integration = ObjectStoreImpl::new_in_memory();
 
         let mut location = integration.new_path();
         location.set_file_name("some_file");
@@ -203,7 +203,7 @@ mod tests {
 
     #[tokio::test]
     async fn nonexistent_location() {
-        let integration = ObjectStore::new_in_memory();
+        let integration = ObjectStoreImpl::new_in_memory();
 
         let mut location = integration.new_path();
         location.set_file_name(NON_EXISTENT_NAME);

--- a/object_store/src/memory.rs
+++ b/object_store/src/memory.rs
@@ -48,7 +48,7 @@ impl ObjectStoreApi for InMemory {
     }
 
     fn path_from_dirs_and_filename(&self, path: DirsAndFileName) -> Self::Path {
-        path.into()
+        path
     }
 
     async fn put(&self, location: &Self::Path, bytes: Bytes) -> Result<()> {
@@ -169,7 +169,7 @@ mod tests {
             get_nonexistent_object, list_uses_directories_correctly, list_with_delimiter,
             put_get_delete_list,
         },
-        Error as ObjectStoreError, ObjectStoreImpl, ObjectStoreApi, ObjectStorePath,
+        Error as ObjectStoreError, ObjectStoreApi, ObjectStoreImpl, ObjectStorePath,
     };
 
     #[tokio::test]

--- a/object_store/src/memory.rs
+++ b/object_store/src/memory.rs
@@ -47,6 +47,10 @@ impl ObjectStoreApi for InMemory {
         cloud_path.into()
     }
 
+    fn path_from_dirs_and_filename(&self, path: DirsAndFileName) -> Self::Path {
+        path.into()
+    }
+
     async fn put(&self, location: &Self::Path, bytes: Bytes) -> Result<()> {
         self.storage
             .write()

--- a/object_store/src/throttle.rs
+++ b/object_store/src/throttle.rs
@@ -1,5 +1,8 @@
 //! This module contains the IOx implementation for wrapping existing object store types into an artificial "sleep" wrapper.
-use std::{convert::TryInto, sync::Mutex};
+use std::{
+    convert::TryInto,
+    sync::{Arc, Mutex},
+};
 
 use crate::{path::parsed::DirsAndFileName, GetResult, ListResult, ObjectStoreApi, Result};
 use async_trait::async_trait;
@@ -82,7 +85,7 @@ pub struct ThrottleConfig {
 #[derive(Debug)]
 pub struct ThrottledStore<T: ObjectStoreApi> {
     inner: T,
-    config: Mutex<ThrottleConfig>,
+    pub config: Arc<Mutex<ThrottleConfig>>,
 }
 
 impl<T: ObjectStoreApi> ThrottledStore<T> {
@@ -90,7 +93,7 @@ impl<T: ObjectStoreApi> ThrottledStore<T> {
     pub fn new(inner: T, config: ThrottleConfig) -> Self {
         Self {
             inner,
-            config: Mutex::new(config),
+            config: Arc::new(Mutex::new(config)),
         }
     }
 

--- a/object_store/src/throttle.rs
+++ b/object_store/src/throttle.rs
@@ -217,7 +217,7 @@ mod tests {
         memory::InMemory,
         path::ObjectStorePath,
         tests::{list_uses_directories_correctly, list_with_delimiter, put_get_delete_list},
-        ObjectStore,
+        ObjectStoreImpl,
     };
     use bytes::Bytes;
     use futures::TryStreamExt;
@@ -243,7 +243,7 @@ mod tests {
     #[tokio::test]
     async fn throttle_test() {
         let config = ThrottleConfig::default();
-        let integration = ObjectStore::new_in_memory_throttled(config);
+        let integration = ObjectStoreImpl::new_in_memory_throttled(config);
 
         put_get_delete_list(&integration).await.unwrap();
         list_uses_directories_correctly(&integration).await.unwrap();

--- a/parquet_catalog/src/cleanup.rs
+++ b/parquet_catalog/src/cleanup.rs
@@ -4,7 +4,7 @@ use std::{collections::HashSet, sync::Arc};
 use data_types::delete_predicate::DeletePredicate;
 use futures::TryStreamExt;
 use iox_object_store::{IoxObjectStore, ParquetFilePath};
-use object_store::{ObjectStoreImpl, ObjectStoreApi};
+use object_store::{ObjectStoreApi, ObjectStoreImpl};
 use observability_deps::tracing::info;
 use parking_lot::Mutex;
 use snafu::{ResultExt, Snafu};

--- a/parquet_catalog/src/cleanup.rs
+++ b/parquet_catalog/src/cleanup.rs
@@ -4,7 +4,7 @@ use std::{collections::HashSet, sync::Arc};
 use data_types::delete_predicate::DeletePredicate;
 use futures::TryStreamExt;
 use iox_object_store::{IoxObjectStore, ParquetFilePath};
-use object_store::{ObjectStore, ObjectStoreApi};
+use object_store::{ObjectStoreImpl, ObjectStoreApi};
 use observability_deps::tracing::info;
 use parking_lot::Mutex;
 use snafu::{ResultExt, Snafu};
@@ -21,12 +21,12 @@ use crate::{
 pub enum Error {
     #[snafu(display("Error from read operation while cleaning object store: {}", source))]
     ReadError {
-        source: <ObjectStore as ObjectStoreApi>::Error,
+        source: <ObjectStoreImpl as ObjectStoreApi>::Error,
     },
 
     #[snafu(display("Error from write operation while cleaning object store: {}", source))]
     WriteError {
-        source: <ObjectStore as ObjectStoreApi>::Error,
+        source: <ObjectStoreImpl as ObjectStoreApi>::Error,
     },
 
     #[snafu(display("Error from catalog loading while cleaning object store: {}", source))]

--- a/parquet_catalog/src/core.rs
+++ b/parquet_catalog/src/core.rs
@@ -6,7 +6,7 @@ use futures::{StreamExt, TryStreamExt};
 use generated_types::google::FieldViolation;
 use generated_types::influxdata::iox::preserved_catalog::v1 as proto;
 use iox_object_store::{IoxObjectStore, ParquetFilePath, TransactionFilePath};
-use object_store::{ObjectStoreImpl, ObjectStoreApi};
+use object_store::{ObjectStoreApi, ObjectStoreImpl};
 use observability_deps::tracing::{info, warn};
 use parking_lot::RwLock;
 use parquet_file::metadata::IoxParquetMetaData;

--- a/parquet_catalog/src/core.rs
+++ b/parquet_catalog/src/core.rs
@@ -6,7 +6,7 @@ use futures::{StreamExt, TryStreamExt};
 use generated_types::google::FieldViolation;
 use generated_types::influxdata::iox::preserved_catalog::v1 as proto;
 use iox_object_store::{IoxObjectStore, ParquetFilePath, TransactionFilePath};
-use object_store::{ObjectStore, ObjectStoreApi};
+use object_store::{ObjectStoreImpl, ObjectStoreApi};
 use observability_deps::tracing::{info, warn};
 use parking_lot::RwLock;
 use parquet_file::metadata::IoxParquetMetaData;
@@ -49,12 +49,12 @@ pub enum Error {
 
     #[snafu(display("Error during store write operation: {}", source))]
     Write {
-        source: <ObjectStore as ObjectStoreApi>::Error,
+        source: <ObjectStoreImpl as ObjectStoreApi>::Error,
     },
 
     #[snafu(display("Error during store read operation: {}", source))]
     Read {
-        source: <ObjectStore as ObjectStoreApi>::Error,
+        source: <ObjectStoreImpl as ObjectStoreApi>::Error,
     },
 
     #[snafu(display("Missing transaction: {}", revision_counter))]

--- a/parquet_catalog/src/dump.rs
+++ b/parquet_catalog/src/dump.rs
@@ -5,7 +5,7 @@ use bytes::Bytes;
 use futures::TryStreamExt;
 use generated_types::influxdata::iox::preserved_catalog::v1 as proto;
 use iox_object_store::{IoxObjectStore, TransactionFilePath};
-use object_store::{ObjectStoreImpl, ObjectStoreApi};
+use object_store::{ObjectStoreApi, ObjectStoreImpl};
 use parquet_file::metadata::{DecodedIoxParquetMetaData, IoxParquetMetaData};
 use snafu::{ResultExt, Snafu};
 

--- a/parquet_catalog/src/dump.rs
+++ b/parquet_catalog/src/dump.rs
@@ -5,7 +5,7 @@ use bytes::Bytes;
 use futures::TryStreamExt;
 use generated_types::influxdata::iox::preserved_catalog::v1 as proto;
 use iox_object_store::{IoxObjectStore, TransactionFilePath};
-use object_store::{ObjectStore, ObjectStoreApi};
+use object_store::{ObjectStoreImpl, ObjectStoreApi};
 use parquet_file::metadata::{DecodedIoxParquetMetaData, IoxParquetMetaData};
 use snafu::{ResultExt, Snafu};
 
@@ -15,7 +15,7 @@ use super::internals::proto_io::load_transaction_proto;
 pub enum Error {
     #[snafu(display("Error while listing files from object store: {}", source))]
     ListFiles {
-        source: <ObjectStore as ObjectStoreApi>::Error,
+        source: <ObjectStoreImpl as ObjectStoreApi>::Error,
     },
 
     #[snafu(display("Error while writing result to output: {}", source))]

--- a/parquet_catalog/src/internals/proto_io.rs
+++ b/parquet_catalog/src/internals/proto_io.rs
@@ -1,7 +1,7 @@
 use bytes::Bytes;
 use generated_types::influxdata::iox::preserved_catalog::v1 as proto;
 use iox_object_store::{IoxObjectStore, TransactionFilePath};
-use object_store::{ObjectStoreImpl, ObjectStoreApi};
+use object_store::{ObjectStoreApi, ObjectStoreImpl};
 use prost::Message;
 use snafu::{ResultExt, Snafu};
 

--- a/parquet_catalog/src/internals/proto_io.rs
+++ b/parquet_catalog/src/internals/proto_io.rs
@@ -1,7 +1,7 @@
 use bytes::Bytes;
 use generated_types::influxdata::iox::preserved_catalog::v1 as proto;
 use iox_object_store::{IoxObjectStore, TransactionFilePath};
-use object_store::{ObjectStore, ObjectStoreApi};
+use object_store::{ObjectStoreImpl, ObjectStoreApi};
 use prost::Message;
 use snafu::{ResultExt, Snafu};
 
@@ -15,12 +15,12 @@ pub enum Error {
 
     #[snafu(display("Error during store write operation: {}", source))]
     Write {
-        source: <ObjectStore as ObjectStoreApi>::Error,
+        source: <ObjectStoreImpl as ObjectStoreApi>::Error,
     },
 
     #[snafu(display("Error during store read operation: {}", source))]
     Read {
-        source: <ObjectStore as ObjectStoreApi>::Error,
+        source: <ObjectStoreImpl as ObjectStoreApi>::Error,
     },
 }
 

--- a/parquet_catalog/src/prune.rs
+++ b/parquet_catalog/src/prune.rs
@@ -3,7 +3,7 @@ use std::{collections::BTreeMap, sync::Arc};
 
 use futures::TryStreamExt;
 use iox_object_store::{IoxObjectStore, TransactionFilePath};
-use object_store::{ObjectStore, ObjectStoreApi};
+use object_store::{ObjectStoreImpl, ObjectStoreApi};
 use snafu::{ResultExt, Snafu};
 use time::Time;
 
@@ -16,12 +16,12 @@ use crate::{
 pub enum Error {
     #[snafu(display("Error during store read operation: {}", source))]
     Read {
-        source: <ObjectStore as ObjectStoreApi>::Error,
+        source: <ObjectStoreImpl as ObjectStoreApi>::Error,
     },
 
     #[snafu(display("Error during store delete operation: {}", source))]
     Delete {
-        source: <ObjectStore as ObjectStoreApi>::Error,
+        source: <ObjectStoreImpl as ObjectStoreApi>::Error,
     },
 
     #[snafu(display("Error during protobuf IO: {}", source))]

--- a/parquet_catalog/src/prune.rs
+++ b/parquet_catalog/src/prune.rs
@@ -3,7 +3,7 @@ use std::{collections::BTreeMap, sync::Arc};
 
 use futures::TryStreamExt;
 use iox_object_store::{IoxObjectStore, TransactionFilePath};
-use object_store::{ObjectStoreImpl, ObjectStoreApi};
+use object_store::{ObjectStoreApi, ObjectStoreImpl};
 use snafu::{ResultExt, Snafu};
 use time::Time;
 

--- a/parquet_file/src/test_utils.rs
+++ b/parquet_file/src/test_utils.rs
@@ -15,7 +15,7 @@ use data_types::{
     server_id::ServerId,
 };
 use iox_object_store::{IoxObjectStore, ParquetFilePath};
-use object_store::ObjectStore;
+use object_store::ObjectStoreImpl;
 use parquet::{
     arrow::{ArrowReader, ParquetFileArrowReader},
     file::serialized_reader::{SerializedFileReader, SliceableCursor},
@@ -750,7 +750,7 @@ pub fn make_server_id() -> ServerId {
 /// Creates new in-memory database iox_object_store for testing.
 pub async fn make_iox_object_store() -> Arc<IoxObjectStore> {
     Arc::new(
-        IoxObjectStore::create(Arc::new(ObjectStore::new_in_memory()), Uuid::new_v4())
+        IoxObjectStore::create(Arc::new(ObjectStoreImpl::new_in_memory()), Uuid::new_v4())
             .await
             .unwrap(),
     )

--- a/querier/src/chunk.rs
+++ b/querier/src/chunk.rs
@@ -2,7 +2,7 @@ use crate::cache::CatalogCache;
 use data_types2::{ChunkAddr, ChunkId, ChunkOrder, ParquetFile};
 use db::catalog::chunk::{CatalogChunk, ChunkMetadata, ChunkMetrics as CatalogChunkMetrics};
 use iox_object_store::IoxObjectStore;
-use object_store::ObjectStore;
+use object_store::ObjectStoreImpl;
 use parquet_file::chunk::{
     new_parquet_chunk, ChunkMetrics as ParquetChunkMetrics, DecodedParquetFile, ParquetChunk,
 };
@@ -30,7 +30,7 @@ impl ParquetChunkAdapter {
     /// Create new adapter with empty cache.
     pub fn new(
         catalog_cache: Arc<CatalogCache>,
-        object_store: Arc<ObjectStore>,
+        object_store: Arc<ObjectStoreImpl>,
         metric_registry: Arc<metric::Registry>,
         time_provider: Arc<dyn TimeProvider>,
     ) -> Self {

--- a/querier/src/chunk.rs
+++ b/querier/src/chunk.rs
@@ -2,7 +2,7 @@ use crate::cache::CatalogCache;
 use data_types2::{ChunkAddr, ChunkId, ChunkOrder, ParquetFile};
 use db::catalog::chunk::{CatalogChunk, ChunkMetadata, ChunkMetrics as CatalogChunkMetrics};
 use iox_object_store::IoxObjectStore;
-use object_store::ObjectStoreImpl;
+use object_store::DynObjectStore;
 use parquet_file::chunk::{
     new_parquet_chunk, ChunkMetrics as ParquetChunkMetrics, DecodedParquetFile, ParquetChunk,
 };
@@ -30,14 +30,14 @@ impl ParquetChunkAdapter {
     /// Create new adapter with empty cache.
     pub fn new(
         catalog_cache: Arc<CatalogCache>,
-        object_store: Arc<ObjectStoreImpl>,
+        object_store: Arc<DynObjectStore>,
         metric_registry: Arc<metric::Registry>,
         time_provider: Arc<dyn TimeProvider>,
     ) -> Self {
         // create a virtual IOx object store, the UUID won't be used anyways
         let iox_object_store = Arc::new(IoxObjectStore::existing(
             Arc::clone(&object_store),
-            IoxObjectStore::root_path_for(&object_store, uuid::Uuid::new_v4()),
+            IoxObjectStore::root_path_for(&*object_store, uuid::Uuid::new_v4()),
         ));
 
         Self {

--- a/querier/src/database.rs
+++ b/querier/src/database.rs
@@ -8,7 +8,7 @@ use crate::{
 use backoff::{Backoff, BackoffConfig};
 use data_types2::NamespaceId;
 use iox_catalog::interface::Catalog;
-use object_store::ObjectStoreImpl;
+use object_store::DynObjectStore;
 use observability_deps::tracing::{error, info};
 use parking_lot::RwLock;
 use query::exec::Executor;
@@ -43,7 +43,7 @@ pub struct QuerierDatabase {
     namespaces: RwLock<HashMap<Arc<str>, Arc<QuerierNamespace>>>,
 
     /// Object store.
-    object_store: Arc<ObjectStoreImpl>,
+    object_store: Arc<DynObjectStore>,
 
     /// Time provider.
     time_provider: Arc<dyn TimeProvider>,
@@ -59,7 +59,7 @@ impl QuerierDatabase {
     pub fn new(
         catalog: Arc<dyn Catalog>,
         metric_registry: Arc<metric::Registry>,
-        object_store: Arc<ObjectStoreImpl>,
+        object_store: Arc<DynObjectStore>,
         time_provider: Arc<dyn TimeProvider>,
         exec: Arc<Executor>,
     ) -> Self {

--- a/querier/src/database.rs
+++ b/querier/src/database.rs
@@ -8,7 +8,7 @@ use crate::{
 use backoff::{Backoff, BackoffConfig};
 use data_types2::NamespaceId;
 use iox_catalog::interface::Catalog;
-use object_store::ObjectStore;
+use object_store::ObjectStoreImpl;
 use observability_deps::tracing::{error, info};
 use parking_lot::RwLock;
 use query::exec::Executor;
@@ -43,7 +43,7 @@ pub struct QuerierDatabase {
     namespaces: RwLock<HashMap<Arc<str>, Arc<QuerierNamespace>>>,
 
     /// Object store.
-    object_store: Arc<ObjectStore>,
+    object_store: Arc<ObjectStoreImpl>,
 
     /// Time provider.
     time_provider: Arc<dyn TimeProvider>,
@@ -59,7 +59,7 @@ impl QuerierDatabase {
     pub fn new(
         catalog: Arc<dyn Catalog>,
         metric_registry: Arc<metric::Registry>,
-        object_store: Arc<ObjectStore>,
+        object_store: Arc<ObjectStoreImpl>,
         time_provider: Arc<dyn TimeProvider>,
         exec: Arc<Executor>,
     ) -> Self {

--- a/querier/src/handler.rs
+++ b/querier/src/handler.rs
@@ -119,7 +119,7 @@ mod tests {
     use std::time::Duration;
 
     use iox_catalog::mem::MemCatalog;
-    use object_store::ObjectStore;
+    use object_store::ObjectStoreImpl;
     use query::exec::Executor;
     use time::{MockProvider, Time};
 
@@ -172,7 +172,7 @@ mod tests {
         fn new() -> Self {
             let metric_registry = Arc::new(metric::Registry::new());
             let catalog = Arc::new(MemCatalog::new(Arc::clone(&metric_registry)));
-            let object_store = Arc::new(ObjectStore::new_in_memory());
+            let object_store = Arc::new(ObjectStoreImpl::new_in_memory());
             let time_provider = Arc::new(MockProvider::new(Time::from_timestamp_nanos(0)));
             let exec = Arc::new(Executor::new(1));
             let database = Arc::new(QuerierDatabase::new(

--- a/querier/src/namespace/mod.rs
+++ b/querier/src/namespace/mod.rs
@@ -5,7 +5,7 @@ use data_types2::{DeletePredicate, NamespaceId, ParquetFileId, SequencerId, Tomb
 use db::{access::QueryCatalogAccess, catalog::Catalog as DbCatalog};
 use iox_catalog::interface::{get_schema_by_name, Catalog};
 use job_registry::JobRegistry;
-use object_store::ObjectStoreImpl;
+use object_store::DynObjectStore;
 use observability_deps::tracing::{info, warn};
 use parking_lot::lock_api::RwLockUpgradableReadGuard;
 use predicate::delete_predicate::parse_delete_predicate;
@@ -74,7 +74,7 @@ impl QuerierNamespace {
         name: Arc<str>,
         id: NamespaceId,
         metric_registry: Arc<metric::Registry>,
-        object_store: Arc<ObjectStoreImpl>,
+        object_store: Arc<DynObjectStore>,
         time_provider: Arc<dyn TimeProvider>,
         exec: Arc<Executor>,
     ) -> Self {

--- a/querier/src/namespace/mod.rs
+++ b/querier/src/namespace/mod.rs
@@ -5,7 +5,7 @@ use data_types2::{DeletePredicate, NamespaceId, ParquetFileId, SequencerId, Tomb
 use db::{access::QueryCatalogAccess, catalog::Catalog as DbCatalog};
 use iox_catalog::interface::{get_schema_by_name, Catalog};
 use job_registry::JobRegistry;
-use object_store::ObjectStore;
+use object_store::ObjectStoreImpl;
 use observability_deps::tracing::{info, warn};
 use parking_lot::lock_api::RwLockUpgradableReadGuard;
 use predicate::delete_predicate::parse_delete_predicate;
@@ -74,7 +74,7 @@ impl QuerierNamespace {
         name: Arc<str>,
         id: NamespaceId,
         metric_registry: Arc<metric::Registry>,
-        object_store: Arc<ObjectStore>,
+        object_store: Arc<ObjectStoreImpl>,
         time_provider: Arc<dyn TimeProvider>,
         exec: Arc<Executor>,
     ) -> Self {

--- a/query_tests/src/cancellation.rs
+++ b/query_tests/src/cancellation.rs
@@ -1,6 +1,6 @@
 use arrow_util::assert_batches_sorted_eq;
 use db::{test_helpers::write_lp, utils::TestDb};
-use object_store::{ObjectStore, ObjectStoreIntegration};
+use object_store::{ObjectStoreImpl, ObjectStoreIntegration};
 use query::{
     exec::{ExecutionContextProvider, IOxExecutionContext},
     frontend::sql::SqlQueryPlanner,
@@ -16,7 +16,7 @@ use std::{
 
 #[tokio::test]
 async fn test_query_cancellation_slow_store() {
-    let object_store = Arc::new(ObjectStore::new_in_memory_throttled(Default::default()));
+    let object_store = Arc::new(ObjectStoreImpl::new_in_memory_throttled(Default::default()));
 
     // create test DB
     let test_db = TestDb::builder()

--- a/server/src/application.rs
+++ b/server/src/application.rs
@@ -1,6 +1,6 @@
 use crate::config::{object_store::ConfigProviderObjectStorage, ConfigProvider};
 use job_registry::JobRegistry;
-use object_store::ObjectStoreImpl;
+use object_store::DynObjectStore;
 use observability_deps::tracing::info;
 use query::exec::Executor;
 use std::sync::Arc;
@@ -12,7 +12,7 @@ use write_buffer::config::WriteBufferConfigFactory;
 /// shared between server and all DatabaseInstances
 #[derive(Debug, Clone)]
 pub struct ApplicationState {
-    object_store: Arc<ObjectStoreImpl>,
+    object_store: Arc<DynObjectStore>,
     write_buffer_factory: Arc<WriteBufferConfigFactory>,
     executor: Arc<Executor>,
     job_registry: Arc<JobRegistry>,
@@ -27,7 +27,7 @@ impl ApplicationState {
     ///
     /// Uses number of CPUs in the system if num_worker_threads is not set
     pub fn new(
-        object_store: Arc<ObjectStoreImpl>,
+        object_store: Arc<DynObjectStore>,
         num_worker_threads: Option<usize>,
         trace_collector: Option<Arc<dyn TraceCollector>>,
         config_provider: Option<Arc<dyn ConfigProvider>>,
@@ -66,8 +66,8 @@ impl ApplicationState {
         }
     }
 
-    pub fn object_store(&self) -> &Arc<ObjectStoreImpl> {
-        &self.object_store
+    pub fn object_store(&self) -> Arc<DynObjectStore> {
+        Arc::clone(&self.object_store)
     }
 
     pub fn write_buffer_factory(&self) -> &Arc<WriteBufferConfigFactory> {

--- a/server/src/application.rs
+++ b/server/src/application.rs
@@ -1,6 +1,6 @@
 use crate::config::{object_store::ConfigProviderObjectStorage, ConfigProvider};
 use job_registry::JobRegistry;
-use object_store::ObjectStore;
+use object_store::ObjectStoreImpl;
 use observability_deps::tracing::info;
 use query::exec::Executor;
 use std::sync::Arc;
@@ -12,7 +12,7 @@ use write_buffer::config::WriteBufferConfigFactory;
 /// shared between server and all DatabaseInstances
 #[derive(Debug, Clone)]
 pub struct ApplicationState {
-    object_store: Arc<ObjectStore>,
+    object_store: Arc<ObjectStoreImpl>,
     write_buffer_factory: Arc<WriteBufferConfigFactory>,
     executor: Arc<Executor>,
     job_registry: Arc<JobRegistry>,
@@ -27,7 +27,7 @@ impl ApplicationState {
     ///
     /// Uses number of CPUs in the system if num_worker_threads is not set
     pub fn new(
-        object_store: Arc<ObjectStore>,
+        object_store: Arc<ObjectStoreImpl>,
         num_worker_threads: Option<usize>,
         trace_collector: Option<Arc<dyn TraceCollector>>,
         config_provider: Option<Arc<dyn ConfigProvider>>,
@@ -66,7 +66,7 @@ impl ApplicationState {
         }
     }
 
-    pub fn object_store(&self) -> &Arc<ObjectStore> {
+    pub fn object_store(&self) -> &Arc<ObjectStoreImpl> {
         &self.object_store
     }
 

--- a/server/src/config/object_store.rs
+++ b/server/src/config/object_store.rs
@@ -16,7 +16,7 @@ use generated_types::google::FieldViolation;
 use generated_types::influxdata::iox::management;
 use generated_types::influxdata::iox::management::v1::OwnerInfo;
 use iox_object_store::IoxObjectStore;
-use object_store::ObjectStore;
+use object_store::ObjectStoreImpl;
 use snafu::{ensure, ResultExt, Snafu};
 use std::sync::Arc;
 use time::TimeProvider;
@@ -101,12 +101,12 @@ fn parse_location(location: &str) -> Result<Uuid> {
 
 #[derive(Debug)]
 pub struct ConfigProviderObjectStorage {
-    object_store: Arc<ObjectStore>,
+    object_store: Arc<ObjectStoreImpl>,
     time_provider: Arc<dyn TimeProvider>,
 }
 
 impl ConfigProviderObjectStorage {
-    pub fn new(object_store: Arc<ObjectStore>, time_provider: Arc<dyn TimeProvider>) -> Self {
+    pub fn new(object_store: Arc<ObjectStoreImpl>, time_provider: Arc<dyn TimeProvider>) -> Self {
         Self {
             object_store,
             time_provider,

--- a/server/src/database.rs
+++ b/server/src/database.rs
@@ -767,7 +767,7 @@ mod tests {
         sequence::Sequence,
         write_buffer::WriteBufferConnection,
     };
-    use object_store::{ObjectStore, ObjectStoreIntegration, ThrottleConfig};
+    use object_store::{ObjectStoreImpl, ObjectStoreIntegration, ThrottleConfig};
     use test_helpers::assert_contains;
     use write_buffer::mock::MockBufferSharedState;
 
@@ -964,7 +964,7 @@ mod tests {
             ..Default::default()
         };
 
-        let store = Arc::new(ObjectStore::new_in_memory_throttled(throttle_config));
+        let store = Arc::new(ObjectStoreImpl::new_in_memory_throttled(throttle_config));
         let application = Arc::new(ApplicationState::new(Arc::clone(&store), None, None, None));
 
         let db_config = DatabaseConfig {

--- a/server/src/database/init.rs
+++ b/server/src/database/init.rs
@@ -627,7 +627,7 @@ pub async fn create_empty_db_in_object_store(
 ) -> Result<String, InitError> {
     let db_name = provided_rules.db_name().clone();
     let iox_object_store = Arc::new(
-        match IoxObjectStore::create(Arc::clone(application.object_store()), uuid).await {
+        match IoxObjectStore::create(Arc::clone(&application.object_store()), uuid).await {
             Ok(ios) => ios,
             Err(source) => return Err(InitError::IoxObjectStoreError { source }),
         },
@@ -675,7 +675,7 @@ pub async fn claim_database_in_object_store(
 ) -> Result<String, InitError> {
     info!(%db_name, %uuid, %force, "claiming database");
 
-    let iox_object_store = IoxObjectStore::load(Arc::clone(application.object_store()), uuid)
+    let iox_object_store = IoxObjectStore::load(Arc::clone(&application.object_store()), uuid)
         .await
         .context(IoxObjectStoreSnafu)?;
 

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -1062,7 +1062,7 @@ pub enum DatabaseNameFromRulesError {
 }
 
 async fn database_name_from_rules_file(
-    object_store: Arc<object_store::ObjectStore>,
+    object_store: Arc<object_store::ObjectStoreImpl>,
     uuid: Uuid,
 ) -> Result<DatabaseName<'static>, DatabaseNameFromRulesError> {
     let rules_bytes = IoxObjectStore::load_database_rules(object_store, uuid)
@@ -1085,12 +1085,12 @@ async fn database_name_from_rules_file(
 
 pub mod test_utils {
     use super::*;
-    use object_store::ObjectStore;
+    use object_store::ObjectStoreImpl;
 
     /// Create a new [`ApplicationState`] with an in-memory object store
     pub fn make_application() -> Arc<ApplicationState> {
         Arc::new(ApplicationState::new(
-            Arc::new(ObjectStore::new_in_memory()),
+            Arc::new(ObjectStoreImpl::new_in_memory()),
             None,
             None,
             None,
@@ -1132,7 +1132,7 @@ mod tests {
     use generated_types::influxdata::iox::management;
     use iox_object_store::IoxObjectStore;
     use mutable_batch_lp::lines_to_batches;
-    use object_store::{path::ObjectStorePath, ObjectStore, ObjectStoreApi};
+    use object_store::{path::ObjectStorePath, ObjectStoreImpl, ObjectStoreApi};
     use parquet_catalog::{
         core::{PreservedCatalog, PreservedCatalogConfig},
         test_helpers::{load_ok, new_empty},
@@ -1153,14 +1153,14 @@ mod tests {
         assert!(matches!(resp, Error::IdNotSet));
     }
 
-    async fn server_config_contents(object_store: &ObjectStore, server_id: ServerId) -> Bytes {
+    async fn server_config_contents(object_store: &ObjectStoreImpl, server_id: ServerId) -> Bytes {
         IoxObjectStore::get_server_config_file(object_store, server_id)
             .await
             .unwrap_or_else(|_| Bytes::new())
     }
 
     async fn server_config(
-        object_store: &ObjectStore,
+        object_store: &ObjectStoreImpl,
         server_id: ServerId,
     ) -> management::v1::ServerConfig {
         let server_config_contents = server_config_contents(object_store, server_id).await;
@@ -1650,7 +1650,7 @@ mod tests {
     #[tokio::test]
     async fn init_error_generic() {
         // use an object store that will hopefully fail to read
-        let store = Arc::new(ObjectStore::new_failing_store().unwrap());
+        let store = Arc::new(ObjectStoreImpl::new_failing_store().unwrap());
         let application = Arc::new(ApplicationState::new(store, None, None, None));
         let server = make_server(application);
 

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -80,6 +80,7 @@ use database::{
     state::DatabaseConfig,
     Database,
 };
+use object_store::DynObjectStore;
 use std::any::Any;
 
 use db::Db;
@@ -757,15 +758,17 @@ impl Server {
         };
 
         // Read the database's rules from object storage to get the database name
-        let db_name =
-            database_name_from_rules_file(Arc::clone(self.shared.application.object_store()), uuid)
-                .await
-                .map_err(|e| match e {
-                    DatabaseNameFromRulesError::DatabaseRulesNotFound { .. } => {
-                        Error::DatabaseUuidNotFound { uuid }
-                    }
-                    _ => Error::CouldNotGetDatabaseNameFromRules { source: e },
-                })?;
+        let db_name = database_name_from_rules_file(
+            Arc::clone(&self.shared.application.object_store()),
+            uuid,
+        )
+        .await
+        .map_err(|e| match e {
+            DatabaseNameFromRulesError::DatabaseRulesNotFound { .. } => {
+                Error::DatabaseUuidNotFound { uuid }
+            }
+            _ => Error::CouldNotGetDatabaseNameFromRules { source: e },
+        })?;
 
         info!(%db_name, %uuid, "start restoring database");
 
@@ -1062,7 +1065,7 @@ pub enum DatabaseNameFromRulesError {
 }
 
 async fn database_name_from_rules_file(
-    object_store: Arc<object_store::ObjectStoreImpl>,
+    object_store: Arc<DynObjectStore>,
     uuid: Uuid,
 ) -> Result<DatabaseName<'static>, DatabaseNameFromRulesError> {
     let rules_bytes = IoxObjectStore::load_database_rules(object_store, uuid)
@@ -1132,7 +1135,7 @@ mod tests {
     use generated_types::influxdata::iox::management;
     use iox_object_store::IoxObjectStore;
     use mutable_batch_lp::lines_to_batches;
-    use object_store::{path::ObjectStorePath, ObjectStoreImpl, ObjectStoreApi};
+    use object_store::{path::ObjectStorePath, DynObjectStore, ObjectStoreImpl};
     use parquet_catalog::{
         core::{PreservedCatalog, PreservedCatalogConfig},
         test_helpers::{load_ok, new_empty},
@@ -1153,14 +1156,14 @@ mod tests {
         assert!(matches!(resp, Error::IdNotSet));
     }
 
-    async fn server_config_contents(object_store: &ObjectStoreImpl, server_id: ServerId) -> Bytes {
+    async fn server_config_contents(object_store: &DynObjectStore, server_id: ServerId) -> Bytes {
         IoxObjectStore::get_server_config_file(object_store, server_id)
             .await
             .unwrap_or_else(|_| Bytes::new())
     }
 
     async fn server_config(
-        object_store: &ObjectStoreImpl,
+        object_store: &DynObjectStore,
         server_id: ServerId,
     ) -> management::v1::ServerConfig {
         let server_config_contents = server_config_contents(object_store, server_id).await;
@@ -1200,7 +1203,7 @@ mod tests {
 
         // assert server config file either doesn't exist or exists but has 0 entries
         let server_config_contents =
-            server_config_contents(application.object_store(), server_id).await;
+            server_config_contents(&*application.object_store(), server_id).await;
         assert_eq!(server_config_contents.len(), 0);
 
         let name = DatabaseName::new("bananas").unwrap();
@@ -1243,11 +1246,11 @@ mod tests {
         assert_eq!(owner_info.id, server_id.get_u32());
         assert_eq!(
             owner_info.location,
-            IoxObjectStore::server_config_path(application.object_store(), server_id).to_string()
+            IoxObjectStore::server_config_path(&*application.object_store(), server_id).to_string()
         );
 
         // assert server config file exists and has 1 entry
-        let config = server_config(application.object_store(), server_id).await;
+        let config = server_config(&*application.object_store(), server_id).await;
         assert_config_contents(&config, &[(&name, format!("dbs/{}/", bananas_uuid))]);
 
         let db2 = DatabaseName::new("db_awesome").unwrap();
@@ -1261,7 +1264,7 @@ mod tests {
         let awesome_uuid = awesome.uuid();
 
         // assert server config file exists and has 2 entries
-        let config = server_config(application.object_store(), server_id).await;
+        let config = server_config(&*application.object_store(), server_id).await;
         assert_config_contents(
             &config,
             &[
@@ -1284,7 +1287,7 @@ mod tests {
         assert!(server2.db(&name).is_ok());
 
         // assert server config file still exists and has 2 entries
-        let config = server_config(application.object_store(), server_id).await;
+        let config = server_config(&*application.object_store(), server_id).await;
         assert_config_contents(
             &config,
             &[
@@ -1405,7 +1408,7 @@ mod tests {
 
         // assert server config file has been recreated and contains 2 entries, even though
         // the databases fail to initialize
-        let config = server_config(application.object_store(), server_id).await;
+        let config = server_config(&*application.object_store(), server_id).await;
         assert_config_contents(
             &config,
             &[
@@ -1510,7 +1513,7 @@ mod tests {
         database.wait_for_init().await.unwrap();
 
         // Server config should be transitioned to the new location
-        let config = server_config(application.object_store(), server_id).await;
+        let config = server_config(&*application.object_store(), server_id).await;
         assert_config_contents(&config, &[(&db_name, format!("dbs/{}/", db_uuid))]);
     }
 
@@ -1845,7 +1848,7 @@ mod tests {
             Error::DatabaseNotFound { .. },
         );
 
-        let config = server_config(application.object_store(), server_id).await;
+        let config = server_config(&*application.object_store(), server_id).await;
         assert_config_contents(&config, &[]);
 
         // create another database
@@ -1910,7 +1913,7 @@ mod tests {
         let claimed = server.database(&foo_db_name).unwrap();
         claimed.wait_for_init().await.unwrap();
 
-        let config = server_config(application.object_store(), server_id).await;
+        let config = server_config(&*application.object_store(), server_id).await;
         assert_config_contents(
             &config,
             &[(&foo_db_name, format!("dbs/{}/", released_uuid))],
@@ -2120,9 +2123,12 @@ mod tests {
             Error::DatabaseNotFound { .. }
         ));
         let non_existing_iox_object_store = Arc::new(
-            IoxObjectStore::create(Arc::clone(application.object_store()), db_uuid_non_existing)
-                .await
-                .unwrap(),
+            IoxObjectStore::create(
+                Arc::clone(&application.object_store()),
+                db_uuid_non_existing,
+            )
+            .await
+            .unwrap(),
         );
 
         let config = PreservedCatalogConfig::new(

--- a/server_benchmarks/benches/catalog_persistence.rs
+++ b/server_benchmarks/benches/catalog_persistence.rs
@@ -1,7 +1,7 @@
 use criterion::{criterion_group, criterion_main, BatchSize, Criterion, SamplingMode};
 use data_types::{chunk_metadata::ChunkId, database_rules::LifecycleRules};
 use db::{test_helpers::write_lp, utils::TestDb};
-use object_store::{ObjectStoreImpl, ThrottleConfig};
+use object_store::{DynObjectStore, ObjectStoreImpl, ThrottleConfig};
 use query::QueryChunk;
 use std::{
     convert::TryFrom,
@@ -74,7 +74,7 @@ fn benchmark_catalog_persistence(c: &mut Criterion) {
 
 /// Persist a database to the given object store with [`N_CHUNKS`] chunks.
 async fn setup(
-    object_store: Arc<ObjectStoreImpl>,
+    object_store: Arc<DynObjectStore>,
     done: &Mutex<Option<Arc<Vec<ChunkId>>>>,
 ) -> Arc<Vec<ChunkId>> {
     let mut guard = done.lock().await;
@@ -115,7 +115,7 @@ async fn setup(
 
 /// Create a persisted database and load its catalog.
 #[inline(never)]
-async fn create_persisted_db(object_store: Arc<ObjectStoreImpl>) -> TestDb {
+async fn create_persisted_db(object_store: Arc<DynObjectStore>) -> TestDb {
     TestDb::builder()
         .object_store(object_store)
         .lifecycle_rules(LifecycleRules {
@@ -148,7 +148,7 @@ fn create_lp(n_tags: usize, n_fields: usize) -> String {
 }
 
 /// Create object store with somewhat realistic operation latencies.
-fn create_throttled_store() -> Arc<ObjectStoreImpl> {
+fn create_throttled_store() -> Arc<DynObjectStore> {
     let config = ThrottleConfig {
         // for every call: assume a 100ms latency
         wait_delete_per_call: Duration::from_millis(100),


### PR DESCRIPTION
Changes consumers of the `ObjectStore` type to use a dynamically dispatched type alias (`DynObjectStore`) instead of the concrete type, and configures the ingester/compactor/querier to emit metrics by decorating the underlying `ObjectStoreImpl` with an instrumentation layer (#4019).

This refactoring was much simpler and more flexible than the original plan outlined in #4019.

This PR has a lot of code churn, but functionally little changes beyond adding the metric decorator in the last three commits.

---

* refactor: rename ObjectStore -> ObjectStoreImpl (1d5066c42)

      Frees up the name for so we can use `dyn ObjectStore` throughout the code
      instead of `ObjectStoreApi`.

* refactor: path_from_dirs_and_filename trait method (b727d26da)

      Moves the path_from_dirs_and_filename from an ObjectStoreImpl method to a
      trait method, completing the abstraction over all object store backends.

* refactor: switch to using DynObjectStore (5585dd3c2)

      Changes all consumers of the object store to use the dynamically dispatched
      DynObjectStore type, instead of using a hardcoded concrete implementation
      type.

* feat(compactor): enable object store metrics (65273721b)


* feat(ingester): enable object store metrics (f4d836eed)


* feat(querier): enable object store metrics (6fb1a9b59)