### PR TITLE
chore: create index on created_at in partition table

### DIFF
--- a/iox_catalog/migrations/20230707195110_add_created_at_index.sql
+++ b/iox_catalog/migrations/20230707195110_add_created_at_index.sql
@@ -1,0 +1,13 @@
+-- Add to help the compactor when it searches for partitions with files created recently.
+
+-- By default we often only have 5min to finish our statements. The `CREATE INDEX CONCURRENTLY` however takes longer.
+-- In our prod test this took about 15min, but better be safe than sorry.
+-- IOX_NO_TRANSACTION
+SET statement_timeout TO '60min';
+
+-- IOX_STEP_BOUNDARY
+
+-- While `CONCURRENTLY` means it runs parallel to other writes, this command will only finish after the index was
+-- successfully built.
+-- IOX_NO_TRANSACTION
+CREATE INDEX CONCURRENTLY IF NOT EXISTS partition_new_file_at_idx ON partition (new_file_at);


### PR DESCRIPTION
Closes # https://github.com/influxdata/idpe/issues/17850

This PR adds an index for `created_at` to the partition table.  The compactor frequently queries based on `created_at` to find partitions with recent activity.

- [x] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb_iox/blob/main/README.md).
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
