### PR TITLE
feat(ingester2): hot partition persistence

### DIFF
--- a/clap_blocks/src/ingester2.rs
+++ b/clap_blocks/src/ingester2.rs
@@ -50,4 +50,14 @@ pub struct Ingester2Config {
         action
     )]
     pub persist_queue_depth: usize,
+
+    /// The limit at which a partition's estimated persistence cost causes it to
+    /// be queued for persistence.
+    #[clap(
+        long = "persist-hot-partition-cost",
+        env = "INFLUXDB_IOX_PERSIST_HOT_PARTITION_COST",
+        default_value = "20000000", // 20,000,000
+        action
+    )]
+    pub persist_hot_partition_cost: usize,
 }

--- a/ingester2/src/buffer_tree/mod.rs
+++ b/ingester2/src/buffer_tree/mod.rs
@@ -6,3 +6,5 @@ pub(crate) mod table;
 mod root;
 #[allow(unused_imports)]
 pub(crate) use root::*;
+
+pub(crate) mod post_write;

--- a/ingester2/src/buffer_tree/partition.rs
+++ b/ingester2/src/buffer_tree/partition.rs
@@ -139,6 +139,10 @@ impl PartitionData {
         Ok(())
     }
 
+    pub(crate) fn persist_cost_estimate(&self) -> usize {
+        self.buffer.persist_cost_estimate()
+    }
+
     /// Return all data for this partition, ordered by the calls to
     /// [`PartitionData::buffer_write()`].
     pub(crate) fn get_query_data(&mut self) -> Option<QueryAdaptor> {

--- a/ingester2/src/buffer_tree/partition/buffer.rs
+++ b/ingester2/src/buffer_tree/partition/buffer.rs
@@ -55,6 +55,12 @@ impl DataBuffer {
         })
     }
 
+    pub(crate) fn persist_cost_estimate(&self) -> usize {
+        match self.0.get() {
+            FsmState::Buffering(b) => b.persist_cost_estimate(),
+        }
+    }
+
     /// Return all data for this buffer, ordered by the [`SequenceNumber`] from
     /// which it was buffered with.
     pub(crate) fn get_query_data(&mut self) -> Vec<Arc<RecordBatch>> {

--- a/ingester2/src/buffer_tree/partition/buffer/always_some.rs
+++ b/ingester2/src/buffer_tree/partition/buffer/always_some.rs
@@ -43,6 +43,11 @@ impl<T> AlwaysSome<T> {
     pub(crate) fn into_inner(self) -> T {
         self.0.unwrap()
     }
+
+    /// Return an immutable reference to the inner `T`.
+    pub(crate) fn get(&self) -> &T {
+        self.0.as_ref().unwrap()
+    }
 }
 
 #[cfg(test)]

--- a/ingester2/src/buffer_tree/partition/buffer/mutable_buffer.rs
+++ b/ingester2/src/buffer_tree/partition/buffer/mutable_buffer.rs
@@ -54,4 +54,8 @@ impl Buffer {
     pub(super) fn buffer(&self) -> Option<&MutableBatch> {
         self.buffer.as_ref()
     }
+
+    pub(crate) fn persist_cost_estimate(&self) -> usize {
+        self.buffer().map(|v| v.size_data()).unwrap_or_default()
+    }
 }

--- a/ingester2/src/buffer_tree/partition/buffer/state_machine/buffering.rs
+++ b/ingester2/src/buffer_tree/partition/buffer/state_machine/buffering.rs
@@ -76,6 +76,10 @@ impl BufferState<Buffering> {
         // And transition to the WithSnapshot state.
         Transition::ok(Snapshot::new(vec![snap]))
     }
+
+    pub(crate) fn persist_cost_estimate(&self) -> usize {
+        self.state.buffer.persist_cost_estimate()
+    }
 }
 
 #[cfg(test)]

--- a/ingester2/src/buffer_tree/post_write/mock.rs
+++ b/ingester2/src/buffer_tree/post_write/mock.rs
@@ -1,0 +1,22 @@
+use std::sync::Arc;
+
+use parking_lot::Mutex;
+
+use crate::buffer_tree::partition::PartitionData;
+
+use super::PostWriteObserver;
+
+#[derive(Debug, Default)]
+pub(crate) struct MockPostWriteObserver {
+    saw: Mutex<Vec<Arc<Mutex<PartitionData>>>>,
+}
+
+impl PostWriteObserver for MockPostWriteObserver {
+    fn observe(
+        &self,
+        partition: Arc<Mutex<PartitionData>>,
+        _guard: parking_lot::MutexGuard<'_, PartitionData>,
+    ) {
+        self.saw.lock().push(partition);
+    }
+}

--- a/ingester2/src/buffer_tree/post_write/mod.rs
+++ b/ingester2/src/buffer_tree/post_write/mod.rs
@@ -1,0 +1,5 @@
+mod r#trait;
+pub(crate) use r#trait::*;
+
+#[cfg(test)]
+pub(crate) mod mock;

--- a/ingester2/src/buffer_tree/post_write/trait.rs
+++ b/ingester2/src/buffer_tree/post_write/trait.rs
@@ -1,0 +1,9 @@
+use std::{fmt::Debug, sync::Arc};
+
+use parking_lot::{Mutex, MutexGuard};
+
+use crate::buffer_tree::partition::PartitionData;
+
+pub(crate) trait PostWriteObserver: Send + Sync + Debug {
+    fn observe(&self, partition: Arc<Mutex<PartitionData>>, guard: MutexGuard<'_, PartitionData>);
+}

--- a/ingester2/src/persist/handle.rs
+++ b/ingester2/src/persist/handle.rs
@@ -444,6 +444,7 @@ mod tests {
         buffer_tree::{
             namespace::{name_resolver::mock::MockNamespaceNameProvider, NamespaceName},
             partition::resolver::mock::MockPartitionProvider,
+            post_write::mock::MockPostWriteObserver,
             table::{name_resolver::mock::MockTableNameProvider, TableName},
             BufferTree,
         },
@@ -493,6 +494,7 @@ mod tests {
                     sort_key,
                 )),
             ),
+            Arc::new(MockPostWriteObserver::default()),
             Default::default(),
         );
 

--- a/ingester2/src/persist/hot_partitions.rs
+++ b/ingester2/src/persist/hot_partitions.rs
@@ -1,0 +1,71 @@
+use std::{fmt::Debug, sync::Arc};
+
+use observability_deps::tracing::info;
+use parking_lot::{Mutex, MutexGuard};
+
+use crate::buffer_tree::{partition::PartitionData, post_write::PostWriteObserver};
+
+use super::handle::PersistHandle;
+
+#[derive(Debug)]
+pub(crate) struct HotPartitionPersister {
+    persist_handle: PersistHandle,
+    max_estimated_persist_cost: usize,
+}
+
+impl HotPartitionPersister {
+    pub fn new(persist_handle: PersistHandle, max_estimated_persist_cost: usize) -> Self {
+        Self {
+            persist_handle,
+            max_estimated_persist_cost,
+        }
+    }
+
+    #[cold]
+    fn persist(
+        &self,
+        cost_estimate: usize,
+        partition: Arc<Mutex<PartitionData>>,
+        mut guard: MutexGuard<'_, PartitionData>,
+    ) {
+        info!(
+            partition_id = guard.partition_id().get(),
+            cost_estimate, "marking hot partition for persistence"
+        );
+
+        let data = guard
+            .mark_persisting()
+            .expect("failed to transition buffer fsm to persisting state");
+
+        // Perform the enqueue in a separate task, to avoid blocking this
+        // writer if the persist system is saturated.
+        let persist_handle = self.persist_handle.clone();
+        tokio::spawn(async move {
+            // There is no need to await on the completion handle.
+            let _ = persist_handle.queue_persist(partition, data).await;
+        });
+    }
+}
+
+impl PostWriteObserver for HotPartitionPersister {
+    #[inline(always)]
+    fn observe(&self, partition: Arc<Mutex<PartitionData>>, guard: MutexGuard<'_, PartitionData>) {
+        // Without releasing the lock, obtain the new persist cost estimate.
+        let cost_estimate = guard.persist_cost_estimate();
+
+        // This observer is called after a successful write, therefore
+        // persisting the partition MUST have a non-zero cost.
+        assert!(cost_estimate > 0);
+
+        // If the estimated persist cost is over the limit, mark the
+        // partition as persisting.
+        //
+        // This SHOULD happen atomically with the above write, to ensure
+        // accurate buffer costing - if the lock were to be released, more
+        // writes could be added to the buffer in parallel, exceeding the
+        // limit before it was marked as persisting.
+        if cost_estimate >= self.max_estimated_persist_cost {
+            self.persist(cost_estimate, partition, guard)
+        }
+    }
+}

--- a/ingester2/src/persist/mod.rs
+++ b/ingester2/src/persist/mod.rs
@@ -2,3 +2,4 @@ pub(crate) mod backpressure;
 pub(super) mod compact;
 mod context;
 pub(crate) mod handle;
+pub(crate) mod hot_partitions;

--- a/ingester2/src/wal/rotate_task.rs
+++ b/ingester2/src/wal/rotate_task.rs
@@ -1,6 +1,6 @@
 use futures::{stream, StreamExt};
 use observability_deps::tracing::*;
-use std::{future, sync::Arc, time::Duration};
+use std::{fmt::Debug, future, sync::Arc, time::Duration};
 use tokio::time::Instant;
 
 use crate::{buffer_tree::BufferTree, persist::handle::PersistHandle};
@@ -10,12 +10,14 @@ use crate::{buffer_tree::BufferTree, persist::handle::PersistHandle};
 const PERSIST_ENQUEUE_CONCURRENCY: usize = 5;
 
 /// Rotate the `wal` segment file every `period` duration of time.
-pub(crate) async fn periodic_rotation(
+pub(crate) async fn periodic_rotation<O>(
     wal: Arc<wal::Wal>,
     period: Duration,
-    buffer: Arc<BufferTree>,
+    buffer: Arc<BufferTree<O>>,
     persist: PersistHandle,
-) {
+) where
+    O: Send + Sync + Debug,
+{
     let mut interval = tokio::time::interval(period);
 
     loop {

--- a/ioxd_ingester2/src/lib.rs
+++ b/ioxd_ingester2/src/lib.rs
@@ -157,6 +157,7 @@ pub async fn create_ingester_server_type(
         exec,
         ingester_config.persist_max_parallelism,
         ingester_config.persist_queue_depth,
+        ingester_config.persist_hot_partition_cost,
         object_store,
     )
     .await?;


### PR DESCRIPTION
Implement hot partition persistence for ingester2 🚒 

This should ensure that a partition receiving a large volume of writes does not grow to such a degree it causes an OOM.

I'm sure we'll iterate on the selection algorithm, but it is decoupled & easily extended.

---

* feat(ingester2): hot partition persistence (c830a8310)

      This PR uses the MutableBatch persist cost estimation added in #6425 to
      selectively mark "hot" partitions for persistence.
      
      This uses a (composable!) "post-write" observer that is invoked after
      each buffer call - this allows the HotPartitionPersister in this commit
      to inspect the cost of the partition after applying the write, and if it
      exceeds the configurable cost threshold, enqueue it for persistence
      (rotating the buffer within the partition in the process).
      
      Unlike ingester(1), this implementation prevents overrun - the
      application of the write that exceeds the cost limit, and enqueueing the
      partition for persistence is atomic.