### PR TITLE
perf(ingester2): streaming queries

### DIFF
--- a/ingester2/src/query/instrumentation.rs
+++ b/ingester2/src/query/instrumentation.rs
@@ -121,7 +121,7 @@ mod tests {
     test_metric!(
         ok,
         inner = {
-            let stream: PartitionStream = Box::pin(Box::new(futures::stream::iter([])));
+            let stream: PartitionStream = PartitionStream::new(futures::stream::iter([]));
             MockQueryExec::default().with_result(Ok(QueryResponse::new(stream)))
         },
         want_metric_attr = [("result", "success")],

--- a/ingester2/src/query/partition_response.rs
+++ b/ingester2/src/query/partition_response.rs
@@ -2,23 +2,13 @@
 //!
 //! [`QueryResponse`]: super::response::QueryResponse
 
-use std::pin::Pin;
-
-use arrow::error::ArrowError;
 use data_types::{PartitionId, SequenceNumber};
 use datafusion::physical_plan::SendableRecordBatchStream;
-use futures::Stream;
-
-/// Stream of [`RecordBatch`].
-///
-/// [`RecordBatch`]: arrow::record_batch::RecordBatch
-pub(crate) type RecordBatchStream =
-    Pin<Box<dyn Stream<Item = Result<SendableRecordBatchStream, ArrowError>> + Send>>;
 
 /// Response data for a single partition.
 pub(crate) struct PartitionResponse {
     /// Stream of snapshots.
-    batches: RecordBatchStream,
+    batches: SendableRecordBatchStream,
 
     /// Partition ID.
     id: PartitionId,
@@ -39,7 +29,7 @@ impl std::fmt::Debug for PartitionResponse {
 
 impl PartitionResponse {
     pub(crate) fn new(
-        batches: RecordBatchStream,
+        batches: SendableRecordBatchStream,
         id: PartitionId,
         max_persisted_sequence_number: Option<SequenceNumber>,
     ) -> Self {
@@ -58,7 +48,7 @@ impl PartitionResponse {
         self.max_persisted_sequence_number
     }
 
-    pub(crate) fn into_record_batch_stream(self) -> RecordBatchStream {
+    pub(crate) fn into_record_batch_stream(self) -> SendableRecordBatchStream {
         self.batches
     }
 }

--- a/ingester2/src/query/response.rs
+++ b/ingester2/src/query/response.rs
@@ -2,18 +2,15 @@
 //!
 //! [`QueryExec::query_exec()`]: super::QueryExec::query_exec()
 
-use std::{pin::Pin, sync::Arc};
+use std::pin::Pin;
 
 use arrow::{error::ArrowError, record_batch::RecordBatch};
-use arrow_util::optimize::{optimize_record_batch, optimize_schema};
-use futures::{Stream, StreamExt, TryStreamExt};
+use futures::{Stream, StreamExt};
 
 use super::partition_response::PartitionResponse;
 
 /// Stream of partitions in this response.
-pub(crate) struct PartitionStream(
-    Pin<Box<dyn Stream<Item = Result<PartitionResponse, ArrowError>> + Send>>,
-);
+pub(crate) struct PartitionStream(Pin<Box<dyn Stream<Item = PartitionResponse> + Send>>);
 
 impl std::fmt::Debug for PartitionStream {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -24,7 +21,7 @@ impl std::fmt::Debug for PartitionStream {
 impl PartitionStream {
     pub(crate) fn new<T>(s: T) -> Self
     where
-        T: Stream<Item = Result<PartitionResponse, ArrowError>> + Send + 'static,
+        T: Stream<Item = PartitionResponse> + Send + 'static,
     {
         Self(s.boxed())
     }
@@ -47,27 +44,13 @@ impl QueryResponse {
     }
 
     /// Return the stream of [`PartitionResponse`].
-    pub(crate) fn into_partition_stream(
-        self,
-    ) -> Pin<Box<dyn Stream<Item = Result<PartitionResponse, ArrowError>> + Send>> {
+    pub(crate) fn into_partition_stream(self) -> impl Stream<Item = PartitionResponse> {
         self.partitions.0
     }
 
-    /// Reduce the [`QueryResponse`] to a set of [`RecordBatch`].
-    pub(crate) async fn into_record_batches(self) -> Result<Vec<RecordBatch>, ArrowError> {
+    /// Reduce the [`QueryResponse`] to a stream of [`RecordBatch`].
+    pub(crate) fn into_record_batches(self) -> impl Stream<Item = Result<RecordBatch, ArrowError>> {
         self.into_partition_stream()
-            .map_ok(|partition| {
-                partition
-                    .into_record_batch_stream()
-                    .map_ok(|snapshot| {
-                        let schema = Arc::new(optimize_schema(&snapshot.schema()));
-                        snapshot
-                            .map(move |batch| optimize_record_batch(&batch?, Arc::clone(&schema)))
-                    })
-                    .try_flatten()
-            })
-            .try_flatten()
-            .try_collect()
-            .await
+            .flat_map(|partition| partition.into_record_batch_stream())
     }
 }

--- a/ingester2/src/query/tracing.rs
+++ b/ingester2/src/query/tracing.rs
@@ -94,7 +94,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_ok() {
-        let stream: PartitionStream = Box::pin(Box::new(futures::stream::iter([])));
+        let stream: PartitionStream = PartitionStream::new(futures::stream::iter([]));
         let mock = MockQueryExec::default().with_result(Ok(QueryResponse::new(stream)));
 
         let traces: Arc<dyn TraceCollector> = Arc::new(RingBufferTraceCollector::new(5));

--- a/ingester2/src/query/tracing.rs
+++ b/ingester2/src/query/tracing.rs
@@ -68,7 +68,10 @@ mod tests {
     use assert_matches::assert_matches;
     use trace::{ctx::SpanContext, span::SpanStatus, RingBufferTraceCollector, TraceCollector};
 
-    use crate::query::{mock_query_exec::MockQueryExec, response::PartitionStream};
+    use crate::query::{
+        mock_query_exec::MockQueryExec,
+        response::{PartitionStream, QueryResponse},
+    };
 
     use super::*;
 


### PR DESCRIPTION
This PR changes the query reponse code path in `ingester2`, diverging it from how queries are streamed in the current ingester code.

This started out as an attempt to make the code/types more readable, and then once I understood what was happening optimising it for a fully streaming response was easy :tada:

**NOTE:** This PR changes the way queries _will_ be run - currently the query path is not connected up in `ingester2` (soon!)

---

* refactor(ingester2): explicit PartitionStream type (2ed9780f6)

      Simplify the streaming types by introducing explicitly named wrappers to
      improve visibility.

* perf(ingester2): streaming query data sourcing (1a379f5f1)

      Changes the query code (taken from the ingester crate) to stream data
      for query execution, tidy up unnecessary Result types and removing
      unnecessary indirection/boxing.
      
      Previously the query data sourcing would collect the set of RecordBatch
      for a query response during execution, prior to sending the data to the
      caller. Any data that was dropped or modified during this time meant the
      underlying ref-counted data could not be released from memory until all
      outstanding queries referencing it completed. When faced with multiple
      concurrent queries and ongoing ingest, this meant multiple copies of
      data could be held in memory at any one time.
      
      After this commit, data is streamed to the user, minimising the duration
      of time a reference to specific partition data is held, and therefore
      eliminating the memory overhead of holding onto all the data necessary
      for a query for as long as the client takes to read the data.
      
      When combined with an upcoming PR to stream RecordBatch out of the
      BufferTree, this should provide performant query execution with minimal
      memory overhead, even for a maliciously slow reading client.