### PR TITLE
fix: fixing validation of max tables/max columns per table

### DIFF
--- a/compactor/src/components/namespaces_source/mock.rs
+++ b/compactor/src/components/namespaces_source/mock.rs
@@ -185,8 +185,8 @@ mod tests {
                     ns: Namespace {
                         id,
                         name: "ns".to_string(),
-                        max_tables: MaxTables::new(10),
-                        max_columns_per_table: MaxColumnsPerTable::new(10),
+                        max_tables: MaxTables::try_from(10).unwrap(),
+                        max_columns_per_table: MaxColumnsPerTable::try_from(10).unwrap(),
                         retention_period_ns: None,
                         deleted_at: None,
                         partition_template: Default::default(),
@@ -194,8 +194,8 @@ mod tests {
                     schema: NamespaceSchema {
                         id,
                         tables,
-                        max_tables: MaxTables::new(42),
-                        max_columns_per_table: MaxColumnsPerTable::new(10),
+                        max_tables: MaxTables::try_from(42).unwrap(),
+                        max_columns_per_table: MaxColumnsPerTable::try_from(10).unwrap(),
                         retention_period_ns: None,
                         partition_template: Default::default(),
                     },

--- a/data_types/src/lib.rs
+++ b/data_types/src/lib.rs
@@ -2681,8 +2681,8 @@ mod tests {
         let schema1 = NamespaceSchema {
             id: NamespaceId::new(1),
             tables: BTreeMap::from([]),
-            max_tables: MaxTables::new(42),
-            max_columns_per_table: MaxColumnsPerTable::new(4),
+            max_tables: MaxTables::try_from(42).unwrap(),
+            max_columns_per_table: MaxColumnsPerTable::try_from(4).unwrap(),
             retention_period_ns: None,
             partition_template: Default::default(),
         };
@@ -2696,8 +2696,8 @@ mod tests {
                     partition_template: Default::default(),
                 },
             )]),
-            max_tables: MaxTables::new(42),
-            max_columns_per_table: MaxColumnsPerTable::new(4),
+            max_tables: MaxTables::try_from(42).unwrap(),
+            max_columns_per_table: MaxColumnsPerTable::try_from(4).unwrap(),
             retention_period_ns: None,
             partition_template: Default::default(),
         };

--- a/data_types/src/service_limits.rs
+++ b/data_types/src/service_limits.rs
@@ -3,26 +3,83 @@
 use generated_types::influxdata::iox::namespace::{
     v1 as namespace_proto, v1::update_namespace_service_protection_limit_request::LimitUpdate,
 };
+use observability_deps::tracing::*;
+use std::num::NonZeroUsize;
 use thiserror::Error;
 
 /// Max tables allowed in a namespace.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, sqlx::Type)]
-#[sqlx(transparent)]
-pub struct MaxTables(i32);
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct MaxTables(NonZeroUsize);
+
+impl TryFrom<usize> for MaxTables {
+    type Error = ServiceLimitError;
+
+    fn try_from(value: usize) -> Result<Self, Self::Error> {
+        // Even though the value is stored as a `usize`, service limits are stored as `i32` in the
+        // database and transferred as i32 over protobuf. So try to convert to an `i32` (and throw
+        // away the result) so that we know about invalid values before trying to use them.
+        if i32::try_from(value).is_err() {
+            return Err(ServiceLimitError::MustFitInI32);
+        }
+
+        let nonzero_value =
+            NonZeroUsize::new(value).ok_or(ServiceLimitError::MustBeGreaterThanZero)?;
+
+        Ok(Self(nonzero_value))
+    }
+}
+
+impl TryFrom<u64> for MaxTables {
+    type Error = ServiceLimitError;
+
+    fn try_from(value: u64) -> Result<Self, Self::Error> {
+        // Even though the value is stored as a `usize`, service limits are stored as `i32` in the
+        // database and transferred as i32 over protobuf. So try to convert to an `i32` (and throw
+        // away the result) so that we know about invalid values before trying to use them.
+        if i32::try_from(value).is_err() {
+            return Err(ServiceLimitError::MustFitInI32);
+        }
+
+        let nonzero_value = usize::try_from(value)
+            .ok()
+            .and_then(NonZeroUsize::new)
+            .ok_or(ServiceLimitError::MustBeGreaterThanZero)?;
+
+        Ok(Self(nonzero_value))
+    }
+}
+
+impl TryFrom<i32> for MaxTables {
+    type Error = ServiceLimitError;
+
+    fn try_from(value: i32) -> Result<Self, Self::Error> {
+        let nonzero_value = usize::try_from(value)
+            .ok()
+            .and_then(NonZeroUsize::new)
+            .ok_or(ServiceLimitError::MustBeGreaterThanZero)?;
+
+        Ok(Self(nonzero_value))
+    }
+}
 
 #[allow(missing_docs)]
 impl MaxTables {
-    pub const fn new(v: i32) -> Self {
-        Self(v)
+    pub fn get(&self) -> usize {
+        self.0.get()
     }
 
-    pub fn get(&self) -> i32 {
-        self.0
+    /// For use by the database and some protobuf representations. It should not be possible to
+    /// construct a `MaxTables` instance that contains a `NonZeroUsize` that won't fit in an `i32`.
+    pub fn get_i32(&self) -> i32 {
+        self.0.get() as i32
     }
 
     /// Default per-namespace table count service protection limit.
     pub const fn const_default() -> Self {
-        Self(500)
+        // This is safe because the hardcoded 500 is not 0.
+        let value = unsafe { NonZeroUsize::new_unchecked(500) };
+
+        Self(value)
     }
 }
 
@@ -38,24 +95,130 @@ impl std::fmt::Display for MaxTables {
     }
 }
 
+// Tell sqlx this is an i32 in the database.
+impl<DB> sqlx::Type<DB> for MaxTables
+where
+    i32: sqlx::Type<DB>,
+    DB: sqlx::Database,
+{
+    fn type_info() -> DB::TypeInfo {
+        <i32 as sqlx::Type<DB>>::type_info()
+    }
+}
+
+impl<'q, DB> sqlx::Encode<'q, DB> for MaxTables
+where
+    DB: sqlx::Database,
+    i32: sqlx::Encode<'q, DB>,
+{
+    fn encode_by_ref(
+        &self,
+        buf: &mut <DB as sqlx::database::HasArguments<'q>>::ArgumentBuffer,
+    ) -> sqlx::encode::IsNull {
+        <i32 as sqlx::Encode<'_, DB>>::encode_by_ref(&self.get_i32(), buf)
+    }
+}
+
+// The database stores i32s, so there's a chance of invalid values already being stored in there.
+// When deserializing those values, rather than panicking or returning an error, log and use the
+// default instead.
+impl<'r, DB: ::sqlx::Database> ::sqlx::decode::Decode<'r, DB> for MaxTables
+where
+    i32: sqlx::Decode<'r, DB>,
+{
+    fn decode(
+        value: <DB as ::sqlx::database::HasValueRef<'r>>::ValueRef,
+    ) -> ::std::result::Result<
+        Self,
+        ::std::boxed::Box<
+            dyn ::std::error::Error + 'static + ::std::marker::Send + ::std::marker::Sync,
+        >,
+    > {
+        let data = <i32 as ::sqlx::decode::Decode<'r, DB>>::decode(value)?;
+
+        let data = Self::try_from(data).unwrap_or_else(|_| {
+            error!("database contains invalid max_tables value {data}");
+            Self::default()
+        });
+
+        Ok(data)
+    }
+}
+
 /// Max columns per table allowed in a namespace.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, sqlx::Type)]
-#[sqlx(transparent)]
-pub struct MaxColumnsPerTable(i32);
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct MaxColumnsPerTable(NonZeroUsize);
+
+impl TryFrom<usize> for MaxColumnsPerTable {
+    type Error = ServiceLimitError;
+
+    fn try_from(value: usize) -> Result<Self, Self::Error> {
+        // Even though the value is stored as a `usize`, service limits are stored as `i32` in the
+        // database and transferred as i32 over protobuf. So try to convert to an `i32` (and throw
+        // away the result) so that we know about invalid values before trying to use them.
+        if i32::try_from(value).is_err() {
+            return Err(ServiceLimitError::MustFitInI32);
+        }
+
+        let nonzero_value =
+            NonZeroUsize::new(value).ok_or(ServiceLimitError::MustBeGreaterThanZero)?;
+
+        Ok(Self(nonzero_value))
+    }
+}
+
+impl TryFrom<u64> for MaxColumnsPerTable {
+    type Error = ServiceLimitError;
+
+    fn try_from(value: u64) -> Result<Self, Self::Error> {
+        // Even though the value is stored as a `usize`, service limits are stored as `i32` in the
+        // database and transferred as i32 over protobuf. So try to convert to an `i32` (and throw
+        // away the result) so that we know about invalid values before trying to use them.
+        if i32::try_from(value).is_err() {
+            return Err(ServiceLimitError::MustFitInI32);
+        }
+
+        let nonzero_value = usize::try_from(value)
+            .ok()
+            .and_then(NonZeroUsize::new)
+            .ok_or(ServiceLimitError::MustBeGreaterThanZero)?;
+
+        Ok(Self(nonzero_value))
+    }
+}
+
+impl TryFrom<i32> for MaxColumnsPerTable {
+    type Error = ServiceLimitError;
+
+    fn try_from(value: i32) -> Result<Self, Self::Error> {
+        let nonzero_value = usize::try_from(value)
+            .ok()
+            .and_then(NonZeroUsize::new)
+            .ok_or(ServiceLimitError::MustBeGreaterThanZero)?;
+
+        Ok(Self(nonzero_value))
+    }
+}
 
 #[allow(missing_docs)]
 impl MaxColumnsPerTable {
-    pub const fn new(v: i32) -> Self {
-        Self(v)
+    pub fn get(&self) -> usize {
+        self.0.get()
     }
 
-    pub fn get(&self) -> i32 {
-        self.0
+    /// For use by the database and some protobuf representations. It should not be possible to
+    /// construct a `MaxColumnsPerTable` instance that contains a `NonZeroUsize` that won't fit in
+    /// an `i32`.
+    pub fn get_i32(&self) -> i32 {
+        self.0.get() as i32
     }
 
     /// Default per-table column count service protection limit.
     pub const fn const_default() -> Self {
-        Self(200)
+        // This is safe because the hardcoded 200 is not 0.
+        let value = unsafe { NonZeroUsize::new_unchecked(200) };
+
+        Self(value)
     }
 }
 
@@ -71,6 +234,56 @@ impl std::fmt::Display for MaxColumnsPerTable {
     }
 }
 
+// Tell sqlx this is an i32 in the database.
+impl<DB> sqlx::Type<DB> for MaxColumnsPerTable
+where
+    i32: sqlx::Type<DB>,
+    DB: sqlx::Database,
+{
+    fn type_info() -> DB::TypeInfo {
+        <i32 as sqlx::Type<DB>>::type_info()
+    }
+}
+
+impl<'q, DB> sqlx::Encode<'q, DB> for MaxColumnsPerTable
+where
+    DB: sqlx::Database,
+    i32: sqlx::Encode<'q, DB>,
+{
+    fn encode_by_ref(
+        &self,
+        buf: &mut <DB as sqlx::database::HasArguments<'q>>::ArgumentBuffer,
+    ) -> sqlx::encode::IsNull {
+        <i32 as sqlx::Encode<'_, DB>>::encode_by_ref(&self.get_i32(), buf)
+    }
+}
+
+// The database stores i32s, so there's a chance of invalid values already being stored in there.
+// When deserializing those values, rather than panicking or returning an error, log and use the
+// default instead.
+impl<'r, DB: ::sqlx::Database> ::sqlx::decode::Decode<'r, DB> for MaxColumnsPerTable
+where
+    i32: sqlx::Decode<'r, DB>,
+{
+    fn decode(
+        value: <DB as ::sqlx::database::HasValueRef<'r>>::ValueRef,
+    ) -> ::std::result::Result<
+        Self,
+        ::std::boxed::Box<
+            dyn ::std::error::Error + 'static + ::std::marker::Send + ::std::marker::Sync,
+        >,
+    > {
+        let data = <i32 as ::sqlx::decode::Decode<'r, DB>>::decode(value)?;
+
+        let data = Self::try_from(data).unwrap_or_else(|_| {
+            error!("database contains invalid max_columns_per_table value {data}");
+            Self::default()
+        });
+
+        Ok(data)
+    }
+}
+
 /// Overrides for service protection limits.
 #[derive(Debug, Copy, Clone)]
 pub struct NamespaceServiceProtectionLimitsOverride {
@@ -80,16 +293,23 @@ pub struct NamespaceServiceProtectionLimitsOverride {
     pub max_columns_per_table: Option<MaxColumnsPerTable>,
 }
 
-impl From<namespace_proto::ServiceProtectionLimits> for NamespaceServiceProtectionLimitsOverride {
-    fn from(value: namespace_proto::ServiceProtectionLimits) -> Self {
+impl TryFrom<namespace_proto::ServiceProtectionLimits>
+    for NamespaceServiceProtectionLimitsOverride
+{
+    type Error = ServiceLimitError;
+
+    fn try_from(value: namespace_proto::ServiceProtectionLimits) -> Result<Self, Self::Error> {
         let namespace_proto::ServiceProtectionLimits {
             max_tables,
             max_columns_per_table,
         } = value;
-        Self {
-            max_tables: max_tables.map(MaxTables::new),
-            max_columns_per_table: max_columns_per_table.map(MaxColumnsPerTable::new),
-        }
+
+        Ok(Self {
+            max_tables: max_tables.map(MaxTables::try_from).transpose()?,
+            max_columns_per_table: max_columns_per_table
+                .map(MaxColumnsPerTable::try_from)
+                .transpose()?,
+        })
     }
 }
 
@@ -114,6 +334,11 @@ pub enum ServiceLimitError {
     /// No value was provided so we can't update anything
     #[error("a supported service limit value is required")]
     NoValueSpecified,
+
+    /// Limits are stored as `i32` in the database and transferred as i32 over protobuf, so even
+    /// though they are stored as `usize` in Rust, the `usize` value must be less than `i32::MAX`.
+    #[error("service limit values must fit in a 32-bit signed integer (`i32`)")]
+    MustFitInI32,
 }
 
 impl TryFrom<Option<LimitUpdate>> for ServiceLimitUpdate {
@@ -122,20 +347,68 @@ impl TryFrom<Option<LimitUpdate>> for ServiceLimitUpdate {
     fn try_from(limit_update: Option<LimitUpdate>) -> Result<Self, Self::Error> {
         match limit_update {
             Some(LimitUpdate::MaxTables(n)) => {
-                if n == 0 {
-                    return Err(ServiceLimitError::MustBeGreaterThanZero);
-                }
-                Ok(ServiceLimitUpdate::MaxTables(MaxTables::new(n)))
+                Ok(ServiceLimitUpdate::MaxTables(MaxTables::try_from(n)?))
             }
-            Some(LimitUpdate::MaxColumnsPerTable(n)) => {
-                if n == 0 {
-                    return Err(ServiceLimitError::MustBeGreaterThanZero);
-                }
-                Ok(ServiceLimitUpdate::MaxColumnsPerTable(
-                    MaxColumnsPerTable::new(n),
-                ))
-            }
+            Some(LimitUpdate::MaxColumnsPerTable(n)) => Ok(ServiceLimitUpdate::MaxColumnsPerTable(
+                MaxColumnsPerTable::try_from(n)?,
+            )),
             None => Err(ServiceLimitError::NoValueSpecified),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::i32;
+
+    #[test]
+    fn max_tables_from_usize() {
+        assert_eq!(MaxTables::try_from(1usize).unwrap().get(), 1);
+
+        assert_eq!(
+            MaxTables::try_from(0usize).unwrap_err().to_string(),
+            "service limit values must be greater than 0"
+        );
+        assert_eq!(
+            MaxTables::try_from(i32::MAX as usize + 1)
+                .unwrap_err()
+                .to_string(),
+            "service limit values must fit in a 32-bit signed integer (`i32`)"
+        );
+    }
+
+    #[test]
+    fn max_tables_from_u64() {
+        assert_eq!(MaxTables::try_from(1u64).unwrap().get(), 1);
+
+        assert_eq!(
+            MaxTables::try_from(0u64).unwrap_err().to_string(),
+            "service limit values must be greater than 0"
+        );
+        assert_eq!(
+            MaxTables::try_from(i32::MAX as u64 + 1)
+                .unwrap_err()
+                .to_string(),
+            "service limit values must fit in a 32-bit signed integer (`i32`)"
+        );
+    }
+
+    #[test]
+    fn max_tables_from_i32() {
+        assert_eq!(MaxTables::try_from(1i32).unwrap().get(), 1);
+        assert_eq!(
+            MaxTables::try_from(i32::MAX).unwrap().get(),
+            i32::MAX as usize
+        );
+
+        assert_eq!(
+            MaxTables::try_from(0i32).unwrap_err().to_string(),
+            "service limit values must be greater than 0"
+        );
+        assert_eq!(
+            MaxTables::try_from(-1i32).unwrap_err().to_string(),
+            "service limit values must be greater than 0"
+        );
     }
 }

--- a/data_types/src/service_limits.rs
+++ b/data_types/src/service_limits.rs
@@ -144,7 +144,7 @@ macro_rules! define_service_limit {
                 let data = <i32 as ::sqlx::decode::Decode<'r, DB>>::decode(value)?;
 
                 let data = Self::try_from(data).unwrap_or_else(|_| {
-                    error!("database contains invalid $type_name value {data}");
+                    error!("database contains invalid $type_name value {data}, using default value");
                     Self::default()
                 });
 

--- a/data_types/src/service_limits.rs
+++ b/data_types/src/service_limits.rs
@@ -279,4 +279,25 @@ mod tests {
             "service limit values must fit in a 32-bit signed integer (`i32`)",
         );
     }
+
+    fn extract_sqlite_argument_i32(
+        argument_value: &sqlx::sqlite::SqliteArgumentValue,
+    ) -> i32 {
+        match argument_value {
+            sqlx::sqlite::SqliteArgumentValue::Int(i) => *i,
+            other => panic!("Expected Int values, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn max_tables_encode() {
+        let max_tables = MaxTables::try_from(10).unwrap();
+        let mut buf = Default::default();
+        let _ = <MaxTables as sqlx::Encode<'_, sqlx::Sqlite>>::encode_by_ref(
+            &max_tables, &mut buf,
+        );
+
+        let encoded_max_tables: Vec<_> = buf.iter().map(extract_sqlite_argument_i32).collect();
+        assert_eq!(encoded_max_tables, &[max_tables.get_i32()]);
+    }
 }

--- a/iox_catalog/src/interface.rs
+++ b/iox_catalog/src/interface.rs
@@ -902,7 +902,7 @@ pub(crate) mod test_helpers {
         namespaces.sort_by_key(|ns| ns.name.clone());
         assert_eq!(namespaces, vec![namespace, namespace2]);
 
-        let new_table_limit = MaxTables::new(15000);
+        let new_table_limit = MaxTables::try_from(15_000).unwrap();
         let modified = repos
             .namespaces()
             .update_table_limit(namespace_name.as_str(), new_table_limit)
@@ -910,7 +910,7 @@ pub(crate) mod test_helpers {
             .expect("namespace should be updateable");
         assert_eq!(new_table_limit, modified.max_tables);
 
-        let new_column_limit = MaxColumnsPerTable::new(1500);
+        let new_column_limit = MaxColumnsPerTable::try_from(1_500).unwrap();
         let modified = repos
             .namespaces()
             .update_column_limit(namespace_name.as_str(), new_column_limit)
@@ -1282,7 +1282,7 @@ pub(crate) mod test_helpers {
         // test per-namespace table limits
         let latest = repos
             .namespaces()
-            .update_table_limit("namespace_table_test", MaxTables::new(1))
+            .update_table_limit("namespace_table_test", MaxTables::try_from(1).unwrap())
             .await
             .expect("namespace should be updateable");
         let err = repos
@@ -1500,7 +1500,10 @@ pub(crate) mod test_helpers {
         // test per-namespace column limits
         repos
             .namespaces()
-            .update_column_limit("namespace_column_test", MaxColumnsPerTable::new(1))
+            .update_column_limit(
+                "namespace_column_test",
+                MaxColumnsPerTable::try_from(1).unwrap(),
+            )
             .await
             .expect("namespace should be updateable");
         let err = repos

--- a/iox_catalog/src/sqlite.rs
+++ b/iox_catalog/src/sqlite.rs
@@ -4,7 +4,7 @@ use crate::{
     interface::{
         self, CasFailure, Catalog, ColumnRepo, ColumnTypeMismatchSnafu, Error, NamespaceRepo,
         ParquetFileRepo, PartitionRepo, RepoCollection, Result, SoftDeletedRows, TableRepo,
-        MAX_PARQUET_FILES_SELECTED_ONCE_FOR_RETENTION,
+        MAX_PARQUET_FILES_SELECTED_ONCE_FOR_DELETE, MAX_PARQUET_FILES_SELECTED_ONCE_FOR_RETENTION,
     },
     kafkaless_transition::{
         SHARED_QUERY_POOL, SHARED_QUERY_POOL_ID, SHARED_TOPIC_ID, SHARED_TOPIC_NAME,
@@ -22,24 +22,24 @@ use data_types::{
     ParquetFileId, ParquetFileParams, Partition, PartitionHashId, PartitionId, PartitionKey,
     SkippedCompaction, SortedColumnSet, Table, TableId, Timestamp, TransitionPartitionId,
 };
-use serde::{Deserialize, Serialize};
-use std::{collections::HashMap, fmt::Display};
-use std::{collections::HashSet, fmt::Write};
-
-use crate::interface::MAX_PARQUET_FILES_SELECTED_ONCE_FOR_DELETE;
 use iox_time::{SystemProvider, TimeProvider};
 use metric::Registry;
 use observability_deps::tracing::debug;
 use parking_lot::Mutex;
+use serde::{Deserialize, Serialize};
 use snafu::prelude::*;
-use sqlx::sqlite::SqliteRow;
-use sqlx::types::Json;
 use sqlx::{
-    migrate::Migrator, sqlite::SqliteConnectOptions, types::Uuid, Executor, Pool, Row, Sqlite,
-    SqlitePool,
+    migrate::Migrator,
+    sqlite::{SqliteConnectOptions, SqliteRow},
+    types::{Json, Uuid},
+    Executor, Pool, Row, Sqlite, SqlitePool,
 };
-use std::str::FromStr;
-use std::sync::Arc;
+use std::{
+    collections::{HashMap, HashSet},
+    fmt::{Display, Write},
+    str::FromStr,
+    sync::Arc,
+};
 
 static MIGRATOR: Migrator = sqlx::migrate!("sqlite/migrations");
 

--- a/iox_tests/src/catalog.rs
+++ b/iox_tests/src/catalog.rs
@@ -265,21 +265,24 @@ impl TestNamespace {
     }
 
     /// Set the number of tables allowed in this namespace.
-    pub async fn update_table_limit(&self, new_max: i32) {
+    pub async fn update_table_limit(&self, new_max: usize) {
         let mut repos = self.catalog.catalog.repositories().await;
         repos
             .namespaces()
-            .update_table_limit(&self.namespace.name, MaxTables::new(new_max))
+            .update_table_limit(&self.namespace.name, MaxTables::try_from(new_max).unwrap())
             .await
             .unwrap();
     }
 
     /// Set the number of columns per table allowed in this namespace.
-    pub async fn update_column_limit(&self, new_max: i32) {
+    pub async fn update_column_limit(&self, new_max: usize) {
         let mut repos = self.catalog.catalog.repositories().await;
         repos
             .namespaces()
-            .update_column_limit(&self.namespace.name, MaxColumnsPerTable::new(new_max))
+            .update_column_limit(
+                &self.namespace.name,
+                MaxColumnsPerTable::try_from(new_max).unwrap(),
+            )
             .await
             .unwrap();
     }

--- a/ioxd_querier/src/rpc/namespace.rs
+++ b/ioxd_querier/src/rpc/namespace.rs
@@ -36,8 +36,8 @@ fn namespace_to_proto(namespace: Namespace) -> proto::Namespace {
         id: namespace.id.get(),
         name: namespace.name,
         retention_period_ns: namespace.retention_period_ns,
-        max_tables: namespace.max_tables.get(),
-        max_columns_per_table: namespace.max_columns_per_table.get(),
+        max_tables: namespace.max_tables.get_i32(),
+        max_columns_per_table: namespace.max_columns_per_table.get_i32(),
         partition_template: namespace.partition_template.as_proto().cloned(),
     }
 }
@@ -181,16 +181,16 @@ mod tests {
                         id: 1,
                         name: "namespace2".to_string(),
                         retention_period_ns: TEST_RETENTION_PERIOD_NS,
-                        max_tables: MaxTables::default().get(),
-                        max_columns_per_table: MaxColumnsPerTable::default().get(),
+                        max_tables: MaxTables::default().get_i32(),
+                        max_columns_per_table: MaxColumnsPerTable::default().get_i32(),
                         partition_template: None,
                     },
                     proto::Namespace {
                         id: 2,
                         name: "namespace1".to_string(),
                         retention_period_ns: TEST_RETENTION_PERIOD_NS,
-                        max_tables: MaxTables::default().get(),
-                        max_columns_per_table: MaxColumnsPerTable::default().get(),
+                        max_tables: MaxTables::default().get_i32(),
+                        max_columns_per_table: MaxColumnsPerTable::default().get_i32(),
                         partition_template: None,
                     },
                 ]

--- a/router/benches/namespace_schema_cache.rs
+++ b/router/benches/namespace_schema_cache.rs
@@ -156,8 +156,8 @@ fn generate_namespace_schema(tables: usize, columns_per_table: usize) -> Namespa
                 (format!("table{i}"), schema)
             })
             .collect::<BTreeMap<_, _>>(),
-        max_tables: MaxTables::new(i32::MAX),
-        max_columns_per_table: MaxColumnsPerTable::new(i32::MAX),
+        max_tables: MaxTables::try_from(i32::MAX).unwrap(),
+        max_columns_per_table: MaxColumnsPerTable::try_from(i32::MAX).unwrap(),
         retention_period_ns: None,
         partition_template,
     }

--- a/router/benches/partitioner.rs
+++ b/router/benches/partitioner.rs
@@ -166,8 +166,8 @@ fn bench(
     let schema = Arc::new(NamespaceSchema {
         id: NamespaceId::new(42),
         tables: Default::default(),
-        max_tables: MaxTables::new(1000),
-        max_columns_per_table: MaxColumnsPerTable::new(1000),
+        max_tables: MaxTables::try_from(1000).unwrap(),
+        max_columns_per_table: MaxColumnsPerTable::try_from(1000).unwrap(),
         retention_period_ns: None,
         partition_template: partition_template.clone(),
     });

--- a/router/benches/schema_validator.rs
+++ b/router/benches/schema_validator.rs
@@ -52,8 +52,8 @@ fn bench(group: &mut BenchmarkGroup<WallTime>, tables: usize, columns_per_table:
     let namespace_schema = NamespaceSchema {
         id: NamespaceId::new(42),
         tables: Default::default(),
-        max_tables: MaxTables::new(42),
-        max_columns_per_table: MaxColumnsPerTable::new(42),
+        max_tables: MaxTables::try_from(42).unwrap(),
+        max_columns_per_table: MaxColumnsPerTable::try_from(42).unwrap(),
         retention_period_ns: None,
         partition_template: Default::default(),
     };

--- a/router/src/dml_handlers/schema_validation.rs
+++ b/router/src/dml_handlers/schema_validation.rs
@@ -394,7 +394,7 @@ mod tests {
             .repositories()
             .await
             .namespaces()
-            .update_table_limit(NAMESPACE.as_str(), MaxTables::new(1))
+            .update_table_limit(NAMESPACE.as_str(), MaxTables::try_from(1).unwrap())
             .await
             .expect("failed to set table limit");
 
@@ -455,7 +455,7 @@ mod tests {
             .repositories()
             .await
             .namespaces()
-            .update_column_limit(NAMESPACE.as_str(), MaxColumnsPerTable::new(3))
+            .update_column_limit(NAMESPACE.as_str(), MaxColumnsPerTable::try_from(3).unwrap())
             .await
             .expect("failed to set column limit");
 

--- a/router/src/gossip/anti_entropy/mod.rs
+++ b/router/src/gossip/anti_entropy/mod.rs
@@ -135,16 +135,16 @@ pub mod prop_gen {
                 arbitrary_table_schema(),
                 (0, 10) // Set size range
             ),
-            max_tables in any::<usize>(),
-            max_columns_per_table in any::<usize>(),
+            max_tables in 1..std::i32::MAX as usize,
+            max_columns_per_table in 1..std::i32::MAX as usize,
             retention_period_ns in any::<Option<i64>>(),
         ) -> NamespaceSchema {
             let tables = tables.into_iter().map(|(k, v)| (k.to_string(), v)).collect();
             NamespaceSchema {
                 id: NamespaceId::new(namespace_id),
                 tables,
-                max_tables: MaxTables::new(max_tables as i32),
-                max_columns_per_table: MaxColumnsPerTable::new(max_columns_per_table as i32),
+                max_tables: MaxTables::try_from(max_tables).unwrap(),
+                max_columns_per_table: MaxColumnsPerTable::try_from(max_columns_per_table).unwrap(),
                 retention_period_ns,
                 partition_template: Default::default(),
             }

--- a/router/src/gossip/anti_entropy/sync/rpc_worker/worker_task.rs
+++ b/router/src/gossip/anti_entropy/sync/rpc_worker/worker_task.rs
@@ -175,8 +175,8 @@ mod tests {
     const DEFAULT_NAMESPACE: NamespaceSchema = NamespaceSchema {
         id: NamespaceId::new(4242),
         tables: BTreeMap::new(),
-        max_columns_per_table: MaxColumnsPerTable::new(1),
-        max_tables: MaxTables::new(2),
+        max_columns_per_table: MaxColumnsPerTable::const_default(),
+        max_tables: MaxTables::const_default(),
         retention_period_ns: None,
         partition_template: DEFAULT_NAMESPACE_PARTITION_TEMPLATE,
     };
@@ -342,8 +342,8 @@ mod tests {
             *platanos,
             NamespaceSchema {
                 id: NamespaceId::new(2424),
-                max_columns_per_table: MaxColumnsPerTable::new(1234),
-                max_tables: MaxTables::new(666),
+                max_columns_per_table: MaxColumnsPerTable::try_from(1234).unwrap(),
+                max_tables: MaxTables::try_from(666).unwrap(),
                 retention_period_ns: Some(4321),
                 partition_template: Default::default(),
                 tables: [(

--- a/router/src/gossip/namespace_cache.rs
+++ b/router/src/gossip/namespace_cache.rs
@@ -180,10 +180,11 @@ where
                     NamespaceSchema {
                         id: NamespaceId::new(note.namespace_id),
                         tables: Default::default(),
-                        max_tables: MaxTables::new(note.max_tables as i32),
-                        max_columns_per_table: MaxColumnsPerTable::new(
-                            note.max_columns_per_table as i32,
-                        ),
+                        max_tables: MaxTables::try_from(note.max_tables).unwrap_or_default(),
+                        max_columns_per_table: MaxColumnsPerTable::try_from(
+                            note.max_columns_per_table,
+                        )
+                        .unwrap_or_default(),
                         retention_period_ns: note.retention_period_ns,
                         partition_template,
                     },

--- a/router/src/namespace_cache/memory.rs
+++ b/router/src/namespace_cache/memory.rs
@@ -186,8 +186,8 @@ mod tests {
         NamespaceSchema {
             id: TEST_NAMESPACE_ID,
             tables: Default::default(),
-            max_tables: MaxTables::new(24),
-            max_columns_per_table: MaxColumnsPerTable::new(50),
+            max_tables: MaxTables::try_from(24).unwrap(),
+            max_columns_per_table: MaxColumnsPerTable::try_from(50).unwrap(),
             retention_period_ns: Some(876),
             partition_template: Default::default(),
         }
@@ -198,8 +198,8 @@ mod tests {
         NamespaceSchema {
             id: TEST_NAMESPACE_ID,
             tables: Default::default(),
-            max_tables: MaxTables::new(42),
-            max_columns_per_table: MaxColumnsPerTable::new(10),
+            max_tables: MaxTables::try_from(42).unwrap(),
+            max_columns_per_table: MaxColumnsPerTable::try_from(10).unwrap(),
             retention_period_ns: Some(876),
             partition_template: Default::default(),
         }
@@ -484,16 +484,17 @@ mod tests {
                 arbitrary_table_schema(),
                 (0, 10) // Set size range
             ),
-            max_tables in any::<usize>(),
-            max_columns_per_table in any::<usize>(),
+            max_tables in 1..std::i32::MAX as usize,
+            max_columns_per_table in 1..std::i32::MAX as usize,
             retention_period_ns in any::<Option<i64>>(),
         ) -> NamespaceSchema {
             let tables = tables.into_iter().map(|(k, v)| (k.to_string(), v)).collect();
             NamespaceSchema {
                 id: TEST_NAMESPACE_ID,
                 tables,
-                max_tables: MaxTables::new(max_tables as i32),
-                max_columns_per_table: MaxColumnsPerTable::new(max_columns_per_table as i32),
+                max_tables: MaxTables::try_from(max_tables).unwrap(),
+                max_columns_per_table: MaxColumnsPerTable::try_from(max_columns_per_table)
+                    .unwrap(),
                 retention_period_ns,
                 partition_template: Default::default(),
             }

--- a/router/src/namespace_cache/metrics.rs
+++ b/router/src/namespace_cache/metrics.rs
@@ -164,8 +164,8 @@ mod tests {
         NamespaceSchema {
             id: NamespaceId::new(42),
             tables,
-            max_tables: MaxTables::new(42),
-            max_columns_per_table: MaxColumnsPerTable::new(100),
+            max_tables: MaxTables::try_from(42).unwrap(),
+            max_columns_per_table: MaxColumnsPerTable::try_from(100).unwrap(),
             retention_period_ns: None,
             partition_template: Default::default(),
         }

--- a/router/src/server/http.rs
+++ b/router/src/server/http.rs
@@ -472,7 +472,8 @@ mod tests {
 
     use assert_matches::assert_matches;
     use data_types::{
-        NamespaceId, NamespaceName, NamespaceNameError, OrgBucketMappingError, TableId,
+        MaxColumnsPerTable, MaxTables, NamespaceId, NamespaceName, NamespaceNameError,
+        OrgBucketMappingError, TableId,
     };
     use flate2::{write::GzEncoder, Compression};
     use hyper::header::HeaderValue;
@@ -1531,7 +1532,7 @@ mod tests {
                 table_name: "bananas".to_string(),
                 existing_column_count: 42,
                 merged_column_count: 4242,
-                max_columns_per_table: 24,
+                max_columns_per_table: MaxColumnsPerTable::try_from(24).unwrap(),
             })))),
             "dml handler error: service limit reached: couldn't create columns in table `bananas`; table contains 42 \
             existing columns, applying this write would result in 4242 columns, limit is 24",
@@ -1541,7 +1542,7 @@ mod tests {
             DmlHandler(DmlError::Schema(SchemaError::ServiceLimit(Box::new(CachedServiceProtectionLimit::Table {
                 existing_table_count: 42,
                 merged_table_count: 4242,
-                table_count_limit: 24,
+                table_count_limit: MaxTables::try_from(24).unwrap(),
             })))),
             "dml handler error: service limit reached: couldn't create new table; namespace contains 42 existing \
             tables, applying this write would result in 4242 tables, limit is 24",

--- a/router/tests/grpc.rs
+++ b/router/tests/grpc.rs
@@ -625,7 +625,7 @@ async fn test_update_namespace_limit_max_tables() {
     assert_eq!(got.max_tables, 1);
     assert_eq!(
         got.max_columns_per_table,
-        MaxColumnsPerTable::default().get()
+        MaxColumnsPerTable::default().get_i32(),
     );
 
     // The list namespace RPC should show the updated namespace
@@ -707,7 +707,7 @@ async fn test_update_namespace_limit_max_columns_per_table() {
 
     assert_eq!(got.name, "bananas_test");
     assert_eq!(got.id, 1);
-    assert_eq!(got.max_tables, MaxTables::default().get());
+    assert_eq!(got.max_tables, MaxTables::default().get_i32());
     assert_eq!(got.max_columns_per_table, 1);
 
     // The list namespace RPC should show the updated namespace
@@ -775,7 +775,7 @@ async fn test_update_namespace_limit_max_columns_per_table() {
                 ..
             } => {
             assert_eq!(table_name, "arán_banana");
-                assert_eq!(max_columns_per_table, 1);
+                assert_eq!(max_columns_per_table.get(), 1);
             });
         }
     )

--- a/router/tests/http.rs
+++ b/router/tests/http.rs
@@ -229,7 +229,7 @@ async fn test_schema_limit() {
         .repositories()
         .await
         .namespaces()
-        .update_table_limit("bananas_test", MaxTables::new(1))
+        .update_table_limit("bananas_test", MaxTables::try_from(1).unwrap())
         .await
         .expect("failed to update table limit");
 


### PR DESCRIPTION
Connects to influxdata/idpe#18100. There's still a little bug and some needed tests that need to be done to close out that issue.

This changes the newtypes added in the previous commit to properly validate MaxTables and MaxColumnsPerTable values whether they're coming from protobuf, the CLI, or the database (because the database stores i32s and there's a chance of invalid values in there, and we don't want to crash if that's the case!).