### PR TITLE
fix: propagate shutdown requests & compactor join() fix

### DIFF
--- a/influxdb_ioxd/src/server_type/querier/mod.rs
+++ b/influxdb_ioxd/src/server_type/querier/mod.rs
@@ -15,7 +15,6 @@ use querier::{
 };
 use query::exec::Executor;
 use time::TimeProvider;
-use tokio_util::sync::CancellationToken;
 use trace::TraceCollector;
 
 use crate::{
@@ -30,7 +29,6 @@ mod rpc;
 pub struct QuerierServerType<C: QuerierHandler> {
     database: Arc<QuerierDatabase>,
     server: QuerierServer<C>,
-    shutdown: CancellationToken,
     trace_collector: Option<Arc<dyn TraceCollector>>,
 }
 
@@ -43,7 +41,6 @@ impl<C: QuerierHandler> QuerierServerType<C> {
         Self {
             server,
             database,
-            shutdown: CancellationToken::new(),
             trace_collector: common_state.trace_collector(),
         }
     }
@@ -86,11 +83,11 @@ impl<C: QuerierHandler + std::fmt::Debug + 'static> ServerType for QuerierServer
     }
 
     async fn join(self: Arc<Self>) {
-        self.shutdown.cancelled().await;
+        self.server.join().await;
     }
 
     fn shutdown(&self) {
-        self.shutdown.cancel();
+        self.server.shutdown();
     }
 }
 


### PR DESCRIPTION
This PR restores #4044 & #4043 which were reverted by #4090 & #4091 and fixes an issue in the compactor that was incorrectly exiting immediately when `join()`-ed - I've left this as a TODO as the compactor worker loop does not yet exist.

Closes #4089.

---

* fix: propagate shutdown into QuerierHandlerImpl (011d3fbf2)

      Prior to this commit, calling shutdown() on the QuerierServer (the server
      layer run by the iox binary) would cancel it's own CancellationToken, while
      the QuerierHandlerImpl (the actual querier workload entrypoint) would be
      watching it's own, different token.

      This commit removes the redundant CancellationToken in the QuerierServer,
      instead using the inner QueryHandlerImpl for cancellation notification &
      completion.

* fix: propagate shutdown into CompactorHandler (a4aedcf2a)

      Prior to this commit, calling shutdown() on the CompactorServerType (the 
      server layer run by the iox binary) would cancel it's own CancellationToken,
      while the CompactorHandler (the actual compaction workload entrypoint) would
      be watching it's own, different token.

      This commit removes the redundant CancellationToken in the 
      CompactorServerType, instead using the inner CompactorHandler for cancellation
      notification & completion.

* fix: compactor early shutdown (bf782de42)

      The compactor stub code would wait on nothing when the caller waited on 
      join()-ing the compactor handler, and this meant any caller who blocked on
      join() would immediately return.