### PR TITLE
feat(gossip): broadcast to randomised peer subset

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2052,6 +2052,7 @@ dependencies = [
  "metric",
  "prost",
  "prost-build",
+ "rand",
  "test_helpers",
  "thiserror",
  "tokio",

--- a/gossip/Cargo.toml
+++ b/gossip/Cargo.toml
@@ -11,6 +11,7 @@ futures = "0.3.28"
 hashbrown.workspace = true
 metric = { version = "0.1.0", path = "../metric" }
 prost = "0.11.9"
+rand = "0.8.5"
 thiserror = "1.0.47"
 tokio = { version = "1.32.0", features = ["net", "io-util", "time", "rt", "sync", "macros"] }
 tracing = "0.1.37"

--- a/gossip/src/reactor.rs
+++ b/gossip/src/reactor.rs
@@ -235,7 +235,7 @@ where
                         Some(Request::GetPeers(tx)) => {
                             let _ = tx.send(self.peer_list.peer_uuids());
                         },
-                        Some(Request::Broadcast(payload, topic)) => {
+                        Some(Request::Broadcast(payload, topic, subset)) => {
                             // The user is guaranteed MAX_USER_PAYLOAD_BYTES to
                             // be send-able, so send this frame without packing
                             // others with it for simplicity.
@@ -255,6 +255,7 @@ where
                                 &self.metric_frames_sent,
                                 &self.metric_bytes_sent,
                                 Some(topic),
+                                subset,
                             ).await;
                         }
                     }


### PR DESCRIPTION
This lets us send frames to a subset of gossip members, instead of all of them.

This will be handy when we want to periodically perform a consistency check, but without full N^2 spamming.

---

* feat(gossip): broadcast to randomised peer subset (43db19b7d)
      
      Provide a new broadcast_subset() method to gossip users, enabling a
      message to be sent to a random subset of peers that have a registered
      interest in the message being dispatched.