### PR TITLE
refactor: Demonstrate use of new datafusion scheduler (WIP)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7059,7 +7059,6 @@ name = "workspace-hack"
 version = "0.1.0"
 dependencies = [
  "ahash",
- "arrow",
  "base64 0.13.0",
  "bitflags",
  "byteorder",
@@ -7068,6 +7067,7 @@ dependencies = [
  "chrono",
  "crossbeam-utils",
  "crypto-common",
+ "datafusion 7.0.0",
  "digest 0.10.3",
  "either",
  "futures-channel",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1201,7 +1201,7 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "7.0.0"
-source = "git+https://github.com/apache/arrow-datafusion.git?rev=cd8bfb46b2f20ac9d44d22e66883e41cecd683e1#cd8bfb46b2f20ac9d44d22e66883e41cecd683e1"
+source = "git+https://github.com/alamb/arrow-datafusion.git?branch=alamb/scheduler_record_batch#d3d163e060bc7915ce7e1be1aec9c2fd2220e385"
 dependencies = [
  "ahash",
  "arrow",
@@ -1233,7 +1233,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "7.0.0"
-source = "git+https://github.com/apache/arrow-datafusion.git?rev=cd8bfb46b2f20ac9d44d22e66883e41cecd683e1#cd8bfb46b2f20ac9d44d22e66883e41cecd683e1"
+source = "git+https://github.com/alamb/arrow-datafusion.git?branch=alamb/scheduler_record_batch#d3d163e060bc7915ce7e1be1aec9c2fd2220e385"
 dependencies = [
  "arrow",
  "ordered-float 2.10.0",
@@ -1244,7 +1244,7 @@ dependencies = [
 [[package]]
 name = "datafusion-data-access"
 version = "1.0.0"
-source = "git+https://github.com/apache/arrow-datafusion.git?rev=cd8bfb46b2f20ac9d44d22e66883e41cecd683e1#cd8bfb46b2f20ac9d44d22e66883e41cecd683e1"
+source = "git+https://github.com/alamb/arrow-datafusion.git?branch=alamb/scheduler_record_batch#d3d163e060bc7915ce7e1be1aec9c2fd2220e385"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1257,7 +1257,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "7.0.0"
-source = "git+https://github.com/apache/arrow-datafusion.git?rev=cd8bfb46b2f20ac9d44d22e66883e41cecd683e1#cd8bfb46b2f20ac9d44d22e66883e41cecd683e1"
+source = "git+https://github.com/alamb/arrow-datafusion.git?branch=alamb/scheduler_record_batch#d3d163e060bc7915ce7e1be1aec9c2fd2220e385"
 dependencies = [
  "ahash",
  "arrow",
@@ -1268,7 +1268,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "7.0.0"
-source = "git+https://github.com/apache/arrow-datafusion.git?rev=cd8bfb46b2f20ac9d44d22e66883e41cecd683e1#cd8bfb46b2f20ac9d44d22e66883e41cecd683e1"
+source = "git+https://github.com/alamb/arrow-datafusion.git?branch=alamb/scheduler_record_batch#d3d163e060bc7915ce7e1be1aec9c2fd2220e385"
 dependencies = [
  "ahash",
  "arrow",
@@ -1286,6 +1286,21 @@ dependencies = [
  "regex",
  "sha2 0.10.2",
  "unicode-segmentation",
+]
+
+[[package]]
+name = "datafusion-scheduler"
+version = "7.0.0"
+source = "git+https://github.com/alamb/arrow-datafusion.git?branch=alamb/scheduler_record_batch#d3d163e060bc7915ce7e1be1aec9c2fd2220e385"
+dependencies = [
+ "ahash",
+ "arrow",
+ "async-trait",
+ "datafusion 7.0.0",
+ "futures",
+ "log",
+ "parking_lot 0.12.0",
+ "rayon",
 ]
 
 [[package]]
@@ -4578,6 +4593,7 @@ dependencies = [
  "croaring",
  "data_types",
  "datafusion 0.1.0",
+ "datafusion-scheduler",
  "datafusion_util",
  "executor",
  "futures",

--- a/datafusion/Cargo.toml
+++ b/datafusion/Cargo.toml
@@ -9,5 +9,5 @@ description = "Re-exports datafusion at a specific version"
 
 # Rename to workaround doctest bug
 # Turn off optional datafusion features (e.g. don't get support for crypo functions or avro)
-upstream = { git = "https://github.com/apache/arrow-datafusion.git", rev="cd8bfb46b2f20ac9d44d22e66883e41cecd683e1", default-features = false, package = "datafusion" }
+upstream = { git = "https://github.com/alamb/arrow-datafusion.git", branch="alamb/scheduler_record_batch", default-features = false, package = "datafusion" }
 workspace-hack = { path = "../workspace-hack"}

--- a/query/Cargo.toml
+++ b/query/Cargo.toml
@@ -39,6 +39,8 @@ trace = { path = "../trace" }
 predicate = { path = "../predicate" }
 workspace-hack = { path = "../workspace-hack"}
 
+datafusion-scheduler = { git = "https://github.com/alamb/arrow-datafusion.git", branch="alamb/scheduler_record_batch" }
+
 [dev-dependencies] # In alphabetical order
 itertools = "0.10.1"
 test_helpers = { path = "../test_helpers" }

--- a/workspace-hack/Cargo.toml
+++ b/workspace-hack/Cargo.toml
@@ -14,7 +14,6 @@ publish = false
 ### BEGIN HAKARI SECTION
 [dependencies]
 ahash = { version = "0.7", features = ["std"] }
-arrow = { version = "12", features = ["comfy-table", "csv", "csv_crate", "flatbuffers", "ipc", "prettyprint", "rand", "test_utils"] }
 base64 = { version = "0.13", features = ["alloc", "std"] }
 bitflags = { version = "1" }
 byteorder = { version = "1", features = ["std"] }
@@ -22,6 +21,7 @@ bytes = { version = "1", features = ["std"] }
 chrono = { version = "0.4", features = ["alloc", "clock", "libc", "oldtime", "serde", "std", "time", "winapi"] }
 crossbeam-utils = { version = "0.8", features = ["lazy_static", "std"] }
 crypto-common = { version = "0.1", default-features = false, features = ["std"] }
+datafusion = { git = "https://github.com/alamb/arrow-datafusion.git", branch = "alamb/scheduler_record_batch", features = ["crypto_expressions", "regex_expressions", "unicode_expressions"] }
 digest = { version = "0.10", features = ["alloc", "block-buffer", "core-api", "mac", "std", "subtle"] }
 either = { version = "1", features = ["use_std"] }
 futures-channel = { version = "0.3", features = ["alloc", "futures-sink", "sink", "std"] }


### PR DESCRIPTION
POC of how the new DataFusion scheduler from @tustvold  in https://github.com/apache/arrow-datafusion/pull/2226 could be used in IOx 

Not ready for merging yet

- [ ] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb_iox/blob/main/README.md).
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
