### PR TITLE
feat: selective NamespaceSchema field MST coverage

### DIFF
--- a/router/src/gossip/anti_entropy/mst/actor.rs
+++ b/router/src/gossip/anti_entropy/mst/actor.rs
@@ -60,7 +60,7 @@ pub struct AntiEntropyActor<T> {
     schema_rx: mpsc::Receiver<NamespaceName<'static>>,
     op_rx: mpsc::Receiver<Op>,
 
-    mst: MerkleSearchTree<NamespaceName<'static>, Arc<NamespaceSchema>>,
+    mst: MerkleSearchTree<NamespaceName<'static>, NamespaceContentHash>,
 }
 
 impl<T> AntiEntropyActor<T>
@@ -162,7 +162,7 @@ where
 
         trace!(%name, ?schema, "applying schema");
 
-        self.mst.upsert(name, &schema);
+        self.mst.upsert(name, &NamespaceContentHash(schema));
     }
 
     fn handle_op(&mut self, op: Op) {
@@ -244,11 +244,127 @@ where
     }
 }
 
+/// A [`NamespaceSchema`] decorator that produces a content hash covering fields
+/// that SHOULD be converged across gossip peers.
+#[derive(Debug)]
+struct NamespaceContentHash(Arc<NamespaceSchema>);
+
+impl std::hash::Hash for NamespaceContentHash {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        // Technically the ID does not need to be covered by the content hash
+        // (the namespace name -> namespace ID is immutable and asserted
+        // elsewhere) but it's not harmful to include it, and would drive
+        // detection of a broken mapping invariant.
+        self.0.id.hash(state);
+
+        // The set of tables, and their schemas MUST form part of the content
+        // hash as they are part of the content that must be converged.
+        self.0.tables.hash(state);
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use crate::namespace_cache::MemoryNamespaceCache;
+    use std::{collections::hash_map::DefaultHasher, hash::Hasher};
+
+    use crate::{
+        gossip::anti_entropy::prop_gen::arbitrary_namespace_schema,
+        namespace_cache::MemoryNamespaceCache,
+    };
 
     use super::*;
+
+    use data_types::{
+        partition_template::test_table_partition_override, ColumnId, ColumnsByName, NamespaceId,
+        TableId, TableSchema,
+    };
+    use proptest::prelude::*;
+
+    proptest! {
+        /// Assert the [`NamespaceContentHash`] decorator results in hashes that
+        /// are equal iff the tables and namespace ID match.
+        ///
+        /// All other fields may vary without affecting the hash.
+        #[test]
+        fn prop_content_hash_coverage(
+            a in arbitrary_namespace_schema(Just(1)),
+            b in arbitrary_namespace_schema(Just(1))
+        ) {
+            assert_eq!(a.id, b.id); // Test invariant
+
+            let a = Arc::new(a);
+            let b = Arc::new(b);
+
+            let wrap_a = NamespaceContentHash(Arc::clone(&a));
+            let wrap_b = NamespaceContentHash(Arc::clone(&b));
+
+            // Invariant: if the schemas are equal, the content hashes match
+            if a == b {
+                assert_eq!(hash(&wrap_a), hash(&wrap_b));
+            }
+
+            // True if the content hashes of a and b are equal.
+            let is_hash_eq = hash(wrap_a) == hash(wrap_b);
+
+            // Invariant: if the tables and ID match, the content hashes match
+            assert_eq!(
+                ((a.tables == b.tables) && (a.id == b.id)),
+                is_hash_eq
+            );
+
+            // Invariant: the hashes chaange if the ID is modified
+            let new_id = NamespaceId::new(a.id.get().wrapping_add(1));
+            let hash_old_a = hash(&a);
+            let mut a = NamespaceSchema::clone(&a);
+            a.id = new_id;
+            assert_ne!(hash_old_a, hash(a));
+        }
+
+        /// A fixture test that asserts the content hash of a given
+        /// [`NamespaceSchema`] does not change.
+        ///
+        /// This uses randomised inputs for fields that do not form part of the
+        /// content hash, proving they're not used, and fixes fields that do
+        /// form the hash to assert a static value given static content hash
+        /// inputs.
+        #[test]
+        fn prop_content_hash_fixture(
+            mut ns in arbitrary_namespace_schema(Just(42))
+        ) {
+            ns.tables = [(
+                "bananas".to_string(),
+                TableSchema {
+                    id: TableId::new(24),
+                    columns: ColumnsByName::new([data_types::Column {
+                        name: "platanos".to_string(),
+                        column_type: data_types::ColumnType::String,
+                        id: ColumnId::new(2442),
+                        table_id: TableId::new(24),
+                    }]),
+                    partition_template: test_table_partition_override(vec![
+                        data_types::partition_template::TemplatePart::TagValue("bananatastic"),
+                    ]),
+                },
+            )]
+            .into_iter()
+            .collect();
+
+            let wrap_ns = NamespaceContentHash(Arc::new(ns));
+
+            // If this assert fails, the content hash for a given representation
+            // has changed, and this will cause peers to consider each other
+            // completely inconsistent regardless of actual content.
+            //
+            // You need to be careful about doing this!
+            assert_eq!(hash(wrap_ns), 13889074233458619864);
+        }
+    }
+
+    fn hash(v: impl std::hash::Hash) -> u64 {
+        let mut hasher = DefaultHasher::default();
+        v.hash(&mut hasher);
+        hasher.finish()
+    }
 
     #[tokio::test]
     async fn test_empty_content_hash_fixture() {


### PR DESCRIPTION
This PR adds (or rather, uses the existing) field mask that ensures only the content the anti-entropy system is (currently!) capable of syncing forms part of the consistency checks.

---

* feat: selective NamespaceSchema field MST coverage (64e0d20a3)
      
      Move and use the NamespaceContentHash to restrict the field coverage of
      merkle tree content hashes over NamespaceSchema's.
      
      Only the schema elements are to be part of the anti-entropy protocol (at
      first!) as only these fields are CRDTs / deterministically merge-able.
      Therefore the MST hashes must only consider these fields when deciding
      if two nodes are consistent, as only these fields will be converged.