### PR TITLE
fix: remove empty parquet panic

### DIFF
--- a/parquet_file/src/storage.rs
+++ b/parquet_file/src/storage.rs
@@ -132,13 +132,6 @@ impl ParquetStorage {
         // This is not a huge concern, as the resulting parquet files are
         // currently smallish on average.
         let (data, parquet_file_meta) = serialize::to_parquet_bytes(batches, meta).await?;
-        // TODO: remove this if after verifying the panic is thrown
-        // correctly inside the serialize::to_parquet_bytes above
-        if parquet_file_meta.row_groups.is_empty() {
-            debug!(
-                ?meta.partition_id, ?parquet_file_meta,
-                "Created parquet_file_meta has no row groups which will introduce panic later when its statistics is read");
-        }
 
         // Read the IOx-specific parquet metadata from the file metadata
         let parquet_meta =


### PR DESCRIPTION
Fixes https://github.com/influxdata/conductor/issues/1121.

While this will stop the code from emitting the panic, it also means we won't notice opportunities to improve our compaction planning - there are a couple cases where we're using `SplitExec` knowing up front that it'll produce no output. We should try to improve our planning logic to eliminate those cases.

Lacking data to prove it, my conjecture is that the situation where this panic was unavoidable is exceedingly rare, and instead was caused by the (far more plausible) cases where we can avoid adding useless split points.

---

* refactor: raise error for no rows in parquet file (769826476)

      Previously when attempting to serialise a stream of one or more RecordBatch
      containing no rows (resulting in an empty file), the parquet serialisation
      code would panic.

      This changes the code path to raise an error instead, to support the compactor
      making multiple splits at once, which may overlap a single chunk:

                       ────────────── Time ────────────▶

                               │                │
                       ┌█████──────────────────────█████┐
                       │█████  │    Chunk 1     │  █████│
                       └█████──────────────────────█████┘
                               │                │

                               │                │

                            Split T1         Split T2

      In the example above, the chunk has an unusual distribution of write 
      timestamps over the time range it covers, with all data having a timestamp
      before T1, or after T2. When a running a SplitExec to slice this chunk at T1
      and T2, the middle of the resulting 3 subsets will contain no rows. Because we
      store only the min/max timestamps in the chunk statistics, it is unfortunately
      impossible to prune one of these split points from the plan ahead of time.

* fix: compactor tolerates empty output (2fc0ddbea)

      Changes the compactor code to tolerate a SplitExec yielding an empty partition
      (with no rows).

      This raises a WARN as the situation in which this is acceptable is very rare,
      and is more likely indicative of an opportunity to improve the SplitExec usage
      (i.e. pruning out unnecessary split points).