### PR TITLE
feat: Start of a read buffer chunk cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3948,6 +3948,7 @@ dependencies = [
  "pin-project",
  "predicate",
  "rand",
+ "read_buffer",
  "schema",
  "service_common",
  "service_grpc_schema",

--- a/compactor/src/compact.rs
+++ b/compactor/src/compact.rs
@@ -1218,11 +1218,11 @@ mod tests {
         let files1 = files.pop().unwrap();
         let files0 = files.pop().unwrap();
         let chunk_0 = adapter
-            .new_querier_chunk_from_file_with_metadata(files0)
+            .new_querier_parquet_chunk_from_file_with_metadata(files0)
             .await
             .unwrap();
         let chunk_1 = adapter
-            .new_querier_chunk_from_file_with_metadata(files1)
+            .new_querier_parquet_chunk_from_file_with_metadata(files1)
             .await
             .unwrap();
         // query the chunks
@@ -1439,11 +1439,11 @@ mod tests {
         let files2 = files.pop().unwrap();
         let files1 = files.pop().unwrap();
         let chunk_0 = adapter
-            .new_querier_chunk_from_file_with_metadata(files1)
+            .new_querier_parquet_chunk_from_file_with_metadata(files1)
             .await
             .unwrap();
         let chunk_1 = adapter
-            .new_querier_chunk_from_file_with_metadata(files2)
+            .new_querier_parquet_chunk_from_file_with_metadata(files2)
             .await
             .unwrap();
         // query the chunks

--- a/querier/Cargo.toml
+++ b/querier/Cargo.toml
@@ -25,6 +25,7 @@ pin-project = "1.0"
 predicate = { path = "../predicate" }
 iox_query = { path = "../iox_query" }
 rand = "0.8.3"
+read_buffer = { path = "../read_buffer" }
 service_common = { path = "../service_common" }
 service_grpc_schema = { path = "../service_grpc_schema" }
 schema = { path = "../schema" }

--- a/querier/src/cache/mod.rs
+++ b/querier/src/cache/mod.rs
@@ -15,6 +15,7 @@ pub mod parquet_file;
 pub mod partition;
 pub mod processed_tombstones;
 mod ram;
+pub mod read_buffer;
 pub mod table;
 pub mod tombstones;
 

--- a/querier/src/cache/read_buffer.rs
+++ b/querier/src/cache/read_buffer.rs
@@ -1,0 +1,93 @@
+//! Cache Parquet file data in Read Buffer chunks.
+
+use super::ram::RamSize;
+use cache_system::{
+    backend::{
+        lru::{LruBackend, ResourcePool},
+        resource_consumption::FunctionEstimator,
+        shared::SharedBackend,
+    },
+    driver::Cache,
+    loader::{metrics::MetricsLoader, FunctionLoader},
+};
+use data_types::ParquetFileId;
+use iox_time::TimeProvider;
+use read_buffer::RBChunk;
+use std::{collections::HashMap, mem, sync::Arc};
+
+const CACHE_ID: &str = "read_buffer";
+
+/// Cache for parquet file data decoded into read buffer chunks
+#[derive(Debug)]
+pub struct ReadBufferCache {
+    _cache: Cache<ParquetFileId, Arc<RBChunk>>,
+
+    /// Handle that allows clearing entries for existing cache entries
+    _backend: SharedBackend<ParquetFileId, Arc<RBChunk>>,
+}
+
+impl ReadBufferCache {
+    /// Create a new empty cache.
+    pub fn new(
+        time_provider: Arc<dyn TimeProvider>,
+        metric_registry: &metric::Registry,
+        ram_pool: Arc<ResourcePool<RamSize>>,
+    ) -> Self {
+        let loader = Box::new(FunctionLoader::new(
+            move |_parquet_file_id: ParquetFileId| async move {
+                unimplemented!();
+            },
+        ));
+
+        let loader = Arc::new(MetricsLoader::new(
+            loader,
+            CACHE_ID,
+            Arc::clone(&time_provider),
+            metric_registry,
+        ));
+
+        // add to memory pool
+        let backend = Box::new(LruBackend::new(
+            Box::new(HashMap::new()),
+            Arc::clone(&ram_pool),
+            CACHE_ID,
+            Arc::new(FunctionEstimator::new(
+                |k: &ParquetFileId, v: &Arc<RBChunk>| {
+                    RamSize(mem::size_of_val(k) + mem::size_of_val(v) + v.size())
+                },
+            )),
+        ));
+
+        // get a direct handle so we can clear out entries as needed
+        let _backend = SharedBackend::new(backend);
+
+        let _cache = Cache::new(loader, Box::new(_backend.clone()));
+
+        Self { _cache, _backend }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cache::ram::test_util::test_ram_pool;
+    use iox_tests::util::TestCatalog;
+
+    fn make_cache(catalog: &TestCatalog) -> ReadBufferCache {
+        ReadBufferCache::new(
+            catalog.time_provider(),
+            &catalog.metric_registry(),
+            test_ram_pool(),
+        )
+    }
+
+    async fn make_catalog() -> Arc<TestCatalog> {
+        TestCatalog::new()
+    }
+
+    #[tokio::test]
+    async fn test_rb_chunks() {
+        let catalog = make_catalog().await;
+        let _cache = make_cache(&catalog);
+    }
+}

--- a/querier/src/cache/read_buffer.rs
+++ b/querier/src/cache/read_buffer.rs
@@ -20,7 +20,7 @@ const CACHE_ID: &str = "read_buffer";
 /// Cache for parquet file data decoded into read buffer chunks
 #[derive(Debug)]
 pub struct ReadBufferCache {
-    _cache: Cache<ParquetFileId, Arc<RBChunk>>,
+    cache: Cache<ParquetFileId, Arc<RBChunk>>,
 
     /// Handle that allows clearing entries for existing cache entries
     _backend: SharedBackend<ParquetFileId, Arc<RBChunk>>,
@@ -61,9 +61,14 @@ impl ReadBufferCache {
         // get a direct handle so we can clear out entries as needed
         let _backend = SharedBackend::new(backend);
 
-        let _cache = Cache::new(loader, Box::new(_backend.clone()));
+        let cache = Cache::new(loader, Box::new(_backend.clone()));
 
-        Self { _cache, _backend }
+        Self { cache, _backend }
+    }
+
+    /// Get read buffer chunks by Parquet file id
+    pub async fn get(&self, parquet_file_id: ParquetFileId) -> Arc<RBChunk> {
+        self.cache.get(parquet_file_id).await
     }
 }
 

--- a/querier/src/chunk/mod.rs
+++ b/querier/src/chunk/mod.rs
@@ -94,9 +94,10 @@ pub enum ChunkStorage {
 
 /// Chunk representation for the querier.
 ///
-/// These chunks are usually created on-demand. The querier cache system does not really have a notion of chunks (rather
-/// it knows about parquet files, local FS caches, ingester data, cached read buffers) but we need to combine all that
-/// knowledge into chunk objects because this is what the query engine (DataFusion and InfluxRPC) expect.
+/// These chunks are usually created on-demand. The querier cache system does not really have a
+/// notion of chunks (rather it knows about parquet files, local FS caches, ingester data, cached
+/// read buffers) but we need to combine all that knowledge into chunk objects because this is what
+/// the query engine (DataFusion and InfluxRPC) expect.
 #[derive(Debug)]
 pub struct QuerierChunk {
     /// How the data is currently structured / available for query.

--- a/querier/src/chunk/mod.rs
+++ b/querier/src/chunk/mod.rs
@@ -106,7 +106,7 @@ pub struct QuerierParquetChunk {
 
 impl QuerierParquetChunk {
     /// Create new parquet-backed chunk (object store data).
-    pub fn new_parquet(
+    pub fn new(
         parquet_file_id: ParquetFileId,
         parquet_chunk: Arc<ParquetChunk>,
         meta: Arc<ChunkMeta>,
@@ -269,7 +269,7 @@ impl ParquetChunkAdapter {
             max_sequence_number: parquet_file.max_sequence_number,
         });
 
-        Some(QuerierParquetChunk::new_parquet(
+        Some(QuerierParquetChunk::new(
             parquet_file.id,
             chunk,
             meta,

--- a/querier/src/chunk/mod.rs
+++ b/querier/src/chunk/mod.rs
@@ -217,21 +217,21 @@ impl ParquetChunkAdapter {
         ))
     }
 
-    /// Create new querier chunk from a catalog record
+    /// Create new querier Parquet chunk from a catalog record
     ///
     /// Returns `None` if some data required to create this chunk is already gone from the catalog.
-    pub async fn new_querier_chunk_from_file_with_metadata(
+    pub async fn new_querier_parquet_chunk_from_file_with_metadata(
         &self,
         parquet_file_with_metadata: ParquetFileWithMetadata,
     ) -> Option<QuerierParquetChunk> {
         let decoded_parquet_file = DecodedParquetFile::new(parquet_file_with_metadata);
-        self.new_querier_chunk(&decoded_parquet_file).await
+        self.new_querier_parquet_chunk(&decoded_parquet_file).await
     }
 
-    /// Create new querier chunk.
+    /// Create new querier Parquet chunk.
     ///
     /// Returns `None` if some data required to create this chunk is already gone from the catalog.
-    pub async fn new_querier_chunk(
+    pub async fn new_querier_parquet_chunk(
         &self,
         decoded_parquet_file: &DecodedParquetFile,
     ) -> Option<QuerierParquetChunk> {
@@ -339,7 +339,7 @@ pub mod tests {
 
         // create chunk
         let chunk = adapter
-            .new_querier_chunk(&DecodedParquetFile::new(parquet_file))
+            .new_querier_parquet_chunk(&DecodedParquetFile::new(parquet_file))
             .await
             .unwrap();
 

--- a/querier/src/chunk/query_access.rs
+++ b/querier/src/chunk/query_access.rs
@@ -1,4 +1,4 @@
-use crate::chunk::{ChunkStorage, QuerierChunk};
+use crate::chunk::{ChunkStorage, QuerierParquetChunk};
 use data_types::{
     ChunkId, ChunkOrder, DeletePredicate, PartitionId, TableSummary, TimestampMinMax,
 };
@@ -18,7 +18,7 @@ pub enum Error {
     },
 }
 
-impl QueryChunkMeta for QuerierChunk {
+impl QueryChunkMeta for QuerierParquetChunk {
     fn summary(&self) -> Option<&TableSummary> {
         match &self.storage {
             ChunkStorage::Parquet { chunk, .. } => Some(chunk.table_summary().as_ref()),
@@ -52,7 +52,7 @@ impl QueryChunkMeta for QuerierChunk {
     }
 }
 
-impl QueryChunk for QuerierChunk {
+impl QueryChunk for QuerierParquetChunk {
     fn id(&self) -> ChunkId {
         self.meta().chunk_id
     }

--- a/querier/src/table/state_reconciler.rs
+++ b/querier/src/table/state_reconciler.rs
@@ -24,7 +24,7 @@ use std::{
 };
 
 use crate::{
-    chunk::{ParquetChunkAdapter, QuerierChunk},
+    chunk::{ParquetChunkAdapter, QuerierParquetChunk},
     tombstone::QuerierTombstone,
     IngesterPartition,
 };
@@ -115,7 +115,7 @@ impl Reconciler {
             "Parquet files after filtering"
         );
 
-        // convert parquet files and tombstones into QuerierChunks
+        // convert parquet files and tombstones into QuerierParquetChunks
         let mut parquet_chunks = Vec::with_capacity(parquet_files.len());
         for parquet_file_with_metadata in parquet_files {
             if let Some(chunk) = self
@@ -282,7 +282,7 @@ trait UpdatableQuerierChunk: QueryChunk {
     fn upcast_to_querier_chunk(self: Box<Self>) -> Box<dyn QueryChunk>;
 }
 
-impl UpdatableQuerierChunk for QuerierChunk {
+impl UpdatableQuerierChunk for QuerierParquetChunk {
     fn update_partition_sort_key(
         self: Box<Self>,
         sort_key: Arc<Option<SortKey>>,

--- a/querier/src/table/state_reconciler.rs
+++ b/querier/src/table/state_reconciler.rs
@@ -120,7 +120,7 @@ impl Reconciler {
         for parquet_file_with_metadata in parquet_files {
             if let Some(chunk) = self
                 .chunk_adapter
-                .new_querier_chunk_from_file_with_metadata(parquet_file_with_metadata)
+                .new_querier_parquet_chunk_from_file_with_metadata(parquet_file_with_metadata)
                 .await
             {
                 parquet_chunks.push(chunk);

--- a/querier/src/table/state_reconciler.rs
+++ b/querier/src/table/state_reconciler.rs
@@ -174,12 +174,7 @@ impl Reconciler {
                         .chunk_adapter
                         .catalog_cache()
                         .processed_tombstones()
-                        .exists(
-                            chunk
-                                .parquet_file_id()
-                                .expect("just created from a parquet file"),
-                            tombstone.tombstone_id(),
-                        )
+                        .exists(chunk.parquet_file_id(), tombstone.tombstone_id())
                         .await
                     {
                         continue;


### PR DESCRIPTION
Connects to #4681.

This is a new querier cache that eventually will cache Read Buffer chunks created from Parquet files as they're requested.

The new querier cache isn't called anywhere yet, and it doesn't work completely: I have a bunch of functions sketched out that show the steps I'm planning on taking, but all except the last one in the sequence are `unimplemented!` in this PR.

However, because this isn't called anywhere yet, this can be safely merged in and iterated on!