### PR TITLE
refactor(proto): SyncMessage -> ConsistencyProbe

### DIFF
--- a/generated_types/protos/influxdata/iox/gossip/v1/schema_sync.proto
+++ b/generated_types/protos/influxdata/iox/gossip/v1/schema_sync.proto
@@ -2,7 +2,8 @@ syntax = "proto3";
 package influxdata.iox.gossip.v1;
 option go_package = "github.com/influxdata/iox/gossip/v1";
 
-message SyncMessage {
+// A gossip frame sent to peers to begin a sync round / consistency check.
+message ConsistencyProbe {
   // A 16-byte Merkle Search Tree root hash convering the schema cache content.
   bytes root_hash = 1;
 


### PR DESCRIPTION
Names are important.

---

* refactor(proto): SyncMessage -> ConsistencyProbe (96d099a29)
      
      Rename "SyncMessage" to "ConsistencyProbe" - it's a clearer name for the
      use - the message does no syncing!