### PR TITLE
chore: editor config spacing for shell scripts

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,5 +9,5 @@ indent_style = space
 [{Dockerfile*,*.proto}]
 indent_size = 2
 
-[{*.rs,*.toml}]
+[{*.rs,*.toml,*.sh,*.bash}]
 indent_size = 4


### PR DESCRIPTION
Makes the indenting sane for shell scripts. Should the default not be 4 anyway?

---

* chore: editor config spacing for shell scripts (65d45fbe9)

      Set .bash and .sh script indent size to 4.