### PR TITLE
refactor(ingester): remove redundant fn args

### DIFF
--- a/ingester/src/data.rs
+++ b/ingester/src/data.rs
@@ -267,7 +267,12 @@ impl Persister for IngesterData {
             .await
             .expect("retry forever");
 
-        let persisting_batch = namespace.snapshot_to_persisting(&partition_info).await;
+        let persisting_batch = namespace
+            .snapshot_to_persisting(
+                &partition_info.table_name,
+                &partition_info.partition.partition_key,
+            )
+            .await;
 
         if let Some(persisting_batch) = persisting_batch {
             // do the CPU intensive work of compaction, de-duplication and sorting

--- a/ingester/src/data.rs
+++ b/ingester/src/data.rs
@@ -166,7 +166,6 @@ impl IngesterData {
         shard_data
             .buffer_operation(
                 dml_operation,
-                shard_id,
                 self.catalog.as_ref(),
                 lifecycle_handle,
                 &self.exec,
@@ -653,7 +652,10 @@ mod tests {
 
         let mut shards = BTreeMap::new();
         let shard_index = ShardIndex::new(0);
-        shards.insert(shard1.id, ShardData::new(shard_index, Arc::clone(&metrics)));
+        shards.insert(
+            shard1.id,
+            ShardData::new(shard_index, shard1.id, Arc::clone(&metrics)),
+        );
 
         let object_store: Arc<DynObjectStore> = Arc::new(InMemory::new());
 
@@ -738,7 +740,7 @@ mod tests {
         let mut shards = BTreeMap::new();
         shards.insert(
             shard1.id,
-            ShardData::new(shard1.shard_index, Arc::clone(&metrics)),
+            ShardData::new(shard1.shard_index, shard1.id, Arc::clone(&metrics)),
         );
 
         let object_store: Arc<DynObjectStore> = Arc::new(InMemory::new());
@@ -843,11 +845,11 @@ mod tests {
         let mut shards = BTreeMap::new();
         shards.insert(
             shard1.id,
-            ShardData::new(shard1.shard_index, Arc::clone(&metrics)),
+            ShardData::new(shard1.shard_index, shard1.id, Arc::clone(&metrics)),
         );
         shards.insert(
             shard2.id,
-            ShardData::new(shard2.shard_index, Arc::clone(&metrics)),
+            ShardData::new(shard2.shard_index, shard2.id, Arc::clone(&metrics)),
         );
 
         let object_store: Arc<DynObjectStore> = Arc::new(InMemory::new());
@@ -1099,11 +1101,11 @@ mod tests {
         let mut shards = BTreeMap::new();
         shards.insert(
             shard1.id,
-            ShardData::new(shard1.shard_index, Arc::clone(&metrics)),
+            ShardData::new(shard1.shard_index, shard1.id, Arc::clone(&metrics)),
         );
         shards.insert(
             shard2.id,
-            ShardData::new(shard2.shard_index, Arc::clone(&metrics)),
+            ShardData::new(shard2.shard_index, shard2.id, Arc::clone(&metrics)),
         );
 
         let object_store: Arc<DynObjectStore> = Arc::new(InMemory::new());
@@ -1338,7 +1340,7 @@ mod tests {
         );
         let exec = Executor::new(1);
 
-        let data = NamespaceData::new(namespace.id, &*metrics);
+        let data = NamespaceData::new(namespace.id, shard.id, &*metrics);
 
         // w1 should be ignored because the per-partition replay offset is set
         // to 1 already, so it shouldn't be buffered and the buffer should
@@ -1346,7 +1348,6 @@ mod tests {
         let should_pause = data
             .buffer_operation(
                 DmlOperation::Write(w1),
-                shard.id,
                 catalog.as_ref(),
                 &manager.handle(),
                 &exec,
@@ -1368,7 +1369,6 @@ mod tests {
         // w2 should be in the buffer
         data.buffer_operation(
             DmlOperation::Write(w2),
-            shard.id,
             catalog.as_ref(),
             &manager.handle(),
             &exec,
@@ -1410,7 +1410,10 @@ mod tests {
 
         let mut shards = BTreeMap::new();
         let shard_index = ShardIndex::new(0);
-        shards.insert(shard1.id, ShardData::new(shard_index, Arc::clone(&metrics)));
+        shards.insert(
+            shard1.id,
+            ShardData::new(shard_index, shard1.id, Arc::clone(&metrics)),
+        );
 
         let object_store: Arc<DynObjectStore> = Arc::new(InMemory::new());
 

--- a/ingester/src/data/namespace.rs
+++ b/ingester/src/data/namespace.rs
@@ -233,11 +233,7 @@ impl NamespaceData {
                 .partition_data
                 .get_mut(&partition_info.partition.partition_key)
                 .and_then(|partition_data| {
-                    partition_data.snapshot_to_persisting_batch(
-                        partition_info.partition.shard_id,
-                        partition_info.partition.table_id,
-                        &partition_info.table_name,
-                    )
+                    partition_data.snapshot_to_persisting_batch(&partition_info.table_name)
                 });
         }
 

--- a/ingester/src/data/namespace.rs
+++ b/ingester/src/data/namespace.rs
@@ -236,7 +236,6 @@ impl NamespaceData {
                     partition_data.snapshot_to_persisting_batch(
                         partition_info.partition.shard_id,
                         partition_info.partition.table_id,
-                        partition_info.partition.id,
                         &partition_info.table_name,
                     )
                 });

--- a/ingester/src/data/partition.rs
+++ b/ingester/src/data/partition.rs
@@ -134,11 +134,10 @@ impl PartitionData {
         &mut self,
         shard_id: ShardId,
         table_id: TableId,
-        partition_id: PartitionId,
         table_name: &str,
     ) -> Option<Arc<PersistingBatch>> {
         self.data
-            .snapshot_to_persisting(shard_id, table_id, partition_id, table_name)
+            .snapshot_to_persisting(shard_id, table_id, self.id, table_name)
     }
 
     /// Snapshot whatever is in the buffer and return a new vec of the
@@ -463,12 +462,7 @@ mod tests {
         // ------------------------------------------
         // Persisting
         let p_batch = p
-            .snapshot_to_persisting_batch(
-                ShardId::new(s_id),
-                TableId::new(t_id),
-                PartitionId::new(p_id),
-                table_name,
-            )
+            .snapshot_to_persisting_batch(ShardId::new(s_id), TableId::new(t_id), table_name)
             .unwrap();
 
         // verify data

--- a/ingester/src/data/partition/buffer.rs
+++ b/ingester/src/data/partition/buffer.rs
@@ -109,7 +109,7 @@ impl DataBuffer {
     /// Both buffer and snapshots will be empty after this
     pub(super) fn snapshot_to_queryable_batch(
         &mut self,
-        table_name: &str,
+        table_name: &Arc<str>,
         partition_id: PartitionId,
         tombstone: Option<Tombstone>,
     ) -> Option<QueryableBatch> {
@@ -129,7 +129,7 @@ impl DataBuffer {
             None
         } else {
             Some(QueryableBatch::new(
-                table_name,
+                Arc::clone(table_name),
                 partition_id,
                 data,
                 tombstones,
@@ -164,7 +164,7 @@ impl DataBuffer {
         shard_id: ShardId,
         table_id: TableId,
         partition_id: PartitionId,
-        table_name: &str,
+        table_name: &Arc<str>,
     ) -> Option<Arc<PersistingBatch>> {
         if self.persisting.is_some() {
             panic!("Unable to snapshot while persisting. This is an unexpected state.")

--- a/ingester/src/data/table.rs
+++ b/ingester/src/data/table.rs
@@ -171,7 +171,12 @@ impl TableData {
 
         self.partition_data.insert(
             partition.partition_key,
-            PartitionData::new(partition.id, partition.persisted_sequence_number),
+            PartitionData::new(
+                partition.id,
+                shard_id,
+                self.table_id,
+                partition.persisted_sequence_number,
+            ),
         );
 
         Ok(())

--- a/ingester/src/handler.rs
+++ b/ingester/src/handler.rs
@@ -140,7 +140,7 @@ impl IngestHandlerImpl {
         for s in shard_states.values() {
             shards.insert(
                 s.id,
-                ShardData::new(s.shard_index, Arc::clone(&metric_registry)),
+                ShardData::new(s.shard_index, s.id, Arc::clone(&metric_registry)),
             );
         }
         let data = Arc::new(IngesterData::new(

--- a/ingester/src/querier_handler.rs
+++ b/ingester/src/querier_handler.rs
@@ -191,7 +191,7 @@ async fn prepare_data_to_querier_for_partition(
         .persisting
         .unwrap_or_else(|| {
             QueryableBatch::new(
-                &request.table,
+                request.table.clone().into(),
                 unpersisted_partition_data.partition_id,
                 vec![],
                 vec![],

--- a/ingester/src/query.rs
+++ b/ingester/src/query.rs
@@ -57,7 +57,7 @@ pub struct QueryableBatch {
     pub(crate) delete_predicates: Vec<Arc<DeletePredicate>>,
 
     /// This is needed to return a reference for a trait function
-    pub(crate) table_name: String,
+    pub(crate) table_name: Arc<str>,
 
     /// Partition ID
     pub(crate) partition_id: PartitionId,
@@ -66,7 +66,7 @@ pub struct QueryableBatch {
 impl QueryableBatch {
     /// Initilaize a QueryableBatch
     pub fn new(
-        table_name: &str,
+        table_name: Arc<str>,
         partition_id: PartitionId,
         data: Vec<Arc<SnapshotBatch>>,
         deletes: Vec<Tombstone>,
@@ -75,7 +75,7 @@ impl QueryableBatch {
         Self {
             data,
             delete_predicates,
-            table_name: table_name.to_string(),
+            table_name,
             partition_id,
         }
     }
@@ -318,7 +318,7 @@ mod tests {
 
         // This new queryable batch will convert tombstone to delete predicates
         let query_batch =
-            QueryableBatch::new("test_table", PartitionId::new(0), vec![], tombstones);
+            QueryableBatch::new("test_table".into(), PartitionId::new(0), vec![], tombstones);
         let predicates = query_batch.delete_predicates();
         let expected = vec![
             Arc::new(DeletePredicate {

--- a/ingester/src/test_util.rs
+++ b/ingester/src/test_util.rs
@@ -952,7 +952,7 @@ fn make_first_partition_data(
 
     if loc.contains(DataLocation::PERSISTING) {
         // Move group 1 data to persisting
-        p1.snapshot_to_persisting_batch(shard_id, table_id, partition_id, table_name);
+        p1.snapshot_to_persisting_batch(shard_id, table_id, table_name);
     } else if loc.contains(DataLocation::SNAPSHOT) {
         // move group 1 data to snapshot
         p1.snapshot().unwrap();

--- a/ingester/src/test_util.rs
+++ b/ingester/src/test_util.rs
@@ -809,7 +809,7 @@ pub(crate) fn make_partitions(
     let mut seq_num = seq_num.get();
     if two_partitions {
         let partition_id = PartitionId::new(2);
-        let mut p2 = PartitionData::new(partition_id, None);
+        let mut p2 = PartitionData::new(partition_id, shard_id, table_id, None);
         // Group 4: in buffer of p2
         // Fill `buffer`
         seq_num += 1;
@@ -933,7 +933,7 @@ fn make_first_partition_data(
 
     // ------------------------------------------
     // Build the first partition
-    let mut p1 = PartitionData::new(partition_id, None);
+    let mut p1 = PartitionData::new(partition_id, shard_id, table_id, None);
     let mut seq_num = 0;
 
     // --------------------
@@ -952,7 +952,7 @@ fn make_first_partition_data(
 
     if loc.contains(DataLocation::PERSISTING) {
         // Move group 1 data to persisting
-        p1.snapshot_to_persisting_batch(shard_id, table_id, table_name);
+        p1.snapshot_to_persisting_batch(table_name);
     } else if loc.contains(DataLocation::SNAPSHOT) {
         // move group 1 data to snapshot
         p1.snapshot().unwrap();

--- a/ingester/src/test_util.rs
+++ b/ingester/src/test_util.rs
@@ -692,11 +692,13 @@ pub fn make_ingester_data(two_partitions: bool, loc: DataLocation) -> IngesterDa
     let empty_tbl = Arc::new(tokio::sync::RwLock::new(TableData::new(
         empty_table_id,
         "test_table",
+        shard_id,
         None,
     )));
     let data_tbl = Arc::new(tokio::sync::RwLock::new(TableData::new_for_test(
         data_table_id,
         "test_table",
+        shard_id,
         None,
         partitions,
     )));
@@ -705,14 +707,18 @@ pub fn make_ingester_data(two_partitions: bool, loc: DataLocation) -> IngesterDa
 
     // Two namespaces: one empty and one with data of 2 tables
     let mut namespaces = BTreeMap::new();
-    let empty_ns = Arc::new(NamespaceData::new(NamespaceId::new(1), &*metrics));
-    let data_ns = Arc::new(NamespaceData::new_for_test(NamespaceId::new(2), tables));
+    let empty_ns = Arc::new(NamespaceData::new(NamespaceId::new(1), shard_id, &*metrics));
+    let data_ns = Arc::new(NamespaceData::new_for_test(
+        NamespaceId::new(2),
+        shard_id,
+        tables,
+    ));
     namespaces.insert(TEST_NAMESPACE_EMPTY.to_string(), empty_ns);
     namespaces.insert(TEST_NAMESPACE.to_string(), data_ns);
 
     // One shard that contains 2 namespaces
     let shard_index = ShardIndex::new(0);
-    let shard_data = ShardData::new_for_test(shard_index, namespaces);
+    let shard_data = ShardData::new_for_test(shard_index, shard_id, namespaces);
     let mut shards = BTreeMap::new();
     shards.insert(shard_id, shard_data);
 
@@ -743,7 +749,7 @@ pub async fn make_ingester_data_with_tombstones(loc: DataLocation) -> IngesterDa
 
     // Two tables: one empty and one with data of one or two partitions
     let mut tables = BTreeMap::new();
-    let data_tbl = TableData::new_for_test(data_table_id, TEST_TABLE, None, partitions);
+    let data_tbl = TableData::new_for_test(data_table_id, TEST_TABLE, shard_id, None, partitions);
     tables.insert(
         TEST_TABLE.to_string(),
         Arc::new(tokio::sync::RwLock::new(data_tbl)),
@@ -751,12 +757,16 @@ pub async fn make_ingester_data_with_tombstones(loc: DataLocation) -> IngesterDa
 
     // Two namespaces: one empty and one with data of 2 tables
     let mut namespaces = BTreeMap::new();
-    let data_ns = Arc::new(NamespaceData::new_for_test(NamespaceId::new(2), tables));
+    let data_ns = Arc::new(NamespaceData::new_for_test(
+        NamespaceId::new(2),
+        shard_id,
+        tables,
+    ));
     namespaces.insert(TEST_NAMESPACE.to_string(), data_ns);
 
     // One shard that contains 1 namespace
     let shard_index = ShardIndex::new(0);
-    let shard_data = ShardData::new_for_test(shard_index, namespaces);
+    let shard_data = ShardData::new_for_test(shard_index, shard_id, namespaces);
     let mut shards = BTreeMap::new();
     shards.insert(shard_id, shard_data);
 

--- a/query_tests/src/scenarios/util.rs
+++ b/query_tests/src/scenarios/util.rs
@@ -694,7 +694,11 @@ impl MockIngester {
 
         let shards = BTreeMap::from([(
             shard.shard.id,
-            ShardData::new(shard.shard.shard_index, catalog.metric_registry()),
+            ShardData::new(
+                shard.shard.shard_index,
+                shard.shard.id,
+                catalog.metric_registry(),
+            ),
         )]);
         let ingester_data = Arc::new(IngesterData::new(
             catalog.object_store(),


### PR DESCRIPTION
All this PR does is change a function like this:

```rust
partition_data.snapshot_to_persisting_batch(
  partition_info.partition.shard_id,
  partition_info.partition.table_id,
  partition_info.partition.id,
  &partition_info.table_name,
)
```

which has a risk of being passed the wrong thing, instead removing the redundant args (a partition should know it's own ID):

```rust
partition_data.snapshot_to_persisting_batch()
```

It replicates the same pattern where necessary for the shard, namespace, table & partition.

There catalog could be pulled out of fn args in a similar way, but I have grander plans for it that will help simplify testing so it can live there for a bit longer.

---

* refactor: snapshot_to_persisting redundant ID (85d6efafe)

      Partition::snapshot_to_persisting() passes the ID of the partition it is 
      calling `snapshot_to_persisting()` on. The partition already knows what its ID
      is, so at best it's redundant, and at worst, inconsistent with the actual ID.

* refactor: ShardId & TableId in PartitionData (c7ba0bea9)

      When we construct a PartitionData we have the ShardId and TableId. This commit
      stores them in the PartitionData for later use, rather than repeatedly passing
      them in again when constructing snapshots, at the risk of passing the wrong
      IDs.

* refactor: add table name in PartitionData (07b08fa9c)

      A partition belongs to a table - this commit stores the table name in the
      PartitionData (which was readily available at construction time) instead of
      redundantly passing it into various functions at the risk of getting it wrong.

* refactor: store ShardId in child nodes (b0eb85ddd)

      Instead of passing the ShardId into each function for child nodes of the 
      Shard, store it. This avoids the possibility of mistakenly passing the wrong
      value.