### PR TITLE
fix(ingester): connect to assigned Kafka partitions

### DIFF
--- a/clap_blocks/src/write_buffer.rs
+++ b/clap_blocks/src/write_buffer.rs
@@ -1,7 +1,7 @@
 //! Config for [`write_buffer`].
 use iox_time::SystemProvider;
 use observability_deps::tracing::*;
-use std::{collections::BTreeMap, num::NonZeroU32, path::PathBuf, sync::Arc};
+use std::{collections::BTreeMap, num::NonZeroU32, ops::Range, path::PathBuf, sync::Arc};
 use tempfile::TempDir;
 use trace::TraceCollector;
 use write_buffer::{
@@ -94,12 +94,13 @@ impl WriteBufferConfig {
     pub async fn writing(
         &self,
         metrics: Arc<metric::Registry>,
+        partitions: Option<Range<i32>>,
         trace_collector: Option<Arc<dyn TraceCollector>>,
     ) -> Result<Arc<dyn WriteBufferWriting>, WriteBufferError> {
         let conn = self.conn();
         let factory = Self::factory(metrics);
         factory
-            .new_config_write(&self.topic, trace_collector.as_ref(), &conn)
+            .new_config_write(&self.topic, partitions, trace_collector.as_ref(), &conn)
             .await
     }
 
@@ -107,12 +108,13 @@ impl WriteBufferConfig {
     pub async fn reading(
         &self,
         metrics: Arc<metric::Registry>,
+        partitions: Option<Range<i32>>,
         trace_collector: Option<Arc<dyn TraceCollector>>,
     ) -> Result<Arc<dyn WriteBufferReading>, WriteBufferError> {
         let conn = self.conn();
         let factory = Self::factory(metrics);
         factory
-            .new_config_read(&self.topic, trace_collector.as_ref(), &conn)
+            .new_config_read(&self.topic, partitions, trace_collector.as_ref(), &conn)
             .await
     }
 

--- a/ioxd_router/src/lib.rs
+++ b/ioxd_router/src/lib.rs
@@ -320,7 +320,7 @@ async fn init_write_buffer(
 )> {
     let write_buffer = Arc::new(
         write_buffer_config
-            .writing(Arc::clone(&metrics), trace_collector)
+            .writing(Arc::clone(&metrics), None, trace_collector)
             .await?,
     );
 


### PR DESCRIPTION
Not initialising producers for Kafka partitions we will never use will speed up ingester startup time, and reduce the request/connection load on the brokers.

---

* fix(ingester): connect to assigned Kafka partition (d1ca29c02)

      During initialisation, the ingester connects to the Kafka brokers - this 
      involves per-partition leadership discovery & connection establishment. These
      connections are then retained for the lifetime of the process.

      Prior to this commit, the ingester would establish a connection to all 
      partition leaders for a given topic. After this commit, the ingester connects
      to only the partition leaders it is going to consume from
      (for those shards that it is assigned.)