### PR TITLE
fix: service limit http code

### DIFF
--- a/iox_catalog/src/interface.rs
+++ b/iox_catalog/src/interface.rs
@@ -15,16 +15,16 @@ use uuid::Uuid;
 #[derive(Debug, Snafu)]
 #[allow(missing_copy_implementations, missing_docs)]
 pub enum Error {
-    #[snafu(display("Name {} already exists", name))]
+    #[snafu(display("name {} already exists", name))]
     NameExists { name: String },
 
-    #[snafu(display("Unhandled sqlx error: {}", source))]
+    #[snafu(display("unhandled sqlx error: {}", source))]
     SqlxError { source: sqlx::Error },
 
-    #[snafu(display("Foreign key violation: {}", source))]
+    #[snafu(display("foreign key violation: {}", source))]
     ForeignKeyViolation { source: sqlx::Error },
 
-    #[snafu(display("Column {} is type {} but write has type {}", name, existing, new))]
+    #[snafu(display("column {} is type {} but write has type {}", name, existing, new))]
     ColumnTypeMismatch {
         name: String,
         existing: String,
@@ -32,7 +32,7 @@ pub enum Error {
     },
 
     #[snafu(display(
-        "Column type {} is in the db for column {}, which is unknown",
+        "column type {} is in the db for column {}, which is unknown",
         data_type,
         name
     ))]
@@ -82,10 +82,10 @@ pub enum Error {
         name: String,
     },
 
-    #[snafu(display("Cannot start a transaction: {}", source))]
+    #[snafu(display("cannot start a transaction: {}", source))]
     StartTransaction { source: sqlx::Error },
 
-    #[snafu(display("No transaction provided"))]
+    #[snafu(display("no transaction provided"))]
     NoTransaction,
 
     #[snafu(display(
@@ -98,10 +98,10 @@ pub enum Error {
         parquet_file_id: i64,
     },
 
-    #[snafu(display("Error while converting usize {} to i64", value))]
+    #[snafu(display("error while converting usize {} to i64", value))]
     InvalidValue { value: usize },
 
-    #[snafu(display("Datbase setup error: {}", source))]
+    #[snafu(display("database setup error: {}", source))]
     Setup { source: sqlx::Error },
 }
 

--- a/router2/tests/http.rs
+++ b/router2/tests/http.rs
@@ -267,7 +267,7 @@ async fn test_schema_conflict() {
         &err,
         router2::server::http::Error::DmlHandler(
             DmlError::Schema(
-                SchemaError::Validate(
+                SchemaError::Conflict(
                     iox_catalog::interface::Error::ColumnTypeMismatch {
                         name,
                         existing,
@@ -326,7 +326,7 @@ async fn test_schema_limit() {
         &err,
         router2::server::http::Error::DmlHandler(
             DmlError::Schema(
-                SchemaError::Validate(
+                SchemaError::ServiceLimit(
                     iox_catalog::interface::Error::TableCreateLimitError {
                         table_name,
                         namespace_id,


### PR DESCRIPTION
The service limits added in #3807 should return a "HTTP 429 Too Many Requests" error when they're reached.

Closes #4066.

---

* refactor: emit HTTP 429 for service limits (1edc4ca56)

      When a user hits the service limit, emit a "HTTP 429 Too Many Requests" error
      with no "Retry-After" header. Reference:

         
      https://docs.influxdata.com/influxdb/cloud/account-management/limits/#api-error-responses

* refactor: explicit schema validation errors (c6af2f593)

      This commit adds new service limit & schema conflict error variants to the
      SchemaError enum, allowing less error-prone matching higher up the stack and
      more explicit log messages for both.

      HTTP status codes are now correctly reported as 500 for internal catalog 
      errors during schema validation.

* refactor: lowercase error messages (8e85846db)

      Lowercases the error messages in the big iox_catalog Error enum for better
      composition of messages (no random capitalisation in glued-together strings,
      which is common with wrapped errors).