### PR TITLE
chore: Update datafusion (with new sqlparser release) - option 2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2434,6 +2434,7 @@ dependencies = [
  "query_functions",
  "schema",
  "snafu",
+ "sqlparser",
  "test_helpers",
  "tokio",
  "tokio-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1145,7 +1145,7 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "11.0.0"
-source = "git+https://github.com/apache/arrow-datafusion.git?rev=929eb6d860fb60ba994b24397ad3c3eb7d839cdf#929eb6d860fb60ba994b24397ad3c3eb7d839cdf"
+source = "git+https://github.com/apache/arrow-datafusion.git?rev=3df9f8002cf14939a82e5182bab553ee5bf6e37b#3df9f8002cf14939a82e5182bab553ee5bf6e37b"
 dependencies = [
  "ahash 0.8.0",
  "arrow",
@@ -1173,7 +1173,7 @@ dependencies = [
  "pin-project-lite",
  "rand 0.8.4",
  "smallvec",
- "sqlparser 0.20.0",
+ "sqlparser",
  "tempfile",
  "tokio",
  "tokio-stream",
@@ -1184,31 +1184,31 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "11.0.0"
-source = "git+https://github.com/apache/arrow-datafusion.git?rev=929eb6d860fb60ba994b24397ad3c3eb7d839cdf#929eb6d860fb60ba994b24397ad3c3eb7d839cdf"
+source = "git+https://github.com/apache/arrow-datafusion.git?rev=3df9f8002cf14939a82e5182bab553ee5bf6e37b#3df9f8002cf14939a82e5182bab553ee5bf6e37b"
 dependencies = [
  "arrow",
  "object_store",
  "ordered-float 3.0.0",
  "parquet",
  "serde_json",
- "sqlparser 0.20.0",
+ "sqlparser",
 ]
 
 [[package]]
 name = "datafusion-expr"
 version = "11.0.0"
-source = "git+https://github.com/apache/arrow-datafusion.git?rev=929eb6d860fb60ba994b24397ad3c3eb7d839cdf#929eb6d860fb60ba994b24397ad3c3eb7d839cdf"
+source = "git+https://github.com/apache/arrow-datafusion.git?rev=3df9f8002cf14939a82e5182bab553ee5bf6e37b#3df9f8002cf14939a82e5182bab553ee5bf6e37b"
 dependencies = [
  "ahash 0.8.0",
  "arrow",
  "datafusion-common",
- "sqlparser 0.20.0",
+ "sqlparser",
 ]
 
 [[package]]
 name = "datafusion-optimizer"
 version = "11.0.0"
-source = "git+https://github.com/apache/arrow-datafusion.git?rev=929eb6d860fb60ba994b24397ad3c3eb7d839cdf#929eb6d860fb60ba994b24397ad3c3eb7d839cdf"
+source = "git+https://github.com/apache/arrow-datafusion.git?rev=3df9f8002cf14939a82e5182bab553ee5bf6e37b#3df9f8002cf14939a82e5182bab553ee5bf6e37b"
 dependencies = [
  "arrow",
  "async-trait",
@@ -1223,7 +1223,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "11.0.0"
-source = "git+https://github.com/apache/arrow-datafusion.git?rev=929eb6d860fb60ba994b24397ad3c3eb7d839cdf#929eb6d860fb60ba994b24397ad3c3eb7d839cdf"
+source = "git+https://github.com/apache/arrow-datafusion.git?rev=3df9f8002cf14939a82e5182bab553ee5bf6e37b#3df9f8002cf14939a82e5182bab553ee5bf6e37b"
 dependencies = [
  "ahash 0.8.0",
  "arrow",
@@ -1247,7 +1247,7 @@ dependencies = [
 [[package]]
 name = "datafusion-proto"
 version = "11.0.0"
-source = "git+https://github.com/apache/arrow-datafusion.git?rev=929eb6d860fb60ba994b24397ad3c3eb7d839cdf#929eb6d860fb60ba994b24397ad3c3eb7d839cdf"
+source = "git+https://github.com/apache/arrow-datafusion.git?rev=3df9f8002cf14939a82e5182bab553ee5bf6e37b#3df9f8002cf14939a82e5182bab553ee5bf6e37b"
 dependencies = [
  "arrow",
  "datafusion 11.0.0",
@@ -1260,7 +1260,7 @@ dependencies = [
 [[package]]
 name = "datafusion-row"
 version = "11.0.0"
-source = "git+https://github.com/apache/arrow-datafusion.git?rev=929eb6d860fb60ba994b24397ad3c3eb7d839cdf#929eb6d860fb60ba994b24397ad3c3eb7d839cdf"
+source = "git+https://github.com/apache/arrow-datafusion.git?rev=3df9f8002cf14939a82e5182bab553ee5bf6e37b#3df9f8002cf14939a82e5182bab553ee5bf6e37b"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -1271,14 +1271,14 @@ dependencies = [
 [[package]]
 name = "datafusion-sql"
 version = "11.0.0"
-source = "git+https://github.com/apache/arrow-datafusion.git?rev=929eb6d860fb60ba994b24397ad3c3eb7d839cdf#929eb6d860fb60ba994b24397ad3c3eb7d839cdf"
+source = "git+https://github.com/apache/arrow-datafusion.git?rev=3df9f8002cf14939a82e5182bab553ee5bf6e37b#3df9f8002cf14939a82e5182bab553ee5bf6e37b"
 dependencies = [
  "ahash 0.8.0",
  "arrow",
  "datafusion-common",
  "datafusion-expr",
  "hashbrown",
- "sqlparser 0.20.0",
+ "sqlparser",
  "tokio",
 ]
 
@@ -2275,7 +2275,7 @@ version = "0.1.0"
 dependencies = [
  "generated_types",
  "snafu",
- "sqlparser 0.21.0",
+ "sqlparser",
  "workspace-hack",
 ]
 
@@ -3732,7 +3732,7 @@ dependencies = [
  "schema",
  "serde_json",
  "snafu",
- "sqlparser 0.21.0",
+ "sqlparser",
  "test_helpers",
  "workspace-hack",
 ]
@@ -4952,15 +4952,6 @@ dependencies = [
  "itertools",
  "nom",
  "unicode_categories",
-]
-
-[[package]]
-name = "sqlparser"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30c67d4d5de027da1da5a4ed4623f09ab5131d808364279a5f5abee5de9b8db3"
-dependencies = [
- "log",
 ]
 
 [[package]]

--- a/datafusion/Cargo.toml
+++ b/datafusion/Cargo.toml
@@ -9,6 +9,6 @@ description = "Re-exports datafusion at a specific version"
 
 # Rename to workaround doctest bug
 # Turn off optional datafusion features (e.g. don't get support for crypto functions or avro)
-upstream = { git = "https://github.com/apache/arrow-datafusion.git", rev="929eb6d860fb60ba994b24397ad3c3eb7d839cdf", default-features = false, package = "datafusion" }
-datafusion-proto = { git = "https://github.com/apache/arrow-datafusion.git", rev="929eb6d860fb60ba994b24397ad3c3eb7d839cdf" }
+upstream = { git = "https://github.com/apache/arrow-datafusion.git", rev="3df9f8002cf14939a82e5182bab553ee5bf6e37b", default-features = false, package = "datafusion" }
+datafusion-proto = { git = "https://github.com/apache/arrow-datafusion.git", rev="3df9f8002cf14939a82e5182bab553ee5bf6e37b" }
 workspace-hack = { path = "../workspace-hack"}

--- a/iox_query/Cargo.toml
+++ b/iox_query/Cargo.toml
@@ -30,6 +30,7 @@ observability_deps = { path = "../observability_deps" }
 parking_lot = "0.12"
 query_functions = { path = "../query_functions"}
 schema = { path = "../schema" }
+sqlparser = "0.21.0"
 snafu = "0.7"
 tokio = { version = "1.20", features = ["macros", "parking_lot"] }
 tokio-stream = "0.1"

--- a/iox_query/src/frontend.rs
+++ b/iox_query/src/frontend.rs
@@ -2,6 +2,7 @@ pub mod common;
 pub mod influxrpc;
 pub mod reorg;
 pub mod sql;
+mod sql_rewrite;
 
 #[cfg(test)]
 mod test {

--- a/iox_query/src/frontend/sql.rs
+++ b/iox_query/src/frontend/sql.rs
@@ -3,6 +3,8 @@ use std::sync::Arc;
 use crate::exec::context::IOxSessionContext;
 use datafusion::{error::Result, physical_plan::ExecutionPlan};
 
+use super::sql_rewrite::rewrite_sql;
+
 /// This struct can create plans for running SQL queries against databases
 #[derive(Debug, Default)]
 pub struct SqlQueryPlanner {}
@@ -19,6 +21,8 @@ impl SqlQueryPlanner {
         query: &str,
         ctx: &IOxSessionContext,
     ) -> Result<Arc<dyn ExecutionPlan>> {
-        ctx.prepare_sql(query).await
+        let query = rewrite_sql(query);
+
+        ctx.prepare_sql(&query).await
     }
 }

--- a/iox_query/src/frontend/sql_rewrite.rs
+++ b/iox_query/src/frontend/sql_rewrite.rs
@@ -1,0 +1,248 @@
+use sqlparser::ast::{
+    Expr, Fetch, Function, FunctionArg, FunctionArgExpr, Ident, LockType, ObjectName, Offset,
+    OrderByExpr, Query, Select, SelectItem, SetExpr, Statement, WindowSpec, With,
+};
+use sqlparser::dialect::GenericDialect;
+use sqlparser::parser::Parser;
+
+pub fn rewrite_sql(sql: &str) -> String {
+    let dialect = GenericDialect {};
+    match Parser::parse_sql(&dialect, sql) {
+        Ok(statements) if statements.len() == 1 => {
+            let statement = statements.into_iter().next().unwrap();
+            let rewritten = RewriteSpecial {}.rewrite_statement(statement);
+            rewritten.to_string()
+        }
+        _ => sql.to_string(),
+    }
+}
+
+// THIS IS NOT COMPLETE -- would need to fill out the rest of the code
+
+/// Rewrites "special" SQL functions (that were created like `user`
+/// rather than `user()`) into normal quoted column references like "user"
+///
+/// This is important in IOx for functions like `user` which are
+/// also common column names in default telegraph data (e..g
+///
+/// ```sql
+/// select user, time from cpu;
+/// ```
+/// To select the amount of time the CPU spent on user queries
+struct RewriteSpecial {}
+
+/// Override only the part we care about
+impl Rewriter for RewriteSpecial {
+    fn rewrite_expr(&mut self, e: Expr) -> Expr {
+        if let Expr::Function(f) = e {
+            if f.special {
+                assert!(f.args.is_empty());
+                assert!(f.over.is_none());
+                let mut names = f.name.0;
+                assert_eq!(names.len(), 1);
+                let mut name = names.pop().unwrap();
+                // ensure it is quoted on the output
+                name.quote_style = Some('"');
+                rewrite_expr(self, Expr::Identifier(name))
+            } else {
+                Expr::Function(rewrite_function(self, f))
+            }
+        } else {
+            rewrite_expr(self, e)
+        }
+    }
+}
+
+/// Rewrites SQL trees recursively
+///
+/// If you override this, you should do your mutation first and then
+/// call the default implementation to complete the recursion
+pub trait Rewriter {
+    fn rewrite_statements(&mut self, s: Vec<Statement>) -> Vec<Statement> {
+        s.into_iter().map(|s| self.rewrite_statement(s)).collect()
+    }
+
+    fn rewrite_statement(&mut self, s: Statement) -> Statement {
+        match s {
+            Statement::Query(query) => Statement::Query(Box::new(self.rewrite_query(*query))),
+            s => s,
+        }
+    }
+
+    fn rewrite_query(&mut self, q: Query) -> Query {
+        let Query {
+            with,
+            body,
+            order_by,
+            limit,
+            offset,
+            fetch,
+            lock,
+        } = q;
+
+        Query {
+            with: with.map(|with| self.rewrite_with(with)),
+            body: Box::new(self.rewrite_set_expr(*body)),
+            order_by: order_by
+                .into_iter()
+                .map(|o| self.rewrite_order_by(o))
+                .collect(),
+            limit: limit.map(|limit| self.rewrite_expr(limit)),
+            offset: offset.map(|offset| self.rewrite_offset(offset)),
+            fetch: fetch.map(|fetch| self.rewrite_fetch(fetch)),
+            lock: lock.map(|lock_type| self.rewrite_lock_type(lock_type)),
+        }
+    }
+
+    fn rewrite_with(&mut self, w: With) -> With {
+        w
+    }
+
+    fn rewrite_set_expr(&mut self, e: SetExpr) -> SetExpr {
+        match e {
+            SetExpr::Select(select) => SetExpr::Select(Box::new(self.rewrite_select(*select))),
+            e => e,
+        }
+    }
+
+    fn rewrite_select(&mut self, s: Select) -> Select {
+        let Select {
+            distinct,
+            top,
+            projection,
+            into,
+            from,
+            lateral_views,
+            selection,
+            group_by,
+            cluster_by,
+            distribute_by,
+            sort_by,
+            having,
+            qualify,
+        } = s;
+
+        // TOOD rewrite all these fields
+
+        Select {
+            distinct,
+            top,
+            projection: projection
+                .into_iter()
+                .map(|s| self.rewrite_select_item(s))
+                .collect(),
+            into,
+            from,
+            lateral_views,
+            selection,
+            group_by,
+            cluster_by,
+            distribute_by,
+            sort_by,
+            having,
+            qualify,
+        }
+    }
+
+    fn rewrite_select_item(&mut self, e: SelectItem) -> SelectItem {
+        match e {
+            SelectItem::UnnamedExpr(expr) => SelectItem::UnnamedExpr(self.rewrite_expr(expr)),
+            SelectItem::ExprWithAlias { expr, alias } => SelectItem::ExprWithAlias {
+                expr: self.rewrite_expr(expr),
+                alias: self.rewrite_ident(alias),
+            },
+            SelectItem::QualifiedWildcard(o) => {
+                SelectItem::QualifiedWildcard(self.rewrite_object_name(o))
+            }
+            SelectItem::Wildcard => SelectItem::Wildcard,
+        }
+    }
+
+    /// low level identifier rewriter -- recursion stops here
+    fn rewrite_ident(&mut self, e: Ident) -> Ident {
+        e
+    }
+
+    fn rewrite_object_name(&mut self, e: ObjectName) -> ObjectName {
+        let ObjectName(names) = e;
+        ObjectName(names.into_iter().map(|i| self.rewrite_ident(i)).collect())
+    }
+
+    fn rewrite_order_by(&mut self, e: OrderByExpr) -> OrderByExpr {
+        e
+    }
+
+    fn rewrite_expr(&mut self, e: Expr) -> Expr {
+        rewrite_expr(self, e)
+    }
+
+    fn rewrite_function(&mut self, f: Function) -> Function {
+        rewrite_function(self, f)
+    }
+
+    fn rewrite_function_arg(&mut self, e: FunctionArg) -> FunctionArg {
+        match e {
+            FunctionArg::Named { name, arg } => FunctionArg::Named {
+                name: self.rewrite_ident(name),
+                arg: self.rewrite_function_arg_expr(arg),
+            },
+            FunctionArg::Unnamed(arg) => FunctionArg::Unnamed(self.rewrite_function_arg_expr(arg)),
+        }
+    }
+
+    fn rewrite_function_arg_expr(&mut self, e: FunctionArgExpr) -> FunctionArgExpr {
+        match e {
+            FunctionArgExpr::Expr(e) => FunctionArgExpr::Expr(self.rewrite_expr(e)),
+            FunctionArgExpr::QualifiedWildcard(o) => {
+                FunctionArgExpr::QualifiedWildcard(self.rewrite_object_name(o))
+            }
+            FunctionArgExpr::Wildcard => FunctionArgExpr::Wildcard,
+        }
+    }
+
+    fn rewrite_window_spec(&mut self, e: WindowSpec) -> WindowSpec {
+        e
+    }
+
+    fn rewrite_offset(&mut self, e: Offset) -> Offset {
+        e
+    }
+
+    fn rewrite_fetch(&mut self, e: Fetch) -> Fetch {
+        e
+    }
+
+    fn rewrite_lock_type(&mut self, e: LockType) -> LockType {
+        e
+    }
+}
+
+// free function that does the work, rather than a default impl
+fn rewrite_expr<R: Rewriter + ?Sized>(rewriter: &mut R, e: Expr) -> Expr {
+    match e {
+        Expr::Identifier(i) => Expr::Identifier(rewriter.rewrite_ident(i)),
+        Expr::Function(f) => Expr::Function(rewriter.rewrite_function(f)),
+        e => e,
+    }
+}
+
+fn rewrite_function<R: Rewriter + ?Sized>(rewriter: &mut R, f: Function) -> Function {
+    let Function {
+        name,
+        args,
+        over,
+        distinct,
+        special,
+    } = f;
+
+    Function {
+        name: rewriter.rewrite_object_name(name),
+        args: args
+            .into_iter()
+            .map(|a| rewriter.rewrite_function_arg(a))
+            .collect(),
+        over: over.map(|o| rewriter.rewrite_window_spec(o)),
+        distinct,
+        special,
+    }
+}


### PR DESCRIPTION
This is an alternate approach than in https://github.com/influxdata/influxdb_iox/pull/5433

Basically this PR parses SQL queries, finds and "special" functions (like `user`) and replaces them with a quoted reference like `"user"`

It isn't complete (I would need to fill out all the structs to properly recurse) but this shows how it would be done