### PR TITLE
feat(catalog): most recent N partitions

### DIFF
--- a/iox_catalog/src/mem.rs
+++ b/iox_catalog/src/mem.rs
@@ -906,6 +906,18 @@ impl PartitionRepo for MemTxn {
             None => Err(Error::PartitionNotFound { id: partition_id }),
         }
     }
+
+    async fn most_recent_n(&mut self, n: usize, shards: &[ShardId]) -> Result<Vec<Partition>> {
+        let stage = self.stage();
+        Ok(stage
+            .partitions
+            .iter()
+            .rev()
+            .filter(|p| shards.contains(&p.shard_id))
+            .take(n)
+            .cloned()
+            .collect())
+    }
 }
 
 #[async_trait]

--- a/iox_catalog/src/metrics.rs
+++ b/iox_catalog/src/metrics.rs
@@ -250,6 +250,7 @@ decorate!(
         "partition_record_skipped_compaction" = record_skipped_compaction(&mut self, partition_id: PartitionId, reason: &str, num_files: usize, limit_num_files: usize,estimated_bytes: u64, limit_bytes: u64) -> Result<()>;
         "partition_list_skipped_compactions" = list_skipped_compactions(&mut self) -> Result<Vec<SkippedCompaction>>;
         "partition_update_persisted_sequence_number" = update_persisted_sequence_number(&mut self, partition_id: PartitionId, sequence_number: SequenceNumber) -> Result<()>;
+        "partition_most_recent_n" = most_recent_n(&mut self, n: usize, shards: &[ShardId]) -> Result<Vec<Partition>>;
     ]
 );
 


### PR DESCRIPTION
Discovering the most recently created partitions can be used as a proxy for partitions that are currently hot for writes - those that were just created, are likely being wrote to. 

Using a proxy / this query is very cheap:

```
                                                QUERY PLAN
----------------------------------------------------------------------------------------------------------
 Limit  (cost=0.42..79.61 rows=10 width=116)
   ->  Index Scan Backward using partition_pkey on partition  (cost=0.42..302094.18 rows=38150 width=116)
         Filter: (shard_id = ANY ('{0,1,2,3,4,5}'::bigint[]))
```

This can be used to identify which partitions to pre-load into an ingester at startup, ref #5638.

---

* feat(catalog): most recent N partitions (c3cd31a83)

      Adds a Partition::most_recent_n() method to the catalog interface, returning
      the N most recent partitions for a given set of shards.

      The most recently created partitions are likely to be currently "hot" for
      writes, and are cheap to list.