### PR TITLE
docs: mark sqlite as for non-production use only

### DIFF
--- a/clap_blocks/src/catalog_dsn.rs
+++ b/clap_blocks/src/catalog_dsn.rs
@@ -55,7 +55,9 @@ pub struct CatalogDsnConfig {
     ///
     /// PostgreSQL: `postgresql://postgres@localhost:5432/postgres`
     ///
-    /// Sqlite (a local filename /tmp/foo.sqlite): `sqlite:///tmp/foo.sqlite`
+    /// Sqlite (a local filename /tmp/foo.sqlite): `sqlite:///tmp/foo.sqlite` -
+    /// note sqlite is for development/testing only and should not be used for
+    /// production workloads.
     ///
     /// Memory (ephemeral, only useful for testing): `memory`
     ///


### PR DESCRIPTION
See https://github.com/influxdata/influxdb_iox/pull/8728

---

* docs: mark sqlite as for non-production use only (c17b61b7a)
      
      The sqlite-based catalog is not maintained to a level which allows it to
      be used for production workloads.
      
      See https://github.com/influxdata/influxdb_iox/pull/8728