### PR TITLE
refactor: move prop data generators and deterministic ID mapping

### DIFF
--- a/router/src/gossip/anti_entropy/mod.rs
+++ b/router/src/gossip/anti_entropy/mod.rs
@@ -60,3 +60,96 @@
 
 pub mod mst;
 pub mod sync;
+
+#[cfg(test)]
+pub mod prop_gen {
+    use std::collections::BTreeMap;
+
+    use data_types::{
+        ColumnId, ColumnSchema, ColumnType, ColumnsByName, MaxColumnsPerTable, MaxTables,
+        NamespaceId, NamespaceName, NamespaceSchema, TableId, TableSchema,
+    };
+    use proptest::prelude::*;
+
+    /// A set of table and column names from which arbitrary names are selected
+    /// in prop tests, instead of using random values that have a low
+    /// probability of overlap.
+    pub const TEST_TABLE_NAME_SET: &[&str] = &[
+        "bananas", "quiero", "un", "platano", "donkey", "goose", "egg", "mr_toro",
+    ];
+
+    prop_compose! {
+        /// Generate a series of ColumnSchema assigned randomised IDs with a
+        /// stable mapping of `id -> data type`.
+        ///
+        /// This generates at most 255 unique columns.
+        pub fn arbitrary_column_schema_stable()(id in 0_i16..255) -> ColumnSchema {
+            // Provide a stable mapping of ID to data type to avoid column type
+            // conflicts by reducing the ID to the data type discriminant range
+            // and using that to assign the data type.
+            let col_type = ColumnType::try_from((id % 7) + 1).expect("valid discriminator range");
+
+            ColumnSchema { id: ColumnId::new(id as _), column_type: col_type }
+        }
+    }
+
+    prop_compose! {
+        /// Generate an arbitrary TableSchema with up to 255 columns that
+        /// contain stable `column name -> data type` and `column name -> column
+        /// id` mappings.
+        pub fn arbitrary_table_schema()(
+            id in any::<i64>(),
+            columns in proptest::collection::hash_set(
+                arbitrary_column_schema_stable(),
+                (0, 255) // Set size range
+            ),
+        ) -> TableSchema {
+            // Map the column schemas into `name -> schema`, generating a
+            // column name derived from the column ID to ensure a consistent
+            // mapping of name -> id, and in turn, name -> data type.
+            let columns = columns.into_iter()
+                .map(|v| (format!("col-{}", v.id.get()), v))
+                .collect::<BTreeMap<String, ColumnSchema>>();
+
+            let columns = ColumnsByName::from(columns);
+            TableSchema {
+                id: TableId::new(id),
+                partition_template: Default::default(),
+                columns,
+            }
+        }
+    }
+
+    prop_compose! {
+        /// Generate an arbitrary NamespaceSchema that contains tables from
+        /// [`TEST_TABLE_NAME_SET`], containing up to 255 columns with stable
+        /// `name -> (id, data type)` mappings.
+        ///
+        /// Namespace IDs are allocated from the specified strategy.
+        pub fn arbitrary_namespace_schema(namespace_ids: impl Strategy<Value = i64>)(
+            namespace_id in namespace_ids,
+            tables in proptest::collection::btree_map(
+                proptest::sample::select(TEST_TABLE_NAME_SET),
+                arbitrary_table_schema(),
+                (0, 10) // Set size range
+            ),
+            max_tables in any::<usize>(),
+            max_columns_per_table in any::<usize>(),
+            retention_period_ns in any::<Option<i64>>(),
+        ) -> NamespaceSchema {
+            let tables = tables.into_iter().map(|(k, v)| (k.to_string(), v)).collect();
+            NamespaceSchema {
+                id: NamespaceId::new(namespace_id),
+                tables,
+                max_tables: MaxTables::new(max_tables as i32),
+                max_columns_per_table: MaxColumnsPerTable::new(max_columns_per_table as i32),
+                retention_period_ns,
+                partition_template: Default::default(),
+            }
+        }
+    }
+
+    pub fn deterministic_name_for_schema(schema: &NamespaceSchema) -> NamespaceName<'static> {
+        NamespaceName::try_from(format!("ns-{}", schema.id)).unwrap()
+    }
+}

--- a/router/src/gossip/anti_entropy/mst/merkle.rs
+++ b/router/src/gossip/anti_entropy/mst/merkle.rs
@@ -117,9 +117,9 @@ impl<'a> std::hash::Hash for NamespaceContentHash<'a> {
 mod tests {
     use std::{collections::hash_map::DefaultHasher, hash::Hasher};
 
-    use super::*;
+    use crate::gossip::anti_entropy::prop_gen::arbitrary_namespace_schema;
 
-    use super::super::tests::arbitrary_namespace_schema;
+    use super::*;
 
     use data_types::{
         partition_template::test_table_partition_override, ColumnId, ColumnsByName, NamespaceId,


### PR DESCRIPTION
:broom: and determinism :+1:

---

* refactor: move prop generators to gossip module (6d9a18033)
      
      Move the arbitrary namespace / table / column generators used for
      property testing to the parent "gossip" module, so they can be shared
      across the sync implementation tests too.

* test: deterministic table name -> IDs generators (74b8fe0e4)
      
      Changes the property test NamespaceSchema generators to
      deterministically build consistent table name -> table ID mappings in
      the generated schemas.
      
      This prevents "table X has ID Y but gossip message maps table X to Z"
      panics - an invariant upheld by IOx, but which was not respected by the
      test generators.