### PR TITLE
feat(idpe-17789): provide CompactionJob throughout compactor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -982,6 +982,7 @@ dependencies = [
  "metric",
  "object_store",
  "observability_deps",
+ "parking_lot",
  "parquet_file",
  "rand",
  "schema",

--- a/compactor/Cargo.toml
+++ b/compactor/Cargo.toml
@@ -30,6 +30,7 @@ trace = { version = "0.1.0", path = "../trace" }
 tracker = { path = "../tracker" }
 uuid = { version = "1", features = ["v4"] }
 workspace-hack = { version = "0.1", path = "../workspace-hack" }
+parking_lot = "0.12.1"
 
 [dev-dependencies]
 arrow_util = { path = "../arrow_util" }

--- a/compactor/src/components/hardcoded.rs
+++ b/compactor/src/components/hardcoded.rs
@@ -4,7 +4,7 @@
 
 use std::{sync::Arc, time::Duration};
 
-use compactor_scheduler::{create_scheduler, PartitionsSource, Scheduler};
+use compactor_scheduler::{create_scheduler, Scheduler};
 use data_types::CompactionLevel;
 use object_store::memory::InMemory;
 
@@ -64,7 +64,7 @@ use super::{
         logging::LoggingPartitionsSourceWrapper, metrics::MetricsPartitionsSourceWrapper,
         not_empty::NotEmptyPartitionsSourceWrapper,
         randomize_order::RandomizeOrderPartitionsSourcesWrapper,
-        scheduled::ScheduledPartitionsSource,
+        scheduled::ScheduledPartitionsSource, PartitionsSource,
     },
     post_classification_partition_filter::{
         logging::LoggingPostClassificationFilterWrapper,

--- a/compactor/src/components/partition_stream/endless.rs
+++ b/compactor/src/components/partition_stream/endless.rs
@@ -1,10 +1,11 @@
 use std::{collections::VecDeque, fmt::Display, sync::Arc};
 
-use compactor_scheduler::PartitionsSource;
 use data_types::PartitionId;
 use futures::{stream::BoxStream, StreamExt};
 
-use super::super::partition_files_source::rate_limit::RateLimit;
+use super::super::{
+    partition_files_source::rate_limit::RateLimit, partitions_source::PartitionsSource,
+};
 use super::PartitionStream;
 
 #[derive(Debug)]
@@ -79,9 +80,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use compactor_scheduler::MockPartitionsSource;
-
-    use super::*;
+    use super::{super::super::partitions_source::mock::MockPartitionsSource, *};
 
     #[test]
     fn test_display() {

--- a/compactor/src/components/partition_stream/mod.rs
+++ b/compactor/src/components/partition_stream/mod.rs
@@ -1,6 +1,6 @@
 use std::fmt::{Debug, Display};
 
-use data_types::PartitionId;
+use compactor_scheduler::CompactionJob;
 use futures::stream::BoxStream;
 
 pub mod endless;
@@ -8,8 +8,8 @@ pub mod once;
 
 /// Source for partitions.
 pub trait PartitionStream: Debug + Display + Send + Sync {
-    /// Create new source stream of partitions.
+    /// Create new source stream of compaction job.
     ///
     /// This stream may be endless.
-    fn stream(&self) -> BoxStream<'_, PartitionId>;
+    fn stream(&self) -> BoxStream<'_, CompactionJob>;
 }

--- a/compactor/src/components/partition_stream/once.rs
+++ b/compactor/src/components/partition_stream/once.rs
@@ -1,6 +1,6 @@
 use std::{fmt::Display, sync::Arc};
 
-use data_types::PartitionId;
+use compactor_scheduler::CompactionJob;
 use futures::{stream::BoxStream, StreamExt};
 
 use super::{super::partitions_source::PartitionsSource, PartitionStream};
@@ -37,7 +37,7 @@ impl<T> PartitionStream for OncePartititionStream<T>
 where
     T: PartitionsSource,
 {
-    fn stream(&self) -> BoxStream<'_, PartitionId> {
+    fn stream(&self) -> BoxStream<'_, CompactionJob> {
         let source = Arc::clone(&self.source);
         futures::stream::once(async move { futures::stream::iter(source.fetch().await) })
             .flatten()
@@ -47,6 +47,8 @@ where
 
 #[cfg(test)]
 mod tests {
+    use data_types::PartitionId;
+
     use super::{super::super::partitions_source::mock::MockPartitionsSource, *};
 
     #[test]
@@ -58,9 +60,9 @@ mod tests {
     #[tokio::test]
     async fn test_stream() {
         let ids = vec![
-            PartitionId::new(1),
-            PartitionId::new(3),
-            PartitionId::new(2),
+            CompactionJob::new(PartitionId::new(1)),
+            CompactionJob::new(PartitionId::new(3)),
+            CompactionJob::new(PartitionId::new(2)),
         ];
         let stream = OncePartititionStream::new(MockPartitionsSource::new(ids.clone()));
 

--- a/compactor/src/components/partition_stream/once.rs
+++ b/compactor/src/components/partition_stream/once.rs
@@ -1,10 +1,9 @@
 use std::{fmt::Display, sync::Arc};
 
-use compactor_scheduler::PartitionsSource;
 use data_types::PartitionId;
 use futures::{stream::BoxStream, StreamExt};
 
-use super::PartitionStream;
+use super::{super::partitions_source::PartitionsSource, PartitionStream};
 
 #[derive(Debug)]
 pub struct OncePartititionStream<T>
@@ -48,9 +47,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use compactor_scheduler::MockPartitionsSource;
-
-    use super::*;
+    use super::{super::super::partitions_source::mock::MockPartitionsSource, *};
 
     #[test]
     fn test_display() {

--- a/compactor/src/components/partitions_source/logging.rs
+++ b/compactor/src/components/partitions_source/logging.rs
@@ -1,7 +1,7 @@
 use std::fmt::Display;
 
 use async_trait::async_trait;
-use data_types::PartitionId;
+use compactor_scheduler::CompactionJob;
 use observability_deps::tracing::{info, warn};
 
 use super::PartitionsSource;
@@ -37,7 +37,7 @@ impl<T> PartitionsSource for LoggingPartitionsSourceWrapper<T>
 where
     T: PartitionsSource,
 {
-    async fn fetch(&self) -> Vec<PartitionId> {
+    async fn fetch(&self) -> Vec<CompactionJob> {
         let partitions = self.inner.fetch().await;
         info!(n_partitions = partitions.len(), "Fetch partitions",);
         if partitions.is_empty() {
@@ -49,6 +49,7 @@ where
 
 #[cfg(test)]
 mod tests {
+    use data_types::PartitionId;
     use test_helpers::tracing::TracingCapture;
 
     use super::{super::mock::MockPartitionsSource, *};
@@ -74,9 +75,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_fetch_some() {
-        let p_1 = PartitionId::new(5);
-        let p_2 = PartitionId::new(1);
-        let p_3 = PartitionId::new(12);
+        let p_1 = CompactionJob::new(PartitionId::new(5));
+        let p_2 = CompactionJob::new(PartitionId::new(1));
+        let p_3 = CompactionJob::new(PartitionId::new(12));
         let partitions = vec![p_1, p_2, p_3];
 
         let source =

--- a/compactor/src/components/partitions_source/logging.rs
+++ b/compactor/src/components/partitions_source/logging.rs
@@ -1,9 +1,10 @@
 use std::fmt::Display;
 
 use async_trait::async_trait;
-use compactor_scheduler::PartitionsSource;
 use data_types::PartitionId;
 use observability_deps::tracing::{info, warn};
+
+use super::PartitionsSource;
 
 #[derive(Debug)]
 pub struct LoggingPartitionsSourceWrapper<T>
@@ -48,10 +49,9 @@ where
 
 #[cfg(test)]
 mod tests {
-    use compactor_scheduler::MockPartitionsSource;
     use test_helpers::tracing::TracingCapture;
 
-    use super::*;
+    use super::{super::mock::MockPartitionsSource, *};
 
     #[test]
     fn test_display() {

--- a/compactor/src/components/partitions_source/metrics.rs
+++ b/compactor/src/components/partitions_source/metrics.rs
@@ -1,7 +1,7 @@
 use std::fmt::Display;
 
 use async_trait::async_trait;
-use data_types::PartitionId;
+use compactor_scheduler::CompactionJob;
 use metric::{Registry, U64Counter};
 
 use super::PartitionsSource;
@@ -59,7 +59,7 @@ impl<T> PartitionsSource for MetricsPartitionsSourceWrapper<T>
 where
     T: PartitionsSource,
 {
-    async fn fetch(&self) -> Vec<PartitionId> {
+    async fn fetch(&self) -> Vec<CompactionJob> {
         let partitions = self.inner.fetch().await;
         self.partitions_fetch_counter.inc(1);
         self.partitions_counter.inc(partitions.len() as u64);
@@ -69,6 +69,7 @@ where
 
 #[cfg(test)]
 mod tests {
+    use data_types::PartitionId;
     use metric::assert_counter;
 
     use super::{super::mock::MockPartitionsSource, *};
@@ -85,9 +86,9 @@ mod tests {
     async fn test_fetch() {
         let registry = Registry::new();
         let partitions = vec![
-            PartitionId::new(5),
-            PartitionId::new(1),
-            PartitionId::new(12),
+            CompactionJob::new(PartitionId::new(5)),
+            CompactionJob::new(PartitionId::new(1)),
+            CompactionJob::new(PartitionId::new(12)),
         ];
         let source = MetricsPartitionsSourceWrapper::new(
             MockPartitionsSource::new(partitions.clone()),

--- a/compactor/src/components/partitions_source/metrics.rs
+++ b/compactor/src/components/partitions_source/metrics.rs
@@ -1,9 +1,10 @@
 use std::fmt::Display;
 
 use async_trait::async_trait;
-use compactor_scheduler::PartitionsSource;
 use data_types::PartitionId;
 use metric::{Registry, U64Counter};
+
+use super::PartitionsSource;
 
 const METRIC_NAME_PARTITIONS_FETCH_COUNT: &str = "iox_compactor_partitions_fetch_count";
 const METRIC_NAME_PARTITIONS_COUNT: &str = "iox_compactor_partitions_count";
@@ -68,10 +69,9 @@ where
 
 #[cfg(test)]
 mod tests {
-    use compactor_scheduler::MockPartitionsSource;
     use metric::assert_counter;
 
-    use super::*;
+    use super::{super::mock::MockPartitionsSource, *};
 
     #[test]
     fn test_display() {

--- a/compactor/src/components/partitions_source/mock.rs
+++ b/compactor/src/components/partitions_source/mock.rs
@@ -1,27 +1,27 @@
 use async_trait::async_trait;
-use data_types::PartitionId;
+use compactor_scheduler::CompactionJob;
 use parking_lot::Mutex;
 
 use super::PartitionsSource;
 
-/// A mock structure for providing [partitions](PartitionId).
+/// A mock structure for providing [partitions](CompactionJob).
 #[derive(Debug)]
 pub struct MockPartitionsSource {
-    partitions: Mutex<Vec<PartitionId>>,
+    partitions: Mutex<Vec<CompactionJob>>,
 }
 
 impl MockPartitionsSource {
     #[allow(dead_code)]
     /// Create a new MockPartitionsSource.
-    pub fn new(partitions: Vec<PartitionId>) -> Self {
+    pub fn new(partitions: Vec<CompactionJob>) -> Self {
         Self {
             partitions: Mutex::new(partitions),
         }
     }
 
-    /// Set PartitionIds for MockPartitionsSource.
+    /// Set CompactionJobs for MockPartitionsSource.
     #[allow(dead_code)] // not used anywhere
-    pub fn set(&self, partitions: Vec<PartitionId>) {
+    pub fn set(&self, partitions: Vec<CompactionJob>) {
         *self.partitions.lock() = partitions;
     }
 }
@@ -34,13 +34,15 @@ impl std::fmt::Display for MockPartitionsSource {
 
 #[async_trait]
 impl PartitionsSource for MockPartitionsSource {
-    async fn fetch(&self) -> Vec<PartitionId> {
+    async fn fetch(&self) -> Vec<CompactionJob> {
         self.partitions.lock().clone()
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use data_types::PartitionId;
+
     use super::*;
 
     #[test]
@@ -53,9 +55,9 @@ mod tests {
         let source = MockPartitionsSource::new(vec![]);
         assert_eq!(source.fetch().await, vec![],);
 
-        let p_1 = PartitionId::new(5);
-        let p_2 = PartitionId::new(1);
-        let p_3 = PartitionId::new(12);
+        let p_1 = CompactionJob::new(PartitionId::new(5));
+        let p_2 = CompactionJob::new(PartitionId::new(1));
+        let p_3 = CompactionJob::new(PartitionId::new(12));
         let parts = vec![p_1, p_2, p_3];
         source.set(parts.clone());
         assert_eq!(source.fetch().await, parts,);

--- a/compactor/src/components/partitions_source/mock.rs
+++ b/compactor/src/components/partitions_source/mock.rs
@@ -1,0 +1,63 @@
+use async_trait::async_trait;
+use data_types::PartitionId;
+use parking_lot::Mutex;
+
+use super::PartitionsSource;
+
+/// A mock structure for providing [partitions](PartitionId).
+#[derive(Debug)]
+pub struct MockPartitionsSource {
+    partitions: Mutex<Vec<PartitionId>>,
+}
+
+impl MockPartitionsSource {
+    #[allow(dead_code)]
+    /// Create a new MockPartitionsSource.
+    pub fn new(partitions: Vec<PartitionId>) -> Self {
+        Self {
+            partitions: Mutex::new(partitions),
+        }
+    }
+
+    /// Set PartitionIds for MockPartitionsSource.
+    #[allow(dead_code)] // not used anywhere
+    pub fn set(&self, partitions: Vec<PartitionId>) {
+        *self.partitions.lock() = partitions;
+    }
+}
+
+impl std::fmt::Display for MockPartitionsSource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "mock")
+    }
+}
+
+#[async_trait]
+impl PartitionsSource for MockPartitionsSource {
+    async fn fetch(&self) -> Vec<PartitionId> {
+        self.partitions.lock().clone()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_display() {
+        assert_eq!(MockPartitionsSource::new(vec![]).to_string(), "mock",);
+    }
+
+    #[tokio::test]
+    async fn test_fetch() {
+        let source = MockPartitionsSource::new(vec![]);
+        assert_eq!(source.fetch().await, vec![],);
+
+        let p_1 = PartitionId::new(5);
+        let p_2 = PartitionId::new(1);
+        let p_3 = PartitionId::new(12);
+        let parts = vec![p_1, p_2, p_3];
+        source.set(parts.clone());
+        assert_eq!(source.fetch().await, parts,);
+    }
+}

--- a/compactor/src/components/partitions_source/mod.rs
+++ b/compactor/src/components/partitions_source/mod.rs
@@ -1,6 +1,6 @@
 //! Abstractions that provide functionality over a [`PartitionsSource`] of PartitionIds.
 //!
-//! These abstractions are for actions taken in a compactor using the PartitionIds received from a compactor_scheduler.
+//! These abstractions are for actions taken in a compactor using the CompactionJobs received from a compactor_scheduler.
 pub mod logging;
 pub mod metrics;
 pub mod mock;
@@ -14,9 +14,9 @@ use std::{
 };
 
 use async_trait::async_trait;
-use data_types::PartitionId;
+use compactor_scheduler::CompactionJob;
 
-/// A source of partitions, noted by [`PartitionId`](data_types::PartitionId), that may potentially need compacting.
+/// A source of partitions, noted by [`CompactionJob`](compactor_scheduler::CompactionJob), that may potentially need compacting.
 #[async_trait]
 pub trait PartitionsSource: Debug + Display + Send + Sync {
     /// Get partition IDs.
@@ -24,7 +24,7 @@ pub trait PartitionsSource: Debug + Display + Send + Sync {
     /// This method performs retries.
     ///
     /// This should only perform basic, efficient filtering. It MUST NOT inspect individual parquet files.
-    async fn fetch(&self) -> Vec<PartitionId>;
+    async fn fetch(&self) -> Vec<CompactionJob>;
 }
 
 #[async_trait]
@@ -32,7 +32,7 @@ impl<T> PartitionsSource for Arc<T>
 where
     T: PartitionsSource + ?Sized,
 {
-    async fn fetch(&self) -> Vec<PartitionId> {
+    async fn fetch(&self) -> Vec<CompactionJob> {
         self.as_ref().fetch().await
     }
 }

--- a/compactor/src/components/partitions_source/mod.rs
+++ b/compactor/src/components/partitions_source/mod.rs
@@ -1,8 +1,38 @@
-//! Abstractions that provide functionality over a [`PartitionsSource`](compactor_scheduler::PartitionsSource) of PartitionIds.
+//! Abstractions that provide functionality over a [`PartitionsSource`] of PartitionIds.
 //!
 //! These abstractions are for actions taken in a compactor using the PartitionIds received from a compactor_scheduler.
 pub mod logging;
 pub mod metrics;
+pub mod mock;
 pub mod not_empty;
 pub mod randomize_order;
 pub mod scheduled;
+
+use std::{
+    fmt::{Debug, Display},
+    sync::Arc,
+};
+
+use async_trait::async_trait;
+use data_types::PartitionId;
+
+/// A source of partitions, noted by [`PartitionId`](data_types::PartitionId), that may potentially need compacting.
+#[async_trait]
+pub trait PartitionsSource: Debug + Display + Send + Sync {
+    /// Get partition IDs.
+    ///
+    /// This method performs retries.
+    ///
+    /// This should only perform basic, efficient filtering. It MUST NOT inspect individual parquet files.
+    async fn fetch(&self) -> Vec<PartitionId>;
+}
+
+#[async_trait]
+impl<T> PartitionsSource for Arc<T>
+where
+    T: PartitionsSource + ?Sized,
+{
+    async fn fetch(&self) -> Vec<PartitionId> {
+        self.as_ref().fetch().await
+    }
+}

--- a/compactor/src/components/partitions_source/not_empty.rs
+++ b/compactor/src/components/partitions_source/not_empty.rs
@@ -1,9 +1,10 @@
 use std::{fmt::Display, sync::Arc, time::Duration};
 
 use async_trait::async_trait;
-use compactor_scheduler::PartitionsSource;
 use data_types::PartitionId;
 use iox_time::TimeProvider;
+
+use super::PartitionsSource;
 
 #[derive(Debug)]
 pub struct NotEmptyPartitionsSourceWrapper<T>
@@ -55,11 +56,10 @@ where
 
 #[cfg(test)]
 mod tests {
-    use compactor_scheduler::MockPartitionsSource;
     use compactor_test_utils::AssertFutureExt;
     use iox_time::{MockProvider, Time};
 
-    use super::*;
+    use super::{super::mock::MockPartitionsSource, *};
 
     #[test]
     fn test_display() {

--- a/compactor/src/components/partitions_source/not_empty.rs
+++ b/compactor/src/components/partitions_source/not_empty.rs
@@ -1,7 +1,7 @@
 use std::{fmt::Display, sync::Arc, time::Duration};
 
 use async_trait::async_trait;
-use data_types::PartitionId;
+use compactor_scheduler::CompactionJob;
 use iox_time::TimeProvider;
 
 use super::PartitionsSource;
@@ -43,7 +43,7 @@ impl<T> PartitionsSource for NotEmptyPartitionsSourceWrapper<T>
 where
     T: PartitionsSource,
 {
-    async fn fetch(&self) -> Vec<PartitionId> {
+    async fn fetch(&self) -> Vec<CompactionJob> {
         loop {
             let res = self.inner.fetch().await;
             if !res.is_empty() {
@@ -57,6 +57,7 @@ where
 #[cfg(test)]
 mod tests {
     use compactor_test_utils::AssertFutureExt;
+    use data_types::PartitionId;
     use iox_time::{MockProvider, Time};
 
     use super::{super::mock::MockPartitionsSource, *};
@@ -90,7 +91,7 @@ mod tests {
         fut.assert_pending().await;
 
         // insert data but system is still throttled
-        let p = PartitionId::new(5);
+        let p = CompactionJob::new(PartitionId::new(5));
         let parts = vec![p];
         inner.set(parts.clone());
         fut.assert_pending().await;

--- a/compactor/src/components/partitions_source/randomize_order.rs
+++ b/compactor/src/components/partitions_source/randomize_order.rs
@@ -1,9 +1,10 @@
 use std::fmt::Display;
 
 use async_trait::async_trait;
-use compactor_scheduler::PartitionsSource;
 use data_types::PartitionId;
 use rand::{rngs::StdRng, seq::SliceRandom, SeedableRng};
+
+use super::PartitionsSource;
 
 #[derive(Debug)]
 pub struct RandomizeOrderPartitionsSourcesWrapper<T>
@@ -47,9 +48,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use compactor_scheduler::MockPartitionsSource;
-
-    use super::*;
+    use super::{super::mock::MockPartitionsSource, *};
 
     #[test]
     fn test_display() {

--- a/compactor/src/components/partitions_source/scheduled.rs
+++ b/compactor/src/components/partitions_source/scheduled.rs
@@ -2,7 +2,6 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use compactor_scheduler::{CompactionJob, Scheduler};
-use data_types::PartitionId;
 
 use super::PartitionsSource;
 
@@ -19,9 +18,8 @@ impl ScheduledPartitionsSource {
 
 #[async_trait]
 impl PartitionsSource for ScheduledPartitionsSource {
-    async fn fetch(&self) -> Vec<PartitionId> {
-        let job: Vec<CompactionJob> = self.scheduler.get_jobs().await;
-        job.into_iter().map(|job| job.partition_id).collect()
+    async fn fetch(&self) -> Vec<CompactionJob> {
+        self.scheduler.get_jobs().await
     }
 }
 

--- a/compactor/src/components/partitions_source/scheduled.rs
+++ b/compactor/src/components/partitions_source/scheduled.rs
@@ -1,8 +1,10 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use compactor_scheduler::{CompactionJob, PartitionsSource, Scheduler};
+use compactor_scheduler::{CompactionJob, Scheduler};
 use data_types::PartitionId;
+
+use super::PartitionsSource;
 
 #[derive(Debug)]
 pub struct ScheduledPartitionsSource {

--- a/compactor/src/driver.rs
+++ b/compactor/src/driver.rs
@@ -1,6 +1,7 @@
 use std::{num::NonZeroUsize, sync::Arc, time::Duration};
 
 use chrono::Utc;
+use compactor_scheduler::CompactionJob;
 use data_types::{CompactionLevel, ParquetFile, ParquetFileParams, PartitionId};
 use futures::{stream, StreamExt, TryStreamExt};
 use iox_query::exec::query_tracing::send_metrics_to_tracing;
@@ -36,7 +37,7 @@ pub async fn compact(
     components
         .partition_stream
         .stream()
-        .map(|partition_id| {
+        .map(|job| {
             let components = Arc::clone(components);
 
             // A root span is created for each partition.  Later this can be linked to the
@@ -48,7 +49,7 @@ pub async fn compact(
 
             compact_partition(
                 span,
-                partition_id,
+                job,
                 partition_timeout,
                 Arc::clone(&df_semaphore),
                 components,
@@ -61,11 +62,12 @@ pub async fn compact(
 
 async fn compact_partition(
     mut span: SpanRecorder,
-    partition_id: PartitionId,
+    job: CompactionJob,
     partition_timeout: Duration,
     df_semaphore: Arc<InstrumentedAsyncSemaphore>,
     components: Arc<Components>,
 ) {
+    let partition_id = job.partition_id;
     info!(partition_id = partition_id.get(), timeout = ?partition_timeout, "compact partition",);
     span.set_metadata("partition_id", partition_id.get().to_string());
     let scratchpad = components.scratchpad_gen.pad();
@@ -76,7 +78,7 @@ async fn compact_partition(
         async {
             try_compact_partition(
                 span,
-                partition_id,
+                job.clone(),
                 df_semaphore,
                 components,
                 scratchpad,
@@ -203,12 +205,13 @@ async fn compact_partition(
 ///   . Round 2 happens or not depends on the stop condition
 async fn try_compact_partition(
     span: SpanRecorder,
-    partition_id: PartitionId,
+    job: CompactionJob,
     df_semaphore: Arc<InstrumentedAsyncSemaphore>,
     components: Arc<Components>,
     scratchpad_ctx: Arc<dyn Scratchpad>,
     transmit_progress_signal: Sender<bool>,
 ) -> Result<(), DynError> {
+    let partition_id = job.partition_id;
     let mut files = components.partition_files_source.fetch(partition_id).await;
     let partition_info = components.partition_info_source.fetch(partition_id).await?;
     let transmit_progress_signal = Arc::new(transmit_progress_signal);
@@ -269,12 +272,13 @@ async fn try_compact_partition(
                 let df_semaphore = Arc::clone(&df_semaphore);
                 let transmit_progress_signal = Arc::clone(&transmit_progress_signal);
                 let scratchpad = Arc::clone(&scratchpad_ctx);
+                let job = job.clone();
                 let branch_span = round_span.child("branch");
 
                 async move {
                     execute_branch(
                         branch_span,
-                        partition_id,
+                        job,
                         branch,
                         df_semaphore,
                         components,
@@ -298,7 +302,7 @@ async fn try_compact_partition(
 #[allow(clippy::too_many_arguments)]
 async fn execute_branch(
     span: SpanRecorder,
-    partition_id: PartitionId,
+    job: CompactionJob,
     branch: Vec<ParquetFile>,
     df_semaphore: Arc<InstrumentedAsyncSemaphore>,
     components: Arc<Components>,
@@ -418,7 +422,7 @@ async fn execute_branch(
         // files and update the upgraded files
         let (created_files, upgraded_files) = update_catalog(
             Arc::clone(&components),
-            partition_id,
+            job.clone(),
             &saved_parquet_file_state,
             files_to_delete,
             upgrade,
@@ -627,13 +631,14 @@ async fn fetch_and_save_parquet_file_state(
 /// Return created and upgraded files
 async fn update_catalog(
     components: Arc<Components>,
-    partition_id: PartitionId,
+    job: CompactionJob,
     saved_parquet_file_state: &SavedParquetFileState,
     files_to_delete: Vec<ParquetFile>,
     files_to_upgrade: Vec<ParquetFile>,
     file_params_to_create: Vec<ParquetFileParams>,
     target_level: CompactionLevel,
 ) -> Result<(Vec<ParquetFile>, Vec<ParquetFile>), DynError> {
+    let partition_id = job.partition_id;
     let current_parquet_file_state =
         fetch_and_save_parquet_file_state(&components, partition_id).await;
 

--- a/compactor_scheduler/src/lib.rs
+++ b/compactor_scheduler/src/lib.rs
@@ -50,7 +50,7 @@ pub(crate) use local_scheduler::{
 
 // partitions_source trait
 mod partitions_source;
-pub use partitions_source::*;
+pub(crate) use partitions_source::*;
 
 // scheduler trait and associated types
 mod scheduler;

--- a/compactor_scheduler/src/partitions_source.rs
+++ b/compactor_scheduler/src/partitions_source.rs
@@ -9,7 +9,7 @@ use parking_lot::Mutex;
 
 /// A source of partitions, noted by [`PartitionId`](data_types::PartitionId), that may potentially need compacting.
 #[async_trait]
-pub trait PartitionsSource: Debug + Display + Send + Sync {
+pub(crate) trait PartitionsSource: Debug + Display + Send + Sync {
     /// Get partition IDs.
     ///
     /// This method performs retries.
@@ -28,19 +28,19 @@ where
     }
 }
 
-pub use mock::MockPartitionsSource;
+pub(crate) use mock::MockPartitionsSource;
 mod mock {
     use super::*;
 
     /// A mock structure for providing [partitions](PartitionId).
     #[derive(Debug)]
-    pub struct MockPartitionsSource {
+    pub(crate) struct MockPartitionsSource {
         partitions: Mutex<Vec<PartitionId>>,
     }
 
     impl MockPartitionsSource {
         /// Create a new MockPartitionsSource.
-        pub fn new(partitions: Vec<PartitionId>) -> Self {
+        pub(crate) fn new(partitions: Vec<PartitionId>) -> Self {
             Self {
                 partitions: Mutex::new(partitions),
             }
@@ -48,7 +48,7 @@ mod mock {
 
         /// Set PartitionIds for MockPartitionsSource.
         #[allow(dead_code)] // not used anywhere
-        pub fn set(&self, partitions: Vec<PartitionId>) {
+        pub(crate) fn set(&self, partitions: Vec<PartitionId>) {
             *self.partitions.lock() = partitions;
         }
     }

--- a/compactor_scheduler/src/scheduler.rs
+++ b/compactor_scheduler/src/scheduler.rs
@@ -60,7 +60,7 @@ impl std::fmt::Display for SchedulerConfig {
 }
 
 /// Job assignment for a given partition.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct CompactionJob {
     #[allow(dead_code)]
     /// Unique identifier for this job.


### PR DESCRIPTION
Part of https://github.com/influxdata/idpe/issues/17789

Move the compactor to have awareness of `CompactionJob`, not just partition id. This meant:
* ensuring that the CompactionJob was exposed to all required levels of the compactor concurrency and branching.
    * this includes where the update_job_status() and end_job() messages are transmitted. 
* easiest way was to enable the source of our partitions (a.k.a. PartitionsSource and PartitionStream) to provide `CompactionJob`


The functional changes are in this PR.
All the renamings (no functional changes) are in [this followup PR](https://github.com/influxdata/influxdb_iox/pull/8326).


---
* refactor(idpe-17789): move PartitionsSource to be separate traits in scheduler vs compactor (82d55fd6b)


* chore(idpe-17789): make PartitionsSource be crate private for scheduler (817bd595c)


* feat(idpe-17789): move Compactor abstractions PartitionsSource and PartitionStream to use CompactionJob (bab6f239e)



## Checklist
- [x] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb_iox/blob/main/README.md).
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
