### PR TITLE
refactor: remove Clone derive on CompletedPersist

### DIFF
--- a/ingester2/src/persist/completion_observer.rs
+++ b/ingester2/src/persist/completion_observer.rs
@@ -22,7 +22,7 @@ pub(crate) trait PersistCompletionObserver: Send + Sync + Debug {
 }
 
 /// A set of details describing the persisted data.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct CompletedPersist {
     /// The catalog identifiers for the persisted partition.
     namespace_id: NamespaceId,


### PR DESCRIPTION
:broom:

---

* refactor: remove Clone derive on CompletedPersist (43d174b89)
      
      This type is exposed as an Arc-wrapped (reference counted) shared item
      to avoid cloning the underlying data, and as such this type should not
      be cloned directly.