### PR TITLE
refactor(router): use KafkaPartition in sequencer

### DIFF
--- a/ioxd_router/src/lib.rs
+++ b/ioxd_router/src/lib.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
 use clap_blocks::write_buffer::WriteBufferConfig;
-use data_types::{DatabaseName, PartitionTemplate, TemplatePart};
+use data_types::{DatabaseName, KafkaPartition, PartitionTemplate, TemplatePart};
 use hashbrown::HashMap;
 use hyper::{Body, Request, Response};
 use iox_catalog::interface::Catalog;
@@ -325,7 +325,13 @@ async fn init_write_buffer(
     Ok(ShardedWriteBuffer::new(JumpHash::new(
         shards
             .into_iter()
-            .map(|id| Sequencer::new(id as _, Arc::clone(&write_buffer), &metrics))
+            .map(|id| {
+                Sequencer::new(
+                    KafkaPartition::new(id.try_into().unwrap()),
+                    Arc::clone(&write_buffer),
+                    &metrics,
+                )
+            })
             .map(Arc::new),
     )?))
 }

--- a/router/benches/e2e.rs
+++ b/router/benches/e2e.rs
@@ -1,5 +1,5 @@
 use criterion::{criterion_group, criterion_main, Criterion, Throughput};
-use data_types::{PartitionTemplate, TemplatePart};
+use data_types::{KafkaPartition, PartitionTemplate, TemplatePart};
 use hyper::{Body, Request};
 use iox_catalog::{interface::Catalog, mem::MemCatalog};
 use router::{
@@ -38,7 +38,13 @@ fn init_write_buffer(n_sequencers: u32) -> ShardedWriteBuffer<JumpHash<Arc<Seque
         JumpHash::new(
             shards
                 .into_iter()
-                .map(|id| Sequencer::new(id as _, Arc::clone(&write_buffer), &Default::default()))
+                .map(|id| {
+                    Sequencer::new(
+                        KafkaPartition::new(id as _),
+                        Arc::clone(&write_buffer),
+                        &Default::default(),
+                    )
+                })
                 .map(Arc::new),
         )
         .expect("failed to init sharder"),

--- a/router/src/sequencer.rs
+++ b/router/src/sequencer.rs
@@ -1,15 +1,21 @@
 //! A representation of a single operation sequencer.
 
+use data_types::KafkaPartition;
 use dml::{DmlMeta, DmlOperation};
 use iox_time::{SystemProvider, TimeProvider};
 use metric::{DurationHistogram, Metric};
 use std::{borrow::Cow, hash::Hash, sync::Arc};
 use write_buffer::core::{WriteBufferError, WriteBufferWriting};
 
-/// A sequencer tags an write buffer with a sequencer ID.
+/// A sequencer tags an write buffer with a Kafka partition index.
 #[derive(Debug)]
 pub struct Sequencer<P = SystemProvider> {
-    id: usize,
+    /// The 0..N index / identifier for the Kakfa partition.
+    ///
+    /// NOTE: this is NOT the ID of the Sequencer row in the catalog this
+    /// Sequencer represents.
+    kafka_index: KafkaPartition,
+
     inner: Arc<dyn WriteBufferWriting>,
     time_provider: P,
 
@@ -21,35 +27,44 @@ impl Eq for Sequencer {}
 
 impl PartialEq for Sequencer {
     fn eq(&self, other: &Self) -> bool {
-        self.id == other.id
+        self.kafka_index == other.kafka_index
     }
 }
 
 impl Hash for Sequencer {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        self.id.hash(state);
+        self.kafka_index.hash(state);
     }
 }
 
 impl Sequencer {
-    /// Tag `inner` with the specified `id`.
-    pub fn new(id: usize, inner: Arc<dyn WriteBufferWriting>, metrics: &metric::Registry) -> Self {
+    /// Tag `inner` with the specified `kafka_index`.
+    pub fn new(
+        kafka_index: KafkaPartition,
+        inner: Arc<dyn WriteBufferWriting>,
+        metrics: &metric::Registry,
+    ) -> Self {
         let write: Metric<DurationHistogram> = metrics.register_metric(
             "sequencer_enqueue_duration",
             "sequencer enqueue call duration",
         );
 
         let enqueue_success = write.recorder([
-            ("kafka_partition", Cow::from(id.to_string())),
+            ("kafka_partition", Cow::from(kafka_index.to_string())),
             ("result", Cow::from("success")),
         ]);
         let enqueue_error = write.recorder([
-            ("kafka_partition", Cow::from(id.to_string())),
+            ("kafka_partition", Cow::from(kafka_index.to_string())),
             ("result", Cow::from("error")),
         ]);
 
+        // Validate the conversion between the kafka partition type's inner
+        // numerical type (an i32) can be cast correctly to the write buffer
+        // abstractions numerical type used to identify the partition (a u32).
+        assert!(u32::try_from(kafka_index.get()).is_ok());
+
         Self {
-            id,
+            kafka_index,
             inner,
             enqueue_success,
             enqueue_error,
@@ -57,9 +72,12 @@ impl Sequencer {
         }
     }
 
-    /// Return the ID of this sequencer.
-    pub fn id(&self) -> usize {
-        self.id
+    /// Return the 0..N index / identifier for the Kafka partition.
+    ///
+    /// NOTE: this is NOT the ID of the Sequencer row in the catalog this
+    /// Sequencer represents.
+    pub fn kafka_index(&self) -> KafkaPartition {
+        self.kafka_index
     }
 
     /// Enqueue `op` into this sequencer.
@@ -70,7 +88,10 @@ impl Sequencer {
     pub async fn enqueue<'a>(&self, op: DmlOperation) -> Result<DmlMeta, WriteBufferError> {
         let t = self.time_provider.now();
 
-        let res = self.inner.store_operation(self.id as u32, op).await;
+        let res = self
+            .inner
+            .store_operation(self.kafka_index.get() as _, op)
+            .await;
 
         if let Some(delta) = self.time_provider.now().checked_duration_since(t) {
             match &res {

--- a/router/tests/http.rs
+++ b/router/tests/http.rs
@@ -1,5 +1,5 @@
 use assert_matches::assert_matches;
-use data_types::{KafkaTopicId, PartitionTemplate, QueryPoolId, TemplatePart};
+use data_types::{KafkaPartition, KafkaTopicId, PartitionTemplate, QueryPoolId, TemplatePart};
 use dml::DmlOperation;
 use hashbrown::HashMap;
 use hyper::{Body, Request, StatusCode};
@@ -86,7 +86,13 @@ impl TestContext {
             JumpHash::new(
                 shards
                     .into_iter()
-                    .map(|id| Sequencer::new(id as _, Arc::clone(&write_buffer), &metrics))
+                    .map(|id| {
+                        Sequencer::new(
+                            KafkaPartition::new(id as _),
+                            Arc::clone(&write_buffer),
+                            &metrics,
+                        )
+                    })
                     .map(Arc::new),
             )
             .unwrap(),


### PR DESCRIPTION
A quick tidy-up PR that uses the `KafkaPartition` type wrapper instead of bare `usize`, adds asserts when we cast between types.

I'm not sure why, but the [`KafkaPartition` is an `i32`](https://github.com/influxdata/influxdb_iox/blob/9b920f1cbbfee5b996b5757cd3f855b4a7a72b95/data_types/src/lib.rs#L184), but the [`WriteBuffer` uses a `u32`](https://github.com/influxdata/influxdb_iox/blob/9b920f1cbbfee5b996b5757cd3f855b4a7a72b95/write_buffer/src/core.rs#L167) even though Kafka (and it's clients) [use `i32`](https://github.com/influxdata/influxdb_iox/blob/9b920f1cbbfee5b996b5757cd3f855b4a7a72b95/write_buffer/src/kafka/mod.rs#L452) to identify partitions - this causes us to cast a whole lotta times.

Relates to https://github.com/influxdata/influxdb_iox/pull/5435

---

* refactor(router): use KafkaPartition in sequencer (9b920f1cb)

      The Sequencer (which will be renamed shortly) is a type that represents a
      single sequencer/shard/kafka partition in the router.

      In order to minimise confusion with all the various IDs floating around, we
      have a KafkaPartition - this commit changes the Sequencer to return the Kafka
      partition index as a typed value, rather than a usize to help eliminate any
      inconsistencies.

      As a side effect of these conversion changes, I've tightened up the casting to
      ensure we assert on any overflows - we juggle a lot of numeric types!