### PR TITLE
feat(wal_inspect): Make table batch writing a trait, support table ID based line protocol

### DIFF
--- a/wal_inspect/src/lib.rs
+++ b/wal_inspect/src/lib.rs
@@ -133,13 +133,17 @@ where
             .entry(ns)
             .or_insert((self.new_write_sink)(ns)?);
 
-        write_batches_as_line_proto(sink, &self.table_name_index, table_batches.into_iter())
+        write_batches_as_line_proto(
+            sink,
+            self.table_name_index.as_ref(),
+            table_batches.into_iter(),
+        )
     }
 }
 
 fn write_batches_as_line_proto<W, B>(
     sink: &mut W,
-    table_name_index: &Option<HashMap<TableId, String>>,
+    table_name_index: Option<&HashMap<TableId, String>>,
     table_batches: B,
 ) -> Result<(), WriteError>
 where
@@ -386,7 +390,7 @@ m2,t=bar v="arán" 1"#,
             .map(|(i, (_table_name, batch))| (i as i64, batch)),
         );
 
-        write_batches_as_line_proto(&mut sink, &None, batches.into_iter())
+        write_batches_as_line_proto(&mut sink, None, batches.into_iter())
             .expect("write back to line proto should succeed");
 
         assert_eq!(


### PR DESCRIPTION
Some small additions to `wal_inspect` I've been making during my implementation of the CLI command. 

This makes 2 changes. First, batch writing behaviour is now a trait so that generic code can operate on writers with different `Fn(NamespaceId) -> Result<W: Write, Error>` write sink closures. Second is to make the Table ID -> Table Name index optional for instances where table names are not needed/catalog lookup is not available. When no index is provided IDs are used as measurement names.

---

* refactor(wal_inspect): Make namespaced table batch writing a trait (e7a0ed4b2)

      This change allows callers to treat LineProtoWriter instances with
      different write sink generators the same using generic parameters.

* feat(wal_inspect): Make table_name_index optional for line proto writing (d530b728d)

      This will allow for decoding a WAL into line protocol without connecting
      to a catalog service (or having an equivalent name lookup mechanism).