### PR TITLE
refactor: accept `impl Into<String>` instead of `&str` for schema methods

### DIFF
--- a/data_types/src/columns.rs
+++ b/data_types/src/columns.rs
@@ -111,10 +111,10 @@ impl ColumnsByName {
 }
 
 // ColumnsByName is a newtype so that we can implement this `TryFrom` in this crate
-impl TryFrom<&ColumnsByName> for Schema {
+impl TryFrom<ColumnsByName> for Schema {
     type Error = schema::builder::Error;
 
-    fn try_from(value: &ColumnsByName) -> Result<Self, Self::Error> {
+    fn try_from(value: ColumnsByName) -> Result<Self, Self::Error> {
         let mut builder = SchemaBuilder::new();
 
         for (column_name, column_schema) in value.iter() {
@@ -123,14 +123,6 @@ impl TryFrom<&ColumnsByName> for Schema {
         }
 
         builder.build()
-    }
-}
-
-impl TryFrom<ColumnsByName> for Schema {
-    type Error = schema::builder::Error;
-
-    fn try_from(value: ColumnsByName) -> Result<Self, Self::Error> {
-        Self::try_from(&value)
     }
 }
 

--- a/data_types/src/columns.rs
+++ b/data_types/src/columns.rs
@@ -126,7 +126,7 @@ impl TryFrom<ColumnsByName> for Schema {
     fn try_from(value: ColumnsByName) -> Result<Self, Self::Error> {
         let mut builder = SchemaBuilder::new();
 
-        for (column_name, column_schema) in value.iter() {
+        for (column_name, column_schema) in value.into_iter() {
             let t = InfluxColumnType::from(column_schema.column_type);
             builder.influx_column(column_name, t);
         }

--- a/data_types/src/columns.rs
+++ b/data_types/src/columns.rs
@@ -110,6 +110,15 @@ impl ColumnsByName {
     }
 }
 
+impl IntoIterator for ColumnsByName {
+    type Item = (String, ColumnSchema);
+    type IntoIter = std::collections::btree_map::IntoIter<String, ColumnSchema>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
+    }
+}
+
 // ColumnsByName is a newtype so that we can implement this `TryFrom` in this crate
 impl TryFrom<ColumnsByName> for Schema {
     type Error = schema::builder::Error;

--- a/mutable_batch/src/lib.rs
+++ b/mutable_batch/src/lib.rs
@@ -102,7 +102,7 @@ impl MutableBatch {
             Projection::Some(cols) => {
                 for col in cols {
                     let column = self.column(col)?;
-                    schema_builder.influx_column(col, column.influx_type());
+                    schema_builder.influx_column(*col, column.influx_type());
                 }
                 schema_builder.build().context(InternalSchemaSnafu)?
             }

--- a/parquet_file/tests/metadata.rs
+++ b/parquet_file/tests/metadata.rs
@@ -62,7 +62,7 @@ async fn test_decoded_iox_metadata() {
 
     let mut schema_builder = SchemaBuilder::new();
     for (name, _array, column_type) in &data {
-        schema_builder.influx_column(name, *column_type);
+        schema_builder.influx_column(*name, *column_type);
     }
     let schema = schema_builder.build().unwrap();
 

--- a/schema/src/builder.rs
+++ b/schema/src/builder.rs
@@ -35,7 +35,7 @@ impl SchemaBuilder {
     /// Add a new tag column to this schema. By default tags are
     /// potentially nullable as they are not guaranteed to be present
     /// for all rows
-    pub fn tag(&mut self, column_name: &str) -> &mut Self {
+    pub fn tag(&mut self, column_name: impl Into<String>) -> &mut Self {
         let influxdb_column_type = InfluxColumnType::Tag;
         let arrow_type = (&influxdb_column_type).into();
 
@@ -45,7 +45,7 @@ impl SchemaBuilder {
     /// Add a new field column with the specified InfluxDB data model type
     pub fn influx_field(
         &mut self,
-        column_name: &str,
+        column_name: impl Into<String>,
         influxdb_field_type: InfluxFieldType,
     ) -> &mut Self {
         let arrow_type: ArrowDataType = influxdb_field_type.into();
@@ -58,7 +58,11 @@ impl SchemaBuilder {
     }
 
     /// Add a new field column with the specified InfluxDB data model type
-    pub fn influx_column(&mut self, column_name: &str, column_type: InfluxColumnType) -> &mut Self {
+    pub fn influx_column(
+        &mut self,
+        column_name: impl Into<String>,
+        column_type: InfluxColumnType,
+    ) -> &mut Self {
         match column_type {
             InfluxColumnType::Tag => self.tag(column_name),
             InfluxColumnType::Field(influx_field_type) => self
@@ -71,7 +75,7 @@ impl SchemaBuilder {
     /// Add a new nullable field column with the specified Arrow datatype.
     pub fn field(
         &mut self,
-        column_name: &str,
+        column_name: impl Into<String>,
         arrow_type: ArrowDataType,
     ) -> Result<&mut Self, &'static str> {
         let influxdb_column_type = arrow_type.clone().try_into().map(InfluxColumnType::Field)?;
@@ -127,7 +131,7 @@ impl SchemaBuilder {
     /// Internal helper method to add a column definition
     fn add_column(
         &mut self,
-        column_name: &str,
+        column_name: impl Into<String>,
         nullable: bool,
         column_type: InfluxColumnType,
         arrow_type: ArrowDataType,


### PR DESCRIPTION
Closes #7764 

Changes `schema` methods to accept `impl Into<String>` instead of `&str` so that caller can decide whether to own it or now. I am not sure if the added flexibility is worth the monomorphization hit the compile time would end up with. Considering it is only couple of methods this shouldn't matter, I wonder if it would affect if this type of changes introduced to everywhere.

- [x] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb_iox/blob/main/README.md).
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
