### PR TITLE
fix: don't redundantly evaluate the same partitions for compaction

### DIFF
--- a/compactor_scheduler/src/local_scheduler/partitions_source/catalog_to_compact.rs
+++ b/compactor_scheduler/src/local_scheduler/partitions_source/catalog_to_compact.rs
@@ -74,18 +74,21 @@ impl PartitionsSource for CatalogToCompactPartitionsSource {
             // we're going check the time range we'd like to query for against the end time of the last query.
             let mut last = self.last_maximum_time.lock().unwrap();
 
-            // if the last query ended further back in time than this query starts, we're about to skip something.
-            if *last < minimum_time {
-                if minimum_time.sub(*last) < self.min_threshold * 3 {
-                    // the end of the last query says we're skipping less than 3x our configured lookback, so
-                    // back up and query everything since the last query.
-                    minimum_time = *last;
-                } else {
-                    // end of the last query says we're skiping a lot.  We should limit how far we lookback to avoid
-                    // returning all partitions, so we'll just backup 3x the configured lookback.
-                    // this might skip something (until cold compaction), but we need a limit in how far we look back.
-                    minimum_time = self.time_provider.now() - self.min_threshold * 3;
-                }
+            // query for partitions with activity since the last query.  We shouldn't query for a time range
+            // we've already covered.  So if the prior query was 2m ago, and the query covered 10m, ending at
+            // the time of that query, we just need to query for activity in the last 2m.  Asking for more than
+            // that creates busy-work that will spam the catalog with more queries to determine no compaction
+            // nneded.  But we also don't want to query so far back in time that we get all partitions, so the
+            // lookback is limited to 3x the configured threshold.
+            if minimum_time < *last || minimum_time.sub(*last) < self.min_threshold * 3 {
+                // the end of the last query is less than 3x our configured lookback, so we can query everything
+                // since the last query.
+                minimum_time = *last;
+            } else {
+                // end of the last query says we're skiping a lot.  We should limit how far we lookback to avoid
+                // returning all partitions, so we'll just backup 3x the configured lookback.
+                // this might skip something (until cold compaction), but we need a limit in how far we look back.
+                minimum_time = self.time_provider.now() - self.min_threshold * 3;
             }
             maximum_time = self.max_threshold.map(|max| self.time_provider.now() - max);
 
@@ -113,6 +116,7 @@ mod tests {
     use data_types::Timestamp;
     use iox_catalog::mem::MemCatalog;
     use iox_tests::PartitionBuilder;
+    use iox_time::MockProvider;
 
     fn partition_ids(ids: &[i64]) -> Vec<PartitionId> {
         ids.iter().cloned().map(PartitionId::new).collect()
@@ -122,17 +126,18 @@ mod tests {
         catalog: Arc<MemCatalog>,
         min_threshold: Duration,
         max_threshold: Option<Duration>,
+        second_query_delta: Duration, // time between first and second query
         first_expected_ids: &[i64], // expected values on first fetch, which does a 3x on min_threshold
         second_expected_ids: &[i64], // expected values on second fetch, which uses min_threshold unmodified
     ) {
-        let time_provider = catalog.time_provider();
+        let time_provider = Arc::new(MockProvider::new(catalog.time_provider().now()));
 
         let partitions_source = CatalogToCompactPartitionsSource::new(
             Default::default(),
             catalog,
             min_threshold,
             max_threshold,
-            time_provider,
+            Arc::<iox_time::MockProvider>::clone(&time_provider),
         );
 
         let mut actual_partition_ids = partitions_source.fetch().await;
@@ -145,6 +150,7 @@ mod tests {
             max_threshold {max_threshold:?} failed (first fetch, 3x lookback)",
         );
 
+        time_provider.inc(second_query_delta);
         let mut actual_partition_ids = partitions_source.fetch().await;
         actual_partition_ids.sort();
 
@@ -163,10 +169,15 @@ mod tests {
 
         let time_three_hour_ago = Timestamp::from(time_provider.hours_ago(3));
         let time_six_hour_ago = Timestamp::from(time_provider.hours_ago(6));
+        let time_one_min_future = Timestamp::from(time_provider.minutes_into_future(1));
 
-        for (id, time) in [(1, time_three_hour_ago), (2, time_six_hour_ago)]
-            .iter()
-            .cloned()
+        for (id, time) in [
+            (1, time_three_hour_ago),
+            (2, time_six_hour_ago),
+            (3, time_one_min_future),
+        ]
+        .iter()
+        .cloned()
         {
             let partition = PartitionBuilder::new(id as i64)
                 .with_new_file_at(time)
@@ -175,13 +186,44 @@ mod tests {
         }
 
         let one_minute = Duration::from_secs(60);
-        fetch_test(Arc::clone(&catalog), one_minute, None, &[], &[]).await;
+        let ten_minute = Duration::from_secs(60) * 10;
+
+        // the lack of end time means it gets the future file (3) in the first query, this is an
+        // oddity of a test case that has files with a future timestamp (not a real world concern).
+        // the second query 10m later with a cap of 3m lookback doesn't get it.
+        fetch_test(
+            Arc::clone(&catalog),
+            one_minute,
+            None,
+            ten_minute,
+            &[3],
+            &[],
+        )
+        .await;
 
         let four_hours = Duration::from_secs(60 * 60 * 4);
-        fetch_test(Arc::clone(&catalog), four_hours, None, &[1, 2], &[1]).await;
+        // again the future file is included in he first query, just an oddity of the test case.
+        fetch_test(
+            Arc::clone(&catalog),
+            four_hours,
+            None,
+            ten_minute,
+            &[1, 2, 3],
+            &[3],
+        )
+        .await;
 
         let seven_hours = Duration::from_secs(60 * 60 * 7);
-        fetch_test(Arc::clone(&catalog), seven_hours, None, &[1, 2], &[1, 2]).await;
+        // again the future file is included in he first query, just an oddity of the test case.
+        fetch_test(
+            Arc::clone(&catalog),
+            seven_hours,
+            None,
+            ten_minute,
+            &[1, 2, 3],
+            &[3],
+        )
+        .await;
     }
 
     #[tokio::test]
@@ -192,11 +234,13 @@ mod tests {
         let time_now = Timestamp::from(time_provider.now());
         let time_three_hour_ago = Timestamp::from(time_provider.hours_ago(3));
         let time_six_hour_ago = Timestamp::from(time_provider.hours_ago(6));
+        let time_one_min_future = Timestamp::from(time_provider.minutes_into_future(1));
 
         for (id, time) in [
             (1, time_now),
             (2, time_three_hour_ago),
             (3, time_six_hour_ago),
+            (4, time_one_min_future),
         ]
         .iter()
         .cloned()
@@ -209,54 +253,80 @@ mod tests {
 
         let one_minute = Duration::from_secs(60);
         let one_hour = Duration::from_secs(60 * 60);
+        let two_hour = Duration::from_secs(60 * 60 * 2);
         let four_hours = Duration::from_secs(60 * 60 * 4);
         let seven_hours = Duration::from_secs(60 * 60 * 7);
 
+        // File 3 is all that falls within the 7-4h lookback window.  With 1m to the next query,
+        // nothing is found with windows advanced by 1m.
         fetch_test(
             Arc::clone(&catalog),
             seven_hours,
             Some(four_hours),
+            one_minute,
             &[3],
-            &[3],
+            &[],
         )
         .await;
 
+        // With a 7-1h lookback window, files 2 and 3 are found.  With 2h to the next query, the
+        // window advances to find the two newer files.
         fetch_test(
             Arc::clone(&catalog),
             seven_hours,
             Some(one_hour),
+            two_hour,
             &[2, 3],
-            &[2, 3],
+            &[1, 4],
         )
         .await;
 
+        // With a 7h-1m lookback window, files 2 and 3 are found.  With 1m to the next query, the
+        // window advances to find the one newer file.
         fetch_test(
             Arc::clone(&catalog),
             seven_hours,
             Some(one_minute),
+            one_minute,
             &[2, 3],
-            &[2, 3],
+            &[1],
         )
         .await;
 
+        // With a 4h-1h lookback window, files 2 and 3 are found.  With 1m to the next query, there's
+        // nothing new in the next window.
         fetch_test(
             Arc::clone(&catalog),
             four_hours,
             Some(one_hour),
+            one_minute,
             &[2, 3],
-            &[2],
+            &[],
         )
         .await;
 
+        // With a 4h-1m lookback window, files 2 and 3 are found.  With 4h to the next query, the
+        // remaining files are found.
         fetch_test(
             Arc::clone(&catalog),
             four_hours,
             Some(one_minute),
+            four_hours,
             &[2, 3],
-            &[2],
+            &[1, 4],
         )
         .await;
 
-        fetch_test(Arc::clone(&catalog), one_hour, Some(one_minute), &[], &[]).await;
+        // With a 1h-1m lookback window, nothing is found.  In the second query 1m later, it finds
+        // the file create 'now'.
+        fetch_test(
+            Arc::clone(&catalog),
+            one_hour,
+            Some(one_minute),
+            one_minute,
+            &[],
+            &[1],
+        )
+        .await;
     }
 }


### PR DESCRIPTION
This PR Is a followon and complementary change to https://github.com/influxdata/influxdb_iox/pull/8112 from yesterday changing the same area of code, but for a different issue.

We've seen the compactor spam the catalog with queries when its idle.  But it doesn't do this in every idle circumstance.  If it is completely idle (no partitions seeing any activity) it doesn't hit the catalog very hard.
When its mostly idle, like many partitions all receiving data trickle in, that's when the catalog may get spammed with many requests.

I believe the cause of spamming the catalog in a semi-idle state results from the hard coded 10m lookback for "hot" partitions that may need compacted.  If the compactor is idle enough that it can get through the batch of hot partitions quickly (e.g. 2m), the next query still looks back 10m.  That means most of the partitions its evaluating in the next batch are guaranteed to not need compacted because it just finished evaluating them.  I believe the catalog spam results from this redundant evaluation of partitions that are guaranteed to not need compacted.  Its a potentially large amount of busy-work to keep re-deciding that these partitions don't need compacted.

The PR I did yesterday expands the lookback to catch previously skipped partitions when the query is slow.  This PR builds on that to shrink the lookback when we know we've already evaluated those partitions.

It might be necessary to put a minimum time between the queries for hot partitions.  For example: if we're targetting a 10m definition of "hot" partitions, and capping the lookback at 30m when the partition processing is slow (per yesterday's PR), if the partition processing is fast we could make sure we wait at least 3-5m between getting batches of hot partitions.  This is probably a good thing to do, and it will be another trivial change to this same area of code, but I'm curious to see how this change performs first.

I'd be surprised if this made the idle cluster slam the catalog worse than it already does.  This PR should make the query pattern of the poorly behaved idle cluster more like the query pattern of the well behaved idle clusters.

But this can be reverted if necessary.

helps: https://github.com/influxdata/influxdb_iox/issues/7973

- [x] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb_iox/blob/main/README.md).
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
