### PR TITLE
feat: Some bonus features for `remote store get-table`

### DIFF
--- a/generated_types/protos/influxdata/iox/catalog/v1/service.proto
+++ b/generated_types/protos/influxdata/iox/catalog/v1/service.proto
@@ -11,8 +11,8 @@ service CatalogService {
     // Get the partition catalog records by the table id
     rpc GetPartitionsByTableId(GetPartitionsByTableIdRequest) returns (GetPartitionsByTableIdResponse);
 
-    // Get the parquet_file catalog records in the given database and table name
-    rpc GetParquetFilesByDatabaseTable(GetParquetFilesByDatabaseTableRequest) returns (GetParquetFilesByDatabaseTableResponse);
+    // Get the parquet_file catalog records in the given namespace and table name
+    rpc GetParquetFilesByNamespaceTable(GetParquetFilesByNamespaceTableRequest) returns (GetParquetFilesByNamespaceTableResponse);
 }
 
 message GetParquetFilesByPartitionIdRequest {
@@ -51,15 +51,15 @@ message GetPartitionsByTableIdResponse {
     repeated Partition partitions = 1;
 }
 
-message GetParquetFilesByDatabaseTableRequest {
-    // the database name
-    string database_name = 1;
+message GetParquetFilesByNamespaceTableRequest {
+    // the namespace name
+    string namespace_name = 1;
 
-    // the table name in the database
+    // the table name in the namespace
     string table_name = 2;
 }
 
-message GetParquetFilesByDatabaseTableResponse {
-    // the parquet_file records in the table in the database
+message GetParquetFilesByNamespaceTableResponse {
+    // the parquet_file records in the table in the namespace
     repeated ParquetFile parquet_files = 1;
 }

--- a/influxdb_iox/src/commands/remote.rs
+++ b/influxdb_iox/src/commands/remote.rs
@@ -9,10 +9,10 @@ mod store;
 #[allow(clippy::enum_variant_names)]
 #[derive(Debug, Error)]
 pub enum Error {
-    #[error("Error in partition subcommand: {0}")]
+    #[error("{0}")]
     Partition(#[from] partition::Error),
 
-    #[error("Error in the store subcommand: {0}")]
+    #[error("{0}")]
     Store(#[from] store::Error),
 
     #[error("Catalog error: {0}")]

--- a/influxdb_iox/src/commands/remote/store.rs
+++ b/influxdb_iox/src/commands/remote/store.rs
@@ -90,14 +90,14 @@ pub async fn command(connection: Connection, config: Config) -> Result<(), Error
                 .await?;
             let num_parquet_files = parquet_files.len();
             println!("found {num_parquet_files} Parquet files, downloading...");
-            let indexed_object_store_ids = parquet_files
+            let indexed_parquet_file_metadata = parquet_files
                 .into_iter()
-                .map(|pf| pf.object_store_id)
+                .map(|pf| (pf.object_store_id, pf.partition_id))
                 .enumerate();
 
-            for (index, uuid) in indexed_object_store_ids {
+            for (index, (uuid, partition_id)) in indexed_parquet_file_metadata {
                 let index = index + 1;
-                let filename = format!("{uuid}.parquet");
+                let filename = format!("{uuid}.{partition_id}.parquet");
                 println!("downloading file {index} of {num_parquet_files} ({filename})...");
                 let mut response = store_client
                     .get_parquet_file_by_object_store_id(uuid.clone())

--- a/influxdb_iox/src/commands/remote/store.rs
+++ b/influxdb_iox/src/commands/remote/store.rs
@@ -41,13 +41,12 @@ struct Get {
     file_name: String,
 }
 
-/// Get all the Parquet files for a particular database's table
-/// into a local directory
+/// Get all the Parquet files for a particular namespace's table into a local directory
 #[derive(Debug, clap::Parser)]
 struct GetTable {
-    /// The database (namespace) to get the Parquet files for
+    /// The namespace to get the Parquet files for
     #[clap(action)]
-    database: String,
+    namespace: String,
 
     /// The name of the table to get the Parquet files for
     #[clap(action)]
@@ -91,8 +90,8 @@ pub async fn command(connection: Connection, config: Config) -> Result<(), Error
             let mut store_client = store::Client::new(connection);
 
             let parquet_files = catalog_client
-                .get_parquet_files_by_database_table(
-                    get_table.database.clone(),
+                .get_parquet_files_by_namespace_table(
+                    get_table.namespace.clone(),
                     get_table.table.clone(),
                 )
                 .await?;

--- a/influxdb_iox/src/commands/remote/store.rs
+++ b/influxdb_iox/src/commands/remote/store.rs
@@ -15,7 +15,7 @@ pub enum Error {
     #[error("JSON Serialization error: {0}")]
     Serde(#[from] serde_json::Error),
 
-    #[error("Client error: {0}")]
+    #[error("IOx request failed: {0}")]
     ClientError(#[from] influxdb_iox_client::error::Error),
 
     #[error("Writing file: {0}")]

--- a/influxdb_iox/tests/end_to_end_cases/remote.rs
+++ b/influxdb_iox/tests/end_to_end_cases/remote.rs
@@ -101,6 +101,38 @@ async fn remote_store_get_table() {
                         1,
                         "Expected 1 file in the directory, got: {entries:?}"
                     );
+
+                    // Specifying a table that doesn't exist prints an error message
+                    Command::cargo_bin("influxdb_iox")
+                        .unwrap()
+                        .current_dir(&dir)
+                        .arg("-h")
+                        .arg(&router_addr)
+                        .arg("remote")
+                        .arg("store")
+                        .arg("get-table")
+                        .arg(&namespace)
+                        .arg("nacho-table")
+                        .assert()
+                        .failure()
+                        .stderr(predicate::str::contains("Table nacho-table not found"));
+
+                    // Specifying a namespace that doesn't exist prints an error message
+                    Command::cargo_bin("influxdb_iox")
+                        .unwrap()
+                        .current_dir(&dir)
+                        .arg("-h")
+                        .arg(&router_addr)
+                        .arg("remote")
+                        .arg("store")
+                        .arg("get-table")
+                        .arg("nacho-namespace")
+                        .arg(&table_name)
+                        .assert()
+                        .failure()
+                        .stderr(predicate::str::contains(
+                            "Database nacho-namespace not found",
+                        ));
                 }
                 .boxed()
             })),

--- a/influxdb_iox/tests/end_to_end_cases/remote.rs
+++ b/influxdb_iox/tests/end_to_end_cases/remote.rs
@@ -131,7 +131,7 @@ async fn remote_store_get_table() {
                         .assert()
                         .failure()
                         .stderr(predicate::str::contains(
-                            "Database nacho-namespace not found",
+                            "Namespace nacho-namespace not found",
                         ));
                 }
                 .boxed()

--- a/influxdb_iox/tests/end_to_end_cases/remote.rs
+++ b/influxdb_iox/tests/end_to_end_cases/remote.rs
@@ -13,6 +13,7 @@ async fn remote_store_get_table() {
     test_helpers::maybe_start_logging();
     let database_url = maybe_skip_integration!();
     let table_name = "my_awesome_table";
+    let other_table_name = "my_ordinary_table";
 
     let mut cluster = MiniCluster::create_shared(database_url).await;
 
@@ -26,7 +27,7 @@ async fn remote_store_get_table() {
             Step::WriteLineProtocol(format!("{table_name},tag1=C,tag2=B val=9000i 789000")),
             Step::WaitForPersisted,
             // Persist some more data for a different table
-            Step::WriteLineProtocol(format!("{table_name}_2,tag1=A,tag2=B val=42i 123456")),
+            Step::WriteLineProtocol(format!("{other_table_name},tag1=A,tag2=B val=42i 123456")),
             Step::WaitForPersisted,
             Step::Custom(Box::new(move |state: &mut StepTestState| {
                 async move {
@@ -45,13 +46,17 @@ async fn remote_store_get_table() {
                         .arg("store")
                         .arg("get-table")
                         .arg(&namespace)
-                        .arg("my_awesome_table")
+                        .arg(&table_name)
                         .assert()
                         .success();
 
                     let table_dir = dir.as_ref().join(&table_name);
+
+                    // There should be a directory created that, by default, is named the same as
+                    // the table
                     assert!(table_dir.is_dir());
                     let entries: Vec<_> = table_dir.read_dir().unwrap().flatten().collect();
+                    // The two Parquet files for this table should be present
                     assert_eq!(
                         entries.len(),
                         2,
@@ -59,11 +64,42 @@ async fn remote_store_get_table() {
                     );
                     let path = entries[0].path();
                     let extension = path.extension().unwrap();
+                    // Their extension should be 'parquet'
                     assert_eq!(
                         "parquet",
                         extension,
                         "Expected filename to have extension 'parquet', got: {}",
                         extension.to_str().unwrap()
+                    );
+
+                    // The `-o` argument should specify where the files go instead of a directory
+                    // named after the table. Note that this `Command` doesn't set `current dir`;
+                    // the `-o` argument shouldn't have anything to do with the current working
+                    // directory.
+                    let custom_output_dir = dir.as_ref().join("my_special_directory");
+
+                    Command::cargo_bin("influxdb_iox")
+                        .unwrap()
+                        .arg("-h")
+                        .arg(&router_addr)
+                        .arg("remote")
+                        .arg("store")
+                        .arg("get-table")
+                        .arg("-o")
+                        .arg(&custom_output_dir)
+                        .arg(&namespace)
+                        // This time ask for the table that only has one Parquet file
+                        .arg(&other_table_name)
+                        .assert()
+                        .success();
+
+                    assert!(custom_output_dir.is_dir());
+                    let entries: Vec<_> = custom_output_dir.read_dir().unwrap().flatten().collect();
+                    // The one Parquet file for this table should be present
+                    assert_eq!(
+                        entries.len(),
+                        1,
+                        "Expected 1 file in the directory, got: {entries:?}"
                     );
                 }
                 .boxed()

--- a/influxdb_iox_client/src/client/catalog.rs
+++ b/influxdb_iox_client/src/client/catalog.rs
@@ -50,16 +50,16 @@ impl Client {
         Ok(response.into_inner().partitions)
     }
 
-    /// Get the Parquet file records by their database and table names
-    pub async fn get_parquet_files_by_database_table(
+    /// Get the Parquet file records by their namespace and table names
+    pub async fn get_parquet_files_by_namespace_table(
         &mut self,
-        database_name: String,
+        namespace_name: String,
         table_name: String,
     ) -> Result<Vec<ParquetFile>, Error> {
         let response = self
             .inner
-            .get_parquet_files_by_database_table(GetParquetFilesByDatabaseTableRequest {
-                database_name,
+            .get_parquet_files_by_namespace_table(GetParquetFilesByNamespaceTableRequest {
+                namespace_name,
                 table_name,
             })
             .await?;

--- a/influxdb_iox_client/src/client/error.rs
+++ b/influxdb_iox_client/src/client/error.rs
@@ -73,7 +73,7 @@ pub enum Error {
     #[error("Deadline expired before operation could complete: {0}")]
     DeadlineExceeded(ServerError<()>),
 
-    #[error("Some requested entity was not found: {0}")]
+    #[error("{0}")]
     NotFound(ServerError<NotFound>),
 
     #[error("Some entity that we attempted to create already exists: {0}")]

--- a/service_grpc_catalog/src/lib.rs
+++ b/service_grpc_catalog/src/lib.rs
@@ -81,20 +81,20 @@ impl catalog_service_server::CatalogService for CatalogService {
         Ok(Response::new(response))
     }
 
-    async fn get_parquet_files_by_database_table(
+    async fn get_parquet_files_by_namespace_table(
         &self,
-        request: Request<GetParquetFilesByDatabaseTableRequest>,
-    ) -> Result<Response<GetParquetFilesByDatabaseTableResponse>, Status> {
+        request: Request<GetParquetFilesByNamespaceTableRequest>,
+    ) -> Result<Response<GetParquetFilesByNamespaceTableResponse>, Status> {
         let mut repos = self.catalog.repositories().await;
         let req = request.into_inner();
 
         let namespace = repos
             .namespaces()
-            .get_by_name(&req.database_name)
+            .get_by_name(&req.namespace_name)
             .await
             .map_err(|e| Status::unknown(e.to_string()))?
             .ok_or_else(|| {
-                Status::not_found(format!("Database {} not found", req.database_name))
+                Status::not_found(format!("Namespace {} not found", req.namespace_name))
             })?;
 
         let table = repos
@@ -113,7 +113,7 @@ impl catalog_service_server::CatalogService for CatalogService {
             .map_err(|e| {
                 warn!(
                     error=%e,
-                    %req.database_name,
+                    %req.namespace_name,
                     %req.table_name,
                     "failed to get parquet_files for table"
                 );
@@ -122,7 +122,7 @@ impl catalog_service_server::CatalogService for CatalogService {
 
         let parquet_files: Vec<_> = parquet_files.into_iter().map(to_parquet_file).collect();
 
-        let response = GetParquetFilesByDatabaseTableResponse { parquet_files };
+        let response = GetParquetFilesByNamespaceTableResponse { parquet_files };
 
         Ok(Response::new(response))
     }


### PR DESCRIPTION
Connects to https://github.com/influxdata/influxdb_iox/issues/5967

This PR implements 2 of the bonus points:

- [x] Allow the output directory to be specified (`influxdb_iox remote store get-table 12345_6788 'sensors' -o output_directory`)
- [x] Add the partition_id in the file names  (`<UUID>`.`<PARTITION_ID>`.`parquet`)

And [feedback from the previous PR](https://github.com/influxdata/influxdb_iox/pull/5984#discussion_r1006216160), at least for the code that I just added (the rest of the codebase I'll save for later): 

- [x] I think we should use the word "namespace" consistently throughout the codebase rather than sometimes using database and sometimes use namespace

I also made what I think are improvements to some error message displays:

Before this change, if the namespace specified wasn't found, the error message would be:

```
Error in the store subcommand: Client error: Some requested entity was not found: Namespace nacho-namespace 
not found
```

Which is:

- Unhelpful, I know I ran the `store` subcommand
- Confusing, am I the client? (no) Does "Client error" mean I did something wrong? (also no)
- Repetitive, why tell me something wasn't found and then tell me what wasn't found

After this change, the error message is:

```
IOx request failed: Namespace nacho-namespace not found
```

which I find much clearer.
