### PR TITLE
feat(ingester2): optimal persist parallelism

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -347,6 +347,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
 
 [[package]]
+name = "async-channel"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf46fee83e5ccffc220104713af3292ff9bc7c64c7de289f66dae8e38d826833"
+dependencies = [
+ "concurrent-queue",
+ "event-listener",
+ "futures-core",
+]
+
+[[package]]
 name = "async-compression"
 version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -921,6 +932,15 @@ dependencies = [
  "tonic",
  "uuid",
  "workspace-hack",
+]
+
+[[package]]
+name = "concurrent-queue"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd7bef69dc86e3c610e4e7aed41035e2a7ed12e72dd7530f61327a6579a4390b"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -2522,6 +2542,7 @@ dependencies = [
  "arrow-flight",
  "arrow_util",
  "assert_matches",
+ "async-channel",
  "async-trait",
  "backoff",
  "bytes",

--- a/clap_blocks/src/ingester2.rs
+++ b/clap_blocks/src/ingester2.rs
@@ -39,16 +39,15 @@ pub struct Ingester2Config {
     )]
     pub persist_max_parallelism: usize,
 
-    /// The maximum number of persist tasks that can be queued for each worker.
+    /// The maximum number of persist tasks that can be queued at any one time.
     ///
-    /// Note that each partition is consistently hashed to the same worker -
-    /// this can cause uneven distribution of persist tasks across workers in
-    /// workloads with skewed / hot partitions.
+    /// Once this limit is reached, ingest is blocked until the persist backlog
+    /// is reduced.
     #[clap(
-        long = "persist-worker-queue-depth",
-        env = "INFLUXDB_IOX_PERSIST_WORKER_QUEUE_DEPTH",
+        long = "persist-queue-depth",
+        env = "INFLUXDB_IOX_PERSIST_QUEUE_DEPTH",
         default_value = "250",
         action
     )]
-    pub persist_worker_queue_depth: usize,
+    pub persist_queue_depth: usize,
 }

--- a/ingester2/Cargo.toml
+++ b/ingester2/Cargo.toml
@@ -9,6 +9,7 @@ license.workspace = true
 arrow = { workspace = true, features = ["prettyprint"] }
 arrow-flight = { workspace = true }
 arrow_util = { version = "0.1.0", path = "../arrow_util" }
+async-channel = "1.8.0"
 async-trait = "0.1.58"
 backoff = { version = "0.1.0", path = "../backoff" }
 bytes = "1.3.0"

--- a/ingester2/src/init.rs
+++ b/ingester2/src/init.rs
@@ -154,7 +154,7 @@ pub async fn new(
     wal_rotation_period: Duration,
     persist_executor: Arc<Executor>,
     persist_workers: usize,
-    persist_worker_queue_depth: usize,
+    persist_queue_depth: usize,
     object_store: ParquetStorage,
 ) -> Result<IngesterGuard<impl IngesterRpcInterface>, InitError> {
     // Create the transition shard.
@@ -243,7 +243,7 @@ pub async fn new(
     // Parquet files, and upload them to object storage.
     let (persist_handle, persist_state) = PersistHandle::new(
         persist_workers,
-        persist_worker_queue_depth,
+        persist_queue_depth,
         persist_executor,
         object_store,
         Arc::clone(&catalog),

--- a/ingester2/src/persist/context.rs
+++ b/ingester2/src/persist/context.rs
@@ -44,6 +44,7 @@ impl PersistRequest {
     pub(super) fn new(
         partition: Arc<Mutex<PartitionData>>,
         data: PersistingData,
+        enqueued_at: Instant,
     ) -> (Self, oneshot::Receiver<()>) {
         let (tx, rx) = oneshot::channel();
         (
@@ -51,7 +52,7 @@ impl PersistRequest {
                 complete: tx,
                 partition,
                 data,
-                enqueued_at: Instant::now(),
+                enqueued_at,
             },
             rx,
         )

--- a/ingester2/src/persist/handle.rs
+++ b/ingester2/src/persist/handle.rs
@@ -1,20 +1,19 @@
 use std::sync::Arc;
 
+use async_channel::RecvError;
 use iox_catalog::interface::Catalog;
-use iox_query::exec::Executor;
+use iox_query::{exec::Executor, QueryChunkMeta};
 use observability_deps::tracing::*;
 use parking_lot::Mutex;
 use parquet_file::storage::ParquetStorage;
+use schema::sort::adjust_sort_key_columns;
 use sharder::JumpHash;
 use tokio::{
-    sync::{
-        mpsc::{self, error::TrySendError},
-        oneshot,
-    },
+    sync::{mpsc, oneshot, Semaphore, TryAcquireError},
     time::Instant,
 };
 
-use crate::buffer_tree::partition::{persisting::PersistingData, PartitionData};
+use crate::buffer_tree::partition::{persisting::PersistingData, PartitionData, SortKeyState};
 
 use super::{
     backpressure::PersistState,
@@ -33,15 +32,15 @@ use super::{
 /// The [`PersistHandle`] can be cheaply cloned and passed over thread/task
 /// boundaries to enqueue persist tasks in parallel.
 ///
-/// Dropping all [`PersistHandle`] instances immediately stops all workers.
+/// Dropping all [`PersistHandle`] instances immediately stops all persist
+/// workers and drops all outstanding persist tasks.
 ///
 /// # Topology
 ///
-/// The [`PersistHandle`] uses an internal work group to parallelise persistence
-/// operations up to `n_workers` number of parallel tasks.
-///
-/// Submitting a persistence request selects a worker for the persist job and
-/// places the job into a bounded queue (of up to `worker_queue_depth` items).
+/// The persist system is exposes a logical queue of persist tasks with up to
+/// `persist_queue_depth` slots. Each persist task is executed on a worker in
+/// the worker pool in order to parallelise persistence operations up to
+/// `n_workers` number of parallel tasks.
 ///
 /// ```text
 ///                            ┌─────────────┐
@@ -50,11 +49,10 @@ use super::{
 ///                             └┬────────────┘│
 ///                              └─────┬───────┘
 ///                                    │
+///                           persist_queue_depth
+///                                    │
 ///                                    │
 ///                   ┌────────────────┼────────────────┐
-///                   │                │                │
-///                   │                │                │
-///       worker_queue_depth  worker_queue_depth  worker_queue_depth
 ///                   │                │                │
 ///                   ▼                ▼                ▼
 ///            ┌────────────┐   ┌────────────┐   ┌────────────┐
@@ -68,19 +66,18 @@ use super::{
 ///                             └ ─ ─ ─ ─ ─ ─
 /// ```
 ///
+/// Internally, several queues are used, and reordering of persist tasks is
+/// allowed for efficiency / performance reasons, allowing maximal
+/// parallelisation of work given the constraints of an individual persist job.
+///
 /// Compaction is performed in the provided [`Executor`] re-org thread-pool and
 /// is shared across all workers.
 ///
-/// At any one time, the number of outstanding persist tasks is bounded by:
-///
-/// ```text
-///
-///                    workers * worker_queue_depth
-///
-/// ```
-///
-/// At any one time, there may be at most `worker_queue_depth` number of
-/// outstanding persist jobs for a single partition or worker.
+/// While the logical queue bounds the number of outstanding persist tasks to at
+/// most `persist_queue_depth`, once this limit is reached threads attempting to
+/// push into the queue block for a free slot to become available in the queue -
+/// this can increase the number of outstanding jobs in the system beyond
+/// `persist_queue_depth` - see "Overload & Back-pressure" below.
 ///
 /// # Parallelism & Partition Serialisation
 ///
@@ -95,17 +92,17 @@ use super::{
 ///
 /// # Overload & Back-pressure
 ///
-/// The persist queue is bounded, but the caller must prevent new persist jobs
-/// from being generated and blocked whilst waiting to add the persist job to
-/// the bounded queue, otherwise the system is effectively unbounded. If an
-/// unbounded number of threads block on [`PersistHandle::queue_persist()`]
-/// waiting to successfully enqueue the job, then there is no bound on
-/// outstanding persist jobs at all.
+/// The logical persist queue is bounded, but the caller must prevent new
+/// persist jobs from being generated and blocked whilst waiting to add the
+/// persist job to the bounded queue, otherwise the system is effectively
+/// unbounded. If an unbounded number of threads block on
+/// [`PersistHandle::queue_persist()`] waiting to successfully enqueue the job,
+/// then there is no bound on outstanding persist jobs at all.
 ///
-/// To prevent this, the persistence system exposes an indicator of saturation
-/// (readable via the [`PersistState`]) that the caller MUST use to prevent the
-/// generation of new persist tasks (for example, by blocking any further
-/// ingest) on a best-effort basis.
+/// To enforce the bound, the persistence system exposes an indicator of
+/// saturation (readable via the [`PersistState`]) that the caller MUST use to
+/// prevent the generation of new persist tasks on a best-effort basis (for
+/// example; by blocking any further ingest).
 ///
 /// When the persist queue is saturated, the [`PersistState::is_saturated()`]
 /// returns true. Once the backlog of persist jobs is reduced, the
@@ -119,16 +116,38 @@ pub(crate) struct PersistHandle {
     /// THe state/dependencies shared across all worker tasks.
     inner: Arc<Inner>,
 
-    /// A consistent hash implementation used to consistently map buffers from
-    /// one partition to the same worker queue.
-    ///
-    /// This ensures persistence is serialised per-partition, but in parallel
-    /// across partitions (up to the number of worker tasks).
-    persist_queues: Arc<JumpHash<mpsc::Sender<PersistRequest>>>,
-
     /// Task handles for the worker tasks, aborted on drop of all
     /// [`PersistHandle`] instances.
-    tasks: Arc<Vec<AbortOnDrop<()>>>,
+    worker_tasks: Arc<Vec<AbortOnDrop<()>>>,
+
+    /// While the persistence system exposes the concept of a "persistence
+    /// queue" externally, it is actually a set of per-worker queues, and the
+    /// global task queue.
+    ///
+    /// Each individual queue is unbounded, with the logical "persistence queue"
+    /// bound by a semaphore to limit the number of global outstanding persist
+    /// operations.
+
+    /// The persist task semaphore that bounds the number of outstanding persist
+    /// operations across all queues.
+    ///
+    /// Before enqueuing an item into any of the (unbounded) worker queues, or
+    /// (unbounded) global queue, the caller MUST obtain a semaphore permit.
+    sem: Arc<Semaphore>,
+
+    /// A global queue of persist tasks that may be executed on any worker in
+    /// parallel with any other persist task.
+    ///
+    /// For correctness, only persist operations that do not cause a sort key
+    /// update should be enqueued in the global work queue.
+    global_queue: async_channel::Sender<PersistRequest>,
+
+    /// A consistent hash implementation used to consistently map persist tasks
+    /// from one partition to the same worker queue.
+    ///
+    /// These queues are used for persist tasks that modify the partition's sort
+    /// key, ensuring sort key updates are serialised per-partition.
+    worker_queues: Arc<JumpHash<mpsc::UnboundedSender<PersistRequest>>>,
 
     /// Records the saturation state of the persist system.
     persist_state: Arc<PersistState>,
@@ -138,21 +157,19 @@ impl PersistHandle {
     /// Initialise a new persist actor & obtain the first handle.
     pub(crate) fn new(
         n_workers: usize,
-        worker_queue_depth: usize,
+        persist_queue_depth: usize,
         exec: Arc<Executor>,
         store: ParquetStorage,
         catalog: Arc<dyn Catalog>,
     ) -> (Self, Arc<PersistState>) {
         assert_ne!(n_workers, 0, "must run at least 1 persist worker");
-        assert_ne!(worker_queue_depth, 0, "worker queue depth must be non-zero");
+        assert_ne!(
+            persist_queue_depth, 0,
+            "persist queue depth must be non-zero"
+        );
 
         // Log the important configuration parameters of the persist subsystem.
-        info!(
-            n_workers,
-            worker_queue_depth,
-            max_queued_tasks = (n_workers * worker_queue_depth),
-            "initialised persist task"
-        );
+        info!(n_workers, persist_queue_depth, "initialised persist task");
 
         let inner = Arc::new(Inner {
             exec,
@@ -160,24 +177,43 @@ impl PersistHandle {
             catalog,
         });
 
+        // Initialise the global queue.
+        //
+        // Persist tasks that do not require a sort key update are enqueued into
+        // this queue, from which all workers consume.
+        let (global_tx, global_rx) = async_channel::unbounded();
+
         let (tx_handles, tasks): (Vec<_>, Vec<_>) = (0..n_workers)
             .map(|_| {
                 let inner = Arc::clone(&inner);
-                let (tx, rx) = mpsc::channel(worker_queue_depth);
-                (tx, AbortOnDrop(tokio::spawn(run_task(inner, rx))))
+
+                // Initialise the worker queue that is not shared across workers
+                // allowing the persist code to address a single worker.
+                let (tx, rx) = mpsc::unbounded_channel();
+                (
+                    tx,
+                    AbortOnDrop(tokio::spawn(run_task(inner, global_rx.clone(), rx))),
+                )
             })
             .unzip();
 
         assert!(!tasks.is_empty());
 
-        // Initialise the saturation state as "not saturated".
-        let persist_state = Default::default();
+        // Initialise the semaphore that bounds the total number of persist jobs
+        // in the system.
+        let sem = Arc::new(Semaphore::new(persist_queue_depth));
+
+        // Initialise the saturation state as "not saturated" and provide it
+        // with the task semaphore and total permit count.
+        let persist_state = Arc::new(PersistState::new(persist_queue_depth, Arc::clone(&sem)));
 
         (
             Self {
                 inner,
-                persist_queues: Arc::new(JumpHash::new(tx_handles)),
-                tasks: Arc::new(tasks),
+                sem,
+                global_queue: global_tx,
+                worker_queues: Arc::new(JumpHash::new(tx_handles)),
+                worker_tasks: Arc::new(tasks),
                 persist_state: Arc::clone(&persist_state),
             },
             persist_state,
@@ -187,14 +223,18 @@ impl PersistHandle {
     /// Place `data` from `partition` into the persistence queue.
     ///
     /// This call (asynchronously) waits for space to become available in the
-    /// assigned worker queue.
+    /// persistence queue.
     ///
     /// Once persistence is complete, the partition will be locked and the sort
-    /// key will be updated, and [`PartitionData::mark_persisted()`] is called
-    /// with `data`.
+    /// key will be updated (if necessary), and
+    /// [`PartitionData::mark_persisted()`] is called with `data` to mark the
+    /// task as complete.
     ///
     /// Once all persistence related tasks for `data` are complete, the returned
     /// channel publishes a notification.
+    ///
+    /// Persist tasks may be re-ordered w.r.t their submission order for
+    /// performance reasons.
     ///
     /// # Panics
     ///
@@ -209,48 +249,116 @@ impl PersistHandle {
         partition: Arc<Mutex<PartitionData>>,
         data: PersistingData,
     ) -> oneshot::Receiver<()> {
-        debug!(
-            partition_id = data.partition_id().get(),
-            "enqueuing persistence task"
-        );
+        let partition_id = data.partition_id().get();
+        debug!(partition_id, "enqueuing persistence task");
 
-        // Build the persist task request.
         let enqueued_at = Instant::now();
-        let (r, notify) = PersistRequest::new(partition, data, enqueued_at);
 
-        // Select a worker to dispatch this request to.
-        let queue = self.persist_queues.hash(r.partition_id());
-
-        // Try and enqueue the persist task immediately.
-        match queue.try_send(r) {
-            Ok(()) => {} // Success!
-            Err(TrySendError::Closed(_)) => panic!("persist worker has stopped"),
-            Err(TrySendError::Full(r)) => {
-                // The worker's queue is full. Mark the persist system as being
-                // saturated, requiring some time to clear outstanding persist
-                // operations.
+        // Try and acquire the persist task permit immediately.
+        let permit = match Arc::clone(&self.sem).try_acquire_owned() {
+            Ok(p) => p, // Success!
+            Err(TryAcquireError::Closed) => panic!("persist work semaphore is closed"),
+            Err(TryAcquireError::NoPermits) => {
+                // The persist system is saturated. Mark the persist system as
+                // being saturated to observers.
                 //
-                // The returned guard MUST be held during the send() await
-                // below.
-                let _guard = PersistState::set_saturated(
-                    Arc::clone(&self.persist_state),
-                    self.persist_queues.shards().to_owned(),
-                );
+                // The returned guard MUST be held during the acquire_owned()
+                // await below.
+                let _guard = PersistState::set_saturated(Arc::clone(&self.persist_state));
 
                 // TODO(test): the guard is held over the await point below
 
-                // Park this task waiting to enqueue the persist whilst holding
+                // Park this task waiting to obtain the permit whilst holding
                 // the guard above.
                 //
-                // If this send() is aborted, the guard is dropped and the
-                // number of waiters is decremented. If the send() is
-                // successful, the guard is dropped immediately when leaving
-                // this scope.
-                queue.send(r).await.expect("persist worker stopped");
+                // If this acquire_owned() is aborted, the guard is dropped and
+                // the number of waiters is decremented. If the acquire_owned()
+                // is successful, the guard is dropped immediately when leaving
+                // this scope, after the permit has been granted.
+
+                Arc::clone(&self.sem)
+                    .acquire_owned()
+                    .await
+                    .expect("persist work semaphore is closed")
             }
         };
 
+        // If the persist job has a known sort key, and it can be determined
+        // that the persist job does not require updating that sort key, it can
+        // be enqueued in the global queue and executed on any worker.
+        //
+        // Conversely if the sort key is not yet known (unresolved deferred
+        // load) do not wait in this handle to resolve it, and instead
+        // pessimistically enqueue the task into a specific worker queue by
+        // consistently hashing the partition ID, serialising the execution of
+        // the persist job w.r.t other persist jobs for the same partition. It
+        // is still executed in parallel with other persist jobs for other
+        // partitions.
+        //
+        // Likewise if it can be determined that a sort key is necessary, it
+        // must be serialised via the same mechanism.
+        //
+        // Do NOT attempt to fetch the sort key in this handler, as doing so
+        // would cause a large number of requests against the catalog in a short
+        // period of time (bounded by the number of tasks being enqueued).
+        // Instead, the workers fetch the sort key, bounding the number of
+        // queries to at most `n_workers`.
+
+        let sort_key = match partition.lock().sort_key() {
+            SortKeyState::Deferred(v) => v.peek().flatten(),
+            SortKeyState::Provided(v) => v.as_ref().cloned(),
+        };
+
+        // Build the persist task request.
+        let schema = data.schema();
+        let (r, notify) = PersistRequest::new(Arc::clone(&partition), data, permit, enqueued_at);
+
+        match sort_key {
+            Some(v) => {
+                // A sort key is known for this partition. If it can be shown
+                // that this persist job does not require a sort key update, it
+                // can be parallelised with impunity.
+                let data_primary_key = schema.primary_key();
+                if let Some(new_sort_key) = adjust_sort_key_columns(&v, &data_primary_key).1 {
+                    // This persist operation will require a sort key update.
+                    trace!(
+                        partition_id,
+                        old_sort_key = %v,
+                        %new_sort_key,
+                        "persist job will require sort key update"
+                    );
+                    self.assign_worker(r);
+                } else {
+                    // This persist operation will not require a sort key
+                    // update.
+                    debug!(partition_id, "enqueue persist job to global work queue");
+                    self.global_queue.send(r).await.expect("no persist workers");
+                }
+            }
+            None => {
+                // If no sort key is known (either because it was unresolved, or
+                // not yet set), the task must be serialised w.r.t other persist
+                // jobs for the same partition.
+                trace!(partition_id, "persist job has no known sort key");
+                self.assign_worker(r);
+            }
+        }
+
         notify
+    }
+
+    fn assign_worker(&self, r: PersistRequest) {
+        debug!(
+            partition_id = r.partition_id().get(),
+            "enqueue persist job to assigned worker"
+        );
+
+        // Consistently map partition tasks for this partition ID to the
+        // same worker.
+        self.worker_queues
+            .hash(r.partition_id())
+            .send(r)
+            .expect("persist worker stopped");
     }
 }
 
@@ -270,13 +378,438 @@ pub(super) struct Inner {
     pub(super) catalog: Arc<dyn Catalog>,
 }
 
-async fn run_task(inner: Arc<Inner>, mut rx: mpsc::Receiver<PersistRequest>) {
-    while let Some(req) = rx.recv().await {
+async fn run_task(
+    inner: Arc<Inner>,
+    global_queue: async_channel::Receiver<PersistRequest>,
+    mut rx: mpsc::UnboundedReceiver<PersistRequest>,
+) {
+    loop {
+        let req = tokio::select! {
+            // Bias the channel polling to prioritise work in the
+            // worker-specific queue.
+            //
+            // This causes the worker to do the work assigned to it specifically
+            // first, falling back to taking jobs from the global queue if it
+            // has no assigned work.
+            //
+            // This allows persist jobs to be reordered w.r.t the order in which
+            // they were enqueued with queue_persist().
+            biased;
+
+            v = rx.recv() => {
+                match v {
+                    Some(v) => v,
+                    None => {
+                        // The worker channel is closed.
+                        return
+                    }
+                }
+            }
+            v = global_queue.recv() => {
+                match v {
+                    Ok(v) => v,
+                    Err(RecvError) => {
+                        // The global channel is closed.
+                        return
+                    },
+                }
+            }
+        };
+
         let ctx = Context::new(req, Arc::clone(&inner));
 
         let compacted = ctx.compact().await;
         let (sort_key_update, parquet_table_data) = ctx.upload(compacted).await;
         ctx.update_database(sort_key_update, parquet_table_data)
             .await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{sync::Arc, time::Duration};
+
+    use assert_matches::assert_matches;
+    use data_types::{NamespaceId, PartitionId, PartitionKey, TableId};
+    use dml::DmlOperation;
+    use iox_catalog::mem::MemCatalog;
+    use lazy_static::lazy_static;
+    use object_store::memory::InMemory;
+    use parquet_file::storage::StorageId;
+    use schema::sort::SortKey;
+    use test_helpers::timeout::FutureTimeout;
+    use tokio::sync::mpsc::error::TryRecvError;
+
+    use crate::{
+        buffer_tree::{
+            namespace::{name_resolver::mock::MockNamespaceNameProvider, NamespaceName},
+            partition::resolver::mock::MockPartitionProvider,
+            table::{name_resolver::mock::MockTableNameProvider, TableName},
+            BufferTree,
+        },
+        deferred_load::DeferredLoad,
+        dml_sink::DmlSink,
+        test_util::make_write_op,
+    };
+
+    use super::*;
+
+    const PARTITION_ID: PartitionId = PartitionId::new(42);
+    const NAMESPACE_ID: NamespaceId = NamespaceId::new(24);
+    const TABLE_ID: TableId = TableId::new(2442);
+    const TABLE_NAME: &str = "banana-report";
+    const NAMESPACE_NAME: &str = "platanos";
+
+    lazy_static! {
+        static ref EXEC: Arc<Executor> = Arc::new(Executor::new_testing());
+        static ref PARTITION_KEY: PartitionKey = PartitionKey::from("bananas");
+        static ref NAMESPACE_NAME_LOADER: Arc<DeferredLoad<NamespaceName>> =
+            Arc::new(DeferredLoad::new(Duration::from_secs(1), async {
+                NamespaceName::from(NAMESPACE_NAME)
+            }));
+        static ref TABLE_NAME_LOADER: Arc<DeferredLoad<TableName>> =
+            Arc::new(DeferredLoad::new(Duration::from_secs(1), async {
+                TableName::from(TABLE_NAME)
+            }));
+    }
+
+    /// Construct a partition with the above constants, with the given sort key,
+    /// and containing a single write.
+    async fn new_partition(
+        partition_id: PartitionId,
+        sort_key: SortKeyState,
+    ) -> Arc<Mutex<PartitionData>> {
+        let buffer_tree = BufferTree::new(
+            Arc::new(MockNamespaceNameProvider::new(NAMESPACE_NAME)),
+            Arc::new(MockTableNameProvider::new(TABLE_NAME)),
+            Arc::new(
+                MockPartitionProvider::default().with_partition(PartitionData::new(
+                    partition_id,
+                    PARTITION_KEY.clone(),
+                    NAMESPACE_ID,
+                    Arc::clone(&NAMESPACE_NAME_LOADER),
+                    TABLE_ID,
+                    Arc::clone(&TABLE_NAME_LOADER),
+                    sort_key,
+                )),
+            ),
+            Default::default(),
+        );
+
+        buffer_tree
+            .apply(DmlOperation::Write(make_write_op(
+                &PARTITION_KEY,
+                NAMESPACE_ID,
+                TABLE_NAME,
+                TABLE_ID,
+                0,
+                r#"banana-report,good=yes level=1000 4242424242"#,
+            )))
+            .await
+            .expect("failed to write partition test dataa");
+
+        Arc::clone(&buffer_tree.partitions().next().unwrap())
+    }
+
+    /// A test that ensures the correct destination of a partition that has no
+    /// assigned sort key yet (a new partition) that was directly assigned. This
+    /// will need a sort key update.
+    #[tokio::test]
+    async fn test_persist_sort_key_provided_none() {
+        let storage = ParquetStorage::new(Arc::new(InMemory::default()), StorageId::from("iox"));
+        let metrics = Arc::new(metric::Registry::default());
+        let catalog = Arc::new(MemCatalog::new(metrics));
+
+        let (mut handle, state) = PersistHandle::new(1, 2, Arc::clone(&EXEC), storage, catalog);
+        assert!(!state.is_saturated());
+
+        // Kill the workers, and replace the queues so we can inspect the
+        // enqueue output.
+        handle.worker_tasks = Arc::new(vec![]);
+
+        let (global_tx, _global_rx) = async_channel::unbounded();
+        handle.global_queue = global_tx;
+
+        let (worker1_tx, mut worker1_rx) = mpsc::unbounded_channel();
+        let (worker2_tx, mut worker2_rx) = mpsc::unbounded_channel();
+        handle.worker_queues = Arc::new(JumpHash::new([worker1_tx, worker2_tx]));
+
+        // Generate a partition with no known sort key.
+        let p = new_partition(PARTITION_ID, SortKeyState::Provided(None)).await;
+        let data = p.lock().mark_persisting().unwrap();
+
+        // Enqueue it
+        let notify = handle.queue_persist(p, data).await;
+
+        // And assert it wound up in a worker queue.
+        assert!(handle.global_queue.is_empty());
+
+        // Remember which queue it wound up in.
+        let mut assigned_worker = &mut worker1_rx;
+        let msg = match assigned_worker.try_recv() {
+            Ok(v) => v,
+            Err(TryRecvError::Disconnected) => panic!("worker channel is closed"),
+            Err(TryRecvError::Empty) => {
+                assigned_worker = &mut worker2_rx;
+                assigned_worker
+                    .try_recv()
+                    .expect("message was not found in either worker")
+            }
+        };
+        assert_eq!(msg.partition_id(), PARTITION_ID);
+
+        // Drop the message, and ensure the notification becomes inactive.
+        drop(msg);
+        assert_matches!(
+            notify.with_timeout_panic(Duration::from_secs(5)).await,
+            Err(_)
+        );
+
+        // Enqueue another partition for the same ID.
+        let p = new_partition(PARTITION_ID, SortKeyState::Provided(None)).await;
+        let data = p.lock().mark_persisting().unwrap();
+
+        // Enqueue it
+        let _notify = handle.queue_persist(p, data).await;
+
+        // And ensure it was mapped to the same worker.
+        let msg = assigned_worker
+            .try_recv()
+            .expect("message was not found in either worker");
+        assert_eq!(msg.partition_id(), PARTITION_ID);
+    }
+
+    /// A test that ensures the correct destination of a partition that has no
+    /// assigned sort key yet (a new partition) that was resolved by the
+    /// deferred load. This will need a sort key update.
+    #[tokio::test]
+    async fn test_persist_sort_key_deferred_resolved_none_update_necessary() {
+        let storage = ParquetStorage::new(Arc::new(InMemory::default()), StorageId::from("iox"));
+        let metrics = Arc::new(metric::Registry::default());
+        let catalog = Arc::new(MemCatalog::new(metrics));
+
+        let (mut handle, state) = PersistHandle::new(1, 2, Arc::clone(&EXEC), storage, catalog);
+        assert!(!state.is_saturated());
+
+        // Kill the workers, and replace the queues so we can inspect the
+        // enqueue output.
+        handle.worker_tasks = Arc::new(vec![]);
+
+        let (global_tx, _global_rx) = async_channel::unbounded();
+        handle.global_queue = global_tx;
+
+        let (worker1_tx, mut worker1_rx) = mpsc::unbounded_channel();
+        let (worker2_tx, mut worker2_rx) = mpsc::unbounded_channel();
+        handle.worker_queues = Arc::new(JumpHash::new([worker1_tx, worker2_tx]));
+
+        // Generate a partition with a resolved, but empty sort key.
+        let p = new_partition(
+            PARTITION_ID,
+            SortKeyState::Deferred(Arc::new(DeferredLoad::new(Duration::from_secs(1), async {
+                None
+            }))),
+        )
+        .await;
+        let (loader, data) = {
+            let mut p = p.lock();
+            (p.sort_key().clone(), p.mark_persisting().unwrap())
+        };
+        // Ensure the key is resolved.
+        assert_matches!(loader.get().await, None);
+
+        // Enqueue it
+        let notify = handle.queue_persist(p, data).await;
+
+        // And assert it wound up in a worker queue.
+        assert!(handle.global_queue.is_empty());
+
+        // Remember which queue it wound up in.
+        let mut assigned_worker = &mut worker1_rx;
+        let msg = match assigned_worker.try_recv() {
+            Ok(v) => v,
+            Err(TryRecvError::Disconnected) => panic!("worker channel is closed"),
+            Err(TryRecvError::Empty) => {
+                assigned_worker = &mut worker2_rx;
+                assigned_worker
+                    .try_recv()
+                    .expect("message was not found in either worker")
+            }
+        };
+        assert_eq!(msg.partition_id(), PARTITION_ID);
+
+        // Drop the message, and ensure the notification becomes inactive.
+        drop(msg);
+        assert_matches!(
+            notify.with_timeout_panic(Duration::from_secs(5)).await,
+            Err(_)
+        );
+
+        // Enqueue another partition for the same ID and same (resolved)
+        // deferred load instance.
+        let p = new_partition(PARTITION_ID, loader).await;
+        let data = p.lock().mark_persisting().unwrap();
+
+        // Enqueue it
+        let _notify = handle.queue_persist(p, data).await;
+
+        // And ensure it was mapped to the same worker.
+        let msg = assigned_worker
+            .try_recv()
+            .expect("message was not found in either worker");
+        assert_eq!(msg.partition_id(), PARTITION_ID);
+    }
+
+    /// A test that ensures the correct destination of a partition that has an
+    /// assigned sort key, but the data differs and a sort key update is
+    /// necessary.
+    #[tokio::test]
+    async fn test_persist_sort_key_deferred_resolved_some_update_necessary() {
+        let storage = ParquetStorage::new(Arc::new(InMemory::default()), StorageId::from("iox"));
+        let metrics = Arc::new(metric::Registry::default());
+        let catalog = Arc::new(MemCatalog::new(metrics));
+
+        let (mut handle, state) = PersistHandle::new(1, 2, Arc::clone(&EXEC), storage, catalog);
+        assert!(!state.is_saturated());
+
+        // Kill the workers, and replace the queues so we can inspect the
+        // enqueue output.
+        handle.worker_tasks = Arc::new(vec![]);
+
+        let (global_tx, _global_rx) = async_channel::unbounded();
+        handle.global_queue = global_tx;
+
+        let (worker1_tx, mut worker1_rx) = mpsc::unbounded_channel();
+        let (worker2_tx, mut worker2_rx) = mpsc::unbounded_channel();
+        handle.worker_queues = Arc::new(JumpHash::new([worker1_tx, worker2_tx]));
+
+        // Generate a partition with a resolved sort key that does not reflect
+        // the data within the partition's buffer.
+        let p = new_partition(
+            PARTITION_ID,
+            SortKeyState::Deferred(Arc::new(DeferredLoad::new(Duration::from_secs(1), async {
+                Some(SortKey::from_columns(["time", "some-other-column"]))
+            }))),
+        )
+        .await;
+        let (loader, data) = {
+            let mut p = p.lock();
+            (p.sort_key().clone(), p.mark_persisting().unwrap())
+        };
+        // Ensure the key is resolved.
+        assert_matches!(loader.get().await, Some(_));
+
+        // Enqueue it
+        let notify = handle.queue_persist(p, data).await;
+
+        // And assert it wound up in a worker queue.
+        assert!(handle.global_queue.is_empty());
+
+        // Remember which queue it wound up in.
+        let mut assigned_worker = &mut worker1_rx;
+        let msg = match assigned_worker.try_recv() {
+            Ok(v) => v,
+            Err(TryRecvError::Disconnected) => panic!("worker channel is closed"),
+            Err(TryRecvError::Empty) => {
+                assigned_worker = &mut worker2_rx;
+                assigned_worker
+                    .try_recv()
+                    .expect("message was not found in either worker")
+            }
+        };
+        assert_eq!(msg.partition_id(), PARTITION_ID);
+
+        // Drop the message, and ensure the notification becomes inactive.
+        drop(msg);
+        assert_matches!(
+            notify.with_timeout_panic(Duration::from_secs(5)).await,
+            Err(_)
+        );
+
+        // Enqueue another partition for the same ID and same (resolved)
+        // deferred load instance.
+        let p = new_partition(PARTITION_ID, loader).await;
+        let data = p.lock().mark_persisting().unwrap();
+
+        // Enqueue it
+        let _notify = handle.queue_persist(p, data).await;
+
+        // And ensure it was mapped to the same worker.
+        let msg = assigned_worker
+            .try_recv()
+            .expect("message was not found in either worker");
+        assert_eq!(msg.partition_id(), PARTITION_ID);
+    }
+
+    /// A test that a partition that does not require a sort key update is
+    /// enqueued into the global queue.
+    #[tokio::test]
+    async fn test_persist_sort_key_no_update_necessary() {
+        let storage = ParquetStorage::new(Arc::new(InMemory::default()), StorageId::from("iox"));
+        let metrics = Arc::new(metric::Registry::default());
+        let catalog = Arc::new(MemCatalog::new(metrics));
+
+        let (mut handle, state) = PersistHandle::new(1, 2, Arc::clone(&EXEC), storage, catalog);
+        assert!(!state.is_saturated());
+
+        // Kill the workers, and replace the queues so we can inspect the
+        // enqueue output.
+        handle.worker_tasks = Arc::new(vec![]);
+
+        let (global_tx, global_rx) = async_channel::unbounded();
+        handle.global_queue = global_tx;
+
+        let (worker1_tx, mut worker1_rx) = mpsc::unbounded_channel();
+        let (worker2_tx, mut worker2_rx) = mpsc::unbounded_channel();
+        handle.worker_queues = Arc::new(JumpHash::new([worker1_tx, worker2_tx]));
+
+        // Generate a partition with a resolved sort key that does not reflect
+        // the data within the partition's buffer.
+        let p = new_partition(
+            PARTITION_ID,
+            SortKeyState::Deferred(Arc::new(DeferredLoad::new(Duration::from_secs(1), async {
+                Some(SortKey::from_columns(["time", "good"]))
+            }))),
+        )
+        .await;
+        let (loader, data) = {
+            let mut p = p.lock();
+            (p.sort_key().clone(), p.mark_persisting().unwrap())
+        };
+        // Ensure the key is resolved.
+        assert_matches!(loader.get().await, Some(_));
+
+        // Enqueue it
+        let notify = handle.queue_persist(p, data).await;
+
+        // Assert the task did not get enqueued in a worker
+        assert_matches!(worker1_rx.try_recv(), Err(TryRecvError::Empty));
+        assert_matches!(worker2_rx.try_recv(), Err(TryRecvError::Empty));
+
+        // And assert it wound up in the global queue.
+        let msg = global_rx
+            .try_recv()
+            .expect("task should be in global queue");
+        assert_eq!(msg.partition_id(), PARTITION_ID);
+
+        // Drop the message, and ensure the notification becomes inactive.
+        drop(msg);
+        assert_matches!(
+            notify.with_timeout_panic(Duration::from_secs(5)).await,
+            Err(_)
+        );
+
+        // Enqueue another partition for the same ID and same (resolved)
+        // deferred load instance.
+        let p = new_partition(PARTITION_ID, loader).await;
+        let data = p.lock().mark_persisting().unwrap();
+
+        // Enqueue it
+        let _notify = handle.queue_persist(p, data).await;
+
+        // And ensure it was mapped to the same worker.
+        let msg = global_rx
+            .try_recv()
+            .expect("task should be in global queue");
+        assert_eq!(msg.partition_id(), PARTITION_ID);
     }
 }

--- a/iox_query/src/exec.rs
+++ b/iox_query/src/exec.rs
@@ -130,7 +130,8 @@ impl Executor {
         Self::new_with_config_and_executors(config, executors)
     }
 
-    /// Get testing executor.
+    /// Get testing executor that runs a on single thread and a low memory bound
+    /// to preserve resources.
     pub fn new_testing() -> Self {
         let config = ExecutorConfig {
             num_threads: 1,

--- a/ioxd_ingester2/src/lib.rs
+++ b/ioxd_ingester2/src/lib.rs
@@ -156,7 +156,7 @@ pub async fn create_ingester_server_type(
         Duration::from_secs(ingester_config.wal_rotation_period_seconds),
         exec,
         ingester_config.persist_max_parallelism,
-        ingester_config.persist_worker_queue_depth,
+        ingester_config.persist_queue_depth,
         object_store,
     )
     .await?;


### PR DESCRIPTION
This PR changes the ingester2 persist system with the aim to perform optimal parallelisation of persist tasks within the parallelism bound; persists that can be parallelised are parallelised (across all workers), serialising only those jobs that **must** be serialised for correctness.

Some persist operations require updating the partition's sort key - this is not a commutative operation; updates must be applied one after another. We can cheaply and easily determine if a persist job will need to update the sort key before starting the persist job, and this PR takes advantage of that fact:

* Persist jobs that need to update a sort key are enqueued to a partition's assigned worker - serialising within the partition, but parallelising across partitions.

* Persist jobs that will not modify the partition's sort key are enqueued into a global work queue, from which all workers consume.

This provides optimal[^1] parallelisation; in the happy path, no sort key update is required and the work is parallelised (without head-of-line blocking) across N workers. In the case of a sort key update being necessary, the task is serialised **only with other persists that update the key for the same partition**. If a task doesn't update the sort key, it happens in parallel regardless of any ongoing, serialised persist jobs for the same partition.

### Back-pressure

Because there are multiple queues, and because we want to bound the total number of tasks in the system (not in any one queue) we give out a semaphore permit for each job, regardless of the queue it is placed in. This lets us effectively control the global number of jobs with a single number.

The back-pressure system introduced in #6403 also accounts for writers waiting to enqueue (waiting for a permit), in order to prevent an effectively unbounded number of persist operations.

All queues are unbounded to prevent them work from blocking when adding to a busy queue - the system itself is bounded with the semaphore.

### Multiple Queues?

Yes, multiple queues! An alternative solution would be to redo a persist operation when at the end you discover the sort key has been updated. It's expensive to redo a single persist operation (the most expensive operation the ingester does!), but it's actually worse than a simple "redo it" might first seem - the cost grows super-linearly with the number of parallel persist jobs!

Assuming the specified number of persist jobs are running in parallel for a single hot partition, you need this many retries:

<div align="center">

| Parallel Jobs | Retries Needed |
|--|--|
|5|15|
|6|21|
|7|27|
|..|..|
|10|51|

</div>

At 20 parallel persists for a single partition, you're looking at ~200 retries! It's easy to imagine a situation in which a user writing to a few hot partitions completely saturates the persist system with a retry strategy.

[^1]: Technically you could enqueue serialised work to an idle worker if the one it should go to is busy already, but this requires maintaining tracking state that constantly grows. I guess this is optimal for a **stateless** implementation you nit picker.

### Thanks

This closes #6146, opened by @aierui to discuss improvements to the persist system in the original ingester. This design is very similar to the one he proposed which was made possible by the recent work we've done on ingester2  ❤️

---

* refactor: inject persist started timestamp (e24d21255)

      Instead of recording the "enqueued_at" when initialising the
      PersistRequest, inject the value in.
      
      This lets us re-order the request construction while retaining accurate
      timing.

* feat(ingester2): optimal persist parallelism (933ab1f8c)

      This commit changes the behaviour of the persist system to enable
      optimal parallelism of persist operations, and improve the accuracy of
      the outstanding job bound / back-pressure.
      
      Previously all persist operations for a given partition were
      consistently hashed to a single worker task. This serialised persistence
      per partition, ensuring all updates to the partition sort key were
      serialised. However, this also unnecessarily serialises persist
      operations that do not need to update the sort key, reducing the
      potential throughput of the system; in the worst case of a single
      partition receiving all the writes, only one worker would be persisting,
      and the other N-1 workers would be idle.
      
      After this change, the sort key is inspected when enqueuing the persist
      operation and if it can be determined that no sort key update is
      necessary (the typical case), then the persist task is placed into a
      global work queue from which all workers consume. This allows for
      maximal parallelisation of these jobs, and the removes the per-worker
      head-of-line blocking.
      
      In the case that the sort key does need updating, these jobs continue to
      be consistently hashed to a single worker, ensuring serialised sort key
      updates only where necessary.
      
      To support these changes, the back-pressure system has been changed to
      account for all outstanding persist jobs in the system, regardless of
      type or assigned worker - a logical, bounded queue is composed together
      of a semaphore limiting the number of persist tasks overall, and a
      series of physical, unbounded queues - one to each worker & the global
      queue. The overall system remains bounded by the
      INFLUXDB_IOX_PERSIST_QUEUE_DEPTH value, and is now simpler to reason
      about (it is independent of the number of workers, etc).