### PR TITLE
refactor(metric): increase partition bucket range

### DIFF
--- a/ingester2/src/query/result_instrumentation.rs
+++ b/ingester2/src/query/result_instrumentation.rs
@@ -166,7 +166,7 @@ impl<T> QueryResultInstrumentation<T> {
             .register_metric_with_options::<U64Histogram, _>(
                 "ingester_query_result_partition",
                 "distribution of query result partition count sent to the client",
-                || U64HistogramOptions::new([1, 2, 3, 4, 5]),
+                || U64HistogramOptions::new([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),
             )
             .recorder(&[]);
 


### PR DESCRIPTION
We already see 3 partitions in a low-volume cluster, so clearly we need more range in the histogram!

It's true ⬇️ 

---

* refactor(metric): increase partition bucket range (90f8166b4)
      
      More buckets -> more better.