### PR TITLE
docs: Update docstring on Schema

### DIFF
--- a/schema/src/lib.rs
+++ b/schema/src/lib.rs
@@ -105,20 +105,25 @@ pub type Result<T, E = Error> = std::result::Result<T, E>;
 
 /// Schema for an IOx table.
 ///
-/// This struct is a wrapper around an Arrow `SchemaRef` that knows
-/// how to create and interpret the "user defined metadata" added to that schema
-/// by IOx.
+/// This structure can be copied / cloned cheaply
+/// 
+/// Holds an Arrow [`SchemaRef`] that stores IOx schema information in
+/// the "user defined metadata".
 ///
-/// The metadata can be used to map back and forth to the InfluxDB
+/// The metadata can be used to map back and forth between the Arrow data model 
+/// (e.g. [`DataType`]) and the to the InfluxDB
 /// data model, which is described in the
 /// [documentation](https://docs.influxdata.com/influxdb/v2.0/reference/syntax/line-protocol/).
 ///
 /// Specifically, each column in the Arrow schema has a corresponding
-/// InfluxDB data model type of Tag, Field or Timestamp which is stored in
-/// the metadata field of the ArrowSchemaRef
+/// InfluxDB data model type of `Tag`, `Field` or `Timestamp` which is stored in
+/// the metadata field of the [`SchemaRef`].
+///
+/// [`SchemaRef`]: arrow::datatypes::SchemaRef
+/// [`DataType`]: arrow::datatypes::DataType
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Schema {
-    /// All the actual data lives on the metadata structure in
+    /// Refcount to underlying Arrow Schema All the actual data lives on the metadata structure in
     /// `ArrowSchemaRef` and this structure knows how to access that
     /// metadata
     inner: ArrowSchemaRef,

--- a/schema/src/lib.rs
+++ b/schema/src/lib.rs
@@ -106,11 +106,11 @@ pub type Result<T, E = Error> = std::result::Result<T, E>;
 /// Schema for an IOx table.
 ///
 /// This structure can be copied / cloned cheaply
-/// 
+///
 /// Holds an Arrow [`SchemaRef`] that stores IOx schema information in
 /// the "user defined metadata".
 ///
-/// The metadata can be used to map back and forth between the Arrow data model 
+/// The metadata can be used to map back and forth between the Arrow data model
 /// (e.g. [`DataType`]) and the to the InfluxDB
 /// data model, which is described in the
 /// [documentation](https://docs.influxdata.com/influxdb/v2.0/reference/syntax/line-protocol/).
@@ -123,7 +123,7 @@ pub type Result<T, E = Error> = std::result::Result<T, E>;
 /// [`DataType`]: arrow::datatypes::DataType
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Schema {
-    /// Reference-counted pointer to underlying Arrow Schema 
+    /// Reference-counted pointer to underlying Arrow Schema
     ///
     /// All the actual data lives on the metadata structure in
     /// `ArrowSchemaRef` and this structure knows how to access that

--- a/schema/src/lib.rs
+++ b/schema/src/lib.rs
@@ -123,7 +123,9 @@ pub type Result<T, E = Error> = std::result::Result<T, E>;
 /// [`DataType`]: arrow::datatypes::DataType
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Schema {
-    /// Refcount to underlying Arrow Schema All the actual data lives on the metadata structure in
+    /// Reference-counted pointer to underlying Arrow Schema 
+    ///
+    /// All the actual data lives on the metadata structure in
     /// `ArrowSchemaRef` and this structure knows how to access that
     /// metadata
     inner: ArrowSchemaRef,


### PR DESCRIPTION
Update docstrings on the `Schema` to clarify it is cheaply cloneable, inspired by @tustvold 's PR https://github.com/influxdata/influxdb_iox/pull/6511

- [ ] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb_iox/blob/main/README.md).
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
