### PR TITLE
refactor: add partition key to DmlWrite

### DIFF
--- a/data_types/src/lib.rs
+++ b/data_types/src/lib.rs
@@ -692,12 +692,14 @@ impl Display for PartitionKey {
 
 impl From<String> for PartitionKey {
     fn from(s: String) -> Self {
+        assert!(!s.is_empty());
         Self(s.into())
     }
 }
 
 impl From<&str> for PartitionKey {
     fn from(s: &str) -> Self {
+        assert!(!s.is_empty());
         Self(s.into())
     }
 }

--- a/influxdb_iox_client/src/client/write.rs
+++ b/influxdb_iox_client/src/client/write.rs
@@ -62,7 +62,7 @@ impl Client {
             .map_err(|e| Error::Client(Box::new(e)))?;
 
         let meta = dml::DmlMeta::unsequenced(None);
-        let write = dml::DmlWrite::new(db_name.as_ref().to_string(), tables, meta);
+        let write = dml::DmlWrite::new(db_name.as_ref().to_string(), tables, None, meta);
         let lines = write.tables().map(|(_, table)| table.rows()).sum();
 
         let database_batch = mutable_batch_pb::encode::encode_write(db_name.as_ref(), &write);

--- a/ingester/src/data.rs
+++ b/ingester/src/data.rs
@@ -1717,6 +1717,7 @@ mod tests {
         let w1 = DmlWrite::new(
             "foo",
             lines_to_batches("mem foo=1 10", 0).unwrap(),
+            Some("1970-01-01".into()),
             DmlMeta::sequenced(
                 Sequence::new(1, SequenceNumber::new(1)),
                 ignored_ts,
@@ -1810,6 +1811,7 @@ mod tests {
         let w1 = DmlWrite::new(
             "foo",
             lines_to_batches("mem foo=1 10", 0).unwrap(),
+            Some("1970-01-01".into()),
             DmlMeta::sequenced(
                 Sequence::new(1, SequenceNumber::new(1)),
                 ignored_ts,
@@ -1825,6 +1827,7 @@ mod tests {
         let w2 = DmlWrite::new(
             "foo",
             lines_to_batches("cpu foo=1 10", 1).unwrap(),
+            Some("1970-01-01".into()),
             DmlMeta::sequenced(
                 Sequence::new(2, SequenceNumber::new(1)),
                 ignored_ts,
@@ -1842,6 +1845,7 @@ mod tests {
         let w3 = DmlWrite::new(
             "foo",
             lines_to_batches("mem foo=1 30", 2).unwrap(),
+            Some("1970-01-01".into()),
             DmlMeta::sequenced(
                 Sequence::new(1, SequenceNumber::new(2)),
                 ignored_ts,
@@ -2004,6 +2008,7 @@ mod tests {
         let w1 = DmlWrite::new(
             "foo",
             lines_to_batches("mem foo=1 10", 0).unwrap(),
+            Some("1970-01-01".into()),
             DmlMeta::sequenced(
                 Sequence::new(1, SequenceNumber::new(1)),
                 ignored_ts,
@@ -2020,6 +2025,7 @@ mod tests {
         let w2 = DmlWrite::new(
             "foo",
             lines_to_batches("mem foo=1 30\ncpu bar=1 20", 0).unwrap(),
+            Some("1970-01-01".into()),
             DmlMeta::sequenced(
                 Sequence::new(1, SequenceNumber::new(2)),
                 ignored_ts,
@@ -2362,6 +2368,7 @@ mod tests {
         let w1 = DmlWrite::new(
             "foo",
             lines_to_batches("mem foo=1 10", 0).unwrap(),
+            Some("1970-01-01".into()),
             DmlMeta::sequenced(
                 Sequence::new(1, SequenceNumber::new(1)),
                 ignored_ts,
@@ -2372,6 +2379,7 @@ mod tests {
         let w2 = DmlWrite::new(
             "foo",
             lines_to_batches("mem foo=1 10", 0).unwrap(),
+            Some("1970-01-01".into()),
             DmlMeta::sequenced(
                 Sequence::new(1, SequenceNumber::new(2)),
                 ignored_ts,
@@ -2544,6 +2552,7 @@ mod tests {
         let w1 = DmlWrite::new(
             "foo",
             lines_to_batches("mem foo=1 10", 0).unwrap(),
+            Some("1970-01-01".into()),
             DmlMeta::sequenced(
                 Sequence::new(1, SequenceNumber::new(1)),
                 ignored_ts,

--- a/ingester/src/handler.rs
+++ b/ingester/src/handler.rs
@@ -407,6 +407,7 @@ mod tests {
         let w1 = DmlWrite::new(
             "foo",
             lines_to_batches("mem foo=1 10", 0).unwrap(),
+            Some("1970-01-01".into()),
             DmlMeta::sequenced(
                 Sequence::new(0, SequenceNumber::new(0)),
                 ingest_ts1,
@@ -422,6 +423,7 @@ mod tests {
         let w2 = DmlWrite::new(
             "foo",
             lines_to_batches("cpu bar=2 20\ncpu bar=3 30", 0).unwrap(),
+            Some("1970-01-01".into()),
             DmlMeta::sequenced(
                 Sequence::new(0, SequenceNumber::new(7)),
                 ingest_ts2,
@@ -437,6 +439,7 @@ mod tests {
         let w3 = DmlWrite::new(
             "foo",
             lines_to_batches("a b=2 200", 0).unwrap(),
+            Some("1970-01-01".into()),
             DmlMeta::sequenced(
                 Sequence::new(0, SequenceNumber::new(9)),
                 ingest_ts2,
@@ -730,6 +733,7 @@ mod tests {
             DmlWrite::new(
                 "foo",
                 lines_to_batches("cpu bar=2 20", 0).unwrap(),
+                Some("1970-01-01".into()),
                 DmlMeta::sequenced(
                     Sequence::new(0, SequenceNumber::new(1)),
                     ingest_ts1,
@@ -740,6 +744,7 @@ mod tests {
             DmlWrite::new(
                 "foo",
                 lines_to_batches("cpu bar=2 30", 0).unwrap(),
+                Some("1970-01-01".into()),
                 DmlMeta::sequenced(
                     Sequence::new(0, SequenceNumber::new(2)),
                     ingest_ts2,
@@ -781,6 +786,7 @@ mod tests {
         let write_operations = vec![DmlWrite::new(
             "foo",
             lines_to_batches("cpu bar=2 20", 0).unwrap(),
+            Some("1970-01-01".into()),
             DmlMeta::sequenced(
                 Sequence::new(0, SequenceNumber::new(1)),
                 ingest_ts1,

--- a/ingester/src/stream_handler/handler.rs
+++ b/ingester/src/stream_handler/handler.rs
@@ -466,7 +466,7 @@ mod tests {
             None,
             42,
         );
-        DmlWrite::new(name, tables, sequence)
+        DmlWrite::new(name, tables, Some("1970-01-01".into()), sequence)
     }
 
     // Return a DmlDelete with the given namespace.

--- a/ingester/src/stream_handler/sink_instrumentation.rs
+++ b/ingester/src/stream_handler/sink_instrumentation.rs
@@ -267,7 +267,7 @@ mod tests {
     /// Return a DmlWrite with the given metadata and a single table.
     fn make_write(meta: DmlMeta) -> DmlWrite {
         let tables = lines_to_batches("bananas level=42 4242", 0).unwrap();
-        DmlWrite::new("bananas", tables, meta)
+        DmlWrite::new("bananas", tables, None, meta)
     }
 
     /// Extract the metric with the given name from `metrics`.

--- a/ioxd_common/src/http/dml.rs
+++ b/ioxd_common/src/http/dml.rs
@@ -231,7 +231,7 @@ pub trait HttpDrivenDml: ServerType {
             "inserting lines into database",
         );
 
-        let write = DmlWrite::new(&db_name, tables, DmlMeta::unsequenced(span_ctx));
+        let write = DmlWrite::new(&db_name, tables, None, DmlMeta::unsequenced(span_ctx));
 
         match self.write(&db_name, DmlOperation::Write(write)).await {
             Ok(_) => {
@@ -447,6 +447,7 @@ pub mod test_utils {
         DmlWrite::new(
             "MyOrg_MyBucket",
             lines_to_batches(lp_data, 0).unwrap(),
+            None,
             Default::default(),
         )
     }
@@ -483,6 +484,7 @@ pub mod test_utils {
         DmlWrite::new(
             "MyOrg_MyBucket",
             lines_to_batches(lp_data, 0).unwrap(),
+            None,
             Default::default(),
         )
     }
@@ -571,6 +573,7 @@ pub mod test_utils {
                 DmlWrite::new(
                     "MyOrg_MyBucket",
                     lines_to_batches(lp, 0).unwrap(),
+                    None,
                     Default::default(),
                 )
             })

--- a/mutable_batch/src/payload.rs
+++ b/mutable_batch/src/payload.rs
@@ -1,7 +1,7 @@
 //! Write payload abstractions derived from [`MutableBatch`]
 
 use crate::{column::ColumnData, MutableBatch, Result};
-use data_types::PartitionTemplate;
+use data_types::{PartitionKey, PartitionTemplate};
 use hashbrown::HashMap;
 use schema::TIME_COLUMN_NAME;
 use std::{num::NonZeroUsize, ops::Range};
@@ -102,7 +102,7 @@ impl<'a> PartitionWrite<'a> {
         table_name: &str,
         batch: &'a MutableBatch,
         partition_template: &PartitionTemplate,
-    ) -> HashMap<String, Self> {
+    ) -> HashMap<PartitionKey, Self> {
         use hashbrown::hash_map::Entry;
         let time = get_time_column(batch);
 
@@ -112,7 +112,7 @@ impl<'a> PartitionWrite<'a> {
             let row_count = NonZeroUsize::new(range.end - range.start).unwrap();
             let (min_timestamp, max_timestamp) = min_max_time(&time[range.clone()]);
 
-            match partition_ranges.entry(partition) {
+            match partition_ranges.entry(PartitionKey::from(partition)) {
                 Entry::Vacant(v) => {
                     v.insert(PartitionWrite {
                         batch,

--- a/mutable_batch_pb/tests/encode.rs
+++ b/mutable_batch_pb/tests/encode.rs
@@ -134,7 +134,7 @@ fn test_encode_decode_null_columns_issue_4272() {
     // Round-trip the "1970-01-01" partition
     let mut got = MutableBatch::default();
     partitions
-        .remove("1970-01-01")
+        .remove(&"1970-01-01".into())
         .expect("partition not found")
         .write_to_batch(&mut got)
         .expect("should write");
@@ -156,7 +156,7 @@ fn test_encode_decode_null_columns_issue_4272() {
     // And finally assert the "1970-07-05" round-trip
     let mut got = MutableBatch::default();
     partitions
-        .remove("1970-07-05")
+        .remove(&"1970-07-05".into())
         .expect("partition not found")
         .write_to_batch(&mut got)
         .expect("should write");

--- a/mutable_batch_tests/benches/write_pb.rs
+++ b/mutable_batch_tests/benches/write_pb.rs
@@ -12,7 +12,12 @@ fn generate_pbdata_bytes() -> Vec<(String, (usize, Bytes))> {
         .into_iter()
         .map(|(bench, lp)| {
             let batches = lines_to_batches(&lp, 0).unwrap();
-            let write = DmlWrite::new("test_db", batches, Default::default());
+            let write = DmlWrite::new(
+                "test_db",
+                batches,
+                Some("bananas".into()),
+                Default::default(),
+            );
             let database_batch = mutable_batch_pb::encode::encode_write("db", &write);
 
             let mut bytes = BytesMut::new();

--- a/query_tests/src/scenarios/util.rs
+++ b/query_tests/src/scenarios/util.rs
@@ -784,6 +784,7 @@ impl MockIngester {
         let op = DmlOperation::Write(DmlWrite::new(
             self.ns.namespace.name.clone(),
             mutable_batches,
+            None,
             meta,
         ));
         (op, partition_ids)

--- a/router/src/dml_handlers/sharded_write_buffer.rs
+++ b/router/src/dml_handlers/sharded_write_buffer.rs
@@ -115,7 +115,12 @@ where
         }
 
         let iter = collated.into_iter().map(|(sequencer, batch)| {
-            let dml = DmlWrite::new(namespace, batch, DmlMeta::unsequenced(span_ctx.clone()));
+            let dml = DmlWrite::new(
+                namespace,
+                batch,
+                Some(partition_key.clone()),
+                DmlMeta::unsequenced(span_ctx.clone()),
+            );
 
             trace!(
                 %partition_key,

--- a/router/src/dml_handlers/sharded_write_buffer.rs
+++ b/router/src/dml_handlers/sharded_write_buffer.rs
@@ -216,7 +216,7 @@ mod tests {
     fn lp_to_writes(lp: &str) -> Partitioned<HashMap<String, MutableBatch>> {
         let (writes, _) = mutable_batch_lp::lines_to_batches_stats(lp, 42)
             .expect("failed to build test writes from LP");
-        Partitioned::new("key".to_owned(), writes)
+        Partitioned::new("key".into(), writes)
     }
 
     // Init a mock write buffer with the given number of sequencers.

--- a/write_buffer/src/codec.rs
+++ b/write_buffer/src/codec.rs
@@ -196,6 +196,8 @@ pub fn decode(
                     Ok(DmlOperation::Write(DmlWrite::new(
                         headers.namespace,
                         tables,
+                        // TODO(3603): propagate partition key through kafka
+                        None,
                         meta,
                     )))
                 }

--- a/write_buffer/src/file.rs
+++ b/write_buffer/src/file.rs
@@ -836,10 +836,42 @@ mod tests {
         let entry_3 = "upc,region=east user=3 300";
         let entry_4 = "upc,region=east user=4 400";
 
-        let w1 = write(&ctx.database_name, &writer, entry_1, sequencer_id, None).await;
-        let w2 = write(&ctx.database_name, &writer, entry_2, sequencer_id, None).await;
-        let w3 = write(&ctx.database_name, &writer, entry_3, sequencer_id, None).await;
-        let w4 = write(&ctx.database_name, &writer, entry_4, sequencer_id, None).await;
+        let w1 = write(
+            &ctx.database_name,
+            &writer,
+            entry_1,
+            sequencer_id,
+            None,
+            None,
+        )
+        .await;
+        let w2 = write(
+            &ctx.database_name,
+            &writer,
+            entry_2,
+            sequencer_id,
+            None,
+            None,
+        )
+        .await;
+        let w3 = write(
+            &ctx.database_name,
+            &writer,
+            entry_3,
+            sequencer_id,
+            None,
+            None,
+        )
+        .await;
+        let w4 = write(
+            &ctx.database_name,
+            &writer,
+            entry_4,
+            sequencer_id,
+            None,
+            None,
+        )
+        .await;
 
         remove_entry(
             &ctx.path,
@@ -874,8 +906,24 @@ mod tests {
         let entry_1 = "upc,region=east user=1 100";
         let entry_2 = "upc,region=east user=2 200";
 
-        let w1 = write(&ctx.database_name, &writer, entry_1, sequencer_id, None).await;
-        let w2 = write(&ctx.database_name, &writer, entry_2, sequencer_id, None).await;
+        let w1 = write(
+            &ctx.database_name,
+            &writer,
+            entry_1,
+            sequencer_id,
+            None,
+            None,
+        )
+        .await;
+        let w2 = write(
+            &ctx.database_name,
+            &writer,
+            entry_2,
+            sequencer_id,
+            None,
+            None,
+        )
+        .await;
 
         remove_entry(
             &ctx.path,

--- a/write_buffer/src/kafka/aggregator.rs
+++ b/write_buffer/src/kafka/aggregator.rs
@@ -151,7 +151,7 @@ impl WriteAggregator {
         };
 
         let meta = DmlMeta::unsequenced(ctx);
-        DmlWrite::new(self.namespace.clone(), self.tables.clone(), meta)
+        DmlWrite::new(self.namespace.clone(), self.tables.clone(), None, meta)
     }
 }
 

--- a/write_buffer/src/kafka/mod.rs
+++ b/write_buffer/src/kafka/mod.rs
@@ -535,6 +535,7 @@ mod tests {
             "table foo=1 1",
             sequencer_id,
             None,
+            None,
         )
         .await;
 
@@ -682,7 +683,12 @@ mod tests {
     ) -> DmlMeta {
         let span_ctx = SpanContext::new(Arc::clone(trace_collector) as Arc<_>);
         let tables = mutable_batch_lp::lines_to_batches("table foo=1", 0).unwrap();
-        let write = DmlWrite::new(namespace, tables, DmlMeta::unsequenced(Some(span_ctx)));
+        let write = DmlWrite::new(
+            namespace,
+            tables,
+            None,
+            DmlMeta::unsequenced(Some(span_ctx)),
+        );
         let op = DmlOperation::Write(write);
         producer.store_operation(sequencer_id, &op).await.unwrap()
     }

--- a/write_buffer/src/mock.rs
+++ b/write_buffer/src/mock.rs
@@ -170,7 +170,7 @@ impl MockBufferSharedState {
     pub fn push_lp(&self, sequence: Sequence, lp: &str) {
         let tables = mutable_batch_lp::lines_to_batches(lp, 0).unwrap();
         let meta = DmlMeta::sequenced(sequence, iox_time::Time::from_timestamp_nanos(0), None, 0);
-        self.push_write(DmlWrite::new("foo", tables, meta))
+        self.push_write(DmlWrite::new("foo", tables, None, meta))
     }
 
     /// Push error to specified sequencer.
@@ -684,7 +684,12 @@ mod tests {
         let state =
             MockBufferSharedState::empty_with_n_sequencers(NonZeroU32::try_from(2).unwrap());
         let tables = lines_to_batches("upc user=1 100", 0).unwrap();
-        state.push_write(DmlWrite::new("test_db", tables, DmlMeta::unsequenced(None)));
+        state.push_write(DmlWrite::new(
+            "test_db",
+            tables,
+            None,
+            DmlMeta::unsequenced(None),
+        ));
     }
 
     #[test]
@@ -848,7 +853,8 @@ mod tests {
         let writer = MockBufferForWritingThatAlwaysErrors {};
 
         let tables = lines_to_batches("upc user=1 100", 0).unwrap();
-        let operation = DmlOperation::Write(DmlWrite::new("test_db", tables, Default::default()));
+        let operation =
+            DmlOperation::Write(DmlWrite::new("test_db", tables, None, Default::default()));
 
         assert_contains!(
             writer


### PR DESCRIPTION
This change allows us to propagate the derived partition key through the system, but stops short of passing it over the kafka boundary - I'll follow up with another PR to add this shortly (tracked in #3603).

Prerequisite for fixing https://github.com/influxdata/influxdb_iox/issues/4787.

---

* refactor: emit PartitionKey from partitioner (61182f506)

      Changes the partitioning code to emit a PartitionKey, instead of a bare 
      String.

* refactor: always generate a partition key (0da8ec87d)

      Changes the partitioner to always generate a partition key, even if the column
      being used to partition doesn't exist. This doesn't functionally change the
      batch partitioning output, but ensures we always have a non-empty string for
      the partition key.

* refactor: store PartitionKey in DmlWrite (4df296456)

      Carry the PartitionKey in the DmlWrite, allowing the batch to be associated
      with a specific partition key.

