### PR TITLE
fix: In DmlMeta, only use SequenceNumber rather than Sequence (shard index plus seq num)

### DIFF
--- a/data_types/src/lib.rs
+++ b/data_types/src/lib.rs
@@ -2039,25 +2039,6 @@ impl TableSummary {
     }
 }
 
-/// Shard index plus offset
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
-pub struct Sequence {
-    /// The shard index
-    pub shard_index: ShardIndex,
-    /// The sequence number
-    pub sequence_number: SequenceNumber,
-}
-
-impl Sequence {
-    /// Create a new Sequence
-    pub fn new(shard_index: ShardIndex, sequence_number: SequenceNumber) -> Self {
-        Self {
-            shard_index,
-            sequence_number,
-        }
-    }
-}
-
 /// minimum time that can be represented.
 ///
 /// 1677-09-21 00:12:43.145224194 +0000 UTC

--- a/ingester2/benches/write.rs
+++ b/ingester2/benches/write.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
-use data_types::{PartitionKey, Sequence, SequenceNumber, ShardIndex};
+use data_types::{PartitionKey, SequenceNumber};
 use dml::{DmlMeta, DmlWrite};
 use futures::{stream::FuturesUnordered, StreamExt};
 use generated_types::influxdata::{
@@ -67,7 +67,7 @@ async fn init(lp: impl AsRef<str>) -> (TestContext<impl IngesterRpcInterface>, D
         batches_by_ids,
         PartitionKey::from(PARTITION_KEY),
         DmlMeta::sequenced(
-            Sequence::new(ShardIndex::new(42), SequenceNumber::new(42)),
+            SequenceNumber::new(42),
             iox_time::SystemProvider::new().now(),
             None,
             50,

--- a/ingester2/src/buffer_tree/namespace.rs
+++ b/ingester2/src/buffer_tree/namespace.rs
@@ -147,8 +147,7 @@ where
         let sequence_number = op
             .meta()
             .sequence()
-            .expect("applying unsequenced op")
-            .sequence_number;
+            .expect("applying unsequenced op");
 
         match op {
             DmlOperation::Write(write) => {

--- a/ingester2/src/dml_sink/tracing.rs
+++ b/ingester2/src/dml_sink/tracing.rs
@@ -130,7 +130,7 @@ mod tests {
         // Populate the metadata with a span context.
         let meta = op.meta();
         op.set_meta(DmlMeta::sequenced(
-            *meta.sequence().unwrap(),
+            meta.sequence().unwrap(),
             meta.producer_ts().unwrap(),
             Some(span),
             42,
@@ -166,7 +166,7 @@ mod tests {
         // Populate the metadata with a span context.
         let meta = op.meta();
         op.set_meta(DmlMeta::sequenced(
-            *meta.sequence().unwrap(),
+            meta.sequence().unwrap(),
             meta.producer_ts().unwrap(),
             Some(span),
             42,

--- a/ingester2/src/init/wal_replay.rs
+++ b/ingester2/src/init/wal_replay.rs
@@ -1,4 +1,4 @@
-use data_types::{NamespaceId, PartitionKey, Sequence, SequenceNumber, TableId};
+use data_types::{NamespaceId, PartitionKey, SequenceNumber, TableId};
 use dml::{DmlMeta, DmlOperation, DmlWrite};
 use generated_types::influxdata::iox::wal::v1::sequenced_wal_op::Op;
 use metric::U64Counter;
@@ -12,7 +12,6 @@ use crate::{
     dml_sink::{DmlError, DmlSink},
     partition_iter::PartitionIter,
     persist::{drain_buffer::persist_partitions, queue::PersistQueue},
-    TRANSITION_SHARD_INDEX,
 };
 
 /// Errors returned when replaying the write-ahead log.
@@ -235,10 +234,7 @@ where
                 partition_key,
                 // The tracing context should be propagated over the RPC boundary.
                 DmlMeta::sequenced(
-                    Sequence {
-                        shard_index: TRANSITION_SHARD_INDEX, // TODO: remove this from DmlMeta
-                        sequence_number,
-                    },
+                    sequence_number,
                     iox_time::Time::MAX, // TODO: remove this from DmlMeta
                     // TODO: A tracing context should be added for WAL replay.
                     None,

--- a/ingester2/src/server/grpc/rpc_write.rs
+++ b/ingester2/src/server/grpc/rpc_write.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use data_types::{NamespaceId, PartitionKey, Sequence, TableId};
+use data_types::{NamespaceId, PartitionKey, TableId};
 use dml::{DmlMeta, DmlOperation, DmlWrite};
 use generated_types::influxdata::iox::ingester::v1::{
     self as proto, write_service_server::WriteService,
@@ -15,7 +15,6 @@ use crate::{
     dml_sink::{DmlError, DmlSink},
     ingest_state::{IngestState, IngestStateError},
     timestamp_oracle::TimestampOracle,
-    TRANSITION_SHARD_INDEX,
 };
 
 /// A list of error states when handling an RPC write request.
@@ -189,10 +188,7 @@ where
                 .collect(),
             partition_key,
             DmlMeta::sequenced(
-                Sequence {
-                    shard_index: TRANSITION_SHARD_INDEX, // TODO: remove this from DmlMeta
-                    sequence_number: self.timestamp.next(),
-                },
+                self.timestamp.next(),
                 iox_time::Time::MAX, // TODO: remove this from DmlMeta
                 // The tracing context should be propagated over the RPC boundary.
                 //
@@ -297,7 +293,7 @@ mod tests {
             assert_eq!(w.namespace_id(), NAMESPACE_ID);
             assert_eq!(w.table_count(), 1);
             assert_eq!(*w.partition_key(), PartitionKey::from(PARTITION_KEY));
-            assert_eq!(w.meta().sequence().unwrap().sequence_number.get(), 1);
+            assert_eq!(w.meta().sequence().unwrap().get(), 1);
         }
     );
 
@@ -405,8 +401,8 @@ mod tests {
         assert_matches!(
             *mock.get_calls(),
             [DmlOperation::Write(ref w1), DmlOperation::Write(ref w2)] => {
-                let w1 = w1.meta().sequence().unwrap().sequence_number.get();
-                let w2 = w2.meta().sequence().unwrap().sequence_number.get();
+                let w1 = w1.meta().sequence().unwrap().get();
+                let w2 = w2.meta().sequence().unwrap().get();
                 assert!(w1 < w2);
             }
         );

--- a/ingester2/src/test_util.rs
+++ b/ingester2/src/test_util.rs
@@ -1,8 +1,6 @@
 use std::collections::BTreeMap;
 
-use data_types::{
-    NamespaceId, PartitionKey, Sequence, SequenceNumber, ShardId, ShardIndex, TableId,
-};
+use data_types::{NamespaceId, PartitionKey, SequenceNumber, ShardId, ShardIndex, TableId};
 use dml::{DmlMeta, DmlWrite};
 use iox_catalog::interface::Catalog;
 use mutable_batch_lp::lines_to_batches;
@@ -147,10 +145,7 @@ pub(crate) fn make_write_op(
         tables_by_id,
         partition_key.clone(),
         DmlMeta::sequenced(
-            Sequence {
-                shard_index: ShardIndex::new(i32::MAX),
-                sequence_number: SequenceNumber::new(sequence_number),
-            },
+            SequenceNumber::new(sequence_number),
             iox_time::Time::MIN,
             None,
             42,
@@ -195,8 +190,8 @@ pub(crate) fn assert_dml_writes_eq(a: DmlWrite, b: DmlWrite) {
     assert_eq!(a.partition_key(), b.partition_key(), "partition key");
 
     // Assert sequence numbers were reassigned
-    let seq_a = a.meta().sequence().map(|s| s.sequence_number);
-    let seq_b = b.meta().sequence().map(|s| s.sequence_number);
+    let seq_a = a.meta().sequence();
+    let seq_b = b.meta().sequence();
     assert_eq!(seq_a, seq_b, "sequence numbers differ");
 
     let a = a.into_tables().collect::<BTreeMap<_, _>>();

--- a/ingester2/src/wal/wal_sink.rs
+++ b/ingester2/src/wal/wal_sink.rs
@@ -102,7 +102,6 @@ impl WalAppender for Arc<wal::Wal> {
             .meta()
             .sequence()
             .expect("committing unsequenced dml operation to wal")
-            .sequence_number
             .get() as u64;
 
         let namespace_id = op.namespace_id();

--- a/ingester2_test_ctx/src/lib.rs
+++ b/ingester2_test_ctx/src/lib.rs
@@ -17,8 +17,8 @@ use std::{collections::HashMap, sync::Arc, time::Duration};
 use arrow::record_batch::RecordBatch;
 use arrow_flight::{decode::FlightRecordBatchStream, flight_service_server::FlightService, Ticket};
 use data_types::{
-    Namespace, NamespaceId, NamespaceSchema, ParquetFile, PartitionKey, QueryPoolId, Sequence,
-    SequenceNumber, ShardIndex, TableId, TopicId,
+    Namespace, NamespaceId, NamespaceSchema, ParquetFile, PartitionKey, QueryPoolId,
+    SequenceNumber, TableId, TopicId,
 };
 use dml::{DmlMeta, DmlWrite};
 use futures::{stream::FuturesUnordered, FutureExt, StreamExt, TryStreamExt};
@@ -179,8 +179,6 @@ impl TestContextBuilder {
     }
 }
 
-const SHARD_INDEX: ShardIndex = ShardIndex::new(42);
-
 /// A command interface to the underlying [`ingester2`] instance.
 ///
 /// When the [`TestContext`] is dropped, the underlying [`ingester2`] instance
@@ -309,7 +307,7 @@ where
             batches_by_ids,
             partition_key,
             DmlMeta::sequenced(
-                Sequence::new(SHARD_INDEX, SequenceNumber::new(sequence_number)),
+                SequenceNumber::new(sequence_number),
                 iox_time::SystemProvider::new().now(),
                 None,
                 50,


### PR DESCRIPTION
Extracted from https://github.com/influxdata/influxdb_iox/pull/7049.

This takes care of a few TODO comments in the ingester.