### PR TITLE
refactor: make `QueryChunk` object-safe

### DIFF
--- a/influxdb_ioxd/src/rpc/storage/service.rs
+++ b/influxdb_ioxd/src/rpc/storage/service.rs
@@ -1381,7 +1381,7 @@ mod tests {
     use predicate::{PredicateBuilder, PredicateMatch};
     use query::{
         exec::Executor,
-        test::{TestChunk, TestDatabase, TestError},
+        test::{TestChunk, TestDatabase},
     };
     use test_helpers::{assert_contains, tracing::TracingCapture};
 
@@ -1465,7 +1465,6 @@ mod tests {
             .test_storage
             .db_or_create(db_info.db_name())
             .await
-            .unwrap()
             .add_chunk("my_partition_key", Arc::new(chunk0))
             .add_chunk("my_partition_key", Arc::new(chunk1));
 
@@ -1567,7 +1566,6 @@ mod tests {
             .test_storage
             .db_or_create(db_info.db_name())
             .await
-            .unwrap()
             .add_chunk("my_partition_key", Arc::new(chunk0))
             .add_chunk("my_partition_key", Arc::new(chunk1));
 
@@ -1617,7 +1615,6 @@ mod tests {
             .test_storage
             .db_or_create(db_info.db_name())
             .await
-            .unwrap()
             .add_chunk("my_partition_key", Arc::new(chunk));
 
         let source = Some(StorageClient::read_source(&db_info, 1));
@@ -1662,7 +1659,6 @@ mod tests {
             .test_storage
             .db_or_create(db_info.db_name())
             .await
-            .unwrap()
             .add_chunk("my_partition_key", Arc::new(chunk0))
             .add_chunk("my_partition_key", Arc::new(chunk1));
 
@@ -1724,7 +1720,6 @@ mod tests {
             .test_storage
             .db_or_create(db_info.db_name())
             .await
-            .unwrap()
             .add_chunk("my_partition_key", Arc::new(chunk));
 
         let source = Some(StorageClient::read_source(&db_info, 1));
@@ -1766,7 +1761,6 @@ mod tests {
             .test_storage
             .db_or_create(db_info.db_name())
             .await
-            .unwrap()
             .add_chunk("my_partition_key", Arc::new(chunk));
 
         let source = Some(StorageClient::read_source(&db_info, 1));
@@ -1816,7 +1810,6 @@ mod tests {
             .test_storage
             .db_or_create(db_info.db_name())
             .await
-            .unwrap()
             .add_chunk("my_partition_key", Arc::new(chunk));
 
         let tag_values = vec!["h2o"];
@@ -1848,7 +1841,6 @@ mod tests {
             .test_storage
             .db_or_create(db_info.db_name())
             .await
-            .unwrap()
             .add_chunk("my_partition_key", Arc::new(chunk));
 
         let source = Some(StorageClient::read_source(&db_info, 1));
@@ -1887,7 +1879,6 @@ mod tests {
             .test_storage
             .db_or_create(db_info.db_name())
             .await
-            .unwrap()
             .add_chunk("my_partition_key", Arc::new(chunk));
 
         let source = Some(StorageClient::read_source(&db_info, 1));
@@ -1956,7 +1947,6 @@ mod tests {
             .test_storage
             .db_or_create(db_info.db_name())
             .await
-            .unwrap()
             .add_chunk("my_partition_key", Arc::new(chunk1))
             .add_chunk("my_partition_key", Arc::new(chunk2));
 
@@ -2173,7 +2163,6 @@ mod tests {
             .test_storage
             .db_or_create(db_info.db_name())
             .await
-            .unwrap()
             .add_chunk("my_partition_key", Arc::new(chunk));
 
         let source = Some(StorageClient::read_source(&db_info, 1));
@@ -2216,7 +2205,6 @@ mod tests {
             .test_storage
             .db_or_create(db_info.db_name())
             .await
-            .unwrap()
             .add_chunk("my_partition_key", Arc::new(chunk));
 
         let source = Some(StorageClient::read_source(&db_info, 1));
@@ -2257,7 +2245,6 @@ mod tests {
             .test_storage
             .db_or_create(db_info.db_name())
             .await
-            .unwrap()
             .add_chunk("my_partition_key", Arc::new(chunk));
 
         let source = Some(StorageClient::read_source(&db_info, 1));
@@ -2359,7 +2346,6 @@ mod tests {
             .test_storage
             .db_or_create(db_info.db_name())
             .await
-            .unwrap()
             .add_chunk("my_partition_key", Arc::new(chunk));
 
         let source = Some(StorageClient::read_source(&db_info, 1));
@@ -2424,7 +2410,6 @@ mod tests {
             .test_storage
             .db_or_create(db_info.db_name())
             .await
-            .unwrap()
             .add_chunk("my_partition_key", Arc::new(chunk));
 
         let source = Some(StorageClient::read_source(&db_info, 1));
@@ -2476,7 +2461,6 @@ mod tests {
             .test_storage
             .db_or_create(db_info.db_name())
             .await
-            .unwrap()
             .add_chunk("my_partition_key", Arc::new(chunk));
 
         let source = Some(StorageClient::read_source(&db_info, 1));
@@ -2516,7 +2500,6 @@ mod tests {
             .test_storage
             .db_or_create(db_info.db_name())
             .await
-            .unwrap()
             .add_chunk("my_partition_key", Arc::new(chunk));
 
         let source = Some(StorageClient::read_source(&db_info, 1));
@@ -2559,7 +2542,6 @@ mod tests {
             .test_storage
             .db_or_create(db_info.db_name())
             .await
-            .unwrap()
             .add_chunk("my_partition_key", Arc::new(chunk));
 
         let source = Some(StorageClient::read_source(&db_info, 1));
@@ -2610,7 +2592,6 @@ mod tests {
             .test_storage
             .db_or_create(db_info.db_name())
             .await
-            .unwrap()
             .add_chunk("my_partition_key", Arc::new(chunk));
 
         let source = Some(StorageClient::read_source(&db_info, 1));
@@ -2664,7 +2645,6 @@ mod tests {
             .test_storage
             .db_or_create(db_info.db_name())
             .await
-            .unwrap()
             .add_chunk("my_partition_key", Arc::new(chunk));
 
         let source = Some(StorageClient::read_source(&db_info, 1));
@@ -2724,7 +2704,6 @@ mod tests {
             .test_storage
             .db_or_create(db_info.db_name())
             .await
-            .unwrap()
             .add_chunk("my_partition_key", Arc::new(chunk));
 
         let source = Some(StorageClient::read_source(&db_info, 1));
@@ -2778,7 +2757,6 @@ mod tests {
             .test_storage
             .db_or_create(db_info.db_name())
             .await
-            .unwrap()
             .add_chunk("my_partition_key", Arc::new(chunk));
 
         let source = Some(StorageClient::read_source(&db_info, 1));
@@ -2819,7 +2797,6 @@ mod tests {
             .test_storage
             .db_or_create(db_info.db_name())
             .await
-            .unwrap()
             .add_chunk("my_partition_key", Arc::new(chunk));
 
         let source = Some(StorageClient::read_source(&db_info, 1));
@@ -2999,7 +2976,6 @@ mod tests {
                 .test_storage
                 .db_or_create(db_name)
                 .await
-                .expect("getting db")
                 .get_chunk(partition_key, ChunkId::new_test(chunk_id))
                 .unwrap()
                 .predicates();
@@ -3025,15 +3001,15 @@ mod tests {
             Self::default()
         }
 
-        async fn db_or_create(&self, name: &str) -> Result<Arc<TestDatabase>, TestError> {
+        async fn db_or_create(&self, name: &str) -> Arc<TestDatabase> {
             let mut databases = self.databases.lock();
 
             if let Some(db) = databases.get(name) {
-                Ok(Arc::clone(db))
+                Arc::clone(db)
             } else {
                 let new_db = Arc::new(TestDatabase::new(Arc::clone(&self.executor)));
                 databases.insert(name.to_string(), Arc::clone(&new_db));
-                Ok(new_db)
+                new_db
             }
         }
     }

--- a/ingester/src/query.rs
+++ b/ingester/src/query.rs
@@ -24,7 +24,7 @@ use predicate::{Predicate, PredicateMatch};
 use query::{
     exec::{stringset::StringSet, IOxExecutionContext},
     util::{df_physical_expr_from_schema_and_expr, MissingColumnsToNull},
-    QueryChunk, QueryChunkMeta,
+    QueryChunk, QueryChunkError, QueryChunkMeta,
 };
 use schema::{merge::merge_record_batch_schemas, selection::Selection, sort::SortKey, Schema};
 use snafu::{ResultExt, Snafu};
@@ -127,8 +127,6 @@ impl QueryChunkMeta for QueryableBatch {
 }
 
 impl QueryChunk for QueryableBatch {
-    type Error = Error;
-
     // This function should not be used in QueryBatch context
     fn id(&self) -> ChunkId {
         // always return id 0 for debugging mode
@@ -162,7 +160,7 @@ impl QueryChunk for QueryableBatch {
     fn apply_predicate_to_metadata(
         &self,
         _predicate: &Predicate,
-    ) -> Result<PredicateMatch, Self::Error> {
+    ) -> Result<PredicateMatch, QueryChunkError> {
         Ok(PredicateMatch::Unknown)
     }
 
@@ -175,7 +173,7 @@ impl QueryChunk for QueryableBatch {
         _ctx: IOxExecutionContext,
         _predicate: &Predicate,
         _columns: Selection<'_>,
-    ) -> Result<Option<StringSet>, Self::Error> {
+    ) -> Result<Option<StringSet>, QueryChunkError> {
         Ok(None)
     }
 
@@ -189,7 +187,7 @@ impl QueryChunk for QueryableBatch {
         _ctx: IOxExecutionContext,
         _column_name: &str,
         _predicate: &Predicate,
-    ) -> Result<Option<StringSet>, Self::Error> {
+    ) -> Result<Option<StringSet>, QueryChunkError> {
         Ok(None)
     }
 
@@ -211,7 +209,7 @@ impl QueryChunk for QueryableBatch {
         mut ctx: IOxExecutionContext,
         predicate: &Predicate,
         selection: Selection<'_>,
-    ) -> Result<SendableRecordBatchStream, Self::Error> {
+    ) -> Result<SendableRecordBatchStream, QueryChunkError> {
         ctx.set_metadata("storage", "ingester");
         ctx.set_metadata("projection", format!("{}", selection));
         trace!(?selection, "selection");

--- a/query/src/frontend/influxrpc.rs
+++ b/query/src/frontend/influxrpc.rs
@@ -266,12 +266,11 @@ impl InfluxRpcPlanner {
                         .push(Arc::clone(&chunk));
                 } else {
                     // Try and apply the predicate using only metadata
-                    let pred_result = chunk
-                        .apply_predicate_to_metadata(predicate)
-                        .map_err(|e| Box::new(e) as _)
-                        .context(CheckingChunkPredicateSnafu {
+                    let pred_result = chunk.apply_predicate_to_metadata(predicate).context(
+                        CheckingChunkPredicateSnafu {
                             chunk_id: chunk.id(),
-                        })?;
+                        },
+                    )?;
 
                     match pred_result {
                         PredicateMatch::AtLeastOneNonNullField => {
@@ -362,12 +361,11 @@ impl InfluxRpcPlanner {
                 let mut do_full_plan = chunk.has_delete_predicates();
 
                 // Try and apply the predicate using only metadata
-                let pred_result = chunk
-                    .apply_predicate_to_metadata(predicate)
-                    .map_err(|e| Box::new(e) as _)
-                    .context(CheckingChunkPredicateSnafu {
+                let pred_result = chunk.apply_predicate_to_metadata(predicate).context(
+                    CheckingChunkPredicateSnafu {
                         chunk_id: chunk.id(),
-                    })?;
+                    },
+                )?;
 
                 if matches!(pred_result, PredicateMatch::Zero) {
                     continue;
@@ -391,7 +389,6 @@ impl InfluxRpcPlanner {
                             predicate,
                             selection,
                         )
-                        .map_err(|e| Box::new(e) as _)
                         .context(FindingColumnNamesSnafu)?;
 
                     match maybe_names {
@@ -505,12 +502,11 @@ impl InfluxRpcPlanner {
                 let mut do_full_plan = chunk.has_delete_predicates();
 
                 // Try and apply the predicate using only metadata
-                let pred_result = chunk
-                    .apply_predicate_to_metadata(predicate)
-                    .map_err(|e| Box::new(e) as _)
-                    .context(CheckingChunkPredicateSnafu {
+                let pred_result = chunk.apply_predicate_to_metadata(predicate).context(
+                    CheckingChunkPredicateSnafu {
                         chunk_id: chunk.id(),
-                    })?;
+                    },
+                )?;
 
                 if matches!(pred_result, PredicateMatch::Zero) {
                     continue;
@@ -553,7 +549,6 @@ impl InfluxRpcPlanner {
                             tag_name,
                             predicate,
                         )
-                        .map_err(|e| Box::new(e) as _)
                         .context(FindingColumnValuesSnafu)?;
 
                     match maybe_values {
@@ -1517,12 +1512,12 @@ where
     let mut filtered = Vec::with_capacity(chunks.len());
     for chunk in chunks {
         // Try and apply the predicate using only metadata
-        let pred_result = chunk
-            .apply_predicate_to_metadata(predicate)
-            .map_err(|e| Box::new(e) as _)
-            .context(CheckingChunkPredicateSnafu {
-                chunk_id: chunk.id(),
-            })?;
+        let pred_result =
+            chunk
+                .apply_predicate_to_metadata(predicate)
+                .context(CheckingChunkPredicateSnafu {
+                    chunk_id: chunk.id(),
+                })?;
 
         trace!(?pred_result, chunk_id=?chunk.id(), "applied predicate to metadata");
 


### PR DESCRIPTION
This makes it way easier to dyn-type database implementations. The only
real change is that we make `QueryChunk::Error` opaque. Nobody is going
to inspect that anyways, it's just printed to the user.

This is a follow-up of #4053.

Ref #3934.
