### PR TITLE
refactor: PartitionKey type

### DIFF
--- a/compactor/src/compact.rs
+++ b/compactor/src/compact.rs
@@ -771,7 +771,7 @@ impl Compactor {
                 table_id: iox_metadata.table_id,
                 table_name: Arc::<str>::clone(&iox_metadata.table_name),
                 partition_id: iox_metadata.partition_id,
-                partition_key: Arc::<str>::clone(&iox_metadata.partition_key),
+                partition_key: iox_metadata.partition_key.clone(),
                 min_sequence_number,
                 max_sequence_number,
                 compaction_level: 1, // compacted result file always have level 1
@@ -2590,7 +2590,7 @@ mod tests {
             .unwrap();
         let partition = txn
             .partitions()
-            .create_or_get("one", sequencer.id, table.id)
+            .create_or_get(&"one".into(), sequencer.id, table.id)
             .await
             .unwrap();
 
@@ -2794,7 +2794,7 @@ mod tests {
             .unwrap();
         let partition = txn
             .partitions()
-            .create_or_get("one", sequencer.id, table.id)
+            .create_or_get(&"one".into(), sequencer.id, table.id)
             .await
             .unwrap();
 
@@ -3018,22 +3018,22 @@ mod tests {
             .unwrap();
         let partition = txn
             .partitions()
-            .create_or_get("one", sequencer.id, table.id)
+            .create_or_get(&"one".into(), sequencer.id, table.id)
             .await
             .unwrap();
         let partition2 = txn
             .partitions()
-            .create_or_get("two", sequencer.id, table.id)
+            .create_or_get(&"two".into(), sequencer.id, table.id)
             .await
             .unwrap();
         let partition3 = txn
             .partitions()
-            .create_or_get("three", sequencer.id, table.id)
+            .create_or_get(&"three".into(), sequencer.id, table.id)
             .await
             .unwrap();
         let partition4 = txn
             .partitions()
-            .create_or_get("four", sequencer.id, table.id)
+            .create_or_get(&"four".into(), sequencer.id, table.id)
             .await
             .unwrap();
 

--- a/compactor/src/garbage_collector.rs
+++ b/compactor/src/garbage_collector.rs
@@ -164,7 +164,7 @@ mod tests {
             .unwrap();
         let partition = txn
             .partitions()
-            .create_or_get("one", sequencer.id, table.id)
+            .create_or_get(&"one".into(), sequencer.id, table.id)
             .await
             .unwrap();
 
@@ -246,7 +246,7 @@ mod tests {
             .unwrap();
         let partition = txn
             .partitions()
-            .create_or_get("one", sequencer.id, table.id)
+            .create_or_get(&"one".into(), sequencer.id, table.id)
             .await
             .unwrap();
 
@@ -332,7 +332,7 @@ mod tests {
             .unwrap();
         let partition = txn
             .partitions()
-            .create_or_get("one", sequencer.id, table.id)
+            .create_or_get(&"one".into(), sequencer.id, table.id)
             .await
             .unwrap();
 

--- a/influxdb_iox/src/commands/remote/partition.rs
+++ b/influxdb_iox/src/commands/remote/partition.rs
@@ -316,7 +316,7 @@ async fn load_partition(
         .expect("table should have been loaded");
     let partition = repos
         .partitions()
-        .create_or_get(&remote_partition.key, sequencer.id, table.id)
+        .create_or_get(&remote_partition.key.clone().into(), sequencer.id, table.id)
         .await?;
 
     Ok(PartitionMapping {
@@ -538,7 +538,7 @@ mod tests {
                 .unwrap();
             partition = repos
                 .partitions()
-                .create_or_get("1970-01-01", sequencer.id, table.id)
+                .create_or_get(&"1970-01-01".into(), sequencer.id, table.id)
                 .await
                 .unwrap();
         }

--- a/ingester/src/compact.rs
+++ b/ingester/src/compact.rs
@@ -104,7 +104,7 @@ pub async fn compact_persisting_batch(
         table_id: batch.table_id,
         table_name: Arc::from(table_name.as_str()),
         partition_id: batch.partition_id,
-        partition_key: Arc::from(partition_key.as_str()),
+        partition_key: partition_key.clone(),
         min_sequence_number: min_seq,
         max_sequence_number: max_seq,
         compaction_level: INITIAL_COMPACTION_LEVEL,

--- a/ingester/src/handler.rs
+++ b/ingester/src/handler.rs
@@ -451,7 +451,7 @@ mod tests {
                 if let Some(data) = ingester.ingester.data.sequencer(ingester.sequencer.id) {
                     if let Some(data) = data.namespace(&ingester.namespace.name) {
                         // verify there's data in the buffer
-                        if let Some((b, _)) = data.snapshot("a", "1970-01-01").await {
+                        if let Some((b, _)) = data.snapshot("a", &"1970-01-01".into()).await {
                             if let Some(b) = b.first() {
                                 if b.data.num_rows() > 0 {
                                     has_measurement = true;
@@ -690,7 +690,7 @@ mod tests {
                 if let Some(data) = ingester.data.sequencer(sequencer.id) {
                     if let Some(data) = data.namespace(&namespace.name) {
                         // verify there's data in the buffer
-                        if let Some((b, _)) = data.snapshot("cpu", "1970-01-01").await {
+                        if let Some((b, _)) = data.snapshot("cpu", &"1970-01-01".into()).await {
                             if let Some(b) = b.first() {
                                 custom_batch_verification(b);
 

--- a/ingester/src/test_util.rs
+++ b/ingester/src/test_util.rs
@@ -13,8 +13,8 @@ use arrow::record_batch::RecordBatch;
 use arrow_util::assert_batches_eq;
 use bitflags::bitflags;
 use data_types::{
-    KafkaPartition, NamespaceId, PartitionId, SequenceNumber, SequencerId, TableId, Timestamp,
-    Tombstone, TombstoneId,
+    KafkaPartition, NamespaceId, PartitionId, PartitionKey, SequenceNumber, SequencerId, TableId,
+    Timestamp, Tombstone, TombstoneId,
 };
 use iox_catalog::{
     interface::{Catalog, INITIAL_COMPACTION_LEVEL},
@@ -144,7 +144,7 @@ pub fn make_meta(
         table_id: TableId::new(table_id),
         table_name: Arc::from(table_name),
         partition_id: PartitionId::new(partition_id),
-        partition_key: Arc::from(partition_key),
+        partition_key: PartitionKey::from(partition_key),
         min_sequence_number: SequenceNumber::new(min_sequence_number),
         max_sequence_number: SequenceNumber::new(max_sequence_number),
         compaction_level,
@@ -766,7 +766,7 @@ pub(crate) fn make_partitions(
     sequencer_id: SequencerId,
     table_id: TableId,
     table_name: &str,
-) -> BTreeMap<String, PartitionData> {
+) -> BTreeMap<PartitionKey, PartitionData> {
     // In-memory data includes these rows but split between 4 groups go into
     // different batches of parittion 1 or partittion 2  as requeted
     // let expected = vec![
@@ -812,7 +812,7 @@ pub(crate) fn make_partitions(
         );
         p2.buffer_write(SequenceNumber::new(seq_num), mb).unwrap();
 
-        partitions.insert(TEST_PARTITION_2.to_string(), p2);
+        partitions.insert(PartitionKey::from(TEST_PARTITION_2), p2);
     } else {
         // Group 4: in buffer of p1
         // Fill `buffer`
@@ -828,7 +828,7 @@ pub(crate) fn make_partitions(
         p1.buffer_write(SequenceNumber::new(seq_num), mb).unwrap();
     }
 
-    partitions.insert(TEST_PARTITION_1.to_string(), p1);
+    partitions.insert(PartitionKey::from(TEST_PARTITION_1), p1);
     partitions
 }
 
@@ -839,7 +839,7 @@ pub(crate) async fn make_one_partition_with_tombstones(
     sequencer_id: SequencerId,
     table_id: TableId,
     table_name: &str,
-) -> BTreeMap<String, PartitionData> {
+) -> BTreeMap<PartitionKey, PartitionData> {
     // In-memory data includes these rows but split between 4 groups go into
     // different batches of parittion 1 or partittion 2  as requeted
     // let expected = vec![
@@ -893,7 +893,7 @@ pub(crate) async fn make_one_partition_with_tombstones(
     p1.buffer_write(SequenceNumber::new(seq_num), mb).unwrap();
 
     let mut partitions = BTreeMap::new();
-    partitions.insert(TEST_PARTITION_1.to_string(), p1);
+    partitions.insert(PartitionKey::from(TEST_PARTITION_1), p1);
 
     partitions
 }

--- a/iox_catalog/src/interface.rs
+++ b/iox_catalog/src/interface.rs
@@ -4,9 +4,9 @@ use async_trait::async_trait;
 use data_types::{
     Column, ColumnSchema, ColumnType, KafkaPartition, KafkaTopic, KafkaTopicId, Namespace,
     NamespaceId, NamespaceSchema, ParquetFile, ParquetFileId, ParquetFileParams,
-    ParquetFileWithMetadata, Partition, PartitionId, PartitionInfo, ProcessedTombstone, QueryPool,
-    QueryPoolId, SequenceNumber, Sequencer, SequencerId, Table, TableId, TablePartition,
-    TableSchema, Timestamp, Tombstone, TombstoneId,
+    ParquetFileWithMetadata, Partition, PartitionId, PartitionInfo, PartitionKey,
+    ProcessedTombstone, QueryPool, QueryPoolId, SequenceNumber, Sequencer, SequencerId, Table,
+    TableId, TablePartition, TableSchema, Timestamp, Tombstone, TombstoneId,
 };
 use iox_time::TimeProvider;
 use snafu::{OptionExt, Snafu};
@@ -405,7 +405,7 @@ pub trait PartitionRepo: Send + Sync {
     /// create or get a partition record for the given partition key, sequencer and table
     async fn create_or_get(
         &mut self,
-        key: &str,
+        key: &PartitionKey,
         sequencer_id: SequencerId,
         table_id: TableId,
     ) -> Result<Partition>;
@@ -1307,14 +1307,14 @@ pub(crate) mod test_helpers {
         for key in ["foo", "bar"] {
             let partition = repos
                 .partitions()
-                .create_or_get(key, sequencer.id, table.id)
+                .create_or_get(&key.into(), sequencer.id, table.id)
                 .await
                 .expect("failed to create partition");
             created.insert(partition.id, partition);
         }
         let other_partition = repos
             .partitions()
-            .create_or_get("asdf", other_sequencer.id, table.id)
+            .create_or_get(&"asdf".into(), other_sequencer.id, table.id)
             .await
             .unwrap();
 
@@ -1383,7 +1383,7 @@ pub(crate) mod test_helpers {
             .unwrap();
         repos
             .partitions()
-            .create_or_get("some_key", sequencer.id, table2.id)
+            .create_or_get(&"some_key".into(), sequencer.id, table2.id)
             .await
             .expect("failed to create partition");
         let listed = repos
@@ -1648,7 +1648,7 @@ pub(crate) mod test_helpers {
             .unwrap();
         let partition = repos
             .partitions()
-            .create_or_get("one", sequencer.id, table.id)
+            .create_or_get(&"one".into(), sequencer.id, table.id)
             .await
             .unwrap();
 
@@ -1858,12 +1858,12 @@ pub(crate) mod test_helpers {
             .unwrap();
         let partition = repos
             .partitions()
-            .create_or_get("one", sequencer.id, table.id)
+            .create_or_get(&"one".into(), sequencer.id, table.id)
             .await
             .unwrap();
         let other_partition = repos
             .partitions()
-            .create_or_get("one", sequencer.id, other_table.id)
+            .create_or_get(&"one".into(), sequencer.id, other_table.id)
             .await
             .unwrap();
 
@@ -2029,7 +2029,7 @@ pub(crate) mod test_helpers {
             .unwrap();
         let partition2 = repos
             .partitions()
-            .create_or_get("foo", sequencer.id, table2.id)
+            .create_or_get(&"foo".into(), sequencer.id, table2.id)
             .await
             .unwrap();
         let files = repos
@@ -2220,7 +2220,7 @@ pub(crate) mod test_helpers {
 
         let partition = repos
             .partitions()
-            .create_or_get("one", sequencer.id, table.id)
+            .create_or_get(&"one".into(), sequencer.id, table.id)
             .await
             .unwrap();
 
@@ -2343,12 +2343,12 @@ pub(crate) mod test_helpers {
             .unwrap();
         let partition = repos
             .partitions()
-            .create_or_get("one", sequencer.id, table.id)
+            .create_or_get(&"one".into(), sequencer.id, table.id)
             .await
             .unwrap();
         let other_partition = repos
             .partitions()
-            .create_or_get("two", sequencer.id, table.id)
+            .create_or_get(&"two".into(), sequencer.id, table.id)
             .await
             .unwrap();
 
@@ -2551,12 +2551,12 @@ pub(crate) mod test_helpers {
 
         let partition = repos
             .partitions()
-            .create_or_get("one", sequencer.id, table.id)
+            .create_or_get(&"one".into(), sequencer.id, table.id)
             .await
             .unwrap();
         let partition2 = repos
             .partitions()
-            .create_or_get("two", sequencer.id, table.id)
+            .create_or_get(&"two".into(), sequencer.id, table.id)
             .await
             .unwrap();
 
@@ -2673,7 +2673,7 @@ pub(crate) mod test_helpers {
             .unwrap();
         let partition = repos
             .partitions()
-            .create_or_get("one", sequencer.id, table.id)
+            .create_or_get(&"one".into(), sequencer.id, table.id)
             .await
             .unwrap();
 
@@ -2794,7 +2794,7 @@ pub(crate) mod test_helpers {
             .unwrap();
         let partition = repos
             .partitions()
-            .create_or_get("one", sequencer.id, table.id)
+            .create_or_get(&"one".into(), sequencer.id, table.id)
             .await
             .unwrap();
 

--- a/iox_catalog/src/metrics.rs
+++ b/iox_catalog/src/metrics.rs
@@ -9,8 +9,8 @@ use async_trait::async_trait;
 use data_types::{
     Column, ColumnType, KafkaPartition, KafkaTopic, KafkaTopicId, Namespace, NamespaceId,
     ParquetFile, ParquetFileId, ParquetFileParams, ParquetFileWithMetadata, Partition, PartitionId,
-    PartitionInfo, ProcessedTombstone, QueryPool, QueryPoolId, SequenceNumber, Sequencer,
-    SequencerId, Table, TableId, TablePartition, Timestamp, Tombstone, TombstoneId,
+    PartitionInfo, PartitionKey, ProcessedTombstone, QueryPool, QueryPoolId, SequenceNumber,
+    Sequencer, SequencerId, Table, TableId, TablePartition, Timestamp, Tombstone, TombstoneId,
 };
 use iox_time::{SystemProvider, TimeProvider};
 use metric::{DurationHistogram, Metric};
@@ -237,7 +237,7 @@ decorate!(
 decorate!(
     impl_trait = PartitionRepo,
     methods = [
-        "partition_create_or_get" = create_or_get(&mut self, key: &str, sequencer_id: SequencerId, table_id: TableId) -> Result<Partition>;
+        "partition_create_or_get" = create_or_get(&mut self, key: &PartitionKey, sequencer_id: SequencerId, table_id: TableId) -> Result<Partition>;
         "partition_get_by_id" = get_by_id(&mut self, partition_id: PartitionId) -> Result<Option<Partition>>;
         "partition_list_by_sequencer" = list_by_sequencer(&mut self, sequencer_id: SequencerId) -> Result<Vec<Partition>>;
         "partition_list_by_namespace" = list_by_namespace(&mut self, namespace_id: NamespaceId) -> Result<Vec<Partition>>;

--- a/iox_catalog/src/postgres.rs
+++ b/iox_catalog/src/postgres.rs
@@ -13,8 +13,8 @@ use async_trait::async_trait;
 use data_types::{
     Column, ColumnType, KafkaPartition, KafkaTopic, KafkaTopicId, Namespace, NamespaceId,
     ParquetFile, ParquetFileId, ParquetFileParams, ParquetFileWithMetadata, Partition, PartitionId,
-    PartitionInfo, ProcessedTombstone, QueryPool, QueryPoolId, SequenceNumber, Sequencer,
-    SequencerId, Table, TableId, TablePartition, Timestamp, Tombstone, TombstoneId,
+    PartitionInfo, PartitionKey, ProcessedTombstone, QueryPool, QueryPoolId, SequenceNumber,
+    Sequencer, SequencerId, Table, TableId, TablePartition, Timestamp, Tombstone, TombstoneId,
 };
 use iox_time::{SystemProvider, TimeProvider};
 use observability_deps::tracing::{info, warn};
@@ -1090,7 +1090,7 @@ WHERE kafka_topic_id = $1
 impl PartitionRepo for PostgresTxn {
     async fn create_or_get(
         &mut self,
-        key: &str,
+        key: &PartitionKey,
         sequencer_id: SequencerId,
         table_id: TableId,
     ) -> Result<Partition> {
@@ -2288,7 +2288,7 @@ mod tests {
             .repositories()
             .await
             .partitions()
-            .create_or_get(key, sequencer_id, table_id)
+            .create_or_get(&key.into(), sequencer_id, table_id)
             .await
             .expect("should create OK");
 
@@ -2299,7 +2299,7 @@ mod tests {
             .repositories()
             .await
             .partitions()
-            .create_or_get(key, sequencer_id, table_id)
+            .create_or_get(&key.into(), sequencer_id, table_id)
             .await
             .expect("idempotent write should succeed");
 
@@ -2359,7 +2359,7 @@ mod tests {
             .repositories()
             .await
             .partitions()
-            .create_or_get(key, sequencers[0].id, table_id)
+            .create_or_get(&key.into(), sequencers[0].id, table_id)
             .await
             .expect("should create OK");
 
@@ -2369,7 +2369,7 @@ mod tests {
             .repositories()
             .await
             .partitions()
-            .create_or_get(key, sequencers[1].id, table_id)
+            .create_or_get(&key.into(), sequencers[1].id, table_id)
             .await
             .expect("result should not be evaluated");
 

--- a/iox_tests/src/util.rs
+++ b/iox_tests/src/util.rs
@@ -346,7 +346,11 @@ impl TestTableBoundSequencer {
 
         let partition = repos
             .partitions()
-            .create_or_get(key, self.sequencer.sequencer.id, self.table.table.id)
+            .create_or_get(
+                &key.into(),
+                self.sequencer.sequencer.id,
+                self.table.table.id,
+            )
             .await
             .unwrap();
 
@@ -369,7 +373,11 @@ impl TestTableBoundSequencer {
 
         let partition = repos
             .partitions()
-            .create_or_get(key, self.sequencer.sequencer.id, self.table.table.id)
+            .create_or_get(
+                &key.into(),
+                self.sequencer.sequencer.id,
+                self.table.table.id,
+            )
             .await
             .unwrap();
 
@@ -543,7 +551,7 @@ impl TestPartition {
             table_id: self.table.table.id,
             table_name: self.table.table.name.clone().into(),
             partition_id: self.partition.id,
-            partition_key: self.partition.partition_key.clone().into(),
+            partition_key: self.partition.partition_key.clone(),
             min_sequence_number,
             max_sequence_number,
             compaction_level: INITIAL_COMPACTION_LEVEL,

--- a/querier/src/cache/parquet_file.rs
+++ b/querier/src/cache/parquet_file.rs
@@ -314,8 +314,8 @@ mod tests {
         // includes timestamps, etc)
         let slop_budget = 10;
 
-        let single_file_size = 1066;
-        let two_file_size = 2097;
+        let single_file_size = 1079;
+        let two_file_size = 2130;
         assert!(single_file_size < two_file_size);
 
         let cache = make_cache(&catalog);

--- a/query_tests/src/scenarios/util.rs
+++ b/query_tests/src/scenarios/util.rs
@@ -5,8 +5,8 @@ use arrow_util::optimize::{optimize_record_batch, optimize_schema};
 use async_trait::async_trait;
 use backoff::BackoffConfig;
 use data_types::{
-    DeletePredicate, NonEmptyString, PartitionId, Sequence, SequenceNumber, SequencerId,
-    TombstoneId,
+    DeletePredicate, NonEmptyString, PartitionId, PartitionKey, Sequence, SequenceNumber,
+    SequencerId, TombstoneId,
 };
 use datafusion::physical_plan::RecordBatchStream;
 use datafusion_util::MemoryStream;
@@ -912,8 +912,8 @@ impl ConstantPartitioner {
 }
 
 impl Partitioner for ConstantPartitioner {
-    fn partition_key(&self, _batch: &MutableBatch) -> Result<String, PartitionerError> {
-        Ok(self.partition_key.lock().unwrap().clone())
+    fn partition_key(&self, _batch: &MutableBatch) -> Result<PartitionKey, PartitionerError> {
+        Ok(self.partition_key.lock().unwrap().clone().into())
     }
 }
 

--- a/service_grpc_catalog/src/lib.rs
+++ b/service_grpc_catalog/src/lib.rs
@@ -106,7 +106,7 @@ fn to_partition(p: data_types::Partition) -> Partition {
     Partition {
         id: p.id.get(),
         sequencer_id: p.sequencer_id.get(),
-        key: p.partition_key,
+        key: p.partition_key.to_string(),
         table_id: p.table_id.get(),
         array_sort_key: p.sort_key,
     }
@@ -157,7 +157,7 @@ mod tests {
                 .unwrap();
             let partition = repos
                 .partitions()
-                .create_or_get("foo", sequencer.id, table.id)
+                .create_or_get(&"foo".into(), sequencer.id, table.id)
                 .await
                 .unwrap();
             let p1params = ParquetFileParams {
@@ -240,12 +240,12 @@ mod tests {
                 .unwrap();
             partition1 = repos
                 .partitions()
-                .create_or_get("foo", sequencer.id, table.id)
+                .create_or_get(&"foo".into(), sequencer.id, table.id)
                 .await
                 .unwrap();
             partition2 = repos
                 .partitions()
-                .create_or_get("bar", sequencer.id, table.id)
+                .create_or_get(&"bar".into(), sequencer.id, table.id)
                 .await
                 .unwrap();
             let sequencer2 = repos
@@ -255,7 +255,7 @@ mod tests {
                 .unwrap();
             partition3 = repos
                 .partitions()
-                .create_or_get("foo", sequencer2.id, table.id)
+                .create_or_get(&"foo".into(), sequencer2.id, table.id)
                 .await
                 .unwrap();
 

--- a/service_grpc_object_store/src/lib.rs
+++ b/service_grpc_object_store/src/lib.rs
@@ -136,7 +136,7 @@ mod tests {
                 .unwrap();
             let partition = repos
                 .partitions()
-                .create_or_get("foo", sequencer.id, table.id)
+                .create_or_get(&"foo".into(), sequencer.id, table.id)
                 .await
                 .unwrap();
             let p1params = ParquetFileParams {


### PR DESCRIPTION
This PR adds a new `PartitionKey` type so we can accept a typed input in fn calls, instead of a bare `String`, taking advantage of type checking to eliminate errors. It also ref-counts the underlying string to reduce memory usage, but this wasn't the primary motivation.

The actual functional code change is small, but quite a few tests needed updating.

---

* refactor: PartitionKey type (b41ea1d71)

      This commit changes the code base to use a new reference-counted PartitionKey
      type wrapper, instead of passing a bare String around.

      This allows the compiler to type check & verify usage of the partition key,
      instead of passing a bare string around. By reference counting the underlying
      string, we reduce memory usage for some use cases.