### PR TITLE
fix: update new_file_at following all compactions

### DIFF
--- a/iox_catalog/migrations/20230720132400_modify_parquet_file_triggers.sql
+++ b/iox_catalog/migrations/20230720132400_modify_parquet_file_triggers.sql
@@ -1,0 +1,13 @@
+-- FUNTION that updates the new_file_at field in the partition table when the update_partition trigger is fired
+-- The field new_file_at signals when the last file was added to the partition for compaction.
+
+CREATE OR REPLACE FUNCTION update_partition_on_new_file_at()
+RETURNS TRIGGER 
+LANGUAGE PLPGSQL
+AS $$
+BEGIN
+    UPDATE partition SET new_file_at = NEW.created_at WHERE id = NEW.partition_id;    
+
+    RETURN NEW;
+END;
+$$;

--- a/iox_catalog/sqlite/migrations/20230720132400_parquet_file_triggers.sql
+++ b/iox_catalog/sqlite/migrations/20230720132400_parquet_file_triggers.sql
@@ -1,0 +1,9 @@
+-- update new_file_at for all compactions, not just L0 & L1
+drop trigger update_partition;
+create trigger if not exists update_partition
+    after insert
+    on parquet_file
+    for each row
+begin
+    UPDATE partition set new_file_at = NEW.created_at WHERE id = NEW.partition_id;
+end;

--- a/iox_catalog/src/interface.rs
+++ b/iox_catalog/src/interface.rs
@@ -2575,7 +2575,6 @@ pub(crate) mod test_helpers {
         assert!(partitions.is_empty());
 
         // Add an L2 file created just now for partition three
-        // Since the file is L2, the partition won't get updated
         let l2_file_params = ParquetFileParams {
             object_store_id: Uuid::new_v4(),
             created_at: time_now,
@@ -2588,16 +2587,17 @@ pub(crate) mod test_helpers {
             .create(l2_file_params.clone())
             .await
             .unwrap();
-        // still should return partition one and two only
+        // now should return partition one two and three
         let mut partitions = repos
             .partitions()
             .partitions_new_file_between(time_two_hour_ago, None)
             .await
             .unwrap();
-        assert_eq!(partitions.len(), 2);
+        assert_eq!(partitions.len(), 3);
         partitions.sort();
         assert_eq!(partitions[0], partition1.id);
         assert_eq!(partitions[1], partition2.id);
+        assert_eq!(partitions[2], partition3.id);
         // Only return partition1: the creation time must be strictly less than the maximum time,
         // not equal
         let partitions = repos

--- a/iox_catalog/src/mem.rs
+++ b/iox_catalog/src/mem.rs
@@ -995,23 +995,19 @@ async fn create_parquet_file(
         parquet_file_params,
         ParquetFileId::new(stage.parquet_files.len() as i64 + 1),
     );
-    let compaction_level = parquet_file.compaction_level;
     let created_at = parquet_file.created_at;
     let partition_id = parquet_file.partition_id;
     stage.parquet_files.push(parquet_file);
 
     // Update the new_file_at field its partition to the time of created_at
-    // Only update if the compaction level is not Final which signal more compaction needed
-    if compaction_level < CompactionLevel::Final {
-        let partition = stage
-            .partitions
-            .iter_mut()
-            .find(|p| p.id == partition_id)
-            .ok_or(Error::PartitionNotFound {
-                id: TransitionPartitionId::Deprecated(partition_id),
-            })?;
-        partition.new_file_at = Some(created_at);
-    }
+    let partition = stage
+        .partitions
+        .iter_mut()
+        .find(|p| p.id == partition_id)
+        .ok_or(Error::PartitionNotFound {
+            id: TransitionPartitionId::Deprecated(partition_id),
+        })?;
+    partition.new_file_at = Some(created_at);
 
     Ok(stage.parquet_files.last().unwrap().clone())
 }


### PR DESCRIPTION
This PR updates `new_file_at` for all new files. Previously, it only updated `new_file_at` for new L0s and L1s. I've observed on backed up partitions, if they have a lot of L1s to compact to L2s, they may time out during that.  In that case, since all they were doing is creating new L2s, `new_file_at` wasn't updated, allowing the partition to become cold.  So it never finishes compacting.

Helps: https://github.com/influxdata/idpe/issues/17902

- [x] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb_iox/blob/main/README.md).
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
