### PR TITLE
fix: panic when using %#z time formatter

### DIFF
--- a/mutable_batch/src/payload/partition.rs
+++ b/mutable_batch/src/payload/partition.rs
@@ -587,6 +587,18 @@ mod tests {
             let mut batch = MutableBatch::new();
             let mut writer = Writer::new(&mut batch, 1);
 
+            // This sequence causes chrono's formatter to panic with a "do not
+            // use this" message...
+            //
+            // This is validated to not be part of the formatter (among other
+            // invalid sequences) when constructing a template from the user
+            // input/proto.
+            //
+            // Uniquely this causes a panic, whereas others do not - so it must
+            // be filtered out when fuzz-testing that invalid sequences do not
+            // cause a panic in the key generator.
+            prop_assume!(!fmt.contains("%#z"));
+
             // Generate a single time-based partitioning template with a
             // randomised format string.
             let template = vec![


### PR DESCRIPTION
I don't think we'd ever have known about this (until too late) without proptesting - `%#z` is literally documented as a supported formatting sequence, only it causes a panic when used (at timestamp formatting time / in the write path).

---

* fix: panic when using %#z time formatter (60d3ae403)
      
      Props to proptesting for this one - the prop_arbitrary_strftime_format()
      randomly generated the formatting sequence "%#z" which turns out to be
      an undocumented way of causing a panic in chrono:
      
          https://github.com/chronotope/chrono/blob/088b69372e93e64f144183fb3324cdb079736f8b/src/format/mod.rs#L673
      
      In fact, the docs actually list is as a usable sequence!