### PR TITLE
refactor: PartitionData carries parent IDs

### DIFF
--- a/data_types/src/lib.rs
+++ b/data_types/src/lib.rs
@@ -80,7 +80,7 @@ pub struct NamespaceId(i64);
 
 #[allow(missing_docs)]
 impl NamespaceId {
-    pub fn new(v: i64) -> Self {
+    pub const fn new(v: i64) -> Self {
         Self(v)
     }
     pub fn get(&self) -> i64 {

--- a/ingester/src/data/namespace.rs
+++ b/ingester/src/data/namespace.rs
@@ -265,6 +265,7 @@ impl NamespaceData {
                     info.table_id,
                     table_name,
                     self.shard_id,
+                    self.namespace_id,
                     info.tombstone_max_sequence_number,
                     Arc::clone(&self.partition_provider),
                 ))));

--- a/ingester/src/data/partition.rs
+++ b/ingester/src/data/partition.rs
@@ -3,7 +3,9 @@
 use std::sync::Arc;
 
 use arrow::record_batch::RecordBatch;
-use data_types::{PartitionId, PartitionKey, SequenceNumber, ShardId, TableId, Tombstone};
+use data_types::{
+    NamespaceId, PartitionId, PartitionKey, SequenceNumber, ShardId, TableId, Tombstone,
+};
 use iox_query::exec::Executor;
 use mutable_batch::MutableBatch;
 use schema::selection::Selection;
@@ -138,8 +140,9 @@ pub struct PartitionData {
     /// The string partition key for this partition.
     partition_key: PartitionKey,
 
-    /// The shard and table IDs for this partition.
+    /// The shard, namespace & table IDs for this partition.
     shard_id: ShardId,
+    namespace_id: NamespaceId,
     table_id: TableId,
     /// The name of the table this partition is part of.
     table_name: Arc<str>,
@@ -157,6 +160,7 @@ impl PartitionData {
         id: PartitionId,
         partition_key: PartitionKey,
         shard_id: ShardId,
+        namespace_id: NamespaceId,
         table_id: TableId,
         table_name: Arc<str>,
         max_persisted_sequence_number: Option<SequenceNumber>,
@@ -165,6 +169,7 @@ impl PartitionData {
             id,
             partition_key,
             shard_id,
+            namespace_id,
             table_id,
             table_name,
             data: Default::default(),
@@ -337,6 +342,11 @@ impl PartitionData {
     pub fn partition_key(&self) -> &PartitionKey {
         &self.partition_key
     }
+
+    /// Return the [`NamespaceId`] this partition is a part of.
+    pub fn namespace_id(&self) -> NamespaceId {
+        self.namespace_id
+    }
 }
 
 #[cfg(test)]
@@ -353,6 +363,7 @@ mod tests {
             PartitionId::new(1),
             "bananas".into(),
             ShardId::new(1),
+            NamespaceId::new(42),
             TableId::new(1),
             "foo".into(),
             None,
@@ -399,6 +410,7 @@ mod tests {
             PartitionId::new(p_id),
             "bananas".into(),
             ShardId::new(s_id),
+            NamespaceId::new(42),
             TableId::new(t_id),
             "restaurant".into(),
             None,

--- a/ingester/src/data/partition/resolver/mock.rs
+++ b/ingester/src/data/partition/resolver/mock.rs
@@ -3,7 +3,7 @@
 use std::{collections::HashMap, sync::Arc};
 
 use async_trait::async_trait;
-use data_types::{PartitionKey, ShardId, TableId};
+use data_types::{NamespaceId, PartitionKey, ShardId, TableId};
 use parking_lot::Mutex;
 
 use crate::data::partition::PartitionData;
@@ -53,6 +53,7 @@ impl PartitionProvider for MockPartitionProvider {
         &self,
         partition_key: PartitionKey,
         shard_id: ShardId,
+        namespace_id: NamespaceId,
         table_id: TableId,
         table_name: Arc<str>,
     ) -> PartitionData {
@@ -64,6 +65,7 @@ impl PartitionProvider for MockPartitionProvider {
                 panic!("no partition data for mock ({partition_key:?}, {shard_id:?}, {table_id:?})")
             });
 
+        assert_eq!(p.namespace_id(), namespace_id);
         assert_eq!(*p.table_name(), *table_name);
         p
     }

--- a/ingester/src/data/table.rs
+++ b/ingester/src/data/table.rs
@@ -2,7 +2,9 @@
 
 use std::{collections::BTreeMap, sync::Arc};
 
-use data_types::{DeletePredicate, PartitionKey, SequenceNumber, ShardId, TableId, Timestamp};
+use data_types::{
+    DeletePredicate, NamespaceId, PartitionKey, SequenceNumber, ShardId, TableId, Timestamp,
+};
 use iox_catalog::interface::Catalog;
 use iox_query::exec::Executor;
 use mutable_batch::MutableBatch;
@@ -20,8 +22,10 @@ pub(crate) struct TableData {
     table_id: TableId,
     table_name: Arc<str>,
 
-    /// The catalog ID of the shard this table is being populated from.
+    /// The catalog ID of the shard & namespace this table is being populated
+    /// from.
     shard_id: ShardId,
+    namespace_id: NamespaceId,
 
     // the max sequence number for a tombstone associated with this table
     tombstone_max_sequence_number: Option<SequenceNumber>,
@@ -49,6 +53,7 @@ impl TableData {
         table_id: TableId,
         table_name: &str,
         shard_id: ShardId,
+        namespace_id: NamespaceId,
         tombstone_max_sequence_number: Option<SequenceNumber>,
         partition_provider: Arc<dyn PartitionProvider>,
     ) -> Self {
@@ -56,6 +61,7 @@ impl TableData {
             table_id,
             table_name: table_name.into(),
             shard_id,
+            namespace_id,
             tombstone_max_sequence_number,
             partition_data: Default::default(),
             partition_provider,
@@ -94,6 +100,7 @@ impl TableData {
                     .get_partition(
                         partition_key.clone(),
                         self.shard_id,
+                        self.namespace_id,
                         self.table_id,
                         Arc::clone(&self.table_name),
                     )


### PR DESCRIPTION
Teaches the `PartitionData` to carry the `NamespaceId` it is part of.

---

* refactor: PartitionData carries parent IDs (726b1d1d3)

      This commit changes the PartitionData buffer structure to carry the IDs of all
      its parents - the table, namespace, and shard. Previously only the table &
      shard were carried.