### PR TITLE
feat: panic metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3909,6 +3909,7 @@ dependencies = [
 name = "panic_logging"
 version = "0.1.0"
 dependencies = [
+ "metric",
  "observability_deps",
  "workspace-hack",
 ]

--- a/influxdb_iox/src/commands/run/all_in_one.rs
+++ b/influxdb_iox/src/commands/run/all_in_one.rs
@@ -370,7 +370,7 @@ pub async fn command(config: Config) -> Result<()> {
     info!(?ingester_addresses, "starting querier");
     let querier = create_querier_server_type(
         &common_state,
-        metrics,
+        Arc::clone(&metrics),
         catalog,
         object_store,
         time_provider,
@@ -388,5 +388,5 @@ pub async fn command(config: Config) -> Result<()> {
         Service::create_grpc_only(querier, &querier_run_config),
     ];
 
-    Ok(main::main(common_state, services).await?)
+    Ok(main::main(common_state, services, metrics).await?)
 }

--- a/influxdb_iox/src/commands/run/compactor.rs
+++ b/influxdb_iox/src/commands/run/compactor.rs
@@ -91,7 +91,7 @@ pub async fn command(config: Config) -> Result<(), Error> {
 
     let server_type = create_compactor_server_type(
         &common_state,
-        metric_registry,
+        Arc::clone(&metric_registry),
         catalog,
         object_store,
         exec,
@@ -103,5 +103,5 @@ pub async fn command(config: Config) -> Result<(), Error> {
     info!("starting compactor");
 
     let services = vec![Service::create(server_type, common_state.run_config())];
-    Ok(main::main(common_state, services).await?)
+    Ok(main::main(common_state, services, metric_registry).await?)
 }

--- a/influxdb_iox/src/commands/run/database.rs
+++ b/influxdb_iox/src/commands/run/database.rs
@@ -130,5 +130,10 @@ pub async fn command(config: Config) -> Result<()> {
     ));
 
     let services = vec![Service::create(server_type, common_state.run_config())];
-    Ok(main::main(common_state, services).await?)
+    Ok(main::main(
+        common_state,
+        services,
+        Arc::new(metric::Registry::default()),
+    )
+    .await?)
 }

--- a/influxdb_iox/src/commands/run/ingester.rs
+++ b/influxdb_iox/src/commands/run/ingester.rs
@@ -89,7 +89,7 @@ pub async fn command(config: Config) -> Result<()> {
     let exec = Arc::new(Executor::new(config.query_exec_thread_count));
     let server_type = create_ingester_server_type(
         &common_state,
-        metric_registry,
+        Arc::clone(&metric_registry),
         catalog,
         object_store,
         exec,
@@ -101,5 +101,5 @@ pub async fn command(config: Config) -> Result<()> {
     info!("starting ingester");
 
     let services = vec![Service::create(server_type, common_state.run_config())];
-    Ok(main::main(common_state, services).await?)
+    Ok(main::main(common_state, services, metric_registry).await?)
 }

--- a/influxdb_iox/src/commands/run/querier.rs
+++ b/influxdb_iox/src/commands/run/querier.rs
@@ -89,7 +89,7 @@ pub async fn command(config: Config) -> Result<(), Error> {
     let exec = Arc::new(Executor::new(num_threads));
     let server_type = create_querier_server_type(
         &common_state,
-        metric_registry,
+        Arc::clone(&metric_registry),
         catalog,
         object_store,
         time_provider,
@@ -101,5 +101,5 @@ pub async fn command(config: Config) -> Result<(), Error> {
     info!("starting querier");
 
     let services = vec![Service::create(server_type, common_state.run_config())];
-    Ok(main::main(common_state, services).await?)
+    Ok(main::main(common_state, services, metric_registry).await?)
 }

--- a/influxdb_iox/src/commands/run/router.rs
+++ b/influxdb_iox/src/commands/run/router.rs
@@ -159,5 +159,10 @@ pub async fn command(config: Config) -> Result<()> {
     ));
 
     let services = vec![Service::create(server_type, common_state.run_config())];
-    Ok(main::main(common_state, services).await?)
+    Ok(main::main(
+        common_state,
+        services,
+        Arc::new(metric::Registry::default()),
+    )
+    .await?)
 }

--- a/influxdb_iox/src/commands/run/router2.rs
+++ b/influxdb_iox/src/commands/run/router2.rs
@@ -96,5 +96,5 @@ pub async fn command(config: Config) -> Result<()> {
 
     info!("starting router2");
     let services = vec![Service::create(server_type, common_state.run_config())];
-    Ok(main::main(common_state, services).await?)
+    Ok(main::main(common_state, services, metrics).await?)
 }

--- a/influxdb_iox/src/commands/run/test.rs
+++ b/influxdb_iox/src/commands/run/test.rs
@@ -61,5 +61,10 @@ pub async fn command(config: Config) -> Result<()> {
     ));
 
     let services = vec![Service::create(server_type, common_state.run_config())];
-    Ok(main::main(common_state, services).await?)
+    Ok(main::main(
+        common_state,
+        services,
+        Arc::new(metric::Registry::default()),
+    )
+    .await?)
 }

--- a/panic_logging/Cargo.toml
+++ b/panic_logging/Cargo.toml
@@ -5,5 +5,6 @@ authors = ["Paul Dix <paul@pauldix.net>"]
 edition = "2021"
 
 [dependencies] # In alphabetical order
+metric = { path = "../metric" }
 observability_deps = { path = "../observability_deps" }
 workspace-hack = { path = "../workspace-hack"}


### PR DESCRIPTION
This PR adds a `thread_panic_count_total` metric to the various server types so we can measure the frequency of, and alert on panics.

I was going to keep the logging-to-tracing and metric recorder concerns separate and compose the impls as needed, but the drop ordering becomes important when setting multiple panic handlers and it was overly brittle / easy to cock up, so it's an optional behaviour of the existing custom panic handler instead 👍 

---

* feat: emit thread panic count metric (49c38c297)

      Allows the panic handler to be optionally configured to emit a thread panic
      metric, increasing by 1 each time a panic is observed.

* refactor: emit panic metrics for server types (c36324290)

      Configures the long-running / server modes to emit panic metrics.