### PR TITLE
refactor(export): Use observer instead of `println!` for export

### DIFF
--- a/import_export/src/file/mod.rs
+++ b/import_export/src/file/mod.rs
@@ -1,6 +1,6 @@
-/// Code to import/export files
+/// Code to import/export catalog and parquet information to files
 mod export;
 mod import;
 
-pub use export::{ExportError, RemoteExporter};
+pub use export::{ExportError, ExportObserver, ExportedParquetFileInfo, RemoteExporter};
 pub use import::{ExportedContents, ImportError};


### PR DESCRIPTION
Draft as it builds on https://github.com/influxdata/influxdb_iox/pull/7779

# Rationale

Follow on to https://github.com/influxdata/influxdb_iox/pull/7779

I moved code that was part of the CLI code (that had `println`s to another crate) but  I want to separate out the printing from the actual logic, to make the code cleaner

# Changes
Move `println!` code to the CLI implementation of export, using an `Observer`