### PR TITLE
ci: remove duplicate RUSTFLAGS definition

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -422,7 +422,7 @@ jobs:
       # https://github.com/influxdata/influxdb_iox/pull/2119
       ROARING_ARCH: "haswell"
       # Use avx512 instructions to take full advantage of the CPUs instruction set
-      RUSTFLAGS: "-C target-feature=+avx2"
+      RUSTFLAGS: "-C target-feature=+avx2 -C link-arg=-fuse-ld=lld"
       # https://github.com/rust-lang/cargo/issues/10280
       CARGO_NET_GIT_FETCH_WITH_CLI: "true"
     steps:
@@ -438,7 +438,7 @@ jobs:
 
             docker buildx build \
               --build-arg RUST_VERSION="$RUST_VERSION" \
-              --build-arg RUSTFLAGS="-C target-feature=+avx2 -C link-arg=-fuse-ld=lld" \
+              --build-arg RUSTFLAGS="$RUSTFLAGS" \
               --progress plain \
               --tag quay.io/influxdb/iox:"$COMMIT_SHA" \
               .
@@ -446,7 +446,7 @@ jobs:
               --build-arg FEATURES="" \
               --build-arg PACKAGE="iox_data_generator" \
               --build-arg RUST_VERSION="$RUST_VERSION" \
-              --build-arg RUSTFLAGS="-C target-feature=+avx2 -C link-arg=-fuse-ld=lld" \
+              --build-arg RUSTFLAGS="$RUSTFLAGS" \
               --progress plain \
               --tag quay.io/influxdb/iox_data_generator:"$COMMIT_SHA" \
               .
@@ -454,7 +454,7 @@ jobs:
               --build-arg FEATURES="" \
               --build-arg PACKAGE="iox_gitops_adapter" \
               --build-arg RUST_VERSION="$RUST_VERSION" \
-              --build-arg RUSTFLAGS="-C target-feature=+avx2 -C link-arg=-fuse-ld=lld" \
+              --build-arg RUSTFLAGS="$RUSTFLAGS" \
               --progress plain \
               --tag quay.io/influxdb/iox_gitops_adapter:"$COMMIT_SHA" \
               .


### PR DESCRIPTION
🧹 cleanup 🧹 

---

* ci: remove duplicate RUSTFLAGS definition (6aac162e)

      This commit unifies RUSTFLAGS config in the CircleCI config.

      Previously in the CircleCI config file for the "build_release" job, we specify
      an env var (RUSTFLAGS) in the env config section, but then override / use a
      different value when passing flags to the docker build steps.