### PR TITLE
refactor: use system-wide ingester ID

### DIFF
--- a/ingester2/src/ingester_id.rs
+++ b/ingester2/src/ingester_id.rs
@@ -1,0 +1,23 @@
+use std::fmt::Display;
+
+use uuid::Uuid;
+
+/// A unique, random, opaque UUID assigned at startup of an ingester.
+///
+/// This [`IngesterId`] uniquely identifies a single ingester process - it
+/// changes each time an ingester starts, reflecting the change of in-memory
+/// state between crashes/restarts.
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub(crate) struct IngesterId(Uuid);
+
+impl Display for IngesterId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl IngesterId {
+    pub(crate) fn new() -> Self {
+        Self(Uuid::new_v4())
+    }
+}

--- a/ingester2/src/init.rs
+++ b/ingester2/src/init.rs
@@ -34,6 +34,7 @@ use crate::{
         BufferTree,
     },
     ingest_state::IngestState,
+    ingester_id::IngesterId,
     persist::{handle::PersistHandle, hot_partitions::HotPartitionPersister},
     server::grpc::GrpcDelegate,
     timestamp_oracle::TimestampOracle,
@@ -227,6 +228,9 @@ where
         .expect("create transition shard");
     txn.commit().await.expect("commit transition shard");
 
+    // Initialise a random ID for this ingester instance.
+    let ingester_id = IngesterId::new();
+
     // Initialise the deferred namespace name resolver.
     let namespace_name_provider: Arc<dyn NamespaceNameProvider> =
         Arc::new(NamespaceNameResolver::new(
@@ -353,6 +357,7 @@ where
             Arc::clone(&buffer),
             timestamp,
             ingest_state,
+            ingester_id,
             catalog,
             metrics,
             buffer,

--- a/ingester2/src/lib.rs
+++ b/ingester2/src/lib.rs
@@ -95,18 +95,19 @@ pub use init::*;
 // through its public API only, and not by poking around at the internals.
 //
 
-mod arcmap;
 maybe_pub!(mod buffer_tree);
-mod deferred_load;
 maybe_pub!(mod dml_sink);
 maybe_pub!(mod persist);
 maybe_pub!(mod partition_iter);
+maybe_pub!(mod wal);
+mod arcmap;
+mod deferred_load;
 mod ingest_state;
+mod ingester_id;
 mod query;
 mod query_adaptor;
 pub(crate) mod server;
 mod timestamp_oracle;
-maybe_pub!(mod wal);
 
 #[cfg(test)]
 mod test_util;

--- a/ingester2/src/server/grpc.rs
+++ b/ingester2/src/server/grpc.rs
@@ -19,6 +19,7 @@ use service_grpc_catalog::CatalogService;
 use crate::{
     dml_sink::DmlSink,
     ingest_state::IngestState,
+    ingester_id::IngesterId,
     init::IngesterRpcInterface,
     partition_iter::PartitionIter,
     persist::queue::PersistQueue,
@@ -39,6 +40,7 @@ pub(crate) struct GrpcDelegate<D, Q, T, P> {
     query_exec: Arc<Q>,
     timestamp: Arc<TimestampOracle>,
     ingest_state: Arc<IngestState>,
+    ingester_id: IngesterId,
     catalog: Arc<dyn Catalog>,
     metrics: Arc<metric::Registry>,
     buffer: Arc<T>,
@@ -59,6 +61,7 @@ where
         query_exec: Arc<Q>,
         timestamp: Arc<TimestampOracle>,
         ingest_state: Arc<IngestState>,
+        ingester_id: IngesterId,
         catalog: Arc<dyn Catalog>,
         metrics: Arc<metric::Registry>,
         buffer: Arc<T>,
@@ -69,6 +72,7 @@ where
             query_exec,
             timestamp,
             ingest_state,
+            ingester_id,
             catalog,
             metrics,
             buffer,
@@ -128,6 +132,7 @@ where
     ) -> FlightServiceServer<Self::FlightHandler> {
         FlightServiceServer::new(query::FlightService::new(
             Arc::clone(&self.query_exec),
+            self.ingester_id,
             max_simultaneous_requests,
             &self.metrics,
         ))


### PR DESCRIPTION
Changes where the ingester UUID is initialised so it can be re-used (also wraps it in a newtype :+1:)

---

* refactor: use system-wide ingester ID (6413362c7)

      The query API exposes a unique-per-instance UUID to allow callers to
      detect a crash of the ingester process - this was initialised directly
      in the query RPC handler.
      
      This commit turns the bare UUID into a type, and initialises it in the
      top-level initialisation of the ingester, plumbing it down into the
      query RPC handler.
      
      This allows the UUID to be reused by other components/handlers.