### PR TITLE
fix: drop WAL segments after replay

### DIFF
--- a/ingester2/Cargo.toml
+++ b/ingester2/Cargo.toml
@@ -41,6 +41,7 @@ schema = { version = "0.1.0", path = "../schema" }
 service_grpc_catalog = { version = "0.1.0", path = "../service_grpc_catalog" }
 sharder = { version = "0.1.0", path = "../sharder" }
 thiserror = "1.0.38"
+test_helpers = { path = "../test_helpers", features = ["future_timeout"], optional = true }
 tokio = { version = "1.22", features = ["macros", "parking_lot", "rt-multi-thread", "sync", "time"] }
 tonic = "0.8.3"
 trace = { version = "0.1.0", path = "../trace" }
@@ -59,7 +60,7 @@ tempfile = "3.3.0"
 test_helpers = { path = "../test_helpers", features = ["future_timeout"] }
 
 [features]
-benches = [] # Export some internal types for benchmark purposes only.
+benches = ["test_helpers"] # Export some internal types for benchmark purposes only.
 
 [lib]
 bench = false

--- a/ingester2/src/buffer_tree/mod.rs
+++ b/ingester2/src/buffer_tree/mod.rs
@@ -8,3 +8,7 @@ mod root;
 pub(crate) use root::*;
 
 pub(crate) mod post_write;
+
+maybe_pub! {
+    pub use super::partition::PartitionData;
+}

--- a/ingester2/src/buffer_tree/partition.rs
+++ b/ingester2/src/buffer_tree/partition.rs
@@ -41,7 +41,7 @@ impl SortKeyState {
 /// Data of an IOx Partition of a given Table of a Namespace that belongs to a
 /// given Shard
 #[derive(Debug)]
-pub(crate) struct PartitionData {
+pub struct PartitionData {
     /// The catalog ID of the partition this buffer is for.
     partition_id: PartitionId,
     /// The string partition key for this partition.
@@ -123,7 +123,7 @@ impl PartitionData {
     }
 
     /// Buffer the given [`MutableBatch`] in memory.
-    pub(super) fn buffer_write(
+    pub(crate) fn buffer_write(
         &mut self,
         mb: MutableBatch,
         sequence_number: SequenceNumber,

--- a/ingester2/src/buffer_tree/partition/persisting.rs
+++ b/ingester2/src/buffer_tree/partition/persisting.rs
@@ -38,7 +38,7 @@ impl Display for BatchIdent {
 /// [`PartitionData::mark_persisting()`]: super::PartitionData::mark_persisting
 /// [`PartitionData::mark_persisted()`]: super::PartitionData::mark_persisted
 #[derive(Debug, Clone)]
-pub(crate) struct PersistingData {
+pub struct PersistingData {
     data: QueryAdaptor,
     batch_ident: BatchIdent,
 }

--- a/ingester2/src/dml_sink/trait.rs
+++ b/ingester2/src/dml_sink/trait.rs
@@ -4,6 +4,7 @@ use async_trait::async_trait;
 use dml::DmlOperation;
 use thiserror::Error;
 
+/// Errors returned due from calls to [`DmlSink::apply()`].
 #[derive(Debug, Error)]
 pub enum DmlError {
     /// An error applying a [`DmlOperation`] to a [`BufferTree`].
@@ -20,6 +21,8 @@ pub enum DmlError {
 /// A [`DmlSink`] handles [`DmlOperation`] instances in some abstract way.
 #[async_trait]
 pub trait DmlSink: Debug + Send + Sync {
+    /// The concrete error type returned by a [`DmlSink`] implementation,
+    /// convertible to a [`DmlError`].
     type Error: Error + Into<DmlError> + Send;
 
     /// Apply `op` to the implementer's state.

--- a/ingester2/src/init.rs
+++ b/ingester2/src/init.rs
@@ -1,6 +1,8 @@
 crate::maybe_pub!(
-    mod wal_replay;
+    pub use super::wal_replay::*;
 );
+
+mod wal_replay;
 
 use std::{path::PathBuf, sync::Arc, time::Duration};
 
@@ -252,7 +254,7 @@ pub async fn new(
     let wal = Wal::new(wal_directory).await.map_err(InitError::WalInit)?;
 
     // Replay the WAL log files, if any.
-    let max_sequence_number = wal_replay::replay(&wal, &buffer)
+    let max_sequence_number = wal_replay::replay(&wal, &buffer, Arc::clone(&persist_handle))
         .await
         .map_err(|e| InitError::WalReplay(e.into()))?;
 

--- a/ingester2/src/init/wal_replay.rs
+++ b/ingester2/src/init/wal_replay.rs
@@ -1,14 +1,16 @@
-use std::time::Instant;
 use data_types::{NamespaceId, PartitionKey, Sequence, SequenceNumber, TableId};
 use dml::{DmlMeta, DmlOperation, DmlWrite};
 use generated_types::influxdata::iox::wal::v1::sequenced_wal_op::Op;
 use mutable_batch_pb::decode::decode_database_batch;
 use observability_deps::tracing::*;
+use std::time::Instant;
 use thiserror::Error;
 use wal::{SequencedWalOp, Wal};
 
 use crate::{
     dml_sink::{DmlError, DmlSink},
+    persist::{drain_buffer::persist_partitions, queue::PersistQueue},
+    wal::rotate_task::PartitionIter,
     TRANSITION_SHARD_INDEX,
 };
 
@@ -41,9 +43,14 @@ pub enum WalReplayError {
 
 /// Replay all the entries in `wal` to `sink`, returning the maximum observed
 /// [`SequenceNumber`].
-pub async fn replay<T>(wal: &Wal, sink: &T) -> Result<Option<SequenceNumber>, WalReplayError>
+pub async fn replay<T, P>(
+    wal: &Wal,
+    sink: &T,
+    persist: P,
+) -> Result<Option<SequenceNumber>, WalReplayError>
 where
-    T: DmlSink,
+    T: DmlSink + PartitionIter,
+    P: PersistQueue + Clone,
 {
     // Read the set of files to replay.
     //
@@ -111,6 +118,30 @@ where
                 }
             }
         };
+
+        info!(
+            file_number,
+            n_files,
+            file_id = %file.id(),
+            size = file.size(),
+            "persisting wal segment data"
+        );
+
+        // Persist all the data that was replayed from the WAL segment.
+        persist_partitions(sink.partition_iter(), persist.clone()).await;
+
+        // Drop the newly persisted data - it should not be replayed.
+        wal.delete(file.id())
+            .await
+            .expect("failed to drop wal segment");
+
+        info!(
+            file_number,
+            n_files,
+            file_id = %file.id(),
+            size = file.size(),
+            "dropped persisted wal segment"
+        );
     }
 
     info!(
@@ -146,10 +177,14 @@ where
         };
 
         for op in ops {
-            let SequencedWalOp{sequence_number, op} = op;
+            let SequencedWalOp {
+                sequence_number,
+                op,
+            } = op;
 
-            let sequence_number =
-                SequenceNumber::new(i64::try_from(sequence_number).expect("sequence number overflow"));
+            let sequence_number = SequenceNumber::new(
+                i64::try_from(sequence_number).expect("sequence number overflow"),
+            );
 
             max_sequence = max_sequence.max(Some(sequence_number));
 
@@ -196,24 +231,51 @@ where
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
+    use std::{sync::Arc, time::Duration};
 
     use assert_matches::assert_matches;
-    use data_types::{NamespaceId, PartitionKey, TableId};
+    use async_trait::async_trait;
+    use data_types::{NamespaceId, PartitionId, PartitionKey, ShardId, TableId};
+    use parking_lot::Mutex;
     use wal::Wal;
 
     use crate::{
+        buffer_tree::partition::{PartitionData, SortKeyState},
+        deferred_load::DeferredLoad,
         dml_sink::mock_sink::MockDmlSink,
+        persist::queue::mock::MockPersistQueue,
         test_util::{assert_dml_writes_eq, make_write_op},
         wal::wal_sink::WalSink,
     };
 
     use super::*;
 
+    const PARTITION_ID: PartitionId = PartitionId::new(42);
     const TABLE_ID: TableId = TableId::new(44);
     const TABLE_NAME: &str = "bananas";
     const NAMESPACE_NAME: &str = "platanos";
     const NAMESPACE_ID: NamespaceId = NamespaceId::new(42);
+
+    #[derive(Debug)]
+    struct MockIter {
+        sink: MockDmlSink,
+        partitions: Vec<Arc<Mutex<PartitionData>>>,
+    }
+
+    impl PartitionIter for MockIter {
+        fn partition_iter(&self) -> Box<dyn Iterator<Item = Arc<Mutex<PartitionData>>> + Send> {
+            Box::new(self.partitions.clone().into_iter())
+        }
+    }
+
+    #[async_trait]
+    impl DmlSink for MockIter {
+        type Error = <MockDmlSink as DmlSink>::Error;
+
+        async fn apply(&self, op: DmlOperation) -> Result<(), Self::Error> {
+            self.sink.apply(op).await
+        }
+    }
 
     #[tokio::test]
     async fn test_replay() {
@@ -286,20 +348,71 @@ mod tests {
             .await
             .expect("failed to initialise WAL");
 
-        // Replay the results into a mock to capture the DmlWrites
+        assert_eq!(wal.closed_segments().len(), 2);
+
+        // Initialise the mock persist system
+        let persist = Arc::new(MockPersistQueue::default());
+
+        // Replay the results into a mock to capture the DmlWrites and returns
+        // some dummy partitions when iterated over.
         let mock_sink = MockDmlSink::default().with_apply_return(vec![Ok(()), Ok(()), Ok(())]);
-        let max_sequence_number = replay(&wal, &mock_sink)
+        let mut partition = PartitionData::new(
+            PARTITION_ID,
+            PartitionKey::from("bananas"),
+            NAMESPACE_ID,
+            Arc::new(DeferredLoad::new(Duration::from_secs(1), async {
+                NAMESPACE_NAME.into()
+            })),
+            TABLE_ID,
+            Arc::new(DeferredLoad::new(Duration::from_secs(1), async {
+                TABLE_NAME.into()
+            })),
+            SortKeyState::Provided(None),
+            ShardId::new(1234),
+        );
+        // Put at least one write into the buffer so it is a candidate for persistence
+        partition
+            .buffer_write(
+                op1.tables().next().unwrap().1.clone(),
+                SequenceNumber::new(1),
+            )
+            .unwrap();
+        let mock_iter = MockIter {
+            sink: mock_sink,
+            partitions: vec![Arc::new(Mutex::new(partition))],
+        };
+
+        let max_sequence_number = replay(&wal, &mock_iter, Arc::clone(&persist))
             .await
             .expect("failed to replay WAL");
 
         assert_eq!(max_sequence_number, Some(SequenceNumber::new(42)));
 
-        // Assert the ops were pushed into the DmlSink
-        let ops = mock_sink.get_calls();
+        // Assert the ops were pushed into the DmlSink exactly as generated.
+        let ops = mock_iter.sink.get_calls();
         assert_matches!(&*ops, &[DmlOperation::Write(ref w1),DmlOperation::Write(ref w2),DmlOperation::Write(ref w3)] => {
             assert_dml_writes_eq(w1.clone(), op1);
             assert_dml_writes_eq(w2.clone(), op2);
             assert_dml_writes_eq(w3.clone(), op3);
-        })
+        });
+
+        // Ensure all partitions were persisted
+        let calls = persist.calls();
+        assert_matches!(&*calls, [p] => {
+            assert_eq!(p.lock().partition_id(), PARTITION_ID);
+        });
+
+        // Ensure there were no partition persist panics.
+        Arc::try_unwrap(persist)
+            .expect("should be no more refs")
+            .join()
+            .await;
+
+        // Ensure the replayed segments were dropped
+        let wal = Wal::new(dir.path())
+            .await
+            .expect("failed to initialise WAL");
+
+        assert_eq!(wal.closed_segments().len(), 1);
     }
 }

--- a/ingester2/src/init/wal_replay.rs
+++ b/ingester2/src/init/wal_replay.rs
@@ -116,6 +116,8 @@ where
                         "error dropping empty wal segment",
                     );
                 }
+
+                continue;
             }
         };
 

--- a/ingester2/src/lib.rs
+++ b/ingester2/src/lib.rs
@@ -48,15 +48,26 @@ use data_types::ShardIndex;
 
 /// A macro to conditionally prepend `pub` to the inner tokens for benchmarking
 /// purposes, should the `benches` feature be enabled.
+///
+/// Call as `maybe_pub!(mod name)` to conditionally export a private module.
+///
+/// Call as `maybe_pub!( <block> )` to conditionally define a private module
+/// called "benches".
 #[macro_export]
 macro_rules! maybe_pub {
+    (mod $($t:tt)+) => {
+        #[cfg(feature = "benches")]
+        #[allow(missing_docs)]
+        pub mod $($t)+;
+        #[cfg(not(feature = "benches"))]
+        mod $($t)+;
+    };
     ($($t:tt)+) => {
         #[cfg(feature = "benches")]
         #[allow(missing_docs)]
-        pub $($t)+
-
-        #[cfg(not(feature = "benches"))]
-        $($t)+
+        pub mod benches {
+            $($t)+
+        }
     };
 }
 
@@ -85,19 +96,15 @@ pub use init::*;
 //
 
 mod arcmap;
-mod buffer_tree;
+maybe_pub!(mod buffer_tree);
 mod deferred_load;
-mod persist;
+maybe_pub!(mod dml_sink);
+maybe_pub!(mod persist);
 mod query;
 mod query_adaptor;
 pub(crate) mod server;
 mod timestamp_oracle;
-mod wal;
-
-// Conditionally exported for benchmark purposes.
-maybe_pub!(
-    mod dml_sink;
-);
+maybe_pub!(mod wal);
 
 #[cfg(test)]
 mod test_util;

--- a/ingester2/src/persist/mod.rs
+++ b/ingester2/src/persist/mod.rs
@@ -4,5 +4,5 @@ mod context;
 pub(crate) mod drain_buffer;
 pub(crate) mod handle;
 pub(crate) mod hot_partitions;
-pub(crate) mod queue;
+pub mod queue;
 mod worker;

--- a/ingester2/src/persist/queue.rs
+++ b/ingester2/src/persist/queue.rs
@@ -1,3 +1,5 @@
+//! A logical persistence queue abstraction.
+
 use std::{fmt::Debug, sync::Arc};
 
 use async_trait::async_trait;
@@ -15,7 +17,7 @@ use crate::buffer_tree::partition::{persisting::PersistingData, PartitionData};
 /// It is a logical error to enqueue a [`PartitionData`] with a
 /// [`PersistingData`] from another instance.
 #[async_trait]
-pub(crate) trait PersistQueue: Send + Sync + Debug {
+pub trait PersistQueue: Send + Sync + Debug {
     /// Place `data` from `partition` into the persistence queue,
     /// (asynchronously) blocking until enqueued.
     async fn enqueue(
@@ -37,5 +39,90 @@ where
         data: PersistingData,
     ) -> oneshot::Receiver<()> {
         (**self).enqueue(partition, data).await
+    }
+}
+
+maybe_pub! {
+    pub use super::mock::*;
+}
+
+#[cfg(any(test, feature = "benches"))]
+pub(crate) mod mock {
+    use std::{sync::Arc, time::Duration};
+
+    use test_helpers::timeout::FutureTimeout;
+    use tokio::task::JoinHandle;
+
+    use super::*;
+
+    #[derive(Debug, Default)]
+    struct State {
+        /// Observed PartitionData instances.
+        calls: Vec<Arc<Mutex<PartitionData>>>,
+        /// Spawned tasks that call [`PartitionData::mark_persisted()`] - may
+        /// have already terminated.
+        handles: Vec<JoinHandle<()>>,
+    }
+
+    impl Drop for State {
+        fn drop(&mut self) {
+            std::mem::take(&mut self.handles)
+                .into_iter()
+                .for_each(|h| h.abort());
+        }
+    }
+
+    /// A mock [`PersistQueue`] implementation.
+    #[derive(Debug, Default)]
+    pub struct MockPersistQueue {
+        state: Mutex<State>,
+    }
+
+    impl MockPersistQueue {
+        /// Return all observed [`PartitionData`].
+        pub fn calls(&self) -> Vec<Arc<Mutex<PartitionData>>> {
+            self.state.lock().calls.clone()
+        }
+
+        /// Wait for all outstanding mock persist jobs to complete, propagating
+        /// any panics.
+        pub async fn join(self) {
+            let handles = std::mem::take(&mut self.state.lock().handles);
+            for h in handles.into_iter() {
+                h.with_timeout_panic(Duration::from_secs(5))
+                    .await
+                    .expect("mock mark persist panic");
+            }
+        }
+    }
+
+    #[async_trait]
+    impl PersistQueue for MockPersistQueue {
+        #[allow(clippy::async_yields_async)]
+        async fn enqueue(
+            &self,
+            partition: Arc<Mutex<PartitionData>>,
+            data: PersistingData,
+        ) -> oneshot::Receiver<()> {
+            let (tx, rx) = oneshot::channel();
+
+            let mut guard = self.state.lock();
+            guard.calls.push(Arc::clone(&partition));
+
+            // Spawn a persist task that randomly completes (soon) in the
+            // future.
+            //
+            // This helps ensure a realistic mock, and that implementations do
+            // not depend on ordered persist operations (which the persist
+            // system does not provide).
+            guard.handles.push(tokio::spawn(async move {
+                let wait_ms: u64 = rand::random::<u64>() % 100;
+                tokio::time::sleep(Duration::from_millis(wait_ms)).await;
+                partition.lock().mark_persisted(data);
+                let _ = tx.send(());
+            }));
+
+            rx
+        }
     }
 }

--- a/ingester2/src/query_adaptor.rs
+++ b/ingester2/src/query_adaptor.rs
@@ -25,7 +25,7 @@ use schema::{merge::merge_record_batch_schemas, sort::SortKey, Projection, Schem
 ///
 /// [`PartitionData`]: crate::buffer_tree::partition::PartitionData
 #[derive(Debug, PartialEq, Clone)]
-pub(crate) struct QueryAdaptor {
+pub struct QueryAdaptor {
     /// The snapshot data from a partition.
     ///
     /// This MUST be non-pub(crate) / closed for modification / immutable to support

--- a/ingester2/src/wal/mod.rs
+++ b/ingester2/src/wal/mod.rs
@@ -7,3 +7,7 @@
 pub(crate) mod rotate_task;
 mod traits;
 pub(crate) mod wal_sink;
+
+maybe_pub! {
+    pub use super::rotate_task::*;
+}

--- a/ingester2/src/wal/rotate_task.rs
+++ b/ingester2/src/wal/rotate_task.rs
@@ -9,7 +9,8 @@ use crate::{
 
 /// An abstraction over any type that can yield an iterator of (potentially
 /// empty) [`PartitionData`].
-pub(crate) trait PartitionIter: Send + Debug {
+pub trait PartitionIter: Send + Debug {
+    /// Return the set of partitions in `self`.
     fn partition_iter(&self) -> Box<dyn Iterator<Item = Arc<Mutex<PartitionData>>> + Send>;
 }
 


### PR DESCRIPTION
Fixes #6461, but may slow down startup as we now wait for persistence to complete for each file before being "ready". As a nice side-effect, crash loops that make some progress (a file or two each time) will eventually recover automatically.

This can be optimised to allow something like:

* Replay file 1
* Enqueue persist jobs but do not wait for completion
* Replay file
* Enqueue persist job
* (persists for job 1 complete) -> drop file 1

But this approach must respect the saturation of the persist system (otherwise we're just moving the OOM problem to persisting data, rather than buffered data). Given there should rarely be many files, this doesn't seem like a big deal.

Now we have a bit of time, we need to increase the test coverage before making WAL replay more complicated - I'd love to get #6366 merged and then increase the coverage ASAP :+1:

---

* fix: drop WAL segments after replay (66f162823)

      Changes the WAL replay logic to:
      
          * Replay a segment file
          * Persist all replayed data
          * Drop segment file
          * ...repeat...
      
      This ensures old WAL segments are removed once their contents have been
      made durable, fixing #6461.