### PR TITLE
fix(ingester): always drive partition resolve futures to completion

### DIFF
--- a/ingester2/src/buffer_tree/partition/resolver/coalesce.rs
+++ b/ingester2/src/buffer_tree/partition/resolver/coalesce.rs
@@ -113,7 +113,8 @@ enum State {
 ///
 /// This type is cancellation safe - calls to
 /// [`CoalescePartitionResolver::get_partition()`] are safe to abort at any
-/// point.
+/// point - the underlying resolve future is always driven to completion in the
+/// background once started.
 ///
 /// [`CatalogPartitionResolver`]: super::CatalogPartitionResolver
 #[derive(Debug)]
@@ -164,18 +165,15 @@ where
                 // Spawn a future to resolve the partition, and retain a handle
                 // to it.
                 let inner = Arc::clone(&self.inner);
-                let fut: BoxedResolveFuture = Box::pin(async move {
-                    inner
-                        .get_partition(
-                            partition_key,
-                            namespace_id,
-                            namespace_name,
-                            table_id,
-                            table_name,
-                            transition_shard_id,
-                        )
-                        .await
-                });
+                let fut: BoxedResolveFuture = Box::pin(do_fetch(
+                    inner,
+                    partition_key,
+                    namespace_id,
+                    namespace_name,
+                    table_id,
+                    table_name,
+                    transition_shard_id,
+                ));
 
                 // Make the future poll-able by many callers, all of which
                 // resolve to the same output PartitionData instance.
@@ -207,29 +205,64 @@ where
         // attempt to. In the presence of aborted callers waiting on the shared
         // future, each completed await caller will attempt to change state
         // (cancellation safe).
-        if !done.load(Ordering::Relaxed) {
-            if done
+        if !done.load(Ordering::Relaxed)
+            && done
                 .compare_exchange(false, true, Ordering::AcqRel, Ordering::Relaxed)
                 .is_ok()
-            {
-                // This task should drop the Shared, swapping it for the
-                // resolved state.
-                //
-                // This thread SHOULD NOT fail to perform this action as no
-                // other thread will attempt it now the bool has been toggled.
-                let old = self
-                    .ongoing
-                    .lock()
-                    .insert(key, State::Resolved(Arc::clone(&res)));
+        {
+            // This task should drop the Shared, swapping it for the resolved
+            // state.
+            //
+            // This thread SHOULD NOT fail to perform this action as no other
+            // thread will attempt it now the bool has been toggled.
+            let old = self
+                .ongoing
+                .lock()
+                .insert(key, State::Resolved(Arc::clone(&res)));
 
-                // Invariant: the resolve future must exist in the map, and the
-                // state may only be changed by the thread that won the CAS.
-                assert!(matches!(old, Some(State::Resolving(..))));
-            }
+            // Invariant: the resolve future must exist in the map, and the
+            // state may only be changed by the thread that won the CAS.
+            assert!(matches!(old, Some(State::Resolving(..))));
         }
 
         res
     }
+}
+
+async fn do_fetch<T>(
+    inner: T,
+    partition_key: PartitionKey,
+    namespace_id: NamespaceId,
+    namespace_name: Arc<DeferredLoad<NamespaceName>>,
+    table_id: TableId,
+    table_name: Arc<DeferredLoad<TableName>>,
+    transition_shard_id: ShardId,
+) -> Arc<Mutex<PartitionData>>
+where
+    T: PartitionProvider + 'static,
+{
+    // Spawn a task, ensuring the resolve future is always driven to completion
+    // independently of callers polling the shared result future.
+    //
+    // This prevents the resolve future from being abandoned by all callers and
+    // left allocated (referenced by the ongoing map) but not polled - this
+    // could result in a connection being taken from the connection pool and
+    // never returned as the resolve future is neither completed, nor dropped
+    // (which would cause the connection to be returned).
+    tokio::spawn(async move {
+        inner
+            .get_partition(
+                partition_key,
+                namespace_id,
+                namespace_name,
+                table_id,
+                table_name,
+                transition_shard_id,
+            )
+            .await
+    })
+    .await
+    .expect("coalesced partition resolve task panic")
 }
 
 #[cfg(test)]
@@ -243,9 +276,11 @@ mod tests {
 
     use assert_matches::assert_matches;
     use data_types::{PartitionId, TRANSITION_SHARD_ID};
+    use futures::Future;
     use futures::{stream::FuturesUnordered, StreamExt};
     use lazy_static::lazy_static;
     use test_helpers::timeout::FutureTimeout;
+    use tokio::sync::{Notify, Semaphore};
 
     use crate::buffer_tree::partition::{resolver::mock::MockPartitionProvider, SortKeyState};
 
@@ -422,5 +457,107 @@ mod tests {
         // While the original requests are still blocked.
         assert_matches!(Pin::new(&mut pa_1).poll(&mut cx), Poll::Pending);
         assert_matches!(Pin::new(&mut pa_2).poll(&mut cx), Poll::Pending);
+    }
+
+    /// A resolver that obtains a semaphore (simulating a connection pool
+    /// semaphore) during a resolve and then blocks until signalled.
+    #[derive(Debug)]
+    struct SemaphoreResolver {
+        /// The resolver call acquires a permit from here.
+        sem: Arc<Semaphore>,
+        /// An then waits for this notify to be unblocked before "completing".
+        wait: Arc<Notify>,
+        /// And returning this data
+        p: Arc<Mutex<PartitionData>>,
+    }
+
+    #[async_trait]
+    impl PartitionProvider for SemaphoreResolver {
+        async fn get_partition(
+            &self,
+            _partition_key: PartitionKey,
+            _namespace_id: NamespaceId,
+            _namespace_name: Arc<DeferredLoad<NamespaceName>>,
+            _table_id: TableId,
+            _table_name: Arc<DeferredLoad<TableName>>,
+            _transition_shard_id: ShardId,
+        ) -> Arc<Mutex<PartitionData>> {
+            let waker = self.wait.notified();
+            let permit = self.sem.acquire().await.unwrap();
+            waker.await;
+            drop(permit); // explicit permit drop for clarity
+            Arc::clone(&self.p)
+        }
+    }
+
+    /// This test asserts a resolve future that is started, is always driven to
+    /// completion.
+    #[tokio::test]
+    async fn test_inner_future_always_resolves() {
+        // Create a fake "connection pool" to highlight the importance of
+        // resolve future completion.
+        //
+        // In this case, the "pool" only has one permit/connection, and the
+        // resolve future will obtain it. If the future does not get driven
+        // forwards (because the caller aborted and is no longer polling it) the
+        // permit will be stuck in the future that is not making progress, but
+        // still allocated, effectively deadlocking the pool.
+        let fake_conn_pool = Arc::new(Semaphore::new(1));
+
+        // A waker to unblock the resolver semaphore for completion.
+        let notify = Arc::new(Notify::default());
+
+        let inner = Arc::new(SemaphoreResolver {
+            sem: Arc::clone(&fake_conn_pool),
+            wait: Arc::clone(&notify),
+            p: Arc::new(Mutex::new(PartitionData::new(
+                PARTITION_ID,
+                PartitionKey::from(PARTITION_KEY),
+                NAMESPACE_ID,
+                Arc::clone(&*NAMESPACE_NAME),
+                TABLE_ID,
+                Arc::clone(&*TABLE_NAME),
+                SortKeyState::Provided(None),
+                TRANSITION_SHARD_ID,
+            ))),
+        });
+
+        let layer = Arc::new(CoalescePartitionResolver::new(inner));
+
+        let fut = layer.get_partition(
+            PartitionKey::from(PARTITION_KEY),
+            NAMESPACE_ID,
+            Arc::clone(&*NAMESPACE_NAME),
+            TABLE_ID,
+            Arc::clone(&*TABLE_NAME),
+            TRANSITION_SHARD_ID,
+        );
+
+        let waker = futures::task::noop_waker();
+        let mut cx = Context::from_waker(&waker);
+
+        futures::pin_mut!(fut);
+
+        // Poll the future until it blocks waiting on notify.
+        assert_matches!(Pin::new(&mut fut).poll(&mut cx), Poll::Pending);
+
+        // Drop the caller's poll future to prove nothing else polls it.
+        #[allow(clippy::drop_non_drop)]
+        drop(fut);
+
+        // Allow the resolve future to unblock and complete, if it is being
+        // polled.
+        notify.notify_waiters();
+
+        // And attempt to acquire the only semaphore permit / "connection"  from
+        // the pool. If this succeeds, the dropped resolve future was driven to
+        // completion in the background, without an explicit poll by this
+        // thread / the only caller.
+        let _conn = fake_conn_pool
+            .acquire()
+            // If a "connection" is not available within 5 seconds, panic.
+            .with_timeout_panic(Duration::from_secs(5))
+            .await
+            .unwrap();
     }
 }


### PR DESCRIPTION
Patches up a hypothetical problem (though unreachable in practice) I introduced as part of #7559.

---

* test(ingester): use constants in coalesce test (23a6dfeda)
      
      Clean up the CoalescePartitionResolver tests by using constants across
      tests - I should have done this before but was rushing around!

* perf(ingester): avoid optimistic RMW operation (5e42c5be6)
      
      Changes the CoalescePartitionResolver state cleanup path to avoid an
      optimistic RMW operation against the atomic "has been cleaned up" flag.
      This gives callers who are going to fail the opportunity to do so
      quickly and cheaply, where all but one caller will fail.

* fix(ingester): always complete partition fetches (b0cc2bda0)
      
      In #7559 I introduced code to coalesce N queries for a given partition
      down to a single query, with the other callers (async) blocking to
      obtain the shared result.
      
      This is usually fine, but it is hypothetically possible for all callers
      to start the partition lookup and abort (cancelling their shared poll
      future) before the partition resolves, leaving it half complete.
      
      The problem is this half-complete future MAY be holding a connection
      from the catalog connection pool (internally a semaphore). This means
      this connection is "stuck", lent out to this future that isn't making
      progress (and may never make progress!). Given sufficient occurrences,
      it's possible this could lead to starving the system of catalog
      connections.
      
      This fix is simple - spawn the resolve future into the runtime so it
      completes irrespective of any caller polling it (they only poll for the
      result, not to drive it forward).
      
      NOTE: this isn't practically possible, because writes that traverse the
      WAL DmlSink currently become uncancellable - this may not always be the
      case however, so this underlying foot gun should be patched over!