### PR TITLE
feat(gossip): schema diff message proto

### DIFF
--- a/generated_types/build.rs
+++ b/generated_types/build.rs
@@ -37,6 +37,7 @@ fn generate_grpc_types(root: &Path) -> Result<()> {
     let catalog_path = root.join("influxdata/iox/catalog/v1");
     let compactor_path = root.join("influxdata/iox/compactor/v1");
     let delete_path = root.join("influxdata/iox/delete/v1");
+    let gossip_path = root.join("influxdata/iox/gossip/v1");
     let ingester_path = root.join("influxdata/iox/ingester/v1");
     let namespace_path = root.join("influxdata/iox/namespace/v1");
     let object_store_path = root.join("influxdata/iox/object_store/v1");
@@ -56,6 +57,7 @@ fn generate_grpc_types(root: &Path) -> Result<()> {
         catalog_path.join("service.proto"),
         compactor_path.join("service.proto"),
         delete_path.join("service.proto"),
+        gossip_path.join("message.proto"),
         ingester_path.join("parquet_metadata.proto"),
         ingester_path.join("persist.proto"),
         ingester_path.join("write.proto"),

--- a/generated_types/protos/influxdata/iox/gossip/v1/message.proto
+++ b/generated_types/protos/influxdata/iox/gossip/v1/message.proto
@@ -1,0 +1,112 @@
+syntax = "proto3";
+package influxdata.iox.gossip.v1;
+option go_package = "github.com/influxdata/iox/gossip/v1";
+
+import "influxdata/iox/partition_template/v1/template.proto";
+
+// A message exchanged via the IOx gossip mechanism.
+message GossipMessage {
+  oneof msg {
+    // A new namespace was created.
+    NamespaceCreated namespace_created = 1;
+
+    // A new table was created.
+    TableCreated table_created = 2;
+
+    // One or more new columns were added to an existing table.
+    TableUpdated table_updated = 3;
+  }
+}
+
+// Initialisation of a new namespace occured.
+//
+// If the local peer already knows of this namespace, this is a no-op.
+message NamespaceCreated {
+  string namespace_name = 1;
+  int64 namespace_id = 2;
+
+  // Immutable fields.
+  //
+  // Fields below this line MUST be immutable for the lifetime of a table -
+  // there is no merge stategy for them.
+  influxdata.iox.partition_template.v1.PartitionTemplate partition_template = 3;
+
+  // Mutable fields.
+  //
+  // Fields below this line may change over the lifetime of the namespace, and
+  // may differ on the local node when it receives this message.
+  //
+  // If the local peer has values that differ from these, the local value takes
+  // prescidence.
+  uint64 max_columns_per_table = 4;
+  uint64 max_tables = 5;
+  optional int64 retention_period_ns = 6;
+}
+
+// An incremental/differential addition to an existing table.
+//
+// If the receiving peer does not know of the table being updated, this is a
+// no-op.
+//
+// This type is designed to function as a commutative, operation-based CRDT.
+//
+// A table can contain many columns, each with a string name, and therefore the
+// serialised representation of an entire table can grow to be fairly large -
+// it's infeasible to send all columns for every update due to space constraints
+// of the gossip message transport. Instead only differentials/new additions are
+// gossiped between peers and an external system is relied on to converge state
+// in the case of lost updates.
+message TableUpdated {
+  string table_name = 1;
+  string namespace_name = 2;
+  int64 table_id = 3;
+
+  // The set of columns in this update.
+  repeated Column columns = 4;
+}
+
+// Initialisation of a new table occured.
+//
+// This is a superset of the merge-able TableUpdated message, containing
+// immutable and large fields that should not be propagated for each column
+// addition for frame size/performance reasons.
+message TableCreated {
+  // The initialised state of the new table, including all, or a subset of,
+  // columns.
+  //
+  // If the serialised message exceeds the underlying max transport frame size,
+  // a subset of columns is transmitted instead of the full set, and one or more
+  // TableUpdated frames MAY be sent containing the remaining columns.
+  TableUpdated table = 1;
+
+  // Fields below this line MUST be immutable for the lifetime of a table -
+  // there is no merge stategy for them.
+
+  // The table partition template used for partitioning writes for this table.
+  influxdata.iox.partition_template.v1.PartitionTemplate partition_template = 2;
+}
+
+// Representation of a column schema within a table.
+//
+// Values within this structure MUST be immutable for the lifetime of the
+// column.
+message Column {
+  string name = 1;
+  int64 column_id = 2;
+  ColumnType column_type = 5;
+
+  enum ColumnType {
+    // An unknown column data type.
+    //
+    // This is an invalid value and SHOULD never be specified.
+    COLUMN_TYPE_UNSPECIFIED = 0;
+
+    COLUMN_TYPE_I64 = 1;
+    COLUMN_TYPE_U64 = 2;
+    COLUMN_TYPE_F64 = 3;
+    COLUMN_TYPE_BOOL = 4;
+    COLUMN_TYPE_STRING = 5;
+    COLUMN_TYPE_TIME = 6;
+    COLUMN_TYPE_TAG = 7;
+  }
+}

--- a/generated_types/src/lib.rs
+++ b/generated_types/src/lib.rs
@@ -89,6 +89,12 @@ pub mod influxdata {
             }
         }
 
+        pub mod gossip {
+            pub mod v1 {
+                include!(concat!(env!("OUT_DIR"), "/influxdata.iox.gossip.v1.rs"));
+            }
+        }
+
         pub mod ingester {
             pub mod v1 {
                 include!(concat!(env!("OUT_DIR"), "/influxdata.iox.ingester.v1.rs"));

--- a/generated_types/src/lib.rs
+++ b/generated_types/src/lib.rs
@@ -8,6 +8,9 @@
 // Workaround for "unused crate" lint false positives.
 use workspace_hack as _;
 
+// Re-export prost for users of proto types.
+pub use prost;
+
 /// This module imports the generated protobuf code into a Rust module
 /// hierarchy that matches the namespace hierarchy of the protobuf
 /// definitions


### PR DESCRIPTION
The router's will gossip schema diffs to interested peers - this PR defines the format of those messages.

Note that _differentials_ are sent to peers, and not the entire schema. This cuts down on unnecessary write amplification caused by retransmitting 100 tables with 100 columns when adding a single column. Because of this, convergence is best effort, which is as strong as we need, as schema cache misses go to the source-of-truth (catalog).

---

* feat(proto): schema gossip message definitions (081dc03a3)
      
      Define the gossip message types used to disseminate schema changes to
      other peers.
      
      Currently there are two types defined: an initial "create" operation,
      intended to be followed by "update" operations where appropriate. Both
      messages are trivial CRDTs in that they are effectively add-only column
      sets (a monotonic type) with other fields required to be immutable (as
      they currently are in IOx).

* refactor: re-export prost in generated_types (58269bf46)
      
      The generated types emit types that depend on prost (through Message
      derives), and therefore all users of generated_types already depend on
      prost.
      
      It would be wrong for users of the generated_types crate to use a
      different version of prost than what is used in generated_types.
      
      By re-exporting prost, users can just depend on generated_types, and
      always use the right prost version. prost prost prost. prost.