### PR TITLE
chore: revert queriers consume sort_key_ids

### DIFF
--- a/data_types/src/partition.rs
+++ b/data_types/src/partition.rs
@@ -514,8 +514,6 @@ impl Partition {
         self.hash_id.as_ref()
     }
 
-    // TODO: remove this function after all PRs that teach compactor, ingester,
-    // and querier to use sort_key_ids are merged.
     /// The sort key for the partition, if present, structured as a `SortKey`
     pub fn sort_key(&self) -> Option<SortKey> {
         if self.sort_key.is_empty() {
@@ -528,20 +526,6 @@ impl Partition {
     /// The sort_key_ids if present
     pub fn sort_key_ids(&self) -> Option<&SortedColumnSet> {
         self.sort_key_ids.as_ref()
-    }
-
-    /// The sort_key_ids if present and not empty
-    pub fn sort_key_ids_none_if_empty(&self) -> Option<SortedColumnSet> {
-        match self.sort_key_ids.as_ref() {
-            None => None,
-            Some(sort_key_ids) => {
-                if sort_key_ids.is_empty() {
-                    None
-                } else {
-                    Some(sort_key_ids.clone())
-                }
-            }
-        }
     }
 }
 

--- a/querier/src/cache/partition.rs
+++ b/querier/src/cache/partition.rs
@@ -17,7 +17,7 @@ use cache_system::{
 };
 use data_types::{
     partition_template::{build_column_values, ColumnValue},
-    ColumnId, Partition, SortedColumnSet, TransitionPartitionId,
+    ColumnId, Partition, TransitionPartitionId,
 };
 use datafusion::scalar::ScalarValue;
 use iox_catalog::{interface::Catalog, partition_lookup_batch};
@@ -251,18 +251,9 @@ pub struct CachedPartition {
 
 impl CachedPartition {
     fn new(partition: Partition, table: &CachedTable) -> Self {
-        // build sort_key from the partition's sort_key_ids and table columns
-        let sort_key = partition.sort_key_ids_none_if_empty().map(|sort_key_ids| {
-            Arc::new(PartitionSortKey::new(sort_key_ids, &table.column_id_map))
-        });
-
-        // This is here to catch bugs if any while mapping sort_key_ids to column names
-        // This wil be removed once sort_key is removed from partition
-        let p_sort_key = partition.sort_key();
-        assert_eq!(
-            sort_key.as_ref().map(|sk| sk.sort_key.as_ref()),
-            p_sort_key.as_ref()
-        );
+        let sort_key = partition
+            .sort_key()
+            .map(|sort_key| Arc::new(PartitionSortKey::new(sort_key, &table.column_id_map_rev)));
 
         let mut column_ranges =
             build_column_values(&table.partition_template, partition.partition_key.inner())
@@ -360,25 +351,23 @@ pub struct PartitionSortKey {
 }
 
 impl PartitionSortKey {
-    fn new(sort_key_ids: SortedColumnSet, column_id_map: &HashMap<ColumnId, Arc<str>>) -> Self {
-        let column_order: Box<[ColumnId]> = sort_key_ids.iter().copied().collect();
+    fn new(sort_key: SortKey, column_id_map_rev: &HashMap<Arc<str>, ColumnId>) -> Self {
+        let sort_key = Arc::new(sort_key);
 
-        // build sort_key from the column order
-        let sort_key = SortKey::from_columns(
-            column_order
-                .iter()
-                .map(|c_id| {
-                    column_id_map.get(c_id).unwrap_or_else(|| {
-                        panic!("column_id_map misses data for column id: {}", c_id.get())
-                    })
-                })
-                .cloned(),
-        );
+        let column_order: Box<[ColumnId]> = sort_key
+            .iter()
+            .map(|(name, _opts)| {
+                *column_id_map_rev
+                    .get(name.as_ref())
+                    .unwrap_or_else(|| panic!("column_id_map_rev misses data: {name}"))
+            })
+            .collect();
 
-        let column_set: HashSet<ColumnId> = column_order.iter().copied().collect();
+        let mut column_set: HashSet<ColumnId> = column_order.iter().copied().collect();
+        column_set.shrink_to_fit();
 
         Self {
-            sort_key: Arc::new(sort_key),
+            sort_key,
             column_set,
             column_order,
         }
@@ -1039,84 +1028,6 @@ mod tests {
         for _ in 0..10 {
             test_multi_table_concurrent_get_inner().await;
         }
-    }
-
-    #[test]
-    fn test_partition_sort_key() {
-        // map column id -> name
-        let column_id_map = HashMap::from([
-            (ColumnId::new(1), Arc::from("tag1")),
-            (ColumnId::new(2), Arc::from("tag2")),
-            (ColumnId::new(3), Arc::from("tag3")),
-            (ColumnId::new(4), Arc::from("time")),
-            (ColumnId::new(5), Arc::from("field1")),
-            (ColumnId::new(6), Arc::from("field2")),
-        ]);
-
-        // same order of the columns
-        let sort_key_ids = SortedColumnSet::from(vec![1, 2, 3, 4]);
-        let p_sort_key = PartitionSortKey::new(sort_key_ids, &column_id_map);
-        assert_eq!(
-            p_sort_key,
-            PartitionSortKey {
-                sort_key: Arc::new(SortKey::from_columns(vec!["tag1", "tag2", "tag3", "time"])),
-                column_set: HashSet::from([
-                    ColumnId::new(1),
-                    ColumnId::new(2),
-                    ColumnId::new(3),
-                    ColumnId::new(4)
-                ]),
-                column_order: [
-                    ColumnId::new(1),
-                    ColumnId::new(2),
-                    ColumnId::new(3),
-                    ColumnId::new(4)
-                ]
-                .into(),
-            }
-        );
-
-        // different order
-        let sort_key_ids = SortedColumnSet::from(vec![3, 1, 4]);
-        let p_sort_key = PartitionSortKey::new(sort_key_ids, &column_id_map);
-        assert_eq!(
-            p_sort_key,
-            PartitionSortKey {
-                sort_key: Arc::new(SortKey::from_columns(vec!["tag3", "tag1", "time"])),
-                column_set: HashSet::from([ColumnId::new(3), ColumnId::new(1), ColumnId::new(4)]),
-                column_order: [ColumnId::new(3), ColumnId::new(1), ColumnId::new(4)].into(),
-            }
-        );
-
-        // only time
-        let sort_key_ids = SortedColumnSet::from(vec![4]);
-        let p_sort_key = PartitionSortKey::new(sort_key_ids, &column_id_map);
-        assert_eq!(
-            p_sort_key,
-            PartitionSortKey {
-                sort_key: Arc::new(SortKey::from_columns(vec!["time"])),
-                column_set: HashSet::from([ColumnId::new(4)]),
-                column_order: [ColumnId::new(4)].into(),
-            }
-        );
-    }
-
-    #[test]
-    #[should_panic(expected = "column_id_map misses data for column id: 9")]
-    fn test_partition_sort_key_panic() {
-        // map column id -> name
-        let column_id_map = HashMap::from([
-            (ColumnId::new(1), Arc::from("tag1")),
-            (ColumnId::new(2), Arc::from("tag2")),
-            (ColumnId::new(3), Arc::from("tag3")),
-            (ColumnId::new(4), Arc::from("time")),
-            (ColumnId::new(5), Arc::from("field1")),
-            (ColumnId::new(6), Arc::from("field2")),
-        ]);
-
-        // same order of the columns
-        let sort_key_ids = SortedColumnSet::from(vec![1, 9]);
-        let _sort_key = PartitionSortKey::new(sort_key_ids, &column_id_map);
     }
 
     /// Actually implementation of [`test_multi_table_concurrent_get`] that is tried multiple times.

--- a/querier/src/parquet/creation.rs
+++ b/querier/src/parquet/creation.rs
@@ -142,7 +142,7 @@ impl ChunkAdapter {
     ) -> QuerierParquetChunk {
         // NOTE: Because we've looked up the sort key AFTER the namespace schema, it may contain columns for which we
         //       don't have any schema information yet. This is OK because we've ensured that all file columns are known
-        //       within the schema and if a column is NOT part of the file, it will also not be part of the chunk sort
+        //       withing the schema and if a column is NOT part of the file, it will also not be part of the chunk sort
         //       key, so we have consistency here.
 
         // NOTE: The schema that we've projected here may have a different column order than the actual parquet file. This


### PR DESCRIPTION
Just in case https://github.com/influxdata/influxdb_iox/pull/8604 does not work as expected


- [ ] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb_iox/blob/main/README.md).
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
