### PR TITLE
refactor: Clear up responsibilities of different parts of the compactor

### DIFF
--- a/compactor/src/cold.rs
+++ b/compactor/src/cold.rs
@@ -186,7 +186,9 @@ fn group_by_size(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{compact_one_partition, handler::CompactorConfig, parquet_file_filtering};
+    use crate::{
+        compact_one_partition, handler::CompactorConfig, parquet_file_filtering, ReadyToCompact,
+    };
     use ::parquet_file::storage::ParquetStorage;
     use arrow_util::assert_batches_sorted_eq;
     use backoff::BackoffConfig;
@@ -406,6 +408,20 @@ mod tests {
             &compactor.parquet_file_candidate_bytes,
         );
 
+        let parquet_file_filtering::FilteredFiles {
+            filter_result,
+            partition,
+        } = to_compact;
+
+        let files =
+            if let parquet_file_filtering::FilterResult::Proceed { files, .. } = filter_result {
+                files
+            } else {
+                panic!("Expected to get FilterResult::Proceed, got {filter_result:?}");
+            };
+
+        let to_compact = ReadyToCompact { files, partition };
+
         compact_one_partition(&compactor, to_compact, "cold")
             .await
             .unwrap();
@@ -586,6 +602,20 @@ mod tests {
             &compactor.parquet_file_candidate_gauge,
             &compactor.parquet_file_candidate_bytes,
         );
+
+        let parquet_file_filtering::FilteredFiles {
+            filter_result,
+            partition,
+        } = to_compact;
+
+        let files =
+            if let parquet_file_filtering::FilterResult::Proceed { files, .. } = filter_result {
+                files
+            } else {
+                panic!("Expected to get FilterResult::Proceed, got {filter_result:?}");
+            };
+
+        let to_compact = ReadyToCompact { files, partition };
 
         compact_one_partition(&compactor, to_compact, "cold")
             .await

--- a/compactor/src/cold.rs
+++ b/compactor/src/cold.rs
@@ -22,7 +22,7 @@ pub async fn compact(compactor: Arc<Compactor>) -> usize {
     debug!(compaction_type, "start collecting partitions to compact");
     let attributes = Attributes::from(&[("partition_type", compaction_type)]);
     let start_time = compactor.time_provider.now();
-    let (candidates, table_columns) = Backoff::new(&compactor.backoff_config)
+    let candidates = Backoff::new(&compactor.backoff_config)
         .retry_all_errors("cold_partitions_to_compact", || async {
             compactor
                 .cold_partitions_to_compact(compactor.config.max_number_partitions_per_shard)
@@ -57,7 +57,6 @@ pub async fn compact(compactor: Arc<Compactor>) -> usize {
         compaction_type,
         compact_in_parallel,
         candidates.into(),
-        table_columns,
     )
     .await;
 
@@ -191,7 +190,7 @@ mod tests {
     use ::parquet_file::storage::ParquetStorage;
     use arrow_util::assert_batches_sorted_eq;
     use backoff::BackoffConfig;
-    use data_types::{ColumnType, ColumnTypeCount, CompactionLevel};
+    use data_types::{ColumnType, CompactionLevel};
     use iox_query::exec::Executor;
     use iox_tests::util::{TestCatalog, TestParquetFileBuilder};
     use iox_time::{SystemProvider, TimeProvider};
@@ -291,20 +290,6 @@ mod tests {
         table.create_column("tag2", ColumnType::Tag).await;
         table.create_column("tag3", ColumnType::Tag).await;
         table.create_column("time", ColumnType::Time).await;
-        let table_column_types = vec![
-            ColumnTypeCount {
-                col_type: ColumnType::Tag,
-                count: 3,
-            },
-            ColumnTypeCount {
-                col_type: ColumnType::I64,
-                count: 1,
-            },
-            ColumnTypeCount {
-                col_type: ColumnType::Time,
-                count: 1,
-            },
-        ];
 
         let partition = table.with_shard(&shard).create_partition("part").await;
         let time = Arc::new(SystemProvider::new());
@@ -396,7 +381,7 @@ mod tests {
 
         // ------------------------------------------------
         // Compact
-        let (mut candidates, _table_columns) = compactor
+        let mut candidates = compactor
             .cold_partitions_to_compact(compactor.config.max_number_partitions_per_shard)
             .await
             .unwrap();
@@ -417,7 +402,6 @@ mod tests {
             c,
             parquet_files_for_compaction,
             compactor.config.memory_budget_bytes,
-            &table_column_types,
             &compactor.parquet_file_candidate_gauge,
             &compactor.parquet_file_candidate_bytes,
         );
@@ -531,20 +515,6 @@ mod tests {
         table.create_column("tag2", ColumnType::Tag).await;
         table.create_column("tag3", ColumnType::Tag).await;
         table.create_column("time", ColumnType::Time).await;
-        let table_column_types = vec![
-            ColumnTypeCount {
-                col_type: ColumnType::Tag,
-                count: 3,
-            },
-            ColumnTypeCount {
-                col_type: ColumnType::I64,
-                count: 1,
-            },
-            ColumnTypeCount {
-                col_type: ColumnType::Time,
-                count: 1,
-            },
-        ];
 
         let partition = table.with_shard(&shard).create_partition("part").await;
         let time = Arc::new(SystemProvider::new());
@@ -592,7 +562,7 @@ mod tests {
 
         // ------------------------------------------------
         // Compact
-        let (mut candidates, _table_columns) = compactor
+        let mut candidates = compactor
             .cold_partitions_to_compact(compactor.config.max_number_partitions_per_shard)
             .await
             .unwrap();
@@ -613,7 +583,6 @@ mod tests {
             Arc::clone(&c),
             parquet_files_for_compaction,
             compactor.config.memory_budget_bytes,
-            &table_column_types,
             &compactor.parquet_file_candidate_gauge,
             &compactor.parquet_file_candidate_bytes,
         );

--- a/compactor/src/cold.rs
+++ b/compactor/src/cold.rs
@@ -111,7 +111,7 @@ async fn full_compaction(
     let parquet_files_for_compaction =
         parquet_file_lookup::ParquetFilesForCompaction::for_partition_with_size_overrides(
             Arc::clone(&compactor.catalog),
-            partition.id(),
+            Arc::clone(&partition),
             size_overrides,
         )
         .await
@@ -392,7 +392,7 @@ mod tests {
         let parquet_files_for_compaction =
             parquet_file_lookup::ParquetFilesForCompaction::for_partition_with_size_overrides(
                 Arc::clone(&compactor.catalog),
-                c.id(),
+                Arc::clone(&c),
                 &size_overrides,
             )
             .await
@@ -573,7 +573,7 @@ mod tests {
         let parquet_files_for_compaction =
             parquet_file_lookup::ParquetFilesForCompaction::for_partition_with_size_overrides(
                 Arc::clone(&compactor.catalog),
-                c.id(),
+                Arc::clone(&c),
                 &size_overrides,
             )
             .await

--- a/compactor/src/cold.rs
+++ b/compactor/src/cold.rs
@@ -186,9 +186,7 @@ fn group_by_size(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{
-        compact_one_partition, handler::CompactorConfig, parquet_file_filtering, ReadyToCompact,
-    };
+    use crate::{compact_one_partition, handler::CompactorConfig, parquet_file_filtering};
     use ::parquet_file::storage::ParquetStorage;
     use arrow_util::assert_batches_sorted_eq;
     use backoff::BackoffConfig;
@@ -408,19 +406,7 @@ mod tests {
             &compactor.parquet_file_candidate_bytes,
         );
 
-        let parquet_file_filtering::FilteredFiles {
-            filter_result,
-            partition,
-        } = to_compact;
-
-        let files =
-            if let parquet_file_filtering::FilterResult::Proceed { files, .. } = filter_result {
-                files
-            } else {
-                panic!("Expected to get FilterResult::Proceed, got {filter_result:?}");
-            };
-
-        let to_compact = ReadyToCompact { files, partition };
+        let to_compact = to_compact.into();
 
         compact_one_partition(&compactor, to_compact, "cold")
             .await
@@ -603,19 +589,7 @@ mod tests {
             &compactor.parquet_file_candidate_bytes,
         );
 
-        let parquet_file_filtering::FilteredFiles {
-            filter_result,
-            partition,
-        } = to_compact;
-
-        let files =
-            if let parquet_file_filtering::FilterResult::Proceed { files, .. } = filter_result {
-                files
-            } else {
-                panic!("Expected to get FilterResult::Proceed, got {filter_result:?}");
-            };
-
-        let to_compact = ReadyToCompact { files, partition };
+        let to_compact = to_compact.into();
 
         compact_one_partition(&compactor, to_compact, "cold")
             .await

--- a/compactor/src/compact.rs
+++ b/compactor/src/compact.rs
@@ -647,16 +647,35 @@ fn estimate_arrow_bytes_for_file(columns: &[ColumnTypeCount], row_count: i64) ->
 }
 
 #[cfg(test)]
-mod tests {
+pub mod tests {
     use super::*;
     use data_types::{
         ColumnId, ColumnSet, CompactionLevel, ParquetFileParams, SequenceNumber, ShardIndex,
         Timestamp,
     };
-    use iox_tests::util::TestCatalog;
+    use iox_tests::util::{TestCatalog, TestPartition};
     use iox_time::SystemProvider;
     use std::time::Duration;
     use uuid::Uuid;
+
+    impl PartitionCompactionCandidateWithInfo {
+        pub(crate) async fn from_test_partition(test_partition: &TestPartition) -> Self {
+            Self {
+                table: Arc::new(test_partition.table.table.clone()),
+                table_schema: Arc::new(test_partition.table.catalog_schema().await),
+                column_type_counts: Vec::new(), // not relevant
+                namespace: Arc::new(test_partition.namespace.namespace.clone()),
+                candidate: PartitionParam {
+                    partition_id: test_partition.partition.id,
+                    shard_id: test_partition.partition.shard_id,
+                    namespace_id: test_partition.namespace.namespace.id,
+                    table_id: test_partition.partition.table_id,
+                },
+                sort_key: test_partition.partition.sort_key(),
+                partition_key: test_partition.partition.partition_key.clone(),
+            }
+        }
+    }
 
     #[test]
     fn test_estimate_arrow_bytes_for_file() {

--- a/compactor/src/hot.rs
+++ b/compactor/src/hot.rs
@@ -506,7 +506,7 @@ mod tests {
         let parquet_files_for_compaction =
             parquet_file_lookup::ParquetFilesForCompaction::for_partition_with_size_overrides(
                 Arc::clone(&compactor.catalog),
-                c.id(),
+                Arc::clone(&c),
                 &size_overrides,
             )
             .await

--- a/compactor/src/hot.rs
+++ b/compactor/src/hot.rs
@@ -77,7 +77,6 @@ mod tests {
         handler::CompactorConfig,
         parquet_file_filtering, parquet_file_lookup,
         tests::{test_setup, TestSetup},
-        ReadyToCompact,
     };
     use arrow_util::assert_batches_sorted_eq;
     use backoff::BackoffConfig;
@@ -516,19 +515,7 @@ mod tests {
             &compactor.parquet_file_candidate_bytes,
         );
 
-        let parquet_file_filtering::FilteredFiles {
-            filter_result,
-            partition,
-        } = to_compact;
-
-        let files =
-            if let parquet_file_filtering::FilterResult::Proceed { files, .. } = filter_result {
-                files
-            } else {
-                panic!("Expected to get FilterResult::Proceed, got {filter_result:?}");
-            };
-
-        let to_compact = ReadyToCompact { files, partition };
+        let to_compact = to_compact.into();
 
         compact_one_partition(&compactor, to_compact, "hot")
             .await

--- a/compactor/src/hot.rs
+++ b/compactor/src/hot.rs
@@ -13,7 +13,7 @@ pub async fn compact(compactor: Arc<Compactor>) -> usize {
     debug!(compaction_type, "start collecting partitions to compact");
     let attributes = Attributes::from(&[("partition_type", compaction_type)]);
     let start_time = compactor.time_provider.now();
-    let (candidates, table_columns) = Backoff::new(&compactor.backoff_config)
+    let candidates = Backoff::new(&compactor.backoff_config)
         .retry_all_errors("hot_partitions_to_compact", || async {
             compactor
                 .hot_partitions_to_compact(
@@ -52,7 +52,6 @@ pub async fn compact(compactor: Arc<Compactor>) -> usize {
         compaction_type,
         compact_in_parallel,
         candidates.into(),
-        table_columns,
     )
     .await;
 
@@ -81,7 +80,7 @@ mod tests {
     };
     use arrow_util::assert_batches_sorted_eq;
     use backoff::BackoffConfig;
-    use data_types::{ColumnType, ColumnTypeCount, CompactionLevel, ParquetFileId};
+    use data_types::{ColumnType, CompactionLevel, ParquetFileId};
     use iox_query::exec::Executor;
     use iox_tests::util::{TestCatalog, TestParquetFileBuilder};
     use iox_time::{SystemProvider, TimeProvider};
@@ -233,7 +232,7 @@ mod tests {
         partition6.create_parquet_file_catalog_record(pf6_2).await;
 
         // partition candidates: partitions with L0 and overlapped L1
-        let (mut candidates, table_columns) = compactor
+        let mut candidates = compactor
             .hot_partitions_to_compact(
                 compactor.config.max_number_partitions_per_shard,
                 compactor
@@ -243,23 +242,7 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(candidates.len(), 6);
-
-        assert_eq!(table_columns.len(), 1);
-        let mut cols = table_columns.get(&table.table.id).unwrap().clone();
-        assert_eq!(cols.len(), 5);
-        cols.sort_by_key(|c| c.col_type);
-        let mut expected_cols = vec![
-            ColumnTypeCount::new(ColumnType::Time, 1),
-            ColumnTypeCount::new(ColumnType::I64, 1),
-            ColumnTypeCount::new(ColumnType::Tag, 1),
-            ColumnTypeCount::new(ColumnType::String, 1),
-            ColumnTypeCount::new(ColumnType::Bool, 1),
-        ];
-        expected_cols.sort_by_key(|c| c.col_type);
-        assert_eq!(cols, expected_cols);
-
         candidates.sort_by_key(|c| c.candidate.partition_id);
-
         {
             let mut repos = compactor.catalog.repositories().await;
             let skipped_compactions = repos.partitions().list_skipped_compactions().await.unwrap();
@@ -281,7 +264,6 @@ mod tests {
             "hot",
             mock_compactor.compaction_function(),
             candidates.into(),
-            table_columns,
         )
         .await;
 
@@ -409,20 +391,7 @@ mod tests {
         table.create_column("tag2", ColumnType::Tag).await;
         table.create_column("tag3", ColumnType::Tag).await;
         table.create_column("time", ColumnType::Time).await;
-        let table_column_types = vec![
-            ColumnTypeCount {
-                col_type: ColumnType::Tag,
-                count: 3,
-            },
-            ColumnTypeCount {
-                col_type: ColumnType::I64,
-                count: 1,
-            },
-            ColumnTypeCount {
-                col_type: ColumnType::Time,
-                count: 1,
-            },
-        ];
+
         let partition = table.with_shard(&shard).create_partition("part").await;
         let time = Arc::new(SystemProvider::new());
         let config = CompactorConfig {
@@ -521,7 +490,7 @@ mod tests {
 
         // ------------------------------------------------
         // Compact
-        let (mut candidates, _table_columns) = compactor
+        let mut candidates = compactor
             .hot_partitions_to_compact(
                 compactor.config.max_number_partitions_per_shard,
                 compactor
@@ -547,7 +516,6 @@ mod tests {
             c,
             parquet_files_for_compaction,
             compactor.config.memory_budget_bytes,
-            &table_column_types,
             &compactor.parquet_file_candidate_gauge,
             &compactor.parquet_file_candidate_bytes,
         );

--- a/compactor/src/lib.rs
+++ b/compactor/src/lib.rs
@@ -88,7 +88,7 @@ async fn compact_candidates_with_memory_budget<C, Fut>(
         let parquet_files_for_compaction =
             parquet_file_lookup::ParquetFilesForCompaction::for_partition(
                 Arc::clone(&compactor.catalog),
-                partition_id,
+                Arc::clone(&partition),
             )
             .await;
         let to_compact = match parquet_files_for_compaction {

--- a/compactor/src/parquet_file_combining.rs
+++ b/compactor/src/parquet_file_combining.rs
@@ -734,11 +734,7 @@ mod tests {
             .with_line_protocol(&lp)
             .with_max_seq(20) // This should be irrelevant because this is a level 1 file
             .with_compaction_level(CompactionLevel::FileNonOverlapped); // Prev compaction
-        let level_1_file = partition
-            .create_parquet_file(builder)
-            .await
-            .parquet_file
-            .into();
+        let level_1_file = partition.create_parquet_file(builder).await.into();
 
         let lp = vec![
             "table,tag1=WA field_int=1000i 8000", // will be eliminated due to duplicate
@@ -749,11 +745,7 @@ mod tests {
         let builder = TestParquetFileBuilder::default()
             .with_line_protocol(&lp)
             .with_max_seq(1);
-        let level_0_max_seq_1 = partition
-            .create_parquet_file(builder)
-            .await
-            .parquet_file
-            .into();
+        let level_0_max_seq_1 = partition.create_parquet_file(builder).await.into();
 
         let lp = vec![
             "table,tag1=WA field_int=1500i 8000", // latest duplicate and kept
@@ -764,11 +756,7 @@ mod tests {
         let builder = TestParquetFileBuilder::default()
             .with_line_protocol(&lp)
             .with_max_seq(2);
-        let level_0_max_seq_2 = partition
-            .create_parquet_file(builder)
-            .await
-            .parquet_file
-            .into();
+        let level_0_max_seq_2 = partition.create_parquet_file(builder).await.into();
 
         let lp = vec![
             "table,tag1=VT field_int=88i 10000", // will be deduplicated with level_0_max_seq_1
@@ -779,22 +767,16 @@ mod tests {
             .with_line_protocol(&lp)
             .with_max_seq(5) // This should be irrelevant because this is a level 1 file
             .with_compaction_level(CompactionLevel::FileNonOverlapped); // Prev compaction
-        let level_1_with_duplicates = partition
-            .create_parquet_file(builder)
-            .await
-            .parquet_file
-            .into();
+        let level_1_with_duplicates = partition.create_parquet_file(builder).await.into();
 
         let lp = vec!["table,tag2=OH,tag3=21 field_int=21i 36000"].join("\n");
         let builder = TestParquetFileBuilder::default()
             .with_line_protocol(&lp)
             .with_min_time(0)
-            .with_max_time(36000);
-        // Will put the group size between "small" and "large"
-        let medium_file = CompactorParquetFile::with_size_override(
-            partition.create_parquet_file(builder).await.parquet_file,
-            50 * 1024 * 1024,
-        );
+            .with_max_time(36000)
+            // Will put the group size between "small" and "large"
+            .with_size_override(50 * 1024 * 1024);
+        let medium_file = partition.create_parquet_file(builder).await.into();
 
         let lp = vec![
             "table,tag1=VT field_int=10i 68000",
@@ -804,12 +786,10 @@ mod tests {
         let builder = TestParquetFileBuilder::default()
             .with_line_protocol(&lp)
             .with_min_time(36001)
-            .with_max_time(136000);
-        // Will put the group size two multiples over "large"
-        let large_file = CompactorParquetFile::with_size_override(
-            partition.create_parquet_file(builder).await.parquet_file,
-            180 * 1024 * 1024,
-        );
+            .with_max_time(136000)
+            // Will put the group size two multiples over "large"
+            .with_size_override(180 * 1024 * 1024);
+        let large_file = partition.create_parquet_file(builder).await.into();
 
         // Order here isn't relevant; the chunk order should ensure the level 1 files are ordered
         // first, then the other files by max seq num.

--- a/compactor/src/parquet_file_combining.rs
+++ b/compactor/src/parquet_file_combining.rs
@@ -713,6 +713,7 @@ mod tests {
         let candidate_partition = Arc::new(PartitionCompactionCandidateWithInfo {
             table: Arc::new(table.table.clone()),
             table_schema: Arc::new(table_schema),
+            column_type_counts: Vec::new(), // not relevant
             namespace: Arc::new(ns.namespace.clone()),
             candidate: PartitionParam {
                 partition_id: partition.partition.id,

--- a/compactor/src/parquet_file_filtering.rs
+++ b/compactor/src/parquet_file_filtering.rs
@@ -118,7 +118,7 @@ pub(crate) fn filter_parquet_files(
     let mut total_estimated_budget = 0;
     for level_0_file in level_0 {
         // Estimate memory needed for this L0 file
-        let l0_estimated_file_bytes = partition.estimated_arrow_bytes(level_0_file.row_count());
+        let l0_estimated_file_bytes = level_0_file.estimated_arrow_bytes();
 
         // Note: even though we can stop here if the l0_estimated_file_bytes is larger than the
         // given budget,we still continue estimated the memory needed for its overlapped L1 to
@@ -132,7 +132,7 @@ pub(crate) fn filter_parquet_files(
         // Estimate memory needed for each of L1
         let current_l1_estimated_file_bytes: Vec<_> = overlaps
             .iter()
-            .map(|file| partition.estimated_arrow_bytes(file.row_count()))
+            .map(|file| file.estimated_arrow_bytes())
             .collect();
         let estimated_file_bytes =
             l0_estimated_file_bytes + current_l1_estimated_file_bytes.iter().sum::<u64>();
@@ -752,7 +752,8 @@ mod tests {
                 created_at: Timestamp::new(12),
                 column_set: ColumnSet::new(std::iter::empty()),
             };
-            f.into()
+            // Estimated arrow bytes for one file with a tag, a time and 11 rows = 1176
+            CompactorParquetFile::new(f, 1176)
         }
 
         fn build_partition_with_extra_info(self) -> PartitionCompactionCandidateWithInfo {

--- a/iox_tests/src/util.rs
+++ b/iox_tests/src/util.rs
@@ -508,6 +508,7 @@ impl TestPartition {
             min_time,
             max_time,
             file_size_bytes,
+            size_override,
             creation_time,
             compaction_level,
             to_delete,
@@ -563,6 +564,7 @@ impl TestPartition {
             min_time,
             max_time,
             file_size_bytes: Some(file_size_bytes.unwrap_or(real_file_size_bytes as u64)),
+            size_override,
             creation_time,
             compaction_level,
             to_delete,
@@ -588,6 +590,7 @@ impl TestPartition {
             min_time,
             max_time,
             file_size_bytes,
+            size_override,
             creation_time,
             compaction_level,
             to_delete,
@@ -657,6 +660,7 @@ impl TestPartition {
             shard: Arc::clone(&self.shard),
             partition: Arc::clone(self),
             parquet_file,
+            size_override,
         }
     }
 }
@@ -671,6 +675,7 @@ pub struct TestParquetFileBuilder {
     min_time: i64,
     max_time: i64,
     file_size_bytes: Option<u64>,
+    size_override: Option<i64>,
     creation_time: i64,
     compaction_level: CompactionLevel,
     to_delete: bool,
@@ -688,6 +693,7 @@ impl Default for TestParquetFileBuilder {
             min_time: now().timestamp_nanos(),
             max_time: now().timestamp_nanos(),
             file_size_bytes: None,
+            size_override: None,
             creation_time: 1,
             compaction_level: CompactionLevel::Initial,
             to_delete: false,
@@ -767,6 +773,12 @@ impl TestParquetFileBuilder {
         self.row_count = Some(row_count);
         self
     }
+
+    /// Specify the size override to use for a CompactorParquetFile
+    pub fn with_size_override(mut self, size_override: i64) -> Self {
+        self.size_override = Some(size_override);
+        self
+    }
 }
 
 async fn update_catalog_sort_key_if_needed(
@@ -834,6 +846,7 @@ pub struct TestParquetFile {
     pub shard: Arc<TestShard>,
     pub partition: Arc<TestPartition>,
     pub parquet_file: ParquetFile,
+    pub size_override: Option<i64>,
 }
 
 impl TestParquetFile {


### PR DESCRIPTION
This is some more refactoring that I think clears up and separates some responsibilities:

- Estimating bytes is now done by the `PartitionCompactionCandidateWithInfo` because it keeps track of the column type counts.
- When `CompactorParquetFile`s are created, they give their number of rows to the partition and ask for their estimated bytes, then that gets carried with them.
- This makes it easier and clearer to test filtering based on the memory budget.
- The `FilteredFiles`' `FilterResult` now combines its data and its states, so that, for example, `NothingToCompact` doesn't need any data.
- There's a new type `ReadyToCompact` that gets created from a `FilterResult::Proceed` because the compaction after that point doesn't need to know about the memory budget at all.

I'm hoping to eventually get a clear pipeline of states like `Partition` -> `PartitionCompactionCandidateWithInfo` -> `FilteredFiles` -> `ReadyToCompact` that's clearer to follow, the code isn't quite there yet but this gets us closer.

Next, I think I'm going to be able to generalize some functions to work for L0+L1 -> L1 compaction as well as L1+L2 -> L2 compaction.