### PR TITLE
fix: respect partition key when batching dml ops

### DIFF
--- a/write_buffer/src/core.rs
+++ b/write_buffer/src/core.rs
@@ -372,14 +372,14 @@ pub mod test_utils {
         writer: &impl WriteBufferWriting,
         lp: &str,
         sequencer_id: u32,
-        partition_key: Option<PartitionKey>,
+        partition_key: PartitionKey,
         span_context: Option<&SpanContext>,
     ) -> DmlWrite {
         let tables = mutable_batch_lp::lines_to_batches(lp, 0).unwrap();
         let write = DmlWrite::new(
             namespace,
             tables,
-            partition_key,
+            Some(partition_key),
             DmlMeta::unsequenced(span_context.cloned()),
         );
         let operation = DmlOperation::Write(write);
@@ -431,7 +431,7 @@ pub mod test_utils {
             &writer,
             entry_1,
             sequencer_id,
-            Some(PartitionKey::from("bananas")),
+            PartitionKey::from("bananas"),
             None,
         )
         .await;
@@ -441,13 +441,21 @@ pub mod test_utils {
         assert_stream_pending(&mut stream).await;
 
         // adding more data unblocks the stream
-        let w2 = write("namespace", &writer, entry_2, sequencer_id, None, None).await;
+        let w2 = write(
+            "namespace",
+            &writer,
+            entry_2,
+            sequencer_id,
+            PartitionKey::from("bananas"),
+            None,
+        )
+        .await;
         let w3 = write(
             "namespace",
             &writer,
             entry_3,
             sequencer_id,
-            Some(PartitionKey::from("bananas")),
+            PartitionKey::from("bananas"),
             None,
         )
         .await;
@@ -478,9 +486,33 @@ pub mod test_utils {
         let writer = context.writing(true).await.unwrap();
         let reader = context.reading(true).await.unwrap();
 
-        let w1 = write("namespace", &writer, entry_1, 0, None, None).await;
-        let w2 = write("namespace", &writer, entry_2, 0, None, None).await;
-        let w3 = write("namespace", &writer, entry_3, 0, None, None).await;
+        let w1 = write(
+            "namespace",
+            &writer,
+            entry_1,
+            0,
+            PartitionKey::from("bananas"),
+            None,
+        )
+        .await;
+        let w2 = write(
+            "namespace",
+            &writer,
+            entry_2,
+            0,
+            PartitionKey::from("bananas"),
+            None,
+        )
+        .await;
+        let w3 = write(
+            "namespace",
+            &writer,
+            entry_3,
+            0,
+            PartitionKey::from("bananas"),
+            None,
+        )
+        .await;
 
         // creating stream, drop stream, re-create it => still starts at first entry
         let sequencer_id = set_pop_first(&mut reader.sequencer_ids()).unwrap();
@@ -552,7 +584,7 @@ pub mod test_utils {
             &writer,
             entry_1,
             sequencer_id_1,
-            Some(PartitionKey::from("bananas")),
+            PartitionKey::from("bananas"),
             None,
         )
         .await;
@@ -564,7 +596,7 @@ pub mod test_utils {
             &writer,
             entry_2,
             sequencer_id_2,
-            Some(PartitionKey::from("bananas")),
+            PartitionKey::from("bananas"),
             None,
         )
         .await;
@@ -576,7 +608,7 @@ pub mod test_utils {
             &writer,
             entry_3,
             sequencer_id_1,
-            Some(PartitionKey::from("bananas")),
+            PartitionKey::from("bananas"),
             None,
         )
         .await;
@@ -623,7 +655,7 @@ pub mod test_utils {
             &writer_1,
             entry_east_1,
             sequencer_id_1,
-            None,
+            PartitionKey::from("bananas"),
             None,
         )
         .await;
@@ -632,7 +664,7 @@ pub mod test_utils {
             &writer_1,
             entry_west_1,
             sequencer_id_2,
-            None,
+            PartitionKey::from("bananas"),
             None,
         )
         .await;
@@ -641,7 +673,7 @@ pub mod test_utils {
             &writer_2,
             entry_east_2,
             sequencer_id_1,
-            None,
+            PartitionKey::from("bananas"),
             None,
         )
         .await;
@@ -687,7 +719,7 @@ pub mod test_utils {
             &writer,
             entry_east_1,
             sequencer_id_1,
-            None,
+            PartitionKey::from("bananas"),
             None,
         )
         .await;
@@ -696,7 +728,7 @@ pub mod test_utils {
             &writer,
             entry_east_2,
             sequencer_id_1,
-            None,
+            PartitionKey::from("bananas"),
             None,
         )
         .await;
@@ -705,7 +737,7 @@ pub mod test_utils {
             &writer,
             entry_west_1,
             sequencer_id_2,
-            None,
+            PartitionKey::from("bananas"),
             None,
         )
         .await;
@@ -744,7 +776,15 @@ pub mod test_utils {
             .seek(SequenceNumber::new(1_000_000))
             .await
             .unwrap();
-        let w_east_3 = write("namespace", &writer, entry_east_3, 0, None, None).await;
+        let w_east_3 = write(
+            "namespace",
+            &writer,
+            entry_east_3,
+            0,
+            PartitionKey::from("bananas"),
+            None,
+        )
+        .await;
 
         let err = handler_1_1_a
             .stream()
@@ -794,7 +834,7 @@ pub mod test_utils {
             &writer,
             entry_east_1,
             sequencer_id_1,
-            None,
+            PartitionKey::from("bananas"),
             None,
         )
         .await;
@@ -803,7 +843,7 @@ pub mod test_utils {
             &writer,
             entry_east_2,
             sequencer_id_1,
-            None,
+            PartitionKey::from("bananas"),
             None,
         )
         .await;
@@ -867,7 +907,7 @@ pub mod test_utils {
             &writer,
             entry_east_1,
             sequencer_id_1,
-            None,
+            PartitionKey::from("bananas"),
             None,
         )
         .await;
@@ -876,7 +916,7 @@ pub mod test_utils {
             &writer,
             entry_east_2,
             sequencer_id_1,
-            None,
+            PartitionKey::from("bananas"),
             None,
         )
         .await;
@@ -885,7 +925,7 @@ pub mod test_utils {
             &writer,
             entry_west_1,
             sequencer_id_2,
-            None,
+            PartitionKey::from("bananas"),
             None,
         )
         .await;
@@ -924,7 +964,15 @@ pub mod test_utils {
         assert_eq!(sequencer_ids.len(), 1);
         let sequencer_id = set_pop_first(&mut sequencer_ids).unwrap();
 
-        let write = write("namespace", &writer, entry, sequencer_id, None, None).await;
+        let write = write(
+            "namespace",
+            &writer,
+            entry,
+            sequencer_id,
+            PartitionKey::from("bananas"),
+            None,
+        )
+        .await;
         let reported_ts = write.meta().producer_ts().unwrap();
 
         // advance time
@@ -1014,7 +1062,15 @@ pub mod test_utils {
         let mut stream = handler.stream().await;
 
         // 1: no context
-        write("namespace", &writer, entry, sequencer_id, None, None).await;
+        write(
+            "namespace",
+            &writer,
+            entry,
+            sequencer_id,
+            PartitionKey::from("bananas"),
+            None,
+        )
+        .await;
 
         // check write 1
         let write_1 = stream.next().await.unwrap().unwrap();
@@ -1031,7 +1087,7 @@ pub mod test_utils {
             &writer,
             entry,
             sequencer_id,
-            None,
+            PartitionKey::from("bananas"),
             Some(&span_context_1),
         )
         .await;
@@ -1044,7 +1100,7 @@ pub mod test_utils {
             &writer,
             entry,
             sequencer_id,
-            None,
+            PartitionKey::from("bananas"),
             Some(&span_context_2),
         )
         .await;
@@ -1106,8 +1162,24 @@ pub mod test_utils {
         assert_eq!(sequencer_ids.len(), 1);
         let sequencer_id = set_pop_first(&mut sequencer_ids).unwrap();
 
-        let w1 = write("namespace_1", &writer, entry_2, sequencer_id, None, None).await;
-        let w2 = write("namespace_2", &writer, entry_1, sequencer_id, None, None).await;
+        let w1 = write(
+            "namespace_1",
+            &writer,
+            entry_2,
+            sequencer_id,
+            PartitionKey::from("bananas"),
+            None,
+        )
+        .await;
+        let w2 = write(
+            "namespace_2",
+            &writer,
+            entry_1,
+            sequencer_id,
+            PartitionKey::from("bananas"),
+            None,
+        )
+        .await;
 
         let mut handler = reader.stream_handler(sequencer_id).await.unwrap();
         assert_reader_content(&mut handler, &[&w1, &w2]).await;
@@ -1133,7 +1205,15 @@ pub mod test_utils {
                 async move {
                     let entry = format!("upc,region=east user={} {}", i, i);
 
-                    write("ns", writer.as_ref(), &entry, sequencer_id, None, None).await;
+                    write(
+                        "ns",
+                        writer.as_ref(),
+                        &entry,
+                        sequencer_id,
+                        PartitionKey::from("bananas"),
+                        None,
+                    )
+                    .await;
                 }
             })
             .collect();

--- a/write_buffer/src/file.rs
+++ b/write_buffer/src/file.rs
@@ -732,6 +732,7 @@ pub mod test_utils {
 mod tests {
     use std::{num::NonZeroU32, time::Duration};
 
+    use data_types::PartitionKey;
     use dml::test_util::assert_write_op_eq;
     use tempfile::TempDir;
     use trace::RingBufferTraceCollector;
@@ -841,7 +842,7 @@ mod tests {
             &writer,
             entry_1,
             sequencer_id,
-            None,
+            PartitionKey::from("bananas"),
             None,
         )
         .await;
@@ -850,7 +851,7 @@ mod tests {
             &writer,
             entry_2,
             sequencer_id,
-            None,
+            PartitionKey::from("bananas"),
             None,
         )
         .await;
@@ -859,7 +860,7 @@ mod tests {
             &writer,
             entry_3,
             sequencer_id,
-            None,
+            PartitionKey::from("bananas"),
             None,
         )
         .await;
@@ -868,7 +869,7 @@ mod tests {
             &writer,
             entry_4,
             sequencer_id,
-            None,
+            PartitionKey::from("bananas"),
             None,
         )
         .await;
@@ -911,7 +912,7 @@ mod tests {
             &writer,
             entry_1,
             sequencer_id,
-            None,
+            PartitionKey::from("bananas"),
             None,
         )
         .await;
@@ -920,7 +921,7 @@ mod tests {
             &writer,
             entry_2,
             sequencer_id,
-            None,
+            PartitionKey::from("bananas"),
             None,
         )
         .await;


### PR DESCRIPTION
This PR fixes #4787.

The router is hard-coded to [partition writes by YMD][scheme] (meaning a partition per day, today's being `2022-06-16`), breaking the writes into a single [DML write request per partition][router-partition]. The router then dispatches each of these partitioned DML writes into kafka via the write buffer abstraction.

On the other side of kafka, the ingester reads these messages and uses the same hard-coded partitioning scheme to [infer the partition key][ingest] of the batch. This inference solution was a temporary workaround until OG was deprecated and removed, which made changing the kafka message format feasible (#3603). 

Correctness of this scheme relies on the atomicity of the DML batches being preserved through the system - a batch is split up by the router according to the partition rules, and then sent to the ingester which uses the same logic to infer it.

Unfortunately the kafka write buffer client (and _only the kafka impl_...) [merges together DML operations][agg] before writing the resulting merged batch to kafka. This undid the partitioning the router performed by glueing together independent, per partition DML ops without respecting the partitioning, causing one DML op to contain many distinct partitions. This would lead to the ingester incorrectly inferring the partition key for the batch which would contain data for multiple desired partitions. This caused both the per-partition catalog metadata, and actual resulting parquet files to incorrectly contain data for multiple partitions.

This led to at least 902,241 partitions which broke the "writes for one day" invariant after being merged together with writes for different dates.

## Further work

* Affected partitions need to be fixed, or removed. This includes both the catalog references, and the parquet files.
* Pass the derived partition key over the API boundary (from router -> ingester) removing the need for inference (follow-up PR incoming!)
* Reconsider the DML aggregation strategy:
  * Aggregation should occur "above" the kafka client - aggregating should be independent of the client used, both for consistency across all write buffer impls, and separation of concerns. This made debugging much harder as it didn't happen when using the all-in-one mode, nor did any unit tests trigger the issue as there is no aggregation for the mock impl used in tests.
  * Consider preserving the individual DML ops, but batching them up (effectively `Vec<DmlOp>` rather than merging them into a single `DmlOp`). The potential loss of compression is likely to be negligible, but both the impl & mental model would be much simpler.


[router-partition]:https://github.com/influxdata/influxdb_iox/blob/43b3f224116f5a886ec7c77e70ed479f21721a17/router/src/dml_handlers/partitioner.rs#L76-L98
[scheme]:https://github.com/influxdata/influxdb_iox/blob/43b3f224116f5a886ec7c77e70ed479f21721a17/ioxd_router/src/lib.rs#L198
[ingest]:https://github.com/influxdata/influxdb_iox/blob/43b3f224116f5a886ec7c77e70ed479f21721a17/ingester/src/partioning.rs#L25-L39
[agg]:https://github.com/influxdata/influxdb_iox/blob/43b3f224116f5a886ec7c77e70ed479f21721a17/write_buffer/src/kafka/aggregator.rs#L128-L147
---

* fix: respect partition key when batching dml ops (43b3f2241)

      This commit changes the kafka write aggregator to only merge DML ops destined
      for the same partition.

      Prior to this commit the aggregator was merging DML ops that had different
      partition keys, causing data to be persisted in incorrect partitions:

          https://github.com/influxdata/influxdb_iox/issues/4787