### PR TITLE
test: accept PartitionDataBuilder in provider

### DIFF
--- a/ingester/src/buffer_tree/namespace.rs
+++ b/ingester/src/buffer_tree/namespace.rs
@@ -255,9 +255,8 @@ mod tests {
 
         // Configure the mock partition provider to return a partition for this
         // table ID.
-        let partition_provider = Arc::new(
-            MockPartitionProvider::default().with_partition(PartitionDataBuilder::new().build()),
-        );
+        let partition_provider =
+            Arc::new(MockPartitionProvider::default().with_partition(PartitionDataBuilder::new()));
 
         let ns = NamespaceData::new(
             ARBITRARY_NAMESPACE_ID,

--- a/ingester/src/buffer_tree/partition/resolver/cache.rs
+++ b/ingester/src/buffer_tree/partition/resolver/cache.rs
@@ -249,8 +249,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_miss() {
-        let data = PartitionDataBuilder::new().build();
-        let inner = MockPartitionProvider::default().with_partition(data);
+        let inner = MockPartitionProvider::default().with_partition(PartitionDataBuilder::new());
 
         let cache = new_cache(inner, []);
         let got = cache
@@ -340,11 +339,8 @@ mod tests {
     async fn test_miss_partition_key() {
         let other_key = PartitionKey::from("test");
         let other_partition_id = TransitionPartitionId::new(ARBITRARY_TABLE_ID, &other_key);
-        let inner = MockPartitionProvider::default().with_partition(
-            PartitionDataBuilder::new()
-                .with_partition_key(other_key.clone())
-                .build(),
-        );
+        let inner = MockPartitionProvider::default()
+            .with_partition(PartitionDataBuilder::new().with_partition_key(other_key.clone()));
 
         let partition = Partition::new_in_memory_only(
             ARBITRARY_CATALOG_PARTITION_ID,
@@ -378,11 +374,8 @@ mod tests {
     async fn test_miss_table_id() {
         let other_table = TableId::new(1234);
         let other_partition_id = TransitionPartitionId::new(other_table, &ARBITRARY_PARTITION_KEY);
-        let inner = MockPartitionProvider::default().with_partition(
-            PartitionDataBuilder::new()
-                .with_table_id(other_table)
-                .build(),
-        );
+        let inner = MockPartitionProvider::default()
+            .with_partition(PartitionDataBuilder::new().with_table_id(other_table));
 
         let partition = Partition::new_in_memory_only(
             ARBITRARY_CATALOG_PARTITION_ID,

--- a/ingester/src/buffer_tree/partition/resolver/coalesce.rs
+++ b/ingester/src/buffer_tree/partition/resolver/coalesce.rs
@@ -286,11 +286,10 @@ mod tests {
     async fn test_coalesce() {
         const MAX_TASKS: usize = 50;
 
-        let data = PartitionDataBuilder::new().build();
-
         // Add a single instance of the partition - if more than one call is
         // made, this will cause a panic.
-        let inner = Arc::new(MockPartitionProvider::default().with_partition(data));
+        let inner =
+            Arc::new(MockPartitionProvider::default().with_partition(PartitionDataBuilder::new()));
         let layer = Arc::new(CoalescePartitionResolver::new(Arc::clone(&inner)));
 
         let results = (0..MAX_TASKS)

--- a/ingester/src/buffer_tree/partition/resolver/trait.rs
+++ b/ingester/src/buffer_tree/partition/resolver/trait.rs
@@ -70,8 +70,7 @@ mod tests {
 
         let data = PartitionDataBuilder::new()
             .with_table_loader(Arc::clone(&table_loader))
-            .with_namespace_loader(Arc::clone(&namespace_loader))
-            .build();
+            .with_namespace_loader(Arc::clone(&namespace_loader));
 
         let mock = Arc::new(MockPartitionProvider::default().with_partition(data));
 

--- a/ingester/src/buffer_tree/root.rs
+++ b/ingester/src/buffer_tree/root.rs
@@ -309,9 +309,8 @@ mod tests {
 
         // Configure the mock partition provider to return a partition for this
         // table ID.
-        let partition_provider = Arc::new(
-            MockPartitionProvider::default().with_partition(PartitionDataBuilder::new().build()),
-        );
+        let partition_provider =
+            Arc::new(MockPartitionProvider::default().with_partition(PartitionDataBuilder::new()));
 
         // Init the namespace
         let ns = NamespaceData::new(
@@ -464,9 +463,8 @@ mod tests {
     // A simple "read your writes" test.
     test_write_query!(
         read_writes,
-        partitions = [PartitionDataBuilder::new()
-            .with_partition_key(ARBITRARY_PARTITION_KEY.clone())
-            .build()],
+        partitions =
+            [PartitionDataBuilder::new().with_partition_key(ARBITRARY_PARTITION_KEY.clone())],
         writes = [make_write_op(
             &ARBITRARY_PARTITION_KEY,
             ARBITRARY_NAMESPACE_ID,
@@ -493,9 +491,8 @@ mod tests {
     test_write_query!(
         projection,
         projection = OwnedProjection::from(vec!["time", "region"]),
-        partitions = [PartitionDataBuilder::new()
-            .with_partition_key(ARBITRARY_PARTITION_KEY.clone())
-            .build()],
+        partitions =
+            [PartitionDataBuilder::new().with_partition_key(ARBITRARY_PARTITION_KEY.clone())],
         writes = [make_write_op(
             &ARBITRARY_PARTITION_KEY,
             ARBITRARY_NAMESPACE_ID,
@@ -522,9 +519,8 @@ mod tests {
     test_write_query!(
         projection_without_time,
         projection = OwnedProjection::from(vec!["region"]),
-        partitions = [PartitionDataBuilder::new()
-            .with_partition_key(ARBITRARY_PARTITION_KEY.clone())
-            .build()],
+        partitions =
+            [PartitionDataBuilder::new().with_partition_key(ARBITRARY_PARTITION_KEY.clone())],
         writes = [make_write_op(
             &ARBITRARY_PARTITION_KEY,
             ARBITRARY_NAMESPACE_ID,
@@ -552,12 +548,8 @@ mod tests {
     test_write_query!(
         multiple_partitions,
         partitions = [
-            PartitionDataBuilder::new()
-                .with_partition_key(ARBITRARY_PARTITION_KEY.clone())
-                .build(),
-            PartitionDataBuilder::new()
-                .with_partition_key(PARTITION2_KEY.clone())
-                .build()
+            PartitionDataBuilder::new().with_partition_key(ARBITRARY_PARTITION_KEY.clone()),
+            PartitionDataBuilder::new().with_partition_key(PARTITION2_KEY.clone())
         ],
         writes = [
             make_write_op(
@@ -601,14 +593,11 @@ mod tests {
     test_write_query!(
         filter_multiple_namespaces,
         partitions = [
-            PartitionDataBuilder::new()
-                .with_partition_key(ARBITRARY_PARTITION_KEY.clone())
-                .build(),
+            PartitionDataBuilder::new().with_partition_key(ARBITRARY_PARTITION_KEY.clone()),
             PartitionDataBuilder::new()
                 .with_partition_key(PARTITION2_KEY.clone())
                 .with_namespace_id(NAMESPACE2_ID) // A different namespace ID.
                 .with_table_id(TABLE2_ID) // A different table ID.
-                .build()
         ],
         writes = [
             make_write_op(
@@ -651,13 +640,10 @@ mod tests {
     test_write_query!(
         filter_multiple_tables,
         partitions = [
-            PartitionDataBuilder::new()
-                .with_partition_key(ARBITRARY_PARTITION_KEY.clone())
-                .build(),
+            PartitionDataBuilder::new().with_partition_key(ARBITRARY_PARTITION_KEY.clone()),
             PartitionDataBuilder::new()
                 .with_partition_key(PARTITION2_KEY.clone())
                 .with_table_id(TABLE2_ID) // A different table ID.
-                .build()
         ],
         writes = [
             make_write_op(
@@ -701,9 +687,8 @@ mod tests {
     // writes).
     test_write_query!(
         duplicate_writes,
-        partitions = [PartitionDataBuilder::new()
-            .with_partition_key(ARBITRARY_PARTITION_KEY.clone())
-            .build()],
+        partitions =
+            [PartitionDataBuilder::new().with_partition_key(ARBITRARY_PARTITION_KEY.clone())],
         writes = [
             make_write_op(
                 &ARBITRARY_PARTITION_KEY,
@@ -756,12 +741,8 @@ mod tests {
             test_table_partition_override(vec![TemplatePart::TagValue("region")])
         ))),
         partitions = [
-            PartitionDataBuilder::new()
-                .with_partition_key(ARBITRARY_PARTITION_KEY.clone()) // "platanos"
-                .build(),
-            PartitionDataBuilder::new()
-                .with_partition_key(PARTITION2_KEY.clone()) // "p2"
-                .build()
+            PartitionDataBuilder::new().with_partition_key(ARBITRARY_PARTITION_KEY.clone()), // "platanos"
+            PartitionDataBuilder::new().with_partition_key(PARTITION2_KEY.clone())           // "p2"
         ],
         writes = [
             make_write_op(
@@ -843,14 +824,10 @@ mod tests {
         let partition_provider = Arc::new(
             MockPartitionProvider::default()
                 .with_partition(
-                    PartitionDataBuilder::new()
-                        .with_partition_key(ARBITRARY_PARTITION_KEY.clone())
-                        .build(),
+                    PartitionDataBuilder::new().with_partition_key(ARBITRARY_PARTITION_KEY.clone()),
                 )
                 .with_partition(
-                    PartitionDataBuilder::new()
-                        .with_partition_key(PARTITION2_KEY.clone())
-                        .build(),
+                    PartitionDataBuilder::new().with_partition_key(PARTITION2_KEY.clone()),
                 ),
         );
 
@@ -914,16 +891,8 @@ mod tests {
     async fn test_partition_metadata_pruning() {
         let partition_provider = Arc::new(
             MockPartitionProvider::default()
-                .with_partition(
-                    PartitionDataBuilder::new()
-                        .with_partition_key("madrid".into())
-                        .build(),
-                )
-                .with_partition(
-                    PartitionDataBuilder::new()
-                        .with_partition_key("asturias".into())
-                        .build(),
-                ),
+                .with_partition(PartitionDataBuilder::new().with_partition_key("madrid".into()))
+                .with_partition(PartitionDataBuilder::new().with_partition_key("asturias".into())),
         );
 
         // Construct a partition template suitable for pruning on the "region"
@@ -1011,14 +980,10 @@ mod tests {
         let partition_provider = Arc::new(
             MockPartitionProvider::default()
                 .with_partition(
-                    PartitionDataBuilder::new()
-                        .with_partition_key(ARBITRARY_PARTITION_KEY.clone())
-                        .build(),
+                    PartitionDataBuilder::new().with_partition_key(ARBITRARY_PARTITION_KEY.clone()),
                 )
                 .with_partition(
-                    PartitionDataBuilder::new()
-                        .with_partition_key(PARTITION2_KEY.clone())
-                        .build(),
+                    PartitionDataBuilder::new().with_partition_key(PARTITION2_KEY.clone()),
                 ),
         );
 
@@ -1092,14 +1057,10 @@ mod tests {
         let partition_provider = Arc::new(
             MockPartitionProvider::default()
                 .with_partition(
-                    PartitionDataBuilder::new()
-                        .with_partition_key(ARBITRARY_PARTITION_KEY.clone())
-                        .build(),
+                    PartitionDataBuilder::new().with_partition_key(ARBITRARY_PARTITION_KEY.clone()),
                 )
                 .with_partition(
-                    PartitionDataBuilder::new()
-                        .with_partition_key(PARTITION2_KEY.clone())
-                        .build(),
+                    PartitionDataBuilder::new().with_partition_key(PARTITION2_KEY.clone()),
                 )
                 .with_partition(
                     PartitionDataBuilder::new()
@@ -1114,8 +1075,7 @@ mod tests {
                                 )
                             },
                             &metric::Registry::default(),
-                        )))
-                        .build(),
+                        ))),
                 ),
         );
 
@@ -1202,13 +1162,9 @@ mod tests {
     /// returns no data (as opposed to panicking, etc).
     #[tokio::test]
     async fn test_not_found() {
-        let partition_provider = Arc::new(
-            MockPartitionProvider::default().with_partition(
-                PartitionDataBuilder::new()
-                    .with_partition_key(ARBITRARY_PARTITION_KEY.clone())
-                    .build(),
-            ),
-        );
+        let partition_provider = Arc::new(MockPartitionProvider::default().with_partition(
+            PartitionDataBuilder::new().with_partition_key(ARBITRARY_PARTITION_KEY.clone()),
+        ));
 
         // Init the BufferTree
         let buf = BufferTree::new(
@@ -1301,14 +1257,10 @@ mod tests {
         let partition_provider = Arc::new(
             MockPartitionProvider::default()
                 .with_partition(
-                    PartitionDataBuilder::new()
-                        .with_partition_key(ARBITRARY_PARTITION_KEY.clone())
-                        .build(),
+                    PartitionDataBuilder::new().with_partition_key(ARBITRARY_PARTITION_KEY.clone()),
                 )
                 .with_partition(
-                    PartitionDataBuilder::new()
-                        .with_partition_key(PARTITION2_KEY.clone())
-                        .build(),
+                    PartitionDataBuilder::new().with_partition_key(PARTITION2_KEY.clone()),
                 ),
         );
 
@@ -1424,8 +1376,7 @@ mod tests {
             MockPartitionProvider::default().with_partition(
                 PartitionDataBuilder::new()
                     .with_deprecated_partition_id(ARBITRARY_CATALOG_PARTITION_ID)
-                    .with_partition_key(ARBITRARY_PARTITION_KEY.clone())
-                    .build(),
+                    .with_partition_key(ARBITRARY_PARTITION_KEY.clone()),
             ),
         );
 

--- a/ingester/src/buffer_tree/table.rs
+++ b/ingester/src/buffer_tree/table.rs
@@ -406,9 +406,8 @@ mod tests {
     #[tokio::test]
     async fn test_partition_init() {
         // Configure the mock partition provider to return a partition for a table ID.
-        let partition_provider = Arc::new(
-            MockPartitionProvider::default().with_partition(PartitionDataBuilder::new().build()),
-        );
+        let partition_provider =
+            Arc::new(MockPartitionProvider::default().with_partition(PartitionDataBuilder::new()));
 
         let partition_counter = Arc::new(PartitionCounter::new(NonZeroUsize::new(42).unwrap()));
 
@@ -454,9 +453,8 @@ mod tests {
     #[tokio::test]
     async fn test_partition_limit() {
         // Configure the mock partition provider to return a partition for a table ID.
-        let partition_provider = Arc::new(
-            MockPartitionProvider::default().with_partition(PartitionDataBuilder::new().build()),
-        );
+        let partition_provider =
+            Arc::new(MockPartitionProvider::default().with_partition(PartitionDataBuilder::new()));
 
         const N: usize = 42;
 

--- a/ingester/src/persist/handle.rs
+++ b/ingester/src/persist/handle.rs
@@ -519,11 +519,8 @@ mod tests {
             Arc::new(MockNamespaceNameProvider::new(&**ARBITRARY_NAMESPACE_NAME)),
             Arc::clone(&*ARBITRARY_TABLE_PROVIDER),
             Arc::new(
-                MockPartitionProvider::default().with_partition(
-                    PartitionDataBuilder::new()
-                        .with_sort_key_state(sort_key)
-                        .build(),
-                ),
+                MockPartitionProvider::default()
+                    .with_partition(PartitionDataBuilder::new().with_sort_key_state(sort_key)),
             ),
             NonZeroUsize::new(usize::MAX).unwrap(),
             Arc::new(MockPostWriteObserver::default()),


### PR DESCRIPTION
No functional change, but allows the mocked partitions to be constructed with the instances of deferred loaders (etc) that are used by the buffer tree itself.

This makes testing a little simpler in an upcoming PR, but I think it'll be nice in general.

---

* test: accept PartitionDataBuilder in provider (429d90cde)
      
      Use the PartitionDataBuilder in the MockPartitionProvider, allowing the
      test caller to specify any necessary parameters, but still allow the
      mock provider to inject the arguments it was called with.