### PR TITLE
revert: granular locking

### DIFF
--- a/ingester/src/data/namespace.rs
+++ b/ingester/src/data/namespace.rs
@@ -23,26 +23,26 @@ use crate::{data::DmlApplyAction, lifecycle::LifecycleHandle};
 #[derive(Debug, Default)]
 struct DoubleRef {
     // TODO(4880): this can be removed when IDs are sent over the wire.
-    by_name: HashMap<TableName, Arc<TableData>>,
-    by_id: HashMap<TableId, Arc<TableData>>,
+    by_name: HashMap<TableName, Arc<tokio::sync::RwLock<TableData>>>,
+    by_id: HashMap<TableId, Arc<tokio::sync::RwLock<TableData>>>,
 }
 
 impl DoubleRef {
-    fn insert(&mut self, t: TableData) -> Arc<TableData> {
+    fn insert(&mut self, t: TableData) -> Arc<tokio::sync::RwLock<TableData>> {
         let name = t.table_name().clone();
         let id = t.table_id();
 
-        let t = Arc::new(t);
+        let t = Arc::new(tokio::sync::RwLock::new(t));
         self.by_name.insert(name, Arc::clone(&t));
         self.by_id.insert(id, Arc::clone(&t));
         t
     }
 
-    fn by_name(&self, name: &TableName) -> Option<Arc<TableData>> {
+    fn by_name(&self, name: &TableName) -> Option<Arc<tokio::sync::RwLock<TableData>>> {
         self.by_name.get(name).map(Arc::clone)
     }
 
-    fn by_id(&self, id: TableId) -> Option<Arc<TableData>> {
+    fn by_id(&self, id: TableId) -> Option<Arc<tokio::sync::RwLock<TableData>>> {
         self.by_id.get(&id).map(Arc::clone)
     }
 }
@@ -206,19 +206,22 @@ impl NamespaceData {
                         None => self.insert_table(&t, catalog).await?,
                     };
 
-                    let action = table_data
-                        .buffer_table_write(
-                            sequence_number,
-                            b,
-                            partition_key.clone(),
-                            lifecycle_handle,
-                        )
-                        .await?;
-                    if let DmlApplyAction::Applied(should_pause) = action {
-                        pause_writes = pause_writes || should_pause;
-                        all_skipped = false;
+                    {
+                        // lock scope
+                        let mut table_data = table_data.write().await;
+                        let action = table_data
+                            .buffer_table_write(
+                                sequence_number,
+                                b,
+                                partition_key.clone(),
+                                lifecycle_handle,
+                            )
+                            .await?;
+                        if let DmlApplyAction::Applied(should_pause) = action {
+                            pause_writes = pause_writes || should_pause;
+                            all_skipped = false;
+                        }
                     }
-
                     #[cfg(test)]
                     self.test_triggers.on_write().await;
                 }
@@ -248,13 +251,19 @@ impl NamespaceData {
     }
 
     /// Return the specified [`TableData`] if it exists.
-    pub(crate) fn table_data(&self, table_name: &TableName) -> Option<Arc<TableData>> {
+    pub(crate) fn table_data(
+        &self,
+        table_name: &TableName,
+    ) -> Option<Arc<tokio::sync::RwLock<TableData>>> {
         let t = self.tables.read();
         t.by_name(table_name)
     }
 
     /// Return the table data by ID.
-    pub(crate) fn table_id(&self, table_id: TableId) -> Option<Arc<TableData>> {
+    pub(crate) fn table_id(
+        &self,
+        table_id: TableId,
+    ) -> Option<Arc<tokio::sync::RwLock<TableData>>> {
         let t = self.tables.read();
         t.by_id(table_id)
     }
@@ -264,7 +273,7 @@ impl NamespaceData {
         &self,
         table_name: &TableName,
         catalog: &Arc<dyn Catalog>,
-    ) -> Result<Arc<TableData>, super::Error> {
+    ) -> Result<Arc<tokio::sync::RwLock<TableData>>, super::Error> {
         let mut repos = catalog.repositories().await;
 
         let table_id = repos
@@ -308,7 +317,7 @@ impl NamespaceData {
             .actively_buffering(*self.buffering_sequence_number.read());
 
         for table_data in tables {
-            progress = progress.combine(table_data.progress())
+            progress = progress.combine(table_data.read().await.progress())
         }
         progress
     }

--- a/ingester/src/data/partition.rs
+++ b/ingester/src/data/partition.rs
@@ -6,7 +6,6 @@ use data_types::{NamespaceId, PartitionId, PartitionKey, SequenceNumber, ShardId
 use mutable_batch::MutableBatch;
 use observability_deps::tracing::*;
 use schema::sort::SortKey;
-use thiserror::Error;
 use write_summary::ShardProgress;
 
 use self::{
@@ -19,18 +18,6 @@ use super::{sequence_range::SequenceNumberRange, table::TableName};
 
 mod buffer;
 pub mod resolver;
-
-/// Errors that occur during DML operation buffering.
-#[derive(Debug, Error)]
-pub(crate) enum BufferError {
-    /// The op being applied has already been previously persisted.
-    #[error("skipped applying already persisted op")]
-    SkipPersisted,
-
-    /// An error occurred writing the data to the [`MutableBatch`].
-    #[error("failed to apply DML op: {0}")]
-    BufferError(#[from] mutable_batch::Error),
-}
 
 /// The load state of the [`SortKey`] for a given partition.
 #[derive(Debug, Clone)]
@@ -120,35 +107,25 @@ impl PartitionData {
     /// Buffer the given [`MutableBatch`] in memory, ordered by the specified
     /// [`SequenceNumber`].
     ///
-    /// This method returns [`BufferError::SkipPersisted`] if `sequence_number`
-    /// falls in the range of previously persisted data (where `sequence_number`
-    /// is strictly less than the value of
-    /// [`Self::max_persisted_sequence_number()`]).
-    ///
     /// # Panics
     ///
     /// This method panics if `sequence_number` is not strictly greater than
-    /// previous calls. This is not enforced for writes before the persist mark.
+    /// previous calls or the persisted maximum.
     pub(super) fn buffer_write(
         &mut self,
         mb: MutableBatch,
         sequence_number: SequenceNumber,
-    ) -> Result<(), BufferError> {
-        // Skip any ops that have already been applied.
+    ) -> Result<(), super::Error> {
+        // Ensure that this write is strictly after any persisted ops.
         if let Some(min) = self.max_persisted_sequence_number {
-            if sequence_number <= min {
-                trace!(
-                    shard_id=%self.shard_id,
-                    op_sequence_number=?sequence_number,
-                    "skipping already-persisted write"
-                );
-                return Err(BufferError::SkipPersisted);
-            }
+            assert!(sequence_number > min, "monotonicity violation");
         }
 
         // Buffer the write, which ensures monotonicity of writes within the
         // buffer itself.
-        self.buffer.buffer_write(mb, sequence_number)?;
+        self.buffer
+            .buffer_write(mb, sequence_number)
+            .map_err(|e| super::Error::BufferWrite { source: e })?;
 
         trace!(
             shard_id = %self.shard_id,
@@ -1104,9 +1081,8 @@ mod tests {
 
     // As above, the sequence numbers are not tracked between buffer instances.
     //
-    // This test ensures that a partition can tolerate replayed ops prior to the
-    // persist marker when first initialising. However once a partition has
-    // buffered beyond the persist marker, it cannot re-buffer ops after it.
+    // This ensures that a write after a batch is persisted is still required to
+    // be monotonic.
     #[tokio::test]
     #[should_panic(expected = "monotonicity violation")]
     async fn test_non_monotonic_writes_after_persistence() {
@@ -1129,26 +1105,13 @@ mod tests {
         p.mark_persisted(SequenceNumber::new(42));
 
         // This should fail as the write "goes backwards".
-        let err = p
-            .buffer_write(mb.clone(), SequenceNumber::new(1))
-            .expect_err("out of order write should succeed");
-
-        // This assert ensures replay is tolerated, with the previously
-        // persisted ops skipping instead of being applied.
-        assert_matches!(err, BufferError::SkipPersisted);
-
-        // Until a write is accepted.
-        p.buffer_write(mb.clone(), SequenceNumber::new(100))
+        p.buffer_write(mb, SequenceNumber::new(1))
             .expect("out of order write should succeed");
-
-        // At which point a write between the persist marker and the maximum
-        // applied sequence number is a hard error.
-        let _ = p.buffer_write(mb, SequenceNumber::new(50));
     }
 
-    // As above, but with a pre-configured persist marker greater than the
-    // sequence number being wrote.
+    // As above, but with a pre-configured persist marker.
     #[tokio::test]
+    #[should_panic(expected = "monotonicity violation")]
     async fn test_non_monotonic_writes_persist_marker() {
         let mut p = PartitionData::new(
             PARTITION_ID,
@@ -1168,11 +1131,8 @@ mod tests {
         let mb = lp_to_mutable_batch(r#"bananas,city=London people=2,pigeons="millions" 10"#).1;
 
         // This should fail as the write "goes backwards".
-        let err = p
-            .buffer_write(mb, SequenceNumber::new(1))
-            .expect_err("out of order write should not succeed");
-
-        assert_matches!(err, BufferError::SkipPersisted);
+        p.buffer_write(mb, SequenceNumber::new(1))
+            .expect("out of order write should succeed");
     }
 
     // Restoring a persist marker is included in progress reports.

--- a/ingester/src/data/table.rs
+++ b/ingester/src/data/table.rs
@@ -1,48 +1,47 @@
 //! Table level data buffer structures.
 
-use std::sync::Arc;
+use std::{collections::HashMap, sync::Arc};
 
 use data_types::{NamespaceId, PartitionId, PartitionKey, SequenceNumber, ShardId, TableId};
 use mutable_batch::MutableBatch;
-use parking_lot::{Mutex, RwLock};
 use write_summary::ShardProgress;
 
 use super::{
     partition::{resolver::PartitionProvider, BufferError, PartitionData},
     DmlApplyAction,
 };
-use crate::{arcmap::ArcMap, lifecycle::LifecycleHandle};
+use crate::lifecycle::LifecycleHandle;
 
 /// A double-referenced map where [`PartitionData`] can be looked up by
 /// [`PartitionKey`], or ID.
 #[derive(Debug, Default)]
 struct DoubleRef {
     // TODO(4880): this can be removed when IDs are sent over the wire.
-    by_key: ArcMap<PartitionKey, Mutex<PartitionData>>,
-    by_id: ArcMap<PartitionId, Mutex<PartitionData>>,
+    by_key: HashMap<PartitionKey, PartitionData>,
+    by_id: HashMap<PartitionId, PartitionKey>,
 }
 
 impl DoubleRef {
-    /// Try to insert the provided [`PartitionData`].
-    ///
-    /// Note that the partition MAY have been inserted concurrently, and the
-    /// returned [`PartitionData`] MAY be a different instance for the same
-    /// underlying partition.
-    fn try_insert(&mut self, ns: PartitionData) -> Arc<Mutex<PartitionData>> {
+    fn insert(&mut self, ns: PartitionData) {
         let id = ns.partition_id();
         let key = ns.partition_key().clone();
 
-        let ns = Arc::new(Mutex::new(ns));
-        self.by_key.get_or_insert_with(&key, || Arc::clone(&ns));
-        self.by_id.get_or_insert_with(&id, || ns)
+        assert!(self.by_key.insert(key.clone(), ns).is_none());
+        assert!(self.by_id.insert(id, key).is_none());
     }
 
-    fn by_key(&self, key: &PartitionKey) -> Option<Arc<Mutex<PartitionData>>> {
+    #[cfg(test)]
+    fn by_key(&self, key: &PartitionKey) -> Option<&PartitionData> {
         self.by_key.get(key)
     }
 
-    fn by_id(&self, id: PartitionId) -> Option<Arc<Mutex<PartitionData>>> {
-        self.by_id.get(&id)
+    fn by_key_mut(&mut self, key: &PartitionKey) -> Option<&mut PartitionData> {
+        self.by_key.get_mut(key)
+    }
+
+    fn by_id_mut(&mut self, id: PartitionId) -> Option<&mut PartitionData> {
+        let key = self.by_id.get(&id)?.clone();
+        self.by_key_mut(&key)
     }
 }
 
@@ -103,7 +102,7 @@ pub(crate) struct TableData {
     partition_provider: Arc<dyn PartitionProvider>,
 
     // Map of partition key to its data
-    partition_data: RwLock<DoubleRef>,
+    partition_data: DoubleRef,
 }
 
 impl TableData {
@@ -137,14 +136,13 @@ impl TableData {
     // buffers the table write and returns true if the lifecycle manager indicates that
     // ingest should be paused.
     pub(super) async fn buffer_table_write(
-        &self,
+        &mut self,
         sequence_number: SequenceNumber,
         batch: MutableBatch,
         partition_key: PartitionKey,
         lifecycle_handle: &dyn LifecycleHandle,
     ) -> Result<DmlApplyAction, super::Error> {
-        let p = self.partition_data.read().by_key(&partition_key);
-        let partition_data = match p {
+        let partition_data = match self.partition_data.by_key.get_mut(&partition_key) {
             Some(p) => p,
             None => {
                 let p = self
@@ -158,25 +156,20 @@ impl TableData {
                     )
                     .await;
                 // Add the double-referenced partition to the map.
-                //
-                // This MAY return a different instance than `p` if another
-                // thread has already initialised the partition.
-                self.partition_data.write().try_insert(p)
+                self.partition_data.insert(p);
+                self.partition_data.by_key_mut(&partition_key).unwrap()
             }
         };
 
         let size = batch.size();
         let rows = batch.rows();
-        let partition_id = {
-            let mut p = partition_data.lock();
-            match p.buffer_write(batch, sequence_number) {
-                Ok(_) => p.partition_id(),
-                Err(BufferError::SkipPersisted) => return Ok(DmlApplyAction::Skipped),
-                Err(BufferError::BufferError(e)) => {
-                    return Err(super::Error::BufferWrite { source: e })
-                }
+        match partition_data.buffer_write(batch, sequence_number) {
+            Ok(_) => { /* continue below */ }
+            Err(BufferError::SkipPersisted) => return Ok(DmlApplyAction::Skipped),
+            Err(BufferError::BufferError(e)) => {
+                return Err(super::Error::BufferWrite { source: e })
             }
-        };
+        }
 
         // Record the write as having been buffered.
         //
@@ -184,7 +177,7 @@ impl TableData {
         // op may fail which would lead to a write being recorded, but not
         // applied.
         let should_pause = lifecycle_handle.log_write(
-            partition_id,
+            partition_data.partition_id(),
             self.shard_id,
             self.namespace_id,
             self.table_id,
@@ -202,17 +195,19 @@ impl TableData {
     ///
     /// The order of [`PartitionData`] in the iterator is arbitrary and should
     /// not be relied upon.
-    pub(crate) fn partitions(&self) -> Vec<Arc<Mutex<PartitionData>>> {
-        self.partition_data.read().by_key.values()
+    pub(crate) fn partition_iter_mut(
+        &mut self,
+    ) -> impl Iterator<Item = &mut PartitionData> + ExactSizeIterator {
+        self.partition_data.by_key.values_mut()
     }
 
     /// Return the [`PartitionData`] for the specified ID.
     #[allow(unused)]
     pub(crate) fn get_partition(
-        &self,
+        &mut self,
         partition_id: PartitionId,
-    ) -> Option<Arc<Mutex<PartitionData>>> {
-        self.partition_data.read().by_id(partition_id)
+    ) -> Option<&mut PartitionData> {
+        self.partition_data.by_id_mut(partition_id)
     }
 
     /// Return the [`PartitionData`] for the specified partition key.
@@ -220,19 +215,17 @@ impl TableData {
     pub(crate) fn get_partition_by_key(
         &self,
         partition_key: &PartitionKey,
-    ) -> Option<Arc<Mutex<PartitionData>>> {
-        self.partition_data.read().by_key(partition_key)
+    ) -> Option<&PartitionData> {
+        self.partition_data.by_key(partition_key)
     }
 
     /// Return progress from this Table
     pub(super) fn progress(&self) -> ShardProgress {
         self.partition_data
-            .read()
             .by_key
             .values()
-            .into_iter()
-            .fold(Default::default(), |progress, p| {
-                progress.combine(p.lock().progress())
+            .fold(Default::default(), |progress, partition_data| {
+                progress.combine(partition_data.progress())
             })
     }
 
@@ -310,7 +303,7 @@ mod tests {
             ),
         ));
 
-        let table = TableData::new(
+        let mut table = TableData::new(
             table_id,
             TABLE_NAME.into(),
             shard_id,
@@ -324,12 +317,8 @@ mod tests {
             .unwrap();
 
         // Assert the table does not contain the test partition
-        assert!(table
-            .partition_data
-            .read()
-            .by_key(&PARTITION_KEY.into())
-            .is_none());
-        assert!(table.partition_data.read().by_id(PARTITION_ID).is_none());
+        assert!(table.partition_data.by_key(&PARTITION_KEY.into()).is_none());
+        assert!(table.partition_data.by_id_mut(PARTITION_ID).is_none());
 
         // Write some test data
         let action = table
@@ -344,12 +333,8 @@ mod tests {
         assert_matches!(action, DmlApplyAction::Applied(false));
 
         // Referencing the partition should succeed
-        assert!(table
-            .partition_data
-            .read()
-            .by_key(&PARTITION_KEY.into())
-            .is_some());
-        assert!(table.partition_data.read().by_id(PARTITION_ID).is_some());
+        assert!(table.partition_data.by_key(&PARTITION_KEY.into()).is_some());
+        assert!(table.partition_data.by_id_mut(PARTITION_ID).is_some());
     }
 
     #[tokio::test]
@@ -377,7 +362,7 @@ mod tests {
             ),
         ));
 
-        let table = TableData::new(
+        let mut table = TableData::new(
             table_id,
             TABLE_NAME.into(),
             shard_id,
@@ -395,11 +380,7 @@ mod tests {
         let handle = MockLifecycleHandle::default();
 
         // Assert the table does not contain the test partition
-        assert!(table
-            .partition_data
-            .read()
-            .by_key(&PARTITION_KEY.into())
-            .is_none());
+        assert!(table.partition_data.by_key(&PARTITION_KEY.into()).is_none());
 
         // Write some test data
         let action = table
@@ -414,11 +395,7 @@ mod tests {
         assert_matches!(action, DmlApplyAction::Applied(false));
 
         // Referencing the partition should succeed
-        assert!(table
-            .partition_data
-            .read()
-            .by_key(&PARTITION_KEY.into())
-            .is_some());
+        assert!(table.partition_data.by_key(&PARTITION_KEY.into()).is_some());
 
         // And the lifecycle handle was called with the expected values
         assert_eq!(

--- a/ingester/src/data/table.rs
+++ b/ingester/src/data/table.rs
@@ -4,10 +4,11 @@ use std::{collections::HashMap, sync::Arc};
 
 use data_types::{NamespaceId, PartitionId, PartitionKey, SequenceNumber, ShardId, TableId};
 use mutable_batch::MutableBatch;
+use observability_deps::tracing::*;
 use write_summary::ShardProgress;
 
 use super::{
-    partition::{resolver::PartitionProvider, BufferError, PartitionData},
+    partition::{resolver::PartitionProvider, PartitionData},
     DmlApplyAction,
 };
 use crate::lifecycle::LifecycleHandle;
@@ -161,15 +162,21 @@ impl TableData {
             }
         };
 
-        let size = batch.size();
-        let rows = batch.rows();
-        match partition_data.buffer_write(batch, sequence_number) {
-            Ok(_) => { /* continue below */ }
-            Err(BufferError::SkipPersisted) => return Ok(DmlApplyAction::Skipped),
-            Err(BufferError::BufferError(e)) => {
-                return Err(super::Error::BufferWrite { source: e })
+        // skip the write if it has already been persisted
+        if let Some(max) = partition_data.max_persisted_sequence_number() {
+            if max >= sequence_number {
+                trace!(
+                    shard_id=%self.shard_id,
+                    op_sequence_number=?sequence_number,
+                    "skipping already-persisted write"
+                );
+                return Ok(DmlApplyAction::Skipped);
             }
         }
+
+        let size = batch.size();
+        let rows = batch.rows();
+        partition_data.buffer_write(batch, sequence_number)?;
 
         // Record the write as having been buffered.
         //

--- a/ingester/src/querier_handler.rs
+++ b/ingester/src/querier_handler.rs
@@ -311,11 +311,10 @@ pub async fn prepare_data_to_querier(
     // acquire locks and read table data in parallel
     let unpersisted_partitions: Vec<_> = futures::stream::iter(table_refs)
         .map(|table_data| async move {
+            let mut table_data = table_data.write().await;
             table_data
-                .partitions()
-                .into_iter()
+                .partition_iter_mut()
                 .map(|p| {
-                    let mut p = p.lock();
                     (
                         p.partition_id(),
                         p.get_query_data(),


### PR DESCRIPTION
There have been panics in the ingesters:

`Thread panic" panic_info="panicked at 'partition 13702863 in table 72 in namespace 75 not in shard 156 state'`

The timing suggests #6068 may be the culprit.

---

* revert: granular per-partition locking (7ac0857a2)

      This reverts commit 79d24fa350a3d83ec7ee311e5de04858ad330a6d.

* revert: push down per-partition op skipping (fbd25a06d)

      This reverts commit 425fd46def52b9e858b5a9f96b9d28559154ad1e.