### PR TITLE
chore: add shutdown logging

### DIFF
--- a/compactor2/src/compactor.rs
+++ b/compactor2/src/compactor.rs
@@ -58,7 +58,7 @@ impl Compactor2 {
                 _ = async {
                     compact(config.partition_concurrency, config.partition_timeout, Arc::clone(&job_semaphore), &components).await;
 
-                    info!("comapctor done");
+                    info!("compactor done");
                 } => {}
             }
         });
@@ -69,6 +69,7 @@ impl Compactor2 {
 
     /// Trigger shutdown. You should [join](Self::join) afterwards.
     pub fn shutdown(&self) {
+        info!("compactor shutting down");
         self.shutdown.cancel();
     }
 


### PR DESCRIPTION
Describe your proposed changes here.
This PR corrects a spelling mistake in an existing compactor done log message, and adds a log message as the compactor begins to shut down.  I'm not finding the existing `comapctor done`, or the `Compactor was not shut down properly` messages in the log.  A log message indicating we're beginning to shut down will make it easier to detect shut downs that time out, etc.

- [x] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb_iox/blob/main/README.md).
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
