### PR TITLE
refactor: delegate frontend shutdown to backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2642,6 +2642,7 @@ dependencies = [
  "test_helpers",
  "thiserror",
  "tokio",
+ "tokio-util",
  "tonic",
  "trace",
  "uuid",
@@ -2895,6 +2896,7 @@ dependencies = [
  "object_store",
  "parquet_file",
  "thiserror",
+ "tokio-util",
  "trace",
  "workspace-hack",
 ]
@@ -2912,6 +2914,7 @@ dependencies = [
  "observability_deps",
  "snafu",
  "tokio",
+ "tokio-util",
  "trace",
  "workspace-hack",
 ]
@@ -2951,6 +2954,7 @@ dependencies = [
  "metric",
  "object_store",
  "thiserror",
+ "tokio-util",
  "trace",
  "workspace-hack",
  "write_buffer",
@@ -2962,6 +2966,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "clap_blocks",
+ "futures",
  "hyper",
  "ingester2",
  "iox_catalog",
@@ -3001,6 +3006,7 @@ dependencies = [
  "sharder",
  "thiserror",
  "tokio",
+ "tokio-util",
  "tonic",
  "trace",
  "workspace-hack",

--- a/ingester2/Cargo.toml
+++ b/ingester2/Cargo.toml
@@ -48,6 +48,7 @@ trace = { version = "0.1.0", path = "../trace" }
 uuid = "1.2.2"
 wal = { version = "0.1.0", path = "../wal" }
 workspace-hack = { path = "../workspace-hack"}
+tokio-util = "0.7.4"
 
 [dev-dependencies]
 assert_matches = "1.5.0"

--- a/ingester2/src/init.rs
+++ b/ingester2/src/init.rs
@@ -20,6 +20,7 @@ use observability_deps::tracing::*;
 use parquet_file::storage::ParquetStorage;
 use thiserror::Error;
 use tokio::sync::oneshot;
+use tokio_util::sync::CancellationToken;
 use wal::Wal;
 
 use crate::{
@@ -198,7 +199,7 @@ pub async fn new<F>(
     shutdown: F,
 ) -> Result<IngesterGuard<impl IngesterRpcInterface>, InitError>
 where
-    F: Future<Output = ()> + Send + 'static,
+    F: Future<Output = CancellationToken> + Send + 'static,
 {
     // Create the transition shard.
     let mut txn = catalog

--- a/ioxd_common/src/server_type.rs
+++ b/ioxd_common/src/server_type.rs
@@ -6,6 +6,7 @@ use async_trait::async_trait;
 use hyper::{Body, Request, Response};
 use metric::Registry;
 use snafu::Snafu;
+use tokio_util::sync::CancellationToken;
 use trace::TraceCollector;
 
 pub use common_state::{CommonServerState, CommonServerStateError};
@@ -60,5 +61,9 @@ pub trait ServerType: std::fmt::Debug + Send + Sync + 'static {
     async fn join(self: Arc<Self>);
 
     /// Shutdown background worker.
-    fn shutdown(&self);
+    ///
+    /// The provided [`CancellationToken`] MUST be used by the background worker
+    /// to shutdown the "frontend" (HTTP & RPC servers) when appropriate - this
+    /// should happen before [`Self::join()`] returns.
+    fn shutdown(&self, frontend: CancellationToken);
 }

--- a/ioxd_compactor/Cargo.toml
+++ b/ioxd_compactor/Cargo.toml
@@ -25,3 +25,4 @@ hyper = "0.14"
 thiserror = "1.0.38"
 workspace-hack = { path = "../workspace-hack"}
 parquet_file = { version = "0.1.0", path = "../parquet_file" }
+tokio-util = "0.7.4"

--- a/ioxd_compactor/src/lib.rs
+++ b/ioxd_compactor/src/lib.rs
@@ -24,6 +24,7 @@ use std::{
     sync::Arc,
 };
 use thiserror::Error;
+use tokio_util::sync::CancellationToken;
 use trace::TraceCollector;
 
 #[derive(Debug, Error)]
@@ -99,7 +100,8 @@ impl<C: CompactorHandler + std::fmt::Debug + 'static> ServerType for CompactorSe
         self.server.join().await;
     }
 
-    fn shutdown(&self) {
+    fn shutdown(&self, frontend: CancellationToken) {
+        frontend.cancel();
         self.server.shutdown();
     }
 }

--- a/ioxd_garbage_collector/Cargo.toml
+++ b/ioxd_garbage_collector/Cargo.toml
@@ -17,3 +17,4 @@ snafu = "0.7"
 tokio = { version = "1", features = ["sync"] }
 trace = { path = "../trace" }
 workspace-hack = { path = "../workspace-hack"}
+tokio-util = "0.7.4"

--- a/ioxd_garbage_collector/src/lib.rs
+++ b/ioxd_garbage_collector/src/lib.rs
@@ -35,6 +35,7 @@ use metric::Registry;
 use snafu::prelude::*;
 use std::{fmt::Debug, sync::Arc, time::Duration};
 use tokio::{select, sync::broadcast, task::JoinError, time};
+use tokio_util::sync::CancellationToken;
 use trace::TraceCollector;
 
 pub use garbage_collector::{Config, SubConfig};
@@ -134,7 +135,8 @@ impl ServerType for Server {
             .unwrap_or_report();
     }
 
-    fn shutdown(&self) {
+    fn shutdown(&self, frontend: CancellationToken) {
+        frontend.cancel();
         self.shutdown_tx.send(()).ok();
     }
 }

--- a/ioxd_ingest_replica/Cargo.toml
+++ b/ioxd_ingest_replica/Cargo.toml
@@ -17,6 +17,6 @@ metric = { path = "../metric" }
 parquet_file = { version = "0.1.0", path = "../parquet_file" }
 thiserror = "1.0.38"
 tokio = { version = "1.22", features = ["macros", "net", "parking_lot", "rt-multi-thread", "signal", "sync", "time"] }
-tokio-util = { version = "0.7.4" }
+tokio-util = "0.7.4"
 trace = { path = "../trace" }
 workspace-hack = { path = "../workspace-hack"}

--- a/ioxd_ingest_replica/src/lib.rs
+++ b/ioxd_ingest_replica/src/lib.rs
@@ -101,7 +101,8 @@ impl<I: IngestReplicaRpcInterface + Sync + Send + Debug + 'static> ServerType
         self.shutdown.cancelled().await;
     }
 
-    fn shutdown(&self) {
+    fn shutdown(&self, frontend: CancellationToken) {
+        frontend.cancel();
         self.shutdown.cancel();
     }
 }

--- a/ioxd_ingester/Cargo.toml
+++ b/ioxd_ingester/Cargo.toml
@@ -23,3 +23,4 @@ async-trait = "0.1"
 hyper = "0.14"
 thiserror = "1.0.38"
 workspace-hack = { path = "../workspace-hack"}
+tokio-util = "0.7.4"

--- a/ioxd_ingester/src/lib.rs
+++ b/ioxd_ingester/src/lib.rs
@@ -26,6 +26,7 @@ use std::{
     time::Duration,
 };
 use thiserror::Error;
+use tokio_util::sync::CancellationToken;
 use trace::TraceCollector;
 
 #[derive(Debug, Error)]
@@ -105,7 +106,8 @@ impl<I: IngestHandler + Sync + Send + Debug + 'static> ServerType for IngesterSe
         self.server.join().await;
     }
 
-    fn shutdown(&self) {
+    fn shutdown(&self, frontend: CancellationToken) {
+        frontend.cancel();
         self.server.shutdown();
     }
 }

--- a/ioxd_ingester2/Cargo.toml
+++ b/ioxd_ingester2/Cargo.toml
@@ -8,6 +8,7 @@ license.workspace = true
 [dependencies] # In alphabetical order
 async-trait = "0.1"
 clap_blocks = { path = "../clap_blocks" }
+futures = "0.3.25"
 hyper = "0.14"
 ingester2 = { path = "../ingester2" }
 iox_catalog = { path = "../iox_catalog" }

--- a/ioxd_querier/Cargo.toml
+++ b/ioxd_querier/Cargo.toml
@@ -32,6 +32,7 @@ tokio = { version = "1.24", features = ["macros", "net", "parking_lot", "rt-mult
 tonic = "0.8"
 workspace-hack = { path = "../workspace-hack"}
 parquet_file = { version = "0.1.0", path = "../parquet_file" }
+tokio-util = "0.7.4"
 
 [dev-dependencies]
 # Workspace dependencies, in alphabetical order

--- a/ioxd_querier/src/lib.rs
+++ b/ioxd_querier/src/lib.rs
@@ -24,6 +24,7 @@ use std::{
 };
 use thiserror::Error;
 use tokio::runtime::Handle;
+use tokio_util::sync::CancellationToken;
 use trace::TraceCollector;
 
 mod rpc;
@@ -106,7 +107,8 @@ impl<C: QuerierHandler + std::fmt::Debug + 'static> ServerType for QuerierServer
         self.server.join().await;
     }
 
-    fn shutdown(&self) {
+    fn shutdown(&self, frontend: CancellationToken) {
+        frontend.cancel();
         self.server.shutdown();
     }
 }

--- a/ioxd_router/src/lib.rs
+++ b/ioxd_router/src/lib.rs
@@ -141,7 +141,8 @@ where
         self.shutdown.cancelled().await;
     }
 
-    fn shutdown(&self) {
+    fn shutdown(&self, frontend: CancellationToken) {
+        frontend.cancel();
         self.shutdown.cancel();
     }
 }
@@ -216,7 +217,8 @@ where
         self.shutdown.cancelled().await;
     }
 
-    fn shutdown(&self) {
+    fn shutdown(&self, frontend: CancellationToken) {
+        frontend.cancel();
         self.shutdown.cancel();
     }
 }

--- a/ioxd_test/Cargo.toml
+++ b/ioxd_test/Cargo.toml
@@ -16,5 +16,5 @@ async-trait = "0.1"
 clap = { version = "4", features = ["derive", "env"] }
 hyper = "0.14"
 snafu = "0.7"
-tokio-util = { version = "0.7.4" }
+tokio-util = "0.7.4"
 workspace-hack = { path = "../workspace-hack"}

--- a/ioxd_test/src/lib.rs
+++ b/ioxd_test/src/lib.rs
@@ -104,7 +104,8 @@ impl ServerType for TestServerType {
         self.shutdown.cancelled().await;
     }
 
-    fn shutdown(&self) {
+    fn shutdown(&self, frontend: CancellationToken) {
+        frontend.cancel();
         self.shutdown.cancel();
     }
 }


### PR DESCRIPTION
After this change, ingester2 can ensure the RPC server is stopped **after** the persist operations have completed:

```
INFO ingester2::init::graceful_shutdown: gracefully stopping ingester
INFO ingester2::init::graceful_shutdown: persisting all data before shutdown
INFO ingester2::init::graceful_shutdown: persisted all data - stopping ingester
INFO ioxd_common: frontend shutdown completed server_type=Ingester2
INFO ioxd_common: backend shutdown completed server_type=Ingester2
```

Fixes https://github.com/influxdata/influxdb_iox/issues/6578.

---

* refactor: delegate frontend shutdown to backend (0d111c467)

      Prior to this commit, the (happy path) shutdown sequence of an IOx
      process was hard coded to:
      
          1. Stop gRPC & HTTP servers
          2. Stop backend server (i.e. ingester2)
      
      After this commit, the execution of step 1 is delegated to the handler
      for step 2; the server implementation (router / ingester / querier /
      etc) now chooses when to shut down the RPC & HTTP servers.
      
      This allows the server shutdown delegate to correctly sequence the
      shutdown of all components of the IOx server. This allows ingester2 to
      correctly sequence the shutdown of the query RPC server w.r.t the
      graceful stop & persist, ensuring queries continue to be serviced.