### PR TITLE
feat(router): configurable partition key

### DIFF
--- a/clap_blocks/src/router2.rs
+++ b/clap_blocks/src/router2.rs
@@ -80,4 +80,16 @@ pub struct Router2Config {
         action
     )]
     pub namespace_autocreation_enabled: bool,
+
+    /// A "strftime" format string used to derive the partition key from the row
+    /// timestamps.
+    ///
+    /// Changing this from the default value is experimental.
+    #[clap(
+        long = "partition-key-pattern",
+        env = "INFLUXDB_IOX_PARTITION_KEY_PATTERN",
+        default_value = "%Y-%m-%d",
+        action
+    )]
+    pub partition_key_pattern: String,
 }

--- a/ioxd_router/src/lib.rs
+++ b/ioxd_router/src/lib.rs
@@ -337,7 +337,9 @@ pub async fn create_router2_server_type(
     // Add a write partitioner into the handler stack that splits by the date
     // portion of the write's timestamp.
     let partitioner = Partitioner::new(PartitionTemplate {
-        parts: vec![TemplatePart::TimeFormat("%Y-%m-%d".to_owned())],
+        parts: vec![TemplatePart::TimeFormat(
+            router_config.partition_key_pattern.clone(),
+        )],
     });
     let partitioner = InstrumentationDecorator::new("partitioner", &metrics, partitioner);
 


### PR DESCRIPTION
Allows the partition key to be configured at runtime. It only supports setting the strftime pattern for now (as opposed to say, the value of a column).

Only supported on kafkaless clusters. Please don't use this.

---

* feat(router): configurable partition key (6797eab5f)
      
      Allows the partition key to be set at runtime, though it's probably best
      no one does so for now.

Context: https://docs.google.com/document/d/1q2Z8_3cX-baK2YISJeoxau9aUFuJuB2xZ9RDzRK-mwI/edit#heading=h.rrplyx64cq2l