### PR TITLE
test: Add an invalid test configuration checker and fix potentially flaky test setups it detects

### DIFF
--- a/influxdb_iox/tests/end_to_end_cases/cli.rs
+++ b/influxdb_iox/tests/end_to_end_cases/cli.rs
@@ -70,7 +70,7 @@ async fn parquet_to_lp() {
             Step::RecordNumParquetFiles,
             Step::WriteLineProtocol(String::from(line_protocol)),
             // wait for partitions to be persisted
-            Step::WaitForPersisted2 {
+            Step::WaitForPersisted {
                 expected_increase: 1,
             },
             // Run the 'remote partition' command
@@ -193,7 +193,7 @@ async fn schema_cli() {
             Step::WriteLineProtocol(String::from(
                 "my_awesome_table2,tag1=A,tag2=B val=42i 123456",
             )),
-            Step::WaitForPersisted2 {
+            Step::WaitForPersisted {
                 expected_increase: 1,
             },
             Step::Custom(Box::new(|state: &mut StepTestState| {

--- a/influxdb_iox/tests/end_to_end_cases/compactor.rs
+++ b/influxdb_iox/tests/end_to_end_cases/compactor.rs
@@ -120,7 +120,7 @@ async fn sharded_compactor_0_always_compacts_partition_1() {
                 "my_awesome_table,tag1=A,tag2=B val=42i 123456",
             )),
             // wait for partitions to be persisted
-            Step::WaitForPersisted2 {
+            Step::WaitForPersisted {
                 expected_increase: 1,
             },
             // Run the compactor
@@ -203,7 +203,7 @@ async fn sharded_compactor_1_never_compacts_partition_1() {
                 "my_awesome_table,tag1=A,tag2=B val=42i 123456",
             )),
             // wait for partitions to be persisted
-            Step::WaitForPersisted2 {
+            Step::WaitForPersisted {
                 expected_increase: 1,
             },
             // Run the compactor

--- a/influxdb_iox/tests/end_to_end_cases/ingester.rs
+++ b/influxdb_iox/tests/end_to_end_cases/ingester.rs
@@ -54,7 +54,7 @@ async fn persist_on_demand() {
                 .boxed()
             })),
             Step::Persist,
-            Step::WaitForPersisted2 {
+            Step::WaitForPersisted {
                 expected_increase: 1,
             },
             // Ensure the ingester responds with the correct file count to tell the querier

--- a/influxdb_iox/tests/end_to_end_cases/querier.rs
+++ b/influxdb_iox/tests/end_to_end_cases/querier.rs
@@ -73,7 +73,7 @@ async fn never_persist_really_never_persists() {
                  {table_name},tag1=A,tag2=C val=43i 123457"
             )),
             // This should_panic if the ingester setup is correct
-            Step::WaitForPersisted2 {
+            Step::WaitForPersisted {
                 expected_increase: 1,
             },
         ],
@@ -98,7 +98,7 @@ async fn basic_on_parquet() {
             Step::RecordNumParquetFiles,
             Step::WriteLineProtocol(format!("{table_name},tag1=A,tag2=B val=42i 123456")),
             // Wait for data to be persisted to parquet
-            Step::WaitForPersisted2 {
+            Step::WaitForPersisted {
                 expected_increase: 1,
             },
             Step::Query {
@@ -147,7 +147,7 @@ async fn basic_empty() {
                  {table_name},tag1=A,tag2=C val=43i 123457"
             )),
             // Wait for data to be persisted to parquet
-            Step::WaitForPersisted2 {
+            Step::WaitForPersisted {
                 expected_increase: 1,
             },
             Step::Custom(Box::new(move |state: &mut StepTestState| {
@@ -215,7 +215,7 @@ async fn basic_no_ingester_connection() {
         vec![
             Step::RecordNumParquetFiles,
             Step::WriteLineProtocol(format!("{table_name},tag1=A,tag2=B val=42i 123456")),
-            Step::WaitForPersisted2 {
+            Step::WaitForPersisted {
                 expected_increase: 1,
             },
             Step::Query {
@@ -251,7 +251,7 @@ async fn query_after_persist_sees_new_files() {
         Step::RecordNumParquetFiles,
         Step::WriteLineProtocol(format!("{table_name},tag1=A,tag2=B val=42i 123456")),
         // Wait for data to be persisted to parquet
-        Step::WaitForPersisted2 {
+        Step::WaitForPersisted {
             expected_increase: 1,
         },
         Step::Query {
@@ -279,7 +279,7 @@ async fn query_after_persist_sees_new_files() {
         // write another parquet file that has non duplicated data
         Step::WriteLineProtocol(format!("{table_name},tag1=B,tag2=A val=43i 789101112")),
         // Wait for data to be persisted to parquet
-        Step::WaitForPersisted2 {
+        Step::WaitForPersisted {
             expected_increase: 1,
         },
         // query should correctly see the data in the second parquet file
@@ -315,12 +315,12 @@ async fn table_not_found_on_ingester() {
         vec![
             Step::RecordNumParquetFiles,
             Step::WriteLineProtocol(format!("{table_name},tag1=A,tag2=B val=42i 123456")),
-            Step::WaitForPersisted2 {
+            Step::WaitForPersisted {
                 expected_increase: 1,
             },
             Step::RecordNumParquetFiles,
             Step::WriteLineProtocol(String::from("other_table,tag1=A,tag2=B val=42i 123456")),
-            Step::WaitForPersisted2 {
+            Step::WaitForPersisted {
                 expected_increase: 1,
             },
             // Restart the ingesters so that they don't have any table data in memory
@@ -391,7 +391,7 @@ async fn issue_4631_a() {
         // Persist ingester data
         Step::Persist,
         // Here the ingester calculates the partition sort key.
-        Step::WaitForPersisted2 {
+        Step::WaitForPersisted {
             expected_increase: 1,
         },
         Step::RecordNumParquetFiles,
@@ -402,7 +402,7 @@ async fn issue_4631_a() {
             "{table_name},tag=A val=\"bar\" 1\n{table_name},tag=B val=\"arglebargle\" 2\n"
         )),
         Step::Persist,
-        Step::WaitForPersisted2 {
+        Step::WaitForPersisted {
             expected_increase: 1,
         },
         // query
@@ -442,7 +442,7 @@ async fn issue_4631_b() {
             Step::RecordNumParquetFiles,
             // create persisted chunk with a single tag column
             Step::WriteLineProtocol(format!("{table_name},tag=A val=\"foo\" 1")),
-            Step::WaitForPersisted2 {
+            Step::WaitForPersisted {
                 expected_increase: 1,
             },
             // query to prime the querier caches with partition sort key
@@ -460,7 +460,7 @@ async fn issue_4631_b() {
             // create 2nd chunk with an additional tag column (which will be included in the
             // partition sort key)
             Step::WriteLineProtocol(format!("{table_name},tag=A,tag2=B val=\"bar\" 1\n")),
-            Step::WaitForPersisted2 {
+            Step::WaitForPersisted {
                 expected_increase: 1,
             },
             // in the original bug the querier would now panic with:

--- a/influxdb_iox/tests/end_to_end_cases/querier/multi_ingester.rs
+++ b/influxdb_iox/tests/end_to_end_cases/querier/multi_ingester.rs
@@ -45,7 +45,7 @@ async fn basic_multi_ingesters() {
     }
     // Persist those writes
     test_steps.push(Step::Persist);
-    test_steps.push(Step::WaitForPersisted2 {
+    test_steps.push(Step::WaitForPersisted {
         // One file from each ingester
         expected_increase: 2,
     });
@@ -129,7 +129,7 @@ async fn write_replication() {
     }
     // Persist those writes
     test_steps.push(Step::Persist);
-    test_steps.push(Step::WaitForPersisted2 {
+    test_steps.push(Step::WaitForPersisted {
         // One file from each ingester
         expected_increase: 2,
     });

--- a/influxdb_iox/tests/end_to_end_cases/remote.rs
+++ b/influxdb_iox/tests/end_to_end_cases/remote.rs
@@ -24,19 +24,19 @@ async fn remote_store_get_table() {
             // Persist some data
             Step::RecordNumParquetFiles,
             Step::WriteLineProtocol(format!("{table_name},tag1=A,tag2=B val=42i 123456")),
-            Step::WaitForPersisted2 {
+            Step::WaitForPersisted {
                 expected_increase: 1,
             },
             // Persist some more data for the same table in a 2nd Parquet file
             Step::RecordNumParquetFiles,
             Step::WriteLineProtocol(format!("{table_name},tag1=C,tag2=B val=9000i 789000")),
-            Step::WaitForPersisted2 {
+            Step::WaitForPersisted {
                 expected_increase: 1,
             },
             // Persist some more data for a different table
             Step::RecordNumParquetFiles,
             Step::WriteLineProtocol(format!("{other_table_name},tag1=A,tag2=B val=42i 123456")),
-            Step::WaitForPersisted2 {
+            Step::WaitForPersisted {
                 expected_increase: 1,
             },
             Step::Custom(Box::new(move |state: &mut StepTestState| {
@@ -253,7 +253,7 @@ async fn remote_partition_and_get_from_store_and_pull() {
                 "my_awesome_table,tag1=A,tag2=B val=42i 123456",
             )),
             // wait for partitions to be persisted
-            Step::WaitForPersisted2 {
+            Step::WaitForPersisted {
                 expected_increase: 1,
             },
             // Run the 'remote partition' command

--- a/influxdb_iox/tests/query_tests/cases.rs
+++ b/influxdb_iox/tests/query_tests/cases.rs
@@ -43,7 +43,7 @@ async fn basic() {
 
     TestCase {
         input: "cases/in/basic.sql",
-        chunk_stage: ChunkStage::All,
+        chunk_stage: ChunkStage::Ingester,
     }
     .run()
     .await;
@@ -55,7 +55,7 @@ async fn date_bin() {
 
     TestCase {
         input: "cases/in/date_bin.sql",
-        chunk_stage: ChunkStage::All,
+        chunk_stage: ChunkStage::Ingester,
     }
     .run()
     .await;
@@ -67,7 +67,7 @@ async fn dedup_and_predicates_parquet() {
 
     TestCase {
         input: "cases/in/dedup_and_predicates_parquet.sql",
-        chunk_stage: ChunkStage::Parquet,
+        chunk_stage: ChunkStage::Ingester,
     }
     .run()
     .await;
@@ -103,7 +103,7 @@ async fn duplicates_parquet() {
 
     TestCase {
         input: "cases/in/duplicates_parquet.sql",
-        chunk_stage: ChunkStage::Parquet,
+        chunk_stage: ChunkStage::Ingester,
     }
     .run()
     .await;
@@ -115,7 +115,7 @@ async fn duplicates_parquet_20() {
 
     TestCase {
         input: "cases/in/duplicates_parquet_20.sql",
-        chunk_stage: ChunkStage::Parquet,
+        chunk_stage: ChunkStage::Ingester,
     }
     .run()
     .await;
@@ -127,7 +127,7 @@ async fn duplicates_parquet_20_and_ingester() {
 
     TestCase {
         input: "cases/in/duplicates_parquet_20_and_ingester.sql",
-        chunk_stage: ChunkStage::Parquet,
+        chunk_stage: ChunkStage::Ingester,
     }
     .run()
     .await;
@@ -139,7 +139,7 @@ async fn duplicates_parquet_50() {
 
     TestCase {
         input: "cases/in/duplicates_parquet_50.sql",
-        chunk_stage: ChunkStage::Parquet,
+        chunk_stage: ChunkStage::Ingester,
     }
     .run()
     .await;
@@ -151,7 +151,7 @@ async fn duplicates_different_domains() {
 
     TestCase {
         input: "cases/in/duplicates_different_domains.sql",
-        chunk_stage: ChunkStage::Parquet,
+        chunk_stage: ChunkStage::Ingester,
     }
     .run()
     .await;
@@ -211,7 +211,7 @@ async fn pushdown() {
 
     TestCase {
         input: "cases/in/pushdown.sql",
-        chunk_stage: ChunkStage::Parquet,
+        chunk_stage: ChunkStage::Ingester,
     }
     .run()
     .await;
@@ -319,7 +319,7 @@ async fn restaurant() {
 
     TestCase {
         input: "cases/in/restaurant.sql",
-        chunk_stage: ChunkStage::All,
+        chunk_stage: ChunkStage::Ingester,
     }
     .run()
     .await;
@@ -331,7 +331,7 @@ async fn union_all() {
 
     TestCase {
         input: "cases/in/union_all.sql",
-        chunk_stage: ChunkStage::All,
+        chunk_stage: ChunkStage::Ingester,
     }
     .run()
     .await;

--- a/influxdb_iox/tests/query_tests/setups.rs
+++ b/influxdb_iox/tests/query_tests/setups.rs
@@ -35,7 +35,7 @@ pub static SETUPS: Lazy<HashMap<SetupName, SetupSteps>> = Lazy::new(|| {
                     .join("\n"),
                 ),
                 Step::Persist,
-                Step::WaitForPersisted2 {
+                Step::WaitForPersisted {
                     expected_increase: 1,
                 },
             ],
@@ -53,7 +53,7 @@ pub static SETUPS: Lazy<HashMap<SetupName, SetupSteps>> = Lazy::new(|| {
                     .join("\n"),
                 ),
                 Step::Persist,
-                Step::WaitForPersisted2 {
+                Step::WaitForPersisted {
                     expected_increase: 2,
                 },
             ],
@@ -64,13 +64,13 @@ pub static SETUPS: Lazy<HashMap<SetupName, SetupSteps>> = Lazy::new(|| {
                 Step::RecordNumParquetFiles,
                 Step::WriteLineProtocol("table,tag=A foo=1,bar=1 0".into()),
                 Step::Persist,
-                Step::WaitForPersisted2 {
+                Step::WaitForPersisted {
                     expected_increase: 1,
                 },
                 Step::RecordNumParquetFiles,
                 Step::WriteLineProtocol(["table,tag=A bar=2 0", "table,tag=B foo=1 0"].join("\n")),
                 Step::Persist,
-                Step::WaitForPersisted2 {
+                Step::WaitForPersisted {
                     expected_increase: 1,
                 },
             ],
@@ -81,7 +81,7 @@ pub static SETUPS: Lazy<HashMap<SetupName, SetupSteps>> = Lazy::new(|| {
                 Step::RecordNumParquetFiles,
                 Step::WriteLineProtocol("table,tag=A foo=1,bar=1 0".into()),
                 Step::Persist,
-                Step::WaitForPersisted2 {
+                Step::WaitForPersisted {
                     expected_increase: 1,
                 },
                 Step::WriteLineProtocol(["table,tag=A bar=2 0", "table,tag=B foo=1 0"].join("\n")),
@@ -104,7 +104,7 @@ pub static SETUPS: Lazy<HashMap<SetupName, SetupSteps>> = Lazy::new(|| {
                     .join("\n"),
                 ),
                 Step::Persist,
-                Step::WaitForPersisted2 {
+                Step::WaitForPersisted {
                     expected_increase: 1,
                 },
                 Step::RecordNumParquetFiles,
@@ -124,7 +124,7 @@ pub static SETUPS: Lazy<HashMap<SetupName, SetupSteps>> = Lazy::new(|| {
                     .join("\n"),
                 ),
                 Step::Persist,
-                Step::WaitForPersisted2 {
+                Step::WaitForPersisted {
                     expected_increase: 1,
                 },
                 Step::RecordNumParquetFiles,
@@ -143,7 +143,7 @@ pub static SETUPS: Lazy<HashMap<SetupName, SetupSteps>> = Lazy::new(|| {
                     .join("\n"),
                 ),
                 Step::Persist,
-                Step::WaitForPersisted2 {
+                Step::WaitForPersisted {
                     expected_increase: 1,
                 },
                 // Chunk 4: no overlap
@@ -179,7 +179,7 @@ pub static SETUPS: Lazy<HashMap<SetupName, SetupSteps>> = Lazy::new(|| {
                     .join("\n"),
                 ),
                 Step::Persist,
-                Step::WaitForPersisted2 {
+                Step::WaitForPersisted {
                     expected_increase: 1,
                 },
                 Step::RecordNumParquetFiles,
@@ -199,7 +199,7 @@ pub static SETUPS: Lazy<HashMap<SetupName, SetupSteps>> = Lazy::new(|| {
                     .join("\n"),
                 ),
                 Step::Persist,
-                Step::WaitForPersisted2 {
+                Step::WaitForPersisted {
                     expected_increase: 1,
                 },
                 Step::RecordNumParquetFiles,
@@ -218,7 +218,7 @@ pub static SETUPS: Lazy<HashMap<SetupName, SetupSteps>> = Lazy::new(|| {
                     .join("\n"),
                 ),
                 Step::Persist,
-                Step::WaitForPersisted2 {
+                Step::WaitForPersisted {
                     expected_increase: 1,
                 },
                 Step::RecordNumParquetFiles,
@@ -237,7 +237,7 @@ pub static SETUPS: Lazy<HashMap<SetupName, SetupSteps>> = Lazy::new(|| {
                     .join("\n"),
                 ),
                 Step::Persist,
-                Step::WaitForPersisted2 {
+                Step::WaitForPersisted {
                     expected_increase: 1,
                 },
             ],
@@ -261,7 +261,7 @@ pub static SETUPS: Lazy<HashMap<SetupName, SetupSteps>> = Lazy::new(|| {
                         Step::RecordNumParquetFiles,
                         write,
                         Step::Persist,
-                        Step::WaitForPersisted2 {
+                        Step::WaitForPersisted {
                             expected_increase: 1,
                         },
                     ]
@@ -288,7 +288,7 @@ pub static SETUPS: Lazy<HashMap<SetupName, SetupSteps>> = Lazy::new(|| {
                         Step::RecordNumParquetFiles,
                         write,
                         Step::Persist,
-                        Step::WaitForPersisted2 {
+                        Step::WaitForPersisted {
                             expected_increase: 1,
                         },
                     ]
@@ -313,7 +313,7 @@ pub static SETUPS: Lazy<HashMap<SetupName, SetupSteps>> = Lazy::new(|| {
                         Step::RecordNumParquetFiles,
                         write,
                         Step::Persist,
-                        Step::WaitForPersisted2 {
+                        Step::WaitForPersisted {
                             expected_increase: 1,
                         },
                     ]
@@ -337,7 +337,7 @@ pub static SETUPS: Lazy<HashMap<SetupName, SetupSteps>> = Lazy::new(|| {
                     .join("\n"),
                 ),
                 Step::Persist,
-                Step::WaitForPersisted2 {
+                Step::WaitForPersisted {
                     expected_increase: 1,
                 },
             ],
@@ -357,7 +357,7 @@ pub static SETUPS: Lazy<HashMap<SetupName, SetupSteps>> = Lazy::new(|| {
                     .join("\n"),
                 ),
                 Step::Persist,
-                Step::WaitForPersisted2 {
+                Step::WaitForPersisted {
                     expected_increase: 2,
                 },
                 Step::RecordNumParquetFiles,
@@ -365,7 +365,7 @@ pub static SETUPS: Lazy<HashMap<SetupName, SetupSteps>> = Lazy::new(|| {
                     "h2o,state=MA,city=Boston temp=70.4,moisture=43.0 100000".into(),
                 ),
                 Step::Persist,
-                Step::WaitForPersisted2 {
+                Step::WaitForPersisted {
                     expected_increase: 1,
                 },
             ],
@@ -382,7 +382,7 @@ pub static SETUPS: Lazy<HashMap<SetupName, SetupSteps>> = Lazy::new(|| {
                     .join("\n"),
                 ),
                 Step::Persist,
-                Step::WaitForPersisted2 {
+                Step::WaitForPersisted {
                     expected_increase: 1,
                 },
                 Step::WriteLineProtocol(
@@ -420,7 +420,7 @@ pub static SETUPS: Lazy<HashMap<SetupName, SetupSteps>> = Lazy::new(|| {
                     .join("\n"),
                 ),
                 Step::Persist,
-                Step::WaitForPersisted2 {
+                Step::WaitForPersisted {
                     expected_increase: 2,
                 },
                 Step::RecordNumParquetFiles,
@@ -433,7 +433,7 @@ pub static SETUPS: Lazy<HashMap<SetupName, SetupSteps>> = Lazy::new(|| {
                     .join("\n"),
                 ),
                 Step::Persist,
-                Step::WaitForPersisted2 {
+                Step::WaitForPersisted {
                     expected_increase: 1,
                 },
             ],
@@ -498,7 +498,7 @@ pub static SETUPS: Lazy<HashMap<SetupName, SetupSteps>> = Lazy::new(|| {
                     .join("\n"),
                 ),
                 Step::Persist,
-                Step::WaitForPersisted2 {
+                Step::WaitForPersisted {
                     expected_increase: 2,
                 },
             ],
@@ -545,14 +545,14 @@ pub static SETUPS: Lazy<HashMap<SetupName, SetupSteps>> = Lazy::new(|| {
                     .join("\n"),
                 ),
                 Step::Persist,
-                Step::WaitForPersisted2 {
+                Step::WaitForPersisted {
                     expected_increase: 1,
                 },
                 Step::RecordNumParquetFiles,
                 // c2: parquet stage & overlaps with c1
                 Step::WriteLineProtocol("h2o,state=CA,city=Andover other_temp=72.4 150".into()),
                 Step::Persist,
-                Step::WaitForPersisted2 {
+                Step::WaitForPersisted {
                     expected_increase: 1,
                 },
                 Step::RecordNumParquetFiles,
@@ -565,7 +565,7 @@ pub static SETUPS: Lazy<HashMap<SetupName, SetupSteps>> = Lazy::new(|| {
                     .join("\n"),
                 ),
                 Step::Persist,
-                Step::WaitForPersisted2 {
+                Step::WaitForPersisted {
                     expected_increase: 1,
                 },
                 Step::RecordNumParquetFiles,
@@ -580,7 +580,7 @@ pub static SETUPS: Lazy<HashMap<SetupName, SetupSteps>> = Lazy::new(|| {
                     .join("\n"),
                 ),
                 Step::Persist,
-                Step::WaitForPersisted2 {
+                Step::WaitForPersisted {
                     expected_increase: 1,
                 },
                 // c5: ingester stage & doesn't overlap with any
@@ -599,7 +599,7 @@ pub static SETUPS: Lazy<HashMap<SetupName, SetupSteps>> = Lazy::new(|| {
                     i64::MAX - 1, // 9223372036854775806
                 )),
                 Step::Persist,
-                Step::WaitForPersisted2 {
+                Step::WaitForPersisted {
                     expected_increase: 1,
                 },
             ],
@@ -616,7 +616,7 @@ pub static SETUPS: Lazy<HashMap<SetupName, SetupSteps>> = Lazy::new(|| {
                     .join("\n"),
                 ),
                 Step::Persist,
-                Step::WaitForPersisted2 {
+                Step::WaitForPersisted {
                     expected_increase: 1,
                 },
             ],
@@ -635,7 +635,7 @@ pub static SETUPS: Lazy<HashMap<SetupName, SetupSteps>> = Lazy::new(|| {
                     .join("\n"),
                 ),
                 Step::Persist,
-                Step::WaitForPersisted2 {
+                Step::WaitForPersisted {
                     expected_increase: 1,
                 },
             ],
@@ -646,13 +646,13 @@ pub static SETUPS: Lazy<HashMap<SetupName, SetupSteps>> = Lazy::new(|| {
                 Step::RecordNumParquetFiles,
                 Step::WriteLineProtocol("table,tag1=a,tag2=b field1=10,field2=11 100".into()),
                 Step::Persist,
-                Step::WaitForPersisted2 {
+                Step::WaitForPersisted {
                     expected_increase: 1,
                 },
                 Step::RecordNumParquetFiles,
                 Step::WriteLineProtocol("table,tag1=a,tag3=c field1=20,field3=22 200".into()),
                 Step::Persist,
-                Step::WaitForPersisted2 {
+                Step::WaitForPersisted {
                     expected_increase: 1,
                 },
             ],
@@ -674,7 +674,7 @@ pub static SETUPS: Lazy<HashMap<SetupName, SetupSteps>> = Lazy::new(|| {
                     .join("\n"),
                 ),
                 Step::Persist,
-                Step::WaitForPersisted2 {
+                Step::WaitForPersisted {
                     expected_increase: 2,
                 },
             ],
@@ -688,7 +688,7 @@ pub static SETUPS: Lazy<HashMap<SetupName, SetupSteps>> = Lazy::new(|| {
                     ["m,tag0=foo fld=\"200\" 1000", "m,tag0=foo fld=\"404\" 1050"].join("\n"),
                 ),
                 Step::Persist,
-                Step::WaitForPersisted2 {
+                Step::WaitForPersisted {
                     expected_increase: 1,
                 },
             ],
@@ -705,7 +705,7 @@ pub static SETUPS: Lazy<HashMap<SetupName, SetupSteps>> = Lazy::new(|| {
                     .join("\n"),
                 ),
                 Step::Persist,
-                Step::WaitForPersisted2 {
+                Step::WaitForPersisted {
                     expected_increase: 1,
                 },
             ],
@@ -725,7 +725,7 @@ pub static SETUPS: Lazy<HashMap<SetupName, SetupSteps>> = Lazy::new(|| {
                     .join("\n"),
                 ),
                 Step::Persist,
-                Step::WaitForPersisted2 {
+                Step::WaitForPersisted {
                     expected_increase: 2,
                 },
             ],
@@ -745,7 +745,7 @@ pub static SETUPS: Lazy<HashMap<SetupName, SetupSteps>> = Lazy::new(|| {
                     .join("\n"),
                 ),
                 Step::Persist,
-                Step::WaitForPersisted2 {
+                Step::WaitForPersisted {
                     expected_increase: 1,
                 },
             ],
@@ -767,7 +767,7 @@ pub static SETUPS: Lazy<HashMap<SetupName, SetupSteps>> = Lazy::new(|| {
                     .join("\n"),
                 ),
                 Step::Persist,
-                Step::WaitForPersisted2 {
+                Step::WaitForPersisted {
                     expected_increase: 1,
                 },
             ],
@@ -791,7 +791,7 @@ pub static SETUPS: Lazy<HashMap<SetupName, SetupSteps>> = Lazy::new(|| {
                     .join("\n"),
                 ),
                 Step::Persist,
-                Step::WaitForPersisted2 {
+                Step::WaitForPersisted {
                     expected_increase: 5,
                 },
             ],
@@ -810,7 +810,7 @@ pub static SETUPS: Lazy<HashMap<SetupName, SetupSteps>> = Lazy::new(|| {
                     .join("\n"),
                 ),
                 Step::Persist,
-                Step::WaitForPersisted2 {
+                Step::WaitForPersisted {
                     expected_increase: 1,
                 },
             ],
@@ -821,7 +821,7 @@ pub static SETUPS: Lazy<HashMap<SetupName, SetupSteps>> = Lazy::new(|| {
                 Step::RecordNumParquetFiles,
                 Step::WriteLineProtocol(["m0 foo=1.0 1", "m0 foo=2.0 2"].join("\n")),
                 Step::Persist,
-                Step::WaitForPersisted2 {
+                Step::WaitForPersisted {
                     expected_increase: 1,
                 },
             ],
@@ -838,7 +838,7 @@ pub static SETUPS: Lazy<HashMap<SetupName, SetupSteps>> = Lazy::new(|| {
                     .join("\n"),
                 ),
                 Step::Persist,
-                Step::WaitForPersisted2 {
+                Step::WaitForPersisted {
                     expected_increase: 1,
                 },
                 Step::RecordNumParquetFiles,
@@ -850,7 +850,7 @@ pub static SETUPS: Lazy<HashMap<SetupName, SetupSteps>> = Lazy::new(|| {
                     .join("\n"),
                 ),
                 Step::Persist,
-                Step::WaitForPersisted2 {
+                Step::WaitForPersisted {
                     expected_increase: 1,
                 },
             ],
@@ -867,7 +867,7 @@ pub static SETUPS: Lazy<HashMap<SetupName, SetupSteps>> = Lazy::new(|| {
                     .join("\n"),
                 ),
                 Step::Persist,
-                Step::WaitForPersisted2 {
+                Step::WaitForPersisted {
                     expected_increase: 1,
                 },
                 Step::RecordNumParquetFiles,
@@ -879,7 +879,7 @@ pub static SETUPS: Lazy<HashMap<SetupName, SetupSteps>> = Lazy::new(|| {
                     .join("\n"),
                 ),
                 Step::Persist,
-                Step::WaitForPersisted2 {
+                Step::WaitForPersisted {
                     expected_increase: 1,
                 },
             ],
@@ -898,7 +898,7 @@ pub static SETUPS: Lazy<HashMap<SetupName, SetupSteps>> = Lazy::new(|| {
                     .join("\n"),
                 ),
                 Step::Persist,
-                Step::WaitForPersisted2 {
+                Step::WaitForPersisted {
                     expected_increase: 1,
                 },
                 Step::RecordNumParquetFiles,
@@ -911,7 +911,7 @@ pub static SETUPS: Lazy<HashMap<SetupName, SetupSteps>> = Lazy::new(|| {
                     .join("\n"),
                 ),
                 Step::Persist,
-                Step::WaitForPersisted2 {
+                Step::WaitForPersisted {
                     expected_increase: 1,
                 },
             ],
@@ -924,7 +924,7 @@ pub static SETUPS: Lazy<HashMap<SetupName, SetupSteps>> = Lazy::new(|| {
                     ["h2o,state=MA,city=Cambridge f=8.0,i=8i,b=true,s=\"d\" 1000"].join("\n"),
                 ),
                 Step::Persist,
-                Step::WaitForPersisted2 {
+                Step::WaitForPersisted {
                     expected_increase: 1,
                 },
                 Step::RecordNumParquetFiles,
@@ -937,7 +937,7 @@ pub static SETUPS: Lazy<HashMap<SetupName, SetupSteps>> = Lazy::new(|| {
                     .join("\n"),
                 ),
                 Step::Persist,
-                Step::WaitForPersisted2 {
+                Step::WaitForPersisted {
                     expected_increase: 1,
                 },
             ],
@@ -954,7 +954,7 @@ pub static SETUPS: Lazy<HashMap<SetupName, SetupSteps>> = Lazy::new(|| {
                     .join("\n"),
                 ),
                 Step::Persist,
-                Step::WaitForPersisted2 {
+                Step::WaitForPersisted {
                     expected_increase: 1,
                 },
                 Step::RecordNumParquetFiles,
@@ -966,7 +966,7 @@ pub static SETUPS: Lazy<HashMap<SetupName, SetupSteps>> = Lazy::new(|| {
                     .join("\n"),
                 ),
                 Step::Persist,
-                Step::WaitForPersisted2 {
+                Step::WaitForPersisted {
                     expected_increase: 1,
                 },
             ],
@@ -984,7 +984,7 @@ pub static SETUPS: Lazy<HashMap<SetupName, SetupSteps>> = Lazy::new(|| {
                     .join("\n"),
                 ),
                 Step::Persist,
-                Step::WaitForPersisted2 {
+                Step::WaitForPersisted {
                     expected_increase: 1,
                 },
                 Step::RecordNumParquetFiles,
@@ -992,7 +992,7 @@ pub static SETUPS: Lazy<HashMap<SetupName, SetupSteps>> = Lazy::new(|| {
                     ["h2o,state=MA,city=Cambridge f=5.0,i=5i,b=false,s=\"z\" 4000"].join("\n"),
                 ),
                 Step::Persist,
-                Step::WaitForPersisted2 {
+                Step::WaitForPersisted {
                     expected_increase: 1,
                 },
             ],
@@ -1010,7 +1010,7 @@ pub static SETUPS: Lazy<HashMap<SetupName, SetupSteps>> = Lazy::new(|| {
                     .join("\n"),
                 ),
                 Step::Persist,
-                Step::WaitForPersisted2 {
+                Step::WaitForPersisted {
                     expected_increase: 1,
                 },
                 Step::RecordNumParquetFiles,
@@ -1024,7 +1024,7 @@ pub static SETUPS: Lazy<HashMap<SetupName, SetupSteps>> = Lazy::new(|| {
                     .join("\n"),
                 ),
                 Step::Persist,
-                Step::WaitForPersisted2 {
+                Step::WaitForPersisted {
                     expected_increase: 1,
                 },
             ],
@@ -1042,7 +1042,7 @@ pub static SETUPS: Lazy<HashMap<SetupName, SetupSteps>> = Lazy::new(|| {
                     .join("\n"),
                 ),
                 Step::Persist,
-                Step::WaitForPersisted2 {
+                Step::WaitForPersisted {
                     expected_increase: 1,
                 },
                 Step::RecordNumParquetFiles,
@@ -1055,7 +1055,7 @@ pub static SETUPS: Lazy<HashMap<SetupName, SetupSteps>> = Lazy::new(|| {
                     .join("\n"),
                 ),
                 Step::Persist,
-                Step::WaitForPersisted2 {
+                Step::WaitForPersisted {
                     expected_increase: 1,
                 },
             ],
@@ -1075,7 +1075,7 @@ pub static SETUPS: Lazy<HashMap<SetupName, SetupSteps>> = Lazy::new(|| {
                     .join("\n"),
                 ),
                 Step::Persist,
-                Step::WaitForPersisted2 {
+                Step::WaitForPersisted {
                     expected_increase: 2,
                 },
             ],
@@ -1096,7 +1096,7 @@ pub static SETUPS: Lazy<HashMap<SetupName, SetupSteps>> = Lazy::new(|| {
                     .join("\n"),
                 ),
                 Step::Persist,
-                Step::WaitForPersisted2 {
+                Step::WaitForPersisted {
                     expected_increase: 1,
                 },
             ],
@@ -1118,7 +1118,7 @@ pub static SETUPS: Lazy<HashMap<SetupName, SetupSteps>> = Lazy::new(|| {
                     .join("\n"),
                 ),
                 Step::Persist,
-                Step::WaitForPersisted2 {
+                Step::WaitForPersisted {
                     expected_increase: 1,
                 },
                 Step::RecordNumParquetFiles,
@@ -1136,7 +1136,7 @@ pub static SETUPS: Lazy<HashMap<SetupName, SetupSteps>> = Lazy::new(|| {
                     .join("\n"),
                 ),
                 Step::Persist,
-                Step::WaitForPersisted2 {
+                Step::WaitForPersisted {
                     expected_increase: 1,
                 },
             ],
@@ -1162,7 +1162,7 @@ pub static SETUPS: Lazy<HashMap<SetupName, SetupSteps>> = Lazy::new(|| {
                     .join("\n"),
                 ),
                 Step::Persist,
-                Step::WaitForPersisted2 {
+                Step::WaitForPersisted {
                     expected_increase: 1,
                 },
             ],
@@ -1173,19 +1173,19 @@ pub static SETUPS: Lazy<HashMap<SetupName, SetupSteps>> = Lazy::new(|| {
                 Step::RecordNumParquetFiles,
                 Step::WriteLineProtocol(RETENTION_SETUP.lp_partially_inside_1.clone()),
                 Step::Persist,
-                Step::WaitForPersisted2 {
+                Step::WaitForPersisted {
                     expected_increase: 1,
                 },
                 Step::RecordNumParquetFiles,
                 Step::WriteLineProtocol(RETENTION_SETUP.lp_fully_inside.clone()),
                 Step::Persist,
-                Step::WaitForPersisted2 {
+                Step::WaitForPersisted {
                     expected_increase: 1,
                 },
                 Step::RecordNumParquetFiles,
                 Step::WriteLineProtocol(RETENTION_SETUP.lp_fully_outside.clone()),
                 Step::Persist,
-                Step::WaitForPersisted2 {
+                Step::WaitForPersisted {
                     expected_increase: 1,
                 },
                 Step::WriteLineProtocol(RETENTION_SETUP.lp_partially_inside_2.clone()),
@@ -1213,7 +1213,7 @@ pub static SETUPS: Lazy<HashMap<SetupName, SetupSteps>> = Lazy::new(|| {
                     .join("\n"),
                 ),
                 Step::Persist,
-                Step::WaitForPersisted2 {
+                Step::WaitForPersisted {
                     expected_increase: 1,
                 },
             ],
@@ -1232,7 +1232,7 @@ pub static SETUPS: Lazy<HashMap<SetupName, SetupSteps>> = Lazy::new(|| {
                     .join("\n"),
                 ),
                 Step::Persist,
-                Step::WaitForPersisted2 {
+                Step::WaitForPersisted {
                     expected_increase: 1,
                 },
                 Step::RecordNumParquetFiles,
@@ -1244,7 +1244,7 @@ pub static SETUPS: Lazy<HashMap<SetupName, SetupSteps>> = Lazy::new(|| {
                     .join("\n"),
                 ),
                 Step::Persist,
-                Step::WaitForPersisted2 {
+                Step::WaitForPersisted {
                     expected_increase: 1,
                 },
             ],
@@ -1263,7 +1263,7 @@ pub static SETUPS: Lazy<HashMap<SetupName, SetupSteps>> = Lazy::new(|| {
                     .join("\n"),
                 ),
                 Step::Persist,
-                Step::WaitForPersisted2 {
+                Step::WaitForPersisted {
                     expected_increase: 1,
                 },
             ],
@@ -1283,7 +1283,7 @@ pub static SETUPS: Lazy<HashMap<SetupName, SetupSteps>> = Lazy::new(|| {
                     .join("\n"),
                 ),
                 Step::Persist,
-                Step::WaitForPersisted2 {
+                Step::WaitForPersisted {
                     expected_increase: 1,
                 },
                 Step::RecordNumParquetFiles,
@@ -1296,7 +1296,7 @@ pub static SETUPS: Lazy<HashMap<SetupName, SetupSteps>> = Lazy::new(|| {
                     .join("\n"),
                 ),
                 Step::Persist,
-                Step::WaitForPersisted2 {
+                Step::WaitForPersisted {
                     expected_increase: 1,
                 },
             ],
@@ -1353,7 +1353,7 @@ pub static SETUPS: Lazy<HashMap<SetupName, SetupSteps>> = Lazy::new(|| {
                     .to_string(),
                 ),
                 Step::Persist,
-                Step::WaitForPersisted2 {
+                Step::WaitForPersisted {
                     expected_increase: 2,
                 },
             ],
@@ -1371,7 +1371,7 @@ pub static SETUPS: Lazy<HashMap<SetupName, SetupSteps>> = Lazy::new(|| {
                             "#.into(),
                         ),
                         Step::Persist,
-                        Step::WaitForPersisted2 {
+                        Step::WaitForPersisted {
                             expected_increase: 2,
                         },
                         Step::RecordNumParquetFiles,
@@ -1381,7 +1381,7 @@ pub static SETUPS: Lazy<HashMap<SetupName, SetupSteps>> = Lazy::new(|| {
                             "#.into(),
                         ),
                         Step::Persist,
-                        Step::WaitForPersisted2 {
+                        Step::WaitForPersisted {
                             expected_increase: 1,
                         },
                     ]

--- a/test_helpers_end_to_end/src/steps.rs
+++ b/test_helpers_end_to_end/src/steps.rs
@@ -65,7 +65,7 @@ impl<'a> StepTestState<'a> {
         let retry_duration = Duration::from_secs(MAX_QUERY_RETRY_TIME_SEC);
         let num_parquet_files = self.num_parquet_files.expect(
             "No previous number of Parquet files recorded! \
-                Use `Step::RecordNumParquetFiles` before `Step::WaitForPersisted2`.",
+                Use `Step::RecordNumParquetFiles` before `Step::WaitForPersisted`.",
         );
         let expected_count = num_parquet_files + expected_increase;
 
@@ -153,7 +153,7 @@ pub enum Step {
 
     /// Ask the catalog service how many Parquet files it has for this cluster's namespace. Do this
     /// before a write where you're interested in when the write has been persisted to Parquet;
-    /// then after the write use `WaitForPersisted2` to observe the change in the number of Parquet
+    /// then after the write use `WaitForPersisted` to observe the change in the number of Parquet
     /// files from the value this step recorded.
     RecordNumParquetFiles,
 
@@ -162,7 +162,7 @@ pub enum Step {
 
     /// Wait for all previously written data to be persisted by observing an increase in the number
     /// of Parquet files in the catalog as specified for this cluster's namespace.
-    WaitForPersisted2 { expected_increase: usize },
+    WaitForPersisted { expected_increase: usize },
 
     /// Set the namespace retention interval to a retention period,
     /// specified in ns relative to `now()`.  `None` represents infinite retention
@@ -357,7 +357,7 @@ where
                 Step::Persist => {
                     state.cluster().persist_ingesters().await;
                 }
-                Step::WaitForPersisted2 { expected_increase } => {
+                Step::WaitForPersisted { expected_increase } => {
                     info!("====Begin waiting for a change in the number of Parquet files");
                     state
                         .wait_for_num_parquet_file_change(*expected_increase)


### PR DESCRIPTION
If the test setup calls `Step::Persist` to persist on-demand, that means it shouldn't be used with `ChunkStage::Parquet`, which tries to persist as fast as possible. This will fail the test with a hopefully helpful message to prevent this.

Also a bonus removal of straggling "2"s!