### PR TITLE
fix: correct time range buckets

### DIFF
--- a/ingester/src/persist/file_metrics.rs
+++ b/ingester/src/persist/file_metrics.rs
@@ -7,7 +7,7 @@ use metric::{
 
 use super::completion_observer::{CompletedPersist, PersistCompletionObserver};
 
-const MINUTES: Duration = Duration::from_secs(60 * 60);
+const MINUTES: Duration = Duration::from_secs(60);
 
 #[derive(Debug)]
 pub(crate) struct ParquetFileInstrumentation<T> {


### PR DESCRIPTION
Who knew?

---

* fix: correct time range buckets (0a31afd00)
      
      Turns out there are 60 seconds in a minute, not 3,600.