### PR TITLE
refactor: infallible JumpHash initialisation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4844,7 +4844,6 @@ dependencies = [
  "parking_lot 0.12.1",
  "rand 0.8.4",
  "siphasher",
- "snafu",
  "test_helpers",
  "workspace-hack",
 ]

--- a/ioxd_router/src/lib.rs
+++ b/ioxd_router/src/lib.rs
@@ -50,8 +50,8 @@ pub enum Error {
     #[error("Catalog DSN error: {0}")]
     CatalogDsn(#[from] clap_blocks::catalog_dsn::Error),
 
-    #[error("failed to initialize sharded cache: {0}")]
-    Sharder(#[from] sharder::Error),
+    #[error("No sequencer shards found in Catalog")]
+    Sharder,
 }
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
@@ -178,7 +178,7 @@ pub async fn create_router_server_type(
     let ns_cache = Arc::new(InstrumentedCache::new(
         Arc::new(ShardedCache::new(
             std::iter::repeat_with(|| Arc::new(MemoryNamespaceCache::default())).take(10),
-        )?),
+        )),
         &*metrics,
     ));
 
@@ -322,6 +322,10 @@ async fn init_write_buffer(
         "connected to write buffer topic",
     );
 
+    if shards.is_empty() {
+        return Err(Error::Sharder);
+    }
+
     Ok(ShardedWriteBuffer::new(JumpHash::new(
         shards
             .into_iter()
@@ -333,7 +337,7 @@ async fn init_write_buffer(
                 )
             })
             .map(Arc::new),
-    )?))
+    )))
 }
 
 /// Pre-populate `cache` with the all existing schemas in `catalog`.

--- a/querier/src/namespace/test_util.rs
+++ b/querier/src/namespace/test_util.rs
@@ -30,7 +30,7 @@ pub async fn querier_namespace_with_limit(
         ns.catalog.metric_registry(),
     ));
 
-    let sharder = Arc::new(JumpHash::new((0..1).map(KafkaPartition::new).map(Arc::new)).unwrap());
+    let sharder = Arc::new(JumpHash::new((0..1).map(KafkaPartition::new).map(Arc::new)));
 
     QuerierNamespace::new_testing(
         catalog_cache,

--- a/querier/src/table/test_util.rs
+++ b/querier/src/table/test_util.rs
@@ -41,7 +41,7 @@ pub async fn querier_table(
     let namespace_name = Arc::from(table.namespace.namespace.name.as_str());
 
     QuerierTable::new(QuerierTableArgs {
-        sharder: Arc::new(JumpHash::new((0..1).map(KafkaPartition::new).map(Arc::new)).unwrap()),
+        sharder: Arc::new(JumpHash::new((0..1).map(KafkaPartition::new).map(Arc::new))),
         namespace_name,
         id: table.table.id,
         table_name: table.table.name.clone().into(),

--- a/query_tests/src/scenarios/util.rs
+++ b/query_tests/src/scenarios/util.rs
@@ -943,8 +943,7 @@ impl MockIngester {
             Arc::clone(&catalog_cache),
         );
         let ingester_connection = Arc::new(ingester_connection);
-        let sharder =
-            Arc::new(JumpHash::new((0..1).map(KafkaPartition::new).map(Arc::new)).unwrap());
+        let sharder = Arc::new(JumpHash::new((0..1).map(KafkaPartition::new).map(Arc::new)));
 
         Arc::new(QuerierNamespace::new_testing(
             catalog_cache,

--- a/router/benches/schema_validator.rs
+++ b/router/benches/schema_validator.rs
@@ -41,10 +41,9 @@ fn bench(group: &mut BenchmarkGroup<WallTime>, tables: usize, columns_per_table:
     let metrics = Arc::new(metric::Registry::default());
 
     let catalog = Arc::new(MemCatalog::new(Arc::clone(&metrics)));
-    let ns_cache = Arc::new(
-        ShardedCache::new(iter::repeat_with(|| Arc::new(MemoryNamespaceCache::default())).take(10))
-            .unwrap(),
-    );
+    let ns_cache = Arc::new(ShardedCache::new(
+        iter::repeat_with(|| Arc::new(MemoryNamespaceCache::default())).take(10),
+    ));
     let validator = SchemaValidator::new(catalog, ns_cache, &*metrics);
 
     for i in 0..65_000 {

--- a/router/src/namespace_cache/sharded_cache.rs
+++ b/router/src/namespace_cache/sharded_cache.rs
@@ -12,10 +12,10 @@ pub struct ShardedCache<T> {
 impl<T> ShardedCache<T> {
     /// initialise a [`ShardedCache`] splitting the keyspace over the given
     /// instances of `T`.
-    pub fn new(shards: impl IntoIterator<Item = T>) -> Result<Self, sharder::Error> {
-        Ok(Self {
-            shards: JumpHash::new(shards)?,
-        })
+    pub fn new(shards: impl IntoIterator<Item = T>) -> Self {
+        Self {
+            shards: JumpHash::new(shards),
+        }
     }
 }
 
@@ -71,12 +71,9 @@ mod tests {
         // The number of shards to hash into.
         const SHARDS: usize = 10;
 
-        let cache = Arc::new(
-            ShardedCache::new(
-                iter::repeat_with(|| Arc::new(MemoryNamespaceCache::default())).take(SHARDS),
-            )
-            .unwrap(),
-        );
+        let cache = Arc::new(ShardedCache::new(
+            iter::repeat_with(|| Arc::new(MemoryNamespaceCache::default())).take(SHARDS),
+        ));
 
         // Build a set of namespace -> unique integer to validate the shard
         // mapping later.

--- a/sharder/Cargo.toml
+++ b/sharder/Cargo.toml
@@ -8,7 +8,6 @@ data_types = { path = "../data_types" }
 mutable_batch = { path = "../mutable_batch" }
 parking_lot = "0.12"
 siphasher = "0.3"
-snafu = "0.7"
 workspace-hack = { path = "../workspace-hack"}
 
 [dev-dependencies]

--- a/sharder/benches/sharder.rs
+++ b/sharder/benches/sharder.rs
@@ -86,7 +86,7 @@ fn benchmark_sharder(
     table: &str,
     namespace: &DatabaseName<'_>,
 ) {
-    let hasher = JumpHash::new((0..num_buckets).map(Arc::new)).unwrap();
+    let hasher = JumpHash::new((0..num_buckets).map(Arc::new));
     let batch = MutableBatch::default();
 
     group.throughput(Throughput::Elements(1));


### PR DESCRIPTION
Bit of a tidy-up whilst working on the gRPC ShardService.

---

* refactor: infallible JumpHash initialisation (13e7b93c1)

      This doesn't really need to be fallible but forces propagation of a ton of
      error handling - no shards is always a sign of something being very wrong, and
      can be caught in the caller if it's for some reason an acceptable state / can
      be recovered from.