### PR TITLE
test: add end to end test for deletes via `/api/v2/delete`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5324,6 +5324,8 @@ dependencies = [
  "prost",
  "rand",
  "reqwest",
+ "serde",
+ "serde_json",
  "sqlx",
  "tempfile",
  "test_helpers",

--- a/ingester/src/data.rs
+++ b/ingester/src/data.rs
@@ -840,6 +840,11 @@ impl TableData {
         let min_time = Timestamp::new(predicate.range.start());
         let max_time = Timestamp::new(predicate.range.end());
 
+        debug!(%table_name,
+               sequence_number=%sequence_number.get(),
+               ?predicate,
+               "buffering table delete");
+
         let mut repos = catalog.repositories().await;
         let tombstone = repos
             .tombstones()

--- a/test_helpers_end_to_end/Cargo.toml
+++ b/test_helpers_end_to_end/Cargo.toml
@@ -21,6 +21,8 @@ parking_lot = "0.12"
 prost = "0.10"
 rand = "0.8.3"
 reqwest = { version = "0.11", default-features = false, features = ["json", "rustls-tls"] }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0.81"
 sqlx = { version = "0.5", features = [ "runtime-tokio-rustls" , "postgres", "uuid" ] }
 tempfile = "3.1.0"
 test_helpers = { path = "../test_helpers", features = ["future_timeout"] }

--- a/test_helpers_end_to_end/src/mini_cluster.rs
+++ b/test_helpers_end_to_end/src/mini_cluster.rs
@@ -1,5 +1,6 @@
 use crate::{
-    rand_id, write_to_router, write_to_router_grpc, ServerFixture, TestConfig, TestServer,
+    delete_to_router, rand_id, write_to_router, write_to_router_grpc, ServerFixture, TestConfig,
+    TestServer,
 };
 use futures::{stream::FuturesOrdered, StreamExt};
 use http::Response;
@@ -249,6 +250,24 @@ impl MiniCluster {
             table_batches,
             &self.namespace,
             self.router().router_grpc_connection(),
+        )
+        .await
+    }
+
+    /// Sends the delete to the router
+    pub async fn delete_to_router(
+        &self,
+        predicate: impl Into<String>,
+        start: u64,
+        stop: u64,
+    ) -> Response<Body> {
+        delete_to_router(
+            predicate,
+            start,
+            stop,
+            &self.org_id,
+            &self.bucket_id,
+            self.router().router_http_base(),
         )
         .await
     }


### PR DESCRIPTION
# Rationale
Draft as the test is failing now (I think there is a bug in the code)

Closes https://github.com/influxdata/influxdb_iox/issues/4691 by adding a basic end to end test of the delete endpoint

# Changes
1. end to end test to ensure deletes are wired up correctly through the router, ingester and querier. 

