### PR TITLE
perf: pre-allocate partition key string buffer

### DIFF
--- a/router/tests/grpc.rs
+++ b/router/tests/grpc.rs
@@ -973,7 +973,7 @@ async fn test_invalid_strftime_partition_template() {
     assert_matches!(
         got,
         Err(Error::DmlHandler(DmlError::Partition(
-            PartitionError::Partitioner(PartitionKeyError::InvalidStrftime(_))
+            PartitionError::Partitioner(PartitionKeyError::InvalidStrftime)
         )))
     );
 


### PR DESCRIPTION
This is a very simple optimisation that nets up to ~18% partitioner throughput increase by reducing the number of times the partition key buffer string must be grown, therefore eliminating preventable allocations.

In the common case (using a default partitioning template of YYYY-MM-DD) every partition key is of identical length, so this reduces the number of allocations needed for the string buffer to 1 per row.

More optimisations to come!

---

* refactor: remove InvalidStrftime value (8e61dc5ae)
      
      It's big, it's annoying, it's already available to the user.

* perf: preallocate partition key strings (ea3dcba30)
      
      Partition keys tend to be approximately the same size each time (and in
      the default case, always exactly the same size).
      
      This simple change reduces allocations by pre-sizing the next partition
      key string to match that of the previous. This should reduce the number
      of allocations needed to grow the string for ~10% throughput increase.