### PR TITLE
docs: ingester overview + subsystem docs

### DIFF
--- a/ingester/src/dml_sink/mod.rs
+++ b/ingester/src/dml_sink/mod.rs
@@ -1,3 +1,5 @@
+//! A composable abstraction for processing write requests.
+
 mod r#trait;
 pub(crate) use r#trait::*;
 

--- a/ingester2/src/buffer_tree/mod.rs
+++ b/ingester2/src/buffer_tree/mod.rs
@@ -1,3 +1,6 @@
+//! A mutable, hierarchical buffer structure of namespace -> table ->
+//! partition -> write payloads.
+
 pub(crate) mod namespace;
 pub(crate) mod partition;
 pub(crate) mod table;

--- a/ingester2/src/buffer_tree/partition.rs
+++ b/ingester2/src/buffer_tree/partition.rs
@@ -146,6 +146,8 @@ impl PartitionData {
         Ok(())
     }
 
+    /// Return an estimated cost of persisting the data buffered in this
+    /// [`PartitionData`].
     pub(crate) fn persist_cost_estimate(&self) -> usize {
         self.buffer.persist_cost_estimate()
     }

--- a/ingester2/src/buffer_tree/root.rs
+++ b/ingester2/src/buffer_tree/root.rs
@@ -53,6 +53,10 @@ use crate::{
 /// apply successive [`DmlOperation`] to its internal state, and makes the
 /// materialised result available through a streaming [`QueryExec`] execution.
 ///
+/// The tree is populated lazily/on-demand as [`DmlOperation`] are applied or
+/// the data is accessed, but some information is pre-cached and made available
+/// to the [`BufferTree`] for performance reasons (see [`PartitionCache`]).
+///
 /// # Read Consistency
 ///
 /// When [`BufferTree::query_exec()`] is called for a given table, a snapshot of
@@ -69,6 +73,7 @@ use crate::{
 ///
 /// [`TableData`]: crate::buffer_tree::table::TableData
 /// [`PartitionData`]: crate::buffer_tree::partition::PartitionData
+/// [`PartitionCache`]: crate::buffer_tree::partition::resolver::PartitionCache
 #[derive(Debug)]
 pub(crate) struct BufferTree<O> {
     /// The resolver of `(table_id, partition_key)` to [`PartitionData`].

--- a/ingester2/src/dml_sink/mod.rs
+++ b/ingester2/src/dml_sink/mod.rs
@@ -1,3 +1,5 @@
+//! A composable abstraction for processing write requests.
+
 mod r#trait;
 pub use r#trait::*;
 

--- a/ingester2/src/ingest_state.rs
+++ b/ingester2/src/ingest_state.rs
@@ -24,7 +24,7 @@ pub(crate) enum IngestStateError {
 
 impl IngestStateError {
     #[inline(always)]
-    fn to_bits(self) -> usize {
+    fn as_bits(self) -> usize {
         // Map the user-friendly enum to a u64 bitmap.
         let set = self as usize;
         debug_assert_eq!(set.count_ones(), 1); // A single bit
@@ -62,7 +62,7 @@ impl IngestState {
     /// Returns true if this call set the error state to `error`, false if
     /// `error` was already set.
     pub(crate) fn set(&self, error: IngestStateError) -> bool {
-        let set = error.to_bits();
+        let set = error.as_bits();
         let mut current = self.state.load(Ordering::Relaxed);
         loop {
             if current & set != 0 {
@@ -98,7 +98,7 @@ impl IngestState {
     /// Returns true if this call unset the `error` state, false if `error` was
     /// already unset.
     pub(crate) fn unset(&self, error: IngestStateError) -> bool {
-        let unset = error.to_bits();
+        let unset = error.as_bits();
         let mut current = self.state.load(Ordering::Relaxed);
         loop {
             if current & unset == 0 {
@@ -141,7 +141,7 @@ impl IngestState {
         if current != 0 {
             // Map the non-healthy state to an error using a "cold" function,
             // asking LLVM to move the mapping logic out of the happy/hot path.
-            return to_err(current);
+            return as_err(current);
         }
 
         Ok(())
@@ -154,12 +154,12 @@ impl IngestState {
 /// the user always sees (instead of potentially flip-flopping between "shutting
 /// down" and "persist saturated").
 #[cold]
-fn to_err(state: usize) -> Result<(), IngestStateError> {
-    if state & IngestStateError::GracefulStop.to_bits() != 0 {
+fn as_err(state: usize) -> Result<(), IngestStateError> {
+    if state & IngestStateError::GracefulStop.as_bits() != 0 {
         return Err(IngestStateError::GracefulStop);
     }
 
-    if state & IngestStateError::PersistSaturated.to_bits() != 0 {
+    if state & IngestStateError::PersistSaturated.as_bits() != 0 {
         return Err(IngestStateError::PersistSaturated);
     }
 
@@ -174,15 +174,15 @@ mod tests {
 
     #[test]
     fn test_disjoint_discriminant_bits() {
-        assert!(IngestStateError::PersistSaturated.to_bits() < usize::BITS as usize);
-        assert_eq!(IngestStateError::PersistSaturated.to_bits().count_ones(), 1);
+        assert!(IngestStateError::PersistSaturated.as_bits() < usize::BITS as usize);
+        assert_eq!(IngestStateError::PersistSaturated.as_bits().count_ones(), 1);
 
-        assert!(IngestStateError::GracefulStop.to_bits() < usize::BITS as usize);
-        assert_eq!(IngestStateError::PersistSaturated.to_bits().count_ones(), 1);
+        assert!(IngestStateError::GracefulStop.as_bits() < usize::BITS as usize);
+        assert_eq!(IngestStateError::PersistSaturated.as_bits().count_ones(), 1);
 
         assert_ne!(
-            IngestStateError::PersistSaturated.to_bits(),
-            IngestStateError::GracefulStop.to_bits()
+            IngestStateError::PersistSaturated.as_bits(),
+            IngestStateError::GracefulStop.as_bits()
         );
     }
 

--- a/ingester2/src/ingest_state.rs
+++ b/ingester2/src/ingest_state.rs
@@ -1,3 +1,9 @@
+//! Propagate subsystem error state between other subsystems.
+//!
+//! A [`IngestState`] allows disparate subsystems to broadcast their health
+//! state to other subsystems. Concretely, it is used to reject writes when the
+//! ingester is unable to process them.
+
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use crossbeam_utils::CachePadded;

--- a/ingester2/src/ingester_id.rs
+++ b/ingester2/src/ingester_id.rs
@@ -1,3 +1,7 @@
+//! A randomised, globally unique identifier of a single ingester instance.
+//!
+//! The value of this ID is expected to change between restarts of the ingester.
+
 use std::fmt::Display;
 
 use uuid::Uuid;

--- a/ingester2/src/lib.rs
+++ b/ingester2/src/lib.rs
@@ -1,12 +1,159 @@
 //! IOx Ingester V2 implementation.
 //!
+//! # Overview
+//!
+//! The purpose of the ingester is to receive RPC write requests, and batch them
+//! up until ready to be persisted. This buffered data must be durable (tolerant
+//! of a crash) and queryable via the Flight RPC query interface. Data is
+//! organised in a hierarchical structure (the [`BufferTree`]) to allow
+//! table-scoped queries, and partition-scoped persistence / parquet file
+//! generation.
+//!
+//! All buffered data is periodically persisted via a WAL file rotation, or
+//! selectively when a single partition has grown too large ("hot partition
+//! persistence").
+//!
+//! ```text
+//!
+//!                ┌──────────────┐        ┌──────────────┐
+//!                │  RPC Write   │        │  RPC Query   │
+//!                └──────────────┘        └──────────────┘
+//!                        │                       ▲
+//!                        ▼                       │
+//!                ┌──────────────┐                │
+//!                │     WAL      │                │
+//!                └──────────────┘                │
+//!                        │                       │
+//!                        │   ┌──────────────┐    │
+//!                        └──▶│  BufferTree  │────┘
+//!                            └──────────────┘
+//!                                    │
+//!                                    ▼
+//!                            ┌──────────────┐
+//!                            │   Persist    │
+//!                            └──────────────┘
+//!                                    │
+//!                                    ▼
+//!
+//!                             Object Storage
+//!
+//!
+//!
+//!                                                   (arrows show data flow)
+//!```
+//!
+//! The write path is composed together of implementers of the [`DmlSink`]
+//! abstraction, and likewise queries stream out of the [`QueryExec`]
+//! abstraction.
+//!
+//!
+//! ## Subsystems
+//!
+//! The Ingester is composed of multiple smaller, distinct subsystems that
+//! communicate / work together to provide the full ingester functionality.
+//!
+//! Each subsystem has its own documentation further describing the behaviours
+//! and problems it solves in more detail.
+//!
+//!
+//! ### [`BufferTree`]
+//!
+//! Perhaps not a "system" as such, but a single instance of the [`BufferTree`]
+//! is the central point of the ingester - all writes are buffered in the tree,
+//! and all queries execute against it. Persist operations persist data in the
+//! buffer tree, removing it once complete.
+//!
+//! All other systems either directly or indirectly operate on, or control
+//! operations against the [`BufferTree`].
+//!
+//!
+//! ### RPC Server
+//!
+//! External services communicate with the ingester via gRPC service calls. All
+//! gRPC handlers can be found in the [`grpc`] modules.
+//!
+//! The two main RPC endpoints are:
+//!
+//!  * Write: buffer new data in the ingester, issued by the router
+//!  * Query: return buffered data scoped by {namespace, table}, issued by the
+//!           queriers
+//!
+//! Both endpoints are latency sensitive, and the call durations are directly
+//! observable by end users.
+//!
+//! Writes commit to the [`wal`] for durability / crash tolerance and are
+//! buffered into the [`BufferTree`] in parallel. Queries execute against the
+//! [`BufferTree`], lazily streaming the results back to the queriers (lock
+//! acquisition and data copying is deferred until "pulled" by the querier).
+//!
+//! If the [`IngestState`] is marked as unhealthy/shutting down, then write
+//! requests are rejected with a "resource exhausted" error message until it
+//! becomes healthy again.
+//!
+//!
+//! ### Persist System
+//!
+//! The persist system is responsible for durably writing data to object
+//! storage; that includes compacting it (to remove duplicate/overwrote rows),
+//! generating a parquet file, uploading it to the configured object store, and
+//! inserting the necessary catalog state to make the new file queryable.
+//!
+//! Data is typically sourced from a [`BufferTree`], and once the new file is
+//! queryable, the data it contains is removed from the [`BufferTree`].
+//!
+//! Code that uses the persist system does so through the [`PersistQueue`]
+//! abstraction, implemented by the [`PersistHandle`].
+//!
+//! The persist system provides a logical queue of outstanding persist jobs, and
+//! a configurable number of worker tasks to execute them - see
+//! [`PersistHandle`] for detailed documentation. If the persist system is
+//! "saturated" (queue depth reached maximum) then further writes are rejected
+//! by setting the [`IngestState`] to [`IngestStateError::PersistSaturated`]
+//! until the queue depth is reduced.
+//!
+//! The persist system is driven mainly by WAL rotation (below), and interacts
+//! with the [`IngestState`] to provide back-pressure, indirectly controlling
+//! the memory utilisation of the Ingester (to prevent OOMs). Partitions with
+//! large volumes of writes (or otherwise problematic data) are prematurely
+//! persisted independently of the WAL rotation ("hot partition persistence").
+//!
+//!
+//! ### WAL
+//!
+//! The write-ahead log ([`wal`]) is used to durably record each operation
+//! against the [`BufferTree`] into a replay log, with a partial order. This
+//! happens synchronously in the hot write path, so WAL performance is a
+//! critical consideration.
+//!
+//! Once a write has been buffered in the [`BufferTree`] AND flushed to disk in
+//! the [`wal`], the request is ACKed to the user.
+//!
+//! If the ingester crashes / stops un-cleanly, then the WAL must be replayed to
+//! rebuild the in-memory state (the [`BufferTree`]) to prevent data loss. This
+//! has some quirks, discussed in "Write Reordering" below.
+//!
+//!
+//! #### WAL Rotation
+//!
+//! The WAL file is periodically rotated at a configurable interval, which
+//! triggers a full persistence of all buffered data in the ingester at the same
+//! time. This "full persist" indirectly affects the ingester in many ways:
+//!
+//!   * Limits the size of a single WAL file
+//!   * Limits the amount of buffered data, which in turn
+//!     * Limits the amount of WAL data to replay after a crash
+//!     * Limits the amount of data a querier must read & dedupe per query
+//!     * Limits the largest source of memory utilisation in the ingester
+//!     * Limits the amount of data in a partition that must be persisted
+//!
+//!
 //! ## Write Reordering
 //!
 //! A write that enters an `ingester2` instance can be reordered arbitrarily
 //! with concurrent write requests.
 //!
-//! For example, two gRPC writes can race to be committed to the WAL, and then
-//! race again to be buffered into the [`BufferTree`]. Writes to a
+//! For example, two gRPC writes can race to be committed to the [`wal`], and
+//! then race again to be buffered into the [`BufferTree`]. Writes to a
 //! [`BufferTree`] may arrive out-of-order w.r.t their assigned sequence
 //! numbers.
 //!
@@ -29,6 +176,14 @@
 //!
 //! [`BufferTree`]: crate::buffer_tree::BufferTree
 //! [`SequenceNumber`]: data_types::SequenceNumber
+//! [`PersistQueue`]: crate::persist::queue::PersistQueue
+//! [`PersistHandle`]: crate::persist::handle::PersistHandle
+//! [`IngestState`]: crate::ingest_state::IngestState
+//! [`grpc`]: crate::server::grpc
+//! [`DmlSink`]: crate::dml_sink::DmlSink
+//! [`QueryExec`]: crate::query::QueryExec
+//! [`IngestStateError::PersistSaturated`]:
+//!     crate::ingest_state::IngestStateError
 
 #![allow(dead_code)] // Until ingester2 is used.
 #![deny(rustdoc::broken_intra_doc_links, rust_2018_idioms)]

--- a/ingester2/src/partition_iter.rs
+++ b/ingester2/src/partition_iter.rs
@@ -1,3 +1,8 @@
+//! An abstraction for a source of [`PartitionData`].
+//!
+//! This abstraction allows code that uses a set of [`PartitionData`] to be
+//! decoupled from the source/provider of that data.
+
 use parking_lot::Mutex;
 use std::{fmt::Debug, sync::Arc};
 

--- a/ingester2/src/persist/mod.rs
+++ b/ingester2/src/persist/mod.rs
@@ -1,3 +1,5 @@
+//! The persistence subsystem; abstractions, types, and implementation.
+
 pub(crate) mod backpressure;
 pub(super) mod compact;
 pub(crate) mod completion_observer;

--- a/ingester2/src/server/mod.rs
+++ b/ingester2/src/server/mod.rs
@@ -1,1 +1,3 @@
+//! External APIs exposed by an ingester & their handlers.
+
 pub(crate) mod grpc;


### PR DESCRIPTION
The ingester is composed of smaller, independent, decoupled components ("subsystems").

This documents what they are, and provides a high-level overview of the purpose & design of the ingester overall.

To view these rendered, run:

```shellsession
% cargo doc --open -p ingester2 --document-private-items
```

---

* docs: ingester overview documentation (3f2c03174)
      
      Adds "overview" documentation for the ingester, including the high-level
      purpose & design. Each subsystem is briefly documented, with links for
      jumping-off points into more specific documentation.

* docs: module-level overviews (b0cf54098)
      
      Adds one-liner documentation of what each module contains - this is
      helpful to understand what is where, when looking at the rendered docs.

* docs(persist): fix-up handle usage (f0dd77cad)
      
      Previously a PersistHandle was cloned for sharing, now it is not
      (shareable by wrapping in an Arc).
      
      This fixes the documentation to reflect the change in expected usage.

* refactor: use as_ for cheap conversion methods (d924dab01)
      
      This follows with the naming conventions of rust - cheap conversions are
      prefixed "as_" and not "to_".

* docs: hot partition persistence (2ba905ffc)
      
      Document the hot partition persistence configuration values.