### PR TITLE
feat(metrics): Parquet file attribute statistics

### DIFF
--- a/ingester/src/init.rs
+++ b/ingester/src/init.rs
@@ -36,8 +36,8 @@ use crate::{
     ingest_state::IngestState,
     ingester_id::IngesterId,
     persist::{
-        completion_observer::NopObserver, handle::PersistHandle,
-        hot_partitions::HotPartitionPersister,
+        completion_observer::NopObserver, file_metrics::ParquetFileInstrumentation,
+        handle::PersistHandle, hot_partitions::HotPartitionPersister,
     },
     query::{
         exec_instrumentation::QueryExecInstrumentation,
@@ -292,7 +292,9 @@ where
         persist_executor,
         object_store,
         Arc::clone(&catalog),
-        NopObserver::default(),
+        // Register a post-persistence observer that emits Parquet file
+        // attributes as metrics.
+        ParquetFileInstrumentation::new(NopObserver::default(), &metrics),
         &metrics,
     );
     let persist_handle = Arc::new(persist_handle);

--- a/ingester/src/persist/completion_observer.rs
+++ b/ingester/src/persist/completion_observer.rs
@@ -84,12 +84,12 @@ impl CompletedPersist {
         self.meta.row_count as _
     }
 
-    /// The number of rows persisted.
+    /// The number of columns persisted.
     pub fn column_count(&self) -> usize {
         self.meta.column_set.len()
     }
 
-    /// The number of rows persisted.
+    /// The byte size of the generated Parquet file.
     pub fn parquet_file_bytes(&self) -> usize {
         self.meta.file_size_bytes as _
     }

--- a/ingester/src/persist/file_metrics.rs
+++ b/ingester/src/persist/file_metrics.rs
@@ -1,0 +1,228 @@
+use std::{sync::Arc, time::Duration};
+
+use async_trait::async_trait;
+use metric::{
+    DurationHistogram, DurationHistogramOptions, U64Histogram, U64HistogramOptions, DURATION_MAX,
+};
+
+use super::completion_observer::{CompletedPersist, PersistCompletionObserver};
+
+const MINUTES: Duration = Duration::from_secs(60 * 60);
+
+#[derive(Debug)]
+pub(crate) struct ParquetFileInstrumentation<T> {
+    inner: T,
+
+    row_count: U64Histogram,
+    column_count: U64Histogram,
+    file_size_bytes: U64Histogram,
+    file_time_range: DurationHistogram,
+}
+
+impl<T> ParquetFileInstrumentation<T> {
+    pub(crate) fn new(inner: T, metrics: &metric::Registry) -> Self {
+        // A metric capturing the duration difference between min & max
+        // timestamps.
+        let file_time_range: DurationHistogram = metrics
+            .register_metric_with_options::<DurationHistogram, _>(
+                "ingester_persist_parquet_file_time_range",
+                "range from min to max timestamp in output parquet file",
+                || {
+                    DurationHistogramOptions::new([
+                        30 * MINUTES,    // 30m
+                        60 * MINUTES,    // 1h
+                        120 * MINUTES,   // 2h
+                        240 * MINUTES,   // 4h
+                        480 * MINUTES,   // 8h
+                        960 * MINUTES,   // 16h
+                        1_920 * MINUTES, // 32h
+                        DURATION_MAX,
+                    ])
+                },
+            )
+            .recorder(&[]);
+
+        // File size distribution.
+        let file_size_bytes: U64Histogram = metrics
+            .register_metric_with_options::<U64Histogram, _>(
+                "ingester_persist_parquet_file_size_bytes",
+                "distribution of output parquet file size in bytes",
+                || {
+                    U64HistogramOptions::new([
+                        4_u64.pow(5),  // 1 kibibyte
+                        4_u64.pow(6),  // 4 kibibytes
+                        4_u64.pow(7),  // 16 kibibytes
+                        4_u64.pow(8),  // 64 kibibytes
+                        4_u64.pow(9),  // 256 kibibytes
+                        4_u64.pow(10), // 1 mebibyte
+                        4_u64.pow(11), // 4 mebibytes
+                        4_u64.pow(12), // 16 mebibytes
+                        4_u64.pow(13), // 64 mebibytes
+                        4_u64.pow(14), // 256 mebibytes
+                        4_u64.pow(15), // 1 gibibyte
+                        4_u64.pow(16), // 4 gibibytes
+                        u64::MAX,
+                    ])
+                },
+            )
+            .recorder(&[]);
+
+        // Row count distribution.
+        let row_count: U64Histogram = metrics
+            .register_metric_with_options::<U64Histogram, _>(
+                "ingester_persist_parquet_file_row_count",
+                "distribution of row count in output parquet files",
+                || {
+                    U64HistogramOptions::new([
+                        4_u64.pow(3),  // 64
+                        4_u64.pow(4),  // 256
+                        4_u64.pow(5),  // 1,024
+                        4_u64.pow(6),  // 4,096
+                        4_u64.pow(7),  // 16,384
+                        4_u64.pow(8),  // 65,536
+                        4_u64.pow(9),  // 262,144
+                        4_u64.pow(10), // 1,048,576
+                        4_u64.pow(11), // 4,194,304
+                        4_u64.pow(12), // 16,777,216
+                        u64::MAX,
+                    ])
+                },
+            )
+            .recorder(&[]);
+
+        // Column count distribution.
+        //
+        // Because the column count is, by default, limited per table, this
+        // range should exceed that limit by some degree to discover overshoot
+        // (limits are eventually consistent) and correctly measure workloads
+        // that have been configured with a higher limit.
+        let column_count: U64Histogram = metrics
+            .register_metric_with_options::<U64Histogram, _>(
+                "ingester_persist_parquet_file_column_count",
+                "distribution of column count in output parquet files",
+                || {
+                    U64HistogramOptions::new([
+                        2_u64.pow(1),  // 2
+                        2_u64.pow(2),  // 4
+                        2_u64.pow(3),  // 8
+                        2_u64.pow(4),  // 16
+                        2_u64.pow(5),  // 32
+                        2_u64.pow(6),  // 64
+                        2_u64.pow(7),  // 128
+                        2_u64.pow(8),  // 256
+                        2_u64.pow(9),  // 512
+                        2_u64.pow(10), // 1,024
+                        2_u64.pow(11), // 2,048
+                        u64::MAX,
+                    ])
+                },
+            )
+            .recorder(&[]);
+
+        Self {
+            inner,
+            row_count,
+            column_count,
+            file_size_bytes,
+            file_time_range,
+        }
+    }
+}
+
+#[async_trait]
+impl<T> PersistCompletionObserver for ParquetFileInstrumentation<T>
+where
+    T: PersistCompletionObserver,
+{
+    async fn persist_complete(&self, note: Arc<CompletedPersist>) {
+        // Observe the persistence notification values.
+        self.row_count.record(note.row_count() as _);
+        self.column_count.record(note.column_count() as _);
+        self.file_size_bytes.record(note.parquet_file_bytes() as _);
+        self.file_time_range.record(note.timestamp_range());
+
+        // Forward on the notification to the next handler.
+        self.inner.persist_complete(note).await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use data_types::{
+        sequence_number_set::SequenceNumberSet, ColumnId, ColumnSet, NamespaceId,
+        ParquetFileParams, PartitionId, TableId, Timestamp,
+    };
+    use metric::assert_histogram;
+
+    use crate::persist::completion_observer::mock::MockCompletionObserver;
+
+    use super::*;
+
+    const NAMESPACE_ID: NamespaceId = NamespaceId::new(1);
+    const TABLE_ID: TableId = TableId::new(1);
+    const PARTITION_ID: PartitionId = PartitionId::new(1);
+
+    #[tokio::test]
+    async fn test_persisted_file_metrics() {
+        let inner = Arc::new(MockCompletionObserver::default());
+
+        let metrics = metric::Registry::default();
+        let decorator = ParquetFileInstrumentation::new(Arc::clone(&inner), &metrics);
+
+        let meta = ParquetFileParams {
+            namespace_id: NAMESPACE_ID,
+            table_id: TABLE_ID,
+            partition_id: PARTITION_ID,
+            object_store_id: Default::default(),
+            min_time: Timestamp::new(Duration::from_secs(1_000).as_nanos() as _),
+            max_time: Timestamp::new(Duration::from_secs(1_042).as_nanos() as _), // 42 seconds later
+            file_size_bytes: 42424242,
+            row_count: 24,
+            compaction_level: data_types::CompactionLevel::Initial,
+            created_at: Timestamp::new(1234),
+            column_set: ColumnSet::new([1, 2, 3, 4].into_iter().map(ColumnId::new)),
+            max_l0_created_at: Timestamp::new(42),
+        };
+
+        decorator
+            .persist_complete(Arc::new(CompletedPersist::new(
+                meta.clone(),
+                SequenceNumberSet::default(),
+            )))
+            .await;
+
+        assert_histogram!(
+            metrics,
+            DurationHistogram,
+            "ingester_persist_parquet_file_time_range",
+            samples = 1,
+            sum = Duration::from_secs(42),
+        );
+
+        assert_histogram!(
+            metrics,
+            U64Histogram,
+            "ingester_persist_parquet_file_size_bytes",
+            samples = 1,
+            sum = meta.file_size_bytes as u64,
+        );
+
+        assert_histogram!(
+            metrics,
+            U64Histogram,
+            "ingester_persist_parquet_file_row_count",
+            samples = 1,
+            sum = meta.row_count as u64,
+        );
+
+        assert_histogram!(
+            metrics,
+            U64Histogram,
+            "ingester_persist_parquet_file_column_count",
+            samples = 1,
+            sum = meta.column_set.len() as u64,
+        );
+    }
+}

--- a/ingester/src/persist/mod.rs
+++ b/ingester/src/persist/mod.rs
@@ -5,6 +5,7 @@ pub(super) mod compact;
 pub(crate) mod completion_observer;
 mod context;
 pub(crate) mod drain_buffer;
+pub(crate) mod file_metrics;
 pub(crate) mod handle;
 pub(crate) mod hot_partitions;
 pub mod queue;

--- a/ingester/src/persist/worker.rs
+++ b/ingester/src/persist/worker.rs
@@ -135,12 +135,17 @@ pub(super) async fn run_task<O>(
         };
 
         // Make the newly uploaded parquet file visible to other nodes.
-        let object_store_id = update_catalog_parquet(&ctx, &worker_state, parquet_table_data).await;
+        let object_store_id =
+            update_catalog_parquet(&ctx, &worker_state, &parquet_table_data).await;
 
         // And finally mark the persist job as complete and notify any
         // observers.
-        ctx.mark_complete(object_store_id, &worker_state.completion_observer)
-            .await;
+        ctx.mark_complete(
+            object_store_id,
+            parquet_table_data,
+            &worker_state.completion_observer,
+        )
+        .await;
 
         // Capture the time spent actively persisting.
         let now = Instant::now();
@@ -459,7 +464,7 @@ where
 async fn update_catalog_parquet<O>(
     ctx: &Context,
     worker_state: &SharedWorkerState<O>,
-    parquet_table_data: ParquetFileParams,
+    parquet_table_data: &ParquetFileParams,
 ) -> Uuid
 where
     O: Send + Sync,

--- a/ingester/src/wal/reference_tracker/handle.rs
+++ b/ingester/src/wal/reference_tracker/handle.rs
@@ -209,7 +209,9 @@ mod tests {
 
     use assert_matches::assert_matches;
     use async_trait::async_trait;
-    use data_types::{NamespaceId, PartitionId, TableId};
+    use data_types::{
+        ColumnId, ColumnSet, NamespaceId, ParquetFileParams, PartitionId, TableId, Timestamp,
+    };
     use futures::{task::Context, Future, FutureExt};
     use metric::{assert_counter, U64Gauge};
     use parking_lot::Mutex;
@@ -262,9 +264,20 @@ mod tests {
         T: IntoIterator<Item = i64>,
     {
         Arc::new(CompletedPersist::new(
-            NamespaceId::new(1),
-            TableId::new(2),
-            PartitionId::new(3),
+            ParquetFileParams {
+                namespace_id: NamespaceId::new(1),
+                table_id: TableId::new(2),
+                partition_id: PartitionId::new(3),
+                object_store_id: Default::default(),
+                min_time: Timestamp::new(42),
+                max_time: Timestamp::new(42),
+                file_size_bytes: 42424242,
+                row_count: 24,
+                compaction_level: data_types::CompactionLevel::Initial,
+                created_at: Timestamp::new(1234),
+                column_set: ColumnSet::new([1, 2, 3, 4].into_iter().map(ColumnId::new)),
+                max_l0_created_at: Timestamp::new(42),
+            },
             new_set(vals),
         ))
     }


### PR DESCRIPTION
This PR adds a metric observer to the Ingester's persist subsystem that captures various statistics about the generated files.

These statistics will help us quantify the effects of tuning the system for less frequent file generation.

---

* refactor: parquet metadata in persist notification (507ccc2eb)
      
      Changes the CompletedPersist notification data structure to embed the
      generated parquet file's metadata for completion observers.

* feat: persisted Parquet file attribute metrics (3114c67cf)
      
      Implements a PersistCompletionObserver that records various attributes
      of the generated and persisted Parquet file as histogram metrics to
      capture the distribution of values:
      
          * File size
          * Row count
          * Column count
          * Time range of data (max - min timestamp)
      
      These metrics will give us insight into the generated files instead of
      relying on intuition when tuning various configuration parameters.

* refactor(ingester): emit Parquet file metrics (74210b625)
      
      Register the ParquetFileInstrumentation as a PersistCompletionObserver
      in the persist subsystem.

* test(ingester): persist & persistence metrics (9b211df05)
      
      Adds a test that asserts (manually triggered) persistence generates a
      file, uploads it to object storage, inserts metadata into the catalog,
      and emits various persistence metrics.