### PR TITLE
refactor: move build sort key function to a more general place to get used by other components

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1382,6 +1382,7 @@ dependencies = [
  "chrono",
  "croaring",
  "generated_types",
+ "hashbrown 0.14.0",
  "hex",
  "influxdb-line-protocol",
  "iox_time",

--- a/data_types/Cargo.toml
+++ b/data_types/Cargo.toml
@@ -12,6 +12,7 @@ croaring = "1.0.0"
 influxdb-line-protocol = { path = "../influxdb_line_protocol" }
 iox_time = { path = "../iox_time" }
 generated_types = { path = "../generated_types" }
+hashbrown.workspace = true
 observability_deps = { path = "../observability_deps" }
 once_cell = "1"
 ordered-float = "4"

--- a/ingester/src/buffer_tree/partition/resolver/catalog.rs
+++ b/ingester/src/buffer_tree/partition/resolver/catalog.rs
@@ -5,7 +5,10 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use backoff::{Backoff, BackoffConfig};
-use data_types::{Column, NamespaceId, Partition, PartitionKey, TableId};
+use data_types::{
+    build_sort_key_from_sort_key_ids_and_columns, Column, NamespaceId, Partition, PartitionKey,
+    TableId,
+};
 use iox_catalog::interface::Catalog;
 use observability_deps::tracing::debug;
 use parking_lot::Mutex;
@@ -14,10 +17,7 @@ use super::r#trait::PartitionProvider;
 use crate::{
     buffer_tree::{
         namespace::NamespaceName,
-        partition::{
-            counter::PartitionCounter, resolver::build_sort_key_from_sort_key_ids_and_columns,
-            PartitionData, SortKeyState,
-        },
+        partition::{counter::PartitionCounter, PartitionData, SortKeyState},
         table::metadata::TableMetadata,
     },
     deferred_load::DeferredLoad,

--- a/ingester/src/buffer_tree/partition/resolver/sort_key.rs
+++ b/ingester/src/buffer_tree/partition/resolver/sort_key.rs
@@ -3,7 +3,9 @@
 use std::sync::Arc;
 
 use backoff::{Backoff, BackoffConfig};
-use data_types::{Column, PartitionKey, SortedColumnSet, TableId};
+use data_types::{
+    build_sort_key_from_sort_key_ids_and_columns, PartitionKey, SortedColumnSet, TableId,
+};
 use iox_catalog::interface::Catalog;
 use schema::sort::SortKey;
 
@@ -66,32 +68,11 @@ impl SortKeyResolver {
     }
 }
 
-// build sort_key from sort_key_ids and columns
-// panic if the sort_key_ids are not found in the columns
-pub(crate) fn build_sort_key_from_sort_key_ids_and_columns<I>(
-    sort_key_ids: &Option<&SortedColumnSet>,
-    columns: I,
-) -> Option<SortKey>
-where
-    I: Iterator<Item = Column>,
-{
-    let mut column_names = columns
-        .map(|c| (c.id, c.name))
-        .collect::<hashbrown::HashMap<_, _>>();
-    sort_key_ids.as_ref().map(|ids| {
-        SortKey::from_columns(ids.iter().map(|id| {
-            column_names
-                .remove(id)
-                .unwrap_or_else(|| panic!("cannot find column names for sort key id {}", id.get()))
-        }))
-    })
-}
-
 #[cfg(test)]
 mod tests {
     use std::sync::Arc;
 
-    use data_types::{ColumnId, ColumnType, SortedColumnSet};
+    use data_types::SortedColumnSet;
 
     use super::*;
     use crate::test_util::populate_catalog_with_table_columns;
@@ -157,117 +138,5 @@ mod tests {
             &fetched_sort_key_ids.unwrap(),
             catalog_state.sort_key_ids_none_if_empty().unwrap()
         );
-    }
-
-    // panic if the sort_key_ids are not found in the columns
-    #[tokio::test]
-    #[should_panic(expected = "cannot find column names for sort key id 3")]
-    async fn test_panic_build_sort_key_from_sort_key_ids_and_columns() {
-        // table columns
-        let columns = vec![
-            Column {
-                name: "uno".into(),
-                id: ColumnId::new(1),
-                column_type: ColumnType::Tag,
-                table_id: TableId::new(1),
-            },
-            Column {
-                name: "dos".into(),
-                id: ColumnId::new(2),
-                column_type: ColumnType::Tag,
-                table_id: TableId::new(1),
-            },
-        ];
-
-        // sort_key_ids include some columns that are not in the columns
-        let sort_key_ids_val = SortedColumnSet::from([2, 3]);
-        let sort_key_ids = Some(&sort_key_ids_val);
-        let _sort_key =
-            build_sort_key_from_sort_key_ids_and_columns(&sort_key_ids, columns.into_iter());
-    }
-
-    #[tokio::test]
-    async fn test_build_sort_key_from_sort_key_ids_and_columns() {
-        // table columns
-        let columns = vec![
-            Column {
-                name: "uno".into(),
-                id: ColumnId::new(1),
-                column_type: ColumnType::Tag,
-                table_id: TableId::new(1),
-            },
-            Column {
-                name: "dos".into(),
-                id: ColumnId::new(2),
-                column_type: ColumnType::Tag,
-                table_id: TableId::new(1),
-            },
-            Column {
-                name: "tres".into(),
-                id: ColumnId::new(3),
-                column_type: ColumnType::Tag,
-                table_id: TableId::new(1),
-            },
-        ];
-
-        // sort_key_ids is None
-        let sort_key_ids = None;
-        let sort_key = build_sort_key_from_sort_key_ids_and_columns(
-            &sort_key_ids,
-            columns.clone().into_iter(),
-        );
-        assert_eq!(sort_key, None);
-
-        // sort_key_ids is empty
-        let sort_key_ids_val = SortedColumnSet::new(vec![]);
-        let sort_key_ids = Some(&sort_key_ids_val);
-        let sort_key = build_sort_key_from_sort_key_ids_and_columns(
-            &sort_key_ids,
-            columns.clone().into_iter(),
-        );
-        let vec: Vec<&str> = vec![];
-        assert_eq!(sort_key, Some(SortKey::from_columns(vec)));
-
-        // sort_key_ids include all columns and in the same order
-        let sort_key_ids_val = SortedColumnSet::from([1, 2, 3]);
-        let sort_key_ids = Some(&sort_key_ids_val);
-        let sort_key = build_sort_key_from_sort_key_ids_and_columns(
-            &sort_key_ids,
-            columns.clone().into_iter(),
-        );
-        assert_eq!(
-            sort_key,
-            Some(SortKey::from_columns(vec!["uno", "dos", "tres"]))
-        );
-
-        // sort_key_ids include all columns but in different order
-        let sort_key_ids_val = SortedColumnSet::from([2, 3, 1]);
-        let sort_key_ids = Some(&sort_key_ids_val);
-        let sort_key = build_sort_key_from_sort_key_ids_and_columns(
-            &sort_key_ids,
-            columns.clone().into_iter(),
-        );
-        assert_eq!(
-            sort_key,
-            Some(SortKey::from_columns(vec!["dos", "tres", "uno"]))
-        );
-
-        // sort_key_ids include some columns
-        let sort_key_ids_val = SortedColumnSet::from([2, 3]);
-        let sort_key_ids = Some(&sort_key_ids_val);
-        let sort_key = build_sort_key_from_sort_key_ids_and_columns(
-            &sort_key_ids,
-            columns.clone().into_iter(),
-        );
-        assert_eq!(sort_key, Some(SortKey::from_columns(vec!["dos", "tres"])));
-
-        // sort_key_ids include some columns in different order
-        let sort_key_ids_val = SortedColumnSet::from([3, 1]);
-        let sort_key_ids = Some(&sort_key_ids_val);
-        let sort_key = build_sort_key_from_sort_key_ids_and_columns(
-            &sort_key_ids,
-            columns.clone().into_iter(),
-        );
-        assert_eq!(sort_key, Some(SortKey::from_columns(vec!["tres", "uno"])));
     }
 }


### PR DESCRIPTION
While working on https://github.com/influxdata/influxdb_iox/issues/8711  I need to use the function `build_sort_key_from_sort_key_ids_and_columns` in the compactor, too. So move it outside ingester to use it in next PR.

Next PR is a big one so I am trying to do refactor in separate PR for easier reviewing 


- [ ] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb_iox/blob/main/README.md).
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
