### PR TITLE
test: refactor ingester query tests

### DIFF
--- a/ingester/src/data/namespace.rs
+++ b/ingester/src/data/namespace.rs
@@ -100,23 +100,6 @@ impl NamespaceData {
         }
     }
 
-    /// Initialize new tables with data for testing purpose only
-    #[cfg(test)]
-    pub(crate) fn new_for_test(
-        namespace_id: NamespaceId,
-        shard_id: ShardId,
-        tables: BTreeMap<String, Arc<tokio::sync::RwLock<TableData>>>,
-    ) -> Self {
-        Self {
-            namespace_id,
-            shard_id,
-            tables: RwLock::new(tables),
-            table_count: Default::default(),
-            buffering_sequence_number: RwLock::new(None),
-            test_triggers: TestTriggers::new(),
-        }
-    }
-
     /// Buffer the operation in the cache, adding any new partitions or delete tombstones to the
     /// catalog. Returns true if ingest should be paused due to memory limits set in the passed
     /// lifecycle manager.

--- a/ingester/src/data/namespace.rs
+++ b/ingester/src/data/namespace.rs
@@ -16,10 +16,7 @@ use write_summary::ShardProgress;
 
 #[cfg(test)]
 use super::triggers::TestTriggers;
-use super::{
-    partition::{PersistingBatch, SnapshotBatch},
-    table::TableData,
-};
+use super::{partition::PersistingBatch, table::TableData};
 use crate::lifecycle::LifecycleHandle;
 
 /// Data of a Namespace that belongs to a given Shard
@@ -103,7 +100,7 @@ impl NamespaceData {
     /// Buffer the operation in the cache, adding any new partitions or delete tombstones to the
     /// catalog. Returns true if ingest should be paused due to memory limits set in the passed
     /// lifecycle manager.
-    pub async fn buffer_operation(
+    pub(super) async fn buffer_operation(
         &self,
         dml_operation: DmlOperation,
         catalog: &dyn Catalog,
@@ -180,11 +177,15 @@ impl NamespaceData {
 
     /// Snapshots the mutable buffer for the partition, which clears it out and moves it over to
     /// snapshots. Then return a vec of the snapshots and the optional persisting batch.
-    pub async fn snapshot(
+    #[cfg(test)] // Only used in tests
+    pub(crate) async fn snapshot(
         &self,
         table_name: &str,
         partition_key: &PartitionKey,
-    ) -> Option<(Vec<Arc<SnapshotBatch>>, Option<Arc<PersistingBatch>>)> {
+    ) -> Option<(
+        Vec<Arc<super::partition::SnapshotBatch>>,
+        Option<Arc<PersistingBatch>>,
+    )> {
         if let Some(t) = self.table_data(table_name) {
             let mut t = t.write().await;
 
@@ -202,7 +203,7 @@ impl NamespaceData {
     /// Snapshots the mutable buffer for the partition, which clears it out and then moves all
     /// snapshots over to a persisting batch, which is returned. If there is no data to snapshot
     /// or persist, None will be returned.
-    pub async fn snapshot_to_persisting(
+    pub(crate) async fn snapshot_to_persisting(
         &self,
         table_name: &str,
         partition_key: &PartitionKey,
@@ -298,12 +299,12 @@ impl NamespaceData {
     }
 
     /// Return the [`NamespaceId`] this [`NamespaceData`] belongs to.
-    pub fn namespace_id(&self) -> NamespaceId {
+    pub(super) fn namespace_id(&self) -> NamespaceId {
         self.namespace_id
     }
 
     #[cfg(test)]
-    pub fn table_count(&self) -> &U64Counter {
+    pub(super) fn table_count(&self) -> &U64Counter {
         &self.table_count
     }
 }

--- a/ingester/src/data/partition/buffer.rs
+++ b/ingester/src/data/partition/buffer.rs
@@ -232,6 +232,7 @@ impl DataBuffer {
         }
     }
 
+    #[cfg(test)]
     pub(super) fn get_snapshots(&self) -> &[Arc<SnapshotBatch>] {
         self.snapshots.as_ref()
     }

--- a/ingester/src/data/shard.rs
+++ b/ingester/src/data/shard.rs
@@ -51,22 +51,6 @@ impl ShardData {
         }
     }
 
-    /// Initialize new ShardData with namespace for testing purpose only
-    #[cfg(test)]
-    pub fn new_for_test(
-        shard_index: ShardIndex,
-        shard_id: ShardId,
-        namespaces: BTreeMap<String, Arc<NamespaceData>>,
-    ) -> Self {
-        Self {
-            shard_index,
-            shard_id,
-            namespaces: RwLock::new(namespaces),
-            metrics: Default::default(),
-            namespace_count: Default::default(),
-        }
-    }
-
     /// Store the write or delete in the shard. Deletes will
     /// be written into the catalog before getting stored in the buffer.
     /// Any writes that create new IOx partitions will have those records

--- a/ingester/src/data/shard.rs
+++ b/ingester/src/data/shard.rs
@@ -55,7 +55,7 @@ impl ShardData {
     /// be written into the catalog before getting stored in the buffer.
     /// Any writes that create new IOx partitions will have those records
     /// created in the catalog before putting into the buffer.
-    pub async fn buffer_operation(
+    pub(super) async fn buffer_operation(
         &self,
         dml_operation: DmlOperation,
         catalog: &dyn Catalog,
@@ -76,7 +76,7 @@ impl ShardData {
     }
 
     /// Gets the namespace data out of the map
-    pub fn namespace(&self, namespace: &str) -> Option<Arc<NamespaceData>> {
+    pub(crate) fn namespace(&self, namespace: &str) -> Option<Arc<NamespaceData>> {
         let n = self.namespaces.read();
         n.get(namespace).cloned()
     }
@@ -127,7 +127,7 @@ impl ShardData {
     }
 
     /// Return the [`ShardIndex`] this [`ShardData`] is buffering for.
-    pub fn shard_index(&self) -> ShardIndex {
+    pub(super) fn shard_index(&self) -> ShardIndex {
         self.shard_index
     }
 }

--- a/ingester/src/data/table.rs
+++ b/ingester/src/data/table.rs
@@ -45,7 +45,7 @@ impl TableData {
     }
 
     /// Return parquet_max_sequence_number
-    pub fn parquet_max_sequence_number(&self) -> Option<SequenceNumber> {
+    pub(super) fn parquet_max_sequence_number(&self) -> Option<SequenceNumber> {
         self.partition_data
             .values()
             .map(|p| p.max_persisted_sequence_number())
@@ -55,7 +55,7 @@ impl TableData {
 
     /// Return tombstone_max_sequence_number
     #[allow(dead_code)] // Used in tests
-    pub fn tombstone_max_sequence_number(&self) -> Option<SequenceNumber> {
+    pub(super) fn tombstone_max_sequence_number(&self) -> Option<SequenceNumber> {
         self.tombstone_max_sequence_number
     }
 
@@ -132,7 +132,7 @@ impl TableData {
         Ok(())
     }
 
-    pub fn unpersisted_partition_data(&self) -> Vec<UnpersistedPartitionData> {
+    pub(crate) fn unpersisted_partition_data(&self) -> Vec<UnpersistedPartitionData> {
         self.partition_data
             .values()
             .map(|p| UnpersistedPartitionData {

--- a/ingester/src/data/table.rs
+++ b/ingester/src/data/table.rs
@@ -44,24 +44,6 @@ impl TableData {
         }
     }
 
-    /// Initialize new table buffer for testing purpose only
-    #[cfg(test)]
-    pub fn new_for_test(
-        table_id: TableId,
-        table_name: &str,
-        shard_id: ShardId,
-        tombstone_max_sequence_number: Option<SequenceNumber>,
-        partitions: BTreeMap<PartitionKey, PartitionData>,
-    ) -> Self {
-        Self {
-            table_id,
-            table_name: table_name.into(),
-            shard_id,
-            tombstone_max_sequence_number,
-            partition_data: partitions,
-        }
-    }
-
     /// Return parquet_max_sequence_number
     pub fn parquet_max_sequence_number(&self) -> Option<SequenceNumber> {
         self.partition_data

--- a/ingester/src/querier_handler.rs
+++ b/ingester/src/querier_handler.rs
@@ -423,7 +423,7 @@ mod tests {
                 DataLocation::SNAPSHOT_PERSISTING,
                 DataLocation::PERSISTING,
             ] {
-                let scenario = Arc::new(make_ingester_data(two_partitions, loc));
+                let scenario = Arc::new(make_ingester_data(two_partitions, loc).await);
                 scenarios.push((loc, scenario));
             }
         }


### PR DESCRIPTION
This is the change needed to unblock #5658, described [here](https://github.com/influxdata/influxdb_iox/pull/5658#issuecomment-1249464240) as:

> The failing tests construct every bit of ingester state from the bottom up - it populates each buffer, partition, table, namespace and shard and is therefore very tightly coupled with the current code - it makes a lot of assumptions about how the ingester works internally, rather than driving the ingester and asserting on the result.
> 
> I am untangling these tests - instead of setting the various bits of state to reflect what the test **believes** should be the state after buffering a write/delete, I am instead writing the test to simply buffer the writes/deletes through the ingester using the same code paths as actual writes/deletes and **test the resulting state** that the ingester builds up.
> 
> This is a large (test code only) change, and I will PR it separately - this PR is on hold until then 👍

The reduced coupling should make #5658 mergeable, and allowed me to remove a bunch of `pub` fields and test-only funcs.

---

* test(ingester): refactor querier API tests (6d00d6b68)

      This commit changes the prepare_data_to_querier() tests to drive the ingester
      state by applying DML ops, therefore driving the prod code paths (and testing
      them!) rather than having the tests set up what the tests believe is the
      correct internal ingester state, and then asserting on that state.

      This gives us much better coverage of prod code paths, decouples the tests
      from the internal state/representation of ingesters (making the tests less
      fragile), and removes a bunch of special-cased, test-only functions that are
      functionally similar, but not the same as, the prod functions.

      Unblocks #5658, further clean-up to come.

* refactor(ingester): reduced internal visibility (c6fe0dab3)

      Changes many pub fields / methods to be pub(super), or if necessary, 
      pub(crate).

      This helps maintain an internal API boundary for code hygiene, and helps 
      identify functions that are unused / only used in tests (which I've annotated
      with cfg(test) and intend to remove - we should be driving code under test via
      the public API rather than using test-only state mutation, otherwise we're
      just testing our tests!)