### PR TITLE
feat(ingester2): periodic WAL rotation

### DIFF
--- a/ingester2/src/init/wal_replay.rs
+++ b/ingester2/src/init/wal_replay.rs
@@ -241,7 +241,6 @@ mod tests {
 
             // Rotate the log file
             wal.rotation_handle()
-                .await
                 .rotate()
                 .await
                 .expect("failed to rotate WAL file");

--- a/ingester2/src/wal/mod.rs
+++ b/ingester2/src/wal/mod.rs
@@ -4,5 +4,6 @@
 //! [`DmlSink`]: crate::dml_sink::DmlSink
 //! [`DmlOperation`]: dml::DmlOperation
 
+pub(crate) mod rotate_task;
 mod traits;
 pub(crate) mod wal_sink;

--- a/ingester2/src/wal/rotate_task.rs
+++ b/ingester2/src/wal/rotate_task.rs
@@ -1,0 +1,20 @@
+use observability_deps::tracing::*;
+use std::time::Duration;
+
+/// Rotate the `wal` segment file every `period` duration of time.
+pub(crate) async fn periodic_rotation(wal: wal::Wal, period: Duration) {
+    let handle = wal.rotation_handle();
+    let mut interval = tokio::time::interval(period);
+
+    loop {
+        interval.tick().await;
+        debug!("rotating wal file");
+
+        let stats = handle.rotate().await.expect("failed to rotate WAL");
+        info!(
+            closed_id = %stats.id(),
+            segment_bytes = stats.size(),
+            "rotated wal"
+        );
+    }
+}

--- a/wal/src/lib.rs
+++ b/wal/src/lib.rs
@@ -263,7 +263,7 @@ impl Wal {
 
     /// Returns a handle to the WAL that enables rotating the open segment and deleting closed
     /// segments.
-    pub async fn rotation_handle(&self) -> WalRotator<'_> {
+    pub fn rotation_handle(&self) -> WalRotator<'_> {
         WalRotator(self)
     }
 }
@@ -685,7 +685,7 @@ mod tests {
         );
 
         // No writes, but rotating is totally fine
-        let wal_rotator = wal.rotation_handle().await;
+        let wal_rotator = wal.rotation_handle();
         let closed_segment_details = wal_rotator.rotate().await.unwrap();
         assert_eq!(closed_segment_details.size(), 16);
 

--- a/wal/tests/end_to_end.rs
+++ b/wal/tests/end_to_end.rs
@@ -45,7 +45,7 @@ async fn crud() {
     );
 
     // Can't read entries from the open segment; have to rotate first
-    let wal_rotator = wal.rotation_handle().await;
+    let wal_rotator = wal.rotation_handle();
     let closed_segment_details = wal_rotator.rotate().await.unwrap();
     assert_eq!(closed_segment_details.size(), 228);
 
@@ -88,7 +88,7 @@ async fn replay() {
         let open = wal.write_handle().await;
         let op = arbitrary_sequenced_wal_op(42);
         open.write_op(op).await.unwrap();
-        let wal_rotator = wal.rotation_handle().await;
+        let wal_rotator = wal.rotation_handle();
         wal_rotator.rotate().await.unwrap();
         let op = arbitrary_sequenced_wal_op(43);
         open.write_op(op).await.unwrap();
@@ -129,7 +129,7 @@ async fn ordering() {
     {
         let wal = wal::Wal::new(dir.path()).await.unwrap();
         let open = wal.write_handle().await;
-        let wal_rotator = wal.rotation_handle().await;
+        let wal_rotator = wal.rotation_handle();
 
         let op = arbitrary_sequenced_wal_op(42);
         open.write_op(op).await.unwrap();
@@ -146,7 +146,7 @@ async fn ordering() {
     // Create a new WAL instance with the same directory to replay from the files
     let wal = wal::Wal::new(dir.path()).await.unwrap();
     let wal_reader = wal.read_handle();
-    let wal_rotator = wal.rotation_handle().await;
+    let wal_rotator = wal.rotation_handle();
 
     // There are 3 segments (from the 2 closed and 1 open) and they're in the order they were
     // created


### PR DESCRIPTION
Adds a background task to `ingester2` that periodically rotates the WAL file (configurable when initialising the ingester2 instance, I intend via CLI/env arg :+1:)

This background task is stopped when the `ingester2` guard instance is dropped, ensuring we don't leak resources.

---

* refactor(wal): remove needless async/await (f40885d4c)

      Obtaining a rotation handle isn't async.

* feat(ingester2): rotate wal periodically (c7f88d779)

      Spawn a background task to rotate the WAL file with the given internal.

* refactor(ingester2): clean-up rotation task (81619fd5b)

      When an ingester2 instance goes out of scope, automatically stop the WAL
      rotation task.