### PR TITLE
feat: extract timestamp predicates from generic expressions

### DIFF
--- a/data_types/src/lib.rs
+++ b/data_types/src/lib.rs
@@ -2085,6 +2085,13 @@ impl TimestampRange {
     pub fn start(&self) -> i64 {
         self.start
     }
+
+    /// Intersect with another range.
+    pub fn intersect(&self, other: &Self) -> Self {
+        let start = self.start.max(other.start);
+        let end = self.end.min(other.end).max(start);
+        Self::new(start, end)
+    }
 }
 
 /// Specifies a min/max timestamp value.
@@ -3220,5 +3227,37 @@ mod tests {
     #[should_panic(expected = "start (2) > end (1)")]
     fn test_timestamprange_invalid() {
         TimestampRange::new(2, 1);
+    }
+
+    #[test]
+    fn test_timestamprange_intersect() {
+        assert_eq!(
+            TimestampRange::new(13, 42).intersect(&TimestampRange::new(13, 42)),
+            TimestampRange::new(13, 42),
+        );
+        assert_eq!(
+            TimestampRange::new(13, 42).intersect(&TimestampRange::new(20, 25)),
+            TimestampRange::new(20, 25),
+        );
+        assert_eq!(
+            TimestampRange::new(20, 25).intersect(&TimestampRange::new(13, 42)),
+            TimestampRange::new(20, 25),
+        );
+        assert_eq!(
+            TimestampRange::new(13, 20).intersect(&TimestampRange::new(20, 42)),
+            TimestampRange::new(20, 20),
+        );
+        assert_eq!(
+            TimestampRange::new(20, 42).intersect(&TimestampRange::new(13, 20)),
+            TimestampRange::new(20, 20),
+        );
+        assert_eq!(
+            TimestampRange::new(13, 20).intersect(&TimestampRange::new(25, 42)),
+            TimestampRange::new(25, 25),
+        );
+        assert_eq!(
+            TimestampRange::new(25, 42).intersect(&TimestampRange::new(13, 20)),
+            TimestampRange::new(25, 25),
+        );
     }
 }

--- a/data_types/src/lib.rs
+++ b/data_types/src/lib.rs
@@ -2050,12 +2050,19 @@ pub const MAX_NANO_TIME: i64 = i64::MAX - 1;
 pub struct TimestampRange {
     /// Start defines the inclusive lower bound. Minimum value is [MIN_NANO_TIME]
     start: i64,
-    /// End defines the inclusive upper bound. Maximum value is [MAX_NANO_TIME]
+    /// End defines the exclusive upper bound. Maximum value is [MAX_NANO_TIME]
     end: i64,
 }
 
 impl TimestampRange {
-    /// Create a new TimestampRange. Clamps to MIN_NANO_TIME/MAX_NANO_TIME.
+    /// Create a new TimestampRange.
+    ///
+    /// Takes an inclusive start and an exclusive end. You may create an empty range by setting `start = end`.
+    ///
+    /// Clamps to [`MIN_NANO_TIME`]/[`MAX_NANO_TIME`].
+    ///
+    /// # Panic
+    /// Panics if `start > end`.
     pub fn new(start: i64, end: i64) -> Self {
         debug_assert!(end >= start);
         let start = start.max(MIN_NANO_TIME);
@@ -2069,12 +2076,12 @@ impl TimestampRange {
         self.start <= v && v < self.end
     }
 
-    /// Return the timestamp range's end.
+    /// Return the timestamp exclusive range's end.
     pub fn end(&self) -> i64 {
         self.end
     }
 
-    /// Return the timestamp range's start.
+    /// Return the timestamp inclusive range's start.
     pub fn start(&self) -> i64 {
         self.start
     }
@@ -2083,7 +2090,7 @@ impl TimestampRange {
 /// Specifies a min/max timestamp value.
 ///
 /// Note this differs subtlety (but critically) from a
-/// `TimestampRange` as the minimum and maximum values are included
+/// [`TimestampRange`] as the minimum and maximum values are included ([`TimestampRange`] has an exclusive end).
 #[derive(Clone, Debug, Copy)]
 pub struct TimestampMinMax {
     /// The minimum timestamp value

--- a/data_types/src/lib.rs
+++ b/data_types/src/lib.rs
@@ -2064,7 +2064,7 @@ impl TimestampRange {
     /// # Panic
     /// Panics if `start > end`.
     pub fn new(start: i64, end: i64) -> Self {
-        debug_assert!(end >= start);
+        assert!(end >= start, "start ({start}) > end ({end})");
         let start = start.max(MIN_NANO_TIME);
         let end = end.min(MAX_NANO_TIME);
         Self { start, end }
@@ -3214,5 +3214,11 @@ mod tests {
     #[should_panic = "set contains duplicates"]
     fn test_column_set_duplicates() {
         ColumnSet::new(["foo", "bar", "foo"]);
+    }
+
+    #[test]
+    #[should_panic(expected = "start (2) > end (1)")]
+    fn test_timestamprange_invalid() {
+        TimestampRange::new(2, 1);
     }
 }


### PR DESCRIPTION
Includes #4994.

Found while working on #4976.

It turns out that most of our chunk filtering looks at the timestamp
ranges within `Predicate`. While this if filled for InfluxRPC queries,
we don't have this information for SQL queries.

I see two ways to fix that:

- **Advanced Chunk Filter:** Teach our chunks to evaluate generic
  datafusion expressions. This would have the advantage that we don't
  rely on IOx-specific magic too much. On the other hand, I am unsure
  how much complexity that would require.
- **Lower Generic Expressions for IOx:** Try to scan datfusion
  expressions for simple timestamp filters. Perform this conversion
  early (i.e. when building `Predicate`) so that all chunks can use
  simple timestamp lookups.

Here I try the 2nd approach. Tests are missing for now, since this is
rather an RFC.
