### PR TITLE
fix: influxdb_iox sql command warns on flight healthcheck failure

### DIFF
--- a/influxdb_iox/src/commands/sql.rs
+++ b/influxdb_iox/src/commands/sql.rs
@@ -45,7 +45,9 @@ pub type Result<T, E = Error> = std::result::Result<T, E>;
 pub async fn command(connection: Connection, config: Config) -> Result<()> {
     debug!("Starting interactive SQL prompt with {:?}", config);
 
-    check_health(connection.clone()).await?;
+    if let Err(e) = check_health(connection.clone()).await {
+        eprintln!("warning: flight healthcheck failed: {}", e);
+    }
 
     println!("Connected to IOx Server");
 


### PR DESCRIPTION
The `influxdb_iox sql` command, unlike the `influxdb_iox query` command or generally other flighsql clients, fails if the endpoint doesn't implement flight healthcheck API. 

Somtimes we serve IOx behind a reverse proxy that doesn't pass throught the flight helthcheck gRPC requests and thus we cannot use the `influxdb_iox sql` REPL because of that, which is annoying.

We _could_ fix the reverse proxy configs, but we can also decide to make `influxdb_iox sql` less skittish.
