### PR TITLE
test(bench): ingester query partition pruning

### DIFF
--- a/ingester/benches/write.rs
+++ b/ingester/benches/write.rs
@@ -33,7 +33,7 @@ async fn init(lp: impl AsRef<str>) -> (TestContext<impl IngesterRpcInterface>, D
         .await;
 
     // Ensure the namespace exists in the catalog.
-    let ns = ctx.ensure_namespace(TEST_NAMESPACE, None).await;
+    let ns = ctx.ensure_namespace(TEST_NAMESPACE, None, None).await;
 
     // Perform a write to drive table / schema population in the catalog.
     ctx.write_lp(

--- a/ingester/tests/query.rs
+++ b/ingester/tests/query.rs
@@ -9,7 +9,7 @@ use metric::{DurationHistogram, U64Histogram};
 async fn write_query() {
     let namespace_name = "write_query_test_namespace";
     let mut ctx = TestContextBuilder::default().build().await;
-    let ns = ctx.ensure_namespace(namespace_name, None).await;
+    let ns = ctx.ensure_namespace(namespace_name, None, None).await;
 
     // Initial write
     let partition_key = PartitionKey::from("1970-01-01");
@@ -94,7 +94,7 @@ async fn write_query() {
 async fn write_query_projection() {
     let namespace_name = "write_query_test_namespace";
     let mut ctx = TestContextBuilder::default().build().await;
-    let ns = ctx.ensure_namespace(namespace_name, None).await;
+    let ns = ctx.ensure_namespace(namespace_name, None, None).await;
 
     // Initial write
     let partition_key = PartitionKey::from("1970-01-01");

--- a/ingester/tests/write.rs
+++ b/ingester/tests/write.rs
@@ -23,7 +23,7 @@ use trace::{ctx::SpanContext, RingBufferTraceCollector};
 async fn write_persist() {
     let namespace_name = "write_query_test_namespace";
     let mut ctx = TestContextBuilder::default().build().await;
-    let ns = ctx.ensure_namespace(namespace_name, None).await;
+    let ns = ctx.ensure_namespace(namespace_name, None, None).await;
 
     let partition_key = PartitionKey::from("1970-01-01");
     ctx.write_lp(
@@ -191,7 +191,7 @@ async fn wal_replay() {
             .build()
             .await;
 
-        let ns = ctx.ensure_namespace(namespace_name, None).await;
+        let ns = ctx.ensure_namespace(namespace_name, None, None).await;
 
         // Initial write
         let partition_key = PartitionKey::from("1970-01-01");
@@ -285,7 +285,7 @@ async fn graceful_shutdown() {
         .build()
         .await;
 
-    let ns = ctx.ensure_namespace(namespace_name, None).await;
+    let ns = ctx.ensure_namespace(namespace_name, None, None).await;
     let namespace_id = ns.id;
 
     // Initial write
@@ -394,7 +394,7 @@ async fn wal_reference_dropping() {
         .build()
         .await;
 
-    let ns = ctx.ensure_namespace(TEST_NAMESPACE_NAME, None).await;
+    let ns = ctx.ensure_namespace(TEST_NAMESPACE_NAME, None, None).await;
 
     // Initial write
     let partition_key = PartitionKey::from("1970-01-01");
@@ -497,7 +497,7 @@ fn get_file_names_in_dir(dir: &Path) -> Result<Vec<OsString>, std::io::Error> {
 async fn write_tracing() {
     let namespace_name = "write_tracing_test_namespace";
     let mut ctx = TestContextBuilder::default().build().await;
-    let ns = ctx.ensure_namespace(namespace_name, None).await;
+    let ns = ctx.ensure_namespace(namespace_name, None, None).await;
 
     let trace_collector = Arc::new(RingBufferTraceCollector::new(5));
     let span_ctx = SpanContext::new(Arc::new(Arc::clone(&trace_collector)));

--- a/ingester_test_ctx/src/lib.rs
+++ b/ingester_test_ctx/src/lib.rs
@@ -22,8 +22,8 @@ use std::{collections::HashMap, sync::Arc, time::Duration};
 use arrow::record_batch::RecordBatch;
 use arrow_flight::{decode::FlightRecordBatchStream, flight_service_server::FlightService, Ticket};
 use data_types::{
-    partition_template::TablePartitionTemplateOverride, Namespace, NamespaceId, NamespaceSchema,
-    ParquetFile, PartitionKey, SequenceNumber, TableId,
+    partition_template::{NamespacePartitionTemplateOverride, TablePartitionTemplateOverride},
+    Namespace, NamespaceId, NamespaceSchema, ParquetFile, PartitionKey, SequenceNumber, TableId,
 };
 use dml::{DmlMeta, DmlWrite};
 use futures::{stream::FuturesUnordered, FutureExt, StreamExt, TryStreamExt};
@@ -222,6 +222,7 @@ where
         &mut self,
         name: &str,
         retention_period_ns: Option<i64>,
+        partition_template: Option<NamespacePartitionTemplateOverride>,
     ) -> Namespace {
         let mut repos = self.catalog.repositories().await;
         let ns = arbitrary_namespace(&mut *repos, name).await;
@@ -236,7 +237,7 @@ where
                         max_columns_per_table: iox_catalog::DEFAULT_MAX_COLUMNS_PER_TABLE as usize,
                         max_tables: iox_catalog::DEFAULT_MAX_TABLES as usize,
                         retention_period_ns,
-                        partition_template: Default::default(),
+                        partition_template: partition_template.unwrap_or_default(),
                     },
                 )
                 .is_none(),


### PR DESCRIPTION
If you can't measure it, you're not optimising it.

---

* test(bench): ingester query partition pruning (32414acb0)
      
      Adds benchmarks that exercise partition pruning during query execution
      within the ingester, for varying partition counts within a table, and
      varying row counts within each partition.