### PR TITLE
feat: Add more logging in particular situations to debug flaky test

### DIFF
--- a/querier/src/ingester/flight_client.rs
+++ b/querier/src/ingester/flight_client.rs
@@ -94,12 +94,12 @@ impl FlightClient for FlightClientImpl {
         ingester_addr: Arc<str>,
         request: IngesterQueryRequest,
     ) -> Result<Box<dyn QueryData>, Error> {
-        let connection = self.connect(ingester_addr).await?;
+        let connection = self.connect(Arc::clone(&ingester_addr)).await?;
 
         let mut client =
             flight::Client::<flight::generated_types::IngesterQueryRequest>::new(connection);
 
-        debug!(?request, "Sending request to ingester");
+        debug!(%ingester_addr, ?request, "Sending request to ingester");
         let request: flight::generated_types::IngesterQueryRequest =
             request.try_into().context(CreatingRequestSnafu)?;
 

--- a/querier/src/ingester/mod.rs
+++ b/querier/src/ingester/mod.rs
@@ -284,7 +284,7 @@ async fn execute(request: GetPartitionForIngester<'_>) -> Result<Vec<Arc<Ingeste
             .push(batch);
         num_batches += 1;
     }
-    debug!(num_batches, "Received batches from ingester");
+    debug!(%ingester_address, num_batches, "Received batches from ingester");
     trace!(?partitions, schema=?perform_query.schema(), "Detailed from ingester");
     ensure!(
         num_batches == partition_ids.len(),

--- a/write_summary/src/lib.rs
+++ b/write_summary/src/lib.rs
@@ -117,6 +117,13 @@ impl WriteSummary {
             .get(&kafka_partition)
             .context(UnknownKafkaPartitionSnafu { kafka_partition })?;
 
+        debug!(
+            ?kafka_partition,
+            ?progress,
+            ?sequence_numbers,
+            "write_status"
+        );
+
         if progress.is_empty() {
             return Ok(KafkaPartitionWriteStatus::KafkaPartitionUnknown);
         }


### PR DESCRIPTION
I still don't know what's causing #4395. 

The debug logs didn't include all the information I was wondering about, like what the ingesters think they have, what they're sending to the querier, when they're persisting what, what the querier gets from the ingesters, what the querier sees in the catalog, what happens when the querier puts together data from the ingester and from the catalog.
