### PR TITLE
chore: change default for compactor_config.query_exec_thread_count 

### DIFF
--- a/clap_blocks/src/compactor2.rs
+++ b/clap_blocks/src/compactor2.rs
@@ -72,13 +72,13 @@ pub struct Compactor2Config {
 
     /// Number of threads to use for the compactor query execution,
     /// compaction and persistence.
+    /// If not specified, defaults to one less than the number of cores on the system
     #[clap(
         long = "query-exec-thread-count",
         env = "INFLUXDB_IOX_QUERY_EXEC_THREAD_COUNT",
-        default_value = "4",
         action
     )]
-    pub query_exec_thread_count: usize,
+    pub query_exec_thread_count: Option<usize>,
 
     /// Size of memory pool used during compaction plan execution, in
     /// bytes.

--- a/influxdb_iox/src/commands/run/all_in_one.rs
+++ b/influxdb_iox/src/commands/run/all_in_one.rs
@@ -420,7 +420,7 @@ impl Config {
             compaction_job_concurrency: NonZeroUsize::new(1).unwrap(),
             compaction_partition_scratchpad_concurrency: NonZeroUsize::new(1).unwrap(),
             compaction_partition_minute_threshold: 10,
-            query_exec_thread_count: 1,
+            query_exec_thread_count: Some(1),
             exec_mem_pool_bytes,
             max_desired_file_size_bytes: 30_000,
             percentage_max_file_size: 30,

--- a/influxdb_iox/src/commands/run/compactor2.rs
+++ b/influxdb_iox/src/commands/run/compactor2.rs
@@ -106,7 +106,10 @@ pub async fn command(config: Config) -> Result<(), Error> {
         StorageId::from("iox_scratchpad"),
     );
 
-    let num_threads = config.compactor_config.query_exec_thread_count.unwrap_or_else(||num_cpus::get() - (1 as usize));
+    let num_threads = config
+        .compactor_config
+        .query_exec_thread_count
+        .unwrap_or_else(|| num_cpus::get() - (1 as usize));
     info!(%num_threads, "using specified number of threads");
 
     let exec = Arc::new(Executor::new_with_config(ExecutorConfig {

--- a/influxdb_iox/src/commands/run/compactor2.rs
+++ b/influxdb_iox/src/commands/run/compactor2.rs
@@ -109,11 +109,11 @@ pub async fn command(config: Config) -> Result<(), Error> {
     let num_threads = config
         .compactor_config
         .query_exec_thread_count
-        .unwrap_or_else(|| num_cpus::get() - (1 as usize));
+        .unwrap_or_else(|| num_cpus::get() - 1_usize);
     info!(%num_threads, "using specified number of threads");
 
     let exec = Arc::new(Executor::new_with_config(ExecutorConfig {
-        num_threads: num_threads,
+        num_threads,
         target_query_partitions: num_threads,
         object_stores: [&parquet_store_real, &parquet_store_scratchpad]
             .into_iter()

--- a/influxdb_iox/src/commands/run/compactor2.rs
+++ b/influxdb_iox/src/commands/run/compactor2.rs
@@ -106,9 +106,12 @@ pub async fn command(config: Config) -> Result<(), Error> {
         StorageId::from("iox_scratchpad"),
     );
 
+    let num_threads = config.compactor_config.query_exec_thread_count.unwrap_or_else(||num_cpus::get() - (1 as usize));
+    info!(%num_threads, "using specified number of threads");
+
     let exec = Arc::new(Executor::new_with_config(ExecutorConfig {
-        num_threads: config.compactor_config.query_exec_thread_count,
-        target_query_partitions: config.compactor_config.query_exec_thread_count,
+        num_threads: num_threads,
+        target_query_partitions: num_threads,
         object_stores: [&parquet_store_real, &parquet_store_scratchpad]
             .into_iter()
             .map(|store| (store.id(), Arc::clone(store.object_store())))


### PR DESCRIPTION
This PR makes the default for compactor_config.query_exec_thread_count be one less than the CPU count, as discussed in the comments for https://github.com/influxdata/influxdb_iox/pull/7022, following the pattern used for https://github.com/influxdata/influxdb_iox/blob/b785f751b354c65d2e0548972f9e94b50e118612/clap_blocks/src/querier.rs#L50-L58

- [x] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb_iox/blob/main/README.md).
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
