### PR TITLE
feat: Use the bloom filter to reduce ingester catalog queries, Luke

### DIFF
--- a/ingester/src/buffer_tree/partition.rs
+++ b/ingester/src/buffer_tree/partition.rs
@@ -991,6 +991,8 @@ mod tests {
         let catalog: Arc<dyn Catalog> =
             Arc::new(iox_catalog::mem::MemCatalog::new(Arc::clone(&metrics)));
 
+        let partition_key = PartitionKey::from("test");
+
         // Populate the catalog with the namespace / table
         let (_ns_id, table_id) = populate_catalog(&*catalog, "bananas", "platanos").await;
 
@@ -998,7 +1000,7 @@ mod tests {
             .repositories()
             .await
             .partitions()
-            .create_or_get("test".into(), table_id)
+            .create_or_get(partition_key.clone(), table_id)
             .await
             .expect("should create");
 
@@ -1014,7 +1016,8 @@ mod tests {
         let fetcher = Arc::new(DeferredLoad::new(
             Duration::from_nanos(1),
             SortKeyResolver::new(
-                partition.transition_partition_id(),
+                partition_key.clone(),
+                table_id,
                 Arc::clone(&catalog),
                 backoff_config.clone(),
             )

--- a/ingester/src/buffer_tree/partition/resolver/cache.rs
+++ b/ingester/src/buffer_tree/partition/resolver/cache.rs
@@ -179,7 +179,8 @@ where
             let sort_key_resolver = DeferredLoad::new(
                 self.max_smear,
                 SortKeyResolver::new(
-                    partition_id.clone(),
+                    partition_key.clone(),
+                    table_id,
                     Arc::clone(&__self.catalog),
                     self.backoff_config.clone(),
                 )

--- a/ingester/src/buffer_tree/partition/resolver/mod.rs
+++ b/ingester/src/buffer_tree/partition/resolver/mod.rs
@@ -17,7 +17,8 @@ pub(crate) use sort_key::*;
 mod coalesce;
 pub(crate) use coalesce::*;
 
-pub mod old_filter;
+mod old_filter;
+pub(crate) use old_filter::*;
 
 #[cfg(test)]
 pub(crate) mod mock;

--- a/ingester/src/buffer_tree/partition/resolver/old_filter.rs
+++ b/ingester/src/buffer_tree/partition/resolver/old_filter.rs
@@ -172,7 +172,8 @@ where
             let sort_key_resolver = DeferredLoad::new(
                 self.max_smear,
                 SortKeyResolver::new(
-                    partition_id.clone(),
+                    partition_key.clone(),
+                    table_id,
                     Arc::clone(&self.catalog),
                     self.backoff_config.clone(),
                 )

--- a/ingester/src/init.rs
+++ b/ingester/src/init.rs
@@ -31,7 +31,8 @@ use crate::{
     buffer_tree::{
         namespace::name_resolver::{NamespaceNameProvider, NamespaceNameResolver},
         partition::resolver::{
-            CatalogPartitionResolver, CoalescePartitionResolver, PartitionCache, PartitionProvider,
+            CatalogPartitionResolver, CoalescePartitionResolver, OldPartitionBloomFilter,
+            PartitionCache, PartitionProvider,
         },
         table::metadata_resolver::{TableProvider, TableResolver},
         BufferTree,
@@ -172,6 +173,10 @@ pub enum InitError {
     #[error("failed to pre-warm partition cache: {0}")]
     PreWarmPartitions(iox_catalog::interface::Error),
 
+    /// A catalog error occurred while fetching the old-style partitions for the bloom filter.
+    #[error("failed to fetch old-style partitions: {0}")]
+    FetchOldStylePartitions(iox_catalog::interface::Error),
+
     /// An error initialising the WAL.
     #[error("failed to initialise write-ahead log: {0}")]
     WalInit(#[from] wal::Error),
@@ -308,8 +313,18 @@ where
         .await
         .map_err(InitError::PreWarmPartitions)?;
 
-    // Build the partition provider, wrapped in the partition cache and request
-    // coalescer.
+    // Fetch all the currently-existing old-style partitions to be put into a bloom filter that
+    // determines if we need to resolve a partition (potentially making a catalog query) or not.
+    let old_style = catalog
+        .repositories()
+        .await
+        .partitions()
+        .list_old_style()
+        .await
+        .map_err(InitError::FetchOldStylePartitions)?;
+
+    // Build the partition provider, wrapped in the old partition bloom filter, partition cache,
+    // and request coalescer.
     let partition_provider = CatalogPartitionResolver::new(Arc::clone(&catalog));
     let partition_provider = CoalescePartitionResolver::new(Arc::new(partition_provider));
     let partition_provider = PartitionCache::new(
@@ -319,6 +334,14 @@ where
         Arc::clone(&catalog),
         BackoffConfig::default(),
         Arc::clone(&metrics),
+    );
+    let partition_provider = OldPartitionBloomFilter::new(
+        partition_provider,
+        Arc::clone(&catalog),
+        BackoffConfig::default(),
+        persist_background_fetch_time,
+        Arc::clone(&metrics),
+        old_style,
     );
     let partition_provider: Arc<dyn PartitionProvider> = Arc::new(partition_provider);
 

--- a/ingester/src/init.rs
+++ b/ingester/src/init.rs
@@ -327,14 +327,6 @@ where
     // and request coalescer.
     let partition_provider = CatalogPartitionResolver::new(Arc::clone(&catalog));
     let partition_provider = CoalescePartitionResolver::new(Arc::new(partition_provider));
-    let partition_provider = PartitionCache::new(
-        partition_provider,
-        recent_partitions,
-        persist_background_fetch_time,
-        Arc::clone(&catalog),
-        BackoffConfig::default(),
-        Arc::clone(&metrics),
-    );
     let partition_provider = OldPartitionBloomFilter::new(
         partition_provider,
         Arc::clone(&catalog),
@@ -342,6 +334,14 @@ where
         persist_background_fetch_time,
         Arc::clone(&metrics),
         old_style,
+    );
+    let partition_provider = PartitionCache::new(
+        partition_provider,
+        recent_partitions,
+        persist_background_fetch_time,
+        Arc::clone(&catalog),
+        BackoffConfig::default(),
+        Arc::clone(&metrics),
     );
     let partition_provider: Arc<dyn PartitionProvider> = Arc::new(partition_provider);
 

--- a/iox_catalog/src/mem.rs
+++ b/iox_catalog/src/mem.rs
@@ -789,6 +789,19 @@ impl PartitionRepo for MemTxn {
 
         Ok(partitions)
     }
+
+    async fn list_old_style(&mut self) -> Result<Vec<Partition>> {
+        let stage = self.stage();
+
+        let old_style: Vec<_> = stage
+            .partitions
+            .iter()
+            .filter(|p| p.hash_id().is_none())
+            .cloned()
+            .collect();
+
+        Ok(old_style)
+    }
 }
 
 #[async_trait]

--- a/iox_catalog/src/metrics.rs
+++ b/iox_catalog/src/metrics.rs
@@ -183,6 +183,7 @@ decorate!(
         "partition_most_recent_n" = most_recent_n(&mut self, n: usize) -> Result<Vec<Partition>>;
         "partition_partitions_new_file_between" = partitions_new_file_between(&mut self, minimum_time: Timestamp, maximum_time: Option<Timestamp>) -> Result<Vec<PartitionId>>;
         "partition_get_in_skipped_compactions" = get_in_skipped_compactions(&mut self, partition_ids: &[PartitionId]) -> Result<Vec<SkippedCompaction>>;
+        "partition_list_old_style" = list_old_style(&mut self) -> Result<Vec<Partition>>;
     ]
 );
 

--- a/iox_catalog/src/postgres.rs
+++ b/iox_catalog/src/postgres.rs
@@ -1499,6 +1499,20 @@ LIMIT $1;"#,
             .await
             .map_err(|e| Error::SqlxError { source: e })
     }
+
+    async fn list_old_style(&mut self) -> Result<Vec<Partition>> {
+        sqlx::query_as(
+            r#"
+SELECT id, hash_id, table_id, partition_key, sort_key, sort_key_ids, persisted_sequence_number,
+       new_file_at
+FROM partition
+WHERE hash_id IS NULL
+ORDER BY id DESC;"#,
+        )
+        .fetch_all(&mut self.inner)
+        .await
+        .map_err(|e| Error::SqlxError { source: e })
+    }
 }
 
 #[async_trait]
@@ -2237,6 +2251,18 @@ RETURNING id, hash_id, table_id, partition_key, sort_key, new_file_at;
             parquet_file.partition_id,
             TransitionPartitionId::Deprecated(_)
         );
+
+        // Add a partition record WITH a hash ID
+        repos
+            .partitions()
+            .create_or_get(PartitionKey::from("Something else"), table_id)
+            .await
+            .unwrap();
+
+        // Ensure we can list only the old-style partitions
+        let old_style_partitions = repos.partitions().list_old_style().await.unwrap();
+        assert_eq!(old_style_partitions.len(), 1);
+        assert_eq!(old_style_partitions[0].id, partition.id);
     }
 
     #[test]

--- a/iox_catalog/src/postgres.rs
+++ b/iox_catalog/src/postgres.rs
@@ -1501,6 +1501,13 @@ LIMIT $1;"#,
     }
 
     async fn list_old_style(&mut self) -> Result<Vec<Partition>> {
+        // Correctness: the main caller of this function, the partition bloom
+        // filter, relies on all partitions being made available to it.
+        //
+        // This function MUST return the full set of old partitions to the
+        // caller - do NOT apply a LIMIT to this query.
+        //
+        // The load this query saves vastly outsizes the load this query causes.
         sqlx::query_as(
             r#"
 SELECT id, hash_id, table_id, partition_key, sort_key, sort_key_ids, persisted_sequence_number,

--- a/test_helpers_end_to_end/src/mini_cluster.rs
+++ b/test_helpers_end_to_end/src/mini_cluster.rs
@@ -563,16 +563,20 @@ impl MiniCluster {
         Ok(IngesterResponse { partitions })
     }
 
-    /// Ask all of the ingesters to persist their data.
+    /// Ask all of the ingesters to persist their data for the cluster namespace.
     pub async fn persist_ingesters(&self) {
+        self.persist_ingesters_by_namespace(None).await;
+    }
+
+    /// Ask all of the ingesters to persist their data for a specified namespace, or the cluster
+    /// namespace if none specified.
+    pub async fn persist_ingesters_by_namespace(&self, namespace: Option<String>) {
+        let namespace = namespace.unwrap_or_else(|| self.namespace().into());
         for ingester in &self.ingesters {
             let mut ingester_client =
                 influxdb_iox_client::ingester::Client::new(ingester.ingester_grpc_connection());
 
-            ingester_client
-                .persist(self.namespace().into())
-                .await
-                .unwrap();
+            ingester_client.persist(namespace.clone()).await.unwrap();
         }
     }
 

--- a/test_helpers_end_to_end/src/steps.rs
+++ b/test_helpers_end_to_end/src/steps.rs
@@ -606,6 +606,12 @@ where
                     namespace_name,
                     expected,
                 } => {
+                    info!("====Persist ingesters to ensure catalog partition records exist");
+                    state
+                        .cluster()
+                        .persist_ingesters_by_namespace(namespace_name.clone())
+                        .await;
+
                     info!("====Begin reading partition keys for table: {}", table_name);
                     let partition_keys = state
                         .cluster()


### PR DESCRIPTION
~~THIS DEPENDS ON https://github.com/influxdata/influxdb_iox/pull/8475 MERGE THAT FIRST~~ Merged!

Closes #8066 

This PR:

- Wires up the `OldPartitionBloomFilter` so that when the ingester resolves the partition, it doesn't go to the ingester's partition cache or the catalog if it's definitely a new-style partition
- When the ingester fetches the sort key from the catalog for persistence, upsert the partition at that point rather than expecting it to exist
- Have end-to-end tests asking the catalog for partitions explicitly ask the ingester to persist before making the catalog request

I *think* all this is correct. Please review commit-by-commit!