### PR TITLE
refactor: reduce duplication in NG end to end testing scenarios

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6002,6 +6002,7 @@ name = "test_helpers_end_to_end_ng"
 version = "0.1.0"
 dependencies = [
  "arrow",
+ "arrow_util",
  "assert_cmd",
  "futures",
  "http",

--- a/influxdb_iox/tests/end_to_end_ng_cases/querier.rs
+++ b/influxdb_iox/tests/end_to_end_ng_cases/querier.rs
@@ -1,8 +1,5 @@
-use arrow_util::assert_batches_sorted_eq;
-use http::StatusCode;
 use test_helpers_end_to_end_ng::{
-    get_write_token, maybe_skip_integration, run_query, wait_for_persisted, wait_for_readable,
-    MiniCluster, TestConfig,
+    maybe_skip_integration, write_read::WriteReadTest, MiniCluster, TestConfig,
 };
 
 #[tokio::test]
@@ -24,37 +21,23 @@ async fn basic_ingester() {
         .with_querier(querier_config)
         .await;
 
-    // Write some data into the v2 HTTP API ==============
-    let lp = format!(
-        "{},tag1=A,tag2=B val=42i 123456\n\
-                      {},tag1=A,tag2=C val=43i 123457",
-        table_name, table_name
-    );
-    let response = cluster.write_to_router(lp).await;
-    assert_eq!(response.status(), StatusCode::NO_CONTENT);
-
-    // Wait for data to be readable
-    let write_token = get_write_token(&response);
-    wait_for_readable(write_token, cluster.ingester().ingester_grpc_connection()).await;
-
-    // run query
-    let sql = format!("select * from {}", table_name);
-    let batches = run_query(
-        sql,
-        cluster.namespace(),
-        cluster.querier().querier_grpc_connection(),
-    )
-    .await;
-
-    let expected = [
-        "+------+------+--------------------------------+-----+",
-        "| tag1 | tag2 | time                           | val |",
-        "+------+------+--------------------------------+-----+",
-        "| A    | B    | 1970-01-01T00:00:00.000123456Z | 42  |",
-        "| A    | C    | 1970-01-01T00:00:00.000123457Z | 43  |",
-        "+------+------+--------------------------------+-----+",
-    ];
-    assert_batches_sorted_eq!(&expected, &batches);
+    WriteReadTest::new(&cluster)
+        .with_line_protocol(format!(
+            "{},tag1=A,tag2=B val=42i 123456\n\
+             {},tag1=A,tag2=C val=43i 123457",
+            table_name, table_name
+        ))
+        .with_query(format!("select * from {}", table_name))
+        .with_expected([
+            "+------+------+--------------------------------+-----+",
+            "| tag1 | tag2 | time                           | val |",
+            "+------+------+--------------------------------+-----+",
+            "| A    | B    | 1970-01-01T00:00:00.000123456Z | 42  |",
+            "| A    | C    | 1970-01-01T00:00:00.000123457Z | 43  |",
+            "+------+------+--------------------------------+-----+",
+        ])
+        .run()
+        .await
 }
 
 #[tokio::test]
@@ -77,32 +60,20 @@ async fn basic_on_parquet() {
         .with_querier(querier_config)
         .await;
 
-    // Write some data into the v2 HTTP API ==============
-    let lp = format!("{},tag1=A,tag2=B val=42i 123456", table_name);
-    let response = cluster.write_to_router(lp).await;
-    assert_eq!(response.status(), StatusCode::NO_CONTENT);
-
-    // Wait for data to be persisted to parquet
-    let write_token = get_write_token(&response);
-    wait_for_persisted(write_token, cluster.ingester().ingester_grpc_connection()).await;
-
-    // run query
-    let sql = format!("select * from {}", table_name);
-    let batches = run_query(
-        sql,
-        cluster.namespace(),
-        cluster.querier().querier_grpc_connection(),
-    )
-    .await;
-
-    let expected = [
-        "+------+------+--------------------------------+-----+",
-        "| tag1 | tag2 | time                           | val |",
-        "+------+------+--------------------------------+-----+",
-        "| A    | B    | 1970-01-01T00:00:00.000123456Z | 42  |",
-        "+------+------+--------------------------------+-----+",
-    ];
-    assert_batches_sorted_eq!(&expected, &batches);
+    WriteReadTest::new(&cluster)
+        .with_line_protocol(format!("{},tag1=A,tag2=B val=42i 123456", table_name))
+        // Wait for data to be persisted to parquet
+        .with_wait_for_parquet()
+        .with_query(format!("select * from {}", table_name))
+        .with_expected([
+            "+------+------+--------------------------------+-----+",
+            "| tag1 | tag2 | time                           | val |",
+            "+------+------+--------------------------------+-----+",
+            "| A    | B    | 1970-01-01T00:00:00.000123456Z | 42  |",
+            "+------+------+--------------------------------+-----+",
+        ])
+        .run()
+        .await
 }
 
 #[tokio::test]
@@ -128,29 +99,18 @@ async fn basic_no_ingster_connection() {
         .await;
 
     // Write some data into the v2 HTTP API ==============
-    let lp = format!("{},tag1=A,tag2=B val=42i 123456", table_name);
-    let response = cluster.write_to_router(lp).await;
-    assert_eq!(response.status(), StatusCode::NO_CONTENT);
-
-    // Wait for data to be persisted to parquet
-    let write_token = get_write_token(&response);
-    wait_for_persisted(write_token, cluster.ingester().ingester_grpc_connection()).await;
-
-    // run query
-    let sql = format!("select * from {}", table_name);
-    let batches = run_query(
-        sql,
-        cluster.namespace(),
-        cluster.querier().querier_grpc_connection(),
-    )
-    .await;
-
-    let expected = [
-        "+------+------+--------------------------------+-----+",
-        "| tag1 | tag2 | time                           | val |",
-        "+------+------+--------------------------------+-----+",
-        "| A    | B    | 1970-01-01T00:00:00.000123456Z | 42  |",
-        "+------+------+--------------------------------+-----+",
-    ];
-    assert_batches_sorted_eq!(&expected, &batches);
+    WriteReadTest::new(&cluster)
+        .with_line_protocol(format!("{},tag1=A,tag2=B val=42i 123456", table_name))
+        // Wait for data to be persisted to parquet
+        .with_wait_for_parquet()
+        .with_query(format!("select * from {}", table_name))
+        .with_expected([
+            "+------+------+--------------------------------+-----+",
+            "| tag1 | tag2 | time                           | val |",
+            "+------+------+--------------------------------+-----+",
+            "| A    | B    | 1970-01-01T00:00:00.000123456Z | 42  |",
+            "+------+------+--------------------------------+-----+",
+        ])
+        .run()
+        .await
 }

--- a/test_helpers_end_to_end_ng/Cargo.toml
+++ b/test_helpers_end_to_end_ng/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 
 [dependencies]
 # Workspace dependencies, in alphabetical order
+arrow_util = { path = "../arrow_util" }
 influxdb_iox_client = { path = "../influxdb_iox_client", features = ["flight", "format", "write_lp"] }
 test_helpers = { path = "../test_helpers" }
 

--- a/test_helpers_end_to_end_ng/src/lib.rs
+++ b/test_helpers_end_to_end_ng/src/lib.rs
@@ -7,6 +7,7 @@ mod database;
 mod mini_cluster;
 mod server_fixture;
 mod server_type;
+pub mod write_read;
 
 pub use client::*;
 pub use config::TestConfig;

--- a/test_helpers_end_to_end_ng/src/write_read.rs
+++ b/test_helpers_end_to_end_ng/src/write_read.rs
@@ -1,0 +1,101 @@
+use http::StatusCode;
+
+use arrow_util::assert_batches_sorted_eq;
+
+use crate::{get_write_token, run_query, wait_for_persisted, wait_for_readable, MiniCluster};
+
+/// Helper for running a test that:
+/// 1. Starts up a MiniCluster,
+/// 2. Optionally writes data to it
+/// 3. Optionally waits for the data after write
+/// 4. Runs a query and compares it to the expected output
+pub struct WriteReadTest<'a> {
+    cluster: &'a MiniCluster,
+
+    /// data to write
+    line_protocol: Option<String>,
+
+    /// should the test harness wait for it to be persisted?
+    wait_for_parquet: bool,
+
+    /// SQL Query to run
+    query: Option<String>,
+
+    /// results to compare results against
+    expected: Option<Vec<String>>,
+}
+
+impl<'a> WriteReadTest<'a> {
+    /// Create a new ready/write test. Must be configured via
+    /// `with_line_protocol`, `with_wait_for_persisted`, `with_query`
+    /// and `with_expected` or else will panic
+    pub fn new(cluster: &'a MiniCluster) -> Self {
+        Self {
+            cluster,
+            line_protocol: None,
+            wait_for_parquet: false,
+            query: None,
+            expected: None,
+        }
+    }
+
+    pub fn with_line_protocol(mut self, line_protocol: impl Into<String>) -> Self {
+        self.line_protocol = Some(line_protocol.into());
+        self
+    }
+
+    pub fn with_wait_for_parquet(mut self) -> Self {
+        self.wait_for_parquet = true;
+        self
+    }
+
+    pub fn with_query(mut self, query: impl Into<String>) -> Self {
+        self.query = Some(query.into());
+        self
+    }
+
+    pub fn with_expected(mut self, expected: impl IntoIterator<Item = impl Into<String>>) -> Self {
+        let expected: Vec<_> = expected.into_iter().map(|s| s.into()).collect();
+        self.expected = Some(expected);
+        self
+    }
+
+    /// run the test.
+    pub async fn run(self) {
+        let Self {
+            cluster,
+            line_protocol,
+            wait_for_parquet,
+            query,
+            expected,
+        } = self;
+        let line_protocol = line_protocol.expect("line protocol not specified");
+        let query = query.expect("query not specified");
+        let expected = expected.expect("expected results not specified");
+
+        // Write some data into the v2 HTTP API ==============
+        let response = cluster.write_to_router(line_protocol).await;
+        assert_eq!(response.status(), StatusCode::NO_CONTENT);
+
+        // Wait for data to be readable
+        let write_token = get_write_token(&response);
+        wait_for_readable(&write_token, cluster.ingester().ingester_grpc_connection()).await;
+
+        // wait for persistence, if requested
+        if wait_for_parquet {
+            wait_for_persisted(write_token, cluster.ingester().ingester_grpc_connection()).await;
+        }
+
+        // run query
+        let batches = run_query(
+            query,
+            cluster.namespace(),
+            cluster.querier().querier_grpc_connection(),
+        )
+        .await;
+
+        // convert String --> str
+        let expected: Vec<_> = expected.iter().map(|s| s.as_str()).collect();
+        assert_batches_sorted_eq!(&expected, &batches);
+    }
+}


### PR DESCRIPTION
~Draft as it builds on https://github.com/influxdata/influxdb_iox/pull/4289~

# Rationale
There are 5 or so tests that are all mostly the same. "Don't Repeat Yourself" is a standard software engineering maxim.

# Changes
1. Introduce a `WriteReadTest` struct that writes data / runs a query and verifies it


I plan to use this setup more as I write more tests (e.g. with multiple ingesters)