### PR TITLE
chore: limit compactor region count computations

### DIFF
--- a/compactor/src/components/split_or_compact/start_level_files_to_split.rs
+++ b/compactor/src/components/split_or_compact/start_level_files_to_split.rs
@@ -198,6 +198,10 @@ pub fn linear_dist_ranges(
             // we can deal with the non-linearity, or we're as small as we can go.
             break;
         }
+        if split_count > 10000 {
+            // this is getting expenisve to compute.  We can use these regions and split again if required.
+            break;
+        }
 
         // retry with smaller regions.  Eventually we'll get regions small enough we can isolate and deal with the non-linearity.
         split_count *= 2;
@@ -805,10 +809,10 @@ mod tests {
             @r###"
         ---
         - case 3 linear data distribution ranges
-        - "[100,100] 100mb          |range|                                                                                   "
-        - "[101,320099] 4.43gb      |-------------------------------range--------------------------------|                    "
-        - "[320100,409698] 275mb                                                                          |------range------| "
-        - "[409699,409699] 78mb                                                                                              |range|"
+        - "[100,137] 102mb          |range|                                                                                   "
+        - "[138,320097] 4.44gb      |--------------------------range--------------------------|                               "
+        - "[320098,460089] 341mb                                                               |---------range---------|      "
+        - "[460090,486499] 12mb                                                                                          |range|"
         "###
         );
 
@@ -850,8 +854,9 @@ mod tests {
             @r###"
         ---
         - case 4 linear data distribution ranges
-        - "[10,1008] 1000mb         |range|                                                                                   "
-        - "[1009,9732105] 100mb     |-----------------------------------------range-----------------------------------------| "
+        - "[10,896] 895mb           |range|                                                                                   "
+        - "[897,1783] 105mb         |range|                                                                                   "
+        - "[1784,9991177] 100mb     |-----------------------------------------range-----------------------------------------| "
         "###
         );
 
@@ -1032,17 +1037,16 @@ mod tests {
             @r###"
         ---
         - case 6 linear data distribution ranges
-        - "[0,1301] 101mb           |range|                                                                                   "
-        - "[1302,1999871] 799mb     |-----range-----|                                                                         "
-        - "[1999872,2001173] 101mb                    |range|                                                                 "
-        - "[2001174,3999743] 799mb                    |-----range-----|                                                       "
-        - "[3999744,4001045] 101mb                                      |range|                                               "
-        - "[4001046,5999615] 799mb                                      |-----range-----|                                     "
-        - "[5999616,6000917] 92mb                                                         |range|                             "
-        - "[6000918,7999921] 808mb                                                        |-----range-----|                   "
-        - "[7999922,8001223] 101mb                                                                          |range|           "
-        - "[8001224,9998925] 799mb                                                                          |-----range-----| "
-        - "[9998926,9999359] 440kb                                                                                           |range|"
+        - "[0,867] 87mb             |range|                                                                                   "
+        - "[868,1999871] 813mb      |-----range-----|                                                                         "
+        - "[1999872,2001607] 101mb                    |range|                                                                 "
+        - "[2001608,3999743] 799mb                    |-----range-----|                                                       "
+        - "[3999744,4001479] 101mb                                      |range|                                               "
+        - "[4001480,5999615] 799mb                                      |-----range-----|                                     "
+        - "[5999616,6001351] 101mb                                                        |range|                             "
+        - "[6001352,7999487] 799mb                                                        |-----range-----|                   "
+        - "[7999488,8001223] 101mb                                                                          |range|           "
+        - "[8001224,9999359] 800mb                                                                          |-----range-----| "
         "###
         );
     }


### PR DESCRIPTION
This PR helps https://github.com/influxdata/idpe/issues/17974
This PR is a followup to https://github.com/influxdata/influxdb_iox/pull/8506

I noticed a cluster with a lot of backlog with highly nonlinearly distributed data was having trouble computing suitable regions for the data distribution.  This caps the calculations at 10,000.  That doesn't mean there will be 10,000 regions, its just estimating data distribution for that many, then it consolidates similar regions before actually splitting files.  Its possible this means we'll need to split more than once, but if there's that much backlog its probably best not to try to deal with it all at once anyway.

After https://github.com/influxdata/influxdb_iox/pull/8559 goes in I want to make more changes related to very highly backlogged scenarios.  

This change does not affect any of the simulation scenarios, which is nice.  But it does affect the quality of the tests specifically for the linear distribution code.  Note the comment before those tests:
```
    // There is a comment before each insta result showing the regions.  The comment describes what we want to see.  If future code changes
    // cause the result to change, we likely don't care, so long as the general objective of the comment is still met.  This is a game of
    // approximation, not precision.
```
Overall, this is probably a slight decline in decision quality, but greatly reduces the compute cost on highly backlogged scenarios.

- [x] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb_iox/blob/main/README.md).
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
