### PR TITLE
fix: Use only humantime; get rid of chrono-english

### DIFF
--- a/.config/hakari.toml
+++ b/.config/hakari.toml
@@ -37,10 +37,6 @@ workspace-members = [
     "influxdb-line-protocol",
     "influxdb2_client",
     "iox_data_generator",
-    # The garbage collector uses chrono-english which needlessly
-    # brings in chrono with the default features. This exclusion can
-    # likely be removed if they publish a version without that.
-    "garbage_collector",
     "mutable_batch_tests",
 ]
 third-party = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2055,6 +2055,7 @@ dependencies = [
  "tokio-stream",
  "tokio-util",
  "uuid",
+ "workspace-hack",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -800,15 +800,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "chrono-english"
-version = "0.1.6"
-source = "git+https://github.com/stevedonovan/chrono-english.git?rev=def5941ebee24b55e1174eb18ab33d91603f907a#def5941ebee24b55e1174eb18ab33d91603f907a"
-dependencies = [
- "chrono",
- "scanlex",
-]
-
-[[package]]
 name = "chrono-tz"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2865,7 +2856,6 @@ version = "0.1.0"
 dependencies = [
  "bytes",
  "chrono",
- "chrono-english",
  "clap 4.2.5",
  "criterion",
  "datafusion_util",
@@ -4911,12 +4901,6 @@ checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
 ]
-
-[[package]]
-name = "scanlex"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "088c5d71572124929ea7549a8ce98e1a6fd33d0a38367b09027b382e67c033db"
 
 [[package]]
 name = "schema"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -115,7 +115,6 @@ license = "MIT OR Apache-2.0"
 [workspace.dependencies]
 arrow = { version = "38.0.0" }
 arrow-flight = { version = "38.0.0" }
-chrono-english = { git = "https://github.com/stevedonovan/chrono-english.git", rev = "def5941ebee24b55e1174eb18ab33d91603f907a" }
 datafusion = { git = "https://github.com/apache/arrow-datafusion.git", rev="451e81eafe5e404de50f6ede1bebf25ed90f5eb0", default-features = false }
 datafusion-proto = { git = "https://github.com/apache/arrow-datafusion.git", rev="451e81eafe5e404de50f6ede1bebf25ed90f5eb0" }
 hashbrown = { version = "0.13.2" }
@@ -124,8 +123,6 @@ tonic = { version = "0.9.2", features = ["tls", "tls-webpki-roots"] }
 tonic-build = { version = "0.9.2" }
 tonic-health = { version = "0.9.2" }
 tonic-reflection = { version = "0.9.2" }
-
-
 
 # This profile optimizes for runtime performance and small binary size at the expense of longer
 # build times. It's most suitable for final release builds.

--- a/deny.toml
+++ b/deny.toml
@@ -56,5 +56,8 @@ deny = [
     # If you're hitting this, you might want to take a look at what new
     # dependencies you have introduced and check if there's a way to depend on
     # rustls instead of OpenSSL (tip: check the crate's feature flags).
-    { name = "openssl-sys" }
+    { name = "openssl-sys" },
+    # We've decided to use the `humantime` crate to parse and generate friendly time formats; use
+    # that rather than chrono-english.
+    { name = "chrono-english" },
 ]

--- a/garbage_collector/Cargo.toml
+++ b/garbage_collector/Cargo.toml
@@ -21,6 +21,7 @@ tokio = { version = "1", features = ["macros", "rt", "sync"] }
 tokio-stream = "0.1"
 tokio-util = { version = "0.7.8" }
 uuid = { version = "1", features = ["v4"] }
+workspace-hack = { version = "0.1", path = "../workspace-hack" }
 
 [dev-dependencies]
 bytes = "1.4"

--- a/iox_data_generator/Cargo.toml
+++ b/iox_data_generator/Cargo.toml
@@ -9,7 +9,6 @@ license.workspace = true
 [dependencies]
 bytes = "1.4"
 chrono = { version = "0.4", default-features = false }
-chrono-english = { workspace = true }
 clap = { version = "4", features = ["derive", "env", "cargo"] }
 datafusion_util = { path = "../datafusion_util" }
 futures = "0.3"


### PR DESCRIPTION
Fixes https://github.com/influxdata/influxdb_iox/issues/5065.

Related to https://github.com/influxdata/influxdb_iox/pull/7568.

Ugh I thought the git source was causing `cargo-deny` to fail in https://github.com/influxdata/influxdb_iox/pull/7704, but now I see that was just a warning and that PR is failing for a different reason. But the work's done now sooo 🤷🏻‍♀️ 