### PR TITLE
docs: remove ref to old docker compose config

### DIFF
--- a/iox_data_generator/README.md
+++ b/iox_data_generator/README.md
@@ -51,14 +51,7 @@ cargo run --release -- run router --server-id 1
 cargo run --release -- run database --server-id 2 --api-bind 127.0.0.1:8084 --grpc-bind 127.0.0.1:8086
 ```
 
-You'll also need to run a Kafka instance. There's a Docker compose script in the influxdb_iox
-repo you can run with:
-
-```
-docker-compose -f docker/ci-kafka-docker-compose.yml up kafka
-```
-
-The Kafka instance will be accessible from `127.0.0.1:9093` if you run it with this script.
+You'll also need to run a Kafka instance separately.
 
 Once you have the two IOx servers and one Kafka instance running, create a database with a name in
 the format `[orgname]_[bucketname]`. For example, create a database in IOx named `mlb_pirates`, and

--- a/write_buffer/src/core.rs
+++ b/write_buffer/src/core.rs
@@ -1145,13 +1145,8 @@ pub mod test_utils {
                 (true, None) => {
                     panic!(
                         "TEST_INTEGRATION is set which requires running integration tests, but \
-                        KAFKA_CONNECT is not set. Please run Kafka, perhaps by using the command \
-                        `docker-compose -f docker/ci-kafka-docker-compose.yml up kafka`, then \
-                        set KAFKA_CONNECT to the host and port where Kafka is accessible. If \
-                        running the `docker-compose` command and the Rust tests on the host, the \
-                        value for `KAFKA_CONNECT` should be `localhost:9093`. If running the Rust \
-                        tests in another container in the `docker-compose` network as on CI, \
-                        `KAFKA_CONNECT` should be `kafka:9092`."
+                        KAFKA_CONNECT is not set. Please run Kafka, then set KAFKA_CONNECT to \
+                        the host and port where Kafka is accessible to run these tests."
                     )
                 }
                 (false, Some(_)) => {


### PR DESCRIPTION
Closes #4828.

---

* docs: remove ref to old docker compose config (c337fe907)

      Remove references to the now-gone ci-kafka-docker-compose.yml command.