### PR TITLE
hack: ignore input to ingester (NOT FOR MERGING) 

### DIFF
--- a/ingester/src/stream_handler/sink_adaptor.rs
+++ b/ingester/src/stream_handler/sink_adaptor.rs
@@ -33,9 +33,12 @@ impl IngestSinkAdaptor {
 
 #[async_trait]
 impl DmlSink for IngestSinkAdaptor {
-    async fn apply(&self, op: DmlOperation) -> Result<bool, crate::data::Error> {
-        self.ingest_data
-            .buffer_operation(self.sequencer_id, op, &self.lifecycle_handle)
-            .await
+    async fn apply(&self, _op: DmlOperation) -> Result<bool, crate::data::Error> {
+        // Simply ignore the operation
+        Ok(false)
+
+        // self.ingest_data
+        //     .buffer_operation(self.sequencer_id, op, &self.lifecycle_handle)
+        //     .await
     }
 }


### PR DESCRIPTION
re https://github.com/influxdata/conductor/issues/971

This PR changes the IOx code to read/decode data from kafka and throw it away (rather than actually try to write it into the IngestrData). It is not intended to merge, but as a way to try 

I want to use this as a way to confirm/deny where the slowdown is occurring in the ingester (aka is it bottlenecked reading from kafka or is it bottlenecked processing the messages)
