### PR TITLE
WIP: Convert TSM data to line protocol

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4218,6 +4218,7 @@ dependencies = [
  "datafusion_util",
  "futures",
  "influxdb-line-protocol",
+ "influxdb_tsm",
  "mutable_batch",
  "mutable_batch_lp",
  "num_cpus",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4214,6 +4214,7 @@ dependencies = [
 name = "parquet_to_line_protocol"
 version = "0.1.0"
 dependencies = [
+ "data_types",
  "datafusion",
  "datafusion_util",
  "futures",

--- a/influxdb_iox/src/commands/debug/mod.rs
+++ b/influxdb_iox/src/commands/debug/mod.rs
@@ -8,7 +8,6 @@ mod parquet_to_lp;
 mod print_cpu;
 mod schema;
 mod skipped_compactions;
-mod tsm_to_lp;
 
 #[derive(Debug, Snafu)]
 pub enum Error {

--- a/parquet_to_line_protocol/Cargo.toml
+++ b/parquet_to_line_protocol/Cargo.toml
@@ -6,6 +6,7 @@ edition.workspace = true
 license.workspace = true
 
 [dependencies]
+data_types = { path = "../data_types" }
 datafusion = { workspace = true }
 datafusion_util = { path = "../datafusion_util" }
 influxdb-line-protocol = { path = "../influxdb_line_protocol" }

--- a/parquet_to_line_protocol/Cargo.toml
+++ b/parquet_to_line_protocol/Cargo.toml
@@ -9,6 +9,7 @@ license.workspace = true
 datafusion = { workspace = true }
 datafusion_util = { path = "../datafusion_util" }
 influxdb-line-protocol = { path = "../influxdb_line_protocol" }
+influxdb_tsm = { path = "../influxdb_tsm" }
 futures = {version = "0.3"}
 num_cpus = "1.15.0"
 object_store = { version = "0.5.5" }

--- a/parquet_to_line_protocol/src/lib.rs
+++ b/parquet_to_line_protocol/src/lib.rs
@@ -99,7 +99,6 @@ where
     todo!();
 }
 
-
 /// Converts a parquet file that was written by IOx from the local
 /// file system path specified a stream of line protocol bytes
 ///

--- a/parquet_to_line_protocol/src/lib.rs
+++ b/parquet_to_line_protocol/src/lib.rs
@@ -87,6 +87,19 @@ pub enum Error {
     IO { source: std::io::Error },
 }
 
+/// Converts a tsm parquet file to an IOx schema and a stream of line protocol bytes
+///
+/// Each returned `Vec<u8>` is guarnteed to have complete line
+/// protocol (aka lines are not split across the buffers)
+pub async fn convert_tsm_file<P>(path: P) -> Result<BoxStream<'static, Result<Vec<u8>>>>
+where
+    P: AsRef<Path>,
+{
+    let path = path.as_ref();
+    todo!();
+}
+
+
 /// Converts a parquet file that was written by IOx from the local
 /// file system path specified a stream of line protocol bytes
 ///

--- a/parquet_to_line_protocol/src/tsm.rs
+++ b/parquet_to_line_protocol/src/tsm.rs
@@ -1,6 +1,103 @@
 //! Convert TSM into RecordBatches (and IOx schema)
 
+use std::collections::{HashMap, HashSet};
+
+use datafusion::arrow::datatypes::DataType;
+use influxdb_tsm::{reader::IndexEntry, BlockType};
+use schema::{SchemaBuilder, Schema};
+
+/// all index entries for a particular measurement
+#[derive(Debug)]
+pub struct TsmMeasurement {
+    index_entries: Vec<IndexEntry>,
+    schema_builder: SchemaBuilder,
+    column_names: HashSet<String>,
+}
+
+impl TsmMeasurement {
+    pub fn new() -> Self {
+        let mut schema_builder = SchemaBuilder::new();
+
+        schema_builder.timestamp();
+
+        Self {
+            index_entries: vec![],
+            schema_builder,
+            column_names: HashSet::new()
+        }
+    }
+
+    /// inserts an index entry for the specified tags / fields
+    /// also building up the schema as needed
+    /// tagset: (name, value)
+    /// field_key: field_name
+    pub fn insert(&mut self, tagset: Vec<(String, String)>, field_key: String, index: IndexEntry) {
+
+        // add all columns we haven't seen before
+        let tag_column_names = tagset.iter().map(|(tag_name, _tag_value)| tag_name);
+
+        for tag_name in tag_column_names {
+            if !self.column_names.contains(tag_name) {
+                self.schema_builder.tag(&tag_name);
+                self.column_names.insert(tag_name.clone());
+            }
+        }
+
+        let data_type = column_type(index.block_type);
+
+        if !self.column_names.contains(&field_key) {
+            self.schema_builder.field(&field_key,data_type).unwrap();
+            self.column_names.insert(field_key.clone());
+        }
+    }
+
+    pub fn schema(&self) -> Schema {
+        self.schema_builder.clone().build().unwrap()
+    }
+
+}
+
+#[derive(Debug, Default)]
+pub struct TsmNamespace {
+    // Maps measurement name to  TsmMeasurements
+    measurements: HashMap<String, TsmMeasurement>,
+}
+
+impl TsmNamespace {
+    pub fn new() -> Self {
+        Default::default()
+    }
+
+    /// return a TsmMeasurement for the measurement name
+    pub fn get_mut(&mut self, name: &str) -> &mut TsmMeasurement {
+        self.measurements.entry(name.to_string())
+            .or_insert_with(|| TsmMeasurement::new())
+    }
+
+    pub fn dump(&self)  {
+        for (name, measurement) in self.measurements.iter() {
+            println!("Measurement Name: {name}");
+            println!("Schema:");
+            println!("{:#?}", measurement.schema());
+        }
+    }
+}
+
+
+
+#[derive(Debug)]
 pub struct TsmConverter {
+
+}
+
+fn column_type(block_type: BlockType) -> DataType {
+    match block_type {
+        BlockType::Float => DataType::Float64,
+        BlockType::Integer => DataType::Int64,
+        BlockType::Bool => DataType::Boolean,
+        BlockType::Str => DataType::Utf8,
+        BlockType::Unsigned => DataType::UInt64,
+    }
 }
 
 // Basic flow will be:

--- a/parquet_to_line_protocol/src/tsm.rs
+++ b/parquet_to_line_protocol/src/tsm.rs
@@ -2,3 +2,8 @@
 
 pub struct TsmConverter {
 }
+
+// Basic flow will be:
+// find each measurement
+// figure out schema
+// bash out record batches

--- a/parquet_to_line_protocol/src/tsm.rs
+++ b/parquet_to_line_protocol/src/tsm.rs
@@ -1,0 +1,4 @@
+//! Convert TSM into RecordBatches (and IOx schema)
+
+pub struct TsmConverter {
+}


### PR DESCRIPTION
WIP -- the idea is that I will follow the parquet model so that I can use `influxbd_iox write` to convert and sent tsm data directly through the IOx frontdoor (`/api/v2/write` endpoiint);

Currently a pretty brutal hack 


However, it does appear to be able to recover the IOx schema:
```shell
cargo test -p parquet_to_line_protocol
```

```
---- test::test_tsm stdout ----
Namespace Name: 05e5b1cc26d7e000_05e5b1cc26d7e001
Measurement Name: cpu
Schema:
Schema {
    inner: Schema {
        fields: [
            Field {
                name: "time",
                data_type: Timestamp(
                    Nanosecond,
                    None,
                ),
                nullable: false,
                dict_id: 0,
                dict_is_ordered: false,
                metadata: {
                    "iox::column::type": "iox::column_type::timestamp",
                },
            },
            Field {
                name: "cpu",
                data_type: Dictionary(
                    Int32,
                    Utf8,
                ),
                nullable: true,
                dict_id: 0,
                dict_is_ordered: false,
                metadata: {
                    "iox::column::type": "iox::column_type::tag",
                },
            },
            Field {
                name: "host",
                data_type: Dictionary(
                    Int32,
                    Utf8,
                ),
                nullable: true,
                dict_id: 0,
                dict_is_ordered: false,
                metadata: {
                    "iox::column::type": "iox::column_type::tag",
                },
            },
            Field {
                name: "usage_guest",
                data_type: Float64,
                nullable: true,
                dict_id: 0,
                dict_is_ordered: false,
                metadata: {
                    "iox::column::type": "iox::column_type::field::float",
                },
            },
            Field {
                name: "usage_guest_nice",
                data_type: Float64,
                nullable: true,
                dict_id: 0,
                dict_is_ordered: false,
                metadata: {
                    "iox::column::type": "iox::column_type::field::float",
                },
            },
            Field {
                name: "usage_idle",
                data_type: Float64,
                nullable: true,
                dict_id: 0,
                dict_is_ordered: false,
                metadata: {
                    "iox::column::type": "iox::column_type::field::float",
                },
            },
            Field {
                name: "usage_iowait",
                data_type: Float64,
                nullable: true,
                dict_id: 0,
                dict_is_ordered: false,
                metadata: {
                    "iox::column::type": "iox::column_type::field::float",
                },
            },
            Field {
                name: "usage_irq",
                data_type: Float64,
                nullable: true,
                dict_id: 0,
                dict_is_ordered: false,
                metadata: {
                    "iox::column::type": "iox::column_type::field::float",
                },
            },
            Field {
                name: "usage_nice",
                data_type: Float64,
                nullable: true,
                dict_id: 0,
                dict_is_ordered: false,
                metadata: {
                    "iox::column::type": "iox::column_type::field::float",
                },
            },
            Field {
                name: "usage_softirq",
                data_type: Float64,
                nullable: true,
                dict_id: 0,
                dict_is_ordered: false,
                metadata: {
                    "iox::column::type": "iox::column_type::field::float",
                },
            },
            Field {
                name: "usage_steal",
                data_type: Float64,
                nullable: true,
                dict_id: 0,
                dict_is_ordered: false,
                metadata: {
                    "iox::column::type": "iox::column_type::field::float",
                },
            },
            Field {
                name: "usage_system",
                data_type: Float64,
                nullable: true,
                dict_id: 0,
                dict_is_ordered: false,
                metadata: {
                    "iox::column::type": "iox::column_type::field::float",
                },
            },
            Field {
                name: "usage_user",
                data_type: Float64,
                nullable: true,
                dict_id: 0,
                dict_is_ordered: false,
                metadata: {
                    "iox::column::type": "iox::column_type::field::float",
                },
            },
        ],
        metadata: {},
    },
}
Measurement Name: disk
Schema:
Schema {
    inner: Schema {
        fields: [
            Field {
                name: "time",
                data_type: Timestamp(
                    Nanosecond,
                    None,
                ),
                nullable: false,
                dict_id: 0,
                dict_is_ordered: false,
                metadata: {
                    "iox::column::type": "iox::column_type::timestamp",
                },
            },
            Field {
                name: "device",
                data_type: Dictionary(
                    Int32,
                    Utf8,
                ),
                nullable: true,
                dict_id: 0,
                dict_is_ordered: false,
                metadata: {
                    "iox::column::type": "iox::column_type::tag",
                },
            },
            Field {
                name: "fstype",
                data_type: Dictionary(
                    Int32,
                    Utf8,
                ),
                nullable: true,
                dict_id: 0,
                dict_is_ordered: false,
                metadata: {
                    "iox::column::type": "iox::column_type::tag",
                },
            },
            Field {
                name: "host",
                data_type: Dictionary(
                    Int32,
                    Utf8,
                ),
                nullable: true,
                dict_id: 0,
                dict_is_ordered: false,
                metadata: {
                    "iox::column::type": "iox::column_type::tag",
                },
            },
            Field {
                name: "mode",
                data_type: Dictionary(
                    Int32,
                    Utf8,
                ),
                nullable: true,
                dict_id: 0,
                dict_is_ordered: false,
                metadata: {
                    "iox::column::type": "iox::column_type::tag",
                },
            },
            Field {
                name: "path",
                data_type: Dictionary(
                    Int32,
                    Utf8,
                ),
                nullable: true,
                dict_id: 0,
                dict_is_ordered: false,
                metadata: {
                    "iox::column::type": "iox::column_type::tag",
                },
            },
            Field {
                name: "free",
                data_type: Int64,
                nullable: true,
                dict_id: 0,
                dict_is_ordered: false,
                metadata: {
                    "iox::column::type": "iox::column_type::field::integer",
                },
            },
            Field {
                name: "inodes_free",
                data_type: Int64,
                nullable: true,
                dict_id: 0,
                dict_is_ordered: false,
                metadata: {
                    "iox::column::type": "iox::column_type::field::integer",
                },
            },
            Field {
                name: "inodes_total",
                data_type: Int64,
                nullable: true,
                dict_id: 0,
                dict_is_ordered: false,
                metadata: {
                    "iox::column::type": "iox::column_type::field::integer",
                },
            },
            Field {
                name: "inodes_used",
                data_type: Int64,
                nullable: true,
                dict_id: 0,
                dict_is_ordered: false,
                metadata: {
                    "iox::column::type": "iox::column_type::field::integer",
                },
            },
            Field {
                name: "total",
                data_type: Int64,
                nullable: true,
                dict_id: 0,
                dict_is_ordered: false,
                metadata: {
                    "iox::column::type": "iox::column_type::field::integer",
                },
            },
            Field {
                name: "used",
                data_type: Int64,
                nullable: true,
                dict_id: 0,
                dict_is_ordered: false,
                metadata: {
                    "iox::column::type": "iox::column_type::field::integer",
                },
            },
            Field {
                name: "used_percent",
                data_type: Float64,
                nullable: true,
                dict_id: 0,
                dict_is_ordered: false,
                metadata: {
                    "iox::column::type": "iox::column_type::field::float",
                },
            },
        ],
        metadata: {},
    },
}
thread 'test::test_tsm' panicked at 'not yet implemented', parquet_to_line_protocol/src/lib.rs:141:5
stack backtrace:

```