### PR TITLE
feat(idpe 17265): CST direct write endpoints

### DIFF
--- a/clap_blocks/src/router.rs
+++ b/clap_blocks/src/router.rs
@@ -9,7 +9,7 @@ pub struct RouterConfig {
     /// At minimum, differs in supports of v1 endpoint. But also includes
     /// differences in namespace handling, etc.
     #[clap(
-        long = "deployment-tenancy",
+        long = "single-tenancy",
         env = "INFLUXDB_IOX_SINGLE_TENANCY",
         default_value = "false"
     )]

--- a/clap_blocks/src/router.rs
+++ b/clap_blocks/src/router.rs
@@ -4,6 +4,17 @@
 #[derive(Debug, Clone, clap::Parser)]
 #[allow(missing_copy_implementations)]
 pub struct RouterConfig {
+    /// Differential handling based upon deployment to CST vs MT.
+    ///
+    /// At minimum, differs in supports of v1 endpoint. But also includes
+    /// differences in namespace handling, etc.
+    #[clap(
+        long = "deployment-tenancy",
+        env = "INFLUXDB_IOX_SINGLE_TENANCY",
+        default_value = "false"
+    )]
+    pub single_tenant_deployment: bool,
+
     /// Query pool name to dispatch writes to.
     #[clap(
         long = "query-pool",

--- a/clap_blocks/src/router2.rs
+++ b/clap_blocks/src/router2.rs
@@ -10,6 +10,17 @@ use std::{
 #[derive(Debug, Clone, clap::Parser)]
 #[allow(missing_copy_implementations)]
 pub struct Router2Config {
+    /// Differential handling based upon deployment to CST vs MT.
+    ///
+    /// At minimum, differs in supports of v1 endpoint. But also includes
+    /// differences in namespace handling, etc.
+    #[clap(
+        long = "deployment-tenancy",
+        env = "INFLUXDB_IOX_SINGLE_TENANCY",
+        default_value = "false"
+    )]
+    pub single_tenant_deployment: bool,
+
     /// The maximum number of simultaneous requests the HTTP server is
     /// configured to accept.
     ///

--- a/clap_blocks/src/router2.rs
+++ b/clap_blocks/src/router2.rs
@@ -15,7 +15,7 @@ pub struct Router2Config {
     /// At minimum, differs in supports of v1 endpoint. But also includes
     /// differences in namespace handling, etc.
     #[clap(
-        long = "deployment-tenancy",
+        long = "single-tenancy",
         env = "INFLUXDB_IOX_SINGLE_TENANCY",
         default_value = "false"
     )]

--- a/data_types/src/lib.rs
+++ b/data_types/src/lib.rs
@@ -1654,20 +1654,14 @@ pub fn org_and_bucket_to_namespace<'a, O: AsRef<str>, B: AsRef<str>>(
 ) -> Result<NamespaceName<'a>, NamespaceMappingError> {
     const SEPARATOR: char = '_';
 
-    match Tenancy::get() {
-        Tenancy::Single => string_to_namespace(bucket),
-        Tenancy::Multiple => {
-            let org: Cow<'_, str> = utf8_percent_encode(org.as_ref(), NON_ALPHANUMERIC).into();
-            let bucket: Cow<'_, str> =
-                utf8_percent_encode(bucket.as_ref(), NON_ALPHANUMERIC).into();
+    let org: Cow<'_, str> = utf8_percent_encode(org.as_ref(), NON_ALPHANUMERIC).into();
+    let bucket: Cow<'_, str> = utf8_percent_encode(bucket.as_ref(), NON_ALPHANUMERIC).into();
 
-            if org.is_empty() || bucket.is_empty() {
-                return Err(NamespaceMappingError::NotSpecified);
-            }
-            let db_name = format!("{}{}{}", org.as_ref(), SEPARATOR, bucket.as_ref());
-            NamespaceName::new(db_name).context(InvalidNamespaceNameSnafu)
-        }
+    if org.is_empty() || bucket.is_empty() {
+        return Err(NamespaceMappingError::NotSpecified);
     }
+    let db_name = format!("{}{}{}", org.as_ref(), SEPARATOR, bucket.as_ref());
+    NamespaceName::new(db_name).context(InvalidNamespaceNameSnafu)
 }
 
 /// Map an InfluxDB 1.X rp & database into an IOx NamespaceName.
@@ -1679,8 +1673,6 @@ pub fn org_and_bucket_to_namespace<'a, O: AsRef<str>, B: AsRef<str>>(
 /// Rp is not required to be defined. Is only consumed if present. If the write dml parameters
 /// does not include rp, yet rp is used in the previously created namespace, then namespace
 /// lookup will fail.
-///
-/// FIXME: what about namespace auto-creation? Will it possibly create a new namespace due to a missing rp?
 pub fn rp_and_database_to_namespace<'a, D: AsRef<str>>(
     rp: &Option<String>,
     database: D,

--- a/import/src/aggregate_tsm_schema/update_catalog.rs
+++ b/import/src/aggregate_tsm_schema/update_catalog.rs
@@ -2,7 +2,7 @@ use self::generated_types::{shard_service_client::ShardServiceClient, *};
 use crate::{AggregateTSMMeasurement, AggregateTSMSchema};
 use chrono::{format::StrftimeItems, offset::FixedOffset, DateTime, Duration};
 use data_types::{
-    org_and_bucket_to_namespace, ColumnType, Namespace, NamespaceSchema, OrgBucketMappingError,
+    org_and_bucket_to_namespace, ColumnType, Namespace, NamespaceMappingError, NamespaceSchema,
     Partition, PartitionKey, QueryPoolId, ShardId, TableSchema, TopicId,
 };
 use influxdb_iox_client::connection::{Connection, GrpcConnection};
@@ -29,7 +29,7 @@ pub enum UpdateCatalogError {
     SortKeyCasError,
 
     #[error("Couldn't construct namespace from org and bucket: {0}")]
-    InvalidOrgBucket(#[from] OrgBucketMappingError),
+    InvalidOrgBucket(#[from] NamespaceMappingError),
 
     #[error("No topic named '{topic_name}' found in the catalog")]
     TopicCatalogLookup { topic_name: String },

--- a/influxdb_iox/src/commands/run/all_in_one.rs
+++ b/influxdb_iox/src/commands/run/all_in_one.rs
@@ -474,6 +474,7 @@ impl Config {
             topic: QUERY_POOL_NAME.to_string(),
             rpc_write_timeout_seconds: Duration::new(3, 0),
             rpc_write_replicas: None,
+            single_tenant_deployment: false,
         };
 
         // create a CompactorConfig for the all in one server based on

--- a/ioxd_router/src/lib.rs
+++ b/ioxd_router/src/lib.rs
@@ -38,7 +38,10 @@ use router::{
     },
     server::{
         grpc::{sharder::ShardService, GrpcDelegate, RpcWriteGrpcDelegate},
-        http::{HttpDelegate, WriteInfoExtractor, CST, MT},
+        http::{
+            cst::SingleTenantRequestParser, mt::MultiTenantRequestParser, HttpDelegate,
+            WriteInfoExtractor,
+        },
         RouterServer, RpcWriteRouterServer,
     },
     shard::Shard,
@@ -441,8 +444,8 @@ pub async fn create_router2_server_type(
     // 4. START: Initialize the HTTP API delegate, this is the same in both router paths
     let dml_info_extractor: &'static dyn WriteInfoExtractor =
         match router_config.single_tenant_deployment {
-            true => &CST,
-            false => &MT,
+            true => &SingleTenantRequestParser,
+            false => &MultiTenantRequestParser,
         };
     let http = HttpDelegate::new(
         common_state.run_config().max_http_request_size,
@@ -636,8 +639,8 @@ pub async fn create_router_server_type(
     // 4. START: Initialize the HTTP API delegate, this is the same in both router paths
     let dml_info_extractor: &'static dyn WriteInfoExtractor =
         match router_config.single_tenant_deployment {
-            true => &CST,
-            false => &MT,
+            true => &SingleTenantRequestParser,
+            false => &MultiTenantRequestParser,
         };
     let http = HttpDelegate::new(
         common_state.run_config().max_http_request_size,

--- a/ioxd_router/src/lib.rs
+++ b/ioxd_router/src/lib.rs
@@ -38,7 +38,7 @@ use router::{
     },
     server::{
         grpc::{sharder::ShardService, GrpcDelegate, RpcWriteGrpcDelegate},
-        http::HttpDelegate,
+        http::{HttpDelegate, WriteInfoExtractor, CST, MT},
         RouterServer, RpcWriteRouterServer,
     },
     shard::Shard,
@@ -439,6 +439,11 @@ pub async fn create_router2_server_type(
     // 3. N/A: Shard mapping setup is only relevant to the write buffer router path
 
     // 4. START: Initialize the HTTP API delegate, this is the same in both router paths
+    let dml_info_extractor: &'static dyn WriteInfoExtractor =
+        match router_config.single_tenant_deployment {
+            true => &CST,
+            false => &MT,
+        };
     let http = HttpDelegate::new(
         common_state.run_config().max_http_request_size,
         router_config.http_request_limit,
@@ -446,6 +451,7 @@ pub async fn create_router2_server_type(
         handler_stack,
         authz,
         &metrics,
+        dml_info_extractor,
     );
     // 4. END
 
@@ -628,6 +634,11 @@ pub async fn create_router_server_type(
     // 3. END
 
     // 4. START: Initialize the HTTP API delegate, this is the same in both router paths
+    let dml_info_extractor: &'static dyn WriteInfoExtractor =
+        match router_config.single_tenant_deployment {
+            true => &CST,
+            false => &MT,
+        };
     let http = HttpDelegate::new(
         common_state.run_config().max_http_request_size,
         router_config.http_request_limit,
@@ -635,6 +646,7 @@ pub async fn create_router_server_type(
         handler_stack,
         authz,
         &metrics,
+        dml_info_extractor,
     );
     // 4. END
 

--- a/ioxd_router/src/lib.rs
+++ b/ioxd_router/src/lib.rs
@@ -442,10 +442,10 @@ pub async fn create_router2_server_type(
     // 3. N/A: Shard mapping setup is only relevant to the write buffer router path
 
     // 4. START: Initialize the HTTP API delegate, this is the same in both router paths
-    let dml_info_extractor: &'static dyn WriteInfoExtractor =
+    let dml_info_extractor: Box<dyn WriteInfoExtractor> =
         match router_config.single_tenant_deployment {
-            true => &SingleTenantRequestParser,
-            false => &MultiTenantRequestParser,
+            true => Box::<SingleTenantRequestParser>::default(),
+            false => Box::<MultiTenantRequestParser>::default(),
         };
     let http = HttpDelegate::new(
         common_state.run_config().max_http_request_size,
@@ -474,7 +474,7 @@ pub async fn create_router2_server_type(
 // NOTE!!! This needs to be kept in sync with `create_router2_server_type` until the
 // switch to the RPC write path/ingester2 is complete! See the numbered sections that annotate
 // where these two functions line up and where they diverge.
-pub async fn create_router_server_type(
+pub async fn create_router_server_type<'a>(
     common_state: &CommonServerState,
     metrics: Arc<metric::Registry>,
     catalog: Arc<dyn Catalog>,
@@ -637,10 +637,10 @@ pub async fn create_router_server_type(
     // 3. END
 
     // 4. START: Initialize the HTTP API delegate, this is the same in both router paths
-    let dml_info_extractor: &'static dyn WriteInfoExtractor =
+    let dml_info_extractor: Box<dyn WriteInfoExtractor> =
         match router_config.single_tenant_deployment {
-            true => &SingleTenantRequestParser,
-            false => &MultiTenantRequestParser,
+            true => Box::<SingleTenantRequestParser>::default(),
+            false => Box::<MultiTenantRequestParser>::default(),
         };
     let http = HttpDelegate::new(
         common_state.run_config().max_http_request_size,

--- a/router/benches/e2e.rs
+++ b/router/benches/e2e.rs
@@ -11,7 +11,10 @@ use router::{
     },
     namespace_cache::{MemoryNamespaceCache, ShardedCache},
     namespace_resolver::mock::MockNamespaceResolver,
-    server::http::{HttpDelegate, WriteInfoExtractor, CST, MT},
+    server::http::{
+        cst::SingleTenantRequestParser, mt::MultiTenantRequestParser, HttpDelegate,
+        WriteInfoExtractor,
+    },
     shard::Shard,
 };
 use sharder::JumpHash;
@@ -80,8 +83,8 @@ fn e2e_benchmarks(c: &mut Criterion) {
             MockNamespaceResolver::default().with_mapping("bananas", NamespaceId::new(42));
 
         let dml_info_extractor: &'static dyn WriteInfoExtractor = match Tenancy::get() {
-            Tenancy::Single => &CST,
-            Tenancy::Multiple => &MT,
+            Tenancy::Single => &SingleTenantRequestParser,
+            Tenancy::Multiple => &MultiTenantRequestParser,
         };
 
         HttpDelegate::new(

--- a/router/src/server/http.rs
+++ b/router/src/server/http.rs
@@ -2,10 +2,10 @@
 
 pub mod cst;
 mod delete_predicate;
+#[cfg(test)]
+mod http_test_helpers;
 pub mod mt;
 mod write_dml;
-#[cfg(test)]
-mod write_test_helpers;
 mod write_v1;
 mod write_v2;
 
@@ -571,41 +571,588 @@ mod tests {
     use crate::{
         dml_handlers::{
             mock::{MockDmlHandler, MockDmlHandlerCall},
-            CachedServiceProtectionLimit,
+            CachedServiceProtectionLimit, DmlError,
         },
         namespace_resolver::{mock::MockNamespaceResolver, NamespaceCreationError},
-        server::http::mt::MultiTenantRequestParser,
+        run_v1_write_test_in_env, run_v2_delete_test_in_env, run_v2_write_test_in_env,
+        server::http::{
+            http_test_helpers::{assert_metric_hit, summary, MAX_BYTES},
+            mt::MultiTenantRequestParser,
+            Error,
+        },
+        test_http_handler,
     };
     use assert_matches::assert_matches;
     use async_trait::async_trait;
     use data_types::{NamespaceId, NamespaceMappingError, NamespaceNameError, TableId};
     use hyper::header::HeaderValue;
-    use metric::{Attributes, Metric, U64Counter};
+    use mutable_batch::column::ColumnData;
+    use mutable_batch_lp::LineWriteError;
     use serde::de::Error as _;
-    use std::{sync::Arc, time::Duration};
+    use std::{iter, sync::Arc, time::Duration};
     use test_helpers::timeout::FutureTimeout;
     use tokio_stream::wrappers::ReceiverStream;
 
-    const MAX_BYTES: usize = 1024;
-
-    fn summary() -> WriteSummary {
-        WriteSummary::default()
-    }
-
-    fn assert_metric_hit(metrics: &metric::Registry, name: &'static str, value: Option<u64>) {
-        let counter = metrics
-            .get_instrument::<Metric<U64Counter>>(name)
-            .expect("failed to read metric")
-            .get_observer(&Attributes::from(&[]))
-            .expect("failed to get observer")
-            .fetch();
-
-        if let Some(want) = value {
-            assert_eq!(want, counter, "metric does not have expected value");
-        } else {
-            assert!(counter > 0, "metric {name} did not record any values");
+    run_v2_write_test_in_env!(
+        ok,
+        query_string = "?org=bananas&bucket=test",
+        body = "platanos,tag1=A,tag2=B val=42i 123456".as_bytes(),
+        dml_handler = [Ok(summary())],
+        want_result = Ok(_),
+        want_dml_calls = [MockDmlHandlerCall::Write{namespace, ..}] => {
+            assert_eq!(namespace, EXPECTED_NAMESPACE);
         }
+    );
+
+    run_v2_write_test_in_env!(
+        ok_precision_s,
+        query_string = "?org=bananas&bucket=test&precision=s",
+        body = "platanos,tag1=A,tag2=B val=42i 1647622847".as_bytes(),
+        dml_handler = [Ok(summary())],
+        want_result = Ok(_),
+        want_dml_calls = [MockDmlHandlerCall::Write{namespace, namespace_id, write_input}] => {
+            assert_eq!(namespace, EXPECTED_NAMESPACE);
+            assert_eq!(*namespace_id, NAMESPACE_ID);
+
+            let table = write_input.get("platanos").expect("table not found");
+            let ts = table.timestamp_summary().expect("no timestamp summary");
+            assert_eq!(Some(1647622847000000000), ts.stats.min);
+        }
+    );
+
+    run_v2_write_test_in_env!(
+        ok_precision_ms,
+        query_string = "?org=bananas&bucket=test&precision=ms",
+        body = "platanos,tag1=A,tag2=B val=42i 1647622847000".as_bytes(),
+        dml_handler = [Ok(summary())],
+        want_result = Ok(_),
+        want_dml_calls = [MockDmlHandlerCall::Write{namespace, namespace_id, write_input}] => {
+            assert_eq!(namespace, EXPECTED_NAMESPACE);
+            assert_eq!(*namespace_id, NAMESPACE_ID);
+
+            let table = write_input.get("platanos").expect("table not found");
+            let ts = table.timestamp_summary().expect("no timestamp summary");
+            assert_eq!(Some(1647622847000000000), ts.stats.min);
+        }
+    );
+
+    run_v2_write_test_in_env!(
+        ok_precision_us,
+        query_string = "?org=bananas&bucket=test&precision=us",
+        body = "platanos,tag1=A,tag2=B val=42i 1647622847000000".as_bytes(),
+        dml_handler = [Ok(summary())],
+        want_result = Ok(_),
+        want_dml_calls = [MockDmlHandlerCall::Write{namespace, namespace_id, write_input}] => {
+            assert_eq!(namespace, EXPECTED_NAMESPACE);
+            assert_eq!(*namespace_id, NAMESPACE_ID);
+
+            let table = write_input.get("platanos").expect("table not found");
+            let ts = table.timestamp_summary().expect("no timestamp summary");
+            assert_eq!(Some(1647622847000000000), ts.stats.min);
+        }
+    );
+
+    run_v2_write_test_in_env!(
+        ok_precision_ns,
+        query_string = "?org=bananas&bucket=test&precision=ns",
+        body = "platanos,tag1=A,tag2=B val=42i 1647622847000000000".as_bytes(),
+        dml_handler = [Ok(summary())],
+        want_result = Ok(_),
+        want_dml_calls = [MockDmlHandlerCall::Write{namespace, namespace_id, write_input}] => {
+            assert_eq!(namespace, EXPECTED_NAMESPACE);
+            assert_eq!(*namespace_id, NAMESPACE_ID);
+
+            let table = write_input.get("platanos").expect("table not found");
+            let ts = table.timestamp_summary().expect("no timestamp summary");
+            assert_eq!(Some(1647622847000000000), ts.stats.min);
+        }
+    );
+
+    run_v2_write_test_in_env!(
+        precision_overflow,
+        // SECONDS, so multiplies the provided timestamp by 1,000,000,000
+        query_string = "?org=bananas&bucket=test&precision=s",
+        body = "platanos,tag1=A,tag2=B val=42i 1647622847000000000".as_bytes(),
+        dml_handler = [Ok(summary())],
+        want_result = Err(Error::ParseLineProtocol(_)),
+        want_dml_calls = []
+    );
+
+    run_v2_write_test_in_env!(
+        no_query_params,
+        query_string = "",
+        body = "platanos,tag1=A,tag2=B val=42i 123456".as_bytes(),
+        dml_handler = [Ok(summary())],
+        want_result = Err(Error::InvalidOrgBucket(OrgBucketError::NotSpecified)),
+        want_dml_calls = [] // None
+    );
+
+    run_v2_write_test_in_env!(
+        no_org_bucket,
+        query_string = "?",
+        body = "platanos,tag1=A,tag2=B val=42i 123456".as_bytes(),
+        dml_handler = [Ok(summary())],
+        want_result = Err(Error::InvalidOrgBucket(OrgBucketError::DecodeFail(_))),
+        want_dml_calls = [] // None
+    );
+
+    run_v2_write_test_in_env!(
+        empty_org_bucket,
+        query_string = "?org=&bucket=",
+        body = "platanos,tag1=A,tag2=B val=42i 123456".as_bytes(),
+        dml_handler = [Ok(summary())],
+        want_result = Err(Error::InvalidOrgBucket(OrgBucketError::NotSpecified)),
+        want_dml_calls = [] // None
+    );
+
+    run_v2_write_test_in_env!(
+        invalid_org_bucket,
+        query_string = format!("?org=test&bucket={}", "A".repeat(1000)),
+        body = "platanos,tag1=A,tag2=B val=42i 123456".as_bytes(),
+        dml_handler = [Ok(summary())],
+        want_result = Err(Error::InvalidOrgBucket(OrgBucketError::MappingFail(_))),
+        want_dml_calls = [] // None
+    );
+
+    run_v2_write_test_in_env!(
+        invalid_line_protocol,
+        query_string = "?org=bananas&bucket=test",
+        body = "not line protocol".as_bytes(),
+        dml_handler = [Ok(summary())],
+        want_result = Err(Error::ParseLineProtocol(_)),
+        want_dml_calls = [] // None
+    );
+
+    run_v2_write_test_in_env!(
+        non_utf8_body,
+        query_string = "?org=bananas&bucket=test",
+        body = vec![0xc3, 0x28],
+        dml_handler = [Ok(summary())],
+        want_result = Err(Error::NonUtf8Body(_)),
+        want_dml_calls = [] // None
+    );
+
+    run_v2_write_test_in_env!(
+        max_request_size_truncation,
+        query_string = "?org=bananas&bucket=test",
+        body = {
+            // Generate a LP string in the form of:
+            //
+            //  bananas,A=AAAAAAAAAA(repeated)... B=42
+            //                                  ^
+            //                                  |
+            //                         MAX_BYTES boundary
+            //
+            // So that reading MAX_BYTES number of bytes produces the string:
+            //
+            //  bananas,A=AAAAAAAAAA(repeated)...
+            //
+            // Effectively trimming off the " B=42" suffix.
+            let body = "bananas,A=";
+            iter::once(body)
+                .chain(iter::repeat("A").take(MAX_BYTES - body.len()))
+                .chain(iter::once(" B=42\n"))
+                .flat_map(|s| s.bytes())
+                .collect::<Vec<u8>>()
+        },
+        dml_handler = [Ok(summary())],
+        want_result = Err(Error::RequestSizeExceeded(_)),
+        want_dml_calls = [] // None
+    );
+
+    run_v2_write_test_in_env!(
+        db_not_found,
+        query_string = "?org=bananas&bucket=test",
+        body = "platanos,tag1=A,tag2=B val=42i 123456".as_bytes(),
+        dml_handler = [Err(DmlError::NamespaceNotFound(EXPECTED_NAMESPACE.to_string()))],
+        want_result = Err(Error::DmlHandler(DmlError::NamespaceNotFound(_))),
+        want_dml_calls = [MockDmlHandlerCall::Write{namespace, ..}] => {
+            assert_eq!(namespace, EXPECTED_NAMESPACE);
+        }
+    );
+
+    run_v2_write_test_in_env!(
+        dml_handler_error,
+        query_string = "?org=bananas&bucket=test",
+        body = "platanos,tag1=A,tag2=B val=42i 123456".as_bytes(),
+        dml_handler = [Err(DmlError::Internal("💣".into()))],
+        want_result = Err(Error::DmlHandler(DmlError::Internal(_))),
+        want_dml_calls = [MockDmlHandlerCall::Write{namespace, ..}] => {
+            assert_eq!(namespace, EXPECTED_NAMESPACE);
+        }
+    );
+
+    run_v2_write_test_in_env!(
+        field_upsert_within_batch,
+        query_string = "?org=bananas&bucket=test",
+        body = "test field=1u 100\ntest field=2u 100".as_bytes(),
+        dml_handler = [Ok(summary())],
+        want_result = Ok(_),
+        want_dml_calls = [MockDmlHandlerCall::Write{namespace, namespace_id, write_input}] => {
+            assert_eq!(namespace, EXPECTED_NAMESPACE);
+            assert_eq!(*namespace_id, NAMESPACE_ID);
+            let table = write_input.get("test").expect("table not in write");
+            let col = table.column("field").expect("column missing");
+            assert_matches!(col.data(), ColumnData::U64(data, _) => {
+                // Ensure both values are recorded, in the correct order.
+                assert_eq!(data.as_slice(), [1, 2]);
+            });
+        }
+    );
+
+    run_v2_write_test_in_env!(
+        column_named_time,
+        query_string = "?org=bananas&bucket=test",
+        body = "test field=1u,time=42u 100".as_bytes(),
+        dml_handler = [],
+        want_result = Err(_),
+        want_dml_calls = []
+    );
+
+    run_v2_delete_test_in_env!(
+        ok,
+        query_string = "?org=bananas&bucket=test",
+        body = r#"{"start":"2021-04-01T14:00:00Z","stop":"2021-04-02T14:00:00Z", "predicate":"_measurement=its_a_table and location=Boston"}"#.as_bytes(),
+        dml_handler = [Ok(())],
+        want_result = Ok(_),
+        want_dml_calls = [MockDmlHandlerCall::Delete{namespace, namespace_id, table, predicate}] => {
+            assert_eq!(table, "its_a_table");
+            assert_eq!(namespace, EXPECTED_NAMESPACE);
+            assert_eq!(*namespace_id, NAMESPACE_ID);
+            assert!(!predicate.exprs.is_empty());
+        }
+    );
+
+    run_v2_delete_test_in_env!(
+        invalid_delete_body,
+        query_string = "?org=bananas&bucket=test",
+        body = r#"{wat}"#.as_bytes(),
+        dml_handler = [],
+        want_result = Err(Error::ParseHttpDelete(_)),
+        want_dml_calls = []
+    );
+
+    run_v2_delete_test_in_env!(
+        no_query_params,
+        query_string = "",
+        body = "".as_bytes(),
+        dml_handler = [Ok(())],
+        want_result = Err(Error::InvalidOrgBucket(OrgBucketError::NotSpecified)),
+        want_dml_calls = [] // None
+    );
+
+    run_v2_delete_test_in_env!(
+        no_org_bucket,
+        query_string = "?",
+        body = "".as_bytes(),
+        dml_handler = [Ok(())],
+        want_result = Err(Error::InvalidOrgBucket(OrgBucketError::DecodeFail(_))),
+        want_dml_calls = [] // None
+    );
+
+    run_v2_delete_test_in_env!(
+        empty_org_bucket,
+        query_string = "?org=&bucket=",
+        body = "".as_bytes(),
+        dml_handler = [Ok(())],
+        want_result = Err(Error::InvalidOrgBucket(OrgBucketError::NotSpecified)),
+        want_dml_calls = [] // None
+    );
+
+    run_v2_delete_test_in_env!(
+        invalid_org_bucket,
+        query_string = format!("?org=test&bucket={}", "A".repeat(1000)),
+        body = "".as_bytes(),
+        dml_handler = [Ok(())],
+        want_result = Err(Error::InvalidOrgBucket(OrgBucketError::MappingFail(_))),
+        want_dml_calls = [] // None
+    );
+
+    run_v2_delete_test_in_env!(
+        non_utf8_body,
+        query_string = "?org=bananas&bucket=test",
+        body = vec![0xc3, 0x28],
+        dml_handler = [Ok(())],
+        want_result = Err(Error::NonUtf8Body(_)),
+        want_dml_calls = [] // None
+    );
+
+    run_v2_delete_test_in_env!(
+        db_not_found,
+        query_string = "?org=bananas&bucket=test",
+        body = r#"{"start":"2021-04-01T14:00:00Z","stop":"2021-04-02T14:00:00Z", "predicate":"_measurement=its_a_table and location=Boston"}"#.as_bytes(),
+        dml_handler = [Err(DmlError::NamespaceNotFound(EXPECTED_NAMESPACE.to_string()))],
+        want_result = Err(Error::DmlHandler(DmlError::NamespaceNotFound(_))),
+        want_dml_calls = [MockDmlHandlerCall::Delete{namespace, namespace_id, table, predicate}] => {
+            assert_eq!(table, "its_a_table");
+            assert_eq!(namespace, EXPECTED_NAMESPACE);
+            assert_eq!(*namespace_id, NAMESPACE_ID);
+            assert!(!predicate.exprs.is_empty());
+        }
+    );
+
+    run_v2_delete_test_in_env!(
+        dml_handler_error,
+        query_string = "?org=bananas&bucket=test",
+        body = r#"{"start":"2021-04-01T14:00:00Z","stop":"2021-04-02T14:00:00Z", "predicate":"_measurement=its_a_table and location=Boston"}"#.as_bytes(),
+        dml_handler = [Err(DmlError::Internal("💣".into()))],
+        want_result = Err(Error::DmlHandler(DmlError::Internal(_))),
+        want_dml_calls = [MockDmlHandlerCall::Delete{namespace, namespace_id, table, predicate}] => {
+            assert_eq!(table, "its_a_table");
+            assert_eq!(namespace, EXPECTED_NAMESPACE);
+            assert_eq!(*namespace_id, NAMESPACE_ID);
+            assert!(!predicate.exprs.is_empty());
+        }
+    );
+
+    test_http_handler!(
+        not_found,
+        uri = "https://bananas.example/wat",
+        body = "".as_bytes(),
+        auth_handler = None,
+        dml_info_handler = Box::<MultiTenantRequestParser>::default(),
+        dml_write_handler = [],
+        dml_delete_handler = [],
+        want_result = Err(Error::NoHandler),
+        want_dml_calls = []
+    );
+
+    // https://github.com/influxdata/influxdb_iox/issues/4326
+    mod issue4326 {
+        use super::*;
+
+        run_v2_write_test_in_env!(
+            duplicate_fields_same_value,
+            query_string = "?org=bananas&bucket=test",
+            body = "whydo InputPower=300i,InputPower=300i".as_bytes(),
+            dml_handler = [Ok(summary())],
+            want_result = Ok(_),
+            want_dml_calls = [MockDmlHandlerCall::Write{namespace, write_input, ..}] => {
+                assert_eq!(namespace, EXPECTED_NAMESPACE);
+                let table = write_input.get("whydo").expect("table not in write");
+                let col = table.column("InputPower").expect("column missing");
+                assert_matches!(col.data(), ColumnData::I64(data, _) => {
+                    // Ensure the duplicate values are coalesced.
+                    assert_eq!(data.as_slice(), [300]);
+                });
+            }
+        );
+
+        run_v2_write_test_in_env!(
+            duplicate_fields_different_value,
+            query_string = "?org=bananas&bucket=test",
+            body = "whydo InputPower=300i,InputPower=42i".as_bytes(),
+            dml_handler = [Ok(summary())],
+            want_result = Ok(_),
+            want_dml_calls = [MockDmlHandlerCall::Write{namespace, write_input, ..}] => {
+                assert_eq!(namespace, EXPECTED_NAMESPACE);
+                let table = write_input.get("whydo").expect("table not in write");
+                let col = table.column("InputPower").expect("column missing");
+                assert_matches!(col.data(), ColumnData::I64(data, _) => {
+                    // Last value wins
+                    assert_eq!(data.as_slice(), [42]);
+                });
+            }
+        );
+
+        run_v2_write_test_in_env!(
+            duplicate_fields_different_type,
+            query_string = "?org=bananas&bucket=test",
+            body = "whydo InputPower=300i,InputPower=4.2".as_bytes(),
+            dml_handler = [],
+            want_result = Err(Error::ParseLineProtocol(mutable_batch_lp::Error::Write {
+                source: LineWriteError::ConflictedFieldTypes { .. },
+                ..
+            })),
+            want_dml_calls = []
+        );
+
+        run_v2_write_test_in_env!(
+            duplicate_tags_same_value,
+            query_string = "?org=bananas&bucket=test",
+            body = "whydo,InputPower=300i,InputPower=300i field=42i".as_bytes(),
+            dml_handler = [],
+            want_result = Err(Error::ParseLineProtocol(mutable_batch_lp::Error::Write {
+                source: LineWriteError::DuplicateTag { .. },
+                ..
+            })),
+            want_dml_calls = []
+        );
+
+        run_v2_write_test_in_env!(
+            duplicate_tags_different_value,
+            query_string = "?org=bananas&bucket=test",
+            body = "whydo,InputPower=300i,InputPower=42i field=42i".as_bytes(),
+            dml_handler = [],
+            want_result = Err(Error::ParseLineProtocol(mutable_batch_lp::Error::Write {
+                source: LineWriteError::DuplicateTag { .. },
+                ..
+            })),
+            want_dml_calls = []
+        );
+
+        run_v2_write_test_in_env!(
+            duplicate_tags_different_type,
+            query_string = "?org=bananas&bucket=test",
+            body = "whydo,InputPower=300i,InputPower=4.2 field=42i".as_bytes(),
+            dml_handler = [],
+            want_result = Err(Error::ParseLineProtocol(mutable_batch_lp::Error::Write {
+                source: LineWriteError::DuplicateTag { .. },
+                ..
+            })),
+            want_dml_calls = []
+        );
+
+        run_v2_write_test_in_env!(
+            duplicate_is_tag_and_field,
+            query_string = "?org=bananas&bucket=test",
+            body = "whydo,InputPower=300i InputPower=300i".as_bytes(),
+            dml_handler = [],
+            want_result = Err(Error::ParseLineProtocol(mutable_batch_lp::Error::Write {
+                source: LineWriteError::MutableBatch {
+                    source: mutable_batch::writer::Error::TypeMismatch { .. }
+                },
+                ..
+            })),
+            want_dml_calls = []
+        );
+
+        run_v2_write_test_in_env!(
+            duplicate_is_tag_and_field_different_types,
+            query_string = "?org=bananas&bucket=test",
+            body = "whydo,InputPower=300i InputPower=30.0".as_bytes(),
+            dml_handler = [],
+            want_result = Err(Error::ParseLineProtocol(mutable_batch_lp::Error::Write {
+                source: LineWriteError::MutableBatch {
+                    source: mutable_batch::writer::Error::TypeMismatch { .. }
+                },
+                ..
+            })),
+            want_dml_calls = []
+        );
     }
+
+    run_v1_write_test_in_env!(
+        v1_ok,
+        query_string = "?db=database",
+        body = "platanos,tag1=A,tag2=B val=42i 123456".as_bytes(),
+        dml_handler = [Ok(summary())],
+        want_result = Ok(_),
+        want_dml_calls = [MockDmlHandlerCall::Write{namespace, ..}] => {
+            assert_eq!(namespace, EXPECTED_NAMESPACE);
+        }
+    );
+
+    run_v1_write_test_in_env!(
+        v1_no_query_params,
+        query_string = "",
+        body = "platanos,tag1=A,tag2=B val=42i 123456".as_bytes(),
+        dml_handler = [Ok(summary())],
+        want_result = Err(Error::InvalidDatabaseRp(DatabaseRpError::NotSpecified)),
+        want_dml_calls = [] // None
+    );
+
+    run_v1_write_test_in_env!(
+        v1_no_db,
+        query_string = "?",
+        body = "platanos,tag1=A,tag2=B val=42i 123456".as_bytes(),
+        dml_handler = [Ok(summary())],
+        want_result = Err(Error::InvalidDatabaseRp(DatabaseRpError::DecodeFail(_))),
+        want_dml_calls = [] // None
+    );
+
+    run_v1_write_test_in_env!(
+        v1_empty_db,
+        query_string = "?db=",
+        body = "platanos,tag1=A,tag2=B val=42i 123456".as_bytes(),
+        dml_handler = [Ok(summary())],
+        want_result = Err(Error::InvalidDatabaseRp(DatabaseRpError::NotSpecified)),
+        want_dml_calls = [] // None
+    );
+
+    run_v1_write_test_in_env!(
+        v1_invalid_db,
+        query_string = format!("?db={}", "A".repeat(1000)),
+        body = "platanos,tag1=A,tag2=B val=42i 123456".as_bytes(),
+        dml_handler = [Ok(summary())],
+        want_result = Err(Error::InvalidDatabaseRp(DatabaseRpError::MappingFail(_))),
+        want_dml_calls = [] // None
+    );
+
+    run_v1_write_test_in_env!(
+        v1_ok_with_consistency,
+        query_string = "?db=database&consistency=any",
+        body = "platanos,tag1=A,tag2=B val=42i 123456".as_bytes(),
+        dml_handler = [Ok(summary())],
+        want_result = Ok(_),
+        want_dml_calls = [MockDmlHandlerCall::Write{namespace, ..}] => {
+            assert_eq!(namespace, EXPECTED_NAMESPACE);
+        }
+    );
+
+    run_v1_write_test_in_env!(
+        v1_invalid_consistency,
+        query_string = "?db=database&consistency=wrong",
+        body = "platanos,tag1=A,tag2=B val=42i 123456".as_bytes(),
+        dml_handler = [Ok(summary())],
+        want_result = Err(Error::InvalidDatabaseRp(DatabaseRpError::DecodeFail(_))),
+        want_dml_calls = [] // None
+    );
+
+    run_v1_write_test_in_env!(
+        v1_rp_ok,
+        query_string = "?db=database&rp=myrp",
+        body = "platanos,tag1=A,tag2=B val=42i 123456".as_bytes(),
+        dml_handler = [Ok(summary())],
+        want_result = Ok(_),
+        want_dml_calls = [MockDmlHandlerCall::Write{namespace, ..}] => {
+            assert_eq!(namespace, "database/myrp");
+        }
+    );
+
+    run_v1_write_test_in_env!(
+        v1_handle_backslash_ok,
+        query_string = "?db=data/base&rp=myrp",
+        body = "platanos,tag1=A,tag2=B val=42i 123456".as_bytes(),
+        dml_handler = [Ok(summary())],
+        want_result = Ok(_),
+        want_dml_calls = [MockDmlHandlerCall::Write{namespace, ..}] => {
+            assert_eq!(namespace, "data%2Fbase/myrp");
+        }
+    );
+
+    run_v1_write_test_in_env!(
+        v1_rp_empty,
+        query_string = "?db=database&rp=",
+        body = "platanos,tag1=A,tag2=B val=42i 123456".as_bytes(),
+        dml_handler = [Ok(summary())],
+        want_result = Ok(_),
+        want_dml_calls = [MockDmlHandlerCall::Write{namespace, ..}] => {
+            assert_eq!(namespace, EXPECTED_NAMESPACE);
+        }
+    );
+
+    run_v1_write_test_in_env!(
+        v1_rp_empty_str,
+        query_string = "?db=database&rp=''",
+        body = "platanos,tag1=A,tag2=B val=42i 123456".as_bytes(),
+        dml_handler = [Ok(summary())],
+        want_result = Ok(_),
+        want_dml_calls = [MockDmlHandlerCall::Write{namespace, ..}] => {
+            assert_eq!(namespace, EXPECTED_NAMESPACE);
+        }
+    );
+
+    run_v1_write_test_in_env!(
+        v1_rp_ignore_autogen,
+        query_string = "?db=database&rp=autogen",
+        body = "platanos,tag1=A,tag2=B val=42i 123456".as_bytes(),
+        dml_handler = [Ok(summary())],
+        want_result = Ok(_),
+        want_dml_calls = [MockDmlHandlerCall::Write{namespace, ..}] => {
+            assert_eq!(namespace, EXPECTED_NAMESPACE);
+        }
+    );
 
     #[derive(Debug, Error)]
     enum MockError {

--- a/router/src/server/http.rs
+++ b/router/src/server/http.rs
@@ -967,441 +967,446 @@ mod tests {
         };
     }
 
-    test_write_handler!(
-        ok,
-        query_string = "?org=bananas&bucket=test",
-        body = "platanos,tag1=A,tag2=B val=42i 123456".as_bytes(),
-        dml_handler = [Ok(summary())],
-        want_result = Ok(_),
-        want_dml_calls = [MockDmlHandlerCall::Write{namespace, ..}] => {
-            assert_eq!(namespace, "bananas_test");
-        }
-    );
+    // Wrapper over a series of v2 test, such that they can be run in different env.
+    macro_rules! run_v2_test_in_env {
+        ($test_scope:ident) => {
+            test_write_handler!(
+                ok,
+                query_string = "?org=bananas&bucket=test",
+                body = "platanos,tag1=A,tag2=B val=42i 123456".as_bytes(),
+                dml_handler = [Ok(summary())],
+                want_result = Ok(_),
+                want_dml_calls = [MockDmlHandlerCall::Write{namespace, ..}] => {
+                    assert_eq!(namespace, "bananas_test");
+                }
+            );
 
-    test_write_handler!(
-        ok_precision_s,
-        query_string = "?org=bananas&bucket=test&precision=s",
-        body = "platanos,tag1=A,tag2=B val=42i 1647622847".as_bytes(),
-        dml_handler = [Ok(summary())],
-        want_result = Ok(_),
-        want_dml_calls = [MockDmlHandlerCall::Write{namespace, namespace_id, write_input}] => {
-            assert_eq!(namespace, "bananas_test");
-            assert_eq!(*namespace_id, NAMESPACE_ID);
+            test_write_handler!(
+                ok_precision_s,
+                query_string = "?org=bananas&bucket=test&precision=s",
+                body = "platanos,tag1=A,tag2=B val=42i 1647622847".as_bytes(),
+                dml_handler = [Ok(summary())],
+                want_result = Ok(_),
+                want_dml_calls = [MockDmlHandlerCall::Write{namespace, namespace_id, write_input}] => {
+                    assert_eq!(namespace, "bananas_test");
+                    assert_eq!(*namespace_id, NAMESPACE_ID);
 
-            let table = write_input.get("platanos").expect("table not found");
-            let ts = table.timestamp_summary().expect("no timestamp summary");
-            assert_eq!(Some(1647622847000000000), ts.stats.min);
-        }
-    );
+                    let table = write_input.get("platanos").expect("table not found");
+                    let ts = table.timestamp_summary().expect("no timestamp summary");
+                    assert_eq!(Some(1647622847000000000), ts.stats.min);
+                }
+            );
 
-    test_write_handler!(
-        ok_precision_ms,
-        query_string = "?org=bananas&bucket=test&precision=ms",
-        body = "platanos,tag1=A,tag2=B val=42i 1647622847000".as_bytes(),
-        dml_handler = [Ok(summary())],
-        want_result = Ok(_),
-        want_dml_calls = [MockDmlHandlerCall::Write{namespace, namespace_id, write_input}] => {
-            assert_eq!(namespace, "bananas_test");
-            assert_eq!(*namespace_id, NAMESPACE_ID);
+            test_write_handler!(
+                ok_precision_ms,
+                query_string = "?org=bananas&bucket=test&precision=ms",
+                body = "platanos,tag1=A,tag2=B val=42i 1647622847000".as_bytes(),
+                dml_handler = [Ok(summary())],
+                want_result = Ok(_),
+                want_dml_calls = [MockDmlHandlerCall::Write{namespace, namespace_id, write_input}] => {
+                    assert_eq!(namespace, "bananas_test");
+                    assert_eq!(*namespace_id, NAMESPACE_ID);
 
-            let table = write_input.get("platanos").expect("table not found");
-            let ts = table.timestamp_summary().expect("no timestamp summary");
-            assert_eq!(Some(1647622847000000000), ts.stats.min);
-        }
-    );
+                    let table = write_input.get("platanos").expect("table not found");
+                    let ts = table.timestamp_summary().expect("no timestamp summary");
+                    assert_eq!(Some(1647622847000000000), ts.stats.min);
+                }
+            );
 
-    test_write_handler!(
-        ok_precision_us,
-        query_string = "?org=bananas&bucket=test&precision=us",
-        body = "platanos,tag1=A,tag2=B val=42i 1647622847000000".as_bytes(),
-        dml_handler = [Ok(summary())],
-        want_result = Ok(_),
-        want_dml_calls = [MockDmlHandlerCall::Write{namespace, namespace_id, write_input}] => {
-            assert_eq!(namespace, "bananas_test");
-            assert_eq!(*namespace_id, NAMESPACE_ID);
+            test_write_handler!(
+                ok_precision_us,
+                query_string = "?org=bananas&bucket=test&precision=us",
+                body = "platanos,tag1=A,tag2=B val=42i 1647622847000000".as_bytes(),
+                dml_handler = [Ok(summary())],
+                want_result = Ok(_),
+                want_dml_calls = [MockDmlHandlerCall::Write{namespace, namespace_id, write_input}] => {
+                    assert_eq!(namespace, "bananas_test");
+                    assert_eq!(*namespace_id, NAMESPACE_ID);
 
-            let table = write_input.get("platanos").expect("table not found");
-            let ts = table.timestamp_summary().expect("no timestamp summary");
-            assert_eq!(Some(1647622847000000000), ts.stats.min);
-        }
-    );
+                    let table = write_input.get("platanos").expect("table not found");
+                    let ts = table.timestamp_summary().expect("no timestamp summary");
+                    assert_eq!(Some(1647622847000000000), ts.stats.min);
+                }
+            );
 
-    test_write_handler!(
-        ok_precision_ns,
-        query_string = "?org=bananas&bucket=test&precision=ns",
-        body = "platanos,tag1=A,tag2=B val=42i 1647622847000000000".as_bytes(),
-        dml_handler = [Ok(summary())],
-        want_result = Ok(_),
-        want_dml_calls = [MockDmlHandlerCall::Write{namespace, namespace_id, write_input}] => {
-            assert_eq!(namespace, "bananas_test");
-            assert_eq!(*namespace_id, NAMESPACE_ID);
+            test_write_handler!(
+                ok_precision_ns,
+                query_string = "?org=bananas&bucket=test&precision=ns",
+                body = "platanos,tag1=A,tag2=B val=42i 1647622847000000000".as_bytes(),
+                dml_handler = [Ok(summary())],
+                want_result = Ok(_),
+                want_dml_calls = [MockDmlHandlerCall::Write{namespace, namespace_id, write_input}] => {
+                    assert_eq!(namespace, "bananas_test");
+                    assert_eq!(*namespace_id, NAMESPACE_ID);
 
-            let table = write_input.get("platanos").expect("table not found");
-            let ts = table.timestamp_summary().expect("no timestamp summary");
-            assert_eq!(Some(1647622847000000000), ts.stats.min);
-        }
-    );
+                    let table = write_input.get("platanos").expect("table not found");
+                    let ts = table.timestamp_summary().expect("no timestamp summary");
+                    assert_eq!(Some(1647622847000000000), ts.stats.min);
+                }
+            );
 
-    test_write_handler!(
-        precision_overflow,
-        // SECONDS, so multiplies the provided timestamp by 1,000,000,000
-        query_string = "?org=bananas&bucket=test&precision=s",
-        body = "platanos,tag1=A,tag2=B val=42i 1647622847000000000".as_bytes(),
-        dml_handler = [Ok(summary())],
-        want_result = Err(Error::ParseLineProtocol(_)),
-        want_dml_calls = []
-    );
+            test_write_handler!(
+                precision_overflow,
+                // SECONDS, so multiplies the provided timestamp by 1,000,000,000
+                query_string = "?org=bananas&bucket=test&precision=s",
+                body = "platanos,tag1=A,tag2=B val=42i 1647622847000000000".as_bytes(),
+                dml_handler = [Ok(summary())],
+                want_result = Err(Error::ParseLineProtocol(_)),
+                want_dml_calls = []
+            );
 
-    test_write_handler!(
-        no_query_params,
-        query_string = "",
-        body = "platanos,tag1=A,tag2=B val=42i 123456".as_bytes(),
-        dml_handler = [Ok(summary())],
-        want_result = Err(Error::InvalidOrgBucket(OrgBucketError::NotSpecified)),
-        want_dml_calls = [] // None
-    );
+            test_write_handler!(
+                no_query_params,
+                query_string = "",
+                body = "platanos,tag1=A,tag2=B val=42i 123456".as_bytes(),
+                dml_handler = [Ok(summary())],
+                want_result = Err(Error::InvalidOrgBucket(OrgBucketError::NotSpecified)),
+                want_dml_calls = [] // None
+            );
 
-    test_write_handler!(
-        no_org_bucket,
-        query_string = "?",
-        body = "platanos,tag1=A,tag2=B val=42i 123456".as_bytes(),
-        dml_handler = [Ok(summary())],
-        want_result = Err(Error::InvalidOrgBucket(OrgBucketError::DecodeFail(_))),
-        want_dml_calls = [] // None
-    );
+            test_write_handler!(
+                no_org_bucket,
+                query_string = "?",
+                body = "platanos,tag1=A,tag2=B val=42i 123456".as_bytes(),
+                dml_handler = [Ok(summary())],
+                want_result = Err(Error::InvalidOrgBucket(OrgBucketError::DecodeFail(_))),
+                want_dml_calls = [] // None
+            );
 
-    test_write_handler!(
-        empty_org_bucket,
-        query_string = "?org=&bucket=",
-        body = "platanos,tag1=A,tag2=B val=42i 123456".as_bytes(),
-        dml_handler = [Ok(summary())],
-        want_result = Err(Error::InvalidOrgBucket(OrgBucketError::NotSpecified)),
-        want_dml_calls = [] // None
-    );
+            test_write_handler!(
+                empty_org_bucket,
+                query_string = "?org=&bucket=",
+                body = "platanos,tag1=A,tag2=B val=42i 123456".as_bytes(),
+                dml_handler = [Ok(summary())],
+                want_result = Err(Error::InvalidOrgBucket(OrgBucketError::NotSpecified)),
+                want_dml_calls = [] // None
+            );
 
-    test_write_handler!(
-        invalid_org_bucket,
-        query_string = format!("?org=test&bucket={}", "A".repeat(1000)),
-        body = "platanos,tag1=A,tag2=B val=42i 123456".as_bytes(),
-        dml_handler = [Ok(summary())],
-        want_result = Err(Error::InvalidOrgBucket(OrgBucketError::MappingFail(_))),
-        want_dml_calls = [] // None
-    );
+            test_write_handler!(
+                invalid_org_bucket,
+                query_string = format!("?org=test&bucket={}", "A".repeat(1000)),
+                body = "platanos,tag1=A,tag2=B val=42i 123456".as_bytes(),
+                dml_handler = [Ok(summary())],
+                want_result = Err(Error::InvalidOrgBucket(OrgBucketError::MappingFail(_))),
+                want_dml_calls = [] // None
+            );
 
-    test_write_handler!(
-        invalid_line_protocol,
-        query_string = "?org=bananas&bucket=test",
-        body = "not line protocol".as_bytes(),
-        dml_handler = [Ok(summary())],
-        want_result = Err(Error::ParseLineProtocol(_)),
-        want_dml_calls = [] // None
-    );
+            test_write_handler!(
+                invalid_line_protocol,
+                query_string = "?org=bananas&bucket=test",
+                body = "not line protocol".as_bytes(),
+                dml_handler = [Ok(summary())],
+                want_result = Err(Error::ParseLineProtocol(_)),
+                want_dml_calls = [] // None
+            );
 
-    test_write_handler!(
-        non_utf8_body,
-        query_string = "?org=bananas&bucket=test",
-        body = vec![0xc3, 0x28],
-        dml_handler = [Ok(summary())],
-        want_result = Err(Error::NonUtf8Body(_)),
-        want_dml_calls = [] // None
-    );
+            test_write_handler!(
+                non_utf8_body,
+                query_string = "?org=bananas&bucket=test",
+                body = vec![0xc3, 0x28],
+                dml_handler = [Ok(summary())],
+                want_result = Err(Error::NonUtf8Body(_)),
+                want_dml_calls = [] // None
+            );
 
-    test_write_handler!(
-        max_request_size_truncation,
-        query_string = "?org=bananas&bucket=test",
-        body = {
-            // Generate a LP string in the form of:
-            //
-            //  bananas,A=AAAAAAAAAA(repeated)... B=42
-            //                                  ^
-            //                                  |
-            //                         MAX_BYTES boundary
-            //
-            // So that reading MAX_BYTES number of bytes produces the string:
-            //
-            //  bananas,A=AAAAAAAAAA(repeated)...
-            //
-            // Effectively trimming off the " B=42" suffix.
-            let body = "bananas,A=";
-            iter::once(body)
-                .chain(iter::repeat("A").take(MAX_BYTES - body.len()))
-                .chain(iter::once(" B=42\n"))
-                .flat_map(|s| s.bytes())
-                .collect::<Vec<u8>>()
-        },
-        dml_handler = [Ok(summary())],
-        want_result = Err(Error::RequestSizeExceeded(_)),
-        want_dml_calls = [] // None
-    );
-
-    test_write_handler!(
-        db_not_found,
-        query_string = "?org=bananas&bucket=test",
-        body = "platanos,tag1=A,tag2=B val=42i 123456".as_bytes(),
-        dml_handler = [Err(DmlError::NamespaceNotFound("bananas_test".to_string()))],
-        want_result = Err(Error::DmlHandler(DmlError::NamespaceNotFound(_))),
-        want_dml_calls = [MockDmlHandlerCall::Write{namespace, ..}] => {
-            assert_eq!(namespace, "bananas_test");
-        }
-    );
-
-    test_write_handler!(
-        dml_handler_error,
-        query_string = "?org=bananas&bucket=test",
-        body = "platanos,tag1=A,tag2=B val=42i 123456".as_bytes(),
-        dml_handler = [Err(DmlError::Internal("💣".into()))],
-        want_result = Err(Error::DmlHandler(DmlError::Internal(_))),
-        want_dml_calls = [MockDmlHandlerCall::Write{namespace, ..}] => {
-            assert_eq!(namespace, "bananas_test");
-        }
-    );
-
-    test_write_handler!(
-        field_upsert_within_batch,
-        query_string = "?org=bananas&bucket=test",
-        body = "test field=1u 100\ntest field=2u 100".as_bytes(),
-        dml_handler = [Ok(summary())],
-        want_result = Ok(_),
-        want_dml_calls = [MockDmlHandlerCall::Write{namespace, namespace_id, write_input}] => {
-            assert_eq!(namespace, "bananas_test");
-            assert_eq!(*namespace_id, NAMESPACE_ID);
-            let table = write_input.get("test").expect("table not in write");
-            let col = table.column("field").expect("column missing");
-            assert_matches!(col.data(), ColumnData::U64(data, _) => {
-                // Ensure both values are recorded, in the correct order.
-                assert_eq!(data.as_slice(), [1, 2]);
-            });
-        }
-    );
-
-    test_write_handler!(
-        column_named_time,
-        query_string = "?org=bananas&bucket=test",
-        body = "test field=1u,time=42u 100".as_bytes(),
-        dml_handler = [],
-        want_result = Err(_),
-        want_dml_calls = []
-    );
-
-    test_delete_handler!(
-        ok,
-        query_string = "?org=bananas&bucket=test",
-        body = r#"{"start":"2021-04-01T14:00:00Z","stop":"2021-04-02T14:00:00Z", "predicate":"_measurement=its_a_table and location=Boston"}"#.as_bytes(),
-        dml_handler = [Ok(())],
-        want_result = Ok(_),
-        want_dml_calls = [MockDmlHandlerCall::Delete{namespace, namespace_id, table, predicate}] => {
-            assert_eq!(table, "its_a_table");
-            assert_eq!(namespace, "bananas_test");
-            assert_eq!(*namespace_id, NAMESPACE_ID);
-            assert!(!predicate.exprs.is_empty());
-        }
-    );
-
-    test_delete_handler!(
-        invalid_delete_body,
-        query_string = "?org=bananas&bucket=test",
-        body = r#"{wat}"#.as_bytes(),
-        dml_handler = [],
-        want_result = Err(Error::ParseHttpDelete(_)),
-        want_dml_calls = []
-    );
-
-    test_delete_handler!(
-        no_query_params,
-        query_string = "",
-        body = "".as_bytes(),
-        dml_handler = [Ok(())],
-        want_result = Err(Error::InvalidOrgBucket(OrgBucketError::NotSpecified)),
-        want_dml_calls = [] // None
-    );
-
-    test_delete_handler!(
-        no_org_bucket,
-        query_string = "?",
-        body = "".as_bytes(),
-        dml_handler = [Ok(())],
-        want_result = Err(Error::InvalidOrgBucket(OrgBucketError::DecodeFail(_))),
-        want_dml_calls = [] // None
-    );
-
-    test_delete_handler!(
-        empty_org_bucket,
-        query_string = "?org=&bucket=",
-        body = "".as_bytes(),
-        dml_handler = [Ok(())],
-        want_result = Err(Error::InvalidOrgBucket(OrgBucketError::NotSpecified)),
-        want_dml_calls = [] // None
-    );
-
-    test_delete_handler!(
-        invalid_org_bucket,
-        query_string = format!("?org=test&bucket={}", "A".repeat(1000)),
-        body = "".as_bytes(),
-        dml_handler = [Ok(())],
-        want_result = Err(Error::InvalidOrgBucket(OrgBucketError::MappingFail(_))),
-        want_dml_calls = [] // None
-    );
-
-    test_delete_handler!(
-        non_utf8_body,
-        query_string = "?org=bananas&bucket=test",
-        body = vec![0xc3, 0x28],
-        dml_handler = [Ok(())],
-        want_result = Err(Error::NonUtf8Body(_)),
-        want_dml_calls = [] // None
-    );
-
-    test_delete_handler!(
-        db_not_found,
-        query_string = "?org=bananas&bucket=test",
-        body = r#"{"start":"2021-04-01T14:00:00Z","stop":"2021-04-02T14:00:00Z", "predicate":"_measurement=its_a_table and location=Boston"}"#.as_bytes(),
-        dml_handler = [Err(DmlError::NamespaceNotFound("bananas_test".to_string()))],
-        want_result = Err(Error::DmlHandler(DmlError::NamespaceNotFound(_))),
-        want_dml_calls = [MockDmlHandlerCall::Delete{namespace, namespace_id, table, predicate}] => {
-            assert_eq!(table, "its_a_table");
-            assert_eq!(namespace, "bananas_test");
-            assert_eq!(*namespace_id, NAMESPACE_ID);
-            assert!(!predicate.exprs.is_empty());
-        }
-    );
-
-    test_delete_handler!(
-        dml_handler_error,
-        query_string = "?org=bananas&bucket=test",
-        body = r#"{"start":"2021-04-01T14:00:00Z","stop":"2021-04-02T14:00:00Z", "predicate":"_measurement=its_a_table and location=Boston"}"#.as_bytes(),
-        dml_handler = [Err(DmlError::Internal("💣".into()))],
-        want_result = Err(Error::DmlHandler(DmlError::Internal(_))),
-        want_dml_calls = [MockDmlHandlerCall::Delete{namespace, namespace_id, table, predicate}] => {
-            assert_eq!(table, "its_a_table");
-            assert_eq!(namespace, "bananas_test");
-            assert_eq!(*namespace_id, NAMESPACE_ID);
-            assert!(!predicate.exprs.is_empty());
-        }
-    );
-
-    test_http_handler!(
-        not_found,
-        uri = "https://bananas.example/wat",
-        body = "".as_bytes(),
-        dml_write_handler = [],
-        dml_delete_handler = [],
-        want_result = Err(Error::NoHandler),
-        want_dml_calls = []
-    );
-
-    // https://github.com/influxdata/influxdb_iox/issues/4326
-    mod issue4326 {
-        use super::*;
-
-        test_write_handler!(
-            duplicate_fields_same_value,
-            query_string = "?org=bananas&bucket=test",
-            body = "whydo InputPower=300i,InputPower=300i".as_bytes(),
-            dml_handler = [Ok(summary())],
-            want_result = Ok(_),
-            want_dml_calls = [MockDmlHandlerCall::Write{namespace, write_input, ..}] => {
-                assert_eq!(namespace, "bananas_test");
-                let table = write_input.get("whydo").expect("table not in write");
-                let col = table.column("InputPower").expect("column missing");
-                assert_matches!(col.data(), ColumnData::I64(data, _) => {
-                    // Ensure the duplicate values are coalesced.
-                    assert_eq!(data.as_slice(), [300]);
-                });
-            }
-        );
-
-        test_write_handler!(
-            duplicate_fields_different_value,
-            query_string = "?org=bananas&bucket=test",
-            body = "whydo InputPower=300i,InputPower=42i".as_bytes(),
-            dml_handler = [Ok(summary())],
-            want_result = Ok(_),
-            want_dml_calls = [MockDmlHandlerCall::Write{namespace, write_input, ..}] => {
-                assert_eq!(namespace, "bananas_test");
-                let table = write_input.get("whydo").expect("table not in write");
-                let col = table.column("InputPower").expect("column missing");
-                assert_matches!(col.data(), ColumnData::I64(data, _) => {
-                    // Last value wins
-                    assert_eq!(data.as_slice(), [42]);
-                });
-            }
-        );
-
-        test_write_handler!(
-            duplicate_fields_different_type,
-            query_string = "?org=bananas&bucket=test",
-            body = "whydo InputPower=300i,InputPower=4.2".as_bytes(),
-            dml_handler = [],
-            want_result = Err(Error::ParseLineProtocol(mutable_batch_lp::Error::Write {
-                source: LineWriteError::ConflictedFieldTypes { .. },
-                ..
-            })),
-            want_dml_calls = []
-        );
-
-        test_write_handler!(
-            duplicate_tags_same_value,
-            query_string = "?org=bananas&bucket=test",
-            body = "whydo,InputPower=300i,InputPower=300i field=42i".as_bytes(),
-            dml_handler = [],
-            want_result = Err(Error::ParseLineProtocol(mutable_batch_lp::Error::Write {
-                source: LineWriteError::DuplicateTag { .. },
-                ..
-            })),
-            want_dml_calls = []
-        );
-
-        test_write_handler!(
-            duplicate_tags_different_value,
-            query_string = "?org=bananas&bucket=test",
-            body = "whydo,InputPower=300i,InputPower=42i field=42i".as_bytes(),
-            dml_handler = [],
-            want_result = Err(Error::ParseLineProtocol(mutable_batch_lp::Error::Write {
-                source: LineWriteError::DuplicateTag { .. },
-                ..
-            })),
-            want_dml_calls = []
-        );
-
-        test_write_handler!(
-            duplicate_tags_different_type,
-            query_string = "?org=bananas&bucket=test",
-            body = "whydo,InputPower=300i,InputPower=4.2 field=42i".as_bytes(),
-            dml_handler = [],
-            want_result = Err(Error::ParseLineProtocol(mutable_batch_lp::Error::Write {
-                source: LineWriteError::DuplicateTag { .. },
-                ..
-            })),
-            want_dml_calls = []
-        );
-
-        test_write_handler!(
-            duplicate_is_tag_and_field,
-            query_string = "?org=bananas&bucket=test",
-            body = "whydo,InputPower=300i InputPower=300i".as_bytes(),
-            dml_handler = [],
-            want_result = Err(Error::ParseLineProtocol(mutable_batch_lp::Error::Write {
-                source: LineWriteError::MutableBatch {
-                    source: mutable_batch::writer::Error::TypeMismatch { .. }
+            test_write_handler!(
+                max_request_size_truncation,
+                query_string = "?org=bananas&bucket=test",
+                body = {
+                    // Generate a LP string in the form of:
+                    //
+                    //  bananas,A=AAAAAAAAAA(repeated)... B=42
+                    //                                  ^
+                    //                                  |
+                    //                         MAX_BYTES boundary
+                    //
+                    // So that reading MAX_BYTES number of bytes produces the string:
+                    //
+                    //  bananas,A=AAAAAAAAAA(repeated)...
+                    //
+                    // Effectively trimming off the " B=42" suffix.
+                    let body = "bananas,A=";
+                    iter::once(body)
+                        .chain(iter::repeat("A").take(MAX_BYTES - body.len()))
+                        .chain(iter::once(" B=42\n"))
+                        .flat_map(|s| s.bytes())
+                        .collect::<Vec<u8>>()
                 },
-                ..
-            })),
-            want_dml_calls = []
-        );
+                dml_handler = [Ok(summary())],
+                want_result = Err(Error::RequestSizeExceeded(_)),
+                want_dml_calls = [] // None
+            );
 
-        test_write_handler!(
-            duplicate_is_tag_and_field_different_types,
-            query_string = "?org=bananas&bucket=test",
-            body = "whydo,InputPower=300i InputPower=30.0".as_bytes(),
-            dml_handler = [],
-            want_result = Err(Error::ParseLineProtocol(mutable_batch_lp::Error::Write {
-                source: LineWriteError::MutableBatch {
-                    source: mutable_batch::writer::Error::TypeMismatch { .. }
-                },
-                ..
-            })),
-            want_dml_calls = []
-        );
+            test_write_handler!(
+                db_not_found,
+                query_string = "?org=bananas&bucket=test",
+                body = "platanos,tag1=A,tag2=B val=42i 123456".as_bytes(),
+                dml_handler = [Err(DmlError::NamespaceNotFound("bananas_test".to_string()))],
+                want_result = Err(Error::DmlHandler(DmlError::NamespaceNotFound(_))),
+                want_dml_calls = [MockDmlHandlerCall::Write{namespace, ..}] => {
+                    assert_eq!(namespace, "bananas_test");
+                }
+            );
+
+            test_write_handler!(
+                dml_handler_error,
+                query_string = "?org=bananas&bucket=test",
+                body = "platanos,tag1=A,tag2=B val=42i 123456".as_bytes(),
+                dml_handler = [Err(DmlError::Internal("💣".into()))],
+                want_result = Err(Error::DmlHandler(DmlError::Internal(_))),
+                want_dml_calls = [MockDmlHandlerCall::Write{namespace, ..}] => {
+                    assert_eq!(namespace, "bananas_test");
+                }
+            );
+
+            test_write_handler!(
+                field_upsert_within_batch,
+                query_string = "?org=bananas&bucket=test",
+                body = "test field=1u 100\ntest field=2u 100".as_bytes(),
+                dml_handler = [Ok(summary())],
+                want_result = Ok(_),
+                want_dml_calls = [MockDmlHandlerCall::Write{namespace, namespace_id, write_input}] => {
+                    assert_eq!(namespace, "bananas_test");
+                    assert_eq!(*namespace_id, NAMESPACE_ID);
+                    let table = write_input.get("test").expect("table not in write");
+                    let col = table.column("field").expect("column missing");
+                    assert_matches!(col.data(), ColumnData::U64(data, _) => {
+                        // Ensure both values are recorded, in the correct order.
+                        assert_eq!(data.as_slice(), [1, 2]);
+                    });
+                }
+            );
+
+            test_write_handler!(
+                column_named_time,
+                query_string = "?org=bananas&bucket=test",
+                body = "test field=1u,time=42u 100".as_bytes(),
+                dml_handler = [],
+                want_result = Err(_),
+                want_dml_calls = []
+            );
+
+            test_delete_handler!(
+                ok,
+                query_string = "?org=bananas&bucket=test",
+                body = r#"{"start":"2021-04-01T14:00:00Z","stop":"2021-04-02T14:00:00Z", "predicate":"_measurement=its_a_table and location=Boston"}"#.as_bytes(),
+                dml_handler = [Ok(())],
+                want_result = Ok(_),
+                want_dml_calls = [MockDmlHandlerCall::Delete{namespace, namespace_id, table, predicate}] => {
+                    assert_eq!(table, "its_a_table");
+                    assert_eq!(namespace, "bananas_test");
+                    assert_eq!(*namespace_id, NAMESPACE_ID);
+                    assert!(!predicate.exprs.is_empty());
+                }
+            );
+
+            test_delete_handler!(
+                invalid_delete_body,
+                query_string = "?org=bananas&bucket=test",
+                body = r#"{wat}"#.as_bytes(),
+                dml_handler = [],
+                want_result = Err(Error::ParseHttpDelete(_)),
+                want_dml_calls = []
+            );
+
+            test_delete_handler!(
+                no_query_params,
+                query_string = "",
+                body = "".as_bytes(),
+                dml_handler = [Ok(())],
+                want_result = Err(Error::InvalidOrgBucket(OrgBucketError::NotSpecified)),
+                want_dml_calls = [] // None
+            );
+
+            test_delete_handler!(
+                no_org_bucket,
+                query_string = "?",
+                body = "".as_bytes(),
+                dml_handler = [Ok(())],
+                want_result = Err(Error::InvalidOrgBucket(OrgBucketError::DecodeFail(_))),
+                want_dml_calls = [] // None
+            );
+
+            test_delete_handler!(
+                empty_org_bucket,
+                query_string = "?org=&bucket=",
+                body = "".as_bytes(),
+                dml_handler = [Ok(())],
+                want_result = Err(Error::InvalidOrgBucket(OrgBucketError::NotSpecified)),
+                want_dml_calls = [] // None
+            );
+
+            test_delete_handler!(
+                invalid_org_bucket,
+                query_string = format!("?org=test&bucket={}", "A".repeat(1000)),
+                body = "".as_bytes(),
+                dml_handler = [Ok(())],
+                want_result = Err(Error::InvalidOrgBucket(OrgBucketError::MappingFail(_))),
+                want_dml_calls = [] // None
+            );
+
+            test_delete_handler!(
+                non_utf8_body,
+                query_string = "?org=bananas&bucket=test",
+                body = vec![0xc3, 0x28],
+                dml_handler = [Ok(())],
+                want_result = Err(Error::NonUtf8Body(_)),
+                want_dml_calls = [] // None
+            );
+
+            test_delete_handler!(
+                db_not_found,
+                query_string = "?org=bananas&bucket=test",
+                body = r#"{"start":"2021-04-01T14:00:00Z","stop":"2021-04-02T14:00:00Z", "predicate":"_measurement=its_a_table and location=Boston"}"#.as_bytes(),
+                dml_handler = [Err(DmlError::NamespaceNotFound("bananas_test".to_string()))],
+                want_result = Err(Error::DmlHandler(DmlError::NamespaceNotFound(_))),
+                want_dml_calls = [MockDmlHandlerCall::Delete{namespace, namespace_id, table, predicate}] => {
+                    assert_eq!(table, "its_a_table");
+                    assert_eq!(namespace, "bananas_test");
+                    assert_eq!(*namespace_id, NAMESPACE_ID);
+                    assert!(!predicate.exprs.is_empty());
+                }
+            );
+
+            test_delete_handler!(
+                dml_handler_error,
+                query_string = "?org=bananas&bucket=test",
+                body = r#"{"start":"2021-04-01T14:00:00Z","stop":"2021-04-02T14:00:00Z", "predicate":"_measurement=its_a_table and location=Boston"}"#.as_bytes(),
+                dml_handler = [Err(DmlError::Internal("💣".into()))],
+                want_result = Err(Error::DmlHandler(DmlError::Internal(_))),
+                want_dml_calls = [MockDmlHandlerCall::Delete{namespace, namespace_id, table, predicate}] => {
+                    assert_eq!(table, "its_a_table");
+                    assert_eq!(namespace, "bananas_test");
+                    assert_eq!(*namespace_id, NAMESPACE_ID);
+                    assert!(!predicate.exprs.is_empty());
+                }
+            );
+
+            test_http_handler!(
+                not_found,
+                uri = "https://bananas.example/wat",
+                body = "".as_bytes(),
+                dml_write_handler = [],
+                dml_delete_handler = [],
+                want_result = Err(Error::NoHandler),
+                want_dml_calls = []
+            );
+
+            // https://github.com/influxdata/influxdb_iox/issues/4326
+            mod issue4326 {
+                use super::*;
+
+                test_write_handler!(
+                    duplicate_fields_same_value,
+                    query_string = "?org=bananas&bucket=test",
+                    body = "whydo InputPower=300i,InputPower=300i".as_bytes(),
+                    dml_handler = [Ok(summary())],
+                    want_result = Ok(_),
+                    want_dml_calls = [MockDmlHandlerCall::Write{namespace, write_input, ..}] => {
+                        assert_eq!(namespace, "bananas_test");
+                        let table = write_input.get("whydo").expect("table not in write");
+                        let col = table.column("InputPower").expect("column missing");
+                        assert_matches!(col.data(), ColumnData::I64(data, _) => {
+                            // Ensure the duplicate values are coalesced.
+                            assert_eq!(data.as_slice(), [300]);
+                        });
+                    }
+                );
+
+                test_write_handler!(
+                    duplicate_fields_different_value,
+                    query_string = "?org=bananas&bucket=test",
+                    body = "whydo InputPower=300i,InputPower=42i".as_bytes(),
+                    dml_handler = [Ok(summary())],
+                    want_result = Ok(_),
+                    want_dml_calls = [MockDmlHandlerCall::Write{namespace, write_input, ..}] => {
+                        assert_eq!(namespace, "bananas_test");
+                        let table = write_input.get("whydo").expect("table not in write");
+                        let col = table.column("InputPower").expect("column missing");
+                        assert_matches!(col.data(), ColumnData::I64(data, _) => {
+                            // Last value wins
+                            assert_eq!(data.as_slice(), [42]);
+                        });
+                    }
+                );
+
+                test_write_handler!(
+                    duplicate_fields_different_type,
+                    query_string = "?org=bananas&bucket=test",
+                    body = "whydo InputPower=300i,InputPower=4.2".as_bytes(),
+                    dml_handler = [],
+                    want_result = Err(Error::ParseLineProtocol(mutable_batch_lp::Error::Write {
+                        source: LineWriteError::ConflictedFieldTypes { .. },
+                        ..
+                    })),
+                    want_dml_calls = []
+                );
+
+                test_write_handler!(
+                    duplicate_tags_same_value,
+                    query_string = "?org=bananas&bucket=test",
+                    body = "whydo,InputPower=300i,InputPower=300i field=42i".as_bytes(),
+                    dml_handler = [],
+                    want_result = Err(Error::ParseLineProtocol(mutable_batch_lp::Error::Write {
+                        source: LineWriteError::DuplicateTag { .. },
+                        ..
+                    })),
+                    want_dml_calls = []
+                );
+
+                test_write_handler!(
+                    duplicate_tags_different_value,
+                    query_string = "?org=bananas&bucket=test",
+                    body = "whydo,InputPower=300i,InputPower=42i field=42i".as_bytes(),
+                    dml_handler = [],
+                    want_result = Err(Error::ParseLineProtocol(mutable_batch_lp::Error::Write {
+                        source: LineWriteError::DuplicateTag { .. },
+                        ..
+                    })),
+                    want_dml_calls = []
+                );
+
+                test_write_handler!(
+                    duplicate_tags_different_type,
+                    query_string = "?org=bananas&bucket=test",
+                    body = "whydo,InputPower=300i,InputPower=4.2 field=42i".as_bytes(),
+                    dml_handler = [],
+                    want_result = Err(Error::ParseLineProtocol(mutable_batch_lp::Error::Write {
+                        source: LineWriteError::DuplicateTag { .. },
+                        ..
+                    })),
+                    want_dml_calls = []
+                );
+
+                test_write_handler!(
+                    duplicate_is_tag_and_field,
+                    query_string = "?org=bananas&bucket=test",
+                    body = "whydo,InputPower=300i InputPower=300i".as_bytes(),
+                    dml_handler = [],
+                    want_result = Err(Error::ParseLineProtocol(mutable_batch_lp::Error::Write {
+                        source: LineWriteError::MutableBatch {
+                            source: mutable_batch::writer::Error::TypeMismatch { .. }
+                        },
+                        ..
+                    })),
+                    want_dml_calls = []
+                );
+
+                test_write_handler!(
+                    duplicate_is_tag_and_field_different_types,
+                    query_string = "?org=bananas&bucket=test",
+                    body = "whydo,InputPower=300i InputPower=30.0".as_bytes(),
+                    dml_handler = [],
+                    want_result = Err(Error::ParseLineProtocol(mutable_batch_lp::Error::Write {
+                        source: LineWriteError::MutableBatch {
+                            source: mutable_batch::writer::Error::TypeMismatch { .. }
+                        },
+                        ..
+                    })),
+                    want_dml_calls = []
+                );
+            }
+        }
     }
 
     #[derive(Debug, Error)]

--- a/router/src/server/http.rs
+++ b/router/src/server/http.rs
@@ -847,6 +847,9 @@ mod tests {
             paste::paste! {
                 #[tokio::test]
                 async fn [<test_http_handler_ $name _ $encoding>]() {
+                    let _ = ENV.iter().for_each(|(k,v)| {
+                        std::env::set_var(*k,*v);
+                    });
                     let body = $body;
 
                     // Optionally generate a fragment of code to encode the body
@@ -864,7 +867,7 @@ mod tests {
                     test_http_handler!(encoding_header=$encoding, request);
 
                     let mock_namespace_resolver = MockNamespaceResolver::default()
-                        .with_mapping("bananas_test", NAMESPACE_ID);
+                        .with_mapping(EXPECTED_NAMESPACE, NAMESPACE_ID);
                     let dml_handler = Arc::new(MockDmlHandler::default()
                         .with_write_return($dml_write_handler)
                         .with_delete_return($dml_delete_handler)
@@ -886,7 +889,7 @@ mod tests {
                     // and metrics should be recorded.
                     if let Ok(v) = got {
                         assert_eq!(v.status(), StatusCode::NO_CONTENT);
-                        if $uri.contains("/api/v2/write") {
+                        if $uri.contains("/write") {
                             assert_metric_hit(&metrics, "http_write_lines", None);
                             assert_metric_hit(&metrics, "http_write_fields", None);
                             assert_metric_hit(&metrics, "http_write_tables", None);
@@ -929,10 +932,29 @@ mod tests {
             want_result = $want_result:pat,
             want_dml_calls = $($want_dml_calls:tt )+
         ) => {
+            test_write_handler!(
+                $name,
+                route_string = "/api/v2/write",
+                query_string = $query_string,
+                body = $body,
+                dml_handler = $dml_handler,
+                want_result = $want_result,
+                want_dml_calls = $($want_dml_calls)+
+            );
+        };
+        (
+            $name:ident,
+            route_string = $route_string:expr,   // v1 versus v2 routes
+            query_string = $query_string:expr,   // Request URI query string
+            body = $body:expr,                   // Request body content
+            dml_handler = $dml_handler:expr,     // DML write handler response (if called)
+            want_result = $want_result:pat,
+            want_dml_calls = $($want_dml_calls:tt )+
+        ) => {
             paste::paste! {
                 test_http_handler!(
                     [<write_ $name>],
-                    uri = format!("https://bananas.example/api/v2/write{}", $query_string),
+                    uri = format!("https://bananas.example{}{}", $route_string, $query_string),
                     body = $body,
                     dml_write_handler = $dml_handler,
                     dml_delete_handler = [],
@@ -967,443 +989,605 @@ mod tests {
         };
     }
 
-    // Wrapper over a series of v2 test, such that they can be run in different env.
     macro_rules! run_v2_test_in_env {
         ($test_scope:ident) => {
+            paste::paste! {
+                test_write_handler!(
+                    [<$test_scope _ ok>],
+                    query_string = "?org=bananas&bucket=test",
+                    body = "platanos,tag1=A,tag2=B val=42i 123456".as_bytes(),
+                    dml_handler = [Ok(summary())],
+                    want_result = Ok(_),
+                    want_dml_calls = [MockDmlHandlerCall::Write{namespace, ..}] => {
+                        assert_eq!(namespace, EXPECTED_NAMESPACE);
+                    }
+                );
+
+                test_write_handler!(
+                    [<$test_scope _ ok_precision_s>],
+                    query_string = "?org=bananas&bucket=test&precision=s",
+                    body = "platanos,tag1=A,tag2=B val=42i 1647622847".as_bytes(),
+                    dml_handler = [Ok(summary())],
+                    want_result = Ok(_),
+                    want_dml_calls = [MockDmlHandlerCall::Write{namespace, namespace_id, write_input}] => {
+                        assert_eq!(namespace, EXPECTED_NAMESPACE);
+                        assert_eq!(*namespace_id, NAMESPACE_ID);
+
+                        let table = write_input.get("platanos").expect("table not found");
+                        let ts = table.timestamp_summary().expect("no timestamp summary");
+                        assert_eq!(Some(1647622847000000000), ts.stats.min);
+                    }
+                );
+
+                test_write_handler!(
+                    [<$test_scope _ ok_precision_ms>],
+                    query_string = "?org=bananas&bucket=test&precision=ms",
+                    body = "platanos,tag1=A,tag2=B val=42i 1647622847000".as_bytes(),
+                    dml_handler = [Ok(summary())],
+                    want_result = Ok(_),
+                    want_dml_calls = [MockDmlHandlerCall::Write{namespace, namespace_id, write_input}] => {
+                        assert_eq!(namespace, EXPECTED_NAMESPACE);
+                        assert_eq!(*namespace_id, NAMESPACE_ID);
+
+                        let table = write_input.get("platanos").expect("table not found");
+                        let ts = table.timestamp_summary().expect("no timestamp summary");
+                        assert_eq!(Some(1647622847000000000), ts.stats.min);
+                    }
+                );
+
+                test_write_handler!(
+                    [<$test_scope _ ok_precision_us>],
+                    query_string = "?org=bananas&bucket=test&precision=us",
+                    body = "platanos,tag1=A,tag2=B val=42i 1647622847000000".as_bytes(),
+                    dml_handler = [Ok(summary())],
+                    want_result = Ok(_),
+                    want_dml_calls = [MockDmlHandlerCall::Write{namespace, namespace_id, write_input}] => {
+                        assert_eq!(namespace, EXPECTED_NAMESPACE);
+                        assert_eq!(*namespace_id, NAMESPACE_ID);
+
+                        let table = write_input.get("platanos").expect("table not found");
+                        let ts = table.timestamp_summary().expect("no timestamp summary");
+                        assert_eq!(Some(1647622847000000000), ts.stats.min);
+                    }
+                );
+
+                test_write_handler!(
+                    [<$test_scope _ ok_precision_ns>],
+                    query_string = "?org=bananas&bucket=test&precision=ns",
+                    body = "platanos,tag1=A,tag2=B val=42i 1647622847000000000".as_bytes(),
+                    dml_handler = [Ok(summary())],
+                    want_result = Ok(_),
+                    want_dml_calls = [MockDmlHandlerCall::Write{namespace, namespace_id, write_input}] => {
+                        assert_eq!(namespace, EXPECTED_NAMESPACE);
+                        assert_eq!(*namespace_id, NAMESPACE_ID);
+
+                        let table = write_input.get("platanos").expect("table not found");
+                        let ts = table.timestamp_summary().expect("no timestamp summary");
+                        assert_eq!(Some(1647622847000000000), ts.stats.min);
+                    }
+                );
+
+                test_write_handler!(
+                    [<$test_scope _ precision_overflow>],
+                    // SECONDS, so multiplies the provided timestamp by 1,000,000,000
+                    query_string = "?org=bananas&bucket=test&precision=s",
+                    body = "platanos,tag1=A,tag2=B val=42i 1647622847000000000".as_bytes(),
+                    dml_handler = [Ok(summary())],
+                    want_result = Err(Error::ParseLineProtocol(_)),
+                    want_dml_calls = []
+                );
+
+                test_write_handler!(
+                    [<$test_scope _ no_query_params>],
+                    query_string = "",
+                    body = "platanos,tag1=A,tag2=B val=42i 123456".as_bytes(),
+                    dml_handler = [Ok(summary())],
+                    want_result = Err(Error::InvalidOrgBucket(OrgBucketError::NotSpecified)),
+                    want_dml_calls = [] // None
+                );
+
+                test_write_handler!(
+                    [<$test_scope _ no_org_bucket>],
+                    query_string = "?",
+                    body = "platanos,tag1=A,tag2=B val=42i 123456".as_bytes(),
+                    dml_handler = [Ok(summary())],
+                    want_result = Err(Error::InvalidOrgBucket(OrgBucketError::DecodeFail(_))),
+                    want_dml_calls = [] // None
+                );
+
+                test_write_handler!(
+                    [<$test_scope _ empty_org_bucket>],
+                    query_string = "?org=&bucket=",
+                    body = "platanos,tag1=A,tag2=B val=42i 123456".as_bytes(),
+                    dml_handler = [Ok(summary())],
+                    want_result = Err(Error::InvalidOrgBucket(OrgBucketError::NotSpecified)),
+                    want_dml_calls = [] // None
+                );
+
+                test_write_handler!(
+                    [<$test_scope _ invalid_org_bucket>],
+                    query_string = format!("?org=test&bucket={}", "A".repeat(1000)),
+                    body = "platanos,tag1=A,tag2=B val=42i 123456".as_bytes(),
+                    dml_handler = [Ok(summary())],
+                    want_result = Err(Error::InvalidOrgBucket(OrgBucketError::MappingFail(_))),
+                    want_dml_calls = [] // None
+                );
+
+                test_write_handler!(
+                    [<$test_scope _ invalid_line_protocol>],
+                    query_string = "?org=bananas&bucket=test",
+                    body = "not line protocol".as_bytes(),
+                    dml_handler = [Ok(summary())],
+                    want_result = Err(Error::ParseLineProtocol(_)),
+                    want_dml_calls = [] // None
+                );
+
+                test_write_handler!(
+                    [<$test_scope _ non_utf8_body>],
+                    query_string = "?org=bananas&bucket=test",
+                    body = vec![0xc3, 0x28],
+                    dml_handler = [Ok(summary())],
+                    want_result = Err(Error::NonUtf8Body(_)),
+                    want_dml_calls = [] // None
+                );
+
+                test_write_handler!(
+                    [<$test_scope _ max_request_size_truncation>],
+                    query_string = "?org=bananas&bucket=test",
+                    body = {
+                        // Generate a LP string in the form of:
+                        //
+                        //  bananas,A=AAAAAAAAAA(repeated)... B=42
+                        //                                  ^
+                        //                                  |
+                        //                         MAX_BYTES boundary
+                        //
+                        // So that reading MAX_BYTES number of bytes produces the string:
+                        //
+                        //  bananas,A=AAAAAAAAAA(repeated)...
+                        //
+                        // Effectively trimming off the " B=42" suffix.
+                        let body = "bananas,A=";
+                        iter::once(body)
+                            .chain(iter::repeat("A").take(MAX_BYTES - body.len()))
+                            .chain(iter::once(" B=42\n"))
+                            .flat_map(|s| s.bytes())
+                            .collect::<Vec<u8>>()
+                    },
+                    dml_handler = [Ok(summary())],
+                    want_result = Err(Error::RequestSizeExceeded(_)),
+                    want_dml_calls = [] // None
+                );
+
+                test_write_handler!(
+                    [<$test_scope _ db_not_found>],
+                    query_string = "?org=bananas&bucket=test",
+                    body = "platanos,tag1=A,tag2=B val=42i 123456".as_bytes(),
+                    dml_handler = [Err(DmlError::NamespaceNotFound(EXPECTED_NAMESPACE.to_string()))],
+                    want_result = Err(Error::DmlHandler(DmlError::NamespaceNotFound(_))),
+                    want_dml_calls = [MockDmlHandlerCall::Write{namespace, ..}] => {
+                        assert_eq!(namespace, EXPECTED_NAMESPACE);
+                    }
+                );
+
+                test_write_handler!(
+                    [<$test_scope _ dml_handler_error>],
+                    query_string = "?org=bananas&bucket=test",
+                    body = "platanos,tag1=A,tag2=B val=42i 123456".as_bytes(),
+                    dml_handler = [Err(DmlError::Internal("💣".into()))],
+                    want_result = Err(Error::DmlHandler(DmlError::Internal(_))),
+                    want_dml_calls = [MockDmlHandlerCall::Write{namespace, ..}] => {
+                        assert_eq!(namespace, EXPECTED_NAMESPACE);
+                    }
+                );
+
+                test_write_handler!(
+                    [<$test_scope _ field_upsert_within_batch>],
+                    query_string = "?org=bananas&bucket=test",
+                    body = "test field=1u 100\ntest field=2u 100".as_bytes(),
+                    dml_handler = [Ok(summary())],
+                    want_result = Ok(_),
+                    want_dml_calls = [MockDmlHandlerCall::Write{namespace, namespace_id, write_input}] => {
+                        assert_eq!(namespace, EXPECTED_NAMESPACE);
+                        assert_eq!(*namespace_id, NAMESPACE_ID);
+                        let table = write_input.get("test").expect("table not in write");
+                        let col = table.column("field").expect("column missing");
+                        assert_matches!(col.data(), ColumnData::U64(data, _) => {
+                            // Ensure both values are recorded, in the correct order.
+                            assert_eq!(data.as_slice(), [1, 2]);
+                        });
+                    }
+                );
+
+                test_write_handler!(
+                    [<$test_scope _ column_named_time>],
+                    query_string = "?org=bananas&bucket=test",
+                    body = "test field=1u,time=42u 100".as_bytes(),
+                    dml_handler = [],
+                    want_result = Err(_),
+                    want_dml_calls = []
+                );
+
+                test_delete_handler!(
+                    [<$test_scope _ ok>],
+                    query_string = "?org=bananas&bucket=test",
+                    body = r#"{"start":"2021-04-01T14:00:00Z","stop":"2021-04-02T14:00:00Z", "predicate":"_measurement=its_a_table and location=Boston"}"#.as_bytes(),
+                    dml_handler = [Ok(())],
+                    want_result = Ok(_),
+                    want_dml_calls = [MockDmlHandlerCall::Delete{namespace, namespace_id, table, predicate}] => {
+                        assert_eq!(table, "its_a_table");
+                        assert_eq!(namespace, EXPECTED_NAMESPACE);
+                        assert_eq!(*namespace_id, NAMESPACE_ID);
+                        assert!(!predicate.exprs.is_empty());
+                    }
+                );
+
+                test_delete_handler!(
+                    [<$test_scope _ invalid_delete_body>],
+                    query_string = "?org=bananas&bucket=test",
+                    body = r#"{wat}"#.as_bytes(),
+                    dml_handler = [],
+                    want_result = Err(Error::ParseHttpDelete(_)),
+                    want_dml_calls = []
+                );
+
+                test_delete_handler!(
+                    [<$test_scope _ no_query_params>],
+                    query_string = "",
+                    body = "".as_bytes(),
+                    dml_handler = [Ok(())],
+                    want_result = Err(Error::InvalidOrgBucket(OrgBucketError::NotSpecified)),
+                    want_dml_calls = [] // None
+                );
+
+                test_delete_handler!(
+                    [<$test_scope _ no_org_bucket>],
+                    query_string = "?",
+                    body = "".as_bytes(),
+                    dml_handler = [Ok(())],
+                    want_result = Err(Error::InvalidOrgBucket(OrgBucketError::DecodeFail(_))),
+                    want_dml_calls = [] // None
+                );
+
+                test_delete_handler!(
+                    [<$test_scope _ empty_org_bucket>],
+                    query_string = "?org=&bucket=",
+                    body = "".as_bytes(),
+                    dml_handler = [Ok(())],
+                    want_result = Err(Error::InvalidOrgBucket(OrgBucketError::NotSpecified)),
+                    want_dml_calls = [] // None
+                );
+
+                test_delete_handler!(
+                    [<$test_scope _ invalid_org_bucket>],
+                    query_string = format!("?org=test&bucket={}", "A".repeat(1000)),
+                    body = "".as_bytes(),
+                    dml_handler = [Ok(())],
+                    want_result = Err(Error::InvalidOrgBucket(OrgBucketError::MappingFail(_))),
+                    want_dml_calls = [] // None
+                );
+
+                test_delete_handler!(
+                    [<$test_scope _ non_utf8_body>],
+                    query_string = "?org=bananas&bucket=test",
+                    body = vec![0xc3, 0x28],
+                    dml_handler = [Ok(())],
+                    want_result = Err(Error::NonUtf8Body(_)),
+                    want_dml_calls = [] // None
+                );
+
+                test_delete_handler!(
+                    [<$test_scope _ db_not_found>],
+                    query_string = "?org=bananas&bucket=test",
+                    body = r#"{"start":"2021-04-01T14:00:00Z","stop":"2021-04-02T14:00:00Z", "predicate":"_measurement=its_a_table and location=Boston"}"#.as_bytes(),
+                    dml_handler = [Err(DmlError::NamespaceNotFound(EXPECTED_NAMESPACE.to_string()))],
+                    want_result = Err(Error::DmlHandler(DmlError::NamespaceNotFound(_))),
+                    want_dml_calls = [MockDmlHandlerCall::Delete{namespace, namespace_id, table, predicate}] => {
+                        assert_eq!(table, "its_a_table");
+                        assert_eq!(namespace, EXPECTED_NAMESPACE);
+                        assert_eq!(*namespace_id, NAMESPACE_ID);
+                        assert!(!predicate.exprs.is_empty());
+                    }
+                );
+
+                test_delete_handler!(
+                    [<$test_scope _ dml_handler_error>],
+                    query_string = "?org=bananas&bucket=test",
+                    body = r#"{"start":"2021-04-01T14:00:00Z","stop":"2021-04-02T14:00:00Z", "predicate":"_measurement=its_a_table and location=Boston"}"#.as_bytes(),
+                    dml_handler = [Err(DmlError::Internal("💣".into()))],
+                    want_result = Err(Error::DmlHandler(DmlError::Internal(_))),
+                    want_dml_calls = [MockDmlHandlerCall::Delete{namespace, namespace_id, table, predicate}] => {
+                        assert_eq!(table, "its_a_table");
+                        assert_eq!(namespace, EXPECTED_NAMESPACE);
+                        assert_eq!(*namespace_id, NAMESPACE_ID);
+                        assert!(!predicate.exprs.is_empty());
+                    }
+                );
+
+                test_http_handler!(
+                    [<$test_scope _ not_found>],
+                    uri = "https://bananas.example/wat",
+                    body = "".as_bytes(),
+                    dml_write_handler = [],
+                    dml_delete_handler = [],
+                    want_result = Err(Error::NoHandler),
+                    want_dml_calls = []
+                );
+
+                // https://github.com/influxdata/influxdb_iox/issues/4326
+                mod [<issue4326 _ $test_scope>] {
+                    use super::*;
+
+                    test_write_handler!(
+                        [<$test_scope _ duplicate_fields_same_value>],
+                        query_string = "?org=bananas&bucket=test",
+                        body = "whydo InputPower=300i,InputPower=300i".as_bytes(),
+                        dml_handler = [Ok(summary())],
+                        want_result = Ok(_),
+                        want_dml_calls = [MockDmlHandlerCall::Write{namespace, write_input, ..}] => {
+                            assert_eq!(namespace, EXPECTED_NAMESPACE);
+                            let table = write_input.get("whydo").expect("table not in write");
+                            let col = table.column("InputPower").expect("column missing");
+                            assert_matches!(col.data(), ColumnData::I64(data, _) => {
+                                // Ensure the duplicate values are coalesced.
+                                assert_eq!(data.as_slice(), [300]);
+                            });
+                        }
+                    );
+
+                    test_write_handler!(
+                        [<$test_scope _ duplicate_fields_different_value>],
+                        query_string = "?org=bananas&bucket=test",
+                        body = "whydo InputPower=300i,InputPower=42i".as_bytes(),
+                        dml_handler = [Ok(summary())],
+                        want_result = Ok(_),
+                        want_dml_calls = [MockDmlHandlerCall::Write{namespace, write_input, ..}] => {
+                            assert_eq!(namespace, EXPECTED_NAMESPACE);
+                            let table = write_input.get("whydo").expect("table not in write");
+                            let col = table.column("InputPower").expect("column missing");
+                            assert_matches!(col.data(), ColumnData::I64(data, _) => {
+                                // Last value wins
+                                assert_eq!(data.as_slice(), [42]);
+                            });
+                        }
+                    );
+
+                    test_write_handler!(
+                        [<$test_scope _ duplicate_fields_different_type>],
+                        query_string = "?org=bananas&bucket=test",
+                        body = "whydo InputPower=300i,InputPower=4.2".as_bytes(),
+                        dml_handler = [],
+                        want_result = Err(Error::ParseLineProtocol(mutable_batch_lp::Error::Write {
+                            source: LineWriteError::ConflictedFieldTypes { .. },
+                            ..
+                        })),
+                        want_dml_calls = []
+                    );
+
+                    test_write_handler!(
+                        [<$test_scope _ duplicate_tags_same_value>],
+                        query_string = "?org=bananas&bucket=test",
+                        body = "whydo,InputPower=300i,InputPower=300i field=42i".as_bytes(),
+                        dml_handler = [],
+                        want_result = Err(Error::ParseLineProtocol(mutable_batch_lp::Error::Write {
+                            source: LineWriteError::DuplicateTag { .. },
+                            ..
+                        })),
+                        want_dml_calls = []
+                    );
+
+                    test_write_handler!(
+                        [<$test_scope _ duplicate_tags_different_value>],
+                        query_string = "?org=bananas&bucket=test",
+                        body = "whydo,InputPower=300i,InputPower=42i field=42i".as_bytes(),
+                        dml_handler = [],
+                        want_result = Err(Error::ParseLineProtocol(mutable_batch_lp::Error::Write {
+                            source: LineWriteError::DuplicateTag { .. },
+                            ..
+                        })),
+                        want_dml_calls = []
+                    );
+
+                    test_write_handler!(
+                        [<$test_scope _ duplicate_tags_different_type>],
+                        query_string = "?org=bananas&bucket=test",
+                        body = "whydo,InputPower=300i,InputPower=4.2 field=42i".as_bytes(),
+                        dml_handler = [],
+                        want_result = Err(Error::ParseLineProtocol(mutable_batch_lp::Error::Write {
+                            source: LineWriteError::DuplicateTag { .. },
+                            ..
+                        })),
+                        want_dml_calls = []
+                    );
+
+                    test_write_handler!(
+                        [<$test_scope _ duplicate_is_tag_and_field>],
+                        query_string = "?org=bananas&bucket=test",
+                        body = "whydo,InputPower=300i InputPower=300i".as_bytes(),
+                        dml_handler = [],
+                        want_result = Err(Error::ParseLineProtocol(mutable_batch_lp::Error::Write {
+                            source: LineWriteError::MutableBatch {
+                                source: mutable_batch::writer::Error::TypeMismatch { .. }
+                            },
+                            ..
+                        })),
+                        want_dml_calls = []
+                    );
+
+                    test_write_handler!(
+                        [<$test_scope _ duplicate_is_tag_and_field_different_types>],
+                        query_string = "?org=bananas&bucket=test",
+                        body = "whydo,InputPower=300i InputPower=30.0".as_bytes(),
+                        dml_handler = [],
+                        want_result = Err(Error::ParseLineProtocol(mutable_batch_lp::Error::Write {
+                            source: LineWriteError::MutableBatch {
+                                source: mutable_batch::writer::Error::TypeMismatch { .. }
+                            },
+                            ..
+                        })),
+                        want_dml_calls = []
+                    );
+                }
+            }
+        };
+    }
+
+    mod mt {
+        use super::*;
+        static ENV: &[(&str, &str)] = &[("INFLUXDB_IOX_TENANCY", "MT")];
+        static EXPECTED_NAMESPACE: &str = "bananas_test";
+        run_v2_test_in_env!(mt);
+
+        test_write_handler!(
+            mt_v1_no_handler,
+            route_string = "/write",
+            query_string = "?db=database",
+            body = "platanos,tag1=A,tag2=B val=42i 123456".as_bytes(),
+            dml_handler = [],
+            want_result = Err(Error::NoHandler),
+            want_dml_calls = []
+        );
+    }
+
+    mod cst {
+        use super::*;
+        static ENV: &[(&str, &str)] = &[("INFLUXDB_IOX_TENANCY", "CST")];
+        static EXPECTED_NAMESPACE: &str = "test";
+        run_v2_test_in_env!(cst);
+
+        mod v1 {
+            use super::*;
+            static EXPECTED_NAMESPACE: &str = "database";
+
             test_write_handler!(
-                ok,
-                query_string = "?org=bananas&bucket=test",
+                cst_v1_ok,
+                route_string = "/write",
+                query_string = "?db=database",
                 body = "platanos,tag1=A,tag2=B val=42i 123456".as_bytes(),
                 dml_handler = [Ok(summary())],
                 want_result = Ok(_),
                 want_dml_calls = [MockDmlHandlerCall::Write{namespace, ..}] => {
-                    assert_eq!(namespace, "bananas_test");
+                    assert_eq!(namespace, EXPECTED_NAMESPACE);
                 }
             );
 
             test_write_handler!(
-                ok_precision_s,
-                query_string = "?org=bananas&bucket=test&precision=s",
-                body = "platanos,tag1=A,tag2=B val=42i 1647622847".as_bytes(),
-                dml_handler = [Ok(summary())],
-                want_result = Ok(_),
-                want_dml_calls = [MockDmlHandlerCall::Write{namespace, namespace_id, write_input}] => {
-                    assert_eq!(namespace, "bananas_test");
-                    assert_eq!(*namespace_id, NAMESPACE_ID);
-
-                    let table = write_input.get("platanos").expect("table not found");
-                    let ts = table.timestamp_summary().expect("no timestamp summary");
-                    assert_eq!(Some(1647622847000000000), ts.stats.min);
-                }
-            );
-
-            test_write_handler!(
-                ok_precision_ms,
-                query_string = "?org=bananas&bucket=test&precision=ms",
-                body = "platanos,tag1=A,tag2=B val=42i 1647622847000".as_bytes(),
-                dml_handler = [Ok(summary())],
-                want_result = Ok(_),
-                want_dml_calls = [MockDmlHandlerCall::Write{namespace, namespace_id, write_input}] => {
-                    assert_eq!(namespace, "bananas_test");
-                    assert_eq!(*namespace_id, NAMESPACE_ID);
-
-                    let table = write_input.get("platanos").expect("table not found");
-                    let ts = table.timestamp_summary().expect("no timestamp summary");
-                    assert_eq!(Some(1647622847000000000), ts.stats.min);
-                }
-            );
-
-            test_write_handler!(
-                ok_precision_us,
-                query_string = "?org=bananas&bucket=test&precision=us",
-                body = "platanos,tag1=A,tag2=B val=42i 1647622847000000".as_bytes(),
-                dml_handler = [Ok(summary())],
-                want_result = Ok(_),
-                want_dml_calls = [MockDmlHandlerCall::Write{namespace, namespace_id, write_input}] => {
-                    assert_eq!(namespace, "bananas_test");
-                    assert_eq!(*namespace_id, NAMESPACE_ID);
-
-                    let table = write_input.get("platanos").expect("table not found");
-                    let ts = table.timestamp_summary().expect("no timestamp summary");
-                    assert_eq!(Some(1647622847000000000), ts.stats.min);
-                }
-            );
-
-            test_write_handler!(
-                ok_precision_ns,
-                query_string = "?org=bananas&bucket=test&precision=ns",
-                body = "platanos,tag1=A,tag2=B val=42i 1647622847000000000".as_bytes(),
-                dml_handler = [Ok(summary())],
-                want_result = Ok(_),
-                want_dml_calls = [MockDmlHandlerCall::Write{namespace, namespace_id, write_input}] => {
-                    assert_eq!(namespace, "bananas_test");
-                    assert_eq!(*namespace_id, NAMESPACE_ID);
-
-                    let table = write_input.get("platanos").expect("table not found");
-                    let ts = table.timestamp_summary().expect("no timestamp summary");
-                    assert_eq!(Some(1647622847000000000), ts.stats.min);
-                }
-            );
-
-            test_write_handler!(
-                precision_overflow,
-                // SECONDS, so multiplies the provided timestamp by 1,000,000,000
-                query_string = "?org=bananas&bucket=test&precision=s",
-                body = "platanos,tag1=A,tag2=B val=42i 1647622847000000000".as_bytes(),
-                dml_handler = [Ok(summary())],
-                want_result = Err(Error::ParseLineProtocol(_)),
-                want_dml_calls = []
-            );
-
-            test_write_handler!(
-                no_query_params,
+                cst_v1_no_query_params,
+                route_string = "/write",
                 query_string = "",
                 body = "platanos,tag1=A,tag2=B val=42i 123456".as_bytes(),
                 dml_handler = [Ok(summary())],
-                want_result = Err(Error::InvalidOrgBucket(OrgBucketError::NotSpecified)),
+                want_result = Err(Error::InvalidDatabaseRp(DatabaseRpError::NotSpecified)),
                 want_dml_calls = [] // None
             );
 
             test_write_handler!(
-                no_org_bucket,
+                cst_v1_no_db,
+                route_string = "/write",
                 query_string = "?",
                 body = "platanos,tag1=A,tag2=B val=42i 123456".as_bytes(),
                 dml_handler = [Ok(summary())],
-                want_result = Err(Error::InvalidOrgBucket(OrgBucketError::DecodeFail(_))),
+                want_result = Err(Error::InvalidDatabaseRp(DatabaseRpError::DecodeFail(_))),
                 want_dml_calls = [] // None
             );
 
             test_write_handler!(
-                empty_org_bucket,
-                query_string = "?org=&bucket=",
+                cst_v1_empty_db,
+                route_string = "/write",
+                query_string = "?db=",
                 body = "platanos,tag1=A,tag2=B val=42i 123456".as_bytes(),
                 dml_handler = [Ok(summary())],
-                want_result = Err(Error::InvalidOrgBucket(OrgBucketError::NotSpecified)),
+                want_result = Err(Error::InvalidDatabaseRp(DatabaseRpError::NotSpecified)),
                 want_dml_calls = [] // None
             );
 
             test_write_handler!(
-                invalid_org_bucket,
-                query_string = format!("?org=test&bucket={}", "A".repeat(1000)),
+                cst_v1_invalid_db,
+                route_string = "/write",
+                query_string = format!("?db={}", "A".repeat(1000)),
                 body = "platanos,tag1=A,tag2=B val=42i 123456".as_bytes(),
                 dml_handler = [Ok(summary())],
-                want_result = Err(Error::InvalidOrgBucket(OrgBucketError::MappingFail(_))),
+                want_result = Err(Error::InvalidDatabaseRp(DatabaseRpError::MappingFail(_))),
                 want_dml_calls = [] // None
             );
 
             test_write_handler!(
-                invalid_line_protocol,
-                query_string = "?org=bananas&bucket=test",
-                body = "not line protocol".as_bytes(),
-                dml_handler = [Ok(summary())],
-                want_result = Err(Error::ParseLineProtocol(_)),
-                want_dml_calls = [] // None
-            );
-
-            test_write_handler!(
-                non_utf8_body,
-                query_string = "?org=bananas&bucket=test",
-                body = vec![0xc3, 0x28],
-                dml_handler = [Ok(summary())],
-                want_result = Err(Error::NonUtf8Body(_)),
-                want_dml_calls = [] // None
-            );
-
-            test_write_handler!(
-                max_request_size_truncation,
-                query_string = "?org=bananas&bucket=test",
-                body = {
-                    // Generate a LP string in the form of:
-                    //
-                    //  bananas,A=AAAAAAAAAA(repeated)... B=42
-                    //                                  ^
-                    //                                  |
-                    //                         MAX_BYTES boundary
-                    //
-                    // So that reading MAX_BYTES number of bytes produces the string:
-                    //
-                    //  bananas,A=AAAAAAAAAA(repeated)...
-                    //
-                    // Effectively trimming off the " B=42" suffix.
-                    let body = "bananas,A=";
-                    iter::once(body)
-                        .chain(iter::repeat("A").take(MAX_BYTES - body.len()))
-                        .chain(iter::once(" B=42\n"))
-                        .flat_map(|s| s.bytes())
-                        .collect::<Vec<u8>>()
-                },
-                dml_handler = [Ok(summary())],
-                want_result = Err(Error::RequestSizeExceeded(_)),
-                want_dml_calls = [] // None
-            );
-
-            test_write_handler!(
-                db_not_found,
-                query_string = "?org=bananas&bucket=test",
+                cst_v1_ok_with_consistency,
+                route_string = "/write",
+                query_string = "?db=database&consistency=any",
                 body = "platanos,tag1=A,tag2=B val=42i 123456".as_bytes(),
-                dml_handler = [Err(DmlError::NamespaceNotFound("bananas_test".to_string()))],
-                want_result = Err(Error::DmlHandler(DmlError::NamespaceNotFound(_))),
-                want_dml_calls = [MockDmlHandlerCall::Write{namespace, ..}] => {
-                    assert_eq!(namespace, "bananas_test");
-                }
-            );
-
-            test_write_handler!(
-                dml_handler_error,
-                query_string = "?org=bananas&bucket=test",
-                body = "platanos,tag1=A,tag2=B val=42i 123456".as_bytes(),
-                dml_handler = [Err(DmlError::Internal("💣".into()))],
-                want_result = Err(Error::DmlHandler(DmlError::Internal(_))),
-                want_dml_calls = [MockDmlHandlerCall::Write{namespace, ..}] => {
-                    assert_eq!(namespace, "bananas_test");
-                }
-            );
-
-            test_write_handler!(
-                field_upsert_within_batch,
-                query_string = "?org=bananas&bucket=test",
-                body = "test field=1u 100\ntest field=2u 100".as_bytes(),
                 dml_handler = [Ok(summary())],
                 want_result = Ok(_),
-                want_dml_calls = [MockDmlHandlerCall::Write{namespace, namespace_id, write_input}] => {
-                    assert_eq!(namespace, "bananas_test");
-                    assert_eq!(*namespace_id, NAMESPACE_ID);
-                    let table = write_input.get("test").expect("table not in write");
-                    let col = table.column("field").expect("column missing");
-                    assert_matches!(col.data(), ColumnData::U64(data, _) => {
-                        // Ensure both values are recorded, in the correct order.
-                        assert_eq!(data.as_slice(), [1, 2]);
-                    });
+                want_dml_calls = [MockDmlHandlerCall::Write{namespace, ..}] => {
+                    assert_eq!(namespace, EXPECTED_NAMESPACE);
                 }
             );
 
             test_write_handler!(
-                column_named_time,
-                query_string = "?org=bananas&bucket=test",
-                body = "test field=1u,time=42u 100".as_bytes(),
-                dml_handler = [],
-                want_result = Err(_),
-                want_dml_calls = []
-            );
-
-            test_delete_handler!(
-                ok,
-                query_string = "?org=bananas&bucket=test",
-                body = r#"{"start":"2021-04-01T14:00:00Z","stop":"2021-04-02T14:00:00Z", "predicate":"_measurement=its_a_table and location=Boston"}"#.as_bytes(),
-                dml_handler = [Ok(())],
-                want_result = Ok(_),
-                want_dml_calls = [MockDmlHandlerCall::Delete{namespace, namespace_id, table, predicate}] => {
-                    assert_eq!(table, "its_a_table");
-                    assert_eq!(namespace, "bananas_test");
-                    assert_eq!(*namespace_id, NAMESPACE_ID);
-                    assert!(!predicate.exprs.is_empty());
-                }
-            );
-
-            test_delete_handler!(
-                invalid_delete_body,
-                query_string = "?org=bananas&bucket=test",
-                body = r#"{wat}"#.as_bytes(),
-                dml_handler = [],
-                want_result = Err(Error::ParseHttpDelete(_)),
-                want_dml_calls = []
-            );
-
-            test_delete_handler!(
-                no_query_params,
-                query_string = "",
-                body = "".as_bytes(),
-                dml_handler = [Ok(())],
-                want_result = Err(Error::InvalidOrgBucket(OrgBucketError::NotSpecified)),
+                cst_v1_invalid_consistency,
+                route_string = "/write",
+                query_string = "?db=database&consistency=wrong",
+                body = "platanos,tag1=A,tag2=B val=42i 123456".as_bytes(),
+                dml_handler = [Ok(summary())],
+                want_result = Err(Error::InvalidDatabaseRp(DatabaseRpError::DecodeFail(_))),
                 want_dml_calls = [] // None
             );
 
-            test_delete_handler!(
-                no_org_bucket,
-                query_string = "?",
-                body = "".as_bytes(),
-                dml_handler = [Ok(())],
-                want_result = Err(Error::InvalidOrgBucket(OrgBucketError::DecodeFail(_))),
-                want_dml_calls = [] // None
-            );
-
-            test_delete_handler!(
-                empty_org_bucket,
-                query_string = "?org=&bucket=",
-                body = "".as_bytes(),
-                dml_handler = [Ok(())],
-                want_result = Err(Error::InvalidOrgBucket(OrgBucketError::NotSpecified)),
-                want_dml_calls = [] // None
-            );
-
-            test_delete_handler!(
-                invalid_org_bucket,
-                query_string = format!("?org=test&bucket={}", "A".repeat(1000)),
-                body = "".as_bytes(),
-                dml_handler = [Ok(())],
-                want_result = Err(Error::InvalidOrgBucket(OrgBucketError::MappingFail(_))),
-                want_dml_calls = [] // None
-            );
-
-            test_delete_handler!(
-                non_utf8_body,
-                query_string = "?org=bananas&bucket=test",
-                body = vec![0xc3, 0x28],
-                dml_handler = [Ok(())],
-                want_result = Err(Error::NonUtf8Body(_)),
-                want_dml_calls = [] // None
-            );
-
-            test_delete_handler!(
-                db_not_found,
-                query_string = "?org=bananas&bucket=test",
-                body = r#"{"start":"2021-04-01T14:00:00Z","stop":"2021-04-02T14:00:00Z", "predicate":"_measurement=its_a_table and location=Boston"}"#.as_bytes(),
-                dml_handler = [Err(DmlError::NamespaceNotFound("bananas_test".to_string()))],
-                want_result = Err(Error::DmlHandler(DmlError::NamespaceNotFound(_))),
-                want_dml_calls = [MockDmlHandlerCall::Delete{namespace, namespace_id, table, predicate}] => {
-                    assert_eq!(table, "its_a_table");
-                    assert_eq!(namespace, "bananas_test");
-                    assert_eq!(*namespace_id, NAMESPACE_ID);
-                    assert!(!predicate.exprs.is_empty());
-                }
-            );
-
-            test_delete_handler!(
-                dml_handler_error,
-                query_string = "?org=bananas&bucket=test",
-                body = r#"{"start":"2021-04-01T14:00:00Z","stop":"2021-04-02T14:00:00Z", "predicate":"_measurement=its_a_table and location=Boston"}"#.as_bytes(),
-                dml_handler = [Err(DmlError::Internal("💣".into()))],
-                want_result = Err(Error::DmlHandler(DmlError::Internal(_))),
-                want_dml_calls = [MockDmlHandlerCall::Delete{namespace, namespace_id, table, predicate}] => {
-                    assert_eq!(table, "its_a_table");
-                    assert_eq!(namespace, "bananas_test");
-                    assert_eq!(*namespace_id, NAMESPACE_ID);
-                    assert!(!predicate.exprs.is_empty());
-                }
-            );
-
-            test_http_handler!(
-                not_found,
-                uri = "https://bananas.example/wat",
-                body = "".as_bytes(),
-                dml_write_handler = [],
-                dml_delete_handler = [],
-                want_result = Err(Error::NoHandler),
-                want_dml_calls = []
-            );
-
-            // https://github.com/influxdata/influxdb_iox/issues/4326
-            mod issue4326 {
+            mod with_rp {
                 use super::*;
+                static EXPECTED_NAMESPACE: &str = "database/myrp";
 
                 test_write_handler!(
-                    duplicate_fields_same_value,
-                    query_string = "?org=bananas&bucket=test",
-                    body = "whydo InputPower=300i,InputPower=300i".as_bytes(),
+                    cst_v1_rp_ok,
+                    route_string = "/write",
+                    query_string = "?db=database&rp=myrp",
+                    body = "platanos,tag1=A,tag2=B val=42i 123456".as_bytes(),
                     dml_handler = [Ok(summary())],
                     want_result = Ok(_),
-                    want_dml_calls = [MockDmlHandlerCall::Write{namespace, write_input, ..}] => {
-                        assert_eq!(namespace, "bananas_test");
-                        let table = write_input.get("whydo").expect("table not in write");
-                        let col = table.column("InputPower").expect("column missing");
-                        assert_matches!(col.data(), ColumnData::I64(data, _) => {
-                            // Ensure the duplicate values are coalesced.
-                            assert_eq!(data.as_slice(), [300]);
-                        });
+                    want_dml_calls = [MockDmlHandlerCall::Write{namespace, ..}] => {
+                        assert_eq!(namespace, EXPECTED_NAMESPACE);
+                    }
+                );
+            }
+
+            mod with_rp_ignored {
+                use super::*;
+                static EXPECTED_NAMESPACE: &str = "database";
+
+                test_write_handler!(
+                    cst_v1_rp_empty,
+                    route_string = "/write",
+                    query_string = "?db=database&rp=",
+                    body = "platanos,tag1=A,tag2=B val=42i 123456".as_bytes(),
+                    dml_handler = [Ok(summary())],
+                    want_result = Ok(_),
+                    want_dml_calls = [MockDmlHandlerCall::Write{namespace, ..}] => {
+                        assert_eq!(namespace, EXPECTED_NAMESPACE);
                     }
                 );
 
                 test_write_handler!(
-                    duplicate_fields_different_value,
-                    query_string = "?org=bananas&bucket=test",
-                    body = "whydo InputPower=300i,InputPower=42i".as_bytes(),
+                    cst_v1_rp_empty_str,
+                    route_string = "/write",
+                    query_string = "?db=database&rp=''",
+                    body = "platanos,tag1=A,tag2=B val=42i 123456".as_bytes(),
                     dml_handler = [Ok(summary())],
                     want_result = Ok(_),
-                    want_dml_calls = [MockDmlHandlerCall::Write{namespace, write_input, ..}] => {
-                        assert_eq!(namespace, "bananas_test");
-                        let table = write_input.get("whydo").expect("table not in write");
-                        let col = table.column("InputPower").expect("column missing");
-                        assert_matches!(col.data(), ColumnData::I64(data, _) => {
-                            // Last value wins
-                            assert_eq!(data.as_slice(), [42]);
-                        });
+                    want_dml_calls = [MockDmlHandlerCall::Write{namespace, ..}] => {
+                        assert_eq!(namespace, EXPECTED_NAMESPACE);
                     }
                 );
 
                 test_write_handler!(
-                    duplicate_fields_different_type,
-                    query_string = "?org=bananas&bucket=test",
-                    body = "whydo InputPower=300i,InputPower=4.2".as_bytes(),
-                    dml_handler = [],
-                    want_result = Err(Error::ParseLineProtocol(mutable_batch_lp::Error::Write {
-                        source: LineWriteError::ConflictedFieldTypes { .. },
-                        ..
-                    })),
-                    want_dml_calls = []
-                );
-
-                test_write_handler!(
-                    duplicate_tags_same_value,
-                    query_string = "?org=bananas&bucket=test",
-                    body = "whydo,InputPower=300i,InputPower=300i field=42i".as_bytes(),
-                    dml_handler = [],
-                    want_result = Err(Error::ParseLineProtocol(mutable_batch_lp::Error::Write {
-                        source: LineWriteError::DuplicateTag { .. },
-                        ..
-                    })),
-                    want_dml_calls = []
-                );
-
-                test_write_handler!(
-                    duplicate_tags_different_value,
-                    query_string = "?org=bananas&bucket=test",
-                    body = "whydo,InputPower=300i,InputPower=42i field=42i".as_bytes(),
-                    dml_handler = [],
-                    want_result = Err(Error::ParseLineProtocol(mutable_batch_lp::Error::Write {
-                        source: LineWriteError::DuplicateTag { .. },
-                        ..
-                    })),
-                    want_dml_calls = []
-                );
-
-                test_write_handler!(
-                    duplicate_tags_different_type,
-                    query_string = "?org=bananas&bucket=test",
-                    body = "whydo,InputPower=300i,InputPower=4.2 field=42i".as_bytes(),
-                    dml_handler = [],
-                    want_result = Err(Error::ParseLineProtocol(mutable_batch_lp::Error::Write {
-                        source: LineWriteError::DuplicateTag { .. },
-                        ..
-                    })),
-                    want_dml_calls = []
-                );
-
-                test_write_handler!(
-                    duplicate_is_tag_and_field,
-                    query_string = "?org=bananas&bucket=test",
-                    body = "whydo,InputPower=300i InputPower=300i".as_bytes(),
-                    dml_handler = [],
-                    want_result = Err(Error::ParseLineProtocol(mutable_batch_lp::Error::Write {
-                        source: LineWriteError::MutableBatch {
-                            source: mutable_batch::writer::Error::TypeMismatch { .. }
-                        },
-                        ..
-                    })),
-                    want_dml_calls = []
-                );
-
-                test_write_handler!(
-                    duplicate_is_tag_and_field_different_types,
-                    query_string = "?org=bananas&bucket=test",
-                    body = "whydo,InputPower=300i InputPower=30.0".as_bytes(),
-                    dml_handler = [],
-                    want_result = Err(Error::ParseLineProtocol(mutable_batch_lp::Error::Write {
-                        source: LineWriteError::MutableBatch {
-                            source: mutable_batch::writer::Error::TypeMismatch { .. }
-                        },
-                        ..
-                    })),
-                    want_dml_calls = []
+                    cst_v1_rp_ignore_autogen,
+                    route_string = "/write",
+                    query_string = "?db=database&rp=autogen",
+                    body = "platanos,tag1=A,tag2=B val=42i 123456".as_bytes(),
+                    dml_handler = [Ok(summary())],
+                    want_result = Ok(_),
+                    want_dml_calls = [MockDmlHandlerCall::Write{namespace, ..}] => {
+                        assert_eq!(namespace, EXPECTED_NAMESPACE);
+                    }
                 );
             }
         }
@@ -1693,15 +1877,25 @@ mod tests {
         ),
 
         (
-            InvalidOrgBucket(OrgBucketError::MappingFail(OrgBucketMappingError::NotSpecified)),
+            InvalidOrgBucket(OrgBucketError::MappingFail(NamespaceMappingError::NotSpecified)),
             "missing org/bucket value",
         ),
 
         (
             InvalidOrgBucket({
                 let e = NamespaceNameError::LengthConstraint { name: "[too long name]".into() };
-                let e = OrgBucketMappingError::InvalidNamespaceName { source: e };
+                let e = NamespaceMappingError::InvalidNamespaceName { source: e };
                 OrgBucketError::MappingFail(e)
+            }),
+            "Invalid namespace name: \
+             Namespace name [too long name] length must be between 1 and 64 characters",
+        ),
+
+        (
+            InvalidDatabaseRp({
+                let e = NamespaceNameError::LengthConstraint { name: "[too long name]".into() };
+                let e = NamespaceMappingError::InvalidNamespaceName { source: e };
+                DatabaseRpError::MappingFail(e)
             }),
             "Invalid namespace name: \
              Namespace name [too long name] length must be between 1 and 64 characters",

--- a/router/src/server/http.rs
+++ b/router/src/server/http.rs
@@ -224,7 +224,7 @@ pub struct HttpDelegate<D, N, T = SystemProvider> {
     namespace_resolver: N,
     dml_handler: D,
     authz: Option<Arc<dyn Authorizer>>,
-    dml_info_extractor: &'static dyn WriteInfoExtractor,
+    dml_info_extractor: Box<dyn WriteInfoExtractor>,
 
     // A request limiter to restrict the number of simultaneous requests this
     // router services.
@@ -257,7 +257,7 @@ impl<D, N> HttpDelegate<D, N, SystemProvider> {
         dml_handler: D,
         authz: Option<Arc<dyn Authorizer>>,
         metrics: &metric::Registry,
-        dml_info_extractor: &'static dyn WriteInfoExtractor,
+        dml_info_extractor: Box<dyn WriteInfoExtractor>,
     ) -> Self {
         let write_metric_lines = metrics
             .register_metric::<U64Counter>(
@@ -622,7 +622,7 @@ mod tests {
 
         let dml_handler = Arc::new(MockDmlHandler::default());
         let metrics = Arc::new(metric::Registry::default());
-        let dml_info_extractor = &MultiTenantRequestParser;
+        let dml_info_extractor = Box::<MultiTenantRequestParser>::default();
         let delegate = Arc::new(HttpDelegate::new(
             MAX_BYTES,
             1,
@@ -771,7 +771,7 @@ mod tests {
         );
         let metrics = Arc::new(metric::Registry::default());
         let authz = Arc::new(MockAuthorizer {});
-        let dml_info_extractor = &MultiTenantRequestParser;
+        let dml_info_extractor = Box::<MultiTenantRequestParser>::default();
         let delegate = HttpDelegate::new(
             MAX_BYTES,
             1,

--- a/router/src/server/http/cst.rs
+++ b/router/src/server/http/cst.rs
@@ -1,11 +1,5 @@
 //! SingleTenantRequestParser
-///  This is a [`WriteInfoExtractor`] implementation that populates [`WriteInfo`]
-/// structs from [`Request`] that conform to the [V1 Write API] or [V2 Write API]
-/// when this router is configured in single-tenancy mode.
-///
-/// [V1 Write API]: https://docs.influxdata.com/influxdb/v1.8/tools/api/#write-http-endpoint
-/// [V2 Write API]: https://docs.influxdata.com/influxdb/v2.6/api/#operation/PostWrite
-/// [CST-specific namespace name construction]: docs TBD
+
 use hyper::{Body, Request};
 
 use super::{
@@ -15,29 +9,40 @@ use super::{
     WriteInfoExtractor,
 };
 use crate::server::http::Error::{self, InvalidOrgBucket};
-use data_types::{rp_and_database_to_namespace, NamespaceName};
+use data_types::NamespaceName;
 
 #[allow(missing_docs)]
 #[derive(Debug, Default)]
 pub struct SingleTenantRequestParser;
 
+///  This is a [`WriteInfoExtractor`] implementation that populates [`WriteInfo`]
+/// structs from [`Request`] that conform to the [V1 Write API] or [V2 Write API]
+/// when this router is configured in single-tenancy mode.
+///
+/// [V1 Write API]: https://docs.influxdata.com/influxdb/v1.8/tools/api/#write-http-endpoint
+/// [V2 Write API]: https://docs.influxdata.com/influxdb/v2.6/api/#operation/PostWrite
+/// [CST-specific namespace name construction]: docs TBD
 impl WriteInfoExtractor for SingleTenantRequestParser {
     fn extract_v1_dml_info(&self, req: &Request<Body>) -> Result<WriteInfo, Error> {
         let write_params = WriteParamsV1::try_from(req)?;
 
+        const SEPARATOR: char = '/';
         let namespace = match write_params.rp {
-            RetentionPolicy::Unspecified => NamespaceName::try_from(&write_params.db),
-            RetentionPolicy::Autogen => NamespaceName::try_from(&write_params.db),
-            RetentionPolicy::Named(rp) => rp_and_database_to_namespace(&rp, &write_params.db),
+            RetentionPolicy::Unspecified | RetentionPolicy::Autogen => {
+                NamespaceName::convert_namespace_name(&write_params.db)
+            }
+            RetentionPolicy::Named(rp) => {
+                if write_params.db.is_empty() {
+                    return Err(Error::InvalidDatabaseRp(DatabaseRpError::NotSpecified));
+                }
+                NamespaceName::generate_namespace_name(&write_params.db, &rp, SEPARATOR)
+            }
         }
         .map_err(DatabaseRpError::MappingFail)?;
-
-        let skip_database_creation = Some(false); // Only in v1 telegraf. Ignored for now.
 
         Ok(WriteInfo {
             namespace,
             precision: write_params.precision,
-            skip_database_creation,
         })
     }
 
@@ -46,14 +51,12 @@ impl WriteInfoExtractor for SingleTenantRequestParser {
         if write_params.bucket.is_empty() {
             return Err(InvalidOrgBucket(OrgBucketError::NotSpecified));
         }
-        let namespace =
-            NamespaceName::try_from(&write_params.bucket).map_err(OrgBucketError::MappingFail)?;
-        let skip_database_creation = None;
+        let namespace = NamespaceName::convert_namespace_name(&write_params.bucket)
+            .map_err(OrgBucketError::MappingFail)?;
 
         Ok(WriteInfo {
             namespace,
             precision: write_params.precision,
-            skip_database_creation,
         })
     }
 }

--- a/router/src/server/http/cst.rs
+++ b/router/src/server/http/cst.rs
@@ -1,0 +1,59 @@
+//! SingleTenantRequestParser
+///  This is a [`WriteInfoExtractor`] implementation that populates [`WriteInfo`]
+/// structs from [`Request`] that conform to the [V1 Write API] or [V2 Write API]
+/// when this router is configured in single-tenancy mode.
+///
+/// [V1 Write API]: https://docs.influxdata.com/influxdb/v1.8/tools/api/#write-http-endpoint
+/// [V2 Write API]: https://docs.influxdata.com/influxdb/v2.6/api/#operation/PostWrite
+/// [CST-specific namespace name construction]: docs TBD
+use hyper::{Body, Request};
+
+use super::{
+    write_dml::WriteInfo,
+    write_v1::{DatabaseRpError, RetentionPolicy, WriteParamsV1},
+    write_v2::{OrgBucketError, WriteParamsV2},
+    WriteInfoExtractor,
+};
+use crate::server::http::Error::{self, InvalidOrgBucket};
+use data_types::{rp_and_database_to_namespace, NamespaceName};
+
+#[allow(missing_docs)]
+#[derive(Debug, Default)]
+pub struct SingleTenantRequestParser;
+
+impl WriteInfoExtractor for SingleTenantRequestParser {
+    fn extract_v1_dml_info(&self, req: &Request<Body>) -> Result<WriteInfo, Error> {
+        let write_params = WriteParamsV1::try_from(req)?;
+
+        let namespace = match write_params.rp {
+            RetentionPolicy::Unspecified => NamespaceName::try_from(&write_params.db),
+            RetentionPolicy::Autogen => NamespaceName::try_from(&write_params.db),
+            RetentionPolicy::Named(rp) => rp_and_database_to_namespace(&rp, &write_params.db),
+        }
+        .map_err(DatabaseRpError::MappingFail)?;
+
+        let skip_database_creation = Some(false); // Only in v1 telegraf. Ignored for now.
+
+        Ok(WriteInfo {
+            namespace,
+            precision: write_params.precision,
+            skip_database_creation,
+        })
+    }
+
+    fn extract_v2_dml_info(&self, req: &Request<Body>) -> Result<WriteInfo, Error> {
+        let write_params = WriteParamsV2::try_from(req)?;
+        if write_params.bucket.is_empty() {
+            return Err(InvalidOrgBucket(OrgBucketError::NotSpecified));
+        }
+        let namespace =
+            NamespaceName::try_from(&write_params.bucket).map_err(OrgBucketError::MappingFail)?;
+        let skip_database_creation = None;
+
+        Ok(WriteInfo {
+            namespace,
+            precision: write_params.precision,
+            skip_database_creation,
+        })
+    }
+}

--- a/router/src/server/http/mt.rs
+++ b/router/src/server/http/mt.rs
@@ -1,10 +1,5 @@
 //! MultiTenantRequestParser
-/// This is a [`WriteInfoExtractor`] implementation that populates [`WriteInfo`]
-/// structs from [`Request`] that conform to the [V1 Write API] or [V2 Write API]
-/// when this router is configured in multiple-tenant mode.
-///
-/// [V1 Write API]: https://docs.influxdata.com/influxdb/v1.8/tools/api/#write-http-endpoint
-/// [V2 Write API]: https://docs.influxdata.com/influxdb/v2.6/api/#operation/PostWrite
+
 use hyper::{Body, Request};
 
 use super::{
@@ -19,10 +14,14 @@ use data_types::org_and_bucket_to_namespace;
 #[derive(Debug, Default)]
 pub struct MultiTenantRequestParser;
 
+/// This is a [`WriteInfoExtractor`] implementation that populates [`WriteInfo`]
+/// structs from [`Request`] that conform to the [V1 Write API] or [V2 Write API]
+/// when this router is configured in multiple-tenant mode.
+///
+/// [V1 Write API]: https://docs.influxdata.com/influxdb/v1.8/tools/api/#write-http-endpoint
+/// [V2 Write API]: https://docs.influxdata.com/influxdb/v2.6/api/#operation/PostWrite
 impl WriteInfoExtractor for MultiTenantRequestParser {
     fn extract_v1_dml_info(&self, _req: &Request<Body>) -> Result<WriteInfo, Error> {
-        println!("mt::extract_v1_dml_info");
-
         Err(Error::NoHandler)
     }
 
@@ -30,12 +29,10 @@ impl WriteInfoExtractor for MultiTenantRequestParser {
         let write_params = WriteParamsV2::try_from(req)?;
         let namespace = org_and_bucket_to_namespace(&write_params.org, &write_params.bucket)
             .map_err(OrgBucketError::MappingFail)?;
-        let skip_database_creation = None;
 
         Ok(WriteInfo {
             namespace,
             precision: write_params.precision,
-            skip_database_creation,
         })
     }
 }

--- a/router/src/server/http/mt.rs
+++ b/router/src/server/http/mt.rs
@@ -36,3 +36,57 @@ impl WriteInfoExtractor for MultiTenantRequestParser {
         })
     }
 }
+
+#[cfg(test)]
+#[macro_export]
+/// Wrapper over test_http_handler specifically for MT.
+macro_rules! test_mt_handler {
+    // Match based on named arg `dml_write_handler`.
+    (
+        $name:ident,
+        route_string = $route_string:expr,   // v1 versus v2 routes
+        query_string = $query_string:expr,   // Request URI query string
+        body = $body:expr,                   // Request body content
+        dml_write_handler = $dml_handler:expr,     // DML write handler response (if called)
+        want_result = $want_result:pat,
+        want_dml_calls = $($want_dml_calls:tt )+
+    ) => {
+        paste::paste! {
+            $crate::test_http_handler!(
+                [<mt_write_ $name>],
+                uri = format!("https://bananas.example{}{}", $route_string, $query_string),
+                body = $body,
+                auth_handler = None, // handled at gateway
+                dml_info_handler = Box::<$crate::server::http::mt::MultiTenantRequestParser>::default(),
+                dml_write_handler = $dml_handler,
+                dml_delete_handler = [],
+                want_result = $want_result,
+                want_dml_calls = $($want_dml_calls)+
+            );
+        }
+    };
+    // Match based on named arg `dml_delete_handler`.
+    (
+        $name:ident,
+        route_string = $route_string:expr,   // v1 versus v2 routes
+        query_string = $query_string:expr,   // Request URI query string
+        body = $body:expr,                   // Request body content
+        dml_delete_handler = $dml_handler:expr,     // DML write handler response (if called)
+        want_result = $want_result:pat,
+        want_dml_calls = $($want_dml_calls:tt )+
+    ) => {
+        paste::paste! {
+            $crate::test_http_handler!(
+                [<mt_delete_ $name>],
+                uri = format!("https://bananas.example{}{}", $route_string, $query_string),
+                body = $body,
+                auth_handler = None, // handled at gateway
+                dml_info_handler = Box::<$crate::server::http::mt::MultiTenantRequestParser>::default(),
+                dml_write_handler = [],
+                dml_delete_handler = $dml_handler,
+                want_result = $want_result,
+                want_dml_calls = $($want_dml_calls)+
+            );
+        }
+    };
+}

--- a/router/src/server/http/mt.rs
+++ b/router/src/server/http/mt.rs
@@ -1,0 +1,41 @@
+//! MultiTenantRequestParser
+/// This is a [`WriteInfoExtractor`] implementation that populates [`WriteInfo`]
+/// structs from [`Request`] that conform to the [V1 Write API] or [V2 Write API]
+/// when this router is configured in multiple-tenant mode.
+///
+/// [V1 Write API]: https://docs.influxdata.com/influxdb/v1.8/tools/api/#write-http-endpoint
+/// [V2 Write API]: https://docs.influxdata.com/influxdb/v2.6/api/#operation/PostWrite
+use hyper::{Body, Request};
+
+use super::{
+    write_dml::WriteInfo,
+    write_v2::{OrgBucketError, WriteParamsV2},
+    WriteInfoExtractor,
+};
+use crate::server::http::Error;
+use data_types::org_and_bucket_to_namespace;
+
+#[allow(missing_docs)]
+#[derive(Debug, Default)]
+pub struct MultiTenantRequestParser;
+
+impl WriteInfoExtractor for MultiTenantRequestParser {
+    fn extract_v1_dml_info(&self, _req: &Request<Body>) -> Result<WriteInfo, Error> {
+        println!("mt::extract_v1_dml_info");
+
+        Err(Error::NoHandler)
+    }
+
+    fn extract_v2_dml_info(&self, req: &Request<Body>) -> Result<WriteInfo, Error> {
+        let write_params = WriteParamsV2::try_from(req)?;
+        let namespace = org_and_bucket_to_namespace(&write_params.org, &write_params.bucket)
+            .map_err(OrgBucketError::MappingFail)?;
+        let skip_database_creation = None;
+
+        Ok(WriteInfo {
+            namespace,
+            precision: write_params.precision,
+            skip_database_creation,
+        })
+    }
+}

--- a/router/src/server/http/write_dml.rs
+++ b/router/src/server/http/write_dml.rs
@@ -37,6 +37,4 @@ impl Precision {
 pub struct WriteInfo {
     pub(crate) namespace: NamespaceName<'static>,
     pub(crate) precision: Precision,
-    #[allow(dead_code)]
-    pub(crate) skip_database_creation: Option<bool>,
 }

--- a/router/src/server/http/write_dml.rs
+++ b/router/src/server/http/write_dml.rs
@@ -1,12 +1,6 @@
-use hyper::{Body, Request};
 use serde::Deserialize;
 
-use super::write_v1::{DatabaseRpError, WriteParamsV1};
-use super::write_v2::{OrgBucketError, WriteParamsV2};
-use crate::server::http::{Error, WriteInfoExtractor, CST, MT};
-use data_types::{
-    org_and_bucket_to_namespace, rp_and_database_to_namespace, string_to_namespace, NamespaceName,
-};
+use data_types::NamespaceName;
 
 #[derive(Clone, Debug, Deserialize)]
 pub(crate) enum Precision {
@@ -39,59 +33,10 @@ impl Precision {
 }
 
 #[derive(Debug)]
-pub(crate) enum ContentEncoding {
-    #[allow(dead_code)]
-    Gzip,
-    Identity,
-}
-
-// TODO: what is the default here?
-impl Default for ContentEncoding {
-    fn default() -> Self {
-        Self::Identity
-    }
-}
-
-#[derive(Debug)]
 /// Standardized DML operation parameters
-pub struct WriteInfo<'a> {
-    pub(crate) namespace: NamespaceName<'a>,
+pub struct WriteInfo {
+    pub(crate) namespace: NamespaceName<'static>,
     pub(crate) precision: Precision,
     #[allow(dead_code)]
     pub(crate) skip_database_creation: Option<bool>,
-    #[allow(dead_code)]
-    pub(crate) content_encoding: ContentEncoding,
-}
-
-pub(crate) trait IntoWriteInfo {
-    fn into_write_info(self, namespace: NamespaceName<'_>) -> Result<WriteInfo<'_>, Error>;
-}
-
-impl WriteInfoExtractor for CST {
-    fn extract_v1_dml_info<'a>(&self, req: &Request<Body>) -> Result<WriteInfo<'a>, Error> {
-        let write_params = WriteParamsV1::try_from(req)?;
-        let namespace = rp_and_database_to_namespace(&write_params.rp, &write_params.db)
-            .map_err(DatabaseRpError::MappingFail)?;
-        write_params.into_write_info(namespace)
-    }
-
-    fn extract_v2_dml_info<'a>(&self, req: &Request<Body>) -> Result<WriteInfo<'a>, Error> {
-        let write_params = WriteParamsV2::try_from(req)?;
-        let namespace =
-            string_to_namespace(&write_params.bucket).map_err(OrgBucketError::MappingFail)?;
-        write_params.into_write_info(namespace)
-    }
-}
-
-impl WriteInfoExtractor for MT {
-    fn extract_v1_dml_info<'a>(&self, _req: &Request<Body>) -> Result<WriteInfo<'a>, Error> {
-        Err(Error::NoHandler)
-    }
-
-    fn extract_v2_dml_info<'a>(&self, req: &Request<Body>) -> Result<WriteInfo<'a>, Error> {
-        let write_params = WriteParamsV2::try_from(req)?;
-        let namespace = org_and_bucket_to_namespace(&write_params.org, &write_params.bucket)
-            .map_err(OrgBucketError::MappingFail)?;
-        write_params.into_write_info(namespace)
-    }
 }

--- a/router/src/server/http/write_dml.rs
+++ b/router/src/server/http/write_dml.rs
@@ -1,0 +1,97 @@
+use hyper::{Body, Request};
+use serde::Deserialize;
+
+use super::write_v1::{DatabaseRpError, WriteParamsV1};
+use super::write_v2::{OrgBucketError, WriteParamsV2};
+use crate::server::http::{Error, WriteInfoExtractor, CST, MT};
+use data_types::{
+    org_and_bucket_to_namespace, rp_and_database_to_namespace, string_to_namespace, NamespaceName,
+};
+
+#[derive(Clone, Debug, Deserialize)]
+pub(crate) enum Precision {
+    #[serde(rename = "s")]
+    Seconds,
+    #[serde(rename = "ms")]
+    Milliseconds,
+    #[serde(rename = "us")]
+    Microseconds,
+    #[serde(rename = "ns")]
+    Nanoseconds,
+}
+
+impl Default for Precision {
+    fn default() -> Self {
+        Self::Nanoseconds
+    }
+}
+
+impl Precision {
+    /// Returns the multiplier to convert to nanosecond timestamps
+    pub(crate) fn timestamp_base(&self) -> i64 {
+        match self {
+            Precision::Seconds => 1_000_000_000,
+            Precision::Milliseconds => 1_000_000,
+            Precision::Microseconds => 1_000,
+            Precision::Nanoseconds => 1,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub(crate) enum ContentEncoding {
+    #[allow(dead_code)]
+    Gzip,
+    Identity,
+}
+
+// TODO: what is the default here?
+impl Default for ContentEncoding {
+    fn default() -> Self {
+        Self::Identity
+    }
+}
+
+#[derive(Debug)]
+/// Standardized DML operation parameters
+pub struct WriteInfo<'a> {
+    pub(crate) namespace: NamespaceName<'a>,
+    pub(crate) precision: Precision,
+    #[allow(dead_code)]
+    pub(crate) skip_database_creation: Option<bool>,
+    #[allow(dead_code)]
+    pub(crate) content_encoding: ContentEncoding,
+}
+
+pub(crate) trait IntoWriteInfo {
+    fn into_write_info(self, namespace: NamespaceName<'_>) -> Result<WriteInfo<'_>, Error>;
+}
+
+impl WriteInfoExtractor for CST {
+    fn extract_v1_dml_info<'a>(&self, req: &Request<Body>) -> Result<WriteInfo<'a>, Error> {
+        let write_params = WriteParamsV1::try_from(req)?;
+        let namespace = rp_and_database_to_namespace(&write_params.rp, &write_params.db)
+            .map_err(DatabaseRpError::MappingFail)?;
+        write_params.into_write_info(namespace)
+    }
+
+    fn extract_v2_dml_info<'a>(&self, req: &Request<Body>) -> Result<WriteInfo<'a>, Error> {
+        let write_params = WriteParamsV2::try_from(req)?;
+        let namespace =
+            string_to_namespace(&write_params.bucket).map_err(OrgBucketError::MappingFail)?;
+        write_params.into_write_info(namespace)
+    }
+}
+
+impl WriteInfoExtractor for MT {
+    fn extract_v1_dml_info<'a>(&self, _req: &Request<Body>) -> Result<WriteInfo<'a>, Error> {
+        Err(Error::NoHandler)
+    }
+
+    fn extract_v2_dml_info<'a>(&self, req: &Request<Body>) -> Result<WriteInfo<'a>, Error> {
+        let write_params = WriteParamsV2::try_from(req)?;
+        let namespace = org_and_bucket_to_namespace(&write_params.org, &write_params.bucket)
+            .map_err(OrgBucketError::MappingFail)?;
+        write_params.into_write_info(namespace)
+    }
+}

--- a/router/src/server/http/write_test_helpers.rs
+++ b/router/src/server/http/write_test_helpers.rs
@@ -37,7 +37,7 @@ macro_rules! test_http_handler {
         $name:ident,
         uri = $uri:expr,                                // Request URI
         body = $body:expr,                              // Request body content
-        dml_info_handler = $dml_info_handler:ident,
+        dml_info_handler = $dml_info_handler:expr,
         dml_write_handler = $dml_write_handler:expr,    // DML write handler response (if called)
         dml_delete_handler = $dml_delete_handler:expr,  // DML delete handler response (if called)
         want_result = $want_result:pat,                 // Expected handler return value (as pattern)
@@ -74,7 +74,7 @@ macro_rules! test_http_handler {
         encoding = $encoding:tt,
         uri = $uri:expr,
         body = $body:expr,
-        dml_info_handler = $dml_info_handler:ident,
+        dml_info_handler = $dml_info_handler:expr,
         dml_write_handler = $dml_write_handler:expr,
         dml_delete_handler = $dml_delete_handler:expr,
         want_result = $want_result:pat,
@@ -90,7 +90,6 @@ macro_rules! test_http_handler {
                     },
                     namespace_resolver::{mock::MockNamespaceResolver},
                     server::http::{
-                        self,
                         HttpDelegate,
                         WriteInfoExtractor,
                         write_test_helpers::assert_metric_hit,
@@ -133,7 +132,7 @@ macro_rules! test_http_handler {
                         .with_delete_return($dml_delete_handler)
                     );
                     let metrics = Arc::new(metric::Registry::default());
-                    let dml_info_extractor: &'static dyn WriteInfoExtractor = &http::[<$dml_info_handler>];
+                    let dml_info_extractor: &'static dyn WriteInfoExtractor = $dml_info_handler;
 
                     let delegate = HttpDelegate::new(
                         MAX_BYTES,
@@ -193,7 +192,7 @@ macro_rules! test_write_handler {
         $name:ident,
         query_string = $query_string:expr,   // Request URI query string
         body = $body:expr,                   // Request body content
-        dml_info_handler = $dml_info_handler:ident,
+        dml_info_handler = $dml_info_handler:expr,
         dml_handler = $dml_handler:expr,     // DML write handler response (if called)
         want_result = $want_result:pat,
         want_dml_calls = $($want_dml_calls:tt )+
@@ -214,7 +213,7 @@ macro_rules! test_write_handler {
         route_string = $route_string:expr,   // v1 versus v2 routes
         query_string = $query_string:expr,   // Request URI query string
         body = $body:expr,                   // Request body content
-        dml_info_handler = $dml_info_handler:ident,
+        dml_info_handler = $dml_info_handler:expr,
         dml_handler = $dml_handler:expr,     // DML write handler response (if called)
         want_result = $want_result:pat,
         want_dml_calls = $($want_dml_calls:tt )+
@@ -241,7 +240,7 @@ macro_rules! test_delete_handler {
         $name:ident,
         query_string = $query_string:expr,   // Request URI query string
         body = $body:expr,                   // Request body content
-        dml_info_handler = $dml_info_handler:ident,
+        dml_info_handler = $dml_info_handler:expr,
         dml_handler = $dml_handler:expr,     // DML delete handler response (if called)
         want_result = $want_result:pat,
         want_dml_calls = $($want_dml_calls:tt )+

--- a/router/src/server/http/write_test_helpers.rs
+++ b/router/src/server/http/write_test_helpers.rs
@@ -126,13 +126,14 @@ macro_rules! test_http_handler {
                         .with_mapping("bananas_test", NAMESPACE_ID)
                         .with_mapping("test", NAMESPACE_ID)
                         .with_mapping("database", NAMESPACE_ID)
-                        .with_mapping("database/myrp", NAMESPACE_ID);
+                        .with_mapping("database/myrp", NAMESPACE_ID)
+                        .with_mapping("data%2Fbase/myrp", NAMESPACE_ID);
                     let dml_handler = Arc::new(MockDmlHandler::default()
                         .with_write_return($dml_write_handler)
                         .with_delete_return($dml_delete_handler)
                     );
                     let metrics = Arc::new(metric::Registry::default());
-                    let dml_info_extractor: &'static dyn WriteInfoExtractor = $dml_info_handler;
+                    let dml_info_extractor: Box<dyn WriteInfoExtractor> = $dml_info_handler;
 
                     let delegate = HttpDelegate::new(
                         MAX_BYTES,

--- a/router/src/server/http/write_test_helpers.rs
+++ b/router/src/server/http/write_test_helpers.rs
@@ -1,0 +1,262 @@
+use data_types::NamespaceId;
+use metric::{Attributes, Metric, U64Counter};
+use write_summary::WriteSummary;
+
+pub(crate) const MAX_BYTES: usize = 1024;
+pub(crate) const NAMESPACE_ID: NamespaceId = NamespaceId::new(42);
+
+pub(crate) fn summary() -> WriteSummary {
+    WriteSummary::default()
+}
+
+pub(crate) fn assert_metric_hit(
+    metrics: &metric::Registry,
+    name: &'static str,
+    value: Option<u64>,
+) {
+    let counter = metrics
+        .get_instrument::<Metric<U64Counter>>(name)
+        .expect("failed to read metric")
+        .get_observer(&Attributes::from(&[]))
+        .expect("failed to get observer")
+        .fetch();
+
+    if let Some(want) = value {
+        assert_eq!(want, counter, "metric does not have expected value");
+    } else {
+        assert!(counter > 0, "metric {name} did not record any values");
+    }
+}
+
+#[macro_export]
+/// Generate two HTTP handler tests - one for a plain request and one with a
+/// gzip-encoded body (and appropriate header), asserting the handler return
+/// value & write op.
+macro_rules! test_http_handler {
+    (
+        $name:ident,
+        uri = $uri:expr,                                // Request URI
+        body = $body:expr,                              // Request body content
+        dml_info_handler = $dml_info_handler:ident,
+        dml_write_handler = $dml_write_handler:expr,    // DML write handler response (if called)
+        dml_delete_handler = $dml_delete_handler:expr,  // DML delete handler response (if called)
+        want_result = $want_result:pat,                 // Expected handler return value (as pattern)
+        want_dml_calls = $($want_dml_calls:tt )+        // assert_matches slice pattern for expected DML calls
+    ) => {
+        // Generate the two test cases by feed the same inputs, but varying
+        // the encoding.
+        $crate::test_http_handler!(
+            $name,
+            encoding=plain,
+            uri = $uri,
+            body = $body,
+            dml_info_handler = $dml_info_handler,
+            dml_write_handler = $dml_write_handler,
+            dml_delete_handler = $dml_delete_handler,
+            want_result = $want_result,
+            want_dml_calls = $($want_dml_calls)+
+        );
+        $crate::test_http_handler!(
+            $name,
+            encoding=gzip,
+            uri = $uri,
+            body = $body,
+            dml_info_handler = $dml_info_handler,
+            dml_write_handler = $dml_write_handler,
+            dml_delete_handler = $dml_delete_handler,
+            want_result = $want_result,
+            want_dml_calls = $($want_dml_calls)+
+        );
+    };
+    // Actual test body generator.
+    (
+        $name:ident,
+        encoding = $encoding:tt,
+        uri = $uri:expr,
+        body = $body:expr,
+        dml_info_handler = $dml_info_handler:ident,
+        dml_write_handler = $dml_write_handler:expr,
+        dml_delete_handler = $dml_delete_handler:expr,
+        want_result = $want_result:pat,
+        want_dml_calls = $($want_dml_calls:tt )+
+    ) => {
+        paste::paste! {
+            mod [<test_mod_ test_http_handler_ $name _ $encoding>] {
+                use super::*;
+                use $crate::{
+                    test_http_handler,
+                    dml_handlers::{
+                        mock::{MockDmlHandler},
+                    },
+                    namespace_resolver::{mock::MockNamespaceResolver},
+                    server::http::{
+                        self,
+                        HttpDelegate,
+                        WriteInfoExtractor,
+                        write_test_helpers::assert_metric_hit,
+                    },
+                };
+                use assert_matches::assert_matches;
+                #[allow(unused_imports)]
+                use flate2::{write::GzEncoder, Compression};
+                #[allow(unused_imports)]
+                use hyper::{header::{CONTENT_ENCODING, HeaderValue}, Body, Request, StatusCode};
+                #[allow(unused_imports)]
+                use std::{io::Write, sync::Arc};
+
+                #[tokio::test]
+                async fn [<test_http_handler_ $name _ $encoding>]() {
+                    let body = $body;
+
+                    // Optionally generate a fragment of code to encode the body
+                    let body = test_http_handler!(encoding=$encoding, body);
+
+                    #[allow(unused_mut)]
+                    let mut request = Request::builder()
+                        .uri($uri)
+                        .method("POST")
+                        .body(Body::from(body))
+                        .unwrap();
+
+                    // Optionally modify request to account for the desired
+                    // encoding
+                    test_http_handler!(encoding_header=$encoding, request);
+
+                    // add all the mappings used in the tests.
+                    let mock_namespace_resolver = MockNamespaceResolver::default()
+                        .with_mapping("bananas_test", NAMESPACE_ID)
+                        .with_mapping("test", NAMESPACE_ID)
+                        .with_mapping("database", NAMESPACE_ID)
+                        .with_mapping("database/myrp", NAMESPACE_ID);
+                    let dml_handler = Arc::new(MockDmlHandler::default()
+                        .with_write_return($dml_write_handler)
+                        .with_delete_return($dml_delete_handler)
+                    );
+                    let metrics = Arc::new(metric::Registry::default());
+                    let dml_info_extractor: &'static dyn WriteInfoExtractor = &http::[<$dml_info_handler>];
+
+                    let delegate = HttpDelegate::new(
+                        MAX_BYTES,
+                        100,
+                        mock_namespace_resolver,
+                        Arc::clone(&dml_handler),
+                        None,
+                        &metrics,
+                        dml_info_extractor,
+                    );
+
+                    let got = delegate.route(request).await;
+                    assert_matches!(got, $want_result);
+
+                    // All successful responses should have a NO_CONTENT code
+                    // and metrics should be recorded.
+                    if let Ok(v) = got {
+                        assert_eq!(v.status(), StatusCode::NO_CONTENT);
+                        if $uri.contains("/write") {
+                            assert_metric_hit(&metrics, "http_write_lines", None);
+                            assert_metric_hit(&metrics, "http_write_fields", None);
+                            assert_metric_hit(&metrics, "http_write_tables", None);
+                            assert_metric_hit(&metrics, "http_write_body_bytes", Some($body.len() as _));
+                        } else {
+                            assert_metric_hit(&metrics, "http_delete_body_bytes", Some($body.len() as _));
+                        }
+                    }
+
+                    let calls = dml_handler.calls();
+                    assert_matches!(calls.as_slice(), $($want_dml_calls)+);
+                }
+            }
+        }
+    };
+    (encoding=plain, $body:ident) => {
+        $body
+    };
+    (encoding=gzip, $body:ident) => {{
+        // Apply gzip compression to the body
+        let mut e = GzEncoder::new(Vec::new(), Compression::default());
+        e.write_all(&$body).unwrap();
+        e.finish().expect("failed to compress test body")
+    }};
+    (encoding_header=plain, $request:ident) => {};
+    (encoding_header=gzip, $request:ident) => {{
+        // Set the gzip content encoding
+        $request
+            .headers_mut()
+            .insert(CONTENT_ENCODING, HeaderValue::from_static("gzip"));
+    }};
+}
+
+#[macro_export]
+/// Wrapper over test_http_handler specifically for write requests.
+macro_rules! test_write_handler {
+    (
+        $name:ident,
+        query_string = $query_string:expr,   // Request URI query string
+        body = $body:expr,                   // Request body content
+        dml_info_handler = $dml_info_handler:ident,
+        dml_handler = $dml_handler:expr,     // DML write handler response (if called)
+        want_result = $want_result:pat,
+        want_dml_calls = $($want_dml_calls:tt )+
+    ) => {
+        $crate::test_write_handler!(
+            $name,
+            route_string = "/api/v2/write",
+            query_string = $query_string,
+            body = $body,
+            dml_info_handler = $dml_info_handler,
+            dml_handler = $dml_handler,
+            want_result = $want_result,
+            want_dml_calls = $($want_dml_calls)+
+        );
+    };
+    (
+        $name:ident,
+        route_string = $route_string:expr,   // v1 versus v2 routes
+        query_string = $query_string:expr,   // Request URI query string
+        body = $body:expr,                   // Request body content
+        dml_info_handler = $dml_info_handler:ident,
+        dml_handler = $dml_handler:expr,     // DML write handler response (if called)
+        want_result = $want_result:pat,
+        want_dml_calls = $($want_dml_calls:tt )+
+    ) => {
+        paste::paste! {
+            $crate::test_http_handler!(
+                [<write_ $name>],
+                uri = format!("https://bananas.example{}{}", $route_string, $query_string),
+                body = $body,
+                dml_info_handler = $dml_info_handler,
+                dml_write_handler = $dml_handler,
+                dml_delete_handler = [],
+                want_result = $want_result,
+                want_dml_calls = $($want_dml_calls)+
+            );
+        }
+    };
+}
+
+#[macro_export]
+/// Wrapper over test_http_handler specifically for delete requests.
+macro_rules! test_delete_handler {
+    (
+        $name:ident,
+        query_string = $query_string:expr,   // Request URI query string
+        body = $body:expr,                   // Request body content
+        dml_info_handler = $dml_info_handler:ident,
+        dml_handler = $dml_handler:expr,     // DML delete handler response (if called)
+        want_result = $want_result:pat,
+        want_dml_calls = $($want_dml_calls:tt )+
+    ) => {
+        paste::paste! {
+            $crate::test_http_handler!(
+                [<delete_ $name>],
+                uri = format!("https://bananas.example/api/v2/delete{}", $query_string),
+                body = $body,
+                dml_info_handler = $dml_info_handler,
+                dml_write_handler = [],
+                dml_delete_handler = $dml_handler,
+                want_result = $want_result,
+                want_dml_calls = $($want_dml_calls)+
+            );
+        }
+    };
+}

--- a/router/src/server/http/write_v1.rs
+++ b/router/src/server/http/write_v1.rs
@@ -1,0 +1,274 @@
+use data_types::{NamespaceMappingError, NamespaceName};
+use hyper::Request;
+use serde::Deserialize;
+
+use crate::server::http::{
+    write_dml::{ContentEncoding, IntoWriteInfo, Precision, WriteInfo},
+    Error,
+};
+
+/// v1 DmlErrors returned when decoding the database / rp information from a
+/// HTTP request and deriving the namespace name from it.
+#[derive(Debug, Error)]
+pub enum DatabaseRpError {
+    /// The request contains no org/bucket destination information.
+    #[error("no db destination provided")]
+    NotSpecified,
+
+    /// The request contains invalid parameters.
+    #[error("failed to deserialize db/rp/precision in request: {0}")]
+    DecodeFail(#[from] serde::de::value::Error),
+
+    /// The provided db (and optional rp) could not be converted into a namespace name.
+    #[error(transparent)]
+    MappingFail(#[from] NamespaceMappingError),
+}
+
+#[derive(Debug, Deserialize)]
+enum Consistency {
+    #[serde(rename = "any")]
+    Any,
+    #[serde(rename = "one")]
+    One,
+    #[serde(rename = "quorum")]
+    Quorum,
+    #[serde(rename = "all")]
+    All,
+}
+
+impl Default for Consistency {
+    fn default() -> Self {
+        Self::One
+    }
+}
+
+/// May be empty string, explicit rp name, or `autogen`.
+type RetentionPolicyName = Option<String>;
+
+#[derive(Debug, Deserialize)]
+/// Query Parameters for v1 DML operation.
+pub(crate) struct WriteParamsV1 {
+    pub(crate) db: String,
+
+    #[allow(dead_code)]
+    u: Option<String>,
+    #[allow(dead_code)]
+    p: Option<String>,
+
+    #[allow(dead_code)]
+    #[serde(default)]
+    consistency: Consistency,
+    #[serde(default)]
+    precision: Precision,
+    pub(crate) rp: RetentionPolicyName,
+}
+
+impl<T> TryFrom<&Request<T>> for WriteParamsV1 {
+    type Error = DatabaseRpError;
+
+    fn try_from(req: &Request<T>) -> Result<Self, Self::Error> {
+        let query = req.uri().query().ok_or(DatabaseRpError::NotSpecified)?;
+        let got: WriteParamsV1 = serde_urlencoded::from_str(query)?;
+
+        // An empty database name is not acceptable.
+        if got.db.is_empty() {
+            return Err(DatabaseRpError::NotSpecified);
+        }
+
+        Ok(got)
+    }
+}
+
+impl IntoWriteInfo for WriteParamsV1 {
+    fn into_write_info(self, namespace: NamespaceName<'_>) -> Result<WriteInfo<'_>, Error> {
+        let skip_database_creation = Some(false); // Only in v1 telegraf. Ignored for now.
+        let content_encoding = ContentEncoding::default();
+
+        Ok(WriteInfo {
+            namespace,
+            precision: self.precision,
+            skip_database_creation,
+            content_encoding,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        dml_handlers::mock::MockDmlHandlerCall,
+        server::http::{
+            write_test_helpers::{summary, MAX_BYTES, NAMESPACE_ID},
+            Error,
+        },
+        test_write_handler,
+    };
+
+    mod mt {
+        use super::*;
+
+        test_write_handler!(
+            mt_v1_no_handler,
+            route_string = "/write",
+            query_string = "?db=database",
+            body = "platanos,tag1=A,tag2=B val=42i 123456".as_bytes(),
+            dml_info_handler = MT,
+            dml_handler = [],
+            want_result = Err(Error::NoHandler),
+            want_dml_calls = []
+        );
+    }
+
+    mod cst {
+        use super::*;
+
+        mod v1 {
+            use super::*;
+            static EXPECTED_NAMESPACE: &str = "database";
+
+            test_write_handler!(
+                cst_v1_ok,
+                route_string = "/write",
+                query_string = "?db=database",
+                body = "platanos,tag1=A,tag2=B val=42i 123456".as_bytes(),
+                dml_info_handler = CST,
+                dml_handler = [Ok(summary())],
+                want_result = Ok(_),
+                want_dml_calls = [MockDmlHandlerCall::Write{namespace, ..}] => {
+                    assert_eq!(namespace, EXPECTED_NAMESPACE);
+                }
+            );
+
+            test_write_handler!(
+                cst_v1_no_query_params,
+                route_string = "/write",
+                query_string = "",
+                body = "platanos,tag1=A,tag2=B val=42i 123456".as_bytes(),
+                dml_info_handler = CST,
+                dml_handler = [Ok(summary())],
+                want_result = Err(Error::InvalidDatabaseRp(DatabaseRpError::NotSpecified)),
+                want_dml_calls = [] // None
+            );
+
+            test_write_handler!(
+                cst_v1_no_db,
+                route_string = "/write",
+                query_string = "?",
+                body = "platanos,tag1=A,tag2=B val=42i 123456".as_bytes(),
+                dml_info_handler = CST,
+                dml_handler = [Ok(summary())],
+                want_result = Err(Error::InvalidDatabaseRp(DatabaseRpError::DecodeFail(_))),
+                want_dml_calls = [] // None
+            );
+
+            test_write_handler!(
+                cst_v1_empty_db,
+                route_string = "/write",
+                query_string = "?db=",
+                body = "platanos,tag1=A,tag2=B val=42i 123456".as_bytes(),
+                dml_info_handler = CST,
+                dml_handler = [Ok(summary())],
+                want_result = Err(Error::InvalidDatabaseRp(DatabaseRpError::NotSpecified)),
+                want_dml_calls = [] // None
+            );
+
+            test_write_handler!(
+                cst_v1_invalid_db,
+                route_string = "/write",
+                query_string = format!("?db={}", "A".repeat(1000)),
+                body = "platanos,tag1=A,tag2=B val=42i 123456".as_bytes(),
+                dml_info_handler = CST,
+                dml_handler = [Ok(summary())],
+                want_result = Err(Error::InvalidDatabaseRp(DatabaseRpError::MappingFail(_))),
+                want_dml_calls = [] // None
+            );
+
+            test_write_handler!(
+                cst_v1_ok_with_consistency,
+                route_string = "/write",
+                query_string = "?db=database&consistency=any",
+                body = "platanos,tag1=A,tag2=B val=42i 123456".as_bytes(),
+                dml_info_handler = CST,
+                dml_handler = [Ok(summary())],
+                want_result = Ok(_),
+                want_dml_calls = [MockDmlHandlerCall::Write{namespace, ..}] => {
+                    assert_eq!(namespace, EXPECTED_NAMESPACE);
+                }
+            );
+
+            test_write_handler!(
+                cst_v1_invalid_consistency,
+                route_string = "/write",
+                query_string = "?db=database&consistency=wrong",
+                body = "platanos,tag1=A,tag2=B val=42i 123456".as_bytes(),
+                dml_info_handler = CST,
+                dml_handler = [Ok(summary())],
+                want_result = Err(Error::InvalidDatabaseRp(DatabaseRpError::DecodeFail(_))),
+                want_dml_calls = [] // None
+            );
+
+            mod with_rp {
+                use super::*;
+                static EXPECTED_NAMESPACE: &str = "database/myrp";
+
+                test_write_handler!(
+                    cst_v1_rp_ok,
+                    route_string = "/write",
+                    query_string = "?db=database&rp=myrp",
+                    body = "platanos,tag1=A,tag2=B val=42i 123456".as_bytes(),
+                    dml_info_handler = CST,
+                    dml_handler = [Ok(summary())],
+                    want_result = Ok(_),
+                    want_dml_calls = [MockDmlHandlerCall::Write{namespace, ..}] => {
+                        assert_eq!(namespace, EXPECTED_NAMESPACE);
+                    }
+                );
+            }
+
+            mod with_rp_ignored {
+                use super::*;
+                static EXPECTED_NAMESPACE: &str = "database";
+
+                test_write_handler!(
+                    cst_v1_rp_empty,
+                    route_string = "/write",
+                    query_string = "?db=database&rp=",
+                    body = "platanos,tag1=A,tag2=B val=42i 123456".as_bytes(),
+                    dml_info_handler = CST,
+                    dml_handler = [Ok(summary())],
+                    want_result = Ok(_),
+                    want_dml_calls = [MockDmlHandlerCall::Write{namespace, ..}] => {
+                        assert_eq!(namespace, EXPECTED_NAMESPACE);
+                    }
+                );
+
+                test_write_handler!(
+                    cst_v1_rp_empty_str,
+                    route_string = "/write",
+                    query_string = "?db=database&rp=''",
+                    body = "platanos,tag1=A,tag2=B val=42i 123456".as_bytes(),
+                    dml_info_handler = CST,
+                    dml_handler = [Ok(summary())],
+                    want_result = Ok(_),
+                    want_dml_calls = [MockDmlHandlerCall::Write{namespace, ..}] => {
+                        assert_eq!(namespace, EXPECTED_NAMESPACE);
+                    }
+                );
+
+                test_write_handler!(
+                    cst_v1_rp_ignore_autogen,
+                    route_string = "/write",
+                    query_string = "?db=database&rp=autogen",
+                    body = "platanos,tag1=A,tag2=B val=42i 123456".as_bytes(),
+                    dml_info_handler = CST,
+                    dml_handler = [Ok(summary())],
+                    want_result = Ok(_),
+                    want_dml_calls = [MockDmlHandlerCall::Write{namespace, ..}] => {
+                        assert_eq!(namespace, EXPECTED_NAMESPACE);
+                    }
+                );
+            }
+        }
+    }
+}

--- a/router/src/server/http/write_v1.rs
+++ b/router/src/server/http/write_v1.rs
@@ -131,7 +131,7 @@ mod tests {
             route_string = "/write",
             query_string = "?db=database",
             body = "platanos,tag1=A,tag2=B val=42i 123456".as_bytes(),
-            dml_info_handler = &MultiTenantRequestParser,
+            dml_info_handler = Box::<MultiTenantRequestParser>::default(),
             dml_handler = [],
             want_result = Err(Error::NoHandler),
             want_dml_calls = []
@@ -151,7 +151,7 @@ mod tests {
                 route_string = "/write",
                 query_string = "?db=database",
                 body = "platanos,tag1=A,tag2=B val=42i 123456".as_bytes(),
-                dml_info_handler = &SingleTenantRequestParser,
+                dml_info_handler = Box::<SingleTenantRequestParser>::default(),
                 dml_handler = [Ok(summary())],
                 want_result = Ok(_),
                 want_dml_calls = [MockDmlHandlerCall::Write{namespace, ..}] => {
@@ -164,7 +164,7 @@ mod tests {
                 route_string = "/write",
                 query_string = "",
                 body = "platanos,tag1=A,tag2=B val=42i 123456".as_bytes(),
-                dml_info_handler = &SingleTenantRequestParser,
+                dml_info_handler = Box::<SingleTenantRequestParser>::default(),
                 dml_handler = [Ok(summary())],
                 want_result = Err(Error::InvalidDatabaseRp(DatabaseRpError::NotSpecified)),
                 want_dml_calls = [] // None
@@ -175,7 +175,7 @@ mod tests {
                 route_string = "/write",
                 query_string = "?",
                 body = "platanos,tag1=A,tag2=B val=42i 123456".as_bytes(),
-                dml_info_handler = &SingleTenantRequestParser,
+                dml_info_handler = Box::<SingleTenantRequestParser>::default(),
                 dml_handler = [Ok(summary())],
                 want_result = Err(Error::InvalidDatabaseRp(DatabaseRpError::DecodeFail(_))),
                 want_dml_calls = [] // None
@@ -186,7 +186,7 @@ mod tests {
                 route_string = "/write",
                 query_string = "?db=",
                 body = "platanos,tag1=A,tag2=B val=42i 123456".as_bytes(),
-                dml_info_handler = &SingleTenantRequestParser,
+                dml_info_handler = Box::<SingleTenantRequestParser>::default(),
                 dml_handler = [Ok(summary())],
                 want_result = Err(Error::InvalidDatabaseRp(DatabaseRpError::NotSpecified)),
                 want_dml_calls = [] // None
@@ -197,7 +197,7 @@ mod tests {
                 route_string = "/write",
                 query_string = format!("?db={}", "A".repeat(1000)),
                 body = "platanos,tag1=A,tag2=B val=42i 123456".as_bytes(),
-                dml_info_handler = &SingleTenantRequestParser,
+                dml_info_handler = Box::<SingleTenantRequestParser>::default(),
                 dml_handler = [Ok(summary())],
                 want_result = Err(Error::InvalidDatabaseRp(DatabaseRpError::MappingFail(_))),
                 want_dml_calls = [] // None
@@ -208,7 +208,7 @@ mod tests {
                 route_string = "/write",
                 query_string = "?db=database&consistency=any",
                 body = "platanos,tag1=A,tag2=B val=42i 123456".as_bytes(),
-                dml_info_handler = &SingleTenantRequestParser,
+                dml_info_handler = Box::<SingleTenantRequestParser>::default(),
                 dml_handler = [Ok(summary())],
                 want_result = Ok(_),
                 want_dml_calls = [MockDmlHandlerCall::Write{namespace, ..}] => {
@@ -221,7 +221,7 @@ mod tests {
                 route_string = "/write",
                 query_string = "?db=database&consistency=wrong",
                 body = "platanos,tag1=A,tag2=B val=42i 123456".as_bytes(),
-                dml_info_handler = &SingleTenantRequestParser,
+                dml_info_handler = Box::<SingleTenantRequestParser>::default(),
                 dml_handler = [Ok(summary())],
                 want_result = Err(Error::InvalidDatabaseRp(DatabaseRpError::DecodeFail(_))),
                 want_dml_calls = [] // None
@@ -236,7 +236,25 @@ mod tests {
                     route_string = "/write",
                     query_string = "?db=database&rp=myrp",
                     body = "platanos,tag1=A,tag2=B val=42i 123456".as_bytes(),
-                    dml_info_handler = &SingleTenantRequestParser,
+                    dml_info_handler = Box::<SingleTenantRequestParser>::default(),
+                    dml_handler = [Ok(summary())],
+                    want_result = Ok(_),
+                    want_dml_calls = [MockDmlHandlerCall::Write{namespace, ..}] => {
+                        assert_eq!(namespace, EXPECTED_NAMESPACE);
+                    }
+                );
+            }
+
+            mod database_with_backslash {
+                use super::*;
+                static EXPECTED_NAMESPACE: &str = "data%2Fbase/myrp";
+
+                test_write_handler!(
+                    cst_v1_rp_ok,
+                    route_string = "/write",
+                    query_string = "?db=data/base&rp=myrp",
+                    body = "platanos,tag1=A,tag2=B val=42i 123456".as_bytes(),
+                    dml_info_handler = Box::<SingleTenantRequestParser>::default(),
                     dml_handler = [Ok(summary())],
                     want_result = Ok(_),
                     want_dml_calls = [MockDmlHandlerCall::Write{namespace, ..}] => {
@@ -254,7 +272,7 @@ mod tests {
                     route_string = "/write",
                     query_string = "?db=database&rp=",
                     body = "platanos,tag1=A,tag2=B val=42i 123456".as_bytes(),
-                    dml_info_handler = &SingleTenantRequestParser,
+                    dml_info_handler = Box::<SingleTenantRequestParser>::default(),
                     dml_handler = [Ok(summary())],
                     want_result = Ok(_),
                     want_dml_calls = [MockDmlHandlerCall::Write{namespace, ..}] => {
@@ -267,7 +285,7 @@ mod tests {
                     route_string = "/write",
                     query_string = "?db=database&rp=''",
                     body = "platanos,tag1=A,tag2=B val=42i 123456".as_bytes(),
-                    dml_info_handler = &SingleTenantRequestParser,
+                    dml_info_handler = Box::<SingleTenantRequestParser>::default(),
                     dml_handler = [Ok(summary())],
                     want_result = Ok(_),
                     want_dml_calls = [MockDmlHandlerCall::Write{namespace, ..}] => {
@@ -280,7 +298,7 @@ mod tests {
                     route_string = "/write",
                     query_string = "?db=database&rp=autogen",
                     body = "platanos,tag1=A,tag2=B val=42i 123456".as_bytes(),
-                    dml_info_handler = &SingleTenantRequestParser,
+                    dml_info_handler = Box::<SingleTenantRequestParser>::default(),
                     dml_handler = [Ok(summary())],
                     want_result = Ok(_),
                     want_dml_calls = [MockDmlHandlerCall::Write{namespace, ..}] => {

--- a/router/src/server/http/write_v2.rs
+++ b/router/src/server/http/write_v2.rs
@@ -1,0 +1,572 @@
+use data_types::{NamespaceMappingError, NamespaceName};
+use hyper::Request;
+use serde::Deserialize;
+
+use crate::server::http::{
+    write_dml::{ContentEncoding, IntoWriteInfo, Precision, WriteInfo},
+    Error,
+};
+
+/// v2 DmlErrors returned when decoding the organisation / bucket information from a
+/// HTTP request and deriving the namespace name from it.
+#[derive(Debug, Error)]
+pub enum OrgBucketError {
+    /// The request contains no org/bucket destination information.
+    #[error("no org/bucket destination provided")]
+    NotSpecified,
+
+    /// The request contains invalid parameters.
+    #[error("failed to deserialize org/bucket/precision in request: {0}")]
+    DecodeFail(#[from] serde::de::value::Error),
+
+    /// The provided org/bucket could not be converted into a namespace name.
+    #[error(transparent)]
+    MappingFail(#[from] NamespaceMappingError),
+}
+
+#[derive(Debug, Deserialize)]
+/// Query Parameters for v2 DML operation.
+pub(crate) struct WriteParamsV2 {
+    pub(crate) org: String,
+    pub(crate) bucket: String,
+
+    #[serde(default)]
+    precision: Precision,
+}
+
+impl<T> TryFrom<&Request<T>> for WriteParamsV2 {
+    type Error = OrgBucketError;
+
+    fn try_from(req: &Request<T>) -> Result<Self, Self::Error> {
+        let query = req.uri().query().ok_or(OrgBucketError::NotSpecified)?;
+        let got: WriteParamsV2 = serde_urlencoded::from_str(query)?;
+
+        // An empty org or bucket is not acceptable.
+        if got.org.is_empty() || got.bucket.is_empty() {
+            return Err(OrgBucketError::NotSpecified);
+        }
+
+        Ok(got)
+    }
+}
+
+impl IntoWriteInfo for WriteParamsV2 {
+    fn into_write_info(self, namespace: NamespaceName<'_>) -> Result<WriteInfo<'_>, Error> {
+        let skip_database_creation = None;
+        let content_encoding = ContentEncoding::default();
+
+        Ok(WriteInfo {
+            namespace,
+            precision: self.precision,
+            skip_database_creation,
+            content_encoding,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        dml_handlers::{mock::MockDmlHandlerCall, DmlError},
+        server::http::{
+            write_test_helpers::{summary, MAX_BYTES, NAMESPACE_ID},
+            Error,
+        },
+    };
+    use mutable_batch::column::ColumnData;
+    use mutable_batch_lp::LineWriteError;
+    use std::iter;
+
+    macro_rules! run_v2_test_in_env {
+        ($test_scope:ident, $dml_info_handler:ident) => {
+            use $crate::{test_http_handler, test_write_handler, test_delete_handler};
+
+            paste::paste! {
+                test_write_handler!(
+                    [<$test_scope _ ok>],
+                    query_string = "?org=bananas&bucket=test",
+                    body = "platanos,tag1=A,tag2=B val=42i 123456".as_bytes(),
+                    dml_info_handler = $dml_info_handler,
+                    dml_handler = [Ok(summary())],
+                    want_result = Ok(_),
+                    want_dml_calls = [MockDmlHandlerCall::Write{namespace, ..}] => {
+                        assert_eq!(namespace, EXPECTED_NAMESPACE);
+                    }
+                );
+
+                test_write_handler!(
+                    [<$test_scope _ ok_precision_s>],
+                    query_string = "?org=bananas&bucket=test&precision=s",
+                    body = "platanos,tag1=A,tag2=B val=42i 1647622847".as_bytes(),
+                    dml_info_handler = $dml_info_handler,
+                    dml_handler = [Ok(summary())],
+                    want_result = Ok(_),
+                    want_dml_calls = [MockDmlHandlerCall::Write{namespace, namespace_id, write_input}] => {
+                        assert_eq!(namespace, EXPECTED_NAMESPACE);
+                        assert_eq!(*namespace_id, NAMESPACE_ID);
+
+                        let table = write_input.get("platanos").expect("table not found");
+                        let ts = table.timestamp_summary().expect("no timestamp summary");
+                        assert_eq!(Some(1647622847000000000), ts.stats.min);
+                    }
+                );
+
+                test_write_handler!(
+                    [<$test_scope _ ok_precision_ms>],
+                    query_string = "?org=bananas&bucket=test&precision=ms",
+                    body = "platanos,tag1=A,tag2=B val=42i 1647622847000".as_bytes(),
+                    dml_info_handler = $dml_info_handler,
+                    dml_handler = [Ok(summary())],
+                    want_result = Ok(_),
+                    want_dml_calls = [MockDmlHandlerCall::Write{namespace, namespace_id, write_input}] => {
+                        assert_eq!(namespace, EXPECTED_NAMESPACE);
+                        assert_eq!(*namespace_id, NAMESPACE_ID);
+
+                        let table = write_input.get("platanos").expect("table not found");
+                        let ts = table.timestamp_summary().expect("no timestamp summary");
+                        assert_eq!(Some(1647622847000000000), ts.stats.min);
+                    }
+                );
+
+                test_write_handler!(
+                    [<$test_scope _ ok_precision_us>],
+                    query_string = "?org=bananas&bucket=test&precision=us",
+                    body = "platanos,tag1=A,tag2=B val=42i 1647622847000000".as_bytes(),
+                    dml_info_handler = $dml_info_handler,
+                    dml_handler = [Ok(summary())],
+                    want_result = Ok(_),
+                    want_dml_calls = [MockDmlHandlerCall::Write{namespace, namespace_id, write_input}] => {
+                        assert_eq!(namespace, EXPECTED_NAMESPACE);
+                        assert_eq!(*namespace_id, NAMESPACE_ID);
+
+                        let table = write_input.get("platanos").expect("table not found");
+                        let ts = table.timestamp_summary().expect("no timestamp summary");
+                        assert_eq!(Some(1647622847000000000), ts.stats.min);
+                    }
+                );
+
+                test_write_handler!(
+                    [<$test_scope _ ok_precision_ns>],
+                    query_string = "?org=bananas&bucket=test&precision=ns",
+                    body = "platanos,tag1=A,tag2=B val=42i 1647622847000000000".as_bytes(),
+                    dml_info_handler = $dml_info_handler,
+                    dml_handler = [Ok(summary())],
+                    want_result = Ok(_),
+                    want_dml_calls = [MockDmlHandlerCall::Write{namespace, namespace_id, write_input}] => {
+                        assert_eq!(namespace, EXPECTED_NAMESPACE);
+                        assert_eq!(*namespace_id, NAMESPACE_ID);
+
+                        let table = write_input.get("platanos").expect("table not found");
+                        let ts = table.timestamp_summary().expect("no timestamp summary");
+                        assert_eq!(Some(1647622847000000000), ts.stats.min);
+                    }
+                );
+
+                test_write_handler!(
+                    [<$test_scope _ precision_overflow>],
+                    // SECONDS, so multiplies the provided timestamp by 1,000,000,000
+                    query_string = "?org=bananas&bucket=test&precision=s",
+                    body = "platanos,tag1=A,tag2=B val=42i 1647622847000000000".as_bytes(),
+                    dml_info_handler = $dml_info_handler,
+                    dml_handler = [Ok(summary())],
+                    want_result = Err(Error::ParseLineProtocol(_)),
+                    want_dml_calls = []
+                );
+
+                test_write_handler!(
+                    [<$test_scope _ no_query_params>],
+                    query_string = "",
+                    body = "platanos,tag1=A,tag2=B val=42i 123456".as_bytes(),
+                    dml_info_handler = $dml_info_handler,
+                    dml_handler = [Ok(summary())],
+                    want_result = Err(Error::InvalidOrgBucket(OrgBucketError::NotSpecified)),
+                    want_dml_calls = [] // None
+                );
+
+                test_write_handler!(
+                    [<$test_scope _ no_org_bucket>],
+                    query_string = "?",
+                    body = "platanos,tag1=A,tag2=B val=42i 123456".as_bytes(),
+                    dml_info_handler = $dml_info_handler,
+                    dml_handler = [Ok(summary())],
+                    want_result = Err(Error::InvalidOrgBucket(OrgBucketError::DecodeFail(_))),
+                    want_dml_calls = [] // None
+                );
+
+                test_write_handler!(
+                    [<$test_scope _ empty_org_bucket>],
+                    query_string = "?org=&bucket=",
+                    body = "platanos,tag1=A,tag2=B val=42i 123456".as_bytes(),
+                    dml_info_handler = $dml_info_handler,
+                    dml_handler = [Ok(summary())],
+                    want_result = Err(Error::InvalidOrgBucket(OrgBucketError::NotSpecified)),
+                    want_dml_calls = [] // None
+                );
+
+                test_write_handler!(
+                    [<$test_scope _ invalid_org_bucket>],
+                    query_string = format!("?org=test&bucket={}", "A".repeat(1000)),
+                    body = "platanos,tag1=A,tag2=B val=42i 123456".as_bytes(),
+                    dml_info_handler = $dml_info_handler,
+                    dml_handler = [Ok(summary())],
+                    want_result = Err(Error::InvalidOrgBucket(OrgBucketError::MappingFail(_))),
+                    want_dml_calls = [] // None
+                );
+
+                test_write_handler!(
+                    [<$test_scope _ invalid_line_protocol>],
+                    query_string = "?org=bananas&bucket=test",
+                    body = "not line protocol".as_bytes(),
+                    dml_info_handler = $dml_info_handler,
+                    dml_handler = [Ok(summary())],
+                    want_result = Err(Error::ParseLineProtocol(_)),
+                    want_dml_calls = [] // None
+                );
+
+                test_write_handler!(
+                    [<$test_scope _ non_utf8_body>],
+                    query_string = "?org=bananas&bucket=test",
+                    body = vec![0xc3, 0x28],
+                    dml_info_handler = $dml_info_handler,
+                    dml_handler = [Ok(summary())],
+                    want_result = Err(Error::NonUtf8Body(_)),
+                    want_dml_calls = [] // None
+                );
+
+                test_write_handler!(
+                    [<$test_scope _ max_request_size_truncation>],
+                    query_string = "?org=bananas&bucket=test",
+                    body = {
+                        // Generate a LP string in the form of:
+                        //
+                        //  bananas,A=AAAAAAAAAA(repeated)... B=42
+                        //                                  ^
+                        //                                  |
+                        //                         MAX_BYTES boundary
+                        //
+                        // So that reading MAX_BYTES number of bytes produces the string:
+                        //
+                        //  bananas,A=AAAAAAAAAA(repeated)...
+                        //
+                        // Effectively trimming off the " B=42" suffix.
+                        let body = "bananas,A=";
+                        iter::once(body)
+                            .chain(iter::repeat("A").take(MAX_BYTES - body.len()))
+                            .chain(iter::once(" B=42\n"))
+                            .flat_map(|s| s.bytes())
+                            .collect::<Vec<u8>>()
+                    },
+                    dml_info_handler = $dml_info_handler,
+                    dml_handler = [Ok(summary())],
+                    want_result = Err(Error::RequestSizeExceeded(_)),
+                    want_dml_calls = [] // None
+                );
+
+                test_write_handler!(
+                    [<$test_scope _ db_not_found>],
+                    query_string = "?org=bananas&bucket=test",
+                    body = "platanos,tag1=A,tag2=B val=42i 123456".as_bytes(),
+                    dml_info_handler = $dml_info_handler,
+                    dml_handler = [Err(DmlError::NamespaceNotFound(EXPECTED_NAMESPACE.to_string()))],
+                    want_result = Err(Error::DmlHandler(DmlError::NamespaceNotFound(_))),
+                    want_dml_calls = [MockDmlHandlerCall::Write{namespace, ..}] => {
+                        assert_eq!(namespace, EXPECTED_NAMESPACE);
+                    }
+                );
+
+                test_write_handler!(
+                    [<$test_scope _ dml_handler_error>],
+                    query_string = "?org=bananas&bucket=test",
+                    body = "platanos,tag1=A,tag2=B val=42i 123456".as_bytes(),
+                    dml_info_handler = $dml_info_handler,
+                    dml_handler = [Err(DmlError::Internal("💣".into()))],
+                    want_result = Err(Error::DmlHandler(DmlError::Internal(_))),
+                    want_dml_calls = [MockDmlHandlerCall::Write{namespace, ..}] => {
+                        assert_eq!(namespace, EXPECTED_NAMESPACE);
+                    }
+                );
+
+                test_write_handler!(
+                    [<$test_scope _ field_upsert_within_batch>],
+                    query_string = "?org=bananas&bucket=test",
+                    body = "test field=1u 100\ntest field=2u 100".as_bytes(),
+                    dml_info_handler = $dml_info_handler,
+                    dml_handler = [Ok(summary())],
+                    want_result = Ok(_),
+                    want_dml_calls = [MockDmlHandlerCall::Write{namespace, namespace_id, write_input}] => {
+                        assert_eq!(namespace, EXPECTED_NAMESPACE);
+                        assert_eq!(*namespace_id, NAMESPACE_ID);
+                        let table = write_input.get("test").expect("table not in write");
+                        let col = table.column("field").expect("column missing");
+                        assert_matches!(col.data(), ColumnData::U64(data, _) => {
+                            // Ensure both values are recorded, in the correct order.
+                            assert_eq!(data.as_slice(), [1, 2]);
+                        });
+                    }
+                );
+
+                test_write_handler!(
+                    [<$test_scope _ column_named_time>],
+                    query_string = "?org=bananas&bucket=test",
+                    body = "test field=1u,time=42u 100".as_bytes(),
+                    dml_info_handler = $dml_info_handler,
+                    dml_handler = [],
+                    want_result = Err(_),
+                    want_dml_calls = []
+                );
+
+                test_delete_handler!(
+                    [<$test_scope _ ok>],
+                    query_string = "?org=bananas&bucket=test",
+                    body = r#"{"start":"2021-04-01T14:00:00Z","stop":"2021-04-02T14:00:00Z", "predicate":"_measurement=its_a_table and location=Boston"}"#.as_bytes(),
+                    dml_info_handler = $dml_info_handler,
+                    dml_handler = [Ok(())],
+                    want_result = Ok(_),
+                    want_dml_calls = [MockDmlHandlerCall::Delete{namespace, namespace_id, table, predicate}] => {
+                        assert_eq!(table, "its_a_table");
+                        assert_eq!(namespace, EXPECTED_NAMESPACE);
+                        assert_eq!(*namespace_id, NAMESPACE_ID);
+                        assert!(!predicate.exprs.is_empty());
+                    }
+                );
+
+                test_delete_handler!(
+                    [<$test_scope _ invalid_delete_body>],
+                    query_string = "?org=bananas&bucket=test",
+                    body = r#"{wat}"#.as_bytes(),
+                    dml_info_handler = $dml_info_handler,
+                    dml_handler = [],
+                    want_result = Err(Error::ParseHttpDelete(_)),
+                    want_dml_calls = []
+                );
+
+                test_delete_handler!(
+                    [<$test_scope _ no_query_params>],
+                    query_string = "",
+                    body = "".as_bytes(),
+                    dml_info_handler = $dml_info_handler,
+                    dml_handler = [Ok(())],
+                    want_result = Err(Error::InvalidOrgBucket(OrgBucketError::NotSpecified)),
+                    want_dml_calls = [] // None
+                );
+
+                test_delete_handler!(
+                    [<$test_scope _ no_org_bucket>],
+                    query_string = "?",
+                    body = "".as_bytes(),
+                    dml_info_handler = $dml_info_handler,
+                    dml_handler = [Ok(())],
+                    want_result = Err(Error::InvalidOrgBucket(OrgBucketError::DecodeFail(_))),
+                    want_dml_calls = [] // None
+                );
+
+                test_delete_handler!(
+                    [<$test_scope _ empty_org_bucket>],
+                    query_string = "?org=&bucket=",
+                    body = "".as_bytes(),
+                    dml_info_handler = $dml_info_handler,
+                    dml_handler = [Ok(())],
+                    want_result = Err(Error::InvalidOrgBucket(OrgBucketError::NotSpecified)),
+                    want_dml_calls = [] // None
+                );
+
+                test_delete_handler!(
+                    [<$test_scope _ invalid_org_bucket>],
+                    query_string = format!("?org=test&bucket={}", "A".repeat(1000)),
+                    body = "".as_bytes(),
+                    dml_info_handler = $dml_info_handler,
+                    dml_handler = [Ok(())],
+                    want_result = Err(Error::InvalidOrgBucket(OrgBucketError::MappingFail(_))),
+                    want_dml_calls = [] // None
+                );
+
+                test_delete_handler!(
+                    [<$test_scope _ non_utf8_body>],
+                    query_string = "?org=bananas&bucket=test",
+                    body = vec![0xc3, 0x28],
+                    dml_info_handler = $dml_info_handler,
+                    dml_handler = [Ok(())],
+                    want_result = Err(Error::NonUtf8Body(_)),
+                    want_dml_calls = [] // None
+                );
+
+                test_delete_handler!(
+                    [<$test_scope _ db_not_found>],
+                    query_string = "?org=bananas&bucket=test",
+                    body = r#"{"start":"2021-04-01T14:00:00Z","stop":"2021-04-02T14:00:00Z", "predicate":"_measurement=its_a_table and location=Boston"}"#.as_bytes(),
+                    dml_info_handler = $dml_info_handler,
+                    dml_handler = [Err(DmlError::NamespaceNotFound(EXPECTED_NAMESPACE.to_string()))],
+                    want_result = Err(Error::DmlHandler(DmlError::NamespaceNotFound(_))),
+                    want_dml_calls = [MockDmlHandlerCall::Delete{namespace, namespace_id, table, predicate}] => {
+                        assert_eq!(table, "its_a_table");
+                        assert_eq!(namespace, EXPECTED_NAMESPACE);
+                        assert_eq!(*namespace_id, NAMESPACE_ID);
+                        assert!(!predicate.exprs.is_empty());
+                    }
+                );
+
+                test_delete_handler!(
+                    [<$test_scope _ dml_handler_error>],
+                    query_string = "?org=bananas&bucket=test",
+                    body = r#"{"start":"2021-04-01T14:00:00Z","stop":"2021-04-02T14:00:00Z", "predicate":"_measurement=its_a_table and location=Boston"}"#.as_bytes(),
+                    dml_info_handler = $dml_info_handler,
+                    dml_handler = [Err(DmlError::Internal("💣".into()))],
+                    want_result = Err(Error::DmlHandler(DmlError::Internal(_))),
+                    want_dml_calls = [MockDmlHandlerCall::Delete{namespace, namespace_id, table, predicate}] => {
+                        assert_eq!(table, "its_a_table");
+                        assert_eq!(namespace, EXPECTED_NAMESPACE);
+                        assert_eq!(*namespace_id, NAMESPACE_ID);
+                        assert!(!predicate.exprs.is_empty());
+                    }
+                );
+
+                test_http_handler!(
+                    [<$test_scope _ not_found>],
+                    uri = "https://bananas.example/wat",
+                    body = "".as_bytes(),
+                    dml_info_handler = $dml_info_handler,
+                    dml_write_handler = [],
+                    dml_delete_handler = [],
+                    want_result = Err(Error::NoHandler),
+                    want_dml_calls = []
+                );
+
+                // https://github.com/influxdata/influxdb_iox/issues/4326
+                mod [<issue4326 _ $test_scope>] {
+                    use super::*;
+
+                    test_write_handler!(
+                        [<$test_scope _ duplicate_fields_same_value>],
+                        query_string = "?org=bananas&bucket=test",
+                        body = "whydo InputPower=300i,InputPower=300i".as_bytes(),
+                        dml_info_handler = $dml_info_handler,
+                        dml_handler = [Ok(summary())],
+                        want_result = Ok(_),
+                        want_dml_calls = [MockDmlHandlerCall::Write{namespace, write_input, ..}] => {
+                            assert_eq!(namespace, EXPECTED_NAMESPACE);
+                            let table = write_input.get("whydo").expect("table not in write");
+                            let col = table.column("InputPower").expect("column missing");
+                            assert_matches!(col.data(), ColumnData::I64(data, _) => {
+                                // Ensure the duplicate values are coalesced.
+                                assert_eq!(data.as_slice(), [300]);
+                            });
+                        }
+                    );
+
+                    test_write_handler!(
+                        [<$test_scope _ duplicate_fields_different_value>],
+                        query_string = "?org=bananas&bucket=test",
+                        body = "whydo InputPower=300i,InputPower=42i".as_bytes(),
+                        dml_info_handler = $dml_info_handler,
+                        dml_handler = [Ok(summary())],
+                        want_result = Ok(_),
+                        want_dml_calls = [MockDmlHandlerCall::Write{namespace, write_input, ..}] => {
+                            assert_eq!(namespace, EXPECTED_NAMESPACE);
+                            let table = write_input.get("whydo").expect("table not in write");
+                            let col = table.column("InputPower").expect("column missing");
+                            assert_matches!(col.data(), ColumnData::I64(data, _) => {
+                                // Last value wins
+                                assert_eq!(data.as_slice(), [42]);
+                            });
+                        }
+                    );
+
+                    test_write_handler!(
+                        [<$test_scope _ duplicate_fields_different_type>],
+                        query_string = "?org=bananas&bucket=test",
+                        body = "whydo InputPower=300i,InputPower=4.2".as_bytes(),
+                        dml_info_handler = $dml_info_handler,
+                        dml_handler = [],
+                        want_result = Err(Error::ParseLineProtocol(mutable_batch_lp::Error::Write {
+                            source: LineWriteError::ConflictedFieldTypes { .. },
+                            ..
+                        })),
+                        want_dml_calls = []
+                    );
+
+                    test_write_handler!(
+                        [<$test_scope _ duplicate_tags_same_value>],
+                        query_string = "?org=bananas&bucket=test",
+                        body = "whydo,InputPower=300i,InputPower=300i field=42i".as_bytes(),
+                        dml_info_handler = $dml_info_handler,
+                        dml_handler = [],
+                        want_result = Err(Error::ParseLineProtocol(mutable_batch_lp::Error::Write {
+                            source: LineWriteError::DuplicateTag { .. },
+                            ..
+                        })),
+                        want_dml_calls = []
+                    );
+
+                    test_write_handler!(
+                        [<$test_scope _ duplicate_tags_different_value>],
+                        query_string = "?org=bananas&bucket=test",
+                        body = "whydo,InputPower=300i,InputPower=42i field=42i".as_bytes(),
+                        dml_info_handler = $dml_info_handler,
+                        dml_handler = [],
+                        want_result = Err(Error::ParseLineProtocol(mutable_batch_lp::Error::Write {
+                            source: LineWriteError::DuplicateTag { .. },
+                            ..
+                        })),
+                        want_dml_calls = []
+                    );
+
+                    test_write_handler!(
+                        [<$test_scope _ duplicate_tags_different_type>],
+                        query_string = "?org=bananas&bucket=test",
+                        body = "whydo,InputPower=300i,InputPower=4.2 field=42i".as_bytes(),
+                        dml_info_handler = $dml_info_handler,
+                        dml_handler = [],
+                        want_result = Err(Error::ParseLineProtocol(mutable_batch_lp::Error::Write {
+                            source: LineWriteError::DuplicateTag { .. },
+                            ..
+                        })),
+                        want_dml_calls = []
+                    );
+
+                    test_write_handler!(
+                        [<$test_scope _ duplicate_is_tag_and_field>],
+                        query_string = "?org=bananas&bucket=test",
+                        body = "whydo,InputPower=300i InputPower=300i".as_bytes(),
+                        dml_info_handler = $dml_info_handler,
+                        dml_handler = [],
+                        want_result = Err(Error::ParseLineProtocol(mutable_batch_lp::Error::Write {
+                            source: LineWriteError::MutableBatch {
+                                source: mutable_batch::writer::Error::TypeMismatch { .. }
+                            },
+                            ..
+                        })),
+                        want_dml_calls = []
+                    );
+
+                    test_write_handler!(
+                        [<$test_scope _ duplicate_is_tag_and_field_different_types>],
+                        query_string = "?org=bananas&bucket=test",
+                        body = "whydo,InputPower=300i InputPower=30.0".as_bytes(),
+                        dml_info_handler = $dml_info_handler,
+                        dml_handler = [],
+                        want_result = Err(Error::ParseLineProtocol(mutable_batch_lp::Error::Write {
+                            source: LineWriteError::MutableBatch {
+                                source: mutable_batch::writer::Error::TypeMismatch { .. }
+                            },
+                            ..
+                        })),
+                        want_dml_calls = []
+                    );
+                }
+            }
+        };
+    }
+
+    mod mt {
+        use super::*;
+        static EXPECTED_NAMESPACE: &str = "bananas_test";
+        run_v2_test_in_env!(mt, MT);
+    }
+
+    mod cst {
+        use super::*;
+        static EXPECTED_NAMESPACE: &str = "test";
+        run_v2_test_in_env!(cst, CST);
+    }
+}

--- a/router/src/server/http/write_v2.rs
+++ b/router/src/server/http/write_v2.rs
@@ -53,505 +53,550 @@ mod tests {
     use crate::{
         dml_handlers::{mock::MockDmlHandlerCall, DmlError},
         server::http::{
+            mt::MultiTenantRequestParser,
             write_test_helpers::{summary, MAX_BYTES, NAMESPACE_ID},
             Error,
         },
+        test_http_handler,
     };
     use mutable_batch::column::ColumnData;
     use mutable_batch_lp::LineWriteError;
     use std::iter;
 
-    macro_rules! run_v2_test_in_env {
-        ($test_scope:ident, $dml_info_handler:expr) => {
-            use $crate::{test_http_handler, test_write_handler, test_delete_handler};
-
+    // ensure v2 WRITE contract stays the same
+    // only namespace_name is different
+    macro_rules! run_v2_write_test_in_env {
+        (
+            $name:ident,
+            query_string = $query_string:expr,   // Request URI query string
+            body = $body:expr,                   // Request body content
+            dml_handler = $dml_handler:expr,     // DML write handler response (if called)
+            want_result = $want_result:pat,
+            want_dml_calls = $($want_dml_calls:tt )+
+        ) => {
             paste::paste! {
-                test_write_handler!(
-                    [<$test_scope _ ok>],
-                    query_string = "?org=bananas&bucket=test",
-                    body = "platanos,tag1=A,tag2=B val=42i 123456".as_bytes(),
-                    dml_info_handler = $dml_info_handler,
-                    dml_handler = [Ok(summary())],
-                    want_result = Ok(_),
-                    want_dml_calls = [MockDmlHandlerCall::Write{namespace, ..}] => {
-                        assert_eq!(namespace, EXPECTED_NAMESPACE);
-                    }
-                );
-
-                test_write_handler!(
-                    [<$test_scope _ ok_precision_s>],
-                    query_string = "?org=bananas&bucket=test&precision=s",
-                    body = "platanos,tag1=A,tag2=B val=42i 1647622847".as_bytes(),
-                    dml_info_handler = $dml_info_handler,
-                    dml_handler = [Ok(summary())],
-                    want_result = Ok(_),
-                    want_dml_calls = [MockDmlHandlerCall::Write{namespace, namespace_id, write_input}] => {
-                        assert_eq!(namespace, EXPECTED_NAMESPACE);
-                        assert_eq!(*namespace_id, NAMESPACE_ID);
-
-                        let table = write_input.get("platanos").expect("table not found");
-                        let ts = table.timestamp_summary().expect("no timestamp summary");
-                        assert_eq!(Some(1647622847000000000), ts.stats.min);
-                    }
-                );
-
-                test_write_handler!(
-                    [<$test_scope _ ok_precision_ms>],
-                    query_string = "?org=bananas&bucket=test&precision=ms",
-                    body = "platanos,tag1=A,tag2=B val=42i 1647622847000".as_bytes(),
-                    dml_info_handler = $dml_info_handler,
-                    dml_handler = [Ok(summary())],
-                    want_result = Ok(_),
-                    want_dml_calls = [MockDmlHandlerCall::Write{namespace, namespace_id, write_input}] => {
-                        assert_eq!(namespace, EXPECTED_NAMESPACE);
-                        assert_eq!(*namespace_id, NAMESPACE_ID);
-
-                        let table = write_input.get("platanos").expect("table not found");
-                        let ts = table.timestamp_summary().expect("no timestamp summary");
-                        assert_eq!(Some(1647622847000000000), ts.stats.min);
-                    }
-                );
-
-                test_write_handler!(
-                    [<$test_scope _ ok_precision_us>],
-                    query_string = "?org=bananas&bucket=test&precision=us",
-                    body = "platanos,tag1=A,tag2=B val=42i 1647622847000000".as_bytes(),
-                    dml_info_handler = $dml_info_handler,
-                    dml_handler = [Ok(summary())],
-                    want_result = Ok(_),
-                    want_dml_calls = [MockDmlHandlerCall::Write{namespace, namespace_id, write_input}] => {
-                        assert_eq!(namespace, EXPECTED_NAMESPACE);
-                        assert_eq!(*namespace_id, NAMESPACE_ID);
-
-                        let table = write_input.get("platanos").expect("table not found");
-                        let ts = table.timestamp_summary().expect("no timestamp summary");
-                        assert_eq!(Some(1647622847000000000), ts.stats.min);
-                    }
-                );
-
-                test_write_handler!(
-                    [<$test_scope _ ok_precision_ns>],
-                    query_string = "?org=bananas&bucket=test&precision=ns",
-                    body = "platanos,tag1=A,tag2=B val=42i 1647622847000000000".as_bytes(),
-                    dml_info_handler = $dml_info_handler,
-                    dml_handler = [Ok(summary())],
-                    want_result = Ok(_),
-                    want_dml_calls = [MockDmlHandlerCall::Write{namespace, namespace_id, write_input}] => {
-                        assert_eq!(namespace, EXPECTED_NAMESPACE);
-                        assert_eq!(*namespace_id, NAMESPACE_ID);
-
-                        let table = write_input.get("platanos").expect("table not found");
-                        let ts = table.timestamp_summary().expect("no timestamp summary");
-                        assert_eq!(Some(1647622847000000000), ts.stats.min);
-                    }
-                );
-
-                test_write_handler!(
-                    [<$test_scope _ precision_overflow>],
-                    // SECONDS, so multiplies the provided timestamp by 1,000,000,000
-                    query_string = "?org=bananas&bucket=test&precision=s",
-                    body = "platanos,tag1=A,tag2=B val=42i 1647622847000000000".as_bytes(),
-                    dml_info_handler = $dml_info_handler,
-                    dml_handler = [Ok(summary())],
-                    want_result = Err(Error::ParseLineProtocol(_)),
-                    want_dml_calls = []
-                );
-
-                test_write_handler!(
-                    [<$test_scope _ no_query_params>],
-                    query_string = "",
-                    body = "platanos,tag1=A,tag2=B val=42i 123456".as_bytes(),
-                    dml_info_handler = $dml_info_handler,
-                    dml_handler = [Ok(summary())],
-                    want_result = Err(Error::InvalidOrgBucket(OrgBucketError::NotSpecified)),
-                    want_dml_calls = [] // None
-                );
-
-                test_write_handler!(
-                    [<$test_scope _ no_org_bucket>],
-                    query_string = "?",
-                    body = "platanos,tag1=A,tag2=B val=42i 123456".as_bytes(),
-                    dml_info_handler = $dml_info_handler,
-                    dml_handler = [Ok(summary())],
-                    want_result = Err(Error::InvalidOrgBucket(OrgBucketError::DecodeFail(_))),
-                    want_dml_calls = [] // None
-                );
-
-                test_write_handler!(
-                    [<$test_scope _ empty_org_bucket>],
-                    query_string = "?org=&bucket=",
-                    body = "platanos,tag1=A,tag2=B val=42i 123456".as_bytes(),
-                    dml_info_handler = $dml_info_handler,
-                    dml_handler = [Ok(summary())],
-                    want_result = Err(Error::InvalidOrgBucket(OrgBucketError::NotSpecified)),
-                    want_dml_calls = [] // None
-                );
-
-                test_write_handler!(
-                    [<$test_scope _ invalid_org_bucket>],
-                    query_string = format!("?org=test&bucket={}", "A".repeat(1000)),
-                    body = "platanos,tag1=A,tag2=B val=42i 123456".as_bytes(),
-                    dml_info_handler = $dml_info_handler,
-                    dml_handler = [Ok(summary())],
-                    want_result = Err(Error::InvalidOrgBucket(OrgBucketError::MappingFail(_))),
-                    want_dml_calls = [] // None
-                );
-
-                test_write_handler!(
-                    [<$test_scope _ invalid_line_protocol>],
-                    query_string = "?org=bananas&bucket=test",
-                    body = "not line protocol".as_bytes(),
-                    dml_info_handler = $dml_info_handler,
-                    dml_handler = [Ok(summary())],
-                    want_result = Err(Error::ParseLineProtocol(_)),
-                    want_dml_calls = [] // None
-                );
-
-                test_write_handler!(
-                    [<$test_scope _ non_utf8_body>],
-                    query_string = "?org=bananas&bucket=test",
-                    body = vec![0xc3, 0x28],
-                    dml_info_handler = $dml_info_handler,
-                    dml_handler = [Ok(summary())],
-                    want_result = Err(Error::NonUtf8Body(_)),
-                    want_dml_calls = [] // None
-                );
-
-                test_write_handler!(
-                    [<$test_scope _ max_request_size_truncation>],
-                    query_string = "?org=bananas&bucket=test",
-                    body = {
-                        // Generate a LP string in the form of:
-                        //
-                        //  bananas,A=AAAAAAAAAA(repeated)... B=42
-                        //                                  ^
-                        //                                  |
-                        //                         MAX_BYTES boundary
-                        //
-                        // So that reading MAX_BYTES number of bytes produces the string:
-                        //
-                        //  bananas,A=AAAAAAAAAA(repeated)...
-                        //
-                        // Effectively trimming off the " B=42" suffix.
-                        let body = "bananas,A=";
-                        iter::once(body)
-                            .chain(iter::repeat("A").take(MAX_BYTES - body.len()))
-                            .chain(iter::once(" B=42\n"))
-                            .flat_map(|s| s.bytes())
-                            .collect::<Vec<u8>>()
-                    },
-                    dml_info_handler = $dml_info_handler,
-                    dml_handler = [Ok(summary())],
-                    want_result = Err(Error::RequestSizeExceeded(_)),
-                    want_dml_calls = [] // None
-                );
-
-                test_write_handler!(
-                    [<$test_scope _ db_not_found>],
-                    query_string = "?org=bananas&bucket=test",
-                    body = "platanos,tag1=A,tag2=B val=42i 123456".as_bytes(),
-                    dml_info_handler = $dml_info_handler,
-                    dml_handler = [Err(DmlError::NamespaceNotFound(EXPECTED_NAMESPACE.to_string()))],
-                    want_result = Err(Error::DmlHandler(DmlError::NamespaceNotFound(_))),
-                    want_dml_calls = [MockDmlHandlerCall::Write{namespace, ..}] => {
-                        assert_eq!(namespace, EXPECTED_NAMESPACE);
-                    }
-                );
-
-                test_write_handler!(
-                    [<$test_scope _ dml_handler_error>],
-                    query_string = "?org=bananas&bucket=test",
-                    body = "platanos,tag1=A,tag2=B val=42i 123456".as_bytes(),
-                    dml_info_handler = $dml_info_handler,
-                    dml_handler = [Err(DmlError::Internal("💣".into()))],
-                    want_result = Err(Error::DmlHandler(DmlError::Internal(_))),
-                    want_dml_calls = [MockDmlHandlerCall::Write{namespace, ..}] => {
-                        assert_eq!(namespace, EXPECTED_NAMESPACE);
-                    }
-                );
-
-                test_write_handler!(
-                    [<$test_scope _ field_upsert_within_batch>],
-                    query_string = "?org=bananas&bucket=test",
-                    body = "test field=1u 100\ntest field=2u 100".as_bytes(),
-                    dml_info_handler = $dml_info_handler,
-                    dml_handler = [Ok(summary())],
-                    want_result = Ok(_),
-                    want_dml_calls = [MockDmlHandlerCall::Write{namespace, namespace_id, write_input}] => {
-                        assert_eq!(namespace, EXPECTED_NAMESPACE);
-                        assert_eq!(*namespace_id, NAMESPACE_ID);
-                        let table = write_input.get("test").expect("table not in write");
-                        let col = table.column("field").expect("column missing");
-                        assert_matches!(col.data(), ColumnData::U64(data, _) => {
-                            // Ensure both values are recorded, in the correct order.
-                            assert_eq!(data.as_slice(), [1, 2]);
-                        });
-                    }
-                );
-
-                test_write_handler!(
-                    [<$test_scope _ column_named_time>],
-                    query_string = "?org=bananas&bucket=test",
-                    body = "test field=1u,time=42u 100".as_bytes(),
-                    dml_info_handler = $dml_info_handler,
-                    dml_handler = [],
-                    want_result = Err(_),
-                    want_dml_calls = []
-                );
-
-                test_delete_handler!(
-                    [<$test_scope _ ok>],
-                    query_string = "?org=bananas&bucket=test",
-                    body = r#"{"start":"2021-04-01T14:00:00Z","stop":"2021-04-02T14:00:00Z", "predicate":"_measurement=its_a_table and location=Boston"}"#.as_bytes(),
-                    dml_info_handler = $dml_info_handler,
-                    dml_handler = [Ok(())],
-                    want_result = Ok(_),
-                    want_dml_calls = [MockDmlHandlerCall::Delete{namespace, namespace_id, table, predicate}] => {
-                        assert_eq!(table, "its_a_table");
-                        assert_eq!(namespace, EXPECTED_NAMESPACE);
-                        assert_eq!(*namespace_id, NAMESPACE_ID);
-                        assert!(!predicate.exprs.is_empty());
-                    }
-                );
-
-                test_delete_handler!(
-                    [<$test_scope _ invalid_delete_body>],
-                    query_string = "?org=bananas&bucket=test",
-                    body = r#"{wat}"#.as_bytes(),
-                    dml_info_handler = $dml_info_handler,
-                    dml_handler = [],
-                    want_result = Err(Error::ParseHttpDelete(_)),
-                    want_dml_calls = []
-                );
-
-                test_delete_handler!(
-                    [<$test_scope _ no_query_params>],
-                    query_string = "",
-                    body = "".as_bytes(),
-                    dml_info_handler = $dml_info_handler,
-                    dml_handler = [Ok(())],
-                    want_result = Err(Error::InvalidOrgBucket(OrgBucketError::NotSpecified)),
-                    want_dml_calls = [] // None
-                );
-
-                test_delete_handler!(
-                    [<$test_scope _ no_org_bucket>],
-                    query_string = "?",
-                    body = "".as_bytes(),
-                    dml_info_handler = $dml_info_handler,
-                    dml_handler = [Ok(())],
-                    want_result = Err(Error::InvalidOrgBucket(OrgBucketError::DecodeFail(_))),
-                    want_dml_calls = [] // None
-                );
-
-                test_delete_handler!(
-                    [<$test_scope _ empty_org_bucket>],
-                    query_string = "?org=&bucket=",
-                    body = "".as_bytes(),
-                    dml_info_handler = $dml_info_handler,
-                    dml_handler = [Ok(())],
-                    want_result = Err(Error::InvalidOrgBucket(OrgBucketError::NotSpecified)),
-                    want_dml_calls = [] // None
-                );
-
-                test_delete_handler!(
-                    [<$test_scope _ invalid_org_bucket>],
-                    query_string = format!("?org=test&bucket={}", "A".repeat(1000)),
-                    body = "".as_bytes(),
-                    dml_info_handler = $dml_info_handler,
-                    dml_handler = [Ok(())],
-                    want_result = Err(Error::InvalidOrgBucket(OrgBucketError::MappingFail(_))),
-                    want_dml_calls = [] // None
-                );
-
-                test_delete_handler!(
-                    [<$test_scope _ non_utf8_body>],
-                    query_string = "?org=bananas&bucket=test",
-                    body = vec![0xc3, 0x28],
-                    dml_info_handler = $dml_info_handler,
-                    dml_handler = [Ok(())],
-                    want_result = Err(Error::NonUtf8Body(_)),
-                    want_dml_calls = [] // None
-                );
-
-                test_delete_handler!(
-                    [<$test_scope _ db_not_found>],
-                    query_string = "?org=bananas&bucket=test",
-                    body = r#"{"start":"2021-04-01T14:00:00Z","stop":"2021-04-02T14:00:00Z", "predicate":"_measurement=its_a_table and location=Boston"}"#.as_bytes(),
-                    dml_info_handler = $dml_info_handler,
-                    dml_handler = [Err(DmlError::NamespaceNotFound(EXPECTED_NAMESPACE.to_string()))],
-                    want_result = Err(Error::DmlHandler(DmlError::NamespaceNotFound(_))),
-                    want_dml_calls = [MockDmlHandlerCall::Delete{namespace, namespace_id, table, predicate}] => {
-                        assert_eq!(table, "its_a_table");
-                        assert_eq!(namespace, EXPECTED_NAMESPACE);
-                        assert_eq!(*namespace_id, NAMESPACE_ID);
-                        assert!(!predicate.exprs.is_empty());
-                    }
-                );
-
-                test_delete_handler!(
-                    [<$test_scope _ dml_handler_error>],
-                    query_string = "?org=bananas&bucket=test",
-                    body = r#"{"start":"2021-04-01T14:00:00Z","stop":"2021-04-02T14:00:00Z", "predicate":"_measurement=its_a_table and location=Boston"}"#.as_bytes(),
-                    dml_info_handler = $dml_info_handler,
-                    dml_handler = [Err(DmlError::Internal("💣".into()))],
-                    want_result = Err(Error::DmlHandler(DmlError::Internal(_))),
-                    want_dml_calls = [MockDmlHandlerCall::Delete{namespace, namespace_id, table, predicate}] => {
-                        assert_eq!(table, "its_a_table");
-                        assert_eq!(namespace, EXPECTED_NAMESPACE);
-                        assert_eq!(*namespace_id, NAMESPACE_ID);
-                        assert!(!predicate.exprs.is_empty());
-                    }
-                );
-
-                test_http_handler!(
-                    [<$test_scope _ not_found>],
-                    uri = "https://bananas.example/wat",
-                    body = "".as_bytes(),
-                    dml_info_handler = $dml_info_handler,
-                    dml_write_handler = [],
-                    dml_delete_handler = [],
-                    want_result = Err(Error::NoHandler),
-                    want_dml_calls = []
-                );
-
-                // https://github.com/influxdata/influxdb_iox/issues/4326
-                mod [<issue4326 _ $test_scope>] {
+                mod [<mt_write_ $name>] {
                     use super::*;
+                    use $crate::test_mt_handler;
+                    #[allow(unused)]
+                    static EXPECTED_NAMESPACE: &str = "bananas_test";
 
-                    test_write_handler!(
-                        [<$test_scope _ duplicate_fields_same_value>],
-                        query_string = "?org=bananas&bucket=test",
-                        body = "whydo InputPower=300i,InputPower=300i".as_bytes(),
-                        dml_info_handler = $dml_info_handler,
-                        dml_handler = [Ok(summary())],
-                        want_result = Ok(_),
-                        want_dml_calls = [MockDmlHandlerCall::Write{namespace, write_input, ..}] => {
-                            assert_eq!(namespace, EXPECTED_NAMESPACE);
-                            let table = write_input.get("whydo").expect("table not in write");
-                            let col = table.column("InputPower").expect("column missing");
-                            assert_matches!(col.data(), ColumnData::I64(data, _) => {
-                                // Ensure the duplicate values are coalesced.
-                                assert_eq!(data.as_slice(), [300]);
-                            });
-                        }
+                    test_mt_handler!(
+                        $name,
+                        route_string = "/api/v2/write",
+                        query_string = $query_string,
+                        body = $body,
+                        dml_write_handler = $dml_handler,
+                        want_result = $want_result,
+                        want_dml_calls = $($want_dml_calls)+
                     );
+                }
 
-                    test_write_handler!(
-                        [<$test_scope _ duplicate_fields_different_value>],
-                        query_string = "?org=bananas&bucket=test",
-                        body = "whydo InputPower=300i,InputPower=42i".as_bytes(),
-                        dml_info_handler = $dml_info_handler,
-                        dml_handler = [Ok(summary())],
-                        want_result = Ok(_),
-                        want_dml_calls = [MockDmlHandlerCall::Write{namespace, write_input, ..}] => {
-                            assert_eq!(namespace, EXPECTED_NAMESPACE);
-                            let table = write_input.get("whydo").expect("table not in write");
-                            let col = table.column("InputPower").expect("column missing");
-                            assert_matches!(col.data(), ColumnData::I64(data, _) => {
-                                // Last value wins
-                                assert_eq!(data.as_slice(), [42]);
-                            });
-                        }
-                    );
+                mod [<cst_write_ $name>] {
+                    use super::*;
+                    use $crate::test_cst_handler;
+                    #[allow(unused)]
+                    static EXPECTED_NAMESPACE: &str = "test";
 
-                    test_write_handler!(
-                        [<$test_scope _ duplicate_fields_different_type>],
-                        query_string = "?org=bananas&bucket=test",
-                        body = "whydo InputPower=300i,InputPower=4.2".as_bytes(),
-                        dml_info_handler = $dml_info_handler,
-                        dml_handler = [],
-                        want_result = Err(Error::ParseLineProtocol(mutable_batch_lp::Error::Write {
-                            source: LineWriteError::ConflictedFieldTypes { .. },
-                            ..
-                        })),
-                        want_dml_calls = []
-                    );
-
-                    test_write_handler!(
-                        [<$test_scope _ duplicate_tags_same_value>],
-                        query_string = "?org=bananas&bucket=test",
-                        body = "whydo,InputPower=300i,InputPower=300i field=42i".as_bytes(),
-                        dml_info_handler = $dml_info_handler,
-                        dml_handler = [],
-                        want_result = Err(Error::ParseLineProtocol(mutable_batch_lp::Error::Write {
-                            source: LineWriteError::DuplicateTag { .. },
-                            ..
-                        })),
-                        want_dml_calls = []
-                    );
-
-                    test_write_handler!(
-                        [<$test_scope _ duplicate_tags_different_value>],
-                        query_string = "?org=bananas&bucket=test",
-                        body = "whydo,InputPower=300i,InputPower=42i field=42i".as_bytes(),
-                        dml_info_handler = $dml_info_handler,
-                        dml_handler = [],
-                        want_result = Err(Error::ParseLineProtocol(mutable_batch_lp::Error::Write {
-                            source: LineWriteError::DuplicateTag { .. },
-                            ..
-                        })),
-                        want_dml_calls = []
-                    );
-
-                    test_write_handler!(
-                        [<$test_scope _ duplicate_tags_different_type>],
-                        query_string = "?org=bananas&bucket=test",
-                        body = "whydo,InputPower=300i,InputPower=4.2 field=42i".as_bytes(),
-                        dml_info_handler = $dml_info_handler,
-                        dml_handler = [],
-                        want_result = Err(Error::ParseLineProtocol(mutable_batch_lp::Error::Write {
-                            source: LineWriteError::DuplicateTag { .. },
-                            ..
-                        })),
-                        want_dml_calls = []
-                    );
-
-                    test_write_handler!(
-                        [<$test_scope _ duplicate_is_tag_and_field>],
-                        query_string = "?org=bananas&bucket=test",
-                        body = "whydo,InputPower=300i InputPower=300i".as_bytes(),
-                        dml_info_handler = $dml_info_handler,
-                        dml_handler = [],
-                        want_result = Err(Error::ParseLineProtocol(mutable_batch_lp::Error::Write {
-                            source: LineWriteError::MutableBatch {
-                                source: mutable_batch::writer::Error::TypeMismatch { .. }
-                            },
-                            ..
-                        })),
-                        want_dml_calls = []
-                    );
-
-                    test_write_handler!(
-                        [<$test_scope _ duplicate_is_tag_and_field_different_types>],
-                        query_string = "?org=bananas&bucket=test",
-                        body = "whydo,InputPower=300i InputPower=30.0".as_bytes(),
-                        dml_info_handler = $dml_info_handler,
-                        dml_handler = [],
-                        want_result = Err(Error::ParseLineProtocol(mutable_batch_lp::Error::Write {
-                            source: LineWriteError::MutableBatch {
-                                source: mutable_batch::writer::Error::TypeMismatch { .. }
-                            },
-                            ..
-                        })),
-                        want_dml_calls = []
+                    test_cst_handler!(
+                        $name,
+                        route_string = "/api/v2/write",
+                        query_string = $query_string,
+                        body = $body,
+                        dml_write_handler = $dml_handler,
+                        want_result = $want_result,
+                        want_dml_calls = $($want_dml_calls)+
                     );
                 }
             }
         };
     }
 
-    mod mt {
-        use super::*;
-        use crate::server::http::mt::MultiTenantRequestParser;
-        static EXPECTED_NAMESPACE: &str = "bananas_test";
-        run_v2_test_in_env!(mt, Box::<MultiTenantRequestParser>::default());
+    // ensure v2 DELETE contract stays the same
+    // only namespace_name is different
+    macro_rules! run_v2_delete_test_in_env {
+        (
+            $name:ident,
+            query_string = $query_string:expr,   // Request URI query string
+            body = $body:expr,                   // Request body content
+            dml_handler = $dml_handler:expr,     // DML write handler response (if called)
+            want_result = $want_result:pat,
+            want_dml_calls = $($want_dml_calls:tt )+
+        ) => {
+            paste::paste! {
+                mod [<mt_delete_ $name>] {
+                    use super::*;
+                    use $crate::test_mt_handler;
+                    #[allow(unused)]
+                    static EXPECTED_NAMESPACE: &str = "bananas_test";
+
+                    test_mt_handler!(
+                        $name,
+                        route_string = "/api/v2/delete",
+                        query_string = $query_string,
+                        body = $body,
+                        dml_delete_handler = $dml_handler,
+                        want_result = $want_result,
+                        want_dml_calls = $($want_dml_calls)+
+                    );
+                }
+
+                mod [<cst_delete_ $name>] {
+                    use super::*;
+                    use $crate::test_cst_handler;
+                    #[allow(unused)]
+                    static EXPECTED_NAMESPACE: &str = "test";
+
+                    test_cst_handler!(
+                        $name,
+                        route_string = "/api/v2/delete",
+                        query_string = $query_string,
+                        body = $body,
+                        dml_delete_handler = $dml_handler,
+                        want_result = $want_result,
+                        want_dml_calls = $($want_dml_calls)+
+                    );
+                }
+            }
+        };
     }
 
-    mod cst {
+    run_v2_write_test_in_env!(
+        ok,
+        query_string = "?org=bananas&bucket=test",
+        body = "platanos,tag1=A,tag2=B val=42i 123456".as_bytes(),
+        dml_handler = [Ok(summary())],
+        want_result = Ok(_),
+        want_dml_calls = [MockDmlHandlerCall::Write{namespace, ..}] => {
+            assert_eq!(namespace, EXPECTED_NAMESPACE);
+        }
+    );
+
+    run_v2_write_test_in_env!(
+        ok_precision_s,
+        query_string = "?org=bananas&bucket=test&precision=s",
+        body = "platanos,tag1=A,tag2=B val=42i 1647622847".as_bytes(),
+        dml_handler = [Ok(summary())],
+        want_result = Ok(_),
+        want_dml_calls = [MockDmlHandlerCall::Write{namespace, namespace_id, write_input}] => {
+            assert_eq!(namespace, EXPECTED_NAMESPACE);
+            assert_eq!(*namespace_id, NAMESPACE_ID);
+
+            let table = write_input.get("platanos").expect("table not found");
+            let ts = table.timestamp_summary().expect("no timestamp summary");
+            assert_eq!(Some(1647622847000000000), ts.stats.min);
+        }
+    );
+
+    run_v2_write_test_in_env!(
+        ok_precision_ms,
+        query_string = "?org=bananas&bucket=test&precision=ms",
+        body = "platanos,tag1=A,tag2=B val=42i 1647622847000".as_bytes(),
+        dml_handler = [Ok(summary())],
+        want_result = Ok(_),
+        want_dml_calls = [MockDmlHandlerCall::Write{namespace, namespace_id, write_input}] => {
+            assert_eq!(namespace, EXPECTED_NAMESPACE);
+            assert_eq!(*namespace_id, NAMESPACE_ID);
+
+            let table = write_input.get("platanos").expect("table not found");
+            let ts = table.timestamp_summary().expect("no timestamp summary");
+            assert_eq!(Some(1647622847000000000), ts.stats.min);
+        }
+    );
+
+    run_v2_write_test_in_env!(
+        ok_precision_us,
+        query_string = "?org=bananas&bucket=test&precision=us",
+        body = "platanos,tag1=A,tag2=B val=42i 1647622847000000".as_bytes(),
+        dml_handler = [Ok(summary())],
+        want_result = Ok(_),
+        want_dml_calls = [MockDmlHandlerCall::Write{namespace, namespace_id, write_input}] => {
+            assert_eq!(namespace, EXPECTED_NAMESPACE);
+            assert_eq!(*namespace_id, NAMESPACE_ID);
+
+            let table = write_input.get("platanos").expect("table not found");
+            let ts = table.timestamp_summary().expect("no timestamp summary");
+            assert_eq!(Some(1647622847000000000), ts.stats.min);
+        }
+    );
+
+    run_v2_write_test_in_env!(
+        ok_precision_ns,
+        query_string = "?org=bananas&bucket=test&precision=ns",
+        body = "platanos,tag1=A,tag2=B val=42i 1647622847000000000".as_bytes(),
+        dml_handler = [Ok(summary())],
+        want_result = Ok(_),
+        want_dml_calls = [MockDmlHandlerCall::Write{namespace, namespace_id, write_input}] => {
+            assert_eq!(namespace, EXPECTED_NAMESPACE);
+            assert_eq!(*namespace_id, NAMESPACE_ID);
+
+            let table = write_input.get("platanos").expect("table not found");
+            let ts = table.timestamp_summary().expect("no timestamp summary");
+            assert_eq!(Some(1647622847000000000), ts.stats.min);
+        }
+    );
+
+    run_v2_write_test_in_env!(
+        precision_overflow,
+        // SECONDS, so multiplies the provided timestamp by 1,000,000,000
+        query_string = "?org=bananas&bucket=test&precision=s",
+        body = "platanos,tag1=A,tag2=B val=42i 1647622847000000000".as_bytes(),
+        dml_handler = [Ok(summary())],
+        want_result = Err(Error::ParseLineProtocol(_)),
+        want_dml_calls = []
+    );
+
+    run_v2_write_test_in_env!(
+        no_query_params,
+        query_string = "",
+        body = "platanos,tag1=A,tag2=B val=42i 123456".as_bytes(),
+        dml_handler = [Ok(summary())],
+        want_result = Err(Error::InvalidOrgBucket(OrgBucketError::NotSpecified)),
+        want_dml_calls = [] // None
+    );
+
+    run_v2_write_test_in_env!(
+        no_org_bucket,
+        query_string = "?",
+        body = "platanos,tag1=A,tag2=B val=42i 123456".as_bytes(),
+        dml_handler = [Ok(summary())],
+        want_result = Err(Error::InvalidOrgBucket(OrgBucketError::DecodeFail(_))),
+        want_dml_calls = [] // None
+    );
+
+    run_v2_write_test_in_env!(
+        empty_org_bucket,
+        query_string = "?org=&bucket=",
+        body = "platanos,tag1=A,tag2=B val=42i 123456".as_bytes(),
+        dml_handler = [Ok(summary())],
+        want_result = Err(Error::InvalidOrgBucket(OrgBucketError::NotSpecified)),
+        want_dml_calls = [] // None
+    );
+
+    run_v2_write_test_in_env!(
+        invalid_org_bucket,
+        query_string = format!("?org=test&bucket={}", "A".repeat(1000)),
+        body = "platanos,tag1=A,tag2=B val=42i 123456".as_bytes(),
+        dml_handler = [Ok(summary())],
+        want_result = Err(Error::InvalidOrgBucket(OrgBucketError::MappingFail(_))),
+        want_dml_calls = [] // None
+    );
+
+    run_v2_write_test_in_env!(
+        invalid_line_protocol,
+        query_string = "?org=bananas&bucket=test",
+        body = "not line protocol".as_bytes(),
+        dml_handler = [Ok(summary())],
+        want_result = Err(Error::ParseLineProtocol(_)),
+        want_dml_calls = [] // None
+    );
+
+    run_v2_write_test_in_env!(
+        non_utf8_body,
+        query_string = "?org=bananas&bucket=test",
+        body = vec![0xc3, 0x28],
+        dml_handler = [Ok(summary())],
+        want_result = Err(Error::NonUtf8Body(_)),
+        want_dml_calls = [] // None
+    );
+
+    run_v2_write_test_in_env!(
+        max_request_size_truncation,
+        query_string = "?org=bananas&bucket=test",
+        body = {
+            // Generate a LP string in the form of:
+            //
+            //  bananas,A=AAAAAAAAAA(repeated)... B=42
+            //                                  ^
+            //                                  |
+            //                         MAX_BYTES boundary
+            //
+            // So that reading MAX_BYTES number of bytes produces the string:
+            //
+            //  bananas,A=AAAAAAAAAA(repeated)...
+            //
+            // Effectively trimming off the " B=42" suffix.
+            let body = "bananas,A=";
+            iter::once(body)
+                .chain(iter::repeat("A").take(MAX_BYTES - body.len()))
+                .chain(iter::once(" B=42\n"))
+                .flat_map(|s| s.bytes())
+                .collect::<Vec<u8>>()
+        },
+        dml_handler = [Ok(summary())],
+        want_result = Err(Error::RequestSizeExceeded(_)),
+        want_dml_calls = [] // None
+    );
+
+    run_v2_write_test_in_env!(
+        db_not_found,
+        query_string = "?org=bananas&bucket=test",
+        body = "platanos,tag1=A,tag2=B val=42i 123456".as_bytes(),
+        dml_handler = [Err(DmlError::NamespaceNotFound(EXPECTED_NAMESPACE.to_string()))],
+        want_result = Err(Error::DmlHandler(DmlError::NamespaceNotFound(_))),
+        want_dml_calls = [MockDmlHandlerCall::Write{namespace, ..}] => {
+            assert_eq!(namespace, EXPECTED_NAMESPACE);
+        }
+    );
+
+    run_v2_write_test_in_env!(
+        dml_handler_error,
+        query_string = "?org=bananas&bucket=test",
+        body = "platanos,tag1=A,tag2=B val=42i 123456".as_bytes(),
+        dml_handler = [Err(DmlError::Internal("💣".into()))],
+        want_result = Err(Error::DmlHandler(DmlError::Internal(_))),
+        want_dml_calls = [MockDmlHandlerCall::Write{namespace, ..}] => {
+            assert_eq!(namespace, EXPECTED_NAMESPACE);
+        }
+    );
+
+    run_v2_write_test_in_env!(
+        field_upsert_within_batch,
+        query_string = "?org=bananas&bucket=test",
+        body = "test field=1u 100\ntest field=2u 100".as_bytes(),
+        dml_handler = [Ok(summary())],
+        want_result = Ok(_),
+        want_dml_calls = [MockDmlHandlerCall::Write{namespace, namespace_id, write_input}] => {
+            assert_eq!(namespace, EXPECTED_NAMESPACE);
+            assert_eq!(*namespace_id, NAMESPACE_ID);
+            let table = write_input.get("test").expect("table not in write");
+            let col = table.column("field").expect("column missing");
+            assert_matches!(col.data(), ColumnData::U64(data, _) => {
+                // Ensure both values are recorded, in the correct order.
+                assert_eq!(data.as_slice(), [1, 2]);
+            });
+        }
+    );
+
+    run_v2_write_test_in_env!(
+        column_named_time,
+        query_string = "?org=bananas&bucket=test",
+        body = "test field=1u,time=42u 100".as_bytes(),
+        dml_handler = [],
+        want_result = Err(_),
+        want_dml_calls = []
+    );
+
+    run_v2_delete_test_in_env!(
+        ok,
+        query_string = "?org=bananas&bucket=test",
+        body = r#"{"start":"2021-04-01T14:00:00Z","stop":"2021-04-02T14:00:00Z", "predicate":"_measurement=its_a_table and location=Boston"}"#.as_bytes(),
+        dml_handler = [Ok(())],
+        want_result = Ok(_),
+        want_dml_calls = [MockDmlHandlerCall::Delete{namespace, namespace_id, table, predicate}] => {
+            assert_eq!(table, "its_a_table");
+            assert_eq!(namespace, EXPECTED_NAMESPACE);
+            assert_eq!(*namespace_id, NAMESPACE_ID);
+            assert!(!predicate.exprs.is_empty());
+        }
+    );
+
+    run_v2_delete_test_in_env!(
+        invalid_delete_body,
+        query_string = "?org=bananas&bucket=test",
+        body = r#"{wat}"#.as_bytes(),
+        dml_handler = [],
+        want_result = Err(Error::ParseHttpDelete(_)),
+        want_dml_calls = []
+    );
+
+    run_v2_delete_test_in_env!(
+        no_query_params,
+        query_string = "",
+        body = "".as_bytes(),
+        dml_handler = [Ok(())],
+        want_result = Err(Error::InvalidOrgBucket(OrgBucketError::NotSpecified)),
+        want_dml_calls = [] // None
+    );
+
+    run_v2_delete_test_in_env!(
+        no_org_bucket,
+        query_string = "?",
+        body = "".as_bytes(),
+        dml_handler = [Ok(())],
+        want_result = Err(Error::InvalidOrgBucket(OrgBucketError::DecodeFail(_))),
+        want_dml_calls = [] // None
+    );
+
+    run_v2_delete_test_in_env!(
+        empty_org_bucket,
+        query_string = "?org=&bucket=",
+        body = "".as_bytes(),
+        dml_handler = [Ok(())],
+        want_result = Err(Error::InvalidOrgBucket(OrgBucketError::NotSpecified)),
+        want_dml_calls = [] // None
+    );
+
+    run_v2_delete_test_in_env!(
+        invalid_org_bucket,
+        query_string = format!("?org=test&bucket={}", "A".repeat(1000)),
+        body = "".as_bytes(),
+        dml_handler = [Ok(())],
+        want_result = Err(Error::InvalidOrgBucket(OrgBucketError::MappingFail(_))),
+        want_dml_calls = [] // None
+    );
+
+    run_v2_delete_test_in_env!(
+        non_utf8_body,
+        query_string = "?org=bananas&bucket=test",
+        body = vec![0xc3, 0x28],
+        dml_handler = [Ok(())],
+        want_result = Err(Error::NonUtf8Body(_)),
+        want_dml_calls = [] // None
+    );
+
+    run_v2_delete_test_in_env!(
+        db_not_found,
+        query_string = "?org=bananas&bucket=test",
+        body = r#"{"start":"2021-04-01T14:00:00Z","stop":"2021-04-02T14:00:00Z", "predicate":"_measurement=its_a_table and location=Boston"}"#.as_bytes(),
+        dml_handler = [Err(DmlError::NamespaceNotFound(EXPECTED_NAMESPACE.to_string()))],
+        want_result = Err(Error::DmlHandler(DmlError::NamespaceNotFound(_))),
+        want_dml_calls = [MockDmlHandlerCall::Delete{namespace, namespace_id, table, predicate}] => {
+            assert_eq!(table, "its_a_table");
+            assert_eq!(namespace, EXPECTED_NAMESPACE);
+            assert_eq!(*namespace_id, NAMESPACE_ID);
+            assert!(!predicate.exprs.is_empty());
+        }
+    );
+
+    run_v2_delete_test_in_env!(
+        dml_handler_error,
+        query_string = "?org=bananas&bucket=test",
+        body = r#"{"start":"2021-04-01T14:00:00Z","stop":"2021-04-02T14:00:00Z", "predicate":"_measurement=its_a_table and location=Boston"}"#.as_bytes(),
+        dml_handler = [Err(DmlError::Internal("💣".into()))],
+        want_result = Err(Error::DmlHandler(DmlError::Internal(_))),
+        want_dml_calls = [MockDmlHandlerCall::Delete{namespace, namespace_id, table, predicate}] => {
+            assert_eq!(table, "its_a_table");
+            assert_eq!(namespace, EXPECTED_NAMESPACE);
+            assert_eq!(*namespace_id, NAMESPACE_ID);
+            assert!(!predicate.exprs.is_empty());
+        }
+    );
+
+    test_http_handler!(
+        not_found,
+        uri = "https://bananas.example/wat",
+        body = "".as_bytes(),
+        auth_handler = None,
+        dml_info_handler = Box::<MultiTenantRequestParser>::default(),
+        dml_write_handler = [],
+        dml_delete_handler = [],
+        want_result = Err(Error::NoHandler),
+        want_dml_calls = []
+    );
+
+    // https://github.com/influxdata/influxdb_iox/issues/4326
+    mod issue4326 {
         use super::*;
-        use crate::server::http::cst::SingleTenantRequestParser;
-        static EXPECTED_NAMESPACE: &str = "test";
-        run_v2_test_in_env!(cst, Box::<SingleTenantRequestParser>::default());
+
+        run_v2_write_test_in_env!(
+            duplicate_fields_same_value,
+            query_string = "?org=bananas&bucket=test",
+            body = "whydo InputPower=300i,InputPower=300i".as_bytes(),
+            dml_handler = [Ok(summary())],
+            want_result = Ok(_),
+            want_dml_calls = [MockDmlHandlerCall::Write{namespace, write_input, ..}] => {
+                assert_eq!(namespace, EXPECTED_NAMESPACE);
+                let table = write_input.get("whydo").expect("table not in write");
+                let col = table.column("InputPower").expect("column missing");
+                assert_matches!(col.data(), ColumnData::I64(data, _) => {
+                    // Ensure the duplicate values are coalesced.
+                    assert_eq!(data.as_slice(), [300]);
+                });
+            }
+        );
+
+        run_v2_write_test_in_env!(
+            duplicate_fields_different_value,
+            query_string = "?org=bananas&bucket=test",
+            body = "whydo InputPower=300i,InputPower=42i".as_bytes(),
+            dml_handler = [Ok(summary())],
+            want_result = Ok(_),
+            want_dml_calls = [MockDmlHandlerCall::Write{namespace, write_input, ..}] => {
+                assert_eq!(namespace, EXPECTED_NAMESPACE);
+                let table = write_input.get("whydo").expect("table not in write");
+                let col = table.column("InputPower").expect("column missing");
+                assert_matches!(col.data(), ColumnData::I64(data, _) => {
+                    // Last value wins
+                    assert_eq!(data.as_slice(), [42]);
+                });
+            }
+        );
+
+        run_v2_write_test_in_env!(
+            duplicate_fields_different_type,
+            query_string = "?org=bananas&bucket=test",
+            body = "whydo InputPower=300i,InputPower=4.2".as_bytes(),
+            dml_handler = [],
+            want_result = Err(Error::ParseLineProtocol(mutable_batch_lp::Error::Write {
+                source: LineWriteError::ConflictedFieldTypes { .. },
+                ..
+            })),
+            want_dml_calls = []
+        );
+
+        run_v2_write_test_in_env!(
+            duplicate_tags_same_value,
+            query_string = "?org=bananas&bucket=test",
+            body = "whydo,InputPower=300i,InputPower=300i field=42i".as_bytes(),
+            dml_handler = [],
+            want_result = Err(Error::ParseLineProtocol(mutable_batch_lp::Error::Write {
+                source: LineWriteError::DuplicateTag { .. },
+                ..
+            })),
+            want_dml_calls = []
+        );
+
+        run_v2_write_test_in_env!(
+            duplicate_tags_different_value,
+            query_string = "?org=bananas&bucket=test",
+            body = "whydo,InputPower=300i,InputPower=42i field=42i".as_bytes(),
+            dml_handler = [],
+            want_result = Err(Error::ParseLineProtocol(mutable_batch_lp::Error::Write {
+                source: LineWriteError::DuplicateTag { .. },
+                ..
+            })),
+            want_dml_calls = []
+        );
+
+        run_v2_write_test_in_env!(
+            duplicate_tags_different_type,
+            query_string = "?org=bananas&bucket=test",
+            body = "whydo,InputPower=300i,InputPower=4.2 field=42i".as_bytes(),
+            dml_handler = [],
+            want_result = Err(Error::ParseLineProtocol(mutable_batch_lp::Error::Write {
+                source: LineWriteError::DuplicateTag { .. },
+                ..
+            })),
+            want_dml_calls = []
+        );
+
+        run_v2_write_test_in_env!(
+            duplicate_is_tag_and_field,
+            query_string = "?org=bananas&bucket=test",
+            body = "whydo,InputPower=300i InputPower=300i".as_bytes(),
+            dml_handler = [],
+            want_result = Err(Error::ParseLineProtocol(mutable_batch_lp::Error::Write {
+                source: LineWriteError::MutableBatch {
+                    source: mutable_batch::writer::Error::TypeMismatch { .. }
+                },
+                ..
+            })),
+            want_dml_calls = []
+        );
+
+        run_v2_write_test_in_env!(
+            duplicate_is_tag_and_field_different_types,
+            query_string = "?org=bananas&bucket=test",
+            body = "whydo,InputPower=300i InputPower=30.0".as_bytes(),
+            dml_handler = [],
+            want_result = Err(Error::ParseLineProtocol(mutable_batch_lp::Error::Write {
+                source: LineWriteError::MutableBatch {
+                    source: mutable_batch::writer::Error::TypeMismatch { .. }
+                },
+                ..
+            })),
+            want_dml_calls = []
+        );
     }
 }

--- a/router/src/server/http/write_v2.rs
+++ b/router/src/server/http/write_v2.rs
@@ -545,13 +545,13 @@ mod tests {
         use super::*;
         use crate::server::http::mt::MultiTenantRequestParser;
         static EXPECTED_NAMESPACE: &str = "bananas_test";
-        run_v2_test_in_env!(mt, &MultiTenantRequestParser);
+        run_v2_test_in_env!(mt, Box::<MultiTenantRequestParser>::default());
     }
 
     mod cst {
         use super::*;
         use crate::server::http::cst::SingleTenantRequestParser;
         static EXPECTED_NAMESPACE: &str = "test";
-        run_v2_test_in_env!(cst, &SingleTenantRequestParser);
+        run_v2_test_in_env!(cst, Box::<SingleTenantRequestParser>::default());
     }
 }

--- a/router/src/server/http/write_v2.rs
+++ b/router/src/server/http/write_v2.rs
@@ -48,555 +48,105 @@ impl<T> TryFrom<&Request<T>> for WriteParamsV2 {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::{
-        dml_handlers::{mock::MockDmlHandlerCall, DmlError},
-        server::http::{
-            mt::MultiTenantRequestParser,
-            write_test_helpers::{summary, MAX_BYTES, NAMESPACE_ID},
-            Error,
-        },
-        test_http_handler,
+#[macro_export]
+// ensure v2 WRITE contract stays the same
+// only namespace_name is different
+macro_rules! run_v2_write_test_in_env {
+    (
+        $name:ident,
+        query_string = $query_string:expr,   // Request URI query string
+        body = $body:expr,                   // Request body content
+        dml_handler = $dml_handler:expr,     // DML write handler response (if called)
+        want_result = $want_result:pat,
+        want_dml_calls = $($want_dml_calls:tt )+
+    ) => {
+        paste::paste! {
+            mod [<mt_write_ $name>] {
+                #[allow(unused)]
+                use super::*;
+                use $crate::test_mt_handler;
+                #[allow(unused)]
+                static EXPECTED_NAMESPACE: &str = "bananas_test";
+
+                test_mt_handler!(
+                    $name,
+                    route_string = "/api/v2/write",
+                    query_string = $query_string,
+                    body = $body,
+                    dml_write_handler = $dml_handler,
+                    want_result = $want_result,
+                    want_dml_calls = $($want_dml_calls)+
+                );
+            }
+
+            mod [<cst_write_ $name>] {
+                #[allow(unused)]
+                use super::*;
+                use $crate::test_cst_handler;
+                #[allow(unused)]
+                static EXPECTED_NAMESPACE: &str = "test";
+
+                test_cst_handler!(
+                    $name,
+                    route_string = "/api/v2/write",
+                    query_string = $query_string,
+                    body = $body,
+                    dml_write_handler = $dml_handler,
+                    want_result = $want_result,
+                    want_dml_calls = $($want_dml_calls)+
+                );
+            }
+        }
     };
-    use mutable_batch::column::ColumnData;
-    use mutable_batch_lp::LineWriteError;
-    use std::iter;
+}
 
-    // ensure v2 WRITE contract stays the same
-    // only namespace_name is different
-    macro_rules! run_v2_write_test_in_env {
-        (
-            $name:ident,
-            query_string = $query_string:expr,   // Request URI query string
-            body = $body:expr,                   // Request body content
-            dml_handler = $dml_handler:expr,     // DML write handler response (if called)
-            want_result = $want_result:pat,
-            want_dml_calls = $($want_dml_calls:tt )+
-        ) => {
-            paste::paste! {
-                mod [<mt_write_ $name>] {
-                    use super::*;
-                    use $crate::test_mt_handler;
-                    #[allow(unused)]
-                    static EXPECTED_NAMESPACE: &str = "bananas_test";
+#[cfg(test)]
+#[macro_export]
+// ensure v2 DELETE contract stays the same
+// only namespace_name is different
+macro_rules! run_v2_delete_test_in_env {
+    (
+        $name:ident,
+        query_string = $query_string:expr,   // Request URI query string
+        body = $body:expr,                   // Request body content
+        dml_handler = $dml_handler:expr,     // DML write handler response (if called)
+        want_result = $want_result:pat,
+        want_dml_calls = $($want_dml_calls:tt )+
+    ) => {
+        paste::paste! {
+            mod [<mt_delete_ $name>] {
+                use super::*;
+                use $crate::test_mt_handler;
+                #[allow(unused)]
+                static EXPECTED_NAMESPACE: &str = "bananas_test";
 
-                    test_mt_handler!(
-                        $name,
-                        route_string = "/api/v2/write",
-                        query_string = $query_string,
-                        body = $body,
-                        dml_write_handler = $dml_handler,
-                        want_result = $want_result,
-                        want_dml_calls = $($want_dml_calls)+
-                    );
-                }
-
-                mod [<cst_write_ $name>] {
-                    use super::*;
-                    use $crate::test_cst_handler;
-                    #[allow(unused)]
-                    static EXPECTED_NAMESPACE: &str = "test";
-
-                    test_cst_handler!(
-                        $name,
-                        route_string = "/api/v2/write",
-                        query_string = $query_string,
-                        body = $body,
-                        dml_write_handler = $dml_handler,
-                        want_result = $want_result,
-                        want_dml_calls = $($want_dml_calls)+
-                    );
-                }
+                test_mt_handler!(
+                    $name,
+                    route_string = "/api/v2/delete",
+                    query_string = $query_string,
+                    body = $body,
+                    dml_delete_handler = $dml_handler,
+                    want_result = $want_result,
+                    want_dml_calls = $($want_dml_calls)+
+                );
             }
-        };
-    }
 
-    // ensure v2 DELETE contract stays the same
-    // only namespace_name is different
-    macro_rules! run_v2_delete_test_in_env {
-        (
-            $name:ident,
-            query_string = $query_string:expr,   // Request URI query string
-            body = $body:expr,                   // Request body content
-            dml_handler = $dml_handler:expr,     // DML write handler response (if called)
-            want_result = $want_result:pat,
-            want_dml_calls = $($want_dml_calls:tt )+
-        ) => {
-            paste::paste! {
-                mod [<mt_delete_ $name>] {
-                    use super::*;
-                    use $crate::test_mt_handler;
-                    #[allow(unused)]
-                    static EXPECTED_NAMESPACE: &str = "bananas_test";
+            mod [<cst_delete_ $name>] {
+                use super::*;
+                use $crate::test_cst_handler;
+                #[allow(unused)]
+                static EXPECTED_NAMESPACE: &str = "test";
 
-                    test_mt_handler!(
-                        $name,
-                        route_string = "/api/v2/delete",
-                        query_string = $query_string,
-                        body = $body,
-                        dml_delete_handler = $dml_handler,
-                        want_result = $want_result,
-                        want_dml_calls = $($want_dml_calls)+
-                    );
-                }
-
-                mod [<cst_delete_ $name>] {
-                    use super::*;
-                    use $crate::test_cst_handler;
-                    #[allow(unused)]
-                    static EXPECTED_NAMESPACE: &str = "test";
-
-                    test_cst_handler!(
-                        $name,
-                        route_string = "/api/v2/delete",
-                        query_string = $query_string,
-                        body = $body,
-                        dml_delete_handler = $dml_handler,
-                        want_result = $want_result,
-                        want_dml_calls = $($want_dml_calls)+
-                    );
-                }
+                test_cst_handler!(
+                    $name,
+                    route_string = "/api/v2/delete",
+                    query_string = $query_string,
+                    body = $body,
+                    dml_delete_handler = $dml_handler,
+                    want_result = $want_result,
+                    want_dml_calls = $($want_dml_calls)+
+                );
             }
-        };
-    }
-
-    run_v2_write_test_in_env!(
-        ok,
-        query_string = "?org=bananas&bucket=test",
-        body = "platanos,tag1=A,tag2=B val=42i 123456".as_bytes(),
-        dml_handler = [Ok(summary())],
-        want_result = Ok(_),
-        want_dml_calls = [MockDmlHandlerCall::Write{namespace, ..}] => {
-            assert_eq!(namespace, EXPECTED_NAMESPACE);
         }
-    );
-
-    run_v2_write_test_in_env!(
-        ok_precision_s,
-        query_string = "?org=bananas&bucket=test&precision=s",
-        body = "platanos,tag1=A,tag2=B val=42i 1647622847".as_bytes(),
-        dml_handler = [Ok(summary())],
-        want_result = Ok(_),
-        want_dml_calls = [MockDmlHandlerCall::Write{namespace, namespace_id, write_input}] => {
-            assert_eq!(namespace, EXPECTED_NAMESPACE);
-            assert_eq!(*namespace_id, NAMESPACE_ID);
-
-            let table = write_input.get("platanos").expect("table not found");
-            let ts = table.timestamp_summary().expect("no timestamp summary");
-            assert_eq!(Some(1647622847000000000), ts.stats.min);
-        }
-    );
-
-    run_v2_write_test_in_env!(
-        ok_precision_ms,
-        query_string = "?org=bananas&bucket=test&precision=ms",
-        body = "platanos,tag1=A,tag2=B val=42i 1647622847000".as_bytes(),
-        dml_handler = [Ok(summary())],
-        want_result = Ok(_),
-        want_dml_calls = [MockDmlHandlerCall::Write{namespace, namespace_id, write_input}] => {
-            assert_eq!(namespace, EXPECTED_NAMESPACE);
-            assert_eq!(*namespace_id, NAMESPACE_ID);
-
-            let table = write_input.get("platanos").expect("table not found");
-            let ts = table.timestamp_summary().expect("no timestamp summary");
-            assert_eq!(Some(1647622847000000000), ts.stats.min);
-        }
-    );
-
-    run_v2_write_test_in_env!(
-        ok_precision_us,
-        query_string = "?org=bananas&bucket=test&precision=us",
-        body = "platanos,tag1=A,tag2=B val=42i 1647622847000000".as_bytes(),
-        dml_handler = [Ok(summary())],
-        want_result = Ok(_),
-        want_dml_calls = [MockDmlHandlerCall::Write{namespace, namespace_id, write_input}] => {
-            assert_eq!(namespace, EXPECTED_NAMESPACE);
-            assert_eq!(*namespace_id, NAMESPACE_ID);
-
-            let table = write_input.get("platanos").expect("table not found");
-            let ts = table.timestamp_summary().expect("no timestamp summary");
-            assert_eq!(Some(1647622847000000000), ts.stats.min);
-        }
-    );
-
-    run_v2_write_test_in_env!(
-        ok_precision_ns,
-        query_string = "?org=bananas&bucket=test&precision=ns",
-        body = "platanos,tag1=A,tag2=B val=42i 1647622847000000000".as_bytes(),
-        dml_handler = [Ok(summary())],
-        want_result = Ok(_),
-        want_dml_calls = [MockDmlHandlerCall::Write{namespace, namespace_id, write_input}] => {
-            assert_eq!(namespace, EXPECTED_NAMESPACE);
-            assert_eq!(*namespace_id, NAMESPACE_ID);
-
-            let table = write_input.get("platanos").expect("table not found");
-            let ts = table.timestamp_summary().expect("no timestamp summary");
-            assert_eq!(Some(1647622847000000000), ts.stats.min);
-        }
-    );
-
-    run_v2_write_test_in_env!(
-        precision_overflow,
-        // SECONDS, so multiplies the provided timestamp by 1,000,000,000
-        query_string = "?org=bananas&bucket=test&precision=s",
-        body = "platanos,tag1=A,tag2=B val=42i 1647622847000000000".as_bytes(),
-        dml_handler = [Ok(summary())],
-        want_result = Err(Error::ParseLineProtocol(_)),
-        want_dml_calls = []
-    );
-
-    run_v2_write_test_in_env!(
-        no_query_params,
-        query_string = "",
-        body = "platanos,tag1=A,tag2=B val=42i 123456".as_bytes(),
-        dml_handler = [Ok(summary())],
-        want_result = Err(Error::InvalidOrgBucket(OrgBucketError::NotSpecified)),
-        want_dml_calls = [] // None
-    );
-
-    run_v2_write_test_in_env!(
-        no_org_bucket,
-        query_string = "?",
-        body = "platanos,tag1=A,tag2=B val=42i 123456".as_bytes(),
-        dml_handler = [Ok(summary())],
-        want_result = Err(Error::InvalidOrgBucket(OrgBucketError::DecodeFail(_))),
-        want_dml_calls = [] // None
-    );
-
-    run_v2_write_test_in_env!(
-        empty_org_bucket,
-        query_string = "?org=&bucket=",
-        body = "platanos,tag1=A,tag2=B val=42i 123456".as_bytes(),
-        dml_handler = [Ok(summary())],
-        want_result = Err(Error::InvalidOrgBucket(OrgBucketError::NotSpecified)),
-        want_dml_calls = [] // None
-    );
-
-    run_v2_write_test_in_env!(
-        invalid_org_bucket,
-        query_string = format!("?org=test&bucket={}", "A".repeat(1000)),
-        body = "platanos,tag1=A,tag2=B val=42i 123456".as_bytes(),
-        dml_handler = [Ok(summary())],
-        want_result = Err(Error::InvalidOrgBucket(OrgBucketError::MappingFail(_))),
-        want_dml_calls = [] // None
-    );
-
-    run_v2_write_test_in_env!(
-        invalid_line_protocol,
-        query_string = "?org=bananas&bucket=test",
-        body = "not line protocol".as_bytes(),
-        dml_handler = [Ok(summary())],
-        want_result = Err(Error::ParseLineProtocol(_)),
-        want_dml_calls = [] // None
-    );
-
-    run_v2_write_test_in_env!(
-        non_utf8_body,
-        query_string = "?org=bananas&bucket=test",
-        body = vec![0xc3, 0x28],
-        dml_handler = [Ok(summary())],
-        want_result = Err(Error::NonUtf8Body(_)),
-        want_dml_calls = [] // None
-    );
-
-    run_v2_write_test_in_env!(
-        max_request_size_truncation,
-        query_string = "?org=bananas&bucket=test",
-        body = {
-            // Generate a LP string in the form of:
-            //
-            //  bananas,A=AAAAAAAAAA(repeated)... B=42
-            //                                  ^
-            //                                  |
-            //                         MAX_BYTES boundary
-            //
-            // So that reading MAX_BYTES number of bytes produces the string:
-            //
-            //  bananas,A=AAAAAAAAAA(repeated)...
-            //
-            // Effectively trimming off the " B=42" suffix.
-            let body = "bananas,A=";
-            iter::once(body)
-                .chain(iter::repeat("A").take(MAX_BYTES - body.len()))
-                .chain(iter::once(" B=42\n"))
-                .flat_map(|s| s.bytes())
-                .collect::<Vec<u8>>()
-        },
-        dml_handler = [Ok(summary())],
-        want_result = Err(Error::RequestSizeExceeded(_)),
-        want_dml_calls = [] // None
-    );
-
-    run_v2_write_test_in_env!(
-        db_not_found,
-        query_string = "?org=bananas&bucket=test",
-        body = "platanos,tag1=A,tag2=B val=42i 123456".as_bytes(),
-        dml_handler = [Err(DmlError::NamespaceNotFound(EXPECTED_NAMESPACE.to_string()))],
-        want_result = Err(Error::DmlHandler(DmlError::NamespaceNotFound(_))),
-        want_dml_calls = [MockDmlHandlerCall::Write{namespace, ..}] => {
-            assert_eq!(namespace, EXPECTED_NAMESPACE);
-        }
-    );
-
-    run_v2_write_test_in_env!(
-        dml_handler_error,
-        query_string = "?org=bananas&bucket=test",
-        body = "platanos,tag1=A,tag2=B val=42i 123456".as_bytes(),
-        dml_handler = [Err(DmlError::Internal("💣".into()))],
-        want_result = Err(Error::DmlHandler(DmlError::Internal(_))),
-        want_dml_calls = [MockDmlHandlerCall::Write{namespace, ..}] => {
-            assert_eq!(namespace, EXPECTED_NAMESPACE);
-        }
-    );
-
-    run_v2_write_test_in_env!(
-        field_upsert_within_batch,
-        query_string = "?org=bananas&bucket=test",
-        body = "test field=1u 100\ntest field=2u 100".as_bytes(),
-        dml_handler = [Ok(summary())],
-        want_result = Ok(_),
-        want_dml_calls = [MockDmlHandlerCall::Write{namespace, namespace_id, write_input}] => {
-            assert_eq!(namespace, EXPECTED_NAMESPACE);
-            assert_eq!(*namespace_id, NAMESPACE_ID);
-            let table = write_input.get("test").expect("table not in write");
-            let col = table.column("field").expect("column missing");
-            assert_matches!(col.data(), ColumnData::U64(data, _) => {
-                // Ensure both values are recorded, in the correct order.
-                assert_eq!(data.as_slice(), [1, 2]);
-            });
-        }
-    );
-
-    run_v2_write_test_in_env!(
-        column_named_time,
-        query_string = "?org=bananas&bucket=test",
-        body = "test field=1u,time=42u 100".as_bytes(),
-        dml_handler = [],
-        want_result = Err(_),
-        want_dml_calls = []
-    );
-
-    run_v2_delete_test_in_env!(
-        ok,
-        query_string = "?org=bananas&bucket=test",
-        body = r#"{"start":"2021-04-01T14:00:00Z","stop":"2021-04-02T14:00:00Z", "predicate":"_measurement=its_a_table and location=Boston"}"#.as_bytes(),
-        dml_handler = [Ok(())],
-        want_result = Ok(_),
-        want_dml_calls = [MockDmlHandlerCall::Delete{namespace, namespace_id, table, predicate}] => {
-            assert_eq!(table, "its_a_table");
-            assert_eq!(namespace, EXPECTED_NAMESPACE);
-            assert_eq!(*namespace_id, NAMESPACE_ID);
-            assert!(!predicate.exprs.is_empty());
-        }
-    );
-
-    run_v2_delete_test_in_env!(
-        invalid_delete_body,
-        query_string = "?org=bananas&bucket=test",
-        body = r#"{wat}"#.as_bytes(),
-        dml_handler = [],
-        want_result = Err(Error::ParseHttpDelete(_)),
-        want_dml_calls = []
-    );
-
-    run_v2_delete_test_in_env!(
-        no_query_params,
-        query_string = "",
-        body = "".as_bytes(),
-        dml_handler = [Ok(())],
-        want_result = Err(Error::InvalidOrgBucket(OrgBucketError::NotSpecified)),
-        want_dml_calls = [] // None
-    );
-
-    run_v2_delete_test_in_env!(
-        no_org_bucket,
-        query_string = "?",
-        body = "".as_bytes(),
-        dml_handler = [Ok(())],
-        want_result = Err(Error::InvalidOrgBucket(OrgBucketError::DecodeFail(_))),
-        want_dml_calls = [] // None
-    );
-
-    run_v2_delete_test_in_env!(
-        empty_org_bucket,
-        query_string = "?org=&bucket=",
-        body = "".as_bytes(),
-        dml_handler = [Ok(())],
-        want_result = Err(Error::InvalidOrgBucket(OrgBucketError::NotSpecified)),
-        want_dml_calls = [] // None
-    );
-
-    run_v2_delete_test_in_env!(
-        invalid_org_bucket,
-        query_string = format!("?org=test&bucket={}", "A".repeat(1000)),
-        body = "".as_bytes(),
-        dml_handler = [Ok(())],
-        want_result = Err(Error::InvalidOrgBucket(OrgBucketError::MappingFail(_))),
-        want_dml_calls = [] // None
-    );
-
-    run_v2_delete_test_in_env!(
-        non_utf8_body,
-        query_string = "?org=bananas&bucket=test",
-        body = vec![0xc3, 0x28],
-        dml_handler = [Ok(())],
-        want_result = Err(Error::NonUtf8Body(_)),
-        want_dml_calls = [] // None
-    );
-
-    run_v2_delete_test_in_env!(
-        db_not_found,
-        query_string = "?org=bananas&bucket=test",
-        body = r#"{"start":"2021-04-01T14:00:00Z","stop":"2021-04-02T14:00:00Z", "predicate":"_measurement=its_a_table and location=Boston"}"#.as_bytes(),
-        dml_handler = [Err(DmlError::NamespaceNotFound(EXPECTED_NAMESPACE.to_string()))],
-        want_result = Err(Error::DmlHandler(DmlError::NamespaceNotFound(_))),
-        want_dml_calls = [MockDmlHandlerCall::Delete{namespace, namespace_id, table, predicate}] => {
-            assert_eq!(table, "its_a_table");
-            assert_eq!(namespace, EXPECTED_NAMESPACE);
-            assert_eq!(*namespace_id, NAMESPACE_ID);
-            assert!(!predicate.exprs.is_empty());
-        }
-    );
-
-    run_v2_delete_test_in_env!(
-        dml_handler_error,
-        query_string = "?org=bananas&bucket=test",
-        body = r#"{"start":"2021-04-01T14:00:00Z","stop":"2021-04-02T14:00:00Z", "predicate":"_measurement=its_a_table and location=Boston"}"#.as_bytes(),
-        dml_handler = [Err(DmlError::Internal("💣".into()))],
-        want_result = Err(Error::DmlHandler(DmlError::Internal(_))),
-        want_dml_calls = [MockDmlHandlerCall::Delete{namespace, namespace_id, table, predicate}] => {
-            assert_eq!(table, "its_a_table");
-            assert_eq!(namespace, EXPECTED_NAMESPACE);
-            assert_eq!(*namespace_id, NAMESPACE_ID);
-            assert!(!predicate.exprs.is_empty());
-        }
-    );
-
-    test_http_handler!(
-        not_found,
-        uri = "https://bananas.example/wat",
-        body = "".as_bytes(),
-        auth_handler = None,
-        dml_info_handler = Box::<MultiTenantRequestParser>::default(),
-        dml_write_handler = [],
-        dml_delete_handler = [],
-        want_result = Err(Error::NoHandler),
-        want_dml_calls = []
-    );
-
-    // https://github.com/influxdata/influxdb_iox/issues/4326
-    mod issue4326 {
-        use super::*;
-
-        run_v2_write_test_in_env!(
-            duplicate_fields_same_value,
-            query_string = "?org=bananas&bucket=test",
-            body = "whydo InputPower=300i,InputPower=300i".as_bytes(),
-            dml_handler = [Ok(summary())],
-            want_result = Ok(_),
-            want_dml_calls = [MockDmlHandlerCall::Write{namespace, write_input, ..}] => {
-                assert_eq!(namespace, EXPECTED_NAMESPACE);
-                let table = write_input.get("whydo").expect("table not in write");
-                let col = table.column("InputPower").expect("column missing");
-                assert_matches!(col.data(), ColumnData::I64(data, _) => {
-                    // Ensure the duplicate values are coalesced.
-                    assert_eq!(data.as_slice(), [300]);
-                });
-            }
-        );
-
-        run_v2_write_test_in_env!(
-            duplicate_fields_different_value,
-            query_string = "?org=bananas&bucket=test",
-            body = "whydo InputPower=300i,InputPower=42i".as_bytes(),
-            dml_handler = [Ok(summary())],
-            want_result = Ok(_),
-            want_dml_calls = [MockDmlHandlerCall::Write{namespace, write_input, ..}] => {
-                assert_eq!(namespace, EXPECTED_NAMESPACE);
-                let table = write_input.get("whydo").expect("table not in write");
-                let col = table.column("InputPower").expect("column missing");
-                assert_matches!(col.data(), ColumnData::I64(data, _) => {
-                    // Last value wins
-                    assert_eq!(data.as_slice(), [42]);
-                });
-            }
-        );
-
-        run_v2_write_test_in_env!(
-            duplicate_fields_different_type,
-            query_string = "?org=bananas&bucket=test",
-            body = "whydo InputPower=300i,InputPower=4.2".as_bytes(),
-            dml_handler = [],
-            want_result = Err(Error::ParseLineProtocol(mutable_batch_lp::Error::Write {
-                source: LineWriteError::ConflictedFieldTypes { .. },
-                ..
-            })),
-            want_dml_calls = []
-        );
-
-        run_v2_write_test_in_env!(
-            duplicate_tags_same_value,
-            query_string = "?org=bananas&bucket=test",
-            body = "whydo,InputPower=300i,InputPower=300i field=42i".as_bytes(),
-            dml_handler = [],
-            want_result = Err(Error::ParseLineProtocol(mutable_batch_lp::Error::Write {
-                source: LineWriteError::DuplicateTag { .. },
-                ..
-            })),
-            want_dml_calls = []
-        );
-
-        run_v2_write_test_in_env!(
-            duplicate_tags_different_value,
-            query_string = "?org=bananas&bucket=test",
-            body = "whydo,InputPower=300i,InputPower=42i field=42i".as_bytes(),
-            dml_handler = [],
-            want_result = Err(Error::ParseLineProtocol(mutable_batch_lp::Error::Write {
-                source: LineWriteError::DuplicateTag { .. },
-                ..
-            })),
-            want_dml_calls = []
-        );
-
-        run_v2_write_test_in_env!(
-            duplicate_tags_different_type,
-            query_string = "?org=bananas&bucket=test",
-            body = "whydo,InputPower=300i,InputPower=4.2 field=42i".as_bytes(),
-            dml_handler = [],
-            want_result = Err(Error::ParseLineProtocol(mutable_batch_lp::Error::Write {
-                source: LineWriteError::DuplicateTag { .. },
-                ..
-            })),
-            want_dml_calls = []
-        );
-
-        run_v2_write_test_in_env!(
-            duplicate_is_tag_and_field,
-            query_string = "?org=bananas&bucket=test",
-            body = "whydo,InputPower=300i InputPower=300i".as_bytes(),
-            dml_handler = [],
-            want_result = Err(Error::ParseLineProtocol(mutable_batch_lp::Error::Write {
-                source: LineWriteError::MutableBatch {
-                    source: mutable_batch::writer::Error::TypeMismatch { .. }
-                },
-                ..
-            })),
-            want_dml_calls = []
-        );
-
-        run_v2_write_test_in_env!(
-            duplicate_is_tag_and_field_different_types,
-            query_string = "?org=bananas&bucket=test",
-            body = "whydo,InputPower=300i InputPower=30.0".as_bytes(),
-            dml_handler = [],
-            want_result = Err(Error::ParseLineProtocol(mutable_batch_lp::Error::Write {
-                source: LineWriteError::MutableBatch {
-                    source: mutable_batch::writer::Error::TypeMismatch { .. }
-                },
-                ..
-            })),
-            want_dml_calls = []
-        );
-    }
+    };
 }

--- a/router/tests/common/mod.rs
+++ b/router/tests/common/mod.rs
@@ -18,7 +18,10 @@ use router::{
     namespace_resolver::{MissingNamespaceAction, NamespaceAutocreation, NamespaceSchemaResolver},
     server::{
         grpc::RpcWriteGrpcDelegate,
-        http::{HttpDelegate, WriteInfoExtractor, CST, MT},
+        http::{
+            cst::SingleTenantRequestParser, mt::MultiTenantRequestParser, HttpDelegate,
+            WriteInfoExtractor,
+        },
     },
 };
 use std::{iter, string::String, sync::Arc, time::Duration};
@@ -162,8 +165,8 @@ impl TestContext {
         let handler_stack = InstrumentationDecorator::new("request", &metrics, handler_stack);
 
         let dml_info_extractor: &'static dyn WriteInfoExtractor = match Tenancy::get() {
-            Tenancy::Single => &CST,
-            Tenancy::Multiple => &MT,
+            Tenancy::Single => &SingleTenantRequestParser,
+            Tenancy::Multiple => &MultiTenantRequestParser,
         };
 
         let http_delegate = HttpDelegate::new(


### PR DESCRIPTION
Part of https://github.com/influxdata/idpe/issues/17265

## Done:
Initial implementation of the v1 and v2 direct write interface for CST. Includes testing of differential handling in CST, versus MT (existing) environment. Focuses on consolidation on an internal abstraction (WriteInfo) of the DML parameters, and keeping any v1 versus v2 handling upstream.

## Not done yet (follow up PRs):
- Authn & Authz.
- Confirmation of http codes to comply with CST spec.

## Control of blast radius:
The assumptions of no-impact to the current MT v2 behavior, are based on the following:
* that the same v2 MT tests all pass
* that the string validation parts of the namespace_name construction, are compliant with the existing (before this PR) code in `org_and_bucket_to_namespace()`.

## Deviations from spec:
- Didn't do `if / character in value: reject with HTTP status code 400`. 
    - Instead, followed the existing (live in iox) pattern:
    - The existing namespace construction results in uri-percent encoding for ascii characters (such as `/` and `_`). This means that it does not reject the use of these characters. (See the use of `utf8_percent_encode()` in existing code.)
        - existing in MT: `/api/v2/write?org=bananas&bucket=te_st` => creates namespace `bananas_te%5Fst`
        - Introduced here: `/write?db=data/base&rp=rp` => creates namespace `data%2Fbase/rp`

## Broader concerns:
- V1 namespace-autocreation:
    - If we enable:
        -  If we have `rp` as optional on write => this will produce problems with auto creation of another (unintended) namespace. The solution cannot be as simple as looking up current namespaces and matching (assuming missing rp), since the lookup resolution will not be unambiguous (e.g. if have db/rp and db/rp1, etc).
    - If we don’t enable:
        - How are these namespaces created in the first place? During data migration to CST iox?



## Checklist
- [x] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb_iox/blob/main/README.md).
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
