### PR TITLE
refactor: Remove fragile `is_tag_field` API

### DIFF
--- a/influxdb_influxql_parser/src/select.rs
+++ b/influxdb_influxql_parser/src/select.rs
@@ -72,13 +72,6 @@ pub struct SelectStatement {
 }
 
 impl SelectStatement {
-    /// Return the `FILL` behaviour for the `SELECT` statement.
-    ///
-    /// The default when no `FILL` clause present is `FILL(null)`.
-    pub fn fill(&self) -> FillClause {
-        self.fill.unwrap_or_default()
-    }
-
     /// Return the sort order for the `SELECT` statement.
     ///
     /// The default when no `ORDER BY` clause present is `TIME ASC`.
@@ -760,8 +753,6 @@ mod test {
     fn test_select_statement() {
         let (_, got) = select_statement("SELECT value FROM foo").unwrap();
         assert_eq!(got.to_string(), "SELECT value FROM foo");
-        // Assert default behaviour when `FILL` is omitted
-        assert_eq!(got.fill(), FillClause::Null);
 
         let (_, got) =
             select_statement(r#"SELECT f1,/f2/, f3 AS "a field" FROM foo WHERE host =~ /c1/"#)
@@ -798,7 +789,7 @@ mod test {
             got.to_string(),
             r#"SELECT sum(value) FROM foo GROUP BY TIME(5m), host FILL(PREVIOUS)"#
         );
-        assert_eq!(got.fill(), FillClause::Previous);
+        assert_matches!(got.fill, Some(FillClause::Previous));
 
         let (_, got) = select_statement("SELECT value FROM foo ORDER BY DESC").unwrap();
         assert_eq!(

--- a/iox_query_influxql/src/plan/ir.rs
+++ b/iox_query_influxql/src/plan/ir.rs
@@ -10,6 +10,15 @@ use influxdb_influxql_parser::select::{
     SelectStatement, TimeZoneClause,
 };
 
+/// Represents a validated and normalized top-level [`SelectStatement]`.
+#[derive(Debug, Default, Clone)]
+pub(super) struct SelectQuery {
+    pub(super) select: Select,
+
+    /// `true` if the query projects from more than one unique measurement.
+    pub(super) has_multiple_measurements: bool,
+}
+
 #[derive(Debug, Default, Clone)]
 pub(super) struct Select {
     /// The schema of the selection.

--- a/iox_query_influxql/src/plan/util.rs
+++ b/iox_query_influxql/src/plan/util.rs
@@ -35,14 +35,6 @@ impl Schemas {
             df_schema: Arc::clone(df_schema),
         })
     }
-
-    /// Returns `true` if the field `name` is a tag type.
-    pub(super) fn is_tag_field(&self, name: &str) -> bool {
-        self.df_schema
-            .fields()
-            .iter()
-            .any(|f| f.name() == name && matches!(f.data_type(), DataType::Dictionary(..)))
-    }
 }
 
 /// Sanitize an InfluxQL regular expression and create a compiled [`regex::Regex`].


### PR DESCRIPTION
Helps #7739

This PR addresses [@crepererum's primary concern](https://github.com/influxdata/influxdb_iox/pull/7727#discussion_r1183718466) by no longer relying on the `is_tag_field` API, which was fragile. With this change, we are now able to determine schema accurately and this sets the foundation for implementing subqueries.

> **Note**
>
> There is still planned work to the intermediate representation following this PR.