### PR TITLE
feat(gossip): define CompactionEvent protobuf

### DIFF
--- a/generated_types/build.rs
+++ b/generated_types/build.rs
@@ -57,6 +57,7 @@ fn generate_grpc_types(root: &Path) -> Result<()> {
         catalog_path.join("service.proto"),
         compactor_path.join("service.proto"),
         delete_path.join("service.proto"),
+        gossip_path.join("compaction.proto"),
         gossip_path.join("parquet_file.proto"),
         gossip_path.join("schema.proto"),
         gossip_path.join("schema_sync.proto"),

--- a/generated_types/protos/influxdata/iox/gossip/v1/compaction.proto
+++ b/generated_types/protos/influxdata/iox/gossip/v1/compaction.proto
@@ -1,0 +1,31 @@
+syntax = "proto3";
+package influxdata.iox.gossip.v1;
+option go_package = "github.com/influxdata/iox/gossip/v1";
+
+import "influxdata/iox/catalog/v1/parquet_file.proto";
+
+// Notification of a compaction round completion.
+//
+// This message defines the output of the compaction round - the files deleted,
+// upgraded, and created. Deleted and upgraded files are addressed by their
+// catalog row IDs ("parquet file ID"), while newly created files are provided
+// with their enitre metadata.
+//
+// # Atomicity
+//
+// This message is atomic - it describes the output of a single compaction job
+// in its entirety. It is never split into multiple messages.
+message CompactionEvent { 
+  // Files that were deleted by this compaction event, addressed by their
+  // parquet row ID in the catalog.
+  repeated int64 deleted_file_ids = 1;
+
+  // The set of parquet catalog row IDs that were upgraded to
+  // `upgraded_target_level` as part of this compaction event.
+  int64 upgraded_target_level = 2;
+  repeated int64 updated_file_ids = 3;
+
+  // The set of newly created parquet files that were output by this compaction
+  // event.
+  repeated influxdata.iox.catalog.v1.ParquetFile new_files = 4;
+}

--- a/generated_types/protos/influxdata/iox/gossip/v1/compaction.proto
+++ b/generated_types/protos/influxdata/iox/gossip/v1/compaction.proto
@@ -9,13 +9,13 @@ import "influxdata/iox/catalog/v1/parquet_file.proto";
 // This message defines the output of the compaction round - the files deleted,
 // upgraded, and created. Deleted and upgraded files are addressed by their
 // catalog row IDs ("parquet file ID"), while newly created files are provided
-// with their enitre metadata.
+// with their entire metadata.
 //
 // # Atomicity
 //
 // This message is atomic - it describes the output of a single compaction job
 // in its entirety. It is never split into multiple messages.
-message CompactionEvent { 
+message CompactionEvent {
   // Files that were deleted by this compaction event, addressed by their
   // parquet row ID in the catalog.
   repeated int64 deleted_file_ids = 1;


### PR DESCRIPTION
Define the gossip message schema that'll be sent when a compaction completes.

This is aiming to enable https://github.com/influxdata/idpe/issues/17854 to increase query performance.

---

* feat(gossip): define CompactionEvent protobuf (855e8bb34)
      
      This commit adds the CompactionEvent protobuf type that'll be gossiped
      between peers to provide a (compact) description of completed
      compactions.