### PR TITLE
chore: don't skip failed rules

### DIFF
--- a/datafusion_util/src/config.rs
+++ b/datafusion_util/src/config.rs
@@ -21,6 +21,7 @@ pub fn iox_session_config() -> SessionConfig {
     options.execution.parquet.pushdown_filters = true;
     options.execution.parquet.reorder_filters = true;
     options.optimizer.repartition_sorts = true;
+    options.optimizer.skip_failed_rules = false;
 
     SessionConfig::from(options)
         .with_batch_size(BATCH_SIZE)


### PR DESCRIPTION
Seeing what fails when `skip_failed_rules` is false.