### PR TITLE
feat: streaming compaction

### DIFF
--- a/compactor/src/utils.rs
+++ b/compactor/src/utils.rs
@@ -1,10 +1,10 @@
 //! Helpers of the Compactor
 
 use crate::query::QueryableParquetChunk;
-use arrow::record_batch::RecordBatch;
 use data_types::{
     ParquetFileId, ParquetFileParams, ParquetFileWithMetadata, Timestamp, Tombstone, TombstoneId,
 };
+use datafusion::physical_plan::SendableRecordBatchStream;
 use observability_deps::tracing::*;
 use parquet_file::{
     chunk::{ChunkMetrics, DecodedParquetFile, ParquetChunk},
@@ -133,7 +133,7 @@ impl ParquetFileWithTombstone {
 
 /// Struct holding output of a compacted stream
 pub struct CompactedData {
-    pub(crate) data: Vec<RecordBatch>,
+    pub(crate) data: SendableRecordBatchStream,
     pub(crate) meta: IoxMetadata,
     pub(crate) tombstones: BTreeMap<TombstoneId, Tombstone>,
 }
@@ -141,7 +141,7 @@ pub struct CompactedData {
 impl CompactedData {
     /// Initialize compacted data
     pub fn new(
-        data: Vec<RecordBatch>,
+        data: SendableRecordBatchStream,
         meta: IoxMetadata,
         tombstones: BTreeMap<TombstoneId, Tombstone>,
     ) -> Self {


### PR DESCRIPTION
This PR changes our compaction process to eliminate any in-memory buffering of resultant `RecordBatch` instances, instead directly streaming the compaction plan execution into a temporary Parquet file on disk before uploading to object storage.

Closes #4324.

---

* refactor: retry object store upload (6aa626ef8)

      Changes the Storage::upload() method to endlessly retry uploading the 
      generated Parquet file.

* feat: steaming compaction (8f05250c9)

      This commit changes the Compactor::compact() method to stream the RecordBatch
      instances directly to the parquet serialiser, before being uploaded directly
      to object storage.

* refactor: concurrent StreamSplitExec execution (c885b845d)

      Changes the compactor to consume both StreamSplitExec output partitions 
      concurrently.

      Practically speaking this means both Parquet files will be generated 
      concurrently, and uploaded to object store concurrently.

* revert: fix: compaction deadlock (8ff1a7379)

      This reverts commit 00b5c1b296fb7b6dbabd28744721e56b05061d0c.

      This change reverts the StreamSplitExec plan to using bounded, blocking 
      channels, with the possibility of deadlock added to the docs.

      This is now tolerable because of the concurrent consumption of both output
      partitions in the compactor.