### PR TITLE
chore: add list command to grpcurl in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,7 +313,7 @@ grpc.health.v1.Health
 influxdata.iox.management.v1.ManagementService
 influxdata.platform.storage.IOxTesting
 influxdata.platform.storage.Storage
-$ ./scripts/grpcurl -plaintext 127.0.0.1:8082 influxdata.iox.management.v1.ManagementService.ListDatabases
+$ ./scripts/grpcurl -plaintext 127.0.0.1:8082 list influxdata.iox.management.v1.ManagementService.ListDatabases
 {
   "names": [
     "foobar_weather"


### PR DESCRIPTION
./scripts/grpcurl command in README includes `list` in the first example command, but not in the second. Example:

`./scripts/grpcurl -plaintext 127.0.0.1:8082 influxdata.iox.namespace.v1.NamespaceService` - fails

Add `list`:

![Screen Shot 2023-03-15 at 11 25 44 AM](https://user-images.githubusercontent.com/91283923/225358308-1d451c30-9982-4ac3-8429-0cbd74b1877c.png)



Describe your proposed changes here.

- [X] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb_iox/blob/main/README.md).
- [X] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed) - influxer
