### PR TITLE
refactor: Add helper methods for computing times to TimeProvider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1019,6 +1019,7 @@ name = "data_types"
 version = "0.1.0"
 dependencies = [
  "influxdb_line_protocol",
+ "iox_time",
  "observability_deps",
  "ordered-float 3.0.0",
  "percent-encoding",

--- a/compactor/src/cold.rs
+++ b/compactor/src/cold.rs
@@ -116,7 +116,7 @@ mod tests {
     use iox_query::exec::Executor;
     use iox_tests::util::{TestCatalog, TestParquetFileBuilder};
     use iox_time::{SystemProvider, TimeProvider};
-    use std::{collections::HashMap, time::Duration};
+    use std::collections::HashMap;
 
     #[tokio::test]
     async fn test_compact_remaining_level_0_files_many_files() {
@@ -178,7 +178,7 @@ mod tests {
 
         let partition = table.with_shard(&shard).create_partition("part").await;
         let time = Arc::new(SystemProvider::new());
-        let time_38_hour_ago = (time.now() - Duration::from_secs(60 * 60 * 38)).timestamp_nanos();
+        let time_38_hour_ago = time.hours_ago_in_ns(38);
         let config = make_compactor_config();
         let metrics = Arc::new(metric::Registry::new());
         let compactor = Compactor::new(
@@ -412,7 +412,7 @@ mod tests {
 
         let partition = table.with_shard(&shard).create_partition("part").await;
         let time = Arc::new(SystemProvider::new());
-        let time_38_hour_ago = (time.now() - Duration::from_secs(60 * 60 * 38)).timestamp_nanos();
+        let time_38_hour_ago = time.hours_ago_in_ns(38);
         let config = make_compactor_config();
         let metrics = Arc::new(metric::Registry::new());
         let compactor = Compactor::new(
@@ -627,7 +627,7 @@ mod tests {
         table.create_column("time", ColumnType::Time).await;
         let partition = table.with_shard(&shard).create_partition("part").await;
         let time = Arc::new(SystemProvider::new());
-        let time_38_hour_ago = (time.now() - Duration::from_secs(60 * 60 * 38)).timestamp_nanos();
+        let time_38_hour_ago = time.hours_ago_in_ns(38);
         let config = make_compactor_config();
         let metrics = Arc::new(metric::Registry::new());
         let compactor = Arc::new(Compactor::new(
@@ -752,7 +752,7 @@ mod tests {
 
         let partition = table.with_shard(&shard).create_partition("part").await;
         let time = Arc::new(SystemProvider::new());
-        let time_38_hour_ago = (time.now() - Duration::from_secs(60 * 60 * 38)).timestamp_nanos();
+        let time_38_hour_ago = time.hours_ago_in_ns(38);
         let config = make_compactor_config();
         let metrics = Arc::new(metric::Registry::new());
         let compactor = Arc::new(Compactor::new(
@@ -962,7 +962,7 @@ mod tests {
 
         let partition = table.with_shard(&shard).create_partition("part").await;
         let time = Arc::new(SystemProvider::new());
-        let time_38_hour_ago = (time.now() - Duration::from_secs(60 * 60 * 38)).timestamp_nanos();
+        let time_38_hour_ago = time.hours_ago_in_ns(38);
         let mut config = make_compactor_config();
 
         // Set the memory budget such that only some of the files will be compacted in a group

--- a/compactor/src/cold.rs
+++ b/compactor/src/cold.rs
@@ -178,7 +178,7 @@ mod tests {
 
         let partition = table.with_shard(&shard).create_partition("part").await;
         let time = Arc::new(SystemProvider::new());
-        let time_38_hour_ago = time.hours_ago_in_ns(38);
+        let time_38_hour_ago = time.hours_ago(38);
         let config = make_compactor_config();
         let metrics = Arc::new(metric::Registry::new());
         let compactor = Compactor::new(
@@ -412,7 +412,7 @@ mod tests {
 
         let partition = table.with_shard(&shard).create_partition("part").await;
         let time = Arc::new(SystemProvider::new());
-        let time_38_hour_ago = time.hours_ago_in_ns(38);
+        let time_38_hour_ago = time.hours_ago(38);
         let config = make_compactor_config();
         let metrics = Arc::new(metric::Registry::new());
         let compactor = Compactor::new(
@@ -627,7 +627,7 @@ mod tests {
         table.create_column("time", ColumnType::Time).await;
         let partition = table.with_shard(&shard).create_partition("part").await;
         let time = Arc::new(SystemProvider::new());
-        let time_38_hour_ago = time.hours_ago_in_ns(38);
+        let time_38_hour_ago = time.hours_ago(38);
         let config = make_compactor_config();
         let metrics = Arc::new(metric::Registry::new());
         let compactor = Arc::new(Compactor::new(
@@ -752,7 +752,7 @@ mod tests {
 
         let partition = table.with_shard(&shard).create_partition("part").await;
         let time = Arc::new(SystemProvider::new());
-        let time_38_hour_ago = time.hours_ago_in_ns(38);
+        let time_38_hour_ago = time.hours_ago(38);
         let config = make_compactor_config();
         let metrics = Arc::new(metric::Registry::new());
         let compactor = Arc::new(Compactor::new(
@@ -962,7 +962,7 @@ mod tests {
 
         let partition = table.with_shard(&shard).create_partition("part").await;
         let time = Arc::new(SystemProvider::new());
-        let time_38_hour_ago = time.hours_ago_in_ns(38);
+        let time_38_hour_ago = time.hours_ago(38);
         let mut config = make_compactor_config();
 
         // Set the memory budget such that only some of the files will be compacted in a group

--- a/compactor/src/compact.rs
+++ b/compactor/src/compact.rs
@@ -285,11 +285,8 @@ impl Compactor {
             // the last 4 hours. If not, increase to 24 hours
             let mut num_partitions = 0;
             for num_hours in [4, 24] {
-                // convert "now() - num_hours" to timenanosecond
-                let time_at_num_hours_ago = Timestamp::new(
-                    (self.time_provider.now() - Duration::from_secs(60 * 60 * num_hours))
-                        .timestamp_nanos(),
-                );
+                let time_at_num_hours_ago =
+                    Timestamp::from(self.time_provider.hours_ago(num_hours));
 
                 let mut partitions = repos
                     .parquet_files()
@@ -804,16 +801,10 @@ pub mod tests {
         );
 
         // Some times in the past to set to created_at of the files
-        let time_now = Timestamp::new(compactor.time_provider.now().timestamp_nanos());
-        let time_three_minutes_ago = Timestamp::new(
-            (compactor.time_provider.now() - Duration::from_secs(60 * 3)).timestamp_nanos(),
-        );
-        let time_five_hour_ago = Timestamp::new(
-            (compactor.time_provider.now() - Duration::from_secs(60 * 60 * 5)).timestamp_nanos(),
-        );
-        let time_38_hour_ago = Timestamp::new(
-            (compactor.time_provider.now() - Duration::from_secs(60 * 60 * 38)).timestamp_nanos(),
-        );
+        let time_now = Timestamp::from(compactor.time_provider.now());
+        let time_three_minutes_ago = Timestamp::from(compactor.time_provider.minutes_ago(3));
+        let time_five_hour_ago = Timestamp::from(compactor.time_provider.hours_ago(5));
+        let time_38_hour_ago = Timestamp::from(compactor.time_provider.hours_ago(38));
 
         // Basic parquet info
         let p1 = ParquetFileParams {

--- a/compactor/src/compact.rs
+++ b/compactor/src/compact.rs
@@ -380,7 +380,7 @@ impl Compactor {
                 ("partition_type", compaction_type.into()),
             ]);
 
-            let time_8_hours_ago = Timestamp::new(self.time_provider.hours_ago_in_ns(8));
+            let time_8_hours_ago = Timestamp::from(self.time_provider.hours_ago(8));
 
             let mut repos = self.catalog.repositories().await;
             let mut partitions = repos
@@ -1075,8 +1075,8 @@ pub mod tests {
         );
 
         // Some times in the past to set to created_at of the files
-        let time_5_hour_ago = Timestamp::new(compactor.time_provider.hours_ago_in_ns(5));
-        let time_9_hour_ago = Timestamp::new(compactor.time_provider.hours_ago_in_ns(9));
+        let time_5_hour_ago = Timestamp::from(compactor.time_provider.hours_ago(5));
+        let time_9_hour_ago = Timestamp::from(compactor.time_provider.hours_ago(9));
 
         // Basic parquet info
         let p1 = ParquetFileParams {

--- a/compactor/src/compact.rs
+++ b/compactor/src/compact.rs
@@ -380,9 +380,7 @@ impl Compactor {
                 ("partition_type", compaction_type.into()),
             ]);
 
-            let time_8_hours_ago = Timestamp::new(
-                (self.time_provider.now() - Duration::from_secs(60 * 60 * 8)).timestamp_nanos(),
-            );
+            let time_8_hours_ago = Timestamp::new(self.time_provider.hours_ago_in_ns(8));
 
             let mut repos = self.catalog.repositories().await;
             let mut partitions = repos
@@ -649,7 +647,6 @@ pub mod tests {
     };
     use iox_tests::util::{TestCatalog, TestPartition};
     use iox_time::SystemProvider;
-    use std::time::Duration;
     use uuid::Uuid;
 
     impl PartitionCompactionCandidateWithInfo {
@@ -1078,12 +1075,8 @@ pub mod tests {
         );
 
         // Some times in the past to set to created_at of the files
-        let time_5_hour_ago = Timestamp::new(
-            (compactor.time_provider.now() - Duration::from_secs(60 * 60 * 5)).timestamp_nanos(),
-        );
-        let time_9_hour_ago = Timestamp::new(
-            (compactor.time_provider.now() - Duration::from_secs(60 * 60 * 9)).timestamp_nanos(),
-        );
+        let time_5_hour_ago = Timestamp::new(compactor.time_provider.hours_ago_in_ns(5));
+        let time_9_hour_ago = Timestamp::new(compactor.time_provider.hours_ago_in_ns(9));
 
         // Basic parquet info
         let p1 = ParquetFileParams {

--- a/compactor/src/garbage_collector.rs
+++ b/compactor/src/garbage_collector.rs
@@ -130,8 +130,7 @@ mod tests {
             Arc::clone(&catalog.catalog),
             Arc::clone(&catalog.object_store),
         );
-        let older_than =
-            Timestamp::new((gc.time_provider.now() + Duration::from_secs(100)).timestamp_nanos());
+        let older_than = Timestamp::from(gc.time_provider.now() + Duration::from_secs(100));
 
         gc.cleanup(older_than).await.unwrap();
     }
@@ -143,8 +142,7 @@ mod tests {
             Arc::clone(&catalog.catalog),
             Arc::clone(&catalog.object_store),
         );
-        let older_than =
-            Timestamp::new((gc.time_provider.now() + Duration::from_secs(100)).timestamp_nanos());
+        let older_than = Timestamp::from(gc.time_provider.now() + Duration::from_secs(100));
 
         let mut txn = catalog.catalog.start_transaction().await.unwrap();
         let topic = txn.topics().create_or_get("foo").await.unwrap();
@@ -224,8 +222,7 @@ mod tests {
             Arc::clone(&catalog.catalog),
             Arc::clone(&catalog.object_store),
         );
-        let older_than =
-            Timestamp::new((gc.time_provider.now() - Duration::from_secs(100)).timestamp_nanos());
+        let older_than = Timestamp::from(gc.time_provider.now() - Duration::from_secs(100));
 
         let mut txn = catalog.catalog.start_transaction().await.unwrap();
         let topic = txn.topics().create_or_get("foo").await.unwrap();
@@ -309,8 +306,7 @@ mod tests {
             Arc::clone(&catalog.catalog),
             Arc::clone(&catalog.object_store),
         );
-        let older_than =
-            Timestamp::new((gc.time_provider.now() + Duration::from_secs(100)).timestamp_nanos());
+        let older_than = Timestamp::from(gc.time_provider.now() + Duration::from_secs(100));
 
         let mut txn = catalog.catalog.start_transaction().await.unwrap();
         let topic = txn.topics().create_or_get("foo").await.unwrap();

--- a/compactor/src/hot.rs
+++ b/compactor/src/hot.rs
@@ -89,7 +89,7 @@ mod tests {
     use iox_tests::util::{TestCatalog, TestParquetFileBuilder};
     use iox_time::{SystemProvider, TimeProvider};
     use parquet_file::storage::ParquetStorage;
-    use std::{collections::HashMap, sync::Arc, time::Duration};
+    use std::{collections::HashMap, sync::Arc};
 
     #[tokio::test]
     async fn test_compact_hot_partition_candidates() {
@@ -104,8 +104,7 @@ mod tests {
         } = test_setup().await;
 
         // Some times in the past to set to created_at of the files
-        let hot_time_one_hour_ago =
-            (compactor.time_provider.now() - Duration::from_secs(60 * 60)).timestamp_nanos();
+        let hot_time_one_hour_ago = compactor.time_provider.hours_ago(1);
 
         // P1:
         //   L0 2 rows. bytes: 1125 * 2 = 2,250
@@ -426,7 +425,7 @@ mod tests {
             .with_max_seq(3)
             .with_min_time(10)
             .with_max_time(20)
-            .with_creation_time(20);
+            .with_creation_time(time.now());
         let f = partition.create_parquet_file(builder).await;
         size_overrides.insert(
             f.parquet_file.id,
@@ -439,7 +438,7 @@ mod tests {
             .with_max_seq(5)
             .with_min_time(8_000)
             .with_max_time(20_000)
-            .with_creation_time(time.now().timestamp_nanos());
+            .with_creation_time(time.now());
         let f = partition.create_parquet_file(builder).await;
         size_overrides.insert(f.parquet_file.id, 100); // small file
 
@@ -449,7 +448,7 @@ mod tests {
             .with_max_seq(10)
             .with_min_time(6_000)
             .with_max_time(25_000)
-            .with_creation_time(time.now().timestamp_nanos());
+            .with_creation_time(time.now());
         let f = partition.create_parquet_file(builder).await;
         size_overrides.insert(f.parquet_file.id, 100); // small file
 
@@ -459,7 +458,7 @@ mod tests {
             .with_max_seq(18)
             .with_min_time(26_000)
             .with_max_time(28_000)
-            .with_creation_time(time.now().timestamp_nanos());
+            .with_creation_time(time.now());
         let f = partition.create_parquet_file(builder).await;
         size_overrides.insert(f.parquet_file.id, 100); // small file
 
@@ -469,7 +468,7 @@ mod tests {
             .with_max_seq(1)
             .with_min_time(9)
             .with_max_time(25)
-            .with_creation_time(time.now().timestamp_nanos())
+            .with_creation_time(time.now())
             .with_compaction_level(CompactionLevel::FileNonOverlapped);
         let f = partition.create_parquet_file(builder).await;
         size_overrides.insert(f.parquet_file.id, 100); // small file
@@ -480,7 +479,7 @@ mod tests {
             .with_max_seq(20)
             .with_min_time(90000)
             .with_max_time(91000)
-            .with_creation_time(time.now().timestamp_nanos())
+            .with_creation_time(time.now())
             .with_compaction_level(CompactionLevel::FileNonOverlapped);
         let f = partition.create_parquet_file(builder).await;
         size_overrides.insert(f.parquet_file.id, 100); // small file

--- a/data_types/Cargo.toml
+++ b/data_types/Cargo.toml
@@ -6,6 +6,7 @@ description = "Shared data types"
 
 [dependencies]
 influxdb_line_protocol = { path = "../influxdb_line_protocol" }
+iox_time = { path = "../iox_time" }
 observability_deps = { path = "../observability_deps" }
 ordered-float = "3"
 percent-encoding = "2.2.0"

--- a/data_types/src/lib.rs
+++ b/data_types/src/lib.rs
@@ -344,8 +344,15 @@ impl Timestamp {
     pub fn new(v: i64) -> Self {
         Self(v)
     }
+
     pub fn get(&self) -> i64 {
         self.0
+    }
+}
+
+impl From<iox_time::Time> for Timestamp {
+    fn from(time: iox_time::Time) -> Self {
+        Self::new(time.timestamp_nanos())
     }
 }
 

--- a/garbage_collector/src/parquetfile/deleter.rs
+++ b/garbage_collector/src/parquetfile/deleter.rs
@@ -12,7 +12,7 @@ pub(crate) async fn perform(
     sleep_interval_minutes: u64,
 ) -> Result<()> {
     loop {
-        let older_than = Timestamp::new((catalog.time_provider().now() - cutoff).timestamp_nanos());
+        let older_than = Timestamp::from(catalog.time_provider().now() - cutoff);
         // do the delete, returning the deleted files
         let deleted = catalog
             .repositories()

--- a/iox_catalog/src/interface.rs
+++ b/iox_catalog/src/interface.rs
@@ -2809,9 +2809,9 @@ pub(crate) mod test_helpers {
             .await
             .unwrap();
 
-        let time_five_hour_ago = Timestamp::new(catalog.time_provider().hours_ago_in_ns(5));
-        let time_8_hours_ago = Timestamp::new(catalog.time_provider().hours_ago_in_ns(8));
-        let time_38_hour_ago = Timestamp::new(catalog.time_provider().hours_ago_in_ns(38));
+        let time_five_hour_ago = Timestamp::from(catalog.time_provider().hours_ago(5));
+        let time_8_hours_ago = Timestamp::from(catalog.time_provider().hours_ago(8));
+        let time_38_hour_ago = Timestamp::from(catalog.time_provider().hours_ago(38));
 
         let num_partitions = 2;
 
@@ -3115,7 +3115,7 @@ pub(crate) mod test_helpers {
         let num_partitions = 2;
 
         let time_at_num_minutes_ago =
-            Timestamp::new(catalog.time_provider().minutes_ago_in_ns(num_minutes));
+            Timestamp::from(catalog.time_provider().minutes_ago(num_minutes));
 
         // Case 1
         // Db has no partition
@@ -3151,12 +3151,12 @@ pub(crate) mod test_helpers {
         assert!(partitions.is_empty());
 
         // Time for testing
-        let time_now = Timestamp::new(catalog.time_provider().now().timestamp_nanos());
-        let time_one_hour_ago = Timestamp::new(catalog.time_provider().hours_ago_in_ns(1));
-        let time_two_hour_ago = Timestamp::new(catalog.time_provider().hours_ago_in_ns(2));
-        let time_three_hour_ago = Timestamp::new(catalog.time_provider().hours_ago_in_ns(3));
-        let time_five_hour_ago = Timestamp::new(catalog.time_provider().hours_ago_in_ns(5));
-        let time_ten_hour_ago = Timestamp::new(catalog.time_provider().hours_ago_in_ns(10));
+        let time_now = Timestamp::from(catalog.time_provider().now());
+        let time_one_hour_ago = Timestamp::from(catalog.time_provider().hours_ago(1));
+        let time_two_hour_ago = Timestamp::from(catalog.time_provider().hours_ago(2));
+        let time_three_hour_ago = Timestamp::from(catalog.time_provider().hours_ago(3));
+        let time_five_hour_ago = Timestamp::from(catalog.time_provider().hours_ago(5));
+        let time_ten_hour_ago = Timestamp::from(catalog.time_provider().hours_ago(10));
 
         // Case 3
         // The partition has one deleted file

--- a/iox_catalog/src/interface.rs
+++ b/iox_catalog/src/interface.rs
@@ -2809,15 +2809,9 @@ pub(crate) mod test_helpers {
             .await
             .unwrap();
 
-        let time_five_hour_ago = Timestamp::new(
-            (catalog.time_provider().now() - Duration::from_secs(60 * 60 * 5)).timestamp_nanos(),
-        );
-        let time_8_hours_ago = Timestamp::new(
-            (catalog.time_provider().now() - Duration::from_secs(60 * 60 * 8)).timestamp_nanos(),
-        );
-        let time_38_hour_ago = Timestamp::new(
-            (catalog.time_provider().now() - Duration::from_secs(60 * 60 * 38)).timestamp_nanos(),
-        );
+        let time_five_hour_ago = Timestamp::new(catalog.time_provider().hours_ago_in_ns(5));
+        let time_8_hours_ago = Timestamp::new(catalog.time_provider().hours_ago_in_ns(8));
+        let time_38_hour_ago = Timestamp::new(catalog.time_provider().hours_ago_in_ns(38));
 
         let num_partitions = 2;
 
@@ -3120,10 +3114,8 @@ pub(crate) mod test_helpers {
         let min_num_files = 2;
         let num_partitions = 2;
 
-        let time_at_num_minutes_ago = Timestamp::new(
-            (catalog.time_provider().now() - Duration::from_secs(60 * num_minutes))
-                .timestamp_nanos(),
-        );
+        let time_at_num_minutes_ago =
+            Timestamp::new(catalog.time_provider().minutes_ago_in_ns(num_minutes));
 
         // Case 1
         // Db has no partition
@@ -3160,21 +3152,11 @@ pub(crate) mod test_helpers {
 
         // Time for testing
         let time_now = Timestamp::new(catalog.time_provider().now().timestamp_nanos());
-        let time_one_hour_ago = Timestamp::new(
-            (catalog.time_provider().now() - Duration::from_secs(60 * 60)).timestamp_nanos(),
-        );
-        let time_two_hour_ago = Timestamp::new(
-            (catalog.time_provider().now() - Duration::from_secs(60 * 60 * 2)).timestamp_nanos(),
-        );
-        let time_three_hour_ago = Timestamp::new(
-            (catalog.time_provider().now() - Duration::from_secs(60 * 60 * 3)).timestamp_nanos(),
-        );
-        let time_five_hour_ago = Timestamp::new(
-            (catalog.time_provider().now() - Duration::from_secs(60 * 60 * 5)).timestamp_nanos(),
-        );
-        let time_ten_hour_ago = Timestamp::new(
-            (catalog.time_provider().now() - Duration::from_secs(60 * 60 * 10)).timestamp_nanos(),
-        );
+        let time_one_hour_ago = Timestamp::new(catalog.time_provider().hours_ago_in_ns(1));
+        let time_two_hour_ago = Timestamp::new(catalog.time_provider().hours_ago_in_ns(2));
+        let time_three_hour_ago = Timestamp::new(catalog.time_provider().hours_ago_in_ns(3));
+        let time_five_hour_ago = Timestamp::new(catalog.time_provider().hours_ago_in_ns(5));
+        let time_ten_hour_ago = Timestamp::new(catalog.time_provider().hours_ago_in_ns(10));
 
         // Case 3
         // The partition has one deleted file

--- a/iox_catalog/src/mem.rs
+++ b/iox_catalog/src/mem.rs
@@ -854,7 +854,7 @@ impl PartitionRepo for MemTxn {
         reason: &str,
     ) -> Result<()> {
         let reason = reason.to_string();
-        let skipped_at = Timestamp::new(self.time_provider.now().timestamp_nanos());
+        let skipped_at = Timestamp::from(self.time_provider.now());
 
         let stage = self.stage();
         match stage
@@ -1076,7 +1076,7 @@ impl ParquetFileRepo for MemTxn {
     }
 
     async fn flag_for_delete(&mut self, id: ParquetFileId) -> Result<()> {
-        let marked_at = Timestamp::new(self.time_provider.now().timestamp_nanos());
+        let marked_at = Timestamp::from(self.time_provider.now());
         let stage = self.stage();
 
         match stage.parquet_files.iter_mut().find(|p| p.id == id) {

--- a/iox_catalog/src/postgres.rs
+++ b/iox_catalog/src/postgres.rs
@@ -1609,7 +1609,7 @@ RETURNING *;
     }
 
     async fn flag_for_delete(&mut self, id: ParquetFileId) -> Result<()> {
-        let marked_at = Timestamp::new(self.time_provider.now().timestamp_nanos());
+        let marked_at = Timestamp::from(self.time_provider.now());
 
         let _ = sqlx::query(r#"UPDATE parquet_file SET to_delete = $1 WHERE id = $2;"#)
             .bind(&marked_at) // $1
@@ -2892,7 +2892,7 @@ mod tests {
         // parquet file to create- all we care about here is the size, the rest is to satisfy DB
         // constraints
         let time_provider = Arc::new(SystemProvider::new());
-        let time_now = Timestamp::new(time_provider.now().timestamp_nanos());
+        let time_now = Timestamp::from(time_provider.now());
         let mut p1 = ParquetFileParams {
             shard_id,
             namespace_id,
@@ -2951,7 +2951,7 @@ mod tests {
         assert_eq!(total_file_size_bytes, 1337 * 2);
 
         // actually deleting shouldn't change the total
-        let now = Timestamp::new((time_provider.now()).timestamp_nanos());
+        let now = Timestamp::from(time_provider.now());
         postgres
             .repositories()
             .await

--- a/iox_tests/src/util.rs
+++ b/iox_tests/src/util.rs
@@ -750,8 +750,8 @@ impl TestParquetFileBuilder {
     }
 
     /// Specify the creation time for the parquet file metadata.
-    pub fn with_creation_time(mut self, creation_time: i64) -> Self {
-        self.creation_time = creation_time;
+    pub fn with_creation_time(mut self, creation_time: iox_time::Time) -> Self {
+        self.creation_time = creation_time.timestamp_nanos();
         self
     }
 

--- a/iox_time/src/lib.rs
+++ b/iox_time/src/lib.rs
@@ -190,6 +190,18 @@ pub trait TimeProvider: std::fmt::Debug + Send + Sync + 'static {
 
     /// Sleep until given time.
     fn sleep_until(&self, t: Time) -> Pin<Box<dyn Future<Output = ()> + Send + 'static>>;
+
+    /// Given a number of minutes, return the number of nanoseconds the specified number of minutes
+    /// in the past relative to this provider's `now`.
+    fn minutes_ago_in_ns(&self, minutes_ago: u64) -> i64 {
+        (self.now() - Duration::from_secs(60 * minutes_ago)).timestamp_nanos()
+    }
+
+    /// Given a number of hours, return the number of nanoseconds the specified number of hours in
+    /// the past relative to this provider's `now`.
+    fn hours_ago_in_ns(&self, hours_ago: u64) -> i64 {
+        (self.now() - Duration::from_secs(60 * 60 * hours_ago)).timestamp_nanos()
+    }
 }
 
 /// A [`TimeProvider`] that uses [`Utc::now`] as a clock source
@@ -579,5 +591,29 @@ mod test {
         assert!(Time::from_timestamp_nanos(505)
             .checked_duration_since(Time::from_timestamp_nanos(506))
             .is_none());
+    }
+
+    #[test]
+    fn test_minutes_ago() {
+        let now = "2022-07-07T00:00:00+00:00";
+        let ago = "2022-07-06T22:38:00+00:00";
+
+        let provider = MockProvider::new(Time::from_rfc3339(now).unwrap());
+
+        let min_ago_ns = provider.minutes_ago_in_ns(82);
+        assert_eq!(min_ago_ns, 1657147080000000000);
+        assert_eq!(Time::from_timestamp_nanos(min_ago_ns).to_rfc3339(), ago);
+    }
+
+    #[test]
+    fn test_hours_ago() {
+        let now = "2022-07-07T00:00:00+00:00";
+        let ago = "2022-07-03T14:00:00+00:00";
+
+        let provider = MockProvider::new(Time::from_rfc3339(now).unwrap());
+
+        let hrs_ago_ns = provider.hours_ago_in_ns(82);
+        assert_eq!(hrs_ago_ns, 1656856800000000000);
+        assert_eq!(Time::from_timestamp_nanos(hrs_ago_ns).to_rfc3339(), ago);
     }
 }

--- a/iox_time/src/lib.rs
+++ b/iox_time/src/lib.rs
@@ -191,16 +191,16 @@ pub trait TimeProvider: std::fmt::Debug + Send + Sync + 'static {
     /// Sleep until given time.
     fn sleep_until(&self, t: Time) -> Pin<Box<dyn Future<Output = ()> + Send + 'static>>;
 
-    /// Given a number of minutes, return the number of nanoseconds the specified number of minutes
-    /// in the past relative to this provider's `now`.
-    fn minutes_ago_in_ns(&self, minutes_ago: u64) -> i64 {
-        (self.now() - Duration::from_secs(60 * minutes_ago)).timestamp_nanos()
+    /// Return a time that is the specified number of minutes in the past relative to this
+    /// provider's `now`.
+    fn minutes_ago(&self, minutes_ago: u64) -> Time {
+        self.now() - Duration::from_secs(60 * minutes_ago)
     }
 
-    /// Given a number of hours, return the number of nanoseconds the specified number of hours in
-    /// the past relative to this provider's `now`.
-    fn hours_ago_in_ns(&self, hours_ago: u64) -> i64 {
-        (self.now() - Duration::from_secs(60 * 60 * hours_ago)).timestamp_nanos()
+    /// Return a time that is the specified number of hours in the past relative to this provider's
+    /// `now`.
+    fn hours_ago(&self, hours_ago: u64) -> Time {
+        self.now() - Duration::from_secs(60 * 60 * hours_ago)
     }
 }
 
@@ -600,9 +600,9 @@ mod test {
 
         let provider = MockProvider::new(Time::from_rfc3339(now).unwrap());
 
-        let min_ago_ns = provider.minutes_ago_in_ns(82);
-        assert_eq!(min_ago_ns, 1657147080000000000);
-        assert_eq!(Time::from_timestamp_nanos(min_ago_ns).to_rfc3339(), ago);
+        let min_ago = provider.minutes_ago(82);
+        assert_eq!(min_ago, Time::from_timestamp_nanos(1657147080000000000));
+        assert_eq!(min_ago.to_rfc3339(), ago);
     }
 
     #[test]
@@ -612,8 +612,8 @@ mod test {
 
         let provider = MockProvider::new(Time::from_rfc3339(now).unwrap());
 
-        let hrs_ago_ns = provider.hours_ago_in_ns(82);
-        assert_eq!(hrs_ago_ns, 1656856800000000000);
-        assert_eq!(Time::from_timestamp_nanos(hrs_ago_ns).to_rfc3339(), ago);
+        let hrs_ago = provider.hours_ago(82);
+        assert_eq!(hrs_ago, Time::from_timestamp_nanos(1656856800000000000));
+        assert_eq!(hrs_ago.to_rfc3339(), ago);
     }
 }

--- a/parquet_file/src/metadata.rs
+++ b/parquet_file/src/metadata.rs
@@ -462,7 +462,7 @@ impl IoxMetadata {
             file_size_bytes: file_size_bytes as i64,
             compaction_level: self.compaction_level,
             row_count: row_count.try_into().expect("row count overflows i64"),
-            created_at: Timestamp::new(self.creation_timestamp.timestamp_nanos()),
+            created_at: Timestamp::from(self.creation_timestamp),
             column_set: ColumnSet::new(columns),
         }
     }


### PR DESCRIPTION
There are a bunch of places this sort of math is done in the compactor and catalog, and rather than copy-pasting this everywhere, it can be a method on `TimeProvider`.