### PR TITLE
feat: SequenceNumberSet intersection + helpers

### DIFF
--- a/data_types/src/sequence_number_set.rs
+++ b/data_types/src/sequence_number_set.rs
@@ -3,7 +3,7 @@
 use crate::SequenceNumber;
 
 /// A space-efficient encoded set of [`SequenceNumber`].
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, PartialEq)]
 pub struct SequenceNumberSet(croaring::Bitmap);
 
 impl SequenceNumberSet {
@@ -154,5 +154,25 @@ mod tests {
         assert!(!a.contains(SequenceNumber::new(42)));
         assert!(a.contains(SequenceNumber::new(4)));
         assert!(a.contains(SequenceNumber::new(2)));
+    }
+
+    #[test]
+    fn test_partial_eq() {
+        let mut a = SequenceNumberSet::default();
+        let mut b = SequenceNumberSet::default();
+
+        assert_eq!(a, b);
+
+        a.add(SequenceNumber::new(42));
+        assert_ne!(a, b);
+
+        b.add(SequenceNumber::new(42));
+        assert_eq!(a, b);
+
+        b.add(SequenceNumber::new(24));
+        assert_ne!(a, b);
+
+        a.add(SequenceNumber::new(24));
+        assert_eq!(a, b);
     }
 }

--- a/data_types/src/sequence_number_set.rs
+++ b/data_types/src/sequence_number_set.rs
@@ -66,6 +66,12 @@ impl SequenceNumberSet {
     pub fn iter(&self) -> impl Iterator<Item = SequenceNumber> + '_ {
         self.0.iter().map(|v| SequenceNumber::new(v as _))
     }
+
+    /// Initialise a [`SequenceNumberSet`] that is pre-allocated to contain up
+    /// to `n` elements without reallocating.
+    pub fn with_capacity(n: u32) -> Self {
+        Self(croaring::Bitmap::create_with_capacity(n))
+    }
 }
 
 /// Deserialisation method.

--- a/data_types/src/sequence_number_set.rs
+++ b/data_types/src/sequence_number_set.rs
@@ -31,6 +31,12 @@ impl SequenceNumberSet {
         self.0.andnot_inplace(&other.0)
     }
 
+    /// Reduce the memory usage of this set (trading off immediate CPU time) by
+    /// efficiently re-encoding the set (using run-length encoding).
+    pub fn run_optimise(&mut self) {
+        self.0.run_optimize();
+    }
+
     /// Serialise `self` into an array of bytes.
     ///
     /// [This document][spec] describes the serialised format.

--- a/data_types/src/sequence_number_set.rs
+++ b/data_types/src/sequence_number_set.rs
@@ -97,6 +97,11 @@ impl FromIterator<SequenceNumber> for SequenceNumberSet {
     }
 }
 
+/// Return the intersection of `self` and `other`.
+pub fn intersect(a: &SequenceNumberSet, b: &SequenceNumberSet) -> SequenceNumberSet {
+    SequenceNumberSet(a.0.and(&b.0))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -186,5 +191,26 @@ mod tests {
 
         a.add(SequenceNumber::new(24));
         assert_eq!(a, b);
+    }
+
+    #[test]
+    fn test_intersect() {
+        let a = [0, i64::MAX, 40, 41, 42, 43, 44, 45]
+            .into_iter()
+            .map(SequenceNumber::new)
+            .collect::<SequenceNumberSet>();
+
+        let b = [1, 5, i64::MAX, 42]
+            .into_iter()
+            .map(SequenceNumber::new)
+            .collect::<SequenceNumberSet>();
+
+        let intersection = intersect(&a, &b);
+        let want = [i64::MAX, 42]
+            .into_iter()
+            .map(SequenceNumber::new)
+            .collect::<SequenceNumberSet>();
+
+        assert_eq!(intersection, want);
     }
 }


### PR DESCRIPTION
Add the ability to compute the intersection between two `SequenceNumberSet` instances, pre-allocate and RLE optimise the underlying storage, and compare two sets for equality.

Necessary for #6566.

---

* feat(data_types): PartialEq for SequenceNumberSet (043f3421b)
      
      Derive + test partial equality matching for SequenceNumberSet.

* feat: apply RLE optimisation for SequenceNumberSet (7801a6333)
      
      Allow a SequenceNumberSet to be space-optimised by transforming it to
      use run length encoding.

* perf: pre-allocation of SequenceNumberSet (146494f61)
      
      Support pre-allocation of SequenceNumberSet for known-length sets.

* feat(data_types): SequenceNumberSet intersection (ac1b37c0f)
      
      Support computing the intersection of two SequenceNumberSet.