### PR TITLE
feat: Store parquet_metadata in catalog, but don't fetch it by default

### DIFF
--- a/compactor/src/utils.rs
+++ b/compactor/src/utils.rs
@@ -89,8 +89,9 @@ impl ParquetFileWithTombstone {
         &self,
         object_store: Arc<DynObjectStore>,
         table_name: String,
+        parquet_metadata_bytes: Vec<u8>,
     ) -> QueryableParquetChunk {
-        let decoded_parquet_file = DecodedParquetFile::new((*self.data).clone());
+        let decoded_parquet_file = DecodedParquetFile::new(*self.data, parquet_metadata_bytes);
         let root_path = IoxObjectStore::root_path_for(&*object_store, self.data.object_store_id);
         let iox_object_store = IoxObjectStore::existing(object_store, root_path);
         let parquet_chunk = new_parquet_chunk(
@@ -115,12 +116,6 @@ impl ParquetFileWithTombstone {
             Arc::new(decoded_parquet_file.iox_metadata),
             &self.tombstones,
         )
-    }
-
-    /// Return iox metadata of the parquet file
-    pub fn iox_metadata(&self) -> IoxMetadata {
-        let decoded_parquet_file = DecodedParquetFile::new((*self.data).clone());
-        decoded_parquet_file.iox_metadata
     }
 }
 

--- a/compactor/src/utils.rs
+++ b/compactor/src/utils.rs
@@ -112,8 +112,11 @@ impl ParquetFileWithTombstone {
         QueryableParquetChunk::new(
             table_name,
             Arc::new(parquet_chunk),
-            Arc::new(decoded_parquet_file.iox_metadata),
             &self.tombstones,
+            self.data.min_sequence_number,
+            self.data.max_sequence_number,
+            self.data.min_time,
+            self.data.max_time,
         )
     }
 

--- a/data_types2/src/lib.rs
+++ b/data_types2/src/lib.rs
@@ -720,7 +720,7 @@ pub fn tombstones_to_delete_predicates_iter(
 }
 
 /// Data for a parquet file reference that has been inserted in the catalog.
-#[derive(Debug, Clone, PartialEq, sqlx::FromRow)]
+#[derive(Debug, Clone, Copy, PartialEq, sqlx::FromRow)]
 pub struct ParquetFile {
     /// the id of the file in the catalog
     pub id: ParquetFileId,
@@ -746,8 +746,6 @@ pub struct ParquetFile {
     pub to_delete: Option<Timestamp>,
     /// file size in bytes
     pub file_size_bytes: i64,
-    /// thrift-encoded parquet metadata
-    pub parquet_metadata: Vec<u8>,
     /// the number of rows of data in this file
     pub row_count: i64,
     /// the compaction level of the file

--- a/iox_catalog/src/interface.rs
+++ b/iox_catalog/src/interface.rs
@@ -559,6 +559,9 @@ pub trait ParquetFileRepo: Send + Sync {
     /// Verify if the parquet file exists by selecting its id
     async fn exist(&mut self, id: ParquetFileId) -> Result<bool>;
 
+    /// Fetch the parquet_metadata bytes for the given id. Potentially expensive.
+    async fn parquet_metadata(&mut self, id: ParquetFileId) -> Result<Vec<u8>>;
+
     /// Return count
     async fn count(&mut self) -> Result<i64>;
 
@@ -1737,6 +1740,13 @@ pub(crate) mod test_helpers {
             .create(parquet_file_params.clone())
             .await
             .unwrap();
+
+        let metadata = repos
+            .parquet_files()
+            .parquet_metadata(parquet_file.id)
+            .await
+            .unwrap();
+        assert_eq!(metadata, b"md1".to_vec());
 
         // verify that trying to create a file with the same UUID throws an error
         let err = repos

--- a/iox_catalog/src/interface.rs
+++ b/iox_catalog/src/interface.rs
@@ -1770,13 +1770,13 @@ pub(crate) mod test_helpers {
             .list_by_sequencer_greater_than(sequencer.id, SequenceNumber::new(1))
             .await
             .unwrap();
-        assert_eq!(vec![parquet_file.clone(), other_file.clone()], files);
+        assert_eq!(vec![parquet_file, other_file], files);
         let files = repos
             .parquet_files()
             .list_by_sequencer_greater_than(sequencer.id, SequenceNumber::new(150))
             .await
             .unwrap();
-        assert_eq!(vec![other_file.clone()], files);
+        assert_eq!(vec![other_file], files);
 
         // verify that to_delete is initially set to null and the file does not get deleted
         assert!(parquet_file.to_delete.is_none());
@@ -1890,7 +1890,7 @@ pub(crate) mod test_helpers {
             .list_by_namespace_not_to_delete(namespace2.id)
             .await
             .unwrap();
-        assert_eq!(vec![f1.clone(), f2.clone()], files);
+        assert_eq!(vec![f1, f2], files);
 
         let f3_params = ParquetFileParams {
             object_store_id: Uuid::new_v4(),
@@ -1906,7 +1906,7 @@ pub(crate) mod test_helpers {
             .list_by_namespace_not_to_delete(namespace2.id)
             .await
             .unwrap();
-        assert_eq!(vec![f1.clone(), f2.clone(), f3.clone()], files);
+        assert_eq!(vec![f1, f2, f3], files);
 
         repos.parquet_files().flag_for_delete(f2.id).await.unwrap();
         let files = repos
@@ -1914,7 +1914,7 @@ pub(crate) mod test_helpers {
             .list_by_namespace_not_to_delete(namespace2.id)
             .await
             .unwrap();
-        assert_eq!(vec![f1.clone(), f3.clone()], files);
+        assert_eq!(vec![f1, f3], files);
 
         let files = repos
             .parquet_files()
@@ -2519,7 +2519,7 @@ pub(crate) mod test_helpers {
         let nonexistent_parquet_file_id = ParquetFileId::new(level_0_file.id.get() + 1);
 
         // Level 0 parquet files should contain both existing files at this point
-        let expected = vec![parquet_file.clone(), level_0_file.clone()];
+        let expected = vec![parquet_file, level_0_file];
         let level_0 = repos.parquet_files().level_0(sequencer.id).await.unwrap();
         let mut level_0_ids: Vec<_> = level_0.iter().map(|pf| pf.id).collect();
         level_0_ids.sort();

--- a/iox_catalog/src/mem.rs
+++ b/iox_catalog/src/mem.rs
@@ -961,12 +961,11 @@ impl ParquetFileRepo for MemTxn {
             row_count,
             to_delete: None,
             file_size_bytes,
-            parquet_metadata,
             compaction_level,
             created_at,
         };
         stage.parquet_files.push(parquet_file);
-        Ok(stage.parquet_files.last().unwrap().clone())
+        Ok(*stage.parquet_files.last().unwrap())
     }
 
     async fn flag_for_delete(&mut self, id: ParquetFileId) -> Result<()> {

--- a/iox_catalog/src/metrics.rs
+++ b/iox_catalog/src/metrics.rs
@@ -275,6 +275,7 @@ decorate!(
         "parquet_level_1" = level_1(&mut self, table_partition: TablePartition, min_time: Timestamp, max_time: Timestamp) -> Result<Vec<ParquetFile>>;
         "parquet_update_to_level_1" = update_to_level_1(&mut self, parquet_file_ids: &[ParquetFileId]) -> Result<Vec<ParquetFileId>>;
         "parquet_exist" = exist(&mut self, id: ParquetFileId) -> Result<bool>;
+        "parquet_parquet_metadata" = parquet_metadata(&mut self, id: ParquetFileId) -> Result<Vec<u8>>;
         "parquet_count" = count(&mut self) -> Result<i64>;
         "parquet_count_by_overlaps" = count_by_overlaps(&mut self, table_id: TableId, sequencer_id: SequencerId, min_time: Timestamp, max_time: Timestamp, sequence_number: SequenceNumber) -> Result<i64>;
     ]

--- a/iox_catalog/src/metrics.rs
+++ b/iox_catalog/src/metrics.rs
@@ -8,9 +8,9 @@ use crate::interface::{
 use async_trait::async_trait;
 use data_types2::{
     Column, ColumnType, KafkaPartition, KafkaTopic, KafkaTopicId, Namespace, NamespaceId,
-    ParquetFile, ParquetFileId, ParquetFileParams, Partition, PartitionId, PartitionInfo,
-    ProcessedTombstone, QueryPool, QueryPoolId, SequenceNumber, Sequencer, SequencerId, Table,
-    TableId, TablePartition, Timestamp, Tombstone, TombstoneId,
+    ParquetFile, ParquetFileId, ParquetFileParams, ParquetFileWithMetadata, Partition, PartitionId,
+    PartitionInfo, ProcessedTombstone, QueryPool, QueryPoolId, SequenceNumber, Sequencer,
+    SequencerId, Table, TableId, TablePartition, Timestamp, Tombstone, TombstoneId,
 };
 use metric::{Metric, U64Histogram, U64HistogramOptions};
 use std::{fmt::Debug, sync::Arc};
@@ -269,9 +269,10 @@ decorate!(
         "parquet_list_by_sequencer_greater_than" = list_by_sequencer_greater_than(&mut self, sequencer_id: SequencerId, sequence_number: SequenceNumber) -> Result<Vec<ParquetFile>>;
         "parquet_list_by_namespace_not_to_delete" = list_by_namespace_not_to_delete(&mut self, namespace_id: NamespaceId) -> Result<Vec<ParquetFile>>;
         "parquet_list_by_table_not_to_delete" = list_by_table_not_to_delete(&mut self, table_id: TableId) -> Result<Vec<ParquetFile>>;
+        "parquet_list_by_table_not_to_delete_with_metadata" = list_by_table_not_to_delete_with_metadata(&mut self, table_id: TableId) -> Result<Vec<ParquetFileWithMetadata>>;
         "parquet_delete_old" = delete_old(&mut self, older_than: Timestamp) -> Result<Vec<ParquetFile>>;
         "parquet_list_by_partition_not_to_delete" = list_by_partition_not_to_delete(&mut self, partition_id: PartitionId) -> Result<Vec<ParquetFile>>;
-        "parquet_list_by_table_not_to_delete_with_metadata" = list_by_table_not_to_delete_with_metadata(&mut self, table_id: TableId) -> Result<Vec<(ParquetFile, Vec<u8>)>>;
+        "parquet_list_by_partition_not_to_delete_with_metadata" = list_by_partition_not_to_delete_with_metadata(&mut self, partition_id: PartitionId) -> Result<Vec<ParquetFileWithMetadata>>;
         "parquet_level_0" = level_0(&mut self, sequencer_id: SequencerId) -> Result<Vec<ParquetFile>>;
         "parquet_level_1" = level_1(&mut self, table_partition: TablePartition, min_time: Timestamp, max_time: Timestamp) -> Result<Vec<ParquetFile>>;
         "parquet_update_to_level_1" = update_to_level_1(&mut self, parquet_file_ids: &[ParquetFileId]) -> Result<Vec<ParquetFileId>>;

--- a/iox_catalog/src/metrics.rs
+++ b/iox_catalog/src/metrics.rs
@@ -271,6 +271,7 @@ decorate!(
         "parquet_list_by_table_not_to_delete" = list_by_table_not_to_delete(&mut self, table_id: TableId) -> Result<Vec<ParquetFile>>;
         "parquet_delete_old" = delete_old(&mut self, older_than: Timestamp) -> Result<Vec<ParquetFile>>;
         "parquet_list_by_partition_not_to_delete" = list_by_partition_not_to_delete(&mut self, partition_id: PartitionId) -> Result<Vec<ParquetFile>>;
+        "parquet_list_by_table_not_to_delete_with_metadata" = list_by_table_not_to_delete_with_metadata(&mut self, table_id: TableId) -> Result<Vec<(ParquetFile, Vec<u8>)>>;
         "parquet_level_0" = level_0(&mut self, sequencer_id: SequencerId) -> Result<Vec<ParquetFile>>;
         "parquet_level_1" = level_1(&mut self, table_partition: TablePartition, min_time: Timestamp, max_time: Timestamp) -> Result<Vec<ParquetFile>>;
         "parquet_update_to_level_1" = update_to_level_1(&mut self, parquet_file_ids: &[ParquetFileId]) -> Result<Vec<ParquetFileId>>;

--- a/iox_catalog/src/metrics.rs
+++ b/iox_catalog/src/metrics.rs
@@ -276,7 +276,7 @@ decorate!(
         "parquet_level_1" = level_1(&mut self, table_partition: TablePartition, min_time: Timestamp, max_time: Timestamp) -> Result<Vec<ParquetFile>>;
         "parquet_update_to_level_1" = update_to_level_1(&mut self, parquet_file_ids: &[ParquetFileId]) -> Result<Vec<ParquetFileId>>;
         "parquet_exist" = exist(&mut self, id: ParquetFileId) -> Result<bool>;
-        "parquet_parquet_metadata" = parquet_metadata(&mut self, id: ParquetFileId) -> Result<Vec<u8>>;
+        "parquet_metadata" = parquet_metadata(&mut self, id: ParquetFileId) -> Result<Vec<u8>>;
         "parquet_count" = count(&mut self) -> Result<i64>;
         "parquet_count_by_overlaps" = count_by_overlaps(&mut self, table_id: TableId, sequencer_id: SequencerId, min_time: Timestamp, max_time: Timestamp, sequence_number: SequenceNumber) -> Result<i64>;
     ]

--- a/iox_catalog/src/postgres.rs
+++ b/iox_catalog/src/postgres.rs
@@ -1502,9 +1502,13 @@ RETURNING *;
         sequencer_id: SequencerId,
         sequence_number: SequenceNumber,
     ) -> Result<Vec<ParquetFile>> {
+        // Deliberately doesn't use `SELECT *` to avoid the performance hit of fetching the large
+        // `parquet_metadata` column!!
         sqlx::query_as::<_, ParquetFile>(
             r#"
-SELECT *
+SELECT id, sequencer_id, namespace_id, table_id, partition_id, object_store_id,
+       min_sequence_number, max_sequence_number, min_time, max_time, to_delete, file_size_bytes,
+       row_count, compaction_level, created_at
 FROM parquet_file
 WHERE sequencer_id = $1
   AND max_sequence_number > $2
@@ -1522,9 +1526,15 @@ ORDER BY id;
         &mut self,
         namespace_id: NamespaceId,
     ) -> Result<Vec<ParquetFile>> {
+        // Deliberately doesn't use `SELECT *` to avoid the performance hit of fetching the large
+        // `parquet_metadata` column!!
         sqlx::query_as::<_, ParquetFile>(
             r#"
-SELECT parquet_file.*
+SELECT parquet_file.id, parquet_file.sequencer_id, parquet_file.namespace_id,
+       parquet_file.table_id, parquet_file.partition_id, parquet_file.object_store_id,
+       parquet_file.min_sequence_number, parquet_file.max_sequence_number, parquet_file.min_time,
+       parquet_file.max_time, parquet_file.to_delete, parquet_file.file_size_bytes,
+       parquet_file.row_count, parquet_file.compaction_level, parquet_file.created_at
 FROM parquet_file
 INNER JOIN table_name on table_name.id = parquet_file.table_id
 WHERE table_name.namespace_id = $1
@@ -1538,9 +1548,13 @@ WHERE table_name.namespace_id = $1
     }
 
     async fn list_by_table_not_to_delete(&mut self, table_id: TableId) -> Result<Vec<ParquetFile>> {
+        // Deliberately doesn't use `SELECT *` to avoid the performance hit of fetching the large
+        // `parquet_metadata` column!!
         sqlx::query_as::<_, ParquetFile>(
             r#"
-SELECT *
+SELECT id, sequencer_id, namespace_id, table_id, partition_id, object_store_id,
+       min_sequence_number, max_sequence_number, min_time, max_time, to_delete, file_size_bytes,
+       row_count, compaction_level, created_at
 FROM parquet_file
 WHERE table_id = $1 AND to_delete IS NULL;
              "#,
@@ -1568,10 +1582,14 @@ RETURNING *;
     async fn level_0(&mut self, sequencer_id: SequencerId) -> Result<Vec<ParquetFile>> {
         // this intentionally limits the returned files to 10,000 as it is used to make
         // a decision on the highest priority partitions. If compaction has never been
-        // run this could end up returning millions of results and taking too long to run
+        // run this could end up returning millions of results and taking too long to run.
+        // Deliberately doesn't use `SELECT *` to avoid the performance hit of fetching the large
+        // `parquet_metadata` column!!
         sqlx::query_as::<_, ParquetFile>(
             r#"
-SELECT *
+SELECT id, sequencer_id, namespace_id, table_id, partition_id, object_store_id,
+       min_sequence_number, max_sequence_number, min_time, max_time, to_delete, file_size_bytes,
+       row_count, compaction_level, created_at
 FROM parquet_file
 WHERE parquet_file.sequencer_id = $1
   AND parquet_file.compaction_level = 0
@@ -1591,9 +1609,13 @@ WHERE parquet_file.sequencer_id = $1
         min_time: Timestamp,
         max_time: Timestamp,
     ) -> Result<Vec<ParquetFile>> {
+        // Deliberately doesn't use `SELECT *` to avoid the performance hit of fetching the large
+        // `parquet_metadata` column!!
         sqlx::query_as::<_, ParquetFile>(
             r#"
-SELECT *
+SELECT id, sequencer_id, namespace_id, table_id, partition_id, object_store_id,
+       min_sequence_number, max_sequence_number, min_time, max_time, to_delete, file_size_bytes,
+       row_count, compaction_level, created_at
 FROM parquet_file
 WHERE parquet_file.sequencer_id = $1
   AND parquet_file.table_id = $2
@@ -1618,9 +1640,13 @@ WHERE parquet_file.sequencer_id = $1
         &mut self,
         partition_id: PartitionId,
     ) -> Result<Vec<ParquetFile>> {
+        // Deliberately doesn't use `SELECT *` to avoid the performance hit of fetching the large
+        // `parquet_metadata` column!!
         sqlx::query_as::<_, ParquetFile>(
             r#"
-SELECT *
+SELECT id, sequencer_id, namespace_id, table_id, partition_id, object_store_id,
+       min_sequence_number, max_sequence_number, min_time, max_time, to_delete, file_size_bytes,
+       row_count, compaction_level, created_at
 FROM parquet_file
 WHERE parquet_file.partition_id = $1
   AND parquet_file.to_delete IS NULL;

--- a/iox_catalog/src/postgres.rs
+++ b/iox_catalog/src/postgres.rs
@@ -1694,6 +1694,17 @@ RETURNING id;
         Ok(read_result.count > 0)
     }
 
+    async fn parquet_metadata(&mut self, id: ParquetFileId) -> Result<Vec<u8>> {
+        let read_result =
+            sqlx::query(r#"SELECT parquet_metadata FROM parquet_file WHERE id = $1;"#)
+                .bind(&id) // $1
+                .fetch_one(&mut self.inner)
+                .await
+                .map_err(|e| Error::SqlxError { source: e })?;
+
+        Ok(read_result.get("parquet_metadata"))
+    }
+
     async fn count(&mut self) -> Result<i64> {
         let read_result =
             sqlx::query_as::<_, Count>(r#"SELECT count(*) as count FROM parquet_file;"#)

--- a/iox_tests/src/util.rs
+++ b/iox_tests/src/util.rs
@@ -6,9 +6,9 @@ use arrow::{
 };
 use bytes::Bytes;
 use data_types2::{
-    Column, ColumnType, KafkaPartition, KafkaTopic, Namespace, ParquetFile, ParquetFileParams,
-    Partition, QueryPool, SequenceNumber, Sequencer, SequencerId, Table, TableId, Timestamp,
-    Tombstone, TombstoneId,
+    Column, ColumnType, KafkaPartition, KafkaTopic, Namespace, ParquetFile, ParquetFileId,
+    ParquetFileParams, Partition, QueryPool, SequenceNumber, Sequencer, SequencerId, Table,
+    TableId, Timestamp, Tombstone, TombstoneId,
 };
 use iox_catalog::{
     interface::{Catalog, INITIAL_COMPACTION_LEVEL},
@@ -186,6 +186,17 @@ impl TestCatalog {
             .await
             .parquet_files()
             .list_by_table_not_to_delete(table_id)
+            .await
+            .unwrap()
+    }
+
+    /// Get a parquet file's metadata bytes
+    pub async fn parquet_metadata(&self, parquet_file_id: ParquetFileId) -> Vec<u8> {
+        self.catalog
+            .repositories()
+            .await
+            .parquet_files()
+            .parquet_metadata(parquet_file_id)
             .await
             .unwrap()
     }

--- a/iox_tests/src/util.rs
+++ b/iox_tests/src/util.rs
@@ -7,8 +7,8 @@ use arrow::{
 use bytes::Bytes;
 use data_types2::{
     Column, ColumnType, KafkaPartition, KafkaTopic, Namespace, ParquetFile, ParquetFileId,
-    ParquetFileParams, Partition, QueryPool, SequenceNumber, Sequencer, SequencerId, Table,
-    TableId, Timestamp, Tombstone, TombstoneId,
+    ParquetFileParams, ParquetFileWithMetadata, Partition, QueryPool, SequenceNumber, Sequencer,
+    SequencerId, Table, TableId, Timestamp, Tombstone, TombstoneId,
 };
 use iox_catalog::{
     interface::{Catalog, INITIAL_COMPACTION_LEVEL},
@@ -186,6 +186,20 @@ impl TestCatalog {
             .await
             .parquet_files()
             .list_by_table_not_to_delete(table_id)
+            .await
+            .unwrap()
+    }
+
+    /// List all non-deleted files with their metadata
+    pub async fn list_by_table_not_to_delete_with_metadata(
+        self: &Arc<Self>,
+        table_id: TableId,
+    ) -> Vec<ParquetFileWithMetadata> {
+        self.catalog
+            .repositories()
+            .await
+            .parquet_files()
+            .list_by_table_not_to_delete_with_metadata(table_id)
             .await
             .unwrap()
     }
@@ -384,7 +398,7 @@ pub struct TestPartition {
 
 impl TestPartition {
     /// Create a parquet for the partition
-    pub async fn create_parquet_file(self: &Arc<Self>, lp: &str) -> Arc<TestParquetFile> {
+    pub async fn create_parquet_file(self: &Arc<Self>, lp: &str) -> TestParquetFile {
         self.create_parquet_file_with_min_max(
             lp,
             1,
@@ -403,7 +417,7 @@ impl TestPartition {
         max_seq: i64,
         min_time: i64,
         max_time: i64,
-    ) -> Arc<TestParquetFile> {
+    ) -> TestParquetFile {
         self.create_parquet_file_with_min_max_and_creation_time(
             lp, min_seq, max_seq, min_time, max_time, 1,
         )
@@ -419,7 +433,7 @@ impl TestPartition {
         min_time: i64,
         max_time: i64,
         creation_time: i64,
-    ) -> Arc<TestParquetFile> {
+    ) -> TestParquetFile {
         let mut repos = self.catalog.catalog.repositories().await;
 
         let (table, batch) = lp_to_mutable_batch(lp);
@@ -462,7 +476,7 @@ impl TestPartition {
             min_time: Timestamp::new(min_time),
             max_time: Timestamp::new(max_time),
             file_size_bytes: real_file_size_bytes as i64,
-            parquet_metadata: parquet_metadata_bin,
+            parquet_metadata: parquet_metadata_bin.clone(),
             row_count: row_count as i64,
             created_at: Timestamp::new(creation_time),
             compaction_level: INITIAL_COMPACTION_LEVEL,
@@ -473,11 +487,13 @@ impl TestPartition {
             .await
             .unwrap();
 
-        Arc::new(TestParquetFile {
+        let parquet_file = ParquetFileWithMetadata::new(parquet_file, parquet_metadata_bin);
+
+        TestParquetFile {
             catalog: Arc::clone(&self.catalog),
             namespace: Arc::clone(&self.namespace),
             parquet_file,
-        })
+        }
     }
 
     /// Create a parquet for the partition with fake sizew for testing
@@ -491,7 +507,7 @@ impl TestPartition {
         max_time: i64,
         file_size_bytes: i64,
         creation_time: i64,
-    ) -> Arc<TestParquetFile> {
+    ) -> TestParquetFile {
         let mut repos = self.catalog.catalog.repositories().await;
 
         let (table, batch) = lp_to_mutable_batch(lp);
@@ -534,7 +550,7 @@ impl TestPartition {
             min_time: Timestamp::new(min_time),
             max_time: Timestamp::new(max_time),
             file_size_bytes,
-            parquet_metadata: parquet_metadata_bin,
+            parquet_metadata: parquet_metadata_bin.clone(),
             row_count: row_count as i64,
             created_at: Timestamp::new(creation_time),
             compaction_level: INITIAL_COMPACTION_LEVEL,
@@ -545,11 +561,13 @@ impl TestPartition {
             .await
             .unwrap();
 
-        Arc::new(TestParquetFile {
+        let parquet_file = ParquetFileWithMetadata::new(parquet_file, parquet_metadata_bin);
+
+        TestParquetFile {
             catalog: Arc::clone(&self.catalog),
             namespace: Arc::clone(&self.namespace),
             parquet_file,
-        })
+        }
     }
 }
 
@@ -601,12 +619,12 @@ async fn create_parquet_file(
 pub struct TestParquetFile {
     pub catalog: Arc<TestCatalog>,
     pub namespace: Arc<TestNamespace>,
-    pub parquet_file: ParquetFile,
+    pub parquet_file: ParquetFileWithMetadata,
 }
 
 impl TestParquetFile {
     /// Make the parquet file deletable
-    pub async fn flag_for_delete(self: &Arc<Self>) {
+    pub async fn flag_for_delete(&self) {
         let mut repos = self.catalog.catalog.repositories().await;
 
         repos
@@ -614,6 +632,11 @@ impl TestParquetFile {
             .flag_for_delete(self.parquet_file.id)
             .await
             .unwrap()
+    }
+
+    /// When only the ParquetFile is needed without the metadata, use this instead of the field
+    pub fn parquet_file_no_metadata(self) -> ParquetFile {
+        self.parquet_file.split_off_metadata().0
     }
 }
 
@@ -627,7 +650,7 @@ pub struct TestTombstone {
 
 impl TestTombstone {
     /// mark the tombstone proccesed
-    pub async fn mark_processed(self: &Arc<Self>, parquet_file: &Arc<TestParquetFile>) {
+    pub async fn mark_processed(self: &Arc<Self>, parquet_file: &TestParquetFile) {
         assert!(Arc::ptr_eq(&self.catalog, &parquet_file.catalog));
         assert!(Arc::ptr_eq(&self.namespace, &parquet_file.namespace));
 

--- a/parquet_file/src/chunk.rs
+++ b/parquet_file/src/chunk.rs
@@ -6,7 +6,7 @@ use data_types::{
     partition_metadata::{Statistics, TableSummary},
     timestamp::{TimestampMinMax, TimestampRange},
 };
-use data_types2::ParquetFile;
+use data_types2::{ParquetFile, ParquetFileWithMetadata};
 use datafusion::physical_plan::SendableRecordBatchStream;
 use iox_object_store::{IoxObjectStore, ParquetFilePath};
 use observability_deps::tracing::*;
@@ -280,10 +280,9 @@ pub struct DecodedParquetFile {
 }
 
 impl DecodedParquetFile {
-    pub fn new(parquet_file: ParquetFile, parquet_metadata_bytes: Vec<u8>) -> Self {
-        let parquet_metadata = Arc::new(IoxParquetMetaData::from_thrift_bytes(
-            parquet_metadata_bytes,
-        ));
+    pub fn new(parquet_file_with_metadata: ParquetFileWithMetadata) -> Self {
+        let (parquet_file, parquet_metadata) = parquet_file_with_metadata.split_off_metadata();
+        let parquet_metadata = Arc::new(IoxParquetMetaData::from_thrift_bytes(parquet_metadata));
         let decoded_metadata = parquet_metadata.decode().expect("parquet metadata broken");
         let iox_metadata = decoded_metadata
             .read_iox_metadata_new()

--- a/parquet_file/src/chunk.rs
+++ b/parquet_file/src/chunk.rs
@@ -280,9 +280,9 @@ pub struct DecodedParquetFile {
 }
 
 impl DecodedParquetFile {
-    pub fn new(parquet_file: ParquetFile) -> Self {
+    pub fn new(parquet_file: ParquetFile, parquet_metadata_bytes: Vec<u8>) -> Self {
         let parquet_metadata = Arc::new(IoxParquetMetaData::from_thrift_bytes(
-            parquet_file.parquet_metadata.clone(),
+            parquet_metadata_bytes,
         ));
         let decoded_metadata = parquet_metadata.decode().expect("parquet metadata broken");
         let iox_metadata = decoded_metadata

--- a/querier/src/table/mod.rs
+++ b/querier/src/table/mod.rs
@@ -7,7 +7,7 @@ use crate::{
     IngesterConnection,
 };
 use backoff::{Backoff, BackoffConfig};
-use data_types2::{ParquetFile, TableId};
+use data_types2::{ParquetFileWithMetadata, TableId};
 use observability_deps::tracing::debug;
 use predicate::Predicate;
 use query::{provider::ChunkPruner, QueryChunk};
@@ -256,7 +256,10 @@ impl QuerierTable {
 ///
 /// Specificially, ensure that the persisted number from all
 /// chunks is consistent with the parquet files we know about
-fn validate_cache(_partitions: &[Arc<IngesterPartition>], _parquet_files: &[ParquetFile]) -> bool {
+fn validate_cache(
+    _partitions: &[Arc<IngesterPartition>],
+    _parquet_files: &[ParquetFileWithMetadata],
+) -> bool {
     // TODO fill out the validation logic here
     true
 }

--- a/querier/src/table/mod.rs
+++ b/querier/src/table/mod.rs
@@ -132,10 +132,10 @@ impl QuerierTable {
 
         // convert parquet files and tombstones to nicer objects
         let mut chunks = Vec::with_capacity(parquet_files.len());
-        for (parquet_file, parquet_metadata) in parquet_files {
+        for parquet_file_with_metadata in parquet_files {
             if let Some(chunk) = self
                 .chunk_adapter
-                .new_querier_chunk(parquet_file, parquet_metadata)
+                .new_querier_chunk(parquet_file_with_metadata)
                 .await
             {
                 chunks.push(chunk);

--- a/querier/src/table/mod.rs
+++ b/querier/src/table/mod.rs
@@ -107,7 +107,7 @@ impl QuerierTable {
 
                     let parquet_files = txn
                         .parquet_files()
-                        .list_by_table_not_to_delete(self.id)
+                        .list_by_table_not_to_delete_with_metadata(self.id)
                         .await?;
 
                     let tombstones = txn.tombstones().list_by_table(self.id).await?;
@@ -132,8 +132,12 @@ impl QuerierTable {
 
         // convert parquet files and tombstones to nicer objects
         let mut chunks = Vec::with_capacity(parquet_files.len());
-        for parquet_file in parquet_files {
-            if let Some(chunk) = self.chunk_adapter.new_querier_chunk(parquet_file).await {
+        for (parquet_file, parquet_metadata) in parquet_files {
+            if let Some(chunk) = self
+                .chunk_adapter
+                .new_querier_chunk(parquet_file, parquet_metadata)
+                .await
+            {
                 chunks.push(chunk);
             }
         }


### PR DESCRIPTION
Connects to #4124.

This is an incremental step to stop fetching the parquet_metadata column from the parquet_files table for most parquet_files queries, which should help with performance.

The places that do use the metadata are still fetching it and decoding it for now. For one place, I made a special `_with_metadata` catalog method. For the other place, I'm doing more queries to get each parquet file's metadata column. It was slightly easier to do each place this way, but not impossible to change either place to use the other technique, so let me know if you'd like me to make these consistent.

However, the next steps should be trying to move to using other catalog data instead of the parquet_metadata, so that change may be moot. These next steps are not trivial 😅 

If we end up removing all uses of the `parquet_metadata` column, then we can stop saving it in the catalog altogether, but this PR isn't there yet. If we decide to keep using `parquet_metadata`, I might recommend storing it in a different catalog table than `parquet_files` so that we don't have to remember not to do `SELECT *` on `parquet_files`.