### PR TITLE
refactor: use TableName, not Arc<str>

### DIFF
--- a/ingester/src/data/partition.rs
+++ b/ingester/src/data/partition.rs
@@ -19,6 +19,8 @@ use self::{
 };
 use crate::{data::query_dedup::query, query::QueryableBatch};
 
+use super::table::TableName;
+
 mod buffer;
 pub mod resolver;
 
@@ -180,7 +182,7 @@ pub struct PartitionData {
     namespace_id: NamespaceId,
     table_id: TableId,
     /// The name of the table this partition is part of.
-    table_name: Arc<str>,
+    table_name: TableName,
 
     pub(super) data: DataBuffer,
 
@@ -198,7 +200,7 @@ impl PartitionData {
         shard_id: ShardId,
         namespace_id: NamespaceId,
         table_id: TableId,
-        table_name: Arc<str>,
+        table_name: TableName,
         sort_key: SortKeyState,
         max_persisted_sequence_number: Option<SequenceNumber>,
     ) -> Self {

--- a/ingester/src/data/partition/buffer.rs
+++ b/ingester/src/data/partition/buffer.rs
@@ -9,6 +9,8 @@ use snafu::ResultExt;
 use uuid::Uuid;
 use write_summary::ShardProgress;
 
+use crate::data::table::TableName;
+
 use super::{PersistingBatch, QueryableBatch, SnapshotBatch};
 
 /// Data of an IOx partition split into batches
@@ -109,7 +111,7 @@ impl DataBuffer {
     /// Both buffer and snapshots will be empty after this
     pub(super) fn snapshot_to_queryable_batch(
         &mut self,
-        table_name: &Arc<str>,
+        table_name: &TableName,
         partition_id: PartitionId,
         tombstone: Option<Tombstone>,
     ) -> Option<QueryableBatch> {
@@ -129,7 +131,7 @@ impl DataBuffer {
             None
         } else {
             Some(QueryableBatch::new(
-                Arc::clone(table_name),
+                table_name.clone(),
                 partition_id,
                 data,
                 tombstones,
@@ -164,7 +166,7 @@ impl DataBuffer {
         shard_id: ShardId,
         table_id: TableId,
         partition_id: PartitionId,
-        table_name: &Arc<str>,
+        table_name: &TableName,
     ) -> Option<Arc<PersistingBatch>> {
         if self.persisting.is_some() {
             panic!("Unable to snapshot while persisting. This is an unexpected state.")

--- a/ingester/src/data/partition/resolver/cache.rs
+++ b/ingester/src/data/partition/resolver/cache.rs
@@ -9,7 +9,10 @@ use iox_catalog::interface::Catalog;
 use observability_deps::tracing::debug;
 use parking_lot::Mutex;
 
-use crate::data::partition::{resolver::DeferredSortKey, PartitionData, SortKeyState};
+use crate::data::{
+    partition::{resolver::DeferredSortKey, PartitionData, SortKeyState},
+    table::TableName,
+};
 
 use super::r#trait::PartitionProvider;
 
@@ -189,7 +192,7 @@ where
         shard_id: ShardId,
         namespace_id: NamespaceId,
         table_id: TableId,
-        table_name: Arc<str>,
+        table_name: TableName,
     ) -> PartitionData {
         // Use the cached PartitionKey instead of the caller's partition_key,
         // instead preferring to reuse the already-shared Arc<str> in the cache.

--- a/ingester/src/data/partition/resolver/catalog.rs
+++ b/ingester/src/data/partition/resolver/catalog.rs
@@ -9,7 +9,10 @@ use data_types::{NamespaceId, Partition, PartitionKey, ShardId, TableId};
 use iox_catalog::interface::Catalog;
 use observability_deps::tracing::debug;
 
-use crate::data::partition::{PartitionData, SortKeyState};
+use crate::data::{
+    partition::{PartitionData, SortKeyState},
+    table::TableName,
+};
 
 use super::r#trait::PartitionProvider;
 
@@ -55,7 +58,7 @@ impl PartitionProvider for CatalogPartitionResolver {
         shard_id: ShardId,
         namespace_id: NamespaceId,
         table_id: TableId,
-        table_name: Arc<str>,
+        table_name: TableName,
     ) -> PartitionData {
         debug!(
             %partition_key,
@@ -132,7 +135,7 @@ mod tests {
         };
 
         let callers_partition_key = PartitionKey::from(PARTITION_KEY);
-        let table_name = TABLE_NAME.into();
+        let table_name = TableName::from(TABLE_NAME);
         let resolver = CatalogPartitionResolver::new(Arc::clone(&catalog));
         let got = resolver
             .get_partition(
@@ -140,7 +143,7 @@ mod tests {
                 shard_id,
                 namespace_id,
                 table_id,
-                Arc::clone(&table_name),
+                table_name.clone(),
             )
             .await;
         assert_eq!(got.namespace_id(), namespace_id);

--- a/ingester/src/data/partition/resolver/mock.rs
+++ b/ingester/src/data/partition/resolver/mock.rs
@@ -1,12 +1,12 @@
 //! A mock [`PartitionProvider`] to inject [`PartitionData`] for tests.
 
-use std::{collections::HashMap, sync::Arc};
+use std::collections::HashMap;
 
 use async_trait::async_trait;
 use data_types::{NamespaceId, PartitionKey, ShardId, TableId};
 use parking_lot::Mutex;
 
-use crate::data::partition::PartitionData;
+use crate::data::{partition::PartitionData, table::TableName};
 
 use super::r#trait::PartitionProvider;
 
@@ -58,7 +58,7 @@ impl PartitionProvider for MockPartitionProvider {
         shard_id: ShardId,
         namespace_id: NamespaceId,
         table_id: TableId,
-        table_name: Arc<str>,
+        table_name: TableName,
     ) -> PartitionData {
         let p = self
             .partitions

--- a/ingester/src/data/partition/resolver/trait.rs
+++ b/ingester/src/data/partition/resolver/trait.rs
@@ -3,7 +3,7 @@ use std::{fmt::Debug, sync::Arc};
 use async_trait::async_trait;
 use data_types::{NamespaceId, PartitionKey, ShardId, TableId};
 
-use crate::data::partition::PartitionData;
+use crate::data::{partition::PartitionData, table::TableName};
 
 /// An infallible resolver of [`PartitionData`] for the specified shard, table,
 /// and partition key, returning an initialised [`PartitionData`] buffer for it.
@@ -20,7 +20,7 @@ pub trait PartitionProvider: Send + Sync + Debug {
         shard_id: ShardId,
         namespace_id: NamespaceId,
         table_id: TableId,
-        table_name: Arc<str>,
+        table_name: TableName,
     ) -> PartitionData;
 }
 
@@ -35,7 +35,7 @@ where
         shard_id: ShardId,
         namespace_id: NamespaceId,
         table_id: TableId,
-        table_name: Arc<str>,
+        table_name: TableName,
     ) -> PartitionData {
         (**self)
             .get_partition(partition_key, shard_id, namespace_id, table_id, table_name)
@@ -59,7 +59,7 @@ mod tests {
         let shard_id = ShardId::new(42);
         let namespace_id = NamespaceId::new(1234);
         let table_id = TableId::new(24);
-        let table_name = "platanos".into();
+        let table_name = TableName::from("platanos");
         let partition = PartitionId::new(4242);
         let data = PartitionData::new(
             partition,
@@ -67,7 +67,7 @@ mod tests {
             shard_id,
             namespace_id,
             table_id,
-            Arc::clone(&table_name),
+            table_name.clone(),
             SortKeyState::Provided(None),
             None,
         );
@@ -75,13 +75,7 @@ mod tests {
         let mock = Arc::new(MockPartitionProvider::default().with_partition(data));
 
         let got = mock
-            .get_partition(
-                key,
-                shard_id,
-                namespace_id,
-                table_id,
-                Arc::clone(&table_name),
-            )
+            .get_partition(key, shard_id, namespace_id, table_id, table_name.clone())
             .await;
         assert_eq!(got.partition_id(), partition);
         assert_eq!(got.namespace_id(), namespace_id);

--- a/ingester/src/handler.rs
+++ b/ingester/src/handler.rs
@@ -445,7 +445,7 @@ mod tests {
     use write_buffer::mock::{MockBufferForReading, MockBufferSharedState};
 
     use super::*;
-    use crate::data::partition::SnapshotBatch;
+    use crate::data::{partition::SnapshotBatch, table::TableName};
 
     #[tokio::test]
     async fn read_from_write_buffer_write_to_mutable_buffer() {
@@ -513,13 +513,15 @@ mod tests {
         // data in there from both writes.
         tokio::time::timeout(Duration::from_secs(2), async {
             let ns_name = ingester.namespace.name.into();
+            let table_name = TableName::from("a");
             loop {
                 let mut has_measurement = false;
 
                 if let Some(data) = ingester.ingester.data.shard(ingester.shard.id) {
                     if let Some(data) = data.namespace(&ns_name) {
                         // verify there's data in the buffer
-                        if let Some((b, _)) = data.snapshot("a", &"1970-01-01".into()).await {
+                        if let Some((b, _)) = data.snapshot(&table_name, &"1970-01-01".into()).await
+                        {
                             if let Some(b) = b.first() {
                                 if b.data.num_rows() > 0 {
                                     has_measurement = true;
@@ -755,13 +757,15 @@ mod tests {
         // data in there
         tokio::time::timeout(Duration::from_secs(1), async move {
             let ns_name = namespace.name.into();
+            let table_name = TableName::from("cpu");
             loop {
                 let mut has_measurement = false;
 
                 if let Some(data) = ingester.data.shard(shard.id) {
                     if let Some(data) = data.namespace(&ns_name) {
                         // verify there's data in the buffer
-                        if let Some((b, _)) = data.snapshot("cpu", &"1970-01-01".into()).await {
+                        if let Some((b, _)) = data.snapshot(&table_name, &"1970-01-01".into()).await
+                        {
                             if let Some(b) = b.first() {
                                 custom_batch_verification(b);
 

--- a/ingester/src/querier_handler.rs
+++ b/ingester/src/querier_handler.rs
@@ -12,8 +12,8 @@ use snafu::{ensure, Snafu};
 
 use crate::{
     data::{
-        namespace::NamespaceName, partition::UnpersistedPartitionData, IngesterData,
-        IngesterQueryPartition, IngesterQueryResponse,
+        namespace::NamespaceName, partition::UnpersistedPartitionData, table::TableName,
+        IngesterData, IngesterQueryPartition, IngesterQueryResponse,
     },
     query::QueryableBatch,
 };
@@ -69,7 +69,8 @@ pub async fn prepare_data_to_querier(
             }
         };
 
-        let table_data = match namespace_data.table_data(&request.table) {
+        let table_name = TableName::from(&request.table);
+        let table_data = match namespace_data.table_data(&table_name) {
             Some(table_data) => {
                 debug!(table_name=%request.table, "found table");
                 table_data

--- a/ingester/src/query.rs
+++ b/ingester/src/query.rs
@@ -28,7 +28,7 @@ use predicate::{
 use schema::{merge::merge_record_batch_schemas, selection::Selection, sort::SortKey, Schema};
 use snafu::{ResultExt, Snafu};
 
-use crate::data::partition::SnapshotBatch;
+use crate::data::{partition::SnapshotBatch, table::TableName};
 
 #[allow(clippy::enum_variant_names)]
 #[derive(Debug, Snafu)]
@@ -60,7 +60,7 @@ pub(crate) struct QueryableBatch {
     pub(crate) delete_predicates: Vec<Arc<DeletePredicate>>,
 
     /// This is needed to return a reference for a trait function
-    pub(crate) table_name: Arc<str>,
+    pub(crate) table_name: TableName,
 
     /// Partition ID
     pub(crate) partition_id: PartitionId,
@@ -69,7 +69,7 @@ pub(crate) struct QueryableBatch {
 impl QueryableBatch {
     /// Initilaize a QueryableBatch
     pub(crate) fn new(
-        table_name: Arc<str>,
+        table_name: TableName,
         partition_id: PartitionId,
         data: Vec<Arc<SnapshotBatch>>,
         deletes: Vec<Tombstone>,

--- a/ingester/src/test_util.rs
+++ b/ingester/src/test_util.rs
@@ -657,7 +657,7 @@ pub(crate) async fn make_ingester_data(two_partitions: bool, loc: DataLocation) 
             .unwrap()
             .namespace(&TEST_NAMESPACE.into())
             .unwrap()
-            .snapshot_to_persisting(TEST_TABLE, &PartitionKey::from(TEST_PARTITION_1))
+            .snapshot_to_persisting(&TEST_TABLE.into(), &PartitionKey::from(TEST_PARTITION_1))
             .await;
     } else if loc.contains(DataLocation::SNAPSHOT) {
         // move partition 1 data to snapshot
@@ -666,7 +666,7 @@ pub(crate) async fn make_ingester_data(two_partitions: bool, loc: DataLocation) 
             .unwrap()
             .namespace(&TEST_NAMESPACE.into())
             .unwrap()
-            .snapshot(TEST_TABLE, &PartitionKey::from(TEST_PARTITION_1))
+            .snapshot(&TEST_TABLE.into(), &PartitionKey::from(TEST_PARTITION_1))
             .await;
     }
 
@@ -826,7 +826,7 @@ async fn make_one_partition_with_tombstones(
             .unwrap()
             .namespace(&TEST_NAMESPACE.into())
             .unwrap()
-            .snapshot_to_persisting(TEST_TABLE, &PartitionKey::from(TEST_PARTITION_1))
+            .snapshot_to_persisting(&TEST_TABLE.into(), &PartitionKey::from(TEST_PARTITION_1))
             .await;
     } else if loc.contains(DataLocation::SNAPSHOT) {
         // move partition 1 data to snapshot
@@ -835,7 +835,7 @@ async fn make_one_partition_with_tombstones(
             .unwrap()
             .namespace(&TEST_NAMESPACE.into())
             .unwrap()
-            .snapshot(TEST_TABLE, &PartitionKey::from(TEST_PARTITION_1))
+            .snapshot(&TEST_TABLE.into(), &PartitionKey::from(TEST_PARTITION_1))
             .await;
     }
 


### PR DESCRIPTION
A quick dev life change - use a typed table name, rather than passing around a string.

This reflects the `NamespaceName` equivalent.

---

* refactor: use TableName, not Arc<str> (97c6e0f8c)

      Adds a type wrapper TableName, internally an Arc<str> to leverage the
      type system instead of passing around untyped strings.