### PR TITLE
test(catalog): independent test state

### DIFF
--- a/iox_catalog/src/mem.rs
+++ b/iox_catalog/src/mem.rs
@@ -1794,7 +1794,11 @@ mod tests {
 
     #[tokio::test]
     async fn test_catalog() {
-        let metrics = Arc::new(metric::Registry::default());
-        crate::interface::test_helpers::test_catalog(Arc::new(MemCatalog::new(metrics))).await;
+        crate::interface::test_helpers::test_catalog(|| async {
+            let metrics = Arc::new(metric::Registry::default());
+            let x: Arc<dyn Catalog> = Arc::new(MemCatalog::new(metrics));
+            x
+        })
+        .await;
     }
 }

--- a/iox_catalog/src/sqlite.rs
+++ b/iox_catalog/src/sqlite.rs
@@ -2371,9 +2371,12 @@ mod tests {
 
     #[tokio::test]
     async fn test_catalog() {
-        let sqlite = setup_db().await;
-        let sqlite: Arc<dyn Catalog> = Arc::new(sqlite);
-        interface::test_helpers::test_catalog(sqlite).await;
+        interface::test_helpers::test_catalog(|| async {
+            let sqlite = setup_db().await;
+            let sqlite: Arc<dyn Catalog> = Arc::new(sqlite);
+            sqlite
+        })
+        .await;
     }
 
     #[tokio::test]


### PR DESCRIPTION
OMG YES - clean test state for each catalog "test" 🎉 🦜 

---

* test(catalog): independent test state (aa74bb629)
      
      All our catalog tests run as one test, over one database connection.
      Prior to this commit, there was no state reset during test execution, so
      earlier tests would pollute the state of later tests, making it an
      increasingly complex and intermingled set of tests trying to assert
      their entities while ignoring other, previously created entities (or
      changing the order of test execution in search of the golden ordering
      that makes everything great again.)
      
      This is a bit of a hack, and is not how I'd have structured catalog
      testing w/ clean state if I was writing it fresh. It is what it is.
      
      This has been driving me mad for SO LONG it's SO BAD <shakes fist>.