### PR TITLE
chore: add catalog index on parquet_file(namespace_id)

### DIFF
--- a/iox_catalog/migrations/20220905111602_parquetfile_add_namespace_idx.sql
+++ b/iox_catalog/migrations/20220905111602_parquetfile_add_namespace_idx.sql
@@ -1,0 +1,3 @@
+-- Add index to support fetching billing information (file size by namespace).
+
+CREATE INDEX IF NOT EXISTS parquet_file_namespace_idx ON parquet_file (namespace_id);


### PR DESCRIPTION
as part of https://github.com/influxdata/conductor/issues/1127 i need to get the sum of `file_size_bytes` of parquet files by namespace. without an index it's going to take forever.

i tested this by running the migrations against a local DB and checking that it appeared:

```
$ ./scripts/docker_catalog.sh
Starting Postres container...
Postgres is up. Running migrations...
Enjoy your database! Point IOx to it by running the following:
$ export INFLUXDB_IOX_CATALOG_DSN="postgresql://postgres@localhost:5432/postgres"

$ psql -h localhost -U postgres -d postgres
psql (14.5, server 14.4 (Debian 14.4-1.pgdg110+1))
Type "help" for help.

postgres=# \d parquet_file
                           Table "iox_catalog.parquet_file"
       Column        |   Type   | Collation | Nullable |           Default
---------------------+----------+-----------+----------+------------------------------
 id                  | bigint   |           | not null | generated always as identity
 shard_id            | bigint   |           | not null |
 table_id            | bigint   |           | not null |
 partition_id        | bigint   |           | not null |
 object_store_id     | uuid     |           | not null |
 max_sequence_number | bigint   |           |          |
 min_time            | bigint   |           |          |
 max_time            | bigint   |           |          |
 to_delete           | bigint   |           |          |
 row_count           | bigint   |           | not null | 0
 file_size_bytes     | bigint   |           | not null | 0
 compaction_level    | smallint |           | not null | 0
 created_at          | bigint   |           |          |
 namespace_id        | bigint   |           | not null |
 column_set          | bigint[] |           | not null |
Indexes:
    "parquet_file_pkey" PRIMARY KEY, btree (id)
    "parquet_file_deleted_at_idx" btree (to_delete)
    "parquet_file_namespace_idx" btree (namespace_id)
    "parquet_file_partition_idx" btree (partition_id)
    "parquet_file_shard_compaction_delete_created_idx" btree (shard_id, compaction_level, to_delete, created_at)
    "parquet_file_shard_compaction_delete_idx" btree (shard_id, compaction_level, to_delete)
    "parquet_file_table_idx" btree (table_id)
    "parquet_location_unique" UNIQUE CONSTRAINT, btree (object_store_id)
Foreign-key constraints:
    "parquet_file_namespace_id_fkey" FOREIGN KEY (namespace_id) REFERENCES namespace(id) NOT VALID
    "parquet_file_partition_id_fkey" FOREIGN KEY (partition_id) REFERENCES partition(id) NOT VALID
    "parquet_file_sequencer_id_fkey" FOREIGN KEY (shard_id) REFERENCES shard(id) NOT VALID
    "parquet_file_table_id_fkey" FOREIGN KEY (table_id) REFERENCES table_name(id) NOT VALID
Referenced by:
    TABLE "processed_tombstone" CONSTRAINT "processed_tombstone_parquet_file_id_fkey" FOREIGN KEY (parquet_file_id) REFERENCES parquet_file(id) NOT VALID
```

- [ ] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb_iox/blob/main/README.md).
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
