### PR TITLE
docs: router writes to partitions

### DIFF
--- a/router/src/lib.rs
+++ b/router/src/lib.rs
@@ -8,7 +8,7 @@
 //!     * Enforcing schema validation & synchronising it within the catalog.
 //!     * Deriving the partition key of each DML operation.
 //!     * Applying sharding logic.
-//!     * Push resulting operations into the appropriate kafka topics.
+//!     * Push resulting operations into the appropriate kafka partitions.
 
 #![deny(
     rustdoc::broken_intra_doc_links,


### PR DESCRIPTION
No one is merging anything and I need deployment-driven data!

---

* docs: router writes to partitions (d3dfc4221)

      Though it can write to different topics, it currently writes to different
      partitions.