### PR TITLE
feat(flightsql): add partial mappings of SqlSupportsConvert to CommandGetSqlInfo

### DIFF
--- a/flightsql/src/sql_info/meta.rs
+++ b/flightsql/src/sql_info/meta.rs
@@ -4,6 +4,11 @@
 //!
 //! [queryrouterd]: https://github.com/influxdata/idpe/blob/85aa7a52b40f173cc4d79ac02b3a4a13e82333c4/queryrouter/internal/server/flightsql_info.go#L4
 
+use std::collections::HashMap;
+
+use arrow_flight::sql::SqlSupportsConvert;
+use once_cell::sync::Lazy;
+
 pub(crate) const SQL_INFO_SQL_KEYWORDS: &[&str] = &[
     // SQL-92 Reserved Words
     "absolute",
@@ -301,3 +306,36 @@ pub(crate) const SQL_INFO_DATE_TIME_FUNCTIONS: &[&str] = &[
 ];
 
 pub(crate) const SQL_INFO_SYSTEM_FUNCTIONS: &[&str] = &["array", "arrow_typeof", "struct"];
+
+pub(crate) static SQL_INFO_SUPPORTS_CONVERT: Lazy<HashMap<i32, Vec<i32>>> = Lazy::new(|| {
+    [
+        // TODO (chunchun): this list is not complete yet
+        // try all the cases that arrow_cast() can convert
+        (
+            SqlSupportsConvert::SqlConvertTinyint as i32,
+            vec![
+                SqlSupportsConvert::SqlConvertBigint as i32,
+                SqlSupportsConvert::SqlConvertChar as i32,
+                SqlSupportsConvert::SqlConvertFloat as i32,
+                SqlSupportsConvert::SqlConvertInteger as i32,
+                SqlSupportsConvert::SqlConvertReal as i32,
+                SqlSupportsConvert::SqlConvertSmallint as i32,
+            ],
+        ),
+        (
+            SqlSupportsConvert::SqlConvertBit as i32,
+            vec![
+                SqlSupportsConvert::SqlConvertBigint as i32,
+                SqlSupportsConvert::SqlConvertChar as i32,
+                SqlSupportsConvert::SqlConvertFloat as i32,
+                SqlSupportsConvert::SqlConvertInteger as i32,
+                SqlSupportsConvert::SqlConvertReal as i32,
+                SqlSupportsConvert::SqlConvertSmallint as i32,
+                SqlSupportsConvert::SqlConvertVarchar as i32,
+            ],
+        ),
+    ]
+    .iter()
+    .cloned()
+    .collect()
+});

--- a/flightsql/src/sql_info/mod.rs
+++ b/flightsql/src/sql_info/mod.rs
@@ -29,7 +29,7 @@ use once_cell::sync::Lazy;
 
 use meta::{
     SQL_INFO_DATE_TIME_FUNCTIONS, SQL_INFO_NUMERIC_FUNCTIONS, SQL_INFO_SQL_KEYWORDS,
-    SQL_INFO_STRING_FUNCTIONS, SQL_INFO_SYSTEM_FUNCTIONS,
+    SQL_INFO_STRING_FUNCTIONS, SQL_INFO_SYSTEM_FUNCTIONS, SQL_INFO_SUPPORTS_CONVERT,
 };
 
 #[allow(non_snake_case)]
@@ -94,9 +94,10 @@ static INSTANCE: Lazy<SqlInfoData> = Lazy::new(|| {
     builder.append(SqlInfo::SqlExtraNameCharacters, "");
     builder.append(SqlInfo::SqlSupportsColumnAliasing, true);
     builder.append(SqlInfo::SqlNullPlusNullIsNull, true);
-    // Skip SqlSupportsConvert (which is the map of the conversions that are supported);
-    // .with_sql_info(SqlInfo::SqlSupportsConvert, TBD);
-    // https://github.com/influxdata/influxdb_iox/issues/7253
+    builder.append(
+        SqlInfo::SqlSupportsConvert,
+        &SQL_INFO_SUPPORTS_CONVERT.clone(),
+    );
     builder.append(SqlInfo::SqlSupportsTableCorrelationNames, false);
     builder.append(SqlInfo::SqlSupportsDifferentTableCorrelationNames, false);
     builder.append(SqlInfo::SqlSupportsExpressionsInOrderBy, true);

--- a/influxdb_iox/tests/end_to_end_cases/flightsql.rs
+++ b/influxdb_iox/tests/end_to_end_cases/flightsql.rs
@@ -1957,6 +1957,7 @@ supportsCatalogsInPrivilegeDefinitions: false
 supportsCatalogsInProcedureCalls: true
 supportsCatalogsInTableDefinitions: true
 supportsColumnAliasing: true
+supportsConvert: true
 supportsCoreSQLGrammar: false
 supportsCorrelatedSubqueries: true
 supportsDataDefinitionAndDataManipulationTransactions: false

--- a/influxdb_iox/tests/jdbc_client/Main.java
+++ b/influxdb_iox/tests/jdbc_client/Main.java
@@ -264,9 +264,20 @@ public class Main {
         System.out.println("supportsCatalogsInProcedureCalls: " + md.supportsCatalogsInProcedureCalls());
         System.out.println("supportsCatalogsInTableDefinitions: " + md.supportsCatalogsInTableDefinitions());
         System.out.println("supportsColumnAliasing: " + md.supportsColumnAliasing());
-        // Convert not yet supported
-        // https://github.com/influxdata/influxdb_iox/issues/7253
-        //System.out.println("supportsConvert: " + md.supportsConvert());
+        System.out.println("supportsConvert: " + md.supportsConvert());
+        System.out.println("supportsConvert - TINYINT to BIGINT: " + md.supportsConvert(java.sql.Types.TINYINT, java.sql.Types.BIGINT));
+        System.out.println("supportsConvert - TINYINT to CHAR: " + md.supportsConvert(java.sql.Types.TINYINT, java.sql.Types.CHAR));
+        System.out.println("supportsConvert - TINYINT to FLOAT: " + md.supportsConvert(java.sql.Types.TINYINT, java.sql.Types.FLOAT));
+        System.out.println("supportsConvert - TINYINT to INTEGER: " + md.supportsConvert(java.sql.Types.TINYINT, java.sql.Types.INTEGER));
+        System.out.println("supportsConvert - TINYINT to REAL: " + md.supportsConvert(java.sql.Types.TINYINT, java.sql.Types.REAL));
+        System.out.println("supportsConvert - TINYINT to SMALLINT: " + md.supportsConvert(java.sql.Types.TINYINT, java.sql.Types.SMALLINT));
+        System.out.println("supportsConvert - SMALLINT to BIGINT: " + md.supportsConvert(java.sql.Types.SMALLINT, java.sql.Types.BIGINT));
+        System.out.println("supportsConvert - SMALLINT to CHAR: " + md.supportsConvert(java.sql.Types.SMALLINT, java.sql.Types.CHAR));
+        System.out.println("supportsConvert - SMALLINT to FLOAT: " + md.supportsConvert(java.sql.Types.SMALLINT, java.sql.Types.FLOAT));
+        System.out.println("supportsConvert - SMALLINT to INTEGER: " + md.supportsConvert(java.sql.Types.SMALLINT, java.sql.Types.INTEGER));
+        System.out.println("supportsConvert - SMALLINT to REAL: " + md.supportsConvert(java.sql.Types.SMALLINT, java.sql.Types.REAL));
+        System.out.println("supportsConvert - SMALLINT to TINYINT: " + md.supportsConvert(java.sql.Types.SMALLINT, java.sql.Types.TINYINT));
+        System.out.println("supportsConvert - BIT to CHAR: " + md.supportsConvert(java.sql.Types.BIT, java.sql.Types.CHAR));
         System.out.println("supportsCoreSQLGrammar: " + md.supportsCoreSQLGrammar());
         System.out.println("supportsCorrelatedSubqueries: " + md.supportsCorrelatedSubqueries());
         System.out.println("supportsDataDefinitionAndDataManipulationTransactions: " + md.supportsDataDefinitionAndDataManipulationTransactions());


### PR DESCRIPTION
Closes #7253 

Support `SqlSupportsConvert` in `CommandGetSqlInfo`

The way I got the conversion mapping is to use datafusion `arrow_cast()` and see what types can be converted into. 

Here is an example:

1. In arrow-datafusion repo, run datafusion locally. Make sure I can have an `Int8` data type
```
❯ SELECT arrow_typeof(arrow_cast(2, 'Int8'));
+------------------------+
| arrow_typeof(Int64(2)) |
+------------------------+
| Int8                   |
+------------------------+
```

2. Then try cast `Int8` into different other data types and see what will return. I'm able to cast `Int8` to `Int16`, `Int32`, `Int64`, `Float32`, `Float64`, `Utf8`
```
❯ SELECT arrow_cast(arrow_cast(2, 'Int8'), 'Int16');
❯ SELECT arrow_cast(arrow_cast(2, 'Int8'), 'Int32');
❯ SELECT arrow_cast(arrow_cast(2, 'Int8'), 'Int64');
❯ SELECT arrow_cast(arrow_cast(2, 'Int8'), 'Utf8');
+----------+
| Int64(2) |
+----------+
| 2        |
+----------+

❯ SELECT arrow_cast(arrow_cast(2, 'Int8'), 'Float32');
❯ SELECT arrow_cast(arrow_cast(2, 'Int8'), 'Float64');
+----------+
| Int64(2) |
+----------+
| 2.0      |
+----------+

❯ SELECT arrow_cast(arrow_cast(2, 'Int8'), 'Binary');
Error during planning: Cannot automatically convert Int8 to Binary

❯ SELECT arrow_cast(arrow_cast(2, 'Int8'), 'Decimal128(3, 2)');
+----------+
| Int64(2) |
+----------+
| 2.00     |
+----------+
❯ SELECT arrow_cast(arrow_cast(2, 'Int8'), 'Decimal128(3, 3)');
Optimizer rule 'simplify_expressions' failed
caused by
Arrow error: Invalid argument error: 2000 is too large to store in a Decimal128 of precision 3. Max is 999
```

Describe your proposed changes here.

- [x] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb_iox/blob/main/README.md).
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
