### PR TITLE
feat(ingester): blocked write load shedding

### DIFF
--- a/ingester2/src/dml_sink/trait.rs
+++ b/ingester2/src/dml_sink/trait.rs
@@ -16,6 +16,11 @@ pub enum DmlError {
     /// An error appending the [`DmlOperation`] to the write-ahead log.
     #[error("wal commit failure: {0}")]
     Wal(String),
+
+    /// The write has hit an internal timeout designed to prevent writes from
+    /// retrying indefinitely.
+    #[error("buffer apply request timeout")]
+    ApplyTimeout,
 }
 
 /// A [`DmlSink`] handles [`DmlOperation`] instances in some abstract way.

--- a/ingester2/src/server/grpc/rpc_write.rs
+++ b/ingester2/src/server/grpc/rpc_write.rs
@@ -63,6 +63,7 @@ impl From<DmlError> for tonic::Status {
         match e {
             DmlError::Buffer(e) => map_write_error(e),
             DmlError::Wal(_) => Self::internal(e.to_string()),
+            DmlError::ApplyTimeout => Self::internal(e.to_string()),
         }
     }
 }


### PR DESCRIPTION
This PR provides a small reliability improvement, allowing an ingester to tolerate an outage of the catalog lasting a significant amount of time that prevents writes from completing (or less time whilst under significant write load, etc).

---

* feat(ingester): blocked write load shedding (2769b5232)
      
      This commit bounds the duration of time a write may take to be processed
      after being added to the WAL for increased reliability.
      
      In ideal cases, anything that is added to the WAL is buffered /
      completed to prevent WAL replay materialising writes that never
      completed in the first place (#7111), but in some cases (i.e. catalog
      outage, etc) the write becomes blocked, stuck in a retry loop or
      otherwise never making progress.
      
      When a write is blocked, the data within it remains in RAM, and the
      overhead of the spawned task retrying also consumes CPU resources. If
      all writes are blocked for sufficient time, these limitless writes keep
      building up until a resource is exhausted (i.e. RAM -> OOM) causing an
      outage of the ingester.
      
      Instead, this change allocates a write at most 15 seconds to complete,
      before it is cancelled and an error returned to the user (if they're
      still connected) to shed load. The error message "buffer apply request
      timeout" was chosen to be uniquely identifying - systems have lots of
      timeouts!
      
      Normally the inner.apply() call at this point completes in microseconds,
      so 15 seconds is more than long enough to avoid shedding legitimate
      load.