### PR TITLE
test: Record number of Parquet files before a write

### DIFF
--- a/generated_types/protos/influxdata/iox/catalog/v1/service.proto
+++ b/generated_types/protos/influxdata/iox/catalog/v1/service.proto
@@ -13,6 +13,9 @@ service CatalogService {
 
     // Get the parquet_file catalog records in the given namespace and table name
     rpc GetParquetFilesByNamespaceTable(GetParquetFilesByNamespaceTableRequest) returns (GetParquetFilesByNamespaceTableResponse);
+
+    // Get the parquet_file catalog records in the given namespace
+    rpc GetParquetFilesByNamespace(GetParquetFilesByNamespaceRequest) returns (GetParquetFilesByNamespaceResponse);
 }
 
 message GetParquetFilesByPartitionIdRequest {
@@ -61,5 +64,15 @@ message GetParquetFilesByNamespaceTableRequest {
 
 message GetParquetFilesByNamespaceTableResponse {
     // the parquet_file records in the table in the namespace
+    repeated ParquetFile parquet_files = 1;
+}
+
+message GetParquetFilesByNamespaceRequest {
+    // the namespace name
+    string namespace_name = 1;
+}
+
+message GetParquetFilesByNamespaceResponse {
+    // the parquet_file records in the namespace
     repeated ParquetFile parquet_files = 1;
 }

--- a/influxdb_iox/tests/end_to_end_cases/querier.rs
+++ b/influxdb_iox/tests/end_to_end_cases/querier.rs
@@ -904,7 +904,9 @@ mod kafkaless_rpc_write {
                 Step::RecordNumParquetFiles,
                 Step::WriteLineProtocol(format!("{},tag1=A,tag2=B val=42i 123456", table_name)),
                 // Wait for data to be persisted to parquet
-                Step::WaitForPersisted2,
+                Step::WaitForPersisted2 {
+                    expected_increase: 1,
+                },
                 Step::Query {
                     sql: format!("select * from {}", table_name),
                     expected: vec![
@@ -948,7 +950,9 @@ mod kafkaless_rpc_write {
             vec![
                 Step::RecordNumParquetFiles,
                 Step::WriteLineProtocol(format!("{},tag1=A,tag2=B val=42i 123456", table_name)),
-                Step::WaitForPersisted2,
+                Step::WaitForPersisted2 {
+                    expected_increase: 1,
+                },
                 Step::Query {
                     sql: format!("select * from {}", table_name),
                     expected: vec![
@@ -983,7 +987,9 @@ mod kafkaless_rpc_write {
             Step::RecordNumParquetFiles,
             Step::WriteLineProtocol(format!("{},tag1=A,tag2=B val=42i 123456", table_name)),
             // Wait for data to be persisted to parquet
-            Step::WaitForPersisted2,
+            Step::WaitForPersisted2 {
+                expected_increase: 1,
+            },
             Step::Query {
                 sql: format!("select * from {}", table_name),
                 expected: vec![
@@ -1009,7 +1015,9 @@ mod kafkaless_rpc_write {
             // write another parquet file that has non duplicated data
             Step::WriteLineProtocol(format!("{},tag1=B,tag2=A val=43i 789101112", table_name)),
             // Wait for data to be persisted to parquet
-            Step::WaitForPersisted2,
+            Step::WaitForPersisted2 {
+                expected_increase: 1,
+            },
             // query should correctly see the data in the second parquet file
             Step::Query {
                 sql: format!("select * from {}", table_name),

--- a/influxdb_iox/tests/end_to_end_cases/querier.rs
+++ b/influxdb_iox/tests/end_to_end_cases/querier.rs
@@ -901,6 +901,7 @@ mod kafkaless_rpc_write {
         StepTest::new(
             &mut cluster,
             vec![
+                Step::RecordNumParquetFiles,
                 Step::WriteLineProtocol(format!("{},tag1=A,tag2=B val=42i 123456", table_name)),
                 // Wait for data to be persisted to parquet
                 Step::WaitForPersisted2,
@@ -945,6 +946,7 @@ mod kafkaless_rpc_write {
         StepTest::new(
             &mut cluster,
             vec![
+                Step::RecordNumParquetFiles,
                 Step::WriteLineProtocol(format!("{},tag1=A,tag2=B val=42i 123456", table_name)),
                 Step::WaitForPersisted2,
                 Step::Query {
@@ -978,6 +980,7 @@ mod kafkaless_rpc_write {
         let mut cluster = MiniCluster::create_shared2(database_url).await;
 
         let steps = vec![
+            Step::RecordNumParquetFiles,
             Step::WriteLineProtocol(format!("{},tag1=A,tag2=B val=42i 123456", table_name)),
             // Wait for data to be persisted to parquet
             Step::WaitForPersisted2,
@@ -1002,6 +1005,7 @@ mod kafkaless_rpc_write {
                     "+------+------+--------------------------------+-----+",
                 ],
             },
+            Step::RecordNumParquetFiles,
             // write another parquet file that has non duplicated data
             Step::WriteLineProtocol(format!("{},tag1=B,tag2=A val=43i 789101112", table_name)),
             // Wait for data to be persisted to parquet

--- a/influxdb_iox/tests/end_to_end_cases/querier.rs
+++ b/influxdb_iox/tests/end_to_end_cases/querier.rs
@@ -903,9 +903,7 @@ mod kafkaless_rpc_write {
             vec![
                 Step::WriteLineProtocol(format!("{},tag1=A,tag2=B val=42i 123456", table_name)),
                 // Wait for data to be persisted to parquet
-                Step::WaitForPersisted2 {
-                    table_name: table_name.into(),
-                },
+                Step::WaitForPersisted2,
                 Step::Query {
                     sql: format!("select * from {}", table_name),
                     expected: vec![
@@ -948,9 +946,7 @@ mod kafkaless_rpc_write {
             &mut cluster,
             vec![
                 Step::WriteLineProtocol(format!("{},tag1=A,tag2=B val=42i 123456", table_name)),
-                Step::WaitForPersisted2 {
-                    table_name: table_name.into(),
-                },
+                Step::WaitForPersisted2,
                 Step::Query {
                     sql: format!("select * from {}", table_name),
                     expected: vec![
@@ -984,9 +980,7 @@ mod kafkaless_rpc_write {
         let steps = vec![
             Step::WriteLineProtocol(format!("{},tag1=A,tag2=B val=42i 123456", table_name)),
             // Wait for data to be persisted to parquet
-            Step::WaitForPersisted2 {
-                table_name: table_name.into(),
-            },
+            Step::WaitForPersisted2,
             Step::Query {
                 sql: format!("select * from {}", table_name),
                 expected: vec![
@@ -1011,9 +1005,7 @@ mod kafkaless_rpc_write {
             // write another parquet file that has non duplicated data
             Step::WriteLineProtocol(format!("{},tag1=B,tag2=A val=43i 789101112", table_name)),
             // Wait for data to be persisted to parquet
-            Step::WaitForPersisted2 {
-                table_name: table_name.into(),
-            },
+            Step::WaitForPersisted2,
             // query should correctly see the data in the second parquet file
             Step::Query {
                 sql: format!("select * from {}", table_name),

--- a/influxdb_iox_client/src/client/catalog.rs
+++ b/influxdb_iox_client/src/client/catalog.rs
@@ -66,4 +66,17 @@ impl Client {
 
         Ok(response.into_inner().parquet_files)
     }
+
+    /// Get the Parquet file records by their namespace
+    pub async fn get_parquet_files_by_namespace(
+        &mut self,
+        namespace_name: String,
+    ) -> Result<Vec<ParquetFile>, Error> {
+        let response = self
+            .inner
+            .get_parquet_files_by_namespace(GetParquetFilesByNamespaceRequest { namespace_name })
+            .await?;
+
+        Ok(response.into_inner().parquet_files)
+    }
 }

--- a/service_grpc_catalog/src/lib.rs
+++ b/service_grpc_catalog/src/lib.rs
@@ -126,6 +126,42 @@ impl catalog_service_server::CatalogService for CatalogService {
 
         Ok(Response::new(response))
     }
+
+    async fn get_parquet_files_by_namespace(
+        &self,
+        request: Request<GetParquetFilesByNamespaceRequest>,
+    ) -> Result<Response<GetParquetFilesByNamespaceResponse>, Status> {
+        let mut repos = self.catalog.repositories().await;
+        let req = request.into_inner();
+
+        let namespace = repos
+            .namespaces()
+            .get_by_name(&req.namespace_name)
+            .await
+            .map_err(|e| Status::unknown(e.to_string()))?
+            .ok_or_else(|| {
+                Status::not_found(format!("Namespace {} not found", req.namespace_name))
+            })?;
+
+        let parquet_files = repos
+            .parquet_files()
+            .list_by_namespace_not_to_delete(namespace.id)
+            .await
+            .map_err(|e| {
+                warn!(
+                    error=%e,
+                    %req.namespace_name,
+                    "failed to get parquet_files for namespace"
+                );
+                Status::not_found(e.to_string())
+            })?;
+
+        let parquet_files: Vec<_> = parquet_files.into_iter().map(to_parquet_file).collect();
+
+        let response = GetParquetFilesByNamespaceResponse { parquet_files };
+
+        Ok(Response::new(response))
+    }
 }
 
 // converts the catalog ParquetFile to protobuf

--- a/test_helpers_end_to_end/src/steps.rs
+++ b/test_helpers_end_to_end/src/steps.rs
@@ -1,13 +1,15 @@
 use crate::{
     check_flight_error, get_write_token, run_influxql, run_sql, token_is_persisted,
-    try_run_influxql, try_run_sql, wait_for_new_parquet_file, wait_for_persisted,
-    wait_for_readable, MiniCluster,
+    try_run_influxql, try_run_sql, wait_for_persisted, wait_for_readable, MiniCluster,
 };
 use arrow::record_batch::RecordBatch;
 use arrow_util::assert_batches_sorted_eq;
 use futures::future::BoxFuture;
 use http::StatusCode;
 use observability_deps::tracing::info;
+use std::time::Duration;
+
+const MAX_QUERY_RETRY_TIME_SEC: u64 = 20;
 
 /// Test harness for end to end tests that are comprised of several steps
 pub struct StepTest<'a> {
@@ -24,6 +26,11 @@ pub struct StepTestState<'a> {
 
     /// Tokens for all data written in WriteLineProtocol steps
     write_tokens: Vec<String>,
+
+    /// How many Parquet files the catalog service knows about for the mini cluster's namespace,
+    /// for tracking when persistence has happened. If this is `None`, we haven't ever checked with
+    /// the catalog service.
+    num_parquet_files: Option<usize>,
 }
 
 impl<'a> StepTestState<'a> {
@@ -43,6 +50,55 @@ impl<'a> StepTestState<'a> {
     #[must_use]
     pub fn write_tokens(&self) -> &[String] {
         self.write_tokens.as_ref()
+    }
+
+    /// Store the number of Parquet files the catalog has for the mini cluster's namespace.
+    /// Call this before a write to be able to tell when a write has been persisted by checking for
+    /// a change in this count.
+    pub async fn record_num_parquet_files(&mut self) {
+        let num_parquet_files = self.get_num_parquet_files().await;
+
+        info!(
+            "Recorded count of Parquet files for namespace {}: {num_parquet_files}",
+            self.cluster.namespace()
+        );
+        self.num_parquet_files = Some(num_parquet_files);
+    }
+
+    /// Wait for a change (up to a timeout) in the number of Parquet files the catalog has for the
+    /// mini cluster's namespacee since the last time the number of Parquet files was recorded,
+    /// which indicates persistence has taken place.
+    pub async fn wait_for_num_parquet_file_change(&mut self) {
+        let retry_duration = Duration::from_secs(MAX_QUERY_RETRY_TIME_SEC);
+
+        tokio::time::timeout(retry_duration, async move {
+            let mut interval = tokio::time::interval(Duration::from_millis(1000));
+            loop {
+                let current_count = self.get_num_parquet_files().await;
+                if Some(current_count) > self.num_parquet_files {
+                    info!("Success; Parquet file count is now {current_count}");
+                    self.num_parquet_files = Some(current_count);
+                    return;
+                }
+                info!("Retrying; Parquet file count is still {current_count}");
+
+                interval.tick().await;
+            }
+        })
+        .await
+        .expect("did not get additional Parquet files in the catalog");
+    }
+
+    /// Ask the catalog service how many Parquet files it has for the mini cluster's namespace.
+    async fn get_num_parquet_files(&self) -> usize {
+        let connection = self.cluster.router().router_grpc_connection();
+        let mut catalog_client = influxdb_iox_client::catalog::Client::new(connection);
+
+        catalog_client
+            .get_parquet_files_by_namespace(self.cluster.namespace().into())
+            .await
+            .map(|parquet_files| parquet_files.len())
+            .unwrap_or_default()
     }
 }
 
@@ -88,9 +144,9 @@ pub enum Step {
     WaitForPersisted,
 
     /// Wait for all previously written data to be persisted by observing an increase in the number
-    /// of Parquet files in the catalog for this cluster's namespace and the specified table name.
-    /// Needed for router2/ingester2/querier2.
-    WaitForPersisted2 { table_name: String },
+    /// of Parquet files in the catalog for this cluster's namespace. Needed for
+    /// router2/ingester2/querier2.
+    WaitForPersisted2,
 
     /// Ask the ingester if it has persisted the data. For use in tests where the querier doesn't
     /// know about the ingester, so the test needs to ask the ingester directly.
@@ -168,6 +224,7 @@ impl<'a> StepTest<'a> {
         let mut state = StepTestState {
             cluster,
             write_tokens: vec![],
+            num_parquet_files: Default::default(),
         };
 
         for (i, step) in steps.into_iter().enumerate() {
@@ -178,6 +235,9 @@ impl<'a> StepTest<'a> {
                         "====Begin writing line protocol to v2 HTTP API:\n{}",
                         line_protocol
                     );
+                    // Get the current number of Parquet files in the cluster's namespace before
+                    // starting a new write so we can observe a change when waiting for persistence.
+                    state.record_num_parquet_files().await;
                     let response = state.cluster.write_to_router(line_protocol).await;
                     assert_eq!(response.status(), StatusCode::NO_CONTENT);
                     let write_token = get_write_token(&response);
@@ -202,17 +262,10 @@ impl<'a> StepTest<'a> {
                     }
                     info!("====Done waiting for all write tokens to be persisted");
                 }
-                Step::WaitForPersisted2 { table_name } => {
-                    info!("====Begin waiting for a new Parquet file to be persisted");
-                    let querier_grpc_connection =
-                        state.cluster().querier().querier_grpc_connection();
-                    wait_for_new_parquet_file(
-                        querier_grpc_connection,
-                        state.cluster().namespace(),
-                        &table_name,
-                    )
-                    .await;
-                    info!("====Done waiting for a new Parquet file to be persisted");
+                Step::WaitForPersisted2 => {
+                    info!("====Begin waiting for a change in the number of Parquet files");
+                    state.wait_for_num_parquet_file_change().await;
+                    info!("====Done waiting for a change in the number of Parquet files");
                 }
                 // Specifically for cases when the querier doesn't know about the ingester so the
                 // test needs to ask the ingester directly.


### PR DESCRIPTION
Fixes #6506.

Also has the pleasant side effect of making this code simpler and less hacky-- it now checks the number of Parquet files for the whole namespace, which is useful in cases where the line protocol writes to several tables.