### PR TITLE
fix: do not panic when writer disconnects

### DIFF
--- a/wal/src/lib.rs
+++ b/wal/src/lib.rs
@@ -458,7 +458,8 @@ impl OpenSegmentFile {
             match req {
                 Write(tx, data) => {
                     let x = open_write.write(&data).unwrap();
-                    tx.send(x).unwrap();
+                    // Ignore send errors - the caller may have disconnected.
+                    let _ = tx.send(x);
                 }
 
                 Rotate(tx, ()) => {


### PR DESCRIPTION
When sending an RPC write and disconnecting before it completes, the WAL would panic because there is nothing listening for the commit ACK.

---

* fix: do not panic when writer disconnects (7cb1636c6)

      When the RPC write disconnects without waiting for completion, the WAL
      panics as there is no longer a consumer of the "committed" ACK.