### PR TITLE
chore(ingester2): Log well-known query errors at debug

### DIFF
--- a/ingester2/src/server/grpc/query.rs
+++ b/ingester2/src/server/grpc/query.rs
@@ -187,13 +187,13 @@ where
             .await
         {
             Ok(v) => v,
-            Err(e) => {
-                error!(
-                    error=%e,
-                    %namespace_id,
-                    %table_id,
-                    "query error"
-                );
+            Err(e @ QueryError::TableNotFound(_, _) | e @ QueryError::NamespaceNotFound(_)) => {
+                debug!(
+                        error=%e,
+                        %namespace_id,
+                        %table_id,
+                        "query error, no buffered data found");
+
                 return Err(e)?;
             }
         };

--- a/ingester2/src/server/grpc/query.rs
+++ b/ingester2/src/server/grpc/query.rs
@@ -187,7 +187,7 @@ where
             .await
         {
             Ok(v) => v,
-            Err(e @ QueryError::TableNotFound(_, _) | e @ QueryError::NamespaceNotFound(_)) => {
+            Err(e @ (QueryError::TableNotFound(_, _) | QueryError::NamespaceNotFound(_))) => {
                 debug!(
                         error=%e,
                         %namespace_id,


### PR DESCRIPTION
When ingester2 handles queries that target data that have previously been persisted and are no longer in the buffer tree, the handler logs a message at error. This is a bit noisy for an expected error state (the querier will have to go check object storage), so I've bumped it to `debug`.

---

* chore(ingester2): Log well-known query error at dbg ([`882d087`](https://github.com/influxdata/influxdb_iox/commit/882d087dd5636e6dd57561e42950436a55932178))

    When the ingester handles a query for a table/namespace
    that has been persisted and the data is not in the
    buffer it logs at error level that the table/namespace
    could not be found. This is a valid state and an
    expected error (the data can be queried from object
    storage), so we can make this less noisy.