### PR TITLE
Dom/ts error

### DIFF
--- a/iox_time/src/lib.rs
+++ b/iox_time/src/lib.rs
@@ -254,7 +254,7 @@ struct MockProviderInner {
 }
 
 /// A [`TimeProvider`] that returns a fixed `Time` that can be set by [`MockProvider::set`]
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct MockProvider {
     inner: Arc<RwLock<MockProviderInner>>,
 }

--- a/router/src/server/http.rs
+++ b/router/src/server/http.rs
@@ -149,7 +149,7 @@ impl From<&DmlError> for StatusCode {
 
             DmlError::Internal(_) => StatusCode::INTERNAL_SERVER_ERROR,
             DmlError::Partition(PartitionError::BatchWrite(_)) => StatusCode::INTERNAL_SERVER_ERROR,
-            DmlError::Retention(RetentionError::OutsideRetention(_)) => StatusCode::FORBIDDEN,
+            DmlError::Retention(RetentionError::OutsideRetention { .. }) => StatusCode::FORBIDDEN,
             DmlError::RpcWrite(RpcWriteError::Client(RpcWriteClientError::Upstream(_))) => {
                 StatusCode::INTERNAL_SERVER_ERROR
             }

--- a/router/tests/grpc.rs
+++ b/router/tests/grpc.rs
@@ -482,9 +482,10 @@ async fn test_update_namespace_0_retention_period() {
     assert_matches!(
         err,
         router::server::http::Error::DmlHandler(DmlError::Retention(
-            RetentionError::OutsideRetention(name)
+            RetentionError::OutsideRetention{table_name, min_acceptable_ts, observed_ts}
         )) => {
-            assert_eq!(name, "platanos");
+            assert_eq!(table_name, "platanos");
+            assert!(observed_ts < min_acceptable_ts);
         }
     );
 

--- a/router/tests/http.rs
+++ b/router/tests/http.rs
@@ -110,9 +110,10 @@ async fn test_write_outside_retention_period() {
         &response,
         router::server::http::Error::DmlHandler(
             DmlError::Retention(
-                RetentionError::OutsideRetention(e))
+                RetentionError::OutsideRetention{table_name, min_acceptable_ts, observed_ts})
         ) => {
-            assert_eq!(e, "apple");
+            assert_eq!(table_name, "apple");
+            assert!(observed_ts < min_acceptable_ts);
         }
     );
     assert_eq!(response.as_status_code(), StatusCode::FORBIDDEN);


### PR DESCRIPTION
Add a little more context to errors emitted when a user writes data that is outside the configured retention period.

The returned error looks like this:

```
data in table bananas is outside of the retention period: minimum acceptable timestamp is 2023-05-23T08:59:06+00:00, but observed timestamp 2023-05-23T07:59:06+00:00 is older.
```

---

* feat(router): put timestamps in retention error (ec0d1375d)
      
      Include the minimum acceptable timestamp (the retention bound) and the
      observed timestamp that exceeds this bound in the retention enforcement
      write error response.

* refactor(iox_time): Clone for MockProvider (067f36b01)
      
      Allow a MockProvider to be cloned, so the testing code can advance and
      inspect it. The internal state is already in an Arc, so looks like the
      intent was for it to be Clone-able anyway.

* test: more exacting retention validation tests (6cf180738)
      
      The old tests used partial error string matching, with the whole error
      message! So when I added more to the error message, the fixture tests
      didn't fail.
      
      This changes the tests to match the full string, and validate the
      timestamps are included.