### PR TITLE
refactor(wal): file management sequencing helpers

### DIFF
--- a/ingester2/src/wal/reference_tracker/actor.rs
+++ b/ingester2/src/wal/reference_tracker/actor.rs
@@ -7,7 +7,10 @@ use data_types::{
 use hashbrown::HashMap;
 use metric::U64Gauge;
 use observability_deps::tracing::{debug, info};
-use tokio::{select, sync::mpsc};
+use tokio::{
+    select,
+    sync::{mpsc, Notify},
+};
 use wal::SegmentId;
 
 use crate::{
@@ -43,6 +46,12 @@ pub(crate) struct WalReferenceActor<T = Arc<wal::Wal>> {
     /// Invariant: sets in this map are always non-empty.
     wal_files: HashMap<wal::SegmentId, SequenceNumberSet>,
 
+    /// A semaphore to wake tasks waiting for the number of inactive
+    /// (old/rotated) WAL segments (in wal_files) to reach 0.
+    ///
+    /// This can happen multiple times during the lifecycle of an ingester.
+    empty_waker: Arc<Notify>,
+
     /// Channels for input from the [`WalReferenceHandle`].
     ///
     /// [`WalReferenceHandle`]: super::WalReferenceHandle
@@ -75,6 +84,7 @@ where
         file_rx: mpsc::Receiver<(SegmentId, SequenceNumberSet)>,
         persist_rx: mpsc::Receiver<Arc<CompletedPersist>>,
         unbuffered_rx: mpsc::Receiver<SequenceNumber>,
+        empty_waker: Arc<Notify>,
         metrics: &metric::Registry,
     ) -> Self {
         let num_files = metrics
@@ -108,6 +118,7 @@ where
             num_files,
             min_id,
             referenced_ops,
+            empty_waker,
         }
     }
 
@@ -132,8 +143,10 @@ where
                 else => break
             }
 
-            // After each action is processed, update the metrics.
+            // After each action is processed, update the metrics and wake any
+            // waiters if the tracker has no unpersisted operations.
             self.update_metrics();
+            self.notify_empty_wakers();
         }
 
         debug!("stopping wal reference counter task");
@@ -309,6 +322,13 @@ where
             assert!(file_set.is_empty());
 
             delete_file(&self.wal, id).await
+        }
+    }
+
+    /// Wake the waiters when the last inactive WAL segment file is deleted.
+    fn notify_empty_wakers(&self) {
+        if self.wal_files.is_empty() {
+            self.empty_waker.notify_waiters();
         }
     }
 }


### PR DESCRIPTION
This PR adds two primitives for sequencing asynchronous events occurring in the WAL reference tracker:

* Wait for a rotated file to be added to the tracker and fully processed
* Wait for all inactive/rotated WAL files to be deleted

Combined, these primitives provide the required synchronisation needed to perform a [graceful shutdown] that avoids replaying WAL files at startup:

* A shutdown is requested
* All data is marked for (asynchronous) persistence
* Wait for all data to be persisted
* Rotate the WAL file, replacing it with an empty file (new: and wait for it to be processed)
* Delete redundant WAL files (new: wait for the ref tracker to delete inactive files)

This new shutdown logic (in an upcoming PR) has a nice property that the reference-counted WAL file deletion ensures only persisted data is ever deleted, and there's never the possibility that some un-persisted data was in a deleted WAL file. 

Part of https://github.com/influxdata/influxdb_iox/issues/6566.

[graceful shutdown]: https://github.com/influxdata/influxdb_iox/blob/fba15cb52189d4f1c03ba4e85a27bbeffa97b856/ingester2/src/init/graceful_shutdown.rs#L97-L120

---

* refactor(test): disambiguate waker (094ea0e73)
      
      The "wal waker" is a waker that is invoked when a WAL file is deleted.
      If there's more than one waker floating around, this can be a confusing
      name.

* refactor: waker for empty WAL files (195854146)
      
      Implement a waker primitive, allowing a caller to be woken once there
      are no inactive WAL files.
      
      This enables a caller to sequence operations to happen after deletion of
      inactive WAL files.

* refactor: wal file process completion notification (fba15cb52)
      
      Allow a caller to await processing of a submitted WAL segment in the WAL
      reference tracker.
      
      This allows callers to (optionally) order operations that should happen
      after the file has been processed.