### PR TITLE
feat(cli): Add `influxdb_iox debug wal regenerate-lp` command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2614,6 +2614,8 @@ dependencies = [
  "trace_exporters",
  "trogging",
  "uuid",
+ "wal",
+ "wal_inspect",
  "workspace-hack",
 ]
 

--- a/influxdb_iox/Cargo.toml
+++ b/influxdb_iox/Cargo.toml
@@ -41,6 +41,8 @@ schema = { path = "../schema" }
 iox_time = { path = "../iox_time" }
 trace_exporters = { path = "../trace_exporters" }
 trogging = { path = "../trogging", default-features = false, features = ["clap"] }
+wal = { version = "0.1", path = "../wal" }
+wal_inspect = { version = "0.1", path = "../wal_inspect" }
 
 # Crates.io dependencies, in alphabetical order
 nu-ansi-term = "0.47.0"

--- a/influxdb_iox/src/commands/debug/mod.rs
+++ b/influxdb_iox/src/commands/debug/mod.rs
@@ -6,6 +6,7 @@ mod parquet_to_lp;
 mod print_cpu;
 mod schema;
 mod skipped_compactions;
+mod wal;
 
 #[derive(Debug, Snafu)]
 pub enum Error {
@@ -20,6 +21,10 @@ pub enum Error {
     #[snafu(context(false))]
     #[snafu(display("Error in skipped-compactions subcommand: {}", source))]
     SkippedCompactions { source: skipped_compactions::Error },
+
+    #[snafu(context(false))]
+    #[snafu(display("Error in wal subcommand: {}", source))]
+    Wal { source: wal::Error },
 }
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
@@ -44,6 +49,9 @@ enum Command {
 
     /// Interrogate skipped compactions
     SkippedCompactions(skipped_compactions::Config),
+
+    /// Subcommands for debugging the WAL
+    Wal(wal::Config),
 }
 
 pub async fn command<C, CFut>(connection: C, config: Config) -> Result<()>
@@ -62,6 +70,7 @@ where
             let connection = connection().await;
             skipped_compactions::command(connection, config).await?
         }
+        Command::Wal(config) => wal::command(config)?,
     }
 
     Ok(())

--- a/influxdb_iox/src/commands/debug/wal/mod.rs
+++ b/influxdb_iox/src/commands/debug/wal/mod.rs
@@ -1,0 +1,42 @@
+//! This module implements CLI commands for debugging the ingester WAL.
+
+use thiserror::Error;
+
+mod regenerate_lp;
+
+/// A command level error type to decorate WAL errors with some extra
+/// "human" context for the user
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error("could not open WAL file: {source}")]
+    UnableToOpenWalFile { source: wal::Error },
+
+    #[error("failed to decode write entries from the WAL file: {0}")]
+    FailedToDecodeWriteOpEntry(#[from] wal::DecodeError),
+
+    #[error("unable to fully regenerate line protocol writes from WAL file")]
+    UnableToFullyRegenerateLineProtocol,
+
+    #[error("i/o failure: {0}")]
+    IoFailure(#[from] std::io::Error),
+}
+
+#[derive(Debug, clap::Parser)]
+pub struct Config {
+    #[clap(subcommand)]
+    command: Command,
+}
+
+/// Subcommands for debugging the ingester WAL
+#[derive(Debug, clap::Parser)]
+enum Command {
+    /// Regenerate line protocol writes from the contents of a WAL file
+    RegenerateLp(regenerate_lp::Config),
+}
+
+/// Executes a WAL debugging subcommand as directed by the config
+pub fn command(config: Config) -> Result<(), Error> {
+    match config.command {
+        Command::RegenerateLp(config) => regenerate_lp::command(config),
+    }
+}

--- a/influxdb_iox/src/commands/debug/wal/regenerate_lp.rs
+++ b/influxdb_iox/src/commands/debug/wal/regenerate_lp.rs
@@ -1,0 +1,100 @@
+//! A module providing a CLI command for regenerating line protocol from a WAL file.
+use std::fs::{create_dir_all, OpenOptions};
+use std::path::PathBuf;
+
+use observability_deps::tracing::{debug, error, info};
+use wal::{ClosedSegmentFileReader, WriteOpEntryDecoder};
+use wal_inspect::{LineProtoWriter, NamespacedBatchWriter, WriteError};
+
+use super::Error;
+
+/// A container for the possible arguments & flags of a `regenerate-lp` command.
+#[derive(Debug, clap::Parser)]
+pub struct Config {
+    /// The path to the input WAL file
+    #[clap(value_parser)]
+    input: PathBuf,
+
+    /// The directory to write regenerated line protocol to. Creates the directory
+    ///if it does not exist.
+    ///
+    /// When unspecified the line protocol is written to stdout
+    #[clap(long, short, value_parser)]
+    output_directory: Option<PathBuf>,
+
+    /// When enabled, pre-existing line protocol files will be overwritten
+    #[clap(long, short)]
+    force: bool,
+}
+
+/// Executes the `regenerate-lp` command with the provided configuration, reading
+/// write operation entries from a WAL file and mapping them to line protocol.
+pub fn command(config: Config) -> Result<(), Error> {
+    let decoder = WriteOpEntryDecoder::from(
+        ClosedSegmentFileReader::from_path(&config.input)
+            .map_err(|wal_err| Error::UnableToOpenWalFile { source: wal_err })?,
+    );
+
+    match config.output_directory {
+        Some(d) => {
+            create_dir_all(d.as_path())?;
+            let writer = LineProtoWriter::new(
+                |namespace_id| {
+                    let file_path = d
+                        .as_path()
+                        .join(format!("namespace_id_{}.lp", namespace_id));
+
+                    let mut open_options = OpenOptions::new().write(true).to_owned();
+                    if config.force {
+                        open_options.create(true);
+                    } else {
+                        open_options.create_new(true);
+                    }
+
+                    info!(
+                        ?file_path,
+                        %namespace_id,
+                        "creating namespaced file as destination for regenerated line protocol",
+                    );
+
+                    open_options.open(&file_path).map_err(WriteError::IoError)
+                },
+                None,
+            );
+            decode_and_write_entries(decoder, writer)
+        }
+        None => {
+            let writer = LineProtoWriter::new(|_namespace_id| Ok(std::io::stdout()), None);
+            decode_and_write_entries(decoder, writer)
+        }
+    }
+}
+
+fn decode_and_write_entries<W: NamespacedBatchWriter>(
+    decoder: WriteOpEntryDecoder,
+    mut writer: W,
+) -> Result<(), Error> {
+    let mut incomplete_write = false;
+    for (wal_entry_number, entry_batch) in decoder.enumerate() {
+        for (write_op_number, entry) in entry_batch?.into_iter().enumerate() {
+            let namespace_id = entry.namespace;
+            debug!(%namespace_id, %wal_entry_number, %write_op_number, "regenerating line protocol for namespace from WAL write op entry");
+            writer
+                .write_namespaced_table_batches(entry.namespace, entry.table_batches)
+                .unwrap_or_else(|err| {
+                    incomplete_write = true;
+                    error!(
+                        %namespace_id,
+                        %wal_entry_number,
+                        %write_op_number,
+                        %err,
+                        "failed to rewrite table batches for write op");
+                });
+        }
+    }
+
+    if incomplete_write {
+        return Err(Error::UnableToFullyRegenerateLineProtocol);
+    }
+    Ok(())
+}

--- a/influxdb_iox/tests/end_to_end_cases/cli.rs
+++ b/influxdb_iox/tests/end_to_end_cases/cli.rs
@@ -1,15 +1,20 @@
 //! Tests CLI commands
+use std::fs::File;
+use std::io::{BufRead, BufReader};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
 
-use super::get_object_store_id;
 use assert_cmd::Command;
+use assert_matches::assert_matches;
 use futures::FutureExt;
 use predicates::prelude::*;
-use std::time::{Duration, Instant};
 use tempfile::tempdir;
 use test_helpers_end_to_end::{
     maybe_skip_integration, AddAddrEnv, BindAddresses, MiniCluster, ServerType, Step, StepTest,
-    StepTestState,
+    StepTestState, TestConfig,
 };
+
+use super::get_object_store_id;
 
 #[tokio::test]
 async fn default_mode_is_run_all_in_one() {
@@ -1001,6 +1006,121 @@ async fn namespace_update_service_limit() {
                                 .and(predicate::str::contains(r#""maxTables": 1337"#))
                                 .and(predicate::str::contains(r#""maxColumnsPerTable": 42"#)),
                         );
+                }
+                .boxed()
+            })),
+        ],
+    )
+    .run()
+    .await
+}
+
+#[tokio::test]
+async fn write_lp_from_wal() {
+    use std::fs;
+
+    test_helpers::maybe_start_logging();
+    let database_url = maybe_skip_integration!();
+
+    let ingester_config = TestConfig::new_ingester_never_persist(&database_url);
+    let router_config = TestConfig::new_router(&ingester_config);
+    let wal_dir = Arc::new(std::path::PathBuf::from(
+        ingester_config
+            .wal_dir()
+            .as_ref()
+            .expect("missing WAL dir")
+            .path(),
+    ));
+
+    let mut cluster = MiniCluster::new()
+        .with_ingester(ingester_config)
+        .await
+        .with_router(router_config)
+        .await;
+
+    StepTest::new(
+        &mut cluster,
+        vec![
+            Step::Custom(Box::new(|state: &mut StepTestState| {
+                async {
+                    let router_addr = state.cluster().router().router_http_base().to_string();
+                    let namespace = state.cluster().namespace();
+
+                    Command::cargo_bin("influxdb_iox")
+                        .unwrap()
+                        .arg("-v")
+                        .arg("-h")
+                        .arg(&router_addr)
+                        .arg("write")
+                        .arg(namespace)
+                        .arg("../test_fixtures/lineproto/air_and_water.lp")
+                        .assert()
+                        .success()
+                        .stdout(predicate::str::contains("1243 Bytes OK"));
+                }
+                .boxed()
+            })),
+            Step::Custom(Box::new(move |_state: &mut StepTestState| {
+                let wal_dir = Arc::clone(&wal_dir);
+                async move {
+                    let mut reader =
+                        fs::read_dir(wal_dir.as_path()).expect("failed to read WAL directory");
+                    let segment_file_path = reader
+                        .next()
+                        .expect("no segment file found")
+                        .unwrap()
+                        .path();
+                    assert_matches!(reader.next(), None);
+
+                    let out_dir = test_helpers::tmp_dir()
+                        .expect("failed to create temp directory for line proto output");
+
+                    Command::cargo_bin("influxdb_iox")
+                        .unwrap()
+                        .arg("-vv")
+                        .arg("debug")
+                        .arg("wal")
+                        .arg("regenerate-lp")
+                        .arg("-o")
+                        .arg(
+                            out_dir
+                                .path()
+                                .to_str()
+                                .expect("should be able to get temp directory as string"),
+                        )
+                        .arg(
+                            segment_file_path
+                                .to_str()
+                                .expect("should be able to get segment file path as string"),
+                        )
+                        .assert()
+                        .success();
+
+                    // TODO(savage): Assert file size is the same after table-name aware implementation is done
+                    let mut reader =
+                        fs::read_dir(out_dir.path()).expect("failed to read output directory");
+                    let regenerated_file = BufReader::new(
+                        File::open(
+                            reader
+                                .next()
+                                .expect("no regenerated files found")
+                                .unwrap()
+                                .path(),
+                        )
+                        .expect("should be able to open regenerated line proto file"),
+                    );
+
+                    assert_matches!(reader.next(), None);
+
+                    let original_file = BufReader::new(
+                        File::open("../test_fixtures/lineproto/air_and_water.lp")
+                            .expect("should be able to read input line proto"),
+                    );
+
+                    assert_eq!(
+                        original_file.lines().count(),
+                        regenerated_file.lines().count()
+                    );
                 }
                 .boxed()
             })),

--- a/test_helpers_end_to_end/src/config.rs
+++ b/test_helpers_end_to_end/src/config.rs
@@ -207,6 +207,11 @@ impl TestConfig {
         &self.catalog_schema_name
     }
 
+    /// Retrieve the directory used to write WAL files to, if set
+    pub fn wal_dir(&self) -> &Option<Arc<TempDir>> {
+        &self.wal_dir
+    }
+
     // copy a reference to the catalog temp dir, if any
     fn with_catalog_dir(mut self, catalog_dir: Option<Arc<TempDir>>) -> Self {
         self.catalog_dir = catalog_dir;

--- a/wal_inspect/src/lib.rs
+++ b/wal_inspect/src/lib.rs
@@ -175,7 +175,6 @@ where
 #[cfg(test)]
 mod tests {
     use std::collections::BTreeMap;
-    use std::fs::{read_dir, OpenOptions};
 
     use assert_matches::assert_matches;
     use data_types::TableId;
@@ -189,7 +188,7 @@ mod tests {
     use super::*;
 
     #[tokio::test]
-    async fn translate_good_wal_segment_file() {
+    async fn translate_valid_wal_segment() {
         let test_dir = test_helpers::tmp_dir().expect("failed to create test dir");
         let wal = wal::Wal::new(test_dir.path()).await.unwrap();
 
@@ -265,111 +264,6 @@ mod tests {
         assert_matches!(results.get(&NamespaceId::new(2)), Some(e) => {
             assert_eq!(
                 String::from_utf8(e.to_owned()).unwrap().as_str(), format!("{}\n", line2));
-        });
-    }
-
-    #[tokio::test]
-    async fn partial_translate_bad_wal_segment_file() {
-        let test_dir = test_helpers::tmp_dir().expect("failed to create test dir");
-        let wal = wal::Wal::new(test_dir.path()).await.unwrap();
-
-        let (table_id_index, table_name_index) =
-            build_indexes([("m3", TableId::new(3)), ("m4", TableId::new(4))]);
-        let line1 = "m3,s=baz v=3i 1";
-        let line2 = "m3,s=baz v=2i 2";
-        let line3 = "m4,s=qux v=2i 3";
-        let line4 = "m4,s=qux v=5i 4";
-
-        // Generate some WAL entries
-        wal.write_op(SequencedWalOp {
-            sequence_number: 0,
-            op: Op::Write(encode_line(NamespaceId::new(3), &table_id_index, line1)),
-        });
-        wal.write_op(SequencedWalOp {
-            sequence_number: 1,
-            op: Op::Write(encode_line(NamespaceId::new(3), &table_id_index, line2)),
-        })
-        .changed()
-        .await
-        .expect("WAL should have changed");
-        wal.write_op(SequencedWalOp {
-            sequence_number: 2,
-            op: Op::Write(encode_line(NamespaceId::new(4), &table_id_index, line3)),
-        });
-        wal.write_op(SequencedWalOp {
-            sequence_number: 3,
-            op: Op::Write(encode_line(NamespaceId::new(4), &table_id_index, line4)),
-        })
-        .changed()
-        .await
-        .expect("WAL should have changed");
-
-        // Get the path of the only segment file, then rotate it and add some
-        // garbage to the end.
-        let mut reader = read_dir(test_dir.path()).unwrap();
-        let closed_path = reader
-            .next()
-            .expect("no segment file found in WAL dir")
-            .unwrap()
-            .path();
-        assert_matches!(reader.next(), None); // Only 1 file should be in the WAL dir prior to rotation
-
-        let (closed, _) = wal.rotate().expect("failed to rotate WAL");
-
-        {
-            let mut file = OpenOptions::new()
-                .append(true)
-                .open(closed_path)
-                .expect("unable to open closed WAL segment for writing");
-            file.write_all(b"bananananananananas").unwrap();
-        }
-
-        // Create the translator and read as much as possible out of the bad segment file
-        let decoder = WriteOpEntryDecoder::from(
-            wal.reader_for_segment(closed.id())
-                .expect("failed to open reader for closed segment"),
-        );
-        let mut writer = LineProtoWriter::new(|_| Ok(Vec::<u8>::new()), Some(table_name_index));
-
-        // The translator should be able to read all 2 good entries containing 4 write ops
-        let decoded_entries = decoder
-            .into_iter()
-            .map_while(|r| r.ok())
-            .collect::<Vec<_>>();
-        assert_eq!(decoded_entries.len(), 2);
-        let decoded_ops = decoded_entries
-            .into_iter()
-            .flatten()
-            .collect::<Vec<WriteOpEntry>>();
-        assert_eq!(decoded_ops.len(), 4);
-        for entry in decoded_ops {
-            writer
-                .write_namespaced_table_batches(entry.namespace, entry.table_batches)
-                .expect("batch write should not fail");
-        }
-
-        let results = &writer.namespaced_output;
-
-        // Assert that the namespaced writes contain ONLY the following:
-        //
-        // NamespaceId 3:
-        //
-        //     m3,s=baz v=3i 1
-        //     m3,s=baz v=2i 2
-        //
-        // NamespaceId 4:
-        //
-        //     m4,s=qux v=2i 3
-        //     m4,s=qux v=5i 4
-        //
-        assert_eq!(results.len(), 2);
-        assert_matches!(results.get(&NamespaceId::new(3)), Some(e) => {
-            assert_eq!(
-                String::from_utf8(e.to_owned()).unwrap().as_str(), format!("{}\n{}\n", line1, line2));
-        });
-        assert_matches!(results.get(&NamespaceId::new(4)), Some(e) => {
-            assert_eq!(
-                String::from_utf8(e.to_owned()).unwrap().as_str(), format!("{}\n{}\n", line3, line4));
         });
     }
 


### PR DESCRIPTION
This adds the first implementation of the `influxdb_iox debug wal regenerate-lp` command. It can take a WAL segment file, decode WriteOp entries from it and regenerate line protocol equivalent to the original writes. 

This first implementation doesn't contain the logic for building a table ID -> table name index from the catalog. This means measurement names are reconstructed as their table IDs, so the resulting line protocol is not textually identical to the original writes (textual ordering of tags & fields are not stored in the WAL, so 1:1 textual equivalence isn't in scope).

Below are some example outputs, logging is on the more minimal side and output currently all goes through log calls so `-v` needs to be passed for any `INFO` output. I spent a lot of time thinking about how to display output and didn't really land on any strong opinions, so please leave thoughts!

**Command options:**
```
$ influxdb_iox debug wal regenerate-lp --help
Regenerate line protocol writes from the contents of a WAL file

Usage: influxdb_iox debug wal regenerate-lp [OPTIONS] <INPUT>

Arguments:
  <INPUT>
          The path to the input WAL file

Options:
  ...

  -o, --output-directory <OUTPUT_DIRECTORY>
          The directory to write regenerated line protocol to. Creates the directory if it does not exist.

          When unspecified the line protocol is written to stdout

  -f, --force
          When enabled, pre-existing line protocol files will be overwritten

  ...
```

**Partial regeneration of corrupt file:**
```
$ influxdb_iox -vv debug wal regenerate-lp -o ~/testdir ~/bad.wal
2023-05-18T16:37:03.810811Z DEBUG influxdb_iox::commands::debug::wal::regenerate_lp: regenerating line protocol for namespace from WAL write op entry namespace_id=1 wal_entry_number=0 write_op_number=0
2023-05-18T16:37:03.810925Z  INFO influxdb_iox::commands::debug::wal::regenerate_lp: creating namespaced file as destination for regenerated line protocol file_path="/Users/savage/testdir/namespace_id_1.lp" namespace_id=1
2023-05-18T16:37:03.864068Z DEBUG influxdb_iox::commands::debug::wal::regenerate_lp: regenerating line protocol for namespace from WAL write op entry namespace_id=2 wal_entry_number=1 write_op_number=0
2023-05-18T16:37:03.864083Z  INFO influxdb_iox::commands::debug::wal::regenerate_lp: creating namespaced file as destination for regenerated line protocol file_path="/Users/savage/testdir/namespace_id_2.lp" namespace_id=2
Error in wal subcommand: failed to decode write entries from the WAL file: FailedToReadWal: UnableToReadNextOps: UnableToReadData: snappy: corrupt input (expected stream header but got unexpected chunk type byte 45)
```

**Full regeneration of uncorrupt file:**
```
$ influxdb_iox -vv debug wal regenerate-lp -o ~/testdir ~/test.wal
2023-05-18T16:38:59.349300Z DEBUG influxdb_iox::commands::debug::wal::regenerate_lp: regenerating line protocol for namespace from WAL write op entry namespace_id=1 wal_entry_number=0 write_op_number=0
2023-05-18T16:38:59.349375Z  INFO influxdb_iox::commands::debug::wal::regenerate_lp: creating namespaced file as destination for regenerated line protocol file_path="/Users/savage/testdir/namespace_id_1.lp" namespace_id=1
2023-05-18T16:38:59.402150Z DEBUG influxdb_iox::commands::debug::wal::regenerate_lp: regenerating line protocol for namespace from WAL write op entry namespace_id=2 wal_entry_number=1 write_op_number=0
2023-05-18T16:38:59.402166Z  INFO influxdb_iox::commands::debug::wal::regenerate_lp: creating namespaced file as destination for regenerated line protocol file_path="/Users/savage/testdir/namespace_id_2.lp" namespace_id=2
```

---

* fix(wal): Assert WriteOpDecoder handles tail-corrupt WAL files correctly (fd5d5e075)

      WAL read errors encountered by the new WAL WriteOpDecoder were being
      discarded and presented as a "happy path" end of file to callers due
      to a bug in handling a nested result type. This moves the test for
      decoding a tail-corrupt WAL into the crate itself and asserts the
      error is reported correctly.

* feat(cli): Add table ID `debug wal regenerate-lp` command implementation (c263585d9)

      This adds a command to `influxdb_iox` that can take a WAL segment file
      and regenerate all write operation entries, writing to stdout or namespaced
      files within a target directory, using table ID as the measurement name
      in the case where there is no catalog access at point of regeneration.