### PR TITLE
build: bump rskafka

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4211,7 +4211,7 @@ dependencies = [
 [[package]]
 name = "rskafka"
 version = "0.3.0"
-source = "git+https://github.com/influxdata/rskafka.git?rev=4f13b67b5e4b4ee8ad25c0c8370f1e63a06243e0#4f13b67b5e4b4ee8ad25c0c8370f1e63a06243e0"
+source = "git+https://github.com/influxdata/rskafka.git?rev=cb9195a58fdf87be886deee961de08e119d4ca8f#cb9195a58fdf87be886deee961de08e119d4ca8f"
 dependencies = [
  "async-socks5",
  "async-trait",

--- a/write_buffer/Cargo.toml
+++ b/write_buffer/Cargo.toml
@@ -22,7 +22,7 @@ observability_deps = { path = "../observability_deps" }
 parking_lot = "0.12"
 pin-project = "1.0"
 prost = "0.11"
-rskafka = { git = "https://github.com/influxdata/rskafka.git", rev="4f13b67b5e4b4ee8ad25c0c8370f1e63a06243e0", default-features = false, features = ["compression-snappy", "transport-socks5"] }
+rskafka = { git = "https://github.com/influxdata/rskafka.git", rev="cb9195a58fdf87be886deee961de08e119d4ca8f", default-features = false, features = ["compression-snappy", "transport-socks5"] }
 schema = { path = "../schema" }
 tokio = { version = "1.20", features = ["fs", "macros", "parking_lot", "rt", "sync", "time"] }
 tokio-util = "0.7.3"

--- a/write_buffer/src/kafka/mod.rs
+++ b/write_buffer/src/kafka/mod.rs
@@ -437,7 +437,7 @@ async fn setup_topic(
         if let Some(topic) = topics.into_iter().find(|t| t.name == topic_name) {
             let mut partition_clients = BTreeMap::new();
             for partition in topic.partitions {
-                let c = client.partition_client(&topic_name, partition)?;
+                let c = client.partition_client(&topic_name, partition).await?;
                 let partition = u32::try_from(partition).map_err(WriteBufferError::invalid_data)?;
                 partition_clients.insert(partition, c);
             }
@@ -633,6 +633,7 @@ mod tests {
             .await
             .unwrap()
             .partition_client(ctx.topic_name.clone(), sequencer_id as i32)
+            .await
             .unwrap()
             .produce(
                 vec![Record {


### PR DESCRIPTION
[Go go gadget deploy](https://www.youtube.com/watch?v=EcF2LOaLgA0)

This moves Kafka connection setup from first-write-per-partition time, to initialisation-of-server time.

This might cause the servers to crashloop if they cannot initialise everything fast enough to satisfy the k8s health checks at startup, but it is unlikely given discovery has been observed as being completed in ~1s after https://github.com/influxdata/influxdb_iox/pull/5376.

If there are any problems, roll back this commit and all will be well 👍 

---

* build: bump rskafka (faa1db9a2)

      Bump rskafka & fix minor breakage in order to pick up client pre-warming:

          https://github.com/influxdata/rskafka/pull/165