### PR TITLE
fix: Remove namespace string from router -> write buffer -> ingester communication

### DIFF
--- a/dml/src/lib.rs
+++ b/dml/src/lib.rs
@@ -151,14 +151,6 @@ impl DmlOperation {
         }
     }
 
-    /// Namespace associated with this operation
-    pub fn namespace(&self) -> &str {
-        match self {
-            Self::Write(w) => w.namespace(),
-            Self::Delete(d) => d.namespace(),
-        }
-    }
-
     /// Namespace catalog ID associated with this operation
     pub fn namespace_id(&self) -> NamespaceId {
         match self {
@@ -184,7 +176,6 @@ impl From<DmlDelete> for DmlOperation {
 #[derive(Debug, Clone)]
 pub struct DmlWrite {
     /// The namespace being written to
-    namespace: String,
     namespace_id: NamespaceId,
     /// Writes to individual tables keyed by table name
     tables: HashMap<String, MutableBatch>,
@@ -208,7 +199,7 @@ impl DmlWrite {
     /// - a MutableBatch is empty
     /// - a MutableBatch lacks an i64 "time" column
     pub fn new(
-        namespace: impl Into<String>,
+        _namespace: impl Into<String>,
         namespace_id: NamespaceId,
         tables: HashMap<String, MutableBatch>,
         table_ids: HashMap<String, TableId>,
@@ -236,7 +227,6 @@ impl DmlWrite {
         }
 
         Self {
-            namespace: namespace.into(),
             tables,
             table_ids,
             partition_key,
@@ -245,11 +235,6 @@ impl DmlWrite {
             max_timestamp: stats.max.unwrap(),
             namespace_id,
         }
-    }
-
-    /// Namespace associated with this write
-    pub fn namespace(&self) -> &str {
-        &self.namespace
     }
 
     /// Metadata associated with this write
@@ -343,7 +328,6 @@ impl DmlWrite {
 /// A delete operation
 #[derive(Debug, Clone, PartialEq)]
 pub struct DmlDelete {
-    namespace: String,
     namespace_id: NamespaceId,
     predicate: DeletePredicate,
     table_name: Option<NonEmptyString>,
@@ -353,24 +337,18 @@ pub struct DmlDelete {
 impl DmlDelete {
     /// Create a new [`DmlDelete`]
     pub fn new(
-        namespace: impl Into<String>,
+        _namespace: impl Into<String>,
         namespace_id: NamespaceId,
         predicate: DeletePredicate,
         table_name: Option<NonEmptyString>,
         meta: DmlMeta,
     ) -> Self {
         Self {
-            namespace: namespace.into(),
             namespace_id,
             predicate,
             table_name,
             meta,
         }
-    }
-
-    /// Namespace associated with this delete
-    pub fn namespace(&self) -> &str {
-        &self.namespace
     }
 
     /// Returns the table_name for this delete

--- a/dml/src/lib.rs
+++ b/dml/src/lib.rs
@@ -439,7 +439,7 @@ pub mod test_util {
 
     /// Asserts two writes are equal
     pub fn assert_writes_eq(a: &DmlWrite, b: &DmlWrite) {
-        assert_eq!(a.namespace, b.namespace);
+        assert_eq!(a.namespace_id, b.namespace_id);
         assert_eq!(a.partition_key(), b.partition_key());
 
         // Depending on what implementation is under test ( :( ) different

--- a/dml/src/lib.rs
+++ b/dml/src/lib.rs
@@ -199,7 +199,6 @@ impl DmlWrite {
     /// - a MutableBatch is empty
     /// - a MutableBatch lacks an i64 "time" column
     pub fn new(
-        _namespace: impl Into<String>,
         namespace_id: NamespaceId,
         tables: HashMap<String, MutableBatch>,
         table_ids: HashMap<String, TableId>,
@@ -337,7 +336,6 @@ pub struct DmlDelete {
 impl DmlDelete {
     /// Create a new [`DmlDelete`]
     pub fn new(
-        _namespace: impl Into<String>,
         namespace_id: NamespaceId,
         predicate: DeletePredicate,
         table_name: Option<NonEmptyString>,

--- a/dml/src/lib.rs
+++ b/dml/src/lib.rs
@@ -160,12 +160,6 @@ impl DmlOperation {
     }
 
     /// Namespace catalog ID associated with this operation
-    ///
-    /// # Safety
-    ///
-    /// Marked unsafe because of the critical invariant; Kafka conumers MUST NOT
-    /// utilise this method until this warning is removed. See [`DmlWrite`]
-    /// docs.
     pub fn namespace_id(&self) -> NamespaceId {
         match self {
             Self::Write(w) => w.namespace_id(),
@@ -414,12 +408,6 @@ impl DmlDelete {
     }
 
     /// Return the [`NamespaceId`] to which this operation should be applied.
-    ///
-    /// # Safety
-    ///
-    /// Marked unsafe because of the critical invariant; Kafka conumers MUST NOT
-    /// utilise this method until this warning is removed. See [`DmlWrite`]
-    /// docs.
     pub fn namespace_id(&self) -> NamespaceId {
         self.namespace_id
     }

--- a/docs/ingester_querier_protocol.md
+++ b/docs/ingester_querier_protocol.md
@@ -9,8 +9,8 @@ The `DoGet` ticket contains a [Protocol Buffer] message
 `influxdata.iox.ingester.v1.IngesterQueryRequest` (see our `generated_types` crate). This message
 contains:
 
-- **namespace:** The namespace of the query.
-- **table:** The table that we request.
+- **namespace ID:** The catalog namespace ID of the query.
+- **table ID:** The catalog table ID that we request.
 - **columns:** List of columns that the querier wants. If the ingester does NOT know about a
   specified column, it may just ignore that column (i.e. the resulting data is the intersection of
   the request and the ingester data).

--- a/generated_types/protos/influxdata/iox/delete/v1/service.proto
+++ b/generated_types/protos/influxdata/iox/delete/v1/service.proto
@@ -35,8 +35,9 @@ message DeleteResponse {
 
 // A delete payload
 message DeletePayload {
-  // The name of the database
-  string db_name = 1;
+  // Was the name of the database / namespace.
+  reserved "db_name";
+  reserved 1;
 
   // The catalog ID for this database / namespace.
   int64 database_id = 4;

--- a/generated_types/protos/influxdata/pbdata/v1/influxdb_pb_data_protocol.proto
+++ b/generated_types/protos/influxdata/pbdata/v1/influxdb_pb_data_protocol.proto
@@ -5,8 +5,9 @@ package influxdata.pbdata.v1;
 option go_package = "github.com/influxdata/influxdb-pb-data-protocol/golang;influxdbpbdataprotocol";
 
 message DatabaseBatch {
-    // The destination database name / namespace for this write.
-    string database_name = 1;
+    // Was the destination database name / namespace for this write.
+    reserved "database_name";
+    reserved 1;
 
     // The catalog ID for this database / namespace.
     int64 database_id = 4;

--- a/influxdb_iox_client/src/client/delete.rs
+++ b/influxdb_iox_client/src/client/delete.rs
@@ -52,7 +52,6 @@ pub mod generated_types {
 /// };
 /// client
 ///     .delete(
-///         "my_db",
 ///         42,
 ///         "my_table",
 ///         pred,
@@ -77,18 +76,15 @@ impl Client {
     /// Delete data from a table on a specified predicate
     pub async fn delete(
         &mut self,
-        db_name: impl Into<String> + Send,
         database_id: i64,
         table_name: impl Into<String> + Send,
         predicate: Predicate,
     ) -> Result<(), Error> {
-        let db_name = db_name.into();
         let table_name = table_name.into();
 
         self.inner
             .delete(DeleteRequest {
                 payload: Some(DeletePayload {
-                    db_name,
                     database_id,
                     table_name,
                     predicate: Some(predicate),

--- a/ingester/src/data.rs
+++ b/ingester/src/data.rs
@@ -771,7 +771,6 @@ mod tests {
 
         let batch = lines_to_batches("mem foo=1 10", 0).unwrap();
         let w1 = DmlWrite::new(
-            "foo",
             namespace.id,
             batch.clone(),
             build_id_map(repos.deref_mut(), namespace.id, &batch).await,
@@ -815,7 +814,6 @@ mod tests {
 
         let batch = lines_to_batches("mem foo=1 10", 0).unwrap();
         let w2 = DmlWrite::new(
-            "foo",
             namespace.id,
             batch.clone(),
             build_id_map(&mut *catalog.repositories().await, namespace.id, &batch).await,
@@ -876,7 +874,6 @@ mod tests {
 
         let batch = lines_to_batches("mem foo=1 10\nmem foo=1 11", 0).unwrap();
         let w1 = DmlWrite::new(
-            "foo",
             namespace.id,
             batch.clone(),
             build_id_map(repos.deref_mut(), namespace.id, &batch).await,
@@ -1004,7 +1001,6 @@ mod tests {
 
         let batch = lines_to_batches("mem foo=1 10", 0).unwrap();
         let w1 = DmlWrite::new(
-            "foo",
             namespace.id,
             batch.clone(),
             build_id_map(repos.deref_mut(), namespace.id, &batch).await,
@@ -1023,7 +1019,6 @@ mod tests {
 
         let batch = lines_to_batches("cpu foo=1 10", 1).unwrap();
         let w2 = DmlWrite::new(
-            "foo",
             namespace.id,
             batch.clone(),
             build_id_map(repos.deref_mut(), namespace.id, &batch).await,
@@ -1044,7 +1039,6 @@ mod tests {
         std::mem::drop(repos);
         let batch = lines_to_batches("mem foo=1 30", 2).unwrap();
         let w3 = DmlWrite::new(
-            "foo",
             namespace.id,
             batch.clone(),
             build_id_map(&mut *catalog.repositories().await, namespace.id, &batch).await,
@@ -1297,7 +1291,6 @@ mod tests {
         // write with sequence number 1
         let batch = lines_to_batches("mem foo=1 10", 0).unwrap();
         let w1 = DmlWrite::new(
-            "foo",
             namespace.id,
             batch.clone(),
             build_id_map(repos.deref_mut(), namespace.id, &batch).await,
@@ -1317,7 +1310,6 @@ mod tests {
         // write with sequence number 2
         let batch = lines_to_batches("mem foo=1 30\ncpu bar=1 20", 0).unwrap();
         let w2 = DmlWrite::new(
-            "foo",
             namespace.id,
             batch.clone(),
             build_id_map(repos.deref_mut(), namespace.id, &batch).await,
@@ -1418,7 +1410,6 @@ mod tests {
 
         let batch = lines_to_batches("mem foo=1 10", 0).unwrap();
         let w1 = DmlWrite::new(
-            "foo",
             namespace.id,
             batch.clone(),
             build_id_map(repos.deref_mut(), namespace.id, &batch).await,
@@ -1432,7 +1423,6 @@ mod tests {
         );
         let batch = lines_to_batches("mem foo=1 10", 0).unwrap();
         let w2 = DmlWrite::new(
-            "foo",
             namespace.id,
             batch.clone(),
             build_id_map(repos.deref_mut(), namespace.id, &batch).await,
@@ -1618,7 +1608,6 @@ mod tests {
 
         let batch = lines_to_batches("mem foo=1 10", 0).unwrap();
         let w1 = DmlWrite::new(
-            "foo",
             namespace.id,
             batch.clone(),
             build_id_map(repos.deref_mut(), namespace.id, &batch).await,
@@ -1663,7 +1652,6 @@ mod tests {
             exprs: vec![],
         };
         let d1 = DmlDelete::new(
-            "foo",
             NamespaceId::new(42),
             predicate,
             Some(NonEmptyString::new("mem").unwrap()),

--- a/ingester/src/data/namespace.rs
+++ b/ingester/src/data/namespace.rs
@@ -381,7 +381,6 @@ mod tests {
             DmlOperation::Write(make_write_op(
                 &PartitionKey::from("banana-split"),
                 SHARD_INDEX,
-                NAMESPACE_NAME,
                 NAMESPACE_ID,
                 TABLE_ID,
                 0,

--- a/ingester/src/data/shard.rs
+++ b/ingester/src/data/shard.rs
@@ -196,7 +196,6 @@ mod tests {
                 DmlOperation::Write(make_write_op(
                     &PartitionKey::from("banana-split"),
                     SHARD_INDEX,
-                    NAMESPACE_NAME,
                     NAMESPACE_ID,
                     TABLE_ID,
                     0,

--- a/ingester/src/handler.rs
+++ b/ingester/src/handler.rs
@@ -551,7 +551,6 @@ mod tests {
 
         let ingest_ts1 = Time::from_timestamp_millis(42).unwrap();
         let write_operations = vec![DmlWrite::new(
-            "foo",
             NamespaceId::new(1),
             lines_to_batches("cpu bar=2 20", 0).unwrap(),
             [("cpu".to_string(), TableId::new(1))].into_iter().collect(),
@@ -579,7 +578,6 @@ mod tests {
 
         let ingest_ts1 = Time::from_timestamp_millis(42).unwrap();
         let write_operations = vec![DmlWrite::new(
-            "foo",
             NamespaceId::new(1),
             lines_to_batches("cpu bar=2 20", 0).unwrap(),
             [("cpu".to_string(), TableId::new(1))].into_iter().collect(),
@@ -607,7 +605,6 @@ mod tests {
 
         let ingest_ts1 = Time::from_timestamp_millis(42).unwrap();
         let write_operations = vec![DmlWrite::new(
-            "foo",
             NamespaceId::new(1),
             lines_to_batches("cpu bar=2 20", 0).unwrap(),
             [("cpu".to_string(), TableId::new(1))].into_iter().collect(),

--- a/ingester/src/stream_handler/handler.rs
+++ b/ingester/src/stream_handler/handler.rs
@@ -553,7 +553,6 @@ mod tests {
             42,
         );
         DmlWrite::new(
-            "deprecated",
             NamespaceId::new(namespace_id),
             tables,
             ids,
@@ -577,7 +576,6 @@ mod tests {
             42,
         );
         DmlDelete::new(
-            "deprecated",
             NamespaceId::new(namespace_id),
             pred,
             None,

--- a/ingester/src/stream_handler/handler.rs
+++ b/ingester/src/stream_handler/handler.rs
@@ -575,12 +575,7 @@ mod tests {
             None,
             42,
         );
-        DmlDelete::new(
-            NamespaceId::new(namespace_id),
-            pred,
-            None,
-            sequence,
-        )
+        DmlDelete::new(NamespaceId::new(namespace_id), pred, None, sequence)
     }
 
     #[derive(Debug)]

--- a/ingester/src/stream_handler/sink_instrumentation.rs
+++ b/ingester/src/stream_handler/sink_instrumentation.rs
@@ -278,7 +278,6 @@ mod tests {
             .map(|(i, v)| (v.clone(), TableId::new(i as _)))
             .collect();
         DmlWrite::new(
-            "bananas",
             NamespaceId::new(42),
             tables,
             ids,

--- a/ingester/src/stream_handler/sink_instrumentation.rs
+++ b/ingester/src/stream_handler/sink_instrumentation.rs
@@ -277,13 +277,7 @@ mod tests {
             .enumerate()
             .map(|(i, v)| (v.clone(), TableId::new(i as _)))
             .collect();
-        DmlWrite::new(
-            NamespaceId::new(42),
-            tables,
-            ids,
-            "1970-01-01".into(),
-            meta,
-        )
+        DmlWrite::new(NamespaceId::new(42), tables, ids, "1970-01-01".into(), meta)
     }
 
     /// Extract the metric with the given name from `metrics`.

--- a/ingester/src/test_util.rs
+++ b/ingester/src/test_util.rs
@@ -541,7 +541,6 @@ pub(crate) fn make_partitions(
         ops.push(DmlOperation::Write(make_write_op(
             &PartitionKey::from(TEST_PARTITION_2),
             shard_index,
-            TEST_NAMESPACE,
             ns_id,
             table_id,
             seq_num,
@@ -552,7 +551,6 @@ pub(crate) fn make_partitions(
         ops.push(DmlOperation::Write(make_write_op(
             &PartitionKey::from(TEST_PARTITION_2),
             shard_index,
-            TEST_NAMESPACE,
             ns_id,
             table_id,
             seq_num,
@@ -563,7 +561,6 @@ pub(crate) fn make_partitions(
         ops.push(DmlOperation::Write(make_write_op(
             &PartitionKey::from(TEST_PARTITION_1),
             shard_index,
-            TEST_NAMESPACE,
             ns_id,
             table_id,
             seq_num,
@@ -574,7 +571,6 @@ pub(crate) fn make_partitions(
         ops.push(DmlOperation::Write(make_write_op(
             &PartitionKey::from(TEST_PARTITION_1),
             shard_index,
-            TEST_NAMESPACE,
             ns_id,
             table_id,
             seq_num,
@@ -588,7 +584,6 @@ pub(crate) fn make_partitions(
 pub(crate) fn make_write_op(
     partition_key: &PartitionKey,
     shard_index: ShardIndex,
-    _namespace: &str,
     namespace_id: NamespaceId,
     table_id: TableId,
     sequence_number: i64,
@@ -648,7 +643,6 @@ fn make_first_partition_data(
     out.push(DmlOperation::Write(make_write_op(
         partition_key,
         shard_index,
-        TEST_NAMESPACE,
         ns_id,
         table_id,
         seq_num,
@@ -659,7 +653,6 @@ fn make_first_partition_data(
     out.push(DmlOperation::Write(make_write_op(
         partition_key,
         shard_index,
-        TEST_NAMESPACE,
         ns_id,
         table_id,
         seq_num,
@@ -672,7 +665,6 @@ fn make_first_partition_data(
     out.push(DmlOperation::Write(make_write_op(
         partition_key,
         shard_index,
-        TEST_NAMESPACE,
         ns_id,
         table_id,
         seq_num,
@@ -683,7 +675,6 @@ fn make_first_partition_data(
     out.push(DmlOperation::Write(make_write_op(
         partition_key,
         shard_index,
-        TEST_NAMESPACE,
         ns_id,
         table_id,
         seq_num,
@@ -697,7 +688,6 @@ fn make_first_partition_data(
     out.push(DmlOperation::Write(make_write_op(
         partition_key,
         shard_index,
-        TEST_NAMESPACE,
         ns_id,
         table_id,
         seq_num,
@@ -708,7 +698,6 @@ fn make_first_partition_data(
     out.push(DmlOperation::Write(make_write_op(
         partition_key,
         shard_index,
-        TEST_NAMESPACE,
         ns_id,
         table_id,
         seq_num,

--- a/ingester/src/test_util.rs
+++ b/ingester/src/test_util.rs
@@ -588,7 +588,7 @@ pub(crate) fn make_partitions(
 pub(crate) fn make_write_op(
     partition_key: &PartitionKey,
     shard_index: ShardIndex,
-    namespace: &str,
+    _namespace: &str,
     namespace_id: NamespaceId,
     table_id: TableId,
     sequence_number: i64,
@@ -600,7 +600,6 @@ pub(crate) fn make_write_op(
 
     let ids = [(TEST_TABLE.into(), table_id)].into_iter().collect();
     DmlWrite::new(
-        namespace.to_string(),
         namespace_id,
         tables,
         ids,

--- a/ingester/tests/common/mod.rs
+++ b/ingester/tests/common/mod.rs
@@ -294,7 +294,6 @@ impl TestContext {
             .await;
 
         self.enqueue_write(DmlWrite::new(
-            namespace,
             namespace_id,
             lines_to_batches(lp, 0).unwrap(),
             ids.clone(),

--- a/mutable_batch_pb/src/encode.rs
+++ b/mutable_batch_pb/src/encode.rs
@@ -12,9 +12,8 @@ use mutable_batch::MutableBatch;
 use schema::InfluxColumnType;
 
 /// Convert a [`DmlWrite`] to a [`DatabaseBatch`]
-pub fn encode_write(db_name: &str, database_id: i64, write: &DmlWrite) -> DatabaseBatch {
+pub fn encode_write(_db_name: &str, database_id: i64, write: &DmlWrite) -> DatabaseBatch {
     DatabaseBatch {
-        database_name: db_name.to_string(),
         table_batches: write
             .tables()
             .map(|(table_name, batch)| {
@@ -24,8 +23,8 @@ pub fn encode_write(db_name: &str, database_id: i64, write: &DmlWrite) -> Databa
                 // can be removed.
                 let table_id = write.table_id(table_name).unwrap_or_else(|| {
                     panic!(
-                        "no table ID mapping found for {} table {}",
-                        db_name, table_name
+                        "no table ID mapping found for namespace ID {} table {}",
+                        database_id, table_name
                     )
                 });
                 encode_batch(table_name, table_id.get(), batch)

--- a/mutable_batch_pb/src/encode.rs
+++ b/mutable_batch_pb/src/encode.rs
@@ -12,7 +12,7 @@ use mutable_batch::MutableBatch;
 use schema::InfluxColumnType;
 
 /// Convert a [`DmlWrite`] to a [`DatabaseBatch`]
-pub fn encode_write(_db_name: &str, database_id: i64, write: &DmlWrite) -> DatabaseBatch {
+pub fn encode_write(database_id: i64, write: &DmlWrite) -> DatabaseBatch {
     DatabaseBatch {
         table_batches: write
             .tables()

--- a/mutable_batch_tests/benches/write_pb.rs
+++ b/mutable_batch_tests/benches/write_pb.rs
@@ -20,7 +20,6 @@ fn generate_pbdata_bytes() -> Vec<(String, (usize, Bytes))> {
                 .collect();
 
             let write = DmlWrite::new(
-                "test_db",
                 NamespaceId::new(42),
                 batches,
                 ids,

--- a/mutable_batch_tests/benches/write_pb.rs
+++ b/mutable_batch_tests/benches/write_pb.rs
@@ -27,7 +27,7 @@ fn generate_pbdata_bytes() -> Vec<(String, (usize, Bytes))> {
                 "bananas".into(),
                 Default::default(),
             );
-            let database_batch = mutable_batch_pb::encode::encode_write("db", 42, &write);
+            let database_batch = mutable_batch_pb::encode::encode_write(42, &write);
 
             let mut bytes = BytesMut::new();
             database_batch.encode(&mut bytes).unwrap();

--- a/query_tests/src/scenarios/util.rs
+++ b/query_tests/src/scenarios/util.rs
@@ -835,7 +835,6 @@ impl MockIngester {
             0,
         );
         let op = DmlOperation::Write(DmlWrite::new(
-            self.ns.namespace.name.clone(),
             self.ns.namespace.id,
             mutable_batches,
             ids,
@@ -862,7 +861,6 @@ impl MockIngester {
             0,
         );
         DmlOperation::Delete(DmlDelete::new(
-            self.ns.namespace.name.clone(),
             self.ns.namespace.id,
             predicate,
             Some(NonEmptyString::new(delete_table_name).unwrap()),

--- a/router/src/dml_handlers/sharded_write_buffer.rs
+++ b/router/src/dml_handlers/sharded_write_buffer.rs
@@ -509,7 +509,7 @@ mod tests {
             .expect("write should have been successful");
         assert_matches!(got, DmlOperation::Delete(d) => {
             assert_eq!(d.table_name(), Some(TABLE));
-            assert_eq!(d.namespace(), &*ns);
+            assert_eq!(d.namespace_id().get(), 42);
             assert_eq!(*d.predicate(), predicate);
         });
     }

--- a/router/src/dml_handlers/sharded_write_buffer.rs
+++ b/router/src/dml_handlers/sharded_write_buffer.rs
@@ -131,7 +131,6 @@ where
 
         let iter = collated.into_iter().map(|(shard, batch)| {
             let dml = DmlWrite::new(
-                namespace,
                 namespace_id,
                 batch,
                 table_ids.remove(&shard).unwrap(),
@@ -168,7 +167,6 @@ where
         let shards = self.sharder.shard(table_name, namespace, &predicate);
 
         let dml = DmlDelete::new(
-            namespace,
             namespace_id,
             predicate,
             NonEmptyString::new(table_name),

--- a/router/tests/http.rs
+++ b/router/tests/http.rs
@@ -179,7 +179,6 @@ async fn test_write_ok() {
     let writes = ctx.write_buffer_state().get_messages(ShardIndex::new(0));
     assert_eq!(writes.len(), 1);
     assert_matches!(writes.as_slice(), [Ok(DmlOperation::Write(w))] => {
-        assert_eq!(w.namespace(), "bananas_test");
         assert!(w.table("platanos").is_some());
     });
 
@@ -406,7 +405,6 @@ async fn test_write_propagate_ids() {
     let writes = ctx.write_buffer_state().get_messages(ShardIndex::new(0));
     assert_eq!(writes.len(), 1);
     assert_matches!(writes.as_slice(), [Ok(DmlOperation::Write(w))] => {
-        assert_eq!(w.namespace(), "bananas_test");
         assert_eq!(w.namespace_id(), ns.id);
         assert!(w.table("platanos").is_some());
 
@@ -458,7 +456,6 @@ async fn test_delete_propagate_ids() {
     let writes = ctx.write_buffer_state().get_messages(ShardIndex::new(0));
     assert_eq!(writes.len(), 1);
     assert_matches!(writes.as_slice(), [Ok(DmlOperation::Delete(w))] => {
-        assert_eq!(w.namespace(), "bananas_test");
         assert_eq!(w.namespace_id(), ns.id);
     });
 }

--- a/write_buffer/src/codec.rs
+++ b/write_buffer/src/codec.rs
@@ -28,9 +28,6 @@ pub const HEADER_CONTENT_TYPE: &str = "content-type";
 /// Message header for tracing context.
 pub const HEADER_TRACE_CONTEXT: &str = "uber-trace-id";
 
-/// Message header for namespace.
-pub const HEADER_NAMESPACE: &str = "iox-namespace";
-
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum ContentType {
     Protobuf,
@@ -41,20 +38,14 @@ pub enum ContentType {
 pub struct IoxHeaders {
     content_type: ContentType,
     span_context: Option<SpanContext>,
-    namespace: String,
 }
 
 impl IoxHeaders {
     /// Create new headers with sane default values and given span context.
-    pub fn new(
-        content_type: ContentType,
-        span_context: Option<SpanContext>,
-        namespace: String,
-    ) -> Self {
+    pub fn new(content_type: ContentType, span_context: Option<SpanContext>) -> Self {
         Self {
             content_type,
             span_context,
-            namespace,
         }
     }
 
@@ -65,7 +56,6 @@ impl IoxHeaders {
     ) -> Result<Self, WriteBufferError> {
         let mut span_context = None;
         let mut content_type = None;
-        let mut namespace = None;
 
         for (name, value) in headers {
             let name = name.as_ref();
@@ -110,15 +100,6 @@ impl IoxHeaders {
                     }
                 }
             }
-
-            if name.eq_ignore_ascii_case(HEADER_NAMESPACE) {
-                namespace = Some(String::from_utf8(value.as_ref().to_vec()).map_err(|e| {
-                    WriteBufferError::invalid_data(format!(
-                        "Error decoding namespace header: {}",
-                        e
-                    ))
-                })?);
-            }
         }
 
         let content_type =
@@ -127,7 +108,6 @@ impl IoxHeaders {
         Ok(Self {
             content_type,
             span_context,
-            namespace: namespace.unwrap_or_default(),
         })
     }
 
@@ -149,22 +129,17 @@ impl IoxHeaders {
             ContentType::Protobuf => CONTENT_TYPE_PROTOBUF.into(),
         };
 
-        std::iter::once((HEADER_CONTENT_TYPE, content_type))
-            .chain(
-                self.span_context
-                    .as_ref()
-                    .map(|ctx| {
-                        (
-                            HEADER_TRACE_CONTEXT,
-                            format_jaeger_trace_context(ctx).into(),
-                        )
-                    })
-                    .into_iter(),
-            )
-            .chain(std::iter::once((
-                HEADER_NAMESPACE,
-                self.namespace.clone().into(),
-            )))
+        std::iter::once((HEADER_CONTENT_TYPE, content_type)).chain(
+            self.span_context
+                .as_ref()
+                .map(|ctx| {
+                    (
+                        HEADER_TRACE_CONTEXT,
+                        format_jaeger_trace_context(ctx).into(),
+                    )
+                })
+                .into_iter(),
+        )
     }
 }
 
@@ -203,7 +178,7 @@ pub fn decode(
                     };
 
                     Ok(DmlOperation::Write(DmlWrite::new(
-                        headers.namespace,
+                        "deprecated",
                         NamespaceId::new(write.database_id),
                         tables,
                         ids.into_iter().map(|(k, v)| (k, TableId::new(v))).collect(),
@@ -218,7 +193,7 @@ pub fn decode(
                         .map_err(WriteBufferError::invalid_data)?;
 
                     Ok(DmlOperation::Delete(DmlDelete::new(
-                        headers.namespace,
+                        "deprecated",
                         NamespaceId::new(delete.database_id),
                         predicate,
                         NonEmptyString::new(delete.table_name),
@@ -276,11 +251,7 @@ mod tests {
 
         let span_context_parent = SpanContext::new(Arc::clone(&collector));
         let span_context = span_context_parent.child("foo").ctx;
-        let iox_headers1 = IoxHeaders::new(
-            ContentType::Protobuf,
-            Some(span_context),
-            "namespace".to_owned(),
-        );
+        let iox_headers1 = IoxHeaders::new(ContentType::Protobuf, Some(span_context));
 
         let encoded: Vec<_> = iox_headers1
             .headers()
@@ -295,7 +266,6 @@ mod tests {
             iox_headers2.span_context.as_ref().unwrap(),
             vec![],
         );
-        assert_eq!(iox_headers1.namespace, iox_headers2.namespace);
     }
 
     #[test]
@@ -306,6 +276,7 @@ mod tests {
             ("conTent-Type", CONTENT_TYPE_PROTOBUF),
             ("uber-trace-id", "1:2:3:1"),
             ("uber-trace-ID", "5:6:7:1"),
+            // Namespace is no longer used; test that specifying it doesn't cause errors
             ("iOx-Namespace", "namespace"),
         ];
 
@@ -315,8 +286,6 @@ mod tests {
         let span_context = actual.span_context.unwrap();
         assert_eq!(span_context.trace_id.get(), 5);
         assert_eq!(span_context.span_id.get(), 6);
-
-        assert_eq!(actual.namespace, "namespace");
     }
 
     #[test]
@@ -325,11 +294,7 @@ mod tests {
 
         let span_context = SpanContext::new(Arc::clone(&collector));
 
-        let iox_headers1 = IoxHeaders::new(
-            ContentType::Protobuf,
-            Some(span_context),
-            "namespace".to_owned(),
-        );
+        let iox_headers1 = IoxHeaders::new(ContentType::Protobuf, Some(span_context));
 
         let encoded: Vec<_> = iox_headers1
             .headers()
@@ -362,20 +327,20 @@ mod tests {
 
         let got = decode(
             &buf,
-            IoxHeaders::new(ContentType::Protobuf, None, "bananas".into()),
+            IoxHeaders::new(ContentType::Protobuf, None),
             Sequence::new(ShardIndex::new(1), SequenceNumber::new(42)),
             time,
             424242,
         )
         .expect("failed to decode valid wire format");
 
-        assert_eq!(w.namespace(), got.namespace());
+        assert_eq!("deprecated", got.namespace());
         let got = match got {
             DmlOperation::Write(w) => w,
             _ => panic!("wrong op type"),
         };
 
-        assert_eq!(w.namespace(), got.namespace());
+        assert_eq!("deprecated", got.namespace());
         assert_eq!(w.namespace_id(), got.namespace_id());
         assert_eq!(w.table_count(), got.table_count());
         assert_eq!(w.min_timestamp(), got.min_timestamp());

--- a/write_buffer/src/codec.rs
+++ b/write_buffer/src/codec.rs
@@ -207,7 +207,7 @@ pub fn decode(
 
 /// Encodes a [`DmlOperation`] as a protobuf [`WriteBufferPayload`]
 pub fn encode_operation(
-    db_name: &str,
+    _db_name: &str,
     operation: &DmlOperation,
     buf: &mut Vec<u8>,
 ) -> Result<(), WriteBufferError> {
@@ -218,7 +218,6 @@ pub fn encode_operation(
             Payload::Write(batch)
         }
         DmlOperation::Delete(delete) => Payload::Delete(DeletePayload {
-            db_name: db_name.to_string(),
             database_id: delete.namespace_id().get(),
             table_name: delete
                 .table_name()

--- a/write_buffer/src/codec.rs
+++ b/write_buffer/src/codec.rs
@@ -332,13 +332,11 @@ mod tests {
         )
         .expect("failed to decode valid wire format");
 
-        assert_eq!("deprecated", got.namespace());
         let got = match got {
             DmlOperation::Write(w) => w,
             _ => panic!("wrong op type"),
         };
 
-        assert_eq!("deprecated", got.namespace());
         assert_eq!(w.namespace_id(), got.namespace_id());
         assert_eq!(w.table_count(), got.table_count());
         assert_eq!(w.min_timestamp(), got.min_timestamp());

--- a/write_buffer/src/codec.rs
+++ b/write_buffer/src/codec.rs
@@ -214,7 +214,7 @@ pub fn encode_operation(
     let payload = match operation {
         DmlOperation::Write(write) => {
             let namespace_id = write.namespace_id().get();
-            let batch = mutable_batch_pb::encode::encode_write(db_name, namespace_id, write);
+            let batch = mutable_batch_pb::encode::encode_write(namespace_id, write);
             Payload::Write(batch)
         }
         DmlOperation::Delete(delete) => Payload::Delete(DeletePayload {

--- a/write_buffer/src/codec.rs
+++ b/write_buffer/src/codec.rs
@@ -207,7 +207,6 @@ pub fn decode(
 
 /// Encodes a [`DmlOperation`] as a protobuf [`WriteBufferPayload`]
 pub fn encode_operation(
-    _db_name: &str,
     operation: &DmlOperation,
     buf: &mut Vec<u8>,
 ) -> Result<(), WriteBufferError> {
@@ -319,7 +318,7 @@ mod tests {
         );
 
         let mut buf = Vec::new();
-        encode_operation("namespace", &DmlOperation::Write(w.clone()), &mut buf)
+        encode_operation(&DmlOperation::Write(w.clone()), &mut buf)
             .expect("should encode valid DmlWrite successfully");
 
         let time = SystemProvider::new().now();

--- a/write_buffer/src/codec.rs
+++ b/write_buffer/src/codec.rs
@@ -178,7 +178,6 @@ pub fn decode(
                     };
 
                     Ok(DmlOperation::Write(DmlWrite::new(
-                        "deprecated",
                         NamespaceId::new(write.database_id),
                         tables,
                         ids.into_iter().map(|(k, v)| (k, TableId::new(v))).collect(),
@@ -193,7 +192,6 @@ pub fn decode(
                         .map_err(WriteBufferError::invalid_data)?;
 
                     Ok(DmlOperation::Delete(DmlDelete::new(
-                        "deprecated",
                         NamespaceId::new(delete.database_id),
                         predicate,
                         NonEmptyString::new(delete.table_name),
@@ -309,7 +307,6 @@ mod tests {
         let (data, ids) = lp_to_batches("platanos great=42 100\nbananas greatness=1000 100");
 
         let w = DmlWrite::new(
-            "bananas",
             NamespaceId::new(42),
             data,
             ids,

--- a/write_buffer/src/core.rs
+++ b/write_buffer/src/core.rs
@@ -392,7 +392,6 @@ pub mod test_utils {
 
     /// Writes line protocol and returns the [`DmlWrite`] that was written.
     pub async fn write(
-        _namespace: &str,
         writer: &impl WriteBufferWriting,
         lp: &str,
         shard_index: ShardIndex,
@@ -453,7 +452,6 @@ pub mod test_utils {
 
         // adding content allows us to get results
         let w1 = write(
-            "namespace",
             &writer,
             entry_1,
             shard_index,
@@ -469,7 +467,6 @@ pub mod test_utils {
 
         // adding more data unblocks the stream
         let w2 = write(
-            "namespace",
             &writer,
             entry_2,
             shard_index,
@@ -478,7 +475,6 @@ pub mod test_utils {
         )
         .await;
         let w3 = write(
-            "namespace",
             &writer,
             entry_3,
             shard_index,
@@ -516,7 +512,6 @@ pub mod test_utils {
         let shard_index = ShardIndex::new(0);
 
         let w1 = write(
-            "namespace",
             &writer,
             entry_1,
             shard_index,
@@ -525,7 +520,6 @@ pub mod test_utils {
         )
         .await;
         let w2 = write(
-            "namespace",
             &writer,
             entry_2,
             shard_index,
@@ -534,7 +528,6 @@ pub mod test_utils {
         )
         .await;
         let w3 = write(
-            "namespace",
             &writer,
             entry_3,
             shard_index,
@@ -609,7 +602,6 @@ pub mod test_utils {
 
         // entries arrive at the right target stream
         let w1 = write(
-            "namespace",
             &writer,
             entry_1,
             shard_index_1,
@@ -621,7 +613,6 @@ pub mod test_utils {
         assert_stream_pending(&mut stream_2).await;
 
         let w2 = write(
-            "namespace",
             &writer,
             entry_2,
             shard_index_2,
@@ -633,7 +624,6 @@ pub mod test_utils {
         assert_write_op_eq(&stream_2.next().await.unwrap().unwrap(), &w2);
 
         let w3 = write(
-            "namespace",
             &writer,
             entry_3,
             shard_index_1,
@@ -680,7 +670,6 @@ pub mod test_utils {
         let shard_index_2 = set_pop_first(&mut shard_indexes_1).unwrap();
 
         let w_east_1 = write(
-            "namespace",
             &writer_1,
             entry_east_1,
             shard_index_1,
@@ -689,7 +678,6 @@ pub mod test_utils {
         )
         .await;
         let w_west_1 = write(
-            "namespace",
             &writer_1,
             entry_west_1,
             shard_index_2,
@@ -698,7 +686,6 @@ pub mod test_utils {
         )
         .await;
         let w_east_2 = write(
-            "namespace",
             &writer_2,
             entry_east_2,
             shard_index_1,
@@ -744,7 +731,6 @@ pub mod test_utils {
         let shard_index_2 = set_pop_first(&mut shard_indexes).unwrap();
 
         let w_east_1 = write(
-            "namespace",
             &writer,
             entry_east_1,
             shard_index_1,
@@ -753,7 +739,6 @@ pub mod test_utils {
         )
         .await;
         let w_east_2 = write(
-            "namespace",
             &writer,
             entry_east_2,
             shard_index_1,
@@ -762,7 +747,6 @@ pub mod test_utils {
         )
         .await;
         let w_west_1 = write(
-            "namespace",
             &writer,
             entry_west_1,
             shard_index_2,
@@ -811,7 +795,6 @@ pub mod test_utils {
         );
 
         let w_east_3 = write(
-            "namespace",
             &writer,
             entry_east_3,
             ShardIndex::new(0),
@@ -854,7 +837,6 @@ pub mod test_utils {
         let shard_index_1 = set_pop_first(&mut shard_indexes).unwrap();
 
         let w_east_1 = write(
-            "namespace",
             &writer,
             entry_east_1,
             shard_index_1,
@@ -863,7 +845,6 @@ pub mod test_utils {
         )
         .await;
         let w_east_2 = write(
-            "namespace",
             &writer,
             entry_east_2,
             shard_index_1,
@@ -927,7 +908,6 @@ pub mod test_utils {
 
         // high water mark moves
         write(
-            "namespace",
             &writer,
             entry_east_1,
             shard_index_1,
@@ -936,7 +916,6 @@ pub mod test_utils {
         )
         .await;
         let w1 = write(
-            "namespace",
             &writer,
             entry_east_2,
             shard_index_1,
@@ -945,7 +924,6 @@ pub mod test_utils {
         )
         .await;
         let w2 = write(
-            "namespace",
             &writer,
             entry_west_1,
             shard_index_2,
@@ -989,7 +967,6 @@ pub mod test_utils {
         let shard_index = set_pop_first(&mut shard_indexes).unwrap();
 
         let write = write(
-            "namespace",
             &writer,
             entry,
             shard_index,
@@ -1039,7 +1016,6 @@ pub mod test_utils {
         // Two ops with the same partition keys, first write at time 100
         time_provider.set(time_provider.inc(Duration::from_millis(100)));
         write(
-            "ns1",
             &writer,
             "table foo=1",
             shard_index,
@@ -1051,7 +1027,6 @@ pub mod test_utils {
         // second write @ time 200
         time_provider.set(time_provider.inc(Duration::from_millis(100)));
         write(
-            "ns1",
             &writer,
             "table foo=1",
             shard_index,
@@ -1063,7 +1038,6 @@ pub mod test_utils {
         // third write @ time 300
         time_provider.set(time_provider.inc(Duration::from_millis(100)));
         write(
-            "ns1",
             &writer,
             "table foo=1",
             shard_index,
@@ -1185,7 +1159,6 @@ pub mod test_utils {
 
         // 1: no context
         write(
-            "namespace",
             &writer,
             entry,
             shard_index,
@@ -1205,7 +1178,6 @@ pub mod test_utils {
         // 2: some context
         let span_context_1 = SpanContext::new(Arc::clone(&collector) as Arc<_>);
         write(
-            "namespace",
             &writer,
             entry,
             shard_index,
@@ -1218,7 +1190,6 @@ pub mod test_utils {
         let span_context_parent = SpanContext::new(Arc::clone(&collector) as Arc<_>);
         let span_context_2 = span_context_parent.child("foo").ctx;
         write(
-            "namespace",
             &writer,
             entry,
             shard_index,
@@ -1292,7 +1263,6 @@ pub mod test_utils {
         let shard_index = set_pop_first(&mut shard_indexes).unwrap();
 
         let w1 = write(
-            "namespace_1",
             &writer,
             entry_2,
             shard_index,
@@ -1301,7 +1271,6 @@ pub mod test_utils {
         )
         .await;
         let w2 = write(
-            "namespace_2",
             &writer,
             entry_1,
             shard_index,
@@ -1335,7 +1304,6 @@ pub mod test_utils {
                     let entry = format!("upc,region=east user={} {}", i, i);
 
                     write(
-                        "ns",
                         writer.as_ref(),
                         &entry,
                         shard_index,

--- a/write_buffer/src/core.rs
+++ b/write_buffer/src/core.rs
@@ -392,7 +392,7 @@ pub mod test_utils {
 
     /// Writes line protocol and returns the [`DmlWrite`] that was written.
     pub async fn write(
-        namespace: &str,
+        _namespace: &str,
         writer: &impl WriteBufferWriting,
         lp: &str,
         shard_index: ShardIndex,
@@ -402,7 +402,6 @@ pub mod test_utils {
         let (tables, names) = lp_to_batches(lp);
 
         let write = DmlWrite::new(
-            namespace,
             NamespaceId::new(42),
             tables,
             names,
@@ -1251,7 +1250,6 @@ pub mod test_utils {
 
         let (tables, names) = lp_to_batches("upc user=1 100");
         let write = DmlWrite::new(
-            "foo",
             NamespaceId::new(42),
             tables,
             names,

--- a/write_buffer/src/file.rs
+++ b/write_buffer/src/file.rs
@@ -848,7 +848,6 @@ mod tests {
         let entry_4 = "upc,region=east user=4 400";
 
         let w1 = write(
-            &ctx.database_name,
             &writer,
             entry_1,
             shard_index,
@@ -857,7 +856,6 @@ mod tests {
         )
         .await;
         let w2 = write(
-            &ctx.database_name,
             &writer,
             entry_2,
             shard_index,
@@ -866,7 +864,6 @@ mod tests {
         )
         .await;
         let w3 = write(
-            &ctx.database_name,
             &writer,
             entry_3,
             shard_index,
@@ -875,7 +872,6 @@ mod tests {
         )
         .await;
         let w4 = write(
-            &ctx.database_name,
             &writer,
             entry_4,
             shard_index,
@@ -918,7 +914,6 @@ mod tests {
         let entry_2 = "upc,region=east user=2 200";
 
         let w1 = write(
-            &ctx.database_name,
             &writer,
             entry_1,
             shard_index,
@@ -927,7 +922,6 @@ mod tests {
         )
         .await;
         let w2 = write(
-            &ctx.database_name,
             &writer,
             entry_2,
             shard_index,

--- a/write_buffer/src/file.rs
+++ b/write_buffer/src/file.rs
@@ -207,7 +207,6 @@ impl WriteBufferWriting for FileBufferProducer {
         let iox_headers = IoxHeaders::new(
             ContentType::Protobuf,
             operation.meta().span_context().cloned(),
-            operation.namespace().to_string(),
         );
 
         for (name, value) in iox_headers.headers() {

--- a/write_buffer/src/file.rs
+++ b/write_buffer/src/file.rs
@@ -154,7 +154,6 @@ pub const HEADER_TIME: &str = "last-modified";
 /// File-based write buffer writer.
 #[derive(Debug)]
 pub struct FileBufferProducer {
-    db_name: String,
     dirs: BTreeMap<ShardIndex, PathBuf>,
     time_provider: Arc<dyn TimeProvider>,
 }
@@ -170,7 +169,6 @@ impl FileBufferProducer {
         let root = root.join(database_name);
         let dirs = maybe_auto_create_directories(&root, creation_config).await?;
         Ok(Self {
-            db_name: database_name.to_string(),
             dirs,
             time_provider,
         })
@@ -215,7 +213,7 @@ impl WriteBufferWriting for FileBufferProducer {
 
         message.extend(b"\n");
 
-        crate::codec::encode_operation(&self.db_name, &operation, &mut message)?;
+        crate::codec::encode_operation(&operation, &mut message)?;
 
         // write data to scratchpad file in temp directory
         let temp_file = shard_path.join("temp").join(Uuid::new_v4().to_string());

--- a/write_buffer/src/kafka/mod.rs
+++ b/write_buffer/src/kafka/mod.rs
@@ -829,7 +829,7 @@ mod tests {
     }
 
     async fn write(
-        namespace: &str,
+        _namespace: &str,
         producer: &RSKafkaProducer,
         trace_collector: &Arc<RingBufferTraceCollector>,
         shard_index: ShardIndex,
@@ -838,7 +838,6 @@ mod tests {
         let span_ctx = SpanContext::new(Arc::clone(trace_collector) as Arc<_>);
         let (tables, names) = lp_to_batches("table foo=1");
         let write = DmlWrite::new(
-            namespace,
             NamespaceId::new(42),
             tables,
             names,
@@ -850,14 +849,13 @@ mod tests {
     }
 
     async fn delete(
-        namespace: &str,
+        _namespace: &str,
         producer: &RSKafkaProducer,
         trace_collector: &Arc<RingBufferTraceCollector>,
         shard_index: ShardIndex,
     ) -> DmlMeta {
         let span_ctx = SpanContext::new(Arc::clone(trace_collector) as Arc<_>);
         let op = DmlOperation::Delete(DmlDelete::new(
-            namespace,
             NamespaceId::new(42),
             DeletePredicate {
                 range: TimestampRange::new(0, 1),

--- a/write_buffer/src/kafka/mod.rs
+++ b/write_buffer/src/kafka/mod.rs
@@ -734,19 +734,19 @@ mod tests {
 
         let (w1_1, w1_2, w2_1, d1_1, d1_2, w1_3, w1_4, w2_2) = tokio::join!(
             // ns1: batch 1
-            write("ns1", &producer, &trace_collector, shard_index, "bananas"),
-            write("ns1", &producer, &trace_collector, shard_index, "bananas"),
+            write(&producer, &trace_collector, shard_index, "bananas"),
+            write(&producer, &trace_collector, shard_index, "bananas"),
             // ns2: batch 1, part A
-            write("ns2", &producer, &trace_collector, shard_index, "bananas"),
+            write(&producer, &trace_collector, shard_index, "bananas"),
             // ns1: batch 2
-            delete("ns1", &producer, &trace_collector, shard_index),
+            delete(&producer, &trace_collector, shard_index),
             // ns1: batch 3
-            delete("ns1", &producer, &trace_collector, shard_index),
+            delete(&producer, &trace_collector, shard_index),
             // ns1: batch 4
-            write("ns1", &producer, &trace_collector, shard_index, "bananas"),
-            write("ns1", &producer, &trace_collector, shard_index, "bananas"),
+            write(&producer, &trace_collector, shard_index, "bananas"),
+            write(&producer, &trace_collector, shard_index, "bananas"),
             // ns2: batch 1, part B
-            write("ns2", &producer, &trace_collector, shard_index, "bananas"),
+            write(&producer, &trace_collector, shard_index, "bananas"),
         );
 
         // ensure that write operations were NOT fused
@@ -828,7 +828,6 @@ mod tests {
     }
 
     async fn write(
-        _namespace: &str,
         producer: &RSKafkaProducer,
         trace_collector: &Arc<RingBufferTraceCollector>,
         shard_index: ShardIndex,
@@ -848,7 +847,6 @@ mod tests {
     }
 
     async fn delete(
-        _namespace: &str,
         producer: &RSKafkaProducer,
         trace_collector: &Arc<RingBufferTraceCollector>,
         shard_index: ShardIndex,

--- a/write_buffer/src/kafka/mod.rs
+++ b/write_buffer/src/kafka/mod.rs
@@ -698,7 +698,6 @@ mod tests {
             .await
             .unwrap();
         let w = crate::core::test_utils::write(
-            "namespace",
             &producer,
             "table foo=1 1",
             shard_index,

--- a/write_buffer/src/kafka/record_aggregator.rs
+++ b/write_buffer/src/kafka/record_aggregator.rs
@@ -83,7 +83,7 @@ impl RecordAggregator {
         let headers = IoxHeaders::new(ContentType::Protobuf, op.meta().span_context().cloned());
 
         let mut buf = Vec::new();
-        crate::codec::encode_operation(op.namespace(), op, &mut buf)?;
+        crate::codec::encode_operation(op, &mut buf)?;
         buf.shrink_to_fit();
 
         let record = Record {

--- a/write_buffer/src/kafka/record_aggregator.rs
+++ b/write_buffer/src/kafka/record_aggregator.rs
@@ -207,7 +207,6 @@ mod tests {
 
     use super::*;
 
-    const NAMESPACE: &str = "bananas";
     const SHARD_INDEX: ShardIndex = ShardIndex::new(42);
     const TIMESTAMP_MILLIS: i64 = 1659990497000;
 
@@ -233,7 +232,6 @@ mod tests {
             .collect();
 
         DmlOperation::Write(DmlWrite::new(
-            NAMESPACE.to_string(),
             NamespaceId::new(42),
             m,
             ids,

--- a/write_buffer/src/kafka/record_aggregator.rs
+++ b/write_buffer/src/kafka/record_aggregator.rs
@@ -311,7 +311,7 @@ mod tests {
             .try_push(write.clone())
             .expect("aggregate call should succeed");
         match res {
-            TryPush::NoCapacity(res) => assert_eq!(res.namespace(), write.namespace()),
+            TryPush::NoCapacity(res) => assert_eq!(res.namespace_id(), write.namespace_id()),
             TryPush::Aggregated(_) => panic!("expected no capacity"),
         };
     }

--- a/write_buffer/src/kafka/record_aggregator.rs
+++ b/write_buffer/src/kafka/record_aggregator.rs
@@ -80,11 +80,7 @@ impl RecordAggregator {
             .producer_ts()
             .unwrap_or_else(|| self.time_provider.now());
 
-        let headers = IoxHeaders::new(
-            ContentType::Protobuf,
-            op.meta().span_context().cloned(),
-            op.namespace().to_owned(),
-        );
+        let headers = IoxHeaders::new(ContentType::Protobuf, op.meta().span_context().cloned());
 
         let mut buf = Vec::new();
         crate::codec::encode_operation(op.namespace(), op, &mut buf)?;
@@ -207,9 +203,7 @@ mod tests {
     use mutable_batch::{writer::Writer, MutableBatch};
     use trace::LogTraceCollector;
 
-    use crate::codec::{
-        CONTENT_TYPE_PROTOBUF, HEADER_CONTENT_TYPE, HEADER_NAMESPACE, HEADER_TRACE_CONTEXT,
-    };
+    use crate::codec::{CONTENT_TYPE_PROTOBUF, HEADER_CONTENT_TYPE, HEADER_TRACE_CONTEXT};
 
     use super::*;
 
@@ -280,13 +274,6 @@ mod tests {
                 .get(HEADER_CONTENT_TYPE)
                 .expect("no content type"),
             Vec::<u8>::from(CONTENT_TYPE_PROTOBUF),
-        );
-        assert_eq!(
-            *record
-                .headers
-                .get(HEADER_NAMESPACE)
-                .expect("no namespace header"),
-            Vec::<u8>::from(NAMESPACE),
         );
         assert!(record.headers.get(HEADER_TRACE_CONTEXT).is_some());
         assert_eq!(record.timestamp.timestamp(), 1659990497);

--- a/write_buffer/src/mock.rs
+++ b/write_buffer/src/mock.rs
@@ -178,7 +178,6 @@ impl MockBufferSharedState {
         let (tables, names) = lp_to_batches(lp);
         let meta = DmlMeta::sequenced(sequence, iox_time::Time::from_timestamp_nanos(0), None, 0);
         self.push_write(DmlWrite::new(
-            "foo",
             NamespaceId::new(42),
             tables,
             names,
@@ -905,7 +904,6 @@ mod tests {
 
         let (tables, names) = lp_to_batches("upc user=1 100");
         let operation = DmlOperation::Write(DmlWrite::new(
-            "test_db",
             NamespaceId::new(42),
             tables,
             names,


### PR DESCRIPTION
I highly recommend reviewing this PR commit-by-commit.

## Summary

This PR:

 - Removes the namespace (database) name from `IoxHeaders`, which is metadata that goes into the write buffer but is never read as far as I can tell. CHECK ME ON THIS BEFORE MERGING!!!
 - Deprecates the protobuf `DeletePayload` `db_name` field and the `DatabaseBatch` `database_name` field, which I believe are unused as far as I can tell. CHECK ME ON THIS BEFORE MERGING!!!
 - Removes the namespace (database) name from `Dml` operations as part of https://github.com/influxdata/influxdb_iox/issues/4880
 - Fixes https://github.com/influxdata/influxdb_iox/issues/6049 by updating the documentation in docs/ingester_querier_protocol.md; everything else looks done for that issue.

## Commit descriptions

* fix: Update docs on the ingester-querier protocol.
 I believe this fixes #6049.
* docs: Remove outdated comments about safety; the temporary unsafe code is gone
* fix: Remove namespace name from IoxHeaders in write messages
* fix: Remove database_name field from DatabaseBatch
 It was only being used in one error message.
* fix: Remove now-unused db_name argument to encode_write
* fix: Remove db_name field from DeletePayload
 Doesn't seem to be used anywhere.
* fix: Remove db_name from encode_operation and FileBufferProducer
* test: Keep track of namespaces by ID in ingester TestContext
* fix: Remove namespace name field from DmlWrite and DmlDelete
 But leave the argument in their constructors for now.
 Not all numbers in tests can be 42, Dom.
* fix: Remove namespace from DmlWrite and DmlDelete constructors
* fix: Remove namespace argument from test helper function
* fix: Remove namespace argument from write test helper fn
* fix: Remove namespace argument from kafka test helper fn