### PR TITLE
refactor: explicit submod for partition_template

### DIFF
--- a/data_types/src/lib.rs
+++ b/data_types/src/lib.rs
@@ -24,8 +24,8 @@ mod columns;
 pub use columns::*;
 mod namespace_name;
 pub use namespace_name::*;
-mod partition_template;
-pub use partition_template::*;
+pub mod partition_template;
+use partition_template::*;
 
 use observability_deps::tracing::warn;
 use schema::{sort::SortKey, TIME_COLUMN_NAME};

--- a/ingester_test_ctx/src/lib.rs
+++ b/ingester_test_ctx/src/lib.rs
@@ -22,8 +22,8 @@ use std::{collections::HashMap, sync::Arc, time::Duration};
 use arrow::record_batch::RecordBatch;
 use arrow_flight::{decode::FlightRecordBatchStream, flight_service_server::FlightService, Ticket};
 use data_types::{
-    Namespace, NamespaceId, NamespaceSchema, ParquetFile, PartitionKey, SequenceNumber, TableId,
-    TablePartitionTemplateOverride,
+    partition_template::TablePartitionTemplateOverride, Namespace, NamespaceId, NamespaceSchema,
+    ParquetFile, PartitionKey, SequenceNumber, TableId,
 };
 use dml::{DmlMeta, DmlWrite};
 use futures::{stream::FuturesUnordered, FutureExt, StreamExt, TryStreamExt};

--- a/iox_catalog/src/interface.rs
+++ b/iox_catalog/src/interface.rs
@@ -2,10 +2,10 @@
 
 use async_trait::async_trait;
 use data_types::{
+    partition_template::{NamespacePartitionTemplateOverride, TablePartitionTemplateOverride},
     Column, ColumnType, ColumnsByName, CompactionLevel, Namespace, NamespaceId, NamespaceName,
-    NamespacePartitionTemplateOverride, NamespaceSchema, ParquetFile, ParquetFileId,
-    ParquetFileParams, Partition, PartitionId, PartitionKey, SkippedCompaction, Table, TableId,
-    TablePartitionTemplateOverride, TableSchema, Timestamp,
+    NamespaceSchema, ParquetFile, ParquetFileId, ParquetFileParams, Partition, PartitionId,
+    PartitionKey, SkippedCompaction, Table, TableId, TableSchema, Timestamp,
 };
 use iox_time::TimeProvider;
 use snafu::{OptionExt, Snafu};

--- a/iox_catalog/src/lib.rs
+++ b/iox_catalog/src/lib.rs
@@ -20,8 +20,8 @@ use workspace_hack as _;
 
 use crate::interface::{ColumnTypeMismatchSnafu, Error, RepoCollection, Result};
 use data_types::{
-    ColumnType, NamespaceId, NamespacePartitionTemplateOverride, NamespaceSchema,
-    TablePartitionTemplateOverride, TableSchema,
+    partition_template::{NamespacePartitionTemplateOverride, TablePartitionTemplateOverride},
+    ColumnType, NamespaceId, NamespaceSchema, TableSchema,
 };
 use mutable_batch::MutableBatch;
 use std::{borrow::Cow, collections::HashMap};
@@ -264,7 +264,9 @@ where
 /// Catalog helper functions for creation of catalog objects
 pub mod test_helpers {
     use crate::RepoCollection;
-    use data_types::{Namespace, NamespaceName, Table, TablePartitionTemplateOverride};
+    use data_types::{
+        partition_template::TablePartitionTemplateOverride, Namespace, NamespaceName, Table,
+    };
 
     /// When the details of the namespace don't matter; the test just needs *a* catalog namespace
     /// with a particular name.

--- a/iox_catalog/src/mem.rs
+++ b/iox_catalog/src/mem.rs
@@ -12,10 +12,10 @@ use crate::{
 };
 use async_trait::async_trait;
 use data_types::{
+    partition_template::{NamespacePartitionTemplateOverride, TablePartitionTemplateOverride},
     Column, ColumnId, ColumnType, CompactionLevel, Namespace, NamespaceId, NamespaceName,
-    NamespacePartitionTemplateOverride, ParquetFile, ParquetFileId, ParquetFileParams, Partition,
-    PartitionId, PartitionKey, SkippedCompaction, Table, TableId, TablePartitionTemplateOverride,
-    Timestamp,
+    ParquetFile, ParquetFileId, ParquetFileParams, Partition, PartitionId, PartitionKey,
+    SkippedCompaction, Table, TableId, Timestamp,
 };
 use iox_time::{SystemProvider, TimeProvider};
 use snafu::ensure;

--- a/iox_catalog/src/metrics.rs
+++ b/iox_catalog/src/metrics.rs
@@ -6,10 +6,10 @@ use crate::interface::{
 };
 use async_trait::async_trait;
 use data_types::{
-    Column, ColumnType, CompactionLevel, Namespace, NamespaceId, NamespaceName,
-    NamespacePartitionTemplateOverride, ParquetFile, ParquetFileId, ParquetFileParams, Partition,
-    PartitionId, PartitionKey, SkippedCompaction, Table, TableId, TablePartitionTemplateOverride,
-    Timestamp,
+    partition_template::{NamespacePartitionTemplateOverride, TablePartitionTemplateOverride},
+    Column, ColumnType, CompactionLevel, Namespace, NamespaceId, NamespaceName, ParquetFile,
+    ParquetFileId, ParquetFileParams, Partition, PartitionId, PartitionKey, SkippedCompaction,
+    Table, TableId, Timestamp,
 };
 use iox_time::{SystemProvider, TimeProvider};
 use metric::{DurationHistogram, Metric};

--- a/iox_catalog/src/postgres.rs
+++ b/iox_catalog/src/postgres.rs
@@ -15,10 +15,10 @@ use crate::{
 };
 use async_trait::async_trait;
 use data_types::{
-    Column, ColumnType, CompactionLevel, Namespace, NamespaceId, NamespaceName,
-    NamespacePartitionTemplateOverride, ParquetFile, ParquetFileId, ParquetFileParams, Partition,
-    PartitionId, PartitionKey, SkippedCompaction, Table, TableId, TablePartitionTemplateOverride,
-    Timestamp,
+    partition_template::{NamespacePartitionTemplateOverride, TablePartitionTemplateOverride},
+    Column, ColumnType, CompactionLevel, Namespace, NamespaceId, NamespaceName, ParquetFile,
+    ParquetFileId, ParquetFileParams, Partition, PartitionId, PartitionKey, SkippedCompaction,
+    Table, TableId, Timestamp,
 };
 use iox_time::{SystemProvider, TimeProvider};
 use observability_deps::tracing::{debug, info, warn};
@@ -1619,7 +1619,7 @@ mod tests {
     use super::*;
     use crate::test_helpers::{arbitrary_namespace, arbitrary_table};
     use assert_matches::assert_matches;
-    use data_types::{ColumnId, ColumnSet, TemplatePart};
+    use data_types::{partition_template::TemplatePart, ColumnId, ColumnSet};
     use generated_types::influxdata::iox::partition_template::v1 as proto;
     use metric::{Attributes, DurationHistogram, Metric};
     use rand::Rng;

--- a/iox_catalog/src/sqlite.rs
+++ b/iox_catalog/src/sqlite.rs
@@ -15,10 +15,10 @@ use crate::{
 };
 use async_trait::async_trait;
 use data_types::{
+    partition_template::{NamespacePartitionTemplateOverride, TablePartitionTemplateOverride},
     Column, ColumnId, ColumnSet, ColumnType, CompactionLevel, Namespace, NamespaceId,
-    NamespaceName, NamespacePartitionTemplateOverride, ParquetFile, ParquetFileId,
-    ParquetFileParams, Partition, PartitionId, PartitionKey, SkippedCompaction, Table, TableId,
-    TablePartitionTemplateOverride, Timestamp,
+    NamespaceName, ParquetFile, ParquetFileId, ParquetFileParams, Partition, PartitionId,
+    PartitionKey, SkippedCompaction, Table, TableId, Timestamp,
 };
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
@@ -1491,7 +1491,7 @@ mod tests {
     use super::*;
     use crate::test_helpers::{arbitrary_namespace, arbitrary_table};
     use assert_matches::assert_matches;
-    use data_types::TemplatePart;
+    use data_types::partition_template::TemplatePart;
     use generated_types::influxdata::iox::partition_template::v1 as proto;
     use metric::{Attributes, DurationHistogram, Metric};
     use std::sync::Arc;

--- a/mutable_batch/src/payload.rs
+++ b/mutable_batch/src/payload.rs
@@ -1,7 +1,7 @@
 //! Write payload abstractions derived from [`MutableBatch`]
 
 use crate::{column::ColumnData, MutableBatch, Result};
-use data_types::{PartitionKey, TablePartitionTemplateOverride};
+use data_types::{partition_template::TablePartitionTemplateOverride, PartitionKey};
 use hashbrown::HashMap;
 use schema::TIME_COLUMN_NAME;
 use std::{num::NonZeroUsize, ops::Range};

--- a/mutable_batch/src/payload/partition.rs
+++ b/mutable_batch/src/payload/partition.rs
@@ -7,7 +7,7 @@ use crate::{
     MutableBatch,
 };
 use chrono::{format::StrftimeItems, TimeZone, Utc};
-use data_types::{TablePartitionTemplateOverride, TemplatePart};
+use data_types::partition_template::{TablePartitionTemplateOverride, TemplatePart};
 use schema::{InfluxColumnType, TIME_COLUMN_NAME};
 use std::ops::Range;
 

--- a/mutable_batch/tests/writer_fuzz.rs
+++ b/mutable_batch/tests/writer_fuzz.rs
@@ -14,7 +14,10 @@ use arrow::{
     record_batch::RecordBatch,
 };
 use arrow_util::bitset::BitSet;
-use data_types::{test_table_partition_override, IsNan, StatValues, Statistics, TemplatePart};
+use data_types::{
+    partition_template::{test_table_partition_override, TemplatePart},
+    IsNan, StatValues, Statistics,
+};
 use hashbrown::HashSet;
 use mutable_batch::{writer::Writer, MutableBatch, PartitionWrite, WritePayload};
 use rand::prelude::*;

--- a/router/src/dml_handlers/partitioner.rs
+++ b/router/src/dml_handlers/partitioner.rs
@@ -1,6 +1,7 @@
 use async_trait::async_trait;
 use data_types::{
-    NamespaceName, NamespaceSchema, PartitionKey, TableId, TablePartitionTemplateOverride,
+    partition_template::TablePartitionTemplateOverride, NamespaceName, NamespaceSchema,
+    PartitionKey, TableId,
 };
 use hashbrown::HashMap;
 use mutable_batch::{MutableBatch, PartitionWrite, WritePayload};
@@ -99,7 +100,10 @@ impl DmlHandler for Partitioner {
 #[cfg(test)]
 mod tests {
     use assert_matches::assert_matches;
-    use data_types::{test_table_partition_override, NamespaceId, TemplatePart};
+    use data_types::{
+        partition_template::{test_table_partition_override, TemplatePart},
+        NamespaceId,
+    };
 
     use super::*;
 

--- a/router/src/dml_handlers/schema_validation.rs
+++ b/router/src/dml_handlers/schema_validation.rs
@@ -1,7 +1,9 @@
 use std::{ops::DerefMut, sync::Arc};
 
 use async_trait::async_trait;
-use data_types::{NamespaceName, NamespaceSchema, TableId, TablePartitionTemplateOverride};
+use data_types::{
+    partition_template::TablePartitionTemplateOverride, NamespaceName, NamespaceSchema, TableId,
+};
 use hashbrown::HashMap;
 use iox_catalog::{
     interface::{Catalog, Error as CatalogError},

--- a/service_grpc_namespace/src/lib.rs
+++ b/service_grpc_namespace/src/lib.rs
@@ -19,7 +19,8 @@ use workspace_hack as _;
 use std::sync::Arc;
 
 use data_types::{
-    Namespace as CatalogNamespace, NamespaceName, NamespacePartitionTemplateOverride,
+    partition_template::NamespacePartitionTemplateOverride, Namespace as CatalogNamespace,
+    NamespaceName,
 };
 use generated_types::influxdata::iox::namespace::v1::{
     update_namespace_service_protection_limit_request::LimitUpdate, *,

--- a/service_grpc_table/src/lib.rs
+++ b/service_grpc_table/src/lib.rs
@@ -25,7 +25,8 @@ use workspace_hack as _;
 use std::sync::Arc;
 
 use data_types::{
-    ColumnType, NamespaceName, Table as CatalogTable, TablePartitionTemplateOverride, TemplatePart,
+    partition_template::{TablePartitionTemplateOverride, TemplatePart},
+    ColumnType, NamespaceName, Table as CatalogTable,
 };
 use generated_types::influxdata::iox::table::v1::*;
 use iox_catalog::interface::{Catalog, SoftDeletedRows};
@@ -159,7 +160,7 @@ fn table_to_create_response_proto(table: CatalogTable) -> CreateTableResponse {
 
 #[cfg(test)]
 mod tests {
-    use data_types::{NamespacePartitionTemplateOverride, TableId};
+    use data_types::{partition_template::NamespacePartitionTemplateOverride, TableId};
     use generated_types::influxdata::iox::{
         partition_template::v1::{template_part, PartitionTemplate, TemplatePart},
         table::v1::table_service_server::TableService as _,


### PR DESCRIPTION
I'll be linking to the module directly later, so it needs to be visible outside the crate.

---

* refactor: explicit submod for partition_template (9e0570f2b)
      
      Move the import into the submodule itself, rather than re-exporting it
      at the crate level.
      
      This will make it possible to link to the specific module/logic.