### PR TITLE
fix: Use `ColumnType` as an enum in more places; make `estimate_arrow_bytes_for_file` infallible

### DIFF
--- a/compactor/src/cold.rs
+++ b/compactor/src/cold.rs
@@ -331,15 +331,15 @@ mod tests {
         table.create_column("time", ColumnType::Time).await;
         let table_column_types = vec![
             ColumnTypeCount {
-                col_type: ColumnType::Tag as i16,
+                col_type: ColumnType::Tag,
                 count: 3,
             },
             ColumnTypeCount {
-                col_type: ColumnType::I64 as i16,
+                col_type: ColumnType::I64,
                 count: 1,
             },
             ColumnTypeCount {
-                col_type: ColumnType::Time as i16,
+                col_type: ColumnType::Time,
                 count: 1,
             },
         ];
@@ -572,15 +572,15 @@ mod tests {
         table.create_column("time", ColumnType::Time).await;
         let table_column_types = vec![
             ColumnTypeCount {
-                col_type: ColumnType::Tag as i16,
+                col_type: ColumnType::Tag,
                 count: 3,
             },
             ColumnTypeCount {
-                col_type: ColumnType::I64 as i16,
+                col_type: ColumnType::I64,
                 count: 1,
             },
             ColumnTypeCount {
-                col_type: ColumnType::Time as i16,
+                col_type: ColumnType::Time,
                 count: 1,
             },
         ];

--- a/compactor/src/cold.rs
+++ b/compactor/src/cold.rs
@@ -124,7 +124,7 @@ pub(crate) enum Error {
 
     #[snafu(display("{}", source))]
     Combining {
-        source: parquet_file_combining::Error,
+        source: Box<parquet_file_combining::Error>,
     },
 
     #[snafu(display("{}", source))]
@@ -186,7 +186,9 @@ async fn full_compaction(
                 &compactor.compaction_input_file_bytes,
             )
             .await
-            .context(CombiningSnafu)?;
+            .map_err(|e| Error::Combining {
+                source: Box::new(e),
+            })?;
         }
     }
 

--- a/compactor/src/hot.rs
+++ b/compactor/src/hot.rs
@@ -458,15 +458,15 @@ mod tests {
         table.create_column("time", ColumnType::Time).await;
         let table_column_types = vec![
             ColumnTypeCount {
-                col_type: ColumnType::Tag as i16,
+                col_type: ColumnType::Tag,
                 count: 3,
             },
             ColumnTypeCount {
-                col_type: ColumnType::I64 as i16,
+                col_type: ColumnType::I64,
                 count: 1,
             },
             ColumnTypeCount {
-                col_type: ColumnType::Time as i16,
+                col_type: ColumnType::Time,
                 count: 1,
             },
         ];

--- a/data_types/src/lib.rs
+++ b/data_types/src/lib.rs
@@ -500,13 +500,11 @@ impl TableSchema {
     /// # Panics
     ///
     /// This method panics if a column of the same name already exists in
-    /// `self`, or the provided [`Column`] cannot be converted into a valid
-    /// [`ColumnSchema`].
+    /// `self`.
     pub fn add_column(&mut self, col: &Column) {
-        let old = self.columns.insert(
-            col.name.clone(),
-            ColumnSchema::try_from(col).expect("column is invalid"),
-        );
+        let old = self
+            .columns
+            .insert(col.name.clone(), ColumnSchema::from(col));
         assert!(old.is_none());
     }
 
@@ -593,14 +591,16 @@ impl ColumnSchema {
     }
 }
 
-impl TryFrom<&Column> for ColumnSchema {
-    type Error = Box<dyn std::error::Error>;
+impl From<&Column> for ColumnSchema {
+    fn from(c: &Column) -> Self {
+        let Column {
+            id, column_type, ..
+        } = c;
 
-    fn try_from(c: &Column) -> Result<Self, Self::Error> {
-        Ok(Self {
-            id: c.id,
-            column_type: ColumnType::try_from(c.column_type)?,
-        })
+        Self {
+            id: *id,
+            column_type: *column_type,
+        }
     }
 }
 

--- a/data_types/src/lib.rs
+++ b/data_types/src/lib.rs
@@ -539,23 +539,23 @@ pub struct Column {
     /// the name of the column, which is unique in the table
     pub name: String,
     /// the logical type of the column
-    pub column_type: i16,
+    pub column_type: ColumnType,
 }
 
 impl Column {
     /// returns true if the column type is a tag
     pub fn is_tag(&self) -> bool {
-        self.column_type == ColumnType::Tag as i16
+        self.column_type == ColumnType::Tag
     }
 
     /// returns true if the column type matches the line protocol field value type
     pub fn matches_field_type(&self, field_value: &FieldValue) -> bool {
         match field_value {
-            FieldValue::I64(_) => self.column_type == ColumnType::I64 as i16,
-            FieldValue::U64(_) => self.column_type == ColumnType::U64 as i16,
-            FieldValue::F64(_) => self.column_type == ColumnType::F64 as i16,
-            FieldValue::String(_) => self.column_type == ColumnType::String as i16,
-            FieldValue::Boolean(_) => self.column_type == ColumnType::Bool as i16,
+            FieldValue::I64(_) => self.column_type == ColumnType::I64,
+            FieldValue::U64(_) => self.column_type == ColumnType::U64,
+            FieldValue::F64(_) => self.column_type == ColumnType::F64,
+            FieldValue::String(_) => self.column_type == ColumnType::String,
+            FieldValue::Boolean(_) => self.column_type == ColumnType::Bool,
         }
     }
 }
@@ -606,7 +606,8 @@ impl TryFrom<&Column> for ColumnSchema {
 
 /// The column data type
 #[allow(missing_docs)]
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, PartialOrd, Ord, Hash, sqlx::Type)]
+#[repr(i16)]
 pub enum ColumnType {
     I64 = 1,
     U64 = 2,
@@ -910,10 +911,10 @@ impl Tombstone {
     }
 }
 /// Map of a column type to its count
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, sqlx::FromRow)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, sqlx::FromRow)]
 pub struct ColumnTypeCount {
     /// column type
-    pub col_type: i16,
+    pub col_type: ColumnType,
     /// count of the column type
     pub count: i64,
 }
@@ -921,10 +922,7 @@ pub struct ColumnTypeCount {
 impl ColumnTypeCount {
     /// make a new ColumnTypeCount
     pub fn new(col_type: ColumnType, count: i64) -> Self {
-        Self {
-            col_type: col_type as i16,
-            count,
-        }
+        Self { col_type, count }
     }
 }
 

--- a/iox_catalog/src/interface.rs
+++ b/iox_catalog/src/interface.rs
@@ -12,7 +12,6 @@ use iox_time::TimeProvider;
 use snafu::{OptionExt, Snafu};
 use std::{
     collections::{BTreeMap, HashMap, HashSet},
-    convert::TryFrom,
     fmt::Debug,
     sync::Arc,
 };
@@ -723,23 +722,13 @@ where
 
     for c in columns {
         let (_, t) = table_id_to_schema.get_mut(&c.table_id).unwrap();
-        match ColumnType::try_from(c.column_type) {
-            Ok(column_type) => {
-                t.columns.insert(
-                    c.name,
-                    ColumnSchema {
-                        id: c.id,
-                        column_type,
-                    },
-                );
-            }
-            _ => {
-                return Err(Error::UnknownColumnType {
-                    data_type: c.column_type,
-                    name: c.name.to_string(),
-                });
-            }
-        }
+        t.columns.insert(
+            c.name,
+            ColumnSchema {
+                id: c.id,
+                column_type: c.column_type,
+            },
+        );
     }
 
     for (_, (table_name, schema)) in table_id_to_schema {
@@ -758,23 +747,13 @@ where
     let mut schema = TableSchema::new(id);
 
     for c in columns {
-        match ColumnType::try_from(c.column_type) {
-            Ok(column_type) => {
-                schema.columns.insert(
-                    c.name,
-                    ColumnSchema {
-                        id: c.id,
-                        column_type,
-                    },
-                );
-            }
-            _ => {
-                return Err(Error::UnknownColumnType {
-                    data_type: c.column_type,
-                    name: c.name,
-                });
-            }
-        }
+        schema.columns.insert(
+            c.name,
+            ColumnSchema {
+                id: c.id,
+                column_type: c.column_type,
+            },
+        );
     }
 
     Ok(schema)
@@ -1315,11 +1294,11 @@ pub(crate) mod test_helpers {
             .unwrap();
         let mut expect = vec![
             ColumnTypeCount {
-                col_type: ColumnType::Tag as i16,
+                col_type: ColumnType::Tag,
                 count: 1,
             },
             ColumnTypeCount {
-                col_type: ColumnType::U64 as i16,
+                col_type: ColumnType::U64,
                 count: 2,
             },
         ];

--- a/iox_catalog/src/interface.rs
+++ b/iox_catalog/src/interface.rs
@@ -33,8 +33,8 @@ pub enum Error {
     #[snafu(display("column {} is type {} but write has type {}", name, existing, new))]
     ColumnTypeMismatch {
         name: String,
-        existing: String,
-        new: String,
+        existing: ColumnType,
+        new: ColumnType,
     },
 
     #[snafu(display(

--- a/iox_catalog/src/mem.rs
+++ b/iox_catalog/src/mem.rs
@@ -527,7 +527,7 @@ impl ColumnRepo for MemTxn {
             .find(|t| t.name == name && t.table_id == table_id)
         {
             Some(c) => {
-                if column_type as i16 != c.column_type {
+                if column_type != c.column_type {
                     return Err(Error::ColumnTypeMismatch {
                         name: name.to_string(),
                         existing: ColumnType::try_from(c.column_type).unwrap().to_string(),
@@ -542,7 +542,7 @@ impl ColumnRepo for MemTxn {
                     id: ColumnId::new(stage.columns.len() as i64 + 1),
                     table_id,
                     name: name.to_string(),
-                    column_type: column_type as i16,
+                    column_type,
                 };
                 stage.columns.push(column);
                 stage.columns.last().unwrap()

--- a/router/tests/http.rs
+++ b/router/tests/http.rs
@@ -1,5 +1,5 @@
 use assert_matches::assert_matches;
-use data_types::{PartitionTemplate, QueryPoolId, ShardIndex, TemplatePart, TopicId};
+use data_types::{ColumnType, PartitionTemplate, QueryPoolId, ShardIndex, TemplatePart, TopicId};
 use dml::DmlOperation;
 use hashbrown::HashMap;
 use hyper::{Body, Request, StatusCode};
@@ -280,8 +280,8 @@ async fn test_schema_conflict() {
                 new,
             } => {
                 assert_eq!(name, "val");
-                assert_eq!(existing, "i64");
-                assert_eq!(new, "iox::column_type::field::float");
+                assert_eq!(*existing, ColumnType::I64);
+                assert_eq!(*new, ColumnType::F64);
             });
         }
     );


### PR DESCRIPTION
I swear I'm going somewhere with this, this is just the first step to some refactoring to improve code reuse, encapsulation, and testing of the compactor code.

`estimate_arrow_bytes_for_file` had the possibility of failing if the column type `i16` couldn't be converted to a `ColumnType` value. This really shouldn't be the case, as we're controlling what goes into and out of the database. And even if there is a failure, it should be at the database interaction level, not computing estimated memory usage.

sqlx can take care of the transformations between int and enum for us if we add `#[repr(i16)]` to `ColumnType` (the `column_type` column in postgres is `SMALLINT`, [which corresponds to Rust `i16`](https://docs.rs/sqlx/latest/sqlx/postgres/types/index.html)).

There's only one spot where we're sending a bunch of records to an INSERT and sqlx isn't doing that quite right-- there's one little `as i16` needed there. 