### PR TITLE
refactor(write_buffer): propagate NamespaceId across Kafka boundary for DML deletes

### DIFF
--- a/generated_types/protos/influxdata/iox/delete/v1/service.proto
+++ b/generated_types/protos/influxdata/iox/delete/v1/service.proto
@@ -38,6 +38,9 @@ message DeletePayload {
   // The name of the database
   string db_name = 1;
 
+  // The catalog ID for this database / namespace.
+  int64 database_id = 4;
+
   // An optional table name to restrict this delete to
   string table_name = 2;
 

--- a/influxdb_iox_client/src/client/delete.rs
+++ b/influxdb_iox_client/src/client/delete.rs
@@ -77,6 +77,7 @@ impl Client {
     pub async fn delete(
         &mut self,
         db_name: impl Into<String> + Send,
+        database_id: i64,
         table_name: impl Into<String> + Send,
         predicate: Predicate,
     ) -> Result<(), Error> {
@@ -87,6 +88,7 @@ impl Client {
             .delete(DeleteRequest {
                 payload: Some(DeletePayload {
                     db_name,
+                    database_id,
                     table_name,
                     predicate: Some(predicate),
                 }),

--- a/influxdb_iox_client/src/client/delete.rs
+++ b/influxdb_iox_client/src/client/delete.rs
@@ -53,6 +53,7 @@ pub mod generated_types {
 /// client
 ///     .delete(
 ///         "my_db",
+///         42,
 ///         "my_table",
 ///         pred,
 ///     )

--- a/ingester/src/data.rs
+++ b/ingester/src/data.rs
@@ -1523,6 +1523,7 @@ mod tests {
         };
         let d1 = DmlDelete::new(
             "foo",
+            NamespaceId::new(42),
             predicate,
             Some(NonEmptyString::new("mem").unwrap()),
             DmlMeta::sequenced(

--- a/ingester/src/stream_handler/handler.rs
+++ b/ingester/src/stream_handler/handler.rs
@@ -576,7 +576,7 @@ mod tests {
             None,
             42,
         );
-        DmlDelete::new(name, pred, None, sequence)
+        DmlDelete::new(name, NamespaceId::new(42), pred, None, sequence)
     }
 
     #[derive(Debug)]

--- a/query_tests/src/scenarios/util.rs
+++ b/query_tests/src/scenarios/util.rs
@@ -862,6 +862,7 @@ impl MockIngester {
         );
         DmlOperation::Delete(DmlDelete::new(
             self.ns.namespace.name.clone(),
+            self.ns.namespace.id,
             predicate,
             Some(NonEmptyString::new(delete_table_name).unwrap()),
             meta,

--- a/router/src/dml_handlers/sharded_write_buffer.rs
+++ b/router/src/dml_handlers/sharded_write_buffer.rs
@@ -169,6 +169,7 @@ where
 
         let dml = DmlDelete::new(
             namespace,
+            namespace_id,
             predicate,
             NonEmptyString::new(table_name),
             DmlMeta::unsequenced(span_ctx),

--- a/write_buffer/src/codec.rs
+++ b/write_buffer/src/codec.rs
@@ -225,6 +225,7 @@ pub fn decode(
 
                     Ok(DmlOperation::Delete(DmlDelete::new(
                         headers.namespace,
+                        NamespaceId::new(delete.database_id),
                         predicate,
                         NonEmptyString::new(delete.table_name),
                         meta,
@@ -254,6 +255,13 @@ pub fn encode_operation(
         }
         DmlOperation::Delete(delete) => Payload::Delete(DeletePayload {
             db_name: db_name.to_string(),
+            database_id: unsafe {
+                // Safety: this code path is only invoked in the Kafka producer, so
+                // it is safe to utilise the ID.
+                //
+                // See DmlWrite docs for context.
+                delete.namespace_id().get()
+            },
             table_name: delete
                 .table_name()
                 .map(ToString::to_string)

--- a/write_buffer/src/kafka/mod.rs
+++ b/write_buffer/src/kafka/mod.rs
@@ -857,6 +857,7 @@ mod tests {
         let span_ctx = SpanContext::new(Arc::clone(trace_collector) as Arc<_>);
         let op = DmlOperation::Delete(DmlDelete::new(
             namespace,
+            NamespaceId::new(42),
             DeletePredicate {
                 range: TimestampRange::new(0, 1),
                 exprs: vec![],


### PR DESCRIPTION
This is the delete counterpart to #6036, part of https://github.com/influxdata/influxdb_iox/issues/4880.

---

* feat: NamespaceId in DmlDelete (6fa48731a)

      Changes the DmlDelete to contain the NamespaceId for which it should be
      applied, propagating this value over the wire.
      
      Like the existing IDs within the DmlWrite, these values are marked
      unsafe to use due to avoid the consumers utilising them accidentally
      during deployment. Unlike DmlWrite, the DmlDelete is completely unused,
      so this is less of an issue.

* test(router): assert DmlHandler ID propagation (906645c5b)

      Adds an integration test asserting that the NamespaceId and Table IDs
      are propagated through the router.