### PR TITLE
chore: use workspace dependencies for `object_store`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -121,6 +121,7 @@ arrow-flight = { version = "40.0.0" }
 datafusion = { git = "https://github.com/apache/arrow-datafusion.git", rev="ee1019d9585252066ef5b288c84aabebcbd93ca6", default-features = false }
 datafusion-proto = { git = "https://github.com/apache/arrow-datafusion.git", rev="ee1019d9585252066ef5b288c84aabebcbd93ca6" }
 hashbrown = { version = "0.13.2" }
+object_store = { version = "0.5.6" }
 parquet = { version = "40.0.0" }
 tonic = { version = "0.9.2", features = ["tls", "tls-webpki-roots"] }
 tonic-build = { version = "0.9.2" }

--- a/clap_blocks/Cargo.toml
+++ b/clap_blocks/Cargo.toml
@@ -12,7 +12,7 @@ http = "0.2.9"
 humantime = "2.1.0"
 iox_catalog = { path = "../iox_catalog" }
 metric = { path = "../metric" }
-object_store = "0.5.6"
+object_store = { workspace = true }
 observability_deps = { path = "../observability_deps" }
 snafu = "0.7"
 trace_exporters = { path = "../trace_exporters" }

--- a/compactor/Cargo.toml
+++ b/compactor/Cargo.toml
@@ -17,7 +17,7 @@ iox_query = { path = "../iox_query" }
 iox_time = { path = "../iox_time" }
 itertools = "0.10.5"
 metric = { path = "../metric" }
-object_store = "0.5.6"
+object_store = { workspace = true }
 observability_deps = { path = "../observability_deps" }
 parquet_file = { path = "../parquet_file" }
 predicate = { path = "../predicate" }

--- a/compactor_test_utils/Cargo.toml
+++ b/compactor_test_utils/Cargo.toml
@@ -18,7 +18,7 @@ iox_catalog = { path = "../iox_catalog" }
 iox_query = { path = "../iox_query" }
 iox_tests = { path = "../iox_tests" }
 iox_time = { path = "../iox_time" }
-object_store = "0.5.6"
+object_store = { workspace = true }
 observability_deps = { path = "../observability_deps" }
 parquet_file = { path = "../parquet_file" }
 schema = { path = "../schema" }

--- a/datafusion_util/Cargo.toml
+++ b/datafusion_util/Cargo.toml
@@ -10,7 +10,7 @@ license.workspace = true
 async-trait = "0.1"
 datafusion = { workspace = true }
 futures = "0.3"
-object_store = "0.5.6"
+object_store = { workspace = true }
 observability_deps = { path = "../observability_deps" }
 pin-project = "1.1"
 tokio = { version = "1.28", features = ["parking_lot", "sync"] }

--- a/garbage_collector/Cargo.toml
+++ b/garbage_collector/Cargo.toml
@@ -14,7 +14,7 @@ futures = "0.3"
 humantime = "2.1.0"
 iox_catalog = { path = "../iox_catalog" }
 backoff = { path = "../backoff" }
-object_store = { version = "0.5.6" }
+object_store = { workspace = true }
 observability_deps = { path = "../observability_deps" }
 snafu = "0.7"
 tokio = { version = "1", features = ["macros", "rt", "sync"] }

--- a/influxdb_iox/Cargo.toml
+++ b/influxdb_iox/Cargo.toml
@@ -29,7 +29,7 @@ ioxd_querier = { path = "../ioxd_querier"}
 ioxd_router = { path = "../ioxd_router"}
 ioxd_test = { path = "../ioxd_test"}
 metric = { path = "../metric" }
-object_store = "0.5.6"
+object_store = { workspace = true }
 object_store_metrics = { path = "../object_store_metrics" }
 observability_deps = { path = "../observability_deps" }
 panic_logging = { path = "../panic_logging" }

--- a/ingester/Cargo.toml
+++ b/ingester/Cargo.toml
@@ -57,7 +57,7 @@ influxdb_iox_client = { path = "../influxdb_iox_client" }
 ingester_test_ctx = { path = "../ingester_test_ctx" }
 lazy_static = "1.4.0"
 mutable_batch_lp = { path = "../mutable_batch_lp" }
-object_store = "0.5.6"
+object_store = { workspace = true }
 paste = "1.0.12"
 tempfile = "3.5.0"
 test_helpers = { path = "../test_helpers", features = ["future_timeout"] }

--- a/ingester_test_ctx/Cargo.toml
+++ b/ingester_test_ctx/Cargo.toml
@@ -23,7 +23,7 @@ iox_time = { path = "../iox_time" }
 metric = { version = "0.1.0", path = "../metric" }
 mutable_batch_lp = { path = "../mutable_batch_lp" }
 mutable_batch_pb = { version = "0.1.0", path = "../mutable_batch_pb" }
-object_store = "0.5.6"
+object_store = { workspace = true }
 observability_deps = { version = "0.1.0", path = "../observability_deps" }
 parquet_file = { version = "0.1.0", path = "../parquet_file" }
 prost = { version = "0.11.9", default-features = false, features = ["std"] }

--- a/iox_query/Cargo.toml
+++ b/iox_query/Cargo.toml
@@ -27,7 +27,7 @@ futures = "0.3"
 hashbrown = { workspace = true }
 indexmap = { version = "1.9", features = ["std"] }
 itertools = "0.10.5"
-object_store = "0.5.6"
+object_store = { workspace = true }
 observability_deps = { path = "../observability_deps" }
 once_cell = "1"
 parking_lot = "0.12"

--- a/iox_tests/Cargo.toml
+++ b/iox_tests/Cargo.toml
@@ -16,7 +16,7 @@ iox_query = { path = "../iox_query" }
 iox_time = { path = "../iox_time" }
 metric = { path = "../metric" }
 mutable_batch_lp = { path = "../mutable_batch_lp" }
-object_store = "0.5.6"
+object_store = { workspace = true }
 observability_deps = { path = "../observability_deps" }
 parquet_file = { path = "../parquet_file" }
 schema = { path = "../schema" }

--- a/ioxd_querier/Cargo.toml
+++ b/ioxd_querier/Cargo.toml
@@ -15,7 +15,7 @@ generated_types = { path = "../generated_types" }
 iox_catalog = { path = "../iox_catalog" }
 ioxd_common = { path = "../ioxd_common" }
 metric = { path = "../metric" }
-object_store = "0.5.6"
+object_store = { workspace = true }
 querier = { path = "../querier" }
 iox_query = { path = "../iox_query" }
 service_grpc_flight = { path = "../service_grpc_flight" }

--- a/ioxd_router/Cargo.toml
+++ b/ioxd_router/Cargo.toml
@@ -16,7 +16,7 @@ iox_catalog = { path = "../iox_catalog" }
 ioxd_common = { path = "../ioxd_common" }
 metric = { path = "../metric" }
 mutable_batch = { path = "../mutable_batch" }
-object_store = "0.5.6"
+object_store = { workspace = true }
 router = { path = "../router" }
 thiserror = "1.0.40"
 tokio-util = { version = "0.7.8" }

--- a/object_store_metrics/Cargo.toml
+++ b/object_store_metrics/Cargo.toml
@@ -11,7 +11,7 @@ bytes = "1.4"
 futures = "0.3"
 iox_time = { version = "0.1.0", path = "../iox_time" }
 metric = { version = "0.1.0", path = "../metric" }
-object_store = "0.5.6"
+object_store = { workspace = true }
 pin-project = "1.1.0"
 tokio = { version = "1.28", features = ["io-util"] }
 workspace-hack = { version = "0.1", path = "../workspace-hack" }

--- a/parquet_file/Cargo.toml
+++ b/parquet_file/Cargo.toml
@@ -15,7 +15,7 @@ datafusion_util = { path = "../datafusion_util" }
 futures = "0.3"
 generated_types = { path = "../generated_types" }
 iox_time = { path = "../iox_time" }
-object_store = "0.5.6"
+object_store = { workspace = true }
 observability_deps = { path = "../observability_deps" }
 parquet = { workspace = true, features = ["experimental"]}
 pbjson-types = "0.5"

--- a/parquet_to_line_protocol/Cargo.toml
+++ b/parquet_to_line_protocol/Cargo.toml
@@ -11,7 +11,7 @@ datafusion_util = { path = "../datafusion_util" }
 influxdb-line-protocol = { path = "../influxdb_line_protocol" }
 futures = {version = "0.3"}
 num_cpus = "1.15.0"
-object_store = { version = "0.5.6" }
+object_store = { workspace = true }
 parquet_file  = { path = "../parquet_file" }
 schema = { path = "../schema" }
 tokio = "1.28"

--- a/querier/Cargo.toml
+++ b/querier/Cargo.toml
@@ -23,7 +23,7 @@ iox_query = { path = "../iox_query" }
 iox_time = { path = "../iox_time" }
 ingester_query_grpc = { path = "../ingester_query_grpc" }
 metric = { path = "../metric" }
-object_store = "0.5.6"
+object_store = { workspace = true }
 observability_deps = { path = "../observability_deps" }
 parking_lot = "0.12"
 parquet_file = { path = "../parquet_file" }

--- a/router/Cargo.toml
+++ b/router/Cargo.toml
@@ -23,7 +23,7 @@ metric = { path = "../metric" }
 mutable_batch = { path = "../mutable_batch" }
 mutable_batch_lp = { path = "../mutable_batch_lp" }
 mutable_batch_pb = { version = "0.1.0", path = "../mutable_batch_pb" }
-object_store = "0.5.6"
+object_store = { workspace = true }
 observability_deps = { path = "../observability_deps" }
 parking_lot = "0.12"
 serde = "1.0"

--- a/service_grpc_object_store/Cargo.toml
+++ b/service_grpc_object_store/Cargo.toml
@@ -9,7 +9,7 @@ license.workspace = true
 futures = "0.3"
 generated_types = { path = "../generated_types" }
 iox_catalog = { path = "../iox_catalog" }
-object_store = "0.5.6"
+object_store = { workspace = true }
 observability_deps = { path = "../observability_deps" }
 parquet_file = { path = "../parquet_file" }
 tonic = { workspace = true }


### PR DESCRIPTION
# Rationale
I really wanted a single place to change the `object_store` dependency specification the other and it was annoying to have to find it in a bunch of crates

# Changes
Make `object_store` a workspace dependency