### PR TITLE
test(e2e): ingester shutdown persist file discovery

### DIFF
--- a/influxdb_iox/tests/end_to_end_cases/querier.rs
+++ b/influxdb_iox/tests/end_to_end_cases/querier.rs
@@ -325,6 +325,7 @@ async fn query_after_shutdown_sees_new_files() {
         Step::WriteLineProtocol("bananas,tag1=A,tag2=B val=42i 123456".to_string()),
         Step::AssertNumParquetFiles { expected: 0 }, // test invariant
         Step::GracefulStopIngesters,
+        Step::AssertNumParquetFiles { expected: 1 },
         Step::Query {
             sql: "select * from bananas".to_string(),
             expected: vec![

--- a/test_helpers_end_to_end/src/config.rs
+++ b/test_helpers_end_to_end/src/config.rs
@@ -155,6 +155,16 @@ impl TestConfig {
         Self::new(ServerType::AllInOne, dsn, random_catalog_schema_name()).with_new_object_store()
     }
 
+    /// Set the number of failed ingester queries before the querier considers
+    /// the ingester to be dead.
+    pub fn with_querier_circuit_breaker_threshold(self, count: usize) -> Self {
+        assert!(count > 0);
+        self.with_env(
+            "INFLUXDB_IOX_INGESTER_CIRCUIT_BREAKER_THRESHOLD",
+            count.to_string(),
+        )
+    }
+
     /// Configure tracing capture
     pub fn with_tracing(self, udp_capture: &UdpCapture) -> Self {
         self.with_env("TRACES_EXPORTER", "jaeger")

--- a/test_helpers_end_to_end/src/mini_cluster.rs
+++ b/test_helpers_end_to_end/src/mini_cluster.rs
@@ -334,6 +334,17 @@ impl MiniCluster {
         self.ingesters = restarted;
     }
 
+    /// Gracefully stop all ingesters and wait for them to exit.
+    ///
+    /// If the shutdown does not complete within
+    /// [`GRACEFUL_SERVER_STOP_TIMEOUT`] it is killed.
+    ///
+    /// [`GRACEFUL_SERVER_STOP_TIMEOUT`]:
+    ///     crate::server_fixture::GRACEFUL_SERVER_STOP_TIMEOUT
+    pub fn gracefully_stop_ingesters(&mut self) {
+        self.ingesters = vec![];
+    }
+
     /// Restart querier.
     ///
     /// This will break all currently connected clients!

--- a/test_helpers_end_to_end/src/steps.rs
+++ b/test_helpers_end_to_end/src/steps.rs
@@ -263,6 +263,15 @@ pub enum Step {
         expected: Vec<&'static str>,
     },
 
+    /// Attempt to gracefully shutdown all running ingester instances.
+    ///
+    /// This step blocks until all ingesters have gracefully stopped, or at
+    /// least [`GRACEFUL_SERVER_STOP_TIMEOUT`] elapses before they are killed.
+    ///
+    /// [`GRACEFUL_SERVER_STOP_TIMEOUT`]:
+    ///     crate::server_fixture::GRACEFUL_SERVER_STOP_TIMEOUT
+    GracefulStopIngesters,
+
     /// Retrieve the metrics and verify the results using the provided
     /// validation function.
     ///
@@ -576,6 +585,11 @@ where
                     batches.push(RecordBatch::new_empty(schema));
                     assert_batches_sorted_eq!(expected, &batches);
                     info!("====Done running");
+                }
+                Step::GracefulStopIngesters => {
+                    info!("====Gracefully stop all ingesters");
+
+                    state.cluster_mut().gracefully_stop_ingesters();
                 }
                 Step::VerifiedMetrics(verify) => {
                     info!("====Begin validating metrics");

--- a/test_helpers_end_to_end/src/steps.rs
+++ b/test_helpers_end_to_end/src/steps.rs
@@ -157,6 +157,10 @@ pub enum Step {
     /// files from the value this step recorded.
     RecordNumParquetFiles,
 
+    /// Query the catalog service for how many parquet files it has for this
+    /// cluster's namespace, asserting the value matches expected.
+    AssertNumParquetFiles { expected: usize },
+
     /// Ask the ingester to persist immediately through the persist service gRPC API
     Persist,
 
@@ -370,6 +374,10 @@ where
                 // starting a new write so we can observe a change when waiting for persistence.
                 Step::RecordNumParquetFiles => {
                     state.record_num_parquet_files().await;
+                }
+                Step::AssertNumParquetFiles { expected } => {
+                    let have_files = state.get_num_parquet_files().await;
+                    assert_eq!(have_files, *expected);
                 }
                 // Ask the ingesters to persist immediately through the persist service gRPC API
                 Step::Persist => {


### PR DESCRIPTION
This was a quick test to confirm file discovery was working as expected after graceful shutdown of the ingesters.

---

* refactor(e2e): const server graceful stop timeout (a2f2f9ef6)
      
      Allow the timeout to be referenced in docs, and increase it a bit - it's
      it a bit close to being too low for ingester shutdown persistence to
      complete.

* feat(e2e): step to gracefully stop ingesters (c933c1532)
      
      Adds a step that gracefully stops all ingesters (stop - not restart -
      they don't come back!)

* feat(e2e): assert absolute parquet count (de9392c01)
      
      An existing pair of e2e steps allows the caller to assert an increase in
      the number of persisted parquet files, but there was no primitive to
      assert the current count.

* feat(e2e): configurable querier circuit breakers (fd15b2e71)
      
      Allow the querier's circuit breaker thresholds to be configured in test
      runs.

* amend! feat(e2e): configurable querier circuit breakers (e94536a72)
      
      feat(e2e): configurable querier circuit breakers
      
      Allow the querier's circuit breaker thresholds to be configured in test
      runs - this helps speed up tests that involve hitting offline ingesters.

* test(e2e): query shutdown-persisted files (6c5833110)
      
      Ensure buffered ingester data is persisted and remains queryable after a
      graceful ingester shutdown.