### PR TITLE
fix: partition null column serialisation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3224,6 +3224,7 @@ name = "mutable_batch_pb"
 version = "0.1.0"
 dependencies = [
  "arrow_util",
+ "data_types",
  "dml",
  "generated_types",
  "hashbrown 0.12.1",

--- a/mutable_batch_pb/Cargo.toml
+++ b/mutable_batch_pb/Cargo.toml
@@ -16,3 +16,4 @@ workspace-hack = { path = "../workspace-hack"}
 
 [dev-dependencies]
 mutable_batch_lp = { path = "../mutable_batch_lp" }
+data_types = { path = "../data_types" }

--- a/mutable_batch_pb/tests/encode.rs
+++ b/mutable_batch_pb/tests/encode.rs
@@ -1,5 +1,6 @@
 use arrow_util::assert_batches_eq;
-use mutable_batch::MutableBatch;
+use data_types::{PartitionTemplate, TemplatePart};
+use mutable_batch::{writer::Writer, MutableBatch, PartitionWrite, WritePayload};
 use mutable_batch_pb::{decode::write_table_batch, encode::encode_batch};
 use schema::selection::Selection;
 
@@ -34,5 +35,143 @@ fn test_encode_decode() {
     let mut batch = MutableBatch::new();
     write_table_batch(&mut batch, &encoded).unwrap();
 
+    assert_batches_eq!(expected, &[batch.to_arrow(Selection::All).unwrap()]);
+}
+
+// This test asserts columns containing no values do not prevent an encoded
+// batch from being deserialised:
+//
+//  https://github.com/influxdata/influxdb_iox/issues/4272
+//
+// The test constructs a table such that after partitioning, one entire column
+// is NULL within a partition. In this test case, the following table is
+// partitioned by YMD:
+//
+//
+//    | time       | A    | B    |
+//    | ---------- | ---- | ---- |
+//    | 1970-01-01 | 1    | NULL |
+//    | 1970-07-05 | NULL | 1    |
+//
+// Yielding two partitions:
+//
+//    | time       | A    | B    |
+//    | ---------- | ---- | ---- |
+//    | 1970-01-01 | 1    | NULL |
+//
+// and:
+//
+//    | time       | A    | B    |
+//    | ---------- | ---- | ---- |
+//    | 1970-07-05 | NULL | 1    |
+//
+// In both partitions, one column is composed entirely of NULL values.
+//
+// Encoding each of these partitions succeeds, but decoding the partition fails
+// due to the inability to infer a column type from the serialised format which
+// contains no values:
+//
+// ```
+//  Column {
+//      column_name: "B",
+//      semantic_type: Field,
+//      values: Some(
+//          Values {
+//              i64_values: [],
+//              f64_values: [],
+//              u64_values: [],
+//              string_values: [],
+//              bool_values: [],
+//              bytes_values: [],
+//              packed_string_values: None,
+//              interned_string_values: None,
+//          },
+//      ),
+//      null_mask: [
+//          1,
+//      ],
+//  },
+// ```
+//
+// In a column that is not entirely NULL, one of the "Values" fields would be
+// non-empty, and the decoder would use this to infer the type of the column.
+//
+// Because we have chosen to not differentiate between "NULL" and "empty" in our
+// proto encoding, the decoder cannot infer which field within the "Values"
+// struct the column belongs to - all are valid, but empty. This causes
+// [`Error::EmptyColumn`] to be returned during deserialisation.
+//
+// This is fixed by skipping entirely-null columns when encoding the batch.
+#[test]
+fn test_encode_decode_null_columns_issue_4272() {
+    let mut batch = MutableBatch::new();
+    let mut writer = Writer::new(&mut batch, 2);
+
+    writer
+        // Yielding partition keys: ["1970-01-01", "1970-07-05"]
+        .write_time("time", [160, 16007561568756160].into_iter())
+        .unwrap();
+    writer
+        .write_i64("A", Some(&[0b00000001]), [1].into_iter())
+        .unwrap();
+    writer
+        .write_i64("B", Some(&[0b00000010]), [1].into_iter())
+        .unwrap();
+    writer.commit();
+
+    let mut partitions = PartitionWrite::partition(
+        "test",
+        &batch,
+        &PartitionTemplate {
+            parts: vec![TemplatePart::TimeFormat("%Y-%m-%d".to_owned())],
+        },
+    );
+
+    // There should be two partitions, one with for the timestamp 160, and
+    // one for the other timestamp.
+    assert_eq!(partitions.len(), 2);
+
+    // Round-trip the "1970-01-01" partition
+    let mut got = MutableBatch::default();
+    partitions
+        .remove("1970-01-01")
+        .expect("partition not found")
+        .write_to_batch(&mut got)
+        .expect("should write");
+
+    let encoded = encode_batch("bananas", &got);
+    let mut batch = MutableBatch::new();
+    // Without the fix for #4272 this deserialisation call would fail.
+    write_table_batch(&mut batch, &encoded).unwrap();
+
+    let expected = &[
+        "+---+--------------------------------+",
+        "| A | time                           |",
+        "+---+--------------------------------+",
+        "| 1 | 1970-01-01T00:00:00.000000160Z |",
+        "+---+--------------------------------+",
+    ];
+    assert_batches_eq!(expected, &[batch.to_arrow(Selection::All).unwrap()]);
+
+    // And finally assert the "1970-07-05" round-trip
+    let mut got = MutableBatch::default();
+    partitions
+        .remove("1970-07-05")
+        .expect("partition not found")
+        .write_to_batch(&mut got)
+        .expect("should write");
+
+    let encoded = encode_batch("bananas", &got);
+    let mut batch = MutableBatch::new();
+    // Without the fix for #4272 this deserialisation call would fail.
+    write_table_batch(&mut batch, &encoded).unwrap();
+
+    let expected = &[
+        "+---+--------------------------------+",
+        "| B | time                           |",
+        "+---+--------------------------------+",
+        "| 1 | 1970-07-05T06:32:41.568756160Z |",
+        "+---+--------------------------------+",
+    ];
     assert_batches_eq!(expected, &[batch.to_arrow(Selection::All).unwrap()]);
 }


### PR DESCRIPTION
As mentioned in slack, this is a "quick fix" for #4272.

The commit message explains the problem and implemented fix, but there are a few notable points:

1. The proto wire format allows a column to contain values of many types at the same time, as it is [expressed as a record/struct][proto] of all available types, rather than an enumeration which would constrain the wire format to match the semantics of the system internals - a record batch column can have only one type, but our wire protocol column can have many types.

2. Because we do not differentiate between NULL and "empty"/"zero value" in the proto messages, the current message is ambiguous - I don't think conflating zero values with NULL is the right strategy, and explicit NULLs would have prevented this bug. Fundamentally 0 != NULL when processing data.

3. Partitioning can yield a record batch that contains a column composed entirely of NULLs - should this column even exist in the resulting partitioned record batch? The overhead of keeping it around is low (effectively just a bitmap of N rows and some fixed, low cost memory overhead) but semantically it seems incorrect: if the original LP input was sent line-by-line, the NULL column would never have been created in the partition - it's an artefact born from the interaction of batching+partitioning.

## Suggestions / discussion points:

1. Make a breaking change to the wire encoding by swapping the `Column` [`Values`][proto] type to use [`Oneof`][oneof]. 

This would cause our wire proto to match the semantics of record batches - a column can have only one type, and it is specified even if no values are serialised.

We can probably do this gracefully by encoding the "message codec version" as a header in the kafka message, where the new version sends something like `version=2`, and defaulting to the current codec if the header is not specified during changeover. Or we can do a hard cutover which would be less faff.

2. Don't allow the partitioner to construct partitions composed of entirely NULL columns.

If the user sent two LP lines as a single batch:

```
cpu A=1 <day 1 timestmap>
cpu B=2 <day 2 timestamp>
```

This leads to the partitioned batch containing A also having an entirely NULL column B, and vice-versa, but if the lines were sent one-at-a-time, the "ghost column" B would never have been created. This seems semantically incorrect, but this is a more in-depth change to the partitioner / writer. It also means encoding/decoding to the wire protocol is lossy/not round-trippable, which can be a further source of confusion and inconsistencies, and makes me uncomfortable!  

I'm happy to take this up if it's what we decide, but it would be a low priority in my backlog of work.

Fixes #4272.

[proto]:https://github.com/influxdata/influxdb_iox/blob/1dc6d6deda83ee0583f90682ed1732bdbc8a5efa/generated_types/protos/influxdata/pbdata/v1/influxdb_pb_data_protocol.proto#L79-L88
[oneof]: https://developers.google.com/protocol-buffers/docs/proto3#oneof

---

* feat: is all set/unset BitSet query methods (f5753d7ea)

      Adds is_all_set() and is_all_unset() methods to the BitSet, to query the state
      of all bits in the bitmap.

* fix(pb): encoding entirely NULL columns (#4272) (1dc6d6ded)

      This commit changes the protobuf record batch encoding to skip entirely NULL
      columns when serialising. This prevents the deserialisation from erroring due
      to a column type inference failure.

      Prior to this commit, when the system was presented a record batch such as
      this:

                 | time       | A    | B    |
                 | ---------- | ---- | ---- |
                 | 1970-01-01 | 1    | NULL |
                 | 1970-07-05 | NULL | 1    |

      Which would be partitioned by YMD into two separate partitions:

                 | time       | A    | B    |
                 | ---------- | ---- | ---- |
                 | 1970-01-01 | 1    | NULL |

      and:

                 | time       | A    | B    |
                 | ---------- | ---- | ---- |
                 | 1970-07-05 | NULL | 1    |

      Both partitions would contain an entirely NULL column.

      Both of these partitioned record batches would be successfully encoded, but
      decoding the partition fails due to the inability to infer a column type from
      the serialised format which contains no values, which on the wire, looks like:

                 Column {
                     column_name: "B",
                     semantic_type: Field,
                     values: Some(
                         Values {
                             i64_values: [],
                             f64_values: [],
                             u64_values: [],
                             string_values: [],
                             bool_values: [],
                             bytes_values: [],
                             packed_string_values: None,
                             interned_string_values: None,
                         },
                     ),
                     null_mask: [
                         1,
                     ],
                 },

      In a column that is not entirely NULL, one of the "Values" fields would be
      non-empty, and the decoder would use this to infer the type of the column.

      Because we have chosen to not differentiate between "NULL" and "empty" in our
      proto encoding, the decoder cannot infer which field within the
      "Values" struct the column belongs to - all are valid, but empty.

      This commit prevents this type inference failure by skipping any columns that
      are entirely NULL during serialisation, preventing the deserialiser from
      having to process columns with ambiguous types.