### PR TITLE
feat: schema validation metrics

### DIFF
--- a/ioxd/src/server_type/router2.rs
+++ b/ioxd/src/server_type/router2.rs
@@ -169,7 +169,8 @@ pub async fn create_router2_server_type(
     ));
 
     // Initialise and instrument the schema validator
-    let schema_validator = SchemaValidator::new(Arc::clone(&catalog), Arc::clone(&ns_cache));
+    let schema_validator =
+        SchemaValidator::new(Arc::clone(&catalog), Arc::clone(&ns_cache), &*metrics);
     let schema_validator =
         InstrumentationDecorator::new("schema_validator", Arc::clone(&metrics), schema_validator);
 

--- a/router2/benches/e2e.rs
+++ b/router2/benches/e2e.rs
@@ -60,7 +60,8 @@ fn e2e_benchmarks(c: &mut Criterion) {
         ));
 
         let write_buffer = init_write_buffer(1);
-        let schema_validator = SchemaValidator::new(Arc::clone(&catalog), Arc::clone(&ns_cache));
+        let schema_validator =
+            SchemaValidator::new(Arc::clone(&catalog), Arc::clone(&ns_cache), &*metrics);
         let partitioner = Partitioner::new(PartitionTemplate {
             parts: vec![TemplatePart::TimeFormat("%Y-%m-%d".to_owned())],
         });

--- a/router2/benches/schema_validator.rs
+++ b/router2/benches/schema_validator.rs
@@ -46,7 +46,7 @@ fn bench(group: &mut BenchmarkGroup<WallTime>, tables: usize, columns_per_table:
     let ns_cache = Arc::new(ShardedCache::new(
         iter::repeat_with(|| Arc::new(MemoryNamespaceCache::default())).take(10),
     ));
-    let validator = SchemaValidator::new(catalog, ns_cache);
+    let validator = SchemaValidator::new(catalog, ns_cache, &*metrics);
 
     for i in 0..65_000 {
         let write = lp_to_writes(format!("{}{}", i + 10_000_000, generate_lp(1, 1)).as_str());

--- a/router2/src/dml_handlers/instrumentation.rs
+++ b/router2/src/dml_handlers/instrumentation.rs
@@ -2,7 +2,6 @@ use super::DmlHandler;
 use async_trait::async_trait;
 use data_types2::{DatabaseName, DeletePredicate};
 use metric::{Metric, U64Histogram, U64HistogramOptions};
-use std::sync::Arc;
 use time::{SystemProvider, TimeProvider};
 use trace::{ctx::SpanContext, span::SpanRecorder};
 
@@ -27,7 +26,7 @@ pub struct InstrumentationDecorator<T, P = SystemProvider> {
 impl<T> InstrumentationDecorator<T> {
     /// Wrap a new [`InstrumentationDecorator`] over `T` exposing metrics
     /// labelled with `handler=name`.
-    pub fn new(name: &'static str, registry: Arc<metric::Registry>, inner: T) -> Self {
+    pub fn new(name: &'static str, registry: &metric::Registry, inner: T) -> Self {
         let buckets = || {
             U64HistogramOptions::new([
                 5,
@@ -215,7 +214,7 @@ mod tests {
         let traces: Arc<dyn TraceCollector> = Arc::new(RingBufferTraceCollector::new(5));
         let span = SpanContext::new(Arc::clone(&traces));
 
-        let decorator = InstrumentationDecorator::new(HANDLER_NAME, Arc::clone(&metrics), handler);
+        let decorator = InstrumentationDecorator::new(HANDLER_NAME, &*metrics, handler);
 
         decorator
             .write(&ns, (), Some(span))
@@ -238,7 +237,7 @@ mod tests {
         let traces: Arc<dyn TraceCollector> = Arc::new(RingBufferTraceCollector::new(5));
         let span = SpanContext::new(Arc::clone(&traces));
 
-        let decorator = InstrumentationDecorator::new(HANDLER_NAME, Arc::clone(&metrics), handler);
+        let decorator = InstrumentationDecorator::new(HANDLER_NAME, &*metrics, handler);
 
         let err = decorator
             .write(&ns, (), Some(span))
@@ -260,7 +259,7 @@ mod tests {
         let traces: Arc<dyn TraceCollector> = Arc::new(RingBufferTraceCollector::new(5));
         let span = SpanContext::new(Arc::clone(&traces));
 
-        let decorator = InstrumentationDecorator::new(HANDLER_NAME, Arc::clone(&metrics), handler);
+        let decorator = InstrumentationDecorator::new(HANDLER_NAME, &*metrics, handler);
 
         let pred = DeletePredicate {
             range: TimestampRange::new(1, 2),
@@ -288,7 +287,7 @@ mod tests {
         let traces: Arc<dyn TraceCollector> = Arc::new(RingBufferTraceCollector::new(5));
         let span = SpanContext::new(Arc::clone(&traces));
 
-        let decorator = InstrumentationDecorator::new(HANDLER_NAME, Arc::clone(&metrics), handler);
+        let decorator = InstrumentationDecorator::new(HANDLER_NAME, &*metrics, handler);
 
         let pred = DeletePredicate {
             range: TimestampRange::new(1, 2),

--- a/router2/tests/http.rs
+++ b/router2/tests/http.rs
@@ -111,8 +111,7 @@ impl TestContext {
             .and_then(partitioner)
             .and_then(FanOutAdaptor::new(sharded_write_buffer));
 
-        let handler_stack =
-            InstrumentationDecorator::new("request", Arc::clone(&metrics), handler_stack);
+        let handler_stack = InstrumentationDecorator::new("request", &*metrics, handler_stack);
 
         let delegate = HttpDelegate::new(1024, Arc::new(handler_stack), &metrics);
 

--- a/router2/tests/http.rs
+++ b/router2/tests/http.rs
@@ -101,7 +101,7 @@ impl TestContext {
             iox_catalog::INFINITE_RETENTION_POLICY.to_owned(),
         );
 
-        let schema_validator = SchemaValidator::new(Arc::clone(&catalog), ns_cache);
+        let schema_validator = SchemaValidator::new(Arc::clone(&catalog), ns_cache, &*metrics);
         let partitioner = Partitioner::new(PartitionTemplate {
             parts: vec![TemplatePart::TimeFormat("%Y-%m-%d".to_owned())],
         });


### PR DESCRIPTION
Records metrics for two client-driven request failures:

* Schema validation failure (request conflicts with existing table schema)
* Service limits reached

This lets us measure the frequency of these events and take remedial action (such as bumping service limits) if needed.

---

* feat: schema validation conflict/limit metrics (91730d6a1)

      Emit metric counters tracking the number of schema conflicts, and number of
      service limit errors observed.

* refactor(router2): no Arc for instrumentation (bc01121c5)

      Removes needless Arc for the InstrumentationDecorator.