### PR TITLE
perf(ingester2): partition persist queue

### DIFF
--- a/ingester2/src/buffer_tree/partition/persisting.rs
+++ b/ingester2/src/buffer_tree/partition/persisting.rs
@@ -1,0 +1,84 @@
+use std::fmt::Display;
+
+use crate::query_adaptor::QueryAdaptor;
+
+/// An opaque generational identifier of a buffer in a [`PartitionData`].
+///
+/// [`PartitionData`]: super::PartitionData
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub(super) struct BatchIdent(u64);
+
+impl BatchIdent {
+    /// Return the next unique value.
+    pub(super) fn next(&mut self) -> Self {
+        self.0 += 1;
+        Self(self.0)
+    }
+
+    /// Only for tests, this allows reading the opaque identifier to assert the
+    /// value changing between persist ops.
+    #[cfg(test)]
+    pub(super) fn get(&self) -> u64 {
+        self.0
+    }
+}
+
+impl Display for BatchIdent {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+/// A type wrapper over [`QueryAdaptor`] that statically ensures only batches of
+/// data from [`PartitionData::mark_persisting()`] are given to
+/// [`PartitionData::mark_persisted()`].
+///
+/// Cloning this type is relatively cheap.
+///
+/// [`PartitionData::mark_persisting()`]: super::PartitionData::mark_persisting
+/// [`PartitionData::mark_persisted()`]: super::PartitionData::mark_persisted
+#[derive(Debug, Clone)]
+pub(crate) struct PersistingData {
+    data: QueryAdaptor,
+    batch_ident: BatchIdent,
+}
+
+impl PersistingData {
+    pub(super) fn new(data: QueryAdaptor, batch_ident: BatchIdent) -> Self {
+        Self { data, batch_ident }
+    }
+
+    pub(super) fn batch_ident(&self) -> BatchIdent {
+        self.batch_ident
+    }
+
+    pub(crate) fn query_adaptor(&self) -> QueryAdaptor {
+        self.data.clone()
+    }
+}
+
+impl std::ops::Deref for PersistingData {
+    type Target = QueryAdaptor;
+
+    fn deref(&self) -> &Self::Target {
+        &self.data
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_batch_ident() {
+        let mut b = BatchIdent::default();
+
+        assert_eq!(b.get(), 0);
+
+        assert_eq!(b.next().get(), 1);
+        assert_eq!(b.get(), 1);
+
+        assert_eq!(b.next().get(), 2);
+        assert_eq!(b.get(), 2);
+    }
+}


### PR DESCRIPTION
This PR changes the `PartitionData` to support an (unbounded) number of buffers in the "persisting" state - this lets us queue up partition work without having to wait for existing persist tasks to complete; see commit message.

I think this fixes https://github.com/influxdata/influxdb_iox/issues/4928 if I understand the ticket correctly.

I think @aierui might be interested in this too! :)

---

* perf(ingester2): partition persist queue (4f928fbd0)

      This commit swaps the existing single "persisting batch" slot (field) in
      a PartitionData for an ordered queue of outstanding partitions.
      
      This decouples marking a partition buffer for persistence from the
      actual persistence operation, allowing them to proceed at different
      rates. This reduces the complexity of persistence management, but also
      allows us to gracefully handle "hot" partitions; for example, this
      problematic scenario in the ingester(1) implementation during recovery:
      
          * Writes come into a partition, reaching a size/row/hotness limit
          * Partition is enqueued for persistence
          * More writes come into the new buffer, exceeding the same limit
          * Cannot persist the hot buffer because of outstanding persist op
      
      Without this change the only possibilities in this situation are:
      
          * stop ingest for the partition and error all writes that
            (partially!) write to the partition, or
          * continue accepting writes, allowing the partition to exceed the
            limit that marked it for persistence in the first place
      
      The latter is what the ingester(1) implementation does today, which
      results in partitions exceeding their row/size/age limits, which exist
      to limit the cost of generating the Parquet file from the buffer - this
      is a significant contributor to instability during recovery.
      
      This strategy enforces configured the limits on the partition buffer,
      but does not block / slow down recovery while persistence is completed.