### PR TITLE
fix: interpret [MIN_NANO_TIME, MAX_NANO_TIME) range as all time

### DIFF
--- a/predicate/src/lib.rs
+++ b/predicate/src/lib.rs
@@ -220,7 +220,10 @@ impl Predicate {
     /// existing storage engine
     pub(crate) fn with_clear_timestamp_if_max_range(mut self) -> Self {
         self.range = self.range.take().and_then(|range| {
-            if range.contains_all() {
+            // FIXME(lesam): This should properly be contains_all, but until
+            // https://github.com/influxdata/idpe/issues/13094 is fixed we are more permissive
+            // about what timestamp range we consider 'all time'
+            if range.contains_nearly_all() {
                 debug!("Cleared timestamp max-range");
 
                 None

--- a/query_tests/src/influxrpc/field_columns.rs
+++ b/query_tests/src/influxrpc/field_columns.rs
@@ -92,7 +92,7 @@ async fn test_field_columns_measurement_pred() {
     // get only fields from h2o using a _measurement predicate
     let predicate = Predicate::default()
         .with_expr(col("_measurement").eq(lit("h2o")))
-        .with_range(i64::MIN, i64::MAX - 1);
+        .with_range(i64::MIN, i64::MAX - 2);
     let predicate = InfluxRpcPredicate::new(None, predicate);
 
     let expected_fields = FieldList {
@@ -283,7 +283,7 @@ async fn test_field_name_plan_with_delete_all_time() {
 
 #[tokio::test]
 async fn list_field_columns_all_time() {
-    let predicate = Predicate::default().with_range(MIN_NANO_TIME, i64::MAX);
+    let predicate = Predicate::default().with_range(MIN_NANO_TIME, MAX_NANO_TIME);
     let predicate = InfluxRpcPredicate::new(None, predicate);
 
     let expected_fields = FieldList {

--- a/service_grpc_influxrpc/src/service.rs
+++ b/service_grpc_influxrpc/src/service.rs
@@ -3034,7 +3034,7 @@ mod tests {
         let request = MeasurementFieldsRequest {
             source: source.clone(),
             measurement: "TheMeasurement".into(),
-            range: Some(make_timestamp_range(i64::MIN, i64::MAX - 1)),
+            range: Some(make_timestamp_range(i64::MIN, i64::MAX - 2)),
             predicate: None,
         };
 


### PR DESCRIPTION
(For optimized metadata queries only)

InfluxQL queries can send (technically incorrect) ranges like this, meaning all time
but excluding the max nanosecond time.

Since this is an important case, we should handle it specially and use the optimized
'all time' handling for meta queries even though this is technically wrong in that
it does not filter out column names / measurement names at MAX_NANO_TIME exactly.

Closes: https://github.com/influxdata/conductor/issues/1072

- [x] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb_iox/blob/main/README.md).
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
