### PR TITLE
refactor(persist): explicit worker module

### DIFF
--- a/ingester2/src/persist/mod.rs
+++ b/ingester2/src/persist/mod.rs
@@ -3,3 +3,4 @@ pub(super) mod compact;
 mod context;
 pub(crate) mod handle;
 pub(crate) mod hot_partitions;
+mod worker;


### PR DESCRIPTION
Moves things around, but changes nothing else.

---

* refactor(persist): explicit worker module (15cff11b0)

      Separate out persist worker types & routines into a separate worker
      module rather than commingling them with the persist handle, and rename
      the unimaginative "inner" to reflect the actual usage.