### PR TITLE
feat: table creation gRPC API with optional custom table template

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4846,6 +4846,7 @@ dependencies = [
  "service_grpc_namespace",
  "service_grpc_object_store",
  "service_grpc_schema",
+ "service_grpc_table",
  "sharder",
  "smallvec",
  "test_helpers",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5229,6 +5229,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "service_grpc_table"
+version = "0.1.0"
+dependencies = [
+ "data_types",
+ "generated_types",
+ "iox_catalog",
+ "metric",
+ "observability_deps",
+ "tokio",
+ "tonic",
+ "workspace-hack",
+]
+
+[[package]]
 name = "service_grpc_testing"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,6 +69,7 @@ members = [
     "service_grpc_namespace",
     "service_grpc_object_store",
     "service_grpc_schema",
+    "service_grpc_table",
     "service_grpc_testing",
     "sharder",
     "sqlx-hotswap-pool",

--- a/data_types/src/partition_template.rs
+++ b/data_types/src/partition_template.rs
@@ -60,7 +60,6 @@ impl TablePartitionTemplateOverride {
     /// When a table is being explicitly created, the creation request might have contained a
     /// custom partition template for that table. If the custom partition template is present, use
     /// it. Otherwise, use the namespace's partition template.
-    #[allow(dead_code)] // This will be used by the as-yet unwritten create table gRPC API.
     pub fn new(
         custom_table_template: Option<proto::PartitionTemplate>,
         namespace_template: &NamespacePartitionTemplateOverride,

--- a/generated_types/build.rs
+++ b/generated_types/build.rs
@@ -28,6 +28,7 @@ fn main() -> Result<()> {
 /// - `influxdata.iox.predicate.v1.rs`
 /// - `influxdata.iox.querier.v1.rs`
 /// - `influxdata.iox.schema.v1.rs`
+/// - `influxdata.iox.table.v1.rs`
 /// - `influxdata.iox.wal.v1.rs`
 /// - `influxdata.iox.write.v1.rs`
 /// - `influxdata.platform.storage.rs`
@@ -45,6 +46,7 @@ fn generate_grpc_types(root: &Path) -> Result<()> {
     let schema_path = root.join("influxdata/iox/schema/v1");
     let storage_errors_path = root.join("influxdata/platform/errors");
     let storage_path = root.join("influxdata/platform/storage");
+    let table_path = root.join("influxdata/iox/table/v1");
     let wal_path = root.join("influxdata/iox/wal/v1");
 
     let proto_files = vec![
@@ -74,6 +76,7 @@ fn generate_grpc_types(root: &Path) -> Result<()> {
         storage_path.join("source.proto"),
         storage_path.join("storage_common.proto"),
         storage_path.join("test.proto"),
+        table_path.join("service.proto"),
         wal_path.join("wal.proto"),
     ];
 

--- a/generated_types/protos/influxdata/iox/table/v1/service.proto
+++ b/generated_types/protos/influxdata/iox/table/v1/service.proto
@@ -1,0 +1,37 @@
+syntax = "proto3";
+package influxdata.iox.table.v1;
+option go_package = "github.com/influxdata/iox/table/v1";
+
+import "influxdata/iox/partition_template/v1/template.proto";
+
+service TableService {
+  // Create a table in a namespace
+  rpc CreateTable(CreateTableRequest) returns (CreateTableResponse);
+}
+
+message CreateTableRequest {
+  // Name of the table to be created
+  string name = 1;
+
+  // Name of the namespace to create the table in
+  string namespace = 2;
+
+  // Partitioning scheme to use for writes to this table. If not specified, the namespace's
+  // partition template will be used.
+  optional influxdata.iox.partition_template.v1.PartitionTemplate partition_template = 3;
+}
+
+message CreateTableResponse {
+  Table table = 1;
+}
+
+message Table {
+  // Table ID
+  int64 id = 1;
+
+  // Name of the Table
+  string name = 2;
+
+  // Namespace ID
+  int64 namespace_id = 3;
+}

--- a/generated_types/protos/influxdata/iox/table/v1/service.proto
+++ b/generated_types/protos/influxdata/iox/table/v1/service.proto
@@ -16,8 +16,11 @@ message CreateTableRequest {
   // Name of the namespace to create the table in
   string namespace = 2;
 
-  // Partitioning scheme to use for writes to this table. If not specified, the namespace's
-  // partition template will be used.
+  // Partitioning scheme to use for writes to this table. If not specified, the
+  // namespace's partition template will be used.
+  //
+  // Any use of "tag_value" template parts will cause the named column schema to
+  // be set as "tag" as part of this request.
   optional influxdata.iox.partition_template.v1.PartitionTemplate partition_template = 3;
 }
 

--- a/generated_types/src/lib.rs
+++ b/generated_types/src/lib.rs
@@ -165,6 +165,16 @@ pub mod influxdata {
             }
         }
 
+        pub mod table {
+            pub mod v1 {
+                include!(concat!(env!("OUT_DIR"), "/influxdata.iox.table.v1.rs"));
+                include!(concat!(
+                    env!("OUT_DIR"),
+                    "/influxdata.iox.table.v1.serde.rs"
+                ));
+            }
+        }
+
         pub mod wal {
             pub mod v1 {
                 include!(concat!(env!("OUT_DIR"), "/influxdata.iox.wal.v1.rs"));

--- a/influxdb_iox/tests/end_to_end_cases/namespace.rs
+++ b/influxdb_iox/tests/end_to_end_cases/namespace.rs
@@ -197,7 +197,10 @@ async fn soft_deletion() {
                         .unwrap_err();
                     assert_eq!(
                         error.to_string(),
-                        format!("Internal error: name {namespace_name} already exists"),
+                        format!(
+                            "Some entity that we attempted to create already exists: \
+                            A namespace with the name `{namespace_name}` already exists"
+                        ),
                     );
                 }
                 .boxed()

--- a/ioxd_router/src/lib.rs
+++ b/ioxd_router/src/lib.rs
@@ -33,6 +33,7 @@ use ioxd_common::{
         generated_types::influxdata::iox::{
             catalog::v1::catalog_service_server, namespace::v1::namespace_service_server,
             object_store::v1::object_store_service_server, schema::v1::schema_service_server,
+            table::v1::table_service_server,
         },
         tonic::transport::Endpoint,
     },
@@ -170,6 +171,10 @@ where
             namespace_service_server::NamespaceServiceServer::new(
                 self.server.grpc().namespace_service()
             )
+        );
+        add_service!(
+            builder,
+            table_service_server::TableServiceServer::new(self.server.grpc().table_service())
         );
         serve_builder!(builder);
 

--- a/router/Cargo.toml
+++ b/router/Cargo.toml
@@ -32,6 +32,7 @@ service_grpc_catalog = { path = "../service_grpc_catalog"}
 service_grpc_namespace = { path = "../service_grpc_namespace"}
 service_grpc_object_store = { path = "../service_grpc_object_store" }
 service_grpc_schema = { path = "../service_grpc_schema" }
+service_grpc_table = { path = "../service_grpc_table" }
 sharder = { path = "../sharder" }
 smallvec = "1.10.0"
 thiserror = "1.0"

--- a/router/src/server/grpc.rs
+++ b/router/src/server/grpc.rs
@@ -1,12 +1,15 @@
 //! gRPC service implementations for `router`.
 
-use generated_types::influxdata::iox::{catalog::v1::*, namespace::v1::*, object_store::v1::*};
+use generated_types::influxdata::iox::{
+    catalog::v1::*, namespace::v1::*, object_store::v1::*, table::v1::*,
+};
 use iox_catalog::interface::Catalog;
 use object_store::DynObjectStore;
 use service_grpc_catalog::CatalogService;
 use service_grpc_namespace::NamespaceService;
 use service_grpc_object_store::ObjectStoreService;
 use service_grpc_schema::SchemaService;
+use service_grpc_table::TableService;
 use std::sync::Arc;
 
 /// This type manages all gRPC services exposed by a `router` using the RPC write path.
@@ -51,5 +54,12 @@ impl RpcWriteGrpcDelegate {
     /// [`NamespaceService`]: generated_types::influxdata::iox::namespace::v1::namespace_service_server::NamespaceService.
     pub fn namespace_service(&self) -> impl namespace_service_server::NamespaceService {
         NamespaceService::new(Arc::clone(&self.catalog))
+    }
+
+    /// Acquire a [`TableService`] gRPC service implementation.
+    ///
+    /// [`TableService`]: generated_types::influxdata::iox::table::v1::table_service_server::TableService
+    pub fn table_service(&self) -> impl table_service_server::TableService {
+        TableService::new(Arc::clone(&self.catalog))
     }
 }

--- a/router/tests/grpc.rs
+++ b/router/tests/grpc.rs
@@ -2,9 +2,14 @@ use std::time::Duration;
 
 use assert_matches::assert_matches;
 use data_types::NamespaceId;
-use generated_types::influxdata::iox::{
-    namespace::v1::{namespace_service_server::NamespaceService, *},
-    table::v1::{table_service_server::TableService, *},
+use generated_types::influxdata::{
+    iox::{
+        ingester::v1::WriteRequest,
+        namespace::v1::{namespace_service_server::NamespaceService, *},
+        partition_template::v1::*,
+        table::v1::{table_service_server::TableService, *},
+    },
+    pbdata::v1::DatabaseBatch,
 };
 use hyper::StatusCode;
 use iox_catalog::interface::{Error as CatalogError, SoftDeletedRows};
@@ -913,4 +918,253 @@ async fn test_table_create() {
     // And writing should succeed
     let response = ctx.write_lp("bananas", "test", lp).await.unwrap();
     assert_eq!(response.status(), StatusCode::NO_CONTENT);
+}
+
+#[tokio::test]
+async fn test_namespace_partition_template_implicit_table_creation() {
+    // Initialise a TestContext without a namespace autocreation policy.
+    let ctx = TestContextBuilder::default().build().await;
+
+    // Explicitly create a namespace with a custom partition template.
+    let req = CreateNamespaceRequest {
+        name: "bananas_test".to_string(),
+        retention_period_ns: None,
+        partition_template: Some(PartitionTemplate {
+            parts: vec![TemplatePart {
+                part: Some(template_part::Part::TagValue("tag1".into())),
+            }],
+        }),
+    };
+    ctx.grpc_delegate()
+        .namespace_service()
+        .create_namespace(Request::new(req))
+        .await
+        .unwrap()
+        .into_inner()
+        .namespace
+        .unwrap();
+
+    // Write, which implicitly creates the table with the namespace's custom partition template
+    let lp = "plantains,tag1=A,tag2=B val=42i".to_string();
+    let response = ctx.write_lp("bananas", "test", lp).await.unwrap();
+    assert_eq!(response.status(), StatusCode::NO_CONTENT);
+
+    // Check the ingester observed the correct write that uses the namespace's template.
+    let writes = ctx.write_calls();
+    assert_eq!(writes.len(), 1);
+    assert_matches!(
+        writes.as_slice(),
+        [
+            WriteRequest {
+                payload: Some(DatabaseBatch {
+                    table_batches,
+                    partition_key,
+                    ..
+                }),
+            },
+        ] => {
+        let table_id = ctx.table_id("bananas_test", "plantains").await.get();
+        assert_eq!(table_batches.len(), 1);
+        assert_eq!(table_batches[0].table_id, table_id);
+        assert_eq!(partition_key, "tag1_A");
+    });
+}
+
+#[tokio::test]
+async fn test_namespace_partition_template_explicit_table_creation_without_partition_template() {
+    // Initialise a TestContext without a namespace autocreation policy.
+    let ctx = TestContextBuilder::default().build().await;
+
+    // Explicitly create a namespace with a custom partition template.
+    let req = CreateNamespaceRequest {
+        name: "bananas_test".to_string(),
+        retention_period_ns: None,
+        partition_template: Some(PartitionTemplate {
+            parts: vec![TemplatePart {
+                part: Some(template_part::Part::TagValue("tag1".into())),
+            }],
+        }),
+    };
+    ctx.grpc_delegate()
+        .namespace_service()
+        .create_namespace(Request::new(req))
+        .await
+        .unwrap()
+        .into_inner()
+        .namespace
+        .unwrap();
+
+    // Explicitly create a table *without* a custom partition template.
+    let req = CreateTableRequest {
+        name: "plantains".to_string(),
+        namespace: "bananas_test".to_string(),
+        partition_template: None,
+    };
+    ctx.grpc_delegate()
+        .table_service()
+        .create_table(Request::new(req))
+        .await
+        .unwrap()
+        .into_inner()
+        .table
+        .unwrap();
+
+    // Write to the just-created table
+    let lp = "plantains,tag1=A,tag2=B val=42i".to_string();
+    let response = ctx.write_lp("bananas", "test", lp).await.unwrap();
+    assert_eq!(response.status(), StatusCode::NO_CONTENT);
+
+    // Check the ingester observed the correct write that uses the namespace's template.
+    let writes = ctx.write_calls();
+    assert_eq!(writes.len(), 1);
+    assert_matches!(
+        writes.as_slice(),
+        [
+            WriteRequest {
+                payload: Some(DatabaseBatch {
+                    table_batches,
+                    partition_key,
+                    ..
+                }),
+            },
+        ] => {
+        let table_id = ctx.table_id("bananas_test", "plantains").await.get();
+        assert_eq!(table_batches.len(), 1);
+        assert_eq!(table_batches[0].table_id, table_id);
+        assert_eq!(partition_key, "tag1_A");
+    });
+}
+
+#[tokio::test]
+async fn test_namespace_partition_template_explicit_table_creation_with_partition_template() {
+    // Initialise a TestContext without a namespace autocreation policy.
+    let ctx = TestContextBuilder::default().build().await;
+
+    // Explicitly create a namespace with a custom partition template.
+    let req = CreateNamespaceRequest {
+        name: "bananas_test".to_string(),
+        retention_period_ns: None,
+        partition_template: Some(PartitionTemplate {
+            parts: vec![TemplatePart {
+                part: Some(template_part::Part::TagValue("tag1".into())),
+            }],
+        }),
+    };
+    ctx.grpc_delegate()
+        .namespace_service()
+        .create_namespace(Request::new(req))
+        .await
+        .unwrap()
+        .into_inner()
+        .namespace
+        .unwrap();
+
+    // Explicitly create a table with a *different* custom partition template.
+    let req = CreateTableRequest {
+        name: "plantains".to_string(),
+        namespace: "bananas_test".to_string(),
+        partition_template: Some(PartitionTemplate {
+            parts: vec![TemplatePart {
+                part: Some(template_part::Part::TagValue("tag2".into())),
+            }],
+        }),
+    };
+    ctx.grpc_delegate()
+        .table_service()
+        .create_table(Request::new(req))
+        .await
+        .unwrap()
+        .into_inner()
+        .table
+        .unwrap();
+
+    // Write to the just-created table
+    let lp = "plantains,tag1=A,tag2=B val=42i".to_string();
+    let response = ctx.write_lp("bananas", "test", lp).await.unwrap();
+    assert_eq!(response.status(), StatusCode::NO_CONTENT);
+
+    // Check the ingester observed the correct write that uses the table's template.
+    let writes = ctx.write_calls();
+    assert_eq!(writes.len(), 1);
+    assert_matches!(
+        writes.as_slice(),
+        [
+            WriteRequest {
+                payload: Some(DatabaseBatch {
+                    table_batches,
+                    partition_key,
+                    ..
+                }),
+            },
+        ] => {
+        let table_id = ctx.table_id("bananas_test", "plantains").await.get();
+        assert_eq!(table_batches.len(), 1);
+        assert_eq!(table_batches[0].table_id, table_id);
+        assert_eq!(partition_key, "tag2_B");
+    });
+}
+
+#[tokio::test]
+async fn test_namespace_without_partition_template_table_with_partition_template() {
+    // Initialise a TestContext without a namespace autocreation policy.
+    let ctx = TestContextBuilder::default().build().await;
+
+    // Explicitly create a namespace _without_ a custom partition template.
+    let req = CreateNamespaceRequest {
+        name: "bananas_test".to_string(),
+        retention_period_ns: None,
+        partition_template: None,
+    };
+    ctx.grpc_delegate()
+        .namespace_service()
+        .create_namespace(Request::new(req))
+        .await
+        .unwrap()
+        .into_inner()
+        .namespace
+        .unwrap();
+
+    // Explicitly create a table _with_ a custom partition template.
+    let req = CreateTableRequest {
+        name: "plantains".to_string(),
+        namespace: "bananas_test".to_string(),
+        partition_template: Some(PartitionTemplate {
+            parts: vec![TemplatePart {
+                part: Some(template_part::Part::TagValue("tag2".into())),
+            }],
+        }),
+    };
+    ctx.grpc_delegate()
+        .table_service()
+        .create_table(Request::new(req))
+        .await
+        .unwrap()
+        .into_inner()
+        .table
+        .unwrap();
+
+    // Write to the just-created table
+    let lp = "plantains,tag1=A,tag2=B val=42i".to_string();
+    let response = ctx.write_lp("bananas", "test", lp).await.unwrap();
+    assert_eq!(response.status(), StatusCode::NO_CONTENT);
+
+    // Check the ingester observed the correct write that uses the table's template.
+    let writes = ctx.write_calls();
+    assert_eq!(writes.len(), 1);
+    assert_matches!(
+        writes.as_slice(),
+        [
+            WriteRequest {
+                payload: Some(DatabaseBatch {
+                    table_batches,
+                    partition_key,
+                    ..
+                }),
+            },
+        ] => {
+        let table_id = ctx.table_id("bananas_test", "plantains").await.get();
+        assert_eq!(table_batches.len(), 1);
+        assert_eq!(table_batches[0].table_id, table_id);
+        assert_eq!(partition_key, "tag2_B");
+    });
 }

--- a/service_grpc_table/Cargo.toml
+++ b/service_grpc_table/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "service_grpc_table"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+data_types = { path = "../data_types" }
+generated_types = { path = "../generated_types" }
+observability_deps = { path = "../observability_deps" }
+tonic = { workspace = true }
+iox_catalog = { path = "../iox_catalog" }
+workspace-hack = { version = "0.1", path = "../workspace-hack" }
+
+[dev-dependencies]
+metric = { path = "../metric" }
+tokio = { version = "1", features = ["rt-multi-thread", "macros"] }

--- a/service_grpc_table/src/lib.rs
+++ b/service_grpc_table/src/lib.rs
@@ -130,6 +130,7 @@ impl table_service_server::TableService for TableService {
         info!(
             %name,
             table_id = %table.id,
+            partition_template = ?table.partition_template,
             "created table"
         );
 

--- a/service_grpc_table/src/lib.rs
+++ b/service_grpc_table/src/lib.rs
@@ -1,0 +1,327 @@
+//! Implementation of the table gRPC service
+
+#![deny(
+    rustdoc::broken_intra_doc_links,
+    rustdoc::bare_urls,
+    rust_2018_idioms,
+    missing_debug_implementations,
+    unreachable_pub
+)]
+#![warn(
+    missing_docs,
+    clippy::todo,
+    clippy::dbg_macro,
+    clippy::clone_on_ref_ptr,
+    clippy::future_not_send,
+    clippy::todo,
+    clippy::dbg_macro,
+    unused_crate_dependencies
+)]
+#![allow(clippy::missing_docs_in_private_items)]
+
+// Workaround for "unused crate" lint false positives.
+use workspace_hack as _;
+
+use std::sync::Arc;
+
+use data_types::{
+    ColumnType, NamespaceName, Table as CatalogTable, TablePartitionTemplateOverride, TemplatePart,
+};
+use generated_types::influxdata::iox::table::v1::*;
+use iox_catalog::interface::{Catalog, SoftDeletedRows};
+use observability_deps::tracing::{debug, info, warn};
+use tonic::{Request, Response, Status};
+
+/// Implementation of the table gRPC service
+#[derive(Debug)]
+pub struct TableService {
+    /// Catalog.
+    catalog: Arc<dyn Catalog>,
+}
+
+impl TableService {
+    /// Create a new `TableService` instance
+    pub fn new(catalog: Arc<dyn Catalog>) -> Self {
+        Self { catalog }
+    }
+}
+
+#[tonic::async_trait]
+impl table_service_server::TableService for TableService {
+    // create a table
+    async fn create_table(
+        &self,
+        request: Request<CreateTableRequest>,
+    ) -> Result<Response<CreateTableResponse>, Status> {
+        let mut repos = self.catalog.repositories().await;
+
+        let CreateTableRequest {
+            name,
+            namespace,
+            partition_template,
+        } = request.into_inner();
+
+        let namespace_name = NamespaceName::try_from(namespace)
+            .map_err(|e| Status::invalid_argument(e.to_string()))?;
+
+        debug!(%name, %namespace_name, "Creating table");
+
+        let namespace = repos
+            .namespaces()
+            .get_by_name(&namespace_name, SoftDeletedRows::ExcludeDeleted)
+            .await
+            .map_err(|e| Status::internal(e.to_string()))?
+            .ok_or_else(|| {
+                Status::not_found(format!(
+                    "Could not find a namespace with name {namespace_name}"
+                ))
+            })?;
+
+        let table = repos
+            .tables()
+            .create(
+                &name,
+                TablePartitionTemplateOverride::new(
+                    partition_template,
+                    &namespace.partition_template,
+                ),
+                namespace.id,
+            )
+            .await
+            .map_err(|e| {
+                warn!(error=%e, %name, "failed to create table");
+                Status::internal(e.to_string())
+            })?;
+
+        // Partitioning is only supported for tags, so create tag columns for all `TagValue`
+        // partition template parts.
+        for template_part in table.partition_template.parts() {
+            if let TemplatePart::TagValue(tag_name) = template_part {
+                repos
+                    .columns()
+                    .create_or_get(tag_name, table.id, ColumnType::Tag)
+                    .await
+                    .map_err(|e| {
+                        warn!(error=%e, %name, "failed to create columns during table creation");
+                        Status::internal(e.to_string())
+                    })?;
+            }
+        }
+
+        info!(
+            %name,
+            table_id = %table.id,
+            "created table"
+        );
+
+        Ok(Response::new(table_to_create_response_proto(table)))
+    }
+}
+
+fn table_to_create_response_proto(table: CatalogTable) -> CreateTableResponse {
+    CreateTableResponse {
+        table: Some(Table {
+            id: table.id.get(),
+            name: table.name.clone(),
+            namespace_id: table.namespace_id.get(),
+        }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use data_types::{NamespacePartitionTemplateOverride, TableId};
+    use generated_types::influxdata::iox::{
+        partition_template::v1::{template_part, PartitionTemplate, TemplatePart},
+        table::v1::table_service_server::TableService as _,
+    };
+    use iox_catalog::{mem::MemCatalog, test_helpers::arbitrary_namespace};
+    use tonic::Code;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_basic_happy_path() {
+        let catalog: Arc<dyn Catalog> =
+            Arc::new(MemCatalog::new(Arc::new(metric::Registry::default())));
+        let handler = TableService::new(Arc::clone(&catalog));
+
+        let namespace = arbitrary_namespace(&mut *catalog.repositories().await, "grapes").await;
+        let table_name = "varietals";
+
+        let request = CreateTableRequest {
+            name: table_name.into(),
+            namespace: namespace.name.clone(),
+            partition_template: None,
+        };
+
+        let created_table = handler
+            .create_table(Request::new(request))
+            .await
+            .unwrap()
+            .into_inner()
+            .table
+            .unwrap();
+
+        assert!(created_table.id > 0);
+        assert_eq!(created_table.name, table_name);
+        assert_eq!(created_table.namespace_id, namespace.id.get());
+
+        // The default template doesn't use any tag values, so no columns need to be created.
+        let table_columns = catalog
+            .repositories()
+            .await
+            .columns()
+            .list_by_table_id(TableId::new(created_table.id))
+            .await
+            .unwrap();
+        assert!(table_columns.is_empty());
+    }
+
+    #[tokio::test]
+    async fn nonexistent_namespace_errors() {
+        let catalog: Arc<dyn Catalog> =
+            Arc::new(MemCatalog::new(Arc::new(metric::Registry::default())));
+        let handler = TableService::new(Arc::clone(&catalog));
+        let table_name = "varietals";
+
+        let request = CreateTableRequest {
+            name: table_name.into(),
+            namespace: "does_not_exist".into(),
+            partition_template: None,
+        };
+
+        let error = handler
+            .create_table(Request::new(request))
+            .await
+            .unwrap_err();
+
+        assert_eq!(error.code(), Code::NotFound);
+        assert_eq!(
+            error.message(),
+            "Could not find a namespace with name does_not_exist"
+        );
+
+        let all_tables = catalog.repositories().await.tables().list().await.unwrap();
+        assert!(all_tables.is_empty());
+    }
+
+    #[tokio::test]
+    async fn custom_table_template_using_tags_creates_tag_columns() {
+        let catalog: Arc<dyn Catalog> =
+            Arc::new(MemCatalog::new(Arc::new(metric::Registry::default())));
+        let handler = TableService::new(Arc::clone(&catalog));
+
+        let namespace = arbitrary_namespace(&mut *catalog.repositories().await, "grapes").await;
+        let table_name = "varietals";
+
+        let request = CreateTableRequest {
+            name: table_name.into(),
+            namespace: namespace.name.clone(),
+            partition_template: Some(PartitionTemplate {
+                parts: vec![
+                    TemplatePart {
+                        part: Some(template_part::Part::TagValue("color".into())),
+                    },
+                    TemplatePart {
+                        part: Some(template_part::Part::TagValue("tannins".into())),
+                    },
+                    TemplatePart {
+                        part: Some(template_part::Part::TimeFormat("%Y".into())),
+                    },
+                ],
+            }),
+        };
+
+        let created_table = handler
+            .create_table(Request::new(request))
+            .await
+            .unwrap()
+            .into_inner()
+            .table
+            .unwrap();
+
+        assert!(created_table.id > 0);
+        assert_eq!(created_table.name, table_name);
+        assert_eq!(created_table.namespace_id, namespace.id.get());
+
+        let table_columns = catalog
+            .repositories()
+            .await
+            .columns()
+            .list_by_table_id(TableId::new(created_table.id))
+            .await
+            .unwrap();
+        assert_eq!(table_columns.len(), 2);
+        assert!(table_columns.iter().all(|c| c.is_tag()));
+        let mut column_names: Vec<_> = table_columns.iter().map(|c| &c.name).collect();
+        column_names.sort();
+        assert_eq!(column_names, &["color", "tannins"])
+    }
+
+    #[tokio::test]
+    async fn custom_namespace_template_using_tags_creates_tag_columns() {
+        let catalog: Arc<dyn Catalog> =
+            Arc::new(MemCatalog::new(Arc::new(metric::Registry::default())));
+        let handler = TableService::new(Arc::clone(&catalog));
+
+        let namespace_name = NamespaceName::new("grapes").unwrap();
+        let namespace = catalog
+            .repositories()
+            .await
+            .namespaces()
+            .create(
+                &namespace_name,
+                Some(NamespacePartitionTemplateOverride::from(
+                    PartitionTemplate {
+                        parts: vec![
+                            TemplatePart {
+                                part: Some(template_part::Part::TagValue("color".into())),
+                            },
+                            TemplatePart {
+                                part: Some(template_part::Part::TagValue("tannins".into())),
+                            },
+                            TemplatePart {
+                                part: Some(template_part::Part::TimeFormat("%Y".into())),
+                            },
+                        ],
+                    },
+                )),
+                None,
+            )
+            .await
+            .unwrap();
+        let table_name = "varietals";
+
+        let request = CreateTableRequest {
+            name: table_name.into(),
+            namespace: namespace.name.clone(),
+            partition_template: None,
+        };
+
+        let created_table = handler
+            .create_table(Request::new(request))
+            .await
+            .unwrap()
+            .into_inner()
+            .table
+            .unwrap();
+
+        assert!(created_table.id > 0);
+        assert_eq!(created_table.name, table_name);
+        assert_eq!(created_table.namespace_id, namespace.id.get());
+
+        let table_columns = catalog
+            .repositories()
+            .await
+            .columns()
+            .list_by_table_id(TableId::new(created_table.id))
+            .await
+            .unwrap();
+        assert_eq!(table_columns.len(), 2);
+        assert!(table_columns.iter().all(|c| c.is_tag()));
+        let mut column_names: Vec<_> = table_columns.iter().map(|c| &c.name).collect();
+        column_names.sort();
+        assert_eq!(column_names, &["color", "tannins"])
+    }
+}


### PR DESCRIPTION
This adds a table creation gRPC API to the router that enables setting a custom partition template for the table.