### PR TITLE
fix(ingester): Skip empty writes with no data during WAL replay

### DIFF
--- a/ingester/src/dml_payload/write/op.rs
+++ b/ingester/src/dml_payload/write/op.rs
@@ -40,6 +40,18 @@ impl WriteOperation {
         }
     }
 
+    /// Do NOT remove this test annotation. This constructor exists to by-pass
+    /// safety invariant assertions for testing code only.
+    #[cfg(test)]
+    pub(crate) fn new_empty_invalid(namespace: NamespaceId, partition_key: PartitionKey) -> Self {
+        Self {
+            namespace,
+            tables: Default::default(),
+            partition_key,
+            span_context: None,
+        }
+    }
+
     /// The namespace which the write is
     pub fn namespace(&self) -> NamespaceId {
         self.namespace


### PR DESCRIPTION
While this doesn't prevent a mid-write crash from potentially resulting in an empty write op appearing in the WAL, it does tolerate it during start-up and track its occurrence. The user would not have got an `OK` response for the write so skipping is consistent with this.

---

* fix(ingester): Skip empty writes with no data during WAL replay (3133f9c2e)

      In very rare cases a panic mid-write can result in a partially completed
      write to the WAL which contains no table data. This is now not replayed
      (as there is nothing to replay) and does not panic when encountered,
      but tracks the occurence into the WAL replayed ops metric and logs a
      warning.