### PR TITLE
feat(metrics): ingester2 WAL replay

### DIFF
--- a/ingester2/benches/wal.rs
+++ b/ingester2/benches/wal.rs
@@ -64,9 +64,14 @@ fn wal_replay_bench(c: &mut Criterion) {
                 let persist = ingester2::persist::queue::benches::MockPersistQueue::default();
 
                 // Replay the wal into the NOP.
-                ingester2::benches::replay(&wal, &sink, Arc::new(persist))
-                    .await
-                    .expect("WAL replay error");
+                ingester2::benches::replay(
+                    &wal,
+                    &sink,
+                    Arc::new(persist),
+                    &metric::Registry::default(),
+                )
+                .await
+                .expect("WAL replay error");
             },
             // Use the WAL for one test invocation only, and re-create a new one
             // for the next iteration.

--- a/ingester2/src/init.rs
+++ b/ingester2/src/init.rs
@@ -320,9 +320,10 @@ where
     let wal = Wal::new(wal_directory).await.map_err(InitError::WalInit)?;
 
     // Replay the WAL log files, if any.
-    let max_sequence_number = wal_replay::replay(&wal, &buffer, Arc::clone(&persist_handle))
-        .await
-        .map_err(|e| InitError::WalReplay(e.into()))?;
+    let max_sequence_number =
+        wal_replay::replay(&wal, &buffer, Arc::clone(&persist_handle), &metrics)
+            .await
+            .map_err(|e| InitError::WalReplay(e.into()))?;
 
     // Build the chain of DmlSink that forms the write path.
     let write_path = DmlSinkInstrumentation::new(


### PR DESCRIPTION
This will let us write alerts to know when WAL replay is necessary - this can happen because:

* Unclean shutdown / crash / not getting SIGTERM (happens!)
* Graceful shutdown taking too long and being SIGKILL'ed

In either case, before replication is introduced, this means reduced read availability - this should not be silent.

---

* feat(metrics): ingester2 WAL replay (67903a4bf)
      
      Adds two metrics:
      
          * Number of files replayed (counted at the start of, not completion)
          * Number of applied ops
      
      This will help identify when WAL replay is happening (an indication of
      an ungraceful shutdown & potential temporary read unavailability).