### PR TITLE
perf(ingester): deferred table name discovery

### DIFF
--- a/ingester/src/data.rs
+++ b/ingester/src/data.rs
@@ -67,7 +67,7 @@ const SORT_KEY_PRE_FETCH: Duration = Duration::from_secs(30);
 /// [`DeferredLoad`]: crate::deferred_load::DeferredLoad
 pub(crate) const NAMESPACE_NAME_PRE_FETCH: Duration = Duration::from_secs(60);
 
-/// The maximum duration of time between observing an initialising the
+/// The maximum duration of time between observing and initialising the
 /// [`TableData`] in response to observing an operation for a table, and
 /// fetching the string identifier for it in the background via a
 /// [`DeferredLoad`].

--- a/ingester/src/data/namespace.rs
+++ b/ingester/src/data/namespace.rs
@@ -392,7 +392,7 @@ mod tests {
         .await
         .expect("buffer op should succeed");
 
-        // Both forms of referencing the table should succeed
+        // Referencing the table should succeed
         assert!(ns.table(TABLE_ID).is_some());
 
         // And the table counter metric should increase

--- a/ingester/src/data/partition/resolver/cache.rs
+++ b/ingester/src/data/partition/resolver/cache.rs
@@ -195,7 +195,7 @@ where
         shard_id: ShardId,
         namespace_id: NamespaceId,
         table_id: TableId,
-        table_name: TableName,
+        table_name: Arc<DeferredLoad<TableName>>,
     ) -> PartitionData {
         // Use the cached PartitionKey instead of the caller's partition_key,
         // instead preferring to reuse the already-shared Arc<str> in the cache.
@@ -277,7 +277,9 @@ mod tests {
             SHARD_ID,
             NAMESPACE_ID,
             TABLE_ID,
-            TABLE_NAME.into(),
+            Arc::new(DeferredLoad::new(Duration::from_secs(1), async {
+                TableName::from(TABLE_NAME)
+            })),
             SortKeyState::Provided(None),
             None,
         );
@@ -290,14 +292,16 @@ mod tests {
                 SHARD_ID,
                 NAMESPACE_ID,
                 TABLE_ID,
-                TABLE_NAME.into(),
+                Arc::new(DeferredLoad::new(Duration::from_secs(1), async {
+                    TableName::from(TABLE_NAME)
+                })),
             )
             .await;
 
         assert_eq!(got.partition_id(), PARTITION_ID);
         assert_eq!(got.shard_id(), SHARD_ID);
         assert_eq!(got.table_id(), TABLE_ID);
-        assert_eq!(got.table_name(), TABLE_NAME);
+        assert_eq!(&**got.table_name().get().await, TABLE_NAME);
         assert!(cache.inner.is_empty());
     }
 
@@ -324,14 +328,16 @@ mod tests {
                 SHARD_ID,
                 NAMESPACE_ID,
                 TABLE_ID,
-                TABLE_NAME.into(),
+                Arc::new(DeferredLoad::new(Duration::from_secs(1), async {
+                    TableName::from(TABLE_NAME)
+                })),
             )
             .await;
 
         assert_eq!(got.partition_id(), PARTITION_ID);
         assert_eq!(got.shard_id(), SHARD_ID);
         assert_eq!(got.table_id(), TABLE_ID);
-        assert_eq!(got.table_name(), TABLE_NAME);
+        assert_eq!(&**got.table_name().get().await, TABLE_NAME);
         assert_eq!(*got.partition_key(), PartitionKey::from(PARTITION_KEY));
 
         // The cache should have been cleaned up as it was consumed.
@@ -356,7 +362,9 @@ mod tests {
             SHARD_ID,
             NAMESPACE_ID,
             TABLE_ID,
-            TABLE_NAME.into(),
+            Arc::new(DeferredLoad::new(Duration::from_secs(1), async {
+                TableName::from(TABLE_NAME)
+            })),
             SortKeyState::Provided(None),
             None,
         ));
@@ -377,14 +385,16 @@ mod tests {
                 SHARD_ID,
                 NAMESPACE_ID,
                 TABLE_ID,
-                TABLE_NAME.into(),
+                Arc::new(DeferredLoad::new(Duration::from_secs(1), async {
+                    TableName::from(TABLE_NAME)
+                })),
             )
             .await;
 
         assert_eq!(got.partition_id(), other_key_id);
         assert_eq!(got.shard_id(), SHARD_ID);
         assert_eq!(got.table_id(), TABLE_ID);
-        assert_eq!(got.table_name(), TABLE_NAME);
+        assert_eq!(&**got.table_name().get().await, TABLE_NAME);
     }
 
     #[tokio::test]
@@ -396,7 +406,9 @@ mod tests {
             SHARD_ID,
             NAMESPACE_ID,
             other_table,
-            TABLE_NAME.into(),
+            Arc::new(DeferredLoad::new(Duration::from_secs(1), async {
+                TableName::from(TABLE_NAME)
+            })),
             SortKeyState::Provided(None),
             None,
         ));
@@ -417,14 +429,16 @@ mod tests {
                 SHARD_ID,
                 NAMESPACE_ID,
                 other_table,
-                TABLE_NAME.into(),
+                Arc::new(DeferredLoad::new(Duration::from_secs(1), async {
+                    TableName::from(TABLE_NAME)
+                })),
             )
             .await;
 
         assert_eq!(got.partition_id(), PARTITION_ID);
         assert_eq!(got.shard_id(), SHARD_ID);
         assert_eq!(got.table_id(), other_table);
-        assert_eq!(got.table_name(), TABLE_NAME);
+        assert_eq!(&**got.table_name().get().await, TABLE_NAME);
     }
 
     #[tokio::test]
@@ -436,7 +450,9 @@ mod tests {
             other_shard,
             NAMESPACE_ID,
             TABLE_ID,
-            TABLE_NAME.into(),
+            Arc::new(DeferredLoad::new(Duration::from_secs(1), async {
+                TableName::from(TABLE_NAME)
+            })),
             SortKeyState::Provided(None),
             None,
         ));
@@ -457,13 +473,15 @@ mod tests {
                 other_shard,
                 NAMESPACE_ID,
                 TABLE_ID,
-                TABLE_NAME.into(),
+                Arc::new(DeferredLoad::new(Duration::from_secs(1), async {
+                    TableName::from(TABLE_NAME)
+                })),
             )
             .await;
 
         assert_eq!(got.partition_id(), PARTITION_ID);
         assert_eq!(got.shard_id(), other_shard);
         assert_eq!(got.table_id(), TABLE_ID);
-        assert_eq!(got.table_name(), TABLE_NAME);
+        assert_eq!(&**got.table_name().get().await, TABLE_NAME);
     }
 }

--- a/ingester/src/data/partition/resolver/mock.rs
+++ b/ingester/src/data/partition/resolver/mock.rs
@@ -1,12 +1,15 @@
 //! A mock [`PartitionProvider`] to inject [`PartitionData`] for tests.
 
-use std::collections::HashMap;
+use std::{collections::HashMap, sync::Arc};
 
 use async_trait::async_trait;
 use data_types::{NamespaceId, PartitionKey, ShardId, TableId};
 use parking_lot::Mutex;
 
-use crate::data::{partition::PartitionData, table::TableName};
+use crate::{
+    data::{partition::PartitionData, table::TableName},
+    deferred_load::DeferredLoad,
+};
 
 use super::r#trait::PartitionProvider;
 
@@ -58,7 +61,7 @@ impl PartitionProvider for MockPartitionProvider {
         shard_id: ShardId,
         namespace_id: NamespaceId,
         table_id: TableId,
-        table_name: TableName,
+        table_name: Arc<DeferredLoad<TableName>>,
     ) -> PartitionData {
         let p = self
             .partitions

--- a/ingester/src/data/partition/resolver/trait.rs
+++ b/ingester/src/data/partition/resolver/trait.rs
@@ -72,7 +72,7 @@ mod tests {
             shard_id,
             namespace_id,
             table_id,
-            table_name.clone(),
+            Arc::clone(&table_name),
             SortKeyState::Provided(None),
             None,
         );

--- a/ingester/src/data/shard.rs
+++ b/ingester/src/data/shard.rs
@@ -122,7 +122,7 @@ impl ShardData {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
+    use std::{sync::Arc, time::Duration};
 
     use data_types::{PartitionId, PartitionKey, ShardIndex, TableId};
     use metric::{Attributes, Metric};
@@ -131,7 +131,9 @@ mod tests {
         data::{
             namespace::name_resolver::mock::MockNamespaceNameProvider,
             partition::{resolver::MockPartitionProvider, PartitionData, SortKeyState},
+            table::TableName,
         },
+        deferred_load::DeferredLoad,
         lifecycle::mock_handle::MockLifecycleHandle,
         test_util::{make_write_op, TEST_TABLE},
     };
@@ -158,7 +160,9 @@ mod tests {
                 SHARD_ID,
                 NAMESPACE_ID,
                 TABLE_ID,
-                TABLE_NAME.into(),
+                Arc::new(DeferredLoad::new(Duration::from_secs(1), async {
+                    TableName::from(TABLE_NAME)
+                })),
                 SortKeyState::Provided(None),
                 None,
             ),

--- a/ingester/src/data/table.rs
+++ b/ingester/src/data/table.rs
@@ -1,5 +1,7 @@
 //! Table level data buffer structures.
 
+pub(crate) mod name_resolver;
+
 use std::sync::Arc;
 
 use data_types::{NamespaceId, PartitionId, PartitionKey, SequenceNumber, ShardId, TableId};

--- a/ingester/src/querier_handler.rs
+++ b/ingester/src/querier_handler.rs
@@ -278,7 +278,7 @@ pub async fn prepare_data_to_querier(
             }
         };
 
-        if let Some(table_data) = namespace_data.table_id(request.table_id) {
+        if let Some(table_data) = namespace_data.table(request.table_id) {
             trace!(
                 shard_id=%shard_id.get(),
                 namespace_id=%request.namespace_id,


### PR DESCRIPTION
This PR is a pre-requisite to removing string identifiers from the ingest write protocol (#4880).

This changes the ingester to no longer use the string table name in the write message, and instead perform a query at some random point in time between the first op for the table, and 1 minute later. This random jitter helps avoid smashing the catalog with lots of queries when an ingester first comes up, and removes the query latency from the ingest hot path, increasing throughput compared to the previous ID discovery mechanism.

This PR contains effectively identical changes as #6121, except for a table name, instead of namespace name.

---

* perf(ingester): address tables by ID only (8dae6d399)

      Changes the buffer tree to address TableData by their ID only (removing
      support for addressing tables by their string names). This removes the
      double reference book keeping / twin indexes and associated overhead.
      
      As part of this change, the TableName is now wrapped in a DeferredLoad
      in preparation for removal of the names in the DmlOperation wire format.
      
      This commit also switches the map of TableData within the NamespaceData
      (the parent node) to use the ArcMap for faster lookups and DRY
      exactly-once initialisation.

* refactor: indirect DeferredLoad<TableName> init (0df6c7877)

      Like the NamespaceNameProvider, this commit adds a TableNameProvider to
      provide decoupled initialisation of a DeferredLoad<TableName> instead of
      hard-coding in a catalog instance / query code, and plumbs it into
      position to be used when initialising a TableName.

* refactor: use table name from catalog (413b7c8f4)

      Changes the TableData within the ingester to utilise a TableNameResolver
      to fetch the TableName via the catalog on demand / in the background,
      instead of using the table name sent over the write.
      
      This change causes the ingester to perform a catalog query in the
      background (or on demand) to resolve the table name. This is a
      pre-requisite for removing the table name from the write wire format.