### PR TITLE
refactor(idpe 17434): namespace validation

### DIFF
--- a/data_types/src/namespace_name.rs
+++ b/data_types/src/namespace_name.rs
@@ -1,4 +1,5 @@
 use std::{borrow::Cow, ops::RangeInclusive};
+
 use thiserror::Error;
 
 /// Length constraints for a [`NamespaceName`] name.

--- a/router/src/server/http/write/multi_tenant.rs
+++ b/router/src/server/http/write/multi_tenant.rs
@@ -75,11 +75,11 @@ fn parse_v2(req: &Request<Body>) -> Result<WriteParams, MultiTenantExtractError>
 
 #[cfg(test)]
 mod tests {
-    use crate::server::http::write::Precision;
     use assert_matches::assert_matches;
     use data_types::NamespaceNameError;
 
     use super::*;
+    use crate::server::http::write::Precision;
 
     #[test]
     fn test_parse_v1_always_errors() {

--- a/router/src/server/http/write/multi_tenant.rs
+++ b/router/src/server/http/write/multi_tenant.rs
@@ -163,6 +163,8 @@ mod tests {
         ))
     );
 
+    // iox's namespace onCreate does not encode non-alphanumeric chars
+    // therefore, we need to maintain the same contract onWrite
     test_parse_v2!(
         encoded_separator,
         query_string = "?org=cool_confusing&bucket=bucket",
@@ -170,7 +172,7 @@ mod tests {
             namespace,
             ..
         }) => {
-            assert_eq!(namespace.as_str(), "cool%5Fconfusing_bucket");
+            assert_eq!(namespace.as_str(), "cool_confusing_bucket");
         }
     );
 
@@ -185,6 +187,8 @@ mod tests {
         }
     );
 
+    // iox's namespace onCreate does not filter for single quotation
+    // therefore, we need to maintain the same contract onWrite
     test_parse_v2!(
         encoded_quotation,
         query_string = "?org=cool'confusing&bucket=bucket",
@@ -192,10 +196,12 @@ mod tests {
             namespace,
             ..
         }) => {
-            assert_eq!(namespace.as_str(), "cool%27confusing_bucket");
+            assert_eq!(namespace.as_str(), "cool'confusing_bucket");
         }
     );
 
+    // iox's namespace onCreate does not filter beginning with underscore
+    // therefore, we need to maintain the same contract onWrite
     test_parse_v2!(
         start_nonalphanumeric,
         query_string = "?org=_coolconfusing&bucket=bucket",
@@ -203,7 +209,7 @@ mod tests {
             namespace,
             ..
         }) => {
-            assert_eq!(namespace.as_str(), "%5Fcoolconfusing_bucket");
+            assert_eq!(namespace.as_str(), "_coolconfusing_bucket");
         }
     );
 

--- a/router/src/server/http/write/single_tenant.rs
+++ b/router/src/server/http/write/single_tenant.rs
@@ -7,6 +7,7 @@
 //! [V1 Write API]:
 //!     https://docs.influxdata.com/influxdb/v1.8/tools/api/#write-http-endpoint
 
+use data_types::{NamespaceName, NamespaceNameError};
 use hyper::{Body, Request};
 use thiserror::Error;
 
@@ -19,7 +20,6 @@ use crate::server::http::{
     write::v1::V1_NAMESPACE_RP_SEPARATOR,
     Error::{self},
 };
-use data_types::{NamespaceName, NamespaceNameError};
 
 /// Request parsing errors when operating in "single tenant" mode.
 #[derive(Debug, Error)]
@@ -139,11 +139,10 @@ fn parse_v2(req: &Request<Body>) -> Result<WriteParams, SingleTenantExtractError
 
 #[cfg(test)]
 mod tests {
-    use crate::server::http::write::Precision;
+    use assert_matches::assert_matches;
 
     use super::*;
-
-    use assert_matches::assert_matches;
+    use crate::server::http::write::Precision;
 
     macro_rules! test_parse_v1 {
         (

--- a/router/src/server/http/write/single_tenant.rs
+++ b/router/src/server/http/write/single_tenant.rs
@@ -280,9 +280,9 @@ mod tests {
     test_parse_v1!(
         encoded_quotation,
         query_string = "?db=ban'anas",
-        want = Ok(WriteParams{ namespace, precision: _ }) => {
-            assert_eq!(namespace.as_str(), "ban'anas");
-        }
+        want = Err(Error::SingleTenantError(
+            SingleTenantExtractError::InvalidNamespace(NamespaceNameError::BadChars { .. })
+        ))
     );
 
     test_parse_v1!(
@@ -415,12 +415,9 @@ mod tests {
     test_parse_v2!(
         encoded_quotation,
         query_string = "?bucket=buc'ket",
-        want = Ok(WriteParams {
-            namespace,
-            ..
-        }) => {
-            assert_eq!(namespace.as_str(), "buc'ket");
-        }
+        want = Err(Error::SingleTenantError(
+            SingleTenantExtractError::InvalidNamespace(NamespaceNameError::BadChars { .. })
+        ))
     );
 
     test_parse_v2!(

--- a/service_grpc_namespace/src/lib.rs
+++ b/service_grpc_namespace/src/lib.rs
@@ -349,13 +349,10 @@ mod tests {
         };
         let create_ns_response = handler.create_namespace(Request::new(req)).await;
         assert_matches!(
-            create_ns_response,
-        s => match s {
-            Err(s) => {
-                assert_eq!(s.code(), Code::InvalidArgument);
-                assert_eq!(s.message(), invalid_name_err.to_string());
-            },
-            Ok(_) => panic!("NamespaceName was successful, when it should have failed."),
+        create_ns_response,
+        Err(s) => {
+            assert_eq!(s.code(), Code::InvalidArgument);
+            assert_eq!(s.message(), invalid_name_err.to_string());
         });
 
         // Restricted char
@@ -372,13 +369,10 @@ mod tests {
         println!("{:?}", create_ns_response);
         assert_matches!(
             create_ns_response,
-        s => match s {
-            Err(s) => {
+        Err(s) => {
                 assert_eq!(s.code(), Code::InvalidArgument);
                 assert_eq!(s.message(), invalid_name_err.to_string());
-            },
-            Ok(_) => panic!("NamespaceName was successful, when it should have failed."),
-        });
+            });
     }
 
     #[test]


### PR DESCRIPTION
This PR implements the iox-level changes mentioned in https://github.com/influxdata/idpe/issues/17434#issuecomment-1505451022, to bring the iox onCreate and onWrite namespace validation into alignment. Another goal is to keep the validation and encoding to the minimum needed to not break iox.

---

refactor(idpe-17434): update the onWrite namespace validation (57510a3ddcb6295f3f9e20d48baa08029bf9c5f2)

    * brings into alignment with NamespaceName::new() validation
        * this will have impact when the onCreate namespace starts using the NamespaceName abtraction

    * also brings v1 and v2 onWrite namespace validation closer together
        * only v2 had the utf8-percent encoding

    Note: this has no impact on prod, as the idpe platform currently uses a more stringent namespace 
    construction scheme, such that onCreate namespaces will not include the extra (now removed) 
    utf8-percent encoding.


refactor(idpe-17434): add namespace validation to onCreate (7dbe278f7fb994b176963cec40c7c0e42e88d5ce)

    * adding validation to onCreate path through use of NamespaceName abstractions in the specific 
      create_namespace() interface.

    * did not update the lower abstractions (Namespace, or the argument type signature of 
      trait NamespaceRepo.create()) to use NamespaceName because:
         (a) these are widely used internally for already created (and validated) namespaces
         (b) we are not performing any encoding within NamespaceName, and therefore no extra benefit/encoding 
               at these lower levels

feat(idpe-17434): NamespaceName validation should include BadChars for sql protection (494f056708c9922bac8471d0066d32c40b8d1559)



## Checklist
- [x] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb_iox/blob/main/README.md).
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
