### PR TITLE
refactor: disable max_debug static tracing level

### DIFF
--- a/iox_gitops_adapter/Cargo.toml
+++ b/iox_gitops_adapter/Cargo.toml
@@ -30,7 +30,7 @@ serde_json = "1.0"
 thiserror = "1.0"
 tokio = { version = "1.17", features = ["rt-multi-thread", "macros", "parking_lot"] }
 tonic = "0.6"
-tracing = { version = "0.1", features = ["release_max_level_debug"] }
+tracing = { version = "0.1" }
 workspace-hack = { path = "../workspace-hack"}
 trogging = { path = "../trogging", default-features = false, features = ["clap"] }
 

--- a/observability_deps/Cargo.toml
+++ b/observability_deps/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 description = "Observability ecosystem dependencies for InfluxDB IOx, to ensure consistent versions and unified updates"
 
 [dependencies] # In alphabetical order
-tracing = { version = "0.1", features = ["max_level_trace", "release_max_level_debug"] }
+tracing = { version = "0.1", features = ["max_level_trace"] }
 workspace-hack = { path = "../workspace-hack"}
 
 [features]

--- a/workspace-hack/Cargo.toml
+++ b/workspace-hack/Cargo.toml
@@ -65,7 +65,7 @@ tokio-stream = { version = "0.1", features = ["fs", "net", "time"] }
 tokio-util = { version = "0.7", features = ["codec", "io", "slab", "time", "tracing"] }
 tower = { version = "0.4", features = ["__common", "balance", "buffer", "discover", "filter", "futures-core", "futures-util", "indexmap", "limit", "load", "log", "make", "pin-project", "pin-project-lite", "rand", "ready-cache", "slab", "timeout", "tokio", "tokio-util", "tracing", "util"] }
 tower-http = { version = "0.2", features = ["auth", "base64", "map-response-body", "tower", "trace", "tracing", "util"] }
-tracing = { version = "0.1", features = ["attributes", "log", "max_level_trace", "release_max_level_debug", "release_max_level_trace", "std", "tracing-attributes"] }
+tracing = { version = "0.1", features = ["attributes", "log", "max_level_trace", "release_max_level_trace", "std", "tracing-attributes"] }
 tracing-core = { version = "0.1", features = ["lazy_static", "std"] }
 tracing-log = { version = "0.1", features = ["log-tracer", "std", "trace-logger"] }
 tracing-subscriber = { version = "0.3", features = ["alloc", "ansi", "ansi_term", "env-filter", "fmt", "json", "lazy_static", "matchers", "parking_lot", "regex", "registry", "serde", "serde_json", "sharded-slab", "smallvec", "std", "thread_local", "tracing", "tracing-log", "tracing-serde"] }


### PR DESCRIPTION
This was fun.

Usually features are (read: should be) additive, but this is not the case with tracing, and the "trace" level logs were being suppressed in the final binary. Hakari only added to the fun by enabling the debug feature even when it was removed from the iox binary.

---

* refactor: disable max_debug static tracing level (63e2a522)

      The tracing "release_max_level_*" feature flags are not additive, and are hard
      to use - especially when the workspace-hack crate enables features behind your
      back!