### PR TITLE
feat: Set, store, and use custom namespace and table partitions on write

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2812,6 +2812,7 @@ dependencies = [
  "data_types",
  "dotenvy",
  "futures",
+ "generated_types",
  "iox_time",
  "log",
  "metric",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2828,6 +2828,7 @@ dependencies = [
  "sqlx",
  "sqlx-hotswap-pool",
  "tempfile",
+ "test_helpers",
  "thiserror",
  "tokio",
  "uuid 1.3.3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1375,6 +1375,7 @@ dependencies = [
 name = "data_types"
 version = "0.1.0"
 dependencies = [
+ "assert_matches",
  "croaring",
  "generated_types",
  "influxdb-line-protocol",

--- a/compactor/src/components/namespaces_source/mock.rs
+++ b/compactor/src/components/namespaces_source/mock.rs
@@ -186,6 +186,7 @@ mod tests {
                         max_columns_per_table: 10,
                         retention_period_ns: None,
                         deleted_at: None,
+                        partition_template: Default::default(),
                     },
                     schema: NamespaceSchema {
                         id,
@@ -193,7 +194,7 @@ mod tests {
                         max_columns_per_table: 10,
                         max_tables: 42,
                         retention_period_ns: None,
-                        partition_template: None,
+                        partition_template: Default::default(),
                     },
                 },
             }

--- a/compactor/src/components/namespaces_source/mock.rs
+++ b/compactor/src/components/namespaces_source/mock.rs
@@ -130,7 +130,7 @@ mod tests {
                     "table1".to_string(),
                     TableSchema {
                         id: TableId::new(1),
-                        partition_template: None,
+                        partition_template: Default::default(),
                         columns: ColumnsByName::new([
                             Column {
                                 name: "col1".to_string(),
@@ -151,7 +151,7 @@ mod tests {
                     "table2".to_string(),
                     TableSchema {
                         id: TableId::new(2),
-                        partition_template: None,
+                        partition_template: Default::default(),
                         columns: ColumnsByName::new([
                             Column {
                                 name: "col1".to_string(),

--- a/compactor/src/partition_info.rs
+++ b/compactor/src/partition_info.rs
@@ -6,7 +6,7 @@ use data_types::{NamespaceId, PartitionId, PartitionKey, Table, TableSchema};
 use schema::sort::SortKey;
 
 /// Information about the Partition being compacted
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq)]
 pub struct PartitionInfo {
     /// the partition
     pub partition_id: PartitionId,

--- a/compactor/src/test_utils.rs
+++ b/compactor/src/test_utils.rs
@@ -15,19 +15,21 @@ impl PartitionInfoBuilder {
     pub fn new() -> Self {
         let partition_id = PartitionId::new(1);
         let namespace_id = NamespaceId::new(2);
-        let table_id = TableId::new(3);
+        let table = Arc::new(Table {
+            id: TableId::new(3),
+            namespace_id,
+            name: String::from("table"),
+            partition_template: Default::default(),
+        });
+        let table_schema = Arc::new(TableSchema::new_empty_from(&table));
 
         Self {
             inner: PartitionInfo {
                 partition_id,
                 namespace_id,
                 namespace_name: String::from("ns"),
-                table: Arc::new(Table {
-                    id: TableId::new(3),
-                    namespace_id,
-                    name: String::from("table"),
-                }),
-                table_schema: Arc::new(TableSchema::new(table_id)),
+                table,
+                table_schema,
                 sort_key: None,
                 partition_key: PartitionKey::from("key"),
             },
@@ -51,7 +53,7 @@ impl PartitionInfoBuilder {
 
         let table_schema = Arc::new(TableSchema {
             id: self.inner.table.id,
-            partition_template: None,
+            partition_template: Default::default(),
             columns: ColumnsByName::new(columns),
         });
         self.inner.table_schema = table_schema;

--- a/data_types/Cargo.toml
+++ b/data_types/Cargo.toml
@@ -21,4 +21,5 @@ uuid = { version = "1", features = ["v4"] }
 workspace-hack = { version = "0.1", path = "../workspace-hack" }
 
 [dev-dependencies] # In alphabetical order
+assert_matches = "1"
 proptest = "1.2.0"

--- a/data_types/src/lib.rs
+++ b/data_types/src/lib.rs
@@ -295,7 +295,6 @@ pub struct Namespace {
     pub id: NamespaceId,
     /// The unique name of the namespace
     pub name: String,
-    #[sqlx(default)]
     /// The retention period in ns. None represents infinite duration (i.e. never drop data).
     pub retention_period_ns: Option<i64>,
     /// The maximum number of tables that can exist in this namespace
@@ -304,7 +303,6 @@ pub struct Namespace {
     pub max_columns_per_table: i32,
     /// When this file was marked for deletion.
     pub deleted_at: Option<Timestamp>,
-    #[sqlx(default)]
     /// The partition template to use for new tables in this namespace either created implicitly or
     /// created without specifying a partition template.
     pub partition_template: NamespacePartitionTemplateOverride,
@@ -375,7 +373,6 @@ pub struct Table {
     pub namespace_id: NamespaceId,
     /// The name of the table, which is unique within the associated namespace
     pub name: String,
-    #[sqlx(default)]
     /// The partition template to use for writes in this table.
     pub partition_template: TablePartitionTemplateOverride,
 }

--- a/data_types/src/partition_template.rs
+++ b/data_types/src/partition_template.rs
@@ -1,3 +1,21 @@
+//! Partition templating with per-namespace & table override types.
+//!
+//! The override types utilise per-entity wrappers for type safety, ensuring a
+//! namespace override is not used in a table (and vice versa), as well as to
+//! ensure the correct chain of inheritance is adhered to at compile time.
+//!
+//! A partitioning template is resolved by evaluating the following (in order of
+//! precedence):
+//!
+//!    1. Table name override, if specified.
+//!    2. Namespace name override, if specified.
+//!    3. Default partitioning scheme (YYYY-MM-DD)
+//!
+//! Each of the [`NamespacePartitionTemplateOverride`] and
+//! [`TablePartitionTemplateOverride`] stores only the override, if provided,
+//! and implicitly resolves to the default partitioning scheme if no override is
+//! specified (indicated by the presence of [`Option::None`] in the wrapper).
+
 use generated_types::influxdata::iox::partition_template::v1 as proto;
 use once_cell::sync::Lazy;
 use std::sync::Arc;

--- a/data_types/src/partition_template.rs
+++ b/data_types/src/partition_template.rs
@@ -163,7 +163,25 @@ pub fn test_table_partition_override(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use assert_matches::assert_matches;
     use sqlx::Encode;
+
+    /// This test asserts the default derived partitioning scheme with no
+    /// overrides.
+    ///
+    /// Changing this default during the lifetime of a cluster will cause the
+    /// implicit (not overridden) partition schemes to change, potentially
+    /// breaking the system invariant that a given primary keys maps to a
+    /// single partition.
+    ///
+    /// You shouldn't be changing this!
+    #[test]
+    fn test_default_template_fixture() {
+        let ns = NamespacePartitionTemplateOverride::default();
+        let table = TablePartitionTemplateOverride::new(None, &ns);
+        let got = table.parts().collect::<Vec<_>>();
+        assert_matches!(got.as_slice(), [TemplatePart::TimeFormat("%Y-%m-%d")]);
+    }
 
     #[test]
     fn no_custom_table_template_specified_gets_namespace_template() {

--- a/data_types/src/partition_template.rs
+++ b/data_types/src/partition_template.rs
@@ -1,20 +1,70 @@
+use generated_types::{google::FieldViolation, influxdata::iox::partition_template::v1 as proto};
 use once_cell::sync::Lazy;
 use std::sync::Arc;
 
 /// A partition template specified by a namespace record.
-#[derive(Debug, Eq, PartialEq, Clone)]
-pub struct NamespacePartitionTemplateOverride(PartitionTemplate);
+#[derive(Debug, PartialEq, Clone)]
+pub struct NamespacePartitionTemplateOverride(Arc<proto::PartitionTemplate>);
 
-impl NamespacePartitionTemplateOverride {
-    /// Create a new, immutable override for a namespace's partition template.
-    pub fn new(partition_template: PartitionTemplate) -> Self {
-        Self(partition_template)
+impl From<proto::PartitionTemplate> for NamespacePartitionTemplateOverride {
+    fn from(partition_template: proto::PartitionTemplate) -> Self {
+        Self(Arc::new(partition_template))
+    }
+}
+
+impl Default for NamespacePartitionTemplateOverride {
+    fn default() -> Self {
+        Self(Arc::clone(&PARTITION_BY_DAY_PROTO))
+    }
+}
+
+impl<DB> sqlx::Type<DB> for NamespacePartitionTemplateOverride
+where
+    sqlx::types::Json<Self>: sqlx::Type<DB>,
+    DB: sqlx::Database,
+{
+    fn type_info() -> DB::TypeInfo {
+        <sqlx::types::Json<Self> as sqlx::Type<DB>>::type_info()
+    }
+}
+
+impl<'q, DB> sqlx::Encode<'q, DB> for NamespacePartitionTemplateOverride
+where
+    DB: sqlx::Database,
+    for<'b> sqlx::types::Json<&'b proto::PartitionTemplate>: sqlx::Encode<'q, DB>,
+{
+    fn encode_by_ref(
+        &self,
+        buf: &mut <DB as sqlx::database::HasArguments<'q>>::ArgumentBuffer,
+    ) -> sqlx::encode::IsNull {
+        // Unambiguous delegation to the Encode impl on the Json type, which
+        // exists due to the constraint in the where clause above.
+        <sqlx::types::Json<&proto::PartitionTemplate> as sqlx::Encode<'_, DB>>::encode_by_ref(
+            &sqlx::types::Json(&self.0),
+            buf,
+        )
+    }
+}
+
+impl<'q, DB> sqlx::Decode<'q, DB> for NamespacePartitionTemplateOverride
+where
+    DB: sqlx::Database,
+    sqlx::types::Json<proto::PartitionTemplate>: sqlx::Decode<'q, DB>,
+{
+    fn decode(
+        value: <DB as sqlx::database::HasValueRef<'q>>::ValueRef,
+    ) -> Result<Self, Box<dyn std::error::Error + 'static + Send + Sync>> {
+        Ok(Self(
+            <sqlx::types::Json<proto::PartitionTemplate> as sqlx::Decode<'_, DB>>::decode(value)?
+                .0
+                .into(),
+        ))
     }
 }
 
 /// A partition template specified by a table record.
 #[derive(Debug, Eq, PartialEq, Clone)]
-pub struct TablePartitionTemplateOverride(PartitionTemplate);
+pub struct TablePartitionTemplateOverride(pub PartitionTemplate);
 
 impl TablePartitionTemplateOverride {
     /// Create a new, immutable override for a table's partition template.
@@ -24,19 +74,59 @@ impl TablePartitionTemplateOverride {
 }
 
 /// A partition template specified as the default to be used in the absence of any overrides.
-#[derive(Debug, Eq, PartialEq, Clone, Copy)]
-pub struct DefaultPartitionTemplate(&'static PartitionTemplate);
+#[derive(Debug, PartialEq, Clone, Copy)]
+pub struct DefaultPartitionTemplate(&'static proto::PartitionTemplate);
 
 impl Default for DefaultPartitionTemplate {
     fn default() -> Self {
-        Self(&PARTITION_BY_DAY)
+        Self(&PARTITION_BY_DAY_PROTO)
     }
 }
 
 /// The default partitioning scheme is by each day according to the "time" column.
-pub static PARTITION_BY_DAY: Lazy<PartitionTemplate> = Lazy::new(|| PartitionTemplate {
-    parts: vec![TemplatePart::TimeFormat("%Y-%m-%d".to_owned())],
+pub static PARTITION_BY_DAY_PROTO: Lazy<Arc<proto::PartitionTemplate>> = Lazy::new(|| {
+    Arc::new(proto::PartitionTemplate {
+        parts: vec![proto::TemplatePart {
+            part: Some(proto::template_part::Part::TimeFormat(
+                "%Y-%m-%d".to_owned(),
+            )),
+        }],
+    })
 });
+
+/// The default partitioning scheme is by each day according to the "time" column.
+pub static PARTITION_BY_DAY: Lazy<Arc<PartitionTemplate>> =
+    Lazy::new(|| Arc::new(PARTITION_BY_DAY_PROTO.as_ref().try_into().unwrap()));
+
+impl TryFrom<&proto::PartitionTemplate> for PartitionTemplate {
+    type Error = FieldViolation;
+
+    fn try_from(value: &proto::PartitionTemplate) -> Result<Self, Self::Error> {
+        Ok(Self {
+            parts: value
+                .parts
+                .iter()
+                .map(TryFrom::try_from)
+                .collect::<Result<Vec<_>, _>>()?,
+        })
+    }
+}
+
+impl TryFrom<&proto::TemplatePart> for TemplatePart {
+    type Error = FieldViolation;
+
+    fn try_from(value: &proto::TemplatePart) -> Result<Self, Self::Error> {
+        let part = value
+            .part
+            .as_ref()
+            .ok_or_else(|| FieldViolation::required(String::from("value")))?;
+
+        Ok(match part {
+            proto::template_part::Part::TagValue(value) => Self::TagValue(value.into()),
+            proto::template_part::Part::TimeFormat(value) => Self::TimeFormat(value.into()),
+        })
+    }
+}
 
 /// `PartitionTemplate` is used to compute the partition key of each row that gets written. It can
 /// consist of a column name and its value or a formatted time. For columns that do not appear in
@@ -55,14 +145,11 @@ impl PartitionTemplate {
     /// partition template, use that. If neither the table nor the namespace has a template,
     /// use the default template.
     pub fn determine_precedence<'a>(
-        table: Option<&'a Arc<TablePartitionTemplateOverride>>,
-        namespace: Option<&'a Arc<NamespacePartitionTemplateOverride>>,
-        default: &'a DefaultPartitionTemplate,
+        _table: Option<&'a Arc<TablePartitionTemplateOverride>>,
+        _namespace: Option<&'a Arc<NamespacePartitionTemplateOverride>>,
+        _default: &'a DefaultPartitionTemplate,
     ) -> &'a PartitionTemplate {
-        table
-            .map(|t| &t.0)
-            .or(namespace.map(|n| &n.0))
-            .unwrap_or(default.0)
+        unimplemented!()
     }
 }
 
@@ -70,8 +157,8 @@ impl PartitionTemplate {
 /// part of a partition key.
 #[derive(Debug, Eq, PartialEq, Clone)]
 pub enum TemplatePart {
-    /// The value in a named column
-    Column(String),
+    /// The value in the named tag, or the tag name if the value isn't present.
+    TagValue(String),
     /// Applies a  `strftime` format to the "time" column.
     ///
     /// For example, a time format of "%Y-%m-%d %H:%M:%S" will produce

--- a/generated_types/protos/influxdata/iox/namespace/v1/service.proto
+++ b/generated_types/protos/influxdata/iox/namespace/v1/service.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 package influxdata.iox.namespace.v1;
 option go_package = "github.com/influxdata/iox/namespace/v1";
 
+import "influxdata/iox/partition_template/v1/template.proto";
+
 service NamespaceService {
   // Get all namespaces
   rpc GetNamespaces(GetNamespacesRequest) returns (GetNamespacesResponse);
@@ -36,6 +38,9 @@ message CreateNamespaceRequest {
   // NULL means "infinite retention", and 0 is mapped to NULL. Negative values
   // are rejected.
   optional int64 retention_period_ns = 2;
+
+  // Partitioning scheme to use for tables created in this namespace
+  optional influxdata.iox.partition_template.v1.PartitionTemplate partition_template = 3;
 }
 
 message CreateNamespaceResponse {

--- a/generated_types/protos/influxdata/iox/partition_template/v1/template.proto
+++ b/generated_types/protos/influxdata/iox/partition_template/v1/template.proto
@@ -12,14 +12,17 @@ message PartitionTemplate {
   //
   // For example, given the following template:
   //
-  //    [ TemplatePart::time_format("%Y.%j") TemplatePart::tag_value("region") ]
+  // ```text
+  // [ TemplatePart::time_format("%Y.%j") TemplatePart::tag_value("region") ]
+  // ```
   //
   // The below example rows would have the specified partition key derived:
   //
-  //    time=2023-03-10T13:00:00, region=EMEA, x=42   => "2023.69-EMEA"
-  //    time=2023-03-10T13:00:00, region=EMEA-bananas => "2023.69-EMEA-bananas"
-  //    time=2023-03-10T13:00:00, x=42                => "2023.69-region"
-  //
+  // ```text
+  // time=2023-03-10T13:00:00, region=EMEA, x=42   => "2023.69-EMEA"
+  // time=2023-03-10T13:00:00, region=EMEA-bananas => "2023.69-EMEA-bananas"
+  // time=2023-03-10T13:00:00, x=42                => "2023.69-region"
+  // ```
   repeated TemplatePart parts = 1;
 }
 

--- a/generated_types/src/lib.rs
+++ b/generated_types/src/lib.rs
@@ -122,6 +122,19 @@ pub mod influxdata {
             }
         }
 
+        pub mod partition_template {
+            pub mod v1 {
+                include!(concat!(
+                    env!("OUT_DIR"),
+                    "/influxdata.iox.partition_template.v1.rs"
+                ));
+                include!(concat!(
+                    env!("OUT_DIR"),
+                    "/influxdata.iox.partition_template.v1.serde.rs"
+                ));
+            }
+        }
+
         pub mod predicate {
             pub mod v1 {
                 include!(concat!(env!("OUT_DIR"), "/influxdata.iox.predicate.v1.rs"));

--- a/influxdb_iox_client/src/client/namespace.rs
+++ b/influxdb_iox_client/src/client/namespace.rs
@@ -50,6 +50,7 @@ impl Client {
             .create_namespace(CreateNamespaceRequest {
                 name: namespace.to_string(),
                 retention_period_ns,
+                partition_template: None,
             })
             .await?;
 

--- a/ingester/benches/write.rs
+++ b/ingester/benches/write.rs
@@ -50,9 +50,10 @@ async fn init(lp: impl AsRef<str>) -> (TestContext<impl IngesterRpcInterface>, D
                     .repositories()
                     .await
                     .tables()
-                    .create_or_get(table_name.as_str(), ns.id)
+                    .get_by_namespace_and_name(ns.id, table_name.as_str())
                     .await
-                    .expect("table should create OK")
+                    .unwrap()
+                    .expect("table should exist because of the write_lp above")
                     .id;
 
                 (id, batch)

--- a/ingester/src/test_util.rs
+++ b/ingester/src/test_util.rs
@@ -298,7 +298,12 @@ pub(crate) async fn populate_catalog(
 ) -> (NamespaceId, TableId) {
     let mut c = catalog.repositories().await;
     let ns_id = arbitrary_namespace(&mut *c, namespace).await.id;
-    let table_id = c.tables().create(table, ns_id).await.unwrap().id;
+    let table_id = c
+        .tables()
+        .create(table, Default::default(), ns_id)
+        .await
+        .unwrap()
+        .id;
 
     (ns_id, table_id)
 }

--- a/ingester/src/test_util.rs
+++ b/ingester/src/test_util.rs
@@ -298,7 +298,7 @@ pub(crate) async fn populate_catalog(
 ) -> (NamespaceId, TableId) {
     let mut c = catalog.repositories().await;
     let ns_id = arbitrary_namespace(&mut *c, namespace).await.id;
-    let table_id = c.tables().create_or_get(table, ns_id).await.unwrap().id;
+    let table_id = c.tables().create(table, ns_id).await.unwrap().id;
 
     (ns_id, table_id)
 }

--- a/ingester_test_ctx/src/lib.rs
+++ b/ingester_test_ctx/src/lib.rs
@@ -222,7 +222,7 @@ where
                         max_columns_per_table: iox_catalog::DEFAULT_MAX_COLUMNS_PER_TABLE as usize,
                         max_tables: iox_catalog::DEFAULT_MAX_TABLES as usize,
                         retention_period_ns,
-                        partition_template: None,
+                        partition_template: Default::default(),
                     },
                 )
                 .is_none(),

--- a/ingester_test_ctx/src/lib.rs
+++ b/ingester_test_ctx/src/lib.rs
@@ -251,7 +251,8 @@ where
             .namespaces
             .get_mut(&namespace_id)
             .expect("namespace does not exist");
-        let partition_template = TablePartitionTemplateOverride::from(&schema.partition_template);
+        let partition_template =
+            TablePartitionTemplateOverride::new(None, &schema.partition_template);
 
         let batches = lines_to_batches(lp, 0).unwrap();
 

--- a/iox_catalog/Cargo.toml
+++ b/iox_catalog/Cargo.toml
@@ -27,6 +27,7 @@ workspace-hack = { version = "0.1", path = "../workspace-hack" }
 [dev-dependencies] # In alphabetical order
 assert_matches = "1.5.0"
 dotenvy = "0.15.7"
+generated_types = { path = "../generated_types" }
 mutable_batch_lp = { path = "../mutable_batch_lp" }
 paste = "1.0.12"
 pretty_assertions = "1.3.0"

--- a/iox_catalog/Cargo.toml
+++ b/iox_catalog/Cargo.toml
@@ -33,3 +33,4 @@ paste = "1.0.12"
 pretty_assertions = "1.3.0"
 rand = "0.8"
 tempfile = "3"
+test_helpers = { path = "../test_helpers" }

--- a/iox_catalog/migrations/20230501173720_add_partition_templates.sql
+++ b/iox_catalog/migrations/20230501173720_add_partition_templates.sql
@@ -1,0 +1,7 @@
+ALTER TABLE
+    IF EXISTS namespace
+    ADD COLUMN partition_template JSONB;
+
+ALTER TABLE
+    IF EXISTS table_name
+    ADD COLUMN partition_template JSONB;

--- a/iox_catalog/sqlite/migrations/20230501173720_add_partition_templates.sql
+++ b/iox_catalog/sqlite/migrations/20230501173720_add_partition_templates.sql
@@ -1,0 +1,7 @@
+ALTER TABLE
+    namespace
+ADD COLUMN partition_template TEXT;
+
+ALTER TABLE
+    table_name
+ADD COLUMN partition_template TEXT;

--- a/iox_catalog/src/interface.rs
+++ b/iox_catalog/src/interface.rs
@@ -754,6 +754,13 @@ pub(crate) mod test_helpers {
             namespace.partition_template,
             NamespacePartitionTemplateOverride::default()
         );
+        let lookup_namespace = repos
+            .namespaces()
+            .get_by_name(&namespace_name, SoftDeletedRows::ExcludeDeleted)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(namespace, lookup_namespace);
 
         // Assert default values for service protection limits.
         assert_eq!(namespace.max_tables, DEFAULT_MAX_TABLES);

--- a/iox_catalog/src/interface.rs
+++ b/iox_catalog/src/interface.rs
@@ -1095,7 +1095,7 @@ pub(crate) mod test_helpers {
             .tables()
             .create(
                 "test_table",
-                TablePartitionTemplateOverride::from(&namespace.partition_template),
+                TablePartitionTemplateOverride::new(None, &namespace.partition_template),
                 namespace.id,
             )
             .await;
@@ -1190,7 +1190,7 @@ pub(crate) mod test_helpers {
             .tables()
             .create(
                 "definitely_unique",
-                TablePartitionTemplateOverride::from(&latest.partition_template),
+                TablePartitionTemplateOverride::new(None, &latest.partition_template),
                 latest.id,
             )
             .await
@@ -1261,7 +1261,7 @@ pub(crate) mod test_helpers {
             .unwrap();
         assert_eq!(
             table_templated_by_namespace.partition_template,
-            TablePartitionTemplateOverride::from(&custom_namespace_template)
+            TablePartitionTemplateOverride::new(None, &custom_namespace_template)
         );
 
         repos

--- a/iox_catalog/src/lib.rs
+++ b/iox_catalog/src/lib.rs
@@ -228,7 +228,7 @@ pub mod test_helpers {
         let namespace_name = NamespaceName::new(name).unwrap();
         repos
             .namespaces()
-            .create(&namespace_name, None)
+            .create(&namespace_name, None, None)
             .await
             .unwrap()
     }
@@ -293,7 +293,6 @@ mod tests {
 
                     let namespace = arbitrary_namespace(&mut *txn, NAMESPACE_NAME)
                         .await;
-
                     let schema = NamespaceSchema::new_empty_from(&namespace);
 
                     // Apply all the lp literals as individual writes, feeding

--- a/iox_catalog/src/lib.rs
+++ b/iox_catalog/src/lib.rs
@@ -234,10 +234,13 @@ where
                 repos
                     .tables()
                     .get_by_namespace_and_name(namespace_id, table_name)
+                    // Propagate any `Err` returned by the catalog
                     .await?
+                    // Getting `Ok(None)` should be impossible if we're in this code path because
+                    // the `create` request just said the table exists
                     .expect(
-                        "Table creation failed because the table exists, \
-                        so looking up the table should succeed",
+                        "Table creation failed because the table exists, so looking up the table \
+                        should return `Some(table)`, but it returned `None`",
                     )
             } else {
                 create_result?

--- a/iox_catalog/src/lib.rs
+++ b/iox_catalog/src/lib.rs
@@ -223,7 +223,10 @@ where
                 .tables()
                 .create(
                     table_name,
-                    TablePartitionTemplateOverride::from(namespace_partition_template),
+                    // This table is being created implicitly by this write, so there's no
+                    // possibility of a user-supplied partition template here, which is why there's
+                    // a hardcoded `None`.
+                    TablePartitionTemplateOverride::new(None, namespace_partition_template),
                     namespace_id,
                 )
                 .await;
@@ -301,7 +304,7 @@ pub mod test_helpers {
             .tables()
             .create(
                 name,
-                TablePartitionTemplateOverride::from(&namespace.partition_template),
+                TablePartitionTemplateOverride::new(None, &namespace.partition_template),
                 namespace.id,
             )
             .await

--- a/iox_catalog/src/mem.rs
+++ b/iox_catalog/src/mem.rs
@@ -13,8 +13,8 @@ use crate::{
 use async_trait::async_trait;
 use data_types::{
     Column, ColumnId, ColumnType, CompactionLevel, Namespace, NamespaceId, NamespaceName,
-    ParquetFile, ParquetFileId, ParquetFileParams, Partition, PartitionId, PartitionKey,
-    SkippedCompaction, Table, TableId, Timestamp,
+    NamespacePartitionTemplateOverride, ParquetFile, ParquetFileId, ParquetFileParams, Partition,
+    PartitionId, PartitionKey, SkippedCompaction, Table, TableId, Timestamp,
 };
 use iox_time::{SystemProvider, TimeProvider};
 use snafu::ensure;
@@ -141,6 +141,7 @@ impl NamespaceRepo for MemTxn {
     async fn create(
         &mut self,
         name: &NamespaceName,
+        partition_template: Option<NamespacePartitionTemplateOverride>,
         retention_period_ns: Option<i64>,
     ) -> Result<Namespace> {
         let stage = self.stage();
@@ -158,6 +159,7 @@ impl NamespaceRepo for MemTxn {
             max_columns_per_table: DEFAULT_MAX_COLUMNS_PER_TABLE,
             retention_period_ns,
             deleted_at: None,
+            partition_template: partition_template.unwrap_or_default(),
         };
         stage.namespaces.push(namespace);
         Ok(stage.namespaces.last().unwrap().clone())

--- a/iox_catalog/src/mem.rs
+++ b/iox_catalog/src/mem.rs
@@ -260,7 +260,7 @@ impl NamespaceRepo for MemTxn {
 
 #[async_trait]
 impl TableRepo for MemTxn {
-    async fn create_or_get(&mut self, name: &str, namespace_id: NamespaceId) -> Result<Table> {
+    async fn create(&mut self, name: &str, namespace_id: NamespaceId) -> Result<Table> {
         let stage = self.stage();
 
         // this block is just to ensure the mem impl correctly creates TableCreateLimitError in
@@ -296,7 +296,12 @@ impl TableRepo for MemTxn {
             .iter()
             .find(|t| t.name == name && t.namespace_id == namespace_id)
         {
-            Some(t) => t,
+            Some(_t) => {
+                return Err(Error::TableNameExists {
+                    name: name.to_string(),
+                    namespace_id,
+                })
+            }
             None => {
                 let table = Table {
                     id: TableId::new(stage.tables.len() as i64 + 1),

--- a/iox_catalog/src/mem.rs
+++ b/iox_catalog/src/mem.rs
@@ -14,7 +14,8 @@ use async_trait::async_trait;
 use data_types::{
     Column, ColumnId, ColumnType, CompactionLevel, Namespace, NamespaceId, NamespaceName,
     NamespacePartitionTemplateOverride, ParquetFile, ParquetFileId, ParquetFileParams, Partition,
-    PartitionId, PartitionKey, SkippedCompaction, Table, TableId, Timestamp,
+    PartitionId, PartitionKey, SkippedCompaction, Table, TableId, TablePartitionTemplateOverride,
+    Timestamp,
 };
 use iox_time::{SystemProvider, TimeProvider};
 use snafu::ensure;
@@ -260,7 +261,12 @@ impl NamespaceRepo for MemTxn {
 
 #[async_trait]
 impl TableRepo for MemTxn {
-    async fn create(&mut self, name: &str, namespace_id: NamespaceId) -> Result<Table> {
+    async fn create(
+        &mut self,
+        name: &str,
+        partition_template: TablePartitionTemplateOverride,
+        namespace_id: NamespaceId,
+    ) -> Result<Table> {
         let stage = self.stage();
 
         // this block is just to ensure the mem impl correctly creates TableCreateLimitError in
@@ -307,6 +313,7 @@ impl TableRepo for MemTxn {
                     id: TableId::new(stage.tables.len() as i64 + 1),
                     namespace_id,
                     name: name.to_string(),
+                    partition_template,
                 };
                 stage.tables.push(table);
                 stage.tables.last().unwrap()

--- a/iox_catalog/src/metrics.rs
+++ b/iox_catalog/src/metrics.rs
@@ -6,9 +6,9 @@ use crate::interface::{
 };
 use async_trait::async_trait;
 use data_types::{
-    Column, ColumnType, CompactionLevel, Namespace, NamespaceId, NamespaceName, ParquetFile,
-    ParquetFileId, ParquetFileParams, Partition, PartitionId, PartitionKey, SkippedCompaction,
-    Table, TableId, Timestamp,
+    Column, ColumnType, CompactionLevel, Namespace, NamespaceId, NamespaceName,
+    NamespacePartitionTemplateOverride, ParquetFile, ParquetFileId, ParquetFileParams, Partition,
+    PartitionId, PartitionKey, SkippedCompaction, Table, TableId, Timestamp,
 };
 use iox_time::{SystemProvider, TimeProvider};
 use metric::{DurationHistogram, Metric};
@@ -131,7 +131,7 @@ macro_rules! decorate {
 decorate!(
     impl_trait = NamespaceRepo,
     methods = [
-        "namespace_create" = create(&mut self, name: &NamespaceName, retention_period_ns: Option<i64>) -> Result<Namespace>;
+        "namespace_create" = create(&mut self, name: &NamespaceName, partition_template: Option<NamespacePartitionTemplateOverride>, retention_period_ns: Option<i64>) -> Result<Namespace>;
         "namespace_update_retention_period" = update_retention_period(&mut self, name: &str, retention_period_ns: Option<i64>) -> Result<Namespace>;
         "namespace_list" = list(&mut self, deleted: SoftDeletedRows) -> Result<Vec<Namespace>>;
         "namespace_get_by_id" = get_by_id(&mut self, id: NamespaceId, deleted: SoftDeletedRows) -> Result<Option<Namespace>>;

--- a/iox_catalog/src/metrics.rs
+++ b/iox_catalog/src/metrics.rs
@@ -8,7 +8,8 @@ use async_trait::async_trait;
 use data_types::{
     Column, ColumnType, CompactionLevel, Namespace, NamespaceId, NamespaceName,
     NamespacePartitionTemplateOverride, ParquetFile, ParquetFileId, ParquetFileParams, Partition,
-    PartitionId, PartitionKey, SkippedCompaction, Table, TableId, Timestamp,
+    PartitionId, PartitionKey, SkippedCompaction, Table, TableId, TablePartitionTemplateOverride,
+    Timestamp,
 };
 use iox_time::{SystemProvider, TimeProvider};
 use metric::{DurationHistogram, Metric};
@@ -145,7 +146,7 @@ decorate!(
 decorate!(
     impl_trait = TableRepo,
     methods = [
-        "table_create" = create(&mut self, name: &str, namespace_id: NamespaceId) -> Result<Table>;
+        "table_create" = create(&mut self, name: &str, partition_template: TablePartitionTemplateOverride, namespace_id: NamespaceId) -> Result<Table>;
         "table_get_by_id" = get_by_id(&mut self, table_id: TableId) -> Result<Option<Table>>;
         "table_get_by_namespace_and_name" = get_by_namespace_and_name(&mut self, namespace_id: NamespaceId, name: &str) -> Result<Option<Table>>;
         "table_list_by_namespace_id" = list_by_namespace_id(&mut self, namespace_id: NamespaceId) -> Result<Vec<Table>>;

--- a/iox_catalog/src/metrics.rs
+++ b/iox_catalog/src/metrics.rs
@@ -145,7 +145,7 @@ decorate!(
 decorate!(
     impl_trait = TableRepo,
     methods = [
-        "table_create_or_get" = create_or_get(&mut self, name: &str, namespace_id: NamespaceId) -> Result<Table>;
+        "table_create" = create(&mut self, name: &str, namespace_id: NamespaceId) -> Result<Table>;
         "table_get_by_id" = get_by_id(&mut self, table_id: TableId) -> Result<Option<Table>>;
         "table_get_by_namespace_and_name" = get_by_namespace_and_name(&mut self, namespace_id: NamespaceId, name: &str) -> Result<Option<Table>>;
         "table_list_by_namespace_id" = list_by_namespace_id(&mut self, namespace_id: NamespaceId) -> Result<Vec<Table>>;

--- a/iox_catalog/src/postgres.rs
+++ b/iox_catalog/src/postgres.rs
@@ -2412,7 +2412,10 @@ RETURNING *;
         // it should have the namespace's template
         assert_eq!(
             table_no_template_with_namespace_template.partition_template,
-            TablePartitionTemplateOverride::from(&namespace_custom_template.partition_template)
+            TablePartitionTemplateOverride::new(
+                None,
+                &namespace_custom_template.partition_template
+            )
         );
 
         // and store that value in the database record.
@@ -2427,7 +2430,10 @@ RETURNING *;
             record.try_get("partition_template").unwrap();
         assert_eq!(
             partition_template.unwrap(),
-            TablePartitionTemplateOverride::from(&namespace_custom_template.partition_template)
+            TablePartitionTemplateOverride::new(
+                None,
+                &namespace_custom_template.partition_template
+            )
         );
 
         // # Table template true, namespace template false

--- a/iox_catalog/src/postgres.rs
+++ b/iox_catalog/src/postgres.rs
@@ -501,8 +501,6 @@ impl NamespaceRepo for PostgresTxn {
         partition_template: Option<NamespacePartitionTemplateOverride>,
         retention_period_ns: Option<i64>,
     ) -> Result<Namespace> {
-        let partition_template = partition_template.unwrap_or_default();
-
         let rec = sqlx::query_as::<_, Namespace>(
             r#"
 INSERT INTO namespace (
@@ -1620,7 +1618,8 @@ mod tests {
     use super::*;
     use crate::test_helpers::{arbitrary_namespace, arbitrary_table};
     use assert_matches::assert_matches;
-    use data_types::{ColumnId, ColumnSet};
+    use data_types::{ColumnId, ColumnSet, TemplatePart};
+    use generated_types::influxdata::iox::partition_template::v1 as proto;
     use metric::{Attributes, DurationHistogram, Metric};
     use rand::Rng;
     use sqlx::migrate::MigrateDatabase;
@@ -2155,5 +2154,419 @@ mod tests {
                 .await
                 .expect("fetch total file size failed");
         assert_eq!(total_file_size_bytes, 1337 * 2);
+    }
+
+    #[tokio::test]
+    async fn namespace_partition_template_null_is_the_default_in_the_database() {
+        maybe_skip_integration!();
+
+        let postgres = setup_db().await;
+        let pool = postgres.pool.clone();
+        let postgres: Arc<dyn Catalog> = Arc::new(postgres);
+        let mut repos = postgres.repositories().await;
+
+        let namespace_name = "apples";
+
+        // Create a namespace record in the database that has `NULL` for its `partition_template`
+        // value, which is what records existing before the migration adding that column will have.
+        let insert_null_partition_template_namespace = sqlx::query(
+            r#"
+INSERT INTO namespace (
+    name, topic_id, query_pool_id, retention_period_ns, max_tables, partition_template
+)
+VALUES ( $1, $2, $3, $4, $5, NULL )
+RETURNING id, name, retention_period_ns, max_tables, max_columns_per_table, deleted_at,
+          partition_template;
+            "#,
+        )
+        .bind(namespace_name) // $1
+        .bind(SHARED_TOPIC_ID) // $2
+        .bind(SHARED_QUERY_POOL_ID) // $3
+        .bind(None::<Option<i64>>) // $4
+        .bind(DEFAULT_MAX_TABLES); // $5
+
+        insert_null_partition_template_namespace
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+
+        let lookup_namespace = repos
+            .namespaces()
+            .get_by_name(namespace_name, SoftDeletedRows::ExcludeDeleted)
+            .await
+            .unwrap()
+            .unwrap();
+        // When fetching this namespace from the database, the `FromRow` impl should set its
+        // `partition_template` to the default.
+        assert_eq!(
+            lookup_namespace.partition_template,
+            NamespacePartitionTemplateOverride::default()
+        );
+
+        // When creating a namespace through the catalog functions without specifying a custom
+        // partition template,
+        let created_without_custom_template = repos
+            .namespaces()
+            .create(
+                &"lemons".try_into().unwrap(),
+                None, // no partition template
+                None,
+            )
+            .await
+            .unwrap();
+
+        // it should have the default template in the application,
+        assert_eq!(
+            created_without_custom_template.partition_template,
+            NamespacePartitionTemplateOverride::default()
+        );
+
+        // and store NULL in the database record.
+        let record = sqlx::query("SELECT name, partition_template FROM namespace WHERE id = $1;")
+            .bind(created_without_custom_template.id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        let name: String = record.try_get("name").unwrap();
+        assert_eq!(created_without_custom_template.name, name);
+        let partition_template: Option<NamespacePartitionTemplateOverride> =
+            record.try_get("partition_template").unwrap();
+        assert!(partition_template.is_none());
+
+        // When explicitly setting a template that happens to be equal to the application default,
+        // assume it's important that it's being specially requested and store it rather than NULL.
+        let namespace_custom_template_name = "kumquats";
+        let custom_partition_template_equal_to_default =
+            NamespacePartitionTemplateOverride::from(proto::PartitionTemplate {
+                parts: vec![proto::TemplatePart {
+                    part: Some(proto::template_part::Part::TimeFormat(
+                        "%Y-%m-%d".to_owned(),
+                    )),
+                }],
+            });
+        let namespace_custom_template = repos
+            .namespaces()
+            .create(
+                &namespace_custom_template_name.try_into().unwrap(),
+                Some(custom_partition_template_equal_to_default.clone()),
+                None,
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            namespace_custom_template.partition_template,
+            custom_partition_template_equal_to_default
+        );
+        let record = sqlx::query("SELECT name, partition_template FROM namespace WHERE id = $1;")
+            .bind(namespace_custom_template.id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        let name: String = record.try_get("name").unwrap();
+        assert_eq!(namespace_custom_template.name, name);
+        let partition_template: Option<NamespacePartitionTemplateOverride> =
+            record.try_get("partition_template").unwrap();
+        assert_eq!(
+            partition_template.unwrap(),
+            custom_partition_template_equal_to_default
+        );
+    }
+
+    #[tokio::test]
+    async fn table_partition_template_null_is_the_default_in_the_database() {
+        maybe_skip_integration!();
+
+        let postgres = setup_db().await;
+        let pool = postgres.pool.clone();
+        let postgres: Arc<dyn Catalog> = Arc::new(postgres);
+        let mut repos = postgres.repositories().await;
+
+        let namespace_default_template_name = "oranges";
+        let namespace_default_template = repos
+            .namespaces()
+            .create(
+                &namespace_default_template_name.try_into().unwrap(),
+                None, // no partition template
+                None,
+            )
+            .await
+            .unwrap();
+
+        let namespace_custom_template_name = "limes";
+        let namespace_custom_template = repos
+            .namespaces()
+            .create(
+                &namespace_custom_template_name.try_into().unwrap(),
+                Some(NamespacePartitionTemplateOverride::from(
+                    proto::PartitionTemplate {
+                        parts: vec![proto::TemplatePart {
+                            part: Some(proto::template_part::Part::TimeFormat("year-%Y".into())),
+                        }],
+                    },
+                )),
+                None,
+            )
+            .await
+            .unwrap();
+
+        // In a namespace that also has a NULL template, create a table record in the database that
+        // has `NULL` for its `partition_template` value, which is what records existing before the
+        // migration adding that column will have.
+        let table_name = "null_template";
+        let insert_null_partition_template_table = sqlx::query(
+            r#"
+INSERT INTO table_name ( name, namespace_id, partition_template )
+VALUES ( $1, $2, NULL )
+RETURNING *;
+            "#,
+        )
+        .bind(table_name) // $1
+        .bind(namespace_default_template.id); // $2
+
+        insert_null_partition_template_table
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+
+        let lookup_table = repos
+            .tables()
+            .get_by_namespace_and_name(namespace_default_template.id, table_name)
+            .await
+            .unwrap()
+            .unwrap();
+        // When fetching this table from the database, the `FromRow` impl should set its
+        // `partition_template` to the system default (because the namespace didn't have a template
+        // either).
+        assert_eq!(
+            lookup_table.partition_template,
+            TablePartitionTemplateOverride::default()
+        );
+
+        // In a namespace that has a custom template, create a table record in the database that
+        // has `NULL` for its `partition_template` value.
+        //
+        // THIS ACTUALLY SHOULD BE IMPOSSIBLE because:
+        //
+        // * Namespaces have to exist before tables
+        // * `partition_tables` are immutable on both namespaces and tables
+        // * When the migration adding the `partition_table` column is deployed, namespaces can
+        //   begin to be created with `partition_templates`
+        // * *Then* tables can be created with `partition_templates` or not
+        // * When tables don't get a custom table partition template but their namespace has one,
+        //   their database record will get the namespace partition template.
+        //
+        // In other words, table `partition_template` values in the database is allowed to possibly
+        // be `NULL` IFF their namespace's `partition_template` is `NULL`.
+        //
+        // That said, this test creates this hopefully-impossible scenario to ensure that the
+        // defined, expected behavior if a table record somehow exists in the database with a `NULL`
+        // `partition_template` value is that it will have the application default partition
+        // template *even if the namespace `partition_template` is not null*.
+        let table_name = "null_template";
+        let insert_null_partition_template_table = sqlx::query(
+            r#"
+INSERT INTO table_name ( name, namespace_id, partition_template )
+VALUES ( $1, $2, NULL )
+RETURNING *;
+            "#,
+        )
+        .bind(table_name) // $1
+        .bind(namespace_custom_template.id); // $2
+
+        insert_null_partition_template_table
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+
+        let lookup_table = repos
+            .tables()
+            .get_by_namespace_and_name(namespace_custom_template.id, table_name)
+            .await
+            .unwrap()
+            .unwrap();
+        // When fetching this table from the database, the `FromRow` impl should set its
+        // `partition_template` to the system default *even though the namespace has a
+        // template*, because this should be impossible as detailed above.
+        assert_eq!(
+            lookup_table.partition_template,
+            TablePartitionTemplateOverride::default()
+        );
+
+        // # Table template false, namespace template true
+        //
+        // When creating a table through the catalog functions *without* a custom table template in
+        // a namespace *with* a custom partition template,
+        let table_no_template_with_namespace_template = repos
+            .tables()
+            .create(
+                "pomelo",
+                TablePartitionTemplateOverride::new(
+                    None, // no custom partition template
+                    &namespace_custom_template.partition_template,
+                ),
+                namespace_custom_template.id,
+            )
+            .await
+            .unwrap();
+
+        // it should have the namespace's template
+        assert_eq!(
+            table_no_template_with_namespace_template.partition_template,
+            TablePartitionTemplateOverride::from(&namespace_custom_template.partition_template)
+        );
+
+        // and store that value in the database record.
+        let record = sqlx::query("SELECT name, partition_template FROM table_name WHERE id = $1;")
+            .bind(table_no_template_with_namespace_template.id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        let name: String = record.try_get("name").unwrap();
+        assert_eq!(table_no_template_with_namespace_template.name, name);
+        let partition_template: Option<TablePartitionTemplateOverride> =
+            record.try_get("partition_template").unwrap();
+        assert_eq!(
+            partition_template.unwrap(),
+            TablePartitionTemplateOverride::from(&namespace_custom_template.partition_template)
+        );
+
+        // # Table template true, namespace template false
+        //
+        // When creating a table through the catalog functions *with* a custom table template in
+        // a namespace *without* a custom partition template,
+        let custom_table_template = proto::PartitionTemplate {
+            parts: vec![proto::TemplatePart {
+                part: Some(proto::template_part::Part::TagValue("chemical".into())),
+            }],
+        };
+        let table_with_template_no_namespace_template = repos
+            .tables()
+            .create(
+                "tangerine",
+                TablePartitionTemplateOverride::new(
+                    Some(custom_table_template), // with custom partition template
+                    &namespace_default_template.partition_template,
+                ),
+                namespace_default_template.id,
+            )
+            .await
+            .unwrap();
+
+        // it should have the custom table template
+        let table_template_parts: Vec<_> = table_with_template_no_namespace_template
+            .partition_template
+            .parts()
+            .collect();
+        assert_eq!(table_template_parts.len(), 1);
+        assert_matches!(
+            table_template_parts[0],
+            TemplatePart::TagValue(tag) if tag == "chemical"
+        );
+
+        // and store that value in the database record.
+        let record = sqlx::query("SELECT name, partition_template FROM table_name WHERE id = $1;")
+            .bind(table_with_template_no_namespace_template.id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        let name: String = record.try_get("name").unwrap();
+        assert_eq!(table_with_template_no_namespace_template.name, name);
+        let partition_template = record
+            .try_get::<Option<TablePartitionTemplateOverride>, _>("partition_template")
+            .unwrap()
+            .unwrap();
+        let table_template_parts: Vec<_> = partition_template.parts().collect();
+        assert_eq!(table_template_parts.len(), 1);
+        assert_matches!(
+            table_template_parts[0],
+            TemplatePart::TagValue(tag) if tag == "chemical"
+        );
+
+        // # Table template true, namespace template true
+        //
+        // When creating a table through the catalog functions *with* a custom table template in
+        // a namespace *with* a custom partition template,
+        let custom_table_template = proto::PartitionTemplate {
+            parts: vec![proto::TemplatePart {
+                part: Some(proto::template_part::Part::TagValue("vegetable".into())),
+            }],
+        };
+        let table_with_template_with_namespace_template = repos
+            .tables()
+            .create(
+                "nectarine",
+                TablePartitionTemplateOverride::new(
+                    Some(custom_table_template), // with custom partition template
+                    &namespace_custom_template.partition_template,
+                ),
+                namespace_custom_template.id,
+            )
+            .await
+            .unwrap();
+
+        // it should have the custom table template
+        let table_template_parts: Vec<_> = table_with_template_with_namespace_template
+            .partition_template
+            .parts()
+            .collect();
+        assert_eq!(table_template_parts.len(), 1);
+        assert_matches!(
+            table_template_parts[0],
+            TemplatePart::TagValue(tag) if tag == "vegetable"
+        );
+
+        // and store that value in the database record.
+        let record = sqlx::query("SELECT name, partition_template FROM table_name WHERE id = $1;")
+            .bind(table_with_template_with_namespace_template.id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        let name: String = record.try_get("name").unwrap();
+        assert_eq!(table_with_template_with_namespace_template.name, name);
+        let partition_template = record
+            .try_get::<Option<TablePartitionTemplateOverride>, _>("partition_template")
+            .unwrap()
+            .unwrap();
+        let table_template_parts: Vec<_> = partition_template.parts().collect();
+        assert_eq!(table_template_parts.len(), 1);
+        assert_matches!(
+            table_template_parts[0],
+            TemplatePart::TagValue(tag) if tag == "vegetable"
+        );
+
+        // # Table template false, namespace template false
+        //
+        // When creating a table through the catalog functions *without* a custom table template in
+        // a namespace *without* a custom partition template,
+        let table_no_template_no_namespace_template = repos
+            .tables()
+            .create(
+                "grapefruit",
+                TablePartitionTemplateOverride::new(
+                    None, // no custom partition template
+                    &namespace_default_template.partition_template,
+                ),
+                namespace_default_template.id,
+            )
+            .await
+            .unwrap();
+
+        // it should have the default template in the application,
+        assert_eq!(
+            table_no_template_no_namespace_template.partition_template,
+            TablePartitionTemplateOverride::default()
+        );
+
+        // and store NULL in the database record.
+        let record = sqlx::query("SELECT name, partition_template FROM table_name WHERE id = $1;")
+            .bind(table_no_template_no_namespace_template.id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        let name: String = record.try_get("name").unwrap();
+        assert_eq!(table_no_template_no_namespace_template.name, name);
+        let partition_template: Option<TablePartitionTemplateOverride> =
+            record.try_get("partition_template").unwrap();
+        assert!(partition_template.is_none());
     }
 }

--- a/iox_catalog/src/sqlite.rs
+++ b/iox_catalog/src/sqlite.rs
@@ -264,8 +264,6 @@ impl NamespaceRepo for SqliteTxn {
         partition_template: Option<NamespacePartitionTemplateOverride>,
         retention_period_ns: Option<i64>,
     ) -> Result<Namespace> {
-        let partition_template = partition_template.unwrap_or_default();
-
         let rec = sqlx::query_as::<_, Namespace>(
             r#"
 INSERT INTO namespace ( name, topic_id, query_pool_id, retention_period_ns, max_tables, partition_template )
@@ -1492,6 +1490,8 @@ mod tests {
     use super::*;
     use crate::test_helpers::{arbitrary_namespace, arbitrary_table};
     use assert_matches::assert_matches;
+    use data_types::TemplatePart;
+    use generated_types::influxdata::iox::partition_template::v1 as proto;
     use metric::{Attributes, DurationHistogram, Metric};
     use std::sync::Arc;
 
@@ -1799,5 +1799,415 @@ mod tests {
                 .await
                 .expect("fetch total file size failed");
         assert_eq!(total_file_size_bytes, 1337 * 2);
+    }
+
+    #[tokio::test]
+    async fn namespace_partition_template_null_is_the_default_in_the_database() {
+        let sqlite = setup_db().await;
+        let pool = sqlite.pool.clone();
+        let sqlite: Arc<dyn Catalog> = Arc::new(sqlite);
+        let mut repos = sqlite.repositories().await;
+
+        let namespace_name = "apples";
+
+        // Create a namespace record in the database that has `NULL` for its `partition_template`
+        // value, which is what records existing before the migration adding that column will have.
+        let insert_null_partition_template_namespace = sqlx::query(
+            r#"
+INSERT INTO namespace (
+    name, topic_id, query_pool_id, retention_period_ns, max_tables, partition_template
+)
+VALUES ( $1, $2, $3, $4, $5, NULL )
+RETURNING id, name, retention_period_ns, max_tables, max_columns_per_table, deleted_at,
+          partition_template;
+            "#,
+        )
+        .bind(namespace_name) // $1
+        .bind(SHARED_TOPIC_ID) // $2
+        .bind(SHARED_QUERY_POOL_ID) // $3
+        .bind(None::<Option<i64>>) // $4
+        .bind(DEFAULT_MAX_TABLES); // $5
+
+        insert_null_partition_template_namespace
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+
+        let lookup_namespace = repos
+            .namespaces()
+            .get_by_name(namespace_name, SoftDeletedRows::ExcludeDeleted)
+            .await
+            .unwrap()
+            .unwrap();
+        // When fetching this namespace from the database, the `FromRow` impl should set its
+        // `partition_template` to the default.
+        assert_eq!(
+            lookup_namespace.partition_template,
+            NamespacePartitionTemplateOverride::default()
+        );
+
+        // When creating a namespace through the catalog functions without specifying a custom
+        // partition template,
+        let created_without_custom_template = repos
+            .namespaces()
+            .create(
+                &"lemons".try_into().unwrap(),
+                None, // no partition template
+                None,
+            )
+            .await
+            .unwrap();
+
+        // it should have the default template in the application,
+        assert_eq!(
+            created_without_custom_template.partition_template,
+            NamespacePartitionTemplateOverride::default()
+        );
+
+        // and store NULL in the database record.
+        let record = sqlx::query("SELECT name, partition_template FROM namespace WHERE id = $1;")
+            .bind(created_without_custom_template.id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        let name: String = record.try_get("name").unwrap();
+        assert_eq!(created_without_custom_template.name, name);
+        let partition_template: Option<NamespacePartitionTemplateOverride> =
+            record.try_get("partition_template").unwrap();
+        assert!(partition_template.is_none());
+
+        // When explicitly setting a template that happens to be equal to the application default,
+        // assume it's important that it's being specially requested and store it rather than NULL.
+        let namespace_custom_template_name = "kumquats";
+        let custom_partition_template_equal_to_default =
+            NamespacePartitionTemplateOverride::from(proto::PartitionTemplate {
+                parts: vec![proto::TemplatePart {
+                    part: Some(proto::template_part::Part::TimeFormat(
+                        "%Y-%m-%d".to_owned(),
+                    )),
+                }],
+            });
+        let namespace_custom_template = repos
+            .namespaces()
+            .create(
+                &namespace_custom_template_name.try_into().unwrap(),
+                Some(custom_partition_template_equal_to_default.clone()),
+                None,
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            namespace_custom_template.partition_template,
+            custom_partition_template_equal_to_default
+        );
+        let record = sqlx::query("SELECT name, partition_template FROM namespace WHERE id = $1;")
+            .bind(namespace_custom_template.id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        let name: String = record.try_get("name").unwrap();
+        assert_eq!(namespace_custom_template.name, name);
+        let partition_template: Option<NamespacePartitionTemplateOverride> =
+            record.try_get("partition_template").unwrap();
+        assert_eq!(
+            partition_template.unwrap(),
+            custom_partition_template_equal_to_default
+        );
+    }
+
+    #[tokio::test]
+    async fn table_partition_template_null_is_the_default_in_the_database() {
+        let sqlite = setup_db().await;
+        let pool = sqlite.pool.clone();
+        let sqlite: Arc<dyn Catalog> = Arc::new(sqlite);
+        let mut repos = sqlite.repositories().await;
+
+        let namespace_default_template_name = "oranges";
+        let namespace_default_template = repos
+            .namespaces()
+            .create(
+                &namespace_default_template_name.try_into().unwrap(),
+                None, // no partition template
+                None,
+            )
+            .await
+            .unwrap();
+
+        let namespace_custom_template_name = "limes";
+        let namespace_custom_template = repos
+            .namespaces()
+            .create(
+                &namespace_custom_template_name.try_into().unwrap(),
+                Some(NamespacePartitionTemplateOverride::from(
+                    proto::PartitionTemplate {
+                        parts: vec![proto::TemplatePart {
+                            part: Some(proto::template_part::Part::TimeFormat("year-%Y".into())),
+                        }],
+                    },
+                )),
+                None,
+            )
+            .await
+            .unwrap();
+
+        // In a namespace that also has a NULL template, create a table record in the database that
+        // has `NULL` for its `partition_template` value, which is what records existing before the
+        // migration adding that column will have.
+        let table_name = "null_template";
+        let insert_null_partition_template_table = sqlx::query(
+            r#"
+INSERT INTO table_name ( name, namespace_id, partition_template )
+VALUES ( $1, $2, NULL )
+RETURNING *;
+            "#,
+        )
+        .bind(table_name) // $1
+        .bind(namespace_default_template.id); // $2
+
+        insert_null_partition_template_table
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+
+        let lookup_table = repos
+            .tables()
+            .get_by_namespace_and_name(namespace_default_template.id, table_name)
+            .await
+            .unwrap()
+            .unwrap();
+        // When fetching this table from the database, the `FromRow` impl should set its
+        // `partition_template` to the system default (because the namespace didn't have a template
+        // either).
+        assert_eq!(
+            lookup_table.partition_template,
+            TablePartitionTemplateOverride::default()
+        );
+
+        // In a namespace that has a custom template, create a table record in the database that
+        // has `NULL` for its `partition_template` value.
+        //
+        // THIS ACTUALLY SHOULD BE IMPOSSIBLE because:
+        //
+        // * Namespaces have to exist before tables
+        // * `partition_tables` are immutable on both namespaces and tables
+        // * When the migration adding the `partition_table` column is deployed, namespaces can
+        //   begin to be created with `partition_templates`
+        // * *Then* tables can be created with `partition_templates` or not
+        // * When tables don't get a custom table partition template but their namespace has one,
+        //   their database record will get the namespace partition template.
+        //
+        // In other words, table `partition_template` values in the database is allowed to possibly
+        // be `NULL` IFF their namespace's `partition_template` is `NULL`.
+        //
+        // That said, this test creates this hopefully-impossible scenario to ensure that the
+        // defined, expected behavior if a table record somehow exists in the database with a `NULL`
+        // `partition_template` value is that it will have the application default partition
+        // template *even if the namespace `partition_template` is not null*.
+        let table_name = "null_template";
+        let insert_null_partition_template_table = sqlx::query(
+            r#"
+INSERT INTO table_name ( name, namespace_id, partition_template )
+VALUES ( $1, $2, NULL )
+RETURNING *;
+            "#,
+        )
+        .bind(table_name) // $1
+        .bind(namespace_custom_template.id); // $2
+
+        insert_null_partition_template_table
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+
+        let lookup_table = repos
+            .tables()
+            .get_by_namespace_and_name(namespace_custom_template.id, table_name)
+            .await
+            .unwrap()
+            .unwrap();
+        // When fetching this table from the database, the `FromRow` impl should set its
+        // `partition_template` to the system default *even though the namespace has a
+        // template*, because this should be impossible as detailed above.
+        assert_eq!(
+            lookup_table.partition_template,
+            TablePartitionTemplateOverride::default()
+        );
+
+        // # Table template false, namespace template true
+        //
+        // When creating a table through the catalog functions *without* a custom table template in
+        // a namespace *with* a custom partition template,
+        let table_no_template_with_namespace_template = repos
+            .tables()
+            .create(
+                "pomelo",
+                TablePartitionTemplateOverride::new(
+                    None, // no custom partition template
+                    &namespace_custom_template.partition_template,
+                ),
+                namespace_custom_template.id,
+            )
+            .await
+            .unwrap();
+
+        // it should have the namespace's template
+        assert_eq!(
+            table_no_template_with_namespace_template.partition_template,
+            TablePartitionTemplateOverride::from(&namespace_custom_template.partition_template)
+        );
+
+        // and store that value in the database record.
+        let record = sqlx::query("SELECT name, partition_template FROM table_name WHERE id = $1;")
+            .bind(table_no_template_with_namespace_template.id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        let name: String = record.try_get("name").unwrap();
+        assert_eq!(table_no_template_with_namespace_template.name, name);
+        let partition_template: Option<TablePartitionTemplateOverride> =
+            record.try_get("partition_template").unwrap();
+        assert_eq!(
+            partition_template.unwrap(),
+            TablePartitionTemplateOverride::from(&namespace_custom_template.partition_template)
+        );
+
+        // # Table template true, namespace template false
+        //
+        // When creating a table through the catalog functions *with* a custom table template in
+        // a namespace *without* a custom partition template,
+        let custom_table_template = proto::PartitionTemplate {
+            parts: vec![proto::TemplatePart {
+                part: Some(proto::template_part::Part::TagValue("chemical".into())),
+            }],
+        };
+        let table_with_template_no_namespace_template = repos
+            .tables()
+            .create(
+                "tangerine",
+                TablePartitionTemplateOverride::new(
+                    Some(custom_table_template), // with custom partition template
+                    &namespace_default_template.partition_template,
+                ),
+                namespace_default_template.id,
+            )
+            .await
+            .unwrap();
+
+        // it should have the custom table template
+        let table_template_parts: Vec<_> = table_with_template_no_namespace_template
+            .partition_template
+            .parts()
+            .collect();
+        assert_eq!(table_template_parts.len(), 1);
+        assert_matches!(
+            table_template_parts[0],
+            TemplatePart::TagValue(tag) if tag == "chemical"
+        );
+
+        // and store that value in the database record.
+        let record = sqlx::query("SELECT name, partition_template FROM table_name WHERE id = $1;")
+            .bind(table_with_template_no_namespace_template.id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        let name: String = record.try_get("name").unwrap();
+        assert_eq!(table_with_template_no_namespace_template.name, name);
+        let partition_template = record
+            .try_get::<Option<TablePartitionTemplateOverride>, _>("partition_template")
+            .unwrap()
+            .unwrap();
+        let table_template_parts: Vec<_> = partition_template.parts().collect();
+        assert_eq!(table_template_parts.len(), 1);
+        assert_matches!(
+            table_template_parts[0],
+            TemplatePart::TagValue(tag) if tag == "chemical"
+        );
+
+        // # Table template true, namespace template true
+        //
+        // When creating a table through the catalog functions *with* a custom table template in
+        // a namespace *with* a custom partition template,
+        let custom_table_template = proto::PartitionTemplate {
+            parts: vec![proto::TemplatePart {
+                part: Some(proto::template_part::Part::TagValue("vegetable".into())),
+            }],
+        };
+        let table_with_template_with_namespace_template = repos
+            .tables()
+            .create(
+                "nectarine",
+                TablePartitionTemplateOverride::new(
+                    Some(custom_table_template), // with custom partition template
+                    &namespace_custom_template.partition_template,
+                ),
+                namespace_custom_template.id,
+            )
+            .await
+            .unwrap();
+
+        // it should have the custom table template
+        let table_template_parts: Vec<_> = table_with_template_with_namespace_template
+            .partition_template
+            .parts()
+            .collect();
+        assert_eq!(table_template_parts.len(), 1);
+        assert_matches!(
+            table_template_parts[0],
+            TemplatePart::TagValue(tag) if tag == "vegetable"
+        );
+
+        // and store that value in the database record.
+        let record = sqlx::query("SELECT name, partition_template FROM table_name WHERE id = $1;")
+            .bind(table_with_template_with_namespace_template.id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        let name: String = record.try_get("name").unwrap();
+        assert_eq!(table_with_template_with_namespace_template.name, name);
+        let partition_template = record
+            .try_get::<Option<TablePartitionTemplateOverride>, _>("partition_template")
+            .unwrap()
+            .unwrap();
+        let table_template_parts: Vec<_> = partition_template.parts().collect();
+        assert_eq!(table_template_parts.len(), 1);
+        assert_matches!(
+            table_template_parts[0],
+            TemplatePart::TagValue(tag) if tag == "vegetable"
+        );
+
+        // # Table template false, namespace template false
+        //
+        // When creating a table through the catalog functions *without* a custom table template in
+        // a namespace *without* a custom partition template,
+        let table_no_template_no_namespace_template = repos
+            .tables()
+            .create(
+                "grapefruit",
+                TablePartitionTemplateOverride::new(
+                    None, // no custom partition template
+                    &namespace_default_template.partition_template,
+                ),
+                namespace_default_template.id,
+            )
+            .await
+            .unwrap();
+
+        // it should have the default template in the application,
+        assert_eq!(
+            table_no_template_no_namespace_template.partition_template,
+            TablePartitionTemplateOverride::default()
+        );
+
+        // and store NULL in the database record.
+        let record = sqlx::query("SELECT name, partition_template FROM table_name WHERE id = $1;")
+            .bind(table_no_template_no_namespace_template.id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        let name: String = record.try_get("name").unwrap();
+        assert_eq!(table_no_template_no_namespace_template.name, name);
+        let partition_template: Option<TablePartitionTemplateOverride> =
+            record.try_get("partition_template").unwrap();
+        assert!(partition_template.is_none());
     }
 }

--- a/iox_catalog/src/sqlite.rs
+++ b/iox_catalog/src/sqlite.rs
@@ -2053,7 +2053,10 @@ RETURNING *;
         // it should have the namespace's template
         assert_eq!(
             table_no_template_with_namespace_template.partition_template,
-            TablePartitionTemplateOverride::from(&namespace_custom_template.partition_template)
+            TablePartitionTemplateOverride::new(
+                None,
+                &namespace_custom_template.partition_template
+            )
         );
 
         // and store that value in the database record.
@@ -2068,7 +2071,10 @@ RETURNING *;
             record.try_get("partition_template").unwrap();
         assert_eq!(
             partition_template.unwrap(),
-            TablePartitionTemplateOverride::from(&namespace_custom_template.partition_template)
+            TablePartitionTemplateOverride::new(
+                None,
+                &namespace_custom_template.partition_template
+            )
         );
 
         // # Table template true, namespace template false

--- a/iox_tests/src/builders.rs
+++ b/iox_tests/src/builders.rs
@@ -121,6 +121,7 @@ impl TableBuilder {
                 id: TableId::new(id),
                 namespace_id: NamespaceId::new(0),
                 name: "table".to_string(),
+                partition_template: Default::default(),
             },
         }
     }

--- a/iox_tests/src/catalog.rs
+++ b/iox_tests/src/catalog.rs
@@ -148,7 +148,7 @@ impl TestCatalog {
         let namespace_name = NamespaceName::new(name).unwrap();
         let namespace = repos
             .namespaces()
-            .create(&namespace_name, retention_period_ns)
+            .create(&namespace_name, None, retention_period_ns)
             .await
             .unwrap();
 

--- a/iox_tests/src/catalog.rs
+++ b/iox_tests/src/catalog.rs
@@ -334,7 +334,7 @@ impl TestTable {
     pub async fn catalog_schema(&self) -> TableSchema {
         TableSchema {
             id: self.table.id,
-            partition_template: None,
+            partition_template: Default::default(),
             columns: self.catalog_columns().await,
         }
     }

--- a/ioxd_router/src/lib.rs
+++ b/ioxd_router/src/lib.rs
@@ -413,7 +413,6 @@ mod tests {
 
         let mut repos = catalog.repositories().await;
         let namespace = arbitrary_namespace(&mut *repos, "test_ns").await;
-
         let table = arbitrary_table(&mut *repos, "name", &namespace).await;
         let _column = repos
             .columns()

--- a/ioxd_router/src/lib.rs
+++ b/ioxd_router/src/lib.rs
@@ -274,7 +274,7 @@ pub async fn create_router_server_type(
     //
     // Add a write partitioner into the handler stack that splits by the date
     // portion of the write's timestamp (the default table partition template)
-    let partitioner = Partitioner::new();
+    let partitioner = Partitioner::default();
     let partitioner = InstrumentationDecorator::new("partitioner", &metrics, partitioner);
 
     // # Namespace resolver

--- a/ioxd_router/src/lib.rs
+++ b/ioxd_router/src/lib.rs
@@ -22,7 +22,7 @@ use std::{
 use async_trait::async_trait;
 use authz::{Authorizer, AuthorizerInstrumentation, IoxAuthorizer};
 use clap_blocks::router::RouterConfig;
-use data_types::{DefaultPartitionTemplate, NamespaceName};
+use data_types::NamespaceName;
 use hashbrown::HashMap;
 use hyper::{Body, Request, Response};
 use iox_catalog::interface::Catalog;
@@ -273,8 +273,8 @@ pub async fn create_router_server_type(
     // # Write partitioner
     //
     // Add a write partitioner into the handler stack that splits by the date
-    // portion of the write's timestamp (the default [`PartitionTemplate`]).
-    let partitioner = Partitioner::new(DefaultPartitionTemplate::default());
+    // portion of the write's timestamp (the default table partition template)
+    let partitioner = Partitioner::new();
     let partitioner = InstrumentationDecorator::new("partitioner", &metrics, partitioner);
 
     // # Namespace resolver

--- a/mutable_batch/src/payload.rs
+++ b/mutable_batch/src/payload.rs
@@ -1,7 +1,7 @@
 //! Write payload abstractions derived from [`MutableBatch`]
 
 use crate::{column::ColumnData, MutableBatch, Result};
-use data_types::{PartitionKey, PartitionTemplate};
+use data_types::{PartitionKey, TablePartitionTemplateOverride};
 use hashbrown::HashMap;
 use schema::TIME_COLUMN_NAME;
 use std::{num::NonZeroUsize, ops::Range};
@@ -97,10 +97,10 @@ impl<'a> PartitionWrite<'a> {
     }
 
     /// Create a collection of [`PartitionWrite`] indexed by partition key
-    /// from a [`MutableBatch`] and [`PartitionTemplate`]
+    /// from a [`MutableBatch`] and [`TablePartitionTemplateOverride`]
     pub fn partition(
         batch: &'a MutableBatch,
-        partition_template: &PartitionTemplate,
+        partition_template: &TablePartitionTemplateOverride,
     ) -> HashMap<PartitionKey, Self> {
         use hashbrown::hash_map::Entry;
         let time = get_time_column(batch);

--- a/mutable_batch/tests/writer_fuzz.rs
+++ b/mutable_batch/tests/writer_fuzz.rs
@@ -14,7 +14,7 @@ use arrow::{
     record_batch::RecordBatch,
 };
 use arrow_util::bitset::BitSet;
-use data_types::{IsNan, PartitionTemplate, StatValues, Statistics, TemplatePart};
+use data_types::{test_table_partition_override, IsNan, StatValues, Statistics, TemplatePart};
 use hashbrown::HashSet;
 use mutable_batch::{writer::Writer, MutableBatch, PartitionWrite, WritePayload};
 use rand::prelude::*;
@@ -432,12 +432,10 @@ fn test_partition_write() {
         assert_eq!(write.rows().get() as u64, stats.total_count);
     };
 
-    let partitioned = PartitionWrite::partition(
-        &batch,
-        &PartitionTemplate {
-            parts: vec![TemplatePart::TagValue("b1".to_string())],
-        },
-    );
+    let table_partition_template =
+        test_table_partition_override(vec![TemplatePart::TagValue("b1")]);
+
+    let partitioned = PartitionWrite::partition(&batch, &table_partition_template);
 
     for (_, write) in &partitioned {
         verify_write(write);

--- a/mutable_batch/tests/writer_fuzz.rs
+++ b/mutable_batch/tests/writer_fuzz.rs
@@ -433,7 +433,7 @@ fn test_partition_write() {
     };
 
     let table_partition_template =
-        test_table_partition_override(vec![TemplatePart::TagValue("b1")]);
+        test_table_partition_override(vec![TemplatePart::TagValue("t1")]);
 
     let partitioned = PartitionWrite::partition(&batch, &table_partition_template);
 

--- a/mutable_batch/tests/writer_fuzz.rs
+++ b/mutable_batch/tests/writer_fuzz.rs
@@ -435,7 +435,7 @@ fn test_partition_write() {
     let partitioned = PartitionWrite::partition(
         &batch,
         &PartitionTemplate {
-            parts: vec![TemplatePart::Column("b1".to_string())],
+            parts: vec![TemplatePart::TagValue("b1".to_string())],
         },
     );
 

--- a/mutable_batch_pb/tests/encode.rs
+++ b/mutable_batch_pb/tests/encode.rs
@@ -1,5 +1,5 @@
 use arrow_util::assert_batches_eq;
-use data_types::{PartitionKey, PARTITION_BY_DAY};
+use data_types::PartitionKey;
 use mutable_batch::{writer::Writer, MutableBatch, PartitionWrite, WritePayload};
 use mutable_batch_pb::{decode::write_table_batch, encode::encode_batch};
 use schema::Projection;
@@ -120,7 +120,7 @@ fn test_encode_decode_null_columns_issue_4272() {
         .unwrap();
     writer.commit();
 
-    let mut partitions = PartitionWrite::partition(&batch, &PARTITION_BY_DAY);
+    let mut partitions = PartitionWrite::partition(&batch, &Default::default());
 
     // There should be two partitions, one with for the timestamp 160, and
     // one for the other timestamp.

--- a/router/src/dml_handlers/instrumentation.rs
+++ b/router/src/dml_handlers/instrumentation.rs
@@ -109,7 +109,7 @@ mod tests {
             max_columns_per_table: 500,
             max_tables: 200,
             retention_period_ns: None,
-            partition_template: None,
+            partition_template: Default::default(),
         })
     }
 

--- a/router/src/dml_handlers/partitioner.rs
+++ b/router/src/dml_handlers/partitioner.rs
@@ -49,21 +49,8 @@ impl<T> Partitioned<T> {
 ///
 /// A vector of partitions are returned to the caller, or the first error that
 /// occurs during partitioning.
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct Partitioner {}
-
-impl Partitioner {
-    /// Initialise a new [`Partitioner`].
-    pub fn new() -> Self {
-        Self {}
-    }
-}
-
-impl Default for Partitioner {
-    fn default() -> Self {
-        Self::new()
-    }
-}
 
 #[async_trait]
 impl DmlHandler for Partitioner {
@@ -156,7 +143,7 @@ mod tests {
             paste::paste! {
                 #[tokio::test]
                 async fn [<test_write_ $name>]() {
-                    let partitioner = Partitioner::new();
+                    let partitioner = Partitioner::default();
                     let ns = NamespaceName::new("bananas").expect("valid db name");
 
                     let writes = lp_to_writes($lp);
@@ -311,7 +298,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_write_table_partition_template() {
-        let partitioner = Partitioner::new();
+        let partitioner = Partitioner::default();
         let ns = NamespaceName::new("bananas").expect("valid db name");
 
         let namespace_schema = namespace_schema(42);

--- a/router/src/dml_handlers/rpc_write.rs
+++ b/router/src/dml_handlers/rpc_write.rs
@@ -385,7 +385,7 @@ mod tests {
             max_columns_per_table: 500,
             max_tables: 200,
             retention_period_ns: None,
-            partition_template: None,
+            partition_template: Default::default(),
         })
     }
 

--- a/router/src/dml_handlers/schema_validation.rs
+++ b/router/src/dml_handlers/schema_validation.rs
@@ -144,15 +144,8 @@ where
 
     // Accepts a map of TableName -> MutableBatch
     type WriteInput = HashMap<String, MutableBatch>;
-    // And returns a map of TableId -> (TableName, OptionalTablePartitionTemplate, MutableBatch)
-    type WriteOutput = HashMap<
-        TableId,
-        (
-            String,
-            Option<Arc<TablePartitionTemplateOverride>>,
-            MutableBatch,
-        ),
-    >;
+    // And returns a map of TableId -> (TableName, TablePartitionTemplate, MutableBatch)
+    type WriteOutput = HashMap<TableId, (String, TablePartitionTemplateOverride, MutableBatch)>;
 
     /// Validate the schema of all the writes in `batches`.
     ///
@@ -292,7 +285,7 @@ where
             }
         };
 
-        // Map the "TableName -> Data" into "TableId -> (TableName, OptionalTablePartitionTemplate,
+        // Map the "TableName -> Data" into "TableId -> (TableName, TablePartitionTemplate,
         // Data)" for downstream handlers.
         let batches = batches
             .into_iter()

--- a/router/src/namespace_cache/memory.rs
+++ b/router/src/namespace_cache/memory.rs
@@ -198,6 +198,16 @@ mod tests {
         );
     }
 
+    // In production code, a `TableSchema` should come from a `Table` that came from the catalog,
+    // but these tests are independent of the catalog.
+    fn empty_table_schema(id: TableId) -> TableSchema {
+        TableSchema {
+            id,
+            partition_template: Default::default(),
+            columns: ColumnsByName::new([]),
+        }
+    }
+
     #[tokio::test]
     async fn test_put_additive_merge_columns() {
         let ns = NamespaceName::new("arán").expect("namespace name is valid");
@@ -219,9 +229,9 @@ mod tests {
             column_type: ColumnType::String,
         };
 
-        let mut first_write_table_schema = TableSchema::new(table_id);
+        let mut first_write_table_schema = empty_table_schema(table_id);
         first_write_table_schema.add_column(column_1.clone());
-        let mut second_write_table_schema = TableSchema::new(table_id);
+        let mut second_write_table_schema = empty_table_schema(table_id);
         second_write_table_schema.add_column(column_2.clone());
 
         // These MUST always be different
@@ -241,7 +251,7 @@ mod tests {
         };
 
         let want_namespace_schema = {
-            let mut want_table_schema = TableSchema::new(table_id);
+            let mut want_table_schema = empty_table_schema(table_id);
             want_table_schema.add_column(column_1);
             want_table_schema.add_column(column_2);
             NamespaceSchema {
@@ -293,21 +303,21 @@ mod tests {
         //
         // Each table has been given a column to assert the table merge logic
         // produces the correct metrics.
-        let mut table_1 = TableSchema::new(TableId::new(1));
+        let mut table_1 = empty_table_schema(TableId::new(1));
         table_1.add_column(Column {
             id: ColumnId::new(1),
             table_id: TableId::new(1),
             name: "column_a".to_string(),
             column_type: ColumnType::String,
         });
-        let mut table_2 = TableSchema::new(TableId::new(2));
+        let mut table_2 = empty_table_schema(TableId::new(2));
         table_2.add_column(Column {
             id: ColumnId::new(2),
             table_id: TableId::new(2),
             name: "column_b".to_string(),
             column_type: ColumnType::String,
         });
-        let mut table_3 = TableSchema::new(TableId::new(3));
+        let mut table_3 = empty_table_schema(TableId::new(3));
         table_3.add_column(Column {
             id: ColumnId::new(3),
             table_id: TableId::new(3),
@@ -404,7 +414,7 @@ mod tests {
             let columns = ColumnsByName::from(columns);
             TableSchema {
                 id: TableId::new(id),
-                partition_template: None,
+                partition_template: Default::default(),
                 columns,
             }
         }

--- a/router/src/namespace_cache/memory.rs
+++ b/router/src/namespace_cache/memory.rs
@@ -168,7 +168,7 @@ mod tests {
             max_columns_per_table: 50,
             max_tables: 24,
             retention_period_ns: Some(876),
-            partition_template: None,
+            partition_template: Default::default(),
         };
         assert_matches!(cache.put_schema(ns.clone(), schema1.clone()), (new, s) => {
             assert_eq!(*new, schema1);
@@ -185,7 +185,7 @@ mod tests {
             max_columns_per_table: 10,
             max_tables: 42,
             retention_period_ns: Some(876),
-            partition_template: None,
+            partition_template: Default::default(),
         };
 
         assert_matches!(cache.put_schema(ns.clone(), schema2.clone()), (new, s) => {
@@ -233,7 +233,7 @@ mod tests {
             max_columns_per_table: 50,
             max_tables: 24,
             retention_period_ns: None,
-            partition_template: None,
+            partition_template: Default::default(),
         };
         let schema_update_2 = NamespaceSchema {
             tables: BTreeMap::from([(String::from(table_name), second_write_table_schema)]),
@@ -324,7 +324,7 @@ mod tests {
             max_columns_per_table: 50,
             max_tables: 24,
             retention_period_ns: None,
-            partition_template: None,
+            partition_template: Default::default(),
         };
         let schema_update_2 = NamespaceSchema {
             tables: BTreeMap::from([
@@ -428,7 +428,7 @@ mod tests {
                 max_columns_per_table,
                 max_tables,
                 retention_period_ns,
-                partition_template: None,
+                partition_template: Default::default(),
             }
         }
     }

--- a/router/src/namespace_cache/metrics.rs
+++ b/router/src/namespace_cache/metrics.rs
@@ -155,7 +155,7 @@ mod tests {
                     i.to_string(),
                     TableSchema {
                         id: TableId::new(i as _),
-                        partition_template: None,
+                        partition_template: Default::default(),
                         columns: ColumnsByName::new(columns),
                     },
                 )

--- a/router/src/namespace_cache/metrics.rs
+++ b/router/src/namespace_cache/metrics.rs
@@ -168,7 +168,7 @@ mod tests {
             max_columns_per_table: 100,
             max_tables: 42,
             retention_period_ns: None,
-            partition_template: None,
+            partition_template: Default::default(),
         }
     }
 

--- a/router/src/namespace_cache/read_through_cache.rs
+++ b/router/src/namespace_cache/read_through_cache.rs
@@ -124,7 +124,7 @@ mod tests {
             max_columns_per_table: iox_catalog::DEFAULT_MAX_COLUMNS_PER_TABLE as usize,
             max_tables: iox_catalog::DEFAULT_MAX_TABLES as usize,
             retention_period_ns: iox_catalog::DEFAULT_RETENTION_PERIOD,
-            partition_template: None,
+            partition_template: Default::default(),
         };
         assert_matches!(cache.put_schema(ns.clone(), schema1.clone()), (result, _) => {
             assert_eq!(*result, schema1);
@@ -160,7 +160,7 @@ mod tests {
             max_columns_per_table: iox_catalog::DEFAULT_MAX_COLUMNS_PER_TABLE as usize,
             max_tables: iox_catalog::DEFAULT_MAX_TABLES as usize,
             retention_period_ns: iox_catalog::DEFAULT_RETENTION_PERIOD,
-            partition_template: None,
+            partition_template: Default::default(),
         };
 
         assert_matches!(
@@ -168,7 +168,7 @@ mod tests {
                 .repositories()
                 .await
                 .namespaces()
-                .create(&ns, iox_catalog::DEFAULT_RETENTION_PERIOD,)
+                .create(&ns, None, iox_catalog::DEFAULT_RETENTION_PERIOD,)
                 .await,
             Ok(_)
         );

--- a/router/src/namespace_cache/sharded_cache.rs
+++ b/router/src/namespace_cache/sharded_cache.rs
@@ -74,7 +74,7 @@ mod tests {
             max_columns_per_table: 7,
             max_tables: 42,
             retention_period_ns: None,
-            partition_template: None,
+            partition_template: Default::default(),
         }
     }
 

--- a/router/src/namespace_resolver.rs
+++ b/router/src/namespace_resolver.rs
@@ -100,7 +100,7 @@ mod tests {
                 max_columns_per_table: 4,
                 max_tables: 42,
                 retention_period_ns: None,
-                partition_template: None,
+                partition_template: Default::default(),
             },
         );
 
@@ -144,7 +144,7 @@ mod tests {
             let mut repos = catalog.repositories().await;
             repos
                 .namespaces()
-                .create(&ns, None)
+                .create(&ns, None, None)
                 .await
                 .expect("failed to setup catalog state");
         }
@@ -176,7 +176,7 @@ mod tests {
             let mut repos = catalog.repositories().await;
             repos
                 .namespaces()
-                .create(&ns, None)
+                .create(&ns, None, None)
                 .await
                 .expect("failed to setup catalog state");
             repos

--- a/router/src/namespace_resolver/mock.rs
+++ b/router/src/namespace_resolver/mock.rs
@@ -45,7 +45,7 @@ fn new_empty_namespace_schema(id: NamespaceId) -> NamespaceSchema {
         max_columns_per_table: 500,
         max_tables: 200,
         retention_period_ns: None,
-        partition_template: None,
+        partition_template: Default::default(),
     }
 }
 

--- a/router/src/namespace_resolver/ns_autocreation.rs
+++ b/router/src/namespace_resolver/ns_autocreation.rs
@@ -107,7 +107,7 @@ where
                         .repositories()
                         .await
                         .namespaces()
-                        .create(namespace, retention_period_ns)
+                        .create(namespace, None, retention_period_ns)
                         .await
                     {
                         Ok(_) => {
@@ -171,7 +171,7 @@ mod tests {
                 max_columns_per_table: 4,
                 max_tables: 42,
                 retention_period_ns: None,
-                partition_template: None,
+                partition_template: Default::default(),
             },
         );
 
@@ -247,6 +247,7 @@ mod tests {
                 max_columns_per_table: iox_catalog::DEFAULT_MAX_COLUMNS_PER_TABLE,
                 retention_period_ns: TEST_RETENTION_PERIOD_NS,
                 deleted_at: None,
+                partition_template: Default::default(),
             }
         );
     }

--- a/router/tests/common/mod.rs
+++ b/router/tests/common/mod.rs
@@ -153,7 +153,7 @@ impl TestContext {
 
         let retention_validator = RetentionValidator::new();
 
-        let partitioner = Partitioner::new();
+        let partitioner = Partitioner::default();
 
         let namespace_resolver = NamespaceSchemaResolver::new(Arc::clone(&ns_cache));
         let namespace_resolver = NamespaceAutocreation::new(

--- a/router/tests/common/mod.rs
+++ b/router/tests/common/mod.rs
@@ -1,6 +1,6 @@
 use std::{iter, string::String, sync::Arc, time::Duration};
 
-use data_types::{DefaultPartitionTemplate, TableId};
+use data_types::TableId;
 use generated_types::influxdata::iox::ingester::v1::WriteRequest;
 use hashbrown::HashMap;
 use hyper::{Body, Request, Response};
@@ -153,7 +153,7 @@ impl TestContext {
 
         let retention_validator = RetentionValidator::new();
 
-        let partitioner = Partitioner::new(DefaultPartitionTemplate::default());
+        let partitioner = Partitioner::new();
 
         let namespace_resolver = NamespaceSchemaResolver::new(Arc::clone(&ns_cache));
         let namespace_resolver = NamespaceAutocreation::new(

--- a/router/tests/grpc.rs
+++ b/router/tests/grpc.rs
@@ -79,6 +79,7 @@ async fn test_namespace_create() {
     let req = CreateNamespaceRequest {
         name: "bananas_test".to_string(),
         retention_period_ns: Some(RETENTION),
+        partition_template: None,
     };
     let got = ctx
         .grpc_delegate()
@@ -151,6 +152,7 @@ async fn test_namespace_delete() {
     let req = CreateNamespaceRequest {
         name: "bananas_test".to_string(),
         retention_period_ns: Some(RETENTION),
+        partition_template: None,
     };
     let got = ctx
         .grpc_delegate()
@@ -280,6 +282,7 @@ async fn test_create_namespace_0_retention_period() {
     let req = CreateNamespaceRequest {
         name: "bananas_test".to_string(),
         retention_period_ns: Some(0), // A zero!
+        partition_template: None,
     };
     let got = ctx
         .grpc_delegate()
@@ -344,6 +347,7 @@ async fn test_create_namespace_negative_retention_period() {
     let req = CreateNamespaceRequest {
         name: "bananas_test".to_string(),
         retention_period_ns: Some(-42),
+        partition_template: None,
     };
     let err = ctx
         .grpc_delegate()
@@ -407,6 +411,7 @@ async fn test_update_namespace_0_retention_period() {
         .create_namespace(Request::new(CreateNamespaceRequest {
             name: "bananas_test".to_string(),
             retention_period_ns: Some(42),
+            partition_template: None,
         }))
         .await
         .expect("failed to create namespace")
@@ -512,6 +517,7 @@ async fn test_update_namespace_negative_retention_period() {
         .create_namespace(Request::new(CreateNamespaceRequest {
             name: "bananas_test".to_string(),
             retention_period_ns: Some(42),
+            partition_template: None,
         }))
         .await
         .expect("failed to create namespace")
@@ -781,6 +787,7 @@ async fn test_update_namespace_limit_0_max_tables_max_columns() {
         .create_namespace(Request::new(CreateNamespaceRequest {
             name: "bananas_test".to_string(),
             retention_period_ns: Some(0),
+            partition_template: None,
         }))
         .await
         .expect("failed to create namespace")

--- a/router/tests/http.rs
+++ b/router/tests/http.rs
@@ -278,7 +278,7 @@ async fn test_write_propagate_ids() {
                     .repositories()
                     .await
                     .tables()
-                    .create_or_get(t, ns.id)
+                    .create(t, ns.id)
                     .await
                     .unwrap();
                 (*t, table.id)

--- a/router/tests/http.rs
+++ b/router/tests/http.rs
@@ -278,7 +278,7 @@ async fn test_write_propagate_ids() {
                     .repositories()
                     .await
                     .tables()
-                    .create(t, ns.id)
+                    .create(t, Default::default(), ns.id)
                     .await
                     .unwrap();
                 (*t, table.id)

--- a/router/tests/http.rs
+++ b/router/tests/http.rs
@@ -349,6 +349,7 @@ async fn test_delete_unsupported() {
         .create(
             &data_types::NamespaceName::new("bananas_test").unwrap(),
             None,
+            None,
         )
         .await
         .expect("failed to update table limit");

--- a/service_grpc_namespace/src/lib.rs
+++ b/service_grpc_namespace/src/lib.rs
@@ -70,6 +70,7 @@ impl namespace_service_server::NamespaceService for NamespaceService {
         let CreateNamespaceRequest {
             name: namespace_name,
             retention_period_ns,
+            partition_template: _,
         } = request.into_inner();
 
         // Ensure the namespace name is consistently processed within IOx - this
@@ -363,6 +364,7 @@ mod tests {
         let req = CreateNamespaceRequest {
             name: NS_NAME.to_string(),
             retention_period_ns: Some(RETENTION),
+            partition_template: None,
         };
         let created_ns = handler
             .create_namespace(Request::new(req))
@@ -486,6 +488,7 @@ mod tests {
         let req = CreateNamespaceRequest {
             name: NS_NAME.to_string(),
             retention_period_ns: Some(RETENTION),
+            partition_template: None,
         };
         let created_ns = handler
             .create_namespace(Request::new(req))
@@ -545,6 +548,7 @@ mod tests {
                     let req = CreateNamespaceRequest {
                         name: String::from($name),
                         retention_period_ns: Some(RETENTION),
+                        partition_template: None,
                     };
 
                     let got = handler.create_namespace(Request::new(req)).await;


### PR DESCRIPTION
Connects to https://github.com/influxdata/idpe/issues/17266.

This stores custom templates for namespaces and tables in the database, if they're specified at namespace or table creation time (there are no catalog methods to allow for updating custom templates).

Table create now takes a table template. The table template can be created from a namespace template (and if a table is created implicitly through a write, it will use its namespace's partition template for this purpose) or from specified protobuf (and @domodwyer is working on the gRPC API that will make use of that feature).

Namespace create now optionally takes protobuf describing a partition template, and this PR hooks the `CreateNamespaceRequest` up to that. If no template is specified, the namespace gets the current partition-by-day default template. 

So if a table is created without a protobuf template in a namespace that was created without a protobuf template, the table will get the current partition-by-day default template through its namespace.

For existing namespace and table catalog records that have `NULL` for their `partition_template` columns, the `#[sqlx(default)]` will select the partition-by-day default template whenever these records are selected from the database. When we've backfilled all values in the database, the `#[sqlx(default)]` can be removed.

These commits are a touch messier than I'd like them to be; please tell me if I should clean them up more. Examples are: 

- some renames to match the what Dom did in https://github.com/influxdata/influxdb_iox/pull/7800 that I just mooshed in with another commit but really could be their own commit
- some intermediate state with the `TablePartitionTemplateOverride` added so that the namespace commit would compile that gets cleaned up in the table commit
- some intermediate changes to the `DefaultPartitionTemplate` and (application) `PartitionTemplate` types, and both those types end up being deleted by the end of the PR

I added a unit-ish type test for encoding the template types to JSON in the database, and I wanted to figure out how to write a similar test for decoding, but I can't figure out how to create a `sqlx::ValueRef` to pass in to `decode` without actually having a database :-/ Ideas extremely welcome!