### PR TITLE
refactor(router): pass TableId through handler stack

### DIFF
--- a/ioxd_router/src/lib.rs
+++ b/ioxd_router/src/lib.rs
@@ -289,12 +289,11 @@ pub async fn create_router_server_type(
     let shard_service = init_shard_service(sharder, write_buffer_config, catalog).await?;
 
     // Initialise the API delegates
-    let handler_stack = Arc::new(handler_stack);
     let http = HttpDelegate::new(
         common_state.run_config().max_http_request_size,
         request_limit,
         namespace_resolver,
-        Arc::clone(&handler_stack),
+        handler_stack,
         &metrics,
     );
     let grpc = GrpcDelegate::new(schema_catalog, object_store, shard_service);

--- a/router/src/dml_handlers/schema_validation.rs
+++ b/router/src/dml_handlers/schema_validation.rs
@@ -571,7 +571,7 @@ mod tests {
     async fn test_write_ok() {
         let (catalog, namespace) = test_setup().await;
 
-        // Create the table so that the is a known ID that must be returned.
+        // Create the table so that there is a known ID that must be returned.
         let want_id = namespace.create_table("bananas").await.table.id;
 
         let metrics = Arc::new(metric::Registry::default());

--- a/router/src/server/http.rs
+++ b/router/src/server/http.rs
@@ -2,7 +2,7 @@
 
 mod delete_predicate;
 
-use std::{str::Utf8Error, sync::Arc, time::Instant};
+use std::{str::Utf8Error, time::Instant};
 
 use bytes::{Bytes, BytesMut};
 use data_types::{org_and_bucket_to_database, OrgBucketMappingError};
@@ -229,7 +229,7 @@ pub struct HttpDelegate<D, N, T = SystemProvider> {
     max_request_bytes: usize,
     time_provider: T,
     namespace_resolver: N,
-    dml_handler: Arc<D>,
+    dml_handler: D,
 
     // A request limiter to restrict the number of simultaneous requests this
     // router services.
@@ -259,7 +259,7 @@ impl<D, N> HttpDelegate<D, N, SystemProvider> {
         max_request_bytes: usize,
         max_requests: usize,
         namespace_resolver: N,
-        dml_handler: Arc<D>,
+        dml_handler: D,
         metrics: &metric::Registry,
     ) -> Self {
         let write_metric_lines = metrics

--- a/router/tests/http.rs
+++ b/router/tests/http.rs
@@ -1,7 +1,9 @@
 use std::{collections::BTreeSet, iter, string::String, sync::Arc};
 
 use assert_matches::assert_matches;
-use data_types::{ColumnType, PartitionTemplate, QueryPoolId, ShardIndex, TemplatePart, TopicId};
+use data_types::{
+    ColumnType, PartitionTemplate, QueryPoolId, ShardIndex, TableId, TemplatePart, TopicId,
+};
 use dml::DmlOperation;
 use hashbrown::HashMap;
 use hyper::{Body, Request, StatusCode};
@@ -50,7 +52,7 @@ type HttpDelegateStack = HttpDelegate<
             WriteSummaryAdapter<
                 FanOutAdaptor<
                     ShardedWriteBuffer<JumpHash<Arc<Shard>>>,
-                    Vec<Partitioned<HashMap<String, MutableBatch>>>,
+                    Vec<Partitioned<HashMap<TableId, (String, MutableBatch)>>>,
                 >,
             >,
         >,

--- a/router/tests/http.rs
+++ b/router/tests/http.rs
@@ -118,13 +118,7 @@ impl TestContext {
             iox_catalog::INFINITE_RETENTION_POLICY.to_owned(),
         );
 
-        let delegate = HttpDelegate::new(
-            1024,
-            100,
-            namespace_resolver,
-            Arc::new(handler_stack),
-            &metrics,
-        );
+        let delegate = HttpDelegate::new(1024, 100, namespace_resolver, handler_stack, &metrics);
 
         Self {
             delegate,


### PR DESCRIPTION
One of a series of PRs to push namespace + table IDs over Kafka (#4880).

This PR changes the router to propagate the `TableId` through the request handlers, so it is available when serialising the DML operation into the Kafka wire format.

---

* refactor(router): pass TableId through DmlHandlers (80e88a77c)

      Changes the DML handler transformers to pass through the TableId once it
      has been resolved during schema validation.
      
      This value is collated by shard, and then unused. This collated TableId
      map will be used in a follow-up PR.

* perf(router): remove routing indirection (c27e3ff32)

      Removes an unnecessary Arc pointer indirection for routing to the HTTP
      handler delegate.