### PR TITLE
refactor(router): pass NamespaceId for deletes

### DIFF
--- a/router/src/dml_handlers/chain.rs
+++ b/router/src/dml_handlers/chain.rs
@@ -79,17 +79,24 @@ where
     async fn delete(
         &self,
         namespace: &DatabaseName<'static>,
+        namespace_id: NamespaceId,
         table_name: &str,
         predicate: &DeletePredicate,
         span_ctx: Option<SpanContext>,
     ) -> Result<(), Self::DeleteError> {
         self.first
-            .delete(namespace, table_name, predicate, span_ctx.clone())
+            .delete(
+                namespace,
+                namespace_id,
+                table_name,
+                predicate,
+                span_ctx.clone(),
+            )
             .await
             .map_err(Into::into)?;
 
         self.second
-            .delete(namespace, table_name, predicate, span_ctx)
+            .delete(namespace, namespace_id, table_name, predicate, span_ctx)
             .await
             .map_err(Into::into)
     }

--- a/router/src/dml_handlers/fan_out.rs
+++ b/router/src/dml_handlers/fan_out.rs
@@ -75,12 +75,13 @@ where
     async fn delete(
         &self,
         namespace: &DatabaseName<'static>,
+        namespace_id: NamespaceId,
         table_name: &str,
         predicate: &DeletePredicate,
         span_ctx: Option<SpanContext>,
     ) -> Result<(), Self::DeleteError> {
         self.inner
-            .delete(namespace, table_name, predicate, span_ctx)
+            .delete(namespace, namespace_id, table_name, predicate, span_ctx)
             .await
     }
 }

--- a/router/src/dml_handlers/instrumentation.rs
+++ b/router/src/dml_handlers/instrumentation.rs
@@ -105,6 +105,7 @@ where
     async fn delete(
         &self,
         namespace: &DatabaseName<'static>,
+        namespace_id: NamespaceId,
         table_name: &str,
         predicate: &DeletePredicate,
         span_ctx: Option<SpanContext>,
@@ -116,7 +117,7 @@ where
 
         let res = self
             .inner
-            .delete(namespace, table_name, predicate, span_ctx)
+            .delete(namespace, namespace_id, table_name, predicate, span_ctx)
             .await;
 
         // Avoid exploding if time goes backwards - simply drop the measurement
@@ -256,7 +257,7 @@ mod tests {
         };
 
         decorator
-            .delete(&ns, "a table", &pred, Some(span))
+            .delete(&ns, NamespaceId::new(42), "a table", &pred, Some(span))
             .await
             .expect("inner handler configured to succeed");
 
@@ -284,7 +285,7 @@ mod tests {
         };
 
         decorator
-            .delete(&ns, "a table", &pred, Some(span))
+            .delete(&ns, NamespaceId::new(42), "a table", &pred, Some(span))
             .await
             .expect_err("inner handler configured to fail");
 

--- a/router/src/dml_handlers/mock.rs
+++ b/router/src/dml_handlers/mock.rs
@@ -19,6 +19,7 @@ pub enum MockDmlHandlerCall<W> {
     },
     Delete {
         namespace: String,
+        namespace_id: NamespaceId,
         table: String,
         predicate: DeletePredicate,
     },
@@ -121,6 +122,7 @@ where
     async fn delete(
         &self,
         namespace: &DatabaseName<'static>,
+        namespace_id: NamespaceId,
         table_name: &str,
         predicate: &DeletePredicate,
         _span_ctx: Option<SpanContext>,
@@ -129,6 +131,7 @@ where
             self,
             MockDmlHandlerCall::Delete {
                 namespace: namespace.into(),
+                namespace_id,
                 table: table_name.to_owned(),
                 predicate: predicate.clone(),
             },

--- a/router/src/dml_handlers/nop.rs
+++ b/router/src/dml_handlers/nop.rs
@@ -43,11 +43,12 @@ where
     async fn delete(
         &self,
         namespace: &DatabaseName<'static>,
+        namespace_id: NamespaceId,
         table_name: &str,
         predicate: &DeletePredicate,
         _span_ctx: Option<SpanContext>,
     ) -> Result<(), Self::DeleteError> {
-        info!(%namespace, %table_name, ?predicate, "dropping delete operation");
+        info!(%namespace, %namespace_id, %table_name, ?predicate, "dropping delete operation");
         Ok(())
     }
 }

--- a/router/src/dml_handlers/partitioner.rs
+++ b/router/src/dml_handlers/partitioner.rs
@@ -109,6 +109,7 @@ impl DmlHandler for Partitioner {
     async fn delete(
         &self,
         _namespace: &DatabaseName<'static>,
+        _namespace_id: NamespaceId,
         _table_name: &str,
         _predicate: &DeletePredicate,
         _span_ctx: Option<SpanContext>,

--- a/router/src/dml_handlers/schema_validation.rs
+++ b/router/src/dml_handlers/schema_validation.rs
@@ -306,6 +306,7 @@ where
     async fn delete(
         &self,
         _namespace: &DatabaseName<'static>,
+        _namespace_id: NamespaceId,
         _table_name: &str,
         _predicate: &DeletePredicate,
         _span_ctx: Option<SpanContext>,
@@ -788,7 +789,7 @@ mod tests {
         let ns = DatabaseName::try_from(NAMESPACE).unwrap();
 
         handler
-            .delete(&ns, TABLE, &predicate, None)
+            .delete(&ns, NamespaceId::new(42), TABLE, &predicate, None)
             .await
             .expect("request should succeed");
 

--- a/router/src/dml_handlers/trait.rs
+++ b/router/src/dml_handlers/trait.rs
@@ -68,6 +68,7 @@ pub trait DmlHandler: Debug + Send + Sync {
     async fn delete(
         &self,
         namespace: &DatabaseName<'static>,
+        namespace_id: NamespaceId,
         table_name: &str,
         predicate: &DeletePredicate,
         span_ctx: Option<SpanContext>,
@@ -100,12 +101,13 @@ where
     async fn delete(
         &self,
         namespace: &DatabaseName<'static>,
+        namespace_id: NamespaceId,
         table_name: &str,
         predicate: &DeletePredicate,
         span_ctx: Option<SpanContext>,
     ) -> Result<(), Self::DeleteError> {
         (**self)
-            .delete(namespace, table_name, predicate, span_ctx)
+            .delete(namespace, namespace_id, table_name, predicate, span_ctx)
             .await
     }
 }

--- a/router/src/dml_handlers/write_summary.rs
+++ b/router/src/dml_handlers/write_summary.rs
@@ -55,12 +55,13 @@ where
     async fn delete(
         &self,
         namespace: &DatabaseName<'static>,
+        namespace_id: NamespaceId,
         table_name: &str,
         predicate: &DeletePredicate,
         span_ctx: Option<SpanContext>,
     ) -> Result<(), Self::DeleteError> {
         self.inner
-            .delete(namespace, table_name, predicate, span_ctx)
+            .delete(namespace, namespace_id, table_name, predicate, span_ctx)
             .await
     }
 }

--- a/router/src/server/http.rs
+++ b/router/src/server/http.rs
@@ -458,9 +458,12 @@ where
             "routing delete"
         );
 
+        let namespace_id = self.namespace_resolver.get_namespace_id(&namespace).await?;
+
         self.dml_handler
             .delete(
                 &namespace,
+                namespace_id,
                 parsed_delete.table_name.as_str(),
                 &predicate,
                 span_ctx,
@@ -966,9 +969,10 @@ mod tests {
         body = r#"{"start":"2021-04-01T14:00:00Z","stop":"2021-04-02T14:00:00Z", "predicate":"_measurement=its_a_table and location=Boston"}"#.as_bytes(),
         dml_handler = [Ok(())],
         want_result = Ok(_),
-        want_dml_calls = [MockDmlHandlerCall::Delete{namespace, table, predicate}] => {
+        want_dml_calls = [MockDmlHandlerCall::Delete{namespace, namespace_id, table, predicate}] => {
             assert_eq!(table, "its_a_table");
             assert_eq!(namespace, "bananas_test");
+            assert_eq!(*namespace_id, NAMESPACE_ID);
             assert!(!predicate.exprs.is_empty());
         }
     );
@@ -1033,9 +1037,10 @@ mod tests {
         body = r#"{"start":"2021-04-01T14:00:00Z","stop":"2021-04-02T14:00:00Z", "predicate":"_measurement=its_a_table and location=Boston"}"#.as_bytes(),
         dml_handler = [Err(DmlError::DatabaseNotFound("bananas_test".to_string()))],
         want_result = Err(Error::DmlHandler(DmlError::DatabaseNotFound(_))),
-        want_dml_calls = [MockDmlHandlerCall::Delete{namespace, table, predicate}] => {
+        want_dml_calls = [MockDmlHandlerCall::Delete{namespace, namespace_id, table, predicate}] => {
             assert_eq!(table, "its_a_table");
             assert_eq!(namespace, "bananas_test");
+            assert_eq!(*namespace_id, NAMESPACE_ID);
             assert!(!predicate.exprs.is_empty());
         }
     );
@@ -1046,9 +1051,10 @@ mod tests {
         body = r#"{"start":"2021-04-01T14:00:00Z","stop":"2021-04-02T14:00:00Z", "predicate":"_measurement=its_a_table and location=Boston"}"#.as_bytes(),
         dml_handler = [Err(DmlError::Internal("💣".into()))],
         want_result = Err(Error::DmlHandler(DmlError::Internal(_))),
-        want_dml_calls = [MockDmlHandlerCall::Delete{namespace, table, predicate}] => {
+        want_dml_calls = [MockDmlHandlerCall::Delete{namespace, namespace_id, table, predicate}] => {
             assert_eq!(table, "its_a_table");
             assert_eq!(namespace, "bananas_test");
+            assert_eq!(*namespace_id, NAMESPACE_ID);
             assert!(!predicate.exprs.is_empty());
         }
     );


### PR DESCRIPTION
This PR changes the router to resolve the `NamespaceId` for each delete request, and push it down the `DmlHandler` stack. It's basically the delete counterpart to #6000.

This value is currently unused.

---

* refactor(router): pass NamespaceId for deletes (a7835009d)

      Pushes the NamespaceId down the DML handler stack like we do for writes.