### PR TITLE
feat(ingester): limit non-empty partitions per namespace

### DIFF
--- a/ingester/src/buffer_tree/namespace.rs
+++ b/ingester/src/buffer_tree/namespace.rs
@@ -81,13 +81,11 @@ pub(crate) struct NamespaceData<O> {
     /// [`PartitionData`]: super::partition::PartitionData
     partition_provider: Arc<dyn PartitionProvider>,
 
-    /// A counter tracking the approximate number of partitions currently
-    /// buffered.
+    /// A counter tracking the number of non-empty partitions currently
+    /// buffered for this namespace.
     ///
-    /// This counter is NOT atomically incremented w.r.t creation of the
-    /// partitions it tracks, and therefore is susceptible to "overrun",
-    /// breaching the configured partition count limit by a relatively small
-    /// degree.
+    /// This counter is eventually consistent / relaxed when read, but strongly
+    /// consistent when enforced.
     partition_count: Arc<PartitionCounter>,
 
     post_write_observer: Arc<O>,

--- a/ingester/src/buffer_tree/partition/counter.rs
+++ b/ingester/src/buffer_tree/partition/counter.rs
@@ -3,10 +3,14 @@ use std::{
     sync::atomic::{AtomicUsize, Ordering},
 };
 
+use crate::buffer_tree::BufferWriteError;
+
 /// A counter typed for counting partitions and applying a configured limit.
 ///
-/// No ordering is guaranteed - increments and reads may be arbitrarily
-/// reordered w.r.t other memory operations (relaxed ordering).
+/// This value is completely unsynchronised (in the context of memory ordering)
+/// and relies on external thread synchronisation. Calls to change the value of
+/// this counter may be arbitrarily reordered with other memory operations - the
+/// caller is responsible for providing external ordering where necessary.
 #[derive(Debug)]
 pub(crate) struct PartitionCounter {
     current: AtomicUsize,
@@ -22,20 +26,49 @@ impl PartitionCounter {
     }
 
     /// Increment the counter by 1.
-    pub(crate) fn inc(&self) {
-        self.current.fetch_add(1, Ordering::Relaxed);
+    ///
+    /// Return [`Err`] if the configured limit has been reached, else returns
+    /// [`Ok`] if the current value is below the limit.
+    pub(crate) fn inc(&self) -> Result<(), BufferWriteError> {
+        if self.current.fetch_add(1, Ordering::Relaxed) >= self.max {
+            // The limit was exceeded, roll back the addition and return an
+            // error.
+            let count = self.current.fetch_sub(1, Ordering::Relaxed);
+            return Err(BufferWriteError::PartitionLimit { count: count - 1 });
+        }
+
+        Ok(())
+    }
+
+    /// Decrement the counter by 1.
+    ///
+    /// # Panics
+    ///
+    /// This method MAY panic if the counter wraps around - never decrement more
+    /// than previously incremented.
+    pub(crate) fn dec(&self) {
+        let v = self.current.fetch_sub(1, Ordering::Relaxed);
+
+        // Correctness: the fetch operations are RMW, which are guaranteed to
+        // see a monotonic history, therefore any prior fetch_add always happens
+        // before the fetch_sub above.
+        debug_assert_ne!(v, usize::MAX); // MUST never wraparound wraparound
+    }
+
+    /// Returns an error if the limit has been reached and a subsequent
+    /// increment would fail.
+    pub(crate) fn is_maxed(&self) -> Result<(), BufferWriteError> {
+        let count = self.read();
+        if count >= self.max {
+            return Err(BufferWriteError::PartitionLimit { count });
+        }
+
+        Ok(())
     }
 
     /// Read the approximate counter value.
-    ///
-    /// Reads may return stale values, but will always be monotonic.
     pub(crate) fn read(&self) -> usize {
         self.current.load(Ordering::Relaxed)
-    }
-
-    /// Return `true` if the configured limit has been reached.
-    pub(crate) fn is_maxed(&self) -> bool {
-        self.read() >= self.max
     }
 
     #[cfg(test)]
@@ -48,6 +81,8 @@ impl PartitionCounter {
 mod tests {
     use super::*;
 
+    use assert_matches::assert_matches;
+
     #[test]
     fn test_counter() {
         const N: usize = 100;
@@ -55,12 +90,23 @@ mod tests {
         let c = PartitionCounter::new(NonZeroUsize::new(N).unwrap());
 
         for v in 0..N {
-            assert!(!c.is_maxed());
             assert_eq!(c.read(), v);
-            c.inc();
+            assert_matches!(c.is_maxed(), Ok(()));
+            assert!(c.inc().is_ok());
         }
 
         assert_eq!(c.read(), N);
-        assert!(c.is_maxed());
+        assert_matches!(
+            c.is_maxed(),
+            Err(BufferWriteError::PartitionLimit { count: N })
+        );
+        assert_matches!(c.inc(), Err(BufferWriteError::PartitionLimit { count: N }));
+        assert_eq!(c.read(), N); // Counter value unchanged.
+
+        c.dec();
+        assert_eq!(c.read(), N - 1);
+        assert_matches!(c.is_maxed(), Ok(()));
+        assert_matches!(c.inc(), Ok(()));
+        assert_eq!(c.read(), N);
     }
 }

--- a/ingester/src/buffer_tree/partition/resolver/old_filter.rs
+++ b/ingester/src/buffer_tree/partition/resolver/old_filter.rs
@@ -14,7 +14,9 @@ use super::PartitionProvider;
 use crate::{
     buffer_tree::{
         namespace::NamespaceName,
-        partition::{resolver::SortKeyResolver, PartitionData, SortKeyState},
+        partition::{
+            counter::PartitionCounter, resolver::SortKeyResolver, PartitionData, SortKeyState,
+        },
         table::metadata::TableMetadata,
     },
     deferred_load::DeferredLoad,
@@ -148,6 +150,7 @@ where
         namespace_name: Arc<DeferredLoad<NamespaceName>>,
         table_id: TableId,
         table: Arc<DeferredLoad<TableMetadata>>,
+        partition_counter: Arc<PartitionCounter>,
     ) -> Arc<Mutex<PartitionData>> {
         let hash_id = PartitionHashId::new(table_id, &partition_key);
 
@@ -189,6 +192,7 @@ where
                 table_id,
                 table,
                 SortKeyState::Deferred(Arc::new(sort_key_resolver)),
+                partition_counter,
             )));
         }
 
@@ -202,14 +206,21 @@ where
         // This partition MAY be an old-style / row-ID-addressed partition
         // that needs querying for.
         self.inner
-            .get_partition(partition_key, namespace_id, namespace_name, table_id, table)
+            .get_partition(
+                partition_key,
+                namespace_id,
+                namespace_name,
+                table_id,
+                table,
+                partition_counter,
+            )
             .await
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
+    use std::{num::NonZeroUsize, sync::Arc};
 
     use data_types::PartitionId;
     use hashbrown::HashMap;
@@ -248,6 +259,7 @@ mod tests {
             _namespace_name: Arc<DeferredLoad<NamespaceName>>,
             table_id: TableId,
             _table: Arc<DeferredLoad<TableMetadata>>,
+            _partition_counter: Arc<PartitionCounter>,
         ) -> Arc<Mutex<PartitionData>> {
             let mut builder = PartitionDataBuilder::default();
 
@@ -366,7 +378,8 @@ mod tests {
                     ARBITRARY_NAMESPACE_ID,
                     defer_namespace_name_1_sec(),
                     p.table_id,
-                    defer_table_metadata_1_sec()
+                    defer_table_metadata_1_sec(),
+                    Arc::new(PartitionCounter::new(NonZeroUsize::new(1).unwrap())),
                 ));
 
                 let got_id = got.lock().partition_id().clone();
@@ -417,6 +430,7 @@ mod tests {
                 defer_namespace_name_1_sec(),
                 ARBITRARY_TABLE_ID,
                 defer_table_metadata_1_sec(),
+                Arc::new(PartitionCounter::new(NonZeroUsize::new(1).unwrap())),
             )
             .await;
 


### PR DESCRIPTION
This changes the previously-merged per-namespace partition limit to only consider _non-empty partitions_ during enforcement. It also tightens up the consistency semantics of the counter, removing any (minor) racy overshoot of the limit.

The previous limit would cause a problem: given a long enough ingester uptime, the limit would always be hit, even for a workload that touches only one partition per day! If the limit was set to 10, and a user was writing to 1 partition per day, after 10 days they'd be locked out. 

This no longer happens, as only _non-empty_ partitions are limited now, so in the example above, there'd be 9 empty partitions, and 1 non-empty that's evaluated for limiting. This correctly limits what we want to limit: the number of parittions that can end up on the persist queue.

Part of https://github.com/influxdata/idpe/issues/18118

---

* feat(ingester): partition is_empty() (3978b07a4)
      
      Adds an is_empty() method to the PartitionData, returning true iff a
      subsequent query of the partition would return no rows.

* feat: only limit non-empty partitions (7ad26e6d0)
      
      This changes the per-namespace buffered partition limiter to only
      consider non-empty partitions when enforcing the partition limit.
      
      Non-empty partitions cost a small amount of RAM, but are not added to
      the persist queue - only non-empty partitions will need persisting, so
      the limiter only needs to limit non-empty partitions.
      
      This commit also significantly improves the consistency properties of
      the limiter - the limit no longer suffers from a small window of
      "overrun" due to non-atomic updates w.r.t partition creation - the limit
      is now exact.
      
      As an optimisation, partitions are not created at all if the limit has
      been reached, preventing an accumulation of empty partitions whilst the
      limit is being enforced.