### PR TITLE
feat: Use workspace package metadata to reduce differences and repetion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4850,7 +4850,7 @@ dependencies = [
 
 [[package]]
 name = "sqlx-hotswap-pool"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "dotenvy",
  "either",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,6 +102,12 @@ exclude = [
     "tools/",
 ]
 
+[workspace.package]
+version = "0.1.0"
+authors = ["IOx Project Developers"]
+edition = "2021"
+license = "MIT OR Apache-2.0"
+
 # This profile optimizes for runtime performance and small binary size at the expense of longer
 # build times. It's most suitable for final release builds.
 [profile.release]

--- a/arrow_util/Cargo.toml
+++ b/arrow_util/Cargo.toml
@@ -1,9 +1,10 @@
 [package]
 name = "arrow_util"
-version = "0.1.0"
-authors = ["Andrew Lamb <andrew@nerdnetworks.org>"]
-edition = "2021"
 description = "Apache Arrow utilities"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [dependencies]
 ahash = { version = "0.8.0", default-features = false, features = ["runtime-rng"] }

--- a/backoff/Cargo.toml
+++ b/backoff/Cargo.toml
@@ -1,7 +1,9 @@
 [package]
 name = "backoff"
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [dependencies]
 tokio = { version = "1.21", features = ["macros", "time"] }

--- a/cache_system/Cargo.toml
+++ b/cache_system/Cargo.toml
@@ -1,7 +1,9 @@
 [package]
 name = "cache_system"
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [dependencies]
 async-trait = "0.1.58"

--- a/clap_blocks/Cargo.toml
+++ b/clap_blocks/Cargo.toml
@@ -1,7 +1,9 @@
 [package]
 name = "clap_blocks"
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [dependencies]
 clap = { version = "4", features = ["derive", "env"] }

--- a/client_util/Cargo.toml
+++ b/client_util/Cargo.toml
@@ -1,9 +1,10 @@
 [package]
 name = "client_util"
-version = "0.1.0"
-authors = ["Raphael Taylor-Davies <r.taylordavies@googlemail.com>"]
 description = "Shared code for IOx clients"
-edition = "2021"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [dependencies]
 http = "0.2.8"

--- a/compactor/Cargo.toml
+++ b/compactor/Cargo.toml
@@ -1,8 +1,9 @@
 [package]
 name = "compactor"
-version = "0.1.0"
-authors = ["Luke Bond <luke.n.bond@gmail.com>"]
-edition = "2021"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [dependencies]
 arrow = { version = "25.0.0", features = ["prettyprint"] }

--- a/data_types/Cargo.toml
+++ b/data_types/Cargo.toml
@@ -1,8 +1,10 @@
 [package]
 name = "data_types"
-version = "0.1.0"
-edition = "2021"
 description = "Shared data types"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [dependencies]
 influxdb_line_protocol = { path = "../influxdb_line_protocol" }

--- a/datafusion/Cargo.toml
+++ b/datafusion/Cargo.toml
@@ -1,9 +1,10 @@
 [package]
 name = "datafusion"
-version = "0.1.0"
-authors = ["Andrew Lamb <andrew@nerdnetworks.org>"]
-edition = "2021"
 description = "Re-exports datafusion at a specific version"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [dependencies]
 

--- a/datafusion_util/Cargo.toml
+++ b/datafusion_util/Cargo.toml
@@ -1,9 +1,10 @@
 [package]
 name = "datafusion_util"
-version = "0.1.0"
-authors = ["Andrew Lamb <andrew@nerdnetworks.org>"]
-edition = "2021"
 description = "Datafusion utilities"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [dependencies]
 async-trait = "0.1"

--- a/dml/Cargo.toml
+++ b/dml/Cargo.toml
@@ -1,8 +1,10 @@
 [package]
 name = "dml"
-version = "0.1.0"
-edition = "2021"
 description = "DML types"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [dependencies]
 arrow_util = { path = "../arrow_util" }

--- a/executor/Cargo.toml
+++ b/executor/Cargo.toml
@@ -1,7 +1,9 @@
 [package]
 name = "executor"
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [dependencies]
 futures = "0.3"

--- a/garbage_collector/Cargo.toml
+++ b/garbage_collector/Cargo.toml
@@ -1,7 +1,9 @@
 [package]
 name = "garbage_collector"
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [dependencies]
 chrono = { version = "0.4", default-features = false }

--- a/generated_types/Cargo.toml
+++ b/generated_types/Cargo.toml
@@ -1,8 +1,9 @@
 [package]
 name = "generated_types"
-version = "0.1.0"
-authors = ["Paul Dix <paul@pauldix.net>"]
-edition = "2021"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [dependencies] # In alphabetical order
 base64 = "0.13"

--- a/grpc-binary-logger-proto/Cargo.toml
+++ b/grpc-binary-logger-proto/Cargo.toml
@@ -1,8 +1,9 @@
 [package]
 name = "grpc-binary-logger-proto"
-version = "0.1.0"
-authors = ["Marko Mikulicic <mmikulicic@gmail.com>"]
-edition = "2021"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [dependencies]
 prost = "0.11"

--- a/grpc-binary-logger-test-proto/Cargo.toml
+++ b/grpc-binary-logger-test-proto/Cargo.toml
@@ -1,8 +1,9 @@
 [package]
 name = "grpc-binary-logger-test-proto"
-version = "0.1.0"
-authors = ["Marko Mikulicic <mmikulicic@gmail.com>"]
-edition = "2021"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [dependencies]
 prost = "0.11"

--- a/grpc-binary-logger/Cargo.toml
+++ b/grpc-binary-logger/Cargo.toml
@@ -1,8 +1,9 @@
 [package]
 name = "grpc-binary-logger"
-version = "0.1.0"
-authors = ["Marko Mikulicic <mmikulicic@gmail.com>"]
-edition = "2021"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [dependencies]
 base64 = "0.13"

--- a/import/Cargo.toml
+++ b/import/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "import"
-version = "0.1.0"
-edition = "2021"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [dependencies]
 clap_blocks = { path = "../clap_blocks" }

--- a/influxdb2_client/Cargo.toml
+++ b/influxdb2_client/Cargo.toml
@@ -1,8 +1,9 @@
 [package]
 name = "influxdb2_client"
-version = "0.1.0"
-authors = ["Paul Dix <paul@pauldix.net>"]
-edition = "2021"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [dependencies] # In alphabetical order
 bytes = "1.2"

--- a/influxdb_influxql_parser/Cargo.toml
+++ b/influxdb_influxql_parser/Cargo.toml
@@ -1,7 +1,9 @@
 [package]
 name = "influxdb_influxql_parser"
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [dependencies] # In alphabetical order
 nom = { version = "7", default-features = false, features = ["std"] }

--- a/influxdb_iox/Cargo.toml
+++ b/influxdb_iox/Cargo.toml
@@ -1,9 +1,10 @@
 [package]
 name = "influxdb_iox"
-version = "0.1.0"
-authors = ["Paul Dix <paul@pauldix.net>"]
-edition = "2021"
 default-run = "influxdb_iox"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [dependencies]
 # Workspace dependencies, in alphabetical order

--- a/influxdb_iox_client/Cargo.toml
+++ b/influxdb_iox_client/Cargo.toml
@@ -1,8 +1,9 @@
 [package]
 name = "influxdb_iox_client"
-version = "0.1.0"
-authors = ["Dom Dwyer <dom@itsallbroken.com>"]
-edition = "2021"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [features]
 default = ["flight", "format"]

--- a/influxdb_line_protocol/Cargo.toml
+++ b/influxdb_line_protocol/Cargo.toml
@@ -1,8 +1,9 @@
 [package]
 name = "influxdb_line_protocol"
-version = "0.1.0"
-authors = ["Paul Dix <paul@pauldix.net>"]
-edition = "2021"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [lib]
 crate-type = ["rlib", "staticlib"]

--- a/influxdb_storage_client/Cargo.toml
+++ b/influxdb_storage_client/Cargo.toml
@@ -1,8 +1,9 @@
 [package]
 name = "influxdb_storage_client"
-version = "0.1.0"
-authors = ["Raphael Taylor-Davies <r.taylordavies@googlemail.com>"]
-edition = "2021"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [dependencies]
 client_util = { path = "../client_util" }

--- a/influxdb_tsm/Cargo.toml
+++ b/influxdb_tsm/Cargo.toml
@@ -1,8 +1,9 @@
 [package]
 name = "influxdb_tsm"
-version = "0.1.0"
-authors = ["Edd Robinson <me@edd.io>"]
-edition = "2021"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [dependencies] # In alphabetical order
 integer-encoding = "3.0.4"

--- a/influxrpc_parser/Cargo.toml
+++ b/influxrpc_parser/Cargo.toml
@@ -1,7 +1,9 @@
 [package]
 name = "influxrpc_parser"
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [dependencies]
 sqlparser = "0.26.0"

--- a/ingester/Cargo.toml
+++ b/ingester/Cargo.toml
@@ -1,8 +1,9 @@
 [package]
 name = "ingester"
-version = "0.1.0"
-authors = ["Nga Tran <nga-tran@live.com>"]
-edition = "2021"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [dependencies]
 arrow = { version = "25.0.0", features = ["prettyprint"] }

--- a/iox_catalog/Cargo.toml
+++ b/iox_catalog/Cargo.toml
@@ -1,8 +1,9 @@
 [package]
 name = "iox_catalog"
-version = "0.1.0"
-authors = ["Paul Dix <paul@pauldix.net>"]
-edition = "2021"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [dependencies] # In alphabetical order
 async-trait = "0.1.58"

--- a/iox_data_generator/Cargo.toml
+++ b/iox_data_generator/Cargo.toml
@@ -1,9 +1,10 @@
 [package]
 name = "iox_data_generator"
-version = "0.1.0"
-authors = ["Paul Dix <paul@pauldix.net>"]
-edition = "2021"
 default-run = "iox_data_generator"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [dependencies]
 bytes = "1.2"

--- a/iox_query/Cargo.toml
+++ b/iox_query/Cargo.toml
@@ -1,9 +1,10 @@
 [package]
 name = "iox_query"
-version = "0.1.0"
-authors = ["Andrew Lamb <andrew@nerdnetworks.org>"]
-edition = "2021"
 description = "IOx Query Interface and Executor"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
 
 # This crate is designed to be independent of the rest of the IOx
 # server and specific storage systems such as Mutable Buffer and Read Buffer.

--- a/iox_tests/Cargo.toml
+++ b/iox_tests/Cargo.toml
@@ -1,9 +1,10 @@
 [package]
 name = "iox_tests"
-version = "0.1.0"
-authors = ["Nga Tran <nga-tran@live.com>"]
-edition = "2021"
 description = "IOx test utils and tests"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [dependencies]
 arrow = "25.0.0"

--- a/iox_time/Cargo.toml
+++ b/iox_time/Cargo.toml
@@ -1,8 +1,10 @@
 [package]
 name = "iox_time"
-version = "0.1.0"
-edition = "2021"
 description = "Time functionality for IOx"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [dependencies]
 chrono = { version = "0.4.22", default-features = false, features = ["clock", "std"] }

--- a/ioxd_common/Cargo.toml
+++ b/ioxd_common/Cargo.toml
@@ -1,7 +1,9 @@
 [package]
 name = "ioxd_common"
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
 
 # Optional feature 'pprof' enables http://localhost:8080/debug/pprof/profile support support
 

--- a/ioxd_compactor/Cargo.toml
+++ b/ioxd_compactor/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "ioxd_compactor"
-version = "0.1.0"
-edition = "2021"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [dependencies]
 # Workspace dependencies, in alphabetical order

--- a/ioxd_garbage_collector/Cargo.toml
+++ b/ioxd_garbage_collector/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "ioxd_garbage_collector"
-version = "0.1.0"
-edition = "2021"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [dependencies]
 async-trait = "0.1"

--- a/ioxd_ingester/Cargo.toml
+++ b/ioxd_ingester/Cargo.toml
@@ -1,7 +1,9 @@
 [package]
 name = "ioxd_ingester"
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [dependencies]
 # Workspace dependencies, in alphabetical order

--- a/ioxd_querier/Cargo.toml
+++ b/ioxd_querier/Cargo.toml
@@ -1,7 +1,9 @@
 [package]
 name = "ioxd_querier"
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [dependencies]
 # Workspace dependencies, in alphabetical order

--- a/ioxd_router/Cargo.toml
+++ b/ioxd_router/Cargo.toml
@@ -1,7 +1,9 @@
 [package]
 name = "ioxd_router"
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [dependencies]
 # Workspace dependencies, in alphabetical order

--- a/ioxd_test/Cargo.toml
+++ b/ioxd_test/Cargo.toml
@@ -1,16 +1,15 @@
 [package]
 name = "ioxd_test"
-version = "0.1.0"
-edition = "2021"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [dependencies]
 # Workspace dependencies, in alphabetical order
 ioxd_common = { path = "../ioxd_common" }
 metric = { path = "../metric" }
 trace = { path = "../trace" }
-
 
 # Crates.io dependencies, in alphabetical order
 async-trait = "0.1"

--- a/logfmt/Cargo.toml
+++ b/logfmt/Cargo.toml
@@ -1,9 +1,10 @@
 [package]
 name = "logfmt"
-version = "0.1.0"
-authors = ["Andrew Lamb <andrew@nerdnetworks.org>"]
 description = "tracing_subscriber layer for writing out logfmt formatted events"
-edition = "2021"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [dependencies] # In alphabetical order
 observability_deps = { path = "../observability_deps" }

--- a/metric/Cargo.toml
+++ b/metric/Cargo.toml
@@ -1,8 +1,9 @@
 [package]
 name = "metric"
-version = "0.1.0"
-authors = ["Raphael Taylor-Davies <r.taylordavies@googlemail.com>"]
-edition = "2021"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [dependencies] # In alphabetical order
 parking_lot = "0.12"

--- a/metric_exporters/Cargo.toml
+++ b/metric_exporters/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "metric_exporters"
-version = "0.1.0"
-authors = ["Raphael Taylor-Davies <r.taylordavies@googlemail.com>"]
-edition = "2021"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [dependencies] # In alphabetical order
-
 observability_deps = { path = "../observability_deps" }
 metric = { path = "../metric" }
 prometheus = { version = "0.13", default-features = false }

--- a/mutable_batch/Cargo.toml
+++ b/mutable_batch/Cargo.toml
@@ -1,8 +1,10 @@
 [package]
 name = "mutable_batch"
-version = "0.1.0"
-edition = "2021"
 description = "A mutable arrow RecordBatch"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [dependencies]
 arrow = { version = "25.0.0", features = ["prettyprint"] }

--- a/mutable_batch_lp/Cargo.toml
+++ b/mutable_batch_lp/Cargo.toml
@@ -1,8 +1,10 @@
 [package]
 name = "mutable_batch_lp"
-version = "0.1.0"
-edition = "2021"
 description = "Conversion logic for line protocol -> MutableBatch"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [dependencies]
 hashbrown = "0.12"

--- a/mutable_batch_pb/Cargo.toml
+++ b/mutable_batch_pb/Cargo.toml
@@ -1,8 +1,10 @@
 [package]
 name = "mutable_batch_pb"
-version = "0.1.0"
-edition = "2021"
 description = "Conversion logic for binary write protocol <-> MutableBatch"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [dependencies]
 arrow_util = { path = "../arrow_util" }

--- a/mutable_batch_tests/Cargo.toml
+++ b/mutable_batch_tests/Cargo.toml
@@ -1,8 +1,10 @@
 [package]
 name = "mutable_batch_tests"
-version = "0.1.0"
-edition = "2021"
 description = "MutableBatch integration tests and benchmarks"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [dependencies]
 dml = { path = "../dml" }

--- a/object_store_metrics/Cargo.toml
+++ b/object_store_metrics/Cargo.toml
@@ -1,8 +1,9 @@
 [package]
 name = "object_store_metrics"
-version = "0.1.0"
-authors = ["Paul Dix <paul@pauldix.net>"]
-edition = "2021"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [dependencies] # In alphabetical order
 async-trait = "0.1.58"

--- a/observability_deps/Cargo.toml
+++ b/observability_deps/Cargo.toml
@@ -1,9 +1,10 @@
 [package]
 name = "observability_deps"
-version = "0.1.0"
-authors = ["Paul Dix <paul@pauldix.net>"]
-edition = "2021"
 description = "Observability ecosystem dependencies for InfluxDB IOx, to ensure consistent versions and unified updates"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [dependencies] # In alphabetical order
 tracing = { version = "0.1", features = ["max_level_trace"] }

--- a/panic_logging/Cargo.toml
+++ b/panic_logging/Cargo.toml
@@ -1,8 +1,9 @@
 [package]
 name = "panic_logging"
-version = "0.1.0"
-authors = ["Paul Dix <paul@pauldix.net>"]
-edition = "2021"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [dependencies] # In alphabetical order
 metric = { path = "../metric" }

--- a/parquet_file/Cargo.toml
+++ b/parquet_file/Cargo.toml
@@ -1,8 +1,9 @@
 [package]
 name = "parquet_file"
-version = "0.1.0"
-authors = ["Nga Tran <nga-tran@live.com>"]
-edition = "2021"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [dependencies] # In alphabetical order
 arrow = { version = "25.0.0", features = ["prettyprint"] }

--- a/parquet_to_line_protocol/Cargo.toml
+++ b/parquet_to_line_protocol/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "parquet_to_line_protocol"
-version = "0.1.0"
-edition = "2021"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [dependencies]
 datafusion = { path = "../datafusion" }

--- a/predicate/Cargo.toml
+++ b/predicate/Cargo.toml
@@ -1,7 +1,9 @@
 [package]
 name = "predicate"
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [dependencies]
 arrow = { version = "25.0.0", features = ["prettyprint"] }

--- a/querier/Cargo.toml
+++ b/querier/Cargo.toml
@@ -1,7 +1,9 @@
 [package]
 name = "querier"
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [dependencies]
 arrow = "25.0.0"

--- a/query_functions/Cargo.toml
+++ b/query_functions/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "query_functions"
-version = "0.1.0"
-edition = "2021"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [dependencies]
 arrow = { version = "25.0.0", features = ["prettyprint"] }

--- a/query_tests/Cargo.toml
+++ b/query_tests/Cargo.toml
@@ -1,9 +1,10 @@
 [package]
 name = "query_tests"
-version = "0.1.0"
-authors = ["Andrew Lamb <andrew@nerdnetworks.org>"]
-edition = "2021"
 description = "Tests of the query engine against different database configurations"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [dependencies]
 arrow = { version = "25.0.0", features = ["prettyprint"] }

--- a/router/Cargo.toml
+++ b/router/Cargo.toml
@@ -1,7 +1,9 @@
 [package]
 name = "router"
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [dependencies]
 async-trait = "0.1"

--- a/schema/Cargo.toml
+++ b/schema/Cargo.toml
@@ -1,9 +1,10 @@
 [package]
 name = "schema"
-version = "0.1.0"
-authors = ["Andrew Lamb <andrew@nerdnetworks.org>"]
-edition = "2021"
 description = "IOx Schema definition"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [dependencies]
 arrow = { version = "25.0.0", features = ["prettyprint"] }

--- a/service_common/Cargo.toml
+++ b/service_common/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "service_common"
-version = "0.1.0"
-edition = "2021"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [dependencies]
 # Workspace dependencies, in alphabetical order

--- a/service_grpc_catalog/Cargo.toml
+++ b/service_grpc_catalog/Cargo.toml
@@ -1,7 +1,9 @@
 [package]
 name = "service_grpc_catalog"
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [dependencies]
 data_types = { path = "../data_types" }

--- a/service_grpc_flight/Cargo.toml
+++ b/service_grpc_flight/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "service_grpc_flight"
-version = "0.1.0"
-edition = "2021"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [dependencies]
 # Workspace dependencies, in alphabetical order

--- a/service_grpc_influxrpc/Cargo.toml
+++ b/service_grpc_influxrpc/Cargo.toml
@@ -1,7 +1,9 @@
 [package]
 name = "service_grpc_influxrpc"
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [dependencies]
 # Workspace dependencies, in alphabetical order

--- a/service_grpc_object_store/Cargo.toml
+++ b/service_grpc_object_store/Cargo.toml
@@ -1,7 +1,9 @@
 [package]
 name = "service_grpc_object_store"
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [dependencies]
 data_types = { path = "../data_types" }

--- a/service_grpc_schema/Cargo.toml
+++ b/service_grpc_schema/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "service_grpc_schema"
-version = "0.1.0"
-edition = "2021"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [dependencies]
 data_types = { path = "../data_types" }

--- a/service_grpc_testing/Cargo.toml
+++ b/service_grpc_testing/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "service_grpc_testing"
-version = "0.1.0"
-edition = "2021"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [dependencies]
 generated_types = { path = "../generated_types" }

--- a/sharder/Cargo.toml
+++ b/sharder/Cargo.toml
@@ -1,7 +1,9 @@
 [package]
 name = "sharder"
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [dependencies]
 data_types = { path = "../data_types" }

--- a/sqlx-hotswap-pool/Cargo.toml
+++ b/sqlx-hotswap-pool/Cargo.toml
@@ -1,9 +1,10 @@
 [package]
 name = "sqlx-hotswap-pool"
-authors = ["Marko Mikulicic <mkm@influxdata.com>"]
-version = "0.0.0"
-edition = "2021"
 description = "Workaround for the lack of dyanmic credential update support in sqlx"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
 
 # Prevent this from being published to crates.io!
 publish = false

--- a/test_helpers/Cargo.toml
+++ b/test_helpers/Cargo.toml
@@ -1,8 +1,9 @@
 [package]
 name = "test_helpers"
-version = "0.1.0"
-authors = ["Paul Dix <paul@pauldix.net>"]
-edition = "2021"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [dependencies] # In alphabetical order
 dotenvy = "0.15.6"

--- a/test_helpers_end_to_end/Cargo.toml
+++ b/test_helpers_end_to_end/Cargo.toml
@@ -1,7 +1,9 @@
 [package]
 name = "test_helpers_end_to_end"
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [dependencies] # In alphabetical order
 arrow = { version = "25.0.0", features = ["prettyprint"] }

--- a/trace/Cargo.toml
+++ b/trace/Cargo.toml
@@ -1,9 +1,10 @@
 [package]
 name = "trace"
-version = "0.1.0"
-authors = ["Raphael Taylor-Davies <r.taylordavies@googlemail.com>"]
-edition = "2021"
 description = "Distributed tracing support within IOx"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [dependencies]
 chrono = { version = "0.4", default-features = false }

--- a/trace_exporters/Cargo.toml
+++ b/trace_exporters/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "trace_exporters"
-version = "0.1.0"
-authors = ["Raphael Taylor-Davies <r.taylordavies@googlemail.com>"]
-edition = "2021"
 description = "Additional tracing exporters for IOx"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [dependencies]
-
 async-trait = "0.1"
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 clap = { version = "4", features = ["derive", "env"] }

--- a/trace_http/Cargo.toml
+++ b/trace_http/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "trace_http"
-version = "0.1.0"
-authors = ["Raphael Taylor-Davies <r.taylordavies@googlemail.com>"]
-edition = "2021"
 description = "Distributed tracing support for HTTP services"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [dependencies]
-
 trace = { path = "../trace" }
 futures = "0.3"
 hashbrown = "0.12"

--- a/tracker/Cargo.toml
+++ b/tracker/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "tracker"
-version = "0.1.0"
-authors = ["Raphael Taylor-Davies <r.taylordavies@googlemail.com>"]
-edition = "2021"
 description = "Utilities for tracking resource utilisation within IOx"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [dependencies]
-
 futures = "0.3"
 hashbrown = "0.12"
 lock_api = "0.4.9"

--- a/trogging/Cargo.toml
+++ b/trogging/Cargo.toml
@@ -1,11 +1,10 @@
 [package]
 name = "trogging"
-version = "0.1.0"
-authors = ["Marko Mikulicic <mkm@influxdata.com>"]
-edition = "2021"
 description = "IOx logging pipeline built upon tokio-tracing"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [dependencies]
 atty = "0.2.14"

--- a/workspace-hack/Cargo.toml
+++ b/workspace-hack/Cargo.toml
@@ -4,9 +4,12 @@
 
 [package]
 name = "workspace-hack"
-version = "0.1.0"
 description = "workspace-hack package, managed by hakari"
 publish = false
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
 
 # The parts of the file between the BEGIN HAKARI SECTION and END HAKARI SECTION comments
 # are managed by hakari.

--- a/write_buffer/Cargo.toml
+++ b/write_buffer/Cargo.toml
@@ -1,7 +1,9 @@
 [package]
 name = "write_buffer"
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [dependencies]
 async-trait = "0.1"

--- a/write_summary/Cargo.toml
+++ b/write_summary/Cargo.toml
@@ -1,7 +1,9 @@
 [package]
 name = "write_summary"
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [dependencies]
 base64 = "0.13"


### PR DESCRIPTION
This is a low-priority enhancement that will save future work.

[Rust 1.64 stabilized workspace inheritance](https://blog.rust-lang.org/2022/09/22/Rust-1.64.0.html#cargo-improvements-workspace-inheritance-and-multi-target-builds), and one of the pieces of that is [inheriting `package` keys](https://doc.rust-lang.org/cargo/reference/workspaces.html#the-package-table).

This PR makes all Cargo.toml files consistent and inherit the version, authors, edition, and license keys from the workspace's Cargo.toml. This will save time in the future when changing metadata like the edition, so that the whole workspace can be updated by changing the value in one place.

I'm happy to close this or undo parts of this if it isn't desired!