### PR TITLE
refactor(ingester): Abstract column map lookup from persist workers

### DIFF
--- a/ingester/src/init.rs
+++ b/ingester/src/init.rs
@@ -45,8 +45,9 @@ use crate::{
     ingest_state::IngestState,
     ingester_id::IngesterId,
     persist::{
-        completion_observer::MaybeLayer, file_metrics::ParquetFileInstrumentation,
-        handle::PersistHandle, hot_partitions::HotPartitionPersister,
+        column_map_resolver::CatalogMapResolver, completion_observer::MaybeLayer,
+        file_metrics::ParquetFileInstrumentation, handle::PersistHandle,
+        hot_partitions::HotPartitionPersister,
     },
     query::{
         exec_instrumentation::QueryExecInstrumentation,
@@ -409,6 +410,7 @@ where
         object_store,
         Arc::clone(&catalog),
         persist_observer,
+        CatalogMapResolver::new(Arc::clone(&catalog)),
         &metrics,
     );
     let persist_handle = Arc::new(persist_handle);

--- a/ingester/src/persist/column_map_resolver.rs
+++ b/ingester/src/persist/column_map_resolver.rs
@@ -1,4 +1,5 @@
 mod catalog;
+pub(crate) use catalog::*;
 
 use std::fmt::Debug;
 
@@ -10,7 +11,7 @@ use schema::sort::SortKey;
 /// [`ColumnsByName`] of any given table, verified against the associated
 /// [`SortKey`].
 #[async_trait]
-trait ColumnMapResolver: Debug + Send + Sync {
+pub(crate) trait ColumnMapResolver: Debug + Send + Sync {
     /// Loads the mapping of column name to column ID for the given `table_id`
     /// and its `sort_key`.
     ///

--- a/ingester/src/persist/column_map_resolver.rs
+++ b/ingester/src/persist/column_map_resolver.rs
@@ -1,3 +1,5 @@
+mod catalog;
+
 use std::fmt::Debug;
 
 use async_trait::async_trait;

--- a/ingester/src/persist/column_map_resolver.rs
+++ b/ingester/src/persist/column_map_resolver.rs
@@ -1,0 +1,24 @@
+use std::fmt::Debug;
+
+use async_trait::async_trait;
+use data_types::{ColumnsByName, TableId};
+use schema::sort::SortKey;
+
+/// A [`ColumnMapResolver`] offers an infallible lookup mechanism for the set of
+/// [`ColumnsByName`] of any given table, verified against the associated
+/// [`SortKey`].
+#[async_trait]
+trait ColumnMapResolver: Debug + Send + Sync {
+    /// Loads the mapping of column name to column ID for the given `table_id`
+    /// and its `sort_key`.
+    ///
+    /// # Panics
+    ///
+    /// If the sort key refers to columns not found in the returned index, a
+    /// correctness invariant is broken and this method will panic.
+    async fn load_verified_column_map(
+        &self,
+        table_id: TableId,
+        sort_key: Option<&SortKey>,
+    ) -> ColumnsByName;
+}

--- a/ingester/src/persist/column_map_resolver/catalog.rs
+++ b/ingester/src/persist/column_map_resolver/catalog.rs
@@ -45,12 +45,86 @@ impl ColumnMapResolver for CatalogMapResolver {
                 .find(|sort_key_column| !column_map.contains_column_name(sort_key_column))
             {
                 panic!(
-                    "sort key column {} not present in column map {:?} for table id {}",
-                    sort_key_column, column_map, table_id
+                    "sort key column {} not present in column map for table id {}",
+                    sort_key_column, table_id
                 )
             }
         }
 
         column_map
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use data_types::Column;
+    use iox_catalog::mem::MemCatalog;
+
+    use crate::test_util::{
+        populate_catalog_with_table_columns, ARBITRARY_NAMESPACE_NAME, ARBITRARY_TABLE_NAME,
+    };
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_load_verified_column_map() {
+        let metrics = Arc::new(metric::Registry::default());
+        let catalog: Arc<dyn Catalog> = Arc::new(MemCatalog::new(metrics));
+
+        let columns = ["bananas", "uno", "dos", "tres"];
+
+        // Populate the catalog with the namespace, table & columns
+        let (_ns_id, table_id, col_ids) = populate_catalog_with_table_columns(
+            &*catalog,
+            &ARBITRARY_NAMESPACE_NAME,
+            &ARBITRARY_TABLE_NAME,
+            &columns,
+        )
+        .await;
+
+        let resolver = CatalogMapResolver::new(catalog);
+
+        let got_map = resolver
+            .load_verified_column_map(table_id, Some(&SortKey::from_columns(columns)))
+            .await;
+
+        assert_eq!(
+            got_map,
+            ColumnsByName::new(columns.into_iter().zip(col_ids).map(|(name, id)| {
+                Column {
+                    id,
+                    table_id,
+                    name: name.to_string(),
+                    column_type: data_types::ColumnType::Tag,
+                }
+            }))
+        );
+    }
+
+    #[tokio::test]
+    #[should_panic(
+        expected = r#"sort key column bananas not present in column map for table id 1"#
+    )]
+    async fn test_load_verified_column_map_panics() {
+        let metrics = Arc::new(metric::Registry::default());
+        let catalog: Arc<dyn Catalog> = Arc::new(MemCatalog::new(metrics));
+
+        let columns = ["uno", "dos", "tres"];
+
+        // Populate the catalog with the namespace, table & columns
+        let (_ns_id, table_id, _col_ids) = populate_catalog_with_table_columns(
+            &*catalog,
+            &ARBITRARY_NAMESPACE_NAME,
+            &ARBITRARY_TABLE_NAME,
+            &columns,
+        )
+        .await;
+
+        let resolver = CatalogMapResolver::new(catalog);
+
+        // Load with a on
+        resolver
+            .load_verified_column_map(table_id, Some(&SortKey::from_columns(["bananas"])))
+            .await;
     }
 }

--- a/ingester/src/persist/column_map_resolver/catalog.rs
+++ b/ingester/src/persist/column_map_resolver/catalog.rs
@@ -1,0 +1,56 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use backoff::Backoff;
+use data_types::{ColumnsByName, TableId};
+use iox_catalog::interface::Catalog;
+use schema::sort::SortKey;
+
+use super::ColumnMapResolver;
+
+#[derive(Debug)]
+pub(crate) struct CatalogMapResolver {
+    catalog: Arc<dyn Catalog>,
+}
+
+impl CatalogMapResolver {
+    pub(crate) fn new(catalog: Arc<dyn Catalog>) -> Self {
+        Self { catalog }
+    }
+}
+
+#[async_trait]
+impl ColumnMapResolver for CatalogMapResolver {
+    async fn load_verified_column_map(
+        &self,
+        table_id: TableId,
+        sort_key: Option<&SortKey>,
+    ) -> ColumnsByName {
+        let column_map = Backoff::new(&Default::default())
+            .retry_all_errors("resolve table schema from catalog", || async {
+                self.catalog
+                    .repositories()
+                    .await
+                    .columns()
+                    .list_by_table_id(table_id)
+                    .await
+                    .map(ColumnsByName::new)
+            })
+            .await
+            .expect("retry forever");
+
+        if let Some(sort_key) = &sort_key {
+            if let Some(sort_key_column) = sort_key
+                .to_columns()
+                .find(|sort_key_column| !column_map.contains_column_name(sort_key_column))
+            {
+                panic!(
+                    "sort key column {} not present in column map {:?} for table id {}",
+                    sort_key_column, column_map, table_id
+                )
+            }
+        }
+
+        column_map
+    }
+}

--- a/ingester/src/persist/handle.rs
+++ b/ingester/src/persist/handle.rs
@@ -15,8 +15,9 @@ use tokio::{
 };
 
 use super::{
-    backpressure::PersistState, completion_observer::PersistCompletionObserver,
-    context::PersistRequest, queue::PersistQueue, worker::SharedWorkerState,
+    backpressure::PersistState, column_map_resolver::ColumnMapResolver,
+    completion_observer::PersistCompletionObserver, context::PersistRequest, queue::PersistQueue,
+    worker::SharedWorkerState,
 };
 use crate::{
     buffer_tree::partition::{persisting::PersistingData, PartitionData, SortKeyState},
@@ -169,7 +170,7 @@ pub(crate) struct PersistHandle {
 impl PersistHandle {
     /// Initialise a new persist actor & obtain the first handle.
     #[allow(clippy::too_many_arguments)]
-    pub(crate) fn new<O>(
+    pub(crate) fn new<O, C>(
         n_workers: usize,
         persist_queue_depth: usize,
         ingest_state: Arc<IngestState>,
@@ -177,10 +178,12 @@ impl PersistHandle {
         store: ParquetStorage,
         catalog: Arc<dyn Catalog>,
         completion_observer: O,
+        column_map_resolver: C,
         metrics: &metric::Registry,
     ) -> Self
     where
         O: PersistCompletionObserver + 'static,
+        C: ColumnMapResolver + 'static,
     {
         assert_ne!(n_workers, 0, "must run at least 1 persist worker");
         assert_ne!(
@@ -195,6 +198,7 @@ impl PersistHandle {
             exec,
             store,
             catalog,
+            column_map_resolver,
             completion_observer,
         });
 
@@ -502,6 +506,7 @@ mod tests {
         dml_sink::DmlSink,
         ingest_state::IngestStateError,
         persist::{
+            column_map_resolver::CatalogMapResolver,
             completion_observer::{mock::MockCompletionObserver, NopObserver},
             tests::{assert_metric_counter, assert_metric_gauge},
         },
@@ -550,7 +555,7 @@ mod tests {
     async fn test_persist_sort_key_provided_none() {
         let storage = ParquetStorage::new(Arc::new(InMemory::default()), StorageId::from("iox"));
         let metrics = Arc::new(metric::Registry::default());
-        let catalog = Arc::new(MemCatalog::new(Arc::clone(&metrics)));
+        let catalog: Arc<dyn Catalog> = Arc::new(MemCatalog::new(Arc::clone(&metrics)));
 
         let mut handle = PersistHandle::new(
             1,
@@ -558,8 +563,9 @@ mod tests {
             Arc::new(IngestState::default()),
             Arc::new(Executor::new_testing()),
             storage,
-            catalog,
+            Arc::clone(&catalog),
             Arc::new(MockCompletionObserver::default()),
+            CatalogMapResolver::new(catalog),
             &metrics,
         );
 
@@ -626,7 +632,7 @@ mod tests {
     async fn test_persist_sort_key_deferred_resolved_none_update_necessary() {
         let storage = ParquetStorage::new(Arc::new(InMemory::default()), StorageId::from("iox"));
         let metrics = Arc::new(metric::Registry::default());
-        let catalog = Arc::new(MemCatalog::new(Arc::clone(&metrics)));
+        let catalog: Arc<dyn Catalog> = Arc::new(MemCatalog::new(Arc::clone(&metrics)));
 
         let mut handle = PersistHandle::new(
             1,
@@ -634,8 +640,9 @@ mod tests {
             Arc::new(IngestState::default()),
             Arc::new(Executor::new_testing()),
             storage,
-            catalog,
+            Arc::clone(&catalog),
             Arc::new(MockCompletionObserver::default()),
+            CatalogMapResolver::new(catalog),
             &metrics,
         );
 
@@ -714,7 +721,7 @@ mod tests {
     async fn test_persist_sort_key_deferred_resolved_some_update_necessary() {
         let storage = ParquetStorage::new(Arc::new(InMemory::default()), StorageId::from("iox"));
         let metrics = Arc::new(metric::Registry::default());
-        let catalog = Arc::new(MemCatalog::new(Arc::clone(&metrics)));
+        let catalog: Arc<dyn Catalog> = Arc::new(MemCatalog::new(Arc::clone(&metrics)));
 
         let mut handle = PersistHandle::new(
             1,
@@ -722,8 +729,9 @@ mod tests {
             Arc::new(IngestState::default()),
             Arc::new(Executor::new_testing()),
             storage,
-            catalog,
+            Arc::clone(&catalog),
             Arc::new(MockCompletionObserver::default()),
+            CatalogMapResolver::new(catalog),
             &metrics,
         );
 
@@ -806,7 +814,7 @@ mod tests {
     async fn test_persist_sort_key_no_update_necessary() {
         let storage = ParquetStorage::new(Arc::new(InMemory::default()), StorageId::from("iox"));
         let metrics = Arc::new(metric::Registry::default());
-        let catalog = Arc::new(MemCatalog::new(Arc::clone(&metrics)));
+        let catalog: Arc<dyn Catalog> = Arc::new(MemCatalog::new(Arc::clone(&metrics)));
 
         let mut handle = PersistHandle::new(
             1,
@@ -814,8 +822,9 @@ mod tests {
             Arc::new(IngestState::default()),
             Arc::new(Executor::new_testing()),
             storage,
-            catalog,
+            Arc::clone(&catalog),
             Arc::new(MockCompletionObserver::default()),
+            CatalogMapResolver::new(catalog),
             &metrics,
         );
 
@@ -891,7 +900,7 @@ mod tests {
     async fn test_persist_saturated_enqueue_counter() {
         let storage = ParquetStorage::new(Arc::new(InMemory::default()), StorageId::from("iox"));
         let metrics = Arc::new(metric::Registry::default());
-        let catalog = Arc::new(MemCatalog::new(Arc::clone(&metrics)));
+        let catalog: Arc<dyn Catalog> = Arc::new(MemCatalog::new(Arc::clone(&metrics)));
         let ingest_state = Arc::new(IngestState::default());
 
         let mut handle = PersistHandle::new(
@@ -900,8 +909,9 @@ mod tests {
             Arc::clone(&ingest_state),
             Arc::new(Executor::new_testing()),
             storage,
-            catalog,
+            Arc::clone(&catalog),
             NopObserver,
+            CatalogMapResolver::new(catalog),
             &metrics,
         );
         assert!(ingest_state.read().is_ok());
@@ -971,7 +981,7 @@ mod tests {
     async fn test_static_config_metrics() {
         let storage = ParquetStorage::new(Arc::new(InMemory::default()), StorageId::from("iox"));
         let metrics = Arc::new(metric::Registry::default());
-        let catalog = Arc::new(MemCatalog::new(Arc::clone(&metrics)));
+        let catalog: Arc<dyn Catalog> = Arc::new(MemCatalog::new(Arc::clone(&metrics)));
         let ingest_state = Arc::new(IngestState::default());
 
         let _handle = PersistHandle::new(
@@ -980,8 +990,9 @@ mod tests {
             Arc::clone(&ingest_state),
             Arc::new(Executor::new_testing()),
             storage,
-            catalog,
+            Arc::clone(&catalog),
             NopObserver,
+            CatalogMapResolver::new(catalog),
             &metrics,
         );
 

--- a/ingester/src/persist/mod.rs
+++ b/ingester/src/persist/mod.rs
@@ -1,6 +1,7 @@
 //! The persistence subsystem; abstractions, types, and implementation.
 
 pub(crate) mod backpressure;
+pub(crate) mod column_map_resolver;
 pub(super) mod compact;
 pub(crate) mod completion_observer;
 mod context;

--- a/ingester/src/persist/mod.rs
+++ b/ingester/src/persist/mod.rs
@@ -45,7 +45,10 @@ mod tests {
         dml_sink::DmlSink,
         ingest_state::IngestState,
         persist::handle::PersistHandle,
-        persist::{completion_observer::mock::MockCompletionObserver, queue::PersistQueue},
+        persist::{
+            column_map_resolver::CatalogMapResolver,
+            completion_observer::mock::MockCompletionObserver, queue::PersistQueue,
+        },
         test_util::{
             make_write_op, populate_catalog, ARBITRARY_NAMESPACE_NAME,
             ARBITRARY_NAMESPACE_NAME_PROVIDER, ARBITRARY_PARTITION_KEY, ARBITRARY_TABLE_NAME,
@@ -173,6 +176,7 @@ mod tests {
         let storage = ParquetStorage::new(Arc::clone(&object_storage), StorageId::from("iox"));
         let metrics = Arc::new(metric::Registry::default());
         let catalog: Arc<dyn Catalog> = Arc::new(MemCatalog::new(Arc::clone(&metrics)));
+        let column_map_resolver = CatalogMapResolver::new(Arc::clone(&catalog));
         let ingest_state = Arc::new(IngestState::default());
         let completion_observer = Arc::new(MockCompletionObserver::default());
 
@@ -185,6 +189,7 @@ mod tests {
             storage,
             Arc::clone(&catalog),
             Arc::clone(&completion_observer),
+            column_map_resolver,
             &metrics,
         );
         assert!(ingest_state.read().is_ok());
@@ -334,6 +339,7 @@ mod tests {
         let storage = ParquetStorage::new(Arc::clone(&object_storage), StorageId::from("iox"));
         let metrics = Arc::new(metric::Registry::default());
         let catalog: Arc<dyn Catalog> = Arc::new(MemCatalog::new(Arc::clone(&metrics)));
+        let column_map_resolver = CatalogMapResolver::new(Arc::clone(&catalog));
         let ingest_state = Arc::new(IngestState::default());
         let completion_observer = Arc::new(MockCompletionObserver::default());
 
@@ -346,6 +352,7 @@ mod tests {
             storage,
             Arc::clone(&catalog),
             Arc::clone(&completion_observer),
+            column_map_resolver,
             &metrics,
         );
         assert!(ingest_state.read().is_ok());

--- a/ingester/src/persist/worker.rs
+++ b/ingester/src/persist/worker.rs
@@ -181,7 +181,7 @@ where
     // defined in the sort key are present in the map. If the values were
     // fetched in reverse order, a race exists where the sort key could be
     // updated to include a column that does not exist in the column map.
-    let column_map = fetch_column_map(ctx, worker_state, sort_key.as_ref()).await?;
+    let column_map = fetch_column_map(ctx, worker_state, sort_key.as_ref()).await;
 
     let compacted = compact(ctx, worker_state, sort_key.as_ref()).await;
     let (sort_key_update, parquet_table_data) =
@@ -336,7 +336,7 @@ async fn fetch_column_map<O>(
     // The purpose to put the sort_key as a param here is to make sure the caller has already loaded the sort key
     // and the same sort_key is returned
     sort_key: Option<&SortKey>,
-) -> Result<ColumnsByName, PersistError>
+) -> ColumnsByName
 where
     O: Send + Sync,
 {
@@ -363,7 +363,7 @@ where
         }
     }
 
-    Ok(column_map)
+    column_map
 }
 
 /// Update the sort key value stored in the catalog for this [`Context`].

--- a/ingester/src/persist/worker.rs
+++ b/ingester/src/persist/worker.rs
@@ -3,7 +3,7 @@ use std::{ops::ControlFlow, sync::Arc};
 use async_channel::RecvError;
 use backoff::Backoff;
 use data_types::{ColumnsByName, CompactionLevel, ParquetFile, ParquetFileParams, SortedColumnSet};
-use iox_catalog::interface::{get_table_columns_by_id, CasFailure, Catalog};
+use iox_catalog::interface::{CasFailure, Catalog};
 use iox_query::exec::Executor;
 use iox_time::{SystemProvider, TimeProvider};
 use metric::DurationHistogram;
@@ -16,6 +16,7 @@ use uuid::Uuid;
 use crate::persist::compact::compact_persisting_batch;
 
 use super::{
+    column_map_resolver::ColumnMapResolver,
     compact::CompactedStream,
     completion_observer::PersistCompletionObserver,
     context::{Context, PersistError, PersistRequest},
@@ -23,11 +24,12 @@ use super::{
 
 /// State shared across workers.
 #[derive(Debug)]
-pub(super) struct SharedWorkerState<O> {
+pub(super) struct SharedWorkerState<O, C> {
     pub(super) exec: Arc<Executor>,
     pub(super) store: ParquetStorage,
     pub(super) catalog: Arc<dyn Catalog>,
     pub(super) completion_observer: O,
+    pub(super) column_map_resolver: C,
 }
 
 /// The worker routine that drives a [`PersistRequest`] to completion,
@@ -71,14 +73,15 @@ pub(super) struct SharedWorkerState<O> {
 /// [`PersistingData`]:
 ///     crate::buffer_tree::partition::persisting::PersistingData
 /// [`PartitionData`]: crate::buffer_tree::partition::PartitionData
-pub(super) async fn run_task<O>(
-    worker_state: Arc<SharedWorkerState<O>>,
+pub(super) async fn run_task<O, C>(
+    worker_state: Arc<SharedWorkerState<O, C>>,
     global_queue: async_channel::Receiver<PersistRequest>,
     mut rx: mpsc::UnboundedReceiver<PersistRequest>,
     queue_duration: DurationHistogram,
     persist_duration: DurationHistogram,
 ) where
     O: PersistCompletionObserver,
+    C: ColumnMapResolver,
 {
     loop {
         let req = tokio::select! {
@@ -162,12 +165,13 @@ pub(super) async fn run_task<O>(
 ///
 /// [`PersistingData`]:
 ///     crate::buffer_tree::partition::persisting::PersistingData
-async fn compact_and_upload<O>(
+async fn compact_and_upload<O, C>(
     ctx: &mut Context,
-    worker_state: &SharedWorkerState<O>,
+    worker_state: &SharedWorkerState<O, C>,
 ) -> Result<ParquetFileParams, PersistError>
 where
     O: Send + Sync,
+    C: ColumnMapResolver,
 {
     // Read the partition sort key from the catalog.
     //
@@ -181,7 +185,10 @@ where
     // defined in the sort key are present in the map. If the values were
     // fetched in reverse order, a race exists where the sort key could be
     // updated to include a column that does not exist in the column map.
-    let column_map = fetch_column_map(ctx, worker_state, sort_key.as_ref()).await;
+    let column_map = worker_state
+        .column_map_resolver
+        .load_verified_column_map(ctx.table_id(), sort_key.as_ref())
+        .await;
 
     let compacted = compact(ctx, worker_state, sort_key.as_ref()).await;
     let (sort_key_update, parquet_table_data) =
@@ -205,13 +212,14 @@ where
 
 /// Compact the data in `ctx` using sorted by the sort key returned from
 /// [`Context::sort_key()`].
-async fn compact<O>(
+async fn compact<O, C>(
     ctx: &Context,
-    worker_state: &SharedWorkerState<O>,
+    worker_state: &SharedWorkerState<O, C>,
     sort_key: Option<&SortKey>,
 ) -> CompactedStream
 where
     O: Send + Sync,
+    C: Send + Sync,
 {
     debug!(
         namespace_id = %ctx.namespace_id(),
@@ -241,14 +249,15 @@ where
 
 /// Upload the compacted data in `compacted`, returning the new sort key value
 /// and parquet metadata to be upserted into the catalog.
-async fn upload<O>(
+async fn upload<O, C>(
     ctx: &Context,
-    worker_state: &SharedWorkerState<O>,
+    worker_state: &SharedWorkerState<O, C>,
     compacted: CompactedStream,
     columns: &ColumnsByName,
 ) -> (Option<SortKey>, ParquetFileParams)
 where
     O: Send + Sync,
+    C: Send + Sync,
 {
     let CompactedStream {
         stream: record_stream,
@@ -327,45 +336,6 @@ where
     (catalog_sort_key_update, parquet_table_data)
 }
 
-/// Fetch the table column map from the catalog and verify if they contain all columns in the sort key
-async fn fetch_column_map<O>(
-    ctx: &Context,
-    worker_state: &SharedWorkerState<O>,
-    // NOTE: CALLER MUST LOAD SORT KEY BEFORE CALLING THIS FUNCTION EVEN IF THE sort key IS NONE.
-    // THIS IS A MUST TO GUARANTEE THE RETURNED COLUMN MAP CONTAINS ALL COLUMNS IN THE SORT KEY
-    // The purpose to put the sort_key as a param here is to make sure the caller has already loaded the sort key
-    // and the same sort_key is returned
-    sort_key: Option<&SortKey>,
-) -> ColumnsByName
-where
-    O: Send + Sync,
-{
-    // Read the table's columns from the catalog to get a map of column name -> column IDs.
-    let column_map = Backoff::new(&Default::default())
-        .retry_all_errors("get table schema", || async {
-            let mut repos = worker_state.catalog.repositories().await;
-            get_table_columns_by_id(ctx.table_id(), repos.as_mut()).await
-        })
-        .await
-        .expect("retry forever");
-
-    // Verify that the sort key columns are in the column map
-    if let Some(sort_key) = &sort_key {
-        for sort_key_column in sort_key.to_columns() {
-            if !column_map.contains_column_name(sort_key_column) {
-                panic!(
-                    "sort key column {} of partition id {} is not in the column map {:?}",
-                    sort_key_column,
-                    ctx.partition_id(),
-                    column_map
-                );
-            }
-        }
-    }
-
-    column_map
-}
-
 /// Update the sort key value stored in the catalog for this [`Context`].
 ///
 /// # Concurrent Updates
@@ -381,9 +351,9 @@ where
 /// Similarly, to avoid too much changes, we will compute new_sort_key_ids from
 /// the provided new_sort_key and the columns. In the future, we will optimize to use
 /// new_sort_key_ids directly.
-async fn update_catalog_sort_key<O>(
+async fn update_catalog_sort_key<O, C>(
     ctx: &mut Context,
-    worker_state: &SharedWorkerState<O>,
+    worker_state: &SharedWorkerState<O, C>,
     old_sort_key: Option<SortKey>, // todo: remove this argument in the future
     old_sort_key_ids: Option<SortedColumnSet>,
     new_sort_key: SortKey,
@@ -392,6 +362,7 @@ async fn update_catalog_sort_key<O>(
 ) -> Result<(), PersistError>
 where
     O: Send + Sync,
+    C: Send + Sync,
 {
     // convert old_sort_key into a vector of string
     let old_sort_key =
@@ -550,13 +521,14 @@ where
     Ok(())
 }
 
-async fn update_catalog_parquet<O>(
+async fn update_catalog_parquet<O, C>(
     ctx: &Context,
-    worker_state: &SharedWorkerState<O>,
+    worker_state: &SharedWorkerState<O, C>,
     parquet_table_data: &ParquetFileParams,
 ) -> ParquetFile
 where
     O: Send + Sync,
+    C: Send + Sync,
 {
     // Extract the object store ID to the local scope so that it can easily
     // be referenced in debug logging to aid correlation of persist events


### PR DESCRIPTION
Part of #8792.

No functional change here (other than perhaps the omission of the entire `column_map` from the invariant panic message. Can add that back in if desired.

This PR just does a bit of shuffling about to abstract away the process of looking up the `ColumnsByName` index retrieved from the catalog at persist time, as well as the verification against the provided sort key. Should be easy to review commit by commit.

I envision the trait allow a few separate decorator layers to go around it, caching retrieved `ColumnsByName` in one, while incrementally updating the cached value from schema change gossip messages in another.

---

* refactor(ingester): Make `fetch_column_map` signature infallible (1e5b1ea43)


* refactor(ingester): Define `ColumnMapResolver` trait (311d4309f)

      This trait abstracts away the act of fetching the index of column name
      to column ID for a given table, verified by the provided sort key.

* refactor(ingester): Add catalog based implementation of `ColumnMapResolver` (d542ca72d)

      This takes the logic from the pre-existing `fetch_column_map()` function
      used by the persist worker and puts it behind the `ColumnMapResolver`
      trait as a base layer implementation.

* refactor(ingester): Use `ColumnMapResolver` in persist workers (89bcb75fa)

      This shifts the responsibility for retrieving a `ColumnsByName` ID
      index from outside the worker code to a generic type stored in the
      `SharedWorkerState`, to enable additional optimisation wrappers, such
      as caching and incremental updates of the cache.

* test(ingester): Add unit testing to cover `CatalogMapResolver` behaviour (ce1186f82)
