### PR TITLE
refactor: Move fetching of table columns, extra partition info into the method

### DIFF
--- a/compactor/src/lib.rs
+++ b/compactor/src/lib.rs
@@ -430,7 +430,7 @@ pub mod tests {
             .with_creation_time(hot_time_one_hour_ago);
         partition1.create_parquet_file_catalog_record(pf1_1).await;
 
-        let candidates = compactor
+        let (mut candidates, _table_columns) = compactor
             .hot_partitions_to_compact(
                 compactor.config.max_number_partitions_per_shard,
                 compactor
@@ -441,17 +441,14 @@ pub mod tests {
             .unwrap();
         assert_eq!(candidates.len(), 1);
 
-        let candidates = compactor.add_info_to_partitions(&candidates).await.unwrap();
-        let mut sorted_candidates = candidates.into_iter().collect::<Vec<_>>();
-        sorted_candidates.sort_by_key(|c| c.candidate.partition_id);
-        let sorted_candidates = sorted_candidates.into_iter().collect::<VecDeque<_>>();
+        candidates.sort_by_key(|c| c.candidate.partition_id);
         let table_columns = HashMap::new();
 
         compact_candidates_with_memory_budget(
             Arc::clone(&compactor),
             "hot",
             mock_compactor.compaction_function(),
-            sorted_candidates,
+            candidates.into(),
             table_columns,
         )
         .await;


### PR DESCRIPTION
This is another step on a refactoring journey.

Advantages of this refactor:

- Less repeated code outside of `Compactor`; hot and cold compaction had to call `compactor.table_columns` and `compactor.add_info_to_partitions` to get usable information after calling `compactor.hot_partitions_to_compact` and `compactor.cold_partitions_to_compact`. Now they only have to call that one method rather than 3 and they get everything they need.
- Tests that need this extra info will also get it without needing the extra setup steps of calling `table_columns` and `add_info_to_partitions`

Disadvantages:

- These functions now return a tuple of (candidates, table_columns) and those table columns aren't always needed, especially in tests-- that will be improved with my next PR :)
- The time to fetch this extra info recorded in `partitions_extra_info_reading_duration` is now also included in the `candidate_selection_duration` time, as reading the extra info is now part of the candidate selection function. Is this a problem? If so, I can move the `candidate_selection_duration` recording within the `compactor.hot_partitions_to_compact` and `compactor.cold_partitions_to_compact` methods and record it before those methods call `table_columns` or `add_info_to_partitions`.