### PR TITLE
chore: update error message when running int tests w/out kafka

### DIFF
--- a/write_buffer/src/core.rs
+++ b/write_buffer/src/core.rs
@@ -1451,12 +1451,9 @@ pub mod test_utils {
                     panic!(
                         "TEST_INTEGRATION is set which requires running integration tests, but \
                         KAFKA_CONNECT is not set. Please run Kafka, perhaps by using the command \
-                        `docker-compose -f docker/ci-kafka-docker-compose.yml up kafka`, then \
-                        set KAFKA_CONNECT to the host and port where Kafka is accessible. If \
-                        running the `docker-compose` command and the Rust tests on the host, the \
-                        value for `KAFKA_CONNECT` should be `localhost:9093`. If running the Rust \
-                        tests in another container in the `docker-compose` network as on CI, \
-                        `KAFKA_CONNECT` should be `kafka:9092`."
+                        `docker-compose -f integration-docker-compose.yml up redpanda`, then \
+                        set KAFKA_CONNECT to the host and port where Kafka is accessible. In \
+                        this case the `KAFKA_CONNECT` envvar should be `localhost:9092`."
                     )
                 }
                 (false, Some(_)) => {


### PR DESCRIPTION
When running integration tests recently I got the error message telling me `KAFKA_CONNECT` wasn't set, which was correct, but the instructions it gives you are out of date. Compose file has moved, and the port was `9092` for me.

- [ ] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb_iox/blob/main/README.md).
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
