### PR TITLE
feat: Re-enable full compaction to level 2, limited by the memory budget

### DIFF
--- a/compactor/src/cold.rs
+++ b/compactor/src/cold.rs
@@ -869,6 +869,9 @@ mod tests {
             .map(|f| (f.id.get(), f.compaction_level))
             .collect();
 
+        // The initial files are: L0 1-4, L1 5-6. The first step of cold compaction took files 1-5
+        // and compacted them and split them into files 7 and 8. The second step of cold compaction
+        // took 6, 7, and 8 and combined them all into file 9.
         assert_eq!(files_and_levels, vec![(9, CompactionLevel::Final)]);
 
         // ------------------------------------------------

--- a/compactor/src/cold.rs
+++ b/compactor/src/cold.rs
@@ -2,18 +2,15 @@
 //! fully compacted.
 
 use crate::{
-    compact::{Compactor, PartitionCompactionCandidateWithInfo},
-    compact_candidates_with_memory_budget, compact_in_parallel,
-    parquet_file::CompactorParquetFile,
-    parquet_file_combining,
-    parquet_file_lookup::{self, ParquetFilesForCompaction},
+    compact::Compactor, compact_candidates_with_memory_budget, compact_in_parallel,
+    parquet_file_combining, parquet_file_lookup,
 };
 use backoff::Backoff;
-use data_types::{CompactionLevel, ParquetFileId};
+use data_types::CompactionLevel;
 use metric::Attributes;
 use observability_deps::tracing::*;
-use snafu::{ResultExt, Snafu};
-use std::{collections::HashMap, sync::Arc};
+use snafu::Snafu;
+use std::sync::Arc;
 
 /// Cold compaction. Returns the number of compacted partitions.
 pub async fn compact(compactor: Arc<Compactor>) -> usize {
@@ -55,7 +52,20 @@ pub async fn compact(compactor: Arc<Compactor>) -> usize {
     compact_candidates_with_memory_budget(
         Arc::clone(&compactor),
         compaction_type,
+        CompactionLevel::Initial,
         compact_in_parallel,
+        true, // split
+        candidates.clone().into(),
+    )
+    .await;
+
+    // Compact level 1 files in parallel ("full compaction")
+    compact_candidates_with_memory_budget(
+        Arc::clone(&compactor),
+        compaction_type,
+        CompactionLevel::FileNonOverlapped,
+        compact_in_parallel,
+        false, // don't split
         candidates.into(),
     )
     .await;
@@ -92,149 +102,21 @@ pub(crate) enum Error {
     },
 }
 
-/// Given a partition that needs to have full compaction run,
-///
-/// - Select all level 1 and level 2 files in the partition.
-///   - This method assumes the level 1 files don't overlap with each other but might overlap with
-///     existing level 2 files.
-///   - Any level 0 files will be ignored.
-/// - Sort the level 1 files by max_sequence_number.
-/// - Take level 1 files with any overlapping level 2 files in the list until the current group
-///   size exceeds the memory budget or the max_desired_file_size_bytes
-/// - Compact each group into a new level 2 file, no splitting
-///
-/// Uses a hashmap of size overrides to allow mocking of file sizes.
-#[allow(dead_code)]
-async fn full_compaction(
-    compactor: &Compactor,
-    partition: Arc<PartitionCompactionCandidateWithInfo>,
-    size_overrides: &HashMap<ParquetFileId, i64>,
-) -> Result<(), Error> {
-    // select all files in this partition
-    let parquet_files_for_compaction =
-        parquet_file_lookup::ParquetFilesForCompaction::for_partition_with_size_overrides(
-            Arc::clone(&compactor.catalog),
-            Arc::clone(&partition),
-            size_overrides,
-        )
-        .await
-        .context(LookupSnafu)?;
-
-    let ParquetFilesForCompaction {
-        level_1,
-        .. // Ignore other levels
-    } = parquet_files_for_compaction;
-
-    let groups = group_by_size(level_1, compactor.config.max_desired_file_size_bytes);
-
-    for group in groups {
-        if group.len() == 1 {
-            // upgrade the one file to l2, don't run compaction
-            let mut repos = compactor.catalog.repositories().await;
-
-            repos
-                .parquet_files()
-                .update_compaction_level(&[group[0].id()], CompactionLevel::Final)
-                .await
-                .context(UpgradingSnafu)?;
-        } else {
-            parquet_file_combining::compact_final_no_splits(
-                group,
-                Arc::clone(&partition),
-                Arc::clone(&compactor.catalog),
-                compactor.store.clone(),
-                Arc::clone(&compactor.exec),
-                Arc::clone(&compactor.time_provider),
-                &compactor.compaction_input_file_bytes,
-            )
-            .await
-            .map_err(|e| Error::Combining {
-                source: Box::new(e),
-            })?;
-        }
-    }
-
-    Ok(())
-}
-
-/// Given a list of parquet files and a size limit, iterate through the list in order. Create
-/// groups based on when the size of files in the group exceeds the size limit.
-fn group_by_size(
-    files: Vec<CompactorParquetFile>,
-    max_file_size_bytes: u64,
-) -> Vec<Vec<CompactorParquetFile>> {
-    let num_files = files.len();
-    let mut group_file_size_bytes = 0;
-
-    let mut group = Vec::with_capacity(num_files);
-    let mut groups = Vec::with_capacity(num_files);
-
-    for file in files {
-        group_file_size_bytes += file.file_size_bytes() as u64;
-        group.push(file);
-
-        if group_file_size_bytes >= max_file_size_bytes {
-            groups.push(group);
-            group = Vec::with_capacity(num_files);
-            group_file_size_bytes = 0;
-        }
-    }
-    if !group.is_empty() {
-        groups.push(group);
-    }
-
-    groups
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{compact_one_partition, handler::CompactorConfig, parquet_file_filtering};
+    use crate::{
+        compact_one_partition, handler::CompactorConfig, parquet_file_filtering,
+        ParquetFilesForCompaction,
+    };
     use ::parquet_file::storage::ParquetStorage;
     use arrow_util::assert_batches_sorted_eq;
     use backoff::BackoffConfig;
-    use data_types::{ColumnType, CompactionLevel};
+    use data_types::{ColumnType, CompactionLevel, ParquetFileId};
     use iox_query::exec::Executor;
     use iox_tests::util::{TestCatalog, TestParquetFileBuilder};
     use iox_time::{SystemProvider, TimeProvider};
-    use std::time::Duration;
-
-    #[tokio::test]
-    async fn test_group_by_size() {
-        // Setup - create a bunch of files
-        let catalog = TestCatalog::new();
-        let ns = catalog.create_namespace("ns").await;
-        let shard = ns.create_shard(1).await;
-        let table = ns.create_table("table").await;
-        table.create_column("field_int", ColumnType::I64).await;
-        table.create_column("time", ColumnType::Time).await;
-        let partition = table.with_shard(&shard).create_partition("part").await;
-        let arbitrary_lp = "table, field_int=9000i 1010101";
-
-        let builder = TestParquetFileBuilder::default().with_line_protocol(arbitrary_lp);
-        let big = partition.create_parquet_file(builder).await.parquet_file;
-        let big = CompactorParquetFile::with_size_override(big, 1_000);
-
-        let builder = TestParquetFileBuilder::default().with_line_protocol(arbitrary_lp);
-        let little = partition.create_parquet_file(builder).await.parquet_file;
-        let little = CompactorParquetFile::with_size_override(little, 2);
-
-        // Empty in, empty out
-        let groups = group_by_size(vec![], 0);
-        assert!(groups.is_empty(), "Expected empty, got: {:?}", groups);
-
-        // One file in, one group out, even if the file limit is 0
-        let groups = group_by_size(vec![big.clone()], 0);
-        assert_eq!(groups, &[&[big.clone()]]);
-
-        // If the first file is already over the limit, return 2 groups
-        let groups = group_by_size(vec![big.clone(), little.clone()], 100);
-        assert_eq!(groups, &[&[big.clone()], &[little.clone()]]);
-
-        // If the first file does not go over the limit, add another file to the group
-        let groups = group_by_size(vec![little.clone(), big.clone()], 100);
-        assert_eq!(groups, &[&[little, big]]);
-    }
+    use std::{collections::HashMap, time::Duration};
 
     #[tokio::test]
     async fn test_compact_remaining_level_0_files_many_files() {
@@ -418,7 +300,7 @@ mod tests {
 
         let to_compact = to_compact.into();
 
-        compact_one_partition(&compactor, to_compact, "cold")
+        compact_one_partition(&compactor, to_compact, "cold", true)
             .await
             .unwrap();
 
@@ -608,7 +490,7 @@ mod tests {
 
         let to_compact = to_compact.into();
 
-        compact_one_partition(&compactor, to_compact, "cold")
+        compact_one_partition(&compactor, to_compact, "cold", true)
             .await
             .unwrap();
 
@@ -670,7 +552,33 @@ mod tests {
         );
 
         // Full compaction will now combine the two level 1 files into one level 2 file
-        full_compaction(&compactor, partition, &size_overrides)
+        let parquet_files_for_compaction =
+            parquet_file_lookup::ParquetFilesForCompaction::for_partition_with_size_overrides(
+                Arc::clone(&compactor.catalog),
+                Arc::clone(&partition),
+                &size_overrides,
+            )
+            .await
+            .unwrap();
+
+        let ParquetFilesForCompaction {
+            level_1,
+            level_2,
+            .. // Ignore other levels
+        } = parquet_files_for_compaction;
+
+        let to_compact = parquet_file_filtering::filter_parquet_files(
+            Arc::clone(&partition),
+            level_1,
+            level_2,
+            compactor.config.memory_budget_bytes,
+            &compactor.parquet_file_candidate_gauge,
+            &compactor.parquet_file_candidate_bytes,
+        );
+
+        let to_compact = to_compact.into();
+
+        compact_one_partition(&compactor, to_compact, "cold", false)
             .await
             .unwrap();
 
@@ -748,15 +656,12 @@ mod tests {
 
         // Should have 1 non-soft-deleted files:
         //
-        // - the newly created file that was upgraded to level 1. Final compaction to level 2 is
-        //   currently disabled.
+        // - the newly created file that was upgraded to level 1 then to level 2
         let mut files = catalog.list_by_table_not_to_delete(table.table.id).await;
         assert_eq!(files.len(), 1);
         let file = files.pop().unwrap();
         assert_eq!(file.id.get(), 1); // ID doesn't change because the file doesn't get rewritten
-
-        // Final compaction is currently disabled.
-        assert_eq!(file.compaction_level, CompactionLevel::FileNonOverlapped);
+        assert_eq!(file.compaction_level, CompactionLevel::Final);
 
         // ------------------------------------------------
         // Verify the parquet file content
@@ -953,23 +858,44 @@ mod tests {
 
         compact(compactor).await;
 
-        // Full cold compaction to level 2 is currently disabled.
-        let files = catalog.list_by_table_not_to_delete(table.table.id).await;
-        assert_eq!(files.len(), 3);
+        // Should have 1 non-soft-deleted file:
+        //
+        // - the level 2 file created after combining all 3 level 1 files created by the first step
+        //   of compaction to compact remaining level 0 files
+        let mut files = catalog.list_by_table_not_to_delete(table.table.id).await;
+        assert_eq!(files.len(), 1, "{files:?}");
         let files_and_levels: Vec<_> = files
             .iter()
             .map(|f| (f.id.get(), f.compaction_level))
             .collect();
-        assert_eq!(
-            files_and_levels,
-            vec![
-                (
-                    pf6.parquet_file.id.get(),
-                    CompactionLevel::FileNonOverlapped
-                ),
-                (7, CompactionLevel::FileNonOverlapped),
-                (8, CompactionLevel::FileNonOverlapped),
-            ]
+
+        assert_eq!(files_and_levels, vec![(9, CompactionLevel::Final)]);
+
+        // ------------------------------------------------
+        // Verify the parquet file content
+        let file = files.pop().unwrap();
+        let batches = table.read_parquet_file(file).await;
+        assert_batches_sorted_eq!(
+            &[
+                "+-----------+------+------+------+--------------------------------+",
+                "| field_int | tag1 | tag2 | tag3 | time                           |",
+                "+-----------+------+------+------+--------------------------------+",
+                "| 10        | VT   |      |      | 1970-01-01T00:00:00.000000020Z |",
+                "| 10        | VT   |      |      | 1970-01-01T00:00:00.000006Z    |",
+                "| 10        | VT   |      |      | 1970-01-01T00:00:00.000010Z    |",
+                "| 1000      | WA   |      |      | 1970-01-01T00:00:00.000000010Z |",
+                "| 1500      | WA   |      |      | 1970-01-01T00:00:00.000008Z    |",
+                "| 1600      |      | WA   | 10   | 1970-01-01T00:00:00.000028Z    |",
+                "| 1601      |      | PA   | 15   | 1970-01-01T00:00:00.000000009Z |",
+                "| 20        |      | VT   | 20   | 1970-01-01T00:00:00.000026Z    |",
+                "| 21        |      | OH   | 21   | 1970-01-01T00:00:00.000000025Z |",
+                "| 270       | UT   |      |      | 1970-01-01T00:00:00.000025Z    |",
+                "| 421       |      | OH   | 21   | 1970-01-01T00:00:00.000091Z    |",
+                "| 70        | UT   |      |      | 1970-01-01T00:00:00.000020Z    |",
+                "| 81601     |      | PA   | 15   | 1970-01-01T00:00:00.000090Z    |",
+                "+-----------+------+------+------+--------------------------------+",
+            ],
+            &batches
         );
     }
 }

--- a/compactor/src/cold.rs
+++ b/compactor/src/cold.rs
@@ -94,10 +94,13 @@ pub(crate) enum Error {
 
 /// Given a partition that needs to have full compaction run,
 ///
-/// - Select all files in the partition, which this method assumes will only be level 1
-///   without overlaps (any level 0 and level 2 files passed into this function will be ignored)
-/// - Split the files into groups based on size: take files in the list until the current group size
-///   is greater than max_desired_file_size_bytes
+/// - Select all level 1 and level 2 files in the partition.
+///   - This method assumes the level 1 files don't overlap with each other but might overlap with
+///     existing level 2 files.
+///   - Any level 0 files will be ignored.
+/// - Sort the level 1 files by max_sequence_number.
+/// - Take level 1 files with any overlapping level 2 files in the list until the current group
+///   size exceeds the memory budget or the max_desired_file_size_bytes
 /// - Compact each group into a new level 2 file, no splitting
 ///
 /// Uses a hashmap of size overrides to allow mocking of file sizes.

--- a/compactor/src/hot.rs
+++ b/compactor/src/hot.rs
@@ -2,6 +2,7 @@
 
 use crate::{compact::Compactor, compact_candidates_with_memory_budget, compact_in_parallel};
 use backoff::Backoff;
+use data_types::CompactionLevel;
 use metric::Attributes;
 use observability_deps::tracing::*;
 use std::sync::Arc;
@@ -50,7 +51,9 @@ pub async fn compact(compactor: Arc<Compactor>) -> usize {
     compact_candidates_with_memory_budget(
         Arc::clone(&compactor),
         compaction_type,
+        CompactionLevel::Initial,
         compact_in_parallel,
+        true, // split
         candidates.into(),
     )
     .await;
@@ -263,7 +266,9 @@ mod tests {
         compact_candidates_with_memory_budget(
             Arc::clone(&compactor),
             "hot",
+            CompactionLevel::Initial,
             mock_compactor.compaction_function(),
+            true,
             candidates.into(),
         )
         .await;
@@ -525,7 +530,7 @@ mod tests {
 
         let to_compact = to_compact.into();
 
-        compact_one_partition(&compactor, to_compact, "hot")
+        compact_one_partition(&compactor, to_compact, "hot", true)
             .await
             .unwrap();
 

--- a/compactor/src/lib.rs
+++ b/compactor/src/lib.rs
@@ -50,10 +50,12 @@ use std::{collections::VecDeque, sync::Arc};
 async fn compact_candidates_with_memory_budget<C, Fut>(
     compactor: Arc<Compactor>,
     compaction_type: &'static str,
+    initial_level: CompactionLevel,
     compact_function: C,
+    split: bool,
     mut candidates: VecDeque<Arc<PartitionCompactionCandidateWithInfo>>,
 ) where
-    C: Fn(Arc<Compactor>, Vec<ReadyToCompact>, &'static str) -> Fut + Send + Sync + 'static,
+    C: Fn(Arc<Compactor>, Vec<ReadyToCompact>, &'static str, bool) -> Fut + Send + Sync + 'static,
     Fut: futures::Future<Output = ()> + Send,
 {
     let mut remaining_budget_bytes = compactor.config.memory_budget_bytes;
@@ -111,13 +113,22 @@ async fn compact_candidates_with_memory_budget<C, Fut>(
                 let ParquetFilesForCompaction {
                     level_0,
                     level_1,
-                    .. // Ignore other levels
+                    level_2,
                 } = parquet_files_for_compaction;
+
+                let (level_n, level_n_plus_1) = match initial_level {
+                    CompactionLevel::Initial => (level_0, level_1),
+                    CompactionLevel::FileNonOverlapped => (level_1, level_2),
+                    _ => {
+                        // Focusing on compacting any other level is a bug
+                        panic!("Unsupported initial compaction level: {initial_level:?}");
+                    }
+                };
 
                 let to_compact = parquet_file_filtering::filter_parquet_files(
                     Arc::clone(&partition),
-                    level_0,
-                    level_1,
+                    level_n,
+                    level_n_plus_1,
                     remaining_budget_bytes,
                     &compactor.parquet_file_candidate_gauge,
                     &compactor.parquet_file_candidate_bytes,
@@ -200,6 +211,7 @@ async fn compact_candidates_with_memory_budget<C, Fut>(
                 Arc::clone(&compactor),
                 parallel_compacting_candidates,
                 compaction_type,
+                split,
             )
             .await;
 
@@ -227,6 +239,7 @@ async fn compact_in_parallel(
     compactor: Arc<Compactor>,
     groups: Vec<ReadyToCompact>,
     compaction_type: &'static str,
+    split: bool,
 ) {
     let mut handles = Vec::with_capacity(groups.len());
     for group in groups {
@@ -234,7 +247,8 @@ async fn compact_in_parallel(
         let handle = tokio::task::spawn(async move {
             let partition_id = group.partition.id();
             debug!(?partition_id, compaction_type, "compaction starting");
-            let compaction_result = compact_one_partition(&comp, group, compaction_type).await;
+            let compaction_result =
+                compact_one_partition(&comp, group, compaction_type, split).await;
             match compaction_result {
                 Err(e) => {
                     warn!(?e, ?partition_id, compaction_type, "compaction failed");
@@ -275,6 +289,7 @@ pub(crate) async fn compact_one_partition(
     compactor: &Compactor,
     to_compact: ReadyToCompact,
     compaction_type: &'static str,
+    split: bool,
 ) -> Result<(), CompactOnePartitionError> {
     let start_time = compactor.time_provider.now();
 
@@ -282,16 +297,17 @@ pub(crate) async fn compact_one_partition(
 
     let shard_id = partition.shard_id();
 
-    if files.len() == 1 && files[0].compaction_level() == CompactionLevel::Initial {
-        // upgrade the one l0 file to l1, don't run compaction
+    if files.len() == 1 {
+        // upgrade the one file, don't run compaction
         let mut repos = compactor.catalog.repositories().await;
+        let upgraded_level = files[0].compaction_level().next();
 
         repos
             .parquet_files()
-            .update_compaction_level(&[files[0].id()], CompactionLevel::FileNonOverlapped)
+            .update_compaction_level(&[files[0].id()], upgraded_level)
             .await
             .context(UpgradingSnafu)?;
-    } else {
+    } else if split {
         parquet_file_combining::compact_parquet_files(
             files,
             partition,
@@ -303,6 +319,20 @@ pub(crate) async fn compact_one_partition(
             compactor.config.max_desired_file_size_bytes,
             compactor.config.percentage_max_file_size,
             compactor.config.split_percentage,
+        )
+        .await
+        .map_err(|e| CompactOnePartitionError::Combining {
+            source: Box::new(e),
+        })?;
+    } else {
+        parquet_file_combining::compact_final_no_splits(
+            files,
+            partition,
+            Arc::clone(&compactor.catalog),
+            compactor.store.clone(),
+            Arc::clone(&compactor.exec),
+            Arc::clone(&compactor.time_provider),
+            &compactor.compaction_input_file_bytes,
         )
         .await
         .map_err(|e| CompactOnePartitionError::Combining {
@@ -380,7 +410,9 @@ pub mod tests {
         compact_candidates_with_memory_budget(
             Arc::clone(&compactor),
             "hot",
+            CompactionLevel::Initial,
             mock_compactor.compaction_function(),
+            true,
             sorted_candidates,
         )
         .await;
@@ -399,6 +431,7 @@ pub mod tests {
                 Arc<Compactor>,
                 Vec<ReadyToCompact>,
                 &'static str,
+                bool,
             ) -> Pin<Box<dyn futures::Future<Output = ()> + Send>>
             + Send
             + Sync
@@ -411,7 +444,8 @@ pub mod tests {
             Box::new(
                 move |_compactor: Arc<Compactor>,
                       parallel_compacting_candidates: Vec<ReadyToCompact>,
-                      _compaction_type: &'static str| {
+                      _compaction_type: &'static str,
+                      _split: bool| {
                     let compaction_groups_for_async = Arc::clone(&compaction_groups_for_closure);
                     Box::pin(async move {
                         compaction_groups_for_async

--- a/compactor/src/lib.rs
+++ b/compactor/src/lib.rs
@@ -27,6 +27,7 @@ use crate::{
     compact::{Compactor, PartitionCompactionCandidateWithInfo},
     parquet_file::CompactorParquetFile,
     parquet_file_filtering::{FilterResult, FilteredFiles},
+    parquet_file_lookup::ParquetFilesForCompaction,
 };
 use data_types::CompactionLevel;
 use metric::Attributes;
@@ -107,9 +108,16 @@ async fn compact_candidates_with_memory_budget<C, Fut>(
             Ok(parquet_files_for_compaction) => {
                 // Return only files under the `remaining_budget_bytes` that should be
                 // compacted
+                let ParquetFilesForCompaction {
+                    level_0,
+                    level_1,
+                    .. // Ignore other levels
+                } = parquet_files_for_compaction;
+
                 let to_compact = parquet_file_filtering::filter_parquet_files(
                     Arc::clone(&partition),
-                    parquet_files_for_compaction,
+                    level_0,
+                    level_1,
                     remaining_budget_bytes,
                     &compactor.parquet_file_candidate_gauge,
                     &compactor.parquet_file_candidate_bytes,

--- a/compactor/src/parquet_file_combining.rs
+++ b/compactor/src/parquet_file_combining.rs
@@ -97,6 +97,8 @@ pub(crate) async fn compact_parquet_files(
     // When data is between a "small" and "large" amount, split the compacted files at roughly this
     // percentage in the earlier compacted file, and the remainder in the later compacted file.
     split_percentage: u16,
+    // Compaction level the newly created file will have.
+    target_level: CompactionLevel,
 ) -> Result<(), Error> {
     let partition_id = partition.id();
 
@@ -127,9 +129,12 @@ pub(crate) async fn compact_parquet_files(
     let num_level_1 = num_files_by_level
         .get(&CompactionLevel::FileNonOverlapped)
         .unwrap_or(&0);
+    let num_level_2 = num_files_by_level
+        .get(&CompactionLevel::Final)
+        .unwrap_or(&0);
     debug!(
         ?partition_id,
-        num_files, num_level_0, num_level_1, "compact files to stream"
+        num_files, num_level_0, num_level_1, num_level_2, "compact files to stream"
     );
 
     // Collect all the parquet file IDs, to be able to set their catalog records to be
@@ -146,6 +151,7 @@ pub(crate) async fn compact_parquet_files(
                 partition.table.name.clone(),
                 &partition.table_schema,
                 partition.sort_key.clone(),
+                target_level,
             )
         })
         .collect();
@@ -244,7 +250,7 @@ pub(crate) async fn compact_parquet_files(
         Arc::clone(&partition),
         partition_id,
         max_sequence_number,
-        CompactionLevel::FileNonOverlapped,
+        target_level,
     )
     .await?;
 
@@ -268,9 +274,7 @@ pub(crate) async fn compact_parquet_files(
     Ok(())
 }
 
-/// Compact all files given, no matter their size, into one level 2 file. When this is called by
-/// `full_compaction`, it should only receive a group of level 1 and level 2 files that has already
-/// been selected to be an appropriate size.
+/// Compact all files given, no matter their size, into one file.
 #[allow(clippy::too_many_arguments)]
 pub(crate) async fn compact_final_no_splits(
     files: Vec<CompactorParquetFile>,
@@ -284,6 +288,8 @@ pub(crate) async fn compact_final_no_splits(
     time_provider: Arc<dyn TimeProvider>,
     // Histogram for the sizes of the files compacted
     compaction_input_file_bytes: &Metric<U64Histogram>,
+    // Compaction level the newly created file will have.
+    target_level: CompactionLevel,
 ) -> Result<(), Error> {
     let partition_id = partition.id();
 
@@ -299,10 +305,7 @@ pub(crate) async fn compact_final_no_splits(
     // Save all file sizes for recording metrics if this compaction succeeds.
     let file_sizes: Vec<_> = files.iter().map(|f| f.file_size_bytes()).collect();
 
-    debug!(
-        ?partition_id,
-        num_files, "final compaction of files to level 2"
-    );
+    debug!(?partition_id, num_files, "compact_final_no_splits");
 
     // Collect all the parquet file IDs, to be able to set their catalog records to be
     // deleted. These should already be unique, no need to dedupe.
@@ -318,6 +321,7 @@ pub(crate) async fn compact_final_no_splits(
                 partition.table.name.clone(),
                 &partition.table_schema,
                 partition.sort_key.clone(),
+                target_level,
             )
         })
         .collect();
@@ -372,7 +376,7 @@ pub(crate) async fn compact_final_no_splits(
         Arc::clone(&partition),
         partition_id,
         max_sequence_number,
-        CompactionLevel::Final,
+        target_level,
     )
     .await?;
 
@@ -406,7 +410,7 @@ async fn compact_with_plan(
     partition: Arc<PartitionCompactionCandidateWithInfo>,
     partition_id: PartitionId,
     max_sequence_number: SequenceNumber,
-    compaction_level: CompactionLevel,
+    target_level: CompactionLevel,
 ) -> Result<Vec<ParquetFileParams>, Error> {
     let ctx = exec.new_context(ExecutorType::Reorg);
     let physical_plan = ctx
@@ -456,7 +460,7 @@ async fn compact_with_plan(
                     partition_id,
                     partition_key: partition.partition_key.clone(),
                     max_sequence_number,
-                    compaction_level,
+                    compaction_level: target_level,
                     sort_key: Some(sort_key.clone()),
                 };
 
@@ -523,6 +527,7 @@ fn to_queryable_parquet_chunk(
     table_name: String,
     table_schema: &TableSchema,
     partition_sort_key: Option<SortKey>,
+    target_level: CompactionLevel,
 ) -> QueryableParquetChunk {
     let column_id_lookup = table_schema.column_id_map();
     let selection: Vec<_> = file
@@ -578,6 +583,7 @@ fn to_queryable_parquet_chunk(
         sort_key,
         partition_sort_key,
         file.compaction_level,
+        target_level,
     )
 }
 
@@ -853,6 +859,7 @@ mod tests {
             DEFAULT_MAX_DESIRED_FILE_SIZE_BYTES,
             DEFAULT_PERCENTAGE_MAX_FILE_SIZE,
             DEFAULT_SPLIT_PERCENTAGE,
+            CompactionLevel::FileNonOverlapped,
         )
         .await;
         assert_error!(result, Error::NotEnoughParquetFiles { num_files: 0, .. });
@@ -893,6 +900,7 @@ mod tests {
             DEFAULT_MAX_DESIRED_FILE_SIZE_BYTES,
             DEFAULT_PERCENTAGE_MAX_FILE_SIZE,
             DEFAULT_SPLIT_PERCENTAGE,
+            CompactionLevel::FileNonOverlapped,
         )
         .await
         .unwrap();
@@ -954,6 +962,7 @@ mod tests {
             DEFAULT_MAX_DESIRED_FILE_SIZE_BYTES,
             DEFAULT_PERCENTAGE_MAX_FILE_SIZE,
             DEFAULT_SPLIT_PERCENTAGE,
+            CompactionLevel::FileNonOverlapped,
         )
         .await
         .unwrap();
@@ -1038,6 +1047,7 @@ mod tests {
             DEFAULT_MAX_DESIRED_FILE_SIZE_BYTES,
             DEFAULT_PERCENTAGE_MAX_FILE_SIZE,
             DEFAULT_SPLIT_PERCENTAGE,
+            CompactionLevel::FileNonOverlapped,
         )
         .await
         .unwrap();
@@ -1140,6 +1150,7 @@ mod tests {
             DEFAULT_MAX_DESIRED_FILE_SIZE_BYTES,
             DEFAULT_PERCENTAGE_MAX_FILE_SIZE,
             split_percentage,
+            CompactionLevel::FileNonOverlapped,
         )
         .await
         .unwrap();
@@ -1223,6 +1234,7 @@ mod tests {
             DEFAULT_MAX_DESIRED_FILE_SIZE_BYTES,
             DEFAULT_PERCENTAGE_MAX_FILE_SIZE,
             DEFAULT_SPLIT_PERCENTAGE,
+            CompactionLevel::FileNonOverlapped,
         )
         .await
         .unwrap();
@@ -1321,34 +1333,51 @@ mod tests {
         let compaction_input_file_bytes = metrics();
         let shard_id = candidate_partition.shard_id();
 
-        // Even though in the real cold compaction code, we'll usually pass a list of level 1 files
-        // selected by size, nothing in this function checks any of that -- it will compact all
-        // files it's given together into one level 2 file.
+        let level_1_files = parquet_files
+            .into_iter()
+            .filter(|f| f.compaction_level() == CompactionLevel::FileNonOverlapped)
+            .collect();
+
+        // Compact all files given together into one level 2 file.
         compact_final_no_splits(
-            parquet_files,
+            level_1_files,
             candidate_partition,
             Arc::clone(&catalog.catalog),
             ParquetStorage::new(Arc::clone(&catalog.object_store)),
             Arc::clone(&catalog.exec),
             Arc::clone(&catalog.time_provider) as Arc<dyn TimeProvider>,
             &compaction_input_file_bytes,
+            CompactionLevel::Final,
         )
         .await
         .unwrap();
 
-        // Should have 1 level 2 file, not split at all
+        // Should have 1 level 2 file, not split at all, and 4 level 0 files.
         let mut files = catalog.list_by_table_not_to_delete(table.table.id).await;
-        assert_eq!(files.len(), 1);
+        assert_eq!(files.len(), 5);
+        let files_and_levels: Vec<_> = files
+            .iter()
+            .map(|f| (f.id.get(), f.compaction_level))
+            .collect();
+        assert_eq!(
+            files_and_levels,
+            vec![
+                (2, CompactionLevel::Initial),
+                (3, CompactionLevel::Initial),
+                (5, CompactionLevel::Initial),
+                (6, CompactionLevel::Initial),
+                (7, CompactionLevel::Final),
+            ]
+        );
+
         let file = files.pop().unwrap();
-        assert_eq!(file.id.get(), 7);
-        assert_eq!(file.compaction_level, CompactionLevel::Final);
 
         // Verify the metrics
         assert_eq!(
             extract_byte_metrics(&compaction_input_file_bytes, shard_id),
             ExtractedByteMetrics {
-                sample_count: 6,
-                buckets_with_counts: vec![(BUCKET_500_KB, 4), (u64::MAX, 2)],
+                sample_count: 2,
+                buckets_with_counts: vec![(BUCKET_500_KB, 2)],
             }
         );
 
@@ -1361,15 +1390,9 @@ mod tests {
                 "+-----------+------+------+------+-----------------------------+",
                 "| field_int | tag1 | tag2 | tag3 | time                        |",
                 "+-----------+------+------+------+-----------------------------+",
-                "| 10        | VT   |      |      | 1970-01-01T00:00:00.000006Z |",
-                "| 10        | VT   |      |      | 1970-01-01T00:00:00.000010Z |",
-                "| 10        | VT   |      |      | 1970-01-01T00:00:00.000068Z |",
-                "| 1500      | WA   |      |      | 1970-01-01T00:00:00.000008Z |",
                 "| 1601      |      | PA   | 15   | 1970-01-01T00:00:00.000030Z |",
                 "| 21        |      | OH   | 21   | 1970-01-01T00:00:00.000036Z |",
-                "| 210       |      | OH   | 21   | 1970-01-01T00:00:00.000136Z |",
-                "| 270       | UT   |      |      | 1970-01-01T00:00:00.000025Z |",
-                "| 70        | UT   |      |      | 1970-01-01T00:00:00.000020Z |",
+                "| 88        | VT   |      |      | 1970-01-01T00:00:00.000010Z |",
                 "| 99        | OR   |      |      | 1970-01-01T00:00:00.000012Z |",
                 "+-----------+------+------+------+-----------------------------+",
             ],

--- a/compactor/src/parquet_file_combining.rs
+++ b/compactor/src/parquet_file_combining.rs
@@ -269,8 +269,8 @@ pub(crate) async fn compact_parquet_files(
 }
 
 /// Compact all files given, no matter their size, into one level 2 file. When this is called by
-/// `full_compaction`, it should only receive a group of level 1 files that has already been
-/// selected to be an appropriate size.
+/// `full_compaction`, it should only receive a group of level 1 and level 2 files that has already
+/// been selected to be an appropriate size.
 #[allow(clippy::too_many_arguments)]
 pub(crate) async fn compact_final_no_splits(
     files: Vec<CompactorParquetFile>,

--- a/compactor/src/parquet_file_filtering.rs
+++ b/compactor/src/parquet_file_filtering.rs
@@ -1,13 +1,11 @@
 //! Logic for filtering a set of Parquet files to the desired set to be used for an optimal
 //! compaction operation.
 
-use crate::{
-    compact::PartitionCompactionCandidateWithInfo, parquet_file::CompactorParquetFile,
-    parquet_file_lookup::ParquetFilesForCompaction,
-};
+use crate::{compact::PartitionCompactionCandidateWithInfo, parquet_file::CompactorParquetFile};
+use data_types::CompactionLevel;
 use metric::{Attributes, Metric, U64Gauge, U64Histogram};
 use observability_deps::tracing::*;
-use std::sync::Arc;
+use std::{borrow::Cow, sync::Arc};
 
 /// Groups of files, their partition, and the estimated budget for compacting this group
 #[derive(Debug)]
@@ -30,23 +28,24 @@ pub(crate) enum FilterResult {
     },
 }
 
-/// Given a list of level 0 files sorted by max sequence number and a list of level 1 files for
+/// Given a list of level N files sorted by max sequence number and a list of level N + 1 files for
 /// a partition, select a subset set of files that:
 ///
-/// - Has a subset of the level 0 files selected, from the start of the sorted level 0 list
+/// - Has a subset of the level N files selected, from the start of the sorted level N list
 /// - Has a total size less than `max_bytes`
-/// - Has only level 1 files that overlap in time with the level 0 files
+/// - Has only level N + 1 files that overlap in time with the level N files
 ///
-/// The returned files will be ordered with the level 1 files first, then the level 0 files ordered
-/// in ascending order by their max sequence number.
+/// The returned files will be ordered with the level N + 1 files first, then the level N files
+/// ordered in ascending order by their max sequence number.
 pub(crate) fn filter_parquet_files(
     // partition of the parquet files
     partition: Arc<PartitionCompactionCandidateWithInfo>,
-    // Level 0 files sorted by max sequence number and level 1 files in arbitrary order for one
-    // partition
-    parquet_files_for_compaction: ParquetFilesForCompaction,
-    // Stop considering level 0 files when the total size of all files selected for compaction so
-    // far exceeds this value
+    // Level N files sorted by max sequence number
+    level_n: Vec<CompactorParquetFile>,
+    // Level N + 1 files
+    level_n_plus_1: Vec<CompactorParquetFile>,
+    // Stop considering level N files when the total estimated arrow size of all files selected for
+    // compaction so far exceeds this value
     max_bytes: u64,
     // Gauge for the number of Parquet file candidates
     parquet_file_candidate_gauge: &Metric<U64Gauge>,
@@ -54,7 +53,8 @@ pub(crate) fn filter_parquet_files(
     parquet_file_candidate_bytes: &Metric<U64Histogram>,
 ) -> FilteredFiles {
     let filter_result = filter_parquet_files_inner(
-        parquet_files_for_compaction,
+        level_n,
+        level_n_plus_1,
         max_bytes,
         parquet_file_candidate_gauge,
         parquet_file_candidate_bytes,
@@ -67,69 +67,68 @@ pub(crate) fn filter_parquet_files(
 }
 
 fn filter_parquet_files_inner(
-    // Level 0 files sorted by max sequence number and level 1 files in arbitrary order for one
-    // partition
-    parquet_files_for_compaction: ParquetFilesForCompaction,
-    // Stop considering level 0 files when the total size of all files selected for compaction so
-    // far exceeds this value
+    // Level N files sorted by max sequence number
+    level_n: Vec<CompactorParquetFile>,
+    // Level N + 1 files
+    mut remaining_level_n_plus_1: Vec<CompactorParquetFile>,
+    // Stop considering level N files when the total estimated arrow size of all files selected for
+    // compaction so far exceeds this value
     max_bytes: u64,
     // Gauge for the number of Parquet file candidates
     parquet_file_candidate_gauge: &Metric<U64Gauge>,
     // Histogram for the number of bytes of Parquet file candidates
     parquet_file_candidate_bytes: &Metric<U64Histogram>,
 ) -> FilterResult {
-    let ParquetFilesForCompaction {
-        level_0,
-        level_1: mut remaining_level_1,
-        .. // Ignore other levels
-    } = parquet_files_for_compaction;
-
-    if level_0.is_empty() {
-        info!("No level 0 files to consider for compaction");
+    if level_n.is_empty() {
+        info!("No level N files to consider for compaction");
         return FilterResult::NothingToCompact;
     }
 
     // Guaranteed to exist because of the empty check and early return above. Also assuming all
     // files are for the same partition.
-    let partition_id = level_0[0].partition_id();
+    let partition_id = level_n[0].partition_id();
 
-    let num_level_0_considering = level_0.len();
-    let num_level_1_considering = remaining_level_1.len();
+    let compaction_level_n = level_n[0].compaction_level();
+    let compaction_level_n_plus_1 = compaction_level_n.next();
 
-    // This will start by holding the level 1 files that are found to overlap an included level 0
-    // file. At the end of this function, the level 0 files are added to the end so they are sorted
-    // last.
-    let mut files_to_return = Vec::with_capacity(level_0.len() + remaining_level_1.len());
-    // Estimated memory bytes needed to compact returned L1 files
-    let mut l1_estimated_budget = Vec::with_capacity(level_0.len() + remaining_level_1.len());
-    // Keep track of level 0 files to include in this compaction operation; maintain assumed
+    let num_level_n_considering = level_n.len();
+    let num_level_n_plus_1_considering = remaining_level_n_plus_1.len();
+
+    // This will start by holding the level N + 1 files that are found to overlap an included level
+    // N file. At the end of this function, the level N files are added to the end so they are
+    // sorted last for deduplication purposes.
+    let mut files_to_return = Vec::with_capacity(level_n.len() + remaining_level_n_plus_1.len());
+    // Estimated memory bytes needed to compact returned LN+1 files
+    let mut ln_plus_1_estimated_budget =
+        Vec::with_capacity(level_n.len() + remaining_level_n_plus_1.len());
+    // Keep track of level N files to include in this compaction operation; maintain assumed
     // ordering by max sequence number.
-    let mut level_0_to_return = Vec::with_capacity(level_0.len());
-    // Estimated memory bytes needed to compact returned L0 files
-    let mut l0_estimated_budget = Vec::with_capacity(level_0.len());
+    let mut level_n_to_return = Vec::with_capacity(level_n.len());
+    // Estimated memory bytes needed to compact returned LN files
+    let mut ln_estimated_budget = Vec::with_capacity(level_n.len());
 
     // Memory needed to compact the returned files
     let mut total_estimated_budget = 0;
-    for level_0_file in level_0 {
-        // Estimate memory needed for this L0 file
-        let l0_estimated_file_bytes = level_0_file.estimated_arrow_bytes();
+    for level_n_file in level_n {
+        // Estimate memory needed for this LN file
+        let ln_estimated_file_bytes = level_n_file.estimated_arrow_bytes();
 
-        // Note: even though we can stop here if the l0_estimated_file_bytes is larger than the
-        // given budget,we still continue estimated the memory needed for its overlapped L1 to
-        // return the total memory needed to compact this L0 with all of its overlapped L1s
+        // Note: even though we can stop here if the ln_estimated_file_bytes is larger than the
+        // given budget,we still continue estimated the memory needed for its overlapped LN+1 to
+        // return the total memory needed to compact this LN with all of its overlapped LN+1s
 
-        // Find all level 1 files that overlap with this level 0 file.
-        let (overlaps, non_overlaps): (Vec<_>, Vec<_>) = remaining_level_1
+        // Find all level N+1 files that overlap with this level N file.
+        let (overlaps, non_overlaps): (Vec<_>, Vec<_>) = remaining_level_n_plus_1
             .into_iter()
-            .partition(|level_1_file| overlaps_in_time(level_1_file, &level_0_file));
+            .partition(|level_n_plus_1_file| overlaps_in_time(level_n_plus_1_file, &level_n_file));
 
-        // Estimate memory needed for each of L1
-        let current_l1_estimated_file_bytes: Vec<_> = overlaps
+        // Estimate memory needed for each LN+1
+        let current_ln_plus_1_estimated_file_bytes: Vec<_> = overlaps
             .iter()
             .map(|file| file.estimated_arrow_bytes())
             .collect();
         let estimated_file_bytes =
-            l0_estimated_file_bytes + current_l1_estimated_file_bytes.iter().sum::<u64>();
+            ln_estimated_file_bytes + current_ln_plus_1_estimated_file_bytes.iter().sum::<u64>();
 
         // Over budget
         if total_estimated_budget + estimated_file_bytes > max_bytes {
@@ -145,46 +144,50 @@ fn filter_parquet_files_inner(
         } else {
             // still under budget
             total_estimated_budget += estimated_file_bytes;
-            l0_estimated_budget.push(l0_estimated_file_bytes);
-            l1_estimated_budget.extend(current_l1_estimated_file_bytes);
+            ln_estimated_budget.push(ln_estimated_file_bytes);
+            ln_plus_1_estimated_budget.extend(current_ln_plus_1_estimated_file_bytes);
 
-            // Move the overlapping level 1 files to `files_to_return` so they're not considered
-            // again; a level 1 file overlapping with one level 0 file is enough for its inclusion.
-            // This way, we also don't include level 1 files multiple times.
+            // Move the overlapping level N+1 files to `files_to_return` so they're not considered
+            // again; a level N+1 file overlapping with one level N file is enough for its
+            // inclusion. This way, we also don't include level N+1 files multiple times.
             files_to_return.extend(overlaps);
 
-            // The remaining level 1 files to possibly include in future iterations are the
-            // remaining ones that did not overlap with this level 0 file.
-            remaining_level_1 = non_overlaps;
+            // The remaining level N+1 files to possibly include in future iterations are the
+            // remaining ones that did not overlap with this level N file.
+            remaining_level_n_plus_1 = non_overlaps;
 
-            // Move the level 0 file into the list of level 0 files to return
-            level_0_to_return.push(level_0_file);
+            // Move the level N file into the list of level N files to return
+            level_n_to_return.push(level_n_file);
         }
     }
 
-    let num_level_0_compacting = level_0_to_return.len();
-    let num_level_1_compacting = files_to_return.len();
+    let num_level_n_compacting = level_n_to_return.len();
+    let num_level_n_plus_1_compacting = files_to_return.len();
 
     info!(
         partition_id = partition_id.get(),
-        num_level_0_considering,
-        num_level_1_considering,
-        num_level_0_compacting,
-        num_level_1_compacting,
+        num_level_n_considering,
+        num_level_n_plus_1_considering,
+        num_level_n_compacting,
+        num_level_n_plus_1_compacting,
         "filtered Parquet files for compaction",
     );
 
     record_file_metrics(
         parquet_file_candidate_gauge,
-        num_level_0_considering as u64,
-        num_level_1_considering as u64,
-        num_level_0_compacting as u64,
-        num_level_1_compacting as u64,
+        compaction_level_n,
+        compaction_level_n_plus_1,
+        num_level_n_considering as u64,
+        num_level_n_plus_1_considering as u64,
+        num_level_n_compacting as u64,
+        num_level_n_plus_1_compacting as u64,
     );
 
     record_byte_metrics(
         parquet_file_candidate_bytes,
-        level_0_to_return
+        compaction_level_n,
+        compaction_level_n_plus_1,
+        level_n_to_return
             .iter()
             .map(|pf| pf.file_size_bytes() as u64)
             .collect(),
@@ -192,13 +195,13 @@ fn filter_parquet_files_inner(
             .iter()
             .map(|pf| pf.file_size_bytes() as u64)
             .collect(),
-        l0_estimated_budget,
-        l1_estimated_budget,
+        ln_estimated_budget,
+        ln_plus_1_estimated_budget,
     );
 
-    // Return the level 1 files first, followed by the level 0 files assuming we've maintained
+    // Return the level N+1 files first, followed by the level N files, assuming we've maintained
     // their ordering by max sequence number.
-    files_to_return.extend(level_0_to_return);
+    files_to_return.extend(level_n_to_return);
 
     FilterResult::Proceed {
         files: files_to_return,
@@ -213,70 +216,87 @@ fn overlaps_in_time(a: &CompactorParquetFile, b: &CompactorParquetFile) -> bool 
 
 fn record_file_metrics(
     gauge: &Metric<U64Gauge>,
-    num_level_0_considering: u64,
-    num_level_1_considering: u64,
-    num_level_0_compacting: u64,
-    num_level_1_compacting: u64,
+    compaction_level_n: CompactionLevel,
+    compaction_level_n_plus_1: CompactionLevel,
+    num_level_n_considering: u64,
+    num_level_n_plus_1_considering: u64,
+    num_level_n_compacting: u64,
+    num_level_n_plus_1_compacting: u64,
 ) {
-    let attributes = Attributes::from(&[
-        ("compaction_level", "0"),
-        ("status", "selected_for_compaction"),
-    ]);
-    let recorder = gauge.recorder(attributes);
-    recorder.set(num_level_0_compacting);
+    let compaction_level_n_string = Cow::from(format!("{}", compaction_level_n as i16));
+    let mut level_n_attributes =
+        Attributes::from([("compaction_level", compaction_level_n_string)]);
 
-    let attributes = Attributes::from(&[
-        ("compaction_level", "0"),
-        ("status", "not_selected_for_compaction"),
-    ]);
-    let recorder = gauge.recorder(attributes);
-    recorder.set(num_level_0_considering - num_level_0_compacting);
+    level_n_attributes.insert("status", "selected_for_compaction");
+    let recorder = gauge.recorder(level_n_attributes.clone());
+    recorder.set(num_level_n_compacting);
 
-    let attributes = Attributes::from(&[
-        ("compaction_level", "1"),
-        ("status", "selected_for_compaction"),
-    ]);
-    let recorder = gauge.recorder(attributes);
-    recorder.set(num_level_1_compacting);
+    level_n_attributes.insert("status", "not_selected_for_compaction");
+    let recorder = gauge.recorder(level_n_attributes);
+    recorder.set(num_level_n_considering - num_level_n_compacting);
 
-    let attributes = Attributes::from(&[
-        ("compaction_level", "1"),
-        ("status", "not_selected_for_compaction"),
-    ]);
-    let recorder = gauge.recorder(attributes);
-    recorder.set(num_level_1_considering - num_level_1_compacting);
+    let compaction_level_n_plus_1_string =
+        Cow::from(format!("{}", compaction_level_n_plus_1 as i16));
+    let mut level_n_plus_1_attributes =
+        Attributes::from([("compaction_level", compaction_level_n_plus_1_string)]);
+
+    level_n_plus_1_attributes.insert("status", "selected_for_compaction");
+    let recorder = gauge.recorder(level_n_plus_1_attributes.clone());
+    recorder.set(num_level_n_plus_1_compacting);
+
+    level_n_plus_1_attributes.insert("status", "not_selected_for_compaction");
+    let recorder = gauge.recorder(level_n_plus_1_attributes);
+    recorder.set(num_level_n_plus_1_considering - num_level_n_plus_1_compacting);
 }
 
 fn record_byte_metrics(
     histogram: &Metric<U64Histogram>,
-    level_0_sizes: Vec<u64>,
-    level_1_sizes: Vec<u64>,
-    level_0_estimated_compacting_budgets: Vec<u64>,
-    level_1_estimated_compacting_budgets: Vec<u64>,
+    compaction_level_n: CompactionLevel,
+    compaction_level_n_plus_1: CompactionLevel,
+    level_n_sizes: Vec<u64>,
+    level_n_plus_1_sizes: Vec<u64>,
+    level_n_estimated_compacting_budgets: Vec<u64>,
+    level_n_plus_1_estimated_compacting_budgets: Vec<u64>,
 ) {
-    let attributes = Attributes::from(&[("file_size_compaction_level", "0")]);
-    let recorder = histogram.recorder(attributes);
-    for size in level_0_sizes {
+    let compaction_level_n_string = Cow::from(format!("{}", compaction_level_n as i16));
+    let level_n_attributes = Attributes::from([(
+        "file_size_compaction_level",
+        compaction_level_n_string.clone(),
+    )]);
+
+    let compaction_level_n_plus_1_string =
+        Cow::from(format!("{}", compaction_level_n_plus_1 as i16));
+    let level_n_plus_1_attributes = Attributes::from([(
+        "file_size_compaction_level",
+        compaction_level_n_plus_1_string.clone(),
+    )]);
+
+    let recorder = histogram.recorder(level_n_attributes);
+    for size in level_n_sizes {
         recorder.record(size);
     }
 
-    let attributes = Attributes::from(&[("file_size_compaction_level", "1")]);
-    let recorder = histogram.recorder(attributes);
-    for size in level_1_sizes {
+    let recorder = histogram.recorder(level_n_plus_1_attributes);
+    for size in level_n_plus_1_sizes {
         recorder.record(size);
     }
 
-    let attributes =
-        Attributes::from(&[("file_estimated_compacting_budget_compaction_level", "0")]);
-    let recorder = histogram.recorder(attributes);
-    for size in level_0_estimated_compacting_budgets {
+    let level_n_attributes = Attributes::from([(
+        "file_estimated_compacting_budget_compaction_level",
+        compaction_level_n_string,
+    )]);
+    let recorder = histogram.recorder(level_n_attributes);
+    for size in level_n_estimated_compacting_budgets {
         recorder.record(size);
     }
 
-    let attributes =
-        Attributes::from(&[("file_estimated_compacting_budget_compaction_level", "1")]);
-    let recorder = histogram.recorder(attributes);
-    for size in level_1_estimated_compacting_budgets {
+    let level_n_plus_1_attributes = Attributes::from([(
+        "file_estimated_compacting_budget_compaction_level",
+        compaction_level_n_plus_1_string,
+    )]);
+
+    let recorder = histogram.recorder(level_n_plus_1_attributes);
+    for size in level_n_plus_1_estimated_compacting_budgets {
         recorder.record(size);
     }
 }
@@ -373,272 +393,414 @@ mod tests {
         (parquet_file_candidate_gauge, parquet_file_candidate_bytes)
     }
 
-    mod hot {
-        use super::*;
+    const MEMORY_BUDGET: u64 = 1024 * 1024 * 10;
 
-        const MEMORY_BUDGET: u64 = 1024 * 1024 * 10;
+    #[test]
+    fn empty_in_empty_out() {
+        let level_0 = vec![];
+        let level_1 = vec![];
+        let (files_metric, bytes_metric) = metrics();
 
-        #[test]
-        fn empty_in_empty_out() {
-            let parquet_files_for_compaction = ParquetFilesForCompaction {
-                level_0: vec![],
-                level_1: vec![],
-                level_2: vec![],
-            };
-            let (files_metric, bytes_metric) = metrics();
+        let filter_result = filter_parquet_files_inner(
+            level_0,
+            level_1,
+            MEMORY_BUDGET,
+            &files_metric,
+            &bytes_metric,
+        );
 
-            let filter_result = filter_parquet_files_inner(
-                parquet_files_for_compaction,
-                MEMORY_BUDGET,
+        assert_eq!(filter_result, FilterResult::NothingToCompact);
+    }
+
+    #[test]
+    fn budget_0_returns_over_budget() {
+        let level_0 = vec![ParquetFileBuilder::level_0().id(1).build()];
+        let level_1 = vec![];
+        let (files_metric, bytes_metric) = metrics();
+
+        let filter_result =
+            filter_parquet_files_inner(level_0, level_1, 0, &files_metric, &bytes_metric);
+
+        assert_eq!(
+            filter_result,
+            FilterResult::OverBudget { budget_bytes: 1176 }
+        );
+    }
+
+    #[test]
+    fn budget_1000_returns_over_budget() {
+        let level_0 = vec![ParquetFileBuilder::level_0().id(1).build()];
+        let level_1 = vec![];
+        let (files_metric, bytes_metric) = metrics();
+
+        let filter_result =
+            filter_parquet_files_inner(level_0, level_1, 1000, &files_metric, &bytes_metric);
+
+        assert_eq!(
+            filter_result,
+            FilterResult::OverBudget { budget_bytes: 1176 }
+        );
+    }
+
+    #[test]
+    fn large_budget_returns_one_level_0_file_and_its_level_1_overlaps() {
+        let level_0 = vec![ParquetFileBuilder::level_0()
+            .id(1)
+            .min_time(200)
+            .max_time(300)
+            .build()];
+        let level_1 = vec![
+            // Too early
+            ParquetFileBuilder::level_1()
+                .id(101)
+                .min_time(1)
+                .max_time(50)
+                .build(),
+            // Completely contains the level 0 times
+            ParquetFileBuilder::level_1()
+                .id(102)
+                .min_time(150)
+                .max_time(350)
+                .build(),
+            // Too late
+            ParquetFileBuilder::level_1()
+                .id(103)
+                .min_time(400)
+                .max_time(500)
+                .build(),
+        ];
+        let (files_metric, bytes_metric) = metrics();
+
+        let filter_result = filter_parquet_files_inner(
+            level_0,
+            level_1,
+            MEMORY_BUDGET,
+            &files_metric,
+            &bytes_metric,
+        );
+
+        assert!(
+            matches!(
+                &filter_result,
+                FilterResult::Proceed { files, budget_bytes }
+                    if files.len() == 2
+                        && files.iter().map(|f| f.id().get()).collect::<Vec<_>>() == [102, 1]
+                        && *budget_bytes == 2 * 1176
+            ),
+            "Match failed, got: {filter_result:?}"
+        );
+    }
+
+    #[test]
+    fn returns_only_overlapping_level_1_files_in_order() {
+        let level_0 = vec![
+            // Level 0 files that overlap in time slightly.
+            ParquetFileBuilder::level_0()
+                .id(1)
+                .min_time(200)
+                .max_time(300)
+                .file_size_bytes(10)
+                .build(),
+            ParquetFileBuilder::level_0()
+                .id(2)
+                .min_time(280)
+                .max_time(310)
+                .file_size_bytes(10)
+                .build(),
+            ParquetFileBuilder::level_0()
+                .id(3)
+                .min_time(309)
+                .max_time(350)
+                .file_size_bytes(10)
+                .build(),
+        ];
+
+        // Level 1 files can be assumed not to overlap each other.
+        let level_1 = vec![
+            // Does not overlap any level 0, times are too early
+            ParquetFileBuilder::level_1()
+                .id(101)
+                .min_time(1)
+                .max_time(50)
+                .file_size_bytes(10)
+                .build(),
+            // Overlaps file 1
+            ParquetFileBuilder::level_1()
+                .id(102)
+                .min_time(199)
+                .max_time(201)
+                .file_size_bytes(10)
+                .build(),
+            // Overlaps files 1 and 2
+            ParquetFileBuilder::level_1()
+                .id(103)
+                .min_time(290)
+                .max_time(300)
+                .file_size_bytes(10)
+                .build(),
+            // Overlaps file 2
+            ParquetFileBuilder::level_1()
+                .id(104)
+                .min_time(305)
+                .max_time(305)
+                .file_size_bytes(10)
+                .build(),
+            // Overlaps files 2 and 3
+            ParquetFileBuilder::level_1()
+                .id(105)
+                .min_time(308)
+                .max_time(311)
+                .file_size_bytes(10)
+                .build(),
+            // Overlaps file 3
+            ParquetFileBuilder::level_1()
+                .id(106)
+                .min_time(340)
+                .max_time(360)
+                .file_size_bytes(BUCKET_500_KB as i64 + 1) // exercise metrics
+                .build(),
+            // Does not overlap any level 0, times are too late
+            ParquetFileBuilder::level_1()
+                .id(107)
+                .min_time(390)
+                .max_time(399)
+                .file_size_bytes(10)
+                .build(),
+        ];
+
+        let (files_metric, bytes_metric) = metrics();
+
+        let filter_result = filter_parquet_files_inner(
+            level_0.clone(),
+            level_1.clone(),
+            1176 * 3 + 5, // enough for 3 files
+            &files_metric,
+            &bytes_metric,
+        );
+
+        assert!(
+            matches!(
+                &filter_result,
+                FilterResult::Proceed { files, budget_bytes }
+                    if files.len() == 3
+                        && files
+                                .iter()
+                                .map(|f| f.id().get())
+                                .collect::<Vec<_>>() == [102, 103, 1]
+                        && *budget_bytes == 3 * 1176
+            ),
+            "Match failed, got: {filter_result:?}"
+        );
+
+        assert_eq!(
+            extract_file_metrics(
                 &files_metric,
-                &bytes_metric,
-            );
+                CompactionLevel::Initial,
+                CompactionLevel::FileNonOverlapped
+            ),
+            ExtractedFileMetrics {
+                level_n_selected: 1,
+                level_n_not_selected: 2,
+                level_n_plus_1_selected: 2,
+                level_n_plus_1_not_selected: 5,
+            }
+        );
 
-            assert_eq!(filter_result, FilterResult::NothingToCompact);
-        }
+        let (files_metric, bytes_metric) = metrics();
 
-        #[test]
-        fn budget_0_returns_over_budget() {
-            let parquet_files_for_compaction = ParquetFilesForCompaction {
-                level_0: vec![ParquetFileBuilder::level_0().id(1).build()],
-                level_1: vec![],
-                level_2: vec![],
-            };
-            let (files_metric, bytes_metric) = metrics();
+        let filter_result = filter_parquet_files_inner(
+            level_0,
+            level_1,
+            // Increase budget to more than 6 files; 1st two level 0 files & their overlapping
+            // level 1 files get returned
+            1176 * 6 + 5,
+            &files_metric,
+            &bytes_metric,
+        );
 
-            let filter_result = filter_parquet_files_inner(
-                parquet_files_for_compaction,
-                0,
+        assert!(
+            matches!(
+                &filter_result,
+                FilterResult::Proceed { files, budget_bytes }
+                    if files.len() == 6
+                        && files
+                                .iter()
+                                .map(|f| f.id().get())
+                                .collect::<Vec<_>>() == [102, 103, 104, 105, 1, 2]
+                        && *budget_bytes == 6 * 1176
+            ),
+            "Match failed, got: {filter_result:?}"
+        );
+
+        assert_eq!(
+            extract_file_metrics(
                 &files_metric,
-                &bytes_metric,
-            );
+                CompactionLevel::Initial,
+                CompactionLevel::FileNonOverlapped
+            ),
+            ExtractedFileMetrics {
+                level_n_selected: 2,
+                level_n_not_selected: 1,
+                level_n_plus_1_selected: 4,
+                level_n_plus_1_not_selected: 3,
+            }
+        );
+    }
 
-            assert_eq!(
-                filter_result,
-                FilterResult::OverBudget { budget_bytes: 1176 }
-            );
-        }
+    #[test]
+    fn returns_only_overlapping_level_2_files_in_order() {
+        let level_1 = vec![
+            // Level 1 files don't overlap each other.
+            ParquetFileBuilder::level_1()
+                .id(1)
+                .min_time(200)
+                .max_time(300)
+                .file_size_bytes(10)
+                .build(),
+            ParquetFileBuilder::level_1()
+                .id(2)
+                .min_time(310)
+                .max_time(330)
+                .file_size_bytes(10)
+                .build(),
+            ParquetFileBuilder::level_1()
+                .id(3)
+                .min_time(340)
+                .max_time(350)
+                .file_size_bytes(10)
+                .build(),
+        ];
 
-        #[test]
-        fn budget_1000_returns_over_budget() {
-            let parquet_files_for_compaction = ParquetFilesForCompaction {
-                level_0: vec![ParquetFileBuilder::level_0().id(1).build()],
-                level_1: vec![],
-                level_2: vec![],
-            };
-            let (files_metric, bytes_metric) = metrics();
+        // Level 2 files can be assumed not to overlap each other.
+        let level_2 = vec![
+            // Does not overlap any level 1, times are too early
+            ParquetFileBuilder::level_2()
+                .id(101)
+                .min_time(1)
+                .max_time(50)
+                .file_size_bytes(10)
+                .build(),
+            // Overlaps file 1
+            ParquetFileBuilder::level_2()
+                .id(102)
+                .min_time(199)
+                .max_time(201)
+                .file_size_bytes(10)
+                .build(),
+            // Overlaps files 1 and 2
+            ParquetFileBuilder::level_2()
+                .id(103)
+                .min_time(290)
+                .max_time(312)
+                .file_size_bytes(10)
+                .build(),
+            // Overlaps file 2
+            ParquetFileBuilder::level_2()
+                .id(104)
+                .min_time(315)
+                .max_time(315)
+                .file_size_bytes(10)
+                .build(),
+            // Overlaps files 2 and 3
+            ParquetFileBuilder::level_2()
+                .id(105)
+                .min_time(329)
+                .max_time(341)
+                .file_size_bytes(10)
+                .build(),
+            // Overlaps file 3
+            ParquetFileBuilder::level_2()
+                .id(106)
+                .min_time(342)
+                .max_time(360)
+                .file_size_bytes(BUCKET_500_KB as i64 + 1) // exercise metrics
+                .build(),
+            // Does not overlap any level 1, times are too late
+            ParquetFileBuilder::level_2()
+                .id(107)
+                .min_time(390)
+                .max_time(399)
+                .file_size_bytes(10)
+                .build(),
+        ];
 
-            let filter_result = filter_parquet_files_inner(
-                parquet_files_for_compaction,
-                1000,
+        let (files_metric, bytes_metric) = metrics();
+
+        let filter_result = filter_parquet_files_inner(
+            level_1.clone(),
+            level_2.clone(),
+            1176 * 3 + 5, // enough for 3 files
+            &files_metric,
+            &bytes_metric,
+        );
+
+        assert!(
+            matches!(
+                &filter_result,
+                FilterResult::Proceed { files, budget_bytes }
+                    if files.len() == 3
+                        && files
+                                .iter()
+                                .map(|f| f.id().get())
+                                .collect::<Vec<_>>() == [102, 103, 1]
+                        && *budget_bytes == 3 * 1176
+            ),
+            "Match failed, got: {filter_result:?}"
+        );
+
+        assert_eq!(
+            extract_file_metrics(
                 &files_metric,
-                &bytes_metric,
-            );
+                CompactionLevel::FileNonOverlapped,
+                CompactionLevel::Final
+            ),
+            ExtractedFileMetrics {
+                level_n_selected: 1,
+                level_n_not_selected: 2,
+                level_n_plus_1_selected: 2,
+                level_n_plus_1_not_selected: 5,
+            }
+        );
 
-            assert_eq!(
-                filter_result,
-                FilterResult::OverBudget { budget_bytes: 1176 }
-            );
-        }
+        let (files_metric, bytes_metric) = metrics();
 
-        #[test]
-        fn large_budget_returns_one_level_0_file_and_its_level_1_overlaps() {
-            let parquet_files_for_compaction = ParquetFilesForCompaction {
-                level_0: vec![ParquetFileBuilder::level_0()
-                    .id(1)
-                    .min_time(200)
-                    .max_time(300)
-                    .build()],
-                level_1: vec![
-                    // Too early
-                    ParquetFileBuilder::level_1()
-                        .id(101)
-                        .min_time(1)
-                        .max_time(50)
-                        .build(),
-                    // Completely contains the level 0 times
-                    ParquetFileBuilder::level_1()
-                        .id(102)
-                        .min_time(150)
-                        .max_time(350)
-                        .build(),
-                    // Too late
-                    ParquetFileBuilder::level_1()
-                        .id(103)
-                        .min_time(400)
-                        .max_time(500)
-                        .build(),
-                ],
-                level_2: vec![],
-            };
-            let (files_metric, bytes_metric) = metrics();
+        let filter_result = filter_parquet_files_inner(
+            level_1,
+            level_2,
+            // Increase budget to more than 6 files; 1st two level 1 files & their overlapping
+            // level 2 files get returned
+            1176 * 6 + 5,
+            &files_metric,
+            &bytes_metric,
+        );
 
-            let filter_result = filter_parquet_files_inner(
-                parquet_files_for_compaction,
-                MEMORY_BUDGET,
+        assert!(
+            matches!(
+                &filter_result,
+                FilterResult::Proceed { files, budget_bytes }
+                    if files.len() == 6
+                        && files
+                                .iter()
+                                .map(|f| f.id().get())
+                                .collect::<Vec<_>>() == [102, 103, 104, 105, 1, 2]
+                        && *budget_bytes == 6 * 1176
+            ),
+            "Match failed, got: {filter_result:?}"
+        );
+
+        assert_eq!(
+            extract_file_metrics(
                 &files_metric,
-                &bytes_metric,
-            );
-
-            assert!(
-                matches!(
-                    &filter_result,
-                    FilterResult::Proceed { files, budget_bytes }
-                        if files.len() == 2
-                            && files.iter().map(|f| f.id().get()).collect::<Vec<_>>() == [102, 1]
-                            && *budget_bytes == 2 * 1176
-                ),
-                "Match failed, got: {filter_result:?}"
-            );
-        }
-
-        #[test]
-        fn returns_only_overlapping_level_1_files_in_order() {
-            let parquet_files_for_compaction = ParquetFilesForCompaction {
-                level_0: vec![
-                    // Level 0 files that overlap in time slightly.
-                    ParquetFileBuilder::level_0()
-                        .id(1)
-                        .min_time(200)
-                        .max_time(300)
-                        .file_size_bytes(10)
-                        .build(),
-                    ParquetFileBuilder::level_0()
-                        .id(2)
-                        .min_time(280)
-                        .max_time(310)
-                        .file_size_bytes(10)
-                        .build(),
-                    ParquetFileBuilder::level_0()
-                        .id(3)
-                        .min_time(309)
-                        .max_time(350)
-                        .file_size_bytes(10)
-                        .build(),
-                ],
-                // Level 1 files can be assumed not to overlap each other.
-                level_1: vec![
-                    // Does not overlap any level 0, times are too early
-                    ParquetFileBuilder::level_1()
-                        .id(101)
-                        .min_time(1)
-                        .max_time(50)
-                        .file_size_bytes(10)
-                        .build(),
-                    // Overlaps file 1
-                    ParquetFileBuilder::level_1()
-                        .id(102)
-                        .min_time(199)
-                        .max_time(201)
-                        .file_size_bytes(10)
-                        .build(),
-                    // Overlaps files 1 and 2
-                    ParquetFileBuilder::level_1()
-                        .id(103)
-                        .min_time(290)
-                        .max_time(300)
-                        .file_size_bytes(10)
-                        .build(),
-                    // Overlaps file 2
-                    ParquetFileBuilder::level_1()
-                        .id(104)
-                        .min_time(305)
-                        .max_time(305)
-                        .file_size_bytes(10)
-                        .build(),
-                    // Overlaps files 2 and 3
-                    ParquetFileBuilder::level_1()
-                        .id(105)
-                        .min_time(308)
-                        .max_time(311)
-                        .file_size_bytes(10)
-                        .build(),
-                    // Overlaps file 3
-                    ParquetFileBuilder::level_1()
-                        .id(106)
-                        .min_time(340)
-                        .max_time(360)
-                        .file_size_bytes(BUCKET_500_KB as i64 + 1) // exercise metrics
-                        .build(),
-                    // Does not overlap any level 0, times are too late
-                    ParquetFileBuilder::level_1()
-                        .id(107)
-                        .min_time(390)
-                        .max_time(399)
-                        .file_size_bytes(10)
-                        .build(),
-                ],
-                level_2: vec![],
-            };
-
-            let (files_metric, bytes_metric) = metrics();
-
-            let filter_result = filter_parquet_files_inner(
-                parquet_files_for_compaction.clone(),
-                1176 * 3 + 5, // enough for 3 files
-                &files_metric,
-                &bytes_metric,
-            );
-
-            assert!(
-                matches!(
-                    &filter_result,
-                    FilterResult::Proceed { files, budget_bytes }
-                        if files.len() == 3
-                            && files
-                                    .iter()
-                                    .map(|f| f.id().get())
-                                    .collect::<Vec<_>>() == [102, 103, 1]
-                            && *budget_bytes == 3 * 1176
-                ),
-                "Match failed, got: {filter_result:?}"
-            );
-
-            assert_eq!(
-                extract_file_metrics(&files_metric),
-                ExtractedFileMetrics {
-                    level_0_selected: 1,
-                    level_0_not_selected: 2,
-                    level_1_selected: 2,
-                    level_1_not_selected: 5,
-                }
-            );
-
-            let (files_metric, bytes_metric) = metrics();
-
-            let filter_result = filter_parquet_files_inner(
-                parquet_files_for_compaction,
-                // Increase budget to more than 6 files; 1st two level 0 files & their overlapping
-                // level 1 files get returned
-                1176 * 6 + 5,
-                &files_metric,
-                &bytes_metric,
-            );
-
-            assert!(
-                matches!(
-                    &filter_result,
-                    FilterResult::Proceed { files, budget_bytes }
-                        if files.len() == 6
-                            && files
-                                    .iter()
-                                    .map(|f| f.id().get())
-                                    .collect::<Vec<_>>() == [102, 103, 104, 105, 1, 2]
-                            && *budget_bytes == 6 * 1176
-                ),
-                "Match failed, got: {filter_result:?}"
-            );
-
-            assert_eq!(
-                extract_file_metrics(&files_metric),
-                ExtractedFileMetrics {
-                    level_0_selected: 2,
-                    level_0_not_selected: 1,
-                    level_1_selected: 4,
-                    level_1_not_selected: 3,
-                }
-            );
-        }
+                CompactionLevel::FileNonOverlapped,
+                CompactionLevel::Final
+            ),
+            ExtractedFileMetrics {
+                level_n_selected: 2,
+                level_n_not_selected: 1,
+                level_n_plus_1_selected: 4,
+                level_n_plus_1_not_selected: 3,
+            }
+        );
     }
 
     /// Create ParquetFile instances for testing. Only sets fields relevant to the filtering; other
@@ -670,6 +832,17 @@ mod tests {
         fn level_1() -> Self {
             Self {
                 compaction_level: CompactionLevel::FileNonOverlapped,
+                id: 1,
+                min_time: 8,
+                max_time: 9,
+                file_size_bytes: 10,
+            }
+        }
+
+        // Start building a level 2 file
+        fn level_2() -> Self {
+            Self {
+                compaction_level: CompactionLevel::Final,
                 id: 1,
                 min_time: 8,
                 max_time: 9,
@@ -730,50 +903,54 @@ mod tests {
 
     #[derive(Debug, PartialEq)]
     struct ExtractedFileMetrics {
-        level_0_selected: u64,
-        level_0_not_selected: u64,
-        level_1_selected: u64,
-        level_1_not_selected: u64,
+        level_n_selected: u64,
+        level_n_not_selected: u64,
+        level_n_plus_1_selected: u64,
+        level_n_plus_1_not_selected: u64,
     }
 
-    fn extract_file_metrics(metric: &Metric<U64Gauge>) -> ExtractedFileMetrics {
-        let level_0_selected = metric
-            .get_observer(&Attributes::from(&[
-                ("compaction_level", "0"),
-                ("status", "selected_for_compaction"),
+    fn extract_file_metrics(
+        metric: &Metric<U64Gauge>,
+        level_n: CompactionLevel,
+        level_n_plus_1: CompactionLevel,
+    ) -> ExtractedFileMetrics {
+        let level_n_string = Cow::from(format!("{}", level_n as i16));
+        let level_n_selected = metric
+            .get_observer(&Attributes::from([
+                ("compaction_level", level_n_string.clone()),
+                ("status", "selected_for_compaction".into()),
+            ]))
+            .unwrap()
+            .fetch();
+        let level_n_not_selected = metric
+            .get_observer(&Attributes::from([
+                ("compaction_level", level_n_string),
+                ("status", "not_selected_for_compaction".into()),
             ]))
             .unwrap()
             .fetch();
 
-        let level_0_not_selected = metric
-            .get_observer(&Attributes::from(&[
-                ("compaction_level", "0"),
-                ("status", "not_selected_for_compaction"),
+        let level_n_plus_1_string = Cow::from(format!("{}", level_n_plus_1 as i16));
+        let level_n_plus_1_selected = metric
+            .get_observer(&Attributes::from([
+                ("compaction_level", level_n_plus_1_string.clone()),
+                ("status", "selected_for_compaction".into()),
             ]))
             .unwrap()
             .fetch();
-
-        let level_1_selected = metric
-            .get_observer(&Attributes::from(&[
-                ("compaction_level", "1"),
-                ("status", "selected_for_compaction"),
-            ]))
-            .unwrap()
-            .fetch();
-
-        let level_1_not_selected = metric
-            .get_observer(&Attributes::from(&[
-                ("compaction_level", "1"),
-                ("status", "not_selected_for_compaction"),
+        let level_n_plus_1_not_selected = metric
+            .get_observer(&Attributes::from([
+                ("compaction_level", level_n_plus_1_string),
+                ("status", "not_selected_for_compaction".into()),
             ]))
             .unwrap()
             .fetch();
 
         ExtractedFileMetrics {
-            level_0_selected,
-            level_0_not_selected,
-            level_1_selected,
-            level_1_not_selected,
+            level_n_selected,
+            level_n_not_selected,
+            level_n_plus_1_selected,
+            level_n_plus_1_not_selected,
         }
     }
 }

--- a/compactor/src/parquet_file_lookup.rs
+++ b/compactor/src/parquet_file_lookup.rs
@@ -97,7 +97,7 @@ impl ParquetFilesForCompaction {
         }
 
         level_0.sort_by_key(|pf| pf.max_sequence_number());
-        level_1.sort_by_key(|pf| pf.max_sequence_number());
+        level_1.sort_by_key(|pf| pf.min_time());
 
         Ok(Self {
             level_0,
@@ -427,6 +427,79 @@ mod tests {
         assert_eq!(
             parquet_files_for_compaction.level_1,
             vec![CompactorParquetFile::new(l1.parquet_file, 0)]
+        );
+    }
+
+    #[tokio::test]
+    async fn level_1_files_are_sorted_on_min_time() {
+        test_helpers::maybe_start_logging();
+        let TestSetup {
+            catalog, partition, ..
+        } = test_setup().await;
+
+        // Create a level 1 file, max seq = 100, min time = 8888
+        let builder = TestParquetFileBuilder::default()
+            .with_line_protocol(ARBITRARY_LINE_PROTOCOL)
+            .with_compaction_level(CompactionLevel::FileNonOverlapped)
+            .with_max_seq(100)
+            .with_min_time(8888);
+        let l1_min_time_8888 = partition.create_parquet_file(builder).await;
+
+        // Create a level 1 file, max seq = 50, min time = 7777
+        let builder = TestParquetFileBuilder::default()
+            .with_line_protocol(ARBITRARY_LINE_PROTOCOL)
+            .with_compaction_level(CompactionLevel::FileNonOverlapped)
+            .with_max_seq(50)
+            .with_min_time(7777);
+        let l1_min_time_7777 = partition.create_parquet_file(builder).await;
+
+        // Create a level 1 file, max seq = 150, min time = 6666
+        let builder = TestParquetFileBuilder::default()
+            .with_line_protocol(ARBITRARY_LINE_PROTOCOL)
+            .with_compaction_level(CompactionLevel::FileNonOverlapped)
+            .with_max_seq(150)
+            .with_min_time(6666);
+        let l1_min_time_6666 = partition.create_parquet_file(builder).await;
+
+        // Create a level 0 file
+        let builder = TestParquetFileBuilder::default()
+            .with_line_protocol(ARBITRARY_LINE_PROTOCOL)
+            .with_compaction_level(CompactionLevel::Initial);
+        let l0 = partition.create_parquet_file(builder).await;
+
+        // Create a level 2 file
+        let builder = TestParquetFileBuilder::default()
+            .with_line_protocol(ARBITRARY_LINE_PROTOCOL)
+            .with_compaction_level(CompactionLevel::Final);
+        let l2 = partition.create_parquet_file(builder).await;
+
+        let partition_with_info =
+            Arc::new(PartitionCompactionCandidateWithInfo::from_test_partition(&partition).await);
+
+        let parquet_files_for_compaction = ParquetFilesForCompaction::for_partition(
+            Arc::clone(&catalog.catalog),
+            partition_with_info,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            parquet_files_for_compaction.level_0,
+            vec![CompactorParquetFile::new(l0.parquet_file, 0)]
+        );
+
+        assert_eq!(
+            parquet_files_for_compaction.level_1,
+            vec![
+                CompactorParquetFile::new(l1_min_time_6666.parquet_file, 0),
+                CompactorParquetFile::new(l1_min_time_7777.parquet_file, 0),
+                CompactorParquetFile::new(l1_min_time_8888.parquet_file, 0),
+            ]
+        );
+
+        assert_eq!(
+            parquet_files_for_compaction.level_2,
+            vec![CompactorParquetFile::new(l2.parquet_file, 0)]
         );
     }
 }

--- a/compactor/src/parquet_file_lookup.rs
+++ b/compactor/src/parquet_file_lookup.rs
@@ -30,7 +30,8 @@ pub(crate) struct ParquetFilesForCompaction {
     /// sequence number.
     pub(crate) level_0: Vec<CompactorParquetFile>,
 
-    /// Parquet files for a partition with `CompactionLevel::FileNonOverlapped`. Arbitrary order.
+    /// Parquet files for a partition with `CompactionLevel::FileNonOverlapped`. Ordered by
+    /// ascending max sequence number.
     pub(crate) level_1: Vec<CompactorParquetFile>,
 
     /// Parquet files for a partition with `CompactionLevel::Final`. Arbitrary order.
@@ -96,6 +97,7 @@ impl ParquetFilesForCompaction {
         }
 
         level_0.sort_by_key(|pf| pf.max_sequence_number());
+        level_1.sort_by_key(|pf| pf.max_sequence_number());
 
         Ok(Self {
             level_0,

--- a/compactor/src/query.rs
+++ b/compactor/src/query.rs
@@ -50,6 +50,17 @@ pub struct QueryableParquetChunk {
     sort_key: Option<SortKey>,
     partition_sort_key: Option<SortKey>,
     compaction_level: CompactionLevel,
+    /// The compaction level that this operation will be when finished. Chunks from files that have
+    /// the same level as this should get chunk order 0 so that files at a lower compaction level
+    /// (and thus created later) should have priority in deduplication.
+    ///
+    /// That is:
+    ///
+    /// * When compacting L0 + L1, the target level is L1. L0 files should have priority, so all L1
+    ///   files should have chunk order 0 to be sorted first.
+    /// * When compacting L1 + L2, the target level is L2. L1 files should have priority, so all L2
+    ///   files should have chunk order 0 to be sorted first.
+    target_level: CompactionLevel,
 }
 
 impl QueryableParquetChunk {
@@ -66,6 +77,7 @@ impl QueryableParquetChunk {
         sort_key: Option<SortKey>,
         partition_sort_key: Option<SortKey>,
         compaction_level: CompactionLevel,
+        target_level: CompactionLevel,
     ) -> Self {
         let delete_predicates = tombstones_to_delete_predicates(deletes);
         Self {
@@ -79,6 +91,7 @@ impl QueryableParquetChunk {
             sort_key,
             partition_sort_key,
             compaction_level,
+            target_level,
         }
     }
 
@@ -233,11 +246,30 @@ impl QueryChunk for QueryableParquetChunk {
         "QueryableParquetChunk"
     }
 
-    // Order of the chunk so they can be deduplicate correctly
+    // Order of the chunk so they can be deduplicated correctly
     fn order(&self) -> ChunkOrder {
-        match self.compaction_level {
-            CompactionLevel::Initial => ChunkOrder::new(self.max_sequence_number.get()),
-            CompactionLevel::FileNonOverlapped | CompactionLevel::Final => ChunkOrder::new(0),
+        use CompactionLevel::*;
+        match (self.target_level, self.compaction_level) {
+            // Files of the same level as what they're being compacting into were created earlier,
+            // so they should be sorted first so that files created later that haven't yet been
+            // compacted to this level will have priority when resolving duplicates.
+            (FileNonOverlapped, FileNonOverlapped) => ChunkOrder::new(0),
+            (Final, Final) => ChunkOrder::new(0),
+
+            // Files that haven't yet been compacted to the target level were created later and
+            // should be sorted based on the appropriate order for their level.
+            (FileNonOverlapped, Initial) => ChunkOrder::new(self.max_sequence_number.get()),
+            (Final, FileNonOverlapped) => ChunkOrder::new(self.min_time()),
+
+            // These combinations of target compaction level and file compaction level are
+            // invalid in this context given the current compaction algorithm.
+            (Initial, _) => panic!("Can't compact into CompactionLevel::Initial"),
+            (FileNonOverlapped, Final) => panic!(
+                "Can't compact CompactionLevel::Final into CompactionLevel::FileNonOverlapped"
+            ),
+            (Final, Initial) => {
+                panic!("Can't compact CompactionLevel::Initial into CompactionLevel::Final")
+            }
         }
     }
 
@@ -255,7 +287,9 @@ mod tests {
 
     async fn test_setup(
         compaction_level: CompactionLevel,
+        target_level: CompactionLevel,
         max_sequence_number: i64,
+        min_time: i64,
     ) -> QueryableParquetChunk {
         let catalog = TestCatalog::new();
         let ns = catalog.create_namespace("ns").await;
@@ -274,7 +308,8 @@ mod tests {
         let builder = TestParquetFileBuilder::default()
             .with_line_protocol(&lp)
             .with_compaction_level(compaction_level)
-            .with_max_seq(max_sequence_number);
+            .with_max_seq(max_sequence_number)
+            .with_min_time(min_time);
         let file = partition.create_parquet_file(builder).await;
         let parquet_file = Arc::new(file.parquet_file);
 
@@ -295,19 +330,52 @@ mod tests {
             None,
             None,
             parquet_file.compaction_level,
+            target_level,
         )
     }
 
     #[tokio::test]
-    async fn chunk_order_is_max_seq_when_compaction_level_0() {
-        let chunk = test_setup(CompactionLevel::Initial, 2).await;
+    async fn chunk_order_is_max_seq_when_compaction_level_0_and_target_level_1() {
+        let chunk = test_setup(
+            CompactionLevel::Initial,
+            CompactionLevel::FileNonOverlapped,
+            2,
+            1_000_000,
+        )
+        .await;
 
         assert_eq!(chunk.order(), ChunkOrder::new(2));
     }
 
     #[tokio::test]
-    async fn chunk_order_is_0_when_compaction_level_1() {
-        let chunk = test_setup(CompactionLevel::FileNonOverlapped, 2).await;
+    async fn chunk_order_is_0_when_compaction_level_1_and_target_level_1() {
+        let chunk = test_setup(
+            CompactionLevel::FileNonOverlapped,
+            CompactionLevel::FileNonOverlapped,
+            2,
+            1_000_000,
+        )
+        .await;
+
+        assert_eq!(chunk.order(), ChunkOrder::new(0));
+    }
+
+    #[tokio::test]
+    async fn chunk_order_is_max_seq_when_compaction_level_1_and_target_level_2() {
+        let chunk = test_setup(
+            CompactionLevel::FileNonOverlapped,
+            CompactionLevel::Final,
+            2,
+            1_000_000,
+        )
+        .await;
+
+        assert_eq!(chunk.order(), ChunkOrder::new(1_000_000,));
+    }
+
+    #[tokio::test]
+    async fn chunk_order_is_0_when_compaction_level_2_and_target_level_2() {
+        let chunk = test_setup(CompactionLevel::Final, CompactionLevel::Final, 2, 1_000_000).await;
 
         assert_eq!(chunk.order(), ChunkOrder::new(0));
     }

--- a/compactor/src/utils.rs
+++ b/compactor/src/utils.rs
@@ -2,7 +2,8 @@
 
 use crate::query::QueryableParquetChunk;
 use data_types::{
-    ParquetFile, ParquetFileId, TableSchema, Timestamp, TimestampMinMax, Tombstone, TombstoneId,
+    CompactionLevel, ParquetFile, ParquetFileId, TableSchema, Timestamp, TimestampMinMax,
+    Tombstone, TombstoneId,
 };
 use observability_deps::tracing::*;
 use parquet_file::{chunk::ParquetChunk, storage::ParquetStorage};
@@ -114,6 +115,7 @@ impl ParquetFileWithTombstone {
         table_name: String,
         table_schema: &TableSchema,
         partition_sort_key: Option<SortKey>,
+        target_level: CompactionLevel,
     ) -> QueryableParquetChunk {
         let column_id_lookup = table_schema.column_id_map();
         let selection: Vec<_> = self
@@ -156,6 +158,7 @@ impl ParquetFileWithTombstone {
             sort_key,
             partition_sort_key,
             self.data.compaction_level,
+            target_level,
         )
     }
 }

--- a/data_types/src/lib.rs
+++ b/data_types/src/lib.rs
@@ -53,7 +53,20 @@ impl TryFrom<i32> for CompactionLevel {
         match value {
             x if x == Self::Initial as i32 => Ok(Self::Initial),
             x if x == Self::FileNonOverlapped as i32 => Ok(Self::FileNonOverlapped),
+            x if x == Self::Final as i32 => Ok(Self::Final),
             _ => Err("invalid compaction level value".into()),
+        }
+    }
+}
+
+impl CompactionLevel {
+    /// When compacting files of this level, provide the level that the resulting file should be.
+    /// Does not exceed the maximum available level.
+    pub fn next(&self) -> Self {
+        match self {
+            Self::Initial => Self::FileNonOverlapped,
+            Self::FileNonOverlapped => Self::Final,
+            _ => Self::Final,
         }
     }
 }


### PR DESCRIPTION
This PR re-enables full compaction by making `filter_parquet_files` more general to handle either level 0 -> level 1 compaction or level 1 -> level 2 compaction.

This implementation of full compaction is more similar to the other compaction procedures in that it will only limit groups based on the estimated arrow bytes memory budget code (it does not use `max_desired_file_size_bytes`). It differs from the other compaction procedures in that it doesn't split the output files based on `split_percentage`; it will always create one level 2 file per group.

I don't think we actually need to limit the group sizes using `max_desired_file_size_bytes` too, because:

- The estimated arrow bytes are a function of the columns and rows
- The file sizes are also a function of the column and rows
- The grouping code is likely to always hit the limiting based on the estimated arrow bytes rather than the limiting based on the file size because as I understand it, the estimated arrow bytes is an underestimate

Please let me know if I'm mistaken and if it would be a problem to even try this code to see how it does.