### PR TITLE
feat: Validate custom partition templates on their creation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1373,6 +1373,7 @@ name = "data_types"
 version = "0.1.0"
 dependencies = [
  "assert_matches",
+ "chrono",
  "croaring",
  "generated_types",
  "influxdb-line-protocol",
@@ -1385,6 +1386,7 @@ dependencies = [
  "proptest",
  "schema",
  "sqlx",
+ "test_helpers",
  "thiserror",
  "uuid 1.3.3",
  "workspace-hack",

--- a/data_types/Cargo.toml
+++ b/data_types/Cargo.toml
@@ -7,6 +7,7 @@ edition.workspace = true
 license.workspace = true
 
 [dependencies]
+chrono = { version = "0.4", default-features = false }
 croaring = "0.8.1"
 influxdb-line-protocol = { path = "../influxdb_line_protocol" }
 iox_time = { path = "../iox_time" }
@@ -25,3 +26,4 @@ percent-encoding = "2.2.0"
 assert_matches = "1"
 paste = "1.0.12"
 proptest = "1.2.0"
+test_helpers = { path = "../test_helpers" }

--- a/ingester_test_ctx/src/lib.rs
+++ b/ingester_test_ctx/src/lib.rs
@@ -252,7 +252,7 @@ where
             .get_mut(&namespace_id)
             .expect("namespace does not exist");
         let partition_template =
-            TablePartitionTemplateOverride::new(None, &schema.partition_template);
+            TablePartitionTemplateOverride::try_new(None, &schema.partition_template).unwrap();
 
         let batches = lines_to_batches(lp, 0).unwrap();
 

--- a/iox_catalog/src/interface.rs
+++ b/iox_catalog/src/interface.rs
@@ -146,11 +146,6 @@ pub enum Error {
 
     #[snafu(display("could not delete namespace: {source}"))]
     CouldNotDeleteNamespace { source: sqlx::Error },
-
-    #[snafu(display("invalid partition template: {source}"))]
-    InvalidPartitionTemplate {
-        source: data_types::partition_template::ValidationError,
-    },
 }
 
 /// A specialized `Error` for Catalog errors

--- a/iox_catalog/src/lib.rs
+++ b/iox_catalog/src/lib.rs
@@ -228,7 +228,8 @@ where
                     // This table is being created implicitly by this write, so there's no
                     // possibility of a user-supplied partition template here, which is why there's
                     // a hardcoded `None`.
-                    TablePartitionTemplateOverride::new(None, namespace_partition_template),
+                    TablePartitionTemplateOverride::try_new(None, namespace_partition_template)
+                        .map_err(|source| Error::InvalidPartitionTemplate { source })?,
                     namespace_id,
                 )
                 .await;
@@ -311,7 +312,8 @@ pub mod test_helpers {
             .tables()
             .create(
                 name,
-                TablePartitionTemplateOverride::new(None, &namespace.partition_template),
+                TablePartitionTemplateOverride::try_new(None, &namespace.partition_template)
+                    .unwrap(),
                 namespace.id,
             )
             .await

--- a/iox_catalog/src/lib.rs
+++ b/iox_catalog/src/lib.rs
@@ -227,9 +227,10 @@ where
                     table_name,
                     // This table is being created implicitly by this write, so there's no
                     // possibility of a user-supplied partition template here, which is why there's
-                    // a hardcoded `None`.
+                    // a hardcoded `None`. If there is a namespace template, it must be valid because
+                    // validity was checked during its creation, so that's why there's an `expect`.
                     TablePartitionTemplateOverride::try_new(None, namespace_partition_template)
-                        .map_err(|source| Error::InvalidPartitionTemplate { source })?,
+                        .expect("no table partition template; namespace partition template has been validated"),
                     namespace_id,
                 )
                 .await;

--- a/iox_catalog/src/postgres.rs
+++ b/iox_catalog/src/postgres.rs
@@ -2311,13 +2311,14 @@ RETURNING id, name, retention_period_ns, max_tables, max_columns_per_table, dele
         // assume it's important that it's being specially requested and store it rather than NULL.
         let namespace_custom_template_name = "kumquats";
         let custom_partition_template_equal_to_default =
-            NamespacePartitionTemplateOverride::from(proto::PartitionTemplate {
+            NamespacePartitionTemplateOverride::try_from(proto::PartitionTemplate {
                 parts: vec![proto::TemplatePart {
                     part: Some(proto::template_part::Part::TimeFormat(
                         "%Y-%m-%d".to_owned(),
                     )),
                 }],
-            });
+            })
+            .unwrap();
         let namespace_custom_template = repos
             .namespaces()
             .create(
@@ -2371,13 +2372,14 @@ RETURNING id, name, retention_period_ns, max_tables, max_columns_per_table, dele
             .namespaces()
             .create(
                 &namespace_custom_template_name.try_into().unwrap(),
-                Some(NamespacePartitionTemplateOverride::from(
-                    proto::PartitionTemplate {
+                Some(
+                    NamespacePartitionTemplateOverride::try_from(proto::PartitionTemplate {
                         parts: vec![proto::TemplatePart {
                             part: Some(proto::template_part::Part::TimeFormat("year-%Y".into())),
                         }],
-                    },
-                )),
+                    })
+                    .unwrap(),
+                ),
                 None,
             )
             .await
@@ -2474,10 +2476,11 @@ RETURNING *;
             .tables()
             .create(
                 "pomelo",
-                TablePartitionTemplateOverride::new(
+                TablePartitionTemplateOverride::try_new(
                     None, // no custom partition template
                     &namespace_custom_template.partition_template,
-                ),
+                )
+                .unwrap(),
                 namespace_custom_template.id,
             )
             .await
@@ -2486,10 +2489,11 @@ RETURNING *;
         // it should have the namespace's template
         assert_eq!(
             table_no_template_with_namespace_template.partition_template,
-            TablePartitionTemplateOverride::new(
+            TablePartitionTemplateOverride::try_new(
                 None,
                 &namespace_custom_template.partition_template
             )
+            .unwrap()
         );
 
         // and store that value in the database record.
@@ -2504,10 +2508,11 @@ RETURNING *;
             record.try_get("partition_template").unwrap();
         assert_eq!(
             partition_template.unwrap(),
-            TablePartitionTemplateOverride::new(
+            TablePartitionTemplateOverride::try_new(
                 None,
                 &namespace_custom_template.partition_template
             )
+            .unwrap()
         );
 
         // # Table template true, namespace template false
@@ -2523,10 +2528,11 @@ RETURNING *;
             .tables()
             .create(
                 "tangerine",
-                TablePartitionTemplateOverride::new(
+                TablePartitionTemplateOverride::try_new(
                     Some(custom_table_template), // with custom partition template
                     &namespace_default_template.partition_template,
-                ),
+                )
+                .unwrap(),
                 namespace_default_template.id,
             )
             .await
@@ -2575,10 +2581,11 @@ RETURNING *;
             .tables()
             .create(
                 "nectarine",
-                TablePartitionTemplateOverride::new(
+                TablePartitionTemplateOverride::try_new(
                     Some(custom_table_template), // with custom partition template
                     &namespace_custom_template.partition_template,
-                ),
+                )
+                .unwrap(),
                 namespace_custom_template.id,
             )
             .await
@@ -2622,10 +2629,11 @@ RETURNING *;
             .tables()
             .create(
                 "grapefruit",
-                TablePartitionTemplateOverride::new(
+                TablePartitionTemplateOverride::try_new(
                     None, // no custom partition template
                     &namespace_default_template.partition_template,
-                ),
+                )
+                .unwrap(),
                 namespace_default_template.id,
             )
             .await

--- a/iox_catalog/src/sqlite.rs
+++ b/iox_catalog/src/sqlite.rs
@@ -1915,13 +1915,14 @@ RETURNING id, name, retention_period_ns, max_tables, max_columns_per_table, dele
         // assume it's important that it's being specially requested and store it rather than NULL.
         let namespace_custom_template_name = "kumquats";
         let custom_partition_template_equal_to_default =
-            NamespacePartitionTemplateOverride::from(proto::PartitionTemplate {
+            NamespacePartitionTemplateOverride::try_from(proto::PartitionTemplate {
                 parts: vec![proto::TemplatePart {
                     part: Some(proto::template_part::Part::TimeFormat(
                         "%Y-%m-%d".to_owned(),
                     )),
                 }],
-            });
+            })
+            .unwrap();
         let namespace_custom_template = repos
             .namespaces()
             .create(
@@ -1973,13 +1974,14 @@ RETURNING id, name, retention_period_ns, max_tables, max_columns_per_table, dele
             .namespaces()
             .create(
                 &namespace_custom_template_name.try_into().unwrap(),
-                Some(NamespacePartitionTemplateOverride::from(
-                    proto::PartitionTemplate {
+                Some(
+                    NamespacePartitionTemplateOverride::try_from(proto::PartitionTemplate {
                         parts: vec![proto::TemplatePart {
                             part: Some(proto::template_part::Part::TimeFormat("year-%Y".into())),
                         }],
-                    },
-                )),
+                    })
+                    .unwrap(),
+                ),
                 None,
             )
             .await
@@ -2076,10 +2078,11 @@ RETURNING *;
             .tables()
             .create(
                 "pomelo",
-                TablePartitionTemplateOverride::new(
+                TablePartitionTemplateOverride::try_new(
                     None, // no custom partition template
                     &namespace_custom_template.partition_template,
-                ),
+                )
+                .unwrap(),
                 namespace_custom_template.id,
             )
             .await
@@ -2088,10 +2091,11 @@ RETURNING *;
         // it should have the namespace's template
         assert_eq!(
             table_no_template_with_namespace_template.partition_template,
-            TablePartitionTemplateOverride::new(
+            TablePartitionTemplateOverride::try_new(
                 None,
                 &namespace_custom_template.partition_template
             )
+            .unwrap()
         );
 
         // and store that value in the database record.
@@ -2106,10 +2110,11 @@ RETURNING *;
             record.try_get("partition_template").unwrap();
         assert_eq!(
             partition_template.unwrap(),
-            TablePartitionTemplateOverride::new(
+            TablePartitionTemplateOverride::try_new(
                 None,
                 &namespace_custom_template.partition_template
             )
+            .unwrap()
         );
 
         // # Table template true, namespace template false
@@ -2125,10 +2130,11 @@ RETURNING *;
             .tables()
             .create(
                 "tangerine",
-                TablePartitionTemplateOverride::new(
+                TablePartitionTemplateOverride::try_new(
                     Some(custom_table_template), // with custom partition template
                     &namespace_default_template.partition_template,
-                ),
+                )
+                .unwrap(),
                 namespace_default_template.id,
             )
             .await
@@ -2177,10 +2183,11 @@ RETURNING *;
             .tables()
             .create(
                 "nectarine",
-                TablePartitionTemplateOverride::new(
+                TablePartitionTemplateOverride::try_new(
                     Some(custom_table_template), // with custom partition template
                     &namespace_custom_template.partition_template,
-                ),
+                )
+                .unwrap(),
                 namespace_custom_template.id,
             )
             .await
@@ -2224,10 +2231,11 @@ RETURNING *;
             .tables()
             .create(
                 "grapefruit",
-                TablePartitionTemplateOverride::new(
+                TablePartitionTemplateOverride::try_new(
                     None, // no custom partition template
                     &namespace_default_template.partition_template,
-                ),
+                )
+                .unwrap(),
                 namespace_default_template.id,
             )
             .await

--- a/mutable_batch/src/payload/partition.rs
+++ b/mutable_batch/src/payload/partition.rs
@@ -231,7 +231,8 @@ mod tests {
             .unwrap();
         writer.commit();
 
-        let template_parts = TablePartitionTemplateOverride::new(None, &Default::default());
+        let template_parts =
+            TablePartitionTemplateOverride::try_new(None, &Default::default()).unwrap();
         let keys: Vec<_> = partition_keys(&batch, template_parts.parts())
             .collect::<Result<Vec<_>, _>>()
             .unwrap();

--- a/mutable_batch/src/payload/partition.rs
+++ b/mutable_batch/src/payload/partition.rs
@@ -509,7 +509,7 @@ mod tests {
         /// [`TEST_TEMPLATE_PARTS`].
         fn arbitrary_template_parts()(set in proptest::collection::vec(
                 proptest::sample::select(TEST_TEMPLATE_PARTS),
-                (0, 12) // Set size range
+                (1, 12) // Set size range
             )) -> Vec<TemplatePart<'static>> {
             let mut set = set;
             set.dedup_by(|a, b| format!("{a:?}") == format!("{b:?}"));
@@ -536,7 +536,10 @@ mod tests {
         /// [`TEST_TEMPLATE_PARTS`], can be reversed to the full set of tags via
         /// [`build_column_values()`].
         #[test]
-        fn prop_reversible_mapping(template in arbitrary_template_parts(), tag_values in arbitrary_tag_value_map()) {
+        fn prop_reversible_mapping(
+            template in arbitrary_template_parts(),
+            tag_values in arbitrary_tag_value_map()
+        ) {
             let mut batch = MutableBatch::new();
             let mut writer = Writer::new(&mut batch, 1);
 

--- a/router/benches/partitioner.rs
+++ b/router/benches/partitioner.rs
@@ -157,9 +157,11 @@ fn bench(
     // Un-normalise the path, adjusting back to the crate root.
     let file_path = format!("{}/../{}", env!("CARGO_MANIFEST_DIR"), file_path);
     let path = Path::new(&file_path);
-    let partition_template = NamespacePartitionTemplateOverride::from(proto::PartitionTemplate {
-        parts: partition_template,
-    });
+    let partition_template =
+        NamespacePartitionTemplateOverride::try_from(proto::PartitionTemplate {
+            parts: partition_template,
+        })
+        .unwrap();
 
     let schema = Arc::new(NamespaceSchema {
         id: NamespaceId::new(42),
@@ -187,7 +189,7 @@ fn bench(
                 TableId::new(i as _),
                 (
                     name,
-                    TablePartitionTemplateOverride::new(None, &partition_template),
+                    TablePartitionTemplateOverride::try_new(None, &partition_template).unwrap(),
                     payload,
                 ),
             )

--- a/service_grpc_namespace/src/lib.rs
+++ b/service_grpc_namespace/src/lib.rs
@@ -89,7 +89,10 @@ impl namespace_service_server::NamespaceService for NamespaceService {
             .namespaces()
             .create(
                 &namespace_name,
-                partition_template.map(NamespacePartitionTemplateOverride::from),
+                partition_template
+                    .map(NamespacePartitionTemplateOverride::try_from)
+                    .transpose()
+                    .map_err(|v| Status::invalid_argument(v.to_string()))?,
                 retention_period_ns,
             )
             .await

--- a/service_grpc_namespace/src/lib.rs
+++ b/service_grpc_namespace/src/lib.rs
@@ -309,7 +309,10 @@ mod tests {
     use std::time::Duration;
 
     use assert_matches::assert_matches;
-    use generated_types::influxdata::iox::namespace::v1::namespace_service_server::NamespaceService as _;
+    use generated_types::influxdata::iox::{
+        namespace::v1::namespace_service_server::NamespaceService as _,
+        partition_template::v1::PartitionTemplate,
+    };
     use iox_catalog::mem::MemCatalog;
     use tonic::Code;
 
@@ -538,6 +541,39 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(all_namespaces.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn invalid_custom_namespace_template_returns_error() {
+        let catalog: Arc<dyn Catalog> =
+            Arc::new(MemCatalog::new(Arc::new(metric::Registry::default())));
+        let handler = NamespaceService::new(Arc::clone(&catalog));
+
+        let req = CreateNamespaceRequest {
+            name: NS_NAME.to_string(),
+            retention_period_ns: None,
+            partition_template: Some(PartitionTemplate { parts: vec![] }),
+        };
+
+        let error = handler
+            .create_namespace(Request::new(req))
+            .await
+            .unwrap_err();
+
+        assert_eq!(error.code(), Code::InvalidArgument);
+        assert_eq!(
+            error.message(),
+            "Custom partition template must have at least one part"
+        );
+
+        let all_namespaces = catalog
+            .repositories()
+            .await
+            .namespaces()
+            .list(SoftDeletedRows::ExcludeDeleted)
+            .await
+            .unwrap();
+        assert_eq!(all_namespaces.len(), 0);
     }
 
     #[tokio::test]

--- a/service_grpc_table/src/lib.rs
+++ b/service_grpc_table/src/lib.rs
@@ -81,10 +81,11 @@ impl table_service_server::TableService for TableService {
             .tables()
             .create(
                 &name,
-                TablePartitionTemplateOverride::new(
+                TablePartitionTemplateOverride::try_new(
                     partition_template,
                     &namespace.partition_template,
-                ),
+                )
+                .map_err(|v| Status::invalid_argument(v.to_string()))?,
                 namespace.id,
             )
             .await
@@ -312,8 +313,8 @@ mod tests {
             .namespaces()
             .create(
                 &namespace_name,
-                Some(NamespacePartitionTemplateOverride::from(
-                    PartitionTemplate {
+                Some(
+                    NamespacePartitionTemplateOverride::try_from(PartitionTemplate {
                         parts: vec![
                             TemplatePart {
                                 part: Some(template_part::Part::TagValue("color".into())),
@@ -325,8 +326,9 @@ mod tests {
                                 part: Some(template_part::Part::TimeFormat("%Y".into())),
                             },
                         ],
-                    },
-                )),
+                    })
+                    .unwrap(),
+                ),
                 None,
             )
             .await


### PR DESCRIPTION
Fixes #7895.

On creation of custom partition templates, they are checked that they have:

- At least one part
- No more than 8 parts
- Only nonempty, valid strftime formats