### PR TITLE
feat: reusable schema notifications via gossip_schema crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2079,6 +2079,7 @@ dependencies = [
  "test_helpers",
  "thiserror",
  "tokio",
+ "workspace-hack",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2073,11 +2073,8 @@ dependencies = [
  "gossip",
  "metric",
  "observability_deps",
- "parking_lot",
- "paste",
  "proptest",
  "test_helpers",
- "thiserror",
  "tokio",
  "workspace-hack",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2062,6 +2062,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "gossip_schema"
+version = "0.1.0"
+dependencies = [
+ "assert_matches",
+ "async-trait",
+ "bytes",
+ "data_types",
+ "generated_types",
+ "gossip",
+ "metric",
+ "observability_deps",
+ "parking_lot",
+ "paste",
+ "proptest",
+ "test_helpers",
+ "thiserror",
+ "tokio",
+]
+
+[[package]]
 name = "grpc-binary-logger"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ members = [
     "garbage_collector",
     "generated_types",
     "gossip",
+    "gossip_schema",
     "grpc-binary-logger-proto",
     "grpc-binary-logger-test-proto",
     "grpc-binary-logger",

--- a/data_types/src/columns.rs
+++ b/data_types/src/columns.rs
@@ -124,6 +124,12 @@ impl IntoIterator for ColumnsByName {
     }
 }
 
+impl FromIterator<(String, ColumnSchema)> for ColumnsByName {
+    fn from_iter<T: IntoIterator<Item = (String, ColumnSchema)>>(iter: T) -> Self {
+        Self(BTreeMap::from_iter(iter))
+    }
+}
+
 // ColumnsByName is a newtype so that we can implement this `TryFrom` in this crate
 impl TryFrom<ColumnsByName> for Schema {
     type Error = schema::builder::Error;

--- a/gossip_schema/Cargo.toml
+++ b/gossip_schema/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "gossip_schema"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+async-trait = "0.1"
+bytes = "1.4"
+data_types = { path = "../data_types" }
+generated_types = { path = "../generated_types" }
+gossip = { version = "0.1.0", path = "../gossip" }
+observability_deps = { path = "../observability_deps" }
+thiserror = "1.0"
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "time"] }
+
+[dev-dependencies]
+assert_matches = "1.5"
+metric = { path = "../metric" }
+parking_lot = "0.12"
+paste = "1.0.14"
+proptest = { version = "1.2.0", default-features = false }
+test_helpers = { version = "0.1.0", path = "../test_helpers", features = [
+    "future_timeout",
+] }
+tokio = { version = "1", features = ["test-util"] }

--- a/gossip_schema/Cargo.toml
+++ b/gossip_schema/Cargo.toml
@@ -10,19 +10,16 @@ license.workspace = true
 [dependencies]
 async-trait = "0.1"
 bytes = "1.4"
-data_types = { path = "../data_types" }
 generated_types = { path = "../generated_types" }
 gossip = { version = "0.1.0", path = "../gossip" }
 observability_deps = { path = "../observability_deps" }
-thiserror = "1.0"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "time"] }
 workspace-hack = { version = "0.1", path = "../workspace-hack" }
 
 [dev-dependencies]
 assert_matches = "1.5"
+data_types = { path = "../data_types" }
 metric = { path = "../metric" }
-parking_lot = "0.12"
-paste = "1.0.14"
 proptest = { version = "1.2.0", default-features = false }
 test_helpers = { version = "0.1.0", path = "../test_helpers", features = [
     "future_timeout",

--- a/gossip_schema/Cargo.toml
+++ b/gossip_schema/Cargo.toml
@@ -16,6 +16,7 @@ gossip = { version = "0.1.0", path = "../gossip" }
 observability_deps = { path = "../observability_deps" }
 thiserror = "1.0"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "time"] }
+workspace-hack = { version = "0.1", path = "../workspace-hack" }
 
 [dev-dependencies]
 assert_matches = "1.5"

--- a/gossip_schema/src/dispatcher.rs
+++ b/gossip_schema/src/dispatcher.rs
@@ -1,0 +1,112 @@
+//! A deserialiser and dispatcher of [`gossip`] messages.
+
+use std::{fmt::Debug, sync::Arc};
+
+use async_trait::async_trait;
+use bytes::Bytes;
+use generated_types::influxdata::iox::gossip::{
+    v1::{schema_message::Event, SchemaMessage},
+    Topic,
+};
+use generated_types::prost::Message;
+use observability_deps::tracing::{info, warn};
+use tokio::{sync::mpsc, task::JoinHandle};
+
+/// A handler of [`Event`] received via gossip.
+#[async_trait]
+pub trait SchemaEventHandler: Send + Sync + Debug {
+    /// Process `message`.
+    async fn handle(&self, event: Event);
+}
+
+#[async_trait]
+impl<T> SchemaEventHandler for Arc<T>
+where
+    T: SchemaEventHandler,
+{
+    async fn handle(&self, event: Event) {
+        T::handle(self, event).await
+    }
+}
+
+/// An async gossip message dispatcher.
+///
+/// This type is responsible for deserialising incoming gossip
+/// [`Topic::SchemaChanges`] payloads and passing them off to the provided
+/// [`SchemaEventHandler`] implementation.
+///
+/// This decoupling allow the handler to deal strictly in terms of messages,
+/// abstracting it from the underlying message transport / format.
+///
+/// This type also provides a buffer between incoming events, and processing,
+/// preventing processing time from blocking the gossip reactor. Once the buffer
+/// is full, incoming events are dropped until space is made through processing
+/// of outstanding events. Dropping the [`SchemaRx`] stops the background event
+/// loop.
+#[derive(Debug)]
+pub struct SchemaRx {
+    tx: mpsc::Sender<Bytes>,
+    task: JoinHandle<()>,
+}
+
+impl SchemaRx {
+    /// Initialise a new dispatcher, buffering up to `buffer` number of events.
+    ///
+    /// The provided `handler` does not block the gossip reactor during
+    /// execution.
+    pub fn new<T>(handler: T, buffer: usize) -> Self
+    where
+        T: SchemaEventHandler + 'static,
+    {
+        // Initialise a buffered channel to decouple the two halves.
+        let (tx, rx) = mpsc::channel(buffer);
+
+        // And run a receiver loop to pull the events from the channel.
+        let task = tokio::spawn(dispatch_loop(rx, handler));
+
+        Self { tx, task }
+    }
+}
+
+#[async_trait]
+impl gossip::Dispatcher<Topic> for SchemaRx {
+    async fn dispatch(&self, topic: Topic, payload: Bytes) {
+        if topic != Topic::SchemaChanges {
+            return;
+        }
+        if let Err(e) = self.tx.try_send(payload) {
+            warn!(error=%e, "failed to buffer gossip event");
+        }
+    }
+}
+
+impl Drop for SchemaRx {
+    fn drop(&mut self) {
+        self.task.abort();
+    }
+}
+
+async fn dispatch_loop<T>(mut rx: mpsc::Receiver<Bytes>, handler: T)
+where
+    T: SchemaEventHandler,
+{
+    while let Some(payload) = rx.recv().await {
+        // Deserialise the payload into the appropriate proto type.
+        let event = match SchemaMessage::decode(payload).map(|v| v.event) {
+            Ok(Some(v)) => v,
+            Ok(None) => {
+                warn!("valid frame contains no message");
+                continue;
+            }
+            Err(e) => {
+                warn!(error=%e, "failed to deserialise gossip message");
+                continue;
+            }
+        };
+
+        // Pass this message off to the handler to process.
+        handler.handle(event).await;
+    }
+
+    info!("stopping gossip dispatcher");
+}

--- a/gossip_schema/src/dispatcher.rs
+++ b/gossip_schema/src/dispatcher.rs
@@ -1,4 +1,5 @@
-//! A deserialiser and dispatcher of [`gossip`] messages.
+//! A deserialiser and dispatcher of [`gossip`] messages for the
+//! [`Topic::SchemaChanges`] topic.
 
 use std::{fmt::Debug, sync::Arc};
 

--- a/gossip_schema/src/handle.rs
+++ b/gossip_schema/src/handle.rs
@@ -1,0 +1,416 @@
+use generated_types::{
+    influxdata::iox::gossip::{
+        v1::{schema_message::Event, SchemaMessage, TableCreated, TableUpdated},
+        Topic,
+    },
+    prost::Message,
+};
+use gossip::MAX_USER_PAYLOAD_BYTES;
+use observability_deps::tracing::{debug, error, warn};
+use tokio::{
+    sync::mpsc::{self, error::TrySendError},
+    task::JoinHandle,
+};
+
+/// A gossip broadcast primitive specialised for schema [`Event`] notifications.
+///
+/// This type accepts [`Event`] from the application logic, serialises the
+/// message (applying any necessary transformations due to the underlying
+/// transport limitations) and broadcasts the result to all listening peers.
+///
+/// Serialisation and processing of the [`Event`] given to the
+/// [`SchemaTx::Broadcast()`] method happen in a background actor task,
+/// decoupling the caller from the latency of processing each frame. Dropping
+/// the [`SchemaTx`] stops this background actor task.
+#[derive(Debug)]
+pub struct SchemaTx {
+    tx: mpsc::Sender<Event>,
+    task: JoinHandle<()>,
+}
+
+impl Drop for SchemaTx {
+    fn drop(&mut self) {
+        self.task.abort();
+    }
+}
+
+impl SchemaTx {
+    /// Construct a new [`SchemaChangeObserver`] that publishes gossip messages
+    /// over `gossip`, and delegates cache operations to `inner`.
+    pub fn new(gossip: gossip::GossipHandle<Topic>) -> Self {
+        let (tx, rx) = mpsc::channel(100);
+
+        let task = tokio::spawn(actor_loop(rx, gossip));
+
+        Self { tx, task }
+    }
+
+    /// Asynchronously broadcast `event` to all interested peers.
+    ///
+    /// This method enqueues `event` into the serialisation queue, and
+    /// processed & transmitted asynchronously.
+    pub fn broadcast(&self, event: Event) {
+        debug!(?event, "sending schema message");
+        match self.tx.try_send(event) {
+            Ok(_) => {}
+            Err(TrySendError::Closed(_)) => panic!("schema serialisation actor not running"),
+            Err(TrySendError::Full(_)) => {
+                warn!("schema serialisation queue full, dropping message")
+            }
+        }
+    }
+}
+
+/// A background task loop that pulls [`Event`] from `rx`, serialises / packs
+/// them into a single gossip frame, and broadcasts the result over `gossip`.
+async fn actor_loop(mut rx: mpsc::Receiver<Event>, gossip: gossip::GossipHandle<Topic>) {
+    while let Some(event) = rx.recv().await {
+        let frames = match event {
+            v @ Event::NamespaceCreated(_) => vec![v],
+            Event::TableCreated(v) => serialise_table_create_frames(v),
+            Event::TableUpdated(v) => {
+                // Split the frame up into N frames, sized as big as the gossip
+                // transport will allow.
+                let mut frames = Vec::with_capacity(1);
+                if !serialise_table_update_frames(v, MAX_USER_PAYLOAD_BYTES, &mut frames) {
+                    warn!("dropping oversized columns in table update");
+                    // Continue sending the columns that were packed
+                    // successfully
+                }
+
+                // It's possible all columns were oversized and therefore
+                // dropped during the split.
+                if frames.is_empty() {
+                    warn!("dropping empty table update message");
+                    continue;
+                }
+
+                frames.into_iter().map(Event::TableUpdated).collect()
+            }
+        };
+
+        for frame in frames {
+            let msg = SchemaMessage { event: Some(frame) };
+
+            // Send the frame
+            if let Err(e) = gossip
+                .broadcast(msg.encode_to_vec(), Topic::SchemaChanges)
+                .await
+            {
+                error!(error=%e, "failed to broadcast payload");
+            }
+        }
+    }
+
+    debug!("stopping schema serialisation actor");
+}
+
+/// Serialise `msg` into one or more frames and append them to `out`.
+///
+/// If when `msg` is serialised it is less than or equal to `max_frame_bytes` in
+/// length, this method appends a single frame. If `msg` is too large, it is
+/// split into `N` multiple smaller frames and each appended individually.
+///
+/// If any [`Column`] within the message is too large to fit into an update
+/// containing only itself, then this method returns `false` indicating
+/// oversized columns were dropped from the output.
+fn serialise_table_update_frames(
+    mut msg: TableUpdated,
+    max_frame_bytes: usize,
+    out: &mut Vec<TableUpdated>,
+) -> bool {
+    // Does this frame fit within the maximum allowed frame size?
+    if msg.encoded_len() <= max_frame_bytes {
+        // Never send empty update messages.
+        if !msg.columns.is_empty() {
+            out.push(msg);
+        }
+        return true;
+    }
+
+    // This message is too large to be sent as a single message.
+    debug!(
+        n_bytes = msg.encoded_len(),
+        "splitting oversized table update message"
+    );
+
+    // Find the midpoint in the column list.
+    //
+    // If the column list is down to one candidate, then the TableUpdate
+    // containing only this column is too large to be sent, so this column must
+    // be dropped from the output.
+    if msg.columns.len() <= 1 {
+        // Return false to indicate some columns were dropped.
+        return false;
+    }
+    let mid = msg.columns.len() / 2;
+
+    // Split up the columns in the message into two.
+    let right = msg.columns.drain(mid..).collect();
+
+    // msg now contains the left-most half of the columns.
+    //
+    // Construct the frame for the right-most half of the columns.
+    let other = TableUpdated {
+        columns: right,
+        table_name: msg.table_name.clone(),
+        namespace_name: msg.namespace_name.clone(),
+        table_id: msg.table_id,
+    };
+
+    // Recursively split the frames until they fit, at which point they'll
+    // be sent within this call.
+    serialise_table_update_frames(msg, max_frame_bytes, out)
+        && serialise_table_update_frames(other, max_frame_bytes, out)
+}
+
+/// Split `msg` into a [`TableCreated`] and a series of [`TableUpdated`] frames,
+/// each sized less than [`MAX_USER_PAYLOAD_BYTES`].
+fn serialise_table_create_frames(mut msg: TableCreated) -> Vec<Event> {
+    // If it fits, do nothing.
+    if msg.encoded_len() <= MAX_USER_PAYLOAD_BYTES {
+        return vec![Event::TableCreated(msg)];
+    }
+
+    // If not, split the message into a single create, followed by N table
+    // updates.
+    let columns = std::mem::take(&mut msg.table.as_mut().unwrap().columns);
+
+    // Check that on its own, without columns, it'll be send-able.
+    if msg.encoded_len() > MAX_USER_PAYLOAD_BYTES {
+        error!("dropping oversized table create message");
+        return vec![];
+    }
+
+    // Recreate the new TableUpdate containing all the columns
+    let mut update = msg.table.as_ref().unwrap().clone();
+    update.columns = columns;
+
+    let mut updates = Vec::with_capacity(1);
+    if !serialise_table_update_frames(update, MAX_USER_PAYLOAD_BYTES, &mut updates) {
+        warn!("dropping oversized columns in table update");
+        // Continue sending the columns that were packed
+        // successfully
+    }
+
+    // Return the table creation, followed by the updates containing columns.
+    std::iter::once(Event::TableCreated(msg))
+        .chain(updates.into_iter().map(Event::TableUpdated))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use assert_matches::assert_matches;
+    use generated_types::influxdata::iox::{
+        gossip::v1::Column,
+        partition_template::v1::{template_part::Part, PartitionTemplate, TemplatePart},
+    };
+    use proptest::prelude::*;
+
+    const TABLE_NAME: &str = "bananas";
+    const NAMESPACE_NAME: &str = "platanos";
+    const TABLE_ID: i64 = 42;
+
+    proptest! {
+        /// Assert that overly-large [`TableUpdated`] frames are correctly split
+        /// into multiple smaller frames that are under the provided maximum
+        /// size.
+        #[test]
+        fn prop_table_update_frame_splitting(
+            max_frame_bytes in 0_usize..1_000,
+            n_columns in 0_i64..1_000,
+        ) {
+            let mut msg = TableUpdated {
+                table_name: TABLE_NAME.to_string(),
+                namespace_name: NAMESPACE_NAME.to_string(),
+                table_id: TABLE_ID,
+                columns: (0..n_columns).map(|v| {
+                    Column {
+                        name: "ignored".to_string(),
+                        column_id: v,
+                        column_type: 42,
+                    }
+                }).collect(),
+            };
+
+            let mut out = Vec::new();
+            let success = serialise_table_update_frames(
+                msg.clone(),
+                max_frame_bytes,
+                &mut out
+            );
+
+            // For all inputs, either:
+            //
+            //  - The return value indicates a frame could not be split
+            //    entirely, in which case at least one column must exceed
+            //    max_frame_bytes when packed in an update message, preventing
+            //    it from being split down to N=1, and that column is absent
+            //    from the output messages.
+            //
+            // or
+            //
+            //  - The message may have been split into more than one message of
+            //    less-than-or-equal-to max_frame_bytes in size, in which case
+            //    all columns must appear exactly once (validated by checking
+            //    the column ID values reduce to the input set)
+            //
+            // All output messages must contain identical table metadata and be
+            // non-empty.
+
+            // Otherwise validate the successful case.
+            for v in &out {
+                // Invariant: the split frames must be less than or equal to the
+                // desired maximum encoded frame size
+                assert!(v.encoded_len() <= max_frame_bytes);
+
+                // Invariant: all messages must contain the same metadata
+                assert_eq!(v.table_name, msg.table_name);
+                assert_eq!(v.namespace_name, msg.namespace_name);
+                assert_eq!(v.table_id, msg.table_id);
+
+                // Invariant: there should always be at least one column per
+                // message (no empty update frames).
+                assert!(!v.columns.is_empty());
+            }
+
+            let got_ids = into_sorted_vec(out.iter()
+                .flat_map(|v| v.columns.iter().map(|v| v.column_id)));
+
+            // Build the set of IDs that should appear.
+            let want_ids = if success {
+                // All column IDs must appear in the output as the splitting was
+                // successful.
+                (0..n_columns).collect::<Vec<_>>()
+            } else {
+                // Splitting failed.
+                //
+                // Build the set of column IDs expected to be in the output
+                // (those that are under the maximum size on their own).
+                let cols = std::mem::take(&mut msg.columns);
+                let want_ids = into_sorted_vec(cols.into_iter().filter_map(|v| {
+                        let column_id = v.column_id;
+                        msg.columns = vec![v];
+                        if msg.encoded_len() > max_frame_bytes {
+                            return None;
+                        }
+                        Some(column_id)
+                    }));
+
+                // Assert at least one column must be too large to be packed
+                // into an update containing only that column if one was
+                // provided.
+                if n_columns != 0 {
+                    assert_ne!(want_ids.len(), n_columns as usize);
+                }
+
+                want_ids
+            };
+
+            // The ordered iterator of observed IDs must match the input
+            // interval of [0, n_columns)
+            assert!(want_ids.into_iter().eq(got_ids.into_iter()));
+        }
+
+        #[test]
+        fn prop_table_create_frame_splitting(
+            n_columns in 0..MAX_USER_PAYLOAD_BYTES as i64,
+            partition_template_size in 0..MAX_USER_PAYLOAD_BYTES
+        ) {
+            let mut msg = TableCreated {
+                table: Some(TableUpdated {
+                    table_name: TABLE_NAME.to_string(),
+                    namespace_name: NAMESPACE_NAME.to_string(),
+                    table_id: TABLE_ID,
+                    columns: (0..n_columns).map(|v| {
+                        Column {
+                            name: "ignored".to_string(),
+                            column_id: v,
+                            column_type: 42,
+                        }
+                    }).collect(),
+                }),
+                // Generate a potentially outrageously big partition template.
+                // It's probably invalid, but that's fine for this test.
+                partition_template: Some(PartitionTemplate{ parts: vec![
+                    TemplatePart{ part: Some(Part::TagValue(
+                        "b".repeat(partition_template_size).to_string()
+                    ))
+                }]}),
+            };
+
+            let frames = serialise_table_create_frames(msg.clone());
+
+            // This TableCreated message is in one of three states:
+            //
+            //   1. Small enough to be sent in a one-er
+            //   2. Big enough to need splitting into a create + updates
+            //   3. Too big to send the create message at all
+            //
+            // For 1 and 2, all columns should be observed, and should follow
+            // the create message. For 3, nothing should be sent, as those
+            // updates are likely to go unused by peers who likely don't know
+            // about this table.
+
+            // Validate 3 first.
+            if frames.is_empty() {
+                // Then it MUST be too large to send even with no columns.
+                //
+                // Remove them and assert the size.
+                msg.table.as_mut().unwrap().columns = vec![];
+                assert!(msg.encoded_len() > MAX_USER_PAYLOAD_BYTES);
+                return Ok(());
+            }
+
+            // Both 1 and 2 require all columns to eventually be observed, as
+            // well as the create message.
+
+            let mut iter = frames.into_iter();
+            let mut columns = assert_matches!(iter.next(), Some(Event::TableCreated(v)) => {
+                // Invariant: table metadata must be correct
+                assert_eq!(v.partition_template, msg.partition_template);
+
+                let update = v.table.unwrap();
+                assert_eq!(update.table_name, TABLE_NAME);
+                assert_eq!(update.namespace_name, NAMESPACE_NAME);
+                assert_eq!(update.table_id, TABLE_ID);
+
+                // Return the columns in this create message, if any.
+                update.columns
+            });
+
+            // Combine the columns from above, with any subsequent update
+            // messages
+            columns.extend(iter.flat_map(|v| {
+                assert_matches!(v, Event::TableUpdated(v) => {
+                    // Invariant: metadata in follow-on updates must also match
+                    assert_eq!(v.table_name, TABLE_NAME);
+                    assert_eq!(v.namespace_name, NAMESPACE_NAME);
+                    assert_eq!(v.table_id, TABLE_ID);
+
+                    v.columns
+                })
+            }));
+
+            // Columns now contains all the columns, across all the output
+            // messages.
+            let got_ids = into_sorted_vec(columns.into_iter().map(|v| v.column_id));
+
+            // Which should match the full input set of column IDs
+            assert!((0..n_columns).eq(got_ids.into_iter()));
+        }
+    }
+
+    /// Generate a `Vec` of sorted `T`, preserving duplicates, if any.
+    fn into_sorted_vec<T>(v: impl IntoIterator<Item = T>) -> Vec<T>
+    where
+        T: Ord,
+    {
+        let mut v = v.into_iter().collect::<Vec<_>>();
+        v.sort_unstable();
+        v
+    }
+}

--- a/gossip_schema/src/handle.rs
+++ b/gossip_schema/src/handle.rs
@@ -19,7 +19,7 @@ use tokio::{
 /// transport limitations) and broadcasts the result to all listening peers.
 ///
 /// Serialisation and processing of the [`Event`] given to the
-/// [`SchemaTx::Broadcast()`] method happen in a background actor task,
+/// [`SchemaTx::broadcast()`] method happen in a background actor task,
 /// decoupling the caller from the latency of processing each frame. Dropping
 /// the [`SchemaTx`] stops this background actor task.
 #[derive(Debug)]
@@ -35,8 +35,8 @@ impl Drop for SchemaTx {
 }
 
 impl SchemaTx {
-    /// Construct a new [`SchemaChangeObserver`] that publishes gossip messages
-    /// over `gossip`, and delegates cache operations to `inner`.
+    /// Construct a new [`SchemaTx`] that publishes gossip messages over
+    /// `gossip`, and delegates cache operations to `inner`.
     pub fn new(gossip: gossip::GossipHandle<Topic>) -> Self {
         let (tx, rx) = mpsc::channel(100);
 
@@ -114,6 +114,8 @@ async fn actor_loop(mut rx: mpsc::Receiver<Event>, gossip: gossip::GossipHandle<
 /// If any [`Column`] within the message is too large to fit into an update
 /// containing only itself, then this method returns `false` indicating
 /// oversized columns were dropped from the output.
+///
+/// [`Column`]: generated_types::influxdata::iox::gossip::v1::Column
 fn serialise_table_update_frames(
     mut msg: TableUpdated,
     max_frame_bytes: usize,

--- a/gossip_schema/src/handle.rs
+++ b/gossip_schema/src/handle.rs
@@ -1,3 +1,6 @@
+//! A serialiser and broadcaster of [`gossip`] messages for the
+//! [`Topic::SchemaChanges`] topic.
+
 use generated_types::{
     influxdata::iox::gossip::{
         v1::{schema_message::Event, SchemaMessage, TableCreated, TableUpdated},
@@ -19,7 +22,7 @@ use tokio::{
 /// transport limitations) and broadcasts the result to all listening peers.
 ///
 /// Serialisation and processing of the [`Event`] given to the
-/// [`SchemaTx::broadcast()`] method happen in a background actor task,
+/// [`SchemaTx::broadcast()`] method happens in a background actor task,
 /// decoupling the caller from the latency of processing each frame. Dropping
 /// the [`SchemaTx`] stops this background actor task.
 #[derive(Debug)]
@@ -36,7 +39,7 @@ impl Drop for SchemaTx {
 
 impl SchemaTx {
     /// Construct a new [`SchemaTx`] that publishes gossip messages over
-    /// `gossip`, and delegates cache operations to `inner`.
+    /// `gossip`.
     pub fn new(gossip: gossip::GossipHandle<Topic>) -> Self {
         let (tx, rx) = mpsc::channel(100);
 
@@ -47,8 +50,8 @@ impl SchemaTx {
 
     /// Asynchronously broadcast `event` to all interested peers.
     ///
-    /// This method enqueues `event` into the serialisation queue, and
-    /// processed & transmitted asynchronously.
+    /// This method enqueues `event` into the serialisation queue, and processed
+    /// & transmitted asynchronously.
     pub fn broadcast(&self, event: Event) {
         debug!(?event, "sending schema message");
         match self.tx.try_send(event) {

--- a/gossip_schema/src/lib.rs
+++ b/gossip_schema/src/lib.rs
@@ -1,0 +1,314 @@
+//! Schema [gossip] event dispatcher & handler implementations.
+//!
+//! This sub-system is composed of the following primary components:
+//!
+//! * [`gossip`] crate: provides the gossip transport, the [`GossipHandle`], and
+//!   the [`Dispatcher`]. This crate operates on raw bytes.
+//!
+//! * The outgoing [`SchemaTx`]: a schema-specific wrapper over the underlying
+//!   [`GossipHandle`]. This type translates the protobuf [`Event`] from the
+//!   application layer into raw serialised bytes, sending them over the
+//!   underlying [`gossip`] impl.
+//!
+//! * The incoming [`SchemaRx`]: deserialises the incoming bytes from the gossip
+//!   [`Dispatcher`] into [`Event`] and passes them off to the
+//!   [`SchemaEventHandler`] implementation for processing.
+//!
+//! Users of this crate should implement the [`SchemaEventHandler`] trait to
+//! receive change events, and push events into the [`SchemaTx`] to broadcast
+//! changes to peers.
+//!
+//! ```text
+//!          ┌ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─
+//!                                                               │
+//!          │                    Application
+//!                                                               │
+//!          └ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─
+//!                      │                           ▲
+//!                      │                           │
+//!                      │                           │
+//!                      │       Schema Event        │
+//!                      │                           │
+//!                      ▼                           │
+//!          ┌──────────────────────┐   ┌─────────────────────────┐
+//!          │       SchemaTx       │   │        SchemaRx         │
+//!          └──────────────────────┘   └─────────────────────────┘
+//!                      │                           ▲
+//!                      │                           │
+//!                      │       Encoded bytes       │
+//!                      │                           │
+//!                      │                           │
+//!         ┌ Gossip  ─ ─│─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─│─ ─ ─ ─ ─ ─ ─
+//!                      ▼                           │             │
+//!         │    ┌──────────────┐          ┌──────────────────┐
+//!              │ GossipHandle │          │    Dispatcher    │    │
+//!         │    └──────────────┘          └──────────────────┘
+//!                                                                │
+//!         └ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─
+//! ```
+//!
+//! # Operation-Based CRDT / Differentials
+//!
+//! The messages exchanged between peers are schema change differentials
+//! observed by the sender - the messages form the update messages of an
+//! operation-based CRDT, as the schemas are additive only (append-only sets).
+//!
+//! # Best Effort
+//!
+//! This underlying gossip subsystem is designed to provide best effort delivery
+//! of messages, and therefore best-effort delivery of schema change events,
+//! without any ordering or delivery guarantees.
+//!
+//! This crate does NOT provide any eventual consistency guarantees of schema
+//! data.
+//!
+//! [`GossipHandle`]: gossip::GossipHandle
+//! [`Dispatcher`]: gossip::Dispatcher
+//! [`SchemaTx`]: handle::SchemaTx
+//! [`Event`]:
+//!     generated_types::influxdata::iox::gossip::v1::schema_message::Event
+//! [`SchemaRx`]: dispatcher::SchemaRx
+//! [`SchemaEventHandler`]: dispatcher::SchemaEventHandler
+
+pub mod dispatcher;
+pub mod handle;
+
+#[cfg(test)]
+mod tests {
+    use std::{net::SocketAddr, sync::Arc, time::Duration};
+
+    use async_trait::async_trait;
+    use data_types::partition_template::{
+        test_table_partition_override, NamespacePartitionTemplateOverride, PARTITION_BY_DAY_PROTO,
+    };
+    use generated_types::influxdata::iox::gossip::v1::{
+        schema_message::Event, Column as GossipColumn, NamespaceCreated, TableCreated, TableUpdated,
+    };
+    use gossip::Builder;
+    use test_helpers::{maybe_start_logging, timeout::FutureTimeout};
+    use tokio::{net::UdpSocket, sync::mpsc};
+
+    use crate::{
+        dispatcher::{SchemaEventHandler, SchemaRx},
+        handle::SchemaTx,
+    };
+
+    /// Bind a UDP socket on a random port and return it alongside the socket
+    /// address.
+    async fn random_udp() -> (UdpSocket, SocketAddr) {
+        // Bind a UDP socket to a random port
+        let socket = UdpSocket::bind("127.0.0.1:0")
+            .await
+            .expect("failed to bind UDP socket");
+        let addr = socket.local_addr().expect("failed to read local addr");
+
+        (socket, addr)
+    }
+
+    #[derive(Debug)]
+    struct Peer {
+        tx: SchemaTx,
+        rx: mpsc::Receiver<Event>,
+    }
+
+    #[derive(Debug)]
+    struct MockSchemaEventHandler(mpsc::Sender<Event>);
+
+    impl MockSchemaEventHandler {
+        fn new() -> (Self, mpsc::Receiver<Event>) {
+            let (tx, rx) = mpsc::channel(10);
+            (Self(tx), rx)
+        }
+    }
+
+    #[async_trait]
+    impl SchemaEventHandler for Arc<MockSchemaEventHandler> {
+        async fn handle(&self, event: Event) {
+            self.0.send(event).await.unwrap();
+        }
+    }
+
+    async fn new_node_pair() -> (Peer, Peer) {
+        let metrics = Arc::new(metric::Registry::default());
+
+        let (a_socket, a_addr) = random_udp().await;
+        let (handler, a_rx) = MockSchemaEventHandler::new();
+        let a_store = Arc::new(handler);
+        let a_dispatcher = SchemaRx::new(Arc::clone(&a_store), 100);
+
+        let (b_socket, b_addr) = random_udp().await;
+        let (handler, b_rx) = MockSchemaEventHandler::new();
+        let b_store = Arc::new(handler);
+        let b_dispatcher = SchemaRx::new(Arc::clone(&b_store), 100);
+
+        // Initialise both gossip reactors
+        let addrs = vec![a_addr.to_string(), b_addr.to_string()];
+        let a = Builder::new(addrs.clone(), a_dispatcher, Arc::clone(&metrics)).build(a_socket);
+        let b = Builder::new(addrs, b_dispatcher, Arc::clone(&metrics)).build(b_socket);
+
+        // Wait for peer discovery to occur
+        async {
+            loop {
+                if a.get_peers().await.len() == 1 && b.get_peers().await.len() == 1 {
+                    break;
+                }
+            }
+        }
+        .with_timeout_panic(Duration::from_secs(5))
+        .await;
+
+        let a = Peer {
+            tx: SchemaTx::new(a),
+            rx: a_rx,
+        };
+
+        let b = Peer {
+            tx: SchemaTx::new(b),
+            rx: b_rx,
+        };
+
+        (a, b)
+    }
+
+    // Broadcast a new namespace from node A and check it's instantiated into
+    // the SchemaStore in node B.
+    //
+    // This is an integration test of the various schema gossip components.
+    #[tokio::test]
+    async fn test_new_namespace() {
+        maybe_start_logging();
+
+        let (node_a, mut node_b) = new_node_pair().await;
+
+        let want = Event::NamespaceCreated(NamespaceCreated {
+            namespace_name: "bananas".to_string(),
+            namespace_id: 4242,
+            partition_template: Some(
+                NamespacePartitionTemplateOverride::try_from((**PARTITION_BY_DAY_PROTO).clone())
+                    .unwrap()
+                    .as_proto()
+                    .unwrap()
+                    .clone(),
+            ),
+            max_columns_per_table: 1,
+            max_tables: 2,
+            retention_period_ns: Some(1234),
+        });
+
+        // Broadcast the event from A
+        node_a.tx.broadcast(want.clone());
+
+        // Receive it from B
+        let got = node_b
+            .rx
+            .recv()
+            .with_timeout_panic(Duration::from_secs(5))
+            .await
+            .unwrap();
+
+        // Ensuring the content is identical
+        assert_eq!(got, want);
+    }
+
+    // As above, but ensuring default partition templates propagate correctly.
+    #[tokio::test]
+    async fn test_namespace_default_partition_templates() {
+        maybe_start_logging();
+
+        let (node_a, mut node_b) = new_node_pair().await;
+
+        let want = Event::NamespaceCreated(NamespaceCreated {
+            namespace_name: "bananas".to_string(),
+            namespace_id: 4242,
+            partition_template: None,
+            max_columns_per_table: 1,
+            max_tables: 2,
+            retention_period_ns: Some(1234),
+        });
+
+        // Broadcast the event from A
+        node_a.tx.broadcast(want.clone());
+
+        // Receive it from B
+        let got = node_b
+            .rx
+            .recv()
+            .with_timeout_panic(Duration::from_secs(5))
+            .await
+            .unwrap();
+
+        // Ensuring the content is identical
+        assert_eq!(got, want);
+    }
+
+    /// Add a new table and column to an existing namespace.
+    #[tokio::test]
+    async fn test_new_table() {
+        maybe_start_logging();
+
+        let (node_a, mut node_b) = new_node_pair().await;
+        let want = Event::TableCreated(TableCreated {
+            table: Some(TableUpdated {
+                table_name: "bananas".to_string(),
+                namespace_name: "platanos".to_string(),
+                table_id: 4242,
+                columns: vec![GossipColumn {
+                    name: "c2".to_string(),
+                    column_id: 12345,
+                    column_type: data_types::ColumnType::U64 as _,
+                }],
+            }),
+            partition_template: test_table_partition_override(vec![
+                data_types::partition_template::TemplatePart::TagValue("bananatastic"),
+            ])
+            .as_proto()
+            .cloned(),
+        });
+
+        // Broadcast the event from A
+        node_a.tx.broadcast(want.clone());
+
+        // Receive it from B
+        let got = node_b
+            .rx
+            .recv()
+            .with_timeout_panic(Duration::from_secs(5))
+            .await
+            .unwrap();
+
+        // Ensuring the content is identical
+        assert_eq!(got, want);
+    }
+
+    /// Add a new column to an existing table
+    #[tokio::test]
+    async fn test_new_column() {
+        maybe_start_logging();
+
+        let (node_a, mut node_b) = new_node_pair().await;
+        let want = Event::TableUpdated(TableUpdated {
+            table_name: "platanos".to_string(),
+            namespace_name: "bananas".to_string(),
+            table_id: 4242,
+            columns: vec![GossipColumn {
+                name: "c2".to_string(),
+                column_id: 12345,
+                column_type: data_types::ColumnType::U64 as _,
+            }],
+        });
+
+        // Broadcast the event from A
+        node_a.tx.broadcast(want.clone());
+
+        // Receive it from B
+        let got = node_b
+            .rx
+            .recv()
+            .with_timeout_panic(Duration::from_secs(5))
+            .await
+            .unwrap();
+
+        // Ensuring the content is identical
+        assert_eq!(got, want);
+    }
+}

--- a/gossip_schema/src/lib.rs
+++ b/gossip_schema/src/lib.rs
@@ -70,6 +70,25 @@
 //! [`SchemaRx`]: dispatcher::SchemaRx
 //! [`SchemaEventHandler`]: dispatcher::SchemaEventHandler
 
+#![deny(rustdoc::broken_intra_doc_links, rust_2018_idioms)]
+#![warn(
+    clippy::clone_on_ref_ptr,
+    clippy::dbg_macro,
+    clippy::explicit_iter_loop,
+    // See https://github.com/influxdata/influxdb_iox/pull/1671
+    clippy::future_not_send,
+    clippy::todo,
+    clippy::use_self,
+    missing_copy_implementations,
+    missing_debug_implementations,
+    unused_crate_dependencies,
+    missing_docs
+)]
+#![allow(clippy::default_constructed_unit_structs)]
+
+// Workaround for "unused crate" lint false positives.
+use workspace_hack as _;
+
 pub mod dispatcher;
 pub mod handle;
 


### PR DESCRIPTION
This PR adds the (currently unused) `gossip_schema` crate, that layers the schema-specific messages / logic onto the underlying `gossip` transport crate.

This is designed to make listening for schema changes easy in IOx - initialise a `gossip` instance, initialise the `SchemaRx` and receive a callback for each incoming schema change event :rocket:

A follow-up PR will switch the router to use this crate, removing the bespoke implementation currently in use. All of the logic in this PR is copy/pasted from the current router implementation.

---

* refactor: ColumnsByName::from_iter() (55631a4f8)
      
      Allow a ColumnsByName to be constructed by collecting a set of (name,
      column_schema) tuples.

* feat: implement gossip_schema crate (2e77507f7)
      
      Adds a new gossip_schema crate that provides a high-level interface to
      schema change notifications.
      
      This crate layers schema-specific interfaces over the existing low-level
      gossip crate. Users can obtain best-effort schema change notifications
      by implementing a SchemaEventHandler delegate given to a SchemaRx, or
      efficiently dispatch schema change notifications to listening peers
      using a SchemaTx.
      
      Schema notifications are sent over the Topic::SchemaChanges topic
      (ID=1), which the caller must register as an interest on receiving
      gossip nodes.