### PR TITLE
fix: docker server fixture had mistake in run command

### DIFF
--- a/influxdb2_client/tests/common/server_fixture.rs
+++ b/influxdb2_client/tests/common/server_fixture.rs
@@ -214,8 +214,8 @@ impl TestServer {
             let container_name = format!("influxdb2_{}", http_port);
 
             Command::new("docker")
+                .arg("container")
                 .arg("run")
-                .arg("database")
                 .arg("--name")
                 .arg(&container_name)
                 .arg("--publish")


### PR DESCRIPTION
It seems I'm the only one who doesn't have an iox binary on my laptop for the test fixtures to use, so it uses Docker, and that code path either never worked or got stale.

The addition of the `container` term is because `docker run` has long been deprecated but will probably never be removed. The real fix is the removal of the superfluous `database` term.