### PR TITLE
refactor: move table metadata alongside resolver

### DIFF
--- a/ingester/src/buffer_tree/partition.rs
+++ b/ingester/src/buffer_tree/partition.rs
@@ -15,7 +15,7 @@ use self::{
     persisting::{BatchIdent, PersistingData},
     persisting_list::PersistingList,
 };
-use super::{namespace::NamespaceName, table::TableMetadata};
+use super::{namespace::NamespaceName, table::metadata::TableMetadata};
 use crate::{
     deferred_load::DeferredLoad, query::projection::OwnedProjection, query_adaptor::QueryAdaptor,
 };

--- a/ingester/src/buffer_tree/partition/resolver/cache.rs
+++ b/ingester/src/buffer_tree/partition/resolver/cache.rs
@@ -12,7 +12,7 @@ use crate::{
     buffer_tree::{
         namespace::NamespaceName,
         partition::{resolver::SortKeyResolver, PartitionData, SortKeyState},
-        table::TableMetadata,
+        table::metadata::TableMetadata,
     },
     deferred_load::DeferredLoad,
 };

--- a/ingester/src/buffer_tree/partition/resolver/catalog.rs
+++ b/ingester/src/buffer_tree/partition/resolver/catalog.rs
@@ -15,7 +15,7 @@ use crate::{
     buffer_tree::{
         namespace::NamespaceName,
         partition::{PartitionData, SortKeyState},
-        table::TableMetadata,
+        table::metadata::TableMetadata,
     },
     deferred_load::DeferredLoad,
 };
@@ -113,7 +113,7 @@ mod tests {
     };
 
     use super::*;
-    use crate::buffer_tree::table::TableName;
+    use crate::buffer_tree::table::metadata::TableName;
 
     const TABLE_NAME: &str = "bananas";
     const NAMESPACE_NAME: &str = "ns-bananas";

--- a/ingester/src/buffer_tree/partition/resolver/coalesce.rs
+++ b/ingester/src/buffer_tree/partition/resolver/coalesce.rs
@@ -13,7 +13,9 @@ use hashbrown::{hash_map::Entry, HashMap};
 use parking_lot::Mutex;
 
 use crate::{
-    buffer_tree::{namespace::NamespaceName, partition::PartitionData, table::TableMetadata},
+    buffer_tree::{
+        namespace::NamespaceName, partition::PartitionData, table::metadata::TableMetadata,
+    },
     deferred_load::DeferredLoad,
 };
 

--- a/ingester/src/buffer_tree/partition/resolver/mock.rs
+++ b/ingester/src/buffer_tree/partition/resolver/mock.rs
@@ -8,7 +8,9 @@ use parking_lot::Mutex;
 
 use super::r#trait::PartitionProvider;
 use crate::{
-    buffer_tree::{namespace::NamespaceName, partition::PartitionData, table::TableMetadata},
+    buffer_tree::{
+        namespace::NamespaceName, partition::PartitionData, table::metadata::TableMetadata,
+    },
     deferred_load::{self, DeferredLoad},
 };
 

--- a/ingester/src/buffer_tree/partition/resolver/old_filter.rs
+++ b/ingester/src/buffer_tree/partition/resolver/old_filter.rs
@@ -15,7 +15,7 @@ use crate::{
     buffer_tree::{
         namespace::NamespaceName,
         partition::{resolver::SortKeyResolver, PartitionData, SortKeyState},
-        table::TableMetadata,
+        table::metadata::TableMetadata,
     },
     deferred_load::DeferredLoad,
 };

--- a/ingester/src/buffer_tree/partition/resolver/trait.rs
+++ b/ingester/src/buffer_tree/partition/resolver/trait.rs
@@ -5,7 +5,9 @@ use data_types::{NamespaceId, PartitionKey, TableId};
 use parking_lot::Mutex;
 
 use crate::{
-    buffer_tree::{namespace::NamespaceName, partition::PartitionData, table::TableMetadata},
+    buffer_tree::{
+        namespace::NamespaceName, partition::PartitionData, table::metadata::TableMetadata,
+    },
     deferred_load::DeferredLoad,
 };
 

--- a/ingester/src/buffer_tree/root.rs
+++ b/ingester/src/buffer_tree/root.rs
@@ -99,7 +99,7 @@ pub(crate) struct BufferTree<O> {
     /// The [`TableMetadata`] provider used by [`NamespaceData`] to initialise a
     /// [`TableData`].
     ///
-    /// [`TableMetadata`]: crate::buffer_tree::table::TableMetadata
+    /// [`TableMetadata`]: crate::buffer_tree::table::metadata::TableMetadata
     /// [`TableData`]: crate::buffer_tree::table::TableData
     table_resolver: Arc<dyn TableProvider>,
 
@@ -257,7 +257,7 @@ mod tests {
             namespace::{name_resolver::mock::MockNamespaceNameProvider, NamespaceData},
             partition::resolver::mock::MockPartitionProvider,
             post_write::mock::MockPostWriteObserver,
-            table::{metadata_resolver::mock::MockTableProvider, TableMetadata},
+            table::{metadata::TableMetadata, metadata_resolver::mock::MockTableProvider},
         },
         deferred_load::{self, DeferredLoad},
         query::partition_response::PartitionResponse,

--- a/ingester/src/buffer_tree/table/metadata.rs
+++ b/ingester/src/buffer_tree/table/metadata.rs
@@ -1,0 +1,87 @@
+use std::sync::Arc;
+
+use data_types::{partition_template::TablePartitionTemplateOverride, Table};
+
+/// Metadata from the catalog for a table
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct TableMetadata {
+    name: TableName,
+    partition_template: TablePartitionTemplateOverride,
+}
+
+impl TableMetadata {
+    #[cfg(test)]
+    pub fn new_for_testing(
+        name: TableName,
+        partition_template: TablePartitionTemplateOverride,
+    ) -> Self {
+        Self {
+            name,
+            partition_template,
+        }
+    }
+
+    pub(crate) fn name(&self) -> &TableName {
+        &self.name
+    }
+
+    pub(crate) fn partition_template(&self) -> &TablePartitionTemplateOverride {
+        &self.partition_template
+    }
+}
+
+impl From<Table> for TableMetadata {
+    fn from(t: Table) -> Self {
+        Self {
+            name: t.name.into(),
+            partition_template: t.partition_template,
+        }
+    }
+}
+
+impl std::fmt::Display for TableMetadata {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::fmt::Display::fmt(&self.name, f)
+    }
+}
+
+/// The string name / identifier of a Table.
+///
+/// A reference-counted, cheap clone-able string.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(crate) struct TableName(Arc<str>);
+
+impl<T> From<T> for TableName
+where
+    T: AsRef<str>,
+{
+    fn from(v: T) -> Self {
+        Self(Arc::from(v.as_ref()))
+    }
+}
+
+impl From<TableName> for Arc<str> {
+    fn from(v: TableName) -> Self {
+        v.0
+    }
+}
+
+impl std::fmt::Display for TableName {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::fmt::Display::fmt(&self.0, f)
+    }
+}
+
+impl std::ops::Deref for TableName {
+    type Target = Arc<str>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl PartialEq<str> for TableName {
+    fn eq(&self, other: &str) -> bool {
+        &*self.0 == other
+    }
+}

--- a/ingester/src/buffer_tree/table/metadata_resolver.rs
+++ b/ingester/src/buffer_tree/table/metadata_resolver.rs
@@ -4,8 +4,9 @@ use backoff::{Backoff, BackoffConfig};
 use data_types::TableId;
 use iox_catalog::interface::Catalog;
 
-use super::TableMetadata;
 use crate::deferred_load::DeferredLoad;
+
+use super::metadata::TableMetadata;
 
 /// An abstract provider of a [`DeferredLoad`] configured to fetch the
 /// catalog [`TableMetadata`] of the specified [`TableId`].

--- a/ingester/src/persist/compact.rs
+++ b/ingester/src/persist/compact.rs
@@ -8,7 +8,7 @@ use iox_query::{
 };
 use schema::sort::{adjust_sort_key_columns, compute_sort_key, SortKey};
 
-use crate::{buffer_tree::table::TableName, query_adaptor::QueryAdaptor};
+use crate::{buffer_tree::table::metadata::TableName, query_adaptor::QueryAdaptor};
 
 /// Result of calling [`compact_persisting_batch`]
 pub(super) struct CompactedStream {

--- a/ingester/src/persist/context.rs
+++ b/ingester/src/persist/context.rs
@@ -16,7 +16,7 @@ use crate::{
     buffer_tree::{
         namespace::NamespaceName,
         partition::{persisting::PersistingData, PartitionData, SortKeyState},
-        table::TableMetadata,
+        table::metadata::TableMetadata,
     },
     deferred_load::DeferredLoad,
     persist::completion_observer::CompletedPersist,

--- a/ingester/src/test_util.rs
+++ b/ingester/src/test_util.rs
@@ -20,8 +20,8 @@ use crate::{
         },
         partition::{PartitionData, SortKeyState},
         table::{
+            metadata::{TableMetadata, TableName},
             metadata_resolver::{mock::MockTableProvider, TableProvider},
-            TableMetadata, TableName,
         },
     },
     deferred_load::DeferredLoad,


### PR DESCRIPTION
🧹 

This just moves the table metadata - no functional change.

---

* refactor: move table metadata alongside resolver (9379a227c)
      
      We already have a metadata resolver, so lets stick the metadata types
      next to it.