### PR TITLE
refactor(catalog): expose deleted_at on Namespace

### DIFF
--- a/compactor2/src/test_util.rs
+++ b/compactor2/src/test_util.rs
@@ -218,6 +218,7 @@ impl NamespaceBuilder {
                     max_tables: 10,
                     max_columns_per_table: 10,
                     retention_period_ns: None,
+                    deleted_at: None,
                 },
                 schema: NamespaceSchema {
                     id,

--- a/data_types/src/lib.rs
+++ b/data_types/src/lib.rs
@@ -483,6 +483,8 @@ pub struct Namespace {
     pub max_tables: i32,
     /// The maximum number of columns per table in this namespace
     pub max_columns_per_table: i32,
+    /// When this file was marked for deletion.
+    pub deleted_at: Option<Timestamp>,
 }
 
 /// Schema collection for a namespace. This is an in-memory object useful for a schema

--- a/iox_catalog/src/mem.rs
+++ b/iox_catalog/src/mem.rs
@@ -305,6 +305,7 @@ impl NamespaceRepo for MemTxn {
             max_tables: DEFAULT_MAX_TABLES,
             max_columns_per_table: DEFAULT_MAX_COLUMNS_PER_TABLE,
             retention_period_ns,
+            deleted_at: None,
         };
         stage.namespaces.push(namespace);
         Ok(stage.namespaces.last().unwrap().clone())

--- a/router/src/namespace_resolver/ns_autocreation.rs
+++ b/router/src/namespace_resolver/ns_autocreation.rs
@@ -257,6 +257,7 @@ mod tests {
                 max_tables: iox_catalog::DEFAULT_MAX_TABLES,
                 max_columns_per_table: iox_catalog::DEFAULT_MAX_COLUMNS_PER_TABLE,
                 retention_period_ns: TEST_RETENTION_PERIOD_NS,
+                deleted_at: None,
             }
         );
     }


### PR DESCRIPTION
I am blown away that there aren't more references to this struct to update 🤷 

Part of https://github.com/influxdata/influxdb_iox/issues/6492.

---

* refactor(catalog): expose deleted_at on Namespace (a85dcd745)
      
      Add the new catalog column to the Namespace representation/model.