### PR TITLE
docs: Remove outdated references to the old MUB -> RUB -> OS chunk cycle

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -6,7 +6,7 @@ Here are useful metrics
 
 ### Requests to IOx Server including Routers and Query Servers
 | Metric name |  Code Name | Description |
-| --- | --- | --- | 
+| --- | --- | --- |
 | http_requests_total | http_requests | Total number of HTTP requests |
 | gRPC_requests_total | requests | Total number of gROC requests |
 | http_request_duration_seconds| ? | Time to finish a request  |
@@ -17,7 +17,7 @@ Here are useful metrics
 ### Line Protocol Data ingested into Routers
 
 | Metric name |  Code Name | Description |
-| --- | --- | --- | 
+| --- | --- | --- |
 | ingest_points_total | ingest_lines_total | Total number of lines ingested |
 | ingest_fields_total | ingest_fields_total | Total number of fields (columns) ingested |
 | ingest_points_bytes_total | ingest_points_bytes_total | Total number of bytes ingested |
@@ -26,9 +26,9 @@ Here are useful metrics
 ### Chunks
 | Metric name |  Code Name | Description |
 | --- | --- | --- |
-| catalog_chunks_mem_usage_bytes | memory_metrics | Total memory usage by chunks (MUB, RUB, OS statistics) |
-| catalog_loaded_chunks | chunk_storage | Total number of chunks (MUB, RUB, RUBandOS) for each table |
-| catalog_loaded_rows | row_count | Total number of rows (MUB, RUB, RUBandOS) for each table |
+| catalog_chunks_mem_usage_bytes | memory_metrics | Total memory usage by chunks |
+| catalog_loaded_chunks | chunk_storage | Total number of chunks for each table |
+| catalog_loaded_rows | row_count | Total number of rows for each table |
 | catalog_lock_total | ? | ? |
 | catalog_lock_wait_seconds_total | ? | ? |
 | ? | partition_lock_tracker | ? |
@@ -55,7 +55,7 @@ Here are useful metrics
 | Metric name |  Code Name | Description |
 | --- | --- | --- |
 | write_buffer_ingest_requests_total | red | Total number of write requests |
-| write_buffer_read_bytes_total | bytes_read | Total number of write requested bytes | 
+| write_buffer_read_bytes_total | bytes_read | Total number of write requested bytes |
 | write_buffer_last_sequence_number | last_sequence_number | sequence number of last write request |
 | write_buffer_sequence_number_lag  |  sequence_number_lag | The difference between the the last sequence number available (e.g. Kafka offset) and (= minus) last consumed sequence number |
 | write_buffer_last_min_ts | last_min_ts | Minimum timestamp of last write as unix timestamp in nanoseconds |

--- a/iox_query/src/lib.rs
+++ b/iox_query/src/lib.rs
@@ -241,7 +241,7 @@ pub trait QueryChunk: QueryChunkMeta + Debug + Send + Sync + 'static {
         selection: Selection<'_>,
     ) -> Result<SendableRecordBatchStream, QueryChunkError>;
 
-    /// Returns chunk type which is either MUB, RUB, OS
+    /// Returns chunk type. Useful in tests and debug logs.
     fn chunk_type(&self) -> &str;
 
     /// Order of this chunk relative to other overlapping chunks.

--- a/iox_query/src/provider.rs
+++ b/iox_query/src/provider.rs
@@ -932,17 +932,19 @@ impl Deduplicater {
     /// Return a sort plan for for a given chunk
     /// This plan is applied for every chunk to read data from chunk
     /// The plan will look like this. Reading bottom up:
-    ///   1. First we scan the data in IOxReadFilterNode which represents
-    ///        a custom implemented scan of MUB, RUB, OS. Both Select Predicate of
-    ///        the query and Delete Predicates of the chunk is pushed down
-    ///        here to eliminate as much data as early as possible but it is not guaranteed
-    ///        all filters are applied because only certain expressions work
-    ///        at this low chunk scan level.
-    ///        Delete Predicates are tombstone of deleted data that will be eliminated at read time.
-    ///   2. If the chunk has Delete Predicates, the FilterExec will be added to filter data out
-    ///       We apply delete predicate filter at this low level because the Delete Predicates are chunk specific.
-    ///   3. Then SortExec is added if there is a request to sort this chunk at this stage
-    ///       See the description of function build_scan_plan to see why the sort may be needed
+    ///
+    ///   1. First we scan the data in IOxReadFilterNode which represents a custom implemented scan
+    ///      of the chunk. Both Select Predicate of the query and Delete Predicates of the chunk is
+    ///      pushed down here to eliminate as much data as early as possible but it is not
+    ///      guaranteed all filters are applied because only certain expressions work at this low
+    ///      chunk scan level. Delete Predicates are tombstone of deleted data that will be
+    ///      eliminated at read time.
+    ///   2. If the chunk has Delete Predicates, the FilterExec will be added to filter data out.
+    ///      We apply delete predicate filter at this low level because the Delete Predicates are
+    ///      chunk specific.
+    ///   3. Then SortExec is added if there is a request to sort this chunk at this stage.
+    ///      See the description of function build_scan_plan to see why the sort may be needed.
+    ///
     /// ```text
     ///                ┌─────────────────┐
     ///                │ ProjectionExec  │

--- a/query_tests/src/scenarios/delete.rs
+++ b/query_tests/src/scenarios/delete.rs
@@ -31,7 +31,6 @@ impl DbSetup for OneDeleteSimpleExprOneChunkDeleteAll {
             exprs: vec![],
         };
 
-        // this returns 15 scenarios
         all_scenarios_for_one_chunk(vec![&pred], vec![], lp_lines, table_name, partition_key).await
     }
 }
@@ -58,7 +57,6 @@ impl DbSetup for OneDeleteSimpleExprOneChunk {
             )],
         };
 
-        // this returns 15 scenarios
         all_scenarios_for_one_chunk(vec![&pred], vec![], lp_lines, table_name, partition_key).await
     }
 }
@@ -79,7 +77,6 @@ impl DbSetup for NoDeleteOneChunk {
             "cpu,foo=me bar=1 40",
         ];
 
-        // this returns 15 scenarios
         all_scenarios_for_one_chunk(vec![], vec![], lp_lines, table_name, partition_key).await
     }
 }
@@ -108,7 +105,6 @@ impl DbSetup for OneDeleteMultiExprsOneChunk {
             ],
         };
 
-        // this returns 15 scenarios
         all_scenarios_for_one_chunk(vec![&pred], vec![], lp_lines, table_name, partition_key).await
     }
 }

--- a/query_tests/src/scenarios/delete.rs
+++ b/query_tests/src/scenarios/delete.rs
@@ -13,8 +13,8 @@ use data_types::{DeleteExpr, DeletePredicate, Op, Scalar, TimestampRange};
 // when they happen
 
 #[derive(Debug)]
-/// Setup for delete query test with one table and one chunk moved from MUB to RUB to OS
-/// All data will be soft deleted in this setup
+/// Setup for delete query test with one table and one chunk. All data will be soft deleted in this
+/// setup.
 pub struct OneDeleteSimpleExprOneChunkDeleteAll {}
 #[async_trait]
 impl DbSetup for OneDeleteSimpleExprOneChunkDeleteAll {
@@ -37,7 +37,7 @@ impl DbSetup for OneDeleteSimpleExprOneChunkDeleteAll {
 }
 
 #[derive(Debug)]
-/// Setup for delete query test with one table and one chunk moved from MUB to RUB to OS
+/// Setup for delete query test with one table and one chunk
 pub struct OneDeleteSimpleExprOneChunk {}
 #[async_trait]
 impl DbSetup for OneDeleteSimpleExprOneChunk {
@@ -64,8 +64,7 @@ impl DbSetup for OneDeleteSimpleExprOneChunk {
 }
 
 #[derive(Debug)]
-/// Setup for many scenario move chunk from from MUB to RUB to OS
-/// No delete in this case
+/// Setup for many scenarios moving the chunk to different stages. No delete in this case.
 pub struct NoDeleteOneChunk {}
 #[async_trait]
 impl DbSetup for NoDeleteOneChunk {
@@ -86,7 +85,7 @@ impl DbSetup for NoDeleteOneChunk {
 }
 
 #[derive(Debug)]
-/// Setup for multi-expression delete query test with one table and one chunk moved from MUB to RUB to OS
+/// Setup for multi-expression delete query test with one table and one chunk
 pub struct OneDeleteMultiExprsOneChunk {}
 #[async_trait]
 impl DbSetup for OneDeleteMultiExprsOneChunk {
@@ -115,14 +114,14 @@ impl DbSetup for OneDeleteMultiExprsOneChunk {
 }
 
 #[derive(Debug)]
-/// Setup for multi-expression delete query test with one table and one chunk moved from MUB to RUB to OS
-/// Two deletes at different chunk stages
+/// Setup for multi-expression delete query test with one table and one chunk. Two deletes at
+/// different chunk stages.
 pub struct TwoDeletesMultiExprsOneChunk {}
 #[async_trait]
 impl DbSetup for TwoDeletesMultiExprsOneChunk {
     async fn make(&self) -> Vec<DbScenario> {
-        // The main purpose of these scenarios is the multi-expression delete predicate is added in MUB and
-        // is moved with chunk moving. Then one more delete after moving
+        // The main purpose of these scenarios is the multi-expression delete predicate is added in
+        // the ingester and is moved with chunk moving. Then one more delete after moving.
 
         // General setup for all scenarios
         let partition_key = "1970-01-01T00";

--- a/query_tests/src/scenarios/library.rs
+++ b/query_tests/src/scenarios/library.rs
@@ -40,7 +40,6 @@ impl DbSetup for OneMeasurementRealisticTimes {
             "cpu,region=west user=21.0 1626809430000000000",
         ];
 
-        // return all possible scenarios a chunk: MUB open, MUB frozen, RUB, RUB & OS, OS
         all_scenarios_for_one_chunk(vec![], vec![], lp_lines, "cpu", partition_key).await
     }
 }
@@ -59,7 +58,6 @@ impl DbSetup for OneMeasurementNoTags {
             "h2o level=200.0 300",
         ];
 
-        // return all possible scenarios a chunk: MUB open, MUB frozen, RUB, RUB & OS, OS
         all_scenarios_for_one_chunk(vec![], vec![], lp_lines, "h2o", partition_key).await
     }
 }
@@ -81,7 +79,6 @@ impl DbSetup for OneMeasurementManyNullTags {
             "h2o,state=NY,city=NYC,borough=Brooklyn temp=61.0 600",
         ];
 
-        // return all possible scenarios a chunk: MUB open, MUB frozen, RUB, RUB & OS, OS
         all_scenarios_for_one_chunk(vec![], vec![], lp_lines, "cpu", partition_key).await
     }
 }
@@ -176,7 +173,6 @@ impl DbSetup for TwoMeasurements {
             "disk,region=east bytes=99i 200",
         ];
 
-        // return all possible scenarios a chunk: MUB open, MUB frozen, RUB, RUB & OS, OS
         all_scenarios_for_one_chunk(vec![], vec![], lp_lines, "cpu", partition_key).await
     }
 }
@@ -208,7 +204,8 @@ impl DbSetup for TwoMeasurementsWithDelete {
             )],
         };
 
-        // return all possible combination scenarios of a chunk stage and when the delete predicates are applied
+        // return all possible combination scenarios of a chunk stage and when the delete
+        // predicates are applied
         all_scenarios_for_one_chunk(vec![&pred], vec![], lp_lines, table_name, partition_key).await
     }
 }
@@ -246,7 +243,8 @@ impl DbSetup for TwoMeasurementsWithDeleteAll {
             exprs: vec![],
         };
 
-        // return all possible combination scenarios of a chunk stage and when the delete predicates are applied
+        // return all possible combination scenarios of a chunk stage and when the delete
+        // predicates are applied
         all_scenarios_for_one_chunk(
             vec![&pred1],
             vec![&pred2],
@@ -489,7 +487,8 @@ impl DbSetup for ManyFieldsSeveralChunks {
         // c4: parquet stage & overlap with c1
         let lp_lines4 = vec![
             "h2o,state=MA,city=Boston temp=88.6 230",
-            "h2o,state=MA,city=Boston other_temp=80 250", // duplicate with a row in c1 but more recent => this row is kept
+            "h2o,state=MA,city=Boston other_temp=80 250", // duplicate with a row in c1 but more
+                                                          // recent => this row is kept
         ];
         let c4 = ChunkData {
             lp_lines: lp_lines4,
@@ -559,8 +558,9 @@ impl DbSetup for OneMeasurementFourChunksWithDuplicates {
         //  . time range: 150 - 300
         //  . no duplicates in its own chunk
         let lp_lines2 = vec![
-            "h2o,state=MA,city=Bedford max_temp=78.75,area=742u 150", // new field (area) and update available NULL (max_temp)
-            "h2o,state=MA,city=Boston min_temp=65.4 250",             // update min_temp from NULL
+            // new field (area) and update available NULL (max_temp)
+            "h2o,state=MA,city=Bedford max_temp=78.75,area=742u 150",
+            "h2o,state=MA,city=Boston min_temp=65.4 250", // update min_temp from NULL
             "h2o,state=MA,city=Reading min_temp=53.4, 250",
             "h2o,state=CA,city=SF min_temp=79.0,max_temp=87.2,area=500u 300",
             "h2o,state=CA,city=SJ min_temp=78.5,max_temp=88.0 300",
@@ -696,7 +696,7 @@ impl DbSetup for EndToEndTest {
         ];
 
         let partition_key = "1970-01-01T00";
-        // return all possible scenarios a chunk: MUB open, MUB frozen, RUB, RUB & OS, OS
+
         all_scenarios_for_one_chunk(vec![], vec![], lp_lines, "cpu_load_short", partition_key).await
     }
 }
@@ -978,9 +978,8 @@ impl DbSetup for OneMeasurementNoTagsWithDelete {
     }
 }
 
-/// This will create many scenarios (at least 15), some have a chunk with
-/// soft deleted data, some have no chunks because there is no point to
-/// create a RUB for one or many compacted MUB with all deleted data.
+/// This will create many scenarios (at least 15), some have a chunk with soft deleted data, some
+/// have no chunks because there is no point to create compacted chunks with all deleted data.
 pub struct OneMeasurementNoTagsWithDeleteAllWithAndWithoutChunk {}
 #[async_trait]
 impl DbSetup for OneMeasurementNoTagsWithDeleteAllWithAndWithoutChunk {

--- a/query_tests/src/scenarios/library.rs
+++ b/query_tests/src/scenarios/library.rs
@@ -759,7 +759,7 @@ impl DbSetup for TwoMeasurementsMultiSeries {
             "o2,state=MA,city=Boston temp=53.4,reading=51 250", // to row 4
         ];
 
-        // Swap around  data is not inserted in series order
+        // Swap around data is not inserted in series order
         lp_lines.swap(0, 2);
         lp_lines.swap(4, 5);
 
@@ -783,7 +783,7 @@ impl DbSetup for TwoMeasurementsMultiSeriesWithDelete {
             "o2,state=MA,city=Boston temp=53.4,reading=51 250", // to row 4
         ];
 
-        // Swap around  data is not inserted in series order
+        // Swap around data is not inserted in series order
         lp_lines.swap(0, 2);
         lp_lines.swap(4, 5);
 
@@ -822,7 +822,7 @@ impl DbSetup for TwoMeasurementsMultiSeriesWithDeleteAll {
             "o2,state=MA,city=Boston temp=53.4,reading=51 250", // to row 4
         ];
 
-        // Swap around  data is not inserted in series order
+        // Swap around data is not inserted in series order
         lp_lines.swap(0, 2);
         lp_lines.swap(4, 5);
 
@@ -978,8 +978,8 @@ impl DbSetup for OneMeasurementNoTagsWithDelete {
     }
 }
 
-/// This will create many scenarios (at least 15), some have a chunk with soft deleted data, some
-/// have no chunks because there is no point to create compacted chunks with all deleted data.
+/// This will create many scenarios: some have a chunk with soft deleted data, some have no chunks
+/// because there is no point to create compacted chunks with all deleted data.
 pub struct OneMeasurementNoTagsWithDeleteAllWithAndWithoutChunk {}
 #[async_trait]
 impl DbSetup for OneMeasurementNoTagsWithDeleteAllWithAndWithoutChunk {
@@ -994,8 +994,8 @@ impl DbSetup for OneMeasurementNoTagsWithDeleteAllWithAndWithoutChunk {
             exprs: vec![],
         };
 
-        // Apply predicate before the chunk is moved if any. There will be
-        // scenario without chunks as a consequence of not-compacting-deleted-data
+        // Apply predicate before the chunk is moved if any. There will be scenarios without chunks
+        // as a consequence of not-compacting-deleted-data
         all_scenarios_for_one_chunk(
             vec![&pred],
             vec![],

--- a/query_tests/src/table_schema.rs
+++ b/query_tests/src/table_schema.rs
@@ -71,7 +71,7 @@ async fn run_table_schema_test_case<D>(
 }
 
 fn is_unsorted_chunk_type(chunk: &dyn QueryChunk) -> bool {
-    (chunk.chunk_type() == "MUB") || (chunk.chunk_type() == "IngesterPartition")
+    chunk.chunk_type() == "IngesterPartition"
 }
 
 #[tokio::test]


### PR DESCRIPTION
Found these in query tests and then searched elsewhere while working on adding the read buffer cache.

Where possible, I tried to future-proof these comments by either removing them or making them a little more vague so maybe they won't need to be continually updated to remain accurate (famous last words, I know!)