### PR TITLE
feat(ingester2): log persist active & queue timings

### DIFF
--- a/ingester2/src/persist/handle.rs
+++ b/ingester2/src/persist/handle.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use iox_catalog::interface::Catalog;
 use iox_query::exec::Executor;
-use observability_deps::tracing::info;
+use observability_deps::tracing::{debug, info};
 use parking_lot::Mutex;
 use parquet_file::storage::ParquetStorage;
 use thiserror::Error;
@@ -169,6 +169,11 @@ impl PersistHandle {
         partition: Arc<Mutex<PartitionData>>,
         data: PersistingData,
     ) -> Arc<Notify> {
+        debug!(
+            partition_id = data.partition_id().get(),
+            "enqueuing persistence task"
+        );
+
         // Build the persist task request
         let r = PersistRequest::new(partition, data);
         let notify = r.complete_notification();


### PR DESCRIPTION
This adds a bit more logging to persist, and captures the time a persist job spent in the queue, and how long it actually took to persist once dequeued - this information is displayed in the existing "persisted partition" INFO log:

```
INFO persisted partition <snip> total_persist_duration=51.535291ms active_persist_duration=12.523375ms queued_persist_duration=39.011916ms
```

---

* feat(ingester2): persist active & queue timings (5fa4e4909)

      Adds more debug logging to the persist code paths, as well as capturing
      & logging (at INFO) timing information tracking the time a persist task
      spends in the queue, the active time spent actually persisting the data,
      and the total duration of time since the request was created (sum of
      both durations).