### PR TITLE
refactor(wal): remove unused checksum

### DIFF
--- a/wal/src/blocking/reader.rs
+++ b/wal/src/blocking/reader.rs
@@ -82,10 +82,7 @@ where
             }
         );
 
-        Ok(Some(SegmentEntry {
-            checksum: expected_checksum,
-            data,
-        }))
+        Ok(Some(SegmentEntry { data }))
     }
 
     pub fn next_batch(&mut self) -> Result<Option<Vec<SequencedWalOp>>> {
@@ -235,12 +232,10 @@ mod tests {
 
         let entry_output_1 = reader.one_entry().unwrap().unwrap();
         let expected_1 = SegmentEntry::from(&entry_input_1);
-        assert_eq!(entry_output_1.checksum, expected_1.checksum);
         assert_eq!(entry_output_1.data, expected_1.data);
 
         let entry_output_2 = reader.one_entry().unwrap().unwrap();
         let expected_2 = SegmentEntry::from(&entry_input_2);
-        assert_eq!(entry_output_2.checksum, expected_2.checksum);
         assert_eq!(entry_output_2.data, expected_2.data);
 
         let entry = reader.one_entry().unwrap();
@@ -321,7 +316,6 @@ mod tests {
         // A bad checksum won't corrupt further entries
         let entry_output_2 = reader.one_entry().unwrap().unwrap();
         let expected_2 = SegmentEntry::from(&good_entry_input);
-        assert_eq!(entry_output_2.checksum, expected_2.checksum);
         assert_eq!(entry_output_2.data, expected_2.data);
 
         let entry = reader.one_entry().unwrap();
@@ -417,7 +411,6 @@ mod tests {
     impl From<&FakeSegmentEntry> for SegmentEntry {
         fn from(fake: &FakeSegmentEntry) -> Self {
             Self {
-                checksum: fake.checksum(),
                 data: fake.uncompressed_data.clone(),
             }
         }

--- a/wal/src/blocking/writer.rs
+++ b/wal/src/blocking/writer.rs
@@ -103,7 +103,6 @@ impl OpenSegmentFileWriter {
             total_bytes: self.bytes_written,
             bytes_written,
             segment_id: self.id,
-            checksum,
         })
     }
 

--- a/wal/src/lib.rs
+++ b/wal/src/lib.rs
@@ -452,8 +452,6 @@ impl From<SequencedWalOp> for ProtoSequencedWalOp {
 /// Raw, uncompressed and unstructured data for a Segment entry with a checksum.
 #[derive(Debug, Eq, PartialEq)]
 pub struct SegmentEntry {
-    /// The CRC checksum of the uncompressed data
-    checksum: u32,
     /// The uncompressed data
     pub data: Vec<u8>,
 }

--- a/wal/src/lib.rs
+++ b/wal/src/lib.rs
@@ -477,9 +477,6 @@ pub struct WriteSummary {
     pub bytes_written: usize,
     /// Which segment file this entry was written to
     pub segment_id: SegmentId,
-    /// Checksum for the compressed data written to segment
-    #[allow(dead_code)]
-    checksum: u32,
 }
 
 /// Reader for a closed segment file


### PR DESCRIPTION
The data is checksummed, but the actual checksum itself has no use outside of the WAL reader/writer.

---

* refactor: remove unused checksum field (6e6a439ef)
      
      This unreachable checksum is meaningless outside of the WAL
      reader/writer implementations.

* refactor: remove test-only checksum (b5ce0e4c4)
      
      The correctness of data checksumming is validated by the tests as a
      reader property (corrupt checksum -> error), the actual value of the
      checksum is irrelevant.