### PR TITLE
feat(router2): pre-warm namespace schema cache

### DIFF
--- a/iox_catalog/src/interface.rs
+++ b/iox_catalog/src/interface.rs
@@ -357,6 +357,9 @@ pub trait ColumnRepo: Send + Sync {
 
     /// Lists all columns in the passed in namespace id.
     async fn list_by_namespace_id(&mut self, namespace_id: NamespaceId) -> Result<Vec<Column>>;
+
+    /// List all columns.
+    async fn list(&mut self) -> Result<Vec<Column>>;
 }
 
 /// Functions for working with sequencers in the catalog
@@ -1075,6 +1078,10 @@ pub(crate) mod test_helpers {
         let mut want = vec![c, ccc];
         want.extend(cols3);
         assert_eq!(want, columns);
+
+        // Listing columns should return all columns in the catalog
+        let list = repos.columns().list().await.unwrap();
+        assert_eq!(list, want);
 
         // test per-namespace column limits
         repos

--- a/iox_catalog/src/lib.rs
+++ b/iox_catalog/src/lib.rs
@@ -247,7 +247,7 @@ mod tests {
                         let schema = {
                             let lp: String = $lp.to_string();
 
-                            let (writes, _) = mutable_batch_lp::lines_to_batches_stats(lp.as_str(), 42)
+                            let writes = mutable_batch_lp::lines_to_batches(lp.as_str(), 42)
                                 .expect("failed to build test writes from LP");
 
                             let got = validate_or_insert_schema(writes.iter().map(|(k, v)| (k.as_str(), v)), &schema, txn.deref_mut())

--- a/iox_catalog/src/mem.rs
+++ b/iox_catalog/src/mem.rs
@@ -437,6 +437,11 @@ impl TableRepo for MemTxn {
         Ok(tables)
     }
 
+    async fn list(&mut self) -> Result<Vec<Table>> {
+        let stage = self.stage();
+        Ok(stage.tables.clone())
+    }
+
     async fn get_table_persist_info(
         &mut self,
         sequencer_id: SequencerId,

--- a/iox_catalog/src/mem.rs
+++ b/iox_catalog/src/mem.rs
@@ -582,6 +582,11 @@ impl ColumnRepo for MemTxn {
 
         Ok(columns)
     }
+
+    async fn list(&mut self) -> Result<Vec<Column>> {
+        let stage = self.stage();
+        Ok(stage.columns.clone())
+    }
 }
 
 #[async_trait]

--- a/iox_catalog/src/metrics.rs
+++ b/iox_catalog/src/metrics.rs
@@ -214,6 +214,7 @@ decorate!(
         "table_get_by_namespace_and_name" = get_by_namespace_and_name(&mut self, namespace_id: NamespaceId, name: &str) -> Result<Option<Table>>;
         "table_list_by_namespace_id" = list_by_namespace_id(&mut self, namespace_id: NamespaceId) -> Result<Vec<Table>>;
         "get_table_persist_info" = get_table_persist_info(&mut self, sequencer_id: SequencerId, namespace_id: NamespaceId, table_name: &str) -> Result<Option<TablePersistInfo>>;
+        "table_list" = list(&mut self) -> Result<Vec<Table>>;
     ]
 );
 

--- a/iox_catalog/src/metrics.rs
+++ b/iox_catalog/src/metrics.rs
@@ -224,6 +224,7 @@ decorate!(
         "column_create_or_get" = create_or_get(&mut self, name: &str, table_id: TableId, column_type: ColumnType) -> Result<Column>;
         "column_list_by_namespace_id" = list_by_namespace_id(&mut self, namespace_id: NamespaceId) -> Result<Vec<Column>>;
         "column_create_or_get_many" = create_or_get_many(&mut self, columns: &[ColumnUpsertRequest<'_>]) -> Result<Vec<Column>>;
+        "column_list" = list(&mut self) -> Result<Vec<Column>>;
     ]
 );
 

--- a/iox_catalog/src/postgres.rs
+++ b/iox_catalog/src/postgres.rs
@@ -905,6 +905,15 @@ WHERE table_name.namespace_id = $1;
         Ok(rec)
     }
 
+    async fn list(&mut self) -> Result<Vec<Column>> {
+        let rec = sqlx::query_as::<_, Column>("SELECT * FROM column_name;")
+            .fetch_all(&mut self.inner)
+            .await
+            .map_err(|e| Error::SqlxError { source: e })?;
+
+        Ok(rec)
+    }
+
     async fn create_or_get_many(
         &mut self,
         columns: &[ColumnUpsertRequest<'_>],

--- a/iox_catalog/src/postgres.rs
+++ b/iox_catalog/src/postgres.rs
@@ -790,6 +790,15 @@ WHERE namespace_id = $1;
         Ok(rec)
     }
 
+    async fn list(&mut self) -> Result<Vec<Table>> {
+        let rec = sqlx::query_as::<_, Table>("SELECT * FROM table_name;")
+            .fetch_all(&mut self.inner)
+            .await
+            .map_err(|e| Error::SqlxError { source: e })?;
+
+        Ok(rec)
+    }
+
     async fn get_table_persist_info(
         &mut self,
         sequencer_id: SequencerId,

--- a/ioxd_router2/src/lib.rs
+++ b/ioxd_router2/src/lib.rs
@@ -6,7 +6,7 @@ use std::{
 
 use async_trait::async_trait;
 use clap_blocks::write_buffer::WriteBufferConfig;
-use data_types2::{PartitionTemplate, TemplatePart};
+use data_types2::{DatabaseName, PartitionTemplate, TemplatePart};
 use hashbrown::HashMap;
 use hyper::{Body, Request, Response};
 use iox_catalog::interface::Catalog;
@@ -19,7 +19,9 @@ use router2::{
         NamespaceAutocreation, Partitioner, SchemaValidator, ShardedWriteBuffer,
         WriteSummaryAdapter,
     },
-    namespace_cache::{metrics::InstrumentedCache, MemoryNamespaceCache, ShardedCache},
+    namespace_cache::{
+        metrics::InstrumentedCache, MemoryNamespaceCache, NamespaceCache, ShardedCache,
+    },
     sequencer::Sequencer,
     server::{grpc::GrpcDelegate, http::HttpDelegate, RouterServer},
     sharder::JumpHash,
@@ -174,6 +176,10 @@ pub async fn create_router2_server_type(
         &*metrics,
     ));
 
+    pre_warm_schema_cache(&ns_cache, &*catalog)
+        .await
+        .expect("namespace cache pre-warming failed");
+
     // Initialise and instrument the schema validator
     let schema_validator =
         SchemaValidator::new(Arc::clone(&catalog), Arc::clone(&ns_cache), &*metrics);
@@ -317,4 +323,69 @@ async fn init_write_buffer(
             .map(Arc::new)
             .collect::<JumpHash<_>>(),
     ))
+}
+
+/// Pre-populate `cache` with the all existing schemas in `catalog`.
+async fn pre_warm_schema_cache<T>(
+    cache: &T,
+    catalog: &dyn Catalog,
+) -> Result<(), iox_catalog::interface::Error>
+where
+    T: NamespaceCache,
+{
+    iox_catalog::interface::list_schemas(catalog)
+        .await?
+        .for_each(|(ns, schema)| {
+            let name = DatabaseName::try_from(ns.name)
+                .expect("cannot convert existing namespace name to database name");
+
+            cache.put_schema(name, schema);
+        });
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use data_types2::ColumnType;
+    use iox_catalog::mem::MemCatalog;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_pre_warm_cache() {
+        let catalog = Arc::new(MemCatalog::new(Default::default()));
+
+        let mut repos = catalog.repositories().await;
+        let kafka = repos.kafka_topics().create_or_get("foo").await.unwrap();
+        let pool = repos.query_pools().create_or_get("foo").await.unwrap();
+        let namespace = repos
+            .namespaces()
+            .create("test_ns", "inf", kafka.id, pool.id)
+            .await
+            .unwrap();
+
+        let table = repos
+            .tables()
+            .create_or_get("name", namespace.id)
+            .await
+            .unwrap();
+        let _column = repos
+            .columns()
+            .create_or_get("name", table.id, ColumnType::U64)
+            .await
+            .unwrap();
+
+        drop(repos); // Or it'll deadlock.
+
+        let cache = Arc::new(MemoryNamespaceCache::default());
+        pre_warm_schema_cache(&cache, &*catalog)
+            .await
+            .expect("pre-warming failed");
+
+        let name = DatabaseName::new("test_ns").unwrap();
+        let got = cache.get_schema(&name).expect("should contain a schema");
+
+        assert!(got.tables.get("name").is_some());
+    }
 }


### PR DESCRIPTION
This should significantly reduce the PG load induced by deployments and significantly reduce PG pool saturation / resulting back-pressure / rejected requests 🎉

Closes https://github.com/influxdata/influxdb_iox/issues/3577

---

* feat(iox_catalog): TableRepo::list() (eb5abce99)

      Allow all tables in the catalog to be fetched.

* feat(iox_catalog): ColumnRepo::list() (874521da8)

      Allow all columns in the catalog to be fetched.

* feat(iox_catalog): list_schemas() (bb8a19b57)

      Adds a function to resolve an atomic snapshot of all NamespaceSchema in the
      catalog with minimal query overhead.

* feat(router2): pre-warm schema cache (d7d4de514)

      Fetch all NamespaceSchema from the catalog and pre-cache them during router
      initialisation.

      This pre-warming happens in 3 queries, and should significantly reduce the
      load on the Postgres instance backing the catalog during deployments/after
      router crashes/etc.

      Pre-warming occurs during init, before the HTTP endpoints are bound, and 
      therefore before the /health HTTP endpoint can return OK. This ensures the
      router pre-warms the cache before it begins receiving traffic.