### PR TITLE
fix(bench): schema validator bench panic

### DIFF
--- a/router/benches/schema_validator.rs
+++ b/router/benches/schema_validator.rs
@@ -4,7 +4,7 @@ use criterion::{
     criterion_group, criterion_main, measurement::WallTime, BatchSize, BenchmarkGroup, Criterion,
     Throughput,
 };
-use data_types::NamespaceName;
+use data_types::{NamespaceId, NamespaceName, NamespaceSchema};
 use hashbrown::HashMap;
 use iox_catalog::{interface::Catalog, mem::MemCatalog};
 use mutable_batch::MutableBatch;
@@ -50,6 +50,16 @@ fn bench(group: &mut BenchmarkGroup<WallTime>, tables: usize, columns_per_table:
     ));
     let validator = SchemaValidator::new(catalog, Arc::clone(&ns_cache), &metrics);
 
+    let namespace_schema = NamespaceSchema {
+        id: NamespaceId::new(42),
+        tables: Default::default(),
+        max_columns_per_table: 42,
+        max_tables: 42,
+        retention_period_ns: None,
+        partition_template: Default::default(),
+    };
+    ns_cache.put_schema(NAMESPACE.clone(), namespace_schema);
+
     for i in 0..65_000 {
         let write = lp_to_writes(format!("{}{}", i + 10_000_000, generate_lp(1, 1)).as_str());
         let namespace_schema = runtime().block_on(ns_cache.get_schema(&NAMESPACE)).unwrap();
@@ -67,7 +77,7 @@ fn bench(group: &mut BenchmarkGroup<WallTime>, tables: usize, columns_per_table:
             || {
                 (
                     write.clone(),
-                    runtime().block_on(ns_cache.get_schema(&NAMESPACE)).unwrap(),
+                    futures::executor::block_on(ns_cache.get_schema(&NAMESPACE)).unwrap(),
                 )
             },
             |(write, namespace_schema)| validator.write(&NAMESPACE, namespace_schema, write, None),


### PR DESCRIPTION
This was broken and now it isn't.

---

* fix(bench): schema validator bench panic (932532c3e)
      
      The benchmark code was completely broken - running the benches would
      immediately panic.