### PR TITLE
refactor(iox_catalog): reduce default column limit

### DIFF
--- a/iox_catalog/migrations/20221014122742_lower-default-per-table-column-limit.sql
+++ b/iox_catalog/migrations/20221014122742_lower-default-per-table-column-limit.sql
@@ -1,0 +1,7 @@
+-- Lower the defualt per-table column limit.
+--
+-- https://github.com/influxdata/influxdb_iox/issues/5858
+ALTER TABLE
+    namespace ALTER max_columns_per_table
+SET
+    DEFAULT 200;

--- a/iox_catalog/src/lib.rs
+++ b/iox_catalog/src/lib.rs
@@ -28,9 +28,9 @@ const SHARED_QUERY_POOL: &str = SHARED_TOPIC_NAME;
 const TIME_COLUMN: &str = "time";
 
 /// Default per-namespace table count service protection limit.
-const DEFAULT_MAX_TABLES: i32 = 1000;
+pub const DEFAULT_MAX_TABLES: i32 = 10_000;
 /// Default per-table column count service protection limit.
-const DEFAULT_MAX_COLUMNS_PER_TABLE: i32 = 200;
+pub const DEFAULT_MAX_COLUMNS_PER_TABLE: i32 = 200;
 
 /// A string value representing an infinite retention policy.
 pub const INFINITE_RETENTION_POLICY: &str = "inf";

--- a/iox_catalog/src/lib.rs
+++ b/iox_catalog/src/lib.rs
@@ -27,6 +27,11 @@ const SHARED_TOPIC_NAME: &str = "iox-shared";
 const SHARED_QUERY_POOL: &str = SHARED_TOPIC_NAME;
 const TIME_COLUMN: &str = "time";
 
+/// Default per-namespace table count service protection limit.
+const DEFAULT_MAX_TABLES: i32 = 1000;
+/// Default per-table column count service protection limit.
+const DEFAULT_MAX_COLUMNS_PER_TABLE: i32 = 200;
+
 /// A string value representing an infinite retention policy.
 pub const INFINITE_RETENTION_POLICY: &str = "inf";
 

--- a/iox_catalog/src/mem.rs
+++ b/iox_catalog/src/mem.rs
@@ -9,6 +9,7 @@ use crate::{
         TombstoneRepo, TopicMetadataRepo, Transaction,
     },
     metrics::MetricDecorator,
+    DEFAULT_MAX_COLUMNS_PER_TABLE, DEFAULT_MAX_TABLES,
 };
 use async_trait::async_trait;
 use data_types::{
@@ -302,8 +303,8 @@ impl NamespaceRepo for MemTxn {
             topic_id,
             query_pool_id,
             retention_duration: Some(retention_duration.to_string()),
-            max_tables: 10000,
-            max_columns_per_table: 1000,
+            max_tables: DEFAULT_MAX_TABLES,
+            max_columns_per_table: DEFAULT_MAX_COLUMNS_PER_TABLE,
         };
         stage.namespaces.push(namespace);
         Ok(stage.namespaces.last().unwrap().clone())

--- a/iox_catalog/src/postgres.rs
+++ b/iox_catalog/src/postgres.rs
@@ -8,6 +8,7 @@ use crate::{
         TombstoneRepo, TopicMetadataRepo, Transaction,
     },
     metrics::MetricDecorator,
+    DEFAULT_MAX_COLUMNS_PER_TABLE, DEFAULT_MAX_TABLES,
 };
 use async_trait::async_trait;
 use data_types::{
@@ -617,6 +618,10 @@ RETURNING *;
                 Error::SqlxError { source: e }
             }
         })?;
+
+        // Ensure the column default values match the code values.
+        debug_assert_eq!(rec.max_tables, DEFAULT_MAX_TABLES);
+        debug_assert_eq!(rec.max_columns_per_table, DEFAULT_MAX_COLUMNS_PER_TABLE);
 
         Ok(rec)
     }

--- a/router/src/dml_handlers/ns_autocreation.rs
+++ b/router/src/dml_handlers/ns_autocreation.rs
@@ -223,8 +223,8 @@ mod tests {
                 retention_duration: Some("inf".to_owned()),
                 topic_id: TopicId::new(42),
                 query_pool_id: QueryPoolId::new(42),
-                max_tables: 10000,
-                max_columns_per_table: 1000,
+                max_tables: iox_catalog::DEFAULT_MAX_TABLES,
+                max_columns_per_table: iox_catalog::DEFAULT_MAX_COLUMNS_PER_TABLE,
             }
         );
     }


### PR DESCRIPTION
This PR changes the default value for the per-column service limit from 1,000 to 200.

**This change only affects new namespaces / org&buckets**.

It also beefs up some of the testing to make sure the code + database default stays in sync.

Closes #5858.

---

* refactor: reduce default column limit (46bbee542)

      Reduces the default number of columns allowed per-table, from 1,000 to
      200.

* test: assert default service limit values (e4179605d)

      Adds tests that assert the default service limit values.