### PR TITLE
feat: Generate parquet files instead of line protocol

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2272,6 +2272,7 @@ dependencies = [
 name = "iox_data_generator"
 version = "0.1.0"
 dependencies = [
+ "bytes",
  "chrono",
  "chrono-english",
  "clap",
@@ -2281,8 +2282,12 @@ dependencies = [
  "humantime",
  "influxdb2_client",
  "itertools",
+ "mutable_batch",
+ "mutable_batch_lp",
+ "parquet_file",
  "rand",
  "regex",
+ "schema",
  "serde",
  "serde_json",
  "snafu",

--- a/iox_data_generator/Cargo.toml
+++ b/iox_data_generator/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 default-run = "iox_data_generator"
 
 [dependencies]
+bytes = "1.2"
 chrono = { version = "0.4", default-features = false }
 chrono-english = "0.1.4"
 clap = { version = "3", features = ["derive", "env", "cargo"] }
@@ -14,8 +15,12 @@ handlebars = "4.3.4"
 humantime = "2.1.0"
 influxdb2_client = { path = "../influxdb2_client" }
 itertools = "0.10.5"
+mutable_batch_lp = { path = "../mutable_batch_lp" }
+mutable_batch = { path = "../mutable_batch" }
+parquet_file = { path = "../parquet_file" }
 rand = { version = "0.8.3", features = ["small_rng"] }
 regex = "1.6"
+schema = { path = "../schema" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.83"
 snafu = "0.7"

--- a/iox_data_generator/src/bin/iox_data_generator.rs
+++ b/iox_data_generator/src/bin/iox_data_generator.rs
@@ -13,8 +13,10 @@
 use chrono::prelude::*;
 use chrono_english::{parse_date_string, Dialect};
 use iox_data_generator::{specification::DataSpec, write::PointsWriterBuilder};
-use std::fs::File;
-use std::io::{self, BufRead};
+use std::{
+    fs::File,
+    io::{self, BufRead},
+};
 use tracing::info;
 
 #[derive(clap::Parser)]
@@ -57,13 +59,18 @@ struct Config {
     #[clap(long, action)]
     print: bool,
 
-    /// Runs the generation with agents writing to a sink. Useful for quick stress test to see how much resources the generator will take
+    /// Runs the generation with agents writing to a sink. Useful for quick stress test to see how
+    /// much resources the generator will take
     #[clap(long, action)]
     noop: bool,
 
-    /// The filename to write line protocol
+    /// The directory to write line protocol to
     #[clap(long, short, action)]
     output: Option<String>,
+
+    /// The directory to write Parquet files to
+    #[clap(long, short, action)]
+    parquet: Option<String>,
 
     /// The host name part of the API endpoint to write to
     #[clap(long, short, action)]
@@ -105,7 +112,8 @@ struct Config {
     #[clap(long = "continue", action)]
     do_continue: bool,
 
-    /// Generate this many samplings to batch into a single API call. Good for sending a bunch of historical data in quickly if paired with a start time from long ago.
+    /// Generate this many samplings to batch into a single API call. Good for sending a bunch of
+    /// historical data in quickly if paired with a start time from long ago.
     #[clap(long, action, default_value = "1")]
     batch_size: usize,
 
@@ -142,10 +150,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let data_spec = DataSpec::from_file(&config.specification)?;
 
-    // TODO: parquet output
-
     let mut points_writer_builder = if let Some(line_protocol_filename) = config.output {
         PointsWriterBuilder::new_file(line_protocol_filename)?
+    } else if let Some(parquet_directory) = config.parquet {
+        PointsWriterBuilder::new_parquet(parquet_directory)?
     } else if let Some(ref host) = config.host {
         let token = config.token.expect("--token must be specified");
 

--- a/iox_data_generator/src/lib.rs
+++ b/iox_data_generator/src/lib.rs
@@ -31,9 +31,9 @@
 
 use crate::{agent::Agent, tag_set::GeneratedTagSets};
 use snafu::{ResultExt, Snafu};
-use std::sync::{atomic::AtomicU64, Arc};
 use std::{
     convert::TryFrom,
+    sync::{atomic::AtomicU64, Arc},
     time::{SystemTime, UNIX_EPOCH},
 };
 use tracing::info;
@@ -154,7 +154,8 @@ pub async fn generate(
             .context(CouldNotCreateAgentSnafu)?;
 
             info!(
-                "Configuring {} agents of \"{}\" to write data to org {} and bucket {} (database {})",
+                "Configuring {} agents of \"{}\" to write data \
+                to org {} and bucket {} (database {})",
                 agent_assignment.count,
                 agent_assignment.spec.name,
                 org,
@@ -171,7 +172,8 @@ pub async fn generate(
 
                 let total_rows = Arc::clone(&total_rows);
                 handles.push(tokio::task::spawn(async move {
-                    // did this weird hack because otherwise the stdout outputs would be jumbled together garbage
+                    // did this weird hack because otherwise the stdout outputs would be jumbled
+                    // together garbage
                     if one_agent_at_a_time {
                         let _l = lock_ref.lock().await;
                         agent

--- a/iox_data_generator/src/specification.rs
+++ b/iox_data_generator/src/specification.rs
@@ -89,8 +89,8 @@ impl DataSpec {
 
         let mut start = 0;
 
-        // either all database writers must use regex or none of them can. It's either ratio or regex
-        // for assignment
+        // either all database writers must use regex or none of them can. It's either ratio or
+        // regex for assignment
         let use_ratio = self.database_writers[0].database_regex.is_none();
         for b in &self.database_writers {
             if use_ratio && b.database_regex.is_some() {
@@ -200,7 +200,8 @@ impl FromStr for DataSpec {
 pub struct ValuesSpec {
     /// The name of the collection of values
     pub name: String,
-    /// If values not specified this handlebars template will be used to create each value in the collection
+    /// If values not specified this handlebars template will be used to create each value in the
+    /// collection
     pub template: String,
     /// How many of these values should be generated. If belongs_to is
     /// specified, each parent will have this many of this value. So
@@ -297,8 +298,8 @@ pub struct AgentSpec {
     pub has_one: Vec<String>,
     /// Specification of tag key/value pairs that get generated once and reused for
     /// every sampling. Every measurement (and thus line) will have these tag pairs added onto it.
-    /// The template can use `{{agent.id}}` to reference the agent's id and `{{guid}}` or `{{random N}}`
-    /// to generate random strings.
+    /// The template can use `{{agent.id}}` to reference the agent's id and `{{guid}}` or
+    /// `{{random N}}` to generate random strings.
     #[serde(default)]
     pub tag_pairs: Vec<TagPairSpec>,
 }
@@ -675,7 +676,10 @@ agents = [{name = "foo", sampling_interval = "10s"}]
         let field_spec = &a0m0f0.field_value_spec;
 
         assert!(
-            matches!(field_spec, FieldValueSpec::String { replacements, .. } if replacements.is_empty()),
+            matches!(
+                field_spec,
+                FieldValueSpec::String { replacements, .. } if replacements.is_empty()
+            ),
             "expected a String field with empty replacements; was {:?}",
             field_spec
         );

--- a/iox_data_generator/src/specification.rs
+++ b/iox_data_generator/src/specification.rs
@@ -12,8 +12,13 @@ use tracing::warn;
 #[allow(missing_docs)]
 pub enum Error {
     /// File-related error that may happen while reading a specification
-    #[snafu(display(r#"Error reading data spec from TOML file: {}"#, source))]
+    #[snafu(display(
+        r#"Error reading data spec from TOML file at {}: {}"#,
+        file_name,
+        source
+    ))]
     ReadFile {
+        file_name: String,
         /// Underlying I/O error that caused this problem
         source: std::io::Error,
     },
@@ -76,7 +81,7 @@ pub struct DataSpec {
 impl DataSpec {
     /// Given a filename, read the file and parse the specification.
     pub fn from_file(file_name: &str) -> Result<Self> {
-        let spec_toml = fs::read_to_string(file_name).context(ReadFileSnafu)?;
+        let spec_toml = fs::read_to_string(file_name).context(ReadFileSnafu { file_name })?;
         Self::from_str(&spec_toml)
     }
 

--- a/iox_tests/src/util.rs
+++ b/iox_tests/src/util.rs
@@ -606,7 +606,7 @@ impl TestPartition {
                 table_catalog_schema
                     .columns
                     .get(f.name())
-                    .expect("Column registered")
+                    .unwrap_or_else(|| panic!("Column {} is not registered", f.name()))
                     .id
             }));
 

--- a/parquet_file/src/metadata.rs
+++ b/parquet_file/src/metadata.rs
@@ -394,6 +394,27 @@ impl IoxMetadata {
         })
     }
 
+    /// Generate metadata for a file generated from some process other than IOx ingesting.
+    ///
+    /// This metadata will not have valid catalog values; inserting files with this metadata into
+    /// the catalog should get valid values out-of-band.
+    pub fn external(creation_timestamp_ns: i64, table_name: impl Into<Arc<str>>) -> Self {
+        Self {
+            object_store_id: Default::default(),
+            creation_timestamp: Time::from_timestamp_nanos(creation_timestamp_ns),
+            namespace_id: NamespaceId::new(1),
+            namespace_name: "external".into(),
+            shard_id: ShardId::new(1),
+            table_id: TableId::new(1),
+            table_name: table_name.into(),
+            partition_id: PartitionId::new(1),
+            partition_key: "unknown".into(),
+            max_sequence_number: SequenceNumber::new(1),
+            compaction_level: CompactionLevel::Initial,
+            sort_key: None,
+        }
+    }
+
     /// verify uuid
     pub fn match_object_store_id(&self, uuid: Uuid) -> bool {
         uuid == self.object_store_id

--- a/parquet_to_line_protocol/src/lib.rs
+++ b/parquet_to_line_protocol/src/lib.rs
@@ -1,12 +1,5 @@
 //! Code that can convert between parquet files and line protocol
 
-use std::{
-    io::Write,
-    path::{Path, PathBuf},
-    result::Result,
-    sync::Arc,
-};
-
 use datafusion::{
     arrow::datatypes::SchemaRef as ArrowSchemaRef,
     datasource::{
@@ -28,11 +21,15 @@ use object_store::{
 };
 use parquet_file::metadata::{IoxMetadata, METADATA_KEY};
 use schema::Schema;
-
 use snafu::{OptionExt, ResultExt, Snafu};
+use std::{
+    io::Write,
+    path::{Path, PathBuf},
+    result::Result,
+    sync::Arc,
+};
 
 mod batch;
-
 use batch::convert_to_lines;
 
 #[derive(Debug, Snafu)]
@@ -155,7 +152,7 @@ where
 
 /// Handles the details of interacting with parquet libraries /
 /// readers. Tries not to have any IOx specific logic
-struct ParquetFileReader {
+pub struct ParquetFileReader {
     object_store: Arc<dyn ObjectStore>,
     object_store_url: ObjectStoreUrl,
     /// Name / path information of the object to read
@@ -171,7 +168,7 @@ struct ParquetFileReader {
 
 impl ParquetFileReader {
     /// Find and open the specified parquet file, and read its metadata / schema
-    async fn try_new(
+    pub async fn try_new(
         object_store: Arc<dyn ObjectStore>,
         object_store_url: ObjectStoreUrl,
         object_meta: ObjectMeta,
@@ -196,12 +193,12 @@ impl ParquetFileReader {
     }
 
     // retrieves the Arrow schema for this file
-    fn schema(&self) -> ArrowSchemaRef {
+    pub fn schema(&self) -> ArrowSchemaRef {
         Arc::clone(&self.schema)
     }
 
     /// read the parquet file as a stream
-    async fn read(&self) -> Result<SendableRecordBatchStream, Error> {
+    pub async fn read(&self) -> Result<SendableRecordBatchStream, Error> {
         let base_config = FileScanConfig {
             object_store_url: self.object_store_url.clone(),
             file_schema: self.schema(),


### PR DESCRIPTION
Connects to https://github.com/influxdata/conductor/issues/1169.

## In this PR

I changed my mind about how `compactor generate` will work; rather than generating line protocol files then converting them to Parquet files, we gave the data generator the ability to output Parquet files.

This only generates the files and does *not* import them into a catalog yet. The `IoxMetadata` put into the file is just placeholders, with the expectation that the code that will import the Parquet files into the catalog will ignore the `IoxMetadata` in the file and will instead generate the appropriate values based on where those files will go in the catalog.

Now, when you run `cargo run -- compactor generate`, rather than a directory of line protocol files, there will be a directory of Parquet files.

## Still unimplemented

These pieces will be coming in future PRs:

- Actually generating files for `--num-partitions` specified
- Adding entries to the catalog
