### PR TITLE
fix: optimize tag_keys to go only to schema when predicate is empty

### DIFF
--- a/predicate/src/rpc_predicate.rs
+++ b/predicate/src/rpc_predicate.rs
@@ -6,9 +6,9 @@ mod value_rewrite;
 
 use crate::{rewrite, Predicate};
 
-use datafusion::common::ScalarValue;
 use datafusion::error::{DataFusionError, Result as DataFusionResult};
 use datafusion::execution::context::ExecutionProps;
+use datafusion::logical_expr::lit;
 use datafusion::logical_plan::{
     Column, Expr, ExprSchema, ExprSchemable, ExprSimplifiable, SimplifyInfo,
 };
@@ -202,7 +202,7 @@ fn normalize_predicate(
         // Filter out literal true so is_empty works correctly
         .filter(|f| match f {
             Err(_) => true,
-            Ok(expr) => !expr.eq(&Expr::Literal(ScalarValue::Boolean(Option::Some(true)))),
+            Ok(expr) => (*expr) != lit(true),
         })
         .collect::<DataFusionResult<Vec<_>>>()?;
 

--- a/query_tests/src/influxrpc/tag_keys.rs
+++ b/query_tests/src/influxrpc/tag_keys.rs
@@ -170,7 +170,7 @@ async fn list_tag_name_end_to_end() {
 }
 
 #[tokio::test]
-async fn list_tag_name_end_to_end_with_delete_pred() {
+async fn list_tag_name_end_to_end_with_delete_and_pred() {
     let predicate = Predicate::default()
         .with_range(0, 10000)
         .with_expr(col("host").eq(lit("server01")));
@@ -181,10 +181,9 @@ async fn list_tag_name_end_to_end_with_delete_pred() {
 
 #[tokio::test]
 async fn list_tag_name_end_to_end_with_delete() {
-    let predicate = Predicate::default()
-        .with_expr(col("_measurement").eq(lit("swap")));
+    let predicate = Predicate::default().with_expr(col("_measurement").eq(lit("swap")));
     let predicate = InfluxRpcPredicate::new(None, predicate);
-    let expected_tag_keys = vec![];
+    let expected_tag_keys = vec!["host", "name"];
     run_tag_keys_test_case(EndToEndTestWithDelete {}, predicate, expected_tag_keys).await;
 }
 

--- a/query_tests/src/influxrpc/tag_keys.rs
+++ b/query_tests/src/influxrpc/tag_keys.rs
@@ -170,12 +170,21 @@ async fn list_tag_name_end_to_end() {
 }
 
 #[tokio::test]
-async fn list_tag_name_end_to_end_with_delete() {
+async fn list_tag_name_end_to_end_with_delete_pred() {
     let predicate = Predicate::default()
         .with_range(0, 10000)
         .with_expr(col("host").eq(lit("server01")));
     let predicate = InfluxRpcPredicate::new(None, predicate);
     let expected_tag_keys = vec!["host", "region"];
+    run_tag_keys_test_case(EndToEndTestWithDelete {}, predicate, expected_tag_keys).await;
+}
+
+#[tokio::test]
+async fn list_tag_name_end_to_end_with_delete() {
+    let predicate = Predicate::default()
+        .with_expr(col("_measurement").eq(lit("swap")));
+    let predicate = InfluxRpcPredicate::new(None, predicate);
+    let expected_tag_keys = vec![];
     run_tag_keys_test_case(EndToEndTestWithDelete {}, predicate, expected_tag_keys).await;
 }
 

--- a/query_tests/src/scenarios/library.rs
+++ b/query_tests/src/scenarios/library.rs
@@ -721,7 +721,7 @@ impl DbSetup for EndToEndTestWithDelete {
         let partition_key = "1970-01-01T00";
 
         // pred: delete from swap where 6000 <= time <= 6000 and name=disk0
-        // 1 rows of h2o with timestamp 250 will be deleted
+        // 1 rows of swap with name=disk0 will be deleted
         let delete_table_name = "swap";
         let pred = DeletePredicate {
             range: TimestampRange::new(6000, 6000),

--- a/service_grpc_influxrpc/src/expr.rs
+++ b/service_grpc_influxrpc/src/expr.rs
@@ -873,7 +873,7 @@ fn format_comparison(v: i32, f: &mut fmt::Formatter<'_>) -> fmt::Result {
 #[cfg(test)]
 mod tests {
     use generated_types::node::Type as RPCNodeType;
-    use predicate::{rpc_predicate::QueryDatabaseMeta, Predicate};
+    use predicate::{rpc_predicate::QueryDatabaseMeta, Predicate, EMPTY_PREDICATE};
     use std::{collections::BTreeSet, sync::Arc};
 
     use super::*;
@@ -1021,12 +1021,12 @@ mod tests {
         let predicate = table_predicate(predicate);
 
         // predicate is rewritten to true (which is simplified to an empty predicate list), and projection is added
-        let expected_exprs: Vec<Expr> = vec![];
+        // but, the table schema is not specified in the test, so the projection is also empty.
 
         assert_eq!(
-            &expected_exprs, &predicate.exprs,
+            predicate, EMPTY_PREDICATE,
             "expected '{:#?}' doesn't match actual '{:#?}'",
-            expected_exprs, predicate.exprs,
+            predicate, EMPTY_PREDICATE,
         );
     }
 

--- a/service_grpc_influxrpc/src/expr.rs
+++ b/service_grpc_influxrpc/src/expr.rs
@@ -1020,8 +1020,8 @@ mod tests {
             .build();
         let predicate = table_predicate(predicate);
 
-        // predicate is rewritten to true, and projection is added
-        let expected_exprs = vec![lit(true)];
+        // predicate is rewritten to true (which is simplified to an empty predicate list), and projection is added
+        let expected_exprs: Vec<Expr> = vec![];
 
         assert_eq!(
             &expected_exprs, &predicate.exprs,

--- a/service_grpc_influxrpc/src/service.rs
+++ b/service_grpc_influxrpc/src/service.rs
@@ -1726,7 +1726,8 @@ mod tests {
         // ---
         let request = TagKeysRequest {
             tags_source: source.clone(),
-            range: None,
+            // add some time range or predicate, otherwise we do a pure metadata lookup
+            range: Some(make_timestamp_range(150, 200)),
             predicate: None,
         };
 
@@ -1814,7 +1815,7 @@ mod tests {
 
         let db_info = org_and_bucket();
 
-        // predicate specifies m4, so this is filtered out
+        // predicate specifies m5
         let chunk = TestChunk::new("m5").with_error("This is an error");
 
         fixture
@@ -1831,7 +1832,8 @@ mod tests {
         let request = MeasurementTagKeysRequest {
             measurement: "m5".into(),
             source: source.clone(),
-            range: None,
+            // add some time range or predicate, otherwise we do a pure metadata lookup
+            range: Some(make_timestamp_range(150, 200)),
             predicate: None,
         };
 


### PR DESCRIPTION
Helps #4827 

When the predicate is empty (note `_measurement = "foo"` and `time range all time` predicates are simplified away), satisfy tag_keys queries from the metadata store instead of reading all the parquet data.

This means deletes are not honoured for this query.

- [x] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb_iox/blob/main/README.md).
