### PR TITLE
feat(router): Merkle Search Tree diff computation support

### DIFF
--- a/data_types/src/namespace_name.rs
+++ b/data_types/src/namespace_name.rs
@@ -131,6 +131,14 @@ impl<'a> NamespaceName<'a> {
 
         Ok(Self::new(format!("{}_{}", org, bucket))?)
     }
+
+    /// Efficiently returns the string representation of this [`NamespaceName`].
+    ///
+    /// If this [`NamespaceName`] contains an owned string, it is returned
+    /// without cloning.
+    pub fn into_string(self) -> String {
+        self.0.into_owned()
+    }
 }
 
 impl<'a> std::convert::From<NamespaceName<'a>> for String {
@@ -191,6 +199,23 @@ mod tests {
             .expect("failed on valid DB mapping");
 
         assert_eq!(got.as_str(), "org_bucket");
+        assert_eq!(got.into_string(), "org_bucket");
+    }
+
+    #[test]
+    fn test_into_string() {
+        // Ref type str
+        assert_eq!(
+            NamespaceName::new("bananas").unwrap().into_string(),
+            "bananas"
+        );
+        // Owned type string
+        assert_eq!(
+            NamespaceName::new("bananas".to_string())
+                .unwrap()
+                .into_string(),
+            "bananas"
+        );
     }
 
     #[test]

--- a/router/src/gossip/anti_entropy/mst/actor.rs
+++ b/router/src/gossip/anti_entropy/mst/actor.rs
@@ -1,5 +1,5 @@
 //! An actor task maintaining [`MerkleSearchTree`] state.
-use std::sync::Arc;
+use std::{ops::RangeInclusive, sync::Arc};
 
 use data_types::{NamespaceName, NamespaceSchema};
 use merkle_search_tree::{diff::PageRangeSnapshot, digest::RootHash, MerkleSearchTree};
@@ -21,6 +21,13 @@ pub(super) enum Op {
 
     /// Request a [`MerkleSnapshot`] of the current MST state.
     Snapshot(oneshot::Sender<MerkleSnapshot>),
+
+    /// Compute the diff between the local MST state and the provided snapshot,
+    /// returning the key ranges that contain inconsistencies.
+    Diff(
+        MerkleSnapshot,
+        oneshot::Sender<Vec<RangeInclusive<NamespaceName<'static>>>>,
+    ),
 }
 
 impl Op {
@@ -29,6 +36,7 @@ impl Op {
         match self {
             Op::ContentHash(tx) => tx.is_closed(),
             Op::Snapshot(tx) => tx.is_closed(),
+            Op::Diff(_, tx) => tx.is_closed(),
         }
     }
 }
@@ -177,6 +185,33 @@ where
                 );
 
                 let _ = tx.send(snap);
+            }
+            Op::Diff(snap, tx) => {
+                self.generate_root();
+
+                // Generate the local MST pages.
+                //
+                // In theory these pages could be cached and invalidated as
+                // necessary, but in practice the MST itself performs lazy hash
+                // invalidation when mutated, so generating the pages from an
+                // unchanged MST is extremely fast (microseconds) making the
+                // additional caching complexity unjustified.
+                let local_pages = self
+                    .mst
+                    .serialise_page_ranges()
+                    .expect("root hash generated");
+
+                // Compute the inconsistent key ranges and map them to an owned
+                // representation.
+                //
+                // This is also extremely fast (microseconds) so executing it on
+                // an I/O runtime thread is unlikely to cause problems.
+                let diff = merkle_search_tree::diff::diff(snap.iter(), local_pages)
+                    .into_iter()
+                    .map(|v| RangeInclusive::new(v.start().to_owned(), v.end().to_owned()))
+                    .collect();
+
+                let _ = tx.send(diff);
             }
         }
     }


### PR DESCRIPTION
Teaches the AntiEntropyActor to perform a merkle tree diff when given a `MerkleSnapshot` from another peer, returning the difference between the local MST and the snapshot.

This diff isn't symmetrical, and from the perspective of the API caller providing the snapshot, the node on which the diff is computed is the peer. The returned diff response describes what pages the _caller_ needs to pull from the _differ_.

---

* perf: don't execute ops for dead callers (bc7260916)
      
      Operations against the AntiEntropyActor that fetch data for the caller
      (with ~no other side effects) can be optimised out when the caller is no
      longer waiting for the answer (i.e. API call timeout, etc).

* perf: efficient NamespaceName -> String conversion (a4b1ded8e)
      
      Allow a NamespaceName constructed from a String to be unwrapped into the
      underlying String instance directly, rather than forcing a clone.

* feat: Merkle Search Tree diff computation (9f2e39d7c)
      
      Allow the AntiEntropyHandle to request a Merkle Search Tree difference
      computation between a provided snapshot (intended to be sent from a
      cluster peer) and the local state, returning the key ranges that contain
      inconsistencies.