### PR TITLE
refactor: Extract more functionality that schema upsert will need too

### DIFF
--- a/iox_catalog/src/lib.rs
+++ b/iox_catalog/src/lib.rs
@@ -227,7 +227,7 @@ where
 // &mut Cow is used to avoid a copy, so allow it
 #[allow(clippy::ptr_arg)]
 async fn validate_and_insert_columns<R>(
-    columns: impl Iterator<Item = (&String, ColumnType)>,
+    columns: impl Iterator<Item = (&String, ColumnType)> + Send,
     table: &mut Cow<'_, TableSchema>,
     repos: &mut R,
 ) -> Result<()>


### PR DESCRIPTION
Extracted from https://github.com/influxdata/influxdb_iox/pull/8682.

Reviewing commit-by-commit should be straightforward. The usage of the extracted functions in another place isn't included in this PR, but I do have a branch locally using these successfully. 