### PR TITLE
docs: fix incomplete comment

### DIFF
--- a/ingester2/src/persist/backpressure.rs
+++ b/ingester2/src/persist/backpressure.rs
@@ -125,7 +125,8 @@ impl PersistState {
     /// Reading this value is extremely cheap and can be done without
     /// performance concern.
     ///
-    /// This value is eventually consistent, with a presumption of
+    /// This value is eventually consistent, with a presumption of being visible
+    /// in a reasonable amount of time.
     pub(crate) fn get(&self) -> CurrentState {
         // Correctness: relaxed as reading the current state is allowed to be
         // racy for performance reasons; this call should be as cheap as


### PR DESCRIPTION
https://github.com/influxdata/influxdb_iox/pull/6403#discussion_r1049779382

---

* docs: fix incomplete comment (84e29791e)

      Finishes the incomplete sentence that