### PR TITLE
fix: Compactor skipped_at is in seconds, not nanoseconds oops

### DIFF
--- a/influxdb_iox/src/commands/debug/skipped_compactions.rs
+++ b/influxdb_iox/src/commands/debug/skipped_compactions.rs
@@ -79,7 +79,7 @@ fn create_table(skipped_compactions: &[SkippedCompaction]) -> Table {
     table.set_header(headers);
 
     for skipped_compaction in skipped_compactions {
-        let timestamp = Time::from_timestamp_nanos(skipped_compaction.skipped_at);
+        let timestamp = Time::from_timestamp(skipped_compaction.skipped_at, 0);
 
         table.add_row(vec![
             Cell::new(skipped_compaction.partition_id.to_string()),


### PR DESCRIPTION
@NGA-TRAN just sent me some production output from the new skipped-compactions command and... I forgot that `skipped_at` hasn't been put through line protocol/etc and therefore is [postgres epoch seconds](https://github.com/influxdata/influxdb_iox/blob/95853aed1a0955e580fc9b96debc940c7eaf3e56/iox_catalog/src/postgres.rs#L1257) rather than nanoseconds 🤦🏻‍♀️ This should bring all the dates displayed back to the present day 😜 

![doc brown saying "to the future"](https://user-images.githubusercontent.com/193874/197286878-6ec75eca-c23e-4062-bf3c-5eb43474813d.gif)
