### PR TITLE
refactor: Prepare for correcting validation of max tables and max columns per table

### DIFF
--- a/compactor/src/components/namespaces_source/mock.rs
+++ b/compactor/src/components/namespaces_source/mock.rs
@@ -194,8 +194,8 @@ mod tests {
                     schema: NamespaceSchema {
                         id,
                         tables,
-                        max_columns_per_table: MaxColumnsPerTable::new(10),
                         max_tables: MaxTables::new(42),
+                        max_columns_per_table: MaxColumnsPerTable::new(10),
                         retention_period_ns: None,
                         partition_template: Default::default(),
                     },

--- a/compactor/src/components/namespaces_source/mock.rs
+++ b/compactor/src/components/namespaces_source/mock.rs
@@ -49,7 +49,10 @@ impl NamespacesSource for MockNamespacesSource {
 mod tests {
     use std::collections::BTreeMap;
 
-    use data_types::{Column, ColumnId, ColumnType, ColumnsByName, TableId, TableSchema};
+    use data_types::{
+        Column, ColumnId, ColumnType, ColumnsByName, MaxColumnsPerTable, MaxTables, TableId,
+        TableSchema,
+    };
 
     use super::*;
 
@@ -182,8 +185,8 @@ mod tests {
                     ns: Namespace {
                         id,
                         name: "ns".to_string(),
-                        max_tables: 10,
-                        max_columns_per_table: 10,
+                        max_tables: MaxTables::new(10),
+                        max_columns_per_table: MaxColumnsPerTable::new(10),
                         retention_period_ns: None,
                         deleted_at: None,
                         partition_template: Default::default(),
@@ -191,8 +194,8 @@ mod tests {
                     schema: NamespaceSchema {
                         id,
                         tables,
-                        max_columns_per_table: 10,
-                        max_tables: 42,
+                        max_columns_per_table: MaxColumnsPerTable::new(10),
+                        max_tables: MaxTables::new(42),
                         retention_period_ns: None,
                         partition_template: Default::default(),
                     },

--- a/data_types/src/lib.rs
+++ b/data_types/src/lib.rs
@@ -302,10 +302,10 @@ pub struct NamespaceSchema {
     pub id: NamespaceId,
     /// the tables in the namespace by name
     pub tables: BTreeMap<String, TableSchema>,
-    /// the number of columns per table this namespace allows
-    pub max_columns_per_table: MaxColumnsPerTable,
     /// The maximum number of tables permitted in this namespace.
     pub max_tables: MaxTables,
+    /// the number of columns per table this namespace allows
+    pub max_columns_per_table: MaxColumnsPerTable,
     /// The retention period in ns.
     /// None represents infinite duration (i.e. never drop data).
     pub retention_period_ns: Option<i64>,
@@ -330,8 +330,8 @@ impl NamespaceSchema {
         Self {
             id,
             tables: BTreeMap::new(),
-            max_columns_per_table,
             max_tables,
+            max_columns_per_table,
             retention_period_ns,
             partition_template: partition_template.clone(),
         }
@@ -2647,8 +2647,8 @@ mod tests {
         let schema1 = NamespaceSchema {
             id: NamespaceId::new(1),
             tables: BTreeMap::from([]),
-            max_columns_per_table: MaxColumnsPerTable::new(4),
             max_tables: MaxTables::new(42),
+            max_columns_per_table: MaxColumnsPerTable::new(4),
             retention_period_ns: None,
             partition_template: Default::default(),
         };
@@ -2662,8 +2662,8 @@ mod tests {
                     partition_template: Default::default(),
                 },
             )]),
-            max_columns_per_table: MaxColumnsPerTable::new(4),
             max_tables: MaxTables::new(42),
+            max_columns_per_table: MaxColumnsPerTable::new(4),
             retention_period_ns: None,
             partition_template: Default::default(),
         };

--- a/data_types/src/lib.rs
+++ b/data_types/src/lib.rs
@@ -273,6 +273,50 @@ impl std::fmt::Display for ParquetFileId {
     }
 }
 
+/// Max tables allowed in a namespace.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, sqlx::Type)]
+#[sqlx(transparent)]
+pub struct MaxTables(i32);
+
+#[allow(missing_docs)]
+impl MaxTables {
+    pub const fn new(v: i32) -> Self {
+        Self(v)
+    }
+
+    pub fn get(&self) -> i32 {
+        self.0
+    }
+}
+
+impl std::fmt::Display for MaxTables {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+/// Max columns per table allowed in a namespace.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, sqlx::Type)]
+#[sqlx(transparent)]
+pub struct MaxColumnsPerTable(i32);
+
+#[allow(missing_docs)]
+impl MaxColumnsPerTable {
+    pub const fn new(v: i32) -> Self {
+        Self(v)
+    }
+
+    pub fn get(&self) -> i32 {
+        self.0
+    }
+}
+
+impl std::fmt::Display for MaxColumnsPerTable {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
 /// Data object for a namespace
 #[derive(Debug, Clone, PartialEq, sqlx::FromRow)]
 pub struct Namespace {
@@ -283,9 +327,9 @@ pub struct Namespace {
     /// The retention period in ns. None represents infinite duration (i.e. never drop data).
     pub retention_period_ns: Option<i64>,
     /// The maximum number of tables that can exist in this namespace
-    pub max_tables: i32,
+    pub max_tables: MaxTables,
     /// The maximum number of columns per table in this namespace
-    pub max_columns_per_table: i32,
+    pub max_columns_per_table: MaxColumnsPerTable,
     /// When this file was marked for deletion.
     pub deleted_at: Option<Timestamp>,
     /// The partition template to use for new tables in this namespace either created implicitly or
@@ -326,9 +370,9 @@ pub struct NamespaceSchema {
     /// the tables in the namespace by name
     pub tables: BTreeMap<String, TableSchema>,
     /// the number of columns per table this namespace allows
-    pub max_columns_per_table: usize,
+    pub max_columns_per_table: MaxColumnsPerTable,
     /// The maximum number of tables permitted in this namespace.
-    pub max_tables: usize,
+    pub max_tables: MaxTables,
     /// The retention period in ns.
     /// None represents infinite duration (i.e. never drop data).
     pub retention_period_ns: Option<i64>,
@@ -353,8 +397,8 @@ impl NamespaceSchema {
         Self {
             id,
             tables: BTreeMap::new(),
-            max_columns_per_table: max_columns_per_table as usize,
-            max_tables: max_tables as usize,
+            max_columns_per_table,
+            max_tables,
             retention_period_ns,
             partition_template: partition_template.clone(),
         }
@@ -2670,8 +2714,8 @@ mod tests {
         let schema1 = NamespaceSchema {
             id: NamespaceId::new(1),
             tables: BTreeMap::from([]),
-            max_columns_per_table: 4,
-            max_tables: 42,
+            max_columns_per_table: MaxColumnsPerTable::new(4),
+            max_tables: MaxTables::new(42),
             retention_period_ns: None,
             partition_template: Default::default(),
         };
@@ -2685,8 +2729,8 @@ mod tests {
                     partition_template: Default::default(),
                 },
             )]),
-            max_columns_per_table: 4,
-            max_tables: 42,
+            max_columns_per_table: MaxColumnsPerTable::new(4),
+            max_tables: MaxTables::new(42),
             retention_period_ns: None,
             partition_template: Default::default(),
         };

--- a/data_types/src/service_limits.rs
+++ b/data_types/src/service_limits.rs
@@ -1,6 +1,9 @@
 //! Types protecting production by implementing limits on customer data.
 
-use generated_types::influxdata::iox::namespace::v1 as namespace_proto;
+use generated_types::influxdata::iox::namespace::{
+    v1 as namespace_proto, v1::update_namespace_service_protection_limit_request::LimitUpdate,
+};
+use thiserror::Error;
 
 /// Max tables allowed in a namespace.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, sqlx::Type)]
@@ -86,6 +89,53 @@ impl From<namespace_proto::ServiceProtectionLimits> for NamespaceServiceProtecti
         Self {
             max_tables: max_tables.map(MaxTables::new),
             max_columns_per_table: max_columns_per_table.map(MaxColumnsPerTable::new),
+        }
+    }
+}
+
+/// Updating one, but not both, of the limits is what the UpdateNamespaceServiceProtectionLimit
+/// gRPC request supports, so match that encoding on the Rust side.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ServiceLimitUpdate {
+    /// Requesting an update to the maximum number of tables allowed in this namespace
+    MaxTables(MaxTables),
+    /// Requesting an update to the maximum number of columns allowed in each table in this
+    /// namespace
+    MaxColumnsPerTable(MaxColumnsPerTable),
+}
+
+/// Errors converting from raw values to the service limits
+#[derive(Error, Debug, Clone, Copy)]
+pub enum ServiceLimitError {
+    /// A negative or 0 value was specified; those aren't allowed
+    #[error("service limit values must be greater than 0")]
+    MustBeGreaterThanZero,
+
+    /// No value was provided so we can't update anything
+    #[error("a supported service limit value is required")]
+    NoValueSpecified,
+}
+
+impl TryFrom<Option<LimitUpdate>> for ServiceLimitUpdate {
+    type Error = ServiceLimitError;
+
+    fn try_from(limit_update: Option<LimitUpdate>) -> Result<Self, Self::Error> {
+        match limit_update {
+            Some(LimitUpdate::MaxTables(n)) => {
+                if n == 0 {
+                    return Err(ServiceLimitError::MustBeGreaterThanZero);
+                }
+                Ok(ServiceLimitUpdate::MaxTables(MaxTables::new(n)))
+            }
+            Some(LimitUpdate::MaxColumnsPerTable(n)) => {
+                if n == 0 {
+                    return Err(ServiceLimitError::MustBeGreaterThanZero);
+                }
+                Ok(ServiceLimitUpdate::MaxColumnsPerTable(
+                    MaxColumnsPerTable::new(n),
+                ))
+            }
+            None => Err(ServiceLimitError::NoValueSpecified),
         }
     }
 }

--- a/data_types/src/service_limits.rs
+++ b/data_types/src/service_limits.rs
@@ -16,6 +16,17 @@ impl MaxTables {
     pub fn get(&self) -> i32 {
         self.0
     }
+
+    /// Default per-namespace table count service protection limit.
+    pub const fn const_default() -> Self {
+        Self(500)
+    }
+}
+
+impl Default for MaxTables {
+    fn default() -> Self {
+        Self::const_default()
+    }
 }
 
 impl std::fmt::Display for MaxTables {
@@ -37,6 +48,17 @@ impl MaxColumnsPerTable {
 
     pub fn get(&self) -> i32 {
         self.0
+    }
+
+    /// Default per-table column count service protection limit.
+    pub const fn const_default() -> Self {
+        Self(200)
+    }
+}
+
+impl Default for MaxColumnsPerTable {
+    fn default() -> Self {
+        Self::const_default()
     }
 }
 

--- a/data_types/src/service_limits.rs
+++ b/data_types/src/service_limits.rs
@@ -72,9 +72,9 @@ impl std::fmt::Display for MaxColumnsPerTable {
 #[derive(Debug, Copy, Clone)]
 pub struct NamespaceServiceProtectionLimitsOverride {
     /// The maximum number of tables that can exist in this namespace
-    pub max_tables: Option<i32>,
+    pub max_tables: Option<MaxTables>,
     /// The maximum number of columns per table in this namespace
-    pub max_columns_per_table: Option<i32>,
+    pub max_columns_per_table: Option<MaxColumnsPerTable>,
 }
 
 impl From<namespace_proto::ServiceProtectionLimits> for NamespaceServiceProtectionLimitsOverride {
@@ -84,8 +84,8 @@ impl From<namespace_proto::ServiceProtectionLimits> for NamespaceServiceProtecti
             max_columns_per_table,
         } = value;
         Self {
-            max_tables,
-            max_columns_per_table,
+            max_tables: max_tables.map(MaxTables::new),
+            max_columns_per_table: max_columns_per_table.map(MaxColumnsPerTable::new),
         }
     }
 }

--- a/data_types/src/service_limits.rs
+++ b/data_types/src/service_limits.rs
@@ -1,0 +1,69 @@
+//! Types protecting production by implementing limits on customer data.
+
+use generated_types::influxdata::iox::namespace::v1 as namespace_proto;
+
+/// Max tables allowed in a namespace.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, sqlx::Type)]
+#[sqlx(transparent)]
+pub struct MaxTables(i32);
+
+#[allow(missing_docs)]
+impl MaxTables {
+    pub const fn new(v: i32) -> Self {
+        Self(v)
+    }
+
+    pub fn get(&self) -> i32 {
+        self.0
+    }
+}
+
+impl std::fmt::Display for MaxTables {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+/// Max columns per table allowed in a namespace.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, sqlx::Type)]
+#[sqlx(transparent)]
+pub struct MaxColumnsPerTable(i32);
+
+#[allow(missing_docs)]
+impl MaxColumnsPerTable {
+    pub const fn new(v: i32) -> Self {
+        Self(v)
+    }
+
+    pub fn get(&self) -> i32 {
+        self.0
+    }
+}
+
+impl std::fmt::Display for MaxColumnsPerTable {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+/// Overrides for service protection limits.
+#[derive(Debug, Copy, Clone)]
+pub struct NamespaceServiceProtectionLimitsOverride {
+    /// The maximum number of tables that can exist in this namespace
+    pub max_tables: Option<i32>,
+    /// The maximum number of columns per table in this namespace
+    pub max_columns_per_table: Option<i32>,
+}
+
+impl From<namespace_proto::ServiceProtectionLimits> for NamespaceServiceProtectionLimitsOverride {
+    fn from(value: namespace_proto::ServiceProtectionLimits) -> Self {
+        let namespace_proto::ServiceProtectionLimits {
+            max_tables,
+            max_columns_per_table,
+        } = value;
+        Self {
+            max_tables,
+            max_columns_per_table,
+        }
+    }
+}

--- a/gossip_schema/src/lib.rs
+++ b/gossip_schema/src/lib.rs
@@ -209,8 +209,8 @@ mod tests {
                     .unwrap()
                     .clone(),
             ),
-            max_columns_per_table: 1,
             max_tables: 2,
+            max_columns_per_table: 1,
             retention_period_ns: Some(1234),
         });
 
@@ -240,8 +240,8 @@ mod tests {
             namespace_name: "bananas".to_string(),
             namespace_id: 4242,
             partition_template: None,
-            max_columns_per_table: 1,
             max_tables: 2,
+            max_columns_per_table: 1,
             retention_period_ns: Some(1234),
         });
 

--- a/ingester_test_ctx/src/lib.rs
+++ b/ingester_test_ctx/src/lib.rs
@@ -236,8 +236,8 @@ where
                     NamespaceSchema {
                         id: ns.id,
                         tables: Default::default(),
-                        max_columns_per_table: Default::default(),
                         max_tables: Default::default(),
+                        max_columns_per_table: Default::default(),
                         retention_period_ns,
                         partition_template: partition_template.unwrap_or_default(),
                     },

--- a/ingester_test_ctx/src/lib.rs
+++ b/ingester_test_ctx/src/lib.rs
@@ -23,7 +23,8 @@ use arrow::record_batch::RecordBatch;
 use arrow_flight::{decode::FlightRecordBatchStream, flight_service_server::FlightService, Ticket};
 use data_types::{
     partition_template::{NamespacePartitionTemplateOverride, TablePartitionTemplateOverride},
-    Namespace, NamespaceId, NamespaceSchema, ParquetFile, PartitionKey, SequenceNumber, TableId,
+    MaxColumnsPerTable, MaxTables, Namespace, NamespaceId, NamespaceSchema, ParquetFile,
+    PartitionKey, SequenceNumber, TableId,
 };
 use dml::{DmlMeta, DmlWrite};
 use futures::{stream::FuturesUnordered, FutureExt, StreamExt, TryStreamExt};
@@ -236,8 +237,10 @@ where
                     NamespaceSchema {
                         id: ns.id,
                         tables: Default::default(),
-                        max_columns_per_table: iox_catalog::DEFAULT_MAX_COLUMNS_PER_TABLE as usize,
-                        max_tables: iox_catalog::DEFAULT_MAX_TABLES as usize,
+                        max_columns_per_table: MaxColumnsPerTable::new(
+                            iox_catalog::DEFAULT_MAX_COLUMNS_PER_TABLE
+                        ),
+                        max_tables: MaxTables::new(iox_catalog::DEFAULT_MAX_TABLES),
                         retention_period_ns,
                         partition_template: partition_template.unwrap_or_default(),
                     },

--- a/ingester_test_ctx/src/lib.rs
+++ b/ingester_test_ctx/src/lib.rs
@@ -23,8 +23,7 @@ use arrow::record_batch::RecordBatch;
 use arrow_flight::{decode::FlightRecordBatchStream, flight_service_server::FlightService, Ticket};
 use data_types::{
     partition_template::{NamespacePartitionTemplateOverride, TablePartitionTemplateOverride},
-    MaxColumnsPerTable, MaxTables, Namespace, NamespaceId, NamespaceSchema, ParquetFile,
-    PartitionKey, SequenceNumber, TableId,
+    Namespace, NamespaceId, NamespaceSchema, ParquetFile, PartitionKey, SequenceNumber, TableId,
 };
 use dml::{DmlMeta, DmlWrite};
 use futures::{stream::FuturesUnordered, FutureExt, StreamExt, TryStreamExt};
@@ -237,10 +236,8 @@ where
                     NamespaceSchema {
                         id: ns.id,
                         tables: Default::default(),
-                        max_columns_per_table: MaxColumnsPerTable::new(
-                            iox_catalog::DEFAULT_MAX_COLUMNS_PER_TABLE
-                        ),
-                        max_tables: MaxTables::new(iox_catalog::DEFAULT_MAX_TABLES),
+                        max_columns_per_table: Default::default(),
+                        max_tables: Default::default(),
                         retention_period_ns,
                         partition_template: partition_template.unwrap_or_default(),
                     },

--- a/iox_catalog/src/interface.rs
+++ b/iox_catalog/src/interface.rs
@@ -764,13 +764,13 @@ pub async fn list_schemas(
 pub(crate) mod test_helpers {
     use crate::{
         test_helpers::{arbitrary_namespace, arbitrary_parquet_file_params, arbitrary_table},
-        validate_or_insert_schema, DEFAULT_MAX_COLUMNS_PER_TABLE, DEFAULT_MAX_TABLES,
+        validate_or_insert_schema,
     };
 
     use super::*;
     use ::test_helpers::assert_error;
     use assert_matches::assert_matches;
-    use data_types::{ColumnId, CompactionLevel};
+    use data_types::{ColumnId, CompactionLevel, MaxColumnsPerTable, MaxTables};
     use futures::Future;
     use generated_types::influxdata::iox::partition_template::v1 as proto;
     use metric::{Attributes, DurationHistogram, Metric};
@@ -843,10 +843,10 @@ pub(crate) mod test_helpers {
         assert_eq!(namespace, lookup_namespace);
 
         // Assert default values for service protection limits.
-        assert_eq!(namespace.max_tables.get(), DEFAULT_MAX_TABLES);
+        assert_eq!(namespace.max_tables, MaxTables::default());
         assert_eq!(
-            namespace.max_columns_per_table.get(),
-            DEFAULT_MAX_COLUMNS_PER_TABLE
+            namespace.max_columns_per_table,
+            MaxColumnsPerTable::default()
         );
 
         let conflict = repos

--- a/iox_catalog/src/interface.rs
+++ b/iox_catalog/src/interface.rs
@@ -843,9 +843,9 @@ pub(crate) mod test_helpers {
         assert_eq!(namespace, lookup_namespace);
 
         // Assert default values for service protection limits.
-        assert_eq!(namespace.max_tables, DEFAULT_MAX_TABLES);
+        assert_eq!(namespace.max_tables.get(), DEFAULT_MAX_TABLES);
         assert_eq!(
-            namespace.max_columns_per_table,
+            namespace.max_columns_per_table.get(),
             DEFAULT_MAX_COLUMNS_PER_TABLE
         );
 
@@ -903,7 +903,7 @@ pub(crate) mod test_helpers {
             .update_table_limit(namespace_name.as_str(), NEW_TABLE_LIMIT)
             .await
             .expect("namespace should be updateable");
-        assert_eq!(NEW_TABLE_LIMIT, modified.max_tables);
+        assert_eq!(NEW_TABLE_LIMIT, modified.max_tables.get());
 
         const NEW_COLUMN_LIMIT: i32 = 1500;
         let modified = repos
@@ -911,7 +911,7 @@ pub(crate) mod test_helpers {
             .update_column_limit(namespace_name.as_str(), NEW_COLUMN_LIMIT)
             .await
             .expect("namespace should be updateable");
-        assert_eq!(NEW_COLUMN_LIMIT, modified.max_columns_per_table);
+        assert_eq!(NEW_COLUMN_LIMIT, modified.max_columns_per_table.get());
 
         const NEW_RETENTION_PERIOD_NS: i64 = 5 * 60 * 60 * 1000 * 1000 * 1000;
         let modified = repos

--- a/iox_catalog/src/lib.rs
+++ b/iox_catalog/src/lib.rs
@@ -30,10 +30,6 @@ use thiserror::Error;
 
 const TIME_COLUMN: &str = "time";
 
-/// Default per-namespace table count service protection limit.
-pub const DEFAULT_MAX_TABLES: i32 = 500;
-/// Default per-table column count service protection limit.
-pub const DEFAULT_MAX_COLUMNS_PER_TABLE: i32 = 200;
 /// Default retention period for data in the catalog.
 pub const DEFAULT_RETENTION_PERIOD: Option<i64> = None;
 

--- a/iox_catalog/src/mem.rs
+++ b/iox_catalog/src/mem.rs
@@ -159,16 +159,18 @@ impl NamespaceRepo for MemTxn {
             });
         }
 
-        let max_tables = service_protection_limits.and_then(|l| l.max_tables);
-        let max_columns_per_table = service_protection_limits.and_then(|l| l.max_columns_per_table);
+        let max_tables = service_protection_limits
+            .and_then(|l| l.max_tables)
+            .unwrap_or_default();
+        let max_columns_per_table = service_protection_limits
+            .and_then(|l| l.max_columns_per_table)
+            .unwrap_or_default();
 
         let namespace = Namespace {
             id: NamespaceId::new(stage.namespaces.len() as i64 + 1),
             name: name.to_string(),
-            max_tables: max_tables.map(MaxTables::new).unwrap_or_default(),
-            max_columns_per_table: max_columns_per_table
-                .map(MaxColumnsPerTable::new)
-                .unwrap_or_default(),
+            max_tables,
+            max_columns_per_table,
             retention_period_ns,
             deleted_at: None,
             partition_template: partition_template.unwrap_or_default(),

--- a/iox_catalog/src/mem.rs
+++ b/iox_catalog/src/mem.rs
@@ -228,11 +228,11 @@ impl NamespaceRepo for MemTxn {
         }
     }
 
-    async fn update_table_limit(&mut self, name: &str, new_max: i32) -> Result<Namespace> {
+    async fn update_table_limit(&mut self, name: &str, new_max: MaxTables) -> Result<Namespace> {
         let stage = self.stage();
         match stage.namespaces.iter_mut().find(|n| n.name == name) {
             Some(n) => {
-                n.max_tables = MaxTables::new(new_max);
+                n.max_tables = new_max;
                 Ok(n.clone())
             }
             None => Err(Error::NamespaceNotFoundByName {
@@ -241,11 +241,15 @@ impl NamespaceRepo for MemTxn {
         }
     }
 
-    async fn update_column_limit(&mut self, name: &str, new_max: i32) -> Result<Namespace> {
+    async fn update_column_limit(
+        &mut self,
+        name: &str,
+        new_max: MaxColumnsPerTable,
+    ) -> Result<Namespace> {
         let stage = self.stage();
         match stage.namespaces.iter_mut().find(|n| n.name == name) {
             Some(n) => {
-                n.max_columns_per_table = MaxColumnsPerTable::new(new_max);
+                n.max_columns_per_table = new_max;
                 Ok(n.clone())
             }
             None => Err(Error::NamespaceNotFoundByName {

--- a/iox_catalog/src/mem.rs
+++ b/iox_catalog/src/mem.rs
@@ -9,7 +9,6 @@ use crate::{
         MAX_PARQUET_FILES_SELECTED_ONCE_FOR_RETENTION,
     },
     metrics::MetricDecorator,
-    DEFAULT_MAX_COLUMNS_PER_TABLE, DEFAULT_MAX_TABLES,
 };
 use async_trait::async_trait;
 use data_types::SortedColumnSet;
@@ -166,10 +165,10 @@ impl NamespaceRepo for MemTxn {
         let namespace = Namespace {
             id: NamespaceId::new(stage.namespaces.len() as i64 + 1),
             name: name.to_string(),
-            max_tables: MaxTables::new(max_tables.unwrap_or(DEFAULT_MAX_TABLES)),
-            max_columns_per_table: MaxColumnsPerTable::new(
-                max_columns_per_table.unwrap_or(DEFAULT_MAX_COLUMNS_PER_TABLE),
-            ),
+            max_tables: max_tables.map(MaxTables::new).unwrap_or_default(),
+            max_columns_per_table: max_columns_per_table
+                .map(MaxColumnsPerTable::new)
+                .unwrap_or_default(),
             retention_period_ns,
             deleted_at: None,
             partition_template: partition_template.unwrap_or_default(),

--- a/iox_catalog/src/metrics.rs
+++ b/iox_catalog/src/metrics.rs
@@ -7,10 +7,10 @@ use crate::interface::{
 use async_trait::async_trait;
 use data_types::{
     partition_template::{NamespacePartitionTemplateOverride, TablePartitionTemplateOverride},
-    Column, ColumnType, CompactionLevel, Namespace, NamespaceId, NamespaceName,
-    NamespaceServiceProtectionLimitsOverride, ParquetFile, ParquetFileId, ParquetFileParams,
-    Partition, PartitionHashId, PartitionId, PartitionKey, SkippedCompaction, SortedColumnSet,
-    Table, TableId, Timestamp, TransitionPartitionId,
+    Column, ColumnType, CompactionLevel, MaxColumnsPerTable, MaxTables, Namespace, NamespaceId,
+    NamespaceName, NamespaceServiceProtectionLimitsOverride, ParquetFile, ParquetFileId,
+    ParquetFileParams, Partition, PartitionHashId, PartitionId, PartitionKey, SkippedCompaction,
+    SortedColumnSet, Table, TableId, Timestamp, TransitionPartitionId,
 };
 use iox_time::{SystemProvider, TimeProvider};
 use metric::{DurationHistogram, Metric};
@@ -139,8 +139,8 @@ decorate!(
         "namespace_get_by_id" = get_by_id(&mut self, id: NamespaceId, deleted: SoftDeletedRows) -> Result<Option<Namespace>>;
         "namespace_get_by_name" = get_by_name(&mut self, name: &str, deleted: SoftDeletedRows) -> Result<Option<Namespace>>;
         "namespace_soft_delete" = soft_delete(&mut self, name: &str) -> Result<()>;
-        "namespace_update_table_limit" = update_table_limit(&mut self, name: &str, new_max: i32) -> Result<Namespace>;
-        "namespace_update_column_limit" = update_column_limit(&mut self, name: &str, new_max: i32) -> Result<Namespace>;
+        "namespace_update_table_limit" = update_table_limit(&mut self, name: &str, new_max: MaxTables) -> Result<Namespace>;
+        "namespace_update_column_limit" = update_column_limit(&mut self, name: &str, new_max: MaxColumnsPerTable) -> Result<Namespace>;
     ]
 );
 

--- a/iox_catalog/src/postgres.rs
+++ b/iox_catalog/src/postgres.rs
@@ -20,10 +20,10 @@ use data_types::{
     partition_template::{
         NamespacePartitionTemplateOverride, TablePartitionTemplateOverride, TemplatePart,
     },
-    Column, ColumnType, CompactionLevel, Namespace, NamespaceId, NamespaceName,
-    NamespaceServiceProtectionLimitsOverride, ParquetFile, ParquetFileId, ParquetFileParams,
-    Partition, PartitionHashId, PartitionId, PartitionKey, SkippedCompaction, Table, TableId,
-    Timestamp, TransitionPartitionId,
+    Column, ColumnType, CompactionLevel, MaxColumnsPerTable, MaxTables, Namespace, NamespaceId,
+    NamespaceName, NamespaceServiceProtectionLimitsOverride, ParquetFile, ParquetFileId,
+    ParquetFileParams, Partition, PartitionHashId, PartitionId, PartitionKey, SkippedCompaction,
+    Table, TableId, Timestamp, TransitionPartitionId,
 };
 use iox_time::{SystemProvider, TimeProvider};
 use metric::{Attributes, Instrument, MetricKind};
@@ -829,7 +829,7 @@ WHERE name=$1 AND {v};
             .map(|_| ())
     }
 
-    async fn update_table_limit(&mut self, name: &str, new_max: i32) -> Result<Namespace> {
+    async fn update_table_limit(&mut self, name: &str, new_max: MaxTables) -> Result<Namespace> {
         let rec = sqlx::query_as::<_, Namespace>(
             r#"
 UPDATE namespace
@@ -854,7 +854,11 @@ RETURNING id, name, retention_period_ns, max_tables, max_columns_per_table, dele
         Ok(namespace)
     }
 
-    async fn update_column_limit(&mut self, name: &str, new_max: i32) -> Result<Namespace> {
+    async fn update_column_limit(
+        &mut self,
+        name: &str,
+        new_max: MaxColumnsPerTable,
+    ) -> Result<Namespace> {
         let rec = sqlx::query_as::<_, Namespace>(
             r#"
 UPDATE namespace

--- a/iox_catalog/src/postgres.rs
+++ b/iox_catalog/src/postgres.rs
@@ -696,8 +696,12 @@ impl NamespaceRepo for PostgresTxn {
         retention_period_ns: Option<i64>,
         service_protection_limits: Option<NamespaceServiceProtectionLimitsOverride>,
     ) -> Result<Namespace> {
-        let max_tables = service_protection_limits.and_then(|l| l.max_tables);
-        let max_columns_per_table = service_protection_limits.and_then(|l| l.max_columns_per_table);
+        let max_tables = service_protection_limits
+            .and_then(|l| l.max_tables)
+            .unwrap_or_default();
+        let max_columns_per_table = service_protection_limits
+            .and_then(|l| l.max_columns_per_table)
+            .unwrap_or_default();
 
         let rec = sqlx::query_as::<_, Namespace>(
             r#"
@@ -713,8 +717,8 @@ RETURNING id, name, retention_period_ns, max_tables, max_columns_per_table, dele
         .bind(SHARED_TOPIC_ID) // $2
         .bind(SHARED_QUERY_POOL_ID) // $3
         .bind(retention_period_ns) // $4
-        .bind(max_tables.unwrap_or_default()) // $5
-        .bind(max_columns_per_table.unwrap_or_default()) // $6
+        .bind(max_tables) // $5
+        .bind(max_columns_per_table) // $6
         .bind(partition_template); // $7
 
         let rec = rec.fetch_one(&mut self.inner).await.map_err(|e| {

--- a/iox_catalog/src/sqlite.rs
+++ b/iox_catalog/src/sqlite.rs
@@ -11,7 +11,6 @@ use crate::{
         TRANSITION_SHARD_ID, TRANSITION_SHARD_INDEX,
     },
     metrics::MetricDecorator,
-    DEFAULT_MAX_COLUMNS_PER_TABLE, DEFAULT_MAX_TABLES,
 };
 use async_trait::async_trait;
 use data_types::{
@@ -286,8 +285,8 @@ RETURNING id, name, retention_period_ns, max_tables, max_columns_per_table, dele
         .bind(SHARED_TOPIC_ID) // $2
         .bind(SHARED_QUERY_POOL_ID) // $3
         .bind(retention_period_ns) // $4
-        .bind(max_tables.unwrap_or(DEFAULT_MAX_TABLES)) // $5
-        .bind(max_columns_per_table.unwrap_or(DEFAULT_MAX_COLUMNS_PER_TABLE)) // $6
+        .bind(max_tables.unwrap_or_default()) // $5
+        .bind(max_columns_per_table.unwrap_or_default()) // $6
         .bind(partition_template); // $7
 
         let rec = rec.fetch_one(self.inner.get_mut()).await.map_err(|e| {
@@ -2121,9 +2120,9 @@ RETURNING id, hash_id, table_id, partition_key, sort_key, sort_key_ids, new_file
         let insert_null_partition_template_namespace = sqlx::query(
             r#"
 INSERT INTO namespace (
-    name, topic_id, query_pool_id, retention_period_ns, max_tables, partition_template
+    name, topic_id, query_pool_id, retention_period_ns, partition_template
 )
-VALUES ( $1, $2, $3, $4, $5, NULL )
+VALUES ( $1, $2, $3, $4, NULL )
 RETURNING id, name, retention_period_ns, max_tables, max_columns_per_table, deleted_at,
           partition_template;
             "#,
@@ -2131,8 +2130,7 @@ RETURNING id, name, retention_period_ns, max_tables, max_columns_per_table, dele
         .bind(namespace_name) // $1
         .bind(SHARED_TOPIC_ID) // $2
         .bind(SHARED_QUERY_POOL_ID) // $3
-        .bind(None::<Option<i64>>) // $4
-        .bind(DEFAULT_MAX_TABLES); // $5
+        .bind(None::<Option<i64>>); // $4
 
         insert_null_partition_template_namespace
             .fetch_one(&pool)

--- a/iox_catalog/src/sqlite.rs
+++ b/iox_catalog/src/sqlite.rs
@@ -17,10 +17,10 @@ use data_types::{
     partition_template::{
         NamespacePartitionTemplateOverride, TablePartitionTemplateOverride, TemplatePart,
     },
-    Column, ColumnId, ColumnSet, ColumnType, CompactionLevel, Namespace, NamespaceId,
-    NamespaceName, NamespaceServiceProtectionLimitsOverride, ParquetFile, ParquetFileId,
-    ParquetFileParams, Partition, PartitionHashId, PartitionId, PartitionKey, SkippedCompaction,
-    SortedColumnSet, Table, TableId, Timestamp, TransitionPartitionId,
+    Column, ColumnId, ColumnSet, ColumnType, CompactionLevel, MaxColumnsPerTable, MaxTables,
+    Namespace, NamespaceId, NamespaceName, NamespaceServiceProtectionLimitsOverride, ParquetFile,
+    ParquetFileId, ParquetFileParams, Partition, PartitionHashId, PartitionId, PartitionKey,
+    SkippedCompaction, SortedColumnSet, Table, TableId, Timestamp, TransitionPartitionId,
 };
 use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, fmt::Display};
@@ -401,7 +401,7 @@ WHERE name=$1 AND {v};
             .map(|_| ())
     }
 
-    async fn update_table_limit(&mut self, name: &str, new_max: i32) -> Result<Namespace> {
+    async fn update_table_limit(&mut self, name: &str, new_max: MaxTables) -> Result<Namespace> {
         let rec = sqlx::query_as::<_, Namespace>(
             r#"
 UPDATE namespace
@@ -426,7 +426,11 @@ RETURNING id, name, retention_period_ns, max_tables, max_columns_per_table, dele
         Ok(namespace)
     }
 
-    async fn update_column_limit(&mut self, name: &str, new_max: i32) -> Result<Namespace> {
+    async fn update_column_limit(
+        &mut self,
+        name: &str,
+        new_max: MaxColumnsPerTable,
+    ) -> Result<Namespace> {
         let rec = sqlx::query_as::<_, Namespace>(
             r#"
 UPDATE namespace

--- a/iox_tests/src/catalog.rs
+++ b/iox_tests/src/catalog.rs
@@ -6,9 +6,9 @@ use arrow::{
 };
 use data_types::{
     partition_template::TablePartitionTemplateOverride, Column, ColumnSet, ColumnType,
-    ColumnsByName, CompactionLevel, Namespace, NamespaceName, NamespaceSchema, ParquetFile,
-    ParquetFileParams, Partition, PartitionId, SortedColumnSet, Table, TableId, TableSchema,
-    Timestamp, TransitionPartitionId,
+    ColumnsByName, CompactionLevel, MaxColumnsPerTable, MaxTables, Namespace, NamespaceName,
+    NamespaceSchema, ParquetFile, ParquetFileParams, Partition, PartitionId, SortedColumnSet,
+    Table, TableId, TableSchema, Timestamp, TransitionPartitionId,
 };
 use datafusion::physical_plan::metrics::Count;
 use datafusion_util::{unbounded_memory_pool, MemoryStream};
@@ -264,22 +264,22 @@ impl TestNamespace {
         .unwrap()
     }
 
-    /// Set the number of columns per table allowed in this namespace.
-    pub async fn update_column_limit(&self, new_max: i32) {
-        let mut repos = self.catalog.catalog.repositories().await;
-        repos
-            .namespaces()
-            .update_column_limit(&self.namespace.name, new_max)
-            .await
-            .unwrap();
-    }
-
     /// Set the number of tables allowed in this namespace.
     pub async fn update_table_limit(&self, new_max: i32) {
         let mut repos = self.catalog.catalog.repositories().await;
         repos
             .namespaces()
-            .update_table_limit(&self.namespace.name, new_max)
+            .update_table_limit(&self.namespace.name, MaxTables::new(new_max))
+            .await
+            .unwrap();
+    }
+
+    /// Set the number of columns per table allowed in this namespace.
+    pub async fn update_column_limit(&self, new_max: i32) {
+        let mut repos = self.catalog.catalog.repositories().await;
+        repos
+            .namespaces()
+            .update_column_limit(&self.namespace.name, MaxColumnsPerTable::new(new_max))
             .await
             .unwrap();
     }

--- a/ioxd_querier/src/rpc/namespace.rs
+++ b/ioxd_querier/src/rpc/namespace.rs
@@ -102,15 +102,11 @@ mod tests {
     use std::collections::HashMap;
 
     use super::*;
+    use data_types::{MaxColumnsPerTable, MaxTables};
     use generated_types::influxdata::iox::namespace::v1::namespace_service_server::NamespaceService;
     use iox_tests::TestCatalog;
     use querier::{create_ingester_connection_for_testing, QuerierCatalogCache};
     use tokio::runtime::Handle;
-
-    use iox_catalog::{
-        DEFAULT_MAX_COLUMNS_PER_TABLE as TEST_MAX_COLUMNS_PER_TABLE,
-        DEFAULT_MAX_TABLES as TEST_MAX_TABLES,
-    };
 
     /// Common retention period value we'll use in tests
     const TEST_RETENTION_PERIOD_NS: Option<i64> = Some(3_600 * 1_000_000_000);
@@ -185,16 +181,16 @@ mod tests {
                         id: 1,
                         name: "namespace2".to_string(),
                         retention_period_ns: TEST_RETENTION_PERIOD_NS,
-                        max_tables: TEST_MAX_TABLES,
-                        max_columns_per_table: TEST_MAX_COLUMNS_PER_TABLE,
+                        max_tables: MaxTables::default().get(),
+                        max_columns_per_table: MaxColumnsPerTable::default().get(),
                         partition_template: None,
                     },
                     proto::Namespace {
                         id: 2,
                         name: "namespace1".to_string(),
                         retention_period_ns: TEST_RETENTION_PERIOD_NS,
-                        max_tables: TEST_MAX_TABLES,
-                        max_columns_per_table: TEST_MAX_COLUMNS_PER_TABLE,
+                        max_tables: MaxTables::default().get(),
+                        max_columns_per_table: MaxColumnsPerTable::default().get(),
                         partition_template: None,
                     },
                 ]

--- a/ioxd_querier/src/rpc/namespace.rs
+++ b/ioxd_querier/src/rpc/namespace.rs
@@ -36,8 +36,8 @@ fn namespace_to_proto(namespace: Namespace) -> proto::Namespace {
         id: namespace.id.get(),
         name: namespace.name,
         retention_period_ns: namespace.retention_period_ns,
-        max_tables: namespace.max_tables,
-        max_columns_per_table: namespace.max_columns_per_table,
+        max_tables: namespace.max_tables.get(),
+        max_columns_per_table: namespace.max_columns_per_table.get(),
         partition_template: namespace.partition_template.as_proto().cloned(),
     }
 }

--- a/router/benches/namespace_schema_cache.rs
+++ b/router/benches/namespace_schema_cache.rs
@@ -156,8 +156,8 @@ fn generate_namespace_schema(tables: usize, columns_per_table: usize) -> Namespa
                 (format!("table{i}"), schema)
             })
             .collect::<BTreeMap<_, _>>(),
-        max_columns_per_table: MaxColumnsPerTable::new(i32::MAX),
         max_tables: MaxTables::new(i32::MAX),
+        max_columns_per_table: MaxColumnsPerTable::new(i32::MAX),
         retention_period_ns: None,
         partition_template,
     }

--- a/router/benches/namespace_schema_cache.rs
+++ b/router/benches/namespace_schema_cache.rs
@@ -6,7 +6,8 @@ use criterion::{
 };
 use data_types::{
     partition_template::{NamespacePartitionTemplateOverride, TablePartitionTemplateOverride},
-    ColumnId, ColumnSchema, NamespaceId, NamespaceName, NamespaceSchema, TableId, TableSchema,
+    ColumnId, ColumnSchema, MaxColumnsPerTable, MaxTables, NamespaceId, NamespaceName,
+    NamespaceSchema, TableId, TableSchema,
 };
 use iox_catalog::{interface::Catalog, mem::MemCatalog};
 use once_cell::sync::Lazy;
@@ -155,8 +156,8 @@ fn generate_namespace_schema(tables: usize, columns_per_table: usize) -> Namespa
                 (format!("table{i}"), schema)
             })
             .collect::<BTreeMap<_, _>>(),
-        max_columns_per_table: usize::MAX,
-        max_tables: usize::MAX,
+        max_columns_per_table: MaxColumnsPerTable::new(i32::MAX),
+        max_tables: MaxTables::new(i32::MAX),
         retention_period_ns: None,
         partition_template,
     }

--- a/router/benches/partitioner.rs
+++ b/router/benches/partitioner.rs
@@ -166,8 +166,8 @@ fn bench(
     let schema = Arc::new(NamespaceSchema {
         id: NamespaceId::new(42),
         tables: Default::default(),
-        max_columns_per_table: MaxColumnsPerTable::new(1000),
         max_tables: MaxTables::new(1000),
+        max_columns_per_table: MaxColumnsPerTable::new(1000),
         retention_period_ns: None,
         partition_template: partition_template.clone(),
     });

--- a/router/benches/partitioner.rs
+++ b/router/benches/partitioner.rs
@@ -6,7 +6,7 @@ use criterion::{
 };
 use data_types::{
     partition_template::{NamespacePartitionTemplateOverride, TablePartitionTemplateOverride},
-    NamespaceId, NamespaceName, NamespaceSchema, TableId,
+    MaxColumnsPerTable, MaxTables, NamespaceId, NamespaceName, NamespaceSchema, TableId,
 };
 use generated_types::influxdata::iox::partition_template::v1 as proto;
 use hashbrown::HashMap;
@@ -166,8 +166,8 @@ fn bench(
     let schema = Arc::new(NamespaceSchema {
         id: NamespaceId::new(42),
         tables: Default::default(),
-        max_columns_per_table: 1000,
-        max_tables: 1000,
+        max_columns_per_table: MaxColumnsPerTable::new(1000),
+        max_tables: MaxTables::new(1000),
         retention_period_ns: None,
         partition_template: partition_template.clone(),
     });

--- a/router/benches/schema_validator.rs
+++ b/router/benches/schema_validator.rs
@@ -51,8 +51,8 @@ fn bench(group: &mut BenchmarkGroup<WallTime>, tables: usize, columns_per_table:
     let namespace_schema = NamespaceSchema {
         id: NamespaceId::new(42),
         tables: Default::default(),
-        max_columns_per_table: MaxColumnsPerTable::new(42),
         max_tables: MaxTables::new(42),
+        max_columns_per_table: MaxColumnsPerTable::new(42),
         retention_period_ns: None,
         partition_template: Default::default(),
     };

--- a/router/benches/schema_validator.rs
+++ b/router/benches/schema_validator.rs
@@ -4,7 +4,7 @@ use criterion::{
     criterion_group, criterion_main, measurement::WallTime, BatchSize, BenchmarkGroup, Criterion,
     Throughput,
 };
-use data_types::{NamespaceId, NamespaceName, NamespaceSchema};
+use data_types::{MaxColumnsPerTable, MaxTables, NamespaceId, NamespaceName, NamespaceSchema};
 use hashbrown::HashMap;
 use iox_catalog::{interface::Catalog, mem::MemCatalog};
 use mutable_batch::MutableBatch;
@@ -51,8 +51,8 @@ fn bench(group: &mut BenchmarkGroup<WallTime>, tables: usize, columns_per_table:
     let namespace_schema = NamespaceSchema {
         id: NamespaceId::new(42),
         tables: Default::default(),
-        max_columns_per_table: 42,
-        max_tables: 42,
+        max_columns_per_table: MaxColumnsPerTable::new(42),
+        max_tables: MaxTables::new(42),
         retention_period_ns: None,
         partition_template: Default::default(),
     };

--- a/router/src/dml_handlers/rpc_write.rs
+++ b/router/src/dml_handlers/rpc_write.rs
@@ -382,7 +382,10 @@ mod tests {
     use rand::seq::SliceRandom;
     use tokio::runtime;
 
-    use crate::dml_handlers::rpc_write::circuit_breaking_client::mock::MockCircuitBreaker;
+    use crate::{
+        dml_handlers::rpc_write::circuit_breaking_client::mock::MockCircuitBreaker,
+        test_helpers::new_empty_namespace_schema,
+    };
 
     use super::{client::mock::MockWriteClient, *};
 
@@ -401,18 +404,6 @@ mod tests {
     const NAMESPACE_NAME: &str = "bananas";
     const NAMESPACE_ID: NamespaceId = NamespaceId::new(42);
     const ARBITRARY_TEST_NUM_PROBES: u64 = 10;
-
-    // Start a new `NamespaceSchema` with only the given ID; the rest of the fields are arbitrary.
-    fn new_empty_namespace_schema() -> Arc<NamespaceSchema> {
-        Arc::new(NamespaceSchema {
-            id: NAMESPACE_ID,
-            tables: Default::default(),
-            max_columns_per_table: 500,
-            max_tables: 200,
-            retention_period_ns: None,
-            partition_template: Default::default(),
-        })
-    }
 
     /// A helper function to perform an arbitrary write against `endpoints`,
     /// with the given number of desired distinct data copies.
@@ -450,7 +441,7 @@ mod tests {
         handler
             .write(
                 &NamespaceName::new(NAMESPACE_NAME).unwrap(),
-                new_empty_namespace_schema(),
+                Arc::new(new_empty_namespace_schema(NAMESPACE_ID.get())),
                 input,
                 None,
             )
@@ -485,7 +476,7 @@ mod tests {
         let got = handler
             .write(
                 &NamespaceName::new(NAMESPACE_NAME).unwrap(),
-                new_empty_namespace_schema(),
+                Arc::new(new_empty_namespace_schema(NAMESPACE_ID.get())),
                 input,
                 None,
             )
@@ -548,7 +539,7 @@ mod tests {
         let got = handler
             .write(
                 &NamespaceName::new(NAMESPACE_NAME).unwrap(),
-                new_empty_namespace_schema(),
+                Arc::new(new_empty_namespace_schema(NAMESPACE_ID.get())),
                 input,
                 None,
             )
@@ -617,7 +608,7 @@ mod tests {
         let got = handler
             .write(
                 &NamespaceName::new(NAMESPACE_NAME).unwrap(),
-                new_empty_namespace_schema(),
+                Arc::new(new_empty_namespace_schema(NAMESPACE_ID.get())),
                 input,
                 None,
             )

--- a/router/src/dml_handlers/schema_validation.rs
+++ b/router/src/dml_handlers/schema_validation.rs
@@ -436,7 +436,7 @@ mod tests {
     use std::sync::Arc;
 
     use assert_matches::assert_matches;
-    use data_types::ColumnType;
+    use data_types::{ColumnType, MaxColumnsPerTable, MaxTables};
     use iox_tests::{TestCatalog, TestNamespace};
     use once_cell::sync::Lazy;
 
@@ -876,7 +876,7 @@ mod tests {
             .repositories()
             .await
             .namespaces()
-            .update_table_limit(NAMESPACE.as_str(), 1)
+            .update_table_limit(NAMESPACE.as_str(), MaxTables::new(1))
             .await
             .expect("failed to set table limit");
 
@@ -937,7 +937,7 @@ mod tests {
             .repositories()
             .await
             .namespaces()
-            .update_column_limit(NAMESPACE.as_str(), 3)
+            .update_column_limit(NAMESPACE.as_str(), MaxColumnsPerTable::new(3))
             .await
             .expect("failed to set column limit");
 

--- a/router/src/gossip/anti_entropy/mst/mod.rs
+++ b/router/src/gossip/anti_entropy/mst/mod.rs
@@ -83,16 +83,16 @@ mod tests {
                 arbitrary_table_schema(),
                 (0, 10) // Set size range
             ),
-            max_columns_per_table in any::<usize>(),
             max_tables in any::<usize>(),
+            max_columns_per_table in any::<usize>(),
             retention_period_ns in any::<Option<i64>>(),
         ) -> NamespaceSchema {
             let tables = tables.into_iter().map(|(k, v)| (k.to_string(), v)).collect();
             NamespaceSchema {
                 id: NamespaceId::new(namespace_id),
                 tables,
-                max_columns_per_table: MaxColumnsPerTable::new(max_columns_per_table as i32),
                 max_tables: MaxTables::new(max_tables as i32),
+                max_columns_per_table: MaxColumnsPerTable::new(max_columns_per_table as i32),
                 retention_period_ns,
                 partition_template: Default::default(),
             }

--- a/router/src/gossip/anti_entropy/mst/mod.rs
+++ b/router/src/gossip/anti_entropy/mst/mod.rs
@@ -16,8 +16,8 @@ mod tests {
     };
 
     use data_types::{
-        ColumnId, ColumnSchema, ColumnType, ColumnsByName, NamespaceId, NamespaceName,
-        NamespaceSchema, TableId, TableSchema,
+        ColumnId, ColumnSchema, ColumnType, ColumnsByName, MaxColumnsPerTable, MaxTables,
+        NamespaceId, NamespaceName, NamespaceSchema, TableId, TableSchema,
     };
     use proptest::prelude::*;
 
@@ -91,8 +91,8 @@ mod tests {
             NamespaceSchema {
                 id: NamespaceId::new(namespace_id),
                 tables,
-                max_columns_per_table,
-                max_tables,
+                max_columns_per_table: MaxColumnsPerTable::new(max_columns_per_table as i32),
+                max_tables: MaxTables::new(max_tables as i32),
                 retention_period_ns,
                 partition_template: Default::default(),
             }

--- a/router/src/gossip/mod.rs
+++ b/router/src/gossip/mod.rs
@@ -82,33 +82,20 @@ mod tests {
             test_table_partition_override, NamespacePartitionTemplateOverride,
             TablePartitionTemplateOverride,
         },
-        Column, ColumnId, ColumnsByName, NamespaceId, NamespaceName, NamespaceSchema, TableId,
-        TableSchema,
+        Column, ColumnId, ColumnsByName, NamespaceName, TableId, TableSchema,
     };
     use generated_types::influxdata::iox::gossip::v1::schema_message::Event;
     use gossip_schema::dispatcher::SchemaEventHandler;
     use test_helpers::timeout::FutureTimeout;
 
-    use crate::namespace_cache::{CacheMissErr, MemoryNamespaceCache, NamespaceCache};
+    use crate::{
+        namespace_cache::{CacheMissErr, MemoryNamespaceCache, NamespaceCache},
+        test_helpers::DEFAULT_NAMESPACE,
+    };
 
     use super::{
         namespace_cache::NamespaceSchemaGossip, schema_change_observer::SchemaChangeObserver,
         traits::SchemaBroadcast,
-    };
-
-    pub(crate) const TABLE_NAME: &str = "bananas";
-    pub(crate) const NAMESPACE_NAME: &str = "platanos";
-    pub(crate) const TABLE_ID: i64 = 42;
-
-    pub(crate) const DEFAULT_NAMESPACE_PARTITION_TEMPLATE: NamespacePartitionTemplateOverride =
-        NamespacePartitionTemplateOverride::const_default();
-    pub(crate) const DEFAULT_NAMESPACE: NamespaceSchema = NamespaceSchema {
-        id: NamespaceId::new(4242),
-        tables: BTreeMap::new(),
-        max_columns_per_table: 1,
-        max_tables: 2,
-        retention_period_ns: None,
-        partition_template: DEFAULT_NAMESPACE_PARTITION_TEMPLATE,
     };
 
     #[derive(Debug)]

--- a/router/src/gossip/mod.rs
+++ b/router/src/gossip/mod.rs
@@ -52,6 +52,24 @@ pub mod namespace_cache;
 pub mod schema_change_observer;
 pub mod traits;
 
+use data_types::NamespaceSchema;
+use generated_types::influxdata::iox::gossip::v1::NamespaceCreated;
+
+/// Make a `NamespaceCreated` protobuf instance from the specified name and schema.
+pub(crate) fn namespace_created(
+    namespace_name: impl Into<String>,
+    schema: &NamespaceSchema,
+) -> NamespaceCreated {
+    NamespaceCreated {
+        namespace_name: namespace_name.into(),
+        namespace_id: schema.id.get(),
+        partition_template: schema.partition_template.as_proto().cloned(),
+        max_columns_per_table: schema.max_columns_per_table as u64,
+        max_tables: schema.max_tables as u64,
+        retention_period_ns: schema.retention_period_ns,
+    }
+}
+
 #[cfg(test)]
 mod mock_schema_broadcast;
 

--- a/router/src/gossip/mod.rs
+++ b/router/src/gossip/mod.rs
@@ -78,6 +78,21 @@ mod tests {
         traits::SchemaBroadcast,
     };
 
+    pub(crate) const TABLE_NAME: &str = "bananas";
+    pub(crate) const NAMESPACE_NAME: &str = "platanos";
+    pub(crate) const TABLE_ID: i64 = 42;
+
+    pub(crate) const DEFAULT_NAMESPACE_PARTITION_TEMPLATE: NamespacePartitionTemplateOverride =
+        NamespacePartitionTemplateOverride::const_default();
+    pub(crate) const DEFAULT_NAMESPACE: NamespaceSchema = NamespaceSchema {
+        id: NamespaceId::new(4242),
+        tables: BTreeMap::new(),
+        max_columns_per_table: 1,
+        max_tables: 2,
+        retention_period_ns: None,
+        partition_template: DEFAULT_NAMESPACE_PARTITION_TEMPLATE,
+    };
+
     #[derive(Debug)]
     struct GossipPipe<C> {
         rx: Arc<NamespaceSchemaGossip<C>>,

--- a/router/src/gossip/mod.rs
+++ b/router/src/gossip/mod.rs
@@ -64,8 +64,8 @@ pub(crate) fn namespace_created(
         namespace_name: namespace_name.into(),
         namespace_id: schema.id.get(),
         partition_template: schema.partition_template.as_proto().cloned(),
-        max_columns_per_table: schema.max_columns_per_table.get() as u64,
         max_tables: schema.max_tables.get() as u64,
+        max_columns_per_table: schema.max_columns_per_table.get() as u64,
         retention_period_ns: schema.retention_period_ns,
     }
 }

--- a/router/src/gossip/mod.rs
+++ b/router/src/gossip/mod.rs
@@ -64,8 +64,8 @@ pub(crate) fn namespace_created(
         namespace_name: namespace_name.into(),
         namespace_id: schema.id.get(),
         partition_template: schema.partition_template.as_proto().cloned(),
-        max_columns_per_table: schema.max_columns_per_table as u64,
-        max_tables: schema.max_tables as u64,
+        max_columns_per_table: schema.max_columns_per_table.get() as u64,
+        max_tables: schema.max_tables.get() as u64,
         retention_period_ns: schema.retention_period_ns,
     }
 }

--- a/router/src/gossip/mod.rs
+++ b/router/src/gossip/mod.rs
@@ -62,7 +62,7 @@ mod tests {
     use data_types::{
         partition_template::{
             test_table_partition_override, NamespacePartitionTemplateOverride,
-            TablePartitionTemplateOverride, PARTITION_BY_DAY_PROTO,
+            TablePartitionTemplateOverride,
         },
         Column, ColumnId, ColumnsByName, NamespaceId, NamespaceName, NamespaceSchema, TableId,
         TableSchema,
@@ -163,17 +163,7 @@ mod tests {
 
         // Wrap the tables into a schema
         let namespace_name = NamespaceName::try_from("bananas").unwrap();
-        let schema = NamespaceSchema {
-            id: NamespaceId::new(4242),
-            tables,
-            max_columns_per_table: 1,
-            max_tables: 2,
-            retention_period_ns: Some(1234),
-            partition_template: NamespacePartitionTemplateOverride::try_from(
-                (**PARTITION_BY_DAY_PROTO).clone(),
-            )
-            .unwrap(),
-        };
+        let schema = DEFAULT_NAMESPACE;
 
         // Put the new schema into A's cache
         node_a.put_schema(namespace_name.clone(), schema.clone());
@@ -221,14 +211,7 @@ mod tests {
 
         // Wrap the tables into a schema
         let namespace_name = NamespaceName::try_from("bananas").unwrap();
-        let schema = NamespaceSchema {
-            id: NamespaceId::new(4242),
-            tables,
-            max_columns_per_table: 1,
-            max_tables: 2,
-            retention_period_ns: Some(1234),
-            partition_template: NamespacePartitionTemplateOverride::default(),
-        };
+        let schema = DEFAULT_NAMESPACE;
 
         // Put the new schema into A's cache
         node_a.put_schema(namespace_name.clone(), schema.clone());

--- a/router/src/gossip/namespace_cache.rs
+++ b/router/src/gossip/namespace_cache.rs
@@ -396,11 +396,12 @@ mod tests {
     };
 
     use crate::{
-        gossip::{
-            namespace_created,
-            tests::{DEFAULT_NAMESPACE, DEFAULT_NAMESPACE_PARTITION_TEMPLATE, NAMESPACE_NAME},
-        },
+        gossip::namespace_created,
         namespace_cache::{CacheMissErr, MemoryNamespaceCache},
+        test_helpers::{
+            new_empty_namespace_schema, DEFAULT_NAMESPACE, DEFAULT_NAMESPACE_PARTITION_TEMPLATE,
+            NAMESPACE_NAME,
+        },
     };
 
     use super::*;
@@ -476,7 +477,7 @@ mod tests {
     // This test focuses on the table metadata.
     test_handle_gossip_message_!(
         table_created_no_columns,
-        existing = Some(DEFAULT_NAMESPACE.clone()),
+        existing = Some(new_empty_namespace_schema(4242)),
         message = Event::TableCreated(TableCreated {
             table: Some(TableUpdated {
                 table_name: "bananas".to_string(),
@@ -487,7 +488,7 @@ mod tests {
             partition_template: Some((**PARTITION_BY_DAY_PROTO).clone()),
         }),
         want = Ok(ns) => {
-            assert_namespace_attributes_eq(&ns, &DEFAULT_NAMESPACE);
+            assert_namespace_attributes_eq(&ns, &new_empty_namespace_schema(4242));
             assert_eq!(ns.tables.len(), 1);
 
             assert_matches!(ns.tables.get("bananas"), Some(TableSchema { id, partition_template, columns }) => {
@@ -505,7 +506,7 @@ mod tests {
     // TableCreated message.
     test_handle_gossip_message_!(
         table_created,
-        existing = Some(DEFAULT_NAMESPACE.clone()),
+        existing = Some(new_empty_namespace_schema(4242)),
         message = Event::TableCreated(TableCreated {
             table: Some(TableUpdated {
                 table_name: "bananas".to_string(),

--- a/router/src/gossip/namespace_cache.rs
+++ b/router/src/gossip/namespace_cache.rs
@@ -5,8 +5,8 @@ use std::{borrow::Cow, collections::BTreeMap, fmt::Debug};
 use async_trait::async_trait;
 use data_types::{
     partition_template::{NamespacePartitionTemplateOverride, TablePartitionTemplateOverride},
-    ColumnSchema, ColumnsByName, NamespaceId, NamespaceName, NamespaceNameError, NamespaceSchema,
-    TableId, TableSchema,
+    ColumnSchema, ColumnsByName, MaxColumnsPerTable, MaxTables, NamespaceId, NamespaceName,
+    NamespaceNameError, NamespaceSchema, TableId, TableSchema,
 };
 use generated_types::influxdata::iox::gossip::v1::{
     schema_message::Event, NamespaceCreated, TableCreated, TableUpdated,
@@ -180,8 +180,10 @@ where
                     NamespaceSchema {
                         id: NamespaceId::new(note.namespace_id),
                         tables: Default::default(),
-                        max_columns_per_table: note.max_columns_per_table as _,
-                        max_tables: note.max_tables as _,
+                        max_columns_per_table: MaxColumnsPerTable::new(
+                            note.max_columns_per_table as i32,
+                        ),
+                        max_tables: MaxTables::new(note.max_tables as i32),
                         retention_period_ns: note.retention_period_ns,
                         partition_template,
                     },

--- a/router/src/gossip/namespace_cache.rs
+++ b/router/src/gossip/namespace_cache.rs
@@ -164,8 +164,8 @@ where
             }) => {
                 debug!(
                     namespace_id = note.namespace_id,
-                    max_columns_per_table = note.max_columns_per_table,
                     max_tables = note.max_tables,
+                    max_columns_per_table = note.max_columns_per_table,
                     retention_period_ns = note.retention_period_ns,
                     ?partition_template,
                     "discovered new namespace via gossip"
@@ -180,10 +180,10 @@ where
                     NamespaceSchema {
                         id: NamespaceId::new(note.namespace_id),
                         tables: Default::default(),
+                        max_tables: MaxTables::new(note.max_tables as i32),
                         max_columns_per_table: MaxColumnsPerTable::new(
                             note.max_columns_per_table as i32,
                         ),
-                        max_tables: MaxTables::new(note.max_tables as i32),
                         retention_period_ns: note.retention_period_ns,
                         partition_template,
                     },
@@ -412,8 +412,8 @@ mod tests {
     // attribute checked separately)
     fn assert_namespace_attributes_eq(left: &NamespaceSchema, right: &NamespaceSchema) {
         assert_eq!(left.id, right.id);
-        assert_eq!(left.max_columns_per_table, right.max_columns_per_table);
         assert_eq!(left.max_tables, right.max_tables);
+        assert_eq!(left.max_columns_per_table, right.max_columns_per_table);
         assert_eq!(left.retention_period_ns, right.retention_period_ns);
         assert_eq!(left.partition_template, right.partition_template);
     }
@@ -888,8 +888,8 @@ mod tests {
             // But these fields can change.
             //
             // They will be ignored, and the local values used instead.
-            max_columns_per_table: 123456,
             max_tables: 123456,
+            max_columns_per_table: 123456,
             retention_period_ns: Some(123456),
             ..namespace_created(NAMESPACE_NAME, &DEFAULT_NAMESPACE)
         }),

--- a/router/src/gossip/namespace_cache.rs
+++ b/router/src/gossip/namespace_cache.rs
@@ -392,24 +392,15 @@ mod tests {
     use assert_matches::assert_matches;
     use data_types::{
         partition_template::{NamespacePartitionTemplateOverride, PARTITION_BY_DAY_PROTO},
-        ColumnId, ColumnType, NamespaceId,
+        ColumnId, ColumnType,
     };
 
-    use crate::namespace_cache::{CacheMissErr, MemoryNamespaceCache};
+    use crate::{
+        gossip::tests::{DEFAULT_NAMESPACE, DEFAULT_NAMESPACE_PARTITION_TEMPLATE, NAMESPACE_NAME},
+        namespace_cache::{CacheMissErr, MemoryNamespaceCache},
+    };
 
     use super::*;
-
-    const NAMESPACE_NAME: &str = "ns_bananas";
-    const DEFAULT_NAMESPACE_PARTITION_TEMPLATE: NamespacePartitionTemplateOverride =
-        NamespacePartitionTemplateOverride::const_default();
-    const DEFAULT_NAMESPACE: NamespaceSchema = NamespaceSchema {
-        id: NamespaceId::new(4242),
-        tables: BTreeMap::new(),
-        max_columns_per_table: 1,
-        max_tables: 2,
-        retention_period_ns: None,
-        partition_template: DEFAULT_NAMESPACE_PARTITION_TEMPLATE,
-    };
 
     /// Generate a test that processes the provided gossip message, and asserts
     /// the state of the namespace named [`NAMESPACE_NAME`] in the cache after.

--- a/router/src/gossip/namespace_cache.rs
+++ b/router/src/gossip/namespace_cache.rs
@@ -405,6 +405,16 @@ mod tests {
 
     use super::*;
 
+    // Compare the simply-typed attributes to ensure they're the same (`tables` being a complex
+    // attribute checked separately)
+    fn assert_namespace_attributes_eq(left: &NamespaceSchema, right: &NamespaceSchema) {
+        assert_eq!(left.id, right.id);
+        assert_eq!(left.max_columns_per_table, right.max_columns_per_table);
+        assert_eq!(left.max_tables, right.max_tables);
+        assert_eq!(left.retention_period_ns, right.retention_period_ns);
+        assert_eq!(left.partition_template, right.partition_template);
+    }
+
     /// Generate a test that processes the provided gossip message, and asserts
     /// the state of the namespace named [`NAMESPACE_NAME`] in the cache after.
     macro_rules! test_handle_gossip_message_ {
@@ -477,12 +487,8 @@ mod tests {
             partition_template: Some((**PARTITION_BY_DAY_PROTO).clone()),
         }),
         want = Ok(ns) => {
-            assert_eq!(ns.id, DEFAULT_NAMESPACE.id);
+            assert_namespace_attributes_eq(&ns, &DEFAULT_NAMESPACE);
             assert_eq!(ns.tables.len(), 1);
-            assert_eq!(ns.max_columns_per_table, DEFAULT_NAMESPACE.max_columns_per_table);
-            assert_eq!(ns.max_tables, DEFAULT_NAMESPACE.max_tables);
-            assert_eq!(ns.retention_period_ns, DEFAULT_NAMESPACE.retention_period_ns);
-            assert_eq!(ns.partition_template, DEFAULT_NAMESPACE.partition_template);
 
             assert_matches!(ns.tables.get("bananas"), Some(TableSchema { id, partition_template, columns }) => {
                 assert_eq!(id.get(), 42);
@@ -516,12 +522,8 @@ mod tests {
             partition_template: Some((**PARTITION_BY_DAY_PROTO).clone()),
         }),
         want = Ok(ns) => {
-            assert_eq!(ns.id, DEFAULT_NAMESPACE.id);
+            assert_namespace_attributes_eq(&ns, &DEFAULT_NAMESPACE);
             assert_eq!(ns.tables.len(), 1);
-            assert_eq!(ns.max_columns_per_table, DEFAULT_NAMESPACE.max_columns_per_table);
-            assert_eq!(ns.max_tables, DEFAULT_NAMESPACE.max_tables);
-            assert_eq!(ns.retention_period_ns, DEFAULT_NAMESPACE.retention_period_ns);
-            assert_eq!(ns.partition_template, DEFAULT_NAMESPACE.partition_template);
 
             assert_matches!(ns.tables.get("bananas"), Some(TableSchema { id, partition_template, columns }) => {
                 assert_eq!(id.get(), 42);
@@ -553,12 +555,8 @@ mod tests {
             partition_template: None,
         }),
         want = Ok(ns) => {
-            assert_eq!(ns.id, DEFAULT_NAMESPACE.id);
+            assert_namespace_attributes_eq(&ns, &DEFAULT_NAMESPACE);
             assert_eq!(ns.tables.len(), 1);
-            assert_eq!(ns.max_columns_per_table, DEFAULT_NAMESPACE.max_columns_per_table);
-            assert_eq!(ns.max_tables, DEFAULT_NAMESPACE.max_tables);
-            assert_eq!(ns.retention_period_ns, DEFAULT_NAMESPACE.retention_period_ns);
-            assert_eq!(ns.partition_template, DEFAULT_NAMESPACE.partition_template);
 
             assert_matches!(ns.tables.get("bananas"), Some(TableSchema { id, partition_template, columns }) => {
                 assert_eq!(id.get(), 42);
@@ -606,12 +604,8 @@ mod tests {
             partition_template: None,
         }),
         want = Ok(ns) => {
-            assert_eq!(ns.id, DEFAULT_NAMESPACE.id);
+            assert_namespace_attributes_eq(&ns, &DEFAULT_NAMESPACE);
             assert_eq!(ns.tables.len(), 2);
-            assert_eq!(ns.max_columns_per_table, DEFAULT_NAMESPACE.max_columns_per_table);
-            assert_eq!(ns.max_tables, DEFAULT_NAMESPACE.max_tables);
-            assert_eq!(ns.retention_period_ns, DEFAULT_NAMESPACE.retention_period_ns);
-            assert_eq!(ns.partition_template, DEFAULT_NAMESPACE.partition_template);
 
             // The original table still exists
             assert_matches!(ns.tables.get("platanos"), Some(TableSchema { id, .. }) => {
@@ -672,12 +666,8 @@ mod tests {
             partition_template: None,
         }),
         want = Ok(ns) => {
-            assert_eq!(ns.id, DEFAULT_NAMESPACE.id);
+            assert_namespace_attributes_eq(&ns, &DEFAULT_NAMESPACE);
             assert_eq!(ns.tables.len(), 1);
-            assert_eq!(ns.max_columns_per_table, DEFAULT_NAMESPACE.max_columns_per_table);
-            assert_eq!(ns.max_tables, DEFAULT_NAMESPACE.max_tables);
-            assert_eq!(ns.retention_period_ns, DEFAULT_NAMESPACE.retention_period_ns);
-            assert_eq!(ns.partition_template, DEFAULT_NAMESPACE.partition_template);
 
             assert_matches!(ns.tables.get("bananas"), Some(TableSchema { id, partition_template, columns }) => {
                 assert_eq!(id.get(), 42);
@@ -817,12 +807,8 @@ mod tests {
             ],
         }),
         want = Ok(ns) => {
-            assert_eq!(ns.id, DEFAULT_NAMESPACE.id);
+            assert_namespace_attributes_eq(&ns, &DEFAULT_NAMESPACE);
             assert_eq!(ns.tables.len(), 1);
-            assert_eq!(ns.max_columns_per_table, DEFAULT_NAMESPACE.max_columns_per_table);
-            assert_eq!(ns.max_tables, DEFAULT_NAMESPACE.max_tables);
-            assert_eq!(ns.retention_period_ns, DEFAULT_NAMESPACE.retention_period_ns);
-            assert_eq!(ns.partition_template, DEFAULT_NAMESPACE.partition_template);
 
             assert_matches!(ns.tables.get("bananas"), Some(TableSchema { id, partition_template, columns }) => {
                 assert_eq!(id.get(), 42);

--- a/router/src/gossip/schema_change_observer.rs
+++ b/router/src/gossip/schema_change_observer.rs
@@ -195,11 +195,11 @@ mod tests {
     use std::sync::Arc;
 
     use crate::{
-        gossip::{
-            mock_schema_broadcast::MockSchemaBroadcast,
-            tests::{DEFAULT_NAMESPACE, NAMESPACE_NAME, TABLE_ID, TABLE_NAME},
-        },
+        gossip::mock_schema_broadcast::MockSchemaBroadcast,
         namespace_cache::MemoryNamespaceCache,
+        test_helpers::{
+            new_empty_namespace_schema, DEFAULT_NAMESPACE, NAMESPACE_NAME, TABLE_ID, TABLE_NAME,
+        },
     };
 
     use super::*;
@@ -253,7 +253,7 @@ mod tests {
             num_new_columns: Default::default(),
             did_update: false,
         },
-        schema = DEFAULT_NAMESPACE,
+        schema = new_empty_namespace_schema(4242),
         want_count = 1,
         want = [Event::NamespaceCreated(created)] => {
             assert_eq!(created, &namespace_created(NAMESPACE_NAME, &DEFAULT_NAMESPACE));

--- a/router/src/gossip/schema_change_observer.rs
+++ b/router/src/gossip/schema_change_observer.rs
@@ -202,32 +202,20 @@ mod tests {
     use std::sync::Arc;
 
     use crate::{
-        gossip::mock_schema_broadcast::MockSchemaBroadcast, namespace_cache::MemoryNamespaceCache,
+        gossip::{
+            mock_schema_broadcast::MockSchemaBroadcast,
+            tests::{DEFAULT_NAMESPACE, NAMESPACE_NAME, TABLE_ID, TABLE_NAME},
+        },
+        namespace_cache::MemoryNamespaceCache,
     };
 
     use super::*;
 
     use assert_matches::assert_matches;
     use data_types::{
-        partition_template::{test_table_partition_override, NamespacePartitionTemplateOverride},
-        ColumnId, NamespaceId, TableId, TableSchema,
+        partition_template::test_table_partition_override, ColumnId, TableId, TableSchema,
     };
     use generated_types::influxdata::iox::gossip::v1::column::ColumnType;
-
-    const TABLE_NAME: &str = "bananas";
-    const NAMESPACE_NAME: &str = "platanos";
-    const TABLE_ID: i64 = 42;
-
-    const DEFAULT_NAMESPACE_PARTITION_TEMPLATE: NamespacePartitionTemplateOverride =
-        NamespacePartitionTemplateOverride::const_default();
-    const DEFAULT_NAMESPACE: NamespaceSchema = NamespaceSchema {
-        id: NamespaceId::new(4242),
-        tables: BTreeMap::new(),
-        max_columns_per_table: 1,
-        max_tables: 2,
-        retention_period_ns: None,
-        partition_template: DEFAULT_NAMESPACE_PARTITION_TEMPLATE,
-    };
 
     macro_rules! test_observe {
         (

--- a/router/src/lib.rs
+++ b/router/src/lib.rs
@@ -160,10 +160,8 @@ pub(crate) mod test_helpers {
         NamespaceSchema {
             id: NamespaceId::new(id),
             tables: BTreeMap::new(),
-            max_columns_per_table: MaxColumnsPerTable::new(
-                iox_catalog::DEFAULT_MAX_COLUMNS_PER_TABLE,
-            ),
-            max_tables: MaxTables::new(iox_catalog::DEFAULT_MAX_TABLES),
+            max_columns_per_table: MaxColumnsPerTable::const_default(),
+            max_tables: MaxTables::const_default(),
             retention_period_ns: None,
             partition_template: DEFAULT_NAMESPACE_PARTITION_TEMPLATE,
         }

--- a/router/src/lib.rs
+++ b/router/src/lib.rs
@@ -138,3 +138,31 @@ pub mod gossip;
 pub mod namespace_cache;
 pub mod namespace_resolver;
 pub mod server;
+
+#[cfg(test)]
+pub(crate) mod test_helpers {
+    use data_types::{
+        partition_template::NamespacePartitionTemplateOverride, NamespaceId, NamespaceSchema,
+    };
+    use std::collections::BTreeMap;
+
+    pub(crate) const DEFAULT_NAMESPACE: NamespaceSchema = new_empty_namespace_schema(4242);
+    pub(crate) const TABLE_NAME: &str = "bananas";
+    pub(crate) const NAMESPACE_NAME: &str = "platanos";
+    pub(crate) const TABLE_ID: i64 = 42;
+
+    pub(crate) const DEFAULT_NAMESPACE_PARTITION_TEMPLATE: NamespacePartitionTemplateOverride =
+        NamespacePartitionTemplateOverride::const_default();
+
+    /// Start a new `NamespaceSchema` with only the given ID; the rest of the fields are arbitrary.
+    pub(crate) const fn new_empty_namespace_schema(id: i64) -> NamespaceSchema {
+        NamespaceSchema {
+            id: NamespaceId::new(id),
+            tables: BTreeMap::new(),
+            max_columns_per_table: iox_catalog::DEFAULT_MAX_COLUMNS_PER_TABLE as usize,
+            max_tables: iox_catalog::DEFAULT_MAX_TABLES as usize,
+            retention_period_ns: None,
+            partition_template: DEFAULT_NAMESPACE_PARTITION_TEMPLATE,
+        }
+    }
+}

--- a/router/src/lib.rs
+++ b/router/src/lib.rs
@@ -142,7 +142,8 @@ pub mod server;
 #[cfg(test)]
 pub(crate) mod test_helpers {
     use data_types::{
-        partition_template::NamespacePartitionTemplateOverride, NamespaceId, NamespaceSchema,
+        partition_template::NamespacePartitionTemplateOverride, MaxColumnsPerTable, MaxTables,
+        NamespaceId, NamespaceSchema,
     };
     use std::collections::BTreeMap;
 
@@ -159,8 +160,10 @@ pub(crate) mod test_helpers {
         NamespaceSchema {
             id: NamespaceId::new(id),
             tables: BTreeMap::new(),
-            max_columns_per_table: iox_catalog::DEFAULT_MAX_COLUMNS_PER_TABLE as usize,
-            max_tables: iox_catalog::DEFAULT_MAX_TABLES as usize,
+            max_columns_per_table: MaxColumnsPerTable::new(
+                iox_catalog::DEFAULT_MAX_COLUMNS_PER_TABLE,
+            ),
+            max_tables: MaxTables::new(iox_catalog::DEFAULT_MAX_TABLES),
             retention_period_ns: None,
             partition_template: DEFAULT_NAMESPACE_PARTITION_TEMPLATE,
         }

--- a/router/src/lib.rs
+++ b/router/src/lib.rs
@@ -160,8 +160,8 @@ pub(crate) mod test_helpers {
         NamespaceSchema {
             id: NamespaceId::new(id),
             tables: BTreeMap::new(),
-            max_columns_per_table: MaxColumnsPerTable::const_default(),
             max_tables: MaxTables::const_default(),
+            max_columns_per_table: MaxColumnsPerTable::const_default(),
             retention_period_ns: None,
             partition_template: DEFAULT_NAMESPACE_PARTITION_TEMPLATE,
         }

--- a/router/src/namespace_cache/memory.rs
+++ b/router/src/namespace_cache/memory.rs
@@ -186,8 +186,8 @@ mod tests {
         NamespaceSchema {
             id: TEST_NAMESPACE_ID,
             tables: Default::default(),
-            max_columns_per_table: MaxColumnsPerTable::new(50),
             max_tables: MaxTables::new(24),
+            max_columns_per_table: MaxColumnsPerTable::new(50),
             retention_period_ns: Some(876),
             partition_template: Default::default(),
         }
@@ -198,8 +198,8 @@ mod tests {
         NamespaceSchema {
             id: TEST_NAMESPACE_ID,
             tables: Default::default(),
-            max_columns_per_table: MaxColumnsPerTable::new(10),
             max_tables: MaxTables::new(42),
+            max_columns_per_table: MaxColumnsPerTable::new(10),
             retention_period_ns: Some(876),
             partition_template: Default::default(),
         }
@@ -484,16 +484,16 @@ mod tests {
                 arbitrary_table_schema(),
                 (0, 10) // Set size range
             ),
-            max_columns_per_table in any::<usize>(),
             max_tables in any::<usize>(),
+            max_columns_per_table in any::<usize>(),
             retention_period_ns in any::<Option<i64>>(),
         ) -> NamespaceSchema {
             let tables = tables.into_iter().map(|(k, v)| (k.to_string(), v)).collect();
             NamespaceSchema {
                 id: TEST_NAMESPACE_ID,
                 tables,
-                max_columns_per_table: MaxColumnsPerTable::new(max_columns_per_table as i32),
                 max_tables: MaxTables::new(max_tables as i32),
+                max_columns_per_table: MaxColumnsPerTable::new(max_columns_per_table as i32),
                 retention_period_ns,
                 partition_template: Default::default(),
             }
@@ -577,8 +577,8 @@ mod tests {
 
             // Assert the "last writer wins" in terms of all other namespace
             // values.
-            assert_eq!(got.max_columns_per_table, b.max_columns_per_table);
             assert_eq!(got.max_tables, b.max_tables);
+            assert_eq!(got.max_columns_per_table, b.max_columns_per_table);
             assert_eq!(got.retention_period_ns, b.retention_period_ns);
         }
     }

--- a/router/src/namespace_cache/memory.rs
+++ b/router/src/namespace_cache/memory.rs
@@ -172,8 +172,8 @@ mod tests {
 
     use assert_matches::assert_matches;
     use data_types::{
-        Column, ColumnId, ColumnSchema, ColumnType, ColumnsByName, NamespaceId, TableId,
-        TableSchema,
+        Column, ColumnId, ColumnSchema, ColumnType, ColumnsByName, MaxColumnsPerTable, MaxTables,
+        NamespaceId, TableId, TableSchema,
     };
     use proptest::{prelude::*, prop_compose, proptest};
 
@@ -186,8 +186,8 @@ mod tests {
         NamespaceSchema {
             id: TEST_NAMESPACE_ID,
             tables: Default::default(),
-            max_columns_per_table: 50,
-            max_tables: 24,
+            max_columns_per_table: MaxColumnsPerTable::new(50),
+            max_tables: MaxTables::new(24),
             retention_period_ns: Some(876),
             partition_template: Default::default(),
         }
@@ -198,8 +198,8 @@ mod tests {
         NamespaceSchema {
             id: TEST_NAMESPACE_ID,
             tables: Default::default(),
-            max_columns_per_table: 10,
-            max_tables: 42,
+            max_columns_per_table: MaxColumnsPerTable::new(10),
+            max_tables: MaxTables::new(42),
             retention_period_ns: Some(876),
             partition_template: Default::default(),
         }
@@ -492,8 +492,8 @@ mod tests {
             NamespaceSchema {
                 id: TEST_NAMESPACE_ID,
                 tables,
-                max_columns_per_table,
-                max_tables,
+                max_columns_per_table: MaxColumnsPerTable::new(max_columns_per_table as i32),
+                max_tables: MaxTables::new(max_tables as i32),
                 retention_period_ns,
                 partition_template: Default::default(),
             }

--- a/router/src/namespace_cache/metrics.rs
+++ b/router/src/namespace_cache/metrics.rs
@@ -164,8 +164,8 @@ mod tests {
         NamespaceSchema {
             id: NamespaceId::new(42),
             tables,
-            max_columns_per_table: MaxColumnsPerTable::new(100),
             max_tables: MaxTables::new(42),
+            max_columns_per_table: MaxColumnsPerTable::new(100),
             retention_period_ns: None,
             partition_template: Default::default(),
         }

--- a/router/src/namespace_cache/metrics.rs
+++ b/router/src/namespace_cache/metrics.rs
@@ -125,7 +125,8 @@ where
 mod tests {
     use assert_matches::assert_matches;
     use data_types::{
-        Column, ColumnId, ColumnType, ColumnsByName, NamespaceId, TableId, TableSchema,
+        Column, ColumnId, ColumnType, ColumnsByName, MaxColumnsPerTable, MaxTables, NamespaceId,
+        TableId, TableSchema,
     };
     use metric::{Attributes, MetricObserver, Observation};
 
@@ -163,8 +164,8 @@ mod tests {
         NamespaceSchema {
             id: NamespaceId::new(42),
             tables,
-            max_columns_per_table: 100,
-            max_tables: 42,
+            max_columns_per_table: MaxColumnsPerTable::new(100),
+            max_tables: MaxTables::new(42),
             retention_period_ns: None,
             partition_template: Default::default(),
         }

--- a/router/src/namespace_cache/read_through_cache.rs
+++ b/router/src/namespace_cache/read_through_cache.rs
@@ -98,11 +98,12 @@ where
 #[cfg(test)]
 mod tests {
     use assert_matches::assert_matches;
-    use data_types::NamespaceId;
     use iox_catalog::mem::MemCatalog;
 
     use super::*;
-    use crate::namespace_cache::memory::MemoryNamespaceCache;
+    use crate::{
+        namespace_cache::memory::MemoryNamespaceCache, test_helpers::new_empty_namespace_schema,
+    };
 
     #[tokio::test]
     async fn test_put_get() {
@@ -118,14 +119,7 @@ mod tests {
         assert_matches!(cache.get_schema(&ns).await, Err(_));
 
         // Place a schema in the cache for that name
-        let schema1 = NamespaceSchema {
-            id: NamespaceId::new(1),
-            tables: Default::default(),
-            max_columns_per_table: iox_catalog::DEFAULT_MAX_COLUMNS_PER_TABLE as usize,
-            max_tables: iox_catalog::DEFAULT_MAX_TABLES as usize,
-            retention_period_ns: iox_catalog::DEFAULT_RETENTION_PERIOD,
-            partition_template: Default::default(),
-        };
+        let schema1 = new_empty_namespace_schema(1);
         assert_matches!(cache.put_schema(ns.clone(), schema1.clone()), (result, _) => {
             assert_eq!(*result, schema1);
         });
@@ -154,14 +148,7 @@ mod tests {
         assert_matches!(cache.get_schema(&ns).await, Err(_));
 
         // Place a schema in the catalog for that name
-        let schema1 = NamespaceSchema {
-            id: NamespaceId::new(1),
-            tables: Default::default(),
-            max_columns_per_table: iox_catalog::DEFAULT_MAX_COLUMNS_PER_TABLE as usize,
-            max_tables: iox_catalog::DEFAULT_MAX_TABLES as usize,
-            retention_period_ns: iox_catalog::DEFAULT_RETENTION_PERIOD,
-            partition_template: Default::default(),
-        };
+        let schema1 = new_empty_namespace_schema(1);
 
         assert_matches!(
             catalog

--- a/router/src/namespace_cache/sharded_cache.rs
+++ b/router/src/namespace_cache/sharded_cache.rs
@@ -51,11 +51,10 @@ mod tests {
     use std::{collections::HashMap, iter};
 
     use assert_matches::assert_matches;
-    use data_types::NamespaceId;
     use rand::{distributions::Alphanumeric, thread_rng, Rng};
 
     use super::*;
-    use crate::namespace_cache::MemoryNamespaceCache;
+    use crate::{namespace_cache::MemoryNamespaceCache, test_helpers::new_empty_namespace_schema};
 
     fn rand_namespace() -> NamespaceName<'static> {
         thread_rng()
@@ -65,17 +64,6 @@ mod tests {
             .collect::<String>()
             .try_into()
             .expect("generated invalid random namespace name")
-    }
-
-    fn schema_with_id(id: i64) -> NamespaceSchema {
-        NamespaceSchema {
-            id: NamespaceId::new(id),
-            tables: Default::default(),
-            max_columns_per_table: 7,
-            max_tables: 42,
-            retention_period_ns: None,
-            partition_template: Default::default(),
-        }
     }
 
     #[tokio::test]
@@ -104,13 +92,13 @@ mod tests {
 
         // Populate the cache
         for (name, id) in &names {
-            let schema = schema_with_id(*id as _);
+            let schema = new_empty_namespace_schema(*id as _);
             assert_matches!(cache.put_schema(name.clone(), schema), (_, _));
         }
 
         // The mapping should be stable
         for (name, id) in names {
-            let want = schema_with_id(id as _);
+            let want = new_empty_namespace_schema(id as _);
             assert_matches!(cache.get_schema(&name).await, Ok(got) => {
                 assert_eq!(got, Arc::new(want));
             });

--- a/router/src/namespace_resolver.rs
+++ b/router/src/namespace_resolver.rs
@@ -8,6 +8,7 @@ use thiserror::Error;
 
 use crate::namespace_cache::NamespaceCache;
 
+#[cfg(test)]
 pub mod mock;
 pub(crate) mod ns_autocreation;
 pub use ns_autocreation::*;
@@ -71,14 +72,16 @@ mod tests {
     use std::sync::Arc;
 
     use assert_matches::assert_matches;
-    use data_types::{NamespaceId, NamespaceSchema};
     use iox_catalog::{
         interface::{Catalog, SoftDeletedRows},
         mem::MemCatalog,
     };
 
     use super::*;
-    use crate::namespace_cache::{MemoryNamespaceCache, ReadThroughCache};
+    use crate::{
+        namespace_cache::{MemoryNamespaceCache, ReadThroughCache},
+        test_helpers::new_empty_namespace_schema,
+    };
 
     #[tokio::test]
     async fn test_cache_hit() {
@@ -92,17 +95,7 @@ mod tests {
             MemoryNamespaceCache::default(),
             Arc::clone(&catalog),
         ));
-        cache.put_schema(
-            ns.clone(),
-            NamespaceSchema {
-                id: NamespaceId::new(42),
-                tables: Default::default(),
-                max_columns_per_table: 4,
-                max_tables: 42,
-                retention_period_ns: None,
-                partition_template: Default::default(),
-            },
-        );
+        cache.put_schema(ns.clone(), new_empty_namespace_schema(42));
 
         let resolver = NamespaceSchemaResolver::new(Arc::clone(&cache));
 

--- a/router/src/namespace_resolver/mock.rs
+++ b/router/src/namespace_resolver/mock.rs
@@ -2,16 +2,15 @@
 
 #![allow(missing_docs)]
 
-use std::{
-    collections::{BTreeMap, HashMap},
-    sync::Arc,
-};
+use std::{collections::HashMap, sync::Arc};
 
 use async_trait::async_trait;
 use data_types::{NamespaceId, NamespaceName, NamespaceSchema};
 use parking_lot::Mutex;
 
 use super::NamespaceResolver;
+
+use crate::test_helpers::new_empty_namespace_schema;
 
 #[derive(Debug, Default)]
 pub struct MockNamespaceResolver {
@@ -27,25 +26,13 @@ impl MockNamespaceResolver {
 
     pub fn with_mapping(self, name: impl Into<String> + 'static, id: NamespaceId) -> Self {
         let name = NamespaceName::try_from(name.into()).unwrap();
-        let empty_namespace_schema = Arc::new(new_empty_namespace_schema(id));
+        let empty_namespace_schema = Arc::new(new_empty_namespace_schema(id.get()));
         assert!(self
             .map
             .lock()
             .insert(name, empty_namespace_schema)
             .is_none());
         self
-    }
-}
-
-// Start a new `NamespaceSchema` with only the given ID; the rest of the fields are arbitrary.
-fn new_empty_namespace_schema(id: NamespaceId) -> NamespaceSchema {
-    NamespaceSchema {
-        id,
-        tables: BTreeMap::new(),
-        max_columns_per_table: 500,
-        max_tables: 200,
-        retention_period_ns: None,
-        partition_template: Default::default(),
     }
 }
 

--- a/router/src/namespace_resolver/ns_autocreation.rs
+++ b/router/src/namespace_resolver/ns_autocreation.rs
@@ -137,13 +137,14 @@ mod tests {
     use std::sync::Arc;
 
     use assert_matches::assert_matches;
-    use data_types::{Namespace, NamespaceId, NamespaceSchema};
+    use data_types::{Namespace, NamespaceId};
     use iox_catalog::{interface::SoftDeletedRows, mem::MemCatalog};
 
     use super::*;
     use crate::{
         namespace_cache::{MemoryNamespaceCache, ReadThroughCache},
         namespace_resolver::{mock::MockNamespaceResolver, NamespaceSchemaResolver},
+        test_helpers::new_empty_namespace_schema,
     };
 
     /// Common retention period value we'll use in tests
@@ -160,17 +161,7 @@ mod tests {
 
         // Prep the cache before the test to cause a hit
         let cache = ReadThroughCache::new(MemoryNamespaceCache::default(), Arc::clone(&catalog));
-        cache.put_schema(
-            ns.clone(),
-            NamespaceSchema {
-                id: NAMESPACE_ID,
-                tables: Default::default(),
-                max_columns_per_table: 4,
-                max_tables: 42,
-                retention_period_ns: None,
-                partition_template: Default::default(),
-            },
-        );
+        cache.put_schema(ns.clone(), new_empty_namespace_schema(NAMESPACE_ID.get()));
 
         let creator = NamespaceAutocreation::new(
             MockNamespaceResolver::default().with_mapping(ns.clone(), NAMESPACE_ID),

--- a/router/src/namespace_resolver/ns_autocreation.rs
+++ b/router/src/namespace_resolver/ns_autocreation.rs
@@ -137,7 +137,7 @@ mod tests {
     use std::sync::Arc;
 
     use assert_matches::assert_matches;
-    use data_types::{Namespace, NamespaceId};
+    use data_types::{MaxColumnsPerTable, MaxTables, Namespace, NamespaceId};
     use iox_catalog::{interface::SoftDeletedRows, mem::MemCatalog};
 
     use super::*;
@@ -228,8 +228,10 @@ mod tests {
             Namespace {
                 id: NamespaceId::new(1),
                 name: ns.to_string(),
-                max_tables: iox_catalog::DEFAULT_MAX_TABLES,
-                max_columns_per_table: iox_catalog::DEFAULT_MAX_COLUMNS_PER_TABLE,
+                max_tables: MaxTables::new(iox_catalog::DEFAULT_MAX_TABLES),
+                max_columns_per_table: MaxColumnsPerTable::new(
+                    iox_catalog::DEFAULT_MAX_COLUMNS_PER_TABLE
+                ),
                 retention_period_ns: TEST_RETENTION_PERIOD_NS,
                 deleted_at: None,
                 partition_template: Default::default(),

--- a/router/src/namespace_resolver/ns_autocreation.rs
+++ b/router/src/namespace_resolver/ns_autocreation.rs
@@ -137,7 +137,7 @@ mod tests {
     use std::sync::Arc;
 
     use assert_matches::assert_matches;
-    use data_types::{MaxColumnsPerTable, MaxTables, Namespace, NamespaceId};
+    use data_types::{Namespace, NamespaceId};
     use iox_catalog::{interface::SoftDeletedRows, mem::MemCatalog};
 
     use super::*;
@@ -228,10 +228,8 @@ mod tests {
             Namespace {
                 id: NamespaceId::new(1),
                 name: ns.to_string(),
-                max_tables: MaxTables::new(iox_catalog::DEFAULT_MAX_TABLES),
-                max_columns_per_table: MaxColumnsPerTable::new(
-                    iox_catalog::DEFAULT_MAX_COLUMNS_PER_TABLE
-                ),
+                max_tables: Default::default(),
+                max_columns_per_table: Default::default(),
                 retention_period_ns: TEST_RETENTION_PERIOD_NS,
                 deleted_at: None,
                 partition_template: Default::default(),

--- a/router/tests/grpc.rs
+++ b/router/tests/grpc.rs
@@ -19,6 +19,7 @@ use router::{
     namespace_resolver::{self, NamespaceCreationError},
     server::http::Error,
 };
+use service_grpc_namespace::namespace_to_proto;
 use test_helpers::assert_error;
 use tonic::{Code, Request};
 
@@ -651,12 +652,7 @@ async fn test_update_namespace_limit_max_tables() {
             .await
             .expect("query failure");
         assert_matches!(db_list.as_slice(), [ns] => {
-            assert_eq!(ns.id.get(), got.id);
-            assert_eq!(ns.name, got.name);
-            assert_eq!(ns.retention_period_ns, got.retention_period_ns);
-            assert_eq!(ns.max_tables, got.max_tables);
-            assert_eq!(ns.max_columns_per_table, got.max_columns_per_table);
-            assert!(ns.deleted_at.is_none());
+            assert_eq!(got, namespace_to_proto(ns));
         });
     }
 
@@ -738,12 +734,7 @@ async fn test_update_namespace_limit_max_columns_per_table() {
             .await
             .expect("query failure");
         assert_matches!(db_list.as_slice(), [ns] => {
-            assert_eq!(ns.id.get(), got.id);
-            assert_eq!(ns.name, got.name);
-            assert_eq!(ns.retention_period_ns, got.retention_period_ns);
-            assert_eq!(ns.max_tables, got.max_tables);
-            assert_eq!(ns.max_columns_per_table, got.max_columns_per_table);
-            assert!(ns.deleted_at.is_none());
+            assert_eq!(got, namespace_to_proto(ns));
         });
     }
 
@@ -853,12 +844,7 @@ async fn test_update_namespace_limit_0_max_tables_max_columns() {
             .await
             .expect("query failure");
         assert_matches!(db_list.as_slice(), [ns] => {
-            assert_eq!(ns.id.get(), create.id);
-            assert_eq!(ns.name, create.name);
-            assert_eq!(ns.retention_period_ns, create.retention_period_ns);
-            assert_eq!(ns.max_tables, create.max_tables);
-            assert_eq!(ns.max_columns_per_table, create.max_columns_per_table);
-            assert!(ns.deleted_at.is_none());
+            assert_eq!(create, namespace_to_proto(ns));
         });
     }
 }

--- a/router/tests/grpc.rs
+++ b/router/tests/grpc.rs
@@ -1,7 +1,7 @@
 use std::time::Duration;
 
 use assert_matches::assert_matches;
-use data_types::NamespaceId;
+use data_types::{MaxColumnsPerTable, MaxTables, NamespaceId};
 use generated_types::influxdata::{
     iox::{
         ingester::v1::WriteRequest,
@@ -624,7 +624,7 @@ async fn test_update_namespace_limit_max_tables() {
     assert_eq!(got.max_tables, 1);
     assert_eq!(
         got.max_columns_per_table,
-        iox_catalog::DEFAULT_MAX_COLUMNS_PER_TABLE
+        MaxColumnsPerTable::default().get()
     );
 
     // The list namespace RPC should show the updated namespace
@@ -706,7 +706,7 @@ async fn test_update_namespace_limit_max_columns_per_table() {
 
     assert_eq!(got.name, "bananas_test");
     assert_eq!(got.id, 1);
-    assert_eq!(got.max_tables, iox_catalog::DEFAULT_MAX_TABLES);
+    assert_eq!(got.max_tables, MaxTables::default().get());
     assert_eq!(got.max_columns_per_table, 1);
 
     // The list namespace RPC should show the updated namespace

--- a/router/tests/http.rs
+++ b/router/tests/http.rs
@@ -1,6 +1,6 @@
 use crate::common::{TestContextBuilder, TEST_RETENTION_PERIOD};
 use assert_matches::assert_matches;
-use data_types::ColumnType;
+use data_types::{ColumnType, MaxTables};
 use futures::{stream::FuturesUnordered, StreamExt};
 use generated_types::influxdata::{iox::ingester::v1::WriteRequest, pbdata::v1::DatabaseBatch};
 use hashbrown::HashMap;
@@ -226,7 +226,7 @@ async fn test_schema_limit() {
         .repositories()
         .await
         .namespaces()
-        .update_table_limit("bananas_test", 1)
+        .update_table_limit("bananas_test", MaxTables::new(1))
         .await
         .expect("failed to update table limit");
 

--- a/service_grpc_namespace/src/lib.rs
+++ b/service_grpc_namespace/src/lib.rs
@@ -266,8 +266,8 @@ pub fn namespace_to_proto(namespace: &CatalogNamespace) -> Namespace {
         id: namespace.id.get(),
         name: namespace.name.clone(),
         retention_period_ns: namespace.retention_period_ns,
-        max_tables: namespace.max_tables,
-        max_columns_per_table: namespace.max_columns_per_table,
+        max_tables: namespace.max_tables.get(),
+        max_columns_per_table: namespace.max_columns_per_table.get(),
         partition_template: namespace.partition_template.as_proto().cloned(),
     }
 }

--- a/service_grpc_namespace/src/lib.rs
+++ b/service_grpc_namespace/src/lib.rs
@@ -19,8 +19,8 @@ use workspace_hack as _;
 use std::sync::Arc;
 
 use data_types::{
-    partition_template::NamespacePartitionTemplateOverride, Namespace as CatalogNamespace,
-    NamespaceName, NamespaceServiceProtectionLimitsOverride,
+    partition_template::NamespacePartitionTemplateOverride, MaxColumnsPerTable, MaxTables,
+    Namespace as CatalogNamespace, NamespaceName, NamespaceServiceProtectionLimitsOverride,
 };
 use generated_types::influxdata::iox::namespace::v1::{
     update_namespace_service_protection_limit_request::LimitUpdate, *,
@@ -207,7 +207,7 @@ impl namespace_service_server::NamespaceService for NamespaceService {
                 }
                 repos
                     .namespaces()
-                    .update_table_limit(&namespace_name, n)
+                    .update_table_limit(&namespace_name, MaxTables::new(n))
                     .await
                     .map_err(|e| {
                         warn!(
@@ -227,7 +227,7 @@ impl namespace_service_server::NamespaceService for NamespaceService {
                 }
                 repos
                     .namespaces()
-                    .update_column_limit(&namespace_name, n)
+                    .update_column_limit(&namespace_name, MaxColumnsPerTable::new(n))
                     .await
                     .map_err(|e| {
                         warn!(

--- a/service_grpc_namespace/src/lib.rs
+++ b/service_grpc_namespace/src/lib.rs
@@ -59,7 +59,7 @@ impl namespace_service_server::NamespaceService for NamespaceService {
                 Status::not_found(e.to_string())
             })?;
         Ok(Response::new(GetNamespacesResponse {
-            namespaces: namespaces.into_iter().map(namespace_to_proto).collect(),
+            namespaces: namespaces.iter().map(namespace_to_proto).collect(),
         }))
     }
 
@@ -175,7 +175,7 @@ impl namespace_service_server::NamespaceService for NamespaceService {
         );
 
         Ok(Response::new(UpdateNamespaceRetentionResponse {
-            namespace: Some(namespace_to_proto(namespace)),
+            namespace: Some(namespace_to_proto(&namespace)),
         }))
     }
 
@@ -252,13 +252,14 @@ impl namespace_service_server::NamespaceService for NamespaceService {
 
         Ok(Response::new(
             UpdateNamespaceServiceProtectionLimitResponse {
-                namespace: Some(namespace_to_proto(namespace)),
+                namespace: Some(namespace_to_proto(&namespace)),
             },
         ))
     }
 }
 
-fn namespace_to_proto(namespace: CatalogNamespace) -> Namespace {
+/// Convert the namespace record from the catalog into its protobuf representation.
+pub fn namespace_to_proto(namespace: &CatalogNamespace) -> Namespace {
     Namespace {
         id: namespace.id.get(),
         name: namespace.name.clone(),

--- a/service_grpc_namespace/src/lib.rs
+++ b/service_grpc_namespace/src/lib.rs
@@ -114,7 +114,9 @@ impl namespace_service_server::NamespaceService for NamespaceService {
             "created namespace"
         );
 
-        Ok(Response::new(namespace_to_create_response_proto(namespace)))
+        Ok(Response::new(CreateNamespaceResponse {
+            namespace: Some(namespace_to_proto(&namespace)),
+        }))
     }
 
     async fn delete_namespace(
@@ -267,19 +269,6 @@ pub fn namespace_to_proto(namespace: &CatalogNamespace) -> Namespace {
         max_tables: namespace.max_tables,
         max_columns_per_table: namespace.max_columns_per_table,
         partition_template: namespace.partition_template.as_proto().cloned(),
-    }
-}
-
-fn namespace_to_create_response_proto(namespace: CatalogNamespace) -> CreateNamespaceResponse {
-    CreateNamespaceResponse {
-        namespace: Some(Namespace {
-            id: namespace.id.get(),
-            name: namespace.name.clone(),
-            retention_period_ns: namespace.retention_period_ns,
-            max_tables: namespace.max_tables,
-            max_columns_per_table: namespace.max_columns_per_table,
-            partition_template: namespace.partition_template.as_proto().cloned(),
-        }),
     }
 }
 


### PR DESCRIPTION
This connects to https://github.com/influxdata/idpe/issues/18100 but doesn't actually fix it yet.

These refactorings makes the change easy, the next PR will make the easy change to fix that issue.

![Bill Hader as Stefon on Saturday Night Live](https://github.com/influxdata/influxdb_iox/assets/193874/f4f88c99-0f65-4575-a878-7ec252d57924)

This is IOx's hottest PR. It's got everything:

- Reduced test code duplication
- Extracting related code from `data_types` into its own module
- Adding a newtype so raw values can't be accidentally mixed up
- Defining application defaults as `Default` impls on the application types, rather than consts in the catalog (the database actually has default values that are different 😱 )
- Hobgoblins providing foolish consistency by having `max_tables` fields always appear before `max_columns_per_table` fields
- Putting all related validation logic into one spot
- Small commits that should be straightforward to review one at a time