### PR TITLE
chore: update chrono to `0.4.31`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -793,9 +793,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.30"
+version = "0.4.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "defd4e7873dbddba6c7c91e199c7fcb946abc4a6a4ac3195400bcfb01b5de877"
+checksum = "7f2c685bad3eb3d45a01354cedb7d5faa66194d1d58ba6e267a8de788f79db38"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",

--- a/influxdb_influxql_parser/src/literal.rs
+++ b/influxdb_influxql_parser/src/literal.rs
@@ -592,10 +592,9 @@ mod test {
 
         // infallible
         let ts = nanos_to_timestamp(i64::MAX);
-        assert_eq!(ts.timestamp_nanos(), i64::MAX);
+        assert_eq!(ts.timestamp_nanos_opt(), Some(i64::MAX));
 
-        // let ts = nanos_to_timestamp(i64::MIN);
-        // This line panics with an arithmetic overflow.
-        // assert_eq!(ts.timestamp_nanos(), i64::MIN);
+        let ts = nanos_to_timestamp(i64::MIN);
+        assert_eq!(ts.timestamp_nanos_opt(), Some(-9223372036854775808));
     }
 }

--- a/iox_data_generator/src/bin/iox_data_generator.rs
+++ b/iox_data_generator/src/bin/iox_data_generator.rs
@@ -143,8 +143,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let start_datetime = datetime_nanoseconds(config.start.as_deref(), execution_start_time);
     let end_datetime = datetime_nanoseconds(config.end.as_deref(), execution_start_time);
 
-    let start_display = start_datetime.unwrap_or_else(|| execution_start_time.timestamp_nanos());
-    let end_display = end_datetime.unwrap_or_else(|| execution_start_time.timestamp_nanos());
+    let start_display =
+        start_datetime.unwrap_or_else(|| execution_start_time.timestamp_nanos_opt().unwrap());
+    let end_display =
+        end_datetime.unwrap_or_else(|| execution_start_time.timestamp_nanos_opt().unwrap());
 
     let continue_on = config.do_continue;
 
@@ -201,7 +203,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         &mut points_writer_builder,
         start_datetime,
         end_datetime,
-        execution_start_time.timestamp_nanos(),
+        execution_start_time.timestamp_nanos_opt().unwrap(),
         continue_on,
         config.batch_size,
         config.print,
@@ -231,7 +233,7 @@ fn datetime_nanoseconds(arg: Option<&str>, now: DateTime<Local>) -> Option<i64> 
                 now - chrono_duration
             });
 
-        datetime.timestamp_nanos()
+        datetime.timestamp_nanos_opt().unwrap()
     })
 }
 
@@ -255,7 +257,9 @@ mod test {
     fn relative() {
         let fixed_now = Local::now();
         let ns = datetime_nanoseconds(Some("1hr"), fixed_now);
-        let expected = (fixed_now - chrono::Duration::hours(1)).timestamp_nanos();
+        let expected = (fixed_now - chrono::Duration::hours(1))
+            .timestamp_nanos_opt()
+            .unwrap();
         assert_eq!(ns, Some(expected));
     }
 }

--- a/iox_query/src/frontend.rs
+++ b/iox_query/src/frontend.rs
@@ -39,12 +39,14 @@ mod test {
                 .start_timestamp
                 .value()
                 .expect("start timestamp")
-                .timestamp_nanos();
+                .timestamp_nanos_opt()
+                .unwrap();
             let end_ts = $EXTRACTED
                 .end_timestamp
                 .value()
                 .expect("end timestamp")
-                .timestamp_nanos();
+                .timestamp_nanos_opt()
+                .unwrap();
 
             assert!(start_ts > 0, "start timestamp was non zero");
             assert!(end_ts > 0, "end timestamp was non zero");

--- a/iox_query_influxql/src/plan/planner.rs
+++ b/iox_query_influxql/src/plan/planner.rs
@@ -1844,7 +1844,7 @@ impl<'a> InfluxQLToLogicalPlan<'a> {
                 Literal::String(v) => Ok(lit(v)),
                 Literal::Boolean(v) => Ok(lit(*v)),
                 Literal::Timestamp(v) => Ok(lit(ScalarValue::TimestampNanosecond(
-                    Some(v.timestamp_nanos()),
+                    Some(v.timestamp_nanos_opt().unwrap()),
                     None,
                 ))),
                 Literal::Duration(v) => {
@@ -2210,9 +2210,9 @@ impl<'a> InfluxQLToLogicalPlan<'a> {
         let time_range = if time_range.is_unbounded() {
             TimeRange {
                 lower: Some(match cutoff {
-                    MetadataCutoff::Absolute(dt) => dt.timestamp_nanos(),
+                    MetadataCutoff::Absolute(dt) => dt.timestamp_nanos_opt().unwrap(),
                     MetadataCutoff::Relative(delta) => {
-                        start_time.timestamp_nanos() - delta.as_nanos() as i64
+                        start_time.timestamp_nanos_opt().unwrap() - delta.as_nanos() as i64
                     }
                 }),
                 upper: None,

--- a/iox_query_influxql/src/plan/rewriter.rs
+++ b/iox_query_influxql/src/plan/rewriter.rs
@@ -123,7 +123,7 @@ impl RewriteSelect {
         let time_range = match (interval, time_range.upper) {
             (Some(interval), None) if interval.duration > 0 => TimeRange {
                 lower: time_range.lower,
-                upper: Some(now.timestamp_nanos()),
+                upper: Some(now.timestamp_nanos_opt().unwrap()),
             },
             _ => time_range,
         };

--- a/iox_time/src/lib.rs
+++ b/iox_time/src/lib.rs
@@ -378,12 +378,12 @@ mod test {
     #[test]
     fn test_mock_provider_now() {
         let provider = MockProvider::new(Time::from_timestamp_nanos(0));
-        assert_eq!(provider.now().timestamp_nanos_opt().unwrap(), 0);
-        assert_eq!(provider.now().timestamp_nanos_opt().unwrap(), 0);
+        assert_eq!(provider.now().timestamp_nanos(), 0);
+        assert_eq!(provider.now().timestamp_nanos(), 0);
 
         provider.set(Time::from_timestamp_nanos(12));
-        assert_eq!(provider.now().timestamp_nanos_opt().unwrap(), 12);
-        assert_eq!(provider.now().timestamp_nanos_opt().unwrap(), 12);
+        assert_eq!(provider.now().timestamp_nanos(), 12);
+        assert_eq!(provider.now().timestamp_nanos(), 12);
     }
 
     #[tokio::test]
@@ -550,7 +550,7 @@ mod test {
             );
 
             assert_eq!(
-                time.timestamp_nanos_opt().unwrap(),
+                time.timestamp_nanos(),
                 date_time.timestamp_nanos_opt().unwrap()
             );
             assert_eq!(time.timestamp_millis(), date_time.timestamp_millis());

--- a/iox_time/src/lib.rs
+++ b/iox_time/src/lib.rs
@@ -111,7 +111,7 @@ impl Time {
 
     /// Returns the number of non-leap-nanoseconds since January 1, 1970 UTC
     pub fn timestamp_nanos(&self) -> i64 {
-        self.0.timestamp_nanos()
+        self.0.timestamp_nanos_opt().unwrap()
     }
 
     /// Returns the number of seconds since January 1, 1970 UTC
@@ -378,12 +378,12 @@ mod test {
     #[test]
     fn test_mock_provider_now() {
         let provider = MockProvider::new(Time::from_timestamp_nanos(0));
-        assert_eq!(provider.now().timestamp_nanos(), 0);
-        assert_eq!(provider.now().timestamp_nanos(), 0);
+        assert_eq!(provider.now().timestamp_nanos_opt().unwrap(), 0);
+        assert_eq!(provider.now().timestamp_nanos_opt().unwrap(), 0);
 
         provider.set(Time::from_timestamp_nanos(12));
-        assert_eq!(provider.now().timestamp_nanos(), 12);
-        assert_eq!(provider.now().timestamp_nanos(), 12);
+        assert_eq!(provider.now().timestamp_nanos_opt().unwrap(), 12);
+        assert_eq!(provider.now().timestamp_nanos_opt().unwrap(), 12);
     }
 
     #[tokio::test]
@@ -539,7 +539,7 @@ mod test {
             );
             assert_eq!(
                 time,
-                Time::from_timestamp_nanos(date_time.timestamp_nanos())
+                Time::from_timestamp_nanos(date_time.timestamp_nanos_opt().unwrap())
             );
             assert_eq!(
                 Time::from_timestamp_millis(date_time.timestamp_millis()).unwrap(),
@@ -549,7 +549,10 @@ mod test {
                 )
             );
 
-            assert_eq!(time.timestamp_nanos(), date_time.timestamp_nanos());
+            assert_eq!(
+                time.timestamp_nanos_opt().unwrap(),
+                date_time.timestamp_nanos_opt().unwrap()
+            );
             assert_eq!(time.timestamp_millis(), date_time.timestamp_millis());
             assert_eq!(time.to_rfc3339(), date_time.to_rfc3339());
 

--- a/predicate/src/delete_predicate.rs
+++ b/predicate/src/delete_predicate.rs
@@ -206,7 +206,7 @@ fn parse_time(input: &str) -> Result<i64> {
     // See examples here https://docs.influxdata.com/influxdb/v2.0/reference/cli/influx/delete/#delete-all-points-within-a-specified-time-frame
     let datetime_result = DateTime::parse_from_rfc3339(input);
     match datetime_result {
-        Ok(datetime) => Ok(datetime.timestamp_nanos()),
+        Ok(datetime) => Ok(datetime.timestamp_nanos_opt().unwrap()),
         Err(timestamp_err) => {
             // See if it is in nanosecond form
             let time_result = input.parse::<i64>();

--- a/query_functions/src/window/internal.rs
+++ b/query_functions/src/window/internal.rs
@@ -199,7 +199,7 @@ fn to_timestamp_nanos_utc(
     let ndatetime = NaiveDateTime::new(ndate, ntime);
 
     let datetime = DateTime::<Utc>::from_naive_utc_and_offset(ndatetime, Utc);
-    datetime.timestamp_nanos()
+    datetime.timestamp_nanos_opt().unwrap()
 }
 
 impl Add<Duration> for i64 {

--- a/query_functions/src/window/internal.rs
+++ b/query_functions/src/window/internal.rs
@@ -386,7 +386,7 @@ mod tests {
     /// t: mustParseTime("1970-02-01T00:00:00Z"),
     fn must_parse_time(s: &str) -> i64 {
         let datetime = DateTime::parse_from_rfc3339(s).unwrap();
-        datetime.timestamp_nanos()
+        datetime.timestamp_nanos_opt().unwrap()
     }
 
     /// TestWindow_GetEarliestBounds

--- a/trace_exporters/src/jaeger/span.rs
+++ b/trace_exporters/src/jaeger/span.rs
@@ -22,10 +22,10 @@ impl From<Span> for jaeger::Span {
 
         let (start_time, duration) = match (s.start, s.end) {
             (Some(start), Some(end)) => (
-                start.timestamp_nanos() / 1000,
+                start.timestamp_nanos_opt().unwrap() / 1000,
                 (end - start).num_microseconds().expect("no overflow"),
             ),
-            (Some(start), _) => (start.timestamp_nanos() / 1000, 0),
+            (Some(start), _) => (start.timestamp_nanos_opt().unwrap() / 1000, 0),
             _ => (0, 0),
         };
 
@@ -100,7 +100,7 @@ impl From<Span> for jaeger::Span {
 impl From<SpanEvent> for jaeger::Log {
     fn from(event: SpanEvent) -> Self {
         Self {
-            timestamp: event.time.timestamp_nanos() / 1000,
+            timestamp: event.time.timestamp_nanos_opt().unwrap() / 1000,
             fields: vec![jaeger::Tag {
                 key: "event".to_string(),
                 v_type: jaeger::TagType::String,


### PR DESCRIPTION
This PR updates cargo to the latest version, `0.4.31` and updates some API usages to avoid deprecation

This is part of updating to the latest DataFusion


Changes:
1. `cargo update -p chrono`
2. Replace usages of `timestamp_nanos()` with `timestamp_nanos_opt().unwrap()` -- this is not a behavior change, it simply makes clear what was previously the case (that this code may panic if given a timestamp outside what can be represented by a i64 nanosecond timestamp)

While we may want to handle

```shell
(arrow_dev) alamb@MacBook-Pro-8:~/Software/influxdb_iox$ cargo update -p chrono
    Updating crates.io index
    Updating chrono v0.4.30 -> v0.4.31
 ```