### PR TITLE
feat: Compactor e2e tests and a "run once" compactor command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2373,6 +2373,7 @@ name = "ioxd_compactor"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "backoff",
  "clap_blocks",
  "compactor",
  "data_types",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2000,6 +2000,7 @@ dependencies = [
  "bytes",
  "clap 3.2.16",
  "clap_blocks",
+ "compactor",
  "console-subscriber",
  "data_types",
  "datafusion 0.1.0",

--- a/clap_blocks/src/compactor.rs
+++ b/clap_blocks/src/compactor.rs
@@ -1,5 +1,7 @@
 //! CLI config for compactor-related commands
 
+#![cfg_attr(rustfmt, rustfmt_skip)] // https://github.com/rust-lang/rustfmt/issues/5489
+
 macro_rules! gen_compactor_config {
     (
         $name:ident,

--- a/clap_blocks/src/compactor.rs
+++ b/clap_blocks/src/compactor.rs
@@ -1,183 +1,191 @@
-//! CLI config for compactor
+//! CLI config for compactor-related commands
 
-/// CLI config for compactor
-#[derive(Debug, Clone, clap::Parser)]
-pub struct CompactorConfig {
-    /// Write buffer topic/database that the compactor will be compacting files for. It won't
-    /// connect to Kafka, but uses this to get the sequencers out of the catalog.
-    #[clap(
-        long = "--write-buffer-topic",
-        env = "INFLUXDB_IOX_WRITE_BUFFER_TOPIC",
-        default_value = "iox-shared",
-        action
-    )]
-    pub topic: String,
+macro_rules! gen_compactor_config {
+    ($name:ident $(,)?) => {
+        /// CLI config for compactor
+        #[derive(Debug, Clone, clap::Parser)]
+        pub struct $name {
+            /// Write buffer topic/database that the compactor will be compacting files for. It won't
+            /// connect to Kafka, but uses this to get the sequencers out of the catalog.
+            #[clap(
+                long = "--write-buffer-topic",
+                env = "INFLUXDB_IOX_WRITE_BUFFER_TOPIC",
+                default_value = "iox-shared",
+                action
+            )]
+            pub topic: String,
 
-    /// Write buffer partition number to start (inclusive) range with
-    #[clap(
-        long = "--write-buffer-partition-range-start",
-        env = "INFLUXDB_IOX_WRITE_BUFFER_PARTITION_RANGE_START",
-        action
-    )]
-    pub write_buffer_partition_range_start: i32,
+            /// Write buffer partition number to start (inclusive) range with
+            #[clap(
+                long = "--write-buffer-partition-range-start",
+                env = "INFLUXDB_IOX_WRITE_BUFFER_PARTITION_RANGE_START",
+                action
+            )]
+            pub write_buffer_partition_range_start: i32,
 
-    /// Write buffer partition number to end (inclusive) range with
-    #[clap(
-        long = "--write-buffer-partition-range-end",
-        env = "INFLUXDB_IOX_WRITE_BUFFER_PARTITION_RANGE_END",
-        action
-    )]
-    pub write_buffer_partition_range_end: i32,
+            /// Write buffer partition number to end (inclusive) range with
+            #[clap(
+                long = "--write-buffer-partition-range-end",
+                env = "INFLUXDB_IOX_WRITE_BUFFER_PARTITION_RANGE_END",
+                action
+            )]
+            pub write_buffer_partition_range_end: i32,
 
-    /// Desired max size of compacted parquet files.
-    /// It is a target desired value, rather than a guarantee.
-    /// 1024 * 1024 * 25 =  26,214,400 (25MB)
-    #[clap(
-        long = "--compaction-max-desired-size-bytes",
-        env = "INFLUXDB_IOX_COMPACTION_MAX_DESIRED_FILE_SIZE_BYTES",
-        default_value = "26214400",
-        action
-    )]
-    pub max_desired_file_size_bytes: u64,
+            /// Desired max size of compacted parquet files.
+            /// It is a target desired value, rather than a guarantee.
+            /// 1024 * 1024 * 25 =  26,214,400 (25MB)
+            #[clap(
+                long = "--compaction-max-desired-size-bytes",
+                env = "INFLUXDB_IOX_COMPACTION_MAX_DESIRED_FILE_SIZE_BYTES",
+                default_value = "26214400",
+                action
+            )]
+            pub max_desired_file_size_bytes: u64,
 
-    /// Percentage of desired max file size.
-    /// If the estimated compacted result is too small, no need to split it.
-    /// This percentage is to determine how small it is:
-    ///    < percentage_max_file_size * max_desired_file_size_bytes:
-    /// This value must be between (0, 100)
-    /// Default is 80
-    #[clap(
-        long = "--compaction-percentage-max-file_size",
-        env = "INFLUXDB_IOX_COMPACTION_PERCENTAGE_MAX_FILE_SIZE",
-        default_value = "80",
-        action
-    )]
-    pub percentage_max_file_size: u16,
+            /// Percentage of desired max file size.
+            /// If the estimated compacted result is too small, no need to split it.
+            /// This percentage is to determine how small it is:
+            ///    < percentage_max_file_size * max_desired_file_size_bytes:
+            /// This value must be between (0, 100)
+            /// Default is 80
+            #[clap(
+                long = "--compaction-percentage-max-file_size",
+                env = "INFLUXDB_IOX_COMPACTION_PERCENTAGE_MAX_FILE_SIZE",
+                default_value = "80",
+                action
+            )]
+            pub percentage_max_file_size: u16,
 
-    /// Split file percentage
-    /// If the estimated compacted result is neither too small nor too large, it will be split
-    /// into 2 files determined by this percentage.
-    ///    . Too small means: < percentage_max_file_size * max_desired_file_size_bytes
-    ///    . Too large means: > max_desired_file_size_bytes
-    ///    . Any size in the middle will be considered neither too small nor too large
-    ///
-    /// This value must be between (0, 100)
-    /// Default is 80
-    #[clap(
-        long = "--compaction-split-percentage",
-        env = "INFLUXDB_IOX_COMPACTION_SPLIT_PERCENTAGE",
-        default_value = "80",
-        action
-    )]
-    pub split_percentage: u16,
+            /// Split file percentage
+            /// If the estimated compacted result is neither too small nor too large, it will be split
+            /// into 2 files determined by this percentage.
+            ///    . Too small means: < percentage_max_file_size * max_desired_file_size_bytes
+            ///    . Too large means: > max_desired_file_size_bytes
+            ///    . Any size in the middle will be considered neither too small nor too large
+            ///
+            /// This value must be between (0, 100)
+            /// Default is 80
+            #[clap(
+                long = "--compaction-split-percentage",
+                env = "INFLUXDB_IOX_COMPACTION_SPLIT_PERCENTAGE",
+                default_value = "80",
+                action
+            )]
+            pub split_percentage: u16,
 
-    /// The compactor will limit the number of simultaneous hot partition compaction jobs based on
-    /// the size of the input files to be compacted. This number should be less than 1/10th of the
-    /// available memory to ensure compactions have enough space to run.
-    ///
-    /// Default is 1024 * 1024 * 1024 = 1,073,741,824 bytes (1GB).
-    //
-    // The number of compact_hot_partititons run in parallel is determined by:
-    //    max_concurrent_size_bytes/input_size_threshold_bytes
-    #[clap(
-        long = "--compaction-concurrent-size-bytes",
-        env = "INFLUXDB_IOX_COMPACTION_CONCURRENT_SIZE_BYTES",
-        default_value = "1073741824",
-        action
-    )]
-    pub max_concurrent_size_bytes: u64,
+            /// The compactor will limit the number of simultaneous hot partition compaction jobs based on
+            /// the size of the input files to be compacted. This number should be less than 1/10th of the
+            /// available memory to ensure compactions have enough space to run.
+            ///
+            /// Default is 1024 * 1024 * 1024 = 1,073,741,824 bytes (1GB).
+            //
+            // The number of compact_hot_partititons run in parallel is determined by:
+            //    max_concurrent_size_bytes/input_size_threshold_bytes
+            #[clap(
+                long = "--compaction-concurrent-size-bytes",
+                env = "INFLUXDB_IOX_COMPACTION_CONCURRENT_SIZE_BYTES",
+                default_value = "1073741824",
+                action
+            )]
+            pub max_concurrent_size_bytes: u64,
 
-    /// The compactor will limit the number of simultaneous cold partition compaction jobs based on
-    /// the size of the input files to be compacted. This number should be less than 1/10th of the
-    /// available memory to ensure compactions have enough space to run.
-    ///
-    /// Default is 1024 * 1024 * 900 = 943,718,400 bytes (900MB).
-    //
-    // The number of compact_cold_partititons run in parallel is determined by:
-    //    max_cold_concurrent_size_bytes/cold_input_size_threshold_bytes
-    #[clap(
-        long = "--compaction-cold-concurrent-size-bytes",
-        env = "INFLUXDB_IOX_COMPACTION_COLD_CONCURRENT_SIZE_BYTES",
-        default_value = "943718400",
-        action
-    )]
-    pub max_cold_concurrent_size_bytes: u64,
+            /// The compactor will limit the number of simultaneous cold partition compaction jobs based on
+            /// the size of the input files to be compacted. This number should be less than 1/10th of the
+            /// available memory to ensure compactions have enough space to run.
+            ///
+            /// Default is 1024 * 1024 * 900 = 943,718,400 bytes (900MB).
+            //
+            // The number of compact_cold_partititons run in parallel is determined by:
+            //    max_cold_concurrent_size_bytes/cold_input_size_threshold_bytes
+            #[clap(
+                long = "--compaction-cold-concurrent-size-bytes",
+                env = "INFLUXDB_IOX_COMPACTION_COLD_CONCURRENT_SIZE_BYTES",
+                default_value = "943718400",
+                action
+            )]
+            pub max_cold_concurrent_size_bytes: u64,
 
-    /// Max number of partitions per sequencer we want to compact per cycle
-    /// Default: 1
-    #[clap(
-        long = "--compaction-max-number-partitions-per-sequencer",
-        env = "INFLUXDB_IOX_COMPACTION_MAX_NUMBER_PARTITIONS_PER_SEQUENCER",
-        default_value = "1",
-        action
-    )]
-    pub max_number_partitions_per_sequencer: usize,
+            /// Max number of partitions per sequencer we want to compact per cycle
+            /// Default: 1
+            #[clap(
+                long = "--compaction-max-number-partitions-per-sequencer",
+                env = "INFLUXDB_IOX_COMPACTION_MAX_NUMBER_PARTITIONS_PER_SEQUENCER",
+                default_value = "1",
+                action
+            )]
+            pub max_number_partitions_per_sequencer: usize,
 
-    /// Min number of recent ingested files a partition needs to be considered for compacting
-    /// Default: 1
-    #[clap(
-        long = "--compaction-min-number-recent-ingested-files-per-partition",
-        env = "INFLUXDB_IOX_COMPACTION_MIN_NUMBER_RECENT_INGESTED_FILES_PER_PARTITION",
-        default_value = "1",
-        action
-    )]
-    pub min_number_recent_ingested_files_per_partition: usize,
+            /// Min number of recent ingested files a partition needs to be considered for compacting
+            /// Default: 1
+            #[clap(
+                long = "--compaction-min-number-recent-ingested-files-per-partition",
+                env = "INFLUXDB_IOX_COMPACTION_MIN_NUMBER_RECENT_INGESTED_FILES_PER_PARTITION",
+                default_value = "1",
+                action
+            )]
+            pub min_number_recent_ingested_files_per_partition: usize,
 
-    /// A compaction operation for hot partitions will gather as many L0 files with their
-    /// overlapping L1 files to compact together until the total size of input files crosses this
-    /// threshold. Later compactions will pick up the remaining L0 files.
-    ///
-    /// A compaction operation will be limited by this or by the file count threshold, whichever is
-    /// hit first.
-    ///
-    /// Default is 1024 * 1024 * 100 = 100,048,576 bytes (100MB).
-    #[clap(
-        long = "--compaction-input-size-threshold-bytes",
-        env = "INFLUXDB_IOX_COMPACTION_INPUT_SIZE_THRESHOLD_BYTES",
-        default_value = "100048576",
-        action
-    )]
-    pub input_size_threshold_bytes: u64,
+            /// A compaction operation for hot partitions will gather as many L0 files with their
+            /// overlapping L1 files to compact together until the total size of input files crosses this
+            /// threshold. Later compactions will pick up the remaining L0 files.
+            ///
+            /// A compaction operation will be limited by this or by the file count threshold, whichever is
+            /// hit first.
+            ///
+            /// Default is 1024 * 1024 * 100 = 100,048,576 bytes (100MB).
+            #[clap(
+                long = "--compaction-input-size-threshold-bytes",
+                env = "INFLUXDB_IOX_COMPACTION_INPUT_SIZE_THRESHOLD_BYTES",
+                default_value = "100048576",
+                action
+            )]
+            pub input_size_threshold_bytes: u64,
 
-    /// A compaction operation for cold partitions will gather as many L0 files with their
-    /// overlapping L1 files to compact together until the total size of input files crosses this
-    /// threshold. Later compactions will pick up the remaining L0 files.
-    ///
-    /// Default is 1024 * 1024 * 600 = 629,145,600 bytes (600MB).
-    #[clap(
-        long = "--compaction-cold-input-size-threshold-bytes",
-        env = "INFLUXDB_IOX_COMPACTION_COLD_INPUT_SIZE_THRESHOLD_BYTES",
-        default_value = "629145600",
-        action
-    )]
-    pub cold_input_size_threshold_bytes: u64,
+            /// A compaction operation for cold partitions will gather as many L0 files with their
+            /// overlapping L1 files to compact together until the total size of input files crosses this
+            /// threshold. Later compactions will pick up the remaining L0 files.
+            ///
+            /// Default is 1024 * 1024 * 600 = 629,145,600 bytes (600MB).
+            #[clap(
+                long = "--compaction-cold-input-size-threshold-bytes",
+                env = "INFLUXDB_IOX_COMPACTION_COLD_INPUT_SIZE_THRESHOLD_BYTES",
+                default_value = "629145600",
+                action
+            )]
+            pub cold_input_size_threshold_bytes: u64,
 
-    /// A compaction operation will gather as many L0 files with their overlapping L1 files to
-    /// compact together until the total number of L0 + L1 files crosses this threshold. Later
-    /// compactions will pick up the remaining L0 files.
-    ///
-    /// A compaction operation will be limited by this or by the input size threshold, whichever is
-    /// hit first.
-    ///
-    /// Default is 50.
-    #[clap(
-        long = "--compaction-input-file-count-threshold",
-        env = "INFLUXDB_IOX_COMPACTION_INPUT_FILE_COUNT_THRESHOLD",
-        default_value = "50",
-        action
-    )]
-    pub input_file_count_threshold: usize,
+            /// A compaction operation will gather as many L0 files with their overlapping L1 files to
+            /// compact together until the total number of L0 + L1 files crosses this threshold. Later
+            /// compactions will pick up the remaining L0 files.
+            ///
+            /// A compaction operation will be limited by this or by the input size threshold, whichever is
+            /// hit first.
+            ///
+            /// Default is 50.
+            #[clap(
+                long = "--compaction-input-file-count-threshold",
+                env = "INFLUXDB_IOX_COMPACTION_INPUT_FILE_COUNT_THRESHOLD",
+                default_value = "50",
+                action
+            )]
+            pub input_file_count_threshold: usize,
 
-    /// The multiple of times that compacting hot partitions should run for every one time that
-    /// compacting cold partitions runs. Set to 1 to compact hot partitions and cold partitions
-    /// equally.
-    ///
-    /// Default is 4.
-    #[clap(
-        long = "--compaction-hot-multiple",
-        env = "INFLUXDB_IOX_COMPACTION_HOT_MULTIPLE",
-        default_value = "4",
-        action
-    )]
-    pub hot_multiple: usize,
+            /// The multiple of times that compacting hot partitions should run for every one time that
+            /// compacting cold partitions runs. Set to 1 to compact hot partitions and cold partitions
+            /// equally.
+            ///
+            /// Default is 4.
+            #[clap(
+                long = "--compaction-hot-multiple",
+                env = "INFLUXDB_IOX_COMPACTION_HOT_MULTIPLE",
+                default_value = "4",
+                action
+            )]
+            pub hot_multiple: usize,
+        }
+    };
 }
+
+gen_compactor_config!(
+    CompactorConfig,
+);

--- a/clap_blocks/src/compactor.rs
+++ b/clap_blocks/src/compactor.rs
@@ -9,8 +9,8 @@ macro_rules! gen_compactor_config {
         /// CLI config for compactor
         #[derive(Debug, Clone, clap::Parser)]
         pub struct $name {
-            /// Write buffer topic/database that the compactor will be compacting files for. It won't
-            /// connect to Kafka, but uses this to get the sequencers out of the catalog.
+            /// Write buffer topic/database that the compactor will be compacting files for. It
+            /// won't connect to Kafka, but uses this to get the sequencers out of the catalog.
             #[clap(
                 long = "--write-buffer-topic",
                 env = "INFLUXDB_IOX_WRITE_BUFFER_TOPIC",
@@ -61,8 +61,8 @@ macro_rules! gen_compactor_config {
             pub percentage_max_file_size: u16,
 
             /// Split file percentage
-            /// If the estimated compacted result is neither too small nor too large, it will be split
-            /// into 2 files determined by this percentage.
+            /// If the estimated compacted result is neither too small nor too large, it will be
+            /// split into 2 files determined by this percentage.
             ///    . Too small means: < percentage_max_file_size * max_desired_file_size_bytes
             ///    . Too large means: > max_desired_file_size_bytes
             ///    . Any size in the middle will be considered neither too small nor too large
@@ -77,9 +77,9 @@ macro_rules! gen_compactor_config {
             )]
             pub split_percentage: u16,
 
-            /// The compactor will limit the number of simultaneous hot partition compaction jobs based on
-            /// the size of the input files to be compacted. This number should be less than 1/10th of the
-            /// available memory to ensure compactions have enough space to run.
+            /// The compactor will limit the number of simultaneous hot partition compaction jobs
+            /// based on the size of the input files to be compacted. This number should be less
+            /// than 1/10th of the available memory to ensure compactions have enough space to run.
             ///
             /// Default is 1024 * 1024 * 1024 = 1,073,741,824 bytes (1GB).
             //
@@ -93,9 +93,9 @@ macro_rules! gen_compactor_config {
             )]
             pub max_concurrent_size_bytes: u64,
 
-            /// The compactor will limit the number of simultaneous cold partition compaction jobs based on
-            /// the size of the input files to be compacted. This number should be less than 1/10th of the
-            /// available memory to ensure compactions have enough space to run.
+            /// The compactor will limit the number of simultaneous cold partition compaction jobs
+            /// based on the size of the input files to be compacted. This number should be less
+            /// than 1/10th of the available memory to ensure compactions have enough space to run.
             ///
             /// Default is 1024 * 1024 * 900 = 943,718,400 bytes (900MB).
             //
@@ -119,7 +119,9 @@ macro_rules! gen_compactor_config {
             )]
             pub max_number_partitions_per_sequencer: usize,
 
-            /// Min number of recent ingested files a partition needs to be considered for compacting
+            /// Min number of recent ingested files a partition needs to be considered for
+            /// compacting
+            ///
             /// Default: 1
             #[clap(
                 long = "--compaction-min-number-recent-ingested-files-per-partition",
@@ -130,11 +132,11 @@ macro_rules! gen_compactor_config {
             pub min_number_recent_ingested_files_per_partition: usize,
 
             /// A compaction operation for hot partitions will gather as many L0 files with their
-            /// overlapping L1 files to compact together until the total size of input files crosses this
-            /// threshold. Later compactions will pick up the remaining L0 files.
+            /// overlapping L1 files to compact together until the total size of input files
+            /// crosses this threshold. Later compactions will pick up the remaining L0 files.
             ///
-            /// A compaction operation will be limited by this or by the file count threshold, whichever is
-            /// hit first.
+            /// A compaction operation will be limited by this or by the file count threshold,
+            /// whichever is hit first.
             ///
             /// Default is 1024 * 1024 * 100 = 100,048,576 bytes (100MB).
             #[clap(
@@ -146,8 +148,8 @@ macro_rules! gen_compactor_config {
             pub input_size_threshold_bytes: u64,
 
             /// A compaction operation for cold partitions will gather as many L0 files with their
-            /// overlapping L1 files to compact together until the total size of input files crosses this
-            /// threshold. Later compactions will pick up the remaining L0 files.
+            /// overlapping L1 files to compact together until the total size of input files
+            /// crosses this threshold. Later compactions will pick up the remaining L0 files.
             ///
             /// Default is 1024 * 1024 * 600 = 629,145,600 bytes (600MB).
             #[clap(
@@ -158,12 +160,12 @@ macro_rules! gen_compactor_config {
             )]
             pub cold_input_size_threshold_bytes: u64,
 
-            /// A compaction operation will gather as many L0 files with their overlapping L1 files to
-            /// compact together until the total number of L0 + L1 files crosses this threshold. Later
-            /// compactions will pick up the remaining L0 files.
+            /// A compaction operation will gather as many L0 files with their overlapping L1 files
+            /// to compact together until the total number of L0 + L1 files crosses this threshold.
+            /// Later compactions will pick up the remaining L0 files.
             ///
-            /// A compaction operation will be limited by this or by the input size threshold, whichever is
-            /// hit first.
+            /// A compaction operation will be limited by this or by the input size threshold,
+            /// whichever is hit first.
             ///
             /// Default is 50.
             #[clap(
@@ -174,9 +176,9 @@ macro_rules! gen_compactor_config {
             )]
             pub input_file_count_threshold: usize,
 
-            /// The multiple of times that compacting hot partitions should run for every one time that
-            /// compacting cold partitions runs. Set to 1 to compact hot partitions and cold partitions
-            /// equally.
+            /// The multiple of times that compacting hot partitions should run for every one time
+            /// that compacting cold partitions runs. Set to 1 to compact hot partitions and cold
+            /// partitions equally.
             ///
             /// Default is
             #[doc = $hot_multiple_def]

--- a/compactor/src/handler.rs
+++ b/compactor/src/handler.rs
@@ -1,18 +1,14 @@
 //! Compactor handler
 
 use async_trait::async_trait;
-use backoff::{Backoff, BackoffConfig};
-use data_types::SequencerId;
+use backoff::Backoff;
 use futures::{
     future::{BoxFuture, Shared},
     FutureExt, StreamExt, TryFutureExt,
 };
-use iox_catalog::interface::Catalog;
 use iox_query::exec::Executor;
-use iox_time::TimeProvider;
 use metric::Attributes;
 use observability_deps::tracing::*;
-use parquet_file::storage::ParquetStorage;
 use std::sync::Arc;
 use thiserror::Error;
 use tokio::{
@@ -66,29 +62,7 @@ pub struct CompactorHandlerImpl {
 
 impl CompactorHandlerImpl {
     /// Initialize the Compactor
-    pub fn new(
-        sequencers: Vec<SequencerId>,
-        catalog: Arc<dyn Catalog>,
-        store: ParquetStorage,
-        exec: Arc<Executor>,
-        time_provider: Arc<dyn TimeProvider>,
-        registry: Arc<metric::Registry>,
-        config: CompactorConfig,
-    ) -> Self {
-        Self::new_with_compactor(Compactor::new(
-            sequencers,
-            catalog,
-            store,
-            exec,
-            time_provider,
-            BackoffConfig::default(),
-            config,
-            registry,
-        ))
-    }
-
-    /// Initialize the Compactor
-    pub fn new_with_compactor(compactor: Compactor) -> Self {
+    pub fn new(compactor: Compactor) -> Self {
         let compactor_data = Arc::new(compactor);
 
         let shutdown = CancellationToken::new();

--- a/influxdb_iox/Cargo.toml
+++ b/influxdb_iox/Cargo.toml
@@ -8,6 +8,7 @@ default-run = "influxdb_iox"
 [dependencies]
 # Workspace dependencies, in alphabetical order
 clap_blocks = { path = "../clap_blocks" }
+compactor = { path = "../compactor" }
 data_types = { path = "../data_types" }
 datafusion = { path = "../datafusion" }
 generated_types = { path = "../generated_types" }

--- a/influxdb_iox/src/commands/compactor.rs
+++ b/influxdb_iox/src/commands/compactor.rs
@@ -1,0 +1,104 @@
+use clap_blocks::{
+    catalog_dsn::CatalogDsnConfig,
+    compactor::CompactorConfig,
+    object_store::{make_object_store, ObjectStoreConfig},
+};
+use iox_query::exec::Executor;
+use iox_time::{SystemProvider, TimeProvider};
+use ioxd_compactor::build_compactor_from_config;
+use object_store::DynObjectStore;
+use object_store_metrics::ObjectStoreMetrics;
+use snafu::prelude::*;
+use std::sync::Arc;
+
+#[derive(Debug, clap::Parser)]
+pub struct Config {
+    #[clap(subcommand)]
+    command: Command,
+}
+
+#[derive(Debug, clap::Parser)]
+pub enum Command {
+    /// Run the compactor for one cycle
+    RunOnce {
+        #[clap(flatten)]
+        object_store_config: ObjectStoreConfig,
+
+        #[clap(flatten)]
+        catalog_dsn: CatalogDsnConfig,
+
+        #[clap(flatten)]
+        compactor_config: CompactorConfig,
+
+        /// Number of threads to use for the compactor query execution, compaction and persistence.
+        #[clap(
+            long = "--query-exec-thread-count",
+            env = "INFLUXDB_IOX_QUERY_EXEC_THREAD_COUNT",
+            default_value = "4",
+            action
+        )]
+        query_exec_thread_count: usize,
+    },
+}
+
+pub async fn command(config: Config) -> Result<()> {
+    match config.command {
+        Command::RunOnce {
+            object_store_config,
+            catalog_dsn,
+            compactor_config,
+            query_exec_thread_count,
+        } => {
+            let time_provider = Arc::new(SystemProvider::new()) as Arc<dyn TimeProvider>;
+            let metric_registry: Arc<metric::Registry> = Default::default();
+            let catalog = catalog_dsn
+                .get_catalog("compactor", Arc::clone(&metric_registry))
+                .await?;
+
+            let object_store = make_object_store(&object_store_config)?;
+
+            // Decorate the object store with a metric recorder.
+            let object_store: Arc<DynObjectStore> = Arc::new(ObjectStoreMetrics::new(
+                object_store,
+                Arc::clone(&time_provider),
+                &*metric_registry,
+            ));
+
+            let exec = Arc::new(Executor::new(query_exec_thread_count));
+            let time_provider = Arc::new(SystemProvider::new());
+
+            let compactor = build_compactor_from_config(
+                compactor_config,
+                catalog,
+                object_store,
+                exec,
+                time_provider,
+                metric_registry,
+            )
+            .await?;
+            let compactor = Arc::new(compactor);
+
+            compactor::handler::run_compactor_once(compactor).await;
+        }
+    }
+
+    Ok(())
+}
+
+#[derive(Debug, Snafu)]
+pub enum Error {
+    #[snafu(context(false))]
+    CatalogParsing {
+        source: clap_blocks::catalog_dsn::Error,
+    },
+
+    #[snafu(context(false))]
+    ObjectStoreParsing {
+        source: clap_blocks::object_store::ParseError,
+    },
+
+    #[snafu(context(false))]
+    Compacting { source: ioxd_compactor::Error },
+}
+
+pub type Result<T, E = Error> = std::result::Result<T, E>;

--- a/influxdb_iox/src/commands/compactor.rs
+++ b/influxdb_iox/src/commands/compactor.rs
@@ -1,6 +1,6 @@
 use clap_blocks::{
     catalog_dsn::CatalogDsnConfig,
-    compactor::CompactorConfig,
+    compactor::CompactorOnceConfig,
     object_store::{make_object_store, ObjectStoreConfig},
 };
 use iox_query::exec::Executor;
@@ -28,7 +28,7 @@ pub enum Command {
         catalog_dsn: CatalogDsnConfig,
 
         #[clap(flatten)]
-        compactor_config: CompactorConfig,
+        compactor_config: CompactorOnceConfig,
 
         /// Number of threads to use for the compactor query execution, compaction and persistence.
         #[clap(
@@ -49,6 +49,8 @@ pub async fn command(config: Config) -> Result<()> {
             compactor_config,
             query_exec_thread_count,
         } => {
+            let compactor_config = compactor_config.into_compactor_config();
+
             let time_provider = Arc::new(SystemProvider::new()) as Arc<dyn TimeProvider>;
             let metric_registry: Arc<metric::Registry> = Default::default();
             let catalog = catalog_dsn

--- a/influxdb_iox/src/main.rs
+++ b/influxdb_iox/src/main.rs
@@ -28,6 +28,7 @@ use tokio::runtime::Runtime;
 
 mod commands {
     pub mod catalog;
+    pub mod compactor;
     pub mod debug;
     pub mod import;
     pub mod query;
@@ -158,6 +159,9 @@ enum Command {
     /// Various commands for catalog manipulation
     Catalog(commands::catalog::Config),
 
+    /// Various commands for compactor manipulation
+    Compactor(Box<commands::compactor::Config>),
+
     /// Interrogate internal database data
     Debug(commands::debug::Config),
 
@@ -274,6 +278,13 @@ fn main() -> Result<(), std::io::Error> {
             Some(Command::Catalog(config)) => {
                 let _tracing_guard = handle_init_logs(init_simple_logs(log_verbose_count));
                 if let Err(e) = commands::catalog::command(config).await {
+                    eprintln!("{}", e);
+                    std::process::exit(ReturnCode::Failure as _)
+                }
+            }
+            Some(Command::Compactor(config)) => {
+                let _tracing_guard = handle_init_logs(init_simple_logs(log_verbose_count));
+                if let Err(e) = commands::compactor::command(*config).await {
                     eprintln!("{}", e);
                     std::process::exit(ReturnCode::Failure as _)
                 }

--- a/influxdb_iox/tests/end_to_end_cases/cli.rs
+++ b/influxdb_iox/tests/end_to_end_cases/cli.rs
@@ -187,6 +187,153 @@ async fn remote_partition_and_get_from_store_and_pull() {
     .await
 }
 
+/// Write, compact, then use the remote partition command
+#[tokio::test]
+async fn compact_and_get_remote_partition() {
+    test_helpers::maybe_start_logging();
+    let database_url = maybe_skip_integration!();
+
+    // The test below assumes a specific partition id, so use a
+    // non-shared one here so concurrent tests don't interfere with
+    // each other
+    let mut cluster = MiniCluster::create_non_shared_standard(database_url).await;
+
+    StepTest::new(
+        &mut cluster,
+        vec![
+            Step::WriteLineProtocol(String::from(
+                "my_awesome_table,tag1=A,tag2=B val=42i 123456",
+            )),
+            // wait for partitions to be persisted
+            Step::WaitForPersisted,
+            // Run the compactor
+            Step::Compact,
+            // Run the 'remote partition' command
+            Step::Custom(Box::new(|state: &mut StepTestState| {
+                async {
+                    let router_addr = state.cluster().router().router_grpc_base().to_string();
+                    let namespace = state.cluster().namespace().to_string();
+
+                    // Validate the output of the remote partittion CLI command
+                    //
+                    // Looks like:
+                    // {
+                    //     "id": "2",
+                    //     "sequencerId": 1,
+                    //     "namespaceId": 1,
+                    //     "tableId": 1,
+                    //     "partitionId": "1",
+                    //     "objectStoreId": "fa6cdcd1-cbc2-4fb7-8b51-4773079124dd",
+                    //     "minTime": "123456",
+                    //     "maxTime": "123456",
+                    //     "fileSizeBytes": "2029",
+                    //     "rowCount": "1",
+                    //     "compactionLevel": "1",
+                    //     "createdAt": "1650019674289347000"
+                    // }
+
+                    let out = Command::cargo_bin("influxdb_iox")
+                        .unwrap()
+                        .arg("-h")
+                        .arg(&router_addr)
+                        .arg("remote")
+                        .arg("partition")
+                        .arg("show")
+                        .arg("1")
+                        .assert()
+                        .success()
+                        .stdout(
+                            predicate::str::contains(r#""id": "2""#)
+                                .and(predicate::str::contains(r#""partitionId": "1","#))
+                                .and(predicate::str::contains(r#""compactionLevel": 1"#)),
+                        )
+                        .get_output()
+                        .stdout
+                        .clone();
+
+                    let v: Value = serde_json::from_slice(&out).unwrap();
+                    let id = v.as_array().unwrap()[0]
+                        .as_object()
+                        .unwrap()
+                        .get("objectStoreId")
+                        .unwrap()
+                        .as_str()
+                        .unwrap();
+
+                    let dir = tempdir().unwrap();
+                    let f = dir.path().join("tmp.parquet");
+                    let filename = f.as_os_str().to_str().unwrap();
+
+                    Command::cargo_bin("influxdb_iox")
+                        .unwrap()
+                        .arg("-h")
+                        .arg(&router_addr)
+                        .arg("remote")
+                        .arg("store")
+                        .arg("get")
+                        .arg(id)
+                        .arg(filename)
+                        .assert()
+                        .success()
+                        .stdout(
+                            predicate::str::contains("wrote")
+                                .and(predicate::str::contains(filename)),
+                        );
+
+                    // Ensure a warning is emitted when specifying (or
+                    // defaulting to) in-memory file storage.
+                    Command::cargo_bin("influxdb_iox")
+                        .unwrap()
+                        .arg("-h")
+                        .arg(&router_addr)
+                        .arg("remote")
+                        .arg("partition")
+                        .arg("pull")
+                        .arg("--catalog")
+                        .arg("memory")
+                        .arg("--object-store")
+                        .arg("memory")
+                        .arg(&namespace)
+                        .arg("my_awesome_table")
+                        .arg("1970-01-01")
+                        .assert()
+                        .failure()
+                        .stderr(predicate::str::contains("try passing --object-store=file"));
+
+                    // Ensure files are actually wrote to the filesystem
+                    let dir = tempfile::tempdir().expect("could not get temporary directory");
+
+                    Command::cargo_bin("influxdb_iox")
+                        .unwrap()
+                        .arg("-h")
+                        .arg(&router_addr)
+                        .arg("remote")
+                        .arg("partition")
+                        .arg("pull")
+                        .arg("--catalog")
+                        .arg("memory")
+                        .arg("--object-store")
+                        .arg("file")
+                        .arg("--data-dir")
+                        .arg(dir.path().to_str().unwrap())
+                        .arg(&namespace)
+                        .arg("my_awesome_table")
+                        .arg("1970-01-01")
+                        .assert()
+                        .success()
+                        .stdout(
+                            predicate::str::contains("wrote file")
+                                .and(predicate::str::contains(id)),
+                        );
+                }
+                .boxed()
+            })),
+        ],
+    )
+    .run()
+    .await
+}
+
 /// Test the schema cli command
 #[tokio::test]
 async fn schema_cli() {

--- a/influxdb_iox/tests/end_to_end_cases/cli.rs
+++ b/influxdb_iox/tests/end_to_end_cases/cli.rs
@@ -73,7 +73,7 @@ async fn remote_partition_and_get_from_store_and_pull() {
                     //
                     // Looks like:
                     // {
-                    //     "id": "2",
+                    //     "id": "1",
                     //     "sequencerId": 1,
                     //     "namespaceId": 1,
                     //     "tableId": 1,
@@ -83,7 +83,6 @@ async fn remote_partition_and_get_from_store_and_pull() {
                     //     "maxTime": "123456",
                     //     "fileSizeBytes": "2029",
                     //     "rowCount": "1",
-                    //     "compactionLevel": 1,
                     //     "createdAt": "1650019674289347000"
                     // }
 
@@ -98,7 +97,7 @@ async fn remote_partition_and_get_from_store_and_pull() {
                         .assert()
                         .success()
                         .stdout(
-                            predicate::str::contains(r#""id": "2""#)
+                            predicate::str::contains(r#""id": "1""#)
                                 .and(predicate::str::contains(r#""partitionId": "1","#)),
                         )
                         .get_output()

--- a/influxdb_iox/tests/end_to_end_cases/error.rs
+++ b/influxdb_iox/tests/end_to_end_cases/error.rs
@@ -28,13 +28,6 @@ pub async fn test_panic() {
                 let querier = state.cluster().querier();
                 assert_panic_logging(querier.querier_grpc_connection(), querier.log_path().await)
                     .await;
-
-                let compactor = state.cluster().compactor();
-                assert_panic_logging(
-                    compactor.compactor_grpc_connection(),
-                    compactor.log_path().await,
-                )
-                .await;
             }
             .boxed()
         }))],

--- a/ioxd_compactor/Cargo.toml
+++ b/ioxd_compactor/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 
 [dependencies]
 # Workspace dependencies, in alphabetical order
+backoff = { path = "../backoff" }
 clap_blocks = { path = "../clap_blocks" }
 compactor = { path = "../compactor" }
 data_types = { path = "../data_types" }

--- a/ioxd_compactor/src/lib.rs
+++ b/ioxd_compactor/src/lib.rs
@@ -146,7 +146,7 @@ pub async fn create_compactor_server_type(
     )
     .await?;
 
-    let compactor_handler = Arc::new(CompactorHandlerImpl::new_with_compactor(compactor));
+    let compactor_handler = Arc::new(CompactorHandlerImpl::new(compactor));
     let compactor = CompactorServer::new(metric_registry, compactor_handler);
     Ok(Arc::new(CompactorServerType::new(compactor, common_state)))
 }

--- a/ioxd_compactor/src/lib.rs
+++ b/ioxd_compactor/src/lib.rs
@@ -176,16 +176,19 @@ pub async fn create_compactor_server_type(
         compactor_config.input_file_count_threshold,
         compactor_config.hot_multiple,
     );
-    let compactor_handler = Arc::new(CompactorHandlerImpl::new(
+
+    let compactor = compactor::compact::Compactor::new(
         sequencers,
         catalog,
         parquet_store,
         exec,
         time_provider,
-        Arc::clone(&metric_registry),
+        backoff::BackoffConfig::default(),
         compactor_config,
-    ));
+        Arc::clone(&metric_registry),
+    );
 
+    let compactor_handler = Arc::new(CompactorHandlerImpl::new_with_compactor(compactor));
     let compactor = CompactorServer::new(metric_registry, compactor_handler);
     Ok(Arc::new(CompactorServerType::new(compactor, common_state)))
 }

--- a/test_helpers_end_to_end/src/lib.rs
+++ b/test_helpers_end_to_end/src/lib.rs
@@ -51,6 +51,25 @@ pub fn rand_id() -> String {
         .collect()
 }
 
+/// Log the [`std::process::Command`] being run in a way that's convenient to copy-paste
+fn log_command(command: &std::process::Command) {
+    use observability_deps::tracing::info;
+
+    let envs_for_printing: Vec<_> = command
+        .get_envs()
+        .map(|(key, value)| {
+            format!(
+                "{}={}",
+                key.to_str().unwrap(),
+                value.unwrap_or_default().to_str().unwrap()
+            )
+        })
+        .collect();
+    let envs_for_printing = envs_for_printing.join(" ");
+
+    info!("Running command: `{envs_for_printing} {:?}`", command);
+}
+
 /// Dumps the content of the log file to stdout
 fn dump_log_to_stdout(server_type: &str, log_path: &std::path::Path) {
     use observability_deps::tracing::info;

--- a/test_helpers_end_to_end/src/lib.rs
+++ b/test_helpers_end_to_end/src/lib.rs
@@ -51,6 +51,37 @@ pub fn rand_id() -> String {
         .collect()
 }
 
+/// Dumps the content of the log file to stdout
+fn dump_log_to_stdout(server_type: &str, log_path: &std::path::Path) {
+    use observability_deps::tracing::info;
+    use std::io::Read;
+
+    let mut f = std::fs::File::open(log_path).expect("failed to open log file");
+    let mut buffer = [0_u8; 8 * 1024];
+
+    info!("****************");
+    info!("Start {server_type} Output");
+    info!("****************");
+
+    while let Ok(read) = f.read(&mut buffer) {
+        if read == 0 {
+            break;
+        }
+        if let Ok(str) = std::str::from_utf8(&buffer[..read]) {
+            print!("{}", str);
+        } else {
+            info!(
+                "\n\n-- ERROR IN TRANSFER -- please see {:?} for raw contents ---\n\n",
+                log_path
+            );
+        }
+    }
+
+    info!("****************");
+    info!("End {server_type} Output");
+    info!("****************");
+}
+
 // Helper macro to skip tests if TEST_INTEGRATION and TEST_INFLUXDB_IOX_CATALOG_DSN environment
 // variables are not set.
 #[macro_export]

--- a/test_helpers_end_to_end/src/server_fixture.rs
+++ b/test_helpers_end_to_end/src/server_fixture.rs
@@ -15,7 +15,7 @@ use tempfile::NamedTempFile;
 use test_helpers::timeout::FutureTimeout;
 use tokio::sync::Mutex;
 
-use crate::{database::initialize_db, dump_log_to_stdout, server_type::AddAddrEnv};
+use crate::{database::initialize_db, dump_log_to_stdout, log_command, server_type::AddAddrEnv};
 
 use super::{addrs::BindAddresses, ServerType, TestConfig};
 
@@ -360,12 +360,14 @@ impl TestServer {
                 .env("INFLUXDB_IOX_CATALOG_POSTGRES_SCHEMA_NAME", schema_name);
         }
 
-        let child = command
+        command = command
             // redirect output to log file
             .stdout(stdout_log_file)
-            .stderr(stderr_log_file)
-            .spawn()
-            .unwrap();
+            .stderr(stderr_log_file);
+
+        log_command(command);
+
+        let child = command.spawn().unwrap();
 
         Process { child, log_path }
     }

--- a/test_helpers_end_to_end/src/steps.rs
+++ b/test_helpers_end_to_end/src/steps.rs
@@ -88,6 +88,9 @@ pub enum Step {
     /// know about the ingester, so the test needs to ask the ingester directly.
     WaitForPersistedAccordingToIngester,
 
+    /// Run one hot and one cold compaction operation and wait for it to finish.
+    Compact,
+
     /// Run a query using the FlightSQL interface and verify that the
     /// results match the expected results using the
     /// `assert_batches_eq!` macro
@@ -195,6 +198,11 @@ impl<'a> StepTest<'a> {
                         assert!(!persisted);
                     }
                     info!("====Done checking all tokens not persisted");
+                }
+                Step::Compact => {
+                    info!("====Begin running compaction");
+                    state.cluster.run_compaction();
+                    info!("====Done running compaction");
                 }
                 Step::Query { sql, expected } => {
                     info!("====Begin running query: {}", sql);


### PR DESCRIPTION
So before this PR, some of the tests were running a compactor, doing its own thing willy-nilly as we want it to do in production. That's pretty inconvenient in the tests, like [in this PR](https://github.com/influxdata/influxdb_iox/pull/5194), as we want to be able to say "ok run compaction now, and once it's done, then assert some things".

So, in the tests, rather than running the compactor as a server, we've created a command `influxdb_iox compactor run-once` that will run the compactor loop one time and then exit. It sets a default of `--compaction-hot-multiple` to 1 so that `run-once` will run one hot and one cold compaction operation. We can change other defaults of other settings if that sounds useful.

I could see this command being useful in development, if you want to run a compaction cycle with particular settings and know it's only going to go through the loop once and then you can examine what it did.

And I can see this command being useful in production-- say there's some sort of incident, a customer dumped in a whole bunch of data, a compactor gets behind, other customers are getting mad or something, and whoever's on call just wants to spin up a new instance and compact a targeted set *right now*-- this command will enable that! 

These other use cases may also inform the setting of defaults for other options. 

So. 

This PR reverted the change made to the e2e test in https://github.com/influxdata/influxdb_iox/pull/5194. That change was necessary because the mini cluster was always running the compactor (and the compactor went from not doing anything to compacting). This PR makes the mini cluster *never* run the compactor.

Then, we added the altered version of the test from that PR, and added in the step `Step::Compact`. This test passes!

I also made some improvements to the test logging along the way, like logging what command exactly the tests are running, both for the server commands and the new `compactor run-once` command.