### PR TITLE
feat: ingester op instrumentation

### DIFF
--- a/ingester/src/stream_handler/mock_watermark_fetcher.rs
+++ b/ingester/src/stream_handler/mock_watermark_fetcher.rs
@@ -1,0 +1,18 @@
+use super::sink_instrumentation::WatermarkFetcher;
+
+#[derive(Debug, Copy, Clone)]
+pub struct MockWatermarkFetcher {
+    ret: Option<u64>,
+}
+
+impl MockWatermarkFetcher {
+    pub fn new(ret: Option<u64>) -> Self {
+        Self { ret }
+    }
+}
+
+impl WatermarkFetcher for MockWatermarkFetcher {
+    fn watermark(&self) -> Option<u64> {
+        self.ret
+    }
+}

--- a/ingester/src/stream_handler/mod.rs
+++ b/ingester/src/stream_handler/mod.rs
@@ -22,6 +22,9 @@ mod sink;
 
 #[cfg(test)]
 pub mod mock_sink;
+#[cfg(test)]
+pub mod mock_watermark_fetcher;
+pub mod sink_instrumentation;
 
 pub use handler::*;
 pub use periodic_watermark_fetcher::*;

--- a/ingester/src/stream_handler/sink_instrumentation.rs
+++ b/ingester/src/stream_handler/sink_instrumentation.rs
@@ -464,7 +464,7 @@ mod tests {
             }
         );
 
-        // Validate the success histogram was hit
+        // Validate the histogram was hit even on error
         let hist = get_metric::<U64Histogram>(&metrics, "ingester_op_apply_duration_ms", &{
             let mut attrs = DEFAULT_ATTRS.clone();
             attrs.insert("result", "error");

--- a/ingester/src/stream_handler/sink_instrumentation.rs
+++ b/ingester/src/stream_handler/sink_instrumentation.rs
@@ -1,0 +1,582 @@
+use std::fmt::Debug;
+
+use async_trait::async_trait;
+use data_types2::KafkaPartition;
+use dml::DmlOperation;
+use metric::{Attributes, U64Counter, U64Gauge, U64Histogram, U64HistogramOptions};
+use time::{SystemProvider, TimeProvider};
+
+use super::DmlSink;
+
+/// A [`WatermarkFetcher`] abstracts a source of the write buffer high watermark
+/// (max known offset).
+///
+/// # Caching
+///
+/// Implementations may cache the watermark and return inaccurate values.
+pub trait WatermarkFetcher: Debug + Send + Sync {
+    /// Return a watermark if available.
+    fn watermark(&self) -> Option<u64>;
+}
+
+/// A [`SinkInstrumentation`] decorates a [`DmlSink`] implementation and records
+/// write buffer metrics and the latency of the decorated [`DmlSink::apply()`]
+/// call.
+///
+/// # Panics
+///
+/// A [`SinkInstrumentation`] is instantiated for a specific sequencer ID, and
+/// panics if it observes a [`DmlOperation`] from a different sequencer.
+///
+/// # Wall Clocks
+///
+/// Some metrics emitted depend on the wall clocks of both the machine this
+/// instance is running on, and the routers. If either of these clocks are
+/// incorrect/skewed/drifting the metrics emitted may be incorrect.
+#[derive(Debug)]
+pub struct SinkInstrumentation<F, T, P = SystemProvider> {
+    /// The [`DmlSink`] impl this layer decorates.
+    ///
+    /// All ops this impl is called with are passed into `inner` for processing.
+    /// The value returned from `inner` is inspected and returned unchanged.
+    inner: T,
+
+    /// A high watermark oracle.
+    ///
+    /// Used to derive ingest lag - tolerant of caching / old values.
+    watermark_fetcher: F,
+
+    /// The sequencer ID this instrumentation is recording op metrics for.
+    sequencer_id: i32,
+
+    /// Op application success/failure call latency histograms (which include
+    /// counters)
+    op_apply_success_ms: U64Histogram,
+    op_apply_error_ms: U64Histogram,
+
+    /// Write buffer metrics
+    write_buffer_bytes_read: U64Counter,
+    write_buffer_last_sequence_number: U64Gauge,
+    write_buffer_sequence_number_lag: U64Gauge,
+    write_buffer_last_ingest_ts: U64Gauge,
+
+    time_provider: P,
+}
+
+impl<F, T> SinkInstrumentation<F, T>
+where
+    F: WatermarkFetcher,
+    T: DmlSink,
+{
+    /// Construct a new [`SinkInstrumentation`] layer that decorates `inner`
+    /// with logic that records metrics from the [`DmlOperation`] instances it
+    /// observes.
+    ///
+    /// The current high watermark is read from `watermark_fetcher` and used to
+    /// derive some metric values (such as lag). This impl is tolerant of
+    /// cached/stale watermark values being returned by `watermark_fetcher`.
+    pub fn new(
+        inner: T,
+        watermark_fetcher: F,
+        kafka_topic_name: String,
+        kafka_partition: KafkaPartition,
+        metrics: &metric::Registry,
+    ) -> Self {
+        let attr = Attributes::from([
+            ("sequencer_id", kafka_partition.to_string().into()),
+            ("kafka_topic", kafka_topic_name.into()),
+        ]);
+
+        let write_buffer_bytes_read = metrics
+            .register_metric::<U64Counter>(
+                "write_buffer_read_bytes",
+                "Total number of bytes read from sequencer",
+            )
+            .recorder(attr.clone());
+        let write_buffer_last_sequence_number = metrics
+            .register_metric::<U64Gauge>(
+                "write_buffer_last_sequence_number",
+                "Last consumed sequence number (e.g. Kafka offset)",
+            )
+            .recorder(attr.clone());
+        let write_buffer_sequence_number_lag = metrics.register_metric::<U64Gauge>(
+            "write_buffer_sequence_number_lag",
+            "The difference between the the last sequence number available (e.g. Kafka offset) and (= minus) last consumed sequence number",
+        ).recorder(attr.clone());
+        let write_buffer_last_ingest_ts = metrics
+            .register_metric::<U64Gauge>(
+                "write_buffer_last_ingest_ts",
+                "Last seen ingest timestamp as unix timestamp in nanoseconds",
+            )
+            .recorder(attr.clone());
+
+        // The buckets for the op apply histogram
+        let buckets = || {
+            U64HistogramOptions::new([
+                5,
+                10,
+                20,
+                40,
+                80,
+                160,
+                320,
+                640,
+                1280,
+                2560,
+                5120,
+                10240,
+                20480,
+                u64::MAX,
+            ])
+        };
+
+        let op_apply = metrics.register_metric_with_options::<U64Histogram, _>(
+            "ingester_op_apply_duration_ms",
+            "The duration of time taken to process an operation read from the sequencer",
+            buckets,
+        );
+        let op_apply_success_ms = op_apply.recorder({
+            let mut attr = attr.clone();
+            attr.insert("result", "success");
+            attr
+        });
+        let op_apply_error_ms = op_apply.recorder({
+            let mut attr = attr;
+            attr.insert("result", "error");
+            attr
+        });
+
+        Self {
+            inner,
+            watermark_fetcher,
+            sequencer_id: kafka_partition.get(),
+
+            op_apply_success_ms,
+            op_apply_error_ms,
+
+            write_buffer_bytes_read,
+            write_buffer_last_sequence_number,
+            write_buffer_sequence_number_lag,
+            write_buffer_last_ingest_ts,
+            time_provider: SystemProvider::default(),
+        }
+    }
+}
+
+#[async_trait]
+impl<F, T, P> DmlSink for SinkInstrumentation<F, T, P>
+where
+    F: WatermarkFetcher,
+    T: DmlSink,
+    P: TimeProvider,
+{
+    async fn apply(&self, op: DmlOperation) -> Result<bool, crate::data::Error> {
+        let meta = op.meta();
+
+        // Immediately increment the "bytes read" metric as it records the
+        // number of bytes read from the sequencer, irrespective of the op
+        // apply call.
+        self.write_buffer_bytes_read.inc(
+            meta.bytes_read()
+                .expect("entry from write buffer should have size") as u64,
+        );
+
+        // Record the producer's wall clock timestamp added to this op.
+        //
+        // For obvious reasons this timestamp cannot be relied upon to be
+        // accurate.
+        self.write_buffer_last_ingest_ts.set(
+            meta.producer_ts()
+                .expect("entry from write buffer must have a producer wallclock time")
+                .timestamp_nanos() as u64,
+        );
+
+        // Extract the sequence number from the op before giving up ownership
+        // to the inner DmlSink (avoiding a clone of the large op).
+        let sequence = meta
+            .sequence()
+            .expect("entry from write buffer must be sequenced");
+        assert_eq!(
+            sequence.sequencer_id as i32, self.sequencer_id,
+            "instrumentation for sequencer {} saw op from sequencer {}",
+            self.sequencer_id, sequence.sequencer_id,
+        );
+
+        // Record the "last read sequence number" write buffer metric.
+        self.write_buffer_last_sequence_number
+            .set(sequence.sequence_number);
+
+        // If it is possible to obtain the sequence number of the most recent op
+        // inserted into the queue, record how far behind the op is.
+        if let Some(watermark) = self.watermark_fetcher.watermark() {
+            self.write_buffer_sequence_number_lag.set(
+                watermark
+                    .saturating_sub(sequence.sequence_number)
+                    .saturating_sub(1),
+            );
+        }
+
+        // Call into the inner handler to process the op and calculate the call
+        // latency.
+        let started_at = self.time_provider.now();
+        let res = self.inner.apply(op).await;
+
+        // If the clocks go backwards, skip recording the (nonsense) call
+        // latency.
+        if let Some(delta) = self.time_provider.now().checked_duration_since(started_at) {
+            let metric = match &res {
+                Ok(_) => &self.op_apply_success_ms,
+                Err(_) => &self.op_apply_error_ms,
+            };
+            metric.record(delta.as_millis() as _);
+        }
+
+        // Return the result from the inner handler unmodified
+        res
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use assert_matches::assert_matches;
+    use data_types2::Sequence;
+    use dml::{DmlMeta, DmlWrite};
+    use metric::{Metric, MetricObserver, Observation};
+    use mutable_batch_lp::lines_to_batches;
+    use time::Time;
+
+    use crate::stream_handler::{
+        mock_sink::MockDmlSink, mock_watermark_fetcher::MockWatermarkFetcher,
+    };
+
+    use super::*;
+
+    /// The sequencer ID the [`SinkInstrumentation`] under test is configured to
+    /// be observing for.
+    const SEQUENCER_ID: u32 = 42;
+
+    static TEST_KAFKA_TOPIC: &str = "kafka_topic_name";
+
+    lazy_static::lazy_static! {
+        static ref TEST_TIME: Time = SystemProvider::default().now();
+
+        /// The attributes assigned to the metrics emitted by the
+        /// instrumentation when using the above sequencer / kafka topic values.
+        static ref DEFAULT_ATTRS: Attributes = Attributes::from([
+            ("sequencer_id", SEQUENCER_ID.to_string().into()),
+            ("kafka_topic", TEST_KAFKA_TOPIC.into()),
+        ]);
+    }
+
+    /// Return a DmlWrite with the given metadata and a single table.
+    fn make_write(meta: DmlMeta) -> DmlWrite {
+        let tables = lines_to_batches("bananas level=42 4242", 0).unwrap();
+        DmlWrite::new("bananas", tables, meta)
+    }
+
+    /// Extract the metric with the given name from `metrics`.
+    fn get_metric<'a, T: MetricObserver>(
+        metrics: &'a metric::Registry,
+        name: &'static str,
+        attrs: &Attributes,
+    ) -> Observation {
+        metrics
+            .get_instrument::<Metric<T>>(name)
+            .expect(format!("did not find metric {}", name).as_str())
+            .get_observer(attrs)
+            .expect(format!("failed to match {} attributes", name).as_str())
+            .observe()
+    }
+
+    /// Initialise a [`SinkInstrumentation`] and drive it with the given
+    /// parameters.
+    async fn test(
+        op: impl Into<DmlOperation>,
+        metrics: &metric::Registry,
+        with_sink_return: Result<bool, crate::data::Error>,
+        with_fetcher_return: Option<u64>,
+    ) -> Result<bool, crate::data::Error> {
+        let op = op.into();
+        let inner = MockDmlSink::default().with_apply_return([with_sink_return]);
+        let instrumentation = SinkInstrumentation::new(
+            inner,
+            MockWatermarkFetcher::new(with_fetcher_return),
+            TEST_KAFKA_TOPIC.to_string(),
+            KafkaPartition::new(SEQUENCER_ID as _),
+            metrics,
+        );
+
+        instrumentation.apply(op).await
+    }
+
+    // This test asserts the various metrics are set in the happy path.
+    #[tokio::test]
+    async fn test_call_inner_ok() {
+        let metrics = metric::Registry::default();
+        let meta = DmlMeta::sequenced(
+            // Op is offset 100 for sequencer 42
+            Sequence::new(SEQUENCER_ID, 100),
+            *TEST_TIME,
+            None,
+            4242,
+        );
+        let op = make_write(meta);
+
+        let got = test(op, &metrics, Ok(true), Some(12345)).await;
+        assert_matches!(got, Ok(true));
+
+        // Validate the various write buffer metrics
+        assert_matches!(
+            get_metric::<U64Counter>(&metrics, "write_buffer_read_bytes", &*DEFAULT_ATTRS),
+            Observation::U64Counter(4242)
+        );
+        assert_matches!(
+            get_metric::<U64Gauge>(
+                &metrics,
+                "write_buffer_last_sequence_number",
+                &*DEFAULT_ATTRS
+            ),
+            Observation::U64Gauge(100)
+        );
+        assert_matches!(
+            get_metric::<U64Gauge>(
+                &metrics,
+                "write_buffer_sequence_number_lag",
+                &*DEFAULT_ATTRS
+            ),
+            // 12345 - 100 - 1
+            Observation::U64Gauge(12_244)
+        );
+        assert_matches!(
+            get_metric::<U64Gauge>(&metrics, "write_buffer_last_ingest_ts", &*DEFAULT_ATTRS),
+            // 12345 - 100 - 1
+            Observation::U64Gauge(t) => {
+                assert_eq!(t, TEST_TIME.timestamp_nanos() as u64);
+            }
+        );
+
+        // Validate the success histogram was hit
+        let hist = get_metric::<U64Histogram>(&metrics, "ingester_op_apply_duration_ms", &{
+            let mut attrs = DEFAULT_ATTRS.clone();
+            attrs.insert("result", "success");
+            attrs
+        });
+        assert_matches!(hist, Observation::U64Histogram(h) => {
+            let hits: u64 = h.buckets.iter().map(|b| b.count).sum();
+            assert_eq!(hits, 1);
+        });
+    }
+
+    // This test asserts the various metrics are set when the inner handler
+    // returns an error.
+    #[tokio::test]
+    async fn test_call_inner_error() {
+        let metrics = metric::Registry::default();
+        let meta = DmlMeta::sequenced(
+            // Op is offset 100 for sequencer 42
+            Sequence::new(SEQUENCER_ID, 100),
+            *TEST_TIME,
+            None,
+            4242,
+        );
+        let op = make_write(meta);
+
+        let got = test(
+            op,
+            &metrics,
+            Err(crate::data::Error::PersistingEmpty),
+            Some(12345),
+        )
+        .await;
+        assert_matches!(got, Err(crate::data::Error::PersistingEmpty));
+
+        // Validate the various write buffer metrics
+        assert_matches!(
+            get_metric::<U64Counter>(&metrics, "write_buffer_read_bytes", &*DEFAULT_ATTRS),
+            Observation::U64Counter(4242)
+        );
+        assert_matches!(
+            get_metric::<U64Gauge>(
+                &metrics,
+                "write_buffer_last_sequence_number",
+                &*DEFAULT_ATTRS
+            ),
+            Observation::U64Gauge(100)
+        );
+        assert_matches!(
+            get_metric::<U64Gauge>(
+                &metrics,
+                "write_buffer_sequence_number_lag",
+                &*DEFAULT_ATTRS
+            ),
+            // 12345 - 100 - 1
+            Observation::U64Gauge(12_244)
+        );
+        assert_matches!(
+            get_metric::<U64Gauge>(&metrics, "write_buffer_last_ingest_ts", &*DEFAULT_ATTRS),
+            // 12345 - 100 - 1
+            Observation::U64Gauge(t) => {
+                assert_eq!(t, TEST_TIME.timestamp_nanos() as u64);
+            }
+        );
+
+        // Validate the success histogram was hit
+        let hist = get_metric::<U64Histogram>(&metrics, "ingester_op_apply_duration_ms", &{
+            let mut attrs = DEFAULT_ATTRS.clone();
+            attrs.insert("result", "error");
+            attrs
+        });
+        assert_matches!(hist, Observation::U64Histogram(h) => {
+            let hits: u64 = h.buckets.iter().map(|b| b.count).sum();
+            assert_eq!(hits, 1);
+        });
+    }
+
+    // If there's no high watermark available, the write should still succeed.
+    #[tokio::test]
+    async fn test_no_high_watermark() {
+        let metrics = metric::Registry::default();
+        let meta = DmlMeta::sequenced(
+            // Op is offset 100 for sequencer 42
+            Sequence::new(SEQUENCER_ID, 100),
+            *TEST_TIME,
+            None,
+            4242,
+        );
+        let op = make_write(meta);
+
+        let got = test(op, &metrics, Ok(true), None).await;
+        assert_matches!(got, Ok(true));
+
+        // Validate the various write buffer metrics
+        assert_matches!(
+            get_metric::<U64Counter>(&metrics, "write_buffer_read_bytes", &*DEFAULT_ATTRS),
+            Observation::U64Counter(4242)
+        );
+        assert_matches!(
+            get_metric::<U64Gauge>(
+                &metrics,
+                "write_buffer_last_sequence_number",
+                &*DEFAULT_ATTRS
+            ),
+            Observation::U64Gauge(100)
+        );
+        assert_matches!(
+            get_metric::<U64Gauge>(
+                &metrics,
+                "write_buffer_sequence_number_lag",
+                &*DEFAULT_ATTRS
+            ),
+            // No value recorded because no watermark was available
+            Observation::U64Gauge(0)
+        );
+        assert_matches!(
+            get_metric::<U64Gauge>(&metrics, "write_buffer_last_ingest_ts", &*DEFAULT_ATTRS),
+            // 12345 - 100 - 1
+            Observation::U64Gauge(t) => {
+                assert_eq!(t, TEST_TIME.timestamp_nanos() as u64);
+            }
+        );
+
+        // Validate the success histogram was hit
+        let hist = get_metric::<U64Histogram>(&metrics, "ingester_op_apply_duration_ms", &{
+            let mut attrs = DEFAULT_ATTRS.clone();
+            attrs.insert("result", "success");
+            attrs
+        });
+        assert_matches!(hist, Observation::U64Histogram(h) => {
+            let hits: u64 = h.buckets.iter().map(|b| b.count).sum();
+            assert_eq!(hits, 1);
+        });
+    }
+
+    // If the high watermark is less than the current sequence number (for
+    // example, due to caching) nothing bad should happen.
+    #[tokio::test]
+    async fn test_high_watermark_less_than_current_op() {
+        let metrics = metric::Registry::default();
+        let meta = DmlMeta::sequenced(
+            // Op is offset 100 for sequencer 42
+            Sequence::new(SEQUENCER_ID, 100),
+            *TEST_TIME,
+            None,
+            4242,
+        );
+        let op = make_write(meta);
+
+        let got = test(op, &metrics, Ok(true), Some(1)).await;
+        assert_matches!(got, Ok(true));
+
+        // Validate the various write buffer metrics
+        assert_matches!(
+            get_metric::<U64Counter>(&metrics, "write_buffer_read_bytes", &*DEFAULT_ATTRS),
+            Observation::U64Counter(4242)
+        );
+        assert_matches!(
+            get_metric::<U64Gauge>(
+                &metrics,
+                "write_buffer_last_sequence_number",
+                &*DEFAULT_ATTRS
+            ),
+            Observation::U64Gauge(100)
+        );
+        assert_matches!(
+            get_metric::<U64Gauge>(
+                &metrics,
+                "write_buffer_sequence_number_lag",
+                &*DEFAULT_ATTRS
+            ),
+            // The current sequence number is not behind the high watermark
+            Observation::U64Gauge(0)
+        );
+        assert_matches!(
+            get_metric::<U64Gauge>(&metrics, "write_buffer_last_ingest_ts", &*DEFAULT_ATTRS),
+            // 12345 - 100 - 1
+            Observation::U64Gauge(t) => {
+                assert_eq!(t, TEST_TIME.timestamp_nanos() as u64);
+            }
+        );
+
+        // Validate the success histogram was hit
+        let hist = get_metric::<U64Histogram>(&metrics, "ingester_op_apply_duration_ms", &{
+            let mut attrs = DEFAULT_ATTRS.clone();
+            attrs.insert("result", "success");
+            attrs
+        });
+        assert_matches!(hist, Observation::U64Histogram(h) => {
+            let hits: u64 = h.buckets.iter().map(|b| b.count).sum();
+            assert_eq!(hits, 1);
+        });
+    }
+
+    // The missing metadata can cause various panics, but the bytes_read is the
+    // first one hit.
+    #[should_panic = "entry from write buffer should have size"]
+    #[tokio::test]
+    async fn test_missing_metadata() {
+        let metrics = metric::Registry::default();
+        let meta = DmlMeta::unsequenced(None);
+        let op = make_write(meta);
+
+        let _ = test(op, &metrics, Ok(true), Some(12345)).await;
+    }
+
+    // The instrumentation emits per-sequencer metrics, so upon observing an op
+    // for a different sequencer it should panic.
+    #[should_panic = "instrumentation for sequencer 42 saw op from sequencer 52"]
+    #[tokio::test]
+    async fn test_op_different_sequencer_id() {
+        let metrics = metric::Registry::default();
+        let meta = DmlMeta::sequenced(
+            // A different sequencer ID from what the handler is configured to
+            // be instrumenting
+            Sequence::new(SEQUENCER_ID + 10, 100),
+            *TEST_TIME,
+            None,
+            4242,
+        );
+        let op = make_write(meta);
+
+        let _ = test(op, &metrics, Ok(true), Some(12345)).await;
+    }
+}

--- a/ingester/src/stream_handler/sink_instrumentation.rs
+++ b/ingester/src/stream_handler/sink_instrumentation.rs
@@ -292,23 +292,23 @@ mod tests {
     }
 
     /// Extract the metric with the given name from `metrics`.
-    fn get_metric<'a, T: MetricObserver>(
-        metrics: &'a metric::Registry,
+    fn get_metric<T: MetricObserver>(
+        metrics: &metric::Registry,
         name: &'static str,
         attrs: &Attributes,
     ) -> Observation {
         metrics
             .get_instrument::<Metric<T>>(name)
-            .expect(format!("did not find metric {}", name).as_str())
+            .unwrap_or_else(|| panic!("did not find metric {}", name))
             .get_observer(attrs)
-            .expect(format!("failed to match {} attributes", name).as_str())
+            .unwrap_or_else(|| panic!("failed to match {} attributes", name))
             .observe()
     }
 
     /// Initialise a [`SinkInstrumentation`] and drive it with the given
     /// parameters.
     async fn test(
-        op: impl Into<DmlOperation>,
+        op: impl Into<DmlOperation> + Send,
         metrics: &metric::Registry,
         with_sink_return: Result<bool, crate::data::Error>,
         with_fetcher_return: Option<u64>,


### PR DESCRIPTION
This PR adds a `DmlSink` implementation that decorates other implementations to emit metrics & traces during the `DmlSink::apply()` call.

This type currently emits both the write buffer metrics and op call metrics - these responsibilities will likely need splitting if we wind up composing together `DmlSink` implementations in the future and would like to record latencies for each.

There are some differences in the metrics this PR adds compared to what we [currently have](https://github.com/influxdata/influxdb_iox/blob/b6f9c9bfd4b138d71d5440b372dc5652223ac53f/db/src/write_buffer/metrics.rs#L29-L60):

* All metrics were [labelled with `db_name`](https://github.com/influxdata/influxdb_iox/blob/b6f9c9bfd4b138d71d5440b372dc5652223ac53f/db/src/write_buffer/metrics.rs#L77) - this is now [`kafka_topic`](https://github.com/influxdata/influxdb_iox/blob/b6f9c9bfd4b138d71d5440b372dc5652223ac53f/ingester/src/stream_handler/sink_instrumentation.rs#L89).
* Removed `write_buffer_last_min_ts` and `write_buffer_last_max_ts` - I'm not sure these are very useful but happy to put them back if they are important to someone.
* `write_buffer_ingest_request_duration` was confusingly named - it recorded the duration of the op apply after being read from the write buffer and was independent of any write buffer latency. This is now `ingester_op_apply_duration_ms` and has been changed to a latency histogram to capture the latency distribution of op handling.
* `write_buffer_ingest_requests` has been removed as it is redundant - the ingest duration histogram counts the number of handled ops/requests.
* All write buffer metrics are emitted immediately after being read from the write buffer and _before_ the op apply is performed so they're kept as up-to-date as possible and record what has been read from the write buffer irrespective of what happens with the op.

These metrics are NOT currently wired in - this is part of a series of PRs to replace the [`stream_in_sequenced_entries()`](https://github.com/influxdata/influxdb_iox/blob/b6f9c9bfd4b138d71d5440b372dc5652223ac53f/ingester/src/handler.rs#L273) fn:

- [x] Stream handler / reading from kafka (#4203)
- [x] High watermark fetcher (feeds into instrumentation) (#4235)
- [ ] **THIS PR:** Instrumentation of op apply
- [ ] Impl DmlSink for existing write buffer code path (via compatibility adaptor)
- [ ] Plumb in the `SequencedStreamHandler` and use it in prod

---

* feat: DmlSink instrumentation (436da19d9)

      This commit adds the SinkInstrumentation type that decorates an inner DmlSink
      with call latency and write buffer metrics.

      The write buffer / sink call metrics may be split apart into two separate
      responsibilities in the future if there are multiple DmlSink that need
      instrumentation, but deferring adding more types until it is needed.

* refactor: impl WatermarkFetcher (f6c65f52a)

      Implement WatermarkFetcher for PeriodicWatermarkFetcher and remove unnecessary
      async.

* feat: emit tracing span for op apply (091640bb2)

      This commit uses the tracing metadata within the DmlOperation to emit a 
      tracing span from the ingester covering the DmlSink::apply() operation.