### PR TITLE
refactor: Extract some catalog test helper methods to reduce places that need to change

### DIFF
--- a/garbage_collector/src/objectstore/checker.rs
+++ b/garbage_collector/src/objectstore/checker.rs
@@ -137,10 +137,10 @@ mod tests {
     use super::*;
     use chrono::TimeZone;
     use data_types::{
-        ColumnId, ColumnSet, CompactionLevel, NamespaceId, NamespaceName, ParquetFile,
-        ParquetFileParams, PartitionId, TableId, Timestamp,
+        ColumnId, ColumnSet, CompactionLevel, NamespaceId, ParquetFile, ParquetFileParams,
+        PartitionId, TableId, Timestamp,
     };
-    use iox_catalog::{interface::Catalog, mem::MemCatalog};
+    use iox_catalog::{interface::Catalog, mem::MemCatalog, test_helpers::arbitrary_namespace};
     use object_store::path::Path;
     use once_cell::sync::Lazy;
     use parquet_file::ParquetFilePath;
@@ -155,14 +155,7 @@ mod tests {
         let metric_registry = Arc::new(metric::Registry::new());
         let catalog = Arc::new(MemCatalog::new(Arc::clone(&metric_registry)));
         let mut repos = catalog.repositories().await;
-        let namespace = repos
-            .namespaces()
-            .create(
-                &NamespaceName::new("namespace_parquet_file_test").unwrap(),
-                None,
-            )
-            .await
-            .unwrap();
+        let namespace = arbitrary_namespace(&mut *repos, "namespace_parquet_file_test").await;
         let table = repos
             .tables()
             .create_or_get("test_table", namespace.id)

--- a/garbage_collector/src/objectstore/checker.rs
+++ b/garbage_collector/src/objectstore/checker.rs
@@ -140,7 +140,11 @@ mod tests {
         ColumnId, ColumnSet, CompactionLevel, NamespaceId, ParquetFile, ParquetFileParams,
         PartitionId, TableId, Timestamp,
     };
-    use iox_catalog::{interface::Catalog, mem::MemCatalog, test_helpers::arbitrary_namespace};
+    use iox_catalog::{
+        interface::Catalog,
+        mem::MemCatalog,
+        test_helpers::{arbitrary_namespace, arbitrary_table},
+    };
     use object_store::path::Path;
     use once_cell::sync::Lazy;
     use parquet_file::ParquetFilePath;
@@ -156,11 +160,7 @@ mod tests {
         let catalog = Arc::new(MemCatalog::new(Arc::clone(&metric_registry)));
         let mut repos = catalog.repositories().await;
         let namespace = arbitrary_namespace(&mut *repos, "namespace_parquet_file_test").await;
-        let table = repos
-            .tables()
-            .create_or_get("test_table", namespace.id)
-            .await
-            .unwrap();
+        let table = arbitrary_table(&mut *repos, "test_table", &namespace).await;
         let partition = repos
             .partitions()
             .create_or_get("one".into(), table.id)

--- a/import/src/aggregate_tsm_schema/update_catalog.rs
+++ b/import/src/aggregate_tsm_schema/update_catalog.rs
@@ -345,7 +345,7 @@ mod tests {
     use crate::{AggregateTSMField, AggregateTSMTag};
     use assert_matches::assert_matches;
     use data_types::{PartitionId, TableId};
-    use iox_catalog::mem::MemCatalog;
+    use iox_catalog::{mem::MemCatalog, test_helpers::arbitrary_namespace};
     use std::collections::HashSet;
 
     #[tokio::test]
@@ -428,11 +428,7 @@ mod tests {
             .await
             .expect("started transaction");
         // create namespace, table and columns for weather measurement
-        let namespace = txn
-            .namespaces()
-            .create(&NamespaceName::new("1234_5678").unwrap(), None)
-            .await
-            .expect("namespace created");
+        let namespace = arbitrary_namespace(&mut *txn, "1234_5678").await;
         let mut table = txn
             .tables()
             .create_or_get("weather", namespace.id)
@@ -520,11 +516,7 @@ mod tests {
             .await
             .expect("started transaction");
         // create namespace, table and columns for weather measurement
-        let namespace = txn
-            .namespaces()
-            .create(&NamespaceName::new("1234_5678").unwrap(), None)
-            .await
-            .expect("namespace created");
+        let namespace = arbitrary_namespace(&mut *txn, "1234_5678").await;
         let mut table = txn
             .tables()
             .create_or_get("weather", namespace.id)
@@ -585,11 +577,7 @@ mod tests {
             .expect("started transaction");
 
         // create namespace, table and columns for weather measurement
-        let namespace = txn
-            .namespaces()
-            .create(&NamespaceName::new("1234_5678").unwrap(), None)
-            .await
-            .expect("namespace created");
+        let namespace = arbitrary_namespace(&mut *txn, "1234_5678").await;
         let mut table = txn
             .tables()
             .create_or_get("weather", namespace.id)

--- a/import/src/aggregate_tsm_schema/update_catalog.rs
+++ b/import/src/aggregate_tsm_schema/update_catalog.rs
@@ -345,7 +345,10 @@ mod tests {
     use crate::{AggregateTSMField, AggregateTSMTag};
     use assert_matches::assert_matches;
     use data_types::{PartitionId, TableId};
-    use iox_catalog::{mem::MemCatalog, test_helpers::arbitrary_namespace};
+    use iox_catalog::{
+        mem::MemCatalog,
+        test_helpers::{arbitrary_namespace, arbitrary_table},
+    };
     use std::collections::HashSet;
 
     #[tokio::test]
@@ -429,12 +432,8 @@ mod tests {
             .expect("started transaction");
         // create namespace, table and columns for weather measurement
         let namespace = arbitrary_namespace(&mut *txn, "1234_5678").await;
-        let mut table = txn
-            .tables()
-            .create_or_get("weather", namespace.id)
-            .await
-            .map(|t| TableSchema::new_empty_from(&t))
-            .expect("table created");
+        let table = arbitrary_table(&mut *txn, "weather", &namespace).await;
+        let mut table = TableSchema::new_empty_from(&table);
         let time_col = txn
             .columns()
             .create_or_get("time", table.id, ColumnType::Time)
@@ -517,12 +516,8 @@ mod tests {
             .expect("started transaction");
         // create namespace, table and columns for weather measurement
         let namespace = arbitrary_namespace(&mut *txn, "1234_5678").await;
-        let mut table = txn
-            .tables()
-            .create_or_get("weather", namespace.id)
-            .await
-            .map(|t| TableSchema::new_empty_from(&t))
-            .expect("table created");
+        let table = arbitrary_table(&mut *txn, "weather", &namespace).await;
+        let mut table = TableSchema::new_empty_from(&table);
         let time_col = txn
             .columns()
             .create_or_get("time", table.id, ColumnType::Time)
@@ -578,12 +573,8 @@ mod tests {
 
         // create namespace, table and columns for weather measurement
         let namespace = arbitrary_namespace(&mut *txn, "1234_5678").await;
-        let mut table = txn
-            .tables()
-            .create_or_get("weather", namespace.id)
-            .await
-            .map(|t| TableSchema::new_empty_from(&t))
-            .expect("table created");
+        let table = arbitrary_table(&mut *txn, "weather", &namespace).await;
+        let mut table = TableSchema::new_empty_from(&table);
         let time_col = txn
             .columns()
             .create_or_get("time", table.id, ColumnType::Time)

--- a/ingester/src/buffer_tree/partition/resolver/catalog.rs
+++ b/ingester/src/buffer_tree/partition/resolver/catalog.rs
@@ -99,7 +99,7 @@ mod tests {
     use std::{sync::Arc, time::Duration};
 
     use assert_matches::assert_matches;
-    use iox_catalog::test_helpers::arbitrary_namespace;
+    use iox_catalog::test_helpers::{arbitrary_namespace, arbitrary_table};
 
     use super::*;
 
@@ -117,11 +117,8 @@ mod tests {
             let mut repos = catalog.repositories().await;
             let ns = arbitrary_namespace(&mut *repos, NAMESPACE_NAME).await;
 
-            let table = repos
-                .tables()
-                .create_or_get(TABLE_NAME, ns.id)
-                .await
-                .unwrap();
+            let table = arbitrary_table(&mut *repos, TABLE_NAME, &ns)
+                .await;
 
             (ns.id, table.id)
         };

--- a/ingester/src/buffer_tree/partition/resolver/catalog.rs
+++ b/ingester/src/buffer_tree/partition/resolver/catalog.rs
@@ -99,6 +99,7 @@ mod tests {
     use std::{sync::Arc, time::Duration};
 
     use assert_matches::assert_matches;
+    use iox_catalog::test_helpers::arbitrary_namespace;
 
     use super::*;
 
@@ -114,12 +115,7 @@ mod tests {
 
         let (namespace_id, table_id) = {
             let mut repos = catalog.repositories().await;
-            let table_ns_name = data_types::NamespaceName::new(TABLE_NAME).unwrap();
-            let ns = repos
-                .namespaces()
-                .create(&table_ns_name, None)
-                .await
-                .unwrap();
+            let ns = arbitrary_namespace(&mut *repos, NAMESPACE_NAME).await;
 
             let table = repos
                 .tables()

--- a/ingester/src/test_util.rs
+++ b/ingester/src/test_util.rs
@@ -2,7 +2,7 @@ use std::{collections::BTreeMap, sync::Arc, time::Duration};
 
 use data_types::{NamespaceId, Partition, PartitionId, PartitionKey, SequenceNumber, TableId};
 use dml::{DmlMeta, DmlWrite};
-use iox_catalog::interface::Catalog;
+use iox_catalog::{interface::Catalog, test_helpers::arbitrary_namespace};
 use lazy_static::lazy_static;
 use mutable_batch_lp::lines_to_batches;
 use schema::Projection;
@@ -298,13 +298,7 @@ pub(crate) async fn populate_catalog(
     table: &str,
 ) -> (NamespaceId, TableId) {
     let mut c = catalog.repositories().await;
-    let namespace_name = data_types::NamespaceName::new(namespace).unwrap();
-    let ns_id = c
-        .namespaces()
-        .create(&namespace_name, None)
-        .await
-        .unwrap()
-        .id;
+    let ns_id = arbitrary_namespace(&mut *c, namespace).await.id;
     let table_id = c.tables().create_or_get(table, ns_id).await.unwrap().id;
 
     (ns_id, table_id)

--- a/iox_catalog/src/lib.rs
+++ b/iox_catalog/src/lib.rs
@@ -201,6 +201,34 @@ where
     Ok(())
 }
 
+/// Catalog helper functions for creation of catalog objects
+pub mod test_helpers {
+    use crate::RepoCollection;
+    use data_types::{Namespace, NamespaceName};
+
+    /// When the details of the namespace don't matter; the test just needs *a* catalog namespace
+    /// with a particular name.
+    ///
+    /// Use [`NamespaceRepo::create`] directly if:
+    ///
+    /// - The values of the parameters to `create` need to be different than what's here
+    /// - The values of the parameters to `create` are relevant to the behavior under test
+    /// - You expect namespace creation to fail in the test
+    ///
+    /// [`NamespaceRepo::create`]: crate::interface::NamespaceRepo::create
+    pub async fn arbitrary_namespace<R: RepoCollection + ?Sized>(
+        repos: &mut R,
+        name: &str,
+    ) -> Namespace {
+        let namespace_name = NamespaceName::new(name).unwrap();
+        repos
+            .namespaces()
+            .create(&namespace_name, None)
+            .await
+            .unwrap()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::{collections::BTreeMap, sync::Arc};
@@ -210,7 +238,6 @@ mod tests {
         interface::{get_schema_by_name, SoftDeletedRows},
         mem::MemCatalog,
     };
-    use data_types::NamespaceName;
 
     // Generate a test that simulates multiple, sequential writes in `lp` and
     // asserts the resulting schema.
@@ -228,21 +255,17 @@ mod tests {
                 #[allow(clippy::bool_assert_comparison)]
                 #[tokio::test]
                 async fn [<test_validate_schema_ $name>]() {
-                    use crate::interface::Catalog;
+                    use crate::{interface::Catalog, test_helpers::arbitrary_namespace};
                     use std::ops::DerefMut;
                     use pretty_assertions::assert_eq;
                     const NAMESPACE_NAME: &str = "bananas";
-                    let ns_name = NamespaceName::new(NAMESPACE_NAME).unwrap();
 
                     let metrics = Arc::new(metric::Registry::default());
                     let repo = MemCatalog::new(metrics);
                     let mut txn = repo.start_transaction().await.unwrap();
 
-                    let namespace = txn
-                        .namespaces()
-                        .create(&ns_name, None)
-                        .await
-                        .unwrap();
+                    let namespace = arbitrary_namespace(&mut *txn, NAMESPACE_NAME)
+                        .await;
 
                     let schema = NamespaceSchema::new_empty_from(&namespace);
 

--- a/iox_catalog/src/lib.rs
+++ b/iox_catalog/src/lib.rs
@@ -204,7 +204,7 @@ where
 /// Catalog helper functions for creation of catalog objects
 pub mod test_helpers {
     use crate::RepoCollection;
-    use data_types::{Namespace, NamespaceName};
+    use data_types::{Namespace, NamespaceName, Table};
 
     /// When the details of the namespace don't matter; the test just needs *a* catalog namespace
     /// with a particular name.
@@ -224,6 +224,28 @@ pub mod test_helpers {
         repos
             .namespaces()
             .create(&namespace_name, None)
+            .await
+            .unwrap()
+    }
+
+    /// When the details of the table don't matter; the test just needs *a* catalog table
+    /// with a particular name in a particular namespace.
+    ///
+    /// Use [`TableRepo::create_or_get`] directly if:
+    ///
+    /// - The values of the parameters to `create_or_get` need to be different than what's here
+    /// - The values of the parameters to `create_or_get` are relevant to the behavior under test
+    /// - You expect table creation to fail in the test
+    ///
+    /// [`TableRepo::create_or_get`]: crate::interface::TableRepo::create_or_get
+    pub async fn arbitrary_table<R: RepoCollection + ?Sized>(
+        repos: &mut R,
+        name: &str,
+        namespace: &Namespace,
+    ) -> Table {
+        repos
+            .tables()
+            .create_or_get(name, namespace.id)
             .await
             .unwrap()
     }

--- a/iox_catalog/src/postgres.rs
+++ b/iox_catalog/src/postgres.rs
@@ -1638,7 +1638,7 @@ fn is_fk_violation(e: &sqlx::Error) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_helpers::arbitrary_namespace;
+    use crate::test_helpers::{arbitrary_namespace, arbitrary_table};
     use assert_matches::assert_matches;
     use data_types::{ColumnId, ColumnSet};
     use metric::{Attributes, DurationHistogram, Metric};
@@ -1824,13 +1824,8 @@ mod tests {
         let postgres: Arc<dyn Catalog> = Arc::new(postgres);
         let mut repos = postgres.repositories().await;
 
-        let namespace_id = arbitrary_namespace(&mut *repos, "ns4").await.id;
-        let table_id = repos
-            .tables()
-            .create_or_get("table", namespace_id)
-            .await
-            .expect("create table failed")
-            .id;
+        let namespace = arbitrary_namespace(&mut *repos, "ns4").await;
+        let table_id = arbitrary_table(&mut *repos, "table", &namespace).await.id;
 
         let key = "bananas";
 
@@ -1950,14 +1945,10 @@ mod tests {
                     let postgres: Arc<dyn Catalog> = Arc::new(postgres);
                     let mut repos = postgres.repositories().await;
 
-                    let namespace_id = arbitrary_namespace(&mut *repos, "ns4")
+                    let namespace = arbitrary_namespace(&mut *repos, "ns4")
+                        .await;
+                    let table_id = arbitrary_table(&mut *repos, "table", &namespace)
                         .await
-                        .id;
-                    let table_id = repos
-                        .tables()
-                        .create_or_get("table", namespace_id)
-                        .await
-                        .expect("create table failed")
                         .id;
 
                     $(
@@ -2104,13 +2095,9 @@ mod tests {
         let pool = postgres.pool.clone();
         let postgres: Arc<dyn Catalog> = Arc::new(postgres);
         let mut repos = postgres.repositories().await;
-        let namespace_id = arbitrary_namespace(&mut *repos, "ns4").await.id;
-        let table_id = repos
-            .tables()
-            .create_or_get("table", namespace_id)
-            .await
-            .expect("create table failed")
-            .id;
+        let namespace = arbitrary_namespace(&mut *repos, "ns4").await;
+        let namespace_id = namespace.id;
+        let table_id = arbitrary_table(&mut *repos, "table", &namespace).await.id;
 
         let key = "bananas";
 

--- a/iox_catalog/src/postgres.rs
+++ b/iox_catalog/src/postgres.rs
@@ -1638,6 +1638,7 @@ fn is_fk_violation(e: &sqlx::Error) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_helpers::arbitrary_namespace;
     use assert_matches::assert_matches;
     use data_types::{ColumnId, ColumnSet};
     use metric::{Attributes, DurationHistogram, Metric};
@@ -1821,18 +1822,10 @@ mod tests {
 
         let postgres = setup_db().await;
         let postgres: Arc<dyn Catalog> = Arc::new(postgres);
+        let mut repos = postgres.repositories().await;
 
-        let namespace_id = postgres
-            .repositories()
-            .await
-            .namespaces()
-            .create(&NamespaceName::new("ns4").unwrap(), None)
-            .await
-            .expect("namespace create failed")
-            .id;
-        let table_id = postgres
-            .repositories()
-            .await
+        let namespace_id = arbitrary_namespace(&mut *repos, "ns4").await.id;
+        let table_id = repos
             .tables()
             .create_or_get("table", namespace_id)
             .await
@@ -1841,18 +1834,14 @@ mod tests {
 
         let key = "bananas";
 
-        let a = postgres
-            .repositories()
-            .await
+        let a = repos
             .partitions()
             .create_or_get(key.into(), table_id)
             .await
             .expect("should create OK");
 
         // Call create_or_get for the same (key, table_id) pair, to ensure the write is idempotent.
-        let b = postgres
-            .repositories()
-            .await
+        let b = repos
             .partitions()
             .create_or_get(key.into(), table_id)
             .await
@@ -1959,18 +1948,12 @@ mod tests {
                     let postgres = setup_db().await;
                     let metrics = Arc::clone(&postgres.metrics);
                     let postgres: Arc<dyn Catalog> = Arc::new(postgres);
+                    let mut repos = postgres.repositories().await;
 
-                    let namespace_id = postgres
-                        .repositories()
+                    let namespace_id = arbitrary_namespace(&mut *repos, "ns4")
                         .await
-                        .namespaces()
-                        .create(&NamespaceName::new("ns4").unwrap(), None)
-                        .await
-                        .expect("namespace create failed")
                         .id;
-                    let table_id = postgres
-                        .repositories()
-                        .await
+                    let table_id = repos
                         .tables()
                         .create_or_get("table", namespace_id)
                         .await
@@ -1983,9 +1966,7 @@ mod tests {
                             insert.insert($col_name, $col_type);
                         )+
 
-                        let got = postgres
-                            .repositories()
-                            .await
+                        let got = repos
                             .columns()
                             .create_or_get_many_unchecked(table_id, insert.clone())
                             .await;
@@ -2122,18 +2103,9 @@ mod tests {
         let postgres = setup_db().await;
         let pool = postgres.pool.clone();
         let postgres: Arc<dyn Catalog> = Arc::new(postgres);
-
-        let namespace_id = postgres
-            .repositories()
-            .await
-            .namespaces()
-            .create(&NamespaceName::new("ns4").unwrap(), None)
-            .await
-            .expect("namespace create failed")
-            .id;
-        let table_id = postgres
-            .repositories()
-            .await
+        let mut repos = postgres.repositories().await;
+        let namespace_id = arbitrary_namespace(&mut *repos, "ns4").await.id;
+        let table_id = repos
             .tables()
             .create_or_get("table", namespace_id)
             .await
@@ -2142,9 +2114,7 @@ mod tests {
 
         let key = "bananas";
 
-        let partition_id = postgres
-            .repositories()
-            .await
+        let partition_id = repos
             .partitions()
             .create_or_get(key.into(), table_id)
             .await
@@ -2169,9 +2139,7 @@ mod tests {
             column_set: ColumnSet::new([ColumnId::new(1), ColumnId::new(2)]),
             max_l0_created_at: time_now,
         };
-        let f1 = postgres
-            .repositories()
-            .await
+        let f1 = repos
             .parquet_files()
             .create(p1.clone())
             .await
@@ -2179,9 +2147,7 @@ mod tests {
         // insert the same again with a different size; we should then have 3x1337 as total file size
         p1.object_store_id = Uuid::new_v4();
         p1.file_size_bytes *= 2;
-        let _f2 = postgres
-            .repositories()
-            .await
+        let _f2 = repos
             .parquet_files()
             .create(p1.clone())
             .await
@@ -2196,9 +2162,7 @@ mod tests {
         assert_eq!(total_file_size_bytes, 1337 * 3);
 
         // flag f1 for deletion and assert that the total file size is reduced accordingly.
-        postgres
-            .repositories()
-            .await
+        repos
             .parquet_files()
             .flag_for_delete(f1.id)
             .await
@@ -2213,9 +2177,7 @@ mod tests {
 
         // actually deleting shouldn't change the total
         let now = Timestamp::from(time_provider.now());
-        postgres
-            .repositories()
-            .await
+        repos
             .parquet_files()
             .delete_old_ids_only(now)
             .await

--- a/iox_catalog/src/sqlite.rs
+++ b/iox_catalog/src/sqlite.rs
@@ -1508,6 +1508,7 @@ fn is_unique_violation(e: &sqlx::Error) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_helpers::arbitrary_namespace;
     use assert_matches::assert_matches;
     use metric::{Attributes, DurationHistogram, Metric};
     use std::sync::Arc;
@@ -1549,20 +1550,11 @@ mod tests {
     #[tokio::test]
     async fn test_partition_create_or_get_idempotent() {
         let sqlite = setup_db().await;
-
         let sqlite: Arc<dyn Catalog> = Arc::new(sqlite);
+        let mut repos = sqlite.repositories().await;
 
-        let namespace_id = sqlite
-            .repositories()
-            .await
-            .namespaces()
-            .create(&NamespaceName::new("ns4").unwrap(), None)
-            .await
-            .expect("namespace create failed")
-            .id;
-        let table_id = sqlite
-            .repositories()
-            .await
+        let namespace_id = arbitrary_namespace(&mut *repos, "ns4").await.id;
+        let table_id = repos
             .tables()
             .create_or_get("table", namespace_id)
             .await
@@ -1571,18 +1563,14 @@ mod tests {
 
         let key = "bananas";
 
-        let a = sqlite
-            .repositories()
-            .await
+        let a = repos
             .partitions()
             .create_or_get(key.into(), table_id)
             .await
             .expect("should create OK");
 
         // Call create_or_get for the same (key, table_id) pair, to ensure the write is idempotent.
-        let b = sqlite
-            .repositories()
-            .await
+        let b = repos
             .partitions()
             .create_or_get(key.into(), table_id)
             .await
@@ -1602,20 +1590,13 @@ mod tests {
                 async fn [<test_column_create_or_get_many_unchecked_ $name>]() {
                     let sqlite = setup_db().await;
                     let metrics = Arc::clone(&sqlite.metrics);
-
                     let sqlite: Arc<dyn Catalog> = Arc::new(sqlite);
+                    let mut repos = sqlite.repositories().await;
 
-                    let namespace_id = sqlite
-                        .repositories()
+                    let namespace_id = arbitrary_namespace(&mut *repos, "ns4")
                         .await
-                        .namespaces()
-                        .create(&NamespaceName::new("ns4").unwrap(), None)
-                        .await
-                        .expect("namespace create failed")
                         .id;
-                    let table_id = sqlite
-                        .repositories()
-                        .await
+                    let table_id = repos
                         .tables()
                         .create_or_get("table", namespace_id)
                         .await
@@ -1628,9 +1609,7 @@ mod tests {
                             insert.insert($col_name, $col_type);
                         )+
 
-                        let got = sqlite
-                            .repositories()
-                            .await
+                        let got = repos
                             .columns()
                             .create_or_get_many_unchecked(table_id, insert.clone())
                             .await;
@@ -1764,20 +1743,11 @@ mod tests {
     async fn test_billing_summary_on_parqet_file_creation() {
         let sqlite = setup_db().await;
         let pool = sqlite.pool.clone();
-
         let sqlite: Arc<dyn Catalog> = Arc::new(sqlite);
+        let mut repos = sqlite.repositories().await;
 
-        let namespace_id = sqlite
-            .repositories()
-            .await
-            .namespaces()
-            .create(&NamespaceName::new("ns4").unwrap(), None)
-            .await
-            .expect("namespace create failed")
-            .id;
-        let table_id = sqlite
-            .repositories()
-            .await
+        let namespace_id = arbitrary_namespace(&mut *repos, "ns4").await.id;
+        let table_id = repos
             .tables()
             .create_or_get("table", namespace_id)
             .await
@@ -1786,9 +1756,7 @@ mod tests {
 
         let key = "bananas";
 
-        let partition_id = sqlite
-            .repositories()
-            .await
+        let partition_id = repos
             .partitions()
             .create_or_get(key.into(), table_id)
             .await
@@ -1813,9 +1781,7 @@ mod tests {
             column_set: ColumnSet::new([ColumnId::new(1), ColumnId::new(2)]),
             max_l0_created_at: time_now,
         };
-        let f1 = sqlite
-            .repositories()
-            .await
+        let f1 = repos
             .parquet_files()
             .create(p1.clone())
             .await
@@ -1823,9 +1789,7 @@ mod tests {
         // insert the same again with a different size; we should then have 3x1337 as total file size
         p1.object_store_id = Uuid::new_v4();
         p1.file_size_bytes *= 2;
-        let _f2 = sqlite
-            .repositories()
-            .await
+        let _f2 = repos
             .parquet_files()
             .create(p1.clone())
             .await
@@ -1840,9 +1804,7 @@ mod tests {
         assert_eq!(total_file_size_bytes, 1337 * 3);
 
         // flag f1 for deletion and assert that the total file size is reduced accordingly.
-        sqlite
-            .repositories()
-            .await
+        repos
             .parquet_files()
             .flag_for_delete(f1.id)
             .await
@@ -1857,9 +1819,7 @@ mod tests {
 
         // actually deleting shouldn't change the total
         let now = Timestamp::from(time_provider.now());
-        sqlite
-            .repositories()
-            .await
+        repos
             .parquet_files()
             .delete_old_ids_only(now)
             .await

--- a/iox_catalog/src/sqlite.rs
+++ b/iox_catalog/src/sqlite.rs
@@ -1508,7 +1508,7 @@ fn is_unique_violation(e: &sqlx::Error) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_helpers::arbitrary_namespace;
+    use crate::test_helpers::{arbitrary_namespace, arbitrary_table};
     use assert_matches::assert_matches;
     use metric::{Attributes, DurationHistogram, Metric};
     use std::sync::Arc;
@@ -1553,13 +1553,8 @@ mod tests {
         let sqlite: Arc<dyn Catalog> = Arc::new(sqlite);
         let mut repos = sqlite.repositories().await;
 
-        let namespace_id = arbitrary_namespace(&mut *repos, "ns4").await.id;
-        let table_id = repos
-            .tables()
-            .create_or_get("table", namespace_id)
-            .await
-            .expect("create table failed")
-            .id;
+        let namespace = arbitrary_namespace(&mut *repos, "ns4").await;
+        let table_id = arbitrary_table(&mut *repos, "table", &namespace).await.id;
 
         let key = "bananas";
 
@@ -1593,14 +1588,10 @@ mod tests {
                     let sqlite: Arc<dyn Catalog> = Arc::new(sqlite);
                     let mut repos = sqlite.repositories().await;
 
-                    let namespace_id = arbitrary_namespace(&mut *repos, "ns4")
+                    let namespace = arbitrary_namespace(&mut *repos, "ns4")
+                        .await;
+                    let table_id = arbitrary_table(&mut *repos, "table", &namespace)
                         .await
-                        .id;
-                    let table_id = repos
-                        .tables()
-                        .create_or_get("table", namespace_id)
-                        .await
-                        .expect("create table failed")
                         .id;
 
                     $(
@@ -1746,13 +1737,9 @@ mod tests {
         let sqlite: Arc<dyn Catalog> = Arc::new(sqlite);
         let mut repos = sqlite.repositories().await;
 
-        let namespace_id = arbitrary_namespace(&mut *repos, "ns4").await.id;
-        let table_id = repos
-            .tables()
-            .create_or_get("table", namespace_id)
-            .await
-            .expect("create table failed")
-            .id;
+        let namespace = arbitrary_namespace(&mut *repos, "ns4").await;
+        let namespace_id = namespace.id;
+        let table_id = arbitrary_table(&mut *repos, "table", &namespace).await.id;
 
         let key = "bananas";
 

--- a/iox_tests/src/catalog.rs
+++ b/iox_tests/src/catalog.rs
@@ -16,6 +16,7 @@ use iox_catalog::{
         get_schema_by_id, get_table_columns_by_id, Catalog, PartitionRepo, SoftDeletedRows,
     },
     mem::MemCatalog,
+    test_helpers::arbitrary_table,
 };
 use iox_query::{
     exec::{DedicatedExecutors, Executor, ExecutorConfig},
@@ -220,11 +221,7 @@ impl TestNamespace {
     pub async fn create_table(self: &Arc<Self>, name: &str) -> Arc<TestTable> {
         let mut repos = self.catalog.catalog.repositories().await;
 
-        let table = repos
-            .tables()
-            .create_or_get(name, self.namespace.id)
-            .await
-            .unwrap();
+        let table = arbitrary_table(&mut *repos, name, &self.namespace).await;
 
         Arc::new(TestTable {
             catalog: Arc::clone(&self.catalog),

--- a/ioxd_router/src/lib.rs
+++ b/ioxd_router/src/lib.rs
@@ -382,7 +382,7 @@ where
 #[cfg(test)]
 mod tests {
     use data_types::ColumnType;
-    use iox_catalog::mem::MemCatalog;
+    use iox_catalog::{mem::MemCatalog, test_helpers::arbitrary_namespace};
 
     use super::*;
 
@@ -391,11 +391,7 @@ mod tests {
         let catalog = Arc::new(MemCatalog::new(Default::default()));
 
         let mut repos = catalog.repositories().await;
-        let namespace = repos
-            .namespaces()
-            .create(&NamespaceName::new("test_ns").unwrap(), None)
-            .await
-            .unwrap();
+        let namespace = arbitrary_namespace(&mut *repos, "test_ns").await;
 
         let table = repos
             .tables()

--- a/ioxd_router/src/lib.rs
+++ b/ioxd_router/src/lib.rs
@@ -382,7 +382,10 @@ where
 #[cfg(test)]
 mod tests {
     use data_types::ColumnType;
-    use iox_catalog::{mem::MemCatalog, test_helpers::arbitrary_namespace};
+    use iox_catalog::{
+        mem::MemCatalog,
+        test_helpers::{arbitrary_namespace, arbitrary_table},
+    };
 
     use super::*;
 
@@ -393,11 +396,7 @@ mod tests {
         let mut repos = catalog.repositories().await;
         let namespace = arbitrary_namespace(&mut *repos, "test_ns").await;
 
-        let table = repos
-            .tables()
-            .create_or_get("name", namespace.id)
-            .await
-            .unwrap();
+        let table = arbitrary_table(&mut *repos, "name", &namespace).await;
         let _column = repos
             .columns()
             .create_or_get("name", table.id, ColumnType::U64)

--- a/router/tests/http.rs
+++ b/router/tests/http.rs
@@ -5,7 +5,7 @@ use futures::{stream::FuturesUnordered, StreamExt};
 use generated_types::influxdata::{iox::ingester::v1::WriteRequest, pbdata::v1::DatabaseBatch};
 use hashbrown::HashMap;
 use hyper::{Body, Request, StatusCode};
-use iox_catalog::interface::SoftDeletedRows;
+use iox_catalog::{interface::SoftDeletedRows, test_helpers::arbitrary_namespace};
 use iox_time::{SystemProvider, TimeProvider};
 use metric::{Attributes, DurationHistogram, Metric, U64Counter};
 use router::dml_handlers::{DmlError, RetentionError, SchemaError};
@@ -265,17 +265,7 @@ async fn test_write_propagate_ids() {
         .await;
 
     // Create the namespace and a set of tables.
-    let ns = ctx
-        .catalog()
-        .repositories()
-        .await
-        .namespaces()
-        .create(
-            &data_types::NamespaceName::new("bananas_test").unwrap(),
-            None,
-        )
-        .await
-        .expect("failed to update table limit");
+    let ns = arbitrary_namespace(&mut *ctx.catalog().repositories().await, "bananas_test").await;
 
     let catalog = ctx.catalog();
     let ids = ["another", "test", "table", "platanos"]

--- a/service_grpc_catalog/src/lib.rs
+++ b/service_grpc_catalog/src/lib.rs
@@ -197,11 +197,9 @@ fn to_partition(p: data_types::Partition) -> Partition {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use data_types::{
-        ColumnId, ColumnSet, CompactionLevel, NamespaceName, ParquetFileParams, Timestamp,
-    };
+    use data_types::{ColumnId, ColumnSet, CompactionLevel, ParquetFileParams, Timestamp};
     use generated_types::influxdata::iox::catalog::v1::catalog_service_server::CatalogService;
-    use iox_catalog::mem::MemCatalog;
+    use iox_catalog::{mem::MemCatalog, test_helpers::arbitrary_namespace};
     use uuid::Uuid;
 
     #[tokio::test]
@@ -214,11 +212,7 @@ mod tests {
             let metrics = Arc::new(metric::Registry::default());
             let catalog = Arc::new(MemCatalog::new(metrics));
             let mut repos = catalog.repositories().await;
-            let namespace = repos
-                .namespaces()
-                .create(&NamespaceName::new("catalog_partition_test").unwrap(), None)
-                .await
-                .unwrap();
+            let namespace = arbitrary_namespace(&mut *repos, "catalog_partition_test").await;
             let table = repos
                 .tables()
                 .create_or_get("schema_test_table", namespace.id)
@@ -277,11 +271,7 @@ mod tests {
             let metrics = Arc::new(metric::Registry::default());
             let catalog = Arc::new(MemCatalog::new(metrics));
             let mut repos = catalog.repositories().await;
-            let namespace = repos
-                .namespaces()
-                .create(&NamespaceName::new("catalog_partition_test").unwrap(), None)
-                .await
-                .unwrap();
+            let namespace = arbitrary_namespace(&mut *repos, "catalog_partition_test").await;
             let table = repos
                 .tables()
                 .create_or_get("schema_test_table", namespace.id)

--- a/service_grpc_catalog/src/lib.rs
+++ b/service_grpc_catalog/src/lib.rs
@@ -199,7 +199,10 @@ mod tests {
     use super::*;
     use data_types::{ColumnId, ColumnSet, CompactionLevel, ParquetFileParams, Timestamp};
     use generated_types::influxdata::iox::catalog::v1::catalog_service_server::CatalogService;
-    use iox_catalog::{mem::MemCatalog, test_helpers::arbitrary_namespace};
+    use iox_catalog::{
+        mem::MemCatalog,
+        test_helpers::{arbitrary_namespace, arbitrary_table},
+    };
     use uuid::Uuid;
 
     #[tokio::test]
@@ -213,11 +216,7 @@ mod tests {
             let catalog = Arc::new(MemCatalog::new(metrics));
             let mut repos = catalog.repositories().await;
             let namespace = arbitrary_namespace(&mut *repos, "catalog_partition_test").await;
-            let table = repos
-                .tables()
-                .create_or_get("schema_test_table", namespace.id)
-                .await
-                .unwrap();
+            let table = arbitrary_table(&mut *repos, "schema_test_table", &namespace).await;
             let partition = repos
                 .partitions()
                 .create_or_get("foo".into(), table.id)
@@ -272,11 +271,7 @@ mod tests {
             let catalog = Arc::new(MemCatalog::new(metrics));
             let mut repos = catalog.repositories().await;
             let namespace = arbitrary_namespace(&mut *repos, "catalog_partition_test").await;
-            let table = repos
-                .tables()
-                .create_or_get("schema_test_table", namespace.id)
-                .await
-                .unwrap();
+            let table = arbitrary_table(&mut *repos, "schema_test_table", &namespace).await;
             partition1 = repos
                 .partitions()
                 .create_or_get("foo".into(), table.id)

--- a/service_grpc_object_store/src/lib.rs
+++ b/service_grpc_object_store/src/lib.rs
@@ -96,11 +96,9 @@ impl object_store_service_server::ObjectStoreService for ObjectStoreService {
 mod tests {
     use super::*;
     use bytes::Bytes;
-    use data_types::{
-        ColumnId, ColumnSet, CompactionLevel, NamespaceName, ParquetFileParams, Timestamp,
-    };
+    use data_types::{ColumnId, ColumnSet, CompactionLevel, ParquetFileParams, Timestamp};
     use generated_types::influxdata::iox::object_store::v1::object_store_service_server::ObjectStoreService;
-    use iox_catalog::mem::MemCatalog;
+    use iox_catalog::{mem::MemCatalog, test_helpers::arbitrary_namespace};
     use object_store::{memory::InMemory, ObjectStore};
     use uuid::Uuid;
 
@@ -112,11 +110,7 @@ mod tests {
             let metrics = Arc::new(metric::Registry::default());
             let catalog = Arc::new(MemCatalog::new(metrics));
             let mut repos = catalog.repositories().await;
-            let namespace = repos
-                .namespaces()
-                .create(&NamespaceName::new("catalog_partition_test").unwrap(), None)
-                .await
-                .unwrap();
+            let namespace = arbitrary_namespace(&mut *repos, "catalog_partition_test").await;
             let table = repos
                 .tables()
                 .create_or_get("schema_test_table", namespace.id)

--- a/service_grpc_object_store/src/lib.rs
+++ b/service_grpc_object_store/src/lib.rs
@@ -98,7 +98,10 @@ mod tests {
     use bytes::Bytes;
     use data_types::{ColumnId, ColumnSet, CompactionLevel, ParquetFileParams, Timestamp};
     use generated_types::influxdata::iox::object_store::v1::object_store_service_server::ObjectStoreService;
-    use iox_catalog::{mem::MemCatalog, test_helpers::arbitrary_namespace};
+    use iox_catalog::{
+        mem::MemCatalog,
+        test_helpers::{arbitrary_namespace, arbitrary_table},
+    };
     use object_store::{memory::InMemory, ObjectStore};
     use uuid::Uuid;
 
@@ -111,11 +114,7 @@ mod tests {
             let catalog = Arc::new(MemCatalog::new(metrics));
             let mut repos = catalog.repositories().await;
             let namespace = arbitrary_namespace(&mut *repos, "catalog_partition_test").await;
-            let table = repos
-                .tables()
-                .create_or_get("schema_test_table", namespace.id)
-                .await
-                .unwrap();
+            let table = arbitrary_table(&mut *repos, "schema_test_table", &namespace).await;
             let partition = repos
                 .partitions()
                 .create_or_get("foo".into(), table.id)

--- a/service_grpc_schema/src/lib.rs
+++ b/service_grpc_schema/src/lib.rs
@@ -81,9 +81,9 @@ fn schema_to_proto(schema: Arc<data_types::NamespaceSchema>) -> GetSchemaRespons
 #[cfg(test)]
 mod tests {
     use super::*;
-    use data_types::{ColumnType, NamespaceName};
+    use data_types::ColumnType;
     use generated_types::influxdata::iox::schema::v1::schema_service_server::SchemaService;
-    use iox_catalog::mem::MemCatalog;
+    use iox_catalog::{mem::MemCatalog, test_helpers::arbitrary_namespace};
     use std::sync::Arc;
 
     #[tokio::test]
@@ -93,11 +93,7 @@ mod tests {
             let metrics = Arc::new(metric::Registry::default());
             let catalog = Arc::new(MemCatalog::new(metrics));
             let mut repos = catalog.repositories().await;
-            let namespace = repos
-                .namespaces()
-                .create(&NamespaceName::new("namespace_schema_test").unwrap(), None)
-                .await
-                .unwrap();
+            let namespace = arbitrary_namespace(&mut *repos, "namespace_schema_test").await;
             let table = repos
                 .tables()
                 .create_or_get("schema_test_table", namespace.id)

--- a/service_grpc_schema/src/lib.rs
+++ b/service_grpc_schema/src/lib.rs
@@ -83,7 +83,10 @@ mod tests {
     use super::*;
     use data_types::ColumnType;
     use generated_types::influxdata::iox::schema::v1::schema_service_server::SchemaService;
-    use iox_catalog::{mem::MemCatalog, test_helpers::arbitrary_namespace};
+    use iox_catalog::{
+        mem::MemCatalog,
+        test_helpers::{arbitrary_namespace, arbitrary_table},
+    };
     use std::sync::Arc;
 
     #[tokio::test]
@@ -94,11 +97,7 @@ mod tests {
             let catalog = Arc::new(MemCatalog::new(metrics));
             let mut repos = catalog.repositories().await;
             let namespace = arbitrary_namespace(&mut *repos, "namespace_schema_test").await;
-            let table = repos
-                .tables()
-                .create_or_get("schema_test_table", namespace.id)
-                .await
-                .unwrap();
+            let table = arbitrary_table(&mut *repos, "schema_test_table", &namespace).await;
             repos
                 .columns()
                 .create_or_get("schema_test_column", table.id, ColumnType::Tag)


### PR DESCRIPTION
In the custom partitioning work, I've been changing the function interface of creating namespaces and tables in the catalog. We've been trying different exact implementations in different PRs like #7713 and #7790, and I wouldn't be surprised if I end up changing the interfaces again when all is said and done.

There are a bunch of places in various tests that create _a_ namespace or _a_ table but these places aren't testing namespaces or tables, they just need those records to put other stuff into the catalog. All of these places create namespaces and tables in exactly the same way, and whenever I change the interface, I have to update all these places. And I'm tired 😴 

Additionally, this PR also changed the interface for creating namespaces in a different way than I am, so that PR also had to update a number of tests and it created merge conflicts with my stuff that I had to resolve in all the places 😥 

So this PR creates two little itty bitty test helper methods provided by the catalog to make one place where like 80% of these arbitrary catalog record creations can be updated.