### PR TITLE
test: refactor ingester helpers

### DIFF
--- a/ingester/src/data/partition/resolver/cache.rs
+++ b/ingester/src/data/partition/resolver/cache.rs
@@ -208,7 +208,7 @@ mod tests {
             TABLE_NAME.into(),
             None,
         );
-        let inner = MockPartitionProvider::default().with_partition(PARTITION_KEY.into(), data);
+        let inner = MockPartitionProvider::default().with_partition(data);
 
         let cache = PartitionCache::new(inner, []);
         let got = cache
@@ -277,18 +277,15 @@ mod tests {
     async fn test_miss_partition_jey() {
         let other_key = PartitionKey::from("test");
         let other_key_id = PartitionId::new(99);
-        let inner = MockPartitionProvider::default().with_partition(
+        let inner = MockPartitionProvider::default().with_partition(PartitionData::new(
+            other_key_id,
             other_key.clone(),
-            PartitionData::new(
-                other_key_id,
-                PARTITION_KEY.into(),
-                SHARD_ID,
-                NAMESPACE_ID,
-                TABLE_ID,
-                TABLE_NAME.into(),
-                None,
-            ),
-        );
+            SHARD_ID,
+            NAMESPACE_ID,
+            TABLE_ID,
+            TABLE_NAME.into(),
+            None,
+        ));
 
         let partition = Partition {
             id: PARTITION_ID,
@@ -319,18 +316,15 @@ mod tests {
     #[tokio::test]
     async fn test_miss_table_id() {
         let other_table = TableId::new(1234);
-        let inner = MockPartitionProvider::default().with_partition(
+        let inner = MockPartitionProvider::default().with_partition(PartitionData::new(
+            PARTITION_ID,
             PARTITION_KEY.into(),
-            PartitionData::new(
-                PARTITION_ID,
-                PARTITION_KEY.into(),
-                SHARD_ID,
-                NAMESPACE_ID,
-                other_table,
-                TABLE_NAME.into(),
-                None,
-            ),
-        );
+            SHARD_ID,
+            NAMESPACE_ID,
+            other_table,
+            TABLE_NAME.into(),
+            None,
+        ));
 
         let partition = Partition {
             id: PARTITION_ID,
@@ -361,18 +355,15 @@ mod tests {
     #[tokio::test]
     async fn test_miss_shard_id() {
         let other_shard = ShardId::new(1234);
-        let inner = MockPartitionProvider::default().with_partition(
+        let inner = MockPartitionProvider::default().with_partition(PartitionData::new(
+            PARTITION_ID,
             PARTITION_KEY.into(),
-            PartitionData::new(
-                PARTITION_ID,
-                PARTITION_KEY.into(),
-                other_shard,
-                NAMESPACE_ID,
-                TABLE_ID,
-                TABLE_NAME.into(),
-                None,
-            ),
-        );
+            other_shard,
+            NAMESPACE_ID,
+            TABLE_ID,
+            TABLE_NAME.into(),
+            None,
+        ));
 
         let partition = Partition {
             id: PARTITION_ID,

--- a/ingester/src/data/partition/resolver/mock.rs
+++ b/ingester/src/data/partition/resolver/mock.rs
@@ -20,22 +20,25 @@ pub(crate) struct MockPartitionProvider {
 impl MockPartitionProvider {
     /// A builder helper for [`Self::insert()`].
     #[must_use]
-    pub(crate) fn with_partition(
-        mut self,
-        partition_key: PartitionKey,
-        data: PartitionData,
-    ) -> Self {
-        self.insert(partition_key, data);
+    pub(crate) fn with_partition(mut self, data: PartitionData) -> Self {
+        self.insert(data);
         self
     }
 
     /// Add `data` to the mock state, returning it when asked for the specified
     /// `(key, shard, table)` triplet.
-    pub(crate) fn insert(&mut self, partition_key: PartitionKey, data: PartitionData) {
+    pub(crate) fn insert(&mut self, data: PartitionData) {
         assert!(
             self.partitions
                 .lock()
-                .insert((partition_key, data.shard_id(), data.table_id()), data)
+                .insert(
+                    (
+                        data.partition_key().clone(),
+                        data.shard_id(),
+                        data.table_id()
+                    ),
+                    data
+                )
                 .is_none(),
             "overwriting an existing mock PartitionData"
         );

--- a/ingester/src/data/partition/resolver/trait.rs
+++ b/ingester/src/data/partition/resolver/trait.rs
@@ -71,7 +71,7 @@ mod tests {
             None,
         );
 
-        let mock = Arc::new(MockPartitionProvider::default().with_partition(key.clone(), data));
+        let mock = Arc::new(MockPartitionProvider::default().with_partition(data));
 
         let got = mock
             .get_partition(

--- a/ingester/src/lifecycle.rs
+++ b/ingester/src/lifecycle.rs
@@ -5,6 +5,8 @@
 //! some absolute number and individual Parquet files that get persisted below some number. It
 //! is expected that they may be above or below the absolute thresholds.
 
+pub mod mock_handle;
+
 use std::{collections::BTreeMap, sync::Arc, time::Duration};
 
 use data_types::{NamespaceId, PartitionId, SequenceNumber, ShardId, TableId};

--- a/ingester/src/lifecycle/mock_handle.rs
+++ b/ingester/src/lifecycle/mock_handle.rs
@@ -1,0 +1,31 @@
+//! A mock [`LifecycleHandle`] impl for testing.
+
+use data_types::{NamespaceId, PartitionId, SequenceNumber, ShardId, TableId};
+
+use super::LifecycleHandle;
+
+/// Special [`LifecycleHandle`] that never persists and always accepts more data.
+///
+/// This is useful to control persists manually.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct NoopLifecycleHandle;
+
+impl LifecycleHandle for NoopLifecycleHandle {
+    fn log_write(
+        &self,
+        _partition_id: PartitionId,
+        _shard_id: ShardId,
+        _namespace_id: NamespaceId,
+        _table_id: TableId,
+        _sequence_number: SequenceNumber,
+        _bytes_written: usize,
+        _rows_written: usize,
+    ) -> bool {
+        // do NOT pause ingest
+        false
+    }
+
+    fn can_resume_ingest(&self) -> bool {
+        true
+    }
+}

--- a/ingester/src/test_util.rs
+++ b/ingester/src/test_util.rs
@@ -745,6 +745,7 @@ pub(crate) fn make_partitions(two_partitions: bool, shard_index: ShardIndex) -> 
         ops.push(DmlOperation::Write(make_write_op(
             &PartitionKey::from(TEST_PARTITION_2),
             shard_index,
+            TEST_NAMESPACE,
             seq_num,
             r#"test_table,city=Medford day="sun",temp=55 22"#,
         )));
@@ -753,6 +754,7 @@ pub(crate) fn make_partitions(two_partitions: bool, shard_index: ShardIndex) -> 
         ops.push(DmlOperation::Write(make_write_op(
             &PartitionKey::from(TEST_PARTITION_2),
             shard_index,
+            TEST_NAMESPACE,
             seq_num,
             r#"test_table,city=Reading day="mon",temp=58 40"#,
         )));
@@ -761,6 +763,7 @@ pub(crate) fn make_partitions(two_partitions: bool, shard_index: ShardIndex) -> 
         ops.push(DmlOperation::Write(make_write_op(
             &PartitionKey::from(TEST_PARTITION_1),
             shard_index,
+            TEST_NAMESPACE,
             seq_num,
             r#"test_table,city=Medford day="sun",temp=55 22"#,
         )));
@@ -769,6 +772,7 @@ pub(crate) fn make_partitions(two_partitions: bool, shard_index: ShardIndex) -> 
         ops.push(DmlOperation::Write(make_write_op(
             &PartitionKey::from(TEST_PARTITION_1),
             shard_index,
+            TEST_NAMESPACE,
             seq_num,
             r#"test_table,city=Reading day="mon",temp=58 40"#,
         )));
@@ -878,6 +882,7 @@ async fn make_one_partition_with_tombstones(
             DmlOperation::Write(make_write_op(
                 &PartitionKey::from(TEST_PARTITION_1),
                 shard_index,
+                TEST_NAMESPACE,
                 seq_num,
                 r#"test_table,city=Medford day="sun",temp=55 22"#,
             )),
@@ -893,6 +898,7 @@ async fn make_one_partition_with_tombstones(
             DmlOperation::Write(make_write_op(
                 &PartitionKey::from(TEST_PARTITION_1),
                 shard_index,
+                TEST_NAMESPACE,
                 seq_num,
                 r#"test_table,city=Reading day="mon",temp=58 40"#,
             )),
@@ -902,14 +908,15 @@ async fn make_one_partition_with_tombstones(
         .unwrap();
 }
 
-fn make_write_op(
+pub(crate) fn make_write_op(
     partition_key: &PartitionKey,
     shard_index: ShardIndex,
+    namespace: &str,
     sequence_number: i64,
     lines: &str,
 ) -> DmlWrite {
     DmlWrite::new(
-        TEST_NAMESPACE.to_string(),
+        namespace.to_string(),
         lines_to_batches(lines, 0).unwrap(),
         Some(partition_key.clone()),
         DmlMeta::sequenced(
@@ -954,6 +961,7 @@ fn make_first_partition_data(
     out.push(DmlOperation::Write(make_write_op(
         partition_key,
         shard_index,
+        TEST_NAMESPACE,
         seq_num,
         r#"test_table,city=Boston day="sun",temp=60 36"#,
     )));
@@ -962,6 +970,7 @@ fn make_first_partition_data(
     out.push(DmlOperation::Write(make_write_op(
         partition_key,
         shard_index,
+        TEST_NAMESPACE,
         seq_num,
         r#"test_table,city=Andover day="tue",temp=56 30"#,
     )));
@@ -972,6 +981,7 @@ fn make_first_partition_data(
     out.push(DmlOperation::Write(make_write_op(
         partition_key,
         shard_index,
+        TEST_NAMESPACE,
         seq_num,
         r#"test_table,city=Andover day="mon" 46"#,
     )));
@@ -980,6 +990,7 @@ fn make_first_partition_data(
     out.push(DmlOperation::Write(make_write_op(
         partition_key,
         shard_index,
+        TEST_NAMESPACE,
         seq_num,
         r#"test_table,city=Medford day="wed" 26"#,
     )));
@@ -991,6 +1002,7 @@ fn make_first_partition_data(
     out.push(DmlOperation::Write(make_write_op(
         partition_key,
         shard_index,
+        TEST_NAMESPACE,
         seq_num,
         r#"test_table,city=Boston day="mon" 38"#,
     )));
@@ -999,6 +1011,7 @@ fn make_first_partition_data(
     out.push(DmlOperation::Write(make_write_op(
         partition_key,
         shard_index,
+        TEST_NAMESPACE,
         seq_num,
         r#"test_table,city=Wilmington day="mon" 35"#,
     )));

--- a/query_tests/src/scenarios/util.rs
+++ b/query_tests/src/scenarios/util.rs
@@ -3,8 +3,8 @@ use super::DbScenario;
 use async_trait::async_trait;
 use backoff::BackoffConfig;
 use data_types::{
-    DeletePredicate, IngesterMapping, NamespaceId, NonEmptyString, ParquetFileId, PartitionId,
-    PartitionKey, Sequence, SequenceNumber, ShardId, ShardIndex, TableId, TombstoneId,
+    DeletePredicate, IngesterMapping, NonEmptyString, ParquetFileId, PartitionId, PartitionKey,
+    Sequence, SequenceNumber, ShardIndex, TombstoneId,
 };
 use dml::{DmlDelete, DmlMeta, DmlOperation, DmlWrite};
 use futures::StreamExt;
@@ -18,7 +18,7 @@ use ingester::{
         partition::resolver::CatalogPartitionResolver, FlatIngesterQueryResponse, IngesterData,
         IngesterQueryResponse, Persister,
     },
-    lifecycle::LifecycleHandle,
+    lifecycle::mock_handle::NoopLifecycleHandle,
     querier_handler::prepare_data_to_querier,
 };
 use iox_catalog::interface::get_schema_by_name;
@@ -961,31 +961,6 @@ impl MockIngester {
             load_settings,
             usize::MAX,
         ))
-    }
-}
-
-/// Special [`LifecycleHandle`] that never persists and always accepts more data.
-///
-/// This is useful to control persists manually.
-struct NoopLifecycleHandle {}
-
-impl LifecycleHandle for NoopLifecycleHandle {
-    fn log_write(
-        &self,
-        _partition_id: PartitionId,
-        _shard_id: ShardId,
-        _namespace_id: NamespaceId,
-        _table_id: TableId,
-        _sequence_number: SequenceNumber,
-        _bytes_written: usize,
-        _rows_written: usize,
-    ) -> bool {
-        // do NOT pause ingest
-        false
-    }
-
-    fn can_resume_ingest(&self) -> bool {
-        true
     }
 }
 


### PR DESCRIPTION
Clean up a bit of ingester test helpers before the next series of PRs that make use of them.

---

* test: shared mock LifecycleHandle impl (f0885612e)

      Moves the NoopLifecycleHandle to the Ingester's test_utils to share it across
      multiple components.

* test: re-use test_utils::make_op (fc47f6ab8)

      Share the make_op helper across all tests in the Ingester.

* test: share populate_catalog() across tests (c33499764)

      Parametrises test_util::populate_catalog() and exports for re-use in ingester
      tests.

* test: simplify PartitionProvider mock (7dd28f423)

      The PartitionKey is now part of the PartitionData, so there is no need to
      specify the redundant ID when configuring the mock.