### PR TITLE
refactor(catalog): Allow kafka columns to be nullable

### DIFF
--- a/iox_catalog/migrations/20230714154828_make-kafka-columns-nullable.sql
+++ b/iox_catalog/migrations/20230714154828_make-kafka-columns-nullable.sql
@@ -1,0 +1,11 @@
+-- Drop the foreign key constraints referencing the various 
+-- placeholder kafka columns
+ALTER TABLE IF EXISTS namespace DROP CONSTRAINT IF EXISTS namespace_kafka_topic_id_fkey, DROP CONSTRAINT IF EXISTS namespace_query_pool_id_fkey;
+ALTER TABLE IF EXISTS parquet_file DROP CONSTRAINT IF EXISTS parquet_file_sequencer_id_fkey;
+ALTER TABLE IF EXISTS partition DROP CONSTRAINT IF EXISTS partition_sequencer_id_fkey;
+ALTER TABLE IF EXISTS tombstone DROP CONSTRAINT IF EXISTS tombstone_sequencer_id_fkey;
+-- Allow the ID columns in these tables to be nullable
+ALTER TABLE IF EXISTS namespace ALTER COLUMN topic_id DROP NOT NULL, ALTER COLUMN query_pool_id DROP NOT NULL;
+ALTER TABLE IF EXISTS parquet_file ALTER COLUMN shard_id DROP NOT NULL;
+ALTER TABLE IF EXISTS partition ALTER COLUMN shard_id DROP NOT NULL;
+ALTER TABLE IF EXISTS tombstone ALTER COLUMN shard_id DROP NOT NULL;


### PR DESCRIPTION
First small step for towards https://github.com/influxdata/influxdb_iox/issues/6217.

This just allows the columns to be nullable and drops related foreign key constraints. I've tested this in a scenario with two routers, and ingester and a querier all on the old db schema having processed some writes and queries, before performing the migration and rolling one of the routers to the new version. All the old services seem happy to serve requests after the change has been made.