### PR TITLE
refactor: Rename `Sequence::sequencer_id` to  `Sequence::kafka_partition` and use proper type

### DIFF
--- a/data_types/src/lib.rs
+++ b/data_types/src/lib.rs
@@ -155,7 +155,7 @@ pub struct KafkaPartition(i32);
 
 #[allow(missing_docs)]
 impl KafkaPartition {
-    pub fn new(v: i32) -> Self {
+    pub const fn new(v: i32) -> Self {
         Self(v)
     }
     pub fn get(&self) -> i32 {
@@ -1963,17 +1963,17 @@ impl TableSummary {
 /// Kafka partition ID plus offset
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub struct Sequence {
-    /// The sequencer id (kafka partition id)
-    pub sequencer_id: u32,
+    /// The kafka partition
+    pub kafka_partition: KafkaPartition,
     /// The sequence number (kafka offset)
     pub sequence_number: SequenceNumber,
 }
 
 impl Sequence {
     /// Create a new Sequence
-    pub fn new(sequencer_id: u32, sequence_number: SequenceNumber) -> Self {
+    pub fn new(kafka_partition: KafkaPartition, sequence_number: SequenceNumber) -> Self {
         Self {
-            sequencer_id,
+            kafka_partition,
             sequence_number,
         }
     }

--- a/ingester/src/data.rs
+++ b/ingester/src/data.rs
@@ -1695,7 +1695,7 @@ mod tests {
             "foo",
             lines_to_batches("mem foo=1 10", 0).unwrap(),
             DmlMeta::sequenced(
-                Sequence::new(1, SequenceNumber::new(1)),
+                Sequence::new(KafkaPartition::new(1), SequenceNumber::new(1)),
                 ignored_ts,
                 None,
                 50,
@@ -1788,7 +1788,7 @@ mod tests {
             "foo",
             lines_to_batches("mem foo=1 10", 0).unwrap(),
             DmlMeta::sequenced(
-                Sequence::new(1, SequenceNumber::new(1)),
+                Sequence::new(KafkaPartition::new(1), SequenceNumber::new(1)),
                 ignored_ts,
                 None,
                 50,
@@ -1803,7 +1803,7 @@ mod tests {
             "foo",
             lines_to_batches("cpu foo=1 10", 1).unwrap(),
             DmlMeta::sequenced(
-                Sequence::new(2, SequenceNumber::new(1)),
+                Sequence::new(KafkaPartition::new(2), SequenceNumber::new(1)),
                 ignored_ts,
                 None,
                 50,
@@ -1820,7 +1820,7 @@ mod tests {
             "foo",
             lines_to_batches("mem foo=1 30", 2).unwrap(),
             DmlMeta::sequenced(
-                Sequence::new(1, SequenceNumber::new(2)),
+                Sequence::new(KafkaPartition::new(1), SequenceNumber::new(2)),
                 ignored_ts,
                 None,
                 50,
@@ -2207,7 +2207,7 @@ mod tests {
             "foo",
             lines_to_batches("mem foo=1 10", 0).unwrap(),
             DmlMeta::sequenced(
-                Sequence::new(1, SequenceNumber::new(1)),
+                Sequence::new(KafkaPartition::new(1), SequenceNumber::new(1)),
                 ignored_ts,
                 None,
                 50,
@@ -2217,7 +2217,7 @@ mod tests {
             "foo",
             lines_to_batches("mem foo=1 10", 0).unwrap(),
             DmlMeta::sequenced(
-                Sequence::new(1, SequenceNumber::new(2)),
+                Sequence::new(KafkaPartition::new(1), SequenceNumber::new(2)),
                 ignored_ts,
                 None,
                 50,
@@ -2389,7 +2389,7 @@ mod tests {
             "foo",
             lines_to_batches("mem foo=1 10", 0).unwrap(),
             DmlMeta::sequenced(
-                Sequence::new(1, SequenceNumber::new(1)),
+                Sequence::new(KafkaPartition::new(1), SequenceNumber::new(1)),
                 ignored_ts,
                 None,
                 50,
@@ -2444,7 +2444,7 @@ mod tests {
             predicate,
             Some(NonEmptyString::new("mem").unwrap()),
             DmlMeta::sequenced(
-                Sequence::new(1, SequenceNumber::new(2)),
+                Sequence::new(KafkaPartition::new(1), SequenceNumber::new(2)),
                 ignored_ts,
                 None,
                 1337,

--- a/ingester/src/handler.rs
+++ b/ingester/src/handler.rs
@@ -188,7 +188,7 @@ impl IngestHandlerImpl {
             // Acquire a write buffer stream and seek it to the last
             // definitely-already-persisted op
             let mut op_stream = write_buffer
-                .stream_handler(kafka_partition.get() as u32)
+                .stream_handler(kafka_partition)
                 .await
                 .context(WriteBufferSnafu)?;
             debug!(
@@ -419,7 +419,7 @@ mod tests {
             "foo",
             lines_to_batches("mem foo=1 10", 0).unwrap(),
             DmlMeta::sequenced(
-                Sequence::new(0, SequenceNumber::new(0)),
+                Sequence::new(KafkaPartition::new(0), SequenceNumber::new(0)),
                 ingest_ts1,
                 None,
                 50,
@@ -434,7 +434,7 @@ mod tests {
             "foo",
             lines_to_batches("cpu bar=2 20\ncpu bar=3 30", 0).unwrap(),
             DmlMeta::sequenced(
-                Sequence::new(0, SequenceNumber::new(7)),
+                Sequence::new(KafkaPartition::new(0), SequenceNumber::new(7)),
                 ingest_ts2,
                 None,
                 150,
@@ -449,7 +449,7 @@ mod tests {
             "foo",
             lines_to_batches("a b=2 200", 0).unwrap(),
             DmlMeta::sequenced(
-                Sequence::new(0, SequenceNumber::new(9)),
+                Sequence::new(KafkaPartition::new(0), SequenceNumber::new(9)),
                 ingest_ts2,
                 None,
                 150,
@@ -742,7 +742,7 @@ mod tests {
                 "foo",
                 lines_to_batches("cpu bar=2 20", 0).unwrap(),
                 DmlMeta::sequenced(
-                    Sequence::new(0, SequenceNumber::new(1)),
+                    Sequence::new(KafkaPartition::new(0), SequenceNumber::new(1)),
                     ingest_ts1,
                     None,
                     150,
@@ -752,7 +752,7 @@ mod tests {
                 "foo",
                 lines_to_batches("cpu bar=2 30", 0).unwrap(),
                 DmlMeta::sequenced(
-                    Sequence::new(0, SequenceNumber::new(2)),
+                    Sequence::new(KafkaPartition::new(0), SequenceNumber::new(2)),
                     ingest_ts2,
                     None,
                     150,
@@ -793,7 +793,7 @@ mod tests {
             "foo",
             lines_to_batches("cpu bar=2 20", 0).unwrap(),
             DmlMeta::sequenced(
-                Sequence::new(0, SequenceNumber::new(1)),
+                Sequence::new(KafkaPartition::new(0), SequenceNumber::new(1)),
                 ingest_ts1,
                 None,
                 150,

--- a/ingester/src/stream_handler/handler.rs
+++ b/ingester/src/stream_handler/handler.rs
@@ -459,7 +459,7 @@ mod tests {
     fn make_write(name: impl Into<String>, write_time: u64) -> DmlWrite {
         let tables = lines_to_batches("bananas level=42 4242", 0).unwrap();
         let sequence = DmlMeta::sequenced(
-            Sequence::new(1, SequenceNumber::new(2)),
+            Sequence::new(KafkaPartition::new(1), SequenceNumber::new(2)),
             TEST_TIME
                 .checked_sub(Duration::from_millis(write_time))
                 .unwrap(),
@@ -476,7 +476,7 @@ mod tests {
             exprs: vec![],
         };
         let sequence = DmlMeta::sequenced(
-            Sequence::new(1, SequenceNumber::new(2)),
+            Sequence::new(KafkaPartition::new(1), SequenceNumber::new(2)),
             TEST_TIME
                 .checked_sub(Duration::from_millis(write_time))
                 .unwrap(),

--- a/ioxd_router/src/lib.rs
+++ b/ioxd_router/src/lib.rs
@@ -310,7 +310,7 @@ async fn init_write_buffer(
     // The sort order must be deterministic in order for all nodes to shard to
     // the same sequencers, therefore we type assert the returned set is of the
     // ordered variety.
-    let shards: BTreeSet<_> = write_buffer.sequencer_ids();
+    let shards: BTreeSet<_> = write_buffer.kafka_partitions();
     //          ^ don't change this to an unordered set
 
     info!(

--- a/router/benches/e2e.rs
+++ b/router/benches/e2e.rs
@@ -33,7 +33,7 @@ fn init_write_buffer(n_sequencers: u32) -> ShardedWriteBuffer<JumpHash<Arc<Seque
         .expect("failed to init mock write buffer"),
     );
 
-    let shards: BTreeSet<_> = write_buffer.sequencer_ids();
+    let shards: BTreeSet<_> = write_buffer.kafka_partitions();
     ShardedWriteBuffer::new(
         shards
             .into_iter()


### PR DESCRIPTION
Draft until  https://github.com/influxdata/influxdb_iox/pull/4817 is merged

# Rationale
Related to https://github.com/influxdata/influxdb_iox/issues/4237

NG uses the term `kafka_partition` for what OG called  `sequencer_id`. Even more confusing NG introduced a new concept called `Sequencer` / `sequencer_id` that is similar, but *different* than what it was in OG. Some of the code in DML still uses the OG naming which is super confusing.

Eventually, we may want to rename `kafka_partition` (see https://github.com/influxdata/influxdb_iox/issues/4246) but for now at least using consistent terminology is better.

# Changes
1. Rename `Sequence::sequencer_id` to  `Sequence::kafka_partition`
2. Change type to `KafkaPartition`
