### PR TITLE
test: Start of porting InfluxRpc query_tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -253,6 +253,14 @@ jobs:
       # When removing this, also remove the ignore on the test in trogging/src/cli.rs
       RUST_LOG: debug,,hyper::proto::h1=info,h2=info
       LOG_FILTER: debug,,hyper::proto::h1=info,h2=info
+      # TEMPORARY: Can be removed when the ingester that uses the write buffer is removed. Tests
+      # need to spin up separate servers because I've only been able to implement a "persist
+      # everything" API, and if tests run in parallel using a shared server, they interfere with
+      # each other. Starting separate servers with the maximum number of Rust test threads uses up
+      # all the Postgres connections in CI, so limit the parallelization until we switch completely
+      # to ingester2, which does have a "persist-per-namespace" API that means tests can run on
+      # shared MiniClusters.
+      RUST_TEST_THREADS: 8
     steps:
       - checkout
       - rust_components

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2453,6 +2453,7 @@ dependencies = [
  "arrow-flight",
  "arrow_util",
  "assert_cmd",
+ "async-trait",
  "backtrace",
  "bytes",
  "clap 4.1.4",

--- a/generated_types/protos/influxdata/iox/ingester/v1/write.proto
+++ b/generated_types/protos/influxdata/iox/ingester/v1/write.proto
@@ -18,6 +18,9 @@ service PersistService {
   rpc Persist(PersistRequest) returns (PersistResponse);
 }
 
-message PersistRequest {}
+message PersistRequest {
+  // The namespace to persist
+  string namespace = 1;
+}
 
 message PersistResponse {}

--- a/influxdb_iox/Cargo.toml
+++ b/influxdb_iox/Cargo.toml
@@ -81,6 +81,7 @@ workspace-hack = { path = "../workspace-hack"}
 # In alphabetical order
 arrow_util = { path = "../arrow_util" }
 assert_cmd = "2.0.8"
+async-trait = "0.1"
 predicate = { path = "../predicate" }
 predicates = "2.1.0"
 tempfile = "3.1.0"

--- a/influxdb_iox/tests/end_to_end.rs
+++ b/influxdb_iox/tests/end_to_end.rs
@@ -6,3 +6,4 @@
 // The tests are defined in the submodules of [`end_to_end_cases`]
 
 mod end_to_end_cases;
+mod query_tests2;

--- a/influxdb_iox/tests/end_to_end_cases/querier.rs
+++ b/influxdb_iox/tests/end_to_end_cases/querier.rs
@@ -903,16 +903,7 @@ mod kafkaless_rpc_write {
         let table_name = "the_table";
 
         // Set up the cluster  ====================================
-        let ingester_config = TestConfig::new_ingester2_never_persist(&database_url);
-        let router_config = TestConfig::new_router2(&ingester_config);
-        let querier_config = TestConfig::new_querier2(&ingester_config);
-        let mut cluster = MiniCluster::new()
-            .with_ingester(ingester_config)
-            .await
-            .with_router(router_config)
-            .await
-            .with_querier(querier_config)
-            .await;
+        let mut cluster = MiniCluster::create_shared2_never_persist(database_url).await;
 
         StepTest::new(
             &mut cluster,
@@ -951,16 +942,7 @@ mod kafkaless_rpc_write {
         let table_name = "the_table";
 
         // Set up the cluster  ====================================
-        let ingester_config = TestConfig::new_ingester2_never_persist(&database_url);
-        let router_config = TestConfig::new_router2(&ingester_config);
-        let querier_config = TestConfig::new_querier2(&ingester_config);
-        let mut cluster = MiniCluster::new()
-            .with_ingester(ingester_config)
-            .await
-            .with_router(router_config)
-            .await
-            .with_querier(querier_config)
-            .await;
+        let mut cluster = MiniCluster::create_shared2_never_persist(database_url).await;
 
         StepTest::new(
             &mut cluster,

--- a/influxdb_iox/tests/end_to_end_cases/querier/influxrpc.rs
+++ b/influxdb_iox/tests/end_to_end_cases/querier/influxrpc.rs
@@ -98,7 +98,7 @@ trait InfluxRpcTest: Send + Sync + 'static {
                         .await
                 }
                 IoxArchitecture::Kafkaless => {
-                    MiniCluster::create_non_shared2_never_persist(database_url.clone()).await
+                    MiniCluster::create_shared2_never_persist(database_url.clone()).await
                 }
             };
 

--- a/influxdb_iox/tests/end_to_end_cases/querier/influxrpc.rs
+++ b/influxdb_iox/tests/end_to_end_cases/querier/influxrpc.rs
@@ -6,9 +6,13 @@ mod read_filter;
 mod read_group;
 mod read_window_aggregate;
 
+use crate::query_tests2::{framework::IoxArchitecture, setups::SETUPS};
+use async_trait::async_trait;
+use futures::FutureExt;
+use observability_deps::tracing::*;
 use std::sync::Arc;
 use test_helpers_end_to_end::{
-    maybe_skip_integration, DataGenerator, FCustom, MiniCluster, Step, StepTest,
+    maybe_skip_integration, DataGenerator, FCustom, MiniCluster, Step, StepTest, StepTestState,
 };
 
 /// Runs the specified custom function on a cluster with no data
@@ -55,4 +59,81 @@ pub(crate) fn read_group_data() -> Vec<&'static str> {
         "cpu,cpu=cpu2,host=bar  usage_user=51.0,usage_system=40.0 1000",
         "cpu,cpu=cpu2,host=bar  usage_user=52.0,usage_system=41.0 2000",
     ]
+}
+
+/// Perform an InfluxRPC test that creates a [`MiniCluster`] appropriate for the architecture(s)
+/// under test, runs a setup defined in [`SETUPS`] and specified by the implementation of
+/// `setup_name`, then performs actions and assertions defined by the implementation of
+/// `request_and_assert` with the [`MiniCluster`].
+#[async_trait]
+trait InfluxRpcTest: Send + Sync + 'static {
+    /// The name of the setup in [`SETUPS`] that should be run on the cluster before running
+    /// `request_and_assert`.
+    fn setup_name(&self) -> &'static str;
+
+    /// Any requests and/or assertions that should be performed on the set up [`MiniCluster`].
+    async fn request_and_assert(&self, cluster: &MiniCluster);
+
+    /// Run the test on the appropriate architecture(s), using the setup specified by `setup_name`,
+    /// and calling `request_and_assert` in a custom step after the setup steps.
+    ///
+    /// Note that this is defined on `Arc<Self>`, so a test using a type that implements this trait
+    /// will need to call:
+    ///
+    /// ```ignore
+    /// Arc::new(ImplementingType {}).run().await;
+    /// ```
+    async fn run(self: Arc<Self>) {
+        test_helpers::maybe_start_logging();
+        let database_url = maybe_skip_integration!();
+        let setup_name = self.setup_name();
+
+        for arch in [IoxArchitecture::Kafkaful, IoxArchitecture::Kafkaless] {
+            info!("Using IoxArchitecture::{arch:?} and setup {setup_name}");
+
+            // Set up the cluster  ====================================
+            let mut cluster = match arch {
+                IoxArchitecture::Kafkaful => {
+                    MiniCluster::create_non_shared_standard_never_persist(database_url.clone())
+                        .await
+                }
+                IoxArchitecture::Kafkaless => {
+                    MiniCluster::create_non_shared2_never_persist(database_url.clone()).await
+                }
+            };
+
+            let setup_steps = SETUPS
+                .get(setup_name)
+                .unwrap_or_else(|| panic!("Could not find setup with key `{setup_name}`"))
+                .iter()
+                // When we've switched over to the Kafkaless architecture, this map can be
+                // removed.
+                .flat_map(|step| match (arch, step) {
+                    // If we're using the old architecture and the test steps include
+                    // `WaitForPersist2`, swap it with `WaitForPersist` instead.
+                    (IoxArchitecture::Kafkaful, Step::WaitForPersisted2 { .. }) => {
+                        vec![&Step::WaitForPersisted]
+                    }
+                    // If we're using the old architecture and the test steps include
+                    // `WriteLineProtocol`, wait for the data to be readable after writing.
+                    (IoxArchitecture::Kafkaful, Step::WriteLineProtocol { .. }) => {
+                        vec![step, &Step::WaitForReadable]
+                    }
+                    (_, other) => vec![other],
+                });
+
+            let cloned_self = Arc::clone(&self);
+
+            let test_step = Step::Custom(Box::new(move |state: &mut StepTestState| {
+                let cloned_self = Arc::clone(&cloned_self);
+                async move {
+                    cloned_self.request_and_assert(state.cluster()).await;
+                }
+                .boxed()
+            }));
+            StepTest::new(&mut cluster, setup_steps.chain(std::iter::once(&test_step)))
+                .run()
+                .await;
+        }
+    }
 }

--- a/influxdb_iox/tests/query.rs
+++ b/influxdb_iox/tests/query.rs
@@ -1,3 +1,0 @@
-//! Tests of various queries for data in various states.
-
-mod query_tests2;

--- a/influxdb_iox/tests/query_tests2/framework.rs
+++ b/influxdb_iox/tests/query_tests2/framework.rs
@@ -41,7 +41,7 @@ impl IntoIterator for ChunkStage {
 
 /// Which architecture is being used in this test run. This enum and running the tests twice is temporary until the Kafkaful architecture is retired.
 #[derive(Debug, Copy, Clone)]
-enum IoxArchitecture {
+pub enum IoxArchitecture {
     /// Use the "standard" MiniCluster that uses ingester, router, querier, compactor with a write
     /// buffer (aka Kafka). This is slated for retirement soon.
     Kafkaful,

--- a/influxdb_iox/tests/query_tests2/framework.rs
+++ b/influxdb_iox/tests/query_tests2/framework.rs
@@ -66,10 +66,10 @@ impl TestCase {
             for chunk_stage in self.chunk_stage {
                 info!("Using IoxArchitecture::{arch:?} and ChunkStage::{chunk_stage:?}");
 
-                // Setup that differs by architecture and chunk stage. These need to be non-shared
-                // clusters; if they're shared, then the tests that run in parallel and persist at
-                // particular times mess with each other because persistence applies to everything in
-                // the ingester.
+                // Setup that differs by architecture and chunk stage. In the Kafka architecture,
+                // these need to be non-shared clusters; if they're shared, then the tests that run
+                // in parallel and persist at particular times mess with each other because
+                // persistence applies to everything in the ingester.
                 let mut cluster = match (arch, chunk_stage) {
                     (IoxArchitecture::Kafkaful, ChunkStage::Ingester) => {
                         MiniCluster::create_non_shared_standard_never_persist(database_url.clone())
@@ -79,10 +79,10 @@ impl TestCase {
                         MiniCluster::create_non_shared_standard(database_url.clone()).await
                     }
                     (IoxArchitecture::Kafkaless, ChunkStage::Ingester) => {
-                        MiniCluster::create_non_shared2_never_persist(database_url.clone()).await
+                        MiniCluster::create_shared2_never_persist(database_url.clone()).await
                     }
                     (IoxArchitecture::Kafkaless, ChunkStage::Parquet) => {
-                        MiniCluster::create_non_shared2(database_url.clone()).await
+                        MiniCluster::create_shared2(database_url.clone()).await
                     }
                     (_, ChunkStage::All) => unreachable!("See `impl IntoIterator for ChunkStage`"),
                 };

--- a/influxdb_iox/tests/query_tests2/mod.rs
+++ b/influxdb_iox/tests/query_tests2/mod.rs
@@ -1,3 +1,3 @@
 mod cases;
-mod framework;
-mod setups;
+pub mod framework;
+pub mod setups;

--- a/influxdb_iox_client/src/client/ingester.rs
+++ b/influxdb_iox_client/src/client/ingester.rs
@@ -21,11 +21,11 @@ impl Client {
         }
     }
 
-    /// Instruct the ingester to persist its data to Parquet. Will block until the data has
-    /// persisted, which is useful in tests asserting on persisted data. May behave in unexpected
-    /// ways if used concurrently with writes and ingester WAL rotations.
-    pub async fn persist(&mut self) -> Result<(), Error> {
-        self.inner.persist(PersistRequest {}).await?;
+    /// Instruct the ingester to persist its data for the specified namespace to Parquet. Useful in
+    /// tests asserting on persisted data. May behave in unexpected ways if used concurrently with
+    /// writes and ingester WAL rotations.
+    pub async fn persist(&mut self, namespace: String) -> Result<(), Error> {
+        self.inner.persist(PersistRequest { namespace }).await?;
 
         Ok(())
     }

--- a/ingester/src/server/grpc/persist.rs
+++ b/ingester/src/server/grpc/persist.rs
@@ -25,6 +25,9 @@ impl<I: IngestHandler + 'static> PersistService for PersistHandler<I> {
         &self,
         _request: Request<proto::PersistRequest>,
     ) -> Result<Response<proto::PersistResponse>, tonic::Status> {
+        // Even though the request specifies the namespace, persist everything. This means tests
+        // that use this API need to be using non-shared MiniClusters in order to avoid messing
+        // with each others' states.
         self.ingest_handler.persist_all().await;
 
         Ok(Response::new(proto::PersistResponse {}))

--- a/ingester2/src/server/grpc.rs
+++ b/ingester2/src/server/grpc.rs
@@ -120,6 +120,7 @@ where
         PersistServiceServer::new(PersistHandler::new(
             Arc::clone(&self.buffer),
             Arc::clone(&self.persist_handle),
+            Arc::clone(&self.catalog),
         ))
     }
 

--- a/ingester2/src/server/grpc/persist.rs
+++ b/ingester2/src/server/grpc/persist.rs
@@ -5,12 +5,15 @@ use crate::{
 use generated_types::influxdata::iox::ingester::v1::{
     self as proto, persist_service_server::PersistService,
 };
+use iox_catalog::interface::Catalog;
+use std::sync::Arc;
 use tonic::{Request, Response};
 
 #[derive(Debug)]
 pub(crate) struct PersistHandler<T, P> {
     buffer: T,
     persist_handle: P,
+    catalog: Arc<dyn Catalog>,
 }
 
 impl<T, P> PersistHandler<T, P>
@@ -18,10 +21,11 @@ where
     T: PartitionIter + Sync + 'static,
     P: PersistQueue + Clone + Sync + 'static,
 {
-    pub(crate) fn new(buffer: T, persist_handle: P) -> Self {
+    pub(crate) fn new(buffer: T, persist_handle: P, catalog: Arc<dyn Catalog>) -> Self {
         Self {
             buffer,
             persist_handle,
+            catalog,
         }
     }
 }
@@ -37,9 +41,27 @@ where
     /// concurrently with writes and ingester WAL rotations.
     async fn persist(
         &self,
-        _request: Request<proto::PersistRequest>,
+        request: Request<proto::PersistRequest>,
     ) -> Result<Response<proto::PersistResponse>, tonic::Status> {
-        persist_partitions(self.buffer.partition_iter(), &self.persist_handle).await;
+        let request = request.into_inner();
+
+        let namespace = self
+            .catalog
+            .repositories()
+            .await
+            .namespaces()
+            .get_by_name(&request.namespace)
+            .await
+            .map_err(|e| tonic::Status::internal(e.to_string()))?
+            .ok_or_else(|| tonic::Status::not_found(&request.namespace))?;
+
+        persist_partitions(
+            self.buffer
+                .partition_iter()
+                .filter(|p| p.lock().namespace_id() == namespace.id),
+            &self.persist_handle,
+        )
+        .await;
 
         Ok(Response::new(proto::PersistResponse {}))
     }

--- a/test_helpers_end_to_end/src/mini_cluster.rs
+++ b/test_helpers_end_to_end/src/mini_cluster.rs
@@ -494,7 +494,10 @@ impl MiniCluster {
         let mut ingester_client =
             influxdb_iox_client::ingester::Client::new(self.ingester().ingester_grpc_connection());
 
-        ingester_client.persist().await.unwrap();
+        ingester_client
+            .persist(self.namespace().into())
+            .await
+            .unwrap();
     }
 
     /// Get a reference to the mini cluster's other servers.


### PR DESCRIPTION
Connects to #6617.

I've ported two tests from [`query_tests/influxrpc/field_columns`](https://github.com/influxdata/influxdb_iox/blob/6f39ae342e64848bd6555bddbc1d3fa30050f75e/query_tests/src/influxrpc/field_columns.rs#L51-L86) and made them more in the style of the tests already existing in [`influxdb_iox/tests/end_to_end_cases/querier/influxrpc/metadata.rs`](https://github.com/influxdata/influxdb_iox/blob/6f39ae342e64848bd6555bddbc1d3fa30050f75e/influxdb_iox/tests/end_to_end_cases/querier/influxrpc/metadata.rs).

I think I have an abstraction that should work for the other kinds of InfluxRpc tests, namely:

- A new trait, `InfluxRpcTest`, that types can implement to define how to run a test on a specific Storage gRPC API. `InfluxRpcTest` takes care of iterating through the two architectures, running the setups, and creating the custom test step.
- Implementers of the trait like `MeasurementFieldsTest` in this PR can define aspects of the tests that differ per run, to make the parameters of the test clearer and highlight what different tests are testing.
