### PR TITLE
fix: avoid splitting compaction output for time ranges with no chunks

### DIFF
--- a/compactor/src/parquet_file_combining.rs
+++ b/compactor/src/parquet_file_combining.rs
@@ -4,6 +4,7 @@ use crate::{
 };
 use data_types::{
     CompactionLevel, ParquetFile, ParquetFileId, ParquetFileParams, PartitionId, TableSchema,
+    TimestampMinMax,
 };
 use datafusion::error::DataFusionError;
 use futures::{stream::FuturesOrdered, StreamExt, TryStreamExt};
@@ -168,9 +169,8 @@ pub(crate) async fn compact_parquet_files(
 
     // extract the min & max chunk times for filtering potential split times.
     let chunk_times: Vec<_> = query_chunks
-        .clone()
-        .into_iter()
-        .map(|c| (c.min_time(), c.max_time()))
+        .iter()
+        .map(|c| TimestampMinMax::new(c.min_time(), c.max_time()))
         .collect();
 
     // Merge schema of the compacting chunks

--- a/compactor/src/parquet_file_combining.rs
+++ b/compactor/src/parquet_file_combining.rs
@@ -167,7 +167,8 @@ pub(crate) async fn compact_parquet_files(
     }
 
     // extract the min & max chunk times for filtering potential split times.
-    let chunk_times : Vec<_> = query_chunks.clone()
+    let chunk_times: Vec<_> = query_chunks
+        .clone()
         .into_iter()
         .map(|c| (c.min_time(), c.max_time()))
         .collect();

--- a/compactor/src/parquet_file_combining.rs
+++ b/compactor/src/parquet_file_combining.rs
@@ -166,6 +166,12 @@ pub(crate) async fn compact_parquet_files(
         max_time = max(max_time, c.max_time());
     }
 
+    // extract the min & max chunk times for filtering potential split times.
+    let chunk_times : Vec<_> = query_chunks.clone()
+        .into_iter()
+        .map(|c| (c.min_time(), c.max_time()))
+        .collect();
+
     // Merge schema of the compacting chunks
     let query_chunks: Vec<_> = query_chunks
         .into_iter()
@@ -201,6 +207,7 @@ pub(crate) async fn compact_parquet_files(
         } else {
             // Split compaction into multiple files
             crate::utils::compute_split_time(
+                chunk_times,
                 min_time,
                 max_time,
                 total_size,

--- a/compactor/src/utils.rs
+++ b/compactor/src/utils.rs
@@ -179,7 +179,7 @@ impl ParquetFileWithTombstone {
 ///     13 = 7 (previous time) + 6 (time range)
 ///     19 = 13 (previous time) + 6 (time range)
 pub(crate) fn compute_split_time(
-    chunk_times: Vec<(i64, i64)>,   // Vec of (min_time, max_time)
+    chunk_times: Vec<(i64, i64)>, // Vec of (min_time, max_time)
     min_time: i64,
     max_time: i64,
     total_size: u64,
@@ -214,14 +214,14 @@ pub(crate) fn compute_split_time(
 
 // time_range_present returns true if the given time range is included in any of the chunks.
 fn time_range_present(
-    chunk_times: Vec<(i64, i64)>,   // Vec of (min_time, max_time)
+    chunk_times: Vec<(i64, i64)>, // Vec of (min_time, max_time)
     min_time: i64,
     max_time: i64,
 ) -> bool {
     for chunk in chunk_times {
         // if chunk.max >= min_time and chunk.min <= max_time, this chunk is within the given time range.
         if chunk.1 >= min_time && chunk.0 <= max_time {
-            return true
+            return true;
         }
     }
     false
@@ -240,20 +240,38 @@ mod tests {
         let chunk_times = vec![(min_time, max_time)];
 
         // no split
-        let result = compute_split_time(chunk_times.clone(), min_time, max_time, total_size, max_desired_file_size);
+        let result = compute_split_time(
+            chunk_times.clone(),
+            min_time,
+            max_time,
+            total_size,
+            max_desired_file_size,
+        );
         assert_eq!(result.len(), 1);
         assert_eq!(result[0], max_time);
 
         // split 70% and 30%
         let max_desired_file_size = 70;
-        let result = compute_split_time(chunk_times.clone(), min_time, max_time, total_size, max_desired_file_size);
+        let result = compute_split_time(
+            chunk_times.clone(),
+            min_time,
+            max_time,
+            total_size,
+            max_desired_file_size,
+        );
         // only need to store the last split time
         assert_eq!(result.len(), 1);
         assert_eq!(result[0], 8); // = 1 (min_time) + 7
 
         // split 40%, 40%, 20%
         let max_desired_file_size = 40;
-        let result = compute_split_time(chunk_times, min_time, max_time, total_size, max_desired_file_size);
+        let result = compute_split_time(
+            chunk_times,
+            min_time,
+            max_time,
+            total_size,
+            max_desired_file_size,
+        );
         // store first and second split time
         assert_eq!(result.len(), 2);
         assert_eq!(result[0], 5); // = 1 (min_time) + 4
@@ -274,7 +292,13 @@ mod tests {
         let max_desired_file_size = 100;
         let chunk_times = vec![(min_time, max_time)];
 
-        let result = compute_split_time(chunk_times, min_time, max_time, total_size, max_desired_file_size);
+        let result = compute_split_time(
+            chunk_times,
+            min_time,
+            max_time,
+            total_size,
+            max_desired_file_size,
+        );
 
         // must return vector of one containing max_time
         assert_eq!(result.len(), 1);
@@ -293,13 +317,18 @@ mod tests {
 
         let chunk_times = vec![(min_time, max_time)];
 
-        let result = compute_split_time(chunk_times, min_time, max_time, total_size, max_desired_file_size);
+        let result = compute_split_time(
+            chunk_times,
+            min_time,
+            max_time,
+            total_size,
+            max_desired_file_size,
+        );
         assert_eq!(result.len(), 9);
     }
 
     #[test]
     fn compute_split_time_chunk_gaps() {
-
         // When the chunks have large gaps, we should not introduce a splits that cause time ranges
         // known to be empty.  Split T2 below should not exist.
         //                   │               │
@@ -316,9 +345,15 @@ mod tests {
 
         let total_size = 200;
         let max_desired_file_size = total_size / 3;
-        let chunk_times = vec![(1,24), (75,100)];
+        let chunk_times = vec![(1, 24), (75, 100)];
 
-        let result = compute_split_time(chunk_times, min_time, max_time, total_size, max_desired_file_size);
+        let result = compute_split_time(
+            chunk_times,
+            min_time,
+            max_time,
+            total_size,
+            max_desired_file_size,
+        );
 
         // must return vector of one, containing a Split T1 shown above.
         assert_eq!(result.len(), 1);


### PR DESCRIPTION
Closes https://github.com/influxdata/influxdb_iox/issues/5511

When computing split times for compaction output, it is assumed that data is dispersed evenly across the time range.  If large gaps exist between chunks, there may be time splits that have no chunks covering them.  This produces empty parquet files.  This PR checks the computed split times against the time ranges of the chunks to be included in the compaction.  If no chunks exist within the time range of split, the split is omitted.

It is still possible to have empty parquet files when chunks have large gaps within them, rather than between them.

- [x] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb_iox/blob/main/README.md).
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
