### PR TITLE
refactor: use default value for sort_key at partition insert

### DIFF
--- a/iox_catalog/migrations/20230914140400_set_default_for_sort_key.sql
+++ b/iox_catalog/migrations/20230914140400_set_default_for_sort_key.sql
@@ -1,0 +1,1 @@
+ALTER TABLE partition ALTER COLUMN sort_key SET DEFAULT '{}';

--- a/iox_catalog/sqlite/migrations/20230914140400_set_default_for_sort_key.sql
+++ b/iox_catalog/sqlite/migrations/20230914140400_set_default_for_sort_key.sql
@@ -1,0 +1,2 @@
+ALTER TABLE partition DROP COLUMN sort_key;
+ALTER TABLE partition ADD COLUMN sort_key TEXT [] NOT NULL DEFAULT '[]';

--- a/iox_catalog/src/postgres.rs
+++ b/iox_catalog/src/postgres.rs
@@ -1175,9 +1175,9 @@ impl PartitionRepo for PostgresTxn {
         let v = sqlx::query_as::<_, Partition>(
             r#"
 INSERT INTO partition
-    (partition_key, shard_id, table_id, hash_id, sort_key, sort_key_ids)
+    (partition_key, shard_id, table_id, hash_id, sort_key_ids)
 VALUES
-    ( $1, $2, $3, $4, '{}', '{}')
+    ( $1, $2, $3, $4, '{}')
 ON CONFLICT ON CONSTRAINT partition_key_unique
 DO UPDATE SET partition_key = partition.partition_key
 RETURNING id, hash_id, table_id, partition_key, sort_key, sort_key_ids, new_file_at;
@@ -2252,9 +2252,9 @@ mod tests {
         sqlx::query(
             r#"
 INSERT INTO partition
-    (partition_key, shard_id, table_id, sort_key, sort_key_ids)
+    (partition_key, shard_id, table_id, sort_key_ids)
 VALUES
-    ( $1, $2, $3, '{}', '{}')
+    ( $1, $2, $3, '{}')
 ON CONFLICT ON CONSTRAINT partition_key_unique
 DO UPDATE SET partition_key = partition.partition_key
 RETURNING id, hash_id, table_id, partition_key, sort_key, sort_key_ids, new_file_at;

--- a/iox_catalog/src/sqlite.rs
+++ b/iox_catalog/src/sqlite.rs
@@ -852,9 +852,9 @@ impl PartitionRepo for SqliteTxn {
         let v = sqlx::query_as::<_, PartitionPod>(
             r#"
 INSERT INTO partition
-    (partition_key, shard_id, table_id, hash_id, sort_key, sort_key_ids)
+    (partition_key, shard_id, table_id, hash_id, sort_key_ids)
 VALUES
-    ($1, $2, $3, $4, '[]', '[]')
+    ($1, $2, $3, $4, '[]')
 ON CONFLICT (table_id, partition_key)
 DO UPDATE SET partition_key = partition.partition_key
 RETURNING id, hash_id, table_id, partition_key, sort_key, sort_key_ids, new_file_at;
@@ -1822,9 +1822,9 @@ mod tests {
         sqlx::query(
             r#"
 INSERT INTO partition
-    (partition_key, shard_id, table_id, sort_key, sort_key_ids)
+    (partition_key, shard_id, table_id, sort_key_ids)
 VALUES
-    ($1, $2, $3, '[]', '[]')
+    ($1, $2, $3, '[]')
 ON CONFLICT (table_id, partition_key)
 DO UPDATE SET partition_key = partition.partition_key
 RETURNING id, hash_id, table_id, partition_key, sort_key, sort_key_ids, new_file_at;


### PR DESCRIPTION
This is second PR of  https://influxdata.slack.com/archives/CRK9M8L5Q/p1694708801747229?thread_ts=1694708781.255299&cid=CRK9M8L5Q

This PR depends on https://github.com/influxdata/influxdb_iox/pull/8737

- [ ] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb_iox/blob/main/README.md).
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
