### PR TITLE
refactor: hoist per-partition persistence watermark from buffer

### DIFF
--- a/ingester/src/data.rs
+++ b/ingester/src/data.rs
@@ -1278,7 +1278,7 @@ mod tests {
             let table = table_data.read().await;
             let p = table.partition_data.get(&"1970-01-01".into()).unwrap();
             assert_eq!(
-                p.data.max_persisted_sequence_number,
+                p.max_persisted_sequence_number(),
                 Some(SequenceNumber::new(1))
             );
             assert!(p.data.buffer.is_none());

--- a/ingester/src/data/namespace.rs
+++ b/ingester/src/data/namespace.rs
@@ -300,7 +300,7 @@ impl NamespaceData {
             let partition = t.partition_data.get_mut(partition_key);
 
             if let Some(p) = partition {
-                p.data.mark_persisted(sequence_number);
+                p.mark_persisted(sequence_number);
             }
         }
     }

--- a/ingester/src/data/partition/buffer.rs
+++ b/ingester/src/data/partition/buffer.rs
@@ -38,9 +38,6 @@ pub(crate) struct DataBuffer {
     /// Buffer of incoming writes
     pub(crate) buffer: Option<BufferBatch>,
 
-    /// The max_persisted_sequence number for any parquet_file in this partition
-    pub(crate) max_persisted_sequence_number: Option<SequenceNumber>,
-
     /// Buffer of tombstones whose time range may overlap with this partition.
     /// All tombstones were already applied to corresponding snapshots. This list
     /// only keep the ones that come during persisting. The reason
@@ -239,14 +236,9 @@ impl DataBuffer {
         self.snapshots.as_ref()
     }
 
-    pub(crate) fn mark_persisted(&mut self, up_to: SequenceNumber) {
-        self.max_persisted_sequence_number = Some(up_to);
+    pub(crate) fn mark_persisted(&mut self) {
         self.persisting = None;
         self.deletes_during_persisting.clear()
-    }
-
-    pub(crate) fn max_persisted_sequence_number(&self) -> Option<SequenceNumber> {
-        self.max_persisted_sequence_number
     }
 
     #[cfg(test)]

--- a/ingester/src/test_util.rs
+++ b/ingester/src/test_util.rs
@@ -809,7 +809,7 @@ pub(crate) fn make_partitions(
     let mut seq_num = seq_num.get();
     if two_partitions {
         let partition_id = PartitionId::new(2);
-        let mut p2 = PartitionData::new(partition_id);
+        let mut p2 = PartitionData::new(partition_id, None);
         // Group 4: in buffer of p2
         // Fill `buffer`
         seq_num += 1;
@@ -933,7 +933,7 @@ fn make_first_partition_data(
 
     // ------------------------------------------
     // Build the first partition
-    let mut p1 = PartitionData::new(partition_id);
+    let mut p1 = PartitionData::new(partition_id, None);
     let mut seq_num = 0;
 
     // --------------------


### PR DESCRIPTION
A quick PR that moves the per-partition "max sequence number" onto the per-partition data structure, instead of being in the data/RecordBatch buffer within it 🧹 

---

* refactor: hoist persistence watermark from buffer (fc17f2ec2)

      The maximum persisted sequence number is tracked to answer "up to where has
      this partition been persisted", used for querying and skipping writes that
      have already been applied (though I suspect this is redundant).

      This is a property of the partition, not the actual data buffer, so this 
      commit hoists it up out of the data buffer and onto the per-partition data
      structure, internalising the field in the process (not pub).