### PR TITLE
feat: Provide basic summaries for `IngesterPartition`

### DIFF
--- a/data_types2/src/lib.rs
+++ b/data_types2/src/lib.rs
@@ -28,7 +28,9 @@ pub use data_types::{
     delete_predicate::{DeleteExpr, DeletePredicate, Op, Scalar},
     names::{org_and_bucket_to_database, OrgBucketMappingError},
     non_empty::NonEmptyString,
-    partition_metadata::{InfluxDbType, PartitionAddr, TableSummary},
+    partition_metadata::{
+        ColumnSummary, InfluxDbType, PartitionAddr, StatValues, Statistics, TableSummary,
+    },
     sequence::Sequence,
     timestamp::TimestampRange,
     DatabaseName,


### PR DESCRIPTION
This is required to pass the query tests with ingester data. (the actual query tests will follow in a separate PR)
