### PR TITLE
fix(iox, gc): delete files from table based on file age

### DIFF
--- a/iox_catalog/src/mem.rs
+++ b/iox_catalog/src/mem.rs
@@ -787,9 +787,11 @@ impl ParquetFileRepo for MemTxn {
     async fn delete_old_ids_only(&mut self, older_than: Timestamp) -> Result<Vec<ParquetFileId>> {
         let stage = self.stage();
 
-        let (delete, keep): (Vec<_>, Vec<_>) = stage.parquet_files.iter().cloned().partition(
-            |f| matches!(f.to_delete, Some(marked_deleted) if marked_deleted < older_than),
-        );
+        let (delete, keep): (Vec<_>, Vec<_>) = stage
+            .parquet_files
+            .iter()
+            .cloned()
+            .partition(|f| matches!(f.to_delete, Some(_) if f.created_at < older_than));
 
         stage.parquet_files = keep;
 

--- a/iox_catalog/src/postgres.rs
+++ b/iox_catalog/src/postgres.rs
@@ -1369,7 +1369,8 @@ WHERE table_id = $1 AND to_delete IS NULL;
 WITH parquet_file_ids as (
     SELECT id
     FROM parquet_file
-    WHERE to_delete < $1
+    WHERE to_delete IS NOT NULL
+    AND created_at < $1
     LIMIT $2
 )
 DELETE FROM parquet_file
@@ -2106,7 +2107,7 @@ mod tests {
     );
 
     #[tokio::test]
-    async fn test_billing_summary_on_parqet_file_creation() {
+    async fn test_billing_summary_on_parquet_file_creation() {
         maybe_skip_integration!();
 
         let postgres = setup_db().await;

--- a/iox_catalog/src/sqlite.rs
+++ b/iox_catalog/src/sqlite.rs
@@ -1227,7 +1227,8 @@ WHERE table_id = $1 AND to_delete IS NULL;
 WITH parquet_file_ids as (
     SELECT id
     FROM parquet_file
-    WHERE to_delete < $1
+    WHERE to_delete IS NOT NULL
+    AND created_at < $1
     LIMIT $2
 )
 DELETE FROM parquet_file


### PR DESCRIPTION
This PR proposes to have the parquet file garbage collector remove files from the parquet_file table based on the to_delete column being non-null and the file's create time being older than the soft delete cutoff.

Because to_delete is filled with the timestamp of when the garbage collector (or compaction) marked the file as soft deleted, it is subject to the availability of the garbage collector running. If the GC is unavailable for a significant amount of time (approaching a day or more), the parquet files will have a to_delete timestamp of when the GC begins running again (or catches up if it is behind). This further delays removing files from the parquet table if only to_delete is used.

We know that if to_delete is not null, the file is soft deleted. We know that the created_at time is immutable so we can use the combination to determine that a file is available to be deleted from the table.

* helps with influxdata/idpe#17708

Closes #

Describe your proposed changes here.

- [ ] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb_iox/blob/main/README.md).
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
