### PR TITLE
chore: Record the duration metric for the authz call.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3470,6 +3470,7 @@ dependencies = [
 name = "metric"
 version = "0.1.0"
 dependencies = [
+ "iox_time",
  "parking_lot 0.12.1",
  "workspace-hack",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -517,6 +517,7 @@ dependencies = [
  "async-trait",
  "generated_types",
  "http",
+ "metric",
  "observability_deps",
  "snafu",
  "tonic 0.9.2",

--- a/authz/Cargo.toml
+++ b/authz/Cargo.toml
@@ -11,6 +11,7 @@ license.workspace = true
 [dependencies]
 http = {version = "0.2.9", optional = true }
 generated_types = { path = "../generated_types" }
+metric = { version = "0.1.0", path = "../metric" }
 observability_deps = { path = "../observability_deps" }
 workspace-hack = { version = "0.1", path = "../workspace-hack" }
 

--- a/metric/Cargo.toml
+++ b/metric/Cargo.toml
@@ -6,6 +6,7 @@ edition.workspace = true
 license.workspace = true
 
 [dependencies] # In alphabetical order
+iox_time = { version = "0.1.0", path = "../iox_time" }
 parking_lot = "0.12"
 workspace-hack = { version = "0.1", path = "../workspace-hack" }
 

--- a/metric/src/decorators.rs
+++ b/metric/src/decorators.rs
@@ -1,0 +1,96 @@
+//! Metrics decorator for durations
+
+use iox_time::{SystemProvider, TimeProvider};
+use std::future::Future;
+
+use crate::{DurationHistogram, Metric, Registry};
+
+/// An instrumentation decorator for recording [`DurationHistogram`] on a given trait.
+///
+/// Use by implementing the target trait in [`DurationHistogramDecorator`].
+/// ```compile_fail
+/// use async_trait::async_trait;
+///
+/// #[async_trait]
+/// impl<T> AnyTrait for DurationHistogramDecorator<T>
+/// where
+///     T: AnyTrait
+/// {
+///     async fn any_method(&self, any_args: AnyType) -> Result<O,E> { <body> };
+/// }
+/// ```
+///
+/// Then utilize the [`DurationHistogramDecorator::record_duration()`](Self::record_duration).
+#[derive(Debug)]
+pub struct DurationHistogramDecorator<T, P = SystemProvider> {
+    inner: T,
+    time_provider: P,
+
+    success: DurationHistogram,
+    error: DurationHistogram,
+}
+
+impl<T> DurationHistogramDecorator<T> {
+    /// Wrap a new [`DurationHistogramDecorator`] over `T` exposing metrics.
+    pub fn new(
+        title: &'static str,
+        description: &'static str,
+        registry: &Registry,
+        inner: T,
+    ) -> Self {
+        let metric: Metric<DurationHistogram> = registry.register_metric(title, description);
+
+        let success = metric.recorder(&[("result", "success")]);
+        let error = metric.recorder(&[("result", "error")]);
+
+        Self {
+            inner,
+            time_provider: Default::default(),
+            success,
+            error,
+        }
+    }
+
+    pub fn inner(&self) -> &T {
+        &self.inner
+    }
+
+    /// Method to call when implementing a given trait for [`DurationHistogramDecorator`],
+    /// to have the duration metric be recorded for a given closure.
+    ///
+    /// Accepts an asynchronous FnOnce. Example:
+    /// ```compile_fail
+    /// use async_trait::async_trait;
+    ///
+    /// #[async_trait]
+    /// impl<T> AnyTrait for DurationHistogramDecorator<T>
+    /// where
+    ///     T: AnyTrait
+    /// {
+    ///     async fn any_method(&self, any_args: AnyType) -> Result<O,E> {
+    ///         self.record_duration(|| async move { self.inner().any_method(any_args).await }).await
+    ///     }
+    /// }
+    /// ```
+    pub async fn record_duration<F, Fut, E, O>(&self, func: F) -> Result<O, E>
+    where
+        O: Sized,
+        E: ToString + Sized,
+        F: FnOnce() -> Fut + Send,
+        Fut: Future<Output = Result<O, E>> + Send,
+    {
+        let t = self.time_provider.now();
+        let res = func().await;
+
+        // Avoid exploding if time goes backwards - simply drop the measurement
+        // if it happens.
+        if let Some(delta) = self.time_provider.now().checked_duration_since(t) {
+            match &res {
+                Ok(_) => self.success.record(delta),
+                Err(_) => self.error.record(delta),
+            };
+        }
+
+        res
+    }
+}

--- a/metric/src/lib.rs
+++ b/metric/src/lib.rs
@@ -120,6 +120,7 @@ use std::collections::BTreeMap;
 
 mod counter;
 mod cumulative;
+mod decorators;
 mod duration;
 mod gauge;
 mod histogram;
@@ -128,6 +129,7 @@ mod metric;
 pub use crate::metric::*;
 pub use counter::*;
 pub use cumulative::*;
+pub use decorators::*;
 pub use duration::*;
 pub use gauge::*;
 pub use histogram::*;

--- a/router/src/server/http/write/single_tenant/auth.rs
+++ b/router/src/server/http/write/single_tenant/auth.rs
@@ -86,6 +86,7 @@ mod tests {
     use assert_matches::assert_matches;
     use data_types::NamespaceId;
     use hyper::header::HeaderValue;
+    use metric::{Attributes, DurationHistogram, DurationHistogramDecorator, Metric};
 
     use super::{mock::*, *};
     use crate::{
@@ -183,6 +184,75 @@ mod tests {
         assert_matches!(calls.as_slice(), [MockDmlHandlerCall::Write{namespace, ..}] => {
             assert_eq!(namespace, NAMESPACE_NAME);
         })
+    }
+
+    #[tokio::test]
+    async fn test_authz_metric() {
+        static NAMESPACE_NAME: &str = "test";
+        let mock_namespace_resolver =
+            MockNamespaceResolver::default().with_mapping(NAMESPACE_NAME, NamespaceId::new(42));
+        let dml_handler = Arc::new(MockDmlHandler::default().with_write_return([Ok(())]));
+
+        let metrics = Arc::new(metric::Registry::default());
+        let topic = "topic";
+        let decorator = Arc::new(DurationHistogramDecorator::new(
+            topic,
+            "describe it",
+            &metrics,
+            MockAuthorizer::default(),
+        ));
+
+        let delegate = HttpDelegate::new(
+            MAX_BYTES,
+            1,
+            mock_namespace_resolver,
+            Arc::clone(&dml_handler),
+            &metrics,
+            Box::new(SingleTenantRequestUnifier::new(decorator)),
+        );
+
+        let request = Request::builder()
+            .uri("https://bananas.example/api/v2/write?org=bananas&bucket=test")
+            .method("POST")
+            .extension(AuthorizationHeaderExtension::new(Some(
+                HeaderValue::from_str(format!("Token {MOCK_AUTH_VALID_TOKEN}").as_str()).unwrap(),
+            )))
+            .body(Body::from("platanos,tag1=A,tag2=B val=42i 123456"))
+            .unwrap();
+        let got = delegate.route(request).await;
+        assert!(got.is_ok());
+
+        let request = Request::builder()
+            .uri("https://bananas.example/api/v2/write?org=bananas&bucket=test")
+            .method("POST")
+            .extension(AuthorizationHeaderExtension::new(Some(
+                HeaderValue::from_str(format!("Token {MOCK_AUTH_INVALID_TOKEN}").as_str()).unwrap(),
+            )))
+            .body(Body::from("platanos,tag1=A,tag2=B val=42i 123456"))
+            .unwrap();
+        let got = delegate.route(request).await;
+        assert!(got.is_err());
+
+        let histogram = &metrics
+            .get_instrument::<Metric<DurationHistogram>>(topic)
+            .expect("failed to read metric");
+
+        assert_eq!(
+            histogram
+                .get_observer(&Attributes::from(&[("result", "success"),]))
+                .expect("failed to get observer")
+                .fetch()
+                .sample_count(),
+            1
+        );
+        assert_eq!(
+            histogram
+                .get_observer(&Attributes::from(&[("result", "error"),]))
+                .expect("failed to get observer")
+                .fetch()
+                .sample_count(),
+            1
+        );
     }
 
     macro_rules! test_authorize {


### PR DESCRIPTION
create DurationHistogramDecorator, and utilize to record the authz duration in SingleTenantRequestUnifier

---
* chore: create DurationHistogramDecorator in metric mod (1904035e12c86851de9e1a0e6946d5abf65e86fa)
* chore: impl Authorizer for DurationMetricDecorator (51c4597ef2da03bf31f704ceb7aa13a3b92e3303)
* chore: wrap authz provided to SingleTenantRequestUnifier with DurationMetricDecorator (cadc07fb8e6dcfdfa48475b053b9eb4a81d1d24c)



## Checklist
- [x] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb_iox/blob/main/README.md).
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
