### PR TITLE
fix(ingester): incorrect memory tracking of failed writes

### DIFF
--- a/ingester/src/data/table.rs
+++ b/ingester/src/data/table.rs
@@ -125,6 +125,11 @@ impl TableData {
         let rows = batch.rows();
         partition_data.buffer_write(sequence_number, batch)?;
 
+        // Record the write as having been buffered.
+        //
+        // This should happen AFTER the write is applied, because buffering the
+        // op may fail which would lead to a write being recorded, but not
+        // applied.
         let should_pause = lifecycle_handle.log_write(
             partition_data.id(),
             self.shard_id,

--- a/ingester/src/data/table.rs
+++ b/ingester/src/data/table.rs
@@ -121,16 +121,19 @@ impl TableData {
             }
         }
 
+        let size = batch.size();
+        let rows = batch.rows();
+        partition_data.buffer_write(sequence_number, batch)?;
+
         let should_pause = lifecycle_handle.log_write(
             partition_data.id(),
             self.shard_id,
             self.namespace_id,
             self.table_id,
             sequence_number,
-            batch.size(),
-            batch.rows(),
+            size,
+            rows,
         );
-        partition_data.buffer_write(sequence_number, batch)?;
 
         Ok(should_pause)
     }
@@ -205,5 +208,148 @@ impl TableData {
     #[cfg(test)]
     pub(super) fn table_id(&self) -> TableId {
         self.table_id
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use assert_matches::assert_matches;
+    use data_types::{PartitionId, ShardIndex};
+    use mutable_batch::writer;
+    use mutable_batch_lp::lines_to_batches;
+    use schema::{InfluxColumnType, InfluxFieldType};
+
+    use crate::{
+        data::{
+            partition::{resolver::MockPartitionProvider, PartitionData},
+            Error,
+        },
+        lifecycle::mock_handle::{MockLifecycleCall, MockLifecycleHandle},
+        test_util::populate_catalog,
+    };
+
+    use super::*;
+
+    const SHARD_INDEX: ShardIndex = ShardIndex::new(24);
+    const TABLE_NAME: &str = "bananas";
+    const NAMESPACE_NAME: &str = "platanos";
+    const PARTITION_KEY: &str = "platanos";
+    const PARTITION_ID: PartitionId = PartitionId::new(0);
+
+    #[tokio::test]
+    async fn test_bad_write_memory_counting() {
+        let metrics = Arc::new(metric::Registry::default());
+        let catalog: Arc<dyn Catalog> =
+            Arc::new(iox_catalog::mem::MemCatalog::new(Arc::clone(&metrics)));
+
+        // Populate the catalog with the shard / namespace / table
+        let (shard_id, ns_id, table_id) =
+            populate_catalog(&*catalog, SHARD_INDEX, NAMESPACE_NAME, TABLE_NAME).await;
+
+        // Configure the mock partition provider to return a partition for this
+        // table ID.
+        let partition_provider = Arc::new(MockPartitionProvider::default().with_partition(
+            PartitionData::new(
+                PARTITION_ID,
+                PARTITION_KEY.into(),
+                shard_id,
+                ns_id,
+                table_id,
+                TABLE_NAME.into(),
+                None,
+            ),
+        ));
+
+        let mut table = TableData::new(
+            table_id,
+            TABLE_NAME,
+            shard_id,
+            ns_id,
+            None,
+            partition_provider,
+        );
+
+        let batch = lines_to_batches(r#"bananas,bat=man value=24 42"#, 0)
+            .unwrap()
+            .remove(TABLE_NAME)
+            .unwrap();
+
+        // Initialise the mock lifecycle handle and use it to inspect the calls
+        // made to the lifecycle manager during buffering.
+        let handle = MockLifecycleHandle::default();
+
+        // Assert the table does not contain the test partition
+        assert!(table.partition_data.get(&PARTITION_KEY.into()).is_none());
+
+        // Write some test data
+        let pause = table
+            .buffer_table_write(
+                SequenceNumber::new(42),
+                batch,
+                PARTITION_KEY.into(),
+                &handle,
+            )
+            .await
+            .expect("buffer op should succeed");
+        assert!(!pause);
+
+        // Referencing the partition should succeed
+        assert!(table.partition_data.get(&PARTITION_KEY.into()).is_some());
+
+        // And the lifecycle handle was called with the expected values
+        assert_eq!(
+            handle.get_log_calls(),
+            &[MockLifecycleCall {
+                partition_id: PARTITION_ID,
+                shard_id,
+                namespace_id: ns_id,
+                table_id,
+                sequence_number: SequenceNumber::new(42),
+                bytes_written: 1131,
+                rows_written: 1,
+            }]
+        );
+
+        // Attempt to buffer the second op that contains a type conflict - this
+        // should return an error, and not make a call to the lifecycle handle
+        // (as no data was buffered)
+        //
+        // Note the type of value was numeric previously, and here it is a string.
+        let batch = lines_to_batches(r#"bananas,bat=man value="platanos" 42"#, 0)
+            .unwrap()
+            .remove(TABLE_NAME)
+            .unwrap();
+
+        let err = table
+            .buffer_table_write(
+                SequenceNumber::new(42),
+                batch,
+                PARTITION_KEY.into(),
+                &handle,
+            )
+            .await
+            .expect_err("type conflict should error");
+
+        // The buffer op should return a column type error
+        assert_matches!(
+            err,
+            Error::BufferWrite {
+                source: mutable_batch::Error::WriterError {
+                    source: writer::Error::TypeMismatch {
+                        existing: InfluxColumnType::Field(InfluxFieldType::Float),
+                        inserted: InfluxColumnType::Field(InfluxFieldType::String),
+                        column: col_name,
+                    }
+                },
+            } => { assert_eq!(col_name, "value") }
+        );
+
+        // And the lifecycle handle should not be called.
+        //
+        // It still contains the first call, so the desired length is 1
+        // indicating no second call was made.
+        assert_eq!(handle.get_log_calls().len(), 1);
     }
 }

--- a/ingester/src/lifecycle/mock_handle.rs
+++ b/ingester/src/lifecycle/mock_handle.rs
@@ -1,26 +1,66 @@
 //! A mock [`LifecycleHandle`] impl for testing.
 
+use std::sync::Arc;
+
 use data_types::{NamespaceId, PartitionId, SequenceNumber, ShardId, TableId};
+use parking_lot::Mutex;
 
 use super::LifecycleHandle;
 
-/// Special [`LifecycleHandle`] that never persists and always accepts more data.
-///
-/// This is useful to control persists manually.
-#[derive(Debug, Default, Clone, Copy)]
-pub struct NoopLifecycleHandle;
+/// A set of arguments captured from a call to
+/// [`MockLifecycleHandle::log_write()`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[allow(missing_docs)]
+pub struct MockLifecycleCall {
+    pub partition_id: PartitionId,
+    pub shard_id: ShardId,
+    pub namespace_id: NamespaceId,
+    pub table_id: TableId,
+    pub sequence_number: SequenceNumber,
+    pub bytes_written: usize,
+    pub rows_written: usize,
+}
 
-impl LifecycleHandle for NoopLifecycleHandle {
+/// A mock [`LifecycleHandle`] implementation that records calls made to
+/// [`Self::log_write()`] and never blocks ingest, always accepting more data.
+///
+/// # Cloning
+///
+/// Cloning a [`MockLifecycleHandle`] will clone the inner state - calls to all
+/// cloned instances are reported in a call to [`Self::get_log_calls()`].
+#[derive(Debug, Default, Clone)]
+pub struct MockLifecycleHandle {
+    log_calls: Arc<Mutex<Vec<MockLifecycleCall>>>,
+}
+
+impl MockLifecycleHandle {
+    /// Returns the ordered [`Self::log_write()`] calls made to this mock.
+    pub fn get_log_calls(&self) -> Vec<MockLifecycleCall> {
+        self.log_calls.lock().clone()
+    }
+}
+
+impl LifecycleHandle for MockLifecycleHandle {
     fn log_write(
         &self,
-        _partition_id: PartitionId,
-        _shard_id: ShardId,
-        _namespace_id: NamespaceId,
-        _table_id: TableId,
-        _sequence_number: SequenceNumber,
-        _bytes_written: usize,
-        _rows_written: usize,
+        partition_id: PartitionId,
+        shard_id: ShardId,
+        namespace_id: NamespaceId,
+        table_id: TableId,
+        sequence_number: SequenceNumber,
+        bytes_written: usize,
+        rows_written: usize,
     ) -> bool {
+        self.log_calls.lock().push(MockLifecycleCall {
+            partition_id,
+            shard_id,
+            namespace_id,
+            table_id,
+            sequence_number,
+            bytes_written,
+            rows_written,
+        });
+
         // do NOT pause ingest
         false
     }

--- a/query_tests/src/scenarios/util.rs
+++ b/query_tests/src/scenarios/util.rs
@@ -18,7 +18,7 @@ use ingester::{
         partition::resolver::CatalogPartitionResolver, FlatIngesterQueryResponse, IngesterData,
         IngesterQueryResponse, Persister,
     },
-    lifecycle::mock_handle::NoopLifecycleHandle,
+    lifecycle::mock_handle::MockLifecycleHandle,
     querier_handler::prepare_data_to_querier,
 };
 use iox_catalog::interface::get_schema_by_name;
@@ -722,7 +722,7 @@ impl MockIngester {
     /// Takes `&self mut` because our partioning implementation does not work with concurrent
     /// access.
     async fn buffer_operation(&mut self, dml_operation: DmlOperation) {
-        let lifecycle_handle = NoopLifecycleHandle {};
+        let lifecycle_handle = MockLifecycleHandle::default();
 
         let should_pause = self
             .ingester_data


### PR DESCRIPTION
A quick fix for the op buffering / memory tracking where a write was recorded in the memory tracker before being applied. Because applying the op is fallible, this could lead to writes being recorded as applied, but not actually applied, and thus slowly draining the ingester of usable memory budget.

I don't think this has ever been hit, but it is in the area I'm working on today and was a quick fix 🚀 

---

* test: MockLifecycleHandle captures calls (20451921d)

      Changes the NoopLifecycleHandle to MockLifecycleCall, and adds code causing it
      to log all calls made to the log_write() method.

      This will allow tests to assert calls and their values in DML buffering tests.

* fix: spurious memory accounting for failed write (b23ad3171)

      Fixes a case where the ingester may incorrectly record a write as having been
      buffered in memory, when in fact the buffering failed.

      This could cause the effective buffer size to be reduced over time as more and
      more data is spuriously "added" to the buffer, but never released back to the
      memory tracker as it is never persisted.