### PR TITLE
refactor(ingester): full parquet file metadata

### DIFF
--- a/ingester/src/persist/completion_observer.rs
+++ b/ingester/src/persist/completion_observer.rs
@@ -2,7 +2,7 @@ use std::{fmt::Debug, sync::Arc, time::Duration};
 
 use async_trait::async_trait;
 use data_types::{
-    sequence_number_set::SequenceNumberSet, NamespaceId, ParquetFileParams, TableId,
+    sequence_number_set::SequenceNumberSet, NamespaceId, ParquetFile, TableId,
     TransitionPartitionId,
 };
 
@@ -30,7 +30,7 @@ pub trait PersistCompletionObserver: Send + Sync + Debug {
 #[derive(Debug)]
 pub struct CompletedPersist {
     /// The catalog metadata for the persist operation.
-    meta: ParquetFileParams,
+    meta: ParquetFile,
 
     /// The [`SequenceNumberSet`] of the persisted data.
     sequence_numbers: SequenceNumberSet,
@@ -38,7 +38,7 @@ pub struct CompletedPersist {
 
 impl CompletedPersist {
     /// Construct a new completion notification.
-    pub(crate) fn new(meta: ParquetFileParams, sequence_numbers: SequenceNumberSet) -> Self {
+    pub(crate) fn new(meta: ParquetFile, sequence_numbers: SequenceNumberSet) -> Self {
         Self {
             meta,
             sequence_numbers,
@@ -170,10 +170,12 @@ mod tests {
     use crate::test_util::{
         ARBITRARY_NAMESPACE_ID, ARBITRARY_TABLE_ID, ARBITRARY_TRANSITION_PARTITION_ID,
     };
-    use data_types::{ColumnId, ColumnSet, SequenceNumber, Timestamp};
+    use data_types::{ColumnId, ColumnSet, ParquetFileId, SequenceNumber, Timestamp};
 
-    fn arbitrary_file_meta() -> ParquetFileParams {
-        ParquetFileParams {
+    fn arbitrary_file_meta() -> ParquetFile {
+        ParquetFile {
+            id: ParquetFileId::new(42),
+            to_delete: None,
             namespace_id: ARBITRARY_NAMESPACE_ID,
             table_id: ARBITRARY_TABLE_ID,
             partition_id: ARBITRARY_TRANSITION_PARTITION_ID.clone(),

--- a/ingester/src/persist/file_metrics.rs
+++ b/ingester/src/persist/file_metrics.rs
@@ -156,7 +156,8 @@ mod tests {
         },
     };
     use data_types::{
-        sequence_number_set::SequenceNumberSet, ColumnId, ColumnSet, ParquetFileParams, Timestamp,
+        sequence_number_set::SequenceNumberSet, ColumnId, ColumnSet, ParquetFile, ParquetFileId,
+        Timestamp,
     };
     use metric::assert_histogram;
     use std::sync::Arc;
@@ -168,7 +169,9 @@ mod tests {
         let metrics = metric::Registry::default();
         let decorator = ParquetFileInstrumentation::new(Arc::clone(&inner), &metrics);
 
-        let meta = ParquetFileParams {
+        let meta = ParquetFile {
+            id: ParquetFileId::new(42),
+            to_delete: None,
             namespace_id: ARBITRARY_NAMESPACE_ID,
             table_id: ARBITRARY_TABLE_ID,
             partition_id: ARBITRARY_TRANSITION_PARTITION_ID.clone(),

--- a/ingester/src/persist/queue.rs
+++ b/ingester/src/persist/queue.rs
@@ -55,8 +55,8 @@ pub(crate) mod mock {
     use std::{sync::Arc, time::Duration};
 
     use data_types::{
-        ColumnId, ColumnSet, NamespaceId, ParquetFileParams, PartitionHashId, PartitionKey,
-        TableId, Timestamp, TransitionPartitionId,
+        ColumnId, ColumnSet, NamespaceId, ParquetFile, ParquetFileId, PartitionHashId,
+        PartitionKey, TableId, Timestamp, TransitionPartitionId,
     };
     use test_helpers::timeout::FutureTimeout;
     use tokio::task::JoinHandle;
@@ -162,7 +162,9 @@ pub(crate) mod mock {
                 let partition_id = TransitionPartitionId::Deterministic(partition_hash_id);
                 completion_observer
                     .persist_complete(Arc::new(CompletedPersist::new(
-                        ParquetFileParams {
+                        ParquetFile {
+                            id: ParquetFileId::new(42),
+                            to_delete: None,
                             namespace_id: NamespaceId::new(1),
                             table_id,
                             partition_id,

--- a/ingester/src/test_util.rs
+++ b/ingester/src/test_util.rs
@@ -2,8 +2,8 @@ use std::{collections::BTreeMap, sync::Arc, time::Duration};
 
 use data_types::{
     partition_template::TablePartitionTemplateOverride, ColumnId, ColumnSet, NamespaceId,
-    ParquetFileParams, PartitionHashId, PartitionId, PartitionKey, SequenceNumber, TableId,
-    Timestamp, TransitionPartitionId,
+    ParquetFile, ParquetFileId, PartitionHashId, PartitionId, PartitionKey, SequenceNumber,
+    TableId, Timestamp, TransitionPartitionId,
 };
 use hashbrown::HashSet;
 use iox_catalog::{interface::Catalog, test_helpers::arbitrary_namespace};
@@ -373,7 +373,9 @@ where
     T: IntoIterator<Item = u64>,
 {
     Arc::new(CompletedPersist::new(
-        ParquetFileParams {
+        ParquetFile {
+            id: ParquetFileId::new(42),
+            to_delete: None,
             namespace_id: NamespaceId::new(1),
             table_id: TableId::new(2),
             partition_id: ARBITRARY_TRANSITION_PARTITION_ID.clone(),


### PR DESCRIPTION
This change propagates the full metadata of newly persisted files to persist completion observers.

No functional change in this PR - nothing needs those fields yet.

---

* refactor(ingester): full parquet file metadata (6ccf3324e)
      
      Include the full ParquetFile metadata when invoking
      PersistCompletionObserver implementations, instead of the
      ParquetFileParams subset.