### PR TITLE
fix: Put authorization header in request extension

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3161,6 +3161,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
+ "server_util",
  "service_grpc_testing",
  "snafu",
  "tokio",
@@ -4947,6 +4948,7 @@ dependencies = [
  "iox_catalog",
  "iox_tests",
  "iox_time",
+ "ioxd_common",
  "metric",
  "mutable_batch",
  "mutable_batch_lp",
@@ -4963,6 +4965,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
+ "server_util",
  "service_grpc_catalog",
  "service_grpc_namespace",
  "service_grpc_object_store",
@@ -5210,6 +5213,14 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "server_util"
+version = "0.1.0"
+dependencies = [
+ "http",
+ "workspace-hack",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,7 @@ members = [
     "query_functions",
     "router",
     "schema",
+    "server_util",
     "service_common",
     "service_grpc_influxrpc",
     "service_grpc_flight",

--- a/ioxd_common/Cargo.toml
+++ b/ioxd_common/Cargo.toml
@@ -20,6 +20,7 @@ observability_deps = { path = "../observability_deps" }
 # (honestly I thought that cargo dependencies were isolated on a per crate basis so I'm a bit surprised that pprof accidentally builds
 # successfully just because another crate happens to depend on backtrace-rs)
 pprof = { version = "0.11", default-features = false, features = ["flamegraph", "prost-codec"], optional = true }
+server_util = { path = "../server_util" }
 service_grpc_testing = { path = "../service_grpc_testing" }
 trace = { path = "../trace" }
 trace_exporters = { path = "../trace_exporters" }

--- a/router/Cargo.toml
+++ b/router/Cargo.toml
@@ -19,6 +19,7 @@ hashbrown = { workspace = true }
 hyper = "0.14"
 iox_catalog = { path = "../iox_catalog" }
 iox_time = { path = "../iox_time" }
+ioxd_common = { path = "../ioxd_common" }
 metric = { path = "../metric" }
 mutable_batch = { path = "../mutable_batch" }
 mutable_batch_lp = { path = "../mutable_batch_lp" }
@@ -31,6 +32,7 @@ schema = { version = "0.1.0", path = "../schema" }
 serde = "1.0"
 serde_json = "1.0.94"
 serde_urlencoded = "0.7"
+server_util = { path = "../server_util" }
 service_grpc_catalog = { path = "../service_grpc_catalog"}
 service_grpc_namespace = { path = "../service_grpc_namespace"}
 service_grpc_schema = { path = "../service_grpc_schema" }

--- a/server_util/Cargo.toml
+++ b/server_util/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "server_util"
+description = "Shared code for IOx servers"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+http = "0.2.9"
+workspace-hack = { version = "0.1", path = "../workspace-hack" }
+

--- a/server_util/src/authorization.rs
+++ b/server_util/src/authorization.rs
@@ -1,0 +1,29 @@
+//! Common authorization helpers
+
+use http::HeaderValue;
+
+/// We strip off the "authorization" header from the request, to prevent it from being accidentally logged
+/// and we put it in an extension of the request. Extensions are typed and this is the typed wrapper that
+/// holds an (optional) authorization header value.
+pub struct AuthorizationHeaderExtension(Option<HeaderValue>);
+
+impl AuthorizationHeaderExtension {
+    /// Construct new extension wrapper for a possible header value
+    pub fn new(header: Option<HeaderValue>) -> Self {
+        Self(header)
+    }
+}
+
+impl std::fmt::Debug for AuthorizationHeaderExtension {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("AuthorizationHeaderExtension(...)")
+    }
+}
+
+impl std::ops::Deref for AuthorizationHeaderExtension {
+    type Target = Option<HeaderValue>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}

--- a/server_util/src/lib.rs
+++ b/server_util/src/lib.rs
@@ -1,0 +1,20 @@
+//! Shared InfluxDB IOx API client functionality
+#![deny(
+    rustdoc::broken_intra_doc_links,
+    rustdoc::bare_urls,
+    rust_2018_idioms,
+    missing_debug_implementations,
+    unreachable_pub
+)]
+#![warn(
+    missing_docs,
+    clippy::todo,
+    clippy::dbg_macro,
+    clippy::clone_on_ref_ptr,
+    clippy::future_not_send,
+    clippy::todo,
+    clippy::dbg_macro
+)]
+#![allow(clippy::missing_docs_in_private_items)]
+
+pub mod authorization;


### PR DESCRIPTION
The router tried to access the "authorization" header of a request but that header gets stripped off by common code in the `ioxd_common` crate:

```rust
   // we don't need the authorization header and we don't want to accidentally log it.
   req.headers_mut().remove("authorization");
```

That code is there for a good reason (#1316): it's very easy to accidentally log an entire request including all the headers and thus leak tokens.

Luckily request extensions offer a nice way to attach custom data to a request without that being logged.

The extensions are "typed", which means that the crate that creates the extension and the crate that reads the extension must share a type.

Importing `ioxd_common` into the `router` is technically possible, but breaks the nice distinction between the `ioxd_<foo>` crates and the `<foo>` crates.

I created a new `server_utils` crate to store such types that all servers may need to share.

---

With this change the token is actually processed by the authorization code:

before:

```console
curl -i -X POST -H "Authorization: Token 1234" "[http://localhost:80/api/v2/write?bucket=test&org=internal&precision=s](http://localhost/api/v2/write?bucket=test&org=internal&precision=s)" --data-binary @$HOME/w/iox/test_fixtures/lineproto/air_and_water.lp
HTTP/1.1 401 Unauthorized
content-type: application/json
content-length: 59
date: Wed, 22 Mar 2023 01:20:02 GMT
x-envoy-upstream-service-time: 2
vary: Accept-Encoding
server: envoy

{"code":"unauthorized","message":"authentication required"}
```

after:

```console
$ curl -i -X POST -H "Authorization: Token 123" "http://localhost:8080/api/v2/write?bucket=test&org=internal&precision=s" --data-binary @$HOME/w/iox/test_fixtures/lineproto/air_and_water.lp
HTTP/1.1 403 Forbidden
content-type: application/json
content-length: 46
date: Wed, 22 Mar 2023 01:54:29 GMT

{"code":"forbidden","message":"access denied"}
```

---

"proof" that extensions are not logged:

Here I sent a request with an authorization header which got lifted into a AuthorizationHeaderExtension value; then I logged the request. As you can see the token is not there

```
2023-03-22T02:46:53.892845Z  INFO router::server::http: LOGGING REQUEST req=Request { method: POST, uri: /api/v2/write?bucket=test&org=internal&precision=s, version: HTTP/1.1, headers: {"host": "localhost:8080", "user-agent": "curl/7.79.1", "accept": "*/*", "content-type": "application/x-www-form-urlencoded", "content-length": "1243"}, body: Body(Streaming) }
```


CC: @mhilton 