### PR TITLE
build: use rust 1.60

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.59"
+channel = "1.60"
 components = [ "rustfmt", "clippy" ]


### PR DESCRIPTION
[Much improvement, many toy](https://blog.rust-lang.org/2022/04/07/Rust-1.60.0.html).

---

* build: use rust 1.60 (3624d635)