### PR TITLE
feat(router): schema gossip skeleton

### DIFF
--- a/router/src/gossip/dispatcher.rs
+++ b/router/src/gossip/dispatcher.rs
@@ -1,0 +1,93 @@
+//! A deserialiser and dispatcher of [`gossip`] messages.
+
+use std::fmt::Debug;
+
+use async_trait::async_trait;
+use bytes::Bytes;
+use generated_types::influxdata::iox::gossip::v1::{gossip_message::Msg, GossipMessage};
+use generated_types::prost::Message;
+use observability_deps::tracing::{info, warn};
+use tokio::{sync::mpsc, task::JoinHandle};
+
+/// A handler of [`Msg`] received via gossip.
+#[async_trait]
+pub trait GossipMessageHandler: Send + Sync + Debug {
+    /// Process `message`.
+    async fn handle(&self, message: Msg);
+}
+
+/// An async gossip message dispatcher.
+///
+/// This type is responsible for deserialising incoming gossip payloads and
+/// passing them off to the provided [`GossipMessageHandler`] implementation.
+/// This decoupling allow the handler to deal strictly in terms of messages,
+/// abstracting it from the underlying message transport / format.
+///
+/// This type provides a buffer between incoming events, and processing,
+/// preventing processing time from blocking the gossip reactor. Once the buffer
+/// is full, incoming events are dropped until space is made through processing
+/// of outstanding events.
+#[derive(Debug)]
+pub struct GossipMessageDispatcher {
+    tx: mpsc::Sender<Bytes>,
+    task: JoinHandle<()>,
+}
+
+impl GossipMessageDispatcher {
+    /// Initialise a new dispatcher, buffering up to `buffer` number of events.
+    ///
+    /// The provided `handler` does not block the gossip reactor during
+    /// execution.
+    pub fn new<T>(handler: T, buffer: usize) -> Self
+    where
+        T: GossipMessageHandler + 'static,
+    {
+        // Initialise a buffered channel to decouple the two halves.
+        let (tx, rx) = mpsc::channel(buffer);
+
+        // And run a receiver loop to pull the events from the channel.
+        let task = tokio::spawn(dispatch_loop(rx, handler));
+
+        Self { tx, task }
+    }
+}
+
+#[async_trait]
+impl gossip::Dispatcher for GossipMessageDispatcher {
+    async fn dispatch(&self, payload: Bytes) {
+        if let Err(e) = self.tx.try_send(payload) {
+            warn!(error=%e, "failed to buffer gossip event");
+        }
+    }
+}
+
+impl Drop for GossipMessageDispatcher {
+    fn drop(&mut self) {
+        self.task.abort();
+    }
+}
+
+async fn dispatch_loop<T>(mut rx: mpsc::Receiver<Bytes>, handler: T)
+where
+    T: GossipMessageHandler,
+{
+    while let Some(payload) = rx.recv().await {
+        // Deserialise the payload into the appropriate proto type.
+        let msg = match GossipMessage::decode(payload).map(|v| v.msg) {
+            Ok(Some(v)) => v,
+            Ok(None) => {
+                warn!("valid frame contains no message");
+                continue;
+            }
+            Err(e) => {
+                warn!(error=%e, "failed to deserialise gossip message");
+                continue;
+            }
+        };
+
+        // Pass this message off to the handler to process.
+        handler.handle(msg).await;
+    }
+
+    info!("stopping gossip dispatcher");
+}

--- a/router/src/gossip/handle.rs
+++ b/router/src/gossip/handle.rs
@@ -1,0 +1,20 @@
+//! A handle to publish gossip messages to other peers.
+
+use crate::namespace_cache::ChangeStats;
+
+/// Application-level event notifiers.
+pub trait SchemaEventHandle {
+    /// Observe a new schema diff.
+    fn observe_diff(&self, c: &ChangeStats);
+}
+
+/// A handle to the [`gossip`] subsystem propagating schema change
+/// notifications.
+#[derive(Debug)]
+pub struct Handle(gossip::GossipHandle);
+
+impl SchemaEventHandle for Handle {
+    fn observe_diff(&self, _c: &ChangeStats) {
+        unreachable!()
+    }
+}

--- a/router/src/gossip/mod.rs
+++ b/router/src/gossip/mod.rs
@@ -1,0 +1,49 @@
+//! Gossip event dispatcher & handler implementations for routers.
+//!
+//! This sub-system is composed of the following primary components:
+//!
+//! * [`gossip`] crate: provides the gossip transport, the [`GossipHandle`], and
+//!   the [`Dispatcher`]. This crate operates on raw bytes.
+//!
+//! * The [`Handle`]: a router-specific wrapper over the underlying
+//!   [`GossipHandle`]. This type translates the application calls into protobuf
+//!   [`Msg`], and serialises them into bytes for the underlying [`gossip`]
+//!   impl.
+//!
+//! * The [`GossipMessageDispatcher`]: deserialises the incoming bytes from the
+//!   gossip [`Dispatcher`] into [`Msg`] and passes them off to the
+//!   [`GossipMessageHandler`] implementation for processing.
+//!
+//! ```text
+//!                   event                      handler
+//!                     │                           ▲
+//!                     │                           │
+//!                     │     Application types     │
+//!                     │                           │
+//!                     ▼                           │
+//!               ┌──────────┐         ┌─────────────────────────┐
+//!               │  Handle  │         │ GossipMessageDispatcher │
+//!               └──────────┘         └─────────────────────────┘
+//!                     │                           ▲
+//!                     │                           │
+//!                     │   Encoded Protobuf bytes  │
+//!                     │                           │
+//!                     │                           │
+//!        ┌ Gossip  ─ ─│─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─│─ ─ ─ ─ ─ ─ ─
+//!                     ▼                           │             │
+//!        │    ┌──────────────┐          ┌──────────────────┐
+//!             │ GossipHandle │          │    Dispatcher    │    │
+//!        │    └──────────────┘          └──────────────────┘
+//!                                                               │
+//!        └ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─
+//! ```
+//!
+//! [`GossipHandle`]: gossip::GossipHandle
+//! [`Dispatcher`]: gossip::Dispatcher
+//! [`Handle`]: handle::Handle
+//! [`Msg`]: generated_types::influxdata::iox::gossip::v1::gossip_message::Msg
+//! [`GossipMessageDispatcher`]: dispatcher::GossipMessageDispatcher
+//! [`GossipMessageHandler`]: dispatcher::GossipMessageHandler
+
+pub mod dispatcher;
+pub mod handle;

--- a/router/src/lib.rs
+++ b/router/src/lib.rs
@@ -137,6 +137,7 @@ use criterion as _;
 use workspace_hack as _;
 
 pub mod dml_handlers;
+pub mod gossip;
 pub mod namespace_cache;
 pub mod namespace_resolver;
 pub mod server;


### PR DESCRIPTION
This PR adds the types that'll form part of the schema gossip subsystem within the router.

---

* feat(router): schema gossip skeleton (41c9604e4)
      
      Adds the supporting types required to integrate the generic gossip crate
      into a schema-specific broadcast primitive.
      
      This commit implements the two "halves":
      
          * GossipMessageDispatcher: async processing of incoming gossip msgs
          * Handle: the send-side handle for async sending of gossip msgs
      
      These types are responsible for converting into/from the serialised
      bytes sent over the gossip primitive into application-level / protobuf
      types.