### PR TITLE
feat(router): anti-entropy service

### DIFF
--- a/gossip_schema/src/lib.rs
+++ b/gossip_schema/src/lib.rs
@@ -177,12 +177,12 @@ mod tests {
         .await;
 
         let a = Peer {
-            tx: SchemaTx::new(a),
+            tx: SchemaTx::new(Arc::new(a)),
             rx: a_rx,
         };
 
         let b = Peer {
-            tx: SchemaTx::new(b),
+            tx: SchemaTx::new(Arc::new(b)),
             rx: b_rx,
         };
 

--- a/influxdb_iox/src/commands/run/all_in_one.rs
+++ b/influxdb_iox/src/commands/run/all_in_one.rs
@@ -654,6 +654,7 @@ pub async fn command(config: Config) -> Result<()> {
             .tracing_config()
             .traces_jaeger_trace_context_header_name
             .clone(),
+        router_run_config.grpc_bind_address.port(),
     )
     .await?;
 

--- a/influxdb_iox/src/commands/run/router.rs
+++ b/influxdb_iox/src/commands/run/router.rs
@@ -104,6 +104,7 @@ pub async fn command(config: Config) -> Result<()> {
             .tracing_config()
             .traces_jaeger_trace_context_header_name
             .clone(),
+        config.run_config.grpc_bind_address.port(),
     )
     .await?;
 

--- a/ioxd_router/src/lib.rs
+++ b/ioxd_router/src/lib.rs
@@ -544,7 +544,7 @@ where
     // This sits above / wraps the NamespaceSchemaGossip layer, ensuring
     // incoming messages processed by that layer are not then broadcast by this
     // node (creating a feedback loop).
-    let ns_cache = SchemaChangeObserver::new(ns_cache, SchemaTx::new(handle));
+    let ns_cache = SchemaChangeObserver::new(ns_cache, SchemaTx::new(Arc::new(handle)));
 
     Ok(ns_cache)
 }

--- a/router/src/gossip/anti_entropy/mst/handle.rs
+++ b/router/src/gossip/anti_entropy/mst/handle.rs
@@ -130,7 +130,6 @@ impl AntiEntropyHandle {
     ///
     /// A [`MerkleSnapshot`] is a compact serialised representation of the MST
     /// state.
-    #[allow(dead_code)]
     pub(crate) async fn snapshot(&self) -> MerkleSnapshot {
         let (tx, rx) = oneshot::channel();
 
@@ -147,7 +146,6 @@ impl AntiEntropyHandle {
     /// contain inconsistencies.
     ///
     /// [`MerkleSearchTree`]: merkle_search_tree::MerkleSearchTree
-    #[allow(dead_code)]
     pub(crate) async fn compute_diff(
         &self,
         snap: MerkleSnapshot,

--- a/router/src/gossip/anti_entropy/sync/rpc_server.rs
+++ b/router/src/gossip/anti_entropy/sync/rpc_server.rs
@@ -51,7 +51,7 @@ impl From<Error> for tonic::Status {
 ///     crate::gossip::anti_entropy::mst::handle::AntiEntropyHandle
 /// [`ConvergenceActor`]:
 ///     crate::gossip::anti_entropy::sync::actor::ConvergenceActor
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct AntiEntropyService<T> {
     mst: AntiEntropyHandle,
 

--- a/router/src/server.rs
+++ b/router/src/server.rs
@@ -10,20 +10,20 @@ pub mod http;
 /// The [`RpcWriteRouterServer`] manages the lifecycle and contains all state for a
 /// `router-rpc-write` server instance.
 #[derive(Debug)]
-pub struct RpcWriteRouterServer<D, N> {
+pub struct RpcWriteRouterServer<D, N, T> {
     metrics: Arc<metric::Registry>,
     trace_collector: Option<Arc<dyn TraceCollector>>,
 
     http: HttpDelegate<D, N>,
-    grpc: RpcWriteGrpcDelegate,
+    grpc: RpcWriteGrpcDelegate<T>,
 }
 
-impl<D, N> RpcWriteRouterServer<D, N> {
+impl<D, N, T> RpcWriteRouterServer<D, N, T> {
     /// Initialise a new [`RpcWriteRouterServer`] using the provided HTTP and gRPC
     /// handlers.
     pub fn new(
         http: HttpDelegate<D, N>,
-        grpc: RpcWriteGrpcDelegate,
+        grpc: RpcWriteGrpcDelegate<T>,
         metrics: Arc<metric::Registry>,
         trace_collector: Option<Arc<dyn TraceCollector>>,
     ) -> Self {
@@ -51,7 +51,7 @@ impl<D, N> RpcWriteRouterServer<D, N> {
     }
 
     /// Get a reference to the router grpc delegate.
-    pub fn grpc(&self) -> &RpcWriteGrpcDelegate {
+    pub fn grpc(&self) -> &RpcWriteGrpcDelegate<T> {
         &self.grpc
     }
 }

--- a/router/src/server/grpc.rs
+++ b/router/src/server/grpc.rs
@@ -1,7 +1,8 @@
 //! gRPC service implementations for `router`.
 
 use generated_types::influxdata::iox::{
-    catalog::v1::*, namespace::v1::*, object_store::v1::*, table::v1::*,
+    catalog::v1::*, gossip::v1::anti_entropy_service_server, namespace::v1::*, object_store::v1::*,
+    table::v1::*,
 };
 use iox_catalog::interface::Catalog;
 use object_store::DynObjectStore;
@@ -12,19 +13,30 @@ use service_grpc_schema::SchemaService;
 use service_grpc_table::TableService;
 use std::sync::Arc;
 
+use crate::{
+    gossip::anti_entropy::sync::rpc_server::AntiEntropyService,
+    namespace_cache::{CacheMissErr, NamespaceCache},
+};
+
 /// This type manages all gRPC services exposed by a `router` using the RPC write path.
 #[derive(Debug)]
-pub struct RpcWriteGrpcDelegate {
+pub struct RpcWriteGrpcDelegate<T> {
     catalog: Arc<dyn Catalog>,
     object_store: Arc<DynObjectStore>,
+    anti_entropy: AntiEntropyService<T>,
 }
 
-impl RpcWriteGrpcDelegate {
+impl<T> RpcWriteGrpcDelegate<T> {
     /// Create a new gRPC handler
-    pub fn new(catalog: Arc<dyn Catalog>, object_store: Arc<DynObjectStore>) -> Self {
+    pub fn new(
+        catalog: Arc<dyn Catalog>,
+        object_store: Arc<DynObjectStore>,
+        anti_entropy: AntiEntropyService<T>,
+    ) -> Self {
         Self {
             catalog,
             object_store,
+            anti_entropy,
         }
     }
 
@@ -61,5 +73,16 @@ impl RpcWriteGrpcDelegate {
     /// [`TableService`]: generated_types::influxdata::iox::table::v1::table_service_server::TableService
     pub fn table_service(&self) -> impl table_service_server::TableService {
         TableService::new(Arc::clone(&self.catalog))
+    }
+
+    /// Acquire a [`AntiEntropyService`] gRPC service implementation.
+    ///
+    /// This method returns the server exactly once, if provided at
+    /// initialisation time.
+    pub fn anti_entropy_service(&self) -> impl anti_entropy_service_server::AntiEntropyService
+    where
+        T: NamespaceCache<ReadError = CacheMissErr> + Clone + 'static,
+    {
+        self.anti_entropy.clone()
     }
 }


### PR DESCRIPTION
This initialises the anti-entropy subsystem and enables it on nodes that are configured to partake in schema gossiping.

---

* refactor: extract gossip init into fn (a7da69c52)
      
      No functional change - just pulls the optional gossip init into a
      function of its own.

* refactor: share gossip handle (7e4418719)
      
      Wrap the gossip handle in an Arc to share it across subsystems.

* feat(router): anti-entropy service (f5764f460)
      
      This commit binds the anti-entropy service to the gRPC server, and
      initialises the ConvergenceActor and associated plumbing to enable the
      anti-entropy subsystem iff gossip is enabled on the node.

* refactor: remove dead code lints (5b84bb668)
      
      It's no longer dead code!