### PR TITLE
refactor: lower pg idle connection timeout

### DIFF
--- a/iox_catalog/src/postgres.rs
+++ b/iox_catalog/src/postgres.rs
@@ -22,7 +22,7 @@ use sqlx_hotswap_pool::HotSwapPool;
 use std::{sync::Arc, time::Duration};
 
 const CONNECT_TIMEOUT: Duration = Duration::from_secs(2);
-const IDLE_TIMEOUT: Duration = Duration::from_secs(500);
+const IDLE_TIMEOUT: Duration = Duration::from_secs(60);
 /// the default schema name to use in Postgres
 pub const SCHEMA_NAME: &str = "iox_catalog";
 


### PR DESCRIPTION
Can't hurt! 60s is still quite a lot but will definitely reduce connection hogging.

---

* refactor: lower pg idle connection timeout (0d4949cd1)

      Configure the postgres catalog to close unused connections after 1 minute,
      rather than 500s to introduce a bit of fluidity to pool of connection
      acquires.