### PR TITLE
fix: ensure panic is propagated throw `AdapterStream`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1290,6 +1290,7 @@ dependencies = [
  "futures",
  "observability_deps",
  "pin-project",
+ "schema",
  "tokio",
  "tokio-stream",
  "workspace-hack",

--- a/datafusion_util/Cargo.toml
+++ b/datafusion_util/Cargo.toml
@@ -13,3 +13,6 @@ pin-project = "1.0"
 tokio = { version = "1.19", features = ["parking_lot", "sync"] }
 tokio-stream = "0.1"
 workspace-hack = { path = "../workspace-hack"}
+
+[dev-dependencies]
+schema = { path = "../schema" }


### PR DESCRIPTION
Prior to this change background tasks that we feed into `AdapterStream`
can panic but that would just end the stream without any user-visible
error (except for the panic message on stdout/stderr).