### PR TITLE
refactor: non-empty RPC endpoint sets

### DIFF
--- a/router/src/dml_handlers/rpc_write.rs
+++ b/router/src/dml_handlers/rpc_write.rs
@@ -132,7 +132,16 @@ where
         };
 
         // Perform the gRPC write to an ingester.
-        tokio::time::timeout(RPC_TIMEOUT, write_loop(self.endpoints.endpoints(), req)).await??;
+        tokio::time::timeout(
+            RPC_TIMEOUT,
+            write_loop(
+                self.endpoints
+                    .endpoints()
+                    .ok_or(RpcWriteError::NoUpstreams)?,
+                req,
+            ),
+        )
+        .await??;
 
         debug!(
             %partition_key,


### PR DESCRIPTION
Prevent an empty `UpstreamSnapshot` from being generated, moving the "there are no healthy upstream ingesters" error from write time, to before the first write is attempted.

---

* refactor: access upstream count in UpstreamSnapshot (2fefbc45c)
      
      Adds a method to return the number of upstreams in an UpstreamSnapshot.

* refactor: disallow empty UpstreamSnapshot (8279ad161)
      
      This simplifies the semantics of upstream RPC endpoint snapshots; an
      empty snapshot will never be returned, and therefore if the caller has a
      snapshot, it contains at least one endpoint to attempt an RPC call
      against.
      
      This moves the "no upstream" error handling from a write-time error, to
      a pre-write error.