### PR TITLE
test: Add verification that aspects of L1 -> L2 compaction are working as expected

### DIFF
--- a/compactor/src/cold.rs
+++ b/compactor/src/cold.rs
@@ -910,7 +910,7 @@ mod tests {
         let mut config = make_compactor_config();
 
         // Set the memory budget such that only one of the files will be compacted in a group
-        config.memory_budget_bytes = 4600;
+        config.memory_budget_bytes = 4_900;
 
         let metrics = Arc::new(metric::Registry::new());
         let compactor = Arc::new(Compactor::new(
@@ -1015,7 +1015,7 @@ mod tests {
         let mut config = make_compactor_config();
 
         // Set the memory budget such that two of the files will be compacted in a group
-        config.memory_budget_bytes = 9_200;
+        config.memory_budget_bytes = 9_800;
 
         let metrics = Arc::new(metric::Registry::new());
         let compactor = Arc::new(Compactor::new(

--- a/compactor/src/cold.rs
+++ b/compactor/src/cold.rs
@@ -876,6 +876,107 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn one_level_1_file_takes_up_memory_budget_gets_upgraded() {
+        test_helpers::maybe_start_logging();
+
+        let catalog = TestCatalog::new();
+
+        // lp1 will be level 1 with min time 26000, no overlaps
+        let lp1 = vec![
+            "table,tag2=WA,tag3=10 field_int=1600i 28000",
+            "table,tag2=VT,tag3=20 field_int=20i 26000",
+        ]
+        .join("\n");
+
+        // lp2 will be level 1 with min time 90000, no overlaps
+        let lp2 = vec![
+            "table,tag2=PA,tag3=15 field_int=81601i 90000",
+            "table,tag2=OH,tag3=21 field_int=421i 91000",
+        ]
+        .join("\n");
+
+        let ns = catalog.create_namespace("ns").await;
+        let shard = ns.create_shard(1).await;
+        let table = ns.create_table("table").await;
+        table.create_column("field_int", ColumnType::I64).await;
+        table.create_column("tag1", ColumnType::Tag).await;
+        table.create_column("tag2", ColumnType::Tag).await;
+        table.create_column("tag3", ColumnType::Tag).await;
+        table.create_column("time", ColumnType::Time).await;
+
+        let partition = table.with_shard(&shard).create_partition("part").await;
+        let time = Arc::new(SystemProvider::new());
+        let time_38_hour_ago = time.hours_ago(38);
+        let mut config = make_compactor_config();
+
+        // Set the memory budget such that only one of the files will be compacted in a group
+        config.memory_budget_bytes = 4600;
+
+        let metrics = Arc::new(metric::Registry::new());
+        let compactor = Arc::new(Compactor::new(
+            vec![shard.shard.id],
+            Arc::clone(&catalog.catalog),
+            ParquetStorage::new(Arc::clone(&catalog.object_store)),
+            Arc::new(Executor::new(1)),
+            Arc::new(SystemProvider::new()),
+            BackoffConfig::default(),
+            config,
+            Arc::clone(&metrics),
+        ));
+
+        // pf1, L1
+        let builder = TestParquetFileBuilder::default()
+            .with_line_protocol(&lp1)
+            .with_max_seq(1)
+            .with_min_time(26_000)
+            .with_max_time(28_000)
+            .with_creation_time(time_38_hour_ago)
+            .with_compaction_level(CompactionLevel::FileNonOverlapped);
+        // pf1 file size: 2183, estimated file bytes: 4590
+        let pf1 = partition.create_parquet_file(builder).await;
+        println!("=== pf1 file size: {:#?}", pf1.parquet_file.file_size_bytes);
+
+        // pf2, L1
+        let builder = TestParquetFileBuilder::default()
+            .with_line_protocol(&lp2)
+            .with_max_seq(20)
+            .with_min_time(90000)
+            .with_max_time(91000)
+            .with_creation_time(time_38_hour_ago)
+            .with_compaction_level(CompactionLevel::FileNonOverlapped);
+        // pf2 file size: 2183
+        let pf2 = partition.create_parquet_file(builder).await;
+        println!("=== pf2 file size: {:#?}", pf2.parquet_file.file_size_bytes);
+
+        // ------------------------------------------------
+        // Compact
+
+        // The first time through, the first file will get upgraded by itself because only the
+        // one file will fit in the memory budget.
+        compact(Arc::clone(&compactor), true).await;
+        // Then when the partition is selected for compaction again, the second file will get
+        // upgraded by itself.
+        compact(compactor, true).await;
+
+        let files = catalog.list_by_table_not_to_delete(table.table.id).await;
+        assert_eq!(files.len(), 2, "{files:?}");
+        let files_and_levels: Vec<_> = files
+            .iter()
+            .map(|f| (f.id.get(), f.compaction_level))
+            .collect();
+
+        // Both files get upgraded from level 1 to level 2 without actually doing compaction,
+        // so their IDs stay the same.
+        assert_eq!(
+            files_and_levels,
+            vec![
+                (1, CompactionLevel::Final),
+                (2, CompactionLevel::Final),
+            ]
+        );
+    }
+
+    #[tokio::test]
     async fn full_cold_compaction_new_level_1_overlapping_with_level_2() {
         test_helpers::maybe_start_logging();
 


### PR DESCRIPTION
Connects to https://github.com/influxdata/influxdb_iox/issues/5836.

@NGA-TRAN as far as I can tell, the code is already doing the two items listed in #5836: 

1. If there is only one L1 file in a group because by itself it takes up the memory budget, upgrade its level to L2 without running compaction
2. Limit the L1 files chosen as input to a compaction round if their memory budget is greater than the limit

I've added tests to verify these, am I missing something or misunderstanding the issue description?
