### PR TITLE
refactor(proto): update ShardService gRPC defintion

### DIFF
--- a/generated_types/build.rs
+++ b/generated_types/build.rs
@@ -26,6 +26,7 @@ fn main() -> Result<()> {
 /// - `influxdata.iox.predicate.v1.rs`
 /// - `influxdata.iox.querier.v1.rs`
 /// - `influxdata.iox.schema.v1.rs`
+/// - `influxdata.iox.sharder.v1.rs`
 /// - `influxdata.iox.write.v1.rs`
 /// - `influxdata.iox.write_buffer.v1.rs`
 /// - `influxdata.platform.storage.rs`
@@ -38,6 +39,7 @@ fn generate_grpc_types(root: &Path) -> Result<()> {
     let predicate_path = root.join("influxdata/iox/predicate/v1");
     let querier_path = root.join("influxdata/iox/querier/v1");
     let schema_path = root.join("influxdata/iox/schema/v1");
+    let sharder_path = root.join("influxdata/iox/sharder/v1");
     let write_buffer_path = root.join("influxdata/iox/write_buffer/v1");
     let write_summary_path = root.join("influxdata/iox/write_summary/v1");
     let storage_path = root.join("influxdata/platform/storage");
@@ -59,6 +61,7 @@ fn generate_grpc_types(root: &Path) -> Result<()> {
         root.join("grpc/health/v1/service.proto"),
         root.join("influxdata/pbdata/v1/influxdb_pb_data_protocol.proto"),
         schema_path.join("service.proto"),
+        sharder_path.join("sharder.proto"),
         write_buffer_path.join("write_buffer.proto"),
         write_summary_path.join("write_summary.proto"),
         storage_path.join("predicate.proto"),

--- a/generated_types/protos/influxdata/iox/sharder/v1/sharder.proto
+++ b/generated_types/protos/influxdata/iox/sharder/v1/sharder.proto
@@ -10,17 +10,11 @@ service ShardService {
 
 message ShardToSequencerIdRequest {
   // The shard input values to map onto a Sequencer.
-  oneof input {
-    // A table & namespace pair.
-    TableNamespaceTuple table_namespace = 1;
-  }
+  string table_name = 1;
+  string namespace_name = 2;
 }
 
 message ShardToSequencerIdResponse {
-  uint64 sequencer_id = 1;
-}
-
-message TableNamespaceTuple {
-  string table = 1;
-  string namespace = 2;
+  int64 sequencer_id = 1;
+  int32 sequencer_index = 2;
 }

--- a/generated_types/src/lib.rs
+++ b/generated_types/src/lib.rs
@@ -140,6 +140,16 @@ pub mod influxdata {
             }
         }
 
+        pub mod sharder {
+            pub mod v1 {
+                include!(concat!(env!("OUT_DIR"), "/influxdata.iox.sharder.v1.rs"));
+                include!(concat!(
+                    env!("OUT_DIR"),
+                    "/influxdata.iox.sharder.v1.serde.rs"
+                ));
+            }
+        }
+
         pub mod write_buffer {
             pub mod v1 {
                 include!(concat!(


### PR DESCRIPTION
An update to the inital proto definition (#5451) for https://github.com/influxdata/influxdb_iox/pull/5447.

---

* refactor(proto): simplify RPC messages & types (f11af90c4)

      Removes the input oneof - a shard caller MUST always provide a 
      table/namespace, and MAY provide an optional payload (which in the future will
      enable sharding using column valuess/etc). As there is currently no
      payload-based sharding, this simplifies the RPC message.

      Changes the returned types to better reflect the types we use internally
      - this should avoid type juggling for both server & client.

* build: generate gRPC bindings for ShardService (c6d4109e0)

      Builds the ShardService proto file in the generated_types package.