### PR TITLE
feat(cli): Add `table list <DATABASE>` command

### DIFF
--- a/influxdb_iox/src/commands/table/create.rs
+++ b/influxdb_iox/src/commands/table/create.rs
@@ -4,7 +4,7 @@ use influxdb_iox_client::connection::Connection;
 /// Write data into the specified database
 #[derive(Debug, clap::Parser, Default, Clone)]
 pub struct Config {
-    /// The namespace of the table
+    /// The database to create the table within
     #[clap(action)]
     database: String,
 

--- a/influxdb_iox/src/commands/table/list.rs
+++ b/influxdb_iox/src/commands/table/list.rs
@@ -1,0 +1,19 @@
+use crate::commands::table::Error;
+use influxdb_iox_client::connection::Connection;
+
+/// List tables within the specified database
+#[derive(Debug, clap::Parser, Default, Clone)]
+pub struct Config {
+    /// The database to display the list of tables for
+    #[clap(action)]
+    database: String,
+}
+
+pub async fn command(connection: Connection, config: Config) -> Result<(), Error> {
+    let mut client = influxdb_iox_client::table::Client::new(connection);
+
+    let tables = client.get_tables(&config.database).await?;
+    println!("{}", serde_json::to_string_pretty(&tables)?);
+
+    Ok(())
+}

--- a/influxdb_iox/src/commands/table/mod.rs
+++ b/influxdb_iox/src/commands/table/mod.rs
@@ -5,6 +5,7 @@ use observability_deps::tracing::info;
 use thiserror::Error;
 
 mod create;
+mod list;
 
 #[allow(clippy::enum_variant_names)]
 #[derive(Debug, Error)]
@@ -28,12 +29,15 @@ pub struct Config {
 /// All possible subcommands for table
 #[derive(Debug, clap::Parser)]
 enum Command {
+    /// List tables in a given database
+    List(list::Config),
     /// Create a new table
     Create(create::Config),
 }
 
 pub async fn command(connection: Connection, config: Config) -> Result<()> {
     match config.command {
+        Command::List(config) => list::command(connection, config).await?,
         Command::Create(config) => {
             info!("Creating table with config: {:?}", config);
             create::command(connection, config).await?;

--- a/influxdb_iox_client/src/client/table.rs
+++ b/influxdb_iox_client/src/client/table.rs
@@ -27,6 +27,18 @@ impl Client {
         }
     }
 
+    /// Fetch the list of tables in the given namespace
+    pub async fn get_tables(&mut self, namespace_name: &str) -> Result<Vec<Table>, Error> {
+        Ok(self
+            .inner
+            .get_tables(GetTablesRequest {
+                namespace_name: namespace_name.to_string(),
+            })
+            .await?
+            .into_inner()
+            .tables)
+    }
+
     /// Create a table
     pub async fn create_table(
         &mut self,


### PR DESCRIPTION
This will close #8618. This uses the `<DATABASE>` terminology in the help text, as that seems to be what the `table create` command intended. The proto types amongst other bits use `namespaceId` still though 😅 

Looks something like this:

```shell
% influxdb_iox table list bananas_database
[
  {
    "id": "1",
    "name": "platanos",
    "namespaceId": "1"
  },
  {
    "id": "2",
    "name": "ananas",
    "namespaceId": "1"
  },
  {
    "id": "3",
    "name": "bananas",
    "namespaceId": "1",
    "partitionTemplate": {
      "parts": [
        {
          "timeFormat": "%Y-%m"
        },
        {
          "tagValue": "great"
        }
      ]
    }
  }
]
```

---

* feat(cli): Add `table list <DATABASE>` command (2a396c1b7)

      This commit hooks the influxdb_iox_client and CLI up to the new
      `GetTables` gRPC endpoint on the `TableService`, allowing users to
      query a list of tables within a database and consequently see any
      custom partitioning schemes.

* test(cli): Add e2e test for `table list` command (00873fac0)


* docs(cli): Table create should have help text match arg for database (4ff3998c2)
