### PR TITLE
fix: Add protobuf compiler to docker build image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ FROM rust:${RUST_VERSION}-slim-bullseye as build
 USER root
 
 RUN apt update \
-    && apt install --yes binutils build-essential pkg-config libssl-dev clang lld git \
+    && apt install --yes binutils build-essential pkg-config libssl-dev clang lld git protobuf-compiler \
     && rm -rf /var/lib/{apt,dpkg,cache,log}
 
 # Build influxdb_iox


### PR DESCRIPTION
Draft as I test this

# Rationale
As pointed out by @domodwyer , https://github.com/influxdata/influxdb_iox/pull/4357 broke the `build_release` job (which builds the docker images that are deployed to production)

# Example failure:
https://app.circleci.com/pipelines/github/influxdata/influxdb_iox/18258/workflows/0a91a876-b32c-4855-af19-61929d6088eb/jobs/151724

```
#17 152.3   CMAKE_PREFIX_PATH = None
#17 152.3   CMAKE_x86_64-unknown-linux-gnu = None
#17 152.3   CMAKE_x86_64_unknown_linux_gnu = None
#17 152.3   HOST_CMAKE = None
#17 152.3   CMAKE = None
#17 152.3   running: "cmake" "/usr/local/cargo/registry/src/github.com-1ecc6299db9ec823/prost-build-0.10.1/third-party/protobuf/cmake" "-DCMAKE_INSTALL_PREFIX=/influxdb_iox/target/release/build/prost-build-86ce3b21d9074480/out" "-DCMAKE_C_FLAGS= -ffunction-sections -fdata-sections -fPIC -m64" "-DCMAKE_C_COMPILER=/usr/bin/cc" "-DCMAKE_CXX_FLAGS= -ffunction-sections -fdata-sections -fPIC -m64" "-DCMAKE_CXX_COMPILER=/usr/bin/c++" "-DCMAKE_ASM_FLAGS= -ffunction-sections -fdata-sections -fPIC -m64" "-DCMAKE_ASM_COMPILER=/usr/bin/cc" "-DCMAKE_BUILD_TYPE=Debug"
#17 152.3 
#17 152.3   --- stderr
#17 152.3   thread 'main' panicked at '
#17 152.3   failed to execute command: No such file or directory (os error 2)
#17 152.3   is `cmake` not installed?
#17 152.3 
#17 152.3   build script failed, must exit now', /usr/local/cargo/registry/src/github.com-1ecc6299db9ec823/cmake-0.1.48/src/lib.rs:975:5
#17 152.3   note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
#17 152.3 warning: build failed, waiting for other jobs to finish...
#17 171.5 error: build failed
```

# Example success (with this change):
(has gotten past the compilation error):
https://app.circleci.com/pipelines/github/influxdata/influxdb_iox/18265/workflows/07df6c6f-04ee-4305-909d-715a37830fbc/jobs/151797


Also closes https://github.com/influxdata/influxdb_iox/pull/4370