### PR TITLE
feat: add compaction_level0_candidate_file_count config param

### DIFF
--- a/clap_blocks/src/compactor.rs
+++ b/clap_blocks/src/compactor.rs
@@ -80,4 +80,14 @@ pub struct CompactorConfig {
         action
     )]
     pub compaction_max_desired_file_size_bytes: i64,
+
+    /// Limit the number of chose partition candidates level-0 parquet files
+    /// Default is 1000 (Only supported Postgres)
+    #[clap(
+        long = "--compaction-level0-candidate-file-count",
+        env = "INFLUXDB_IOX_COMPACTION_LEVEL0_CANDIDATE_FILE_COUNT",
+        default_value = "1000",
+        action
+    )]
+    pub compaction_level0_candidate_file_count: i64,
 }

--- a/compactor/src/compact.rs
+++ b/compactor/src/compact.rs
@@ -271,7 +271,11 @@ impl Compactor {
         }
     }
 
-    async fn level_0_parquet_files(&self, sequencer_id: SequencerId, compaction_level0_candidate_file_count: i64) -> Result<Vec<ParquetFile>> {
+    async fn level_0_parquet_files(
+        &self,
+        sequencer_id: SequencerId,
+        compaction_level0_candidate_file_count: i64,
+    ) -> Result<Vec<ParquetFile>> {
         let mut repos = self.catalog.repositories().await;
 
         repos
@@ -307,12 +311,17 @@ impl Compactor {
     /// Returns a list of partitions that have level 0 files to compact along with some summary
     /// statistics that the scheduler can use to decide which partitions to prioritize. Orders
     /// them by the number of level 0 files and then size.
-    pub async fn partitions_to_compact(&self, compaction_level0_candidate_file_count: i64) -> Result<Vec<PartitionCompactionCandidate>> {
+    pub async fn partitions_to_compact(
+        &self,
+        compaction_level0_candidate_file_count: i64,
+    ) -> Result<Vec<PartitionCompactionCandidate>> {
         let mut candidates = vec![];
 
         for sequencer_id in &self.sequencers {
             // Read level-0 parquet files
-            let level_0_files = self.level_0_parquet_files(*sequencer_id, compaction_level0_candidate_file_count).await?;
+            let level_0_files = self
+                .level_0_parquet_files(*sequencer_id, compaction_level0_candidate_file_count)
+                .await?;
 
             let mut partitions = BTreeMap::new();
             for f in level_0_files {
@@ -3951,7 +3960,10 @@ mod tests {
             Arc::new(metric::Registry::new()),
         );
 
-        let candidates = compactor.partitions_to_compact(compaction_level0_candidate_file_count).await.unwrap();
+        let candidates = compactor
+            .partitions_to_compact(compaction_level0_candidate_file_count)
+            .await
+            .unwrap();
         let expect: Vec<PartitionCompactionCandidate> = vec![
             PartitionCompactionCandidate {
                 sequencer_id: sequencer.id,

--- a/compactor/src/compact.rs
+++ b/compactor/src/compact.rs
@@ -2027,6 +2027,7 @@ mod tests {
         let compaction_max_size_bytes = 100000;
         let compaction_max_file_count = 10;
         let compaction_max_desired_file_size_bytes = 30000;
+        let compaction_level0_candidate_file_count = 1000;
         let compactor = Compactor::new(
             vec![sequencer.sequencer.id],
             Arc::clone(&catalog.catalog),
@@ -2041,6 +2042,7 @@ mod tests {
                 compaction_max_size_bytes,
                 compaction_max_file_count,
                 compaction_max_desired_file_size_bytes,
+                compaction_level0_candidate_file_count,
             ),
             Arc::new(metric::Registry::new()),
         );

--- a/compactor/src/handler.rs
+++ b/compactor/src/handler.rs
@@ -185,10 +185,13 @@ impl CompactorConfig {
 /// next top partitions to compact.
 async fn run_compactor(compactor: Arc<Compactor>, shutdown: CancellationToken) {
     while !shutdown.is_cancelled() {
-        let compaction_level0_candidate_file_count = compactor.config.compaction_level0_candidate_file_count();
+        let compaction_level0_candidate_file_count =
+            compactor.config.compaction_level0_candidate_file_count();
         let candidates = Backoff::new(&compactor.backoff_config)
             .retry_all_errors("partitions_to_compact", || async {
-                compactor.partitions_to_compact(compaction_level0_candidate_file_count).await
+                compactor
+                    .partitions_to_compact(compaction_level0_candidate_file_count)
+                    .await
             })
             .await
             .expect("retry forever");

--- a/influxdb_iox/src/commands/run/all_in_one.rs
+++ b/influxdb_iox/src/commands/run/all_in_one.rs
@@ -397,6 +397,7 @@ impl Config {
             compaction_max_size_bytes: 100000,
             compaction_max_file_count: 10,
             compaction_max_desired_file_size_bytes: 30000,
+            compaction_level0_candidate_file_count: 1000,
         };
 
         let querier_config = QuerierConfig {

--- a/iox_catalog/src/interface.rs
+++ b/iox_catalog/src/interface.rs
@@ -531,7 +531,7 @@ pub trait ParquetFileRepo: Send + Sync {
 
     /// List parquet files for a given sequencer with compaction level 0 and other criteria that
     /// define a file as a candidate for compaction
-    async fn level_0(&mut self, sequencer_id: SequencerId) -> Result<Vec<ParquetFile>>;
+    async fn level_0(&mut self, sequencer_id: SequencerId, compaction_level0_candidate_file_count: i64) -> Result<Vec<ParquetFile>>;
 
     /// List parquet files for a given table partition, in a given time range, with compaction
     /// level 2, and other criteria that define a file as a candidate for compaction with a level 0
@@ -2314,7 +2314,7 @@ pub(crate) mod test_helpers {
 
         // Level 0 parquet files for a sequencer should contain only those that match the right
         // criteria
-        let level_0 = repos.parquet_files().level_0(sequencer.id).await.unwrap();
+        let level_0 = repos.parquet_files().level_0(sequencer.id, 1000).await.unwrap();
         let mut level_0_ids: Vec<_> = level_0.iter().map(|pf| pf.id).collect();
         level_0_ids.sort();
         let expected = vec![parquet_file];
@@ -2724,7 +2724,7 @@ pub(crate) mod test_helpers {
 
         // Level 0 parquet files should contain both existing files at this point
         let expected = vec![parquet_file.clone(), level_0_file.clone()];
-        let level_0 = repos.parquet_files().level_0(sequencer.id).await.unwrap();
+        let level_0 = repos.parquet_files().level_0(sequencer.id, 1000).await.unwrap();
         let mut level_0_ids: Vec<_> = level_0.iter().map(|pf| pf.id).collect();
         level_0_ids.sort();
         let mut expected_ids: Vec<_> = expected.iter().map(|pf| pf.id).collect();
@@ -2746,7 +2746,7 @@ pub(crate) mod test_helpers {
 
         // Level 0 parquet files should only contain level_0_file
         let expected = vec![level_0_file];
-        let level_0 = repos.parquet_files().level_0(sequencer.id).await.unwrap();
+        let level_0 = repos.parquet_files().level_0(sequencer.id, 1000).await.unwrap();
         let mut level_0_ids: Vec<_> = level_0.iter().map(|pf| pf.id).collect();
         level_0_ids.sort();
         let mut expected_ids: Vec<_> = expected.iter().map(|pf| pf.id).collect();

--- a/iox_catalog/src/interface.rs
+++ b/iox_catalog/src/interface.rs
@@ -531,7 +531,11 @@ pub trait ParquetFileRepo: Send + Sync {
 
     /// List parquet files for a given sequencer with compaction level 0 and other criteria that
     /// define a file as a candidate for compaction
-    async fn level_0(&mut self, sequencer_id: SequencerId, compaction_level0_candidate_file_count: i64) -> Result<Vec<ParquetFile>>;
+    async fn level_0(
+        &mut self,
+        sequencer_id: SequencerId,
+        compaction_level0_candidate_file_count: i64,
+    ) -> Result<Vec<ParquetFile>>;
 
     /// List parquet files for a given table partition, in a given time range, with compaction
     /// level 2, and other criteria that define a file as a candidate for compaction with a level 0
@@ -2314,7 +2318,11 @@ pub(crate) mod test_helpers {
 
         // Level 0 parquet files for a sequencer should contain only those that match the right
         // criteria
-        let level_0 = repos.parquet_files().level_0(sequencer.id, 1000).await.unwrap();
+        let level_0 = repos
+            .parquet_files()
+            .level_0(sequencer.id, 1000)
+            .await
+            .unwrap();
         let mut level_0_ids: Vec<_> = level_0.iter().map(|pf| pf.id).collect();
         level_0_ids.sort();
         let expected = vec![parquet_file];
@@ -2724,7 +2732,11 @@ pub(crate) mod test_helpers {
 
         // Level 0 parquet files should contain both existing files at this point
         let expected = vec![parquet_file.clone(), level_0_file.clone()];
-        let level_0 = repos.parquet_files().level_0(sequencer.id, 1000).await.unwrap();
+        let level_0 = repos
+            .parquet_files()
+            .level_0(sequencer.id, 1000)
+            .await
+            .unwrap();
         let mut level_0_ids: Vec<_> = level_0.iter().map(|pf| pf.id).collect();
         level_0_ids.sort();
         let mut expected_ids: Vec<_> = expected.iter().map(|pf| pf.id).collect();
@@ -2746,7 +2758,11 @@ pub(crate) mod test_helpers {
 
         // Level 0 parquet files should only contain level_0_file
         let expected = vec![level_0_file];
-        let level_0 = repos.parquet_files().level_0(sequencer.id, 1000).await.unwrap();
+        let level_0 = repos
+            .parquet_files()
+            .level_0(sequencer.id, 1000)
+            .await
+            .unwrap();
         let mut level_0_ids: Vec<_> = level_0.iter().map(|pf| pf.id).collect();
         level_0_ids.sort();
         let mut expected_ids: Vec<_> = expected.iter().map(|pf| pf.id).collect();

--- a/iox_catalog/src/mem.rs
+++ b/iox_catalog/src/mem.rs
@@ -1064,7 +1064,11 @@ impl ParquetFileRepo for MemTxn {
         Ok(delete)
     }
 
-    async fn level_0(&mut self, sequencer_id: SequencerId, _compaction_level0_candidate_file_count: i64) -> Result<Vec<ParquetFile>> {
+    async fn level_0(
+        &mut self,
+        sequencer_id: SequencerId,
+        _compaction_level0_candidate_file_count: i64,
+    ) -> Result<Vec<ParquetFile>> {
         let stage = self.stage();
 
         Ok(stage

--- a/iox_catalog/src/mem.rs
+++ b/iox_catalog/src/mem.rs
@@ -1064,7 +1064,7 @@ impl ParquetFileRepo for MemTxn {
         Ok(delete)
     }
 
-    async fn level_0(&mut self, sequencer_id: SequencerId) -> Result<Vec<ParquetFile>> {
+    async fn level_0(&mut self, sequencer_id: SequencerId, _compaction_level0_candidate_file_count: i64) -> Result<Vec<ParquetFile>> {
         let stage = self.stage();
 
         Ok(stage

--- a/iox_catalog/src/metrics.rs
+++ b/iox_catalog/src/metrics.rs
@@ -271,7 +271,7 @@ decorate!(
         "parquet_list_by_table_not_to_delete" = list_by_table_not_to_delete(&mut self, table_id: TableId) -> Result<Vec<ParquetFile>>;
         "parquet_delete_old" = delete_old(&mut self, older_than: Timestamp) -> Result<Vec<ParquetFile>>;
         "parquet_list_by_partition_not_to_delete" = list_by_partition_not_to_delete(&mut self, partition_id: PartitionId) -> Result<Vec<ParquetFile>>;
-        "parquet_level_0" = level_0(&mut self, sequencer_id: SequencerId) -> Result<Vec<ParquetFile>>;
+        "parquet_level_0" = level_0(&mut self, sequencer_id: SequencerId, compaction_level0_candidate_file_count: i64) -> Result<Vec<ParquetFile>>;
         "parquet_level_2" = level_2(&mut self, table_partition: TablePartition, min_time: Timestamp, max_time: Timestamp) -> Result<Vec<ParquetFile>>;
         "parquet_update_to_level_2" = update_to_level_2(&mut self, parquet_file_ids: &[ParquetFileId]) -> Result<Vec<ParquetFileId>>;
         "parquet_exist" = exist(&mut self, id: ParquetFileId) -> Result<bool>;

--- a/iox_catalog/src/postgres.rs
+++ b/iox_catalog/src/postgres.rs
@@ -1621,7 +1621,11 @@ RETURNING *;
         .map_err(|e| Error::SqlxError { source: e })
     }
 
-    async fn level_0(&mut self, sequencer_id: SequencerId, compaction_level0_candidate_file_count: i64) -> Result<Vec<ParquetFile>> {
+    async fn level_0(
+        &mut self,
+        sequencer_id: SequencerId,
+        compaction_level0_candidate_file_count: i64,
+    ) -> Result<Vec<ParquetFile>> {
         // this intentionally limits the returned files to 10,000 as it is used to make
         // a decision on the highest priority partitions. If compaction has never been
         // run this could end up returning millions of results and taking too long to run.

--- a/iox_tests/src/util.rs
+++ b/iox_tests/src/util.rs
@@ -179,7 +179,7 @@ impl TestCatalog {
             .repositories()
             .await
             .parquet_files()
-            .level_0(sequencer_id)
+            .level_0(sequencer_id, 1000)
             .await
             .unwrap()
     }
@@ -191,7 +191,7 @@ impl TestCatalog {
             .repositories()
             .await
             .parquet_files()
-            .level_0(sequencer_id)
+            .level_0(sequencer_id, 1000)
             .await
             .unwrap();
         level_0.len()

--- a/ioxd_compactor/src/lib.rs
+++ b/ioxd_compactor/src/lib.rs
@@ -169,6 +169,7 @@ pub async fn create_compactor_server_type(
         compactor_config.compaction_max_size_bytes,
         compactor_config.compaction_max_file_count,
         compactor_config.compaction_max_desired_file_size_bytes,
+        compactor_config.compaction_level0_candidate_file_count,
     );
     let compactor_handler = Arc::new(CompactorHandlerImpl::new(
         sequencers,


### PR DESCRIPTION
Helps #4940


[Design Doc](https://docs.google.com/document/d/1bN2_HMBKeCNoKms1H4xXQPjq_dQFU1sy5EcpBD9dETE/edit#) that Chose Partition Candidates 1.


The default of compaction_level0_candidate_file_count is 1000 (Only supported Postgres).


- [x] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb_iox/blob/main/README.md).
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
