### PR TITLE
fix(ingester2): handle concurrent sort key updates

### DIFF
--- a/ingester2/src/persist/context.rs
+++ b/ingester2/src/persist/context.rs
@@ -530,3 +530,4 @@ impl Context {
 
 // TODO(test): persist
 // TODO(test): persist completion notification
+// TODO(test): sort key conflict

--- a/ingester2/src/persist/handle.rs
+++ b/ingester2/src/persist/handle.rs
@@ -384,9 +384,9 @@ pub(super) struct Inner {
 ///
 /// Optimistically compacts the [`PersistingData`] using the locally cached sort
 /// key read from the [`PartitionData`] instance. If this key proves to be
-/// stale, the compaction is retried with the new key. See:
+/// stale, the compaction is retried with the new key.
 ///
-///     <https://github.com/influxdata/influxdb_iox/issues/6439>
+/// See <https://github.com/influxdata/influxdb_iox/issues/6439>.
 ///
 /// ```text
 ///           ┌───────┐

--- a/ingester2/src/persist/handle.rs
+++ b/ingester2/src/persist/handle.rs
@@ -483,10 +483,8 @@ async fn run_task(
 ///
 /// If in the course of this the sort key is updated, this function attempts to
 /// update the sort key in the catalog. This MAY fail because another node has
-/// concurrently done the same and the persist must be restarted, see:
-///
-///     <https://github.com/influxdata/influxdb_iox/issues/6439>
-///
+/// concurrently done the same and the persist must be restarted, see
+/// <https://github.com/influxdata/influxdb_iox/issues/6439>.
 async fn compact_and_upload(ctx: &Context) -> Result<ParquetFileParams, PersistError> {
     let compacted = ctx.compact().await;
     let (sort_key_update, parquet_table_data) = ctx.upload(compacted).await;

--- a/ingester2/src/persist/worker.rs
+++ b/ingester2/src/persist/worker.rs
@@ -1,0 +1,154 @@
+use std::sync::Arc;
+
+use async_channel::RecvError;
+use data_types::ParquetFileParams;
+use iox_catalog::interface::Catalog;
+use iox_query::{exec::Executor, QueryChunkMeta};
+use observability_deps::tracing::*;
+use parking_lot::Mutex;
+use parquet_file::storage::ParquetStorage;
+use schema::sort::adjust_sort_key_columns;
+use sharder::JumpHash;
+use tokio::{
+    sync::{mpsc, oneshot, Semaphore, TryAcquireError},
+    time::Instant,
+};
+
+use crate::{
+    buffer_tree::partition::{persisting::PersistingData, PartitionData, SortKeyState},
+    persist::worker,
+};
+
+use super::{
+    backpressure::PersistState,
+    context::{Context, PersistError, PersistRequest},
+};
+
+/// State shared across workers.
+#[derive(Debug)]
+pub(super) struct SharedWorkerState {
+    pub(super) exec: Arc<Executor>,
+    pub(super) store: ParquetStorage,
+    pub(super) catalog: Arc<dyn Catalog>,
+}
+
+/// The worker routine that drives a [`PersistRequest`] to completion,
+/// prioritising jobs from the worker-specific queue, and falling back to jobs
+/// from the global work queue.
+///
+/// Optimistically compacts the [`PersistingData`] using the locally cached sort
+/// key read from the [`PartitionData`] instance. If this key proves to be
+/// stale, the compaction is retried with the new key.
+///
+/// See <https://github.com/influxdata/influxdb_iox/issues/6439>.
+///
+/// ```text
+///           ┌───────┐
+///           │COMPACT│
+///           └───┬───┘
+///           ┌───▽──┐
+///           │UPLOAD│
+///           └───┬──┘
+///        _______▽________     ┌────────────────┐
+///       ╱                ╲    │TRY UPDATE      │
+///      ╱ NEEDS CATALOG    ╲___│CATALOG SORT KEY│
+///      ╲ SORT KEY UPDATE? ╱yes└────────┬───────┘
+///       ╲________________╱      _______▽________     ┌────────────┐
+///               │no            ╱                ╲    │RESTART WITH│
+///               │             ╱ SAW CONCURRENT   ╲___│NEW SORT KEY│
+///               │             ╲ SORT KEY UPDATE? ╱yes└────────────┘
+///               │              ╲________________╱
+///               │                      │no
+///               └─────┬────────────────┘
+///               ┌─────▽─────┐
+///               │ADD PARQUET│
+///               │TO CATALOG │
+///               └─────┬─────┘
+///             ┌───────▽──────┐
+///             │NOTIFY PERSIST│
+///             │JOB COMPLETE  │
+///             └──────────────┘
+/// ```
+pub(super) async fn run_task(
+    worker_state: Arc<SharedWorkerState>,
+    global_queue: async_channel::Receiver<PersistRequest>,
+    mut rx: mpsc::UnboundedReceiver<PersistRequest>,
+) {
+    loop {
+        let req = tokio::select! {
+            // Bias the channel polling to prioritise work in the
+            // worker-specific queue.
+            //
+            // This causes the worker to do the work assigned to it specifically
+            // first, falling back to taking jobs from the global queue if it
+            // has no assigned work.
+            //
+            // This allows persist jobs to be reordered w.r.t the order in which
+            // they were enqueued with queue_persist().
+            biased;
+
+            v = rx.recv() => {
+                match v {
+                    Some(v) => v,
+                    None => {
+                        // The worker channel is closed.
+                        return
+                    }
+                }
+            }
+            v = global_queue.recv() => {
+                match v {
+                    Ok(v) => v,
+                    Err(RecvError) => {
+                        // The global channel is closed.
+                        return
+                    },
+                }
+            }
+        };
+
+        let ctx = Context::new(req, Arc::clone(&worker_state));
+
+        // Compact the data, generate the parquet file from the result, and
+        // upload it to object storage.
+        //
+        // If this process generated a new sort key that must be added to the
+        // catalog, attempt to update the catalog with a compare-and-swap
+        // operation; if this update fails due to a concurrent sort key update,
+        // the compaction must be redone with the new sort key and uploaded
+        // before continuing.
+        let parquet_table_data = loop {
+            match compact_and_upload(&ctx).await {
+                Ok(v) => break v,
+                Err(PersistError::ConcurrentSortKeyUpdate) => continue,
+            };
+        };
+
+        // Make the newly uploaded parquet file visible to other nodes.
+        let object_store_id = ctx.update_catalog_parquet(parquet_table_data).await;
+        // And finally mark the persist job as complete and notify any
+        // observers.
+        ctx.mark_complete(object_store_id);
+    }
+}
+
+/// Run a compaction on the [`PersistingData`], generate a parquet file and
+/// upload it to object storage.
+///
+/// If in the course of this the sort key is updated, this function attempts to
+/// update the sort key in the catalog. This MAY fail because another node has
+/// concurrently done the same and the persist must be restarted, see:
+///
+///     https://github.com/influxdata/influxdb_iox/issues/6439
+///
+async fn compact_and_upload(ctx: &Context) -> Result<ParquetFileParams, PersistError> {
+    let compacted = ctx.compact().await;
+    let (sort_key_update, parquet_table_data) = ctx.upload(compacted).await;
+
+    if let Some(update) = sort_key_update {
+        ctx.update_catalog_sort_key(update, parquet_table_data.object_store_id)
+            .await?
+    }
+
+    Ok(parquet_table_data)
+}


### PR DESCRIPTION
Handle concurrent, cross-node catalog sort key updates as described in https://github.com/influxdata/influxdb_iox/issues/6439.

Closes https://github.com/influxdata/influxdb_iox/issues/6439.

---

* fix(ingester2): handle concurrent sort key updates (f64ffbe03)

      Allow an ingester2 instance to tolerate concurrent partition sort key
      updates in the catalog.
      
      A persist job is optimistically executed with the locally cached sort
      key. If an ingester2 instance observes a concurrent update, it aborts
      both the sort key update, and the overall persist operation (before
      making the parquet file visible) and retries the operation with the
      newly observed sort key. Concurrent sort key updates are theorised to be
      relatively rare overall.
      
      Any orphaned parquet files uploaded as part of a persist job that aborts
      due to a concurrent sort key update are eventually removed by the
      (external) object store GC task.
      
      See https://github.com/influxdata/influxdb_iox/issues/6439

* feat(persist): accept concurrent matching updates (e083f3276)

      As an optimisation, allow a persist task to progress if it observes a
      concurrent catalog sort key update that exactly matches the sort key it
      was committing.

