### PR TITLE
feat(router): Expose `num_probes` request count used to health-check ingesters as config option

### DIFF
--- a/clap_blocks/src/router.rs
+++ b/clap_blocks/src/router.rs
@@ -142,6 +142,16 @@ pub struct RouterConfig {
         value_parser = parse_duration
     )]
     pub rpc_write_health_error_window_seconds: Duration,
+
+    /// Specify the number of probe requests made within a probing window of
+    /// 1 second to compare against the maximum error ratio of 80% when the
+    /// is making judgements about the health of downstream RPC write handlers.
+    #[clap(
+        long = "rpc-write-health-num-probes",
+        env = "INFLUXDB_IOX_RPC_WRITE_HEALTH_NUM_PROBES",
+        default_value = "10"
+    )]
+    pub rpc_write_health_num_probes: u64,
 }
 
 /// Map a string containing an integer number of seconds into a [`Duration`].

--- a/clap_blocks/src/router.rs
+++ b/clap_blocks/src/router.rs
@@ -144,7 +144,7 @@ pub struct RouterConfig {
     pub rpc_write_health_error_window_seconds: Duration,
 
     /// Specify the maximum number of probe requests to be sent per second.
-    /// 
+    ///
     /// At least 20% of these requests must succeed within a second for the
     /// endpoint to be considered healthy.
     #[clap(

--- a/clap_blocks/src/router.rs
+++ b/clap_blocks/src/router.rs
@@ -143,9 +143,10 @@ pub struct RouterConfig {
     )]
     pub rpc_write_health_error_window_seconds: Duration,
 
-    /// Specify the number of probe requests made within a probing window of
-    /// 1 second to compare against the maximum error ratio of 80% when the
-    /// is making judgements about the health of downstream RPC write handlers.
+    /// Specify the maximum number of probe requests to be sent per second.
+    /// 
+    /// At least 20% of these requests must succeed within a second for the
+    /// endpoint to be considered healthy.
     #[clap(
         long = "rpc-write-health-num-probes",
         env = "INFLUXDB_IOX_RPC_WRITE_HEALTH_NUM_PROBES",

--- a/influxdb_iox/src/commands/run/all_in_one.rs
+++ b/influxdb_iox/src/commands/run/all_in_one.rs
@@ -491,6 +491,7 @@ impl Config {
             rpc_write_replicas: 1.try_into().unwrap(),
             rpc_write_max_outgoing_bytes: ingester_config.rpc_write_max_incoming_bytes,
             rpc_write_health_error_window_seconds: Duration::from_secs(5),
+            rpc_write_health_num_probes: 10,
             gossip_config: GossipConfig::disabled(),
         };
 

--- a/ioxd_router/src/lib.rs
+++ b/ioxd_router/src/lib.rs
@@ -248,6 +248,7 @@ pub async fn create_router_server_type(
         router_config.rpc_write_replicas,
         &metrics,
         router_config.rpc_write_health_error_window_seconds,
+        router_config.rpc_write_health_num_probes,
     );
     let rpc_writer = InstrumentationDecorator::new("rpc_writer", &metrics, rpc_writer);
 

--- a/router/src/dml_handlers/rpc_write.rs
+++ b/router/src/dml_handlers/rpc_write.rs
@@ -1070,12 +1070,13 @@ mod tests {
                 async move {
                     let endpoints = upstreams.into_iter()
                         .map(|(circuit, client)| {
-                            CircuitBreakingClient::new(client, "bananas",ARBITRARY_TEST_ERROR_WINDOW,
-
-
-            ARBITRARY_TEST_NUM_PROBES,
-                        )
-                                .with_circuit_breaker(circuit)
+                            CircuitBreakingClient::new(
+                                client,
+                                "bananas",
+                                ARBITRARY_TEST_ERROR_WINDOW,
+                                ARBITRARY_TEST_NUM_PROBES,
+                            )
+                            .with_circuit_breaker(circuit)
                         });
 
                     make_request(endpoints, n_copies).await

--- a/router/src/dml_handlers/rpc_write.rs
+++ b/router/src/dml_handlers/rpc_write.rs
@@ -116,7 +116,9 @@ pub struct RpcWrite<T, C = CircuitBreaker> {
 
 impl<T> RpcWrite<T> {
     /// Initialise a new [`RpcWrite`] that sends requests to an arbitrary
-    /// downstream Ingester, using a round-robin strategy.
+    /// downstream Ingester, using a round-robin strategy. Health checks are
+    /// configured by `error_window` and `num_probes` as laid out by the
+    /// documentation for [`CircuitBreaker`].
     ///
     /// If [`Some`], `replica_copies` specifies the number of additional
     /// upstream ingesters that must receive and acknowledge the write for it to
@@ -131,6 +133,7 @@ impl<T> RpcWrite<T> {
         n_copies: NonZeroUsize,
         metrics: &metric::Registry,
         error_window: Duration,
+        num_probes: u64,
     ) -> Self
     where
         T: Send + Sync + Debug + 'static,
@@ -138,7 +141,7 @@ impl<T> RpcWrite<T> {
     {
         let endpoints = Balancer::new(
             endpoints.into_iter().map(|(client, name)| {
-                CircuitBreakingClient::new(client, name.into(), error_window)
+                CircuitBreakingClient::new(client, name.into(), error_window, num_probes)
             }),
             Some(metrics),
         );
@@ -385,6 +388,7 @@ mod tests {
     const NAMESPACE_NAME: &str = "bananas";
     const NAMESPACE_ID: NamespaceId = NamespaceId::new(42);
     const ARBITRARY_TEST_ERROR_WINDOW: Duration = Duration::from_secs(5);
+    const ARBITRARY_TEST_NUM_PROBES: u64 = 10;
 
     // Start a new `NamespaceSchema` with only the given ID; the rest of the fields are arbitrary.
     fn new_empty_namespace_schema() -> Arc<NamespaceSchema> {
@@ -463,6 +467,7 @@ mod tests {
             1.try_into().unwrap(),
             &metric::Registry::default(),
             ARBITRARY_TEST_ERROR_WINDOW,
+            ARBITRARY_TEST_NUM_PROBES,
         );
 
         // Drive the RPC writer
@@ -526,6 +531,7 @@ mod tests {
             1.try_into().unwrap(),
             &metric::Registry::default(),
             ARBITRARY_TEST_ERROR_WINDOW,
+            ARBITRARY_TEST_NUM_PROBES,
         );
 
         // Drive the RPC writer
@@ -595,6 +601,7 @@ mod tests {
             1.try_into().unwrap(),
             &metric::Registry::default(),
             ARBITRARY_TEST_ERROR_WINDOW,
+            ARBITRARY_TEST_NUM_PROBES,
         );
 
         // Drive the RPC writer
@@ -645,10 +652,13 @@ mod tests {
         circuit_1.set_healthy(false);
 
         let got = make_request(
-            [
-                CircuitBreakingClient::new(client_1, "client_1", ARBITRARY_TEST_ERROR_WINDOW)
-                    .with_circuit_breaker(circuit_1),
-            ],
+            [CircuitBreakingClient::new(
+                client_1,
+                "client_1",
+                ARBITRARY_TEST_ERROR_WINDOW,
+                ARBITRARY_TEST_NUM_PROBES,
+            )
+            .with_circuit_breaker(circuit_1)],
             1,
         )
         .await;
@@ -669,10 +679,13 @@ mod tests {
         circuit_1.set_healthy(true);
 
         let got = make_request(
-            [
-                CircuitBreakingClient::new(client_1, "client_1", ARBITRARY_TEST_ERROR_WINDOW)
-                    .with_circuit_breaker(circuit_1),
-            ],
+            [CircuitBreakingClient::new(
+                client_1,
+                "client_1",
+                ARBITRARY_TEST_ERROR_WINDOW,
+                ARBITRARY_TEST_NUM_PROBES,
+            )
+            .with_circuit_breaker(circuit_1)],
             1,
         )
         .await;
@@ -693,10 +706,13 @@ mod tests {
         circuit_1.set_healthy(true);
 
         let got = make_request(
-            [
-                CircuitBreakingClient::new(client_1, "client_1", ARBITRARY_TEST_ERROR_WINDOW)
-                    .with_circuit_breaker(circuit_1),
-            ],
+            [CircuitBreakingClient::new(
+                client_1,
+                "client_1",
+                ARBITRARY_TEST_ERROR_WINDOW,
+                ARBITRARY_TEST_NUM_PROBES,
+            )
+            .with_circuit_breaker(circuit_1)],
             1,
         )
         .await;
@@ -728,10 +744,20 @@ mod tests {
 
         let got = make_request(
             [
-                CircuitBreakingClient::new(client_1, "client_1", ARBITRARY_TEST_ERROR_WINDOW)
-                    .with_circuit_breaker(circuit_1),
-                CircuitBreakingClient::new(client_2, "client_2", ARBITRARY_TEST_ERROR_WINDOW)
-                    .with_circuit_breaker(circuit_2),
+                CircuitBreakingClient::new(
+                    client_1,
+                    "client_1",
+                    ARBITRARY_TEST_ERROR_WINDOW,
+                    ARBITRARY_TEST_NUM_PROBES,
+                )
+                .with_circuit_breaker(circuit_1),
+                CircuitBreakingClient::new(
+                    client_2,
+                    "client_2",
+                    ARBITRARY_TEST_ERROR_WINDOW,
+                    ARBITRARY_TEST_NUM_PROBES,
+                )
+                .with_circuit_breaker(circuit_2),
             ],
             2, // 2 copies required
         )
@@ -758,12 +784,14 @@ mod tests {
                     Arc::clone(&client_1),
                     "client_1",
                     ARBITRARY_TEST_ERROR_WINDOW,
+                    ARBITRARY_TEST_NUM_PROBES,
                 )
                 .with_circuit_breaker(circuit_1),
                 CircuitBreakingClient::new(
                     Arc::clone(&client_2),
                     "client_2",
                     ARBITRARY_TEST_ERROR_WINDOW,
+                    ARBITRARY_TEST_NUM_PROBES,
                 )
                 .with_circuit_breaker(circuit_2),
             ],
@@ -802,12 +830,14 @@ mod tests {
                 Arc::clone(&client_1),
                 "client_1",
                 ARBITRARY_TEST_ERROR_WINDOW,
+                ARBITRARY_TEST_NUM_PROBES,
             )
             .with_circuit_breaker(circuit_1),
             CircuitBreakingClient::new(
                 Arc::clone(&client_2),
                 "client_2",
                 ARBITRARY_TEST_ERROR_WINDOW,
+                ARBITRARY_TEST_NUM_PROBES,
             )
             .with_circuit_breaker(circuit_2),
         ];
@@ -856,12 +886,14 @@ mod tests {
                     Arc::clone(&client_1),
                     "client_1",
                     ARBITRARY_TEST_ERROR_WINDOW,
+                    ARBITRARY_TEST_NUM_PROBES,
                 )
                 .with_circuit_breaker(circuit_1),
                 CircuitBreakingClient::new(
                     Arc::clone(&client_2),
                     "client_2",
                     ARBITRARY_TEST_ERROR_WINDOW,
+                    ARBITRARY_TEST_NUM_PROBES,
                 )
                 .with_circuit_breaker(circuit_2),
             ],
@@ -920,18 +952,21 @@ mod tests {
                 Arc::clone(&client_1),
                 "client_1",
                 ARBITRARY_TEST_ERROR_WINDOW,
+                ARBITRARY_TEST_NUM_PROBES,
             )
             .with_circuit_breaker(circuit_1),
             CircuitBreakingClient::new(
                 Arc::clone(&client_2),
                 "client_2",
                 ARBITRARY_TEST_ERROR_WINDOW,
+                ARBITRARY_TEST_NUM_PROBES,
             )
             .with_circuit_breaker(circuit_2),
             CircuitBreakingClient::new(
                 Arc::clone(&client_3),
                 "client_3",
                 ARBITRARY_TEST_ERROR_WINDOW,
+                ARBITRARY_TEST_NUM_PROBES,
             )
             .with_circuit_breaker(circuit_3),
         ];
@@ -1035,7 +1070,11 @@ mod tests {
                 async move {
                     let endpoints = upstreams.into_iter()
                         .map(|(circuit, client)| {
-                            CircuitBreakingClient::new(client, "bananas",ARBITRARY_TEST_ERROR_WINDOW)
+                            CircuitBreakingClient::new(client, "bananas",ARBITRARY_TEST_ERROR_WINDOW,
+
+
+            ARBITRARY_TEST_NUM_PROBES,
+                        )
                                 .with_circuit_breaker(circuit)
                         });
 

--- a/router/src/dml_handlers/rpc_write/balancer.rs
+++ b/router/src/dml_handlers/rpc_write/balancer.rs
@@ -220,6 +220,7 @@ mod tests {
     use super::*;
 
     const ARBITRARY_TEST_ERROR_WINDOW: Duration = Duration::from_secs(5);
+    const ARBITRARY_TEST_NUM_PROBES: u64 = 10;
 
     /// No healthy nodes prevents a snapshot from being returned.
     #[tokio::test]
@@ -233,6 +234,7 @@ mod tests {
             Arc::new(MockWriteClient::default()),
             "bananas",
             ARBITRARY_TEST_ERROR_WINDOW,
+            ARBITRARY_TEST_NUM_PROBES,
         )
         .with_circuit_breaker(Arc::clone(&circuit_err_1));
 
@@ -243,6 +245,7 @@ mod tests {
             Arc::new(MockWriteClient::default()),
             "bananas",
             ARBITRARY_TEST_ERROR_WINDOW,
+            ARBITRARY_TEST_NUM_PROBES,
         )
         .with_circuit_breaker(Arc::clone(&circuit_err_2));
 
@@ -266,6 +269,7 @@ mod tests {
             Arc::new(MockWriteClient::default()),
             "bananas",
             ARBITRARY_TEST_ERROR_WINDOW,
+            ARBITRARY_TEST_NUM_PROBES,
         )
         .with_circuit_breaker(Arc::clone(&circuit_err_1));
 
@@ -276,6 +280,7 @@ mod tests {
             Arc::new(MockWriteClient::default()),
             "bananas",
             ARBITRARY_TEST_ERROR_WINDOW,
+            ARBITRARY_TEST_NUM_PROBES,
         )
         .with_circuit_breaker(Arc::clone(&circuit_err_2));
         let circuit_ok = Arc::new(MockCircuitBreaker::default());
@@ -285,6 +290,7 @@ mod tests {
             Arc::new(MockWriteClient::default()),
             "bananas",
             ARBITRARY_TEST_ERROR_WINDOW,
+            ARBITRARY_TEST_NUM_PROBES,
         )
         .with_circuit_breaker(Arc::clone(&circuit_ok));
 
@@ -345,6 +351,7 @@ mod tests {
             Arc::new(MockWriteClient::default()),
             "bananas",
             ARBITRARY_TEST_ERROR_WINDOW,
+            ARBITRARY_TEST_NUM_PROBES,
         )
         .with_circuit_breaker(Arc::clone(&circuit_err_1));
 
@@ -355,6 +362,7 @@ mod tests {
             Arc::new(MockWriteClient::default()),
             "bananas",
             ARBITRARY_TEST_ERROR_WINDOW,
+            ARBITRARY_TEST_NUM_PROBES,
         )
         .with_circuit_breaker(Arc::clone(&circuit_err_2));
 
@@ -364,6 +372,7 @@ mod tests {
             Arc::new(MockWriteClient::default()),
             "bananas",
             ARBITRARY_TEST_ERROR_WINDOW,
+            ARBITRARY_TEST_NUM_PROBES,
         )
         .with_circuit_breaker(Arc::clone(&circuit_ok));
 
@@ -415,6 +424,7 @@ mod tests {
             Arc::new(MockWriteClient::default()),
             "bananas",
             ARBITRARY_TEST_ERROR_WINDOW,
+            ARBITRARY_TEST_NUM_PROBES,
         )
         .with_circuit_breaker(Arc::clone(&circuit));
 
@@ -468,6 +478,7 @@ mod tests {
             Arc::new(MockWriteClient::default()),
             "bananas",
             ARBITRARY_TEST_ERROR_WINDOW,
+            ARBITRARY_TEST_NUM_PROBES,
         )
         .with_circuit_breaker(Arc::clone(&circuit_err));
 
@@ -477,6 +488,7 @@ mod tests {
             Arc::new(MockWriteClient::default()),
             "bananas",
             ARBITRARY_TEST_ERROR_WINDOW,
+            ARBITRARY_TEST_NUM_PROBES,
         )
         .with_circuit_breaker(Arc::clone(&circuit_ok_1));
 
@@ -486,6 +498,7 @@ mod tests {
             Arc::new(MockWriteClient::default()),
             "bananas",
             ARBITRARY_TEST_ERROR_WINDOW,
+            ARBITRARY_TEST_NUM_PROBES,
         )
         .with_circuit_breaker(Arc::clone(&circuit_ok_2));
 
@@ -523,6 +536,7 @@ mod tests {
             Arc::new(MockWriteClient::default()),
             "bad-client-1",
             ARBITRARY_TEST_ERROR_WINDOW,
+            ARBITRARY_TEST_NUM_PROBES,
         )
         .with_circuit_breaker(Arc::clone(&circuit_err_1));
 
@@ -533,6 +547,7 @@ mod tests {
             Arc::new(MockWriteClient::default()),
             "bad-client-2",
             ARBITRARY_TEST_ERROR_WINDOW,
+            ARBITRARY_TEST_NUM_PROBES,
         )
         .with_circuit_breaker(Arc::clone(&circuit_err_2));
 
@@ -542,6 +557,7 @@ mod tests {
             Arc::new(MockWriteClient::default()),
             "ok-client",
             ARBITRARY_TEST_ERROR_WINDOW,
+            ARBITRARY_TEST_NUM_PROBES,
         )
         .with_circuit_breaker(Arc::clone(&circuit_ok));
 
@@ -612,6 +628,7 @@ mod tests {
             Arc::new(MockWriteClient::default()),
             "bad-client-1",
             ARBITRARY_TEST_ERROR_WINDOW,
+            ARBITRARY_TEST_NUM_PROBES,
         )
         .with_circuit_breaker(Arc::clone(&circuit_err));
 

--- a/router/src/dml_handlers/rpc_write/circuit_breaker.rs
+++ b/router/src/dml_handlers/rpc_write/circuit_breaker.rs
@@ -20,10 +20,8 @@ use tokio::{
 /// healthy. If updating this value, remember to update the documentation
 /// in the CLI flag for the configurable error window.
 const MAX_ERROR_RATIO: f32 = 0.8;
-/// The maximum number of probe requests to allow when in an unhealthy state.
-const NUM_PROBES: u64 = 10;
-/// The length of time during which up to [`NUM_PROBES`] are allowed when in an
-/// unhealthy state.
+/// The length of time during which up to the configured number of probes
+/// are allowed when in an unhealthy state.
 const PROBE_INTERVAL: Duration = Duration::from_secs(1);
 
 /// A low-overhead, error ratio gated [`CircuitBreaker`].
@@ -41,7 +39,7 @@ const PROBE_INTERVAL: Duration = Duration::from_secs(1);
 /// to detect recovery (with an expectation this will likely fail). The
 /// [`CircuitBreaker`] selects callers to send a probe request, indicated by a
 /// `true` return value from [`CircuitBreaker::should_probe()`]. At least
-/// [`NUM_PROBES`] must be sent to drive a [`CircuitBreaker`] to a healthy
+/// the configured number of probes must be sent to drive a [`CircuitBreaker`] to a healthy
 /// state, so callers must call [`CircuitBreaker::should_probe()`] periodically.
 ///
 /// When requests made to the ingester return, [`CircuitBreaker::observe()`] is
@@ -63,7 +61,7 @@ const PROBE_INTERVAL: Duration = Duration::from_secs(1);
 /// The circuit breaker is considered unhealthy when 80% ([`MAX_ERROR_RATIO`])
 /// of requests within the configured error window fail. The breaker
 /// becomes healthy again when the error rate falls below 80%
-/// ([`MAX_ERROR_RATIO`]) for the, at most, 10 probe requests ([`NUM_PROBES`])
+/// ([`MAX_ERROR_RATIO`]) for the, at most, configured number of probe requests
 /// allowed through within 1 second ([`PROBE_INTERVAL`]).
 ///
 /// The circuit breaker initialises in the healthy state.
@@ -90,7 +88,7 @@ const PROBE_INTERVAL: Duration = Duration::from_secs(1);
 ///
 ///   * Half-open: A transition state between "open/unhealthy" and
 ///     "closed/healthy"; a majority of traffic is refused, but up to
-///     [`NUM_PROBES`] number of requests are allowed to proceed per
+///     the configured number of probes number of requests are allowed to proceed per
 ///     [`PROBE_INTERVAL`]. Once the probes are sent, the error ratio is
 ///     evaluated, and the system returns to either open or closed as
 ///     appropriate.
@@ -103,7 +101,7 @@ const PROBE_INTERVAL: Duration = Duration::from_secs(1);
 /// [`MAX_ERROR_RATIO`] within a single window to open the circuit breaker to
 /// start being considered unhealthy.
 ///
-/// A floor of at least [`MAX_ERROR_RATIO`] * [`NUM_PROBES`] must be observed per
+/// A floor of at least [`MAX_ERROR_RATIO`] * `configured num_probes` must be observed per
 /// error window before the circuit breaker opens / becomes unhealthy.
 ///
 /// Error ratios are measured on every call to [`CircuitBreaker::is_healthy`],
@@ -118,7 +116,7 @@ const PROBE_INTERVAL: Duration = Duration::from_secs(1);
 ///
 /// ## Probing / Closing (becoming healthy)
 ///
-/// Once a circuit breaker transitions to "open/unhealthy", up to 10 [`NUM_PROBES`]
+/// Once a circuit breaker transitions to "open/unhealthy", up to the configured number of probe
 /// requests are allowed per 1s [`PROBE_INTERVAL`], as determined by calling
 /// [`CircuitBreaker::should_probe`] before sending a request. This is referred
 /// to as "probing", allowing the client to discover the state of the
@@ -126,17 +124,17 @@ const PROBE_INTERVAL: Duration = Duration::from_secs(1);
 /// may fail as a result.
 ///
 /// Whilst in the probing state, the result of each allowed probing request is
-/// recorded - once at least [`NUM_PROBES`] requests have been completed and the
+/// recorded - once at least the configured number of probe requests have been completed and the
 /// ratio of errors drops below [`MAX_ERROR_RATIO`], the circuit breaker
 /// transitions to "closed/healthy".
 ///
-/// If [`NUM_PROBES`] requests have been completed and the ratio of errors to
+/// If the configured number of probe requests have been completed and the ratio of errors to
 /// successes continues to be above [`MAX_ERROR_RATIO`], transition back to
 /// "open/unhealthy" to wait another [`PROBE_INTERVAL`] delay before
-/// transitioning back to the probing state and allowing another [`NUM_PROBES`]
+/// transitioning back to the probing state and allowing another the set of probe
 /// requests to proceed.
 ///
-/// If there are not enough requests made to exceed [`NUM_PROBES`] within a
+/// If there are not enough requests made to exceed the configured number of probes within a
 /// period of [`PROBE_INTERVAL`], all requests are probes and are allowed
 /// through.
 #[derive(Debug)]
@@ -145,7 +143,7 @@ pub struct CircuitBreaker {
     /// current error window.
     ///
     /// When the total number of requests ([`RequestCounterValue::total()`]) is
-    /// less than [`NUM_PROBES`], the circuit is in the "probing" regime. When
+    /// less than the configured number of probes, the circuit is in the "probing" regime. When
     /// the number of requests is greater than this amount, the circuit
     /// open/closed state depends on the current error ratio.
     requests: Arc<RequestCounter>,
@@ -161,13 +159,15 @@ pub struct CircuitBreaker {
     ///
     /// Used for logging context only.
     endpoint: Arc<str>,
+
+    num_probes: u64,
 }
 
 #[derive(Debug, Default)]
 struct ProbeState {
     /// The instant at which this set of probes started to be sent.
     ///
-    /// Up to [`NUM_PROBES`] SHOULD be sent in the time range between this
+    /// Up to the configured probe limit SHOULD be sent in the time range between this
     /// timestamp plus [`PROBE_INTERVAL`].
     probe_window_started_at: Option<Instant>,
     /// The number of probes sent so far in this [`PROBE_INTERVAL`].
@@ -175,7 +175,11 @@ struct ProbeState {
 }
 
 impl CircuitBreaker {
-    pub(crate) fn new(endpoint: impl Into<Arc<str>>, error_window: Duration) -> Self {
+    pub(crate) fn new(
+        endpoint: impl Into<Arc<str>>,
+        error_window: Duration,
+        num_probes: u64,
+    ) -> Self {
         let requests = Arc::new(RequestCounter::default());
         let s = Self {
             requests: Arc::clone(&requests),
@@ -185,10 +189,11 @@ impl CircuitBreaker {
                 ticker.set_missed_tick_behavior(MissedTickBehavior::Delay);
                 loop {
                     ticker.tick().await;
-                    reset_closed_state_counters(&requests);
+                    reset_closed_state_counters(&requests, num_probes);
                 }
             }),
             endpoint: endpoint.into(),
+            num_probes,
         };
         s.set_healthy();
         s
@@ -196,7 +201,7 @@ impl CircuitBreaker {
 
     /// Force-set the state of the circuit breaker to "closed" / healthy.
     pub(crate) fn set_healthy(&self) {
-        self.requests.set(NUM_PROBES as u32, 0);
+        self.requests.set(self.num_probes as u32, 0);
     }
 
     /// Observe a request result, recording the success/error.
@@ -223,7 +228,7 @@ impl CircuitBreaker {
         // If the counts have previously transitioned to being in the probing
         // state, the circuit breaker can't be healthy, and we don't need to
         // check the error ratio.
-        if is_probing(counts) {
+        if is_probing(counts, self.num_probes) {
             return false;
         }
 
@@ -238,7 +243,7 @@ impl CircuitBreaker {
     /// "closed/healthy" state; callers should check `is_healthy` first and only
     /// call this if `is_healthy` returns `false`.
     ///
-    /// This method will return `true` at most [`NUM_PROBES`] per
+    /// This method will return `true` at most `num_probes` per
     /// [`PROBE_INTERVAL`] discrete duration.
     ///
     /// # Blocking
@@ -250,7 +255,7 @@ impl CircuitBreaker {
     /// Concurrent requests that were started before (or after) `self` switches
     /// to the probing regime without observing [`Self::should_probe()`] as
     /// `true` count as probes when evaluating the state of the circuit. These
-    /// requests are in addition to the [`NUM_PROBES`] guaranteed to observe
+    /// requests are in addition to the configured number of probes guaranteed to observe
     /// `true` when calling this method.
     pub(crate) fn should_probe(&self) -> bool {
         // Enable this code path only when probing needs to start, or has
@@ -273,7 +278,7 @@ impl CircuitBreaker {
                 // has been reset because of the `return false` in the next
                 // match arm that prevents the increase of
                 // `guard.probes_started` if it has reached `NUM_PROBES`.
-                assert!(guard.probes_started <= NUM_PROBES);
+                assert!(guard.probes_started <= self.num_probes);
                 // Record the start of a probing interval.
                 guard.probe_window_started_at = Some(now);
                 // Reset the number of probes allowed.
@@ -292,7 +297,7 @@ impl CircuitBreaker {
                 //
                 // If there have already been the configured number of probes,
                 // do not allow more.
-                if guard.probes_started >= NUM_PROBES {
+                if guard.probes_started >= self.num_probes {
                     debug!(
                         endpoint=%self.endpoint,
                         "probes exhausted"
@@ -316,7 +321,7 @@ impl CircuitBreaker {
 
         debug!(
             nth_probe = guard.probes_started,
-            max_probes = NUM_PROBES,
+            max_probes = self.num_probes,
             endpoint=%self.endpoint,
             "sending probe"
         );
@@ -333,12 +338,12 @@ impl Drop for CircuitBreaker {
 
 // Returns `true` if the circuit is currently in the "probe" state.
 #[inline]
-fn is_probing(counts: RequestCounterValue) -> bool {
+fn is_probing(counts: RequestCounterValue, num_probes: u64) -> bool {
     // When there are less than `NUM_PROBES` completed requests, the circuit is
     // not closed/healthy, as some previous call to `should_probe` has observed
     // an error rate to put the circuit into the probing state, which resets the
     // request counts to start at 0.
-    counts.total() < NUM_PROBES
+    counts.total() < num_probes
 }
 
 /// Return `true` if the current ratio of errors is below MAX_ERROR_RATIO,
@@ -363,17 +368,17 @@ fn is_healthy(counts: RequestCounterValue) -> bool {
 
 /// Resets the absolute request counter values if the current circuit state is
 /// "closed" (healthy, not probing) at the time of the call, such that the there
-/// must be [`NUM_PROBES`] * [`MAX_ERROR_RATIO`] number of failed requests to open the
+/// must be `num_probes` * [`MAX_ERROR_RATIO`] number of failed requests to open the
 /// circuit (mark as unhealthy).
 ///
 /// Retains the closed/healthy state of the circuit. This is NOT an atomic
 /// operation.
-fn reset_closed_state_counters(counters: &RequestCounter) {
+fn reset_closed_state_counters(counters: &RequestCounter, num_probes: u64) {
     let counts = counters.read();
-    if !is_healthy(counts) || is_probing(counts) {
+    if !is_healthy(counts) || is_probing(counts, num_probes) {
         return;
     }
-    counters.set(NUM_PROBES as u32, 0);
+    counters.set(num_probes as u32, 0);
 }
 
 /// A store of two `u32` that can be read atomically; one tracking successful
@@ -449,9 +454,9 @@ mod tests {
 
     /// Assert that calling [`reset_closed_state_counters`] does nothing.
     #[track_caller]
-    fn assert_reset_is_nop(counters: &RequestCounter) {
+    fn assert_reset_is_nop(counters: &RequestCounter, num_probes: u64) {
         let v = counters.read();
-        reset_closed_state_counters(counters);
+        reset_closed_state_counters(counters, num_probes);
         assert_eq!(v, counters.read());
     }
 
@@ -463,7 +468,7 @@ mod tests {
 
     /// Return a new [`CircuitBreaker`] with the reset ticker disabled.
     fn new_no_reset() -> CircuitBreaker {
-        let c = CircuitBreaker::new("bananas", Duration::from_secs(5));
+        let c = CircuitBreaker::new("bananas", Duration::from_secs(5), 10);
         c.reset_task.abort();
         c
     }
@@ -478,7 +483,7 @@ mod tests {
         // The circuit breaker starts in a healthy state.
         assert!(c.is_healthy());
         assert!(!c.should_probe());
-        assert_reset_is_nop(&c.requests);
+        assert_reset_is_nop(&c.requests, c.num_probes);
 
         // Observe enough errors to become unhealthy
         let n = errors_to_unhealthy(&c.requests);
@@ -490,12 +495,12 @@ mod tests {
 
         // It should then transition to the probe state, and allow the
         // configured amount of probe requests.
-        for _ in 0..NUM_PROBES {
+        for _ in 0..c.num_probes {
             assert!(!c.is_healthy());
             assert!(c.should_probe());
             // Counter resets should not be allowed when the circuit is not
             // healthy.
-            assert_reset_is_nop(&c.requests);
+            assert_reset_is_nop(&c.requests, c.num_probes);
         }
 
         // And once NUM_PROBES is reached, stop allowing more probes.
@@ -503,7 +508,7 @@ mod tests {
         // It should remain unhealthy during this time.
         assert!(!c.should_probe());
         assert!(!c.is_healthy());
-        assert_reset_is_nop(&c.requests);
+        assert_reset_is_nop(&c.requests, c.num_probes);
 
         // Pretend it is time to probe again.
         c.probes.lock().probe_window_started_at = Some(
@@ -512,13 +517,13 @@ mod tests {
                 .expect("instant cannot roll back far enough - test issue, not code issue"),
         );
 
-        for _ in 0..(NUM_PROBES - 1) {
+        for _ in 0..(c.num_probes - 1) {
             // Recording a successful probe request should not mark the circuit
             // as healthy until the NUM_PROBES has been observed.
             assert!(c.should_probe());
             assert!(!c.is_healthy());
             c.requests.observe::<(), ()>(&Ok(()));
-            assert_reset_is_nop(&c.requests);
+            assert_reset_is_nop(&c.requests, c.num_probes);
         }
 
         // Upon reaching NUM_PROBES of entirely successful requests, the circuit
@@ -553,27 +558,27 @@ mod tests {
         //
         // Observing half of them as failing should end probing until the next
         // probe period.
-        let n_failed = NUM_PROBES / 2;
+        let n_failed = c.num_probes / 2;
         for _ in 0..(n_failed) {
             assert!(!c.is_healthy());
             assert!(c.should_probe());
-            assert_reset_is_nop(&c.requests);
+            assert_reset_is_nop(&c.requests, c.num_probes);
             c.requests.observe::<(), ()>(&Ok(()));
         }
-        for _ in 0..(NUM_PROBES - n_failed) {
+        for _ in 0..(c.num_probes - n_failed) {
             assert!(!c.is_healthy());
             assert!(c.should_probe());
-            assert_reset_is_nop(&c.requests);
+            assert_reset_is_nop(&c.requests, c.num_probes);
             c.requests.observe::<(), ()>(&Err(()));
         }
-        assert_eq!(c.requests.read().total(), NUM_PROBES);
+        assert_eq!(c.requests.read().total(), c.num_probes);
 
         // The probes did not drive the circuit breaker to closed/healthy.
         assert!(!c.is_healthy());
         // And no more probes should be allowed.
         assert!(!c.should_probe());
         // The request counters should not reset when unhealthy.
-        assert_reset_is_nop(&c.requests);
+        assert_reset_is_nop(&c.requests, c.num_probes);
 
         // Pretend it is time to probe again.
         c.probes.lock().probe_window_started_at = Some(
@@ -583,10 +588,10 @@ mod tests {
         );
 
         // Do the probe requests, all succeeding.
-        for _ in 0..NUM_PROBES {
+        for _ in 0..c.num_probes {
             assert!(!c.is_healthy());
             assert!(c.should_probe());
-            assert_reset_is_nop(&c.requests);
+            assert_reset_is_nop(&c.requests, c.num_probes);
             c.requests.observe::<(), ()>(&Ok(()));
         }
 
@@ -602,11 +607,11 @@ mod tests {
     /// error window periods from changing the circuit to open/unhealthy.
     #[tokio::test]
     async fn test_periodic_counter_reset() {
-        let c = CircuitBreaker::new("bananas", Duration::from_secs(5));
+        let c = CircuitBreaker::new("bananas", Duration::from_secs(5), 10);
 
         // Assert the circuit breaker as healthy.
         assert!(c.is_healthy());
-        assert_reset_is_nop(&c.requests);
+        assert_reset_is_nop(&c.requests, c.num_probes);
 
         // Calculate how many errors are needed to mark the circuit breaker as
         // unhealthy.
@@ -622,7 +627,7 @@ mod tests {
 
         // Reset the counters for the new error observation window
         let v = c.requests.read();
-        reset_closed_state_counters(&c.requests);
+        reset_closed_state_counters(&c.requests, c.num_probes);
         assert_ne!(v, c.requests.read());
 
         assert!(c.is_healthy());
@@ -668,7 +673,7 @@ mod tests {
                             // the error window advances and the counters are
                             // reset.
                             if (random::<usize>() % 50) == 0 {
-                                reset_closed_state_counters(&c.requests);
+                                reset_closed_state_counters(&c.requests, c.num_probes);
                             }
                         }
                     }
@@ -690,7 +695,7 @@ mod tests {
         );
 
         // Drive successful probes if needed.
-        for _ in 0..NUM_PROBES {
+        for _ in 0..c.num_probes {
             if c.should_probe() {
                 c.requests.observe::<(), ()>(&Ok(()));
             }
@@ -700,5 +705,35 @@ mod tests {
         // healthy at the end of the fuzz threads, or because it was
         // successfully probed and driven healthy afterwards.
         assert!(c.is_healthy(), "{c:?}");
+    }
+
+    /// Assert that when configured for low write volumes, a single successful
+    /// request is sufficient to drive the state to "healthy".
+    #[tokio::test]
+    async fn test_low_volume_configuration() {
+        let c = CircuitBreaker::new("bananas", Duration::from_secs(5), 1);
+        c.reset_task.abort();
+
+        // Assert the circuit breaker as healthy.
+        assert!(c.is_healthy());
+        assert_reset_is_nop(&c.requests, c.num_probes);
+
+        // Calculate how many errors are needed to mark the circuit breaker as
+        // unhealthy.
+        let n = errors_to_unhealthy(&c.requests);
+
+        // Drive the circuit to unhealthy.
+        for _ in 0..n {
+            assert!(c.is_healthy());
+            c.requests.observe::<(), ()>(&Err(()));
+        }
+        assert!(!c.is_healthy());
+
+        // Observe a single successful request
+        assert!(c.should_probe());
+        c.requests.observe::<(), ()>(&Ok(()));
+
+        // And the circuit should now be healthy.
+        assert!(c.is_healthy());
     }
 }

--- a/router/src/dml_handlers/rpc_write/circuit_breaker.rs
+++ b/router/src/dml_handlers/rpc_write/circuit_breaker.rs
@@ -131,7 +131,7 @@ const PROBE_INTERVAL: Duration = Duration::from_secs(1);
 /// If the configured number of probe requests have been completed and the ratio of errors to
 /// successes continues to be above [`MAX_ERROR_RATIO`], transition back to
 /// "open/unhealthy" to wait another [`PROBE_INTERVAL`] delay before
-/// transitioning back to the probing state and allowing another the set of probe
+/// transitioning back to the probing state and allowing another set of probe
 /// requests to proceed.
 ///
 /// If there are not enough requests made to exceed the configured number of probes within a

--- a/router/tests/common/mod.rs
+++ b/router/tests/common/mod.rs
@@ -35,6 +35,7 @@ pub struct TestContextBuilder {
     namespace_autocreation: MissingNamespaceAction,
     single_tenancy: bool,
     rpc_write_error_window: Duration,
+    rpc_write_num_probes: u64,
 }
 
 impl Default for TestContextBuilder {
@@ -43,6 +44,7 @@ impl Default for TestContextBuilder {
             namespace_autocreation: MissingNamespaceAction::Reject,
             single_tenancy: false,
             rpc_write_error_window: Duration::from_secs(5),
+            rpc_write_num_probes: 10,
         }
     }
 }
@@ -82,6 +84,7 @@ impl TestContextBuilder {
             catalog,
             metrics,
             self.rpc_write_error_window,
+            self.rpc_write_num_probes,
         )
         .await
     }
@@ -98,6 +101,7 @@ pub struct TestContext {
     namespace_autocreation: MissingNamespaceAction,
     single_tenancy: bool,
     rpc_write_error_window: Duration,
+    rpc_write_num_probes: u64,
 }
 
 // This mass of words is certainly a downside of chained handlers.
@@ -138,6 +142,7 @@ impl TestContext {
         catalog: Arc<dyn Catalog>,
         metrics: Arc<metric::Registry>,
         rpc_write_error_window: Duration,
+        rpc_write_num_probes: u64,
     ) -> Self {
         let client = Arc::new(MockWriteClient::default());
         let rpc_writer = RpcWrite::new(
@@ -145,6 +150,7 @@ impl TestContext {
             1.try_into().unwrap(),
             &metrics,
             rpc_write_error_window,
+            rpc_write_num_probes,
         );
 
         let ns_cache = Arc::new(ReadThroughCache::new(
@@ -202,6 +208,7 @@ impl TestContext {
             namespace_autocreation,
             single_tenancy,
             rpc_write_error_window,
+            rpc_write_num_probes,
         }
     }
 
@@ -216,6 +223,7 @@ impl TestContext {
             catalog,
             metrics,
             self.rpc_write_error_window,
+            self.rpc_write_num_probes,
         )
         .await
     }


### PR DESCRIPTION
Follow-up to https://github.com/influxdata/idpe/issues/17928.

---

* feat(router): Expose `num_probes` request count used to health-check ingesters as config option (e4a5d2efa)

      This allows routers to be configured to mark downstreams as healthy/
      unhealthy with a requirement for the number of probe requests
      which can/must be collected to transition the health checkers circuit
      state to healthy/unhealthy.
