### PR TITLE
fix: Remove the rpc_write feature flag and use INFLUXDB_IOX_MODE env var instead

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -259,7 +259,7 @@ jobs:
       - cache_restore
       - run:
           name: Cargo test RPC write path
-          command: cargo test --workspace --features rpc_write
+          command: cargo test --workspace
       - cache_save
 
   test:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1570,18 +1570,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "escargot"
-version = "0.5.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5584ba17d7ab26a8a7284f13e5bd196294dd2f2d79773cff29b9e9edef601a6"
-dependencies = [
- "log",
- "once_cell",
- "serde",
- "serde_json",
-]
-
-[[package]]
 name = "event-listener"
 version = "2.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5429,7 +5417,6 @@ dependencies = [
  "assert_cmd",
  "bytes",
  "data_types",
- "escargot",
  "futures",
  "generated_types",
  "http",

--- a/clap_blocks/Cargo.toml
+++ b/clap_blocks/Cargo.toml
@@ -33,7 +33,3 @@ test_helpers = { path = "../test_helpers" }
 azure = ["object_store/azure"] # Optional Azure Object store support
 gcp = ["object_store/gcp"] # Optional GCP object store support
 aws = ["object_store/aws"] # Optional AWS / S3 object store support
-
-# Temporary feature to use the RPC write path instead of the write buffer during the transition
-# away from using Kafka.
-rpc_write = []

--- a/clap_blocks/src/lib.rs
+++ b/clap_blocks/src/lib.rs
@@ -19,7 +19,7 @@ pub mod ingester2;
 pub mod object_store;
 pub mod querier;
 pub mod router;
-pub mod router_rpc_write;
+pub mod router2;
 pub mod run_config;
 pub mod socket_addr;
 pub mod write_buffer;

--- a/clap_blocks/src/querier.rs
+++ b/clap_blocks/src/querier.rs
@@ -278,9 +278,9 @@ impl QuerierConfig {
     // When we have switched to using the RPC write path only, this method can be changed to be
     // infallible as clap will handle failure to parse the list of strings.
     //
-    // Switching into the RPC write path mode requires *both* the `INFLUXDB_IOX_MODE` environment
+    // Switching into the RPC write path mode requires *both* the `INFLUXDB_IOX_RPC_MODE` environment
     // variable to be specified *and* `--ingester-addresses` to be set in order to switch. If the
-    // `INFLUXDB_IOX_MODE` is enabled and `--shard-to-ingesters*` is set, use the write buffer path
+    // `INFLUXDB_IOX_RPC_MODE` is enabled and `--shard-to-ingesters*` is set, use the write buffer path
     // instead.
     pub fn ingester_addresses(&self) -> Result<IngesterAddresses, Error> {
         if let Some(file) = &self.shard_to_ingesters_file {

--- a/clap_blocks/src/querier.rs
+++ b/clap_blocks/src/querier.rs
@@ -212,7 +212,6 @@ pub struct QuerierConfig {
     ///
     /// for multiple addresses.
     #[clap(long = "ingester-addresses", env = "INFLUXDB_IOX_INGESTER_ADDRESSES")]
-    #[cfg(feature = "rpc_write")]
     pub ingester_addresses: Vec<String>,
 
     /// Size of the RAM cache used to store catalog metadata information in bytes.
@@ -275,42 +274,14 @@ impl QuerierConfig {
     /// Return the querier config's ingester addresses. If `--shard-to-ingesters-file` is used to
     /// specify a JSON file containing shard to ingester address mappings, this returns `Err` if
     /// there are any problems reading, deserializing, or interpreting the file.
-    #[cfg(not(feature = "rpc_write"))]
-    pub fn ingester_addresses(&self) -> Result<IngesterAddresses, Error> {
-        if let Some(file) = &self.shard_to_ingesters_file {
-            let contents =
-                fs::read_to_string(file).context(ShardToIngesterFileReadingSnafu { file })?;
-            let map = deserialize_shard_ingester_map(&contents)?;
-            if map.is_empty() {
-                Ok(IngesterAddresses::None)
-            } else {
-                Ok(IngesterAddresses::ByShardIndex(map))
-            }
-        } else if let Some(contents) = &self.shard_to_ingesters {
-            let map = deserialize_shard_ingester_map(contents)?;
-            if map.is_empty() {
-                Ok(IngesterAddresses::None)
-            } else {
-                Ok(IngesterAddresses::ByShardIndex(map))
-            }
-        } else {
-            Ok(IngesterAddresses::None)
-        }
-    }
 
-    /// Return the querier config's ingester addresses. If `--shard-to-ingesters-file` is used to
-    /// specify a JSON file containing shard to ingester address mappings, this returns `Err` if
-    /// there are any problems reading, deserializing, or interpreting the file.
-
-    // When we have switched to using the RPC write path and remove the rpc_write feature, this
-    // method can be changed to be infallible as clap will handle failure to parse the list of
-    // strings.
+    // When we have switched to using the RPC write path only, this method can be changed to be
+    // infallible as clap will handle failure to parse the list of strings.
     //
-    // For now, to enable turning on the `rpc_write` feature in tests but not necessarily switching
-    // into the RPC write path mode, require *both* the feature flag to be enabled *and*
-    // `--ingester-addresses` to be set in order to switch. If the `rpc_write` feature is enabled
-    // and `--shard-to-ingesters*` are set, use the write buffer path instead.
-    #[cfg(feature = "rpc_write")]
+    // Switching into the RPC write path mode requires *both* the `INFLUXDB_IOX_MODE` environment
+    // variable to be specified *and* `--ingester-addresses` to be set in order to switch. If the
+    // `INFLUXDB_IOX_MODE` is enabled and `--shard-to-ingesters*` is set, use the write buffer path
+    // instead.
     pub fn ingester_addresses(&self) -> Result<IngesterAddresses, Error> {
         if let Some(file) = &self.shard_to_ingesters_file {
             let contents =
@@ -353,18 +324,6 @@ impl QuerierConfig {
     /// Number of queries allowed to run concurrently
     pub fn max_concurrent_queries(&self) -> usize {
         self.max_concurrent_queries
-    }
-
-    /// Whether the querier is contacting ingesters that use the RPC write path or not.
-    #[cfg(feature = "rpc_write")]
-    pub fn rpc_write(&self) -> bool {
-        true
-    }
-
-    /// Whether the querier is contacting ingesters that use the RPC write path or not.
-    #[cfg(not(feature = "rpc_write"))]
-    pub fn rpc_write(&self) -> bool {
-        false
     }
 }
 

--- a/clap_blocks/src/querier.rs
+++ b/clap_blocks/src/querier.rs
@@ -278,10 +278,10 @@ impl QuerierConfig {
     // When we have switched to using the RPC write path only, this method can be changed to be
     // infallible as clap will handle failure to parse the list of strings.
     //
-    // Switching into the RPC write path mode requires *both* the `INFLUXDB_IOX_RPC_MODE` environment
-    // variable to be specified *and* `--ingester-addresses` to be set in order to switch. If the
-    // `INFLUXDB_IOX_RPC_MODE` is enabled and `--shard-to-ingesters*` is set, use the write buffer path
-    // instead.
+    // Switching into the RPC write path mode requires *both* the `INFLUXDB_IOX_RPC_MODE`
+    // environment variable to be specified *and* `--ingester-addresses` to be set in order to
+    // switch. Setting `INFLUXDB_IOX_RPC_MODE` and shard-to-ingesters mapping, or not setting
+    // `INFLUXDB_IOX_RPC_MODE` and setting ingester addresses, will panic.
     pub fn ingester_addresses(&self) -> Result<IngesterAddresses, Error> {
         if let Some(file) = &self.shard_to_ingesters_file {
             let contents =

--- a/clap_blocks/src/router2.rs
+++ b/clap_blocks/src/router2.rs
@@ -3,7 +3,7 @@
 /// CLI config for the router using the RPC write path
 #[derive(Debug, Clone, clap::Parser)]
 #[allow(missing_copy_implementations)]
-pub struct RouterRpcWriteConfig {
+pub struct Router2Config {
     /// The maximum number of simultaneous requests the HTTP server is
     /// configured to accept.
     ///

--- a/influxdb_iox/Cargo.toml
+++ b/influxdb_iox/Cargo.toml
@@ -106,7 +106,3 @@ jemalloc_replacing_malloc = ["tikv-jemalloc-sys", "tikv-jemalloc-ctl"]
 # Implicit feature selected when running under `clippy --all-features` to accept mutable exclusive features during
 # linting
 clippy = []
-
-# Temporary feature to use the RPC write path instead of the write buffer during the transition
-# away from using Kafka.
-rpc_write = ["ioxd_router/rpc_write", "clap_blocks/rpc_write", "test_helpers_end_to_end/rpc_write"]

--- a/influxdb_iox/src/commands/run/all_in_one.rs
+++ b/influxdb_iox/src/commands/run/all_in_one.rs
@@ -465,8 +465,7 @@ impl Config {
             num_query_threads: None,       // will be ignored
             shard_to_ingesters_file: None, // will be ignored
             shard_to_ingesters: None,      // will be ignored
-            #[cfg(feature = "rpc_write")]
-            ingester_addresses: vec![], // will be ignored
+            ingester_addresses: vec![],    // will be ignored
             ram_pool_metadata_bytes: querier_ram_pool_metadata_bytes,
             ram_pool_data_bytes: querier_ram_pool_data_bytes,
             max_concurrent_queries: querier_max_concurrent_queries,
@@ -620,6 +619,7 @@ pub async fn command(config: Config) -> Result<()> {
         time_provider,
         ingester_addresses,
         querier_config,
+        rpc_write: false,
     })
     .await?;
 

--- a/influxdb_iox/src/commands/run/ingester.rs
+++ b/influxdb_iox/src/commands/run/ingester.rs
@@ -87,10 +87,10 @@ pub struct Config {
 }
 
 pub async fn command(config: Config) -> Result<()> {
-    if std::env::var("INFLUXDB_IOX_MODE").is_ok() {
+    if std::env::var("INFLUXDB_IOX_RPC_MODE").is_ok() {
         panic!(
-            "`INFLUXDB_IOX_MODE` was specified but `ingester` was the command run. Either unset
-             `INFLUXDB_IOX_MODE` or run the `ingester2` command."
+            "`INFLUXDB_IOX_RPC_MODE` was specified but `ingester` was the command run. Either unset
+             `INFLUXDB_IOX_RPC_MODE` or run the `ingester2` command."
         );
     }
 

--- a/influxdb_iox/src/commands/run/ingester.rs
+++ b/influxdb_iox/src/commands/run/ingester.rs
@@ -87,6 +87,13 @@ pub struct Config {
 }
 
 pub async fn command(config: Config) -> Result<()> {
+    if std::env::var("INFLUXDB_IOX_MODE").is_ok() {
+        panic!(
+            "`INFLUXDB_IOX_MODE` was specified but `ingester` was the command run. Either unset
+             `INFLUXDB_IOX_MODE` or run the `ingester2` command."
+        );
+    }
+
     let common_state = CommonServerState::from_config(config.run_config.clone())?;
 
     let time_provider = Arc::new(SystemProvider::new()) as Arc<dyn TimeProvider>;

--- a/influxdb_iox/src/commands/run/ingester2.rs
+++ b/influxdb_iox/src/commands/run/ingester2.rs
@@ -82,6 +82,13 @@ pub struct Config {
 }
 
 pub async fn command(config: Config) -> Result<()> {
+    if std::env::var("INFLUXDB_IOX_MODE").is_err() {
+        panic!(
+            "`INFLUXDB_IOX_MODE` was not specified but `ingester2` was the command run. Either set
+             `INFLUXDB_IOX_MODE` or run the `ingester` command."
+        );
+    }
+
     let common_state = CommonServerState::from_config(config.run_config.clone())?;
     let metric_registry = setup_metric_registry();
 

--- a/influxdb_iox/src/commands/run/ingester2.rs
+++ b/influxdb_iox/src/commands/run/ingester2.rs
@@ -82,10 +82,10 @@ pub struct Config {
 }
 
 pub async fn command(config: Config) -> Result<()> {
-    if std::env::var("INFLUXDB_IOX_MODE").is_err() {
+    if std::env::var("INFLUXDB_IOX_RPC_MODE").is_err() {
         panic!(
-            "`INFLUXDB_IOX_MODE` was not specified but `ingester2` was the command run. Either set
-             `INFLUXDB_IOX_MODE` or run the `ingester` command."
+            "`INFLUXDB_IOX_RPC_MODE` was not specified but `ingester2` was the command run. Either set
+             `INFLUXDB_IOX_RPC_MODE` or run the `ingester` command."
         );
     }
 

--- a/influxdb_iox/src/commands/run/mod.rs
+++ b/influxdb_iox/src/commands/run/mod.rs
@@ -5,12 +5,10 @@ pub(crate) mod all_in_one;
 mod compactor;
 mod garbage_collector;
 mod ingester;
-#[cfg(feature = "rpc_write")]
 mod ingester2;
 mod main;
 mod querier;
 mod router;
-#[cfg(feature = "rpc_write")]
 mod router_rpc_write;
 mod test;
 
@@ -29,14 +27,12 @@ pub enum Error {
     #[snafu(display("Error in router subcommand: {}", source))]
     RouterError { source: router::Error },
 
-    #[cfg(feature = "rpc_write")]
     #[snafu(display("Error in router-rpc-write subcommand: {}", source))]
     RouterRpcWriteError { source: router_rpc_write::Error },
 
     #[snafu(display("Error in ingester subcommand: {}", source))]
     IngesterError { source: ingester::Error },
 
-    #[cfg(feature = "rpc_write")]
     #[snafu(display("Error in ingester2 subcommand: {}", source))]
     Ingester2Error { source: ingester2::Error },
 
@@ -67,10 +63,8 @@ impl Config {
             Some(Command::GarbageCollector(config)) => config.run_config.logging_config(),
             Some(Command::Querier(config)) => config.run_config.logging_config(),
             Some(Command::Router(config)) => config.run_config.logging_config(),
-            #[cfg(feature = "rpc_write")]
             Some(Command::RouterRpcWrite(config)) => config.run_config.logging_config(),
             Some(Command::Ingester(config)) => config.run_config.logging_config(),
-            #[cfg(feature = "rpc_write")]
             Some(Command::Ingester2(config)) => config.run_config.logging_config(),
             Some(Command::AllInOne(config)) => &config.logging_config,
             Some(Command::Test(config)) => config.run_config.logging_config(),
@@ -90,14 +84,12 @@ enum Command {
     Router(router::Config),
 
     /// Run the server in router mode using the RPC write path.
-    #[cfg(feature = "rpc_write")]
     RouterRpcWrite(router_rpc_write::Config),
 
     /// Run the server in ingester mode
     Ingester(ingester::Config),
 
     /// Run the server in ingester2 mode
-    #[cfg(feature = "rpc_write")]
     Ingester2(ingester2::Config),
 
     /// Run the server in "all in one" mode (Default)
@@ -123,12 +115,10 @@ pub async fn command(config: Config) -> Result<()> {
             .context(GarbageCollectorSnafu),
         Some(Command::Querier(config)) => querier::command(config).await.context(QuerierSnafu),
         Some(Command::Router(config)) => router::command(config).await.context(RouterSnafu),
-        #[cfg(feature = "rpc_write")]
         Some(Command::RouterRpcWrite(config)) => router_rpc_write::command(config)
             .await
             .context(RouterRpcWriteSnafu),
         Some(Command::Ingester(config)) => ingester::command(config).await.context(IngesterSnafu),
-        #[cfg(feature = "rpc_write")]
         Some(Command::Ingester2(config)) => {
             ingester2::command(config).await.context(Ingester2Snafu)
         }

--- a/influxdb_iox/src/commands/run/mod.rs
+++ b/influxdb_iox/src/commands/run/mod.rs
@@ -9,7 +9,7 @@ mod ingester2;
 mod main;
 mod querier;
 mod router;
-mod router_rpc_write;
+mod router2;
 mod test;
 
 #[derive(Debug, Snafu)]
@@ -27,8 +27,8 @@ pub enum Error {
     #[snafu(display("Error in router subcommand: {}", source))]
     RouterError { source: router::Error },
 
-    #[snafu(display("Error in router-rpc-write subcommand: {}", source))]
-    RouterRpcWriteError { source: router_rpc_write::Error },
+    #[snafu(display("Error in router2 subcommand: {}", source))]
+    Router2Error { source: router2::Error },
 
     #[snafu(display("Error in ingester subcommand: {}", source))]
     IngesterError { source: ingester::Error },
@@ -63,7 +63,7 @@ impl Config {
             Some(Command::GarbageCollector(config)) => config.run_config.logging_config(),
             Some(Command::Querier(config)) => config.run_config.logging_config(),
             Some(Command::Router(config)) => config.run_config.logging_config(),
-            Some(Command::RouterRpcWrite(config)) => config.run_config.logging_config(),
+            Some(Command::Router2(config)) => config.run_config.logging_config(),
             Some(Command::Ingester(config)) => config.run_config.logging_config(),
             Some(Command::Ingester2(config)) => config.run_config.logging_config(),
             Some(Command::AllInOne(config)) => &config.logging_config,
@@ -83,8 +83,8 @@ enum Command {
     /// Run the server in router mode
     Router(router::Config),
 
-    /// Run the server in router mode using the RPC write path.
-    RouterRpcWrite(router_rpc_write::Config),
+    /// Run the server in router2 mode
+    Router2(router2::Config),
 
     /// Run the server in ingester mode
     Ingester(ingester::Config),
@@ -115,9 +115,7 @@ pub async fn command(config: Config) -> Result<()> {
             .context(GarbageCollectorSnafu),
         Some(Command::Querier(config)) => querier::command(config).await.context(QuerierSnafu),
         Some(Command::Router(config)) => router::command(config).await.context(RouterSnafu),
-        Some(Command::RouterRpcWrite(config)) => router_rpc_write::command(config)
-            .await
-            .context(RouterRpcWriteSnafu),
+        Some(Command::Router2(config)) => router2::command(config).await.context(Router2Snafu),
         Some(Command::Ingester(config)) => ingester::command(config).await.context(IngesterSnafu),
         Some(Command::Ingester2(config)) => {
             ingester2::command(config).await.context(Ingester2Snafu)

--- a/influxdb_iox/src/commands/run/querier.rs
+++ b/influxdb_iox/src/commands/run/querier.rs
@@ -96,7 +96,7 @@ pub async fn command(config: Config) -> Result<(), Error> {
     let num_threads = num_query_threads.unwrap_or_else(num_cpus::get);
     info!(%num_threads, "using specified number of threads per thread pool");
 
-    let rpc_write = std::env::var("INFLUXDB_IOX_MODE").is_ok();
+    let rpc_write = std::env::var("INFLUXDB_IOX_RPC_MODE").is_ok();
     if rpc_write {
         info!("using the RPC write path");
     } else {

--- a/influxdb_iox/src/commands/run/router.rs
+++ b/influxdb_iox/src/commands/run/router.rs
@@ -70,6 +70,13 @@ pub struct Config {
 }
 
 pub async fn command(config: Config) -> Result<()> {
+    if std::env::var("INFLUXDB_IOX_MODE").is_ok() {
+        panic!(
+            "`INFLUXDB_IOX_MODE` was specified but `router` was the command run. Either unset
+             `INFLUXDB_IOX_MODE` or run the `router2` command."
+        );
+    }
+
     let common_state = CommonServerState::from_config(config.run_config.clone())?;
     let time_provider = Arc::new(SystemProvider::new()) as Arc<dyn TimeProvider>;
     let metrics = setup_metric_registry();

--- a/influxdb_iox/src/commands/run/router.rs
+++ b/influxdb_iox/src/commands/run/router.rs
@@ -70,10 +70,10 @@ pub struct Config {
 }
 
 pub async fn command(config: Config) -> Result<()> {
-    if std::env::var("INFLUXDB_IOX_MODE").is_ok() {
+    if std::env::var("INFLUXDB_IOX_RPC_MODE").is_ok() {
         panic!(
-            "`INFLUXDB_IOX_MODE` was specified but `router` was the command run. Either unset
-             `INFLUXDB_IOX_MODE` or run the `router2` command."
+            "`INFLUXDB_IOX_RPC_MODE` was specified but `router` was the command run. Either unset
+             `INFLUXDB_IOX_RPC_MODE` or run the `router2` command."
         );
     }
 

--- a/influxdb_iox/src/commands/run/router2.rs
+++ b/influxdb_iox/src/commands/run/router2.rs
@@ -64,10 +64,10 @@ pub struct Config {
 }
 
 pub async fn command(config: Config) -> Result<()> {
-    if std::env::var("INFLUXDB_IOX_MODE").is_err() {
+    if std::env::var("INFLUXDB_IOX_RPC_MODE").is_err() {
         panic!(
-            "`INFLUXDB_IOX_MODE` was not specified but `router2` was the command run. Either set
-             `INFLUXDB_IOX_MODE` or run the `router` command."
+            "`INFLUXDB_IOX_RPC_MODE` was not specified but `router2` was the command run. Either set
+             `INFLUXDB_IOX_RPC_MODE` or run the `router` command."
         );
     }
 

--- a/influxdb_iox/src/commands/run/router2.rs
+++ b/influxdb_iox/src/commands/run/router2.rs
@@ -1,9 +1,9 @@
-//! Command line options for running a router using the RPC write path.
+//! Command line options for running a router2 that uses the RPC write path.
 use super::main;
 use crate::process_info::setup_metric_registry;
 use clap_blocks::{
-    catalog_dsn::CatalogDsnConfig, object_store::make_object_store,
-    router_rpc_write::RouterRpcWriteConfig, run_config::RunConfig,
+    catalog_dsn::CatalogDsnConfig, object_store::make_object_store, router2::Router2Config,
+    run_config::RunConfig,
 };
 use iox_time::{SystemProvider, TimeProvider};
 use ioxd_common::{
@@ -60,10 +60,17 @@ pub struct Config {
     pub(crate) catalog_dsn: CatalogDsnConfig,
 
     #[clap(flatten)]
-    pub(crate) router_config: RouterRpcWriteConfig,
+    pub(crate) router_config: Router2Config,
 }
 
 pub async fn command(config: Config) -> Result<()> {
+    if std::env::var("INFLUXDB_IOX_MODE").is_err() {
+        panic!(
+            "`INFLUXDB_IOX_MODE` was not specified but `router2` was the command run. Either set
+             `INFLUXDB_IOX_MODE` or run the `router` command."
+        );
+    }
+
     let common_state = CommonServerState::from_config(config.run_config.clone())?;
     let time_provider = Arc::new(SystemProvider::new()) as Arc<dyn TimeProvider>;
     let metrics = setup_metric_registry();

--- a/influxdb_iox/src/commands/run/router_rpc_write.rs
+++ b/influxdb_iox/src/commands/run/router_rpc_write.rs
@@ -10,7 +10,7 @@ use ioxd_common::{
     server_type::{CommonServerState, CommonServerStateError},
     Service,
 };
-use ioxd_router::create_router_grpc_write_server_type;
+use ioxd_router::create_router2_server_type;
 use object_store::DynObjectStore;
 use object_store_metrics::ObjectStoreMetrics;
 use observability_deps::tracing::*;
@@ -70,7 +70,7 @@ pub async fn command(config: Config) -> Result<()> {
 
     let catalog = config
         .catalog_dsn
-        .get_catalog("router_rpc_write", Arc::clone(&metrics))
+        .get_catalog("router2", Arc::clone(&metrics))
         .await?;
 
     let object_store = make_object_store(config.run_config.object_store_config())
@@ -82,7 +82,7 @@ pub async fn command(config: Config) -> Result<()> {
         &metrics,
     ));
 
-    let server_type = create_router_grpc_write_server_type(
+    let server_type = create_router2_server_type(
         &common_state,
         Arc::clone(&metrics),
         catalog,
@@ -91,7 +91,7 @@ pub async fn command(config: Config) -> Result<()> {
     )
     .await?;
 
-    info!("starting router_rpc_write");
+    info!("starting router2");
     let services = vec![Service::create(server_type, common_state.run_config())];
     Ok(main::main(common_state, services, metrics).await?)
 }

--- a/influxdb_iox/tests/end_to_end_cases/ingester.rs
+++ b/influxdb_iox/tests/end_to_end_cases/ingester.rs
@@ -89,7 +89,6 @@ async fn ingester_flight_api() {
     });
 }
 
-#[cfg(feature = "rpc_write")]
 #[tokio::test]
 async fn ingester2_flight_api() {
     test_helpers::maybe_start_logging();
@@ -98,7 +97,7 @@ async fn ingester2_flight_api() {
     let table_name = "mytable";
 
     // Set up cluster
-    let mut cluster = MiniCluster::create_non_shared_rpc_write(database_url).await;
+    let mut cluster = MiniCluster::create_non_shared2(database_url).await;
 
     // Write some data into the v2 HTTP API ==============
     let lp = format!("{},tag1=A,tag2=B val=42i 123456", table_name);

--- a/influxdb_iox/tests/end_to_end_cases/mod.rs
+++ b/influxdb_iox/tests/end_to_end_cases/mod.rs
@@ -10,6 +10,7 @@ mod influxql;
 mod ingester;
 mod logging;
 mod metrics;
+mod mode_switching;
 mod namespace;
 mod querier;
 mod remote;

--- a/influxdb_iox/tests/end_to_end_cases/mode_switching.rs
+++ b/influxdb_iox/tests/end_to_end_cases/mode_switching.rs
@@ -9,7 +9,7 @@ fn router_errors_with_mode_env_var() {
     Command::cargo_bin("influxdb_iox")
         .unwrap()
         .env_clear()
-        .env("INFLUXDB_IOX_MODE", "2")
+        .env("INFLUXDB_IOX_RPC_MODE", "2")
         .arg("run")
         .arg("router")
         .arg("--write-buffer")
@@ -20,7 +20,7 @@ fn router_errors_with_mode_env_var() {
         .assert()
         .failure()
         .stderr(predicate::str::contains(
-            "`INFLUXDB_IOX_MODE` was specified but `router` was the command run",
+            "`INFLUXDB_IOX_RPC_MODE` was specified but `router` was the command run",
         ));
 }
 
@@ -37,7 +37,7 @@ fn router2_errors_without_mode_env_var() {
         .assert()
         .failure()
         .stderr(predicate::str::contains(
-            "`INFLUXDB_IOX_MODE` was not specified but `router2` was the command run",
+            "`INFLUXDB_IOX_RPC_MODE` was not specified but `router2` was the command run",
         ));
 }
 
@@ -46,7 +46,7 @@ fn ingester_errors_with_mode_env_var() {
     Command::cargo_bin("influxdb_iox")
         .unwrap()
         .env_clear()
-        .env("INFLUXDB_IOX_MODE", "2")
+        .env("INFLUXDB_IOX_RPC_MODE", "2")
         .arg("run")
         .arg("ingester")
         .arg("--write-buffer")
@@ -65,7 +65,7 @@ fn ingester_errors_with_mode_env_var() {
         .assert()
         .failure()
         .stderr(predicate::str::contains(
-            "`INFLUXDB_IOX_MODE` was specified but `ingester` was the command run",
+            "`INFLUXDB_IOX_RPC_MODE` was specified but `ingester` was the command run",
         ));
 }
 
@@ -84,7 +84,7 @@ fn ingester2_errors_without_mode_env_var() {
         .assert()
         .failure()
         .stderr(predicate::str::contains(
-            "`INFLUXDB_IOX_MODE` was not specified but `ingester2` was the command run",
+            "`INFLUXDB_IOX_RPC_MODE` was not specified but `ingester2` was the command run",
         ));
 }
 
@@ -106,7 +106,7 @@ fn querier_errors_with_mode_env_var_and_shard_to_ingester_mapping() {
     Command::cargo_bin("influxdb_iox")
         .unwrap()
         .env_clear()
-        .env("INFLUXDB_IOX_MODE", "2")
+        .env("INFLUXDB_IOX_RPC_MODE", "2")
         .arg("run")
         .arg("querier")
         .arg("--shard-to-ingesters")
@@ -117,7 +117,7 @@ fn querier_errors_with_mode_env_var_and_shard_to_ingester_mapping() {
         .assert()
         .failure()
         .stderr(predicate::str::contains(
-            "`INFLUXDB_IOX_MODE` is set but shard to ingester mappings were provided",
+            "`INFLUXDB_IOX_RPC_MODE` is set but shard to ingester mappings were provided",
         ));
 }
 
@@ -136,7 +136,7 @@ fn querier_errors_without_mode_env_var_and_ingester_addresses() {
         .assert()
         .failure()
         .stderr(predicate::str::contains(
-            "`INFLUXDB_IOX_MODE` is unset but ingester addresses were provided",
+            "`INFLUXDB_IOX_RPC_MODE` is unset but ingester addresses were provided",
         ));
 }
 
@@ -161,7 +161,7 @@ fn querier_without_ingesters_with_mode_env_var_uses_rpc_write() {
     Command::cargo_bin("influxdb_iox")
         .unwrap()
         .env_clear()
-        .env("INFLUXDB_IOX_MODE", "2")
+        .env("INFLUXDB_IOX_RPC_MODE", "2")
         .arg("run")
         .arg("querier")
         .arg("-v")

--- a/influxdb_iox/tests/end_to_end_cases/mode_switching.rs
+++ b/influxdb_iox/tests/end_to_end_cases/mode_switching.rs
@@ -1,0 +1,174 @@
+// This file can be deleted when everything has been switched over to the RPC write path.
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+use std::time::Duration;
+
+#[test]
+fn router_errors_with_mode_env_var() {
+    Command::cargo_bin("influxdb_iox")
+        .unwrap()
+        .env_clear()
+        .env("INFLUXDB_IOX_MODE", "2")
+        .arg("run")
+        .arg("router")
+        .arg("--write-buffer")
+        .arg("file")
+        .arg("--write-buffer-addr")
+        .arg("required")
+        .timeout(Duration::from_secs(2))
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "`INFLUXDB_IOX_MODE` was specified but `router` was the command run",
+        ));
+}
+
+#[test]
+fn router2_errors_without_mode_env_var() {
+    Command::cargo_bin("influxdb_iox")
+        .unwrap()
+        .env_clear()
+        .arg("run")
+        .arg("router2")
+        .arg("--ingester-addresses")
+        .arg("required")
+        .timeout(Duration::from_secs(2))
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "`INFLUXDB_IOX_MODE` was not specified but `router2` was the command run",
+        ));
+}
+
+#[test]
+fn ingester_errors_with_mode_env_var() {
+    Command::cargo_bin("influxdb_iox")
+        .unwrap()
+        .env_clear()
+        .env("INFLUXDB_IOX_MODE", "2")
+        .arg("run")
+        .arg("ingester")
+        .arg("--write-buffer")
+        .arg("required")
+        .arg("--write-buffer-addr")
+        .arg("required")
+        .arg("--shard-index-range-start")
+        .arg("0")
+        .arg("--shard-index-range-end")
+        .arg("1")
+        .arg("--pause-ingest-size-bytes")
+        .arg("300")
+        .arg("--persist-memory-threshold-bytes")
+        .arg("500")
+        .timeout(Duration::from_secs(2))
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "`INFLUXDB_IOX_MODE` was specified but `ingester` was the command run",
+        ));
+}
+
+#[test]
+fn ingester2_errors_without_mode_env_var() {
+    Command::cargo_bin("influxdb_iox")
+        .unwrap()
+        .env_clear()
+        .arg("run")
+        .arg("ingester2")
+        .arg("--wal-directory")
+        .arg("required")
+        .arg("--catalog")
+        .arg("memory")
+        .timeout(Duration::from_secs(2))
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "`INFLUXDB_IOX_MODE` was not specified but `ingester2` was the command run",
+        ));
+}
+
+#[test]
+fn querier_errors_with_mode_env_var_and_shard_to_ingester_mapping() {
+    let shard_to_ingesters_json = r#"{
+          "ingesters": {
+            "i1": {
+              "addr": "arbitrary"
+            }
+          },
+          "shards": {
+            "0": {
+              "ingester": "i1"
+            }
+        }
+    }"#;
+
+    Command::cargo_bin("influxdb_iox")
+        .unwrap()
+        .env_clear()
+        .env("INFLUXDB_IOX_MODE", "2")
+        .arg("run")
+        .arg("querier")
+        .arg("--shard-to-ingesters")
+        .arg(shard_to_ingesters_json)
+        .arg("--catalog")
+        .arg("memory")
+        .timeout(Duration::from_secs(2))
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "`INFLUXDB_IOX_MODE` is set but shard to ingester mappings were provided",
+        ));
+}
+
+#[test]
+fn querier_errors_without_mode_env_var_and_ingester_addresses() {
+    Command::cargo_bin("influxdb_iox")
+        .unwrap()
+        .env_clear()
+        .arg("run")
+        .arg("querier")
+        .arg("--ingester-addresses")
+        .arg("arbitrary")
+        .arg("--catalog")
+        .arg("memory")
+        .timeout(Duration::from_secs(2))
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "`INFLUXDB_IOX_MODE` is unset but ingester addresses were provided",
+        ));
+}
+
+#[test]
+fn querier_without_ingesters_without_mode_env_var_uses_write_buffer() {
+    Command::cargo_bin("influxdb_iox")
+        .unwrap()
+        .env_clear()
+        .arg("run")
+        .arg("querier")
+        .arg("-v")
+        .arg("--catalog")
+        .arg("memory")
+        .timeout(Duration::from_secs(2))
+        .assert()
+        .failure()
+        .stdout(predicate::str::contains("using the write buffer path"));
+}
+
+#[test]
+fn querier_without_ingesters_with_mode_env_var_uses_rpc_write() {
+    Command::cargo_bin("influxdb_iox")
+        .unwrap()
+        .env_clear()
+        .env("INFLUXDB_IOX_MODE", "2")
+        .arg("run")
+        .arg("querier")
+        .arg("-v")
+        .arg("--catalog")
+        .arg("memory")
+        .timeout(Duration::from_secs(2))
+        .assert()
+        .failure()
+        .stdout(predicate::str::contains("using the RPC write path"));
+}

--- a/ioxd_querier/src/lib.rs
+++ b/ioxd_querier/src/lib.rs
@@ -192,8 +192,8 @@ pub async fn create_querier_server_type(
         IngesterAddresses::ByShardIndex(map) => {
             if args.rpc_write {
                 panic!(
-                    "`INFLUXDB_IOX_MODE` is set but shard to ingester mappings were provided; \
-                    either unset `INFLUXDB_IOX_MODE` or specify `--ingester-addresses` instead"
+                    "`INFLUXDB_IOX_RPC_MODE` is set but shard to ingester mappings were provided; \
+                    either unset `INFLUXDB_IOX_RPC_MODE` or specify `--ingester-addresses` instead"
                 );
             }
             Some(create_ingester_connections(
@@ -206,8 +206,8 @@ pub async fn create_querier_server_type(
         IngesterAddresses::List(list) => {
             if !args.rpc_write {
                 panic!(
-                    "`INFLUXDB_IOX_MODE` is unset but ingester addresses were provided; \
-                    either set `INFLUXDB_IOX_MODE` or specify shard to ingester mappings instead"
+                    "`INFLUXDB_IOX_RPC_MODE` is unset but ingester addresses were provided; \
+                    either set `INFLUXDB_IOX_RPC_MODE` or specify shard to ingester mappings instead"
                 );
             }
             Some(create_ingester_connections(

--- a/ioxd_querier/src/lib.rs
+++ b/ioxd_querier/src/lib.rs
@@ -150,6 +150,7 @@ pub struct QuerierServerTypeArgs<'a> {
     pub time_provider: Arc<dyn TimeProvider>,
     pub ingester_addresses: IngesterAddresses,
     pub querier_config: QuerierConfig,
+    pub rpc_write: bool,
 }
 
 #[derive(Debug, Error)]
@@ -186,23 +187,36 @@ pub async fn create_querier_server_type(
         );
     assert!(existing.is_none());
 
-    let rpc_write = args.querier_config.rpc_write()
-        && matches!(args.ingester_addresses, IngesterAddresses::List(_));
-
     let ingester_connection = match args.ingester_addresses {
         IngesterAddresses::None => None,
-        IngesterAddresses::ByShardIndex(map) => Some(create_ingester_connections(
-            Some(map),
-            None,
-            Arc::clone(&catalog_cache),
-            args.querier_config.ingester_circuit_breaker_threshold,
-        )),
-        IngesterAddresses::List(list) => Some(create_ingester_connections(
-            None,
-            Some(list),
-            Arc::clone(&catalog_cache),
-            args.querier_config.ingester_circuit_breaker_threshold,
-        )),
+        IngesterAddresses::ByShardIndex(map) => {
+            if args.rpc_write {
+                panic!(
+                    "`INFLUXDB_IOX_MODE` is set but shard to ingester mappings were provided; \
+                    either unset `INFLUXDB_IOX_MODE` or specify `--ingester-addresses` instead"
+                );
+            }
+            Some(create_ingester_connections(
+                Some(map),
+                None,
+                Arc::clone(&catalog_cache),
+                args.querier_config.ingester_circuit_breaker_threshold,
+            ))
+        }
+        IngesterAddresses::List(list) => {
+            if !args.rpc_write {
+                panic!(
+                    "`INFLUXDB_IOX_MODE` is unset but ingester addresses were provided; \
+                    either set `INFLUXDB_IOX_MODE` or specify shard to ingester mappings instead"
+                );
+            }
+            Some(create_ingester_connections(
+                None,
+                Some(list),
+                Arc::clone(&catalog_cache),
+                args.querier_config.ingester_circuit_breaker_threshold,
+            ))
+        }
     };
 
     let database = Arc::new(
@@ -212,7 +226,7 @@ pub async fn create_querier_server_type(
             args.exec,
             ingester_connection,
             args.querier_config.max_concurrent_queries(),
-            rpc_write,
+            args.rpc_write,
         )
         .await?,
     );

--- a/ioxd_router/Cargo.toml
+++ b/ioxd_router/Cargo.toml
@@ -29,9 +29,3 @@ thiserror = "1.0.37"
 tokio = { version = "1.22", features = ["macros", "net", "parking_lot", "rt-multi-thread", "signal", "sync", "time"] }
 tokio-util = { version = "0.7.4" }
 workspace-hack = { path = "../workspace-hack"}
-
-[features]
-
-# Temporary feature to use the RPC write path instead of the write buffer during the transition
-# away from using Kafka.
-rpc_write = []

--- a/ioxd_router/src/lib.rs
+++ b/ioxd_router/src/lib.rs
@@ -248,7 +248,7 @@ impl HttpApiErrorSource for IoxHttpErrorAdaptor {
 // NOTE!!! This needs to be kept in sync with `create_router_server_type` until the
 // switch to the RPC write path/ingester2 is complete! See the numbered sections that annotate
 // where these two functions line up and where they diverge.
-pub async fn create_router_grpc_write_server_type(
+pub async fn create_router2_server_type(
     common_state: &CommonServerState,
     metrics: Arc<metric::Registry>,
     catalog: Arc<dyn Catalog>,
@@ -423,7 +423,7 @@ pub async fn create_router_grpc_write_server_type(
 }
 
 /// Instantiate a router server
-// NOTE!!! This needs to be kept in sync with `create_router_grpc_write_server_type` until the
+// NOTE!!! This needs to be kept in sync with `create_router2_server_type` until the
 // switch to the RPC write path/ingester2 is complete! See the numbered sections that annotate
 // where these two functions line up and where they diverge.
 pub async fn create_router_server_type(
@@ -435,7 +435,7 @@ pub async fn create_router_server_type(
     router_config: &RouterConfig,
 ) -> Result<Arc<dyn ServerType>> {
     // 1. START: Different Setup Per Router Path: this part is only relevant to using a write
-    //    buffer and should not be added to `create_router_grpc_write_server_type`.
+    //    buffer and should not be added to `create_router2_server_type`.
 
     // Initialise the sharded write buffer and instrument it with DML handler metrics.
     let (write_buffer, sharder) = init_write_buffer(

--- a/ioxd_router/src/lib.rs
+++ b/ioxd_router/src/lib.rs
@@ -1,7 +1,5 @@
 use async_trait::async_trait;
-use clap_blocks::{
-    router::RouterConfig, router_rpc_write::RouterRpcWriteConfig, write_buffer::WriteBufferConfig,
-};
+use clap_blocks::{router::RouterConfig, router2::Router2Config, write_buffer::WriteBufferConfig};
 use data_types::{NamespaceName, PartitionTemplate, TemplatePart};
 use hashbrown::HashMap;
 use hyper::{Body, Request, Response};
@@ -253,7 +251,7 @@ pub async fn create_router2_server_type(
     metrics: Arc<metric::Registry>,
     catalog: Arc<dyn Catalog>,
     object_store: Arc<DynObjectStore>,
-    router_config: &RouterRpcWriteConfig,
+    router_config: &Router2Config,
 ) -> Result<Arc<dyn ServerType>> {
     // 1. START: Different Setup Per Router Path: this part is only relevant to using RPC write
     //    path and should not be added to `create_router_server_type`.

--- a/test_helpers_end_to_end/Cargo.toml
+++ b/test_helpers_end_to_end/Cargo.toml
@@ -11,7 +11,6 @@ arrow_util = { path = "../arrow_util" }
 assert_cmd = "2.0.7"
 bytes = "1.3"
 data_types = { path = "../data_types" }
-escargot = "0.5"
 futures = "0.3"
 generated_types = { path = "../generated_types" }
 http = "0.2.8"
@@ -31,8 +30,3 @@ tokio = { version = "1.22", features = ["macros", "net", "parking_lot", "rt-mult
 tokio-util = "0.7"
 tonic = "0.8"
 workspace-hack = { path = "../workspace-hack"}
-
-[features]
-# Temporary feature to use the RPC write path instead of the write buffer during the transition
-# away from using Kafka.
-rpc_write = []

--- a/test_helpers_end_to_end/src/config.rs
+++ b/test_helpers_end_to_end/src/config.rs
@@ -65,16 +65,17 @@ impl TestConfig {
             .with_new_object_store()
     }
 
-    /// Create a minimal router configuration sharing configuration with the ingester config
-    pub fn new_router_rpc_write(ingester_config: &TestConfig) -> Self {
-        assert_eq!(ingester_config.server_type(), ServerType::IngesterRpcWrite);
+    /// Create a minimal router2 configuration sharing configuration with the ingester2 config
+    pub fn new_router2(ingester_config: &TestConfig) -> Self {
+        assert_eq!(ingester_config.server_type(), ServerType::Ingester2);
 
         Self::new(
-            ServerType::RouterRpcWrite,
+            ServerType::Router2,
             ingester_config.dsn().to_owned(),
             ingester_config.catalog_schema_name(),
         )
         .with_existing_object_store(ingester_config)
+        .with_env("INFLUXDB_IOX_MODE", "2")
         .with_env(
             "INFLUXDB_IOX_INGESTER_ADDRESSES",
             ingester_config
@@ -98,17 +99,13 @@ impl TestConfig {
         .with_default_ingester_options()
     }
 
-    /// Create a minimal ingester configuration, using the dsn configuration from other
-    pub fn new_ingester_rpc_write(dsn: impl Into<String>) -> Self {
+    /// Create a minimal ingester2 configuration, using the dsn configuration specified
+    pub fn new_ingester2(dsn: impl Into<String>) -> Self {
         let dsn = Some(dsn.into());
-        Self::new(
-            ServerType::IngesterRpcWrite,
-            dsn,
-            random_catalog_schema_name(),
-        )
-        .with_new_object_store()
-        .with_new_wal()
-        .with_default_ingester_options()
+        Self::new(ServerType::Ingester2, dsn, random_catalog_schema_name())
+            .with_new_object_store()
+            .with_new_wal()
+            .with_default_ingester_options()
     }
 
     /// Create a minimal querier configuration from the specified

--- a/test_helpers_end_to_end/src/config.rs
+++ b/test_helpers_end_to_end/src/config.rs
@@ -75,7 +75,7 @@ impl TestConfig {
             ingester_config.catalog_schema_name(),
         )
         .with_existing_object_store(ingester_config)
-        .with_env("INFLUXDB_IOX_MODE", "2")
+        .with_env("INFLUXDB_IOX_RPC_MODE", "2")
         .with_env(
             "INFLUXDB_IOX_INGESTER_ADDRESSES",
             ingester_config

--- a/test_helpers_end_to_end/src/mini_cluster.rs
+++ b/test_helpers_end_to_end/src/mini_cluster.rs
@@ -152,9 +152,9 @@ impl MiniCluster {
             .with_compactor_config(compactor_config)
     }
 
-    pub async fn create_non_shared_rpc_write(database_url: String) -> Self {
-        let ingester_config = TestConfig::new_ingester_rpc_write(&database_url);
-        let router_config = TestConfig::new_router_rpc_write(&ingester_config);
+    pub async fn create_non_shared2(database_url: String) -> Self {
+        let ingester_config = TestConfig::new_ingester2(&database_url);
+        let router_config = TestConfig::new_router2(&ingester_config);
 
         // Set up the cluster  ====================================
         Self::new()

--- a/test_helpers_end_to_end/src/server_type.rs
+++ b/test_helpers_end_to_end/src/server_type.rs
@@ -4,9 +4,9 @@ use super::addrs::BindAddresses;
 pub enum ServerType {
     AllInOne,
     Ingester,
-    IngesterRpcWrite,
+    Ingester2,
     Router,
-    RouterRpcWrite,
+    Router2,
     Querier,
     Compactor,
 }
@@ -17,9 +17,9 @@ impl ServerType {
         match self {
             Self::AllInOne => "all-in-one",
             Self::Ingester => "ingester",
-            Self::IngesterRpcWrite => "ingester2",
+            Self::Ingester2 => "ingester2",
             Self::Router => "router",
-            Self::RouterRpcWrite => "router-rpc-write",
+            Self::Router2 => "router2",
             Self::Querier => "querier",
             Self::Compactor => "compactor",
         }
@@ -77,7 +77,7 @@ fn addr_envs(server_type: ServerType, addrs: &BindAddresses) -> Vec<(&'static st
                 addrs.ingester_grpc_api().bind_addr().to_string(),
             ),
         ],
-        ServerType::IngesterRpcWrite => vec![
+        ServerType::Ingester2 => vec![
             (
                 "INFLUXDB_IOX_BIND_ADDR",
                 addrs.router_http_api().bind_addr().to_string(),
@@ -86,6 +86,7 @@ fn addr_envs(server_type: ServerType, addrs: &BindAddresses) -> Vec<(&'static st
                 "INFLUXDB_IOX_GRPC_BIND_ADDR",
                 addrs.ingester_grpc_api().bind_addr().to_string(),
             ),
+            ("INFLUXDB_IOX_MODE", "2".to_string()),
         ],
         ServerType::Router => vec![
             (
@@ -97,7 +98,7 @@ fn addr_envs(server_type: ServerType, addrs: &BindAddresses) -> Vec<(&'static st
                 addrs.router_grpc_api().bind_addr().to_string(),
             ),
         ],
-        ServerType::RouterRpcWrite => vec![
+        ServerType::Router2 => vec![
             (
                 "INFLUXDB_IOX_BIND_ADDR",
                 addrs.router_http_api().bind_addr().to_string(),
@@ -110,6 +111,7 @@ fn addr_envs(server_type: ServerType, addrs: &BindAddresses) -> Vec<(&'static st
                 "INFLUXDB_IOX_INGESTER_ADDRESSES",
                 addrs.ingester_grpc_api().bind_addr().to_string(),
             ),
+            ("INFLUXDB_IOX_MODE", "2".to_string()),
         ],
         ServerType::Querier => vec![
             (

--- a/test_helpers_end_to_end/src/server_type.rs
+++ b/test_helpers_end_to_end/src/server_type.rs
@@ -86,7 +86,7 @@ fn addr_envs(server_type: ServerType, addrs: &BindAddresses) -> Vec<(&'static st
                 "INFLUXDB_IOX_GRPC_BIND_ADDR",
                 addrs.ingester_grpc_api().bind_addr().to_string(),
             ),
-            ("INFLUXDB_IOX_MODE", "2".to_string()),
+            ("INFLUXDB_IOX_RPC_MODE", "2".to_string()),
         ],
         ServerType::Router => vec![
             (
@@ -111,7 +111,7 @@ fn addr_envs(server_type: ServerType, addrs: &BindAddresses) -> Vec<(&'static st
                 "INFLUXDB_IOX_INGESTER_ADDRESSES",
                 addrs.ingester_grpc_api().bind_addr().to_string(),
             ),
-            ("INFLUXDB_IOX_MODE", "2".to_string()),
+            ("INFLUXDB_IOX_RPC_MODE", "2".to_string()),
         ],
         ServerType::Querier => vec![
             (


### PR DESCRIPTION
And standardize on ingester2 and router2 for consistency.

**The `test_rpc_write` CI job is now exactly the same as the `test` job but I can't remove it because it's required; @domodwyer could you un-require it please?** ❤️

Closes #6402.

You will now see `router2` and `ingester2` in `influxdb_iox run --help`.

BUT it shouldn't be possible to *only* typo the command by adding `2`; you also need to set `INFLUXDB_IOX_RPC_MODE` (to any value, I've been setting it to `2`, but it's only set/unset that's checked).

Querier is still different as it shares more code; there is no `querier2`. But the `INFLUXDB_IOX_RPC_MODE` and setting `--ingester-addresses` instead of shard to ingester mappings is how you switch the querier into the RPC write path.

## Great, what do I copy-paste now?

So now you can run these commands to use the RPC write path all the way through:

```
# ingester2
INFLUXDB_IOX_RPC_MODE=2 ./target/debug/influxdb_iox run ingester2 --grpc-bind=127.0.0.1:8042

# router2
INFLUXDB_IOX_RPC_MODE=2 ./target/debug/influxdb_iox run router2 --api-bind=127.0.0.1:8081 --ingester-addresses=127.0.0.1:8042

# querier
INFLUXDB_IOX_RPC_MODE=2 ./target/debug/influxdb_iox run querier --ingester-addresses=http://127.0.0.1:8042 --grpc-bind 127.0.0.1:8043
```
