### PR TITLE
perf(ingester): eliminate table / namespace queries

### DIFF
--- a/ingester/src/data.rs
+++ b/ingester/src/data.rs
@@ -185,7 +185,7 @@ impl IngesterData {
             .get(&shard_id)
             .context(ShardNotFoundSnafu { shard_id })?;
         shard_data
-            .buffer_operation(dml_operation, &self.catalog, lifecycle_handle)
+            .buffer_operation(dml_operation, lifecycle_handle)
             .await
     }
 
@@ -1393,7 +1393,7 @@ mod tests {
         // to 1 already, so it shouldn't be buffered and the buffer should
         // remain empty.
         let action = data
-            .buffer_operation(DmlOperation::Write(w1), &catalog, &manager.handle())
+            .buffer_operation(DmlOperation::Write(w1), &manager.handle())
             .await
             .unwrap();
         {
@@ -1414,7 +1414,7 @@ mod tests {
         assert_matches!(action, DmlApplyAction::Skipped);
 
         // w2 should be in the buffer
-        data.buffer_operation(DmlOperation::Write(w2), &catalog, &manager.handle())
+        data.buffer_operation(DmlOperation::Write(w2), &manager.handle())
             .await
             .unwrap();
 

--- a/ingester/src/data/namespace.rs
+++ b/ingester/src/data/namespace.rs
@@ -351,30 +351,26 @@ mod tests {
     use std::sync::Arc;
 
     use data_types::{PartitionId, PartitionKey, ShardIndex};
-    use iox_catalog::interface::Catalog;
     use metric::{Attributes, Metric};
 
     use crate::{
         data::partition::{resolver::MockPartitionProvider, PartitionData, SortKeyState},
         lifecycle::mock_handle::MockLifecycleHandle,
-        test_util::{make_write_op, populate_catalog},
+        test_util::{make_write_op, TEST_TABLE},
     };
 
     use super::*;
 
     const SHARD_INDEX: ShardIndex = ShardIndex::new(24);
-    const TABLE_NAME: &str = "bananas";
+    const SHARD_ID: ShardId = ShardId::new(22);
+    const TABLE_NAME: &str = TEST_TABLE;
+    const TABLE_ID: TableId = TableId::new(44);
     const NAMESPACE_NAME: &str = "platanos";
+    const NAMESPACE_ID: NamespaceId = NamespaceId::new(42);
 
     #[tokio::test]
     async fn test_namespace_double_ref() {
         let metrics = Arc::new(metric::Registry::default());
-        let catalog: Arc<dyn Catalog> =
-            Arc::new(iox_catalog::mem::MemCatalog::new(Arc::clone(&metrics)));
-
-        // Populate the catalog with the shard / namespace / table
-        let (shard_id, ns_id, table_id) =
-            populate_catalog(&*catalog, SHARD_INDEX, NAMESPACE_NAME, TABLE_NAME).await;
 
         // Configure the mock partition provider to return a partition for this
         // table ID.
@@ -382,9 +378,9 @@ mod tests {
             PartitionData::new(
                 PartitionId::new(0),
                 PartitionKey::from("banana-split"),
-                shard_id,
-                ns_id,
-                table_id,
+                SHARD_ID,
+                NAMESPACE_ID,
+                TABLE_ID,
                 TABLE_NAME.into(),
                 SortKeyState::Provided(None),
                 None,
@@ -392,9 +388,9 @@ mod tests {
         ));
 
         let ns = NamespaceData::new(
-            ns_id,
+            NAMESPACE_ID,
             NAMESPACE_NAME.into(),
-            shard_id,
+            SHARD_ID,
             partition_provider,
             &*metrics,
         );
@@ -404,7 +400,7 @@ mod tests {
 
         // Assert the namespace does not contain the test data
         assert!(ns.table_data(&TABLE_NAME.into()).is_none());
-        assert!(ns.table_id(table_id).is_none());
+        assert!(ns.table_id(TABLE_ID).is_none());
 
         // Write some test data
         ns.buffer_operation(
@@ -412,8 +408,10 @@ mod tests {
                 &PartitionKey::from("banana-split"),
                 SHARD_INDEX,
                 NAMESPACE_NAME,
+                NAMESPACE_ID,
+                TABLE_ID,
                 0,
-                r#"bananas,city=Medford day="sun",temp=55 22"#,
+                r#"test_table,city=Medford day="sun",temp=55 22"#,
             )),
             &MockLifecycleHandle::default(),
         )
@@ -422,7 +420,7 @@ mod tests {
 
         // Both forms of referencing the table should succeed
         assert!(ns.table_data(&TABLE_NAME.into()).is_some());
-        assert!(ns.table_id(table_id).is_some());
+        assert!(ns.table_id(TABLE_ID).is_some());
 
         // And the table counter metric should increase
         let tables = metrics

--- a/ingester/src/data/namespace.rs
+++ b/ingester/src/data/namespace.rs
@@ -199,7 +199,7 @@ impl NamespaceData {
                 // Extract the partition key derived by the router.
                 let partition_key = write.partition_key().clone();
 
-                for (t, b) in write.into_tables() {
+                for (t, _, b) in write.into_tables() {
                     let t = TableName::from(t);
                     let table_data = match self.table_data(&t) {
                         Some(t) => t,

--- a/ingester/src/querier_handler.rs
+++ b/ingester/src/querier_handler.rs
@@ -488,7 +488,7 @@ mod tests {
         // make 14 scenarios for ingester data
         let mut scenarios = vec![];
         for two_partitions in [false, true] {
-            let scenario = Arc::new(make_ingester_data(two_partitions).await);
+            let scenario = Arc::new(make_ingester_data(two_partitions).await.0);
             scenarios.push(scenario);
         }
 

--- a/mutable_batch_pb/src/decode.rs
+++ b/mutable_batch_pb/src/decode.rs
@@ -60,7 +60,7 @@ pub type Result<T, E = Error> = std::result::Result<T, E>;
 /// Decodes a [`DatabaseBatch`] to a map of [`MutableBatch`] keyed by table name
 pub fn decode_database_batch(
     database_batch: &DatabaseBatch,
-) -> Result<(HashMap<String, MutableBatch>, HashMap<i64, String>)> {
+) -> Result<(HashMap<String, MutableBatch>, HashMap<String, i64>)> {
     let mut name_to_data = HashMap::with_capacity(database_batch.table_batches.len());
     let mut id_to_name = HashMap::with_capacity(database_batch.table_batches.len());
 
@@ -70,7 +70,7 @@ pub fn decode_database_batch(
             .from_key(table_batch.table_name.as_str())
             .or_insert_with(|| (table_batch.table_name.clone(), MutableBatch::new()));
 
-        id_to_name.insert(table_batch.table_id, table_batch.table_name.clone());
+        id_to_name.insert(table_batch.table_name.clone(), table_batch.table_id);
 
         write_table_batch(batch, table_batch)?;
     }

--- a/mutable_batch_pb/src/encode.rs
+++ b/mutable_batch_pb/src/encode.rs
@@ -22,18 +22,12 @@ pub fn encode_write(db_name: &str, database_id: i64, write: &DmlWrite) -> Databa
                 //
                 // Once only IDs are pushed over the network this extra lookup
                 // can be removed.
-                //
-                // Safety: this code path is invoked only in the producer, and
-                // therefore accessing the table IDs is acceptable. See
-                // DmlWrite for context.
-                let table_id = unsafe {
-                    write.table_id(table_name).unwrap_or_else(|| {
-                        panic!(
-                            "no table ID mapping found for {} table {}",
-                            db_name, table_name
-                        )
-                    })
-                };
+                let table_id = write.table_id(table_name).unwrap_or_else(|| {
+                    panic!(
+                        "no table ID mapping found for {} table {}",
+                        db_name, table_name
+                    )
+                });
                 encode_batch(table_name, table_id.get(), batch)
             })
             .collect(),

--- a/router/tests/http.rs
+++ b/router/tests/http.rs
@@ -411,11 +411,11 @@ async fn test_write_propagate_ids() {
     assert_eq!(writes.len(), 1);
     assert_matches!(writes.as_slice(), [Ok(DmlOperation::Write(w))] => {
         assert_eq!(w.namespace(), "bananas_test");
-        assert_eq!(unsafe { w.namespace_id() } , ns.id);
+        assert_eq!(w.namespace_id(), ns.id);
         assert!(w.table("platanos").is_some());
 
         for (name, id) in ids {
-            assert_eq!(unsafe { w.table_id(name).unwrap() }, id);
+            assert_eq!(w.table_id(name).unwrap(), id);
         }
     });
 }
@@ -464,6 +464,6 @@ async fn test_delete_propagate_ids() {
     assert_eq!(writes.len(), 1);
     assert_matches!(writes.as_slice(), [Ok(DmlOperation::Delete(w))] => {
         assert_eq!(w.namespace(), "bananas_test");
-        assert_eq!(unsafe { w.namespace_id() } , ns.id);
+        assert_eq!(w.namespace_id(), ns.id);
     });
 }


### PR DESCRIPTION
This PR makes use of the namespace & table IDs that are sent over the wire by the router since #6036, allowing the ingester to eliminate the namespace & table queries in the hot path 🎉 

As an added bonus, this fixes potential data loss in the ingester due to lack of retries on these queries (https://github.com/influxdata/influxdb_iox/issues/5008), and also simplifies testing.

This should make a large difference in catalog load during deployments & cluster bootstrapping, as well as speed up the ingester recovery rate (https://github.com/influxdata/conductor/issues/971).

---

* feat: table/namespace IDs in write protocol (f46df5bb5)

      Expose the Table and Namespace IDs encoded within the serialised DML
      write (added in #6036).
      
      This makes the IDs available for use in the consumers, ending the
      transition period. This commit DOES NOT remove the strings sent over the
      wire.

* perf(ingester): remove namespace lookup query (f30ea243f)

      Now DML operations contain the namespace ID, the ingester has all
      necessary data to initialise the NamespaceData buffer node without
      having to query the catalog.

* perf(ingester): remove table lookup query (26a360037)

      Now DML operations contain the table ID, the ingester has all necessary
      data to initialise the TableData buffer node without having to query the
      catalog.
      
      This also removes the catalog from the buffer_operation() call path,
      simplifying testing.

* test: simplify tests / remove catalog (4668f7308)

      Remove the catalog from tests that only initialised an implementation in
      order to call buffer_operation().