### PR TITLE
feat: interface for V2 ingester query client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2727,6 +2727,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "ingester_query_client"
+version = "0.1.0"
+dependencies = [
+ "arrow",
+ "async-trait",
+ "data_types",
+ "datafusion",
+ "futures",
+ "trace",
+ "uuid",
+ "workspace-hack",
+]
+
+[[package]]
 name = "ingester_query_grpc"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ members = [
     "influxdb2_client",
     "influxrpc_parser",
     "ingester_query_grpc",
+    "ingester_query_client",
     "ingester_test_ctx",
     "ingester",
     "iox_catalog",

--- a/ingester_query_client/Cargo.toml
+++ b/ingester_query_client/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "ingester_query_client"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies] # In alphabetical order
+arrow = { workspace = true, features = ["prettyprint", "dyn_cmp_dict"] }
+async-trait = "0.1"
+data_types = { path = "../data_types" }
+datafusion = { workspace = true }
+futures = "0.3"
+trace = { path = "../trace" }
+uuid = "1"
+workspace-hack = { version = "0.1", path = "../workspace-hack" }

--- a/ingester_query_client/src/dynamic.rs
+++ b/ingester_query_client/src/dynamic.rs
@@ -1,0 +1,76 @@
+//! Type-erased implementations of the client interface.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use futures::{stream::BoxStream, Stream, StreamExt};
+use trace::span::Span;
+
+use crate::interface::{
+    IngesterQueryClient, QueryError, QueryRequest, QueryResponse, ResponseStreamResult,
+};
+
+/// Type-erased response stream.
+pub type DynResponseStream = BoxStream<'static, ResponseStreamResult>;
+
+/// Type-erased [`IngesterQueryClient`].
+pub type DynIngesterQueryClient = Arc<dyn IngesterQueryClient<ResponseStream = DynResponseStream>>;
+
+/// Erase type of [`IngesterQueryClient`].
+///
+/// This should normally be done after building client and apply all wrappers.
+pub fn erase_client_type<C>(client: C) -> DynIngesterQueryClient
+where
+    C: IngesterQueryClient,
+{
+    Arc::new(BoxedStreamClient { inner: client })
+}
+
+#[async_trait]
+impl<S> IngesterQueryClient for Arc<dyn IngesterQueryClient<ResponseStream = S>>
+where
+    S: Send + Stream<Item = ResponseStreamResult> + 'static,
+{
+    type ResponseStream = S;
+
+    async fn query(
+        &self,
+        request: QueryRequest,
+        span: Option<Span>,
+    ) -> Result<QueryResponse<Self::ResponseStream>, QueryError> {
+        self.as_ref().query(request, span).await
+    }
+}
+
+/// Helper type to type-erase the [response stream](IngesterQueryClient::ResponseStream).
+#[derive(Debug)]
+struct BoxedStreamClient<C>
+where
+    C: IngesterQueryClient,
+{
+    inner: C,
+}
+
+#[async_trait]
+impl<C> IngesterQueryClient for BoxedStreamClient<C>
+where
+    C: IngesterQueryClient,
+{
+    type ResponseStream = DynResponseStream;
+
+    async fn query(
+        &self,
+        request: QueryRequest,
+        span: Option<Span>,
+    ) -> Result<QueryResponse<Self::ResponseStream>, QueryError> {
+        let resp = self.inner.query(request, span).await?;
+
+        Ok(QueryResponse {
+            ingester_uuid: resp.ingester_uuid,
+            persist_counter: resp.persist_counter,
+            table_schema: resp.table_schema,
+            partitions: resp.partitions,
+            payload_stream: resp.payload_stream.boxed(),
+        })
+    }
+}

--- a/ingester_query_client/src/interface.rs
+++ b/ingester_query_client/src/interface.rs
@@ -1,0 +1,98 @@
+//! Interface for all implementation of the client interface.
+use arrow::{datatypes::SchemaRef, record_batch::RecordBatch};
+use async_trait::async_trait;
+use data_types::{NamespaceId, TableId, TimestampMinMax, TransitionPartitionId};
+use datafusion::prelude::Expr;
+use futures::Stream;
+use std::fmt::Debug;
+use trace::span::Span;
+use uuid::Uuid;
+
+/// Request to an ingester.
+#[derive(Debug, Clone)]
+pub struct QueryRequest {
+    /// Namespace to search
+    pub namespace_id: NamespaceId,
+
+    /// Table that should be queried.
+    pub table_id: TableId,
+
+    /// Columns the query service is interested in.
+    pub columns: Vec<String>,
+
+    /// Predicate for filtering.
+    ///
+    /// The client (and ingester) SHOULD apply these but are free to drop some or all of the expressions.
+    pub filters: Vec<Expr>,
+}
+
+/// Response from the ingester.
+#[derive(Debug, Clone)]
+pub struct QueryResponse<S>
+where
+    S: Send + Stream<Item = ResponseStreamResult> + 'static,
+{
+    /// Ingester UUID
+    pub ingester_uuid: Uuid,
+
+    /// Number of persisted parquet files for this ingester.
+    pub persist_counter: i64,
+
+    /// Serialized table schema.
+    pub table_schema: SchemaRef,
+
+    /// Ingester partitions.
+    pub partitions: Vec<QueryResponsePartition>,
+
+    /// Payload stream.
+    pub payload_stream: S,
+}
+
+/// Partition metadata as part of a [`QueryResponse`].
+#[derive(Debug, Clone)]
+pub struct QueryResponsePartition {
+    /// Partition ID.
+    pub id: TransitionPartitionId,
+
+    /// Timestamp min and max.
+    pub t_min_max: TimestampMinMax,
+
+    /// Partition schema.
+    ///
+    /// This is always a projection of the [table schema](QueryResponse::table_schema).
+    pub schema: SchemaRef,
+}
+
+/// Data payload in the [`QueryResponse`].
+#[derive(Debug, Clone)]
+pub struct QueryResponsePayload {
+    /// Associated partition.
+    ///
+    /// This is always one of the partitions present in [`QueryResponse::partitions`].
+    pub partition_id: TransitionPartitionId,
+
+    /// Record batch data.
+    ///
+    /// This is always a projection of the [partition schema](QueryResponsePartition::schema).
+    pub batch: RecordBatch,
+}
+
+/// Query error.
+pub type QueryError = Box<dyn std::error::Error + Send + Sync>;
+
+/// Result of the response stream.
+pub type ResponseStreamResult = Result<QueryResponsePayload, QueryError>;
+
+/// Abstract query client.
+#[async_trait]
+pub trait IngesterQueryClient: Debug + Send + Sync + 'static {
+    /// Response stream type.
+    type ResponseStream: Send + Stream<Item = ResponseStreamResult> + 'static;
+
+    /// Perform request.
+    async fn query(
+        &self,
+        request: QueryRequest,
+        span: Option<Span>,
+    ) -> Result<QueryResponse<Self::ResponseStream>, QueryError>;
+}

--- a/ingester_query_client/src/lib.rs
+++ b/ingester_query_client/src/lib.rs
@@ -1,0 +1,20 @@
+//! Client to query the ingester.
+#![deny(rustdoc::broken_intra_doc_links, rust_2018_idioms)]
+#![warn(
+    missing_copy_implementations,
+    missing_docs,
+    clippy::explicit_iter_loop,
+    // See https://github.com/influxdata/influxdb_iox/pull/1671
+    clippy::future_not_send,
+    clippy::use_self,
+    clippy::clone_on_ref_ptr,
+    clippy::todo,
+    clippy::dbg_macro,
+    unused_crate_dependencies
+)]
+
+pub mod dynamic;
+pub mod interface;
+
+// Workaround for "unused crate" lint false positives.
+use workspace_hack as _;


### PR DESCRIPTION
Generic interface for #8349.

The plan is to fill this later with:

1. the actual gRPC client
2. a mock client
3. multiple layers/wrappers that implement all the functionality that we need in the end but that should ideally be unitested as well (backoff, connection reset, circuit breaker, logging/metrics/tracing)

We also probably need a better `Error` implementation, but I first need to figure out a nice interface while I write the gRPC client. It should compose well across layers and should also have machine-readable attributes like "was this upstream?". So I defer this to a follow-up PR.