### PR TITLE
refactor(ingester2): cache more hot partitions

### DIFF
--- a/ingester2/src/init.rs
+++ b/ingester2/src/init.rs
@@ -125,7 +125,7 @@ pub async fn new(
         .repositories()
         .await
         .partitions()
-        .most_recent_n(10_000, &[TRANSITION_SHARD_ID])
+        .most_recent_n(40_000, &[TRANSITION_SHARD_ID])
         .await
         .map_err(InitError::PreWarmPartitions)?;
 


### PR DESCRIPTION
A simple PR!

When the ingester starts up, it pre-loads the most recently created N partitions from the catalog - optimistically we assume that recently created partitions are "hot" for writes, whereas old partitions (from days ago) are not.

Without this cache, every request that hits a just-started-up ingester will cause the ingester to query the catalog to find out the partition information, and then place it into the `BufferTree`. Subsequent requests use the information in the `BufferTree`, avoiding the query.

By using this cache, we remove the latency (and correlated load) of a catalog query for every new partition that is a cache hit.

Recent PRs have reduced the amount of data we need to maintain in the cache (namely removing the persist marker sequence number, and the shard ID), so we can substantially increase the number of items in the cache:

https://github.com/influxdata/influxdb_iox/blob/1be9ffb40916444d2ed93ce61343b845521bf8ea/ingester2/src/buffer_tree/partition/resolver/cache.rs#L27-L37

Additionally each cache hit _removes_ the entry from the cache (as the partition is now in the `BufferTree`), so the memory overhead of this cache amortises to 0 - it's free[^1] performance!

[^1]: almost

---

* refactor(ingester2): cache more hot partitions (1be9ffb40)

      Now partition cache entries are smaller, the number of entries held in
      memory can be increased - this now uses ~2MiB of memory and drains the
      cache during execution, amortising to 0.