### PR TITLE
revert: "ci: use rust 1.66.0 for CI"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -392,9 +392,7 @@ jobs:
           command: |
             COMMIT_SHA="$(git rev-parse HEAD)"
 
-            # FIXME: revert this override - https://github.com/rust-lang/docker-rust/issues/128
-            # RUST_VERSION="$(sed -E -ne 's/channel = "(.*)"/\1/p' rust-toolchain.toml)"
-            RUST_VERSION="1.66"
+            RUST_VERSION="$(sed -E -ne 's/channel = "(.*)"/\1/p' rust-toolchain.toml)"
 
             docker buildx build \
               --build-arg FEATURES="aws,gcp,azure,jemalloc_replacing_malloc,tokio_console,pprof" \


### PR DESCRIPTION
There is now a [1.66.1 image](https://hub.docker.com/layers/library/rust/1.66.1-slim-buster/images/sha256-8c19cad1f738f87f56622d10f9aeaacf99a06d9fbed40f15ed37ea5b5660f505?context=explore).

---

* revert: "ci: use rust 1.66.0 for CI" (38eeffac0)

      This reverts commit 71f54528d086aee10bf046acaa954ccc7c0ddc5e.