### PR TITLE
refactor: reference buffer tree nodes by ID

### DIFF
--- a/ingester/src/compact.rs
+++ b/ingester/src/compact.rs
@@ -86,11 +86,8 @@ pub(crate) async fn compact_persisting_batch(
     namespace_id: i64,
     partition_info: &PartitionInfo,
     batch: Arc<PersistingBatch>,
-) -> Result<Option<CompactedStream>> {
-    // Nothing to compact
-    if batch.data.data.is_empty() {
-        return Ok(None);
-    }
+) -> Result<CompactedStream> {
+    assert!(!batch.data.data.is_empty());
 
     let namespace_name = &partition_info.namespace_name;
     let table_name = &partition_info.table_name;
@@ -141,11 +138,11 @@ pub(crate) async fn compact_persisting_batch(
         sort_key: Some(metadata_sort_key),
     };
 
-    Ok(Some(CompactedStream {
+    Ok(CompactedStream {
         stream,
         iox_metadata,
         sort_key_update,
-    }))
+    })
 }
 
 /// Compact a given Queryable Batch
@@ -254,7 +251,6 @@ mod tests {
         let CompactedStream { stream, .. } =
             compact_persisting_batch(time_provider, &exc, 1, &partition_info, persisting_batch)
                 .await
-                .unwrap()
                 .unwrap();
 
         let output_batches = datafusion::physical_plan::common::collect(stream)
@@ -328,7 +324,6 @@ mod tests {
             sort_key_update,
         } = compact_persisting_batch(time_provider, &exc, 1, &partition_info, persisting_batch)
             .await
-            .unwrap()
             .unwrap();
 
         let output_batches = datafusion::physical_plan::common::collect(stream)
@@ -426,7 +421,6 @@ mod tests {
             sort_key_update,
         } = compact_persisting_batch(time_provider, &exc, 1, &partition_info, persisting_batch)
             .await
-            .unwrap()
             .unwrap();
 
         let output_batches = datafusion::physical_plan::common::collect(stream)
@@ -527,7 +521,6 @@ mod tests {
             sort_key_update,
         } = compact_persisting_batch(time_provider, &exc, 1, &partition_info, persisting_batch)
             .await
-            .unwrap()
             .unwrap();
 
         let output_batches = datafusion::physical_plan::common::collect(stream)
@@ -629,7 +622,6 @@ mod tests {
             sort_key_update,
         } = compact_persisting_batch(time_provider, &exc, 1, &partition_info, persisting_batch)
             .await
-            .unwrap()
             .unwrap();
 
         let output_batches = datafusion::physical_plan::common::collect(stream)
@@ -739,7 +731,6 @@ mod tests {
             sort_key_update,
         } = compact_persisting_batch(time_provider, &exc, 1, &partition_info, persisting_batch)
             .await
-            .unwrap()
             .unwrap();
 
         let output_batches = datafusion::physical_plan::common::collect(stream)

--- a/ingester/src/data.rs
+++ b/ingester/src/data.rs
@@ -811,7 +811,7 @@ mod tests {
             assert!(n.table_data("mem").is_some());
             let mem_table = mem_table.write().await;
             let p = mem_table.partition_data.get(&"1970-01-01".into()).unwrap();
-            p.id()
+            p.partition_id()
         };
 
         data.persist(partition_id).await;
@@ -955,7 +955,7 @@ mod tests {
             let p = mem_table.partition_data.get(&"1970-01-01".into()).unwrap();
 
             table_id = mem_table.table_id();
-            partition_id = p.id();
+            partition_id = p.partition_id();
         }
         {
             // verify the partition doesn't have a sort key before any data has been persisted

--- a/ingester/src/data.rs
+++ b/ingester/src/data.rs
@@ -810,7 +810,9 @@ mod tests {
             let mem_table = n.table_data("mem").unwrap();
             assert!(n.table_data("mem").is_some());
             let mem_table = mem_table.write().await;
-            let p = mem_table.partition_data.get(&"1970-01-01".into()).unwrap();
+            let p = mem_table
+                .get_partition_by_key(&"1970-01-01".into())
+                .unwrap();
             p.partition_id()
         };
 
@@ -952,7 +954,9 @@ mod tests {
             let mem_table = n.table_data("mem").unwrap();
             assert!(n.table_data("cpu").is_some());
             let mem_table = mem_table.write().await;
-            let p = mem_table.partition_data.get(&"1970-01-01".into()).unwrap();
+            let p = mem_table
+                .get_partition_by_key(&"1970-01-01".into())
+                .unwrap();
 
             table_id = mem_table.table_id();
             partition_id = p.partition_id();
@@ -1352,7 +1356,7 @@ mod tests {
         {
             let table_data = data.table_data("mem").unwrap();
             let table = table_data.read().await;
-            let p = table.partition_data.get(&"1970-01-01".into()).unwrap();
+            let p = table.get_partition_by_key(&"1970-01-01".into()).unwrap();
             assert_eq!(
                 p.max_persisted_sequence_number(),
                 Some(SequenceNumber::new(1))
@@ -1368,7 +1372,7 @@ mod tests {
 
         let table_data = data.table_data("mem").unwrap();
         let table = table_data.read().await;
-        let partition = table.partition_data.get(&"1970-01-01".into()).unwrap();
+        let partition = table.get_partition_by_key(&"1970-01-01".into()).unwrap();
         assert_eq!(
             partition.data.buffer.as_ref().unwrap().min_sequence_number,
             SequenceNumber::new(2)

--- a/ingester/src/data.rs
+++ b/ingester/src/data.rs
@@ -6,7 +6,7 @@ use arrow::{error::ArrowError, record_batch::RecordBatch};
 use arrow_util::optimize::{optimize_record_batch, optimize_schema};
 use async_trait::async_trait;
 use backoff::{Backoff, BackoffConfig};
-use data_types::{PartitionId, SequenceNumber, ShardId, ShardIndex};
+use data_types::{NamespaceId, PartitionId, SequenceNumber, ShardId, ShardIndex, TableId};
 use datafusion::physical_plan::SendableRecordBatchStream;
 use dml::DmlOperation;
 use futures::{Stream, StreamExt};
@@ -220,7 +220,13 @@ impl IngesterData {
 #[async_trait]
 pub trait Persister: Send + Sync + 'static {
     /// Persits the partition ID. Will retry forever until it succeeds.
-    async fn persist(&self, partition_id: PartitionId);
+    async fn persist(
+        &self,
+        shard_id: ShardId,
+        namespace_id: NamespaceId,
+        table_id: TableId,
+        partition_id: PartitionId,
+    );
 
     /// Updates the shard's `min_unpersisted_sequence_number` in the catalog.
     /// This number represents the minimum that might be unpersisted, which is the
@@ -235,7 +241,69 @@ pub trait Persister: Send + Sync + 'static {
 
 #[async_trait]
 impl Persister for IngesterData {
-    async fn persist(&self, partition_id: PartitionId) {
+    async fn persist(
+        &self,
+        shard_id: ShardId,
+        namespace_id: NamespaceId,
+        table_id: TableId,
+        partition_id: PartitionId,
+    ) {
+        // lookup the state from the ingester data. If something isn't found,
+        // it's unexpected. Crash so someone can take a look.
+        let shard_data = self
+            .shards
+            .get(&shard_id)
+            .unwrap_or_else(|| panic!("shard state for {shard_id} not in ingester data"));
+        let namespace = shard_data
+            .namespace_by_id(namespace_id)
+            .unwrap_or_else(|| panic!("namespace {namespace_id} not in shard {shard_id} state"));
+
+        let partition_key;
+        let batch;
+        {
+            let table_data = namespace.table_id(table_id).unwrap_or_else(|| {
+                panic!("table {table_id} in namespace {namespace_id} not in shard {shard_id} state")
+            });
+
+            let mut guard = table_data.write().await;
+            let partition = guard.get_partition(partition_id).unwrap_or_else(|| {
+                panic!(
+                    "partition {partition_id} in table {table_id} in namespace {namespace_id} not in shard {shard_id} state"
+                )
+            });
+
+            partition_key = partition.partition_key().clone();
+            batch = partition.snapshot_to_persisting_batch();
+        };
+
+        debug!(%shard_id, %namespace_id, %table_id, %partition_id, %partition_key, "persisting partition");
+
+        // Check if there is any data to persist.
+        let batch = match batch {
+            Some(v) if !v.data.data.is_empty() => v,
+            _ => {
+                warn!(
+                    %shard_id,
+                    %namespace_id,
+                    %table_id,
+                    %partition_id,
+                    %partition_key,
+                    "partition marked for persistence contains no data"
+                );
+                return;
+            }
+        };
+
+        // lookup column IDs from catalog
+        // TODO: this can be removed once the ingester uses column IDs internally as well
+        let table_schema = Backoff::new(&self.backoff_config)
+            .retry_all_errors("get table schema", || async {
+                let mut repos = self.catalog.repositories().await;
+                get_table_schema_by_id(table_id, repos.as_mut()).await
+            })
+            .await
+            .expect("retry forever");
+
         // lookup the partition_info from the catalog
         let partition_info = Backoff::new(&self.backoff_config)
             .retry_all_errors("get partition_info_by_id", || async {
@@ -243,217 +311,158 @@ impl Persister for IngesterData {
                 repos.partitions().partition_info_by_id(partition_id).await
             })
             .await
-            .expect("retry forever");
+            .expect("retry forever").unwrap_or_else(|| panic!("partition {partition_id} in table {table_id} in namespace {namespace_id} in shard {shard_id} has no partition info in catalog"));
 
-        // lookup the state from the ingester data. If something isn't found, it's unexpected. Crash
-        // so someone can take a look.
-        let partition_info = partition_info
-            .unwrap_or_else(|| panic!("partition {} not found in catalog", partition_id));
-        let shard_data = self
-            .shards
-            .get(&partition_info.partition.shard_id)
-            .unwrap_or_else(|| {
-                panic!(
-                    "shard state for {} not in ingester data",
-                    partition_info.partition.shard_id
-                )
-            }); //{
-        let namespace = shard_data
-            .namespace(&partition_info.namespace_name)
-            .unwrap_or_else(|| {
-                panic!(
-                    "namespace {} not in shard {} state",
-                    partition_info.namespace_name, partition_info.partition.shard_id
-                )
-            });
-        debug!(?partition_id, ?partition_info, "persisting partition");
+        // do the CPU intensive work of compaction, de-duplication and sorting
+        let CompactedStream {
+            stream: record_stream,
+            iox_metadata,
+            sort_key_update,
+        } = compact_persisting_batch(
+            Arc::new(SystemProvider::new()),
+            &self.exec,
+            namespace.namespace_id().get(),
+            &partition_info,
+            Arc::clone(&batch),
+        )
+        .await
+        .expect("unable to compact persisting batch");
 
-        // lookup column IDs from catalog
-        // TODO: this can be removed once the ingester uses column IDs internally as well
-        let table_schema = Backoff::new(&self.backoff_config)
-            .retry_all_errors("get table schema", || async {
-                let mut repos = self.catalog.repositories().await;
-                let table = repos
-                    .tables()
-                    .get_by_namespace_and_name(namespace.namespace_id(), &partition_info.table_name)
-                    .await?
-                    .expect("table not found in catalog");
-                get_table_schema_by_id(table.id, repos.as_mut()).await
-            })
+        // Save the compacted data to a parquet file in object storage.
+        //
+        // This call retries until it completes.
+        let (md, file_size) = self
+            .store
+            .upload(record_stream, &iox_metadata)
             .await
-            .expect("retry forever");
+            .expect("unexpected fatal persist error");
 
-        let persisting_batch = namespace
-            .snapshot_to_persisting(
-                &partition_info.table_name,
-                &partition_info.partition.partition_key,
-            )
-            .await;
-
-        if let Some(persisting_batch) = persisting_batch {
-            // do the CPU intensive work of compaction, de-duplication and sorting
-            let compacted_stream = match compact_persisting_batch(
-                Arc::new(SystemProvider::new()),
-                &self.exec,
-                namespace.namespace_id().get(),
-                &partition_info,
-                Arc::clone(&persisting_batch),
-            )
-            .await
-            {
-                Err(e) => {
-                    // this should never error out. if it does, we need to crash hard so
-                    // someone can take a look.
-                    panic!("unable to compact persisting batch with error: {:?}", e);
-                }
-                Ok(Some(r)) => r,
-                Ok(None) => {
-                    warn!("persist called with no data");
-                    return;
-                }
-            };
-            let CompactedStream {
-                stream: record_stream,
-                iox_metadata,
-                sort_key_update,
-            } = compacted_stream;
-
-            // Save the compacted data to a parquet file in object storage.
-            //
-            // This call retries until it completes.
-            let (md, file_size) = self
-                .store
-                .upload(record_stream, &iox_metadata)
-                .await
-                .expect("unexpected fatal persist error");
-
-            // Update the sort key in the catalog if there are
-            // additional columns BEFORE adding parquet file to the
-            // catalog. If the order is reversed, the querier or
-            // compactor may see a parquet file with an inconsistent
-            // sort key. https://github.com/influxdata/influxdb_iox/issues/5090
-            if let Some(new_sort_key) = sort_key_update {
-                let sort_key = new_sort_key.to_columns().collect::<Vec<_>>();
-                Backoff::new(&self.backoff_config)
-                    .retry_all_errors("update_sort_key", || async {
-                        let mut repos = self.catalog.repositories().await;
-                        let _partition = repos
-                            .partitions()
-                            .update_sort_key(partition_id, &sort_key)
-                            .await?;
-                        // compiler insisted on getting told the type of the error :shrug:
-                        Ok(()) as Result<(), iox_catalog::interface::Error>
-                    })
-                    .await
-                    .expect("retry forever");
-                debug!(
-                    ?partition_id,
-                    table = partition_info.table_name,
-                    ?new_sort_key,
-                    "adjusted sort key during batch compact & persist"
-                );
-            }
-
-            // Add the parquet file to the catalog until succeed
-            let parquet_file = iox_metadata.to_parquet_file(partition_id, file_size, &md, |name| {
-                table_schema.columns.get(name).expect("Unknown column").id
-            });
-
-            // Assert partitions are persisted in-order.
-            //
-            // It is an invariant that partitions are persisted in order so that
-            // both the per-shard, and per-partition watermarks are correctly
-            // advanced and accurate.
-            if let Some(last_persist) = partition_info.partition.persisted_sequence_number {
-                assert!(
-                    parquet_file.max_sequence_number > last_persist,
-                    "out of order partition persistence, persisting {}, previously persisted {}",
-                    parquet_file.max_sequence_number.get(),
-                    last_persist.get(),
-                );
-            }
-
-            // Add the parquet file to the catalog.
-            //
-            // This has the effect of allowing the queriers to "discover" the
-            // parquet file by polling / querying the catalog.
+        // Update the sort key in the catalog if there are
+        // additional columns BEFORE adding parquet file to the
+        // catalog. If the order is reversed, the querier or
+        // compactor may see a parquet file with an inconsistent
+        // sort key. https://github.com/influxdata/influxdb_iox/issues/5090
+        if let Some(new_sort_key) = sort_key_update {
+            let sort_key = new_sort_key.to_columns().collect::<Vec<_>>();
             Backoff::new(&self.backoff_config)
-                .retry_all_errors("add parquet file to catalog", || async {
+                .retry_all_errors("update_sort_key", || async {
                     let mut repos = self.catalog.repositories().await;
-                    let parquet_file = repos.parquet_files().create(parquet_file.clone()).await?;
-                    debug!(
-                        ?partition_id,
-                        table_id=?parquet_file.table_id,
-                        parquet_file_id=?parquet_file.id,
-                        table_name=%iox_metadata.table_name,
-                        "parquet file written to catalog"
-                    );
+                    let _partition = repos
+                        .partitions()
+                        .update_sort_key(partition_id, &sort_key)
+                        .await?;
                     // compiler insisted on getting told the type of the error :shrug:
                     Ok(()) as Result<(), iox_catalog::interface::Error>
                 })
                 .await
                 .expect("retry forever");
-
-            // Update the per-partition persistence watermark, so that new
-            // ingester instances skip the just-persisted ops during replay.
-            //
-            // This could be transactional with the above parquet insert to
-            // maintain catalog consistency, though in practice it is an
-            // unnecessary overhead - the system can tolerate replaying the ops
-            // that lead to this parquet file being generated, and tolerate
-            // creating a parquet file containing duplicate data (remedied by
-            // compaction).
-            //
-            // This means it is possible to observe a parquet file with a
-            // max_persisted_sequence_number >
-            // partition.persisted_sequence_number, either in-between these
-            // catalog updates, or for however long it takes a crashed ingester
-            // to restart and replay the ops, and re-persist a file containing
-            // the same (or subset of) data.
-            //
-            // The above is also true of the per-shard persist marker that
-            // governs the ingester's replay start point, which is
-            // non-transactionally updated after all partitions have persisted.
-            Backoff::new(&self.backoff_config)
-                .retry_all_errors("set partition persist marker", || async {
-                    self.catalog
-                        .repositories()
-                        .await
-                        .partitions()
-                        .update_persisted_sequence_number(
-                            parquet_file.partition_id,
-                            parquet_file.max_sequence_number,
-                        )
-                        .await
-                })
-                .await
-                .expect("retry forever");
-
-            // Record metrics
-            let attributes = Attributes::from([(
-                "shard_id",
-                format!("{}", partition_info.partition.shard_id).into(),
-            )]);
-            self.persisted_file_size_bytes
-                .recorder(attributes)
-                .record(file_size as u64);
-
-            // and remove the persisted data from memory
-            namespace
-                .mark_persisted(
-                    &partition_info.table_name,
-                    &partition_info.partition.partition_key,
-                    iox_metadata.max_sequence_number,
-                )
-                .await;
             debug!(
                 ?partition_id,
-                table_name=%partition_info.table_name,
-                partition_key=%partition_info.partition.partition_key,
-                max_sequence_number=%iox_metadata.max_sequence_number.get(),
-                "marked partition as persisted"
+                table = partition_info.table_name,
+                ?new_sort_key,
+                "adjusted sort key during batch compact & persist"
             );
         }
+
+        // Add the parquet file to the catalog until succeed
+        let parquet_file = iox_metadata.to_parquet_file(partition_id, file_size, &md, |name| {
+            table_schema.columns.get(name).expect("Unknown column").id
+        });
+
+        // Assert partitions are persisted in-order.
+        //
+        // It is an invariant that partitions are persisted in order so that
+        // both the per-shard, and per-partition watermarks are correctly
+        // advanced and accurate.
+        if let Some(last_persist) = partition_info.partition.persisted_sequence_number {
+            assert!(
+                parquet_file.max_sequence_number > last_persist,
+                "out of order partition persistence, persisting {}, previously persisted {}",
+                parquet_file.max_sequence_number.get(),
+                last_persist.get(),
+            );
+        }
+
+        // Add the parquet file to the catalog.
+        //
+        // This has the effect of allowing the queriers to "discover" the
+        // parquet file by polling / querying the catalog.
+        Backoff::new(&self.backoff_config)
+            .retry_all_errors("add parquet file to catalog", || async {
+                let mut repos = self.catalog.repositories().await;
+                let parquet_file = repos.parquet_files().create(parquet_file.clone()).await?;
+                debug!(
+                    ?partition_id,
+                    table_id=?parquet_file.table_id,
+                    parquet_file_id=?parquet_file.id,
+                    table_name=%iox_metadata.table_name,
+                    "parquet file written to catalog"
+                );
+                // compiler insisted on getting told the type of the error :shrug:
+                Ok(()) as Result<(), iox_catalog::interface::Error>
+            })
+            .await
+            .expect("retry forever");
+
+        // Update the per-partition persistence watermark, so that new
+        // ingester instances skip the just-persisted ops during replay.
+        //
+        // This could be transactional with the above parquet insert to
+        // maintain catalog consistency, though in practice it is an
+        // unnecessary overhead - the system can tolerate replaying the ops
+        // that lead to this parquet file being generated, and tolerate
+        // creating a parquet file containing duplicate data (remedied by
+        // compaction).
+        //
+        // This means it is possible to observe a parquet file with a
+        // max_persisted_sequence_number >
+        // partition.persisted_sequence_number, either in-between these
+        // catalog updates, or for however long it takes a crashed ingester
+        // to restart and replay the ops, and re-persist a file containing
+        // the same (or subset of) data.
+        //
+        // The above is also true of the per-shard persist marker that
+        // governs the ingester's replay start point, which is
+        // non-transactionally updated after all partitions have persisted.
+        Backoff::new(&self.backoff_config)
+            .retry_all_errors("set partition persist marker", || async {
+                self.catalog
+                    .repositories()
+                    .await
+                    .partitions()
+                    .update_persisted_sequence_number(
+                        parquet_file.partition_id,
+                        parquet_file.max_sequence_number,
+                    )
+                    .await
+            })
+            .await
+            .expect("retry forever");
+
+        // Record metrics
+        let attributes = Attributes::from([(
+            "shard_id",
+            format!("{}", partition_info.partition.shard_id).into(),
+        )]);
+        self.persisted_file_size_bytes
+            .recorder(attributes)
+            .record(file_size as u64);
+
+        // and remove the persisted data from memory
+        namespace
+            .mark_persisted(
+                &partition_info.table_name,
+                &partition_info.partition.partition_key,
+                iox_metadata.max_sequence_number,
+            )
+            .await;
+        debug!(
+            ?partition_id,
+            table_name=%partition_info.table_name,
+            partition_key=%partition_info.partition.partition_key,
+            max_sequence_number=%iox_metadata.max_sequence_number.get(),
+            "marked partition as persisted"
+        );
     }
 
     async fn update_min_unpersisted_sequence_number(
@@ -804,7 +813,7 @@ mod tests {
         // limits)
         assert!(!should_pause);
 
-        let partition_id = {
+        let (table_id, partition_id) = {
             let sd = data.shards.get(&shard1.id).unwrap();
             let n = sd.namespace("foo").unwrap();
             let mem_table = n.table_data("mem").unwrap();
@@ -813,10 +822,11 @@ mod tests {
             let p = mem_table
                 .get_partition_by_key(&"1970-01-01".into())
                 .unwrap();
-            p.partition_id()
+            (mem_table.table_id(), p.partition_id())
         };
 
-        data.persist(partition_id).await;
+        data.persist(shard1.id, namespace.id, table_id, partition_id)
+            .await;
 
         // verify that a file got put into object store
         let file_paths: Vec<_> = object_store
@@ -953,12 +963,13 @@ mod tests {
         {
             let mem_table = n.table_data("mem").unwrap();
             assert!(n.table_data("cpu").is_some());
+
             let mem_table = mem_table.write().await;
+            table_id = mem_table.table_id();
+
             let p = mem_table
                 .get_partition_by_key(&"1970-01-01".into())
                 .unwrap();
-
-            table_id = mem_table.table_id();
             partition_id = p.partition_id();
         }
         {
@@ -973,7 +984,8 @@ mod tests {
             assert!(partition_info.partition.sort_key.is_empty());
         }
 
-        data.persist(partition_id).await;
+        data.persist(shard1.id, namespace.id, table_id, partition_id)
+            .await;
 
         // verify that a file got put into object store
         let file_paths: Vec<_> = object_store

--- a/ingester/src/data/namespace.rs
+++ b/ingester/src/data/namespace.rs
@@ -39,7 +39,6 @@ impl DoubleRef {
         self.by_name.get(name).map(Arc::clone)
     }
 
-    #[cfg(test)]
     fn by_id(&self, id: TableId) -> Option<Arc<tokio::sync::RwLock<TableData>>> {
         self.by_id.get(&id).map(Arc::clone)
     }
@@ -240,6 +239,7 @@ impl NamespaceData {
     /// Snapshots the mutable buffer for the partition, which clears it out and then moves all
     /// snapshots over to a persisting batch, which is returned. If there is no data to snapshot
     /// or persist, None will be returned.
+    #[cfg(test)] // Only used in tests
     pub(crate) async fn snapshot_to_persisting(
         &self,
         table_name: &str,
@@ -266,7 +266,6 @@ impl NamespaceData {
     }
 
     /// Return the table data by ID.
-    #[cfg(test)]
     pub(crate) fn table_id(
         &self,
         table_id: TableId,

--- a/ingester/src/data/namespace.rs
+++ b/ingester/src/data/namespace.rs
@@ -1,11 +1,8 @@
 //! Namespace level data buffer structures.
 
-use std::{
-    collections::{btree_map::Entry, BTreeMap},
-    sync::Arc,
-};
+use std::{collections::HashMap, sync::Arc};
 
-use data_types::{NamespaceId, PartitionKey, SequenceNumber, ShardId};
+use data_types::{NamespaceId, PartitionKey, SequenceNumber, ShardId, TableId};
 use dml::DmlOperation;
 use iox_catalog::interface::Catalog;
 use iox_query::exec::Executor;
@@ -16,11 +13,37 @@ use write_summary::ShardProgress;
 
 #[cfg(test)]
 use super::triggers::TestTriggers;
-use super::{
-    partition::{resolver::PartitionProvider, PersistingBatch},
-    table::TableData,
-};
+use super::{partition::resolver::PartitionProvider, table::TableData};
 use crate::lifecycle::LifecycleHandle;
+
+/// A double-referenced map where [`TableData`] can be looked up by name, or ID.
+#[derive(Debug, Default)]
+struct DoubleRef {
+    // TODO(4880): this can be removed when IDs are sent over the wire.
+    by_name: HashMap<Arc<str>, Arc<tokio::sync::RwLock<TableData>>>,
+    by_id: HashMap<TableId, Arc<tokio::sync::RwLock<TableData>>>,
+}
+
+impl DoubleRef {
+    fn insert(&mut self, t: TableData) -> Arc<tokio::sync::RwLock<TableData>> {
+        let name = Arc::clone(t.table_name());
+        let id = t.table_id();
+
+        let t = Arc::new(tokio::sync::RwLock::new(t));
+        self.by_name.insert(name, Arc::clone(&t));
+        self.by_id.insert(id, Arc::clone(&t));
+        t
+    }
+
+    fn by_name(&self, name: &str) -> Option<Arc<tokio::sync::RwLock<TableData>>> {
+        self.by_name.get(name).map(Arc::clone)
+    }
+
+    #[cfg(test)]
+    fn by_id(&self, id: TableId) -> Option<Arc<tokio::sync::RwLock<TableData>>> {
+        self.by_id.get(&id).map(Arc::clone)
+    }
+}
 
 /// Data of a Namespace that belongs to a given Shard
 #[derive(Debug)]
@@ -30,7 +53,7 @@ pub(crate) struct NamespaceData {
     /// The catalog ID of the shard this namespace is being populated from.
     shard_id: ShardId,
 
-    tables: RwLock<BTreeMap<String, Arc<tokio::sync::RwLock<TableData>>>>,
+    tables: RwLock<DoubleRef>,
     table_count: U64Counter,
 
     /// The resolver of `(shard_id, table_id, partition_key)` to
@@ -198,7 +221,7 @@ impl NamespaceData {
         partition_key: &PartitionKey,
     ) -> Option<(
         Vec<Arc<super::partition::SnapshotBatch>>,
-        Option<Arc<PersistingBatch>>,
+        Option<Arc<super::partition::PersistingBatch>>,
     )> {
         if let Some(t) = self.table_data(table_name) {
             let mut t = t.write().await;
@@ -221,7 +244,7 @@ impl NamespaceData {
         &self,
         table_name: &str,
         partition_key: &PartitionKey,
-    ) -> Option<Arc<PersistingBatch>> {
+    ) -> Option<Arc<super::partition::PersistingBatch>> {
         if let Some(table_data) = self.table_data(table_name) {
             let mut table_data = table_data.write().await;
 
@@ -240,7 +263,17 @@ impl NamespaceData {
         table_name: &str,
     ) -> Option<Arc<tokio::sync::RwLock<TableData>>> {
         let t = self.tables.read();
-        t.get(table_name).cloned()
+        t.by_name(table_name)
+    }
+
+    /// Return the table data by ID.
+    #[cfg(test)]
+    pub(crate) fn table_id(
+        &self,
+        table_id: TableId,
+    ) -> Option<Arc<tokio::sync::RwLock<TableData>>> {
+        let t = self.tables.read();
+        t.by_id(table_id)
     }
 
     /// Inserts the table or returns it if it happens to be inserted by some other thread
@@ -259,23 +292,22 @@ impl NamespaceData {
 
         let mut t = self.tables.write();
 
-        let data = match t.entry(table_name.to_string()) {
-            Entry::Vacant(v) => {
-                let v = v.insert(Arc::new(tokio::sync::RwLock::new(TableData::new(
+        Ok(match t.by_name(table_name) {
+            Some(v) => v,
+            None => {
+                self.table_count.inc(1);
+
+                // Insert the table and then return a ref to it.
+                t.insert(TableData::new(
                     info.table_id,
                     table_name,
                     self.shard_id,
                     self.namespace_id,
                     info.tombstone_max_sequence_number,
                     Arc::clone(&self.partition_provider),
-                ))));
-                self.table_count.inc(1);
-                Arc::clone(v)
+                ))
             }
-            Entry::Occupied(v) => Arc::clone(v.get()),
-        };
-
-        Ok(data)
+        })
     }
 
     /// Walks down the table and partition and clears the persisting batch. The sequence number is
@@ -299,7 +331,7 @@ impl NamespaceData {
 
     /// Return progress from this Namespace
     pub(super) async fn progress(&self) -> ShardProgress {
-        let tables: Vec<_> = self.tables.read().values().map(Arc::clone).collect();
+        let tables: Vec<_> = self.tables.read().by_id.values().map(Arc::clone).collect();
 
         // Consolidate progtress across partitions.
         let mut progress = ShardProgress::new()
@@ -355,5 +387,86 @@ impl<'a> Drop for ScopedSequenceNumber<'a> {
             "multiple operations are being buffered concurrently"
         );
         *buffering_sequence_number = None;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use data_types::{PartitionId, ShardIndex};
+    use metric::{Attributes, Metric};
+
+    use crate::{
+        data::partition::{resolver::MockPartitionProvider, PartitionData},
+        lifecycle::mock_handle::MockLifecycleHandle,
+        test_util::{make_write_op, populate_catalog},
+    };
+
+    use super::*;
+
+    const SHARD_INDEX: ShardIndex = ShardIndex::new(24);
+    const TABLE_NAME: &str = "bananas";
+    const NAMESPACE_NAME: &str = "platanos";
+
+    #[tokio::test]
+    async fn test_namespace_double_ref() {
+        let metrics = Arc::new(metric::Registry::default());
+        let catalog: Arc<dyn Catalog> =
+            Arc::new(iox_catalog::mem::MemCatalog::new(Arc::clone(&metrics)));
+        let exec = Executor::new(1);
+
+        // Populate the catalog with the shard / namespace / table
+        let (shard_id, ns_id, table_id) =
+            populate_catalog(&*catalog, SHARD_INDEX, NAMESPACE_NAME, TABLE_NAME).await;
+
+        // Configure the mock partition provider to return a partition for this
+        // table ID.
+        let partition_provider = Arc::new(MockPartitionProvider::default().with_partition(
+            PartitionData::new(
+                PartitionId::new(0),
+                PartitionKey::from("banana-split"),
+                shard_id,
+                ns_id,
+                table_id,
+                TABLE_NAME.into(),
+                None,
+            ),
+        ));
+
+        let ns = NamespaceData::new(ns_id, shard_id, partition_provider, &*metrics);
+
+        // Assert the namespace does not contain the test data
+        assert!(ns.table_data(TABLE_NAME).is_none());
+        assert!(ns.table_id(table_id).is_none());
+
+        // Write some test data
+        ns.buffer_operation(
+            DmlOperation::Write(make_write_op(
+                &PartitionKey::from("banana-split"),
+                SHARD_INDEX,
+                NAMESPACE_NAME,
+                0,
+                r#"bananas,city=Medford day="sun",temp=55 22"#,
+            )),
+            &catalog,
+            &MockLifecycleHandle::default(),
+            &exec,
+        )
+        .await
+        .expect("buffer op should succeed");
+
+        // Both forms of referencing the table should succeed
+        assert!(ns.table_data(TABLE_NAME).is_some());
+        assert!(ns.table_id(table_id).is_some());
+
+        // And the table counter metric should increase
+        let tables = metrics
+            .get_instrument::<Metric<U64Counter>>("ingester_tables_total")
+            .expect("failed to read metric")
+            .get_observer(&Attributes::from([]))
+            .expect("failed to get observer")
+            .fetch();
+        assert_eq!(tables, 1);
     }
 }

--- a/ingester/src/data/namespace.rs
+++ b/ingester/src/data/namespace.rs
@@ -226,7 +226,7 @@ impl NamespaceData {
         if let Some(t) = self.table_data(table_name) {
             let mut t = t.write().await;
 
-            return t.partition_data.get_mut(partition_key).map(|p| {
+            return t.get_partition_by_key_mut(partition_key).map(|p| {
                 p.data
                     .generate_snapshot()
                     .expect("snapshot on mutable batch should never fail");
@@ -249,8 +249,7 @@ impl NamespaceData {
             let mut table_data = table_data.write().await;
 
             return table_data
-                .partition_data
-                .get_mut(partition_key)
+                .get_partition_by_key_mut(partition_key)
                 .and_then(|partition_data| partition_data.snapshot_to_persisting_batch());
         }
 
@@ -321,7 +320,7 @@ impl NamespaceData {
     ) {
         if let Some(t) = self.table_data(table_name) {
             let mut t = t.write().await;
-            let partition = t.partition_data.get_mut(partition_key);
+            let partition = t.get_partition_by_key_mut(partition_key);
 
             if let Some(p) = partition {
                 p.mark_persisted(sequence_number);

--- a/ingester/src/data/partition.rs
+++ b/ingester/src/data/partition.rs
@@ -302,7 +302,7 @@ impl PartitionData {
         self.data.progress()
     }
 
-    pub(super) fn id(&self) -> PartitionId {
+    pub(super) fn partition_id(&self) -> PartitionId {
         self.id
     }
 

--- a/ingester/src/data/partition/resolver/cache.rs
+++ b/ingester/src/data/partition/resolver/cache.rs
@@ -221,7 +221,7 @@ mod tests {
             )
             .await;
 
-        assert_eq!(got.id(), PARTITION_ID);
+        assert_eq!(got.partition_id(), PARTITION_ID);
         assert_eq!(got.shard_id(), SHARD_ID);
         assert_eq!(got.table_id(), TABLE_ID);
         assert_eq!(got.table_name(), TABLE_NAME);
@@ -255,7 +255,7 @@ mod tests {
             )
             .await;
 
-        assert_eq!(got.id(), PARTITION_ID);
+        assert_eq!(got.partition_id(), PARTITION_ID);
         assert_eq!(got.shard_id(), SHARD_ID);
         assert_eq!(got.table_id(), TABLE_ID);
         assert_eq!(got.table_name(), TABLE_NAME);
@@ -307,7 +307,7 @@ mod tests {
             )
             .await;
 
-        assert_eq!(got.id(), other_key_id);
+        assert_eq!(got.partition_id(), other_key_id);
         assert_eq!(got.shard_id(), SHARD_ID);
         assert_eq!(got.table_id(), TABLE_ID);
         assert_eq!(got.table_name(), TABLE_NAME);
@@ -346,7 +346,7 @@ mod tests {
             )
             .await;
 
-        assert_eq!(got.id(), PARTITION_ID);
+        assert_eq!(got.partition_id(), PARTITION_ID);
         assert_eq!(got.shard_id(), SHARD_ID);
         assert_eq!(got.table_id(), other_table);
         assert_eq!(got.table_name(), TABLE_NAME);
@@ -385,7 +385,7 @@ mod tests {
             )
             .await;
 
-        assert_eq!(got.id(), PARTITION_ID);
+        assert_eq!(got.partition_id(), PARTITION_ID);
         assert_eq!(got.shard_id(), other_shard);
         assert_eq!(got.table_id(), TABLE_ID);
         assert_eq!(got.table_name(), TABLE_NAME);

--- a/ingester/src/data/partition/resolver/trait.rs
+++ b/ingester/src/data/partition/resolver/trait.rs
@@ -82,7 +82,7 @@ mod tests {
                 Arc::clone(&table_name),
             )
             .await;
-        assert_eq!(got.id(), partition);
+        assert_eq!(got.partition_id(), partition);
         assert_eq!(got.namespace_id(), namespace_id);
         assert_eq!(*got.table_name(), *table_name);
     }

--- a/ingester/src/data/shard.rs
+++ b/ingester/src/data/shard.rs
@@ -37,6 +37,7 @@ impl DoubleRef {
         self.by_name.get(name).map(Arc::clone)
     }
 
+    #[cfg(test)]
     fn by_id(&self, id: NamespaceId) -> Option<Arc<NamespaceData>> {
         self.by_id.get(&id).map(Arc::clone)
     }
@@ -119,6 +120,7 @@ impl ShardData {
     }
 
     /// Gets the namespace data out of the map
+    #[cfg(test)]
     pub(crate) fn namespace_by_id(&self, namespace_id: NamespaceId) -> Option<Arc<NamespaceData>> {
         // TODO: this should be the default once IDs are pushed over the wire.
         //

--- a/ingester/src/data/shard.rs
+++ b/ingester/src/data/shard.rs
@@ -37,7 +37,6 @@ impl DoubleRef {
         self.by_name.get(name).map(Arc::clone)
     }
 
-    #[cfg(test)]
     fn by_id(&self, id: NamespaceId) -> Option<Arc<NamespaceData>> {
         self.by_id.get(&id).map(Arc::clone)
     }
@@ -120,7 +119,6 @@ impl ShardData {
     }
 
     /// Gets the namespace data out of the map
-    #[cfg(test)]
     pub(crate) fn namespace_by_id(&self, namespace_id: NamespaceId) -> Option<Arc<NamespaceData>> {
         // TODO: this should be the default once IDs are pushed over the wire.
         //

--- a/ingester/src/data/table.rs
+++ b/ingester/src/data/table.rs
@@ -210,9 +210,14 @@ impl TableData {
             })
     }
 
-    #[cfg(test)]
+    /// Returns the table ID for this partition.
     pub(super) fn table_id(&self) -> TableId {
         self.table_id
+    }
+
+    /// Returns the name of this table.
+    pub(crate) fn table_name(&self) -> &Arc<str> {
+        &self.table_name
     }
 }
 

--- a/ingester/src/data/table.rs
+++ b/ingester/src/data/table.rs
@@ -131,7 +131,7 @@ impl TableData {
         // op may fail which would lead to a write being recorded, but not
         // applied.
         let should_pause = lifecycle_handle.log_write(
-            partition_data.id(),
+            partition_data.partition_id(),
             self.shard_id,
             self.namespace_id,
             self.table_id,
@@ -182,7 +182,7 @@ impl TableData {
         self.partition_data
             .values()
             .map(|p| UnpersistedPartitionData {
-                partition_id: p.id(),
+                partition_id: p.partition_id(),
                 non_persisted: p
                     .get_non_persisting_data()
                     .expect("get_non_persisting should always work"),


### PR DESCRIPTION
This PR accomplishes two things:

* Makes all the ID lookup queries at `persist()` time redundant, with the exception of acquiring the `SortKey`. In a follow-up PR I will remove this requirement and significantly reduce the query load at persist time (part of #5767).

* Changes the buffer tree nodes (shards -> namespaces -> tables -> partitions) to support being addressed by ID, in addition to string names. This enables the above, but is also in preparation for #4880.

There will be a slight memory overhead for maintaining the additional ID indexes, but I've been careful to minimise the amount of memory these will use (through use of existing Arc's, storing ref-counted keys and making two lookups in the cold ID path, etc).

This also documents a TOCTOU bug tracking the memory usage of partitions, and releasing that memory back during persist ops: https://github.com/influxdata/influxdb_iox/issues/5777. The effect of this bug is the usable amount of buffer memory **decreases over time** so is not likely to be a contributor to OOMs.

---

* refactor: ref TableData by name & ID (9c0e4e98c)

      Changes the NamespaceData to hold a map of table name -> TableData, and table
      ID -> TableData simultaneously.

      This allows for cheap lookups when the caller holds an ID, and is part of
      preparatory work to transition away from using string names in the ingester
      for tables.

      This commit also switches from a BTreeMap to a HashMap as the backing 
      collection, as maintaining key ordering doesn't appear to be necessary.

* refactor: ref NamespaceData by name & ID (66e05b5ea)

      Changes the ShardData to hold a map of namespace name -> NamespaceData, and
      namespace ID -> NamespaceData simultaneously.

      This allows for cheap lookups when the caller holds an ID, and is part of
      preparatory work to transition away from using string names in the ingester
      for tables.

      This commit also switches from a BTreeMap to a HashMap as the backing 
      collection, as maintaining key ordering doesn't appear to be necessary.

* refactor: PartitionData::id() -> partition_id() (0847cc545)

      Consistent naming is consistent - all the others are thing_id().

* refactor: ref PartitionData by key & ID (f9bf86927)

      Changes the TableData to hold a map of partition key -> PartitionData, and
      partition ID -> PartitionData simultaneously. This allows for cheap lookups
      when the caller holds an ID.

      This commit also manages to internalise the partition map within the TableData
      - one less pub / peeking!

      This commit also switches from a BTreeMap to a HashMap as the backing 
      collection, as maintaining key ordering doesn't appear to be necessary.

* refactor: persist() passes all necessary IDs (1a7eb47b8)

      This commit changes the persist() call so that it passes through all relevant
      IDs so that the impl can locate the partition in the buffer tree - this will
      enable elimination of many queries against the catalog in the future.

      This commit also cleans up the persist() impl, deferring queries until the
      result will be used to avoid unnecessary load, improves logging & error
      handling, and documents a TOCTOU bug in code:

          https://github.com/influxdata/influxdb_iox/issues/5777