### PR TITLE
chore: set default empty array for sort_key

### DIFF
--- a/iox_catalog/migrations/20230914140400_set_default_for_sort_key.sql
+++ b/iox_catalog/migrations/20230914140400_set_default_for_sort_key.sql
@@ -1,0 +1,1 @@
+ALTER TABLE partition ALTER COLUMN sort_key SET DEFAULT '{}';

--- a/iox_catalog/sqlite/migrations/20230914140400_set_default_for_sort_key.sql
+++ b/iox_catalog/sqlite/migrations/20230914140400_set_default_for_sort_key.sql
@@ -1,0 +1,2 @@
+ALTER TABLE partition DROP COLUMN sort_key;
+ALTER TABLE partition ADD COLUMN sort_key TEXT [] NOT NULL DEFAULT '[]';


### PR DESCRIPTION
Thi is the first PR in this https://influxdata.slack.com/archives/CRK9M8L5Q/p1694708801747229?thread_ts=1694708781.255299&cid=CRK9M8L5Q


- [ ] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb_iox/blob/main/README.md).
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
