### PR TITLE
perf(wal): dedicated file writer I/O thread

### DIFF
--- a/wal/src/lib.rs
+++ b/wal/src/lib.rs
@@ -389,11 +389,13 @@ impl std::fmt::Debug for Wal {
     }
 }
 
+#[derive(Debug)]
 struct Segments {
     closed_segments: BTreeMap<SegmentId, ClosedSegment>,
     open_segment: OpenSegmentFileWriter,
 }
 
+#[derive(Debug)]
 struct WalBuffer {
     ops: Vec<SequencedWalOp>,
     notify_flush: tokio::sync::watch::Sender<Option<WriteResult>>,

--- a/wal/src/lib.rs
+++ b/wal/src/lib.rs
@@ -18,12 +18,10 @@ use generated_types::{
     google::{FieldViolation, OptionalField},
     influxdata::iox::wal::v1::{
         sequenced_wal_op::Op as WalOp, SequencedWalOp as ProtoSequencedWalOp,
-        WalOpBatch as ProtoWalOpBatch,
     },
 };
 use observability_deps::tracing::info;
 use parking_lot::Mutex;
-use prost::Message;
 use snafu::prelude::*;
 use std::{
     collections::BTreeMap,
@@ -34,8 +32,10 @@ use std::{
     time::Duration,
 };
 use tokio::sync::watch;
+use writer_thread::WriterIoThreadHandle;
 
 pub mod blocking;
+mod writer_thread;
 
 const WAL_FLUSH_INTERVAL: Duration = Duration::from_millis(10);
 
@@ -192,7 +192,7 @@ const SEGMENT_FILE_EXTENSION: &str = "dat";
 /// is not supported.
 pub struct Wal {
     root: PathBuf,
-    segments: Mutex<Segments>,
+    segments: Arc<Mutex<Segments>>,
     next_id_source: Arc<AtomicU64>,
     buffer: Mutex<WalBuffer>,
 }
@@ -271,10 +271,10 @@ impl Wal {
 
         let wal = Self {
             root,
-            segments: Mutex::new(Segments {
+            segments: Arc::new(Mutex::new(Segments {
                 closed_segments,
                 open_segment,
-            }),
+            })),
             next_id_source,
             buffer: Mutex::new(buffer),
         };
@@ -328,6 +328,15 @@ impl Wal {
     }
 
     async fn flush_buffer_background_task(&self) {
+        // Start a separate I/O thread to handle the serialisation, compression,
+        // and actual file I/O.
+        //
+        // This prevents the file I/O from blocking an async runtime thread,
+        // which in turn would starve it of the ability to service other tasks.
+        //
+        // When this handle is dropped, the I/O thread is gracefully stopped.
+        let io_thread = WriterIoThreadHandle::new(Arc::clone(&self.segments));
+
         let mut interval = tokio::time::interval(WAL_FLUSH_INTERVAL);
 
         loop {
@@ -343,28 +352,7 @@ impl Wal {
                 std::mem::replace(&mut *b, WalBuffer::new())
             };
 
-            // do the encoding while we're not holding any locks
-            let ops: Vec<_> = filled_buffer
-                .ops
-                .into_iter()
-                .map(ProtoSequencedWalOp::from)
-                .collect();
-            let batch = ProtoWalOpBatch { ops };
-            let encoded = batch.encode_to_vec();
-
-            // now write the data and let everyone know how things went
-            let res = {
-                let mut segments = self.segments.lock();
-                match segments.open_segment.write(&encoded) {
-                    Ok(summary) => WriteResult::Ok(summary),
-                    Err(e) => WriteResult::Err(e.to_string()),
-                }
-            };
-
-            // Do not panic if no thread is waiting for the flush notification -
-            // this may be the case if all writes disconnected before the WAL
-            // was flushed.
-            let _ = filled_buffer.notify_flush.send(Some(res));
+            io_thread.enqueue_batch(filled_buffer).await;
         }
     }
 

--- a/wal/src/writer_thread.rs
+++ b/wal/src/writer_thread.rs
@@ -1,0 +1,151 @@
+use std::{sync::Arc, thread::JoinHandle};
+
+use generated_types::influxdata::iox::wal::v1 as proto;
+use observability_deps::tracing::{debug, warn};
+use parking_lot::Mutex;
+use prost::Message;
+use tokio::sync::mpsc;
+
+use crate::{Segments, WalBuffer, WriteResult};
+
+/// The number of [`WalBuffer`] that may be enqueued for persistence.
+const FLUSH_QUEUE_DEPTH: usize = 1;
+
+/// An inner/non-pub struct that contains the [`WriterIoThreadHandle`] state -
+/// this lets the [`Drop`] impl of [`WriterIoThreadHandle`] destroy the channel
+/// tx and consume the [`JoinHandle`].
+struct HandleInner {
+    batch_tx: mpsc::Sender<WalBuffer>,
+    join_handle: JoinHandle<()>,
+}
+
+/// A [`WriterIoThreadHandle`] provides an interface for the caller to interact
+/// with an I/O thread.
+///
+/// Constructing a [`WriterIoThreadHandle`] spawns an I/O thread, and dropping
+/// the handle gracefully stops the I/O thread after it finishes flushing the
+/// current batch it is processing, if any.
+pub(crate) struct WriterIoThreadHandle {
+    inner: Option<HandleInner>,
+}
+
+impl WriterIoThreadHandle {
+    /// Spawn an I/O writer thread, flushing batches to the open segment in
+    /// `segments`.
+    pub(crate) fn new(segments: Arc<Mutex<Segments>>) -> Self {
+        let (batch_tx, batch_rx) = mpsc::channel(FLUSH_QUEUE_DEPTH);
+
+        // Spawn the I/O thread and retain a handle to wait for shutdown when
+        // this handle is dropped.
+        let join_handle = std::thread::Builder::new()
+            .name("WAL writer I/O thread".to_string())
+            .spawn(move || {
+                let writer = WriterIoThread::new(batch_rx, segments);
+                writer.run();
+            })
+            .expect("failed to spawn WAL I/O thread");
+
+        Self {
+            inner: Some(HandleInner {
+                batch_tx,
+                join_handle,
+            }),
+        }
+    }
+
+    /// Enqueue `batch` to be wrote to the current open segment file.
+    ///
+    /// Once flushed to disk and durable (or the write failed) the write result
+    /// is broadcast through the embedded channel.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the I/O thread is not running.
+    pub(crate) async fn enqueue_batch(&self, batch: WalBuffer) {
+        self.inner
+            .as_ref()
+            .unwrap()
+            .batch_tx
+            .send(batch)
+            .await
+            .expect("wal writer IO thread is dead")
+    }
+}
+
+impl Drop for WriterIoThreadHandle {
+    fn drop(&mut self) {
+        let inner = self.inner.take().unwrap();
+        // Signal to the IO thread that it should stop.
+        drop(inner.batch_tx);
+        // Wait for the IO thread to gracefully stop, discarding any errors -
+        // attempting to unwrap/panic in this Drop implwill cause an immediate
+        // SIGSEV.
+        let _ = inner.join_handle.join();
+    }
+}
+
+/// The state of the I/O actor thread.
+struct WriterIoThread {
+    /// A channel to receive batches to flush.
+    batch_rx: mpsc::Receiver<WalBuffer>,
+    /// The set of segments, used to obtain the current open segment handle.
+    segments: Arc<Mutex<Segments>>,
+}
+
+impl WriterIoThread {
+    fn new(batch_rx: mpsc::Receiver<WalBuffer>, segments: Arc<Mutex<Segments>>) -> Self {
+        Self { batch_rx, segments }
+    }
+
+    fn run(mut self) {
+        // Maintain a serialisation buffer for re-use, instead of allocating a
+        // new one for each batch.
+        let mut proto_data = Vec::with_capacity(4 * 1024);
+
+        loop {
+            proto_data.clear();
+
+            let batch = match self.batch_rx.blocking_recv() {
+                Some(batch) => batch,
+                None => {
+                    // The batch channel has closed - all handles have been
+                    // dropped.
+                    debug!("stopping WAL IO thread");
+                    return;
+                }
+            };
+
+            // Encode the batch into the proto types
+            let ops: Vec<_> = batch
+                .ops
+                .into_iter()
+                .map(proto::SequencedWalOp::from)
+                .collect();
+            let proto_batch = proto::WalOpBatch { ops };
+
+            // Generate the binary protobuf message, storing it into proto_data
+            proto_batch
+                .encode(&mut proto_data)
+                .expect("encoding batch into vec cannot fail");
+
+            // Write the serialised data to the current open segment file.
+            let res = {
+                let mut segments = self.segments.lock();
+                match segments.open_segment.write(&proto_data) {
+                    Ok(summary) => WriteResult::Ok(summary),
+                    Err(e) => {
+                        warn!(erorr=%e, "failed to write WAL batch");
+                        WriteResult::Err(e.to_string())
+                    }
+                }
+            };
+
+            // Broadcast the result to all writers to this batch.
+            //
+            // Do not panic if no thread is waiting for the flush notification -
+            // this may be the case if all writes disconnected before the WAL
+            // was flushed.
+            let _ = batch.notify_flush.send(Some(res));
+        }
+    }
+}

--- a/wal/src/writer_thread.rs
+++ b/wal/src/writer_thread.rs
@@ -1,7 +1,7 @@
 use std::{sync::Arc, thread::JoinHandle};
 
 use generated_types::influxdata::iox::wal::v1 as proto;
-use observability_deps::tracing::{debug, warn};
+use observability_deps::tracing::{debug, error};
 use parking_lot::Mutex;
 use prost::Message;
 use tokio::sync::mpsc;
@@ -134,7 +134,7 @@ impl WriterIoThread {
                 match segments.open_segment.write(&proto_data) {
                     Ok(summary) => WriteResult::Ok(summary),
                     Err(e) => {
-                        warn!(erorr=%e, "failed to write WAL batch");
+                        error!(error=%e, "failed to write WAL batch");
                         WriteResult::Err(e.to_string())
                     }
                 }


### PR DESCRIPTION
Moves the buffer serialisation, compression and blocking file syscalls / I/O from the async runtime threads.

This should help reduce the latency variance, which would be much more pronounced when running with fewer threads/cores.

---

* refactor: derive Debug on WAL types (d57b3319c)
      
      Deriving debug is highly encouraged so that Result::unwrap() and friends
      can print the state of an object if it is causing a panic (it's
      impossible to call unwrap() otherwise!)

* perf(wal): use dedicated writer I/O thread (7c6d80c73)
      
      Change the WAL buffer flusher to use a dedicated I/O thread instead of
      performing serialisation & blocking file I/O on the async runtime
      threads. This should reduce runtime blocking / latency variance on the
      async threads.
      
      The added overhead is 1 channel send, but this is per WAL batch of
      writes (not per DML write, or worse, per file write). This impl also
      amortises allocation of the serialisation buffer, rather than growing
      one incrementally for each batch.