### PR TITLE
fix(router2): drive ingester node (re)-discovery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4626,6 +4626,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tonic",
+ "tower",
  "trace",
  "workspace-hack",
  "write_buffer",

--- a/router/Cargo.toml
+++ b/router/Cargo.toml
@@ -43,6 +43,7 @@ trace = { path = "../trace/" }
 workspace-hack = { path = "../workspace-hack"}
 write_buffer = { path = "../write_buffer" }
 write_summary = { path = "../write_summary" }
+tower = { version = "0.4.13", features = ["balance"] }
 
 [dev-dependencies]
 assert_matches = "1.5"


### PR DESCRIPTION
I'm not sure the upstream tonic/tower load-balancing implementation works as it should for a static list of endpoints. See https://github.com/hyperium/tonic/issues/1147.

Hopefully fixes https://github.com/influxdata/influxdb_iox/issues/6508.

---

* fix(router2): drive ingester node (re)-discovery (9ab86fa15)

      The tonic / tower load-balance implementation discards failed nodes,
      even when using a static list - this causes nodes that fail once to
      never be retried.
      
      This doesn't happen for the last node for some reason, and leads to all
      the load from one router hitting a single ingester instead of load
      balancing across all ingesters.
      
      This commit adds a hack to constantly tell the load balancer to probe
      all nodes, hopefully causing them to re-discover previously failed
      nodes. I don't have the time to do this properly :(