### PR TITLE
perf(ingester): partition ID + persist marker cache

### DIFF
--- a/data_types/src/lib.rs
+++ b/data_types/src/lib.rs
@@ -135,7 +135,7 @@ pub struct TableId(i64);
 
 #[allow(missing_docs)]
 impl TableId {
-    pub fn new(v: i64) -> Self {
+    pub const fn new(v: i64) -> Self {
         Self(v)
     }
     pub fn get(&self) -> i64 {
@@ -178,7 +178,7 @@ pub struct ShardId(i64);
 
 #[allow(missing_docs)]
 impl ShardId {
-    pub fn new(v: i64) -> Self {
+    pub const fn new(v: i64) -> Self {
         Self(v)
     }
     pub fn get(&self) -> i64 {
@@ -245,7 +245,7 @@ pub struct PartitionId(i64);
 
 #[allow(missing_docs)]
 impl PartitionId {
-    pub fn new(v: i64) -> Self {
+    pub const fn new(v: i64) -> Self {
         Self(v)
     }
     pub fn get(&self) -> i64 {

--- a/ingester/src/data.rs
+++ b/ingester/src/data.rs
@@ -32,10 +32,7 @@ pub mod shard;
 pub mod table;
 
 use self::{
-    partition::{
-        resolver::{CatalogPartitionResolver, PartitionProvider},
-        PartitionStatus,
-    },
+    partition::{resolver::PartitionProvider, PartitionStatus},
     shard::ShardData,
 };
 
@@ -109,6 +106,7 @@ impl IngesterData {
         catalog: Arc<dyn Catalog>,
         shards: T,
         exec: Arc<Executor>,
+        partition_provider: Arc<dyn PartitionProvider>,
         backoff_config: BackoffConfig,
         metrics: Arc<metric::Registry>,
     ) -> Self
@@ -129,10 +127,6 @@ impl IngesterData {
                 ])
             },
         );
-
-        // Build the partition provider.
-        let partition_provider: Arc<dyn PartitionProvider> =
-            Arc::new(CatalogPartitionResolver::new(Arc::clone(&catalog)));
 
         let shards = shards
             .into_iter()
@@ -681,6 +675,7 @@ mod tests {
             Arc::clone(&catalog),
             [(shard1.id, shard_index)],
             Arc::new(Executor::new(1)),
+            Arc::new(CatalogPartitionResolver::new(Arc::clone(&catalog))),
             BackoffConfig::default(),
             Arc::clone(&metrics),
         ));
@@ -762,6 +757,7 @@ mod tests {
             Arc::clone(&catalog),
             [(shard1.id, shard1.shard_index)],
             Arc::new(Executor::new(1)),
+            Arc::new(CatalogPartitionResolver::new(catalog)),
             BackoffConfig::default(),
             Arc::clone(&metrics),
         ));
@@ -865,6 +861,7 @@ mod tests {
                 (shard2.id, shard2.shard_index),
             ],
             Arc::new(Executor::new(1)),
+            Arc::new(CatalogPartitionResolver::new(Arc::clone(&catalog))),
             BackoffConfig::default(),
             Arc::clone(&metrics),
         ));
@@ -1115,6 +1112,7 @@ mod tests {
                 (shard2.id, shard2.shard_index),
             ],
             Arc::new(Executor::new(1)),
+            Arc::new(CatalogPartitionResolver::new(catalog)),
             BackoffConfig::default(),
             Arc::clone(&metrics),
         ));
@@ -1408,6 +1406,7 @@ mod tests {
             Arc::clone(&catalog),
             [(shard1.id, shard_index)],
             Arc::new(Executor::new(1)),
+            Arc::new(CatalogPartitionResolver::new(catalog)),
             BackoffConfig::default(),
             Arc::clone(&metrics),
         ));

--- a/ingester/src/data/partition.rs
+++ b/ingester/src/data/partition.rs
@@ -315,6 +315,18 @@ impl PartitionData {
     pub(crate) fn table_name(&self) -> &str {
         self.table_name.as_ref()
     }
+
+    /// Return the shard ID for this partition.
+    #[cfg(test)]
+    pub(crate) fn shard_id(&self) -> ShardId {
+        self.shard_id
+    }
+
+    /// Return the table ID for this partition.
+    #[cfg(test)]
+    pub(crate) fn table_id(&self) -> TableId {
+        self.table_id
+    }
 }
 
 #[cfg(test)]

--- a/ingester/src/data/partition.rs
+++ b/ingester/src/data/partition.rs
@@ -132,7 +132,7 @@ impl SnapshotBatch {
 
 /// Data of an IOx Partition of a given Table of a Namesapce that belongs to a given Shard
 #[derive(Debug)]
-pub(crate) struct PartitionData {
+pub struct PartitionData {
     /// The catalog ID of the partition this buffer is for.
     id: PartitionId,
     /// The shard and table IDs for this partition.

--- a/ingester/src/data/partition/resolver/cache.rs
+++ b/ingester/src/data/partition/resolver/cache.rs
@@ -1,0 +1,290 @@
+use std::{collections::HashMap, sync::Arc};
+
+use async_trait::async_trait;
+use data_types::{Partition, PartitionId, PartitionKey, SequenceNumber, ShardId, TableId};
+use observability_deps::tracing::debug;
+
+use crate::data::partition::PartitionData;
+
+use super::r#trait::PartitionProvider;
+
+/// The data-carrying value of a `(shard_id, table_id, partition_key)` lookup.
+#[derive(Debug)]
+struct Entry {
+    partition_id: PartitionId,
+    max_sequence_number: Option<SequenceNumber>,
+}
+
+/// A read-through cache mapping `(shard_id, table_id, partition_key)` tuples to
+/// `(partition_id, max_sequence_number)`.
+///
+/// This data is safe to cache as only one ingester is ever responsible for a
+/// given table partition, and this amortises partition persist marker discovery
+/// queries during startup, eliminating them from the ingest hot path in the
+/// common startup case (an ingester restart with no new partitions to add).
+///
+/// # Memory Overhead
+///
+/// Excluding map overhead, and assuming partition keys in the form
+/// "YYYY-MM-DD", each entry takes:
+///
+///   - Partition key: String (8 len + 8 cap + 8 ptr + data len) = 34 bytes
+///   - ShardId: 8 bytes
+///   - TableId: 8 bytes
+///   - PartitionId: 8 bytes
+///   - Optional sequence number: 16 bytes
+///
+/// For a total of 74 bytes per entry - approx 1,690 entries can be held in 1Mb
+/// of memory.
+#[derive(Debug)]
+pub(crate) struct PartitionCache<T> {
+    // The inner delegate called for a cache miss.
+    inner: T,
+
+    /// Cached entries.
+    ///
+    /// First lookup level is the shared partition keys - this eliminates
+    /// needing to share the string key per shard_id/table_id in memory which
+    /// would be the case if using either as the first level lookup. This is
+    /// cheaper (memory) than using Arc refs to share the keys.
+    ///
+    /// It's also likely a smaller N (more tables than partition keys) making it
+    /// a faster search for cache misses.
+    #[allow(clippy::type_complexity)]
+    entries: HashMap<String, HashMap<ShardId, HashMap<TableId, Entry>>>,
+}
+
+impl<T> PartitionCache<T> {
+    /// Initialise a [`PartitionCache`] containing the specified partitions.
+    ///
+    /// Any cache miss is passed through to `inner`.
+    pub(crate) fn new<P>(inner: T, partitions: P) -> Self
+    where
+        P: IntoIterator<Item = Partition>,
+    {
+        let mut entries = HashMap::<String, HashMap<ShardId, HashMap<TableId, Entry>>>::new();
+        for p in partitions.into_iter() {
+            entries
+                .entry(p.partition_key.to_string())
+                .or_default()
+                .entry(p.shard_id)
+                .or_default()
+                .insert(
+                    p.table_id,
+                    Entry {
+                        partition_id: p.id,
+                        max_sequence_number: p.persisted_sequence_number,
+                    },
+                );
+        }
+
+        // Minimise the overhead of the maps.
+        for shards in entries.values_mut() {
+            for tables in shards.values_mut() {
+                tables.shrink_to_fit();
+            }
+            shards.shrink_to_fit();
+        }
+        entries.shrink_to_fit();
+
+        Self { entries, inner }
+    }
+
+    /// Search for an cached entry matching the `(partition_key, shard_id, table_id)`
+    /// tuple.
+    fn find(
+        &self,
+        shard_id: ShardId,
+        table_id: TableId,
+        partition_key: &PartitionKey,
+    ) -> Option<&Entry> {
+        self.entries
+            .get(&partition_key.to_string())?
+            .get(&shard_id)?
+            .get(&table_id)
+    }
+}
+
+#[async_trait]
+impl<T> PartitionProvider for PartitionCache<T>
+where
+    T: PartitionProvider,
+{
+    async fn get_partition(
+        &self,
+        partition_key: PartitionKey,
+        shard_id: ShardId,
+        table_id: TableId,
+        table_name: Arc<str>,
+    ) -> PartitionData {
+        // Use the cached PartitionKey instead of the caller's partition_key,
+        // instead preferring to reuse the already-shared Arc<str> in the cache.
+
+        if let Some(cached) = self.find(shard_id, table_id, &partition_key) {
+            debug!(%table_id, %partition_key, "partition cache hit");
+            return PartitionData::new(
+                cached.partition_id,
+                shard_id,
+                table_id,
+                table_name,
+                cached.max_sequence_number,
+            );
+        }
+
+        debug!(%table_id, %partition_key, "partition cache miss");
+
+        // Otherwise delegate to the catalog / inner impl.
+        self.inner
+            .get_partition(partition_key, shard_id, table_id, table_name)
+            .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::data::partition::resolver::MockPartitionProvider;
+
+    use super::*;
+
+    const PARTITION_KEY: &str = "bananas";
+    const PARTITION_ID: PartitionId = PartitionId::new(42);
+    const SHARD_ID: ShardId = ShardId::new(1);
+    const TABLE_ID: TableId = TableId::new(2);
+    const TABLE_NAME: &str = "platanos";
+
+    #[tokio::test]
+    async fn test_miss() {
+        let data = PartitionData::new(PARTITION_ID, SHARD_ID, TABLE_ID, TABLE_NAME.into(), None);
+        let inner = MockPartitionProvider::default().with_partition(PARTITION_KEY.into(), data);
+
+        let cache = PartitionCache::new(inner, []);
+        let got = cache
+            .get_partition(PARTITION_KEY.into(), SHARD_ID, TABLE_ID, TABLE_NAME.into())
+            .await;
+
+        assert_eq!(got.id(), PARTITION_ID);
+        assert_eq!(got.shard_id(), SHARD_ID);
+        assert_eq!(got.table_id(), TABLE_ID);
+        assert_eq!(got.table_name(), TABLE_NAME);
+        assert!(cache.inner.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_hit() {
+        let inner = MockPartitionProvider::default();
+
+        let partition = Partition {
+            id: PARTITION_ID,
+            shard_id: SHARD_ID,
+            table_id: TABLE_ID,
+            partition_key: PARTITION_KEY.into(),
+            sort_key: Default::default(),
+            persisted_sequence_number: Default::default(),
+        };
+
+        let cache = PartitionCache::new(inner, [partition]);
+        let got = cache
+            .get_partition(PARTITION_KEY.into(), SHARD_ID, TABLE_ID, TABLE_NAME.into())
+            .await;
+
+        assert_eq!(got.id(), PARTITION_ID);
+        assert_eq!(got.shard_id(), SHARD_ID);
+        assert_eq!(got.table_id(), TABLE_ID);
+        assert_eq!(got.table_name(), TABLE_NAME);
+    }
+
+    #[tokio::test]
+    async fn test_miss_partition_jey() {
+        let other_key = PartitionKey::from("test");
+        let other_key_id = PartitionId::new(99);
+        let inner = MockPartitionProvider::default().with_partition(
+            other_key.clone(),
+            PartitionData::new(other_key_id, SHARD_ID, TABLE_ID, TABLE_NAME.into(), None),
+        );
+
+        let partition = Partition {
+            id: PARTITION_ID,
+            shard_id: SHARD_ID,
+            table_id: TABLE_ID,
+            partition_key: PARTITION_KEY.into(),
+            sort_key: Default::default(),
+            persisted_sequence_number: Default::default(),
+        };
+
+        let cache = PartitionCache::new(inner, [partition]);
+        let got = cache
+            .get_partition(other_key.clone(), SHARD_ID, TABLE_ID, TABLE_NAME.into())
+            .await;
+
+        assert_eq!(got.id(), other_key_id);
+        assert_eq!(got.shard_id(), SHARD_ID);
+        assert_eq!(got.table_id(), TABLE_ID);
+        assert_eq!(got.table_name(), TABLE_NAME);
+    }
+
+    #[tokio::test]
+    async fn test_miss_table_id() {
+        let other_table = TableId::new(1234);
+        let inner = MockPartitionProvider::default().with_partition(
+            PARTITION_KEY.into(),
+            PartitionData::new(PARTITION_ID, SHARD_ID, other_table, TABLE_NAME.into(), None),
+        );
+
+        let partition = Partition {
+            id: PARTITION_ID,
+            shard_id: SHARD_ID,
+            table_id: TABLE_ID,
+            partition_key: PARTITION_KEY.into(),
+            sort_key: Default::default(),
+            persisted_sequence_number: Default::default(),
+        };
+
+        let cache = PartitionCache::new(inner, [partition]);
+        let got = cache
+            .get_partition(
+                PARTITION_KEY.into(),
+                SHARD_ID,
+                other_table,
+                TABLE_NAME.into(),
+            )
+            .await;
+
+        assert_eq!(got.id(), PARTITION_ID);
+        assert_eq!(got.shard_id(), SHARD_ID);
+        assert_eq!(got.table_id(), other_table);
+        assert_eq!(got.table_name(), TABLE_NAME);
+    }
+
+    #[tokio::test]
+    async fn test_miss_shard_id() {
+        let other_shard = ShardId::new(1234);
+        let inner = MockPartitionProvider::default().with_partition(
+            PARTITION_KEY.into(),
+            PartitionData::new(PARTITION_ID, other_shard, TABLE_ID, TABLE_NAME.into(), None),
+        );
+
+        let partition = Partition {
+            id: PARTITION_ID,
+            shard_id: SHARD_ID,
+            table_id: TABLE_ID,
+            partition_key: PARTITION_KEY.into(),
+            sort_key: Default::default(),
+            persisted_sequence_number: Default::default(),
+        };
+
+        let cache = PartitionCache::new(inner, [partition]);
+        let got = cache
+            .get_partition(
+                PARTITION_KEY.into(),
+                other_shard,
+                TABLE_ID,
+                TABLE_NAME.into(),
+            )
+            .await;
+
+        assert_eq!(got.id(), PARTITION_ID);
+        assert_eq!(got.shard_id(), other_shard);
+        assert_eq!(got.table_id(), TABLE_ID);
+        assert_eq!(got.table_name(), TABLE_NAME);
+    }
+}

--- a/ingester/src/data/partition/resolver/catalog.rs
+++ b/ingester/src/data/partition/resolver/catalog.rs
@@ -17,7 +17,7 @@ use super::r#trait::PartitionProvider;
 /// the partition id and persist offset, returning an initialised
 /// [`PartitionData`].
 #[derive(Debug)]
-pub(crate) struct CatalogPartitionResolver {
+pub struct CatalogPartitionResolver {
     catalog: Arc<dyn Catalog>,
     backoff_config: BackoffConfig,
 }
@@ -25,7 +25,7 @@ pub(crate) struct CatalogPartitionResolver {
 impl CatalogPartitionResolver {
     /// Construct a [`CatalogPartitionResolver`] that looks up partitions in
     /// `catalog`.
-    pub(crate) fn new(catalog: Arc<dyn Catalog>) -> Self {
+    pub fn new(catalog: Arc<dyn Catalog>) -> Self {
         Self {
             catalog,
             backoff_config: Default::default(),

--- a/ingester/src/data/partition/resolver/mock.rs
+++ b/ingester/src/data/partition/resolver/mock.rs
@@ -40,6 +40,11 @@ impl MockPartitionProvider {
             "overwriting an existing mock PartitionData"
         );
     }
+
+    /// Returns true if all mock values have been consumed.
+    pub fn is_empty(&self) -> bool {
+        self.partitions.lock().is_empty()
+    }
 }
 
 #[async_trait]

--- a/ingester/src/data/partition/resolver/mock.rs
+++ b/ingester/src/data/partition/resolver/mock.rs
@@ -23,27 +23,19 @@ impl MockPartitionProvider {
     pub(crate) fn with_partition(
         mut self,
         partition_key: PartitionKey,
-        shard_id: ShardId,
-        table_id: TableId,
         data: PartitionData,
     ) -> Self {
-        self.insert(partition_key, shard_id, table_id, data);
+        self.insert(partition_key, data);
         self
     }
 
     /// Add `data` to the mock state, returning it when asked for the specified
     /// `(key, shard, table)` triplet.
-    pub(crate) fn insert(
-        &mut self,
-        partition_key: PartitionKey,
-        shard_id: ShardId,
-        table_id: TableId,
-        data: PartitionData,
-    ) {
+    pub(crate) fn insert(&mut self, partition_key: PartitionKey, data: PartitionData) {
         assert!(
             self.partitions
                 .lock()
-                .insert((partition_key, shard_id, table_id), data)
+                .insert((partition_key, data.shard_id(), data.table_id()), data)
                 .is_none(),
             "overwriting an existing mock PartitionData"
         );

--- a/ingester/src/data/partition/resolver/mod.rs
+++ b/ingester/src/data/partition/resolver/mod.rs
@@ -6,10 +6,10 @@ mod cache;
 pub(crate) use cache::*;
 
 mod r#trait;
-pub(crate) use r#trait::*;
+pub use r#trait::*;
 
 mod catalog;
-pub(crate) use catalog::*;
+pub use catalog::*;
 
 #[cfg(test)]
 mod mock;

--- a/ingester/src/data/partition/resolver/mod.rs
+++ b/ingester/src/data/partition/resolver/mod.rs
@@ -2,6 +2,9 @@
 //!
 //! [`PartitionData`]: crate::data::partition::PartitionData
 
+mod cache;
+pub(crate) use cache::*;
+
 mod r#trait;
 pub(crate) use r#trait::*;
 

--- a/ingester/src/data/partition/resolver/trait.rs
+++ b/ingester/src/data/partition/resolver/trait.rs
@@ -8,7 +8,12 @@ use crate::data::partition::PartitionData;
 /// An infallible resolver of [`PartitionData`] for the specified shard, table,
 /// and partition key, returning an initialised [`PartitionData`] buffer for it.
 #[async_trait]
-pub(crate) trait PartitionProvider: Send + Sync + Debug {
+pub trait PartitionProvider: Send + Sync + Debug {
+    /// Return an initialised [`PartitionData`] for a given `(partition_key,
+    /// shard_id, table_id)` tuple.
+    ///
+    /// NOTE: the constructor for [`PartitionData`] is NOT `pub` and SHOULD NOT
+    /// be `pub` so this trait is effectively sealed.
     async fn get_partition(
         &self,
         partition_key: PartitionKey,

--- a/ingester/src/data/partition/resolver/trait.rs
+++ b/ingester/src/data/partition/resolver/trait.rs
@@ -55,12 +55,7 @@ mod tests {
         let partition = PartitionId::new(4242);
         let data = PartitionData::new(partition, shard_id, table_id, Arc::clone(&table_name), None);
 
-        let mock = Arc::new(MockPartitionProvider::default().with_partition(
-            key.clone(),
-            shard_id,
-            table_id,
-            data,
-        ));
+        let mock = Arc::new(MockPartitionProvider::default().with_partition(key.clone(), data));
 
         let got = mock
             .get_partition(key, shard_id, table_id, Arc::clone(&table_name))

--- a/ingester/src/test_util.rs
+++ b/ingester/src/test_util.rs
@@ -25,7 +25,7 @@ use uuid::Uuid;
 
 use crate::{
     data::{
-        partition::{PersistingBatch, SnapshotBatch},
+        partition::{resolver::CatalogPartitionResolver, PersistingBatch, SnapshotBatch},
         IngesterData,
     },
     lifecycle::{LifecycleConfig, LifecycleHandle, LifecycleManager},
@@ -630,9 +630,10 @@ pub(crate) async fn make_ingester_data(two_partitions: bool, loc: DataLocation) 
 
     let ingester = IngesterData::new(
         object_store,
-        catalog,
+        Arc::clone(&catalog),
         [(shard_id, shard_index)],
         exec,
+        Arc::new(CatalogPartitionResolver::new(catalog)),
         backoff::BackoffConfig::default(),
         metrics,
     );
@@ -696,9 +697,10 @@ pub(crate) async fn make_ingester_data_with_tombstones(loc: DataLocation) -> Ing
 
     let ingester = IngesterData::new(
         object_store,
-        catalog,
+        Arc::clone(&catalog),
         [(shard_id, shard_index)],
         exec,
+        Arc::new(CatalogPartitionResolver::new(catalog)),
         backoff::BackoffConfig::default(),
         metrics,
     );

--- a/query_tests/src/scenarios/util.rs
+++ b/query_tests/src/scenarios/util.rs
@@ -14,7 +14,10 @@ use generated_types::{
 };
 use influxdb_iox_client::flight::{low_level::LowLevelMessage, Error as FlightError};
 use ingester::{
-    data::{FlatIngesterQueryResponse, IngesterData, IngesterQueryResponse, Persister},
+    data::{
+        partition::resolver::CatalogPartitionResolver, FlatIngesterQueryResponse, IngesterData,
+        IngesterQueryResponse, Persister,
+    },
     lifecycle::LifecycleHandle,
     querier_handler::prepare_data_to_querier,
 };
@@ -696,6 +699,7 @@ impl MockIngester {
             catalog.catalog(),
             [(shard.shard.id, shard.shard.shard_index)],
             catalog.exec(),
+            Arc::new(CatalogPartitionResolver::new(catalog.catalog())),
             BackoffConfig::default(),
             catalog.metric_registry(),
         ));


### PR DESCRIPTION
This should deliver a decent improvement to ingester catchup time after a deployment (https://github.com/influxdata/conductor/issues/971) and eliminate a whole lotta catalog load :tada:

Closes https://github.com/influxdata/influxdb_iox/issues/5638.

---

* test: simplify partition provider mock (38ebd5fb2)

      Removes redundant fields from the MockPartitionProvider.

* refactor(ingester): server-wide PartitionProvider (a3d6e7a45)

      Lifts the PartitionProvider initialisation higher in the stack to a point
      where a single instance can be used across all shards an ingester manages.

      This is a pre-requisite for sharing a cache of Partitions across all shards.

* perf(ingester): cache Partition (2068ff394)

      This commit implements a PartitionCache decorator over the PartitionProvider
      abstraction.

      When an ingester starts up, the internal data structures are empty and are
      lazily initialised for each namespace / table / partition as they are observed
      in the stream of DML ops.

      This lazy initialisation includes resolving the Partition ID and last 
      persisted sequence number offset value from the catalog for each partition in
      each table in each namespace for which an op is observed - this occurs in the
      hot path, while blocking ingest for a shard. resolving each partition will
      cause a catalog query, this can cause a spike in queries against the catalog,
      also resulting in unnecessarily slow ingester recovery - we're effectively
      lazily warming a cache of PartitionData in the hot path!

      Instead this cache can be used to pre-warm the N most recently created 
      partitions (which are likely to have ongoing writes) at startup to eliminate
      the hot-path overhead and associated catalog queries.

      NOTE: unlike most of the other hot-path queries, partition persist offset
      resolution cannot be eliminated by changes to the Kafka wire format.

* refactor(ingester): use Partition cache (1311a8746)

      Cache the 10,000 most recent partitions at startup, and share them across all
      shards.

      At commit time, there are approx ~8,000 partitions per day, per ingester, so
      this should cache all of the partitions for a given day so far at startup.

* perf(ingester): amortise Partition cache memory (8cf81f457)

      Remove each cache hit from the partition cache, as each partition should be
      looked up at most once.

      This amortises the memory usage of the cache, as it should be "drained" of hot
      partitions.