### PR TITLE
chore: bump rust to 1.66.1

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.66"
+channel = "1.66.1"
 components = [ "rustfmt", "clippy" ]


### PR DESCRIPTION
Use the newest rust release 🧹 

---

* chore: bump rust to 1.66.1 (e0dcfc883)

      Picks up a fix to SSH host authentication in cargo when pulling the
      crates index:
      
          https://blog.rust-lang.org/2023/01/10/cve-2022-46176.html