### PR TITLE
refactor: SequenceNumberSet::as_bytes -> to_bytes

### DIFF
--- a/data_types/src/sequence_number_set.rs
+++ b/data_types/src/sequence_number_set.rs
@@ -31,12 +31,12 @@ impl SequenceNumberSet {
         self.0.andnot_inplace(&other.0)
     }
 
-    /// Serialise `self` into a set of bytes.
+    /// Serialise `self` into an array of bytes.
     ///
     /// [This document][spec] describes the serialised format.
     ///
     /// [spec]: https://github.com/RoaringBitmap/RoaringFormatSpec/
-    pub fn as_bytes(&self) -> Vec<u8> {
+    pub fn to_bytes(&self) -> Vec<u8> {
         self.0.serialize()
     }
 


### PR DESCRIPTION
A pick of the first commit in https://github.com/influxdata/influxdb_iox/pull/6608 which I intend to close.

---

* refactor: SequenceNumberSet::as_bytes -> to_bytes (1805f7fbe)
      
      The conversion is not (always) a cheap cast/conversion, and therefore
      should be prefixed with "to_" and not "as_".