### PR TITLE
refactor(ingester2): decouple persistence subsystem

### DIFF
--- a/ingester2/src/init.rs
+++ b/ingester2/src/init.rs
@@ -225,6 +225,7 @@ pub async fn new(
         Arc::clone(&catalog),
         &metrics,
     );
+    let persist_handle = Arc::new(persist_handle);
 
     // Instantiate a post-write observer for hot partition persistence.
     //
@@ -236,7 +237,7 @@ pub async fn new(
     // smaller partitions in-between executions because it was OOMing during WAL
     // replay (and the configuration was changed to mitigate it).
     let hot_partition_persister =
-        HotPartitionPersister::new(persist_handle.clone(), persist_hot_partition_cost);
+        HotPartitionPersister::new(Arc::clone(&persist_handle), persist_hot_partition_cost);
 
     let buffer = Arc::new(BufferTree::new(
         namespace_name_provider,

--- a/ingester2/src/persist/backpressure.rs
+++ b/ingester2/src/persist/backpressure.rs
@@ -60,14 +60,11 @@ pub(crate) struct PersistState {
     state: CachePadded<AtomicUsize>,
 
     /// Tracks the number of [`WaitGuard`] instances, which in turn tracks the
-    /// number of async tasks waiting within [`PersistHandle::queue_persist()`]
-    /// to obtain a semaphore permit and enqueue a persist job.
+    /// number of async tasks waiting within `PersistHandle::enqueue()` to
+    /// obtain a semaphore permit and enqueue a persist job.
     ///
     /// This is modified using [`Ordering::SeqCst`] as performance is not a
     /// priority for code paths that modify it.
-    ///
-    /// [`PersistHandle::queue_persist()`]:
-    ///     super::handle::PersistHandle::queue_persist()
     waiting_to_enqueue: Arc<AtomicUsize>,
 
     /// The persist task semaphore with a maximum of `persist_queue_depth`

--- a/ingester2/src/persist/drain_buffer.rs
+++ b/ingester2/src/persist/drain_buffer.rs
@@ -1,0 +1,75 @@
+use std::{fmt::Debug, future};
+
+use futures::{stream, StreamExt};
+use observability_deps::tracing::debug;
+use tokio::time::Instant;
+
+use crate::buffer_tree::BufferTree;
+
+use super::handle::PersistHandle;
+
+/// [`PERSIST_ENQUEUE_CONCURRENCY`] defines the parallelism used when acquiring
+/// partition locks and marking the partition as persisting.
+const PERSIST_ENQUEUE_CONCURRENCY: usize = 5;
+
+// Drain the [`BufferTree`] of partition data and persist each one. Blocks for
+// completion of all enqueued persist jobs.
+//
+// This call is not atomic, partitions are marked for persistence incrementally.
+// Writes that landed into the partition buffer after this call, but before the
+// partition data is read will be included in the persisted data.
+pub(crate) async fn persist_buffer<O>(buffer: &BufferTree<O>, persist: PersistHandle)
+where
+    O: Send + Sync + Debug,
+{
+    let notifications = stream::iter(buffer.partitions())
+        .filter_map(|p| {
+            async move {
+                let t = Instant::now();
+
+                // Skip this partition if there is no data to persist
+                let data = p.lock().mark_persisting()?;
+
+                debug!(
+                    partition_id=data.partition_id().get(),
+                    lock_wait=?Instant::now().duration_since(t),
+                    "read data for persistence"
+                );
+
+                // Enqueue the partition for persistence.
+                //
+                // The persist task will call mark_persisted() on the partition
+                // once complete.
+                // Some(future::ready(persist.queue_persist(p, data).await))
+                Some(future::ready((p, data)))
+            }
+        })
+        // Concurrently attempt to obtain partition locks and mark them as
+        // persisting. This will hide the latency of individual lock
+        // acquisitions.
+        .buffer_unordered(PERSIST_ENQUEUE_CONCURRENCY)
+        // Serialise adding partitions to the persist queue (a fast
+        // operation that doesn't benefit from contention at all).
+        .then(|(p, data)| {
+            let persist = persist.clone();
+
+            // Enqueue and retain the notification receiver, which will be
+            // awaited later.
+            #[allow(clippy::async_yields_async)]
+            async move {
+                persist.queue_persist(p, data).await
+            }
+        })
+        .collect::<Vec<_>>()
+        .await;
+
+    debug!(
+        n_partitions = notifications.len(),
+        "queued all non-empty partitions for persist"
+    );
+
+    // Wait for all the persist completion notifications.
+    for n in notifications {
+        n.await.expect("persist worker task panic");
+    }
+}

--- a/ingester2/src/persist/drain_buffer.rs
+++ b/ingester2/src/persist/drain_buffer.rs
@@ -22,7 +22,7 @@ const PERSIST_ENQUEUE_CONCURRENCY: usize = 5;
 pub(crate) async fn persist_partitions<T, P>(iter: T, persist: P)
 where
     T: Iterator<Item = Arc<Mutex<PartitionData>>> + Send,
-    P: PersistQueue,
+    P: PersistQueue + Clone,
 {
     let notifications = stream::iter(iter)
         .filter_map(|p| {

--- a/ingester2/src/persist/hot_partitions.rs
+++ b/ingester2/src/persist/hot_partitions.rs
@@ -15,7 +15,7 @@ pub(crate) struct HotPartitionPersister<P> {
 
 impl<P> HotPartitionPersister<P>
 where
-    P: PersistQueue + Sync + 'static,
+    P: PersistQueue + Clone + Sync + 'static,
 {
     pub fn new(persist_handle: P, max_estimated_persist_cost: usize) -> Self {
         Self {
@@ -52,7 +52,7 @@ where
 
 impl<P> PostWriteObserver for HotPartitionPersister<P>
 where
-    P: PersistQueue + Sync + 'static,
+    P: PersistQueue + Clone + Sync + 'static,
 {
     #[inline(always)]
     fn observe(&self, partition: Arc<Mutex<PartitionData>>, guard: MutexGuard<'_, PartitionData>) {

--- a/ingester2/src/persist/mod.rs
+++ b/ingester2/src/persist/mod.rs
@@ -4,4 +4,5 @@ mod context;
 pub(crate) mod drain_buffer;
 pub(crate) mod handle;
 pub(crate) mod hot_partitions;
+pub(crate) mod queue;
 mod worker;

--- a/ingester2/src/persist/mod.rs
+++ b/ingester2/src/persist/mod.rs
@@ -1,6 +1,7 @@
 pub(crate) mod backpressure;
 pub(super) mod compact;
 mod context;
+pub(crate) mod drain_buffer;
 pub(crate) mod handle;
 pub(crate) mod hot_partitions;
 mod worker;

--- a/ingester2/src/persist/queue.rs
+++ b/ingester2/src/persist/queue.rs
@@ -1,0 +1,26 @@
+use std::{fmt::Debug, sync::Arc};
+
+use async_trait::async_trait;
+use parking_lot::Mutex;
+use tokio::sync::oneshot;
+
+use crate::buffer_tree::partition::{persisting::PersistingData, PartitionData};
+
+/// An abstract logical queue into which [`PersistingData`] (and their matching
+/// [`PartitionData`]) are placed to be persisted.
+///
+/// Implementations MAY reorder persist jobs placed in this queue, and MAY block
+/// indefinitely.
+///
+/// It is a logical error to enqueue a [`PartitionData`] with a
+/// [`PersistingData`] from another instance.
+#[async_trait]
+pub(crate) trait PersistQueue: Clone + Send + Sync + Debug {
+    /// Place `data` from `partition` into the persistence queue,
+    /// (asynchronously) blocking until enqueued.
+    async fn enqueue(
+        &self,
+        partition: Arc<Mutex<PartitionData>>,
+        data: PersistingData,
+    ) -> oneshot::Receiver<()>;
+}

--- a/ingester2/src/wal/rotate_task.rs
+++ b/ingester2/src/wal/rotate_task.rs
@@ -39,7 +39,7 @@ pub(crate) async fn periodic_rotation<T, P>(
     persist: P,
 ) where
     T: PartitionIter + Sync,
-    P: PersistQueue,
+    P: PersistQueue + Clone,
 {
     let mut interval = tokio::time::interval(period);
 

--- a/ingester2/src/wal/rotate_task.rs
+++ b/ingester2/src/wal/rotate_task.rs
@@ -4,7 +4,7 @@ use std::{fmt::Debug, sync::Arc, time::Duration};
 
 use crate::{
     buffer_tree::partition::PartitionData,
-    persist::{drain_buffer::persist_partitions, handle::PersistHandle},
+    persist::{drain_buffer::persist_partitions, queue::PersistQueue},
 };
 
 /// An abstraction over any type that can yield an iterator of (potentially
@@ -32,13 +32,14 @@ where
 }
 
 /// Rotate the `wal` segment file every `period` duration of time.
-pub(crate) async fn periodic_rotation<T>(
+pub(crate) async fn periodic_rotation<T, P>(
     wal: Arc<wal::Wal>,
     period: Duration,
     buffer: T,
-    persist: PersistHandle,
+    persist: P,
 ) where
     T: PartitionIter + Sync,
+    P: PersistQueue,
 {
     let mut interval = tokio::time::interval(period);
 


### PR DESCRIPTION
Decoupling! 🚀 

Everything in ingester2 that enqueued partitions for persistence was **painfully** coupled to the `PersistHandle`. This made it difficult to test, and reuse. It's also just good engineering practice to depend on _behaviours_ rather than types.

There is no new code in this PR, only new abstractions & reusability.

Pre-requisite to the fix for #6461 which needs `PartitionIter`.

---

* refactor: extract BufferTree persist helper (e54896e5f)

      Extract an existing function for re-use (from the WAL rotation task)
      that marks & enqueues all non-empty partitions in a BufferTree for
      persistence.

* refactor(persist): decoupled PartitionIter (dee9743e5)

      The persist_buffer() fn iterates over all the partitions in a BufferTree
      and persists them - however it only depends on one behaviour; getting an
      iterator of partitions.
      
      This commit introduces the PartitionIter, an abstraction over anything
      that can produce an iterator of PartitionData, decoupling the
      persist_buffer() helper (and the callers!) from the concrete BufferTree
      type.

* refactor(ingester2): decouple persist subsystem (26eea6078)

      Multiple components of the ingester depend on being able to enqueue a
      partition's data for persistence. This commit decouples those components
      from the concrete PersistHandle by introducing a PersistQueue trait that
      defines the desired behaviour, on which the components depend.
      
      This is a much needed clean-up of something I knowingly punted on for
      the MVP, and I feel much better about the situation now!

* refactor(persist): no PersistQueue Clone bound (456368f71)

      Removes the Clone bound from PersistQueue, also removing the Clone impl
      from the PersistHandle.
      
      Instead of wrapping all internal PersistHandle state in Arcs, this
      commit changes the system to use a single Arc wrapping the PersistHandle
      which is shared.