### PR TITLE
refactor: warn for silly object store configs

### DIFF
--- a/influxdb_iox/tests/end_to_end_cases/cli.rs
+++ b/influxdb_iox/tests/end_to_end_cases/cli.rs
@@ -119,6 +119,8 @@ async fn remote_partition_and_get_from_store_and_pull() {
                                 .and(predicate::str::contains(filename)),
                         );
 
+                    // Ensure a warning is emitted when specifying (or
+                    // defaulting to) in-memory file storage.
                     Command::cargo_bin("influxdb_iox")
                         .unwrap()
                         .arg("-h")
@@ -134,6 +136,8 @@ async fn remote_partition_and_get_from_store_and_pull() {
                         .arg("my_awesome_table")
                         .arg("1970-01-01")
                         .assert()
+                        .failure()
+                        .stderr(predicate::str::contains("try passing --object-store=file"));
                         .success()
                         .stdout(
                             predicate::str::contains("wrote file")

--- a/influxdb_iox/tests/end_to_end_cases/cli.rs
+++ b/influxdb_iox/tests/end_to_end_cases/cli.rs
@@ -138,6 +138,27 @@ async fn remote_partition_and_get_from_store_and_pull() {
                         .assert()
                         .failure()
                         .stderr(predicate::str::contains("try passing --object-store=file"));
+
+                    // Ensure files are actually wrote to the filesystem
+                    let dir = tempfile::tempdir().expect("could not get temporary directory");
+
+                    Command::cargo_bin("influxdb_iox")
+                        .unwrap()
+                        .arg("-h")
+                        .arg(&router_addr)
+                        .arg("remote")
+                        .arg("partition")
+                        .arg("pull")
+                        .arg("--catalog")
+                        .arg("memory")
+                        .arg("--object-store")
+                        .arg("file")
+                        .arg("--data-dir")
+                        .arg(dir.path().to_str().unwrap())
+                        .arg(&namespace)
+                        .arg("my_awesome_table")
+                        .arg("1970-01-01")
+                        .assert()
                         .success()
                         .stdout(
                             predicate::str::contains("wrote file")


### PR DESCRIPTION
I'll let you guess why I am proposing this change.

---

* refactor: warn for silly object store configs (0e5c86fd8)

      Warn when downloading files to an in-memory object store.

      The "remote partition pull" command downloads parquet files from an object
      store via a router, and saves them locally. It's pretty unlikely the user
      intends to download those files to memory of the CLI process which then exits
      when the pull is complete, throwing away the downloaded files, but this is the
      default.

* test(e2e): ensure "partition pull" writes files (1fc95ba72)

      Adds a test case covering the "remote partition pull" command configured with
      file-based object storage.

