### PR TITLE
feat: store per partition persist markers

### DIFF
--- a/data_types/src/lib.rs
+++ b/data_types/src/lib.rs
@@ -842,6 +842,17 @@ pub struct Partition {
 
     /// The inclusive maximum [`SequenceNumber`] of the most recently persisted
     /// data for this partition.
+    ///
+    /// All writes with a [`SequenceNumber`] less than and equal to this
+    /// [`SequenceNumber`] have been persisted to the object store. The inverse
+    /// is not guaranteed to be true due to update ordering; some files for this
+    /// partition may exist in the `parquet_files` table that have a greater
+    /// [`SequenceNumber`] than is specified here - the system will converge so
+    /// long as the ingester progresses.
+    ///
+    /// It is a system invariant that this value monotonically increases over
+    /// time - wrote another way, it is an invariant that partitions are
+    /// persisted (or at least made visible) in sequence order.
     pub persisted_sequence_number: SequenceNumber,
 }
 

--- a/data_types/src/lib.rs
+++ b/data_types/src/lib.rs
@@ -839,6 +839,10 @@ pub struct Partition {
     /// is legal. However, updating to `A,C,D,B` is not because the
     /// relative order of B and C have been reversed.
     pub sort_key: Vec<String>,
+
+    /// The inclusive maximum [`SequenceNumber`] of the most recently persisted
+    /// data for this partition.
+    pub persisted_sequence_number: SequenceNumber,
 }
 
 impl Partition {

--- a/import/src/aggregate_tsm_schema/update_catalog.rs
+++ b/import/src/aggregate_tsm_schema/update_catalog.rs
@@ -406,7 +406,7 @@ mod tests {
     use crate::{AggregateTSMField, AggregateTSMTag};
     use assert_matches::assert_matches;
     use client_util::connection::Builder;
-    use data_types::{PartitionId, TableId};
+    use data_types::{PartitionId, SequenceNumber, TableId};
     use iox_catalog::mem::MemCatalog;
     use parking_lot::RwLock;
     use std::{collections::HashSet, net::SocketAddr};
@@ -1313,9 +1313,8 @@ mod tests {
             id: PartitionId::new(1),
             shard_id: ShardId::new(1),
             table_id: TableId::new(1),
+            persisted_sequence_number: SequenceNumber::new(0),
             partition_key: PartitionKey::from("2022-06-21"),
-            // N.B. empty sort key at this point; will return as None from the getter and will be
-            // computed
             sort_key: Vec::new(),
         };
         let sort_key = get_sort_key(&partition, &m).1.unwrap();
@@ -1361,6 +1360,7 @@ mod tests {
             id: PartitionId::new(1),
             shard_id: ShardId::new(1),
             table_id: TableId::new(1),
+            persisted_sequence_number: SequenceNumber::new(0),
             partition_key: PartitionKey::from("2022-06-21"),
             // N.B. sort key is already what it will computed to; here we're testing the `adjust_sort_key_columns` code path
             sort_key: vec!["host".to_string(), "arch".to_string(), "time".to_string()],
@@ -1407,6 +1407,7 @@ mod tests {
             id: PartitionId::new(1),
             shard_id: ShardId::new(1),
             table_id: TableId::new(1),
+            persisted_sequence_number: SequenceNumber::new(0),
             partition_key: PartitionKey::from("2022-06-21"),
             // N.B. is missing host so will need updating
             sort_key: vec!["arch".to_string(), "time".to_string()],
@@ -1455,6 +1456,7 @@ mod tests {
             id: PartitionId::new(1),
             shard_id: ShardId::new(1),
             table_id: TableId::new(1),
+            persisted_sequence_number: SequenceNumber::new(0),
             partition_key: PartitionKey::from("2022-06-21"),
             // N.B. is missing arch so will need updating
             sort_key: vec!["host".to_string(), "time".to_string()],

--- a/ingester/src/compact.rs
+++ b/ingester/src/compact.rs
@@ -178,7 +178,7 @@ pub async fn compact(
 #[cfg(test)]
 mod tests {
     use arrow_util::assert_batches_eq;
-    use data_types::{Partition, PartitionId, ShardId, TableId};
+    use data_types::{Partition, PartitionId, SequenceNumber, ShardId, TableId};
     use iox_time::SystemProvider;
     use mutable_batch_lp::lines_to_batches;
     use schema::selection::Selection;
@@ -247,6 +247,7 @@ mod tests {
                 table_id: TableId::new(table_id),
                 partition_key: partition_key.into(),
                 sort_key: vec![],
+                persisted_sequence_number: SequenceNumber::new(42),
             },
         };
 
@@ -317,6 +318,7 @@ mod tests {
                 table_id: TableId::new(table_id),
                 partition_key: partition_key.into(),
                 sort_key: vec![],
+                persisted_sequence_number: SequenceNumber::new(42),
             },
         };
 
@@ -414,6 +416,7 @@ mod tests {
                 partition_key: partition_key.into(),
                 // NO SORT KEY from the catalog here, first persisting batch
                 sort_key: vec![],
+                persisted_sequence_number: SequenceNumber::new(42),
             },
         };
 
@@ -514,6 +517,7 @@ mod tests {
                 // SPECIFY A SORT KEY HERE to simulate a sort key being stored in the catalog
                 // this is NOT what the computed sort key would be based on this data's cardinality
                 sort_key: vec!["tag3".to_string(), "tag1".to_string(), "time".to_string()],
+                persisted_sequence_number: SequenceNumber::new(42),
             },
         };
 
@@ -615,6 +619,7 @@ mod tests {
                 // this is NOT what the computed sort key would be based on this data's cardinality
                 // The new column, tag1, should get added just before the time column
                 sort_key: vec!["tag3".to_string(), "time".to_string()],
+                persisted_sequence_number: SequenceNumber::new(42),
             },
         };
 
@@ -724,6 +729,7 @@ mod tests {
                     "tag4".to_string(),
                     "time".to_string(),
                 ],
+                persisted_sequence_number: SequenceNumber::new(42),
             },
         };
 

--- a/ingester/src/data.rs
+++ b/ingester/src/data.rs
@@ -403,7 +403,7 @@ impl Persister for IngesterData {
                         .repositories()
                         .await
                         .partitions()
-                        .update_persist_watermark(
+                        .update_persisted_sequence_number(
                             parquet_file.partition_id,
                             parquet_file.max_sequence_number,
                         )

--- a/ingester/src/data.rs
+++ b/ingester/src/data.rs
@@ -356,6 +356,10 @@ impl Persister for IngesterData {
                 );
             }
 
+            // Add the parquet file to the catalog.
+            //
+            // This has the effect of allowing the queriers to "discover" the
+            // parquet file by polling / querying the catalog.
             Backoff::new(&self.backoff_config)
                 .retry_all_errors("add parquet file to catalog", || async {
                     let mut repos = self.catalog.repositories().await;
@@ -369,6 +373,41 @@ impl Persister for IngesterData {
                     );
                     // compiler insisted on getting told the type of the error :shrug:
                     Ok(()) as Result<(), iox_catalog::interface::Error>
+                })
+                .await
+                .expect("retry forever");
+
+            // Update the per-partition persistence watermark, so that new
+            // ingester instances skip the just-persisted ops during replay.
+            //
+            // This could be transactional with the above parquet insert to
+            // maintain catalog consistency, though in practice it is an
+            // unnecessary overhead - the system can tolerate replaying the ops
+            // that lead to this parquet file being generated, and tolerate
+            // creating a parquet file containing duplicate data (remedied by
+            // compaction).
+            //
+            // This means it is possible to observe a parquet file with a
+            // max_persisted_sequence_number >
+            // partition.persisted_sequence_number, either in-between these
+            // catalog updates, or for however long it takes a crashed ingester
+            // to restart and replay the ops, and re-persist a file containing
+            // the same (or subset of) data.
+            //
+            // The above is also true of the per-shard persist marker that
+            // governs the ingester's replay start point, which is
+            // non-transactionally updated after all partitions have persisted.
+            Backoff::new(&self.backoff_config)
+                .retry_all_errors("set partition persist marker", || async {
+                    self.catalog
+                        .repositories()
+                        .await
+                        .partitions()
+                        .update_persist_watermark(
+                            parquet_file.partition_id,
+                            parquet_file.max_sequence_number,
+                        )
+                        .await
                 })
                 .await
                 .expect("retry forever");
@@ -952,6 +991,17 @@ mod tests {
         assert_eq!(pf.max_sequence_number, SequenceNumber::new(2));
         assert_eq!(pf.shard_id, shard1.id);
         assert!(pf.to_delete.is_none());
+
+        // Verify the per-partition persist mark was updated to a value
+        // inclusive of the persisted data, forming the exclusive lower-bound
+        // from which a partition should start applying ops to ingest new data.
+        let partition = repos
+            .partitions()
+            .get_by_id(partition_id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(partition.persisted_sequence_number, SequenceNumber::new(2));
 
         // This value should be recorded in the metrics asserted next;
         // it is less than 500 KB

--- a/iox_catalog/migrations/20220915085930_per-partition-persist-offset.sql
+++ b/iox_catalog/migrations/20220915085930_per-partition-persist-offset.sql
@@ -1,0 +1,9 @@
+/*
+ Add a per-partition persistence watermark (inclusive).
+
+ https://github.com/influxdata/influxdb_iox/issues/5638
+ */
+ALTER TABLE
+    "partition"
+ADD
+    COLUMN "persisted_sequence_number" BIGINT NOT NULL DEFAULT 0;

--- a/iox_catalog/src/interface.rs
+++ b/iox_catalog/src/interface.rs
@@ -485,7 +485,7 @@ pub trait PartitionRepo: Send + Sync {
     ///
     /// The given `sequence_number` is the inclusive maximum [`SequenceNumber`]
     /// of the most recently persisted data for this partition.
-    async fn update_persist_watermark(
+    async fn update_persisted_sequence_number(
         &mut self,
         partition_id: PartitionId,
         sequence_number: SequenceNumber,
@@ -1618,7 +1618,7 @@ pub(crate) mod test_helpers {
         // Set
         repos
             .partitions()
-            .update_persist_watermark(other_partition.id, SequenceNumber::new(42))
+            .update_persisted_sequence_number(other_partition.id, SequenceNumber::new(42))
             .await
             .unwrap();
         // Read

--- a/iox_catalog/src/interface.rs
+++ b/iox_catalog/src/interface.rs
@@ -480,6 +480,16 @@ pub trait PartitionRepo: Send + Sync {
 
     /// List the records of compacting a partition being skipped. This is mostly useful for testing.
     async fn list_skipped_compactions(&mut self) -> Result<Vec<SkippedCompaction>>;
+
+    /// Update the per-partition persistence watermark.
+    ///
+    /// The given `sequence_number` is the inclusive maximum [`SequenceNumber`]
+    /// of the most recently persisted data for this partition.
+    async fn update_persist_watermark(
+        &mut self,
+        partition_id: PartitionId,
+        sequence_number: SequenceNumber,
+    ) -> Result<()>;
 }
 
 /// Functions for working with tombstones in the catalog
@@ -1596,6 +1606,29 @@ pub(crate) mod test_helpers {
         assert_eq!(skipped_compactions.len(), 1);
         assert_eq!(skipped_compactions[0].partition_id, other_partition.id);
         assert_eq!(skipped_compactions[0].reason, "I'm on fire");
+
+        // Test setting and reading the per-partition persistence numbers
+        let partition = repos
+            .partitions()
+            .get_by_id(other_partition.id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(partition.persisted_sequence_number, SequenceNumber::new(0));
+        // Set
+        repos
+            .partitions()
+            .update_persist_watermark(other_partition.id, SequenceNumber::new(42))
+            .await
+            .unwrap();
+        // Read
+        let partition = repos
+            .partitions()
+            .get_by_id(other_partition.id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(partition.persisted_sequence_number, SequenceNumber::new(42));
     }
 
     async fn test_tombstone(catalog: Arc<dyn Catalog>) {

--- a/iox_catalog/src/mem.rs
+++ b/iox_catalog/src/mem.rs
@@ -880,7 +880,7 @@ impl PartitionRepo for MemTxn {
         Ok(stage.skipped_compactions.clone())
     }
 
-    async fn update_persist_watermark(
+    async fn update_persisted_sequence_number(
         &mut self,
         partition_id: PartitionId,
         sequence_number: SequenceNumber,

--- a/iox_catalog/src/metrics.rs
+++ b/iox_catalog/src/metrics.rs
@@ -249,7 +249,7 @@ decorate!(
         "partition_update_sort_key" = update_sort_key(&mut self, partition_id: PartitionId, sort_key: &[&str]) -> Result<Partition>;
         "partition_record_skipped_compaction" = record_skipped_compaction(&mut self, partition_id: PartitionId, reason: &str) -> Result<()>;
         "partition_list_skipped_compactions" = list_skipped_compactions(&mut self) -> Result<Vec<SkippedCompaction>>;
-        "partition_update_persist_watermark" = update_persist_watermark(&mut self, partition_id: PartitionId, sequence_number: SequenceNumber) -> Result<()>;
+        "partition_update_persisted_sequence_number" = update_persisted_sequence_number(&mut self, partition_id: PartitionId, sequence_number: SequenceNumber) -> Result<()>;
     ]
 );
 

--- a/iox_catalog/src/metrics.rs
+++ b/iox_catalog/src/metrics.rs
@@ -249,6 +249,7 @@ decorate!(
         "partition_update_sort_key" = update_sort_key(&mut self, partition_id: PartitionId, sort_key: &[&str]) -> Result<Partition>;
         "partition_record_skipped_compaction" = record_skipped_compaction(&mut self, partition_id: PartitionId, reason: &str) -> Result<()>;
         "partition_list_skipped_compactions" = list_skipped_compactions(&mut self) -> Result<Vec<SkippedCompaction>>;
+        "partition_update_persist_watermark" = update_persist_watermark(&mut self, partition_id: PartitionId, sequence_number: SequenceNumber) -> Result<()>;
     ]
 );
 

--- a/iox_catalog/src/postgres.rs
+++ b/iox_catalog/src/postgres.rs
@@ -1327,7 +1327,7 @@ SELECT * FROM skipped_compactions
         .context(interface::CouldNotListSkippedCompactionsSnafu)
     }
 
-    async fn update_persist_watermark(
+    async fn update_persisted_sequence_number(
         &mut self,
         partition_id: PartitionId,
         sequence_number: SequenceNumber,


### PR DESCRIPTION
This PR adds a new field `persisted_sequence_number` to the `partitions` table in the catalog, and adds the necessary code for the ingesters to WRITE to it only.

### Default 0 Value

The field in the DB is marked `NOT NULL` with a default of  `0`. Upon loading this offset, an ingester will replay writes in partitions that have already been persisted. This is tolerable by the system overall as it only creates (slightly) more work for the compactors, as this extra replay is **bounded by the shard minimum persist marker**, which means relatively little data would be duplicated.

Obviously new catalog instances / "the future" clusters will always have the value populated, and this minor replay is just for the currently live clusters.

### Rollout Plan

However despite the above probably being absolutely fine, I intend to deploy this write-only half today (or tomorrow, etc), and then merge the read half the next day. Because the partition key is derived from the YMD of the write date, all writes tomorrow (excluding backfill/old timestamps) will be for new partitions, and therefore have a proper partition-level persistence marker set (not 0),so we should have practically no parquet file duplication at all :tada:

The ingesters will populate todays partition persistence markers if they persist a batch for the given partition - basically "hot" partitions will be populated today anyway too.


Part of https://github.com/influxdata/influxdb_iox/issues/5638.

---

* refactor(db): persist marker for partition table (4e738e5b5)

      Adds a migration to add a column "persisted_sequence_number" that defines the
      inclusive upper-bound on sequencer writes materialised and uploaded to object
      store for the partition.

* feat(catalog): per-partition persist mark API (30908158d)

      Adds the "persisted_sequence_number" field to the Partition model, and updates
      the catalog API to read & update it.

* refactor: assert partition persistence ordering (3b6f54715)

      Assert the per-shard / per-partition persistence watermarks monotonically
      increase, and document the invariant.

      NOTE: this is not a new invariant, just a new assertion to validate it.

* feat: store per-partition persist markers (6f0876d5d)

      Changes the ingester to record the per-partition, maximum persisted sequencer
      offsets to the catalog. This will enable quick O(1) lookup in the future, but
      the currently persisted value is only used to assert the per-partition
      monotonic persist ordering invariant.