### PR TITLE
refactor(write_buffer): pass IDs in wire format

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2294,6 +2294,7 @@ dependencies = [
  "flatbuffers",
  "futures",
  "generated_types",
+ "hashbrown",
  "hyper",
  "iox_catalog",
  "iox_query",
@@ -3061,6 +3062,7 @@ version = "0.1.0"
 dependencies = [
  "bytes",
  "criterion",
+ "data_types",
  "dml",
  "flate2",
  "generated_types",

--- a/dml/src/lib.rs
+++ b/dml/src/lib.rs
@@ -15,7 +15,10 @@
 
 use std::time::Duration;
 
-use data_types::{DeletePredicate, NonEmptyString, PartitionKey, Sequence, StatValues, Statistics};
+use data_types::{
+    DeletePredicate, NamespaceId, NonEmptyString, PartitionKey, Sequence, StatValues, Statistics,
+    TableId,
+};
 use hashbrown::HashMap;
 use iox_time::{Time, TimeProvider};
 use mutable_batch::MutableBatch;
@@ -182,6 +185,32 @@ pub struct DmlWrite {
     max_timestamp: i64,
     /// The partition key derived for this write.
     partition_key: PartitionKey,
+
+    //                  !!!!!!! TRANSITION TIME !!!!!!!
+    //
+    // While implementing "sending IDs over Kafka" (#4880) there has to be a
+    // transition period where the producers (routers) populate the fields, but
+    // the consumers (ingesters) do not utilise them.
+    //
+    // This period of overlap is necessary to support a rolling deployment where
+    // the consumers MAY be deployed before the producers, or the producer code
+    // MAY be rolled back due to a defect. During this potential rollback
+    // window, all fields need to be populated to ensure both new and old
+    // versions of the code can process the enqueued messages.
+    //
+    // Because the consumers (ingesters) and the producers (routers) use the
+    // same common application-level type to represent writes (the DmlWrite), it
+    // has to support the producer pushing the IDs into the DmlWrite, but the
+    // consumer must not make use of them.
+    //
+    // In a follow-up PR, this consumer will be switched to make use of the
+    // TableIds, at which point the table map will change from the current
+    // `Table name -> Data` to `TableId -> Data`, and the second map can be
+    // removed from the DmlWrite.
+    #[allow(dead_code)]
+    namespace_id: NamespaceId,
+    // Used to resolve the table ID for a given table name during serialisation.
+    table_ids: HashMap<String, TableId>,
 }
 
 impl DmlWrite {
@@ -196,7 +225,9 @@ impl DmlWrite {
     /// - a MutableBatch lacks an i64 "time" column
     pub fn new(
         namespace: impl Into<String>,
+        namespace_id: NamespaceId,
         tables: HashMap<String, MutableBatch>,
+        table_ids: HashMap<String, TableId>,
         partition_key: PartitionKey,
         meta: DmlMeta,
     ) -> Self {
@@ -221,10 +252,12 @@ impl DmlWrite {
         Self {
             namespace: namespace.into(),
             tables,
+            table_ids,
             partition_key,
             meta,
             min_timestamp: stats.min.unwrap(),
             max_timestamp: stats.max.unwrap(),
+            namespace_id,
         }
     }
 
@@ -284,7 +317,13 @@ impl DmlWrite {
                 .iter()
                 .map(|(k, v)| std::mem::size_of_val(k) + k.capacity() + v.size())
                 .sum::<usize>()
+            + self
+                .table_ids
+                .keys()
+                .map(|k| std::mem::size_of_val(k) + k.capacity() + std::mem::size_of::<TableId>())
+                .sum::<usize>()
             + self.meta.size()
+            + std::mem::size_of::<NamespaceId>()
             + std::mem::size_of::<PartitionKey>()
             - std::mem::size_of::<DmlMeta>()
     }
@@ -292,6 +331,28 @@ impl DmlWrite {
     /// Return the partition key derived for this op.
     pub fn partition_key(&self) -> &PartitionKey {
         &self.partition_key
+    }
+
+    /// Return the map of [`TableId`] to table names for this batch.
+    ///
+    /// # Safety
+    ///
+    /// Marked unsafe because of the critical invariant; Kafka conumers MUST NOT
+    /// utilise this method until this warning is removed. See [`DmlWrite`]
+    /// docs.
+    pub unsafe fn table_id(&self, name: &str) -> Option<TableId> {
+        self.table_ids.get(name).cloned()
+    }
+
+    /// Return the [`NamespaceId`] to which this [`DmlWrite`] should be applied.
+    ///
+    /// # Safety
+    ///
+    /// Marked unsafe because of the critical invariant; Kafka conumers MUST NOT
+    /// utilise this method until this warning is removed. See [`DmlWrite`]
+    /// docs.
+    pub unsafe fn namespace_id(&self) -> NamespaceId {
+        self.namespace_id
     }
 }
 

--- a/generated_types/protos/influxdata/pbdata/v1/influxdb_pb_data_protocol.proto
+++ b/generated_types/protos/influxdata/pbdata/v1/influxdb_pb_data_protocol.proto
@@ -8,6 +8,9 @@ message DatabaseBatch {
     // The destination database name / namespace for this write.
     string database_name = 1;
 
+    // The catalog ID for this database / namespace.
+    int64 database_id = 4;
+
     // An optional partition key for this batch.
     //
     // If specified, all batches in this write MUST map to this partition key.
@@ -21,6 +24,9 @@ message DatabaseBatch {
 
 message TableBatch {
     string table_name = 1;
+
+    // The catalog ID for this table.
+    int64 table_id = 4;
 
     // Data are represented here.
     //
@@ -119,7 +125,7 @@ message Column {
 }
 
 // Note there used to be a service that would load this internal protobuf format.
-// See https://github.com/influxdata/influxdb_iox/pull/5750 and 
+// See https://github.com/influxdata/influxdb_iox/pull/5750 and
 // https://github.com/influxdata/influxdb_iox/issues/4866
 // for rationale of why it was removed
 

--- a/ingester/Cargo.toml
+++ b/ingester/Cargo.toml
@@ -7,8 +7,8 @@ license.workspace = true
 
 [dependencies]
 arrow = { workspace = true, features = ["prettyprint"] }
-arrow-flight = { workspace = true }
 arrow_util = { path = "../arrow_util" }
+arrow-flight = { workspace = true }
 async-trait = "0.1.58"
 backoff = { path = "../backoff" }
 bytes = "1.2"
@@ -20,6 +20,7 @@ dml = { path = "../dml" }
 flatbuffers = "2.1.2"
 futures = "0.3"
 generated_types = { path = "../generated_types" }
+hashbrown = "0.12.3"
 hyper = "0.14"
 iox_catalog = { path = "../iox_catalog" }
 iox_query = { path = "../iox_query" }

--- a/ingester/src/handler.rs
+++ b/ingester/src/handler.rs
@@ -445,7 +445,7 @@ impl<T> Drop for IngestHandlerImpl<T> {
 mod tests {
     use std::{num::NonZeroU32, ops::DerefMut};
 
-    use data_types::{Namespace, NamespaceSchema, Sequence, SequenceNumber};
+    use data_types::{Namespace, NamespaceId, NamespaceSchema, Sequence, SequenceNumber, TableId};
     use dml::{DmlMeta, DmlWrite};
     use iox_catalog::{mem::MemCatalog, validate_or_insert_schema};
     use iox_time::Time;
@@ -600,7 +600,9 @@ mod tests {
         let ingest_ts1 = Time::from_timestamp_millis(42);
         let write_operations = vec![DmlWrite::new(
             "foo",
+            NamespaceId::new(1),
             lines_to_batches("cpu bar=2 20", 0).unwrap(),
+            [("cpu".to_string(), TableId::new(1))].into_iter().collect(),
             "1970-01-01".into(),
             DmlMeta::sequenced(
                 Sequence::new(ShardIndex::new(0), SequenceNumber::new(10)),
@@ -626,7 +628,9 @@ mod tests {
         let ingest_ts1 = Time::from_timestamp_millis(42);
         let write_operations = vec![DmlWrite::new(
             "foo",
+            NamespaceId::new(1),
             lines_to_batches("cpu bar=2 20", 0).unwrap(),
+            [("cpu".to_string(), TableId::new(1))].into_iter().collect(),
             "1970-01-01".into(),
             DmlMeta::sequenced(
                 Sequence::new(ShardIndex::new(0), SequenceNumber::new(2)),
@@ -652,7 +656,9 @@ mod tests {
         let ingest_ts1 = Time::from_timestamp_millis(42);
         let write_operations = vec![DmlWrite::new(
             "foo",
+            NamespaceId::new(1),
             lines_to_batches("cpu bar=2 20", 0).unwrap(),
+            [("cpu".to_string(), TableId::new(1))].into_iter().collect(),
             "1970-01-01".into(),
             DmlMeta::sequenced(
                 Sequence::new(ShardIndex::new(0), SequenceNumber::new(2)),

--- a/ingester/src/stream_handler/sink_instrumentation.rs
+++ b/ingester/src/stream_handler/sink_instrumentation.rs
@@ -239,7 +239,7 @@ mod tests {
     use std::sync::Arc;
 
     use assert_matches::assert_matches;
-    use data_types::{Sequence, SequenceNumber};
+    use data_types::{NamespaceId, Sequence, SequenceNumber, TableId};
     use dml::{DmlMeta, DmlWrite};
     use iox_time::Time;
     use metric::{Metric, MetricObserver, Observation};
@@ -272,7 +272,19 @@ mod tests {
     /// Return a DmlWrite with the given metadata and a single table.
     fn make_write(meta: DmlMeta) -> DmlWrite {
         let tables = lines_to_batches("bananas level=42 4242", 0).unwrap();
-        DmlWrite::new("bananas", tables, "1970-01-01".into(), meta)
+        let ids = tables
+            .keys()
+            .enumerate()
+            .map(|(i, v)| (v.clone(), TableId::new(i as _)))
+            .collect();
+        DmlWrite::new(
+            "bananas",
+            NamespaceId::new(42),
+            tables,
+            ids,
+            "1970-01-01".into(),
+            meta,
+        )
     }
 
     /// Extract the metric with the given name from `metrics`.

--- a/ingester/src/test_util.rs
+++ b/ingester/src/test_util.rs
@@ -572,9 +572,17 @@ pub(crate) fn make_write_op(
     sequence_number: i64,
     lines: &str,
 ) -> DmlWrite {
+    let tables = lines_to_batches(lines, 0).unwrap();
+    let ids = tables
+        .keys()
+        .enumerate()
+        .map(|(i, v)| (v.clone(), TableId::new(i as _)))
+        .collect();
     DmlWrite::new(
         namespace.to_string(),
-        lines_to_batches(lines, 0).unwrap(),
+        NamespaceId::new(42),
+        tables,
+        ids,
         partition_key.clone(),
         DmlMeta::sequenced(
             Sequence {

--- a/mutable_batch_pb/src/encode.rs
+++ b/mutable_batch_pb/src/encode.rs
@@ -12,19 +12,38 @@ use mutable_batch::MutableBatch;
 use schema::InfluxColumnType;
 
 /// Convert a [`DmlWrite`] to a [`DatabaseBatch`]
-pub fn encode_write(db_name: &str, write: &DmlWrite) -> DatabaseBatch {
+pub fn encode_write(db_name: &str, database_id: i64, write: &DmlWrite) -> DatabaseBatch {
     DatabaseBatch {
         database_name: db_name.to_string(),
         table_batches: write
             .tables()
-            .map(|(table_name, batch)| encode_batch(table_name, batch))
+            .map(|(table_name, batch)| {
+                // Temporary code.
+                //
+                // Once only IDs are pushed over the network this extra lookup
+                // can be removed.
+                //
+                // Safety: this code path is invoked only in the producer, and
+                // therefore accessing the table IDs is acceptable. See
+                // DmlWrite for context.
+                let table_id = unsafe {
+                    write.table_id(table_name).unwrap_or_else(|| {
+                        panic!(
+                            "no table ID mapping found for {} table {}",
+                            db_name, table_name
+                        )
+                    })
+                };
+                encode_batch(table_name, table_id.get(), batch)
+            })
             .collect(),
         partition_key: write.partition_key().to_string(),
+        database_id,
     }
 }
 
 /// Convert a [`MutableBatch`] to [`TableBatch`]
-pub fn encode_batch(table_name: &str, batch: &MutableBatch) -> TableBatch {
+pub fn encode_batch(table_name: &str, table_id: i64, batch: &MutableBatch) -> TableBatch {
     TableBatch {
         table_name: table_name.to_string(),
         columns: batch
@@ -45,6 +64,7 @@ pub fn encode_batch(table_name: &str, batch: &MutableBatch) -> TableBatch {
             })
             .collect(),
         row_count: batch.rows() as u32,
+        table_id,
     }
 }
 

--- a/mutable_batch_pb/tests/encode.rs
+++ b/mutable_batch_pb/tests/encode.rs
@@ -30,7 +30,8 @@ fn test_encode_decode() {
 
     assert_batches_eq!(expected, &[batch.to_arrow(Selection::All).unwrap()]);
 
-    let encoded = encode_batch("foo", &batch);
+    let encoded = encode_batch("foo", 42, &batch);
+    assert_eq!(encoded.table_id, 42);
 
     let mut batch = MutableBatch::new();
     write_table_batch(&mut batch, &encoded).unwrap();
@@ -139,7 +140,9 @@ fn test_encode_decode_null_columns_issue_4272() {
         .write_to_batch(&mut got)
         .expect("should write");
 
-    let encoded = encode_batch("bananas", &got);
+    let encoded = encode_batch("bananas", 24, &got);
+    assert_eq!(encoded.table_id, 24);
+
     let mut batch = MutableBatch::new();
     // Without the fix for #4272 this deserialisation call would fail.
     write_table_batch(&mut batch, &encoded).unwrap();
@@ -161,7 +164,9 @@ fn test_encode_decode_null_columns_issue_4272() {
         .write_to_batch(&mut got)
         .expect("should write");
 
-    let encoded = encode_batch("bananas", &got);
+    let encoded = encode_batch("bananas", 42, &got);
+    assert_eq!(encoded.table_id, 42);
+
     let mut batch = MutableBatch::new();
     // Without the fix for #4272 this deserialisation call would fail.
     write_table_batch(&mut batch, &encoded).unwrap();

--- a/mutable_batch_tests/Cargo.toml
+++ b/mutable_batch_tests/Cargo.toml
@@ -18,6 +18,7 @@ prost = "0.11"
 [dev-dependencies]
 bytes = "1.2"
 criterion = { version = "0.4", default-features = false, features = ["rayon"]}
+data_types = { path = "../data_types", default-features = false }
 
 [[bench]]
 name = "write_lp"

--- a/query_tests/src/scenarios/util.rs
+++ b/query_tests/src/scenarios/util.rs
@@ -806,6 +806,12 @@ impl MockIngester {
                 .await;
             partition_ids.push(partition.partition.id);
         }
+
+        let ids = tables
+            .iter()
+            .map(|v| (v.table.name.clone(), v.table.id))
+            .collect();
+
         for table in tables {
             let schema = mutable_batches
                 .get(&table.table.name)
@@ -829,7 +835,9 @@ impl MockIngester {
         );
         let op = DmlOperation::Write(DmlWrite::new(
             self.ns.namespace.name.clone(),
+            self.ns.namespace.id,
             mutable_batches,
+            ids,
             PartitionKey::from(partition_key),
             meta,
         ));

--- a/router/src/dml_handlers/sharded_write_buffer.rs
+++ b/router/src/dml_handlers/sharded_write_buffer.rs
@@ -132,7 +132,9 @@ where
         let iter = collated.into_iter().map(|(shard, batch)| {
             let dml = DmlWrite::new(
                 namespace,
+                namespace_id,
                 batch,
+                table_ids.remove(&shard).unwrap(),
                 partition_key.clone(),
                 DmlMeta::unsequenced(span_ctx.clone()),
             );

--- a/write_buffer/src/codec.rs
+++ b/write_buffer/src/codec.rs
@@ -352,7 +352,7 @@ mod tests {
 
     #[test]
     fn test_dml_write_round_trip() {
-        let (data, ids) = lp_to_batches("platanos great=yes 100\nbananas greatness=1000 100");
+        let (data, ids) = lp_to_batches("platanos great=42 100\nbananas greatness=1000 100");
 
         let w = DmlWrite::new(
             "bananas",
@@ -388,11 +388,13 @@ mod tests {
         assert_eq!(w.table_count(), got.table_count());
         assert_eq!(w.min_timestamp(), got.min_timestamp());
         assert_eq!(w.max_timestamp(), got.max_timestamp());
-        assert_eq!(w.size(), got.size());
         assert!(got.table("bananas").is_some());
-        assert_eq!(
-            w.tables().map(|(name, _)| name).collect::<Vec<_>>(),
-            got.tables().map(|(name, _)| name).collect::<Vec<_>>(),
-        );
+
+        let mut a = w.tables().map(|(name, _)| name).collect::<Vec<_>>();
+        a.sort_unstable();
+
+        let mut b = got.tables().map(|(name, _)| name).collect::<Vec<_>>();
+        b.sort_unstable();
+        assert_eq!(a, b);
     }
 }

--- a/write_buffer/src/core.rs
+++ b/write_buffer/src/core.rs
@@ -142,6 +142,8 @@ pub enum WriteBufferErrorKind {
 
 /// Writing to a Write Buffer takes a [`DmlWrite`] and returns the [`DmlMeta`] for the
 /// payload that was written
+///
+/// [`DmlWrite`]: dml::DmlWrite
 #[async_trait]
 pub trait WriteBufferWriting: Sync + Send + Debug + 'static {
     /// List all known shard indexes/indices.
@@ -166,8 +168,7 @@ pub trait WriteBufferWriting: Sync + Send + Debug + 'static {
         operation: DmlOperation,
     ) -> Result<DmlMeta, WriteBufferError>;
 
-    /// Flush all currently blocking store operations ([`store_operation`](Self::store_operation) /
-    /// [`store_lp`](Self::store_lp)).
+    /// Flush all currently blocking store operations ([`store_operation`](Self::store_operation)).
     ///
     /// This call is pending while outstanding data is being submitted and will return AFTER the
     /// flush completed. However you still need to poll the store operations to get the metadata
@@ -226,6 +227,8 @@ impl WriteBufferStreamHandler for Box<dyn WriteBufferStreamHandler> {
 }
 
 /// Produce streams (one per shard) of [`DmlWrite`]s.
+///
+/// [`DmlWrite`]: dml::DmlWrite
 #[async_trait]
 pub trait WriteBufferReading: Sync + Send + Debug + 'static {
     /// List all known shard indexes/indices.

--- a/write_buffer/src/core.rs
+++ b/write_buffer/src/core.rs
@@ -382,8 +382,8 @@ pub mod test_utils {
             .enumerate()
             .map(|(idx, (name, data))| {
                 let idx = idx as i64;
-                let name_mapping = (name.to_string(), data);
-                let id_mapping = (name.to_string(), TableId::new(idx));
+                let name_mapping = (name.clone(), data);
+                let id_mapping = (name, TableId::new(idx));
 
                 (name_mapping, id_mapping)
             })

--- a/write_buffer/src/kafka/record_aggregator.rs
+++ b/write_buffer/src/kafka/record_aggregator.rs
@@ -200,6 +200,7 @@ impl StatusDeaggregator for DmlMetaDeaggregator {
 mod tests {
     use std::sync::Arc;
 
+    use data_types::{NamespaceId, TableId};
     use dml::DmlWrite;
     use hashbrown::HashMap;
     use iox_time::MockProvider;
@@ -233,9 +234,15 @@ mod tests {
 
         let span = SpanContext::new(Arc::new(LogTraceCollector::new()));
 
+        let ids = [("table".to_string(), TableId::new(24))]
+            .into_iter()
+            .collect();
+
         DmlOperation::Write(DmlWrite::new(
             NAMESPACE.to_string(),
+            NamespaceId::new(42),
             m,
+            ids,
             "1970-01-01".into(),
             DmlMeta::unsequenced(Some(span)),
         ))


### PR DESCRIPTION
This PR changes the router -> ingester write protocol message format to include the IDs of the table & namespaces for the write, as part of https://github.com/influxdata/influxdb_iox/issues/4880.

Note that this commit only **pushes the IDs on the sender-side** and the consumer **does not make use of them**. This will allow us a transition period where messages will contain both the names, and their IDs (see various large and shouty code comments).

In a follow-up PR I will remove the extra map added to the `DmlWrite` in this PR when switching the consumer to use IDs, so the size inflation is temporary.

---

* refactor(write_buffer): pass IDs in wire format (ddd6ab0ba)

      This commit is part of a two-part change in order to add the table &
      namespace IDs to the write buffer wire format. This commit forms the
      first half; changing the producer to send the IDs.
      
      In this commit the new ID values are never read on the consumer side,
      ensuring there is no consumer dependency on them. This ensures they
      remain operational during a rollout, where the consumer may be updated
      to the latest code dependent on the IDs before the producer is updated
      to send them. This also ensures we have a window of time where where the
      consumers can be rolled back after being updated, and still handle
      replaying messages in Kafka.

