### PR TITLE
fix: Remove old confusing configuration names

### DIFF
--- a/clap_blocks/src/compactor.rs
+++ b/clap_blocks/src/compactor.rs
@@ -1,3 +1,5 @@
+use crate::kafka_partitions::KafkaPartitionConfig;
+
 /// CLI config for compactor
 #[derive(Debug, Clone, clap::Parser)]
 pub struct CompactorConfig {
@@ -10,19 +12,9 @@ pub struct CompactorConfig {
     )]
     pub topic: String,
 
-    /// Write buffer partition number to start (inclusive) range with
-    #[clap(
-        long = "--write-buffer-partition-range-start",
-        env = "INFLUXDB_IOX_WRITE_BUFFER_PARTITION_RANGE_START"
-    )]
-    pub write_buffer_partition_range_start: i32,
-
-    /// Write buffer partition number to end (inclusive) range with
-    #[clap(
-        long = "--write-buffer-partition-range-end",
-        env = "INFLUXDB_IOX_WRITE_BUFFER_PARTITION_RANGE_END"
-    )]
-    pub write_buffer_partition_range_end: i32,
+    /// Kafka Partition options
+    #[clap(flatten)]
+    pub kafka_partition_config: KafkaPartitionConfig,
 
     /// Percentage of least recent data we want to split to reduce compacting non-overlapped data
     /// Must be between 0 and 100. Default is 100, which won't split the resulting file.

--- a/clap_blocks/src/ingester.rs
+++ b/clap_blocks/src/ingester.rs
@@ -1,19 +1,11 @@
+use crate::kafka_partitions::KafkaPartitionConfig;
+
 /// CLI config for catalog ingest lifecycle
 #[derive(Debug, Clone, clap::Parser)]
 pub struct IngesterConfig {
-    /// Write buffer partition number to start (inclusive) range with
-    #[clap(
-        long = "--write-buffer-partition-range-start",
-        env = "INFLUXDB_IOX_WRITE_BUFFER_PARTITION_RANGE_START"
-    )]
-    pub write_buffer_partition_range_start: i32,
-
-    /// Write buffer partition number to end (inclusive) range with
-    #[clap(
-        long = "--write-buffer-partition-range-end",
-        env = "INFLUXDB_IOX_WRITE_BUFFER_PARTITION_RANGE_END"
-    )]
-    pub write_buffer_partition_range_end: i32,
+    /// Kafka Partition options
+    #[clap(flatten)]
+    pub kafka_partition_config: KafkaPartitionConfig,
 
     /// The ingester will continue to pull data and buffer it from Kafka
     /// as long as it is below this size. If it hits this size it will pause

--- a/clap_blocks/src/kafka_partitions.rs
+++ b/clap_blocks/src/kafka_partitions.rs
@@ -1,27 +1,13 @@
 /// CLI config for Kafka partition information
 #[derive(Debug, Clone, clap::Parser)]
 pub struct KafkaPartitionConfig {
-    /// DEPRECATED: Write buffer partition number to start (inclusive) range with
-    #[clap(
-        long = "--write-buffer-partition-range-start",
-        env = "INFLUXDB_IOX_WRITE_BUFFER_PARTITION_RANGE_START"
-    )]
-    write_buffer_partition_range_start: Option<i32>,
-
-    /// DEPRECATED: Write buffer partition number to end (inclusive) range with
-    #[clap(
-        long = "--write-buffer-partition-range-end",
-        env = "INFLUXDB_IOX_WRITE_BUFFER_PARTITION_RANGE_END"
-    )]
-    write_buffer_partition_range_end: Option<i32>,
-
     /// First write buffer kafka partition number (inclusive) this
     /// service is responsible for
     #[clap(
         long = "--write-buffer-kafka-partition-range-start",
         env = "INFLUXDB_IOX_WRITE_BUFFER_KAFKA_PARTITION_RANGE_START"
     )]
-    write_buffer_kafka_partition_range_start: Option<i32>,
+    write_buffer_kafka_partition_range_start: i32,
 
     /// Last write buffer kafka partition number (inclusive) this
     /// service is responsible for
@@ -29,52 +15,20 @@ pub struct KafkaPartitionConfig {
         long = "--write-buffer-kafka-partition-range-end",
         env = "INFLUXDB_IOX_WRITE_BUFFER_KAFKA_PARTITION_RANGE_END"
     )]
-    write_buffer_kafka_partition_range_end: Option<i32>,
+    write_buffer_kafka_partition_range_end: i32,
 }
 
 impl KafkaPartitionConfig {
     /// Return the first write buffer kafka partition number (inclusive) this
     /// ingester is responsible for
     pub fn range_start(&self) -> i32 {
-        match (
-            self.write_buffer_partition_range_start,
-            self.write_buffer_kafka_partition_range_start,
-        ) {
-            // this code is temporary as we roll out the change, so don't worry about nice error handling
-            // https://github.com/influxdata/influxdb_iox/issues/4311
-            (Some(_), Some(_)) => panic!(
-                "Can not specify both write_buffer_partition_range_start and \
-                                          write_buffer_kafka_partition_range_start (partition)"
-            ),
-            (Some(v), None) => v,
-            (None, Some(v)) => v,
-            (None, None) => panic!(
-                "must specify either write_buffer_partition_range_start or \
-                                    write_buffer_kafka_partition_range_start (partition)"
-            ),
-        }
+        self.write_buffer_kafka_partition_range_start
     }
 
     /// Return the last write buffer kafka partition number (inclusive) this
     /// ingester is responsible for
     pub fn range_end(&self) -> i32 {
-        match (
-            self.write_buffer_partition_range_end,
-            self.write_buffer_kafka_partition_range_end,
-        ) {
-            // this code is temporary as we roll out the change, so don't worry about nice error handling
-            // https://github.com/influxdata/influxdb_iox/issues/4311
-            (Some(_), Some(_)) => panic!(
-                "Can not specify both write_buffer_partition_range_end and \
-                                          write_buffer_kafka_partition_range_end (partition)"
-            ),
-            (Some(v), None) => v,
-            (None, Some(v)) => v,
-            (None, None) => panic!(
-                "must specify either write_buffer_partition_range_end or \
-                                    write_buffer_kafka_partition_range_end (partition)"
-            ),
-        }
+        self.write_buffer_kafka_partition_range_end
     }
 }
 
@@ -96,60 +50,5 @@ mod tests {
         .unwrap();
         assert_eq!(cfg.range_start(), 1);
         assert_eq!(cfg.range_end(), 42);
-    }
-
-    #[test]
-    fn test_legacy_values() {
-        let cfg = KafkaPartitionConfig::try_parse_from([
-            "my_binary",
-            // note doesn't have 'partition'
-            "--write-buffer-partition-range-start",
-            "1",
-            "--write-buffer-partition-range-end",
-            "42",
-        ])
-        .unwrap();
-        assert_eq!(cfg.range_start(), 1);
-        assert_eq!(cfg.range_end(), 42);
-    }
-
-    #[test]
-    #[should_panic(
-        expected = "Can not specify both write_buffer_partition_range_start and write_buffer_kafka_partition_range_start (partition)"
-    )]
-    fn test_duplicated_start() {
-        let cfg = KafkaPartitionConfig::try_parse_from([
-            "my_binary",
-            "--write-buffer-partition-range-start",
-            "1",
-            // duplicated
-            "--write-buffer-kafka-partition-range-start",
-            "1",
-            "--write-buffer-partition-range-end",
-            "42",
-        ])
-        .unwrap();
-
-        cfg.range_start();
-    }
-
-    #[test]
-    #[should_panic(
-        expected = "Can not specify both write_buffer_partition_range_end and write_buffer_kafka_partition_range_end (partition)"
-    )]
-    fn test_duplicated_end() {
-        let cfg = KafkaPartitionConfig::try_parse_from([
-            "my_binary",
-            "--write-buffer-partition-range-start",
-            "1",
-            "--write-buffer-partition-range-end",
-            "42",
-            // duplicated
-            "--write-buffer-kafka-partition-range-end",
-            "42",
-        ])
-        .unwrap();
-
-        cfg.range_end();
     }
 }

--- a/clap_blocks/src/kafka_partitions.rs
+++ b/clap_blocks/src/kafka_partitions.rs
@@ -1,0 +1,155 @@
+/// CLI config for Kafka partition information
+#[derive(Debug, Clone, clap::Parser)]
+pub struct KafkaPartitionConfig {
+    /// DEPRECATED: Write buffer partition number to start (inclusive) range with
+    #[clap(
+        long = "--write-buffer-partition-range-start",
+        env = "INFLUXDB_IOX_WRITE_BUFFER_PARTITION_RANGE_START"
+    )]
+    write_buffer_partition_range_start: Option<i32>,
+
+    /// DEPRECATED: Write buffer partition number to end (inclusive) range with
+    #[clap(
+        long = "--write-buffer-partition-range-end",
+        env = "INFLUXDB_IOX_WRITE_BUFFER_PARTITION_RANGE_END"
+    )]
+    write_buffer_partition_range_end: Option<i32>,
+
+    /// First write buffer kafka partition number (inclusive) this
+    /// service is responsible for
+    #[clap(
+        long = "--write-buffer-kafka-partition-range-start",
+        env = "INFLUXDB_IOX_WRITE_BUFFER_KAFKA_PARTITION_RANGE_START"
+    )]
+    write_buffer_kafka_partition_range_start: Option<i32>,
+
+    /// Last write buffer kafka partition number (inclusive) this
+    /// service is responsible for
+    #[clap(
+        long = "--write-buffer-kafka-partition-range-end",
+        env = "INFLUXDB_IOX_WRITE_BUFFER_KAFKA_PARTITION_RANGE_END"
+    )]
+    write_buffer_kafka_partition_range_end: Option<i32>,
+}
+
+impl KafkaPartitionConfig {
+    /// Return the first write buffer kafka partition number (inclusive) this
+    /// ingester is responsible for
+    pub fn range_start(&self) -> i32 {
+        match (
+            self.write_buffer_partition_range_start,
+            self.write_buffer_kafka_partition_range_start,
+        ) {
+            // this code is temporary as we roll out the change, so don't worry about nice error handling
+            // https://github.com/influxdata/influxdb_iox/issues/4311
+            (Some(_), Some(_)) => panic!(
+                "Can not specify both write_buffer_partition_range_start and \
+                                          write_buffer_kafka_partition_range_start (partition)"
+            ),
+            (Some(v), None) => v,
+            (None, Some(v)) => v,
+            (None, None) => panic!(
+                "must specify either write_buffer_partition_range_start or \
+                                    write_buffer_kafka_partition_range_start (partition)"
+            ),
+        }
+    }
+
+    /// Return the last write buffer kafka partition number (inclusive) this
+    /// ingester is responsible for
+    pub fn range_end(&self) -> i32 {
+        match (
+            self.write_buffer_partition_range_end,
+            self.write_buffer_kafka_partition_range_end,
+        ) {
+            // this code is temporary as we roll out the change, so don't worry about nice error handling
+            // https://github.com/influxdata/influxdb_iox/issues/4311
+            (Some(_), Some(_)) => panic!(
+                "Can not specify both write_buffer_partition_range_end and \
+                                          write_buffer_kafka_partition_range_end (partition)"
+            ),
+            (Some(v), None) => v,
+            (None, Some(v)) => v,
+            (None, None) => panic!(
+                "must specify either write_buffer_partition_range_end or \
+                                    write_buffer_kafka_partition_range_end (partition)"
+            ),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use clap::StructOpt;
+
+    use super::*;
+
+    #[test]
+    fn test_values() {
+        let cfg = KafkaPartitionConfig::try_parse_from([
+            "my_binary",
+            "--write-buffer-kafka-partition-range-start",
+            "1",
+            "--write-buffer-kafka-partition-range-end",
+            "42",
+        ])
+        .unwrap();
+        assert_eq!(cfg.range_start(), 1);
+        assert_eq!(cfg.range_end(), 42);
+    }
+
+    #[test]
+    fn test_legacy_values() {
+        let cfg = KafkaPartitionConfig::try_parse_from([
+            "my_binary",
+            // note doesn't have 'partition'
+            "--write-buffer-partition-range-start",
+            "1",
+            "--write-buffer-partition-range-end",
+            "42",
+        ])
+        .unwrap();
+        assert_eq!(cfg.range_start(), 1);
+        assert_eq!(cfg.range_end(), 42);
+    }
+
+    #[test]
+    #[should_panic(
+        expected = "Can not specify both write_buffer_partition_range_start and write_buffer_kafka_partition_range_start (partition)"
+    )]
+    fn test_duplicated_start() {
+        let cfg = KafkaPartitionConfig::try_parse_from([
+            "my_binary",
+            "--write-buffer-partition-range-start",
+            "1",
+            // duplicated
+            "--write-buffer-kafka-partition-range-start",
+            "1",
+            "--write-buffer-partition-range-end",
+            "42",
+        ])
+        .unwrap();
+
+        cfg.range_start();
+    }
+
+    #[test]
+    #[should_panic(
+        expected = "Can not specify both write_buffer_partition_range_end and write_buffer_kafka_partition_range_end (partition)"
+    )]
+    fn test_duplicated_end() {
+        let cfg = KafkaPartitionConfig::try_parse_from([
+            "my_binary",
+            "--write-buffer-partition-range-start",
+            "1",
+            "--write-buffer-partition-range-end",
+            "42",
+            // duplicated
+            "--write-buffer-kafka-partition-range-end",
+            "42",
+        ])
+        .unwrap();
+
+        cfg.range_end();
+    }
+}

--- a/clap_blocks/src/lib.rs
+++ b/clap_blocks/src/lib.rs
@@ -4,6 +4,7 @@
 pub mod catalog_dsn;
 pub mod compactor;
 pub mod ingester;
+mod kafka_partitions;
 pub mod object_store;
 pub mod querier;
 pub mod run_config;

--- a/clap_blocks/src/write_buffer.rs
+++ b/clap_blocks/src/write_buffer.rs
@@ -44,12 +44,23 @@ pub struct WriteBufferConfig {
     )]
     pub(crate) connection_config: Vec<String>,
 
-    /// The number of topics to create automatically, if any. Default is to not create any topics.
+    /// DEPRECATED: The number of topics to create automatically, if any. Default is to not create any topics.
     #[clap(
         long = "--write-buffer-auto-create-topics",
         env = "INFLUXDB_IOX_WRITE_BUFFER_AUTO_CREATE_TOPICS"
     )]
-    pub(crate) auto_create_topics: Option<NonZeroU32>,
+    auto_create_topics: Option<NonZeroU32>,
+
+    /// The total number of kafka partitions to use in this write
+    /// buffer. If any of the kafka partitions do not yet exist, IOx
+    /// will create them.
+    ///
+    /// If not specified, no kafka partitions are created.
+    #[clap(
+        long = "--write-buffer-kafka-partition-count",
+        env = "INFLUXDB_IOX_WRITE_BUFFER_KAFKA_PARTITION_COUNT"
+    )]
+    kafka_partition_count: Option<NonZeroU32>,
 }
 
 impl WriteBufferConfig {
@@ -99,7 +110,7 @@ impl WriteBufferConfig {
 
     fn conn(&self) -> WriteBufferConnection {
         let creation_config =
-            self.auto_create_topics
+            self.kafka_partition_count()
                 .map(|n_sequencers| WriteBufferCreationConfig {
                     n_sequencers,
                     ..Default::default()
@@ -121,14 +132,26 @@ impl WriteBufferConfig {
         self.topic.as_ref()
     }
 
-    /// Get the write buffer config's auto create topics.
-    pub fn auto_create_topics(&self) -> Option<NonZeroU32> {
-        self.auto_create_topics
+    /// Get the number of kafka partitions the write buffer should auto create
+    pub fn kafka_partition_count(&self) -> Option<NonZeroU32> {
+        match (
+            self.auto_create_topics.is_some(),
+            self.kafka_partition_count.is_some(),
+        ) {
+            // this code is temporary as we roll out the change, so don't worry about nice error handling
+            // https://github.com/influxdata/influxdb_iox/issues/4311
+            (true, true) => {
+                panic!("Can not specify both auto create topics and kafka partition count")
+            }
+            (true, false) => self.auto_create_topics,
+            (false, true) => self.kafka_partition_count,
+            (false, false) => None,
+        }
     }
 
     /// Set the write buffer config's auto create topics.
-    pub fn set_auto_create_topics(&mut self, auto_create_topics: Option<NonZeroU32>) {
-        self.auto_create_topics = auto_create_topics;
+    pub fn set_kafka_partition_count(&mut self, kafka_partition_count: Option<NonZeroU32>) {
+        self.kafka_partition_count = kafka_partition_count;
     }
 }
 
@@ -163,5 +186,63 @@ mod tests {
             (String::from("so"), String::from("many=args")),
         ]);
         assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_kafka_partition_count_backwards_compatible() {
+        let cfg = WriteBufferConfig::try_parse_from([
+            "my_binary",
+            "--write-buffer",
+            "kafka",
+            "--write-buffer-addr",
+            "localhost:1234",
+            "--write-buffer-kafka-partition-count",
+            "4",
+        ])
+        .unwrap();
+        assert_eq!(
+            cfg.kafka_partition_count(),
+            Some(NonZeroU32::new(4).unwrap())
+        );
+    }
+
+    #[test]
+    fn test_kafka_partition_count_legacy() {
+        // Test legacy option
+        let cfg = WriteBufferConfig::try_parse_from([
+            "my_binary",
+            "--write-buffer",
+            "kafka",
+            "--write-buffer-addr",
+            "localhost:1234",
+            "--write-buffer-auto-create-topics",
+            "4",
+        ])
+        .unwrap();
+        assert_eq!(
+            cfg.kafka_partition_count(),
+            Some(NonZeroU32::new(4).unwrap())
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "Can not specify both auto create topics and kafka partition count")]
+    fn test_kafka_partition_count_legacy_bad() {
+        let cfg = WriteBufferConfig::try_parse_from([
+            "my_binary",
+            "--write-buffer",
+            "kafka",
+            "--write-buffer-addr",
+            "localhost:1234",
+            "--write-buffer-auto-create-topics",
+            "4",
+            // can't pass both
+            "--write-buffer-kafka-partition-count",
+            "4",
+        ])
+        .unwrap();
+
+        // panic!
+        cfg.kafka_partition_count();
     }
 }

--- a/ioxd_compactor/src/lib.rs
+++ b/ioxd_compactor/src/lib.rs
@@ -133,9 +133,9 @@ pub async fn create_compactor_server_type(
     time_provider: Arc<dyn TimeProvider>,
     compactor_config: CompactorConfig,
 ) -> Result<Arc<dyn ServerType>> {
-    if compactor_config.write_buffer_partition_range_start
-        > compactor_config.write_buffer_partition_range_end
-    {
+    let kafka_partition_config = compactor_config.kafka_partition_config;
+
+    if kafka_partition_config.range_start() > kafka_partition_config.range_end() {
         return Err(Error::KafkaRange);
     }
 
@@ -146,8 +146,8 @@ pub async fn create_compactor_server_type(
         .await?
         .ok_or(Error::KafkaTopicNotFound(compactor_config.topic))?;
 
-    let kafka_partitions: Vec<_> = (compactor_config.write_buffer_partition_range_start
-        ..=compactor_config.write_buffer_partition_range_end)
+    let kafka_partitions: Vec<_> = (kafka_partition_config.range_start()
+        ..=kafka_partition_config.range_end())
         .map(KafkaPartition::new)
         .collect();
 

--- a/ioxd_ingester/src/lib.rs
+++ b/ioxd_ingester/src/lib.rs
@@ -150,14 +150,13 @@ pub async fn create_ingester_server_type(
         .await?
         .ok_or_else(|| Error::KafkaTopicNotFound(write_buffer_config.topic().to_string()))?;
 
-    if ingester_config.write_buffer_partition_range_start
-        > ingester_config.write_buffer_partition_range_end
-    {
+    let kafka_partition_config = ingester_config.kafka_partition_config;
+    if kafka_partition_config.range_start() > kafka_partition_config.range_end() {
         return Err(Error::KafkaRange);
     }
 
-    let kafka_partitions: Vec<_> = (ingester_config.write_buffer_partition_range_start
-        ..=ingester_config.write_buffer_partition_range_end)
+    let kafka_partitions: Vec<_> = (kafka_partition_config.range_start()
+        ..=kafka_partition_config.range_end())
         .map(KafkaPartition::new)
         .collect();
 

--- a/test_helpers_end_to_end_ng/src/config.rs
+++ b/test_helpers_end_to_end_ng/src/config.rs
@@ -131,8 +131,8 @@ impl TestConfig {
     fn with_default_ingester_options(self) -> Self {
         self.with_env("INFLUXDB_IOX_PAUSE_INGEST_SIZE_BYTES", "20")
             .with_env("INFLUXDB_IOX_PERSIST_MEMORY_THRESHOLD_BYTES", "10")
-            .with_env("INFLUXDB_IOX_WRITE_BUFFER_PARTITION_RANGE_START", "0")
-            .with_env("INFLUXDB_IOX_WRITE_BUFFER_PARTITION_RANGE_END", "0")
+            .with_env("INFLUXDB_IOX_WRITE_BUFFER_KAFKA_PARTITION_RANGE_START", "0")
+            .with_env("INFLUXDB_IOX_WRITE_BUFFER_KAFKA_PARTITION_RANGE_END", "0")
     }
 
     /// Adds the ingester addresses
@@ -182,10 +182,7 @@ impl TestConfig {
     /// Configures the write buffer to use the specified kafka partition count
     fn with_kafka_partition_count(self, kafka_partition_count: usize) -> Self {
         self.with_env(
-            // change to:
-            // "INFLUXDB_IOX_WRITE_BUFFER_KAFAKA_PARTITION_COUNT,
-            // https://github.com/influxdata/influxdb_iox/issues/4311
-            "INFLUXDB_IOX_WRITE_BUFFER_AUTO_CREATE_TOPICS",
+            "INFLUXDB_IOX_WRITE_BUFFER_KAFKA_PARTITION_COUNT",
             kafka_partition_count.to_string(),
         )
     }
@@ -201,10 +198,7 @@ impl TestConfig {
         // copy the the directory, if any
         self.write_buffer_dir = other.write_buffer_dir.clone();
         self.copy_env("INFLUXDB_IOX_WRITE_BUFFER_TYPE", other)
-            // change to:
-            // "INFLUXDB_IOX_WRITE_BUFFER_KAFAKA_PARTITION_COUNT,
-            // https://github.com/influxdata/influxdb_iox/issues/4311
-            .copy_env("INFLUXDB_IOX_WRITE_BUFFER_AUTO_CREATE_TOPICS", other)
+            .copy_env("INFLUXDB_IOX_WRITE_BUFFER_KAFKA_PARTITION_COUNT", other)
             .copy_env("INFLUXDB_IOX_WRITE_BUFFER_ADDR", other)
     }
 


### PR DESCRIPTION
# Rationale:
Part 3/3  and closes https://github.com/influxdata/influxdb_iox/issues/4311

Draft until https://github.com/influxdata/k8s-idpe/pull/7112 and https://github.com/influxdata/influxdb_iox/pull/4312 are merged

# Changes:
Remove old configuration names and use new ones consistently
