### PR TITLE
chore: apply proto lints to ingester->query gRPC

### DIFF
--- a/buf.yaml
+++ b/buf.yaml
@@ -3,6 +3,7 @@ version: v1beta1
 build:
   roots:
     - generated_types/protos/
+    - ingester_query_grpc/protos/
 
 lint:
   allow_comment_ignores: true


### PR DESCRIPTION
We should catch breaking changes for the ingester->querier protobufs as well.