### PR TITLE
feat(router): CST mode

### DIFF
--- a/clap_blocks/src/router.rs
+++ b/clap_blocks/src/router.rs
@@ -4,6 +4,17 @@
 #[derive(Debug, Clone, clap::Parser)]
 #[allow(missing_copy_implementations)]
 pub struct RouterConfig {
+    /// Differential handling based upon deployment to CST vs MT.
+    ///
+    /// At minimum, differs in supports of v1 endpoint. But also includes
+    /// differences in namespace handling, etc.
+    #[clap(
+        long = "single-tenancy",
+        env = "INFLUXDB_IOX_SINGLE_TENANCY",
+        default_value = "false"
+    )]
+    pub single_tenant_deployment: bool,
+
     /// Query pool name to dispatch writes to.
     #[clap(
         long = "query-pool",

--- a/clap_blocks/src/router2.rs
+++ b/clap_blocks/src/router2.rs
@@ -10,6 +10,17 @@ use std::{
 #[derive(Debug, Clone, clap::Parser)]
 #[allow(missing_copy_implementations)]
 pub struct Router2Config {
+    /// Differential handling based upon deployment to CST vs MT.
+    ///
+    /// At minimum, differs in supports of v1 endpoint. But also includes
+    /// differences in namespace handling, etc.
+    #[clap(
+        long = "single-tenancy",
+        env = "INFLUXDB_IOX_SINGLE_TENANCY",
+        default_value = "false"
+    )]
+    pub single_tenant_deployment: bool,
+
     /// The maximum number of simultaneous requests the HTTP server is
     /// configured to accept.
     ///

--- a/data_types/src/namespace_name.rs
+++ b/data_types/src/namespace_name.rs
@@ -19,7 +19,7 @@ pub enum OrgBucketMappingError {
 
     /// Either the org, or bucket is an empty string.
     #[error("missing org/bucket value")]
-    NotSpecified,
+    NoOrgBucketSpecified,
 }
 
 /// [`NamespaceName`] name validation errors.
@@ -120,7 +120,7 @@ impl<'a> NamespaceName<'a> {
         let bucket = bucket.as_ref();
 
         if org.is_empty() || bucket.is_empty() {
-            return Err(OrgBucketMappingError::NotSpecified);
+            return Err(OrgBucketMappingError::NoOrgBucketSpecified);
         }
 
         let prefix: Cow<'_, str> = utf8_percent_encode(org, NON_ALPHANUMERIC).into();
@@ -222,7 +222,7 @@ mod tests {
     fn test_empty_org_bucket() {
         let err = NamespaceName::from_org_and_bucket("", "")
             .expect_err("should fail with empty org/bucket valuese");
-        assert!(matches!(err, OrgBucketMappingError::NotSpecified));
+        assert!(matches!(err, OrgBucketMappingError::NoOrgBucketSpecified));
     }
 
     #[test]

--- a/influxdb_iox/src/commands/run/all_in_one.rs
+++ b/influxdb_iox/src/commands/run/all_in_one.rs
@@ -468,6 +468,7 @@ impl Config {
             topic: QUERY_POOL_NAME.to_string(),
             rpc_write_timeout_seconds: Duration::new(3, 0),
             rpc_write_replicas: None,
+            single_tenant_deployment: false,
         };
 
         // create a CompactorConfig for the all in one server based on

--- a/router/benches/e2e.rs
+++ b/router/benches/e2e.rs
@@ -11,7 +11,10 @@ use router::{
     },
     namespace_cache::{MemoryNamespaceCache, ShardedCache},
     namespace_resolver::mock::MockNamespaceResolver,
-    server::http::HttpDelegate,
+    server::http::{
+        write::{multi_tenant::MultiTenantRequestParser, WriteParamExtractor},
+        HttpDelegate,
+    },
     shard::Shard,
 };
 use sharder::JumpHash;
@@ -79,6 +82,9 @@ fn e2e_benchmarks(c: &mut Criterion) {
         let namespace_resolver =
             MockNamespaceResolver::default().with_mapping("bananas", NamespaceId::new(42));
 
+        let write_param_extractor: Box<dyn WriteParamExtractor> =
+            Box::<MultiTenantRequestParser>::default();
+
         HttpDelegate::new(
             1024,
             100,
@@ -86,6 +92,7 @@ fn e2e_benchmarks(c: &mut Criterion) {
             Arc::new(handler_stack),
             None,
             &metrics,
+            write_param_extractor,
         )
     };
 

--- a/router/src/server/http.rs
+++ b/router/src/server/http.rs
@@ -629,6 +629,7 @@ mod tests {
 
     const MAX_BYTES: usize = 1024;
     const NAMESPACE_ID: NamespaceId = NamespaceId::new(42);
+    static NAMESPACE_NAME: &str = "bananas_test";
 
     fn summary() -> WriteSummary {
         WriteSummary::default()
@@ -716,7 +717,7 @@ mod tests {
                     test_http_handler!(encoding_header=$encoding, request);
 
                     let mock_namespace_resolver = MockNamespaceResolver::default()
-                        .with_mapping("bananas_test", NAMESPACE_ID);
+                        .with_mapping(NAMESPACE_NAME, NAMESPACE_ID);
                     let dml_handler = Arc::new(MockDmlHandler::default()
                         .with_write_return($dml_write_handler)
                         .with_delete_return($dml_delete_handler)
@@ -826,7 +827,7 @@ mod tests {
         dml_handler = [Ok(summary())],
         want_result = Ok(_),
         want_dml_calls = [MockDmlHandlerCall::Write{namespace, ..}] => {
-            assert_eq!(namespace, "bananas_test");
+            assert_eq!(namespace, NAMESPACE_NAME);
         }
     );
 
@@ -837,7 +838,7 @@ mod tests {
         dml_handler = [Ok(summary())],
         want_result = Ok(_),
         want_dml_calls = [MockDmlHandlerCall::Write{namespace, namespace_id, write_input}] => {
-            assert_eq!(namespace, "bananas_test");
+            assert_eq!(namespace, NAMESPACE_NAME);
             assert_eq!(*namespace_id, NAMESPACE_ID);
 
             let table = write_input.get("platanos").expect("table not found");
@@ -853,7 +854,7 @@ mod tests {
         dml_handler = [Ok(summary())],
         want_result = Ok(_),
         want_dml_calls = [MockDmlHandlerCall::Write{namespace, namespace_id, write_input}] => {
-            assert_eq!(namespace, "bananas_test");
+            assert_eq!(namespace, NAMESPACE_NAME);
             assert_eq!(*namespace_id, NAMESPACE_ID);
 
             let table = write_input.get("platanos").expect("table not found");
@@ -869,7 +870,7 @@ mod tests {
         dml_handler = [Ok(summary())],
         want_result = Ok(_),
         want_dml_calls = [MockDmlHandlerCall::Write{namespace, namespace_id, write_input}] => {
-            assert_eq!(namespace, "bananas_test");
+            assert_eq!(namespace, NAMESPACE_NAME);
             assert_eq!(*namespace_id, NAMESPACE_ID);
 
             let table = write_input.get("platanos").expect("table not found");
@@ -885,7 +886,7 @@ mod tests {
         dml_handler = [Ok(summary())],
         want_result = Ok(_),
         want_dml_calls = [MockDmlHandlerCall::Write{namespace, namespace_id, write_input}] => {
-            assert_eq!(namespace, "bananas_test");
+            assert_eq!(namespace, NAMESPACE_NAME);
             assert_eq!(*namespace_id, NAMESPACE_ID);
 
             let table = write_input.get("platanos").expect("table not found");
@@ -990,10 +991,10 @@ mod tests {
         db_not_found,
         query_string = "?org=bananas&bucket=test",
         body = "platanos,tag1=A,tag2=B val=42i 123456".as_bytes(),
-        dml_handler = [Err(DmlError::NamespaceNotFound("bananas_test".to_string()))],
+        dml_handler = [Err(DmlError::NamespaceNotFound(NAMESPACE_NAME.to_string()))],
         want_result = Err(Error::DmlHandler(DmlError::NamespaceNotFound(_))),
         want_dml_calls = [MockDmlHandlerCall::Write{namespace, ..}] => {
-            assert_eq!(namespace, "bananas_test");
+            assert_eq!(namespace, NAMESPACE_NAME);
         }
     );
 
@@ -1004,7 +1005,7 @@ mod tests {
         dml_handler = [Err(DmlError::Internal("💣".into()))],
         want_result = Err(Error::DmlHandler(DmlError::Internal(_))),
         want_dml_calls = [MockDmlHandlerCall::Write{namespace, ..}] => {
-            assert_eq!(namespace, "bananas_test");
+            assert_eq!(namespace, NAMESPACE_NAME);
         }
     );
 
@@ -1015,7 +1016,7 @@ mod tests {
         dml_handler = [Ok(summary())],
         want_result = Ok(_),
         want_dml_calls = [MockDmlHandlerCall::Write{namespace, namespace_id, write_input}] => {
-            assert_eq!(namespace, "bananas_test");
+            assert_eq!(namespace, NAMESPACE_NAME);
             assert_eq!(*namespace_id, NAMESPACE_ID);
             let table = write_input.get("test").expect("table not in write");
             let col = table.column("field").expect("column missing");
@@ -1043,7 +1044,7 @@ mod tests {
         want_result = Ok(_),
         want_dml_calls = [MockDmlHandlerCall::Delete{namespace, namespace_id, table, predicate}] => {
             assert_eq!(table, "its_a_table");
-            assert_eq!(namespace, "bananas_test");
+            assert_eq!(namespace, NAMESPACE_NAME);
             assert_eq!(*namespace_id, NAMESPACE_ID);
             assert!(!predicate.exprs.is_empty());
         }
@@ -1107,11 +1108,11 @@ mod tests {
         db_not_found,
         query_string = "?org=bananas&bucket=test",
         body = r#"{"start":"2021-04-01T14:00:00Z","stop":"2021-04-02T14:00:00Z", "predicate":"_measurement=its_a_table and location=Boston"}"#.as_bytes(),
-        dml_handler = [Err(DmlError::NamespaceNotFound("bananas_test".to_string()))],
+        dml_handler = [Err(DmlError::NamespaceNotFound(NAMESPACE_NAME.to_string()))],
         want_result = Err(Error::DmlHandler(DmlError::NamespaceNotFound(_))),
         want_dml_calls = [MockDmlHandlerCall::Delete{namespace, namespace_id, table, predicate}] => {
             assert_eq!(table, "its_a_table");
-            assert_eq!(namespace, "bananas_test");
+            assert_eq!(namespace, NAMESPACE_NAME);
             assert_eq!(*namespace_id, NAMESPACE_ID);
             assert!(!predicate.exprs.is_empty());
         }
@@ -1125,7 +1126,7 @@ mod tests {
         want_result = Err(Error::DmlHandler(DmlError::Internal(_))),
         want_dml_calls = [MockDmlHandlerCall::Delete{namespace, namespace_id, table, predicate}] => {
             assert_eq!(table, "its_a_table");
-            assert_eq!(namespace, "bananas_test");
+            assert_eq!(namespace, NAMESPACE_NAME);
             assert_eq!(*namespace_id, NAMESPACE_ID);
             assert!(!predicate.exprs.is_empty());
         }
@@ -1152,7 +1153,7 @@ mod tests {
             dml_handler = [Ok(summary())],
             want_result = Ok(_),
             want_dml_calls = [MockDmlHandlerCall::Write{namespace, write_input, ..}] => {
-                assert_eq!(namespace, "bananas_test");
+                assert_eq!(namespace, NAMESPACE_NAME);
                 let table = write_input.get("whydo").expect("table not in write");
                 let col = table.column("InputPower").expect("column missing");
                 assert_matches!(col.data(), ColumnData::I64(data, _) => {
@@ -1169,7 +1170,7 @@ mod tests {
             dml_handler = [Ok(summary())],
             want_result = Ok(_),
             want_dml_calls = [MockDmlHandlerCall::Write{namespace, write_input, ..}] => {
-                assert_eq!(namespace, "bananas_test");
+                assert_eq!(namespace, NAMESPACE_NAME);
                 let table = write_input.get("whydo").expect("table not in write");
                 let col = table.column("InputPower").expect("column missing");
                 assert_matches!(col.data(), ColumnData::I64(data, _) => {
@@ -1409,7 +1410,7 @@ mod tests {
     #[tokio::test]
     async fn test_authz() {
         let mock_namespace_resolver =
-            MockNamespaceResolver::default().with_mapping("bananas_test", NamespaceId::new(42));
+            MockNamespaceResolver::default().with_mapping(NAMESPACE_NAME, NamespaceId::new(42));
 
         let dml_handler = Arc::new(
             MockDmlHandler::default()
@@ -1474,7 +1475,7 @@ mod tests {
 
         let calls = dml_handler.calls();
         assert_matches!(calls.as_slice(), [MockDmlHandlerCall::Write{namespace, ..}] => {
-            assert_eq!(namespace, "bananas_test");
+            assert_eq!(namespace, NAMESPACE_NAME);
         })
     }
 

--- a/router/src/server/http.rs
+++ b/router/src/server/http.rs
@@ -1,10 +1,10 @@
 //! HTTP service implementations for `router`.
 
 mod delete_predicate;
+pub mod write;
 
 use authz::{Action, Authorizer, Permission, Resource};
 use bytes::{Bytes, BytesMut};
-use data_types::{NamespaceName, OrgBucketMappingError};
 use futures::StreamExt;
 use hashbrown::HashMap;
 use hyper::{header::CONTENT_ENCODING, Body, Method, Request, Response, StatusCode};
@@ -14,7 +14,6 @@ use mutable_batch::MutableBatch;
 use mutable_batch_lp::LinesConverter;
 use observability_deps::tracing::*;
 use predicate::delete_predicate::parse_delete_predicate;
-use serde::Deserialize;
 use server_util::authorization::AuthorizationHeaderExtension;
 use std::{str::Utf8Error, sync::Arc, time::Instant};
 use thiserror::Error;
@@ -22,7 +21,13 @@ use tokio::sync::{Semaphore, TryAcquireError};
 use trace::ctx::SpanContext;
 use write_summary::WriteSummary;
 
-use self::delete_predicate::parse_http_delete_request;
+use self::{
+    delete_predicate::parse_http_delete_request,
+    write::{
+        multi_tenant::MultiTenantExtractError, single_tenant::SingleTenantExtractError,
+        WriteParamExtractor, WriteParams,
+    },
+};
 use crate::{
     dml_handlers::{
         DmlError, DmlHandler, PartitionError, RetentionError, RpcWriteError, SchemaError,
@@ -39,9 +44,13 @@ pub enum Error {
     #[error("not found")]
     NoHandler,
 
-    /// An error with the org/bucket in the request.
+    /// An error parsing a single-tenant HTTP request.
     #[error(transparent)]
-    InvalidOrgBucket(#[from] OrgBucketError),
+    SingleTenantError(#[from] SingleTenantExtractError),
+
+    /// An error parsing a multi-tenant HTTP request.
+    #[error(transparent)]
+    MultiTenantError(#[from] MultiTenantExtractError),
 
     /// The request body content is not valid utf8.
     #[error("body content is not valid utf8: {0}")]
@@ -114,7 +123,6 @@ impl Error {
     pub fn as_status_code(&self) -> StatusCode {
         match self {
             Error::NoHandler => StatusCode::NOT_FOUND,
-            Error::InvalidOrgBucket(_) => StatusCode::BAD_REQUEST,
             Error::ClientHangup(_) => StatusCode::BAD_REQUEST,
             Error::InvalidGzip(_) => StatusCode::BAD_REQUEST,
             Error::NonUtf8ContentHeader(_) => StatusCode::BAD_REQUEST,
@@ -137,6 +145,8 @@ impl Error {
             Error::Unauthenticated => StatusCode::UNAUTHORIZED,
             Error::Forbidden => StatusCode::FORBIDDEN,
             Error::Authorizer(_) => StatusCode::INTERNAL_SERVER_ERROR,
+            Error::SingleTenantError(e) => StatusCode::from(e),
+            Error::MultiTenantError(e) => StatusCode::from(e),
         }
     }
 }
@@ -190,79 +200,6 @@ impl From<&DmlError> for StatusCode {
     }
 }
 
-/// Errors returned when decoding the organisation / bucket information from a
-/// HTTP request and deriving the namespace name from it.
-#[derive(Debug, Error)]
-pub enum OrgBucketError {
-    /// The request contains no org/bucket destination information.
-    #[error("no org/bucket destination provided")]
-    NotSpecified,
-
-    /// The request contains invalid parameters.
-    #[error("failed to deserialize org/bucket/precision in request: {0}")]
-    DecodeFail(#[from] serde::de::value::Error),
-
-    /// The provided org/bucket could not be converted into a namespace name.
-    #[error(transparent)]
-    MappingFail(#[from] OrgBucketMappingError),
-}
-
-#[derive(Debug, Deserialize)]
-enum Precision {
-    #[serde(rename = "s")]
-    Seconds,
-    #[serde(rename = "ms")]
-    Milliseconds,
-    #[serde(rename = "us")]
-    Microseconds,
-    #[serde(rename = "ns")]
-    Nanoseconds,
-}
-
-impl Default for Precision {
-    fn default() -> Self {
-        Self::Nanoseconds
-    }
-}
-
-impl Precision {
-    /// Returns the multiplier to convert to nanosecond timestamps
-    fn timestamp_base(&self) -> i64 {
-        match self {
-            Precision::Seconds => 1_000_000_000,
-            Precision::Milliseconds => 1_000_000,
-            Precision::Microseconds => 1_000,
-            Precision::Nanoseconds => 1,
-        }
-    }
-}
-
-#[derive(Debug, Deserialize)]
-/// Org & bucket identifiers for a DML operation.
-pub struct WriteInfo {
-    org: String,
-    bucket: String,
-
-    #[serde(default)]
-    precision: Precision,
-}
-
-impl<T> TryFrom<&Request<T>> for WriteInfo {
-    type Error = OrgBucketError;
-
-    fn try_from(req: &Request<T>) -> Result<Self, Self::Error> {
-        let query = req.uri().query().ok_or(OrgBucketError::NotSpecified)?;
-        let got: WriteInfo = serde_urlencoded::from_str(query)?;
-
-        // An empty org or bucket is not acceptable.
-        if got.org.is_empty() || got.bucket.is_empty() {
-            return Err(OrgBucketError::NotSpecified);
-        }
-
-        Ok(got)
-    }
-}
-
 /// This type is responsible for servicing requests to the `router` HTTP
 /// endpoint.
 ///
@@ -276,6 +213,7 @@ pub struct HttpDelegate<D, N, T = SystemProvider> {
     namespace_resolver: N,
     dml_handler: D,
     authz: Option<Arc<dyn Authorizer>>,
+    write_param_extractor: Box<dyn WriteParamExtractor>,
 
     // A request limiter to restrict the number of simultaneous requests this
     // router services.
@@ -308,6 +246,7 @@ impl<D, N> HttpDelegate<D, N, SystemProvider> {
         dml_handler: D,
         authz: Option<Arc<dyn Authorizer>>,
         metrics: &metric::Registry,
+        write_param_extractor: Box<dyn WriteParamExtractor>,
     ) -> Self {
         let write_metric_lines = metrics
             .register_metric::<U64Counter>(
@@ -356,6 +295,7 @@ impl<D, N> HttpDelegate<D, N, SystemProvider> {
             max_request_bytes,
             time_provider: SystemProvider::default(),
             namespace_resolver,
+            write_param_extractor,
             dml_handler,
             authz,
             request_sem: Semaphore::new(max_requests),
@@ -398,7 +338,14 @@ where
 
         // Route the request to a handler.
         match (req.method(), req.uri().path()) {
-            (&Method::POST, "/api/v2/write") => self.write_handler(req).await,
+            (&Method::POST, "/write") => {
+                let dml_info = self.write_param_extractor.parse_v1(&req)?;
+                self.write_handler(req, dml_info).await
+            }
+            (&Method::POST, "/api/v2/write") => {
+                let dml_info = self.write_param_extractor.parse_v2(&req)?;
+                self.write_handler(req, dml_info).await
+            }
             (&Method::POST, "/api/v2/delete") => self.delete_handler(req).await,
             _ => return Err(Error::NoHandler),
         }
@@ -411,12 +358,12 @@ where
         })
     }
 
-    async fn write_handler(&self, req: Request<Body>) -> Result<WriteSummary, Error> {
+    async fn write_handler(
+        &self,
+        req: Request<Body>,
+        write_info: WriteParams,
+    ) -> Result<WriteSummary, Error> {
         let span_ctx: Option<SpanContext> = req.extensions().get().cloned();
-
-        let write_info = WriteInfo::try_from(&req)?;
-        let namespace = NamespaceName::from_org_and_bucket(write_info.org, write_info.bucket)
-            .map_err(OrgBucketError::MappingFail)?;
 
         let token = req
             .extensions()
@@ -434,13 +381,13 @@ where
                 }
             });
         let perms = [Permission::ResourceAction(
-            Resource::Namespace(namespace.to_string()),
+            Resource::Namespace(write_info.namespace.to_string()),
             Action::Write,
         )];
         self.authz.require_any_permission(token, &perms).await?;
 
         trace!(
-            %namespace,
+            namespace=%write_info.namespace,
             "processing write request"
         );
 
@@ -473,17 +420,20 @@ where
             num_tables,
             precision=?write_info.precision,
             body_size=body.len(),
-            %namespace,
+            namespace=%write_info.namespace,
             duration=?duration,
             "routing write",
         );
 
         // Retrieve the namespace ID for this namespace.
-        let namespace_id = self.namespace_resolver.get_namespace_id(&namespace).await?;
+        let namespace_id = self
+            .namespace_resolver
+            .get_namespace_id(&write_info.namespace)
+            .await?;
 
         let summary = self
             .dml_handler
-            .write(&namespace, namespace_id, batches, span_ctx)
+            .write(&write_info.namespace, namespace_id, batches, span_ctx)
             .await
             .map_err(Into::into)?;
 
@@ -497,12 +447,9 @@ where
 
     async fn delete_handler(&self, req: Request<Body>) -> Result<WriteSummary, Error> {
         let span_ctx: Option<SpanContext> = req.extensions().get().cloned();
+        let write_info = self.write_param_extractor.parse_v2(&req)?;
 
-        let account = WriteInfo::try_from(&req)?;
-        let namespace = NamespaceName::from_org_and_bucket(account.org, account.bucket)
-            .map_err(OrgBucketError::MappingFail)?;
-
-        trace!(%namespace, "processing delete request");
+        trace!(namespace=%write_info.namespace, "processing delete request");
 
         // Read the HTTP body and convert it to a str.
         let body = self.read_body(req).await?;
@@ -522,15 +469,18 @@ where
             start=%parsed_delete.start_time,
             stop=%parsed_delete.stop_time,
             body_size=body.len(),
-            %namespace,
+            namespace=%write_info.namespace,
             "routing delete"
         );
 
-        let namespace_id = self.namespace_resolver.get_namespace_id(&namespace).await?;
+        let namespace_id = self
+            .namespace_resolver
+            .get_namespace_id(&write_info.namespace)
+            .await?;
 
         self.dml_handler
             .delete(
-                &namespace,
+                &write_info.namespace,
                 namespace_id,
                 parsed_delete.table_name.as_str(),
                 &predicate,
@@ -613,16 +563,24 @@ mod tests {
             CachedServiceProtectionLimit,
         },
         namespace_resolver::{mock::MockNamespaceResolver, NamespaceCreationError},
+        server::http::write::{
+            mock::{MockExtractorCall, MockWriteParamsExtractor},
+            multi_tenant::MultiTenantRequestParser,
+            v1::V1WriteParseError,
+            v2::V2WriteParseError,
+            Precision,
+        },
     };
     use assert_matches::assert_matches;
     use async_trait::async_trait;
-    use data_types::{NamespaceId, NamespaceNameError, TableId};
+    use data_types::{
+        NamespaceId, NamespaceName, NamespaceNameError, OrgBucketMappingError, TableId,
+    };
     use flate2::{write::GzEncoder, Compression};
     use hyper::header::HeaderValue;
     use metric::{Attributes, Metric};
     use mutable_batch::column::ColumnData;
     use mutable_batch_lp::LineWriteError;
-    use serde::de::Error as _;
     use std::{io::Write, iter, sync::Arc, time::Duration};
     use test_helpers::timeout::FutureTimeout;
     use tokio_stream::wrappers::ReceiverStream;
@@ -649,6 +607,16 @@ mod tests {
             assert!(counter > 0, "metric {name} did not record any values");
         }
     }
+
+    ////////////////////////////////////////////////////////////////////////////
+    //
+    // The following tests assert "cloud2" or "multi-tenant" mode only, as this
+    // is the default operating mode.
+    //
+    // Tests of the single-tenant behaviour differs from the established norms,
+    // and can be found alongside the single-tenant implementation.
+    //
+    ////////////////////////////////////////////////////////////////////////////
 
     // Generate two HTTP handler tests - one for a plain request and one with a
     // gzip-encoded body (and appropriate header), asserting the handler return
@@ -729,7 +697,8 @@ mod tests {
                         mock_namespace_resolver,
                         Arc::clone(&dml_handler),
                         None,
-                        &metrics
+                        &metrics,
+                        Box::<crate::server::http::write::multi_tenant::MultiTenantRequestParser>::default(),
                     );
 
                     let got = delegate.route(request).await;
@@ -910,7 +879,9 @@ mod tests {
         query_string = "",
         body = "platanos,tag1=A,tag2=B val=42i 123456".as_bytes(),
         dml_handler = [Ok(summary())],
-        want_result = Err(Error::InvalidOrgBucket(OrgBucketError::NotSpecified)),
+        want_result = Err(Error::MultiTenantError(
+            MultiTenantExtractError::ParseV2Request(V2WriteParseError::NoQueryParams)
+        )),
         want_dml_calls = [] // None
     );
 
@@ -919,7 +890,11 @@ mod tests {
         query_string = "?",
         body = "platanos,tag1=A,tag2=B val=42i 123456".as_bytes(),
         dml_handler = [Ok(summary())],
-        want_result = Err(Error::InvalidOrgBucket(OrgBucketError::DecodeFail(_))),
+        want_result = Err(Error::MultiTenantError(
+            MultiTenantExtractError::InvalidOrgAndBucket(
+                OrgBucketMappingError::NoOrgBucketSpecified
+            )
+        )),
         want_dml_calls = [] // None
     );
 
@@ -928,7 +903,11 @@ mod tests {
         query_string = "?org=&bucket=",
         body = "platanos,tag1=A,tag2=B val=42i 123456".as_bytes(),
         dml_handler = [Ok(summary())],
-        want_result = Err(Error::InvalidOrgBucket(OrgBucketError::NotSpecified)),
+        want_result = Err(Error::MultiTenantError(
+            MultiTenantExtractError::InvalidOrgAndBucket(
+                OrgBucketMappingError::NoOrgBucketSpecified
+            )
+        )),
         want_dml_calls = [] // None
     );
 
@@ -937,7 +916,13 @@ mod tests {
         query_string = format!("?org=test&bucket={}", "A".repeat(1000)),
         body = "platanos,tag1=A,tag2=B val=42i 123456".as_bytes(),
         dml_handler = [Ok(summary())],
-        want_result = Err(Error::InvalidOrgBucket(OrgBucketError::MappingFail(_))),
+        want_result = Err(Error::MultiTenantError(
+            MultiTenantExtractError::InvalidOrgAndBucket(
+                OrgBucketMappingError::InvalidNamespaceName(
+                    NamespaceNameError::LengthConstraint { .. }
+                )
+            )
+        )),
         want_dml_calls = [] // None
     );
 
@@ -1064,7 +1049,9 @@ mod tests {
         query_string = "",
         body = "".as_bytes(),
         dml_handler = [Ok(())],
-        want_result = Err(Error::InvalidOrgBucket(OrgBucketError::NotSpecified)),
+        want_result = Err(Error::MultiTenantError(
+            MultiTenantExtractError::ParseV2Request(V2WriteParseError::NoQueryParams)
+        )),
         want_dml_calls = [] // None
     );
 
@@ -1073,7 +1060,11 @@ mod tests {
         query_string = "?",
         body = "".as_bytes(),
         dml_handler = [Ok(())],
-        want_result = Err(Error::InvalidOrgBucket(OrgBucketError::DecodeFail(_))),
+        want_result = Err(Error::MultiTenantError(
+            MultiTenantExtractError::InvalidOrgAndBucket(
+                OrgBucketMappingError::NoOrgBucketSpecified
+            )
+        )),
         want_dml_calls = [] // None
     );
 
@@ -1082,7 +1073,11 @@ mod tests {
         query_string = "?org=&bucket=",
         body = "".as_bytes(),
         dml_handler = [Ok(())],
-        want_result = Err(Error::InvalidOrgBucket(OrgBucketError::NotSpecified)),
+        want_result = Err(Error::MultiTenantError(
+            MultiTenantExtractError::InvalidOrgAndBucket(
+                OrgBucketMappingError::NoOrgBucketSpecified
+            )
+        )),
         want_dml_calls = [] // None
     );
 
@@ -1091,7 +1086,13 @@ mod tests {
         query_string = format!("?org=test&bucket={}", "A".repeat(1000)),
         body = "".as_bytes(),
         dml_handler = [Ok(())],
-        want_result = Err(Error::InvalidOrgBucket(OrgBucketError::MappingFail(_))),
+        want_result = Err(Error::MultiTenantError(
+            MultiTenantExtractError::InvalidOrgAndBucket(
+                OrgBucketMappingError::InvalidNamespaceName(
+                    NamespaceNameError::LengthConstraint { .. }
+                )
+            )
+        )),
         want_dml_calls = [] // None
     );
 
@@ -1279,6 +1280,14 @@ mod tests {
             Arc::clone(&dml_handler),
             None,
             &metrics,
+            Box::new(
+                MockWriteParamsExtractor::default().with_ret(iter::repeat_with(|| {
+                    Ok(WriteParams {
+                        namespace: NamespaceName::new(NAMESPACE_NAME).unwrap(),
+                        precision: Precision::default(),
+                    })
+                })),
+            ),
         ));
 
         // Use a channel to hold open the request.
@@ -1426,13 +1435,21 @@ mod tests {
             Arc::clone(&dml_handler),
             Some(authz),
             &metrics,
+            Box::new(
+                MockWriteParamsExtractor::default().with_ret(iter::repeat_with(|| {
+                    Ok(WriteParams {
+                        namespace: NamespaceName::new(NAMESPACE_NAME).unwrap(),
+                        precision: Precision::default(),
+                    })
+                })),
+            ),
         );
 
         let request = Request::builder()
             .uri("https://bananas.example/api/v2/write?org=bananas&bucket=test")
             .method("POST")
             .extension(AuthorizationHeaderExtension::new(Some(
-                HeaderValue::from_str("Token GOOD").expect("ok"),
+                HeaderValue::from_str("Token GOOD").unwrap(),
             )))
             .body(Body::from("platanos,tag1=A,tag2=B val=42i 123456"))
             .unwrap();
@@ -1444,7 +1461,7 @@ mod tests {
             .uri("https://bananas.example/api/v2/write?org=bananas&bucket=test")
             .method("POST")
             .extension(AuthorizationHeaderExtension::new(Some(
-                HeaderValue::from_str("Token BAD").expect("ok"),
+                HeaderValue::from_str("Token BAD").unwrap(),
             )))
             .body(Body::from(""))
             .unwrap();
@@ -1465,7 +1482,7 @@ mod tests {
             .uri("https://bananas.example/api/v2/write?org=bananas&bucket=test")
             .method("POST")
             .extension(AuthorizationHeaderExtension::new(Some(
-                HeaderValue::from_str("Token UGLY").expect("ok"),
+                HeaderValue::from_str("Token UGLY").unwrap(),
             )))
             .body(Body::from(""))
             .unwrap();
@@ -1477,6 +1494,133 @@ mod tests {
         assert_matches!(calls.as_slice(), [MockDmlHandlerCall::Write{namespace, ..}] => {
             assert_eq!(namespace, NAMESPACE_NAME);
         })
+    }
+
+    /// Assert the router rejects writes to the V1 endpoint when in
+    /// "multi-tenant" mode.
+    #[tokio::test]
+    async fn test_multi_tenant_denies_v1_writes() {
+        let mock_namespace_resolver =
+            MockNamespaceResolver::default().with_mapping(NAMESPACE_NAME, NamespaceId::new(42));
+
+        let dml_handler = Arc::new(
+            MockDmlHandler::default()
+                .with_write_return([Ok(summary())])
+                .with_delete_return([]),
+        );
+        let metrics = Arc::new(metric::Registry::default());
+        let delegate = HttpDelegate::new(
+            MAX_BYTES,
+            1,
+            mock_namespace_resolver,
+            Arc::clone(&dml_handler),
+            None,
+            &metrics,
+            Box::<MultiTenantRequestParser>::default(),
+        );
+
+        let request = Request::builder()
+            .uri("https://bananas.example/write")
+            .method("POST")
+            .extension(AuthorizationHeaderExtension::new(Some(
+                HeaderValue::from_str("Token GOOD").unwrap(),
+            )))
+            .body(Body::from("platanos,tag1=A,tag2=B val=42i 123456"))
+            .unwrap();
+
+        let got = delegate.route(request).await;
+        assert_matches!(got, Err(Error::NoHandler));
+    }
+
+    /// Assert the router delegates request parsing to the
+    /// [`WriteParamExtractor`] implementation.
+    ///
+    /// By validating request parsing is delegated, behavioural tests for each
+    /// implementation can be implemented directly against those implementations
+    /// (instead of putting them all here).
+    #[tokio::test]
+    async fn test_delegate_to_write_param_extractor_ok() {
+        let mock_namespace_resolver =
+            MockNamespaceResolver::default().with_mapping(NAMESPACE_NAME, NamespaceId::new(42));
+
+        let request_parser = Arc::new(MockWriteParamsExtractor::default().with_ret(
+            iter::repeat_with(|| {
+                Ok(WriteParams {
+                    namespace: NamespaceName::new(NAMESPACE_NAME).unwrap(),
+                    precision: Precision::default(),
+                })
+            }),
+        ));
+
+        let dml_handler = Arc::new(
+            MockDmlHandler::default()
+                .with_write_return([Ok(summary()), Ok(summary()), Ok(summary())])
+                .with_delete_return([]),
+        );
+        let metrics = Arc::new(metric::Registry::default());
+        let delegate = HttpDelegate::new(
+            MAX_BYTES,
+            1,
+            mock_namespace_resolver,
+            Arc::clone(&dml_handler),
+            None,
+            &metrics,
+            Box::new(Arc::clone(&request_parser)),
+        );
+
+        // A route miss does not invoke the parser
+        let request = Request::builder()
+            .uri("https://bananas.example/wat")
+            .method("POST")
+            .body(Body::from(""))
+            .unwrap();
+        let got = delegate.route(request).await;
+        assert_matches!(got, Err(Error::NoHandler));
+
+        // V1 write parsing is delegated
+        let request = Request::builder()
+            .uri("https://bananas.example/write")
+            .method("POST")
+            .body(Body::from("platanos,tag1=A,tag2=B val=42i 123456"))
+            .unwrap();
+        let got = delegate.route(request).await;
+        assert_matches!(got, Ok(_));
+
+        // Only one call was received, and it should be v1.
+        assert_matches!(request_parser.calls().as_slice(), [MockExtractorCall::V1]);
+
+        // V2 write parsing is delegated
+        let request = Request::builder()
+            .uri("https://bananas.example/api/v2/write")
+            .method("POST")
+            .body(Body::from("platanos,tag1=A,tag2=B val=42i 123456"))
+            .unwrap();
+        let got = delegate.route(request).await;
+        assert_matches!(got, Ok(_));
+
+        // Both call were received.
+        assert_matches!(
+            request_parser.calls().as_slice(),
+            [MockExtractorCall::V1, MockExtractorCall::V2]
+        );
+
+        // Delete requests hit the v2 parser
+        let request = Request::builder()
+            .uri("https://bananas.example/api/v2/delete")
+            .method("POST")
+            .body(Body::from(""))
+            .unwrap();
+        let _got = delegate.route(request).await;
+
+        // The delete should have hit v2.
+        assert_matches!(
+            request_parser.calls().as_slice(),
+            [
+                MockExtractorCall::V1,
+                MockExtractorCall::V2,
+                MockExtractorCall::V2
+            ]
+        );
     }
 
     // The display text of Error gets passed through `ioxd_router::IoxHttpErrorAdaptor` then
@@ -1528,31 +1672,6 @@ mod tests {
         (
             NoHandler,
             "not found",
-        ),
-
-        (InvalidOrgBucket(OrgBucketError::NotSpecified), "no org/bucket destination provided"),
-
-        (
-            InvalidOrgBucket({
-                let e = serde::de::value::Error::custom("[deserialization error]");
-                OrgBucketError::DecodeFail(e)
-            }),
-            "failed to deserialize org/bucket/precision in request: [deserialization error]",
-        ),
-
-        (
-            InvalidOrgBucket(OrgBucketError::MappingFail(OrgBucketMappingError::NotSpecified)),
-            "missing org/bucket value",
-        ),
-
-        (
-            InvalidOrgBucket({
-                let e = NamespaceNameError::LengthConstraint { name: "[too long name]".into() };
-                let e = OrgBucketMappingError::InvalidNamespaceName(e);
-                OrgBucketError::MappingFail(e)
-            }),
-            "invalid namespace name: \
-             namespace name [too long name] length must be between 1 and 64 characters",
         ),
 
         (
@@ -1727,6 +1846,40 @@ mod tests {
                 namespace_id: NamespaceId::new(42),
             })))),
             "dml handler error: service limit reached: couldn't create table bananas; limit reached on namespace 42",
+        ),
+
+        // A single-tenant namespace parsing error
+        (
+            SingleTenantError(SingleTenantExtractError::InvalidNamespace(NamespaceNameError::LengthConstraint{name: "bananas".to_string()})),
+            "namespace name bananas length must be between 1 and 64 characters",
+        ),
+        // A single-tenant v1 parsing error
+        (
+            SingleTenantError(SingleTenantExtractError::ParseV1Request(V1WriteParseError::NoQueryParams)),
+            "no db destination provided",
+        ),
+        // A single-tenant v2 parsing error
+        (
+            SingleTenantError(SingleTenantExtractError::ParseV2Request(V2WriteParseError::NoQueryParams)),
+            "no org/bucket destination provided",
+        ),
+
+        // A multi-tenant namespace parsing error
+        (
+            MultiTenantError(MultiTenantExtractError::InvalidOrgAndBucket(OrgBucketMappingError::InvalidNamespaceName(NamespaceNameError::LengthConstraint{name: "bananas".to_string()}))),
+            "invalid namespace name: namespace name bananas length must be between 1 and 64 characters",
+        ),
+        (
+            MultiTenantError(MultiTenantExtractError::InvalidOrgAndBucket(OrgBucketMappingError::NoOrgBucketSpecified)),
+            "missing org/bucket value",
+        ),
+
+        // There is no multi-tenant support for v1 parsing, so no errors!
+
+        // A multi-tenant v2 parsing error
+        (
+            MultiTenantError(MultiTenantExtractError::ParseV2Request(V2WriteParseError::NoQueryParams)),
+            "no org/bucket destination provided",
         ),
     }
 }

--- a/router/src/server/http/write/mod.rs
+++ b/router/src/server/http/write/mod.rs
@@ -1,0 +1,11 @@
+//! HTTP Write V1 and V2 implementation logic for both single, and multi-tenant
+//! operational modes.
+
+pub mod v1;
+pub mod v2;
+
+pub mod multi_tenant;
+pub mod single_tenant;
+
+mod params;
+pub use params::*;

--- a/router/src/server/http/write/multi_tenant.rs
+++ b/router/src/server/http/write/multi_tenant.rs
@@ -115,6 +115,14 @@ mod tests {
     }
 
     test_parse_v2!(
+        no_query_string,
+        query_string = "",
+        want = Err(Error::MultiTenantError(
+            MultiTenantExtractError::ParseV2Request(V2WriteParseError::NoQueryParams)
+        ))
+    );
+
+    test_parse_v2!(
         empty_query_string,
         query_string = "?",
         want = Err(Error::MultiTenantError(

--- a/router/src/server/http/write/multi_tenant.rs
+++ b/router/src/server/http/write/multi_tenant.rs
@@ -1,0 +1,71 @@
+//! MultiTenantRequestParser
+
+use data_types::{NamespaceName, OrgBucketMappingError};
+use hyper::{Body, Request};
+
+use super::{
+    v2::{V2WriteParseError, WriteParamsV2},
+    WriteParamExtractor, WriteParams,
+};
+use crate::server::http::Error;
+
+/// Request parsing errors when operating in "single tenant" mode.
+#[derive(Debug, Error)]
+pub enum MultiTenantExtractError {
+    /// A failure to map a org & bucket to a reasonable [`NamespaceName`].
+    #[error(transparent)]
+    InvalidOrgAndBucket(#[from] OrgBucketMappingError),
+
+    /// A [`WriteParamsV2`] failed to be parsed from the HTTP request.
+    #[error(transparent)]
+    ParseV2Request(#[from] V2WriteParseError),
+}
+
+/// Implement a by-ref conversion to avoid "moving" the inner errors when only
+/// matching against the variants is necessary (the actual error content is
+/// discarded, replaced with only a HTTP code)
+impl From<&MultiTenantExtractError> for hyper::StatusCode {
+    fn from(value: &MultiTenantExtractError) -> Self {
+        // Exhaustively match the inner parser errors to ensure new additions
+        // have to be explicitly mapped and are not accidentally mapped to a
+        // "catch all" code.
+        match value {
+            MultiTenantExtractError::InvalidOrgAndBucket(_) => Self::BAD_REQUEST,
+            MultiTenantExtractError::ParseV2Request(
+                V2WriteParseError::NoQueryParams | V2WriteParseError::DecodeFail(_),
+            ) => Self::BAD_REQUEST,
+        }
+    }
+}
+
+/// Request parsing for cloud2 / multi-tenant deployments.
+///
+/// This handler respects the [V2 Write API] without modification, and rejects
+/// any V1 write requests.
+///
+/// [V2 Write API]:
+///     https://docs.influxdata.com/influxdb/v2.6/api/#operation/PostWrite
+#[derive(Debug, Default)]
+pub struct MultiTenantRequestParser;
+
+impl WriteParamExtractor for MultiTenantRequestParser {
+    fn parse_v1(&self, _req: &Request<Body>) -> Result<WriteParams, Error> {
+        Err(Error::NoHandler)
+    }
+
+    fn parse_v2(&self, req: &Request<Body>) -> Result<WriteParams, Error> {
+        Ok(parse_v2(req)?)
+    }
+}
+
+// Parse a V2 write request for multi tenant mode.
+fn parse_v2(req: &Request<Body>) -> Result<WriteParams, MultiTenantExtractError> {
+    let write_params = WriteParamsV2::try_from(req)?;
+
+    let namespace = NamespaceName::from_org_and_bucket(write_params.org, write_params.bucket)?;
+
+    Ok(WriteParams {
+        namespace,
+        precision: write_params.precision,
+    })
+}

--- a/router/src/server/http/write/multi_tenant.rs
+++ b/router/src/server/http/write/multi_tenant.rs
@@ -164,13 +164,57 @@ mod tests {
     );
 
     test_parse_v2!(
-        encoded_bucket_separator,
+        encoded_separator,
         query_string = "?org=cool_confusing&bucket=bucket",
         want = Ok(WriteParams {
             namespace,
             ..
         }) => {
             assert_eq!(namespace.as_str(), "cool%5Fconfusing_bucket");
+        }
+    );
+
+    test_parse_v2!(
+        encoded_case_sensitive,
+        query_string = "?org=Captialize&bucket=bucket",
+        want = Ok(WriteParams {
+            namespace,
+            ..
+        }) => {
+            assert_eq!(namespace.as_str(), "Captialize_bucket");
+        }
+    );
+
+    test_parse_v2!(
+        encoded_quotation,
+        query_string = "?org=cool'confusing&bucket=bucket",
+        want = Ok(WriteParams {
+            namespace,
+            ..
+        }) => {
+            assert_eq!(namespace.as_str(), "cool%27confusing_bucket");
+        }
+    );
+
+    test_parse_v2!(
+        start_nonalphanumeric,
+        query_string = "?org=_coolconfusing&bucket=bucket",
+        want = Ok(WriteParams {
+            namespace,
+            ..
+        }) => {
+            assert_eq!(namespace.as_str(), "%5Fcoolconfusing_bucket");
+        }
+    );
+
+    test_parse_v2!(
+        minimum_length_possible,
+        query_string = "?org=o&bucket=b",
+        want = Ok(WriteParams {
+            namespace,
+            ..
+        }) => {
+            assert_eq!(namespace.as_str().len(), 3);
         }
     );
 

--- a/router/src/server/http/write/params.rs
+++ b/router/src/server/http/write/params.rs
@@ -1,0 +1,146 @@
+use std::sync::Arc;
+
+use data_types::NamespaceName;
+use hyper::{Body, Request};
+use serde::Deserialize;
+
+use crate::server::http::Error;
+
+#[derive(Clone, Debug, Deserialize)]
+pub(crate) enum Precision {
+    #[serde(rename = "s")]
+    Seconds,
+    #[serde(rename = "ms")]
+    Milliseconds,
+    #[serde(rename = "us")]
+    Microseconds,
+    #[serde(rename = "ns")]
+    Nanoseconds,
+}
+
+impl Default for Precision {
+    fn default() -> Self {
+        Self::Nanoseconds
+    }
+}
+
+impl Precision {
+    /// Returns the multiplier to convert to nanosecond timestamps
+    pub(crate) fn timestamp_base(&self) -> i64 {
+        match self {
+            Precision::Seconds => 1_000_000_000,
+            Precision::Milliseconds => 1_000_000,
+            Precision::Microseconds => 1_000,
+            Precision::Nanoseconds => 1,
+        }
+    }
+}
+
+#[derive(Debug)]
+/// Standardized DML operation parameters
+pub struct WriteParams {
+    pub(crate) namespace: NamespaceName<'static>,
+    pub(crate) precision: Precision,
+}
+
+/// A [`WriteParamExtractor`] abstraction returns [`WriteParams`] from
+/// [`Request`] that conform to the [V1 Write API] or [V2 Write API].
+///
+/// Differing request parsing semantics are abstracted through this trait
+/// (single tenant, vs multi tenant).
+///
+/// [V1 Write API]:
+///     https://docs.influxdata.com/influxdb/v1.8/tools/api/#write-http-endpoint
+/// [V2 Write API]:
+///     https://docs.influxdata.com/influxdb/v2.6/api/#operation/PostWrite
+pub trait WriteParamExtractor: std::fmt::Debug + Send + Sync {
+    /// Parse a [`WriteParams`] from a HTTP [`Request]`, according to the V1
+    /// Write API.
+    fn parse_v1(&self, req: &Request<Body>) -> Result<WriteParams, Error>;
+
+    /// Parse a [`WriteParams`] from a HTTP [`Request]`, according to the V2
+    /// Write API.
+    fn parse_v2(&self, req: &Request<Body>) -> Result<WriteParams, Error>;
+}
+
+impl<T> WriteParamExtractor for Arc<T>
+where
+    T: WriteParamExtractor,
+{
+    fn parse_v1(&self, req: &Request<Body>) -> Result<WriteParams, Error> {
+        (**self).parse_v1(req)
+    }
+
+    fn parse_v2(&self, req: &Request<Body>) -> Result<WriteParams, Error> {
+        (**self).parse_v2(req)
+    }
+}
+
+#[cfg(test)]
+pub mod mock {
+    use parking_lot::Mutex;
+
+    use super::*;
+
+    #[derive(Debug, Clone, Copy)]
+    pub enum MockExtractorCall {
+        V1,
+        V2,
+    }
+
+    struct State {
+        calls: Vec<MockExtractorCall>,
+        ret: Box<dyn Iterator<Item = Result<WriteParams, Error>> + Send + Sync>,
+    }
+
+    impl Default for State {
+        fn default() -> Self {
+            Self {
+                calls: Default::default(),
+                ret: Box::new(std::iter::empty()),
+            }
+        }
+    }
+
+    impl std::fmt::Debug for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            f.debug_struct("State").field("calls", &self.calls).finish()
+        }
+    }
+
+    #[derive(Debug, Default)]
+    pub struct MockWriteParamsExtractor {
+        state: Mutex<State>,
+    }
+
+    impl MockWriteParamsExtractor {
+        /// Read values off of the provided iterator and return them for calls
+        /// to [`Self::write()`].
+        pub(crate) fn with_ret<T, U>(self, ret: T) -> Self
+        where
+            T: IntoIterator<IntoIter = U>,
+            U: Iterator<Item = Result<WriteParams, Error>> + Send + Sync + 'static,
+        {
+            self.state.lock().ret = Box::new(ret.into_iter());
+            self
+        }
+
+        pub(crate) fn calls(&self) -> Vec<MockExtractorCall> {
+            self.state.lock().calls.clone()
+        }
+    }
+
+    impl WriteParamExtractor for MockWriteParamsExtractor {
+        fn parse_v1(&self, _req: &Request<Body>) -> Result<WriteParams, Error> {
+            let mut guard = self.state.lock();
+            guard.calls.push(MockExtractorCall::V1);
+            guard.ret.next().unwrap()
+        }
+
+        fn parse_v2(&self, _req: &Request<Body>) -> Result<WriteParams, Error> {
+            let mut guard = self.state.lock();
+            guard.calls.push(MockExtractorCall::V2);
+            guard.ret.next().unwrap()
+        }
+    }
+}

--- a/router/src/server/http/write/single_tenant.rs
+++ b/router/src/server/http/write/single_tenant.rs
@@ -270,6 +270,38 @@ mod tests {
     );
 
     test_parse_v1!(
+        encoded_case_sensitive,
+        query_string = "?db=BaNanas",
+        want = Ok(WriteParams{ namespace, precision: _ }) => {
+            assert_eq!(namespace.as_str(), "BaNanas");
+        }
+    );
+
+    test_parse_v1!(
+        encoded_quotation,
+        query_string = "?db=ban'anas",
+        want = Ok(WriteParams{ namespace, precision: _ }) => {
+            assert_eq!(namespace.as_str(), "ban'anas");
+        }
+    );
+
+    test_parse_v1!(
+        start_nonalphanumeric,
+        query_string = "?db=_bananas",
+        want = Ok(WriteParams{ namespace, precision: _ }) => {
+            assert_eq!(namespace.as_str(), "_bananas");
+        }
+    );
+
+    test_parse_v1!(
+        minimum_length_possible,
+        query_string = "?db=d",
+        want = Ok(WriteParams{ namespace, precision: _ }) => {
+            assert_eq!(namespace.as_str().len(), 1);
+        }
+    );
+
+    test_parse_v1!(
         with_precision,
         query_string = "?db=bananas&rp=ageless&precision=ms",
         want = Ok(WriteParams{ namespace, precision }) => {
@@ -366,6 +398,50 @@ mod tests {
         }) => {
             assert_eq!(namespace.as_str(), "bananas");
             assert_matches!(precision, Precision::Nanoseconds);
+        }
+    );
+
+    test_parse_v2!(
+        encoded_case_sensitive,
+        query_string = "?bucket=buCket",
+        want = Ok(WriteParams {
+            namespace,
+            ..
+        }) => {
+            assert_eq!(namespace.as_str(), "buCket");
+        }
+    );
+
+    test_parse_v2!(
+        encoded_quotation,
+        query_string = "?bucket=buc'ket",
+        want = Ok(WriteParams {
+            namespace,
+            ..
+        }) => {
+            assert_eq!(namespace.as_str(), "buc'ket");
+        }
+    );
+
+    test_parse_v2!(
+        start_nonalphanumeric,
+        query_string = "?bucket=_bucket",
+        want = Ok(WriteParams {
+            namespace,
+            ..
+        }) => {
+            assert_eq!(namespace.as_str(), "_bucket");
+        }
+    );
+
+    test_parse_v2!(
+        minimum_length_possible,
+        query_string = "?bucket=b",
+        want = Ok(WriteParams {
+            namespace,
+            ..
+        }) => {
+            assert_eq!(namespace.as_str().len(), 1);
         }
     );
 

--- a/router/src/server/http/write/single_tenant.rs
+++ b/router/src/server/http/write/single_tenant.rs
@@ -1,0 +1,130 @@
+//! Parsing of HTTP requests that conform to either the [V2 Write API] or [V1
+//! Write API], with modified behaviour (see
+//! <https://github.com/influxdata/idpe/issues/17265>).
+//!
+//! [V2 Write API]:
+//!     https://docs.influxdata.com/influxdb/v2.6/api/#operation/PostWrite
+//! [V1 Write API]:
+//!     https://docs.influxdata.com/influxdb/v1.8/tools/api/#write-http-endpoint
+
+use hyper::{Body, Request};
+use thiserror::Error;
+
+use super::{
+    v1::{RetentionPolicy, V1WriteParseError, WriteParamsV1},
+    v2::{V2WriteParseError, WriteParamsV2},
+    WriteParamExtractor, WriteParams,
+};
+use crate::server::http::{
+    write::v1::V1_NAMESPACE_RP_SEPARATOR,
+    Error::{self},
+};
+use data_types::{NamespaceName, NamespaceNameError};
+
+/// Request parsing errors when operating in "single tenant" mode.
+#[derive(Debug, Error)]
+pub enum SingleTenantExtractError {
+    /// The namespace (or "db" for V1) is not valid.
+    #[error(transparent)]
+    InvalidNamespace(#[from] NamespaceNameError),
+
+    /// A [`WriteParamsV1`] failed to be parsed from the HTTP request.
+    #[error(transparent)]
+    ParseV1Request(#[from] V1WriteParseError),
+
+    /// A [`WriteParamsV2`] failed to be parsed from the HTTP request.
+    #[error(transparent)]
+    ParseV2Request(#[from] V2WriteParseError),
+}
+
+/// Implement a by-ref conversion to avoid "moving" the inner errors when only
+/// matching against the variants is necessary (the actual error content is
+/// discarded, replaced with only a HTTP code)
+impl From<&SingleTenantExtractError> for hyper::StatusCode {
+    fn from(value: &SingleTenantExtractError) -> Self {
+        // Exhaustively match the inner parser errors to ensure new additions
+        // have to be explicitly mapped and are not accidentally mapped to a
+        // "catch all" code.
+        match value {
+            SingleTenantExtractError::InvalidNamespace(_) => Self::BAD_REQUEST,
+            SingleTenantExtractError::ParseV1Request(
+                V1WriteParseError::NoQueryParams
+                | V1WriteParseError::DecodeFail(_)
+                | V1WriteParseError::NamespaceContainsRpSeparator,
+            ) => Self::BAD_REQUEST,
+            SingleTenantExtractError::ParseV2Request(
+                V2WriteParseError::NoQueryParams | V2WriteParseError::DecodeFail(_),
+            ) => Self::BAD_REQUEST,
+        }
+    }
+}
+
+/// Request parsing for cloud2 / multi-tenant deployments.
+///
+/// This handler respects the [V2 Write API] with the following modifications:
+///
+///   * The namespace is derived from ONLY the bucket name (org is discarded)
+///
+/// This handler respects a limited subset of the [V1 Write API] defined in
+/// <https://github.com/influxdata/idpe/issues/17265>.
+///
+/// [V2 Write API]:
+///     https://docs.influxdata.com/influxdb/v2.6/api/#operation/PostWrite
+/// [V1 Write API]:
+///     https://docs.influxdata.com/influxdb/v1.8/tools/api/#write-http-endpoint
+#[derive(Debug, Default)]
+pub struct SingleTenantRequestParser;
+
+impl WriteParamExtractor for SingleTenantRequestParser {
+    fn parse_v1(&self, req: &Request<Body>) -> Result<WriteParams, Error> {
+        Ok(parse_v1(req)?)
+    }
+
+    fn parse_v2(&self, req: &Request<Body>) -> Result<WriteParams, Error> {
+        Ok(parse_v2(req)?)
+    }
+}
+
+// Parse a V1 write request for single tenant mode.
+fn parse_v1(req: &Request<Body>) -> Result<WriteParams, SingleTenantExtractError> {
+    // Extract the write parameters.
+    let write_params = WriteParamsV1::try_from(req)?;
+
+    // Extracting the write parameters validates the db field never contains the
+    // '/' separator to avoid ambiguity with the "namespace/rp" construction.
+    debug_assert!(!write_params.db.contains(V1_NAMESPACE_RP_SEPARATOR));
+
+    // Extract or construct the namespace name string from the write parameters
+    let namespace = match write_params.rp {
+        RetentionPolicy::Unspecified | RetentionPolicy::Autogen => write_params.db,
+        RetentionPolicy::Named(rp) => {
+            format!(
+                "{db}{sep}{rp}",
+                db = write_params.db,
+                sep = V1_NAMESPACE_RP_SEPARATOR
+            )
+        }
+    };
+
+    Ok(WriteParams {
+        namespace: NamespaceName::new(namespace)?,
+        precision: write_params.precision,
+    })
+}
+
+// Parse a V2 write request for single tenant mode.
+fn parse_v2(req: &Request<Body>) -> Result<WriteParams, SingleTenantExtractError> {
+    let write_params = WriteParamsV2::try_from(req)?;
+
+    // For V2 requests in "single tenant" mode, only the bucket parameter is
+    // respected and it is never escaped or otherwise changed. The "org" field
+    // is discarded.
+    //
+    //      See https://github.com/influxdata/idpe/issues/17265
+    //
+
+    Ok(WriteParams {
+        namespace: NamespaceName::new(write_params.bucket)?,
+        precision: write_params.precision,
+    })
+}

--- a/router/src/server/http/write/single_tenant.rs
+++ b/router/src/server/http/write/single_tenant.rs
@@ -59,7 +59,7 @@ impl From<&SingleTenantExtractError> for hyper::StatusCode {
     }
 }
 
-/// Request parsing for cloud2 / multi-tenant deployments.
+/// Request parsing for single-tenant deployments.
 ///
 /// This handler respects the [V2 Write API] with the following modifications:
 ///

--- a/router/src/server/http/write/v1.rs
+++ b/router/src/server/http/write/v1.rs
@@ -1,0 +1,96 @@
+//! Parsing of HTTP requests that conform to the [V1 Write API], modified for
+//! single-tenancy clusters only.
+//!
+//! See <https://github.com/influxdata/idpe/issues/17265>.
+//!
+//! [V1 Write API]:
+//!     https://docs.influxdata.com/influxdb/v1.8/tools/api/#write-http-endpoint
+
+use hyper::Request;
+use serde::{Deserialize, Deserializer};
+
+use crate::server::http::{write::Precision, Error};
+
+// When a retention policy is provided, it is appended to the db field,
+// separated by a single `/`.
+//
+//      See https://github.com/influxdata/idpe/issues/17265
+//
+pub(crate) const V1_NAMESPACE_RP_SEPARATOR: char = '/';
+
+/// v1 DmlErrors returned when decoding the database / rp information from a
+/// HTTP request and deriving the namespace name from it.
+#[derive(Debug, Error)]
+pub enum V1WriteParseError {
+    /// The request contains no org/bucket destination information.
+    #[error("no db destination provided")]
+    NoQueryParams,
+
+    /// The request contains invalid parameters.
+    #[error("failed to deserialize db/rp/precision in request: {0}")]
+    DecodeFail(#[from] serde::de::value::Error),
+
+    /// The provided "db" value contains the reserved `/` character.
+    ///
+    /// See [`V1_NAMESPACE_RP_SEPARATOR`].
+    #[error("db cannot contain the reserved character '/'")]
+    NamespaceContainsRpSeparator,
+}
+
+/// May be empty string, explicit rp name, or `autogen`. As provided at the
+/// write API. Handling is described in context of the construction of the
+/// `NamespaceName`, and not an explicit honouring for retention duration.
+#[derive(Debug, Default)]
+pub(crate) enum RetentionPolicy {
+    /// The user did not specify a retention policy (at the write API).
+    #[default]
+    Unspecified,
+    /// Default on v1 database creation, if no rp was provided.
+    Autogen,
+    /// The user specified the name of the retention policy to be used.
+    Named(String),
+}
+
+impl<'de> Deserialize<'de> for RetentionPolicy {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?.to_lowercase();
+
+        Ok(match s.as_str() {
+            "" => RetentionPolicy::Unspecified,
+            "''" => RetentionPolicy::Unspecified,
+            "autogen" => RetentionPolicy::Autogen,
+            _ => RetentionPolicy::Named(s),
+        })
+    }
+}
+
+/// Query parameters for v2 write requests.
+#[derive(Debug, Deserialize)]
+pub(crate) struct WriteParamsV1 {
+    pub(crate) db: String,
+
+    #[serde(default)]
+    pub(crate) precision: Precision,
+    #[serde(default)]
+    pub(crate) rp: RetentionPolicy,
+}
+
+impl<T> TryFrom<&Request<T>> for WriteParamsV1 {
+    type Error = V1WriteParseError;
+
+    fn try_from(req: &Request<T>) -> Result<Self, Self::Error> {
+        let query = req.uri().query().ok_or(V1WriteParseError::NoQueryParams)?;
+        let params: WriteParamsV1 = serde_urlencoded::from_str(query)?;
+
+        // No namespace (db) is ever allowed to contain a `/` to prevent
+        // ambiguity with the namespace/rp NamespaceName construction.
+        if params.db.contains(V1_NAMESPACE_RP_SEPARATOR) {
+            return Err(V1WriteParseError::NamespaceContainsRpSeparator);
+        }
+
+        Ok(params)
+    }
+}

--- a/router/src/server/http/write/v1.rs
+++ b/router/src/server/http/write/v1.rs
@@ -22,7 +22,7 @@ pub(crate) const V1_NAMESPACE_RP_SEPARATOR: char = '/';
 /// HTTP request and deriving the namespace name from it.
 #[derive(Debug, Error)]
 pub enum V1WriteParseError {
-    /// The request contains no org/bucket destination information.
+    /// The request contains no db destination information.
     #[error("no db destination provided")]
     NoQueryParams,
 

--- a/router/src/server/http/write/v2.rs
+++ b/router/src/server/http/write/v2.rs
@@ -1,0 +1,44 @@
+//! Parsing of HTTP requests that conform to the [V2 Write API], with modified
+//! behaviour for single-tenancy clusters only.
+//!
+//! [V2 Write API]:
+//!     https://docs.influxdata.com/influxdb/v2.6/api/#operation/PostWrite
+
+use hyper::Request;
+use serde::Deserialize;
+
+use crate::server::http::{write::Precision, Error};
+
+/// v2 DmlErrors returned when decoding the organisation / bucket information
+/// from a HTTP request and deriving the namespace name from it.
+#[derive(Debug, Error)]
+pub enum V2WriteParseError {
+    /// The request contains no org/bucket destination information.
+    #[error("no org/bucket destination provided")]
+    NoQueryParams,
+
+    /// The request contains invalid parameters.
+    #[error("failed to deserialize org/bucket/precision in request: {0}")]
+    DecodeFail(#[from] serde::de::value::Error),
+}
+
+/// Query parameters for v2 write requests.
+#[derive(Debug, Deserialize)]
+pub(crate) struct WriteParamsV2 {
+    #[serde(default)]
+    pub(crate) org: String,
+    #[serde(default)]
+    pub(crate) bucket: String,
+
+    #[serde(default)]
+    pub(crate) precision: Precision,
+}
+
+impl<T> TryFrom<&Request<T>> for WriteParamsV2 {
+    type Error = V2WriteParseError;
+
+    fn try_from(req: &Request<T>) -> Result<Self, Self::Error> {
+        let query = req.uri().query().ok_or(V2WriteParseError::NoQueryParams)?;
+        serde_urlencoded::from_str(query).map_err(Into::into)
+    }
+}

--- a/router/tests/common/mod.rs
+++ b/router/tests/common/mod.rs
@@ -16,7 +16,16 @@ use router::{
     },
     namespace_cache::{MemoryNamespaceCache, ShardedCache},
     namespace_resolver::{MissingNamespaceAction, NamespaceAutocreation, NamespaceSchemaResolver},
-    server::{grpc::RpcWriteGrpcDelegate, http::HttpDelegate},
+    server::{
+        grpc::RpcWriteGrpcDelegate,
+        http::{
+            write::{
+                multi_tenant::MultiTenantRequestParser, single_tenant::SingleTenantRequestParser,
+                WriteParamExtractor,
+            },
+            HttpDelegate,
+        },
+    },
 };
 use std::{iter, string::String, sync::Arc, time::Duration};
 
@@ -37,12 +46,14 @@ pub const TEST_RETENTION_PERIOD: Duration = Duration::from_secs(3600);
 #[derive(Debug)]
 pub struct TestContextBuilder {
     namespace_autocreation: MissingNamespaceAction,
+    single_tenancy: bool,
 }
 
 impl Default for TestContextBuilder {
     fn default() -> Self {
         Self {
             namespace_autocreation: MissingNamespaceAction::Reject,
+            single_tenancy: false,
         }
     }
 }
@@ -65,13 +76,24 @@ impl TestContextBuilder {
         self
     }
 
+    pub fn with_single_tenancy(mut self) -> Self {
+        self.single_tenancy = true;
+        self
+    }
+
     pub async fn build(self) -> TestContext {
         test_helpers::maybe_start_logging();
 
         let metrics: Arc<metric::Registry> = Default::default();
         let catalog = Arc::new(MemCatalog::new(Arc::clone(&metrics)));
 
-        TestContext::new(self.namespace_autocreation, catalog, metrics).await
+        TestContext::new(
+            self.namespace_autocreation,
+            self.single_tenancy,
+            catalog,
+            metrics,
+        )
+        .await
     }
 }
 
@@ -84,6 +106,7 @@ pub struct TestContext {
     metrics: Arc<metric::Registry>,
 
     namespace_autocreation: MissingNamespaceAction,
+    single_tenancy: bool,
 }
 
 // This mass of words is certainly a downside of chained handlers.
@@ -118,6 +141,7 @@ type HttpDelegateStack = HttpDelegate<
 impl TestContext {
     async fn new(
         namespace_autocreation: MissingNamespaceAction,
+        single_tenancy: bool,
         catalog: Arc<dyn Catalog>,
         metrics: Arc<metric::Registry>,
     ) -> Self {
@@ -158,8 +182,20 @@ impl TestContext {
 
         let handler_stack = InstrumentationDecorator::new("request", &metrics, handler_stack);
 
-        let http_delegate =
-            HttpDelegate::new(1024, 100, namespace_resolver, handler_stack, None, &metrics);
+        let write_param_extractor: Box<dyn WriteParamExtractor> = match single_tenancy {
+            true => Box::<SingleTenantRequestParser>::default(),
+            false => Box::<MultiTenantRequestParser>::default(),
+        };
+
+        let http_delegate = HttpDelegate::new(
+            1024,
+            100,
+            namespace_resolver,
+            handler_stack,
+            None,
+            &metrics,
+            write_param_extractor,
+        );
 
         let grpc_delegate = RpcWriteGrpcDelegate::new(
             Arc::clone(&catalog),
@@ -176,6 +212,7 @@ impl TestContext {
             metrics,
 
             namespace_autocreation,
+            single_tenancy,
         }
     }
 
@@ -184,7 +221,13 @@ impl TestContext {
     pub async fn restart(self) -> Self {
         let catalog = self.catalog();
         let metrics = Arc::clone(&self.metrics);
-        Self::new(self.namespace_autocreation, catalog, metrics).await
+        Self::new(
+            self.namespace_autocreation,
+            self.single_tenancy,
+            catalog,
+            metrics,
+        )
+        .await
     }
 
     /// Get a reference to the test context's http delegate.


### PR DESCRIPTION
This PR builds on https://github.com/influxdata/influxdb_iox/pull/7331 - some minor logical changes, but mostly the same. This PR effectively moves some things around and tidies up some loose ends.

Note that the existing HTTP write test coverage has been preserved and runs in the default "run mode" (multi-tenant for cloud2) to assert no change to behaviour when this is deployed.

Additional per-mode tests have been added for multi-tenant and I will push a commit adding single-tenant tests tomorrow - opening this for early review - I don't anticipate any logic changes :+1:

Part of https://github.com/influxdata/idpe/issues/17265.

---

* test(router): constify test namespace (857a5afa5)
      
      Define the namespace as a const to make the purpose/magic clear.

* feat(router): single tenancy operational mode (867a7c25a)
      
      Adds a single-tenant mode (CST) to the IOx routers.
      
      Single-tenancy mode differs in two main ways:
      
          * V1 write endpoint is partially supported
          * V2 write endpoint ignores "org" parameter
      
      The "normal" mode is "multi tenant" which is the default operational
      mode, and all existing behaviour remains unchanged. Single tenant mode
      can be enabled by specifying INFLUXDB_IOX_SINGLE_TENANCY=true.
      
      Request parsing is delegated to two implementations of the
      WriteParamExtractor trait, one each for CST and MT - the logic of each
      "mode" is defined within these files and all other functionality is
      common between the two.
      
      This commit also renames some of the error types for clarity
      (NoSpecified -> NoOrgBucketSpecified, other NotSpecified ->
      NoQueryParams, etc).
      
      Note: single tenant code requires testing

* test: multi-tenant write handler (29931183a)
      
      Adds tests that drive the multi-tenant HTTP write request parser.
      
      Note that in addition to these unit tests, there's still considerable
      integration converge of the HTTP write endpoint in multi-tenant mode in
      http.rs (test_write_handler!) that asserts the system is unchanged in
      the "default" run-mode of multi-tenant.