### PR TITLE
perf: use half of logical cores for persist exec

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6965,6 +6965,8 @@ dependencies = [
  "bytes",
  "cc",
  "chrono",
+ "clap",
+ "clap_builder",
  "crossbeam-utils",
  "crypto-common",
  "datafusion",

--- a/influxdb_iox/Cargo.toml
+++ b/influxdb_iox/Cargo.toml
@@ -50,7 +50,7 @@ nu-ansi-term = "0.49.0"
 arrow = { workspace = true, features = ["prettyprint"] }
 backtrace = "0.3"
 bytes = "1.5"
-clap = { version = "4", features = ["derive", "env"] }
+clap = { version = "4", features = ["derive", "env", "string"] }
 comfy-table = { version = "7.0", default-features = false }
 console-subscriber = { version = "0.1.10", optional = true, features = ["parking_lot"] }
 dotenvy = "0.15.7"

--- a/workspace-hack/Cargo.toml
+++ b/workspace-hack/Cargo.toml
@@ -25,6 +25,8 @@ base64 = { version = "0.21" }
 byteorder = { version = "1" }
 bytes = { version = "1" }
 chrono = { version = "0.4", default-features = false, features = ["alloc", "clock", "serde"] }
+clap = { version = "4", features = ["derive", "env", "string"] }
+clap_builder = { version = "4", default-features = false, features = ["color", "env", "help", "std", "string", "suggestions", "usage"] }
 crossbeam-utils = { version = "0.8" }
 crypto-common = { version = "0.1", default-features = false, features = ["std"] }
 datafusion = { git = "https://github.com/apache/arrow-datafusion.git", rev = "3ea870cf0995a86b5297a92be5d5432577aefabe" }


### PR DESCRIPTION
Have the ingesters automatically use half the CPU cores for DF, instead of always trying to use 4.

This might reduce the performance of persist when cores < 4, increasing the time taken to process N tasks, but the throughput reduction will be less than you might expect because DF wouldn't have had full use of the cores that were also serving API requests anyway.

Nothing is even close to saturating the persist queues as far as I am aware, so I believe this to be totally fine to change without needing to reconfigure prod anywhere.

---

* perf: use half of logical cores for persist exec (1bb4c0806)
      
      Changes the default ingester configuration to assign half the logical
      cores to datafusion for persist execution. Prior to this commit,
      datafusion always used 4 threads by default.
      
      In situations where the ingesters are configured with 4 logical cores or
      less, the periodic persist can start enough persist jobs to keep the 4
      threads assigned to datafusion busy. Because there are enough threads to
      saturate all CPU cores, these CPU-heavy persist threads can impact write
      latency by stealing CPU time from the tokio runtime threads.
      
      This change assigns exactly half the threads to DF by default, ensuring
      there's always N/2 cores to service I/O heavy API requests.