### PR TITLE
refactor: steps towards dynamic database type dispatch

### DIFF
--- a/db/src/access.rs
+++ b/db/src/access.rs
@@ -292,7 +292,7 @@ impl QueryDatabase for QueryCatalogAccess {
     fn record_query(
         &self,
         ctx: &IOxExecutionContext,
-        query_type: impl Into<String>,
+        query_type: &str,
         query_text: QueryText,
     ) -> QueryCompletedToken {
         // When the query token is dropped the query entry's completion time

--- a/db/src/lib.rs
+++ b/db/src/lib.rs
@@ -1237,7 +1237,7 @@ impl QueryDatabase for Db {
     fn record_query(
         &self,
         ctx: &IOxExecutionContext,
-        query_type: impl Into<String>,
+        query_type: &str,
         query_text: QueryText,
     ) -> QueryCompletedToken {
         self.catalog_access

--- a/db/src/lib.rs
+++ b/db/src/lib.rs
@@ -1256,10 +1256,10 @@ impl QueryDatabaseMeta for Db {
 }
 
 impl ExecutionContextProvider for Db {
-    fn new_query_context(self: &Arc<Self>, span_ctx: Option<SpanContext>) -> IOxExecutionContext {
+    fn new_query_context(&self, span_ctx: Option<SpanContext>) -> IOxExecutionContext {
         self.exec
             .new_execution_config(ExecutorType::Query)
-            .with_default_catalog(Arc::<Self>::clone(self))
+            .with_default_catalog(Arc::clone(&self.catalog_access) as _)
             .with_span_context(span_ctx)
             .build()
     }

--- a/querier/src/namespace/query_access.rs
+++ b/querier/src/namespace/query_access.rs
@@ -34,7 +34,7 @@ impl QueryDatabase for QuerierNamespace {
     fn record_query(
         &self,
         ctx: &IOxExecutionContext,
-        query_type: impl Into<String>,
+        query_type: &str,
         query_text: QueryText,
     ) -> QueryCompletedToken {
         self.catalog_access

--- a/querier/src/namespace/query_access.rs
+++ b/querier/src/namespace/query_access.rs
@@ -57,10 +57,10 @@ impl CatalogProvider for QuerierNamespace {
 }
 
 impl ExecutionContextProvider for QuerierNamespace {
-    fn new_query_context(self: &Arc<Self>, span_ctx: Option<SpanContext>) -> IOxExecutionContext {
+    fn new_query_context(&self, span_ctx: Option<SpanContext>) -> IOxExecutionContext {
         self.exec
             .new_execution_config(ExecutorType::Query)
-            .with_default_catalog(Arc::<Self>::clone(self))
+            .with_default_catalog(Arc::clone(&self.catalog_access) as _)
             .with_span_context(span_ctx)
             .build()
     }

--- a/query/src/exec.rs
+++ b/query/src/exec.rs
@@ -238,10 +238,7 @@ pub fn make_stream_split(input: LogicalPlan, split_expr: Expr) -> LogicalPlan {
 /// A type that can provide `IOxExecutionContext` for query
 pub trait ExecutionContextProvider {
     /// Returns a new execution context suitable for running queries
-    fn new_query_context(
-        self: &Arc<Self>,
-        span_ctx: Option<trace::ctx::SpanContext>,
-    ) -> IOxExecutionContext;
+    fn new_query_context(&self, span_ctx: Option<trace::ctx::SpanContext>) -> IOxExecutionContext;
 }
 
 #[cfg(test)]

--- a/query/src/lib.rs
+++ b/query/src/lib.rs
@@ -148,7 +148,7 @@ pub trait QueryDatabase: QueryDatabaseMeta + Debug + Send + Sync {
     fn record_query(
         &self,
         ctx: &IOxExecutionContext,
-        query_type: impl Into<String>,
+        query_type: &str,
         query_text: QueryText,
     ) -> QueryCompletedToken;
 }

--- a/query/src/test.rs
+++ b/query/src/test.rs
@@ -120,7 +120,7 @@ impl QueryDatabase for TestDatabase {
     fn record_query(
         &self,
         _ctx: &IOxExecutionContext,
-        _query_type: impl Into<String>,
+        _query_type: &str,
         _query_text: QueryText,
     ) -> QueryCompletedToken {
         QueryCompletedToken::new(|_| {})

--- a/query/src/test.rs
+++ b/query/src/test.rs
@@ -159,7 +159,7 @@ impl QueryDatabaseMeta for TestDatabase {
 }
 
 impl ExecutionContextProvider for TestDatabase {
-    fn new_query_context(self: &Arc<Self>, span_ctx: Option<SpanContext>) -> IOxExecutionContext {
+    fn new_query_context(&self, span_ctx: Option<SpanContext>) -> IOxExecutionContext {
         // Note: unlike Db this does not register a catalog provider
         self.executor
             .new_execution_config(ExecutorType::Query)

--- a/query_tests/src/db.rs
+++ b/query_tests/src/db.rs
@@ -66,10 +66,10 @@ impl QueryDatabase for AbstractDb {
     fn record_query(
         &self,
         ctx: &IOxExecutionContext,
-        query_type: impl Into<String>,
+        query_type: &str,
         query_text: query::QueryText,
     ) -> query::QueryCompletedToken {
-        self.0.record_query(ctx, query_type.into(), query_text)
+        self.0.record_query(ctx, query_type, query_text)
     }
 }
 
@@ -187,7 +187,7 @@ mod sealed {
         fn record_query(
             &self,
             ctx: &IOxExecutionContext,
-            query_type: String,
+            query_type: &str,
             query_text: query::QueryText,
         ) -> query::QueryCompletedToken;
 
@@ -230,7 +230,7 @@ impl AbstractDbInterface for OldDb {
     fn record_query(
         &self,
         ctx: &IOxExecutionContext,
-        query_type: String,
+        query_type: &str,
         query_text: query::QueryText,
     ) -> query::QueryCompletedToken {
         self.0.record_query(ctx, query_type, query_text)

--- a/query_tests/src/db.rs
+++ b/query_tests/src/db.rs
@@ -32,10 +32,7 @@ impl AbstractDb {
 }
 
 impl ExecutionContextProvider for AbstractDb {
-    fn new_query_context(
-        self: &Arc<Self>,
-        span_ctx: Option<trace::ctx::SpanContext>,
-    ) -> IOxExecutionContext {
+    fn new_query_context(&self, span_ctx: Option<trace::ctx::SpanContext>) -> IOxExecutionContext {
         self.0.new_query_context(span_ctx)
     }
 }


### PR DESCRIPTION
It should be possible to use some form of `Arc<dyn AbstractDb>` like DataFusion  already does it. There are only a few methods that are currently not object-safe and I'm about to fix that.

After this PR the last big TODO is `QueryDatabase::Chunk` (associated type) but that's a bit of a bigger change, so I'll create a separate PR for that.

Ref #3934.
