### PR TITLE
fix: Require some metadata, delete some metadata

### DIFF
--- a/compactor2/src/components/parquet_file_sink/mock.rs
+++ b/compactor2/src/components/parquet_file_sink/mock.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use async_trait::async_trait;
-use data_types::{ColumnSet, CompactionLevel, ParquetFileParams, SequenceNumber, Timestamp};
+use data_types::{ColumnSet, CompactionLevel, ParquetFileParams, Timestamp};
 use datafusion::{
     arrow::{datatypes::SchemaRef, record_batch::RecordBatch},
     error::DataFusionError,
@@ -72,7 +72,6 @@ impl ParquetFileSink for MockParquetFileSink {
             table_id: partition.table.id,
             partition_id: partition.partition_id,
             object_store_id: Uuid::from_u128(guard.len() as u128),
-            max_sequence_number: SequenceNumber::new(0),
             min_time: Timestamp::new(0),
             max_time: Timestamp::new(0),
             file_size_bytes: 1,
@@ -168,7 +167,6 @@ mod tests {
                 table_id: TableId::new(3),
                 partition_id: PartitionId::new(1),
                 object_store_id: Uuid::from_u128(2),
-                max_sequence_number: SequenceNumber::new(0),
                 min_time: Timestamp::new(0),
                 max_time: Timestamp::new(0),
                 file_size_bytes: 1,
@@ -231,7 +229,6 @@ mod tests {
                 table_id: TableId::new(3),
                 partition_id: PartitionId::new(1),
                 object_store_id: Uuid::from_u128(0),
-                max_sequence_number: SequenceNumber::new(0),
                 min_time: Timestamp::new(0),
                 max_time: Timestamp::new(0),
                 file_size_bytes: 1,

--- a/compactor2/src/components/parquet_file_sink/object_store.rs
+++ b/compactor2/src/components/parquet_file_sink/object_store.rs
@@ -1,7 +1,7 @@
 use std::{fmt::Display, sync::Arc};
 
 use async_trait::async_trait;
-use data_types::{CompactionLevel, ParquetFileParams, SequenceNumber};
+use data_types::{CompactionLevel, ParquetFileParams};
 use datafusion::{error::DataFusionError, physical_plan::SendableRecordBatchStream};
 use iox_time::{Time, TimeProvider};
 use parquet_file::{
@@ -14,9 +14,6 @@ use uuid::Uuid;
 use crate::partition_info::PartitionInfo;
 
 use super::ParquetFileSink;
-
-// fields no longer used but still exists in the catalog
-const MAX_SEQUENCE_NUMBER: i64 = 0;
 
 #[derive(Debug)]
 pub struct ObjectStoreParquetFileSink {
@@ -57,7 +54,6 @@ impl ParquetFileSink for ObjectStoreParquetFileSink {
             table_name: partition.table.name.clone().into(),
             partition_id: partition.partition_id,
             partition_key: partition.partition_key.clone(),
-            max_sequence_number: SequenceNumber::new(MAX_SEQUENCE_NUMBER),
             compaction_level: level,
             sort_key: partition.sort_key.clone(),
             max_l0_created_at,

--- a/compactor2_test_utils/src/simulator.rs
+++ b/compactor2_test_utils/src/simulator.rs
@@ -7,9 +7,7 @@ use std::{
 };
 
 use async_trait::async_trait;
-use data_types::{
-    ColumnSet, CompactionLevel, ParquetFile, ParquetFileParams, SequenceNumber, Timestamp,
-};
+use data_types::{ColumnSet, CompactionLevel, ParquetFile, ParquetFileParams, Timestamp};
 use datafusion::physical_plan::SendableRecordBatchStream;
 use iox_time::Time;
 use observability_deps::tracing::info;
@@ -206,7 +204,6 @@ impl SimulatedFile {
             table_id: partition_info.table.id,
             partition_id: partition_info.partition_id,
             object_store_id: Uuid::new_v4(),
-            max_sequence_number: SequenceNumber::new(0),
             min_time,
             max_time,
             file_size_bytes,

--- a/data_types/src/lib.rs
+++ b/data_types/src/lib.rs
@@ -830,23 +830,6 @@ pub struct Partition {
     /// relative order of B and C have been reversed.
     pub sort_key: Vec<String>,
 
-    /// The inclusive maximum [`SequenceNumber`] of the most recently persisted
-    /// data for this partition.
-    ///
-    /// All writes with a [`SequenceNumber`] less than and equal to this
-    /// [`SequenceNumber`] have been persisted to the object store. The inverse
-    /// is not guaranteed to be true due to update ordering; some files for this
-    /// partition may exist in the `parquet_files` table that have a greater
-    /// [`SequenceNumber`] than is specified here - the system will converge so
-    /// long as the ingester progresses.
-    ///
-    /// It is a system invariant that this value monotonically increases over
-    /// time - wrote another way, it is an invariant that partitions are
-    /// persisted (or at least made visible) in sequence order.
-    ///
-    /// If [`None`] no data has been persisted for this partition.
-    pub persisted_sequence_number: Option<SequenceNumber>,
-
     /// The time at which the newest file of the partition is created
     pub new_file_at: Option<Timestamp>,
 }
@@ -945,8 +928,6 @@ pub struct ParquetFile {
     pub partition_id: PartitionId,
     /// the uuid used in the object store path for this file
     pub object_store_id: Uuid,
-    /// the maximum sequence number from a record in this file
-    pub max_sequence_number: SequenceNumber,
     /// the min timestamp of data in this file
     pub min_time: Timestamp,
     /// the max timestamp of data in this file
@@ -1003,7 +984,6 @@ impl ParquetFile {
             table_id: params.table_id,
             partition_id: params.partition_id,
             object_store_id: params.object_store_id,
-            max_sequence_number: params.max_sequence_number,
             min_time: params.min_time,
             max_time: params.max_time,
             to_delete: None,
@@ -1044,8 +1024,6 @@ pub struct ParquetFileParams {
     pub partition_id: PartitionId,
     /// the uuid used in the object store path for this file
     pub object_store_id: Uuid,
-    /// the maximum sequence number from a record in this file
-    pub max_sequence_number: SequenceNumber,
     /// the min timestamp of data in this file
     pub min_time: Timestamp,
     /// the max timestamp of data in this file
@@ -1071,7 +1049,6 @@ impl From<ParquetFile> for ParquetFileParams {
             table_id: value.table_id,
             partition_id: value.partition_id,
             object_store_id: value.object_store_id,
-            max_sequence_number: value.max_sequence_number,
             min_time: value.min_time,
             max_time: value.max_time,
             file_size_bytes: value.file_size_bytes,

--- a/docs/ingester_querier_protocol.md
+++ b/docs/ingester_querier_protocol.md
@@ -3,8 +3,8 @@ This document describes the query protocol that the querier uses to request data
 
 The protocol is based on [Apache Flight]. We however only support a single request type: `DoGet`.
 
-
 ## Request (Querier ⇒ Ingester)
+
 The `DoGet` ticket contains a [Protocol Buffer] message
 `influxdata.iox.ingester.v1.IngesterQueryRequest` (see our `generated_types` crate). This message
 contains:
@@ -16,20 +16,20 @@ contains:
   the request and the ingester data).
 - **predicate:** Predicate for row-filtering on the ingester side.
 
-The request does NOT contain a selection of partitions or shards. The ingester must respond with
-all partitions and shards it knows for that specified namespace-table combination.
+The request does NOT contain a selection of partitions. The ingester must respond with all
+partitions it knows for that specified namespace-table combination.
 
 ## Response (Ingester ⇒ Querier)
+
 The goal of the response is to stream the following ingester data hierarchy:
 
-- For each shard:
-  - For each partition **(A)**:
-    - Persistence Information:
-      - Sequence number of max. persisted parquet file
-    - For each snapshot (contains _persisting_ data) **(B)**:
-      - Record batches with following operations applied **(C)**:
-        - selection (i.e. row filter via predicates)
-        - projection (i.e. column filter)
+- For each partition **(A)**:
+- Persistence Information:
+  - Sequence number of max. persisted parquet file
+- For each snapshot (contains _persisting_ data) **(B)**:
+  - Record batches with following operations applied **(C)**:
+    - selection (i.e. row filter via predicates)
+    - projection (i.e. column filter)
 
 This is mapped to the following stream of Flight messages:
 
@@ -37,35 +37,36 @@ This is mapped to the following stream of Flight messages:
   `influxdata.iox.ingester.v1.IngesterQueryResponseMetadata`. This message contains:
   - partition id
   - Sequence number of max. persisted parquet file
-- **B:** `Schema` message that announces the snapshot schema. No app metadata is attached. The snapshot belongs to the
-  partition that was just announced. Transmitting a schema resets the dictionary information.
-- **Between B and C:** `DictionaryBatch` messages that set the dictionary information for the next record batch.
-- **C:** `RecordBatch` message that uses the last schema and the current dictionary state. The batch belongs to the
-  snapshot that was just announced.
+- **B:** `Schema` message that announces the snapshot schema. No app metadata is attached. The
+  snapshot belongs to the partition that was just announced. Transmitting a schema resets the
+  dictionary information.
+- **Between B and C:** `DictionaryBatch` messages that set the dictionary information for the next
+  record batch.
+- **C:** `RecordBatch` message that uses the last schema and the current dictionary state. The
+  batch belongs to the snapshot that was just announced.
 
-The protocol is stateful and therefore the order of the messages is important. A specific partition and snapshot may only
-be announced once.
+The protocol is stateful and therefore the order of the messages is important. A specific partition
+and snapshot may only be announced once.
 
-All other messages types (at the time of writing these are `Tensor` and `SparseTensor`) are unsupported.
-
+All other messages types (at the time of writing these are `Tensor` and `SparseTensor`) are
+unsupported.
 
 ## Example
+
 Imagine the following ingester state:
 
-- shard S1:
-  - partition P1:
-    - max. persisted parquet file at `sequence_number=10`
-    - snapshots C1 and C2
-  - partition P2:
-    - max. persisted parquet file at `sequence_number=1`
-    - snapshot C3
-- shard S2:
-  - partition P3:
-    - no persisted parquet file
-    - no snapshots (all deleted)
-  - partition P4:
-    - no persisted parquet file
-    - snapshot C4
+- partition P1:
+  - max. persisted parquet file at `sequence_number=10`
+  - snapshots C1 and C2
+- partition P2:
+  - max. persisted parquet file at `sequence_number=1`
+  - snapshot C3
+- partition P3:
+  - no persisted parquet file
+  - no snapshots (all deleted)
+- partition P4:
+  - no persisted parquet file
+  - snapshot C4
 
 This results in the following response stream:
 
@@ -88,7 +89,6 @@ This results in the following response stream:
 8. zero, one, or multiple `RecordBatch`es for C4
 
 Note that P3 was skipped because there was no unpersisted data.
-
 
 [Apache Flight]: https://arrow.apache.org/docs/Format/Flight.html
 [Protocol Buffer]: https://developers.google.com/protocol-buffers

--- a/garbage_collector/src/objectstore/checker.rs
+++ b/garbage_collector/src/objectstore/checker.rs
@@ -138,7 +138,7 @@ mod tests {
     use chrono::TimeZone;
     use data_types::{
         ColumnId, ColumnSet, CompactionLevel, NamespaceId, ParquetFile, ParquetFileParams,
-        PartitionId, SequenceNumber, TableId, Timestamp,
+        PartitionId, TableId, Timestamp,
     };
     use iox_catalog::{interface::Catalog, mem::MemCatalog};
     use object_store::path::Path;
@@ -178,7 +178,6 @@ mod tests {
             table_id: partition.table_id,
             partition_id: partition.id,
             object_store_id: Uuid::new_v4(),
-            max_sequence_number: SequenceNumber::new(140),
             min_time: Timestamp::new(1),
             max_time: Timestamp::new(10),
             file_size_bytes: 1337,

--- a/generated_types/protos/influxdata/iox/catalog/v1/parquet_file.proto
+++ b/generated_types/protos/influxdata/iox/catalog/v1/parquet_file.proto
@@ -9,6 +9,8 @@ message ParquetFile {
     reserved "sequencer_id";
     reserved 17;
     reserved "shard_id";
+    reserved 8;
+    reserved "max_sequence_number";
 
     // the id of the file in the catalog
     int64 id = 1;
@@ -20,8 +22,6 @@ message ParquetFile {
     int64 partition_id = 5;
     // the object store uuid
     string object_store_id = 6;
-    // the maximum sequence number from a record in this file
-    int64 max_sequence_number = 8;
     // the min timestamp of data in this file
     int64 min_time = 9;
     // the max timestamp of data in this file

--- a/generated_types/protos/influxdata/iox/ingester/v1/parquet_metadata.proto
+++ b/generated_types/protos/influxdata/iox/ingester/v1/parquet_metadata.proto
@@ -19,6 +19,9 @@ message IoxMetadata {
   // shard_id was removed
   reserved 17;
   reserved "shard_id";
+  // max_sequence_number was removed
+  reserved 13;
+  reserved "max_sequence_number";
 
   // Object store ID. Used in the parquet filename. 16 bytes in big-endian order.
   bytes object_store_id = 1;
@@ -43,9 +46,6 @@ message IoxMetadata {
 
   // Partition key of the partition that holds this parquet file.
   string partition_key = 9;
-
-  // The maximum sequence number from a shard in this parquet file.
-  int64 max_sequence_number = 13;
 
   // The sort key of this chunk
   SortKey sort_key = 15;

--- a/generated_types/protos/influxdata/iox/ingester/v1/query.proto
+++ b/generated_types/protos/influxdata/iox/ingester/v1/query.proto
@@ -73,28 +73,15 @@ message IngesterQueryResponseMetadata {
   // Partition id for this batch.
   int64 partition_id = 7;
 
-  // Optional partition status.
-  //
-  // If this is given, then no schema and no batch will be part of this FlightData object.
-  PartitionStatus status = 8;
+  // Was partition status.
+  reserved "status";
+  reserved 8;
 
   // UUID of this ingester instance.
   string ingester_uuid = 9;
 
   // Number of Parquet files that have been persisted to object storage for this partition.
   uint64 completed_persistence_count = 10;
-}
-
-// Status of a partition that has unpersisted data.
-//
-// Note that this structure is specific to a partition (which itself is bound to a table and shard)!
-message PartitionStatus {
-  // Max sequence number persisted
-  optional int64 parquet_max_sequence_number = 1;
-
-  // Deprecated tombstone support in ingester (#5825).
-  reserved "tombstone_max_sequence_number";
-  reserved 2;
 }
 
 // Serialization of `predicate::predicate::Predicate` that contains DataFusion `Expr`s

--- a/import/src/aggregate_tsm_schema/update_catalog.rs
+++ b/import/src/aggregate_tsm_schema/update_catalog.rs
@@ -1023,7 +1023,6 @@ mod tests {
         let partition = Partition {
             id: PartitionId::new(1),
             table_id: TableId::new(1),
-            persisted_sequence_number: None,
             partition_key: PartitionKey::from("2022-06-21"),
             sort_key: Vec::new(),
             new_file_at: None,
@@ -1070,7 +1069,6 @@ mod tests {
         let partition = Partition {
             id: PartitionId::new(1),
             table_id: TableId::new(1),
-            persisted_sequence_number: None,
             partition_key: PartitionKey::from("2022-06-21"),
             // N.B. sort key is already what it will computed to; here we're testing the `adjust_sort_key_columns` code path
             sort_key: vec!["host".to_string(), "arch".to_string(), "time".to_string()],
@@ -1117,7 +1115,6 @@ mod tests {
         let partition = Partition {
             id: PartitionId::new(1),
             table_id: TableId::new(1),
-            persisted_sequence_number: None,
             partition_key: PartitionKey::from("2022-06-21"),
             // N.B. is missing host so will need updating
             sort_key: vec!["arch".to_string(), "time".to_string()],
@@ -1166,7 +1163,6 @@ mod tests {
         let partition = Partition {
             id: PartitionId::new(1),
             table_id: TableId::new(1),
-            persisted_sequence_number: None,
             partition_key: PartitionKey::from("2022-06-21"),
             // N.B. is missing arch so will need updating
             sort_key: vec!["host".to_string(), "time".to_string()],

--- a/ingester2/src/persist/mod.rs
+++ b/ingester2/src/persist/mod.rs
@@ -15,7 +15,7 @@ mod tests {
     use std::{sync::Arc, time::Duration};
 
     use assert_matches::assert_matches;
-    use data_types::{CompactionLevel, ParquetFile, SequenceNumber};
+    use data_types::{CompactionLevel, ParquetFile};
     use dml::DmlOperation;
     use futures::TryStreamExt;
     use iox_catalog::{
@@ -252,7 +252,6 @@ mod tests {
                 table_id: got_table_id,
                 partition_id: got_partition_id,
                 object_store_id,
-                max_sequence_number,
                 row_count,
                 compaction_level,
                 file_size_bytes,
@@ -266,7 +265,6 @@ mod tests {
                 assert_eq!(got_namespace_id, namespace_id);
                 assert_eq!(got_table_id, table_id);
                 assert_eq!(got_partition_id, partition_id);
-                assert_eq!(max_sequence_number, SequenceNumber::new(0));
 
                 assert_eq!(row_count, 1);
                 assert_eq!(compaction_level, CompactionLevel::Initial);
@@ -402,7 +400,6 @@ mod tests {
                 table_id: got_table_id,
                 partition_id: got_partition_id,
                 object_store_id,
-                max_sequence_number,
                 row_count,
                 compaction_level,
                 file_size_bytes,
@@ -419,8 +416,6 @@ mod tests {
 
                 assert_eq!(row_count, 1);
                 assert_eq!(compaction_level, CompactionLevel::Initial);
-
-                assert_eq!(max_sequence_number.get(), 0); // Unused, dummy value
 
                 (object_store_id, file_size_bytes)
             }

--- a/ingester2/src/persist/worker.rs
+++ b/ingester2/src/persist/worker.rs
@@ -2,7 +2,7 @@ use std::{ops::ControlFlow, sync::Arc};
 
 use async_channel::RecvError;
 use backoff::Backoff;
-use data_types::{CompactionLevel, ParquetFileParams, SequenceNumber};
+use data_types::{CompactionLevel, ParquetFileParams};
 use iox_catalog::interface::{get_table_schema_by_id, CasFailure, Catalog};
 use iox_query::exec::Executor;
 use iox_time::{SystemProvider, TimeProvider};
@@ -263,7 +263,6 @@ where
         table_name: Arc::clone(&*ctx.table_name().get().await),
         partition_id: ctx.partition_id(),
         partition_key: ctx.partition_key().clone(),
-        max_sequence_number: SequenceNumber::new(0), // TODO: not ordered!
         compaction_level: CompactionLevel::Initial,
         sort_key: Some(data_sort_key),
         max_l0_created_at: time_now,

--- a/ingester2/src/test_util.rs
+++ b/ingester2/src/test_util.rs
@@ -126,7 +126,6 @@ pub(crate) fn arbitrary_partition() -> Partition {
         table_id: ARBITRARY_TABLE_ID,
         partition_key: ARBITRARY_PARTITION_KEY.clone(),
         sort_key: Default::default(),
-        persisted_sequence_number: Default::default(),
         new_file_at: Default::default(),
     }
 }

--- a/iox_catalog/src/interface.rs
+++ b/iox_catalog/src/interface.rs
@@ -792,7 +792,7 @@ pub(crate) mod test_helpers {
     use super::*;
     use ::test_helpers::{assert_contains, tracing::TracingCapture};
     use assert_matches::assert_matches;
-    use data_types::{ColumnId, ColumnSet, CompactionLevel, SequenceNumber};
+    use data_types::{ColumnId, ColumnSet, CompactionLevel};
     use futures::Future;
     use metric::{Attributes, DurationHistogram, Metric};
     use std::{collections::BTreeSet, ops::DerefMut, sync::Arc, time::Duration};
@@ -1803,7 +1803,6 @@ pub(crate) mod test_helpers {
             table_id: partition.table_id,
             partition_id: partition.id,
             object_store_id: Uuid::new_v4(),
-            max_sequence_number: SequenceNumber::new(140),
             min_time: Timestamp::new(1),
             max_time: Timestamp::new(10),
             file_size_bytes: 1337,
@@ -1839,7 +1838,6 @@ pub(crate) mod test_helpers {
             table_id: other_partition.table_id,
             partition_id: other_partition.id,
             object_store_id: Uuid::new_v4(),
-            max_sequence_number: SequenceNumber::new(200),
             min_time: Timestamp::new(50),
             max_time: Timestamp::new(60),
             ..parquet_file_params.clone()
@@ -1987,7 +1985,6 @@ pub(crate) mod test_helpers {
             object_store_id: Uuid::new_v4(),
             min_time: Timestamp::new(1),
             max_time: Timestamp::new(10),
-            max_sequence_number: SequenceNumber::new(10),
             ..parquet_file_params
         };
         let f1 = repos
@@ -2000,7 +1997,6 @@ pub(crate) mod test_helpers {
             object_store_id: Uuid::new_v4(),
             min_time: Timestamp::new(50),
             max_time: Timestamp::new(60),
-            max_sequence_number: SequenceNumber::new(11),
             ..f1_params.clone()
         };
         let f2 = repos
@@ -2019,7 +2015,6 @@ pub(crate) mod test_helpers {
             object_store_id: Uuid::new_v4(),
             min_time: Timestamp::new(50),
             max_time: Timestamp::new(60),
-            max_sequence_number: SequenceNumber::new(12),
             ..f2_params
         };
         let f3 = repos
@@ -2223,7 +2218,6 @@ pub(crate) mod test_helpers {
             table_id: table_1.id,
             partition_id: partition_1.id,
             object_store_id: Uuid::new_v4(),
-            max_sequence_number: SequenceNumber::new(140),
             min_time: Timestamp::new(1),
             max_time: Timestamp::new(10),
             file_size_bytes: 1337,
@@ -2238,7 +2232,6 @@ pub(crate) mod test_helpers {
             table_id: table_2.id,
             partition_id: partition_2.id,
             object_store_id: Uuid::new_v4(),
-            max_sequence_number: SequenceNumber::new(140),
             min_time: Timestamp::new(1),
             max_time: Timestamp::new(10),
             file_size_bytes: 1337,
@@ -2327,7 +2320,6 @@ pub(crate) mod test_helpers {
             table_id: partition1.table_id,
             partition_id: partition1.id,
             object_store_id: Uuid::new_v4(),
-            max_sequence_number: SequenceNumber::new(140),
             min_time: Timestamp::new(1),
             max_time: Timestamp::new(10),
             file_size_bytes: 1337,
@@ -2683,7 +2675,6 @@ pub(crate) mod test_helpers {
             table_id: partition.table_id,
             partition_id: partition.id,
             object_store_id: Uuid::new_v4(),
-            max_sequence_number: SequenceNumber::new(140),
             min_time,
             max_time,
             file_size_bytes: 1337,
@@ -2794,7 +2785,6 @@ pub(crate) mod test_helpers {
             table_id: partition.table_id,
             partition_id: partition.id,
             object_store_id: Uuid::new_v4(),
-            max_sequence_number: SequenceNumber::new(140),
             min_time: query_min_time + 1,
             max_time: query_max_time - 1,
             file_size_bytes: 1337,
@@ -2884,7 +2874,6 @@ pub(crate) mod test_helpers {
             table_id: partition_1.table_id,
             partition_id: partition_1.id,
             object_store_id: Uuid::new_v4(),
-            max_sequence_number: SequenceNumber::new(1),
             min_time: Timestamp::new(100),
             max_time: Timestamp::new(250),
             file_size_bytes: 1337,
@@ -2901,7 +2890,6 @@ pub(crate) mod test_helpers {
             .unwrap();
         let parquet_file_params_2 = ParquetFileParams {
             object_store_id: Uuid::new_v4(),
-            max_sequence_number: SequenceNumber::new(3),
             min_time: Timestamp::new(200),
             max_time: Timestamp::new(300),
             ..parquet_file_params
@@ -2941,7 +2929,6 @@ pub(crate) mod test_helpers {
             table_id: partition_2.table_id,
             partition_id: partition_2.id,
             object_store_id: Uuid::new_v4(),
-            max_sequence_number: SequenceNumber::new(1),
             min_time: Timestamp::new(100),
             max_time: Timestamp::new(250),
             file_size_bytes: 1337,
@@ -2958,7 +2945,6 @@ pub(crate) mod test_helpers {
             .unwrap();
         let parquet_file_params_2 = ParquetFileParams {
             object_store_id: Uuid::new_v4(),
-            max_sequence_number: SequenceNumber::new(3),
             min_time: Timestamp::new(200),
             max_time: Timestamp::new(300),
             ..parquet_file_params

--- a/iox_catalog/src/kafkaless_transition.rs
+++ b/iox_catalog/src/kafkaless_transition.rs
@@ -1,4 +1,4 @@
-use data_types::{SequenceNumber, TopicId};
+use data_types::TopicId;
 
 /// Magic number to be used shard indices and shard ids in "kafkaless".
 pub(crate) const TRANSITION_SHARD_NUMBER: i32 = 1234;
@@ -66,18 +66,4 @@ pub(crate) struct Shard {
     /// the shard index of the shard the sequence numbers are coming from, sharded by the router
     /// and write buffer
     pub(crate) shard_index: ShardIndex,
-    /// The minimum unpersisted sequence number. Because different tables
-    /// can be persisted at different times, it is possible some data has been persisted
-    /// with a higher sequence number than this. However, all data with a sequence number
-    /// lower than this must have been persisted to Parquet.
-    pub(crate) min_unpersisted_sequence_number: SequenceNumber,
-}
-
-/// Shard index plus offset
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
-pub(crate) struct Sequence {
-    /// The shard index
-    pub(crate) shard_index: ShardIndex,
-    /// The sequence number
-    pub(crate) sequence_number: SequenceNumber,
 }

--- a/iox_catalog/src/mem.rs
+++ b/iox_catalog/src/mem.rs
@@ -16,7 +16,7 @@ use async_trait::async_trait;
 use data_types::{
     Column, ColumnId, ColumnType, CompactionLevel, Namespace, NamespaceId, ParquetFile,
     ParquetFileId, ParquetFileParams, Partition, PartitionId, PartitionKey, QueryPool, QueryPoolId,
-    SequenceNumber, SkippedCompaction, Table, TableId, Timestamp, TopicId, TopicMetadata,
+    SkippedCompaction, Table, TableId, Timestamp, TopicId, TopicMetadata,
 };
 use iox_time::{SystemProvider, TimeProvider};
 use observability_deps::tracing::warn;
@@ -149,7 +149,6 @@ impl Catalog for MemCatalog {
             id: TRANSITION_SHARD_ID,
             topic_id: topic.id,
             shard_index: TRANSITION_SHARD_INDEX,
-            min_unpersisted_sequence_number: SequenceNumber::new(0),
         };
         stage.shards.push(shard);
         transaction.commit_inplace().await?;
@@ -701,7 +700,6 @@ impl PartitionRepo for MemTxn {
                     table_id,
                     partition_key: key,
                     sort_key: vec![],
-                    persisted_sequence_number: None,
                     new_file_at: None,
                 };
                 stage.partitions.push(p);

--- a/iox_tests/src/builders.rs
+++ b/iox_tests/src/builders.rs
@@ -1,6 +1,6 @@
 use data_types::{
     ColumnSet, CompactionLevel, NamespaceId, ParquetFile, ParquetFileId, Partition, PartitionId,
-    PartitionKey, SequenceNumber, SkippedCompaction, Table, TableId, Timestamp,
+    PartitionKey, SkippedCompaction, Table, TableId, Timestamp,
 };
 use uuid::Uuid;
 
@@ -21,7 +21,6 @@ impl ParquetFileBuilder {
                 table_id: TableId::new(0),
                 partition_id: PartitionId::new(0),
                 object_store_id: Uuid::from_u128(id.try_into().expect("invalid id")),
-                max_sequence_number: SequenceNumber::new(0),
                 min_time: Timestamp::new(0),
                 max_time: Timestamp::new(0),
                 to_delete: None,
@@ -157,7 +156,6 @@ impl PartitionBuilder {
                 table_id: TableId::new(0),
                 partition_key: PartitionKey::from("key"),
                 sort_key: vec![],
-                persisted_sequence_number: None,
                 new_file_at: None,
             },
         }

--- a/iox_tests/src/catalog.rs
+++ b/iox_tests/src/catalog.rs
@@ -6,8 +6,8 @@ use arrow::{
 };
 use data_types::{
     Column, ColumnSet, ColumnType, CompactionLevel, Namespace, NamespaceSchema, ParquetFile,
-    ParquetFileParams, Partition, PartitionId, QueryPool, SequenceNumber, Table, TableId,
-    TableSchema, Timestamp, TopicMetadata,
+    ParquetFileParams, Partition, PartitionId, QueryPool, Table, TableId, TableSchema, Timestamp,
+    TopicMetadata,
 };
 use datafusion::physical_plan::metrics::Count;
 use datafusion_util::MemoryStream;
@@ -456,7 +456,6 @@ impl TestPartition {
             record_batch,
             table,
             schema,
-            max_sequence_number,
             min_time,
             max_time,
             file_size_bytes,
@@ -497,7 +496,6 @@ impl TestPartition {
             table_name: self.table.table.name.clone().into(),
             partition_id: self.partition.id,
             partition_key: self.partition.partition_key.clone(),
-            max_sequence_number,
             compaction_level: CompactionLevel::Initial,
             sort_key: Some(sort_key.clone()),
             max_l0_created_at: Time::from_timestamp_nanos(max_l0_created_at),
@@ -516,7 +514,6 @@ impl TestPartition {
             record_batch: Some(record_batch),
             table: Some(table),
             schema: Some(schema),
-            max_sequence_number,
             min_time,
             max_time,
             file_size_bytes: Some(file_size_bytes.unwrap_or(real_file_size_bytes as u64)),
@@ -543,7 +540,6 @@ impl TestPartition {
     ) -> TestParquetFile {
         let TestParquetFileBuilder {
             record_batch,
-            max_sequence_number,
             min_time,
             max_time,
             file_size_bytes,
@@ -585,7 +581,6 @@ impl TestPartition {
             table_id: self.table.table.id,
             partition_id: self.partition.id,
             object_store_id: object_store_id.unwrap_or_else(Uuid::new_v4),
-            max_sequence_number,
             min_time: Timestamp::new(min_time),
             max_time: Timestamp::new(max_time),
             file_size_bytes: file_size_bytes.unwrap_or(0) as i64,
@@ -628,7 +623,6 @@ pub struct TestParquetFileBuilder {
     record_batch: Option<RecordBatch>,
     table: Option<String>,
     schema: Option<Schema>,
-    max_sequence_number: SequenceNumber,
     min_time: i64,
     max_time: i64,
     file_size_bytes: Option<u64>,
@@ -647,7 +641,6 @@ impl Default for TestParquetFileBuilder {
             record_batch: None,
             table: None,
             schema: None,
-            max_sequence_number: SequenceNumber::new(100),
             min_time: now().timestamp_nanos(),
             max_time: now().timestamp_nanos(),
             file_size_bytes: None,
@@ -687,12 +680,6 @@ impl TestParquetFileBuilder {
 
     fn with_schema(mut self, schema: Schema) -> Self {
         self.schema = Some(schema);
-        self
-    }
-
-    /// Specify the maximum sequence number for the parquet file metadata.
-    pub fn with_max_seq(mut self, max_seq: i64) -> Self {
-        self.max_sequence_number = SequenceNumber::new(max_seq);
         self
     }
 

--- a/parquet_file/src/metadata.rs
+++ b/parquet_file/src/metadata.rs
@@ -90,8 +90,7 @@ use base64::{prelude::BASE64_STANDARD, Engine};
 use bytes::Bytes;
 use data_types::{
     ColumnId, ColumnSet, ColumnSummary, CompactionLevel, InfluxDbType, NamespaceId,
-    ParquetFileParams, PartitionId, PartitionKey, SequenceNumber, StatValues, Statistics, TableId,
-    Timestamp,
+    ParquetFileParams, PartitionId, PartitionKey, StatValues, Statistics, TableId, Timestamp,
 };
 use generated_types::influxdata::iox::ingester::v1 as proto;
 use iox_time::Time;
@@ -274,9 +273,6 @@ pub struct IoxMetadata {
     /// partition key of the data
     pub partition_key: PartitionKey,
 
-    /// sequence number of the last write
-    pub max_sequence_number: SequenceNumber,
-
     /// The compaction level of the file.
     ///
     ///  * 0 (`CompactionLevel::Initial`): represents a level-0 file that is persisted by an
@@ -340,7 +336,6 @@ impl IoxMetadata {
             table_name: self.table_name.to_string(),
             partition_id: self.partition_id.get(),
             partition_key: self.partition_key.to_string(),
-            max_sequence_number: self.max_sequence_number.get(),
             sort_key,
             compaction_level: self.compaction_level as i32,
             max_l0_created_at: Some(self.max_l0_created_at.date_time().into()),
@@ -392,7 +387,6 @@ impl IoxMetadata {
             table_name,
             partition_id: PartitionId::new(proto_msg.partition_id),
             partition_key,
-            max_sequence_number: SequenceNumber::new(proto_msg.max_sequence_number),
             sort_key,
             compaction_level: proto_msg.compaction_level.try_into().context(
                 InvalidCompactionLevelSnafu {
@@ -417,7 +411,6 @@ impl IoxMetadata {
             table_name: table_name.into(),
             partition_id: PartitionId::new(1),
             partition_key: "unknown".into(),
-            max_sequence_number: SequenceNumber::new(1),
             compaction_level: CompactionLevel::Initial,
             sort_key: None,
             max_l0_created_at: Time::from_timestamp_nanos(creation_timestamp_ns),
@@ -499,7 +492,6 @@ impl IoxMetadata {
             table_id: self.table_id,
             partition_id: self.partition_id,
             object_store_id: self.object_store_id,
-            max_sequence_number: self.max_sequence_number,
             min_time,
             max_time,
             file_size_bytes: file_size_bytes as i64,
@@ -1017,7 +1009,6 @@ mod tests {
             table_name: Arc::from("weather"),
             partition_id: PartitionId::new(4),
             partition_key: PartitionKey::from("part"),
-            max_sequence_number: SequenceNumber::new(6),
             compaction_level: CompactionLevel::Initial,
             sort_key: Some(sort_key),
             max_l0_created_at: create_time,
@@ -1041,7 +1032,6 @@ mod tests {
             table_name: "platanos".into(),
             partition_id: PartitionId::new(4),
             partition_key: "potato".into(),
-            max_sequence_number: SequenceNumber::new(11),
             compaction_level: CompactionLevel::FileNonOverlapped,
             sort_key: None,
             max_l0_created_at: Time::from_timestamp_nanos(42),

--- a/parquet_file/src/serialize.rs
+++ b/parquet_file/src/serialize.rs
@@ -197,7 +197,7 @@ mod tests {
         record_batch::RecordBatch,
     };
     use bytes::Bytes;
-    use data_types::{CompactionLevel, NamespaceId, PartitionId, SequenceNumber, TableId};
+    use data_types::{CompactionLevel, NamespaceId, PartitionId, TableId};
     use datafusion::parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
     use datafusion_util::MemoryStream;
     use iox_time::Time;
@@ -214,7 +214,6 @@ mod tests {
             table_name: "platanos".into(),
             partition_id: PartitionId::new(4),
             partition_key: "potato".into(),
-            max_sequence_number: SequenceNumber::new(11),
             compaction_level: CompactionLevel::FileNonOverlapped,
             sort_key: None,
             max_l0_created_at: Time::from_timestamp_nanos(42),

--- a/parquet_file/src/storage.rs
+++ b/parquet_file/src/storage.rs
@@ -323,7 +323,7 @@ mod tests {
         array::{ArrayRef, Int64Array, StringArray},
         record_batch::RecordBatch,
     };
-    use data_types::{CompactionLevel, NamespaceId, PartitionId, SequenceNumber, TableId};
+    use data_types::{CompactionLevel, NamespaceId, PartitionId, TableId};
     use datafusion::common::DataFusionError;
     use datafusion_util::MemoryStream;
     use iox_time::Time;
@@ -579,7 +579,6 @@ mod tests {
             table_name: "platanos".into(),
             partition_id: PartitionId::new(4),
             partition_key: "potato".into(),
-            max_sequence_number: SequenceNumber::new(11),
             compaction_level: CompactionLevel::FileNonOverlapped,
             sort_key: None,
             max_l0_created_at: Time::from_timestamp_nanos(42),

--- a/parquet_file/tests/metadata.rs
+++ b/parquet_file/tests/metadata.rs
@@ -4,9 +4,7 @@ use arrow::{
     array::{ArrayRef, StringArray, TimestampNanosecondArray},
     record_batch::RecordBatch,
 };
-use data_types::{
-    ColumnId, CompactionLevel, NamespaceId, PartitionId, SequenceNumber, TableId, Timestamp,
-};
+use data_types::{ColumnId, CompactionLevel, NamespaceId, PartitionId, TableId, Timestamp};
 use datafusion_util::MemoryStream;
 use iox_time::Time;
 use object_store::DynObjectStore;
@@ -57,7 +55,6 @@ async fn test_decoded_iox_metadata() {
         table_name: "platanos".into(),
         partition_id: PartitionId::new(4),
         partition_key: "potato".into(),
-        max_sequence_number: SequenceNumber::new(11),
         compaction_level: CompactionLevel::FileNonOverlapped,
         sort_key: None,
         max_l0_created_at: Time::from_timestamp_nanos(42),
@@ -198,7 +195,6 @@ async fn test_empty_parquet_file_panic() {
         table_name: "platanos".into(),
         partition_id: PartitionId::new(4),
         partition_key: "potato".into(),
-        max_sequence_number: SequenceNumber::new(11),
         compaction_level: CompactionLevel::FileNonOverlapped,
         sort_key: None,
         max_l0_created_at: Time::from_timestamp_nanos(42),
@@ -292,7 +288,6 @@ async fn test_decoded_many_columns_with_null_cols_iox_metadata() {
         table_name: "platanos".into(),
         partition_id: PartitionId::new(4),
         partition_key: "potato".into(),
-        max_sequence_number: SequenceNumber::new(11),
         compaction_level: CompactionLevel::FileNonOverlapped,
         sort_key: Some(sort_key),
         max_l0_created_at: Time::from_timestamp_nanos(42),
@@ -380,7 +375,6 @@ async fn test_derive_parquet_file_params() {
         table_name: "platanos".into(),
         partition_id,
         partition_key: "potato".into(),
-        max_sequence_number: SequenceNumber::new(11),
         compaction_level: CompactionLevel::FileNonOverlapped,
         sort_key: None,
         max_l0_created_at: Time::from_timestamp_nanos(1234),
@@ -424,7 +418,6 @@ async fn test_derive_parquet_file_params() {
     assert_eq!(catalog_data.table_id, meta.table_id);
     assert_eq!(catalog_data.partition_id, meta.partition_id);
     assert_eq!(catalog_data.object_store_id, meta.object_store_id);
-    assert_eq!(catalog_data.max_sequence_number, meta.max_sequence_number);
     assert_eq!(catalog_data.file_size_bytes, file_size as i64);
     assert_eq!(catalog_data.compaction_level, meta.compaction_level);
     assert_eq!(catalog_data.created_at, Timestamp::new(1234));

--- a/querier/src/cache/parquet_file.rs
+++ b/querier/src/cache/parquet_file.rs
@@ -347,8 +347,8 @@ mod tests {
         partition.create_parquet_file(builder).await;
         let table_id = table.table.id;
 
-        let single_file_size = 224;
-        let two_file_size = 408;
+        let single_file_size = 216;
+        let two_file_size = 392;
         assert!(single_file_size < two_file_size);
 
         let cache = make_cache(&catalog);

--- a/querier/src/ingester/mod.rs
+++ b/querier/src/ingester/mod.rs
@@ -567,16 +567,10 @@ impl IngesterStreamDecoder {
                 // columns that the sort key must cover.
                 let partition_sort_key = None;
 
-                let ingester_uuid = if md.ingester_uuid.is_empty() {
-                    // Using the write buffer path, no UUID specified
-                    None
-                } else {
-                    Some(
-                        Uuid::parse_str(&md.ingester_uuid).context(IngesterUuidSnafu {
-                            ingester_uuid: md.ingester_uuid,
-                        })?,
-                    )
-                };
+                let ingester_uuid =
+                    Uuid::parse_str(&md.ingester_uuid).context(IngesterUuidSnafu {
+                        ingester_uuid: md.ingester_uuid,
+                    })?;
 
                 let partition = IngesterPartition::new(
                     ingester_uuid,
@@ -767,17 +761,15 @@ impl IngesterConnection for IngesterConnectionImpl {
 /// more than one IngesterPartition for each table the ingester knows about.
 #[derive(Debug, Clone)]
 pub struct IngesterPartition {
-    /// If using ingester2/rpc write path, the ingester UUID will be present and will identify
-    /// whether this ingester has restarted since the last time it was queried or not.
-    ///
-    /// When we fully switch over to always using the RPC write path, the `Option` in this type can
-    /// be removed.
-    ingester_uuid: Option<Uuid>,
+    /// The ingester UUID that identifies whether this ingester has restarted since the last time
+    /// it was queried or not, which affects whether we can compare the
+    /// `completed_persistence_count` with a previous count for this ingester to know if we need
+    /// to refresh the catalog cache or not.
+    ingester_uuid: Uuid,
 
     partition_id: PartitionId,
 
-    /// If using ingester2/rpc write path, this will be the number of Parquet files this ingester
-    /// UUID has persisted for this partition.
+    /// The number of Parquet files this ingester UUID has persisted for this partition.
     completed_persistence_count: u64,
 
     /// Maximum sequence number of parquet files the ingester has
@@ -795,7 +787,7 @@ impl IngesterPartition {
     /// `RecordBatches` into the correct types
     #[allow(clippy::too_many_arguments)]
     pub fn new(
-        ingester_uuid: Option<Uuid>,
+        ingester_uuid: Uuid,
         partition_id: PartitionId,
         completed_persistence_count: u64,
         parquet_max_sequence_number: Option<SequenceNumber>,
@@ -860,7 +852,7 @@ impl IngesterPartition {
         Ok(self)
     }
 
-    pub(crate) fn ingester_uuid(&self) -> Option<Uuid> {
+    pub(crate) fn ingester_uuid(&self) -> Uuid {
         self.ingester_uuid
     }
 
@@ -1200,7 +1192,7 @@ mod tests {
         assert_eq!(p.partition_id.get(), 1);
         assert_eq!(p.parquet_max_sequence_number, None);
         assert_eq!(p.chunks.len(), 0);
-        assert_eq!(p.ingester_uuid.unwrap(), ingester_uuid);
+        assert_eq!(p.ingester_uuid, ingester_uuid);
         assert_eq!(p.completed_persistence_count, 5);
     }
 
@@ -1540,7 +1532,7 @@ mod tests {
         assert_eq!(partitions.len(), 3);
 
         let p1 = &partitions[0];
-        assert_eq!(p1.ingester_uuid.unwrap(), ingester_uuid1);
+        assert_eq!(p1.ingester_uuid, ingester_uuid1);
         assert_eq!(p1.completed_persistence_count, 0);
         assert_eq!(p1.partition_id.get(), 1);
         assert_eq!(
@@ -1549,7 +1541,7 @@ mod tests {
         );
 
         let p2 = &partitions[1];
-        assert_eq!(p2.ingester_uuid.unwrap(), ingester_uuid1);
+        assert_eq!(p2.ingester_uuid, ingester_uuid1);
         assert_eq!(p2.completed_persistence_count, 42);
         assert_eq!(p2.partition_id.get(), 2);
         assert_eq!(
@@ -1558,7 +1550,7 @@ mod tests {
         );
 
         let p3 = &partitions[2];
-        assert_eq!(p3.ingester_uuid.unwrap(), ingester_uuid2);
+        assert_eq!(p3.ingester_uuid, ingester_uuid2);
         assert_eq!(p3.completed_persistence_count, 9000);
         assert_eq!(p3.partition_id.get(), 3);
         assert_eq!(
@@ -1824,7 +1816,7 @@ mod tests {
             let parquet_max_sequence_number = None;
             // Construct a partition and ensure it doesn't error
             let ingester_partition = IngesterPartition::new(
-                Some(ingester_uuid),
+                ingester_uuid,
                 PartitionId::new(1),
                 0,
                 parquet_max_sequence_number,
@@ -1853,7 +1845,7 @@ mod tests {
 
         let parquet_max_sequence_number = None;
         let err = IngesterPartition::new(
-            Some(ingester_uuid),
+            ingester_uuid,
             PartitionId::new(1),
             0,
             parquet_max_sequence_number,

--- a/querier/src/ingester/mod.rs
+++ b/querier/src/ingester/mod.rs
@@ -13,8 +13,7 @@ use async_trait::async_trait;
 use backoff::{Backoff, BackoffConfig, BackoffError};
 use client_util::connection;
 use data_types::{
-    ChunkId, ChunkOrder, DeletePredicate, NamespaceId, PartitionId, SequenceNumber, TableSummary,
-    TimestampMinMax,
+    ChunkId, ChunkOrder, DeletePredicate, NamespaceId, PartitionId, TableSummary, TimestampMinMax,
 };
 use datafusion::error::DataFusionError;
 use futures::{stream::FuturesUnordered, TryStreamExt};
@@ -103,14 +102,6 @@ pub enum Error {
         write_token: String,
         #[snafu(source(from(influxdb_iox_client::error::Error, Box::new)))]
         source: Box<influxdb_iox_client::error::Error>,
-    },
-
-    #[snafu(display(
-        "Partition status missing for partition {partition_id}, ingestger: {ingester_address}"
-    ))]
-    PartitionStatusMissing {
-        partition_id: PartitionId,
-        ingester_address: String,
     },
 
     #[snafu(display("Got batch without chunk information from ingester: {ingester_address}"))]
@@ -550,10 +541,6 @@ impl IngesterStreamDecoder {
                 self.flush_partition()?;
 
                 let partition_id = PartitionId::new(md.partition_id);
-                let status = md.status.context(PartitionStatusMissingSnafu {
-                    partition_id,
-                    ingester_address: self.ingester_address.as_ref(),
-                })?;
                 ensure!(
                     !self.finished_partitions.contains_key(&partition_id),
                     DuplicatePartitionInfoSnafu {
@@ -576,7 +563,6 @@ impl IngesterStreamDecoder {
                     ingester_uuid,
                     partition_id,
                     md.completed_persistence_count,
-                    status.parquet_max_sequence_number.map(SequenceNumber::new),
                     partition_sort_key,
                 );
                 self.current_partition = Some(partition);
@@ -772,10 +758,6 @@ pub struct IngesterPartition {
     /// The number of Parquet files this ingester UUID has persisted for this partition.
     completed_persistence_count: u64,
 
-    /// Maximum sequence number of parquet files the ingester has
-    /// persisted for this partition
-    parquet_max_sequence_number: Option<SequenceNumber>,
-
     /// Partition-wide sort key.
     partition_sort_key: Option<Arc<SortKey>>,
 
@@ -790,14 +772,12 @@ impl IngesterPartition {
         ingester_uuid: Uuid,
         partition_id: PartitionId,
         completed_persistence_count: u64,
-        parquet_max_sequence_number: Option<SequenceNumber>,
         partition_sort_key: Option<Arc<SortKey>>,
     ) -> Self {
         Self {
             ingester_uuid,
             partition_id,
             completed_persistence_count,
-            parquet_max_sequence_number,
             partition_sort_key,
             chunks: vec![],
         }
@@ -862,10 +842,6 @@ impl IngesterPartition {
 
     pub(crate) fn completed_persistence_count(&self) -> u64 {
         self.completed_persistence_count
-    }
-
-    pub(crate) fn parquet_max_sequence_number(&self) -> Option<SequenceNumber> {
-        self.parquet_max_sequence_number
     }
 
     pub(crate) fn chunks(&self) -> &[IngesterChunk] {
@@ -1077,7 +1053,6 @@ mod tests {
     };
     use assert_matches::assert_matches;
     use data_types::TableId;
-    use generated_types::influxdata::iox::ingester::v1::PartitionStatus;
     use influxdb_iox_client::flight::generated_types::IngesterQueryResponseMetadata;
     use iox_tests::TestCatalog;
     use metric::Attributes;
@@ -1171,14 +1146,7 @@ mod tests {
             MockFlightClient::new([(
                 "addr1",
                 Ok(MockQueryData {
-                    results: vec![metadata(
-                        1,
-                        Some(PartitionStatus {
-                            parquet_max_sequence_number: None,
-                        }),
-                        ingester_uuid.to_string(),
-                        5,
-                    )],
+                    results: vec![metadata(1, ingester_uuid.to_string(), 5)],
                 }),
             )])
             .await,
@@ -1190,28 +1158,9 @@ mod tests {
 
         let p = &partitions[0];
         assert_eq!(p.partition_id.get(), 1);
-        assert_eq!(p.parquet_max_sequence_number, None);
         assert_eq!(p.chunks.len(), 0);
         assert_eq!(p.ingester_uuid, ingester_uuid);
         assert_eq!(p.completed_persistence_count, 5);
-    }
-
-    #[tokio::test]
-    async fn test_flight_err_partition_status_missing() {
-        let ingester_uuid = Uuid::new_v4();
-
-        let mock_flight_client = Arc::new(
-            MockFlightClient::new([(
-                "addr1",
-                Ok(MockQueryData {
-                    results: vec![metadata(1, None, ingester_uuid.to_string(), 5)],
-                }),
-            )])
-            .await,
-        );
-        let ingester_conn = mock_flight_client.ingester_conn().await;
-        let err = get_partitions(&ingester_conn).await.unwrap_err();
-        assert_matches!(err, Error::PartitionStatusMissing { .. });
     }
 
     #[tokio::test]
@@ -1223,30 +1172,9 @@ mod tests {
                 "addr1",
                 Ok(MockQueryData {
                     results: vec![
-                        metadata(
-                            1,
-                            Some(PartitionStatus {
-                                parquet_max_sequence_number: None,
-                            }),
-                            ingester_uuid.to_string(),
-                            3,
-                        ),
-                        metadata(
-                            2,
-                            Some(PartitionStatus {
-                                parquet_max_sequence_number: None,
-                            }),
-                            ingester_uuid.to_string(),
-                            4,
-                        ),
-                        metadata(
-                            1,
-                            Some(PartitionStatus {
-                                parquet_max_sequence_number: None,
-                            }),
-                            ingester_uuid.to_string(),
-                            5,
-                        ),
+                        metadata(1, ingester_uuid.to_string(), 3),
+                        metadata(2, ingester_uuid.to_string(), 4),
+                        metadata(1, ingester_uuid.to_string(), 5),
                     ],
                 }),
             )])
@@ -1320,14 +1248,7 @@ mod tests {
                     "addr1",
                     Ok(MockQueryData {
                         results: vec![
-                            metadata(
-                                1,
-                                Some(PartitionStatus {
-                                    parquet_max_sequence_number: Some(11),
-                                }),
-                                ingester_uuid1.to_string(),
-                                3,
-                            ),
+                            metadata(1, ingester_uuid1.to_string(), 3),
                             Ok((
                                 DecodedPayload::Schema(Arc::clone(&schema_1_1)),
                                 IngesterQueryResponseMetadata::default(),
@@ -1348,14 +1269,7 @@ mod tests {
                                 DecodedPayload::RecordBatch(record_batch_1_2),
                                 IngesterQueryResponseMetadata::default(),
                             )),
-                            metadata(
-                                2,
-                                Some(PartitionStatus {
-                                    parquet_max_sequence_number: Some(21),
-                                }),
-                                ingester_uuid1.to_string(),
-                                4,
-                            ),
+                            metadata(2, ingester_uuid1.to_string(), 4),
                             Ok((
                                 DecodedPayload::Schema(Arc::clone(&schema_2_1)),
                                 IngesterQueryResponseMetadata::default(),
@@ -1371,14 +1285,7 @@ mod tests {
                     "addr2",
                     Ok(MockQueryData {
                         results: vec![
-                            metadata(
-                                3,
-                                Some(PartitionStatus {
-                                    parquet_max_sequence_number: Some(31),
-                                }),
-                                ingester_uuid2.to_string(),
-                                5,
-                            ),
+                            metadata(3, ingester_uuid2.to_string(), 5),
                             Ok((
                                 DecodedPayload::Schema(Arc::clone(&schema_3_1)),
                                 IngesterQueryResponseMetadata::default(),
@@ -1400,10 +1307,6 @@ mod tests {
 
         let p1 = &partitions[0];
         assert_eq!(p1.partition_id.get(), 1);
-        assert_eq!(
-            p1.parquet_max_sequence_number,
-            Some(SequenceNumber::new(11))
-        );
         assert_eq!(p1.chunks.len(), 2);
         assert_eq!(p1.chunks[0].schema().as_arrow(), schema_1_1);
         assert_eq!(p1.chunks[0].batches.len(), 2);
@@ -1415,10 +1318,6 @@ mod tests {
 
         let p2 = &partitions[1];
         assert_eq!(p2.partition_id.get(), 2);
-        assert_eq!(
-            p2.parquet_max_sequence_number,
-            Some(SequenceNumber::new(21))
-        );
         assert_eq!(p2.chunks.len(), 1);
         assert_eq!(p2.chunks[0].schema().as_arrow(), schema_2_1);
         assert_eq!(p2.chunks[0].batches.len(), 1);
@@ -1426,10 +1325,6 @@ mod tests {
 
         let p3 = &partitions[2];
         assert_eq!(p3.partition_id.get(), 3);
-        assert_eq!(
-            p3.parquet_max_sequence_number,
-            Some(SequenceNumber::new(31))
-        );
         assert_eq!(p3.chunks.len(), 1);
         assert_eq!(p3.chunks[0].schema().as_arrow(), schema_3_1);
         assert_eq!(p3.chunks[0].batches.len(), 1);
@@ -1442,14 +1337,7 @@ mod tests {
             MockFlightClient::new([(
                 "addr1",
                 Ok(MockQueryData {
-                    results: vec![metadata(
-                        1,
-                        Some(PartitionStatus {
-                            parquet_max_sequence_number: Some(11),
-                        }),
-                        "not-a-valid-uuid",
-                        42,
-                    )],
+                    results: vec![metadata(1, "not-a-valid-uuid", 42)],
                 }),
             )])
             .await,
@@ -1481,36 +1369,15 @@ mod tests {
                     "addr1",
                     Ok(MockQueryData {
                         results: vec![
-                            metadata(
-                                1,
-                                Some(PartitionStatus {
-                                    parquet_max_sequence_number: Some(11),
-                                }),
-                                ingester_uuid1.to_string(),
-                                0,
-                            ),
-                            metadata(
-                                2,
-                                Some(PartitionStatus {
-                                    parquet_max_sequence_number: Some(21),
-                                }),
-                                ingester_uuid1.to_string(),
-                                42,
-                            ),
+                            metadata(1, ingester_uuid1.to_string(), 0),
+                            metadata(2, ingester_uuid1.to_string(), 42),
                         ],
                     }),
                 ),
                 (
                     "addr2",
                     Ok(MockQueryData {
-                        results: vec![metadata(
-                            3,
-                            Some(PartitionStatus {
-                                parquet_max_sequence_number: Some(31),
-                            }),
-                            ingester_uuid2.to_string(),
-                            9000,
-                        )],
+                        results: vec![metadata(3, ingester_uuid2.to_string(), 9000)],
                     }),
                 ),
             ])
@@ -1535,28 +1402,16 @@ mod tests {
         assert_eq!(p1.ingester_uuid, ingester_uuid1);
         assert_eq!(p1.completed_persistence_count, 0);
         assert_eq!(p1.partition_id.get(), 1);
-        assert_eq!(
-            p1.parquet_max_sequence_number,
-            Some(SequenceNumber::new(11))
-        );
 
         let p2 = &partitions[1];
         assert_eq!(p2.ingester_uuid, ingester_uuid1);
         assert_eq!(p2.completed_persistence_count, 42);
         assert_eq!(p2.partition_id.get(), 2);
-        assert_eq!(
-            p2.parquet_max_sequence_number,
-            Some(SequenceNumber::new(21))
-        );
 
         let p3 = &partitions[2];
         assert_eq!(p3.ingester_uuid, ingester_uuid2);
         assert_eq!(p3.completed_persistence_count, 9000);
         assert_eq!(p3.partition_id.get(), 3);
-        assert_eq!(
-            p3.parquet_max_sequence_number,
-            Some(SequenceNumber::new(31))
-        );
     }
 
     #[tokio::test]
@@ -1694,7 +1549,6 @@ mod tests {
 
     fn metadata(
         partition_id: i64,
-        status: Option<PartitionStatus>,
         ingester_uuid: impl Into<String>,
         completed_persistence_count: u64,
     ) -> MockFlightResult {
@@ -1702,7 +1556,6 @@ mod tests {
             DecodedPayload::None,
             IngesterQueryResponseMetadata {
                 partition_id,
-                status,
                 ingester_uuid: ingester_uuid.into(),
                 completed_persistence_count,
             },
@@ -1813,17 +1666,11 @@ mod tests {
         ];
 
         for case in cases {
-            let parquet_max_sequence_number = None;
             // Construct a partition and ensure it doesn't error
-            let ingester_partition = IngesterPartition::new(
-                ingester_uuid,
-                PartitionId::new(1),
-                0,
-                parquet_max_sequence_number,
-                None,
-            )
-            .try_add_chunk(ChunkId::new(), expected_schema.clone(), vec![case])
-            .unwrap();
+            let ingester_partition =
+                IngesterPartition::new(ingester_uuid, PartitionId::new(1), 0, None)
+                    .try_add_chunk(ChunkId::new(), expected_schema.clone(), vec![case])
+                    .unwrap();
 
             for batch in &ingester_partition.chunks[0].batches {
                 assert_eq!(batch.schema(), expected_schema.as_arrow());
@@ -1843,16 +1690,9 @@ mod tests {
         let batch =
             RecordBatch::try_from_iter(vec![("b", int64_array()), ("time", ts_array())]).unwrap();
 
-        let parquet_max_sequence_number = None;
-        let err = IngesterPartition::new(
-            ingester_uuid,
-            PartitionId::new(1),
-            0,
-            parquet_max_sequence_number,
-            None,
-        )
-        .try_add_chunk(ChunkId::new(), expected_schema, vec![batch])
-        .unwrap_err();
+        let err = IngesterPartition::new(ingester_uuid, PartitionId::new(1), 0, None)
+            .try_add_chunk(ChunkId::new(), expected_schema, vec![batch])
+            .unwrap_err();
 
         assert_matches!(err, Error::RecordBatchType { .. });
     }

--- a/querier/src/namespace/query_access.rs
+++ b/querier/src/namespace/query_access.rs
@@ -244,7 +244,6 @@ mod tests {
         let builder = TestParquetFileBuilder::default()
             .with_max_l0_created_at(Time::from_timestamp_nanos(1))
             .with_line_protocol("cpu,host=a load=1 11")
-            .with_max_seq(1)
             .with_min_time(11)
             .with_max_time(11);
         partition_cpu_a_1.create_parquet_file(builder).await;
@@ -252,7 +251,6 @@ mod tests {
         let builder = TestParquetFileBuilder::default()
             .with_max_l0_created_at(Time::from_timestamp_nanos(2))
             .with_line_protocol("cpu,host=a load=2 22")
-            .with_max_seq(2)
             .with_min_time(22)
             .with_max_time(22);
         partition_cpu_a_1
@@ -264,7 +262,6 @@ mod tests {
         let builder = TestParquetFileBuilder::default()
             .with_max_l0_created_at(Time::from_timestamp_nanos(3))
             .with_line_protocol("cpu,host=z load=0 0")
-            .with_max_seq(2)
             .with_min_time(22)
             .with_max_time(22);
         partition_cpu_a_1.create_parquet_file(builder).await;
@@ -272,7 +269,6 @@ mod tests {
         let builder = TestParquetFileBuilder::default()
             .with_max_l0_created_at(Time::from_timestamp_nanos(4))
             .with_line_protocol("cpu,host=a load=3 33")
-            .with_max_seq(3)
             .with_min_time(33)
             .with_max_time(33);
         partition_cpu_a_1.create_parquet_file(builder).await;
@@ -280,7 +276,6 @@ mod tests {
         let builder = TestParquetFileBuilder::default()
             .with_max_l0_created_at(Time::from_timestamp_nanos(5))
             .with_line_protocol("cpu,host=a load=4 10001")
-            .with_max_seq(4)
             .with_min_time(10_001)
             .with_max_time(10_001);
         partition_cpu_a_2.create_parquet_file(builder).await;
@@ -288,7 +283,6 @@ mod tests {
         let builder = TestParquetFileBuilder::default()
             .with_creation_time(Time::from_timestamp_nanos(6))
             .with_line_protocol("cpu,host=b load=5 11")
-            .with_max_seq(5)
             .with_min_time(11)
             .with_max_time(11);
         partition_cpu_b_1.create_parquet_file(builder).await;
@@ -302,7 +296,6 @@ mod tests {
         let builder = TestParquetFileBuilder::default()
             .with_max_l0_created_at(Time::from_timestamp_nanos(7))
             .with_line_protocol(&lp)
-            .with_max_seq(6)
             .with_min_time(11)
             .with_max_time(14);
         partition_mem_c_1.create_parquet_file(builder).await;
@@ -310,7 +303,6 @@ mod tests {
         let builder = TestParquetFileBuilder::default()
             .with_max_l0_created_at(Time::from_timestamp_nanos(8))
             .with_line_protocol("mem,host=c perc=50 1001")
-            .with_max_seq(7)
             .with_min_time(1001)
             .with_max_time(1001);
         partition_mem_c_2
@@ -523,7 +515,6 @@ mod tests {
             .with_max_l0_created_at(Time::from_timestamp_nanos(10))
             // duplicate row with different field value (load=14)
             .with_line_protocol("cpu,host=a load=14 10001")
-            .with_max_seq(2_000)
             .with_min_time(10_001)
             .with_max_time(10_001);
         partition_cpu_a_2.create_parquet_file(builder).await;

--- a/querier/src/parquet/creation.rs
+++ b/querier/src/parquet/creation.rs
@@ -226,7 +226,6 @@ impl ChunkAdapter {
             order,
             sort_key: Some(sort_key),
             partition_id: parquet_file.partition_id,
-            max_sequence_number: parquet_file.max_sequence_number,
             compaction_level: parquet_file.compaction_level,
         });
 

--- a/querier/src/parquet/mod.rs
+++ b/querier/src/parquet/mod.rs
@@ -1,8 +1,7 @@
 //! Querier Chunks
 
 use data_types::{
-    ChunkId, ChunkOrder, CompactionLevel, DeletePredicate, PartitionId, SequenceNumber,
-    TableSummary,
+    ChunkId, ChunkOrder, CompactionLevel, DeletePredicate, PartitionId, TableSummary,
 };
 use iox_query::util::create_basic_summary;
 use parquet_file::chunk::ParquetChunk;
@@ -29,9 +28,6 @@ pub struct QuerierParquetChunkMeta {
     /// Partition ID.
     partition_id: PartitionId,
 
-    /// The maximum sequence number within this chunk.
-    max_sequence_number: SequenceNumber,
-
     /// Compaction level of the parquet file of the chunk
     compaction_level: CompactionLevel,
 }
@@ -50,11 +46,6 @@ impl QuerierParquetChunkMeta {
     /// Partition ID.
     pub fn partition_id(&self) -> PartitionId {
         self.partition_id
-    }
-
-    /// The maximum sequence number within this chunk.
-    pub fn max_sequence_number(&self) -> SequenceNumber {
-        self.max_sequence_number
     }
 
     /// Compaction level of the parquet file of the chunk

--- a/querier/src/table/mod.rs
+++ b/querier/src/table/mod.rs
@@ -461,7 +461,7 @@ mod tests {
         table::test_util::{querier_table, IngesterPartitionBuilder},
     };
     use arrow_util::assert_batches_eq;
-    use data_types::{ChunkId, ColumnType, SequenceNumber};
+    use data_types::{ChunkId, ColumnType};
     use iox_query::exec::IOxSessionContext;
     use iox_tests::{TestCatalog, TestParquetFileBuilder, TestTable};
     use iox_time::TimeProvider;
@@ -522,7 +522,6 @@ mod tests {
         );
         let builder = TestParquetFileBuilder::default()
             .with_line_protocol(&lp)
-            .with_max_seq(1)
             .with_min_time(outside_retention)
             .with_max_time(inside_retention);
         let file_partially_inside = partition.create_parquet_file(builder).await;
@@ -536,7 +535,6 @@ mod tests {
         );
         let builder = TestParquetFileBuilder::default()
             .with_line_protocol(&lp)
-            .with_max_seq(2)
             .with_min_time(inside_retention)
             .with_max_time(inside_retention);
         let file_fully_inside = partition.create_parquet_file(builder).await;
@@ -550,7 +548,6 @@ mod tests {
         );
         let builder = TestParquetFileBuilder::default()
             .with_line_protocol(&lp)
-            .with_max_seq(3)
             .with_min_time(outside_retention)
             .with_max_time(outside_retention);
         let _file_fully_outside = partition.create_parquet_file(builder).await;
@@ -601,63 +598,54 @@ mod tests {
 
         let builder = TestParquetFileBuilder::default()
             .with_line_protocol("table1 foo=1 11")
-            .with_max_seq(2)
             .with_min_time(11)
             .with_max_time(11);
         let file111 = partition11.create_parquet_file(builder).await;
 
         let builder = TestParquetFileBuilder::default()
             .with_line_protocol("table1 foo=2 22")
-            .with_max_seq(4)
             .with_min_time(22)
             .with_max_time(22);
         let file112 = partition11.create_parquet_file(builder).await;
 
         let builder = TestParquetFileBuilder::default()
             .with_line_protocol("table1 foo=3 33")
-            .with_max_seq(6)
             .with_min_time(33)
             .with_max_time(33);
         let file113 = partition11.create_parquet_file(builder).await;
 
         let builder = TestParquetFileBuilder::default()
             .with_line_protocol("table1 foo=4 44")
-            .with_max_seq(8)
             .with_min_time(44)
             .with_max_time(44);
         let file114 = partition11.create_parquet_file(builder).await;
 
         let builder = TestParquetFileBuilder::default()
             .with_line_protocol("table1 foo=5 55")
-            .with_max_seq(10)
             .with_min_time(55)
             .with_max_time(55);
         let file115 = partition11.create_parquet_file(builder).await;
 
         let builder = TestParquetFileBuilder::default()
             .with_line_protocol("table1 foo=5 55")
-            .with_max_seq(2)
             .with_min_time(55)
             .with_max_time(55);
         let file121 = partition12.create_parquet_file(builder).await;
 
         let builder = TestParquetFileBuilder::default()
             .with_line_protocol("table1 foo=10 100")
-            .with_max_seq(2)
             .with_min_time(99)
             .with_max_time(99);
         let file122 = partition12.create_parquet_file(builder).await;
 
         let builder = TestParquetFileBuilder::default()
             .with_line_protocol("table1 foo=10 100")
-            .with_max_seq(2)
             .with_min_time(100)
             .with_max_time(100);
         let _file123 = partition12.create_parquet_file(builder).await;
 
         let builder = TestParquetFileBuilder::default()
             .with_line_protocol("table2 foo=6 66")
-            .with_max_seq(2)
             .with_min_time(66)
             .with_max_time(66);
         let _file211 = partition21.create_parquet_file(builder).await;
@@ -716,8 +704,7 @@ mod tests {
         let builder = IngesterPartitionBuilder::new(schema, &partition)
             .with_lp(["table,tag1=val1,tag2=val2 foo=3,bar=4 11"]);
 
-        let ingester_partition =
-            builder.build_with_max_parquet_sequence_number(Some(SequenceNumber::new(1)));
+        let ingester_partition = builder.build();
 
         let querier_table = TestQuerierTable::new(&catalog, &table)
             .await
@@ -783,13 +770,10 @@ mod tests {
         let builder = IngesterPartitionBuilder::new(schema, &partition).with_lp(["table foo=1 1"]);
 
         // Parquet file between with max sequence number 2
-        let pf_builder = TestParquetFileBuilder::default()
-            .with_line_protocol("table1 foo=1 11")
-            .with_max_seq(2);
+        let pf_builder = TestParquetFileBuilder::default().with_line_protocol("table1 foo=1 11");
         partition.create_parquet_file(pf_builder).await;
 
-        let ingester_partition =
-            builder.build_with_max_parquet_sequence_number(Some(SequenceNumber::new(2)));
+        let ingester_partition = builder.build();
 
         let querier_table = TestQuerierTable::new(&catalog, &table)
             .await
@@ -800,9 +784,7 @@ mod tests {
         assert_eq!(chunks.len(), 2);
 
         // Now, make a second chunk with max sequence number 3
-        let pf_builder = TestParquetFileBuilder::default()
-            .with_line_protocol("table1 foo=1 22")
-            .with_max_seq(3);
+        let pf_builder = TestParquetFileBuilder::default().with_line_protocol("table1 foo=1 22");
         partition.create_parquet_file(pf_builder).await;
 
         // With the same ingester response, still expect 2 chunks: one
@@ -810,10 +792,8 @@ mod tests {
         let chunks = querier_table.chunks().await.unwrap();
         assert_eq!(chunks.len(), 2);
 
-        // update the ingester response to return a new max parquet
-        // sequence number that includes the new file (3)
-        let ingester_partition =
-            builder.build_with_max_parquet_sequence_number(Some(SequenceNumber::new(3)));
+        // update the ingester response
+        let ingester_partition = builder.build();
 
         let querier_table = querier_table
             .clear_ingester_partitions()

--- a/querier/src/table/state_reconciler/interface.rs
+++ b/querier/src/table/state_reconciler/interface.rs
@@ -1,7 +1,7 @@
 //! Interface for reconciling Ingester and catalog state
 
 use crate::{ingester::IngesterPartition, parquet::QuerierParquetChunk};
-use data_types::{CompactionLevel, ParquetFile, PartitionId, SequenceNumber};
+use data_types::{CompactionLevel, ParquetFile, PartitionId};
 use std::{ops::Deref, sync::Arc};
 
 /// Information about an ingester partition.
@@ -9,16 +9,11 @@ use std::{ops::Deref, sync::Arc};
 /// This is mostly the same as [`IngesterPartition`] but allows easier mocking.
 pub trait IngesterPartitionInfo {
     fn partition_id(&self) -> PartitionId;
-    fn parquet_max_sequence_number(&self) -> Option<SequenceNumber>;
 }
 
 impl IngesterPartitionInfo for IngesterPartition {
     fn partition_id(&self) -> PartitionId {
         self.deref().partition_id()
-    }
-
-    fn parquet_max_sequence_number(&self) -> Option<SequenceNumber> {
-        self.deref().parquet_max_sequence_number()
     }
 }
 
@@ -29,10 +24,6 @@ where
     fn partition_id(&self) -> PartitionId {
         self.deref().partition_id()
     }
-
-    fn parquet_max_sequence_number(&self) -> Option<SequenceNumber> {
-        self.deref().parquet_max_sequence_number()
-    }
 }
 
 /// Information about a parquet file.
@@ -40,17 +31,12 @@ where
 /// This is mostly the same as [`ParquetFile`] but allows easier mocking.
 pub trait ParquetFileInfo {
     fn partition_id(&self) -> PartitionId;
-    fn max_sequence_number(&self) -> SequenceNumber;
     fn compaction_level(&self) -> CompactionLevel;
 }
 
 impl ParquetFileInfo for Arc<ParquetFile> {
     fn partition_id(&self) -> PartitionId {
         self.partition_id
-    }
-
-    fn max_sequence_number(&self) -> SequenceNumber {
-        self.max_sequence_number
     }
 
     fn compaction_level(&self) -> CompactionLevel {
@@ -61,10 +47,6 @@ impl ParquetFileInfo for Arc<ParquetFile> {
 impl ParquetFileInfo for QuerierParquetChunk {
     fn partition_id(&self) -> PartitionId {
         self.meta().partition_id()
-    }
-
-    fn max_sequence_number(&self) -> SequenceNumber {
-        self.meta().max_sequence_number()
     }
 
     fn compaction_level(&self) -> CompactionLevel {

--- a/querier/src/table/test_util.rs
+++ b/querier/src/table/test_util.rs
@@ -107,7 +107,7 @@ impl IngesterPartitionBuilder {
         let data = self.lp.iter().map(|lp| lp_to_record_batch(lp)).collect();
 
         IngesterPartition::new(
-            Some(Uuid::new_v4()),
+            Uuid::new_v4(),
             self.partition.partition.id,
             0,
             parquet_max_sequence_number,

--- a/querier/src/table/test_util.rs
+++ b/querier/src/table/test_util.rs
@@ -4,7 +4,7 @@ use crate::{
     IngesterPartition,
 };
 use arrow::record_batch::RecordBatch;
-use data_types::{ChunkId, SequenceNumber};
+use data_types::ChunkId;
 use iox_catalog::interface::{get_schema_by_name, SoftDeletedRows};
 use iox_tests::{TestCatalog, TestPartition, TestTable};
 use mutable_batch_lp::test_helpers::lp_to_mutable_batch;
@@ -91,26 +91,14 @@ impl IngesterPartitionBuilder {
         self
     }
 
-    /// Create a ingester partition with the specified max parquet sequence number
-    pub(crate) fn build_with_max_parquet_sequence_number(
-        &self,
-        parquet_max_sequence_number: Option<SequenceNumber>,
-    ) -> IngesterPartition {
-        self.build(parquet_max_sequence_number)
-    }
-
     /// Create an ingester partition with the specified field values
-    pub(crate) fn build(
-        &self,
-        parquet_max_sequence_number: Option<SequenceNumber>,
-    ) -> IngesterPartition {
+    pub(crate) fn build(&self) -> IngesterPartition {
         let data = self.lp.iter().map(|lp| lp_to_record_batch(lp)).collect();
 
         IngesterPartition::new(
             Uuid::new_v4(),
             self.partition.partition.id,
             0,
-            parquet_max_sequence_number,
             self.partition_sort_key.clone(),
         )
         .try_add_chunk(

--- a/service_grpc_catalog/src/lib.rs
+++ b/service_grpc_catalog/src/lib.rs
@@ -172,7 +172,6 @@ fn to_parquet_file(p: data_types::ParquetFile) -> ParquetFile {
         table_id: p.table_id.get(),
         partition_id: p.partition_id.get(),
         object_store_id: p.object_store_id.to_string(),
-        max_sequence_number: p.max_sequence_number.get(),
         min_time: p.min_time.get(),
         max_time: p.max_time.get(),
         to_delete: p.to_delete.map(|t| t.get()).unwrap_or(0),
@@ -198,9 +197,7 @@ fn to_partition(p: data_types::Partition) -> Partition {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use data_types::{
-        ColumnId, ColumnSet, CompactionLevel, ParquetFileParams, SequenceNumber, Timestamp,
-    };
+    use data_types::{ColumnId, ColumnSet, CompactionLevel, ParquetFileParams, Timestamp};
     use generated_types::influxdata::iox::catalog::v1::catalog_service_server::CatalogService;
     use iox_catalog::mem::MemCatalog;
     use uuid::Uuid;
@@ -241,7 +238,6 @@ mod tests {
                 table_id: table.id,
                 partition_id: partition.id,
                 object_store_id: Uuid::new_v4(),
-                max_sequence_number: SequenceNumber::new(40),
                 min_time: Timestamp::new(1),
                 max_time: Timestamp::new(5),
                 file_size_bytes: 2343,
@@ -253,7 +249,6 @@ mod tests {
             };
             let p2params = ParquetFileParams {
                 object_store_id: Uuid::new_v4(),
-                max_sequence_number: SequenceNumber::new(70),
                 ..p1params.clone()
             };
             p1 = repos.parquet_files().create(p1params).await.unwrap();

--- a/service_grpc_object_store/src/lib.rs
+++ b/service_grpc_object_store/src/lib.rs
@@ -96,9 +96,7 @@ impl object_store_service_server::ObjectStoreService for ObjectStoreService {
 mod tests {
     use super::*;
     use bytes::Bytes;
-    use data_types::{
-        ColumnId, ColumnSet, CompactionLevel, ParquetFileParams, SequenceNumber, Timestamp,
-    };
+    use data_types::{ColumnId, ColumnSet, CompactionLevel, ParquetFileParams, Timestamp};
     use generated_types::influxdata::iox::object_store::v1::object_store_service_server::ObjectStoreService;
     use iox_catalog::mem::MemCatalog;
     use object_store::{memory::InMemory, ObjectStore};
@@ -138,7 +136,6 @@ mod tests {
                 table_id: table.id,
                 partition_id: partition.id,
                 object_store_id: Uuid::new_v4(),
-                max_sequence_number: SequenceNumber::new(40),
                 min_time: Timestamp::new(1),
                 max_time: Timestamp::new(5),
                 file_size_bytes: 2343,


### PR DESCRIPTION
Extracted from https://github.com/influxdata/influxdb_iox/pull/7049/commits.

This PR has 2 commits that I suggest reviewing separately:

- Make ingester UUID required and expected. `ingester2` always sends it, and the querier is now only contacting `ingester2` servers.
- Remove unused `parquet_max_sequence_number` from the Parquet file metadata; it's currently always being set to 0 and never being used for anything. 