### PR TITLE
feat(router): intra-cluster schema diff gossiping 

### DIFF
--- a/router/src/gossip/mod.rs
+++ b/router/src/gossip/mod.rs
@@ -64,3 +64,131 @@ pub mod traits;
 
 #[cfg(test)]
 mod mock_schema_broadcast;
+
+#[cfg(test)]
+mod tests {
+    use std::{collections::BTreeMap, sync::Arc, time::Duration};
+
+    use async_trait::async_trait;
+    use data_types::{
+        partition_template::{
+            test_table_partition_override, NamespacePartitionTemplateOverride,
+            PARTITION_BY_DAY_PROTO,
+        },
+        Column, ColumnId, ColumnsByName, NamespaceId, NamespaceName, NamespaceSchema, TableId,
+        TableSchema,
+    };
+    use gossip::Dispatcher;
+    use test_helpers::timeout::FutureTimeout;
+    use tokio::sync::Mutex;
+
+    use crate::namespace_cache::{MemoryNamespaceCache, NamespaceCache};
+
+    use super::{
+        dispatcher::GossipMessageDispatcher, namespace_cache::NamespaceSchemaGossip,
+        schema_change_observer::SchemaChangeObserver, traits::SchemaBroadcast,
+    };
+
+    #[derive(Debug, Default)]
+    struct GossipPipe {
+        dispatcher: Mutex<Option<GossipMessageDispatcher>>,
+    }
+
+    impl GossipPipe {
+        async fn set_dispatcher(&self, dispatcher: GossipMessageDispatcher) {
+            *self.dispatcher.lock().await = Some(dispatcher);
+        }
+    }
+
+    #[async_trait]
+    impl SchemaBroadcast for Arc<GossipPipe> {
+        async fn broadcast(&self, payload: Vec<u8>) {
+            self.dispatcher
+                .lock()
+                .await
+                .as_mut()
+                .unwrap()
+                .dispatch(payload.into())
+                .with_timeout_panic(Duration::from_secs(5))
+                .await;
+        }
+    }
+
+    // Place a new namespace with a table and column into node A, and check it
+    // becomes readable on node B.
+    //
+    // This is an integration test of the various schema gossip components.
+    #[tokio::test]
+    async fn test_integration() {
+        // Two adaptors that will plug one "node" into the other.
+        let gossip_a = Arc::new(GossipPipe::default());
+        let gossip_b = Arc::new(GossipPipe::default());
+
+        // Setup a cache for node A and wrap it in the gossip layer.
+        let node_a_cache = Arc::new(MemoryNamespaceCache::default());
+        let dispatcher_a = Arc::new(NamespaceSchemaGossip::new(Arc::clone(&node_a_cache)));
+        let dispatcher_a = GossipMessageDispatcher::new(dispatcher_a, 100);
+        let node_a = SchemaChangeObserver::new(Arc::clone(&node_a_cache), Arc::clone(&gossip_b));
+
+        // Setup a cache for node B.
+
+        let node_b_cache = Arc::new(MemoryNamespaceCache::default());
+        let dispatcher_b = Arc::new(NamespaceSchemaGossip::new(Arc::clone(&node_b_cache)));
+        let dispatcher_b = GossipMessageDispatcher::new(dispatcher_b, 100);
+        let node_b = SchemaChangeObserver::new(Arc::clone(&node_b_cache), Arc::clone(&gossip_b));
+
+        // Connect them together
+        gossip_a.set_dispatcher(dispatcher_a).await;
+        gossip_b.set_dispatcher(dispatcher_b).await;
+
+        // Fill in a table with a column to insert into A
+        let mut tables = BTreeMap::new();
+        tables.insert(
+            "platanos".to_string(),
+            TableSchema {
+                id: TableId::new(4242),
+                partition_template: test_table_partition_override(vec![
+                    data_types::partition_template::TemplatePart::TagValue("bananatastic"),
+                ]),
+                columns: ColumnsByName::new([Column {
+                    id: ColumnId::new(1234),
+                    table_id: TableId::new(4242),
+                    name: "c1".to_string(),
+                    column_type: data_types::ColumnType::U64,
+                }]),
+            },
+        );
+
+        // Wrap the tables into a schema
+        let namespace_name = NamespaceName::try_from("bananas").unwrap();
+        let schema = NamespaceSchema {
+            id: NamespaceId::new(4242),
+            tables,
+            max_columns_per_table: 1,
+            max_tables: 2,
+            retention_period_ns: Some(1234),
+            partition_template: NamespacePartitionTemplateOverride::try_from(
+                (**PARTITION_BY_DAY_PROTO).clone(),
+            )
+            .unwrap(),
+        };
+
+        // Put the new schema into A's cache
+        node_a.put_schema(namespace_name.clone(), schema.clone());
+
+        // And read it back in B
+        let got = async {
+            loop {
+                if let Ok(v) = node_b.get_schema(&namespace_name).await {
+                    return v;
+                }
+                tokio::time::sleep(Duration::from_secs(1)).await;
+            }
+        }
+        .with_timeout_panic(Duration::from_secs(5))
+        .await;
+
+        // Ensuring the content is identical
+        assert_eq!(*got, schema);
+    }
+}

--- a/router/src/gossip/mod.rs
+++ b/router/src/gossip/mod.rs
@@ -5,17 +5,29 @@
 //! * [`gossip`] crate: provides the gossip transport, the [`GossipHandle`], and
 //!   the [`Dispatcher`]. This crate operates on raw bytes.
 //!
-//! * The [`SchemaChangeObserver`]: a router-specific wrapper over the underlying
-//!   [`GossipHandle`]. This type translates the application calls into protobuf
-//!   [`Msg`], and serialises them into bytes for the underlying [`gossip`]
-//!   impl.
+//! * The outgoing [`SchemaChangeObserver`]: a router-specific wrapper over the
+//!   underlying [`GossipHandle`]. This type translates the application calls
+//!   into protobuf [`Msg`], and serialises them into bytes, sending them over
+//!   the underlying [`gossip`] impl.
 //!
-//! * The [`GossipMessageDispatcher`]: deserialises the incoming bytes from the
-//!   gossip [`Dispatcher`] into [`Msg`] and passes them off to the
-//!   [`GossipMessageHandler`] implementation for processing.
+//! * The incoming [`GossipMessageDispatcher`]: deserialises the incoming bytes
+//!   from the gossip [`Dispatcher`] into [`Msg`] and passes them off to the
+//!   [`NamespaceSchemaGossip`] implementation for processing.
+//!
+//! * The incoming [`NamespaceSchemaGossip`]: processes [`Msg`] received from
+//!   peers, applying them to the local cache state if necessary.
 //!
 //! ```text
-//!                   event                      handler
+//!         ┌────────────────────────────────────────────────────┐
+//!         │                   NamespaceCache                   │
+//!         └────────────────────────────────────────────────────┘
+//!                     │                           ▲
+//!                     │                           │
+//!                   diff                        diff
+//!                     │                           │
+//!                     │              ┌─────────────────────────┐
+//!                     │              │  NamespaceSchemaGossip  │
+//!                     │              └─────────────────────────┘
 //!                     │                           ▲
 //!                     │                           │
 //!                     │     Application types     │
@@ -43,7 +55,7 @@
 //! [`SchemaChangeObserver`]: schema_change_observer::SchemaChangeObserver
 //! [`Msg`]: generated_types::influxdata::iox::gossip::v1::gossip_message::Msg
 //! [`GossipMessageDispatcher`]: dispatcher::GossipMessageDispatcher
-//! [`GossipMessageHandler`]: dispatcher::GossipMessageHandler
+//! [`NamespaceSchemaGossip`]: namespace_cache::NamespaceSchemaGossip
 
 pub mod dispatcher;
 pub mod namespace_cache;

--- a/router/src/server.rs
+++ b/router/src/server.rs
@@ -16,9 +16,6 @@ pub struct RpcWriteRouterServer<D, N> {
 
     http: HttpDelegate<D, N>,
     grpc: RpcWriteGrpcDelegate,
-
-    // TODO: this shouldn't be here but it is here while it's unused elsewhere
-    _gossip_handle: Option<gossip::GossipHandle>,
 }
 
 impl<D, N> RpcWriteRouterServer<D, N> {
@@ -29,14 +26,12 @@ impl<D, N> RpcWriteRouterServer<D, N> {
         grpc: RpcWriteGrpcDelegate,
         metrics: Arc<metric::Registry>,
         trace_collector: Option<Arc<dyn TraceCollector>>,
-        gossip_handle: Option<gossip::GossipHandle>,
     ) -> Self {
         Self {
             metrics,
             trace_collector,
             http,
             grpc,
-            _gossip_handle: gossip_handle,
         }
     }
 


### PR DESCRIPTION
Lets do it :rocket:

This PR adds more docs, more tests, and then the bits necessary to slot it into the router runtime.

After this PR is merged, clusters that are configured to use gossip will start gossiping schema changes to each other! Currently this is only an internal staging cluster, with a wider rollout soon.

---

* refactor: remove redundant NamespaceCache impl (3133318e1)
      
      The NamespaceCache does not need to be a decorator itself - it can
      operate using a reference to the cache without needing access to cache
      requests.

* docs(router): gossip subsystem types / topology (16c115d5c)
      
      Describes the router's schema gossiping types and how they fit together.

* test: schema gossip integration (00542f704)
      
      Adds an integration test ensuring the schema gossip layer added to one
      instance ("node A") propagates schema diffs to another ("node B").

* test: schema gossip w/ default partition keys (8928c838a)
      
      Ensure gossiping namespace & tables with empty partition keys is
      correct.

* perf(router): schema gossip between peers (757ecc1d0)
      
      This commit allows schema gossiping to be enabled on router nodes.
      
      Enabling gossiping allows any schema changes made on router A to be sent
      to the N-1 other routers, populating their internal caches in
      anticipation of handling a similar request.
      
      By populating their cache, they avoid incurring a catalog lookup to
      populate their local state upon a cache miss, therefore reducing request
      latency, and reducing catalog load.
      
      Enabling gossip on the routers automatically enables schema gossiping -
      enabling gossip remains optional, and off by default.