### PR TITLE
feat(ingester): Drop WAL segments once all writes in it are persistent

### DIFF
--- a/ingester/src/dml_payload/ingest_op.rs
+++ b/ingester/src/dml_payload/ingest_op.rs
@@ -1,4 +1,4 @@
-use data_types::NamespaceId;
+use data_types::{sequence_number_set::SequenceNumberSet, NamespaceId};
 use trace::ctx::SpanContext;
 
 use super::write::WriteOperation;
@@ -23,6 +23,16 @@ impl IngestOp {
     pub fn span_context(&self) -> Option<&SpanContext> {
         match self {
             Self::Write(w) => w.span_context(),
+        }
+    }
+
+    /// The [`SequenceNumberSet`] the [`IngestOp`] maps to.
+    pub fn sequence_number_set(&self) -> SequenceNumberSet {
+        match self {
+            Self::Write(w) => w
+                .tables()
+                .map(|(_, t)| t.partitioned_data().sequence_number())
+                .collect(),
         }
     }
 }

--- a/ingester/src/init.rs
+++ b/ingester/src/init.rs
@@ -360,6 +360,7 @@ where
                         &metrics,
                     ),
                     Arc::clone(&wal),
+                    Arc::clone(&wal_reference_handle),
                 ),
                 "wal",
             ),

--- a/ingester/src/init/graceful_shutdown.rs
+++ b/ingester/src/init/graceful_shutdown.rs
@@ -105,6 +105,8 @@ pub(super) async fn graceful_shutdown_handler<F, T, P>(
     //
     //  https://github.com/influxdata/influxdb_iox/issues/6566
     //
+    // TODO(savage): Remove this once the WAL reference tracker is hooked up.
+    //               Should this drop the reference to the handle?
     wal.rotate().expect("failed to rotate wal");
     for file in wal.closed_segments() {
         if let Err(error) = wal.delete(file.id()).await {

--- a/ingester/src/init/wal_replay.rs
+++ b/ingester/src/init/wal_replay.rs
@@ -285,7 +285,7 @@ mod tests {
             ARBITRARY_NAMESPACE_ID, ARBITRARY_PARTITION_ID, ARBITRARY_PARTITION_KEY,
             ARBITRARY_TABLE_ID, ARBITRARY_TABLE_NAME,
         },
-        wal::wal_sink::WalSink,
+        wal::wal_sink::{mock::MockUnbufferedWriteNotifier, WalSink},
     };
 
     use super::*;
@@ -377,8 +377,13 @@ mod tests {
             let wal = Wal::new(dir.path())
                 .await
                 .expect("failed to initialise WAL");
+            let notifier_handle = Arc::new(MockUnbufferedWriteNotifier::default());
 
-            let wal_sink = WalSink::new(Arc::clone(&inner), Arc::clone(&wal));
+            let wal_sink = WalSink::new(
+                Arc::clone(&inner),
+                Arc::clone(&wal),
+                Arc::clone(&notifier_handle),
+            );
 
             // Apply the first op through the decorator
             wal_sink

--- a/ingester/src/persist/completion_observer.rs
+++ b/ingester/src/persist/completion_observer.rs
@@ -5,6 +5,8 @@ use data_types::{
     sequence_number_set::SequenceNumberSet, NamespaceId, ParquetFileParams, PartitionId, TableId,
 };
 
+use crate::wal::reference_tracker::WalReferenceHandle;
+
 /// An abstract observer of persistence completion events.
 ///
 /// This call is made synchronously by the persist worker, after
@@ -123,6 +125,13 @@ where
 {
     async fn persist_complete(&self, note: Arc<CompletedPersist>) {
         (**self).persist_complete(note).await
+    }
+}
+
+#[async_trait]
+impl PersistCompletionObserver for WalReferenceHandle {
+    async fn persist_complete(&self, note: Arc<CompletedPersist>) {
+        self.enqueue_persist_notification(note).await
     }
 }
 

--- a/ingester/src/wal/rotate_task.rs
+++ b/ingester/src/wal/rotate_task.rs
@@ -4,12 +4,15 @@ use std::{sync::Arc, time::Duration};
 use crate::{
     partition_iter::PartitionIter,
     persist::{drain_buffer::persist_partitions, queue::PersistQueue},
+    wal::reference_tracker::WalReferenceHandle,
 };
 
-/// Rotate the `wal` segment file every `period` duration of time.
+/// Rotate the `wal` segment file every `period` duration of time, notifying
+/// the [`WalReferenceHandle`].
 pub(crate) async fn periodic_rotation<T, P>(
     wal: Arc<wal::Wal>,
     period: Duration,
+    wal_reference_handle: Arc<WalReferenceHandle>,
     buffer: T,
     persist: P,
 ) where
@@ -33,51 +36,9 @@ pub(crate) async fn periodic_rotation<T, P>(
             n_ops = ids.len(),
             "rotated wal"
         );
-
-        // TEMPORARY HACK: wait 5 seconds for in-flight writes to the old WAL
-        // segment to complete before draining the partitions.
-        //
-        // This can occur because writes to the WAL & buffer tree are not atomic
-        // (avoiding a serialising mutex in the write path).
-        //
-        // A flawed solution would be to have this code read the current
-        // SequenceNumber after rotation, and then wait until at least that
-        // sequence number has been buffered in the BufferTree. This may work in
-        // most cases, but is racy / not deterministic - writes are not ordered,
-        // so sequence number 5 might be buffered before sequence number 1.
-        //
-        // As a temporary hack, wait 5 seconds for in-flight writes to complete
-        // (which should be more than enough time) before proceeding under the
-        // assumption that they have indeed completed, and all writes from the
-        // previous WAL segment are now buffered. Because they're buffered, the
-        // persist operation performed next will persist all the writes that
-        // were in the previous WAL segment, and therefore at the end of the
-        // persist operation the WAL segment can be dropped.
-        //
-        // The potential downside of this hack is that in the very unlikely
-        // situation that an in-flight write has not completed before the
-        // persist operation starts (after the 5 second sleep) and the WAL entry
-        // for it is dropped - we then reduce the durability of that write until
-        // it is persisted next time, or it is lost after an ingester crash
-        // before the next rotation.
-        //
-        // In the future, a proper fix will be to keep the set of sequence
-        // numbers wrote to each partition buffer, and each WAL segment as a
-        // bitmap, and after persistence submit the partition's bitmap to the
-        // WAL for it to do a set difference to derive the remaining sequence
-        // IDs, and therefore number of references to the WAL segment. Once the
-        // set of remaining IDs is empty (all data is persisted), the segment is
-        // safe to delete. This content-addressed reference counting technique
-        // has the added advantage of working even with parallel / out-of-order
-        // / hot partition persists that span WAL segments, and means there's no
-        // special code path between "hot partition persist" and "wal rotation
-        // persist" - it all works the same way!
-        //
-        //      https://github.com/influxdata/influxdb_iox/issues/6566
-        //
-        // TODO: this properly as described above.
-
-        tokio::time::sleep(Duration::from_secs(5)).await;
+        wal_reference_handle
+            .enqueue_rotated_file(stats.id(), ids)
+            .await;
 
         // Do not block the ticker while partitions are persisted to ensure
         // timely ticking.
@@ -97,7 +58,6 @@ pub(crate) async fn periodic_rotation<T, P>(
         // the right WAL segment regardless of concurrent tasks.
         tokio::spawn({
             let persist = persist.clone();
-            let wal = Arc::clone(&wal);
             let iter = buffer.partition_iter();
             async move {
                 // Drain the BufferTree of partition data and persist each one.
@@ -121,17 +81,6 @@ pub(crate) async fn periodic_rotation<T, P>(
                     closed_id = %stats.id(),
                     "partitions persisted"
                 );
-
-                wal.delete(stats.id())
-                    .await
-                    .expect("failed to drop wal segment");
-
-                info!(
-                    closed_id = %stats.id(),
-                    file_bytes = stats.size(),
-                    n_ops = ids.len(),
-                    "dropped persisted wal segment"
-                );
             }
         });
     }
@@ -143,40 +92,64 @@ mod tests {
 
     use assert_matches::assert_matches;
     use async_trait::async_trait;
-    use data_types::SequenceNumber;
-    use mutable_batch_lp::test_helpers::lp_to_mutable_batch;
     use parking_lot::Mutex;
     use tempfile::tempdir;
     use test_helpers::timeout::FutureTimeout;
     use tokio::sync::oneshot;
+    use wal::WriteResult;
 
     use super::*;
     use crate::{
-        buffer_tree::{partition::persisting::PersistingData, partition::PartitionData},
+        buffer_tree::partition::{persisting::PersistingData, PartitionData},
+        dml_payload::IngestOp,
         persist::queue::mock::MockPersistQueue,
-        test_util::{PartitionDataBuilder, ARBITRARY_PARTITION_ID},
+        test_util::{
+            make_write_op, new_persist_notification, PartitionDataBuilder, ARBITRARY_NAMESPACE_ID,
+            ARBITRARY_PARTITION_ID, ARBITRARY_PARTITION_KEY, ARBITRARY_TABLE_ID,
+            ARBITRARY_TABLE_NAME,
+        },
+        wal::traits::WalAppender,
     };
 
     const TICK_INTERVAL: Duration = Duration::from_millis(10);
 
     #[tokio::test]
-    async fn test_persist() {
+    async fn test_notify_rotate_persist() {
+        let metrics = metric::Registry::default();
+
+        // Create a write operation to stick in the WAL, and create a partition
+        // iter from the data within it to mock out the buffer tree.
+        let write_op = make_write_op(
+            &ARBITRARY_PARTITION_KEY,
+            ARBITRARY_NAMESPACE_ID,
+            &ARBITRARY_TABLE_NAME,
+            ARBITRARY_TABLE_ID,
+            1,
+            &format!(
+                r#"{},city=London people=2,pigeons="millions" 10"#,
+                &*ARBITRARY_TABLE_NAME
+            ),
+            None,
+        );
+
         let mut p = PartitionDataBuilder::new().build();
-
-        // Perform a single write to populate the partition.
-        let mb = lp_to_mutable_batch(r#"bananas,city=London people=2,pigeons="millions" 10"#).1;
-        p.buffer_write(mb, SequenceNumber::new(1))
+        for (_, table_data) in write_op.tables() {
+            let partitioned_data = table_data.partitioned_data();
+            p.buffer_write(
+                partitioned_data.data().clone(),
+                partitioned_data.sequence_number(),
+            )
             .expect("write should succeed");
-
+        }
         // Wrap the partition in the lock.
         assert_eq!(p.completed_persistence_count(), 0);
         let p = Arc::new(Mutex::new(p));
 
         // Initialise a mock persist queue to inspect the calls made to the
         // persist subsystem.
-        let persist = Arc::new(MockPersistQueue::default());
+        let persist_handle = Arc::new(MockPersistQueue::default());
 
-        // Initialise the WAL
+        // Initialise the WAL, write the operation to it
         let tmp_dir = tempdir().expect("no temp dir available");
         let wal = wal::Wal::new(tmp_dir.path())
             .await
@@ -184,12 +157,34 @@ mod tests {
 
         assert_eq!(wal.closed_segments().len(), 0);
 
+        let mut write_result = wal.append(&IngestOp::Write(write_op));
+
+        write_result
+            .changed()
+            .await
+            .expect("should be able to get WAL write result");
+
+        assert_matches!(
+            write_result
+                .borrow()
+                .as_ref()
+                .expect("WAL should always return result"),
+            WriteResult::Ok(_),
+            "test write should succeed"
+        );
+
+        let (wal_reference_handle, wal_reference_actor) =
+            WalReferenceHandle::new(Arc::clone(&wal), &metrics);
+        let wal_reference_handle = Arc::new(wal_reference_handle);
+        let wal_reference_actor_task = tokio::spawn(wal_reference_actor.run());
+
         // Start the rotation task
-        let handle = tokio::spawn(periodic_rotation(
+        let rotate_task_handle = tokio::spawn(periodic_rotation(
             Arc::clone(&wal),
             TICK_INTERVAL,
+            Arc::clone(&wal_reference_handle),
             vec![Arc::clone(&p)],
-            Arc::clone(&persist),
+            Arc::clone(&persist_handle),
         ));
 
         tokio::time::pause();
@@ -209,39 +204,38 @@ mod tests {
         .await;
 
         // There should be exactly 1 segment.
-        let mut segment = wal.closed_segments();
-        assert_eq!(segment.len(), 1);
-        let segment = segment.pop().unwrap();
+        let mut segments = wal.closed_segments();
+        assert_eq!(segments.len(), 1);
+        let closed_segment = segments.pop().unwrap();
 
-        // Move past the hacky sleep.
-        tokio::time::pause();
-        tokio::time::advance(Duration::from_secs(10)).await;
-        tokio::time::resume();
+        // Send a persistence notification to allow the actor to delete
+        // the WAL file
+        wal_reference_handle
+            .enqueue_persist_notification(new_persist_notification([1]))
+            .await;
 
-        // Wait for the WAL segment to be deleted, indicating the end of
-        // processing.
+        // Wait for the closed segment to no longer appear in the WAL,
+        // indicating deletion
         async {
             loop {
-                match wal.closed_segments().pop() {
-                    Some(p) if p.id() != segment.id() => {
-                        // Rotation has occurred.
-                        break;
-                    }
-                    // Rotation has not yet occurred.
-                    Some(_) => tokio::task::yield_now().await,
-                    // The old file was deleted and no new one has yet taken its
-                    // place.
-                    None => break,
+                if wal
+                    .closed_segments()
+                    .iter()
+                    .all(|s| s.id() != closed_segment.id())
+                {
+                    break;
                 }
+                tokio::task::yield_now().await;
             }
         }
         .with_timeout_panic(Duration::from_secs(5))
         .await;
 
-        // Stop the worker and assert the state of the persist queue.
-        handle.abort();
+        // Stop the tasks and assert the state of the persist queue
+        rotate_task_handle.abort();
+        wal_reference_actor_task.abort();
 
-        assert_matches!(persist.calls().as_slice(), [got] => {
+        assert_matches!(persist_handle.calls().as_slice(), [got] => {
             let guard = got.lock();
             assert_eq!(guard.partition_id(), ARBITRARY_PARTITION_ID);
         })
@@ -277,19 +271,38 @@ mod tests {
 
     #[tokio::test]
     async fn test_persist_ticks_when_blocked() {
+        let metrics = metric::Registry::default();
+
+        // Create a write operation to stick in the WAL, and create a partition
+        // iter from the data within it to mock out the buffer tree.
+        let write_op = make_write_op(
+            &ARBITRARY_PARTITION_KEY,
+            ARBITRARY_NAMESPACE_ID,
+            &ARBITRARY_TABLE_NAME,
+            ARBITRARY_TABLE_ID,
+            1,
+            &format!(
+                r#"{},city=London people=2,pigeons="millions" 10"#,
+                &*ARBITRARY_TABLE_NAME
+            ),
+            None,
+        );
+
         let mut p = PartitionDataBuilder::new().build();
-
-        // Perform a single write to populate the partition.
-        let mb = lp_to_mutable_batch(r#"bananas,city=London people=2,pigeons="millions" 10"#).1;
-        p.buffer_write(mb.clone(), SequenceNumber::new(1))
+        for (_, table_data) in write_op.tables() {
+            let partitioned_data = table_data.partitioned_data();
+            p.buffer_write(
+                partitioned_data.data().clone(),
+                partitioned_data.sequence_number(),
+            )
             .expect("write should succeed");
-
+        }
         // Wrap the partition in the lock.
         assert_eq!(p.completed_persistence_count(), 0);
         let p = Arc::new(Mutex::new(p));
 
         // Initialise a mock persist queue that never completes.
-        let persist = Arc::new(BlockedPersistQueue::default());
+        let persist_handle = Arc::new(BlockedPersistQueue::default());
 
         // Initialise the WAL
         let tmp_dir = tempdir().expect("no temp dir available");
@@ -299,12 +312,34 @@ mod tests {
 
         assert_eq!(wal.closed_segments().len(), 0);
 
+        let mut write_result = wal.append(&IngestOp::Write(write_op.clone()));
+
+        write_result
+            .changed()
+            .await
+            .expect("should be able to get WAL write result");
+
+        assert_matches!(
+            write_result
+                .borrow()
+                .as_ref()
+                .expect("WAL should always return result"),
+            WriteResult::Ok(_),
+            "test write should succeed"
+        );
+
+        let (wal_reference_handle, wal_reference_actor) =
+            WalReferenceHandle::new(Arc::clone(&wal), &metrics);
+        let wal_reference_handle = Arc::new(wal_reference_handle);
+        let wal_reference_actor_task = tokio::spawn(wal_reference_actor.run());
+
         // Start the rotation task
-        let handle = tokio::spawn(periodic_rotation(
+        let rotate_task_handle = tokio::spawn(periodic_rotation(
             Arc::clone(&wal),
             TICK_INTERVAL,
+            Arc::clone(&wal_reference_handle),
             vec![Arc::clone(&p)],
-            Arc::clone(&persist),
+            Arc::clone(&persist_handle),
         ));
 
         tokio::time::pause();
@@ -355,24 +390,25 @@ mod tests {
         .await;
 
         // Pause the ticker loop and buffer another write in the partition.
-        p.lock()
-            .buffer_write(mb, SequenceNumber::new(2))
-            .expect("write should succeed");
+        for (i, (_, table_data)) in write_op.tables().enumerate() {
+            let partitioned_data = table_data.partitioned_data();
+            p.lock()
+                .buffer_write(
+                    partitioned_data.data().clone(),
+                    partitioned_data.sequence_number() + i as u64 + 1,
+                )
+                .expect("write should succeed");
+        }
 
         // Cause another tick to occur, driving the loop again.
         tokio::time::pause();
         tokio::time::advance(TICK_INTERVAL).await;
         tokio::time::resume();
 
-        // Move past the sleep.
-        tokio::time::pause();
-        tokio::time::advance(Duration::from_secs(10)).await;
-        tokio::time::resume();
-
         // Wait the second tick to complete.
         async {
             loop {
-                if persist.calls.lock().len() == 2 {
+                if persist_handle.calls.lock().len() == 2 {
                     break;
                 }
                 tokio::task::yield_now().await;
@@ -381,10 +417,11 @@ mod tests {
         .with_timeout_panic(Duration::from_secs(5))
         .await;
 
-        // Stop the worker and assert the state of the persist queue.
-        handle.abort();
+        // Stop the workers and assert the state of the persist queue.
+        rotate_task_handle.abort();
+        wal_reference_actor_task.abort();
 
-        let calls = persist.calls.lock().clone();
+        let calls = persist_handle.calls.lock().clone();
         assert_matches!(calls.as_slice(), [got1, got2] => {
             assert!(Arc::ptr_eq(got1, got2));
         })

--- a/ingester/src/wal/traits.rs
+++ b/ingester/src/wal/traits.rs
@@ -1,5 +1,7 @@
 use std::fmt::Debug;
 
+use async_trait::async_trait;
+use data_types::sequence_number_set::SequenceNumberSet;
 use tokio::sync::watch::Receiver;
 use wal::WriteResult;
 
@@ -10,4 +12,13 @@ use crate::dml_payload::IngestOp;
 pub(super) trait WalAppender: Send + Sync + Debug {
     /// Add `op` to the write-head log, returning once `op` is durable.
     fn append(&self, op: &IngestOp) -> Receiver<Option<WriteResult>>;
+}
+
+/// An abstraction over a sequence number tracker for a write-ahead log,
+/// decoupling the write path from the underlying implementation.
+#[async_trait]
+pub(super) trait UnbufferedWriteNotifier: Send + Sync + Debug {
+    /// Notifies the receiver that a write with the given [`SequenceNumberSet`]
+    /// failed to buffer.
+    async fn notify_failed_write_buffer(&self, set: SequenceNumberSet);
 }

--- a/ingester/src/wal/wal_sink.rs
+++ b/ingester/src/wal/wal_sink.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use data_types::TableId;
+use data_types::{sequence_number_set::SequenceNumberSet, TableId};
 use generated_types::influxdata::iox::wal::v1::sequenced_wal_op::Op;
 use std::{collections::HashMap, sync::Arc, time::Duration};
 use tokio::sync::watch::Receiver;
@@ -11,7 +11,10 @@ use crate::{
     dml_sink::{DmlError, DmlSink},
 };
 
-use super::traits::WalAppender;
+use super::{
+    reference_tracker::WalReferenceHandle,
+    traits::{UnbufferedWriteNotifier, WalAppender},
+};
 
 /// [`DELEGATE_APPLY_TIMEOUT`] defines how long the inner [`DmlSink`] is given
 /// to complete the write [`DmlSink::apply()`] call.
@@ -27,34 +30,46 @@ const DELEGATE_APPLY_TIMEOUT: Duration = Duration::from_secs(15);
 /// A [`DmlSink`] decorator that ensures any [`IngestOp`] is committed to
 /// the write-ahead log before passing the operation to the inner [`DmlSink`].
 #[derive(Debug)]
-pub(crate) struct WalSink<T, W = wal::Wal> {
+pub(crate) struct WalSink<T, W = wal::Wal, N = WalReferenceHandle> {
     /// The inner chain of [`DmlSink`] that a [`IngestOp`] is passed to once
     /// committed to the write-ahead log.
     inner: T,
 
     /// The write-ahead log implementation.
     wal: W,
+
+    /// A notifier handle to report the sequence numbers of writes that enter
+    /// the write-ahead log but fail to buffer.
+    notifier_handle: N,
 }
 
-impl<T, W> WalSink<T, W> {
+impl<T, W, N> WalSink<T, W, N> {
     /// Initialise a new [`WalSink`] that appends [`IngestOp`] to `W` and
-    /// on success, passes the op through to `T`.
-    pub(crate) fn new(inner: T, wal: W) -> Self {
-        Self { inner, wal }
+    /// on success, passes the op through to `T`, using `N` to keep `W` informed
+    /// of writes that fail to buffer.
+    pub(crate) fn new(inner: T, wal: W, notifier_handle: N) -> Self {
+        Self {
+            inner,
+            wal,
+            notifier_handle,
+        }
     }
 }
 
 #[async_trait]
-impl<T, W> DmlSink for WalSink<T, W>
+impl<T, W, N> DmlSink for WalSink<T, W, N>
 where
     T: DmlSink + Clone + 'static,
     W: WalAppender + 'static,
+    N: UnbufferedWriteNotifier + 'static,
 {
     type Error = DmlError;
 
     async fn apply(&self, op: IngestOp) -> Result<(), Self::Error> {
         // Append the operation to the WAL
         let mut write_result = self.wal.append(&op);
+
+        let set = op.sequence_number_set();
 
         // Pass it to the inner handler while we wait for the write to be made
         // durable.
@@ -73,14 +88,18 @@ where
         //  https://github.com/influxdata/influxdb_iox/issues/7111
         //
         let inner = self.inner.clone();
-        CancellationSafe::new(async move {
+        let inner_result = CancellationSafe::new(async move {
             let res = tokio::time::timeout(DELEGATE_APPLY_TIMEOUT, inner.apply(op))
                 .await
                 .map_err(|_| DmlError::ApplyTimeout)?;
 
             res.map_err(Into::into)
         })
-        .await?;
+        .await;
+        if inner_result.is_err() {
+            self.notifier_handle.notify_failed_write_buffer(set).await;
+        }
+        inner_result?;
 
         // Wait for the write to be durable before returning to the user
         write_result
@@ -122,38 +141,77 @@ impl WalAppender for Arc<wal::Wal> {
     }
 }
 
+#[async_trait]
+impl UnbufferedWriteNotifier for Arc<WalReferenceHandle> {
+    async fn notify_failed_write_buffer(&self, set: SequenceNumberSet) {
+        self.enqueue_unbuffered_write(set).await;
+    }
+}
+
+#[cfg(test)]
+pub(crate) mod mock {
+    use parking_lot::Mutex;
+
+    use super::*;
+
+    #[derive(Debug, Default)]
+    pub(crate) struct MockUnbufferedWriteNotifier {
+        calls: Mutex<Vec<SequenceNumberSet>>,
+    }
+
+    impl MockUnbufferedWriteNotifier {
+        pub(crate) fn calls(&self) -> Vec<SequenceNumberSet> {
+            self.calls.lock().clone()
+        }
+    }
+
+    #[async_trait]
+    impl UnbufferedWriteNotifier for Arc<MockUnbufferedWriteNotifier> {
+        async fn notify_failed_write_buffer(&self, set: SequenceNumberSet) {
+            self.calls.lock().push(set);
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
+    use core::{future::Future, marker::Send, pin::Pin};
+    use std::{future, sync::Arc};
+
+    use assert_matches::assert_matches;
+    use data_types::{SequenceNumber, TableId};
+    use lazy_static::lazy_static;
+    use mutable_batch_lp::lines_to_batches;
+    use wal::Wal;
+
     use super::*;
     use crate::{
         dml_payload::write::{PartitionedData, TableData, WriteOperation},
         dml_sink::mock_sink::MockDmlSink,
         test_util::{
-            make_write_op, ARBITRARY_NAMESPACE_ID, ARBITRARY_PARTITION_KEY, ARBITRARY_TABLE_ID,
-            ARBITRARY_TABLE_NAME,
+            make_multi_table_write_op, ARBITRARY_NAMESPACE_ID, ARBITRARY_PARTITION_KEY,
+            ARBITRARY_TABLE_ID, ARBITRARY_TABLE_NAME,
         },
     };
-    use assert_matches::assert_matches;
-    use core::{future::Future, marker::Send, pin::Pin};
-    use data_types::{SequenceNumber, TableId};
-    use mutable_batch_lp::lines_to_batches;
-    use std::{future, sync::Arc};
-    use wal::Wal;
+
+    lazy_static! {
+        static ref ALTERNATIVE_TABLE_NAME: &'static str = "arán";
+    }
 
     #[tokio::test]
     async fn test_append() {
         let dir = tempfile::tempdir().unwrap();
 
-        const SECOND_TABLE_ID: TableId = TableId::new(45);
-        const SECOND_TABLE_NAME: &str = "banani";
+        const ALTERNATIVE_TABLE_ID: TableId = TableId::new(45);
         // Generate a test op containing writes for multiple tables that will
         // be appended and read back
         let mut tables_by_name = lines_to_batches(
-            &format!(
+            format!(
                 "{},region=Madrid temp=35 4242424242\n\
-             banani,region=Iceland temp=25 7676767676",
-                &*ARBITRARY_TABLE_NAME
-            ),
+             {},region=Galway temp=25 7676767676",
+                &*ARBITRARY_TABLE_NAME, &*ALTERNATIVE_TABLE_NAME
+            )
+            .as_str(),
             0,
         )
         .expect("invalid line proto");
@@ -167,20 +225,20 @@ mod tests {
                         PartitionedData::new(
                             SequenceNumber::new(42),
                             tables_by_name
-                                .remove(ARBITRARY_TABLE_NAME.as_ref())
+                                .remove(&ARBITRARY_TABLE_NAME.to_string())
                                 .expect("table does not exist in LP"),
                         ),
                     ),
                 ),
                 (
-                    SECOND_TABLE_ID,
+                    ALTERNATIVE_TABLE_ID,
                     TableData::new(
-                        SECOND_TABLE_ID,
+                        ALTERNATIVE_TABLE_ID,
                         PartitionedData::new(
-                            SequenceNumber::new(42),
+                            SequenceNumber::new(43),
                             tables_by_name
-                                .remove(SECOND_TABLE_NAME)
-                                .expect("second table does not exist in LP"),
+                                .remove(&ALTERNATIVE_TABLE_NAME.to_string())
+                                .expect("alternative table does not exist in LP"),
                         ),
                     ),
                 ),
@@ -197,8 +255,9 @@ mod tests {
             let wal = Wal::new(dir.path())
                 .await
                 .expect("failed to initialise WAL");
+            let notifier_handle = Arc::new(mock::MockUnbufferedWriteNotifier::default());
 
-            let wal_sink = WalSink::new(Arc::clone(&inner), wal);
+            let wal_sink = WalSink::new(Arc::clone(&inner), wal, Arc::clone(&notifier_handle));
 
             // Apply the op through the decorator
             wal_sink
@@ -206,8 +265,10 @@ mod tests {
                 .await
                 .expect("wal should not error");
 
-            // Assert the mock inner sink saw the call
+            // Assert the mock inner sink saw the call and that no unbuffered
+            // write notification was sent
             assert_eq!(inner.get_calls().len(), 1);
+            assert_eq!(notifier_handle.calls().len(), 0);
         }
 
         // Read the op back
@@ -230,7 +291,7 @@ mod tests {
         let read_op = assert_matches!(&*ops, [op] => op, "expected 1 DML operation");
         assert_eq!(
             read_op.table_write_sequence_numbers,
-            [(ARBITRARY_TABLE_ID, 42), (SECOND_TABLE_ID, 42)]
+            [(ARBITRARY_TABLE_ID, 42), (ALTERNATIVE_TABLE_ID, 43)]
                 .into_iter()
                 .collect::<std::collections::HashMap<TableId, u64>>()
         );
@@ -268,24 +329,39 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
 
         // Generate the test op
-        let op = make_write_op(
+        let op = make_multi_table_write_op(
             &ARBITRARY_PARTITION_KEY,
             ARBITRARY_NAMESPACE_ID,
-            &ARBITRARY_TABLE_NAME,
-            ARBITRARY_TABLE_ID,
-            42,
+            [
+                (
+                    ARBITRARY_TABLE_NAME.to_string().as_str(),
+                    ARBITRARY_TABLE_ID,
+                    SequenceNumber::new(42),
+                ),
+                (
+                    &ALTERNATIVE_TABLE_NAME,
+                    TableId::new(ARBITRARY_TABLE_ID.get() + 1),
+                    SequenceNumber::new(43),
+                ),
+            ]
+            .into_iter(),
             &format!(
-                r#"{},region=Madrid temp=35 4242424242"#,
-                &*ARBITRARY_TABLE_NAME
+                r#"{},region=Madrid temp=35,climate="dry" 4242424242
+                {},region=Belfast temp=14,climate="wet" 4242424242"#,
+                &*ARBITRARY_TABLE_NAME, &*ALTERNATIVE_TABLE_NAME,
             ),
-            None,
         );
 
         let wal = Wal::new(dir.path())
             .await
             .expect("failed to initialise WAL");
+        let notifier_handle = Arc::new(mock::MockUnbufferedWriteNotifier::default());
 
-        let wal_sink = WalSink::new(BlockingDmlSink::default(), wal);
+        let wal_sink = WalSink::new(
+            BlockingDmlSink::default(),
+            wal,
+            Arc::clone(&notifier_handle),
+        );
 
         // Allow tokio to automatically advance time past the timeout duration,
         // when all threads are blocked on await points.
@@ -308,5 +384,17 @@ mod tests {
         // before erroring.
         let duration = tokio::time::Instant::now().duration_since(start);
         assert!(duration > DELEGATE_APPLY_TIMEOUT);
+
+        // Assert that an unbuffered write notification was sent for the
+        // correct [`SequenceNumberSet`]
+        assert_eq!(
+            notifier_handle.calls(),
+            [SequenceNumberSet::from_iter([
+                SequenceNumber::new(42),
+                SequenceNumber::new(43)
+            ])]
+            .into_iter()
+            .collect::<Vec<_>>()
+        );
     }
 }


### PR DESCRIPTION
This PR will close #6566 by moving the responsibility for deleting WAL segment files from the rotation task to `WalReferenceActor` type added in #7209, dropping WAL segments once all writes in it have been persisted.

While the rotation task no longer deletes segment files, I have kept graceful shutdown draining the buffer tree and deleting all segments as persisted. I'd like to add an integration test at the service level that adds coverage of the ASAP (as soon as persistent) deletion behaviour.

- [ ] Add integration test of WAL reference actor as service level

---

* refactor(ingester): Notify `SequenceNumberSet` when tracking unbuffered writes (7b2ef53c7)

      Writes now contain multiple sequence numbers, so the WAL reference
      actor must be notified of *all* sequence numbers contained for a write
      that failed to be applied to the buffer.

* feat(ingester): WIP - WAL rotate task uses reference tracker for delete (fd8a89dee)

      This is the first commit in line to connect the WAL segment reference
      tracker actor up to the rest of the ingester. It removes the segment file
      deletion and hacky sleep from the rotate task, deferring to the actor
      for deletion tracking.

* refactor(ingester): Expose `SequenceNumberSet` for each ingest op (f481ce707)

      This allows code shuttling around ingest operations to know how the
      operation has sequenced without having to fiddle about with the value.

* feat(ingester): WIP - WAL reference tracking of unbuffered writes (9ca0abfe0)

      This commit updates the DML sink for the write-ahead log to notify the
      reference tracker of writes that have been committed to the log, but
      failed to be applied to the buffer tree.

* refactor(ingester): Use multi-table write op test util for wal_sink test (b4a5d994d)


* feat(ingester): Drop WAL segments once all writes are persistent (15b22728c)

      This implements `PersistCompletionObserver` for the `WalReferenceHandle`
      so that it can be given to the persist handle and notified of persist
      completions in order to drop WAL segments once all writes are
      persistent.