### PR TITLE
fix: Cleanups for docs and long lines

### DIFF
--- a/iox_catalog/src/migrate.rs
+++ b/iox_catalog/src/migrate.rs
@@ -410,7 +410,7 @@ impl IOxMigrator {
         if let Some(m) = migrations.windows(2).find(|m| m[0].version > m[1].version) {
             return Err(MigrateError::Source(
                 format!(
-                    "migrations are not sorted: version {} is before {} but should not",
+                    "migrations are not sorted: version {} is before {} but should not be",
                     m[0].version, m[1].version,
                 )
                 .into(),
@@ -1036,7 +1036,7 @@ mod tests {
 
             assert_eq!(
                 err.to_string(),
-                "while resolving migrations: migrations are not sorted: version 2 is before 1 but should not",
+                "while resolving migrations: migrations are not sorted: version 2 is before 1 but should not be",
             );
         }
 

--- a/iox_catalog/src/migrate.rs
+++ b/iox_catalog/src/migrate.rs
@@ -620,9 +620,13 @@ fn validate_applied_migrations(
 
         if dirty_version > new_first {
             // database state error, so use a proper error
-            return Err(MigrateError::Source(format!(
-                "new migration ({new_first}) goes before dirty version ({dirty_version}), this should not have been merged!",
-            ).into()));
+            return Err(MigrateError::Source(
+                format!(
+                    "new migration ({new_first}) goes before dirty version ({dirty_version}), \
+                this should not have been merged!",
+                )
+                .into(),
+            ));
         }
     }
     if let (Some(applied_last), Some(new_first)) = (applied_last, new_first) {
@@ -631,9 +635,13 @@ fn validate_applied_migrations(
 
         if applied_last > new_first {
             // database state error, so use a proper error
-            return Err(MigrateError::Source(format!(
-                "new migration ({new_first}) goes before last applied migration ({applied_last}), this should not have been merged!",
-            ).into()));
+            return Err(MigrateError::Source(
+                format!(
+                "new migration ({new_first}) goes before last applied migration ({applied_last}), \
+                this should not have been merged!",
+            )
+                .into(),
+            ));
         }
     }
 
@@ -1004,7 +1012,9 @@ mod tests {
 
         #[test]
         fn test_parse_valid_checksum() {
-            let actual = Checksum::from_str("b88c635e27f8b9ba8547b24efcb081429a8f3e85b70f35916e1900dffc4e6a77eed8a02acc7c72526dd7d50166b63fbd").unwrap();
+            let actual = Checksum::from_str(
+                "b88c635e27f8b9ba8547b24efcb081429a8f3e85b70f35916e1900dffc4e6a77eed8a02acc7c72526dd7d50166b63fbd"
+            ).unwrap();
             let expected = Checksum::from([
                 184, 140, 99, 94, 39, 248, 185, 186, 133, 71, 178, 78, 252, 176, 129, 66, 154, 143,
                 62, 133, 183, 15, 53, 145, 110, 25, 0, 223, 252, 78, 106, 119, 238, 216, 160, 42,
@@ -1432,7 +1442,8 @@ mod tests {
                         // `CREATE INDEX CONCURRENTLY` is NOT possible w/ a transaction. Verify that.
                         assert_eq!(
                             res.unwrap_err().to_string(),
-                            "while executing migrations: error returned from database: CREATE INDEX CONCURRENTLY cannot run inside a transaction block",
+                            "while executing migrations: error returned from database: \
+                            CREATE INDEX CONCURRENTLY cannot run inside a transaction block",
                         );
                     }
                 }
@@ -2026,7 +2037,10 @@ mod tests {
 
             // fails because is not unique
             let err = migrator.run_direct(conn).await.unwrap_err();
-            assert_eq!(err.to_string(), "while executing migrations: error returned from database: could not create unique index \"i\"");
+            assert_eq!(
+                err.to_string(),
+                "while executing migrations: error returned from database: could not create unique index \"i\""
+            );
 
             // re-applying fails due to sanity checks
             // NOTE: Even though the actual migration script passes, the sanity checks DO NOT and hence the migration is
@@ -2083,11 +2097,17 @@ mod tests {
 
             // fails because is not unique
             let err = migrator.run_direct(conn).await.unwrap_err();
-            assert_eq!(err.to_string(), "while executing migrations: error returned from database: could not create unique index \"i\"");
+            assert_eq!(
+                err.to_string(),
+                "while executing migrations: error returned from database: could not create unique index \"i\""
+            );
 
             // re-applying fails with same error (index is wiped but fails w/ same error)
             let err = migrator.run_direct(conn).await.unwrap_err();
-            assert_eq!(err.to_string(), "while executing migrations: error returned from database: could not create unique index \"i\"");
+            assert_eq!(
+                err.to_string(),
+                "while executing migrations: error returned from database: could not create unique index \"i\""
+            );
 
             // fix data issue
             conn.execute("UPDATE t SET x = 2 WHERE y = 2")
@@ -2131,7 +2151,8 @@ mod tests {
 
             assert_eq!(
                 err.to_string(),
-                "while resolving migrations: new migration (1) goes before last applied migration (2), this should not have been merged!",
+                "while resolving migrations: new migration (1) goes before last applied migration (2), \
+                this should not have been merged!",
             );
         }
 
@@ -2170,7 +2191,8 @@ mod tests {
 
             assert_eq!(
                 err.to_string(),
-                "while resolving migrations: new migration (1) goes before dirty version (2), this should not have been merged!",
+                "while resolving migrations: new migration (1) goes before dirty version (2), \
+                this should not have been merged!",
             );
         }
 
@@ -2208,7 +2230,8 @@ mod tests {
 
             assert_eq!(
                 err.to_string(),
-                "while resolving migrations: there are multiple dirty versions, this should not happen and is considered a bug: [1, 2]",
+                "while resolving migrations: there are multiple dirty versions, \
+                this should not happen and is considered a bug: [1, 2]",
             );
         }
 

--- a/iox_catalog/src/migrate.rs
+++ b/iox_catalog/src/migrate.rs
@@ -419,7 +419,7 @@ impl IOxMigrator {
         if let Some(m) = migrations.windows(2).find(|m| m[0].version == m[1].version) {
             return Err(MigrateError::Source(
                 format!(
-                    "migrations are not not unique: version {} found twice",
+                    "migrations are not unique: version {} found twice",
                     m[0].version,
                 )
                 .into(),
@@ -1062,7 +1062,7 @@ mod tests {
 
             assert_eq!(
                 err.to_string(),
-                "while resolving migrations: migrations are not not unique: version 2 found twice",
+                "while resolving migrations: migrations are not unique: version 2 found twice",
             );
         }
 

--- a/iox_catalog/src/migrate.rs
+++ b/iox_catalog/src/migrate.rs
@@ -401,7 +401,7 @@ impl IOxMigrator {
     /// Create new migrator.
     ///
     /// # Error
-    /// Fails if migrations are not sorted or if there are duplication [versions](IOxMigration::version).
+    /// Fails if migrations are not sorted or if there are duplicate [versions](IOxMigration::version).
     pub fn try_new(
         migrations: impl IntoIterator<Item = IOxMigration>,
     ) -> Result<Self, MigrateError> {

--- a/iox_catalog/src/migrate.rs
+++ b/iox_catalog/src/migrate.rs
@@ -164,7 +164,7 @@ impl IOxMigrationStep {
         Ok(())
     }
 
-    /// Will this step set up a transaction if there is non yet?
+    /// Will this step set up a transaction if there is none yet?
     fn in_transaction(&self) -> bool {
         match self {
             Self::SqlStatement { in_transaction, .. } => *in_transaction,


### PR DESCRIPTION
I was reading through the docs and code for the migrations to see if there was anything I needed to do differently. I found some typos and unclear parts of the docs, and some long lines in the code that I find easier to read when they're broken up (and rustfmt didn't handle them).

Please check that I didn't misunderstand and change the meaning of any of the docs!