### PR TITLE
refactor: handle errors in ingester stream handler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2323,6 +2323,7 @@ dependencies = [
  "parking_lot 0.12.0",
  "parquet",
  "parquet_file",
+ "paste",
  "pin-project",
  "predicate",
  "prost 0.9.0",
@@ -2333,6 +2334,7 @@ dependencies = [
  "thiserror",
  "time 0.1.0",
  "tokio",
+ "tokio-stream",
  "tokio-util 0.7.1",
  "tonic",
  "trace",
@@ -5890,10 +5892,12 @@ checksum = "507e9898683b6c43a9aa55b64259b721b52ba226e0f3779137e50ad114a4c90b"
 name = "test_helpers"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "dotenv",
  "observability_deps",
  "parking_lot 0.12.0",
  "tempfile",
+ "tokio",
  "tracing-log",
  "tracing-subscriber",
  "workspace-hack",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2315,6 +2315,7 @@ dependencies = [
  "hyper",
  "iox_catalog",
  "iox_object_store",
+ "lazy_static",
  "metric",
  "mutable_batch",
  "mutable_batch_lp",

--- a/ingester/Cargo.toml
+++ b/ingester/Cargo.toml
@@ -50,4 +50,7 @@ trace = { path = "../trace" }
 [dev-dependencies]
 assert_matches = "1.5.0"
 bitflags = {version = "1.3.2"}
-test_helpers = { path = "../test_helpers" }
+lazy_static = "1.4.0"
+paste = "1.0.7"
+test_helpers = { path = "../test_helpers", features = ["future_timeout"] }
+tokio-stream = {version = "0.1.8", default_features = false }

--- a/ingester/src/lib.rs
+++ b/ingester/src/lib.rs
@@ -25,6 +25,7 @@ pub mod querier_handler;
 pub mod query;
 pub mod server;
 pub mod sort_key;
+pub mod stream_handler;
 
 #[cfg(test)]
 pub mod test_util;

--- a/ingester/src/stream_handler/handler.rs
+++ b/ingester/src/stream_handler/handler.rs
@@ -1,0 +1,616 @@
+use std::{fmt::Debug, time::Duration};
+
+use data_types2::KafkaPartition;
+use dml::DmlOperation;
+use futures::{pin_mut, FutureExt, Stream, StreamExt};
+use metric::{Attributes, U64Counter, U64Gauge};
+use observability_deps::tracing::*;
+use time::{SystemProvider, TimeProvider};
+use tokio_util::sync::CancellationToken;
+use write_buffer::core::{WriteBufferError, WriteBufferErrorKind};
+
+use crate::lifecycle::LifecycleHandle;
+
+use super::DmlSink;
+
+/// When the [`LifecycleManager`] indicates that ingest should be paused because
+/// of memory pressure, the sequencer will loop, sleeping this long between
+/// calls to [`LifecycleHandle::can_resume_ingest()`] with the manager if it
+/// can resume ingest.
+///
+/// [`LifecycleManager`]: crate::lifecycle::LifecycleManager
+/// [`LifecycleHandle::can_resume_ingest()`]: crate::lifecycle::LifecycleHandle::can_resume_ingest()
+const INGEST_POLL_INTERVAL: Duration = Duration::from_millis(100);
+
+/// A [`SequencedStreamHandler`] consumes a sequence of [`DmlOperation`] from a
+/// sequencer stream and pushes them into the configured [`DmlSink`].
+///
+/// Ingest reads are rate limited by the [`LifecycleManager`] it is initialised
+/// by, pausing until the [`LifecycleHandle::can_resume_ingest()`] obtained from
+/// it returns true, and TTBR / error metrics are emitted on a per-sequencer
+/// basis.
+///
+/// [`LifecycleManager`]: crate::lifecycle::LifecycleManager
+/// [`LifecycleHandle::can_resume_ingest()`]: crate::lifecycle::LifecycleHandle::can_resume_ingest()
+#[derive(Debug)]
+pub struct SequencedStreamHandler<I, O, T = SystemProvider> {
+    /// A input stream of DML ops
+    stream: I,
+    /// An output sink that processes DML operations and applies them to
+    /// in-memory state.
+    sink: O,
+
+    /// A handle to the [`LifecycleManager`] singleton that may periodically
+    /// request ingest be paused to control memory pressure.
+    ///
+    /// [`LifecycleManager`]: crate::lifecycle::LifecycleManager
+    lifecycle_handle: LifecycleHandle,
+
+    // Metrics
+    time_provider: T,
+    time_to_be_readable_ms: U64Gauge,
+    /// Duration of time ingest is paused at the request of the LifecycleManager
+    pause_duration_ms: U64Counter,
+
+    /// Log context fields - otherwise unused.
+    kafka_topic_name: String,
+    kafka_partition: KafkaPartition,
+}
+
+impl<I, O> SequencedStreamHandler<I, O> {
+    /// Initialise a new [`SequencedStreamHandler`], consuming from `stream` and
+    /// dispatching successfully decoded [`DmlOperation`] instances to `sink`.
+    ///
+    /// A [`SequencedStreamHandler`] starts actively consuming items from
+    /// `stream` once [`SequencedStreamHandler::run()`] is called, and
+    /// gracefully stops when `shutdown` is cancelled.
+    pub fn new(
+        stream: I,
+        sink: O,
+        lifecycle_handle: LifecycleHandle,
+        kafka_topic_name: String,
+        kafka_partition: KafkaPartition,
+        metrics: &metric::Registry,
+    ) -> Self {
+        let attributes = Attributes::from([
+            ("sequencer_id", kafka_partition.to_string().into()),
+            ("kafka_topic", kafka_topic_name.clone().into()),
+        ]);
+        let time_to_be_readable_ms = metrics.register_metric::<U64Gauge>(
+            "ingester_ttbr_ms",
+            "duration of time between producer writing to consumer putting into queryable cache in milliseconds",
+        ).recorder(attributes.clone());
+
+        let pause_duration_ms = metrics.register_metric::<U64Counter>(
+            "ingest_paused_duration_ms_total",
+            "duration of time ingestion has been paused by the lifecycle manager in milliseconds",
+        ).recorder(&[]);
+
+        Self {
+            stream,
+            sink,
+            lifecycle_handle,
+            time_provider: SystemProvider::default(),
+            time_to_be_readable_ms,
+            pause_duration_ms,
+            kafka_topic_name,
+            kafka_partition,
+        }
+    }
+
+    /// Switch to the specified [`TimeProvider`] implementation.
+    #[cfg(test)]
+    pub(crate) fn with_time_provider<T>(self, provider: T) -> SequencedStreamHandler<I, O, T> {
+        SequencedStreamHandler {
+            stream: self.stream,
+            sink: self.sink,
+            lifecycle_handle: self.lifecycle_handle,
+            time_provider: provider,
+            time_to_be_readable_ms: self.time_to_be_readable_ms,
+            pause_duration_ms: self.pause_duration_ms,
+            kafka_topic_name: self.kafka_topic_name,
+            kafka_partition: self.kafka_partition,
+        }
+    }
+}
+
+impl<I, O, T> SequencedStreamHandler<I, O, T>
+where
+    I: Stream<Item = Result<DmlOperation, WriteBufferError>> + Unpin + Send + Sync,
+    O: DmlSink,
+    T: TimeProvider,
+{
+    /// Run the stream handler, consuming items from [`Stream`] and applying
+    /// them to the [`DmlSink`].
+    ///
+    /// This method blocks until gracefully shutdown by cancelling the
+    /// `shutdown` [`CancellationToken`]. Once cancelled, this handler will
+    /// complete the current operation it is
+    ///
+    /// # Panics
+    ///
+    /// This method panics if the input stream ends (yields a `None`).
+    pub async fn run(mut self, shutdown: CancellationToken) {
+        let shutdown_fut = shutdown.cancelled().fuse();
+        pin_mut!(shutdown_fut);
+
+        loop {
+            // Wait for a DML operation from the sequencer, or a graceful stop
+            // signal.
+            let maybe_op = futures::select!(
+                next = self.stream.next().fuse() => next,
+                _ = shutdown_fut => {
+                    info!(
+                        kafka_topic=%self.kafka_topic_name,
+                        kafka_partition=%self.kafka_partition,
+                        "stream handler shutdown",
+                    );
+                    return;
+                }
+            );
+
+            // Read a DML op from the write buffer, logging and emitting metrics
+            // for any potential errors to enable alerting on potential data
+            // loss.
+            //
+            // If this evaluation results in no viable DML op to apply to the
+            // DmlSink, return None rather than continuing the loop to ensure
+            // ingest pauses are respected.
+            let maybe_op = match maybe_op {
+                Some(Ok(op)) => Some(op),
+                Some(Err(e)) if e.kind() == WriteBufferErrorKind::UnknownSequenceNumber => {
+                    error!(
+                        error=%e,
+                        kafka_topic=%self.kafka_topic_name,
+                        kafka_partition=%self.kafka_partition,
+                        potential_data_loss=true,
+                        "unable to read from desired sequencer offset"
+                    );
+                    // TODO: emit metric
+                    None
+                }
+                Some(Err(e)) if e.kind() == WriteBufferErrorKind::IO => {
+                    warn!(
+                        error=%e,
+                        kafka_topic=%self.kafka_topic_name,
+                        kafka_partition=%self.kafka_partition,
+                        "I/O error reading from sequencer"
+                    );
+                    tokio::time::sleep(Duration::from_secs(1)).await;
+                    None
+                }
+                Some(Err(e)) if e.kind() == WriteBufferErrorKind::InvalidData => {
+                    // The DmlOperation could not be de-serialised from the
+                    // kafka message.
+                    //
+                    // This is almost certainly data loss as the write will not
+                    // be applied/persisted.
+                    error!(
+                        error=%e,
+                        kafka_topic=%self.kafka_topic_name,
+                        kafka_partition=%self.kafka_partition,
+                        potential_data_loss=true,
+                        "unable to deserialise dml operation"
+                    );
+
+                    // TODO: emit metric
+                    None
+                }
+                Some(Err(e)) => {
+                    error!(
+                        error=%e,
+                        kafka_topic=%self.kafka_topic_name,
+                        kafka_partition=%self.kafka_partition,
+                        potential_data_loss=true,
+                        "unhandled error converting write buffer data to DmlOperation",
+                    );
+                    // TODO: emit metric
+                    tokio::time::sleep(Duration::from_secs(1)).await;
+                    None
+                }
+                None => {
+                    panic!(
+                        "sequencer {:?} stream for topic {} ended without graceful shutdown",
+                        self.kafka_partition, self.kafka_topic_name
+                    );
+                }
+            };
+
+            // If a DML operation was successfully decoded, push it into the
+            // DmlSink.
+            self.maybe_apply_op(maybe_op).await;
+        }
+    }
+
+    async fn maybe_apply_op(&self, op: Option<DmlOperation>) {
+        if let Some(op) = op {
+            // Extract the producer timestamp (added in the router when
+            // dispatching the request).
+            let produced_at = op.meta().producer_ts();
+
+            let should_pause = match self.sink.apply(op).await {
+                Ok(should_pause) => {
+                    trace!(
+                        kafka_topic=%self.kafka_topic_name,
+                        kafka_partition=%self.kafka_partition,
+                        "successfully applied dml operation"
+                    );
+                    should_pause
+                }
+                Err(e) => {
+                    error!(
+                        error=%e,
+                        kafka_topic=%self.kafka_topic_name,
+                        kafka_partition=%self.kafka_partition,
+                        potential_data_loss=true,
+                        "failed to apply dml operation"
+                    );
+                    // TODO: emit metric
+                    return;
+                }
+            };
+
+            // Update the TTBR metric before potentially sleeping.
+            if let Some(delta) =
+                produced_at.and_then(|ts| self.time_provider.now().checked_duration_since(ts))
+            {
+                self.time_to_be_readable_ms.set(delta.as_millis() as u64);
+            }
+
+            if should_pause {
+                // The lifecycle manager may temporarily pause ingest - wait for
+                // persist operations to shed memory pressure if needed.
+                self.pause_ingest().await;
+            }
+        }
+    }
+
+    async fn pause_ingest(&self) {
+        // Record how long this pause is, for logging purposes.
+        let started_at = self.time_provider.now();
+
+        warn!(
+            kafka_topic=%self.kafka_topic_name,
+            kafka_partition=%self.kafka_partition,
+            "pausing ingest until persistence has run"
+        );
+        while !self.lifecycle_handle.can_resume_ingest() {
+            // Incrementally report on the sleeps (as opposed to
+            // measuring the start/end duration) in order to report
+            // a blocked ingester _before_ it recovers.
+            //
+            // While the actual sleep may be slightly longer than
+            // INGEST_POLL_INTERVAL, it's not likely to be a useful
+            // distinction in the metrics.
+            self.pause_duration_ms
+                .inc(INGEST_POLL_INTERVAL.as_millis() as _);
+
+            tokio::time::sleep(INGEST_POLL_INTERVAL).await;
+        }
+
+        let duration_str = self
+            .time_provider
+            .now()
+            .checked_duration_since(started_at)
+            .map(|v| format!("{}ms", v.as_millis()))
+            .unwrap_or_else(|| "unknown".to_string());
+
+        info!(
+            kafka_topic=%self.kafka_topic_name,
+            kafka_partition=%self.kafka_partition,
+            pause_duration=%duration_str,
+            "resuming ingest"
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use super::*;
+    use crate::{
+        lifecycle::{LifecycleConfig, LifecycleManager},
+        stream_handler::mock_sink::MockDmlSink,
+    };
+    use assert_matches::assert_matches;
+    use data_types2::{DeletePredicate, Sequence, TimestampRange};
+    use dml::{DmlDelete, DmlMeta, DmlWrite};
+    use futures::stream;
+    use metric::Metric;
+    use mutable_batch_lp::lines_to_batches;
+    use test_helpers::timeout::FutureTimeout;
+    use time::{SystemProvider, Time};
+    use tokio::sync::mpsc;
+    use tokio_stream::wrappers::ReceiverStream;
+
+    lazy_static::lazy_static! {
+        static ref TEST_TIME: Time = SystemProvider::default().now();
+    }
+
+    // Return a DmlWrite with the given namespace and a single table.
+    fn make_write(name: impl Into<String>, ttbr: u64) -> DmlWrite {
+        let tables = lines_to_batches("bananas level=42 4242", 0).unwrap();
+        let sequence = DmlMeta::sequenced(
+            Sequence::new(1, 2),
+            TEST_TIME.checked_sub(Duration::from_millis(ttbr)).unwrap(),
+            None,
+            42,
+        );
+        DmlWrite::new(name, tables, sequence)
+    }
+
+    // Return a DmlDelete with the given namespace.
+    fn make_delete(name: impl Into<String>, ttbr: u64) -> DmlDelete {
+        let pred = DeletePredicate {
+            range: TimestampRange::new(1, 2),
+            exprs: vec![],
+        };
+        let sequence = DmlMeta::sequenced(
+            Sequence::new(1, 2),
+            TEST_TIME.checked_sub(Duration::from_millis(ttbr)).unwrap(),
+            None,
+            42,
+        );
+        DmlDelete::new(name, pred, None, sequence)
+    }
+
+    // Generates a test that ensures that the handler given $stream_ops makes
+    // $want_sink calls.
+    //
+    // Additionally all test cases assert the handler does not panic, and the
+    // handler gracefully shuts down after the test input sequence is exhausted.
+    macro_rules! test_stream_handler {
+        (
+            $name:ident,
+            stream_ops = $stream_ops:expr,  // An ordered set of stream items to feed to the handler
+            sink_rets = $sink_ret:expr,     // An ordered set of values to return from the mock op sink
+            want_ttbr = $want_ttbr:literal, // Desired TTBR value in milliseconds
+            want_sink = $($want_sink:tt)+   // A pattern to match against the calls made to the op sink
+        ) => {
+            paste::paste! {
+                #[tokio::test]
+                async fn [<test_stream_handler_ $name>]() {
+                    let metrics = Arc::new(metric::Registry::default());
+                    let time_provider: Arc< dyn TimeProvider> = Arc::new(SystemProvider::default());
+                    let lifecycle = LifecycleManager::new(
+                        LifecycleConfig::new(100, 2, 3, Duration::from_secs(4), Duration::from_secs(5)),
+                        Arc::clone(&metrics),
+                        time_provider,
+                    );
+
+                    // The DML sink that records ops.
+                    let sink = Arc::new(
+                        MockDmlSink::default()
+                            .with_apply_return($sink_ret)
+                    );
+
+                    // Create an channel to pass input to the handler, with a
+                    // buffer capacity of 1 (used below).
+                    let (tx, rx) = mpsc::channel(1);
+
+                    let handler = SequencedStreamHandler::new(
+                        ReceiverStream::new(rx),
+                        Arc::clone(&sink),
+                        lifecycle.handle(),
+                        "kafka_topic_name".to_string(),
+                        KafkaPartition::new(42),
+                        &*metrics,
+                    ).with_time_provider(time::MockProvider::new(*TEST_TIME));
+
+                    // Run the handler in the background and push inputs to it
+                    let shutdown = CancellationToken::default();
+                    let handler_shutdown = shutdown.child_token();
+                    let handler = tokio::spawn(async move {
+                        handler.run(handler_shutdown).await;
+                    });
+
+                    // Push the input one at a time, wait for the the last
+                    // message to be consumed by the handler (channel capacity
+                    // increases to 1 once the message is read) and then request
+                    // a graceful shutdown.
+                    for op in $stream_ops {
+                        tx.send(op)
+                            .with_timeout_panic(Duration::from_secs(5))
+                            .await
+                            .expect("early handler exit");
+                    }
+                    // Wait for the handler to read the last op, restoring the
+                    // capacity to 1.
+                    let _permit = tx.reserve()
+                        .with_timeout_panic(Duration::from_secs(5))
+                        .await
+                        .expect("early handler exit");
+
+                    // Trigger graceful shutdown
+                    shutdown.cancel();
+
+                    // And wait for the handler to stop.
+                    handler.with_timeout_panic(Duration::from_secs(5))
+                        .await
+                        .expect("handler did not shutdown");
+
+                    // Assert the calls into the DML sink are as expected
+                    let calls = sink.get_calls();
+                    assert_matches!(calls.as_slice(), $($want_sink)+);
+
+                    // Assert the TTBR metric value
+                    let ttbr = metrics
+                        .get_instrument::<Metric<U64Gauge>>("ingester_ttbr_ms")
+                        .expect("did not find ttbr metric")
+                        .get_observer(&Attributes::from(&[
+                            ("kafka_topic", "kafka_topic_name"),
+                            ("sequencer_id", "42"),
+                        ]))
+                        .expect("did not match metric attributes")
+                        .fetch();
+                    assert_eq!(ttbr, $want_ttbr);
+                }
+            }
+        };
+    }
+
+    test_stream_handler!(
+        immediate_shutdown,
+        stream_ops = [],
+        sink_rets = [],
+        want_ttbr = 0, // No ops, no TTBR
+        want_sink = []
+    );
+
+    // Single write op applies OK, then shutdown.
+    test_stream_handler!(
+        write_ok,
+        stream_ops = [
+            Ok(DmlOperation::Write(make_write("bananas", 42)))
+        ],
+        sink_rets = [Ok(true)],
+        want_ttbr = 42,
+        want_sink = [DmlOperation::Write(op)] => {
+            assert_eq!(op.namespace(), "bananas");
+        }
+    );
+
+    // Single delete op applies OK, then shutdown.
+    test_stream_handler!(
+        delete_ok,
+        stream_ops = [
+            Ok(DmlOperation::Delete(make_delete("platanos", 24)))
+        ],
+        sink_rets = [Ok(true)],
+        want_ttbr = 24,
+        want_sink = [DmlOperation::Delete(op)] => {
+            assert_eq!(op.namespace(), "platanos");
+        }
+    );
+
+    // An error reading from the sequencer stream is processed and does not
+    // affect the next op in the stream.
+    test_stream_handler!(
+        non_fatal_stream_io_error,
+        stream_ops = [
+            Err(WriteBufferError::new(WriteBufferErrorKind::IO, "explosions")),
+            Ok(DmlOperation::Write(make_write("bananas", 13)))
+        ],
+        sink_rets = [Ok(true)],
+        want_ttbr = 13,
+        want_sink = [DmlOperation::Write(op)] => {
+            assert_eq!(op.namespace(), "bananas");
+        }
+    );
+    test_stream_handler!(
+        non_fatal_stream_offset_error,
+        stream_ops = [
+            Err(WriteBufferError::new(WriteBufferErrorKind::UnknownSequenceNumber, "explosions")),
+            Ok(DmlOperation::Write(make_write("bananas", 31)))
+        ],
+        sink_rets = [Ok(true)],
+        want_ttbr = 31,
+        want_sink = [DmlOperation::Write(op)] => {
+            assert_eq!(op.namespace(), "bananas");
+        }
+    );
+    test_stream_handler!(
+        non_fatal_stream_invalid_data,
+        stream_ops = [
+            Err(WriteBufferError::new(WriteBufferErrorKind::InvalidData, "explosions")),
+            Ok(DmlOperation::Write(make_write("bananas", 50)))
+        ],
+        sink_rets = [Ok(true)],
+        want_ttbr = 50,
+        want_sink = [DmlOperation::Write(op)] => {
+            assert_eq!(op.namespace(), "bananas");
+        }
+    );
+    test_stream_handler!(
+        non_fatal_stream_unknown_error,
+        stream_ops = [
+            Err(WriteBufferError::new(WriteBufferErrorKind::Unknown, "explosions")),
+            Ok(DmlOperation::Write(make_write("bananas", 60)))
+        ],
+        sink_rets = [Ok(true)],
+        want_ttbr = 60,
+        want_sink = [DmlOperation::Write(op)] => {
+            assert_eq!(op.namespace(), "bananas");
+        }
+    );
+
+    // Asserts the TTBR is not set unless an op is successfully sunk.
+    test_stream_handler!(
+        no_success_no_ttbr,
+        stream_ops = [Err(WriteBufferError::new(
+            WriteBufferErrorKind::IO,
+            "explosions"
+        )),],
+        sink_rets = [],
+        want_ttbr = 0,
+        want_sink = []
+    );
+
+    // Asserts the TTBR is uses the last value in the stream.
+    test_stream_handler!(
+        reports_last_ttbr,
+        stream_ops = [
+            Ok(DmlOperation::Write(make_write("bananas", 1))),
+            Ok(DmlOperation::Write(make_write("bananas", 2))),
+            Ok(DmlOperation::Write(make_write("bananas", 3))),
+            Ok(DmlOperation::Write(make_write("bananas", 42))),
+        ],
+        sink_rets = [Ok(true), Ok(false), Ok(true), Ok(false),],
+        want_ttbr = 42,
+        want_sink = _
+    );
+
+    // An error applying an op to the DmlSink is non-fatal and does not prevent
+    // the next op in the stream from being processed.
+    test_stream_handler!(
+        non_fatal_sink_error,
+        stream_ops = [
+            Ok(DmlOperation::Write(make_write("bad_op", 1))),
+            Ok(DmlOperation::Write(make_write("good_op", 2)))
+        ],
+        sink_rets = [
+            Err(crate::data::Error::TimeColumnNotPresent),
+            Ok(true),
+        ],
+        want_ttbr = 2,
+        want_sink = [
+            DmlOperation::Write(_),  // First call into sink is bad_op, returning an error
+            DmlOperation::Write(op), // Second call succeeds
+        ] => {
+            assert_eq!(op.namespace(), "good_op");
+        }
+    );
+
+    // An abnormal end to the steam causes a panic, rather than a silent stream
+    // reader exit.
+    #[tokio::test]
+    #[should_panic = "sequencer KafkaPartition(42) stream for topic kafka_topic_name ended without graceful shutdown"]
+    async fn test_early_stream_end_panic() {
+        let metrics = Arc::new(metric::Registry::default());
+        let time_provider = Arc::new(SystemProvider::default());
+        let lifecycle = LifecycleManager::new(
+            LifecycleConfig::new(100, 2, 3, Duration::from_secs(4), Duration::from_secs(5)),
+            Arc::clone(&metrics),
+            time_provider,
+        );
+
+        // An empty stream iter immediately yields none.
+        let stream = stream::iter([]);
+        let sink = MockDmlSink::default();
+
+        let handler = SequencedStreamHandler::new(
+            stream,
+            sink,
+            lifecycle.handle(),
+            "kafka_topic_name".to_string(),
+            KafkaPartition::new(42),
+            &*metrics,
+        );
+
+        handler
+            .run(Default::default())
+            .with_timeout_panic(Duration::from_secs(1))
+            .await;
+    }
+}

--- a/ingester/src/stream_handler/handler.rs
+++ b/ingester/src/stream_handler/handler.rs
@@ -394,11 +394,13 @@ mod tests {
     static TEST_KAFKA_TOPIC: &str = "kafka_topic_name";
 
     // Return a DmlWrite with the given namespace and a single table.
-    fn make_write(name: impl Into<String>, ttbr: u64) -> DmlWrite {
+    fn make_write(name: impl Into<String>, write_time: u64) -> DmlWrite {
         let tables = lines_to_batches("bananas level=42 4242", 0).unwrap();
         let sequence = DmlMeta::sequenced(
             Sequence::new(1, 2),
-            TEST_TIME.checked_sub(Duration::from_millis(ttbr)).unwrap(),
+            TEST_TIME
+                .checked_sub(Duration::from_millis(write_time))
+                .unwrap(),
             None,
             42,
         );
@@ -406,14 +408,16 @@ mod tests {
     }
 
     // Return a DmlDelete with the given namespace.
-    fn make_delete(name: impl Into<String>, ttbr: u64) -> DmlDelete {
+    fn make_delete(name: impl Into<String>, write_time: u64) -> DmlDelete {
         let pred = DeletePredicate {
             range: TimestampRange::new(1, 2),
             exprs: vec![],
         };
         let sequence = DmlMeta::sequenced(
             Sequence::new(1, 2),
-            TEST_TIME.checked_sub(Duration::from_millis(ttbr)).unwrap(),
+            TEST_TIME
+                .checked_sub(Duration::from_millis(write_time))
+                .unwrap(),
             None,
             42,
         );

--- a/ingester/src/stream_handler/handler.rs
+++ b/ingester/src/stream_handler/handler.rs
@@ -166,7 +166,8 @@ where
     ///
     /// This method blocks until gracefully shutdown by cancelling the
     /// `shutdown` [`CancellationToken`]. Once cancelled, this handler will
-    /// complete the current operation it is
+    /// complete the current operation it is processing before this method
+    /// returns.
     ///
     /// # Panics
     ///

--- a/ingester/src/stream_handler/mock_sink.rs
+++ b/ingester/src/stream_handler/mock_sink.rs
@@ -1,0 +1,41 @@
+use std::collections::VecDeque;
+
+use async_trait::async_trait;
+use dml::DmlOperation;
+use parking_lot::Mutex;
+
+use super::DmlSink;
+
+#[derive(Debug, Default)]
+struct MockDmlSinkState {
+    calls: Vec<DmlOperation>,
+    ret: VecDeque<Result<bool, crate::data::Error>>,
+}
+
+#[derive(Debug, Default)]
+pub struct MockDmlSink {
+    state: Mutex<MockDmlSinkState>,
+}
+
+impl MockDmlSink {
+    pub fn with_apply_return(
+        self,
+        ret: impl Into<VecDeque<Result<bool, crate::data::Error>>>,
+    ) -> Self {
+        self.state.lock().ret = ret.into();
+        self
+    }
+
+    pub fn get_calls(&self) -> Vec<DmlOperation> {
+        self.state.lock().calls.clone()
+    }
+}
+
+#[async_trait]
+impl DmlSink for MockDmlSink {
+    async fn apply(&self, op: DmlOperation) -> Result<bool, crate::data::Error> {
+        let mut state = self.state.lock();
+        state.calls.push(op);
+        state.ret.pop_front().expect("no mock sink value to return")
+    }
+}

--- a/ingester/src/stream_handler/mod.rs
+++ b/ingester/src/stream_handler/mod.rs
@@ -1,0 +1,26 @@
+//! An implementation of the "consumer-end" of the sequencer - pulling messages
+//! from the sequencer, decoding the [`DmlOperation`] within and applying them
+//! to in-memory state.
+//!
+//! A [`SequencedStreamHandler`] is responsible for consuming messages from the
+//! sequencer (through the [`WriteBufferReading`] interface), decoding them to
+//! [`DmlOperation`] instances and pushing them to the [`DmlSink`] for further
+//! processing and buffering.
+//!
+//! The ingest/reads performed by the [`SequencedStreamHandler`] are rate
+//! limited by the [`LifecycleManager`] it is initialised by, pausing until
+//! [`LifecycleHandle::can_resume_ingest()`] returns true.
+//!
+//! [`DmlOperation`]: dml::DmlOperation
+//! [`WriteBufferReading`]: write_buffer::core::WriteBufferReading
+//! [`LifecycleManager`]: crate::lifecycle::LifecycleManager
+//! [`LifecycleHandle::can_resume_ingest()`]: crate::lifecycle::LifecycleHandle::can_resume_ingest()
+
+mod handler;
+mod sink;
+
+#[cfg(test)]
+pub mod mock_sink;
+
+pub use handler::*;
+pub use sink::*;

--- a/ingester/src/stream_handler/sink.rs
+++ b/ingester/src/stream_handler/sink.rs
@@ -1,4 +1,4 @@
-use std::{fmt::Debug, sync::Arc};
+use std::{fmt::Debug, ops::Deref, sync::Arc};
 
 use async_trait::async_trait;
 use dml::DmlOperation;
@@ -17,6 +17,6 @@ where
     T: DmlSink,
 {
     async fn apply(&self, op: DmlOperation) -> Result<bool, crate::data::Error> {
-        (**self).apply(op).await
+        self.deref().apply(op).await
     }
 }

--- a/ingester/src/stream_handler/sink.rs
+++ b/ingester/src/stream_handler/sink.rs
@@ -1,0 +1,22 @@
+use std::{fmt::Debug, sync::Arc};
+
+use async_trait::async_trait;
+use dml::DmlOperation;
+
+/// A [`DmlSink`] handles [`DmlOperation`] instances read from a sequencer.
+#[async_trait]
+pub trait DmlSink: Debug + Send + Sync {
+    /// Apply `op` read from a sequencer, returning `Ok(true)` if ingest should
+    /// be paused.
+    async fn apply(&self, op: DmlOperation) -> Result<bool, crate::data::Error>;
+}
+
+#[async_trait]
+impl<T> DmlSink for Arc<T>
+where
+    T: DmlSink,
+{
+    async fn apply(&self, op: DmlOperation) -> Result<bool, crate::data::Error> {
+        (**self).apply(op).await
+    }
+}

--- a/test_helpers/Cargo.toml
+++ b/test_helpers/Cargo.toml
@@ -12,3 +12,9 @@ tracing-log = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 observability_deps = { path = "../observability_deps" }
 workspace-hack = { path = "../workspace-hack"}
+async-trait = { version = "0.1.53", optional = true }
+tokio = { version = "1.17.0", optional = true, default_features = false, features = ["time"] }
+
+[features]
+default = []
+future_timeout = ["async-trait", "tokio"]

--- a/test_helpers/src/lib.rs
+++ b/test_helpers/src/lib.rs
@@ -12,7 +12,8 @@ use std::{
     sync::{Arc, Once},
 };
 pub use tempfile;
-
+#[cfg(feature = "future_timeout")]
+pub mod timeout;
 pub mod tracing;
 
 pub type Error = Box<dyn std::error::Error + Send + Sync + 'static>;

--- a/test_helpers/src/timeout.rs
+++ b/test_helpers/src/timeout.rs
@@ -1,0 +1,59 @@
+use std::time::Duration;
+
+use async_trait::async_trait;
+use std::future::Future;
+use tokio::time::error::Elapsed;
+
+/// An extension trait to add wall-clock execution timeouts to a future running
+/// in a tokio runtime.
+///
+/// Uses [tokio::time::timeout] internally to apply the timeout.
+#[async_trait]
+pub trait FutureTimeout: Future + Sized {
+    /// Wraps `self` returning the result, or panicking if the future hasn't
+    /// completed after `d` length of time.
+    ///
+    /// # Safety
+    ///
+    /// This method panics if `d` elapses before the task rejoins.
+    async fn with_timeout_panic(mut self, d: Duration) -> <Self as Future>::Output {
+        self.with_timeout(d)
+            .await
+            .expect("timeout waiting for task to join")
+    }
+
+    /// Wraps `self` returning the result, or an error if the future hasn't
+    /// completed after `d` length of time.
+    async fn with_timeout(mut self, d: Duration) -> Result<<Self as Future>::Output, Elapsed> {
+        tokio::time::timeout(d, self).await
+    }
+}
+
+impl<F> FutureTimeout for F where F: Future {}
+
+#[cfg(test)]
+mod tests {
+    use tokio::sync::oneshot;
+
+    use super::*;
+
+    #[tokio::test]
+    #[should_panic(expected = "timeout")]
+    async fn test_exceeded_panic() {
+        let (_tx, rx) = oneshot::channel::<()>();
+        let task = tokio::spawn(async move { rx.await });
+
+        let _ = task.with_timeout_panic(Duration::from_millis(1)).await;
+    }
+
+    #[tokio::test]
+    async fn test_exceeded() {
+        let (_tx, rx) = oneshot::channel::<()>();
+        let task = tokio::spawn(async move { rx.await });
+
+        let _ = task
+            .with_timeout(Duration::from_millis(1))
+            .await
+            .expect_err("should time out");
+    }
+}


### PR DESCRIPTION
This PR is aims to refactor the [`stream_in_sequenced_entries()`](https://github.com/influxdata/influxdb_iox/blob/d393ec6c257800508e33a6486c27d78b85b400fa/ingester/src/handler.rs#L273) fn that currently handles reading from kafka and applying the operation down through to the table buffer (and other things) with the intent being primarily to refine error handling and observability, and secondarily decouple various responsibilities within the ingest process to improve encapsulation / make testing easier.

This PR does NOT add the code within it to the ingest pipeline, instead the old handler remains in place - I've a little more to add to this refactor (specifically instrumentation, kafka watermark fetching, and a sink to connect the handler to the existing op processing impl) but felt this was more than big enough to review already.


---

* feat(tests): future timeout helper (ea3983e86)

      Adds a timeout test helper for futures - this lets us easily write tests that
      await on futures for a bounded duration of time.

      Optional feature to avoid dragging tokio into existing consumers of the 
      test_helpers crate that don't need it.

* refactor: ingest stream handler (e787e700d)

      Refactors the stream_in_sequenced_entries() into a new impl in the 
      SequencedStreamHandler type, decoupling the reading / decoding of ops from
      Kafka (and associated error handling) from the "what happens to those ops"
      concern to ease testing, encapsulate the specifics of "how to get an op" and
      improve flexibility.

      This is intended to provide robust error handling within what is reasonably
      possible (unexpected errors are always unexpected!) while retaining the
      existing metrics and functionality. I've also separated out code that exists
      in the current impl specifically to drive tests from the prod code path,
      instead driving those behaviours through mocks.

      As of this commit, the handler is not used - this commit simply adds the new
      impl.

* feat: expose ingest sequencer errors (0e8e46d9a)

      Instruments the SequencedStreamHandler with a series of new metrics that 
      record the various error classes observable in the stream handler.

      These metrics are labelled with potential_data_loss=true where relevant to
      surface potential data loss events for alerting & further review.