### PR TITLE
feat(catalog): linearise sort key updates

### DIFF
--- a/compactor/src/compact.rs
+++ b/compactor/src/compact.rs
@@ -842,7 +842,11 @@ pub mod tests {
         // update sort key for this another_partition
         let another_partition = txn
             .partitions()
-            .update_sort_key(another_partition.id, &["tag1", "time"])
+            .cas_sort_key(
+                another_partition.id,
+                Some(another_partition.sort_key),
+                &["tag1", "time"],
+            )
             .await
             .unwrap();
         txn.commit().await.unwrap();

--- a/ingester/src/buffer_tree/partition.rs
+++ b/ingester/src/buffer_tree/partition.rs
@@ -939,7 +939,7 @@ mod tests {
             .repositories()
             .await
             .partitions()
-            .update_sort_key(partition_id, &["terrific"])
+            .cas_sort_key(partition_id, None, &["terrific"])
             .await
             .unwrap();
 

--- a/ingester/src/buffer_tree/partition/resolver/sort_key.rs
+++ b/ingester/src/buffer_tree/partition/resolver/sort_key.rs
@@ -92,7 +92,7 @@ mod tests {
             .repositories()
             .await
             .partitions()
-            .update_sort_key(partition_id, &["uno", "dos", "bananas"])
+            .cas_sort_key(partition_id, None, &["uno", "dos", "bananas"])
             .await
             .expect("should update existing partition key");
 

--- a/ingester/src/data.rs
+++ b/ingester/src/data.rs
@@ -12,7 +12,7 @@ use data_types::{
     CompactionLevel, NamespaceId, PartitionId, SequenceNumber, ShardId, ShardIndex, TableId,
 };
 use dml::DmlOperation;
-use iox_catalog::interface::{get_table_schema_by_id, Catalog};
+use iox_catalog::interface::{get_table_schema_by_id, CasFailure, Catalog};
 use iox_query::exec::Executor;
 use iox_time::{SystemProvider, TimeProvider};
 use metric::{Attributes, Metric, U64Histogram, U64HistogramOptions};
@@ -442,7 +442,7 @@ impl Persister for IngesterData {
             stream: record_stream,
             catalog_sort_key_update,
             data_sort_key,
-        } = compact_persisting_batch(&self.exec, sort_key, table_name.clone(), batch)
+        } = compact_persisting_batch(&self.exec, sort_key.clone(), table_name.clone(), batch)
             .await
             .expect("unable to compact persisting batch");
 
@@ -481,16 +481,35 @@ impl Persister for IngesterData {
         // compactor may see a parquet file with an inconsistent
         // sort key. https://github.com/influxdata/influxdb_iox/issues/5090
         if let Some(new_sort_key) = catalog_sort_key_update {
-            let sort_key = new_sort_key.to_columns().collect::<Vec<_>>();
+            let new_sort_key_str = new_sort_key.to_columns().collect::<Vec<_>>();
+            let old_sort_key: Option<Vec<String>> =
+                sort_key.map(|v| v.to_columns().map(ToString::to_string).collect());
             Backoff::new(&self.backoff_config)
-                .retry_all_errors("update_sort_key", || async {
-                    let mut repos = self.catalog.repositories().await;
-                    let _partition = repos
-                        .partitions()
-                        .update_sort_key(partition_id, &sort_key)
-                        .await?;
-                    // compiler insisted on getting told the type of the error :shrug:
-                    Ok(()) as Result<(), iox_catalog::interface::Error>
+                .retry_all_errors("cas_sort_key", || {
+                    let old_sort_key = old_sort_key.clone();
+                    async {
+                        let mut repos = self.catalog.repositories().await;
+                        match repos
+                            .partitions()
+                            .cas_sort_key(partition_id, old_sort_key, &new_sort_key_str)
+                            .await
+                        {
+                            Ok(_) => {}
+                            Err(CasFailure::ValueMismatch(_)) => {
+                                // An ingester concurrently updated the sort key.
+                                //
+                                // This breaks a sort-key update invariant - sort
+                                // key updates MUST be serialised. This should
+                                // not happen because writes for a given table
+                                // are always mapped to a single ingester
+                                // instance.
+                                panic!("detected concurrent sort key update");
+                            }
+                            Err(CasFailure::QueryError(e)) => return Err(e),
+                        };
+                        // compiler insisted on getting told the type of the error :shrug:
+                        Ok(()) as Result<(), iox_catalog::interface::Error>
+                    }
                 })
                 .await
                 .expect("retry forever");
@@ -507,7 +526,7 @@ impl Persister for IngesterData {
                 %table_name,
                 %partition_id,
                 %partition_key,
-                old_sort_key = ?sort_key,
+                ?old_sort_key,
                 %new_sort_key,
                 "adjusted sort key during batch compact & persist"
             );

--- a/ingester2/src/buffer_tree/partition.rs
+++ b/ingester2/src/buffer_tree/partition.rs
@@ -1006,7 +1006,7 @@ mod tests {
             .repositories()
             .await
             .partitions()
-            .update_sort_key(partition_id, &["terrific"])
+            .cas_sort_key(partition_id, None, &["terrific"])
             .await
             .unwrap();
 

--- a/ingester2/src/buffer_tree/partition/resolver/sort_key.rs
+++ b/ingester2/src/buffer_tree/partition/resolver/sort_key.rs
@@ -92,7 +92,7 @@ mod tests {
             .repositories()
             .await
             .partitions()
-            .update_sort_key(partition_id, &["uno", "dos", "bananas"])
+            .cas_sort_key(partition_id, None, &["uno", "dos", "bananas"])
             .await
             .expect("should update existing partition key");
 

--- a/iox_catalog/src/interface.rs
+++ b/iox_catalog/src/interface.rs
@@ -17,6 +17,18 @@ use std::{
 };
 use uuid::Uuid;
 
+/// An error wrapper detailing the reason for a compare-and-swap failure.
+#[derive(Debug)]
+pub enum CasFailure<T> {
+    /// The compare-and-swap failed because the current value differers from the
+    /// comparator.
+    ///
+    /// Contains the new current value.
+    ValueMismatch(T),
+    /// A query error occurred.
+    QueryError(Error),
+}
+
 #[derive(Debug, Snafu)]
 #[allow(missing_copy_implementations, missing_docs)]
 #[snafu(visibility(pub(crate)))]
@@ -441,15 +453,22 @@ pub trait PartitionRepo: Send + Sync {
     /// return the partitions by table id
     async fn list_by_table_id(&mut self, table_id: TableId) -> Result<Vec<Partition>>;
 
-    /// Update the sort key for the partition.
+    /// Update the sort key for the partition, setting it to `new_sort_key` iff
+    /// the current value matches `old_sort_key`. Returns
     ///
     /// NOTE: it is expected that ONLY the ingesters update sort keys for
     /// existing partitions.
-    async fn update_sort_key(
+    ///
+    /// # Spurious failure
+    ///
+    /// Implementations are allowed to spuriously return
+    /// [`CasFailure::ValueMismatch`] for performance reasons.
+    async fn cas_sort_key(
         &mut self,
         partition_id: PartitionId,
-        sort_key: &[&str],
-    ) -> Result<Partition>;
+        old_sort_key: Option<Vec<String>>,
+        new_sort_key: &[&str],
+    ) -> Result<Partition, CasFailure<Vec<String>>>;
 
     /// Record an instance of a partition being selected for compaction but compaction was not
     /// completed for the specified reason.
@@ -1570,9 +1589,23 @@ pub(crate) mod test_helpers {
         // test update_sort_key from None to Some
         repos
             .partitions()
-            .update_sort_key(other_partition.id, &["tag2", "tag1", "time"])
+            .cas_sort_key(other_partition.id, None, &["tag2", "tag1", "time"])
             .await
             .unwrap();
+
+        // test sort key CAS with an incorrect value
+        let err = repos
+            .partitions()
+            .cas_sort_key(
+                other_partition.id,
+                Some(["bananas".to_string()].to_vec()),
+                &["tag2", "tag1", "tag3 , with comma", "time"],
+            )
+            .await
+            .expect_err("CAS with incorrect value should fail");
+        assert_matches!(err, CasFailure::ValueMismatch(old) => {
+            assert_eq!(old, &["tag2", "tag1", "time"]);
+        });
 
         // test getting the new sort key
         let updated_other_partition = repos
@@ -1586,11 +1619,45 @@ pub(crate) mod test_helpers {
             vec!["tag2", "tag1", "time"]
         );
 
+        // test sort key CAS with no value
+        let err = repos
+            .partitions()
+            .cas_sort_key(
+                other_partition.id,
+                None,
+                &["tag2", "tag1", "tag3 , with comma", "time"],
+            )
+            .await
+            .expect_err("CAS with incorrect value should fail");
+        assert_matches!(err, CasFailure::ValueMismatch(old) => {
+            assert_eq!(old, ["tag2", "tag1", "time"]);
+        });
+
+        // test sort key CAS with an incorrect value
+        let err = repos
+            .partitions()
+            .cas_sort_key(
+                other_partition.id,
+                Some(["bananas".to_string()].to_vec()),
+                &["tag2", "tag1", "tag3 , with comma", "time"],
+            )
+            .await
+            .expect_err("CAS with incorrect value should fail");
+        assert_matches!(err, CasFailure::ValueMismatch(old) => {
+            assert_eq!(old, ["tag2", "tag1", "time"]);
+        });
+
         // test update_sort_key from Some value to Some other value
         repos
             .partitions()
-            .update_sort_key(
+            .cas_sort_key(
                 other_partition.id,
+                Some(
+                    ["tag2", "tag1", "time"]
+                        .into_iter()
+                        .map(ToString::to_string)
+                        .collect(),
+                ),
                 &["tag2", "tag1", "tag3 , with comma", "time"],
             )
             .await

--- a/iox_catalog/src/interface.rs
+++ b/iox_catalog/src/interface.rs
@@ -454,7 +454,7 @@ pub trait PartitionRepo: Send + Sync {
     async fn list_by_table_id(&mut self, table_id: TableId) -> Result<Vec<Partition>>;
 
     /// Update the sort key for the partition, setting it to `new_sort_key` iff
-    /// the current value matches `old_sort_key`. Returns
+    /// the current value matches `old_sort_key`.
     ///
     /// NOTE: it is expected that ONLY the ingesters update sort keys for
     /// existing partitions.
@@ -462,7 +462,8 @@ pub trait PartitionRepo: Send + Sync {
     /// # Spurious failure
     ///
     /// Implementations are allowed to spuriously return
-    /// [`CasFailure::ValueMismatch`] for performance reasons.
+    /// [`CasFailure::ValueMismatch`] for performance reasons in the presence of
+    /// concurrent writers.
     async fn cas_sort_key(
         &mut self,
         partition_id: PartitionId,

--- a/iox_catalog/src/metrics.rs
+++ b/iox_catalog/src/metrics.rs
@@ -1,9 +1,9 @@
 //! Metric instrumentation for catalog implementations.
 
 use crate::interface::{
-    sealed::TransactionFinalize, ColumnRepo, NamespaceRepo, ParquetFileRepo, PartitionRepo,
-    ProcessedTombstoneRepo, QueryPoolRepo, RepoCollection, Result, ShardRepo, TableRepo,
-    TombstoneRepo, TopicMetadataRepo,
+    sealed::TransactionFinalize, CasFailure, ColumnRepo, NamespaceRepo, ParquetFileRepo,
+    PartitionRepo, ProcessedTombstoneRepo, QueryPoolRepo, RepoCollection, Result, ShardRepo,
+    TableRepo, TombstoneRepo, TopicMetadataRepo,
 };
 use async_trait::async_trait;
 use data_types::{
@@ -138,7 +138,7 @@ macro_rules! decorate {
             $metric:literal = $method:ident(
                 &mut self $(,)?
                 $($arg:ident : $t:ty),*
-            ) -> Result<$out:ty>;
+            ) -> Result<$out:ty$(, $err:ty)?>;
         )+]
     ) => {
         #[async_trait]
@@ -149,7 +149,7 @@ macro_rules! decorate {
             /// below.
 
             $(
-                async fn $method(&mut self, $($arg : $t),*) -> Result<$out> {
+                async fn $method(&mut self, $($arg : $t),*) -> Result<$out$(, $err)?> {
                     let observer: Metric<DurationHistogram> = self.metrics.register_metric(
                         "catalog_op_duration",
                         "catalog call duration",
@@ -245,7 +245,7 @@ decorate!(
         "partition_list_by_shard" = list_by_shard(&mut self, shard_id: ShardId) -> Result<Vec<Partition>>;
         "partition_list_by_namespace" = list_by_namespace(&mut self, namespace_id: NamespaceId) -> Result<Vec<Partition>>;
         "partition_list_by_table_id" = list_by_table_id(&mut self, table_id: TableId) -> Result<Vec<Partition>>;
-        "partition_update_sort_key" = update_sort_key(&mut self, partition_id: PartitionId, sort_key: &[&str]) -> Result<Partition>;
+        "partition_update_sort_key" = cas_sort_key(&mut self, partition_id: PartitionId, old_sort_key: Option<Vec<String>>, new_sort_key: &[&str]) -> Result<Partition, CasFailure<Vec<String>>>;
         "partition_record_skipped_compaction" = record_skipped_compaction(&mut self, partition_id: PartitionId, reason: &str, num_files: usize, limit_num_files: usize, limit_num_files_first_in_partition: usize, estimated_bytes: u64, limit_bytes: u64) -> Result<()>;
         "partition_list_skipped_compactions" = list_skipped_compactions(&mut self) -> Result<Vec<SkippedCompaction>>;
         "partition_delete_skipped_compactions" = delete_skipped_compactions(&mut self, partition_id: PartitionId) -> Result<Option<SkippedCompaction>>;

--- a/querier/src/cache/partition.rs
+++ b/querier/src/cache/partition.rs
@@ -495,7 +495,7 @@ mod tests {
                 column_order: vec![c1.column.id, c2.column.id],
             }
         );
-        assert_histogram_metric_count(&catalog.metric_registry, "partition_get_by_id", 3);
+        assert_histogram_metric_count(&catalog.metric_registry, "partition_get_by_id", 4);
 
         // subsets and the full key don't expire
         for should_cover in [
@@ -511,7 +511,7 @@ mod tests {
                 sort_key.as_ref().unwrap(),
                 sort_key_2.as_ref().unwrap()
             ));
-            assert_histogram_metric_count(&catalog.metric_registry, "partition_get_by_id", 3);
+            assert_histogram_metric_count(&catalog.metric_registry, "partition_get_by_id", 4);
         }
 
         // unknown columns expire
@@ -529,7 +529,7 @@ mod tests {
             sort_key_2.as_ref().unwrap()
         ));
         assert_eq!(sort_key, sort_key_2);
-        assert_histogram_metric_count(&catalog.metric_registry, "partition_get_by_id", 4);
+        assert_histogram_metric_count(&catalog.metric_registry, "partition_get_by_id", 5);
     }
 
     fn schema() -> Arc<Schema> {


### PR DESCRIPTION
Change the partition `update_sort_key` method in the catalog interface to a compare-and-swap primitive, allowing the caller to detect serialisation violations.

This is related to https://github.com/influxdata/influxdb_iox/issues/6439 in that it allows ingester2 to detect parallel updates.

* ingester1 will panic if it observes a prohibited parallel update (an invariant in the design)
* ingester2 will (incorrectly) overwrite the sort key as it did before this PR (for now, next PR fixes this)

---

* feat(catalog): linearise sort key updates (2a8454583)

      Updating the sort key is not commutative and MUST be serialised. The
      correctness of the current catalog interface relies on the caller
      serialising updates globally, something it cannot reasonably assert in a
      distributed system.
      
      This change of the catalog interface pushes this responsibility to the
      catalog itself where it can be effectively enforced, and allows a caller
      to detect parallel updates to the sort key.