### PR TITLE
feat: Renaming kafka topic types

### DIFF
--- a/compactor/src/compact.rs
+++ b/compactor/src/compact.rs
@@ -495,14 +495,14 @@ mod tests {
         // empty partition
         let mut txn = catalog.catalog.start_transaction().await.unwrap();
 
-        let kafka = txn.kafka_topics().create_or_get("foo").await.unwrap();
+        let topic = txn.topics().create_or_get("foo").await.unwrap();
         let pool = txn.query_pools().create_or_get("foo").await.unwrap();
         let namespace = txn
             .namespaces()
             .create(
                 "namespace_hot_partitions_to_compact",
                 "inf",
-                kafka.id,
+                topic.id,
                 pool.id,
             )
             .await
@@ -514,7 +514,7 @@ mod tests {
             .unwrap();
         let shard = txn
             .shards()
-            .create_or_get(&kafka, ShardIndex::new(1))
+            .create_or_get(&topic, ShardIndex::new(1))
             .await
             .unwrap();
         let partition1 = txn
@@ -545,7 +545,7 @@ mod tests {
             .unwrap();
         let another_shard = txn
             .shards()
-            .create_or_get(&kafka, ShardIndex::new(2))
+            .create_or_get(&topic, ShardIndex::new(2))
             .await
             .unwrap();
         let another_partition = txn
@@ -791,14 +791,14 @@ mod tests {
         // empty partition
         let mut txn = catalog.catalog.start_transaction().await.unwrap();
 
-        let kafka = txn.kafka_topics().create_or_get("foo").await.unwrap();
+        let topic = txn.topics().create_or_get("foo").await.unwrap();
         let pool = txn.query_pools().create_or_get("foo").await.unwrap();
         let namespace = txn
             .namespaces()
             .create(
                 "namespace_hot_partitions_to_compact",
                 "inf",
-                kafka.id,
+                topic.id,
                 pool.id,
             )
             .await
@@ -810,7 +810,7 @@ mod tests {
             .unwrap();
         let shard = txn
             .shards()
-            .create_or_get(&kafka, ShardIndex::new(1))
+            .create_or_get(&topic, ShardIndex::new(1))
             .await
             .unwrap();
         let partition1 = txn
@@ -846,7 +846,7 @@ mod tests {
             .unwrap();
         let another_shard = txn
             .shards()
-            .create_or_get(&kafka, ShardIndex::new(2))
+            .create_or_get(&topic, ShardIndex::new(2))
             .await
             .unwrap();
         let another_partition = txn

--- a/compactor/src/garbage_collector.rs
+++ b/compactor/src/garbage_collector.rs
@@ -147,11 +147,11 @@ mod tests {
             Timestamp::new((gc.time_provider.now() + Duration::from_secs(100)).timestamp_nanos());
 
         let mut txn = catalog.catalog.start_transaction().await.unwrap();
-        let kafka = txn.kafka_topics().create_or_get("foo").await.unwrap();
+        let topic = txn.topics().create_or_get("foo").await.unwrap();
         let pool = txn.query_pools().create_or_get("foo").await.unwrap();
         let namespace = txn
             .namespaces()
-            .create("gc_leave_undeleted_files_alone", "inf", kafka.id, pool.id)
+            .create("gc_leave_undeleted_files_alone", "inf", topic.id, pool.id)
             .await
             .unwrap();
         let table = txn
@@ -161,7 +161,7 @@ mod tests {
             .unwrap();
         let shard = txn
             .shards()
-            .create_or_get(&kafka, ShardIndex::new(1))
+            .create_or_get(&topic, ShardIndex::new(1))
             .await
             .unwrap();
         let partition = txn
@@ -228,11 +228,11 @@ mod tests {
             Timestamp::new((gc.time_provider.now() - Duration::from_secs(100)).timestamp_nanos());
 
         let mut txn = catalog.catalog.start_transaction().await.unwrap();
-        let kafka = txn.kafka_topics().create_or_get("foo").await.unwrap();
+        let topic = txn.topics().create_or_get("foo").await.unwrap();
         let pool = txn.query_pools().create_or_get("foo").await.unwrap();
         let namespace = txn
             .namespaces()
-            .create("gc_leave_too_new_files_alone", "inf", kafka.id, pool.id)
+            .create("gc_leave_too_new_files_alone", "inf", topic.id, pool.id)
             .await
             .unwrap();
         let table = txn
@@ -242,7 +242,7 @@ mod tests {
             .unwrap();
         let shard = txn
             .shards()
-            .create_or_get(&kafka, ShardIndex::new(1))
+            .create_or_get(&topic, ShardIndex::new(1))
             .await
             .unwrap();
         let partition = txn
@@ -313,11 +313,11 @@ mod tests {
             Timestamp::new((gc.time_provider.now() + Duration::from_secs(100)).timestamp_nanos());
 
         let mut txn = catalog.catalog.start_transaction().await.unwrap();
-        let kafka = txn.kafka_topics().create_or_get("foo").await.unwrap();
+        let topic = txn.topics().create_or_get("foo").await.unwrap();
         let pool = txn.query_pools().create_or_get("foo").await.unwrap();
         let namespace = txn
             .namespaces()
-            .create("gc_remove_old_enough_files", "inf", kafka.id, pool.id)
+            .create("gc_remove_old_enough_files", "inf", topic.id, pool.id)
             .await
             .unwrap();
         let table = txn
@@ -327,7 +327,7 @@ mod tests {
             .unwrap();
         let shard = txn
             .shards()
-            .create_or_get(&kafka, ShardIndex::new(1))
+            .create_or_get(&topic, ShardIndex::new(1))
             .await
             .unwrap();
         let partition = txn

--- a/data_types/src/lib.rs
+++ b/data_types/src/lib.rs
@@ -387,9 +387,10 @@ impl std::fmt::Display for ParquetFileId {
     }
 }
 
-/// Data object for a kafka topic
+/// Data object for a topic. When Kafka is used as the write buffer, this is the Kafka topic name
+/// plus a catalog-assigned ID.
 #[derive(Debug, Clone, Eq, PartialEq, sqlx::FromRow)]
-pub struct KafkaTopic {
+pub struct TopicMetadata {
     /// The id of the topic
     pub id: KafkaTopicId,
     /// The unique name of the topic

--- a/garbage_collector/src/checker.rs
+++ b/garbage_collector/src/checker.rs
@@ -133,11 +133,11 @@ mod tests {
         let metric_registry = Arc::new(metric::Registry::new());
         let catalog = Arc::new(MemCatalog::new(Arc::clone(&metric_registry)));
         let mut repos = catalog.repositories().await;
-        let kafka = repos.kafka_topics().create_or_get("foo").await.unwrap();
+        let topic = repos.topics().create_or_get("foo").await.unwrap();
         let pool = repos.query_pools().create_or_get("foo").await.unwrap();
         let namespace = repos
             .namespaces()
-            .create("namespace_parquet_file_test", "inf", kafka.id, pool.id)
+            .create("namespace_parquet_file_test", "inf", topic.id, pool.id)
             .await
             .unwrap();
         let table = repos
@@ -147,7 +147,7 @@ mod tests {
             .unwrap();
         let shard = repos
             .shards()
-            .create_or_get(&kafka, ShardIndex::new(1))
+            .create_or_get(&topic, ShardIndex::new(1))
             .await
             .unwrap();
         let partition = repos

--- a/generated_types/protos/influxdata/iox/schema/v1/service.proto
+++ b/generated_types/protos/influxdata/iox/schema/v1/service.proto
@@ -17,10 +17,14 @@ message GetSchemaResponse {
 }
 
 message NamespaceSchema {
+  // Renamed to topic_id
+  reserved 2;
+  reserved "kafka_topic_id";
+
   // Namespace ID
   int64 id = 1;
-  // Kafka Topic ID
-  int64 kafka_topic_id = 2;
+  // Topic ID
+  int64 topic_id = 5;
   // Query Pool ID
   int64 query_pool_id = 3;
   // Map of Table Name -> Table Schema

--- a/import/src/aggregate_tsm_schema/update_catalog.rs
+++ b/import/src/aggregate_tsm_schema/update_catalog.rs
@@ -2,8 +2,8 @@ use self::generated_types::{shard_service_client::ShardServiceClient, *};
 use crate::{AggregateTSMMeasurement, AggregateTSMSchema};
 use chrono::{format::StrftimeItems, offset::FixedOffset, DateTime, Duration};
 use data_types::{
-    org_and_bucket_to_database, ColumnType, KafkaTopicId, Namespace, NamespaceSchema,
-    OrgBucketMappingError, Partition, PartitionKey, QueryPoolId, ShardId, TableSchema,
+    org_and_bucket_to_database, ColumnType, Namespace, NamespaceSchema, OrgBucketMappingError,
+    Partition, PartitionKey, QueryPoolId, ShardId, TableSchema, TopicId,
 };
 use influxdb_iox_client::connection::Connection;
 use iox_catalog::interface::{get_schema_by_name, Catalog, ColumnUpsertRequest, RepoCollection};
@@ -114,7 +114,7 @@ async fn get_topic_id_and_query_id<'a, R>(
     repos: &mut R,
     topic_name: &'a str,
     query_pool_name: &'a str,
-) -> Result<(KafkaTopicId, QueryPoolId), UpdateCatalogError>
+) -> Result<(TopicId, QueryPoolId), UpdateCatalogError>
 where
     R: RepoCollection + ?Sized,
 {
@@ -139,7 +139,7 @@ where
 async fn create_namespace<R>(
     name: &str,
     retention: &str,
-    topic_id: KafkaTopicId,
+    topic_id: TopicId,
     query_id: QueryPoolId,
     repos: &mut R,
 ) -> Result<Namespace, UpdateCatalogError>
@@ -592,12 +592,7 @@ mod tests {
         // create namespace, table and columns for weather measurement
         let namespace = txn
             .namespaces()
-            .create(
-                "1234_5678",
-                "inf",
-                KafkaTopicId::new(1),
-                QueryPoolId::new(1),
-            )
+            .create("1234_5678", "inf", TopicId::new(1), QueryPoolId::new(1))
             .await
             .expect("namespace created");
         let mut table = txn
@@ -702,12 +697,7 @@ mod tests {
         // create namespace, table and columns for weather measurement
         let namespace = txn
             .namespaces()
-            .create(
-                "1234_5678",
-                "inf",
-                KafkaTopicId::new(1),
-                QueryPoolId::new(1),
-            )
+            .create("1234_5678", "inf", TopicId::new(1), QueryPoolId::new(1))
             .await
             .expect("namespace created");
         let mut table = txn
@@ -788,12 +778,7 @@ mod tests {
         // create namespace, table and columns for weather measurement
         let namespace = txn
             .namespaces()
-            .create(
-                "1234_5678",
-                "inf",
-                KafkaTopicId::new(1),
-                QueryPoolId::new(1),
-            )
+            .create("1234_5678", "inf", TopicId::new(1), QueryPoolId::new(1))
             .await
             .expect("namespace created");
         let mut table = txn

--- a/influxdb_iox/src/commands/catalog.rs
+++ b/influxdb_iox/src/commands/catalog.rs
@@ -40,7 +40,7 @@ enum Command {
     /// Run database migrations
     Setup(Setup),
 
-    /// Manage kafka topic
+    /// Manage topic
     Topic(topic::Config),
 }
 

--- a/influxdb_iox/src/commands/catalog/topic.rs
+++ b/influxdb_iox/src/commands/catalog/topic.rs
@@ -46,7 +46,7 @@ pub async fn command(config: Config) -> Result<(), Error> {
             let metrics = Arc::new(metric::Registry::new());
             let catalog = update.catalog_dsn.get_catalog("cli", metrics).await?;
             let mut repos = catalog.repositories().await;
-            let topic = repos.kafka_topics().create_or_get(&update.db_name).await?;
+            let topic = repos.topics().create_or_get(&update.db_name).await?;
             println!("{}", topic.id);
             Ok(())
         }

--- a/influxdb_iox/src/commands/remote/partition.rs
+++ b/influxdb_iox/src/commands/remote/partition.rs
@@ -231,7 +231,7 @@ const QUERY_POOL: &str = "iox_shared";
 
 // loads the protobuf namespace schema returned from a remote IOx server into the passed in
 // catalog. It does this based on namespace, table, and column names, not IDs. It also inserts
-// a kafka topic and query pool for the namespace to use, which aren't for real use, but just
+// a topic and query pool for the namespace to use, which aren't for real use, but just
 // to make the loaded schema work.
 async fn load_schema(
     catalog: &Arc<dyn Catalog>,
@@ -398,7 +398,7 @@ mod tests {
 
         let schema = NamespaceSchema {
             id: 1,
-            kafka_topic_id: 1,
+            topic_id: 1,
             query_pool_id: 1,
             tables: HashMap::from([(
                 "table1".to_string(),
@@ -431,7 +431,7 @@ mod tests {
 
         let schema = NamespaceSchema {
             id: 1,
-            kafka_topic_id: 1,
+            topic_id: 1,
             query_pool_id: 1,
             tables: HashMap::from([(
                 "table1".to_string(),
@@ -451,7 +451,7 @@ mod tests {
 
         let schema = NamespaceSchema {
             id: 1,
-            kafka_topic_id: 1,
+            topic_id: 1,
             query_pool_id: 1,
             tables: HashMap::from([
                 (

--- a/influxdb_iox/src/commands/run/all_in_one.rs
+++ b/influxdb_iox/src/commands/run/all_in_one.rs
@@ -225,7 +225,7 @@ pub struct Config {
 
     /// If a partition has had data buffered for longer than this period of time
     /// it will be persisted. This puts an upper bound on how far back the
-    /// ingester may need to read in Kafka on restart or recovery. The default value
+    /// ingester may need to read in the write buffer on restart or recovery. The default value
     /// is 30 minutes (in seconds).
     #[clap(
         long = "--persist-partition-age-threshold-seconds",
@@ -499,7 +499,7 @@ pub async fn command(config: Config) -> Result<()> {
     catalog
         .repositories()
         .await
-        .kafka_topics()
+        .topics()
         .create_or_get(QUERY_POOL_NAME)
         .await?;
 

--- a/ingester/src/data.rs
+++ b/ingester/src/data.rs
@@ -1787,17 +1787,17 @@ mod tests {
         let metrics = Arc::new(metric::Registry::new());
         let catalog: Arc<dyn Catalog> = Arc::new(MemCatalog::new(Arc::clone(&metrics)));
         let mut repos = catalog.repositories().await;
-        let kafka_topic = repos.kafka_topics().create_or_get("whatevs").await.unwrap();
+        let topic = repos.topics().create_or_get("whatevs").await.unwrap();
         let query_pool = repos.query_pools().create_or_get("whatevs").await.unwrap();
         let shard_index = ShardIndex::new(0);
         let namespace = repos
             .namespaces()
-            .create("foo", "inf", kafka_topic.id, query_pool.id)
+            .create("foo", "inf", topic.id, query_pool.id)
             .await
             .unwrap();
         let shard1 = repos
             .shards()
-            .create_or_get(&kafka_topic, shard_index)
+            .create_or_get(&topic, shard_index)
             .await
             .unwrap();
 
@@ -1816,7 +1816,7 @@ mod tests {
             Arc::clone(&metrics),
         ));
 
-        let schema = NamespaceSchema::new(namespace.id, kafka_topic.id, query_pool.id);
+        let schema = NamespaceSchema::new(namespace.id, topic.id, query_pool.id);
 
         let ignored_ts = Time::from_timestamp_millis(42);
 
@@ -1871,22 +1871,22 @@ mod tests {
         let metrics = Arc::new(metric::Registry::new());
         let catalog: Arc<dyn Catalog> = Arc::new(MemCatalog::new(Arc::clone(&metrics)));
         let mut repos = catalog.repositories().await;
-        let kafka_topic = repos.kafka_topics().create_or_get("whatevs").await.unwrap();
+        let topic = repos.topics().create_or_get("whatevs").await.unwrap();
         let query_pool = repos.query_pools().create_or_get("whatevs").await.unwrap();
         let shard_index = ShardIndex::new(0);
         let namespace = repos
             .namespaces()
-            .create("foo", "inf", kafka_topic.id, query_pool.id)
+            .create("foo", "inf", topic.id, query_pool.id)
             .await
             .unwrap();
         let shard1 = repos
             .shards()
-            .create_or_get(&kafka_topic, shard_index)
+            .create_or_get(&topic, shard_index)
             .await
             .unwrap();
         let shard2 = repos
             .shards()
-            .create_or_get(&kafka_topic, shard_index)
+            .create_or_get(&topic, shard_index)
             .await
             .unwrap();
         let mut shards = BTreeMap::new();
@@ -1910,7 +1910,7 @@ mod tests {
             Arc::clone(&metrics),
         ));
 
-        let schema = NamespaceSchema::new(namespace.id, kafka_topic.id, query_pool.id);
+        let schema = NamespaceSchema::new(namespace.id, topic.id, query_pool.id);
 
         let ignored_ts = Time::from_timestamp_millis(42);
 
@@ -2106,22 +2106,22 @@ mod tests {
         let metrics = Arc::new(metric::Registry::new());
         let catalog: Arc<dyn Catalog> = Arc::new(MemCatalog::new(Arc::clone(&metrics)));
         let mut repos = catalog.repositories().await;
-        let kafka_topic = repos.kafka_topics().create_or_get("whatevs").await.unwrap();
+        let topic = repos.topics().create_or_get("whatevs").await.unwrap();
         let query_pool = repos.query_pools().create_or_get("whatevs").await.unwrap();
         let shard_index = ShardIndex::new(0);
         let namespace = repos
             .namespaces()
-            .create("foo", "inf", kafka_topic.id, query_pool.id)
+            .create("foo", "inf", topic.id, query_pool.id)
             .await
             .unwrap();
         let shard1 = repos
             .shards()
-            .create_or_get(&kafka_topic, shard_index)
+            .create_or_get(&topic, shard_index)
             .await
             .unwrap();
         let shard2 = repos
             .shards()
-            .create_or_get(&kafka_topic, shard_index)
+            .create_or_get(&topic, shard_index)
             .await
             .unwrap();
         let mut shards = BTreeMap::new();
@@ -2145,7 +2145,7 @@ mod tests {
             Arc::clone(&metrics),
         ));
 
-        let schema = NamespaceSchema::new(namespace.id, kafka_topic.id, query_pool.id);
+        let schema = NamespaceSchema::new(namespace.id, topic.id, query_pool.id);
 
         let ignored_ts = Time::from_timestamp_millis(42);
 
@@ -2495,21 +2495,21 @@ mod tests {
         let metrics = Arc::new(metric::Registry::new());
         let catalog: Arc<dyn Catalog> = Arc::new(MemCatalog::new(Arc::clone(&metrics)));
         let mut repos = catalog.repositories().await;
-        let kafka_topic = repos.kafka_topics().create_or_get("whatevs").await.unwrap();
+        let topic = repos.topics().create_or_get("whatevs").await.unwrap();
         let query_pool = repos.query_pools().create_or_get("whatevs").await.unwrap();
         let shard_index = ShardIndex::new(0);
         let namespace = repos
             .namespaces()
-            .create("foo", "inf", kafka_topic.id, query_pool.id)
+            .create("foo", "inf", topic.id, query_pool.id)
             .await
             .unwrap();
         let shard = repos
             .shards()
-            .create_or_get(&kafka_topic, shard_index)
+            .create_or_get(&topic, shard_index)
             .await
             .unwrap();
 
-        let schema = NamespaceSchema::new(namespace.id, kafka_topic.id, query_pool.id);
+        let schema = NamespaceSchema::new(namespace.id, topic.id, query_pool.id);
 
         let ignored_ts = Time::from_timestamp_millis(42);
 
@@ -2656,17 +2656,17 @@ mod tests {
         let metrics = Arc::new(metric::Registry::new());
         let catalog: Arc<dyn Catalog> = Arc::new(MemCatalog::new(Arc::clone(&metrics)));
         let mut repos = catalog.repositories().await;
-        let kafka_topic = repos.kafka_topics().create_or_get("whatevs").await.unwrap();
+        let topic = repos.topics().create_or_get("whatevs").await.unwrap();
         let query_pool = repos.query_pools().create_or_get("whatevs").await.unwrap();
         let shard_index = ShardIndex::new(0);
         let namespace = repos
             .namespaces()
-            .create("foo", "inf", kafka_topic.id, query_pool.id)
+            .create("foo", "inf", topic.id, query_pool.id)
             .await
             .unwrap();
         let shard1 = repos
             .shards()
-            .create_or_get(&kafka_topic, shard_index)
+            .create_or_get(&topic, shard_index)
             .await
             .unwrap();
 
@@ -2685,7 +2685,7 @@ mod tests {
             Arc::clone(&metrics),
         ));
 
-        let schema = NamespaceSchema::new(namespace.id, kafka_topic.id, query_pool.id);
+        let schema = NamespaceSchema::new(namespace.id, topic.id, query_pool.id);
 
         let ignored_ts = Time::from_timestamp_millis(42);
 

--- a/ingester/src/handler.rs
+++ b/ingester/src/handler.rs
@@ -83,7 +83,7 @@ fn shared_handle(handle: JoinHandle<()>) -> SharedJoinHandle {
 /// persistence and answer queries
 #[derive(Debug)]
 pub struct IngestHandlerImpl<T = SystemProvider> {
-    /// Kafka Topic assigned to this ingester
+    /// Topic assigned to this ingester
     #[allow(dead_code)]
     topic: TopicMetadata,
 

--- a/ingester/src/handler.rs
+++ b/ingester/src/handler.rs
@@ -12,7 +12,7 @@ use crate::{
 };
 use async_trait::async_trait;
 use backoff::BackoffConfig;
-use data_types::{KafkaTopic, Shard, ShardIndex};
+use data_types::{Shard, ShardIndex, TopicMetadata};
 use futures::{
     future::{BoxFuture, Shared},
     stream::FuturesUnordered,
@@ -85,7 +85,7 @@ fn shared_handle(handle: JoinHandle<()>) -> SharedJoinHandle {
 pub struct IngestHandlerImpl<T = SystemProvider> {
     /// Kafka Topic assigned to this ingester
     #[allow(dead_code)]
-    kafka_topic: KafkaTopic,
+    topic: TopicMetadata,
 
     /// Future that resolves when the background worker exits
     join_handles: Vec<(String, SharedJoinHandle)>,
@@ -123,7 +123,7 @@ impl IngestHandlerImpl {
     #[allow(clippy::too_many_arguments)]
     pub async fn new(
         lifecycle_config: LifecycleConfig,
-        topic: KafkaTopic,
+        topic: TopicMetadata,
         shard_states: BTreeMap<ShardIndex, Shard>,
         catalog: Arc<dyn Catalog>,
         object_store: Arc<DynObjectStore>,
@@ -151,7 +151,7 @@ impl IngestHandlerImpl {
         ));
 
         let ingester_data = Arc::clone(&data);
-        let kafka_topic_name = topic.name.clone();
+        let topic_name = topic.name.clone();
 
         // start the lifecycle manager
         let persister = Arc::clone(&data);
@@ -212,7 +212,7 @@ impl IngestHandlerImpl {
             let sink = SinkInstrumentation::new(
                 sink,
                 watermark_fetcher,
-                kafka_topic_name.clone(),
+                topic_name.clone(),
                 shard.shard_index,
                 &*metric_registry,
             );
@@ -222,14 +222,14 @@ impl IngestHandlerImpl {
             let handle = tokio::task::spawn({
                 let shutdown = shutdown.child_token();
                 let lifecycle_handle = lifecycle_handle.clone();
-                let kafka_topic_name = kafka_topic_name.clone();
+                let topic_name = topic_name.clone();
                 async move {
                     let handler = SequencedStreamHandler::new(
                         op_stream,
                         shard.min_unpersisted_sequence_number,
                         sink,
                         lifecycle_handle,
-                        kafka_topic_name,
+                        topic_name,
                         shard.shard_index,
                         &*metric_registry,
                         skip_to_oldest_available,
@@ -262,7 +262,7 @@ impl IngestHandlerImpl {
 
         Ok(Self {
             data,
-            kafka_topic: topic,
+            topic,
             join_handles,
             shutdown,
             query_duration_success,
@@ -401,7 +401,7 @@ mod tests {
 
         let schema = NamespaceSchema::new(
             ingester.namespace.id,
-            ingester.kafka_topic.id,
+            ingester.topic.id,
             ingester.query_pool.id,
         );
         let mut txn = ingester.catalog.start_transaction().await.unwrap();
@@ -482,7 +482,7 @@ mod tests {
                     .repositories()
                     .await
                     .shards()
-                    .create_or_get(&ingester.kafka_topic, ingester.shard_index)
+                    .create_or_get(&ingester.topic, ingester.shard_index)
                     .await
                     .unwrap();
 
@@ -621,17 +621,17 @@ mod tests {
         let catalog: Arc<dyn Catalog> = Arc::new(MemCatalog::new(Arc::clone(&metrics)));
 
         let mut txn = catalog.start_transaction().await.unwrap();
-        let kafka_topic = txn.kafka_topics().create_or_get("whatevs").await.unwrap();
+        let topic = txn.topics().create_or_get("whatevs").await.unwrap();
         let query_pool = txn.query_pools().create_or_get("whatevs").await.unwrap();
         let shard_index = ShardIndex::new(0);
         let namespace = txn
             .namespaces()
-            .create("foo", "inf", kafka_topic.id, query_pool.id)
+            .create("foo", "inf", topic.id, query_pool.id)
             .await
             .unwrap();
         let mut shard = txn
             .shards()
-            .create_or_get(&kafka_topic, shard_index)
+            .create_or_get(&topic, shard_index)
             .await
             .unwrap();
         // update the min unpersisted
@@ -652,7 +652,7 @@ mod tests {
         let write_buffer_state =
             MockBufferSharedState::empty_with_n_shards(NonZeroU32::try_from(1).unwrap());
 
-        let schema = NamespaceSchema::new(namespace.id, kafka_topic.id, query_pool.id);
+        let schema = NamespaceSchema::new(namespace.id, topic.id, query_pool.id);
         for write_operation in write_operations {
             validate_or_insert_schema(write_operation.tables(), &schema, txn.deref_mut())
                 .await
@@ -675,7 +675,7 @@ mod tests {
         );
         let ingester = IngestHandlerImpl::new(
             lifecycle_config,
-            kafka_topic.clone(),
+            topic.clone(),
             shard_states,
             Arc::clone(&catalog),
             object_store,
@@ -900,7 +900,7 @@ mod tests {
         catalog: Arc<dyn Catalog>,
         shard: Shard,
         namespace: Namespace,
-        kafka_topic: KafkaTopic,
+        topic: TopicMetadata,
         shard_index: ShardIndex,
         query_pool: QueryPool,
         metrics: Arc<metric::Registry>,
@@ -914,17 +914,17 @@ mod tests {
             let catalog: Arc<dyn Catalog> = Arc::new(MemCatalog::new(Arc::clone(&metrics)));
 
             let mut txn = catalog.start_transaction().await.unwrap();
-            let kafka_topic = txn.kafka_topics().create_or_get("whatevs").await.unwrap();
+            let topic = txn.topics().create_or_get("whatevs").await.unwrap();
             let query_pool = txn.query_pools().create_or_get("whatevs").await.unwrap();
             let shard_index = ShardIndex::new(0);
             let namespace = txn
                 .namespaces()
-                .create("foo", "inf", kafka_topic.id, query_pool.id)
+                .create("foo", "inf", topic.id, query_pool.id)
                 .await
                 .unwrap();
             let shard = txn
                 .shards()
-                .create_or_get(&kafka_topic, shard_index)
+                .create_or_get(&topic, shard_index)
                 .await
                 .unwrap();
             txn.commit().await.unwrap();
@@ -947,7 +947,7 @@ mod tests {
             );
             let ingester = IngestHandlerImpl::new(
                 lifecycle_config,
-                kafka_topic.clone(),
+                topic.clone(),
                 shard_states,
                 Arc::clone(&catalog),
                 object_store,
@@ -964,7 +964,7 @@ mod tests {
                 catalog,
                 shard,
                 namespace,
-                kafka_topic,
+                topic,
                 shard_index,
                 query_pool,
                 metrics,

--- a/ingester/src/lifecycle.rs
+++ b/ingester/src/lifecycle.rs
@@ -129,8 +129,8 @@ pub struct LifecycleManager {
 /// The configuration options for the lifecycle on the ingester.
 #[derive(Debug, Clone, Copy)]
 pub struct LifecycleConfig {
-    /// The ingester will pause pulling data from Kafka if it hits this amount of memory used, waiting
-    /// until persistence evicts partitions from memory.
+    /// The ingester will pause pulling data from the write buffer if it hits this amount of memory
+    /// used, waiting until persistence evicts partitions from memory.
     pause_ingest_size: usize,
     /// When the ingester hits this threshold, the lifecycle manager will persist the largest
     /// partitions currently buffered until it falls below this threshold. An ingester running
@@ -147,7 +147,7 @@ pub struct LifecycleConfig {
     partition_size_threshold: usize,
     /// If an individual partitiion has had data buffered for longer than this period of time, the
     /// manager will persist it. This setting is to ensure we have an upper bound on how far back
-    /// we will need to read in Kafka on restart or recovery.
+    /// we will need to read in the write buffer on restart or recovery.
     partition_age_threshold: Duration,
     /// If an individual partition hasn't received a write for longer than this period of time, the
     /// manager will persist it. This is to ensure that cold partitions get cleared out to make

--- a/ingester/src/stream_handler/sink_instrumentation.rs
+++ b/ingester/src/stream_handler/sink_instrumentation.rs
@@ -79,13 +79,13 @@ where
     pub fn new(
         inner: T,
         watermark_fetcher: F,
-        kafka_topic_name: String,
+        topic_name: String,
         shard_index: ShardIndex,
         metrics: &metric::Registry,
     ) -> Self {
         let attr = Attributes::from([
             ("kafka_partition", shard_index.to_string().into()),
-            ("kafka_topic", kafka_topic_name.into()),
+            ("kafka_topic", topic_name.into()),
         ]);
 
         let write_buffer_bytes_read = metrics
@@ -250,16 +250,16 @@ mod tests {
     /// be observing for.
     const SHARD_INDEX: ShardIndex = ShardIndex::new(42);
 
-    static TEST_KAFKA_TOPIC: &str = "kafka_topic_name";
+    static TEST_TOPIC_NAME: &str = "topic_name";
 
     static TEST_TIME: Lazy<Time> = Lazy::new(|| SystemProvider::default().now());
 
     /// The attributes assigned to the metrics emitted by the
-    /// instrumentation when using the above shard / kafka topic values.
+    /// instrumentation when using the above shard / topic values.
     static DEFAULT_ATTRS: Lazy<Attributes> = Lazy::new(|| {
         Attributes::from([
             ("kafka_partition", SHARD_INDEX.to_string().into()),
-            ("kafka_topic", TEST_KAFKA_TOPIC.into()),
+            ("kafka_topic", TEST_TOPIC_NAME.into()),
         ])
     });
 
@@ -296,7 +296,7 @@ mod tests {
         let instrumentation = SinkInstrumentation::new(
             inner,
             MockWatermarkFetcher::new(with_fetcher_return),
-            TEST_KAFKA_TOPIC.to_string(),
+            TEST_TOPIC_NAME.to_string(),
             SHARD_INDEX,
             metrics,
         );

--- a/iox_catalog/src/interface.rs
+++ b/iox_catalog/src/interface.rs
@@ -2,11 +2,11 @@
 
 use async_trait::async_trait;
 use data_types::{
-    Column, ColumnSchema, ColumnType, KafkaTopic, KafkaTopicId, Namespace, NamespaceId,
-    NamespaceSchema, ParquetFile, ParquetFileId, ParquetFileParams, Partition, PartitionId,
-    PartitionInfo, PartitionKey, PartitionParam, ProcessedTombstone, QueryPool, QueryPoolId,
-    SequenceNumber, Shard, ShardId, ShardIndex, Table, TableId, TablePartition, TableSchema,
-    Timestamp, Tombstone, TombstoneId,
+    Column, ColumnSchema, ColumnType, KafkaTopicId, Namespace, NamespaceId, NamespaceSchema,
+    ParquetFile, ParquetFileId, ParquetFileParams, Partition, PartitionId, PartitionInfo,
+    PartitionKey, PartitionParam, ProcessedTombstone, QueryPool, QueryPoolId, SequenceNumber,
+    Shard, ShardId, ShardIndex, Table, TableId, TablePartition, TableSchema, Timestamp, Tombstone,
+    TombstoneId, TopicMetadata,
 };
 use iox_time::TimeProvider;
 use snafu::{OptionExt, Snafu};
@@ -216,8 +216,8 @@ impl<T> Transaction for T where T: Send + Sync + Debug + sealed::TransactionFina
 /// are implemented.
 #[async_trait]
 pub trait RepoCollection: Send + Sync + Debug {
-    /// Repository for [Kafka topics](data_types::KafkaTopic).
-    fn kafka_topics(&mut self) -> &mut dyn KafkaTopicRepo;
+    /// Repository for [Kafka topics](data_types::TopicMetadata).
+    fn topics(&mut self) -> &mut dyn TopicMetadataRepo;
 
     /// Repository for [query pools](data_types::QueryPool).
     fn query_pools(&mut self) -> &mut dyn QueryPoolRepo;
@@ -247,14 +247,14 @@ pub trait RepoCollection: Send + Sync + Debug {
     fn processed_tombstones(&mut self) -> &mut dyn ProcessedTombstoneRepo;
 }
 
-/// Functions for working with Kafka topics in the catalog.
+/// Functions for working with topics in the catalog.
 #[async_trait]
-pub trait KafkaTopicRepo: Send + Sync {
-    /// Creates the kafka topic in the catalog or gets the existing record by name.
-    async fn create_or_get(&mut self, name: &str) -> Result<KafkaTopic>;
+pub trait TopicMetadataRepo: Send + Sync {
+    /// Creates the topic in the catalog or gets the existing record by name.
+    async fn create_or_get(&mut self, name: &str) -> Result<TopicMetadata>;
 
-    /// Gets the kafka topic by its unique name
-    async fn get_by_name(&mut self, name: &str) -> Result<Option<KafkaTopic>>;
+    /// Gets the topic by its unique name
+    async fn get_by_name(&mut self, name: &str) -> Result<Option<TopicMetadata>>;
 }
 
 /// Functions for working with query pools in the catalog.
@@ -273,7 +273,7 @@ pub trait NamespaceRepo: Send + Sync {
         &mut self,
         name: &str,
         retention_duration: &str,
-        kafka_topic_id: KafkaTopicId,
+        topic_id: KafkaTopicId,
         query_pool_id: QueryPoolId,
     ) -> Result<Namespace>;
 
@@ -384,9 +384,12 @@ pub trait ColumnRepo: Send + Sync {
 /// Functions for working with shards in the catalog
 #[async_trait]
 pub trait ShardRepo: Send + Sync {
-    /// create a shard record for the kafka topic and shard index or return the existing record
-    async fn create_or_get(&mut self, topic: &KafkaTopic, shard_index: ShardIndex)
-        -> Result<Shard>;
+    /// create a shard record for the topic and shard index or return the existing record
+    async fn create_or_get(
+        &mut self,
+        topic: &TopicMetadata,
+        shard_index: ShardIndex,
+    ) -> Result<Shard>;
 
     /// get the shard record by `KafkaTopicId` and `ShardIndex`
     async fn get_by_topic_id_and_shard_index(
@@ -398,8 +401,8 @@ pub trait ShardRepo: Send + Sync {
     /// list all shards
     async fn list(&mut self) -> Result<Vec<Shard>>;
 
-    /// list all shards for a given kafka topic
-    async fn list_by_kafka_topic(&mut self, topic: &KafkaTopic) -> Result<Vec<Shard>>;
+    /// list all shards for a given topic
+    async fn list_by_topic(&mut self, topic: &TopicMetadata) -> Result<Vec<Shard>>;
 
     /// updates the `min_unpersisted_sequence_number` for a shard
     async fn update_min_unpersisted_sequence_number(
@@ -855,7 +858,7 @@ pub(crate) mod test_helpers {
 
     pub(crate) async fn test_catalog(catalog: Arc<dyn Catalog>) {
         test_setup(Arc::clone(&catalog)).await;
-        test_kafka_topic(Arc::clone(&catalog)).await;
+        test_topic(Arc::clone(&catalog)).await;
         test_query_pool(Arc::clone(&catalog)).await;
         test_namespace(Arc::clone(&catalog)).await;
         test_table(Arc::clone(&catalog)).await;
@@ -877,7 +880,7 @@ pub(crate) mod test_helpers {
         test_list_schemas(Arc::clone(&catalog)).await;
 
         let metrics = catalog.metrics();
-        assert_metric_hit(&*metrics, "kafka_create_or_get");
+        assert_metric_hit(&*metrics, "topic_create_or_get");
         assert_metric_hit(&*metrics, "query_create_or_get");
         assert_metric_hit(&*metrics, "namespace_create");
         assert_metric_hit(&*metrics, "table_create_or_get");
@@ -893,18 +896,18 @@ pub(crate) mod test_helpers {
         catalog.setup().await.expect("second catalog setup");
     }
 
-    async fn test_kafka_topic(catalog: Arc<dyn Catalog>) {
+    async fn test_topic(catalog: Arc<dyn Catalog>) {
         let mut repos = catalog.repositories().await;
-        let kafka_repo = repos.kafka_topics();
+        let topic_repo = repos.topics();
 
-        let k = kafka_repo.create_or_get("foo").await.unwrap();
+        let k = topic_repo.create_or_get("foo").await.unwrap();
         assert!(k.id > KafkaTopicId::new(0));
         assert_eq!(k.name, "foo");
-        let k2 = kafka_repo.create_or_get("foo").await.unwrap();
+        let k2 = topic_repo.create_or_get("foo").await.unwrap();
         assert_eq!(k, k2);
-        let k3 = kafka_repo.get_by_name("foo").await.unwrap().unwrap();
+        let k3 = topic_repo.get_by_name("foo").await.unwrap().unwrap();
         assert_eq!(k3, k);
-        let k3 = kafka_repo.get_by_name("asdf").await.unwrap();
+        let k3 = topic_repo.get_by_name("asdf").await.unwrap();
         assert!(k3.is_none());
     }
 
@@ -921,13 +924,13 @@ pub(crate) mod test_helpers {
 
     async fn test_namespace(catalog: Arc<dyn Catalog>) {
         let mut repos = catalog.repositories().await;
-        let kafka = repos.kafka_topics().create_or_get("foo").await.unwrap();
+        let topic = repos.topics().create_or_get("foo").await.unwrap();
         let pool = repos.query_pools().create_or_get("foo").await.unwrap();
 
         let namespace_name = "test_namespace";
         let namespace = repos
             .namespaces()
-            .create(namespace_name, "inf", kafka.id, pool.id)
+            .create(namespace_name, "inf", topic.id, pool.id)
             .await
             .unwrap();
         assert!(namespace.id > NamespaceId::new(0));
@@ -935,7 +938,7 @@ pub(crate) mod test_helpers {
 
         let conflict = repos
             .namespaces()
-            .create(namespace_name, "inf", kafka.id, pool.id)
+            .create(namespace_name, "inf", topic.id, pool.id)
             .await;
         assert!(matches!(
             conflict.unwrap_err(),
@@ -975,7 +978,7 @@ pub(crate) mod test_helpers {
         let namespace2_name = "test_namespace2";
         let namespace2 = repos
             .namespaces()
-            .create(namespace2_name, "inf", kafka.id, pool.id)
+            .create(namespace2_name, "inf", topic.id, pool.id)
             .await
             .unwrap();
         let mut namespaces = repos.namespaces().list().await.unwrap();
@@ -1001,11 +1004,11 @@ pub(crate) mod test_helpers {
 
     async fn test_table(catalog: Arc<dyn Catalog>) {
         let mut repos = catalog.repositories().await;
-        let kafka = repos.kafka_topics().create_or_get("foo").await.unwrap();
+        let topic = repos.topics().create_or_get("foo").await.unwrap();
         let pool = repos.query_pools().create_or_get("foo").await.unwrap();
         let namespace = repos
             .namespaces()
-            .create("namespace_table_test", "inf", kafka.id, pool.id)
+            .create("namespace_table_test", "inf", topic.id, pool.id)
             .await
             .unwrap();
 
@@ -1042,7 +1045,7 @@ pub(crate) mod test_helpers {
         // test we can create a table of the same name in a different namespace
         let namespace2 = repos
             .namespaces()
-            .create("two", "inf", kafka.id, pool.id)
+            .create("two", "inf", topic.id, pool.id)
             .await
             .unwrap();
         assert_ne!(namespace, namespace2);
@@ -1110,7 +1113,7 @@ pub(crate) mod test_helpers {
         // test we can get table persistence info with no persistence so far
         let shard = repos
             .shards()
-            .create_or_get(&kafka, ShardIndex::new(555))
+            .create_or_get(&topic, ShardIndex::new(555))
             .await
             .unwrap();
         let ti = repos
@@ -1178,11 +1181,11 @@ pub(crate) mod test_helpers {
 
     async fn test_column(catalog: Arc<dyn Catalog>) {
         let mut repos = catalog.repositories().await;
-        let kafka = repos.kafka_topics().create_or_get("foo").await.unwrap();
+        let topic = repos.topics().create_or_get("foo").await.unwrap();
         let pool = repos.query_pools().create_or_get("foo").await.unwrap();
         let namespace = repos
             .namespaces()
-            .create("namespace_column_test", "inf", kafka.id, pool.id)
+            .create("namespace_column_test", "inf", topic.id, pool.id)
             .await
             .unwrap();
         let table = repos
@@ -1292,18 +1295,14 @@ pub(crate) mod test_helpers {
 
     async fn test_shards(catalog: Arc<dyn Catalog>) {
         let mut repos = catalog.repositories().await;
-        let kafka = repos
-            .kafka_topics()
-            .create_or_get("shard_test")
-            .await
-            .unwrap();
+        let topic = repos.topics().create_or_get("shard_test").await.unwrap();
 
         // Create 10 shards
         let mut created = BTreeMap::new();
         for shard_index in 1..=10 {
             let shard = repos
                 .shards()
-                .create_or_get(&kafka, ShardIndex::new(shard_index))
+                .create_or_get(&topic, ShardIndex::new(shard_index))
                 .await
                 .expect("failed to create shard");
             created.insert(shard.id, shard);
@@ -1312,7 +1311,7 @@ pub(crate) mod test_helpers {
         // List them and assert they match
         let listed = repos
             .shards()
-            .list_by_kafka_topic(&kafka)
+            .list_by_topic(&topic)
             .await
             .expect("failed to list shards")
             .into_iter()
@@ -1325,11 +1324,11 @@ pub(crate) mod test_helpers {
         let shard_index = ShardIndex::new(1);
         let shard = repos
             .shards()
-            .get_by_topic_id_and_shard_index(kafka.id, shard_index)
+            .get_by_topic_id_and_shard_index(topic.id, shard_index)
             .await
             .unwrap()
             .unwrap();
-        assert_eq!(kafka.id, shard.kafka_topic_id);
+        assert_eq!(topic.id, shard.kafka_topic_id);
         assert_eq!(shard_index, shard.shard_index);
 
         // update the number
@@ -1340,7 +1339,7 @@ pub(crate) mod test_helpers {
             .unwrap();
         let updated_shard = repos
             .shards()
-            .create_or_get(&kafka, shard_index)
+            .create_or_get(&topic, shard_index)
             .await
             .unwrap();
         assert_eq!(updated_shard.id, shard.id);
@@ -1351,7 +1350,7 @@ pub(crate) mod test_helpers {
 
         let shard = repos
             .shards()
-            .get_by_topic_id_and_shard_index(kafka.id, ShardIndex::new(523))
+            .get_by_topic_id_and_shard_index(topic.id, ShardIndex::new(523))
             .await
             .unwrap();
         assert!(shard.is_none());
@@ -1359,11 +1358,11 @@ pub(crate) mod test_helpers {
 
     async fn test_partition(catalog: Arc<dyn Catalog>) {
         let mut repos = catalog.repositories().await;
-        let kafka = repos.kafka_topics().create_or_get("foo").await.unwrap();
+        let topic = repos.topics().create_or_get("foo").await.unwrap();
         let pool = repos.query_pools().create_or_get("foo").await.unwrap();
         let namespace = repos
             .namespaces()
-            .create("namespace_partition_test", "inf", kafka.id, pool.id)
+            .create("namespace_partition_test", "inf", topic.id, pool.id)
             .await
             .unwrap();
         let table = repos
@@ -1373,12 +1372,12 @@ pub(crate) mod test_helpers {
             .unwrap();
         let shard = repos
             .shards()
-            .create_or_get(&kafka, ShardIndex::new(1))
+            .create_or_get(&topic, ShardIndex::new(1))
             .await
             .unwrap();
         let other_shard = repos
             .shards()
-            .create_or_get(&kafka, ShardIndex::new(2))
+            .create_or_get(&topic, ShardIndex::new(2))
             .await
             .unwrap();
 
@@ -1452,7 +1451,7 @@ pub(crate) mod test_helpers {
         // test list_by_namespace
         let namespace2 = repos
             .namespaces()
-            .create("namespace_partition_test2", "inf", kafka.id, pool.id)
+            .create("namespace_partition_test2", "inf", topic.id, pool.id)
             .await
             .unwrap();
         let table2 = repos
@@ -1530,11 +1529,11 @@ pub(crate) mod test_helpers {
 
     async fn test_tombstone(catalog: Arc<dyn Catalog>) {
         let mut repos = catalog.repositories().await;
-        let kafka = repos.kafka_topics().create_or_get("foo").await.unwrap();
+        let topic = repos.topics().create_or_get("foo").await.unwrap();
         let pool = repos.query_pools().create_or_get("foo").await.unwrap();
         let namespace = repos
             .namespaces()
-            .create("namespace_tombstone_test", "inf", kafka.id, pool.id)
+            .create("namespace_tombstone_test", "inf", topic.id, pool.id)
             .await
             .unwrap();
         let table = repos
@@ -1549,7 +1548,7 @@ pub(crate) mod test_helpers {
             .unwrap();
         let shard = repos
             .shards()
-            .create_or_get(&kafka, ShardIndex::new(1))
+            .create_or_get(&topic, ShardIndex::new(1))
             .await
             .unwrap();
 
@@ -1618,7 +1617,7 @@ pub(crate) mod test_helpers {
         // test list_by_namespace
         let namespace2 = repos
             .namespaces()
-            .create("namespace_tombstone_test2", "inf", kafka.id, pool.id)
+            .create("namespace_tombstone_test2", "inf", topic.id, pool.id)
             .await
             .unwrap();
         let table2 = repos
@@ -1693,14 +1692,14 @@ pub(crate) mod test_helpers {
 
     async fn test_tombstones_by_parquet_file(catalog: Arc<dyn Catalog>) {
         let mut repos = catalog.repositories().await;
-        let kafka = repos.kafka_topics().create_or_get("foo").await.unwrap();
+        let topic = repos.topics().create_or_get("foo").await.unwrap();
         let pool = repos.query_pools().create_or_get("foo").await.unwrap();
         let namespace = repos
             .namespaces()
             .create(
                 "namespace_tombstones_by_parquet_file_test",
                 "inf",
-                kafka.id,
+                topic.id,
                 pool.id,
             )
             .await
@@ -1717,12 +1716,12 @@ pub(crate) mod test_helpers {
             .unwrap();
         let shard = repos
             .shards()
-            .create_or_get(&kafka, ShardIndex::new(57))
+            .create_or_get(&topic, ShardIndex::new(57))
             .await
             .unwrap();
         let other_shard = repos
             .shards()
-            .create_or_get(&kafka, ShardIndex::new(58))
+            .create_or_get(&topic, ShardIndex::new(58))
             .await
             .unwrap();
         let partition = repos
@@ -1912,11 +1911,11 @@ pub(crate) mod test_helpers {
 
     async fn test_parquet_file(catalog: Arc<dyn Catalog>) {
         let mut repos = catalog.repositories().await;
-        let kafka = repos.kafka_topics().create_or_get("foo").await.unwrap();
+        let topic = repos.topics().create_or_get("foo").await.unwrap();
         let pool = repos.query_pools().create_or_get("foo").await.unwrap();
         let namespace = repos
             .namespaces()
-            .create("namespace_parquet_file_test", "inf", kafka.id, pool.id)
+            .create("namespace_parquet_file_test", "inf", topic.id, pool.id)
             .await
             .unwrap();
         let table = repos
@@ -1931,7 +1930,7 @@ pub(crate) mod test_helpers {
             .unwrap();
         let shard = repos
             .shards()
-            .create_or_get(&kafka, ShardIndex::new(1))
+            .create_or_get(&topic, ShardIndex::new(1))
             .await
             .unwrap();
         let partition = repos
@@ -2071,7 +2070,7 @@ pub(crate) mod test_helpers {
         // test list_by_namespace_not_to_delete
         let namespace2 = repos
             .namespaces()
-            .create("namespace_parquet_file_test1", "inf", kafka.id, pool.id)
+            .create("namespace_parquet_file_test1", "inf", topic.id, pool.id)
             .await
             .unwrap();
         let table2 = repos
@@ -2328,14 +2327,14 @@ pub(crate) mod test_helpers {
 
     async fn test_parquet_file_compaction_level_0(catalog: Arc<dyn Catalog>) {
         let mut repos = catalog.repositories().await;
-        let kafka = repos.kafka_topics().create_or_get("foo").await.unwrap();
+        let topic = repos.topics().create_or_get("foo").await.unwrap();
         let pool = repos.query_pools().create_or_get("foo").await.unwrap();
         let namespace = repos
             .namespaces()
             .create(
                 "namespace_parquet_file_compaction_level_0_test",
                 "inf",
-                kafka.id,
+                topic.id,
                 pool.id,
             )
             .await
@@ -2347,12 +2346,12 @@ pub(crate) mod test_helpers {
             .unwrap();
         let shard = repos
             .shards()
-            .create_or_get(&kafka, ShardIndex::new(100))
+            .create_or_get(&topic, ShardIndex::new(100))
             .await
             .unwrap();
         let other_shard = repos
             .shards()
-            .create_or_get(&kafka, ShardIndex::new(101))
+            .create_or_get(&topic, ShardIndex::new(101))
             .await
             .unwrap();
 
@@ -2446,14 +2445,14 @@ pub(crate) mod test_helpers {
 
     async fn test_parquet_file_compaction_level_1(catalog: Arc<dyn Catalog>) {
         let mut repos = catalog.repositories().await;
-        let kafka = repos.kafka_topics().create_or_get("foo").await.unwrap();
+        let topic = repos.topics().create_or_get("foo").await.unwrap();
         let pool = repos.query_pools().create_or_get("foo").await.unwrap();
         let namespace = repos
             .namespaces()
             .create(
                 "namespace_parquet_file_compaction_level_1_test",
                 "inf",
-                kafka.id,
+                topic.id,
                 pool.id,
             )
             .await
@@ -2470,12 +2469,12 @@ pub(crate) mod test_helpers {
             .unwrap();
         let shard = repos
             .shards()
-            .create_or_get(&kafka, ShardIndex::new(100))
+            .create_or_get(&topic, ShardIndex::new(100))
             .await
             .unwrap();
         let other_shard = repos
             .shards()
-            .create_or_get(&kafka, ShardIndex::new(101))
+            .create_or_get(&topic, ShardIndex::new(101))
             .await
             .unwrap();
         let partition = repos
@@ -2662,11 +2661,7 @@ pub(crate) mod test_helpers {
 
     async fn test_most_level_0_files_partitions(catalog: Arc<dyn Catalog>) {
         let mut repos = catalog.repositories().await;
-        let kafka = repos
-            .kafka_topics()
-            .create_or_get("most_level_0")
-            .await
-            .unwrap();
+        let topic = repos.topics().create_or_get("most_level_0").await.unwrap();
         let pool = repos
             .query_pools()
             .create_or_get("most_level_0")
@@ -2677,7 +2672,7 @@ pub(crate) mod test_helpers {
             .create(
                 "test_most_level_0_files_partitions",
                 "inf",
-                kafka.id,
+                topic.id,
                 pool.id,
             )
             .await
@@ -2689,7 +2684,7 @@ pub(crate) mod test_helpers {
             .unwrap();
         let shard = repos
             .shards()
-            .create_or_get(&kafka, ShardIndex::new(100))
+            .create_or_get(&topic, ShardIndex::new(100))
             .await
             .unwrap();
 
@@ -2870,8 +2865,8 @@ pub(crate) mod test_helpers {
 
     async fn test_recent_highest_throughput_partitions(catalog: Arc<dyn Catalog>) {
         let mut repos = catalog.repositories().await;
-        let kafka = repos
-            .kafka_topics()
+        let topic = repos
+            .topics()
             .create_or_get("highest_throughput")
             .await
             .unwrap();
@@ -2885,7 +2880,7 @@ pub(crate) mod test_helpers {
             .create(
                 "test_recent_highest_throughput_partitions",
                 "inf",
-                kafka.id,
+                topic.id,
                 pool.id,
             )
             .await
@@ -2897,7 +2892,7 @@ pub(crate) mod test_helpers {
             .unwrap();
         let shard = repos
             .shards()
-            .create_or_get(&kafka, ShardIndex::new(100))
+            .create_or_get(&topic, ShardIndex::new(100))
             .await
             .unwrap();
 
@@ -3135,14 +3130,14 @@ pub(crate) mod test_helpers {
 
     async fn test_list_by_partiton_not_to_delete(catalog: Arc<dyn Catalog>) {
         let mut repos = catalog.repositories().await;
-        let kafka = repos.kafka_topics().create_or_get("foo").await.unwrap();
+        let topic = repos.topics().create_or_get("foo").await.unwrap();
         let pool = repos.query_pools().create_or_get("foo").await.unwrap();
         let namespace = repos
             .namespaces()
             .create(
                 "namespace_parquet_file_test_list_by_partiton_not_to_delete",
                 "inf",
-                kafka.id,
+                topic.id,
                 pool.id,
             )
             .await
@@ -3154,7 +3149,7 @@ pub(crate) mod test_helpers {
             .unwrap();
         let shard = repos
             .shards()
-            .create_or_get(&kafka, ShardIndex::new(100))
+            .create_or_get(&topic, ShardIndex::new(100))
             .await
             .unwrap();
 
@@ -3244,14 +3239,14 @@ pub(crate) mod test_helpers {
 
     async fn test_update_to_compaction_level_1(catalog: Arc<dyn Catalog>) {
         let mut repos = catalog.repositories().await;
-        let kafka = repos.kafka_topics().create_or_get("foo").await.unwrap();
+        let topic = repos.topics().create_or_get("foo").await.unwrap();
         let pool = repos.query_pools().create_or_get("foo").await.unwrap();
         let namespace = repos
             .namespaces()
             .create(
                 "namespace_update_to_compaction_level_1_test",
                 "inf",
-                kafka.id,
+                topic.id,
                 pool.id,
             )
             .await
@@ -3263,7 +3258,7 @@ pub(crate) mod test_helpers {
             .unwrap();
         let shard = repos
             .shards()
-            .create_or_get(&kafka, ShardIndex::new(1000))
+            .create_or_get(&topic, ShardIndex::new(1000))
             .await
             .unwrap();
         let partition = repos
@@ -3365,14 +3360,14 @@ pub(crate) mod test_helpers {
 
     async fn test_processed_tombstones(catalog: Arc<dyn Catalog>) {
         let mut repos = catalog.repositories().await;
-        let kafka = repos.kafka_topics().create_or_get("foo").await.unwrap();
+        let topic = repos.topics().create_or_get("foo").await.unwrap();
         let pool = repos.query_pools().create_or_get("foo").await.unwrap();
         let namespace = repos
             .namespaces()
             .create(
                 "namespace_processed_tombstone_test",
                 "inf",
-                kafka.id,
+                topic.id,
                 pool.id,
             )
             .await
@@ -3384,7 +3379,7 @@ pub(crate) mod test_helpers {
             .unwrap();
         let shard = repos
             .shards()
-            .create_or_get(&kafka, ShardIndex::new(1))
+            .create_or_get(&topic, ShardIndex::new(1))
             .await
             .unwrap();
         let partition = repos
@@ -3550,7 +3545,7 @@ pub(crate) mod test_helpers {
             barrier_captured.wait().await;
 
             let mut txn = catalog_captured.start_transaction().await.unwrap();
-            txn.kafka_topics()
+            txn.topics()
                 .create_or_get("test_txn_isolation")
                 .await
                 .unwrap();
@@ -3565,7 +3560,7 @@ pub(crate) mod test_helpers {
         tokio::time::sleep(Duration::from_millis(100)).await;
 
         let topic = txn
-            .kafka_topics()
+            .topics()
             .get_by_name("test_txn_isolation")
             .await
             .unwrap();
@@ -3576,7 +3571,7 @@ pub(crate) mod test_helpers {
 
         let mut txn = catalog.start_transaction().await.unwrap();
         let topic = txn
-            .kafka_topics()
+            .topics()
             .get_by_name("test_txn_isolation")
             .await
             .unwrap();
@@ -3587,10 +3582,7 @@ pub(crate) mod test_helpers {
     async fn test_txn_drop(catalog: Arc<dyn Catalog>) {
         let capture = TracingCapture::new();
         let mut txn = catalog.start_transaction().await.unwrap();
-        txn.kafka_topics()
-            .create_or_get("test_txn_drop")
-            .await
-            .unwrap();
+        txn.topics().create_or_get("test_txn_drop").await.unwrap();
         drop(txn);
 
         // got a warning
@@ -3599,11 +3591,7 @@ pub(crate) mod test_helpers {
 
         // data is NOT committed
         let mut txn = catalog.start_transaction().await.unwrap();
-        let topic = txn
-            .kafka_topics()
-            .get_by_name("test_txn_drop")
-            .await
-            .unwrap();
+        let topic = txn.topics().get_by_name("test_txn_drop").await.unwrap();
         assert!(topic.is_none());
         txn.abort().await.unwrap();
     }
@@ -3617,11 +3605,11 @@ pub(crate) mod test_helpers {
     where
         R: RepoCollection + ?Sized,
     {
-        let kafka = repos.kafka_topics().create_or_get("foo").await.unwrap();
+        let topic = repos.topics().create_or_get("foo").await.unwrap();
         let pool = repos.query_pools().create_or_get("foo").await.unwrap();
         let namespace = repos
             .namespaces()
-            .create(namespace_name, "inf", kafka.id, pool.id)
+            .create(namespace_name, "inf", topic.id, pool.id)
             .await;
 
         let namespace = match namespace {
@@ -3637,7 +3625,7 @@ pub(crate) mod test_helpers {
 
         let batches = mutable_batch_lp::lines_to_batches(lines, 42).unwrap();
         let batches = batches.iter().map(|(table, batch)| (table.as_str(), batch));
-        let ns = NamespaceSchema::new(namespace.id, kafka.id, pool.id);
+        let ns = NamespaceSchema::new(namespace.id, topic.id, pool.id);
 
         let schema = validate_or_insert_schema(batches, &ns, repos)
             .await

--- a/iox_catalog/src/lib.rs
+++ b/iox_catalog/src/lib.rs
@@ -13,7 +13,7 @@
 
 use crate::interface::{ColumnUpsertRequest, Error, RepoCollection, Result, Transaction};
 use data_types::{
-    ColumnType, KafkaTopic, NamespaceSchema, QueryPool, Shard, ShardId, ShardIndex, TableSchema,
+    ColumnType, NamespaceSchema, QueryPool, Shard, ShardId, ShardIndex, TableSchema, TopicMetadata,
 };
 use mutable_batch::MutableBatch;
 use std::{borrow::Cow, collections::BTreeMap};
@@ -194,15 +194,15 @@ where
     Ok(())
 }
 
-/// Creates or gets records in the catalog for the shared kafka topic, query pool, and shards
+/// Creates or gets records in the catalog for the shared topic, query pool, and shards
 /// for each of the partitions.
 ///
 /// Used in tests and when creating an in-memory catalog.
 pub async fn create_or_get_default_records(
     shard_count: i32,
     txn: &mut dyn Transaction,
-) -> Result<(KafkaTopic, QueryPool, BTreeMap<ShardId, Shard>)> {
-    let kafka_topic = txn.kafka_topics().create_or_get(SHARED_KAFKA_TOPIC).await?;
+) -> Result<(TopicMetadata, QueryPool, BTreeMap<ShardId, Shard>)> {
+    let topic = txn.topics().create_or_get(SHARED_KAFKA_TOPIC).await?;
     let query_pool = txn.query_pools().create_or_get(SHARED_QUERY_POOL).await?;
 
     let mut shards = BTreeMap::new();
@@ -210,12 +210,12 @@ pub async fn create_or_get_default_records(
     for shard_index in 0..shard_count {
         let shard = txn
             .shards()
-            .create_or_get(&kafka_topic, ShardIndex::new(shard_index))
+            .create_or_get(&topic, ShardIndex::new(shard_index))
             .await?;
         shards.insert(shard.id, shard);
     }
 
-    Ok((kafka_topic, query_pool, shards))
+    Ok((topic, query_pool, shards))
 }
 
 #[cfg(test)]
@@ -250,14 +250,14 @@ mod tests {
                     let metrics = Arc::new(metric::Registry::default());
                     let repo = MemCatalog::new(metrics);
                     let mut txn = repo.start_transaction().await.unwrap();
-                    let (kafka_topic, query_pool, _) = create_or_get_default_records(
+                    let (topic, query_pool, _) = create_or_get_default_records(
                         2,
                         txn.deref_mut()
                     ).await.unwrap();
 
                     let namespace = txn
                         .namespaces()
-                        .create(NAMESPACE_NAME, "inf", kafka_topic.id, query_pool.id)
+                        .create(NAMESPACE_NAME, "inf", topic.id, query_pool.id)
                         .await
                         .unwrap();
 

--- a/iox_catalog/src/lib.rs
+++ b/iox_catalog/src/lib.rs
@@ -19,8 +19,8 @@ use mutable_batch::MutableBatch;
 use std::{borrow::Cow, collections::BTreeMap};
 use thiserror::Error;
 
-const SHARED_KAFKA_TOPIC: &str = "iox-shared";
-const SHARED_QUERY_POOL: &str = SHARED_KAFKA_TOPIC;
+const SHARED_TOPIC_NAME: &str = "iox-shared";
+const SHARED_QUERY_POOL: &str = SHARED_TOPIC_NAME;
 const TIME_COLUMN: &str = "time";
 
 /// A string value representing an infinite retention policy.
@@ -202,7 +202,7 @@ pub async fn create_or_get_default_records(
     shard_count: i32,
     txn: &mut dyn Transaction,
 ) -> Result<(TopicMetadata, QueryPool, BTreeMap<ShardId, Shard>)> {
-    let topic = txn.topics().create_or_get(SHARED_KAFKA_TOPIC).await?;
+    let topic = txn.topics().create_or_get(SHARED_TOPIC_NAME).await?;
     let query_pool = txn.query_pools().create_or_get(SHARED_QUERY_POOL).await?;
 
     let mut shards = BTreeMap::new();

--- a/iox_catalog/src/lib.rs
+++ b/iox_catalog/src/lib.rs
@@ -263,7 +263,7 @@ mod tests {
 
                     let schema = NamespaceSchema::new(
                         namespace.id,
-                        namespace.kafka_topic_id,
+                        namespace.topic_id,
                         namespace.query_pool_id,
                     );
 

--- a/iox_catalog/src/metrics.rs
+++ b/iox_catalog/src/metrics.rs
@@ -7,10 +7,10 @@ use crate::interface::{
 };
 use async_trait::async_trait;
 use data_types::{
-    Column, ColumnType, KafkaTopicId, Namespace, NamespaceId, ParquetFile, ParquetFileId,
-    ParquetFileParams, Partition, PartitionId, PartitionInfo, PartitionKey, PartitionParam,
-    ProcessedTombstone, QueryPool, QueryPoolId, SequenceNumber, Shard, ShardId, ShardIndex, Table,
-    TableId, TablePartition, Timestamp, Tombstone, TombstoneId, TopicMetadata,
+    Column, ColumnType, Namespace, NamespaceId, ParquetFile, ParquetFileId, ParquetFileParams,
+    Partition, PartitionId, PartitionInfo, PartitionKey, PartitionParam, ProcessedTombstone,
+    QueryPool, QueryPoolId, SequenceNumber, Shard, ShardId, ShardIndex, Table, TableId,
+    TablePartition, Timestamp, Tombstone, TombstoneId, TopicId, TopicMetadata,
 };
 use iox_time::{SystemProvider, TimeProvider};
 use metric::{DurationHistogram, Metric};
@@ -192,7 +192,7 @@ decorate!(
 decorate!(
     impl_trait = NamespaceRepo,
     methods = [
-        "namespace_create" = create(&mut self, name: &str, retention_duration: &str, kafka_topic_id: KafkaTopicId, query_pool_id: QueryPoolId) -> Result<Namespace>;
+        "namespace_create" = create(&mut self, name: &str, retention_duration: &str, topic_id: TopicId, query_pool_id: QueryPoolId) -> Result<Namespace>;
         "namespace_list" = list(&mut self) -> Result<Vec<Namespace>>;
         "namespace_get_by_id" = get_by_id(&mut self, id: NamespaceId) -> Result<Option<Namespace>>;
         "namespace_get_by_name" = get_by_name(&mut self, name: &str) -> Result<Option<Namespace>>;
@@ -228,7 +228,7 @@ decorate!(
     impl_trait = ShardRepo,
     methods = [
         "shard_create_or_get" = create_or_get(&mut self, topic: &TopicMetadata, shard_index: ShardIndex) -> Result<Shard>;
-        "shard_get_by_topic_id_and_shard_index" = get_by_topic_id_and_shard_index(&mut self, topic_id: KafkaTopicId, shard_index: ShardIndex) -> Result<Option<Shard>>;
+        "shard_get_by_topic_id_and_shard_index" = get_by_topic_id_and_shard_index(&mut self, topic_id: TopicId, shard_index: ShardIndex) -> Result<Option<Shard>>;
         "shard_list" = list(&mut self) -> Result<Vec<Shard>>;
         "shard_list_by_topic" = list_by_topic(&mut self, topic: &TopicMetadata) -> Result<Vec<Shard>>;
         "shard_update_min_unpersisted_sequence_number" = update_min_unpersisted_sequence_number(&mut self, shard_id: ShardId, sequence_number: SequenceNumber) -> Result<()>;

--- a/iox_catalog/src/postgres.rs
+++ b/iox_catalog/src/postgres.rs
@@ -11,10 +11,10 @@ use crate::{
 };
 use async_trait::async_trait;
 use data_types::{
-    Column, ColumnType, CompactionLevel, KafkaTopicId, Namespace, NamespaceId, ParquetFile,
-    ParquetFileId, ParquetFileParams, Partition, PartitionId, PartitionInfo, PartitionKey,
-    PartitionParam, ProcessedTombstone, QueryPool, QueryPoolId, SequenceNumber, Shard, ShardId,
-    ShardIndex, Table, TableId, TablePartition, Timestamp, Tombstone, TombstoneId, TopicMetadata,
+    Column, ColumnType, CompactionLevel, Namespace, NamespaceId, ParquetFile, ParquetFileId,
+    ParquetFileParams, Partition, PartitionId, PartitionInfo, PartitionKey, PartitionParam,
+    ProcessedTombstone, QueryPool, QueryPoolId, SequenceNumber, Shard, ShardId, ShardIndex, Table,
+    TableId, TablePartition, Timestamp, Tombstone, TombstoneId, TopicId, TopicMetadata,
 };
 use iox_time::{SystemProvider, TimeProvider};
 use observability_deps::tracing::{debug, info, warn};
@@ -570,7 +570,7 @@ impl NamespaceRepo for PostgresTxn {
         &mut self,
         name: &str,
         retention_duration: &str,
-        kafka_topic_id: KafkaTopicId,
+        topic_id: TopicId,
         query_pool_id: QueryPoolId,
     ) -> Result<Namespace> {
         let rec = sqlx::query_as::<_, Namespace>(
@@ -582,7 +582,7 @@ RETURNING *;
         )
         .bind(&name) // $1
         .bind(&retention_duration) // $2
-        .bind(kafka_topic_id) // $3
+        .bind(topic_id) // $3
         .bind(query_pool_id) // $4
         .fetch_one(&mut self.inner)
         .await
@@ -1043,7 +1043,7 @@ RETURNING *;;
 
     async fn get_by_topic_id_and_shard_index(
         &mut self,
-        topic_id: KafkaTopicId,
+        topic_id: TopicId,
         shard_index: ShardIndex,
     ) -> Result<Option<Shard>> {
         let rec = sqlx::query_as::<_, Shard>(

--- a/iox_catalog/src/postgres.rs
+++ b/iox_catalog/src/postgres.rs
@@ -3,18 +3,18 @@
 use crate::{
     interface::{
         sealed::TransactionFinalize, Catalog, ColumnRepo, ColumnUpsertRequest, Error,
-        KafkaTopicRepo, NamespaceRepo, ParquetFileRepo, PartitionRepo, ProcessedTombstoneRepo,
-        QueryPoolRepo, RepoCollection, Result, ShardRepo, TablePersistInfo, TableRepo,
-        TombstoneRepo, Transaction,
+        NamespaceRepo, ParquetFileRepo, PartitionRepo, ProcessedTombstoneRepo, QueryPoolRepo,
+        RepoCollection, Result, ShardRepo, TablePersistInfo, TableRepo, TombstoneRepo,
+        TopicMetadataRepo, Transaction,
     },
     metrics::MetricDecorator,
 };
 use async_trait::async_trait;
 use data_types::{
-    Column, ColumnType, CompactionLevel, KafkaTopic, KafkaTopicId, Namespace, NamespaceId,
-    ParquetFile, ParquetFileId, ParquetFileParams, Partition, PartitionId, PartitionInfo,
-    PartitionKey, PartitionParam, ProcessedTombstone, QueryPool, QueryPoolId, SequenceNumber,
-    Shard, ShardId, ShardIndex, Table, TableId, TablePartition, Timestamp, Tombstone, TombstoneId,
+    Column, ColumnType, CompactionLevel, KafkaTopicId, Namespace, NamespaceId, ParquetFile,
+    ParquetFileId, ParquetFileParams, Partition, PartitionId, PartitionInfo, PartitionKey,
+    PartitionParam, ProcessedTombstone, QueryPool, QueryPoolId, SequenceNumber, Shard, ShardId,
+    ShardIndex, Table, TableId, TablePartition, Timestamp, Tombstone, TombstoneId, TopicMetadata,
 };
 use iox_time::{SystemProvider, TimeProvider};
 use observability_deps::tracing::{debug, info, warn};
@@ -460,7 +460,7 @@ fn get_dsn_file_path(dsn: &str) -> Option<String> {
 
 #[async_trait]
 impl RepoCollection for PostgresTxn {
-    fn kafka_topics(&mut self) -> &mut dyn KafkaTopicRepo {
+    fn topics(&mut self) -> &mut dyn TopicMetadataRepo {
         self
     }
 
@@ -502,9 +502,9 @@ impl RepoCollection for PostgresTxn {
 }
 
 #[async_trait]
-impl KafkaTopicRepo for PostgresTxn {
-    async fn create_or_get(&mut self, name: &str) -> Result<KafkaTopic> {
-        let rec = sqlx::query_as::<_, KafkaTopic>(
+impl TopicMetadataRepo for PostgresTxn {
+    async fn create_or_get(&mut self, name: &str) -> Result<TopicMetadata> {
+        let rec = sqlx::query_as::<_, TopicMetadata>(
             r#"
 INSERT INTO kafka_topic ( name )
 VALUES ( $1 )
@@ -521,8 +521,8 @@ RETURNING *;
         Ok(rec)
     }
 
-    async fn get_by_name(&mut self, name: &str) -> Result<Option<KafkaTopic>> {
-        let rec = sqlx::query_as::<_, KafkaTopic>(
+    async fn get_by_name(&mut self, name: &str) -> Result<Option<TopicMetadata>> {
+        let rec = sqlx::query_as::<_, TopicMetadata>(
             r#"
 SELECT *
 FROM kafka_topic
@@ -537,9 +537,9 @@ WHERE name = $1;
             return Ok(None);
         }
 
-        let kafka_topic = rec.map_err(|e| Error::SqlxError { source: e })?;
+        let topic = rec.map_err(|e| Error::SqlxError { source: e })?;
 
-        Ok(Some(kafka_topic))
+        Ok(Some(topic))
     }
 }
 
@@ -1014,7 +1014,7 @@ RETURNING *;
 impl ShardRepo for PostgresTxn {
     async fn create_or_get(
         &mut self,
-        topic: &KafkaTopic,
+        topic: &TopicMetadata,
         shard_index: ShardIndex,
     ) -> Result<Shard> {
         sqlx::query_as::<_, Shard>(
@@ -1075,7 +1075,7 @@ WHERE kafka_topic_id = $1
             .map_err(|e| Error::SqlxError { source: e })
     }
 
-    async fn list_by_kafka_topic(&mut self, topic: &KafkaTopic) -> Result<Vec<Shard>> {
+    async fn list_by_topic(&mut self, topic: &TopicMetadata) -> Result<Vec<Shard>> {
         sqlx::query_as::<_, Shard>(r#"SELECT * FROM sequencer WHERE kafka_topic_id = $1;"#)
             .bind(&topic.id) // $1
             .fetch_all(&mut self.inner)

--- a/ioxd_querier/src/lib.rs
+++ b/ioxd_querier/src/lib.rs
@@ -155,7 +155,7 @@ pub enum Error {
     #[error("failed to initialise write buffer connection: {0}")]
     WriteBuffer(#[from] write_buffer::core::WriteBufferError),
 
-    #[error("failed to create KafkaPartition from id: {0}")]
+    #[error("failed to create ShardIndex from id: {0}")]
     InvalidData(#[from] std::num::TryFromIntError),
 
     #[error("querier error: {0}")]

--- a/querier/src/cache/namespace.rs
+++ b/querier/src/cache/namespace.rs
@@ -253,7 +253,7 @@ mod tests {
             .unwrap();
         let expected_schema_1 = NamespaceSchema {
             id: ns1.namespace.id,
-            kafka_topic_id: ns1.namespace.kafka_topic_id,
+            topic_id: ns1.namespace.topic_id,
             query_pool_id: ns1.namespace.query_pool_id,
             tables: BTreeMap::from([
                 (
@@ -318,7 +318,7 @@ mod tests {
             .unwrap();
         let expected_schema_2 = NamespaceSchema {
             id: ns2.namespace.id,
-            kafka_topic_id: ns2.namespace.kafka_topic_id,
+            topic_id: ns2.namespace.topic_id,
             query_pool_id: ns2.namespace.query_pool_id,
             tables: BTreeMap::from([(
                 String::from("table1"),

--- a/querier/src/handler.rs
+++ b/querier/src/handler.rs
@@ -177,15 +177,11 @@ mod tests {
             {
                 let mut repos = catalog.repositories().await;
 
-                let kafka_topic = repos
-                    .kafka_topics()
-                    .create_or_get("kafka_topic")
-                    .await
-                    .unwrap();
+                let topic = repos.topics().create_or_get("topic").await.unwrap();
                 let shard_index = ShardIndex::new(0);
                 repos
                     .shards()
-                    .create_or_get(&kafka_topic, shard_index)
+                    .create_or_get(&topic, shard_index)
                     .await
                     .unwrap();
             }

--- a/router/src/dml_handlers/ns_autocreation.rs
+++ b/router/src/dml_handlers/ns_autocreation.rs
@@ -1,7 +1,7 @@
 use super::DmlHandler;
 use crate::namespace_cache::NamespaceCache;
 use async_trait::async_trait;
-use data_types::{DatabaseName, DeletePredicate, KafkaTopicId, QueryPoolId};
+use data_types::{DatabaseName, DeletePredicate, QueryPoolId, TopicId};
 use iox_catalog::interface::Catalog;
 use observability_deps::tracing::*;
 use std::{fmt::Debug, marker::PhantomData, sync::Arc};
@@ -26,7 +26,7 @@ pub struct NamespaceAutocreation<C, T> {
     catalog: Arc<dyn Catalog>,
     cache: C,
 
-    topic_id: KafkaTopicId,
+    topic_id: TopicId,
     query_id: QueryPoolId,
     retention: String,
     _input: PhantomData<T>,
@@ -44,7 +44,7 @@ impl<C, T> NamespaceAutocreation<C, T> {
     pub fn new(
         catalog: Arc<dyn Catalog>,
         cache: C,
-        topic_id: KafkaTopicId,
+        topic_id: TopicId,
         query_id: QueryPoolId,
         retention: String,
     ) -> Self {
@@ -146,7 +146,7 @@ mod tests {
             ns.clone(),
             NamespaceSchema {
                 id: NamespaceId::new(1),
-                kafka_topic_id: KafkaTopicId::new(2),
+                topic_id: TopicId::new(2),
                 query_pool_id: QueryPoolId::new(3),
                 tables: Default::default(),
             },
@@ -158,7 +158,7 @@ mod tests {
         let creator = NamespaceAutocreation::new(
             Arc::clone(&catalog),
             cache,
-            KafkaTopicId::new(42),
+            TopicId::new(42),
             QueryPoolId::new(42),
             "inf".to_owned(),
         );
@@ -194,7 +194,7 @@ mod tests {
         let creator = NamespaceAutocreation::new(
             Arc::clone(&catalog),
             cache,
-            KafkaTopicId::new(42),
+            TopicId::new(42),
             QueryPoolId::new(42),
             "inf".to_owned(),
         );
@@ -220,7 +220,7 @@ mod tests {
                 id: NamespaceId::new(1),
                 name: ns.to_string(),
                 retention_duration: Some("inf".to_owned()),
-                kafka_topic_id: KafkaTopicId::new(42),
+                topic_id: TopicId::new(42),
                 query_pool_id: QueryPoolId::new(42),
                 max_tables: 10000,
                 max_columns_per_table: 1000,

--- a/router/src/dml_handlers/schema_validation.rs
+++ b/router/src/dml_handlers/schema_validation.rs
@@ -257,7 +257,7 @@ where
 mod tests {
     use super::*;
     use assert_matches::assert_matches;
-    use data_types::{ColumnType, KafkaTopicId, QueryPoolId, TimestampRange};
+    use data_types::{ColumnType, QueryPoolId, TimestampRange, TopicId};
     use iox_catalog::mem::MemCatalog;
     use once_cell::sync::Lazy;
     use std::sync::Arc;
@@ -283,7 +283,7 @@ mod tests {
             .create(
                 NAMESPACE.as_str(),
                 "inf",
-                KafkaTopicId::new(42),
+                TopicId::new(42),
                 QueryPoolId::new(24),
             )
             .await

--- a/router/src/lib.rs
+++ b/router/src/lib.rs
@@ -8,7 +8,7 @@
 //!     * Enforcing schema validation & synchronising it within the catalog.
 //!     * Deriving the partition key of each DML operation.
 //!     * Applying sharding logic.
-//!     * Push resulting operations into the appropriate kafka partitions.
+//!     * Push resulting operations into the appropriate shards (Kafka partitions if using Kafka).
 
 #![deny(
     rustdoc::broken_intra_doc_links,

--- a/router/src/namespace_cache/memory.rs
+++ b/router/src/namespace_cache/memory.rs
@@ -28,7 +28,7 @@ impl NamespaceCache for Arc<MemoryNamespaceCache> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use data_types::{KafkaTopicId, NamespaceId, QueryPoolId};
+    use data_types::{NamespaceId, QueryPoolId, TopicId};
 
     #[test]
     fn test_put_get() {
@@ -39,7 +39,7 @@ mod tests {
 
         let schema1 = NamespaceSchema {
             id: NamespaceId::new(42),
-            kafka_topic_id: KafkaTopicId::new(24),
+            topic_id: TopicId::new(24),
             query_pool_id: QueryPoolId::new(1234),
             tables: Default::default(),
         };
@@ -48,7 +48,7 @@ mod tests {
 
         let schema2 = NamespaceSchema {
             id: NamespaceId::new(2),
-            kafka_topic_id: KafkaTopicId::new(2),
+            topic_id: TopicId::new(2),
             query_pool_id: QueryPoolId::new(2),
             tables: Default::default(),
         };

--- a/router/src/namespace_cache/metrics.rs
+++ b/router/src/namespace_cache/metrics.rs
@@ -154,8 +154,7 @@ mod tests {
     use super::*;
     use crate::namespace_cache::MemoryNamespaceCache;
     use data_types::{
-        ColumnId, ColumnSchema, ColumnType, KafkaTopicId, NamespaceId, QueryPoolId, TableId,
-        TableSchema,
+        ColumnId, ColumnSchema, ColumnType, NamespaceId, QueryPoolId, TableId, TableSchema, TopicId,
     };
     use metric::{Attributes, MetricObserver, Observation};
     use std::collections::BTreeMap;
@@ -192,7 +191,7 @@ mod tests {
 
         NamespaceSchema {
             id: NamespaceId::new(42),
-            kafka_topic_id: KafkaTopicId::new(24),
+            topic_id: TopicId::new(24),
             query_pool_id: QueryPoolId::new(1234),
             tables,
         }

--- a/router/src/namespace_cache/sharded_cache.rs
+++ b/router/src/namespace_cache/sharded_cache.rs
@@ -40,7 +40,7 @@ where
 mod tests {
     use super::*;
     use crate::namespace_cache::MemoryNamespaceCache;
-    use data_types::{KafkaTopicId, NamespaceId, QueryPoolId};
+    use data_types::{NamespaceId, QueryPoolId, TopicId};
     use rand::{distributions::Alphanumeric, thread_rng, Rng};
     use std::{collections::HashMap, iter};
 
@@ -57,7 +57,7 @@ mod tests {
     fn schema_with_id(id: i64) -> NamespaceSchema {
         NamespaceSchema {
             id: NamespaceId::new(id),
-            kafka_topic_id: KafkaTopicId::new(1),
+            topic_id: TopicId::new(1),
             query_pool_id: QueryPoolId::new(1),
             tables: Default::default(),
         }

--- a/router/src/server/grpc/sharder.rs
+++ b/router/src/server/grpc/sharder.rs
@@ -1,7 +1,7 @@
 //! A gRPC service to provide shard mappings to external clients.
 
 use crate::shard::Shard;
-use data_types::{DatabaseName, KafkaTopic, ShardId, ShardIndex};
+use data_types::{DatabaseName, ShardId, ShardIndex, TopicMetadata};
 use generated_types::influxdata::iox::sharder::v1::{
     shard_service_server, MapToShardRequest, MapToShardResponse,
 };
@@ -42,7 +42,7 @@ where
     /// [`ShardService`]: generated_types::influxdata::iox::sharder::v1::shard_service_server::ShardService
     pub async fn new(
         sharder: S,
-        topic: KafkaTopic,
+        topic: TopicMetadata,
         catalog: Arc<dyn Catalog>,
     ) -> Result<Self, iox_catalog::interface::Error> {
         // Build the mapping of Kafka partition (shard) index -> Catalog shard ID
@@ -50,7 +50,7 @@ where
             .repositories()
             .await
             .shards()
-            .list_by_kafka_topic(&topic)
+            .list_by_topic(&topic)
             .await?
             .into_iter()
             .map(|s| (s.shard_index, s.id))
@@ -118,7 +118,7 @@ mod tests {
         let topic = catalog
             .repositories()
             .await
-            .kafka_topics()
+            .topics()
             .create_or_get("test")
             .await
             .expect("topic create");

--- a/router/tests/http.rs
+++ b/router/tests/http.rs
@@ -1,5 +1,5 @@
 use assert_matches::assert_matches;
-use data_types::{KafkaTopicId, PartitionTemplate, QueryPoolId, ShardIndex, TemplatePart};
+use data_types::{PartitionTemplate, QueryPoolId, ShardIndex, TemplatePart, TopicId};
 use dml::DmlOperation;
 use hashbrown::HashMap;
 use hyper::{Body, Request, StatusCode};
@@ -23,9 +23,9 @@ use write_buffer::{
     mock::{MockBufferForWriting, MockBufferSharedState},
 };
 
-/// The kafka topic catalog ID assigned by the namespace auto-creator in the
+/// The topic catalog ID assigned by the namespace auto-creator in the
 /// handler stack for namespaces it has not yet observed.
-const TEST_KAFKA_TOPIC_ID: i64 = 1;
+const TEST_TOPIC_ID: i64 = 1;
 
 /// The query pool catalog ID assigned by the namespace auto-creator in the
 /// handler stack for namespaces it has not yet observed.
@@ -97,7 +97,7 @@ impl TestContext {
         let ns_creator = NamespaceAutocreation::new(
             Arc::clone(&catalog),
             Arc::clone(&ns_cache),
-            KafkaTopicId::new(TEST_KAFKA_TOPIC_ID),
+            TopicId::new(TEST_TOPIC_ID),
             QueryPoolId::new(TEST_QUERY_POOL_ID),
             iox_catalog::INFINITE_RETENTION_POLICY.to_owned(),
         );
@@ -194,7 +194,7 @@ async fn test_write_ok() {
         ns.retention_duration.as_deref(),
         Some(iox_catalog::INFINITE_RETENTION_POLICY)
     );
-    assert_eq!(ns.kafka_topic_id, KafkaTopicId::new(TEST_KAFKA_TOPIC_ID));
+    assert_eq!(ns.topic_id, TopicId::new(TEST_TOPIC_ID));
     assert_eq!(ns.query_pool_id, QueryPoolId::new(TEST_QUERY_POOL_ID));
 
     // Ensure the metric instrumentation was hit

--- a/service_grpc_catalog/src/lib.rs
+++ b/service_grpc_catalog/src/lib.rs
@@ -133,11 +133,7 @@ mod tests {
             let metrics = Arc::new(metric::Registry::default());
             let catalog = Arc::new(MemCatalog::new(metrics));
             let mut repos = catalog.repositories().await;
-            let kafka = repos
-                .kafka_topics()
-                .create_or_get("iox_shared")
-                .await
-                .unwrap();
+            let topic = repos.topics().create_or_get("iox_shared").await.unwrap();
             let pool = repos
                 .query_pools()
                 .create_or_get("iox_shared")
@@ -145,12 +141,12 @@ mod tests {
                 .unwrap();
             let shard = repos
                 .shards()
-                .create_or_get(&kafka, ShardIndex::new(1))
+                .create_or_get(&topic, ShardIndex::new(1))
                 .await
                 .unwrap();
             let namespace = repos
                 .namespaces()
-                .create("catalog_partition_test", "inf", kafka.id, pool.id)
+                .create("catalog_partition_test", "inf", topic.id, pool.id)
                 .await
                 .unwrap();
             let table = repos
@@ -214,11 +210,7 @@ mod tests {
             let metrics = Arc::new(metric::Registry::default());
             let catalog = Arc::new(MemCatalog::new(metrics));
             let mut repos = catalog.repositories().await;
-            let kafka = repos
-                .kafka_topics()
-                .create_or_get("iox_shared")
-                .await
-                .unwrap();
+            let topic = repos.topics().create_or_get("iox_shared").await.unwrap();
             let pool = repos
                 .query_pools()
                 .create_or_get("iox_shared")
@@ -226,12 +218,12 @@ mod tests {
                 .unwrap();
             let shard = repos
                 .shards()
-                .create_or_get(&kafka, ShardIndex::new(1))
+                .create_or_get(&topic, ShardIndex::new(1))
                 .await
                 .unwrap();
             let namespace = repos
                 .namespaces()
-                .create("catalog_partition_test", "inf", kafka.id, pool.id)
+                .create("catalog_partition_test", "inf", topic.id, pool.id)
                 .await
                 .unwrap();
             let table = repos
@@ -251,7 +243,7 @@ mod tests {
                 .unwrap();
             let shard2 = repos
                 .shards()
-                .create_or_get(&kafka, ShardIndex::new(2))
+                .create_or_get(&topic, ShardIndex::new(2))
                 .await
                 .unwrap();
             partition3 = repos

--- a/service_grpc_object_store/src/lib.rs
+++ b/service_grpc_object_store/src/lib.rs
@@ -112,11 +112,7 @@ mod tests {
             let metrics = Arc::new(metric::Registry::default());
             let catalog = Arc::new(MemCatalog::new(metrics));
             let mut repos = catalog.repositories().await;
-            let kafka = repos
-                .kafka_topics()
-                .create_or_get("iox_shared")
-                .await
-                .unwrap();
+            let topic = repos.topics().create_or_get("iox_shared").await.unwrap();
             let pool = repos
                 .query_pools()
                 .create_or_get("iox_shared")
@@ -124,12 +120,12 @@ mod tests {
                 .unwrap();
             let shard = repos
                 .shards()
-                .create_or_get(&kafka, ShardIndex::new(1))
+                .create_or_get(&topic, ShardIndex::new(1))
                 .await
                 .unwrap();
             let namespace = repos
                 .namespaces()
-                .create("catalog_partition_test", "inf", kafka.id, pool.id)
+                .create("catalog_partition_test", "inf", topic.id, pool.id)
                 .await
                 .unwrap();
             let table = repos

--- a/service_grpc_schema/src/lib.rs
+++ b/service_grpc_schema/src/lib.rs
@@ -91,11 +91,11 @@ mod tests {
             let metrics = Arc::new(metric::Registry::default());
             let catalog = Arc::new(MemCatalog::new(metrics));
             let mut repos = catalog.repositories().await;
-            let kafka = repos.kafka_topics().create_or_get("franz").await.unwrap();
+            let topic = repos.topics().create_or_get("franz").await.unwrap();
             let pool = repos.query_pools().create_or_get("franz").await.unwrap();
             let namespace = repos
                 .namespaces()
-                .create("namespace_schema_test", "inf", kafka.id, pool.id)
+                .create("namespace_schema_test", "inf", topic.id, pool.id)
                 .await
                 .unwrap();
             let table = repos

--- a/service_grpc_schema/src/lib.rs
+++ b/service_grpc_schema/src/lib.rs
@@ -44,7 +44,7 @@ fn schema_to_proto(schema: Arc<data_types::NamespaceSchema>) -> GetSchemaRespons
     let response = GetSchemaResponse {
         schema: Some(NamespaceSchema {
             id: schema.id.get(),
-            kafka_topic_id: schema.kafka_topic_id.get(),
+            topic_id: schema.topic_id.get(),
             query_pool_id: schema.query_pool_id.get(),
             tables: schema
                 .tables

--- a/test_helpers_end_to_end/src/database.rs
+++ b/test_helpers_end_to_end/src/database.rs
@@ -37,7 +37,7 @@ pub async fn initialize_db(dsn: &str, schema_name: &str) {
         .ok()
         .unwrap();
 
-    // Create the shared Kafka topic in the catalog
+    // Create the shared topic in the catalog
     Command::cargo_bin("influxdb_iox")
         .unwrap()
         .arg("catalog")


### PR DESCRIPTION
Follow up to https://github.com/influxdata/influxdb_iox/pull/5435. Blocks https://github.com/influxdata/influxdb_iox/pull/5475.

This PR:

- Renames `KafkaTopic`, the struct that holds a Kafka topic name and its catalog ID, to `TopicMetadata`
- Renames `KafkaTopicId`, the wrapper type for the Kafka topic catalog IDs, to `TopicId`
- Renames parameters named `kafka_topic_name` that held the Kafka topic name string to `topic_name`
- Renames the catalog `kafka_topics` method to `topics`
- Removes `kafka` from local variable names, constants, test names, error messages

This is still only in the code; this isn't the big scary database rename PR yet.

There are also still some metric names and log messages that have "kafka" in them; I'm happy to take care of those too but I don't think those contribute to confusion or break encapsulation in harmful ways.