### PR TITLE
fix: Correct *some* problems mkm found with ingester2/querier

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -225,43 +225,6 @@ jobs:
               echo "No changes to commit"
             fi
 
-  test_rpc_write:
-    # setup multiple docker images (see https://circleci.com/docs/2.0/configuration-reference/#docker)
-    docker:
-      - image: quay.io/influxdb/rust:ci
-      - image: vectorized/redpanda:v22.1.5
-        command: redpanda start --overprovisioned --smp 1 --memory 1G --reserve-memory 0M
-      - image: postgres
-        environment:
-          POSTGRES_HOST_AUTH_METHOD: trust
-    resource_class: 2xlarge+ # use of a smaller executor tends crashes on link
-    environment:
-      # Disable incremental compilation to avoid overhead. We are not preserving these files anyway.
-      CARGO_INCREMENTAL: "0"
-      # Disable full debug symbol generation to speed up CI build
-      # "1" means line tables only, which is useful for panic tracebacks.
-      RUSTFLAGS: "-C debuginfo=1"
-      # https://github.com/rust-lang/cargo/issues/10280
-      CARGO_NET_GIT_FETCH_WITH_CLI: "true"
-      RUST_BACKTRACE: "1"
-      # Run integration tests
-      TEST_INTEGRATION: 1
-      INFLUXDB_IOX_INTEGRATION_LOCAL: 1
-      KAFKA_CONNECT: "localhost:9092"
-      POSTGRES_USER: postgres
-      TEST_INFLUXDB_IOX_CATALOG_DSN: "postgres://postgres@localhost/iox_shared"
-      # When removing this, also remove the ignore on the test in trogging/src/cli.rs
-      RUST_LOG: debug,,hyper::proto::h1=info,h2=info
-      LOG_FILTER: debug,,hyper::proto::h1=info,h2=info
-    steps:
-      - checkout
-      - rust_components
-      - cache_restore
-      - run:
-          name: Cargo test RPC write path
-          command: cargo test --workspace
-      - cache_save
-
   test:
     # setup multiple docker images (see https://circleci.com/docs/2.0/configuration-reference/#docker)
     docker:
@@ -590,7 +553,6 @@ workflows:
       - protobuf-lint
       - docs-lint
       - test
-      - test_rpc_write
       - test_heappy
       - build_dev
       - doc
@@ -610,7 +572,6 @@ workflows:
             - protobuf-lint
             - docs-lint
             - test
-            - test_rpc_write
             - test_heappy
             - build_dev
             - build_release

--- a/ingester2/src/buffer_tree/partition/resolver/mock.rs
+++ b/ingester2/src/buffer_tree/partition/resolver/mock.rs
@@ -3,7 +3,7 @@
 use std::{collections::HashMap, sync::Arc};
 
 use async_trait::async_trait;
-use data_types::{NamespaceId, PartitionKey, TableId};
+use data_types::{NamespaceId, PartitionKey, ShardId, TableId};
 use parking_lot::Mutex;
 
 use super::r#trait::PartitionProvider;
@@ -54,6 +54,7 @@ impl PartitionProvider for MockPartitionProvider {
         namespace_name: Arc<DeferredLoad<NamespaceName>>,
         table_id: TableId,
         table_name: Arc<DeferredLoad<TableName>>,
+        _transition_shard_id: ShardId,
     ) -> PartitionData {
         let p = self
             .partitions

--- a/ingester2/src/buffer_tree/partition/resolver/trait.rs
+++ b/ingester2/src/buffer_tree/partition/resolver/trait.rs
@@ -1,7 +1,7 @@
 use std::{fmt::Debug, sync::Arc};
 
 use async_trait::async_trait;
-use data_types::{NamespaceId, PartitionKey, TableId};
+use data_types::{NamespaceId, PartitionKey, ShardId, TableId};
 
 use crate::{
     buffer_tree::{namespace::NamespaceName, partition::PartitionData, table::TableName},
@@ -24,6 +24,7 @@ pub(crate) trait PartitionProvider: Send + Sync + Debug {
         namespace_name: Arc<DeferredLoad<NamespaceName>>,
         table_id: TableId,
         table_name: Arc<DeferredLoad<TableName>>,
+        transition_shard_id: ShardId,
     ) -> PartitionData;
 }
 
@@ -39,6 +40,7 @@ where
         namespace_name: Arc<DeferredLoad<NamespaceName>>,
         table_id: TableId,
         table_name: Arc<DeferredLoad<TableName>>,
+        transition_shard_id: ShardId,
     ) -> PartitionData {
         (**self)
             .get_partition(
@@ -47,6 +49,7 @@ where
                 namespace_name,
                 table_id,
                 table_name,
+                transition_shard_id,
             )
             .await
     }
@@ -56,10 +59,12 @@ where
 mod tests {
     use std::{sync::Arc, time::Duration};
 
-    use data_types::PartitionId;
+    use data_types::{PartitionId, ShardId};
 
     use super::*;
     use crate::buffer_tree::partition::{resolver::mock::MockPartitionProvider, SortKeyState};
+
+    const TRANSITION_SHARD_ID: ShardId = ShardId::new(84);
 
     #[tokio::test]
     async fn test_arc_impl() {
@@ -81,6 +86,7 @@ mod tests {
             table_id,
             Arc::clone(&table_name),
             SortKeyState::Provided(None),
+            TRANSITION_SHARD_ID,
         );
 
         let mock = Arc::new(MockPartitionProvider::default().with_partition(data));
@@ -92,6 +98,7 @@ mod tests {
                 Arc::clone(&namespace_name),
                 table_id,
                 Arc::clone(&table_name),
+                TRANSITION_SHARD_ID,
             )
             .await;
         assert_eq!(got.partition_id(), partition);

--- a/ingester2/src/buffer_tree/root.rs
+++ b/ingester2/src/buffer_tree/root.rs
@@ -1041,10 +1041,11 @@ mod tests {
         let partition = partitions.pop().unwrap();
 
         // Perform the partition read
-        let batches =
-            datafusion::physical_plan::common::collect(partition.into_record_batch_stream())
-                .await
-                .expect("failed to collate query results");
+        let batches = datafusion::physical_plan::common::collect(
+            partition.into_record_batch_stream().unwrap(),
+        )
+        .await
+        .expect("failed to collate query results");
 
         // Assert the contents of p1 contains both the initial write, and the
         // 3rd write in a single RecordBatch.

--- a/ingester2/src/buffer_tree/root.rs
+++ b/ingester2/src/buffer_tree/root.rs
@@ -1,7 +1,7 @@
 use std::{fmt::Debug, sync::Arc};
 
 use async_trait::async_trait;
-use data_types::{NamespaceId, TableId};
+use data_types::{NamespaceId, ShardId, TableId};
 use dml::DmlOperation;
 use metric::U64Counter;
 use parking_lot::Mutex;
@@ -97,6 +97,7 @@ pub(crate) struct BufferTree<O> {
     namespace_count: U64Counter,
 
     post_write_observer: Arc<O>,
+    transition_shard_id: ShardId,
 }
 
 impl<O> BufferTree<O>
@@ -110,6 +111,7 @@ where
         partition_provider: Arc<dyn PartitionProvider>,
         post_write_observer: Arc<O>,
         metrics: Arc<metric::Registry>,
+        transition_shard_id: ShardId,
     ) -> Self {
         let namespace_count = metrics
             .register_metric::<U64Counter>(
@@ -126,6 +128,7 @@ where
             partition_provider,
             post_write_observer,
             namespace_count,
+            transition_shard_id,
         }
     }
 
@@ -176,6 +179,7 @@ where
                 Arc::clone(&self.partition_provider),
                 Arc::clone(&self.post_write_observer),
                 &self.metrics,
+                self.transition_shard_id,
             ))
         });
 
@@ -239,6 +243,7 @@ mod tests {
     const TABLE_NAME: &str = "bananas";
     const NAMESPACE_NAME: &str = "platanos";
     const NAMESPACE_ID: NamespaceId = NamespaceId::new(42);
+    const TRANSITION_SHARD_ID: ShardId = ShardId::new(84);
 
     #[tokio::test]
     async fn test_namespace_init_table() {
@@ -259,6 +264,7 @@ mod tests {
                     TableName::from(TABLE_NAME)
                 })),
                 SortKeyState::Provided(None),
+                TRANSITION_SHARD_ID,
             ),
         ));
 
@@ -270,6 +276,7 @@ mod tests {
             partition_provider,
             Arc::new(MockPostWriteObserver::default()),
             &metrics,
+            TRANSITION_SHARD_ID,
         );
 
         // Assert the namespace name was stored
@@ -339,6 +346,7 @@ mod tests {
                         partition_provider,
                         Arc::new(MockPostWriteObserver::default()),
                         Arc::new(metric::Registry::default()),
+                        TRANSITION_SHARD_ID,
                     );
 
                     // Write the provided DmlWrites
@@ -383,6 +391,7 @@ mod tests {
                 TableName::from(TABLE_NAME)
             })),
             SortKeyState::Provided(None),
+            TRANSITION_SHARD_ID,
         )],
         writes = [make_write_op(
             &PartitionKey::from("p1"),
@@ -418,6 +427,7 @@ mod tests {
                     TableName::from(TABLE_NAME)
                 })),
                 SortKeyState::Provided(None),
+                TRANSITION_SHARD_ID,
             ),
             PartitionData::new(
                 PartitionId::new(1),
@@ -431,6 +441,7 @@ mod tests {
                     TableName::from(TABLE_NAME)
                 })),
                 SortKeyState::Provided(None),
+                TRANSITION_SHARD_ID,
             )
         ],
         writes = [
@@ -478,6 +489,7 @@ mod tests {
                     TableName::from(TABLE_NAME)
                 })),
                 SortKeyState::Provided(None),
+                TRANSITION_SHARD_ID,
             ),
             PartitionData::new(
                 PartitionId::new(1),
@@ -491,6 +503,7 @@ mod tests {
                     TableName::from(TABLE_NAME)
                 })),
                 SortKeyState::Provided(None),
+                TRANSITION_SHARD_ID,
             )
         ],
         writes = [
@@ -537,6 +550,7 @@ mod tests {
                     TableName::from(TABLE_NAME)
                 })),
                 SortKeyState::Provided(None),
+                TRANSITION_SHARD_ID,
             ),
             PartitionData::new(
                 PartitionId::new(1),
@@ -550,6 +564,7 @@ mod tests {
                     TableName::from(TABLE_NAME)
                 })),
                 SortKeyState::Provided(None),
+                TRANSITION_SHARD_ID,
             )
         ],
         writes = [
@@ -597,6 +612,7 @@ mod tests {
                 TableName::from(TABLE_NAME)
             })),
             SortKeyState::Provided(None),
+            TRANSITION_SHARD_ID,
         )],
         writes = [
             make_write_op(
@@ -646,6 +662,7 @@ mod tests {
                         TableName::from(TABLE_NAME)
                     })),
                     SortKeyState::Provided(None),
+                    TRANSITION_SHARD_ID,
                 ))
                 .with_partition(PartitionData::new(
                     PartitionId::new(0),
@@ -659,6 +676,7 @@ mod tests {
                         TableName::from(TABLE_NAME)
                     })),
                     SortKeyState::Provided(None),
+                    TRANSITION_SHARD_ID,
                 )),
         );
 
@@ -671,6 +689,7 @@ mod tests {
             partition_provider,
             Arc::new(MockPostWriteObserver::default()),
             Arc::clone(&metrics),
+            TRANSITION_SHARD_ID,
         );
 
         // Write data to partition p1, in table "bananas".
@@ -740,6 +759,7 @@ mod tests {
                         TableName::from(TABLE_NAME)
                     })),
                     SortKeyState::Provided(None),
+                    TRANSITION_SHARD_ID,
                 ))
                 .with_partition(PartitionData::new(
                     PartitionId::new(1),
@@ -753,6 +773,7 @@ mod tests {
                         TableName::from(TABLE_NAME)
                     })),
                     SortKeyState::Provided(None),
+                    TRANSITION_SHARD_ID,
                 ))
                 .with_partition(PartitionData::new(
                     PartitionId::new(2),
@@ -766,6 +787,7 @@ mod tests {
                         TableName::from("another_table")
                     })),
                     SortKeyState::Provided(None),
+                    TRANSITION_SHARD_ID,
                 )),
         );
 
@@ -776,6 +798,7 @@ mod tests {
             partition_provider,
             Arc::new(MockPostWriteObserver::default()),
             Arc::clone(&Arc::new(metric::Registry::default())),
+            TRANSITION_SHARD_ID,
         );
 
         assert_eq!(buf.partitions().count(), 0);
@@ -849,6 +872,7 @@ mod tests {
                     TableName::from(TABLE_NAME)
                 })),
                 SortKeyState::Provided(None),
+                TRANSITION_SHARD_ID,
             ),
         ));
 
@@ -859,6 +883,7 @@ mod tests {
             partition_provider,
             Arc::new(MockPostWriteObserver::default()),
             Arc::new(metric::Registry::default()),
+            TRANSITION_SHARD_ID,
         );
 
         // Query the empty tree
@@ -932,6 +957,7 @@ mod tests {
                         TableName::from(TABLE_NAME)
                     })),
                     SortKeyState::Provided(None),
+                    TRANSITION_SHARD_ID,
                 ))
                 .with_partition(PartitionData::new(
                     PartitionId::new(1),
@@ -945,6 +971,7 @@ mod tests {
                         TableName::from(TABLE_NAME)
                     })),
                     SortKeyState::Provided(None),
+                    TRANSITION_SHARD_ID,
                 )),
         );
 
@@ -955,6 +982,7 @@ mod tests {
             partition_provider,
             Arc::new(MockPostWriteObserver::default()),
             Arc::new(metric::Registry::default()),
+            TRANSITION_SHARD_ID,
         );
 
         // Write data to partition p1, in table "bananas".

--- a/ingester2/src/lib.rs
+++ b/ingester2/src/lib.rs
@@ -44,7 +44,7 @@
     missing_docs
 )]
 
-use data_types::{ShardId, ShardIndex};
+use data_types::ShardIndex;
 
 /// A macro to conditionally prepend `pub` to the inner tokens for benchmarking
 /// purposes, should the `benches` feature be enabled.
@@ -60,9 +60,9 @@ macro_rules! maybe_pub {
     };
 }
 
-/// During the testing of ingester2, the catalog will require a ShardId for
-/// various operations. This is a const value for these occasions.
-const TRANSITION_SHARD_ID: ShardId = ShardId::new(1);
+/// During the testing of ingester2, the catalog will require a ShardIndex for
+/// various operations. This is a const value for these occasions. Look up the ShardId for this
+/// ShardIndex when needed.
 const TRANSITION_SHARD_INDEX: ShardIndex = ShardIndex::new(1);
 
 /// Ingester initialisation methods & types.

--- a/ingester2/src/persist/handle.rs
+++ b/ingester2/src/persist/handle.rs
@@ -430,7 +430,7 @@ mod tests {
     use std::{sync::Arc, time::Duration};
 
     use assert_matches::assert_matches;
-    use data_types::{NamespaceId, PartitionId, PartitionKey, TableId};
+    use data_types::{NamespaceId, PartitionId, PartitionKey, ShardId, TableId};
     use dml::DmlOperation;
     use iox_catalog::mem::MemCatalog;
     use lazy_static::lazy_static;
@@ -460,6 +460,7 @@ mod tests {
     const TABLE_ID: TableId = TableId::new(2442);
     const TABLE_NAME: &str = "banana-report";
     const NAMESPACE_NAME: &str = "platanos";
+    const TRANSITION_SHARD_ID: ShardId = ShardId::new(84);
 
     lazy_static! {
         static ref EXEC: Arc<Executor> = Arc::new(Executor::new_testing());
@@ -492,10 +493,12 @@ mod tests {
                     TABLE_ID,
                     Arc::clone(&TABLE_NAME_LOADER),
                     sort_key,
+                    TRANSITION_SHARD_ID,
                 )),
             ),
             Arc::new(MockPostWriteObserver::default()),
             Default::default(),
+            TRANSITION_SHARD_ID,
         );
 
         buffer_tree

--- a/ingester2/src/query/partition_response.rs
+++ b/ingester2/src/query/partition_response.rs
@@ -8,7 +8,7 @@ use datafusion::physical_plan::SendableRecordBatchStream;
 /// Response data for a single partition.
 pub(crate) struct PartitionResponse {
     /// Stream of snapshots.
-    batches: SendableRecordBatchStream,
+    batches: Option<SendableRecordBatchStream>,
 
     /// Partition ID.
     id: PartitionId,
@@ -42,7 +42,20 @@ impl PartitionResponse {
         completed_persistence_count: u64,
     ) -> Self {
         Self {
-            batches,
+            batches: Some(batches),
+            id,
+            max_persisted_sequence_number,
+            completed_persistence_count,
+        }
+    }
+
+    pub(crate) fn new_no_batches(
+        id: PartitionId,
+        max_persisted_sequence_number: Option<SequenceNumber>,
+        completed_persistence_count: u64,
+    ) -> Self {
+        Self {
+            batches: None,
             id,
             max_persisted_sequence_number,
             completed_persistence_count,
@@ -61,7 +74,7 @@ impl PartitionResponse {
         self.completed_persistence_count
     }
 
-    pub(crate) fn into_record_batch_stream(self) -> SendableRecordBatchStream {
+    pub(crate) fn into_record_batch_stream(self) -> Option<SendableRecordBatchStream> {
         self.batches
     }
 }

--- a/ingester2/src/query/response.rs
+++ b/ingester2/src/query/response.rs
@@ -51,6 +51,7 @@ impl QueryResponse {
     /// Reduce the [`QueryResponse`] to a stream of [`RecordBatch`].
     pub(crate) fn into_record_batches(self) -> impl Stream<Item = Result<RecordBatch, ArrowError>> {
         self.into_partition_stream()
-            .flat_map(|partition| partition.into_record_batch_stream())
+            .flat_map(|partition| futures::stream::iter(partition.into_record_batch_stream()))
+            .flatten()
     }
 }

--- a/ingester2/src/test_util.rs
+++ b/ingester2/src/test_util.rs
@@ -78,8 +78,6 @@ pub(crate) async fn populate_catalog(
         .unwrap()
         .id;
 
-    assert_eq!(shard_id, crate::TRANSITION_SHARD_ID);
-
     (shard_id, ns_id, table_id)
 }
 


### PR DESCRIPTION
Connects to #6421. Does not completely solve yet.

# Commit 1

The first problem both Dom and I suspected was that the transition shard ID was not matching the hardcoded hack value. The first commit in this PR changes the code to still hardcode the transition shard *index* to 1, but to look up in the catalog what the transition shard *id* ends up being and use that value. This didn't seem to affect the problem in the issue at all as far as I could tell, but was incorrect, so good to change anyway. Ultimately, shards will completely go away when the transition is complete.

# Commit 2

The next problem I noticed is in the test mkm was doing, the steps were:

- Enqueue data
- Query, data is returned
- Ingester persists
- Query, data is not returned

I noticed the querier was not getting any metadata about the ingester UUID and number of files persisted from the second query when it queries the ingester. The ingester was just not returning anything if there were no record batches to return from its memory, but we need to always send back the metadata.

The second commit in this PR changes that, and I'm now able to see the querier get the metadata and the function I expect to say "should I refresh the cache?" is now returning `true` for the second request, but I'm still not seeing the data returned, so there's still another bug somewhere.

I can't write a test for this because ingester2 doesn't implement the write info service yet, so there's not a convenient way for tests to tell that data has been persisted or not.

# Commit 3

The third commit removes the `test_rpc_write` CI job; Dom already made it un-required again. Since the feature flag has been removed, it's exactly the same as the `test` job and is just wasting resources.