### PR TITLE
feat(proto): define parquet file gossip type

### DIFF
--- a/generated_types/build.rs
+++ b/generated_types/build.rs
@@ -57,6 +57,7 @@ fn generate_grpc_types(root: &Path) -> Result<()> {
         catalog_path.join("service.proto"),
         compactor_path.join("service.proto"),
         delete_path.join("service.proto"),
+        gossip_path.join("parquet_file.proto"),
         gossip_path.join("schema.proto"),
         ingester_path.join("parquet_metadata.proto"),
         ingester_path.join("persist.proto"),

--- a/generated_types/protos/influxdata/iox/gossip/v1/parquet_file.proto
+++ b/generated_types/protos/influxdata/iox/gossip/v1/parquet_file.proto
@@ -1,0 +1,8 @@
+syntax = "proto3";
+package influxdata.iox.gossip.v1;
+option go_package = "github.com/influxdata/iox/gossip/v1";
+
+import "influxdata/iox/catalog/v1/parquet_file.proto";
+
+/// A gossip-specific wrapper over a `ParquetFile` record.
+message NewParquetFile { influxdata.iox.catalog.v1.ParquetFile file = 1; }


### PR DESCRIPTION
This PR adds a proto file that wraps this existing proto message:

https://github.com/influxdata/influxdb_iox/blob/a1211b0d03d3c917f2c8e0ed2a1e60762f0e9043/generated_types/protos/influxdata/iox/catalog/v1/parquet_file.proto#L7-L48

This will be sent to gossip peers when a new parquet file is persisted in the ingester :+1: 

Part of #8201

---

* feat(proto): define parquet file gossip type (a1211b0d0)
      
      Specify the gossip message used to notify peers of new parquet files.
      
      This reuses the existing ParquetFile type in the "catalog" proto
      package.
      
      This will probably expand in the future to differentiate between new
      files (via ingest) and compacted files (which make other files
      obsolete).