### PR TITLE
ci: ignore RUSTSEC-2022-0048

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -16,6 +16,11 @@ ignore = [
     # why needed: part of `arrow`
     # upstream issue: https://github.com/google/flatbuffers/issues/6627
     "RUSTSEC-2021-0122",
+
+    # title: xml-rs is Unmaintained
+    # why needed: upstream of Azure SDK, removal in-progress
+    # upstream issue: many (https://github.com/netvl/xml-rs/issues)
+    "RUSTSEC-2022-0048",
 ]
 git-fetch-with-cli = true
 


### PR DESCRIPTION
Fixes CI.

https://rustsec.org/advisories/RUSTSEC-2022-0048

---

* ci: ignore RUSTSEC-2022-0048 (130785977)

      XML parsing lib for the Azure SDK is unmaintained and reportedly contains
      integer overflow / panic issues in the parsing functionality.

      Low risk ignore as it is used when talking to Azure only. The Azure SDK is in
      the progress of being removed as a dependency.