### PR TITLE
refactor: remove ununused `parquet_file` indices

### DIFF
--- a/iox_catalog/migrations/20230524095337_remove_unused_parquet_file_indices.sql
+++ b/iox_catalog/migrations/20230524095337_remove_unused_parquet_file_indices.sql
@@ -1,0 +1,4 @@
+-- Remove unused indices
+DROP INDEX IF EXISTS parquet_file_partition_created_idx;
+DROP INDEX IF EXISTS parquet_file_shard_compaction_delete_created_idx;
+DROP INDEX IF EXISTS parquet_file_shard_compaction_delete_idx;


### PR DESCRIPTION
Remove unused Postgres indices. This lower database load but also gives us room to install actually useful indices (see #7842).

To detect which indices are used, I've used the following query (on the actual write/master replicate in eu-central-1):

```sql
SELECT
    n.nspname                                      AS namespace_name,
    t.relname                                      AS table_name,
    pg_size_pretty(pg_relation_size(t.oid))        AS table_size,
    t.reltuples::bigint                            AS num_rows,
    psai.indexrelname                              AS index_name,
    pg_size_pretty(pg_relation_size(i.indexrelid)) AS index_size,
    CASE WHEN i.indisunique THEN 'Y' ELSE 'N' END  AS "unique",
    psai.idx_scan                                  AS number_of_scans,
    psai.idx_tup_read                              AS tuples_read,
    psai.idx_tup_fetch                             AS tuples_fetched
FROM
    pg_index i
    INNER JOIN pg_class t               ON t.oid = i.indrelid
    INNER JOIN pg_namespace n           ON n.oid = t.relnamespace
    INNER JOIN pg_stat_all_indexes psai ON i.indexrelid = psai.indexrelid
WHERE
    n.nspname = 'iox_catalog' AND t.relname = 'parquet_file'
ORDER BY 1, 2, 5;
```

At `2023-05-23T16:00:00Z`:

```text
 namespace_name |  table_name  | table_size | num_rows  |                    index_name                    | index_size | unique | number_of_scans |  tuples_read   | tuples_fetched
----------------+--------------+------------+-----------+--------------------------------------------------+------------+--------+-----------------+----------------+----------------
 iox_catalog    | parquet_file | 31 GB      | 120985000 | parquet_file_deleted_at_idx                      | 5398 MB    | N      |      1693383413 | 21036174283392 |    21336337964
 iox_catalog    | parquet_file | 31 GB      | 120985000 | parquet_file_partition_created_idx               | 11 GB      | N      |        34190874 |     4749070532 |       61934212
 iox_catalog    | parquet_file | 31 GB      | 120985000 | parquet_file_partition_idx                       | 2032 MB    | N      |      1612961601 |  9935669905489 |  8611676799872
 iox_catalog    | parquet_file | 31 GB      | 120985000 | parquet_file_pkey                                | 7135 MB    | Y      |       453927041 |      454181262 |      453894565
 iox_catalog    | parquet_file | 31 GB      | 120985000 | parquet_file_shard_compaction_delete_created_idx | 14 GB      | N      |               0 |              0 |              0
 iox_catalog    | parquet_file | 31 GB      | 120985000 | parquet_file_shard_compaction_delete_idx         | 8767 MB    | N      |               2 |          30717 |           4860
 iox_catalog    | parquet_file | 31 GB      | 120985000 | parquet_file_table_idx                           | 1602 MB    | N      |         9136844 |   341839537275 |          27551
 iox_catalog    | parquet_file | 31 GB      | 120985000 | parquet_location_unique                          | 4989 MB    | Y      |       332341872 |           3123 |           3123
```

At `2023-05-24T09:50:00Z` (i.e. nearly 18h later):

```text
 namespace_name |  table_name  | table_size | num_rows  |                    index_name                    | index_size | unique | number_of_scans |  tuples_read   | tuples_fetched
----------------+--------------+------------+-----------+--------------------------------------------------+------------+--------+-----------------+----------------+----------------
 iox_catalog    | parquet_file | 31 GB      | 123869328 | parquet_file_deleted_at_idx                      | 5448 MB    | N      |      1693485804 | 21409285169862 |    21364369704
 iox_catalog    | parquet_file | 31 GB      | 123869328 | parquet_file_partition_created_idx               | 11 GB      | N      |        34190874 |     4749070532 |       61934212
 iox_catalog    | parquet_file | 31 GB      | 123869328 | parquet_file_partition_idx                       | 2044 MB    | N      |      1615214409 | 10159380553599 |  8811036969123
 iox_catalog    | parquet_file | 31 GB      | 123869328 | parquet_file_pkey                                | 7189 MB    | Y      |       455128165 |      455382386 |      455095624
 iox_catalog    | parquet_file | 31 GB      | 123869328 | parquet_file_shard_compaction_delete_created_idx | 14 GB      | N      |               0 |              0 |              0
 iox_catalog    | parquet_file | 31 GB      | 123869328 | parquet_file_shard_compaction_delete_idx         | 8849 MB    | N      |               2 |          30717 |           4860
 iox_catalog    | parquet_file | 31 GB      | 123869328 | parquet_file_table_idx                           | 1618 MB    | N      |         9239071 |   348304417343 |          27551
 iox_catalog    | parquet_file | 31 GB      | 123869328 | parquet_location_unique                          | 5043 MB    | Y      |       343484617 |           3123 |           3123
```

The cluster currently is under load and all components are running. Conclusion:

- `parquet_file_deleted_at_idx`: Used, likely by the GC. We could probably shrink this index by binning `deleted_at` (within the index, not within the actual database table), but let's do this in a later PR.
- `parquet_file_partition_created_idx`: Unused and huge (`created_at` is NOT binned). So let's remove it.
- `parquet_file_partition_idx`: Used, likely by the compactor and querier because we currently don't have a better index (see #7842 as well). This includes deleted files as well which is somewhat pointless. May become obsolete after #7842, not touching for now.
- `parquet_file_pkey`: Primary key. We should probably use the object store UUID as a primary key BTW, which would also make the GC faster. Not touching for now.
- `parquet_file_shard_compaction_delete_created_idx`: Huge unused index. Shards don't exist anymore. Delete it.
- `parquet_file_shard_compaction_delete_idx`: Same as `parquet_file_shard_compaction_delete_created_idx`.
- `parquet_file_table_idx`: Used but is somewhat too large because it contains deleted files. Might become obsolete after #7842, don't touch for now.
- `parquet_location_unique`: See note `parquet_file_pkey`, it's pointless to have two IDs here. Not touching for now but this is a potential future improvement.

So we remove:

- `parquet_file_partition_created_idx`
- `parquet_file_shard_compaction_delete_created_idx`
- `parquet_file_shard_compaction_delete_idx`
