### PR TITLE
refactor(metric): assert macro import scopes

### DIFF
--- a/compactor2/src/components/commit/metrics.rs
+++ b/compactor2/src/components/commit/metrics.rs
@@ -305,7 +305,7 @@ where
 mod tests {
     use std::sync::Arc;
 
-    use metric::{assert_histogram, Attributes, Metric};
+    use metric::{assert_histogram, Attributes};
 
     use crate::components::commit::mock::{CommitHistoryEntry, MockCommit};
     use iox_tests::ParquetFileBuilder;

--- a/compactor2/src/components/partition_done_sink/metrics.rs
+++ b/compactor2/src/components/partition_done_sink/metrics.rs
@@ -83,7 +83,7 @@ where
 mod tests {
     use std::{collections::HashMap, sync::Arc};
 
-    use metric::{assert_counter, Attributes, Metric};
+    use metric::{assert_counter, Attributes};
     use object_store::Error as ObjectStoreError;
 
     use crate::components::partition_done_sink::mock::MockPartitionDoneSink;

--- a/compactor2/src/components/partition_filter/metrics.rs
+++ b/compactor2/src/components/partition_filter/metrics.rs
@@ -85,7 +85,7 @@ where
 mod tests {
     use std::sync::Arc;
 
-    use metric::{assert_counter, Attributes, Metric};
+    use metric::{assert_counter, Attributes};
 
     use crate::{
         components::partition_filter::has_files::HasFilesPartitionFilter,

--- a/compactor2/src/components/partition_source/metrics.rs
+++ b/compactor2/src/components/partition_source/metrics.rs
@@ -64,7 +64,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use metric::{assert_counter, Attributes, Metric};
+    use metric::{assert_counter, Attributes};
 
     use crate::components::partition_source::mock::MockPartitionSource;
     use iox_tests::PartitionBuilder;

--- a/compactor2/src/components/partitions_source/metrics.rs
+++ b/compactor2/src/components/partitions_source/metrics.rs
@@ -69,7 +69,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use metric::{assert_counter, Attributes, Metric};
+    use metric::assert_counter;
 
     use crate::components::partitions_source::mock::MockPartitionsSource;
 

--- a/compactor2/src/components/split_or_compact/metrics.rs
+++ b/compactor2/src/components/split_or_compact/metrics.rs
@@ -106,7 +106,7 @@ mod tests {
 
     use compactor2_test_utils::{create_overlapped_l0_l1_files_2, create_overlapped_l1_l2_files_2};
     use data_types::CompactionLevel;
-    use metric::{assert_counter, assert_histogram, Attributes, Metric};
+    use metric::{assert_counter, assert_histogram};
 
     use crate::{
         components::split_or_compact::{split_compact::SplitCompact, SplitOrCompact},

--- a/metric/src/counter.rs
+++ b/metric/src/counter.rs
@@ -48,10 +48,10 @@ macro_rules! assert_counter {
         #[allow(unused)]
         let mut attr = None;
         $(attr = Some($attr);)*
-        let attr = attr.unwrap_or_else(|| Attributes::from(&[]));
+        let attr = attr.unwrap_or_else(|| metric::Attributes::from(&[]));
 
         let counter = $metrics
-            .get_instrument::<Metric<$counter>>($name)
+            .get_instrument::<metric::Metric<$counter>>($name)
             .expect("failed to find metric with provided name")
             .get_observer(&attr)
             .expect("failed to find metric with provided attributes")

--- a/metric/src/histogram.rs
+++ b/metric/src/histogram.rs
@@ -106,10 +106,10 @@ macro_rules! assert_histogram {
         #[allow(unused)]
         let mut attr = None;
         $(attr = Some($attr);)*
-        let attr = attr.unwrap_or_else(|| Attributes::from(&[]));
+        let attr = attr.unwrap_or_else(|| metric::Attributes::from(&[]));
 
         let hist = $metrics
-            .get_instrument::<Metric<$hist>>($name)
+            .get_instrument::<metric::Metric<$hist>>($name)
             .expect("failed to find metric with provided name")
             .get_observer(&attr)
             .expect("failed to find metric with provided attributes")


### PR DESCRIPTION
Slight usability improvement :+1:

---

* refactor(metric): assert macro import scopes (45c8519a0)
      
      The assert_counter! and assert_histogram! macros use items in the metric
      crate, but the macros can be called from other crates/modules that may
      not have those items in scope.