### PR TITLE
test(router): router restarts + caching effects

### DIFF
--- a/router/tests/grpc.rs
+++ b/router/tests/grpc.rs
@@ -353,6 +353,15 @@ async fn test_update_namespace_0_retention_period() {
             assert_eq!(name, "platanos");
         }
     );
+
+    // The router restarts, and writes are then accepted.
+    let ctx = ctx.restart();
+
+    let response = ctx
+        .write_lp("bananas", "test", "platanos,tag1=A,tag2=B val=42i 42424242")
+        .await
+        .expect("cached entry should be removed");
+    assert_eq!(response.status(), StatusCode::NO_CONTENT);
 }
 
 /// Ensure updating a namespace with a negative retention period fails.


### PR DESCRIPTION
This change to the router's e2e testing harness allows us to simulate a router restart, and then uses that functionality to assert the current behaviour of retention period caching (https://github.com/influxdata/influxdb_iox/issues/6175).

This is a pre-requisite to having a similar test for namespace soft-deletion (https://github.com/influxdata/influxdb_iox/issues/6492).

---

* refactor(e2e): simulate router restart (ce12daa96)
      
      Allow a router to be "restarted" within an e2e test.

* test(router): retention change after cache reset (4a0149a41)
      
      Assert that the new retention period value is used once a router is
      restarted and the cache converged.