### PR TITLE
feat: Remove transactions from Catalog Trait

### DIFF
--- a/compactor2/src/components/commit/catalog.rs
+++ b/compactor2/src/components/commit/catalog.rs
@@ -38,32 +38,13 @@ impl Commit for CatalogCommit {
         create: &[ParquetFileParams],
         target_level: CompactionLevel,
     ) -> Vec<ParquetFileId> {
-        // Either upgrade or (delete & create) must not empty
-        assert!(!upgrade.is_empty() || (!delete.is_empty() && !create.is_empty()));
-
-        let upgrade = upgrade.iter().map(|f| f.id).collect::<Vec<_>>();
-
         Backoff::new(&self.backoff_config)
             .retry_all_errors("commit parquet file changes", || async {
-                let mut txn = self.catalog.start_transaction().await?;
-
-                let parquet_files = txn.parquet_files();
-
-                for file in delete {
-                    parquet_files.flag_for_delete(file.id).await?;
-                }
-
-                parquet_files
-                    .update_compaction_level(&upgrade, target_level)
+                let mut repos = self.catalog.repositories().await;
+                let parquet_files = repos.parquet_files();
+                let ids = parquet_files
+                    .create_update_delete(_partition_id, delete, upgrade, create, target_level)
                     .await?;
-
-                let mut ids = Vec::with_capacity(create.len());
-                for file in create {
-                    let res = parquet_files.create(file.clone()).await?;
-                    ids.push(res.id);
-                }
-
-                txn.commit().await?;
 
                 Ok::<_, iox_catalog::interface::Error>(ids)
             })

--- a/import/src/aggregate_tsm_schema/update_catalog.rs
+++ b/import/src/aggregate_tsm_schema/update_catalog.rs
@@ -421,41 +421,41 @@ mod tests {
         // init a test catalog stack
         let metrics = Arc::new(metric::Registry::default());
         let catalog: Arc<dyn Catalog> = Arc::new(MemCatalog::new(Arc::clone(&metrics)));
-        let mut txn = catalog
-            .start_transaction()
-            .await
-            .expect("started transaction");
-        // create namespace, table and columns for weather measurement
-        let namespace = txn
-            .namespaces()
-            .create("1234_5678", None)
-            .await
-            .expect("namespace created");
-        let mut table = txn
-            .tables()
-            .create_or_get("weather", namespace.id)
-            .await
-            .map(|t| TableSchema::new(t.id))
-            .expect("table created");
-        let time_col = txn
-            .columns()
-            .create_or_get("time", table.id, ColumnType::Time)
-            .await
-            .expect("column created");
-        table.add_column(&time_col);
-        let location_col = txn
-            .columns()
-            .create_or_get("city", table.id, ColumnType::Tag)
-            .await
-            .expect("column created");
-        let temperature_col = txn
-            .columns()
-            .create_or_get("temperature", table.id, ColumnType::F64)
-            .await
-            .expect("column created");
-        table.add_column(&location_col);
-        table.add_column(&temperature_col);
-        txn.commit().await.unwrap();
+
+        // We need txn to go out of scope to release the lock before update_iox_catalog
+        {
+            let mut txn = catalog.repositories().await;
+            // create namespace, table and columns for weather measurement
+            let namespace = txn
+                .namespaces()
+                .create("1234_5678", None)
+                .await
+                .expect("namespace created");
+            let mut table = txn
+                .tables()
+                .create_or_get("weather", namespace.id)
+                .await
+                .map(|t| TableSchema::new(t.id))
+                .expect("table created");
+            let time_col = txn
+                .columns()
+                .create_or_get("time", table.id, ColumnType::Time)
+                .await
+                .expect("column created");
+            table.add_column(&time_col);
+            let location_col = txn
+                .columns()
+                .create_or_get("city", table.id, ColumnType::Tag)
+                .await
+                .expect("column created");
+            let temperature_col = txn
+                .columns()
+                .create_or_get("temperature", table.id, ColumnType::F64)
+                .await
+                .expect("column created");
+            table.add_column(&location_col);
+            table.add_column(&temperature_col);
+        }
 
         // merge with aggregate schema that has some overlap
         let json = r#"
@@ -513,35 +513,34 @@ mod tests {
         // init a test catalog stack
         let metrics = Arc::new(metric::Registry::default());
         let catalog: Arc<dyn Catalog> = Arc::new(MemCatalog::new(Arc::clone(&metrics)));
-        let mut txn = catalog
-            .start_transaction()
-            .await
-            .expect("started transaction");
-        // create namespace, table and columns for weather measurement
-        let namespace = txn
-            .namespaces()
-            .create("1234_5678", None)
-            .await
-            .expect("namespace created");
-        let mut table = txn
-            .tables()
-            .create_or_get("weather", namespace.id)
-            .await
-            .map(|t| TableSchema::new(t.id))
-            .expect("table created");
-        let time_col = txn
-            .columns()
-            .create_or_get("time", table.id, ColumnType::Time)
-            .await
-            .expect("column created");
-        table.add_column(&time_col);
-        let temperature_col = txn
-            .columns()
-            .create_or_get("temperature", table.id, ColumnType::F64)
-            .await
-            .expect("column created");
-        table.add_column(&temperature_col);
-        txn.commit().await.unwrap();
+        // We need txn to go out of scope to release the lock before update_iox_catalog
+        {
+            let mut txn = catalog.repositories().await;
+            // create namespace, table and columns for weather measurement
+            let namespace = txn
+                .namespaces()
+                .create("1234_5678", None)
+                .await
+                .expect("namespace created");
+            let mut table = txn
+                .tables()
+                .create_or_get("weather", namespace.id)
+                .await
+                .map(|t| TableSchema::new(t.id))
+                .expect("table created");
+            let time_col = txn
+                .columns()
+                .create_or_get("time", table.id, ColumnType::Time)
+                .await
+                .expect("column created");
+            table.add_column(&time_col);
+            let temperature_col = txn
+                .columns()
+                .create_or_get("temperature", table.id, ColumnType::F64)
+                .await
+                .expect("column created");
+            table.add_column(&temperature_col);
+        }
 
         // merge with aggregate schema that has some issue that will trip a catalog error
         let json = r#"
@@ -577,36 +576,35 @@ mod tests {
         // init a test catalog stack
         let metrics = Arc::new(metric::Registry::default());
         let catalog: Arc<dyn Catalog> = Arc::new(MemCatalog::new(Arc::clone(&metrics)));
-        let mut txn = catalog
-            .start_transaction()
-            .await
-            .expect("started transaction");
 
         // create namespace, table and columns for weather measurement
-        let namespace = txn
-            .namespaces()
-            .create("1234_5678", None)
-            .await
-            .expect("namespace created");
-        let mut table = txn
-            .tables()
-            .create_or_get("weather", namespace.id)
-            .await
-            .map(|t| TableSchema::new(t.id))
-            .expect("table created");
-        let time_col = txn
-            .columns()
-            .create_or_get("time", table.id, ColumnType::Time)
-            .await
-            .expect("column created");
-        table.add_column(&time_col);
-        let temperature_col = txn
-            .columns()
-            .create_or_get("temperature", table.id, ColumnType::F64)
-            .await
-            .expect("column created");
-        table.add_column(&temperature_col);
-        txn.commit().await.unwrap();
+        // We need txn to go out of scope to release the lock before update_iox_catalog
+        {
+            let mut txn = catalog.repositories().await;
+            let namespace = txn
+                .namespaces()
+                .create("1234_5678", None)
+                .await
+                .expect("namespace created");
+            let mut table = txn
+                .tables()
+                .create_or_get("weather", namespace.id)
+                .await
+                .map(|t| TableSchema::new(t.id))
+                .expect("table created");
+            let time_col = txn
+                .columns()
+                .create_or_get("time", table.id, ColumnType::Time)
+                .await
+                .expect("column created");
+            table.add_column(&time_col);
+            let temperature_col = txn
+                .columns()
+                .create_or_get("temperature", table.id, ColumnType::F64)
+                .await
+                .expect("column created");
+            table.add_column(&temperature_col);
+        }
 
         // merge with aggregate schema that has some issue that will trip a catalog error
         let json = r#"

--- a/iox_catalog/src/lib.rs
+++ b/iox_catalog/src/lib.rs
@@ -235,7 +235,7 @@ mod tests {
 
                     let metrics = Arc::new(metric::Registry::default());
                     let repo = MemCatalog::new(metrics);
-                    let mut txn = repo.start_transaction().await.unwrap();
+                    let mut txn = repo.repositories().await;
 
                     let namespace = txn
                         .namespaces()

--- a/iox_catalog/src/metrics.rs
+++ b/iox_catalog/src/metrics.rs
@@ -1,8 +1,8 @@
 //! Metric instrumentation for catalog implementations.
 
 use crate::interface::{
-    sealed::TransactionFinalize, CasFailure, ColumnRepo, NamespaceRepo, ParquetFileRepo,
-    PartitionRepo, RepoCollection, Result, SoftDeletedRows, TableRepo,
+    CasFailure, ColumnRepo, NamespaceRepo, ParquetFileRepo, PartitionRepo, RepoCollection, Result,
+    SoftDeletedRows, TableRepo,
 };
 use async_trait::async_trait;
 use data_types::{
@@ -62,20 +62,6 @@ where
 
     fn parquet_files(&mut self) -> &mut dyn ParquetFileRepo {
         self
-    }
-}
-
-#[async_trait]
-impl<T, P> TransactionFinalize for MetricDecorator<T, P>
-where
-    T: TransactionFinalize,
-    P: TimeProvider,
-{
-    async fn commit_inplace(&mut self) -> Result<(), super::interface::Error> {
-        self.inner.commit_inplace().await
-    }
-    async fn abort_inplace(&mut self) -> Result<(), super::interface::Error> {
-        self.inner.abort_inplace().await
     }
 }
 
@@ -213,5 +199,6 @@ decorate!(
         "parquet_exist" = exist(&mut self, id: ParquetFileId) -> Result<bool>;
         "parquet_count" = count(&mut self) -> Result<i64>;
         "parquet_get_by_object_store_id" = get_by_object_store_id(&mut self, object_store_id: Uuid) -> Result<Option<ParquetFile>>;
+        "parquet_create_update_delete" = create_update_delete(&mut self, _partition_id: PartitionId, delete: &[ParquetFile], upgrade: &[ParquetFile], create: &[ParquetFileParams], target_level: CompactionLevel) -> Result<Vec<ParquetFileId>>;
     ]
 );

--- a/iox_catalog/src/metrics.rs
+++ b/iox_catalog/src/metrics.rs
@@ -6,9 +6,9 @@ use crate::interface::{
 };
 use async_trait::async_trait;
 use data_types::{
-    Column, ColumnType, ColumnTypeCount, CompactionLevel, Namespace, NamespaceId, ParquetFile,
-    ParquetFileId, ParquetFileParams, Partition, PartitionId, PartitionKey, SkippedCompaction,
-    Table, TableId, Timestamp,
+    Column, ColumnType, CompactionLevel, Namespace, NamespaceId, ParquetFile, ParquetFileId,
+    ParquetFileParams, Partition, PartitionId, PartitionKey, SkippedCompaction, Table, TableId,
+    Timestamp,
 };
 use iox_time::{SystemProvider, TimeProvider};
 use metric::{DurationHistogram, Metric};
@@ -161,7 +161,6 @@ decorate!(
         "column_list_by_table_id" = list_by_table_id(&mut self, table_id: TableId) -> Result<Vec<Column>>;
         "column_create_or_get_many_unchecked" = create_or_get_many_unchecked(&mut self, table_id: TableId, columns: HashMap<&str, ColumnType>) -> Result<Vec<Column>>;
         "column_list" = list(&mut self) -> Result<Vec<Column>>;
-        "column_list_type_count_by_table_id" = list_type_count_by_table_id(&mut self, table_id: TableId) -> Result<Vec<ColumnTypeCount>>;
     ]
 );
 
@@ -170,13 +169,11 @@ decorate!(
     methods = [
         "partition_create_or_get" = create_or_get(&mut self, key: PartitionKey, table_id: TableId) -> Result<Partition>;
         "partition_get_by_id" = get_by_id(&mut self, partition_id: PartitionId) -> Result<Option<Partition>>;
-        "partition_list_by_namespace" = list_by_namespace(&mut self, namespace_id: NamespaceId) -> Result<Vec<Partition>>;
         "partition_list_by_table_id" = list_by_table_id(&mut self, table_id: TableId) -> Result<Vec<Partition>>;
         "partition_list_ids" = list_ids(&mut self) -> Result<Vec<PartitionId>>;
         "partition_update_sort_key" = cas_sort_key(&mut self, partition_id: PartitionId, old_sort_key: Option<Vec<String>>, new_sort_key: &[&str]) -> Result<Partition, CasFailure<Vec<String>>>;
         "partition_record_skipped_compaction" = record_skipped_compaction(&mut self, partition_id: PartitionId, reason: &str, num_files: usize, limit_num_files: usize, limit_num_files_first_in_partition: usize, estimated_bytes: u64, limit_bytes: u64) -> Result<()>;
         "partition_list_skipped_compactions" = list_skipped_compactions(&mut self) -> Result<Vec<SkippedCompaction>>;
-        "partition_delete_skipped_compactions" = delete_skipped_compactions(&mut self, partition_id: PartitionId) -> Result<Option<SkippedCompaction>>;
         "partition_most_recent_n" = most_recent_n(&mut self, n: usize) -> Result<Vec<Partition>>;
         "partitions_new_file_between" = partitions_new_file_between(&mut self, minimum_time: Timestamp, maximum_time: Option<Timestamp>) -> Result<Vec<PartitionId>>;
         "get_in_skipped_compaction" = get_in_skipped_compaction(&mut self, partition_id: PartitionId) -> Result<Option<SkippedCompaction>>;
@@ -197,7 +194,6 @@ decorate!(
         "parquet_list_by_partition_not_to_delete" = list_by_partition_not_to_delete(&mut self, partition_id: PartitionId) -> Result<Vec<ParquetFile>>;
         "parquet_update_compaction_level" = update_compaction_level(&mut self, parquet_file_ids: &[ParquetFileId], compaction_level: CompactionLevel) -> Result<Vec<ParquetFileId>>;
         "parquet_exist" = exist(&mut self, id: ParquetFileId) -> Result<bool>;
-        "parquet_count" = count(&mut self) -> Result<i64>;
         "parquet_get_by_object_store_id" = get_by_object_store_id(&mut self, object_store_id: Uuid) -> Result<Option<ParquetFile>>;
         "parquet_create_update_delete" = create_update_delete(&mut self, _partition_id: PartitionId, delete: &[ParquetFile], upgrade: &[ParquetFile], create: &[ParquetFileParams], target_level: CompactionLevel) -> Result<Vec<ParquetFileId>>;
     ]

--- a/iox_catalog/src/postgres.rs
+++ b/iox_catalog/src/postgres.rs
@@ -2,9 +2,8 @@
 
 use crate::{
     interface::{
-        self, sealed::TransactionFinalize, CasFailure, Catalog, ColumnRepo,
-        ColumnTypeMismatchSnafu, Error, NamespaceRepo, ParquetFileRepo, PartitionRepo,
-        RepoCollection, Result, SoftDeletedRows, TableRepo, Transaction,
+        self, CasFailure, Catalog, ColumnRepo, ColumnTypeMismatchSnafu, Error, NamespaceRepo,
+        ParquetFileRepo, PartitionRepo, RepoCollection, Result, SoftDeletedRows, TableRepo,
     },
     kafkaless_transition::{
         SHARED_QUERY_POOL, SHARED_QUERY_POOL_ID, SHARED_TOPIC_ID, SHARED_TOPIC_NAME,
@@ -155,11 +154,121 @@ pub struct PostgresTxn {
     time_provider: Arc<dyn TimeProvider>,
 }
 
+impl PostgresTxn {
+    async fn create_parquet_file<'q, E>(
+        executor: E,
+        parquet_file_params: ParquetFileParams,
+    ) -> Result<ParquetFile>
+    where
+        E: Executor<'q, Database = Postgres>,
+    {
+        let ParquetFileParams {
+            namespace_id,
+            table_id,
+            partition_id,
+            object_store_id,
+            min_time,
+            max_time,
+            file_size_bytes,
+            row_count,
+            compaction_level,
+            created_at,
+            column_set,
+            max_l0_created_at,
+        } = parquet_file_params;
+
+        let query = sqlx::query_as::<_, ParquetFile>(
+            r#"
+INSERT INTO parquet_file (
+    shard_id, table_id, partition_id, object_store_id,
+    min_time, max_time, file_size_bytes,
+    row_count, compaction_level, created_at, namespace_id, column_set, max_l0_created_at )
+VALUES ( $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13 )
+RETURNING
+    id, table_id, partition_id, object_store_id,
+    min_time, max_time, to_delete, file_size_bytes,
+    row_count, compaction_level, created_at, namespace_id, column_set, max_l0_created_at;
+        "#,
+        )
+        .bind(TRANSITION_SHARD_ID) // $1
+        .bind(table_id) // $2
+        .bind(partition_id) // $3
+        .bind(object_store_id) // $4
+        .bind(min_time) // $5
+        .bind(max_time) // $6
+        .bind(file_size_bytes) // $7
+        .bind(row_count) // $8
+        .bind(compaction_level) // $9
+        .bind(created_at) // $10
+        .bind(namespace_id) // $11
+        .bind(column_set) // $12
+        .bind(max_l0_created_at); // $13
+        let parquet_file = query.fetch_one(executor).await.map_err(|e| {
+            if is_unique_violation(&e) {
+                Error::FileExists { object_store_id }
+            } else if is_fk_violation(&e) {
+                Error::ForeignKeyViolation { source: e }
+            } else {
+                Error::SqlxError { source: e }
+            }
+        })?;
+
+        Ok(parquet_file)
+    }
+
+    async fn flag_for_delete<'q, E>(
+        executor: E,
+        id: ParquetFileId,
+        marked_at: Timestamp,
+    ) -> Result<()>
+    where
+        E: Executor<'q, Database = Postgres>,
+    {
+        let query = sqlx::query(r#"UPDATE parquet_file SET to_delete = $1 WHERE id = $2;"#)
+            .bind(marked_at) // $1
+            .bind(id); // $2
+        query
+            .execute(executor)
+            .await
+            .map_err(|e| Error::SqlxError { source: e })?;
+
+        Ok(())
+    }
+
+    async fn update_compaction_level<'q, E>(
+        executor: E,
+        parquet_file_ids: &[ParquetFileId],
+        compaction_level: CompactionLevel,
+    ) -> Result<Vec<ParquetFileId>>
+    where
+        E: Executor<'q, Database = Postgres>,
+    {
+        // If I try to do `.bind(parquet_file_ids)` directly, I get a compile error from sqlx.
+        // See https://github.com/launchbadge/sqlx/issues/1744
+        let ids: Vec<_> = parquet_file_ids.iter().map(|p| p.get()).collect();
+        let query = sqlx::query(
+            r#"
+UPDATE parquet_file
+SET compaction_level = $1
+WHERE id = ANY($2)
+RETURNING id;
+        "#,
+        )
+        .bind(compaction_level) // $1
+        .bind(&ids[..]); // $2
+        let updated = query
+            .fetch_all(executor)
+            .await
+            .map_err(|e| Error::SqlxError { source: e })?;
+
+        let updated = updated.into_iter().map(|row| row.get("id")).collect();
+        Ok(updated)
+    }
+}
+
 #[derive(Debug)]
-#[allow(clippy::large_enum_variant)]
-enum PostgresTxnInner {
-    Txn(Option<sqlx::Transaction<'static, Postgres>>),
-    Oneshot(HotSwapPool<Postgres>),
+struct PostgresTxnInner {
+    pool: HotSwapPool<Postgres>,
 }
 
 impl<'c> Executor<'c> for &'c mut PostgresTxnInner {
@@ -183,12 +292,7 @@ impl<'c> Executor<'c> for &'c mut PostgresTxnInner {
         'c: 'e,
         E: sqlx::Execute<'q, Self::Database>,
     {
-        match self {
-            PostgresTxnInner::Txn(txn) => {
-                txn.as_mut().expect("Not yet finalized").fetch_many(query)
-            }
-            PostgresTxnInner::Oneshot(pool) => pool.fetch_many(query),
-        }
+        self.pool.fetch_many(query)
     }
 
     fn fetch_optional<'e, 'q: 'e, E: 'q>(
@@ -202,13 +306,7 @@ impl<'c> Executor<'c> for &'c mut PostgresTxnInner {
         'c: 'e,
         E: sqlx::Execute<'q, Self::Database>,
     {
-        match self {
-            PostgresTxnInner::Txn(txn) => txn
-                .as_mut()
-                .expect("Not yet finalized")
-                .fetch_optional(query),
-            PostgresTxnInner::Oneshot(pool) => pool.fetch_optional(query),
-        }
+        self.pool.fetch_optional(query)
     }
 
     fn prepare_with<'e, 'q: 'e>(
@@ -222,13 +320,7 @@ impl<'c> Executor<'c> for &'c mut PostgresTxnInner {
     where
         'c: 'e,
     {
-        match self {
-            PostgresTxnInner::Txn(txn) => txn
-                .as_mut()
-                .expect("Not yet finalized")
-                .prepare_with(sql, parameters),
-            PostgresTxnInner::Oneshot(pool) => pool.prepare_with(sql, parameters),
-        }
+        self.pool.prepare_with(sql, parameters)
     }
 
     fn describe<'e, 'q: 'e>(
@@ -238,52 +330,7 @@ impl<'c> Executor<'c> for &'c mut PostgresTxnInner {
     where
         'c: 'e,
     {
-        match self {
-            PostgresTxnInner::Txn(txn) => txn.as_mut().expect("Not yet finalized").describe(sql),
-            PostgresTxnInner::Oneshot(pool) => pool.describe(sql),
-        }
-    }
-}
-
-impl Drop for PostgresTxn {
-    fn drop(&mut self) {
-        if let PostgresTxnInner::Txn(Some(_)) = self.inner {
-            warn!("Dropping PostgresTxn w/o finalizing (commit or abort)");
-
-            // SQLx ensures that the inner transaction enqueues a rollback when it is dropped, so
-            // we don't need to spawn a task here to call `rollback` manually.
-        }
-    }
-}
-
-#[async_trait]
-impl TransactionFinalize for PostgresTxn {
-    async fn commit_inplace(&mut self) -> Result<(), Error> {
-        match &mut self.inner {
-            PostgresTxnInner::Txn(txn) => txn
-                .take()
-                .expect("Not yet finalized")
-                .commit()
-                .await
-                .map_err(|e| Error::SqlxError { source: e }),
-            PostgresTxnInner::Oneshot(_) => {
-                panic!("cannot commit oneshot");
-            }
-        }
-    }
-
-    async fn abort_inplace(&mut self) -> Result<(), Error> {
-        match &mut self.inner {
-            PostgresTxnInner::Txn(txn) => txn
-                .take()
-                .expect("Not yet finalized")
-                .rollback()
-                .await
-                .map_err(|e| Error::SqlxError { source: e }),
-            PostgresTxnInner::Oneshot(_) => {
-                panic!("cannot abort oneshot");
-            }
-        }
+        self.pool.describe(sql)
     }
 }
 
@@ -359,26 +406,12 @@ DO NOTHING;
         Ok(())
     }
 
-    async fn start_transaction(&self) -> Result<Box<dyn Transaction>, Error> {
-        let transaction = self
-            .pool
-            .begin()
-            .await
-            .map_err(|e| Error::SqlxError { source: e })?;
-
-        Ok(Box::new(MetricDecorator::new(
-            PostgresTxn {
-                inner: PostgresTxnInner::Txn(Some(transaction)),
-                time_provider: Arc::clone(&self.time_provider),
-            },
-            Arc::clone(&self.metrics),
-        )))
-    }
-
     async fn repositories(&self) -> Box<dyn RepoCollection> {
         Box::new(MetricDecorator::new(
             PostgresTxn {
-                inner: PostgresTxnInner::Oneshot(self.pool.clone()),
+                inner: PostgresTxnInner {
+                    pool: self.pool.clone(),
+                },
                 time_provider: Arc::clone(&self.time_provider),
             },
             Arc::clone(&self.metrics),
@@ -1352,73 +1385,13 @@ LIMIT $1;
 #[async_trait]
 impl ParquetFileRepo for PostgresTxn {
     async fn create(&mut self, parquet_file_params: ParquetFileParams) -> Result<ParquetFile> {
-        let ParquetFileParams {
-            namespace_id,
-            table_id,
-            partition_id,
-            object_store_id,
-            min_time,
-            max_time,
-            file_size_bytes,
-            row_count,
-            compaction_level,
-            created_at,
-            column_set,
-            max_l0_created_at,
-        } = parquet_file_params;
-
-        let rec = sqlx::query_as::<_, ParquetFile>(
-            r#"
-INSERT INTO parquet_file (
-    shard_id, table_id, partition_id, object_store_id,
-    min_time, max_time, file_size_bytes,
-    row_count, compaction_level, created_at, namespace_id, column_set, max_l0_created_at )
-VALUES ( $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13 )
-RETURNING
-    id, table_id, partition_id, object_store_id,
-    min_time, max_time, to_delete, file_size_bytes,
-    row_count, compaction_level, created_at, namespace_id, column_set, max_l0_created_at;
-        "#,
-        )
-        .bind(TRANSITION_SHARD_ID) // $1
-        .bind(table_id) // $2
-        .bind(partition_id) // $3
-        .bind(object_store_id) // $4
-        .bind(min_time) // $5
-        .bind(max_time) // $6
-        .bind(file_size_bytes) // $7
-        .bind(row_count) // $8
-        .bind(compaction_level) // $9
-        .bind(created_at) // $10
-        .bind(namespace_id) // $11
-        .bind(column_set) // $12
-        .bind(max_l0_created_at) // $13
-        .fetch_one(&mut self.inner)
-        .await
-        .map_err(|e| {
-            if is_unique_violation(&e) {
-                Error::FileExists { object_store_id }
-            } else if is_fk_violation(&e) {
-                Error::ForeignKeyViolation { source: e }
-            } else {
-                Error::SqlxError { source: e }
-            }
-        })?;
-
-        Ok(rec)
+        let executor = &mut self.inner;
+        Self::create_parquet_file(executor, parquet_file_params).await
     }
 
     async fn flag_for_delete(&mut self, id: ParquetFileId) -> Result<()> {
-        let marked_at = Timestamp::from(self.time_provider.now());
-
-        let _ = sqlx::query(r#"UPDATE parquet_file SET to_delete = $1 WHERE id = $2;"#)
-            .bind(marked_at) // $1
-            .bind(id) // $2
-            .execute(&mut self.inner)
-            .await
-            .map_err(|e| Error::SqlxError { source: e })?;
-
-        Ok(())
+        let executor = &mut self.inner;
+        Self::flag_for_delete(executor, id, Timestamp::from(self.time_provider.now())).await
     }
 
     async fn flag_for_delete_by_retention(&mut self) -> Result<Vec<ParquetFileId>> {
@@ -1569,25 +1542,8 @@ WHERE parquet_file.partition_id = $1
         parquet_file_ids: &[ParquetFileId],
         compaction_level: CompactionLevel,
     ) -> Result<Vec<ParquetFileId>> {
-        // If I try to do `.bind(parquet_file_ids)` directly, I get a compile error from sqlx.
-        // See https://github.com/launchbadge/sqlx/issues/1744
-        let ids: Vec<_> = parquet_file_ids.iter().map(|p| p.get()).collect();
-        let updated = sqlx::query(
-            r#"
-UPDATE parquet_file
-SET compaction_level = $1
-WHERE id = ANY($2)
-RETURNING id;
-        "#,
-        )
-        .bind(compaction_level) // $1
-        .bind(&ids[..]) // $2
-        .fetch_all(&mut self.inner)
-        .await
-        .map_err(|e| Error::SqlxError { source: e })?;
-
-        let updated = updated.into_iter().map(|row| row.get("id")).collect();
-        Ok(updated)
+        let executor = &mut self.inner;
+        Self::update_compaction_level(executor, parquet_file_ids, compaction_level).await
     }
 
     async fn exist(&mut self, id: ParquetFileId) -> Result<bool> {
@@ -1636,6 +1592,45 @@ WHERE object_store_id = $1;
         let parquet_file = rec.map_err(|e| Error::SqlxError { source: e })?;
 
         Ok(Some(parquet_file))
+    }
+
+    async fn create_update_delete(
+        &mut self,
+        _partition_id: PartitionId,
+        delete: &[ParquetFile],
+        upgrade: &[ParquetFile],
+        create: &[ParquetFileParams],
+        target_level: CompactionLevel,
+    ) -> Result<Vec<ParquetFileId>> {
+        assert!(!upgrade.is_empty() || (!delete.is_empty() && !create.is_empty()));
+        let mut tx = self
+            .inner
+            .pool
+            .begin()
+            .await
+            .map_err(|e| Error::StartTransaction { source: e })?;
+
+        let upgrade = upgrade.iter().map(|f| f.id).collect::<Vec<_>>();
+
+        for file in delete {
+            let marked_at = Timestamp::from(self.time_provider.now());
+            Self::flag_for_delete(&mut tx, file.id, marked_at).await?;
+        }
+
+        Self::update_compaction_level(&mut tx, &upgrade, target_level).await?;
+
+        let mut ids = Vec::with_capacity(create.len());
+        for file in create {
+            let pf = Self::create_parquet_file(&mut tx, file.clone()).await?;
+            ids.push(pf.id);
+        }
+
+        let res = tx.commit().await;
+        if let Err(e) = res {
+            return Err(Error::FailedToCommit { source: e });
+        }
+
+        Ok(ids)
     }
 }
 


### PR DESCRIPTION
Describe your proposed changes here.

Transactions are a rarely used feature of the Catalog Trait and don't align with every potential Catalog implementation. This PR removes transactions from the API (as well as some other unused methods) and implements a new method that contains the main current use of transactions (compactor2). More context in the discussion [here](https://influxdata.slack.com/archives/C04MLN8NELX/p1680623895881139) 

- [x] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb_iox/blob/main/README.md).
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
