### PR TITLE
chore: remove old comment

### DIFF
--- a/ingester2/src/init.rs
+++ b/ingester2/src/init.rs
@@ -232,8 +232,6 @@ pub async fn new(
     );
     let persist_task = tokio::spawn(persist_actor.run());
 
-    // TODO: persist replayed ops, if any
-
     // Build the chain of DmlSink that forms the write path.
     let write_path = WalSink::new(Arc::clone(&buffer), wal.write_handle().await);
 


### PR DESCRIPTION
It's done! 👌 

---

* chore: remove old comment (de52a2475)

      The ingester will replay the ops, and then immediately trigger a
      persist! This comment is done :)
      
      Outstanding is actually deleting the replayed files, which will come
      with the ref-counted WAL segment change later.