### PR TITLE
fix: proper executor shutdown in querier

### DIFF
--- a/querier/src/database.rs
+++ b/querier/src/database.rs
@@ -134,6 +134,11 @@ impl QuerierDatabase {
             .await
             .expect("retry forever")
     }
+
+    /// Executor
+    pub(crate) fn exec(&self) -> &Executor {
+        &self.exec
+    }
 }
 
 #[cfg(test)]

--- a/querier/src/handler.rs
+++ b/querier/src/handler.rs
@@ -90,10 +90,12 @@ impl QuerierHandler for QuerierHandlerImpl {
         }
 
         self.shutdown.cancelled().await;
+        self.database.exec().join().await;
     }
 
     fn shutdown(&self) {
         self.shutdown.cancel();
+        self.database.exec().shutdown();
     }
 }
 


### PR DESCRIPTION
This is not a huge issue but might drain resources like file descriptors
during tests. The dedicated exuector also logs a warning.