### PR TITLE
refactor(ingester): limit visibility of internals

### DIFF
--- a/ingester/src/data.rs
+++ b/ingester/src/data.rs
@@ -98,14 +98,17 @@ pub struct IngesterData {
 
 impl IngesterData {
     /// Create new instance.
-    pub fn new(
+    pub fn new<T>(
         object_store: Arc<DynObjectStore>,
         catalog: Arc<dyn Catalog>,
-        shards: BTreeMap<ShardId, ShardData>,
+        shards: T,
         exec: Arc<Executor>,
         backoff_config: BackoffConfig,
         metrics: Arc<metric::Registry>,
-    ) -> Self {
+    ) -> Self
+    where
+        T: IntoIterator<Item = (ShardId, ShardIndex)>,
+    {
         let persisted_file_size_bytes = metrics.register_metric_with_options(
             "ingester_persisted_file_size_bytes",
             "Size of files persisted by the ingester",
@@ -120,6 +123,11 @@ impl IngesterData {
                 ])
             },
         );
+
+        let shards = shards
+            .into_iter()
+            .map(|(id, index)| (id, ShardData::new(index, id, Arc::clone(&metrics))))
+            .collect();
 
         Self {
             store: ParquetStorage::new(object_store),
@@ -645,19 +653,12 @@ mod tests {
             .await
             .unwrap();
 
-        let mut shards = BTreeMap::new();
-        let shard_index = ShardIndex::new(0);
-        shards.insert(
-            shard1.id,
-            ShardData::new(shard_index, shard1.id, Arc::clone(&metrics)),
-        );
-
         let object_store: Arc<DynObjectStore> = Arc::new(InMemory::new());
 
         let data = Arc::new(IngesterData::new(
             Arc::clone(&object_store),
             Arc::clone(&catalog),
-            shards,
+            [(shard1.id, shard_index)],
             Arc::new(Executor::new(1)),
             BackoffConfig::default(),
             Arc::clone(&metrics),
@@ -732,18 +733,13 @@ mod tests {
             .create_or_get(&topic, shard_index)
             .await
             .unwrap();
-        let mut shards = BTreeMap::new();
-        shards.insert(
-            shard1.id,
-            ShardData::new(shard1.shard_index, shard1.id, Arc::clone(&metrics)),
-        );
 
         let object_store: Arc<DynObjectStore> = Arc::new(InMemory::new());
 
         let data = Arc::new(IngesterData::new(
             Arc::clone(&object_store),
             Arc::clone(&catalog),
-            shards,
+            [(shard1.id, shard1.shard_index)],
             Arc::new(Executor::new(1)),
             BackoffConfig::default(),
             Arc::clone(&metrics),
@@ -837,22 +833,16 @@ mod tests {
             .create_or_get(&topic, shard_index)
             .await
             .unwrap();
-        let mut shards = BTreeMap::new();
-        shards.insert(
-            shard1.id,
-            ShardData::new(shard1.shard_index, shard1.id, Arc::clone(&metrics)),
-        );
-        shards.insert(
-            shard2.id,
-            ShardData::new(shard2.shard_index, shard2.id, Arc::clone(&metrics)),
-        );
 
         let object_store: Arc<DynObjectStore> = Arc::new(InMemory::new());
 
         let data = Arc::new(IngesterData::new(
             Arc::clone(&object_store),
             Arc::clone(&catalog),
-            shards,
+            [
+                (shard1.id, shard1.shard_index),
+                (shard2.id, shard2.shard_index),
+            ],
             Arc::new(Executor::new(1)),
             BackoffConfig::default(),
             Arc::clone(&metrics),
@@ -1093,22 +1083,16 @@ mod tests {
             .create_or_get(&topic, shard_index)
             .await
             .unwrap();
-        let mut shards = BTreeMap::new();
-        shards.insert(
-            shard1.id,
-            ShardData::new(shard1.shard_index, shard1.id, Arc::clone(&metrics)),
-        );
-        shards.insert(
-            shard2.id,
-            ShardData::new(shard2.shard_index, shard2.id, Arc::clone(&metrics)),
-        );
 
         let object_store: Arc<DynObjectStore> = Arc::new(InMemory::new());
 
         let data = Arc::new(IngesterData::new(
             Arc::clone(&object_store),
             Arc::clone(&catalog),
-            shards,
+            [
+                (shard1.id, shard1.shard_index),
+                (shard2.id, shard2.shard_index),
+            ],
             Arc::new(Executor::new(1)),
             BackoffConfig::default(),
             Arc::clone(&metrics),
@@ -1392,20 +1376,14 @@ mod tests {
             .create_or_get(&topic, shard_index)
             .await
             .unwrap();
-
-        let mut shards = BTreeMap::new();
         let shard_index = ShardIndex::new(0);
-        shards.insert(
-            shard1.id,
-            ShardData::new(shard_index, shard1.id, Arc::clone(&metrics)),
-        );
 
         let object_store: Arc<DynObjectStore> = Arc::new(InMemory::new());
 
         let data = Arc::new(IngesterData::new(
             Arc::clone(&object_store),
             Arc::clone(&catalog),
-            shards,
+            [(shard1.id, shard_index)],
             Arc::new(Executor::new(1)),
             BackoffConfig::default(),
             Arc::clone(&metrics),

--- a/ingester/src/data.rs
+++ b/ingester/src/data.rs
@@ -145,7 +145,7 @@ impl IngesterData {
     }
 
     /// Get shard data for specific shard.
-    #[allow(dead_code)] // Used in tests
+    #[cfg(test)]
     pub(crate) fn shard(&self, shard_id: ShardId) -> Option<&ShardData> {
         self.shards.get(&shard_id)
     }
@@ -178,7 +178,7 @@ impl IngesterData {
 
     /// Return the ingestion progress for the specified shards
     /// Returns an empty `ShardProgress` for any shards that this ingester doesn't know about.
-    pub(crate) async fn progresses(
+    pub(super) async fn progresses(
         &self,
         shard_indexes: Vec<ShardIndex>,
     ) -> BTreeMap<ShardIndex, ShardProgress> {
@@ -571,7 +571,7 @@ impl IngesterQueryResponse {
 }
 
 /// Flattened version of [`IngesterQueryResponse`].
-pub type FlatIngesterQueryResponseStream =
+pub(crate) type FlatIngesterQueryResponseStream =
     Pin<Box<dyn Stream<Item = Result<FlatIngesterQueryResponse, ArrowError>> + Send>>;
 
 /// Element within the flat wire protocol.

--- a/ingester/src/data/namespace.rs
+++ b/ingester/src/data/namespace.rs
@@ -81,7 +81,11 @@ pub(crate) struct NamespaceData {
 
 impl NamespaceData {
     /// Initialize new tables with default partition template of daily
-    pub fn new(namespace_id: NamespaceId, shard_id: ShardId, metrics: &metric::Registry) -> Self {
+    pub(super) fn new(
+        namespace_id: NamespaceId,
+        shard_id: ShardId,
+        metrics: &metric::Registry,
+    ) -> Self {
         let table_count = metrics
             .register_metric::<U64Counter>(
                 "ingester_tables_total",
@@ -271,7 +275,7 @@ impl NamespaceData {
     /// Walks down the table and partition and clears the persisting batch. The sequence number is
     /// the max_sequence_number for the persisted parquet file, which should be kept in the table
     /// data buffer.
-    pub(crate) async fn mark_persisted(
+    pub(super) async fn mark_persisted(
         &self,
         table_name: &str,
         partition_key: &PartitionKey,
@@ -288,7 +292,7 @@ impl NamespaceData {
     }
 
     /// Return progress from this Namespace
-    pub(crate) async fn progress(&self) -> ShardProgress {
+    pub(super) async fn progress(&self) -> ShardProgress {
         let tables: Vec<_> = self.tables.read().values().map(Arc::clone).collect();
 
         // Consolidate progtress across partitions.

--- a/ingester/src/data/partition.rs
+++ b/ingester/src/data/partition.rs
@@ -20,10 +20,10 @@ pub mod resolver;
 /// Read only copy of the unpersisted data for a partition in the ingester for a specific partition.
 #[derive(Debug)]
 pub(crate) struct UnpersistedPartitionData {
-    pub partition_id: PartitionId,
-    pub non_persisted: Vec<Arc<SnapshotBatch>>,
-    pub persisting: Option<QueryableBatch>,
-    pub partition_status: PartitionStatus,
+    pub(crate) partition_id: PartitionId,
+    pub(crate) non_persisted: Vec<Arc<SnapshotBatch>>,
+    pub(crate) persisting: Option<QueryableBatch>,
+    pub(crate) partition_status: PartitionStatus,
 }
 
 /// Status of a partition that has unpersisted data.
@@ -43,7 +43,7 @@ pub struct PartitionStatus {
 /// PersistingBatch contains all needed info and data for creating
 /// a parquet file for given set of SnapshotBatches
 #[derive(Debug, PartialEq, Clone)]
-pub struct PersistingBatch {
+pub(crate) struct PersistingBatch {
     /// Shard id of the data
     pub(crate) shard_id: ShardId,
 
@@ -60,9 +60,27 @@ pub struct PersistingBatch {
     pub(crate) data: Arc<QueryableBatch>,
 }
 
+impl PersistingBatch {
+    pub(crate) fn object_store_id(&self) -> Uuid {
+        self.object_store_id
+    }
+
+    pub(crate) fn shard_id(&self) -> ShardId {
+        self.shard_id
+    }
+
+    pub(crate) fn table_id(&self) -> TableId {
+        self.table_id
+    }
+
+    pub(crate) fn partition_id(&self) -> PartitionId {
+        self.partition_id
+    }
+}
+
 /// SnapshotBatch contains data of many contiguous BufferBatches
 #[derive(Debug, PartialEq)]
-pub struct SnapshotBatch {
+pub(crate) struct SnapshotBatch {
     /// Min sequence number of its combined BufferBatches
     pub(crate) min_sequence_number: SequenceNumber,
     /// Max sequence number of its combined BufferBatches
@@ -73,7 +91,10 @@ pub struct SnapshotBatch {
 
 impl SnapshotBatch {
     /// Return only data of the given columns
-    pub fn scan(&self, selection: Selection<'_>) -> Result<Option<Arc<RecordBatch>>, super::Error> {
+    pub(crate) fn scan(
+        &self,
+        selection: Selection<'_>,
+    ) -> Result<Option<Arc<RecordBatch>>, super::Error> {
         Ok(match selection {
             Selection::All => Some(Arc::clone(&self.data)),
             Selection::Some(columns) => {
@@ -129,7 +150,7 @@ pub(crate) struct PartitionData {
 
 impl PartitionData {
     /// Initialize a new partition data buffer
-    pub fn new(
+    pub(crate) fn new(
         id: PartitionId,
         shard_id: ShardId,
         table_id: TableId,

--- a/ingester/src/data/partition/buffer.rs
+++ b/ingester/src/data/partition/buffer.rs
@@ -251,13 +251,13 @@ impl DataBuffer {
 /// BufferBatch is a MutableBatch with its ingesting order, sequence_number, that helps the
 /// ingester keep the batches of data in their ingesting order
 #[derive(Debug)]
-pub struct BufferBatch {
+pub(crate) struct BufferBatch {
     /// Sequence number of the first write in this batch
     pub(crate) min_sequence_number: SequenceNumber,
     /// Sequence number of the last write in this batch
-    pub(crate) max_sequence_number: SequenceNumber,
+    pub(super) max_sequence_number: SequenceNumber,
     /// Ingesting data
-    pub(crate) data: MutableBatch,
+    pub(super) data: MutableBatch,
 }
 
 impl BufferBatch {

--- a/ingester/src/data/query_dedup.rs
+++ b/ingester/src/data/query_dedup.rs
@@ -39,7 +39,7 @@ pub type Result<T, E = Error> = std::result::Result<T, E>;
 
 /// Query a given Queryable Batch, applying selection and filters as appropriate
 /// Return stream of record batches
-pub async fn query(
+pub(crate) async fn query(
     executor: &Executor,
     data: Arc<QueryableBatch>,
 ) -> Result<SendableRecordBatchStream> {

--- a/ingester/src/data/shard.rs
+++ b/ingester/src/data/shard.rs
@@ -19,7 +19,7 @@ use crate::lifecycle::LifecycleHandle;
 
 /// Data of a Shard
 #[derive(Debug)]
-pub struct ShardData {
+pub(crate) struct ShardData {
     /// The shard index for this shard
     shard_index: ShardIndex,
     /// The catalog ID for this shard.
@@ -34,7 +34,11 @@ pub struct ShardData {
 
 impl ShardData {
     /// Initialise a new [`ShardData`] that emits metrics to `metrics`.
-    pub fn new(shard_index: ShardIndex, shard_id: ShardId, metrics: Arc<metric::Registry>) -> Self {
+    pub(super) fn new(
+        shard_index: ShardIndex,
+        shard_id: ShardId,
+        metrics: Arc<metric::Registry>,
+    ) -> Self {
         let namespace_count = metrics
             .register_metric::<U64Counter>(
                 "ingester_namespaces_total",
@@ -115,7 +119,7 @@ impl ShardData {
     }
 
     /// Return the progress of this shard
-    pub(crate) async fn progress(&self) -> ShardProgress {
+    pub(super) async fn progress(&self) -> ShardProgress {
         let namespaces: Vec<_> = self.namespaces.read().values().map(Arc::clone).collect();
 
         let mut progress = ShardProgress::new();

--- a/ingester/src/data/table.rs
+++ b/ingester/src/data/table.rs
@@ -45,7 +45,7 @@ impl TableData {
     /// The partition provider is used to instantiate a [`PartitionData`]
     /// instance when this [`TableData`] instance observes an op for a partition
     /// for the first time.
-    pub fn new(
+    pub(super) fn new(
         table_id: TableId,
         table_name: &str,
         shard_id: ShardId,
@@ -179,7 +179,7 @@ impl TableData {
     }
 
     /// Return progress from this Table
-    pub(crate) fn progress(&self) -> ShardProgress {
+    pub(super) fn progress(&self) -> ShardProgress {
         let progress = ShardProgress::new();
         let progress = match self.parquet_max_sequence_number() {
             Some(n) => progress.with_persisted(n),
@@ -194,7 +194,7 @@ impl TableData {
     }
 
     #[cfg(test)]
-    pub(crate) fn table_id(&self) -> TableId {
+    pub(super) fn table_id(&self) -> TableId {
         self.table_id
     }
 }

--- a/ingester/src/handler.rs
+++ b/ingester/src/handler.rs
@@ -32,8 +32,8 @@ use crate::{
     poison::PoisonCabinet,
     querier_handler::prepare_data_to_querier,
     stream_handler::{
-        sink_adaptor::IngestSinkAdaptor, sink_instrumentation::SinkInstrumentation,
-        PeriodicWatermarkFetcher, SequencedStreamHandler,
+        handler::SequencedStreamHandler, sink_adaptor::IngestSinkAdaptor,
+        sink_instrumentation::SinkInstrumentation, PeriodicWatermarkFetcher,
     },
 };
 

--- a/ingester/src/handler.rs
+++ b/ingester/src/handler.rs
@@ -27,7 +27,7 @@ use write_buffer::core::WriteBufferReading;
 use write_summary::ShardProgress;
 
 use crate::{
-    data::{shard::ShardData, IngesterData, IngesterQueryResponse},
+    data::{IngesterData, IngesterQueryResponse},
     lifecycle::{run_lifecycle_manager, LifecycleConfig, LifecycleManager},
     poison::PoisonCabinet,
     querier_handler::prepare_data_to_querier,
@@ -135,18 +135,10 @@ impl IngestHandlerImpl {
         skip_to_oldest_available: bool,
         max_requests: usize,
     ) -> Result<Self> {
-        // build the initial ingester data state
-        let mut shards = BTreeMap::new();
-        for s in shard_states.values() {
-            shards.insert(
-                s.id,
-                ShardData::new(s.shard_index, s.id, Arc::clone(&metric_registry)),
-            );
-        }
         let data = Arc::new(IngesterData::new(
             object_store,
             catalog,
-            shards,
+            shard_states.clone().into_iter().map(|(idx, s)| (s.id, idx)),
             exec,
             BackoffConfig::default(),
             Arc::clone(&metric_registry),

--- a/ingester/src/lib.rs
+++ b/ingester/src/lib.rs
@@ -13,16 +13,16 @@
     clippy::clone_on_ref_ptr
 )]
 
-pub mod compact;
+pub(crate) mod compact;
 pub mod data;
 pub mod handler;
 mod job;
 pub mod lifecycle;
 mod poison;
 pub mod querier_handler;
-pub mod query;
+pub(crate) mod query;
 pub mod server;
-pub mod stream_handler;
+pub(crate) mod stream_handler;
 
 #[cfg(test)]
-pub mod test_util;
+pub(crate) mod test_util;

--- a/ingester/src/lifecycle.rs
+++ b/ingester/src/lifecycle.rs
@@ -21,7 +21,7 @@ use crate::{
     poison::{PoisonCabinet, PoisonPill},
 };
 
-/// API suitable for ingester tasks to query and update the [`LifecycleManager`] state.
+/// API suitable for ingester tasks to query and update the server lifecycle state.
 pub trait LifecycleHandle: Send + Sync + 'static {
     /// Logs bytes written into a partition so that it can be tracked for the manager to
     /// trigger persistence. Returns true if the ingester should pause consuming from the
@@ -46,7 +46,7 @@ pub trait LifecycleHandle: Send + Sync + 'static {
 /// This handle presents an API suitable for ingester tasks to query and update
 /// the [`LifecycleManager`] state.
 #[derive(Debug, Clone)]
-pub struct LifecycleHandleImpl {
+pub(crate) struct LifecycleHandleImpl {
     time_provider: Arc<dyn TimeProvider>,
 
     config: Arc<LifecycleConfig>,
@@ -113,7 +113,7 @@ impl LifecycleHandle for LifecycleHandleImpl {
 /// A [`LifecycleManager`] MUST be driven by an external actor periodically
 /// calling [`LifecycleManager::maybe_persist()`].
 #[derive(Debug)]
-pub struct LifecycleManager {
+pub(crate) struct LifecycleManager {
     config: Arc<LifecycleConfig>,
     time_provider: Arc<dyn TimeProvider>,
     job_registry: Arc<JobRegistry>,
@@ -280,7 +280,7 @@ impl LifecycleManager {
     }
 
     /// Acquire a shareable [`LifecycleHandle`] for this manager instance.
-    pub fn handle(&self) -> LifecycleHandleImpl {
+    pub(super) fn handle(&self) -> LifecycleHandleImpl {
         LifecycleHandleImpl {
             time_provider: Arc::clone(&self.time_provider),
             config: Arc::clone(&self.config),

--- a/ingester/src/query.rs
+++ b/ingester/src/query.rs
@@ -49,7 +49,7 @@ pub type Result<T, E = Error> = std::result::Result<T, E>;
 
 /// Queryable data used for both query and persistence
 #[derive(Debug, PartialEq, Clone)]
-pub struct QueryableBatch {
+pub(crate) struct QueryableBatch {
     /// data
     pub(crate) data: Vec<Arc<SnapshotBatch>>,
 
@@ -65,7 +65,7 @@ pub struct QueryableBatch {
 
 impl QueryableBatch {
     /// Initilaize a QueryableBatch
-    pub fn new(
+    pub(crate) fn new(
         table_name: Arc<str>,
         partition_id: PartitionId,
         data: Vec<Arc<SnapshotBatch>>,
@@ -81,19 +81,19 @@ impl QueryableBatch {
     }
 
     /// Add snapshots to this batch
-    pub fn with_data(mut self, mut data: Vec<Arc<SnapshotBatch>>) -> Self {
+    pub(crate) fn with_data(mut self, mut data: Vec<Arc<SnapshotBatch>>) -> Self {
         self.data.append(&mut data);
         self
     }
 
     /// Add more tombstones
-    pub fn add_tombstones(&mut self, deletes: &[Tombstone]) {
+    pub(crate) fn add_tombstones(&mut self, deletes: &[Tombstone]) {
         let delete_predicates = tombstones_to_delete_predicates_iter(deletes);
         self.delete_predicates.extend(delete_predicates);
     }
 
     /// return min and max of all the snapshots
-    pub fn min_max_sequence_numbers(&self) -> (SequenceNumber, SequenceNumber) {
+    pub(crate) fn min_max_sequence_numbers(&self) -> (SequenceNumber, SequenceNumber) {
         let min = self
             .data
             .first()
@@ -112,7 +112,7 @@ impl QueryableBatch {
     }
 
     /// return true if it has no data
-    pub fn is_empty(&self) -> bool {
+    pub(crate) fn is_empty(&self) -> bool {
         self.data.is_empty()
     }
 }

--- a/ingester/src/stream_handler/handler.rs
+++ b/ingester/src/stream_handler/handler.rs
@@ -1,3 +1,5 @@
+//! A handler of streamed ops from a write buffer.
+
 use std::{fmt::Debug, time::Duration};
 
 use data_types::{SequenceNumber, ShardIndex};
@@ -32,7 +34,7 @@ const INGEST_POLL_INTERVAL: Duration = Duration::from_millis(100);
 /// [`LifecycleManager`]: crate::lifecycle::LifecycleManager
 /// [`LifecycleHandle::can_resume_ingest()`]: crate::lifecycle::LifecycleHandle::can_resume_ingest()
 #[derive(Debug)]
-pub struct SequencedStreamHandler<I, O, T = SystemProvider> {
+pub(crate) struct SequencedStreamHandler<I, O, T = SystemProvider> {
     /// Creator/manager of the stream of DML ops
     write_buffer_stream_handler: I,
 
@@ -80,7 +82,7 @@ impl<I, O> SequencedStreamHandler<I, O> {
     /// `stream` once [`SequencedStreamHandler::run()`] is called, and
     /// gracefully stops when `shutdown` is cancelled.
     #[allow(clippy::too_many_arguments)]
-    pub fn new(
+    pub(crate) fn new(
         write_buffer_stream_handler: I,
         current_sequence_number: SequenceNumber,
         sink: O,

--- a/ingester/src/stream_handler/mod.rs
+++ b/ingester/src/stream_handler/mod.rs
@@ -11,12 +11,13 @@
 //! limited by the [`LifecycleManager`] it is initialised by, pausing until
 //! [`LifecycleHandle::can_resume_ingest()`] returns true.
 //!
+//! [`SequencedStreamHandler`]: handler::SequencedStreamHandler
 //! [`DmlOperation`]: dml::DmlOperation
 //! [`WriteBufferReading`]: write_buffer::core::WriteBufferReading
 //! [`LifecycleManager`]: crate::lifecycle::LifecycleManager
 //! [`LifecycleHandle::can_resume_ingest()`]: crate::lifecycle::LifecycleHandle::can_resume_ingest()
 
-mod handler;
+pub mod handler;
 mod periodic_watermark_fetcher;
 mod sink;
 
@@ -27,6 +28,5 @@ pub mod mock_watermark_fetcher;
 pub mod sink_adaptor;
 pub mod sink_instrumentation;
 
-pub use handler::*;
 pub use periodic_watermark_fetcher::*;
 pub use sink::*;

--- a/ingester/src/stream_handler/periodic_watermark_fetcher.rs
+++ b/ingester/src/stream_handler/periodic_watermark_fetcher.rs
@@ -32,7 +32,7 @@ pub struct PeriodicWatermarkFetcher {
 impl PeriodicWatermarkFetcher {
     /// Instantiate a new [`PeriodicWatermarkFetcher`] that polls `write_buffer`
     /// every `interval` period for the maximum offset for `shard_index`.
-    pub fn new(
+    pub(crate) fn new(
         write_buffer: Arc<dyn WriteBufferReading>,
         shard_index: ShardIndex,
         interval: Duration,
@@ -61,7 +61,7 @@ impl PeriodicWatermarkFetcher {
     ///
     /// If the watermark value has yet to be observed (i.e. due to continuous
     /// fetch errors) `None` is returned.
-    pub fn cached_watermark(&self) -> Option<i64> {
+    pub(crate) fn cached_watermark(&self) -> Option<i64> {
         match self.last_watermark.load(Ordering::Relaxed) {
             // A value of 0 means "never observed a watermark".
             0 => None,

--- a/ingester/src/stream_handler/sink_adaptor.rs
+++ b/ingester/src/stream_handler/sink_adaptor.rs
@@ -11,7 +11,7 @@ use crate::{data::IngesterData, lifecycle::LifecycleHandleImpl};
 
 /// Provides a [`DmlSink`] implementation for a [`IngesterData`] instance.
 #[derive(Debug)]
-pub struct IngestSinkAdaptor {
+pub(crate) struct IngestSinkAdaptor {
     ingest_data: Arc<IngesterData>,
     lifecycle_handle: LifecycleHandleImpl,
     shard_id: ShardId,
@@ -20,7 +20,7 @@ pub struct IngestSinkAdaptor {
 impl IngestSinkAdaptor {
     /// Wrap an [`IngesterData`] in an adaptor layer to provide a [`DmlSink`]
     /// implementation.
-    pub fn new(
+    pub(crate) fn new(
         ingest_data: Arc<IngesterData>,
         lifecycle_handle: LifecycleHandleImpl,
         shard_id: ShardId,

--- a/ingester/src/stream_handler/sink_instrumentation.rs
+++ b/ingester/src/stream_handler/sink_instrumentation.rs
@@ -17,7 +17,7 @@ use super::DmlSink;
 /// # Caching
 ///
 /// Implementations may cache the watermark and return inaccurate values.
-pub trait WatermarkFetcher: Debug + Send + Sync {
+pub(crate) trait WatermarkFetcher: Debug + Send + Sync {
     /// Return a watermark if available.
     fn watermark(&self) -> Option<i64>;
 }
@@ -37,7 +37,7 @@ pub trait WatermarkFetcher: Debug + Send + Sync {
 /// instance is running on, and the routers. If either of these clocks are
 /// incorrect/skewed/drifting the metrics emitted may be incorrect.
 #[derive(Debug)]
-pub struct SinkInstrumentation<F, T, P = SystemProvider> {
+pub(crate) struct SinkInstrumentation<F, T, P = SystemProvider> {
     /// The [`DmlSink`] impl this layer decorates.
     ///
     /// All ops this impl is called with are passed into `inner` for processing.
@@ -78,7 +78,7 @@ where
     /// The current high watermark is read from `watermark_fetcher` and used to
     /// derive some metric values (such as lag). This impl is tolerant of
     /// cached/stale watermark values being returned by `watermark_fetcher`.
-    pub fn new(
+    pub(crate) fn new(
         inner: T,
         watermark_fetcher: F,
         topic_name: String,

--- a/ingester/src/test_util.rs
+++ b/ingester/src/test_util.rs
@@ -2,7 +2,7 @@
 
 #![allow(missing_docs)]
 
-use std::{collections::BTreeMap, sync::Arc, time::Duration};
+use std::{sync::Arc, time::Duration};
 
 use arrow::record_batch::RecordBatch;
 use arrow_util::assert_batches_eq;
@@ -25,7 +25,6 @@ use uuid::Uuid;
 use crate::{
     data::{
         partition::{PersistingBatch, SnapshotBatch},
-        shard::ShardData,
         IngesterData,
     },
     lifecycle::{LifecycleConfig, LifecycleHandle, LifecycleManager},
@@ -696,16 +695,11 @@ pub async fn make_ingester_data(two_partitions: bool, loc: DataLocation) -> Inge
     // Make data for one shard and two tables
     let shard_index = ShardIndex::new(1);
     let shard_id = populate_catalog(&*catalog).await;
-    let mut shards = BTreeMap::new();
-    shards.insert(
-        shard_id,
-        ShardData::new(shard_index, shard_id, Arc::clone(&metrics)),
-    );
 
     let ingester = IngesterData::new(
         object_store,
         catalog,
-        shards,
+        [(shard_id, shard_index)],
         exec,
         backoff::BackoffConfig::default(),
         metrics,
@@ -768,16 +762,10 @@ pub async fn make_ingester_data_with_tombstones(loc: DataLocation) -> IngesterDa
     let shard_index = ShardIndex::new(0);
     let shard_id = populate_catalog(&*catalog).await;
 
-    let mut shards = BTreeMap::new();
-    shards.insert(
-        shard_id,
-        ShardData::new(shard_index, shard_id, Arc::clone(&metrics)),
-    );
-
     let ingester = IngesterData::new(
         object_store,
         catalog,
-        shards,
+        [(shard_id, shard_index)],
         exec,
         backoff::BackoffConfig::default(),
         metrics,

--- a/query_tests/src/scenarios/util.rs
+++ b/query_tests/src/scenarios/util.rs
@@ -14,9 +14,7 @@ use generated_types::{
 };
 use influxdb_iox_client::flight::{low_level::LowLevelMessage, Error as FlightError};
 use ingester::{
-    data::{
-        shard::ShardData, FlatIngesterQueryResponse, IngesterData, IngesterQueryResponse, Persister,
-    },
+    data::{FlatIngesterQueryResponse, IngesterData, IngesterQueryResponse, Persister},
     lifecycle::LifecycleHandle,
     querier_handler::prepare_data_to_querier,
 };
@@ -35,7 +33,7 @@ use schema::selection::Selection;
 use sharder::JumpHash;
 use std::{
     cmp::Ordering,
-    collections::{BTreeMap, HashMap, HashSet},
+    collections::{HashMap, HashSet},
     fmt::Display,
     fmt::Write,
     sync::Arc,
@@ -693,18 +691,10 @@ impl MockIngester {
         let ns = catalog.create_namespace("test_db").await;
         let shard = ns.create_shard(1).await;
 
-        let shards = BTreeMap::from([(
-            shard.shard.id,
-            ShardData::new(
-                shard.shard.shard_index,
-                shard.shard.id,
-                catalog.metric_registry(),
-            ),
-        )]);
         let ingester_data = Arc::new(IngesterData::new(
             catalog.object_store(),
             catalog.catalog(),
-            shards,
+            [(shard.shard.id, shard.shard.shard_index)],
             catalog.exec(),
             BackoffConfig::default(),
             catalog.metric_registry(),


### PR DESCRIPTION
**This PR has no functional changes**.

The only real code change is in de0be877b, where the `ShardData` initialisation is DRYed and internalised - this allows the `ShardData` (an internal data structure) to be non-pub.

The following commit 72e02ee9e capitalises on this reduced scope which cascades through the lower tiers of the buffer tree, marking child/related structures as also non-pub, which in turn highlighted various bits of dead code. I also got some drive-by non-pub :tada:

---

* refactor: internalise ShardData init (72e02ee9e)

      Move the initialisation of ShardData (an internal ingester data structure)
      into the ingester itself.

      Previously callers would initialise the ingester state, and pass it into the
      IngesterData constructor.

* refactor(ingester): limit visibility (de0be877b)

      Marks many internal data structures as non-pub.

      Many remain as they're used across tests / from multiple callers
      "peeking", but this limits the scope of false sharing in the future.