### PR TITLE
feat(router): schema cache anti-entropy/sync actor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4887,6 +4887,7 @@ dependencies = [
  "flate2",
  "futures",
  "generated_types",
+ "gossip",
  "gossip_schema",
  "hashbrown 0.14.0",
  "hyper",

--- a/data_types/src/columns.rs
+++ b/data_types/src/columns.rs
@@ -26,7 +26,7 @@ impl ColumnId {
 }
 
 /// Column definitions for a table indexed by their name
-#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Default)]
 pub struct ColumnsByName(BTreeMap<String, ColumnSchema>);
 
 impl From<BTreeMap<String, ColumnSchema>> for ColumnsByName {

--- a/router/Cargo.toml
+++ b/router/Cargo.toml
@@ -15,6 +15,7 @@ dml = { path = "../dml" }
 flate2 = "1.0"
 futures = "0.3.28"
 generated_types = { path = "../generated_types" }
+gossip = { version = "0.1.0", path = "../gossip" }
 gossip_schema = { version = "0.1.0", path = "../gossip_schema" }
 hashbrown = { workspace = true }
 hyper = "0.14"

--- a/router/src/gossip/anti_entropy/mod.rs
+++ b/router/src/gossip/anti_entropy/mod.rs
@@ -1,3 +1,62 @@
 //! Anti-entropy primitives providing eventual consistency over gossip.
+//!
+//! [`NamespaceCache`] anti-entropy between gossip peers is driven by the
+//! following components:
+//!
+//! ```text
+//!                        ┌───────────────┐
+//!                ┌──────▶│   MST Actor   │◀──┐
+//!                │       └───────────────┘   │
+//!             Schema                         │
+//!            Updates                    MST Hashes
+//!                │                           │
+//!                │                           │
+//!    ┌ ─ ─ ─ ─ ─ ┼ ─ ─ ─ ─ ─                 │
+//!         NamespaceCache    │                ▼
+//!    │           ▼                   ┌───────────────┐
+//!        ┌──────────────┐   │        │  Convergence  │
+//!    │   │ MST Observer │◀───────────│     Actor     │◀────────┐
+//!        └──────────────┘   │        └───────────────┘         │
+//!    │                                       ▲                 │
+//!     ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ┘                │                 │
+//!                                       Consistency        Diffs &
+//!                                         Probes           Schemas
+//!                                            │                 │
+//!                                            ▼                 ▼
+//!                                    ┌───────────────┐ ┌───────────────┐
+//!                                    │    Gossip     │ │   Sync RPC    │
+//!                                    └───────────────┘ └───────────────┘
+//! ```
+//!
+//! From left to right:
+//!
+//!   * [`MerkleTree`]: a [`NamespaceCache`] decorator observing any changes
+//!         made to the local [`NamespaceCache`], providing diffs to the local
+//!         node's [`MerkleSearchTree`].
+//!
+//!   * [`AntiEntropyActor`]: an actor task maintaining the local node's
+//!         [`MerkleSearchTree`] state to accurately reflect the
+//!         [`NamespaceCache`] content.
+//!
+//!   * [`ConvergenceActor`]: an actor task responsible for performing
+//!         consistency checks with cluster peers, and driving convergence when
+//!         inconsistencies are detected.
+//!
+//!   * [`ConsistencyProber`]: an abstract mechanism for exchanging MST
+//!         consistency proofs / root hashes. Typically using gossip messages.
+//!
+//!   * [`RpcWorker`]: a reconciliation worker, spawned by the
+//!         [`ConvergenceActor`] to perform differential convergence between the
+//!         local node and an inconsistent peer. Makes RPC calls to perform MST
+//!         diffs and fetch inconsistent schemas.
+//!
+//! [`NamespaceCache`]: crate::namespace_cache::NamespaceCache
+//! [`MerkleTree`]: mst::merkle::MerkleTree
+//! [`AntiEntropyActor`]: mst::actor::AntiEntropyActor
+//! [`MerkleSearchTree`]: merkle_search_tree::MerkleSearchTree
+//! [`ConvergenceActor`]: sync::actor::ConvergenceActor
+//! [`ConsistencyProber`]: sync::consistency_prober::ConsistencyProber
+//! [`RpcWorker`]: sync::rpc_worker::RpcWorker
 
 pub mod mst;
+pub mod sync;

--- a/router/src/gossip/anti_entropy/sync/actor.rs
+++ b/router/src/gossip/anti_entropy/sync/actor.rs
@@ -1,0 +1,458 @@
+//! [`NamespaceCache`] anti-entropy background worker.
+//!
+//! [`NamespaceCache`]: crate::namespace_cache::NamespaceCache
+
+use std::{fmt::Debug, net::SocketAddr, time::Duration};
+
+use generated_types::influxdata::iox::gossip::v1::ConsistencyProbe;
+use gossip::Identity;
+use gossip_schema::dispatcher::SchemaEventHandler;
+use observability_deps::tracing::{debug, warn};
+use tokio::sync::mpsc;
+
+use crate::gossip::anti_entropy::mst::handle::AntiEntropyHandle;
+
+use super::{
+    consistency_prober::ConsistencyProber, rpc_worker::RpcWorker, traits::SyncRpcConnector,
+};
+
+/// How often to perform a consistency check with random peers.
+const SYNC_ROUND_INTERVAL: Duration = Duration::from_secs(5);
+
+/// The [`ConvergenceActor`] is responsible for driving peer anti-entropy to
+/// achieve eventual consistency of the [`NamespaceCache`] content across peers.
+///
+/// To converge peers within the cluster, periodic "sync rounds" are performed
+/// ([`SYNC_ROUND_INTERVAL`]), using the [`MerkleSearchTree`] state managed by
+/// the [`AntiEntropyActor`].
+///
+///
+/// # Sync Round Sequence
+///
+/// The local node begins a sync round by sending a consistency probe to a
+/// random peer (or in this implementation, multiple random peers) over gossip.
+///
+/// This probe includes the Merkle Search Tree root hash that accurately and
+/// compactly describes the content of the local node's [`NamespaceCache`].
+///
+/// This initial consistency probe is shown as request 1 in the diagram below:
+///
+/// ```text
+///                       ┌─────┐                   ┌────┐
+///                       │Local│                   │Peer│
+///                       └──┬──┘                   └─┬──┘
+///                          │ [1] Send content hash  │
+///                          │────────────────────────>
+///                          │                        │
+///                          │                 ┌───────────────┐
+///                          │                 │Compute hash,  │
+///                          │                 │stop if equal  │
+///                          │                 └───────────────┘
+///                          │                        │
+///                          │   ╔════════════════╗   │
+///   ═══════════════════════╪═══╣ Switch to gRPC ╠═══╪═══════════════════════
+///                          │   ╚════════════════╝   │
+///                          │                        │
+///                          │[2] Serialised MST pages│
+///                          │<────────────────────────
+///                          │                        │
+///                   ┌──────────────┐                │
+///                   │Perform diff  │                │
+///                   └──────────────┘                │
+///                          │ [3] Inconsistent pages │
+///                          │────────────────────────>
+///                          │                        │
+///                          │                        │
+///             ╔═══════╤════╪════════════════════════╪════════════╗
+///             ║ LOOP  │  For each inconsistent page │            ║
+///             ╟───────┘    │                        │            ║
+///             ║            │      [4] Schemas       │            ║
+///             ║            │<────────────────────────            ║
+///             ╚════════════╪════════════════════════╪════════════╝
+///                       ┌──┴──┐                   ┌─┴──┐
+///                       │Local│                   │Peer│
+///                       └─────┘                   └────┘
+/// ```
+///
+/// Upon receipt of a consistency probe, the peer computes its own root hash,
+/// and if they are equal, both nodes are consistent - no further action is
+/// necessary, and the sync round ends.
+///
+/// If the root hashes are not equal, the protocol switches to gRPC over TCP (a
+/// reliable transport with guaranteed delivery) for further requests, and the
+/// peer sends an RPC request describing the peer's [`MerkleSearchTree`] in a
+/// form suitable for identification of inconsistent key ranges (the set of
+/// [`PageRange`] - request 2).
+///
+/// The local node computes the tree difference, and responds with a set of key
+/// ranges that contain inconsistencies (request 3). The peer then fetches these
+/// key ranges, merging the returned schemas into its [`NamespaceCache`] to
+/// converge the content.
+///
+///
+/// # Service Discovery
+///
+/// To switch to gRPC / TCP, the receiver of a consistency probe must know how
+/// to connect to the sender's RPC service.
+///
+/// IOx is expected to run in environments without stable endpoints to address
+/// each router across executions - put simply, routers come and go - and
+/// frequently!
+///
+/// To ensure the receiver can connect and complete the sync round without any
+/// external dependencies or config, the sender of a consistency probe includes
+/// the gRPC port the service is bound to. This port is used along with the
+/// sender's IP from the UDP packet header of the consistency probe to derive
+/// the gRPC service address.
+///
+/// This scheme relies on the gRPC bind port matching the externally visible
+/// gRPC port (no remapping / NAT) and for the gRPC service to be reachable on
+/// the same interface as what is used for the gossip transport.
+///
+/// If a derived RPC address can't be connected to, a warning is logged -
+/// constant connection warnings might indicate a problem as described above.
+///
+///
+/// [`AntiEntropyActor`]:
+///     crate::gossip::anti_entropy::mst::actor::AntiEntropyActor
+/// [`PageRange`]: merkle_search_tree::diff::PageRange
+/// [`MerkleSearchTree`]: merkle_search_tree::MerkleSearchTree
+/// [`NamespaceCache`]: crate::namespace_cache::NamespaceCache
+#[derive(Debug)]
+pub struct ConvergenceActor<T, U, C> {
+    /// An abstract connector returning a [`SyncRpcClient`] instance for a given
+    /// peer RPC address.
+    ///
+    /// [`SyncRpcClient`]: super::traits::SyncRpcClient
+    connector: T,
+
+    /// An abstract [`SchemaEventHandler`] responsible for processing the
+    /// incoming stream of gossip events, merging their payloads into the local
+    /// [`NamespaceCache`].
+    ///
+    /// [`NamespaceCache`]: crate::namespace_cache::NamespaceCache
+    schema_event_handler: U,
+
+    /// A handle to the Merkle Search Tree state actor.
+    mst: AntiEntropyHandle,
+
+    /// The bind port used by the local node.
+    ///
+    /// This value is sent to peers in the initial consistency probe request to
+    /// enable service discovery.
+    grpc_bind_port: u16,
+
+    /// A [`ConsistencyProber`] for sending consistency probe requests to peers.
+    prober: C,
+
+    /// An incoming stream of consistency probes from other peers, containing
+    /// the sender's [`SocketAddr`].
+    probe_rx: mpsc::Receiver<(ConsistencyProbe, Identity, SocketAddr)>,
+}
+
+impl<T, U, C> ConvergenceActor<T, U, C>
+where
+    T: SyncRpcConnector + Clone + 'static,
+    U: SchemaEventHandler + Clone + 'static,
+    C: ConsistencyProber,
+{
+    /// Initialise a new [`ConvergenceActor`].
+    ///
+    /// The actor does not start until [`ConvergenceActor::run()`] is called.
+    pub fn new(
+        connector: T,
+        schema_event_handler: U,
+        mst: AntiEntropyHandle,
+        grpc_bind_port: u16,
+        prober: C,
+        probe_rx: mpsc::Receiver<(ConsistencyProbe, Identity, SocketAddr)>,
+    ) -> Self {
+        Self {
+            connector,
+            schema_event_handler,
+            mst,
+            grpc_bind_port,
+            prober,
+            probe_rx,
+        }
+    }
+
+    /// Block and run the convergence actor.
+    ///
+    /// The actor immediately begins probing random peers.
+    pub async fn run(mut self) {
+        let mut ticker = tokio::time::interval(SYNC_ROUND_INTERVAL);
+
+        // Wait at least SYNC_ROUND_INTERVAL between consistency checks.
+        ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+
+        loop {
+            tokio::select! {
+                _ = ticker.tick() =>
+                    self.solicit_consistency_check().await,
+
+                Some((v, ident, peer_addr)) = self.probe_rx.recv() =>
+                    self.perform_consistency_check(v, ident, peer_addr).await,
+            }
+        }
+    }
+
+    /// Generate a root hash and exchange it with some random peers
+    ///
+    /// (consistency probe, request 1).
+    async fn solicit_consistency_check(&mut self) {
+        let root_hash = self.mst.content_hash().await;
+        self.prober.probe(root_hash, self.grpc_bind_port).await;
+    }
+
+    /// Handle a received consistency probe.
+    ///
+    /// If the local node's MST root hash is equal to the peer root hash, this
+    /// is a no-op.
+    ///
+    /// If the hashes differ, this function switchs the exchange to gRPC/TCP,
+    /// and sends a serialised representation of the MST to the sender (request
+    /// 2).
+    async fn perform_consistency_check(
+        &mut self,
+        msg: ConsistencyProbe,
+        peer_identity: Identity,
+        peer_addr: SocketAddr,
+    ) {
+        // Request the current root hash from the MST
+        let root_hash = self.mst.content_hash().await;
+
+        // If the root hashes are equal, the content of the caches are equal.
+        if root_hash.as_bytes() == msg.root_hash.as_slice() {
+            debug!(
+                %root_hash,
+                %peer_addr,
+                %peer_identity,
+                "detected consistent peer"
+            );
+            return;
+        }
+
+        warn!(
+            %peer_identity,
+            %peer_addr,
+            local_root_hash=%root_hash,
+            local_root_hash_bytes=?root_hash.as_bytes(),
+            peer_root_hash_bytes=?msg.root_hash,
+            "peer inconsistency detected - converging"
+        );
+
+        // Construct the RPC address for the sender.
+        let rpc_addr = SocketAddr::new(peer_addr.ip(), msg.grpc_port as u16);
+        debug!(%peer_identity, %peer_addr, ?rpc_addr, "derived peer rpc address");
+
+        // Spawn a task the drive the cache synchronisation.
+        tokio::spawn(start_sync(
+            self.connector.clone(),
+            rpc_addr,
+            peer_identity,
+            self.mst.clone(),
+            self.schema_event_handler.clone(),
+        ));
+    }
+}
+
+/// Connect to the given `peer_addr` and being a sync round.
+async fn start_sync<T, U>(
+    connector: T,
+    peer_addr: SocketAddr,
+    peer_identity: Identity,
+    mst: AntiEntropyHandle,
+    merge_delegate: U,
+) where
+    T: SyncRpcConnector,
+    U: SchemaEventHandler,
+{
+    let client = match connector.connect(peer_addr).await {
+        Ok(v) => v,
+        Err(error) => {
+            warn!(
+                %error,
+                %peer_addr,
+                %peer_identity,
+                "failed to connect to sync rpc peer"
+            );
+            return;
+        }
+    };
+
+    RpcWorker::new(client, merge_delegate, mst, peer_addr, peer_identity)
+        .run()
+        .await
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        net::{IpAddr, Ipv4Addr},
+        sync::Arc,
+    };
+
+    use assert_matches::assert_matches;
+    use test_helpers::timeout::FutureTimeout;
+
+    use crate::{
+        gossip::{
+            anti_entropy::{
+                mst::actor::AntiEntropyActor,
+                sync::{
+                    mock_consistency_prober::MockConsistencyProber,
+                    mock_rpc_client::{MockSyncRpcClient, MockSyncRpcConnector},
+                },
+            },
+            namespace_cache::NamespaceSchemaGossip,
+        },
+        namespace_cache::MemoryNamespaceCache,
+    };
+
+    use super::*;
+
+    const RPC_PORT: u16 = 42;
+
+    /// Assert a consistency probe is sent, and advertises the correct state.
+    #[tokio::test]
+    async fn test_send_consistency_probe() {
+        // Schema cache being synchronised, and the gossip event handler that
+        // merges events into the cache.
+        let schema_cache = Arc::new(MemoryNamespaceCache::default());
+        let schema_event_handler = Arc::new(NamespaceSchemaGossip::new(Arc::clone(&schema_cache)));
+
+        // The MST state actor & handle.
+        let (actor, mst) = AntiEntropyActor::new(Arc::clone(&schema_cache));
+        tokio::spawn(actor.run());
+
+        // A consistency prober recording probe attempts.
+        let consistency_prober = Arc::new(MockConsistencyProber::default());
+
+        // A stream of incoming probes.
+        let (_probe_tx, probe_rx) = mpsc::channel(10);
+
+        // Spawn the convergence actor and run it.
+        tokio::spawn(
+            ConvergenceActor::new(
+                Arc::new(MockSyncRpcConnector::default()),
+                schema_event_handler,
+                mst.clone(),
+                RPC_PORT,
+                Arc::clone(&consistency_prober),
+                probe_rx,
+            )
+            .run(),
+        );
+
+        // Wait for a probe to happen.
+        let mut calls = async {
+            loop {
+                let calls = consistency_prober.calls();
+                if !calls.is_empty() {
+                    return calls;
+                }
+                tokio::time::sleep(Duration::from_millis(50)).await;
+            }
+        }
+        .with_timeout_panic(Duration::from_secs(5))
+        .await;
+
+        // It's technically possible that multiple probes could have been sent
+        // before the loop was scheduled and noticed, so only inspect the first.
+        let (root, port) = calls.swap_remove(0);
+
+        // Given the absence of MST updates since sending the probe, the
+        // advertised root hash must match the MST root hash.
+        assert_eq!(root, mst.content_hash().await);
+
+        // The advertised service port must match the configured value.
+        assert_eq!(port, RPC_PORT);
+    }
+
+    /// Assert that upon receipt of a consistent probe containing an
+    /// inconsistent root hash, some resolution mechanism is started such that
+    /// an RPC is made to discover inconsistencies.
+    ///
+    /// This is effectively asserting the RpcWorker is started and provided a
+    /// correctly derived RPC address. Behaviours of the worker are tested
+    /// independently.
+    #[tokio::test]
+    async fn test_inconsistent_spawns_sync_worker() {
+        const INCONSISTENT_HASH: &[u8; 16] = b"bananas_bananas!";
+
+        // Schema cache being synchronised, and the gossip event handler that
+        // merges events into the cache.
+        let schema_cache = Arc::new(MemoryNamespaceCache::default());
+        let schema_event_handler = Arc::new(NamespaceSchemaGossip::new(Arc::clone(&schema_cache)));
+
+        // The MST state actor & handle.
+        let (actor, mst) = AntiEntropyActor::new(Arc::clone(&schema_cache));
+        tokio::spawn(actor.run());
+
+        // A consistency prober recording probe attempts.
+        let consistency_prober = Arc::new(MockConsistencyProber::default());
+
+        // A stream of incoming probes.
+        let (probe_tx, probe_rx) = mpsc::channel(10);
+
+        // Configure the RPC client to reply that the peers are fully
+        // consistent.
+        //
+        // This should stop the rpc worker, allowing the test to assert it
+        // started.
+        let rpc_client =
+            Arc::new(MockSyncRpcClient::default().with_find_inconsistent_ranges([Ok(vec![])]));
+
+        // And configure the mock connector to return it.
+        let rpc_connector =
+            Arc::new(MockSyncRpcConnector::default().with_client(Arc::clone(&rpc_client)));
+
+        // Spawn the convergence actor and run it.
+        tokio::spawn(
+            ConvergenceActor::new(
+                Arc::clone(&rpc_connector),
+                schema_event_handler,
+                mst.clone(),
+                RPC_PORT,
+                Arc::clone(&consistency_prober),
+                probe_rx,
+            )
+            .run(),
+        );
+
+        // Send the consistency probe indicating the peers are inconsistent.
+        //
+        // This starts the RPC worker, which then discovers the peers are
+        // actually consistent (due to concurrent updates) and stops.
+        let identity = Identity::try_from(b"1234567890123456".to_vec()).unwrap();
+        let sender_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8042);
+        let probe = ConsistencyProbe {
+            root_hash: INCONSISTENT_HASH.to_vec(),
+            grpc_port: RPC_PORT as _,
+        };
+
+        probe_tx
+            .send((probe, identity.clone(), sender_addr))
+            .await
+            .expect("probe send must succeed");
+
+        // Wait for a RPC call to be made.
+        async {
+            loop {
+                let calls = rpc_client.calls();
+                if !calls.is_empty() {
+                    return;
+                }
+                tokio::time::sleep(Duration::from_millis(50)).await;
+            }
+        }
+        .with_timeout_panic(Duration::from_secs(5))
+        .await;
+
+        // Inspect the connection parameters.
+        assert_matches!(rpc_connector.calls().as_slice(), [addr] => {
+            assert_eq!(*addr, SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), RPC_PORT));
+        });
+    }
+}

--- a/router/src/gossip/anti_entropy/sync/consistency_prober.rs
+++ b/router/src/gossip/anti_entropy/sync/consistency_prober.rs
@@ -1,0 +1,47 @@
+//! An abstract transport used to send Merkle Search Tree consistency probes.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use generated_types::{
+    influxdata::iox::gossip::{v1::ConsistencyProbe, Topic},
+    prost::Message,
+};
+use gossip::GossipHandle;
+use merkle_search_tree::digest::RootHash;
+
+/// An abstract mechanism of probing the consistency of cluster peers.
+#[async_trait]
+pub trait ConsistencyProber: Send + Sync + std::fmt::Debug {
+    /// Perform a consistency probe against an arbitrary set of peers.
+    ///
+    /// Advertise the local node is listening on `rpc_bind` to provide the RPC
+    /// sync service, and `local_root` as the MST root hash for the local node.
+    async fn probe(&self, local_root: RootHash, rpc_bind: u16);
+}
+
+#[async_trait]
+impl ConsistencyProber for GossipHandle<Topic> {
+    async fn probe(&self, local_root: RootHash, rpc_bind: u16) {
+        // Generate the solicitation payload.
+        let payload = ConsistencyProbe {
+            root_hash: local_root.as_bytes().to_vec(),
+            grpc_port: rpc_bind as _,
+        };
+
+        // Broadcast the root hash to a random subset of cluster peers.
+        self.broadcast_subset(payload.encode_to_vec(), Topic::SchemaCacheConsistency)
+            .await
+            .expect("gossip message size exceeds max");
+    }
+}
+
+#[async_trait]
+impl<T> ConsistencyProber for Arc<T>
+where
+    T: ConsistencyProber,
+{
+    async fn probe(&self, local_root: RootHash, rpc_bind: u16) {
+        T::probe(self, local_root, rpc_bind).await
+    }
+}

--- a/router/src/gossip/anti_entropy/sync/mock_consistency_prober.rs
+++ b/router/src/gossip/anti_entropy/sync/mock_consistency_prober.rs
@@ -1,0 +1,23 @@
+use async_trait::async_trait;
+use merkle_search_tree::digest::RootHash;
+use parking_lot::Mutex;
+
+use super::consistency_prober::ConsistencyProber;
+
+#[derive(Debug, Default)]
+pub struct MockConsistencyProber {
+    calls: Mutex<Vec<(RootHash, u16)>>,
+}
+
+impl MockConsistencyProber {
+    pub fn calls(&self) -> Vec<(RootHash, u16)> {
+        self.calls.lock().clone()
+    }
+}
+
+#[async_trait]
+impl ConsistencyProber for MockConsistencyProber {
+    async fn probe(&self, local_root: RootHash, rpc_bind: u16) {
+        self.calls.lock().push((local_root, rpc_bind));
+    }
+}

--- a/router/src/gossip/anti_entropy/sync/mock_rpc_client.rs
+++ b/router/src/gossip/anti_entropy/sync/mock_rpc_client.rs
@@ -1,0 +1,120 @@
+//! A mock [`SyncRpcClient`] and [`SyncRpcConnector`] factory.
+
+use std::{collections::VecDeque, net::SocketAddr, ops::RangeInclusive, sync::Arc};
+
+use async_trait::async_trait;
+use data_types::NamespaceName;
+use generated_types::influxdata::iox::gossip::v1::NamespaceSchemaEntry;
+use parking_lot::Mutex;
+
+use crate::gossip::anti_entropy::mst::actor::MerkleSnapshot;
+
+use super::traits::{BoxedError, SyncRpcClient, SyncRpcConnector};
+
+#[derive(Debug)]
+pub struct MockSyncRpcConnector<T> {
+    client: T,
+    calls: Mutex<Vec<SocketAddr>>,
+}
+
+impl Default for MockSyncRpcConnector<Arc<MockSyncRpcClient>> {
+    fn default() -> Self {
+        Self {
+            client: Arc::new(MockSyncRpcClient::default()),
+            calls: Default::default(),
+        }
+    }
+}
+
+#[async_trait]
+impl<T> SyncRpcConnector for MockSyncRpcConnector<T>
+where
+    T: SyncRpcClient + Clone,
+{
+    type Client = T;
+
+    async fn connect(&self, addr: SocketAddr) -> Result<Self::Client, BoxedError> {
+        self.calls.lock().push(addr);
+        Ok(self.client.clone())
+    }
+}
+
+impl<T> MockSyncRpcConnector<T> {
+    pub fn with_client<U>(self, client: U) -> MockSyncRpcConnector<U> {
+        MockSyncRpcConnector {
+            client,
+            calls: Default::default(),
+        }
+    }
+
+    pub fn calls(&self) -> Vec<SocketAddr> {
+        self.calls.lock().clone()
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum MockCalls {
+    FindInconsistentRanges(MerkleSnapshot),
+    GetSchemasInRange(RangeInclusive<NamespaceName<'static>>),
+}
+
+#[derive(Debug, Default)]
+pub struct MockSyncRpcClient {
+    calls: Mutex<Vec<MockCalls>>,
+
+    ret_find_inconsistent_ranges:
+        Mutex<VecDeque<Result<Vec<RangeInclusive<NamespaceName<'static>>>, BoxedError>>>,
+
+    ret_get_schemas_in_range: Mutex<VecDeque<Result<Vec<NamespaceSchemaEntry>, BoxedError>>>,
+}
+
+impl MockSyncRpcClient {
+    pub fn with_find_inconsistent_ranges(
+        self,
+        ret: impl Into<VecDeque<Result<Vec<RangeInclusive<NamespaceName<'static>>>, BoxedError>>>,
+    ) -> Self {
+        *self.ret_find_inconsistent_ranges.lock() = ret.into();
+        self
+    }
+
+    pub fn with_get_schemas_in_range(
+        self,
+        ret: impl Into<VecDeque<Result<Vec<NamespaceSchemaEntry>, BoxedError>>>,
+    ) -> Self {
+        *self.ret_get_schemas_in_range.lock() = ret.into();
+        self
+    }
+
+    pub fn calls(&self) -> Vec<MockCalls> {
+        self.calls.lock().clone()
+    }
+}
+
+#[async_trait]
+impl SyncRpcClient for Arc<MockSyncRpcClient> {
+    async fn find_inconsistent_ranges(
+        &mut self,
+        pages: MerkleSnapshot,
+    ) -> Result<Vec<RangeInclusive<NamespaceName<'static>>>, BoxedError> {
+        self.calls
+            .lock()
+            .push(MockCalls::FindInconsistentRanges(pages));
+
+        self.ret_find_inconsistent_ranges
+            .lock()
+            .pop_front()
+            .expect("no mock value configured for find_inconsistent_ranges()")
+    }
+
+    async fn get_schemas_in_range(
+        &mut self,
+        range: RangeInclusive<NamespaceName<'static>>,
+    ) -> Result<Vec<NamespaceSchemaEntry>, BoxedError> {
+        self.calls.lock().push(MockCalls::GetSchemasInRange(range));
+
+        self.ret_get_schemas_in_range
+            .lock()
+            .pop_front()
+            .expect("no mock value configured for get_schemas_in_range()")
+    }
+}

--- a/router/src/gossip/anti_entropy/sync/mod.rs
+++ b/router/src/gossip/anti_entropy/sync/mod.rs
@@ -1,0 +1,14 @@
+//! Convergence of [`NamespaceCache`] content across gossip peers.
+//!
+//! [`NamespaceCache`]: crate::namespace_cache::NamespaceCache
+
+pub mod actor;
+pub mod consistency_prober;
+pub(crate) mod rpc_worker;
+pub mod traits;
+
+#[cfg(test)]
+pub mod mock_rpc_client;
+
+#[cfg(test)]
+pub mod mock_consistency_prober;

--- a/router/src/gossip/anti_entropy/sync/rpc_worker.rs
+++ b/router/src/gossip/anti_entropy/sync/rpc_worker.rs
@@ -1,0 +1,372 @@
+use std::{fmt::Debug, net::SocketAddr};
+
+use generated_types::influxdata::iox::gossip::v1::schema_message::Event;
+use gossip::Identity;
+use gossip_schema::dispatcher::SchemaEventHandler;
+use observability_deps::tracing::{debug, info, warn};
+use thiserror::Error;
+
+use crate::gossip::anti_entropy::mst::handle::AntiEntropyHandle;
+
+use super::traits::{BoxedError, SyncRpcClient};
+
+#[derive(Debug, Error)]
+enum SyncError {
+    #[error(transparent)]
+    Boxed(#[from] BoxedError),
+
+    #[error("sync is missing namespace creation event")]
+    NoNamespaceCreate,
+}
+
+/// A worker task to perform sync RPC requests to a given peer, and merge the
+/// resulting gossip event responses into the local schema cache.
+///
+/// This task lives for the duration of a single sync round and then exits.
+#[derive(Debug)]
+pub(crate) struct RpcWorker<T, U> {
+    /// The RPC client used to perform sync operations against the peer.
+    rpc_client: T,
+
+    /// The [`SchemaEventHandler`] that merges gossip events into the schema
+    /// cache.
+    schema_event_delegate: U,
+
+    /// The [`MerkleSearchTree`] state actor.
+    ///
+    /// [`MerkleSearchTree`]: merkle_search_tree::MerkleSearchTree
+    mst: AntiEntropyHandle,
+
+    // Fields for log context.
+    //
+    /// The derived RPC service address for the sync peer.
+    peer_addr: SocketAddr,
+    /// The [`Identity`] of the sync peer.
+    identity: Identity,
+}
+
+impl<T, U> RpcWorker<T, U>
+where
+    T: SyncRpcClient,
+    U: SchemaEventHandler,
+{
+    pub(super) fn new(
+        rpc_client: T,
+        schema_event_delegate: U,
+        mst: AntiEntropyHandle,
+        peer_addr: SocketAddr,
+        identity: Identity,
+    ) -> Self {
+        Self {
+            rpc_client,
+            schema_event_delegate,
+            mst,
+            peer_addr,
+            identity,
+        }
+    }
+
+    pub(super) async fn run(mut self) {
+        debug!(
+            peer_addr=%self.peer_addr,
+            peer_identity=%self.identity,
+            "starting cache sync with peer"
+        );
+
+        match self.try_sync().await {
+            Ok(()) => info!(
+                peer_addr=%self.peer_addr,
+                peer_identity=%self.identity,
+                "completed cache sync with peer"
+            ),
+            Err(error) => warn!(
+                %error,
+                peer_addr=%self.peer_addr,
+                peer_identity=%self.identity,
+                "failed to cache sync with peer"
+            ),
+        }
+    }
+
+    async fn try_sync(&mut self) -> Result<(), SyncError> {
+        // Get the current snapshot of the local MST state.
+        let snap = self.mst.snapshot().await;
+
+        // Perform the RPC to the peer to identify inconsistent pages.
+        //
+        // While this sync round was started because the root hashes of two
+        // peers differ (meaning they were inconsistent), the inconsistency may
+        // have been resolved by the time this RPC call is made, so this may
+        // return "not inconsistent" without issue.
+        let inconsistent_ranges = self.rpc_client.find_inconsistent_ranges(snap).await?;
+
+        debug!(
+            n_ranges=inconsistent_ranges.len(),
+            peer_addr=%self.peer_addr,
+            peer_identity=%self.identity,
+            "identified inconsistent pages"
+        );
+
+        for range in inconsistent_ranges {
+            // Fetch the schemas in each inconsistent range
+            let events = self.rpc_client.get_schemas_in_range(range).await?;
+
+            // Apply each schema (represented as a composition of gossip events
+            // needed to create the schema) to the local cache.
+            for event in events {
+                // Create the namespace if necessary and block for it to be
+                // added to the cache.
+                self.schema_event_delegate
+                    .handle(Event::NamespaceCreated(
+                        event.namespace.ok_or(SyncError::NoNamespaceCreate)?,
+                    ))
+                    .await;
+
+                // Add merge each table schema in this namespace.
+                for table in event.tables {
+                    self.schema_event_delegate
+                        .handle(Event::TableCreated(table))
+                        .await;
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        collections::BTreeMap,
+        net::{IpAddr, Ipv4Addr},
+        sync::Arc,
+    };
+
+    use data_types::{
+        partition_template::{
+            NamespacePartitionTemplateOverride, TablePartitionTemplateOverride,
+            PARTITION_BY_DAY_PROTO,
+        },
+        Column, ColumnId, ColumnType, ColumnsByName, MaxColumnsPerTable, MaxTables, NamespaceId,
+        NamespaceName, NamespaceSchema, TableId, TableSchema,
+    };
+    use generated_types::influxdata::iox::gossip::v1::{
+        NamespaceCreated, NamespaceSchemaEntry, TableCreated, TableUpdated,
+    };
+
+    use crate::{
+        gossip::{
+            anti_entropy::{
+                mst::actor::AntiEntropyActor, sync::mock_rpc_client::MockSyncRpcClient,
+            },
+            namespace_cache::NamespaceSchemaGossip,
+        },
+        namespace_cache::{MemoryNamespaceCache, NamespaceCache},
+    };
+
+    use super::*;
+
+    const MOCK_ADDR: SocketAddr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 42);
+    const NAMESPACE_NAME: &str = "bananas_namespace";
+    const NAMESPACE_NAME2: &str = "platanos_namespace";
+    const DEFAULT_NAMESPACE_PARTITION_TEMPLATE: NamespacePartitionTemplateOverride =
+        NamespacePartitionTemplateOverride::const_default();
+    const DEFAULT_NAMESPACE: NamespaceSchema = NamespaceSchema {
+        id: NamespaceId::new(4242),
+        tables: BTreeMap::new(),
+        max_columns_per_table: MaxColumnsPerTable::new(1),
+        max_tables: MaxTables::new(2),
+        retention_period_ns: None,
+        partition_template: DEFAULT_NAMESPACE_PARTITION_TEMPLATE,
+    };
+
+    /// Assert that a sync worker will request the appropriate gossip events
+    /// from the remote peer, and merge them into the schema cache.
+    ///
+    /// This ensures the RpcWorker is correct, but also that the integration
+    /// with the SchemaEventHandler is sufficient to converge the cache given a
+    /// set of events.
+    #[tokio::test]
+    async fn test_synchronises_cache() {
+        // Schema cache being synchronised, and the gossip event handler that
+        // merges events into the cache.
+        let schema_cache = Arc::new(MemoryNamespaceCache::default());
+        let schema_event_handler = Arc::new(NamespaceSchemaGossip::new(Arc::clone(&schema_cache)));
+
+        // The MST state actor & handle.
+        //
+        // The content of the MST does not matter - this test simulates pulling
+        // from a populated peer into a completely empty local peer.
+        let (actor, mst) = AntiEntropyActor::new(Arc::clone(&schema_cache));
+        tokio::spawn(actor.run());
+
+        // Initialise the mock RPC client, simulating a server returning the
+        // provided responses.
+        let rpc_client = Arc::new(
+            MockSyncRpcClient::default()
+                .with_find_inconsistent_ranges([Ok(vec![
+                    name("a")..=name("d"),
+                    name("y")..=name("z"),
+                ])])
+                .with_get_schemas_in_range([
+                    // First call, a->d
+                    Ok(vec![NamespaceSchemaEntry {
+                        namespace: Some(NamespaceCreated {
+                            namespace_name: NAMESPACE_NAME.to_string(),
+                            namespace_id: DEFAULT_NAMESPACE.id.get(),
+                            partition_template: Some((**PARTITION_BY_DAY_PROTO).clone()),
+                            max_columns_per_table: DEFAULT_NAMESPACE.max_columns_per_table.get()
+                                as _,
+                            max_tables: DEFAULT_NAMESPACE.max_tables.get() as _,
+                            retention_period_ns: DEFAULT_NAMESPACE.retention_period_ns,
+                        }),
+                        tables: vec![
+                            TableCreated {
+                                table: Some(TableUpdated {
+                                    table_name: "bananas1".to_string(),
+                                    namespace_name: NAMESPACE_NAME.to_string(),
+                                    table_id: 421,
+                                    columns: vec![],
+                                }),
+                                partition_template: Some((**PARTITION_BY_DAY_PROTO).clone()),
+                            },
+                            TableCreated {
+                                table: Some(TableUpdated {
+                                    table_name: "bananas2".to_string(),
+                                    namespace_name: NAMESPACE_NAME.to_string(),
+                                    table_id: 422,
+                                    columns: vec![],
+                                }),
+                                partition_template: None,
+                            },
+                        ],
+                    }]),
+                    // Second call, y->z
+                    Ok(vec![NamespaceSchemaEntry {
+                        namespace: Some(NamespaceCreated {
+                            namespace_name: NAMESPACE_NAME2.to_string(),
+                            namespace_id: 2424,
+                            partition_template: None,
+                            max_columns_per_table: 1234,
+                            max_tables: 666,
+                            retention_period_ns: Some(4321),
+                        }),
+                        tables: vec![TableCreated {
+                            table: Some(TableUpdated {
+                                table_name: "platanos".to_string(),
+                                namespace_name: NAMESPACE_NAME2.to_string(),
+                                table_id: 423,
+                                columns: vec![
+                                    generated_types::influxdata::iox::gossip::v1::Column {
+                                        name: "c1".to_string(),
+                                        column_id: 101,
+                                        column_type: ColumnType::U64 as _,
+                                    },
+                                ],
+                            }),
+                            partition_template: None,
+                        }],
+                    }]),
+                ]),
+        );
+
+        // Initialise the worker task.
+        let sync_worker = RpcWorker::new(
+            Arc::clone(&rpc_client),
+            schema_event_handler,
+            mst,
+            MOCK_ADDR,
+            Identity::try_from(b"1234567890123456".to_vec()).unwrap(),
+        );
+
+        // Run the sync worker to completion.
+        sync_worker.run().await;
+
+        // The cache should now contain the two namespaces pulled from the peer.
+        let bananas = schema_cache
+            .get_schema(&name(NAMESPACE_NAME))
+            .await
+            .expect("schema pulled from peer must exist");
+
+        pretty_assertions::assert_eq!(
+            *bananas,
+            NamespaceSchema {
+                tables: [
+                    (
+                        "bananas1",
+                        TableSchema {
+                            id: TableId::new(421),
+                            partition_template: TablePartitionTemplateOverride::try_new(
+                                Some((**PARTITION_BY_DAY_PROTO).clone()),
+                                &DEFAULT_NAMESPACE_PARTITION_TEMPLATE,
+                            )
+                            .unwrap(),
+                            columns: ColumnsByName::default(),
+                        },
+                    ),
+                    (
+                        "bananas2",
+                        TableSchema {
+                            id: TableId::new(422),
+                            partition_template: TablePartitionTemplateOverride::try_new(
+                                None,
+                                &NamespacePartitionTemplateOverride::try_from(
+                                    (**PARTITION_BY_DAY_PROTO).clone()
+                                )
+                                .unwrap(),
+                            )
+                            .unwrap(),
+                            columns: ColumnsByName::default(),
+                        },
+                    ),
+                ]
+                .map(|(a, b)| (a.to_string(), b))
+                .into_iter()
+                .collect(),
+                partition_template: NamespacePartitionTemplateOverride::try_from(
+                    (**PARTITION_BY_DAY_PROTO).clone()
+                )
+                .unwrap(),
+                ..DEFAULT_NAMESPACE.clone()
+            }
+        );
+
+        // Validate the second namespace (ensuring all were pulled)
+        let platanos = schema_cache
+            .get_schema(&name(NAMESPACE_NAME2))
+            .await
+            .expect("schema pulled from peer must exist");
+
+        pretty_assertions::assert_eq!(
+            *platanos,
+            NamespaceSchema {
+                id: NamespaceId::new(2424),
+                max_columns_per_table: MaxColumnsPerTable::new(1234),
+                max_tables: MaxTables::new(666),
+                retention_period_ns: Some(4321),
+                partition_template: Default::default(),
+                tables: [(
+                    "platanos",
+                    TableSchema {
+                        id: TableId::new(423),
+                        partition_template: Default::default(),
+                        columns: ColumnsByName::new([Column {
+                            id: ColumnId::new(101),
+                            table_id: TableId::new(423),
+                            name: "c1".to_string(),
+                            column_type: ColumnType::U64,
+                        }]),
+                    },
+                ),]
+                .map(|(a, b)| (a.to_string(), b))
+                .into_iter()
+                .collect(),
+            }
+        );
+    }
+
+    fn name(s: &str) -> NamespaceName<'static> {
+        NamespaceName::new(s.to_string()).unwrap()
+    }
+}

--- a/router/src/gossip/anti_entropy/sync/traits.rs
+++ b/router/src/gossip/anti_entropy/sync/traits.rs
@@ -1,0 +1,57 @@
+//! Abstractions decoupling the anti-entropy subsystem from other subsystems.
+
+use std::{fmt::Debug, net::SocketAddr, ops::RangeInclusive, sync::Arc};
+
+use async_trait::async_trait;
+use data_types::NamespaceName;
+use generated_types::influxdata::iox::gossip::v1::NamespaceSchemaEntry;
+
+use crate::gossip::anti_entropy::mst::actor::MerkleSnapshot;
+
+pub(super) type BoxedError = Box<dyn std::error::Error + Send + Sync>;
+
+/// An abstract constructor of [`SyncRpcClient`] instances.
+#[async_trait]
+pub trait SyncRpcConnector: Send + Sync + Debug {
+    /// The concrete client type.
+    type Client: SyncRpcClient;
+
+    /// Connect to the specified `addr`, returning an error if unreachable.
+    async fn connect(&self, addr: SocketAddr) -> Result<Self::Client, BoxedError>;
+}
+
+#[async_trait]
+impl<T> SyncRpcConnector for Arc<T>
+where
+    T: SyncRpcConnector,
+{
+    type Client = T::Client;
+
+    async fn connect(&self, addr: SocketAddr) -> Result<Self::Client, BoxedError> {
+        T::connect(self, addr).await
+    }
+}
+
+/// An abstract RPC mechanism used to perform cache synchronisation.
+#[async_trait]
+pub trait SyncRpcClient: Send + Sync + Debug {
+    /// Have the remote perform a [`MerkleSearchTree`] diff against the provided
+    /// [`MerkleSnapshot`], returning the set of [`NamespaceName`] ranges that
+    /// contain inconsistent entries.
+    ///
+    /// [`MerkleSearchTree`]: merkle_search_tree::MerkleSearchTree
+    async fn find_inconsistent_ranges(
+        &mut self,
+        pages: MerkleSnapshot,
+    ) -> Result<Vec<RangeInclusive<NamespaceName<'static>>>, BoxedError>;
+
+    /// Retrieve the set of [`NamespaceSchemaEntry`] for the given range.
+    ///
+    /// The [`NamespaceSchemaEntry`] is a compound type containing the set of
+    /// gossip events necessary to reconstruct peer's full schema entry for a
+    /// given [`NamespaceName`].
+    async fn get_schemas_in_range(
+        &mut self,
+        range: RangeInclusive<NamespaceName<'static>>,
+    ) -> Result<Vec<NamespaceSchemaEntry>, BoxedError>;
+}


### PR DESCRIPTION
This PR builds on #8780, consuming the merkle search tree content and eventually using it to drive eventual consistency of the schema cache content across gossip peers.

This PR introduces the client-side sync mechanism driving eventual consistency of the schema cache content across gossip peers, using the sync protocol described in https://github.com/influxdata/influxdb_iox/pull/8753.

A follow-up PR will introduce the server-side component this client interacts with.

---

* refactor: ColumnsByName default impl (9493ce74a)
      
      The ColumnsByName type can/should default to an empty set.

* feat(router): schema cache anti-entropy/sync actor (ee0334dab)
      
      Adds the foundational components of the router anti-entropy subsystem.
      This subsystem compliments the existing schema gossiping mechanism to
      provide eventual consistency of the router schema caches.
      
      This commit introduces the "convergence actor", an actor task
      responsible for detecting peer inconsistencies and efficiently
      converging those differences using the existing Merkle Search Tree
      actor.
      
      Various sub-components break this convergence problem down into simple,
      singly-responsible parts:
      
        * The existing Merkle Search Tree actor tracking the NamespaceCache
          content
      
        * A consistency prober to send MST root hashes to peers over gossip
      
        * An actor task to send and and process received consistency probes
          from peers, and start a sync worker to converge inconsistencies
      
        * A sync worker that drives MST differential syncing and convergence
          against a single peer
      
      The sync worker makes use of the existing gossip message format used to
      communicate schema cache changes between peers, and drives convergence
      by fetching & replaying the messages necessary to fully construct the
      diverged schemas; reusing the gossip messages ensures all schema updates
      flow through the same code paths, regardless of source (sync vs gossip).