### PR TITLE
feat(ingester2): metrics

### DIFF
--- a/ingester2/src/dml_sink/instrumentation.rs
+++ b/ingester2/src/dml_sink/instrumentation.rs
@@ -1,0 +1,167 @@
+use async_trait::async_trait;
+use dml::DmlOperation;
+use iox_time::{SystemProvider, TimeProvider};
+use metric::{DurationHistogram, Metric};
+
+use super::DmlSink;
+
+/// An instrumentation decorator over a [`DmlSink`] implementation.
+///
+/// This wrapper captures the latency distribution of the decorated
+/// [`DmlSink::apply()`] call, faceted by success/error result.
+#[derive(Debug)]
+pub(crate) struct DmlSinkInstrumentation<T, P = SystemProvider> {
+    inner: T,
+    time_provider: P,
+
+    /// Query execution duration distribution for successes.
+    apply_duration_success: DurationHistogram,
+
+    /// Query execution duration distribution for "not found" errors
+    apply_duration_error: DurationHistogram,
+}
+
+impl<T> DmlSinkInstrumentation<T> {
+    pub(crate) fn new(name: &'static str, inner: T, metrics: &metric::Registry) -> Self {
+        // Record query duration metrics, broken down by query execution result
+        let apply_duration: Metric<DurationHistogram> = metrics.register_metric(
+            "ingester_dml_sink_apply_duration",
+            "duration distribution of dml apply calls",
+        );
+        let apply_duration_success =
+            apply_duration.recorder(&[("handler", name), ("result", "success")]);
+        let apply_duration_error =
+            apply_duration.recorder(&[("handler", name), ("result", "error")]);
+
+        Self {
+            inner,
+            time_provider: Default::default(),
+            apply_duration_success,
+            apply_duration_error,
+        }
+    }
+}
+
+#[async_trait]
+impl<T, P> DmlSink for DmlSinkInstrumentation<T, P>
+where
+    T: DmlSink,
+    P: TimeProvider,
+{
+    type Error = T::Error;
+
+    /// Apply `op` to the implementer's state.
+    async fn apply(&self, op: DmlOperation) -> Result<(), Self::Error> {
+        let t = self.time_provider.now();
+
+        let res = self.inner.apply(op).await;
+
+        if let Some(delta) = self.time_provider.now().checked_duration_since(t) {
+            match &res {
+                Ok(_) => self.apply_duration_success.record(delta),
+                Err(_) => self.apply_duration_error.record(delta),
+            };
+        }
+
+        res
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{sync::Arc, time::Duration};
+
+    use assert_matches::assert_matches;
+    use data_types::{NamespaceId, PartitionId, PartitionKey, TableId};
+    use iox_query::exec::Executor;
+    use lazy_static::lazy_static;
+    use metric::Attributes;
+
+    use super::*;
+    use crate::{
+        buffer_tree::{namespace::NamespaceName, table::TableName},
+        deferred_load::DeferredLoad,
+        dml_sink::{mock_sink::MockDmlSink, DmlError},
+        test_util::make_write_op,
+    };
+
+    const PARTITION_ID: PartitionId = PartitionId::new(42);
+    const NAMESPACE_ID: NamespaceId = NamespaceId::new(24);
+    const TABLE_ID: TableId = TableId::new(2442);
+    const TABLE_NAME: &str = "banana-report";
+    const NAMESPACE_NAME: &str = "platanos";
+
+    lazy_static! {
+        static ref EXEC: Arc<Executor> = Arc::new(Executor::new_testing());
+        static ref PARTITION_KEY: PartitionKey = PartitionKey::from("bananas");
+        static ref NAMESPACE_NAME_LOADER: Arc<DeferredLoad<NamespaceName>> =
+            Arc::new(DeferredLoad::new(Duration::from_secs(1), async {
+                NamespaceName::from(NAMESPACE_NAME)
+            }));
+        static ref TABLE_NAME_LOADER: Arc<DeferredLoad<TableName>> =
+            Arc::new(DeferredLoad::new(Duration::from_secs(1), async {
+                TableName::from(TABLE_NAME)
+            }));
+    }
+
+    const LAYER_NAME: &str = "test-bananas";
+
+    macro_rules! test_metric {
+        (
+            $name:ident,
+            ret = $ret:expr,
+            want_metric_attr = $want_metric_attr:expr,
+            want_ret = $($want_ret:tt)+
+        ) => {
+            paste::paste! {
+                #[tokio::test]
+                async fn [<test_metric_ $name>]() {
+                    let mock = MockDmlSink::default().with_apply_return([$ret]);
+                    let metrics = metric::Registry::default();
+                    let decorator = DmlSinkInstrumentation::new(LAYER_NAME, mock, &metrics);
+
+                    let op = DmlOperation::Write(make_write_op(
+                        &PARTITION_KEY,
+                        NAMESPACE_ID,
+                        TABLE_NAME,
+                        TABLE_ID,
+                        42,
+                        "banana-report,tag=1 v=2 42424242",
+                    ));
+
+                    // Call the decorator and assert the return value
+                    let got = decorator
+                        .apply(op)
+                        .await;
+                    assert_matches!(got, $($want_ret)+);
+
+                    // Validate the histogram with the specified attributes saw
+                    // an observation
+                    let histogram = metrics
+                        .get_instrument::<Metric<DurationHistogram>>("ingester_dml_sink_apply_duration")
+                        .expect("failed to find metric")
+                        .get_observer(&Attributes::from(&$want_metric_attr))
+                        .expect("failed to find attributes")
+                        .fetch();
+                    assert_eq!(histogram.sample_count(), 1);
+                }
+            }
+        };
+    }
+
+    test_metric!(
+        ok,
+        ret = Ok(()),
+        want_metric_attr = [("handler", LAYER_NAME), ("result", "success")],
+        want_ret = Ok(_)
+    );
+
+    test_metric!(
+        error,
+        ret = Err(DmlError::Wal("broken".to_string())),
+        want_metric_attr = [("handler", LAYER_NAME), ("result", "error")],
+        want_ret = Err(DmlError::Wal(e)) => {
+            assert_eq!(e, "broken");
+        }
+    );
+}

--- a/ingester2/src/dml_sink/mod.rs
+++ b/ingester2/src/dml_sink/mod.rs
@@ -1,6 +1,7 @@
 mod r#trait;
 pub use r#trait::*;
 
+pub(crate) mod instrumentation;
 pub(crate) mod tracing;
 
 #[cfg(test)]

--- a/ingester2/src/dml_sink/mod.rs
+++ b/ingester2/src/dml_sink/mod.rs
@@ -1,5 +1,7 @@
 mod r#trait;
 pub use r#trait::*;
 
+pub(crate) mod tracing;
+
 #[cfg(test)]
 pub(crate) mod mock_sink;

--- a/ingester2/src/dml_sink/tracing.rs
+++ b/ingester2/src/dml_sink/tracing.rs
@@ -1,0 +1,187 @@
+use std::borrow::Cow;
+
+use async_trait::async_trait;
+use dml::DmlOperation;
+use trace::span::SpanRecorder;
+
+use super::DmlSink;
+
+/// An tracing decorator over a [`DmlSink`] implementation.
+///
+/// This wrapper emits child tracing spans covering the execution of the inner
+/// [`DmlSink::apply()`] call.
+///
+/// Constructing this decorator is cheap.
+#[derive(Debug)]
+pub(crate) struct DmlSinkTracing<T> {
+    inner: T,
+    name: Cow<'static, str>,
+}
+
+impl<T> DmlSinkTracing<T> {
+    pub(crate) fn new(inner: T, name: impl Into<Cow<'static, str>>) -> Self {
+        Self {
+            inner,
+            name: name.into(),
+        }
+    }
+}
+
+#[async_trait]
+impl<T> DmlSink for DmlSinkTracing<T>
+where
+    T: DmlSink,
+{
+    type Error = T::Error;
+
+    /// Apply `op` to the implementer's state, emitting a trace for the duration.
+    async fn apply(&self, op: DmlOperation) -> Result<(), Self::Error> {
+        let span = op.meta().span_context().map(|x| x.child(self.name.clone()));
+        let mut recorder = SpanRecorder::new(span);
+
+        match self.inner.apply(op).await {
+            Ok(v) => {
+                recorder.ok("apply complete");
+                Ok(v)
+            }
+            Err(e) => {
+                recorder.error(e.to_string());
+                Err(e)
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{sync::Arc, time::Duration};
+
+    use assert_matches::assert_matches;
+    use data_types::{NamespaceId, PartitionId, PartitionKey, TableId};
+    use dml::DmlMeta;
+    use iox_query::exec::Executor;
+    use lazy_static::lazy_static;
+    use trace::{ctx::SpanContext, span::SpanStatus, RingBufferTraceCollector, TraceCollector};
+
+    use crate::{
+        buffer_tree::{namespace::NamespaceName, table::TableName},
+        deferred_load::DeferredLoad,
+        dml_sink::{mock_sink::MockDmlSink, DmlError},
+        test_util::make_write_op,
+    };
+
+    use super::*;
+
+    const PARTITION_ID: PartitionId = PartitionId::new(42);
+    const NAMESPACE_ID: NamespaceId = NamespaceId::new(24);
+    const TABLE_ID: TableId = TableId::new(2442);
+    const TABLE_NAME: &str = "banana-report";
+    const NAMESPACE_NAME: &str = "platanos";
+
+    lazy_static! {
+        static ref EXEC: Arc<Executor> = Arc::new(Executor::new_testing());
+        static ref PARTITION_KEY: PartitionKey = PartitionKey::from("bananas");
+        static ref NAMESPACE_NAME_LOADER: Arc<DeferredLoad<NamespaceName>> =
+            Arc::new(DeferredLoad::new(Duration::from_secs(1), async {
+                NamespaceName::from(NAMESPACE_NAME)
+            }));
+        static ref TABLE_NAME_LOADER: Arc<DeferredLoad<TableName>> =
+            Arc::new(DeferredLoad::new(Duration::from_secs(1), async {
+                TableName::from(TABLE_NAME)
+            }));
+    }
+
+    #[track_caller]
+    fn assert_trace(name: impl Into<String>, status: SpanStatus, traces: &dyn TraceCollector) {
+        let traces = traces
+            .as_any()
+            .downcast_ref::<RingBufferTraceCollector>()
+            .expect("unexpected collector impl");
+
+        let name = name.into();
+        let span = traces
+            .spans()
+            .into_iter()
+            .find(|s| s.name == name)
+            .unwrap_or_else(|| panic!("tracing span {name} not found"));
+
+        assert_eq!(
+            span.status, status,
+            "span status does not match expected value"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_ok() {
+        let mock = MockDmlSink::default().with_apply_return([Ok(())]);
+
+        let traces: Arc<dyn TraceCollector> = Arc::new(RingBufferTraceCollector::new(5));
+        let span = SpanContext::new(Arc::clone(&traces));
+
+        let mut op = DmlOperation::Write(make_write_op(
+            &PARTITION_KEY,
+            NAMESPACE_ID,
+            TABLE_NAME,
+            TABLE_ID,
+            42,
+            "banana-report,tag=1 v=2 42424242",
+        ));
+
+        // Populate the metadata with a span context.
+        let meta = op.meta();
+        op.set_meta(DmlMeta::sequenced(
+            *meta.sequence().unwrap(),
+            meta.producer_ts().unwrap(),
+            Some(span),
+            42,
+        ));
+
+        // Drive the trace wrapper
+        DmlSinkTracing::new(mock, "bananas")
+            .apply(op)
+            .await
+            .expect("wrapper should not modify result");
+
+        // Assert the trace showed up.
+        assert_trace("bananas", SpanStatus::Ok, &*traces);
+    }
+
+    #[tokio::test]
+    async fn test_err() {
+        let mock =
+            MockDmlSink::default().with_apply_return([Err(DmlError::Wal("broken".to_string()))]);
+
+        let traces: Arc<dyn TraceCollector> = Arc::new(RingBufferTraceCollector::new(5));
+        let span = SpanContext::new(Arc::clone(&traces));
+
+        let mut op = DmlOperation::Write(make_write_op(
+            &PARTITION_KEY,
+            NAMESPACE_ID,
+            TABLE_NAME,
+            TABLE_ID,
+            42,
+            "banana-report,tag=1 v=2 42424242",
+        ));
+
+        // Populate the metadata with a span context.
+        let meta = op.meta();
+        op.set_meta(DmlMeta::sequenced(
+            *meta.sequence().unwrap(),
+            meta.producer_ts().unwrap(),
+            Some(span),
+            42,
+        ));
+
+        // Drive the trace wrapper
+        let got = DmlSinkTracing::new(mock, "bananas")
+            .apply(op)
+            .await
+            .expect_err("wrapper should not modify result");
+        assert_matches!(got, DmlError::Wal(s) => {
+            assert_eq!(s, "broken");
+        });
+
+        // Assert the trace showed up.
+        assert_trace("bananas", SpanStatus::Err, &*traces);
+    }
+}

--- a/ingester2/src/persist/context.rs
+++ b/ingester2/src/persist/context.rs
@@ -271,6 +271,10 @@ impl Context {
         let _ = self.complete.send(());
     }
 
+    pub(super) fn enqueued_at(&self) -> Instant {
+        self.enqueued_at
+    }
+
     pub(super) fn sort_key(&self) -> &SortKeyState {
         &self.sort_key
     }

--- a/ingester2/src/persist/handle.rs
+++ b/ingester2/src/persist/handle.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use iox_catalog::interface::Catalog;
 use iox_query::{exec::Executor, QueryChunkMeta};
+use metric::U64Counter;
 use observability_deps::tracing::*;
 use parking_lot::Mutex;
 use parquet_file::storage::ParquetStorage;
@@ -154,6 +155,9 @@ pub(crate) struct PersistHandle {
 
     /// Marks and recovers the saturation state of the persist system.
     persist_state: Arc<PersistState>,
+
+    /// A counter tracking the number of enqueued into the persist system.
+    enqueued_jobs: U64Counter,
 }
 
 impl PersistHandle {
@@ -227,12 +231,24 @@ impl PersistHandle {
             metrics,
         ));
 
+        // Initialise a metric tracking the number of jobs enqueued.
+        //
+        // When combined with the completion count metric, this allows us to
+        // derive the rate of enqueues and the number of outstanding jobs.
+        let enqueued_jobs = metrics
+            .register_metric::<U64Counter>(
+                "ingester_persist_enqueued_jobs",
+                "the number of partition persist tasks enqueued",
+            )
+            .recorder(&[]);
+
         Self {
             sem,
             global_queue: global_tx,
             worker_queues: JumpHash::new(tx_handles),
             worker_tasks,
             persist_state,
+            enqueued_jobs,
         }
     }
 
@@ -286,7 +302,12 @@ impl PersistQueue for PersistHandle {
         let partition_id = data.partition_id().get();
         debug!(partition_id, "enqueuing persistence task");
 
+        // Record a starting timestamp, and increment the number of persist jobs
+        // before waiting on the semaphore - this ensures the difference between
+        // started and completed includes the full count of pending jobs (even
+        // those blocked waiting for queue capacity).
         let enqueued_at = Instant::now();
+        self.enqueued_jobs.inc(1);
 
         // Try and acquire the persist task permit immediately.
         let permit = match Arc::clone(&self.sem).try_acquire_owned() {
@@ -393,13 +414,15 @@ impl<T> Drop for AbortOnDrop<T> {
 
 #[cfg(test)]
 mod tests {
-    use std::{sync::Arc, time::Duration};
+    use std::{sync::Arc, task::Poll, time::Duration};
 
     use assert_matches::assert_matches;
     use data_types::{NamespaceId, PartitionId, PartitionKey, ShardId, TableId};
     use dml::DmlOperation;
+    use futures::Future;
     use iox_catalog::mem::MemCatalog;
     use lazy_static::lazy_static;
+    use metric::{Attributes, Metric};
     use object_store::memory::InMemory;
     use parquet_file::storage::StorageId;
     use schema::sort::SortKey;
@@ -417,7 +440,8 @@ mod tests {
         },
         deferred_load::DeferredLoad,
         dml_sink::DmlSink,
-        persist::completion_observer::mock::MockCompletionObserver,
+        ingest_state::IngestStateError,
+        persist::completion_observer::{mock::MockCompletionObserver, NopObserver},
         test_util::make_write_op,
     };
 
@@ -439,6 +463,18 @@ mod tests {
             Arc::new(DeferredLoad::new(Duration::from_secs(1), async {
                 TableName::from(TABLE_NAME)
             }));
+    }
+
+    #[track_caller]
+    fn assert_metric(metrics: &metric::Registry, name: &'static str, value: u64) {
+        let v = metrics
+            .get_instrument::<Metric<U64Counter>>(name)
+            .expect("failed to read metric")
+            .get_observer(&Attributes::from([]))
+            .expect("failed to get observer")
+            .fetch();
+
+        assert_eq!(v, value, "metric {name} had value {v} want {value}");
     }
 
     /// Construct a partition with the above constants, with the given sort key,
@@ -814,5 +850,78 @@ mod tests {
             .try_recv()
             .expect("task should be in global queue");
         assert_eq!(msg.partition_id(), PARTITION_ID);
+    }
+
+    /// A test that a ensures tasks waiting to be enqueued (waiting on the
+    /// semaphore) appear in the metrics.
+    #[tokio::test]
+    async fn test_persist_saturated_enqueue_counter() {
+        let storage = ParquetStorage::new(Arc::new(InMemory::default()), StorageId::from("iox"));
+        let metrics = Arc::new(metric::Registry::default());
+        let catalog = Arc::new(MemCatalog::new(Arc::clone(&metrics)));
+        let ingest_state = Arc::new(IngestState::default());
+
+        let mut handle = PersistHandle::new(
+            1,
+            1,
+            Arc::clone(&ingest_state),
+            Arc::clone(&EXEC),
+            storage,
+            catalog,
+            NopObserver::default(),
+            &metrics,
+        );
+        assert!(ingest_state.read().is_ok());
+
+        // Kill the workers, and replace the queues so we can inspect the
+        // enqueue output.
+        handle.worker_tasks = vec![];
+
+        let (global_tx, _global_rx) = async_channel::unbounded();
+        handle.global_queue = global_tx;
+
+        let (worker1_tx, _worker1_rx) = mpsc::unbounded_channel();
+        let (worker2_tx, _worker2_rx) = mpsc::unbounded_channel();
+        handle.worker_queues = JumpHash::new([worker1_tx, worker2_tx]);
+
+        // Generate a partition
+        let p = new_partition(
+            PARTITION_ID,
+            SortKeyState::Deferred(Arc::new(DeferredLoad::new(Duration::from_secs(1), async {
+                Some(SortKey::from_columns(["time", "good"]))
+            }))),
+        )
+        .await;
+        let data = p.lock().mark_persisting().unwrap();
+
+        // Enqueue it
+        let _notify1 = handle.enqueue(p, data).await;
+
+        // Generate a second partition
+        let p = new_partition(
+            PARTITION_ID,
+            SortKeyState::Deferred(Arc::new(DeferredLoad::new(Duration::from_secs(1), async {
+                Some(SortKey::from_columns(["time", "good"]))
+            }))),
+        )
+        .await;
+        let data = p.lock().mark_persisting().unwrap();
+
+        // Enqueue it
+        let fut = handle.enqueue(p, data);
+
+        // Poll it to the pending state
+        let waker = futures::task::noop_waker();
+        let mut cx = futures::task::Context::from_waker(&waker);
+        futures::pin_mut!(fut);
+
+        let poll = std::pin::Pin::new(&mut fut).poll(&mut cx);
+        assert_matches!(poll, Poll::Pending);
+
+        // The queue is now full, and the second enqueue above is blocked
+        assert_matches!(ingest_state.read(), Err(IngestStateError::PersistSaturated));
+
+        // And the counter shows two persist ops.
+        assert_metric(&metrics, "ingester_persist_enqueued_jobs", 2);
     }
 }

--- a/ingester2/src/persist/handle.rs
+++ b/ingester2/src/persist/handle.rs
@@ -197,13 +197,13 @@ impl PersistHandle {
         let persist_duration = metrics
             .register_metric::<DurationHistogram>(
                 "ingester_persist_active_duration",
-                "the distribution of persist job processing duration in nanoseconds",
+                "the distribution of persist job processing duration in seconds",
             )
             .recorder(&[]);
         let queue_duration = metrics
             .register_metric::<DurationHistogram>(
                 "ingester_persist_enqueue_duration",
-                "the distribution of duration a persist job spent enqueued, waiting to be processed in nanoseconds",
+                "the distribution of duration a persist job spent enqueued, waiting to be processed in seconds",
             )
             .recorder(&[]);
 


### PR DESCRIPTION
Here's a load of metrics:

* Persist jobs enqueued / completed + latency
* Query execution against the buffer (inc. locks acquisition, `RecordBatch` generation, etc)
* DML apply count/latency
* Tracing spans for write/query paths.

More to come, but this should give us decent viability into what is going on with the ingester (write path metrics + persist system metrics)

---

* feat(metrics): cumulative persist job count (0637540aa)
      
      Tracks the cumulative number of persist jobs enqueued on a single
      ingester (the total amount, so including now-completed jobs).

* feat(metrics): persist duration histograms (3541243fc)
      
      Adds metrics to track the distribution duration spent actively
      persisting a batch of partition data (compacting, generating parquet,
      uploading, DB entries, etc) and another tracking the duration of time an
      entry spent in the persist queue.
      
      Together these provide a measurement of the latency of persist requests,
      and as they contain event counters, they also provide the throughput and
      number of outstanding jobs.

* feat(metrics): instrumented query execution (c9a1c7435)
      
      Instrument the query path in ingester2, capturing the query latency +
      counts, broken down by success/error.

* feat(tracing): emit spans for write path (28d575d90)
      
      Emit tracing spans for each component of the write path in ingester2.

* feat(metrics): instrument DmlSink::apply() (d198756a2)
      
      Record latency histograms for DmlSink::apply() calls, configuring
      ingester2 to report the overall write path latency, and separately the
      buffer apply latency.