### PR TITLE
feat(ingester2): commit DML ops to WAL

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2497,12 +2497,14 @@ dependencies = [
  "rand",
  "schema",
  "service_grpc_catalog",
+ "tempfile",
  "test_helpers",
  "thiserror",
  "tokio",
  "tonic",
  "trace",
  "uuid",
+ "wal",
  "workspace-hack",
 ]
 

--- a/ingester2/Cargo.toml
+++ b/ingester2/Cargo.toml
@@ -42,6 +42,7 @@ tokio = { version = "1.22", features = ["macros", "parking_lot", "rt-multi-threa
 tonic = "0.8.3"
 trace = { version = "0.1.0", path = "../trace" }
 uuid = "1.2.2"
+wal = { version = "0.1.0", path = "../wal" }
 workspace-hack = { path = "../workspace-hack"}
 
 [dev-dependencies]
@@ -50,4 +51,5 @@ datafusion_util = { path = "../datafusion_util" }
 lazy_static = "1.4.0"
 mutable_batch_lp = { path = "../mutable_batch_lp" }
 paste = "1.0.9"
+tempfile = "3.3.0"
 test_helpers = { path = "../test_helpers", features = ["future_timeout"] }

--- a/ingester2/src/dml_sink/trait.rs
+++ b/ingester2/src/dml_sink/trait.rs
@@ -11,6 +11,10 @@ pub(crate) enum DmlError {
     /// [`BufferTree`]: crate::buffer_tree::BufferTree
     #[error("failed to buffer op: {0}")]
     Buffer(#[from] mutable_batch::Error),
+
+    /// An error appending the [`DmlOperation`] to the write-ahead log.
+    #[error("wal commit failure: {0}")]
+    Wal(#[from] wal::Error),
 }
 
 /// A [`DmlSink`] handles [`DmlOperation`] instances in some abstract way.

--- a/ingester2/src/lib.rs
+++ b/ingester2/src/lib.rs
@@ -50,6 +50,7 @@ mod query_adaptor;
 mod sequence_range;
 pub(crate) mod server;
 mod timestamp_oracle;
+mod wal;
 
 #[cfg(test)]
 mod test_util;

--- a/ingester2/src/server/grpc/rpc_write.rs
+++ b/ingester2/src/server/grpc/rpc_write.rs
@@ -54,6 +54,7 @@ impl From<DmlError> for tonic::Status {
     fn from(e: DmlError) -> Self {
         match e {
             DmlError::Buffer(e) => map_write_error(e),
+            DmlError::Wal(_) => Self::internal(e.to_string()),
         }
     }
 }

--- a/ingester2/src/wal/mod.rs
+++ b/ingester2/src/wal/mod.rs
@@ -1,0 +1,8 @@
+//! A [`DmlSink`] decorator to make request [`DmlOperation`] durable in a
+//! write-ahead log.
+//!
+//! [`DmlSink`]: crate::dml_sink::DmlSink
+//! [`DmlOperation`]: dml::DmlOperation
+
+mod traits;
+pub(crate) mod wal_sink;

--- a/ingester2/src/wal/traits.rs
+++ b/ingester2/src/wal/traits.rs
@@ -1,0 +1,12 @@
+use std::fmt::Debug;
+
+use async_trait::async_trait;
+use dml::DmlOperation;
+
+/// An abstraction over a write-ahead log, decoupling the write path from the
+/// underlying implementation.
+#[async_trait]
+pub(super) trait WalAppender: Send + Sync + Debug {
+    /// Add `op` to the write-head log, returning once `op` is durable.
+    async fn append(&self, op: &DmlOperation) -> Result<(), wal::Error>;
+}

--- a/ingester2/src/wal/wal_sink.rs
+++ b/ingester2/src/wal/wal_sink.rs
@@ -39,6 +39,8 @@ where
     async fn apply(&self, op: DmlOperation) -> Result<(), Self::Error> {
         // TODO: cancellation safety
         //
+        // See https://github.com/influxdata/influxdb_iox/issues/6281.
+        //
         // Once an item is in the WAL, it should be passed into the inner
         // DmlSink so that is becomes readable - failing to do this means writes
         // will randomly appear after replaying the WAL.

--- a/ingester2/src/wal/wal_sink.rs
+++ b/ingester2/src/wal/wal_sink.rs
@@ -1,0 +1,169 @@
+use async_trait::async_trait;
+use dml::DmlOperation;
+use generated_types::influxdata::iox::wal::v1::sequenced_wal_op::Op;
+use mutable_batch_pb::encode::encode_write;
+use wal::SequencedWalOp;
+
+use crate::dml_sink::{DmlError, DmlSink};
+
+use super::traits::WalAppender;
+
+/// A [`DmlSink`] decorator that ensures any [`DmlOperation`] is committed to
+/// the write-ahead log before passing the operation to the inner [`DmlSink`].
+#[derive(Debug)]
+pub(crate) struct WalSink<T, W = wal::WalWriter> {
+    /// The inner chain of [`DmlSink`] that a [`DmlOperation`] is passed to once
+    /// committed to the write-ahead log.
+    inner: T,
+
+    /// The write-ahead log implementation.
+    wal: W,
+}
+
+impl<T, W> WalSink<T, W> {
+    /// Initialise a new [`WalSink`] that appends [`DmlOperation`] to `W` and
+    /// on success, passes the op through to `T`.
+    pub(crate) fn new(inner: T, wal: W) -> Self {
+        Self { inner, wal }
+    }
+}
+
+#[async_trait]
+impl<T, W> DmlSink for WalSink<T, W>
+where
+    T: DmlSink,
+    W: WalAppender + 'static,
+{
+    type Error = DmlError;
+
+    async fn apply(&self, op: DmlOperation) -> Result<(), Self::Error> {
+        // TODO: cancellation safety
+        //
+        // Once an item is in the WAL, it should be passed into the inner
+        // DmlSink so that is becomes readable - failing to do this means writes
+        // will randomly appear after replaying the WAL.
+        //
+        // This can happen If the caller stops polling just after the WAL commit
+        // future completes and before the inner DmlSink call returns Ready.
+
+        // Append the operation to the WAL
+        self.wal.append(&op).await?;
+
+        // And once durable, pass it to the inner handler.
+        self.inner.apply(op).await.map_err(Into::into)
+    }
+}
+
+#[async_trait]
+impl WalAppender for wal::WalWriter {
+    async fn append(&self, op: &DmlOperation) -> Result<(), wal::Error> {
+        let sequence_number = op
+            .meta()
+            .sequence()
+            .expect("committing unsequenced dml operation to wal")
+            .sequence_number
+            .get() as u64;
+
+        let namespace_id = op.namespace_id();
+
+        let wal_op = match op {
+            DmlOperation::Write(w) => Op::Write(encode_write(namespace_id.get(), w)),
+            DmlOperation::Delete(_) => unreachable!(),
+        };
+
+        self.write_op(SequencedWalOp {
+            sequence_number,
+            op: wal_op,
+        })
+        .await?;
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use assert_matches::assert_matches;
+    use data_types::{NamespaceId, PartitionKey, TableId};
+    use wal::Wal;
+
+    use crate::{dml_sink::mock_sink::MockDmlSink, test_util::make_write_op};
+
+    use super::*;
+
+    const TABLE_ID: TableId = TableId::new(44);
+    const TABLE_NAME: &str = "bananas";
+    const NAMESPACE_NAME: &str = "platanos";
+    const NAMESPACE_ID: NamespaceId = NamespaceId::new(42);
+
+    #[tokio::test]
+    async fn test_append() {
+        let dir = tempfile::tempdir().unwrap();
+
+        // Generate the test op that will be appended and read back
+        let op = make_write_op(
+            &PartitionKey::from("p1"),
+            NAMESPACE_ID,
+            TABLE_NAME,
+            TABLE_ID,
+            42,
+            r#"bananas,region=Madrid temp=35 4242424242"#,
+        );
+
+        // The write portion of this test.
+        {
+            let inner = Arc::new(MockDmlSink::default().with_apply_return(vec![Ok(())]));
+            let wal = Wal::new(dir.path())
+                .await
+                .expect("failed to initialise WAL");
+            let wal_handle = wal.write_handle().await;
+
+            let wal_sink = WalSink::new(Arc::clone(&inner), wal_handle);
+
+            // Apply the op through the decorator
+            wal_sink
+                .apply(DmlOperation::Write(op.clone()))
+                .await
+                .expect("wal should not error");
+
+            // Assert the mock inner sink saw the call
+            assert_eq!(inner.get_calls().len(), 1);
+        }
+
+        // Read the op back
+        let wal = Wal::new(dir.path())
+            .await
+            .expect("failed to initialise WAL");
+        let read_handle = wal.read_handle();
+
+        // Identify the segment file
+        let files = read_handle.closed_segments().await;
+        let file = assert_matches!(&*files, [f] => f, "expected 1 file");
+
+        // Open a reader
+        let mut reader = read_handle
+            .reader_for_segment(file.id())
+            .await
+            .expect("failed to obtain reader");
+
+        // Obtain all the ops in the file
+        let mut ops = Vec::new();
+        while let Ok(Some(op)) = reader.next_op().await {
+            ops.push(op);
+        }
+
+        // Extract the op payload read from the WAL
+        let read_op = assert_matches!(&*ops, [op] => op, "expected 1 DML operation");
+        assert_eq!(read_op.sequence_number, 42);
+        let payload =
+            assert_matches!(&read_op.op, Op::Write(w) => w, "expected DML write WAL entry");
+
+        // The payload should match the serialised form of the "op" originally
+        // wrote above.
+        let want = encode_write(NAMESPACE_ID.get(), &op);
+
+        assert_eq!(want, *payload);
+    }
+}

--- a/wal/src/lib.rs
+++ b/wal/src/lib.rs
@@ -549,7 +549,7 @@ impl ClosedSegmentFileReader {
     }
 
     /// Return the next [`SequencedWalOp`] from this reader, if any.
-    pub async fn next_ops(&mut self) -> Result<Option<SequencedWalOp>> {
+    pub async fn next_op(&mut self) -> Result<Option<SequencedWalOp>> {
         Self::one_command(&self.tx, ClosedSegmentFileReaderRequest::NextOps)
             .await?
             .context(UnableToReadNextOpsSnafu)
@@ -622,19 +622,19 @@ mod tests {
         let mut reader = ClosedSegmentFileReader::from_path(&closed.path)
             .await
             .unwrap();
-        let read_op1 = reader.next_ops().await.unwrap().unwrap();
+        let read_op1 = reader.next_op().await.unwrap().unwrap();
         assert_eq!(op1, read_op1);
 
-        let read_op2 = reader.next_ops().await.unwrap().unwrap();
+        let read_op2 = reader.next_op().await.unwrap().unwrap();
         assert_eq!(op2, read_op2);
 
-        let read_op3 = reader.next_ops().await.unwrap().unwrap();
+        let read_op3 = reader.next_op().await.unwrap().unwrap();
         assert_eq!(op3, read_op3);
 
-        let read_op4 = reader.next_ops().await.unwrap().unwrap();
+        let read_op4 = reader.next_op().await.unwrap().unwrap();
         assert_eq!(op4, read_op4);
 
-        assert!(reader.next_ops().await.unwrap().is_none());
+        assert!(reader.next_op().await.unwrap().is_none());
     }
 
     // open wal with files that aren't segments (should log and skip)
@@ -671,7 +671,7 @@ mod tests {
             .reader_for_segment(closed_segment_details.id())
             .await
             .unwrap();
-        assert!(reader.next_ops().await.unwrap().is_none());
+        assert!(reader.next_op().await.unwrap().is_none());
 
         // Can delete an empty segment, leaving no closed segments again
         wal_rotator

--- a/wal/tests/end_to_end.rs
+++ b/wal/tests/end_to_end.rs
@@ -59,9 +59,9 @@ async fn crud() {
         .reader_for_segment(closed_segment_details.id())
         .await
         .unwrap();
-    let op = reader.next_ops().await.unwrap().unwrap();
+    let op = reader.next_op().await.unwrap().unwrap();
     assert_eq!(op.sequence_number, 42);
-    let op = reader.next_ops().await.unwrap().unwrap();
+    let op = reader.next_op().await.unwrap().unwrap();
     assert_eq!(op.sequence_number, 43);
 
     // Can delete a segment, leaving no closed segments again
@@ -104,8 +104,8 @@ async fn replay() {
         .reader_for_segment(closed_segment_ids[0])
         .await
         .unwrap();
-    let op = reader.next_ops().await.unwrap().unwrap();
-    assert_eq!(op.sequence_number.get(), 42);
+    let op = reader.next_op().await.unwrap().unwrap();
+    assert_eq!(op.sequence_number, 42);
 }
 
 fn arbitrary_sequenced_wal_op(sequence_number: u64) -> SequencedWalOp {

--- a/wal/tests/end_to_end.rs
+++ b/wal/tests/end_to_end.rs
@@ -5,7 +5,7 @@ use generated_types::influxdata::{
     pbdata::v1::{DatabaseBatch, TableBatch},
 };
 use mutable_batch_lp::lines_to_batches;
-use wal::{SequenceNumberNg, SequencedWalOp};
+use wal::SequencedWalOp;
 
 #[tokio::test]
 async fn crud() {
@@ -60,9 +60,9 @@ async fn crud() {
         .await
         .unwrap();
     let op = reader.next_ops().await.unwrap().unwrap();
-    assert_eq!(op.sequence_number.get(), 42);
+    assert_eq!(op.sequence_number, 42);
     let op = reader.next_ops().await.unwrap().unwrap();
-    assert_eq!(op.sequence_number.get(), 43);
+    assert_eq!(op.sequence_number, 43);
 
     // Can delete a segment, leaving no closed segments again
     wal_rotator
@@ -111,7 +111,7 @@ async fn replay() {
 fn arbitrary_sequenced_wal_op(sequence_number: u64) -> SequencedWalOp {
     let w = test_data("m1,t=foo v=1i 1");
     SequencedWalOp {
-        sequence_number: SequenceNumberNg::new(sequence_number),
+        sequence_number,
         op: WalOp::Write(w),
     }
 }


### PR DESCRIPTION
This commit adds the functionality to write incoming DML operations to a write-ahead log.

There is currently no functionality to rotate or replay this log (coming next).

---

* refactor(Wal): remove SequenceNumberNg (30e2dd7fb)

      This actually starts getting more confusing than passing the bare u64
      around.

* refactor(wal): rename next_ops -> next_op (628e0a713)

      It only returns one op, so remove the plural.

* feat(ingester2): commit writes to write-ahead log (4f4687569)

      Adds WalSink, an implementation of the DmlSink trait that commits DML
      operations to the write-ahead log before passing the DML op into the
      decorated inner DmlSink chain.
      
      By structuring the WAL logic as a decorator, the chain of inner DmlSink
      handlers within it are only ever invoked after the WAL commit has
      successfully completed, which keeps all the WAL commit code in a
      singly-responsible component. This also lets us layer on the WAL commit
      logic to the DML sink chain after replaying any existing WAL files,
      avoiding a circular WAL mess.
      
      The application-logic level WAL code abstracts over the underlying WAL
      implementation & codec through the WalAppender trait. This decouples the
      business logic from the WAL implementation both for testing purposes,
      and for trying different WAL implementations in the future.

* docs: reference WAL cancellation safety ticket (2fb04e80b)

      Reference https://github.com/influxdata/influxdb_iox/issues/6281

