### PR TITLE
fix(ingester): projection without time column

### DIFF
--- a/compactor/src/components/df_planner/query_chunk.rs
+++ b/compactor/src/components/df_planner/query_chunk.rs
@@ -33,7 +33,7 @@ impl QueryableParquetChunk {
         let stats = Arc::new(create_basic_summary(
             data.rows() as u64,
             data.schema(),
-            data.timestamp_min_max(),
+            Some(data.timestamp_min_max()),
         ));
         Self {
             data,

--- a/ingester/src/query_adaptor.rs
+++ b/ingester/src/query_adaptor.rs
@@ -116,9 +116,11 @@ impl QueryAdaptor {
         self.data.iter().map(|b| b.num_rows()).sum::<usize>() as u64
     }
 
-    /// Time range, useful for building stats
-    pub(crate) fn ts_min_max(&self) -> TimestampMinMax {
-        compute_timenanosecond_min_max(self.data.iter()).expect("Should have time range")
+    /// The (inclusive) time range covered by all data in this [`QueryAdaptor`],
+    /// if this batch contains a `time` column.
+    pub(crate) fn ts_min_max(&self) -> Option<TimestampMinMax> {
+        // This batch may have been projected to exclude the time column
+        compute_timenanosecond_min_max(self.data.iter()).ok()
     }
 }
 

--- a/querier/src/ingester/mod.rs
+++ b/querier/src/ingester/mod.rs
@@ -848,7 +848,7 @@ impl IngesterPartition {
             let stats = Arc::new(create_chunk_statistics(
                 row_count,
                 &chunk.schema,
-                ts_min_max,
+                Some(ts_min_max),
                 partition_column_ranges,
             ));
             chunk.stats = Some(stats);

--- a/querier/src/parquet/mod.rs
+++ b/querier/src/parquet/mod.rs
@@ -67,7 +67,7 @@ impl QuerierParquetChunk {
         let stats = Arc::new(create_chunk_statistics(
             parquet_chunk.rows() as u64,
             parquet_chunk.schema(),
-            parquet_chunk.timestamp_min_max(),
+            Some(parquet_chunk.timestamp_min_max()),
             &column_ranges,
         ));
 


### PR DESCRIPTION
In practice it'll likely always be part of a projection, but in theory it doesn't have to be (when combined with partition pruning / custom partitioning).

---

* fix(ingester): projection without time column (7f7d1f2ee)
      
      The ingester can project arbitrary columns at query time, and has no
      special requirement that the "time" column be part of that projection.
      
      Because the timestamp summary generation explicitly requires the time
      column to exist, it panics when there's no "time" column in the
      projection - this is a bit of a modelling mismatch more than anything.