### PR TITLE
refactor(persist): decouple persist job Context & logic

### DIFF
--- a/ingester2/src/persist/mod.rs
+++ b/ingester2/src/persist/mod.rs
@@ -6,3 +6,225 @@ pub(crate) mod handle;
 pub(crate) mod hot_partitions;
 pub mod queue;
 mod worker;
+
+#[cfg(test)]
+mod tests {
+    use std::{sync::Arc, time::Duration};
+
+    use assert_matches::assert_matches;
+    use data_types::{CompactionLevel, ParquetFile, PartitionKey, ShardId};
+    use dml::DmlOperation;
+    use futures::TryStreamExt;
+    use iox_catalog::{
+        interface::{get_schema_by_id, Catalog},
+        mem::MemCatalog,
+        validate_or_insert_schema,
+    };
+    use iox_query::exec::Executor;
+    use lazy_static::lazy_static;
+    use object_store::{memory::InMemory, ObjectMeta, ObjectStore};
+    use parking_lot::Mutex;
+    use parquet_file::storage::{ParquetStorage, StorageId};
+    use test_helpers::{maybe_start_logging, timeout::FutureTimeout};
+
+    use crate::{
+        buffer_tree::{
+            namespace::name_resolver::mock::MockNamespaceNameProvider,
+            partition::{resolver::CatalogPartitionResolver, PartitionData, SortKeyState},
+            post_write::mock::MockPostWriteObserver,
+            table::name_resolver::mock::MockTableNameProvider,
+            BufferTree,
+        },
+        dml_sink::DmlSink,
+        ingest_state::IngestState,
+        persist::queue::PersistQueue,
+        test_util::{make_write_op, populate_catalog},
+        TRANSITION_SHARD_INDEX,
+    };
+
+    use super::handle::PersistHandle;
+
+    const TABLE_NAME: &str = "bananas";
+    const NAMESPACE_NAME: &str = "platanos";
+    const TRANSITION_SHARD_ID: ShardId = ShardId::new(84);
+
+    lazy_static! {
+        static ref EXEC: Arc<Executor> = Arc::new(Executor::new_testing());
+        static ref PARTITION_KEY: PartitionKey = PartitionKey::from("bananas");
+    }
+
+    /// Generate a [`PartitionData`] containing one write, and populate the
+    /// catalog such that the schema is set (by validating the schema) and the
+    /// partition entry exists (by driving the buffer tree to create it).
+    async fn partition_with_write(catalog: Arc<dyn Catalog>) -> Arc<Mutex<PartitionData>> {
+        // Create the namespace in the catalog and it's the schema
+        let (_shard_id, namespace_id, table_id) = populate_catalog(
+            &*catalog,
+            TRANSITION_SHARD_INDEX,
+            NAMESPACE_NAME,
+            TABLE_NAME,
+        )
+        .await;
+
+        // Init the buffer tree
+        let buf = BufferTree::new(
+            Arc::new(MockNamespaceNameProvider::default()),
+            Arc::new(MockTableNameProvider::new(TABLE_NAME)),
+            Arc::new(CatalogPartitionResolver::new(Arc::clone(&catalog))),
+            Arc::new(MockPostWriteObserver::default()),
+            Arc::new(metric::Registry::default()),
+            TRANSITION_SHARD_ID,
+        );
+
+        let write = make_write_op(
+            &PARTITION_KEY,
+            namespace_id,
+            TABLE_NAME,
+            table_id,
+            0,
+            r#"bananas,region=Asturias temp=35 4242424242"#,
+        );
+
+        let mut repos = catalog
+            .repositories()
+            .with_timeout_panic(Duration::from_secs(1))
+            .await;
+
+        let schema = get_schema_by_id(namespace_id, &mut *repos)
+            .await
+            .expect("failed to find namespace schema");
+
+        // Insert the schema elements into the catalog
+        validate_or_insert_schema(
+            write.tables().map(|(_id, data)| (TABLE_NAME, data)),
+            &schema,
+            &mut *repos,
+        )
+        .await
+        .expect("populating schema elements failed");
+
+        drop(repos); // Don't you love this testing-only deadlock bug? #3859
+
+        // Apply the write
+        buf.apply(DmlOperation::Write(write))
+            .await
+            .expect("failed to apply write to buffer");
+
+        // And finally return the namespace
+        buf.partitions().next().unwrap()
+    }
+
+    /// A complete integration test of the persistence system components.
+    #[tokio::test]
+    async fn test_persist_integration() {
+        maybe_start_logging();
+
+        let object_storage: Arc<dyn ObjectStore> = Arc::new(InMemory::default());
+        let storage = ParquetStorage::new(Arc::clone(&object_storage), StorageId::from("iox"));
+        let metrics = Arc::new(metric::Registry::default());
+        let catalog: Arc<dyn Catalog> = Arc::new(MemCatalog::new(Arc::clone(&metrics)));
+        let ingest_state = Arc::new(IngestState::default());
+
+        // Initialise the persist system.
+        let handle = PersistHandle::new(
+            1,
+            2,
+            Arc::clone(&ingest_state),
+            Arc::clone(&EXEC),
+            storage,
+            Arc::clone(&catalog),
+            &metrics,
+        );
+        assert!(ingest_state.read().is_ok());
+
+        // Generate a partition with data
+        let partition = partition_with_write(Arc::clone(&catalog)).await;
+        let table_id = partition.lock().table_id();
+        let partition_id = partition.lock().partition_id();
+        let namespace_id = partition.lock().namespace_id();
+        assert_matches!(partition.lock().sort_key(), SortKeyState::Provided(None));
+
+        // Transition it to "persisting".
+        let data = partition
+            .lock()
+            .mark_persisting()
+            .expect("partition with write should transition to persisting");
+
+        // Enqueue the persist job
+        let notify = handle.enqueue(Arc::clone(&partition), data).await;
+        assert!(ingest_state.read().is_ok());
+
+        // Wait for the persist to complete.
+        notify
+            .with_timeout(Duration::from_secs(10))
+            .await
+            .expect("timeout waiting for completion notification")
+            .expect("worker task failed");
+
+        // Assert the partition persistence count increased, an indication that
+        // mark_persisted() was called.
+        assert_eq!(partition.lock().completed_persistence_count(), 1);
+
+        // Assert the sort key was also updated
+        assert_matches!(partition.lock().sort_key(), SortKeyState::Provided(Some(p)) => {
+            assert_eq!(p.to_columns().collect::<Vec<_>>(), &["region", "time"]);
+        });
+
+        // Ensure a file was made visible in the catalog
+        let files = catalog
+            .repositories()
+            .await
+            .parquet_files()
+            .list_by_partition_not_to_delete(partition_id)
+            .await
+            .expect("query for parquet files failed");
+
+        // Validate a single file was inserted with the expected properties.
+        let (object_store_id, file_size_bytes) = assert_matches!(&*files, &[ParquetFile {
+                namespace_id: got_namespace_id,
+                table_id: got_table_id,
+                partition_id: got_partition_id,
+                object_store_id,
+                max_sequence_number,
+                row_count,
+                compaction_level,
+                file_size_bytes,
+                ..
+            }] =>
+            {
+                assert_eq!(got_namespace_id, namespace_id);
+                assert_eq!(got_table_id, table_id);
+                assert_eq!(got_partition_id, partition_id);
+
+                assert_eq!(row_count, 1);
+                assert_eq!(compaction_level, CompactionLevel::Initial);
+
+                assert_eq!(max_sequence_number.get(), 0); // Unused, dummy value
+
+                (object_store_id, file_size_bytes)
+            }
+        );
+
+        // Validate the file exists in object storage.
+        let files: Vec<ObjectMeta> = object_storage
+            .list(None)
+            .await
+            .expect("listing object storage failed")
+            .try_collect::<Vec<_>>()
+            .await
+            .expect("failed to list object store files");
+
+        assert_matches!(
+            &*files,
+            &[ObjectMeta {
+                ref location,
+                size,
+                ..
+            }] => {
+                let want_path = format!("{object_store_id}.parquet");
+                assert!(location.as_ref().ends_with(&want_path));
+                assert_eq!(size, file_size_bytes as usize);
+            }
+        )
+    }
+}

--- a/ingester2/src/persist/worker.rs
+++ b/ingester2/src/persist/worker.rs
@@ -1,15 +1,25 @@
-use std::sync::Arc;
+use std::{ops::ControlFlow, sync::Arc};
 
 use async_channel::RecvError;
-use data_types::ParquetFileParams;
-use iox_catalog::interface::Catalog;
+use backoff::Backoff;
+use data_types::{CompactionLevel, ParquetFileParams, SequenceNumber};
+use iox_catalog::interface::{get_table_schema_by_id, CasFailure, Catalog};
 use iox_query::exec::Executor;
 
-use parquet_file::storage::ParquetStorage;
+use iox_time::{SystemProvider, TimeProvider};
+use observability_deps::tracing::{debug, info, warn};
+use parquet_file::{metadata::IoxMetadata, storage::ParquetStorage};
 
+use schema::sort::SortKey;
 use tokio::sync::mpsc;
+use uuid::Uuid;
 
-use super::context::{Context, PersistError, PersistRequest};
+use crate::persist::compact::compact_persisting_batch;
+
+use super::{
+    compact::CompactedStream,
+    context::{Context, PersistError, PersistRequest},
+};
 
 /// State shared across workers.
 #[derive(Debug)]
@@ -98,7 +108,7 @@ pub(super) async fn run_task(
             }
         };
 
-        let mut ctx = Context::new(req, Arc::clone(&worker_state));
+        let mut ctx = Context::new(req);
 
         // Compact the data, generate the parquet file from the result, and
         // upload it to object storage.
@@ -109,14 +119,15 @@ pub(super) async fn run_task(
         // the compaction must be redone with the new sort key and uploaded
         // before continuing.
         let parquet_table_data = loop {
-            match compact_and_upload(&mut ctx).await {
+            match compact_and_upload(&mut ctx, &worker_state).await {
                 Ok(v) => break v,
                 Err(PersistError::ConcurrentSortKeyUpdate(_)) => continue,
             };
         };
 
         // Make the newly uploaded parquet file visible to other nodes.
-        let object_store_id = ctx.update_catalog_parquet(parquet_table_data).await;
+        let object_store_id = update_catalog_parquet(&ctx, &worker_state, parquet_table_data).await;
+
         // And finally mark the persist job as complete and notify any
         // observers.
         ctx.mark_complete(object_store_id);
@@ -126,6 +137,9 @@ pub(super) async fn run_task(
 /// Run a compaction on the [`PersistingData`], generate a parquet file and
 /// upload it to object storage.
 ///
+/// This function composes functionality from the smaller [`compact()`],
+/// [`upload()`], and [`update_catalog_sort_key()`] functions.
+///
 /// If in the course of this the sort key is updated, this function attempts to
 /// update the sort key in the catalog. This MAY fail because another node has
 /// concurrently done the same and the persist must be restarted.
@@ -134,14 +148,337 @@ pub(super) async fn run_task(
 ///
 /// [`PersistingData`]:
 ///     crate::buffer_tree::partition::persisting::PersistingData
-async fn compact_and_upload(ctx: &mut Context) -> Result<ParquetFileParams, PersistError> {
-    let compacted = ctx.compact().await;
-    let (sort_key_update, parquet_table_data) = ctx.upload(compacted).await;
+async fn compact_and_upload(
+    ctx: &mut Context,
+    worker_state: &SharedWorkerState,
+) -> Result<ParquetFileParams, PersistError> {
+    let compacted = compact(ctx, worker_state).await;
+    let (sort_key_update, parquet_table_data) = upload(ctx, worker_state, compacted).await;
 
     if let Some(update) = sort_key_update {
-        ctx.update_catalog_sort_key(update, parquet_table_data.object_store_id)
-            .await?
+        update_catalog_sort_key(
+            ctx,
+            worker_state,
+            update,
+            parquet_table_data.object_store_id,
+        )
+        .await?
     }
 
     Ok(parquet_table_data)
 }
+
+/// Compact the data in `ctx` using sorted by the sort key returned from
+/// [`Context::sort_key()`].
+async fn compact(ctx: &Context, worker_state: &SharedWorkerState) -> CompactedStream {
+    let sort_key = ctx.sort_key().get().await;
+
+    debug!(
+        namespace_id = %ctx.namespace_id(),
+        namespace_name = %ctx.namespace_name(),
+        table_id = %ctx.table_id(),
+        table_name = %ctx.table_name(),
+        partition_id = %ctx.partition_id(),
+        partition_key = %ctx.partition_key(),
+        ?sort_key,
+        "compacting partition"
+    );
+
+    assert!(!ctx.data().record_batches().is_empty());
+
+    // Run a compaction sort the data and resolve any duplicate values.
+    //
+    // This demands the deferred load values and may have to wait for them
+    // to be loaded before compaction starts.
+    compact_persisting_batch(
+        &worker_state.exec,
+        sort_key,
+        ctx.table_name().get().await,
+        ctx.data().query_adaptor(),
+    )
+    .await
+    .expect("unable to compact persisting batch")
+}
+
+/// Upload the compacted data in `compacted`, returning the new sort key value
+/// and parquet metadata to be upserted into the catalog.
+async fn upload(
+    ctx: &Context,
+    worker_state: &SharedWorkerState,
+    compacted: CompactedStream,
+) -> (Option<SortKey>, ParquetFileParams) {
+    let CompactedStream {
+        stream: record_stream,
+        catalog_sort_key_update,
+        data_sort_key,
+    } = compacted;
+
+    // Generate a UUID to uniquely identify this parquet file in
+    // object storage.
+    let object_store_id = Uuid::new_v4();
+
+    debug!(
+        namespace_id = %ctx.namespace_id(),
+        namespace_name = %ctx.namespace_name(),
+        table_id = %ctx.table_id(),
+        table_name = %ctx.table_name(),
+        partition_id = %ctx.partition_id(),
+        partition_key = %ctx.partition_key(),
+        %object_store_id,
+        sort_key = %data_sort_key,
+        "uploading partition parquet"
+    );
+
+    // Construct the metadata for this parquet file.
+    let iox_metadata = IoxMetadata {
+        object_store_id,
+        creation_timestamp: SystemProvider::new().now(),
+        shard_id: ctx.transition_shard_id(),
+        namespace_id: ctx.namespace_id(),
+        namespace_name: Arc::clone(&*ctx.namespace_name().get().await),
+        table_id: ctx.table_id(),
+        table_name: Arc::clone(&*ctx.table_name().get().await),
+        partition_id: ctx.partition_id(),
+        partition_key: ctx.partition_key().clone(),
+        max_sequence_number: SequenceNumber::new(0), // TODO: not ordered!
+        compaction_level: CompactionLevel::Initial,
+        sort_key: Some(data_sort_key),
+    };
+
+    // Save the compacted data to a parquet file in object storage.
+    //
+    // This call retries until it completes.
+    let (md, file_size) = worker_state
+        .store
+        .upload(record_stream, &iox_metadata)
+        .await
+        .expect("unexpected fatal persist error");
+
+    debug!(
+        namespace_id = %ctx.namespace_id(),
+        namespace_name = %ctx.namespace_name(),
+        table_id = %ctx.table_id(),
+        table_name = %ctx.table_name(),
+        partition_id = %ctx.partition_id(),
+        partition_key = %ctx.partition_key(),
+        %object_store_id,
+        file_size,
+        "partition parquet uploaded"
+    );
+
+    // Read the table schema from the catalog to act as a map of column name
+    // -> column IDs.
+    let table_schema = Backoff::new(&Default::default())
+        .retry_all_errors("get table schema", || async {
+            let mut repos = worker_state.catalog.repositories().await;
+            get_table_schema_by_id(ctx.table_id(), repos.as_mut()).await
+        })
+        .await
+        .expect("retry forever");
+
+    // Build the data that must be inserted into the parquet_files catalog
+    // table in order to make the file visible to queriers.
+    let parquet_table_data =
+        iox_metadata.to_parquet_file(ctx.partition_id(), file_size, &md, |name| {
+            table_schema.columns.get(name).expect("unknown column").id
+        });
+
+    (catalog_sort_key_update, parquet_table_data)
+}
+
+/// Update the sort key value stored in the catalog for this [`Context`].
+///
+/// # Concurrent Updates
+///
+/// If a concurrent sort key change is detected (issued by another node) then
+/// this method updates the sort key in `ctx` to reflect the newly observed
+/// value and returns [`PersistError::ConcurrentSortKeyUpdate`] to the caller.
+async fn update_catalog_sort_key(
+    ctx: &mut Context,
+    worker_state: &SharedWorkerState,
+    new_sort_key: SortKey,
+    object_store_id: Uuid,
+) -> Result<(), PersistError> {
+    let old_sort_key = ctx
+        .sort_key()
+        .get()
+        .await
+        .map(|v| v.to_columns().map(|v| v.to_string()).collect::<Vec<_>>());
+
+    debug!(
+        %object_store_id,
+        namespace_id = %ctx.namespace_id(),
+        namespace_name = %ctx.namespace_name(),
+        table_id = %ctx.table_id(),
+        table_name = %ctx.table_name(),
+        partition_id = %ctx.partition_id(),
+        partition_key = %ctx.partition_key(),
+        ?new_sort_key,
+        ?old_sort_key,
+        "updating partition sort key"
+    );
+
+    let update_result = Backoff::new(&Default::default())
+        .retry_with_backoff("cas_sort_key", || {
+            let old_sort_key = old_sort_key.clone();
+            let new_sort_key_str = new_sort_key.to_columns().collect::<Vec<_>>();
+            let catalog = Arc::clone(&worker_state.catalog);
+            let ctx = &ctx;
+            async move {
+                let mut repos = catalog.repositories().await;
+                match repos
+                    .partitions()
+                    .cas_sort_key(ctx.partition_id(), old_sort_key.clone(), &new_sort_key_str)
+                    .await
+                {
+                    Ok(_) => ControlFlow::Break(Ok(())),
+                    Err(CasFailure::QueryError(e)) => ControlFlow::Continue(e),
+                    Err(CasFailure::ValueMismatch(observed)) if observed == new_sort_key_str => {
+                        // A CAS failure occurred because of a concurrent
+                        // sort key update, however the new catalog sort key
+                        // exactly matches the sort key this node wants to
+                        // commit.
+                        //
+                        // This is the sad-happy path, and this task can
+                        // continue.
+                        info!(
+                            %object_store_id,
+                            namespace_id = %ctx.namespace_id(),
+                            namespace_name = %ctx.namespace_name(),
+                            table_id = %ctx.table_id(),
+                            table_name = %ctx.table_name(),
+                            partition_id = %ctx.partition_id(),
+                            partition_key = %ctx.partition_key(),
+                            expected=?old_sort_key,
+                            ?observed,
+                            update=?new_sort_key_str,
+                            "detected matching concurrent sort key update"
+                        );
+                        ControlFlow::Break(Ok(()))
+                    }
+                    Err(CasFailure::ValueMismatch(observed)) => {
+                        // Another ingester concurrently updated the sort
+                        // key.
+                        //
+                        // This breaks a sort-key update invariant - sort
+                        // key updates MUST be serialised. This persist must
+                        // be retried.
+                        //
+                        // See:
+                        //   https://github.com/influxdata/influxdb_iox/issues/6439
+                        //
+                        warn!(
+                            %object_store_id,
+                            namespace_id = %ctx.namespace_id(),
+                            namespace_name = %ctx.namespace_name(),
+                            table_id = %ctx.table_id(),
+                            table_name = %ctx.table_name(),
+                            partition_id = %ctx.partition_id(),
+                            partition_key = %ctx.partition_key(),
+                            expected=?old_sort_key,
+                            ?observed,
+                            update=?new_sort_key_str,
+                            "detected concurrent sort key update, regenerating parquet"
+                        );
+                        // Stop the retry loop with an error containing the
+                        // newly observed sort key.
+                        ControlFlow::Break(Err(PersistError::ConcurrentSortKeyUpdate(
+                            SortKey::from_columns(observed),
+                        )))
+                    }
+                }
+            }
+        })
+        .await
+        .expect("retry forever");
+
+    match update_result {
+        Ok(_) => {}
+        Err(PersistError::ConcurrentSortKeyUpdate(new_key)) => {
+            // Update the cached sort key in the Context (which pushes it
+            // through into the PartitionData also) to reflect the newly
+            // observed value for the next attempt.
+            ctx.set_partition_sort_key(new_key.clone()).await;
+
+            return Err(PersistError::ConcurrentSortKeyUpdate(new_key));
+        }
+    }
+
+    // Update the sort key in the Context & PartitionData.
+    ctx.set_partition_sort_key(new_sort_key.clone()).await;
+
+    debug!(
+        %object_store_id,
+        namespace_id = %ctx.namespace_id(),
+        namespace_name = %ctx.namespace_name(),
+        table_id = %ctx.table_id(),
+        table_name = %ctx.table_name(),
+        partition_id = %ctx.partition_id(),
+        partition_key = %ctx.partition_key(),
+        ?old_sort_key,
+        %new_sort_key,
+        "adjusted partition sort key"
+    );
+
+    Ok(())
+}
+
+async fn update_catalog_parquet(
+    ctx: &Context,
+    worker_state: &SharedWorkerState,
+    parquet_table_data: ParquetFileParams,
+) -> Uuid {
+    // Extract the object store ID to the local scope so that it can easily
+    // be referenced in debug logging to aid correlation of persist events
+    // for a specific file.
+    let object_store_id = parquet_table_data.object_store_id;
+
+    debug!(
+        namespace_id = %ctx.namespace_id(),
+        namespace_name = %ctx.namespace_name(),
+        table_id = %ctx.table_id(),
+        table_name = %ctx.table_name(),
+        partition_id = %ctx.partition_id(),
+        partition_key = %ctx.partition_key(),
+        %object_store_id,
+        ?parquet_table_data,
+        "updating catalog parquet table"
+    );
+
+    // Add the parquet file to the catalog.
+    //
+    // This has the effect of allowing the queriers to "discover" the
+    // parquet file by polling / querying the catalog.
+    Backoff::new(&Default::default())
+        .retry_all_errors("add parquet file to catalog", || async {
+            let mut repos = worker_state.catalog.repositories().await;
+            let parquet_file = repos
+                .parquet_files()
+                .create(parquet_table_data.clone())
+                .await?;
+
+            debug!(
+                namespace_id = %ctx.namespace_id(),
+                namespace_name = %ctx.namespace_name(),
+                table_id = %ctx.table_id(),
+                table_name = %ctx.table_name(),
+                partition_id = %ctx.partition_id(),
+                partition_key = %ctx.partition_key(),
+                %object_store_id,
+                ?parquet_table_data,
+                parquet_file_id=?parquet_file.id,
+                "parquet file added to catalog"
+            );
+
+            // compiler insisted on getting told the type of the error :shrug:
+            Ok(()) as Result<(), iox_catalog::interface::Error>
+        })
+        .await
+        .expect("retry forever");
+
+    object_store_id
+}
+
+// TODO(test): persist
+// TODO(test): persist completion notification
+// TODO(test): sort key conflict

--- a/ingester2/src/persist/worker.rs
+++ b/ingester2/src/persist/worker.rs
@@ -478,7 +478,3 @@ async fn update_catalog_parquet(
 
     object_store_id
 }
-
-// TODO(test): persist
-// TODO(test): persist completion notification
-// TODO(test): sort key conflict


### PR DESCRIPTION
There is **❕no new logic in this PR ❕** - only moving things around, and new tests.

---

Cleans up a mess I willingly made when nocking out `ingester2` before the deadline.

This moves the "logic" of how a persistence happens away from the data of the persist job itself (in the persist job's `Context`). This also adds two integration tests covering the entire persist subsystem:

* A normal persistence
* A persistence that observes a concurrent sort key update, retries, and completes (#6439)

---

* test: persistence system integration test (1f5294c09)

      This test ensures the persistence system as a whole works in the happy
      path.

* refactor(persist): decouple Context & worker logic (091b428d4)

      The persist::Context struct carries the data to be persisted, a
      reference to the partition from which it came, and various cached fields
      to avoid re-acquiring the partition read lock all the time.
      
      Prior to this commit, the Context also had the full persist logic as
      methods, invoked by the persist worker. This tightly couples the data &
      logic - it's fairly clear a worker should implement the work, and
      operate on the data - not commingling the two. I even knew the mess I
      was making when I wrote it, but effectively copy-pasted it from
      ingester1 because deadlines.
      
      This commit decouples the persist logic from the Context.

* test: persist concurrent sort key catalog updates (fa62c0000)

      Adds an integration test of the persist system, covering:
      
          * Node A starts a persist operation
          * Node B starts a persist operation for the same partition
          * Node A completes, setting the catalog sort key to a new value
          * Node B attempts to update the catalog, observing the new sort key
          * Node B re-compacts the data, re-uploads, and drives to completion
      
      This scenario is/was tracked in:
      
          https://github.com/influxdata/influxdb_iox/issues/6439
