### PR TITLE
fix: Reject `time` as a tag value for custom partition templates

### DIFF
--- a/data_types/src/partition_template.rs
+++ b/data_types/src/partition_template.rs
@@ -451,7 +451,7 @@ mod serialization {
 
                         if value.contains(TAG_VALUE_KEY_TIME) {
                             return Err(ValidationError::InvalidTagValue(format!(
-                                "{TAG_VALUE_KEY_TIME} cannot not be used"
+                                "{TAG_VALUE_KEY_TIME} cannot be used"
                             )));
                         }
                     }


### PR DESCRIPTION
By rejecting `time` for TagValue parts and preventing it during template construction code-paths this should be enough to close #8320.

---

* fix: Reject `time` as a tag value for custom partition templates (aac4166bf)

      Time has a special meaning and can be partitioned on by the strftime
      formatter. It should not be used as a tag value part in a custom
      partitioning template.