### PR TITLE
fix: Sync ReadWindowAggregate API: TagKeyMetaNames

### DIFF
--- a/generated_types/protos/influxdata/platform/storage/storage_common.proto
+++ b/generated_types/protos/influxdata/platform/storage/storage_common.proto
@@ -64,7 +64,7 @@ message ReadGroupRequest {
 
   enum Group {
     // option (gogoproto.goproto_enum_prefix) = false;
-    
+
     // GroupNone returns all series as a single group.
     // The single GroupFrame.TagKeys will be the union of all tag keys.
     GroupNone = 0;
@@ -81,7 +81,7 @@ message ReadGroupRequest {
   Aggregate aggregate = 6;
 
   // Deprecated field only used in TSM storage-related tests.
-  reserved "Hints"; 
+  reserved "Hints";
 }
 
 message Aggregate {
@@ -204,7 +204,7 @@ message TagKeysRequest {
 
 // TagValuesRequest is the request message for Storage.TagValues.
 message TagValuesRequest {
-  google.protobuf.Any TagsSource = 1; 
+  google.protobuf.Any TagsSource = 1;
   TimestampRange range = 2; // [(gogoproto.nullable) = false];
   Predicate predicate = 3;
   bytes tag_key = 4;
@@ -294,6 +294,9 @@ message ReadWindowAggregateRequest {
   int64 Offset = 6;
   repeated Aggregate aggregate = 5;
   Window window = 7;
+  // TagKeyMetaNames determines the key format used for the measurement and field
+  // tags.
+  TagKeyMetaNames tag_key_meta_names = 8;
 }
 
 message TagValuesGroupedByMeasurementAndTagKeyRequest {

--- a/influxdb_iox/src/commands/storage/request.rs
+++ b/influxdb_iox/src/commands/storage/request.rs
@@ -85,6 +85,7 @@ pub fn read_window_aggregate(
         offset,
         aggregate,
         window,
+        tag_key_meta_names: TagKeyMetaNames::Text as i32,
     })
 }
 

--- a/test_helpers_end_to_end/src/grpc.rs
+++ b/test_helpers_end_to_end/src/grpc.rs
@@ -5,7 +5,7 @@ use generated_types::{
     read_group_request::Group,
     Aggregate, MeasurementFieldsRequest, MeasurementNamesRequest, MeasurementTagKeysRequest,
     MeasurementTagValuesRequest, Node, Predicate, ReadFilterRequest, ReadGroupRequest, ReadSource,
-    ReadWindowAggregateRequest, TagKeysRequest, TagValuesRequest, TimestampRange,
+    ReadWindowAggregateRequest, TagKeyMetaNames, TagKeysRequest, TagValuesRequest, TimestampRange,
 };
 use prost::Message;
 
@@ -346,6 +346,7 @@ impl GrpcRequestBuilder {
             offset: self.offset.expect("no offset specified"),
             aggregate,
             window: None,
+            tag_key_meta_names: TagKeyMetaNames::Text as i32,
         })
     }
 }


### PR DESCRIPTION
The storage API has been updated in https://github.com/influxdata/idpe/pull/12868
in January, but since we forked the `.proto` files we never noticed.

Closes https://github.com/influxdata/conductor/issues/1054
