### PR TITLE
fix(ingester2): Make ingester2 work with empty or existing catalogs 

### DIFF
--- a/ingester2/README.md
+++ b/ingester2/README.md
@@ -1,0 +1,35 @@
+# ingester2
+
+## Quick run
+
+Set-up empty catalog db:
+
+```bash
+mkdir -p /tmp/iox/{wal,obj}
+
+createdb iox_shared
+./target/debug/influxdb_iox catalog setup --catalog-dsn postgres:///iox_shared
+
+# there has to exist one "topic", see https://github.com/influxdata/influxdb_iox/issues/6420
+psql 'dbname=iox_shared options=-csearch_path=public,iox_catalog' -c "insert into topic (name) values ('iox-shared')"
+```
+
+
+Run ingester2:
+
+```bash
+INFLUXDB_IOX_RPC_MODE=2 ./target/debug/influxdb_iox run ingester2 --api-bind=127.0.0.1:8081 --grpc-bind=127.0.0.1:8042 --wal-directory /tmp/iox/wal  --catalog-dsn postgres:///iox_shared --object-store=file --data-dir=/tmp/iox/obj -v 
+```
+
+Run router2:
+
+```bash
+INFLUXDB_IOX_RPC_MODE=2 ./target/debug/influxdb_iox run router2 --api-bind=127.0.0.1:8080 --grpc-bind=127.0.0.1:8085 --ingester-addresses=127.0.0.1:8042 --catalog-dsn postgres:///iox_shared -v
+```
+
+Run querier:
+
+```bash
+INFLUXDB_IOX_RPC_MODE=2 ./target/debug/influxdb_iox run querier --ingester-addresses=http://127.0.0.1:8042 --api-bind 127.0.0.1:8083 --grpc-bind 127.0.0.1:8082 --catalog-dsn postgres:///iox_shared --object-store=file --data-dir=/tmp/iox/obj -v
+```
+

--- a/ingester2/src/init.rs
+++ b/ingester2/src/init.rs
@@ -164,16 +164,13 @@ pub async fn new(
         .expect("start transaction");
     let topic = txn
         .topics()
-        .get_by_name("iox-shared")
+        .create_or_get("iox-shared")
         .await
-        .expect("get topic")
-        .unwrap();
-    let s = txn
-        .shards()
+        .expect("get topic");
+    txn.shards()
         .create_or_get(&topic, TRANSITION_SHARD_INDEX)
         .await
         .expect("create transition shard");
-    assert_eq!(s.id, TRANSITION_SHARD_ID);
     txn.commit().await.expect("commit transition shard");
 
     // Initialise the deferred namespace name resolver.


### PR DESCRIPTION
Make ingester2 work with empty or existing catalogs. Also adds a quickstart documentation that shows how to run it the i/r/q triplet locally.

Closes https://github.com/influxdata/influxdb_iox/issues/6420
I see that the `TRANSITION_SHARD_ID` is also asserted by the test utils, it seems that that's the place this assert belongs to, thus removing from the main init code.

The documentation is based on the gourmet copy pasta first cooked by @carols10cents in #6406
