### PR TITLE
fix: compactor deadlock

### DIFF
--- a/query/src/exec/split.rs
+++ b/query/src/exec/split.rs
@@ -31,8 +31,8 @@ use datafusion::{
 
 use datafusion_util::AdapterStream;
 use futures::StreamExt;
-use observability_deps::tracing::{debug, trace};
-use tokio::sync::{mpsc::Sender, Mutex};
+use observability_deps::tracing::*;
+use tokio::sync::{mpsc::UnboundedSender, Mutex};
 
 /// Implements stream splitting described in `make_stream_split`
 ///
@@ -259,8 +259,8 @@ impl StreamSplitExec {
         trace!("Setting up SplitStreamExec state");
 
         let input_stream = self.input.execute(0, context).await?;
-        let (tx0, rx0) = tokio::sync::mpsc::channel(2);
-        let (tx1, rx1) = tokio::sync::mpsc::channel(2);
+        let (tx0, rx0) = tokio::sync::mpsc::unbounded_channel();
+        let (tx1, rx1) = tokio::sync::mpsc::unbounded_channel();
         let split_expr = Arc::clone(&self.split_expr);
 
         // launch the work on a different task, with a task to handle its output values
@@ -279,18 +279,18 @@ impl StreamSplitExec {
             let txs = [tx0, tx1];
             match worker.await {
                 Err(e) => {
-                    debug!(%e, "error joining task");
+                    debug!(%e, "error joining split task");
                     for tx in &txs {
                         let err: ArrowError =
                             DataFusionError::Execution(format!("Join Error: {}", e)).into();
-                        tx.send(Err(err)).await.ok();
+                        tx.send(Err(err)).ok();
                     }
                 }
                 Ok(Err(e)) => {
                     debug!(%e, "error in work function");
                     for tx in &txs {
                         let err: ArrowError = DataFusionError::Execution(e.to_string()).into();
-                        tx.send(Err(err)).await.ok();
+                        tx.send(Err(err)).ok();
                     }
                 }
                 // Input task completed successfully
@@ -301,8 +301,8 @@ impl StreamSplitExec {
         });
 
         *state = State::Running {
-            stream0: Some(AdapterStream::adapt(self.input.schema(), rx0)),
-            stream1: Some(AdapterStream::adapt(self.input.schema(), rx1)),
+            stream0: Some(AdapterStream::adapt_unbounded(self.input.schema(), rx0)),
+            stream1: Some(AdapterStream::adapt_unbounded(self.input.schema(), rx1)),
         };
         Ok(())
     }
@@ -314,8 +314,8 @@ impl StreamSplitExec {
 async fn split_the_stream(
     mut input_stream: SendableRecordBatchStream,
     split_expr: Arc<dyn PhysicalExpr>,
-    tx0: Sender<ArrowResult<RecordBatch>>,
-    tx1: Sender<ArrowResult<RecordBatch>>,
+    tx0: UnboundedSender<ArrowResult<RecordBatch>>,
+    tx1: UnboundedSender<ArrowResult<RecordBatch>>,
     baseline_metrics0: BaselineMetrics,
     baseline_metrics1: BaselineMetrics,
 ) -> Result<()> {
@@ -392,11 +392,12 @@ async fn split_the_stream(
         // don't treat a hangup as an error, as it can also be caused
         // by a LIMIT operation where the entire stream is not
         // consumed)
-        if let Err(e) = tx0.send(Ok(true_batch)).await {
+        if let Err(e) = tx0.send(Ok(true_batch)) {
             debug!(%e, "Split tx0 hung up, ignoring");
             tx0_done = true;
         }
-        if let Err(e) = tx1.send(Ok(not_true_batch)).await {
+
+        if let Err(e) = tx1.send(Ok(not_true_batch)) {
             debug!(%e, "Split tx1 hung up, ignoring");
             tx1_done = true;
         }

--- a/query/src/exec/split.rs
+++ b/query/src/exec/split.rs
@@ -279,7 +279,7 @@ impl StreamSplitExec {
             let txs = [tx0, tx1];
             match worker.await {
                 Err(e) => {
-                    debug!(%e, "error joining split task");
+                    error!(%e, "error joining split task");
                     for tx in &txs {
                         let err: ArrowError =
                             DataFusionError::Execution(format!("Join Error: {}", e)).into();


### PR DESCRIPTION
This PR fixes the compaction deadlock we have observed during testing.

The deadlock is caused by the `StreamSplitExec` background worker that pushes results into two channels - one for each partition. The channels have a [buffer size of 2], and the worker [gets stuck] trying to push results into the second partition while the compactor is reading the first partition.

Because the worker is stuck, it cannot push the rest of the records into the channel for the first partition, nor close the channel (indicating completion, and signalling to the compactor that it can move on). Because the channel is never closed, the compaction loop [blocks waiting for the first partition](https://github.com/influxdata/influxdb_iox/blob/31fdeaaabc21d2e7d24b801b8503d77aee7853f8/compactor/src/compact.rs#L671) to complete, and can't drain the second partition to unblock the worker 💣 

[gets stuck]:https://github.com/influxdata/influxdb_iox/blob/351b0d0c152a36f03dd12514df56fa50c143cc75/query/src/exec/split.rs#L399
[buffer size of 2]:https://github.com/influxdata/influxdb_iox/blob/main/query/src/exec/split.rs#L263


This change prevents us from performing a streaming compaction - records are split, buffered in memory, and then read by the compactor. Currently the compactor buffers the resulting record batches it reads from datafusion in memory anyway, so this isn't a big deal. I will address this in the future (#4324).

Closes #4306.

---

* feat: unbounded channel support for AdaptorStream (5ac4785e)

      Allows the AdaptorStream to work with either a bounded, or unbounded channel
      internally.

* fix: compaction deadlock (00b5c1b2)

      This commit resolves the compaction deadlock described in #4306.

      The deadlock occurs during StreamSplitExec execution, where a background 
      worker is spawned to read input record batches and partition them into two
      groups. This code pushes the resulting split record batches into two channels
      - one for records that match a given predicate, and another channel for those
      that do not. These channels buffer at most 2 record batches each.

      The compactor that executes this plan reads the resulting partitions 
      sequentially to completion. Completion is indicated by reading until the 
      results stream ends, which ends when the underlying channel is closed, and
      therefore the split worker task must have finished and closed the results
      channel for the partition to be successfully read.

      While the compactor is reading from the first partition, the worker is 
      attempting to push record batches into the second partition and blocks due to
      the channel capacity being reached. The worker never drops the channel for the
      first partition, so the compactor never finishes reading the first partition,
      and nothing is reading the second partition to unblock the worker. Deadlock!

* refactor: log split worker panics at error level (31fdeaaa)

      When the split background worker panics, it now causes an ERROR level log to
      be emitted.