### PR TITLE
refactor: Consolidate cluster creation in end to end tests

### DIFF
--- a/influxdb_iox/tests/end_to_end_cases/influxrpc.rs
+++ b/influxdb_iox/tests/end_to_end_cases/influxrpc.rs
@@ -316,6 +316,8 @@ async fn measurement_fields_endpoint(
     assert_eq!(field.timestamp, scenario.ns_since_epoch() + 4);
 }
 
+//////// Tests above here have been ported to NG. Tests below have not yet been /////
+
 #[tokio::test]
 pub async fn read_filter_regex_operator() {
     do_read_filter_test(

--- a/influxdb_iox/tests/end_to_end_ng_cases/cli.rs
+++ b/influxdb_iox/tests/end_to_end_ng_cases/cli.rs
@@ -4,7 +4,7 @@ use predicates::prelude::*;
 use serde_json::Value;
 use tempfile::tempdir;
 use test_helpers_end_to_end_ng::{
-    maybe_skip_integration, MiniCluster, Step, StepTest, StepTestState, TestConfig,
+    maybe_skip_integration, MiniCluster, Step, StepTest, StepTestState,
 };
 
 /// Tests CLI commands
@@ -14,16 +14,8 @@ use test_helpers_end_to_end_ng::{
 async fn remote_partition_and_get_from_store() {
     let database_url = maybe_skip_integration!();
 
-    let router2_config = TestConfig::new_router2(&database_url);
-    // generate parquet files quickly
-    let ingester_config = TestConfig::new_ingester(&router2_config).with_fast_parquet_generation();
-
     // Set up the cluster  ====================================
-    let mut cluster = MiniCluster::new()
-        .with_router2(router2_config)
-        .await
-        .with_ingester(ingester_config)
-        .await;
+    let mut cluster = MiniCluster::create_quickly_peristing(database_url).await;
 
     StepTest::new(
         &mut cluster,

--- a/influxdb_iox/tests/end_to_end_ng_cases/ingester.rs
+++ b/influxdb_iox/tests/end_to_end_ng_cases/ingester.rs
@@ -3,7 +3,7 @@ use std::collections::BTreeMap;
 use generated_types::influxdata::iox::ingester::v1::PartitionStatus;
 use http::StatusCode;
 use test_helpers_end_to_end_ng::{
-    get_write_token, maybe_skip_integration, wait_for_readable, MiniCluster, TestConfig,
+    get_write_token, maybe_skip_integration, wait_for_readable, MiniCluster,
 };
 
 use arrow_util::assert_batches_sorted_eq;
@@ -15,15 +15,8 @@ async fn ingester_flight_api() {
 
     let table_name = "mytable";
 
-    let router2_config = TestConfig::new_router2(&database_url);
-    let ingester_config = TestConfig::new_ingester(&router2_config);
-
     // Set up cluster
-    let cluster = MiniCluster::new()
-        .with_router2(router2_config)
-        .await
-        .with_ingester(ingester_config)
-        .await;
+    let cluster = MiniCluster::create_standard(database_url).await;
 
     // Write some data into the v2 HTTP API ==============
     let lp = format!("{},tag1=A,tag2=B val=42i 123456", table_name);
@@ -99,9 +92,7 @@ async fn ingester_flight_api_namespace_not_found() {
     let table_name = "mytable";
 
     // Set up cluster
-    let router2_config = TestConfig::new_router2(&database_url);
-    let ingester_config = TestConfig::new_ingester(&router2_config);
-    let cluster = MiniCluster::new().with_ingester(ingester_config).await;
+    let cluster = MiniCluster::create_standard(database_url).await;
 
     let mut querier_flight = influxdb_iox_client::flight::Client::<
         influxdb_iox_client::flight::generated_types::IngesterQueryRequest,
@@ -130,13 +121,7 @@ async fn ingester_flight_api_table_not_found() {
     let database_url = maybe_skip_integration!();
 
     // Set up cluster
-    let router2_config = TestConfig::new_router2(&database_url);
-    let ingester_config = TestConfig::new_ingester(&router2_config);
-    let cluster = MiniCluster::new()
-        .with_router2(router2_config)
-        .await
-        .with_ingester(ingester_config)
-        .await;
+    let cluster = MiniCluster::create_standard(database_url).await;
 
     // Write some data into the v2 HTTP API ==============
     let lp = String::from("my_table,tag1=A,tag2=B val=42i 123456");

--- a/influxdb_iox/tests/end_to_end_ng_cases/querier.rs
+++ b/influxdb_iox/tests/end_to_end_ng_cases/querier.rs
@@ -12,18 +12,8 @@ async fn basic_ingester() {
 
     let table_name = "the_table";
 
-    let router2_config = TestConfig::new_router2(&database_url);
-    let ingester_config = TestConfig::new_ingester(&router2_config);
-    let querier_config = TestConfig::new_querier(&ingester_config);
-
     // Set up the cluster  ====================================
-    let mut cluster = MiniCluster::new()
-        .with_router2(router2_config)
-        .await
-        .with_ingester(ingester_config)
-        .await
-        .with_querier(querier_config)
-        .await;
+    let mut cluster = MiniCluster::create_standard(database_url).await;
 
     StepTest::new(
         &mut cluster,
@@ -58,19 +48,8 @@ async fn basic_on_parquet() {
 
     let table_name = "the_table";
 
-    let router2_config = TestConfig::new_router2(&database_url);
-    // fast parquet
-    let ingester_config = TestConfig::new_ingester(&router2_config).with_fast_parquet_generation();
-    let querier_config = TestConfig::new_querier(&ingester_config);
-
     // Set up the cluster  ====================================
-    let mut cluster = MiniCluster::new()
-        .with_router2(router2_config)
-        .await
-        .with_ingester(ingester_config)
-        .await
-        .with_querier(querier_config)
-        .await;
+    let mut cluster = MiniCluster::create_quickly_peristing(database_url).await;
 
     StepTest::new(
         &mut cluster,
@@ -145,19 +124,8 @@ async fn table_not_found_on_ingester() {
 
     let table_name = "the_table";
 
-    let router2_config = TestConfig::new_router2(&database_url);
-    // fast parquet
-    let ingester_config = TestConfig::new_ingester(&router2_config).with_fast_parquet_generation();
-    let querier_config = TestConfig::new_querier(&ingester_config);
-
     // Set up the cluster  ====================================
-    let mut cluster = MiniCluster::new()
-        .with_router2(router2_config)
-        .await
-        .with_ingester(ingester_config)
-        .await
-        .with_querier(querier_config)
-        .await;
+    let mut cluster = MiniCluster::create_quickly_peristing(database_url).await;
 
     StepTest::new(
         &mut cluster,

--- a/influxdb_iox/tests/end_to_end_ng_cases/querier.rs
+++ b/influxdb_iox/tests/end_to_end_ng_cases/querier.rs
@@ -1,3 +1,4 @@
+mod influxrpc;
 mod multi_ingester;
 
 use futures::FutureExt;

--- a/influxdb_iox/tests/end_to_end_ng_cases/querier/influxrpc.rs
+++ b/influxdb_iox/tests/end_to_end_ng_cases/querier/influxrpc.rs
@@ -1,0 +1,448 @@
+//! Tests for influxrpc / Storage gRPC endpoints
+
+mod data;
+mod dump;
+mod exprs;
+
+use std::sync::Arc;
+
+use futures::prelude::*;
+use futures::FutureExt;
+use generated_types::ReadSource;
+use generated_types::{
+    google::protobuf::Empty, measurement_fields_response::FieldType,
+    offsets_response::PartitionOffsetResponse, read_response::frame::Data,
+    storage_client::StorageClient, MeasurementFieldsRequest, MeasurementNamesRequest,
+    MeasurementTagKeysRequest, MeasurementTagValuesRequest, OffsetsResponse, ReadFilterRequest,
+    TagKeysRequest, TagValuesRequest,
+};
+use influxdb_storage_client::tag_key_bytes_to_strings;
+use prost::Message;
+use test_helpers_end_to_end_ng::FCustom;
+use test_helpers_end_to_end_ng::{
+    maybe_skip_integration, MiniCluster, Step, StepTest, StepTestState,
+};
+
+use self::data::DataGenerator;
+
+#[tokio::test]
+/// Validate that capabilities storage endpoint is hooked up
+async fn capabilities() {
+    run_no_data_test(Box::new(|state: &mut StepTestState| {
+        async move {
+            let mut storage_client =
+                StorageClient::new(state.cluster().querier().querier_grpc_connection());
+            let capabilities_response = storage_client
+                .capabilities(Empty {})
+                .await
+                .unwrap()
+                .into_inner();
+            assert_eq!(
+                capabilities_response.caps.len(),
+                3,
+                "Response: {:?}",
+                capabilities_response
+            );
+        }
+        .boxed()
+    }))
+    .await
+}
+
+#[tokio::test]
+/// Validate that storage offsets endpoint is hooked up (required by internal Influx cloud)
+async fn offsets() {
+    run_no_data_test(Box::new(|state: &mut StepTestState| {
+        async move {
+            let mut storage_client =
+                StorageClient::new(state.cluster().querier().querier_grpc_connection());
+            let offsets_response = storage_client.offsets(Empty {}).await.unwrap().into_inner();
+            let expected = OffsetsResponse {
+                partitions: vec![PartitionOffsetResponse { id: 0, offset: 1 }],
+            };
+            assert_eq!(offsets_response, expected);
+        }
+        .boxed()
+    }))
+    .await
+}
+
+/// Runs the specified custom function on a cluster with no data
+async fn run_no_data_test(custom: FCustom) {
+    let database_url = maybe_skip_integration!();
+
+    // Set up the cluster  ====================================
+    let mut cluster = MiniCluster::create_standard(database_url).await;
+
+    StepTest::new(&mut cluster, vec![Step::Custom(custom)])
+        .run()
+        .await
+}
+
+#[tokio::test]
+async fn read_filter() {
+    let generator = Arc::new(data::DataGenerator::new());
+    run_data_test(Arc::clone(&generator), Box::new(move |state: &mut StepTestState| {
+        let mut storage_client =
+            StorageClient::new(state.cluster().querier().querier_grpc_connection());
+        let read_source = make_read_source(state.cluster());
+        let range = generator.timestamp_range();
+
+        let predicate = exprs::make_tag_predicate("host", "server01");
+        let predicate = Some(predicate);
+
+        let read_filter_request = tonic::Request::new(ReadFilterRequest {
+            read_source,
+            range,
+            predicate,
+            ..Default::default()
+        });
+
+        let expected_frames = generator.substitute_nanos(&[
+            "SeriesFrame, tags: _measurement=cpu_load_short,host=server01,_field=value, type: 0",
+            "FloatPointsFrame, timestamps: [ns1], values: \"27.99\"",
+            "SeriesFrame, tags: _measurement=cpu_load_short,host=server01,region=us-east,_field=value, type: 0",
+            "FloatPointsFrame, timestamps: [ns3], values: \"1234567.891011\"",
+            "SeriesFrame, tags: _measurement=cpu_load_short,host=server01,region=us-west,_field=value, type: 0",
+            "FloatPointsFrame, timestamps: [ns0, ns4], values: \"0.64,0.000003\"",
+            "SeriesFrame, tags: _measurement=swap,host=server01,name=disk0,_field=in, type: 1",
+            "IntegerPointsFrame, timestamps: [ns6], values: \"3\"",
+            "SeriesFrame, tags: _measurement=swap,host=server01,name=disk0,_field=out, type: 1",
+            "IntegerPointsFrame, timestamps: [ns6], values: \"4\""
+        ]);
+
+        async move {
+            let read_response = storage_client
+                .read_filter(read_filter_request)
+                .await
+                .unwrap();
+
+            let responses: Vec<_> = read_response.into_inner().try_collect().await.unwrap();
+            let frames: Vec<Data> = responses
+                .into_iter()
+                .flat_map(|r| r.frames)
+                .flat_map(|f| f.data)
+                .collect();
+
+            let actual_frames = dump::dump_data_frames(&frames);
+
+            assert_eq!(
+                expected_frames,
+                actual_frames,
+                "Expected:\n{}\nActual:\n{}",
+                expected_frames.join("\n"),
+                actual_frames.join("\n")
+            )
+        }.boxed()
+    })).await
+}
+
+#[tokio::test]
+async fn tag_keys() {
+    let generator = Arc::new(data::DataGenerator::new());
+    run_data_test(
+        Arc::clone(&generator),
+        Box::new(move |state: &mut StepTestState| {
+            let mut storage_client =
+                StorageClient::new(state.cluster().querier().querier_grpc_connection());
+            let read_source = make_read_source(state.cluster());
+            let range = generator.timestamp_range();
+            let predicate = exprs::make_tag_predicate("host", "server01");
+            let predicate = Some(predicate);
+
+            let tag_keys_request = tonic::Request::new(TagKeysRequest {
+                tags_source: read_source,
+                range,
+                predicate,
+            });
+
+            async move {
+                let tag_keys_response = storage_client.tag_keys(tag_keys_request).await.unwrap();
+                let responses: Vec<_> = tag_keys_response.into_inner().try_collect().await.unwrap();
+
+                let keys = &responses[0].values;
+                let keys: Vec<_> = keys
+                    .iter()
+                    .map(|v| tag_key_bytes_to_strings(v.clone()))
+                    .collect();
+
+                assert_eq!(keys, vec!["_m(0x00)", "host", "name", "region", "_f(0xff)"]);
+            }
+            .boxed()
+        }),
+    )
+    .await
+}
+
+#[tokio::test]
+async fn tag_values() {
+    let generator = Arc::new(data::DataGenerator::new());
+    run_data_test(
+        Arc::clone(&generator),
+        Box::new(move |state: &mut StepTestState| {
+            let mut storage_client =
+                StorageClient::new(state.cluster().querier().querier_grpc_connection());
+            let read_source = make_read_source(state.cluster());
+            let range = generator.timestamp_range();
+            let predicate = exprs::make_tag_predicate("host", "server01");
+            let predicate = Some(predicate);
+
+            let tag_values_request = tonic::Request::new(TagValuesRequest {
+                tags_source: read_source,
+                range,
+                predicate,
+                tag_key: b"host".to_vec(),
+            });
+
+            async move {
+                let tag_values_response =
+                    storage_client.tag_values(tag_values_request).await.unwrap();
+                let responses: Vec<_> = tag_values_response
+                    .into_inner()
+                    .try_collect()
+                    .await
+                    .unwrap();
+
+                let values = &responses[0].values;
+                let values: Vec<_> = values
+                    .iter()
+                    .map(|v| tag_key_bytes_to_strings(v.clone()))
+                    .collect();
+
+                assert_eq!(values, vec!["server01"]);
+            }
+            .boxed()
+        }),
+    )
+    .await
+}
+
+#[tokio::test]
+async fn measurement_names() {
+    let generator = Arc::new(data::DataGenerator::new());
+    run_data_test(
+        Arc::clone(&generator),
+        Box::new(move |state: &mut StepTestState| {
+            let mut storage_client =
+                StorageClient::new(state.cluster().querier().querier_grpc_connection());
+            let read_source = make_read_source(state.cluster());
+            let range = generator.timestamp_range();
+
+            let measurement_names_request = tonic::Request::new(MeasurementNamesRequest {
+                source: read_source,
+                range,
+                predicate: None,
+            });
+
+            async move {
+                let measurement_names_response = storage_client
+                    .measurement_names(measurement_names_request)
+                    .await
+                    .unwrap();
+                let responses: Vec<_> = measurement_names_response
+                    .into_inner()
+                    .try_collect()
+                    .await
+                    .unwrap();
+
+                let values = &responses[0].values;
+                let values: Vec<_> = values
+                    .iter()
+                    .map(|s| std::str::from_utf8(s).unwrap())
+                    .collect();
+
+                assert_eq!(
+                    values,
+                    vec!["attributes", "cpu_load_short", "status", "swap", "system"]
+                );
+            }
+            .boxed()
+        }),
+    )
+    .await
+}
+
+#[tokio::test]
+async fn measurement_tag_keys() {
+    let generator = Arc::new(data::DataGenerator::new());
+    run_data_test(
+        Arc::clone(&generator),
+        Box::new(move |state: &mut StepTestState| {
+            let mut storage_client =
+                StorageClient::new(state.cluster().querier().querier_grpc_connection());
+            let read_source = make_read_source(state.cluster());
+            let range = generator.timestamp_range();
+
+            let predicate = exprs::make_tag_predicate("host", "server01");
+            let predicate = Some(predicate);
+
+            let measurement_tag_keys_request = tonic::Request::new(MeasurementTagKeysRequest {
+                source: read_source,
+                measurement: String::from("cpu_load_short"),
+                range,
+                predicate,
+            });
+
+            async move {
+                let measurement_tag_keys_response = storage_client
+                    .measurement_tag_keys(measurement_tag_keys_request)
+                    .await
+                    .unwrap();
+                let responses: Vec<_> = measurement_tag_keys_response
+                    .into_inner()
+                    .try_collect()
+                    .await
+                    .unwrap();
+
+                let values = &responses[0].values;
+                let values: Vec<_> = values
+                    .iter()
+                    .map(|v| tag_key_bytes_to_strings(v.clone()))
+                    .collect();
+
+                assert_eq!(values, vec!["_m(0x00)", "host", "region", "_f(0xff)"]);
+            }
+            .boxed()
+        }),
+    )
+    .await
+}
+
+#[tokio::test]
+async fn measurement_tag_values() {
+    let generator = Arc::new(data::DataGenerator::new());
+    run_data_test(
+        Arc::clone(&generator),
+        Box::new(move |state: &mut StepTestState| {
+            let mut storage_client =
+                StorageClient::new(state.cluster().querier().querier_grpc_connection());
+            let read_source = make_read_source(state.cluster());
+            let range = generator.timestamp_range();
+
+            let predicate = exprs::make_tag_predicate("host", "server01");
+            let predicate = Some(predicate);
+
+            let measurement_tag_values_request = tonic::Request::new(MeasurementTagValuesRequest {
+                source: read_source,
+                measurement: String::from("cpu_load_short"),
+                tag_key: String::from("host"),
+                range,
+                predicate,
+            });
+
+            async move {
+                let measurement_tag_values_response = storage_client
+                    .measurement_tag_values(measurement_tag_values_request)
+                    .await
+                    .unwrap();
+                let responses: Vec<_> = measurement_tag_values_response
+                    .into_inner()
+                    .try_collect()
+                    .await
+                    .unwrap();
+
+                let values = &responses[0].values;
+                let values: Vec<_> = values
+                    .iter()
+                    .map(|v| tag_key_bytes_to_strings(v.clone()))
+                    .collect();
+
+                assert_eq!(values, vec!["server01"]);
+            }
+            .boxed()
+        }),
+    )
+    .await
+}
+
+#[tokio::test]
+async fn measurement_fields() {
+    let generator = Arc::new(data::DataGenerator::new());
+    run_data_test(
+        Arc::clone(&generator),
+        Box::new(move |state: &mut StepTestState| {
+            let mut storage_client =
+                StorageClient::new(state.cluster().querier().querier_grpc_connection());
+            let read_source = make_read_source(state.cluster());
+            let range = generator.timestamp_range();
+
+            let predicate = exprs::make_tag_predicate("host", "server01");
+            let predicate = Some(predicate);
+
+            let measurement_fields_request = tonic::Request::new(MeasurementFieldsRequest {
+                source: read_source,
+                measurement: String::from("cpu_load_short"),
+                range,
+                predicate,
+            });
+
+            let ns_since_epoch = generator.ns_since_epoch();
+            async move {
+                let measurement_fields_response = storage_client
+                    .measurement_fields(measurement_fields_request)
+                    .await
+                    .unwrap();
+                let responses: Vec<_> = measurement_fields_response
+                    .into_inner()
+                    .try_collect()
+                    .await
+                    .unwrap();
+
+                let fields = &responses[0].fields;
+                assert_eq!(fields.len(), 1);
+
+                let field = &fields[0];
+                assert_eq!(field.key, "value");
+                assert_eq!(field.r#type(), FieldType::Float);
+                assert_eq!(field.timestamp, ns_since_epoch + 4);
+            }
+            .boxed()
+        }),
+    )
+    .await
+}
+
+/// Run the custom test function with a cluster that has had the data from `generator` loaded
+async fn run_data_test(generator: Arc<DataGenerator>, custom: FCustom) {
+    let database_url = maybe_skip_integration!();
+
+    // Set up the cluster  ====================================
+    let mut cluster = MiniCluster::create_standard(database_url).await;
+
+    StepTest::new(
+        &mut cluster,
+        vec![
+            Step::WriteLineProtocol(generator.line_protocol().to_string()),
+            Step::WaitForReadable,
+            Step::Custom(custom),
+        ],
+    )
+    .run()
+    .await
+}
+
+/// Creates the appropriate `Any` protobuf magic for a read source
+/// with a specified org and bucket name
+fn make_read_source(cluster: &MiniCluster) -> Option<generated_types::google::protobuf::Any> {
+    let org_id = cluster.org_id();
+    let bucket_id = cluster.bucket_id();
+    let org_id = u64::from_str_radix(org_id, 16).unwrap();
+    let bucket_id = u64::from_str_radix(bucket_id, 16).unwrap();
+
+    let partition_id = u64::from(u32::MAX);
+    let read_source = ReadSource {
+        org_id,
+        bucket_id,
+        partition_id,
+    };
+
+    // Do the magic to-any conversion
+    let mut d = bytes::BytesMut::new();
+    read_source.encode(&mut d).unwrap();
+    let read_source = generated_types::google::protobuf::Any {
+        type_url: "/TODO".to_string(),
+        value: d.freeze(),
+    };
+
+    Some(read_source)
+}

--- a/influxdb_iox/tests/end_to_end_ng_cases/querier/influxrpc/data.rs
+++ b/influxdb_iox/tests/end_to_end_ng_cases/querier/influxrpc/data.rs
@@ -1,0 +1,103 @@
+use std::time::SystemTime;
+
+use generated_types::TimestampRange;
+
+/// Manages a dataset for writing / reading
+pub(crate) struct DataGenerator {
+    ns_since_epoch: i64,
+    line_protocol: String,
+}
+
+impl DataGenerator {
+    pub(crate) fn new() -> Self {
+        let ns_since_epoch = SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .expect("System time should have been after the epoch")
+            .as_nanos()
+            .try_into()
+            .expect("Unable to represent system time");
+
+        let points = vec![
+            format!(
+                "cpu_load_short,host=server01,region=us-west value=0.64 {}",
+                ns_since_epoch
+            ),
+            format!(
+                "cpu_load_short,host=server01 value=27.99 {}",
+                ns_since_epoch + 1
+            ),
+            format!(
+                "cpu_load_short,host=server02,region=us-west value=3.89 {}",
+                ns_since_epoch + 2
+            ),
+            format!(
+                "cpu_load_short,host=server01,region=us-east value=1234567.891011 {}",
+                ns_since_epoch + 3
+            ),
+            format!(
+                "cpu_load_short,host=server01,region=us-west value=0.000003 {}",
+                ns_since_epoch + 4
+            ),
+            format!(
+                "system,host=server03 uptime=1303385i {}",
+                ns_since_epoch + 5
+            ),
+            format!(
+                "swap,host=server01,name=disk0 in=3i,out=4i {}",
+                ns_since_epoch + 6
+            ),
+            format!("status active=true {}", ns_since_epoch + 7),
+            format!("attributes color=\"blue\" {}", ns_since_epoch + 8),
+        ];
+
+        Self {
+            ns_since_epoch,
+            line_protocol: points.join("\n"),
+        }
+    }
+
+    /// Return a timestamp range that covers the entire data range
+    pub(crate) fn timestamp_range(&self) -> Option<TimestampRange> {
+        Some(TimestampRange {
+            start: self.ns_since_epoch,
+            end: self.ns_since_epoch + 10,
+        })
+    }
+
+    /// substitutes "ns" --> ns_since_epoch, ns1-->ns_since_epoch+1, etc
+    pub(crate) fn substitute_nanos(&self, lines: &[&str]) -> Vec<String> {
+        let ns_since_epoch = self.ns_since_epoch;
+        let substitutions = vec![
+            ("ns0", format!("{}", ns_since_epoch)),
+            ("ns1", format!("{}", ns_since_epoch + 1)),
+            ("ns2", format!("{}", ns_since_epoch + 2)),
+            ("ns3", format!("{}", ns_since_epoch + 3)),
+            ("ns4", format!("{}", ns_since_epoch + 4)),
+            ("ns5", format!("{}", ns_since_epoch + 5)),
+            ("ns6", format!("{}", ns_since_epoch + 6)),
+        ];
+
+        lines
+            .iter()
+            .map(|line| {
+                let mut line = line.to_string();
+                for (from, to) in &substitutions {
+                    line = line.replace(from, to);
+                }
+                line
+            })
+            .collect()
+    }
+
+    /// Get a reference to the data generator's line protocol.
+    #[must_use]
+    pub(crate) fn line_protocol(&self) -> &str {
+        self.line_protocol.as_ref()
+    }
+
+    /// Get the data generator's ns since epoch.
+    #[must_use]
+    pub(crate) fn ns_since_epoch(&self) -> i64 {
+        self.ns_since_epoch
+    }
+}

--- a/influxdb_iox/tests/end_to_end_ng_cases/querier/influxrpc/dump.rs
+++ b/influxdb_iox/tests/end_to_end_ng_cases/querier/influxrpc/dump.rs
@@ -1,0 +1,86 @@
+//! Routines for dumping read_* responses
+use generated_types::{
+    read_response::{frame::Data, *},
+    Tag,
+};
+
+/// Convert a slice of frames to a format suitable for
+/// comparing in tests.
+pub(crate) fn dump_data_frames(frames: &[Data]) -> Vec<String> {
+    frames.iter().map(dump_data).collect()
+}
+
+fn dump_data(data: &Data) -> String {
+    match Some(data) {
+        Some(Data::Series(SeriesFrame { tags, data_type })) => format!(
+            "SeriesFrame, tags: {}, type: {:?}",
+            dump_tags(tags),
+            data_type
+        ),
+        Some(Data::FloatPoints(FloatPointsFrame { timestamps, values })) => format!(
+            "FloatPointsFrame, timestamps: {:?}, values: {:?}",
+            timestamps,
+            dump_values(values)
+        ),
+        Some(Data::IntegerPoints(IntegerPointsFrame { timestamps, values })) => format!(
+            "IntegerPointsFrame, timestamps: {:?}, values: {:?}",
+            timestamps,
+            dump_values(values)
+        ),
+        Some(Data::BooleanPoints(BooleanPointsFrame { timestamps, values })) => format!(
+            "BooleanPointsFrame, timestamps: {:?}, values: {}",
+            timestamps,
+            dump_values(values)
+        ),
+        Some(Data::StringPoints(StringPointsFrame { timestamps, values })) => format!(
+            "StringPointsFrame, timestamps: {:?}, values: {}",
+            timestamps,
+            dump_values(values)
+        ),
+        Some(Data::UnsignedPoints(UnsignedPointsFrame { timestamps, values })) => format!(
+            "UnsignedPointsFrame, timestamps: {:?}, values: {}",
+            timestamps,
+            dump_values(values)
+        ),
+        Some(Data::Group(GroupFrame {
+            tag_keys,
+            partition_key_vals,
+        })) => format!(
+            "GroupFrame, tag_keys: {}, partition_key_vals: {}",
+            dump_u8_vec(tag_keys),
+            dump_u8_vec(partition_key_vals),
+        ),
+        None => "<NO data field>".into(),
+    }
+}
+
+fn dump_values<T>(v: &[T]) -> String
+where
+    T: std::fmt::Display,
+{
+    v.iter()
+        .map(|item| format!("{}", item))
+        .collect::<Vec<_>>()
+        .join(",")
+}
+
+fn dump_u8_vec(encoded_strings: &[Vec<u8>]) -> String {
+    encoded_strings
+        .iter()
+        .map(|b| String::from_utf8_lossy(b))
+        .collect::<Vec<_>>()
+        .join(",")
+}
+
+fn dump_tags(tags: &[Tag]) -> String {
+    tags.iter()
+        .map(|tag| {
+            format!(
+                "{}={}",
+                String::from_utf8_lossy(&tag.key),
+                String::from_utf8_lossy(&tag.value),
+            )
+        })
+        .collect::<Vec<_>>()
+        .join(",")
+}

--- a/influxdb_iox/tests/end_to_end_ng_cases/querier/influxrpc/exprs.rs
+++ b/influxdb_iox/tests/end_to_end_ng_cases/querier/influxrpc/exprs.rs
@@ -1,0 +1,30 @@
+use generated_types::{
+    node::{Comparison, Type as NodeType, Value},
+    Node, Predicate,
+};
+
+/// Create a predicate representing tag_name=tag_value in the horrible gRPC
+/// structs
+pub(crate) fn make_tag_predicate(
+    tag_name: impl Into<String>,
+    tag_value: impl Into<String>,
+) -> Predicate {
+    Predicate {
+        root: Some(Node {
+            node_type: NodeType::ComparisonExpression as i32,
+            children: vec![
+                Node {
+                    node_type: NodeType::TagRef as i32,
+                    children: vec![],
+                    value: Some(Value::TagRefValue(tag_name.into().into())),
+                },
+                Node {
+                    node_type: NodeType::Literal as i32,
+                    children: vec![],
+                    value: Some(Value::StringValue(tag_value.into())),
+                },
+            ],
+            value: Some(Value::Comparison(Comparison::Equal as _)),
+        }),
+    }
+}

--- a/influxdb_iox/tests/end_to_end_ng_cases/schema.rs
+++ b/influxdb_iox/tests/end_to_end_ng_cases/schema.rs
@@ -1,6 +1,6 @@
 use futures::FutureExt;
 use test_helpers_end_to_end_ng::{
-    maybe_skip_integration, MiniCluster, Step, StepTest, StepTestState, TestConfig,
+    maybe_skip_integration, MiniCluster, Step, StepTest, StepTestState,
 };
 
 use assert_cmd::Command;
@@ -11,10 +11,7 @@ use predicates::prelude::*;
 async fn ingester_schema_client() {
     let database_url = maybe_skip_integration!();
 
-    let router2_config = TestConfig::new_router2(&database_url);
-
-    // Set up router2  ====================================
-    let mut cluster = MiniCluster::new().with_router2(router2_config).await;
+    let mut cluster = MiniCluster::create_standard(database_url).await;
 
     StepTest::new(
         &mut cluster,
@@ -60,10 +57,7 @@ async fn ingester_schema_client() {
 async fn ingester_schema_cli() {
     let database_url = maybe_skip_integration!();
 
-    let router2_config = TestConfig::new_router2(&database_url);
-
-    // Set up router2  ====================================
-    let mut cluster = MiniCluster::new().with_router2(router2_config).await;
+    let mut cluster = MiniCluster::create_standard(database_url).await;
 
     StepTest::new(
         &mut cluster,

--- a/test_helpers_end_to_end_ng/src/lib.rs
+++ b/test_helpers_end_to_end_ng/src/lib.rs
@@ -1,4 +1,7 @@
-use rand::{distributions::Alphanumeric, thread_rng, Rng};
+use rand::{
+    distributions::{Alphanumeric, Standard},
+    thread_rng, Rng,
+};
 
 mod addrs;
 mod client;
@@ -22,6 +25,23 @@ pub fn rand_name() -> String {
         .sample_iter(&Alphanumeric)
         .take(10)
         .map(char::from)
+        .collect()
+}
+
+// return a random 16 digit string comprised of numbers suitable for
+// use as a influxdb2 org_id or bucket_id
+pub fn rand_id() -> String {
+    thread_rng()
+        .sample_iter(&Standard)
+        .filter_map(|c: u8| {
+            if c.is_ascii_digit() {
+                Some(char::from(c))
+            } else {
+                // discard if out of range
+                None
+            }
+        })
+        .take(16)
         .collect()
 }
 

--- a/test_helpers_end_to_end_ng/src/mini_cluster.rs
+++ b/test_helpers_end_to_end_ng/src/mini_cluster.rs
@@ -64,7 +64,7 @@ impl MiniCluster {
 
     /// return a "standard" MiniCluster that has a router, ingester,
     /// querier and quickly persists files to parquet
-    pub async fn ccreate_quickly_peristing(database_url: String) -> MiniCluster {
+    pub async fn create_quickly_peristing(database_url: String) -> MiniCluster {
         let router2_config = TestConfig::new_router2(&database_url);
         // fast parquet
         let ingester_config =

--- a/test_helpers_end_to_end_ng/src/steps.rs
+++ b/test_helpers_end_to_end_ng/src/steps.rs
@@ -81,14 +81,20 @@ pub enum Step {
     /// Wait for all previously written data to be persisted
     WaitForPersisted,
 
-    /// Run a query and verify that the results are as expected
+    /// Run a query using the FlightSQL interface and verify that the
+    /// results match the expected results using the
+    /// `assert_batches_eq!` macro
     Query {
         sql: String,
         expected: Vec<&'static str>,
     },
 
-    /// Run a query and run the validation function on the
-    /// results. The validation function is expected to panic if there is an error
+    /// Run a query using the FlightSQL interface, and then verifies
+    /// the results using the provided validation function on the
+    /// results.
+    ///
+    /// The validation function is expected to panic on validation
+    /// failure.
     VerifiedQuery {
         sql: String,
         verify: Box<dyn Fn(Vec<RecordBatch>)>,


### PR DESCRIPTION
Draft until https://github.com/influxdata/influxdb_iox/pull/4372 is merged

# Rationale:
I want to reuse the same serve processes for multiple end to end tests (in different namespaces) for speed and to reduce the chance of a port conflict locally -- see https://github.com/influxdata/influxdb_iox/issues/4368.

Also the MiniCluster creation logic is replicated in several places which is annoying

# Changes:
1. This PR routes creation of MiniClusters with the same config through the same creation logic. 

A follow on PR will make `MiniCluster::create_standard` and `MiniCluster::create_quickly_peristing` share the same underlying `TestServer`s
