### PR TITLE
feat: Generate the requested num rows and compaction type

### DIFF
--- a/influxdb_iox/src/commands/compactor/generate.rs
+++ b/influxdb_iox/src/commands/compactor/generate.rs
@@ -390,7 +390,9 @@ impl TimeValues {
                 start: minutes_per_file * (file_id + 1) - overlap_minutes * file_id
                     + full_range_end_minutes,
                 end: minutes_per_file * file_id - overlap_minutes * file_id
-                    + full_range_end_minutes,
+                    + full_range_end_minutes
+                    // When the overlap is 0, subtract 1 because the data generator is inclusive
+                    - (if overlap_minutes == 0 { 1 } else { 0 }),
             })
             .collect();
 
@@ -502,7 +504,7 @@ mod tests {
                 start_end_args,
                 vec![StartEndMinutesAgo {
                     start: 24 * 60,
-                    end: 8 * 60,
+                    end: 8 * 60 - 1,
                 }]
             );
         }
@@ -521,7 +523,7 @@ mod tests {
                 start_end_args,
                 vec![StartEndMinutesAgo {
                     start: 24 * 60,
-                    end: 8 * 60,
+                    end: 8 * 60 - 1,
                 }]
             );
         }
@@ -541,15 +543,15 @@ mod tests {
                 vec![
                     StartEndMinutesAgo {
                         start: 1440,
-                        end: 1120
+                        end: 1119,
                     },
                     StartEndMinutesAgo {
                         start: 1120,
-                        end: 800
+                        end: 799,
                     },
                     StartEndMinutesAgo {
                         start: 800,
-                        end: 480
+                        end: 479,
                     },
                 ]
             );
@@ -570,15 +572,15 @@ mod tests {
                 vec![
                     StartEndMinutesAgo {
                         start: 1440,
-                        end: 1120
+                        end: 1119,
                     },
                     StartEndMinutesAgo {
                         start: 1120,
-                        end: 800
+                        end: 799,
                     },
                     StartEndMinutesAgo {
                         start: 800,
-                        end: 480
+                        end: 479,
                     },
                 ]
             );

--- a/influxdb_iox/src/commands/compactor/generate.rs
+++ b/influxdb_iox/src/commands/compactor/generate.rs
@@ -109,8 +109,13 @@ pub async fn run(config: Config) -> Result<()> {
     let spec_in_root = root_dir.join(&spec_location);
 
     for file_id in 0..config.num_files.get() {
-        write_data_generation_spec(file_id, Arc::clone(&object_store), &config, &spec_location)
-            .await?;
+        write_data_generation_spec(
+            file_id,
+            Arc::clone(&object_store),
+            config.num_columns.get(),
+            &spec_location,
+        )
+        .await?;
         generate_data(&spec_in_root, &lp_dir)?;
     }
 
@@ -152,13 +157,13 @@ pub type Result<T, E = Error> = std::result::Result<T, E>;
 async fn write_data_generation_spec(
     file_id: usize,
     object_store: Arc<DynObjectStore>,
-    config: &Config,
+    num_columns: usize,
     spec_location: &str,
 ) -> Result<()> {
     let object_store_spec_path =
         object_store::path::Path::parse(spec_location).context(ObjectStorePathParsingSnafu)?;
 
-    let contents = data_generation_spec_contents(file_id, 1, config.num_columns.get());
+    let contents = data_generation_spec_contents(file_id, 1, num_columns);
     let data = Bytes::from(contents);
 
     object_store


### PR DESCRIPTION
Connects to https://github.com/influxdata/conductor/issues/1169.

Builds on https://github.com/influxdata/influxdb_iox/pull/5729.

## In this PR

- The `--num-rows` argument will now control how many rows end up in each line protocol file.
- When `--compaction-type hot` is specified (or if `--compaction-type` isn't specified, because hot is the default), the files will have data from about the last 30 minutes until now, and the data in each file will overlap its adjacent files' data by a minute on either side.
- When `--compaction-type cold` is specified, the files will have data from 24 hours ago to 8 hours ago, and the data in the files will NOT overlap their adjacent files' data.

## Still unimplemented

These pieces will be coming in future PRs:

- Actually generating files for `--num-partitions` specified
- Writing parquet files from these line protocol files
- Adding entries to the catalog
