### PR TITLE
test: ingester integration tests

### DIFF
--- a/ingester/src/lifecycle.rs
+++ b/ingester/src/lifecycle.rs
@@ -201,7 +201,7 @@ pub struct LifecycleConfig {
 impl LifecycleConfig {
     /// Initialize a new LifecycleConfig. panics if the passed `pause_ingest_size` is less than the
     /// `persist_memory_threshold`.
-    pub fn new(
+    pub const fn new(
         pause_ingest_size: usize,
         persist_memory_threshold: usize,
         partition_size_threshold: usize,

--- a/ingester/src/stream_handler/handler.rs
+++ b/ingester/src/stream_handler/handler.rs
@@ -279,7 +279,8 @@ where
                             shard_index=%self.shard_index,
                             shard_id=%self.shard_id,
                             potential_data_loss=true,
-                            "reset stream"
+                            "unable to read from desired sequence number offset \
+                                - reset stream to oldest available data"
                         );
                         self.shard_reset_count.inc(1);
                         sequence_number_before_reset = Some(self.current_sequence_number);
@@ -293,7 +294,8 @@ where
                             shard_index=%self.shard_index,
                             shard_id=%self.shard_id,
                             potential_data_loss=true,
-                            "unable to read from desired sequence number offset"
+                            "unable to read from desired sequence number offset \
+                                - aborting ingest due to configuration"
                         );
                         self.shard_unknown_sequence_number_count.inc(1);
                         None

--- a/ingester/tests/common/mod.rs
+++ b/ingester/tests/common/mod.rs
@@ -1,0 +1,350 @@
+use std::{collections::HashMap, num::NonZeroU32, sync::Arc, time::Duration};
+
+use data_types::{
+    Namespace, NamespaceSchema, PartitionKey, QueryPoolId, Sequence, SequenceNumber, ShardId,
+    ShardIndex, TopicId,
+};
+use dml::{DmlMeta, DmlWrite};
+use generated_types::ingester::IngesterQueryRequest;
+use ingester::{
+    handler::{IngestHandler, IngestHandlerImpl},
+    lifecycle::LifecycleConfig,
+    querier_handler::IngesterQueryResponse,
+};
+use iox_catalog::{interface::Catalog, mem::MemCatalog, validate_or_insert_schema};
+use iox_query::exec::Executor;
+use iox_time::TimeProvider;
+use metric::{Attributes, Metric, MetricObserver};
+use mutable_batch_lp::lines_to_batches;
+use object_store::DynObjectStore;
+use observability_deps::tracing::*;
+use test_helpers::{maybe_start_logging, timeout::FutureTimeout};
+use write_buffer::{
+    core::WriteBufferReading,
+    mock::{MockBufferForReading, MockBufferSharedState},
+};
+use write_summary::ShardProgress;
+
+/// The byte size of 1 MiB.
+const ONE_MIB: usize = 1024 * 1024;
+
+/// The shard index used for the [`TestContext`].
+pub const TEST_SHARD_INDEX: ShardIndex = ShardIndex::new(0);
+
+/// The topic name used for tests.
+pub const TEST_TOPIC_NAME: &str = "banana-topics";
+
+/// The lifecycle configuration used for tests.
+pub const TEST_LIFECYCLE_CONFIG: LifecycleConfig = LifecycleConfig::new(
+    ONE_MIB,
+    ONE_MIB / 10,
+    ONE_MIB / 10,
+    Duration::from_secs(10),
+    Duration::from_secs(10),
+    1_000,
+);
+
+pub struct TestContext {
+    ingester: IngestHandlerImpl,
+
+    // Catalog data initialised at construction time for later reuse.
+    query_id: QueryPoolId,
+    topic_id: TopicId,
+    shard_id: ShardId,
+
+    // A map of namespaces to schemas, also serving as the set of known
+    // namespaces.
+    namespaces: HashMap<String, NamespaceSchema>,
+
+    catalog: Arc<dyn Catalog>,
+    object_store: Arc<DynObjectStore>,
+    write_buffer_state: MockBufferSharedState,
+    metrics: Arc<metric::Registry>,
+}
+
+impl TestContext {
+    pub async fn new() -> Self {
+        maybe_start_logging();
+
+        let metrics: Arc<metric::Registry> = Default::default();
+        let catalog: Arc<dyn Catalog> = Arc::new(MemCatalog::new(Arc::clone(&metrics)));
+
+        // Initialise a topic, query pool and shard.
+        //
+        // Note that tests should set up their own namespace via
+        // ensure_namespace()
+        let mut txn = catalog.start_transaction().await.unwrap();
+        let topic = txn.topics().create_or_get(TEST_TOPIC_NAME).await.unwrap();
+        let query_id = txn
+            .query_pools()
+            .create_or_get("banana-query-pool")
+            .await
+            .unwrap()
+            .id;
+        let shard = txn
+            .shards()
+            .create_or_get(&topic, TEST_SHARD_INDEX)
+            .await
+            .unwrap();
+        txn.commit().await.unwrap();
+
+        // Mock in-memory write buffer.
+        let write_buffer_state =
+            MockBufferSharedState::empty_with_n_shards(NonZeroU32::try_from(1).unwrap());
+        let write_buffer_read: Arc<dyn WriteBufferReading> =
+            Arc::new(MockBufferForReading::new(write_buffer_state.clone(), None).unwrap());
+
+        // Mock object store that persists in memory.
+        let object_store: Arc<DynObjectStore> = Arc::new(object_store::memory::InMemory::new());
+
+        let ingester = IngestHandlerImpl::new(
+            TEST_LIFECYCLE_CONFIG,
+            topic.clone(),
+            [(TEST_SHARD_INDEX, shard)].into_iter().collect(),
+            Arc::clone(&catalog),
+            Arc::clone(&object_store),
+            write_buffer_read,
+            Arc::new(Executor::new(1)),
+            Arc::clone(&metrics),
+            true,
+            1,
+        )
+        .await
+        .unwrap();
+
+        Self {
+            ingester,
+            query_id,
+            topic_id: topic.id,
+            shard_id: shard.id,
+            catalog,
+            object_store,
+            write_buffer_state,
+            metrics,
+            namespaces: Default::default(),
+        }
+    }
+
+    /// Restart the Ingester, driving initialisation again.
+    ///
+    /// NOTE: metric contents are not reset.
+    pub async fn restart(&mut self) {
+        info!("restarting test context ingester");
+
+        let write_buffer_read: Arc<dyn WriteBufferReading> =
+            Arc::new(MockBufferForReading::new(self.write_buffer_state.clone(), None).unwrap());
+
+        let topic = self
+            .catalog
+            .repositories()
+            .await
+            .topics()
+            .create_or_get(TEST_TOPIC_NAME)
+            .await
+            .unwrap();
+
+        let shard = self
+            .catalog
+            .repositories()
+            .await
+            .shards()
+            .create_or_get(&topic, TEST_SHARD_INDEX)
+            .await
+            .unwrap();
+
+        self.ingester = IngestHandlerImpl::new(
+            TEST_LIFECYCLE_CONFIG,
+            topic,
+            [(TEST_SHARD_INDEX, shard)].into_iter().collect(),
+            Arc::clone(&self.catalog),
+            Arc::clone(&self.object_store),
+            write_buffer_read,
+            Arc::new(Executor::new(1)),
+            Arc::clone(&self.metrics),
+            true,
+            1,
+        )
+        .await
+        .unwrap();
+    }
+
+    /// Create a namespace in the catalog for the ingester to discover.
+    ///
+    /// # Panics
+    ///
+    /// Must not be called twice with the same `name`.
+    #[track_caller]
+    pub async fn ensure_namespace(&mut self, name: &str) -> Namespace {
+        let ns = self
+            .catalog
+            .repositories()
+            .await
+            .namespaces()
+            .create(
+                name,
+                iox_catalog::INFINITE_RETENTION_POLICY,
+                self.topic_id,
+                self.query_id,
+            )
+            .await
+            .expect("failed to create test namespace");
+
+        assert!(
+            self.namespaces
+                .insert(
+                    name.to_owned(),
+                    NamespaceSchema::new(
+                        ns.id,
+                        self.topic_id,
+                        self.query_id,
+                        iox_catalog::DEFAULT_MAX_COLUMNS_PER_TABLE,
+                    ),
+                )
+                .is_none(),
+            "namespace must not be duplicated"
+        );
+
+        debug!(?ns, "test namespace created");
+
+        ns
+    }
+
+    /// Enqueue the specified `op` into the write buffer for the ingester to
+    /// consume.
+    ///
+    /// This call takes care of validating the schema of `op` and populating the
+    /// catalog with any new schema elements.
+    ///
+    /// # Panics
+    ///
+    /// This method panics if the namespace for `op` does not exist, or the
+    /// schema is invalid or conflicts with the existing namespace schema.
+    #[track_caller]
+    pub async fn enqueue_write(&mut self, op: DmlWrite) -> SequenceNumber {
+        let schema = self
+            .namespaces
+            .get_mut(op.namespace())
+            .expect("namespace does not exist");
+
+        // Pull the sequence number out of the op to return it back to the user
+        // for simplicity.
+        let offset = op
+            .meta()
+            .sequence()
+            .expect("write must be sequenced")
+            .sequence_number;
+
+        // Perform schema validation, populating the catalog.
+        let mut repo = self.catalog.repositories().await;
+        if let Some(new) = validate_or_insert_schema(op.tables(), schema, repo.as_mut())
+            .await
+            .expect("failed schema validation for enqueuing write")
+        {
+            // Retain the updated schema.
+            debug!(?schema, "updated test context schema");
+            *schema = new;
+        }
+
+        // Push the write into the write buffer.
+        self.write_buffer_state.push_write(op);
+
+        debug!(?offset, "enqueued write in write buffer");
+        offset
+    }
+
+    /// A helper wrapper over [`Self::enqueue_write()`] for line-protocol.
+    #[track_caller]
+    pub async fn write_lp(
+        &mut self,
+        namespace: &str,
+        lp: &str,
+        partition_key: PartitionKey,
+        sequence_number: i64,
+    ) -> SequenceNumber {
+        self.enqueue_write(DmlWrite::new(
+            namespace,
+            lines_to_batches(lp, 0).unwrap(),
+            Some(partition_key),
+            DmlMeta::sequenced(
+                Sequence::new(TEST_SHARD_INDEX, SequenceNumber::new(sequence_number)),
+                iox_time::SystemProvider::new().now(),
+                None,
+                50,
+            ),
+        ))
+        .await
+    }
+
+    /// Utilise the progress API to query for the current state of the test
+    /// shard.
+    pub async fn progress(&self) -> ShardProgress {
+        self.ingester
+            .progresses(vec![TEST_SHARD_INDEX])
+            .await
+            .get(&TEST_SHARD_INDEX)
+            .unwrap()
+            .clone()
+    }
+
+    /// Wait for the specified `offset` to be readable according to the external
+    /// progress API.
+    ///
+    /// # Panics
+    ///
+    /// This method panics if `offset` is not readable within 10 seconds.
+    pub async fn wait_for_readable(&self, offset: SequenceNumber) {
+        async {
+            loop {
+                let is_readable = self.progress().await.readable(offset);
+                if is_readable {
+                    debug!(?offset, "offset reported as readable");
+                    return;
+                }
+
+                trace!(?offset, "offset reported as not yet readable");
+                tokio::time::sleep(Duration::from_millis(100)).await;
+            }
+        }
+        .with_timeout_panic(Duration::from_secs(10))
+        .await;
+    }
+
+    /// Submit a query to the ingester's public query interface.
+    pub async fn query(
+        &self,
+        req: IngesterQueryRequest,
+    ) -> Result<IngesterQueryResponse, ingester::querier_handler::Error> {
+        self.ingester.query(req).await
+    }
+
+    /// Retrieve the specified metric value.
+    pub fn get_metric<T, A>(&self, name: &'static str, attrs: A) -> T::Recorder
+    where
+        T: MetricObserver,
+        A: Into<Attributes>,
+    {
+        let attrs = attrs.into();
+
+        self.metrics
+            .get_instrument::<Metric<T>>(name)
+            .unwrap_or_else(|| panic!("failed to find metric {}", name))
+            .get_observer(&attrs)
+            .unwrap_or_else(|| {
+                panic!(
+                    "failed to find metric {} with attributes {:?}",
+                    name, &attrs
+                )
+            })
+            .recorder()
+    }
+
+    /// Return a reference to the catalog.
+    pub fn catalog(&self) -> &dyn Catalog {
+        self.catalog.as_ref()
+    }
+
+    /// Return the [`ShardId`] of the test shard.
+    pub fn shard_id(&self) -> ShardId {
+        self.shard_id
+    }
+}

--- a/ingester/tests/write.rs
+++ b/ingester/tests/write.rs
@@ -1,8 +1,9 @@
 mod common;
 
 use arrow_util::assert_batches_sorted_eq;
+use assert_matches::assert_matches;
 pub use common::*;
-use data_types::PartitionKey;
+use data_types::{Partition, PartitionKey, SequenceNumber};
 use generated_types::ingester::IngesterQueryRequest;
 use iox_time::{SystemProvider, TimeProvider};
 use metric::{DurationHistogram, U64Counter, U64Gauge};
@@ -116,4 +117,305 @@ async fn test_write_query() {
         .fetch();
     let now = SystemProvider::new().now();
     assert!(metric < now.timestamp_nanos() as _);
+}
+
+// Ensure an ingester correctly seeks to the offset stored in the catalog at
+// startup, skipping any empty offsets.
+#[tokio::test]
+async fn test_seek_on_init() {
+    let mut ctx = TestContext::new().await;
+
+    // Place some writes into the write buffer.
+
+    let partition_key = PartitionKey::from("1970-01-01");
+
+    ctx.ensure_namespace("test_namespace").await;
+    ctx.write_lp(
+        "test_namespace",
+        "bananas greatness=\"unbounded\" 10",
+        partition_key.clone(),
+        0,
+    )
+    .await;
+
+    // A subsequent write with a non-contiguous sequence number to a different
+    // table.
+    //
+    // Resuming will be configured against an offset in the middle of the two
+    // ranges.
+    let w2 = ctx
+        .write_lp(
+            "test_namespace",
+            "bananas greatness=\"amazing\",platanos=42 20",
+            partition_key.clone(),
+            7,
+        )
+        .await;
+
+    // Wait for the writes to be processed.
+    ctx.wait_for_readable(w2).await;
+
+    // Assert the data in memory.
+    let data = ctx
+        .query(IngesterQueryRequest {
+            namespace: "test_namespace".to_string(),
+            table: "bananas".to_string(),
+            columns: vec![],
+            predicate: None,
+        })
+        .await
+        .expect("query should succeed")
+        .into_record_batches()
+        .await;
+
+    let expected = vec![
+        "+-----------+----------+--------------------------------+",
+        "| greatness | platanos | time                           |",
+        "+-----------+----------+--------------------------------+",
+        "| amazing   | 42       | 1970-01-01T00:00:00.000000020Z |",
+        "| unbounded |          | 1970-01-01T00:00:00.000000010Z |",
+        "+-----------+----------+--------------------------------+",
+    ];
+    assert_batches_sorted_eq!(&expected, &data);
+
+    // Update the catalog state, causing the next boot of the ingester to seek
+    // past the first write, but before the second write.
+    ctx.catalog()
+        .repositories()
+        .await
+        .shards()
+        .update_min_unpersisted_sequence_number(ctx.shard_id(), SequenceNumber::new(3))
+        .await
+        .expect("failed to update persisted marker");
+
+    // Restart the ingester.
+    ctx.restart().await;
+
+    // Wait for the second write to become readable again.
+    ctx.wait_for_readable(w2).await;
+
+    // Assert the data in memory now contains only w2.
+    let data = ctx
+        .query(IngesterQueryRequest {
+            namespace: "test_namespace".to_string(),
+            table: "bananas".to_string(),
+            columns: vec![],
+            predicate: None,
+        })
+        .await
+        .expect("query should succeed")
+        .into_record_batches()
+        .await;
+
+    let expected = vec![
+        "+-----------+----------+--------------------------------+",
+        "| greatness | platanos | time                           |",
+        "+-----------+----------+--------------------------------+",
+        "| amazing   | 42       | 1970-01-01T00:00:00.000000020Z |",
+        "+-----------+----------+--------------------------------+",
+    ];
+    assert_batches_sorted_eq!(&expected, &data);
+}
+
+// Ensure an ingester respects the per-partition persist watermark, skipping
+// already applied ops.
+#[tokio::test]
+async fn test_skip_previously_applied_partition_ops() {
+    let mut ctx = TestContext::new().await;
+
+    // Place some writes into the write buffer.
+    let ns = ctx.ensure_namespace("test_namespace").await;
+    let partition_key = PartitionKey::from("1970-01-01");
+    ctx.write_lp(
+        "test_namespace",
+        "bananas greatness=\"unbounded\" 10",
+        partition_key.clone(),
+        5,
+    )
+    .await;
+    let w2 = ctx
+        .write_lp(
+            "test_namespace",
+            "bananas greatness=\"amazing\",platanos=42 20",
+            partition_key.clone(),
+            10,
+        )
+        .await;
+
+    // Wait for the writes to be processed.
+    ctx.wait_for_readable(w2).await;
+
+    // Assert the data in memory.
+    let data = ctx
+        .query(IngesterQueryRequest {
+            namespace: "test_namespace".to_string(),
+            table: "bananas".to_string(),
+            columns: vec![],
+            predicate: None,
+        })
+        .await
+        .expect("query should succeed")
+        .into_record_batches()
+        .await;
+
+    let expected = vec![
+        "+-----------+----------+--------------------------------+",
+        "| greatness | platanos | time                           |",
+        "+-----------+----------+--------------------------------+",
+        "| amazing   | 42       | 1970-01-01T00:00:00.000000020Z |",
+        "| unbounded |          | 1970-01-01T00:00:00.000000010Z |",
+        "+-----------+----------+--------------------------------+",
+    ];
+    assert_batches_sorted_eq!(&expected, &data);
+
+    // Read the partition ID of the writes above.
+    let partitions = ctx
+        .catalog()
+        .repositories()
+        .await
+        .partitions()
+        .list_by_namespace(ns.id)
+        .await
+        .unwrap();
+    assert_matches!(&*partitions, &[Partition { .. }]);
+
+    // And set the per-partition persist marker after the first write, but
+    // before the second.
+    ctx.catalog()
+        .repositories()
+        .await
+        .partitions()
+        .update_persisted_sequence_number(partitions[0].id, SequenceNumber::new(6))
+        .await
+        .expect("failed to update persisted marker");
+
+    // Restart the ingester, which shall seek to the shard offset of 0, and
+    // begin replaying ops.
+    ctx.restart().await;
+
+    // Wait for the second write to become readable again.
+    ctx.wait_for_readable(w2).await;
+
+    // Assert the partition replay skipped the first write.
+    let data = ctx
+        .query(IngesterQueryRequest {
+            namespace: "test_namespace".to_string(),
+            table: "bananas".to_string(),
+            columns: vec![],
+            predicate: None,
+        })
+        .await
+        .expect("query should succeed")
+        .into_record_batches()
+        .await;
+
+    let expected = vec![
+        "+-----------+----------+--------------------------------+",
+        "| greatness | platanos | time                           |",
+        "+-----------+----------+--------------------------------+",
+        "| amazing   | 42       | 1970-01-01T00:00:00.000000020Z |",
+        "+-----------+----------+--------------------------------+",
+    ];
+    assert_batches_sorted_eq!(&expected, &data);
+}
+
+// Ensure a seek beyond the actual data available (i.e. into the future) causes
+// a panic to bring about a human response.
+#[tokio::test]
+#[should_panic = "attempted to seek to offset 42, but current high watermark for partition 0 is 0"]
+async fn test_seek_beyond_available_data() {
+    let mut ctx = TestContext::new().await;
+
+    // Place a write into the write buffer so it is not empty.
+    ctx.ensure_namespace("test_namespace").await;
+    ctx.write_lp(
+        "test_namespace",
+        "bananas greatness=\"unbounded\" 10",
+        PartitionKey::from("1970-01-01"),
+        0,
+    )
+    .await;
+
+    // Update the catalog state, causing the next boot of the ingester to seek
+    // past the write, beyond valid data offsets.
+    ctx.catalog()
+        .repositories()
+        .await
+        .shards()
+        .update_min_unpersisted_sequence_number(ctx.shard_id(), SequenceNumber::new(42))
+        .await
+        .expect("failed to update persisted marker");
+
+    // Restart the ingester.
+    ctx.restart().await;
+}
+
+// Ensure an ingester configured to resume from offset 1 correctly seeks to the
+// oldest available data when that offset no longer exists.
+#[tokio::test]
+async fn test_seek_dropped_offset() {
+    let mut ctx = TestContext::new().await;
+
+    // Place a write into the write buffer so it is not empty.
+    ctx.ensure_namespace("test_namespace").await;
+
+    // A write at offset 42
+    let w1 = ctx
+        .write_lp(
+            "test_namespace",
+            "bananas greatness=\"unbounded\" 10",
+            PartitionKey::from("1970-01-01"),
+            42,
+        )
+        .await;
+
+    // Configure the ingester to seek to offset 1, which does not exist.
+    ctx.catalog()
+        .repositories()
+        .await
+        .shards()
+        .update_min_unpersisted_sequence_number(ctx.shard_id(), SequenceNumber::new(1))
+        .await
+        .expect("failed to update persisted marker");
+
+    // Restart the ingester.
+    ctx.restart().await;
+
+    // Wait for the op to be applied
+    ctx.wait_for_readable(w1).await;
+
+    // Assert the data in memory now contains only w2.
+    let data = ctx
+        .query(IngesterQueryRequest {
+            namespace: "test_namespace".to_string(),
+            table: "bananas".to_string(),
+            columns: vec![],
+            predicate: None,
+        })
+        .await
+        .expect("query should succeed")
+        .into_record_batches()
+        .await;
+
+    let expected = vec![
+        "+-----------+--------------------------------+",
+        "| greatness | time                           |",
+        "+-----------+--------------------------------+",
+        "| unbounded | 1970-01-01T00:00:00.000000010Z |",
+        "+-----------+--------------------------------+",
+    ];
+    assert_batches_sorted_eq!(&expected, &data);
+
+    // Ensure the metric was set to cause an alert for potential data loss.
+    let metric = ctx
+        .get_metric::<U64Counter, _>(
+            "shard_reset_count",
+            &[
+                ("kafka_topic", TEST_TOPIC_NAME),
+                ("kafka_partition", "0"),
+                ("potential_data_loss", "true"),
+            ],
+        )
+        .fetch();
+    assert!(metric > 0);
 }

--- a/ingester/tests/write.rs
+++ b/ingester/tests/write.rs
@@ -1,0 +1,119 @@
+mod common;
+
+use arrow_util::assert_batches_sorted_eq;
+pub use common::*;
+use data_types::PartitionKey;
+use generated_types::ingester::IngesterQueryRequest;
+use iox_time::{SystemProvider, TimeProvider};
+use metric::{DurationHistogram, U64Counter, U64Gauge};
+
+// Write data to an ingester through the write buffer interface, utilise the
+// progress API to wait for it to become readable, and finally query the data
+// and validate the contents.
+#[tokio::test]
+async fn test_write_query() {
+    let mut ctx = TestContext::new().await;
+
+    ctx.ensure_namespace("test_namespace").await;
+
+    // Initial write
+    let partition_key = PartitionKey::from("1970-01-01");
+    ctx.write_lp(
+        "test_namespace",
+        "bananas greatness=\"unbounded\" 10",
+        partition_key.clone(),
+        0,
+    )
+    .await;
+
+    // A subsequent write with a non-contiguous sequence number to a different table.
+    ctx.write_lp(
+        "test_namespace",
+        "cpu bar=2 20\ncpu bar=3 30",
+        partition_key.clone(),
+        7,
+    )
+    .await;
+
+    // And a third write that appends more data to the table in the initial
+    // write.
+    let offset = ctx
+        .write_lp(
+            "test_namespace",
+            "bananas count=42 200",
+            partition_key.clone(),
+            42,
+        )
+        .await;
+
+    ctx.wait_for_readable(offset).await;
+
+    // Perform a query to validate the actual data buffered.
+    let data = ctx
+        .query(IngesterQueryRequest {
+            namespace: "test_namespace".to_string(),
+            table: "bananas".to_string(),
+            columns: vec![],
+            predicate: None,
+        })
+        .await
+        .expect("query should succeed")
+        .into_record_batches()
+        .await;
+
+    let expected = vec![
+        "+-------+-----------+--------------------------------+",
+        "| count | greatness | time                           |",
+        "+-------+-----------+--------------------------------+",
+        "|       | unbounded | 1970-01-01T00:00:00.000000010Z |",
+        "| 42    |           | 1970-01-01T00:00:00.000000200Z |",
+        "+-------+-----------+--------------------------------+",
+    ];
+    assert_batches_sorted_eq!(&expected, &data);
+
+    // Assert various ingest metrics.
+    let hist = ctx
+        .get_metric::<DurationHistogram, _>(
+            "ingester_op_apply_duration",
+            &[
+                ("kafka_topic", TEST_TOPIC_NAME),
+                ("kafka_partition", "0"),
+                ("result", "success"),
+            ],
+        )
+        .fetch();
+    assert_eq!(hist.sample_count(), 3);
+
+    let metric = ctx
+        .get_metric::<U64Counter, _>(
+            "ingester_write_buffer_read_bytes",
+            &[("kafka_topic", TEST_TOPIC_NAME), ("kafka_partition", "0")],
+        )
+        .fetch();
+    assert_eq!(metric, 150);
+
+    let metric = ctx
+        .get_metric::<U64Gauge, _>(
+            "ingester_write_buffer_last_sequence_number",
+            &[("kafka_topic", TEST_TOPIC_NAME), ("kafka_partition", "0")],
+        )
+        .fetch();
+    assert_eq!(metric, 42);
+
+    let metric = ctx
+        .get_metric::<U64Gauge, _>(
+            "ingester_write_buffer_sequence_number_lag",
+            &[("kafka_topic", TEST_TOPIC_NAME), ("kafka_partition", "0")],
+        )
+        .fetch();
+    assert_eq!(metric, 0);
+
+    let metric = ctx
+        .get_metric::<U64Gauge, _>(
+            "ingester_write_buffer_last_ingest_ts",
+            &[("kafka_topic", TEST_TOPIC_NAME), ("kafka_partition", "0")],
+        )
+        .fetch();
+    let now = SystemProvider::new().now();
+    assert!(metric < now.timestamp_nanos() as _);
+}


### PR DESCRIPTION
This PR serves three purposes:

* Create a reusable, easy-to-use test harness for ingester integration tests that allows easy writing and querying of data, and asserting of alert-able metrics so that adding new tests is low-friction - the easier they are to write, the more that will be wrote!
* Add sufficient tests to guard against any breakage in upcoming PRs that significantly refactors the way data is buffered/snapshot'ed and bubbled up to queries by driving all external APIs.
* Replace some tests that are very tightly coupled to how data is currently stored in the ingester, which will change with the above referenced PRs anyway.

---
* refactor: impl converting IngesterQueryResponse (d0b546109)

      An existing function to map the complex IngesterQueryResponse type to a
      simple set of RecordBatch existed in test code - this has been lifted
      onto an inherent method on the response type itself for reuse.

* test(ingester): add integration TestContext (b12d472a1)

      Adds a test helper type that maintains the in-memory state for a single
      ingester integration test, and provides easy-to-use methods to
      manipulate and inspect the ingester instance.

* test: write, query & progress API coverage (7729494f6)

      This commit adds a new test that exercises all major external APIs of
      the ingester:
      
          * Writing data via the write buffer
          * Waiting for data to be readable via the progress API
          * Querying data and and asserting the contents
      
      This should provide basic integration coverage for the Ingester
      internals. This commit also removes a similar test (though with less
      coverage) that was tightly coupled to the existing buffering structures.

* test: write buffer seeking tests (40f1937e6)

      Asserts write buffer seeking behaviour, including:
      
          * Seeking past already persisted data correctly
          * Skipping to next available op in non-contiguous offset stream
          * Skipping to next available op for dropped ops due to retention
          * Panics when seeking beyond available data (into the future)
      
      Removes a pair of tests that covered some of the above due to their
      tight coupling with ingester internals.

* refactor: more verbose shard reset logs (0c0a38c48)

      Adds a little more context to the "shard reset" logs.

