### PR TITLE
build: bump dotenvy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1225,9 +1225,9 @@ checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
 name = "dotenvy"
-version = "0.15.1"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e851a83c30366fd01d75b913588e95e74a1705c1ecc5d58b1f8e1a6d556525f"
+checksum = "da3db6fcad7c1fc4abdd99bf5276a4db30d6a819127903a709ed41e5ff016e84"
 dependencies = [
  "dirs",
 ]


### PR DESCRIPTION
Bump dotenvy to the latest version - I fixed the cause of https://github.com/influxdata/influxdb_iox/issues/5454 which was a dependabot bump here https://github.com/influxdata/influxdb_iox/pull/5468.

@mkmik  added a regression test that remains in the code base and now passes: https://github.com/influxdata/influxdb_iox/pull/5461 (I added my own regression test to dotenvy itself in the fix PR: https://github.com/allan2/dotenvy/pull/16)


---

* build: bump dotenvy (dcc0f9d34)

      I fixed this while waiting for my build to deploy. I think that says more
      about our build than anything else!