### PR TITLE
test: remove hard-coded metric count

### DIFF
--- a/influxdb_iox/tests/end_to_end_ng_cases/metrics.rs
+++ b/influxdb_iox/tests/end_to_end_ng_cases/metrics.rs
@@ -16,13 +16,13 @@ pub async fn test_metrics() {
             Step::WriteLineProtocol(lp),
             Step::WaitForReadable,
             Step::VerifiedMetrics(Box::new(|_state, metrics| {
-                assert_eq!(
+                assert!(
                     metrics
                         .trim()
                         .split('\n')
                         .filter(|x| x.starts_with("catalog_op_duration_ms_bucket"))
-                        .count(),
-                    180
+                        .count()
+                        >= 180
                 );
             })),
         ],


### PR DESCRIPTION
Fixes an e2e failure first noticed in #3577.

I'm not sure if this was intentional - I can't think of a reason why we'd want to assert this one metric appears an exact number of times, though I am happy to change it back to an == if needed 👍 

Relates to https://github.com/influxdata/influxdb_iox/issues/4457

---

* test: remove hard-coded metric count (246af0c3c)

      Prior to this commit, adding any metric to the catalog (and only the catalog)
      would cause the end_to_end_ng_cases::metrics::test_metrics test to fail due to
      asserting an exact number of metrics observed.

      This commit changes the check condition to a more permisive >= rather than ==.