### PR TITLE
refactor: internalise PartitionProvider

### DIFF
--- a/ingester/src/data.rs
+++ b/ingester/src/data.rs
@@ -720,6 +720,7 @@ mod tests {
 
         let object_store: Arc<DynObjectStore> = Arc::new(InMemory::new());
 
+        drop(repos); // test catalog deadlock
         let data = Arc::new(
             IngesterData::new(
                 Arc::clone(&object_store),
@@ -732,6 +733,8 @@ mod tests {
             .await
             .expect("failed to initialise ingester"),
         );
+
+        let mut repos = catalog.repositories().await;
 
         let schema = NamespaceSchema::new(namespace.id, topic.id, query_pool.id, 100);
 
@@ -824,6 +827,7 @@ mod tests {
 
         let object_store: Arc<DynObjectStore> = Arc::new(InMemory::new());
 
+        drop(repos); // test catalog deadlock
         let data = Arc::new(
             IngesterData::new(
                 Arc::clone(&object_store),
@@ -836,6 +840,8 @@ mod tests {
             .await
             .expect("failed to initialise ingester"),
         );
+
+        let mut repos = catalog.repositories().await;
 
         let schema = NamespaceSchema::new(namespace.id, topic.id, query_pool.id, 100);
 
@@ -935,6 +941,7 @@ mod tests {
 
         let object_store: Arc<DynObjectStore> = Arc::new(InMemory::new());
 
+        drop(repos); // test catalog deadlock
         let data = Arc::new(
             IngesterData::new(
                 Arc::clone(&object_store),
@@ -950,6 +957,8 @@ mod tests {
             .await
             .expect("failed to initialise ingester"),
         );
+
+        let mut repos = catalog.repositories().await;
 
         let schema = NamespaceSchema::new(namespace.id, topic.id, query_pool.id, 100);
 
@@ -1218,6 +1227,7 @@ mod tests {
 
         let object_store: Arc<DynObjectStore> = Arc::new(InMemory::new());
 
+        drop(repos); // test catalog deadlock
         let data = Arc::new(
             IngesterData::new(
                 Arc::clone(&object_store),
@@ -1233,6 +1243,8 @@ mod tests {
             .await
             .expect("failed to initialise ingester"),
         );
+
+        let mut repos = catalog.repositories().await;
 
         let schema = NamespaceSchema::new(namespace.id, topic.id, query_pool.id, 100);
 
@@ -1539,6 +1551,7 @@ mod tests {
 
         let object_store: Arc<DynObjectStore> = Arc::new(InMemory::new());
 
+        drop(repos); // test catalog deadlock
         let data = Arc::new(
             IngesterData::new(
                 Arc::clone(&object_store),
@@ -1551,6 +1564,8 @@ mod tests {
             .await
             .expect("failed to initialise ingester"),
         );
+
+        let mut repos = catalog.repositories().await;
 
         let schema = NamespaceSchema::new(namespace.id, topic.id, query_pool.id, 100);
 

--- a/ingester/src/data.rs
+++ b/ingester/src/data.rs
@@ -1,6 +1,10 @@
 //! Data for the lifecycle of the Ingester
 
-use std::{collections::BTreeMap, sync::Arc, time::Instant};
+use std::{
+    collections::BTreeMap,
+    sync::Arc,
+    time::{Duration, Instant},
+};
 
 use async_trait::async_trait;
 use backoff::{Backoff, BackoffConfig};
@@ -20,12 +24,12 @@ use parquet_file::{
     storage::{ParquetStorage, StorageId},
 };
 use snafu::{OptionExt, Snafu};
+use thiserror::Error;
 use uuid::Uuid;
 use write_summary::ShardProgress;
 
 use crate::{
     compact::{compact_persisting_batch, CompactedStream},
-    handler::NAMESPACE_NAME_PRE_FETCH,
     lifecycle::LifecycleHandle,
 };
 
@@ -39,12 +43,28 @@ pub(crate) use sequence_range::*;
 
 use self::{
     namespace::name_resolver::{NamespaceNameProvider, NamespaceNameResolver},
-    partition::resolver::PartitionProvider,
+    partition::resolver::{CatalogPartitionResolver, PartitionCache, PartitionProvider},
     shard::ShardData,
 };
 
 #[cfg(test)]
 mod triggers;
+
+/// The maximum duration of time between creating a [`PartitionData`] and its
+/// [`SortKey`] being fetched from the catalog.
+///
+/// [`PartitionData`]: crate::data::partition::PartitionData
+/// [`SortKey`]: schema::sort::SortKey
+const SORT_KEY_PRE_FETCH: Duration = Duration::from_secs(30);
+
+/// The maximum duration of time between observing an initialising the
+/// [`NamespaceData`] in response to observing an operation for a namespace, and
+/// fetching the string identifier for it in the background via a
+/// [`DeferredLoad`].
+///
+/// [`NamespaceData`]: crate::data::namespace::NamespaceData
+/// [`DeferredLoad`]: crate::deferred_load::DeferredLoad
+pub(crate) const NAMESPACE_NAME_PRE_FETCH: Duration = Duration::from_secs(60);
 
 #[derive(Debug, Snafu)]
 #[allow(missing_copy_implementations, missing_docs)]
@@ -76,6 +96,15 @@ pub enum Error {
     BufferWrite { source: mutable_batch::Error },
 }
 
+/// Errors that occur during initialisation of an [`IngesterData`].
+#[derive(Debug, Error)]
+pub enum InitError {
+    /// A catalog error occured while fetching the most recent partitions for
+    /// the internal cache.
+    #[error("failed to pre-warm partition cache: {0}")]
+    PreWarmPartitions(iox_catalog::interface::Error),
+}
+
 /// A specialized `Error` for Ingester Data errors
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
@@ -105,17 +134,16 @@ pub struct IngesterData {
 
 impl IngesterData {
     /// Create new instance.
-    pub fn new<T>(
+    pub async fn new<T>(
         object_store: Arc<DynObjectStore>,
         catalog: Arc<dyn Catalog>,
         shards: T,
         exec: Arc<Executor>,
-        partition_provider: Arc<dyn PartitionProvider>,
         backoff_config: BackoffConfig,
         metrics: Arc<metric::Registry>,
-    ) -> Self
+    ) -> Result<Self, InitError>
     where
-        T: IntoIterator<Item = (ShardId, ShardIndex)>,
+        T: IntoIterator<Item = (ShardId, ShardIndex)> + Send,
     {
         let persisted_file_size_bytes = metrics.register_metric_with_options(
             "ingester_persisted_file_size_bytes",
@@ -132,6 +160,34 @@ impl IngesterData {
             },
         );
 
+        // Read the most recently created partitions for the shards this
+        // ingester instance will be consuming from.
+        //
+        // By caching these hot partitions overall catalog load after an
+        // ingester starts up is reduced, and the associated query latency is
+        // removed from the (blocking) ingest hot path.
+        let shards = shards.into_iter().collect::<Vec<_>>();
+        let shard_ids = shards.iter().map(|(id, _)| *id).collect::<Vec<_>>();
+        let recent_partitions = catalog
+            .repositories()
+            .await
+            .partitions()
+            .most_recent_n(10_000, &shard_ids)
+            .await
+            .map_err(InitError::PreWarmPartitions)?;
+
+        // Build the partition provider.
+        let partition_provider = CatalogPartitionResolver::new(Arc::clone(&catalog));
+        let partition_provider = PartitionCache::new(
+            partition_provider,
+            recent_partitions,
+            SORT_KEY_PRE_FETCH,
+            Arc::clone(&catalog),
+            BackoffConfig::default(),
+        );
+        let partition_provider: Arc<dyn PartitionProvider> = Arc::new(partition_provider);
+
+        // Initialise the deferred namespace name resolver.
         let namespace_name_provider: Arc<dyn NamespaceNameProvider> =
             Arc::new(NamespaceNameResolver::new(
                 NAMESPACE_NAME_PRE_FETCH,
@@ -155,14 +211,14 @@ impl IngesterData {
             })
             .collect();
 
-        Self {
+        Ok(Self {
             store: ParquetStorage::new(object_store, StorageId::from("iox")),
             catalog,
             shards,
             exec,
             backoff_config,
             persisted_file_size_bytes,
-        }
+        })
     }
 
     /// Executor for running queries and compacting and persisting
@@ -664,15 +720,18 @@ mod tests {
 
         let object_store: Arc<DynObjectStore> = Arc::new(InMemory::new());
 
-        let data = Arc::new(IngesterData::new(
-            Arc::clone(&object_store),
-            Arc::clone(&catalog),
-            [(shard1.id, shard_index)],
-            Arc::new(Executor::new(1)),
-            Arc::new(CatalogPartitionResolver::new(Arc::clone(&catalog))),
-            BackoffConfig::default(),
-            Arc::clone(&metrics),
-        ));
+        let data = Arc::new(
+            IngesterData::new(
+                Arc::clone(&object_store),
+                Arc::clone(&catalog),
+                [(shard1.id, shard_index)],
+                Arc::new(Executor::new(1)),
+                BackoffConfig::default(),
+                Arc::clone(&metrics),
+            )
+            .await
+            .expect("failed to initialise ingester"),
+        );
 
         let schema = NamespaceSchema::new(namespace.id, topic.id, query_pool.id, 100);
 
@@ -765,15 +824,18 @@ mod tests {
 
         let object_store: Arc<DynObjectStore> = Arc::new(InMemory::new());
 
-        let data = Arc::new(IngesterData::new(
-            Arc::clone(&object_store),
-            Arc::clone(&catalog),
-            [(shard1.id, shard1.shard_index)],
-            Arc::new(Executor::new(1)),
-            Arc::new(CatalogPartitionResolver::new(Arc::clone(&catalog))),
-            BackoffConfig::default(),
-            Arc::clone(&metrics),
-        ));
+        let data = Arc::new(
+            IngesterData::new(
+                Arc::clone(&object_store),
+                Arc::clone(&catalog),
+                [(shard1.id, shard1.shard_index)],
+                Arc::new(Executor::new(1)),
+                BackoffConfig::default(),
+                Arc::clone(&metrics),
+            )
+            .await
+            .expect("failed to initialise ingester"),
+        );
 
         let schema = NamespaceSchema::new(namespace.id, topic.id, query_pool.id, 100);
 
@@ -873,18 +935,21 @@ mod tests {
 
         let object_store: Arc<DynObjectStore> = Arc::new(InMemory::new());
 
-        let data = Arc::new(IngesterData::new(
-            Arc::clone(&object_store),
-            Arc::clone(&catalog),
-            [
-                (shard1.id, shard1.shard_index),
-                (shard2.id, shard2.shard_index),
-            ],
-            Arc::new(Executor::new(1)),
-            Arc::new(CatalogPartitionResolver::new(Arc::clone(&catalog))),
-            BackoffConfig::default(),
-            Arc::clone(&metrics),
-        ));
+        let data = Arc::new(
+            IngesterData::new(
+                Arc::clone(&object_store),
+                Arc::clone(&catalog),
+                [
+                    (shard1.id, shard1.shard_index),
+                    (shard2.id, shard2.shard_index),
+                ],
+                Arc::new(Executor::new(1)),
+                BackoffConfig::default(),
+                Arc::clone(&metrics),
+            )
+            .await
+            .expect("failed to initialise ingester"),
+        );
 
         let schema = NamespaceSchema::new(namespace.id, topic.id, query_pool.id, 100);
 
@@ -1153,18 +1218,21 @@ mod tests {
 
         let object_store: Arc<DynObjectStore> = Arc::new(InMemory::new());
 
-        let data = Arc::new(IngesterData::new(
-            Arc::clone(&object_store),
-            Arc::clone(&catalog),
-            [
-                (shard1.id, shard1.shard_index),
-                (shard2.id, shard2.shard_index),
-            ],
-            Arc::new(Executor::new(1)),
-            Arc::new(CatalogPartitionResolver::new(Arc::clone(&catalog))),
-            BackoffConfig::default(),
-            Arc::clone(&metrics),
-        ));
+        let data = Arc::new(
+            IngesterData::new(
+                Arc::clone(&object_store),
+                Arc::clone(&catalog),
+                [
+                    (shard1.id, shard1.shard_index),
+                    (shard2.id, shard2.shard_index),
+                ],
+                Arc::new(Executor::new(1)),
+                BackoffConfig::default(),
+                Arc::clone(&metrics),
+            )
+            .await
+            .expect("failed to initialise ingester"),
+        );
 
         let schema = NamespaceSchema::new(namespace.id, topic.id, query_pool.id, 100);
 
@@ -1471,15 +1539,18 @@ mod tests {
 
         let object_store: Arc<DynObjectStore> = Arc::new(InMemory::new());
 
-        let data = Arc::new(IngesterData::new(
-            Arc::clone(&object_store),
-            Arc::clone(&catalog),
-            [(shard1.id, shard_index)],
-            Arc::new(Executor::new(1)),
-            Arc::new(CatalogPartitionResolver::new(Arc::clone(&catalog))),
-            BackoffConfig::default(),
-            Arc::clone(&metrics),
-        ));
+        let data = Arc::new(
+            IngesterData::new(
+                Arc::clone(&object_store),
+                Arc::clone(&catalog),
+                [(shard1.id, shard_index)],
+                Arc::new(Executor::new(1)),
+                BackoffConfig::default(),
+                Arc::clone(&metrics),
+            )
+            .await
+            .expect("failed to initialise ingester"),
+        );
 
         let schema = NamespaceSchema::new(namespace.id, topic.id, query_pool.id, 100);
 

--- a/ingester/src/data/partition/resolver/catalog.rs
+++ b/ingester/src/data/partition/resolver/catalog.rs
@@ -20,7 +20,7 @@ use super::r#trait::PartitionProvider;
 /// the partition id and persist offset, returning an initialised
 /// [`PartitionData`].
 #[derive(Debug)]
-pub struct CatalogPartitionResolver {
+pub(crate) struct CatalogPartitionResolver {
     catalog: Arc<dyn Catalog>,
     backoff_config: BackoffConfig,
 }
@@ -28,7 +28,7 @@ pub struct CatalogPartitionResolver {
 impl CatalogPartitionResolver {
     /// Construct a [`CatalogPartitionResolver`] that looks up partitions in
     /// `catalog`.
-    pub fn new(catalog: Arc<dyn Catalog>) -> Self {
+    pub(crate) fn new(catalog: Arc<dyn Catalog>) -> Self {
         Self {
             catalog,
             backoff_config: Default::default(),

--- a/ingester/src/data/partition/resolver/mock.rs
+++ b/ingester/src/data/partition/resolver/mock.rs
@@ -45,7 +45,7 @@ impl MockPartitionProvider {
     }
 
     /// Returns true if all mock values have been consumed.
-    pub fn is_empty(&self) -> bool {
+    pub(crate) fn is_empty(&self) -> bool {
         self.partitions.lock().is_empty()
     }
 }

--- a/ingester/src/data/partition/resolver/mod.rs
+++ b/ingester/src/data/partition/resolver/mod.rs
@@ -6,10 +6,10 @@ mod cache;
 pub(crate) use cache::*;
 
 mod r#trait;
-pub use r#trait::*;
+pub(crate) use r#trait::*;
 
 mod catalog;
-pub use catalog::*;
+pub(crate) use catalog::*;
 
 mod sort_key;
 pub(crate) use sort_key::*;

--- a/ingester/src/data/partition/resolver/sort_key.rs
+++ b/ingester/src/data/partition/resolver/sort_key.rs
@@ -30,7 +30,7 @@ impl SortKeyResolver {
 
     /// Fetch the [`SortKey`] from the [`Catalog`] for `partition_id`, retrying
     /// endlessly when errors occur.
-    pub async fn fetch(self) -> Option<SortKey> {
+    pub(crate) async fn fetch(self) -> Option<SortKey> {
         Backoff::new(&self.backoff_config)
             .retry_all_errors("fetch partition sort key", || async {
                 let s = self

--- a/ingester/src/data/partition/resolver/trait.rs
+++ b/ingester/src/data/partition/resolver/trait.rs
@@ -8,7 +8,7 @@ use crate::data::{partition::PartitionData, table::TableName};
 /// An infallible resolver of [`PartitionData`] for the specified shard, table,
 /// and partition key, returning an initialised [`PartitionData`] buffer for it.
 #[async_trait]
-pub trait PartitionProvider: Send + Sync + Debug {
+pub(crate) trait PartitionProvider: Send + Sync + Debug {
     /// Return an initialised [`PartitionData`] for a given `(partition_key,
     /// shard_id, table_id)` tuple.
     ///

--- a/ingester/src/test_util.rs
+++ b/ingester/src/test_util.rs
@@ -18,7 +18,7 @@ use mutable_batch_lp::lines_to_batches;
 use object_store::memory::InMemory;
 
 use crate::{
-    data::{partition::resolver::CatalogPartitionResolver, IngesterData},
+    data::IngesterData,
     lifecycle::{LifecycleConfig, LifecycleManager},
 };
 
@@ -479,10 +479,11 @@ pub(crate) async fn make_ingester_data(
         Arc::clone(&catalog),
         [(shard_id, shard_index)],
         exec,
-        Arc::new(CatalogPartitionResolver::new(Arc::clone(&catalog))),
         backoff::BackoffConfig::default(),
         metrics,
-    );
+    )
+    .await
+    .expect("failed to initialise ingester");
 
     // Make partitions per requested
     let ops = make_partitions(two_partitions, shard_index, table_id, ns_id);

--- a/query_tests/src/scenarios/util.rs
+++ b/query_tests/src/scenarios/util.rs
@@ -14,9 +14,7 @@ use generated_types::{
 };
 use influxdb_iox_client::flight::{low_level::LowLevelMessage, Error as FlightError};
 use ingester::{
-    data::{
-        partition::resolver::CatalogPartitionResolver, DmlApplyAction, IngesterData, Persister,
-    },
+    data::{DmlApplyAction, IngesterData, Persister},
     lifecycle::mock_handle::MockLifecycleHandle,
     querier_handler::{prepare_data_to_querier, FlatIngesterQueryResponse, IngesterQueryResponse},
 };
@@ -658,15 +656,18 @@ impl MockIngester {
         let ns = catalog.create_namespace("test_db").await;
         let shard = ns.create_shard(1).await;
 
-        let ingester_data = Arc::new(IngesterData::new(
-            catalog.object_store(),
-            catalog.catalog(),
-            [(shard.shard.id, shard.shard.shard_index)],
-            catalog.exec(),
-            Arc::new(CatalogPartitionResolver::new(catalog.catalog())),
-            BackoffConfig::default(),
-            catalog.metric_registry(),
-        ));
+        let ingester_data = Arc::new(
+            IngesterData::new(
+                catalog.object_store(),
+                catalog.catalog(),
+                [(shard.shard.id, shard.shard.shard_index)],
+                catalog.exec(),
+                BackoffConfig::default(),
+                catalog.metric_registry(),
+            )
+            .await
+            .expect("failed to initialise ingester"),
+        );
 
         Self {
             catalog,


### PR DESCRIPTION
A little cleanup now, to prevent a mess later 👌 

---

* refactor: internalise PartitionProvider (75a7a287c)

      Removes the need to leak the PartitionProvider outside of the ingester
      crate.
      
      This will allow the PartitionProvider to utilise a
      DeferredLoad<TableName> without having to make the DeferredLoad and
      TableName pub.