### PR TITLE
feat: write & persist replication primitives

### DIFF
--- a/data_types/src/sequence_number_set.rs
+++ b/data_types/src/sequence_number_set.rs
@@ -31,12 +31,12 @@ impl SequenceNumberSet {
         self.0.andnot_inplace(&other.0)
     }
 
-    /// Serialise `self` into a set of bytes.
+    /// Serialise `self` into an array of bytes.
     ///
     /// [This document][spec] describes the serialised format.
     ///
     /// [spec]: https://github.com/RoaringBitmap/RoaringFormatSpec/
-    pub fn as_bytes(&self) -> Vec<u8> {
+    pub fn to_bytes(&self) -> Vec<u8> {
         self.0.serialize()
     }
 

--- a/ingester2/src/dml_sink/trait.rs
+++ b/ingester2/src/dml_sink/trait.rs
@@ -4,6 +4,8 @@ use async_trait::async_trait;
 use dml::DmlOperation;
 use thiserror::Error;
 
+use crate::replication::replication_sink::ReplicationError;
+
 /// Errors returned due from calls to [`DmlSink::apply()`].
 #[derive(Debug, Error)]
 pub enum DmlError {
@@ -16,6 +18,9 @@ pub enum DmlError {
     /// An error appending the [`DmlOperation`] to the write-ahead log.
     #[error("wal commit failure: {0}")]
     Wal(String),
+
+    #[error("replication error: {0}")]
+    Replication(#[from] ReplicationError),
 }
 
 /// A [`DmlSink`] handles [`DmlOperation`] instances in some abstract way.

--- a/ingester2/src/lib.rs
+++ b/ingester2/src/lib.rs
@@ -106,6 +106,7 @@ mod ingest_state;
 mod ingester_id;
 mod query;
 mod query_adaptor;
+mod replication;
 pub(crate) mod server;
 mod timestamp_oracle;
 

--- a/ingester2/src/replication/mod.rs
+++ b/ingester2/src/replication/mod.rs
@@ -1,0 +1,1 @@
+pub(crate) mod replication_sink;

--- a/ingester2/src/replication/mod.rs
+++ b/ingester2/src/replication/mod.rs
@@ -1,1 +1,2 @@
+pub(crate) mod persist_observer;
 pub(crate) mod replication_sink;

--- a/ingester2/src/replication/persist_observer.rs
+++ b/ingester2/src/replication/persist_observer.rs
@@ -1,0 +1,72 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use generated_types::influxdata::iox::ingester::v1::{
+    replication_service_client::ReplicationServiceClient, PersistCompleteRequest,
+};
+use observability_deps::tracing::{debug, warn};
+use tonic::transport::Channel;
+
+use crate::{
+    ingester_id::IngesterId,
+    persist::completion_observer::{CompletedPersist, PersistCompletionObserver},
+};
+
+/// An [`PersistCompletionObserver`] implementation that synchronously
+/// replicates persistence completion events to an upstream replica.
+#[derive(Debug)]
+pub(crate) struct PersistReplicationObserver {
+    ingester_id: IngesterId,
+    client: ReplicationServiceClient<Channel>,
+}
+
+impl PersistReplicationObserver {
+    /// Construct a new [`PersistReplicationObserver`], pushing persist
+    /// notifications to `client`.
+    pub(crate) fn new(ingester_id: IngesterId, client: ReplicationServiceClient<Channel>) -> Self {
+        Self {
+            ingester_id,
+            client,
+        }
+    }
+}
+
+#[async_trait]
+impl PersistCompletionObserver for PersistReplicationObserver {
+    async fn persist_complete(&self, note: Arc<CompletedPersist>) {
+        let resp = self
+            .client
+            .clone()
+            .persist_complete(PersistCompleteRequest {
+                ingester_uuid: self.ingester_id.to_string(),
+                namespace_id: note.namespace_id().get(),
+                table_id: note.table_id().get(),
+                partition_id: note.partition_id().get(),
+                croaring_sequence_number_bitmap: note.sequence_numbers().to_bytes(),
+            })
+            .await;
+
+        let namespace_id = note.namespace_id();
+        let table_id = note.table_id();
+        let partition_id = note.partition_id();
+        let n_writes = note.sequence_numbers().len();
+
+        match resp {
+            Ok(_) => debug!(
+                %partition_id,
+                %table_id,
+                %namespace_id,
+                %n_writes,
+                "replicated persist completion event"
+            ),
+            Err(error) => warn!(
+                %error,
+                %partition_id,
+                %table_id,
+                %namespace_id,
+                %n_writes,
+                "failed to replicate persist completion event"
+            ),
+        };
+    }
+}

--- a/ingester2/src/replication/replication_sink.rs
+++ b/ingester2/src/replication/replication_sink.rs
@@ -1,0 +1,97 @@
+use async_trait::async_trait;
+use dml::DmlOperation;
+use futures::TryFutureExt;
+use generated_types::influxdata::iox::ingester::v1::{
+    replication_service_client::ReplicationServiceClient, ReplicateRequest,
+};
+use mutable_batch_pb::encode::encode_write;
+use thiserror::Error;
+use tokio::try_join;
+use tonic::transport::Channel;
+
+use crate::{
+    dml_sink::{DmlError, DmlSink},
+    ingester_id::IngesterId,
+};
+
+/// Errors returned when replicating a write to a upstream replica.
+#[derive(Debug, Error)]
+pub enum ReplicationError {
+    #[error("upstream replica returned error: {0}")]
+    UpstreamReplica(#[from] tonic::Status),
+
+    #[error(transparent)]
+    Inner(#[from] Box<DmlError>),
+}
+
+/// A [`DmlSink`] layer that pushes writes to a configured replica, while
+/// concurrently applying them to `T`.
+///
+/// Blocks for the write to be applied to `T`, and a successful ACK from the
+/// replica.
+#[derive(Debug)]
+pub(crate) struct ReplicationSink<T> {
+    inner: T,
+
+    ingester_id: IngesterId,
+    client: ReplicationServiceClient<Channel>,
+}
+
+impl<T> ReplicationSink<T> {
+    /// Construct a new [`ReplicationSink`], pushing writes to `client`.
+    pub(crate) fn new(
+        inner: T,
+        ingester_id: IngesterId,
+        client: ReplicationServiceClient<Channel>,
+    ) -> Self {
+        Self {
+            inner,
+            ingester_id,
+            client,
+        }
+    }
+}
+
+#[async_trait]
+impl<T> DmlSink for ReplicationSink<T>
+where
+    T: DmlSink,
+{
+    type Error = ReplicationError;
+
+    async fn apply(&self, op: DmlOperation) -> Result<(), Self::Error> {
+        match &op {
+            DmlOperation::Write(w) => {
+                // Generate the future that replicates the write, while op is in
+                // scope.
+                let mut client = self.client.clone();
+                let fut = client
+                    .replicate(ReplicateRequest {
+                        ingester_uuid: self.ingester_id.to_string(),
+                        sequence_number: op
+                            .meta()
+                            .sequence()
+                            .expect("replicating unsequenced write")
+                            .sequence_number
+                            .get(),
+                        payload: Some(encode_write(op.namespace_id().get(), w)),
+                    })
+                    .map_err(ReplicationError::from);
+
+                // Pass op into the inner handler, obtaining the future to
+                // execute it.
+                let inner_fut = self
+                    .inner
+                    .apply(op)
+                    .map_err(|e| ReplicationError::Inner(Box::new(Into::<DmlError>::into(e))));
+
+                // Execute both the apply to the inner handler, and the
+                // replication push to the replica at the same time.
+                try_join!(fut, inner_fut)?;
+
+                Ok(())
+            }
+            DmlOperation::Delete(_) => unreachable!(),
+        }
+    }
+}

--- a/ingester2/src/server/grpc/rpc_write.rs
+++ b/ingester2/src/server/grpc/rpc_write.rs
@@ -63,6 +63,7 @@ impl From<DmlError> for tonic::Status {
         match e {
             DmlError::Buffer(e) => map_write_error(e),
             DmlError::Wal(_) => Self::internal(e.to_string()),
+            DmlError::Replication(e) => Self::unavailable(e.to_string()),
         }
     }
 }


### PR DESCRIPTION
Implements simple replication primitives:

* `ReplicationSink`: push writes to a replica as they are applied to an ingester
* `PersistReplicationObserver`: push persist completion notifications to a replica

Neither implementation handles errors in any special way (they're just logged), nor are any optimisations (such as batching) implemented. It's a proof-of-concept!

To enable replication, apply the diff below to initialise the components and slot them into the system - replication RPC requests will be sent to `127.0.0.1:8083`.

<details><summary>
Click for Diff
</summary>

```diff
diff --git a/ingester2/src/init.rs b/ingester2/src/init.rs
index c5b0c374e..c7b3402e4 100644
--- a/ingester2/src/init.rs
+++ b/ingester2/src/init.rs
@@ -13,6 +13,7 @@ use generated_types::influxdata::iox::{
     catalog::v1::catalog_service_server::{CatalogService, CatalogServiceServer},
     ingester::v1::{
         persist_service_server::{PersistService, PersistServiceServer},
+        replication_service_client::ReplicationServiceClient,
         write_service_server::{WriteService, WriteServiceServer},
     },
 };
@@ -24,6 +25,7 @@ use parquet_file::storage::ParquetStorage;
 use thiserror::Error;
 use tokio::sync::oneshot;
 use tokio_util::sync::CancellationToken;
+use tonic::transport::Endpoint;
 use wal::Wal;
 
 use crate::{
@@ -35,9 +37,9 @@ use crate::{
     },
     ingest_state::IngestState,
     ingester_id::IngesterId,
-    persist::{
-        completion_observer::NopObserver, handle::PersistHandle,
-        hot_partitions::HotPartitionPersister,
+    persist::{handle::PersistHandle, hot_partitions::HotPartitionPersister},
+    replication::{
+        persist_observer::PersistReplicationObserver, replication_sink::ReplicationSink,
     },
     server::grpc::GrpcDelegate,
     timestamp_oracle::TimestampOracle,
@@ -279,6 +281,12 @@ where
     // write path.
     let ingest_state = Arc::new(IngestState::default());
 
+    // TODO(dom): do not push
+    let replica = ReplicationServiceClient::new(
+        Endpoint::from_static("http://127.0.0.1:8083").connect_lazy(),
+    );
+    let replicate_persist = PersistReplicationObserver::new(ingester_id, replica.clone());
+
     // Spawn the persist workers to compact partition data, convert it into
     // Parquet files, and upload them to object storage.
     let persist_handle = PersistHandle::new(
@@ -288,7 +296,7 @@ where
         persist_executor,
         object_store,
         Arc::clone(&catalog),
-        NopObserver::default(),
+        replicate_persist,
         &metrics,
     );
     let persist_handle = Arc::new(persist_handle);
@@ -323,7 +331,12 @@ where
         .map_err(|e| InitError::WalReplay(e.into()))?;
 
     // Build the chain of DmlSink that forms the write path.
-    let write_path = WalSink::new(Arc::clone(&buffer), Arc::clone(&wal));
+    let write_path = WalSink::new(
+        // Perform the replication in parallel with the WAL commit, by having
+        // the WAL call into it while building the WAL entry batch.
+        ReplicationSink::new(Arc::clone(&buffer), ingester_id, replica),
+        Arc::clone(&wal),
+    );
 
     // Spawn a background thread to periodically rotate the WAL segment file.
     let rotation_task = tokio::spawn(periodic_rotation(

```
</details>

---

* refactor: SequenceNumberSet::as_bytes -> to_bytes (86ffe840a)
      
      The conversion is not (always) a cheap cast/conversion, and therefore
      should be prefixed with "to_" and not "as_".

* feat: write-push replication layer (837eb1e3c)
      
      Adds a implementation of DmlSink that pushes all writes that pass
      through it to an upstream ingester.
      
      This executes in-line with the ingester's normal write path, waiting for
      an ACK from the replica before returning an ACK to the user. This is a
      naive implementation, with no regard for retries, back-pressure,
      batching, etc.

* feat: replicated persistence notifications (f1fc87731)
      
      Adds a post-persist completion observer that replicates writes to an
      upstream replica.
      
      Persist notification requests are dispatched synchronously before the
      persist job is marked as complete, driven by the persistence worker
      itself. At most one attempt is made to replicate the notification,
      logging any errors.