### PR TITLE
refactor: reduce INFO verbosity

### DIFF
--- a/db/src/catalog/partition.rs
+++ b/db/src/catalog/partition.rs
@@ -9,7 +9,7 @@ use data_types::{
     partition_metadata::{PartitionAddr, PartitionSummary},
 };
 use hashbrown::HashMap;
-use observability_deps::tracing::info;
+use observability_deps::tracing::*;
 use persistence_windows::{
     min_max_sequence::OptionalMinMaxSequence, persistence_windows::PersistenceWindows,
 };
@@ -261,7 +261,7 @@ impl Partition {
         );
 
         let addr = ChunkAddr::new(&self.addr, chunk_id);
-        info!(%addr, row_count=chunk.rows(), "inserting RUB chunk to catalog");
+        debug!(%addr, row_count=chunk.rows(), "inserting RUB chunk to catalog");
 
         let chunk = CatalogChunk::new_rub_chunk(
             addr,

--- a/db/src/lifecycle/compact.rs
+++ b/db/src/lifecycle/compact.rs
@@ -9,7 +9,7 @@ use crate::{
 };
 use data_types::{chunk_metadata::ChunkOrder, delete_predicate::DeletePredicate, job::Job};
 use lifecycle::LifecycleWriteGuard;
-use observability_deps::tracing::info;
+use observability_deps::tracing::*;
 use query::{compute_sort_key, exec::ExecutorType, frontend::reorg::ReorgPlanner, QueryChunkMeta};
 use std::{collections::HashSet, future::Future, sync::Arc};
 use time::Time;
@@ -36,7 +36,7 @@ pub(crate) fn compact_chunks(
     let addr = partition.addr().clone();
     let chunk_ids: Vec<_> = chunks.iter().map(|x| x.id()).collect();
 
-    info!(%addr, ?chunk_ids, "compacting chunks");
+    debug!(%addr, ?chunk_ids, "compacting chunks");
 
     let (tracker, registration) = db.jobs.register(Job::CompactChunks {
         partition: partition.addr().clone(),
@@ -159,7 +159,7 @@ pub(crate) fn compact_chunks(
         let elapsed = now.elapsed();
         let throughput = (input_rows as u128 * 1_000_000_000) / elapsed.as_nanos();
 
-        info!(input_chunks=chunk_ids.len(), %rub_row_groups,
+        debug!(input_chunks=chunk_ids.len(), %rub_row_groups,
                         %input_rows, %output_rows,
                         %sort_key, compaction_took = ?elapsed, fut_execution_duration= ?fut_now.elapsed(),
                         rows_per_sec=?throughput,  "chunk(s) compacted");

--- a/tracker/src/task/history.rs
+++ b/tracker/src/task/history.rs
@@ -2,7 +2,7 @@ use super::registry::AbstractTaskRegistry;
 use super::{TaskId, TaskRegistration, TaskTracker};
 use hashbrown::hash_map::Entry;
 use hashbrown::HashMap;
-use observability_deps::tracing::info;
+use observability_deps::tracing::*;
 use std::hash::Hash;
 
 /// A wrapper around a TaskRegistry that automatically retains a history
@@ -63,7 +63,7 @@ where
         let mut pruned = vec![];
 
         for job in self.registry.reclaim() {
-            info!(?job, "job finished");
+            debug!(?job, "job finished");
             if let Some((_pruned_id, pruned_job)) = self.history.push(job.id(), job) {
                 pruned.push(pruned_job);
             }


### PR DESCRIPTION
We're killing our logging infrastructure :fire:

---

* refactor: reduce INFO verbosity (1b26bf1d7)

      We're currently emitting ~5GB of logs every 30 minutes, and a quick scan 
      through the logs shows the lines this PR changes to be the most frequent
      (multiple times per second).

      I don't believe any of these are important enough to be INFO, but if needed,
      an appropriate log filter will bring them back.