### PR TITLE
feat: Port end-to-end tracing tests to NG end-to-end tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6055,12 +6055,14 @@ dependencies = [
  "influxdb_iox_client",
  "nix 0.24.0",
  "once_cell",
+ "parking_lot 0.12.0",
  "rand",
  "reqwest",
  "sqlx",
  "tempfile",
  "test_helpers",
  "tokio",
+ "tokio-util 0.7.1",
  "workspace-hack",
 ]
 

--- a/influxdb_iox/tests/end_to_end_ng_cases/mod.rs
+++ b/influxdb_iox/tests/end_to_end_ng_cases/mod.rs
@@ -4,3 +4,4 @@ mod ingester;
 mod namespace;
 mod querier;
 mod schema;
+mod tracing;

--- a/influxdb_iox/tests/end_to_end_ng_cases/tracing.rs
+++ b/influxdb_iox/tests/end_to_end_ng_cases/tracing.rs
@@ -1,0 +1,162 @@
+use super::scenario::Scenario;
+use crate::common::{
+    server_fixture::{ServerFixture, ServerType, TestConfig},
+    udp_listener::UdpCapture,
+};
+use futures::TryStreamExt;
+use generated_types::{storage_client::StorageClient, ReadFilterRequest};
+use influxdb_iox_client::flight::generated_types::ReadInfo;
+use std::num::NonZeroU32;
+
+async fn setup() -> (UdpCapture, ServerFixture) {
+    let udp_capture = UdpCapture::new().await;
+
+    let test_config = TestConfig::new(ServerType::Database)
+        .with_env("TRACES_EXPORTER", "jaeger")
+        .with_env("TRACES_EXPORTER_JAEGER_AGENT_HOST", udp_capture.ip())
+        .with_env("TRACES_EXPORTER_JAEGER_AGENT_PORT", udp_capture.port())
+        .with_env(
+            "TRACES_EXPORTER_JAEGER_TRACE_CONTEXT_HEADER_NAME",
+            "custom-trace-header",
+        )
+        .with_client_header("custom-trace-header", "4:3:2:1");
+
+    let server_fixture = ServerFixture::create_single_use_with_config(test_config).await;
+
+    let mut deployment_client = server_fixture.deployment_client();
+
+    deployment_client
+        .update_server_id(NonZeroU32::new(1).unwrap())
+        .await
+        .unwrap();
+    server_fixture.wait_server_initialized().await;
+
+    (udp_capture, server_fixture)
+}
+
+/// Runs a query, discarding the results
+async fn run_sql_query(server_fixture: &ServerFixture) {
+    let scenario = Scenario::new();
+    scenario
+        .create_database(&mut server_fixture.management_client())
+        .await;
+    scenario.load_data(&mut server_fixture.write_client()).await;
+
+    // run a query, ensure we get traces
+    let sql_query = "select * from cpu_load_short";
+    let mut client = server_fixture.flight_client();
+
+    client
+        .perform_query(ReadInfo {
+            namespace_name: scenario.database_name().to_string(),
+            sql_query: sql_query.to_string(),
+        })
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+pub async fn test_tracing_sql() {
+    let (udp_capture, server_fixture) = setup().await;
+    run_sql_query(&server_fixture).await;
+
+    //  "shallow" packet inspection and verify the UDP server got
+    //  something that had some expected results (maybe we could
+    //  eventually verify the payload here too)
+    udp_capture
+        .wait_for(|m| m.to_string().contains("IOxReadFilterNode"))
+        .await;
+
+    // debugging assistance
+    //println!("Traces received (1):\n\n{:#?}", udp_capture.messages());
+
+    // wait for the UDP server to shutdown
+    udp_capture.stop().await
+}
+
+#[tokio::test]
+pub async fn test_tracing_storage_api() {
+    let (udp_capture, server_fixture) = setup().await;
+
+    let scenario = Scenario::new();
+    scenario
+        .create_database(&mut server_fixture.management_client())
+        .await;
+    scenario.load_data(&mut server_fixture.write_client()).await;
+
+    // run a query via gRPC, ensure we get traces
+    let read_source = scenario.read_source();
+    let range = scenario.timestamp_range();
+    let predicate = None;
+    let read_filter_request = tonic::Request::new(ReadFilterRequest {
+        read_source,
+        range,
+        predicate,
+        ..Default::default()
+    });
+    let mut storage_client = StorageClient::new(server_fixture.grpc_channel());
+    let read_response = storage_client
+        .read_filter(read_filter_request)
+        .await
+        .unwrap();
+
+    read_response
+        .into_inner()
+        .try_collect::<Vec<_>>()
+        .await
+        .unwrap();
+
+    //  "shallow" packet inspection and verify the UDP server got
+    //  something that had some expected results (maybe we could
+    //  eventually verify the payload here too)
+    udp_capture
+        .wait_for(|m| m.to_string().contains("IOxReadFilterNode"))
+        .await;
+
+    // debugging assistance
+    //println!("Traces received (2):\n\n{:#?}", udp_capture.messages());
+
+    // wait for the UDP server to shutdown
+    udp_capture.stop().await
+}
+
+#[tokio::test]
+pub async fn test_tracing_create_trace() {
+    let udp_capture = UdpCapture::new().await;
+
+    let test_config = TestConfig::new(ServerType::Database)
+        .with_env("TRACES_EXPORTER", "jaeger")
+        .with_env("TRACES_EXPORTER_JAEGER_AGENT_HOST", udp_capture.ip())
+        .with_env("TRACES_EXPORTER_JAEGER_AGENT_PORT", udp_capture.port())
+        // setup a custom debug name (to ensure it gets plumbed through)
+        .with_env("TRACES_EXPORTER_JAEGER_DEBUG_NAME", "force-trace")
+        .with_client_header("force-trace", "some-debug-id");
+
+    let server_fixture = ServerFixture::create_single_use_with_config(test_config).await;
+
+    let mut deployment_client = server_fixture.deployment_client();
+
+    deployment_client
+        .update_server_id(NonZeroU32::new(1).unwrap())
+        .await
+        .unwrap();
+    server_fixture.wait_server_initialized().await;
+
+    run_sql_query(&server_fixture).await;
+
+    //  "shallow" packet inspection and verify the UDP server got
+    //  something that had some expected results (maybe we could
+    //  eventually verify the payload here too)
+    udp_capture
+        .wait_for(|m| m.to_string().contains("IOxReadFilterNode"))
+        .await;
+
+    // debugging assistance
+    //println!("Traces received (1):\n\n{:#?}", udp_capture.messages());
+
+    // wait for the UDP server to shutdown
+    udp_capture.stop().await
+}

--- a/test_helpers_end_to_end_ng/Cargo.toml
+++ b/test_helpers_end_to_end_ng/Cargo.toml
@@ -3,25 +3,22 @@ name = "test_helpers_end_to_end_ng"
 version = "0.1.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
-[dependencies]
-# Workspace dependencies, in alphabetical order
-arrow_util = { path = "../arrow_util" }
-influxdb_iox_client = { path = "../influxdb_iox_client", features = ["flight", "format", "write_lp"] }
-test_helpers = { path = "../test_helpers" }
-
-# Crates.io dependencies, in alphabetical order
+[dependencies] # In alphabetical order
 arrow = { version = "12", features = ["prettyprint"] }
+arrow_util = { path = "../arrow_util" }
 assert_cmd = "2.0.2"
 futures = "0.3"
 http = "0.2.0"
 hyper = "0.14"
+influxdb_iox_client = { path = "../influxdb_iox_client", features = ["flight", "format", "write_lp"] }
 nix = "0.24"
 once_cell = { version = "1.10.0", features = ["parking_lot"] }
+parking_lot = "0.12"
 rand = "0.8.3"
 reqwest = { version = "0.11", default-features = false, features = ["json", "rustls-tls"] }
 sqlx = { version = "0.5", features = [ "runtime-tokio-rustls" , "postgres", "uuid" ] }
 tempfile = "3.1.0"
+test_helpers = { path = "../test_helpers" }
 tokio = { version = "1.17", features = ["macros", "net", "parking_lot", "rt-multi-thread", "signal", "sync", "time"] }
+tokio-util = "0.7"
 workspace-hack = { path = "../workspace-hack"}

--- a/test_helpers_end_to_end_ng/src/lib.rs
+++ b/test_helpers_end_to_end_ng/src/lib.rs
@@ -11,6 +11,7 @@ mod mini_cluster;
 mod server_fixture;
 mod server_type;
 mod steps;
+mod udp_listener;
 
 pub use client::*;
 pub use config::TestConfig;
@@ -18,6 +19,7 @@ pub use mini_cluster::MiniCluster;
 pub use server_fixture::{ServerFixture, TestServer};
 pub use server_type::ServerType;
 pub use steps::{FCustom, Step, StepTest, StepTestState};
+pub use udp_listener::UdpCapture;
 
 /// Return a random string suitable for use as a database name
 pub fn rand_name() -> String {

--- a/test_helpers_end_to_end_ng/src/mini_cluster.rs
+++ b/test_helpers_end_to_end_ng/src/mini_cluster.rs
@@ -45,7 +45,7 @@ impl MiniCluster {
     /// querier
     ///
     /// Long term plan is that this will be shared across multiple tests if possible
-    pub async fn create_standard(database_url: String) -> MiniCluster {
+    pub async fn create_standard(database_url: String) -> Self {
         let router2_config = TestConfig::new_router2(&database_url);
         // fast parquet
         let ingester_config =
@@ -64,7 +64,7 @@ impl MiniCluster {
 
     /// return a "standard" MiniCluster that has a router, ingester,
     /// querier and quickly persists files to parquet
-    pub async fn create_quickly_peristing(database_url: String) -> MiniCluster {
+    pub async fn create_quickly_peristing(database_url: String) -> Self {
         let router2_config = TestConfig::new_router2(&database_url);
         // fast parquet
         let ingester_config =
@@ -78,6 +78,17 @@ impl MiniCluster {
             .with_ingester(ingester_config)
             .await
             .with_querier(querier_config)
+            .await
+    }
+
+    /// Create an all-in-one server with the specified configuration
+    pub async fn create_all_in_one(test_config: TestConfig) -> Self {
+        Self::new()
+            .with_router2(test_config.clone())
+            .await
+            .with_ingester(test_config.clone())
+            .await
+            .with_querier(test_config)
             .await
     }
 

--- a/test_helpers_end_to_end_ng/src/udp_listener.rs
+++ b/test_helpers_end_to_end_ng/src/udp_listener.rs
@@ -1,0 +1,135 @@
+//! Captures UDP packets
+
+use std::{
+    sync::Arc,
+    time::{Duration, Instant},
+};
+
+/// UDP listener server that captures UDP messages (e.g. Jaeger spans)
+/// for use in tests
+use parking_lot::Mutex;
+use tokio::{net::UdpSocket, select};
+use tokio_util::sync::CancellationToken;
+
+/// Maximum time to wait for a message, in seconds
+const MAX_WAIT_TIME_SEC: u64 = 2;
+
+/// A UDP message received by this server
+#[derive(Clone)]
+pub struct Message {
+    data: Vec<u8>,
+}
+
+impl std::fmt::Debug for Message {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Message({} bytes: {}", self.data.len(), self.to_string())
+    }
+}
+
+impl ToString for Message {
+    fn to_string(&self) -> String {
+        String::from_utf8_lossy(&self.data).to_string()
+    }
+}
+
+pub struct UdpCapture {
+    socket_addr: std::net::SocketAddr,
+    join_handle: tokio::task::JoinHandle<()>,
+    token: CancellationToken,
+    messages: Arc<Mutex<Vec<Message>>>,
+}
+
+impl UdpCapture {
+    // Create a new server, listening for Udp messages
+    pub async fn new() -> Self {
+        // Bind to some address, letting the OS pick
+        let socket = UdpSocket::bind("127.0.0.1:0")
+            .await
+            .expect("bind udp listener");
+
+        let socket_addr = socket.local_addr().unwrap();
+
+        println!(
+            "UDP server listening at {} port {}",
+            socket_addr.ip(),
+            socket_addr.port()
+        );
+
+        let token = CancellationToken::new();
+        let messages = Arc::new(Mutex::new(vec![]));
+
+        // Spawns a background task that listens on the
+        let captured_messages = Arc::clone(&messages);
+        let captured_token = token.clone();
+
+        let join_handle = tokio::spawn(async move {
+            println!("Starting udp listen");
+            loop {
+                let mut data = vec![0; 1024];
+
+                select! {
+                    _ = captured_token.cancelled() => {
+                        println!("Received shutdown request");
+                        return;
+                    },
+                    res  = socket.recv_from(&mut data) => {
+                        let (sz, _origin) = res.expect("successful socket read");
+                        data.resize(sz, 0);
+                        let mut messages = captured_messages.lock();
+                        messages.push(Message { data });
+                    }
+                }
+            }
+        });
+
+        Self {
+            socket_addr,
+            join_handle,
+            token,
+            messages,
+        }
+    }
+
+    /// return the ip on which this server is listening
+    pub fn ip(&self) -> String {
+        self.socket_addr.ip().to_string()
+    }
+
+    /// return the port on which this server is listening
+    pub fn port(&self) -> String {
+        self.socket_addr.port().to_string()
+    }
+
+    /// stop and wait for succesful shutdown of this server
+    pub async fn stop(self) {
+        self.token.cancel();
+        if let Err(e) = self.join_handle.await {
+            println!("Error waiting for shutdown of udp server: {}", e);
+        }
+    }
+
+    // Return all messages this server has seen so far
+    pub fn messages(&self) -> Vec<Message> {
+        let messages = self.messages.lock();
+        messages.clone()
+    }
+
+    // wait for a message to appear that passes `pred` or the timeout expires
+    pub async fn wait_for<P>(&self, pred: P)
+    where
+        P: FnMut(&Message) -> bool + Copy,
+    {
+        let end = Instant::now() + Duration::from_secs(MAX_WAIT_TIME_SEC);
+
+        while Instant::now() < end {
+            if self.messages.lock().iter().any(pred) {
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(200)).await
+        }
+        panic!(
+            "Timeout expired before finding find messages that matches predicate. Messages:\n{:#?}",
+            self.messages.lock()
+        )
+    }
+}


### PR DESCRIPTION
Connects to #4102.

Adds some infrastructure to the test helper crate; there is some more that could maybe be shared with the NG querier RPC tests, but I wasn't sure if that was worth it or not.

The port is done in 2 commits: one where I just ran `cp influxdb_iox/tests/end_to_end_cases/tracing.rs influxdb_iox/tests/end_to_end_ng_cases` and committed even though it doesn't compile at all, and then another commit that actually does the port, so that if you review this PR commit-by-commit it should hopefully be easier to see what actually changed in the port.