### PR TITLE
refactor: log IDs in panic messages

### DIFF
--- a/ingester2/src/buffer_tree/namespace/name_resolver.rs
+++ b/ingester2/src/buffer_tree/namespace/name_resolver.rs
@@ -48,7 +48,12 @@ impl NamespaceNameResolver {
                     .namespaces()
                     .get_by_id(namespace_id)
                     .await?
-                    .expect("resolving namespace name for non-existent namespace id")
+                    .unwrap_or_else(|| {
+                        panic!(
+                            "resolving namespace name for non-existent namespace id {}",
+                            namespace_id
+                        )
+                    })
                     .name
                     .into();
 

--- a/ingester2/src/buffer_tree/partition/resolver/sort_key.rs
+++ b/ingester2/src/buffer_tree/partition/resolver/sort_key.rs
@@ -40,7 +40,12 @@ impl SortKeyResolver {
                     .partitions()
                     .get_by_id(self.partition_id)
                     .await?
-                    .expect("resolving sort key for non-existent partition")
+                    .unwrap_or_else(|| {
+                        panic!(
+                            "resolving sort key for non-existent partition ID {}",
+                            self.partition_id
+                        )
+                    })
                     .sort_key();
 
                 Result::<_, iox_catalog::interface::Error>::Ok(s)

--- a/ingester2/src/buffer_tree/table/name_resolver.rs
+++ b/ingester2/src/buffer_tree/table/name_resolver.rs
@@ -48,7 +48,12 @@ impl TableNameResolver {
                     .tables()
                     .get_by_id(table_id)
                     .await?
-                    .expect("resolving table name for non-existent table id")
+                    .unwrap_or_else(|| {
+                        panic!(
+                            "resolving table name for non-existent table id {}",
+                            table_id
+                        )
+                    })
                     .name
                     .into();
 


### PR DESCRIPTION
Log some IDs when it's all on fire.

---

* refactor: panic with unresolvable partition IDs (0d9b77369)
      
      Include the partition ID in the panic message.

* refactor: panic with unresolvable namespace IDs (6e540bc8d)
      
      Include the namespace ID in the panic message.

* refactor: panic with unresolvable table IDs (a029de95f)
      
      Include the table ID in the panic message.