### PR TITLE
feat: enable schema cache gossiping

### DIFF
--- a/ioxd_router/src/lib.rs
+++ b/ioxd_router/src/lib.rs
@@ -565,7 +565,11 @@ where
     // the above dispatcher.
     let handle = gossip::Builder::<_, Topic>::new(seed_list, dispatcher, Arc::clone(metrics))
         // Configure the router to listen to SchemaChange messages.
-        .with_topic_filter(TopicInterests::default().with_topic(Topic::SchemaChanges))
+        .with_topic_filter(
+            TopicInterests::default()
+                .with_topic(Topic::SchemaChanges)
+                .with_topic(Topic::SchemaCacheConsistency),
+        )
         .bind(bind_addr)
         .await
         .map(Arc::new)


### PR DESCRIPTION
⚡ It's alive!

---

* feat: enable schema cache gossiping (4340749d9)
      
      This enables the schema cache consistency probes between router gossip
      peers.