### PR TITLE
(NOT FOR MERGING) Demonstrate upstream fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1172,7 +1172,7 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "8.0.0"
-source = "git+https://github.com/apache/arrow-datafusion.git?rev=3cd62e91e724ce0d549a2571104c32bbf899c327#3cd62e91e724ce0d549a2571104c32bbf899c327"
+source = "git+https://github.com/waynexia/arrow-datafusion.git?branch=fix-2712#835f2646cc09688d50564d440d9f88105f447cdd"
 dependencies = [
  "ahash",
  "arrow",
@@ -1199,7 +1199,7 @@ dependencies = [
  "pin-project-lite",
  "rand",
  "smallvec",
- "sqlparser 0.17.0",
+ "sqlparser",
  "tempfile",
  "tokio",
  "tokio-stream",
@@ -1210,18 +1210,18 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "8.0.0"
-source = "git+https://github.com/apache/arrow-datafusion.git?rev=3cd62e91e724ce0d549a2571104c32bbf899c327#3cd62e91e724ce0d549a2571104c32bbf899c327"
+source = "git+https://github.com/waynexia/arrow-datafusion.git?branch=fix-2712#835f2646cc09688d50564d440d9f88105f447cdd"
 dependencies = [
  "arrow",
  "ordered-float 3.0.0",
  "parquet",
- "sqlparser 0.17.0",
+ "sqlparser",
 ]
 
 [[package]]
 name = "datafusion-data-access"
 version = "8.0.0"
-source = "git+https://github.com/apache/arrow-datafusion.git?rev=3cd62e91e724ce0d549a2571104c32bbf899c327#3cd62e91e724ce0d549a2571104c32bbf899c327"
+source = "git+https://github.com/waynexia/arrow-datafusion.git?branch=fix-2712#835f2646cc09688d50564d440d9f88105f447cdd"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1234,18 +1234,18 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "8.0.0"
-source = "git+https://github.com/apache/arrow-datafusion.git?rev=3cd62e91e724ce0d549a2571104c32bbf899c327#3cd62e91e724ce0d549a2571104c32bbf899c327"
+source = "git+https://github.com/waynexia/arrow-datafusion.git?branch=fix-2712#835f2646cc09688d50564d440d9f88105f447cdd"
 dependencies = [
  "ahash",
  "arrow",
  "datafusion-common",
- "sqlparser 0.17.0",
+ "sqlparser",
 ]
 
 [[package]]
 name = "datafusion-optimizer"
 version = "8.0.0"
-source = "git+https://github.com/apache/arrow-datafusion.git?rev=3cd62e91e724ce0d549a2571104c32bbf899c327#3cd62e91e724ce0d549a2571104c32bbf899c327"
+source = "git+https://github.com/waynexia/arrow-datafusion.git?branch=fix-2712#835f2646cc09688d50564d440d9f88105f447cdd"
 dependencies = [
  "arrow",
  "async-trait",
@@ -1260,7 +1260,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "8.0.0"
-source = "git+https://github.com/apache/arrow-datafusion.git?rev=3cd62e91e724ce0d549a2571104c32bbf899c327#3cd62e91e724ce0d549a2571104c32bbf899c327"
+source = "git+https://github.com/waynexia/arrow-datafusion.git?branch=fix-2712#835f2646cc09688d50564d440d9f88105f447cdd"
 dependencies = [
  "ahash",
  "arrow",
@@ -1284,7 +1284,7 @@ dependencies = [
 [[package]]
 name = "datafusion-proto"
 version = "8.0.0"
-source = "git+https://github.com/apache/arrow-datafusion.git?rev=3cd62e91e724ce0d549a2571104c32bbf899c327#3cd62e91e724ce0d549a2571104c32bbf899c327"
+source = "git+https://github.com/waynexia/arrow-datafusion.git?branch=fix-2712#835f2646cc09688d50564d440d9f88105f447cdd"
 dependencies = [
  "arrow",
  "datafusion 8.0.0",
@@ -1297,7 +1297,7 @@ dependencies = [
 [[package]]
 name = "datafusion-row"
 version = "8.0.0"
-source = "git+https://github.com/apache/arrow-datafusion.git?rev=3cd62e91e724ce0d549a2571104c32bbf899c327#3cd62e91e724ce0d549a2571104c32bbf899c327"
+source = "git+https://github.com/waynexia/arrow-datafusion.git?branch=fix-2712#835f2646cc09688d50564d440d9f88105f447cdd"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -1308,14 +1308,14 @@ dependencies = [
 [[package]]
 name = "datafusion-sql"
 version = "8.0.0"
-source = "git+https://github.com/apache/arrow-datafusion.git?rev=3cd62e91e724ce0d549a2571104c32bbf899c327#3cd62e91e724ce0d549a2571104c32bbf899c327"
+source = "git+https://github.com/waynexia/arrow-datafusion.git?branch=fix-2712#835f2646cc09688d50564d440d9f88105f447cdd"
 dependencies = [
  "ahash",
  "arrow",
  "datafusion-common",
  "datafusion-expr",
  "hashbrown 0.12.1",
- "sqlparser 0.17.0",
+ "sqlparser",
  "tokio",
 ]
 
@@ -2258,7 +2258,7 @@ version = "0.1.0"
 dependencies = [
  "generated_types",
  "snafu",
- "sqlparser 0.18.0",
+ "sqlparser",
  "workspace-hack",
 ]
 
@@ -3743,7 +3743,7 @@ dependencies = [
  "schema",
  "serde_json",
  "snafu",
- "sqlparser 0.18.0",
+ "sqlparser",
  "test_helpers",
  "workspace-hack",
 ]
@@ -5048,15 +5048,6 @@ dependencies = [
  "itertools",
  "nom",
  "unicode_categories",
-]
-
-[[package]]
-name = "sqlparser"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddc2739f3a9bfc68e2f7b7695589f6cb0181c88af73ceaee0c84215cd2a2ae28"
-dependencies = [
- "log",
 ]
 
 [[package]]

--- a/datafusion/Cargo.toml
+++ b/datafusion/Cargo.toml
@@ -9,6 +9,6 @@ description = "Re-exports datafusion at a specific version"
 
 # Rename to workaround doctest bug
 # Turn off optional datafusion features (e.g. don't get support for crypto functions or avro)
-upstream = { git = "https://github.com/apache/arrow-datafusion.git", rev="3cd62e91e724ce0d549a2571104c32bbf899c327", default-features = false, package = "datafusion" }
-datafusion-proto = { git = "https://github.com/apache/arrow-datafusion.git", rev="3cd62e91e724ce0d549a2571104c32bbf899c327" }
+upstream = { git = "https://github.com/waynexia/arrow-datafusion.git", branch="fix-2712", default-features = false, package = "datafusion" }
+datafusion-proto = { git = "https://github.com/waynexia/arrow-datafusion.git", branch="fix-2712" }
 workspace-hack = { path = "../workspace-hack"}


### PR DESCRIPTION
This PR is based on 46de8d6cb3b34230bc982f94687b68d5434ddcd2 (right before the fix for #4800 f34282be2ca6dc51506d53e94302cf8e8f30963e which stopped running the optimizer twice)

I am using it as a way to verify the fix proposed by @waynexia in https://github.com/apache/arrow-datafusion/pull/2715