### PR TITLE
feat(ingester): use SequencedStreamHandler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2308,7 +2308,6 @@ dependencies = [
  "chrono",
  "data_types2",
  "datafusion 0.1.0",
- "db",
  "dml",
  "futures",
  "generated_types",

--- a/ingester/Cargo.toml
+++ b/ingester/Cargo.toml
@@ -17,7 +17,6 @@ data_types2 = { path = "../data_types2" }
 futures = "0.3"
 generated_types = { path = "../generated_types" }
 chrono = { version = "0.4", default-features = false }
-db = { path = "../db" }
 dml = { path = "../dml" }
 hyper = "0.14"
 iox_catalog = { path = "../iox_catalog" }

--- a/ingester/src/stream_handler/handler.rs
+++ b/ingester/src/stream_handler/handler.rs
@@ -157,7 +157,7 @@ impl<I, O> SequencedStreamHandler<I, O> {
 
 impl<I, O, T> SequencedStreamHandler<I, O, T>
 where
-    I: Stream<Item = Result<DmlOperation, WriteBufferError>> + Unpin + Send + Sync,
+    I: Stream<Item = Result<DmlOperation, WriteBufferError>> + Unpin + Send,
     O: DmlSink,
     T: TimeProvider,
 {
@@ -264,7 +264,7 @@ where
         }
     }
 
-    async fn maybe_apply_op(&self, op: Option<DmlOperation>) {
+    async fn maybe_apply_op(&mut self, op: Option<DmlOperation>) {
         if let Some(op) = op {
             // Extract the producer timestamp (added in the router when
             // dispatching the request).
@@ -307,7 +307,7 @@ where
         }
     }
 
-    async fn pause_ingest(&self) {
+    async fn pause_ingest(&mut self) {
         // Record how long this pause is, for logging purposes.
         let started_at = self.time_provider.now();
 

--- a/ingester/src/stream_handler/mod.rs
+++ b/ingester/src/stream_handler/mod.rs
@@ -24,6 +24,7 @@ mod sink;
 pub mod mock_sink;
 #[cfg(test)]
 pub mod mock_watermark_fetcher;
+pub mod sink_adaptor;
 pub mod sink_instrumentation;
 
 pub use handler::*;

--- a/ingester/src/stream_handler/sink_adaptor.rs
+++ b/ingester/src/stream_handler/sink_adaptor.rs
@@ -1,0 +1,44 @@
+//! Compatibility layer providing a [`DmlSink`] impl for [`IngesterData`].
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use data_types2::SequencerId;
+use dml::DmlOperation;
+
+use crate::{data::IngesterData, lifecycle::LifecycleHandle};
+
+use super::DmlSink;
+
+/// Provides a [`DmlSink`] implementation for a [`IngesterData`] instance.
+#[derive(Debug)]
+pub struct IngestSinkAdaptor {
+    ingest_data: Arc<IngesterData>,
+    lifecycle_handle: LifecycleHandle,
+    sequencer_id: SequencerId,
+}
+
+impl IngestSinkAdaptor {
+    /// Wrap an [`IngesterData`] in an adaptor layer to provide a [`DmlSink`]
+    /// implementation.
+    pub fn new(
+        ingest_data: Arc<IngesterData>,
+        lifecycle_handle: LifecycleHandle,
+        sequencer_id: SequencerId,
+    ) -> Self {
+        Self {
+            ingest_data,
+            lifecycle_handle,
+            sequencer_id,
+        }
+    }
+}
+
+#[async_trait]
+impl DmlSink for IngestSinkAdaptor {
+    async fn apply(&self, op: DmlOperation) -> Result<bool, crate::data::Error> {
+        self.ingest_data
+            .buffer_operation(self.sequencer_id, op, &self.lifecycle_handle)
+            .await
+    }
+}

--- a/ioxd_ingester/src/lib.rs
+++ b/ioxd_ingester/src/lib.rs
@@ -30,7 +30,6 @@ use ioxd_common::{
     setup_builder,
 };
 use thiserror::Error;
-use time::SystemProvider;
 
 #[derive(Debug, Error)]
 pub enum Error {
@@ -192,7 +191,6 @@ pub async fn create_ingester_server_type(
             write_buffer,
             exec,
             Arc::clone(&metric_registry),
-            Arc::new(SystemProvider::new()),
         )
         .await?,
     );


### PR DESCRIPTION
This PR switches out the old `stream_in_sequenced_entries()` kafka consumer for the `SequencedStreamHandler` introduced in #4203.

If this swap causes problems, reverting dce939c58 (or this whole PR) should switch back to the old code paths - if anything goes wrong, I'll be doing this to unblock prod once I've grabbed enough problem context. As such, depending on what time this PR is reviewed, I may **hold off merging** until Monday to ensure I am around when it is deployed.

Once merged the ingesters will emit slightly different metrics, and I will ensure the dashboards are updated.

- [x] Stream handler / reading from kafka (#4203)
- [x] High watermark fetcher (feeds into instrumentation) (#4235)
- [x] Instrumentation of op apply (#4243)
- [x] **THIS PR:** Impl DmlSink for existing write buffer code path (via compatibility adaptor)
- [x] **THIS PR:** Plumb in the `SequencedStreamHandler` and use it in prod

---

* feat: impl DmlSink for IngesterData (c2236fa3f)

      This commit adds an adaptor (IngestSinkAdaptor) that provides a DmlSink 
      implementation for the existing write path (IngesterData). With this, the
      existing write path becomes compatible with the new op stream handler
      (SequencedStreamHandler).

* refactor: accept !Sync write buffer streams (71a278ac7)

      Removes the Sync bound SequencedStreamHandler input stream type, as the 
      BoxStream returned by the WriteBufferStreamHandler is not Sync.

      This change means the SequencedStreamHandler is not Sync either, but is still
      Send and therefore can be moved into tokio tasks.

* refactor: use SequencedStreamHandler (dce939c58)

      Removes the old stream_in_sequenced_entries() write buffer handler, replacing
      it with the SequencedStreamHandler introduced in #4203.

      This change will affect the metrics emitted by an ingester as outlined in
      #4243.