### PR TITLE
feat: MVP of remote store get-table command

### DIFF
--- a/generated_types/protos/influxdata/iox/catalog/v1/service.proto
+++ b/generated_types/protos/influxdata/iox/catalog/v1/service.proto
@@ -10,6 +10,9 @@ service CatalogService {
 
     // Get the partition catalog records by the table id
     rpc GetPartitionsByTableId(GetPartitionsByTableIdRequest) returns (GetPartitionsByTableIdResponse);
+
+    // Get the parquet_file catalog records in the given database and table name
+    rpc GetParquetFilesByDatabaseTable(GetParquetFilesByDatabaseTableRequest) returns (GetParquetFilesByDatabaseTableResponse);
 }
 
 message GetParquetFilesByPartitionIdRequest {
@@ -46,4 +49,17 @@ message GetPartitionsByTableIdRequest {
 
 message GetPartitionsByTableIdResponse {
     repeated Partition partitions = 1;
+}
+
+message GetParquetFilesByDatabaseTableRequest {
+    // the database name
+    string database_name = 1;
+
+    // the table name in the database
+    string table_name = 2;
+}
+
+message GetParquetFilesByDatabaseTableResponse {
+    // the parquet_file records in the table in the database
+    repeated ParquetFile parquet_files = 1;
 }

--- a/influxdb_iox/src/commands/remote.rs
+++ b/influxdb_iox/src/commands/remote.rs
@@ -29,12 +29,12 @@ pub struct Config {
     command: Command,
 }
 
-/// All possible subcommands for catalog
+/// All possible subcommands for remote
 #[derive(Debug, clap::Parser)]
 enum Command {
     /// Get partition data
     Partition(partition::Config),
-    /// Get parquet files from the object store
+    /// Get Parquet files from the object store
     Store(store::Config),
 }
 

--- a/influxdb_iox/src/commands/remote/store.rs
+++ b/influxdb_iox/src/commands/remote/store.rs
@@ -41,13 +41,14 @@ struct Get {
 }
 
 /// Get all the Parquet files for a particular database's table
+/// into a local directory
 #[derive(Debug, clap::Parser)]
 struct GetTable {
     /// The database (namespace) to get the Parquet files for
     #[clap(action)]
     database: String,
 
-    /// The table to get the Parquet files for
+    /// The name of the table to get the Parquet files for
     #[clap(action)]
     table: String,
 }

--- a/influxdb_iox/tests/end_to_end_cases/cli.rs
+++ b/influxdb_iox/tests/end_to_end_cases/cli.rs
@@ -1,9 +1,9 @@
 //! Tests CLI commands
 
+use super::get_object_store_id;
 use assert_cmd::Command;
 use futures::FutureExt;
 use predicates::prelude::*;
-use serde_json::Value;
 use std::time::{Duration, Instant};
 use tempfile::tempdir;
 use test_helpers_end_to_end::{
@@ -50,143 +50,6 @@ async fn default_run_mode_is_all_in_one() {
         .assert()
         .failure()
         .stdout(predicate::str::contains("starting all in one server"));
-}
-
-/// remote partition command and getting a parquet file from the object store and pulling the files
-#[tokio::test]
-async fn remote_partition_and_get_from_store_and_pull() {
-    test_helpers::maybe_start_logging();
-    let database_url = maybe_skip_integration!();
-
-    // The test below assumes a specific partition id, so use a
-    // non-shared one here so concurrent tests don't interfere with
-    // each other
-    let mut cluster = MiniCluster::create_non_shared_standard(database_url).await;
-
-    StepTest::new(
-        &mut cluster,
-        vec![
-            Step::WriteLineProtocol(String::from(
-                "my_awesome_table,tag1=A,tag2=B val=42i 123456",
-            )),
-            // wait for partitions to be persisted
-            Step::WaitForPersisted,
-            // Run the 'remote partition' command
-            Step::Custom(Box::new(|state: &mut StepTestState| {
-                async {
-                    let router_addr = state.cluster().router().router_grpc_base().to_string();
-                    let namespace = state.cluster().namespace().to_string();
-
-                    // Validate the output of the remote partition CLI command
-                    //
-                    // Looks like:
-                    // {
-                    //     "id": "1",
-                    //     "shardId": 1,
-                    //     "namespaceId": 1,
-                    //     "tableId": 1,
-                    //     "partitionId": "1",
-                    //     "objectStoreId": "fa6cdcd1-cbc2-4fb7-8b51-4773079124dd",
-                    //     "minTime": "123456",
-                    //     "maxTime": "123456",
-                    //     "fileSizeBytes": "2029",
-                    //     "rowCount": "1",
-                    //     "createdAt": "1650019674289347000"
-                    // }
-
-                    let out = Command::cargo_bin("influxdb_iox")
-                        .unwrap()
-                        .arg("-h")
-                        .arg(&router_addr)
-                        .arg("remote")
-                        .arg("partition")
-                        .arg("show")
-                        .arg("1")
-                        .assert()
-                        .success()
-                        .stdout(
-                            predicate::str::contains(r#""id": "1""#)
-                                .and(predicate::str::contains(r#""shardId": "1","#))
-                                .and(predicate::str::contains(r#""partitionId": "1","#)),
-                        )
-                        .get_output()
-                        .stdout
-                        .clone();
-
-                    let object_store_id = get_object_store_id(&out);
-
-                    let dir = tempdir().unwrap();
-                    let f = dir.path().join("tmp.parquet");
-                    let filename = f.as_os_str().to_str().unwrap();
-
-                    Command::cargo_bin("influxdb_iox")
-                        .unwrap()
-                        .arg("-h")
-                        .arg(&router_addr)
-                        .arg("remote")
-                        .arg("store")
-                        .arg("get")
-                        .arg(&object_store_id)
-                        .arg(filename)
-                        .assert()
-                        .success()
-                        .stdout(
-                            predicate::str::contains("wrote")
-                                .and(predicate::str::contains(filename)),
-                        );
-
-                    // Ensure a warning is emitted when specifying (or
-                    // defaulting to) in-memory file storage.
-                    Command::cargo_bin("influxdb_iox")
-                        .unwrap()
-                        .arg("-h")
-                        .arg(&router_addr)
-                        .arg("remote")
-                        .arg("partition")
-                        .arg("pull")
-                        .arg("--catalog")
-                        .arg("memory")
-                        .arg("--object-store")
-                        .arg("memory")
-                        .arg(&namespace)
-                        .arg("my_awesome_table")
-                        .arg("1970-01-01")
-                        .assert()
-                        .failure()
-                        .stderr(predicate::str::contains("try passing --object-store=file"));
-
-                    // Ensure files are actually wrote to the filesystem
-                    let dir = tempfile::tempdir().expect("could not get temporary directory");
-
-                    Command::cargo_bin("influxdb_iox")
-                        .unwrap()
-                        .arg("-h")
-                        .arg(&router_addr)
-                        .arg("remote")
-                        .arg("partition")
-                        .arg("pull")
-                        .arg("--catalog")
-                        .arg("memory")
-                        .arg("--object-store")
-                        .arg("file")
-                        .arg("--data-dir")
-                        .arg(dir.path().to_str().unwrap())
-                        .arg(&namespace)
-                        .arg("my_awesome_table")
-                        .arg("1970-01-01")
-                        .assert()
-                        .success()
-                        .stdout(
-                            predicate::str::contains("wrote file")
-                                .and(predicate::str::contains(&object_store_id)),
-                        );
-                }
-                .boxed()
-            })),
-        ],
-    )
-    .run()
-    .await
 }
 
 #[tokio::test]
@@ -808,29 +671,4 @@ async fn query_ingester() {
     )
     .run()
     .await
-}
-
-/// extracts the parquet filename from JSON that looks like
-/// ```text
-/// {
-///    "id": "1",
-///    ...
-//     "objectStoreId": "fa6cdcd1-cbc2-4fb7-8b51-4773079124dd",
-///    ...
-/// }
-/// ```
-fn get_object_store_id(output: &[u8]) -> String {
-    let v: Value = serde_json::from_slice(output).unwrap();
-    // We only process the first value, so panic if it isn't there
-    let arr = v.as_array().unwrap();
-    assert_eq!(arr.len(), 1);
-    let id = arr[0]
-        .as_object()
-        .unwrap()
-        .get("objectStoreId")
-        .unwrap()
-        .as_str()
-        .unwrap();
-
-    id.to_string()
 }

--- a/influxdb_iox/tests/end_to_end_cases/mod.rs
+++ b/influxdb_iox/tests/end_to_end_cases/mod.rs
@@ -11,5 +11,31 @@ mod logging;
 mod metrics;
 mod namespace;
 mod querier;
+mod remote;
 mod schema;
 mod tracing;
+
+/// extracts the parquet filename from JSON that looks like
+/// ```text
+/// {
+///    "id": "1",
+///    ...
+//     "objectStoreId": "fa6cdcd1-cbc2-4fb7-8b51-4773079124dd",
+///    ...
+/// }
+/// ```
+fn get_object_store_id(output: &[u8]) -> String {
+    let v: serde_json::Value = serde_json::from_slice(output).unwrap();
+    // We only process the first value, so panic if it isn't there
+    let arr = v.as_array().unwrap();
+    assert_eq!(arr.len(), 1);
+    let id = arr[0]
+        .as_object()
+        .unwrap()
+        .get("objectStoreId")
+        .unwrap()
+        .as_str()
+        .unwrap();
+
+    id.to_string()
+}

--- a/influxdb_iox/tests/end_to_end_cases/remote.rs
+++ b/influxdb_iox/tests/end_to_end_cases/remote.rs
@@ -1,0 +1,150 @@
+//! Tests the `influxdb_iox remote` commands
+
+use super::get_object_store_id;
+use assert_cmd::Command;
+use futures::FutureExt;
+use predicates::prelude::*;
+use tempfile::tempdir;
+use test_helpers_end_to_end::{maybe_skip_integration, MiniCluster, Step, StepTest, StepTestState};
+
+/// remote partition command and getting a parquet file from the object store and pulling the
+/// files, using these commands:
+///
+/// - `remote partition show`
+/// - `remote store get`
+/// - `remote partition pull`
+#[tokio::test]
+async fn remote_partition_and_get_from_store_and_pull() {
+    test_helpers::maybe_start_logging();
+    let database_url = maybe_skip_integration!();
+
+    // The test below assumes a specific partition id, so use a
+    // non-shared one here so concurrent tests don't interfere with
+    // each other
+    let mut cluster = MiniCluster::create_non_shared_standard(database_url).await;
+
+    StepTest::new(
+        &mut cluster,
+        vec![
+            Step::WriteLineProtocol(String::from(
+                "my_awesome_table,tag1=A,tag2=B val=42i 123456",
+            )),
+            // wait for partitions to be persisted
+            Step::WaitForPersisted,
+            // Run the 'remote partition' command
+            Step::Custom(Box::new(|state: &mut StepTestState| {
+                async {
+                    let router_addr = state.cluster().router().router_grpc_base().to_string();
+                    let namespace = state.cluster().namespace().to_string();
+
+                    // Validate the output of the remote partition CLI command
+                    //
+                    // Looks like:
+                    // {
+                    //     "id": "1",
+                    //     "shardId": 1,
+                    //     "namespaceId": 1,
+                    //     "tableId": 1,
+                    //     "partitionId": "1",
+                    //     "objectStoreId": "fa6cdcd1-cbc2-4fb7-8b51-4773079124dd",
+                    //     "minTime": "123456",
+                    //     "maxTime": "123456",
+                    //     "fileSizeBytes": "2029",
+                    //     "rowCount": "1",
+                    //     "createdAt": "1650019674289347000"
+                    // }
+
+                    let out = Command::cargo_bin("influxdb_iox")
+                        .unwrap()
+                        .arg("-h")
+                        .arg(&router_addr)
+                        .arg("remote")
+                        .arg("partition")
+                        .arg("show")
+                        .arg("1")
+                        .assert()
+                        .success()
+                        .stdout(
+                            predicate::str::contains(r#""id": "1""#)
+                                .and(predicate::str::contains(r#""shardId": "1","#))
+                                .and(predicate::str::contains(r#""partitionId": "1","#)),
+                        )
+                        .get_output()
+                        .stdout
+                        .clone();
+
+                    let object_store_id = get_object_store_id(&out);
+
+                    let dir = tempdir().unwrap();
+                    let f = dir.path().join("tmp.parquet");
+                    let filename = f.as_os_str().to_str().unwrap();
+
+                    Command::cargo_bin("influxdb_iox")
+                        .unwrap()
+                        .arg("-h")
+                        .arg(&router_addr)
+                        .arg("remote")
+                        .arg("store")
+                        .arg("get")
+                        .arg(&object_store_id)
+                        .arg(filename)
+                        .assert()
+                        .success()
+                        .stdout(
+                            predicate::str::contains("wrote")
+                                .and(predicate::str::contains(filename)),
+                        );
+
+                    // Ensure a warning is emitted when specifying (or
+                    // defaulting to) in-memory file storage.
+                    Command::cargo_bin("influxdb_iox")
+                        .unwrap()
+                        .arg("-h")
+                        .arg(&router_addr)
+                        .arg("remote")
+                        .arg("partition")
+                        .arg("pull")
+                        .arg("--catalog")
+                        .arg("memory")
+                        .arg("--object-store")
+                        .arg("memory")
+                        .arg(&namespace)
+                        .arg("my_awesome_table")
+                        .arg("1970-01-01")
+                        .assert()
+                        .failure()
+                        .stderr(predicate::str::contains("try passing --object-store=file"));
+
+                    // Ensure files are actually wrote to the filesystem
+                    let dir = tempfile::tempdir().expect("could not get temporary directory");
+
+                    Command::cargo_bin("influxdb_iox")
+                        .unwrap()
+                        .arg("-h")
+                        .arg(&router_addr)
+                        .arg("remote")
+                        .arg("partition")
+                        .arg("pull")
+                        .arg("--catalog")
+                        .arg("memory")
+                        .arg("--object-store")
+                        .arg("file")
+                        .arg("--data-dir")
+                        .arg(dir.path().to_str().unwrap())
+                        .arg(&namespace)
+                        .arg("my_awesome_table")
+                        .arg("1970-01-01")
+                        .assert()
+                        .success()
+                        .stdout(
+                            predicate::str::contains("wrote file")
+                                .and(predicate::str::contains(&object_store_id)),
+                        );
+                }
+                .boxed()
+            })),
+        ],
+    )
+    .run()
+    .await
+}

--- a/influxdb_iox_client/src/client/catalog.rs
+++ b/influxdb_iox_client/src/client/catalog.rs
@@ -24,7 +24,7 @@ impl Client {
         }
     }
 
-    /// Get the parquet file records by their partition id
+    /// Get the Parquet file records by their partition id
     pub async fn get_parquet_files_by_partition_id(
         &mut self,
         partition_id: i64,
@@ -48,5 +48,22 @@ impl Client {
             .await?;
 
         Ok(response.into_inner().partitions)
+    }
+
+    /// Get the Parquet file records by their database and table names
+    pub async fn get_parquet_files_by_database_table(
+        &mut self,
+        database_name: String,
+        table_name: String,
+    ) -> Result<Vec<ParquetFile>, Error> {
+        let response = self
+            .inner
+            .get_parquet_files_by_database_table(GetParquetFilesByDatabaseTableRequest {
+                database_name,
+                table_name,
+            })
+            .await?;
+
+        Ok(response.into_inner().parquet_files)
     }
 }

--- a/service_grpc_catalog/src/lib.rs
+++ b/service_grpc_catalog/src/lib.rs
@@ -80,6 +80,52 @@ impl catalog_service_server::CatalogService for CatalogService {
 
         Ok(Response::new(response))
     }
+
+    async fn get_parquet_files_by_database_table(
+        &self,
+        request: Request<GetParquetFilesByDatabaseTableRequest>,
+    ) -> Result<Response<GetParquetFilesByDatabaseTableResponse>, Status> {
+        let mut repos = self.catalog.repositories().await;
+        let req = request.into_inner();
+
+        let namespace = repos
+            .namespaces()
+            .get_by_name(&req.database_name)
+            .await
+            .map_err(|e| Status::unknown(e.to_string()))?
+            .ok_or_else(|| {
+                Status::not_found(format!("Database {} not found", req.database_name))
+            })?;
+
+        let table = repos
+            .tables()
+            .get_by_namespace_and_name(namespace.id, &req.table_name)
+            .await
+            .map_err(|e| Status::unknown(e.to_string()))?
+            .ok_or_else(|| Status::not_found(format!("Table {} not found", req.table_name)))?;
+
+        let table_id = table.id;
+
+        let parquet_files = repos
+            .parquet_files()
+            .list_by_table_not_to_delete(table_id)
+            .await
+            .map_err(|e| {
+                warn!(
+                    error=%e,
+                    %req.database_name,
+                    %req.table_name,
+                    "failed to get parquet_files for table"
+                );
+                Status::not_found(e.to_string())
+            })?;
+
+        let parquet_files: Vec<_> = parquet_files.into_iter().map(to_parquet_file).collect();
+
+        let response = GetParquetFilesByDatabaseTableResponse { parquet_files };
+
+        Ok(Response::new(response))
+    }
 }
 
 // converts the catalog ParquetFile to protobuf


### PR DESCRIPTION
Connects to https://github.com/influxdata/influxdb_iox/issues/5967.

This PR adds the new command `influxdb_iox remote store get-table <DATABASE> <TABLE>` that will fetch all Parquet files for the specified database's table to the local filesystem.

I tested this out by running a local all-in-one server, which has http://localhost:8081 as the router gRPC port. I set `INFLUXDB_IOX_PERSIST_PARTITION_AGE_THRESHOLD_SECONDS=10` to get lots of Parquet files.  I wrote some data into the database `test_db`, table `disk`. Then I ran:

```
influxdb_iox -h http://localhost:8081 remote store get-table test_db disk
```

and I saw this output:

```
found 2 Parquet files, downloading...
downloading file 1 of 2 (a1fb45f9-d04f-4aa1-a058-0a75c846264c.parquet)...
downloading file 2 of 2 (54e03fa9-01fa-4da6-90b1-c92fa034d0a0.parquet)...
Done.
```

and I had those two files in a directory named `disk` in my current directory.

I'm going to work on the bonus points next but wanted to get feedback on the main logic/behavior before I got too far!