### PR TITLE
perf(ingester): reduce catalog queries during persist()

### DIFF
--- a/data_types/src/lib.rs
+++ b/data_types/src/lib.rs
@@ -899,15 +899,6 @@ impl Partition {
     }
 }
 
-/// Information for a partition from the catalog.
-#[derive(Debug)]
-#[allow(missing_docs)]
-pub struct PartitionInfo {
-    pub partition: Partition,
-    pub namespace_name: String,
-    pub table_name: String,
-}
-
 /// Data for a partition  chosen from its parquet files
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, sqlx::FromRow)]
 pub struct PartitionParam {

--- a/ingester/src/data.rs
+++ b/ingester/src/data.rs
@@ -876,11 +876,11 @@ mod tests {
             let mut repos = catalog.repositories().await;
             let partition_info = repos
                 .partitions()
-                .partition_info_by_id(partition_id)
+                .get_by_id(partition_id)
                 .await
                 .unwrap()
                 .unwrap();
-            assert!(partition_info.partition.sort_key.is_empty());
+            assert!(partition_info.sort_key.is_empty());
         }
 
         data.persist(shard1.id, namespace.id, table_id, partition_id)
@@ -970,11 +970,11 @@ mod tests {
         // verify it set a sort key on the partition in the catalog
         let partition_info = repos
             .partitions()
-            .partition_info_by_id(partition_id)
+            .get_by_id(partition_id)
             .await
             .unwrap()
             .unwrap();
-        assert_eq!(partition_info.partition.sort_key, vec!["time"]);
+        assert_eq!(partition_info.sort_key, vec!["time"]);
 
         let mem_table = n.table_data(&"mem".into()).unwrap();
         let mem_table = mem_table.read().await;

--- a/ingester/src/data.rs
+++ b/ingester/src/data.rs
@@ -4,16 +4,18 @@ use std::{collections::BTreeMap, sync::Arc};
 
 use async_trait::async_trait;
 use backoff::{Backoff, BackoffConfig};
-use data_types::{NamespaceId, PartitionId, SequenceNumber, ShardId, ShardIndex, TableId};
+use data_types::{
+    CompactionLevel, NamespaceId, PartitionId, SequenceNumber, ShardId, ShardIndex, TableId,
+};
 
 use dml::DmlOperation;
 use iox_catalog::interface::{get_table_schema_by_id, Catalog};
 use iox_query::exec::Executor;
-use iox_time::SystemProvider;
+use iox_time::{SystemProvider, TimeProvider};
 use metric::{Attributes, Metric, U64Histogram, U64HistogramOptions};
 use object_store::DynObjectStore;
 use observability_deps::tracing::*;
-use parquet_file::storage::ParquetStorage;
+use parquet_file::{metadata::IoxMetadata, storage::ParquetStorage};
 use snafu::{OptionExt, Snafu};
 use write_summary::ShardProgress;
 
@@ -27,7 +29,7 @@ pub mod partition;
 pub(crate) mod shard;
 pub(crate) mod table;
 
-use self::{partition::resolver::PartitionProvider, shard::ShardData, table::TableName};
+use self::{partition::resolver::PartitionProvider, shard::ShardData};
 
 #[cfg(test)]
 mod triggers;
@@ -247,16 +249,21 @@ impl Persister for IngesterData {
         let namespace = shard_data
             .namespace_by_id(namespace_id)
             .unwrap_or_else(|| panic!("namespace {namespace_id} not in shard {shard_id} state"));
+        let namespace_name = namespace.namespace_name();
 
         let partition_key;
+        let table_name;
         let batch;
         let sort_key;
+        let last_persisted_sequence_number;
         {
             let table_data = namespace.table_id(table_id).unwrap_or_else(|| {
                 panic!("table {table_id} in namespace {namespace_id} not in shard {shard_id} state")
             });
 
             let mut guard = table_data.write().await;
+            table_name = guard.table_name().clone();
+
             let partition = guard.get_partition(partition_id).unwrap_or_else(|| {
                 panic!(
                     "partition {partition_id} in table {table_id} in namespace {namespace_id} not in shard {shard_id} state"
@@ -266,12 +273,15 @@ impl Persister for IngesterData {
             partition_key = partition.partition_key().clone();
             batch = partition.snapshot_to_persisting_batch();
             sort_key = partition.sort_key().clone();
+            last_persisted_sequence_number = partition.max_persisted_sequence_number();
         };
 
         trace!(
             %shard_id,
             %namespace_id,
+            %namespace_name,
             %table_id,
+            %table_name,
             %partition_id,
             %partition_key,
             "fetching sort key"
@@ -281,7 +291,9 @@ impl Persister for IngesterData {
         debug!(
             %shard_id,
             %namespace_id,
+            %namespace_name,
             %table_id,
+            %table_name,
             %partition_id,
             %partition_key,
             ?sort_key,
@@ -295,7 +307,9 @@ impl Persister for IngesterData {
                 warn!(
                     %shard_id,
                     %namespace_id,
+                    %namespace_name,
                     %table_id,
+                    %table_name,
                     %partition_id,
                     %partition_key,
                     "partition marked for persistence contains no data"
@@ -303,6 +317,10 @@ impl Persister for IngesterData {
                 return;
             }
         };
+
+        assert_eq!(batch.shard_id(), shard_id);
+        assert_eq!(batch.table_id(), table_id);
+        assert_eq!(batch.partition_id(), partition_id);
 
         // lookup column IDs from catalog
         // TODO: this can be removed once the ingester uses column IDs internally as well
@@ -314,29 +332,37 @@ impl Persister for IngesterData {
             .await
             .expect("retry forever");
 
-        // lookup the partition_info from the catalog
-        let partition_info = Backoff::new(&self.backoff_config)
-            .retry_all_errors("get partition_info_by_id", || async {
-                let mut repos = self.catalog.repositories().await;
-                repos.partitions().partition_info_by_id(partition_id).await
-            })
-            .await
-            .expect("retry forever").unwrap_or_else(|| panic!("partition {partition_id} in table {table_id} in namespace {namespace_id} in shard {shard_id} has no partition info in catalog"));
+        // Read the maximum SequenceNumber in the batch.
+        let (_min, max_sequence_number) = batch.data.min_max_sequence_numbers();
+
+        // Read the future object store ID before passing the batch into
+        // compaction, instead of retaining a copy of the data post-compaction.
+        let object_store_id = batch.object_store_id();
 
         // do the CPU intensive work of compaction, de-duplication and sorting
         let CompactedStream {
             stream: record_stream,
-            iox_metadata,
-            sort_key_update,
-        } = compact_persisting_batch(
-            Arc::new(SystemProvider::new()),
-            &self.exec,
-            namespace.namespace_id().get(),
-            &partition_info,
-            Arc::clone(&batch),
-        )
-        .await
-        .expect("unable to compact persisting batch");
+            catalog_sort_key_update,
+            data_sort_key,
+        } = compact_persisting_batch(&self.exec, sort_key, batch)
+            .await
+            .expect("unable to compact persisting batch");
+
+        // Construct the metadata for this parquet file.
+        let iox_metadata = IoxMetadata {
+            object_store_id,
+            creation_timestamp: SystemProvider::new().now(),
+            shard_id,
+            namespace_id,
+            namespace_name: Arc::clone(&**namespace.namespace_name()),
+            table_id,
+            table_name: Arc::clone(&*table_name),
+            partition_id,
+            partition_key: partition_key.clone(),
+            max_sequence_number,
+            compaction_level: CompactionLevel::Initial,
+            sort_key: Some(data_sort_key),
+        };
 
         // Save the compacted data to a parquet file in object storage.
         //
@@ -352,7 +378,7 @@ impl Persister for IngesterData {
         // catalog. If the order is reversed, the querier or
         // compactor may see a parquet file with an inconsistent
         // sort key. https://github.com/influxdata/influxdb_iox/issues/5090
-        if let Some(new_sort_key) = sort_key_update {
+        if let Some(new_sort_key) = catalog_sort_key_update {
             let sort_key = new_sort_key.to_columns().collect::<Vec<_>>();
             Backoff::new(&self.backoff_config)
                 .retry_all_errors("update_sort_key", || async {
@@ -367,9 +393,16 @@ impl Persister for IngesterData {
                 .await
                 .expect("retry forever");
             debug!(
-                ?partition_id,
-                table = partition_info.table_name,
-                ?new_sort_key,
+                %object_store_id,
+                %shard_id,
+                %namespace_id,
+                %namespace_name,
+                %table_id,
+                %table_name,
+                %partition_id,
+                %partition_key,
+                old_sort_key = ?sort_key,
+                %new_sort_key,
                 "adjusted sort key during batch compact & persist"
             );
         }
@@ -384,7 +417,7 @@ impl Persister for IngesterData {
         // It is an invariant that partitions are persisted in order so that
         // both the per-shard, and per-partition watermarks are correctly
         // advanced and accurate.
-        if let Some(last_persist) = partition_info.partition.persisted_sequence_number {
+        if let Some(last_persist) = last_persisted_sequence_number {
             assert!(
                 parquet_file.max_sequence_number > last_persist,
                 "out of order partition persistence, persisting {}, previously persisted {}",
@@ -450,27 +483,28 @@ impl Persister for IngesterData {
             .expect("retry forever");
 
         // Record metrics
-        let attributes = Attributes::from([(
-            "shard_id",
-            format!("{}", partition_info.partition.shard_id).into(),
-        )]);
+        let attributes = Attributes::from([("shard_id", format!("{}", shard_id).into())]);
         self.persisted_file_size_bytes
             .recorder(attributes)
             .record(file_size as u64);
 
         // and remove the persisted data from memory
-        let table_name = TableName::from(&partition_info.table_name);
         namespace
             .mark_persisted(
                 &table_name,
-                &partition_info.partition.partition_key,
+                &partition_key,
                 iox_metadata.max_sequence_number,
             )
             .await;
         debug!(
-            ?partition_id,
+            %object_store_id,
+            %shard_id,
+            %namespace_id,
+            %namespace_name,
+            %table_id,
             %table_name,
-            partition_key=%partition_info.partition.partition_key,
+            %partition_id,
+            %partition_key,
             max_sequence_number=%iox_metadata.max_sequence_number.get(),
             "marked partition as persisted"
         );

--- a/ingester/src/data/namespace.rs
+++ b/ingester/src/data/namespace.rs
@@ -63,7 +63,7 @@ where
 }
 
 impl std::ops::Deref for NamespaceName {
-    type Target = str;
+    type Target = Arc<str>;
 
     fn deref(&self) -> &Self::Target {
         &self.0
@@ -391,7 +391,6 @@ impl NamespaceData {
     }
 
     /// Returns the [`NamespaceName`] for this namespace.
-    #[cfg(test)]
     pub(crate) fn namespace_name(&self) -> &NamespaceName {
         &self.namespace_name
     }
@@ -483,7 +482,7 @@ mod tests {
         );
 
         // Assert the namespace name was stored
-        assert_eq!(&**ns.namespace_name(), NAMESPACE_NAME);
+        assert_eq!(ns.namespace_name().to_string(), NAMESPACE_NAME);
 
         // Assert the namespace does not contain the test data
         assert!(ns.table_data(&TABLE_NAME.into()).is_none());

--- a/ingester/src/data/partition.rs
+++ b/ingester/src/data/partition.rs
@@ -268,7 +268,7 @@ impl PartitionData {
 
     /// Return the [`SequenceNumber`] that forms the (inclusive) persistence
     /// watermark for this partition.
-    pub(super) fn max_persisted_sequence_number(&self) -> Option<SequenceNumber> {
+    pub(crate) fn max_persisted_sequence_number(&self) -> Option<SequenceNumber> {
         self.max_persisted_sequence_number
     }
 

--- a/ingester/src/data/partition/resolver/cache.rs
+++ b/ingester/src/data/partition/resolver/cache.rs
@@ -209,12 +209,12 @@ where
                 namespace_id,
                 table_id,
                 table_name,
-                SortKeyState::Deferred(DeferredSortKey::new(
+                SortKeyState::Deferred(Arc::new(DeferredSortKey::new(
                     cached.partition_id,
                     self.max_smear,
                     Arc::clone(&__self.catalog),
                     self.backoff_config.clone(),
-                )),
+                ))),
                 cached.max_sequence_number,
             );
         }

--- a/ingester/src/data/partition/resolver/catalog.rs
+++ b/ingester/src/data/partition/resolver/catalog.rs
@@ -148,7 +148,7 @@ mod tests {
             )
             .await;
         assert_eq!(got.namespace_id(), namespace_id);
-        assert_eq!(*got.table_name(), *table_name);
+        assert_eq!(got.table_name().to_string(), table_name.to_string());
         assert_matches!(got.sort_key(), SortKeyState::Provided(None));
         assert_eq!(got.max_persisted_sequence_number(), None);
         assert!(got.partition_key.ptr_eq(&callers_partition_key));

--- a/ingester/src/data/partition/resolver/catalog.rs
+++ b/ingester/src/data/partition/resolver/catalog.rs
@@ -91,6 +91,7 @@ impl PartitionProvider for CatalogPartitionResolver {
 mod tests {
     use std::sync::Arc;
 
+    use assert_matches::assert_matches;
     use data_types::ShardIndex;
 
     use super::*;
@@ -148,7 +149,7 @@ mod tests {
             .await;
         assert_eq!(got.namespace_id(), namespace_id);
         assert_eq!(*got.table_name(), *table_name);
-        assert_eq!(got.sort_key().await, None);
+        assert_matches!(got.sort_key(), SortKeyState::Provided(None));
         assert_eq!(got.max_persisted_sequence_number(), None);
         assert!(got.partition_key.ptr_eq(&callers_partition_key));
 

--- a/ingester/src/data/partition/resolver/mock.rs
+++ b/ingester/src/data/partition/resolver/mock.rs
@@ -69,7 +69,7 @@ impl PartitionProvider for MockPartitionProvider {
             });
 
         assert_eq!(p.namespace_id(), namespace_id);
-        assert_eq!(*p.table_name(), *table_name);
+        assert_eq!(p.table_name().to_string(), table_name.to_string());
         p
     }
 }

--- a/ingester/src/data/partition/resolver/trait.rs
+++ b/ingester/src/data/partition/resolver/trait.rs
@@ -79,6 +79,6 @@ mod tests {
             .await;
         assert_eq!(got.partition_id(), partition);
         assert_eq!(got.namespace_id(), namespace_id);
-        assert_eq!(*got.table_name(), *table_name);
+        assert_eq!(got.table_name().to_string(), table_name.to_string());
     }
 }

--- a/ingester/src/data/table.rs
+++ b/ingester/src/data/table.rs
@@ -65,7 +65,7 @@ impl std::fmt::Display for TableName {
 }
 
 impl std::ops::Deref for TableName {
-    type Target = str;
+    type Target = Arc<str>;
 
     fn deref(&self) -> &Self::Target {
         &self.0

--- a/ingester/src/test_util.rs
+++ b/ingester/src/test_util.rs
@@ -9,8 +9,7 @@ use arrow::record_batch::RecordBatch;
 use arrow_util::assert_batches_eq;
 use bitflags::bitflags;
 use data_types::{
-    CompactionLevel, NamespaceId, PartitionId, PartitionKey, Sequence, SequenceNumber, ShardId,
-    ShardIndex, TableId,
+    NamespaceId, PartitionId, PartitionKey, Sequence, SequenceNumber, ShardId, ShardIndex, TableId,
 };
 use dml::{DmlMeta, DmlOperation, DmlWrite};
 use iox_catalog::{interface::Catalog, mem::MemCatalog};
@@ -18,8 +17,6 @@ use iox_query::test::{raw_data, TestChunk};
 use iox_time::{SystemProvider, Time};
 use mutable_batch_lp::lines_to_batches;
 use object_store::memory::InMemory;
-use parquet_file::metadata::IoxMetadata;
-use schema::sort::SortKey;
 use uuid::Uuid;
 
 use crate::{
@@ -30,37 +27,6 @@ use crate::{
     lifecycle::{LifecycleConfig, LifecycleManager},
     query::QueryableBatch,
 };
-
-#[allow(clippy::too_many_arguments)]
-pub(crate) fn make_meta(
-    object_store_id: Uuid,
-    creation_timestamp: Time,
-    shard_id: i64,
-    namespace_id: i64,
-    namespace_name: &str,
-    table_id: i64,
-    table_name: &str,
-    partition_id: i64,
-    partition_key: &str,
-    max_sequence_number: i64,
-    compaction_level: CompactionLevel,
-    sort_key: Option<SortKey>,
-) -> IoxMetadata {
-    IoxMetadata {
-        object_store_id,
-        creation_timestamp,
-        shard_id: ShardId::new(shard_id),
-        namespace_id: NamespaceId::new(namespace_id),
-        namespace_name: Arc::from(namespace_name),
-        table_id: TableId::new(table_id),
-        table_name: Arc::from(table_name),
-        partition_id: PartitionId::new(partition_id),
-        partition_key: PartitionKey::from(partition_key),
-        max_sequence_number: SequenceNumber::new(max_sequence_number),
-        compaction_level,
-        sort_key,
-    }
-}
 
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn make_persisting_batch(

--- a/iox_catalog/src/interface.rs
+++ b/iox_catalog/src/interface.rs
@@ -4,9 +4,9 @@ use async_trait::async_trait;
 use data_types::{
     Column, ColumnSchema, ColumnType, ColumnTypeCount, CompactionLevel, Namespace, NamespaceId,
     NamespaceSchema, ParquetFile, ParquetFileId, ParquetFileParams, Partition, PartitionId,
-    PartitionInfo, PartitionKey, PartitionParam, ProcessedTombstone, QueryPool, QueryPoolId,
-    SequenceNumber, Shard, ShardId, ShardIndex, SkippedCompaction, Table, TableId, TablePartition,
-    TableSchema, Timestamp, Tombstone, TombstoneId, TopicId, TopicMetadata,
+    PartitionKey, PartitionParam, ProcessedTombstone, QueryPool, QueryPoolId, SequenceNumber,
+    Shard, ShardId, ShardIndex, SkippedCompaction, Table, TableId, TablePartition, TableSchema,
+    Timestamp, Tombstone, TombstoneId, TopicId, TopicMetadata,
 };
 use iox_time::TimeProvider;
 use snafu::{OptionExt, Snafu};
@@ -436,13 +436,6 @@ pub trait PartitionRepo: Send + Sync {
 
     /// return the partitions by table id
     async fn list_by_table_id(&mut self, table_id: TableId) -> Result<Vec<Partition>>;
-
-    /// return the partition record, the namespace name it belongs to, and the table name it is
-    /// under
-    async fn partition_info_by_id(
-        &mut self,
-        partition_id: PartitionId,
-    ) -> Result<Option<PartitionInfo>>;
 
     /// Update the sort key for the partition.
     ///
@@ -1434,17 +1427,6 @@ pub(crate) mod test_helpers {
 
         created.insert(other_partition.id, other_partition.clone());
         assert_eq!(created, listed);
-
-        // test get_partition_info_by_id
-        let info = repos
-            .partitions()
-            .partition_info_by_id(other_partition.id)
-            .await
-            .unwrap()
-            .unwrap();
-        assert_eq!(info.partition, other_partition);
-        assert_eq!(info.table_name, "test_table");
-        assert_eq!(info.namespace_name, "namespace_partition_test");
 
         // test list_by_namespace
         let namespace2 = repos

--- a/iox_catalog/src/mem.rs
+++ b/iox_catalog/src/mem.rs
@@ -13,10 +13,10 @@ use crate::{
 use async_trait::async_trait;
 use data_types::{
     Column, ColumnId, ColumnType, ColumnTypeCount, CompactionLevel, Namespace, NamespaceId,
-    ParquetFile, ParquetFileId, ParquetFileParams, Partition, PartitionId, PartitionInfo,
-    PartitionKey, PartitionParam, ProcessedTombstone, QueryPool, QueryPoolId, SequenceNumber,
-    Shard, ShardId, ShardIndex, SkippedCompaction, Table, TableId, TablePartition, Timestamp,
-    Tombstone, TombstoneId, TopicId, TopicMetadata,
+    ParquetFile, ParquetFileId, ParquetFileParams, Partition, PartitionId, PartitionKey,
+    PartitionParam, ProcessedTombstone, QueryPool, QueryPoolId, SequenceNumber, Shard, ShardId,
+    ShardIndex, SkippedCompaction, Table, TableId, TablePartition, Timestamp, Tombstone,
+    TombstoneId, TopicId, TopicMetadata,
 };
 use iox_time::{SystemProvider, TimeProvider};
 use observability_deps::tracing::warn;
@@ -764,43 +764,6 @@ impl PartitionRepo for MemTxn {
             .cloned()
             .collect();
         Ok(partitions)
-    }
-
-    async fn partition_info_by_id(
-        &mut self,
-        partition_id: PartitionId,
-    ) -> Result<Option<PartitionInfo>> {
-        let stage = self.stage();
-
-        let partition = stage
-            .partitions
-            .iter()
-            .find(|p| p.id == partition_id)
-            .cloned();
-
-        if let Some(partition) = partition {
-            let table = stage
-                .tables
-                .iter()
-                .find(|t| t.id == partition.table_id)
-                .cloned();
-            if let Some(table) = table {
-                let namespace = stage
-                    .namespaces
-                    .iter()
-                    .find(|n| n.id == table.namespace_id)
-                    .cloned();
-                if let Some(namespace) = namespace {
-                    return Ok(Some(PartitionInfo {
-                        namespace_name: namespace.name,
-                        table_name: table.name,
-                        partition,
-                    }));
-                }
-            }
-        }
-
-        Ok(None)
     }
 
     async fn update_sort_key(

--- a/iox_catalog/src/metrics.rs
+++ b/iox_catalog/src/metrics.rs
@@ -8,10 +8,10 @@ use crate::interface::{
 use async_trait::async_trait;
 use data_types::{
     Column, ColumnType, ColumnTypeCount, CompactionLevel, Namespace, NamespaceId, ParquetFile,
-    ParquetFileId, ParquetFileParams, Partition, PartitionId, PartitionInfo, PartitionKey,
-    PartitionParam, ProcessedTombstone, QueryPool, QueryPoolId, SequenceNumber, Shard, ShardId,
-    ShardIndex, SkippedCompaction, Table, TableId, TablePartition, Timestamp, Tombstone,
-    TombstoneId, TopicId, TopicMetadata,
+    ParquetFileId, ParquetFileParams, Partition, PartitionId, PartitionKey, PartitionParam,
+    ProcessedTombstone, QueryPool, QueryPoolId, SequenceNumber, Shard, ShardId, ShardIndex,
+    SkippedCompaction, Table, TableId, TablePartition, Timestamp, Tombstone, TombstoneId, TopicId,
+    TopicMetadata,
 };
 use iox_time::{SystemProvider, TimeProvider};
 use metric::{DurationHistogram, Metric};
@@ -244,7 +244,6 @@ decorate!(
         "partition_list_by_shard" = list_by_shard(&mut self, shard_id: ShardId) -> Result<Vec<Partition>>;
         "partition_list_by_namespace" = list_by_namespace(&mut self, namespace_id: NamespaceId) -> Result<Vec<Partition>>;
         "partition_list_by_table_id" = list_by_table_id(&mut self, table_id: TableId) -> Result<Vec<Partition>>;
-        "partition_partition_info_by_id" = partition_info_by_id(&mut self, partition_id: PartitionId) -> Result<Option<PartitionInfo>>;
         "partition_update_sort_key" = update_sort_key(&mut self, partition_id: PartitionId, sort_key: &[&str]) -> Result<Partition>;
         "partition_record_skipped_compaction" = record_skipped_compaction(&mut self, partition_id: PartitionId, reason: &str, num_files: usize, limit_num_files: usize,estimated_bytes: u64, limit_bytes: u64) -> Result<()>;
         "partition_list_skipped_compactions" = list_skipped_compactions(&mut self) -> Result<Vec<SkippedCompaction>>;


### PR DESCRIPTION
This PR reduces the number of catalog queries needed at `persist()` time by a third.

Closes #5767.

---

* refactor: use deferred sort key loading (10d77b0ef)

      Changes the persist() implementation in the ingester to load the sort
      key using the deferred loading mechanism, instead of on-demand.

* perf(ingester): remove persist lookup queries (e55667719)

      Removes the catalog queries previously used to look up various
      information about the partition/table/namespace that was already in
      memory.
      
      As part of this change, the compaction helper function is changed to
      accept the inputs it needs, rather than a struct of data from the
      catalog - this significantly simplifies testing.
      
      This commit also adds additional context to all log messages in the
      persist() fn.

* refactor: defer querying for table schema (920f7edf7)

      Do not query for the table schema until it is needed.

* refactor: assert monotonic partition persistence (3fbeaa131)

      Copies the existing monotonic partition persistence check into the
      partition too - this ensures that even if the partitions are persisted
      in order, they are never marked as persisted OUT of order.

* refactor(catalog): remove partition_info_by_id() (3e70dc44a)

      This method used to return a subset of partition metadata, and was used
      exclusively for persistence in the ingester. It is now no longer
      necessary.