### PR TITLE
refactor: PartitionData carries PartitionKey

### DIFF
--- a/data_types/src/lib.rs
+++ b/data_types/src/lib.rs
@@ -772,6 +772,14 @@ pub struct Shard {
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct PartitionKey(Arc<str>);
 
+impl PartitionKey {
+    /// Returns true if this instance of [`PartitionKey`] is backed by the same
+    /// string storage as other.
+    pub fn ptr_eq(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.0, &other.0)
+    }
+}
+
 impl Display for PartitionKey {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_str(&self.0)

--- a/ingester/src/data/partition.rs
+++ b/ingester/src/data/partition.rs
@@ -3,7 +3,7 @@
 use std::sync::Arc;
 
 use arrow::record_batch::RecordBatch;
-use data_types::{PartitionId, SequenceNumber, ShardId, TableId, Tombstone};
+use data_types::{PartitionId, PartitionKey, SequenceNumber, ShardId, TableId, Tombstone};
 use iox_query::exec::Executor;
 use mutable_batch::MutableBatch;
 use schema::selection::Selection;
@@ -135,6 +135,9 @@ impl SnapshotBatch {
 pub struct PartitionData {
     /// The catalog ID of the partition this buffer is for.
     id: PartitionId,
+    /// The string partition key for this partition.
+    partition_key: PartitionKey,
+
     /// The shard and table IDs for this partition.
     shard_id: ShardId,
     table_id: TableId,
@@ -152,6 +155,7 @@ impl PartitionData {
     /// Initialize a new partition data buffer
     pub(crate) fn new(
         id: PartitionId,
+        partition_key: PartitionKey,
         shard_id: ShardId,
         table_id: TableId,
         table_name: Arc<str>,
@@ -159,6 +163,7 @@ impl PartitionData {
     ) -> Self {
         Self {
             id,
+            partition_key,
             shard_id,
             table_id,
             table_name,
@@ -327,6 +332,11 @@ impl PartitionData {
     pub(crate) fn table_id(&self) -> TableId {
         self.table_id
     }
+
+    /// Return the partition key for this partition.
+    pub fn partition_key(&self) -> &PartitionKey {
+        &self.partition_key
+    }
 }
 
 #[cfg(test)]
@@ -341,6 +351,7 @@ mod tests {
     fn snapshot_buffer_different_but_compatible_schemas() {
         let mut partition_data = PartitionData::new(
             PartitionId::new(1),
+            "bananas".into(),
             ShardId::new(1),
             TableId::new(1),
             "foo".into(),
@@ -386,6 +397,7 @@ mod tests {
         let p_id = 1;
         let mut p = PartitionData::new(
             PartitionId::new(p_id),
+            "bananas".into(),
             ShardId::new(s_id),
             TableId::new(t_id),
             "restaurant".into(),

--- a/ingester/src/data/partition/resolver/trait.rs
+++ b/ingester/src/data/partition/resolver/trait.rs
@@ -58,7 +58,14 @@ mod tests {
         let table_id = TableId::new(24);
         let table_name = "platanos".into();
         let partition = PartitionId::new(4242);
-        let data = PartitionData::new(partition, shard_id, table_id, Arc::clone(&table_name), None);
+        let data = PartitionData::new(
+            partition,
+            "bananas".into(),
+            shard_id,
+            table_id,
+            Arc::clone(&table_name),
+            None,
+        );
 
         let mock = Arc::new(MockPartitionProvider::default().with_partition(key.clone(), data));
 


### PR DESCRIPTION
Change the `PartitionData` buffer structure so that it carries the `PartitionKey` derived for it to avoid having to resolve it later.

As an added bonus, these `PartitionKey` strings will be shared across many tables when read from the cache via ref counting rather than copying :tada:

Relates to #5767 - this is a stepping stone towards removing a bunch of queries.

---

* refactor: PartitionData carries PartitionKey (f5a7fbf8e)

      Changes the PartitionData to carry the derived PartitionKey for which it is
      buffering ops for. This is used at persist time.