### PR TITLE
perf: use rskafka producer optimisations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -521,7 +521,7 @@ dependencies = [
  "num-integer",
  "num-traits",
  "serde",
- "time 0.1.44",
+ "time",
  "wasm-bindgen",
  "winapi",
 ]
@@ -3063,15 +3063,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num_threads"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "object"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4195,11 +4186,12 @@ dependencies = [
 [[package]]
 name = "rskafka"
 version = "0.3.0"
-source = "git+https://github.com/influxdata/rskafka.git?rev=59295beeae2106c2536008065e171dd88fd1c64e#59295beeae2106c2536008065e171dd88fd1c64e"
+source = "git+https://github.com/influxdata/rskafka.git?rev=3208e4742f08048bbab4e8fc4e0a775507fe3e66#3208e4742f08048bbab4e8fc4e0a775507fe3e66"
 dependencies = [
  "async-socks5",
  "async-trait",
  "bytes",
+ "chrono",
  "crc32c",
  "futures",
  "integer-encoding 3.0.4",
@@ -4208,7 +4200,6 @@ dependencies = [
  "rand",
  "snap",
  "thiserror",
- "time 0.3.14",
  "tokio",
  "tracing",
 ]
@@ -5103,16 +5094,6 @@ dependencies = [
  "libc",
  "wasi 0.10.0+wasi-snapshot-preview1",
  "winapi",
-]
-
-[[package]]
-name = "time"
-version = "0.3.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c3f9a28b618c3a6b9251b6908e9c99e04b9e5c02e6581ccbb67d59c34ef7f9b"
-dependencies = [
- "libc",
- "num_threads",
 ]
 
 [[package]]

--- a/write_buffer/Cargo.toml
+++ b/write_buffer/Cargo.toml
@@ -22,7 +22,7 @@ observability_deps = { path = "../observability_deps" }
 parking_lot = "0.12"
 pin-project = "1.0"
 prost = "0.11"
-rskafka = { git = "https://github.com/influxdata/rskafka.git", rev="59295beeae2106c2536008065e171dd88fd1c64e", default-features = false, features = ["compression-snappy", "transport-socks5"] }
+rskafka = { git = "https://github.com/influxdata/rskafka.git", rev="3208e4742f08048bbab4e8fc4e0a775507fe3e66", default-features = false, features = ["compression-snappy", "transport-socks5"] }
 schema = { path = "../schema" }
 tokio = { version = "1.21", features = ["fs", "macros", "parking_lot", "rt", "sync", "time"] }
 tokio-util = "0.7.3"

--- a/write_buffer/src/kafka/instrumentation.rs
+++ b/write_buffer/src/kafka/instrumentation.rs
@@ -152,7 +152,7 @@ mod tests {
     use iox_time::Time;
     use metric::Metric;
     use parking_lot::Mutex;
-    use rskafka::time::OffsetDateTime;
+    use rskafka::chrono::{self, Utc};
 
     use super::*;
 
@@ -207,7 +207,7 @@ mod tests {
             key: Some("bananas".into()),
             value: None,
             headers: Default::default(),
-            timestamp: OffsetDateTime::UNIX_EPOCH,
+            timestamp: chrono::DateTime::<Utc>::MIN_UTC,
         };
 
         wrapper

--- a/write_buffer/src/kafka/record_aggregator.rs
+++ b/write_buffer/src/kafka/record_aggregator.rs
@@ -97,9 +97,7 @@ impl RecordAggregator {
                 .headers()
                 .map(|(k, v)| (k.to_owned(), v.as_bytes().to_vec()))
                 .collect(),
-            timestamp: rskafka::time::OffsetDateTime::from_unix_timestamp_nanos(
-                now.date_time().timestamp_nanos() as i128,
-            )?,
+            timestamp: now.date_time(),
         };
 
         Ok((record, now))
@@ -284,7 +282,7 @@ mod tests {
             Vec::<u8>::from(NAMESPACE),
         );
         assert!(record.headers.get(HEADER_TRACE_CONTEXT).is_some());
-        assert_eq!(record.timestamp.unix_timestamp(), 1659990497);
+        assert_eq!(record.timestamp.timestamp(), 1659990497);
 
         // Extract the DmlMeta from the de-aggregator
         let got = deagg


### PR DESCRIPTION
This PR bumps rskakfa to HEAD, primarily to pick up:

* Perf changes in https://github.com/influxdata/rskafka/pull/173
* Switching to chrono for timestamps in https://github.com/influxdata/rskafka/pull/176

The former should change the latency profile of the routers, and the latter saves a lot of error-prone timestamp juggling :tada:

---

* build: bump rskafka (33b78eb5d)

      Update rskafka to HEAD, picking up:

		d7e14a8 test: increase timeouts, CircleCI is slow
		4e92ed2 refactor: replace `time` w/ `chono`
		c0ba668 fix: never leak flusher background tasks
		786d6e1 refactor: move batch into producer mod
		82862df perf: use RwLock for BroadcastOnce
		e12c812 perf: async batch flushing & lock contention
		ad126c5 test: increase timeouts
		6565321 test: improve testing config
		3379959 refactor: also invalidate broker cache when erroring on "unknown topic/partition"
		14ae812 refactor: clarify binding mechanism
		b59d9ad docs: fix spelling
		e73fef5 test: increase timeouts
		0dd1bda feat: introduce bind mode for partition client
		a3633c6 fix: disable topic auto creation in tests
		72c6dd2 fix: make redpanda happy
		ae6df2e ci: bump redpanda version
		a1ff3e5 chore: update Rust to 1.63
		1ca7c5f ci: shellcheck
		01a648b ci: yammlint
		3248dd6 ci: check that versions are in-sync
		ebf87b5 ci: run doctests
		32c34ec fix: address deprecation warnings
		0f6ad6c chore: fix `cargo bench -- --save-baseline`