### PR TITLE
test(ingester): fix flappy tests

### DIFF
--- a/ingester2/src/buffer_tree/namespace.rs
+++ b/ingester2/src/buffer_tree/namespace.rs
@@ -232,9 +232,9 @@ mod tests {
         },
         deferred_load,
         test_util::{
-            make_write_op, PartitionDataBuilder, ARBITRARY_NAMESPACE_ID, ARBITRARY_NAMESPACE_NAME,
-            ARBITRARY_PARTITION_KEY, ARBITRARY_TABLE_ID, ARBITRARY_TABLE_NAME,
-            ARBITRARY_TABLE_NAME_PROVIDER, DEFER_NAMESPACE_NAME_1_MS,
+            defer_namespace_name_1_ms, make_write_op, PartitionDataBuilder, ARBITRARY_NAMESPACE_ID,
+            ARBITRARY_NAMESPACE_NAME, ARBITRARY_PARTITION_KEY, ARBITRARY_TABLE_ID,
+            ARBITRARY_TABLE_NAME, ARBITRARY_TABLE_NAME_PROVIDER,
         },
     };
 
@@ -250,7 +250,7 @@ mod tests {
 
         let ns = NamespaceData::new(
             ARBITRARY_NAMESPACE_ID,
-            Arc::clone(&*DEFER_NAMESPACE_NAME_1_MS),
+            defer_namespace_name_1_ms(),
             Arc::clone(&*ARBITRARY_TABLE_NAME_PROVIDER),
             partition_provider,
             Arc::new(MockPostWriteObserver::default()),

--- a/ingester2/src/buffer_tree/partition/resolver/cache.rs
+++ b/ingester2/src/buffer_tree/partition/resolver/cache.rs
@@ -222,10 +222,10 @@ mod tests {
     use crate::{
         buffer_tree::partition::resolver::mock::MockPartitionProvider,
         test_util::{
-            arbitrary_partition, PartitionDataBuilder, ARBITRARY_NAMESPACE_ID,
-            ARBITRARY_NAMESPACE_NAME, ARBITRARY_PARTITION_ID, ARBITRARY_PARTITION_KEY,
-            ARBITRARY_PARTITION_KEY_STR, ARBITRARY_TABLE_ID, ARBITRARY_TABLE_NAME,
-            DEFER_NAMESPACE_NAME_1_SEC, DEFER_TABLE_NAME_1_SEC,
+            arbitrary_partition, defer_namespace_name_1_sec, defer_table_name_1_sec,
+            PartitionDataBuilder, ARBITRARY_NAMESPACE_ID, ARBITRARY_NAMESPACE_NAME,
+            ARBITRARY_PARTITION_ID, ARBITRARY_PARTITION_KEY, ARBITRARY_PARTITION_KEY_STR,
+            ARBITRARY_TABLE_ID, ARBITRARY_TABLE_NAME,
         },
     };
 
@@ -255,9 +255,9 @@ mod tests {
             .get_partition(
                 ARBITRARY_PARTITION_KEY.clone(),
                 ARBITRARY_NAMESPACE_ID,
-                Arc::clone(&*DEFER_NAMESPACE_NAME_1_SEC),
+                defer_namespace_name_1_sec(),
                 ARBITRARY_TABLE_ID,
-                Arc::clone(&*DEFER_TABLE_NAME_1_SEC),
+                defer_table_name_1_sec(),
             )
             .await;
 
@@ -292,9 +292,9 @@ mod tests {
             .get_partition(
                 callers_partition_key.clone(),
                 ARBITRARY_NAMESPACE_ID,
-                Arc::clone(&*DEFER_NAMESPACE_NAME_1_SEC),
+                defer_namespace_name_1_sec(),
                 ARBITRARY_TABLE_ID,
-                Arc::clone(&*DEFER_TABLE_NAME_1_SEC),
+                defer_table_name_1_sec(),
             )
             .await;
 
@@ -343,9 +343,9 @@ mod tests {
             .get_partition(
                 other_key,
                 ARBITRARY_NAMESPACE_ID,
-                Arc::clone(&*DEFER_NAMESPACE_NAME_1_SEC),
+                defer_namespace_name_1_sec(),
                 ARBITRARY_TABLE_ID,
-                Arc::clone(&*DEFER_TABLE_NAME_1_SEC),
+                defer_table_name_1_sec(),
             )
             .await;
 
@@ -373,9 +373,9 @@ mod tests {
             .get_partition(
                 ARBITRARY_PARTITION_KEY.clone(),
                 ARBITRARY_NAMESPACE_ID,
-                Arc::clone(&*DEFER_NAMESPACE_NAME_1_SEC),
+                defer_namespace_name_1_sec(),
                 other_table,
-                Arc::clone(&*DEFER_TABLE_NAME_1_SEC),
+                defer_table_name_1_sec(),
             )
             .await;
 

--- a/ingester2/src/buffer_tree/partition/resolver/coalesce.rs
+++ b/ingester2/src/buffer_tree/partition/resolver/coalesce.rs
@@ -281,8 +281,8 @@ mod tests {
     use crate::{
         buffer_tree::partition::{resolver::mock::MockPartitionProvider, SortKeyState},
         test_util::{
-            PartitionDataBuilder, ARBITRARY_NAMESPACE_ID, ARBITRARY_PARTITION_KEY,
-            ARBITRARY_TABLE_ID, DEFER_NAMESPACE_NAME_1_SEC, DEFER_TABLE_NAME_1_SEC,
+            defer_namespace_name_1_sec, defer_table_name_1_sec, PartitionDataBuilder,
+            ARBITRARY_NAMESPACE_ID, ARBITRARY_PARTITION_KEY, ARBITRARY_TABLE_ID,
         },
     };
 
@@ -307,9 +307,9 @@ mod tests {
                 layer.get_partition(
                     ARBITRARY_PARTITION_KEY.clone(),
                     ARBITRARY_NAMESPACE_ID,
-                    Arc::clone(&*DEFER_NAMESPACE_NAME_1_SEC),
+                    defer_namespace_name_1_sec(),
                     ARBITRARY_TABLE_ID,
-                    Arc::clone(&*DEFER_TABLE_NAME_1_SEC),
+                    defer_table_name_1_sec(),
                 )
             })
             .collect::<FuturesUnordered<_>>()
@@ -368,6 +368,8 @@ mod tests {
         use futures::Future;
 
         let data = PartitionDataBuilder::new().build();
+        let namespace_loader = defer_namespace_name_1_sec();
+        let table_name_loader = defer_table_name_1_sec();
 
         // Add a single instance of the partition - if more than one call is
         // made to the mock, it will panic.
@@ -381,16 +383,16 @@ mod tests {
         let pa_1 = layer.get_partition(
             ARBITRARY_PARTITION_KEY.clone(),
             ARBITRARY_NAMESPACE_ID,
-            Arc::clone(&*DEFER_NAMESPACE_NAME_1_SEC),
+            Arc::clone(&namespace_loader),
             ARBITRARY_TABLE_ID,
-            Arc::clone(&*DEFER_TABLE_NAME_1_SEC),
+            Arc::clone(&table_name_loader),
         );
         let pa_2 = layer.get_partition(
             ARBITRARY_PARTITION_KEY.clone(),
             ARBITRARY_NAMESPACE_ID,
-            Arc::clone(&*DEFER_NAMESPACE_NAME_1_SEC),
+            Arc::clone(&namespace_loader),
             ARBITRARY_TABLE_ID,
-            Arc::clone(&*DEFER_TABLE_NAME_1_SEC),
+            Arc::clone(&table_name_loader),
         );
 
         let waker = futures::task::noop_waker();
@@ -408,9 +410,9 @@ mod tests {
             .get_partition(
                 PartitionKey::from("orange you glad i didn't say bananas"),
                 ARBITRARY_NAMESPACE_ID,
-                Arc::clone(&*DEFER_NAMESPACE_NAME_1_SEC),
+                namespace_loader,
                 ARBITRARY_TABLE_ID,
-                Arc::clone(&*DEFER_TABLE_NAME_1_SEC),
+                table_name_loader,
             )
             .with_timeout_panic(Duration::from_secs(5))
             .await;
@@ -478,9 +480,9 @@ mod tests {
         let fut = layer.get_partition(
             ARBITRARY_PARTITION_KEY.clone(),
             ARBITRARY_NAMESPACE_ID,
-            Arc::clone(&*DEFER_NAMESPACE_NAME_1_SEC),
+            defer_namespace_name_1_sec(),
             ARBITRARY_TABLE_ID,
-            Arc::clone(&*DEFER_TABLE_NAME_1_SEC),
+            defer_table_name_1_sec(),
         );
 
         let waker = futures::task::noop_waker();

--- a/ingester2/src/buffer_tree/root.rs
+++ b/ingester2/src/buffer_tree/root.rs
@@ -246,9 +246,9 @@ mod tests {
         deferred_load::{self, DeferredLoad},
         query::partition_response::PartitionResponse,
         test_util::{
-            make_write_op, PartitionDataBuilder, ARBITRARY_NAMESPACE_ID, ARBITRARY_NAMESPACE_NAME,
-            ARBITRARY_PARTITION_KEY, ARBITRARY_TABLE_ID, ARBITRARY_TABLE_NAME,
-            ARBITRARY_TABLE_NAME_PROVIDER, DEFER_NAMESPACE_NAME_1_MS,
+            defer_namespace_name_1_ms, make_write_op, PartitionDataBuilder, ARBITRARY_NAMESPACE_ID,
+            ARBITRARY_NAMESPACE_NAME, ARBITRARY_PARTITION_KEY, ARBITRARY_TABLE_ID,
+            ARBITRARY_TABLE_NAME, ARBITRARY_TABLE_NAME_PROVIDER,
         },
     };
 
@@ -265,7 +265,7 @@ mod tests {
         // Init the namespace
         let ns = NamespaceData::new(
             ARBITRARY_NAMESPACE_ID,
-            Arc::clone(&*DEFER_NAMESPACE_NAME_1_MS),
+            defer_namespace_name_1_ms(),
             Arc::clone(&*ARBITRARY_TABLE_NAME_PROVIDER),
             partition_provider,
             Arc::new(MockPostWriteObserver::default()),
@@ -703,7 +703,7 @@ mod tests {
                         .with_partition_id(PartitionId::new(2))
                         .with_partition_key(PartitionKey::from("p3"))
                         .with_table_id(TABLE2_ID)
-                        .with_table_name(Arc::new(DeferredLoad::new(
+                        .with_table_name_loader(Arc::new(DeferredLoad::new(
                             Duration::from_secs(1),
                             async move { TableName::from(TABLE2_NAME) },
                         )))

--- a/ingester2/src/buffer_tree/table.rs
+++ b/ingester2/src/buffer_tree/table.rs
@@ -267,9 +267,9 @@ mod tests {
             post_write::mock::MockPostWriteObserver,
         },
         test_util::{
-            PartitionDataBuilder, ARBITRARY_NAMESPACE_ID, ARBITRARY_PARTITION_KEY,
-            ARBITRARY_TABLE_ID, ARBITRARY_TABLE_NAME, DEFER_NAMESPACE_NAME_1_SEC,
-            DEFER_TABLE_NAME_1_SEC,
+            defer_namespace_name_1_sec, defer_table_name_1_sec, PartitionDataBuilder,
+            ARBITRARY_NAMESPACE_ID, ARBITRARY_PARTITION_KEY, ARBITRARY_TABLE_ID,
+            ARBITRARY_TABLE_NAME,
         },
     };
 
@@ -282,9 +282,9 @@ mod tests {
 
         let table = TableData::new(
             ARBITRARY_TABLE_ID,
-            Arc::clone(&*DEFER_TABLE_NAME_1_SEC),
+            defer_table_name_1_sec(),
             ARBITRARY_NAMESPACE_ID,
-            Arc::clone(&*DEFER_NAMESPACE_NAME_1_SEC),
+            defer_namespace_name_1_sec(),
             partition_provider,
             Arc::new(MockPostWriteObserver::default()),
         );

--- a/ingester2/src/dml_sink/instrumentation.rs
+++ b/ingester2/src/dml_sink/instrumentation.rs
@@ -73,7 +73,6 @@ mod tests {
 
     use assert_matches::assert_matches;
     use data_types::{NamespaceId, PartitionId, PartitionKey, TableId};
-    use iox_query::exec::Executor;
     use lazy_static::lazy_static;
     use metric::Attributes;
 
@@ -92,7 +91,6 @@ mod tests {
     const NAMESPACE_NAME: &str = "platanos";
 
     lazy_static! {
-        static ref EXEC: Arc<Executor> = Arc::new(Executor::new_testing());
         static ref PARTITION_KEY: PartitionKey = PartitionKey::from("bananas");
         static ref NAMESPACE_NAME_LOADER: Arc<DeferredLoad<NamespaceName>> =
             Arc::new(DeferredLoad::new(Duration::from_secs(1), async {

--- a/ingester2/src/dml_sink/tracing.rs
+++ b/ingester2/src/dml_sink/tracing.rs
@@ -59,7 +59,6 @@ mod tests {
     use assert_matches::assert_matches;
     use data_types::{NamespaceId, PartitionId, PartitionKey, TableId};
     use dml::DmlMeta;
-    use iox_query::exec::Executor;
     use lazy_static::lazy_static;
     use trace::{ctx::SpanContext, span::SpanStatus, RingBufferTraceCollector, TraceCollector};
 
@@ -79,7 +78,6 @@ mod tests {
     const NAMESPACE_NAME: &str = "platanos";
 
     lazy_static! {
-        static ref EXEC: Arc<Executor> = Arc::new(Executor::new_testing());
         static ref PARTITION_KEY: PartitionKey = PartitionKey::from("bananas");
         static ref NAMESPACE_NAME_LOADER: Arc<DeferredLoad<NamespaceName>> =
             Arc::new(DeferredLoad::new(Duration::from_secs(1), async {

--- a/ingester2/src/persist/handle.rs
+++ b/ingester2/src/persist/handle.rs
@@ -478,7 +478,6 @@ mod tests {
     use dml::DmlOperation;
     use futures::Future;
     use iox_catalog::mem::MemCatalog;
-    use lazy_static::lazy_static;
     use object_store::memory::InMemory;
     use parquet_file::storage::StorageId;
     use schema::sort::SortKey;
@@ -505,10 +504,6 @@ mod tests {
             ARBITRARY_TABLE_NAME, ARBITRARY_TABLE_NAME_PROVIDER,
         },
     };
-
-    lazy_static! {
-        static ref EXEC: Arc<Executor> = Arc::new(Executor::new_testing());
-    }
 
     /// Construct a partition with the above constants, with the given sort key,
     /// and containing a single write.
@@ -555,7 +550,7 @@ mod tests {
             1,
             2,
             Arc::new(IngestState::default()),
-            Arc::clone(&EXEC),
+            Arc::new(Executor::new_testing()),
             storage,
             catalog,
             Arc::new(MockCompletionObserver::default()),
@@ -631,7 +626,7 @@ mod tests {
             1,
             2,
             Arc::new(IngestState::default()),
-            Arc::clone(&EXEC),
+            Arc::new(Executor::new_testing()),
             storage,
             catalog,
             Arc::new(MockCompletionObserver::default()),
@@ -717,7 +712,7 @@ mod tests {
             1,
             2,
             Arc::new(IngestState::default()),
-            Arc::clone(&EXEC),
+            Arc::new(Executor::new_testing()),
             storage,
             catalog,
             Arc::new(MockCompletionObserver::default()),
@@ -803,7 +798,7 @@ mod tests {
             1,
             2,
             Arc::new(IngestState::default()),
-            Arc::clone(&EXEC),
+            Arc::new(Executor::new_testing()),
             storage,
             catalog,
             Arc::new(MockCompletionObserver::default()),
@@ -883,7 +878,7 @@ mod tests {
             1,
             1,
             Arc::clone(&ingest_state),
-            Arc::clone(&EXEC),
+            Arc::new(Executor::new_testing()),
             storage,
             catalog,
             NopObserver::default(),
@@ -951,7 +946,7 @@ mod tests {
             5,
             42,
             Arc::clone(&ingest_state),
-            Arc::clone(&EXEC),
+            Arc::new(Executor::new_testing()),
             storage,
             catalog,
             NopObserver::default(),

--- a/ingester2/src/persist/mod.rs
+++ b/ingester2/src/persist/mod.rs
@@ -42,6 +42,7 @@ mod tests {
         },
         dml_sink::DmlSink,
         ingest_state::IngestState,
+        persist::handle::PersistHandle,
         persist::{completion_observer::mock::MockCompletionObserver, queue::PersistQueue},
         test_util::{
             make_write_op, populate_catalog, ARBITRARY_NAMESPACE_NAME,
@@ -49,8 +50,6 @@ mod tests {
             ARBITRARY_TABLE_NAME_PROVIDER,
         },
     };
-
-    use super::handle::PersistHandle;
 
     lazy_static! {
         static ref EXEC: Arc<Executor> = Arc::new(Executor::new_testing());
@@ -178,7 +177,7 @@ mod tests {
             1,
             2,
             Arc::clone(&ingest_state),
-            Arc::clone(&EXEC),
+            Arc::new(Executor::new_testing()),
             storage,
             Arc::clone(&catalog),
             Arc::clone(&completion_observer),
@@ -314,7 +313,7 @@ mod tests {
             1,
             2,
             Arc::clone(&ingest_state),
-            Arc::clone(&EXEC),
+            Arc::new(Executor::new_testing()),
             storage,
             Arc::clone(&catalog),
             Arc::clone(&completion_observer),


### PR DESCRIPTION
https://github.com/influxdata/influxdb_iox/pull/7651 refactored a bunch of test code to re-use stuff - some of that stuff causes problems, and @carols10cents fixed it in this PR: https://github.com/influxdata/influxdb_iox/pull/7673

I've picked the commits into a new PR while we work on #7673 to get the fixes merged ASAP :+1:

---

* fix: don't share Executor instances between tests (edf5b310e)
      
      And remove some executor instances where they're not even being used

* fix: don't share DeferredLoad instances between tests (537874042)
      