### PR TITLE
build: bump rskafka

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4211,7 +4211,7 @@ dependencies = [
 [[package]]
 name = "rskafka"
 version = "0.3.0"
-source = "git+https://github.com/influxdata/rskafka.git?rev=9f1e36e8f34a4b0a7323bde623667470b4559a7d#9f1e36e8f34a4b0a7323bde623667470b4559a7d"
+source = "git+https://github.com/influxdata/rskafka.git?rev=4f13b67b5e4b4ee8ad25c0c8370f1e63a06243e0#4f13b67b5e4b4ee8ad25c0c8370f1e63a06243e0"
 dependencies = [
  "async-socks5",
  "async-trait",

--- a/write_buffer/Cargo.toml
+++ b/write_buffer/Cargo.toml
@@ -22,7 +22,7 @@ observability_deps = { path = "../observability_deps" }
 parking_lot = "0.12"
 pin-project = "1.0"
 prost = "0.11"
-rskafka = { git = "https://github.com/influxdata/rskafka.git", rev="9f1e36e8f34a4b0a7323bde623667470b4559a7d", default-features = false, features = ["compression-snappy", "transport-socks5"] }
+rskafka = { git = "https://github.com/influxdata/rskafka.git", rev="4f13b67b5e4b4ee8ad25c0c8370f1e63a06243e0", default-features = false, features = ["compression-snappy", "transport-socks5"] }
 schema = { path = "../schema" }
 tokio = { version = "1.20", features = ["fs", "macros", "parking_lot", "rt", "sync", "time"] }
 tokio-util = "0.7.3"


### PR DESCRIPTION
Lets deploy https://github.com/influxdata/rskafka/pull/164 and see how much difference (if any) it makes.

Of the two (or three) planned changes, this is likely the least impactful - it's still good to see it in isolation though!

---

* build: bump rskafka (7174f38f3)

      Bumps rskafka to HEAD to pick up:

          https://github.com/influxdata/rskafka/pull/164