### PR TITLE
feat: sharder API definition

### DIFF
--- a/generated_types/protos/influxdata/iox/sharder/v1/sharder.proto
+++ b/generated_types/protos/influxdata/iox/sharder/v1/sharder.proto
@@ -1,0 +1,26 @@
+syntax = "proto3";
+package influxdata.iox.sharder.v1;
+option go_package = "github.com/influxdata/iox/sharder/v1";
+
+service ShardService {
+  // Shard the given inputs to a Catalog ID for the destination Sequencer
+  // (Sequencer ID).
+  rpc ShardToSequencerId(ShardToSequencerIdRequest) returns (ShardToSequencerIdResponse);
+}
+
+message ShardToSequencerIdRequest {
+  // The shard input values to map onto a Sequencer.
+  oneof input {
+    // A table & namespace pair.
+    TableNamespaceTuple table_namespace = 1;
+  }
+}
+
+message ShardToSequencerIdResponse {
+  uint64 sequencer_id = 1;
+}
+
+message TableNamespaceTuple {
+  string table = 1;
+  string namespace = 2;
+}


### PR DESCRIPTION
A proposed API definition to expose sharding logic outside of the router.

Ideally the sharding logic lives in one place, rather than multiple components having their own  compiled-in implementation to minimise bugs / simplify keeping everything in sync / support customised sharding keys in the future. This PR exposes the sharding logic in the router to any caller in a future-proof way.

Relates to https://github.com/influxdata/influxdb_iox/pull/5447#pullrequestreview-1080574538

---

* feat: sharder API definition (57bbe6b21)

      This commit adds a gRPC endpoint for callers to map (table, namespace) tuples
      to Sequencer IDs, using the logic internal to the router.

      Reference:
        
      https://github.com/influxdata/influxdb_iox/pull/5447#pullrequestreview-1080574538