### PR TITLE
feat(router): Propagate tracing spans for RPC write to Ingester

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4699,6 +4699,7 @@ dependencies = [
  "tokio-stream",
  "tonic",
  "trace",
+ "trace_http",
  "workspace-hack",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2712,6 +2712,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tonic",
+ "trace",
  "workspace-hack",
 ]
 

--- a/influxdb_iox/src/commands/run/all_in_one.rs
+++ b/influxdb_iox/src/commands/run/all_in_one.rs
@@ -636,6 +636,10 @@ pub async fn command(config: Config) -> Result<()> {
         Arc::clone(&catalog),
         Arc::clone(&object_store),
         &router_config,
+        router_run_config
+            .tracing_config()
+            .traces_jaeger_trace_context_header_name
+            .clone(),
     )
     .await?;
 

--- a/influxdb_iox/src/commands/run/router.rs
+++ b/influxdb_iox/src/commands/run/router.rs
@@ -98,6 +98,11 @@ pub async fn command(config: Config) -> Result<()> {
         catalog,
         object_store,
         &config.router_config,
+        config
+            .run_config
+            .tracing_config()
+            .traces_jaeger_trace_context_header_name
+            .clone(),
     )
     .await?;
 

--- a/ingester/benches/query.rs
+++ b/ingester/benches/query.rs
@@ -40,8 +40,14 @@ async fn init(
     let ns = ctx.ensure_namespace(TEST_NAMESPACE, None).await;
 
     // Write the test data
-    ctx.write_lp(TEST_NAMESPACE, lp, PartitionKey::from(PARTITION_KEY), 42)
-        .await;
+    ctx.write_lp(
+        TEST_NAMESPACE,
+        lp,
+        PartitionKey::from(PARTITION_KEY),
+        42,
+        None,
+    )
+    .await;
 
     let table_id = ctx.table_id(TEST_NAMESPACE, "bananas").await;
 

--- a/ingester/benches/write.rs
+++ b/ingester/benches/write.rs
@@ -36,8 +36,14 @@ async fn init(lp: impl AsRef<str>) -> (TestContext<impl IngesterRpcInterface>, D
     let ns = ctx.ensure_namespace(TEST_NAMESPACE, None).await;
 
     // Perform a write to drive table / schema population in the catalog.
-    ctx.write_lp(TEST_NAMESPACE, lp, PartitionKey::from(PARTITION_KEY), 42)
-        .await;
+    ctx.write_lp(
+        TEST_NAMESPACE,
+        lp,
+        PartitionKey::from(PARTITION_KEY),
+        42,
+        None,
+    )
+    .await;
 
     // Construct the write request once, and reuse it for each iteration.
     let batches = lines_to_batches(lp, 0).unwrap();

--- a/ingester/tests/query.rs
+++ b/ingester/tests/query.rs
@@ -18,6 +18,7 @@ async fn write_query() {
         "bananas greatness=\"unbounded\" 10",
         partition_key.clone(),
         0,
+        None,
     )
     .await;
 
@@ -27,6 +28,7 @@ async fn write_query() {
         "cpu bar=2 20\ncpu bar=3 30",
         partition_key.clone(),
         7,
+        None,
     )
     .await;
 
@@ -37,6 +39,7 @@ async fn write_query() {
         "bananas count=42 200",
         partition_key.clone(),
         42,
+        None,
     )
     .await;
 
@@ -100,6 +103,7 @@ async fn write_query_projection() {
         "bananas greatness=\"unbounded\",level=42 10",
         partition_key.clone(),
         0,
+        None,
     )
     .await;
 
@@ -109,6 +113,7 @@ async fn write_query_projection() {
         "bananas count=42,level=4242 200",
         partition_key.clone(),
         42,
+        None,
     )
     .await;
 

--- a/ingester/tests/write.rs
+++ b/ingester/tests/write.rs
@@ -9,6 +9,7 @@ use metric::{
 };
 use parquet_file::ParquetFilePath;
 use std::{sync::Arc, time::Duration};
+use trace::{ctx::SpanContext, RingBufferTraceCollector};
 
 // Write data to an ingester through the RPC interface and persist the data.
 #[tokio::test]
@@ -23,6 +24,7 @@ async fn write_persist() {
         r#"bananas count=42,greatness="inf" 200"#,
         partition_key.clone(),
         42,
+        None,
     )
     .await;
 
@@ -191,6 +193,7 @@ async fn wal_replay() {
             "bananas greatness=\"unbounded\" 10",
             partition_key.clone(),
             0,
+            None,
         )
         .await;
 
@@ -200,6 +203,7 @@ async fn wal_replay() {
             "cpu bar=2 20\ncpu bar=3 30",
             partition_key.clone(),
             7,
+            None,
         )
         .await;
 
@@ -210,6 +214,7 @@ async fn wal_replay() {
             "bananas count=42 200",
             partition_key.clone(),
             42,
+            None,
         )
         .await;
 
@@ -283,6 +288,7 @@ async fn graceful_shutdown() {
         "bananas greatness=\"unbounded\" 10",
         partition_key.clone(),
         0,
+        None,
     )
     .await;
 
@@ -295,6 +301,7 @@ async fn graceful_shutdown() {
         "cpu bar=2 20\ncpu bar=3 30",
         partition_key.clone(),
         7,
+        None,
     )
     .await;
 
@@ -305,6 +312,7 @@ async fn graceful_shutdown() {
         "bananas count=42 200",
         partition_key.clone(),
         42,
+        None,
     )
     .await;
 
@@ -357,4 +365,62 @@ async fn graceful_shutdown() {
         .await
         .unwrap();
     assert_eq!(parquet_files.len(), 3);
+}
+
+#[tokio::test]
+async fn write_tracing() {
+    let namespace_name = "write_tracing_test_namespace";
+    let mut ctx = TestContextBuilder::default().build().await;
+    let ns = ctx.ensure_namespace(namespace_name, None).await;
+
+    let trace_collector = Arc::new(RingBufferTraceCollector::new(5));
+    let span_ctx = SpanContext::new(Arc::new(Arc::clone(&trace_collector)));
+    let request_span = span_ctx.child("write request span");
+
+    let partition_key = PartitionKey::from("1970-01-01");
+    ctx.write_lp(
+        namespace_name,
+        r#"bananas count=42,greatness="inf" 200"#,
+        partition_key.clone(),
+        42,
+        Some(request_span.ctx.clone()),
+    )
+    .await;
+
+    // Perform a query to validate the actual data buffered.
+    let table_id = ctx.table_id(namespace_name, "bananas").await.get();
+    let data: Vec<_> = ctx
+        .query(IngesterQueryRequest {
+            namespace_id: ns.id.get(),
+            table_id,
+            columns: vec![],
+            predicate: None,
+        })
+        .await
+        .expect("query request failed");
+
+    let expected = vec![
+        "+-------+-----------+--------------------------------+",
+        "| count | greatness | time                           |",
+        "+-------+-----------+--------------------------------+",
+        "| 42.0  | inf       | 1970-01-01T00:00:00.000000200Z |",
+        "+-------+-----------+--------------------------------+",
+    ];
+    assert_batches_sorted_eq!(&expected, &data);
+
+    // Check the spans emitted for the write request align capture what is expected
+    let spans = trace_collector.spans();
+    assert_matches!(spans.as_slice(), [span3, span2, span1, handler_span] => {
+        // Check that the DML handlers are hit, and that they inherit from the
+        // handler span, which in turn inherits from the request
+        assert_eq!(handler_span.name, "ingester write");
+        assert_eq!(span1.name, "write_apply");
+        assert_eq!(span2.name, "wal");
+        assert_eq!(span3.name, "buffer");
+
+        assert_eq!(handler_span.ctx.parent_span_id, Some(request_span.ctx.span_id));
+        assert_eq!(span1.ctx.parent_span_id, Some(handler_span.ctx.span_id));
+        assert_eq!(span2.ctx.parent_span_id, Some(handler_span.ctx.span_id));
+        assert_eq!(span3.ctx.parent_span_id, Some(handler_span.ctx.span_id));
+    })
 }

--- a/ingester_test_ctx/Cargo.toml
+++ b/ingester_test_ctx/Cargo.toml
@@ -32,4 +32,5 @@ test_helpers = { path = "../test_helpers", features = ["future_timeout"] }
 tokio = { version = "1.29", features = ["macros", "parking_lot", "rt-multi-thread", "sync", "time"] }
 tokio-util = "0.7.8"
 tonic = { workspace = true }
+trace = { version = "0.1.0", path = "../trace" }
 workspace-hack = { version = "0.1", path = "../workspace-hack" }

--- a/ioxd_router/src/lib.rs
+++ b/ioxd_router/src/lib.rs
@@ -218,6 +218,7 @@ pub async fn create_router_server_type(
     catalog: Arc<dyn Catalog>,
     object_store: Arc<DynObjectStore>,
     router_config: &RouterConfig,
+    trace_context_header_name: String,
 ) -> Result<Arc<dyn ServerType>> {
     let ingester_connections = router_config.ingester_addresses.iter().map(|addr| {
         let addr = addr.to_string();
@@ -228,6 +229,7 @@ pub async fn create_router_server_type(
                 endpoint,
                 router_config.rpc_write_timeout_seconds,
                 router_config.rpc_write_max_outgoing_bytes,
+                trace_context_header_name.clone(),
             ),
             addr,
         )

--- a/querier/src/ingester/mod.rs
+++ b/querier/src/ingester/mod.rs
@@ -111,7 +111,7 @@ pub enum Error {
     ChunkWithoutPartition { ingester_address: String },
 
     #[snafu(display(
-        "Duplicate partition info for partition {partition_id}, ingestger: {ingester_address}"
+        "Duplicate partition info for partition {partition_id}, ingester: {ingester_address}"
     ))]
     DuplicatePartitionInfo {
         partition_id: PartitionId,

--- a/router/Cargo.toml
+++ b/router/Cargo.toml
@@ -39,6 +39,8 @@ thiserror = "1.0"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "time"] }
 tonic = { workspace = true }
 trace = { path = "../trace/" }
+trace_http = { path = "../trace_http" }
+
 workspace-hack = { version = "0.1", path = "../workspace-hack" }
 
 [dev-dependencies]

--- a/router/src/dml_handlers/rpc_write/balancer.rs
+++ b/router/src/dml_handlers/rpc_write/balancer.rs
@@ -278,7 +278,7 @@ mod tests {
         let _ = endpoints
             .next()
             .unwrap()
-            .write(WriteRequest::default())
+            .write(WriteRequest::default(), None)
             .await;
         assert!((circuit_err_1.ok_count() == 1) ^ (circuit_err_2.ok_count() == 1));
         assert!(circuit_ok.ok_count() == 0);
@@ -287,7 +287,7 @@ mod tests {
         let _ = endpoints
             .next()
             .unwrap()
-            .write(WriteRequest::default())
+            .write(WriteRequest::default(), None)
             .await;
         assert!((circuit_err_1.ok_count() == 1) ^ (circuit_err_2.ok_count() == 1));
         assert!(circuit_ok.ok_count() == 1);
@@ -296,7 +296,7 @@ mod tests {
         let _ = endpoints
             .next()
             .unwrap()
-            .write(WriteRequest::default())
+            .write(WriteRequest::default(), None)
             .await;
         assert!((circuit_err_1.ok_count() == 2) ^ (circuit_err_2.ok_count() == 2));
         assert!(circuit_ok.ok_count() == 1);
@@ -305,7 +305,7 @@ mod tests {
         let _ = endpoints
             .next()
             .unwrap()
-            .write(WriteRequest::default())
+            .write(WriteRequest::default(), None)
             .await;
         assert!((circuit_err_1.ok_count() == 2) ^ (circuit_err_2.ok_count() == 2));
         assert!(circuit_ok.ok_count() == 2);
@@ -352,7 +352,7 @@ mod tests {
             endpoints
                 .next()
                 .expect("should yield healthy client")
-                .write(WriteRequest::default())
+                .write(WriteRequest::default(), None)
                 .await
                 .expect("should succeed");
 
@@ -409,7 +409,7 @@ mod tests {
             endpoints
                 .next()
                 .expect("should yield healthy client")
-                .write(WriteRequest::default())
+                .write(WriteRequest::default(), None)
                 .await
                 .expect("should succeed");
         }
@@ -456,7 +456,7 @@ mod tests {
                 .unwrap()
                 .next()
                 .expect("should yield healthy client")
-                .write(WriteRequest::default())
+                .write(WriteRequest::default(), None)
                 .await
                 .expect("should succeed");
         }

--- a/router/src/server/http.rs
+++ b/router/src/server/http.rs
@@ -157,6 +157,12 @@ impl From<&DmlError> for StatusCode {
                 StatusCode::INTERNAL_SERVER_ERROR
             }
             DmlError::RpcWrite(RpcWriteError::Client(
+                RpcWriteClientError::MisconfiguredMetadataKey(_),
+            )) => StatusCode::INTERNAL_SERVER_ERROR,
+            DmlError::RpcWrite(RpcWriteError::Client(
+                RpcWriteClientError::MisconfiguredMetadataValue(_),
+            )) => StatusCode::INTERNAL_SERVER_ERROR,
+            DmlError::RpcWrite(RpcWriteError::Client(
                 RpcWriteClientError::UpstreamNotConnected(_),
             )) => StatusCode::SERVICE_UNAVAILABLE,
             DmlError::RpcWrite(RpcWriteError::Timeout(_)) => StatusCode::GATEWAY_TIMEOUT,


### PR DESCRIPTION
This resolves #6177, by encoding the Jaeger format trace context into the RPC write request and inheriting from it at the Ingester's RPC handler.

Here's a screenshot from running the following against an all-in-one mode instance:

```
influxdb_iox write company_sensors test_fixtures/lineproto/metrics.lp --host http://localhost:8080 --gen-trace-id
```

<img width="1122" alt="image" src="https://github.com/influxdata/influxdb_iox/assets/9120151/b9352735-e640-453e-88d4-14d2bf2717f8">

The details on spans and their hierarchy could be looked at in a follow up PR if needed - this PR doesn't make any new opinions on how the trace should look.

Maybe this should be `chore`? I'm not very consistent with that semcommit 😅 

---

* feat(router): Send tracing SpanContext header to ingester during RPC write (5a37c92c2)


* feat(ingester): Extract SpanContext from RPC write request (458b1bf1a)

      Ensure that if a `SpanContext` type is present in the request that the
      trace ID is used for spans in the RPC write path.

* test(ingester): Integration test for RPC write trace context inheritrance (729851be5)


* test(router): Assert RPC write span contexts can be parsed as encoded (7e595eca8)

      This test aims to add some assertion that the span context is correctly
      encoded into an RPC write request as long as the [`TraceHeaderParser`]
      is responsible for decorating the requests extensions with the added
      information.
