### PR TITLE
refactor: increase maximum grpc sync message size

### DIFF
--- a/ioxd_router/src/lib.rs
+++ b/ioxd_router/src/lib.rs
@@ -64,7 +64,7 @@ use router::{
             sync::{
                 actor::ConvergenceActor,
                 consistency_prober::{ProbeDispatcher, SenderAddressResolver},
-                rpc_server::AntiEntropyService,
+                rpc_server::{AntiEntropyService, MAX_SYNC_MSG_SIZE},
                 rpc_worker::grpc_connector::GrpcConnector,
             },
         },
@@ -208,6 +208,8 @@ where
             anti_entropy_service_server::AntiEntropyServiceServer::new(
                 self.server.grpc().anti_entropy_service()
             )
+            .max_decoding_message_size(MAX_SYNC_MSG_SIZE)
+            .max_encoding_message_size(MAX_SYNC_MSG_SIZE)
         );
         serve_builder!(builder);
 

--- a/router/src/gossip/anti_entropy/sync/rpc_server.rs
+++ b/router/src/gossip/anti_entropy/sync/rpc_server.rs
@@ -20,6 +20,9 @@ use crate::{
     namespace_cache::{CacheMissErr, NamespaceCache},
 };
 
+/// [`MAX_SYNC_MSG_SIZE`] defines the maximum allowed sync RPC size (over TCP).
+pub const MAX_SYNC_MSG_SIZE: usize = 20 * 1024 * 1024; // 20 MiB
+
 #[derive(Debug, Error)]
 enum Error {
     /// The sender provided an invalid namespace name.

--- a/router/src/gossip/anti_entropy/sync/rpc_worker/grpc_connector.rs
+++ b/router/src/gossip/anti_entropy/sync/rpc_worker/grpc_connector.rs
@@ -11,7 +11,10 @@ use tonic::transport::Endpoint;
 
 use crate::gossip::anti_entropy::{
     mst::actor::MerkleSnapshot,
-    sync::traits::{BoxedError, SyncRpcClient, SyncRpcConnector},
+    sync::{
+        rpc_server::MAX_SYNC_MSG_SIZE,
+        traits::{BoxedError, SyncRpcClient, SyncRpcConnector},
+    },
 };
 
 const CONNECT_TIMEOUT: Duration = Duration::from_secs(2);
@@ -32,7 +35,11 @@ impl SyncRpcConnector for GrpcConnector {
 
         let c = endpoint.connect().await?;
 
-        Ok(RpcClient(AntiEntropyServiceClient::new(c)))
+        Ok(RpcClient(
+            AntiEntropyServiceClient::new(c)
+                .max_encoding_message_size(MAX_SYNC_MSG_SIZE)
+                .max_decoding_message_size(MAX_SYNC_MSG_SIZE),
+        ))
     }
 }
 


### PR DESCRIPTION
The current limit limits syncs to about 0.08% of a cache :fire:

---

* refactor: increase maximum grpc sync message size (6572a500d)
      
      The default (4MiB) limit doesn't allow for many schemas to be
      transferred, and causes sync failures when large diffs need exchanging.