### PR TITLE
fix: full u64 range in SequenceNumberSet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6834,6 +6834,7 @@ dependencies = [
  "petgraph",
  "phf_shared",
  "predicates",
+ "proptest",
  "prost",
  "prost-types",
  "rand",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -580,6 +580,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
 
 [[package]]
+name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1423,6 +1438,7 @@ dependencies = [
  "observability_deps",
  "ordered-float 3.4.0",
  "percent-encoding",
+ "proptest",
  "schema",
  "serde",
  "snafu",
@@ -4501,15 +4517,18 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29f1b898011ce9595050a68e60f90bad083ff2987a695a42357134c8381fba70"
 dependencies = [
+ "bit-set",
  "bitflags 1.3.2",
  "byteorder",
  "lazy_static",
  "num-traits",
- "quick-error",
+ "quick-error 2.0.1",
  "rand",
  "rand_chacha",
  "rand_xorshift",
  "regex-syntax",
+ "rusty-fork",
+ "tempfile",
  "unarray",
 ]
 
@@ -4646,6 +4665,12 @@ dependencies = [
  "tokio",
  "workspace-hack",
 ]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quick-error"
@@ -4985,6 +5010,18 @@ name = "rustversion"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f3208ce4d8448b3f3e7d168a73f5e0c43a61e32930de3bceeccedb388b6bf06"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb3dcc6e454c328bb824492db107ab7c0ae8fcffe4ad210136ef014458c1bc4f"
+dependencies = [
+ "fnv",
+ "quick-error 1.2.3",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "rustyline"

--- a/data_types/Cargo.toml
+++ b/data_types/Cargo.toml
@@ -21,4 +21,5 @@ uuid = { version = "1", features = ["v4"] }
 workspace-hack = { version = "0.1", path = "../workspace-hack" }
 
 [dev-dependencies] # In alphabetical order
+proptest = "1.1.0"
 test_helpers = { path = "../test_helpers" }

--- a/workspace-hack/Cargo.toml
+++ b/workspace-hack/Cargo.toml
@@ -64,6 +64,7 @@ parquet = { version = "34", features = ["async", "experimental"] }
 petgraph = { version = "0.6" }
 phf_shared = { version = "0.11" }
 predicates = { version = "3" }
+proptest = { version = "1" }
 prost = { version = "0.11" }
 prost-types = { version = "0.11" }
 rand = { version = "0.8", features = ["small_rng"] }


### PR DESCRIPTION
This allows the `SequenceNumberSet` to contain values outside of the `u32` range. This has a low risk of occurrence (we roll pods frequently, and reset counters as a result) but it's the right thing to do.

This also adds a bunch of property tests to assert correctness under fuzzy inputs.

I also took the time to document a known (but very low risk) issue; `i64` rollover causing bad `Ord` results - see [this ticket](https://github.com/influxdata/influxdb_iox/issues/7260) to mitigate it as much as we can given the postgres constraints.

---

* fix: full u64 range in SequenceNumberSet (5680710e7)
      
      Prior to this commit, the SequenceNumberSet accepted values up to
      u32::MAX (approx 4.2 billion) which works out to be ~50 days of
      continious ID allocation at 1k writes/s.
      
      This commit changes the SequenceNumberSet to accept the full range of a
      u64, with the caveat that outside of the u32 range, values may be
      ordered incorrectly. See:
      
          https://github.com/influxdata/influxdb_iox/issues/7260
      
      Fortunately values from SequenceNumberSet are used as an identity, and
      never for ordering. We should remove the PartialOrd bounds on
      SequenceNumber once Kafka has been cleaned up to encode this in the type
      system.

* test: property test SequenceNumberSet operations (0a2cb33f7)
      
      Adds proptests to assert correctness of set operations against a
      SequenceNumberSet, by ensuring they match those of a known-good
      implementation from the stdlib (HashSet).
      
      Ensure (de-)serialisation correctness by asserting a round trip results
      in equal sets.

* chore: workspace-hack update (8f9e4d21c)
      
      Add proptest to workspace-hack.