### PR TITLE
refactor: make `PartitionHashId: Copy`

### DIFF
--- a/compactor/src/components/parquet_file_sink/mock.rs
+++ b/compactor/src/components/parquet_file_sink/mock.rs
@@ -71,7 +71,7 @@ impl ParquetFileSink for MockParquetFileSink {
             namespace_id: partition.namespace_id,
             table_id: partition.table.id,
             partition_id: partition.partition_id,
-            partition_hash_id: partition.partition_hash_id.clone(),
+            partition_hash_id: partition.partition_hash_id,
             object_store_id: Uuid::from_u128(guard.len() as u128),
             min_time: Timestamp::new(0),
             max_time: Timestamp::new(0),
@@ -159,7 +159,7 @@ mod tests {
             Arc::clone(&schema),
             futures::stream::once(async move { Ok(record_batch_captured) }),
         ));
-        let partition_hash_id = partition.partition_hash_id.clone();
+        let partition_hash_id = partition.partition_hash_id;
         assert_eq!(
             sink.store(stream, Arc::clone(&partition), level, max_l0_created_at)
                 .await
@@ -223,7 +223,7 @@ mod tests {
             Arc::clone(&schema),
             futures::stream::empty(),
         ));
-        let partition_hash_id = partition.partition_hash_id.clone();
+        let partition_hash_id = partition.partition_hash_id;
         assert_eq!(
             sink.store(stream, Arc::clone(&partition), level, max_l0_created_at)
                 .await

--- a/compactor/src/components/parquet_file_sink/object_store.rs
+++ b/compactor/src/components/parquet_file_sink/object_store.rs
@@ -74,7 +74,7 @@ impl ParquetFileSink for ObjectStoreParquetFileSink {
         let pool = Arc::clone(&self.pool);
         let (parquet_meta, file_size) = match self
             .store
-            .upload(stream, &partition.transition_partition_id(), &meta, pool)
+            .upload(stream, partition.transition_partition_id(), &meta, pool)
             .await
         {
             Ok(v) => v,
@@ -93,7 +93,7 @@ impl ParquetFileSink for ObjectStoreParquetFileSink {
 
         let parquet_file = meta.to_parquet_file(
             partition.partition_id,
-            partition.partition_hash_id.clone(),
+            partition.partition_hash_id,
             file_size,
             &parquet_meta,
             |name| {

--- a/compactor/src/components/partition_info_source/sub_sources.rs
+++ b/compactor/src/components/partition_info_source/sub_sources.rs
@@ -98,7 +98,7 @@ where
 
         Ok(Arc::new(PartitionInfo {
             partition_id,
-            partition_hash_id: partition.hash_id().cloned(),
+            partition_hash_id: partition.hash_id(),
             namespace_id: table.namespace_id,
             namespace_name: namespace.name,
             table: Arc::new(table),

--- a/compactor/src/components/scratchpad/test_util.rs
+++ b/compactor/src/components/scratchpad/test_util.rs
@@ -23,7 +23,7 @@ pub fn file_path(i: u128) -> ParquetFilePath {
     ParquetFilePath::new(
         NamespaceId::new(1),
         TableId::new(1),
-        &TransitionPartitionId::Deprecated(PartitionId::new(1)),
+        TransitionPartitionId::Deprecated(PartitionId::new(1)),
         Uuid::from_u128(i),
     )
 }

--- a/compactor/src/partition_info.rs
+++ b/compactor/src/partition_info.rs
@@ -46,7 +46,6 @@ impl PartitionInfo {
     /// the database-assigned `PartitionId`.
     pub fn transition_partition_id(&self) -> TransitionPartitionId {
         self.partition_hash_id
-            .clone()
             .map(TransitionPartitionId::Deterministic)
             .unwrap_or_else(|| TransitionPartitionId::Deprecated(self.partition_id))
     }

--- a/compactor_test_utils/src/lib.rs
+++ b/compactor_test_utils/src/lib.rs
@@ -565,7 +565,7 @@ impl<const WITH_FILES: bool> TestSetupBuilder<WITH_FILES> {
     pub async fn build(self) -> TestSetup {
         let candidate_partition = Arc::new(PartitionInfo {
             partition_id: self.partition.partition.id,
-            partition_hash_id: self.partition.partition.hash_id().cloned(),
+            partition_hash_id: self.partition.partition.hash_id(),
             namespace_id: self.ns.namespace.id,
             namespace_name: self.ns.namespace.name.clone(),
             table: Arc::new(self.table.table.clone()),

--- a/compactor_test_utils/src/simulator.rs
+++ b/compactor_test_utils/src/simulator.rs
@@ -203,7 +203,7 @@ impl SimulatedFile {
             namespace_id: partition_info.namespace_id,
             table_id: partition_info.table.id,
             partition_id: partition_info.partition_id,
-            partition_hash_id: partition_info.partition_hash_id.clone(),
+            partition_hash_id: partition_info.partition_hash_id,
             object_store_id: Uuid::new_v4(),
             min_time,
             max_time,

--- a/data_types/src/lib.rs
+++ b/data_types/src/lib.rs
@@ -607,7 +607,6 @@ impl ParquetFile {
     /// Otherwise, use the database-assigned `PartitionId`.
     pub fn transition_partition_id(&self) -> TransitionPartitionId {
         self.partition_hash_id
-            .clone()
             .map(TransitionPartitionId::Deterministic)
             .unwrap_or_else(|| TransitionPartitionId::Deprecated(self.partition_id))
     }
@@ -665,7 +664,6 @@ impl ParquetFileParams {
     /// Otherwise, use the database-assigned `PartitionId`.
     pub fn transition_partition_id(&self) -> TransitionPartitionId {
         self.partition_hash_id
-            .clone()
             .map(TransitionPartitionId::Deterministic)
             .unwrap_or_else(|| TransitionPartitionId::Deprecated(self.partition_id))
     }

--- a/garbage_collector/src/objectstore/checker.rs
+++ b/garbage_collector/src/objectstore/checker.rs
@@ -268,7 +268,7 @@ mod tests {
             namespace_id: namespace.id,
             table_id: partition.table_id,
             partition_id: partition.id,
-            partition_hash_id: partition.hash_id().cloned(),
+            partition_hash_id: partition.hash_id(),
             object_store_id: Uuid::new_v4(),
             min_time: Timestamp::new(1),
             max_time: Timestamp::new(10),
@@ -298,7 +298,7 @@ mod tests {
         let location = ParquetFilePath::new(
             file_in_catalog.namespace_id,
             file_in_catalog.table_id,
-            &file_in_catalog.transition_partition_id(),
+            file_in_catalog.transition_partition_id(),
             file_in_catalog.object_store_id,
         )
         .object_store_path();
@@ -327,7 +327,7 @@ mod tests {
         let location = ParquetFilePath::new(
             NamespaceId::new(1),
             TableId::new(2),
-            &TransitionPartitionId::Deprecated(PartitionId::new(4)),
+            TransitionPartitionId::Deprecated(PartitionId::new(4)),
             Uuid::new_v4(),
         )
         .object_store_path();
@@ -376,7 +376,7 @@ mod tests {
         let location = ParquetFilePath::new(
             file_in_catalog.namespace_id,
             file_in_catalog.table_id,
-            &file_in_catalog.transition_partition_id(),
+            file_in_catalog.transition_partition_id(),
             file_in_catalog.object_store_id,
         )
         .object_store_path();
@@ -405,7 +405,7 @@ mod tests {
         let location = ParquetFilePath::new(
             NamespaceId::new(1),
             TableId::new(2),
-            &TransitionPartitionId::Deprecated(PartitionId::new(4)),
+            TransitionPartitionId::Deprecated(PartitionId::new(4)),
             Uuid::new_v4(),
         )
         .object_store_path();
@@ -469,7 +469,7 @@ mod tests {
         let loc = ParquetFilePath::new(
             file_in_catalog.namespace_id,
             file_in_catalog.table_id,
-            &file_in_catalog.transition_partition_id(),
+            file_in_catalog.transition_partition_id(),
             file_in_catalog.object_store_id,
         )
         .object_store_path();

--- a/garbage_collector/src/objectstore/deleter.rs
+++ b/garbage_collector/src/objectstore/deleter.rs
@@ -147,7 +147,7 @@ mod tests {
         ParquetFilePath::new(
             NamespaceId::new(1),
             TableId::new(2),
-            &TransitionPartitionId::Deprecated(PartitionId::new(4)),
+            TransitionPartitionId::Deprecated(PartitionId::new(4)),
             Uuid::new_v4(),
         )
         .object_store_path()

--- a/ingester/src/buffer_tree/partition.rs
+++ b/ingester/src/buffer_tree/partition.rs
@@ -286,13 +286,12 @@ impl PartitionData {
         self.partition_id
     }
 
-    pub(crate) fn partition_hash_id(&self) -> Option<&PartitionHashId> {
-        self.partition_hash_id.as_ref()
+    pub(crate) fn partition_hash_id(&self) -> Option<PartitionHashId> {
+        self.partition_hash_id
     }
 
     pub(crate) fn transition_partition_id(&self) -> TransitionPartitionId {
         self.partition_hash_id
-            .clone()
             .map(TransitionPartitionId::Deterministic)
             .unwrap_or_else(|| TransitionPartitionId::Deprecated(self.partition_id))
     }

--- a/ingester/src/buffer_tree/partition/resolver/cache.rs
+++ b/ingester/src/buffer_tree/partition/resolver/cache.rs
@@ -106,7 +106,7 @@ impl<T> PartitionCache<T> {
             HashMap::<PartitionKey, HashMap<TableId, (PartitionId, Option<PartitionHashId>)>>::new(
             );
         for p in partitions.into_iter() {
-            let hash_id = p.hash_id().cloned();
+            let hash_id = p.hash_id();
             entries
                 .entry(p.partition_key)
                 .or_default()

--- a/ingester/src/buffer_tree/partition/resolver/catalog.rs
+++ b/ingester/src/buffer_tree/partition/resolver/catalog.rs
@@ -78,7 +78,7 @@ impl PartitionProvider for CatalogPartitionResolver {
 
         Arc::new(Mutex::new(PartitionData::new(
             p.id,
-            p.hash_id().cloned(),
+            p.hash_id(),
             // Use the caller's partition key instance, as it MAY be shared with
             // other instance, but the instance returned from the catalog
             // definitely has no other refs.

--- a/ingester/src/buffer_tree/table.rs
+++ b/ingester/src/buffer_tree/table.rs
@@ -277,7 +277,7 @@ where
                 let mut p = p.lock();
                 (
                     p.partition_id(),
-                    p.partition_hash_id().cloned(),
+                    p.partition_hash_id(),
                     p.completed_persistence_count(),
                     p.get_query_data(),
                     p.partition_key().clone(),

--- a/ingester/src/persist/context.rs
+++ b/ingester/src/persist/context.rs
@@ -161,7 +161,7 @@ impl Context {
                 namespace_id: guard.namespace_id(),
                 table_id: guard.table_id(),
                 partition_id,
-                partition_hash_id: guard.partition_hash_id().cloned(),
+                partition_hash_id: guard.partition_hash_id(),
                 partition_key: guard.partition_key().clone(),
                 namespace_name: Arc::clone(guard.namespace_name()),
                 table: Arc::clone(guard.table()),
@@ -297,12 +297,11 @@ impl Context {
     }
 
     pub(super) fn partition_hash_id(&self) -> Option<PartitionHashId> {
-        self.partition_hash_id.clone()
+        self.partition_hash_id
     }
 
     pub(super) fn transition_partition_id(&self) -> TransitionPartitionId {
         self.partition_hash_id
-            .clone()
             .map(TransitionPartitionId::Deterministic)
             .unwrap_or_else(|| TransitionPartitionId::Deprecated(self.partition_id))
     }

--- a/ingester/src/persist/mod.rs
+++ b/ingester/src/persist/mod.rs
@@ -441,7 +441,7 @@ mod tests {
         let want_path = ParquetFilePath::new(
             namespace_id,
             table_id,
-            &transition_partition_id,
+            transition_partition_id,
             object_store_id,
         )
         .object_store_path();

--- a/ingester/src/persist/worker.rs
+++ b/ingester/src/persist/worker.rs
@@ -280,7 +280,7 @@ where
         .store
         .upload(
             record_stream,
-            &ctx.transition_partition_id(),
+            ctx.transition_partition_id(),
             &iox_metadata,
             pool,
         )

--- a/ingester/src/query/partition_response.rs
+++ b/ingester/src/query/partition_response.rs
@@ -40,8 +40,8 @@ impl PartitionResponse {
         self.id
     }
 
-    pub(crate) fn partition_hash_id(&self) -> Option<&PartitionHashId> {
-        self.partition_hash_id.as_ref()
+    pub(crate) fn partition_hash_id(&self) -> Option<PartitionHashId> {
+        self.partition_hash_id
     }
 
     pub(crate) fn completed_persistence_count(&self) -> u64 {

--- a/ingester/src/query/result_instrumentation.rs
+++ b/ingester/src/query/result_instrumentation.rs
@@ -333,7 +333,7 @@ where
 
                 // Extract all the fields of the PartitionResponse
                 let id = p.id();
-                let hash_id = p.partition_hash_id().cloned();
+                let hash_id = p.partition_hash_id();
                 let persist_count = p.completed_persistence_count();
 
                 // And wrap the underlying stream of RecordBatch for this

--- a/ingester/src/server/grpc/query.rs
+++ b/ingester/src/server/grpc/query.rs
@@ -349,7 +349,7 @@ fn encode_response(
 ) -> impl Stream<Item = Result<FlightData, FlightError>> {
     response.into_partition_stream().flat_map(move |partition| {
         let partition_id = partition.id();
-        let partition_hash_id = partition.partition_hash_id().cloned();
+        let partition_hash_id = partition.partition_hash_id();
         let completed_persistence_count = partition.completed_persistence_count();
 
         // prefix payload data w/ metadata for that particular partition
@@ -474,7 +474,7 @@ mod tests {
                         batch4.clone(),
                     ],
                     PartitionId::new(2),
-                    partition_hash_id.clone(),
+                    partition_hash_id,
                     42,
                 )]),
             )))),

--- a/iox_catalog/src/interface.rs
+++ b/iox_catalog/src/interface.rs
@@ -375,7 +375,7 @@ pub trait PartitionRepo: Send + Sync {
     /// get partition by deterministic hash ID
     async fn get_by_hash_id(
         &mut self,
-        partition_hash_id: &PartitionHashId,
+        partition_hash_id: PartitionHashId,
     ) -> Result<Option<Partition>>;
 
     /// return the partitions by table id
@@ -1513,7 +1513,7 @@ pub(crate) mod test_helpers {
             .is_none());
         assert!(repos
             .partitions()
-            .get_by_hash_id(&PartitionHashId::new(
+            .get_by_hash_id(PartitionHashId::new(
                 TableId::new(i64::MAX),
                 &PartitionKey::from("arbitrary")
             ))

--- a/iox_catalog/src/lib.rs
+++ b/iox_catalog/src/lib.rs
@@ -334,7 +334,7 @@ pub mod test_helpers {
             namespace_id: namespace.id,
             table_id: table.id,
             partition_id: partition.id,
-            partition_hash_id: partition.hash_id().cloned(),
+            partition_hash_id: partition.hash_id(),
             object_store_id: Uuid::new_v4(),
             min_time: Timestamp::new(1),
             max_time: Timestamp::new(10),

--- a/iox_catalog/src/mem.rs
+++ b/iox_catalog/src/mem.rs
@@ -588,7 +588,7 @@ impl PartitionRepo for MemTxn {
 
     async fn get_by_hash_id(
         &mut self,
-        partition_hash_id: &PartitionHashId,
+        partition_hash_id: PartitionHashId,
     ) -> Result<Option<Partition>> {
         let stage = self.stage();
 

--- a/iox_catalog/src/metrics.rs
+++ b/iox_catalog/src/metrics.rs
@@ -171,7 +171,7 @@ decorate!(
     methods = [
         "partition_create_or_get" = create_or_get(&mut self, key: PartitionKey, table_id: TableId) -> Result<Partition>;
         "partition_get_by_id" = get_by_id(&mut self, partition_id: PartitionId) -> Result<Option<Partition>>;
-        "partition_get_by_hash_id" = get_by_hash_id(&mut self, partition_hash_id: &PartitionHashId) -> Result<Option<Partition>>;
+        "partition_get_by_hash_id" = get_by_hash_id(&mut self, partition_hash_id: PartitionHashId) -> Result<Option<Partition>>;
         "partition_list_by_table_id" = list_by_table_id(&mut self, table_id: TableId) -> Result<Vec<Partition>>;
         "partition_list_ids" = list_ids(&mut self) -> Result<Vec<PartitionId>>;
         "partition_update_sort_key" = cas_sort_key(&mut self, partition_id: PartitionId, old_sort_key: Option<Vec<String>>, new_sort_key: &[&str]) -> Result<Partition, CasFailure<Vec<String>>>;

--- a/iox_catalog/src/postgres.rs
+++ b/iox_catalog/src/postgres.rs
@@ -1060,7 +1060,7 @@ RETURNING id, hash_id, table_id, partition_key, sort_key, new_file_at;
         .bind(key) // $1
         .bind(TRANSITION_SHARD_ID) // $2
         .bind(table_id) // $3
-        .bind(&hash_id) // $4
+        .bind(hash_id) // $4
         .fetch_one(&mut self.inner)
         .await
         .map_err(|e| {
@@ -1097,7 +1097,7 @@ WHERE id = $1;
 
     async fn get_by_hash_id(
         &mut self,
-        partition_hash_id: &PartitionHashId,
+        partition_hash_id: PartitionHashId,
     ) -> Result<Option<Partition>> {
         let rec = sqlx::query_as::<_, Partition>(
             r#"
@@ -1950,7 +1950,7 @@ mod tests {
             .await
             .expect("should create OK");
 
-        assert_eq!(a.hash_id().unwrap(), &hash_id);
+        assert_eq!(a.hash_id().unwrap(), hash_id);
 
         // Call create_or_get for the same (key, table_id) pair, to ensure the write is idempotent.
         let b = repos
@@ -1970,7 +1970,7 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(table_partitions.len(), 1);
-        assert_eq!(table_partitions[0].hash_id().unwrap(), &hash_id);
+        assert_eq!(table_partitions[0].hash_id().unwrap(), hash_id);
     }
 
     #[tokio::test]

--- a/iox_catalog/src/sqlite.rs
+++ b/iox_catalog/src/sqlite.rs
@@ -856,7 +856,7 @@ RETURNING id, hash_id, table_id, partition_key, sort_key, new_file_at;
         .bind(key) // $1
         .bind(TRANSITION_SHARD_ID) // $2
         .bind(table_id) // $3
-        .bind(&hash_id) // $4
+        .bind(hash_id) // $4
         .fetch_one(self.inner.get_mut())
         .await
         .map_err(|e| {
@@ -893,7 +893,7 @@ WHERE id = $1;
 
     async fn get_by_hash_id(
         &mut self,
-        partition_hash_id: &PartitionHashId,
+        partition_hash_id: PartitionHashId,
     ) -> Result<Option<Partition>> {
         let rec = sqlx::query_as::<_, PartitionPod>(
             r#"
@@ -1652,7 +1652,7 @@ mod tests {
             .await
             .expect("should create OK");
 
-        assert_eq!(a.hash_id().unwrap(), &hash_id);
+        assert_eq!(a.hash_id().unwrap(), hash_id);
 
         // Call create_or_get for the same (key, table_id) pair, to ensure the write is idempotent.
         let b = repos
@@ -1672,7 +1672,7 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(table_partitions.len(), 1);
-        assert_eq!(table_partitions[0].hash_id().unwrap(), &hash_id);
+        assert_eq!(table_partitions[0].hash_id().unwrap(), hash_id);
     }
 
     #[tokio::test]

--- a/iox_tests/src/catalog.rs
+++ b/iox_tests/src/catalog.rs
@@ -525,7 +525,7 @@ impl TestPartition {
                 Arc::clone(&self.catalog.object_store),
                 StorageId::from("iox"),
             ),
-            &self.partition.transition_partition_id(),
+            self.partition.transition_partition_id(),
             &metadata,
             record_batch.clone(),
         )
@@ -599,7 +599,7 @@ impl TestPartition {
             namespace_id: self.namespace.namespace.id,
             table_id: self.table.table.id,
             partition_id: self.partition.id,
-            partition_hash_id: self.partition.hash_id().cloned(),
+            partition_hash_id: self.partition.hash_id(),
             object_store_id: object_store_id.unwrap_or_else(Uuid::new_v4),
             min_time: Timestamp::new(min_time),
             max_time: Timestamp::new(max_time),
@@ -813,7 +813,7 @@ async fn update_catalog_sort_key_if_needed(
 /// Create parquet file and return file size.
 async fn create_parquet_file(
     store: ParquetStorage,
-    partition_id: &TransitionPartitionId,
+    partition_id: TransitionPartitionId,
     metadata: &IoxMetadata,
     record_batch: RecordBatch,
 ) -> usize {

--- a/parquet_file/src/lib.rs
+++ b/parquet_file/src/lib.rs
@@ -33,6 +33,7 @@ use uuid::Uuid;
 /// Location of a Parquet file within a namespace's object store.
 /// The exact format is an implementation detail and is subject to change.
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
+#[allow(missing_copy_implementations)]
 pub struct ParquetFilePath {
     namespace_id: NamespaceId,
     table_id: TableId,
@@ -45,13 +46,13 @@ impl ParquetFilePath {
     pub fn new(
         namespace_id: NamespaceId,
         table_id: TableId,
-        partition_id: &TransitionPartitionId,
+        partition_id: TransitionPartitionId,
         object_store_id: Uuid,
     ) -> Self {
         Self {
             namespace_id,
             table_id,
-            partition_id: partition_id.clone(),
+            partition_id,
             object_store_id,
         }
     }
@@ -92,12 +93,12 @@ impl From<&Self> for ParquetFilePath {
     }
 }
 
-impl From<(&TransitionPartitionId, &crate::metadata::IoxMetadata)> for ParquetFilePath {
-    fn from((partition_id, m): (&TransitionPartitionId, &crate::metadata::IoxMetadata)) -> Self {
+impl From<(TransitionPartitionId, &crate::metadata::IoxMetadata)> for ParquetFilePath {
+    fn from((partition_id, m): (TransitionPartitionId, &crate::metadata::IoxMetadata)) -> Self {
         Self {
             namespace_id: m.namespace_id,
             table_id: m.table_id,
-            partition_id: partition_id.clone(),
+            partition_id,
             object_store_id: m.object_store_id,
         }
     }
@@ -135,7 +136,7 @@ mod tests {
         let pfp = ParquetFilePath::new(
             NamespaceId::new(1),
             TableId::new(2),
-            &TransitionPartitionId::Deprecated(PartitionId::new(4)),
+            TransitionPartitionId::Deprecated(PartitionId::new(4)),
             Uuid::nil(),
         );
         let path = pfp.object_store_path();
@@ -151,7 +152,7 @@ mod tests {
         let pfp = ParquetFilePath::new(
             NamespaceId::new(1),
             table_id,
-            &TransitionPartitionId::Deterministic(PartitionHashId::new(
+            TransitionPartitionId::Deterministic(PartitionHashId::new(
                 table_id,
                 &PartitionKey::from("hello there"),
             )),

--- a/parquet_file/src/storage.rs
+++ b/parquet_file/src/storage.rs
@@ -223,7 +223,7 @@ impl ParquetStorage {
     pub async fn upload(
         &self,
         batches: SendableRecordBatchStream,
-        partition_id: &TransitionPartitionId,
+        partition_id: TransitionPartitionId,
         meta: &IoxMetadata,
         pool: Arc<dyn MemoryPool>,
     ) -> Result<(IoxParquetMetaData, usize), UploadError> {
@@ -345,7 +345,7 @@ mod tests {
         let batch = RecordBatch::try_from_iter([("a", to_string_array(&["value"]))]).unwrap();
 
         // Serialize & upload the record batches.
-        let (file_meta, _file_size) = upload(&store, &partition_id, &meta, batch.clone()).await;
+        let (file_meta, _file_size) = upload(&store, partition_id, &meta, batch.clone()).await;
 
         // Extract the various bits of metadata.
         let file_meta = file_meta.decode().expect("should decode parquet metadata");
@@ -491,7 +491,7 @@ mod tests {
         let schema = batch.schema();
 
         // Serialize & upload the record batches.
-        let (_iox_md, file_size) = upload(&store, &partition_id, &meta, batch).await;
+        let (_iox_md, file_size) = upload(&store, partition_id, &meta, batch).await;
 
         // add metadata to reference schema
         let schema = Arc::new(
@@ -502,7 +502,7 @@ mod tests {
         );
         download(
             &store,
-            &partition_id,
+            partition_id,
             &meta,
             Projection::All,
             schema,
@@ -534,11 +534,11 @@ mod tests {
         .unwrap();
 
         // Serialize & upload the record batches.
-        let (_iox_md, file_size) = upload(&store, &partition_id, &meta, batch).await;
+        let (_iox_md, file_size) = upload(&store, partition_id, &meta, batch).await;
 
         download(
             &store,
-            &partition_id,
+            partition_id,
             &meta,
             Projection::All,
             schema,
@@ -614,7 +614,7 @@ mod tests {
 
     async fn upload(
         store: &ParquetStorage,
-        partition_id: &TransitionPartitionId,
+        partition_id: TransitionPartitionId,
         meta: &IoxMetadata,
         batch: RecordBatch,
     ) -> (IoxParquetMetaData, usize) {
@@ -627,7 +627,7 @@ mod tests {
 
     async fn download<'a>(
         store: &ParquetStorage,
-        partition_id: &TransitionPartitionId,
+        partition_id: TransitionPartitionId,
         meta: &IoxMetadata,
         selection: Projection<'_>,
         expected_schema: SchemaRef,
@@ -656,12 +656,12 @@ mod tests {
 
         // Serialize & upload the record batches.
         let (partition_id, meta) = meta();
-        let (_iox_md, file_size) = upload(&store, &partition_id, &meta, upload_batch).await;
+        let (_iox_md, file_size) = upload(&store, partition_id, &meta, upload_batch).await;
 
         // And compare to the original input
         let actual_batch = download(
             &store,
-            &partition_id,
+            partition_id,
             &meta,
             selection,
             expected_schema,
@@ -682,11 +682,11 @@ mod tests {
         let store = ParquetStorage::new(object_store, StorageId::from("iox"));
 
         let (partition_id, meta) = meta();
-        let (_iox_md, file_size) = upload(&store, &partition_id, &meta, persisted_batch).await;
+        let (_iox_md, file_size) = upload(&store, partition_id, &meta, persisted_batch).await;
 
         let err = download(
             &store,
-            &partition_id,
+            partition_id,
             &meta,
             Projection::All,
             expected_schema,

--- a/parquet_file/tests/metadata.rs
+++ b/parquet_file/tests/metadata.rs
@@ -82,7 +82,7 @@ async fn test_decoded_iox_metadata() {
     let storage = ParquetStorage::new(object_store, StorageId::from("iox"));
 
     let (iox_parquet_meta, file_size) = storage
-        .upload(stream, &partition_id, &meta, unbounded_memory_pool())
+        .upload(stream, partition_id, &meta, unbounded_memory_pool())
         .await
         .expect("failed to serialize & persist record batch");
 
@@ -212,7 +212,7 @@ async fn test_empty_parquet_file_panic() {
 
     // Serialising empty data should cause a panic for human investigation.
     let err = storage
-        .upload(stream, &partition_id, &meta, unbounded_memory_pool())
+        .upload(stream, partition_id, &meta, unbounded_memory_pool())
         .await
         .expect_err("empty file should raise an error");
 
@@ -315,7 +315,7 @@ async fn test_decoded_many_columns_with_null_cols_iox_metadata() {
     let storage = ParquetStorage::new(object_store, StorageId::from("iox"));
 
     let (iox_parquet_meta, file_size) = storage
-        .upload(stream, &partition_id, &meta, unbounded_memory_pool())
+        .upload(stream, partition_id, &meta, unbounded_memory_pool())
         .await
         .expect("failed to serialize & persist record batch");
 
@@ -402,7 +402,7 @@ async fn test_derive_parquet_file_params() {
     let (iox_parquet_meta, file_size) = storage
         .upload(
             stream,
-            &transition_partition_id,
+            transition_partition_id,
             &meta,
             unbounded_memory_pool(),
         )

--- a/querier/src/cache/parquet_file.rs
+++ b/querier/src/cache/parquet_file.rs
@@ -361,8 +361,8 @@ mod tests {
         partition.create_parquet_file(builder).await;
         let table_id = table.table.id;
 
-        let single_file_size = 208;
-        let two_file_size = 384;
+        let single_file_size = 232;
+        let two_file_size = 432;
         assert!(single_file_size < two_file_size);
 
         let cache = make_cache(&catalog);

--- a/querier/src/table/test_util.rs
+++ b/querier/src/table/test_util.rs
@@ -105,7 +105,7 @@ impl IngesterPartitionBuilder {
         let mut part = IngesterPartition::new(
             Uuid::new_v4(),
             self.partition.partition.id,
-            self.partition.partition.hash_id().cloned(),
+            self.partition.partition.hash_id(),
             0,
         )
         .try_add_chunk(

--- a/service_grpc_catalog/src/lib.rs
+++ b/service_grpc_catalog/src/lib.rs
@@ -231,7 +231,7 @@ mod tests {
                 namespace_id: namespace.id,
                 table_id: table.id,
                 partition_id: partition.id,
-                partition_hash_id: partition.hash_id().cloned(),
+                partition_hash_id: partition.hash_id(),
                 object_store_id: Uuid::new_v4(),
                 min_time: Timestamp::new(1),
                 max_time: Timestamp::new(5),

--- a/service_grpc_object_store/src/lib.rs
+++ b/service_grpc_object_store/src/lib.rs
@@ -75,7 +75,7 @@ impl object_store_service_server::ObjectStoreService for ObjectStoreService {
         let path = ParquetFilePath::new(
             parquet_file.namespace_id,
             parquet_file.table_id,
-            &parquet_file.transition_partition_id(),
+            parquet_file.transition_partition_id(),
             parquet_file.object_store_id,
         );
         let path = path.object_store_path();
@@ -129,7 +129,7 @@ mod tests {
                 namespace_id: namespace.id,
                 table_id: table.id,
                 partition_id: partition.id,
-                partition_hash_id: partition.hash_id().cloned(),
+                partition_hash_id: partition.hash_id(),
                 object_store_id: Uuid::new_v4(),
                 min_time: Timestamp::new(1),
                 max_time: Timestamp::new(5),
@@ -150,7 +150,7 @@ mod tests {
         let path = ParquetFilePath::new(
             p1.namespace_id,
             p1.table_id,
-            &p1.transition_partition_id(),
+            p1.transition_partition_id(),
             p1.object_store_id,
         );
         let path = path.object_store_path();


### PR DESCRIPTION
The hash is 256 bits. Rustc recommends implementing `Copy` for this size:

<https://github.com/rust-lang/rust/blob/b7bc6f88ac771e1197ac9e06bf20586eeb5d0bdf/compiler/rustc_lint/src/builtin.rs#L724-L725>

Going through an `Arc` is counterproductive here because you need to perform pointer chasing (= cache miss) and clones need atomic operations which are not free.

Furthermore the handling of non-`Clone` IDs is quite a PAIN as the code simplifications in the commit demonstrate.
