### PR TITLE
test: property test namespace schema merging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4753,6 +4753,7 @@ dependencies = [
  "parking_lot 0.12.1",
  "paste",
  "pretty_assertions",
+ "proptest",
  "rand",
  "schema",
  "serde",

--- a/router/Cargo.toml
+++ b/router/Cargo.toml
@@ -51,6 +51,7 @@ iox_tests = { path = "../iox_tests" }
 once_cell = "1"
 paste = "1.0.12"
 pretty_assertions = "1.3.0"
+proptest = "1.1.0"
 rand = "0.8.3"
 test_helpers = { version = "0.1.0", path = "../test_helpers", features = ["future_timeout"] }
 tokio = { version = "1", features = ["test-util"] }


### PR DESCRIPTION
The new `NamespaceCache` API is a good candidate for a proptest - this PR is a nice example of composing together data generation methods to produce a randomised property test!

---

* test: property test namespace schema merging (9cc58eb4e)
      
      This commit adds a randomised property test, that compares the results
      of the new namespace cache schema merging (#7555) with a known-good
      stdlib HashSet union (the cache implementation is effectively a more
      specialised set union operation).
      
      This property test also validates the "last writer wins" semantics for
      other, non-schema data within the namespace.
      
      Additionally the ChangeSet values returned over a pair of updates are
      asserted to reflect the actual values added to the cache (but not each
      call individually) to ensure accurate metrics are reported.