### PR TITLE
feat: prune partitions before creating parquet chunks

### DIFF
--- a/querier/src/parquet/creation.rs
+++ b/querier/src/parquet/creation.rs
@@ -55,7 +55,7 @@ impl ChunkAdapter {
     pub(crate) async fn new_chunks(
         &self,
         cached_table: Arc<CachedTable>,
-        files: Arc<[Arc<ParquetFile>]>,
+        files: impl IntoIterator<Item = Arc<ParquetFile>> + Send,
         cached_partitions: &HashMap<TransitionPartitionId, Arc<CachedPartition>>,
         span: Option<Span>,
     ) -> Vec<QuerierParquetChunk> {
@@ -66,10 +66,7 @@ impl ChunkAdapter {
             let _span_recorder = span_recorder.child("prepare files");
 
             files
-                .iter()
-                // throw out files that belong to removed partitions
-                .filter(|f| cached_partitions.contains_key(&f.partition_id))
-                .cloned()
+                .into_iter()
                 .map(|f| PreparedParquetFile::new(f, &cached_table))
                 .collect::<Vec<_>>()
         };

--- a/querier/src/parquet/mod.rs
+++ b/querier/src/parquet/mod.rs
@@ -260,7 +260,7 @@ pub mod tests {
             self.adapter
                 .new_chunks(
                     Arc::clone(&self.cached_table),
-                    vec![Arc::clone(&self.parquet_file)].into(),
+                    [Arc::clone(&self.parquet_file)],
                     &cached_partitions,
                     None,
                 )

--- a/querier/src/table/metrics.rs
+++ b/querier/src/table/metrics.rs
@@ -48,9 +48,13 @@ impl PruneMetricsGroup {
     }
 
     pub fn register(&self, chunk: &dyn QueryChunk) {
+        self.register_low_level(chunk_rows(chunk) as u64, chunk_estimate_size(chunk) as u64);
+    }
+
+    fn register_low_level(&self, rows: u64, bytes: u64) {
         self.chunks.inc(1);
-        self.rows.inc(chunk_rows(chunk) as u64);
-        self.bytes.inc(chunk_estimate_size(chunk) as u64);
+        self.rows.inc(rows);
+        self.bytes.inc(bytes);
     }
 }
 
@@ -128,8 +132,8 @@ impl PruneMetrics {
     }
 
     /// Called when the specified chunk was pruned late (i.e. before partition pruning).
-    pub fn was_pruned_early(&self, chunk: &dyn QueryChunk) {
-        self.pruned_early.register(chunk);
+    pub fn was_pruned_early(&self, rows: u64, bytes: u64) {
+        self.pruned_early.register_low_level(rows, bytes);
     }
 
     /// Called when the specified chunk was pruned late (i.e. after partition pruning).


### PR DESCRIPTION
This should lower query latency, because creating many chunks just to throw them away afterwards isn't exactly cheap.

Closes #8705.
