### PR TITLE
feat(parquet): limit buffering when writing parquet files

### DIFF
--- a/compactor/src/components/hardcoded.rs
+++ b/compactor/src/components/hardcoded.rs
@@ -390,6 +390,7 @@ fn make_parquet_files_sink(config: &Config) -> Arc<dyn ParquetFilesSink> {
         let parquet_file_sink = Arc::new(LoggingParquetFileSinkWrapper::new(
             DedicatedExecParquetFileSinkWrapper::new(
                 ObjectStoreParquetFileSink::new(
+                    config.exec.pool(),
                     config.parquet_store_scratchpad.clone(),
                     Arc::clone(&config.time_provider),
                 ),

--- a/datafusion_util/src/lib.rs
+++ b/datafusion_util/src/lib.rs
@@ -19,6 +19,7 @@
 //! [datafusion_optimizer::utils](https://docs.rs/datafusion-optimizer/13.0.0/datafusion_optimizer/utils/index.html)
 //! for expression manipulation functions.
 
+use datafusion::execution::memory_pool::{MemoryPool, UnboundedMemoryPool};
 // Workaround for "unused crate" lint false positives.
 use workspace_hack as _;
 
@@ -390,6 +391,11 @@ pub fn create_pruning_predicate(
 ) -> Result<PruningPredicate, DataFusionError> {
     let expr = create_physical_expr_from_schema(props, expr, schema)?;
     PruningPredicate::try_new(expr, Arc::clone(schema))
+}
+
+/// Create a memory pool that has no limit
+pub fn unbounded_memory_pool() -> Arc<dyn MemoryPool> {
+    Arc::new(UnboundedMemoryPool::default())
 }
 
 #[cfg(test)]

--- a/ingester/src/persist/worker.rs
+++ b/ingester/src/persist/worker.rs
@@ -276,9 +276,10 @@ where
     // Save the compacted data to a parquet file in object storage.
     //
     // This call retries until it completes.
+    let pool = worker_state.exec.pool();
     let (md, file_size) = worker_state
         .store
-        .upload(record_stream, &iox_metadata)
+        .upload(record_stream, &iox_metadata, pool)
         .await
         .expect("unexpected fatal persist error");
 

--- a/iox_query/src/exec.rs
+++ b/iox_query/src/exec.rs
@@ -23,6 +23,7 @@ use datafusion::{
     self,
     execution::{
         disk_manager::DiskManagerConfig,
+        memory_pool::MemoryPool,
         runtime_env::{RuntimeConfig, RuntimeEnv},
     },
     logical_expr::{expr_rewriter::normalize_col, Extension},
@@ -230,6 +231,11 @@ impl Executor {
     pub async fn join(&self) {
         self.executors.query_exec.join().await;
         self.executors.reorg_exec.join().await;
+    }
+
+    /// Returns the memory pool associated with this `Executor`
+    pub fn pool(&self) -> Arc<dyn MemoryPool> {
+        Arc::clone(&self.runtime.memory_pool)
     }
 }
 

--- a/iox_tests/src/catalog.rs
+++ b/iox_tests/src/catalog.rs
@@ -10,7 +10,7 @@ use data_types::{
     TableSchema, Timestamp,
 };
 use datafusion::physical_plan::metrics::Count;
-use datafusion_util::MemoryStream;
+use datafusion_util::{unbounded_memory_pool, MemoryStream};
 use iox_catalog::{
     interface::{
         get_schema_by_id, get_table_columns_by_id, Catalog, PartitionRepo, SoftDeletedRows,
@@ -796,7 +796,7 @@ async fn create_parquet_file(
 ) -> usize {
     let stream = Box::pin(MemoryStream::new(vec![record_batch]));
     let (_meta, file_size) = store
-        .upload(stream, metadata)
+        .upload(stream, metadata, unbounded_memory_pool())
         .await
         .expect("persisting parquet file should succeed");
     file_size

--- a/parquet_file/src/lib.rs
+++ b/parquet_file/src/lib.rs
@@ -24,6 +24,7 @@ pub mod chunk;
 pub mod metadata;
 pub mod serialize;
 pub mod storage;
+pub mod writer;
 
 use data_types::{NamespaceId, ParquetFile, ParquetFileParams, PartitionId, TableId};
 use object_store::path::Path;

--- a/parquet_file/src/metadata.rs
+++ b/parquet_file/src/metadata.rs
@@ -989,7 +989,7 @@ mod tests {
         record_batch::RecordBatch,
     };
     use data_types::CompactionLevel;
-    use datafusion_util::MemoryStream;
+    use datafusion_util::{unbounded_memory_pool, MemoryStream};
     use schema::builder::SchemaBuilder;
 
     #[test]
@@ -1055,9 +1055,10 @@ mod tests {
         let batch = RecordBatch::try_new(schema, vec![data, timestamps]).unwrap();
         let stream = Box::pin(MemoryStream::new(vec![batch.clone()]));
 
-        let (bytes, file_meta) = crate::serialize::to_parquet_bytes(stream, &meta)
-            .await
-            .expect("should serialize");
+        let (bytes, file_meta) =
+            crate::serialize::to_parquet_bytes(stream, &meta, unbounded_memory_pool())
+                .await
+                .expect("should serialize");
 
         // Verify if the parquet file meta data has values
         assert!(!file_meta.row_groups.is_empty());

--- a/parquet_file/src/serialize.rs
+++ b/parquet_file/src/serialize.rs
@@ -4,19 +4,24 @@
 
 use std::{io::Write, sync::Arc};
 
-use datafusion::{error::DataFusionError, physical_plan::SendableRecordBatchStream};
+use datafusion::{
+    error::DataFusionError, execution::memory_pool::MemoryPool,
+    physical_plan::SendableRecordBatchStream,
+};
 use datafusion_util::config::BATCH_SIZE;
 use futures::{pin_mut, TryStreamExt};
 use observability_deps::tracing::{debug, trace, warn};
 use parquet::{
-    arrow::ArrowWriter,
     basic::Compression,
     errors::ParquetError,
     file::{metadata::KeyValue, properties::WriterProperties},
 };
 use thiserror::Error;
 
-use crate::metadata::{IoxMetadata, METADATA_KEY};
+use crate::{
+    metadata::{IoxMetadata, METADATA_KEY},
+    writer::TrackedMemoryArrowWriter,
+};
 
 /// Parquet row group write size
 pub const ROW_GROUP_WRITE_SIZE: usize = 1024 * 1024;
@@ -44,7 +49,7 @@ pub enum CodecError {
     #[error("no rows to serialise")]
     NoRows,
 
-    /// An arrow error during the plan execution.
+    /// A DataFusion error during the plan execution.
     #[error(transparent)]
     DataFusion(#[from] DataFusionError),
 
@@ -59,6 +64,10 @@ pub enum CodecError {
     /// Attempting to clone a handle to the provided write sink failed.
     #[error("failed to obtain writer handle clone: {0}")]
     CloneSink(std::io::Error),
+
+    /// Could not allocate sufficient memory
+    #[error("failed to allocate buffer while writing parquet: {0}")]
+    OutOfMemory(DataFusionError),
 }
 
 impl From<CodecError> for DataFusionError {
@@ -70,6 +79,16 @@ impl From<CodecError> for DataFusionError {
             | CodecError::CloneSink(_)) => Self::External(Box::new(e)),
             CodecError::Writer(e) => Self::ParquetError(e),
             CodecError::DataFusion(e) => e,
+            CodecError::OutOfMemory(e) => e,
+        }
+    }
+}
+
+impl From<crate::writer::Error> for CodecError {
+    fn from(value: crate::writer::Error) -> Self {
+        match value {
+            crate::writer::Error::Writer(e) => Self::Writer(e),
+            crate::writer::Error::OutOfMemory(e) => Self::OutOfMemory(e),
         }
     }
 }
@@ -104,6 +123,7 @@ impl From<CodecError> for DataFusionError {
 pub async fn to_parquet<W>(
     batches: SendableRecordBatchStream,
     meta: &IoxMetadata,
+    pool: Arc<dyn MemoryPool>,
     sink: W,
 ) -> Result<parquet::format::FileMetaData, CodecError>
 where
@@ -123,15 +143,15 @@ where
 
     // Construct the arrow serializer with the metadata as part of the parquet
     // file properties.
-    let mut writer = ArrowWriter::try_new(sink, Arc::clone(&schema), Some(props))?;
+    let mut writer = TrackedMemoryArrowWriter::try_new(sink, Arc::clone(&schema), props, pool)?;
 
     let mut num_batches = 0;
     while let Some(batch) = stream.try_next().await? {
-        writer.write(&batch)?;
+        writer.write(batch)?;
         num_batches += 1;
     }
 
-    let writer_meta = writer.close().map_err(CodecError::from)?;
+    let writer_meta = writer.close()?;
     if writer_meta.num_rows == 0 {
         // throw warning if all input batches are empty
         warn!("parquet serialisation encoded 0 rows");
@@ -154,6 +174,7 @@ where
 pub async fn to_parquet_bytes(
     batches: SendableRecordBatchStream,
     meta: &IoxMetadata,
+    pool: Arc<dyn MemoryPool>,
 ) -> Result<(Vec<u8>, parquet::format::FileMetaData), CodecError> {
     let mut bytes = vec![];
 
@@ -165,7 +186,7 @@ pub async fn to_parquet_bytes(
     );
 
     // Serialize the record batches into the in-memory buffer
-    let meta = to_parquet(batches, meta, &mut bytes).await?;
+    let meta = to_parquet(batches, meta, pool, &mut bytes).await?;
     bytes.shrink_to_fit();
 
     trace!(?partition_id, ?meta, "generated parquet file metadata");
@@ -173,9 +194,9 @@ pub async fn to_parquet_bytes(
     Ok((bytes, meta))
 }
 
-/// Helper to construct [`WriterProperties`] for the [`ArrowWriter`],
-/// serialising the given [`IoxMetadata`] and embedding it as a key=value
-/// property keyed by [`METADATA_KEY`].
+/// Helper to construct [`WriterProperties`] , serialising the given
+/// [`IoxMetadata`] and embedding it as a key=value property keyed by
+/// [`METADATA_KEY`].
 fn writer_props(meta: &IoxMetadata) -> Result<WriterProperties, prost::EncodeError> {
     let builder = WriterProperties::builder()
         .set_key_value_metadata(Some(vec![KeyValue {
@@ -199,7 +220,7 @@ mod tests {
     use bytes::Bytes;
     use data_types::{CompactionLevel, NamespaceId, PartitionId, TableId};
     use datafusion::parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
-    use datafusion_util::MemoryStream;
+    use datafusion_util::{unbounded_memory_pool, MemoryStream};
     use iox_time::Time;
     use std::sync::Arc;
 
@@ -222,7 +243,7 @@ mod tests {
         let batch = RecordBatch::try_from_iter([("a", to_string_array(&["value"]))]).unwrap();
         let stream = Box::pin(MemoryStream::new(vec![batch.clone()]));
 
-        let (bytes, _file_meta) = to_parquet_bytes(stream, &meta)
+        let (bytes, _file_meta) = to_parquet_bytes(stream, &meta, unbounded_memory_pool())
             .await
             .expect("should serialize");
 

--- a/parquet_file/src/writer.rs
+++ b/parquet_file/src/writer.rs
@@ -92,6 +92,7 @@ pub struct TrackedMemoryArrowWriter<W: Write + Send> {
 }
 
 // ArrowWriter doesn't implement Debug
+// Can remove when https://github.com/apache/arrow-rs/pull/4278 is available
 impl<W: Write + Send> Debug for TrackedMemoryArrowWriter<W> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("TrackedMemoryArrowWriter<W>")

--- a/parquet_file/src/writer.rs
+++ b/parquet_file/src/writer.rs
@@ -1,0 +1,409 @@
+//! Memory tracked parquet writer
+use std::{collections::VecDeque, fmt::Debug, io::Write, sync::Arc};
+
+use arrow::{datatypes::SchemaRef, record_batch::RecordBatch};
+use datafusion::{
+    error::DataFusionError,
+    execution::memory_pool::{MemoryConsumer, MemoryPool, MemoryReservation},
+};
+use observability_deps::tracing::debug;
+use parquet::{arrow::ArrowWriter, errors::ParquetError, file::properties::WriterProperties};
+use thiserror::Error;
+
+/// Default max buffer size. See [`TrackedMemoryArrowWriter::with_max_buffer_size`] for more details
+pub const MAX_BUFFER_SIZE: usize = 512 * 1024 * 1024; // 512 MB
+
+/// Default allocation increment size. See [`TrackedMemoryArrowWriter::with_min_allocation_increment`] for more details
+pub const MIN_ALLOCATION_INCREMENT: usize = 64 * 1024 * 1024; // 64MB
+
+/// Errors related to [`TrackedMemoryArrowWriter`]
+#[derive(Debug, Error)]
+pub enum Error {
+    /// Writing the parquet file failed with the specified error.
+    #[error("failed to write parquet file: {0}")]
+    Writer(#[from] ParquetError),
+
+    /// Could not allocate sufficient memory
+    #[error("failed to allocate buffer while writing parquet: {0}")]
+    OutOfMemory(#[from] DataFusionError),
+}
+
+/// Results!
+pub type Result<T, E = Error> = std::result::Result<T, E>;
+
+/// Wraps an [`ArrowWriter`] so that all data that is buffered is
+/// accounted for in the DataFusion [`MemoryPool`]
+///
+/// # Behavior
+///
+/// Buffers [`RecordBatch`]es before writing them to the parquet
+/// writer until either:
+///
+/// 1. No more buffer space is allowed by the `MemoryPool`
+/// 2. The number of rows buffered exceeds the `max_buffer_rows` size
+///
+/// Once either condition is hit, the data is flushed to the output
+///
+/// # Limitations
+///
+/// This writer does not take into account the actual parquet bytes in
+/// the underlying writer (it only tracks `RecordBatch` memory)
+///
+/// # Background
+///
+/// Internally, the [`ArrowWriter`] buffers data until it has
+/// `set_max_row_group_size` rows before it encodes the data.
+///
+/// This often works well and results in well encoded parquet
+/// files. However, for some datasets the buffering requires
+/// substantial (10s of GB) memory.  For more details, see
+/// <https://github.com/influxdata/influxdb_iox/issues/7783>
+///
+/// # Future Improvements:
+///
+/// See <https://github.com/apache/arrow-rs/issues/3871>
+///
+/// When this ticket for improving the arrow-rs behavior is complete,
+/// this code can probably be improved (to delegate the buffering to
+/// the ArrowWriter and just track its memory use with the pool).
+pub struct TrackedMemoryArrowWriter<W: Write + Send> {
+    /// The inner ArrowWriter
+    inner: ArrowWriter<W>,
+    /// Buffered data waiting for write. Data is pushed on front, popped from back
+    buffer: VecDeque<RecordBatch>,
+    /// current bytes buffered
+    buffer_size: usize,
+    /// current number of rows buffered
+    buffer_rows: usize,
+    /// maximum number of bytes to buffer
+    max_buffer_size: usize,
+    /// maximum number of row groups
+    max_buffer_rows: usize,
+    /// Minimum size to allocate in each increment
+    min_allocation_increment: usize,
+    /// Memory manager reservation with DataFusion
+    reservation: MemoryReservation,
+}
+
+// ArrowWriter doesn't implement Debug
+impl<W: Write + Send> Debug for TrackedMemoryArrowWriter<W> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TrackedMemoryArrowWriter<W>")
+            .field("inner", &"ArrowWriter<W>")
+            .field("buffer", &"<buffer>")
+            .field("buffer_size", &self.buffer_size)
+            .field("buffer_rows", &self.buffer_rows)
+            .field("max_buffer_size", &self.max_buffer_size)
+            .field("max_buffer_rows", &self.max_buffer_rows)
+            .field("min_allocation_increment", &self.min_allocation_increment)
+            .field("reservation", &self.reservation)
+            .finish()
+    }
+}
+
+impl<W: Write + Send> TrackedMemoryArrowWriter<W> {
+    /// create a new `LimitedBufferingParquetWriter`
+    pub fn try_new(
+        sink: W,
+        schema: SchemaRef,
+        props: WriterProperties,
+        pool: Arc<dyn MemoryPool>,
+    ) -> Result<Self> {
+        let max_row_group_size = props.max_row_group_size();
+        let inner = ArrowWriter::try_new(sink, schema, Some(props))?;
+        let consumer = MemoryConsumer::new("IOx ParquetWriter (TrackedMemoryArrowWriter)");
+        let reservation = consumer.register(&pool);
+
+        Ok(Self {
+            inner,
+            buffer: VecDeque::new(),
+            buffer_size: 0,
+            buffer_rows: 0,
+            max_buffer_size: MAX_BUFFER_SIZE,
+            max_buffer_rows: max_row_group_size,
+            min_allocation_increment: MIN_ALLOCATION_INCREMENT,
+            reservation,
+        })
+    }
+
+    /// Set the maximum amount of data that will be buffered before a flush.
+    ///
+    /// Defaults to [`MAX_BUFFER_SIZE`]
+    ///
+    /// The writer will force a flush when it has buffered this amount
+    /// of memory, even if it could get more memory from the memory
+    /// pool
+    pub fn with_max_buffer_size(mut self, max_buffer_size: usize) -> Self {
+        self.max_buffer_size = max_buffer_size;
+        self
+    }
+
+    /// Set the maximum number of rows that will be buffered before a flush.
+    ///
+    /// The writer will force a flush once it has buffered this many
+    /// rows, regardless of the size of its buffer
+    pub fn with_max_buffer_rows(mut self, max_buffer_rows: usize) -> Self {
+        self.max_buffer_rows = max_buffer_rows;
+        self
+    }
+
+    /// Set the minimum allocation increment size.
+    ///
+    /// The writer will always allocate at least this much additional
+    /// space from the memory pool.
+    pub fn with_min_allocation_increment(mut self, min_allocation_increment: usize) -> Self {
+        self.min_allocation_increment = min_allocation_increment;
+        self
+    }
+
+    /// Returns the total size, in bytes, of the buffered data
+    pub fn buffer_size(&self) -> usize {
+        self.buffer_size
+    }
+
+    /// Push a `RecordBatch` into the buffer, flushing if we can't
+    /// allocate sufficient space from the memory manager
+    pub fn write(&mut self, batch: RecordBatch) -> Result<()> {
+        let batch_rows = batch.num_rows();
+        let batch_size = batch.get_array_memory_size();
+
+        // enforce the limits, if needed
+        if self.buffer_size + batch_size > self.max_buffer_size
+            || self.buffer_rows + batch_rows > self.max_buffer_rows
+        {
+            self.flush()?;
+        }
+        self.buffer_rows += batch_rows;
+        self.buffer_size += batch_size;
+        self.ensure_reservation()?;
+
+        // add batch to queue
+        self.buffer.push_back(batch);
+        Ok(())
+    }
+
+    /// Ensures that our reservation with the memory pool is
+    /// sufficiently large for the amount of data that is currently
+    /// buffered. If not, attempts to grow the reservation to match
+    /// what is currently buffered.
+    pub fn ensure_reservation(&mut self) -> Result<()> {
+        if self.reservation.size() < self.buffer_size {
+            let increment =
+                (self.buffer_size - self.reservation.size()).max(self.min_allocation_increment);
+
+            debug!(
+                increment,
+                rows = self.buffer_rows,
+                max_buffer_rows = self.max_buffer_rows,
+                buffer_size = self.buffer_size,
+                max_buffer_size = self.max_buffer_size,
+                "Attemping to reserve additional space"
+            );
+
+            self.reservation
+                .try_grow(increment)
+                .map_err(Error::OutOfMemory)?
+        }
+
+        Ok(())
+    }
+
+    /// flushes all buffered [`RecordBatch`] to the underlying writer.
+    pub fn flush(&mut self) -> Result<()> {
+        debug!(
+            rows = self.buffer_rows,
+            max_buffer_rows = self.max_buffer_rows,
+            buffer_size = self.buffer_size,
+            max_buffer_size = self.max_buffer_size,
+            reservation = self.reservation.size(),
+            "Flushing data to parquet"
+        );
+
+        while let Some(batch) = self.buffer.pop_front() {
+            self.inner.write(&batch)?;
+        }
+        self.inner.flush()?;
+        self.buffer_rows = 0;
+        self.buffer_size = 0;
+        // Note don't return the reservation once the data is
+        // flushed. Instead the writer holds on to the reservation as
+        // the expectation is we will be getting more data to buffer
+        // soon
+        Ok(())
+    }
+
+    /// closes the writer, flushing any remaining data and returning
+    /// the written [`FileMetaData`]
+    ///
+    /// [`FileMetaData`]: parquet::format::FileMetaData
+    pub fn close(mut self) -> Result<parquet::format::FileMetaData> {
+        self.flush()?;
+        Ok(self.inner.close()?)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use arrow::array::{ArrayRef, StringArray};
+    use datafusion::execution::memory_pool::GreedyMemoryPool;
+
+    /// Number of rows to trigger writer flush
+    const TEST_MAX_ROW_GROUP_SIZE: usize = 100;
+    /// Allocation increments
+    const TEST_INCREMENT_SIZE: usize = 1000; // allocate in multiples of 1000
+    /// Memory (multiple of increment size) for 100 rows (at time of
+    /// writing each 10 row batch takes up 248 bytes so 10 batches
+    /// need 2480 --> rounded up to 3000)
+    const MEMORY_NEEDED_FOR_100_ROWS: usize = 3000;
+
+    #[tokio::test]
+    async fn test_pool_allocation() {
+        let props = WriterProperties::builder()
+            .set_max_row_group_size(TEST_MAX_ROW_GROUP_SIZE)
+            .build();
+
+        let pool = memory_pool(10000);
+        let mut writer =
+            TrackedMemoryArrowWriter::try_new(vec![], batch().schema(), props, Arc::clone(&pool))
+                .unwrap()
+                .with_min_allocation_increment(TEST_INCREMENT_SIZE);
+
+        let mut batches = StreamGenerator::new();
+
+        // feed 9 batches in (right before row group max)
+        for _ in 0..9 {
+            writer.write(batches.next_batch()).unwrap();
+        }
+
+        // The writer wrote in several batches
+        // expect that the memory reservation is the minimum incremented
+        assert_eq!(writer.buffer_size(), batches.total_mem);
+        assert_eq!(pool.reserved(), MEMORY_NEEDED_FOR_100_ROWS);
+
+        // Feed in 2 more batches (that exceed the max_group_size of
+        // 11 and expect a flush happens)
+        writer.write(batches.next_batch()).unwrap();
+        writer.write(batches.next_batch()).unwrap();
+
+        assert!(
+            writer.buffer_size() < batches.total_mem,
+            "buffered size {} should be less than generated size {}",
+            writer.buffer_size(),
+            batches.total_mem
+        );
+        // reservation should not to up or down (the reservation is not released)
+        assert_eq!(pool.reserved(), MEMORY_NEEDED_FOR_100_ROWS);
+
+        // feed in 50 more batches, and expect that the reservation
+        // doesn't need to go up (it is reused)
+        for _ in 0..50 {
+            writer.write(batches.next_batch()).unwrap();
+        }
+        assert_eq!(pool.reserved(), MEMORY_NEEDED_FOR_100_ROWS);
+    }
+
+    #[tokio::test]
+    async fn test_pool_memory_pressure() {
+        let props = WriterProperties::builder()
+            .set_max_row_group_size(TEST_MAX_ROW_GROUP_SIZE)
+            .build();
+
+        // Use a smaller pool size that can't fit all 100 rows, but also limit the writer to that limit as well
+        let pool_size = 2000;
+        assert!(pool_size < MEMORY_NEEDED_FOR_100_ROWS);
+        let pool = memory_pool(pool_size);
+        let mut writer =
+            TrackedMemoryArrowWriter::try_new(vec![], batch().schema(), props, Arc::clone(&pool))
+                .unwrap()
+                .with_max_buffer_size(pool_size / 2)
+                .with_min_allocation_increment(TEST_INCREMENT_SIZE);
+
+        let mut batches = StreamGenerator::new();
+
+        // Should be able to write more than 10 batches without error
+        // as the writer will be flushing more frequently
+        for _ in 0..20 {
+            writer.write(batches.next_batch()).unwrap();
+        }
+
+        // The writer wrote in several batches
+        // expect that the memory reservation was kept at the allocation limit (pool_size / 2) = 1000
+        assert_eq!(pool.reserved(), pool_size / 2);
+    }
+
+    #[tokio::test]
+    async fn test_pool_oom() {
+        let props = WriterProperties::builder()
+            .set_max_row_group_size(TEST_MAX_ROW_GROUP_SIZE)
+            .build();
+
+        // Pool can only grow to 2000, but we need 3000 to buffer enough batches to get to 100 rows
+        let pool_size = 2000;
+        assert!(pool_size < MEMORY_NEEDED_FOR_100_ROWS);
+        let pool = memory_pool(pool_size);
+        let mut writer =
+            TrackedMemoryArrowWriter::try_new(vec![], batch().schema(), props, Arc::clone(&pool))
+                .unwrap()
+                .with_min_allocation_increment(TEST_INCREMENT_SIZE);
+
+        let mut batches = StreamGenerator::new();
+
+        // should error with oom
+        for _ in 0..20 {
+            match &writer.write(batches.next_batch()) {
+                Ok(_) => continue,
+                Err(Error::OutOfMemory(e)) => {
+                    assert_eq!("Resources exhausted: Failed to allocate additional 1000 bytes for IOx ParquetWriter (TrackedMemoryArrowWriter) with 2000 bytes already allocated - maximum available is 0", e.to_string());
+                    return;
+                }
+                Err(e) => {
+                    panic!("unexpected error: {e})");
+                }
+            }
+        }
+        panic!("Did not error with out of memory as expected");
+    }
+
+    // This time test that the memory limit is enforced and it will stay under the limit
+
+    #[derive(Debug, Clone, PartialEq)]
+    struct StreamGenerator {
+        num_rows: usize,
+        num_batches: usize,
+        total_mem: usize,
+    }
+
+    impl StreamGenerator {
+        fn new() -> Self {
+            Self {
+                num_rows: 0,
+                num_batches: 0,
+                total_mem: 0,
+            }
+        }
+
+        fn next_batch(&mut self) -> RecordBatch {
+            let batch = batch();
+            self.num_batches += 1;
+            self.num_rows += batch.num_rows();
+            self.total_mem += batch.get_array_memory_size();
+            batch
+        }
+    }
+
+    fn batch() -> RecordBatch {
+        RecordBatch::try_from_iter([("a", string_array(10))]).unwrap()
+    }
+
+    /// Makes a string array with `count` entries
+    fn string_array(count: usize) -> ArrayRef {
+        let array: StringArray = std::iter::repeat(Some("foo")).take(count).collect();
+        Arc::new(array)
+    }
+
+    /// make a MemoryPool with the specified max size
+    fn memory_pool(max_size: usize) -> Arc<dyn MemoryPool> {
+        Arc::new(GreedyMemoryPool::new(max_size))
+    }
+}

--- a/parquet_file/src/writer.rs
+++ b/parquet_file/src/writer.rs
@@ -11,6 +11,12 @@ use parquet::{arrow::ArrowWriter, errors::ParquetError, file::properties::Writer
 use thiserror::Error;
 
 /// Default max buffer size. See [`TrackedMemoryArrowWriter::with_max_buffer_size`] for more details
+///
+/// Note that this limit was introduced to limit the compactor's
+/// memory usage when writing large parquet files. Changing this
+/// setting will increase the amount of memory used for buffering in
+/// the compactor and could lead to out of memory errors if the memory
+/// pool is not sufficiently large.
 pub const MAX_BUFFER_SIZE: usize = 512 * 1024 * 1024; // 512 MB
 
 /// Default allocation increment size. See [`TrackedMemoryArrowWriter::with_min_allocation_increment`] for more details

--- a/parquet_file/tests/metadata.rs
+++ b/parquet_file/tests/metadata.rs
@@ -5,7 +5,7 @@ use arrow::{
     record_batch::RecordBatch,
 };
 use data_types::{ColumnId, CompactionLevel, NamespaceId, PartitionId, TableId, Timestamp};
-use datafusion_util::MemoryStream;
+use datafusion_util::{unbounded_memory_pool, MemoryStream};
 use iox_time::Time;
 use object_store::DynObjectStore;
 use parquet_file::{
@@ -79,7 +79,7 @@ async fn test_decoded_iox_metadata() {
     let storage = ParquetStorage::new(object_store, StorageId::from("iox"));
 
     let (iox_parquet_meta, file_size) = storage
-        .upload(stream, &meta)
+        .upload(stream, &meta, unbounded_memory_pool())
         .await
         .expect("failed to serialize & persist record batch");
 
@@ -208,7 +208,7 @@ async fn test_empty_parquet_file_panic() {
 
     // Serialising empty data should cause a panic for human investigation.
     let err = storage
-        .upload(stream, &meta)
+        .upload(stream, &meta, unbounded_memory_pool())
         .await
         .expect_err("empty file should raise an error");
 
@@ -312,7 +312,7 @@ async fn test_decoded_many_columns_with_null_cols_iox_metadata() {
     let storage = ParquetStorage::new(object_store, StorageId::from("iox"));
 
     let (iox_parquet_meta, file_size) = storage
-        .upload(stream, &meta)
+        .upload(stream, &meta, unbounded_memory_pool())
         .await
         .expect("failed to serialize & persist record batch");
 
@@ -396,7 +396,7 @@ async fn test_derive_parquet_file_params() {
     let storage = ParquetStorage::new(object_store, StorageId::from("iox"));
 
     let (iox_parquet_meta, file_size) = storage
-        .upload(stream, &meta)
+        .upload(stream, &meta, unbounded_memory_pool())
         .await
         .expect("failed to serialize & persist record batch");
 


### PR DESCRIPTION
Closes https://github.com/influxdata/influxdb_iox/issues/7783

# TLDR
I believe this PR will
1.  Reduce the memory required for compaction significantly (it should now remain much cluster to the limits configured) and will likely increase its speed
2. *Increase* the resulting parquet files (25% bigger worst case). 
3. Note we could improve the parquet sizes by buffering more (e.g 1GB instead of 512MB per parquet file)
4. We have a plan (https://github.com/influxdata/influxdb_iox/issues/7860) that requires upstream arrow-rs changes, but can improve the parquet file size without requiring more memory

# Rationale:
As explained on https://github.com/influxdata/influxdb_iox/issues/7783#issuecomment-1557789373 the parquet writer will currently buffer up to 1M rows, prior to encoding a row group, regardless of the amount of memory that consumes. For some types of data, this amount of memory can be 10s of GB which causes the compactor to be OOM killed.

# Changes
1. Add explicit buffering (with a limit) of `RecordBatch`es to the parquet writer in IOx 
2. Add tests for same

# Effect on Memory Usage

While writing out the parquet files from the scenario on https://github.com/influxdata/influxdb_iox/issues/7783 with this change, the memory profile is consistent and stays under 1GB. Here is a screen shot from `Instruments`:
![Screenshot 2023-05-23 at 5 55 49 PM](https://github.com/influxdata/influxdb_iox/assets/490673/77edfd64-1e9b-4d7f-8fc6-7b9505e7db68)

On `main`, the memory usage peaks at 20+GB (picture from https://github.com/influxdata/influxdb_iox/issues/7783#issuecomment-1557713255):
![Screenshot 2023-05-22 at 2 35 11 PM](https://github.com/influxdata/influxdb_iox/assets/490673/13cfcdda-5496-4348-9ac9-c398b79b7b65)


# Effect on Parquet File Size

For each parquet write, this PR buffers up to 512 MB of `RecordBatch` data, and if that is exceeded forces the writer to write out whatever it has so far. For some datasets this results in fewer rows per group and thus lower compression for the resulting parquet files.  After https://github.com/apache/arrow-rs/issues/3871 is available, the buffering can be done much more efficiently at the parquet level and we can restore the parquet file improvement

| Size of first file | Time to create | Description |
|--------|--------|--------|
| 113,430,799  | 151.25s | `main` |
| 143,247,332 (25% larger)| 71.35s | this PR | 

<details><summary>Details</summary>
<p>
Here are the sizes of the first parquet file written in the scenario  on main
```
2023-05-23T23:50:19.892374Z DEBUG parquet_file::serialize: Created parquet file num_batches=3419 num_rows=14721462 object_store_id=c4778201-26de-4980-94ee-4705a5d2f87a partition_id=PartitionId(1) write_batch_size=1024 max_row_group_size=1048576
2023-05-23T23:50:19.896574Z DEBUG parquet_file::storage: Uploading parquet to object store file_size=113430799 object_store_id=c4778201-26de-4980-94ee-4705a5d2f87a partition_id=PartitionId(1) total_time_to_create_parquet_bytes=151.246987854s
```

Here is the first parquet file made with this PR: 
```
2023-05-24T10:22:29.745603Z DEBUG parquet_file::serialize: Created parquet file num_batches=3419 num_rows=14721462 object_store_id=f5d7b027-da96-4e49-8bf7-f93673b9d1f0 partition_id=PartitionId(1) write_batch_size=1024 max_row_group_size=1048576
2023-05-24T10:22:29.810283Z DEBUG parquet_file::storage: Uploading parquet to object store file_size=143247332 object_store_id=f5d7b027-da96-4e49-8bf7-f93673b9d1f0 partition_id=PartitionId(1) total_time_to_create_parquet_bytes=71.356486275s

```


</p>
</details> 


Here is a summary on the here is the compression data. :

| Delta | Total Size | Description |
|--------|--------|--------|
| 235M | 0 | Original (non compacted) |
| 542M | 307M | `main` (without this PR, use 20GB of memory) |
| 583M | 348M  | This PR (uses les than 1GB of memory) |

This results in row groups between 16,000 and 60,000 rows per group with the reproducer data from https://github.com/influxdata/influxdb_iox/issues/7783

<details><summary>Here are some example row group sizes</summary>
<p>

Example logs:
```
2023-05-23T18:30:01.232107Z DEBUG parquet_file::writer: Attemping to reserve additional space increment=4855104 rows=13616 max_buffer_rows=1048576 buffer_size=522596128 max_buffer_size=536870912
2023-05-23T18:30:01.374408Z DEBUG parquet_file::writer: Flushing data to parquet rows=50517 max_buffer_rows=1048576 buffer_size=531001248 max_buffer_size=536870912 reservation=531001248
2023-05-23T18:30:01.440516Z DEBUG parquet_file::writer: Flushing data to parquet rows=13616 max_buffer_rows=1048576 buffer_size=522596128 max_buffer_size=536870912 reservation=522596128
2023-05-23T18:30:02.496324Z DEBUG parquet_file::writer: Flushing data to parquet rows=60708 max_buffer_rows=1048576 buffer_size=497685152 max_buffer_size=536870912 reservation=526903008
2023-05-23T18:30:03.688217Z DEBUG parquet_file::writer: Flushing data to parquet rows=61593 max_buffer_rows=1048576 buffer_size=503093696 max_buffer_size=536870912 reservation=531001248
2023-05-23T18:30:03.690626Z DEBUG parquet_file::writer: Attemping to reserve additional space increment=5732544 rows=16818 max_buffer_rows=1048576 buffer_size=528328672 max_buffer_size=536870912
2023-05-23T18:30:03.956755Z DEBUG parquet_file::writer: Flushing data to parquet rows=16818 max_buffer_rows=1048576 buffer_size=528328672 max_buffer_size=536870912 reservation=528328672
2023-05-23T18:30:05.531610Z DEBUG parquet_file::writer: Flushing data to parquet rows=60038 max_buffer_rows=1048576 buffer_size=526885376 max_buffer_size=536870912 reservation=526903008
2023-05-23T18:30:06.010282Z DEBUG parquet_file::writer: Flushing data to parquet rows=41842 max_buffer_rows=1048576 buffer_size=517718272 max_buffer_size=536870912 reservation=531001248
```



</p>
</details> 

