### PR TITLE
build: bump rust to 1.72.1

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.72"
-components = [ "rustfmt", "clippy" ]
+channel = "1.72.1"
+components = ["rustfmt", "clippy"]


### PR DESCRIPTION
Pick up latest rust.

---

* build: bump rust to 1.72.1 (3c9f28283)
      
      https://github.com/rust-lang/rust/releases/tag/1.72.1