### PR TITLE
build: bump rskafka

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4211,7 +4211,7 @@ dependencies = [
 [[package]]
 name = "rskafka"
 version = "0.3.0"
-source = "git+https://github.com/influxdata/rskafka.git?rev=cb9195a58fdf87be886deee961de08e119d4ca8f#cb9195a58fdf87be886deee961de08e119d4ca8f"
+source = "git+https://github.com/influxdata/rskafka.git?rev=59295beeae2106c2536008065e171dd88fd1c64e#59295beeae2106c2536008065e171dd88fd1c64e"
 dependencies = [
  "async-socks5",
  "async-trait",

--- a/write_buffer/Cargo.toml
+++ b/write_buffer/Cargo.toml
@@ -22,7 +22,7 @@ observability_deps = { path = "../observability_deps" }
 parking_lot = "0.12"
 pin-project = "1.0"
 prost = "0.11"
-rskafka = { git = "https://github.com/influxdata/rskafka.git", rev="cb9195a58fdf87be886deee961de08e119d4ca8f", default-features = false, features = ["compression-snappy", "transport-socks5"] }
+rskafka = { git = "https://github.com/influxdata/rskafka.git", rev="59295beeae2106c2536008065e171dd88fd1c64e", default-features = false, features = ["compression-snappy", "transport-socks5"] }
 schema = { path = "../schema" }
 tokio = { version = "1.20", features = ["fs", "macros", "parking_lot", "rt", "sync", "time"] }
 tokio-util = "0.7.3"


### PR DESCRIPTION
Bump rskafka to pick up the changes to pre-warming - now the broker connections will be established during server init too.

---

* build: bump rskafka (711833477)

      Bump rskafka to pick up connection pre-warming:

          https://github.com/influxdata/rskafka/pull/166