### PR TITLE
fix: Correctly set up querier-to-ingester config, sequencers, and catalog for all-in-one ephemeral mode

### DIFF
--- a/clap_blocks/src/catalog_dsn.rs
+++ b/clap_blocks/src/catalog_dsn.rs
@@ -175,7 +175,7 @@ impl CatalogDsnConfig {
                 let mem = MemCatalog::new(metrics);
 
                 let mut txn = mem.start_transaction().await.context(CatalogSnafu)?;
-                create_or_get_default_records(2, txn.deref_mut())
+                create_or_get_default_records(1, txn.deref_mut())
                     .await
                     .context(CatalogSnafu)?;
                 txn.commit().await.context(CatalogSnafu)?;

--- a/influxdb_iox/tests/end_to_end_cases/all_in_one.rs
+++ b/influxdb_iox/tests/end_to_end_cases/all_in_one.rs
@@ -17,7 +17,46 @@ async fn smoke() {
 
     // Set up all_in_one ====================================
 
-    let test_config = TestConfig::new_all_in_one(database_url);
+    let test_config = TestConfig::new_all_in_one(Some(database_url));
+
+    let all_in_one = ServerFixture::create(test_config).await;
+
+    // Write some data into the v2 HTTP API ==============
+    let lp = format!("{},tag1=A,tag2=B val=42i 123456", table_name);
+
+    let response = write_to_router(lp, org, bucket, all_in_one.router_http_base()).await;
+
+    // wait for data to be persisted to parquet
+    assert_eq!(response.status(), StatusCode::NO_CONTENT);
+    let write_token = get_write_token(&response);
+    wait_for_persisted(write_token, all_in_one.querier_grpc_connection()).await;
+
+    // run query
+    let sql = format!("select * from {}", table_name);
+    let batches = run_query(sql, namespace, all_in_one.querier_grpc_connection()).await;
+
+    let expected = [
+        "+------+------+--------------------------------+-----+",
+        "| tag1 | tag2 | time                           | val |",
+        "+------+------+--------------------------------+-----+",
+        "| A    | B    | 1970-01-01T00:00:00.000123456Z | 42  |",
+        "+------+------+--------------------------------+-----+",
+    ];
+    assert_batches_sorted_eq!(&expected, &batches);
+}
+
+#[tokio::test]
+async fn ephemeral_mode() {
+    test_helpers::maybe_start_logging();
+
+    let org = rand_name();
+    let bucket = rand_name();
+    let namespace = format!("{}_{}", org, bucket);
+    let table_name = "test_table";
+
+    // Set up all_in_one ====================================
+
+    let test_config = TestConfig::new_all_in_one(None);
 
     let all_in_one = ServerFixture::create(test_config).await;
 

--- a/influxdb_iox/tests/end_to_end_cases/metrics.rs
+++ b/influxdb_iox/tests/end_to_end_cases/metrics.rs
@@ -5,7 +5,7 @@ use test_helpers_end_to_end::{
 #[tokio::test]
 pub async fn test_metrics() {
     let database_url = maybe_skip_integration!();
-    let test_config = TestConfig::new_all_in_one(database_url);
+    let test_config = TestConfig::new_all_in_one(Some(database_url));
     let mut cluster = MiniCluster::create_all_in_one(test_config).await;
 
     let lp = DataGenerator::new().line_protocol().to_owned();
@@ -41,7 +41,7 @@ pub async fn test_jemalloc_metrics() {
     use test_helpers::assert_contains;
 
     let database_url = maybe_skip_integration!();
-    let test_config = TestConfig::new_all_in_one(database_url);
+    let test_config = TestConfig::new_all_in_one(Some(database_url));
     let mut cluster = MiniCluster::create_all_in_one(test_config).await;
 
     StepTest::new(

--- a/influxdb_iox/tests/end_to_end_cases/tracing.rs
+++ b/influxdb_iox/tests/end_to_end_cases/tracing.rs
@@ -10,7 +10,7 @@ pub async fn test_tracing_sql() {
     let database_url = maybe_skip_integration!();
     let table_name = "the_table";
     let udp_capture = UdpCapture::new().await;
-    let test_config = TestConfig::new_all_in_one(database_url).with_tracing(&udp_capture);
+    let test_config = TestConfig::new_all_in_one(Some(database_url)).with_tracing(&udp_capture);
     let mut cluster = MiniCluster::create_all_in_one(test_config).await;
 
     StepTest::new(
@@ -56,7 +56,7 @@ pub async fn test_tracing_storage_api() {
     let database_url = maybe_skip_integration!();
     let table_name = "the_table";
     let udp_capture = UdpCapture::new().await;
-    let test_config = TestConfig::new_all_in_one(database_url).with_tracing(&udp_capture);
+    let test_config = TestConfig::new_all_in_one(Some(database_url)).with_tracing(&udp_capture);
     let mut cluster = MiniCluster::create_all_in_one(test_config).await;
 
     StepTest::new(
@@ -111,7 +111,7 @@ pub async fn test_tracing_create_trace() {
     let database_url = maybe_skip_integration!();
     let table_name = "the_table";
     let udp_capture = UdpCapture::new().await;
-    let test_config = TestConfig::new_all_in_one(database_url)
+    let test_config = TestConfig::new_all_in_one(Some(database_url))
         .with_tracing(&udp_capture)
         .with_tracing_debug_name("force-trace");
     let mut cluster = MiniCluster::create_all_in_one(test_config).await;


### PR DESCRIPTION
Fixes #5022.

Since https://github.com/influxdata/influxdb_iox/pull/4887, the all-in-one ephemeral mode, used by some integration tests, has been intermittently failing.

The problem was that the all-in-one mode was assuming 1 Kafka partition/sequencer in most places, but if an ephemeral in-memory catalog was being used, `create_or_get_default_records` was making 2 sequencer records in the catalog. That meant the router was sharding using 1 shard, and the querier was sharding using the 2 shards in the catalog (but only had 1 sequencer -> ingester mapping configured). If the querier happened to shard the query to the same shard the router used, everything worked fine, but if the querier sharded to the other shard, the query would error.

The `create_or_get_default_records` method was also starting the Kafka Partition IDs at 1, when the rest of the all-in-one setup was assuming the IDs start at 0.

Most people using all-in-one mode locally, as well as production, are using a postgres catalog that's already set up, so we haven't been hitting these issues.

This PR also adds a test for this situation directly.