### PR TITLE
feat(cli): Queries for namespaces and tables should return their `PartitionTemplate`

### DIFF
--- a/generated_types/protos/influxdata/iox/namespace/v1/service.proto
+++ b/generated_types/protos/influxdata/iox/namespace/v1/service.proto
@@ -111,4 +111,8 @@ message Namespace {
 
   // The maximum number of columns a table belonging to this namespace may have.
   int32 max_columns_per_table = 5;
+
+  // The default partitioning scheme used for any new tables that are created
+  // in this namespace, if any.
+  optional influxdata.iox.partition_template.v1.PartitionTemplate partition_template = 6;
 }

--- a/generated_types/protos/influxdata/iox/table/v1/service.proto
+++ b/generated_types/protos/influxdata/iox/table/v1/service.proto
@@ -37,4 +37,7 @@ message Table {
 
   // Namespace ID
   int64 namespace_id = 3;
+  
+  // The partitioning scheme applied to writes for this table
+  influxdata.iox.partition_template.v1.PartitionTemplate partition_template = 4;
 }

--- a/influxdb_iox/tests/end_to_end_cases/cli/helpers.rs
+++ b/influxdb_iox/tests/end_to_end_cases/cli/helpers.rs
@@ -260,6 +260,20 @@ impl NamespaceCmd {
                 expected_output = BoxPredicate::new(expected_output.and(predicate::str::contains(
                     format!(r#""maxColumnsPerTable": {expected_max_columns_per_table}"#),
                 )));
+
+                match self.partition_template.clone() {
+                    Some(_) => {
+                        expected_output = BoxPredicate::new(
+                            expected_output
+                                .and(predicate::str::contains(format!(r#""partitionTemplate":"#))),
+                        );
+                    }
+                    None => {
+                        expected_output = BoxPredicate::new(expected_output.and(
+                            predicate::str::contains(format!(r#""partitionTemplate":"#)).not(),
+                        ));
+                    }
+                };
             }
         }
 

--- a/influxdb_iox/tests/end_to_end_cases/cli/namespace.rs
+++ b/influxdb_iox/tests/end_to_end_cases/cli/namespace.rs
@@ -441,7 +441,7 @@ async fn create_partition_template_implicit_table_creation() {
                     NamespaceCmd::new("create", NAMESPACE_NAME)
                         .with_partition_template(
                             "{\"parts\":[\
-                            {\"timeFormat\":\"%Y-%m\"}, \
+                            {\"timeFormat\":\"%Y-%m\"},\
                             {\"tagValue\":\"location\"}\
                         ]}",
                         )

--- a/influxdb_iox/tests/end_to_end_cases/cli/table.rs
+++ b/influxdb_iox/tests/end_to_end_cases/cli/table.rs
@@ -231,7 +231,10 @@ async fn create_positive() {
                         .arg("t1")
                         .assert()
                         .success()
-                        .stdout(predicate::str::contains("t1"));
+                        .stdout(
+                            predicate::str::contains("t1")
+                                .and(predicate::str::contains(r#""partitionTemplate":"#).not()),
+                        );
 
                     // Partition template with time format
                     Command::cargo_bin("influxdb_iox")
@@ -246,7 +249,10 @@ async fn create_positive() {
                         .arg("{\"parts\":[{\"timeFormat\":\"%Y-%m\"}]}")
                         .assert()
                         .success()
-                        .stdout(predicate::str::contains("t2"));
+                        .stdout(
+                            predicate::str::contains("t2")
+                                .and(predicate::str::contains(r#""partitionTemplate":"#)),
+                        );
 
                     // Partition template with tag
                     Command::cargo_bin("influxdb_iox")
@@ -261,7 +267,10 @@ async fn create_positive() {
                         .arg("{\"parts\":[{\"tagValue\":\"col1\"}]}")
                         .assert()
                         .success()
-                        .stdout(predicate::str::contains("t3"));
+                        .stdout(
+                            predicate::str::contains("t3")
+                                .and(predicate::str::contains(r#""partitionTemplate":"#)),
+                        );
 
                     // Partition template with time format, tag value, and tag of unsual column name
                     Command::cargo_bin("influxdb_iox")
@@ -282,7 +291,10 @@ async fn create_positive() {
                         )
                         .assert()
                         .success()
-                        .stdout(predicate::str::contains("t4"));
+                        .stdout(
+                            predicate::str::contains("t4")
+                                .and(predicate::str::contains(r#""partitionTemplate":"#)),
+                        );
                 }
                 .boxed()
             })),

--- a/ioxd_querier/src/rpc/namespace.rs
+++ b/ioxd_querier/src/rpc/namespace.rs
@@ -38,6 +38,7 @@ fn namespace_to_proto(namespace: Namespace) -> proto::Namespace {
         retention_period_ns: namespace.retention_period_ns,
         max_tables: namespace.max_tables,
         max_columns_per_table: namespace.max_columns_per_table,
+        partition_template: namespace.partition_template.as_proto().cloned(),
     }
 }
 
@@ -186,6 +187,7 @@ mod tests {
                         retention_period_ns: TEST_RETENTION_PERIOD_NS,
                         max_tables: TEST_MAX_TABLES,
                         max_columns_per_table: TEST_MAX_COLUMNS_PER_TABLE,
+                        partition_template: None,
                     },
                     proto::Namespace {
                         id: 2,
@@ -193,6 +195,7 @@ mod tests {
                         retention_period_ns: TEST_RETENTION_PERIOD_NS,
                         max_tables: TEST_MAX_TABLES,
                         max_columns_per_table: TEST_MAX_COLUMNS_PER_TABLE,
+                        partition_template: None,
                     },
                 ]
             }


### PR DESCRIPTION
Closes #8576.

Just a small one to expose partition templates for namespaces and their tables through the current set of proto interfaces. Follow up PRs for new commands and requests will continue to do so for any new methods 👍 

---

* feat(namespace): Return namespace custom partition templates to API (e6ab51a2d)

      This exposes the custom partitionining scheme of a namespace (if any)
      in the response to namespace create and list calls.

* feat(table): Return PartitionTemplate in table create proto response (125135399)

      If tables can be created with a custom partition template (or the namespace
      has a custom partition template) then this should be exposed to the user
      interacting with it through the CLI too!