### PR TITLE
fix: Possible fix for flaky end to end test `end_to_end_ng_cases::querier::multi_ingester::basic_multi_ingesters`

### DIFF
--- a/influxdb_iox/tests/end_to_end_ng_cases/querier/multi_ingester.rs
+++ b/influxdb_iox/tests/end_to_end_ng_cases/querier/multi_ingester.rs
@@ -21,9 +21,13 @@ async fn basic_multi_ingesters() {
     let router2_config =
         TestConfig::new_router2(&database_url).with_new_write_buffer_kafka_partitions(2);
 
-    // ingester gets partition 0
-    let ingester_config = TestConfig::new_ingester(&router2_config).with_kafka_partition(0);
-    let ingester2_config = TestConfig::new_ingester(&router2_config).with_kafka_partition(1);
+    let ingester_config = TestConfig::new_ingester(&router2_config)
+        .with_kafka_partition(0)
+        .with_no_persist();
+
+    let ingester2_config = TestConfig::new_ingester(&router2_config)
+        .with_kafka_partition(1)
+        .with_no_persist();
 
     let querier_config = TestConfig::new_querier_without_ingester(&ingester_config)
         // Configure to talk with both the ingesters

--- a/test_helpers_end_to_end_ng/src/config.rs
+++ b/test_helpers_end_to_end_ng/src/config.rs
@@ -138,6 +138,12 @@ impl TestConfig {
             .with_kafka_partition(0)
     }
 
+    /// sets the ingester so that it will not persist any data (as the perist threshold is too high)
+    pub fn with_no_persist(self) -> Self {
+        // chosen to be one less than default INFLUXDB_IOX_PAUSE_INGEST_SIZE_BYTES
+        self.with_env("INFLUXDB_IOX_PERSIST_MEMORY_THRESHOLD_BYTES", "1999999")
+    }
+
     /// Adds an ingester that ingests from the specified kafka partition
     pub fn with_kafka_partition(self, kafka_partition_id: u64) -> Self {
         self.with_env(


### PR DESCRIPTION
Draft while testing

# Rationale
Closes https://github.com/influxdata/influxdb_iox/issues/4395 (I hope)

I discovered in https://github.com/influxdata/influxdb_iox/pull/4387#discussion_r860997349 that the configuration options that claim to make a test fixture not persist quicky was a sham (all configurations ended up persisting quickly)

The failure mode on #4395 is that there is no data in the ingester even though we had previously observed that all the data was readable. This could have happened if the ingester *persisted* the data between when the test checked for readable and when it ran the query. 

# Changes
1. Configures the ingester to (practically speaking) not persist its data

# Testing:
I ran a sophisticated script (below) to run `cargo test --test end_to_end_ng -- multi_ingester` 100 times.

* Before this change: TODO
* with this change: IN PROGRESS


Sophisticated script:
```bash
set -e

for i in `seq 1 100`; do
    echo "iteration $i"
    TEST_INTEGRATION=1 TEST_INFLUXDB_IOX_CATALOG_DSN=postgresql://localhost:5432/alamb RUST_BACKTRACE=1 CARGO_TARGET_DIR=/Users/alamb/Software/iox-target cargo test --test end_to_end_ng -- multi_ingester
done
```
