### PR TITLE
feat: Start generating PartitionHashIds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1355,6 +1355,7 @@ dependencies = [
  "chrono",
  "croaring",
  "generated_types",
+ "hex",
  "influxdb-line-protocol",
  "iox_time",
  "observability_deps",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1364,6 +1364,7 @@ dependencies = [
  "percent-encoding",
  "proptest",
  "schema",
+ "sha2",
  "sqlx",
  "test_helpers",
  "thiserror",

--- a/arrow_util/src/test_util.rs
+++ b/arrow_util/src/test_util.rs
@@ -199,11 +199,11 @@ pub static REGEX_UUID: Lazy<Regex> = Lazy::new(|| {
 
 /// Match the parquet directory names
 /// For example, given
-/// `51/216/13452/1d325760-2b20-48de-ab48-2267b034133d.parquet`
+/// `51/216/1a3f45021a3f45021a3f45021a3f45021a3f45021a3f45021a3f45021a3f4502/1d325760-2b20-48de-ab48-2267b034133d.parquet`
 ///
-/// matches `51/216/13452/`
+/// matches `51/216/1a3f45021a3f45021a3f45021a3f45021a3f45021a3f45021a3f45021a3f4502`
 static REGEX_DIRS: Lazy<Regex> =
-    Lazy::new(|| Regex::new(r#"[0-9]+/[0-9]+/[0-9]+/"#).expect("directory regex"));
+    Lazy::new(|| Regex::new(r#"[0-9]+/[0-9]+/[0-9a-f]+/"#).expect("directory regex"));
 
 /// Replace table row separators of flexible width with fixed with. This is required
 /// because the original timing values may differ in "printed width", so the table
@@ -315,7 +315,7 @@ impl Normalizer {
                 .into_iter()
                 .map(|s| {
                     // Rewrite Parquet directory names like
-                    // `51/216/13452/1d325760-2b20-48de-ab48-2267b034133d.parquet`
+                    // `51/216/1a3f45021a3f45021a3f45021a3f45021a3f45021a3f45021a3f45021a3f4502/1d325760-2b20-48de-ab48-2267b034133d.parquet`
                     //
                     // to:
                     // 1/1/1/00000000-0000-0000-0000-000000000000.parquet

--- a/compactor/src/components/parquet_file_sink/mock.rs
+++ b/compactor/src/components/parquet_file_sink/mock.rs
@@ -71,6 +71,7 @@ impl ParquetFileSink for MockParquetFileSink {
             namespace_id: partition.namespace_id,
             table_id: partition.table.id,
             partition_id: partition.partition_id,
+            partition_hash_id: partition.partition_hash_id.clone(),
             object_store_id: Uuid::from_u128(guard.len() as u128),
             min_time: Timestamp::new(0),
             max_time: Timestamp::new(0),
@@ -158,6 +159,7 @@ mod tests {
             Arc::clone(&schema),
             futures::stream::once(async move { Ok(record_batch_captured) }),
         ));
+        let partition_hash_id = partition.partition_hash_id.clone();
         assert_eq!(
             sink.store(stream, Arc::clone(&partition), level, max_l0_created_at)
                 .await
@@ -166,6 +168,7 @@ mod tests {
                 namespace_id: NamespaceId::new(2),
                 table_id: TableId::new(3),
                 partition_id: PartitionId::new(1),
+                partition_hash_id,
                 object_store_id: Uuid::from_u128(2),
                 min_time: Timestamp::new(0),
                 max_time: Timestamp::new(0),
@@ -220,6 +223,7 @@ mod tests {
             Arc::clone(&schema),
             futures::stream::empty(),
         ));
+        let partition_hash_id = partition.partition_hash_id.clone();
         assert_eq!(
             sink.store(stream, Arc::clone(&partition), level, max_l0_created_at)
                 .await
@@ -228,6 +232,7 @@ mod tests {
                 namespace_id: NamespaceId::new(2),
                 table_id: TableId::new(3),
                 partition_id: PartitionId::new(1),
+                partition_hash_id,
                 object_store_id: Uuid::from_u128(0),
                 min_time: Timestamp::new(0),
                 max_time: Timestamp::new(0),

--- a/compactor/src/components/parquet_file_sink/object_store.rs
+++ b/compactor/src/components/parquet_file_sink/object_store.rs
@@ -74,7 +74,7 @@ impl ParquetFileSink for ObjectStoreParquetFileSink {
         let pool = Arc::clone(&self.pool);
         let (parquet_meta, file_size) = match self
             .store
-            .upload(stream, partition.transition_partition_id(), &meta, pool)
+            .upload(stream, &partition.transition_partition_id(), &meta, pool)
             .await
         {
             Ok(v) => v,

--- a/compactor/src/components/parquet_file_sink/object_store.rs
+++ b/compactor/src/components/parquet_file_sink/object_store.rs
@@ -74,7 +74,7 @@ impl ParquetFileSink for ObjectStoreParquetFileSink {
         let pool = Arc::clone(&self.pool);
         let (parquet_meta, file_size) = match self
             .store
-            .upload(stream, partition.partition_id, &meta, pool)
+            .upload(stream, partition.transition_partition_id(), &meta, pool)
             .await
         {
             Ok(v) => v,
@@ -91,15 +91,20 @@ impl ParquetFileSink for ObjectStoreParquetFileSink {
             }
         };
 
-        let parquet_file =
-            meta.to_parquet_file(partition.partition_id, file_size, &parquet_meta, |name| {
+        let parquet_file = meta.to_parquet_file(
+            partition.partition_id,
+            partition.partition_hash_id.clone(),
+            file_size,
+            &parquet_meta,
+            |name| {
                 partition
                     .table_schema
                     .columns
                     .get(name)
                     .expect("unknown column")
                     .id
-            });
+            },
+        );
 
         Ok(Some(parquet_file))
     }

--- a/compactor/src/components/partition_info_source/sub_sources.rs
+++ b/compactor/src/components/partition_info_source/sub_sources.rs
@@ -98,6 +98,7 @@ where
 
         Ok(Arc::new(PartitionInfo {
             partition_id,
+            partition_hash_id: partition.hash_id().cloned(),
             namespace_id: table.namespace_id,
             namespace_name: namespace.name,
             table: Arc::new(table),

--- a/compactor/src/components/scratchpad/test_util.rs
+++ b/compactor/src/components/scratchpad/test_util.rs
@@ -1,6 +1,6 @@
 use std::{collections::HashSet, sync::Arc};
 
-use data_types::{NamespaceId, PartitionId, TableId};
+use data_types::{NamespaceId, PartitionId, TableId, TransitionPartitionId};
 use object_store::{memory::InMemory, DynObjectStore};
 use parquet_file::ParquetFilePath;
 use uuid::Uuid;
@@ -23,7 +23,7 @@ pub fn file_path(i: u128) -> ParquetFilePath {
     ParquetFilePath::new(
         NamespaceId::new(1),
         TableId::new(1),
-        PartitionId::new(1),
+        TransitionPartitionId::Deprecated(PartitionId::new(1)),
         Uuid::from_u128(i),
     )
 }

--- a/compactor/src/components/scratchpad/test_util.rs
+++ b/compactor/src/components/scratchpad/test_util.rs
@@ -23,7 +23,7 @@ pub fn file_path(i: u128) -> ParquetFilePath {
     ParquetFilePath::new(
         NamespaceId::new(1),
         TableId::new(1),
-        TransitionPartitionId::Deprecated(PartitionId::new(1)),
+        &TransitionPartitionId::Deprecated(PartitionId::new(1)),
         Uuid::from_u128(i),
     )
 }

--- a/compactor/src/components/scratchpad/util.rs
+++ b/compactor/src/components/scratchpad/util.rs
@@ -13,7 +13,7 @@ pub async fn copy_files(
     backoff_config: &BackoffConfig,
     concurrency: NonZeroUsize,
 ) {
-    futures::stream::iter(files_in.iter().copied().zip(files_out.to_vec()))
+    futures::stream::iter(files_in.iter().cloned().zip(files_out.to_vec()))
         .map(|(f_in, f_out)| {
             let backoff_config = backoff_config.clone();
             let from = Arc::clone(&from);

--- a/compactor/src/test_utils.rs
+++ b/compactor/src/test_utils.rs
@@ -1,8 +1,8 @@
 use std::sync::Arc;
 
 use data_types::{
-    Column, ColumnId, ColumnType, ColumnsByName, NamespaceId, PartitionId, PartitionKey, Table,
-    TableId, TableSchema,
+    Column, ColumnId, ColumnType, ColumnsByName, NamespaceId, PartitionHashId, PartitionId,
+    PartitionKey, Table, TableId, TableSchema,
 };
 
 use crate::PartitionInfo;
@@ -15,8 +15,11 @@ impl PartitionInfoBuilder {
     pub fn new() -> Self {
         let partition_id = PartitionId::new(1);
         let namespace_id = NamespaceId::new(2);
+        let table_id = TableId::new(3);
+        let partition_key = PartitionKey::from("key");
+        let partition_hash_id = Some(PartitionHashId::new(table_id, &partition_key));
         let table = Arc::new(Table {
-            id: TableId::new(3),
+            id: table_id,
             namespace_id,
             name: String::from("table"),
             partition_template: Default::default(),
@@ -26,12 +29,13 @@ impl PartitionInfoBuilder {
         Self {
             inner: PartitionInfo {
                 partition_id,
+                partition_hash_id,
                 namespace_id,
                 namespace_name: String::from("ns"),
                 table,
                 table_schema,
                 sort_key: None,
-                partition_key: PartitionKey::from("key"),
+                partition_key,
             },
         }
     }

--- a/compactor_test_utils/src/lib.rs
+++ b/compactor_test_utils/src/lib.rs
@@ -569,6 +569,7 @@ impl<const WITH_FILES: bool> TestSetupBuilder<WITH_FILES> {
     pub async fn build(self) -> TestSetup {
         let candidate_partition = Arc::new(PartitionInfo {
             partition_id: self.partition.partition.id,
+            partition_hash_id: self.partition.partition.hash_id().cloned(),
             namespace_id: self.ns.namespace.id,
             namespace_name: self.ns.namespace.name.clone(),
             table: Arc::new(self.table.table.clone()),

--- a/compactor_test_utils/src/simulator.rs
+++ b/compactor_test_utils/src/simulator.rs
@@ -203,6 +203,7 @@ impl SimulatedFile {
             namespace_id: partition_info.namespace_id,
             table_id: partition_info.table.id,
             partition_id: partition_info.partition_id,
+            partition_hash_id: partition_info.partition_hash_id.clone(),
             object_store_id: Uuid::new_v4(),
             min_time,
             max_time,

--- a/data_types/Cargo.toml
+++ b/data_types/Cargo.toml
@@ -28,3 +28,4 @@ assert_matches = "1"
 paste = "1.0.12"
 proptest = { version = "1.2.0", default-features = false }
 test_helpers = { path = "../test_helpers" }
+hex = "0.4.2"

--- a/data_types/Cargo.toml
+++ b/data_types/Cargo.toml
@@ -16,6 +16,7 @@ observability_deps = { path = "../observability_deps" }
 once_cell = "1"
 ordered-float = "3"
 schema = { path = "../schema" }
+sha2 = "0.10"
 sqlx = { version = "0.6", features = ["runtime-tokio-rustls", "postgres", "uuid"] }
 thiserror = "1.0.40"
 uuid = { version = "1", features = ["v4"] }

--- a/data_types/src/lib.rs
+++ b/data_types/src/lib.rs
@@ -24,11 +24,13 @@ mod columns;
 pub use columns::*;
 mod namespace_name;
 pub use namespace_name::*;
+pub mod partition;
+pub use partition::*;
 pub mod partition_template;
 use partition_template::*;
 
 use observability_deps::tracing::warn;
-use schema::{sort::SortKey, TIME_COLUMN_NAME};
+use schema::TIME_COLUMN_NAME;
 use std::{
     borrow::Borrow,
     collections::{BTreeMap, BTreeSet, HashMap},
@@ -37,7 +39,6 @@ use std::{
     mem::{self, size_of_val},
     num::{FpCategory, NonZeroU64},
     ops::{Add, Deref, Sub},
-    sync::Arc,
 };
 use uuid::Uuid;
 
@@ -149,27 +150,6 @@ impl TableId {
 }
 
 impl std::fmt::Display for TableId {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(f, "{}", self.0)
-    }
-}
-
-/// Unique ID for a `Partition`
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, sqlx::Type, sqlx::FromRow)]
-#[sqlx(transparent)]
-pub struct PartitionId(i64);
-
-#[allow(missing_docs)]
-impl PartitionId {
-    pub const fn new(v: i64) -> Self {
-        Self(v)
-    }
-    pub fn get(&self) -> i64 {
-        self.0
-    }
-}
-
-impl std::fmt::Display for PartitionId {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(f, "{}", self.0)
     }
@@ -483,150 +463,6 @@ impl TableSchema {
     /// Return number of columns of the table
     pub fn column_count(&self) -> usize {
         self.columns.column_count()
-    }
-}
-
-/// Defines an partition via an arbitrary string within a table within
-/// a namespace.
-///
-/// Implemented as a reference-counted string, serialisable to
-/// the Postgres VARCHAR data type.
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct PartitionKey(Arc<str>);
-
-impl PartitionKey {
-    /// Returns true if this instance of [`PartitionKey`] is backed by the same
-    /// string storage as other.
-    pub fn ptr_eq(&self, other: &Self) -> bool {
-        Arc::ptr_eq(&self.0, &other.0)
-    }
-
-    /// Returns underlying string.
-    pub fn inner(&self) -> &str {
-        &self.0
-    }
-}
-
-impl Display for PartitionKey {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(&self.0)
-    }
-}
-
-impl From<String> for PartitionKey {
-    fn from(s: String) -> Self {
-        assert!(!s.is_empty());
-        Self(s.into())
-    }
-}
-
-impl From<&str> for PartitionKey {
-    fn from(s: &str) -> Self {
-        assert!(!s.is_empty());
-        Self(s.into())
-    }
-}
-
-impl sqlx::Type<sqlx::Postgres> for PartitionKey {
-    fn type_info() -> sqlx::postgres::PgTypeInfo {
-        // Store this type as VARCHAR
-        sqlx::postgres::PgTypeInfo::with_name("VARCHAR")
-    }
-}
-
-impl sqlx::Encode<'_, sqlx::Postgres> for PartitionKey {
-    fn encode_by_ref(
-        &self,
-        buf: &mut <sqlx::Postgres as sqlx::database::HasArguments<'_>>::ArgumentBuffer,
-    ) -> sqlx::encode::IsNull {
-        <&str as sqlx::Encode<sqlx::Postgres>>::encode(&self.0, buf)
-    }
-}
-
-impl sqlx::Decode<'_, sqlx::Postgres> for PartitionKey {
-    fn decode(
-        value: <sqlx::Postgres as sqlx::database::HasValueRef<'_>>::ValueRef,
-    ) -> Result<Self, Box<dyn std::error::Error + 'static + Send + Sync>> {
-        Ok(Self(
-            <String as sqlx::Decode<sqlx::Postgres>>::decode(value)?.into(),
-        ))
-    }
-}
-
-impl sqlx::Type<sqlx::Sqlite> for PartitionKey {
-    fn type_info() -> sqlx::sqlite::SqliteTypeInfo {
-        <String as sqlx::Type<sqlx::Sqlite>>::type_info()
-    }
-}
-
-impl sqlx::Encode<'_, sqlx::Sqlite> for PartitionKey {
-    fn encode_by_ref(
-        &self,
-        buf: &mut <sqlx::Sqlite as sqlx::database::HasArguments<'_>>::ArgumentBuffer,
-    ) -> sqlx::encode::IsNull {
-        <String as sqlx::Encode<sqlx::Sqlite>>::encode(self.0.to_string(), buf)
-    }
-}
-
-impl sqlx::Decode<'_, sqlx::Sqlite> for PartitionKey {
-    fn decode(
-        value: <sqlx::Sqlite as sqlx::database::HasValueRef<'_>>::ValueRef,
-    ) -> Result<Self, Box<dyn std::error::Error + 'static + Send + Sync>> {
-        Ok(Self(
-            <String as sqlx::Decode<sqlx::Sqlite>>::decode(value)?.into(),
-        ))
-    }
-}
-
-/// Data object for a partition. The combination of table and key are unique (i.e. only one record
-/// can exist for each combo)
-#[derive(Debug, Clone, PartialEq, Eq, sqlx::FromRow)]
-pub struct Partition {
-    /// the id of the partition
-    pub id: PartitionId,
-    /// the table the partition is under
-    pub table_id: TableId,
-    /// the string key of the partition
-    pub partition_key: PartitionKey,
-    /// vector of column names that describes how *every* parquet file
-    /// in this [`Partition`] is sorted. The sort_key contains all the
-    /// primary key (PK) columns that have been persisted, and nothing
-    /// else. The PK columns are all `tag` columns and the `time`
-    /// column.
-    ///
-    /// Even though it is possible for both the unpersisted data
-    /// and/or multiple parquet files to contain different subsets of
-    /// columns, the partition's sort_key is guaranteed to be
-    /// "compatible" across all files. Compatible means that the
-    /// parquet file is sorted in the same order as the partition
-    /// sort_key after removing any missing columns.
-    ///
-    /// Partitions are initially created before any data is persisted
-    /// with an empty sort_key. The partition sort_key is updated as
-    /// needed when data is persisted to parquet files: both on the
-    /// first persist when the sort key is empty, as on subsequent
-    /// persist operations when new tags occur in newly inserted data.
-    ///
-    /// Updating inserts new column into the existing order. The order
-    /// of the existing columns relative to each other is NOT changed.
-    ///
-    /// For example, updating `A,B,C` to either `A,D,B,C` or `A,B,C,D`
-    /// is legal. However, updating to `A,C,D,B` is not because the
-    /// relative order of B and C have been reversed.
-    pub sort_key: Vec<String>,
-
-    /// The time at which the newest file of the partition is created
-    pub new_file_at: Option<Timestamp>,
-}
-
-impl Partition {
-    /// The sort key for the partition, if present, structured as a `SortKey`
-    pub fn sort_key(&self) -> Option<SortKey> {
-        if self.sort_key.is_empty() {
-            return None;
-        }
-
-        Some(SortKey::from_columns(self.sort_key.iter().map(|s| &**s)))
     }
 }
 

--- a/data_types/src/partition.rs
+++ b/data_types/src/partition.rs
@@ -386,6 +386,12 @@ mod tests {
     use super::*;
     use proptest::{prelude::*, proptest};
 
+    /// A fixture test asserting the deterministic partition ID generation
+    /// algorithm outputs a fixed value, preventing accidental changes to the
+    /// derived ID.
+    ///
+    /// This hash byte value MUST NOT change for the lifetime of a cluster
+    /// (though the encoding used in this test can).
     #[test]
     fn display_partition_hash_id_in_hex() {
         let partition_hash_id =

--- a/data_types/src/partition.rs
+++ b/data_types/src/partition.rs
@@ -416,6 +416,15 @@ mod tests {
 
             let partition_hash_id = PartitionHashId::new(table_id, &partition_key);
 
+            // ID generation MUST be deterministic.
+            let partition_hash_id_regenerated = PartitionHashId::new(table_id, &partition_key);
+            assert_eq!(partition_hash_id, partition_hash_id_regenerated);
+
+            // ID generation MUST be collision resistant; different inputs -> different IDs
+            let other_table_id = TableId::new(table_id.get().wrapping_add(1));
+            let different_partition_hash_id = PartitionHashId::new(other_table_id, &partition_key);
+            assert_ne!(partition_hash_id, different_partition_hash_id);
+
             // The bytes of the partition hash ID are stored in the catalog and sent from the
             // ingesters to the queriers. We should be able to round-trip through bytes.
             let bytes_representation = partition_hash_id.as_bytes();

--- a/data_types/src/partition.rs
+++ b/data_types/src/partition.rs
@@ -1,0 +1,171 @@
+//! Types having to do with partitions.
+
+use super::{TableId, Timestamp};
+
+use schema::sort::SortKey;
+use std::{fmt::Display, sync::Arc};
+
+/// Unique ID for a `Partition`
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, sqlx::Type, sqlx::FromRow)]
+#[sqlx(transparent)]
+pub struct PartitionId(i64);
+
+#[allow(missing_docs)]
+impl PartitionId {
+    pub const fn new(v: i64) -> Self {
+        Self(v)
+    }
+    pub fn get(&self) -> i64 {
+        self.0
+    }
+}
+
+impl std::fmt::Display for PartitionId {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+/// Defines an partition via an arbitrary string within a table within
+/// a namespace.
+///
+/// Implemented as a reference-counted string, serialisable to
+/// the Postgres VARCHAR data type.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct PartitionKey(Arc<str>);
+
+impl PartitionKey {
+    /// Returns true if this instance of [`PartitionKey`] is backed by the same
+    /// string storage as other.
+    pub fn ptr_eq(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.0, &other.0)
+    }
+
+    /// Returns underlying string.
+    pub fn inner(&self) -> &str {
+        &self.0
+    }
+}
+
+impl Display for PartitionKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl From<String> for PartitionKey {
+    fn from(s: String) -> Self {
+        assert!(!s.is_empty());
+        Self(s.into())
+    }
+}
+
+impl From<&str> for PartitionKey {
+    fn from(s: &str) -> Self {
+        assert!(!s.is_empty());
+        Self(s.into())
+    }
+}
+
+impl sqlx::Type<sqlx::Postgres> for PartitionKey {
+    fn type_info() -> sqlx::postgres::PgTypeInfo {
+        // Store this type as VARCHAR
+        sqlx::postgres::PgTypeInfo::with_name("VARCHAR")
+    }
+}
+
+impl sqlx::Encode<'_, sqlx::Postgres> for PartitionKey {
+    fn encode_by_ref(
+        &self,
+        buf: &mut <sqlx::Postgres as sqlx::database::HasArguments<'_>>::ArgumentBuffer,
+    ) -> sqlx::encode::IsNull {
+        <&str as sqlx::Encode<sqlx::Postgres>>::encode(&self.0, buf)
+    }
+}
+
+impl sqlx::Decode<'_, sqlx::Postgres> for PartitionKey {
+    fn decode(
+        value: <sqlx::Postgres as sqlx::database::HasValueRef<'_>>::ValueRef,
+    ) -> Result<Self, Box<dyn std::error::Error + 'static + Send + Sync>> {
+        Ok(Self(
+            <String as sqlx::Decode<sqlx::Postgres>>::decode(value)?.into(),
+        ))
+    }
+}
+
+impl sqlx::Type<sqlx::Sqlite> for PartitionKey {
+    fn type_info() -> sqlx::sqlite::SqliteTypeInfo {
+        <String as sqlx::Type<sqlx::Sqlite>>::type_info()
+    }
+}
+
+impl sqlx::Encode<'_, sqlx::Sqlite> for PartitionKey {
+    fn encode_by_ref(
+        &self,
+        buf: &mut <sqlx::Sqlite as sqlx::database::HasArguments<'_>>::ArgumentBuffer,
+    ) -> sqlx::encode::IsNull {
+        <String as sqlx::Encode<sqlx::Sqlite>>::encode(self.0.to_string(), buf)
+    }
+}
+
+impl sqlx::Decode<'_, sqlx::Sqlite> for PartitionKey {
+    fn decode(
+        value: <sqlx::Sqlite as sqlx::database::HasValueRef<'_>>::ValueRef,
+    ) -> Result<Self, Box<dyn std::error::Error + 'static + Send + Sync>> {
+        Ok(Self(
+            <String as sqlx::Decode<sqlx::Sqlite>>::decode(value)?.into(),
+        ))
+    }
+}
+
+/// Data object for a partition. The combination of table and key are unique (i.e. only one record
+/// can exist for each combo)
+#[derive(Debug, Clone, PartialEq, Eq, sqlx::FromRow)]
+pub struct Partition {
+    /// the id of the partition
+    pub id: PartitionId,
+    /// the table the partition is under
+    pub table_id: TableId,
+    /// the string key of the partition
+    pub partition_key: PartitionKey,
+    /// vector of column names that describes how *every* parquet file
+    /// in this [`Partition`] is sorted. The sort_key contains all the
+    /// primary key (PK) columns that have been persisted, and nothing
+    /// else. The PK columns are all `tag` columns and the `time`
+    /// column.
+    ///
+    /// Even though it is possible for both the unpersisted data
+    /// and/or multiple parquet files to contain different subsets of
+    /// columns, the partition's sort_key is guaranteed to be
+    /// "compatible" across all files. Compatible means that the
+    /// parquet file is sorted in the same order as the partition
+    /// sort_key after removing any missing columns.
+    ///
+    /// Partitions are initially created before any data is persisted
+    /// with an empty sort_key. The partition sort_key is updated as
+    /// needed when data is persisted to parquet files: both on the
+    /// first persist when the sort key is empty, as on subsequent
+    /// persist operations when new tags occur in newly inserted data.
+    ///
+    /// Updating inserts new column into the existing order. The order
+    /// of the existing columns relative to each other is NOT changed.
+    ///
+    /// For example, updating `A,B,C` to either `A,D,B,C` or `A,B,C,D`
+    /// is legal. However, updating to `A,C,D,B` is not because the
+    /// relative order of B and C have been reversed.
+    pub sort_key: Vec<String>,
+
+    /// The time at which the newest file of the partition is created
+    pub new_file_at: Option<Timestamp>,
+}
+
+impl Partition {
+    /// The sort key for the partition, if present, structured as a `SortKey`
+    pub fn sort_key(&self) -> Option<SortKey> {
+        if self.sort_key.is_empty() {
+            return None;
+        }
+
+        Some(SortKey::from_columns(self.sort_key.iter().map(|s| &**s)))
+    }
+}

--- a/data_types/src/partition.rs
+++ b/data_types/src/partition.rs
@@ -313,7 +313,9 @@ pub struct Partition {
 impl Partition {
     /// Create a new Partition data object from the given attributes. This constructor will take
     /// care of computing the [`PartitionHashId`].
-    pub fn new(
+    ///
+    /// This is only appropriate to use in the in-memory catalog or in tests.
+    pub fn new_in_memory_only(
         id: PartitionId,
         table_id: TableId,
         partition_key: PartitionKey,
@@ -324,6 +326,30 @@ impl Partition {
         Self {
             id,
             hash_id: Some(hash_id),
+            table_id,
+            partition_key,
+            sort_key,
+            new_file_at,
+        }
+    }
+
+    /// The sqlite catalog has to define a `PartitionPod` type that's slightly different than
+    /// `Partition` because of what sqlite serialization is supported. This function is for
+    /// conversion between the `PartitionPod` type and `Partition` and should not be used anywhere
+    /// else.
+    ///
+    /// The in-memory catalog also creates the `Partition` directly from w
+    pub fn new_with_hash_id_from_sqlite_catalog_only(
+        id: PartitionId,
+        hash_id: Option<PartitionHashId>,
+        table_id: TableId,
+        partition_key: PartitionKey,
+        sort_key: Vec<String>,
+        new_file_at: Option<Timestamp>,
+    ) -> Self {
+        Self {
+            id,
+            hash_id,
             table_id,
             partition_key,
             sort_key,

--- a/garbage_collector/src/objectstore/checker.rs
+++ b/garbage_collector/src/objectstore/checker.rs
@@ -230,7 +230,7 @@ mod tests {
     use chrono::TimeZone;
     use data_types::{
         ColumnId, ColumnSet, CompactionLevel, NamespaceId, ParquetFile, ParquetFileId,
-        ParquetFileParams, PartitionId, TableId, Timestamp,
+        ParquetFileParams, PartitionId, TableId, Timestamp, TransitionPartitionId,
     };
     use iox_catalog::{
         interface::Catalog,
@@ -268,6 +268,7 @@ mod tests {
             namespace_id: namespace.id,
             table_id: partition.table_id,
             partition_id: partition.id,
+            partition_hash_id: partition.hash_id().cloned(),
             object_store_id: Uuid::new_v4(),
             min_time: Timestamp::new(1),
             max_time: Timestamp::new(10),
@@ -297,7 +298,7 @@ mod tests {
         let location = ParquetFilePath::new(
             file_in_catalog.namespace_id,
             file_in_catalog.table_id,
-            file_in_catalog.partition_id,
+            file_in_catalog.transition_partition_id(),
             file_in_catalog.object_store_id,
         )
         .object_store_path();
@@ -326,7 +327,7 @@ mod tests {
         let location = ParquetFilePath::new(
             NamespaceId::new(1),
             TableId::new(2),
-            PartitionId::new(4),
+            TransitionPartitionId::Deprecated(PartitionId::new(4)),
             Uuid::new_v4(),
         )
         .object_store_path();
@@ -375,7 +376,7 @@ mod tests {
         let location = ParquetFilePath::new(
             file_in_catalog.namespace_id,
             file_in_catalog.table_id,
-            file_in_catalog.partition_id,
+            file_in_catalog.transition_partition_id(),
             file_in_catalog.object_store_id,
         )
         .object_store_path();
@@ -404,7 +405,7 @@ mod tests {
         let location = ParquetFilePath::new(
             NamespaceId::new(1),
             TableId::new(2),
-            PartitionId::new(4),
+            TransitionPartitionId::Deprecated(PartitionId::new(4)),
             Uuid::new_v4(),
         )
         .object_store_path();
@@ -468,7 +469,7 @@ mod tests {
         let loc = ParquetFilePath::new(
             file_in_catalog.namespace_id,
             file_in_catalog.table_id,
-            file_in_catalog.partition_id,
+            file_in_catalog.transition_partition_id(),
             file_in_catalog.object_store_id,
         )
         .object_store_path();

--- a/garbage_collector/src/objectstore/checker.rs
+++ b/garbage_collector/src/objectstore/checker.rs
@@ -298,7 +298,7 @@ mod tests {
         let location = ParquetFilePath::new(
             file_in_catalog.namespace_id,
             file_in_catalog.table_id,
-            file_in_catalog.transition_partition_id(),
+            &file_in_catalog.transition_partition_id(),
             file_in_catalog.object_store_id,
         )
         .object_store_path();
@@ -327,7 +327,7 @@ mod tests {
         let location = ParquetFilePath::new(
             NamespaceId::new(1),
             TableId::new(2),
-            TransitionPartitionId::Deprecated(PartitionId::new(4)),
+            &TransitionPartitionId::Deprecated(PartitionId::new(4)),
             Uuid::new_v4(),
         )
         .object_store_path();
@@ -376,7 +376,7 @@ mod tests {
         let location = ParquetFilePath::new(
             file_in_catalog.namespace_id,
             file_in_catalog.table_id,
-            file_in_catalog.transition_partition_id(),
+            &file_in_catalog.transition_partition_id(),
             file_in_catalog.object_store_id,
         )
         .object_store_path();
@@ -405,7 +405,7 @@ mod tests {
         let location = ParquetFilePath::new(
             NamespaceId::new(1),
             TableId::new(2),
-            TransitionPartitionId::Deprecated(PartitionId::new(4)),
+            &TransitionPartitionId::Deprecated(PartitionId::new(4)),
             Uuid::new_v4(),
         )
         .object_store_path();
@@ -469,7 +469,7 @@ mod tests {
         let loc = ParquetFilePath::new(
             file_in_catalog.namespace_id,
             file_in_catalog.table_id,
-            file_in_catalog.transition_partition_id(),
+            &file_in_catalog.transition_partition_id(),
             file_in_catalog.object_store_id,
         )
         .object_store_path();

--- a/garbage_collector/src/objectstore/deleter.rs
+++ b/garbage_collector/src/objectstore/deleter.rs
@@ -147,7 +147,7 @@ mod tests {
         ParquetFilePath::new(
             NamespaceId::new(1),
             TableId::new(2),
-            TransitionPartitionId::Deprecated(PartitionId::new(4)),
+            &TransitionPartitionId::Deprecated(PartitionId::new(4)),
             Uuid::new_v4(),
         )
         .object_store_path()

--- a/garbage_collector/src/objectstore/deleter.rs
+++ b/garbage_collector/src/objectstore/deleter.rs
@@ -64,7 +64,7 @@ mod tests {
     use super::*;
     use bytes::Bytes;
     use chrono::Utc;
-    use data_types::{NamespaceId, PartitionId, TableId};
+    use data_types::{NamespaceId, PartitionId, TableId, TransitionPartitionId};
     use object_store::path::Path;
     use parquet_file::ParquetFilePath;
     use std::time::Duration;
@@ -147,7 +147,7 @@ mod tests {
         ParquetFilePath::new(
             NamespaceId::new(1),
             TableId::new(2),
-            PartitionId::new(4),
+            TransitionPartitionId::Deprecated(PartitionId::new(4)),
             Uuid::new_v4(),
         )
         .object_store_path()

--- a/ingester/src/buffer_tree/partition/resolver/cache.rs
+++ b/ingester/src/buffer_tree/partition/resolver/cache.rs
@@ -20,10 +20,10 @@ use crate::{
 };
 
 /// A read-through cache mapping `(table_id, partition_key)` tuples to
-/// `(partition_id, max_sequence_number)`.
+/// `(partition_id, optional_partition_hash_id)`.
 ///
 /// This data is safe to cache as only one ingester is ever responsible for a
-/// given table partition, and this amortises partition persist marker discovery
+/// given table partition, and this amortises partition discovery
 /// queries during startup, eliminating them from the ingest hot path in the
 /// common startup case (an ingester restart with no new partitions to add).
 ///
@@ -32,11 +32,12 @@ use crate::{
 /// Excluding map overhead, and assuming partition keys in the form
 /// "YYYY-MM-DD", each entry takes:
 ///
-///   - Partition key: String (8 len + 8 cap + 8 ptr + data len) = 34 bytes
-///   - TableId: 8 bytes
-///   - PartitionId: 8 bytes
+///   - `PartitionKey`: String (8 len + 8 cap + 8 ptr + data len) = 34 bytes
+///   - `TableId`: 8 bytes
+///   - `PartitionId`: 8 bytes
+///   - `Option<PartitionHashId>`: 8 bytes
 ///
-/// For a total of 50 bytes per entry - approx 20,971 entries can be held in
+/// For a total of 58 bytes per entry - approx 18.078 entries can be held in
 /// 1MiB of memory.
 ///
 /// Each cache hit _removes_ the entry from the cache - this eliminates the

--- a/ingester/src/buffer_tree/partition/resolver/cache.rs
+++ b/ingester/src/buffer_tree/partition/resolver/cache.rs
@@ -291,7 +291,7 @@ mod tests {
         let inner = MockPartitionProvider::default();
 
         let stored_partition_key = PartitionKey::from(ARBITRARY_PARTITION_KEY_STR);
-        let partition = Partition::new(
+        let partition = Partition::new_in_memory_only(
             ARBITRARY_PARTITION_ID,
             ARBITRARY_TABLE_ID,
             stored_partition_key.clone(),
@@ -350,7 +350,7 @@ mod tests {
                 .build(),
         );
 
-        let partition = Partition::new(
+        let partition = Partition::new_in_memory_only(
             ARBITRARY_PARTITION_ID,
             ARBITRARY_TABLE_ID,
             ARBITRARY_PARTITION_KEY.clone(),
@@ -386,7 +386,7 @@ mod tests {
                 .build(),
         );
 
-        let partition = Partition::new(
+        let partition = Partition::new_in_memory_only(
             ARBITRARY_PARTITION_ID,
             ARBITRARY_TABLE_ID,
             ARBITRARY_PARTITION_KEY.clone(),

--- a/ingester/src/buffer_tree/partition/resolver/catalog.rs
+++ b/ingester/src/buffer_tree/partition/resolver/catalog.rs
@@ -78,6 +78,7 @@ impl PartitionProvider for CatalogPartitionResolver {
 
         Arc::new(Mutex::new(PartitionData::new(
             p.id,
+            p.hash_id().cloned(),
             // Use the caller's partition key instance, as it MAY be shared with
             // other instance, but the instance returned from the catalog
             // definitely has no other refs.

--- a/ingester/src/buffer_tree/table.rs
+++ b/ingester/src/buffer_tree/table.rs
@@ -216,10 +216,11 @@ where
         let partitions = self.partitions().into_iter().map(move |p| {
             let mut span = span.child("partition read");
 
-            let (id, completed_persistence_count, data) = {
+            let (id, hash_id, completed_persistence_count, data) = {
                 let mut p = p.lock();
                 (
                     p.partition_id(),
+                    p.partition_hash_id().cloned(),
                     p.completed_persistence_count(),
                     p.get_query_data(),
                 )
@@ -238,9 +239,9 @@ where
                     };
 
                     let data = data.project_selection(selection).into_iter().collect();
-                    PartitionResponse::new(data, id, completed_persistence_count)
+                    PartitionResponse::new(data, id, hash_id, completed_persistence_count)
                 }
-                None => PartitionResponse::new(vec![], id, completed_persistence_count),
+                None => PartitionResponse::new(vec![], id, hash_id, completed_persistence_count),
             };
 
             span.ok("read partition data");

--- a/ingester/src/persist/completion_observer.rs
+++ b/ingester/src/persist/completion_observer.rs
@@ -169,6 +169,7 @@ mod tests {
             namespace_id: NAMESPACE_ID,
             table_id: TABLE_ID,
             partition_id: PARTITION_ID,
+            partition_hash_id: None,
             object_store_id: Default::default(),
             min_time: Timestamp::new(42),
             max_time: Timestamp::new(42),

--- a/ingester/src/persist/file_metrics.rs
+++ b/ingester/src/persist/file_metrics.rs
@@ -175,6 +175,7 @@ mod tests {
             namespace_id: NAMESPACE_ID,
             table_id: TABLE_ID,
             partition_id: PARTITION_ID,
+            partition_hash_id: None,
             object_store_id: Default::default(),
             min_time: Timestamp::new(Duration::from_secs(1_000).as_nanos() as _),
             max_time: Timestamp::new(Duration::from_secs(1_042).as_nanos() as _), // 42 seconds later

--- a/ingester/src/persist/mod.rs
+++ b/ingester/src/persist/mod.rs
@@ -327,6 +327,7 @@ mod tests {
         let partition = partition_with_write(Arc::clone(&catalog)).await;
         let table_id = partition.lock().table_id();
         let partition_id = partition.lock().partition_id();
+        let transition_partition_id = partition.lock().transition_partition_id();
         let namespace_id = partition.lock().namespace_id();
         assert_matches!(partition.lock().sort_key(), SortKeyState::Provided(None));
 
@@ -437,8 +438,13 @@ mod tests {
         assert_eq!(files.len(), 2, "expected two uploaded files");
 
         // Ensure the catalog record points at a valid file in object storage.
-        let want_path = ParquetFilePath::new(namespace_id, table_id, partition_id, object_store_id)
-            .object_store_path();
+        let want_path = ParquetFilePath::new(
+            namespace_id,
+            table_id,
+            transition_partition_id,
+            object_store_id,
+        )
+        .object_store_path();
         let file = files
             .into_iter()
             .find(|f| f.location == want_path)

--- a/ingester/src/persist/mod.rs
+++ b/ingester/src/persist/mod.rs
@@ -441,7 +441,7 @@ mod tests {
         let want_path = ParquetFilePath::new(
             namespace_id,
             table_id,
-            transition_partition_id,
+            &transition_partition_id,
             object_store_id,
         )
         .object_store_path();

--- a/ingester/src/persist/worker.rs
+++ b/ingester/src/persist/worker.rs
@@ -280,7 +280,7 @@ where
         .store
         .upload(
             record_stream,
-            ctx.transition_partition_id(),
+            &ctx.transition_partition_id(),
             &iox_metadata,
             pool,
         )

--- a/ingester/src/persist/worker.rs
+++ b/ingester/src/persist/worker.rs
@@ -278,7 +278,12 @@ where
     let pool = worker_state.exec.pool();
     let (md, file_size) = worker_state
         .store
-        .upload(record_stream, ctx.partition_id(), &iox_metadata, pool)
+        .upload(
+            record_stream,
+            ctx.transition_partition_id(),
+            &iox_metadata,
+            pool,
+        )
         .await
         .expect("unexpected fatal persist error");
 
@@ -305,8 +310,12 @@ where
 
     // Build the data that must be inserted into the parquet_files catalog
     // table in order to make the file visible to queriers.
-    let parquet_table_data =
-        iox_metadata.to_parquet_file(ctx.partition_id(), file_size, &md, |name| {
+    let parquet_table_data = iox_metadata.to_parquet_file(
+        ctx.partition_id(),
+        ctx.partition_hash_id(),
+        file_size,
+        &md,
+        |name| {
             columns
                 .get(name)
                 .unwrap_or_else(|| {
@@ -316,7 +325,8 @@ where
                     )
                 })
                 .id
-        });
+        },
+    );
 
     (catalog_sort_key_update, parquet_table_data)
 }

--- a/ingester/src/query/partition_response.rs
+++ b/ingester/src/query/partition_response.rs
@@ -3,7 +3,7 @@
 //! [`QueryResponse`]: super::response::QueryResponse
 
 use arrow::record_batch::RecordBatch;
-use data_types::PartitionId;
+use data_types::{PartitionHashId, PartitionId};
 
 /// Response data for a single partition.
 #[derive(Debug)]
@@ -14,6 +14,9 @@ pub(crate) struct PartitionResponse {
     /// Partition ID.
     id: PartitionId,
 
+    /// Partition hash ID, if stored in the database.
+    partition_hash_id: Option<PartitionHashId>,
+
     /// Count of persisted Parquet files for this partition by this ingester instance.
     completed_persistence_count: u64,
 }
@@ -22,17 +25,23 @@ impl PartitionResponse {
     pub(crate) fn new(
         data: Vec<RecordBatch>,
         id: PartitionId,
+        partition_hash_id: Option<PartitionHashId>,
         completed_persistence_count: u64,
     ) -> Self {
         Self {
             batches: data,
             id,
+            partition_hash_id,
             completed_persistence_count,
         }
     }
 
     pub(crate) fn id(&self) -> PartitionId {
         self.id
+    }
+
+    pub(crate) fn partition_hash_id(&self) -> Option<&PartitionHashId> {
+        self.partition_hash_id.as_ref()
     }
 
     pub(crate) fn completed_persistence_count(&self) -> u64 {

--- a/ingester/src/test_util.rs
+++ b/ingester/src/test_util.rs
@@ -1,6 +1,6 @@
 use std::{collections::BTreeMap, sync::Arc, time::Duration};
 
-use data_types::{NamespaceId, Partition, PartitionId, PartitionKey, SequenceNumber, TableId};
+use data_types::{NamespaceId, PartitionId, PartitionKey, SequenceNumber, TableId};
 use iox_catalog::{interface::Catalog, test_helpers::arbitrary_namespace};
 use lazy_static::lazy_static;
 use mutable_batch_lp::lines_to_batches;
@@ -127,6 +127,7 @@ impl PartitionDataBuilder {
     pub(crate) fn build(self) -> PartitionData {
         PartitionData::new(
             self.partition_id.unwrap_or(ARBITRARY_PARTITION_ID),
+            None,
             self.partition_key
                 .unwrap_or_else(|| ARBITRARY_PARTITION_KEY.clone()),
             self.namespace_id.unwrap_or(ARBITRARY_NAMESPACE_ID),
@@ -137,18 +138,6 @@ impl PartitionDataBuilder {
                 .unwrap_or_else(defer_table_name_1_sec),
             self.sort_key.unwrap_or(SortKeyState::Provided(None)),
         )
-    }
-}
-
-/// Generate a valid [`Partition`] for use in the tests where the exact values (or at least some of
-/// them) don't particularly matter.
-pub(crate) fn arbitrary_partition() -> Partition {
-    Partition {
-        id: ARBITRARY_PARTITION_ID,
-        table_id: ARBITRARY_TABLE_ID,
-        partition_key: ARBITRARY_PARTITION_KEY.clone(),
-        sort_key: Default::default(),
-        new_file_at: Default::default(),
     }
 }
 

--- a/ingester/src/test_util.rs
+++ b/ingester/src/test_util.rs
@@ -235,7 +235,19 @@ macro_rules! make_partition_stream {
 
                     PartitionResponse::new(
                         batches,
-                        $id,
+                        // Using the $id as both the PartitionId and the TableId in the
+                        // PartitionHashId is a temporary way to reduce duplication in tests where
+                        // the important part is which batches are in the same partition and which
+                        // batches are in a different partition, not what the actual identifier
+                        // values are. This will go away when the ingester no longer sends
+                        // PartitionIds.
+                        PartitionId::new($id),
+                        Some(
+                            PartitionHashId::new(
+                                TableId::new($id),
+                                &PartitionKey::from("arbitrary")
+                            )
+                        ),
                         42,
                     )
                 },)+

--- a/ingester/src/wal/reference_tracker/handle.rs
+++ b/ingester/src/wal/reference_tracker/handle.rs
@@ -268,6 +268,7 @@ mod tests {
                 namespace_id: NamespaceId::new(1),
                 table_id: TableId::new(2),
                 partition_id: PartitionId::new(3),
+                partition_hash_id: None,
                 object_store_id: Default::default(),
                 min_time: Timestamp::new(42),
                 max_time: Timestamp::new(42),

--- a/ingester_query_grpc/protos/influxdata/iox/ingester/v1/query.proto
+++ b/ingester_query_grpc/protos/influxdata/iox/ingester/v1/query.proto
@@ -73,6 +73,10 @@ message IngesterQueryResponseMetadata {
   // Partition id for this batch.
   int64 partition_id = 7;
 
+  // A unique identifier of this partition, deterministically created from the table ID and
+  // partition key.
+  optional bytes partition_hash_id = 11;
+
   // Was partition status.
   reserved "status";
   reserved 8;

--- a/iox_catalog/migrations/20230417173102_deterministic_partition_id.sql
+++ b/iox_catalog/migrations/20230417173102_deterministic_partition_id.sql
@@ -1,0 +1,16 @@
+-- Add a new, nullable hash ID column to the partition table
+ALTER TABLE
+  IF EXISTS partition
+  ADD COLUMN hash_id bytea;
+
+-- If it's specified, it must be unique
+ALTER TABLE
+  IF EXISTS partition
+  ADD CONSTRAINT partition_hash_id_unique UNIQUE (hash_id);
+
+-- Add a new, nullable foreign key column to the parquet_file table referencing the partition table
+ALTER TABLE
+  IF EXISTS parquet_file
+  ADD COLUMN partition_hash_id bytea
+  REFERENCES partition (hash_id);
+

--- a/iox_catalog/sqlite/migrations/20230417173102_deterministic_partition_id.sql
+++ b/iox_catalog/sqlite/migrations/20230417173102_deterministic_partition_id.sql
@@ -1,0 +1,13 @@
+-- Add a new, nullable hash ID column to the partition table
+ALTER TABLE
+  partition
+  ADD COLUMN hash_id BLOB;
+
+-- If it's specified, it must be unique
+CREATE UNIQUE INDEX IF NOT EXISTS partition_hash_id_unique ON partition (hash_id);
+
+-- Add a new, nullable foreign key column to the parquet_file table referencing the partition table
+ALTER TABLE
+  parquet_file
+  ADD COLUMN partition_hash_id bytea
+  REFERENCES partition (hash_id);

--- a/iox_catalog/src/lib.rs
+++ b/iox_catalog/src/lib.rs
@@ -334,6 +334,7 @@ pub mod test_helpers {
             namespace_id: namespace.id,
             table_id: table.id,
             partition_id: partition.id,
+            partition_hash_id: partition.hash_id().cloned(),
             object_store_id: Uuid::new_v4(),
             min_time: Timestamp::new(1),
             max_time: Timestamp::new(10),

--- a/iox_catalog/src/mem.rs
+++ b/iox_catalog/src/mem.rs
@@ -560,13 +560,13 @@ impl PartitionRepo for MemTxn {
         {
             Some(p) => p,
             None => {
-                let p = Partition {
-                    id: PartitionId::new(stage.partitions.len() as i64 + 1),
+                let p = Partition::new(
+                    PartitionId::new(stage.partitions.len() as i64 + 1),
                     table_id,
-                    partition_key: key,
-                    sort_key: vec![],
-                    new_file_at: None,
-                };
+                    key,
+                    vec![],
+                    None,
+                );
                 stage.partitions.push(p);
                 stage.partitions.last().unwrap()
             }

--- a/iox_catalog/src/mem.rs
+++ b/iox_catalog/src/mem.rs
@@ -560,7 +560,7 @@ impl PartitionRepo for MemTxn {
         {
             Some(p) => p,
             None => {
-                let p = Partition::new(
+                let p = Partition::new_in_memory_only(
                     PartitionId::new(stage.partitions.len() as i64 + 1),
                     table_id,
                     key,

--- a/iox_catalog/src/postgres.rs
+++ b/iox_catalog/src/postgres.rs
@@ -1564,10 +1564,9 @@ where
         max_l0_created_at,
     } = parquet_file_params;
 
-    // This nonsense is because sqlx doesn't like inserting NULL; it should go away soon
-    let query = match partition_hash_id {
-        Some(partition_hash_id) => sqlx::query_scalar::<_, ParquetFileId>(
-            r#"
+    let partition_hash_id_ref = &partition_hash_id.as_ref();
+    let query = sqlx::query_scalar::<_, ParquetFileId>(
+        r#"
 INSERT INTO parquet_file (
     shard_id, table_id, partition_id, partition_hash_id, object_store_id,
     min_time, max_time, file_size_bytes,
@@ -1575,46 +1574,21 @@ INSERT INTO parquet_file (
 VALUES ( $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14 )
 RETURNING id;
         "#,
-        )
-        .bind(TRANSITION_SHARD_ID) // $1
-        .bind(table_id) // $2
-        .bind(partition_id) // $3
-        .bind(partition_hash_id) // $4
-        .bind(object_store_id) // $5
-        .bind(min_time) // $6
-        .bind(max_time) // $7
-        .bind(file_size_bytes) // $8
-        .bind(row_count) // $9
-        .bind(compaction_level) // $10
-        .bind(created_at) // $11
-        .bind(namespace_id) // $12
-        .bind(column_set) // $13
-        .bind(max_l0_created_at), // $14
-        None => sqlx::query_scalar::<_, ParquetFileId>(
-            r#"
-INSERT INTO parquet_file (
-    shard_id, table_id, partition_id, partition_hash_id, object_store_id, min_time, max_time,
-    file_size_bytes, row_count, compaction_level, created_at, namespace_id, column_set,
-    max_l0_created_at
-)
-VALUES ( $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13 )
-RETURNING id;
-        "#,
-        )
-        .bind(TRANSITION_SHARD_ID) // $1
-        .bind(table_id) // $2
-        .bind(partition_id) // $3
-        .bind(object_store_id) // $4
-        .bind(min_time) // $5
-        .bind(max_time) // $6
-        .bind(file_size_bytes) // $7
-        .bind(row_count) // $8
-        .bind(compaction_level) // $9
-        .bind(created_at) // $10
-        .bind(namespace_id) // $11
-        .bind(column_set) // $12
-        .bind(max_l0_created_at), // $13
-    };
+    )
+    .bind(TRANSITION_SHARD_ID) // $1
+    .bind(table_id) // $2
+    .bind(partition_id) // $3
+    .bind(partition_hash_id_ref) // $4
+    .bind(object_store_id) // $5
+    .bind(min_time) // $6
+    .bind(max_time) // $7
+    .bind(file_size_bytes) // $8
+    .bind(row_count) // $9
+    .bind(compaction_level) // $10
+    .bind(created_at) // $11
+    .bind(namespace_id) // $12
+    .bind(column_set) // $13
+    .bind(max_l0_created_at); // $14
 
     let parquet_file_id = query.fetch_one(executor).await.map_err(|e| {
         if is_unique_violation(&e) {
@@ -1985,7 +1959,8 @@ mod tests {
         let mut repos = postgres.repositories().await;
 
         let namespace = arbitrary_namespace(&mut *repos, "ns4").await;
-        let table_id = arbitrary_table(&mut *repos, "table", &namespace).await.id;
+        let table = arbitrary_table(&mut *repos, "table", &namespace).await;
+        let table_id = table.id;
         let key = PartitionKey::from("francis-scott-key-key");
 
         // Create a partition record in the database that has `NULL` for its `hash_id`
@@ -2011,18 +1986,28 @@ RETURNING id, hash_id, table_id, partition_key, sort_key, new_file_at;
         // Check that the hash_id being null in the database doesn't break querying for partitions.
         let table_partitions = repos.partitions().list_by_table_id(table_id).await.unwrap();
         assert_eq!(table_partitions.len(), 1);
-        let a = &table_partitions[0];
-        assert!(a.hash_id().is_none());
+        let partition = &table_partitions[0];
+        assert!(partition.hash_id().is_none());
 
         // Call create_or_get for the same (key, table_id) pair, to ensure the write is idempotent
         // and that the hash_id still doesn't get set.
-        let b = repos
+        let inserted_again = repos
             .partitions()
             .create_or_get(key, table_id)
             .await
             .expect("idempotent write should succeed");
 
-        assert_eq!(a, &b);
+        assert_eq!(partition, &inserted_again);
+
+        // Create a Parquet file record in this partition to ensure we don't break new data
+        // ingestion for old-style partitions
+        let parquet_file_params = arbitrary_parquet_file_params(&namespace, &table, partition);
+        let parquet_file = repos
+            .parquet_files()
+            .create(parquet_file_params)
+            .await
+            .unwrap();
+        assert!(parquet_file.partition_hash_id.is_none());
     }
 
     #[test]

--- a/iox_catalog/src/sqlite.rs
+++ b/iox_catalog/src/sqlite.rs
@@ -20,8 +20,8 @@ use data_types::{
     },
     Column, ColumnId, ColumnSet, ColumnType, CompactionLevel, Namespace, NamespaceId,
     NamespaceName, NamespaceServiceProtectionLimitsOverride, ParquetFile, ParquetFileId,
-    ParquetFileParams, Partition, PartitionId, PartitionKey, SkippedCompaction, Table, TableId,
-    Timestamp,
+    ParquetFileParams, Partition, PartitionHashId, PartitionId, PartitionKey, SkippedCompaction,
+    Table, TableId, Timestamp,
 };
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
@@ -813,6 +813,7 @@ RETURNING *;
 #[derive(Debug, Clone, PartialEq, Eq, sqlx::FromRow)]
 struct PartitionPod {
     id: PartitionId,
+    hash_id: Option<PartitionHashId>,
     table_id: TableId,
     partition_key: PartitionKey,
     sort_key: Json<Vec<String>>,
@@ -821,13 +822,26 @@ struct PartitionPod {
 
 impl From<PartitionPod> for Partition {
     fn from(value: PartitionPod) -> Self {
-        Self {
-            id: value.id,
-            table_id: value.table_id,
-            partition_key: value.partition_key,
-            sort_key: value.sort_key.0,
-            new_file_at: value.new_file_at,
+        let partition = Self::new(
+            value.id,
+            value.table_id,
+            value.partition_key,
+            value.sort_key.0,
+            value.new_file_at,
+        );
+
+        // The constructor recomputes the `PartitionHashId` even though it may be in the database.
+        // If it is in the database, it'd better match what we just computed.
+        if let Some(hash_id) = value.hash_id.as_ref() {
+            assert_eq!(
+                hash_id,
+                partition
+                    .hash_id()
+                    .expect("hash_id just computed by Partition::new")
+            );
         }
+
+        partition
     }
 }
 
@@ -838,20 +852,23 @@ impl PartitionRepo for SqliteTxn {
         // array rather than NULL which sqlx will throw `UnexpectedNullError` while is is doing
         // `ColumnDecode`
 
+        let hash_id = PartitionHashId::new(table_id, &key);
+
         let v = sqlx::query_as::<_, PartitionPod>(
             r#"
 INSERT INTO partition
-    ( partition_key, shard_id, table_id, sort_key)
+    (partition_key, shard_id, table_id, hash_id, sort_key)
 VALUES
-    ( $1, $2, $3, '[]')
+    ($1, $2, $3, $4, '[]')
 ON CONFLICT (table_id, partition_key)
 DO UPDATE SET partition_key = partition.partition_key
-RETURNING id, table_id, partition_key, sort_key, new_file_at;
+RETURNING id, hash_id, table_id, partition_key, sort_key, new_file_at;
         "#,
         )
         .bind(key) // $1
         .bind(TRANSITION_SHARD_ID) // $2
         .bind(table_id) // $3
+        .bind(&hash_id) // $4
         .fetch_one(self.inner.get_mut())
         .await
         .map_err(|e| {
@@ -868,7 +885,7 @@ RETURNING id, table_id, partition_key, sort_key, new_file_at;
     async fn get_by_id(&mut self, partition_id: PartitionId) -> Result<Option<Partition>> {
         let rec = sqlx::query_as::<_, PartitionPod>(
             r#"
-SELECT id, table_id, partition_key, sort_key, new_file_at
+SELECT id, hash_id, table_id, partition_key, sort_key, new_file_at
 FROM partition
 WHERE id = $1;
             "#,
@@ -889,7 +906,7 @@ WHERE id = $1;
     async fn list_by_table_id(&mut self, table_id: TableId) -> Result<Vec<Partition>> {
         Ok(sqlx::query_as::<_, PartitionPod>(
             r#"
-SELECT id, table_id, partition_key, sort_key, new_file_at
+SELECT id, hash_id, table_id, partition_key, sort_key, new_file_at
 FROM partition
 WHERE table_id = $1;
             "#,
@@ -933,7 +950,7 @@ WHERE table_id = $1;
 UPDATE partition
 SET sort_key = $1
 WHERE id = $2 AND sort_key = $3
-RETURNING id, table_id, partition_key, sort_key, new_file_at;
+RETURNING id, hash_id, table_id, partition_key, sort_key, new_file_at;
         "#,
         )
         .bind(Json(new_sort_key)) // $1
@@ -1072,7 +1089,7 @@ RETURNING *
     async fn most_recent_n(&mut self, n: usize) -> Result<Vec<Partition>> {
         Ok(sqlx::query_as::<_, PartitionPod>(
             r#"
-SELECT id, table_id, partition_key, sort_key, new_file_at
+SELECT id, hash_id, table_id, partition_key, sort_key, new_file_at
 FROM partition
 ORDER BY id DESC
 LIMIT $1;
@@ -1127,6 +1144,7 @@ struct ParquetFilePod {
     namespace_id: NamespaceId,
     table_id: TableId,
     partition_id: PartitionId,
+    partition_hash_id: Option<PartitionHashId>,
     object_store_id: Uuid,
     min_time: Timestamp,
     max_time: Timestamp,
@@ -1146,6 +1164,7 @@ impl From<ParquetFilePod> for ParquetFile {
             namespace_id: value.namespace_id,
             table_id: value.table_id,
             partition_id: value.partition_id,
+            partition_hash_id: value.partition_hash_id,
             object_store_id: value.object_store_id,
             min_time: value.min_time,
             max_time: value.max_time,
@@ -1173,7 +1192,7 @@ impl ParquetFileRepo for SqliteTxn {
         Ok(sqlx::query_as::<_, ParquetFilePod>(
             r#"
 SELECT parquet_file.id, parquet_file.namespace_id, parquet_file.table_id,
-       parquet_file.partition_id, parquet_file.object_store_id,
+       parquet_file.partition_id, parquet_file.partition_hash_id, parquet_file.object_store_id,
        parquet_file.min_time, parquet_file.max_time, parquet_file.to_delete,
        parquet_file.file_size_bytes, parquet_file.row_count, parquet_file.compaction_level,
        parquet_file.created_at, parquet_file.column_set, parquet_file.max_l0_created_at
@@ -1227,7 +1246,7 @@ RETURNING id;
         Ok(sqlx::query_as::<_, ParquetFilePod>(
             r#"
 SELECT parquet_file.id, parquet_file.namespace_id, parquet_file.table_id,
-       parquet_file.partition_id, parquet_file.object_store_id,
+       parquet_file.partition_id, parquet_file.partition_hash_id, parquet_file.object_store_id,
        parquet_file.min_time, parquet_file.max_time, parquet_file.to_delete,
        parquet_file.file_size_bytes, parquet_file.row_count, parquet_file.compaction_level,
        parquet_file.created_at, parquet_file.column_set, parquet_file.max_l0_created_at
@@ -1249,7 +1268,7 @@ WHERE table_name.namespace_id = $1
     async fn list_by_table_not_to_delete(&mut self, table_id: TableId) -> Result<Vec<ParquetFile>> {
         Ok(sqlx::query_as::<_, ParquetFilePod>(
             r#"
-SELECT id, namespace_id, table_id, partition_id, object_store_id,
+SELECT id, namespace_id, table_id, partition_id, partition_hash_id, object_store_id,
        min_time, max_time, to_delete, file_size_bytes,
        row_count, compaction_level, created_at, column_set, max_l0_created_at
 FROM parquet_file
@@ -1296,9 +1315,9 @@ RETURNING id;
     ) -> Result<Vec<ParquetFile>> {
         Ok(sqlx::query_as::<_, ParquetFilePod>(
             r#"
-SELECT id, namespace_id, table_id, partition_id, object_store_id,
-       min_time, max_time, to_delete, file_size_bytes,
-       row_count, compaction_level, created_at, column_set, max_l0_created_at
+SELECT id, namespace_id, table_id, partition_id, partition_hash_id, object_store_id, min_time,
+       max_time, to_delete, file_size_bytes, row_count, compaction_level, created_at, column_set,
+       max_l0_created_at
 FROM parquet_file
 WHERE parquet_file.partition_id = $1
   AND parquet_file.to_delete IS NULL;
@@ -1319,9 +1338,9 @@ WHERE parquet_file.partition_id = $1
     ) -> Result<Option<ParquetFile>> {
         let rec = sqlx::query_as::<_, ParquetFilePod>(
             r#"
-SELECT id, namespace_id, table_id, partition_id, object_store_id,
-       min_time, max_time, to_delete, file_size_bytes,
-       row_count, compaction_level, created_at, column_set, max_l0_created_at
+SELECT id, namespace_id, table_id, partition_id, partition_hash_id, object_store_id, min_time,
+       max_time, to_delete, file_size_bytes, row_count, compaction_level, created_at, column_set,
+       max_l0_created_at
 FROM parquet_file
 WHERE object_store_id = $1;
              "#,
@@ -1420,6 +1439,7 @@ where
         namespace_id,
         table_id,
         partition_id,
+        partition_hash_id,
         object_store_id,
         min_time,
         max_time,
@@ -1431,33 +1451,72 @@ where
         max_l0_created_at,
     } = parquet_file_params;
 
-    let query = sqlx::query_as::<_, ParquetFilePod>(
-        r#"
+    // This nonsense is because sqlx doesn't like inserting NULL; it should go away soon
+    let res = match partition_hash_id {
+        Some(partition_hash_id) => {
+            sqlx::query_as::<_, ParquetFilePod>(
+                r#"
+INSERT INTO parquet_file (
+    shard_id, table_id, partition_id, partition_hash_id, object_store_id,
+    min_time, max_time, file_size_bytes,
+    row_count, compaction_level, created_at, namespace_id, column_set, max_l0_created_at )
+VALUES ( $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14 )
+RETURNING
+    id, table_id, partition_id, partition_hash_id, object_store_id, min_time, max_time, to_delete,
+    file_size_bytes, row_count, compaction_level, created_at, namespace_id, column_set,
+    max_l0_created_at;
+        "#,
+            )
+            .bind(TRANSITION_SHARD_ID) // $1
+            .bind(table_id) // $2
+            .bind(partition_id) // $3
+            .bind(&partition_hash_id) // $4
+            .bind(object_store_id) // $5
+            .bind(min_time) // $6
+            .bind(max_time) // $7
+            .bind(file_size_bytes) // $8
+            .bind(row_count) // $9
+            .bind(compaction_level) // $10
+            .bind(created_at) // $11
+            .bind(namespace_id) // $12
+            .bind(from_column_set(&column_set)) // $13
+            .bind(max_l0_created_at) // $14
+            .fetch_one(executor)
+            .await
+        }
+        None => {
+            sqlx::query_as::<_, ParquetFilePod>(
+                r#"
 INSERT INTO parquet_file (
     shard_id, table_id, partition_id, object_store_id,
     min_time, max_time, file_size_bytes,
     row_count, compaction_level, created_at, namespace_id, column_set, max_l0_created_at )
 VALUES ( $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13 )
 RETURNING
-    id, table_id, partition_id, object_store_id,
-    min_time, max_time, to_delete, file_size_bytes,
-    row_count, compaction_level, created_at, namespace_id, column_set, max_l0_created_at;
+    id, table_id, partition_id, partition_hash_id, object_store_id, min_time, max_time, to_delete,
+    file_size_bytes, row_count, compaction_level, created_at, namespace_id, column_set,
+    max_l0_created_at;
         "#,
-    )
-    .bind(TRANSITION_SHARD_ID) // $1
-    .bind(table_id) // $2
-    .bind(partition_id) // $3
-    .bind(object_store_id) // $4
-    .bind(min_time) // $5
-    .bind(max_time) // $6
-    .bind(file_size_bytes) // $7
-    .bind(row_count) // $8
-    .bind(compaction_level) // $9
-    .bind(created_at) // $10
-    .bind(namespace_id) // $11
-    .bind(from_column_set(&column_set)) // $12
-    .bind(max_l0_created_at); // $13
-    let rec = query.fetch_one(executor).await.map_err(|e| {
+            )
+            .bind(TRANSITION_SHARD_ID) // $1
+            .bind(table_id) // $2
+            .bind(partition_id) // $3
+            .bind(object_store_id) // $4
+            .bind(min_time) // $5
+            .bind(max_time) // $6
+            .bind(file_size_bytes) // $7
+            .bind(row_count) // $8
+            .bind(compaction_level) // $9
+            .bind(created_at) // $10
+            .bind(namespace_id) // $11
+            .bind(from_column_set(&column_set)) // $12
+            .bind(max_l0_created_at) // $13
+            .fetch_one(executor)
+            .await
+        }
+    };
+
+    let rec = res.map_err(|e| {
         if is_unique_violation(&e) {
             Error::FileExists { object_store_id }
         } else if is_fk_violation(&e) {
@@ -1605,22 +1664,89 @@ mod tests {
         let namespace = arbitrary_namespace(&mut *repos, "ns4").await;
         let table_id = arbitrary_table(&mut *repos, "table", &namespace).await.id;
 
-        let key = "bananas";
+        let key = PartitionKey::from("bananas");
+
+        let hash_id = PartitionHashId::new(table_id, &key);
 
         let a = repos
             .partitions()
-            .create_or_get(key.into(), table_id)
+            .create_or_get(key.clone(), table_id)
             .await
             .expect("should create OK");
+
+        assert_eq!(a.hash_id().unwrap(), &hash_id);
 
         // Call create_or_get for the same (key, table_id) pair, to ensure the write is idempotent.
         let b = repos
             .partitions()
-            .create_or_get(key.into(), table_id)
+            .create_or_get(key.clone(), table_id)
             .await
             .expect("idempotent write should succeed");
 
         assert_eq!(a, b);
+
+        // Check that the hash_id is saved in the database and is returned when queried.
+        let table_partitions = sqlite
+            .repositories()
+            .await
+            .partitions()
+            .list_by_table_id(table_id)
+            .await
+            .unwrap();
+        assert_eq!(table_partitions.len(), 1);
+        assert_eq!(table_partitions[0].hash_id().unwrap(), &hash_id);
+    }
+
+    #[tokio::test]
+    async fn existing_partitions_without_hash_id() {
+        let sqlite = setup_db().await;
+        let pool = sqlite.pool.clone();
+        let sqlite: Arc<dyn Catalog> = Arc::new(sqlite);
+        let mut repos = sqlite.repositories().await;
+
+        let namespace = arbitrary_namespace(&mut *repos, "ns4").await;
+        let table_id = arbitrary_table(&mut *repos, "table", &namespace).await.id;
+        let key = PartitionKey::from("francis-scott-key-key");
+
+        let hash_id = PartitionHashId::new(table_id, &key);
+
+        // Create a partition record in the database that has `NULL` for its `hash_id`
+        // value, which is what records existing before the migration adding that column will have.
+        sqlx::query(
+            r#"
+INSERT INTO partition
+    (partition_key, shard_id, table_id, sort_key)
+VALUES
+    ($1, $2, $3, '[]')
+ON CONFLICT (table_id, partition_key)
+DO UPDATE SET partition_key = partition.partition_key
+RETURNING id, hash_id, table_id, partition_key, sort_key, new_file_at;
+        "#,
+        )
+        .bind(&key) // $1
+        .bind(TRANSITION_SHARD_ID) // $2
+        .bind(table_id) // $3
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+
+        // Check that the hash_id being null in the database doesn't break querying for partitions.
+        let table_partitions = repos.partitions().list_by_table_id(table_id).await.unwrap();
+        assert_eq!(table_partitions.len(), 1);
+        let a = &table_partitions[0];
+
+        // But because sqlite uses `Partition::new`, it will have the partition key set
+        assert_eq!(a.hash_id().unwrap(), &hash_id);
+
+        // Call create_or_get for the same (key, table_id) pair, to ensure the write is idempotent
+        // and that the hash_id will still be set by `Partition::new`
+        let b = repos
+            .partitions()
+            .create_or_get(key, table_id)
+            .await
+            .expect("idempotent write should succeed");
+
+        assert_eq!(a, &b);
     }
 
     macro_rules! test_column_create_or_get_many_unchecked {

--- a/iox_tests/src/builders.rs
+++ b/iox_tests/src/builders.rs
@@ -1,6 +1,6 @@
 use data_types::{
-    ColumnSet, CompactionLevel, NamespaceId, ParquetFile, ParquetFileId, Partition, PartitionId,
-    PartitionKey, SkippedCompaction, Table, TableId, Timestamp,
+    ColumnSet, CompactionLevel, NamespaceId, ParquetFile, ParquetFileId, Partition,
+    PartitionHashId, PartitionId, PartitionKey, SkippedCompaction, Table, TableId, Timestamp,
 };
 use uuid::Uuid;
 
@@ -14,12 +14,17 @@ impl ParquetFileBuilder {
     /// Create a builder that will create a parquet file with
     /// `parquet_id` of `id`
     pub fn new(id: i64) -> Self {
+        let table_id = TableId::new(0);
         Self {
             file: ParquetFile {
                 id: ParquetFileId::new(id),
                 namespace_id: NamespaceId::new(0),
-                table_id: TableId::new(0),
+                table_id,
                 partition_id: PartitionId::new(0),
+                partition_hash_id: Some(PartitionHashId::new(
+                    table_id,
+                    &PartitionKey::from("arbitrary"),
+                )),
                 object_store_id: Uuid::from_u128(id.try_into().expect("invalid id")),
                 min_time: Timestamp::new(0),
                 max_time: Timestamp::new(0),
@@ -152,13 +157,13 @@ impl PartitionBuilder {
     /// Create a builder to create a partition with `partition_id` `id`
     pub fn new(id: i64) -> Self {
         Self {
-            partition: Partition {
-                id: PartitionId::new(id),
-                table_id: TableId::new(0),
-                partition_key: PartitionKey::from("key"),
-                sort_key: vec![],
-                new_file_at: None,
-            },
+            partition: Partition::new(
+                PartitionId::new(id),
+                TableId::new(0),
+                PartitionKey::from("key"),
+                vec![],
+                None,
+            ),
         }
     }
 

--- a/iox_tests/src/builders.rs
+++ b/iox_tests/src/builders.rs
@@ -157,7 +157,7 @@ impl PartitionBuilder {
     /// Create a builder to create a partition with `partition_id` `id`
     pub fn new(id: i64) -> Self {
         Self {
-            partition: Partition::new(
+            partition: Partition::new_in_memory_only(
                 PartitionId::new(id),
                 TableId::new(0),
                 PartitionKey::from("key"),

--- a/iox_tests/src/catalog.rs
+++ b/iox_tests/src/catalog.rs
@@ -524,7 +524,7 @@ impl TestPartition {
                 Arc::clone(&self.catalog.object_store),
                 StorageId::from("iox"),
             ),
-            self.partition.transition_partition_id(),
+            &self.partition.transition_partition_id(),
             &metadata,
             record_batch.clone(),
         )
@@ -812,7 +812,7 @@ async fn update_catalog_sort_key_if_needed(
 /// Create parquet file and return file size.
 async fn create_parquet_file(
     store: ParquetStorage,
-    partition_id: TransitionPartitionId,
+    partition_id: &TransitionPartitionId,
     metadata: &IoxMetadata,
     record_batch: RecordBatch,
 ) -> usize {

--- a/iox_tests/src/catalog.rs
+++ b/iox_tests/src/catalog.rs
@@ -8,6 +8,7 @@ use data_types::{
     partition_template::TablePartitionTemplateOverride, Column, ColumnSet, ColumnType,
     ColumnsByName, CompactionLevel, Namespace, NamespaceName, NamespaceSchema, ParquetFile,
     ParquetFileParams, Partition, PartitionId, Table, TableId, TableSchema, Timestamp,
+    TransitionPartitionId,
 };
 use datafusion::physical_plan::metrics::Count;
 use datafusion_util::{unbounded_memory_pool, MemoryStream};
@@ -523,7 +524,7 @@ impl TestPartition {
                 Arc::clone(&self.catalog.object_store),
                 StorageId::from("iox"),
             ),
-            self.partition.id,
+            self.partition.transition_partition_id(),
             &metadata,
             record_batch.clone(),
         )
@@ -597,6 +598,7 @@ impl TestPartition {
             namespace_id: self.namespace.namespace.id,
             table_id: self.table.table.id,
             partition_id: self.partition.id,
+            partition_hash_id: self.partition.hash_id().cloned(),
             object_store_id: object_store_id.unwrap_or_else(Uuid::new_v4),
             min_time: Timestamp::new(min_time),
             max_time: Timestamp::new(max_time),
@@ -810,7 +812,7 @@ async fn update_catalog_sort_key_if_needed(
 /// Create parquet file and return file size.
 async fn create_parquet_file(
     store: ParquetStorage,
-    partition_id: PartitionId,
+    partition_id: TransitionPartitionId,
     metadata: &IoxMetadata,
     record_batch: RecordBatch,
 ) -> usize {

--- a/parquet_file/src/lib.rs
+++ b/parquet_file/src/lib.rs
@@ -45,13 +45,13 @@ impl ParquetFilePath {
     pub fn new(
         namespace_id: NamespaceId,
         table_id: TableId,
-        partition_id: TransitionPartitionId,
+        partition_id: &TransitionPartitionId,
         object_store_id: Uuid,
     ) -> Self {
         Self {
             namespace_id,
             table_id,
-            partition_id,
+            partition_id: partition_id.clone(),
             object_store_id,
         }
     }
@@ -92,12 +92,12 @@ impl From<&Self> for ParquetFilePath {
     }
 }
 
-impl From<(TransitionPartitionId, &crate::metadata::IoxMetadata)> for ParquetFilePath {
-    fn from((partition_id, m): (TransitionPartitionId, &crate::metadata::IoxMetadata)) -> Self {
+impl From<(&TransitionPartitionId, &crate::metadata::IoxMetadata)> for ParquetFilePath {
+    fn from((partition_id, m): (&TransitionPartitionId, &crate::metadata::IoxMetadata)) -> Self {
         Self {
             namespace_id: m.namespace_id,
             table_id: m.table_id,
-            partition_id,
+            partition_id: partition_id.clone(),
             object_store_id: m.object_store_id,
         }
     }
@@ -135,7 +135,7 @@ mod tests {
         let pfp = ParquetFilePath::new(
             NamespaceId::new(1),
             TableId::new(2),
-            TransitionPartitionId::Deprecated(PartitionId::new(4)),
+            &TransitionPartitionId::Deprecated(PartitionId::new(4)),
             Uuid::nil(),
         );
         let path = pfp.object_store_path();
@@ -151,7 +151,7 @@ mod tests {
         let pfp = ParquetFilePath::new(
             NamespaceId::new(1),
             table_id,
-            TransitionPartitionId::Deterministic(PartitionHashId::new(
+            &TransitionPartitionId::Deterministic(PartitionHashId::new(
                 table_id,
                 &PartitionKey::from("hello there"),
             )),

--- a/parquet_file/src/lib.rs
+++ b/parquet_file/src/lib.rs
@@ -26,17 +26,17 @@ pub mod serialize;
 pub mod storage;
 pub mod writer;
 
-use data_types::{NamespaceId, ParquetFile, ParquetFileParams, PartitionId, TableId};
+use data_types::{NamespaceId, ParquetFile, ParquetFileParams, TableId, TransitionPartitionId};
 use object_store::path::Path;
 use uuid::Uuid;
 
 /// Location of a Parquet file within a namespace's object store.
 /// The exact format is an implementation detail and is subject to change.
-#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, Ord, PartialOrd)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
 pub struct ParquetFilePath {
     namespace_id: NamespaceId,
     table_id: TableId,
-    partition_id: PartitionId,
+    partition_id: TransitionPartitionId,
     object_store_id: Uuid,
 }
 
@@ -45,7 +45,7 @@ impl ParquetFilePath {
     pub fn new(
         namespace_id: NamespaceId,
         table_id: TableId,
-        partition_id: PartitionId,
+        partition_id: TransitionPartitionId,
         object_store_id: Uuid,
     ) -> Self {
         Self {
@@ -88,12 +88,12 @@ impl ParquetFilePath {
 
 impl From<&Self> for ParquetFilePath {
     fn from(borrowed: &Self) -> Self {
-        *borrowed
+        borrowed.clone()
     }
 }
 
-impl From<(PartitionId, &crate::metadata::IoxMetadata)> for ParquetFilePath {
-    fn from((partition_id, m): (PartitionId, &crate::metadata::IoxMetadata)) -> Self {
+impl From<(TransitionPartitionId, &crate::metadata::IoxMetadata)> for ParquetFilePath {
+    fn from((partition_id, m): (TransitionPartitionId, &crate::metadata::IoxMetadata)) -> Self {
         Self {
             namespace_id: m.namespace_id,
             table_id: m.table_id,
@@ -108,7 +108,7 @@ impl From<&ParquetFile> for ParquetFilePath {
         Self {
             namespace_id: f.namespace_id,
             table_id: f.table_id,
-            partition_id: f.partition_id,
+            partition_id: f.transition_partition_id(),
             object_store_id: f.object_store_id,
         }
     }
@@ -119,7 +119,7 @@ impl From<&ParquetFileParams> for ParquetFilePath {
         Self {
             namespace_id: f.namespace_id,
             table_id: f.table_id,
-            partition_id: f.partition_id,
+            partition_id: f.transition_partition_id(),
             object_store_id: f.object_store_id,
         }
     }
@@ -128,19 +128,40 @@ impl From<&ParquetFileParams> for ParquetFilePath {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use data_types::{PartitionHashId, PartitionId, PartitionKey, TransitionPartitionId};
 
     #[test]
-    fn parquet_file_absolute_dirs_and_file_path() {
+    fn parquet_file_absolute_dirs_and_file_path_database_partition_ids() {
         let pfp = ParquetFilePath::new(
             NamespaceId::new(1),
             TableId::new(2),
-            PartitionId::new(4),
+            TransitionPartitionId::Deprecated(PartitionId::new(4)),
             Uuid::nil(),
         );
         let path = pfp.object_store_path();
         assert_eq!(
             path.to_string(),
-            "1/2/4/00000000-0000-0000-0000-000000000000.parquet".to_string(),
+            "1/2/4/00000000-0000-0000-0000-000000000000.parquet",
+        );
+    }
+
+    #[test]
+    fn parquet_file_absolute_dirs_and_file_path_deterministic_partition_ids() {
+        let table_id = TableId::new(2);
+        let pfp = ParquetFilePath::new(
+            NamespaceId::new(1),
+            table_id,
+            TransitionPartitionId::Deterministic(PartitionHashId::new(
+                table_id,
+                &PartitionKey::from("hello there"),
+            )),
+            Uuid::nil(),
+        );
+        let path = pfp.object_store_path();
+        assert_eq!(
+            path.to_string(),
+            "1/2/d10f045c8fb5589e1db57a0ab650175c422310a1474b4de619cc2ded48f65b81\
+            /00000000-0000-0000-0000-000000000000.parquet",
         );
     }
 }

--- a/parquet_file/src/metadata.rs
+++ b/parquet_file/src/metadata.rs
@@ -90,7 +90,8 @@ use base64::{prelude::BASE64_STANDARD, Engine};
 use bytes::Bytes;
 use data_types::{
     ColumnId, ColumnSet, ColumnSummary, CompactionLevel, InfluxDbType, NamespaceId,
-    ParquetFileParams, PartitionId, PartitionKey, StatValues, Statistics, TableId, Timestamp,
+    ParquetFileParams, PartitionHashId, PartitionId, PartitionKey, StatValues, Statistics, TableId,
+    Timestamp,
 };
 use generated_types::influxdata::iox::ingester::v1 as proto;
 use iox_time::Time;
@@ -434,6 +435,7 @@ impl IoxMetadata {
     pub fn to_parquet_file<F>(
         &self,
         partition_id: PartitionId,
+        partition_hash_id: Option<PartitionHashId>,
         file_size_bytes: usize,
         metadata: &IoxParquetMetaData,
         column_id_map: F,
@@ -485,6 +487,7 @@ impl IoxMetadata {
             namespace_id: self.namespace_id,
             table_id: self.table_id,
             partition_id,
+            partition_hash_id,
             object_store_id: self.object_store_id,
             min_time,
             max_time,

--- a/parquet_file/src/storage.rs
+++ b/parquet_file/src/storage.rs
@@ -223,7 +223,7 @@ impl ParquetStorage {
     pub async fn upload(
         &self,
         batches: SendableRecordBatchStream,
-        partition_id: TransitionPartitionId,
+        partition_id: &TransitionPartitionId,
         meta: &IoxMetadata,
         pool: Arc<dyn MemoryPool>,
     ) -> Result<(IoxParquetMetaData, usize), UploadError> {
@@ -345,7 +345,7 @@ mod tests {
         let batch = RecordBatch::try_from_iter([("a", to_string_array(&["value"]))]).unwrap();
 
         // Serialize & upload the record batches.
-        let (file_meta, _file_size) = upload(&store, partition_id, &meta, batch.clone()).await;
+        let (file_meta, _file_size) = upload(&store, &partition_id, &meta, batch.clone()).await;
 
         // Extract the various bits of metadata.
         let file_meta = file_meta.decode().expect("should decode parquet metadata");
@@ -491,7 +491,7 @@ mod tests {
         let schema = batch.schema();
 
         // Serialize & upload the record batches.
-        let (_iox_md, file_size) = upload(&store, partition_id.clone(), &meta, batch).await;
+        let (_iox_md, file_size) = upload(&store, &partition_id, &meta, batch).await;
 
         // add metadata to reference schema
         let schema = Arc::new(
@@ -502,7 +502,7 @@ mod tests {
         );
         download(
             &store,
-            partition_id,
+            &partition_id,
             &meta,
             Projection::All,
             schema,
@@ -534,11 +534,11 @@ mod tests {
         .unwrap();
 
         // Serialize & upload the record batches.
-        let (_iox_md, file_size) = upload(&store, partition_id.clone(), &meta, batch).await;
+        let (_iox_md, file_size) = upload(&store, &partition_id, &meta, batch).await;
 
         download(
             &store,
-            partition_id,
+            &partition_id,
             &meta,
             Projection::All,
             schema,
@@ -614,7 +614,7 @@ mod tests {
 
     async fn upload(
         store: &ParquetStorage,
-        partition_id: TransitionPartitionId,
+        partition_id: &TransitionPartitionId,
         meta: &IoxMetadata,
         batch: RecordBatch,
     ) -> (IoxParquetMetaData, usize) {
@@ -627,7 +627,7 @@ mod tests {
 
     async fn download<'a>(
         store: &ParquetStorage,
-        partition_id: TransitionPartitionId,
+        partition_id: &TransitionPartitionId,
         meta: &IoxMetadata,
         selection: Projection<'_>,
         expected_schema: SchemaRef,
@@ -656,12 +656,12 @@ mod tests {
 
         // Serialize & upload the record batches.
         let (partition_id, meta) = meta();
-        let (_iox_md, file_size) = upload(&store, partition_id.clone(), &meta, upload_batch).await;
+        let (_iox_md, file_size) = upload(&store, &partition_id, &meta, upload_batch).await;
 
         // And compare to the original input
         let actual_batch = download(
             &store,
-            partition_id,
+            &partition_id,
             &meta,
             selection,
             expected_schema,
@@ -682,12 +682,11 @@ mod tests {
         let store = ParquetStorage::new(object_store, StorageId::from("iox"));
 
         let (partition_id, meta) = meta();
-        let (_iox_md, file_size) =
-            upload(&store, partition_id.clone(), &meta, persisted_batch).await;
+        let (_iox_md, file_size) = upload(&store, &partition_id, &meta, persisted_batch).await;
 
         let err = download(
             &store,
-            partition_id,
+            &partition_id,
             &meta,
             Projection::All,
             expected_schema,

--- a/parquet_file/tests/metadata.rs
+++ b/parquet_file/tests/metadata.rs
@@ -4,7 +4,9 @@ use arrow::{
     array::{ArrayRef, StringArray, TimestampNanosecondArray},
     record_batch::RecordBatch,
 };
-use data_types::{ColumnId, CompactionLevel, NamespaceId, PartitionId, TableId, Timestamp};
+use data_types::{
+    ColumnId, CompactionLevel, NamespaceId, PartitionId, TableId, Timestamp, TransitionPartitionId,
+};
 use datafusion_util::{unbounded_memory_pool, MemoryStream};
 use iox_time::Time;
 use object_store::DynObjectStore;
@@ -44,7 +46,7 @@ async fn test_decoded_iox_metadata() {
         ),
     ];
 
-    let partition_id = PartitionId::new(4);
+    let partition_id = TransitionPartitionId::Deprecated(PartitionId::new(4));
 
     // And the metadata the batch would be encoded with if it came through the
     // IOx write path.
@@ -185,7 +187,7 @@ async fn test_empty_parquet_file_panic() {
         ("some_field", to_string_array(&[])),
     ];
 
-    let partition_id = PartitionId::new(4);
+    let partition_id = TransitionPartitionId::Deprecated(PartitionId::new(4));
 
     // And the metadata the batch would be encoded with if it came through the
     // IOx write path.
@@ -280,7 +282,7 @@ async fn test_decoded_many_columns_with_null_cols_iox_metadata() {
     }
     sort_key_data.push(TIME_COLUMN_NAME.to_string());
     let sort_key = SortKey::from_columns(sort_key_data);
-    let partition_id = PartitionId::new(4);
+    let partition_id = TransitionPartitionId::Deprecated(PartitionId::new(4));
     let meta = IoxMetadata {
         object_store_id: Default::default(),
         creation_timestamp: Time::from_timestamp_nanos(42),
@@ -367,6 +369,8 @@ async fn test_derive_parquet_file_params() {
     // And the metadata the batch would be encoded with if it came through the
     // IOx write path.
     let partition_id = PartitionId::new(4);
+    let partition_hash_id = None;
+    let transition_partition_id = TransitionPartitionId::Deprecated(partition_id);
     let meta = IoxMetadata {
         object_store_id: Default::default(),
         creation_timestamp: Time::from_timestamp_nanos(1234),
@@ -396,7 +400,12 @@ async fn test_derive_parquet_file_params() {
     let storage = ParquetStorage::new(object_store, StorageId::from("iox"));
 
     let (iox_parquet_meta, file_size) = storage
-        .upload(stream, partition_id, &meta, unbounded_memory_pool())
+        .upload(
+            stream,
+            transition_partition_id,
+            &meta,
+            unbounded_memory_pool(),
+        )
         .await
         .expect("failed to serialize & persist record batch");
 
@@ -406,9 +415,13 @@ async fn test_derive_parquet_file_params() {
         ("some_field".into(), ColumnId::new(1)),
         ("time".into(), ColumnId::new(2)),
     ]);
-    let catalog_data = meta.to_parquet_file(partition_id, file_size, &iox_parquet_meta, |name| {
-        *column_id_map.get(name).unwrap()
-    });
+    let catalog_data = meta.to_parquet_file(
+        partition_id,
+        partition_hash_id,
+        file_size,
+        &iox_parquet_meta,
+        |name| *column_id_map.get(name).unwrap(),
+    );
 
     // And verify the resulting statistics used in the catalog.
     //

--- a/parquet_file/tests/metadata.rs
+++ b/parquet_file/tests/metadata.rs
@@ -82,7 +82,7 @@ async fn test_decoded_iox_metadata() {
     let storage = ParquetStorage::new(object_store, StorageId::from("iox"));
 
     let (iox_parquet_meta, file_size) = storage
-        .upload(stream, partition_id, &meta, unbounded_memory_pool())
+        .upload(stream, &partition_id, &meta, unbounded_memory_pool())
         .await
         .expect("failed to serialize & persist record batch");
 
@@ -212,7 +212,7 @@ async fn test_empty_parquet_file_panic() {
 
     // Serialising empty data should cause a panic for human investigation.
     let err = storage
-        .upload(stream, partition_id, &meta, unbounded_memory_pool())
+        .upload(stream, &partition_id, &meta, unbounded_memory_pool())
         .await
         .expect_err("empty file should raise an error");
 
@@ -315,7 +315,7 @@ async fn test_decoded_many_columns_with_null_cols_iox_metadata() {
     let storage = ParquetStorage::new(object_store, StorageId::from("iox"));
 
     let (iox_parquet_meta, file_size) = storage
-        .upload(stream, partition_id, &meta, unbounded_memory_pool())
+        .upload(stream, &partition_id, &meta, unbounded_memory_pool())
         .await
         .expect("failed to serialize & persist record batch");
 
@@ -402,7 +402,7 @@ async fn test_derive_parquet_file_params() {
     let (iox_parquet_meta, file_size) = storage
         .upload(
             stream,
-            transition_partition_id,
+            &transition_partition_id,
             &meta,
             unbounded_memory_pool(),
         )

--- a/querier/src/cache/parquet_file.rs
+++ b/querier/src/cache/parquet_file.rs
@@ -359,8 +359,8 @@ mod tests {
         partition.create_parquet_file(builder).await;
         let table_id = table.table.id;
 
-        let single_file_size = 200;
-        let two_file_size = 368;
+        let single_file_size = 208;
+        let two_file_size = 384;
         assert!(single_file_size < two_file_size);
 
         let cache = make_cache(&catalog);

--- a/querier/src/table/test_util.rs
+++ b/querier/src/table/test_util.rs
@@ -106,6 +106,7 @@ impl IngesterPartitionBuilder {
         IngesterPartition::new(
             Uuid::new_v4(),
             self.partition.partition.id,
+            self.partition.partition.hash_id().cloned(),
             0,
             self.partition_sort_key.clone(),
             Arc::clone(&self.partition_column_ranges),

--- a/service_grpc_catalog/src/lib.rs
+++ b/service_grpc_catalog/src/lib.rs
@@ -231,6 +231,7 @@ mod tests {
                 namespace_id: namespace.id,
                 table_id: table.id,
                 partition_id: partition.id,
+                partition_hash_id: partition.hash_id().cloned(),
                 object_store_id: Uuid::new_v4(),
                 min_time: Timestamp::new(1),
                 max_time: Timestamp::new(5),

--- a/service_grpc_object_store/src/lib.rs
+++ b/service_grpc_object_store/src/lib.rs
@@ -75,7 +75,7 @@ impl object_store_service_server::ObjectStoreService for ObjectStoreService {
         let path = ParquetFilePath::new(
             parquet_file.namespace_id,
             parquet_file.table_id,
-            parquet_file.partition_id,
+            parquet_file.transition_partition_id(),
             parquet_file.object_store_id,
         );
         let path = path.object_store_path();
@@ -129,6 +129,7 @@ mod tests {
                 namespace_id: namespace.id,
                 table_id: table.id,
                 partition_id: partition.id,
+                partition_hash_id: partition.hash_id().cloned(),
                 object_store_id: Uuid::new_v4(),
                 min_time: Timestamp::new(1),
                 max_time: Timestamp::new(5),
@@ -149,7 +150,7 @@ mod tests {
         let path = ParquetFilePath::new(
             p1.namespace_id,
             p1.table_id,
-            p1.partition_id,
+            p1.transition_partition_id(),
             p1.object_store_id,
         );
         let path = path.object_store_path();

--- a/service_grpc_object_store/src/lib.rs
+++ b/service_grpc_object_store/src/lib.rs
@@ -75,7 +75,7 @@ impl object_store_service_server::ObjectStoreService for ObjectStoreService {
         let path = ParquetFilePath::new(
             parquet_file.namespace_id,
             parquet_file.table_id,
-            parquet_file.transition_partition_id(),
+            &parquet_file.transition_partition_id(),
             parquet_file.object_store_id,
         );
         let path = path.object_store_path();
@@ -150,7 +150,7 @@ mod tests {
         let path = ParquetFilePath::new(
             p1.namespace_id,
             p1.table_id,
-            p1.transition_partition_id(),
+            &p1.transition_partition_id(),
             p1.object_store_id,
         );
         let path = path.object_store_path();

--- a/test_helpers_end_to_end/src/snapshot_comparison.rs
+++ b/test_helpers_end_to_end/src/snapshot_comparison.rs
@@ -59,11 +59,11 @@ pub type Result<T, E = Error> = std::result::Result<T, E>;
 
 /// Match the parquet directory names
 /// For example, given
-/// `51/216/13452/1d325760-2b20-48de-ab48-2267b034133d.parquet`
+/// `51/216/1a3f45021a3f45021a3f45021a3f45021a3f45021a3f45021a3f45021a3f4502/1d325760-2b20-48de-ab48-2267b034133d.parquet`
 ///
-/// matches `51/216/13452`
+/// matches `51/216/1a3f45021a3f45021a3f45021a3f45021a3f45021a3f45021a3f45021a3f4502`
 pub static REGEX_DIRS: Lazy<Regex> =
-    Lazy::new(|| Regex::new(r#"([0-9])+/([0-9])+/([0-9])+"#).expect("directory regex"));
+    Lazy::new(|| Regex::new(r#"([0-9]+)/([0-9]+)/([0-9a-f]{64})"#).expect("directory regex"));
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub enum Language {
@@ -114,15 +114,10 @@ impl Language {
                             .to_string()
                         });
 
-                        let s = REGEX_DIRS.replace_all(&s, |c: &Captures<'_>| {
-                            // this ensures 15/232/5 is replaced with a string of the same width
-                            //              11/111/1
-                            [
-                                "1".repeat(c.get(1).unwrap().range().len()),
-                                "1".repeat(c.get(2).unwrap().range().len()),
-                                "1".repeat(c.get(3).unwrap().range().len()),
-                            ]
-                            .join("/")
+                        let s = REGEX_DIRS.replace_all(&s, |_c: &Captures<'_>| {
+                            // this ensures 15/232/5 is replaced with a string of a known width
+                            //              1/1/1
+                            ["1", "1", "1"].join("/")
                         });
 
                         // Need to remove trailing spaces when using no_borders


### PR DESCRIPTION
Connects to https://github.com/influxdata/idpe/issues/17476, particularly [this comment](https://github.com/influxdata/idpe/issues/17476).

And if a partition has a hash ID in the catalog, use the hash ID in that partition's object store paths for Parquet files.

I attempted to make this PR only add the hash ID to the database and not use the hash ID in the object store paths, but we decided the presence of the hash ID in the database is what's going to determine where we look for the file in object storage, so we have to do both at once.

This has some unfortunate churn because the `PartitionHashId` type is currently represented as `Arc<[u8; 32]>` which can't implement `Copy` (and `PartitionId` does implement `Copy`) so a bunch of places (like the compactor scratchpad, some places in the `parquet_file` crate) now need explicit clones. `[u8; 32]` technically _does_ implement `Copy`, but it's the amount of data that seems like it could impact performance if we `Copy` it a lot, so `Arc` seemed like the safer choice.

## Remaining work

This PR does NOT remove the catalog queries from the write path, unfortunately :( See the discussion in the issue for why we might not be able to do that until old partitions age out.

This PR also does not change how the querier collates data. The ingesters will start _sending_ the hash ID to the queriers, but the querier is not using that value yet.