### PR TITLE
feat(gossip): expose peer identity & socket address

### DIFF
--- a/gossip/src/handle.rs
+++ b/gossip/src/handle.rs
@@ -63,7 +63,7 @@ where
 
     /// Return the randomly generated identity of this gossip instance.
     pub fn identity(&self) -> Uuid {
-        *self.identity
+        self.identity.as_uuid()
     }
 
     /// Broadcast `payload` to all known peers.

--- a/gossip/src/handle.rs
+++ b/gossip/src/handle.rs
@@ -3,7 +3,6 @@ use std::marker::PhantomData;
 use crate::{topic_set::Topic, Bytes, MAX_USER_PAYLOAD_BYTES};
 use thiserror::Error;
 use tokio::sync::{mpsc, oneshot};
-use uuid::Uuid;
 
 use crate::peers::Identity;
 
@@ -33,7 +32,7 @@ pub(crate) enum Request {
     Broadcast(Bytes, Topic, BroadcastType),
 
     /// Get a snapshot of the peer identities.
-    GetPeers(oneshot::Sender<Vec<Uuid>>),
+    GetPeers(oneshot::Sender<Vec<Identity>>),
 }
 
 /// A handle to the gossip subsystem.
@@ -62,8 +61,8 @@ where
     }
 
     /// Return the randomly generated identity of this gossip instance.
-    pub fn identity(&self) -> Uuid {
-        self.identity.as_uuid()
+    pub fn identity(&self) -> Identity {
+        self.identity.clone()
     }
 
     /// Broadcast `payload` to all known peers.
@@ -132,7 +131,7 @@ where
     }
 
     /// Retrieve a snapshot of the connected peer list.
-    pub async fn get_peers(&self) -> Vec<Uuid> {
+    pub async fn get_peers(&self) -> Vec<Identity> {
         let (tx, rx) = oneshot::channel();
         self.tx.send(Request::GetPeers(tx)).await.unwrap();
         rx.await.unwrap()

--- a/gossip/src/lib.rs
+++ b/gossip/src/lib.rs
@@ -34,6 +34,7 @@ use workspace_hack as _;
 pub use builder::*;
 pub use dispatcher::*;
 pub use handle::*;
+pub use peers::Identity;
 
 /// The maximum duration of time allotted to performing a DNS resolution against
 /// a seed/peer address.

--- a/gossip/src/peers.rs
+++ b/gossip/src/peers.rs
@@ -66,8 +66,8 @@ impl Identity {
         &self.0
     }
 
-    // Parse this identity into a UUID.
-    pub(crate) fn as_uuid(&self) -> Uuid {
+    /// Parse this identity into a UUID.
+    pub fn as_uuid(&self) -> Uuid {
         Uuid::from_slice(&self.0).unwrap()
     }
 }
@@ -184,8 +184,8 @@ impl PeerList {
     }
 
     /// Return the UUIDs of all known peers.
-    pub(crate) fn peer_uuids(&self) -> Vec<Uuid> {
-        self.list.keys().map(|v| v.as_uuid()).collect()
+    pub(crate) fn peer_identities(&self) -> Vec<Identity> {
+        self.list.keys().cloned().collect()
     }
 
     /// Returns an iterator of all known peers in the peer list.

--- a/gossip/src/peers.rs
+++ b/gossip/src/peers.rs
@@ -133,6 +133,10 @@ impl Peer {
     pub(crate) fn mark_observed(&mut self) {
         self.unacked_ping_count = 0;
     }
+
+    pub(crate) fn addr(&self) -> SocketAddr {
+        self.addr
+    }
 }
 
 impl From<&Peer> for crate::proto::Peer {
@@ -196,6 +200,11 @@ impl PeerList {
     /// Returns true if `identity` is already in the peer list.
     pub(crate) fn contains(&self, identity: &Identity) -> bool {
         self.list.contains_key(identity)
+    }
+
+    /// Returns the [`Peer`] for the provided [`Identity`], if any.
+    pub(crate) fn get(&self, identity: &Identity) -> Option<&Peer> {
+        self.list.get(identity)
     }
 
     /// Upsert a peer identified by `identity` to the peer list, associating it

--- a/gossip/src/peers.rs
+++ b/gossip/src/peers.rs
@@ -19,17 +19,9 @@ use crate::{
 /// members a subset broadcast is sent to.
 const SUBSET_FRACTION: f32 = 0.33;
 
-/// A unique generated identity containing 128 bits of randomness (V4 UUID).
-#[derive(Debug, Eq, Clone)]
-pub(crate) struct Identity(Bytes, Uuid);
-
-impl std::ops::Deref for Identity {
-    type Target = Uuid;
-
-    fn deref(&self) -> &Self::Target {
-        &self.1
-    }
-}
+/// A unique peer identity containing 128 bits of randomness (V4 UUID).
+#[derive(Debug, Eq, Clone, PartialEq)]
+pub struct Identity(Bytes);
 
 impl std::hash::Hash for Identity {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
@@ -37,16 +29,9 @@ impl std::hash::Hash for Identity {
     }
 }
 
-impl PartialEq for Identity {
-    fn eq(&self, other: &Self) -> bool {
-        debug_assert!((self.1 == other.1) == (self.0 == other.0));
-        self.0 == other.0
-    }
-}
-
 impl std::fmt::Display for Identity {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        self.1.fmt(f)
+        self.as_uuid().fmt(f)
     }
 }
 
@@ -54,8 +39,9 @@ impl TryFrom<Bytes> for Identity {
     type Error = uuid::Error;
 
     fn try_from(value: Bytes) -> Result<Self, Self::Error> {
-        let uuid = Uuid::from_slice(&value)?;
-        Ok(Self(value, uuid))
+        // Validate bytes are a UUID
+        Uuid::from_slice(&value)?;
+        Ok(Self(value))
     }
 }
 
@@ -63,8 +49,9 @@ impl TryFrom<Vec<u8>> for Identity {
     type Error = uuid::Error;
 
     fn try_from(value: Vec<u8>) -> Result<Self, Self::Error> {
-        let uuid = Uuid::from_slice(&value)?;
-        Ok(Self(Bytes::from(value), uuid))
+        // Validate bytes
+        Uuid::from_slice(&value)?;
+        Ok(Self(Bytes::from(value)))
     }
 }
 
@@ -72,11 +59,16 @@ impl Identity {
     /// Generate a new random identity.
     pub(crate) fn new() -> Self {
         let id = Uuid::new_v4();
-        Self(Bytes::from(id.as_bytes().to_vec()), id)
+        Self(Bytes::from(id.as_bytes().to_vec()))
     }
 
     pub(crate) fn as_bytes(&self) -> &Bytes {
         &self.0
+    }
+
+    // Parse this identity into a UUID.
+    pub(crate) fn as_uuid(&self) -> Uuid {
+        Uuid::from_slice(&self.0).unwrap()
     }
 }
 
@@ -193,7 +185,7 @@ impl PeerList {
 
     /// Return the UUIDs of all known peers.
     pub(crate) fn peer_uuids(&self) -> Vec<Uuid> {
-        self.list.keys().map(|v| **v).collect()
+        self.list.keys().map(|v| v.as_uuid()).collect()
     }
 
     /// Returns an iterator of all known peers in the peer list.
@@ -401,7 +393,7 @@ mod tests {
         let text = v.to_string();
 
         let uuid = Uuid::try_parse(&text).expect("display impl should output valid uuids");
-        assert_eq!(*v, uuid);
+        assert_eq!(v.as_uuid(), uuid);
     }
 
     fn hash_identity(v: &Identity) -> u64 {

--- a/gossip/src/reactor.rs
+++ b/gossip/src/reactor.rs
@@ -235,6 +235,9 @@ where
                         Some(Request::GetPeers(tx)) => {
                             let _ = tx.send(self.peer_list.peer_identities());
                         },
+                        Some(Request::GetPeerAddr(identity, tx)) => {
+                            let _ = tx.send(self.peer_list.get(&identity).map(|v| v.addr()));
+                        },
                         Some(Request::Broadcast(payload, topic, subset)) => {
                             // The user is guaranteed MAX_USER_PAYLOAD_BYTES to
                             // be send-able, so send this frame without packing

--- a/gossip/src/reactor.rs
+++ b/gossip/src/reactor.rs
@@ -233,7 +233,7 @@ where
                             return;
                         }
                         Some(Request::GetPeers(tx)) => {
-                            let _ = tx.send(self.peer_list.peer_uuids());
+                            let _ = tx.send(self.peer_list.peer_identities());
                         },
                         Some(Request::Broadcast(payload, topic, subset)) => {
                             // The user is guaranteed MAX_USER_PAYLOAD_BYTES to

--- a/gossip/src/reactor.rs
+++ b/gossip/src/reactor.rs
@@ -360,7 +360,7 @@ where
                     if self.interests.is_interested(topic) {
                         match S::try_from(topic.as_id()) {
                             Ok(v) => {
-                                self.dispatch.dispatch(v, data).await;
+                                self.dispatch.dispatch(v, data, identity.clone()).await;
                             }
                             Err(e) => {
                                 error!(error=?e, "dropping message for invalid topic");

--- a/gossip/tests/smoke.rs
+++ b/gossip/tests/smoke.rs
@@ -711,3 +711,57 @@ async fn test_broadcast_subset() {
     assert_eq!(b_rx.try_recv(), Err(TryRecvError::Empty));
     assert_eq!(c_rx.try_recv(), Err(TryRecvError::Empty));
 }
+
+/// Assert that subset broadcasts are sent to a portion of the peers.
+#[tokio::test]
+async fn test_sender_ident() {
+    maybe_start_logging();
+
+    struct Dispatch(mpsc::Sender<Identity>);
+    #[async_trait::async_trait]
+    impl<T: TryFrom<u64> + Send + Sync + 'static> Dispatcher<T> for Dispatch {
+        async fn dispatch(&self, _topic: T, _payload: Bytes, sender: Identity) {
+            self.0.send(sender).await.unwrap();
+        }
+    }
+
+    let metrics = Arc::new(metric::Registry::default());
+
+    let (a_socket, a_addr) = random_udp().await;
+    let (b_socket, b_addr) = random_udp().await;
+
+    // Initialise the dispatchers for the reactors
+    let (a_tx, _a_rx) = mpsc::channel(5);
+    let (b_tx, mut b_rx) = mpsc::channel(5);
+
+    // Initialise all reactors
+    let addrs = vec![a_addr.to_string(), b_addr.to_string()];
+    let a = Builder::<_, Topic>::new(addrs.clone(), a_tx, Arc::clone(&metrics)).build(a_socket);
+    let b = Builder::<_, Topic>::new(addrs.clone(), Dispatch(b_tx), Arc::clone(&metrics))
+        .build(b_socket);
+
+    // Wait for peer discovery to occur
+    async {
+        loop {
+            if a.get_peers().await.len() == 1 && b.get_peers().await.len() == 1 {
+                break;
+            }
+        }
+    }
+    .with_timeout_panic(TIMEOUT)
+    .await;
+
+    // Send the payload through peer A to a subset of peers.
+    let a_payload = Bytes::from_static(b"bananas");
+    a.broadcast_subset(a_payload.clone(), Topic::Bananas)
+        .await
+        .unwrap();
+
+    let got_ident = b_rx
+        .recv()
+        .with_timeout_panic(TIMEOUT)
+        .await
+        .expect("reactor should be running");
+
+    assert_eq!(a.identity(), got_ident);
+}

--- a/gossip/tests/smoke.rs
+++ b/gossip/tests/smoke.rs
@@ -764,4 +764,12 @@ async fn test_sender_ident() {
         .expect("reactor should be running");
 
     assert_eq!(a.identity(), got_ident);
+
+    // Validate the "get socket address" API using the identity
+    let expect_addr = b
+        .get_peer_addr(got_ident)
+        .await
+        .expect("a must exist in peer list");
+
+    assert_eq!(expect_addr, a_addr);
 }

--- a/gossip_parquet_file/src/rx.rs
+++ b/gossip_parquet_file/src/rx.rs
@@ -10,6 +10,7 @@ use generated_types::influxdata::iox::{
     gossip::{v1::NewParquetFile, Topic},
 };
 use generated_types::prost::Message;
+use gossip::Identity;
 use observability_deps::tracing::{info, warn};
 use tokio::{sync::mpsc, task::JoinHandle};
 
@@ -71,7 +72,7 @@ impl ParquetFileRx {
 
 #[async_trait]
 impl gossip::Dispatcher<Topic> for ParquetFileRx {
-    async fn dispatch(&self, topic: Topic, payload: Bytes) {
+    async fn dispatch(&self, topic: Topic, payload: Bytes, _sender: Identity) {
         if topic != Topic::NewParquetFiles {
             return;
         }

--- a/gossip_schema/src/dispatcher.rs
+++ b/gossip_schema/src/dispatcher.rs
@@ -10,6 +10,7 @@ use generated_types::influxdata::iox::gossip::{
     Topic,
 };
 use generated_types::prost::Message;
+use gossip::Identity;
 use observability_deps::tracing::{info, warn};
 use tokio::{sync::mpsc, task::JoinHandle};
 
@@ -71,7 +72,7 @@ impl SchemaRx {
 
 #[async_trait]
 impl gossip::Dispatcher<Topic> for SchemaRx {
-    async fn dispatch(&self, topic: Topic, payload: Bytes) {
+    async fn dispatch(&self, topic: Topic, payload: Bytes, _sender: Identity) {
         if topic != Topic::SchemaChanges {
             return;
         }


### PR DESCRIPTION
When a callback receives a message, provide it with the opaque peer identity of the sender.

76dafa511 allows a caller to use this identity to discover the sender's socket address, which can be used as a simple primitive for discovering service addresses.

We'll use gossip to have the routers say "hey, do we need to perform a sync round?" to converge cache state, and if the answer is "yes", we'll use this identity / socket address lookup functionality to derive the RPC address of the peer, and then use a TCP-based RPC interface to reliably perform the actual sync operation.

---

* refactor(gossip): remove Uuid from Identity (f81f6efb2)
      
      The identity contains both a UUID, and the byte representation of this
      UUID. This change retains the latter, generating the former on-demand
      (which is rarely needed).
      
      This halves the size of the identity, and the underlying Bytes storage
      is a ref-counted container, making clones very cheap.

* feat(gossip): expose sender identity in Dispatcher (20d63b8aa)
      
      When the gossip subsystem hands an application payload off to the
      Dispatcher impl, include the sender's Identity.

* refactor(gossip): Identity in API, not UUID (507739f9f)
      
      Swap all uses of UUID in the gossip API for the Identity, allowing the
      caller to parse into the UUID format if needed, and not forcing it on
      them.

* test(gossip): sender identity (1737ce045)
      
      Ensure the correct Identity is provided to the payload Dispatcher.

* feat(gossip): peer socket address lookup (76dafa511)
      
      This allows a caller to obtain the socket address of a peer identity,
      and therefore the address from which a message came from.
      
      I think the use cases of this are pretty slim (which is why I purposely
      kept the concept of peers out of the handle) but it definitely is useful
      as a primitive service discovery directory.