### PR TITLE
perf: remove double-ref Partition map

### DIFF
--- a/ingester2/src/buffer_tree/namespace.rs
+++ b/ingester2/src/buffer_tree/namespace.rs
@@ -231,7 +231,7 @@ where
 mod tests {
     use std::{sync::Arc, time::Duration};
 
-    use data_types::{PartitionId, PartitionKey, ShardId, ShardIndex};
+    use data_types::{PartitionId, PartitionKey, ShardId};
     use metric::{Attributes, Metric};
 
     use super::*;
@@ -246,7 +246,6 @@ mod tests {
         test_util::make_write_op,
     };
 
-    const SHARD_INDEX: ShardIndex = ShardIndex::new(24);
     const TABLE_NAME: &str = "bananas";
     const TABLE_ID: TableId = TableId::new(44);
     const NAMESPACE_NAME: &str = "platanos";


### PR DESCRIPTION
Remove an unused extra mapping, and the shared mutex protecting it (used in the hot path) 🧹 

---

* perf: remove double-ref Partition map (8dc18a983)

      The ingester no longer needs to access a specific PartitionData by ID
      (they are addressed either via an iterator over the BufferTree, or
      shared by Arc reference).
      
      This allows us to remove the extra map maintaining ID -> PartitionData
      references, and the shared access lock protecting it.