### PR TITLE
build(arrow_util): datafusion is not a release dep

### DIFF
--- a/arrow_util/Cargo.toml
+++ b/arrow_util/Cargo.toml
@@ -13,7 +13,6 @@ arrow = { workspace = true, features = ["prettyprint", "dyn_cmp_dict"] }
 # used by arrow anyway (needed for printing workaround)
 chrono = { version = "0.4", default-features = false }
 comfy-table = { version = "6.1", default-features = false }
-datafusion = { workspace = true }
 hashbrown = { workspace = true }
 num-traits = "0.2"
 snafu = "0.7"
@@ -21,4 +20,5 @@ workspace-hack = { path = "../workspace-hack"}
 
 [dev-dependencies]
 arrow-flight = { workspace = true }
+datafusion = { workspace = true }
 rand = "0.8.3"


### PR DESCRIPTION
:broom:

---

* build(arrow_util): datafusion is not a release dep (4435d7259)

      Moves datafusion to dev-dependencies.