### PR TITLE
feat: Compute a sort key in the ingester

### DIFF
--- a/ingester/src/compact.rs
+++ b/ingester/src/compact.rs
@@ -301,7 +301,7 @@ mod tests {
             seq_num_end,
             3,
             INITIAL_COMPACTION_LEVEL,
-            None, // todo: this  will have value when #3968 is done
+            None, // todo: this will have value when #3968 is done
         );
         assert_eq!(expected_meta, meta);
     }

--- a/ingester/src/compact.rs
+++ b/ingester/src/compact.rs
@@ -309,7 +309,7 @@ mod tests {
             seq_num_end,
             3,
             INITIAL_COMPACTION_LEVEL,
-            None, // todo: this will have value when #3968 is done
+            Some(SortKey::from_columns(["tag1", "time"])),
         );
         assert_eq!(expected_meta, meta);
     }

--- a/ingester/src/compact.rs
+++ b/ingester/src/compact.rs
@@ -331,6 +331,7 @@ mod tests {
         assert_eq!(expected_pk, pk);
 
         let sort_key = compute_sort_key(&compact_batch);
+        assert_eq!(sort_key, SortKey::from_columns(["tag1", "time"]));
 
         // compact
         let exc = Executor::new(1);
@@ -371,6 +372,7 @@ mod tests {
         assert_eq!(expected_pk, pk);
 
         let sort_key = compute_sort_key(&compact_batch);
+        assert_eq!(sort_key, SortKey::from_columns(["tag1", "time"]));
 
         // compact
         let exc = Executor::new(1);
@@ -411,6 +413,7 @@ mod tests {
         assert_eq!(expected_pk, pk);
 
         let sort_key = compute_sort_key(&compact_batch);
+        assert_eq!(sort_key, SortKey::from_columns(["tag1", "time"]));
 
         // compact
         let exc = Executor::new(1);
@@ -456,6 +459,7 @@ mod tests {
         assert_eq!(expected_pk, pk);
 
         let sort_key = compute_sort_key(&compact_batch);
+        assert_eq!(sort_key, SortKey::from_columns(["tag1", "time"]));
 
         // compact
         let exc = Executor::new(1);
@@ -498,6 +502,7 @@ mod tests {
         assert_eq!(expected_pk, pk);
 
         let sort_key = compute_sort_key(&compact_batch);
+        assert_eq!(sort_key, SortKey::from_columns(["tag1", "tag2", "time"]));
 
         // compact
         let exc = Executor::new(1);
@@ -554,6 +559,7 @@ mod tests {
         assert_eq!(expected_pk, pk);
 
         let sort_key = compute_sort_key(&compact_batch);
+        assert_eq!(sort_key, SortKey::from_columns(["tag1", "tag2", "time"]));
 
         // compact
         let exc = Executor::new(1);
@@ -618,6 +624,7 @@ mod tests {
         assert_eq!(expected_pk, pk);
 
         let sort_key = compute_sort_key(&compact_batch);
+        assert_eq!(sort_key, SortKey::from_columns(["tag1", "tag2", "time"]));
 
         // compact
         let exc = Executor::new(1);
@@ -675,6 +682,7 @@ mod tests {
         assert_eq!(expected_pk, pk);
 
         let sort_key = compute_sort_key(&compact_batch);
+        assert_eq!(sort_key, SortKey::from_columns(["tag1", "tag2", "time"]));
 
         // compact
         let exc = Executor::new(1);

--- a/ingester/src/data.rs
+++ b/ingester/src/data.rs
@@ -1153,8 +1153,8 @@ impl DataBuffer {
     }
 }
 
-/// BufferBatch is a MutauableBatch with its ingesting order, sequencer_number, that
-/// helps the ingester keep the batches of data in thier ingesting order
+/// BufferBatch is a MutableBatch with its ingesting order, sequencer_number, that helps the
+/// ingester keep the batches of data in their ingesting order
 #[derive(Debug)]
 pub struct BufferBatch {
     /// Sequence number of the first write in this batch
@@ -1172,7 +1172,7 @@ pub struct SnapshotBatch {
     pub(crate) min_sequencer_number: SequenceNumber,
     /// Max sequencer number of its combined BufferBatches
     pub(crate) max_sequencer_number: SequenceNumber,
-    /// Data of its comebined BufferBatches kept in one RecordBatch
+    /// Data of its combined BufferBatches kept in one RecordBatch
     pub(crate) data: Arc<RecordBatch>,
 }
 
@@ -1209,13 +1209,13 @@ impl SnapshotBatch {
 /// a parquet file for given set of SnapshotBatches
 #[derive(Debug, PartialEq, Clone)]
 pub struct PersistingBatch {
-    /// Sesquencer id of the data
+    /// Sequencer id of the data
     pub(crate) sequencer_id: SequencerId,
 
     /// Table id of the data
     pub(crate) table_id: TableId,
 
-    /// Parittion Id of the data
+    /// Partition Id of the data
     pub(crate) partition_id: PartitionId,
 
     /// Id of to-be-created parquet file of this data

--- a/ingester/src/lib.rs
+++ b/ingester/src/lib.rs
@@ -24,6 +24,7 @@ mod poison;
 pub mod querier_handler;
 pub mod query;
 pub mod server;
+pub mod sort_key;
 
 #[cfg(test)]
 pub mod test_util;

--- a/ingester/src/sort_key.rs
+++ b/ingester/src/sort_key.rs
@@ -1,0 +1,13 @@
+//! Functions for computing a sort key based on cardinality of primary key columns.
+
+use crate::data::QueryableBatch;
+use schema::sort::SortKey;
+
+/// Given a `QueryableBatch`, compute a sort key based on:
+///
+/// - The columns that make up the primary key of the schema of this batch
+/// - Order those columns from low cardinality to high cardinality based on the data
+/// - Always have the time column last
+pub fn compute_sort_key(_queryable_batch: &QueryableBatch) -> SortKey {
+    unimplemented!()
+}

--- a/ingester/src/sort_key.rs
+++ b/ingester/src/sort_key.rs
@@ -1,13 +1,107 @@
 //! Functions for computing a sort key based on cardinality of primary key columns.
 
-use crate::data::QueryableBatch;
-use schema::sort::SortKey;
+use crate::data::{QueryableBatch, SnapshotBatch};
+use observability_deps::tracing::trace;
+use query::QueryChunkMeta;
+use schema::{
+    sort::{SortKey, SortKeyBuilder},
+    TIME_COLUMN_NAME,
+};
+use std::{collections::HashMap, num::NonZeroU64, sync::Arc};
 
 /// Given a `QueryableBatch`, compute a sort key based on:
 ///
 /// - The columns that make up the primary key of the schema of this batch
 /// - Order those columns from low cardinality to high cardinality based on the data
 /// - Always have the time column last
-pub fn compute_sort_key(_queryable_batch: &QueryableBatch) -> SortKey {
-    unimplemented!()
+pub fn compute_sort_key(queryable_batch: &QueryableBatch) -> SortKey {
+    let schema = queryable_batch.schema();
+    let primary_key = schema.primary_key();
+
+    let cardinalities = distinct_counts(&queryable_batch.data, &primary_key);
+
+    trace!(cardinalities=?cardinalities, "cardinalities of of columns to compute sort key");
+
+    let mut cardinalities: Vec<_> = cardinalities.into_iter().collect();
+    // Sort by (cardinality, column_name) to have deterministic order if same cardinality
+    cardinalities.sort_by_cached_key(|x| (x.1, x.0.clone()));
+
+    let mut builder = SortKeyBuilder::with_capacity(cardinalities.len() + 1);
+    for (col, _) in cardinalities {
+        builder = builder.with_col(col)
+    }
+    builder = builder.with_col(TIME_COLUMN_NAME);
+
+    let key = builder.build();
+
+    trace!(computed_sort_key=?key, "Value of sort key from compute_sort_key");
+
+    key
+}
+
+/// Takes batches of data and the columns that make up the primary key. Computes the number of
+/// distinct values for each primary key column across all batches, also known as "cardinality".
+/// Used to determine sort order.
+fn distinct_counts(
+    _batches: &[Arc<SnapshotBatch>],
+    _primary_key: &[&str],
+) -> HashMap<String, NonZeroU64> {
+    HashMap::new()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use data_types2::SequenceNumber;
+    use schema::selection::Selection;
+
+    fn lp_to_queryable_batch(line_protocol_batches: &[&str]) -> QueryableBatch {
+        let data = line_protocol_batches
+            .iter()
+            .map(|line_protocol| {
+                let (_, mb) = mutable_batch_lp::test_helpers::lp_to_mutable_batch(line_protocol);
+                let rb = mb.to_arrow(Selection::All).unwrap();
+
+                Arc::new(SnapshotBatch {
+                    min_sequencer_number: SequenceNumber::new(0),
+                    max_sequencer_number: SequenceNumber::new(1),
+                    data: Arc::new(rb),
+                })
+            })
+            .collect();
+
+        QueryableBatch {
+            data,
+            delete_predicates: Default::default(),
+            table_name: Default::default(),
+        }
+    }
+
+    #[test]
+    fn test_sort_key() {
+        // Across these three record batches:
+        // - `host` has 2 distinct values: "a", "b"
+        // - 'env' has 3 distinct values: "prod", "stage", "dev"
+        // host's 2 values appear in each record batch, so the distinct counts could be incorrectly
+        // aggregated together as 2 + 2 + 2 = 6. env's 3 values each occur in their own record
+        // batch, so they should always be aggregated as 3.
+        // host has the lower cardinality, so it should appear first in the sort key.
+        let lp1 = r#"
+            cpu,host=a,env=prod val=23 1
+            cpu,host=b,env=prod val=2 2
+        "#;
+        let lp2 = r#"
+            cpu,host=a,env=stage val=23 3
+            cpu,host=b,env=stage val=2 4
+        "#;
+        let lp3 = r#"
+            cpu,host=a,env=dev val=23 5
+            cpu,host=b,env=dev val=2 6
+        "#;
+        let qb = lp_to_queryable_batch(&[lp1, lp2, lp3]);
+
+        let sort_key = compute_sort_key(&qb);
+
+        assert_eq!(sort_key, SortKey::from_columns(["host", "env", "time"]));
+    }
 }

--- a/query/src/lib.rs
+++ b/query/src/lib.rs
@@ -270,7 +270,7 @@ pub fn chunks_have_stats(chunks: &[Arc<dyn QueryChunk>]) -> bool {
 
 pub fn compute_sort_key_for_chunks(schema: &Schema, chunks: &[Arc<dyn QueryChunk>]) -> SortKey {
     if !chunks_have_stats(chunks) {
-        // chunks have not enough stats, return its  pk that is
+        // chunks have not enough stats, return its pk that is
         // sorted lexicographically but time column always last
         SortKey::from_columns(schema.primary_key())
     } else {


### PR DESCRIPTION
Fixes #4194.

I have now SPLIT #3968 into 3 parts, so this PR now only contains the *computation* of the sort key. It does *not* cover storing the sort key in the catalog (now #4195) or checking and potentially updating the sort key (now #4196).
