### PR TITLE
chore: bump kube to version 0.71.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2523,7 +2523,7 @@ dependencies = [
  "glob",
  "k8s-openapi",
  "kube",
- "kube-derive",
+ "kube-derive 0.71.0",
  "kube-runtime",
  "parking_lot 0.11.2",
  "pbjson-build 0.3.0",
@@ -2971,7 +2971,7 @@ dependencies = [
  "k8s-openapi",
  "kube-client",
  "kube-core",
- "kube-derive",
+ "kube-derive 0.70.0",
 ]
 
 [[package]]
@@ -3033,6 +3033,19 @@ name = "kube-derive"
 version = "0.70.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1322e25c20dd6f18ca6baecc88bb130331e99d988df9d7a9a207f15819e05bff"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "serde_json",
+ "syn",
+]
+
+[[package]]
+name = "kube-derive"
+version = "0.71.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "203f7c5acf9d0dfb0b08d44ec1d66ace3d1dfe0cdd82e65e274f3f96615d666c"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2969,42 +2969,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "342744dfeb81fe186b84f485b33f12c6a15d3396987d933b06a566a3db52ca38"
 dependencies = [
  "k8s-openapi",
- "kube-client 0.71.0",
- "kube-core 0.71.0",
+ "kube-client",
+ "kube-core",
  "kube-derive",
-]
-
-[[package]]
-name = "kube-client"
-version = "0.70.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94b01c722d55ffedec74cbc259b4508d8a59bf19540006ec87618f76ab156579"
-dependencies = [
- "base64 0.13.0",
- "bytes",
- "chrono",
- "dirs-next",
- "either",
- "futures",
- "http",
- "http-body",
- "hyper",
- "hyper-timeout",
- "jsonpath_lib",
- "k8s-openapi",
- "kube-core 0.70.0",
- "pem 1.0.2",
- "pin-project",
- "secrecy",
- "serde",
- "serde_json",
- "serde_yaml",
- "thiserror",
- "tokio",
- "tokio-util 0.7.1",
- "tower",
- "tower-http",
- "tracing",
 ]
 
 [[package]]
@@ -3026,7 +2993,7 @@ dependencies = [
  "hyper-timeout",
  "jsonpath_lib",
  "k8s-openapi",
- "kube-core 0.71.0",
+ "kube-core",
  "pem 1.0.2",
  "pin-project",
  "rustls 0.20.4",
@@ -3045,23 +3012,6 @@ dependencies = [
 
 [[package]]
 name = "kube-core"
-version = "0.70.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd9e3535777edd122cc26fe3fe6357066b33eff63d8b919862edbe7a956a679"
-dependencies = [
- "chrono",
- "form_urlencoded",
- "http",
- "json-patch",
- "k8s-openapi",
- "once_cell",
- "serde",
- "serde_json",
- "thiserror",
-]
-
-[[package]]
-name = "kube-core"
 version = "0.71.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4a247487699941baaf93438d65b12d4e32450bea849d619d19ed394e8a4a645"
@@ -3069,6 +3019,7 @@ dependencies = [
  "chrono",
  "form_urlencoded",
  "http",
+ "json-patch",
  "k8s-openapi",
  "once_cell",
  "schemars",
@@ -3092,9 +3043,9 @@ dependencies = [
 
 [[package]]
 name = "kube-runtime"
-version = "0.70.0"
+version = "0.71.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "816c8c086f8bbcf9a4db0b7a68db90b784ef6292a57de35c64cccb90d5edfbe5"
+checksum = "02ea50e6ed56578e1d1d02548901b12fe6d3edbf110269a396955e285d487973"
 dependencies = [
  "ahash",
  "backoff 0.4.0",
@@ -3102,7 +3053,7 @@ dependencies = [
  "futures",
  "json-patch",
  "k8s-openapi",
- "kube-client 0.70.0",
+ "kube-client",
  "parking_lot 0.12.0",
  "pin-project",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2523,7 +2523,7 @@ dependencies = [
  "glob",
  "k8s-openapi",
  "kube",
- "kube-derive 0.71.0",
+ "kube-derive",
  "kube-runtime",
  "parking_lot 0.11.2",
  "pbjson-build 0.3.0",
@@ -2964,14 +2964,14 @@ dependencies = [
 
 [[package]]
 name = "kube"
-version = "0.70.0"
+version = "0.71.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dcc72fdf0c491160a34d4a1bfb03f96da8a5054288d61c816d514b5c2fa49ea"
+checksum = "342744dfeb81fe186b84f485b33f12c6a15d3396987d933b06a566a3db52ca38"
 dependencies = [
  "k8s-openapi",
- "kube-client",
- "kube-core",
- "kube-derive 0.70.0",
+ "kube-client 0.71.0",
+ "kube-core 0.71.0",
+ "kube-derive",
 ]
 
 [[package]]
@@ -2989,11 +2989,44 @@ dependencies = [
  "http",
  "http-body",
  "hyper",
+ "hyper-timeout",
+ "jsonpath_lib",
+ "k8s-openapi",
+ "kube-core 0.70.0",
+ "pem 1.0.2",
+ "pin-project",
+ "secrecy",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "thiserror",
+ "tokio",
+ "tokio-util 0.7.1",
+ "tower",
+ "tower-http",
+ "tracing",
+]
+
+[[package]]
+name = "kube-client"
+version = "0.71.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f69a504997799340408635d6e351afb8aab2c34ca3165e162f41b3b34a69a79"
+dependencies = [
+ "base64 0.13.0",
+ "bytes",
+ "chrono",
+ "dirs-next",
+ "either",
+ "futures",
+ "http",
+ "http-body",
+ "hyper",
  "hyper-rustls 0.23.0",
  "hyper-timeout",
  "jsonpath_lib",
  "k8s-openapi",
- "kube-core",
+ "kube-core 0.71.0",
  "pem 1.0.2",
  "pin-project",
  "rustls 0.20.4",
@@ -3022,23 +3055,26 @@ dependencies = [
  "json-patch",
  "k8s-openapi",
  "once_cell",
- "schemars",
  "serde",
  "serde_json",
  "thiserror",
 ]
 
 [[package]]
-name = "kube-derive"
-version = "0.70.0"
+name = "kube-core"
+version = "0.71.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1322e25c20dd6f18ca6baecc88bb130331e99d988df9d7a9a207f15819e05bff"
+checksum = "a4a247487699941baaf93438d65b12d4e32450bea849d619d19ed394e8a4a645"
 dependencies = [
- "darling",
- "proc-macro2",
- "quote",
+ "chrono",
+ "form_urlencoded",
+ "http",
+ "k8s-openapi",
+ "once_cell",
+ "schemars",
+ "serde",
  "serde_json",
- "syn",
+ "thiserror",
 ]
 
 [[package]]
@@ -3066,7 +3102,7 @@ dependencies = [
  "futures",
  "json-patch",
  "k8s-openapi",
- "kube-client",
+ "kube-client 0.70.0",
  "parking_lot 0.12.0",
  "pin-project",
  "serde",

--- a/iox_gitops_adapter/Cargo.toml
+++ b/iox_gitops_adapter/Cargo.toml
@@ -22,7 +22,7 @@ futures = "0.3"
 k8s-openapi = { version = "0.14", features = ["v1_19", "schemars"], default-features = false }
 kube = { version = "0.71", default-features = false, features = ["client", "rustls-tls", "derive"] }
 kube-derive = { version = "0.71", default-features = false } # only needed to opt out of schema
-kube-runtime = "0.70"
+kube-runtime = "0.71"
 prost = "0.9"
 schemars = { version = "0.8.8", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }

--- a/iox_gitops_adapter/Cargo.toml
+++ b/iox_gitops_adapter/Cargo.toml
@@ -21,7 +21,7 @@ dotenv = "0.15"
 futures = "0.3"
 k8s-openapi = { version = "0.14", features = ["v1_19", "schemars"], default-features = false }
 kube = { version = "0.70", default-features = false, features = ["client", "rustls-tls", "derive"] }
-kube-derive = { version = "0.70", default-features = false } # only needed to opt out of schema
+kube-derive = { version = "0.71", default-features = false } # only needed to opt out of schema
 kube-runtime = "0.70"
 prost = "0.9"
 schemars = { version = "0.8.8", features = ["derive"] }

--- a/iox_gitops_adapter/Cargo.toml
+++ b/iox_gitops_adapter/Cargo.toml
@@ -20,7 +20,7 @@ clap = { version = "3", features = ["derive", "env"] }
 dotenv = "0.15"
 futures = "0.3"
 k8s-openapi = { version = "0.14", features = ["v1_19", "schemars"], default-features = false }
-kube = { version = "0.70", default-features = false, features = ["client", "rustls-tls", "derive"] }
+kube = { version = "0.71", default-features = false, features = ["client", "rustls-tls", "derive"] }
 kube-derive = { version = "0.71", default-features = false } # only needed to opt out of schema
 kube-runtime = "0.70"
 prost = "0.9"


### PR DESCRIPTION
Closes #4292.
Closes #4294.
Closes #4295.