### PR TITLE
ci: use rust 1.66.0 for CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -392,6 +392,8 @@ jobs:
           command: |
             COMMIT_SHA="$(git rev-parse HEAD)"
 
+            # FIXME: revert this override - https://github.com/rust-lang/docker-rust/issues/128
+            # RUST_VERSION="$(sed -E -ne 's/channel = "(.*)"/\1/p' rust-toolchain.toml)"
             RUST_VERSION="1.66"
 
             docker buildx build \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -392,7 +392,7 @@ jobs:
           command: |
             COMMIT_SHA="$(git rev-parse HEAD)"
 
-            RUST_VERSION="$(sed -E -ne 's/channel = "(.*)"/\1/p' rust-toolchain.toml)"
+            RUST_VERSION="1.66"
 
             docker buildx build \
               --build-arg FEATURES="aws,gcp,azure,jemalloc_replacing_malloc,tokio_console,pprof" \


### PR DESCRIPTION
There's no rust 1.66.1 docker image: https://hub.docker.com/_/rust/tags

This lets us use the fixed cargo, and unblocks the failing CI / deployments on "main".

I will revert this when it's possible.

---

* ci: use rust 1.66.0 for CI (71f54528d)

      Temporary fix as there's no official 1.66.1 docker image (yet?), so use
      1.66 for now.
      
      I kept the toolchain version pinned and switched only the CI version so
      that we are all using the fixed cargo. I will revert this commit when
      there's a 1.66.1 image.