### PR TITLE
refactor: remove atty & bump tokio

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2982,9 +2982,9 @@ checksum = "f88c5561171189e69df9d98bcf18fd5f9558300f7ea7b801eb8a0fd748bd8745"
 
 [[package]]
 name = "is-terminal"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "927609f78c2913a6f6ac3c27a4fe87f43e2a35367c0c4b0f8265e8f49a104330"
+checksum = "28dfb6c8100ccc63462345b67d1bbc3679177c75ee4bf59bf29c8b1d110b8189"
 dependencies = [
  "hermit-abi 0.2.6",
  "io-lifetimes",
@@ -5994,8 +5994,8 @@ dependencies = [
 name = "trogging"
 version = "0.1.0"
 dependencies = [
- "atty",
  "clap 4.0.32",
+ "is-terminal",
  "logfmt",
  "observability_deps",
  "regex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5627,9 +5627,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.22.0"
+version = "1.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d76ce4a75fb488c605c54bf610f221cea8b0dafb53333c1a67e8ee199dcd2ae3"
+checksum = "7125661431c26622a80ca5051a2f936c9a678318e0351007b0cc313143024e5c"
 dependencies = [
  "autocfg",
  "bytes",
@@ -5643,7 +5643,7 @@ dependencies = [
  "socket2",
  "tokio-macros",
  "tracing",
- "winapi",
+ "windows-sys",
 ]
 
 [[package]]

--- a/deny.toml
+++ b/deny.toml
@@ -11,6 +11,11 @@ ignore = [
     # why needed: used by `chrono`
     # upstream issue: https://github.com/chronotope/chrono/issues/553
     "RUSTSEC-2020-0071",
+
+    # potential unalinged read in atty
+    # https://rustsec.org/advisories/RUSTSEC-2021-0145
+    # Acceptable because only dependencies are dev/test (not used in prod code).
+    "RUSTSEC-2021-0145",
 ]
 git-fetch-with-cli = true
 

--- a/trogging/Cargo.toml
+++ b/trogging/Cargo.toml
@@ -7,8 +7,8 @@ edition.workspace = true
 license.workspace = true
 
 [dependencies]
-atty = "0.2.14"
 clap = { version = "4", features = ["derive", "env"], optional = true }
+is-terminal = "0.4.2"
 logfmt = { path = "../logfmt" }
 observability_deps = { path = "../observability_deps" }
 thiserror = "1.0.38"

--- a/trogging/src/lib.rs
+++ b/trogging/src/lib.rs
@@ -18,6 +18,7 @@ pub mod config;
 
 pub use config::*;
 
+use is_terminal::IsTerminal;
 // Re-export tracing_subscriber
 pub use tracing_subscriber;
 
@@ -75,7 +76,7 @@ impl Default for Builder {
             make_writer: io::stdout,
             with_target: true,
             // use ansi control codes for color if connected to a TTY
-            with_ansi: atty::is(atty::Stream::Stdout),
+            with_ansi: std::io::stdout().is_terminal(),
         }
     }
 }

--- a/workspace-hack/Cargo.toml
+++ b/workspace-hack/Cargo.toml
@@ -167,15 +167,15 @@ once_cell = { version = "1", default-features = false, features = ["unstable"] }
 [target.x86_64-pc-windows-msvc.dependencies]
 once_cell = { version = "1", default-features = false, features = ["unstable"] }
 scopeguard = { version = "1", features = ["use_std"] }
-tokio = { version = "1", default-features = false, features = ["winapi"] }
-winapi = { version = "0.3", default-features = false, features = ["accctrl", "aclapi", "activation", "basetsd", "combaseapi", "consoleapi", "errhandlingapi", "fileapi", "handleapi", "impl-debug", "impl-default", "knownfolders", "minwinbase", "minwindef", "namedpipeapi", "ntsecapi", "ntstatus", "objbase", "processenv", "roapi", "shellapi", "shlobj", "std", "stringapiset", "synchapi", "timezoneapi", "winbase", "wincon", "winerror", "winnt", "winreg", "winstring", "winuser", "ws2ipdef", "ws2tcpip", "wtypesbase"] }
+tokio = { version = "1", default-features = false, features = ["windows-sys"] }
+winapi = { version = "0.3", default-features = false, features = ["activation", "basetsd", "combaseapi", "consoleapi", "errhandlingapi", "fileapi", "handleapi", "impl-debug", "impl-default", "knownfolders", "minwinbase", "minwindef", "ntsecapi", "ntstatus", "objbase", "processenv", "roapi", "shellapi", "shlobj", "std", "stringapiset", "synchapi", "timezoneapi", "winbase", "wincon", "winerror", "winnt", "winreg", "winstring", "winuser", "ws2ipdef", "ws2tcpip", "wtypesbase"] }
 windows-sys = { version = "0.42", features = ["Win32", "Win32_Foundation", "Win32_Networking", "Win32_Networking_WinSock", "Win32_Security", "Win32_Storage", "Win32_Storage_FileSystem", "Win32_System", "Win32_System_Console", "Win32_System_IO", "Win32_System_LibraryLoader", "Win32_System_Pipes", "Win32_System_SystemServices", "Win32_System_Threading", "Win32_System_WindowsProgramming", "Win32_UI", "Win32_UI_Input", "Win32_UI_Input_KeyboardAndMouse"] }
 
 [target.x86_64-pc-windows-msvc.build-dependencies]
 once_cell = { version = "1", default-features = false, features = ["unstable"] }
 scopeguard = { version = "1", features = ["use_std"] }
-tokio = { version = "1", default-features = false, features = ["winapi"] }
-winapi = { version = "0.3", default-features = false, features = ["accctrl", "aclapi", "activation", "basetsd", "combaseapi", "consoleapi", "errhandlingapi", "fileapi", "handleapi", "impl-debug", "impl-default", "knownfolders", "minwinbase", "minwindef", "namedpipeapi", "ntsecapi", "ntstatus", "objbase", "processenv", "roapi", "shellapi", "shlobj", "std", "stringapiset", "synchapi", "timezoneapi", "winbase", "wincon", "winerror", "winnt", "winreg", "winstring", "winuser", "ws2ipdef", "ws2tcpip", "wtypesbase"] }
+tokio = { version = "1", default-features = false, features = ["windows-sys"] }
+winapi = { version = "0.3", default-features = false, features = ["activation", "basetsd", "combaseapi", "consoleapi", "errhandlingapi", "fileapi", "handleapi", "impl-debug", "impl-default", "knownfolders", "minwinbase", "minwindef", "ntsecapi", "ntstatus", "objbase", "processenv", "roapi", "shellapi", "shlobj", "std", "stringapiset", "synchapi", "timezoneapi", "winbase", "wincon", "winerror", "winnt", "winreg", "winstring", "winuser", "ws2ipdef", "ws2tcpip", "wtypesbase"] }
 windows-sys = { version = "0.42", features = ["Win32", "Win32_Foundation", "Win32_Networking", "Win32_Networking_WinSock", "Win32_Security", "Win32_Storage", "Win32_Storage_FileSystem", "Win32_System", "Win32_System_Console", "Win32_System_IO", "Win32_System_LibraryLoader", "Win32_System_Pipes", "Win32_System_SystemServices", "Win32_System_Threading", "Win32_System_WindowsProgramming", "Win32_UI", "Win32_UI_Input", "Win32_UI_Input_KeyboardAndMouse"] }
 
 ### END HAKARI SECTION


### PR DESCRIPTION
This unblocks CI: https://app.circleci.com/pipelines/github/influxdata/influxdb_iox/27576/workflows/1c554826-4058-4005-adeb-ad87167b3881/jobs/246465

bonus: is-terminal was already a dependency.

---

* refactor(trogging): remove atty dependency (fa6b07f3a)

      Replace atty with IsTerminal due to:
      
          https://rustsec.org/advisories/RUSTSEC-2021-0145

* ci: whitelist RUSTSEC-2021-0145 (6b090fae5)

      atty is used by criterion and mockito, both dev-only dependencies.

* chore: bump tokio 1.22 -> 1.24 (7f7f0ca17)

      Fixes a bug on windows:
      
      https://github.com/tokio-rs/tokio/security/advisories/GHSA-7rrj-xr53-82p7

