### PR TITLE
fix(router2): lazily connect to ingesters

### DIFF
--- a/router/src/dml_handlers/rpc_write/client.rs
+++ b/router/src/dml_handlers/rpc_write/client.rs
@@ -12,9 +12,19 @@ pub(super) trait WriteClient: Send + Sync + std::fmt::Debug {
     async fn write(&self, op: WriteRequest) -> Result<(), RpcWriteError>;
 }
 
-/// An implementation of [`WriteClient`] for the tonic gRPC client.
+/// An implementation of [`WriteClient`] for the bespoke IOx wrapper over the
+/// tonic gRPC client.
 #[async_trait]
 impl WriteClient for WriteServiceClient<client_util::connection::GrpcConnection> {
+    async fn write(&self, op: WriteRequest) -> Result<(), RpcWriteError> {
+        WriteServiceClient::write(&mut self.clone(), op).await?;
+        Ok(())
+    }
+}
+
+/// An implementation of [`WriteClient`] for the tonic gRPC client.
+#[async_trait]
+impl WriteClient for WriteServiceClient<tonic::transport::Channel> {
     async fn write(&self, op: WriteRequest) -> Result<(), RpcWriteError> {
         WriteServiceClient::write(&mut self.clone(), op).await?;
         Ok(())


### PR DESCRIPTION
As per the commit message, this has (minor) downsides. I'll add a comment to #6173 that should include improving this logic.

Fixes #6503.

---

* fix(router2): lazily connect to ingesters (a5a26f5ef)

      Allow the routers to start up without requiring full availability of all
      downstream ingesters. Previously a single unavailable ingester prevented
      the routers from starting up.
      
      This has downsides:
      
        * Lazily initialising a connection will cause the first writes to have
          higher latency as the connection is established.
        * The routers MAY come up in a state that will never work (i.e. bad
          ingester addresses)
        * Using the opaque gRPC load balancing mechanism restricts the
          visibility into which nodes are up/down (hindering useful log
          messages) and prevents us from implementing more advanced circuit
          breaking / probing logic / load-balancing strategies.
      
      This change is a quick fix - it leaves the round-robin handler in place,
      load-balancing over a single tonic Channel, which internally
      load-balances. This will need cleaning up.

