### PR TITLE
chore: Update heappy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1879,13 +1879,13 @@ dependencies = [
 [[package]]
 name = "heappy"
 version = "0.1.0"
-source = "git+https://github.com/mkmik/heappy?rev=df8c1428a2ff727db239999c458c49fdc2ca270a#df8c1428a2ff727db239999c458c49fdc2ca270a"
+source = "git+https://github.com/mkmik/heappy?rev=5d47dff152b8430e1dc1aea5a54c91c0c3099219#5d47dff152b8430e1dc1aea5a54c91c0c3099219"
 dependencies = [
  "backtrace",
  "bytes",
  "lazy_static",
  "libc",
- "pprof",
+ "pprof 0.9.0",
  "spin 0.9.3",
  "thiserror",
  "tikv-jemalloc-sys",
@@ -2492,7 +2492,7 @@ dependencies = [
  "mutable_batch_lp",
  "observability_deps",
  "parking_lot 0.12.0",
- "pprof",
+ "pprof 0.8.0",
  "predicate",
  "reqwest",
  "serde",
@@ -3889,6 +3889,30 @@ dependencies = [
  "libc",
  "log",
  "nix 0.23.1",
+ "once_cell",
+ "parking_lot 0.12.0",
+ "prost",
+ "prost-build",
+ "prost-derive",
+ "smallvec",
+ "symbolic-demangle",
+ "tempfile",
+ "thiserror",
+]
+
+[[package]]
+name = "pprof"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f9307de92566887d485ac6f20df17b0fe1704fffdbad0bdbc05a3864d3082f6"
+dependencies = [
+ "backtrace",
+ "cfg-if",
+ "findshlibs",
+ "inferno",
+ "libc",
+ "log",
+ "nix 0.24.1",
  "once_cell",
  "parking_lot 0.12.0",
  "prost",

--- a/influxdb_iox/Cargo.toml
+++ b/influxdb_iox/Cargo.toml
@@ -61,7 +61,7 @@ tonic = "0.7"
 uuid = { version = "0.8", features = ["v4"] }
 # jemalloc-sys with unprefixed_malloc_on_supported_platforms feature and heappy are mutually exclusive
 tikv-jemalloc-sys = { version = "0.4.0", optional = true, features = ["unprefixed_malloc_on_supported_platforms"] }
-heappy = { git = "https://github.com/mkmik/heappy", rev = "df8c1428a2ff727db239999c458c49fdc2ca270a", features = ["enable_heap_profiler", "jemalloc_shim", "measure_free"], optional = true }
+heappy = { git = "https://github.com/mkmik/heappy", rev = "5d47dff152b8430e1dc1aea5a54c91c0c3099219", features = ["enable_heap_profiler", "jemalloc_shim", "measure_free"], optional = true }
 workspace-hack = { path = "../workspace-hack"}
 
 [dev-dependencies]


### PR DESCRIPTION
# Rationale
pprof updated a new version, see https://github.com/influxdata/influxdb_iox/pull/4562 and I noticed that the old version of pprof was still used by heappy.

# Changes
1. update heappy to https://github.com/mkmik/heappy/commit/5d47dff152b8430e1dc1aea5a54c91c0c3099219
