### PR TITLE
perf(ingester): cache summary statistics in partition FSM

### DIFF
--- a/data_types/src/lib.rs
+++ b/data_types/src/lib.rs
@@ -1593,7 +1593,7 @@ impl TimestampRange {
 ///
 /// Note this differs subtlety (but critically) from a
 /// [`TimestampRange`] as the minimum and maximum values are included ([`TimestampRange`] has an exclusive end).
-#[derive(Clone, Debug, Copy)]
+#[derive(Clone, Debug, Copy, PartialEq)]
 pub struct TimestampMinMax {
     /// The minimum timestamp value
     pub min: i64,

--- a/ingester/src/buffer_tree/partition/buffer.rs
+++ b/ingester/src/buffer_tree/partition/buffer.rs
@@ -1,5 +1,5 @@
 use arrow::record_batch::RecordBatch;
-use data_types::SequenceNumber;
+use data_types::{SequenceNumber, TimestampMinMax};
 use mutable_batch::MutableBatch;
 
 mod always_some;
@@ -72,6 +72,20 @@ impl DataBuffer {
                 (FsmState::Buffering(b), ret)
             }
         })
+    }
+
+    /// Return the row count for this buffer.
+    pub(crate) fn rows(&self) -> usize {
+        match self.0.get() {
+            FsmState::Buffering(v) => v.rows(),
+        }
+    }
+
+    /// Return the timestamp min/max values, if this buffer contains data.
+    pub(crate) fn timestamp_stats(&self) -> Option<TimestampMinMax> {
+        match self.0.get() {
+            FsmState::Buffering(v) => v.timestamp_stats(),
+        }
     }
 
     // Deconstruct the [`DataBuffer`] into the underlying FSM in a

--- a/ingester/src/buffer_tree/partition/buffer/mutable_buffer.rs
+++ b/ingester/src/buffer_tree/partition/buffer/mutable_buffer.rs
@@ -49,6 +49,8 @@ impl Buffer {
         self.buffer.is_none()
     }
 
+    /// Returns the underlying buffer if this [`Buffer`] contains data,
+    /// otherwise returns [`None`].
     pub(super) fn buffer(&self) -> Option<&MutableBatch> {
         self.buffer.as_ref()
     }

--- a/ingester/src/buffer_tree/partition/buffer/state_machine/buffering.rs
+++ b/ingester/src/buffer_tree/partition/buffer/state_machine/buffering.rs
@@ -1,7 +1,9 @@
 //! A write buffer.
 
 use arrow::record_batch::RecordBatch;
-use mutable_batch::MutableBatch;
+use data_types::{StatValues, TimestampMinMax};
+use mutable_batch::{column::ColumnData, MutableBatch};
+use schema::TIME_COLUMN_NAME;
 
 use super::{snapshot::Snapshot, BufferState, Transition};
 use crate::{
@@ -41,6 +43,22 @@ impl Queryable for Buffering {
             .map(|v| vec![projection.project_mutable_batches(v)])
             .unwrap_or_default()
     }
+
+    fn rows(&self) -> usize {
+        self.buffer.buffer().map(|v| v.rows()).unwrap_or_default()
+    }
+
+    fn timestamp_stats(&self) -> Option<TimestampMinMax> {
+        self.buffer
+            .buffer()
+            .map(extract_timestamp_summary)
+            // Safety: unwrapping the timestamp bounds is safe, as any non-empty
+            // buffer must contain timestamps.
+            .map(|v| TimestampMinMax {
+                min: v.min.unwrap(),
+                max: v.max.unwrap(),
+            })
+    }
 }
 
 impl Writeable for Buffering {
@@ -72,6 +90,18 @@ impl BufferState<Buffering> {
 
     pub(crate) fn persist_cost_estimate(&self) -> usize {
         self.state.buffer.persist_cost_estimate()
+    }
+}
+
+/// Perform an O(1) extraction of the timestamp column statistics.
+fn extract_timestamp_summary(batch: &MutableBatch) -> &StatValues<i64> {
+    let col = batch
+        .column(TIME_COLUMN_NAME)
+        .expect("timestamps must exist for non-empty buffer");
+
+    match col.data() {
+        ColumnData::I64(_data, stats) => stats,
+        _ => unreachable!(),
     }
 }
 

--- a/ingester/src/buffer_tree/partition/buffer/state_machine/snapshot.rs
+++ b/ingester/src/buffer_tree/partition/buffer/state_machine/snapshot.rs
@@ -1,6 +1,8 @@
 //! A writfield1 buffer, with one or more snapshots.
 
 use arrow::record_batch::RecordBatch;
+use data_types::TimestampMinMax;
+use iox_query::util::compute_timenanosecond_min_max;
 
 use super::BufferState;
 use crate::{
@@ -15,12 +17,26 @@ pub(crate) struct Snapshot {
     ///
     /// INVARIANT: this array is always non-empty.
     snapshots: Vec<RecordBatch>,
+
+    /// Statistics describing the data in snapshots.
+    row_count: usize,
+    timestamp_stats: TimestampMinMax,
 }
 
 impl Snapshot {
     pub(super) fn new(snapshots: Vec<RecordBatch>) -> Self {
         assert!(!snapshots.is_empty());
-        Self { snapshots }
+
+        // Compute some summary statistics for query pruning/reuse later.
+        let row_count = snapshots.iter().map(|v| v.num_rows()).sum();
+        let timestamp_stats = compute_timenanosecond_min_max(snapshots.iter())
+            .expect("non-empty batch must contain timestamps");
+
+        Self {
+            snapshots,
+            row_count,
+            timestamp_stats,
+        }
     }
 }
 
@@ -28,13 +44,25 @@ impl Queryable for Snapshot {
     fn get_query_data(&self, projection: &OwnedProjection) -> Vec<RecordBatch> {
         projection.project_record_batch(&self.snapshots)
     }
+
+    fn rows(&self) -> usize {
+        self.row_count
+    }
+
+    fn timestamp_stats(&self) -> Option<TimestampMinMax> {
+        Some(self.timestamp_stats)
+    }
 }
 
 impl BufferState<Snapshot> {
     pub(crate) fn into_persisting(self) -> BufferState<Persisting> {
         assert!(!self.state.snapshots.is_empty());
         BufferState {
-            state: Persisting::new(self.state.snapshots),
+            state: Persisting::new(
+                self.state.snapshots,
+                self.state.row_count,
+                self.state.timestamp_stats,
+            ),
             sequence_numbers: self.sequence_numbers,
         }
     }

--- a/ingester/src/buffer_tree/partition/buffer/traits.rs
+++ b/ingester/src/buffer_tree/partition/buffer/traits.rs
@@ -3,6 +3,7 @@
 use std::fmt::Debug;
 
 use arrow::record_batch::RecordBatch;
+use data_types::TimestampMinMax;
 use mutable_batch::MutableBatch;
 
 use crate::query::projection::OwnedProjection;
@@ -15,5 +16,10 @@ pub(crate) trait Writeable: Debug {
 /// A state that can return the contents of the buffer as one or more
 /// [`RecordBatch`] instances.
 pub(crate) trait Queryable: Debug {
+    fn rows(&self) -> usize;
+
+    fn timestamp_stats(&self) -> Option<TimestampMinMax>;
+
+    /// Return the set of [`RecordBatch`] containing ONLY the projected columns.
     fn get_query_data(&self, projection: &OwnedProjection) -> Vec<RecordBatch>;
 }

--- a/ingester/src/query/projection.rs
+++ b/ingester/src/query/projection.rs
@@ -138,4 +138,12 @@ impl OwnedProjection {
             }
         }
     }
+
+    /// Return the column names in this projection, if specified.
+    pub(crate) fn columns(&self) -> Option<&[String]> {
+        match &self.0 {
+            Projection::All => None,
+            Projection::Project(v) => Some(v.as_ref()),
+        }
+    }
 }


### PR DESCRIPTION
This PR makes per-partition row count / timestamp summary statistics available to holders of a `PartitionData`.

This will be used to improve partition pruning performance during query execution.

---

* perf: cache summary statistics in partition FSM (b4b7822f2)
      
      Cache the row count & timestamp min/max values within the partition FSM
      / buffer, and make them available through the Queryable trait.
      
      This allows the PartitionData to read the row count of a buffer (either
      "hot" for writes, a "snapshot" of immutable RecordBatch, or "persisting"
      for in-flight persisting data).
      
      These values will enable early partition pruning.

* refactor: per-partition summary statistics (b79b12078)
      
      Provide row count & timestamp min/max statistics on a per-partition
      basis.
      
      This commit builds on the FSM summary statistics, merging all FSM
      statistics across all data within the PartitionData (in various states)
      and making them available to the caller.