### PR TITLE
refactor(router): pass NamespaceId through handler stack

### DIFF
--- a/router/benches/e2e.rs
+++ b/router/benches/e2e.rs
@@ -1,3 +1,5 @@
+use std::{collections::BTreeSet, iter, sync::Arc};
+
 use criterion::{criterion_group, criterion_main, Criterion, Throughput};
 use data_types::{PartitionTemplate, TemplatePart};
 use hyper::{Body, Request};
@@ -12,7 +14,6 @@ use router::{
     shard::Shard,
 };
 use sharder::JumpHash;
-use std::{collections::BTreeSet, iter, sync::Arc};
 use tokio::runtime::Runtime;
 use write_buffer::{
     core::WriteBufferWriting,

--- a/router/benches/schema_validator.rs
+++ b/router/benches/schema_validator.rs
@@ -4,7 +4,7 @@ use criterion::{
     criterion_group, criterion_main, measurement::WallTime, BatchSize, BenchmarkGroup, Criterion,
     Throughput,
 };
-use data_types::DatabaseName;
+use data_types::{DatabaseName, NamespaceId};
 use hashbrown::HashMap;
 use iox_catalog::mem::MemCatalog;
 use mutable_batch::MutableBatch;
@@ -49,7 +49,7 @@ fn bench(group: &mut BenchmarkGroup<WallTime>, tables: usize, columns_per_table:
 
     for i in 0..65_000 {
         let write = lp_to_writes(format!("{}{}", i + 10_000_000, generate_lp(1, 1)).as_str());
-        let _ = runtime().block_on(validator.write(&*NAMESPACE, write, None));
+        let _ = runtime().block_on(validator.write(&*NAMESPACE, NamespaceId::new(42), write, None));
     }
 
     let write = lp_to_writes(&generate_lp(tables, columns_per_table));
@@ -61,7 +61,7 @@ fn bench(group: &mut BenchmarkGroup<WallTime>, tables: usize, columns_per_table:
     group.bench_function(format!("{tables}x{columns_per_table}"), |b| {
         b.to_async(runtime()).iter_batched(
             || write.clone(),
-            |write| validator.write(&*NAMESPACE, write, None),
+            |write| validator.write(&*NAMESPACE, NamespaceId::new(42), write, None),
             BatchSize::SmallInput,
         );
     });

--- a/router/benches/schema_validator.rs
+++ b/router/benches/schema_validator.rs
@@ -1,3 +1,5 @@
+use std::{iter, sync::Arc};
+
 use criterion::{
     criterion_group, criterion_main, measurement::WallTime, BatchSize, BenchmarkGroup, Criterion,
     Throughput,
@@ -12,7 +14,6 @@ use router::{
     namespace_cache::{MemoryNamespaceCache, ShardedCache},
 };
 use schema::selection::Selection;
-use std::{iter, sync::Arc};
 use tokio::runtime::Runtime;
 
 static NAMESPACE: Lazy<DatabaseName<'static>> = Lazy::new(|| "bananas".try_into().unwrap());

--- a/router/src/dml_handlers/chain.rs
+++ b/router/src/dml_handlers/chain.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use data_types::{DatabaseName, DeletePredicate};
+use data_types::{DatabaseName, DeletePredicate, NamespaceId};
 use trace::ctx::SpanContext;
 
 use super::{DmlError, DmlHandler};
@@ -59,17 +59,18 @@ where
     async fn write(
         &self,
         namespace: &DatabaseName<'static>,
+        namespace_id: NamespaceId,
         input: Self::WriteInput,
         span_ctx: Option<SpanContext>,
     ) -> Result<Self::WriteOutput, Self::WriteError> {
         let output = self
             .first
-            .write(namespace, input, span_ctx.clone())
+            .write(namespace, namespace_id, input, span_ctx.clone())
             .await
             .map_err(Into::into)?;
 
         self.second
-            .write(namespace, output, span_ctx)
+            .write(namespace, namespace_id, output, span_ctx)
             .await
             .map_err(Into::into)
     }

--- a/router/src/dml_handlers/chain.rs
+++ b/router/src/dml_handlers/chain.rs
@@ -1,7 +1,8 @@
-use super::{DmlError, DmlHandler};
 use async_trait::async_trait;
 use data_types::{DatabaseName, DeletePredicate};
 use trace::ctx::SpanContext;
+
+use super::{DmlError, DmlHandler};
 
 /// An extension trait to chain together the execution of a pair of
 /// [`DmlHandler`] implementations.

--- a/router/src/dml_handlers/fan_out.rs
+++ b/router/src/dml_handlers/fan_out.rs
@@ -1,9 +1,11 @@
-use super::DmlHandler;
+use std::{fmt::Debug, marker::PhantomData};
+
 use async_trait::async_trait;
 use data_types::{DatabaseName, DeletePredicate};
 use futures::{stream::FuturesUnordered, TryStreamExt};
-use std::{fmt::Debug, marker::PhantomData};
 use trace::ctx::SpanContext;
+
+use super::DmlHandler;
 
 /// A [`FanOutAdaptor`] takes an iterator of DML write operation inputs and
 /// executes them concurrently against the inner handler, returning once all

--- a/router/src/dml_handlers/instrumentation.rs
+++ b/router/src/dml_handlers/instrumentation.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use data_types::{DatabaseName, DeletePredicate};
+use data_types::{DatabaseName, DeletePredicate, NamespaceId};
 use iox_time::{SystemProvider, TimeProvider};
 use metric::{DurationHistogram, Metric};
 use trace::{
@@ -68,6 +68,7 @@ where
     async fn write(
         &self,
         namespace: &DatabaseName<'static>,
+        namespace_id: NamespaceId,
         input: Self::WriteInput,
         span_ctx: Option<SpanContext>,
     ) -> Result<Self::WriteOutput, Self::WriteError> {
@@ -77,7 +78,10 @@ where
         let mut span_recorder =
             SpanRecorder::new(span_ctx.clone().map(|parent| parent.child(self.name)));
 
-        let res = self.inner.write(namespace, input, span_ctx).await;
+        let res = self
+            .inner
+            .write(namespace, namespace_id, input, span_ctx)
+            .await;
 
         // Avoid exploding if time goes backwards - simply drop the measurement
         // if it happens.
@@ -202,7 +206,7 @@ mod tests {
         let decorator = InstrumentationDecorator::new(HANDLER_NAME, &*metrics, handler);
 
         decorator
-            .write(&ns, (), Some(span))
+            .write(&ns, NamespaceId::new(42), (), Some(span))
             .await
             .expect("inner handler configured to succeed");
 
@@ -225,7 +229,7 @@ mod tests {
         let decorator = InstrumentationDecorator::new(HANDLER_NAME, &*metrics, handler);
 
         let err = decorator
-            .write(&ns, (), Some(span))
+            .write(&ns, NamespaceId::new(42), (), Some(span))
             .await
             .expect_err("inner handler configured to fail");
 

--- a/router/src/dml_handlers/instrumentation.rs
+++ b/router/src/dml_handlers/instrumentation.rs
@@ -1,4 +1,3 @@
-use super::DmlHandler;
 use async_trait::async_trait;
 use data_types::{DatabaseName, DeletePredicate};
 use iox_time::{SystemProvider, TimeProvider};
@@ -7,6 +6,8 @@ use trace::{
     ctx::SpanContext,
     span::{SpanExt, SpanRecorder},
 };
+
+use super::DmlHandler;
 
 /// An instrumentation decorator recording call latencies for [`DmlHandler`] implementations.
 ///
@@ -135,14 +136,16 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::dml_handlers::{mock::MockDmlHandler, DmlError};
+    use std::sync::Arc;
+
     use assert_matches::assert_matches;
     use data_types::TimestampRange;
     use metric::Attributes;
-    use std::sync::Arc;
     use trace::{span::SpanStatus, RingBufferTraceCollector, TraceCollector};
     use write_summary::WriteSummary;
+
+    use super::*;
+    use crate::dml_handlers::{mock::MockDmlHandler, DmlError};
 
     const HANDLER_NAME: &str = "bananas";
 

--- a/router/src/dml_handlers/mock.rs
+++ b/router/src/dml_handlers/mock.rs
@@ -1,10 +1,12 @@
-use super::{DmlError, DmlHandler};
+use std::{collections::VecDeque, fmt::Debug};
+
 use async_trait::async_trait;
 use data_types::{DatabaseName, DeletePredicate};
 use parking_lot::Mutex;
-use std::{collections::VecDeque, fmt::Debug};
 use trace::ctx::SpanContext;
 use write_summary::WriteSummary;
+
+use super::{DmlError, DmlHandler};
 
 /// A captured call to a [`MockDmlHandler`], generic over `W`, the captured
 /// [`DmlHandler::WriteInput`] type.

--- a/router/src/dml_handlers/mock.rs
+++ b/router/src/dml_handlers/mock.rs
@@ -1,7 +1,7 @@
 use std::{collections::VecDeque, fmt::Debug};
 
 use async_trait::async_trait;
-use data_types::{DatabaseName, DeletePredicate};
+use data_types::{DatabaseName, DeletePredicate, NamespaceId};
 use parking_lot::Mutex;
 use trace::ctx::SpanContext;
 use write_summary::WriteSummary;
@@ -14,6 +14,7 @@ use super::{DmlError, DmlHandler};
 pub enum MockDmlHandlerCall<W> {
     Write {
         namespace: String,
+        namespace_id: NamespaceId,
         write_input: W,
     },
     Delete {
@@ -102,6 +103,7 @@ where
     async fn write(
         &self,
         namespace: &DatabaseName<'static>,
+        namespace_id: NamespaceId,
         write_input: Self::WriteInput,
         _span_ctx: Option<SpanContext>,
     ) -> Result<Self::WriteOutput, Self::WriteError> {
@@ -109,6 +111,7 @@ where
             self,
             MockDmlHandlerCall::Write {
                 namespace: namespace.into(),
+                namespace_id,
                 write_input,
             },
             write_return

--- a/router/src/dml_handlers/mod.rs
+++ b/router/src/dml_handlers/mod.rs
@@ -4,27 +4,17 @@
 //! processing handler chain:
 //!
 //! ```text
-//!                 ┌──────────────┐    ┌──────────────┐
-//!                 │   HTTP API   │    │   gRPC API   │
-//!                 └──────────────┘    └──────────────┘
-//!                         │                   │
-//!                         └─────────┬─────────┘
-//!                                   │
-//!                                   ▼
-//!                      ╔═ DmlHandler Stack ═════╗
+//!                                                  ┌─────────────────┐
+//!                                                  │ Namespace Cache │
+//!                                                  └─────────────────┘
+//!                      ╔═ DmlHandler Stack ═════╗           │
 //!                      ║                        ║
-//!                      ║  ┌──────────────────┐  ║
-//!                      ║  │    Namespace     │  ║
-//!                      ║  │   Autocreation   │─ ─ ─ ─ ─ ─ ─ ┐
-//!                      ║  └──────────────────┘  ║
-//!                      ║            │           ║           │
-//!                      ║            ▼           ║
 //!                      ║  ┌──────────────────┐  ║           │
 //!                      ║  │   Partitioner    │  ║
 //!                      ║  └──────────────────┘  ║           │
-//!                      ║            │           ║  ┌─────────────────┐
-//!                      ║            ▼           ║  │ Namespace Cache │
-//!                      ║  ┌──────────────────┐  ║  └─────────────────┘
+//!                      ║            │           ║
+//!                      ║            ▼           ║           │
+//!                      ║  ┌──────────────────┐  ║
 //!                      ║  │      Schema      │  ║           │
 //!                      ║  │    Validation    │ ─║─ ─ ─ ─ ─ ─
 //!                      ║  └──────────────────┘  ║
@@ -49,23 +39,17 @@
 //!                            └──────────────┘
 //! ```
 //!
-//! The HTTP / gRPC APIs decode their respective request format and funnel the
-//! resulting operation through the common [`DmlHandler`] composed of the layers
-//! described above.
+//! The HTTP API decodes the request and funnels the resulting operation through
+//! the [`DmlHandler`] stack composed of the layers described above.
 //!
-//! The [`NamespaceAutocreation`] handler (for testing only) populates the
-//! global catalog with an entry for each namespace it observes, using the
-//! [`NamespaceCache`] as an optimisation, allowing the handler to skip sending
-//! requests to the catalog for namespaces that are known to exist.
-//!
-//! Incoming line-protocol writes then pass through the [`Partitioner`], parsing
-//! the LP and splitting them into batches per partition, before passing each
+//! Incoming line-protocol writes pass through the [`Partitioner`], parsing the
+//! LP and splitting them into batches per IOx partition, before passing each
 //! partitioned batch through the rest of the request pipeline.
 //!
-//! Writes then pass through the [`SchemaValidator`] applying schema enforcement
-//! (a NOP layer for deletes) which pushes additive schema changes to the
-//! catalog and populates the [`NamespaceCache`], converging it to match the set
-//! of [`NamespaceSchema`] in the global catalog.
+//! Writes then pass through the [`SchemaValidator`] applying schema & limit
+//! enforcement (a NOP layer for deletes) which pushes additive schema changes
+//! to the catalog and populates the [`NamespaceCache`], converging it to match
+//! the set of [`NamespaceSchema`] in the global catalog.
 //!
 //! The [`ShardedWriteBuffer`] uses a sharder implementation to direct the DML
 //! operations into a fixed set of shards.
@@ -83,9 +67,6 @@ pub mod nop;
 
 mod sharded_write_buffer;
 pub use sharded_write_buffer::*;
-
-mod ns_autocreation;
-pub use ns_autocreation::*;
 
 mod partitioner;
 pub use partitioner::*;

--- a/router/src/dml_handlers/nop.rs
+++ b/router/src/dml_handlers/nop.rs
@@ -3,7 +3,7 @@
 use std::{fmt::Debug, marker::PhantomData};
 
 use async_trait::async_trait;
-use data_types::{DatabaseName, DeletePredicate};
+use data_types::{DatabaseName, DeletePredicate, NamespaceId};
 use observability_deps::tracing::*;
 use trace::ctx::SpanContext;
 
@@ -32,10 +32,11 @@ where
     async fn write(
         &self,
         namespace: &DatabaseName<'static>,
+        namespace_id: NamespaceId,
         batches: Self::WriteInput,
         _span_ctx: Option<SpanContext>,
     ) -> Result<Self::WriteOutput, Self::WriteError> {
-        info!(%namespace, ?batches, "dropping write operation");
+        info!(%namespace, %namespace_id, ?batches, "dropping write operation");
         Ok(batches)
     }
 

--- a/router/src/dml_handlers/nop.rs
+++ b/router/src/dml_handlers/nop.rs
@@ -1,11 +1,13 @@
 //! A NOP implementation of [`DmlHandler`].
 
-use super::{DmlError, DmlHandler};
+use std::{fmt::Debug, marker::PhantomData};
+
 use async_trait::async_trait;
 use data_types::{DatabaseName, DeletePredicate};
 use observability_deps::tracing::*;
-use std::{fmt::Debug, marker::PhantomData};
 use trace::ctx::SpanContext;
+
+use super::{DmlError, DmlHandler};
 
 /// A [`DmlHandler`] implementation that does nothing.
 #[derive(Debug)]

--- a/router/src/dml_handlers/ns_autocreation.rs
+++ b/router/src/dml_handlers/ns_autocreation.rs
@@ -1,12 +1,14 @@
-use super::DmlHandler;
-use crate::namespace_cache::NamespaceCache;
+use std::{fmt::Debug, marker::PhantomData, sync::Arc};
+
 use async_trait::async_trait;
 use data_types::{DatabaseName, DeletePredicate, QueryPoolId, TopicId};
 use iox_catalog::interface::Catalog;
 use observability_deps::tracing::*;
-use std::{fmt::Debug, marker::PhantomData, sync::Arc};
 use thiserror::Error;
 use trace::ctx::SpanContext;
+
+use super::DmlHandler;
+use crate::namespace_cache::NamespaceCache;
 
 /// An error auto-creating the request namespace.
 #[derive(Debug, Error)]
@@ -130,11 +132,13 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::namespace_cache::MemoryNamespaceCache;
+    use std::sync::Arc;
+
     use data_types::{Namespace, NamespaceId, NamespaceSchema};
     use iox_catalog::mem::MemCatalog;
-    use std::sync::Arc;
+
+    use super::*;
+    use crate::namespace_cache::MemoryNamespaceCache;
 
     #[tokio::test]
     async fn test_cache_hit() {

--- a/router/src/dml_handlers/partitioner.rs
+++ b/router/src/dml_handlers/partitioner.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use data_types::{DatabaseName, DeletePredicate, PartitionKey, PartitionTemplate};
+use data_types::{DatabaseName, DeletePredicate, NamespaceId, PartitionKey, PartitionTemplate};
 use hashbrown::HashMap;
 use mutable_batch::{MutableBatch, PartitionWrite, WritePayload};
 use observability_deps::tracing::*;
@@ -71,6 +71,7 @@ impl DmlHandler for Partitioner {
     async fn write(
         &self,
         _namespace: &DatabaseName<'static>,
+        _namespace_id: NamespaceId,
         batch: Self::WriteInput,
         _span_ctx: Option<SpanContext>,
     ) -> Result<Self::WriteOutput, Self::WriteError> {
@@ -145,7 +146,7 @@ mod tests {
 
                     let (writes, _) = mutable_batch_lp::lines_to_batches_stats($lp, DEFAULT_TIMESTAMP_NANOS).expect("failed to parse test LP");
 
-                    let handler_ret = partitioner.write(&ns, writes, None).await;
+                    let handler_ret = partitioner.write(&ns, NamespaceId::new(42), writes, None).await;
                     assert_matches!(handler_ret, $($want_handler_ret)+);
 
                     // Check the partition -> table mapping.

--- a/router/src/dml_handlers/partitioner.rs
+++ b/router/src/dml_handlers/partitioner.rs
@@ -1,4 +1,3 @@
-use super::DmlHandler;
 use async_trait::async_trait;
 use data_types::{DatabaseName, DeletePredicate, PartitionKey, PartitionTemplate};
 use hashbrown::HashMap;
@@ -6,6 +5,8 @@ use mutable_batch::{MutableBatch, PartitionWrite, WritePayload};
 use observability_deps::tracing::*;
 use thiserror::Error;
 use trace::ctx::SpanContext;
+
+use super::DmlHandler;
 
 /// An error raised by the [`Partitioner`] handler.
 #[derive(Debug, Error)]
@@ -112,9 +113,10 @@ impl DmlHandler for Partitioner {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use assert_matches::assert_matches;
     use data_types::TemplatePart;
+
+    use super::*;
 
     /// The default timestamp applied to test LP if the write does not specify
     /// one.

--- a/router/src/dml_handlers/schema_validation.rs
+++ b/router/src/dml_handlers/schema_validation.rs
@@ -1,5 +1,5 @@
-use super::DmlHandler;
-use crate::namespace_cache::{metrics::InstrumentedCache, MemoryNamespaceCache, NamespaceCache};
+use std::{ops::DerefMut, sync::Arc};
+
 use async_trait::async_trait;
 use data_types::{DatabaseName, DeletePredicate, NamespaceSchema};
 use hashbrown::HashMap;
@@ -10,9 +10,11 @@ use iox_catalog::{
 use metric::U64Counter;
 use mutable_batch::MutableBatch;
 use observability_deps::tracing::*;
-use std::{ops::DerefMut, sync::Arc};
 use thiserror::Error;
 use trace::ctx::SpanContext;
+
+use super::DmlHandler;
+use crate::namespace_cache::{metrics::InstrumentedCache, MemoryNamespaceCache, NamespaceCache};
 
 /// Errors emitted during schema validation.
 #[derive(Debug, Error)]
@@ -328,12 +330,14 @@ fn validate_column_limits(
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use std::sync::Arc;
+
     use assert_matches::assert_matches;
     use data_types::{ColumnType, TimestampRange};
     use iox_tests::util::{TestCatalog, TestNamespace};
     use once_cell::sync::Lazy;
-    use std::sync::Arc;
+
+    use super::*;
 
     static NAMESPACE: Lazy<DatabaseName<'static>> = Lazy::new(|| "bananas".try_into().unwrap());
 

--- a/router/src/dml_handlers/schema_validation.rs
+++ b/router/src/dml_handlers/schema_validation.rs
@@ -1,7 +1,7 @@
 use std::{ops::DerefMut, sync::Arc};
 
 use async_trait::async_trait;
-use data_types::{DatabaseName, DeletePredicate, NamespaceSchema};
+use data_types::{DatabaseName, DeletePredicate, NamespaceId, NamespaceSchema};
 use hashbrown::HashMap;
 use iox_catalog::{
     interface::{get_schema_by_name, Catalog, Error as CatalogError},
@@ -167,6 +167,7 @@ where
     async fn write(
         &self,
         namespace: &DatabaseName<'static>,
+        namespace_id: NamespaceId,
         batches: Self::WriteInput,
         _span_ctx: Option<SpanContext>,
     ) -> Result<Self::WriteOutput, Self::WriteError> {
@@ -183,7 +184,12 @@ where
                 let schema = get_schema_by_name(namespace, repos.deref_mut())
                     .await
                     .map_err(|e| {
-                        warn!(error=%e, %namespace, "failed to retrieve namespace schema");
+                        warn!(
+                            error=%e,
+                            %namespace,
+                            %namespace_id,
+                            "failed to retrieve namespace schema"
+                        );
                         SchemaError::NamespaceLookup(e)
                     })
                     .map(Arc::new)?;
@@ -197,7 +203,12 @@ where
         };
 
         validate_column_limits(&batches, &schema).map_err(|e| {
-            warn!(%namespace, error=%e, "service protection limit reached");
+            warn!(
+                %namespace,
+                %namespace_id,
+                error=%e,
+                "service protection limit reached"
+            );
             self.service_limit_hit.inc(1);
             SchemaError::ServiceLimit(Box::new(e))
         })?;
@@ -218,6 +229,7 @@ where
                 } => {
                     warn!(
                         %namespace,
+                        %namespace_id,
                         column_name=%name,
                         existing_column_type=%existing,
                         request_column_type=%new,
@@ -230,12 +242,22 @@ where
                 // Service limits
                 CatalogError::ColumnCreateLimitError { .. }
                 | CatalogError::TableCreateLimitError { .. } => {
-                    warn!(%namespace, error=%e, "service protection limit reached");
+                    warn!(
+                        %namespace,
+                        %namespace_id,
+                        error=%e,
+                        "service protection limit reached"
+                    );
                     self.service_limit_hit.inc(1);
                     SchemaError::ServiceLimit(Box::new(e.into_err()))
                 }
                 _ => {
-                    error!(%namespace, error=%e, "schema validation failed");
+                    error!(
+                        %namespace,
+                        %namespace_id,
+                        error=%e,
+                        "schema validation failed"
+                    );
                     SchemaError::UnexpectedCatalogError(e.into_err())
                 }
             }
@@ -453,12 +475,12 @@ mod tests {
             // namespace schema gets cached
             let writes1_valid = lp_to_writes("dragonfruit val=42i 123456");
             handler1
-                .write(&*NAMESPACE, writes1_valid, None)
+                .write(&*NAMESPACE, NamespaceId::new(42), writes1_valid, None)
                 .await
                 .expect("request should succeed");
             let writes2_valid = lp_to_writes("dragonfruit val=43i 123457");
             handler2
-                .write(&*NAMESPACE, writes2_valid, None)
+                .write(&*NAMESPACE, NamespaceId::new(42), writes2_valid, None)
                 .await
                 .expect("request should succeed");
 
@@ -466,12 +488,12 @@ mod tests {
             // putting the table over the limit
             let writes1_add_column = lp_to_writes("dragonfruit,tag1=A val=42i 123456");
             handler1
-                .write(&*NAMESPACE, writes1_add_column, None)
+                .write(&*NAMESPACE, NamespaceId::new(42), writes1_add_column, None)
                 .await
                 .expect("request should succeed");
             let writes2_add_column = lp_to_writes("dragonfruit,tag2=B val=43i 123457");
             handler2
-                .write(&*NAMESPACE, writes2_add_column, None)
+                .write(&*NAMESPACE, NamespaceId::new(42), writes2_add_column, None)
                 .await
                 .expect("request should succeed");
 
@@ -542,7 +564,7 @@ mod tests {
 
         let writes = lp_to_writes("bananas,tag1=A,tag2=B val=42i 123456");
         handler
-            .write(&*NAMESPACE, writes, None)
+            .write(&*NAMESPACE, NamespaceId::new(42), writes, None)
             .await
             .expect("request should succeed");
 
@@ -567,7 +589,7 @@ mod tests {
 
         let writes = lp_to_writes("bananas,tag1=A,tag2=B val=42i 123456");
         let err = handler
-            .write(&ns, writes, None)
+            .write(&ns, NamespaceId::new(42), writes, None)
             .await
             .expect_err("request should fail");
 
@@ -590,7 +612,7 @@ mod tests {
         // First write sets the schema
         let writes = lp_to_writes("bananas,tag1=A,tag2=B val=42i 123456"); // val=i64
         let got = handler
-            .write(&*NAMESPACE, writes.clone(), None)
+            .write(&*NAMESPACE, NamespaceId::new(42), writes.clone(), None)
             .await
             .expect("request should succeed");
         assert_eq!(writes.len(), got.len());
@@ -598,7 +620,7 @@ mod tests {
         // Second write attempts to violate it causing an error
         let writes = lp_to_writes("bananas,tag1=A,tag2=B val=42.0 123456"); // val=float
         let err = handler
-            .write(&*NAMESPACE, writes, None)
+            .write(&*NAMESPACE, NamespaceId::new(42), writes, None)
             .await
             .expect_err("request should fail");
 
@@ -628,7 +650,7 @@ mod tests {
         // First write sets the schema
         let writes = lp_to_writes("bananas,tag1=A,tag2=B val=42i 123456");
         let got = handler
-            .write(&*NAMESPACE, writes.clone(), None)
+            .write(&*NAMESPACE, NamespaceId::new(42), writes.clone(), None)
             .await
             .expect("request should succeed");
         assert_eq!(writes.len(), got.len());
@@ -646,7 +668,7 @@ mod tests {
         // Second write attempts to violate limits, causing an error
         let writes = lp_to_writes("bananas2,tag1=A,tag2=B val=42i 123456");
         let err = handler
-            .write(&*NAMESPACE, writes, None)
+            .write(&*NAMESPACE, NamespaceId::new(42), writes, None)
             .await
             .expect_err("request should fail");
 
@@ -667,7 +689,7 @@ mod tests {
         // First write sets the schema
         let writes = lp_to_writes("bananas,tag1=A,tag2=B val=42i 123456");
         let got = handler
-            .write(&*NAMESPACE, writes.clone(), None)
+            .write(&*NAMESPACE, NamespaceId::new(42), writes.clone(), None)
             .await
             .expect("request should succeed");
         assert_eq!(writes.len(), got.len());
@@ -683,7 +705,7 @@ mod tests {
         // Second write attempts to violate limits, causing an error
         let writes = lp_to_writes("bananas,tag1=A,tag2=B val=42i,val2=42i 123456");
         let err = handler
-            .write(&*NAMESPACE, writes, None)
+            .write(&*NAMESPACE, NamespaceId::new(42), writes, None)
             .await
             .expect_err("request should fail");
 
@@ -714,7 +736,7 @@ mod tests {
         // First write attempts to add columns over the limit, causing an error
         let writes = lp_to_writes("bananas,tag1=A,tag2=B val=42i,val2=42i 123456");
         let err = handler
-            .write(&*NAMESPACE, writes, None)
+            .write(&*NAMESPACE, NamespaceId::new(42), writes, None)
             .await
             .expect_err("request should fail");
 

--- a/router/src/dml_handlers/sharded_write_buffer.rs
+++ b/router/src/dml_handlers/sharded_write_buffer.rs
@@ -1,7 +1,10 @@
 //! Logic to shard writes/deletes and push them into a write buffer shard.
 
-use super::Partitioned;
-use crate::{dml_handlers::DmlHandler, shard::Shard};
+use std::{
+    fmt::{Debug, Display},
+    sync::Arc,
+};
+
 use async_trait::async_trait;
 use data_types::{DatabaseName, DeletePredicate, NonEmptyString};
 use dml::{DmlDelete, DmlMeta, DmlOperation, DmlWrite};
@@ -10,13 +13,12 @@ use hashbrown::HashMap;
 use mutable_batch::MutableBatch;
 use observability_deps::tracing::*;
 use sharder::Sharder;
-use std::{
-    fmt::{Debug, Display},
-    sync::Arc,
-};
 use thiserror::Error;
 use trace::ctx::SpanContext;
 use write_buffer::core::WriteBufferError;
+
+use super::Partitioned;
+use crate::{dml_handlers::DmlHandler, shard::Shard};
 
 /// Errors occurring while writing to one or more write buffer shards.
 #[derive(Debug, Error)]
@@ -211,13 +213,15 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::dml_handlers::DmlHandler;
+    use std::sync::Arc;
+
     use assert_matches::assert_matches;
     use data_types::{ShardIndex, TimestampRange};
     use sharder::mock::{MockSharder, MockSharderCall, MockSharderPayload};
-    use std::sync::Arc;
     use write_buffer::mock::{MockBufferForWriting, MockBufferSharedState};
+
+    use super::*;
+    use crate::dml_handlers::DmlHandler;
 
     // Parse `lp` into a table-keyed MutableBatch map.
     fn lp_to_writes(lp: &str) -> Partitioned<HashMap<String, MutableBatch>> {

--- a/router/src/dml_handlers/trait.rs
+++ b/router/src/dml_handlers/trait.rs
@@ -1,9 +1,11 @@
-use super::{partitioner::PartitionError, NamespaceCreationError, SchemaError, ShardError};
+use std::{error::Error, fmt::Debug, sync::Arc};
+
 use async_trait::async_trait;
 use data_types::{DatabaseName, DeletePredicate};
-use std::{error::Error, fmt::Debug, sync::Arc};
 use thiserror::Error;
 use trace::ctx::SpanContext;
+
+use super::{partitioner::PartitionError, NamespaceCreationError, SchemaError, ShardError};
 
 /// Errors emitted by a [`DmlHandler`] implementation during DML request
 /// processing.

--- a/router/src/dml_handlers/write_summary.rs
+++ b/router/src/dml_handlers/write_summary.rs
@@ -1,7 +1,7 @@
 use std::fmt::Debug;
 
 use async_trait::async_trait;
-use data_types::{DatabaseName, DeletePredicate};
+use data_types::{DatabaseName, DeletePredicate, NamespaceId};
 use dml::DmlMeta;
 use trace::ctx::SpanContext;
 use write_summary::WriteSummary;
@@ -40,10 +40,14 @@ where
     async fn write(
         &self,
         namespace: &DatabaseName<'static>,
+        namespace_id: NamespaceId,
         input: Self::WriteInput,
         span_ctx: Option<SpanContext>,
     ) -> Result<Self::WriteOutput, Self::WriteError> {
-        let metas = self.inner.write(namespace, input, span_ctx).await?;
+        let metas = self
+            .inner
+            .write(namespace, namespace_id, input, span_ctx)
+            .await?;
         Ok(WriteSummary::new(metas))
     }
 

--- a/router/src/dml_handlers/write_summary.rs
+++ b/router/src/dml_handlers/write_summary.rs
@@ -1,10 +1,12 @@
-use super::DmlHandler;
+use std::fmt::Debug;
+
 use async_trait::async_trait;
 use data_types::{DatabaseName, DeletePredicate};
 use dml::DmlMeta;
-use std::fmt::Debug;
 use trace::ctx::SpanContext;
 use write_summary::WriteSummary;
+
+use super::DmlHandler;
 
 /// A [`WriteSummaryAdapter`] wraps DML Handler that produces
 ///  `Vec<Vec<DmlMeta>>` for each write, and produces a WriteSummary,

--- a/router/src/lib.rs
+++ b/router/src/lib.rs
@@ -1,14 +1,96 @@
-//! IOx router role implementation.
+//! IOx router implementation.
 //!
 //! An IOx router is responsible for:
 //!
 //! * Creating IOx namespaces & synchronising them within the catalog.
 //! * Handling writes:
-//!     * Receiving IOx write/delete requests via HTTP and gRPC endpoints.
+//!     * Receiving IOx write/delete requests via HTTP.
 //!     * Enforcing schema validation & synchronising it within the catalog.
 //!     * Deriving the partition key of each DML operation.
 //!     * Applying sharding logic.
-//!     * Push resulting operations into the appropriate shards (Kafka partitions if using Kafka).
+//!     * Push resulting operations into the appropriate shards (Kafka
+//!       partitions if using Kafka).
+//!
+//! The router is composed of singly-responsible components that each apply a
+//! transformation to the request:
+//!
+//! ```text
+//!                           ┌──────────────┐
+//!                           │   HTTP API   │
+//!                           └──────────────┘
+//!                                   │
+//!                                   │
+//!                                   ▼
+//!                      ╔═ NamespaceResolver ════╗
+//!                      ║                        ║
+//!                      ║  ┌──────────────────┐  ║
+//!                      ║  │    Namespace     │  ║
+//!                      ║  │   Autocreation   │ ─║─ ─ ─ ─ ─ ─
+//!                      ║  └──────────────────┘  ║           │
+//!                      ║            │           ║
+//!                      ║            ▼           ║           │
+//!                      ║  ┌──────────────────┐  ║
+//!                      ║  │ NamespaceSchema  │  ║           │
+//!                      ║  │     Resolver     │ ─║─ ─ ─ ─ ─ ─
+//!                      ║  └──────────────────┘  ║           │
+//!                      ║            │           ║
+//!                      ╚════════════│═══════════╝           │
+//!                                   │              ┌─────────────────┐
+//!                                   │              │ Namespace Cache │
+//!                                   │              └─────────────────┘
+//!                      ╔═ DmlHandler│Stack ═════╗           │
+//!                      ║            ▼           ║
+//!                      ║  ┌──────────────────┐  ║           │
+//!                      ║  │   Partitioner    │  ║
+//!                      ║  └──────────────────┘  ║           │
+//!                      ║            │           ║
+//!                      ║            ▼           ║           │
+//!                      ║  ┌──────────────────┐  ║
+//!                      ║  │      Schema      │  ║           │
+//!                      ║  │    Validation    │ ─║─ ─ ─ ─ ─ ─
+//!                      ║  └──────────────────┘  ║
+//!                      ║            │           ║
+//!                      ║            ▼           ║
+//!         ┌───────┐    ║  ┌──────────────────┐  ║
+//!         │Sharder│◀ ─ ─ ▶│ShardedWriteBuffer│  ║
+//!         └───────┘    ║  └──────────────────┘  ║
+//!                      ║            │           ║
+//!                      ╚════════════│═══════════╝
+//!                                   │
+//!                                   ▼
+//!                           ┌──────────────┐
+//!                           │ Write Buffer │
+//!                           └──────────────┘
+//!                                   │
+//!                                   │
+//!                          ┌────────▼─────┐
+//!                          │    Kafka     ├┐
+//!                          └┬─────────────┘├┐
+//!                           └┬─────────────┘│
+//!                            └──────────────┘
+//! ```
+//!
+//! The [`NamespaceAutocreation`] handler (for testing only) populates the
+//! global catalog with an entry for each namespace it observes, using the
+//! [`NamespaceCache`] as an optimisation, allowing the handler to skip sending
+//! requests to the catalog for namespaces that are known to exist.
+//!
+//! A [`NamespaceResolver`] maps a user-provided namespace string to the
+//! catalog ID ([`NamespaceId`]). The [`NamespaceSchemaResolver`] achieves this
+//! by inspecting the contents of the [`NamespaceCache`]. If a cache-miss
+//! occurs the [`NamespaceSchemaResolver`] queries the catalog and populates the
+//! cache for subsequent requests.
+//!
+//! Once the [`NamespaceId`] has been resolved, the request is passed into the
+//! [`DmlHandler`] stack.
+//!
+//! [`NamespaceAutocreation`]: crate::namespace_resolver::NamespaceAutocreation
+//! [`NamespaceSchemaResolver`]: crate::namespace_resolver::NamespaceSchemaResolver
+//! [`NamespaceResolver`]: crate::namespace_resolver
+//! [`NamespaceId`]: data_types::NamespaceId
+//! [`NamespaceCache`]: crate::namespace_cache::NamespaceCache
+//! [`NamespaceSchema`]: data_types::NamespaceSchema
+//! [`DmlHandler`]: crate::dml_handlers
 
 #![deny(
     rustdoc::broken_intra_doc_links,
@@ -28,5 +110,6 @@
 
 pub mod dml_handlers;
 pub mod namespace_cache;
+pub mod namespace_resolver;
 pub mod server;
 pub mod shard;

--- a/router/src/namespace_cache.rs
+++ b/router/src/namespace_cache.rs
@@ -8,8 +8,9 @@ pub use sharded_cache::*;
 
 pub mod metrics;
 
-use data_types::{DatabaseName, NamespaceSchema};
 use std::{fmt::Debug, sync::Arc};
+
+use data_types::{DatabaseName, NamespaceSchema};
 
 /// An abstract cache of [`NamespaceSchema`].
 pub trait NamespaceCache: Debug + Send + Sync {

--- a/router/src/namespace_cache/memory.rs
+++ b/router/src/namespace_cache/memory.rs
@@ -1,8 +1,10 @@
-use super::NamespaceCache;
+use std::sync::Arc;
+
 use data_types::{DatabaseName, NamespaceSchema};
 use hashbrown::HashMap;
 use parking_lot::RwLock;
-use std::sync::Arc;
+
+use super::NamespaceCache;
 
 /// An in-memory cache of [`NamespaceSchema`] backed by a hashmap protected with
 /// a read-write mutex.
@@ -27,8 +29,9 @@ impl NamespaceCache for Arc<MemoryNamespaceCache> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use data_types::{NamespaceId, QueryPoolId, TopicId};
+
+    use super::*;
 
     #[test]
     fn test_put_get() {

--- a/router/src/namespace_cache/metrics.rs
+++ b/router/src/namespace_cache/metrics.rs
@@ -1,10 +1,12 @@
 //! Metric instrumentation for a [`NamespaceCache`] implementation.
 
-use super::NamespaceCache;
+use std::sync::Arc;
+
 use data_types::{DatabaseName, NamespaceSchema};
 use iox_time::{SystemProvider, TimeProvider};
 use metric::{DurationHistogram, Metric, U64Gauge};
-use std::sync::Arc;
+
+use super::NamespaceCache;
 
 /// An [`InstrumentedCache`] decorates a [`NamespaceCache`] with cache read
 /// hit/miss and cache put insert/update metrics.
@@ -151,13 +153,15 @@ impl NamespaceStats {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::namespace_cache::MemoryNamespaceCache;
+    use std::collections::BTreeMap;
+
     use data_types::{
         ColumnId, ColumnSchema, ColumnType, NamespaceId, QueryPoolId, TableId, TableSchema, TopicId,
     };
     use metric::{Attributes, MetricObserver, Observation};
-    use std::collections::BTreeMap;
+
+    use super::*;
+    use crate::namespace_cache::MemoryNamespaceCache;
 
     /// Deterministically generate a schema containing tables with the specified
     /// column cardinality.

--- a/router/src/namespace_cache/sharded_cache.rs
+++ b/router/src/namespace_cache/sharded_cache.rs
@@ -1,7 +1,9 @@
-use super::NamespaceCache;
+use std::sync::Arc;
+
 use data_types::{DatabaseName, NamespaceSchema};
 use sharder::JumpHash;
-use std::sync::Arc;
+
+use super::NamespaceCache;
 
 /// A decorator sharding the [`NamespaceCache`] keyspace into a set of `T`.
 #[derive(Debug)]
@@ -38,11 +40,13 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::namespace_cache::MemoryNamespaceCache;
+    use std::{collections::HashMap, iter};
+
     use data_types::{NamespaceId, QueryPoolId, TopicId};
     use rand::{distributions::Alphanumeric, thread_rng, Rng};
-    use std::{collections::HashMap, iter};
+
+    use super::*;
+    use crate::namespace_cache::MemoryNamespaceCache;
 
     fn rand_namespace() -> DatabaseName<'static> {
         thread_rng()

--- a/router/src/namespace_resolver.rs
+++ b/router/src/namespace_resolver.rs
@@ -1,0 +1,209 @@
+//! An trait to abstract resolving a[`DatabaseName`] to [`NamespaceId`], and a
+//! collection of composable implementations.
+
+use std::{ops::DerefMut, sync::Arc};
+
+use async_trait::async_trait;
+use data_types::{DatabaseName, NamespaceId};
+use iox_catalog::interface::{get_schema_by_name, Catalog};
+use observability_deps::tracing::*;
+use thiserror::Error;
+
+use crate::namespace_cache::NamespaceCache;
+
+pub mod mock;
+mod ns_autocreation;
+pub use ns_autocreation::*;
+
+/// Error states encountered during [`NamespaceId`] lookup.
+#[derive(Debug, Error)]
+pub enum Error {
+    /// An error occured when attempting to fetch the namespace ID.
+    #[error("failed to resolve namespace ID: {0}")]
+    Lookup(iox_catalog::interface::Error),
+
+    /// An error state for errors returned by [`NamespaceAutocreation`].
+    #[error(transparent)]
+    Create(#[from] NamespaceCreationError),
+}
+
+/// An abstract resolver of [`DatabaseName`] to [`NamespaceId`].
+#[async_trait]
+pub trait NamespaceResolver: std::fmt::Debug + Send + Sync {
+    /// Return the [`NamespaceId`] for the given [`DatabaseName`].
+    async fn get_namespace_id(
+        &self,
+        namespace: &DatabaseName<'static>,
+    ) -> Result<NamespaceId, Error>;
+}
+
+/// An implementation of [`NamespaceResolver`] that queries the [`Catalog`] to
+/// resolve a [`NamespaceId`], and populates the [`NamespaceCache`] as a side
+/// effect.
+#[derive(Debug)]
+pub struct NamespaceSchemaResolver<C> {
+    catalog: Arc<dyn Catalog>,
+    cache: C,
+}
+
+impl<C> NamespaceSchemaResolver<C> {
+    /// Construct a new [`NamespaceSchemaResolver`] that fetches schemas from
+    /// `catalog` and caches them in `cache`.
+    pub fn new(catalog: Arc<dyn Catalog>, cache: C) -> Self {
+        Self { catalog, cache }
+    }
+}
+
+#[async_trait]
+impl<C> NamespaceResolver for NamespaceSchemaResolver<C>
+where
+    C: NamespaceCache,
+{
+    async fn get_namespace_id(
+        &self,
+        namespace: &DatabaseName<'static>,
+    ) -> Result<NamespaceId, Error> {
+        // Load the namespace schema from the cache, falling back to pulling it
+        // from the global catalog (if it exists).
+        match self.cache.get_schema(namespace) {
+            Some(v) => Ok(v.id),
+            None => {
+                let mut repos = self.catalog.repositories().await;
+
+                // Pull the schema from the global catalog or error if it does
+                // not exist.
+                let schema = get_schema_by_name(namespace, repos.deref_mut())
+                    .await
+                    .map_err(|e| {
+                        warn!(
+                            error=%e,
+                            %namespace,
+                            "failed to retrieve namespace schema"
+                        );
+                        Error::Lookup(e)
+                    })
+                    .map(Arc::new)?;
+
+                // Cache population MAY race with other threads and lead to
+                // overwrites, but an entry will always exist once inserted, and
+                // the schemas will eventually converge.
+                self.cache
+                    .put_schema(namespace.clone(), Arc::clone(&schema));
+
+                trace!(%namespace, "schema cache populated");
+                Ok(schema.id)
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use assert_matches::assert_matches;
+    use data_types::{NamespaceId, NamespaceSchema, QueryPoolId, TopicId};
+    use iox_catalog::mem::MemCatalog;
+
+    use super::*;
+    use crate::namespace_cache::MemoryNamespaceCache;
+
+    #[tokio::test]
+    async fn test_cache_hit() {
+        let ns = DatabaseName::try_from("bananas").unwrap();
+
+        // Prep the cache before the test to cause a hit
+        let cache = Arc::new(MemoryNamespaceCache::default());
+        cache.put_schema(
+            ns.clone(),
+            NamespaceSchema {
+                id: NamespaceId::new(42),
+                topic_id: TopicId::new(2),
+                query_pool_id: QueryPoolId::new(3),
+                tables: Default::default(),
+                max_columns_per_table: 4,
+            },
+        );
+
+        let metrics = Arc::new(metric::Registry::new());
+        let catalog: Arc<dyn Catalog> = Arc::new(MemCatalog::new(metrics));
+
+        let resolver = NamespaceSchemaResolver::new(Arc::clone(&catalog), Arc::clone(&cache));
+
+        // Drive the code under test
+        resolver
+            .get_namespace_id(&ns)
+            .await
+            .expect("lookup should succeed");
+
+        assert!(cache.get_schema(&ns).is_some());
+
+        // The cache hit should mean the catalog SHOULD NOT see a create request
+        // for the namespace.
+        let mut repos = catalog.repositories().await;
+        assert!(
+            repos
+                .namespaces()
+                .get_by_name(ns.as_str())
+                .await
+                .expect("lookup should not error")
+                .is_none(),
+            "expected no request to the catalog"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_cache_miss() {
+        let ns = DatabaseName::try_from("bananas").unwrap();
+
+        let cache = Arc::new(MemoryNamespaceCache::default());
+        let metrics = Arc::new(metric::Registry::new());
+        let catalog: Arc<dyn Catalog> = Arc::new(MemCatalog::new(metrics));
+
+        // Create the namespace in the catalog
+        {
+            let mut repos = catalog.repositories().await;
+            let topic = repos.topics().create_or_get("bananas").await.unwrap();
+            let query_pool = repos.query_pools().create_or_get("platanos").await.unwrap();
+            repos
+                .namespaces()
+                .create(
+                    &ns,
+                    iox_catalog::INFINITE_RETENTION_POLICY,
+                    topic.id,
+                    query_pool.id,
+                )
+                .await
+                .expect("failed to setup catalog state");
+        }
+
+        let resolver = NamespaceSchemaResolver::new(Arc::clone(&catalog), Arc::clone(&cache));
+
+        resolver
+            .get_namespace_id(&ns)
+            .await
+            .expect("lookup should succeed");
+
+        // The cache should be populated as a result of the lookup.
+        assert!(cache.get_schema(&ns).is_some());
+    }
+
+    #[tokio::test]
+    async fn test_cache_miss_does_not_exist() {
+        let ns = DatabaseName::try_from("bananas").unwrap();
+
+        let cache = Arc::new(MemoryNamespaceCache::default());
+        let metrics = Arc::new(metric::Registry::new());
+        let catalog: Arc<dyn Catalog> = Arc::new(MemCatalog::new(metrics));
+
+        let resolver = NamespaceSchemaResolver::new(Arc::clone(&catalog), Arc::clone(&cache));
+
+        let err = resolver
+            .get_namespace_id(&ns)
+            .await
+            .expect_err("lookup should error");
+
+        assert_matches!(err, Error::Lookup(_));
+        assert!(cache.get_schema(&ns).is_none());
+    }
+}

--- a/router/src/namespace_resolver/mock.rs
+++ b/router/src/namespace_resolver/mock.rs
@@ -1,0 +1,45 @@
+//! A mock implementation of [`NamespaceResolver`].
+
+#![allow(missing_docs)]
+
+use std::collections::HashMap;
+
+use async_trait::async_trait;
+use data_types::{DatabaseName, NamespaceId};
+use parking_lot::Mutex;
+
+use super::NamespaceResolver;
+
+#[derive(Debug, Default)]
+pub struct MockNamespaceResolver {
+    map: Mutex<HashMap<DatabaseName<'static>, NamespaceId>>,
+}
+
+impl MockNamespaceResolver {
+    pub fn new(map: HashMap<DatabaseName<'static>, NamespaceId>) -> Self {
+        Self {
+            map: Mutex::new(map),
+        }
+    }
+
+    pub fn with_mapping(self, name: impl Into<String> + 'static, id: NamespaceId) -> Self {
+        let name = DatabaseName::try_from(name.into()).unwrap();
+        assert!(self.map.lock().insert(name, id).is_none());
+        self
+    }
+}
+
+#[async_trait]
+impl NamespaceResolver for MockNamespaceResolver {
+    /// Return the [`NamespaceId`] for the given [`DatabaseName`].
+    async fn get_namespace_id(
+        &self,
+        namespace: &DatabaseName<'static>,
+    ) -> Result<NamespaceId, super::Error> {
+        Ok(*self
+            .map
+            .lock()
+            .get(namespace)
+            .expect("mock namespace resolver does not have ID"))
+    }
+}

--- a/router/src/namespace_resolver/ns_autocreation.rs
+++ b/router/src/namespace_resolver/ns_autocreation.rs
@@ -1,0 +1,221 @@
+use std::{fmt::Debug, sync::Arc};
+
+use async_trait::async_trait;
+use data_types::{DatabaseName, NamespaceId, QueryPoolId, TopicId};
+use iox_catalog::interface::Catalog;
+use observability_deps::tracing::*;
+use thiserror::Error;
+
+use super::NamespaceResolver;
+use crate::namespace_cache::NamespaceCache;
+
+/// An error auto-creating the request namespace.
+#[derive(Debug, Error)]
+pub enum NamespaceCreationError {
+    /// An error returned from a namespace creation request.
+    #[error("failed to create namespace: {0}")]
+    Create(iox_catalog::interface::Error),
+}
+
+/// A layer to populate the [`Catalog`] with all the namespaces the router
+/// observes.
+///
+/// Uses a [`NamespaceCache`] to limit issuing create requests to namespaces the
+/// router has not yet observed a schema for.
+#[derive(Debug)]
+pub struct NamespaceAutocreation<C, T> {
+    inner: T,
+    cache: C,
+    catalog: Arc<dyn Catalog>,
+
+    topic_id: TopicId,
+    query_id: QueryPoolId,
+    retention: String,
+}
+
+impl<C, T> NamespaceAutocreation<C, T> {
+    /// Return a new [`NamespaceAutocreation`] layer that ensures a requested
+    /// namespace exists in `catalog`.
+    ///
+    /// If the namespace does not exist, it is created with the specified
+    /// `topic_id`, `query_id` and `retention` policy.
+    ///
+    /// Namespaces are looked up in `cache`, skipping the creation request to
+    /// the catalog if there's a hit.
+    pub fn new(
+        inner: T,
+        cache: C,
+        catalog: Arc<dyn Catalog>,
+        topic_id: TopicId,
+        query_id: QueryPoolId,
+        retention: String,
+    ) -> Self {
+        Self {
+            inner,
+            cache,
+            catalog,
+            topic_id,
+            query_id,
+            retention,
+        }
+    }
+}
+
+#[async_trait]
+impl<C, T> NamespaceResolver for NamespaceAutocreation<C, T>
+where
+    C: NamespaceCache,
+    T: NamespaceResolver,
+{
+    /// Force the creation of `namespace` if it does not already exist in the
+    /// cache, before passing the request through to the inner delegate.
+    async fn get_namespace_id(
+        &self,
+        namespace: &DatabaseName<'static>,
+    ) -> Result<NamespaceId, super::Error> {
+        if self.cache.get_schema(namespace).is_none() {
+            trace!(%namespace, "namespace auto-create cache miss");
+
+            let mut repos = self.catalog.repositories().await;
+
+            match repos
+                .namespaces()
+                .create(
+                    namespace.as_str(),
+                    &self.retention,
+                    self.topic_id,
+                    self.query_id,
+                )
+                .await
+            {
+                Ok(_) => {
+                    debug!(%namespace, "created namespace");
+                }
+                Err(iox_catalog::interface::Error::NameExists { .. }) => {
+                    // Either the cache has not yet converged to include this
+                    // namespace, or another thread raced populating the catalog
+                    // and beat this thread to it.
+                    debug!(%namespace, "spurious namespace create failed");
+                }
+                Err(e) => {
+                    error!(error=%e, %namespace, "failed to auto-create namespace");
+                    return Err(NamespaceCreationError::Create(e).into());
+                }
+            }
+        }
+
+        self.inner.get_namespace_id(namespace).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use data_types::{Namespace, NamespaceId, NamespaceSchema};
+    use iox_catalog::mem::MemCatalog;
+
+    use super::*;
+    use crate::{
+        namespace_cache::MemoryNamespaceCache, namespace_resolver::mock::MockNamespaceResolver,
+    };
+
+    #[tokio::test]
+    async fn test_cache_hit() {
+        const NAMESPACE_ID: NamespaceId = NamespaceId::new(42);
+
+        let ns = DatabaseName::try_from("bananas").unwrap();
+
+        // Prep the cache before the test to cause a hit
+        let cache = Arc::new(MemoryNamespaceCache::default());
+        cache.put_schema(
+            ns.clone(),
+            NamespaceSchema {
+                id: NAMESPACE_ID,
+                topic_id: TopicId::new(2),
+                query_pool_id: QueryPoolId::new(3),
+                tables: Default::default(),
+                max_columns_per_table: 4,
+            },
+        );
+
+        let metrics = Arc::new(metric::Registry::new());
+        let catalog: Arc<dyn Catalog> = Arc::new(MemCatalog::new(metrics));
+
+        let creator = NamespaceAutocreation::new(
+            MockNamespaceResolver::default().with_mapping(ns.clone(), NAMESPACE_ID),
+            cache,
+            Arc::clone(&catalog),
+            TopicId::new(42),
+            QueryPoolId::new(42),
+            "inf".to_owned(),
+        );
+
+        // Drive the code under test
+        let got = creator
+            .get_namespace_id(&ns)
+            .await
+            .expect("handler should succeed");
+        assert_eq!(got, NAMESPACE_ID);
+
+        // The cache hit should mean the catalog SHOULD NOT see a create request
+        // for the namespace.
+        let mut repos = catalog.repositories().await;
+        assert!(
+            repos
+                .namespaces()
+                .get_by_name(ns.as_str())
+                .await
+                .expect("lookup should not error")
+                .is_none(),
+            "expected no request to the catalog"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_cache_miss() {
+        let ns = DatabaseName::try_from("bananas").unwrap();
+
+        let cache = Arc::new(MemoryNamespaceCache::default());
+        let metrics = Arc::new(metric::Registry::new());
+        let catalog: Arc<dyn Catalog> = Arc::new(MemCatalog::new(metrics));
+
+        let creator = NamespaceAutocreation::new(
+            MockNamespaceResolver::default().with_mapping(ns.clone(), NamespaceId::new(1)),
+            cache,
+            Arc::clone(&catalog),
+            TopicId::new(42),
+            QueryPoolId::new(42),
+            "inf".to_owned(),
+        );
+
+        let created_id = creator
+            .get_namespace_id(&ns)
+            .await
+            .expect("handler should succeed");
+
+        // The cache miss should mean the catalog MUST see a create request for
+        // the namespace.
+        let mut repos = catalog.repositories().await;
+        let got = repos
+            .namespaces()
+            .get_by_name(ns.as_str())
+            .await
+            .expect("lookup should not error")
+            .expect("creation request should be sent to catalog");
+
+        assert_eq!(got.id, created_id);
+        assert_eq!(
+            got,
+            Namespace {
+                id: NamespaceId::new(1),
+                name: ns.to_string(),
+                retention_duration: Some("inf".to_owned()),
+                topic_id: TopicId::new(42),
+                query_pool_id: QueryPoolId::new(42),
+                max_tables: iox_catalog::DEFAULT_MAX_TABLES,
+                max_columns_per_table: iox_catalog::DEFAULT_MAX_COLUMNS_PER_TABLE,
+            }
+        );
+    }
+}

--- a/router/src/server.rs
+++ b/router/src/server.rs
@@ -1,11 +1,13 @@
 //! Router server entrypoint.
 
-use self::{grpc::GrpcDelegate, http::HttpDelegate};
-use crate::dml_handlers::DmlHandler;
+use std::sync::Arc;
+
 use hashbrown::HashMap;
 use mutable_batch::MutableBatch;
-use std::sync::Arc;
 use trace::TraceCollector;
+
+use self::{grpc::GrpcDelegate, http::HttpDelegate};
+use crate::dml_handlers::DmlHandler;
 
 pub mod grpc;
 pub mod http;

--- a/router/src/server.rs
+++ b/router/src/server.rs
@@ -15,19 +15,19 @@ pub mod http;
 /// The [`RouterServer`] manages the lifecycle and contains all state for a
 /// `router` server instance.
 #[derive(Debug)]
-pub struct RouterServer<D, S> {
+pub struct RouterServer<D, N, S> {
     metrics: Arc<metric::Registry>,
     trace_collector: Option<Arc<dyn TraceCollector>>,
 
-    http: HttpDelegate<D>,
+    http: HttpDelegate<D, N>,
     grpc: GrpcDelegate<S>,
 }
 
-impl<D, S> RouterServer<D, S> {
+impl<D, N, S> RouterServer<D, N, S> {
     /// Initialise a new [`RouterServer`] using the provided HTTP and gRPC
     /// handlers.
     pub fn new(
-        http: HttpDelegate<D>,
+        http: HttpDelegate<D, N>,
         grpc: GrpcDelegate<S>,
         metrics: Arc<metric::Registry>,
         trace_collector: Option<Arc<dyn TraceCollector>>,
@@ -51,12 +51,12 @@ impl<D, S> RouterServer<D, S> {
     }
 }
 
-impl<D, S> RouterServer<D, S>
+impl<D, N, S> RouterServer<D, N, S>
 where
     D: DmlHandler<WriteInput = HashMap<String, MutableBatch>>,
 {
     /// Get a reference to the router http delegate.
-    pub fn http(&self) -> &HttpDelegate<D> {
+    pub fn http(&self) -> &HttpDelegate<D, N> {
         &self.http
     }
 

--- a/router/src/server/grpc.rs
+++ b/router/src/server/grpc.rs
@@ -2,8 +2,8 @@
 
 pub mod sharder;
 
-use self::sharder::ShardService;
-use crate::shard::Shard;
+use std::sync::Arc;
+
 use ::sharder::Sharder;
 use generated_types::influxdata::iox::{
     catalog::v1::*, object_store::v1::*, schema::v1::*, sharder::v1::*,
@@ -13,7 +13,9 @@ use object_store::DynObjectStore;
 use service_grpc_catalog::CatalogService;
 use service_grpc_object_store::ObjectStoreService;
 use service_grpc_schema::SchemaService;
-use std::sync::Arc;
+
+use self::sharder::ShardService;
+use crate::shard::Shard;
 
 /// This type is responsible for managing all gRPC services exposed by `router`.
 #[derive(Debug)]

--- a/router/src/server/grpc/sharder.rs
+++ b/router/src/server/grpc/sharder.rs
@@ -1,6 +1,7 @@
 //! A gRPC service to provide shard mappings to external clients.
 
-use crate::shard::Shard;
+use std::sync::Arc;
+
 use data_types::{DatabaseName, ShardId, ShardIndex, TopicMetadata};
 use generated_types::influxdata::iox::sharder::v1::{
     shard_service_server, MapToShardRequest, MapToShardResponse,
@@ -8,8 +9,9 @@ use generated_types::influxdata::iox::sharder::v1::{
 use hashbrown::HashMap;
 use iox_catalog::interface::Catalog;
 use sharder::Sharder;
-use std::sync::Arc;
 use tonic::{Request, Response};
+
+use crate::shard::Shard;
 
 /// A [`ShardService`] exposes a [gRPC endpoint] for external systems to discover the shard mapping
 /// for specific tables.

--- a/router/src/server/http.rs
+++ b/router/src/server/http.rs
@@ -2,8 +2,8 @@
 
 mod delete_predicate;
 
-use self::delete_predicate::parse_http_delete_request;
-use crate::dml_handlers::{DmlError, DmlHandler, PartitionError, SchemaError};
+use std::{str::Utf8Error, sync::Arc, time::Instant};
+
 use bytes::{Bytes, BytesMut};
 use data_types::{org_and_bucket_to_database, OrgBucketMappingError};
 use futures::StreamExt;
@@ -16,12 +16,13 @@ use mutable_batch_lp::LinesConverter;
 use observability_deps::tracing::*;
 use predicate::delete_predicate::parse_delete_predicate;
 use serde::Deserialize;
-use std::time::Instant;
-use std::{str::Utf8Error, sync::Arc};
 use thiserror::Error;
 use tokio::sync::{Semaphore, TryAcquireError};
 use trace::ctx::SpanContext;
 use write_summary::WriteSummary;
+
+use self::delete_predicate::parse_http_delete_request;
+use crate::dml_handlers::{DmlError, DmlHandler, PartitionError, SchemaError};
 
 const WRITE_TOKEN_HTTP_HEADER: &str = "X-IOx-Write-Token";
 
@@ -521,7 +522,6 @@ mod tests {
     use std::{io::Write, iter, sync::Arc, time::Duration};
 
     use assert_matches::assert_matches;
-
     use flate2::{write::GzEncoder, Compression};
     use hyper::header::HeaderValue;
     use metric::{Attributes, Metric};
@@ -530,9 +530,8 @@ mod tests {
     use test_helpers::timeout::FutureTimeout;
     use tokio_stream::wrappers::ReceiverStream;
 
-    use crate::dml_handlers::mock::{MockDmlHandler, MockDmlHandlerCall};
-
     use super::*;
+    use crate::dml_handlers::mock::{MockDmlHandler, MockDmlHandlerCall};
 
     const MAX_BYTES: usize = 1024;
 

--- a/router/src/server/http.rs
+++ b/router/src/server/http.rs
@@ -22,7 +22,10 @@ use trace::ctx::SpanContext;
 use write_summary::WriteSummary;
 
 use self::delete_predicate::parse_http_delete_request;
-use crate::dml_handlers::{DmlError, DmlHandler, PartitionError, SchemaError};
+use crate::{
+    dml_handlers::{DmlError, DmlHandler, PartitionError, SchemaError},
+    namespace_resolver::NamespaceResolver,
+};
 
 const WRITE_TOKEN_HTTP_HEADER: &str = "X-IOx-Write-Token";
 
@@ -77,6 +80,13 @@ pub enum Error {
     #[error("dml handler error: {0}")]
     DmlHandler(#[from] DmlError),
 
+    /// An error that occurs when attempting to map the user-provided namespace
+    /// name into a [`NamespaceId`].
+    ///
+    /// [`NamespaceId`]: data_types::NamespaceId
+    #[error("failed to resolve namespace ID: {0}")]
+    NamespaceResolver(#[from] crate::namespace_resolver::Error),
+
     /// The router is currently servicing the maximum permitted number of
     /// simultaneous requests.
     #[error("this service is overloaded, please try again later")]
@@ -103,6 +113,7 @@ impl Error {
                 StatusCode::UNSUPPORTED_MEDIA_TYPE
             }
             Error::DmlHandler(err) => StatusCode::from(err),
+            Error::NamespaceResolver(_) => StatusCode::INTERNAL_SERVER_ERROR,
             Error::RequestLimit => StatusCode::SERVICE_UNAVAILABLE,
         }
     }
@@ -128,9 +139,7 @@ impl From<&DmlError> for StatusCode {
                 StatusCode::INTERNAL_SERVER_ERROR
             }
 
-            DmlError::Internal(_) | DmlError::WriteBuffer(_) | DmlError::NamespaceCreation(_) => {
-                StatusCode::INTERNAL_SERVER_ERROR
-            }
+            DmlError::Internal(_) | DmlError::WriteBuffer(_) => StatusCode::INTERNAL_SERVER_ERROR,
             DmlError::Partition(PartitionError::BatchWrite(_)) => StatusCode::INTERNAL_SERVER_ERROR,
         }
     }
@@ -216,9 +225,10 @@ impl<T> TryFrom<&Request<T>> for WriteInfo {
 /// server runner framework takes care of implementing the heath endpoint,
 /// metrics, pprof, etc.
 #[derive(Debug)]
-pub struct HttpDelegate<D, T = SystemProvider> {
+pub struct HttpDelegate<D, N, T = SystemProvider> {
     max_request_bytes: usize,
     time_provider: T,
+    namespace_resolver: N,
     dml_handler: Arc<D>,
 
     // A request limiter to restrict the number of simultaneous requests this
@@ -239,7 +249,7 @@ pub struct HttpDelegate<D, T = SystemProvider> {
     request_limit_rejected: U64Counter,
 }
 
-impl<D> HttpDelegate<D, SystemProvider> {
+impl<D, N> HttpDelegate<D, N, SystemProvider> {
     /// Initialise a new [`HttpDelegate`] passing valid requests to the
     /// specified `dml_handler`.
     ///
@@ -248,6 +258,7 @@ impl<D> HttpDelegate<D, SystemProvider> {
     pub fn new(
         max_request_bytes: usize,
         max_requests: usize,
+        namespace_resolver: N,
         dml_handler: Arc<D>,
         metrics: &metric::Registry,
     ) -> Self {
@@ -297,6 +308,7 @@ impl<D> HttpDelegate<D, SystemProvider> {
         Self {
             max_request_bytes,
             time_provider: SystemProvider::default(),
+            namespace_resolver,
             dml_handler,
             request_sem: Semaphore::new(max_requests),
             write_metric_lines,
@@ -310,9 +322,10 @@ impl<D> HttpDelegate<D, SystemProvider> {
     }
 }
 
-impl<D, T> HttpDelegate<D, T>
+impl<D, N, T> HttpDelegate<D, N, T>
 where
     D: DmlHandler<WriteInput = HashMap<String, MutableBatch>, WriteOutput = WriteSummary>,
+    N: NamespaceResolver,
     T: TimeProvider,
 {
     /// Routes `req` to the appropriate handler, if any, returning the handler
@@ -395,9 +408,12 @@ where
             "routing write",
         );
 
+        // Retrieve the namespace ID for this namespace.
+        let namespace_id = self.namespace_resolver.get_namespace_id(&namespace).await?;
+
         let summary = self
             .dml_handler
-            .write(&namespace, batches, span_ctx)
+            .write(&namespace, namespace_id, batches, span_ctx)
             .await
             .map_err(Into::into)?;
 
@@ -522,6 +538,7 @@ mod tests {
     use std::{io::Write, iter, sync::Arc, time::Duration};
 
     use assert_matches::assert_matches;
+    use data_types::NamespaceId;
     use flate2::{write::GzEncoder, Compression};
     use hyper::header::HeaderValue;
     use metric::{Attributes, Metric};
@@ -531,9 +548,13 @@ mod tests {
     use tokio_stream::wrappers::ReceiverStream;
 
     use super::*;
-    use crate::dml_handlers::mock::{MockDmlHandler, MockDmlHandlerCall};
+    use crate::{
+        dml_handlers::mock::{MockDmlHandler, MockDmlHandlerCall},
+        namespace_resolver::mock::MockNamespaceResolver,
+    };
 
     const MAX_BYTES: usize = 1024;
+    const NAMESPACE_ID: NamespaceId = NamespaceId::new(42);
 
     fn summary() -> WriteSummary {
         WriteSummary::default()
@@ -620,12 +641,20 @@ mod tests {
                     // encoding
                     test_http_handler!(encoding_header=$encoding, request);
 
+                    let mock_namespace_resolver = MockNamespaceResolver::default()
+                        .with_mapping("bananas_test", NAMESPACE_ID);
                     let dml_handler = Arc::new(MockDmlHandler::default()
                         .with_write_return($dml_write_handler)
                         .with_delete_return($dml_delete_handler)
                     );
                     let metrics = Arc::new(metric::Registry::default());
-                    let delegate = HttpDelegate::new(MAX_BYTES, 100, Arc::clone(&dml_handler), &metrics);
+                    let delegate = HttpDelegate::new(
+                        MAX_BYTES,
+                        100,
+                        mock_namespace_resolver,
+                        Arc::clone(&dml_handler),
+                        &metrics
+                    );
 
                     let got = delegate.route(request).await;
                     assert_matches!(got, $want_result);
@@ -732,8 +761,9 @@ mod tests {
         body = "platanos,tag1=A,tag2=B val=42i 1647622847".as_bytes(),
         dml_handler = [Ok(summary())],
         want_result = Ok(_),
-        want_dml_calls = [MockDmlHandlerCall::Write{namespace, write_input}] => {
+        want_dml_calls = [MockDmlHandlerCall::Write{namespace, namespace_id, write_input}] => {
             assert_eq!(namespace, "bananas_test");
+            assert_eq!(*namespace_id, NAMESPACE_ID);
 
             let table = write_input.get("platanos").expect("table not found");
             let ts = table.timestamp_summary().expect("no timestamp summary");
@@ -747,8 +777,9 @@ mod tests {
         body = "platanos,tag1=A,tag2=B val=42i 1647622847000".as_bytes(),
         dml_handler = [Ok(summary())],
         want_result = Ok(_),
-        want_dml_calls = [MockDmlHandlerCall::Write{namespace, write_input}] => {
+        want_dml_calls = [MockDmlHandlerCall::Write{namespace, namespace_id, write_input}] => {
             assert_eq!(namespace, "bananas_test");
+            assert_eq!(*namespace_id, NAMESPACE_ID);
 
             let table = write_input.get("platanos").expect("table not found");
             let ts = table.timestamp_summary().expect("no timestamp summary");
@@ -762,8 +793,9 @@ mod tests {
         body = "platanos,tag1=A,tag2=B val=42i 1647622847000000".as_bytes(),
         dml_handler = [Ok(summary())],
         want_result = Ok(_),
-        want_dml_calls = [MockDmlHandlerCall::Write{namespace, write_input}] => {
+        want_dml_calls = [MockDmlHandlerCall::Write{namespace, namespace_id, write_input}] => {
             assert_eq!(namespace, "bananas_test");
+            assert_eq!(*namespace_id, NAMESPACE_ID);
 
             let table = write_input.get("platanos").expect("table not found");
             let ts = table.timestamp_summary().expect("no timestamp summary");
@@ -777,8 +809,9 @@ mod tests {
         body = "platanos,tag1=A,tag2=B val=42i 1647622847000000000".as_bytes(),
         dml_handler = [Ok(summary())],
         want_result = Ok(_),
-        want_dml_calls = [MockDmlHandlerCall::Write{namespace, write_input}] => {
+        want_dml_calls = [MockDmlHandlerCall::Write{namespace, namespace_id, write_input}] => {
             assert_eq!(namespace, "bananas_test");
+            assert_eq!(*namespace_id, NAMESPACE_ID);
 
             let table = write_input.get("platanos").expect("table not found");
             let ts = table.timestamp_summary().expect("no timestamp summary");
@@ -906,8 +939,9 @@ mod tests {
         body = "test field=1u 100\ntest field=2u 100".as_bytes(),
         dml_handler = [Ok(summary())],
         want_result = Ok(_),
-        want_dml_calls = [MockDmlHandlerCall::Write{namespace, write_input}] => {
+        want_dml_calls = [MockDmlHandlerCall::Write{namespace, namespace_id, write_input}] => {
             assert_eq!(namespace, "bananas_test");
+            assert_eq!(*namespace_id, NAMESPACE_ID);
             let table = write_input.get("test").expect("table not in write");
             let col = table.column("field").expect("column missing");
             assert_matches!(col.data(), ColumnData::U64(data, _) => {
@@ -1039,7 +1073,7 @@ mod tests {
             body = "whydo InputPower=300i,InputPower=300i".as_bytes(),
             dml_handler = [Ok(summary())],
             want_result = Ok(_),
-            want_dml_calls = [MockDmlHandlerCall::Write{namespace, write_input}] => {
+            want_dml_calls = [MockDmlHandlerCall::Write{namespace, write_input, ..}] => {
                 assert_eq!(namespace, "bananas_test");
                 let table = write_input.get("whydo").expect("table not in write");
                 let col = table.column("InputPower").expect("column missing");
@@ -1056,7 +1090,7 @@ mod tests {
             body = "whydo InputPower=300i,InputPower=42i".as_bytes(),
             dml_handler = [Ok(summary())],
             want_result = Ok(_),
-            want_dml_calls = [MockDmlHandlerCall::Write{namespace, write_input}] => {
+            want_dml_calls = [MockDmlHandlerCall::Write{namespace, write_input, ..}] => {
                 assert_eq!(namespace, "bananas_test");
                 let table = write_input.get("whydo").expect("table not in write");
                 let col = table.column("InputPower").expect("column missing");
@@ -1154,11 +1188,15 @@ mod tests {
     // number of simultaneous requests are being serviced.
     #[tokio::test]
     async fn test_request_limit_enforced() {
+        let mock_namespace_resolver =
+            MockNamespaceResolver::default().with_mapping("bananas", NamespaceId::new(42));
+
         let dml_handler = Arc::new(MockDmlHandler::default());
         let metrics = Arc::new(metric::Registry::default());
         let delegate = Arc::new(HttpDelegate::new(
             MAX_BYTES,
             1,
+            mock_namespace_resolver,
             Arc::clone(&dml_handler),
             &metrics,
         ));

--- a/router/src/shard.rs
+++ b/router/src/shard.rs
@@ -1,10 +1,11 @@
 //! A representation of a single operation shard.
 
+use std::{borrow::Cow, hash::Hash, sync::Arc};
+
 use data_types::ShardIndex;
 use dml::{DmlMeta, DmlOperation};
 use iox_time::{SystemProvider, TimeProvider};
 use metric::{DurationHistogram, Metric};
-use std::{borrow::Cow, hash::Hash, sync::Arc};
 use write_buffer::core::{WriteBufferError, WriteBufferWriting};
 
 /// A shard tags a write buffer with a shard index (Kafka partition).

--- a/router/tests/http.rs
+++ b/router/tests/http.rs
@@ -10,11 +10,11 @@ use metric::{Attributes, DurationHistogram, Metric, Registry, U64Counter};
 use mutable_batch::MutableBatch;
 use router::{
     dml_handlers::{
-        Chain, DmlError, DmlHandlerChainExt, FanOutAdaptor, InstrumentationDecorator,
-        NamespaceAutocreation, Partitioned, Partitioner, SchemaError, SchemaValidator,
-        ShardedWriteBuffer, WriteSummaryAdapter,
+        Chain, DmlError, DmlHandlerChainExt, FanOutAdaptor, InstrumentationDecorator, Partitioned,
+        Partitioner, SchemaError, SchemaValidator, ShardedWriteBuffer, WriteSummaryAdapter,
     },
     namespace_cache::{MemoryNamespaceCache, ShardedCache},
+    namespace_resolver::{NamespaceAutocreation, NamespaceSchemaResolver},
     server::http::HttpDelegate,
     shard::Shard,
 };
@@ -46,16 +46,7 @@ pub struct TestContext {
 type HttpDelegateStack = HttpDelegate<
     InstrumentationDecorator<
         Chain<
-            Chain<
-                Chain<
-                    NamespaceAutocreation<
-                        Arc<ShardedCache<Arc<MemoryNamespaceCache>>>,
-                        HashMap<String, MutableBatch>,
-                    >,
-                    SchemaValidator<Arc<ShardedCache<Arc<MemoryNamespaceCache>>>>,
-                >,
-                Partitioner,
-            >,
+            Chain<SchemaValidator<Arc<ShardedCache<Arc<MemoryNamespaceCache>>>>, Partitioner>,
             WriteSummaryAdapter<
                 FanOutAdaptor<
                     ShardedWriteBuffer<JumpHash<Arc<Shard>>>,
@@ -63,6 +54,10 @@ type HttpDelegateStack = HttpDelegate<
                 >,
             >,
         >,
+    >,
+    NamespaceAutocreation<
+        Arc<ShardedCache<Arc<MemoryNamespaceCache>>>,
+        NamespaceSchemaResolver<Arc<ShardedCache<Arc<MemoryNamespaceCache>>>>,
     >,
 >;
 
@@ -95,29 +90,39 @@ impl TestContext {
             iter::repeat_with(|| Arc::new(MemoryNamespaceCache::default())).take(10),
         ));
 
-        let ns_creator = NamespaceAutocreation::new(
-            Arc::clone(&catalog),
+        let schema_validator =
+            SchemaValidator::new(Arc::clone(&catalog), Arc::clone(&ns_cache), &*metrics);
+        let partitioner = Partitioner::new(PartitionTemplate {
+            parts: vec![TemplatePart::TimeFormat("%Y-%m-%d".to_owned())],
+        });
+
+        let handler_stack =
+            schema_validator
+                .and_then(partitioner)
+                .and_then(WriteSummaryAdapter::new(FanOutAdaptor::new(
+                    sharded_write_buffer,
+                )));
+
+        let handler_stack = InstrumentationDecorator::new("request", &*metrics, handler_stack);
+
+        let namespace_resolver =
+            NamespaceSchemaResolver::new(Arc::clone(&catalog), Arc::clone(&ns_cache));
+        let namespace_resolver = NamespaceAutocreation::new(
+            namespace_resolver,
             Arc::clone(&ns_cache),
+            Arc::clone(&catalog),
             TopicId::new(TEST_TOPIC_ID),
             QueryPoolId::new(TEST_QUERY_POOL_ID),
             iox_catalog::INFINITE_RETENTION_POLICY.to_owned(),
         );
 
-        let schema_validator = SchemaValidator::new(Arc::clone(&catalog), ns_cache, &*metrics);
-        let partitioner = Partitioner::new(PartitionTemplate {
-            parts: vec![TemplatePart::TimeFormat("%Y-%m-%d".to_owned())],
-        });
-
-        let handler_stack = ns_creator
-            .and_then(schema_validator)
-            .and_then(partitioner)
-            .and_then(WriteSummaryAdapter::new(FanOutAdaptor::new(
-                sharded_write_buffer,
-            )));
-
-        let handler_stack = InstrumentationDecorator::new("request", &*metrics, handler_stack);
-
-        let delegate = HttpDelegate::new(1024, 100, Arc::new(handler_stack), &metrics);
+        let delegate = HttpDelegate::new(
+            1024,
+            100,
+            namespace_resolver,
+            Arc::new(handler_stack),
+            &metrics,
+        );
 
         Self {
             delegate,

--- a/router/tests/http.rs
+++ b/router/tests/http.rs
@@ -1,3 +1,5 @@
+use std::{collections::BTreeSet, iter, string::String, sync::Arc};
+
 use assert_matches::assert_matches;
 use data_types::{ColumnType, PartitionTemplate, QueryPoolId, ShardIndex, TemplatePart, TopicId};
 use dml::DmlOperation;
@@ -17,7 +19,6 @@ use router::{
     shard::Shard,
 };
 use sharder::JumpHash;
-use std::{collections::BTreeSet, iter, string::String, sync::Arc};
 use write_buffer::{
     core::WriteBufferWriting,
     mock::{MockBufferForWriting, MockBufferSharedState},


### PR DESCRIPTION
The first in a series of PRs to push namespace + table IDs over Kafka (#4880).

This PR changes the router to propagate the `NamespaceId` through the request handlers, so it is available when serialising the DML operation into the Kafka wire format.

---

* style: format imports (0c5eb3f70)

      Re-order and re-format the imports so that they follow a consistent
      pattern.
      
      This helps eliminate conflicts due to imports.

* refactor: resolve namespace before DML dispatch (d166de931)

      This commit introduces a new (composable) trait; a NamespaceResolver is
      an abstraction responsible for taking a string namespace from a user
      request, and mapping to it's catalog ID.
      
      This allows the NamespaceId to be injected through the DmlHandler chain
      in addition to the namespace name.
      
      As part of this change, the NamespaceAutocreation layer was changed from
      an implementator of the DmlHandler trait, to a NamespaceResolver as it
      is a more appropriate abstraction for the functionality it provides.