### PR TITLE
feat(5226): enable partial writes configured per instance

### DIFF
--- a/clap_blocks/src/router.rs
+++ b/clap_blocks/src/router.rs
@@ -57,6 +57,17 @@ pub struct RouterConfig {
     )]
     pub http_request_limit: usize,
 
+    /// When writing line protocol data, does an error on a single line
+    /// reject the write? Or will all individual valid lines be written?
+    /// Set to true to enable all valid lines to write.
+    #[clap(
+        long = "partial-writes-enabled",
+        env = "INFLUXDB_IOX_PARTIAL_WRITES_ENABLED",
+        default_value = "false",
+        action
+    )]
+    pub permit_partial_writes: bool,
+
     /// gRPC address for the router to talk with the ingesters. For
     /// example:
     ///

--- a/influxdb_iox/src/commands/run/all_in_one.rs
+++ b/influxdb_iox/src/commands/run/all_in_one.rs
@@ -185,6 +185,14 @@ pub struct Config {
     )]
     pub(crate) single_tenant_deployment: bool,
 
+    #[clap(
+        long = "partial-writes-enabled",
+        env = "INFLUXDB_IOX_PARTIAL_WRITES_ENABLED",
+        default_value = "false",
+        action
+    )]
+    pub permit_partial_writes: bool,
+
     /// logging options
     #[clap(flatten)]
     pub(crate) logging_config: LoggingConfig,
@@ -390,6 +398,7 @@ impl Config {
             querier_max_concurrent_queries,
             exec_mem_pool_bytes,
             single_tenant_deployment,
+            permit_partial_writes,
         } = self;
 
         // Determine where to store files (wal and possibly catalog
@@ -492,6 +501,7 @@ impl Config {
             authz_address: authz_address.clone(),
             single_tenant_deployment,
             http_request_limit: 1_000,
+            permit_partial_writes,
             ingester_addresses: ingester_addresses.clone(),
             new_namespace_retention_hours: None, // infinite retention
             namespace_autocreation_enabled: true,

--- a/influxdb_iox/tests/end_to_end_cases/router.rs
+++ b/influxdb_iox/tests/end_to_end_cases/router.rs
@@ -104,6 +104,65 @@ pub async fn test_writes_are_atomic() {
     .await;
 }
 
+#[tokio::test]
+pub async fn test_partial_writes() {
+    let database_url = maybe_skip_integration!();
+
+    let test_config = TestConfig::new_all_in_one(Some(database_url)).with_partial_writes();
+    let mut cluster = MiniCluster::create_all_in_one(test_config).await;
+
+    StepTest::new(
+        &mut cluster,
+        vec![
+            Step::WriteLineProtocol(
+                "table_atomic,tag1=A,tag2=good val=42i 123456\n\
+                table_atomic,tag1=A,tag2=good val=43i 123457"
+                    .into(),
+            ),
+            Step::Query {
+                sql: "select * from table_atomic".into(),
+                expected: vec![
+                    "+------+------+--------------------------------+-----+",
+                    "| tag1 | tag2 | time                           | val |",
+                    "+------+------+--------------------------------+-----+",
+                    "| A    | good | 1970-01-01T00:00:00.000123456Z | 42  |",
+                    "| A    | good | 1970-01-01T00:00:00.000123457Z | 43  |",
+                    "+------+------+--------------------------------+-----+",
+                ],
+            },
+            Step::WriteLineProtocolExpectingError {
+                line_protocol: "table_atomic,tag1=B,tag2=good val=44i 123458\n\
+                     ,tag1=B,tag2=bad val=45i 123459\n\
+                     table_atomic,tag1=B,tag2=good val=46i 123460\n\
+                     table_atomic,tag1=B,tag2=bad val=47i 123461000000000000000000000000"
+                    .into(),
+                expected_error_code: StatusCode::BAD_REQUEST,
+                expected_error_message: "failed to parse line protocol: \
+                    errors encountered on line(s):\
+                    \nerror parsing line 2 (1-based): Invalid measurement was provided\
+                    \nerror parsing line 4 (1-based): Unable to parse timestamp value '123461000000000000000000000000"
+                    .to_string(),
+                expected_line_number: Some(2),
+            },
+            Step::Query {
+                sql: "select * from table_atomic".into(),
+                expected: vec![
+                    "+------+------+--------------------------------+-----+",
+                    "| tag1 | tag2 | time                           | val |",
+                    "+------+------+--------------------------------+-----+",
+                    "| A    | good | 1970-01-01T00:00:00.000123456Z | 42  |",
+                    "| A    | good | 1970-01-01T00:00:00.000123457Z | 43  |",
+                    "| B    | good | 1970-01-01T00:00:00.000123458Z | 44  |",
+                    "| B    | good | 1970-01-01T00:00:00.000123460Z | 46  |",
+                    "+------+------+--------------------------------+-----+",
+                ],
+            },
+        ],
+    )
+    .run()
+    .await;
+}
+
 async fn read_body<T, E>(mut body: T) -> Vec<u8>
 where
     T: Body<Data = bytes::Bytes, Error = E> + Unpin,

--- a/ioxd_router/src/lib.rs
+++ b/ioxd_router/src/lib.rs
@@ -473,6 +473,7 @@ pub async fn create_router_server_type(
     let http = HttpDelegate::new(
         common_state.run_config().max_http_request_size,
         router_config.http_request_limit,
+        router_config.permit_partial_writes,
         namespace_resolver,
         handler_stack,
         &metrics,

--- a/router/src/server/http.rs
+++ b/router/src/server/http.rs
@@ -206,6 +206,7 @@ impl From<&DmlError> for StatusCode {
 #[derive(Debug)]
 pub struct HttpDelegate<D, N, T = SystemProvider> {
     max_request_bytes: usize,
+    permit_partial_writes: bool,
     time_provider: T,
     namespace_resolver: N,
     dml_handler: D,
@@ -237,6 +238,7 @@ impl<D, N> HttpDelegate<D, N, SystemProvider> {
     pub fn new(
         max_request_bytes: usize,
         max_requests: usize,
+        permit_partial_writes: bool,
         namespace_resolver: N,
         dml_handler: D,
         metrics: &metric::Registry,
@@ -281,6 +283,7 @@ impl<D, N> HttpDelegate<D, N, SystemProvider> {
 
         Self {
             max_request_bytes,
+            permit_partial_writes,
             time_provider: SystemProvider::default(),
             namespace_resolver,
             write_request_mode_handler,
@@ -610,6 +613,7 @@ mod tests {
                     let delegate = HttpDelegate::new(
                         MAX_BYTES,
                         100,
+                        false,
                         mock_namespace_resolver,
                         Arc::clone(&dml_handler),
                         &metrics,
@@ -1097,6 +1101,7 @@ mod tests {
         let delegate = Arc::new(HttpDelegate::new(
             MAX_BYTES,
             1,
+            false,
             mock_namespace_resolver,
             Arc::clone(&dml_handler),
             &metrics,
@@ -1229,6 +1234,7 @@ mod tests {
         let delegate = HttpDelegate::new(
             MAX_BYTES,
             1,
+            false,
             mock_namespace_resolver,
             Arc::clone(&dml_handler),
             &metrics,
@@ -1271,6 +1277,7 @@ mod tests {
         let delegate = HttpDelegate::new(
             MAX_BYTES,
             1,
+            false,
             mock_namespace_resolver,
             Arc::clone(&dml_handler),
             &metrics,

--- a/router/src/server/http/write/single_tenant/auth.rs
+++ b/router/src/server/http/write/single_tenant/auth.rs
@@ -98,6 +98,7 @@ mod tests {
         let delegate = HttpDelegate::new(
             MAX_BYTES,
             1,
+            false,
             mock_namespace_resolver,
             Arc::clone(&dml_handler),
             &metrics,
@@ -187,6 +188,7 @@ mod tests {
         let delegate = HttpDelegate::new(
             MAX_BYTES,
             1,
+            false,
             mock_namespace_resolver,
             Arc::clone(&dml_handler),
             &metrics,

--- a/router/tests/common/mod.rs
+++ b/router/tests/common/mod.rs
@@ -184,6 +184,7 @@ impl TestContext {
         let http_delegate = HttpDelegate::new(
             1024,
             100,
+            false,
             namespace_resolver,
             handler_stack,
             &metrics,

--- a/test_helpers_end_to_end/src/config.rs
+++ b/test_helpers_end_to_end/src/config.rs
@@ -224,6 +224,11 @@ impl TestConfig {
             .with_env("INFLUXDB_IOX_SINGLE_TENANCY", "true")
     }
 
+    /// Enable partial writes.
+    pub fn with_partial_writes(self) -> Self {
+        self.with_env("INFLUXDB_IOX_PARTIAL_WRITES_ENABLED", "true")
+    }
+
     // Get the catalog DSN URL if set.
     pub fn dsn(&self) -> &Option<String> {
         &self.dsn


### PR DESCRIPTION
Closes #5226 

Enabled partial writes of line protocol, based on env configuration per router.


---
* feat(5226): provide flag for partial writes (6930c5196)


* refactor(5226): provide permit_partial_writes bool to the router's HttpDelegate (0f18b55c9)


* feat(5226): enable partial writes in router (1c63434fe)


* test(5226): integration test for partial writes (6c2e83a83)


## Checklist
- [x] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb_iox/blob/main/README.md).
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
