### PR TITLE
feat: benchmark LP -> MutableBuffer conversion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3526,6 +3526,7 @@ version = "0.1.0"
 dependencies = [
  "arrow_util",
  "assert_matches",
+ "criterion",
  "hashbrown 0.12.0",
  "influxdb_line_protocol",
  "mutable_batch",

--- a/mutable_batch_lp/Cargo.toml
+++ b/mutable_batch_lp/Cargo.toml
@@ -15,3 +15,11 @@ workspace-hack = { path = "../workspace-hack"}
 [dev-dependencies]
 arrow_util = { path = "../arrow_util" }
 assert_matches = "1.5.0"
+criterion = "0.3"
+
+[[bench]]
+name = "parse_lp"
+harness = false
+
+[lib]
+bench = false

--- a/mutable_batch_lp/benches/parse_lp.rs
+++ b/mutable_batch_lp/benches/parse_lp.rs
@@ -1,0 +1,29 @@
+use criterion::{criterion_group, criterion_main, BatchSize, Criterion, Throughput};
+use mutable_batch_lp::LinesConverter;
+
+fn bench_write_line(c: &mut Criterion) {
+    // Read the text_fixtures/metrics.lp data set, containing 1,000 lines of LP.
+    let lp = std::fs::read_to_string(format!(
+        "{}/../test_fixtures/lineproto/metrics.lp",
+        env!("CARGO_MANIFEST_DIR")
+    ))
+    .expect("reading test fixture failed");
+
+    let lines = lp.chars().filter(|&c| c == '\n').count();
+    assert_eq!(lines, 1000); // Perf would vary if the fixture changed
+
+    let mut group = c.benchmark_group("parse_lp");
+    group.throughput(Throughput::Elements(lines as _));
+    group.bench_function("metrics.lp", |b| {
+        b.iter_batched(
+            || LinesConverter::new(42),
+            |mut converter| {
+                converter.write_lp(&lp).unwrap();
+            },
+            BatchSize::PerIteration,
+        );
+    });
+}
+
+criterion_group!(benches, bench_write_line);
+criterion_main!(benches);


### PR DESCRIPTION
A quick benchmark to check the overhead of #4398 - see https://github.com/influxdata/influxdb_iox/pull/4398#discussion_r857476339 

---

* feat: benchmark LP -> MutableBuffer conversion (4174c88bc)

      Adds a benchmark that measures the time taken to parse the 
      test_fixtures/metrics.lp dataset, and convert it into a MutableBuffer 
      instance.