### PR TITLE
refactor(proto): unsigned port numbers

### DIFF
--- a/generated_types/protos/influxdata/iox/gossip/v1/schema_sync.proto
+++ b/generated_types/protos/influxdata/iox/gossip/v1/schema_sync.proto
@@ -10,5 +10,5 @@ message SyncMessage {
   //
   // Peers will combine this port with the source address of gossip frames to
   // derive the gRPC address for sync operations.
-  int32 grpc_port = 2;
+  uint32 grpc_port = 2;
 }


### PR DESCRIPTION
🥔 

---

* refactor(proto): unsigned port numbers (3a2e70157)
      
      I was trying to remember what the notation for integer types was in
      proto - -1 is not a port number...