### PR TITLE
perf(ingester): persisting list & cached statistics

### DIFF
--- a/ingester/src/buffer_tree/partition.rs
+++ b/ingester/src/buffer_tree/partition.rs
@@ -309,7 +309,7 @@ impl PartitionData {
         // Increment the "started persist" counter.
         //
         // This is used to cheaply identify batches given to the
-        // mark_persisted() call.
+        // mark_persisted() call and ensure monotonicity.
         let batch_ident = self.started_persistence_count.next();
 
         debug!(
@@ -332,9 +332,8 @@ impl PartitionData {
             batch_ident,
         );
 
-        // Push the new buffer to the back of the persisting queue, so that
-        // iterating from back to front during queries iterates over writes from
-        // oldest to newest.
+        // Push the buffer into the persisting list (which maintains batch
+        // order).
         self.persisting.push(batch_ident, fsm);
 
         Some(data)

--- a/ingester/src/buffer_tree/partition.rs
+++ b/ingester/src/buffer_tree/partition.rs
@@ -1,6 +1,6 @@
 //! Partition level data buffer structures.
 
-use std::{collections::VecDeque, sync::Arc};
+use std::sync::Arc;
 
 use data_types::{
     sequence_number_set::SequenceNumberSet, NamespaceId, PartitionHashId, PartitionId,
@@ -8,11 +8,12 @@ use data_types::{
 };
 use mutable_batch::MutableBatch;
 use observability_deps::tracing::*;
-use schema::sort::SortKey;
+use schema::{merge::SchemaMerger, sort::SortKey, Schema};
 
 use self::{
-    buffer::{traits::Queryable, BufferState, DataBuffer, Persisting},
+    buffer::{traits::Queryable, DataBuffer},
     persisting::{BatchIdent, PersistingData},
+    persisting_list::PersistingList,
 };
 use super::{namespace::NamespaceName, table::TableMetadata};
 use crate::{
@@ -21,6 +22,7 @@ use crate::{
 
 mod buffer;
 pub(crate) mod persisting;
+mod persisting_list;
 pub(crate) mod resolver;
 
 /// The load state of the [`SortKey`] for a given partition.
@@ -89,7 +91,7 @@ pub struct PartitionData {
     ///
     /// The [`BatchIdent`] is a generational counter that is used to tag each
     /// persisting with a unique, opaque identifier.
-    persisting: VecDeque<(BatchIdent, BufferState<Persisting>)>,
+    persisting: PersistingList,
 
     /// The number of persist operations started over the lifetime of this
     /// [`PartitionData`].
@@ -123,7 +125,7 @@ impl PartitionData {
             table_id,
             table,
             buffer: DataBuffer::default(),
-            persisting: VecDeque::with_capacity(1),
+            persisting: PersistingList::default(),
             started_persistence_count: BatchIdent::default(),
             completed_persistence_count: 0,
         }
@@ -169,7 +171,7 @@ impl PartitionData {
     /// persisting batches, plus 1 for the "hot" buffer. Reading the row count
     /// of each batch is `O(1)`. This method is expected to be fast.
     pub(crate) fn rows(&self) -> usize {
-        self.persisting.iter().map(|(_, v)| v.rows()).sum::<usize>() + self.buffer.rows()
+        self.persisting.rows() + self.buffer.rows()
     }
 
     /// Return the timestamp min/max values for the data contained within this
@@ -188,16 +190,37 @@ impl PartitionData {
     /// statistics for each batch is `O(1)`. This method is expected to be fast.
     pub(crate) fn timestamp_stats(&self) -> Option<TimestampMinMax> {
         self.persisting
-            .iter()
-            .map(|(_, v)| {
-                v.timestamp_stats()
-                    .expect("persisting batches must be non-empty")
-            })
+            .timestamp_stats()
+            .into_iter()
             .chain(self.buffer.timestamp_stats())
             .reduce(|acc, v| TimestampMinMax {
                 min: acc.min.min(v.min),
                 max: acc.max.max(v.max),
             })
+    }
+
+    /// Return the schema of the data currently buffered within this
+    /// [`PartitionData`].
+    ///
+    /// This schema is not additive - it is the union of the individual schema
+    /// batches currently buffered and as such columns are removed as the
+    /// individual batches containing those columns are persisted and dropped.
+    pub(crate) fn schema(&self) -> Option<Schema> {
+        if self.persisting.is_empty() && self.buffer.rows() == 0 {
+            return None;
+        }
+
+        Some(
+            self.persisting
+                .schema()
+                .into_iter()
+                .cloned()
+                .chain(self.buffer.schema())
+                .fold(SchemaMerger::new(), |acc, v| {
+                    acc.merge(&v).expect("schemas are incompatible")
+                })
+                .build(),
+        )
     }
 
     /// Return all data for this partition, ordered by the calls to
@@ -213,8 +236,7 @@ impl PartitionData {
         // existing rows materialise to the correct output.
         let data = self
             .persisting
-            .iter()
-            .flat_map(|(_, b)| b.get_query_data(projection))
+            .get_query_data(projection)
             .chain(buffered_data)
             .collect::<Vec<_>>();
 
@@ -313,7 +335,7 @@ impl PartitionData {
         // Push the new buffer to the back of the persisting queue, so that
         // iterating from back to front during queries iterates over writes from
         // oldest to newest.
-        self.persisting.push_back((batch_ident, fsm));
+        self.persisting.push(batch_ident, fsm);
 
         Some(data)
     }
@@ -328,22 +350,11 @@ impl PartitionData {
     /// This method panics if [`Self`] is not marked as undergoing a persist
     /// operation, or `batch` is not currently being persisted.
     pub(crate) fn mark_persisted(&mut self, batch: PersistingData) -> SequenceNumberSet {
-        // Find the batch in the persisting queue.
-        let idx = self
-            .persisting
-            .iter()
-            .position(|(old, _)| *old == batch.batch_ident())
-            .expect("no currently persisting batch");
-
-        // Remove the batch from the queue, preserving the order of the queue
-        // for batch iteration during queries.
-        let (old_ident, fsm) = self.persisting.remove(idx).unwrap();
-        assert_eq!(old_ident, batch.batch_ident());
+        let fsm = self.persisting.remove(batch.batch_ident());
 
         self.completed_persistence_count += 1;
 
         debug!(
-            batch_ident = %old_ident,
             persistence_count = %self.completed_persistence_count,
             namespace_id = %self.namespace_id,
             table_id = %self.table_id,

--- a/ingester/src/buffer_tree/partition/buffer/mutable_buffer.rs
+++ b/ingester/src/buffer_tree/partition/buffer/mutable_buffer.rs
@@ -7,7 +7,7 @@ use schema::Projection;
 ///
 /// A [`Buffer`] can contain no writes.
 ///
-/// [`BufferState`]: super::super::BufferState
+/// [`BufferState`]: super::BufferState
 #[derive(Debug, Default)]
 pub(super) struct Buffer {
     buffer: Option<MutableBatch>,

--- a/ingester/src/buffer_tree/partition/buffer/state_machine.rs
+++ b/ingester/src/buffer_tree/partition/buffer/state_machine.rs
@@ -77,7 +77,7 @@ pub(crate) struct BufferState<T> {
 
 impl BufferState<Buffering> {
     /// Initialise a new buffer state machine.
-    pub(super) fn new() -> Self {
+    pub(crate) fn new() -> Self {
         Self {
             state: Buffering::default(),
             sequence_numbers: SequenceNumberSet::default(),

--- a/ingester/src/buffer_tree/partition/persisting.rs
+++ b/ingester/src/buffer_tree/partition/persisting.rs
@@ -2,14 +2,18 @@ use std::fmt::Display;
 
 use crate::query_adaptor::QueryAdaptor;
 
-/// An opaque generational identifier of a buffer in a [`PartitionData`].
+/// An opaque, monotonic generational identifier of a buffer in a
+/// [`PartitionData`].
+///
+/// A [`BatchIdent`] is strictly greater than all those that were obtained
+/// before it.
 ///
 /// [`PartitionData`]: super::PartitionData
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
-pub(super) struct BatchIdent(u64);
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd)]
+pub(crate) struct BatchIdent(u64);
 
 impl BatchIdent {
-    /// Return the next unique value.
+    /// Return the next unique monotonic value.
     pub(super) fn next(&mut self) -> Self {
         self.0 += 1;
         Self(self.0)

--- a/ingester/src/buffer_tree/partition/persisting_list.rs
+++ b/ingester/src/buffer_tree/partition/persisting_list.rs
@@ -1,0 +1,470 @@
+use std::collections::VecDeque;
+
+use arrow::record_batch::RecordBatch;
+use data_types::TimestampMinMax;
+use schema::{merge::SchemaMerger, Schema};
+
+use crate::query::projection::OwnedProjection;
+
+use super::{
+    buffer::{traits::Queryable, BufferState, Persisting},
+    persisting::BatchIdent,
+};
+
+/// An ordered list of buffered, persisting data as [`BufferState<Persisting>`]
+/// FSM instances.
+///
+/// This type maintains a cache of row count & timestamp min/max statistics
+/// across all persisting batches, and performs incremental computation at
+/// persist time, moving it out of the query execution path.
+#[derive(Debug)]
+pub(crate) struct PersistingList {
+    /// The currently persisting [`DataBuffer`] instances, if any.
+    ///
+    /// This queue is ordered from newest at the head, to oldest at the tail -
+    /// forward iteration order matches write order.
+    ///
+    /// The [`BatchIdent`] is a generational counter that is used to tag each
+    /// persisting with a unique, opaque, monotonic identifier.
+    ///
+    /// [`DataBuffer`]: super::buffer::DataBuffer
+    persisting: VecDeque<(BatchIdent, BufferState<Persisting>)>,
+
+    cached: Option<CachedStats>,
+}
+
+impl Default for PersistingList {
+    fn default() -> Self {
+        Self {
+            persisting: VecDeque::with_capacity(1),
+            cached: None,
+        }
+    }
+}
+
+impl PersistingList {
+    /// Add this `buffer` which was assigned `ident` when marked as persisting
+    /// to the list.
+    ///
+    /// This call incrementally recomputes the cached data statistics.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a batch with a later `ident` has already been added to this
+    /// list - calls MUST push ordered buffers/idents to maintain correct
+    /// ordering of row updates across batches.
+    ///
+    /// The provided buffer MUST be non-empty (containing a timestamp column,
+    /// and a schema)
+    pub(crate) fn push(&mut self, ident: BatchIdent, buffer: BufferState<Persisting>) {
+        // Recompute the statistics.
+        match &mut self.cached {
+            Some(v) => v.push(&buffer),
+            None => {
+                // Set the cached stats, as there's no other stats to merge
+                // with, so skip merging schemas.
+                self.cached = Some(CachedStats {
+                    rows: buffer.rows(),
+                    timestamps: buffer
+                        .timestamp_stats()
+                        .expect("persisting batch must contain timestamps"),
+                    schema: buffer.schema().expect("persisting batch must have schema"),
+                });
+            }
+        }
+
+        // Invariant: the batch being added MUST be ordered strictly after
+        // existing batches.
+        //
+        // The BatchIdent provides this ordering assurance, as it is a monotonic
+        // (opaque) identifier.
+        assert!(self
+            .persisting
+            .back()
+            .map(|(last, _)| ident > *last)
+            .unwrap_or(true));
+
+        self.persisting.push_back((ident, buffer));
+    }
+
+    /// Remove the buffer identified by `ident` from the list.
+    ///
+    /// There is no ordering requirement for this call, but is more efficient
+    /// when removals match the order of calls to [`PersistingList::push()`].
+    ///
+    /// # Panics
+    ///
+    /// This method panics if there is currently no batch identified by `ident`
+    /// in the list.
+    pub(crate) fn remove(&mut self, ident: BatchIdent) -> BufferState<Persisting> {
+        let idx = self
+            .persisting
+            .iter()
+            .position(|(old, _)| *old == ident)
+            .expect("no currently persisting batch");
+
+        let (old_ident, fsm) = self.persisting.remove(idx).unwrap();
+        assert_eq!(old_ident, ident);
+
+        // Recompute the cache of all remaining persisting batch stats (if any)
+        self.cached = CachedStats::new(self.persisting.iter().map(|(_, v)| v));
+
+        fsm
+    }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.persisting.is_empty()
+    }
+
+    /// Returns the row count sum across all batches in this list.
+    ///
+    /// This is an `O(1)` operation.
+    pub(crate) fn rows(&self) -> usize {
+        self.cached.as_ref().map(|v| v.rows).unwrap_or_default()
+    }
+
+    /// Returns the timestamp min/max values across all batches in this list.
+    ///
+    /// This is an `O(1)` operation.
+    pub(crate) fn timestamp_stats(&self) -> Option<TimestampMinMax> {
+        self.cached.as_ref().map(|v| v.timestamps)
+    }
+
+    /// Returns the merged schema of all batches in this list.
+    ///
+    /// This is an `O(1)` operation.
+    pub(crate) fn schema(&self) -> Option<&Schema> {
+        self.cached.as_ref().map(|v| &v.schema)
+    }
+
+    /// Returns the [`RecordBatch`] in this list, optionally applying the given
+    /// projection.
+    ///
+    /// This is an `O(n)` operation.
+    pub(crate) fn get_query_data<'a, 'b: 'a>(
+        &'a self,
+        projection: &'b OwnedProjection,
+    ) -> impl Iterator<Item = RecordBatch> + 'a {
+        self.persisting
+            .iter()
+            .flat_map(move |(_, b)| b.get_query_data(projection))
+    }
+}
+
+/// The set of cached statistics describing the batches of data within the
+/// [`PersistingList`].
+#[derive(Debug)]
+struct CachedStats {
+    rows: usize,
+    timestamps: TimestampMinMax,
+
+    /// The merged schema of all the persisting batches.
+    ///
+    /// This is invalidated (set to [`None`]) when an entry is added or removed
+    /// from `persisting`.
+    schema: Schema,
+}
+
+impl CachedStats {
+    /// Generate a new [`CachedStats`] from an iterator of batches, if any.
+    ///
+    /// # Panics
+    ///
+    /// If any batches are empty (containing no schema or timestamp column), or
+    /// the batches do not contain compatible schemas, this call panics.
+    fn new<'a, T>(mut iter: T) -> Option<Self>
+    where
+        T: Iterator<Item = &'a BufferState<Persisting>> + 'a,
+    {
+        let v = iter.next()?;
+
+        let mut schema = SchemaMerger::new();
+        schema = schema
+            .merge(&v.schema().expect("persisting batch must be non-empty"))
+            .unwrap();
+
+        let mut rows = v.rows();
+        debug_assert!(rows > 0);
+
+        let mut timestamps = v
+            .timestamp_stats()
+            .expect("unprojected batch should have timestamp");
+
+        for buf in iter {
+            rows += buf.rows();
+            if let Some(v) = buf.schema() {
+                debug_assert!(buf.rows() > 0);
+
+                schema = schema
+                    .merge(&v)
+                    .expect("persit list contains incompatible schemas");
+
+                let ts = buf
+                    .timestamp_stats()
+                    .expect("no timestamp for bach containing rows");
+
+                timestamps.min = timestamps.min.min(ts.min);
+                timestamps.max = timestamps.max.max(ts.max);
+            }
+        }
+
+        Some(Self {
+            rows,
+            timestamps,
+            schema: schema.build(),
+        })
+    }
+
+    // Incrementally recompute the cached stats by adding `buffer` to the
+    // statistics.
+    fn push(&mut self, buffer: &BufferState<Persisting>) {
+        // This re-computation below MUST complete - no early exit is allowed or
+        // the stats will be left in an inconsistent state.
+
+        self.rows += buffer.rows();
+
+        let ts = buffer
+            .timestamp_stats()
+            .expect("persisting batch must contain timestamps");
+
+        self.timestamps.min = self.timestamps.min.min(ts.min);
+        self.timestamps.max = self.timestamps.max.max(ts.max);
+
+        let mut schema = SchemaMerger::new();
+        schema = schema.merge(&self.schema).unwrap();
+        schema = schema
+            .merge(&buffer.schema().expect("persisting batch must have schema"))
+            .expect("incompatible schema");
+        self.schema = schema.build()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeSet;
+
+    use arrow_util::assert_batches_eq;
+    use assert_matches::assert_matches;
+    use data_types::SequenceNumber;
+    use mutable_batch_lp::test_helpers::lp_to_mutable_batch;
+
+    use crate::buffer_tree::partition::buffer::Transition;
+
+    use super::*;
+
+    /// Ensure the ordering of yielded batches matches that of the calls to
+    /// push(), preserving batch ordering, and in turn, causal row ordering.
+    #[test]
+    fn test_batch_ordering() {
+        let mut list = PersistingList::default();
+        let mut ident_oracle = BatchIdent::default();
+
+        assert!(list.is_empty());
+
+        // Generate a buffer with a single row.
+        let buffer = buffer_with_lp(r#"bananas,tag=platanos great="yes" 42"#);
+
+        // Add it to the list.
+        list.push(ident_oracle.next(), buffer);
+
+        // The statistics must now match the expected values.
+        assert!(!list.is_empty());
+        assert_eq!(list.rows(), 1);
+        assert_matches!(
+            list.timestamp_stats(),
+            Some(TimestampMinMax { min: 42, max: 42 })
+        );
+        assert_schema_matches(list.schema().unwrap(), &["time", "great", "tag"]);
+
+        // Assert the row content
+        let data = list
+            .get_query_data(&OwnedProjection::default())
+            .collect::<Vec<_>>();
+        let expected = vec![
+            "+-------+----------+--------------------------------+",
+            "| great | tag      | time                           |",
+            "+-------+----------+--------------------------------+",
+            "| yes   | platanos | 1970-01-01T00:00:00.000000042Z |",
+            "+-------+----------+--------------------------------+",
+        ];
+        assert_eq!(data.len(), 1);
+        assert_batches_eq!(&expected, &data);
+
+        // Push a new buffer updating the last row to check yielded row ordering.
+        let buffer = buffer_with_lp(r#"bananas,tag=platanos great="definitely" 42"#);
+        list.push(ident_oracle.next(), buffer);
+
+        // The statistics must now match the expected values.
+        assert!(!list.is_empty());
+        assert_eq!(list.rows(), 2);
+        assert_matches!(
+            list.timestamp_stats(),
+            Some(TimestampMinMax { min: 42, max: 42 })
+        );
+        assert_schema_matches(list.schema().unwrap(), &["time", "great", "tag"]);
+
+        // Assert the row content
+        let data = list
+            .get_query_data(&OwnedProjection::default())
+            .collect::<Vec<_>>();
+        let expected = vec![
+            "+------------+----------+--------------------------------+",
+            "| great      | tag      | time                           |",
+            "+------------+----------+--------------------------------+",
+            "| yes        | platanos | 1970-01-01T00:00:00.000000042Z |",
+            "| definitely | platanos | 1970-01-01T00:00:00.000000042Z |",
+            "+------------+----------+--------------------------------+",
+        ];
+        assert_eq!(data.len(), 2);
+        assert_batches_eq!(&expected, &data);
+    }
+
+    /// Assert projection across batches works, and does not panic when given a
+    /// missing column.
+    #[test]
+    fn test_projection() {
+        let mut list = PersistingList::default();
+        let mut ident_oracle = BatchIdent::default();
+
+        assert!(list.is_empty());
+
+        // Populate the list.
+        list.push(
+            ident_oracle.next(),
+            buffer_with_lp(
+                "\
+                bananas,tag=platanos v=1 42\n\
+                bananas,tag=platanos v=2,bananas=100 4242\n\
+            ",
+            ),
+        );
+
+        list.push(
+            ident_oracle.next(),
+            buffer_with_lp(
+                "\
+                bananas,tag=platanos v=3 424242\n\
+                bananas v=4,bananas=200 42424242\n\
+            ",
+            ),
+        );
+
+        // Assert the row content
+        let data = list
+            .get_query_data(&OwnedProjection::from(vec!["time", "tag", "missing"]))
+            .collect::<Vec<_>>();
+        let expected = vec![
+            "+--------------------------------+----------+",
+            "| time                           | tag      |",
+            "+--------------------------------+----------+",
+            "| 1970-01-01T00:00:00.000000042Z | platanos |",
+            "| 1970-01-01T00:00:00.000004242Z | platanos |",
+            "| 1970-01-01T00:00:00.000424242Z | platanos |",
+            "| 1970-01-01T00:00:00.042424242Z |          |",
+            "+--------------------------------+----------+",
+        ];
+        assert_batches_eq!(&expected, &data);
+    }
+
+    /// Validate the cached statistics as batches are added and removed.
+    #[test]
+    fn test_cached_statistics() {
+        let mut list = PersistingList::default();
+        let mut ident_oracle = BatchIdent::default();
+
+        assert!(list.is_empty());
+
+        // Generate a buffer with a single row.
+        let first_batch = ident_oracle.next();
+        list.push(
+            first_batch,
+            buffer_with_lp(r#"bananas,tag=platanos great="yes" 42"#),
+        );
+
+        // The statistics must now match the expected values.
+        assert!(!list.is_empty());
+        assert_eq!(list.rows(), 1);
+        assert_matches!(
+            list.timestamp_stats(),
+            Some(TimestampMinMax { min: 42, max: 42 })
+        );
+        assert_schema_matches(list.schema().unwrap(), &["time", "great", "tag"]);
+
+        // Push another row.
+        let second_batch = ident_oracle.next();
+        list.push(
+            second_batch,
+            buffer_with_lp(r#"bananas,another=yes great="definitely",incremental=true 4242"#),
+        );
+
+        // The statistics must now match the expected values.
+        assert!(!list.is_empty());
+        assert_eq!(list.rows(), 2);
+        assert_matches!(
+            list.timestamp_stats(),
+            Some(TimestampMinMax { min: 42, max: 4242 })
+        );
+        assert_schema_matches(
+            list.schema().unwrap(),
+            &["time", "great", "tag", "another", "incremental"],
+        );
+
+        // Remove the first batch.
+        list.remove(first_batch);
+
+        // The statistics must now match the second batch values.
+        assert!(!list.is_empty());
+        assert_eq!(list.rows(), 1);
+        assert_matches!(
+            list.timestamp_stats(),
+            Some(TimestampMinMax {
+                min: 4242,
+                max: 4242
+            })
+        );
+        assert_schema_matches(
+            list.schema().unwrap(),
+            &["time", "great", "another", "incremental"],
+        );
+
+        // Remove the second/final batch.
+        list.remove(second_batch);
+
+        assert!(list.is_empty());
+        assert_eq!(list.rows(), 0);
+        assert_matches!(list.timestamp_stats(), None);
+        assert_matches!(list.schema(), None);
+    }
+
+    /// Assert the schema columns match the given names.
+    fn assert_schema_matches(schema: &Schema, cols: &[&str]) {
+        let schema = schema.as_arrow();
+        let got = schema
+            .all_fields()
+            .into_iter()
+            .map(|v| v.name().to_owned())
+            .collect::<BTreeSet<_>>();
+
+        let want = cols
+            .iter()
+            .map(ToString::to_string)
+            .collect::<BTreeSet<_>>();
+
+        assert_eq!(got, want);
+    }
+
+    /// Return a persisting buffer containing the given LP content.
+    fn buffer_with_lp(lp: &str) -> BufferState<Persisting> {
+        let mut buffer = BufferState::new();
+        // Write some data to a buffer.
+        buffer
+            .write(lp_to_mutable_batch(lp).1, SequenceNumber::new(0))
+            .expect("write to empty buffer should succeed");
+
+        // Convert the buffer into a persisting snapshot.
+        match buffer.snapshot() {
+            Transition::Ok(v) => v.into_persisting(),
+            Transition::Unchanged(_) => panic!("did not transition to snapshot state"),
+        }
+    }
+}

--- a/ingester/src/buffer_tree/partition/persisting_list.rs
+++ b/ingester/src/buffer_tree/partition/persisting_list.rs
@@ -159,9 +159,6 @@ struct CachedStats {
     timestamps: TimestampMinMax,
 
     /// The merged schema of all the persisting batches.
-    ///
-    /// This is invalidated (set to [`None`]) when an entry is added or removed
-    /// from `persisting`.
     schema: Schema,
 }
 


### PR DESCRIPTION
This PR both _simplifies_ and _speeds up_ querying of persisting batches of data! :rocket:

It moves statistic computation and schema union-ing from query time (which can happen an unbounded number of times) to batch-persist time (which happens exactly once per batch), and caches the resulting data for subsequent queries.

This improves performance linear to the number of persisting batches - it's effectively an unbounded improvement.

---

* perf(ingester): persisting list & cached statistics (13d60ed01)
      
      This commit breaks the ordered list of persisting buffers into its own
      type (PersistingList) for clarity, and implements a cache within it of
      the merged set of schemas across all persisting buffer FSMs, and
      row/timestamp summaries.
      
      This cleans up the code, and prevents N persisting schemas from being
      merged at query time (for every query!), instead schemas and statistics
      are incrementally maintained, pushing the computation to persist time
      rather than query time.