### PR TITLE
feat(router): sharding lookup gRPC service 

### DIFF
--- a/router/src/server.rs
+++ b/router/src/server.rs
@@ -13,20 +13,20 @@ pub mod http;
 /// The [`RouterServer`] manages the lifecycle and contains all state for a
 /// `router` server instance.
 #[derive(Debug)]
-pub struct RouterServer<D> {
+pub struct RouterServer<D, S> {
     metrics: Arc<metric::Registry>,
     trace_collector: Option<Arc<dyn TraceCollector>>,
 
     http: HttpDelegate<D>,
-    grpc: GrpcDelegate<D>,
+    grpc: GrpcDelegate<D, S>,
 }
 
-impl<D> RouterServer<D> {
+impl<D, S> RouterServer<D, S> {
     /// Initialise a new [`RouterServer`] using the provided HTTP and gRPC
     /// handlers.
     pub fn new(
         http: HttpDelegate<D>,
-        grpc: GrpcDelegate<D>,
+        grpc: GrpcDelegate<D, S>,
         metrics: Arc<metric::Registry>,
         trace_collector: Option<Arc<dyn TraceCollector>>,
     ) -> Self {
@@ -49,7 +49,7 @@ impl<D> RouterServer<D> {
     }
 }
 
-impl<D> RouterServer<D>
+impl<D, S> RouterServer<D, S>
 where
     D: DmlHandler<WriteInput = HashMap<String, MutableBatch>>,
 {
@@ -59,7 +59,7 @@ where
     }
 
     /// Get a reference to the router grpc delegate.
-    pub fn grpc(&self) -> &GrpcDelegate<D> {
+    pub fn grpc(&self) -> &GrpcDelegate<D, S> {
         &self.grpc
     }
 }

--- a/router/src/server/grpc.rs
+++ b/router/src/server/grpc.rs
@@ -2,11 +2,15 @@
 
 pub mod sharder;
 
-use crate::dml_handlers::{DmlError, DmlHandler, PartitionError};
+use crate::{
+    dml_handlers::{DmlError, DmlHandler, PartitionError},
+    sequencer::Sequencer,
+};
+use ::sharder::Sharder;
 use generated_types::{
     google::FieldViolation,
     influxdata::{
-        iox::{catalog::v1::*, object_store::v1::*, schema::v1::*},
+        iox::{catalog::v1::*, object_store::v1::*, schema::v1::*, sharder::v1::*},
         pbdata::v1::*,
     },
 };
@@ -25,39 +29,45 @@ use tonic::{metadata::AsciiMetadataValue, Request, Response, Status};
 use trace::ctx::SpanContext;
 use write_summary::WriteSummary;
 
+use self::sharder::ShardService;
+
 // HERE BE DRAGONS: Uppercase characters in this constant cause a panic. Insert them and
 // investigate the cause if you dare.
 const WRITE_TOKEN_GRPC_HEADER: &str = "x-iox-write-token";
 
 /// This type is responsible for managing all gRPC services exposed by `router`.
 #[derive(Debug)]
-pub struct GrpcDelegate<D> {
+pub struct GrpcDelegate<D, S> {
     dml_handler: Arc<D>,
     catalog: Arc<dyn Catalog>,
     object_store: Arc<DynObjectStore>,
     metrics: Arc<metric::Registry>,
+    shard_service: ShardService<S>,
 }
 
-impl<D> GrpcDelegate<D> {
+impl<D, S> GrpcDelegate<D, S> {
     /// Initialise a new gRPC handler, dispatching DML operations to `dml_handler`.
     pub fn new(
         dml_handler: Arc<D>,
         catalog: Arc<dyn Catalog>,
         object_store: Arc<DynObjectStore>,
         metrics: Arc<metric::Registry>,
+        shard_service: ShardService<S>,
     ) -> Self {
         Self {
             dml_handler,
             catalog,
             object_store,
             metrics,
+            shard_service,
         }
     }
 }
 
-impl<D> GrpcDelegate<D>
+impl<D, S> GrpcDelegate<D, S>
 where
     D: DmlHandler<WriteInput = HashMap<String, MutableBatch>, WriteOutput = WriteSummary> + 'static,
+    S: Sharder<(), Item = Arc<Sequencer>> + Clone + 'static,
 {
     /// Acquire a [`WriteService`] gRPC service implementation.
     ///
@@ -104,6 +114,15 @@ where
             Arc::clone(&self.catalog),
             Arc::clone(&self.object_store),
         ))
+    }
+
+    /// Return a gRPC [`ShardService`] handler.
+    ///
+    /// [`ShardService`]: generated_types::influxdata::iox::sharder::v1::shard_service_server::ShardService
+    pub fn shard_service(
+        &self,
+    ) -> shard_service_server::ShardServiceServer<impl shard_service_server::ShardService> {
+        shard_service_server::ShardServiceServer::new(self.shard_service.clone())
     }
 }
 

--- a/router/src/server/grpc.rs
+++ b/router/src/server/grpc.rs
@@ -1,5 +1,7 @@
 //! gRPC service implementations for `router`.
 
+pub mod sharder;
+
 use crate::dml_handlers::{DmlError, DmlHandler, PartitionError};
 use generated_types::{
     google::FieldViolation,

--- a/router/src/server/grpc/sharder.rs
+++ b/router/src/server/grpc/sharder.rs
@@ -1,0 +1,194 @@
+//! A gRPC service to provide shard mappings to external clients.
+
+use std::sync::Arc;
+
+use data_types::{DatabaseName, KafkaPartition, KafkaTopic, SequencerId};
+use generated_types::influxdata::iox::sharder::v1::{
+    shard_service_server, ShardToSequencerIdRequest, ShardToSequencerIdResponse,
+};
+use hashbrown::HashMap;
+use iox_catalog::interface::Catalog;
+use sharder::Sharder;
+use tonic::{Request, Response};
+
+use crate::sequencer::Sequencer;
+
+/// A [`ShardService`] exposes a [gRPC endpoint] for external systems to
+/// discover the shard mapping for specific tables.
+///
+/// The [`ShardService`] builds a cached mapping of Kafka partition index
+/// numbers to [`Catalog`] row IDs in order to handle requests without
+/// generating Catalog queries. This mapping is expected to be unchanged over
+/// the lifetime of a router instance.
+///
+/// This service MUST be initialised with the same sharder instance as the
+/// [`ShardedWriteBuffer`] for the outputs to be correct.
+///
+/// [gRPC endpoint]: generated_types::influxdata::iox::sharder::v1::shard_service_server::ShardService
+/// [`ShardedWriteBuffer`]: crate::dml_handlers::ShardedWriteBuffer
+#[derive(Debug)]
+pub struct ShardService<S> {
+    sharder: S,
+
+    // A pre-loaded mapping of all Kafka partition indexes for the in-use Kafka
+    // topic, to their respective catalog row ID.
+    mapping: HashMap<KafkaPartition, SequencerId>,
+}
+
+impl<S> ShardService<S>
+where
+    S: Send + Sync,
+{
+    /// Initialise a gRPC [`ShardService`] handler, building a cached mapping
+    /// from the catalog.
+    ///
+    /// [`ShardService`]: generated_types::influxdata::iox::sharder::v1::shard_service_server::ShardService
+    pub async fn new(
+        sharder: S,
+        topic: KafkaTopic,
+        catalog: Arc<dyn Catalog>,
+    ) -> Result<Self, iox_catalog::interface::Error> {
+        // Build the mapping of Kafka partition index -> Catalog ID
+        let mapping = catalog
+            .repositories()
+            .await
+            .sequencers()
+            .list_by_kafka_topic(&topic)
+            .await?
+            .into_iter()
+            .map(|s| (s.kafka_partition, s.id))
+            .collect();
+
+        Ok(Self { sharder, mapping })
+    }
+}
+
+#[tonic::async_trait]
+impl<S> shard_service_server::ShardService for ShardService<S>
+where
+    S: Sharder<(), Item = Arc<Sequencer>> + 'static,
+{
+    async fn shard_to_sequencer_id(
+        &self,
+        request: Request<ShardToSequencerIdRequest>,
+    ) -> Result<Response<ShardToSequencerIdResponse>, tonic::Status> {
+        let req = request.into_inner();
+
+        // Validate the namespace.
+        let ns = DatabaseName::try_from(req.namespace_name)
+            .map_err(|e| tonic::Status::invalid_argument(e.to_string()))?;
+
+        // Map the (table, namespace) tuple to the Sequencer for it.
+        let sequencer = self.sharder.shard(&req.table_name, &ns, &());
+
+        // Lookup the Kafka partition index in the cached mapping, to extract
+        // the catalog ID associated with the Sequencer.
+        let catalog_id = self
+            .mapping
+            .get(&sequencer.kafka_index())
+            .expect("in-use shard maps to non-existant catalog entry");
+
+        Ok(Response::new(ShardToSequencerIdResponse {
+            sequencer_id: catalog_id.get(),
+            sequencer_index: sequencer.kafka_index().get(),
+        }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{num::NonZeroU32, sync::Arc};
+
+    use futures::stream::{FuturesUnordered, StreamExt};
+    use generated_types::influxdata::iox::sharder::v1::shard_service_server::ShardService as _;
+    use iox_catalog::mem::MemCatalog;
+    use sharder::JumpHash;
+    use write_buffer::{
+        core::WriteBufferWriting,
+        mock::{MockBufferForWriting, MockBufferSharedState},
+    };
+
+    use super::*;
+
+    const N_SEQUENCERS: i32 = 10;
+
+    #[tokio::test]
+    async fn test_mapping() {
+        let metrics = Arc::new(metric::Registry::default());
+        let catalog = Arc::new(MemCatalog::new(Arc::clone(&metrics)));
+        let write_buffer: Arc<dyn WriteBufferWriting> = Arc::new(init_write_buffer());
+
+        let topic = catalog
+            .repositories()
+            .await
+            .kafka_topics()
+            .create_or_get("test")
+            .await
+            .expect("topic create");
+
+        let actual_mapping = (0..N_SEQUENCERS)
+            .map(|idx| {
+                let catalog = Arc::clone(&catalog);
+                let topic = topic.clone();
+                async move {
+                    let partition_idx = KafkaPartition::new(idx);
+                    let row = catalog
+                        .repositories()
+                        .await
+                        .sequencers()
+                        .create_or_get(&topic, partition_idx)
+                        .await
+                        .expect("failed to create sequencer");
+                    (partition_idx, row.id)
+                }
+            })
+            .collect::<FuturesUnordered<_>>()
+            .collect::<HashMap<KafkaPartition, SequencerId>>()
+            .await;
+
+        let sharder = JumpHash::new(
+            actual_mapping
+                .clone()
+                .into_iter()
+                .map(|(idx, _id)| Sequencer::new(idx, Arc::clone(&write_buffer), &*metrics))
+                .map(Arc::new),
+        );
+
+        let svc = ShardService::new(sharder, topic, catalog)
+            .await
+            .expect("failed to init service");
+
+        // Validate the correct mapping was constructed.
+        assert_eq!(svc.mapping, actual_mapping);
+
+        // Validate calling the RPC service returns correct mapping data.
+        for i in 0..100 {
+            let resp = svc
+                .shard_to_sequencer_id(Request::new(ShardToSequencerIdRequest {
+                    table_name: format!("{}", i),
+                    namespace_name: "bananas".to_string(),
+                }))
+                .await
+                .expect("rpc call should succeed")
+                .into_inner();
+
+            let actual = actual_mapping
+                .get(&KafkaPartition::new(resp.sequencer_index))
+                .expect("returned kafka partition index must exist in mapping");
+            assert_eq!(actual.get(), resp.sequencer_id);
+        }
+    }
+
+    // Init a mock write buffer with the given number of sequencers.
+    fn init_write_buffer() -> MockBufferForWriting {
+        let time = iox_time::MockProvider::new(iox_time::Time::from_timestamp_millis(668563200000));
+        MockBufferForWriting::new(
+            MockBufferSharedState::empty_with_n_sequencers(
+                NonZeroU32::new(N_SEQUENCERS as _).unwrap(),
+            ),
+            None,
+            Arc::new(time),
+        )
+        .expect("failed to init mock write buffer")
+    }
+}

--- a/router/src/server/grpc/sharder.rs
+++ b/router/src/server/grpc/sharder.rs
@@ -26,7 +26,7 @@ use crate::sequencer::Sequencer;
 ///
 /// [gRPC endpoint]: generated_types::influxdata::iox::sharder::v1::shard_service_server::ShardService
 /// [`ShardedWriteBuffer`]: crate::dml_handlers::ShardedWriteBuffer
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ShardService<S> {
     sharder: S,
 

--- a/sharder/src/trait.rs
+++ b/sharder/src/trait.rs
@@ -1,5 +1,5 @@
 use data_types::DatabaseName;
-use std::fmt::Debug;
+use std::{fmt::Debug, sync::Arc};
 
 /// A [`Sharder`] implementation is responsible for mapping an opaque payload
 /// for a given table name & namespace to an output type.
@@ -20,4 +20,36 @@ pub trait Sharder<P>: Debug + Send + Sync {
 
     /// Map the specified `payload` to a shard.
     fn shard(&self, table: &str, namespace: &DatabaseName<'_>, payload: &P) -> Self::Item;
+}
+
+impl<T, P> Sharder<P> for Arc<T>
+where
+    T: Sharder<P>,
+{
+    type Item = T::Item;
+
+    fn shard(&self, table: &str, namespace: &DatabaseName<'_>, payload: &P) -> Self::Item {
+        (**self).shard(table, namespace, payload)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use mutable_batch::MutableBatch;
+
+    use crate::JumpHash;
+
+    use super::*;
+
+    #[test]
+    fn test_arc_wrapped_sharder() {
+        let hasher: Arc<dyn Sharder<MutableBatch, Item = Arc<u32>>> =
+            Arc::new(JumpHash::new((0..10_u32).map(Arc::new)));
+
+        let _ = hasher.shard(
+            "table",
+            &DatabaseName::try_from("namespace").unwrap(),
+            &MutableBatch::default(),
+        );
+    }
 }


### PR DESCRIPTION
This PR completes the implementation of a gRPC shard service for external clients to look up the mapping of `(table, namespace)` to a Kafka shard/partition/whatevs.

I used "shard" (instead of "partition"/etc) because of the impending [changes](https://github.com/influxdata/influxdb_iox/pull/5435).

---

* feat: impl Sharder<()> for JumpHash (baacc015d)

      Implement a payload-less Sharder for the JumpHash concrete type. This models
      the input the gRPC ShardService will provide.

* feat: ShardService gRPC endpoint handler (da31f3140)

      Implements the ShardService to expose the shard mapping produced by routers to
      external clients.

      This impl uses an internal cache to eliminate unnecessary Catalog queries, as
      the Kafka partition/Sequencer/Shard mapping is static once a router has
      initialised.

* refactor: impl Sharder for Arc-wrapped Sharder (3594e5d09)

      Allows any Sharder wrapped in an Arc to be used as a Sharder impl, allowing
      the same Sharder instance to be shared across independent code modules.

* feat: expose ShardService over gRPC (7afa3bfae)

      Plumbs in the ShardService impl, and exposes it over the router's gRPC 
      interface.