### PR TITLE
perf(ingester): mutex pushdown

### DIFF
--- a/ingester/src/data.rs
+++ b/ingester/src/data.rs
@@ -265,45 +265,46 @@ impl Persister for IngesterData {
         let table_data = namespace.table_id(table_id).unwrap_or_else(|| {
             panic!("table {table_id} in namespace {namespace_id} not in shard {shard_id} state")
         });
+        // Assert various properties of the table to ensure the index is
+        // correct, out of an abundance of caution.
+        assert_eq!(table_data.shard_id(), shard_id);
+        assert_eq!(table_data.namespace_id(), namespace_id);
+        assert_eq!(table_data.table_id(), table_id);
+        let table_name = table_data.table_name().clone();
 
-        let table_name;
+        let partition = table_data.get_partition(partition_id).unwrap_or_else(|| {
+                panic!(
+                    "partition {partition_id} in table {table_id} in namespace {namespace_id} not in shard {shard_id} state"
+                )
+            });
+
         let partition_key;
         let sort_key;
         let last_persisted_sequence_number;
         let batch;
         let batch_sequence_number_range;
         {
-            let mut guard = table_data.write().await;
-            // Assert various properties of the table to ensure the index is
-            // correct, out of an abundance of caution.
-            assert_eq!(guard.shard_id(), shard_id);
-            assert_eq!(guard.namespace_id(), namespace_id);
-            assert_eq!(guard.table_id(), table_id);
-            table_name = guard.table_name().clone();
-
-            let partition = guard.get_partition(partition_id).unwrap_or_else(|| {
-                panic!(
-                    "partition {partition_id} in table {table_id} in namespace {namespace_id} not in shard {shard_id} state"
-                )
-            });
+            // Acquire a write lock over the partition and extract all the
+            // necessary data.
+            let mut guard = partition.lock();
 
             // Assert various properties of the partition to ensure the index is
             // correct, out of an abundance of caution.
-            assert_eq!(partition.partition_id(), partition_id);
-            assert_eq!(partition.shard_id(), shard_id);
-            assert_eq!(partition.namespace_id(), namespace_id);
-            assert_eq!(partition.table_id(), table_id);
-            assert_eq!(*partition.table_name(), table_name);
+            assert_eq!(guard.partition_id(), partition_id);
+            assert_eq!(guard.shard_id(), shard_id);
+            assert_eq!(guard.namespace_id(), namespace_id);
+            assert_eq!(guard.table_id(), table_id);
+            assert_eq!(*guard.table_name(), table_name);
 
-            partition_key = partition.partition_key().clone();
-            sort_key = partition.sort_key().clone();
-            last_persisted_sequence_number = partition.max_persisted_sequence_number();
+            partition_key = guard.partition_key().clone();
+            sort_key = guard.sort_key().clone();
+            last_persisted_sequence_number = guard.max_persisted_sequence_number();
 
             // The sequence number MUST be read without releasing the write lock
             // to ensure a consistent snapshot of batch contents and batch
             // sequence number range.
-            batch = partition.mark_persisting();
-            batch_sequence_number_range = partition.sequence_number_range();
+            batch = guard.mark_persisting();
+            batch_sequence_number_range = guard.sequence_number_range();
         };
 
         // From this point on, the code MUST be infallible.
@@ -423,12 +424,7 @@ impl Persister for IngesterData {
                 .expect("retry forever");
 
             // Update the sort key in the partition cache.
-            table_data
-                .write()
-                .await
-                .get_partition(partition_id)
-                .unwrap()
-                .update_sort_key(Some(new_sort_key.clone()));
+            partition.lock().update_sort_key(Some(new_sort_key.clone()));
 
             debug!(
                 %object_store_id,
@@ -545,18 +541,15 @@ impl Persister for IngesterData {
         // This SHOULD cause the data to be dropped, but there MAY be ongoing
         // queries that currently hold a reference to the data. In either case,
         // the persisted data will be dropped "shortly".
-        table_data
-            .write()
-            .await
-            .get_partition(partition_id)
-            .unwrap()
+        partition
+            .lock()
             .mark_persisted(iox_metadata.max_sequence_number);
 
         // BUG: ongoing queries retain references to the persisting data,
         // preventing it from being dropped, but memory is released back to
         // lifecycle memory tracker when this fn returns.
         //
-        //  https://github.com/influxdata/influxdb_iox/issues/5872
+        //  https://github.com/influxdata/influxdb_iox/issues/5805
         //
         info!(
             %object_store_id,
@@ -813,11 +806,12 @@ mod tests {
             let n = sd.namespace(&"foo".into()).unwrap();
             let mem_table = n.table_data(&"mem".into()).unwrap();
             assert!(n.table_data(&"mem".into()).is_some());
-            let mem_table = mem_table.write().await;
             let p = mem_table
                 .get_partition_by_key(&"1970-01-01".into())
-                .unwrap();
-            (mem_table.table_id(), p.partition_id())
+                .unwrap()
+                .lock()
+                .partition_id();
+            (mem_table.table_id(), p)
         };
 
         data.persist(shard1.id, namespace.id, table_id, partition_id)
@@ -968,13 +962,12 @@ mod tests {
             let mem_table = n.table_data(&"mem".into()).unwrap();
             assert!(n.table_data(&"cpu".into()).is_some());
 
-            let mem_table = mem_table.write().await;
             table_id = mem_table.table_id();
 
             let p = mem_table
                 .get_partition_by_key(&"1970-01-01".into())
                 .unwrap();
-            partition_id = p.partition_id();
+            partition_id = p.lock().partition_id();
         }
         {
             // verify the partition doesn't have a sort key before any data has been persisted
@@ -1044,13 +1037,12 @@ mod tests {
             .unwrap()
             .table_id(table_id)
             .unwrap()
-            .write()
-            .await
             .get_partition(partition_id)
             .unwrap()
+            .lock()
             .sort_key()
-            .get()
-            .await;
+            .clone();
+        let cached_sort_key = cached_sort_key.get().await;
         assert_eq!(
             cached_sort_key,
             Some(SortKey::from_columns(partition.sort_key))
@@ -1101,10 +1093,9 @@ mod tests {
         // verify that the parquet_max_sequence_number got updated
         assert_eq!(
             mem_table
-                .write()
-                .await
                 .get_partition(partition_id)
                 .unwrap()
+                .lock()
                 .max_persisted_sequence_number(),
             Some(SequenceNumber::new(2))
         );
@@ -1406,15 +1397,16 @@ mod tests {
             .await
             .unwrap();
         {
-            let table_data = data.table_data(&"mem".into()).unwrap();
-            let mut table = table_data.write().await;
+            let table = data.table_data(&"mem".into()).unwrap();
             assert!(table
-                .partition_iter_mut()
-                .all(|p| p.get_query_data().is_none()));
+                .partitions()
+                .into_iter()
+                .all(|p| p.lock().get_query_data().is_none()));
             assert_eq!(
                 table
                     .get_partition_by_key(&"1970-01-01".into())
                     .unwrap()
+                    .lock()
                     .max_persisted_sequence_number(),
                 Some(SequenceNumber::new(1))
             );
@@ -1426,11 +1418,10 @@ mod tests {
             .await
             .unwrap();
 
-        let table_data = data.table_data(&"mem".into()).unwrap();
-        let table = table_data.read().await;
+        let table = data.table_data(&"mem".into()).unwrap();
         let partition = table.get_partition_by_key(&"1970-01-01".into()).unwrap();
         assert_eq!(
-            partition.sequence_number_range().inclusive_min(),
+            partition.lock().sequence_number_range().inclusive_min(),
             Some(SequenceNumber::new(2))
         );
 

--- a/ingester/src/data/namespace.rs
+++ b/ingester/src/data/namespace.rs
@@ -23,26 +23,26 @@ use crate::{data::DmlApplyAction, lifecycle::LifecycleHandle};
 #[derive(Debug, Default)]
 struct DoubleRef {
     // TODO(4880): this can be removed when IDs are sent over the wire.
-    by_name: HashMap<TableName, Arc<tokio::sync::RwLock<TableData>>>,
-    by_id: HashMap<TableId, Arc<tokio::sync::RwLock<TableData>>>,
+    by_name: HashMap<TableName, Arc<TableData>>,
+    by_id: HashMap<TableId, Arc<TableData>>,
 }
 
 impl DoubleRef {
-    fn insert(&mut self, t: TableData) -> Arc<tokio::sync::RwLock<TableData>> {
+    fn insert(&mut self, t: TableData) -> Arc<TableData> {
         let name = t.table_name().clone();
         let id = t.table_id();
 
-        let t = Arc::new(tokio::sync::RwLock::new(t));
+        let t = Arc::new(t);
         self.by_name.insert(name, Arc::clone(&t));
         self.by_id.insert(id, Arc::clone(&t));
         t
     }
 
-    fn by_name(&self, name: &TableName) -> Option<Arc<tokio::sync::RwLock<TableData>>> {
+    fn by_name(&self, name: &TableName) -> Option<Arc<TableData>> {
         self.by_name.get(name).map(Arc::clone)
     }
 
-    fn by_id(&self, id: TableId) -> Option<Arc<tokio::sync::RwLock<TableData>>> {
+    fn by_id(&self, id: TableId) -> Option<Arc<TableData>> {
         self.by_id.get(&id).map(Arc::clone)
     }
 }
@@ -206,22 +206,19 @@ impl NamespaceData {
                         None => self.insert_table(&t, catalog).await?,
                     };
 
-                    {
-                        // lock scope
-                        let mut table_data = table_data.write().await;
-                        let action = table_data
-                            .buffer_table_write(
-                                sequence_number,
-                                b,
-                                partition_key.clone(),
-                                lifecycle_handle,
-                            )
-                            .await?;
-                        if let DmlApplyAction::Applied(should_pause) = action {
-                            pause_writes = pause_writes || should_pause;
-                            all_skipped = false;
-                        }
+                    let action = table_data
+                        .buffer_table_write(
+                            sequence_number,
+                            b,
+                            partition_key.clone(),
+                            lifecycle_handle,
+                        )
+                        .await?;
+                    if let DmlApplyAction::Applied(should_pause) = action {
+                        pause_writes = pause_writes || should_pause;
+                        all_skipped = false;
                     }
+
                     #[cfg(test)]
                     self.test_triggers.on_write().await;
                 }
@@ -251,19 +248,13 @@ impl NamespaceData {
     }
 
     /// Return the specified [`TableData`] if it exists.
-    pub(crate) fn table_data(
-        &self,
-        table_name: &TableName,
-    ) -> Option<Arc<tokio::sync::RwLock<TableData>>> {
+    pub(crate) fn table_data(&self, table_name: &TableName) -> Option<Arc<TableData>> {
         let t = self.tables.read();
         t.by_name(table_name)
     }
 
     /// Return the table data by ID.
-    pub(crate) fn table_id(
-        &self,
-        table_id: TableId,
-    ) -> Option<Arc<tokio::sync::RwLock<TableData>>> {
+    pub(crate) fn table_id(&self, table_id: TableId) -> Option<Arc<TableData>> {
         let t = self.tables.read();
         t.by_id(table_id)
     }
@@ -273,7 +264,7 @@ impl NamespaceData {
         &self,
         table_name: &TableName,
         catalog: &Arc<dyn Catalog>,
-    ) -> Result<Arc<tokio::sync::RwLock<TableData>>, super::Error> {
+    ) -> Result<Arc<TableData>, super::Error> {
         let mut repos = catalog.repositories().await;
 
         let table_id = repos
@@ -317,7 +308,7 @@ impl NamespaceData {
             .actively_buffering(*self.buffering_sequence_number.read());
 
         for table_data in tables {
-            progress = progress.combine(table_data.read().await.progress())
+            progress = progress.combine(table_data.progress())
         }
         progress
     }

--- a/ingester/src/querier_handler.rs
+++ b/ingester/src/querier_handler.rs
@@ -311,10 +311,11 @@ pub async fn prepare_data_to_querier(
     // acquire locks and read table data in parallel
     let unpersisted_partitions: Vec<_> = futures::stream::iter(table_refs)
         .map(|table_data| async move {
-            let mut table_data = table_data.write().await;
             table_data
-                .partition_iter_mut()
+                .partitions()
+                .into_iter()
                 .map(|p| {
+                    let mut p = p.lock();
                     (
                         p.partition_id(),
                         p.get_query_data(),


### PR DESCRIPTION
This PR contains the exact same code changes as what was in #6068, which was subsequently reverted by #6083 due to a problem with the ArcMap which was resolved in #6086.

**TL;DR**: 
![image](https://user-images.githubusercontent.com/9275968/200596066-65c4f810-23ca-4076-ba6e-5ed7b318b70d.png)

---

* refactor: push down per-partition op skipping (b8181119e)

      This moves the logic that skips operations that do not need to be
      applied to a partition during shard replay from the table level, to the
      partition level.

* perf(ingester): granular per-partition locking (b73d07c22)

      This commit pushes the existing table-level mutex down to the partition.
      
      This allows the ingester to gather data from multiple partitions within
      a single table in parallel, and reduces contention between ingest/query
      workloads.