### PR TITLE
build:  latest merkle-search-tree version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3501,12 +3501,12 @@ dependencies = [
 
 [[package]]
 name = "merkle-search-tree"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6f5f8e25bd481489f8e0389fd4ced21ec6cbaf1a30e3204102df45dc6b04ce5"
+checksum = "f7775d0a8399d72f2dfde32855fa9b50f331e05c980009e5260d77031f059fc7"
 dependencies = [
  "base64 0.21.4",
- "siphasher 0.3.11",
+ "siphasher 1.0.0",
  "tracing",
 ]
 

--- a/router/Cargo.toml
+++ b/router/Cargo.toml
@@ -20,7 +20,7 @@ hashbrown = { workspace = true }
 hyper = "0.14"
 iox_catalog = { path = "../iox_catalog" }
 iox_time = { path = "../iox_time" }
-merkle-search-tree = { version = "0.6.0", features = ["tracing"] }
+merkle-search-tree = { version = "0.7.0", features = ["tracing"] }
 metric = { path = "../metric" }
 mutable_batch = { path = "../mutable_batch" }
 mutable_batch_lp = { path = "../mutable_batch_lp" }


### PR DESCRIPTION
This picks up a more efficient way of constructing page range snapshots from owned values that'll be used in API requests in a follow-up PR:

https://docs.rs/merkle-search-tree/latest/merkle_search_tree/diff/struct.OwnedPageRange.html

---

* build: pick up latest merkle-search-tree version (33a441fbe)
      
      Pick up the improvements allowing construction of PageRangeSnapshots
      from owned keys / no cloning.