### PR TITLE
refactor: disable large variant lint

### DIFF
--- a/predicate/src/delete_expr.rs
+++ b/predicate/src/delete_expr.rs
@@ -20,6 +20,7 @@ pub(crate) fn expr_to_df(expr: DeleteExpr) -> Expr {
 }
 
 #[derive(Debug, Snafu)]
+#[allow(clippy::large_enum_variant)]
 pub enum DataFusionToExprError {
     #[snafu(display("unsupported expression: {:?}", expr))]
     UnsupportedExpression { expr: Expr },


### PR DESCRIPTION
This lint upsets me (and my IDE).

---

* refactor: disable large variant lint (eb603bfb5)

      The DataFusionToExprError::UnsupportedOperants variant contains twice as
      many Expr to the second biggest variant. This is of a sufficient size
      difference to cause a lint warning.