### PR TITLE
refactor: add table_id index on column_name

### DIFF
--- a/iox_catalog/migrations/20220404120116_column_name-table_id-index.sql
+++ b/iox_catalog/migrations/20220404120116_column_name-table_id-index.sql
@@ -1,0 +1,2 @@
+-- Avoid seqscan when filtering columns by their table ID.
+CREATE INDEX IF NOT EXISTS column_name_table_idx ON column_name (table_id);


### PR DESCRIPTION
Adds a missing index to the `column_name` table.

---

* refactor: add table_id index on column_name (61bc9c83a)

      After checking the postgres workload for the catalog in prod, this missing
      index was noted as the cause of unexpectedly expensive plans for simple
      queries.