### PR TITLE
refactor: carry namespace name in NamespaceData

### DIFF
--- a/ingester/src/data.rs
+++ b/ingester/src/data.rs
@@ -815,7 +815,7 @@ mod tests {
 
         let (table_id, partition_id) = {
             let sd = data.shards.get(&shard1.id).unwrap();
-            let n = sd.namespace("foo").unwrap();
+            let n = sd.namespace(&"foo".into()).unwrap();
             let mem_table = n.table_data("mem").unwrap();
             assert!(n.table_data("mem").is_some());
             let mem_table = mem_table.write().await;
@@ -957,7 +957,7 @@ mod tests {
         assert_progress(&data, shard_index, expected_progress).await;
 
         let sd = data.shards.get(&shard1.id).unwrap();
-        let n = sd.namespace("foo").unwrap();
+        let n = sd.namespace(&"foo".into()).unwrap();
         let partition_id;
         let table_id;
         {
@@ -1193,7 +1193,7 @@ mod tests {
 
         // Get the namespace
         let sd = data.shards.get(&shard1.id).unwrap();
-        let n = sd.namespace("foo").unwrap();
+        let n = sd.namespace(&"foo".into()).unwrap();
 
         let expected_progress = ShardProgress::new().with_buffered(SequenceNumber::new(1));
         assert_progress(&data, shard_index, expected_progress).await;
@@ -1356,7 +1356,13 @@ mod tests {
 
         let partition_provider = Arc::new(CatalogPartitionResolver::new(Arc::clone(&catalog)));
 
-        let data = NamespaceData::new(namespace.id, shard.id, partition_provider, &*metrics);
+        let data = NamespaceData::new(
+            namespace.id,
+            "foo".into(),
+            shard.id,
+            partition_provider,
+            &*metrics,
+        );
 
         // w1 should be ignored because the per-partition replay offset is set
         // to 1 already, so it shouldn't be buffered and the buffer should
@@ -1473,7 +1479,7 @@ mod tests {
         assert_eq!(
             data.shard(shard1.id)
                 .unwrap()
-                .namespace(&namespace.name)
+                .namespace(&namespace.name.clone().into())
                 .unwrap()
                 .table_data("mem")
                 .unwrap()
@@ -1505,7 +1511,7 @@ mod tests {
         assert_eq!(
             data.shard(shard1.id)
                 .unwrap()
-                .namespace(&namespace.name)
+                .namespace(&namespace.name.into())
                 .unwrap()
                 .table_data("mem")
                 .unwrap()

--- a/ingester/src/handler.rs
+++ b/ingester/src/handler.rs
@@ -499,11 +499,12 @@ mod tests {
         // give the writes some time to go through the buffer. Exit once we've verified there's
         // data in there from both writes.
         tokio::time::timeout(Duration::from_secs(2), async {
+            let ns_name = ingester.namespace.name.into();
             loop {
                 let mut has_measurement = false;
 
                 if let Some(data) = ingester.ingester.data.shard(ingester.shard.id) {
-                    if let Some(data) = data.namespace(&ingester.namespace.name) {
+                    if let Some(data) = data.namespace(&ns_name) {
                         // verify there's data in the buffer
                         if let Some((b, _)) = data.snapshot("a", &"1970-01-01".into()).await {
                             if let Some(b) = b.first() {
@@ -740,11 +741,12 @@ mod tests {
         // give the writes some time to go through the buffer. Exit once we've verified there's
         // data in there
         tokio::time::timeout(Duration::from_secs(1), async move {
+            let ns_name = namespace.name.into();
             loop {
                 let mut has_measurement = false;
 
                 if let Some(data) = ingester.data.shard(shard.id) {
-                    if let Some(data) = data.namespace(&namespace.name) {
+                    if let Some(data) = data.namespace(&ns_name) {
                         // verify there's data in the buffer
                         if let Some((b, _)) = data.snapshot("cpu", &"1970-01-01".into()).await {
                             if let Some(b) = b.first() {

--- a/ingester/src/querier_handler.rs
+++ b/ingester/src/querier_handler.rs
@@ -12,8 +12,8 @@ use snafu::{ensure, Snafu};
 
 use crate::{
     data::{
-        partition::UnpersistedPartitionData, IngesterData, IngesterQueryPartition,
-        IngesterQueryResponse,
+        namespace::NamespaceName, partition::UnpersistedPartitionData, IngesterData,
+        IngesterQueryPartition, IngesterQueryResponse,
     },
     query::QueryableBatch,
 };
@@ -57,7 +57,8 @@ pub async fn prepare_data_to_querier(
     let mut found_namespace = false;
     for (shard_id, shard_data) in ingest_data.shards() {
         debug!(shard_id=%shard_id.get());
-        let namespace_data = match shard_data.namespace(&request.namespace) {
+        let namespace_name = NamespaceName::from(&request.namespace);
+        let namespace_data = match shard_data.namespace(&namespace_name) {
             Some(namespace_data) => {
                 debug!(namespace=%request.namespace, "found namespace");
                 found_namespace = true;

--- a/ingester/src/test_util.rs
+++ b/ingester/src/test_util.rs
@@ -655,7 +655,7 @@ pub(crate) async fn make_ingester_data(two_partitions: bool, loc: DataLocation) 
         let _ignored = ingester
             .shard(shard_id)
             .unwrap()
-            .namespace(TEST_NAMESPACE)
+            .namespace(&TEST_NAMESPACE.into())
             .unwrap()
             .snapshot_to_persisting(TEST_TABLE, &PartitionKey::from(TEST_PARTITION_1))
             .await;
@@ -664,7 +664,7 @@ pub(crate) async fn make_ingester_data(two_partitions: bool, loc: DataLocation) 
         let _ignored = ingester
             .shard(shard_id)
             .unwrap()
-            .namespace(TEST_NAMESPACE)
+            .namespace(&TEST_NAMESPACE.into())
             .unwrap()
             .snapshot(TEST_TABLE, &PartitionKey::from(TEST_PARTITION_1))
             .await;
@@ -824,7 +824,7 @@ async fn make_one_partition_with_tombstones(
         let _ignored = ingester
             .shard(shard_id)
             .unwrap()
-            .namespace(TEST_NAMESPACE)
+            .namespace(&TEST_NAMESPACE.into())
             .unwrap()
             .snapshot_to_persisting(TEST_TABLE, &PartitionKey::from(TEST_PARTITION_1))
             .await;
@@ -833,7 +833,7 @@ async fn make_one_partition_with_tombstones(
         let _ignored = ingester
             .shard(shard_id)
             .unwrap()
-            .namespace(TEST_NAMESPACE)
+            .namespace(&TEST_NAMESPACE.into())
             .unwrap()
             .snapshot(TEST_TABLE, &PartitionKey::from(TEST_PARTITION_1))
             .await;


### PR DESCRIPTION
This PR embeds the name of the namespace in the `NamespaceData`, using a ref-counted type wrapper (`NamespaceName`) for type safety (aka getting the compiler to do the work for me).

---

* refactor: carry namespace name in NamespaceData (abb9122e2)

      Changes the ingester's NamespaceData to carry a ref-counted string
      identifier as well as the ID.
      
      The backing storage for the name in NamespaceData is shared with the
      index map in ShardData, so it is effectively free!

