### PR TITLE
test: Query an ingester with a predicate that should prune partitions

### DIFF
--- a/test_helpers_end_to_end/src/mini_cluster.rs
+++ b/test_helpers_end_to_end/src/mini_cluster.rs
@@ -479,6 +479,9 @@ impl MiniCluster {
 
         let mut record_batches = vec![];
         while let Some((msg, _md)) = next_message(&mut performed_query).await {
+            if matches!(msg, DecodedPayload::None | DecodedPayload::Schema(_)) {
+                continue;
+            }
             let batch = unwrap_record_batch(msg);
             record_batches.push(batch);
         }


### PR DESCRIPTION
Connects to https://github.com/influxdata/idpe/issues/17830

I was hoping I could just re-use the custom partitioning snapshot test added in https://github.com/influxdata/influxdb_iox/pull/8025, but there's lots of translation to get from SQL to an `IngesterQueryRequest`, so I used some code and data from that test.

This currently fails, as expected, because the ingester is ignoring the predicate and returning all rows. 

If I run the test with `LOG_FILTER=debug`, I do see this line as expected:

```
DEBUG ingester::server::grpc::query: ignoring query predicate (unsupported)
```