### PR TITLE
docs: retention period value mappings

### DIFF
--- a/generated_types/protos/influxdata/iox/namespace/v1/service.proto
+++ b/generated_types/protos/influxdata/iox/namespace/v1/service.proto
@@ -27,7 +27,10 @@ message CreateNamespaceRequest {
   // Name of the namespace to be created
   string name = 1;
 
-  // Retention period ns
+  // Retention period in nanoseconds.
+  //
+  // NULL means "infinite retention", and 0 is mapped to NULL. Negative values
+  // are rejected.
   optional int64 retention_period_ns = 2;
 }
 
@@ -47,7 +50,10 @@ message UpdateNamespaceRetentionRequest {
   // Name of the namespace to be set
   string name = 1;
 
-  // Retention period ns
+  // Retention period in nanoseconds.
+  //
+  // NULL means "infinite retention", and 0 is mapped to NULL. Negative values
+  // are rejected.
   optional int64 retention_period_ns = 2;
 }
 
@@ -62,6 +68,8 @@ message Namespace {
   // Name of the Namespace
   string name = 2;
 
-  // Retention period ns
+  // Retention period in nanoseconds.
+  //
+  // NULL means "infinite retention".
   optional int64 retention_period_ns = 3;
 }

--- a/influxdb_iox_client/src/client/namespace.rs
+++ b/influxdb_iox_client/src/client/namespace.rs
@@ -33,8 +33,11 @@ impl Client {
 
     /// Create a namespace
     ///
-    /// `retention_period_ns` is the the retention period in nanoseconds, measured from `now()`.
-    /// `None` represents infinite retention (i.e. never drop data).
+    /// `retention_period_ns` is the the retention period in nanoseconds,
+    /// measured from `now()`. `None` represents infinite retention (i.e. never
+    /// drop data), and 0 is also mapped to `None` on the server side.
+    ///
+    /// Negative retention periods are rejected, returning an error.
     pub async fn create_namespace(
         &mut self,
         namespace: &str,
@@ -53,8 +56,11 @@ impl Client {
 
     /// Update retention for a namespace
     ///
-    /// `retention_period_ns` is the the retention period in nanoseconds, measured from `now()`.
-    /// `None` represents infinite retention (i.e. never drop data).
+    /// `retention_period_ns` is the the retention period in nanoseconds,
+    /// measured from `now()`. `None` represents infinite retention (i.e. never
+    /// drop data), and 0 is also mapped to `None` on the server side.
+    ///
+    /// Negative retention periods are rejected, returning an error.
     pub async fn update_namespace_retention(
         &mut self,
         namespace: &str,


### PR DESCRIPTION
Document changes made in #6795.

---

* docs: namespace retention protobuf mappings (52ac1b97a)
      
      Document that the caller can specify 0 or NULL for an infinite retention
      period, and that IOx will respond with NULL.
      
      Document that negative retention periods are rejected.

* docs: retention period values in Namespace client (77ff4dc4b)
      
      Document the 0/null and negative value behaviours for retention periods
      in the namespace RPC client.