### PR TITLE
fix: cross-thread ArcMap::get()

### DIFF
--- a/ingester/src/arcmap.rs
+++ b/ingester/src/arcmap.rs
@@ -172,12 +172,14 @@ where
         self.map.read().values().map(Arc::clone).collect()
     }
 
+    #[inline]
     fn compute_hash<Q: Hash + ?Sized>(&self, key: &Q) -> u64 {
         let mut state = self.hasher.build_hasher();
         key.hash(&mut state);
         state.finish()
     }
 
+    #[inline]
     fn key_equal<Q>(q: &Q) -> impl FnMut(&'_ K) -> bool + '_
     where
         K: Borrow<Q>,

--- a/ingester/src/arcmap.rs
+++ b/ingester/src/arcmap.rs
@@ -36,9 +36,11 @@ impl<K, V, S> std::ops::Deref for ArcMap<K, V, S> {
 
 impl<K, V> Default for ArcMap<K, V> {
     fn default() -> Self {
+        let map: HashMap<K, Arc<V>> = Default::default();
+        let hasher = map.hasher().clone();
         Self {
-            map: Default::default(),
-            hasher: Default::default(),
+            map: RwLock::new(map),
+            hasher,
         }
     }
 }

--- a/ingester/src/arcmap.rs
+++ b/ingester/src/arcmap.rs
@@ -36,6 +36,10 @@ impl<K, V, S> std::ops::Deref for ArcMap<K, V, S> {
 
 impl<K, V> Default for ArcMap<K, V> {
     fn default() -> Self {
+        // The same hasher should be used by everything that hashes for a
+        // consistent result.
+        //
+        // See https://github.com/influxdata/influxdb_iox/pull/6086.
         let map: HashMap<K, Arc<V>> = Default::default();
         let hasher = map.hasher().clone();
         Self {


### PR DESCRIPTION
This PR fixes an issue with the `ArcMap` that caused an `insert()` in one thread to not be visible in another thread because different thread-local hasher instances were being used.

Also included is a small refactor to DRY the key checking, and avoid cloning a key when calling `insert()` that I noticed while working on this.

---

* test: cross-thread hashmap entry visibility (e9bda70c7)

      At the time of this commit, this test fails. Performing a get() on a key
      previously inserted by another thread should not fail.

* fix: cross-thread map entry visibility (1fb9cfba8)

      This commit changes the ArcMap HashBuilder to use the same instance as
      the underlying HashMap hasher.
      
      This prevents divergent hashing across threads that MAY initialise a
      hasher with a different seed.

* refactor: extract key equality checking (e50a854e6)

      Creates a shared fn for checking key equality to DRY the various
      chaining checks.

* refactor: accept owned key for insert() (08f82786a)

      Changes the bounds on the ArcMap to accept an owned key, avoiding an
      extra allocation.
      
      Cleans up the bounds on other fn to ensure the borrowed key impl Eq and
      is the ref type of K.

* refactor: inline helpers (b3c2ae72b)

      Inline the hash generation & key comparator.