### PR TITLE
fix(write_buffer): spurious watermark < read offset panic

### DIFF
--- a/ingester/src/handler.rs
+++ b/ingester/src/handler.rs
@@ -792,7 +792,9 @@ mod tests {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "JoinError::Panic")]
+    #[should_panic(
+        expected = "attempted to seek to offset 10, but current high watermark for partition 0 is 2"
+    )]
     async fn sequence_number_after_watermark() {
         maybe_start_logging();
 
@@ -816,7 +818,9 @@ mod tests {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "JoinError::Panic")]
+    #[should_panic(
+        expected = "attempted to seek to offset 10, but current high watermark for partition 0 is 2"
+    )]
     async fn sequence_number_after_watermark_skip_to_oldest_available() {
         maybe_start_logging();
 

--- a/ingester/src/stream_handler/handler.rs
+++ b/ingester/src/stream_handler/handler.rs
@@ -794,6 +794,7 @@ mod tests {
             assert_eq!(op.namespace(), "bananas");
         }
     );
+
     test_stream_handler!(
         non_fatal_stream_offset_error,
         skip_to_oldest_available = false,
@@ -815,6 +816,7 @@ mod tests {
             assert_eq!(op.namespace(), "bananas");
         }
     );
+
     test_stream_handler!(
         skip_to_oldest_on_unknown_sequence_number,
         skip_to_oldest_available = true,
@@ -843,6 +845,7 @@ mod tests {
             assert_eq!(op.namespace(), "bananas");
         }
     );
+
     test_stream_handler!(
         non_fatal_stream_invalid_data,
         skip_to_oldest_available = false,
@@ -864,6 +867,7 @@ mod tests {
             assert_eq!(op.namespace(), "bananas");
         }
     );
+
     test_stream_handler!(
         non_fatal_stream_unknown_error,
         skip_to_oldest_available = false,

--- a/write_buffer/src/kafka/mod.rs
+++ b/write_buffer/src/kafka/mod.rs
@@ -280,6 +280,14 @@ impl WriteBufferStreamHandler for RSKafkaStreamHandler {
                     let kind = match e {
                         RSKafkaError::ServerError {
                             protocol_error: ProtocolError::OffsetOutOfRange,
+                            response:
+                                Some(ServerErrorResponse::PartitionFetchState {
+                                    high_watermark, ..
+                                }),
+                            ..
+                        } if high_watermark < 0 => WriteBufferErrorKind::Unknown,
+                        RSKafkaError::ServerError {
+                            protocol_error: ProtocolError::OffsetOutOfRange,
                             request: RequestContext::Fetch { offset, .. },
                             response:
                                 Some(ServerErrorResponse::PartitionFetchState {


### PR DESCRIPTION
Fixes a panic:

```
thread 'tokio-runtime-workerthread 'tokio-runtime-worker' panicked at '' panicked at 'Shard Index ShardIndex(23) stream for topic iox-shared has a high watermark BEFORE the sequence number we want. This is either a bug (see https://github.com/influxdata/rskafka/issues/147 for example) or means that someone re-created the shard and data is lost. In both cases, it's better to panic than to try something clever.Shard Index ShardIndex(16) stream for topic iox-shared has a high watermark BEFORE the sequence number we want. This is either a bug (see https://github.com/influxdata/rskafka/issues/147 for example) or means that someone re-created the shard and data is lost. In both cases, it's better to panic than to try something clever.', ', /influxdb_iox/ingester/src/stream_handler/handler.rs/influxdb_iox/ingester/src/stream_handler/handler.rs::320:32021
```

This is caused by the response not having a valid high watermark value (note `high_watermark: -1`):

```
WriteBufferError(SequenceNumberAfterWatermark): Server error OffsetOutOfRange with message "n/a", request: Fetch { topic_name: "iox-shared", partition_id: 23, offset: 1 }, response: Some(PartitionFetchState { high_watermark: -1, last_stable_offset: Some(-1) }), virtual: false
```

Which in turn was incorrectly mapped to a `SequenceNumberAfterWatermark` error:

https://github.com/influxdata/influxdb_iox/blob/5f2f735c7ef342b8af1a9248a091bf81cb3e6265/write_buffer/src/kafka/mod.rs#L297-L299

This now maps to an unknown error as we cannot definitely map it to a `SequenceNumberNoLongerExists` error state.

---

* fix: spurious watermark < read offset panic (5f2f735c7)

      In staging we observed an ingester panic due to the write buffer stream 
      yielding an WriteBufferErrorKind::SequenceNumberAfterWatermark, suggesting the
      ingester was attempting to read from an offset that exceeds the current max
      write offset in Kafka (high watermark offset).

      This turned out not to be the case - the partition had a single write at 
      offset 2, and the ingester was attempting to seek to offset 1. The first read
      would fail (offset 1 does not exist) and the error handling did not account
      for the high watermark not being correctly set (-1 in the response).

      I have no idea why rskafka returns this watermark / doesn't retry / etc but
      this change will allow the ingesters to recover.