### PR TITLE
ci: use new influx gpg signing key

### DIFF
--- a/docker/Dockerfile.ci
+++ b/docker/Dockerfile.ci
@@ -39,7 +39,7 @@ ENV CURL_FLAGS="--proto =https --tlsv1.2 -sSf"
 # Install InfluxDB 2.0 OSS to enable integration tests of the influxdb2_client crate
 ENV INFLUXDB2_VERSION=2.0.4
 ENV INFLUXDB2_DOWNLOAD_BASE="https://dl.influxdata.com/influxdb/releases"
-RUN curl ${CURL_FLAGS} https://repos.influxdata.com/influxdb2.key | gpg --import - \
+RUN curl ${CURL_FLAGS} https://repos.influxdata.com/influxdata-archive_compat.key | gpg --import - \
     && curl ${CURL_FLAGS} -o influxdb2.tar.gz ${INFLUXDB2_DOWNLOAD_BASE}/influxdb2-${INFLUXDB2_VERSION}-linux-amd64.tar.gz \
     && curl ${CURL_FLAGS} -O ${INFLUXDB2_DOWNLOAD_BASE}/influxdb2-${INFLUXDB2_VERSION}-linux-amd64.tar.gz.asc \
     && gpg --verify influxdb2-${INFLUXDB2_VERSION}-linux-amd64.tar.gz.asc influxdb2.tar.gz \


### PR DESCRIPTION
This fixes the nightly CI image generation (probably).

We recently [rotated our security keys](https://www.influxdata.com/blog/linux-package-signing-key-rotation/) in response to a CircleCI security incident - this changes the build script to use the new key.

---

* ci: use new influx gpg signing key (8ca12d488)
      
      We recently rotated our GPG keys:
      
          https://www.influxdata.com/blog/linux-package-signing-key-rotation/