### PR TITLE
chore: prune `thrift` features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5585,15 +5585,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "threadpool"
-version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
-dependencies = [
- "num_cpus",
-]
-
-[[package]]
 name = "thrift"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5601,9 +5592,7 @@ checksum = "7e54bc85fc7faa8bc175c4bab5b92ba8d9a3ce893d0e9f42cc455c8ab16a9e09"
 dependencies = [
  "byteorder",
  "integer-encoding",
- "log",
  "ordered-float 2.10.0",
- "threadpool",
 ]
 
 [[package]]
@@ -6671,7 +6660,6 @@ dependencies = [
  "strum",
  "syn 1.0.109",
  "syn 2.0.16",
- "thrift",
  "tokio",
  "tokio-stream",
  "tokio-util",

--- a/parquet_file/Cargo.toml
+++ b/parquet_file/Cargo.toml
@@ -23,7 +23,7 @@ prost = "0.11"
 schema = { path = "../schema" }
 snafu = "0.7"
 thiserror = "1.0.40"
-thrift = "0.17"
+thrift = { version = "0.17", default-features = false }
 tokio = { version = "1.28", features = ["macros", "parking_lot", "rt", "rt-multi-thread", "sync"] }
 uuid = { version = "1", features = ["v4"] }
 zstd = "0.12"

--- a/trace_exporters/Cargo.toml
+++ b/trace_exporters/Cargo.toml
@@ -13,7 +13,7 @@ futures = "0.3"
 iox_time = { path = "../iox_time" }
 observability_deps = { path = "../observability_deps" }
 snafu = "0.7"
-thrift = { version = "0.17.0" }
+thrift = { version = "0.17.0", default-features = false }
 tokio = { version = "1.28", features = ["macros", "parking_lot", "rt", "sync"] }
 trace = { path = "../trace" }
 workspace-hack = { version = "0.1", path = "../workspace-hack" }

--- a/workspace-hack/Cargo.toml
+++ b/workspace-hack/Cargo.toml
@@ -81,7 +81,6 @@ sqlparser = { version = "0.34", features = ["visitor"] }
 sqlx = { version = "0.6", features = ["json", "postgres", "runtime-tokio-rustls", "sqlite", "tls", "uuid"] }
 sqlx-core = { version = "0.6", default-features = false, features = ["any", "migrate", "postgres", "runtime-tokio-rustls", "sqlite", "uuid"] }
 strum = { version = "0.24", features = ["derive"] }
-thrift = { version = "0.17" }
 tokio = { version = "1", features = ["full", "test-util", "tracing"] }
 tokio-stream = { version = "0.1", features = ["fs", "net"] }
 tokio-util = { version = "0.7", features = ["codec", "compat", "io"] }


### PR DESCRIPTION
We don't use the `thrift` server feature.
