### PR TITLE
feat: Compact cold partitions; upgrade a single non-overlapping level 0 file to level 1 without running compaction

### DIFF
--- a/clap_blocks/src/compactor.rs
+++ b/clap_blocks/src/compactor.rs
@@ -69,13 +69,14 @@ pub struct CompactorConfig {
     )]
     pub split_percentage: u16,
 
-    /// The compactor will limit the number of simultaneous compaction jobs based on the
-    /// size of the input files to be compacted. This number should be less than 1/10th
-    /// of the available memory to ensure compactions have
-    /// enough space to run.
-    /// Default is 1,073,741,824 bytes (1GB).
-    /// The number of compact_partititons run in parallel is determined by:
-    ///    max_concurrent_size_bytes/input_size_threshold_bytes
+    /// The compactor will limit the number of simultaneous hot partition compaction jobs based on
+    /// the size of the input files to be compacted. This number should be less than 1/10th of the
+    /// available memory to ensure compactions have enough space to run.
+    ///
+    /// Default is 1024 * 1024 * 1024 = 1,073,741,824 bytes (1GB).
+    //
+    // The number of compact_hot_partititons run in parallel is determined by:
+    //    max_concurrent_size_bytes/input_size_threshold_bytes
     #[clap(
         long = "--compaction-concurrent-size-bytes",
         env = "INFLUXDB_IOX_COMPACTION_CONCURRENT_SIZE_BYTES",
@@ -83,6 +84,22 @@ pub struct CompactorConfig {
         action
     )]
     pub max_concurrent_size_bytes: u64,
+
+    /// The compactor will limit the number of simultaneous cold partition compaction jobs based on
+    /// the size of the input files to be compacted. This number should be less than 1/10th of the
+    /// available memory to ensure compactions have enough space to run.
+    ///
+    /// Default is 1024 * 1024 * 900 = 943,718,400 bytes (900MB).
+    //
+    // The number of compact_cold_partititons run in parallel is determined by:
+    //    max_cold_concurrent_size_bytes/cold_input_size_threshold_bytes
+    #[clap(
+        long = "--compaction-cold-concurrent-size-bytes",
+        env = "INFLUXDB_IOX_COMPACTION_COLD_CONCURRENT_SIZE_BYTES",
+        default_value = "943718400",
+        action
+    )]
+    pub max_cold_concurrent_size_bytes: u64,
 
     /// Max number of partitions per sequencer we want to compact per cycle
     /// Default: 1
@@ -104,14 +121,14 @@ pub struct CompactorConfig {
     )]
     pub min_number_recent_ingested_files_per_partition: usize,
 
-    /// A compaction operation will gather as many L0 files with their overlapping L1 files to
-    /// compact together until the total size of input files crosses this threshold. Later
-    /// compactions will pick up the remaining L0 files.
+    /// A compaction operation for hot partitions will gather as many L0 files with their
+    /// overlapping L1 files to compact together until the total size of input files crosses this
+    /// threshold. Later compactions will pick up the remaining L0 files.
     ///
     /// A compaction operation will be limited by this or by the file count threshold, whichever is
     /// hit first.
     ///
-    /// Default is 1024 * 1024 * 100 = 100,048,576 (100MB).
+    /// Default is 1024 * 1024 * 100 = 100,048,576 bytes (100MB).
     #[clap(
         long = "--compaction-input-size-threshold-bytes",
         env = "INFLUXDB_IOX_COMPACTION_INPUT_SIZE_THRESHOLD_BYTES",
@@ -119,6 +136,19 @@ pub struct CompactorConfig {
         action
     )]
     pub input_size_threshold_bytes: u64,
+
+    /// A compaction operation for cold partitions will gather as many L0 files with their
+    /// overlapping L1 files to compact together until the total size of input files crosses this
+    /// threshold. Later compactions will pick up the remaining L0 files.
+    ///
+    /// Default is 1024 * 1024 * 600 = 629,145,600 bytes (600MB).
+    #[clap(
+        long = "--compaction-cold-input-size-threshold-bytes",
+        env = "INFLUXDB_IOX_COMPACTION_COLD_INPUT_SIZE_THRESHOLD_BYTES",
+        default_value = "629145600",
+        action
+    )]
+    pub cold_input_size_threshold_bytes: u64,
 
     /// A compaction operation will gather as many L0 files with their overlapping L1 files to
     /// compact together until the total number of L0 + L1 files crosses this threshold. Later

--- a/clap_blocks/src/compactor.rs
+++ b/clap_blocks/src/compactor.rs
@@ -135,4 +135,17 @@ pub struct CompactorConfig {
         action
     )]
     pub input_file_count_threshold: usize,
+
+    /// The multiple of times that compacting hot partitions should run for every one time that
+    /// compacting cold partitions runs. Set to 1 to compact hot partitions and cold partitions
+    /// equally.
+    ///
+    /// Default is 4.
+    #[clap(
+        long = "--compaction-hot-multiple",
+        env = "INFLUXDB_IOX_COMPACTION_HOT_MULTIPLE",
+        default_value = "4",
+        action
+    )]
+    pub hot_multiple: usize,
 }

--- a/compactor/src/compact.rs
+++ b/compactor/src/compact.rs
@@ -1047,28 +1047,5 @@ mod tests {
         assert_eq!(candidates[1].sequencer_id, sequencer.id);
         assert_eq!(candidates[2].partition_id, another_partition.id);
         assert_eq!(candidates[2].sequencer_id, another_sequencer.id);
-
-        // Add info to partition
-        let partitions_with_info = compactor.add_info_to_partitions(&candidates).await.unwrap();
-        assert_eq!(partitions_with_info.len(), 2);
-
-        assert_eq!(*partitions_with_info[0].namespace, namespace);
-        assert_eq!(*partitions_with_info[0].table, table);
-        assert_eq!(
-            partitions_with_info[0].partition_key,
-            partition4.partition_key
-        );
-        assert_eq!(partitions_with_info[0].sort_key, partition4.sort_key()); // this sort key is None
-
-        assert_eq!(*partitions_with_info[1].namespace, namespace);
-        assert_eq!(*partitions_with_info[1].table, another_table);
-        assert_eq!(
-            partitions_with_info[1].partition_key,
-            another_partition.partition_key
-        );
-        assert_eq!(
-            partitions_with_info[1].sort_key,
-            another_partition.sort_key()
-        ); // this sort key is Some(tag1, time)
     }
 }

--- a/compactor/src/compact.rs
+++ b/compactor/src/compact.rs
@@ -238,7 +238,7 @@ impl Compactor {
     /// * In all cases above, for each sequencer, N partitions with the most new ingested files
     ///   will be selected and the return list will include at most, P = N * S, partitions where S
     ///   is the number of sequencers this compactor handles.
-    pub async fn partitions_to_compact(
+    pub async fn hot_partitions_to_compact(
         &self,
         // Max number of the most recent highest ingested throughput partitions
         // per sequencer we want to read
@@ -582,7 +582,7 @@ mod tests {
         // --------------------------------------
         // Case 1: no files yet --> no partition candidates
         //
-        let candidates = compactor.partitions_to_compact(1, 1).await.unwrap();
+        let candidates = compactor.hot_partitions_to_compact(1, 1).await.unwrap();
         assert!(candidates.is_empty());
 
         // --------------------------------------
@@ -606,7 +606,7 @@ mod tests {
             .unwrap();
         txn.commit().await.unwrap();
         // No non-deleted level 0 files yet --> no candidates
-        let candidates = compactor.partitions_to_compact(1, 1).await.unwrap();
+        let candidates = compactor.hot_partitions_to_compact(1, 1).await.unwrap();
         assert!(candidates.is_empty());
 
         // --------------------------------------
@@ -624,7 +624,7 @@ mod tests {
         txn.commit().await.unwrap();
         //
         // Has at least one partition with a L0 file --> make it a candidate
-        let candidates = compactor.partitions_to_compact(1, 1).await.unwrap();
+        let candidates = compactor.hot_partitions_to_compact(1, 1).await.unwrap();
         assert_eq!(candidates.len(), 1);
         assert_eq!(candidates[0].partition_id, partition2.id);
 
@@ -643,7 +643,7 @@ mod tests {
         txn.commit().await.unwrap();
         //
         // Has at least one partition with a recent write --> make it a candidate
-        let candidates = compactor.partitions_to_compact(1, 1).await.unwrap();
+        let candidates = compactor.hot_partitions_to_compact(1, 1).await.unwrap();
         assert_eq!(candidates.len(), 1);
         assert_eq!(candidates[0].partition_id, partition4.id);
 
@@ -665,7 +665,7 @@ mod tests {
         txn.commit().await.unwrap();
         //
         // make partitions in the most recent group candidates
-        let candidates = compactor.partitions_to_compact(1, 1).await.unwrap();
+        let candidates = compactor.hot_partitions_to_compact(1, 1).await.unwrap();
         assert_eq!(candidates.len(), 1);
         assert_eq!(candidates[0].partition_id, partition3.id);
 
@@ -686,7 +686,7 @@ mod tests {
         txn.commit().await.unwrap();
         //
         // Will have 2 candidates, one for each sequencer
-        let mut candidates = compactor.partitions_to_compact(1, 1).await.unwrap();
+        let mut candidates = compactor.hot_partitions_to_compact(1, 1).await.unwrap();
         candidates.sort();
         assert_eq!(candidates.len(), 2);
         assert_eq!(candidates[0].partition_id, partition3.id);

--- a/compactor/src/compact.rs
+++ b/compactor/src/compact.rs
@@ -749,9 +749,11 @@ mod tests {
         let percentage_max_file_size = 30;
         let split_percentage = 80;
         let max_concurrent_size_bytes = 100_000;
+        let max_cold_concurrent_size_bytes = 90_000;
         let max_number_partitions_per_sequencer = 1;
         let min_number_recent_ingested_per_partition = 1;
         let input_size_threshold_bytes = 300 * 1024 * 1024;
+        let cold_input_size_threshold_bytes = 600 * 1024 * 1024;
         let input_file_count_threshold = 100;
         let hot_multiple = 4;
         CompactorConfig::new(
@@ -759,9 +761,11 @@ mod tests {
             percentage_max_file_size,
             split_percentage,
             max_concurrent_size_bytes,
+            max_cold_concurrent_size_bytes,
             max_number_partitions_per_sequencer,
             min_number_recent_ingested_per_partition,
             input_size_threshold_bytes,
+            cold_input_size_threshold_bytes,
             input_file_count_threshold,
             hot_multiple,
         )

--- a/compactor/src/compact.rs
+++ b/compactor/src/compact.rs
@@ -753,6 +753,7 @@ mod tests {
         let min_number_recent_ingested_per_partition = 1;
         let input_size_threshold_bytes = 300 * 1024 * 1024;
         let input_file_count_threshold = 100;
+        let hot_multiple = 4;
         CompactorConfig::new(
             max_desired_file_size_bytes,
             percentage_max_file_size,
@@ -762,6 +763,7 @@ mod tests {
             min_number_recent_ingested_per_partition,
             input_size_threshold_bytes,
             input_file_count_threshold,
+            hot_multiple,
         )
     }
 

--- a/compactor/src/handler.rs
+++ b/compactor/src/handler.rs
@@ -320,8 +320,7 @@ async fn compact_hot_partitions(compactor: Arc<Compactor>) {
     // --> num_parallel_partitions = max_concurrent_compaction_size_bytes/
     //     input_size_threshold_bytes
     let num_parallel_partitions = (compactor.config.max_concurrent_compaction_size_bytes
-        / compactor.config.input_size_threshold_bytes)
-        as usize;
+        / compactor.config.input_size_threshold_bytes) as usize;
 
     futures::stream::iter(candidates)
         .map(|p| {

--- a/compactor/src/handler.rs
+++ b/compactor/src/handler.rs
@@ -421,8 +421,6 @@ async fn compact_cold_partitions(compactor: Arc<Compactor>) {
     let n_candidates = candidates.len();
     if n_candidates == 0 {
         debug!("no cold compaction candidates found");
-        // sleep for a second to avoid a hot busy loop when the catalog is polled
-        tokio::time::sleep(PAUSE_BETWEEN_NO_WORK).await;
         return;
     } else {
         debug!(n_candidates, "found cold compaction candidates");

--- a/compactor/src/handler.rs
+++ b/compactor/src/handler.rs
@@ -129,7 +129,7 @@ pub struct CompactorConfig {
     /// The compactor will limit the number of simultaneous hot partition compaction jobs based on
     /// the size of the input files to be compacted.  This number should be less than 1/10th of the
     /// available memory to ensure compactions have enough space to run.
-    max_concurrent_compaction_size_bytes: u64,
+    max_concurrent_size_bytes: u64,
 
     /// The compactor will limit the number of simultaneous cold partition compaction jobs based on
     /// the size of the input files to be compacted. This number should be less than 1/10th of the
@@ -176,7 +176,7 @@ impl CompactorConfig {
         max_desired_file_size_bytes: u64,
         percentage_max_file_size: u16,
         split_percentage: u16,
-        max_concurrent_compaction_size_bytes: u64,
+        max_concurrent_size_bytes: u64,
         max_cold_concurrent_size_bytes: u64,
         max_number_partitions_per_sequencer: usize,
         min_number_recent_ingested_files_per_partition: usize,
@@ -191,7 +191,7 @@ impl CompactorConfig {
             max_desired_file_size_bytes,
             percentage_max_file_size,
             split_percentage,
-            max_concurrent_compaction_size_bytes,
+            max_concurrent_size_bytes,
             max_cold_concurrent_size_bytes,
             max_number_partitions_per_sequencer,
             min_number_recent_ingested_files_per_partition,
@@ -222,8 +222,8 @@ impl CompactorConfig {
     /// level 0 files, but should later also consider the level 1 files to be compacted. This
     /// number should be less than 1/10th of the available memory to ensure compactions have
     /// enough space to run.
-    pub fn max_concurrent_compaction_size_bytes(&self) -> u64 {
-        self.max_concurrent_compaction_size_bytes
+    pub fn max_concurrent_size_bytes(&self) -> u64 {
+        self.max_concurrent_size_bytes
     }
 
     /// Max number of partitions per sequencer we want to compact per cycle
@@ -345,10 +345,10 @@ async fn compact_hot_partitions(compactor: Arc<Compactor>) {
     // Concurrency level calculation (this is estimated from previous experiments. The actual
     // resource management will be more complicated and a future feature):
     //   . Each `compact partititon` takes max of this much memory input_size_threshold_bytes
-    //   . We have this memory budget: max_concurrent_compaction_size_bytes
-    // --> num_parallel_partitions = max_concurrent_compaction_size_bytes/
+    //   . We have this memory budget: max_concurrent_size_bytes
+    // --> num_parallel_partitions = max_concurrent_size_bytes/
     //     input_size_threshold_bytes
-    let num_parallel_partitions = (compactor.config.max_concurrent_compaction_size_bytes
+    let num_parallel_partitions = (compactor.config.max_concurrent_size_bytes
         / compactor.config.input_size_threshold_bytes) as usize;
 
     futures::stream::iter(candidates)

--- a/compactor/src/lib.rs
+++ b/compactor/src/lib.rs
@@ -253,7 +253,7 @@ mod tests {
         // ------------------------------------------------
         // Compact
         let candidates = compactor
-            .partitions_to_compact(
+            .hot_partitions_to_compact(
                 compactor.config.max_number_partitions_per_sequencer(),
                 compactor
                     .config

--- a/compactor/src/lib.rs
+++ b/compactor/src/lib.rs
@@ -118,6 +118,7 @@ pub(crate) async fn compact_cold_partition(
 
     let to_compact = parquet_file_filtering::filter_cold_parquet_files(
         parquet_files_for_compaction,
+        compactor.config.cold_input_size_threshold_bytes(),
         &compactor.parquet_file_candidate_gauge,
         &compactor.parquet_file_candidate_bytes_gauge,
     );
@@ -786,19 +787,24 @@ mod tests {
         let percentage_max_file_size = 30;
         let split_percentage = 80;
         let max_concurrent_size_bytes = 100_000;
+        let max_cold_concurrent_size_bytes = 90_000;
         let max_number_partitions_per_sequencer = 1;
         let min_number_recent_ingested_per_partition = 1;
         let input_size_threshold_bytes = 300 * 1024 * 1024;
+        let cold_input_size_threshold_bytes = 600 * 1024 * 1024;
         let input_file_count_threshold = 100;
         let hot_multiple = 4;
+
         CompactorConfig::new(
             max_desired_file_size_bytes,
             percentage_max_file_size,
             split_percentage,
             max_concurrent_size_bytes,
+            max_cold_concurrent_size_bytes,
             max_number_partitions_per_sequencer,
             min_number_recent_ingested_per_partition,
             input_size_threshold_bytes,
+            cold_input_size_threshold_bytes,
             input_file_count_threshold,
             hot_multiple,
         )

--- a/compactor/src/lib.rs
+++ b/compactor/src/lib.rs
@@ -790,6 +790,7 @@ mod tests {
         let min_number_recent_ingested_per_partition = 1;
         let input_size_threshold_bytes = 300 * 1024 * 1024;
         let input_file_count_threshold = 100;
+        let hot_multiple = 4;
         CompactorConfig::new(
             max_desired_file_size_bytes,
             percentage_max_file_size,
@@ -799,6 +800,7 @@ mod tests {
             min_number_recent_ingested_per_partition,
             input_size_threshold_bytes,
             input_file_count_threshold,
+            hot_multiple,
         )
     }
 }

--- a/compactor/src/lib.rs
+++ b/compactor/src/lib.rs
@@ -166,6 +166,7 @@ mod tests {
     use iox_tests::util::{TestCatalog, TestParquetFileBuilder, TestTable};
     use iox_time::{SystemProvider, TimeProvider};
     use parquet_file::{storage::ParquetStorage, ParquetFilePath};
+    use std::time::Duration;
 
     // A quite sophisticated integration test
     // Beside lp data, every value min/max sequence numbers and min/max time are important
@@ -330,6 +331,223 @@ mod tests {
         let c = candidates.pop().unwrap();
 
         compact_hot_partition(&compactor, c).await.unwrap();
+
+        // Should have 3 non-soft-deleted files:
+        //
+        // - the level 1 file that didn't overlap with anything
+        // - the two newly created after compacting and splitting pf1, pf2, pf3, pf4, pf5
+        let mut files = catalog.list_by_table_not_to_delete(table.table.id).await;
+        assert_eq!(files.len(), 3);
+        let files_and_levels: Vec<_> = files
+            .iter()
+            .map(|f| (f.id.get(), f.compaction_level))
+            .collect();
+        assert_eq!(
+            files_and_levels,
+            vec![
+                (6, CompactionLevel::FileNonOverlapped),
+                (7, CompactionLevel::FileNonOverlapped),
+                (8, CompactionLevel::FileNonOverlapped),
+            ]
+        );
+
+        // ------------------------------------------------
+        // Verify the parquet file content
+
+        // Later compacted file
+        let file1 = files.pop().unwrap();
+        let batches = read_parquet_file(&table, file1).await;
+        assert_batches_sorted_eq!(
+            &[
+                "+-----------+------+------+------+-----------------------------+",
+                "| field_int | tag1 | tag2 | tag3 | time                        |",
+                "+-----------+------+------+------+-----------------------------+",
+                "| 1600      |      | WA   | 10   | 1970-01-01T00:00:00.000028Z |",
+                "| 20        |      | VT   | 20   | 1970-01-01T00:00:00.000026Z |",
+                "| 270       | UT   |      |      | 1970-01-01T00:00:00.000025Z |",
+                "+-----------+------+------+------+-----------------------------+",
+            ],
+            &batches
+        );
+
+        // Earlier compacted file
+        let file0 = files.pop().unwrap();
+        let batches = read_parquet_file(&table, file0).await;
+        assert_batches_sorted_eq!(
+            &[
+                "+-----------+------+------+------+--------------------------------+",
+                "| field_int | tag1 | tag2 | tag3 | time                           |",
+                "+-----------+------+------+------+--------------------------------+",
+                "| 10        | VT   |      |      | 1970-01-01T00:00:00.000000020Z |",
+                "| 10        | VT   |      |      | 1970-01-01T00:00:00.000006Z    |",
+                "| 10        | VT   |      |      | 1970-01-01T00:00:00.000010Z    |",
+                "| 1000      | WA   |      |      | 1970-01-01T00:00:00.000000010Z |",
+                "| 1500      | WA   |      |      | 1970-01-01T00:00:00.000008Z    |",
+                "| 1601      |      | PA   | 15   | 1970-01-01T00:00:00.000000009Z |",
+                "| 21        |      | OH   | 21   | 1970-01-01T00:00:00.000000025Z |",
+                "| 70        | UT   |      |      | 1970-01-01T00:00:00.000020Z    |",
+                "+-----------+------+------+------+--------------------------------+",
+            ],
+            &batches
+        );
+    }
+
+    #[tokio::test]
+    async fn test_compact_cold_partition_many_files() {
+        test_helpers::maybe_start_logging();
+        let catalog = TestCatalog::new();
+
+        // lp1 does not overlap with any other level 0
+        let lp1 = vec![
+            "table,tag1=WA field_int=1000i 10",
+            "table,tag1=VT field_int=10i 20",
+        ]
+        .join("\n");
+
+        // lp2 overlaps with lp3
+        let lp2 = vec![
+            "table,tag1=WA field_int=1000i 8000", // will be eliminated due to duplicate
+            "table,tag1=VT field_int=10i 10000",
+            "table,tag1=UT field_int=70i 20000",
+        ]
+        .join("\n");
+
+        // lp3 overlaps with lp2
+        let lp3 = vec![
+            "table,tag1=WA field_int=1500i 8000", // latest duplicate and kept
+            "table,tag1=VT field_int=10i 6000",
+            "table,tag1=UT field_int=270i 25000",
+        ]
+        .join("\n");
+
+        // lp4 does not overlap with any
+        let lp4 = vec![
+            "table,tag2=WA,tag3=10 field_int=1600i 28000",
+            "table,tag2=VT,tag3=20 field_int=20i 26000",
+        ]
+        .join("\n");
+
+        // lp5 overlaps with lp1
+        let lp5 = vec![
+            "table,tag2=PA,tag3=15 field_int=1601i 9",
+            "table,tag2=OH,tag3=21 field_int=21i 25",
+        ]
+        .join("\n");
+
+        // lp6 does not overlap with any
+        let lp6 = vec![
+            "table,tag2=PA,tag3=15 field_int=81601i 90000",
+            "table,tag2=OH,tag3=21 field_int=421i 91000",
+        ]
+        .join("\n");
+
+        let ns = catalog.create_namespace("ns").await;
+        let sequencer = ns.create_sequencer(1).await;
+        let table = ns.create_table("table").await;
+        table.create_column("field_int", ColumnType::I64).await;
+        table.create_column("tag1", ColumnType::Tag).await;
+        table.create_column("tag2", ColumnType::Tag).await;
+        table.create_column("tag3", ColumnType::Tag).await;
+        table.create_column("time", ColumnType::Time).await;
+        let partition = table
+            .with_sequencer(&sequencer)
+            .create_partition("part")
+            .await;
+        let time = Arc::new(SystemProvider::new());
+        let time_38_hour_ago = (time.now() - Duration::from_secs(60 * 60 * 38)).timestamp_nanos();
+        let config = make_compactor_config();
+        let metrics = Arc::new(metric::Registry::new());
+        let compactor = Compactor::new(
+            vec![sequencer.sequencer.id],
+            Arc::clone(&catalog.catalog),
+            ParquetStorage::new(Arc::clone(&catalog.object_store)),
+            Arc::new(Executor::new(1)),
+            Arc::new(SystemProvider::new()),
+            BackoffConfig::default(),
+            config,
+            Arc::clone(&metrics),
+        );
+
+        // parquet files that are all in the same partition
+
+        // pf1 does not overlap with any other level 0
+        let builder = TestParquetFileBuilder::default()
+            .with_line_protocol(&lp1)
+            .with_max_seq(3)
+            .with_min_time(10)
+            .with_max_time(20)
+            .with_file_size_bytes(compactor.config.max_desired_file_size_bytes() + 10)
+            .with_creation_time(time_38_hour_ago);
+        partition.create_parquet_file(builder).await;
+
+        // pf2 overlaps with pf3
+        let builder = TestParquetFileBuilder::default()
+            .with_line_protocol(&lp2)
+            .with_max_seq(5)
+            .with_min_time(8_000)
+            .with_max_time(20_000)
+            .with_file_size_bytes(100) // small file
+            .with_creation_time(time_38_hour_ago);
+        partition.create_parquet_file(builder).await;
+
+        // pf3 overlaps with pf2
+        let builder = TestParquetFileBuilder::default()
+            .with_line_protocol(&lp3)
+            .with_max_seq(10)
+            .with_min_time(6_000)
+            .with_max_time(25_000)
+            .with_file_size_bytes(100) // small file
+            .with_creation_time(time_38_hour_ago);
+        partition.create_parquet_file(builder).await;
+
+        // pf4 does not overlap with any but is small
+        let builder = TestParquetFileBuilder::default()
+            .with_line_protocol(&lp4)
+            .with_max_seq(18)
+            .with_min_time(26_000)
+            .with_max_time(28_000)
+            .with_file_size_bytes(100) // small file
+            .with_creation_time(time_38_hour_ago);
+        partition.create_parquet_file(builder).await;
+
+        // pf5 was created in a previous compaction cycle; overlaps with pf1
+        let builder = TestParquetFileBuilder::default()
+            .with_line_protocol(&lp5)
+            .with_max_seq(1)
+            .with_min_time(9)
+            .with_max_time(25)
+            .with_file_size_bytes(100) // small file
+            .with_creation_time(time_38_hour_ago)
+            .with_compaction_level(CompactionLevel::FileNonOverlapped);
+        partition.create_parquet_file(builder).await;
+
+        // pf6 was created in a previous compaction cycle; does not overlap with any
+        let builder = TestParquetFileBuilder::default()
+            .with_line_protocol(&lp6)
+            .with_max_seq(20)
+            .with_min_time(90000)
+            .with_max_time(91000)
+            .with_file_size_bytes(100) // small file
+            .with_creation_time(time_38_hour_ago)
+            .with_compaction_level(CompactionLevel::FileNonOverlapped);
+        partition.create_parquet_file(builder).await;
+
+        // should have 4 level-0 files before compacting
+        let count = catalog.count_level_0_files(sequencer.sequencer.id).await;
+        assert_eq!(count, 4);
+
+        // ------------------------------------------------
+        // Compact
+        let candidates = compactor
+            .cold_partitions_to_compact(compactor.config.max_number_partitions_per_sequencer())
+            .await
+            .unwrap();
+        let mut candidates = compactor.add_info_to_partitions(&candidates).await.unwrap();
+
+        assert_eq!(candidates.len(), 1);
+        let c = candidates.pop().unwrap();
+
+        compact_cold_partition(&compactor, c).await.unwrap();
 
         // Should have 3 non-soft-deleted files:
         //

--- a/compactor/src/parquet_file_filtering.rs
+++ b/compactor/src/parquet_file_filtering.rs
@@ -6,8 +6,8 @@ use data_types::ParquetFile;
 use metric::{Attributes, Metric, U64Gauge};
 use observability_deps::tracing::*;
 
-/// Given a list of level 0 files sorted by max sequence number and a list of level 1 files for a
-/// partition, select a subset set of files that:
+/// Given a list of hot level 0 files sorted by max sequence number and a list of level 1 files for
+/// a partition, select a subset set of files that:
 ///
 /// - Has a subset of the level 0 files selected, from the start of the sorted level 0 list
 /// - Has a total size less than `max_bytes`
@@ -16,7 +16,7 @@ use observability_deps::tracing::*;
 ///
 /// The returned files will be ordered with the level 1 files first, then the level 0 files ordered
 /// in ascending order by their max sequence number.
-pub(crate) fn filter_parquet_files(
+pub(crate) fn filter_hot_parquet_files(
     // Level 0 files sorted by max sequence number and level 1 files in arbitrary order for one
     // partition
     parquet_files_for_compaction: ParquetFilesForCompaction,
@@ -79,7 +79,7 @@ pub(crate) fn filter_parquet_files(
         // Increase the running total by the size of all the overlapping level 1 files
         total_level_1_bytes += overlaps.iter().map(|f| f.file_size_bytes).sum::<i64>() as u64;
 
-        // Move the overlapping level 1 files to`files_to_return` so they're not considered again;
+        // Move the overlapping level 1 files to `files_to_return` so they're not considered again;
         // a level 1 file overlapping with one level 0 file is enough for its inclusion. This way,
         // we also don't include level 1 files multiple times.
         files_to_return.extend(overlaps);
@@ -126,6 +126,103 @@ pub(crate) fn filter_parquet_files(
     // Return the level 1 files first, followed by the level 0 files assuming we've maintained
     // their ordering by max sequence number.
     files_to_return.extend(level_0_to_return);
+    files_to_return
+}
+
+/// Given a list of cold level 0 files sorted by max sequence number and a list of level 1 files for
+/// a partition, select a subset set of files that:
+///
+/// - Has all of the level 0 files selected
+/// - Has only level 1 files that overlap in time with the level 0 files
+///
+/// The returned files will be ordered with the level 1 files first, then the level 0 files ordered
+/// in ascending order by their max sequence number.
+///
+/// If only one level 0 file is returned, it can be upgraded to level 1 without running compaction.
+pub(crate) fn filter_cold_parquet_files(
+    // Level 0 files sorted by max sequence number and level 1 files in arbitrary order for one
+    // partition
+    parquet_files_for_compaction: ParquetFilesForCompaction,
+    // Gauge for the number of Parquet file candidates
+    parquet_file_candidate_gauge: &Metric<U64Gauge>,
+    // Gauge for the number of bytes of Parquet file candidates
+    parquet_file_candidate_bytes_gauge: &Metric<U64Gauge>,
+) -> Vec<ParquetFile> {
+    let ParquetFilesForCompaction {
+        level_0,
+        level_1: mut remaining_level_1,
+    } = parquet_files_for_compaction;
+
+    if level_0.is_empty() {
+        info!("No level 0 files to consider for compaction");
+        return Vec::new();
+    }
+
+    // Guaranteed to exist because of the empty check and early return above. Also assuming all
+    // files are for the same partition.
+    let partition_id = level_0[0].partition_id;
+
+    let num_level_0_considering = level_0.len();
+    let num_level_1_considering = remaining_level_1.len();
+
+    // This will start by holding the level 1 files that are found to overlap an included level 0
+    // file. At the end of this function, the level 0 files are added to the end so they are sorted
+    // last.
+    let mut files_to_return = Vec::with_capacity(level_0.len() + remaining_level_1.len());
+    // Running total of the size, in bytes, of level 0 files and level 1 files for inclusion.
+    // The levels are counted up separately for metrics.
+    let mut total_level_0_bytes = 0;
+    let mut total_level_1_bytes = 0;
+
+    for level_0_file in &level_0 {
+        total_level_0_bytes += level_0_file.file_size_bytes as u64;
+
+        // Find all level 1 files that overlap with this level 0 file.
+        let (overlaps, non_overlaps): (Vec<_>, Vec<_>) = remaining_level_1
+            .into_iter()
+            .partition(|level_1_file| overlaps_in_time(level_1_file, level_0_file));
+
+        // Increase the running total by the size of all the overlapping level 1 files
+        total_level_1_bytes += overlaps.iter().map(|f| f.file_size_bytes).sum::<i64>() as u64;
+
+        // Move the overlapping level 1 files to `files_to_return` so they're not considered again;
+        // a level 1 file overlapping with one level 0 file is enough for its inclusion. This way,
+        // we also don't include level 1 files multiple times.
+        files_to_return.extend(overlaps);
+
+        // The remaining level 1 files to possibly include in future iterations are the remaining
+        // ones that did not overlap with this level 0 file.
+        remaining_level_1 = non_overlaps;
+    }
+
+    let num_level_0_compacting = level_0.len();
+    let num_level_1_compacting = files_to_return.len();
+
+    info!(
+        partition_id = partition_id.get(),
+        num_level_0_considering,
+        num_level_1_considering,
+        num_level_0_compacting,
+        num_level_1_compacting,
+        "filtered Parquet files for compaction",
+    );
+
+    record_file_metrics(
+        parquet_file_candidate_gauge,
+        num_level_0_considering as u64,
+        num_level_1_considering as u64,
+        num_level_0_compacting as u64,
+        num_level_1_compacting as u64,
+    );
+    record_byte_metrics(
+        parquet_file_candidate_bytes_gauge,
+        total_level_0_bytes as u64,
+        total_level_1_bytes as u64,
+    );
+
+    // Return the level 1 files first, followed by the level 0 files assuming we've maintained
+    // their ordering by max sequence number.
+    files_to_return.extend(level_0);
     files_to_return
 }
 
@@ -246,9 +343,6 @@ mod tests {
         );
     }
 
-    const DEFAULT_MAX_FILE_SIZE: u64 = 1024 * 1024 * 10;
-    const DEFAULT_INPUT_FILE_COUNT: usize = 100;
-
     fn metrics() -> (Metric<U64Gauge>, Metric<U64Gauge>) {
         let registry = Arc::new(metric::Registry::new());
 
@@ -268,392 +362,681 @@ mod tests {
         )
     }
 
-    #[test]
-    fn empty_in_empty_out() {
-        let parquet_files_for_compaction = ParquetFilesForCompaction {
-            level_0: vec![],
-            level_1: vec![],
-        };
-        let (files_metric, bytes_metric) = metrics();
+    mod hot {
+        use super::*;
 
-        let files = filter_parquet_files(
-            parquet_files_for_compaction,
-            DEFAULT_MAX_FILE_SIZE,
-            DEFAULT_INPUT_FILE_COUNT,
-            &files_metric,
-            &bytes_metric,
-        );
+        const DEFAULT_MAX_FILE_SIZE: u64 = 1024 * 1024 * 10;
+        const DEFAULT_INPUT_FILE_COUNT: usize = 100;
 
-        assert!(files.is_empty(), "Expected empty, got: {:#?}", files);
-    }
+        #[test]
+        fn empty_in_empty_out() {
+            let parquet_files_for_compaction = ParquetFilesForCompaction {
+                level_0: vec![],
+                level_1: vec![],
+            };
+            let (files_metric, bytes_metric) = metrics();
 
-    #[test]
-    fn max_size_0_returns_one_level_0_file() {
-        let parquet_files_for_compaction = ParquetFilesForCompaction {
-            level_0: vec![ParquetFileBuilder::level_0().id(1).build()],
-            level_1: vec![],
-        };
-        let (files_metric, bytes_metric) = metrics();
+            let files = filter_hot_parquet_files(
+                parquet_files_for_compaction,
+                DEFAULT_MAX_FILE_SIZE,
+                DEFAULT_INPUT_FILE_COUNT,
+                &files_metric,
+                &bytes_metric,
+            );
 
-        let files = filter_parquet_files(
-            parquet_files_for_compaction,
-            0,
-            DEFAULT_INPUT_FILE_COUNT,
-            &files_metric,
-            &bytes_metric,
-        );
+            assert!(files.is_empty(), "Expected empty, got: {:#?}", files);
+        }
 
-        assert_eq!(files.len(), 1);
-        assert_eq!(files[0].id.get(), 1);
-    }
+        #[test]
+        fn max_size_0_returns_one_level_0_file() {
+            let parquet_files_for_compaction = ParquetFilesForCompaction {
+                level_0: vec![ParquetFileBuilder::level_0().id(1).build()],
+                level_1: vec![],
+            };
+            let (files_metric, bytes_metric) = metrics();
 
-    #[test]
-    fn max_file_count_0_returns_empty() {
-        let parquet_files_for_compaction = ParquetFilesForCompaction {
-            level_0: vec![ParquetFileBuilder::level_0().id(1).build()],
-            level_1: vec![],
-        };
-        let (files_metric, bytes_metric) = metrics();
+            let files = filter_hot_parquet_files(
+                parquet_files_for_compaction,
+                0,
+                DEFAULT_INPUT_FILE_COUNT,
+                &files_metric,
+                &bytes_metric,
+            );
 
-        let files = filter_parquet_files(
-            parquet_files_for_compaction,
-            DEFAULT_MAX_FILE_SIZE,
-            0,
-            &files_metric,
-            &bytes_metric,
-        );
+            assert_eq!(files.len(), 1);
+            assert_eq!(files[0].id.get(), 1);
+        }
 
-        assert!(files.is_empty(), "Expected empty, got: {:#?}", files);
-    }
+        #[test]
+        fn max_file_count_0_returns_empty() {
+            let parquet_files_for_compaction = ParquetFilesForCompaction {
+                level_0: vec![ParquetFileBuilder::level_0().id(1).build()],
+                level_1: vec![],
+            };
+            let (files_metric, bytes_metric) = metrics();
 
-    #[test]
-    fn max_size_0_returns_one_level_0_file_and_its_level_1_overlaps() {
-        let parquet_files_for_compaction = ParquetFilesForCompaction {
-            level_0: vec![ParquetFileBuilder::level_0()
-                .id(1)
-                .min_time(200)
-                .max_time(300)
-                .build()],
-            level_1: vec![
-                // Too early
-                ParquetFileBuilder::level_1()
-                    .id(101)
-                    .min_time(1)
-                    .max_time(50)
-                    .build(),
-                // Completely contains the level 0 times
-                ParquetFileBuilder::level_1()
-                    .id(102)
-                    .min_time(150)
-                    .max_time(350)
-                    .build(),
-                // Too late
-                ParquetFileBuilder::level_1()
-                    .id(103)
-                    .min_time(400)
-                    .max_time(500)
-                    .build(),
-            ],
-        };
-        let (files_metric, bytes_metric) = metrics();
+            let files = filter_hot_parquet_files(
+                parquet_files_for_compaction,
+                DEFAULT_MAX_FILE_SIZE,
+                0,
+                &files_metric,
+                &bytes_metric,
+            );
 
-        let files = filter_parquet_files(
-            parquet_files_for_compaction,
-            0,
-            DEFAULT_INPUT_FILE_COUNT,
-            &files_metric,
-            &bytes_metric,
-        );
+            assert!(files.is_empty(), "Expected empty, got: {:#?}", files);
+        }
 
-        assert_eq!(files.len(), 2);
-        assert_eq!(files[0].id.get(), 102);
-        assert_eq!(files[1].id.get(), 1);
-    }
-
-    #[test]
-    fn returns_only_overlapping_level_1_files_in_order() {
-        let parquet_files_for_compaction = ParquetFilesForCompaction {
-            level_0: vec![
-                // Level 0 files that overlap in time slightly.
-                ParquetFileBuilder::level_0()
+        #[test]
+        fn max_size_0_returns_one_level_0_file_and_its_level_1_overlaps() {
+            let parquet_files_for_compaction = ParquetFilesForCompaction {
+                level_0: vec![ParquetFileBuilder::level_0()
                     .id(1)
                     .min_time(200)
                     .max_time(300)
-                    .file_size_bytes(10)
-                    .build(),
-                ParquetFileBuilder::level_0()
-                    .id(2)
-                    .min_time(280)
-                    .max_time(310)
-                    .file_size_bytes(10)
-                    .build(),
-                ParquetFileBuilder::level_0()
-                    .id(3)
-                    .min_time(309)
-                    .max_time(350)
-                    .file_size_bytes(10)
-                    .build(),
-            ],
-            // Level 1 files can be assumed not to overlap each other.
-            level_1: vec![
-                // Does not overlap any level 0, times are too early
-                ParquetFileBuilder::level_1()
-                    .id(101)
-                    .min_time(1)
-                    .max_time(50)
-                    .file_size_bytes(10)
-                    .build(),
-                // Overlaps file 1
-                ParquetFileBuilder::level_1()
-                    .id(102)
-                    .min_time(199)
-                    .max_time(201)
-                    .file_size_bytes(10)
-                    .build(),
-                // Overlaps files 1 and 2
-                ParquetFileBuilder::level_1()
-                    .id(103)
-                    .min_time(290)
+                    .build()],
+                level_1: vec![
+                    // Too early
+                    ParquetFileBuilder::level_1()
+                        .id(101)
+                        .min_time(1)
+                        .max_time(50)
+                        .build(),
+                    // Completely contains the level 0 times
+                    ParquetFileBuilder::level_1()
+                        .id(102)
+                        .min_time(150)
+                        .max_time(350)
+                        .build(),
+                    // Too late
+                    ParquetFileBuilder::level_1()
+                        .id(103)
+                        .min_time(400)
+                        .max_time(500)
+                        .build(),
+                ],
+            };
+            let (files_metric, bytes_metric) = metrics();
+
+            let files = filter_hot_parquet_files(
+                parquet_files_for_compaction,
+                0,
+                DEFAULT_INPUT_FILE_COUNT,
+                &files_metric,
+                &bytes_metric,
+            );
+
+            assert_eq!(files.len(), 2);
+            assert_eq!(files[0].id.get(), 102);
+            assert_eq!(files[1].id.get(), 1);
+        }
+
+        #[test]
+        fn returns_only_overlapping_level_1_files_in_order() {
+            let parquet_files_for_compaction = ParquetFilesForCompaction {
+                level_0: vec![
+                    // Level 0 files that overlap in time slightly.
+                    ParquetFileBuilder::level_0()
+                        .id(1)
+                        .min_time(200)
+                        .max_time(300)
+                        .file_size_bytes(10)
+                        .build(),
+                    ParquetFileBuilder::level_0()
+                        .id(2)
+                        .min_time(280)
+                        .max_time(310)
+                        .file_size_bytes(10)
+                        .build(),
+                    ParquetFileBuilder::level_0()
+                        .id(3)
+                        .min_time(309)
+                        .max_time(350)
+                        .file_size_bytes(10)
+                        .build(),
+                ],
+                // Level 1 files can be assumed not to overlap each other.
+                level_1: vec![
+                    // Does not overlap any level 0, times are too early
+                    ParquetFileBuilder::level_1()
+                        .id(101)
+                        .min_time(1)
+                        .max_time(50)
+                        .file_size_bytes(10)
+                        .build(),
+                    // Overlaps file 1
+                    ParquetFileBuilder::level_1()
+                        .id(102)
+                        .min_time(199)
+                        .max_time(201)
+                        .file_size_bytes(10)
+                        .build(),
+                    // Overlaps files 1 and 2
+                    ParquetFileBuilder::level_1()
+                        .id(103)
+                        .min_time(290)
+                        .max_time(300)
+                        .file_size_bytes(10)
+                        .build(),
+                    // Overlaps file 2
+                    ParquetFileBuilder::level_1()
+                        .id(104)
+                        .min_time(305)
+                        .max_time(305)
+                        .file_size_bytes(10)
+                        .build(),
+                    // Overlaps files 2 and 3
+                    ParquetFileBuilder::level_1()
+                        .id(105)
+                        .min_time(308)
+                        .max_time(311)
+                        .file_size_bytes(10)
+                        .build(),
+                    // Overlaps file 3
+                    ParquetFileBuilder::level_1()
+                        .id(106)
+                        .min_time(340)
+                        .max_time(360)
+                        .file_size_bytes(10)
+                        .build(),
+                    // Does not overlap any level 0, times are too late
+                    ParquetFileBuilder::level_1()
+                        .id(107)
+                        .min_time(390)
+                        .max_time(399)
+                        .file_size_bytes(10)
+                        .build(),
+                ],
+            };
+
+            // Max size 0; only the first level 0 file and its overlapping level 1 files get
+            // returned
+            let max_size = 0;
+            let (files_metric, bytes_metric) = metrics();
+            let files = filter_hot_parquet_files(
+                parquet_files_for_compaction.clone(),
+                max_size,
+                DEFAULT_INPUT_FILE_COUNT,
+                &files_metric,
+                &bytes_metric,
+            );
+            let ids: Vec<_> = files.iter().map(|f| f.id.get()).collect();
+            assert_eq!(ids, [102, 103, 1]);
+            assert_eq!(
+                extract_file_metrics(&files_metric),
+                ExtractedFileMetrics {
+                    level_0_selected: 1,
+                    level_0_not_selected: 2,
+                    level_1_selected: 2,
+                    level_1_not_selected: 5,
+                }
+            );
+            assert_eq!(
+                extract_byte_metrics(&bytes_metric),
+                ExtractedByteMetrics {
+                    level_0: 10,
+                    level_1: 20,
+                }
+            );
+
+            // Increase max size; 1st two level 0 files & their overlapping level 1 files get
+            // returned
+            let max_size = 40;
+            let (files_metric, bytes_metric) = metrics();
+            let files = filter_hot_parquet_files(
+                parquet_files_for_compaction.clone(),
+                max_size,
+                DEFAULT_INPUT_FILE_COUNT,
+                &files_metric,
+                &bytes_metric,
+            );
+            let ids: Vec<_> = files.iter().map(|f| f.id.get()).collect();
+            assert_eq!(ids, [102, 103, 104, 105, 1, 2]);
+            assert_eq!(
+                extract_file_metrics(&files_metric),
+                ExtractedFileMetrics {
+                    level_0_selected: 2,
+                    level_0_not_selected: 1,
+                    level_1_selected: 4,
+                    level_1_not_selected: 3,
+                }
+            );
+            assert_eq!(
+                extract_byte_metrics(&bytes_metric),
+                ExtractedByteMetrics {
+                    level_0: 20,
+                    level_1: 40,
+                }
+            );
+
+            // Increase max size to be exactly equal to the size of the 1st two level 0 files &
+            // their overlapping level 1 files, which is all that should get returned
+            let max_size = 60;
+            let (files_metric, bytes_metric) = metrics();
+            let files = filter_hot_parquet_files(
+                parquet_files_for_compaction.clone(),
+                max_size,
+                DEFAULT_INPUT_FILE_COUNT,
+                &files_metric,
+                &bytes_metric,
+            );
+            let ids: Vec<_> = files.iter().map(|f| f.id.get()).collect();
+            assert_eq!(ids, [102, 103, 104, 105, 1, 2]);
+            assert_eq!(
+                extract_file_metrics(&files_metric),
+                ExtractedFileMetrics {
+                    level_0_selected: 2,
+                    level_0_not_selected: 1,
+                    level_1_selected: 4,
+                    level_1_not_selected: 3,
+                }
+            );
+            assert_eq!(
+                extract_byte_metrics(&bytes_metric),
+                ExtractedByteMetrics {
+                    level_0: 20,
+                    level_1: 40,
+                }
+            );
+
+            // Increase max size; all level 0 files & their overlapping level 1 files get returned
+            let max_size = 70;
+            let (files_metric, bytes_metric) = metrics();
+            let files = filter_hot_parquet_files(
+                parquet_files_for_compaction.clone(),
+                max_size,
+                DEFAULT_INPUT_FILE_COUNT,
+                &files_metric,
+                &bytes_metric,
+            );
+            let ids: Vec<_> = files.iter().map(|f| f.id.get()).collect();
+            assert_eq!(ids, [102, 103, 104, 105, 106, 1, 2, 3]);
+            assert_eq!(
+                extract_file_metrics(&files_metric),
+                ExtractedFileMetrics {
+                    level_0_selected: 3,
+                    level_0_not_selected: 0,
+                    level_1_selected: 5,
+                    level_1_not_selected: 2,
+                }
+            );
+            assert_eq!(
+                extract_byte_metrics(&bytes_metric),
+                ExtractedByteMetrics {
+                    level_0: 30,
+                    level_1: 50,
+                }
+            );
+
+            // Set input_file_count_threshold to 1; the first level 0 file and its overlapping
+            // level 1 files get returned
+            let input_file_count_threshold = 1;
+            let (files_metric, bytes_metric) = metrics();
+            let files = filter_hot_parquet_files(
+                parquet_files_for_compaction.clone(),
+                DEFAULT_MAX_FILE_SIZE,
+                input_file_count_threshold,
+                &files_metric,
+                &bytes_metric,
+            );
+            let ids: Vec<_> = files.iter().map(|f| f.id.get()).collect();
+            assert_eq!(ids, [102, 103, 1]);
+            assert_eq!(
+                extract_file_metrics(&files_metric),
+                ExtractedFileMetrics {
+                    level_0_selected: 1,
+                    level_0_not_selected: 2,
+                    level_1_selected: 2,
+                    level_1_not_selected: 5,
+                }
+            );
+            assert_eq!(
+                extract_byte_metrics(&bytes_metric),
+                ExtractedByteMetrics {
+                    level_0: 10,
+                    level_1: 20,
+                }
+            );
+
+            // Set input_file_count_threshold to 3; still only the first level 0 file and its
+            // overlapping level 1 files get returned
+            let input_file_count_threshold = 3;
+            let (files_metric, bytes_metric) = metrics();
+            let files = filter_hot_parquet_files(
+                parquet_files_for_compaction.clone(),
+                DEFAULT_MAX_FILE_SIZE,
+                input_file_count_threshold,
+                &files_metric,
+                &bytes_metric,
+            );
+            let ids: Vec<_> = files.iter().map(|f| f.id.get()).collect();
+            assert_eq!(ids, [102, 103, 1]);
+            assert_eq!(
+                extract_file_metrics(&files_metric),
+                ExtractedFileMetrics {
+                    level_0_selected: 1,
+                    level_0_not_selected: 2,
+                    level_1_selected: 2,
+                    level_1_not_selected: 5,
+                }
+            );
+            assert_eq!(
+                extract_byte_metrics(&bytes_metric),
+                ExtractedByteMetrics {
+                    level_0: 10,
+                    level_1: 20,
+                }
+            );
+
+            // Set input_file_count_threshold to 4; the first two level 0 files and their
+            // overlapping level 1 files get returned
+            let input_file_count_threshold = 4;
+            let (files_metric, bytes_metric) = metrics();
+            let files = filter_hot_parquet_files(
+                parquet_files_for_compaction,
+                DEFAULT_MAX_FILE_SIZE,
+                input_file_count_threshold,
+                &files_metric,
+                &bytes_metric,
+            );
+            let ids: Vec<_> = files.iter().map(|f| f.id.get()).collect();
+            assert_eq!(ids, [102, 103, 104, 105, 1, 2]);
+            assert_eq!(
+                extract_file_metrics(&files_metric),
+                ExtractedFileMetrics {
+                    level_0_selected: 2,
+                    level_0_not_selected: 1,
+                    level_1_selected: 4,
+                    level_1_not_selected: 3,
+                }
+            );
+            assert_eq!(
+                extract_byte_metrics(&bytes_metric),
+                ExtractedByteMetrics {
+                    level_0: 20,
+                    level_1: 40,
+                }
+            );
+        }
+    }
+
+    mod cold {
+        use super::*;
+
+        #[test]
+        fn empty_in_empty_out() {
+            let parquet_files_for_compaction = ParquetFilesForCompaction {
+                level_0: vec![],
+                level_1: vec![],
+            };
+            let (files_metric, bytes_metric) = metrics();
+
+            let files = filter_cold_parquet_files(
+                parquet_files_for_compaction,
+                &files_metric,
+                &bytes_metric,
+            );
+
+            assert!(files.is_empty(), "Expected empty, got: {:#?}", files);
+        }
+
+        #[test]
+        fn one_level_0_file_no_level_1_overlaps() {
+            let parquet_files_for_compaction = ParquetFilesForCompaction {
+                level_0: vec![ParquetFileBuilder::level_0()
+                    .id(1)
+                    .min_time(200)
                     .max_time(300)
-                    .file_size_bytes(10)
-                    .build(),
-                // Overlaps file 2
-                ParquetFileBuilder::level_1()
-                    .id(104)
-                    .min_time(305)
-                    .max_time(305)
-                    .file_size_bytes(10)
-                    .build(),
-                // Overlaps files 2 and 3
-                ParquetFileBuilder::level_1()
-                    .id(105)
-                    .min_time(308)
-                    .max_time(311)
-                    .file_size_bytes(10)
-                    .build(),
-                // Overlaps file 3
-                ParquetFileBuilder::level_1()
-                    .id(106)
-                    .min_time(340)
-                    .max_time(360)
-                    .file_size_bytes(10)
-                    .build(),
-                // Does not overlap any level 0, times are too late
-                ParquetFileBuilder::level_1()
-                    .id(107)
-                    .min_time(390)
-                    .max_time(399)
-                    .file_size_bytes(10)
-                    .build(),
-            ],
-        };
+                    .build()],
+                level_1: vec![
+                    // Too early
+                    ParquetFileBuilder::level_1()
+                        .id(101)
+                        .min_time(1)
+                        .max_time(50)
+                        .build(),
+                    // Too late
+                    ParquetFileBuilder::level_1()
+                        .id(103)
+                        .min_time(400)
+                        .max_time(500)
+                        .build(),
+                ],
+            };
+            let (files_metric, bytes_metric) = metrics();
 
-        // Max size 0; only the first level 0 file and its overlapping level 1 files get returned
-        let max_size = 0;
-        let (files_metric, bytes_metric) = metrics();
-        let files = filter_parquet_files(
-            parquet_files_for_compaction.clone(),
-            max_size,
-            DEFAULT_INPUT_FILE_COUNT,
-            &files_metric,
-            &bytes_metric,
-        );
-        let ids: Vec<_> = files.iter().map(|f| f.id.get()).collect();
-        assert_eq!(ids, [102, 103, 1]);
-        assert_eq!(
-            extract_file_metrics(&files_metric),
-            ExtractedFileMetrics {
-                level_0_selected: 1,
-                level_0_not_selected: 2,
-                level_1_selected: 2,
-                level_1_not_selected: 5,
-            }
-        );
-        assert_eq!(
-            extract_byte_metrics(&bytes_metric),
-            ExtractedByteMetrics {
-                level_0: 10,
-                level_1: 20,
-            }
-        );
+            let files = filter_cold_parquet_files(
+                parquet_files_for_compaction,
+                &files_metric,
+                &bytes_metric,
+            );
 
-        // Increase max size; 1st two level 0 files & their overlapping level 1 files get returned
-        let max_size = 40;
-        let (files_metric, bytes_metric) = metrics();
-        let files = filter_parquet_files(
-            parquet_files_for_compaction.clone(),
-            max_size,
-            DEFAULT_INPUT_FILE_COUNT,
-            &files_metric,
-            &bytes_metric,
-        );
-        let ids: Vec<_> = files.iter().map(|f| f.id.get()).collect();
-        assert_eq!(ids, [102, 103, 104, 105, 1, 2]);
-        assert_eq!(
-            extract_file_metrics(&files_metric),
-            ExtractedFileMetrics {
-                level_0_selected: 2,
-                level_0_not_selected: 1,
-                level_1_selected: 4,
-                level_1_not_selected: 3,
-            }
-        );
-        assert_eq!(
-            extract_byte_metrics(&bytes_metric),
-            ExtractedByteMetrics {
-                level_0: 20,
-                level_1: 40,
-            }
-        );
+            assert_eq!(files.len(), 1);
+            assert_eq!(files[0].id.get(), 1);
+        }
 
-        // Increase max size to be exactly equal to the size of the 1st two level 0 files & their
-        // overlapping level 1 files, which is all that should get returned
-        let max_size = 60;
-        let (files_metric, bytes_metric) = metrics();
-        let files = filter_parquet_files(
-            parquet_files_for_compaction.clone(),
-            max_size,
-            DEFAULT_INPUT_FILE_COUNT,
-            &files_metric,
-            &bytes_metric,
-        );
-        let ids: Vec<_> = files.iter().map(|f| f.id.get()).collect();
-        assert_eq!(ids, [102, 103, 104, 105, 1, 2]);
-        assert_eq!(
-            extract_file_metrics(&files_metric),
-            ExtractedFileMetrics {
-                level_0_selected: 2,
-                level_0_not_selected: 1,
-                level_1_selected: 4,
-                level_1_not_selected: 3,
-            }
-        );
-        assert_eq!(
-            extract_byte_metrics(&bytes_metric),
-            ExtractedByteMetrics {
-                level_0: 20,
-                level_1: 40,
-            }
-        );
+        #[test]
+        fn one_level_0_file_with_level_1_overlaps() {
+            let parquet_files_for_compaction = ParquetFilesForCompaction {
+                level_0: vec![ParquetFileBuilder::level_0()
+                    .id(1)
+                    .min_time(200)
+                    .max_time(300)
+                    .build()],
+                level_1: vec![
+                    // Too early
+                    ParquetFileBuilder::level_1()
+                        .id(101)
+                        .min_time(1)
+                        .max_time(50)
+                        .build(),
+                    // Completely contains the level 0 times
+                    ParquetFileBuilder::level_1()
+                        .id(102)
+                        .min_time(150)
+                        .max_time(350)
+                        .build(),
+                    // Too late
+                    ParquetFileBuilder::level_1()
+                        .id(103)
+                        .min_time(400)
+                        .max_time(500)
+                        .build(),
+                ],
+            };
+            let (files_metric, bytes_metric) = metrics();
 
-        // Increase max size; all level 0 files & their overlapping level 1 files get returned
-        let max_size = 70;
-        let (files_metric, bytes_metric) = metrics();
-        let files = filter_parquet_files(
-            parquet_files_for_compaction.clone(),
-            max_size,
-            DEFAULT_INPUT_FILE_COUNT,
-            &files_metric,
-            &bytes_metric,
-        );
-        let ids: Vec<_> = files.iter().map(|f| f.id.get()).collect();
-        assert_eq!(ids, [102, 103, 104, 105, 106, 1, 2, 3]);
-        assert_eq!(
-            extract_file_metrics(&files_metric),
-            ExtractedFileMetrics {
-                level_0_selected: 3,
-                level_0_not_selected: 0,
-                level_1_selected: 5,
-                level_1_not_selected: 2,
-            }
-        );
-        assert_eq!(
-            extract_byte_metrics(&bytes_metric),
-            ExtractedByteMetrics {
-                level_0: 30,
-                level_1: 50,
-            }
-        );
+            let files = filter_cold_parquet_files(
+                parquet_files_for_compaction,
+                &files_metric,
+                &bytes_metric,
+            );
 
-        // Set input_file_count_threshold to 1; the first level 0 file and its overlapping level 1
-        // files get returned
-        let input_file_count_threshold = 1;
-        let (files_metric, bytes_metric) = metrics();
-        let files = filter_parquet_files(
-            parquet_files_for_compaction.clone(),
-            DEFAULT_MAX_FILE_SIZE,
-            input_file_count_threshold,
-            &files_metric,
-            &bytes_metric,
-        );
-        let ids: Vec<_> = files.iter().map(|f| f.id.get()).collect();
-        assert_eq!(ids, [102, 103, 1]);
-        assert_eq!(
-            extract_file_metrics(&files_metric),
-            ExtractedFileMetrics {
-                level_0_selected: 1,
-                level_0_not_selected: 2,
-                level_1_selected: 2,
-                level_1_not_selected: 5,
-            }
-        );
-        assert_eq!(
-            extract_byte_metrics(&bytes_metric),
-            ExtractedByteMetrics {
-                level_0: 10,
-                level_1: 20,
-            }
-        );
+            assert_eq!(files.len(), 2);
+            assert_eq!(files[0].id.get(), 102);
+            assert_eq!(files[1].id.get(), 1);
+        }
 
-        // Set input_file_count_threshold to 3; still only the first level 0 file and its
-        // overlapping level 1 files get returned
-        let input_file_count_threshold = 3;
-        let (files_metric, bytes_metric) = metrics();
-        let files = filter_parquet_files(
-            parquet_files_for_compaction.clone(),
-            DEFAULT_MAX_FILE_SIZE,
-            input_file_count_threshold,
-            &files_metric,
-            &bytes_metric,
-        );
-        let ids: Vec<_> = files.iter().map(|f| f.id.get()).collect();
-        assert_eq!(ids, [102, 103, 1]);
-        assert_eq!(
-            extract_file_metrics(&files_metric),
-            ExtractedFileMetrics {
-                level_0_selected: 1,
-                level_0_not_selected: 2,
-                level_1_selected: 2,
-                level_1_not_selected: 5,
-            }
-        );
-        assert_eq!(
-            extract_byte_metrics(&bytes_metric),
-            ExtractedByteMetrics {
-                level_0: 10,
-                level_1: 20,
-            }
-        );
+        #[test]
+        fn multiple_level_0_files_no_level_1_overlaps() {
+            let parquet_files_for_compaction = ParquetFilesForCompaction {
+                level_0: vec![
+                    // Level 0 files, some of which overlap in time slightly.
+                    ParquetFileBuilder::level_0()
+                        .id(1)
+                        .min_time(200)
+                        .max_time(300)
+                        .file_size_bytes(10)
+                        .build(),
+                    ParquetFileBuilder::level_0()
+                        .id(2)
+                        .min_time(280)
+                        .max_time(310)
+                        .file_size_bytes(10)
+                        .build(),
+                    ParquetFileBuilder::level_0()
+                        .id(3)
+                        .min_time(320)
+                        .max_time(350)
+                        .file_size_bytes(10)
+                        .build(),
+                ],
+                // Level 1 files can be assumed not to overlap each other.
+                level_1: vec![
+                    // too early
+                    ParquetFileBuilder::level_1()
+                        .id(101)
+                        .min_time(1)
+                        .max_time(50)
+                        .file_size_bytes(10)
+                        .build(),
+                    // between 2 and 3 (there can't be one between 1 and 2 because they overlap)
+                    ParquetFileBuilder::level_1()
+                        .id(103)
+                        .min_time(315)
+                        .max_time(316)
+                        .file_size_bytes(10)
+                        .build(),
+                    // too late
+                    ParquetFileBuilder::level_1()
+                        .id(107)
+                        .min_time(390)
+                        .max_time(399)
+                        .file_size_bytes(10)
+                        .build(),
+                ],
+            };
 
-        // Set input_file_count_threshold to 4; the first two level 0 files and their overlapping
-        // level 1 files get returned
-        let input_file_count_threshold = 4;
-        let (files_metric, bytes_metric) = metrics();
-        let files = filter_parquet_files(
-            parquet_files_for_compaction,
-            DEFAULT_MAX_FILE_SIZE,
-            input_file_count_threshold,
-            &files_metric,
-            &bytes_metric,
-        );
-        let ids: Vec<_> = files.iter().map(|f| f.id.get()).collect();
-        assert_eq!(ids, [102, 103, 104, 105, 1, 2]);
-        assert_eq!(
-            extract_file_metrics(&files_metric),
-            ExtractedFileMetrics {
-                level_0_selected: 2,
-                level_0_not_selected: 1,
-                level_1_selected: 4,
-                level_1_not_selected: 3,
-            }
-        );
-        assert_eq!(
-            extract_byte_metrics(&bytes_metric),
-            ExtractedByteMetrics {
-                level_0: 20,
-                level_1: 40,
-            }
-        );
+            // all level 0 files & no level 1 files get returned
+            let (files_metric, bytes_metric) = metrics();
+            let files = filter_cold_parquet_files(
+                parquet_files_for_compaction,
+                &files_metric,
+                &bytes_metric,
+            );
+            let ids: Vec<_> = files.iter().map(|f| f.id.get()).collect();
+            assert_eq!(ids, [1, 2, 3]);
+            assert_eq!(
+                extract_file_metrics(&files_metric),
+                ExtractedFileMetrics {
+                    level_0_selected: 3,
+                    level_0_not_selected: 0,
+                    level_1_selected: 0,
+                    level_1_not_selected: 3,
+                }
+            );
+            assert_eq!(
+                extract_byte_metrics(&bytes_metric),
+                ExtractedByteMetrics {
+                    level_0: 30,
+                    level_1: 0,
+                }
+            );
+        }
+
+        #[test]
+        fn multiple_level_0_files_with_level_1_overlaps() {
+            let parquet_files_for_compaction = ParquetFilesForCompaction {
+                level_0: vec![
+                    // Level 0 files that overlap in time slightly.
+                    ParquetFileBuilder::level_0()
+                        .id(1)
+                        .min_time(200)
+                        .max_time(300)
+                        .file_size_bytes(10)
+                        .build(),
+                    ParquetFileBuilder::level_0()
+                        .id(2)
+                        .min_time(280)
+                        .max_time(310)
+                        .file_size_bytes(10)
+                        .build(),
+                    ParquetFileBuilder::level_0()
+                        .id(3)
+                        .min_time(309)
+                        .max_time(350)
+                        .file_size_bytes(10)
+                        .build(),
+                ],
+                // Level 1 files can be assumed not to overlap each other.
+                level_1: vec![
+                    // Does not overlap any level 0, times are too early
+                    ParquetFileBuilder::level_1()
+                        .id(101)
+                        .min_time(1)
+                        .max_time(50)
+                        .file_size_bytes(10)
+                        .build(),
+                    // Overlaps file 1
+                    ParquetFileBuilder::level_1()
+                        .id(102)
+                        .min_time(199)
+                        .max_time(201)
+                        .file_size_bytes(10)
+                        .build(),
+                    // Overlaps files 1 and 2
+                    ParquetFileBuilder::level_1()
+                        .id(103)
+                        .min_time(290)
+                        .max_time(300)
+                        .file_size_bytes(10)
+                        .build(),
+                    // Overlaps file 2
+                    ParquetFileBuilder::level_1()
+                        .id(104)
+                        .min_time(305)
+                        .max_time(305)
+                        .file_size_bytes(10)
+                        .build(),
+                    // Overlaps files 2 and 3
+                    ParquetFileBuilder::level_1()
+                        .id(105)
+                        .min_time(308)
+                        .max_time(311)
+                        .file_size_bytes(10)
+                        .build(),
+                    // Overlaps file 3
+                    ParquetFileBuilder::level_1()
+                        .id(106)
+                        .min_time(340)
+                        .max_time(360)
+                        .file_size_bytes(10)
+                        .build(),
+                    // Does not overlap any level 0, times are too late
+                    ParquetFileBuilder::level_1()
+                        .id(107)
+                        .min_time(390)
+                        .max_time(399)
+                        .file_size_bytes(10)
+                        .build(),
+                ],
+            };
+
+            // all level 0 files & their overlapping level 1 files get returned
+            let (files_metric, bytes_metric) = metrics();
+            let files = filter_cold_parquet_files(
+                parquet_files_for_compaction,
+                &files_metric,
+                &bytes_metric,
+            );
+            let ids: Vec<_> = files.iter().map(|f| f.id.get()).collect();
+            assert_eq!(ids, [102, 103, 104, 105, 106, 1, 2, 3]);
+            assert_eq!(
+                extract_file_metrics(&files_metric),
+                ExtractedFileMetrics {
+                    level_0_selected: 3,
+                    level_0_not_selected: 0,
+                    level_1_selected: 5,
+                    level_1_not_selected: 2,
+                }
+            );
+            assert_eq!(
+                extract_byte_metrics(&bytes_metric),
+                ExtractedByteMetrics {
+                    level_0: 30,
+                    level_1: 50,
+                }
+            );
+        }
     }
 
     /// Create ParquetFile instances for testing. Only sets fields relevant to the filtering; other

--- a/compactor/src/parquet_file_filtering.rs
+++ b/compactor/src/parquet_file_filtering.rs
@@ -37,7 +37,7 @@ pub(crate) fn filter_hot_parquet_files(
     } = parquet_files_for_compaction;
 
     if level_0.is_empty() {
-        info!("No level 0 files to consider for compaction");
+        info!("No hot level 0 files to consider for compaction");
         return Vec::new();
     }
 
@@ -107,7 +107,7 @@ pub(crate) fn filter_hot_parquet_files(
         num_level_1_considering,
         num_level_0_compacting,
         num_level_1_compacting,
-        "filtered Parquet files for compaction",
+        "filtered hot Parquet files for compaction",
     );
 
     record_file_metrics(
@@ -157,7 +157,7 @@ pub(crate) fn filter_cold_parquet_files(
     } = parquet_files_for_compaction;
 
     if level_0.is_empty() {
-        info!("No level 0 files to consider for compaction");
+        info!("No cold level 0 files to consider for compaction");
         return Vec::new();
     }
 
@@ -220,7 +220,7 @@ pub(crate) fn filter_cold_parquet_files(
         num_level_1_considering,
         num_level_0_compacting,
         num_level_1_compacting,
-        "filtered Parquet files for compaction",
+        "filtered cold Parquet files for compaction",
     );
 
     record_file_metrics(

--- a/influxdb_iox/src/commands/run/all_in_one.rs
+++ b/influxdb_iox/src/commands/run/all_in_one.rs
@@ -420,9 +420,11 @@ impl Config {
             percentage_max_file_size: 30,
             split_percentage: 80,
             max_concurrent_size_bytes: 100_000,
+            max_cold_concurrent_size_bytes: 90_000,
             max_number_partitions_per_sequencer: 1,
             min_number_recent_ingested_files_per_partition: 1,
             input_size_threshold_bytes: 314_572_800,
+            cold_input_size_threshold_bytes: 629_145_600,
             input_file_count_threshold: 100,
             hot_multiple: 4,
         };

--- a/influxdb_iox/src/commands/run/all_in_one.rs
+++ b/influxdb_iox/src/commands/run/all_in_one.rs
@@ -424,6 +424,7 @@ impl Config {
             min_number_recent_ingested_files_per_partition: 1,
             input_size_threshold_bytes: 314_572_800,
             input_file_count_threshold: 100,
+            hot_multiple: 4,
         };
 
         let querier_config = QuerierConfig {

--- a/iox_catalog/src/metrics.rs
+++ b/iox_catalog/src/metrics.rs
@@ -280,7 +280,7 @@ decorate!(
         "parquet_count_by_overlaps_with_level_1" = count_by_overlaps_with_level_1(&mut self, table_id: TableId, sequencer_id: SequencerId, min_time: Timestamp, max_time: Timestamp) -> Result<i64>;
         "parquet_get_by_object_store_id" = get_by_object_store_id(&mut self, object_store_id: Uuid) -> Result<Option<ParquetFile>>;
         "recent_highest_throughput_partitions" = recent_highest_throughput_partitions(&mut self, sequencer_id: SequencerId, num_hours: u32, min_num_files: usize, num_partitions: usize) -> Result<Vec<PartitionParam>>;
-        "most_level_0_files_partitions" =  most_level_0_files_partitions(&mut self, sequencer_id: SequencerId, num_partitions: usize) -> Result<Vec<PartitionParam>>;
+        "most_level_0_files_partitions" =  most_level_0_files_partitions(&mut self, sequencer_id: SequencerId, older_than_num_hours: u32, num_partitions: usize) -> Result<Vec<PartitionParam>>;
     ]
 );
 

--- a/ioxd_compactor/src/lib.rs
+++ b/ioxd_compactor/src/lib.rs
@@ -172,6 +172,7 @@ pub async fn create_compactor_server_type(
         compactor_config.min_number_recent_ingested_files_per_partition,
         compactor_config.input_size_threshold_bytes,
         compactor_config.input_file_count_threshold,
+        compactor_config.hot_multiple,
     );
     let compactor_handler = Arc::new(CompactorHandlerImpl::new(
         sequencers,

--- a/ioxd_compactor/src/lib.rs
+++ b/ioxd_compactor/src/lib.rs
@@ -168,9 +168,11 @@ pub async fn create_compactor_server_type(
         compactor_config.percentage_max_file_size,
         compactor_config.split_percentage,
         compactor_config.max_concurrent_size_bytes,
+        compactor_config.max_cold_concurrent_size_bytes,
         compactor_config.max_number_partitions_per_sequencer,
         compactor_config.min_number_recent_ingested_files_per_partition,
         compactor_config.input_size_threshold_bytes,
+        compactor_config.cold_input_size_threshold_bytes,
         compactor_config.input_file_count_threshold,
         compactor_config.hot_multiple,
     );


### PR DESCRIPTION
Fixes [#1078](https://github.com/influxdata/conductor/issues/1078).

This PR does somewhat more than the issue describes, but Nga and Paul and I have discussed it and this is ok.

This PR moves the current compaction procedure to `compact_hot_partitions`, and adds a new, slightly different procedure in `compact_cold_partitions` which also runs in the compaction handler loop.

There's a new CLI flag/env var, `--compaction-hot-multiple` (thoughts on a better name?), that controls how many times a compactor loop iteration will run compaction of hot partitions for every 1 time the loop runs compaction of cold partitions, to control how much we bias the compactor towards spending time on hot partitions. I've set the default to 4, so every compaction loop iteration will compact hot partitions 4 times and compact cold partitions once (is this default ok? a good starting place, at least?)

The main purpose of the cold compaction loop as I was thinking about it is to ensure partitions that got starved out of compaction while they were hot (because they weren't as hot as other partitions) eventually get compacted.

The cold compaction logic:

- Looks for partitions that contain any number of level 0 files with the maximum creation time of the level 0 files being more than 24 hours ago (right now that 24 hours is hardcoded but this could be another setting)
- Orders by the number of level 0 files descending and takes `max_num_partitions_per_sequencer` partitions per sequencer (this is something we could make into a separate parameter for different tuning someday after experimentation) 
- Selects all level 1 files in the partition that overlap with the level 0 files
- **Doesn't** limit the number of files or the total file size as the hot compaction does, include all level 0 and overlapping level 1 files for this partition
- If there's only one level 0 file (and no overlapping level 1 files), upgrade that file to level 1 without running compaction (this is [#1078](https://github.com/influxdata/conductor/issues/1078))
- Otherwise, run compaction on all the selected level 0 and level 1 files calling the same `compact_parquet_files` function that hot compaction uses, which splits the files based on `max_desired_file_size_bytes`, `percentage_max_file_size`, and `split_percentage`. We could change this in the future if we wanted to, say, always compact into one file no matter how big it is.