### PR TITLE
feat(router): Expose circuit breaker healthcheck `ERROR_WINDOW` for config 

### DIFF
--- a/clap_blocks/src/router.rs
+++ b/clap_blocks/src/router.rs
@@ -126,10 +126,10 @@ pub struct RouterConfig {
     )]
     pub rpc_write_replicas: NonZeroUsize,
 
-    /// Specify the (discrete) slices of time in which the
-    // [`router::dml_handlers::rpc_write::circuit_breaker::CircuitBreaker`] must
-    /// exceed its maximum error ratio for downstream RPC write handler to be
-    /// considered in the unhealthy state.
+    /// Specify the (discrete) slices of time in which the router's write
+    /// request failures must exceed the write client's maximum error ratio of
+    /// 80% for a downstream RPC write handler to be considered in the unhealthy
+    /// state.
     #[clap(
         long = "rpc-write-health-error-window-seconds",
         env = "INFLUXDB_IOX_RPC_WRITE_HEALTH_ERROR_WINDOW_SECONDS",

--- a/clap_blocks/src/router.rs
+++ b/clap_blocks/src/router.rs
@@ -125,6 +125,18 @@ pub struct RouterConfig {
         default_value = "1"
     )]
     pub rpc_write_replicas: NonZeroUsize,
+
+    /// Specify the (discrete) slices of time in which the
+    // [`router::dml_handlers::rpc_write::circuit_breaker::CircuitBreaker`] must
+    /// exceed its maximum error ratio for downstream RPC write handler to be
+    /// considered in the unhealthy state.
+    #[clap(
+        long = "rpc-write-health-error-window-seconds",
+        env = "INFLUXDB_IOX_RPC_WRITE_HEALTH_ERROR_WINDOW_SECONDS",
+        default_value = "5",
+        value_parser = parse_duration
+    )]
+    pub rpc_write_health_error_window_seconds: Duration,
 }
 
 /// Map a string containing an integer number of seconds into a [`Duration`].

--- a/influxdb_iox/src/commands/run/all_in_one.rs
+++ b/influxdb_iox/src/commands/run/all_in_one.rs
@@ -488,6 +488,7 @@ impl Config {
             rpc_write_timeout_seconds: Duration::new(3, 0),
             rpc_write_replicas: 1.try_into().unwrap(),
             rpc_write_max_outgoing_bytes: ingester_config.rpc_write_max_incoming_bytes,
+            rpc_write_health_error_window_seconds: Duration::from_secs(5),
         };
 
         // create a CompactorConfig for the all in one server based on

--- a/ioxd_router/src/lib.rs
+++ b/ioxd_router/src/lib.rs
@@ -240,6 +240,7 @@ pub async fn create_router_server_type(
         ingester_connections,
         router_config.rpc_write_replicas,
         &metrics,
+        router_config.rpc_write_health_error_window_seconds,
     );
     let rpc_writer = InstrumentationDecorator::new("rpc_writer", &metrics, rpc_writer);
 

--- a/router/src/dml_handlers/rpc_write/balancer.rs
+++ b/router/src/dml_handlers/rpc_write/balancer.rs
@@ -219,6 +219,8 @@ mod tests {
 
     use super::*;
 
+    const ARBITRARY_TEST_ERROR_WINDOW: Duration = Duration::from_secs(5);
+
     /// No healthy nodes prevents a snapshot from being returned.
     #[tokio::test]
     async fn test_balancer_empty_iter() {
@@ -227,16 +229,22 @@ mod tests {
         let circuit_err_1 = Arc::new(MockCircuitBreaker::default());
         circuit_err_1.set_healthy(false);
         circuit_err_1.set_should_probe(false);
-        let client_err_1 =
-            CircuitBreakingClient::new(Arc::new(MockWriteClient::default()), "bananas")
-                .with_circuit_breaker(Arc::clone(&circuit_err_1));
+        let client_err_1 = CircuitBreakingClient::new(
+            Arc::new(MockWriteClient::default()),
+            "bananas",
+            ARBITRARY_TEST_ERROR_WINDOW,
+        )
+        .with_circuit_breaker(Arc::clone(&circuit_err_1));
 
         let circuit_err_2 = Arc::new(MockCircuitBreaker::default());
         circuit_err_2.set_healthy(false);
         circuit_err_2.set_should_probe(false);
-        let client_err_2 =
-            CircuitBreakingClient::new(Arc::new(MockWriteClient::default()), "bananas")
-                .with_circuit_breaker(Arc::clone(&circuit_err_2));
+        let client_err_2 = CircuitBreakingClient::new(
+            Arc::new(MockWriteClient::default()),
+            "bananas",
+            ARBITRARY_TEST_ERROR_WINDOW,
+        )
+        .with_circuit_breaker(Arc::clone(&circuit_err_2));
 
         assert_eq!(circuit_err_1.ok_count(), 0);
         assert_eq!(circuit_err_2.ok_count(), 0);
@@ -254,21 +262,31 @@ mod tests {
         let circuit_err_1 = Arc::new(MockCircuitBreaker::default());
         circuit_err_1.set_healthy(false);
         circuit_err_1.set_should_probe(true);
-        let client_err_1 =
-            CircuitBreakingClient::new(Arc::new(MockWriteClient::default()), "bananas")
-                .with_circuit_breaker(Arc::clone(&circuit_err_1));
+        let client_err_1 = CircuitBreakingClient::new(
+            Arc::new(MockWriteClient::default()),
+            "bananas",
+            ARBITRARY_TEST_ERROR_WINDOW,
+        )
+        .with_circuit_breaker(Arc::clone(&circuit_err_1));
 
         let circuit_err_2 = Arc::new(MockCircuitBreaker::default());
         circuit_err_2.set_healthy(false);
         circuit_err_2.set_should_probe(true);
-        let client_err_2 =
-            CircuitBreakingClient::new(Arc::new(MockWriteClient::default()), "bananas")
-                .with_circuit_breaker(Arc::clone(&circuit_err_2));
+        let client_err_2 = CircuitBreakingClient::new(
+            Arc::new(MockWriteClient::default()),
+            "bananas",
+            ARBITRARY_TEST_ERROR_WINDOW,
+        )
+        .with_circuit_breaker(Arc::clone(&circuit_err_2));
         let circuit_ok = Arc::new(MockCircuitBreaker::default());
         circuit_ok.set_healthy(true);
         circuit_ok.set_should_probe(false);
-        let client_ok = CircuitBreakingClient::new(Arc::new(MockWriteClient::default()), "bananas")
-            .with_circuit_breaker(Arc::clone(&circuit_ok));
+        let client_ok = CircuitBreakingClient::new(
+            Arc::new(MockWriteClient::default()),
+            "bananas",
+            ARBITRARY_TEST_ERROR_WINDOW,
+        )
+        .with_circuit_breaker(Arc::clone(&circuit_ok));
 
         let balancer = Balancer::new([client_err_1, client_err_2, client_ok], None);
 
@@ -323,21 +341,31 @@ mod tests {
         let circuit_err_1 = Arc::new(MockCircuitBreaker::default());
         circuit_err_1.set_healthy(false);
         circuit_err_1.set_should_probe(false);
-        let client_err_1 =
-            CircuitBreakingClient::new(Arc::new(MockWriteClient::default()), "bananas")
-                .with_circuit_breaker(Arc::clone(&circuit_err_1));
+        let client_err_1 = CircuitBreakingClient::new(
+            Arc::new(MockWriteClient::default()),
+            "bananas",
+            ARBITRARY_TEST_ERROR_WINDOW,
+        )
+        .with_circuit_breaker(Arc::clone(&circuit_err_1));
 
         let circuit_err_2 = Arc::new(MockCircuitBreaker::default());
         circuit_err_2.set_healthy(false);
         circuit_err_2.set_should_probe(false);
-        let client_err_2 =
-            CircuitBreakingClient::new(Arc::new(MockWriteClient::default()), "bananas")
-                .with_circuit_breaker(Arc::clone(&circuit_err_2));
+        let client_err_2 = CircuitBreakingClient::new(
+            Arc::new(MockWriteClient::default()),
+            "bananas",
+            ARBITRARY_TEST_ERROR_WINDOW,
+        )
+        .with_circuit_breaker(Arc::clone(&circuit_err_2));
 
         let circuit_ok = Arc::new(MockCircuitBreaker::default());
         circuit_ok.set_healthy(true);
-        let client_ok = CircuitBreakingClient::new(Arc::new(MockWriteClient::default()), "bananas")
-            .with_circuit_breaker(Arc::clone(&circuit_ok));
+        let client_ok = CircuitBreakingClient::new(
+            Arc::new(MockWriteClient::default()),
+            "bananas",
+            ARBITRARY_TEST_ERROR_WINDOW,
+        )
+        .with_circuit_breaker(Arc::clone(&circuit_ok));
 
         assert_eq!(circuit_ok.ok_count(), 0);
         assert_eq!(circuit_err_1.ok_count(), 0);
@@ -383,8 +411,12 @@ mod tests {
         let circuit = Arc::new(MockCircuitBreaker::default());
         circuit.set_healthy(false);
         circuit.set_should_probe(false);
-        let client = CircuitBreakingClient::new(Arc::new(MockWriteClient::default()), "bananas")
-            .with_circuit_breaker(Arc::clone(&circuit));
+        let client = CircuitBreakingClient::new(
+            Arc::new(MockWriteClient::default()),
+            "bananas",
+            ARBITRARY_TEST_ERROR_WINDOW,
+        )
+        .with_circuit_breaker(Arc::clone(&circuit));
 
         assert_eq!(circuit.ok_count(), 0);
 
@@ -432,21 +464,30 @@ mod tests {
         // two returns a healthy state, one is unhealthy.
         let circuit_err = Arc::new(MockCircuitBreaker::default());
         circuit_err.set_healthy(false);
-        let client_err =
-            CircuitBreakingClient::new(Arc::new(MockWriteClient::default()), "bananas")
-                .with_circuit_breaker(Arc::clone(&circuit_err));
+        let client_err = CircuitBreakingClient::new(
+            Arc::new(MockWriteClient::default()),
+            "bananas",
+            ARBITRARY_TEST_ERROR_WINDOW,
+        )
+        .with_circuit_breaker(Arc::clone(&circuit_err));
 
         let circuit_ok_1 = Arc::new(MockCircuitBreaker::default());
         circuit_ok_1.set_healthy(true);
-        let client_ok_1 =
-            CircuitBreakingClient::new(Arc::new(MockWriteClient::default()), "bananas")
-                .with_circuit_breaker(Arc::clone(&circuit_ok_1));
+        let client_ok_1 = CircuitBreakingClient::new(
+            Arc::new(MockWriteClient::default()),
+            "bananas",
+            ARBITRARY_TEST_ERROR_WINDOW,
+        )
+        .with_circuit_breaker(Arc::clone(&circuit_ok_1));
 
         let circuit_ok_2 = Arc::new(MockCircuitBreaker::default());
         circuit_ok_2.set_healthy(true);
-        let client_ok_2 =
-            CircuitBreakingClient::new(Arc::new(MockWriteClient::default()), "bananas")
-                .with_circuit_breaker(Arc::clone(&circuit_ok_2));
+        let client_ok_2 = CircuitBreakingClient::new(
+            Arc::new(MockWriteClient::default()),
+            "bananas",
+            ARBITRARY_TEST_ERROR_WINDOW,
+        )
+        .with_circuit_breaker(Arc::clone(&circuit_ok_2));
 
         let balancer = Balancer::new([client_err, client_ok_1, client_ok_2], None);
 
@@ -478,22 +519,31 @@ mod tests {
         let circuit_err_1 = Arc::new(MockCircuitBreaker::default());
         circuit_err_1.set_healthy(false);
         circuit_err_1.set_should_probe(false);
-        let client_err_1 =
-            CircuitBreakingClient::new(Arc::new(MockWriteClient::default()), "bad-client-1")
-                .with_circuit_breaker(Arc::clone(&circuit_err_1));
+        let client_err_1 = CircuitBreakingClient::new(
+            Arc::new(MockWriteClient::default()),
+            "bad-client-1",
+            ARBITRARY_TEST_ERROR_WINDOW,
+        )
+        .with_circuit_breaker(Arc::clone(&circuit_err_1));
 
         let circuit_err_2 = Arc::new(MockCircuitBreaker::default());
         circuit_err_2.set_healthy(false);
         circuit_err_2.set_should_probe(true);
-        let client_err_2 =
-            CircuitBreakingClient::new(Arc::new(MockWriteClient::default()), "bad-client-2")
-                .with_circuit_breaker(Arc::clone(&circuit_err_2));
+        let client_err_2 = CircuitBreakingClient::new(
+            Arc::new(MockWriteClient::default()),
+            "bad-client-2",
+            ARBITRARY_TEST_ERROR_WINDOW,
+        )
+        .with_circuit_breaker(Arc::clone(&circuit_err_2));
 
         let circuit_ok = Arc::new(MockCircuitBreaker::default());
         circuit_ok.set_healthy(true);
-        let client_ok =
-            CircuitBreakingClient::new(Arc::new(MockWriteClient::default()), "ok-client")
-                .with_circuit_breaker(Arc::clone(&circuit_ok));
+        let client_ok = CircuitBreakingClient::new(
+            Arc::new(MockWriteClient::default()),
+            "ok-client",
+            ARBITRARY_TEST_ERROR_WINDOW,
+        )
+        .with_circuit_breaker(Arc::clone(&circuit_ok));
 
         let balancer = Balancer::new([client_err_1, client_err_2, client_ok], None);
 
@@ -558,9 +608,12 @@ mod tests {
         let circuit_err = Arc::new(MockCircuitBreaker::default());
         circuit_err.set_healthy(false);
         circuit_err.set_should_probe(false);
-        let client_err =
-            CircuitBreakingClient::new(Arc::new(MockWriteClient::default()), "bad-client-1")
-                .with_circuit_breaker(Arc::clone(&circuit_err));
+        let client_err = CircuitBreakingClient::new(
+            Arc::new(MockWriteClient::default()),
+            "bad-client-1",
+            ARBITRARY_TEST_ERROR_WINDOW,
+        )
+        .with_circuit_breaker(Arc::clone(&circuit_err));
 
         let balancer = Balancer::new([client_err], None);
         assert!(balancer.endpoints().is_none());

--- a/router/src/dml_handlers/rpc_write/circuit_breaker.rs
+++ b/router/src/dml_handlers/rpc_write/circuit_breaker.rs
@@ -17,7 +17,8 @@ use tokio::{
 
 /// The limit on the ratio of the number of error requests to the number of
 /// successful requests within the configured error window to be considered
-/// healthy.
+/// healthy. If updating this value, remember to update the documentation
+/// in the CLI flag for the configurable error window.
 const MAX_ERROR_RATIO: f32 = 0.8;
 /// The maximum number of probe requests to allow when in an unhealthy state.
 const NUM_PROBES: u64 = 10;

--- a/router/src/dml_handlers/rpc_write/circuit_breaker.rs
+++ b/router/src/dml_handlers/rpc_write/circuit_breaker.rs
@@ -16,13 +16,9 @@ use tokio::{
 };
 
 /// The limit on the ratio of the number of error requests to the number of
-/// successful requests within an [`ERROR_WINDOW`] interval to be considered
+/// successful requests within the configured error window to be considered
 /// healthy.
 const MAX_ERROR_RATIO: f32 = 0.8;
-/// The (discrete) slices of time in which the error ratio must exceed
-/// [`MAX_ERROR_RATIO`] to cause the [`CircuitBreaker`] to transition to the
-/// unhealthy state.
-const ERROR_WINDOW: Duration = Duration::from_secs(5);
 /// The maximum number of probe requests to allow when in an unhealthy state.
 const NUM_PROBES: u64 = 10;
 /// The length of time during which up to [`NUM_PROBES`] are allowed when in an
@@ -64,7 +60,7 @@ const PROBE_INTERVAL: Duration = Duration::from_secs(1);
 /// # Implementation
 ///
 /// The circuit breaker is considered unhealthy when 80% ([`MAX_ERROR_RATIO`])
-/// of requests within a 5 second window [`ERROR_WINDOW`] fail. The breaker
+/// of requests within the configured error window fail. The breaker
 /// becomes healthy again when the error rate falls below 80%
 /// ([`MAX_ERROR_RATIO`]) for the, at most, 10 probe requests ([`NUM_PROBES`])
 /// allowed through within 1 second ([`PROBE_INTERVAL`]).
@@ -80,7 +76,7 @@ const PROBE_INTERVAL: Duration = Duration::from_secs(1);
 ///     breaker is considered healthy when the ratio of the number of error
 ///     requests to the number of successful requests in the current window is
 ///     less than [`MAX_ERROR_RATIO`]. If the ratio of errors exceeds
-///     [`MAX_ERROR_RATIO`] within a single [`ERROR_WINDOW`] duration of time,
+///     [`MAX_ERROR_RATIO`] within a single error window,
 ///     the circuit breaker is then considered to be in the "open/unhealthy"
 ///     state.
 ///
@@ -102,12 +98,12 @@ const PROBE_INTERVAL: Duration = Duration::from_secs(1);
 ///
 /// Successful requests and errors are recorded when passed to
 /// [`CircuitBreaker::observe()`]. These counters are reset at intervals of
-/// [`ERROR_WINDOW`], meaning that the ratio of errors must exceed
+/// the configured error window, meaning that the ratio of errors must exceed
 /// [`MAX_ERROR_RATIO`] within a single window to open the circuit breaker to
 /// start being considered unhealthy.
 ///
-/// A floor of at least `MAX_ERROR_RATIO * NUM_PROBES` must be observed per
-/// [`ERROR_WINDOW`] before the circuit breaker opens / becomes unhealthy.
+/// A floor of at least [`MAX_ERROR_RATIO`] * [`NUM_PROBES`] must be observed per
+/// error window before the circuit breaker opens / becomes unhealthy.
 ///
 /// Error ratios are measured on every call to [`CircuitBreaker::is_healthy`],
 /// which should be done before determining whether to perform each request.
@@ -121,8 +117,8 @@ const PROBE_INTERVAL: Duration = Duration::from_secs(1);
 ///
 /// ## Probing / Closing (becoming healthy)
 ///
-/// Once a circuit breaker transitions to "open/unhealthy", up to [`NUM_PROBES`]
-/// requests are allowed per [`PROBE_INTERVAL`], as determined by calling
+/// Once a circuit breaker transitions to "open/unhealthy", up to 10 [`NUM_PROBES`]
+/// requests are allowed per 1s [`PROBE_INTERVAL`], as determined by calling
 /// [`CircuitBreaker::should_probe`] before sending a request. This is referred
 /// to as "probing", allowing the client to discover the state of the
 /// (potentially unavailable) remote while bounding the number of requests that
@@ -145,7 +141,7 @@ const PROBE_INTERVAL: Duration = Duration::from_secs(1);
 #[derive(Debug)]
 pub struct CircuitBreaker {
     /// Counters tracking the number of [`Ok`] and [`Err`] observed in the
-    /// current [`ERROR_WINDOW`].
+    /// current error window.
     ///
     /// When the total number of requests ([`RequestCounterValue::total()`]) is
     /// less than [`NUM_PROBES`], the circuit is in the "probing" regime. When
@@ -157,7 +153,7 @@ pub struct CircuitBreaker {
     /// should be allowed and resetting the [`PROBE_INTERVAL`].
     probes: Mutex<ProbeState>,
 
-    /// A task to reset the request count at intervals of [`ERROR_WINDOW`].
+    /// A task to reset the request count at the configured error window.
     reset_task: JoinHandle<()>,
 
     /// A string description of the endpoint this [`CircuitBreaker`] models.
@@ -178,13 +174,13 @@ struct ProbeState {
 }
 
 impl CircuitBreaker {
-    pub(crate) fn new(endpoint: impl Into<Arc<str>>) -> Self {
+    pub(crate) fn new(endpoint: impl Into<Arc<str>>, error_window: Duration) -> Self {
         let requests = Arc::new(RequestCounter::default());
         let s = Self {
             requests: Arc::clone(&requests),
             probes: Mutex::new(ProbeState::default()),
             reset_task: tokio::spawn(async move {
-                let mut ticker = tokio::time::interval(ERROR_WINDOW);
+                let mut ticker = tokio::time::interval(error_window);
                 ticker.set_missed_tick_behavior(MissedTickBehavior::Delay);
                 loop {
                     ticker.tick().await;
@@ -366,7 +362,7 @@ fn is_healthy(counts: RequestCounterValue) -> bool {
 
 /// Resets the absolute request counter values if the current circuit state is
 /// "closed" (healthy, not probing) at the time of the call, such that the there
-/// must be NUM_PROBES * MAX_ERROR_RATIO number of failed requests to open the
+/// must be [`NUM_PROBES`] * [`MAX_ERROR_RATIO`] number of failed requests to open the
 /// circuit (mark as unhealthy).
 ///
 /// Retains the closed/healthy state of the circuit. This is NOT an atomic
@@ -466,7 +462,7 @@ mod tests {
 
     /// Return a new [`CircuitBreaker`] with the reset ticker disabled.
     fn new_no_reset() -> CircuitBreaker {
-        let c = CircuitBreaker::new("bananas");
+        let c = CircuitBreaker::new("bananas", Duration::from_secs(5));
         c.reset_task.abort();
         c
     }
@@ -599,13 +595,13 @@ mod tests {
     }
 
     /// The circuit is marked unhealthy if the error rate exceeds
-    /// MAX_ERROR_RATIO within a single ERROR_WINDOW (approximately).
+    /// MAX_ERROR_RATIO within a single error window (approximately).
     ///
     /// This test ensures the counter reset logic prevents errors from different
-    /// ERROR_WINDOW periods from changing the circuit to open/unhealthy.
+    /// error window periods from changing the circuit to open/unhealthy.
     #[tokio::test]
     async fn test_periodic_counter_reset() {
-        let c = CircuitBreaker::new("bananas");
+        let c = CircuitBreaker::new("bananas", Duration::from_secs(5));
 
         // Assert the circuit breaker as healthy.
         assert!(c.is_healthy());

--- a/router/src/dml_handlers/rpc_write/circuit_breaking_client.rs
+++ b/router/src/dml_handlers/rpc_write/circuit_breaking_client.rs
@@ -1,4 +1,4 @@
-use std::{fmt::Debug, sync::Arc};
+use std::{fmt::Debug, sync::Arc, time::Duration};
 
 use async_trait::async_trait;
 use generated_types::influxdata::iox::ingester::v1::WriteRequest;
@@ -51,9 +51,13 @@ pub(super) struct CircuitBreakingClient<T, C = CircuitBreaker> {
 }
 
 impl<T> CircuitBreakingClient<T> {
-    pub(super) fn new(inner: T, endpoint_name: impl Into<Arc<str>>) -> Self {
+    pub(super) fn new(
+        inner: T,
+        endpoint_name: impl Into<Arc<str>>,
+        error_window: Duration,
+    ) -> Self {
         let endpoint_name = endpoint_name.into();
-        let state = CircuitBreaker::new(Arc::clone(&endpoint_name));
+        let state = CircuitBreaker::new(Arc::clone(&endpoint_name), error_window);
         state.set_healthy();
         Self {
             inner,
@@ -181,8 +185,12 @@ mod tests {
     #[tokio::test]
     async fn test_healthy() {
         let circuit_breaker = Arc::new(MockCircuitBreaker::default());
-        let wrapper = CircuitBreakingClient::new(MockWriteClient::default(), "bananas")
-            .with_circuit_breaker(Arc::clone(&circuit_breaker));
+        let wrapper = CircuitBreakingClient::new(
+            MockWriteClient::default(),
+            "bananas",
+            Duration::from_secs(5),
+        )
+        .with_circuit_breaker(Arc::clone(&circuit_breaker));
 
         circuit_breaker.set_healthy(true);
         assert_eq!(wrapper.is_healthy(), circuit_breaker.is_healthy());
@@ -213,8 +221,9 @@ mod tests {
                 .into_iter(),
             )),
         );
-        let wrapper = CircuitBreakingClient::new(Arc::clone(&mock_client), "bananas")
-            .with_circuit_breaker(Arc::clone(&circuit_breaker));
+        let wrapper =
+            CircuitBreakingClient::new(Arc::clone(&mock_client), "bananas", Duration::from_secs(5))
+                .with_circuit_breaker(Arc::clone(&circuit_breaker));
 
         assert_eq!(circuit_breaker.ok_count(), 0);
         assert_eq!(circuit_breaker.err_count(), 0);

--- a/router/tests/common/mod.rs
+++ b/router/tests/common/mod.rs
@@ -34,6 +34,7 @@ pub const TEST_RETENTION_PERIOD: Duration = Duration::from_secs(3600);
 pub struct TestContextBuilder {
     namespace_autocreation: MissingNamespaceAction,
     single_tenancy: bool,
+    rpc_write_error_window: Duration,
 }
 
 impl Default for TestContextBuilder {
@@ -41,6 +42,7 @@ impl Default for TestContextBuilder {
         Self {
             namespace_autocreation: MissingNamespaceAction::Reject,
             single_tenancy: false,
+            rpc_write_error_window: Duration::from_secs(5),
         }
     }
 }
@@ -79,6 +81,7 @@ impl TestContextBuilder {
             self.single_tenancy,
             catalog,
             metrics,
+            self.rpc_write_error_window,
         )
         .await
     }
@@ -94,6 +97,7 @@ pub struct TestContext {
 
     namespace_autocreation: MissingNamespaceAction,
     single_tenancy: bool,
+    rpc_write_error_window: Duration,
 }
 
 // This mass of words is certainly a downside of chained handlers.
@@ -133,12 +137,14 @@ impl TestContext {
         single_tenancy: bool,
         catalog: Arc<dyn Catalog>,
         metrics: Arc<metric::Registry>,
+        rpc_write_error_window: Duration,
     ) -> Self {
         let client = Arc::new(MockWriteClient::default());
         let rpc_writer = RpcWrite::new(
             [(Arc::clone(&client), "mock client")],
             1.try_into().unwrap(),
             &metrics,
+            rpc_write_error_window,
         );
 
         let ns_cache = Arc::new(ReadThroughCache::new(
@@ -195,6 +201,7 @@ impl TestContext {
 
             namespace_autocreation,
             single_tenancy,
+            rpc_write_error_window,
         }
     }
 
@@ -208,6 +215,7 @@ impl TestContext {
             self.single_tenancy,
             catalog,
             metrics,
+            self.rpc_write_error_window,
         )
         .await
     }


### PR DESCRIPTION
This PR exposes the `ERROR_WINDOW` parameter as a way to tune router <-> ingester on-path health checking for different volumes of writes.

My thinking is that for now, extending the duration within which the error rate is assessed provides an opportunity to smooth out errors in low volume clusters over a period of time, while keeping current `#[inline]` functions in place. If we need more leniency then we can follow up and allow `MAX_ERROR_RATIO` to be configurable.

---

* feat(router): Expose circuit breaker healthcheck config (61e79374e)

      Exposes the `ERROR_WINDOW` parameter that controls the router's
      downstream error-gate health check behaviour as an environment
      variable/command line flag. This allows tuning, per-environment, the
      period over which the error rate of 80% must be exceeded to cause an
      ingester to appear unhealthy.