### PR TITLE
perf: O(1) partition persist mark discovery

### DIFF
--- a/ingester/src/data.rs
+++ b/ingester/src/data.rs
@@ -1271,6 +1271,11 @@ mod tests {
             .create_or_get("1970-01-01".into(), shard.id, table.id)
             .await
             .unwrap();
+        repos
+            .partitions()
+            .update_persisted_sequence_number(partition.id, SequenceNumber::new(1))
+            .await
+            .unwrap();
         let partition2 = repos
             .partitions()
             .create_or_get("1970-01-02".into(), shard.id, table.id)
@@ -1330,7 +1335,9 @@ mod tests {
 
         let data = NamespaceData::new(namespace.id, &*metrics);
 
-        // w1 should be ignored so it shouldn't be present in the buffer
+        // w1 should be ignored because the per-partition replay offset is set
+        // to 1 already, so it shouldn't be buffered and the buffer should
+        // remain empty.
         let should_pause = data
             .buffer_operation(
                 DmlOperation::Write(w1),


### PR DESCRIPTION
This is the read-side change to use the per-partition persist markers added in https://github.com/influxdata/influxdb_iox/pull/5648 (described/tracked in https://github.com/influxdata/influxdb_iox/issues/5638).

This should significantly help https://github.com/influxdata/conductor/issues/971 for clusters that have been running more than a couple of weeks.

---

* perf: O(1) partition persist mark discovery (2b8985071)

      Changes the ingest code path to eliminate scanning the parquet_files table to
      discover the last persisted offset per partition, instead utilising the new
      persisted_sequence_number field on the Partition itself to read the same
      value.

      This lookup blocks ingest for the shard, so removing the expensive query from
      the ingest hot path should improve catch-up time after a restart/deployment.