### PR TITLE
fix: Don't try to parse /api/v2/query response as JSON

### DIFF
--- a/influxdb2_client/examples/query.rs
+++ b/influxdb2_client/examples/query.rs
@@ -11,7 +11,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     client.query_suggestions_name("some-name").await?;
 
     client
-        .query("some-org", Some(Query::new("some-query".to_string())))
+        .query_raw("some-org", Some(Query::new("some-query".to_string())))
         .await?;
 
     client

--- a/influxdb2_client/src/api/query.rs
+++ b/influxdb2_client/src/api/query.rs
@@ -61,8 +61,8 @@ impl Client {
         }
     }
 
-    /// Query
-    pub async fn query(&self, org: &str, query: Option<Query>) -> Result<String, RequestError> {
+    /// Query and return the raw string data from the server
+    pub async fn query_raw(&self, org: &str, query: Option<Query>) -> Result<String, RequestError> {
         let req_url = format!("{}/api/v2/query", self.url);
 
         let response = self
@@ -189,7 +189,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn query() {
+    async fn query_raw() {
         let token = "some-token";
         let org = "some-org";
         let query: Option<Query> = Some(Query::new("some-influx-query-string".to_string()));
@@ -207,13 +207,13 @@ mod tests {
 
         let client = Client::new(&mockito::server_url(), token);
 
-        let _result = client.query(org, query).await;
+        let _result = client.query_raw(org, query).await;
 
         mock_server.assert();
     }
 
     #[tokio::test]
-    async fn query_opt() {
+    async fn query_raw_opt() {
         let token = "some-token";
         let org = "some-org";
         let query: Option<Query> = None;
@@ -232,7 +232,7 @@ mod tests {
 
         let client = Client::new(&mockito::server_url(), token);
 
-        let _result = client.query(org, None).await;
+        let _result = client.query_raw(org, None).await;
 
         mock_server.assert();
     }
@@ -323,7 +323,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn query_no_results() {
+    async fn query_raw_no_results() {
         let token = "some-token";
         let org = "some-org";
         let query: Option<Query> = Some(Query::new("some-influx-query-string".to_string()));
@@ -342,7 +342,7 @@ mod tests {
 
         let client = Client::new(&mockito::server_url(), token);
 
-        let result = client.query(org, query).await.expect("request success");
+        let result = client.query_raw(org, query).await.expect("request success");
         assert_eq!(result, "");
 
         mock_server.assert();

--- a/influxdb2_client/src/lib.rs
+++ b/influxdb2_client/src/lib.rs
@@ -43,7 +43,9 @@
 //!
 //!     let client = Client::new("http://localhost:8888", "some-token");
 //!
-//!     client.create_bucket(Some(PostBucketRequest::new(org_id.to_string(), bucket.to_string()))).await?;
+//!     client.create_bucket(
+//!         Some(PostBucketRequest::new(org_id.to_string(), bucket.to_string()))
+//!     ).await?;
 //!
 //!     let points = vec![
 //!         DataPoint::builder("cpu")
@@ -128,7 +130,8 @@ pub struct Client {
 }
 
 impl Client {
-    /// Default [jaeger debug header](Self::with_jaeger_debug) that should work in many environments.
+    /// Default [jaeger debug header](Self::with_jaeger_debug) that should work in many
+    /// environments.
     pub const DEFAULT_JAEGER_DEBUG_HEADER: &'static str = "jaeger-debug-id";
 
     /// Create a new client pointing to the URL specified in


### PR DESCRIPTION
It's just plain text afaict.

Closes #5484.

So after actually getting a local influxdb 2.4 running and trying out queries that return data and queries that don't, I think the real problem is that we're trying to parse the response as JSON at all... 😳 

Looking at some of the other influxdb2 clients, it looks like the APIs that return the text without interpreting it at all are called `query_raw` rather than `query`, so I have another commit proposing to rename the function here... not sure if it'll break anything, but I doubt it as I don't think this ever worked 🤣 

@rkudryashov could you try out this branch and see if it works as you'd expect? Thanks!