### PR TITLE
fix: Pause ingester if `persist` can't keep up with ingest

### DIFF
--- a/ingester/src/lifecycle.rs
+++ b/ingester/src/lifecycle.rs
@@ -101,12 +101,13 @@ impl LifecycleHandle for LifecycleHandleImpl {
         // This is designed to protect the ingester from OOMing by
         // when partitions have higher write throughput than persist
         // throughput (e.g. during a long recovery when data in kafka
-        // is plentify or if there is something about a particular
+        // is plentiful or if there is something about a particular
         // persist operation that is abnormally slow).
         //
-        // We pause all ingest if *any* partition exceeds its limit
-        // because persists happen in batches so *no* new persist will
-        // start until outstanding persists are complete.
+        // We pause all ingest if *any* partition exceeds its limit whilst there
+        // is an ongoing persist operation, because persists happen in batches
+        // so *no* new persist will start until outstanding persists are
+        // complete.
         //
         // More details: https://github.com/influxdata/influxdb_iox/issues/4928
         if partition_bytes_written > self.config.partition_size_threshold
@@ -120,7 +121,7 @@ impl LifecycleHandle for LifecycleHandleImpl {
             return true;
         }
 
-        // can keep consummng
+        // can keep consuming
         false
     }
 
@@ -537,7 +538,7 @@ impl LifecycleManager {
         }
     }
 
-    /// Removes the partition from the state and marks it peristing
+    /// Removes the partition from the state and marks it persisting
     fn mark_persisting(&self, partition_id: PartitionId) {
         let mut s = self.state.lock();
         s.remove(&partition_id);

--- a/ingester/src/lifecycle.rs
+++ b/ingester/src/lifecycle.rs
@@ -648,12 +648,12 @@ mod tests {
     }
 
     /// This persister will pause after persist is called
-    struct PausiblePersister {
+    struct PausablePersister {
         inner: TestPersister,
         events: Mutex<BTreeMap<PartitionId, EventBarrier>>,
     }
 
-    impl PausiblePersister {
+    impl PausablePersister {
         fn new() -> Self {
             Self {
                 inner: TestPersister::default(),
@@ -663,7 +663,7 @@ mod tests {
     }
 
     #[async_trait]
-    impl Persister for PausiblePersister {
+    impl Persister for PausablePersister {
         async fn persist(&self, partition_id: PartitionId) {
             self.inner.persist(partition_id).await;
             if let Some(event) = self.event(partition_id) {
@@ -683,7 +683,7 @@ mod tests {
         }
     }
 
-    impl PausiblePersister {
+    impl PausablePersister {
         fn inner(&self) -> &TestPersister {
             &self.inner
         }
@@ -975,7 +975,7 @@ mod tests {
         let state = Arc::clone(&m.state);
 
         let partition_id = PartitionId::new(1);
-        let persister = Arc::new(PausiblePersister::new());
+        let persister = Arc::new(PausablePersister::new());
         persister.pause_next(partition_id);
 
         // write 7 bytes (over the 5 limit) which should trigger a persist

--- a/ingester/src/lifecycle.rs
+++ b/ingester/src/lifecycle.rs
@@ -53,6 +53,9 @@ pub struct LifecycleHandleImpl {
 }
 
 impl LifecycleHandle for LifecycleHandleImpl {
+
+    /// Updates the LifecycleManager's internal state to account for
+    /// `bytes_written` were ingested to `partition_id`
     fn log_write(
         &self,
         partition_id: PartitionId,
@@ -336,7 +339,7 @@ impl LifecycleManager {
         }
 
         // for the sequencers that are getting data persisted, keep track of what
-        // the highest seqeunce number was for each.
+        // the highest sequence number was for each.
         let mut sequencer_maxes = BTreeMap::new();
         for s in &to_persist {
             sequencer_maxes


### PR DESCRIPTION
# Rationale
Closes https://github.com/influxdata/influxdb_iox/issues/4928

There are times (during replay especially) that we saw the ingester ingesting faster than the `persist` operation could keep up (perhaps due to https://github.com/influxdata/influxdb_iox/issues/4886). If this continues unabated eventually the ingester will be OOM killed (due to out of memory) as each persist gets bigger.

This meant that even after setting `INFLUXDB_IOX_PERSIST_PARTITION_SIZE_THRESHOLD_BYTES` to limit the maximum size of an individual persist operation, we were persisting larger partitions -- see here for an example https://github.com/influxdata/conductor/issues/980#issuecomment-1159094137

Bonus is that this doesn't require any new knobs

# Changes:
Pause ingest if any partition exceeds the `INFLUXDB_IOX_PERSIST_PARTITION_SIZE_THRESHOLD_BYTES` setting while a persist to that same partition is underway

# Expected change in behavior:
1. There should be fewer OOM errors in production, and we can increase the overall "ingest pause" threshold to get more memory bufferd
2. The ingester will pause more frequently (especially when recovering large periods of time)

