### PR TITLE
refactor: remove unused errors

### DIFF
--- a/ingester/src/data.rs
+++ b/ingester/src/data.rs
@@ -82,26 +82,6 @@ pub enum Error {
     #[snafu(display("Shard {} not found in data map", shard_id))]
     ShardNotFound { shard_id: ShardId },
 
-    #[snafu(display("Namespace {} not found in catalog", namespace))]
-    NamespaceNotFound { namespace: String },
-
-    #[snafu(display("Table {} not found in buffer", table_name))]
-    TableNotFound { table_name: String },
-
-    #[snafu(display("Error accessing catalog: {}", source))]
-    Catalog {
-        source: iox_catalog::interface::Error,
-    },
-
-    #[snafu(display("Snapshot error: {}", source))]
-    Snapshot { source: mutable_batch::Error },
-
-    #[snafu(display("Error while filtering columns from snapshot: {}", source))]
-    FilterColumn { source: arrow::error::ArrowError },
-
-    #[snafu(display("Error while copying buffer to snapshot: {}", source))]
-    BufferToSnapshot { source: mutable_batch::Error },
-
     #[snafu(display("Error adding to buffer in mutable batch: {}", source))]
     BufferWrite { source: mutable_batch::Error },
 }

--- a/ingester/src/stream_handler/handler.rs
+++ b/ingester/src/stream_handler/handler.rs
@@ -1001,7 +1001,7 @@ mod tests {
             Ok(DmlOperation::Write(make_write(2222, 2)))
         ]],
         sink_rets = [
-            Err(crate::data::Error::NamespaceNotFound{namespace: "bananas".to_string() }),
+            Err(crate::data::Error::ShardNotFound{shard_id: ShardId::new(42)}),
             Ok(DmlApplyAction::Applied(true)),
         ],
         want_ttbr = 2,

--- a/ingester/src/stream_handler/sink_instrumentation.rs
+++ b/ingester/src/stream_handler/sink_instrumentation.rs
@@ -239,7 +239,7 @@ mod tests {
     use std::sync::Arc;
 
     use assert_matches::assert_matches;
-    use data_types::{NamespaceId, Sequence, SequenceNumber, TableId};
+    use data_types::{NamespaceId, Sequence, SequenceNumber, ShardId, TableId};
     use dml::{DmlMeta, DmlWrite};
     use iox_time::Time;
     use metric::{Metric, MetricObserver, Observation};
@@ -417,13 +417,13 @@ mod tests {
         let got = test(
             op,
             &metrics,
-            Err(crate::data::Error::NamespaceNotFound {
-                namespace: "bananas".to_string(),
+            Err(crate::data::Error::ShardNotFound {
+                shard_id: ShardId::new(42),
             }),
             Some(12345),
         )
         .await;
-        assert_matches!(got, Err(crate::data::Error::NamespaceNotFound { .. }));
+        assert_matches!(got, Err(crate::data::Error::ShardNotFound { .. }));
 
         // Validate the various write buffer metrics
         assert_matches!(


### PR DESCRIPTION
:broom:

---

* refactor: remove unused errors (5afe58d4d)

      These error states are no longer possible after several refactors, but
      do not cause a "not used" lint because of macro magic.