### PR TITLE
feat: support multiple bootstrap_broker server config

### DIFF
--- a/write_buffer/src/config.rs
+++ b/write_buffer/src/config.rs
@@ -33,6 +33,7 @@ pub struct WriteBufferConnection {
     pub type_: String,
 
     /// Connection string, depends on [`type_`](Self::type_).
+    /// When Kafka type is selected, multiple bootstrap_broker can be separated by commas.
     pub connection: String,
 
     /// Special configs to be applied when establishing the connection.

--- a/write_buffer/src/kafka/mod.rs
+++ b/write_buffer/src/kafka/mod.rs
@@ -431,7 +431,8 @@ async fn setup_topic(
     partitions: Option<Range<i32>>,
 ) -> Result<BTreeMap<ShardIndex, PartitionClient>> {
     let client_config = ClientConfig::try_from(connection_config)?;
-    let mut client_builder = ClientBuilder::new(vec![conn]);
+    let mut client_builder =
+        ClientBuilder::new(conn.split(',').map(|s| s.trim().to_owned()).collect());
     if let Some(client_id) = client_config.client_id {
         client_builder = client_builder.client_id(client_id);
     }


### PR DESCRIPTION
Describe your proposed changes here.

When Kafka type is selected in WriteBuffer, we expect to be able to configure multiple bootstrap_broker server.

- [x] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb_iox/blob/main/README.md).
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
