### PR TITLE
feat(router): query merkle tree for key ranges

### DIFF
--- a/router/src/gossip/anti_entropy/mst/handle.rs
+++ b/router/src/gossip/anti_entropy/mst/handle.rs
@@ -161,4 +161,21 @@ impl AntiEntropyHandle {
 
         rx.await.expect("anti-entropy actor has stopped")
     }
+
+    /// Request all [`NamespaceName`] known to the MST in the given inclusive
+    /// key range.
+    #[allow(dead_code)]
+    pub(crate) async fn get_keys_in_range(
+        &self,
+        range: RangeInclusive<NamespaceName<'static>>,
+    ) -> Vec<NamespaceName<'static>> {
+        let (tx, rx) = oneshot::channel();
+
+        self.op_tx
+            .send(Op::KeysInRange(range, tx))
+            .await
+            .expect("anti-entropy actor has stopped");
+
+        rx.await.expect("anti-entropy actor has stopped")
+    }
 }


### PR DESCRIPTION
Allow a caller to ask the MST "what keys do your consistency proofs cover?"

This will allow us to extract the keys that need to be synced when we have identified a range of keys that are inconsistent. Put another way, given the range `[bananas, platanos]` we can ask the MST "what keys are between `bananas` and `platanos` that you care about?" and it'll return the set (obviously the correct answer is `bananas, donkey, platanos`).

Test in the next PR which ties together (and tests) everything MST :+1:

---

* feat(router): query merkle tree for key ranges (86608c72f)
      
      Allow an AntiEntropyHandle holder to query the actor (and in turn, the
      merkle tree) for the keys (namespaces) the tree covers within a given
      lexicographic range.