### PR TITLE
refactor: avoid clones for `policy::Subscriber::set`

### DIFF
--- a/cache_system/src/backend/policy/refresh.rs
+++ b/cache_system/src/backend/policy/refresh.rs
@@ -330,11 +330,11 @@ where
 
     fn set(
         &mut self,
-        k: Self::K,
-        v: Self::V,
+        k: &Self::K,
+        v: &Self::V,
         now: Time,
     ) -> Vec<ChangeRequest<'static, Self::K, Self::V>> {
-        let d = self.refresh_duration_provider.refresh_in(&k, &v);
+        let d = self.refresh_duration_provider.refresh_in(k, v);
 
         let mut timings = self.timings.lock();
 
@@ -345,10 +345,10 @@ where
                 running_refresh: None,
             };
 
-            timings.insert(k, state);
+            timings.insert(k.clone(), state);
         } else {
             // need to remove potentially existing entry that had some refresh set
-            timings.remove(&k);
+            timings.remove(k);
 
             // the removal drops the RefreshState which triggers a cancelation for any potentially running
             // refresh operation

--- a/cache_system/src/backend/policy/ttl.rs
+++ b/cache_system/src/backend/policy/ttl.rs
@@ -184,13 +184,13 @@ where
 
     fn set(
         &mut self,
-        k: Self::K,
-        v: Self::V,
+        k: &Self::K,
+        v: &Self::V,
         now: Time,
     ) -> Vec<ChangeRequest<'static, Self::K, Self::V>> {
         let mut requests = self.evict_expired(now);
 
-        if let Some(ttl) = self.ttl_provider.expires_in(&k, &v) {
+        if let Some(ttl) = self.ttl_provider.expires_in(k, v) {
             if ttl.is_zero() {
                 requests.push(ChangeRequest::remove(k.clone()));
             }
@@ -201,12 +201,12 @@ where
                 }
                 None => {
                     // Still need to ensure that any current expiration is disabled
-                    self.expiration.remove(&k);
+                    self.expiration.remove(k);
                 }
             }
         } else {
             // Still need to ensure that any current expiration is disabled
-            self.expiration.remove(&k);
+            self.expiration.remove(k);
         };
 
         requests


### PR DESCRIPTION
Policy subscribers basically never store `V` (the cached value), so we should not clone that one unconditionally. But even `K` (the cache key) is not stored in all cases. So let's pass a reference for both and let the policies decide if they wanna clone the data or not.