### PR TITLE
chore: Minor cleanup

### DIFF
--- a/iox_query_influxql/src/plan/rewriter.rs
+++ b/iox_query_influxql/src/plan/rewriter.rs
@@ -1450,7 +1450,7 @@ pub(crate) enum ProjectionType {
 /// Holds high-level information as the result of analysing
 /// a `SELECT` query.
 #[derive(Default, Debug, Copy, Clone)]
-pub(crate) struct SelectStatementInfo {
+struct SelectStatementInfo {
     /// Identifies the projection type for the `SELECT` query.
     pub projection_type: ProjectionType,
 }


### PR DESCRIPTION
This PR is some minor housekeeping I extracted from another branch so it can be used sooner.

I separated out the `scope` from the `Context` in the planner, as this concern does not belong in the `Context` structure. In particular, it results in unnecessary copying for each transformation of a column in the projection:

https://github.com/influxdata/influxdb_iox/blob/928731767e98ed5d108e45d8594ee328ae907366/iox_query_influxql/src/plan/planner.rs#L926

and when transforming the `WHERE` condition:

https://github.com/influxdata/influxdb_iox/blob/928731767e98ed5d108e45d8594ee328ae907366/iox_query_influxql/src/plan/planner.rs#L1258-L1262