### PR TITLE
fix: Consolidate ingester address specification

### DIFF
--- a/clap_blocks/src/ingest_replica.rs
+++ b/clap_blocks/src/ingest_replica.rs
@@ -1,5 +1,7 @@
 //! CLI config for the ingest_replica
 
+use crate::ingester_address::IngesterAddress;
+
 /// CLI config for the ingest_replica
 #[derive(Debug, Clone, clap::Parser)]
 #[allow(missing_copy_implementations)]
@@ -21,7 +23,7 @@ pub struct IngestReplicaConfig {
         num_args=1..,
         value_delimiter = ','
     )]
-    pub ingester_addresses: Vec<String>,
+    pub ingester_addresses: Vec<IngesterAddress>,
 
     /// Sets how many queries the replica will handle simultaneously before
     /// rejecting further incoming requests.

--- a/clap_blocks/src/ingester_address.rs
+++ b/clap_blocks/src/ingester_address.rs
@@ -1,0 +1,308 @@
+//! Shared configuration and tests for accepting ingester addresses as arguments.
+
+use http::uri::{InvalidUri, InvalidUriParts, Uri};
+use snafu::Snafu;
+use std::{fmt::Display, str::FromStr};
+
+/// An address to an ingester's gRPC API. Create by using `IngesterAddress::from_str`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IngesterAddress {
+    uri: Uri,
+}
+
+/// Why a specified ingester address might be invalid
+#[allow(missing_docs)]
+#[derive(Snafu, Debug)]
+pub enum Error {
+    #[snafu(context(false))]
+    Invalid { source: InvalidUri },
+
+    #[snafu(display("Port is required; no port found in `{value}`"))]
+    MissingPort { value: String },
+
+    #[snafu(context(false))]
+    InvalidParts { source: InvalidUriParts },
+}
+
+impl FromStr for IngesterAddress {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let uri = Uri::from_str(s)?;
+
+        if uri.port().is_none() {
+            return MissingPortSnafu { value: s }.fail();
+        }
+
+        let uri = if uri.scheme().is_none() {
+            Uri::from_str(&format!("http://{}", s))?
+        } else {
+            uri
+        };
+
+        Ok(Self { uri })
+    }
+}
+
+impl Display for IngesterAddress {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.uri)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::{error::ErrorKind, Parser};
+    use std::env;
+    use test_helpers::{assert_contains, assert_error};
+
+    /// Applications such as the router MUST have valid ingester addresses.
+    #[derive(Debug, Clone, clap::Parser)]
+    struct RouterConfig {
+        #[clap(
+            long = "ingester-addresses",
+            env = "TEST_INFLUXDB_IOX_INGESTER_ADDRESSES",
+            required = true,
+            num_args=1..,
+            value_delimiter = ','
+        )]
+        pub ingester_addresses: Vec<IngesterAddress>,
+    }
+
+    #[test]
+    fn error_if_not_specified_when_required() {
+        assert_error!(
+            RouterConfig::try_parse_from(["my_binary"]),
+            ref e if e.kind() == ErrorKind::MissingRequiredArgument
+        );
+    }
+
+    /// Applications such as the querier might not have any ingester addresses, but if they have
+    /// any, they should be valid.
+    #[derive(Debug, Clone, clap::Parser)]
+    struct QuerierConfig {
+        #[clap(
+            long = "ingester-addresses",
+            env = "TEST_INFLUXDB_IOX_INGESTER_ADDRESSES",
+            required = false,
+            num_args=0..,
+            value_delimiter = ','
+        )]
+        pub ingester_addresses: Vec<IngesterAddress>,
+    }
+
+    #[test]
+    fn empty_if_not_specified_when_optional() {
+        assert!(QuerierConfig::try_parse_from(["my_binary"])
+            .unwrap()
+            .ingester_addresses
+            .is_empty());
+    }
+
+    fn both_types_valid(args: &[&'static str], expected: &[&'static str]) {
+        let router = RouterConfig::try_parse_from(args).unwrap();
+        let actual: Vec<_> = router
+            .ingester_addresses
+            .iter()
+            .map(ToString::to_string)
+            .collect();
+        assert_eq!(actual, expected);
+
+        let querier = QuerierConfig::try_parse_from(args).unwrap();
+        let actual: Vec<_> = querier
+            .ingester_addresses
+            .iter()
+            .map(ToString::to_string)
+            .collect();
+        assert_eq!(actual, expected);
+    }
+
+    fn both_types_error(args: &[&'static str], expected_error_message: &'static str) {
+        assert_contains!(
+            RouterConfig::try_parse_from(args).unwrap_err().to_string(),
+            expected_error_message
+        );
+        assert_contains!(
+            QuerierConfig::try_parse_from(args).unwrap_err().to_string(),
+            expected_error_message
+        );
+    }
+
+    #[test]
+    fn accepts_one() {
+        let args = [
+            "my_binary",
+            "--ingester-addresses",
+            "http://example.com:1234",
+        ];
+        let expected = ["http://example.com:1234/"];
+
+        both_types_valid(&args, &expected);
+    }
+
+    #[test]
+    fn accepts_two() {
+        let args = [
+            "my_binary",
+            "--ingester-addresses",
+            "http://example.com:1234,http://example.com:5678",
+        ];
+        let expected = ["http://example.com:1234/", "http://example.com:5678/"];
+
+        both_types_valid(&args, &expected);
+    }
+
+    #[test]
+    fn rejects_any_invalid_uri() {
+        let args = [
+            "my_binary",
+            "--ingester-addresses",
+            "http://example.com:1234,", // note the trailing comma; empty URIs are invalid
+        ];
+        let expected = "error: invalid value '' for '--ingester-addresses";
+
+        both_types_error(&args, expected);
+    }
+
+    #[test]
+    fn rejects_uri_without_port() {
+        let args = [
+            "my_binary",
+            "--ingester-addresses",
+            "example.com,http://example.com:1234",
+        ];
+        let expected = "Port is required; no port found in `example.com`";
+
+        both_types_error(&args, expected);
+    }
+
+    #[test]
+    fn no_scheme_assumes_http() {
+        let args = [
+            "my_binary",
+            "--ingester-addresses",
+            "http://example.com:1234,somescheme://0.0.0.0:1000,127.0.0.1:8080",
+        ];
+        let expected = [
+            "http://example.com:1234/",
+            "somescheme://0.0.0.0:1000/",
+            "http://127.0.0.1:8080/",
+        ];
+
+        both_types_valid(&args, &expected);
+    }
+
+    #[test]
+    fn specifying_flag_multiple_times_works() {
+        let args = [
+            "my_binary",
+            "--ingester-addresses",
+            "http://example.com:1234",
+            "--ingester-addresses",
+            "somescheme://0.0.0.0:1000",
+            "--ingester-addresses",
+            "127.0.0.1:8080",
+        ];
+        let expected = [
+            "http://example.com:1234/",
+            "somescheme://0.0.0.0:1000/",
+            "http://127.0.0.1:8080/",
+        ];
+
+        both_types_valid(&args, &expected);
+    }
+
+    #[test]
+    fn specifying_flag_multiple_times_and_using_commas_works() {
+        let args = [
+            "my_binary",
+            "--ingester-addresses",
+            "http://example.com:1234",
+            "--ingester-addresses",
+            "somescheme://0.0.0.0:1000,127.0.0.1:8080",
+        ];
+        let expected = [
+            "http://example.com:1234/",
+            "somescheme://0.0.0.0:1000/",
+            "http://127.0.0.1:8080/",
+        ];
+
+        both_types_valid(&args, &expected);
+    }
+
+    /// Use an environment variable name not shared with any other config to avoid conflicts when
+    /// setting the var in tests.
+    /// Applications such as the router MUST have valid ingester addresses.
+    #[derive(Debug, Clone, clap::Parser)]
+    struct EnvRouterConfig {
+        #[clap(
+            long = "ingester-addresses",
+            env = "NO_CONFLICT_ROUTER_TEST_INFLUXDB_IOX_INGESTER_ADDRESSES",
+            required = true,
+            num_args=1..,
+            value_delimiter = ','
+        )]
+        pub ingester_addresses: Vec<IngesterAddress>,
+    }
+
+    #[test]
+    fn required_and_specified_via_environment_variable() {
+        env::set_var(
+            "NO_CONFLICT_ROUTER_TEST_INFLUXDB_IOX_INGESTER_ADDRESSES",
+            "http://example.com:1234,somescheme://0.0.0.0:1000,127.0.0.1:8080",
+        );
+        let args = ["my_binary"];
+        let expected = [
+            "http://example.com:1234/",
+            "somescheme://0.0.0.0:1000/",
+            "http://127.0.0.1:8080/",
+        ];
+
+        let router = EnvRouterConfig::try_parse_from(args).unwrap();
+        let actual: Vec<_> = router
+            .ingester_addresses
+            .iter()
+            .map(ToString::to_string)
+            .collect();
+        assert_eq!(actual, expected);
+    }
+
+    /// Use an environment variable name not shared with any other config to avoid conflicts when
+    /// setting the var in tests.
+    /// Applications such as the querier might not have any ingester addresses, but if they have
+    /// any, they should be valid.
+    #[derive(Debug, Clone, clap::Parser)]
+    struct EnvQuerierConfig {
+        #[clap(
+            long = "ingester-addresses",
+            env = "NO_CONFLICT_QUERIER_TEST_INFLUXDB_IOX_INGESTER_ADDRESSES",
+            required = false,
+            num_args=0..,
+            value_delimiter = ','
+        )]
+        pub ingester_addresses: Vec<IngesterAddress>,
+    }
+
+    #[test]
+    fn optional_and_specified_via_environment_variable() {
+        env::set_var(
+            "NO_CONFLICT_QUERIER_TEST_INFLUXDB_IOX_INGESTER_ADDRESSES",
+            "http://example.com:1234,somescheme://0.0.0.0:1000,127.0.0.1:8080",
+        );
+        let args = ["my_binary"];
+        let expected = [
+            "http://example.com:1234/",
+            "somescheme://0.0.0.0:1000/",
+            "http://127.0.0.1:8080/",
+        ];
+
+        let querier = EnvQuerierConfig::try_parse_from(args).unwrap();
+        let actual: Vec<_> = querier
+            .ingester_addresses
+            .iter()
+            .map(ToString::to_string)
+            .collect();
+        assert_eq!(actual, expected);
+    }
+}

--- a/clap_blocks/src/lib.rs
+++ b/clap_blocks/src/lib.rs
@@ -19,6 +19,7 @@ pub mod garbage_collector;
 pub mod ingest_replica;
 pub mod ingester;
 pub mod ingester2;
+pub mod ingester_address;
 pub mod object_store;
 pub mod querier;
 pub mod router;

--- a/clap_blocks/src/router2.rs
+++ b/clap_blocks/src/router2.rs
@@ -1,5 +1,6 @@
 //! CLI config for the router using the RPC write path
 
+use crate::ingester_address::IngesterAddress;
 use std::{num::ParseIntError, time::Duration};
 
 /// CLI config for the router using the RPC write path
@@ -40,7 +41,7 @@ pub struct Router2Config {
         num_args=1..,
         value_delimiter = ','
     )]
-    pub ingester_addresses: Vec<String>,
+    pub ingester_addresses: Vec<IngesterAddress>,
 
     /// Write buffer topic/database that should be used.
     // This isn't really relevant to the RPC write path and will be removed eventually.

--- a/ioxd_ingest_replica/src/lib.rs
+++ b/ioxd_ingest_replica/src/lib.rs
@@ -145,7 +145,11 @@ pub async fn create_ingest_replica_server_type(
 ) -> Result<Arc<dyn ServerType>> {
     let grpc = ingest_replica::new(
         catalog,
-        ingest_replica_config.ingester_addresses.clone(),
+        ingest_replica_config
+            .ingester_addresses
+            .iter()
+            .map(ToString::to_string)
+            .collect(),
         exec,
         Arc::clone(&metrics),
     )

--- a/ioxd_querier/src/lib.rs
+++ b/ioxd_querier/src/lib.rs
@@ -214,7 +214,7 @@ pub async fn create_querier_server_type(
             }
             Some(create_ingester_connections(
                 None,
-                Some(list),
+                Some(list.iter().map(|addr| addr.to_string().into()).collect()),
                 Arc::clone(&catalog_cache),
                 args.querier_config.ingester_circuit_breaker_threshold,
             ))

--- a/ioxd_router/src/lib.rs
+++ b/ioxd_router/src/lib.rs
@@ -282,11 +282,9 @@ pub async fn create_router2_server_type(
     // 1. START: Different Setup Per Router Path: this part is only relevant to using RPC write
     //    path and should not be added to `create_router_server_type`.
 
-    // Hack to handle multiple ingester addresses separated by commas in potentially many uses of
-    // the CLI arg
-    let ingester_connections = router_config.ingester_addresses.join(",");
-    let ingester_connections = ingester_connections.split(',').map(|addr| {
-        let endpoint = Endpoint::from_shared(format!("http://{addr}"))
+    let ingester_connections = router_config.ingester_addresses.iter().map(|addr| {
+        let addr = addr.to_string();
+        let endpoint = Endpoint::from_shared(hyper::body::Bytes::from(addr.clone()))
             .expect("invalid ingester connection address");
         (
             LazyConnector::new(endpoint, router_config.rpc_write_timeout_seconds),


### PR DESCRIPTION
Fixes #6418.

Makes sure the querier, the router, and the ingest replica CLI all accept and validate ingester addresses the same, except whether or not at least one value is required.

I saw https://github.com/influxdata/influxdb_iox/pull/6740 that added enforcement that the address *must* contain a scheme, but sometimes I'm lazy and I don't want to type `http://` 😝

This doesn't _overwrite_ any existing scheme, but if there's _no_ scheme it'll assume `http://`.

This makes it so that `--ingester-addresses`/`INFLUXDB_IOX_INGESTER_ADDRESSES`  behaves exactly the same in:

- router2
- querier
- ingest replica (not used yet)
