### PR TITLE
refactor(catalog): mark metrics() as test only

### DIFF
--- a/iox_catalog/src/interface.rs
+++ b/iox_catalog/src/interface.rs
@@ -207,7 +207,8 @@ pub trait Catalog: Send + Sync + Debug + Display {
     /// Accesses the repositories without a transaction scope.
     async fn repositories(&self) -> Box<dyn RepoCollection>;
 
-    /// Gets metric registry associated with this catalog.
+    /// Gets metric registry associated with this catalog for testing purposes.
+    #[cfg(test)]
     fn metrics(&self) -> Arc<metric::Registry>;
 
     /// Gets the time provider associated with this catalog.

--- a/iox_catalog/src/mem.rs
+++ b/iox_catalog/src/mem.rs
@@ -105,6 +105,7 @@ impl Catalog for MemCatalog {
         ))
     }
 
+    #[cfg(test)]
     fn metrics(&self) -> Arc<metric::Registry> {
         Arc::clone(&self.metrics)
     }

--- a/iox_catalog/src/postgres.rs
+++ b/iox_catalog/src/postgres.rs
@@ -300,6 +300,7 @@ DO NOTHING;
         ))
     }
 
+    #[cfg(test)]
     fn metrics(&self) -> Arc<metric::Registry> {
         Arc::clone(&self.metrics)
     }

--- a/iox_catalog/src/sqlite.rs
+++ b/iox_catalog/src/sqlite.rs
@@ -224,6 +224,7 @@ DO NOTHING;
         ))
     }
 
+    #[cfg(test)]
     fn metrics(&self) -> Arc<Registry> {
         Arc::clone(&self.metrics)
     }


### PR DESCRIPTION
It's not possible to remove this because our testing setup is a bit circular.... but at least this removes it from the prod code, which should make it less likely to be used incorrectly.

---

* refactor(catalog): mark metrics() as test only (2094b45c1)
      
      This method is used to enable tests - it's never intended to be used in
      production code to access the underlying metric registry. The Catalog
      trait is responsible for Catalog things, not acting as a dependency
      injection for metrics.
      
      The only current use of this is in test code, so no changes needed.