### PR TITLE
feat: Cache read buffer chunks

### DIFF
--- a/parquet_file/src/chunk.rs
+++ b/parquet_file/src/chunk.rs
@@ -6,11 +6,12 @@ use crate::{
     storage::ParquetStorage,
 };
 use data_types::{
-    ParquetFile, ParquetFileWithMetadata, TableSummary, TimestampMinMax, TimestampRange,
+    ParquetFile, ParquetFileId, ParquetFileWithMetadata, PartitionId, SequenceNumber, SequencerId,
+    TableId, TableSummary, TimestampMinMax, TimestampRange,
 };
 use datafusion::physical_plan::SendableRecordBatchStream;
 use predicate::Predicate;
-use schema::{selection::Selection, Schema};
+use schema::{selection::Selection, sort::SortKey, Schema};
 use std::{collections::BTreeSet, mem, sync::Arc};
 
 #[derive(Debug)]
@@ -212,6 +213,46 @@ impl DecodedParquetFile {
             decoded_metadata,
             iox_metadata,
         }
+    }
+
+    /// The IOx schema from the decoded IOx parquet metadata
+    pub fn schema(&self) -> Arc<Schema> {
+        self.decoded_metadata.read_schema().unwrap()
+    }
+
+    /// The IOx parquet file ID
+    pub fn parquet_file_id(&self) -> ParquetFileId {
+        self.parquet_file.id
+    }
+
+    /// The IOx partition ID
+    pub fn partition_id(&self) -> PartitionId {
+        self.parquet_file.partition_id
+    }
+
+    /// The IOx sequencer ID
+    pub fn sequencer_id(&self) -> SequencerId {
+        self.iox_metadata.sequencer_id
+    }
+
+    /// The IOx table ID
+    pub fn table_id(&self) -> TableId {
+        self.parquet_file.table_id
+    }
+
+    /// The sort key from the IOx metadata
+    pub fn sort_key(&self) -> Option<&SortKey> {
+        self.iox_metadata.sort_key.as_ref()
+    }
+
+    /// The minimum sequence number in this file
+    pub fn min_sequence_number(&self) -> SequenceNumber {
+        self.parquet_file.min_sequence_number
+    }
+
+    /// The maximum sequence number in this file
+    pub fn max_sequence_number(&self) -> SequenceNumber {
+        self.parquet_file.max_sequence_number
     }
 
     /// Estimate the memory consumption of this object and its contents

--- a/parquet_file/src/storage.rs
+++ b/parquet_file/src/storage.rs
@@ -207,6 +207,15 @@ impl ParquetStorage {
             Some(Arc::new(AutoAbortJoinHandle::new(handle))),
         ))
     }
+
+    /// Read all data from the parquet file.
+    pub fn read_all(
+        &self,
+        schema: SchemaRef,
+        meta: &IoxMetadata,
+    ) -> Result<SendableRecordBatchStream, ReadError> {
+        self.read_filter(&Predicate::default(), Selection::All, schema, meta)
+    }
 }
 
 /// Return indices of the schema's fields of the selection columns

--- a/querier/src/cache/read_buffer.rs
+++ b/querier/src/cache/read_buffer.rs
@@ -41,13 +41,14 @@ pub struct ReadBufferCache {
 impl ReadBufferCache {
     /// Create a new empty cache.
     pub fn new(
+        backoff_config: BackoffConfig,
         time_provider: Arc<dyn TimeProvider>,
         metric_registry: &metric::Registry,
         ram_pool: Arc<ResourcePool<RamSize>>,
     ) -> Self {
         let loader = Box::new(FunctionLoader::new(
             move |_parquet_file_id, extra_fetch_info: ExtraFetchInfo| {
-                let backoff_config = BackoffConfig::default();
+                let backoff_config = backoff_config.clone();
 
                 async move {
                     let rb_chunk = Backoff::new(&backoff_config)
@@ -199,6 +200,7 @@ mod tests {
 
     fn make_cache(catalog: &TestCatalog) -> ReadBufferCache {
         ReadBufferCache::new(
+            BackoffConfig::default(),
             catalog.time_provider(),
             &catalog.metric_registry(),
             test_ram_pool(),
@@ -300,6 +302,7 @@ mod tests {
             Arc::clone(&catalog.metric_registry()),
         ));
         let cache = ReadBufferCache::new(
+            BackoffConfig::default(),
             catalog.time_provider(),
             &catalog.metric_registry(),
             ram_pool,

--- a/querier/src/chunk/mod.rs
+++ b/querier/src/chunk/mod.rs
@@ -257,7 +257,10 @@ pub struct ChunkAdapter {
     /// Cache
     catalog_cache: Arc<CatalogCache>,
 
-    /// Object store. Wrapper around an Arc; cheap to clone.
+    /// Object store.
+    ///
+    /// Internally, `ParquetStorage` wraps the actual store implementation in an `Arc`, so
+    /// `ParquetStorage` is cheap to clone.
     store: ParquetStorage,
 
     /// Metric registry.


### PR DESCRIPTION
Connects to #4681. 

This adds a new type parameter to the cache loader so that, if we need to load the chunk from the parquet file, we can use the other information we already have about that parquet file rather than needing to look it up in the catalog again.

The cache still stores the chunk by parquet file ID.

This still isn't actually hooked up yet as there's only the most rudimentary tests. ~~Namely, I haven't verified the LRU behavior at all.~~