### PR TITLE
perf(ingester): cheapen table lookup

### DIFF
--- a/iox_catalog/src/mem.rs
+++ b/iox_catalog/src/mem.rs
@@ -5,8 +5,8 @@ use crate::{
     interface::{
         sealed::TransactionFinalize, Catalog, ColumnRepo, ColumnTypeMismatchSnafu,
         ColumnUpsertRequest, Error, NamespaceRepo, ParquetFileRepo, PartitionRepo,
-        ProcessedTombstoneRepo, QueryPoolRepo, RepoCollection, Result, ShardRepo, TablePersistInfo,
-        TableRepo, TombstoneRepo, TopicMetadataRepo, Transaction,
+        ProcessedTombstoneRepo, QueryPoolRepo, RepoCollection, Result, ShardRepo, TableRepo,
+        TombstoneRepo, TopicMetadataRepo, Transaction,
     },
     metrics::MetricDecorator,
 };
@@ -442,36 +442,6 @@ impl TableRepo for MemTxn {
     async fn list(&mut self) -> Result<Vec<Table>> {
         let stage = self.stage();
         Ok(stage.tables.clone())
-    }
-
-    async fn get_table_persist_info(
-        &mut self,
-        shard_id: ShardId,
-        namespace_id: NamespaceId,
-        table_name: &str,
-    ) -> Result<Option<TablePersistInfo>> {
-        let stage = self.stage();
-
-        if let Some(table) = stage
-            .tables
-            .iter()
-            .find(|t| t.name == table_name && t.namespace_id == namespace_id)
-        {
-            let tombstone_max_sequence_number = stage
-                .tombstones
-                .iter()
-                .filter(|t| t.shard_id == shard_id && t.table_id == table.id)
-                .max_by_key(|t| t.sequence_number)
-                .map(|t| t.sequence_number);
-
-            return Ok(Some(TablePersistInfo {
-                shard_id,
-                table_id: table.id,
-                tombstone_max_sequence_number,
-            }));
-        }
-
-        Ok(None)
     }
 }
 

--- a/iox_catalog/src/metrics.rs
+++ b/iox_catalog/src/metrics.rs
@@ -3,7 +3,7 @@
 use crate::interface::{
     sealed::TransactionFinalize, ColumnRepo, ColumnUpsertRequest, NamespaceRepo, ParquetFileRepo,
     PartitionRepo, ProcessedTombstoneRepo, QueryPoolRepo, RepoCollection, Result, ShardRepo,
-    TablePersistInfo, TableRepo, TombstoneRepo, TopicMetadataRepo,
+    TableRepo, TombstoneRepo, TopicMetadataRepo,
 };
 use async_trait::async_trait;
 use data_types::{
@@ -209,7 +209,6 @@ decorate!(
         "table_get_by_id" = get_by_id(&mut self, table_id: TableId) -> Result<Option<Table>>;
         "table_get_by_namespace_and_name" = get_by_namespace_and_name(&mut self, namespace_id: NamespaceId, name: &str) -> Result<Option<Table>>;
         "table_list_by_namespace_id" = list_by_namespace_id(&mut self, namespace_id: NamespaceId) -> Result<Vec<Table>>;
-        "get_table_persist_info" = get_table_persist_info(&mut self, shard_id: ShardId, namespace_id: NamespaceId, table_name: &str) -> Result<Option<TablePersistInfo>>;
         "table_list" = list(&mut self) -> Result<Vec<Table>>;
     ]
 );

--- a/iox_catalog/src/postgres.rs
+++ b/iox_catalog/src/postgres.rs
@@ -4,8 +4,8 @@ use crate::{
     interface::{
         self, sealed::TransactionFinalize, Catalog, ColumnRepo, ColumnTypeMismatchSnafu,
         ColumnUpsertRequest, Error, NamespaceRepo, ParquetFileRepo, PartitionRepo,
-        ProcessedTombstoneRepo, QueryPoolRepo, RepoCollection, Result, ShardRepo, TablePersistInfo,
-        TableRepo, TombstoneRepo, TopicMetadataRepo, Transaction,
+        ProcessedTombstoneRepo, QueryPoolRepo, RepoCollection, Result, ShardRepo, TableRepo,
+        TombstoneRepo, TopicMetadataRepo, Transaction,
     },
     metrics::MetricDecorator,
 };
@@ -843,42 +843,6 @@ WHERE namespace_id = $1;
             .map_err(|e| Error::SqlxError { source: e })?;
 
         Ok(rec)
-    }
-
-    async fn get_table_persist_info(
-        &mut self,
-        shard_id: ShardId,
-        namespace_id: NamespaceId,
-        table_name: &str,
-    ) -> Result<Option<TablePersistInfo>> {
-        let rec = sqlx::query_as::<_, TablePersistInfo>(
-            r#"
-WITH tid as (SELECT id FROM table_name WHERE name = $2 AND namespace_id = $3)
-SELECT $1 as shard_id, id as table_id,
-       tombstone.sequence_number as tombstone_max_sequence_number
-FROM tid
-LEFT JOIN (
-  SELECT tombstone.table_id, sequence_number
-  FROM tombstone
-  WHERE shard_id = $1 AND tombstone.table_id = (SELECT id FROM tid)
-  ORDER BY sequence_number DESC
-  LIMIT 1
-) tombstone ON tombstone.table_id = tid.id
-            "#,
-        )
-        .bind(&shard_id) // $1
-        .bind(&table_name) // $2
-        .bind(&namespace_id) // $3
-        .fetch_one(&mut self.inner)
-        .await;
-
-        if let Err(sqlx::Error::RowNotFound) = rec {
-            return Ok(None);
-        }
-
-        let info = rec.map_err(|e| Error::SqlxError { source: e })?;
-
-        Ok(Some(info))
     }
 }
 


### PR DESCRIPTION
Resolving a table name -> table ID happens in the ingest hot path (once per table, when the first op for it is observed).

After the recent changes (#5807) this can now be a cheaper indexed query with no JOIN, which should improve the ingest rate immediately after startup ("recovery rate"). 

Ultimately I intend to remove this query entirely.

---

* perf(ingester): cheaper table discovery (15e153a74)

      This commit changes the table ID lookup query from an expensive,
      JOIN multi-query to a simple, single table, indexed lookup.
      
      As this is on the hot path, this should help with the recovery rate of
      the ingesters.

* refactor: remove Table::get_table_persist_info() (3e1e4c1f0)

      Remove the now-redundant get_table_persist_info() implementations.