### PR TITLE
feat: define router -> ingester write protocol

### DIFF
--- a/generated_types/build.rs
+++ b/generated_types/build.rs
@@ -54,6 +54,7 @@ fn generate_grpc_types(root: &Path) -> Result<()> {
         ingester_path.join("parquet_metadata.proto"),
         ingester_path.join("query.proto"),
         ingester_path.join("write_info.proto"),
+        ingester_path.join("write.proto"),
         namespace_path.join("service.proto"),
         object_store_path.join("service.proto"),
         predicate_path.join("predicate.proto"),

--- a/generated_types/protos/influxdata/iox/ingester/v1/write.proto
+++ b/generated_types/protos/influxdata/iox/ingester/v1/write.proto
@@ -1,0 +1,15 @@
+syntax = "proto3";
+package influxdata.iox.ingester.v1;
+option go_package = "github.com/influxdata/iox/ingester/v1";
+
+import "influxdata/pbdata/v1/influxdb_pb_data_protocol.proto";
+
+service WriteService {
+  rpc Write(WriteRequest) returns (WriteResponse);
+}
+
+message WriteRequest {
+  influxdata.pbdata.v1.DatabaseBatch payload = 1;
+}
+
+message WriteResponse {}

--- a/generated_types/protos/influxdata/pbdata/v1/influxdb_pb_data_protocol.proto
+++ b/generated_types/protos/influxdata/pbdata/v1/influxdb_pb_data_protocol.proto
@@ -123,19 +123,3 @@ message Column {
     // Trailing off bits (0) *may* be omitted.
     bytes null_mask = 4;
 }
-
-// Note there used to be a service that would load this internal protobuf format.
-// See https://github.com/influxdata/influxdb_iox/pull/5750 and
-// https://github.com/influxdata/influxdb_iox/issues/4866
-// for rationale of why it was removed
-
-// service WriteService {
-//     rpc Write (WriteRequest) returns (WriteResponse);
-// }
-
-message WriteRequest {
-    DatabaseBatch database_batch = 1;
-}
-
-message WriteResponse {
-}

--- a/test_helpers_end_to_end/src/client.rs
+++ b/test_helpers_end_to_end/src/client.rs
@@ -1,7 +1,6 @@
 //! Client helpers for writing end to end ng tests
 use arrow::record_batch::RecordBatch;
 use futures::{stream::FuturesUnordered, StreamExt};
-use generated_types::influxdata::pbdata::v1::WriteResponse;
 use http::Response;
 use hyper::{Body, Client, Request};
 use influxdb_iox_client::{
@@ -44,18 +43,6 @@ pub fn get_write_token(response: &Response<Body>) -> String {
     let message = format!("no write token in {:?}", response);
     response
         .headers()
-        .get("X-IOx-Write-Token")
-        .expect(&message)
-        .to_str()
-        .expect("Value not a string")
-        .to_string()
-}
-
-/// Extracts the write token from the specified response (to the gRPC write API)
-pub fn get_write_token_from_grpc(response: &tonic::Response<WriteResponse>) -> String {
-    let message = format!("no write token in {:?}", response);
-    response
-        .metadata()
         .get("X-IOx-Write-Token")
         .expect(&message)
         .to_str()


### PR DESCRIPTION
This PR defines a simple request/response placeholder for a direct RPC write from a router, to an ingester.

---

* feat: define router -> ingester write protocol (dcc7b10bc)

      Specify a gRPC service and request/response message formats to push
      writes directly from a router to an ingester.