### PR TITLE
refactor: decouple DmlSink error type

### DIFF
--- a/ingester/src/dml_sink/trait.rs
+++ b/ingester/src/dml_sink/trait.rs
@@ -1,17 +1,27 @@
-use std::{fmt::Debug, ops::Deref, sync::Arc};
+use std::{error::Error, fmt::Debug, ops::Deref, sync::Arc};
 
 use async_trait::async_trait;
 use dml::DmlOperation;
+use thiserror::Error;
 
 use crate::data::DmlApplyAction;
+
+#[derive(Debug, Error)]
+pub(crate) enum DmlError {
+    /// An error applying a [`DmlOperation`].
+    #[error(transparent)]
+    Data(#[from] crate::data::Error),
+}
 
 /// A [`DmlSink`] handles [`DmlOperation`] instances read from a shard.
 #[async_trait]
 pub(crate) trait DmlSink: Debug + Send + Sync {
+    type Error: Error + Into<DmlError> + Send;
+
     /// Apply `op` read from a shard, returning `Ok(DmlApplyAction::Applied(bool))`, the bool indicating if the
     /// ingest should be paused. Returns `Ok(DmlApplyAction::Skipped)` if the operation has been
     /// applied previously and was skipped.
-    async fn apply(&self, op: DmlOperation) -> Result<DmlApplyAction, crate::data::Error>;
+    async fn apply(&self, op: DmlOperation) -> Result<DmlApplyAction, Self::Error>;
 }
 
 #[async_trait]
@@ -19,7 +29,8 @@ impl<T> DmlSink for Arc<T>
 where
     T: DmlSink,
 {
-    async fn apply(&self, op: DmlOperation) -> Result<DmlApplyAction, crate::data::Error> {
+    type Error = T::Error;
+    async fn apply(&self, op: DmlOperation) -> Result<DmlApplyAction, Self::Error> {
         self.deref().apply(op).await
     }
 }

--- a/ingester/src/stream_handler/handler.rs
+++ b/ingester/src/stream_handler/handler.rs
@@ -510,7 +510,7 @@ fn metric_attrs(
 mod tests {
     use super::*;
     use crate::{
-        dml_sink::mock_sink::MockDmlSink,
+        dml_sink::{mock_sink::MockDmlSink, DmlError},
         lifecycle::{LifecycleConfig, LifecycleManager},
     };
     use assert_matches::assert_matches;
@@ -996,7 +996,7 @@ mod tests {
             Ok(DmlOperation::Write(make_write(2222, 2)))
         ]],
         sink_rets = [
-            Err(crate::data::Error::ShardNotFound{shard_id: ShardId::new(42)}),
+            Err(DmlError::Data(crate::data::Error::ShardNotFound{shard_id: ShardId::new(42)})),
             Ok(DmlApplyAction::Applied(true)),
         ],
         want_ttbr = 2,

--- a/ingester/src/stream_handler/sink_adaptor.rs
+++ b/ingester/src/stream_handler/sink_adaptor.rs
@@ -38,7 +38,9 @@ impl IngestSinkAdaptor {
 
 #[async_trait]
 impl DmlSink for IngestSinkAdaptor {
-    async fn apply(&self, op: DmlOperation) -> Result<DmlApplyAction, crate::data::Error> {
+    type Error = crate::data::Error;
+
+    async fn apply(&self, op: DmlOperation) -> Result<DmlApplyAction, Self::Error> {
         self.ingest_data
             .buffer_operation(self.shard_id, op, &self.lifecycle_handle)
             .await


### PR DESCRIPTION
Allow the `DmlSink` implementation to specify what error type it returns, requiring that error type to be convertable into a `DmlError`.

This allows concise impl-specific error types, but still allow the API handlers that interact with one or more `DmlSink` to convert the impl error into a type they can enumerate and map to a suitable response. 

---

* refactor: decouple DmlSink error type (1938c18c5)

      Allows different DmlSink implementations to return different error
      types. This allows for small, concise errors that are local to the
      DmlSink implementation and specific to it. This helps avoid bloated
      "kitchen sink" error types.