### PR TITLE
refactor: compactor debug logging

### DIFF
--- a/compactor/src/compact.rs
+++ b/compactor/src/compact.rs
@@ -413,6 +413,8 @@ impl Compactor {
 
             // compact
             let split_compacted_files = self.compact(group.parquet_files).await?;
+            debug!("compacted files");
+
             let mut catalog_update_info = Vec::with_capacity(split_compacted_files.len());
 
             for split_file in split_compacted_files {
@@ -588,6 +590,11 @@ impl Compactor {
                 )
             })
             .collect();
+
+        debug!(
+            n_query_chunks = query_chunks.len(),
+            "gathered parquet data to compact"
+        );
 
         // Compute min & max sequence numbers and time
         // unwrap here will work becasue the len of the query_chunks already >= 1

--- a/compactor/src/utils.rs
+++ b/compactor/src/utils.rs
@@ -7,6 +7,7 @@ use data_types2::{
 };
 use iox_object_store::IoxObjectStore;
 use object_store::DynObjectStore;
+use observability_deps::tracing::*;
 use parquet_file::{
     chunk::{new_parquet_chunk, ChunkMetrics, DecodedParquetFile},
     metadata::{IoxMetadata, IoxParquetMetaData},
@@ -18,6 +19,7 @@ use std::{
 
 /// Wrapper of a group of parquet files and their tombstones that overlap in time and should be
 /// considered during compaction.
+#[derive(Debug)]
 pub struct GroupWithTombstones {
     /// Each file with the set of tombstones relevant to it
     pub(crate) parquet_files: Vec<ParquetFileWithTombstone>,
@@ -95,6 +97,11 @@ impl ParquetFileWithTombstone {
             &decoded_parquet_file,
             ChunkMetrics::new_unregistered(), // TODO: need to add metrics
             Arc::new(iox_object_store),
+        );
+
+        debug!(
+            parquet_file=?decoded_parquet_file.parquet_file,
+            "generated parquet chunk from object store"
         );
 
         QueryableParquetChunk::new(

--- a/parquet_file/src/chunk.rs
+++ b/parquet_file/src/chunk.rs
@@ -9,6 +9,7 @@ use data_types::{
 use data_types2::ParquetFile;
 use datafusion::physical_plan::SendableRecordBatchStream;
 use iox_object_store::{IoxObjectStore, ParquetFilePath};
+use observability_deps::tracing::*;
 use predicate::Predicate;
 use schema::selection::Selection;
 use schema::{Schema, TIME_COLUMN_NAME};
@@ -231,6 +232,7 @@ impl ParquetChunk {
         predicate: &Predicate,
         selection: Selection<'_>,
     ) -> Result<SendableRecordBatchStream> {
+        debug!(path=?self.path, "fetching parquet data for filtered read");
         Storage::read_filter(
             predicate,
             selection,

--- a/parquet_file/src/storage.rs
+++ b/parquet_file/src/storage.rs
@@ -12,7 +12,7 @@ use datafusion_util::AdapterStream;
 use futures::{stream, Stream, StreamExt};
 use iox_object_store::{IoxObjectStore, ParquetFilePath};
 use object_store::GetResult;
-use observability_deps::tracing::debug;
+use observability_deps::tracing::*;
 use parking_lot::Mutex;
 use parquet::arrow::{ArrowReader, ParquetFileArrowReader};
 use parquet::file::reader::SerializedFileReader;
@@ -300,6 +300,8 @@ impl Storage {
             }
         }
 
+        debug!("Completed parquet download & scan");
+
         Ok(())
     }
 
@@ -332,6 +334,7 @@ impl Storage {
 
             // If there was an error returned from download_and_scan_parquet send it back to the receiver.
             if let Err(e) = download_result {
+                warn!(error=%e, "Parquet download & scan failed");
                 let e = ArrowError::ExternalError(Box::new(e));
                 if let Err(e) = tx.blocking_send(ArrowResult::Err(e)) {
                     // if no one is listening, there is no one else to hear our screams


### PR DESCRIPTION
This PR simply adds more debug logging - can't fix what you can't see 👀 

---

* refactor: print parquet path in Debug impl (2607151ec)

      Print the actual path being used when debug-printing a ParquetFilePath.

* refactor: add debug in compaction path (3706ac042)

      Adds debug!() and friends through the compaction path.