### PR TITLE
refactor: return HTTP 400 for service limits

### DIFF
--- a/router/src/server/http.rs
+++ b/router/src/server/http.rs
@@ -120,7 +120,7 @@ impl From<&DmlError> for StatusCode {
             }
             DmlError::Schema(SchemaError::ServiceLimit(_)) => {
                 // https://docs.influxdata.com/influxdb/cloud/account-management/limits/#api-error-responses
-                StatusCode::TOO_MANY_REQUESTS
+                StatusCode::BAD_REQUEST
             }
             DmlError::Schema(SchemaError::Conflict(_)) => StatusCode::BAD_REQUEST,
             DmlError::Schema(SchemaError::UnexpectedCatalogError(_)) => {

--- a/router/tests/http.rs
+++ b/router/tests/http.rs
@@ -339,5 +339,5 @@ async fn test_schema_limit() {
             );
         }
     );
-    assert_eq!(err.as_status_code(), StatusCode::TOO_MANY_REQUESTS);
+    assert_eq!(err.as_status_code(), StatusCode::BAD_REQUEST);
 }


### PR DESCRIPTION
Does what it says on the tin.

Closes https://github.com/influxdata/influxdb_iox/issues/5861.

---

* refactor: return HTTP 400 for service limits (895ac97d7)

      Changes the HTTP response code from 429 to 400 for requests that exceed
      a service protection limit (table count, per-table column count).