### PR TITLE
perf(ingester): reusable FSM / RecordBatch schemas

### DIFF
--- a/ingester/src/buffer_tree/partition/buffer.rs
+++ b/ingester/src/buffer_tree/partition/buffer.rs
@@ -7,6 +7,7 @@ mod mutable_buffer;
 mod state_machine;
 pub(crate) mod traits;
 
+use schema::Schema;
 pub(crate) use state_machine::*;
 
 use crate::query::projection::OwnedProjection;
@@ -85,6 +86,12 @@ impl DataBuffer {
     pub(crate) fn timestamp_stats(&self) -> Option<TimestampMinMax> {
         match self.0.get() {
             FsmState::Buffering(v) => v.timestamp_stats(),
+        }
+    }
+
+    pub(crate) fn schema(&self) -> Option<Schema> {
+        match self.0.get() {
+            FsmState::Buffering(v) => v.schema(),
         }
     }
 

--- a/ingester/src/buffer_tree/partition/buffer.rs
+++ b/ingester/src/buffer_tree/partition/buffer.rs
@@ -89,6 +89,7 @@ impl DataBuffer {
         }
     }
 
+    /// Returns the [`Schema`] for the buffered data.
     pub(crate) fn schema(&self) -> Option<Schema> {
         match self.0.get() {
             FsmState::Buffering(v) => v.schema(),

--- a/ingester/src/buffer_tree/partition/buffer/state_machine.rs
+++ b/ingester/src/buffer_tree/partition/buffer/state_machine.rs
@@ -133,6 +133,10 @@ where
     fn timestamp_stats(&self) -> Option<TimestampMinMax> {
         self.state.timestamp_stats()
     }
+
+    fn schema(&self) -> Option<schema::Schema> {
+        self.state.schema()
+    }
 }
 
 #[cfg(test)]

--- a/ingester/src/buffer_tree/partition/buffer/state_machine/buffering.rs
+++ b/ingester/src/buffer_tree/partition/buffer/state_machine/buffering.rs
@@ -3,7 +3,7 @@
 use arrow::record_batch::RecordBatch;
 use data_types::{StatValues, TimestampMinMax};
 use mutable_batch::{column::ColumnData, MutableBatch};
-use schema::TIME_COLUMN_NAME;
+use schema::{Projection, TIME_COLUMN_NAME};
 
 use super::{snapshot::Snapshot, BufferState, Transition};
 use crate::{
@@ -58,6 +58,13 @@ impl Queryable for Buffering {
                 min: v.min.unwrap(),
                 max: v.max.unwrap(),
             })
+    }
+
+    fn schema(&self) -> Option<schema::Schema> {
+        self.buffer.buffer().map(|v| {
+            v.schema(Projection::All)
+                .expect("failed to construct batch schema")
+        })
     }
 }
 

--- a/ingester/src/buffer_tree/partition/buffer/state_machine/persisting.rs
+++ b/ingester/src/buffer_tree/partition/buffer/state_machine/persisting.rs
@@ -3,6 +3,7 @@
 use arrow::record_batch::RecordBatch;
 use data_types::{sequence_number_set::SequenceNumberSet, TimestampMinMax};
 use iox_query::util::compute_timenanosecond_min_max;
+use schema::{merge::merge_record_batch_schemas, Schema};
 
 use super::BufferState;
 use crate::{
@@ -20,6 +21,7 @@ pub(crate) struct Persisting {
     /// Statistics describing the data in snapshots.
     row_count: usize,
     timestamp_stats: TimestampMinMax,
+    schema: Schema,
 }
 
 impl Persisting {
@@ -27,6 +29,7 @@ impl Persisting {
         snapshots: Vec<RecordBatch>,
         row_count: usize,
         timestamp_stats: TimestampMinMax,
+        schema: Schema,
     ) -> Self {
         // Invariant: the summary statistics provided must match the actual
         // data.
@@ -38,11 +41,13 @@ impl Persisting {
             timestamp_stats,
             compute_timenanosecond_min_max(snapshots.iter()).unwrap()
         );
+        debug_assert_eq!(schema, merge_record_batch_schemas(&snapshots));
 
         Self {
             snapshots,
             row_count,
             timestamp_stats,
+            schema,
         }
     }
 }
@@ -58,6 +63,10 @@ impl Queryable for Persisting {
 
     fn timestamp_stats(&self) -> Option<TimestampMinMax> {
         Some(self.timestamp_stats)
+    }
+
+    fn schema(&self) -> Option<schema::Schema> {
+        Some(self.schema.clone())
     }
 }
 

--- a/ingester/src/buffer_tree/partition/buffer/state_machine/persisting.rs
+++ b/ingester/src/buffer_tree/partition/buffer/state_machine/persisting.rs
@@ -66,7 +66,7 @@ impl Queryable for Persisting {
     }
 
     fn schema(&self) -> Option<schema::Schema> {
-        Some(self.schema.clone())
+        Some(self.schema.clone()) // Ref clone
     }
 }
 

--- a/ingester/src/buffer_tree/partition/buffer/state_machine/snapshot.rs
+++ b/ingester/src/buffer_tree/partition/buffer/state_machine/snapshot.rs
@@ -59,7 +59,7 @@ impl Queryable for Snapshot {
     }
 
     fn schema(&self) -> Option<schema::Schema> {
-        Some(self.schema.clone())
+        Some(self.schema.clone()) // Ref clone
     }
 }
 

--- a/ingester/src/buffer_tree/partition/buffer/state_machine/snapshot.rs
+++ b/ingester/src/buffer_tree/partition/buffer/state_machine/snapshot.rs
@@ -3,6 +3,7 @@
 use arrow::record_batch::RecordBatch;
 use data_types::TimestampMinMax;
 use iox_query::util::compute_timenanosecond_min_max;
+use schema::{merge::merge_record_batch_schemas, Schema};
 
 use super::BufferState;
 use crate::{
@@ -21,6 +22,7 @@ pub(crate) struct Snapshot {
     /// Statistics describing the data in snapshots.
     row_count: usize,
     timestamp_stats: TimestampMinMax,
+    schema: Schema,
 }
 
 impl Snapshot {
@@ -32,10 +34,13 @@ impl Snapshot {
         let timestamp_stats = compute_timenanosecond_min_max(snapshots.iter())
             .expect("non-empty batch must contain timestamps");
 
+        let schema = merge_record_batch_schemas(&snapshots);
+
         Self {
             snapshots,
             row_count,
             timestamp_stats,
+            schema,
         }
     }
 }
@@ -52,6 +57,10 @@ impl Queryable for Snapshot {
     fn timestamp_stats(&self) -> Option<TimestampMinMax> {
         Some(self.timestamp_stats)
     }
+
+    fn schema(&self) -> Option<schema::Schema> {
+        Some(self.schema.clone())
+    }
 }
 
 impl BufferState<Snapshot> {
@@ -62,6 +71,7 @@ impl BufferState<Snapshot> {
                 self.state.snapshots,
                 self.state.row_count,
                 self.state.timestamp_stats,
+                self.state.schema,
             ),
             sequence_numbers: self.sequence_numbers,
         }

--- a/ingester/src/buffer_tree/partition/buffer/traits.rs
+++ b/ingester/src/buffer_tree/partition/buffer/traits.rs
@@ -5,6 +5,7 @@ use std::fmt::Debug;
 use arrow::record_batch::RecordBatch;
 use data_types::TimestampMinMax;
 use mutable_batch::MutableBatch;
+use schema::Schema;
 
 use crate::query::projection::OwnedProjection;
 
@@ -19,6 +20,8 @@ pub(crate) trait Queryable: Debug {
     fn rows(&self) -> usize;
 
     fn timestamp_stats(&self) -> Option<TimestampMinMax>;
+
+    fn schema(&self) -> Option<Schema>;
 
     /// Return the set of [`RecordBatch`] containing ONLY the projected columns.
     fn get_query_data(&self, projection: &OwnedProjection) -> Vec<RecordBatch>;


### PR DESCRIPTION
This PR allows us to (later) re-use batch snapshot schemas, instead of regenerating them for every query.

Less is definitely more :rocket:

---

* perf(ingester): reusable FSM / RecordBatch schemas (41c9c0f39)
      
      Cache the merged Schema of all the RecordBatch within a buffer at
      snapshot generation time.
      
      To be useful, this cached schema is made available to the PartitionData
      for re-use, allowing the schema of "hot" data within a partition's
      mutable buffer to be read without generating a RecordBatch first.