### PR TITLE
feat(ingester): restrict partition row count

### DIFF
--- a/clap_blocks/src/ingester.rs
+++ b/clap_blocks/src/ingester.rs
@@ -75,6 +75,15 @@ pub struct IngesterConfig {
     )]
     pub persist_partition_cold_threshold_seconds: u64,
 
+    /// Trigger persistence of a partition if it contains more than this many rows.
+    #[clap(
+        long = "--persist-partition-max-rows",
+        env = "INFLUXDB_IOX_PERSIST_PARTITION_MAX_ROWS",
+        default_value = "500000",
+        action
+    )]
+    pub persist_partition_rows_max: usize,
+
     /// If the catalog's max sequence number for the partition is no longer available in the write
     /// buffer due to the retention policy, by default the ingester will panic. If this flag is
     /// specified, the ingester will skip any sequence numbers that have not been retained in the

--- a/influxdb_iox/src/commands/run/all_in_one.rs
+++ b/influxdb_iox/src/commands/run/all_in_one.rs
@@ -407,6 +407,7 @@ impl Config {
             skip_to_oldest_available,
             test_flight_do_get_panic: 0,
             concurrent_request_limit: 10,
+            persist_partition_rows_max: 500_000,
         };
 
         // create a CompactorConfig for the all in one server based on

--- a/ingester/src/handler.rs
+++ b/ingester/src/handler.rs
@@ -672,6 +672,7 @@ mod tests {
             1000,
             Duration::from_secs(10),
             Duration::from_secs(10),
+            100000000,
         );
         let ingester = IngestHandlerImpl::new(
             lifecycle_config,
@@ -944,6 +945,7 @@ mod tests {
                 1000,
                 Duration::from_secs(10),
                 Duration::from_secs(10),
+                10000000,
             );
             let ingester = IngestHandlerImpl::new(
                 lifecycle_config,

--- a/ingester/src/stream_handler/handler.rs
+++ b/ingester/src/stream_handler/handler.rs
@@ -610,7 +610,7 @@ mod tests {
                     let time_provider: Arc<dyn TimeProvider> = Arc::new(SystemProvider::default());
                     let lifecycle = LifecycleManager::new(
                         LifecycleConfig::new(
-                            100, 2, 3, Duration::from_secs(4), Duration::from_secs(5)
+                            100, 2, 3, Duration::from_secs(4), Duration::from_secs(5), 10000000,
                         ),
                         Arc::clone(&metrics),
                         time_provider,
@@ -974,7 +974,14 @@ mod tests {
         let metrics = Arc::new(metric::Registry::default());
         let time_provider = Arc::new(SystemProvider::default());
         let lifecycle = LifecycleManager::new(
-            LifecycleConfig::new(100, 2, 3, Duration::from_secs(4), Duration::from_secs(5)),
+            LifecycleConfig::new(
+                100,
+                2,
+                3,
+                Duration::from_secs(4),
+                Duration::from_secs(5),
+                1000000,
+            ),
             Arc::clone(&metrics),
             time_provider,
         );
@@ -1007,7 +1014,14 @@ mod tests {
         let metrics = Arc::new(metric::Registry::default());
         let time_provider = Arc::new(SystemProvider::default());
         let lifecycle = LifecycleManager::new(
-            LifecycleConfig::new(100, 2, 3, Duration::from_secs(4), Duration::from_secs(5)),
+            LifecycleConfig::new(
+                100,
+                2,
+                3,
+                Duration::from_secs(4),
+                Duration::from_secs(5),
+                1000000,
+            ),
             Arc::clone(&metrics),
             time_provider,
         );

--- a/ioxd_ingester/src/lib.rs
+++ b/ioxd_ingester/src/lib.rs
@@ -180,6 +180,7 @@ pub async fn create_ingester_server_type(
         ingester_config.persist_partition_size_threshold_bytes,
         Duration::from_secs(ingester_config.persist_partition_age_threshold_seconds),
         Duration::from_secs(ingester_config.persist_partition_cold_threshold_seconds),
+        ingester_config.persist_partition_rows_max,
     );
     let ingest_handler = Arc::new(
         IngestHandlerImpl::new(

--- a/query_tests/src/scenarios/util.rs
+++ b/query_tests/src/scenarios/util.rs
@@ -968,6 +968,7 @@ impl LifecycleHandle for NoopLifecycleHandle {
         _shard_id: ShardId,
         _sequence_number: SequenceNumber,
         _bytes_written: usize,
+        _rows_written: usize,
     ) -> bool {
         // do NOT pause ingest
         false


### PR DESCRIPTION
Restrict the number of rows in each partition before marking for persistence - defaulting to 500,000.

---

* feat(ingester): restrict partition row count (2a1960645)

      This limit restricts a single partition to containing at most N rows before it
      is marked for persistence (note: being marked for persistence does not
      currently prevent further ingest for that partition.)